### PR TITLE
docs(registry): /publisher unauthenticated note — parity with /operator (closes #3546)

### DIFF
--- a/.changeset/registry-publisher-public-note.md
+++ b/.changeset/registry-publisher-public-note.md
@@ -1,0 +1,4 @@
+---
+---
+
+Document `/api/registry/publisher` as unauthenticated with a fixed response shape. Contrasts with `/operator` (#3542), where AAO membership tier and profile ownership unlock `members_only` and `private` visibility — making it explicit that membership does not change the `/publisher` response today. Closes #3546.

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -707,7 +707,12 @@ registry.registerPath({
   path: "/api/registry/publisher",
   operationId: "lookupPublisher",
   summary: "Publisher lookup",
-  description: "Given a domain, returns the inventory this entity publishes and which agents it authorizes.",
+  description:
+    "Given a domain, returns the inventory this entity publishes and which agents it authorizes.\n\n" +
+    "**This endpoint is unauthenticated and returns the same response shape for every caller.** " +
+    "Compare to `/api/registry/operator`, where AAO membership tier and profile ownership unlock " +
+    "additional agent visibility (`members_only`, `private`). AAO membership does not change the " +
+    "`/publisher` response today.",
   tags: ["Authorization Lookups"],
   request: {
     query: z.object({

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -2909,7 +2909,10 @@ paths:
     get:
       operationId: lookupPublisher
       summary: Publisher lookup
-      description: Given a domain, returns the inventory this entity publishes and which agents it authorizes.
+      description: |-
+        Given a domain, returns the inventory this entity publishes and which agents it authorizes.
+
+        **This endpoint is unauthenticated and returns the same response shape for every caller.** Compare to `/api/registry/operator`, where AAO membership tier and profile ownership unlock additional agent visibility (`members_only`, `private`). AAO membership does not change the `/publisher` response today.
       tags:
         - Authorization Lookups
       parameters:


### PR DESCRIPTION
Closes #3546. Refs #3538 / #3542.

#3542 documented `/api/registry/operator`'s caller-tier response-shape rules (anonymous → public; AAO API → +members_only; profile owner → +private). Asymmetry surfaced during #3559 investigation: `/api/registry/publisher` (`server/src/routes/registry-api.ts:5229`) has no auth middleware and returns identical shape for every caller.

Documenting the asymmetry rather than introducing one. AAO membership does NOT unlock more on `/publisher` today — telling the caller explicitly so the docs don't oversell membership value.

## What changed

- `server/src/routes/registry-api.ts:669` — `/publisher` endpoint registration gains a `description` block noting "unauthenticated, identical shape for every caller. Compare to `/operator` for the auth-aware contrast."
- `static/openapi/registry.yaml` — mechanical regen via `npm run build:openapi` (separate commit).

## Test plan

- [x] `npx vitest run server/tests/unit/openapi-coverage.test.ts` — 3/3 pass.
- [x] `npx tsc --noEmit -p server/tsconfig.json` — clean.

## Out of scope

- Whether `/publisher` SHOULD become auth-aware (open product question — #3546 explicitly defers).
- Any consumer-side change.