### PR TITLE
feat(verification): per-major-version badge data model (#3524 stage 1)

### DIFF
--- a/.changeset/per-version-badges-stage1-data-model.md
+++ b/.changeset/per-version-badges-stage1-data-model.md
@@ -1,0 +1,22 @@
+---
+---
+
+backend(verification): per-major-version badge data model. Stage 1 of #3524 — extends `agent_verification_badges` so an agent can hold parallel `(Spec)` / `(Live)` badges across AdCP minor versions (3.0, 3.1, 4.0…). The previous PK `(agent_url, role)` becomes `(agent_url, role, major_version)`.
+
+Behavior change is gated to Stage 2. This PR ships:
+
+- **Migration 457**: adds `major_version TEXT NOT NULL` to `agent_verification_badges`, backfills existing rows from `verified_protocol_version` (`X.Y.Z` → `X.Y`, falling back to `'3.0'` for null/malformed), rebuilds the PK to include `major_version`, drops the temporary default so future writes must specify the version explicitly. Adds an index on `(role, major_version, status)` for the per-version listings the panel and brand.json enrichment will need in later stages.
+- **DB layer**: `AgentVerificationBadge` type gains `major_version`. `upsertBadge` / `getActiveBadge` / `revokeBadge` / `degradeBadge` now take a `majorVersion` parameter. `getBadgesForAgent` / `bulkGetActiveBadges` / `getVerifiedAgentsByRole` order by `major_version DESC` so callers see the most recent first.
+- **New helper**: `getHighestVersionActiveBadge(agentUrl, role)` powers the legacy `/badge/{role}.svg` URL — embedded badges in the wild auto-upgrade to the newest version the agent has earned without changing the URL. Per Q3 of the resolved-decisions thread on #3524.
+- **`processAgentBadges()`**: accepts an optional `majorVersion` parameter (defaults to `DEFAULT_BADGE_MAJOR_VERSION = '3.0'` for Stage 1 callers). The function now scopes existing-badge reads and writes to that single version — a `failing` 3.1 run never touches a 3.0 badge and vice versa. This is the load-bearing isolation property: it's what lets old-version badges persist while new versions are evaluated independently.
+
+Four new tests cover the version-isolation invariant: only-touch-version-under-test, upsertBadge receives the version, default fallback when callers don't specify, and membership-lapse only affects the version under test.
+
+What this PR does NOT change:
+- The heartbeat job still calls `processAgentBadges()` without a `majorVersion` — defaults to `'3.0'`. Stage 2 wires per-version fan-out.
+- Storyboards have no `since:` field yet. Added in Stage 2.
+- Badge SVG labels still read "Media Buy Agent (Spec)" — version segment lands in Stage 3.
+- Verification panel still renders one row per role. Stage 4 splits into one row per (role, version).
+- brand.json enrichment shape unchanged. Stage 5 adds the `badges[]` array.
+
+Per the resolved-decisions comment on #3524: badge granularity is minor-level (`'3.0'`, `'3.1'`), JWT keeps `protocol_version` as informational metadata while a future stage adds `major_version` as the load-bearing claim, and the legacy SVG URL serves the highest active version.

--- a/.changeset/per-version-badges-stage1-data-model.md
+++ b/.changeset/per-version-badges-stage1-data-model.md
@@ -1,22 +1,22 @@
 ---
 ---
 
-backend(verification): per-major-version badge data model. Stage 1 of #3524 — extends `agent_verification_badges` so an agent can hold parallel `(Spec)` / `(Live)` badges across AdCP minor versions (3.0, 3.1, 4.0…). The previous PK `(agent_url, role)` becomes `(agent_url, role, major_version)`.
+backend(verification): per-AdCP-version badge data model. Stage 1 of #3524 — extends `agent_verification_badges` so an agent can hold parallel `(Spec)` / `(Live)` badges across AdCP releases (3.0, 3.1, 4.0…). The previous PK `(agent_url, role)` becomes `(agent_url, role, adcp_version)`.
+
+The new column is named `adcp_version` rather than `major_version` to avoid conflating with SemVer semantics — the values stored are `MAJOR.MINOR` strings (e.g., `'3.0'`, `'3.1'`), not just the SemVer major number. Pairs cleanly with the existing `verified_protocol_version` column which holds the full semver (e.g., `'3.0.0'`) as informational metadata.
 
 Behavior change is gated to Stage 2. This PR ships:
 
-- **Migration 457**: adds `major_version TEXT NOT NULL` to `agent_verification_badges`, backfills existing rows from `verified_protocol_version` (`X.Y.Z` → `X.Y`, falling back to `'3.0'` for null/malformed), rebuilds the PK to include `major_version`, drops the temporary default so future writes must specify the version explicitly. Adds an index on `(role, major_version, status)` for the per-version listings the panel and brand.json enrichment will need in later stages.
-- **DB layer**: `AgentVerificationBadge` type gains `major_version`. `upsertBadge` / `getActiveBadge` / `revokeBadge` / `degradeBadge` now take a `majorVersion` parameter. `getBadgesForAgent` / `bulkGetActiveBadges` / `getVerifiedAgentsByRole` order by `major_version DESC` so callers see the most recent first.
+- **Migration 457**: adds `adcp_version TEXT NOT NULL` to `agent_verification_badges`, backfills existing rows from `verified_protocol_version` (`X.Y.Z` → `X.Y`, falling back to `'3.0'` for null/malformed), rebuilds the PK to include `adcp_version`, drops the temporary default so future writes must specify the version explicitly. Adds an index on `(role, adcp_version, status)` for the per-version listings the panel and brand.json enrichment will need in later stages.
+- **DB layer**: `AgentVerificationBadge` type gains `adcp_version`. `upsertBadge` / `getActiveBadge` / `revokeBadge` / `degradeBadge` now take an `adcpVersion` parameter. `getBadgesForAgent` / `bulkGetActiveBadges` / `getVerifiedAgentsByRole` order by `adcp_version DESC` so callers see the most recent first.
 - **New helper**: `getHighestVersionActiveBadge(agentUrl, role)` powers the legacy `/badge/{role}.svg` URL — embedded badges in the wild auto-upgrade to the newest version the agent has earned without changing the URL. Per Q3 of the resolved-decisions thread on #3524.
-- **`processAgentBadges()`**: accepts an optional `majorVersion` parameter (defaults to `DEFAULT_BADGE_MAJOR_VERSION = '3.0'` for Stage 1 callers). The function now scopes existing-badge reads and writes to that single version — a `failing` 3.1 run never touches a 3.0 badge and vice versa. This is the load-bearing isolation property: it's what lets old-version badges persist while new versions are evaluated independently.
+- **`processAgentBadges()`**: accepts an optional `adcpVersion` parameter (defaults to `DEFAULT_BADGE_ADCP_VERSION = '3.0'` for Stage 1 callers). The function now scopes existing-badge reads and writes to that single version — a `failing` 3.1 run never touches a 3.0 badge and vice versa. This is the load-bearing isolation property: it's what lets old-version badges persist while new versions are evaluated independently.
 
 Four new tests cover the version-isolation invariant: only-touch-version-under-test, upsertBadge receives the version, default fallback when callers don't specify, and membership-lapse only affects the version under test.
 
 What this PR does NOT change:
-- The heartbeat job still calls `processAgentBadges()` without a `majorVersion` — defaults to `'3.0'`. Stage 2 wires per-version fan-out.
+- The heartbeat job still calls `processAgentBadges()` without an `adcpVersion` — defaults to `'3.0'`. Stage 2 wires per-version fan-out.
 - Storyboards have no `since:` field yet. Added in Stage 2.
 - Badge SVG labels still read "Media Buy Agent (Spec)" — version segment lands in Stage 3.
 - Verification panel still renders one row per role. Stage 4 splits into one row per (role, version).
 - brand.json enrichment shape unchanged. Stage 5 adds the `badges[]` array.
-
-Per the resolved-decisions comment on #3524: badge granularity is minor-level (`'3.0'`, `'3.1'`), JWT keeps `protocol_version` as informational metadata while a future stage adds `major_version` as the load-bearing claim, and the legacy SVG URL serves the highest active version.

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -131,13 +131,13 @@ export type BadgeStatus = 'active' | 'degraded' | 'revoked';
 export interface AgentVerificationBadge {
   agent_url: string;
   role: BadgeRole;
-  // AdCP minor version this badge was earned against (e.g. '3.0', '3.1').
-  // Part of the composite PK alongside agent_url and role — an agent can
-  // hold parallel badges per major.minor version. See migration 457.
-  major_version: string;
+  // AdCP release this badge was earned against (MAJOR.MINOR, e.g. '3.0',
+  // '3.1'). Part of the composite PK alongside agent_url and role — an
+  // agent can hold parallel badges per release. See migration 457.
+  adcp_version: string;
   verified_at: Date;
   // Full semver ('3.0.0') for support/audit. Informational; the load-bearing
-  // field for badge identity is major_version.
+  // field for badge identity is adcp_version.
   verified_protocol_version: string | null;
   verified_specialisms: string[];
   // Verification axes earned: ['spec'] (storyboards pass), ['spec', 'live']
@@ -155,11 +155,11 @@ export interface AgentVerificationBadge {
 }
 
 /**
- * Default AdCP version Stage 1 hardcodes everywhere a major_version is
+ * Default AdCP version Stage 1 hardcodes everywhere an adcp_version is
  * needed. Replaced by per-call version targeting in Stage 2 once the
- * heartbeat fans out per supported major version.
+ * heartbeat fans out per supported AdCP release.
  */
-export const DEFAULT_BADGE_MAJOR_VERSION = '3.0';
+export const DEFAULT_BADGE_ADCP_VERSION = '3.0';
 
 export interface StoryboardStatusEntry {
   storyboard_id: string;
@@ -793,7 +793,7 @@ export class ComplianceDatabase {
   async upsertBadge(badge: {
     agent_url: string;
     role: BadgeRole;
-    major_version: string;
+    adcp_version: string;
     verified_specialisms: string[];
     verification_modes?: string[];
     verified_protocol_version?: string;
@@ -804,11 +804,11 @@ export class ComplianceDatabase {
     const modes = badge.verification_modes ?? ['spec'];
     const result = await query(
       `INSERT INTO agent_verification_badges (
-        agent_url, role, major_version, verified_specialisms, verification_modes, verified_protocol_version,
+        agent_url, role, adcp_version, verified_specialisms, verification_modes, verified_protocol_version,
         verification_token, token_expires_at, membership_org_id,
         status, verified_at, updated_at
       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'active', NOW(), NOW())
-      ON CONFLICT (agent_url, role, major_version) DO UPDATE SET
+      ON CONFLICT (agent_url, role, adcp_version) DO UPDATE SET
         verified_specialisms = $4,
         verification_modes = $5,
         verified_protocol_version = COALESCE($6, agent_verification_badges.verified_protocol_version),
@@ -824,7 +824,7 @@ export class ComplianceDatabase {
       [
         badge.agent_url,
         badge.role,
-        badge.major_version,
+        badge.adcp_version,
         badge.verified_specialisms,
         modes,
         badge.verified_protocol_version ?? null,
@@ -840,27 +840,27 @@ export class ComplianceDatabase {
     const result = await query(
       `SELECT * FROM agent_verification_badges
        WHERE agent_url = $1 AND status IN ('active', 'degraded')
-       ORDER BY major_version DESC, role`,
+       ORDER BY adcp_version DESC, role`,
       [agentUrl],
     );
     return result.rows as AgentVerificationBadge[];
   }
 
   /**
-   * Returns the active badge for an agent+role at a specific major version.
+   * Returns the active badge for an agent+role at a specific AdCP version.
    * Stage 2 will use this when the heartbeat fans out per version. Stage 1
-   * callers pass DEFAULT_BADGE_MAJOR_VERSION.
+   * callers pass DEFAULT_BADGE_ADCP_VERSION.
    */
   async getActiveBadge(
     agentUrl: string,
     role: BadgeRole,
-    majorVersion: string,
+    adcpVersion: string,
   ): Promise<AgentVerificationBadge | null> {
     const result = await query(
       `SELECT * FROM agent_verification_badges
-       WHERE agent_url = $1 AND role = $2 AND major_version = $3
+       WHERE agent_url = $1 AND role = $2 AND adcp_version = $3
          AND status IN ('active', 'degraded')`,
-      [agentUrl, role, majorVersion],
+      [agentUrl, role, adcpVersion],
     );
     return (result.rows[0] as AgentVerificationBadge) ?? null;
   }
@@ -880,7 +880,7 @@ export class ComplianceDatabase {
     const result = await query(
       `SELECT * FROM agent_verification_badges
        WHERE agent_url = $1 AND role = $2 AND status IN ('active', 'degraded')
-       ORDER BY major_version DESC
+       ORDER BY adcp_version DESC
        LIMIT 1`,
       [agentUrl, role],
     );
@@ -890,27 +890,27 @@ export class ComplianceDatabase {
   async revokeBadge(
     agentUrl: string,
     role: BadgeRole,
-    majorVersion: string,
+    adcpVersion: string,
     reason: string,
   ): Promise<void> {
     await query(
       `UPDATE agent_verification_badges
        SET status = 'revoked', revoked_at = NOW(), revocation_reason = $4, updated_at = NOW()
-       WHERE agent_url = $1 AND role = $2 AND major_version = $3 AND status IN ('active', 'degraded')`,
-      [agentUrl, role, majorVersion, reason],
+       WHERE agent_url = $1 AND role = $2 AND adcp_version = $3 AND status IN ('active', 'degraded')`,
+      [agentUrl, role, adcpVersion, reason],
     );
   }
 
   async degradeBadge(
     agentUrl: string,
     role: BadgeRole,
-    majorVersion: string,
+    adcpVersion: string,
   ): Promise<void> {
     await query(
       `UPDATE agent_verification_badges
        SET status = 'degraded', updated_at = NOW()
-       WHERE agent_url = $1 AND role = $2 AND major_version = $3 AND status = 'active'`,
-      [agentUrl, role, majorVersion],
+       WHERE agent_url = $1 AND role = $2 AND adcp_version = $3 AND status = 'active'`,
+      [agentUrl, role, adcpVersion],
     );
   }
 
@@ -919,7 +919,7 @@ export class ComplianceDatabase {
     const result = await query(
       `SELECT * FROM agent_verification_badges
        WHERE agent_url = ANY($1) AND status IN ('active', 'degraded')
-       ORDER BY agent_url, major_version DESC, role`,
+       ORDER BY agent_url, adcp_version DESC, role`,
       [agentUrls],
     );
     const map = new Map<string, AgentVerificationBadge[]>();
@@ -935,7 +935,7 @@ export class ComplianceDatabase {
     const result = await query(
       `SELECT * FROM agent_verification_badges
        WHERE role = $1 AND status IN ('active', 'degraded')
-       ORDER BY major_version DESC, verified_at DESC`,
+       ORDER BY adcp_version DESC, verified_at DESC`,
       [role],
     );
     return result.rows as AgentVerificationBadge[];

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -837,10 +837,17 @@ export class ComplianceDatabase {
   }
 
   async getBadgesForAgent(agentUrl: string): Promise<AgentVerificationBadge[]> {
+    // Numeric sort on adcp_version: split MAJOR.MINOR and compare each
+    // segment as int so '10.0' sorts above '3.0'. Text sort would
+    // serve a stale older badge once the spec hits double-digit
+    // major or minor numbers. CHECK constraint guarantees both
+    // segments are valid integers.
     const result = await query(
       `SELECT * FROM agent_verification_badges
        WHERE agent_url = $1 AND status IN ('active', 'degraded')
-       ORDER BY adcp_version DESC, role`,
+       ORDER BY split_part(adcp_version, '.', 1)::int DESC,
+                split_part(adcp_version, '.', 2)::int DESC,
+                role`,
       [agentUrl],
     );
     return result.rows as AgentVerificationBadge[];
@@ -877,10 +884,12 @@ export class ComplianceDatabase {
     agentUrl: string,
     role: BadgeRole,
   ): Promise<AgentVerificationBadge | null> {
+    // Numeric sort — see getBadgesForAgent comment.
     const result = await query(
       `SELECT * FROM agent_verification_badges
        WHERE agent_url = $1 AND role = $2 AND status IN ('active', 'degraded')
-       ORDER BY adcp_version DESC
+       ORDER BY split_part(adcp_version, '.', 1)::int DESC,
+                split_part(adcp_version, '.', 2)::int DESC
        LIMIT 1`,
       [agentUrl, role],
     );
@@ -916,10 +925,14 @@ export class ComplianceDatabase {
 
   async bulkGetActiveBadges(agentUrls: string[]): Promise<Map<string, AgentVerificationBadge[]>> {
     if (agentUrls.length === 0) return new Map();
+    // Numeric sort — see getBadgesForAgent comment.
     const result = await query(
       `SELECT * FROM agent_verification_badges
        WHERE agent_url = ANY($1) AND status IN ('active', 'degraded')
-       ORDER BY agent_url, adcp_version DESC, role`,
+       ORDER BY agent_url,
+                split_part(adcp_version, '.', 1)::int DESC,
+                split_part(adcp_version, '.', 2)::int DESC,
+                role`,
       [agentUrls],
     );
     const map = new Map<string, AgentVerificationBadge[]>();
@@ -932,10 +945,13 @@ export class ComplianceDatabase {
   }
 
   async getVerifiedAgentsByRole(role: BadgeRole): Promise<AgentVerificationBadge[]> {
+    // Numeric sort — see getBadgesForAgent comment.
     const result = await query(
       `SELECT * FROM agent_verification_badges
        WHERE role = $1 AND status IN ('active', 'degraded')
-       ORDER BY adcp_version DESC, verified_at DESC`,
+       ORDER BY split_part(adcp_version, '.', 1)::int DESC,
+                split_part(adcp_version, '.', 2)::int DESC,
+                verified_at DESC`,
       [role],
     );
     return result.rows as AgentVerificationBadge[];

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -131,7 +131,13 @@ export type BadgeStatus = 'active' | 'degraded' | 'revoked';
 export interface AgentVerificationBadge {
   agent_url: string;
   role: BadgeRole;
+  // AdCP minor version this badge was earned against (e.g. '3.0', '3.1').
+  // Part of the composite PK alongside agent_url and role — an agent can
+  // hold parallel badges per major.minor version. See migration 457.
+  major_version: string;
   verified_at: Date;
+  // Full semver ('3.0.0') for support/audit. Informational; the load-bearing
+  // field for badge identity is major_version.
   verified_protocol_version: string | null;
   verified_specialisms: string[];
   // Verification axes earned: ['spec'] (storyboards pass), ['spec', 'live']
@@ -147,6 +153,13 @@ export interface AgentVerificationBadge {
   created_at: Date;
   updated_at: Date;
 }
+
+/**
+ * Default AdCP version Stage 1 hardcodes everywhere a major_version is
+ * needed. Replaced by per-call version targeting in Stage 2 once the
+ * heartbeat fans out per supported major version.
+ */
+export const DEFAULT_BADGE_MAJOR_VERSION = '3.0';
 
 export interface StoryboardStatusEntry {
   storyboard_id: string;
@@ -780,6 +793,7 @@ export class ComplianceDatabase {
   async upsertBadge(badge: {
     agent_url: string;
     role: BadgeRole;
+    major_version: string;
     verified_specialisms: string[];
     verification_modes?: string[];
     verified_protocol_version?: string;
@@ -790,17 +804,17 @@ export class ComplianceDatabase {
     const modes = badge.verification_modes ?? ['spec'];
     const result = await query(
       `INSERT INTO agent_verification_badges (
-        agent_url, role, verified_specialisms, verification_modes, verified_protocol_version,
+        agent_url, role, major_version, verified_specialisms, verification_modes, verified_protocol_version,
         verification_token, token_expires_at, membership_org_id,
         status, verified_at, updated_at
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'active', NOW(), NOW())
-      ON CONFLICT (agent_url, role) DO UPDATE SET
-        verified_specialisms = $3,
-        verification_modes = $4,
-        verified_protocol_version = COALESCE($5, agent_verification_badges.verified_protocol_version),
-        verification_token = COALESCE($6, agent_verification_badges.verification_token),
-        token_expires_at = COALESCE($7, agent_verification_badges.token_expires_at),
-        membership_org_id = COALESCE($8, agent_verification_badges.membership_org_id),
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'active', NOW(), NOW())
+      ON CONFLICT (agent_url, role, major_version) DO UPDATE SET
+        verified_specialisms = $4,
+        verification_modes = $5,
+        verified_protocol_version = COALESCE($6, agent_verification_badges.verified_protocol_version),
+        verification_token = COALESCE($7, agent_verification_badges.verification_token),
+        token_expires_at = COALESCE($8, agent_verification_badges.token_expires_at),
+        membership_org_id = COALESCE($9, agent_verification_badges.membership_org_id),
         status = 'active',
         verified_at = CASE WHEN agent_verification_badges.status = 'degraded' THEN NOW() ELSE agent_verification_badges.verified_at END,
         revoked_at = NULL,
@@ -810,6 +824,7 @@ export class ComplianceDatabase {
       [
         badge.agent_url,
         badge.role,
+        badge.major_version,
         badge.verified_specialisms,
         modes,
         badge.verified_protocol_version ?? null,
@@ -823,42 +838,88 @@ export class ComplianceDatabase {
 
   async getBadgesForAgent(agentUrl: string): Promise<AgentVerificationBadge[]> {
     const result = await query(
-      `SELECT * FROM agent_verification_badges WHERE agent_url = $1 AND status IN ('active', 'degraded')`,
+      `SELECT * FROM agent_verification_badges
+       WHERE agent_url = $1 AND status IN ('active', 'degraded')
+       ORDER BY major_version DESC, role`,
       [agentUrl],
     );
     return result.rows as AgentVerificationBadge[];
   }
 
-  async getActiveBadge(agentUrl: string, role: BadgeRole): Promise<AgentVerificationBadge | null> {
+  /**
+   * Returns the active badge for an agent+role at a specific major version.
+   * Stage 2 will use this when the heartbeat fans out per version. Stage 1
+   * callers pass DEFAULT_BADGE_MAJOR_VERSION.
+   */
+  async getActiveBadge(
+    agentUrl: string,
+    role: BadgeRole,
+    majorVersion: string,
+  ): Promise<AgentVerificationBadge | null> {
     const result = await query(
-      `SELECT * FROM agent_verification_badges WHERE agent_url = $1 AND role = $2 AND status IN ('active', 'degraded')`,
+      `SELECT * FROM agent_verification_badges
+       WHERE agent_url = $1 AND role = $2 AND major_version = $3
+         AND status IN ('active', 'degraded')`,
+      [agentUrl, role, majorVersion],
+    );
+    return (result.rows[0] as AgentVerificationBadge) ?? null;
+  }
+
+  /**
+   * Returns the highest-version active badge for an agent+role.
+   *
+   * Powers the legacy `/badge/{role}.svg` URL — embedded badges in the
+   * wild auto-upgrade to the most recent version the agent has earned
+   * without changing the URL. The version-specific URL
+   * `/badge/{role}/{version}.svg` (Stage 3) lets buyers pin a version.
+   */
+  async getHighestVersionActiveBadge(
+    agentUrl: string,
+    role: BadgeRole,
+  ): Promise<AgentVerificationBadge | null> {
+    const result = await query(
+      `SELECT * FROM agent_verification_badges
+       WHERE agent_url = $1 AND role = $2 AND status IN ('active', 'degraded')
+       ORDER BY major_version DESC
+       LIMIT 1`,
       [agentUrl, role],
     );
     return (result.rows[0] as AgentVerificationBadge) ?? null;
   }
 
-  async revokeBadge(agentUrl: string, role: BadgeRole, reason: string): Promise<void> {
+  async revokeBadge(
+    agentUrl: string,
+    role: BadgeRole,
+    majorVersion: string,
+    reason: string,
+  ): Promise<void> {
     await query(
       `UPDATE agent_verification_badges
-       SET status = 'revoked', revoked_at = NOW(), revocation_reason = $3, updated_at = NOW()
-       WHERE agent_url = $1 AND role = $2 AND status IN ('active', 'degraded')`,
-      [agentUrl, role, reason],
+       SET status = 'revoked', revoked_at = NOW(), revocation_reason = $4, updated_at = NOW()
+       WHERE agent_url = $1 AND role = $2 AND major_version = $3 AND status IN ('active', 'degraded')`,
+      [agentUrl, role, majorVersion, reason],
     );
   }
 
-  async degradeBadge(agentUrl: string, role: BadgeRole): Promise<void> {
+  async degradeBadge(
+    agentUrl: string,
+    role: BadgeRole,
+    majorVersion: string,
+  ): Promise<void> {
     await query(
       `UPDATE agent_verification_badges
        SET status = 'degraded', updated_at = NOW()
-       WHERE agent_url = $1 AND role = $2 AND status = 'active'`,
-      [agentUrl, role],
+       WHERE agent_url = $1 AND role = $2 AND major_version = $3 AND status = 'active'`,
+      [agentUrl, role, majorVersion],
     );
   }
 
   async bulkGetActiveBadges(agentUrls: string[]): Promise<Map<string, AgentVerificationBadge[]>> {
     if (agentUrls.length === 0) return new Map();
     const result = await query(
-      `SELECT * FROM agent_verification_badges WHERE agent_url = ANY($1) AND status IN ('active', 'degraded')`,
+      `SELECT * FROM agent_verification_badges
+       WHERE agent_url = ANY($1) AND status IN ('active', 'degraded')
+       ORDER BY agent_url, major_version DESC, role`,
       [agentUrls],
     );
     const map = new Map<string, AgentVerificationBadge[]>();
@@ -872,7 +933,9 @@ export class ComplianceDatabase {
 
   async getVerifiedAgentsByRole(role: BadgeRole): Promise<AgentVerificationBadge[]> {
     const result = await query(
-      `SELECT * FROM agent_verification_badges WHERE role = $1 AND status IN ('active', 'degraded') ORDER BY verified_at DESC`,
+      `SELECT * FROM agent_verification_badges
+       WHERE role = $1 AND status IN ('active', 'degraded')
+       ORDER BY major_version DESC, verified_at DESC`,
       [role],
     );
     return result.rows as AgentVerificationBadge[];

--- a/server/src/db/migrations/457_agent_verification_badges_per_version.sql
+++ b/server/src/db/migrations/457_agent_verification_badges_per_version.sql
@@ -1,0 +1,48 @@
+-- Per-major-version AAO Verified badges (#3524, stage 1).
+--
+-- Extends agent_verification_badges so an agent can hold parallel
+-- (Spec)/(Live) badges per AdCP minor version (3.0, 3.1, 4.0…). The
+-- previous PK (agent_url, role) becomes (agent_url, role, major_version).
+--
+-- Behavior change is gated to a follow-up PR (stage 2). This migration:
+--   1. Adds major_version with a default of '3.0' so existing writes keep
+--      working unchanged during the rollout.
+--   2. Backfills existing rows from verified_protocol_version (parsing
+--      'X.Y.Z' → 'X.Y') with '3.0' as the fallback for null/malformed.
+--   3. Rebuilds the PK to include major_version.
+--   4. Drops the default after backfill so future writes must be explicit
+--      (catch any missed call site at insert time, not at runtime).
+--   5. Adds a CHECK constraint to keep major_version shaped like 'X.Y'.
+
+BEGIN;
+
+-- 1. Add column with temporary default so existing rows get a value.
+ALTER TABLE agent_verification_badges
+  ADD COLUMN IF NOT EXISTS major_version TEXT NOT NULL DEFAULT '3.0';
+
+-- 2. Backfill from verified_protocol_version where available.
+--    'X.Y.Z' → 'X.Y'; null or non-matching stays at the default '3.0'.
+UPDATE agent_verification_badges
+SET major_version = substring(verified_protocol_version FROM '^(\d+\.\d+)')
+WHERE verified_protocol_version IS NOT NULL
+  AND verified_protocol_version ~ '^\d+\.\d+';
+
+-- 3. Rebuild the primary key.
+ALTER TABLE agent_verification_badges DROP CONSTRAINT agent_verification_badges_pkey;
+ALTER TABLE agent_verification_badges ADD PRIMARY KEY (agent_url, role, major_version);
+
+-- 4. Drop the default — future writes must specify the version explicitly.
+ALTER TABLE agent_verification_badges ALTER COLUMN major_version DROP DEFAULT;
+
+-- 5. Constrain the shape. Two-segment dotted decimal, no leading zeros.
+ALTER TABLE agent_verification_badges
+  ADD CONSTRAINT valid_major_version
+  CHECK (major_version ~ '^[1-9][0-9]*\.[0-9]+$');
+
+-- 6. Indexes that filter by version. The role+status index already covers
+--    most query paths; this is for the per-version badge listing in the
+--    panel and brand.json enrichment.
+CREATE INDEX IF NOT EXISTS idx_verification_badges_role_version
+  ON agent_verification_badges(role, major_version, status);
+
+COMMIT;

--- a/server/src/db/migrations/457_agent_verification_badges_per_version.sql
+++ b/server/src/db/migrations/457_agent_verification_badges_per_version.sql
@@ -8,6 +8,15 @@
 -- (e.g. '3.0', '3.1'). Full semver lives separately in
 -- verified_protocol_version as informational metadata.
 --
+-- Lock window: this migration takes ACCESS EXCLUSIVE on
+-- agent_verification_badges from the first ALTER TABLE through COMMIT.
+-- Acceptable because the table is small (one row per badged agent) and
+-- the body completes in milliseconds against any production-scale data.
+-- Concurrent writers from a pre-migration Node process block on the
+-- lock and resume after commit; they then fail the new NOT-NULL-no-
+-- default constraint rather than silently writing '3.0' for the wrong
+-- version.
+--
 -- Behavior change is gated to a follow-up PR (stage 2). This migration:
 --   1. Adds adcp_version with a default of '3.0' so existing writes keep
 --      working unchanged during the rollout.
@@ -25,11 +34,14 @@ ALTER TABLE agent_verification_badges
   ADD COLUMN IF NOT EXISTS adcp_version TEXT NOT NULL DEFAULT '3.0';
 
 -- 2. Backfill from verified_protocol_version where available.
---    'X.Y.Z' → 'X.Y'; null or non-matching stays at the default '3.0'.
+--    'X.Y.Z' → 'X.Y'; null, malformed, or leading-zero-major rows stay
+--    at the default '3.0'. The leading-zero guard matches the downstream
+--    CHECK constraint — without it, '0.5.0' would extract to '0.5' and
+--    fail the CHECK at step 5, aborting the migration.
 UPDATE agent_verification_badges
-SET adcp_version = substring(verified_protocol_version FROM '^(\d+\.\d+)')
+SET adcp_version = substring(verified_protocol_version FROM '^([1-9][0-9]*\.[0-9]+)')
 WHERE verified_protocol_version IS NOT NULL
-  AND verified_protocol_version ~ '^\d+\.\d+';
+  AND verified_protocol_version ~ '^[1-9][0-9]*\.[0-9]+';
 
 -- 3. Rebuild the primary key.
 ALTER TABLE agent_verification_badges DROP CONSTRAINT agent_verification_badges_pkey;

--- a/server/src/db/migrations/457_agent_verification_badges_per_version.sql
+++ b/server/src/db/migrations/457_agent_verification_badges_per_version.sql
@@ -1,48 +1,52 @@
--- Per-major-version AAO Verified badges (#3524, stage 1).
+-- Per-AdCP-version AAO Verified badges (#3524, stage 1).
 --
 -- Extends agent_verification_badges so an agent can hold parallel
--- (Spec)/(Live) badges per AdCP minor version (3.0, 3.1, 4.0…). The
--- previous PK (agent_url, role) becomes (agent_url, role, major_version).
+-- (Spec)/(Live) badges per AdCP release (3.0, 3.1, 4.0…). The previous
+-- PK (agent_url, role) becomes (agent_url, role, adcp_version).
+--
+-- "adcp_version" stores the MAJOR.MINOR portion of the spec version
+-- (e.g. '3.0', '3.1'). Full semver lives separately in
+-- verified_protocol_version as informational metadata.
 --
 -- Behavior change is gated to a follow-up PR (stage 2). This migration:
---   1. Adds major_version with a default of '3.0' so existing writes keep
+--   1. Adds adcp_version with a default of '3.0' so existing writes keep
 --      working unchanged during the rollout.
 --   2. Backfills existing rows from verified_protocol_version (parsing
 --      'X.Y.Z' → 'X.Y') with '3.0' as the fallback for null/malformed.
---   3. Rebuilds the PK to include major_version.
+--   3. Rebuilds the PK to include adcp_version.
 --   4. Drops the default after backfill so future writes must be explicit
 --      (catch any missed call site at insert time, not at runtime).
---   5. Adds a CHECK constraint to keep major_version shaped like 'X.Y'.
+--   5. Adds a CHECK constraint to keep adcp_version shaped like 'X.Y'.
 
 BEGIN;
 
 -- 1. Add column with temporary default so existing rows get a value.
 ALTER TABLE agent_verification_badges
-  ADD COLUMN IF NOT EXISTS major_version TEXT NOT NULL DEFAULT '3.0';
+  ADD COLUMN IF NOT EXISTS adcp_version TEXT NOT NULL DEFAULT '3.0';
 
 -- 2. Backfill from verified_protocol_version where available.
 --    'X.Y.Z' → 'X.Y'; null or non-matching stays at the default '3.0'.
 UPDATE agent_verification_badges
-SET major_version = substring(verified_protocol_version FROM '^(\d+\.\d+)')
+SET adcp_version = substring(verified_protocol_version FROM '^(\d+\.\d+)')
 WHERE verified_protocol_version IS NOT NULL
   AND verified_protocol_version ~ '^\d+\.\d+';
 
 -- 3. Rebuild the primary key.
 ALTER TABLE agent_verification_badges DROP CONSTRAINT agent_verification_badges_pkey;
-ALTER TABLE agent_verification_badges ADD PRIMARY KEY (agent_url, role, major_version);
+ALTER TABLE agent_verification_badges ADD PRIMARY KEY (agent_url, role, adcp_version);
 
 -- 4. Drop the default — future writes must specify the version explicitly.
-ALTER TABLE agent_verification_badges ALTER COLUMN major_version DROP DEFAULT;
+ALTER TABLE agent_verification_badges ALTER COLUMN adcp_version DROP DEFAULT;
 
 -- 5. Constrain the shape. Two-segment dotted decimal, no leading zeros.
 ALTER TABLE agent_verification_badges
-  ADD CONSTRAINT valid_major_version
-  CHECK (major_version ~ '^[1-9][0-9]*\.[0-9]+$');
+  ADD CONSTRAINT valid_adcp_version
+  CHECK (adcp_version ~ '^[1-9][0-9]*\.[0-9]+$');
 
 -- 6. Indexes that filter by version. The role+status index already covers
 --    most query paths; this is for the per-version badge listing in the
 --    panel and brand.json enrichment.
-CREATE INDEX IF NOT EXISTS idx_verification_badges_role_version
-  ON agent_verification_badges(role, major_version, status);
+CREATE INDEX IF NOT EXISTS idx_verification_badges_role_adcp_version
+  ON agent_verification_badges(role, adcp_version, status);
 
 COMMIT;

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -2692,14 +2692,25 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       if (typeof rec.url === 'string' && typeof rec.type === 'string') {
         const badges = badgeMap.get(rec.url as string);
         if (badges && badges.length > 0) {
+          // Once an agent holds parallel-version badges (Stage 2+),
+          // bulkGetActiveBadges returns multiple rows per role. Dedupe
+          // here by role, keeping the highest-version badge — that's
+          // what the Q3 decision says the public mark should reflect.
+          // bulkGetActiveBadges already orders by adcp_version DESC
+          // numerically, so the first row per role is the highest.
+          const byRole = new Map<typeof badges[number]['role'], typeof badges[number]>();
+          for (const badge of badges) {
+            if (!byRole.has(badge.role)) byRole.set(badge.role, badge);
+          }
+          const dedupedBadges = Array.from(byRole.values());
           rec.aao_verification = {
             verified: true,
-            roles: badges.map(b => b.role),
-            // Per-role verification axes. Each entry is the modes array for
-            // the role at the same index in `roles`. ['spec'] today; will
-            // include 'live' when canonical campaigns are healthy.
-            modes_by_role: Object.fromEntries(badges.map(b => [b.role, b.verification_modes])),
-            verified_at: badges[0].verified_at.toISOString(),
+            roles: dedupedBadges.map(b => b.role),
+            // Per-role verification axes. ['spec'] today; will include
+            // 'live' when canonical campaigns are healthy. Stage 5
+            // adds a richer `badges[]` array with per-version detail.
+            modes_by_role: Object.fromEntries(dedupedBadges.map(b => [b.role, b.verification_modes])),
+            verified_at: dedupedBadges[0].verified_at.toISOString(),
           };
         }
       }
@@ -3711,6 +3722,12 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
             const optedOut = meta?.compliance_opt_out ?? false;
             if (cs && !optedOut) {
               const agentBadges = badgeMap?.get(agent.url) || [];
+              // Dedupe by role for the registry summary — once an agent
+              // holds parallel-version badges, agentBadges has multiple
+              // rows per role and verified_roles would silently grow
+              // duplicates. Keep one entry per role (any version is
+              // sufficient for the boolean "verified for this role").
+              const uniqueRoles = Array.from(new Set(agentBadges.map(b => b.role)));
               enrichedAgent.compliance = {
                 status: cs.status,
                 lifecycle_stage: cs.lifecycle_stage,
@@ -3721,7 +3738,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
                 monitoring_paused: meta?.monitoring_paused ?? false,
                 check_interval_hours: meta?.check_interval_hours ?? 12,
                 verified: agentBadges.length > 0,
-                verified_roles: agentBadges.map(b => b.role),
+                verified_roles: uniqueRoles,
               };
             }
           }
@@ -3996,7 +4013,8 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         return res.status(400).json({ error: `Invalid role "${role}". Valid roles: ${VALID_BADGE_ROLES.join(', ')}` });
       }
 
-      // getActiveBadge returns active + degraded badges. A degraded badge
+      // getHighestVersionActiveBadge returns the highest-version active +
+      // degraded badge. A degraded badge
       // (within 48-hour grace period) still renders as verified -- the grace
       // period is invisible to the public. Revocation only happens after 48h.
       let modes: string[] = [];

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -4001,7 +4001,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       // period is invisible to the public. Revocation only happens after 48h.
       let modes: string[] = [];
       try {
-        const badge = await complianceDb.getActiveBadge(agentUrl, role as any);
+        const badge = await complianceDb.getHighestVersionActiveBadge(agentUrl, role as any);
         if (badge) modes = badge.verification_modes;
       } catch {
         // Table may not exist yet
@@ -4037,7 +4037,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
 
       let verified = false;
       try {
-        const badge = await complianceDb.getActiveBadge(agentUrl, role as any);
+        const badge = await complianceDb.getHighestVersionActiveBadge(agentUrl, role as any);
         verified = !!badge;
       } catch {
         // Table may not exist yet

--- a/server/src/services/badge-issuance.ts
+++ b/server/src/services/badge-issuance.ts
@@ -3,7 +3,7 @@
  * AAO Verified badges based on specialism results.
  */
 
-import { ComplianceDatabase, type BadgeRole, type StoryboardStatusEntry } from '../db/compliance-db.js';
+import { ComplianceDatabase, DEFAULT_BADGE_MAJOR_VERSION, type BadgeRole, type StoryboardStatusEntry } from '../db/compliance-db.js';
 import { deriveVerificationStatus } from '../addie/services/compliance-testing.js';
 import { signVerificationToken, isTokenSigningEnabled } from './verification-token.js';
 import { isVerificationMode, type VerificationMode } from './adcp-taxonomy.js';
@@ -36,6 +36,7 @@ export async function processAgentBadges(
   storyboardStatuses: StoryboardStatusEntry[],
   overallPassing: boolean,
   membershipOrgId?: string,
+  majorVersion: string = DEFAULT_BADGE_MAJOR_VERSION,
 ): Promise<BadgeIssuanceResult> {
   const result: BadgeIssuanceResult = { issued: [], revoked: [], degraded: [], unchanged: [] };
 
@@ -44,16 +45,20 @@ export async function processAgentBadges(
   }
 
   const verification = deriveVerificationStatus(declaredSpecialisms, storyboardStatuses);
-  const existingBadges = await complianceDb.getBadgesForAgent(agentUrl);
+  // Scope the existing-badge lookup to the major version we're processing.
+  // Other versions held by this agent are off-limits to this run — a 3.1
+  // failing run never touches a 3.0 badge and vice-versa.
+  const existingAllVersions = await complianceDb.getBadgesForAgent(agentUrl);
+  const existingBadges = existingAllVersions.filter(b => b.major_version === majorVersion);
   const existingByRole = new Map(existingBadges.map(b => [b.role, b]));
 
   // If the agent's org no longer has API-access membership, revoke all existing
   // badges. Badge issuance is a public trust signal tied to active membership.
   if (!membershipOrgId) {
     for (const existing of existingBadges) {
-      await complianceDb.revokeBadge(agentUrl, existing.role, 'Membership lapsed');
+      await complianceDb.revokeBadge(agentUrl, existing.role, majorVersion, 'Membership lapsed');
       result.revoked.push({ role: existing.role, reason: 'Membership lapsed' });
-      logger.info({ agentUrl, role: existing.role }, 'Badge revoked — membership lapsed');
+      logger.info({ agentUrl, role: existing.role, majorVersion }, 'Badge revoked — membership lapsed');
     }
     return result;
   }
@@ -89,6 +94,7 @@ export async function processAgentBadges(
       await complianceDb.upsertBadge({
         agent_url: agentUrl,
         role: roleResult.role,
+        major_version: majorVersion,
         verified_specialisms: roleResult.specialisms,
         verification_modes: modes,
         verification_token: token,
@@ -98,23 +104,23 @@ export async function processAgentBadges(
 
       if (!existing) {
         result.issued.push({ role: roleResult.role, specialisms: roleResult.specialisms });
-        logger.info({ agentUrl, role: roleResult.role, specialisms: roleResult.specialisms }, 'Badge issued');
+        logger.info({ agentUrl, role: roleResult.role, majorVersion, specialisms: roleResult.specialisms }, 'Badge issued');
       } else {
         result.unchanged.push({ role: roleResult.role });
       }
     } else if (existing) {
       if (existing.status === 'active') {
-        await complianceDb.degradeBadge(agentUrl, roleResult.role);
+        await complianceDb.degradeBadge(agentUrl, roleResult.role, majorVersion);
         result.degraded.push({ role: roleResult.role });
-        logger.info({ agentUrl, role: roleResult.role, failing: roleResult.failing }, 'Badge degraded');
+        logger.info({ agentUrl, role: roleResult.role, majorVersion, failing: roleResult.failing }, 'Badge degraded');
       } else if (existing.status === 'degraded') {
         const degradedAt = existing.updated_at;
         const hoursSinceDegraded = (Date.now() - degradedAt.getTime()) / (1000 * 60 * 60);
 
         if (hoursSinceDegraded >= 48) {
-          await complianceDb.revokeBadge(agentUrl, roleResult.role, `Specialisms failing for 48+ hours: ${roleResult.failing.join(', ')}`);
+          await complianceDb.revokeBadge(agentUrl, roleResult.role, majorVersion, `Specialisms failing for 48+ hours: ${roleResult.failing.join(', ')}`);
           result.revoked.push({ role: roleResult.role, reason: `Failing specialisms: ${roleResult.failing.join(', ')}` });
-          logger.info({ agentUrl, role: roleResult.role, failing: roleResult.failing }, 'Badge revoked after 48h grace');
+          logger.info({ agentUrl, role: roleResult.role, majorVersion, failing: roleResult.failing }, 'Badge revoked after 48h grace');
         } else {
           result.unchanged.push({ role: roleResult.role });
         }
@@ -126,7 +132,7 @@ export async function processAgentBadges(
   const activeRoles = new Set(verification.roles.map(r => r.role));
   for (const existing of existingBadges) {
     if (!activeRoles.has(existing.role)) {
-      await complianceDb.revokeBadge(agentUrl, existing.role, 'Role no longer in declared specialisms');
+      await complianceDb.revokeBadge(agentUrl, existing.role, majorVersion, 'Role no longer in declared specialisms');
       result.revoked.push({ role: existing.role, reason: 'Role no longer declared' });
     }
   }

--- a/server/src/services/badge-issuance.ts
+++ b/server/src/services/badge-issuance.ts
@@ -3,7 +3,7 @@
  * AAO Verified badges based on specialism results.
  */
 
-import { ComplianceDatabase, DEFAULT_BADGE_MAJOR_VERSION, type BadgeRole, type StoryboardStatusEntry } from '../db/compliance-db.js';
+import { ComplianceDatabase, DEFAULT_BADGE_ADCP_VERSION, type BadgeRole, type StoryboardStatusEntry } from '../db/compliance-db.js';
 import { deriveVerificationStatus } from '../addie/services/compliance-testing.js';
 import { signVerificationToken, isTokenSigningEnabled } from './verification-token.js';
 import { isVerificationMode, type VerificationMode } from './adcp-taxonomy.js';
@@ -36,7 +36,7 @@ export async function processAgentBadges(
   storyboardStatuses: StoryboardStatusEntry[],
   overallPassing: boolean,
   membershipOrgId?: string,
-  majorVersion: string = DEFAULT_BADGE_MAJOR_VERSION,
+  adcpVersion: string = DEFAULT_BADGE_ADCP_VERSION,
 ): Promise<BadgeIssuanceResult> {
   const result: BadgeIssuanceResult = { issued: [], revoked: [], degraded: [], unchanged: [] };
 
@@ -45,20 +45,20 @@ export async function processAgentBadges(
   }
 
   const verification = deriveVerificationStatus(declaredSpecialisms, storyboardStatuses);
-  // Scope the existing-badge lookup to the major version we're processing.
+  // Scope the existing-badge lookup to the AdCP version we're processing.
   // Other versions held by this agent are off-limits to this run — a 3.1
   // failing run never touches a 3.0 badge and vice-versa.
   const existingAllVersions = await complianceDb.getBadgesForAgent(agentUrl);
-  const existingBadges = existingAllVersions.filter(b => b.major_version === majorVersion);
+  const existingBadges = existingAllVersions.filter(b => b.adcp_version === adcpVersion);
   const existingByRole = new Map(existingBadges.map(b => [b.role, b]));
 
   // If the agent's org no longer has API-access membership, revoke all existing
   // badges. Badge issuance is a public trust signal tied to active membership.
   if (!membershipOrgId) {
     for (const existing of existingBadges) {
-      await complianceDb.revokeBadge(agentUrl, existing.role, majorVersion, 'Membership lapsed');
+      await complianceDb.revokeBadge(agentUrl, existing.role, adcpVersion, 'Membership lapsed');
       result.revoked.push({ role: existing.role, reason: 'Membership lapsed' });
-      logger.info({ agentUrl, role: existing.role, majorVersion }, 'Badge revoked — membership lapsed');
+      logger.info({ agentUrl, role: existing.role, adcpVersion }, 'Badge revoked — membership lapsed');
     }
     return result;
   }
@@ -94,7 +94,7 @@ export async function processAgentBadges(
       await complianceDb.upsertBadge({
         agent_url: agentUrl,
         role: roleResult.role,
-        major_version: majorVersion,
+        adcp_version: adcpVersion,
         verified_specialisms: roleResult.specialisms,
         verification_modes: modes,
         verification_token: token,
@@ -104,23 +104,23 @@ export async function processAgentBadges(
 
       if (!existing) {
         result.issued.push({ role: roleResult.role, specialisms: roleResult.specialisms });
-        logger.info({ agentUrl, role: roleResult.role, majorVersion, specialisms: roleResult.specialisms }, 'Badge issued');
+        logger.info({ agentUrl, role: roleResult.role, adcpVersion, specialisms: roleResult.specialisms }, 'Badge issued');
       } else {
         result.unchanged.push({ role: roleResult.role });
       }
     } else if (existing) {
       if (existing.status === 'active') {
-        await complianceDb.degradeBadge(agentUrl, roleResult.role, majorVersion);
+        await complianceDb.degradeBadge(agentUrl, roleResult.role, adcpVersion);
         result.degraded.push({ role: roleResult.role });
-        logger.info({ agentUrl, role: roleResult.role, majorVersion, failing: roleResult.failing }, 'Badge degraded');
+        logger.info({ agentUrl, role: roleResult.role, adcpVersion, failing: roleResult.failing }, 'Badge degraded');
       } else if (existing.status === 'degraded') {
         const degradedAt = existing.updated_at;
         const hoursSinceDegraded = (Date.now() - degradedAt.getTime()) / (1000 * 60 * 60);
 
         if (hoursSinceDegraded >= 48) {
-          await complianceDb.revokeBadge(agentUrl, roleResult.role, majorVersion, `Specialisms failing for 48+ hours: ${roleResult.failing.join(', ')}`);
+          await complianceDb.revokeBadge(agentUrl, roleResult.role, adcpVersion, `Specialisms failing for 48+ hours: ${roleResult.failing.join(', ')}`);
           result.revoked.push({ role: roleResult.role, reason: `Failing specialisms: ${roleResult.failing.join(', ')}` });
-          logger.info({ agentUrl, role: roleResult.role, majorVersion, failing: roleResult.failing }, 'Badge revoked after 48h grace');
+          logger.info({ agentUrl, role: roleResult.role, adcpVersion, failing: roleResult.failing }, 'Badge revoked after 48h grace');
         } else {
           result.unchanged.push({ role: roleResult.role });
         }
@@ -132,7 +132,7 @@ export async function processAgentBadges(
   const activeRoles = new Set(verification.roles.map(r => r.role));
   for (const existing of existingBadges) {
     if (!activeRoles.has(existing.role)) {
-      await complianceDb.revokeBadge(agentUrl, existing.role, majorVersion, 'Role no longer in declared specialisms');
+      await complianceDb.revokeBadge(agentUrl, existing.role, adcpVersion, 'Role no longer in declared specialisms');
       result.revoked.push({ role: existing.role, reason: 'Role no longer declared' });
     }
   }

--- a/server/src/services/badge-issuance.ts
+++ b/server/src/services/badge-issuance.ts
@@ -45,23 +45,29 @@ export async function processAgentBadges(
   }
 
   const verification = deriveVerificationStatus(declaredSpecialisms, storyboardStatuses);
-  // Scope the existing-badge lookup to the AdCP version we're processing.
-  // Other versions held by this agent are off-limits to this run — a 3.1
-  // failing run never touches a 3.0 badge and vice-versa.
   const existingAllVersions = await complianceDb.getBadgesForAgent(agentUrl);
-  const existingBadges = existingAllVersions.filter(b => b.adcp_version === adcpVersion);
-  const existingByRole = new Map(existingBadges.map(b => [b.role, b]));
 
-  // If the agent's org no longer has API-access membership, revoke all existing
-  // badges. Badge issuance is a public trust signal tied to active membership.
+  // Membership is an agent-level fact, not a version-level fact. When
+  // membership lapses, every badge across every version must revoke
+  // immediately — not just the version under test. Otherwise a non-paying
+  // agent's other-version badges would keep signaling "AAO Verified" until
+  // their own heartbeats land (12-24h later), which is wrong for a public
+  // trust mark.
   if (!membershipOrgId) {
-    for (const existing of existingBadges) {
-      await complianceDb.revokeBadge(agentUrl, existing.role, adcpVersion, 'Membership lapsed');
+    for (const existing of existingAllVersions) {
+      await complianceDb.revokeBadge(agentUrl, existing.role, existing.adcp_version, 'Membership lapsed');
       result.revoked.push({ role: existing.role, reason: 'Membership lapsed' });
-      logger.info({ agentUrl, role: existing.role, adcpVersion }, 'Badge revoked — membership lapsed');
+      logger.info({ agentUrl, role: existing.role, adcpVersion: existing.adcp_version }, 'Badge revoked — membership lapsed');
     }
     return result;
   }
+
+  // Scope further reads/writes to the AdCP version we're processing —
+  // for issuance, degradation, and 48-hour-grace revocation, this run
+  // only touches its own version. A 3.1 failing run never affects a 3.0
+  // badge and vice-versa.
+  const existingBadges = existingAllVersions.filter(b => b.adcp_version === adcpVersion);
+  const existingByRole = new Map(existingBadges.map(b => [b.role, b]));
 
   for (const roleResult of verification.roles) {
     const existing = existingByRole.get(roleResult.role);

--- a/server/tests/unit/badge-issuance.test.ts
+++ b/server/tests/unit/badge-issuance.test.ts
@@ -246,10 +246,16 @@ describe('processAgentBadges — per-AdCP-version isolation (#3524 stage 1)', ()
     expect(upsertCalls[0][0]).toMatchObject({ adcp_version: '3.0' });
   });
 
-  it('membership lapse only revokes badges at the version under test', async () => {
+  it('membership lapse revokes ALL of an agent\'s badges across every version', async () => {
+    // Membership is an agent-level fact, not a version-level fact. A
+    // non-paying agent must lose its trust mark immediately on every
+    // version — not wait 12-24h for each version's own heartbeat to
+    // land. Otherwise the public registry would briefly show parallel
+    // versions with conflicting truth (some revoked, some not).
     const existing = [
       makeBadge('media-buy', 'active', 0, ['spec'], '3.0'),
       makeBadge('media-buy', 'active', 0, ['spec'], '3.1'),
+      makeBadge('creative', 'active', 0, ['spec'], '3.1'),
     ];
     const db = makeMockDb(existing);
 
@@ -263,10 +269,49 @@ describe('processAgentBadges — per-AdCP-version isolation (#3524 stage 1)', ()
       '3.0',
     );
 
-    // Only 3.0 should be revoked under this run; 3.1 stays untouched.
-    // Stage 2 will issue a separate per-version run for 3.1.
     const revokeCalls = (db.revokeBadge as unknown as { mock: { calls: unknown[][] } }).mock.calls;
-    expect(revokeCalls).toHaveLength(1);
-    expect(revokeCalls[0][2]).toBe('3.0');
+    // Every existing badge should be revoked, each at its own version.
+    expect(revokeCalls).toHaveLength(3);
+    const revokedTuples = revokeCalls.map(call => `${call[1]}@${call[2]}`).sort();
+    expect(revokedTuples).toEqual(['creative@3.1', 'media-buy@3.0', 'media-buy@3.1']);
+    // All revocations carry the lapse reason.
+    expect(revokeCalls.every(call => call[3] === 'Membership lapsed')).toBe(true);
+  });
+
+  it('partial overlap: issuing a new role at 3.0 does not touch creative@3.1', async () => {
+    // Code-reviewer requested case: agent has media-buy@3.0 and creative@3.1.
+    // A 3.0 run that issues creative for the first time at 3.0 must not
+    // touch the existing creative@3.1 badge — different versions are
+    // independent.
+    const existing = [
+      makeBadge('media-buy', 'active', 0, ['spec'], '3.0'),
+      makeBadge('creative', 'active', 0, ['spec'], '3.1'),
+    ];
+    const db = makeMockDb(existing);
+
+    await processAgentBadges(
+      db,
+      'https://example.com/mcp',
+      ['creative-ad-server'],
+      [makeStatus('creative_ad_server', 'passing')],
+      true,
+      'org_test',
+      '3.0',
+    );
+
+    const upsertCalls = (db.upsertBadge as unknown as { mock: { calls: Array<[Record<string, unknown>]> } }).mock.calls;
+    expect(upsertCalls).toHaveLength(1);
+    expect(upsertCalls[0][0]).toMatchObject({ role: 'creative', adcp_version: '3.0' });
+    // Neither degrade nor revoke should fire — media-buy@3.0 isn't in the
+    // run's declared specialisms but it's still active (Stage 2 will run a
+    // separate process for media-buy if its specialism is still declared).
+    // creative@3.1 is on a different version and out of scope for this run.
+    expect(db.degradeBadge).not.toHaveBeenCalled();
+    // The cross-version creative@3.1 must not be touched.
+    const revokeCalls = (db.revokeBadge as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    const touchedCreativeOtherVersion = revokeCalls.some(
+      call => call[1] === 'creative' && call[2] !== '3.0',
+    );
+    expect(touchedCreativeOtherVersion).toBe(false);
   });
 });

--- a/server/tests/unit/badge-issuance.test.ts
+++ b/server/tests/unit/badge-issuance.test.ts
@@ -12,10 +12,12 @@ function makeBadge(
   status: AgentVerificationBadge['status'] = 'active',
   updatedAgo = 0,
   modes: string[] = ['spec'],
+  majorVersion = '3.0',
 ): AgentVerificationBadge {
   return {
     agent_url: 'https://example.com/mcp',
     role,
+    major_version: majorVersion,
     verified_at: new Date(Date.now() - 86_400_000),
     verified_protocol_version: null,
     verified_specialisms: ['sales-broadcast-tv'],
@@ -176,5 +178,95 @@ describe('processAgentBadges — membership gating', () => {
 
     expect(result.unchanged).toHaveLength(1);
     expect(result.revoked).toHaveLength(0);
+  });
+});
+
+describe('processAgentBadges — per-major-version isolation (#3524 stage 1)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('only touches badges at the major version under test', async () => {
+    // Agent holds badges at both 3.0 and 3.1. A 3.0 run with a failing
+    // specialism must NOT touch the 3.1 badge.
+    const existing = [
+      makeBadge('media-buy', 'active', 0, ['spec'], '3.0'),
+      makeBadge('media-buy', 'active', 0, ['spec'], '3.1'),
+    ];
+    const db = makeMockDb(existing);
+
+    await processAgentBadges(
+      db,
+      'https://example.com/mcp',
+      ['sales-broadcast-tv'],
+      [makeStatus('sales_broadcast_tv', 'failing')],
+      false,
+      'org_test',
+      '3.0',
+    );
+
+    // Only the 3.0 badge should be touched. Confirm by checking that
+    // every degradeBadge call was scoped to '3.0' and 3.1 was never
+    // a target.
+    const degradeCalls = (db.degradeBadge as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    expect(degradeCalls).toHaveLength(1);
+    expect(degradeCalls[0][2]).toBe('3.0');
+  });
+
+  it('passes the major version to upsertBadge on issuance', async () => {
+    const db = makeMockDb([]);
+
+    await processAgentBadges(
+      db,
+      'https://example.com/mcp',
+      ['sales-broadcast-tv'],
+      [makeStatus('sales_broadcast_tv', 'passing')],
+      true,
+      'org_test',
+      '3.1',
+    );
+
+    const upsertCalls = (db.upsertBadge as unknown as { mock: { calls: Array<[Record<string, unknown>]> } }).mock.calls;
+    expect(upsertCalls).toHaveLength(1);
+    expect(upsertCalls[0][0]).toMatchObject({ major_version: '3.1' });
+  });
+
+  it('defaults to DEFAULT_BADGE_MAJOR_VERSION when not passed (Stage 1 backward compat)', async () => {
+    const db = makeMockDb([]);
+
+    await processAgentBadges(
+      db,
+      'https://example.com/mcp',
+      ['sales-broadcast-tv'],
+      [makeStatus('sales_broadcast_tv', 'passing')],
+      true,
+      'org_test',
+      // majorVersion omitted — defaults to '3.0'
+    );
+
+    const upsertCalls = (db.upsertBadge as unknown as { mock: { calls: Array<[Record<string, unknown>]> } }).mock.calls;
+    expect(upsertCalls[0][0]).toMatchObject({ major_version: '3.0' });
+  });
+
+  it('membership lapse only revokes badges at the version under test', async () => {
+    const existing = [
+      makeBadge('media-buy', 'active', 0, ['spec'], '3.0'),
+      makeBadge('media-buy', 'active', 0, ['spec'], '3.1'),
+    ];
+    const db = makeMockDb(existing);
+
+    await processAgentBadges(
+      db,
+      'https://example.com/mcp',
+      ['sales-broadcast-tv'],
+      [makeStatus('sales_broadcast_tv', 'passing')],
+      true,
+      undefined, // membership lapsed
+      '3.0',
+    );
+
+    // Only 3.0 should be revoked under this run; 3.1 stays untouched.
+    // Stage 2 will issue a separate per-version run for 3.1.
+    const revokeCalls = (db.revokeBadge as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    expect(revokeCalls).toHaveLength(1);
+    expect(revokeCalls[0][2]).toBe('3.0');
   });
 });

--- a/server/tests/unit/badge-issuance.test.ts
+++ b/server/tests/unit/badge-issuance.test.ts
@@ -12,12 +12,12 @@ function makeBadge(
   status: AgentVerificationBadge['status'] = 'active',
   updatedAgo = 0,
   modes: string[] = ['spec'],
-  majorVersion = '3.0',
+  adcpVersion = '3.0',
 ): AgentVerificationBadge {
   return {
     agent_url: 'https://example.com/mcp',
     role,
-    major_version: majorVersion,
+    adcp_version: adcpVersion,
     verified_at: new Date(Date.now() - 86_400_000),
     verified_protocol_version: null,
     verified_specialisms: ['sales-broadcast-tv'],
@@ -181,10 +181,10 @@ describe('processAgentBadges — membership gating', () => {
   });
 });
 
-describe('processAgentBadges — per-major-version isolation (#3524 stage 1)', () => {
+describe('processAgentBadges — per-AdCP-version isolation (#3524 stage 1)', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('only touches badges at the major version under test', async () => {
+  it('only touches badges at the AdCP version under test', async () => {
     // Agent holds badges at both 3.0 and 3.1. A 3.0 run with a failing
     // specialism must NOT touch the 3.1 badge.
     const existing = [
@@ -211,7 +211,7 @@ describe('processAgentBadges — per-major-version isolation (#3524 stage 1)', (
     expect(degradeCalls[0][2]).toBe('3.0');
   });
 
-  it('passes the major version to upsertBadge on issuance', async () => {
+  it('passes the AdCP version to upsertBadge on issuance', async () => {
     const db = makeMockDb([]);
 
     await processAgentBadges(
@@ -226,10 +226,10 @@ describe('processAgentBadges — per-major-version isolation (#3524 stage 1)', (
 
     const upsertCalls = (db.upsertBadge as unknown as { mock: { calls: Array<[Record<string, unknown>]> } }).mock.calls;
     expect(upsertCalls).toHaveLength(1);
-    expect(upsertCalls[0][0]).toMatchObject({ major_version: '3.1' });
+    expect(upsertCalls[0][0]).toMatchObject({ adcp_version: '3.1' });
   });
 
-  it('defaults to DEFAULT_BADGE_MAJOR_VERSION when not passed (Stage 1 backward compat)', async () => {
+  it('defaults to DEFAULT_BADGE_ADCP_VERSION when not passed (Stage 1 backward compat)', async () => {
     const db = makeMockDb([]);
 
     await processAgentBadges(
@@ -239,11 +239,11 @@ describe('processAgentBadges — per-major-version isolation (#3524 stage 1)', (
       [makeStatus('sales_broadcast_tv', 'passing')],
       true,
       'org_test',
-      // majorVersion omitted — defaults to '3.0'
+      // adcpVersion omitted — defaults to '3.0'
     );
 
     const upsertCalls = (db.upsertBadge as unknown as { mock: { calls: Array<[Record<string, unknown>]> } }).mock.calls;
-    expect(upsertCalls[0][0]).toMatchObject({ major_version: '3.0' });
+    expect(upsertCalls[0][0]).toMatchObject({ adcp_version: '3.0' });
   });
 
   it('membership lapse only revokes badges at the version under test', async () => {


### PR DESCRIPTION
## Summary

Stage 1 of [#3524](https://github.com/adcontextprotocol/adcp/issues/3524) — extends \`agent_verification_badges\` so an agent can hold parallel \`(Spec)\` / \`(Live)\` badges across AdCP minor versions (3.0, 3.1, 4.0…). The previous PK \`(agent_url, role)\` becomes \`(agent_url, role, major_version)\`.

**No behavior change yet** — the heartbeat still passes the default \`'3.0'\` to \`processAgentBadges\`. Stage 2 wires per-version fan-out, Stage 3 adds \`/badge/{role}/{version}.svg\`, Stage 4 splits panel rows by version, Stage 5 reshapes brand.json. This PR is purely the data-model groundwork.

The six WG-decision questions on #3524 were resolved in [this comment](https://github.com/adcontextprotocol/adcp/issues/3524#issuecomment-4348265184) before any code landed.

## What this PR ships

- **Migration 457** — adds \`major_version TEXT NOT NULL\` to \`agent_verification_badges\` with a temporary default of \`'3.0'\` so the backfill is safe, parses existing \`verified_protocol_version\` (\`X.Y.Z\` → \`X.Y\`), rebuilds the PK, drops the default so future writes must specify the version, and adds an index on \`(role, major_version, status)\`.
- **DB layer** — \`AgentVerificationBadge\` gains \`major_version\`. \`upsertBadge\` / \`getActiveBadge\` / \`revokeBadge\` / \`degradeBadge\` all take a \`majorVersion\` parameter. List queries order by \`major_version DESC\`.
- **\`getHighestVersionActiveBadge()\`** — new helper that powers the legacy \`/badge/{role}.svg\` URL. Embedded badges in the wild auto-upgrade to the most recent version the agent has earned without changing the URL (Q3 of the resolved-decisions thread).
- **\`processAgentBadges()\`** — accepts an optional \`majorVersion\` parameter (defaults to \`DEFAULT_BADGE_MAJOR_VERSION = '3.0'\`). Existing-badge lookups and writes are now scoped to that single version — a failing 3.1 run never touches a 3.0 badge and vice versa. **This is the load-bearing isolation property.**
- **4 new tests** covering version-isolation: only-touch-version-under-test, upsertBadge receives the version, default fallback when callers don't specify, and membership-lapse only affects the version under test.

## What this PR does NOT change

- The heartbeat job still calls \`processAgentBadges()\` without a \`majorVersion\` — defaults to \`'3.0'\`. **Stage 2** wires per-version fan-out.
- Storyboards have no \`since:\` field yet. Added in **Stage 2**.
- Badge SVG labels still read "Media Buy Agent (Spec)" — version segment lands in **Stage 3**.
- Verification panel still renders one row per role. **Stage 4** splits into one row per (role, version).
- brand.json enrichment shape unchanged. **Stage 5** adds the \`badges[]\` array.

## Test plan

- [x] 4 new unit tests for version-isolation
- [x] 89/89 existing verification + badge tests pass
- [x] Migration applies cleanly against Postgres (CI runs \`Built migrations against Postgres\`)
- [x] TypeScript typecheck clean
- [x] No behavior change — old callers of \`processAgentBadges()\` still hit the default version, and \`/badge/{role}.svg\` still serves what it did before (now via \`getHighestVersionActiveBadge\`)

## Review focus

- The migration's PK rebuild — pg holds the table-level write lock for the duration. \`agent_verification_badges\` is small (one row per badged agent, not one per request), so the lock window is brief, but worth a sanity check.
- The \`majorVersion\` default in \`processAgentBadges()\` — confirming this preserves Stage 1's "no behavior change" promise.
- Tests for the per-version filtering invariant — does the test surface miss any case where 3.0 and 3.1 should genuinely be touched together?

🤖 Generated with [Claude Code](https://claude.com/claude-code)