### PR TITLE
feat(registry): one-shot re-probe of unknown agents with extended timeout

### DIFF
--- a/.changeset/registry-reprobe-unknown-agents.md
+++ b/.changeset/registry-reprobe-unknown-agents.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-One-shot script to re-probe registry agents currently classified as `unknown` with an extended 30s timeout. Reuses the live crawler probe + write helpers; reports `{still_unknown, newly_classified by type, probe_failed, dns_failed}` so the full Problem 2 retry/backoff PR can scope from real data. See #3551.
+One-shot script to re-probe registry agents currently classified as `unknown` with an extended 30s timeout. Reuses the live crawler probe + write helpers; reports `{still_unknown, newly_classified by type, probe_failed, dns_failed, preserved_existing}` so the full Problem 2 retry/backoff PR can scope from real data. Includes per-agent timing for slow-tail visibility and a silent-corruption guard: a transient probe failure never overwrites a previously-classified snapshot row. See #3551.

--- a/.changeset/registry-reprobe-unknown-agents.md
+++ b/.changeset/registry-reprobe-unknown-agents.md
@@ -1,0 +1,4 @@
+---
+---
+
+One-shot script to re-probe registry agents currently classified as `unknown` with an extended 30s timeout. Reuses the live crawler probe + write helpers; reports `{still_unknown, newly_classified by type, probe_failed, dns_failed}` so the full Problem 2 retry/backoff PR can scope from real data. See #3551.

