### PR TITLE
spec(error): standardize VALIDATION_ERROR issues[] on core/error.json (closes #3059)

### DIFF
--- a/.changeset/error-issues-array.md
+++ b/.changeset/error-issues-array.md
@@ -1,0 +1,19 @@
+---
+"adcontextprotocol": minor
+---
+
+spec(error): standardize VALIDATION_ERROR `issues[]` as a normative field on `core/error.json`
+
+Closes #3059. Adds an optional top-level `issues` array to the standard error envelope, normalizing what `@adcp/client` (and prospectively `adcp-go` / `adcp-client-python` / hand-rolled sellers) already need for multi-field validation rejections.
+
+**Why minor**: new optional field on a published schema (`core/error.json`). Existing senders/receivers stay conformant — the field is additive. Receivers that ignore unknown fields keep working; receivers that look for it gain a richer pointer map without parsing `message` text.
+
+**Shape**: each entry is `{ pointer (RFC 6901), message, keyword, schemaPath? }`. `schemaPath` MAY be omitted in production to avoid fingerprinting `oneOf` branch selection on adversarial payloads.
+
+**Backward compatibility with `field` (singular)**: when both are present, sellers SHOULD set `field` to `issues[0].pointer`. Pre-3.1 consumers reading only `field` get the first failure; 3.1+ consumers prefer the top-level `issues`.
+
+**`details.issues` mirror**: sellers MAY mirror `issues[]` into `details.issues` for backward compat with consumers reading from `details`. New consumers should prefer top-level.
+
+Updates:
+- `static/schemas/source/core/error.json` — adds `issues` property with item shape
+- `docs/building/implementation/error-handling.mdx` — adds `issues` to the error-envelope field table; clarifies `field`/`issues` interaction

--- a/docs/building/implementation/error-handling.mdx
+++ b/docs/building/implementation/error-handling.mdx
@@ -131,9 +131,10 @@ These fields are defined by the [`error.json`](https://adcontextprotocol.org/sch
 | `message` | string | Yes | Human-readable error description |
 | `recovery` | string | No | Agent recovery classification: `transient`, `correctable`, or `terminal` |
 | `retry_after` | number | No | Seconds to wait before retrying (transient errors) |
-| `field` | string | No | Field path that caused the error (e.g., `packages[0].targeting`) |
+| `field` | string | No | Field path that caused the error (e.g., `packages[0].targeting`). For multi-field validation rejections, sellers SHOULD set this to `issues[0].pointer`. |
+| `issues` | array | No | Structured list of validation failures. Each entry carries `pointer` (RFC 6901), `message`, `keyword` (the schema keyword that rejected, e.g. `required` / `type` / `format`), and optional `schemaPath`. Use on `VALIDATION_ERROR` and any other code where multiple fields were rejected at once. Lets agents recover the full pointer map without parsing `message` text. |
 | `suggestion` | string | No | Suggested fix for the error |
-| `details` | object | No | Additional context-specific information |
+| `details` | object | No | Additional context-specific information. Sellers MAY mirror `issues[]` here as `details.issues` for backward compatibility with pre-3.1 consumers; new consumers SHOULD prefer the top-level `issues` field. |
 
 ## Standard Error Codes
 

--- a/docs/building/implementation/error-handling.mdx
+++ b/docs/building/implementation/error-handling.mdx
@@ -131,8 +131,8 @@ These fields are defined by the [`error.json`](https://adcontextprotocol.org/sch
 | `message` | string | Yes | Human-readable error description |
 | `recovery` | string | No | Agent recovery classification: `transient`, `correctable`, or `terminal` |
 | `retry_after` | number | No | Seconds to wait before retrying (transient errors) |
-| `field` | string | No | Field path that caused the error (e.g., `packages[0].targeting`). For multi-field validation rejections, sellers SHOULD set this to `issues[0].pointer`. |
-| `issues` | array | No | Structured list of validation failures. Each entry carries `pointer` (RFC 6901), `message`, `keyword` (the schema keyword that rejected, e.g. `required` / `type` / `format`), and optional `schemaPath`. Use on `VALIDATION_ERROR` and any other code where multiple fields were rejected at once. Lets agents recover the full pointer map without parsing `message` text. |
+| `field` | string | No | Field path in JSONPath-lite format (e.g., `packages[0].targeting`). When `issues` is present, sellers MUST set this to `issues[0].pointer` translated from RFC 6901 to JSONPath-lite (e.g., `/packages/0/targeting` → `packages[0].targeting`). Will be deprecated in a future major version. |
+| `issues` | array | No | Structured list of validation failures, drawn from JSON Schema validator output. Each entry carries `pointer` (RFC 6901, matches Ajv's `instancePath`), `message`, `keyword` (the JSON Schema keyword that rejected — `required` / `type` / `format` / etc.), and optional `schemaPath`. Use on `VALIDATION_ERROR` and any other code where multiple fields were rejected at once. **`schemaPath` SHOULD NOT be emitted on production-facing endpoints** — it leaks which `oneOf` branch the validator selected, a probe oracle for adversarial callers crafting payloads against polymorphic unions. Sellers MAY emit in dev/sandbox modes. |
 | `suggestion` | string | No | Suggested fix for the error |
 | `details` | object | No | Additional context-specific information. Sellers MAY mirror `issues[]` here as `details.issues` for backward compatibility with pre-3.1 consumers; new consumers SHOULD prefer the top-level `issues` field. |
 

--- a/static/schemas/source/core/error.json
+++ b/static/schemas/source/core/error.json
@@ -29,9 +29,36 @@
       "minimum": 1,
       "maximum": 3600
     },
+    "issues": {
+      "type": "array",
+      "description": "Structured list of validation failures. Primary use is `VALIDATION_ERROR`, where multi-field rejections are common and `field` (singular) cannot carry the full pointer map. MAY appear on other error codes that reject multiple fields at once. When present alongside `field`, sellers SHOULD set `field` to `issues[0].pointer` for backward compatibility with consumers that read only `field`.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "pointer": {
+            "type": "string",
+            "description": "RFC 6901 JSON Pointer to the offending field in the request payload (e.g., '/packages/0/targeting/geo_countries/2')."
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable description of why this specific field was rejected."
+          },
+          "keyword": {
+            "type": "string",
+            "description": "Schema keyword that rejected the payload (e.g., 'required', 'type', 'format', 'enum', 'pattern'). Lets agents pattern-match on the rejection class without parsing message text."
+          },
+          "schemaPath": {
+            "type": "string",
+            "description": "Optional. Path inside the schema that rejected the payload (e.g., '#/properties/packages/items/properties/targeting/oneOf/1'). Sellers MAY omit in production to avoid fingerprinting `oneOf` branch selection on adversarial payloads."
+          }
+        },
+        "required": ["pointer", "message", "keyword"],
+        "additionalProperties": true
+      }
+    },
     "details": {
       "type": "object",
-      "description": "Additional task-specific error details",
+      "description": "Additional task-specific error details. Sellers MAY mirror `issues[]` here as `details.issues` for backward compatibility with pre-3.1 consumers reading from `details`; new consumers SHOULD prefer the top-level `issues` field.",
       "additionalProperties": true
     },
     "recovery": {

--- a/static/schemas/source/core/error.json
+++ b/static/schemas/source/core/error.json
@@ -17,7 +17,7 @@
     },
     "field": {
       "type": "string",
-      "description": "Field path associated with the error (e.g., 'packages[0].targeting')"
+      "description": "Field path associated with the error in JSONPath-lite format (e.g., 'packages[0].targeting'). When `issues[]` is also present, sellers MUST set this to `issues[0].pointer` translated from RFC 6901 to JSONPath-lite (e.g., '/packages/0/targeting' → 'packages[0].targeting') so pre-3.1 consumers reading `field` only get deterministic behavior. Will be deprecated in a future major version in favor of `issues[].pointer`."
     },
     "suggestion": {
       "type": "string",
@@ -31,13 +31,13 @@
     },
     "issues": {
       "type": "array",
-      "description": "Structured list of validation failures. Primary use is `VALIDATION_ERROR`, where multi-field rejections are common and `field` (singular) cannot carry the full pointer map. MAY appear on other error codes that reject multiple fields at once. When present alongside `field`, sellers SHOULD set `field` to `issues[0].pointer` for backward compatibility with consumers that read only `field`.",
+      "description": "Structured list of validation failures. Primary use is `VALIDATION_ERROR`, where multi-field rejections are common and `field` (singular) cannot carry the full pointer map. MAY appear on other error codes that reject multiple fields at once. When `issues` is present, sellers MUST also populate `field` from `issues[0]` for backward compatibility with pre-3.1 consumers that read `field` only — translating the RFC 6901 `pointer` format to the JSONPath-lite format `field` uses (e.g., `/packages/0/targeting` → `packages[0].targeting`). MUST (not SHOULD) so consumers reading `field` get deterministic behavior across sellers — the cost is one line of dual-write per seller; the cost of SHOULD is a long tail of seller-A-vs-seller-B inconsistency. Future major versions will deprecate `field` in favor of `issues[].pointer`.",
       "items": {
         "type": "object",
         "properties": {
           "pointer": {
             "type": "string",
-            "description": "RFC 6901 JSON Pointer to the offending field in the request payload (e.g., '/packages/0/targeting/geo_countries/2')."
+            "description": "RFC 6901 JSON Pointer to the offending field in the request payload (e.g., '/packages/0/targeting/geo_countries/2'). Format chosen to match Ajv's native validation output (`instancePath`); standardized and unambiguous on keys containing `/` or `~`. NOTE: this differs from the legacy top-level `field` which uses JSONPath-lite (`packages[0].targeting.geo_countries[2]`). When sellers populate `field` from `issues[0].pointer` for backward compatibility (see `field` description), they MUST translate the format — `/packages/0/x` → `packages[0].x`. Future major versions will deprecate `field` in favor of `issues[].pointer`."
           },
           "message": {
             "type": "string",
@@ -45,11 +45,11 @@
           },
           "keyword": {
             "type": "string",
-            "description": "Schema keyword that rejected the payload (e.g., 'required', 'type', 'format', 'enum', 'pattern'). Lets agents pattern-match on the rejection class without parsing message text."
+            "description": "Schema keyword that rejected the payload, drawn from the JSON Schema vocabulary (e.g., 'required', 'type', 'format', 'enum', 'pattern', 'minimum', 'maxLength'). Matches the keyword names emitted by JSON Schema validators (Ajv, jsonschema, etc.) so agents can pattern-match on rejection class without parsing message text. Implementers SHOULD use the validator's native keyword name; do not invent custom values here."
           },
           "schemaPath": {
             "type": "string",
-            "description": "Optional. Path inside the schema that rejected the payload (e.g., '#/properties/packages/items/properties/targeting/oneOf/1'). Sellers MAY omit in production to avoid fingerprinting `oneOf` branch selection on adversarial payloads."
+            "description": "Optional. Path inside the schema that rejected the payload (e.g., '#/properties/packages/items/properties/targeting/oneOf/1'). Sellers SHOULD NOT emit on production-facing endpoints — `schemaPath` leaks which `oneOf` branch the validator selected before semantic rejection, which is a probe oracle for adversarial callers crafting payloads against polymorphic unions. Sellers MAY emit in dev/sandbox modes where the diagnostic value outweighs the fingerprinting risk."
           }
         },
         "required": ["pointer", "message", "keyword"],


### PR DESCRIPTION
## Summary

Closes #3059. Adds an optional top-level \`issues\` array to \`core/error.json\`, normalizing what \`@adcp/client\` already emits for multi-field validation rejections (adcp-client#874, adcp-client#915 made framework AJV validation authoritative across both MCP and A2A).

## Why now

The SDK ships \`issues[]\` today on every \`VALIDATION_ERROR\` envelope. Other AdCP implementations (\`adcp-go\`, \`adcp-client-python\`, hand-rolled sellers) would either miss the structured pointer list, adopt it ad-hoc with different naming, or converge if the spec normalizes it. Filing now — before adoption deepens — keeps the ecosystem aligned. A second-pass protocol review of adcp-client#915 specifically flagged this as an extension not endorsed by the spec.

## Shape

Each entry: \`{ pointer (RFC 6901), message, keyword, schemaPath? }\`.

- \`pointer\`: e.g. \`/packages/0/targeting/geo_countries/2\`
- \`message\`: human-readable
- \`keyword\`: schema keyword that rejected (\`required\`, \`type\`, \`format\`, \`enum\`, \`pattern\`) — lets agents pattern-match without parsing message text
- \`schemaPath\`: optional. Sellers MAY omit in production to avoid fingerprinting \`oneOf\` branch selection on adversarial payloads.

## Backward compatibility

- \`field\` (singular) retained. When both are present, sellers SHOULD set \`field\` to \`issues[0].pointer\` for pre-3.1 consumers reading \`field\` only.
- Sellers MAY mirror \`issues[]\` into \`details.issues\` for backward compat with consumers reading from \`details\`. New consumers should prefer top-level.
- Existing receivers that ignore unknown fields keep working — additive change.

## Why \`minor\`

New optional field on a published schema. The bump signals to consumers that a new field is available without breaking anything.

## Files

- \`static/schemas/source/core/error.json\` — adds \`issues\` property with item shape
- \`docs/building/implementation/error-handling.mdx\` — adds \`issues\` to the error-envelope field table; documents the \`field\`/\`issues\` interaction

## Test plan

- [x] \`npm run test:schemas\` — 7/7 passing
- [x] \`npm run test:json-schema\` — 255/255 passing
- [x] JSON syntax verified
- [ ] CI: composed-schema and storyboard validators (run on PR)

## Refs

- adcp-client#874 — \`issues[]\` first shipped here
- adcp-client#909 — validation-asymmetry issue prompting cross-transport enforcement
- adcp-client#915 — PR making framework validation authoritative on both transports

🤖 Generated with [Claude Code](https://claude.com/claude-code)