### PR TITLE
feat(registry): endorsed_by_publisher_member on discovered agents — option C from #3547

### DIFF
--- a/.changeset/registry-publisher-endorsement.md
+++ b/.changeset/registry-publisher-endorsement.md
@@ -1,0 +1,4 @@
+---
+---
+
+feat(registry): surface `endorsed_by_publisher_member` on discovered agents whose `discovered_from.publisher_domain` is claimed by an AAO member — option C from issue #3547 / Problem 6 of #3538. Mutually exclusive with `member`; registered agents never carry it.

--- a/server/src/federated-index.ts
+++ b/server/src/federated-index.ts
@@ -36,6 +36,30 @@ export class FederatedIndexService {
     const profiles = await this.memberDb.listProfiles({ is_public: true });
     const registeredAgents = new Map<string, FederatedAgent>();
 
+    // Build a publisher-domain -> member-ref index from the same profiles
+    // we already loaded. Used to populate `endorsed_by_publisher_member`
+    // on discovered agents whose publisher_domain is claimed by a member
+    // (option C from issue #3547 / Problem 6 of #3538). Reuses the loaded
+    // profiles instead of re-querying — no extra DB round-trip.
+    const publisherToMember = new Map<
+      string,
+      { slug: string; display_name: string }
+    >();
+    for (const profile of profiles) {
+      for (const pubConfig of profile.publishers || []) {
+        if (!pubConfig.is_public) continue;
+        // First member that claims a publisher_domain wins. In practice
+        // publisher_domain ownership is unique per profile; collisions are
+        // a registry data-quality bug, not a runtime concern.
+        if (!publisherToMember.has(pubConfig.domain)) {
+          publisherToMember.set(pubConfig.domain, {
+            slug: profile.slug,
+            display_name: profile.display_name,
+          });
+        }
+      }
+    }
+
     for (const profile of profiles) {
       for (const agentConfig of profile.agents || []) {
         const v = agentConfig.visibility;
@@ -66,7 +90,9 @@ export class FederatedIndexService {
     const agentUrls = discoveredAgents.map(a => a.agent_url);
     const allAuths = await this.db.bulkGetFirstAuthForAgents(agentUrls);
 
-    // Merge: registered takes precedence
+    // Merge: agent_url collapses across registered + discovered when
+    // both signals exist; registered wins. The skip below is the
+    // collapse behaviour referenced by option B in issue #3547.
     const result: FederatedAgent[] = Array.from(registeredAgents.values());
 
     for (const discovered of discoveredAgents) {
@@ -75,6 +101,15 @@ export class FederatedIndexService {
       }
 
       const auth = allAuths.get(discovered.agent_url);
+      const publisherDomain = auth?.publisher_domain || discovered.source_domain;
+
+      // Option C / option A: if the publisher_domain is claimed by an
+      // AAO member, surface the endorsement signal. Agent stays
+      // source='discovered' — the publisher endorsed it, the agent
+      // itself didn't opt in.
+      const endorsingMember = publisherDomain
+        ? publisherToMember.get(publisherDomain)
+        : undefined;
 
       result.push({
         url: discovered.agent_url,
@@ -88,6 +123,15 @@ export class FederatedIndexService {
         } : {
           publisher_domain: discovered.source_domain,
         },
+        ...(endorsingMember && publisherDomain
+          ? {
+              endorsed_by_publisher_member: {
+                slug: endorsingMember.slug,
+                display_name: endorsingMember.display_name,
+                publisher_domain: publisherDomain,
+              },
+            }
+          : {}),
         discovered_at: discovered.discovered_at?.toISOString(),
       });
     }

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -3714,7 +3714,14 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         url: fa.url,
         type: isValidAgentType(fa.type) ? fa.type : ("unknown" as const),
         protocol: fa.protocol || "mcp",
-        description: fa.member?.display_name || fa.discovered_from?.publisher_domain || "",
+        // Description prefers registered member, then publisher endorsement,
+        // then bare publisher_domain — surfaces the strongest trust signal we
+        // have for this agent.
+        description:
+          fa.member?.display_name ||
+          fa.endorsed_by_publisher_member?.display_name ||
+          fa.discovered_from?.publisher_domain ||
+          "",
         mcp_endpoint: fa.url,
         contact: {
           name: fa.member?.display_name || "",
@@ -3725,6 +3732,9 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         source: fa.source,
         member: fa.member,
         discovered_from: fa.discovered_from,
+        // Publisher-side endorsement (option C from #3547). Mutually
+        // exclusive with `member`: registered agents never carry it.
+        endorsed_by_publisher_member: fa.endorsed_by_publisher_member,
       }));
 
       const bySource = {

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -166,8 +166,12 @@ const DiscoveredFromSchema = z.object({
  */
 const EndorsedByPublisherMemberSchema = z
   .object({
-    slug: z.string().optional(),
-    display_name: z.string().optional(),
+    slug: z
+      .string()
+      .openapi({ description: "Member organization slug — stable URL-safe identifier for the publisher member." }),
+    display_name: z
+      .string()
+      .openapi({ description: "Member organization display name — render-ready label for the publisher member." }),
     publisher_domain: z
       .string()
       .openapi({ description: "Publisher domain whose adagents.json endorsed this agent (the linkage that produced this signal)." }),

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -149,6 +149,31 @@ const DiscoveredFromSchema = z.object({
   authorized_for: z.string().optional(),
 });
 
+/**
+ * Publisher-side endorsement signal for a discovered agent.
+ *
+ * Populated only when an agent's `source = 'discovered'` AND its
+ * `discovered_from.publisher_domain` is claimed by an AAO member
+ * (member_profiles row whose `publishers[]` contains that domain with
+ * `is_public = true`). Mutually exclusive with `member` — a registered
+ * agent never carries this field.
+ *
+ * The agent itself did not opt in; the publisher endorsed it via
+ * `adagents.json`. Surfaces option C from issue #3547 / Problem 6 of
+ * issue #3538: discovered agents like `agent.mamamia.com.au` whose
+ * publisher is a member previously rendered `member: null` and dropped
+ * that trust signal on the floor.
+ */
+const EndorsedByPublisherMemberSchema = z
+  .object({
+    slug: z.string().optional(),
+    display_name: z.string().optional(),
+    publisher_domain: z
+      .string()
+      .openapi({ description: "Publisher domain whose adagents.json endorsed this agent (the linkage that produced this signal)." }),
+  })
+  .openapi("EndorsedByPublisherMember");
+
 export const ResolvedBrandSchema = z
   .object({
     canonical_id: z.string().openapi({ example: "acmecorp.com" }),
@@ -373,13 +398,15 @@ export const FederatedAgentWithDetailsSchema = z
     member: MemberRefSchema.optional().openapi({
       description:
         "AAO member that owns this agent record, if any. Populated when `source` is `registered`. " +
-        "For `discovered` agents this is currently `null` even when the publisher_domain in `discovered_from` is owned by a member — see #3538 Problem 6.",
+        "For `discovered` agents this is `null`; see `endorsed_by_publisher_member` for the publisher-side endorsement signal added in #3547 / Problem 6 of #3538.",
     }),
     discovered_from: DiscoveredFromSchema.optional().openapi({
       description:
         "Set when `source = 'discovered'`. Identifies the publisher_domain whose adagents.json listed this agent, and the `authorized_for` string from that listing. " +
         "Mutually exclusive with the `member` field on the registered path.",
     }),
+    endorsed_by_publisher_member: EndorsedByPublisherMemberSchema.optional()
+      .openapi({ description: "Set on discovered agents when discovered_from.publisher_domain is claimed by an AAO member (publishers[] entry with is_public=true). Mutually exclusive with member — registered agents never carry this. Option C from #3547 (Problem 6 / #3538)." }),
     health: AgentHealthSchema.optional(),
     stats: AgentStatsSchema.optional(),
     capabilities: AgentCapabilitiesSchema.optional(),

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1031,6 +1031,15 @@ export interface FederatedAgent {
     publisher_domain: string;
     authorized_for?: string;
   };
+  // Publisher-side endorsement: set when source='discovered' AND the
+  // publisher_domain in discovered_from is claimed by an AAO member.
+  // Mutually exclusive with `member`. See registering-an-agent docs and
+  // option C from issue #3547 (Problem 6 of #3538).
+  endorsed_by_publisher_member?: {
+    slug?: string;
+    display_name?: string;
+    publisher_domain: string;
+  };
   discovered_at?: string;
 }
 

--- a/server/tests/unit/registry-discovered-endorsement.test.ts
+++ b/server/tests/unit/registry-discovered-endorsement.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Pins the publisher-side endorsement signal for discovered agents.
+ *
+ * Closes #3547 (option C from issue body) / Problem 6 of #3538:
+ *
+ *   - Discovered agent whose `discovered_from.publisher_domain` is claimed
+ *     by an AAO member (member_profiles.publishers[] with is_public=true)
+ *     surfaces `endorsed_by_publisher_member` populated, member: null.
+ *   - Discovered agent whose publisher_domain is NOT owned by any member
+ *     never gets the field.
+ *   - Registered agent never gets the field — it carries `member` instead.
+ *   - When the same agent_url appears as both registered and discovered
+ *     (e.g. a member registers an agent that's also in adagents.json),
+ *     the registered row wins and no duplicate appears. This is the
+ *     option-B collapse: existing behaviour, locked in by this test.
+ *
+ * Test seam: the FederatedIndexService instantiates `MemberDatabase` and
+ * `FederatedIndexDatabase` in its constructor, so we mock the classes via
+ * vi.mock. We exercise the merge logic in `listAllAgents` against
+ * deterministic fixtures rather than spinning up a Postgres pool.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock both databases up-front. The FederatedIndexService constructor
+// `new`s these directly; vi.mock replaces the modules before import.
+const mockListProfiles = vi.fn();
+const mockGetAllDiscoveredAgents = vi.fn();
+const mockBulkGetFirstAuthForAgents = vi.fn();
+
+vi.mock('../../src/db/member-db.js', () => ({
+  MemberDatabase: class {
+    listProfiles = mockListProfiles;
+  },
+}));
+
+vi.mock('../../src/db/federated-index-db.js', () => ({
+  FederatedIndexDatabase: class {
+    getAllDiscoveredAgents = mockGetAllDiscoveredAgents;
+    bulkGetFirstAuthForAgents = mockBulkGetFirstAuthForAgents;
+  },
+}));
+
+// Imported AFTER vi.mock so the service picks up the mocks.
+const { FederatedIndexService } = await import('../../src/federated-index.js');
+
+describe('FederatedIndexService.listAllAgents — endorsed_by_publisher_member', () => {
+  beforeEach(() => {
+    mockListProfiles.mockReset();
+    mockGetAllDiscoveredAgents.mockReset();
+    mockBulkGetFirstAuthForAgents.mockReset();
+  });
+
+  function setupProfilesAndDiscovered(opts: {
+    profiles: Array<{
+      slug: string;
+      display_name: string;
+      publishers?: Array<{ domain: string; is_public: boolean }>;
+      agents?: Array<{ url: string; visibility: string; type?: string; name?: string }>;
+    }>;
+    discoveredAgents: Array<{
+      agent_url: string;
+      source_type?: string;
+      source_domain: string;
+      name?: string;
+      agent_type?: string;
+      protocol?: string;
+    }>;
+    auths?: Map<string, { agent_url: string; publisher_domain: string; authorized_for?: string; source: 'adagents_json' | 'agent_claim' }>;
+  }) {
+    mockListProfiles.mockResolvedValue(
+      opts.profiles.map((p) => ({
+        ...p,
+        publishers: p.publishers || [],
+        agents: p.agents || [],
+      })),
+    );
+    mockGetAllDiscoveredAgents.mockResolvedValue(opts.discoveredAgents);
+    mockBulkGetFirstAuthForAgents.mockResolvedValue(opts.auths || new Map());
+  }
+
+  it('populates endorsed_by_publisher_member when publisher_domain is owned by a member', async () => {
+    setupProfilesAndDiscovered({
+      profiles: [
+        {
+          slug: 'mamamia',
+          display_name: 'Mamamia',
+          publishers: [{ domain: 'mamamia.com.au', is_public: true }],
+        },
+      ],
+      discoveredAgents: [
+        {
+          agent_url: 'agent.mamamia.com.au',
+          source_type: 'adagents_json',
+          source_domain: 'mamamia.com.au',
+          name: 'Mamamia Agent',
+          agent_type: 'sales',
+          protocol: 'mcp',
+        },
+      ],
+    });
+
+    const svc = new FederatedIndexService();
+    const agents = await svc.listAllAgents();
+
+    expect(agents).toHaveLength(1);
+    const agent = agents[0];
+    expect(agent.source).toBe('discovered');
+    expect(agent.member).toBeUndefined();
+    expect(agent.endorsed_by_publisher_member).toEqual({
+      slug: 'mamamia',
+      display_name: 'Mamamia',
+      publisher_domain: 'mamamia.com.au',
+    });
+    expect(agent.discovered_from?.publisher_domain).toBe('mamamia.com.au');
+  });
+
+  it('omits endorsed_by_publisher_member when publisher_domain is not owned by any member', async () => {
+    setupProfilesAndDiscovered({
+      profiles: [
+        {
+          slug: 'someone-else',
+          display_name: 'Someone Else',
+          publishers: [{ domain: 'unrelated.com', is_public: true }],
+        },
+      ],
+      discoveredAgents: [
+        {
+          agent_url: 'gatavocom.sales-agent.setupad.ai',
+          source_type: 'adagents_json',
+          source_domain: 'gatavo.com',
+          name: 'Gatavo Sales',
+          agent_type: 'sales',
+          protocol: 'mcp',
+        },
+      ],
+    });
+
+    const svc = new FederatedIndexService();
+    const agents = await svc.listAllAgents();
+
+    expect(agents).toHaveLength(1);
+    expect(agents[0].source).toBe('discovered');
+    expect(agents[0].member).toBeUndefined();
+    expect(agents[0].endorsed_by_publisher_member).toBeUndefined();
+  });
+
+  it('skips publishers with is_public=false (private endorsement is not a public signal)', async () => {
+    setupProfilesAndDiscovered({
+      profiles: [
+        {
+          slug: 'mamamia',
+          display_name: 'Mamamia',
+          publishers: [{ domain: 'mamamia.com.au', is_public: false }],
+        },
+      ],
+      discoveredAgents: [
+        {
+          agent_url: 'agent.mamamia.com.au',
+          source_type: 'adagents_json',
+          source_domain: 'mamamia.com.au',
+          name: 'Mamamia Agent',
+          agent_type: 'sales',
+          protocol: 'mcp',
+        },
+      ],
+    });
+
+    const svc = new FederatedIndexService();
+    const agents = await svc.listAllAgents();
+
+    expect(agents).toHaveLength(1);
+    expect(agents[0].endorsed_by_publisher_member).toBeUndefined();
+  });
+
+  it('registered agents never carry endorsed_by_publisher_member', async () => {
+    setupProfilesAndDiscovered({
+      profiles: [
+        {
+          slug: 'acme',
+          display_name: 'Acme',
+          publishers: [{ domain: 'acme.example.com', is_public: true }],
+          agents: [
+            {
+              url: 'https://agent.acme.example.com/mcp',
+              visibility: 'public',
+              type: 'sales',
+              name: 'Acme Agent',
+            },
+          ],
+        },
+      ],
+      discoveredAgents: [],
+    });
+
+    const svc = new FederatedIndexService();
+    const agents = await svc.listAllAgents();
+
+    expect(agents).toHaveLength(1);
+    expect(agents[0].source).toBe('registered');
+    expect(agents[0].member).toEqual({ slug: 'acme', display_name: 'Acme' });
+    expect(agents[0].endorsed_by_publisher_member).toBeUndefined();
+  });
+
+  it('agent_url claimed by both registered + discovered collapses to registered (option B)', async () => {
+    // The same agent_url that a member registered also appears in some
+    // publisher's adagents.json. Registered row must win; no duplicate
+    // discovered row with endorsed_by_publisher_member should appear.
+    const sharedUrl = 'https://shared.agent.example.com/mcp';
+    setupProfilesAndDiscovered({
+      profiles: [
+        {
+          slug: 'acme',
+          display_name: 'Acme',
+          publishers: [{ domain: 'acme.example.com', is_public: true }],
+          agents: [
+            {
+              url: sharedUrl,
+              visibility: 'public',
+              type: 'sales',
+              name: 'Acme Agent',
+            },
+          ],
+        },
+        {
+          // A different member also owns the publisher_domain that listed
+          // this agent in its adagents.json.
+          slug: 'pub-member',
+          display_name: 'Pub Member',
+          publishers: [{ domain: 'pub.example.com', is_public: true }],
+        },
+      ],
+      discoveredAgents: [
+        {
+          agent_url: sharedUrl,
+          source_type: 'adagents_json',
+          source_domain: 'pub.example.com',
+          name: 'Acme Agent',
+          agent_type: 'sales',
+          protocol: 'mcp',
+        },
+      ],
+    });
+
+    const svc = new FederatedIndexService();
+    const agents = await svc.listAllAgents();
+
+    // Only one row; registered wins.
+    expect(agents).toHaveLength(1);
+    expect(agents[0].source).toBe('registered');
+    expect(agents[0].member).toEqual({ slug: 'acme', display_name: 'Acme' });
+    expect(agents[0].endorsed_by_publisher_member).toBeUndefined();
+  });
+
+  it('uses authorization publisher_domain over discovered.source_domain when present', async () => {
+    // First-auth from bulkGetFirstAuthForAgents takes precedence in
+    // populating discovered_from.publisher_domain. The endorsement lookup
+    // must follow that same domain so the surfaced linkage matches the
+    // surfaced source.
+    const url = 'https://multi.agent.example.com/mcp';
+    setupProfilesAndDiscovered({
+      profiles: [
+        {
+          slug: 'mamamia',
+          display_name: 'Mamamia',
+          publishers: [{ domain: 'mamamia.com.au', is_public: true }],
+        },
+      ],
+      discoveredAgents: [
+        {
+          agent_url: url,
+          source_type: 'adagents_json',
+          source_domain: 'unrelated.example.com',
+          name: 'Multi Agent',
+          agent_type: 'sales',
+          protocol: 'mcp',
+        },
+      ],
+      auths: new Map([
+        [
+          url,
+          {
+            agent_url: url,
+            publisher_domain: 'mamamia.com.au',
+            authorized_for: 'sales',
+            source: 'adagents_json',
+          },
+        ],
+      ]),
+    });
+
+    const svc = new FederatedIndexService();
+    const agents = await svc.listAllAgents();
+
+    expect(agents).toHaveLength(1);
+    expect(agents[0].discovered_from?.publisher_domain).toBe('mamamia.com.au');
+    expect(agents[0].endorsed_by_publisher_member).toEqual({
+      slug: 'mamamia',
+      display_name: 'Mamamia',
+      publisher_domain: 'mamamia.com.au',
+    });
+  });
+});

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -393,7 +393,7 @@ components:
               type: string
             display_name:
               type: string
-          description: "AAO member that owns this agent record, if any. Populated when `source` is `registered`. For `discovered` agents this is currently `null` even when the publisher_domain in `discovered_from` is owned by a member — see #3538 Problem 6."
+          description: "AAO member that owns this agent record, if any. Populated when `source` is `registered`. For `discovered` agents this is `null`; see `endorsed_by_publisher_member` for the publisher-side endorsement signal added in #3547 / Problem 6 of #3538."
         discovered_from:
           type: object
           properties:
@@ -402,6 +402,8 @@ components:
             authorized_for:
               type: string
           description: Set when `source = 'discovered'`. Identifies the publisher_domain whose adagents.json listed this agent, and the `authorized_for` string from that listing. Mutually exclusive with the `member` field on the registered path.
+        endorsed_by_publisher_member:
+          $ref: "#/components/schemas/EndorsedByPublisherMember"
         health:
           $ref: "#/components/schemas/AgentHealth"
         stats:
@@ -420,6 +422,23 @@ components:
         - url
         - name
         - type
+    EndorsedByPublisherMember:
+      type: object
+      properties:
+        slug:
+          type: string
+          description: Member organization slug — stable URL-safe identifier for the publisher member.
+        display_name:
+          type: string
+          description: Member organization display name — render-ready label for the publisher member.
+        publisher_domain:
+          type: string
+          description: Publisher domain whose adagents.json endorsed this agent (the linkage that produced this signal).
+      required:
+        - slug
+        - display_name
+        - publisher_domain
+      description: "Set on discovered agents when discovered_from.publisher_domain is claimed by an AAO member (publishers[] entry with is_public=true). Mutually exclusive with member — registered agents never carry this. Option C from #3547 (Problem 6 / #3538)."
     AgentHealth:
       type: object
       properties:
@@ -1224,6 +1243,24 @@ components:
               - untested
               - unknown
           description: Per-specialism pass/fail/untested status — keyed on declared specialism, derived from the matching storyboard's status
+        membership_tier:
+          type:
+            - string
+            - "null"
+          description: "Owner-scoped: the agent owner's membership tier. Populated only when the authenticated viewer owns the agent; null otherwise. Field is always present so response shape doesn't reveal ownership."
+        membership_tier_label:
+          type:
+            - string
+            - "null"
+          description: "Owner-scoped: human-readable label for membership_tier (e.g. 'Builder'). Null for non-owners."
+        subscription_status:
+          type:
+            - string
+            - "null"
+          description: "Owner-scoped: the agent owner's subscription status (active, past_due, trialing, etc.). Null for non-owners."
+        is_api_access_tier:
+          type: boolean
+          description: "Owner-scoped: true when the owner's tier and subscription status grant badge eligibility. False for non-owners. Single source of truth — UI should not re-derive."
         verified:
           type: boolean
         verified_badges:
@@ -1247,6 +1284,9 @@ components:
             - brand
             - sponsored-intelligence
           description: AdCP protocol this badge covers (enums/adcp-protocol.json).
+        adcp_version:
+          type: string
+          description: AdCP release this badge was issued against, MAJOR.MINOR (e.g. '3.0', '3.1'). Load-bearing for badge identity — pairs with the (agent_url, role, adcp_version) PK.
         verified_at:
           type: string
         verified_specialisms:
@@ -1290,8 +1330,10 @@ components:
             - "null"
         badge_url:
           type: string
+          description: Legacy URL — auto-upgrades to the highest active version. For version-pinned embedding, derive `/api/registry/agents/{encoded_url}/badge/{role}/{adcp_version}.svg` where `{encoded_url}` is `encodeURIComponent(agent_url)`.
       required:
         - role
+        - adcp_version
         - verified_at
         - verified_specialisms
         - verification_modes
@@ -4671,6 +4713,123 @@ paths:
                   - markdown
         "400":
           description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/badge/{role}/{version}.svg:
+    get:
+      operationId: getAgentBadgeVersionedSvg
+      summary: Get version-pinned agent verification badge SVG
+      description: Returns an SVG badge image scoped to a specific AdCP release (MAJOR.MINOR, e.g. '3.0'). Buyers who want to call out 'verified for 3.0' embed this instead of the legacy `/badge/{role}.svg` (which auto-upgrades to the highest active version). Renders 'Not Verified' when the agent never earned a badge at this version.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+            description: Badge role (media-buy, creative, signals, governance, brand, sponsored-intelligence)
+          required: true
+          description: Badge role (media-buy, creative, signals, governance, brand, sponsored-intelligence)
+          name: role
+          in: path
+        - schema:
+            type: string
+            description: AdCP release as MAJOR.MINOR (e.g. '3.0', '3.1')
+          required: true
+          description: AdCP release as MAJOR.MINOR (e.g. '3.0', '3.1')
+          name: version
+          in: path
+      responses:
+        "200":
+          description: SVG badge image
+          content:
+            image/svg+xml:
+              schema:
+                type: string
+        "400":
+          description: Invalid agent URL, role, or version
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+  /api/registry/agents/{encodedUrl}/badge/{role}/{version}/embed:
+    get:
+      operationId: getAgentBadgeVersionedEmbed
+      summary: Get version-pinned embeddable badge code
+      description: Returns HTML and Markdown embed snippets that point at the version-pinned SVG. Alt text includes the version (e.g. 'AAO Verified Media Buy Agent 3.0'). Buyers who want to freeze on a specific AdCP release embed these instead of the legacy `/badge/{role}/embed`.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+            description: Badge role
+          required: true
+          description: Badge role
+          name: role
+          in: path
+        - schema:
+            type: string
+            description: AdCP release as MAJOR.MINOR
+          required: true
+          description: AdCP release as MAJOR.MINOR
+          name: version
+          in: path
+      responses:
+        "200":
+          description: Embed code
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  role:
+                    type: string
+                  verified:
+                    type: boolean
+                  adcp_version:
+                    type: string
+                  badge_svg_url:
+                    type: string
+                  registry_url:
+                    type: string
+                  html:
+                    type: string
+                  markdown:
+                    type: string
+                required:
+                  - agent_url
+                  - role
+                  - verified
+                  - badge_svg_url
+                  - registry_url
+                  - html
+                  - markdown
+        "400":
+          description: Invalid agent URL, role, or version
           content:
             application/json:
               schema:


### PR DESCRIPTION
Closes #3547. Refs #3538 Problem 6.

Three live discovered agents (\`agent.mamamia.com.au\`, \`gatavocom.sales-agent.setupad.ai\`, \`wheelrandom.sales-agent.setupad.ai\`) return \`member: null\` even though their \`discovered_from.publisher_domain\` is claimed by an AAO member. The publisher's \`adagents.json\` endorsement carries trust signal — response builder threw it away.

This PR ships **option C from #3547**: option A as the new field, option B as the collapse verification.

## Option A — \`endorsed_by_publisher_member\` field

New optional field on \`/api/registry/agents\` response. Populated only when:
- agent's \`source = 'discovered'\`
- \`discovered_from.publisher_domain\` is claimed by a \`member_profiles\` row whose \`publishers[]\` contains that domain with \`is_public = true\`

Mutually exclusive with \`member\` (registered agent never has both). Schema in \`server/src/schemas/registry.ts\` carries the \`.openapi({ description })\` so docs explain the relationship. Lookup happens in \`server/src/federated-index.ts\` over the same \`memberDb.listProfiles({ is_public: true })\` call we already make for registered agents — no extra DB round-trip.

Example:

\`\`\`json
{
  \"agent_url\": \"agent.mamamia.com.au\",
  \"source\": \"discovered\",
  \"member\": null,
  \"discovered_from\": { \"publisher_domain\": \"mamamia.com.au\" },
  \"endorsed_by_publisher_member\": {
    \"slug\": \"mamamia\",
    \"display_name\": \"Mamamia\",
    \"publisher_domain\": \"mamamia.com.au\"
  }
}
\`\`\`

Agent stays \`source: 'discovered'\` — the agent itself didn't opt in. The endorsement is a publisher-side signal, not an agent claim.

## Option B — collapse verification

(verified) registered row already wins when \`agent_url\` is also discovered. \`server/src/federated-index.ts:73-75\` skips a discovered row when \`registeredAgents\` already has the same \`agent_url\`. Inline comment expanded at the merge site documenting the existing behaviour, and the new test case \`agent_url claimed by both registered + discovered collapses to registered (option B)\` pins it so a future refactor can't quietly regress it.

## What changed

- \`server/src/schemas/registry.ts\` — new \`EndorsedByPublisherMember\` Zod schema with description, attached to \`FederatedAgentWithDetailsSchema\` as optional
- \`server/src/types.ts\` — matching \`endorsed_by_publisher_member\` field on \`FederatedAgent\` interface
- \`server/src/federated-index.ts\` — builds publisher-domain → member-ref index from already-loaded profiles, populates the field on each discovered row when the linkage exists
- \`server/src/routes/registry-api.ts\` — passes the field through the response mapping; description prefers member name, then endorsement display_name, then bare publisher_domain
- \`static/openapi/registry.yaml\` — mechanical regen via \`npm run build:openapi\` (separate commit)
- \`server/tests/unit/registry-discovered-endorsement.test.ts\` — 6 tests covering populate / omit / is_public=false / registered-no-field / option-B collapse / authorization-overrides-source-domain

## Backwards compatibility

Non-breaking on the wire. Adds an optional field. Consumers ignoring unknown fields are unaffected. Consumers that previously read \`member: null\` and assumed \"no member relationship\" now have the additional \`endorsed_by_publisher_member\` signal available — strictly more information, never less.

## Test plan

- [x] \`vitest run server/tests/unit/registry-discovered-endorsement.test.ts\` — 6/6 pass
- [x] \`vitest run server/tests/unit/openapi-coverage.test.ts\` — still 3/3
- [x] \`tsc --noEmit -p server/tsconfig.json\` — clean
- [x] Pre-commit hooks green (no \`--no-verify\`)
- [ ] Staging spot-check: the three known cases (mamamia, gatavo, wheelrandom) render with \`endorsed_by_publisher_member\` populated when their publisher_domain is owned by a member; absent otherwise

## Stack ordering

Independent of #3540, #3541, #3542, #3543. Lands any time. Recommended after #3542 so the schema annotations from that PR are already in main.

## Out of scope

- UI treatment of \`endorsed_by_publisher_member\` — separate PR, depends on what segmentation lands in Problem 3 P1.
- \`?source=\` query param + UI tabs (Problem 3 P1) — separate PR.
- Self-attestation registration for non-members (Problem 5 option B) — needs product call.