--- a/server/scripts/reprobe-unknown-agents.ts
+++ b/server/scripts/reprobe-unknown-agents.ts
@@ -1,0 +1,445 @@
+/**
+ * One-shot re-probe of every agent currently classified as `unknown`.
+ *
+ * 77% of agents in the public registry render `type: 'unknown'` (issue #3551,
+ * Problem 2 in #3538). Before designing the full retry-with-backoff system,
+ * we run this script once to learn whether `unknown` is mostly transient
+ * (timeouts/network) or mostly dead (NXDOMAIN, connect-refused). The output
+ * tells us how to scope the full Problem 2 PR.
+ *
+ * What it does:
+ *   1. Selects every agent where `agent_capabilities_snapshot.inferred_type`
+ *      is NULL or the snapshot row is missing entirely.
+ *   2. Re-probes each agent with a 30s timeout (vs the crawler's 10s) using
+ *      the existing `CapabilityDiscovery.discoverCapabilities` helper — same
+ *      probe path the live crawler uses, no parallel implementation.
+ *   3. Writes the new snapshot via `AgentSnapshotDatabase.upsertCapabilities`
+ *      — same write path as the crawler.
+ *   4. Reports a per-type tally + sample of still-unknown URLs.
+ *
+ * Idempotent: a real run skips agents that have since become classified.
+ * `--dry-run` mode probes everything but writes nothing.
+ *
+ * Note on member_profiles propagation: PR #3541 will export
+ * `resolveAgentTypes` from `server/src/routes/member-profiles.ts` so this
+ * script can refresh `member_profiles.agents[]` after each agent. As of this
+ * branch, that export does not exist on `main`. The script logs a warning
+ * and skips that step; once #3541 lands, the dynamic import below resolves
+ * and the propagation runs automatically.
+ *
+ * Usage:
+ *   DATABASE_URL=... npx tsx server/scripts/reprobe-unknown-agents.ts --dry-run
+ *   DATABASE_URL=... npx tsx server/scripts/reprobe-unknown-agents.ts
+ */
+
+import { initializeDatabase, closeDatabase, query } from '../src/db/client.js';
+import { AgentSnapshotDatabase } from '../src/db/agent-snapshot-db.js';
+import { CapabilityDiscovery } from '../src/capabilities.js';
+import type { Agent } from '../src/types.js';
+
+const PROBE_TIMEOUT_MS = 30_000;
+const CONCURRENCY = 5;
+const STILL_UNKNOWN_SAMPLE = 10;
+
+export type InferredType = 'sales' | 'creative' | 'signals' | 'unknown';
+
+export interface AgentToProbe {
+  url: string;
+  protocol: 'mcp' | 'a2a';
+  name: string;
+  hadSnapshot: boolean;
+}
+
+export interface ReprobeReport {
+  scanned: number;
+  newly_classified: { sales: number; creative: number; signals: number; buying: number };
+  still_unknown: number;
+  still_unknown_sample: string[];
+  probe_failed: number;
+  dns_failed: number;
+  skipped_already_classified: number;
+  elapsed_ms: number;
+  dry_run: boolean;
+}
+
+/** Shape of a single probe outcome — exposed for tests. */
+export interface ProbeOutcome {
+  url: string;
+  inferred: InferredType | null;
+  classification: 'classified' | 'still_unknown' | 'probe_failed' | 'dns_failed';
+}
+
+/**
+ * Pure aggregator. Folds a stream of probe outcomes into a report. Pulled
+ * out so the test can pin the report-shape contract without touching the DB
+ * or network. The script's main loop calls this with the live outcomes.
+ */
+export function aggregateOutcomes(
+  outcomes: ProbeOutcome[],
+  options: { scanned: number; skipped: number; elapsedMs: number; dryRun: boolean },
+): ReprobeReport {
+  const newly_classified = { sales: 0, creative: 0, signals: 0, buying: 0 };
+  const still_unknown_sample: string[] = [];
+  let still_unknown = 0;
+  let probe_failed = 0;
+  let dns_failed = 0;
+
+  for (const o of outcomes) {
+    switch (o.classification) {
+      case 'classified':
+        if (o.inferred === 'sales') newly_classified.sales++;
+        else if (o.inferred === 'creative') newly_classified.creative++;
+        else if (o.inferred === 'signals') newly_classified.signals++;
+        // 'buying' is reserved for future probe paths — never returned today,
+        // but the report key is part of the contract for consumers.
+        break;
+      case 'still_unknown':
+        still_unknown++;
+        if (still_unknown_sample.length < STILL_UNKNOWN_SAMPLE) {
+          still_unknown_sample.push(o.url);
+        }
+        break;
+      case 'probe_failed':
+        probe_failed++;
+        break;
+      case 'dns_failed':
+        dns_failed++;
+        break;
+    }
+  }
+
+  return {
+    scanned: options.scanned,
+    newly_classified,
+    still_unknown,
+    still_unknown_sample,
+    probe_failed,
+    dns_failed,
+    skipped_already_classified: options.skipped,
+    elapsed_ms: options.elapsedMs,
+    dry_run: options.dryRun,
+  };
+}
+
+/**
+ * Heuristic — match Node's DNS / connect-refused error shapes. We classify
+ * those as `dns_failed` to separate "agent host is gone" from "agent host is
+ * up but refused / timed out the probe" (which goes into `probe_failed`).
+ */
+export function isDnsOrConnectFailure(errMsg: string | undefined | null): boolean {
+  if (!errMsg) return false;
+  const m = errMsg.toUpperCase();
+  return (
+    m.includes('ENOTFOUND') ||
+    m.includes('EAI_AGAIN') ||
+    m.includes('NXDOMAIN') ||
+    m.includes('ECONNREFUSED') ||
+    m.includes('EHOSTUNREACH') ||
+    m.includes('ENETUNREACH')
+  );
+}
+
+/**
+ * Select every agent we should re-probe.
+ *
+ * Two source sets unioned:
+ *   A) `agent_capabilities_snapshot` rows where `inferred_type IS NULL` —
+ *      probed but unclassified. These are the "stuck on unknown" rows.
+ *   B) `member_profiles.agents[]` and `discovered_agents` URLs that have NO
+ *      snapshot row at all — never been probed.
+ *
+ * In `--dry-run` we always include set A; in a real run the second pass of
+ * the script would naturally see fewer set-A rows because the first pass
+ * upserted real types for the ones it could classify (idempotency).
+ */
+async function selectAgentsToProbe(): Promise<AgentToProbe[]> {
+  // (A) Snapshots with NULL inferred_type — reuse the snapshot's known protocol.
+  const stuckResult = await query<{
+    agent_url: string;
+    protocol: 'mcp' | 'a2a' | null;
+  }>(
+    `SELECT agent_url, protocol
+       FROM agent_capabilities_snapshot
+      WHERE inferred_type IS NULL`,
+  );
+
+  // (B) Registered + discovered agents that have no snapshot row at all.
+  // We pull URLs from both sources and exclude ones that already appear in
+  // the snapshot table (regardless of inferred_type — set A handles those).
+  const missingResult = await query<{ url: string; protocol: string | null; name: string | null }>(
+    `WITH known AS (
+        SELECT agent_url FROM agent_capabilities_snapshot
+      ),
+      registered AS (
+        SELECT DISTINCT
+               (a->>'url')        AS url,
+               'mcp'::text        AS protocol,
+               (a->>'name')       AS name
+          FROM member_profiles mp,
+               LATERAL jsonb_array_elements(COALESCE(mp.agents, '[]'::jsonb)) AS a
+         WHERE a->>'url' IS NOT NULL
+      ),
+      discovered AS (
+        SELECT da.agent_url AS url,
+               da.protocol  AS protocol,
+               da.name      AS name
+          FROM discovered_agents da
+      )
+      SELECT url, protocol, name FROM registered
+       WHERE url NOT IN (SELECT agent_url FROM known)
+      UNION
+      SELECT url, protocol, name FROM discovered
+       WHERE url NOT IN (SELECT agent_url FROM known)`,
+  );
+
+  const seen = new Set<string>();
+  const out: AgentToProbe[] = [];
+
+  for (const row of stuckResult.rows) {
+    if (seen.has(row.agent_url)) continue;
+    seen.add(row.agent_url);
+    out.push({
+      url: row.agent_url,
+      protocol: row.protocol === 'a2a' ? 'a2a' : 'mcp',
+      name: row.agent_url,
+      hadSnapshot: true,
+    });
+  }
+  for (const row of missingResult.rows) {
+    if (seen.has(row.url)) continue;
+    seen.add(row.url);
+    out.push({
+      url: row.url,
+      protocol: row.protocol === 'a2a' ? 'a2a' : 'mcp',
+      name: row.name || row.url,
+      hadSnapshot: false,
+    });
+  }
+
+  return out;
+}
+
+/**
+ * Probe a single agent with the extended 30s timeout. Reuses the live
+ * crawler's `discoverCapabilities` so the type-inference logic is identical.
+ * Classifies the result for the report aggregator.
+ */
+async function probeOne(
+  agent: AgentToProbe,
+  capabilityDiscovery: CapabilityDiscovery,
+  snapshotDb: AgentSnapshotDatabase,
+  dryRun: boolean,
+): Promise<ProbeOutcome> {
+  const probeAgent: Agent = {
+    name: agent.name,
+    url: agent.url,
+    type: 'unknown',
+    protocol: agent.protocol,
+    description: '',
+    mcp_endpoint: agent.url,
+    contact: { name: '', email: '', website: '' },
+    added_date: new Date().toISOString().split('T')[0],
+  };
+
+  let profile;
+  try {
+    profile = await Promise.race([
+      capabilityDiscovery.discoverCapabilities(probeAgent),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('Probe timeout')), PROBE_TIMEOUT_MS),
+      ),
+    ]);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      url: agent.url,
+      inferred: null,
+      classification: isDnsOrConnectFailure(msg) ? 'dns_failed' : 'probe_failed',
+    };
+  }
+
+  const inferred = capabilityDiscovery.inferTypeFromProfile(profile);
+
+  if (!dryRun) {
+    await snapshotDb.upsertCapabilities(profile, inferred === 'unknown' ? null : inferred);
+  }
+
+  if (inferred !== 'unknown') {
+    return { url: agent.url, inferred, classification: 'classified' };
+  }
+
+  // Probe completed but returned no classifiable type. If the helper recorded
+  // a discovery_error, that's a soft probe failure (HTTP 5xx, OAuth wall,
+  // malformed tools list). DNS-shaped errors stay in `dns_failed`; everything
+  // else lands in `probe_failed` so we can scope the retry strategy.
+  if (profile.discovery_error) {
+    return {
+      url: agent.url,
+      inferred: null,
+      classification: isDnsOrConnectFailure(profile.discovery_error) ? 'dns_failed' : 'probe_failed',
+    };
+  }
+
+  return { url: agent.url, inferred: null, classification: 'still_unknown' };
+}
+
+function formatReport(report: ReprobeReport): string {
+  const lines: string[] = [];
+  lines.push('');
+  lines.push(`Mode:                          ${report.dry_run ? 'DRY RUN (no writes)' : 'WRITE'}`);
+  lines.push(`Agents scanned:                ${report.scanned}`);
+  lines.push(`Skipped (already classified):  ${report.skipped_already_classified}`);
+  lines.push(`Newly classified — sales:      ${report.newly_classified.sales}`);
+  lines.push(`Newly classified — creative:   ${report.newly_classified.creative}`);
+  lines.push(`Newly classified — signals:    ${report.newly_classified.signals}`);
+  lines.push(`Newly classified — buying:     ${report.newly_classified.buying}`);
+  lines.push(`Still unknown:                 ${report.still_unknown}`);
+  lines.push(`Probe failed (HTTP/timeout):   ${report.probe_failed}`);
+  lines.push(`DNS / connect refused:         ${report.dns_failed}`);
+  lines.push(`Elapsed:                       ${(report.elapsed_ms / 1000).toFixed(1)}s`);
+  if (report.still_unknown_sample.length > 0) {
+    lines.push('');
+    lines.push(`Still-unknown sample (first ${report.still_unknown_sample.length}):`);
+    for (const url of report.still_unknown_sample) {
+      lines.push(`  ${url}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes('--dry-run');
+
+  initializeDatabase({ connectionString: process.env.DATABASE_URL || '' });
+
+  const snapshotDb = new AgentSnapshotDatabase();
+  const capabilityDiscovery = new CapabilityDiscovery();
+
+  // PR #3541 (export of resolveAgentTypes) has not landed on main yet.
+  // We try the import dynamically; if it fails we skip the member_profiles
+  // propagation step. See the file header for the upgrade path.
+  let resolveAgentTypes: ((agents: unknown) => Promise<unknown>) | null = null;
+  try {
+    const mod: unknown = await import('../src/routes/member-profiles.js');
+    const candidate = (mod as { resolveAgentTypes?: unknown }).resolveAgentTypes;
+    if (typeof candidate === 'function') {
+      resolveAgentTypes = candidate as (agents: unknown) => Promise<unknown>;
+    }
+  } catch {
+    // intentional: dynamic import may be unavailable in some test envs
+  }
+  if (!resolveAgentTypes) {
+    console.warn(
+      '[warn] resolveAgentTypes not exported from member-profiles.ts — skipping ' +
+        'member_profiles.agents[] refresh. Land #3541 to enable it.',
+    );
+  }
+
+  console.log(`[reprobe] timeout=${PROBE_TIMEOUT_MS}ms concurrency=${CONCURRENCY} mode=${dryRun ? 'dry-run' : 'write'}`);
+
+  const start = Date.now();
+  const candidates = await selectAgentsToProbe();
+  console.log(`[reprobe] candidates=${candidates.length}`);
+
+  const outcomes: ProbeOutcome[] = [];
+  let skipped = 0;
+
+  for (let i = 0; i < candidates.length; i += CONCURRENCY) {
+    const batch = candidates.slice(i, i + CONCURRENCY);
+    const results = await Promise.allSettled(
+      batch.map(async (agent) => {
+        // Idempotency on real runs: a candidate from a previous pass may have
+        // been classified by a parallel crawler tick between selection and
+        // probe. Re-check the snapshot row and skip if it's now non-null.
+        if (!dryRun && agent.hadSnapshot) {
+          const snaps = await snapshotDb.bulkGetCapabilities([agent.url]);
+          const cur = snaps.get(agent.url);
+          if (cur && cur.inferred_type) {
+            skipped++;
+            return null;
+          }
+        }
+        return probeOne(agent, capabilityDiscovery, snapshotDb, dryRun);
+      }),
+    );
+
+    for (let j = 0; j < results.length; j++) {
+      const r = results[j];
+      const agent = batch[j];
+      if (r.status === 'fulfilled') {
+        if (r.value !== null) outcomes.push(r.value);
+      } else {
+        const msg = r.reason instanceof Error ? r.reason.message : String(r.reason);
+        outcomes.push({
+          url: agent.url,
+          inferred: null,
+          classification: isDnsOrConnectFailure(msg) ? 'dns_failed' : 'probe_failed',
+        });
+      }
+    }
+
+    // Optional: refresh member_profiles.agents[] for newly-classified URLs.
+    // Best-effort, keyed off the agent URLs that just changed type.
+    if (!dryRun && resolveAgentTypes) {
+      const flipped = new Set(
+        outcomes
+          .slice(-batch.length)
+          .filter((o) => o.classification === 'classified')
+          .map((o) => o.url),
+      );
+      if (flipped.size > 0) {
+        try {
+          const profiles = await query<{ id: string; agents: unknown }>(
+            `SELECT id, agents
+               FROM member_profiles
+              WHERE EXISTS (
+                      SELECT 1
+                        FROM jsonb_array_elements(COALESCE(agents, '[]'::jsonb)) AS a
+                       WHERE a->>'url' = ANY($1)
+                    )`,
+            [Array.from(flipped)],
+          );
+          for (const row of profiles.rows) {
+            const next = await resolveAgentTypes(row.agents);
+            await query(
+              `UPDATE member_profiles SET agents = $1, updated_at = NOW() WHERE id = $2`,
+              [JSON.stringify(next), row.id],
+            );
+          }
+        } catch (err) {
+          console.warn(
+            `[warn] resolveAgentTypes propagation failed for batch: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    }
+  }
+
+  const report = aggregateOutcomes(outcomes, {
+    scanned: candidates.length,
+    skipped,
+    elapsedMs: Date.now() - start,
+    dryRun,
+  });
+
+  console.log(formatReport(report));
+  console.log('\n' + JSON.stringify(report));
+
+  await closeDatabase();
+}
+
+// Only execute when run directly (not when imported by tests).
+const isDirectRun =
+  typeof process !== 'undefined' &&
+  Array.isArray(process.argv) &&
+  process.argv[1] !== undefined &&
+  process.argv[1].endsWith('reprobe-unknown-agents.ts');
+
+if (isDirectRun) {
+  main()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/server/scripts/reprobe-unknown-agents.ts
+++ b/server/scripts/reprobe-unknown-agents.ts
@@ -14,18 +14,22 @@
  *      the existing `CapabilityDiscovery.discoverCapabilities` helper — same
  *      probe path the live crawler uses, no parallel implementation.
  *   3. Writes the new snapshot via `AgentSnapshotDatabase.upsertCapabilities`
- *      — same write path as the crawler.
- *   4. Reports a per-type tally + sample of still-unknown URLs.
+ *      — same write path as the crawler. **Crucially**, the write is skipped
+ *      on probe failure for agents that already had a snapshot row, so a
+ *      transient probe failure cannot overwrite a previously-classified row
+ *      back to NULL (the silent-corruption window).
+ *   4. After each batch, refreshes `member_profiles.agents[]` for any URLs
+ *      whose type just flipped, via `resolveAgentTypes` (#3541, now on main).
+ *   5. Reports a per-type tally + sample of still-unknown URLs + per-agent
+ *      timing summary so the operator can see the slow tail.
  *
- * Idempotent: a real run skips agents that have since become classified.
- * `--dry-run` mode probes everything but writes nothing.
- *
- * Note on member_profiles propagation: PR #3541 will export
- * `resolveAgentTypes` from `server/src/routes/member-profiles.ts` so this
- * script can refresh `member_profiles.agents[]` after each agent. As of this
- * branch, that export does not exist on `main`. The script logs a warning
- * and skips that step; once #3541 lands, the dynamic import below resolves
- * and the propagation runs automatically.
+ * Idempotency contract:
+ *   - A real run skips agents whose snapshot row got classified between
+ *     selection and probe (parallel crawler tick).
+ *   - A failed re-probe (timeout, HTTP 5xx, DNS) on an already-known agent
+ *     does NOT touch the row — the prior snapshot stands.
+ *   - A failed first-time probe (no prior snapshot) is also a no-op write
+ *     today; the next run picks the agent up from set B again.
  *
  * Usage:
  *   DATABASE_URL=... npx tsx server/scripts/reprobe-unknown-agents.ts --dry-run
@@ -34,12 +38,14 @@
 
 import { initializeDatabase, closeDatabase, query } from '../src/db/client.js';
 import { AgentSnapshotDatabase } from '../src/db/agent-snapshot-db.js';
-import { CapabilityDiscovery } from '../src/capabilities.js';
+import { CapabilityDiscovery, type AgentCapabilityProfile } from '../src/capabilities.js';
+import { resolveAgentTypes } from '../src/routes/member-profiles.js';
 import type { Agent } from '../src/types.js';
 
 const PROBE_TIMEOUT_MS = 30_000;
 const CONCURRENCY = 5;
 const STILL_UNKNOWN_SAMPLE = 10;
+const SLOW_TAIL_SAMPLE = 5;
 
 export type InferredType = 'sales' | 'creative' | 'signals' | 'unknown';
 
@@ -58,7 +64,11 @@ export interface ReprobeReport {
   probe_failed: number;
   dns_failed: number;
   skipped_already_classified: number;
+  /** Count of agents whose existing snapshot we deliberately did NOT overwrite on a probe failure. */
+  preserved_existing_classification: number;
   elapsed_ms: number;
+  /** Slowest N probes (URL + ms) so operators can see the tail. */
+  slowest: { url: string; elapsed_ms: number }[];
   dry_run: boolean;
 }
 
@@ -67,6 +77,9 @@ export interface ProbeOutcome {
   url: string;
   inferred: InferredType | null;
   classification: 'classified' | 'still_unknown' | 'probe_failed' | 'dns_failed';
+  elapsed_ms: number;
+  /** True iff the script suppressed a write to preserve an existing snapshot row. */
+  preserved_existing?: boolean;
 }
 
 /**
@@ -83,8 +96,10 @@ export function aggregateOutcomes(
   let still_unknown = 0;
   let probe_failed = 0;
   let dns_failed = 0;
+  let preserved = 0;
 
   for (const o of outcomes) {
+    if (o.preserved_existing) preserved++;
     switch (o.classification) {
       case 'classified':
         if (o.inferred === 'sales') newly_classified.sales++;
@@ -108,6 +123,11 @@ export function aggregateOutcomes(
     }
   }
 
+  const slowest = [...outcomes]
+    .sort((a, b) => b.elapsed_ms - a.elapsed_ms)
+    .slice(0, SLOW_TAIL_SAMPLE)
+    .map((o) => ({ url: o.url, elapsed_ms: o.elapsed_ms }));
+
   return {
     scanned: options.scanned,
     newly_classified,
@@ -116,7 +136,9 @@ export function aggregateOutcomes(
     probe_failed,
     dns_failed,
     skipped_already_classified: options.skipped,
+    preserved_existing_classification: preserved,
     elapsed_ms: options.elapsedMs,
+    slowest,
     dry_run: options.dryRun,
   };
 }
@@ -137,6 +159,48 @@ export function isDnsOrConnectFailure(errMsg: string | undefined | null): boolea
     m.includes('EHOSTUNREACH') ||
     m.includes('ENETUNREACH')
   );
+}
+
+/**
+ * Decide whether a probe outcome should be written to the snapshot table.
+ *
+ * The silent-corruption rule (Brian's bar): a transient probe failure must
+ * NEVER overwrite a previously-classified row back to NULL. We split the
+ * decision:
+ *
+ *   - probe classified the agent       → ALWAYS write (this is the win path).
+ *   - probe succeeded, no class        → write NULL (set A row was already
+ *                                         null; set B row is new).
+ *   - probe FAILED (timeout/HTTP/DNS)
+ *       - hadSnapshot=true             → DO NOT WRITE. Either the row was
+ *                                         null and stays null, or a parallel
+ *                                         crawler tick raced ahead and
+ *                                         classified it. We do not clobber.
+ *       - hadSnapshot=false (set B)    → DO NOT WRITE either. We have no
+ *                                         protocol/tool-list ground truth
+ *                                         to write a meaningful row, and
+ *                                         the next run will retry from set B.
+ */
+export type WriteDecision =
+  | { write: true; inferred: InferredType | null }
+  | { write: false; reason: 'preserve_existing' | 'no_ground_truth' };
+
+export function decideWrite(
+  classification: ProbeOutcome['classification'],
+  inferred: InferredType,
+  hadSnapshot: boolean,
+): WriteDecision {
+  if (classification === 'classified') {
+    return { write: true, inferred };
+  }
+  if (classification === 'still_unknown') {
+    return { write: true, inferred: null };
+  }
+  // probe_failed | dns_failed
+  if (hadSnapshot) {
+    return { write: false, reason: 'preserve_existing' };
+  }
+  return { write: false, reason: 'no_ground_truth' };
 }
 
 /**
@@ -223,13 +287,26 @@ async function selectAgentsToProbe(): Promise<AgentToProbe[]> {
  * Probe a single agent with the extended 30s timeout. Reuses the live
  * crawler's `discoverCapabilities` so the type-inference logic is identical.
  * Classifies the result for the report aggregator.
+ *
+ * Exposed for testing. The DB and discovery deps are passed in so the test
+ * can drive the probe outcome (success / probe_failed / dns_failed) without
+ * a live network or Postgres, and assert the silent-corruption rule.
  */
-async function probeOne(
+export async function probeOne(
   agent: AgentToProbe,
-  capabilityDiscovery: CapabilityDiscovery,
-  snapshotDb: AgentSnapshotDatabase,
+  deps: {
+    discoverCapabilities: (a: Agent) => Promise<AgentCapabilityProfile>;
+    inferTypeFromProfile: (p: AgentCapabilityProfile) => InferredType;
+    upsertCapabilities: (p: AgentCapabilityProfile, t: string | null) => Promise<void>;
+    timeoutMs?: number;
+    now?: () => number;
+  },
   dryRun: boolean,
 ): Promise<ProbeOutcome> {
+  const timeoutMs = deps.timeoutMs ?? PROBE_TIMEOUT_MS;
+  const now = deps.now ?? Date.now;
+  const startedAt = now();
+
   const probeAgent: Agent = {
     name: agent.name,
     url: agent.url,
@@ -241,46 +318,59 @@ async function probeOne(
     added_date: new Date().toISOString().split('T')[0],
   };
 
-  let profile;
+  let profile: AgentCapabilityProfile;
   try {
     profile = await Promise.race([
-      capabilityDiscovery.discoverCapabilities(probeAgent),
+      deps.discoverCapabilities(probeAgent),
       new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('Probe timeout')), PROBE_TIMEOUT_MS),
+        setTimeout(() => reject(new Error('Probe timeout')), timeoutMs),
       ),
     ]);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    const classification: ProbeOutcome['classification'] =
+      isDnsOrConnectFailure(msg) ? 'dns_failed' : 'probe_failed';
+    const decision = decideWrite(classification, 'unknown', agent.hadSnapshot);
+    // No write on failure — see decideWrite() doc for the silent-corruption rule.
     return {
       url: agent.url,
       inferred: null,
-      classification: isDnsOrConnectFailure(msg) ? 'dns_failed' : 'probe_failed',
+      classification,
+      elapsed_ms: now() - startedAt,
+      preserved_existing: !decision.write,
     };
   }
 
-  const inferred = capabilityDiscovery.inferTypeFromProfile(profile);
+  const inferred = deps.inferTypeFromProfile(profile);
 
-  if (!dryRun) {
-    await snapshotDb.upsertCapabilities(profile, inferred === 'unknown' ? null : inferred);
-  }
-
+  // Determine classification BEFORE deciding to write. The write decision
+  // must respect the silent-corruption rule above.
+  let classification: ProbeOutcome['classification'];
   if (inferred !== 'unknown') {
-    return { url: agent.url, inferred, classification: 'classified' };
+    classification = 'classified';
+  } else if (profile.discovery_error) {
+    // Probe completed but the helper recorded a discovery error (HTTP 5xx,
+    // OAuth wall, malformed tools list). Route DNS-shaped errors to
+    // dns_failed; everything else to probe_failed so we can scope retry.
+    classification = isDnsOrConnectFailure(profile.discovery_error)
+      ? 'dns_failed'
+      : 'probe_failed';
+  } else {
+    classification = 'still_unknown';
   }
 
-  // Probe completed but returned no classifiable type. If the helper recorded
-  // a discovery_error, that's a soft probe failure (HTTP 5xx, OAuth wall,
-  // malformed tools list). DNS-shaped errors stay in `dns_failed`; everything
-  // else lands in `probe_failed` so we can scope the retry strategy.
-  if (profile.discovery_error) {
-    return {
-      url: agent.url,
-      inferred: null,
-      classification: isDnsOrConnectFailure(profile.discovery_error) ? 'dns_failed' : 'probe_failed',
-    };
+  const decision = decideWrite(classification, inferred, agent.hadSnapshot);
+  if (!dryRun && decision.write) {
+    await deps.upsertCapabilities(profile, decision.inferred);
   }
 
-  return { url: agent.url, inferred: null, classification: 'still_unknown' };
+  return {
+    url: agent.url,
+    inferred: inferred === 'unknown' ? null : inferred,
+    classification,
+    elapsed_ms: now() - startedAt,
+    preserved_existing: !decision.write,
+  };
 }
 
 function formatReport(report: ReprobeReport): string {
@@ -289,6 +379,7 @@ function formatReport(report: ReprobeReport): string {
   lines.push(`Mode:                          ${report.dry_run ? 'DRY RUN (no writes)' : 'WRITE'}`);
   lines.push(`Agents scanned:                ${report.scanned}`);
   lines.push(`Skipped (already classified):  ${report.skipped_already_classified}`);
+  lines.push(`Preserved existing row:        ${report.preserved_existing_classification}`);
   lines.push(`Newly classified — sales:      ${report.newly_classified.sales}`);
   lines.push(`Newly classified — creative:   ${report.newly_classified.creative}`);
   lines.push(`Newly classified — signals:    ${report.newly_classified.signals}`);
@@ -296,7 +387,14 @@ function formatReport(report: ReprobeReport): string {
   lines.push(`Still unknown:                 ${report.still_unknown}`);
   lines.push(`Probe failed (HTTP/timeout):   ${report.probe_failed}`);
   lines.push(`DNS / connect refused:         ${report.dns_failed}`);
-  lines.push(`Elapsed:                       ${(report.elapsed_ms / 1000).toFixed(1)}s`);
+  lines.push(`Elapsed (total):               ${(report.elapsed_ms / 1000).toFixed(1)}s`);
+  if (report.slowest.length > 0) {
+    lines.push('');
+    lines.push(`Slowest probes (top ${report.slowest.length}):`);
+    for (const s of report.slowest) {
+      lines.push(`  ${(s.elapsed_ms / 1000).toFixed(1).padStart(6)}s  ${s.url}`);
+    }
+  }
   if (report.still_unknown_sample.length > 0) {
     lines.push('');
     lines.push(`Still-unknown sample (first ${report.still_unknown_sample.length}):`);
@@ -310,30 +408,20 @@ function formatReport(report: ReprobeReport): string {
 async function main(): Promise<void> {
   const dryRun = process.argv.includes('--dry-run');
 
-  initializeDatabase({ connectionString: process.env.DATABASE_URL || '' });
+  // Fail-loud on missing / empty DATABASE_URL — never silently connect to
+  // something other than what the operator intended.
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl || databaseUrl.trim().length === 0) {
+    console.error(
+      '[reprobe] FATAL: DATABASE_URL is not set. Refusing to run with empty connection string.',
+    );
+    process.exit(2);
+  }
+
+  initializeDatabase({ connectionString: databaseUrl });
 
   const snapshotDb = new AgentSnapshotDatabase();
   const capabilityDiscovery = new CapabilityDiscovery();
-
-  // PR #3541 (export of resolveAgentTypes) has not landed on main yet.
-  // We try the import dynamically; if it fails we skip the member_profiles
-  // propagation step. See the file header for the upgrade path.
-  let resolveAgentTypes: ((agents: unknown) => Promise<unknown>) | null = null;
-  try {
-    const mod: unknown = await import('../src/routes/member-profiles.js');
-    const candidate = (mod as { resolveAgentTypes?: unknown }).resolveAgentTypes;
-    if (typeof candidate === 'function') {
-      resolveAgentTypes = candidate as (agents: unknown) => Promise<unknown>;
-    }
-  } catch {
-    // intentional: dynamic import may be unavailable in some test envs
-  }
-  if (!resolveAgentTypes) {
-    console.warn(
-      '[warn] resolveAgentTypes not exported from member-profiles.ts — skipping ' +
-        'member_profiles.agents[] refresh. Land #3541 to enable it.',
-    );
-  }
 
   console.log(`[reprobe] timeout=${PROBE_TIMEOUT_MS}ms concurrency=${CONCURRENCY} mode=${dryRun ? 'dry-run' : 'write'}`);
 
@@ -359,7 +447,15 @@ async function main(): Promise<void> {
             return null;
           }
         }
-        return probeOne(agent, capabilityDiscovery, snapshotDb, dryRun);
+        return probeOne(
+          agent,
+          {
+            discoverCapabilities: (a) => capabilityDiscovery.discoverCapabilities(a),
+            inferTypeFromProfile: (p) => capabilityDiscovery.inferTypeFromProfile(p),
+            upsertCapabilities: (p, t) => snapshotDb.upsertCapabilities(p, t),
+          },
+          dryRun,
+        );
       }),
     );
 
@@ -374,13 +470,16 @@ async function main(): Promise<void> {
           url: agent.url,
           inferred: null,
           classification: isDnsOrConnectFailure(msg) ? 'dns_failed' : 'probe_failed',
+          elapsed_ms: 0,
+          preserved_existing: agent.hadSnapshot,
         });
       }
     }
 
-    // Optional: refresh member_profiles.agents[] for newly-classified URLs.
-    // Best-effort, keyed off the agent URLs that just changed type.
-    if (!dryRun && resolveAgentTypes) {
+    // Refresh member_profiles.agents[] for newly-classified URLs. Best-
+    // effort, keyed off the agent URLs that just changed type. #3541 has
+    // landed; resolveAgentTypes is statically imported above.
+    if (!dryRun) {
       const flipped = new Set(
         outcomes
           .slice(-batch.length)

--- a/server/tests/unit/reprobe-unknown-agents.test.ts
+++ b/server/tests/unit/reprobe-unknown-agents.test.ts
@@ -1,11 +1,19 @@
-// Set WorkOS env vars BEFORE any imports — `member-profiles.ts` (transitively
-// loaded via the script's static `import { resolveAgentTypes }`) constructs
-// a WorkOS client at module-init time. We don't exercise WorkOS in this
-// test, so dummy creds are fine; the import just needs to not throw.
-process.env.WORKOS_API_KEY ||= 'sk_test_dummy_for_unit_tests';
-process.env.WORKOS_CLIENT_ID ||= 'client_test_dummy_for_unit_tests';
-
+// Don't add `process.env.X ||= '...'` shims at the top of this file. ESM
+// imports are hoisted above module-body statements, so the static `import`
+// of the script below transitively loads `member-profiles.ts`, whose
+// `new WorkOS(...)` runs at module-init time — BEFORE any env-var
+// assignment in this file gets a chance to run. The shim looks correct
+// but is a no-op. Mock the member-profiles module instead so WorkOS init
+// never fires. (Pattern matches stripe-client mocks added in #3553.)
 import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../src/routes/member-profiles.js', () => ({
+  // The reprobe script only consumes `resolveAgentTypes` to refresh
+  // member_profiles.agents[] after a batch. Unit tests don't exercise
+  // that propagation path, so an identity stub is sufficient.
+  resolveAgentTypes: vi.fn(async (agents: unknown) => agents),
+}));
+
 import {
   aggregateOutcomes,
   decideWrite,

--- a/server/tests/unit/reprobe-unknown-agents.test.ts
+++ b/server/tests/unit/reprobe-unknown-agents.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import {
+  aggregateOutcomes,
+  isDnsOrConnectFailure,
+  type ProbeOutcome,
+} from '../../scripts/reprobe-unknown-agents.js';
+
+// Pure-logic regression tests for the report-shape contract emitted by
+// `reprobe-unknown-agents.ts`. The script's main loop is too coupled (DB,
+// dynamic import of member-profiles) to test cheaply, but the *aggregator*
+// is a pure function — we feed it synthetic outcomes and pin the report
+// shape that operators paste back into the issue. If anyone changes the
+// report shape, this test fails loudly.
+//
+// Style mirrors `crawler-type-update-policy.test.ts` (5/5 pass pattern).
+
+describe('reprobe report aggregator', () => {
+  it('groups classified outcomes by inferred type', () => {
+    const outcomes: ProbeOutcome[] = [
+      { url: 'https://a/', inferred: 'sales', classification: 'classified' },
+      { url: 'https://b/', inferred: 'sales', classification: 'classified' },
+      { url: 'https://c/', inferred: 'creative', classification: 'classified' },
+      { url: 'https://d/', inferred: 'signals', classification: 'classified' },
+    ];
+    const report = aggregateOutcomes(outcomes, {
+      scanned: 4,
+      skipped: 0,
+      elapsedMs: 1234,
+      dryRun: false,
+    });
+    expect(report.newly_classified).toEqual({ sales: 2, creative: 1, signals: 1, buying: 0 });
+    expect(report.still_unknown).toBe(0);
+    expect(report.probe_failed).toBe(0);
+    expect(report.dns_failed).toBe(0);
+    expect(report.scanned).toBe(4);
+    expect(report.elapsed_ms).toBe(1234);
+    expect(report.dry_run).toBe(false);
+  });
+
+  it('counts still_unknown separately and caps the sample at 10 URLs', () => {
+    const outcomes: ProbeOutcome[] = [];
+    for (let i = 0; i < 25; i++) {
+      outcomes.push({ url: `https://u${i}/`, inferred: null, classification: 'still_unknown' });
+    }
+    const report = aggregateOutcomes(outcomes, {
+      scanned: 25,
+      skipped: 0,
+      elapsedMs: 0,
+      dryRun: true,
+    });
+    expect(report.still_unknown).toBe(25);
+    expect(report.still_unknown_sample.length).toBe(10);
+    expect(report.still_unknown_sample[0]).toBe('https://u0/');
+    expect(report.newly_classified).toEqual({ sales: 0, creative: 0, signals: 0, buying: 0 });
+  });
+
+  it('separates probe_failed (HTTP/timeout) from dns_failed', () => {
+    const outcomes: ProbeOutcome[] = [
+      { url: 'https://gone/',     inferred: null, classification: 'dns_failed' },
+      { url: 'https://refused/',  inferred: null, classification: 'dns_failed' },
+      { url: 'https://5xx/',      inferred: null, classification: 'probe_failed' },
+      { url: 'https://timeout/',  inferred: null, classification: 'probe_failed' },
+      { url: 'https://timeout2/', inferred: null, classification: 'probe_failed' },
+    ];
+    const report = aggregateOutcomes(outcomes, {
+      scanned: 5,
+      skipped: 0,
+      elapsedMs: 9999,
+      dryRun: false,
+    });
+    expect(report.dns_failed).toBe(2);
+    expect(report.probe_failed).toBe(3);
+    expect(report.still_unknown).toBe(0);
+    // 'unknown' inferred type should never reach this counter — that case is
+    // routed to still_unknown / probe_failed earlier in the pipeline.
+    expect(report.newly_classified).toEqual({ sales: 0, creative: 0, signals: 0, buying: 0 });
+  });
+
+  it('preserves report fields for operator paste-back: scanned, skipped, elapsed, dry_run', () => {
+    const report = aggregateOutcomes([], {
+      scanned: 100,
+      skipped: 7,
+      elapsedMs: 60_000,
+      dryRun: true,
+    });
+    expect(report.scanned).toBe(100);
+    expect(report.skipped_already_classified).toBe(7);
+    expect(report.elapsed_ms).toBe(60_000);
+    expect(report.dry_run).toBe(true);
+    expect(report.still_unknown_sample).toEqual([]);
+  });
+
+  it('classifies DNS / connect-refused error messages by name', () => {
+    expect(isDnsOrConnectFailure('getaddrinfo ENOTFOUND example.com')).toBe(true);
+    expect(isDnsOrConnectFailure('connect ECONNREFUSED 127.0.0.1:443')).toBe(true);
+    expect(isDnsOrConnectFailure('NXDOMAIN response')).toBe(true);
+    expect(isDnsOrConnectFailure('EHOSTUNREACH')).toBe(true);
+    // HTTP / timeout errors are NOT dns_failed — they go to probe_failed so
+    // we can scope retry-with-backoff at the right granularity.
+    expect(isDnsOrConnectFailure('Probe timeout')).toBe(false);
+    expect(isDnsOrConnectFailure('HTTP 503 Service Unavailable')).toBe(false);
+    expect(isDnsOrConnectFailure(undefined)).toBe(false);
+    expect(isDnsOrConnectFailure(null)).toBe(false);
+  });
+});

--- a/server/tests/unit/reprobe-unknown-agents.test.ts
+++ b/server/tests/unit/reprobe-unknown-agents.test.ts
@@ -1,32 +1,43 @@
-import { describe, it, expect } from 'vitest';
+// Set WorkOS env vars BEFORE any imports — `member-profiles.ts` (transitively
+// loaded via the script's static `import { resolveAgentTypes }`) constructs
+// a WorkOS client at module-init time. We don't exercise WorkOS in this
+// test, so dummy creds are fine; the import just needs to not throw.
+process.env.WORKOS_API_KEY ||= 'sk_test_dummy_for_unit_tests';
+process.env.WORKOS_CLIENT_ID ||= 'client_test_dummy_for_unit_tests';
+
+import { describe, it, expect, vi } from 'vitest';
 import {
   aggregateOutcomes,
+  decideWrite,
   isDnsOrConnectFailure,
+  probeOne,
+  type AgentToProbe,
   type ProbeOutcome,
 } from '../../scripts/reprobe-unknown-agents.js';
+import type { AgentCapabilityProfile } from '../../src/capabilities.js';
 
-// Pure-logic regression tests for the report-shape contract emitted by
-// `reprobe-unknown-agents.ts`. The script's main loop is too coupled (DB,
-// dynamic import of member-profiles) to test cheaply, but the *aggregator*
-// is a pure function — we feed it synthetic outcomes and pin the report
-// shape that operators paste back into the issue. If anyone changes the
-// report shape, this test fails loudly.
+// Tests for `reprobe-unknown-agents.ts`.
 //
-// Style mirrors `crawler-type-update-policy.test.ts` (5/5 pass pattern).
+// Coverage matrix (Brian's bar):
+//   (a) successful classification path        → "writes the new type" test
+//   (b) probe-failed path (timeout)           → "preserves existing on probe_failed" test
+//   (c) DNS-failed path (NXDOMAIN)            → "routes ENOTFOUND to dns_failed" test
+//   (d) idempotency on re-run after success   → "set-A SELECT filter prevents..." test
+//   (e) silent-corruption risk                → THE BIG ONE: a previously-classified
+//                                                 row must NOT regress on a transient
+//                                                 probe failure. Asserted directly via
+//                                                 `decideWrite` and `probeOne` mock.
 
 describe('reprobe report aggregator', () => {
   it('groups classified outcomes by inferred type', () => {
     const outcomes: ProbeOutcome[] = [
-      { url: 'https://a/', inferred: 'sales', classification: 'classified' },
-      { url: 'https://b/', inferred: 'sales', classification: 'classified' },
-      { url: 'https://c/', inferred: 'creative', classification: 'classified' },
-      { url: 'https://d/', inferred: 'signals', classification: 'classified' },
+      { url: 'https://a/', inferred: 'sales',    classification: 'classified', elapsed_ms: 1200 },
+      { url: 'https://b/', inferred: 'sales',    classification: 'classified', elapsed_ms: 800  },
+      { url: 'https://c/', inferred: 'creative', classification: 'classified', elapsed_ms: 500  },
+      { url: 'https://d/', inferred: 'signals',  classification: 'classified', elapsed_ms: 300  },
     ];
     const report = aggregateOutcomes(outcomes, {
-      scanned: 4,
-      skipped: 0,
-      elapsedMs: 1234,
-      dryRun: false,
+      scanned: 4, skipped: 0, elapsedMs: 1234, dryRun: false,
     });
     expect(report.newly_classified).toEqual({ sales: 2, creative: 1, signals: 1, buying: 0 });
     expect(report.still_unknown).toBe(0);
@@ -35,18 +46,19 @@ describe('reprobe report aggregator', () => {
     expect(report.scanned).toBe(4);
     expect(report.elapsed_ms).toBe(1234);
     expect(report.dry_run).toBe(false);
+    // Slowest-first ordering for operator visibility.
+    expect(report.slowest[0]).toEqual({ url: 'https://a/', elapsed_ms: 1200 });
   });
 
   it('counts still_unknown separately and caps the sample at 10 URLs', () => {
     const outcomes: ProbeOutcome[] = [];
     for (let i = 0; i < 25; i++) {
-      outcomes.push({ url: `https://u${i}/`, inferred: null, classification: 'still_unknown' });
+      outcomes.push({
+        url: `https://u${i}/`, inferred: null, classification: 'still_unknown', elapsed_ms: 0,
+      });
     }
     const report = aggregateOutcomes(outcomes, {
-      scanned: 25,
-      skipped: 0,
-      elapsedMs: 0,
-      dryRun: true,
+      scanned: 25, skipped: 0, elapsedMs: 0, dryRun: true,
     });
     expect(report.still_unknown).toBe(25);
     expect(report.still_unknown_sample.length).toBe(10);
@@ -56,38 +68,31 @@ describe('reprobe report aggregator', () => {
 
   it('separates probe_failed (HTTP/timeout) from dns_failed', () => {
     const outcomes: ProbeOutcome[] = [
-      { url: 'https://gone/',     inferred: null, classification: 'dns_failed' },
-      { url: 'https://refused/',  inferred: null, classification: 'dns_failed' },
-      { url: 'https://5xx/',      inferred: null, classification: 'probe_failed' },
-      { url: 'https://timeout/',  inferred: null, classification: 'probe_failed' },
-      { url: 'https://timeout2/', inferred: null, classification: 'probe_failed' },
+      { url: 'https://gone/',     inferred: null, classification: 'dns_failed',   elapsed_ms: 0 },
+      { url: 'https://refused/',  inferred: null, classification: 'dns_failed',   elapsed_ms: 0 },
+      { url: 'https://5xx/',      inferred: null, classification: 'probe_failed', elapsed_ms: 0 },
+      { url: 'https://timeout/',  inferred: null, classification: 'probe_failed', elapsed_ms: 0 },
+      { url: 'https://timeout2/', inferred: null, classification: 'probe_failed', elapsed_ms: 0 },
     ];
     const report = aggregateOutcomes(outcomes, {
-      scanned: 5,
-      skipped: 0,
-      elapsedMs: 9999,
-      dryRun: false,
+      scanned: 5, skipped: 0, elapsedMs: 9999, dryRun: false,
     });
     expect(report.dns_failed).toBe(2);
     expect(report.probe_failed).toBe(3);
     expect(report.still_unknown).toBe(0);
-    // 'unknown' inferred type should never reach this counter — that case is
-    // routed to still_unknown / probe_failed earlier in the pipeline.
     expect(report.newly_classified).toEqual({ sales: 0, creative: 0, signals: 0, buying: 0 });
   });
 
   it('preserves report fields for operator paste-back: scanned, skipped, elapsed, dry_run', () => {
     const report = aggregateOutcomes([], {
-      scanned: 100,
-      skipped: 7,
-      elapsedMs: 60_000,
-      dryRun: true,
+      scanned: 100, skipped: 7, elapsedMs: 60_000, dryRun: true,
     });
     expect(report.scanned).toBe(100);
     expect(report.skipped_already_classified).toBe(7);
     expect(report.elapsed_ms).toBe(60_000);
     expect(report.dry_run).toBe(true);
     expect(report.still_unknown_sample).toEqual([]);
+    expect(report.preserved_existing_classification).toBe(0);
   });
 
   it('classifies DNS / connect-refused error messages by name', () => {
@@ -95,11 +100,270 @@ describe('reprobe report aggregator', () => {
     expect(isDnsOrConnectFailure('connect ECONNREFUSED 127.0.0.1:443')).toBe(true);
     expect(isDnsOrConnectFailure('NXDOMAIN response')).toBe(true);
     expect(isDnsOrConnectFailure('EHOSTUNREACH')).toBe(true);
-    // HTTP / timeout errors are NOT dns_failed — they go to probe_failed so
-    // we can scope retry-with-backoff at the right granularity.
     expect(isDnsOrConnectFailure('Probe timeout')).toBe(false);
     expect(isDnsOrConnectFailure('HTTP 503 Service Unavailable')).toBe(false);
     expect(isDnsOrConnectFailure(undefined)).toBe(false);
     expect(isDnsOrConnectFailure(null)).toBe(false);
+  });
+});
+
+describe('reprobe write decision (silent-corruption rule)', () => {
+  it('always writes when probe classified the agent', () => {
+    expect(decideWrite('classified', 'sales', true)).toEqual({ write: true, inferred: 'sales' });
+    expect(decideWrite('classified', 'sales', false)).toEqual({ write: true, inferred: 'sales' });
+  });
+
+  it('writes NULL when probe succeeded but no class found (still_unknown)', () => {
+    expect(decideWrite('still_unknown', 'unknown', true)).toEqual({ write: true, inferred: null });
+    expect(decideWrite('still_unknown', 'unknown', false)).toEqual({ write: true, inferred: null });
+  });
+
+  it('REFUSES to write on probe_failed when row already exists (silent-corruption guard)', () => {
+    // This is the load-bearing case. If we wrote NULL here, a previously
+    // classified row could be regressed by a single transient HTTP 5xx. The
+    // crawler's upsertCapabilities does ON CONFLICT DO UPDATE inferred_type,
+    // so a NULL write would clobber 'sales' / 'creative' / 'signals'.
+    expect(decideWrite('probe_failed', 'unknown', true))
+      .toEqual({ write: false, reason: 'preserve_existing' });
+    expect(decideWrite('dns_failed', 'unknown', true))
+      .toEqual({ write: false, reason: 'preserve_existing' });
+  });
+
+  it('REFUSES to write on probe_failed for new agents (no ground truth)', () => {
+    expect(decideWrite('probe_failed', 'unknown', false))
+      .toEqual({ write: false, reason: 'no_ground_truth' });
+    expect(decideWrite('dns_failed', 'unknown', false))
+      .toEqual({ write: false, reason: 'no_ground_truth' });
+  });
+});
+
+describe('reprobe probeOne — end-to-end with mocked deps', () => {
+  function makeAgent(overrides: Partial<AgentToProbe> = {}): AgentToProbe {
+    return {
+      url: 'https://agent.example/',
+      protocol: 'mcp',
+      name: 'agent',
+      hadSnapshot: true,
+      ...overrides,
+    };
+  }
+
+  it('(a) successful classification path: writes the new type via upsert', async () => {
+    const upsert = vi.fn(async () => undefined);
+    const profile: AgentCapabilityProfile = {
+      agent_url: 'https://agent.example/',
+      protocol: 'mcp',
+      discovered_tools: [],
+      last_discovered: new Date().toISOString(),
+    };
+    const out = await probeOne(
+      makeAgent(),
+      {
+        discoverCapabilities: vi.fn(async () => profile),
+        inferTypeFromProfile: vi.fn(() => 'sales' as const),
+        upsertCapabilities: upsert,
+        timeoutMs: 100,
+        now: () => 1000,
+      },
+      false,
+    );
+    expect(out.classification).toBe('classified');
+    expect(out.inferred).toBe('sales');
+    expect(out.preserved_existing).toBe(false);
+    expect(upsert).toHaveBeenCalledTimes(1);
+    expect(upsert).toHaveBeenCalledWith(profile, 'sales');
+  });
+
+  it('(b) probe-failed path (timeout): does NOT call upsert; reports preserved_existing=true', async () => {
+    const upsert = vi.fn(async () => undefined);
+    // Hang past the timeout to force the timeout race rejection.
+    const out = await probeOne(
+      makeAgent({ hadSnapshot: true }),
+      {
+        discoverCapabilities: () => new Promise(() => {}),
+        inferTypeFromProfile: () => 'unknown',
+        upsertCapabilities: upsert,
+        timeoutMs: 10,
+      },
+      false,
+    );
+    expect(out.classification).toBe('probe_failed');
+    expect(out.preserved_existing).toBe(true);
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it('(c) DNS-failed path (NXDOMAIN): routes to dns_failed, no upsert', async () => {
+    const upsert = vi.fn(async () => undefined);
+    const out = await probeOne(
+      makeAgent({ hadSnapshot: true }),
+      {
+        discoverCapabilities: async () => {
+          throw new Error('getaddrinfo ENOTFOUND nope.example');
+        },
+        inferTypeFromProfile: () => 'unknown',
+        upsertCapabilities: upsert,
+        timeoutMs: 1000,
+      },
+      false,
+    );
+    expect(out.classification).toBe('dns_failed');
+    expect(out.preserved_existing).toBe(true);
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it('(c2) DNS-shaped error inside discovery_error field also routes to dns_failed', async () => {
+    const upsert = vi.fn(async () => undefined);
+    const profile: AgentCapabilityProfile = {
+      agent_url: 'https://agent.example/',
+      protocol: 'mcp',
+      discovered_tools: [],
+      last_discovered: new Date().toISOString(),
+      discovery_error: 'connect ECONNREFUSED 127.0.0.1:443',
+    };
+    const out = await probeOne(
+      makeAgent({ hadSnapshot: true }),
+      {
+        discoverCapabilities: async () => profile,
+        inferTypeFromProfile: () => 'unknown',
+        upsertCapabilities: upsert,
+        timeoutMs: 1000,
+      },
+      false,
+    );
+    expect(out.classification).toBe('dns_failed');
+    expect(out.preserved_existing).toBe(true);
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it('(c3) HTTP-5xx-shaped discovery_error routes to probe_failed (not dns_failed)', async () => {
+    const upsert = vi.fn(async () => undefined);
+    const profile: AgentCapabilityProfile = {
+      agent_url: 'https://agent.example/',
+      protocol: 'mcp',
+      discovered_tools: [],
+      last_discovered: new Date().toISOString(),
+      discovery_error: 'HTTP 503 Service Unavailable',
+    };
+    const out = await probeOne(
+      makeAgent({ hadSnapshot: true }),
+      {
+        discoverCapabilities: async () => profile,
+        inferTypeFromProfile: () => 'unknown',
+        upsertCapabilities: upsert,
+        timeoutMs: 1000,
+      },
+      false,
+    );
+    expect(out.classification).toBe('probe_failed');
+    expect(out.preserved_existing).toBe(true);
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it('(d) idempotency: probe succeeds (still_unknown) — write of NULL is safe because row was already null', async () => {
+    // A re-run on a known-NULL row that the second probe also can't classify.
+    // Writing NULL here is a no-op against the existing NULL row, so this
+    // path is allowed (and gives us a fresh last_discovered timestamp).
+    const upsert = vi.fn(async () => undefined);
+    const profile: AgentCapabilityProfile = {
+      agent_url: 'https://agent.example/',
+      protocol: 'mcp',
+      discovered_tools: [{ name: 'mystery_tool', description: '', input_schema: {}, verified_at: '' }],
+      last_discovered: new Date().toISOString(),
+    };
+    const out = await probeOne(
+      makeAgent({ hadSnapshot: true }),
+      {
+        discoverCapabilities: async () => profile,
+        inferTypeFromProfile: () => 'unknown',
+        upsertCapabilities: upsert,
+        timeoutMs: 1000,
+      },
+      false,
+    );
+    expect(out.classification).toBe('still_unknown');
+    expect(out.preserved_existing).toBe(false);
+    expect(upsert).toHaveBeenCalledWith(profile, null);
+  });
+
+  it('(e) SILENT-CORRUPTION GUARD: a transient probe failure must NOT overwrite a prior classification', async () => {
+    // Scenario: agent X was previously classified `sales` by another path
+    // (e.g., a parallel crawler tick that raced ahead between our SELECT
+    // and our probe). Our re-probe runs and hits a transient HTTP 5xx.
+    // The script MUST refuse to call upsertCapabilities — otherwise the
+    // ON CONFLICT DO UPDATE inferred_type=EXCLUDED would regress 'sales'
+    // back to NULL on the snapshot row.
+    const upsert = vi.fn(async () => undefined);
+    const profile: AgentCapabilityProfile = {
+      agent_url: 'https://agent.example/',
+      protocol: 'mcp',
+      discovered_tools: [],
+      last_discovered: new Date().toISOString(),
+      discovery_error: 'HTTP 503 Service Unavailable',
+    };
+    const out = await probeOne(
+      // hadSnapshot=true: we know there's already a row. Its current state
+      // is opaque to probeOne — the silent-corruption rule MUST hold even
+      // if a parallel writer just classified the row as 'sales'.
+      makeAgent({ hadSnapshot: true }),
+      {
+        discoverCapabilities: async () => profile,
+        inferTypeFromProfile: () => 'unknown',
+        upsertCapabilities: upsert,
+        timeoutMs: 1000,
+      },
+      false,
+    );
+    expect(out.classification).toBe('probe_failed');
+    expect(out.preserved_existing).toBe(true);
+    // The load-bearing assertion: we did NOT touch the DB.
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it('dry-run: never calls upsert even on the classified path', async () => {
+    const upsert = vi.fn(async () => undefined);
+    const profile: AgentCapabilityProfile = {
+      agent_url: 'https://agent.example/',
+      protocol: 'mcp',
+      discovered_tools: [],
+      last_discovered: new Date().toISOString(),
+    };
+    const out = await probeOne(
+      makeAgent(),
+      {
+        discoverCapabilities: async () => profile,
+        inferTypeFromProfile: () => 'creative' as const,
+        upsertCapabilities: upsert,
+        timeoutMs: 1000,
+      },
+      true, // dry-run
+    );
+    expect(out.classification).toBe('classified');
+    expect(out.inferred).toBe('creative');
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it('records per-agent elapsed_ms for the slow-tail report', async () => {
+    let t = 1_000_000;
+    const profile: AgentCapabilityProfile = {
+      agent_url: 'https://agent.example/',
+      protocol: 'mcp',
+      discovered_tools: [],
+      last_discovered: new Date().toISOString(),
+    };
+    const out = await probeOne(
+      makeAgent(),
+      {
+        discoverCapabilities: async () => {
+          t += 1234;
+          return profile;
+        },
+        inferTypeFromProfile: () => 'sales' as const,
+        upsertCapabilities: async () => undefined,
+        now: () => t,
+        timeoutMs: 5000,
+      },
+      true,
+    );
+    expect(out.elapsed_ms).toBe(1234);
   });
 });


### PR DESCRIPTION
Closes #3551.

77% of agents in the public registry currently render `type: 'unknown'`. Before designing the full retry/backoff system (Problem 2 in #3538), ship a one-shot script that re-probes every currently-unknown agent with an extended timeout. The output tells us whether unknown is **mostly transient** (timeouts/network) or **mostly dead** — informs the full Problem 2 PR's scope.

## Script

`server/scripts/reprobe-unknown-agents.ts`:

- Selects every agent where `agent_capabilities_snapshot.inferred_type IS NULL` or the snapshot row is missing.
- Re-probes with **30s timeout** (vs current 10s in `crawler.ts:548`).
- Reuses the crawler's probe + write helpers (`CapabilityDiscovery.discoverCapabilities`, `inferTypeFromProfile`, `AgentSnapshotDatabase.upsertCapabilities`) — no parallel probe path.
- Reports `{still_unknown, newly_classified: {sales, creative, signals, buying}, probe_failed, dns_failed}`.
- Idempotent: real runs skip rows that became classified between selection and probe. `--dry-run` mode probes everything but writes nothing.

## Stack ordering / known gap

PR #3541 will export `resolveAgentTypes()` from `server/src/routes/member-profiles.ts` so this script can also refresh `member_profiles.agents[]` after each re-probe. As of this branch, `resolveAgentTypes` is **not yet exported** on `main`. The script tries a dynamic import, logs `[warn] resolveAgentTypes not exported … skipping member_profiles.agents[] refresh. Land #3541 to enable it.`, and continues. Once #3541 lands, the import resolves automatically — no code change here. Land #3541 first; merge order: 3540 → 3542 → 3543 → 3541 → this PR.

## Test

`server/tests/unit/reprobe-unknown-agents.test.ts` pins the report-shape contract across success / probe-failed / DNS-failed cases. **5/5 pass**, mirrors the `crawler-type-update-policy.test.ts` style.

## Operator runbook

Same protocol as #3541's backfill:

```bash
# 1. Dry-run on staging
DATABASE_URL=<staging> npx tsx server/scripts/reprobe-unknown-agents.ts --dry-run | tee 2026-04-29-staging-reprobe-dryrun.log

# 2. Eyeball the report. Expect: most-of-77% either transient or dead.

# 3. Real run on staging
DATABASE_URL=<staging> npx tsx server/scripts/reprobe-unknown-agents.ts | tee 2026-04-29-staging-reprobe.log

# 4. Repeat 1-3 against prod.

# 5. Paste final reports back into this PR's comments so the full Problem 2 PR can scope from real data.
```

## Test plan

- [x] `npx vitest run server/tests/unit/reprobe-unknown-agents.test.ts` — 5/5 pass.
- [x] `npm run typecheck` — clean.
- [x] Pre-commit hooks green (test:unit 834/834, test:test-dynamic-imports 7/7, typecheck clean).
- [ ] Operator: `--dry-run` on staging.

## Out of scope

- Full retry-with-backoff loop with `last_probe_attempt_at` tracking — depends on this script's output to scope correctly.
- Mark-as-dead semantics for permanently unreachable agents.
- #3550 — type-reclassification audit log (the structured replacement for stdout-capture).