### PR TITLE
fix(addie): route GitHub Connect through session-aware bouncer + add disconnect

### DIFF
--- a/.changeset/addie-github-connect-bouncer-and-disconnect.md
+++ b/.changeset/addie-github-connect-bouncer-and-disconnect.md
@@ -1,0 +1,6 @@
+---
+---
+
+Addie's GitHub Connect link now goes through a session-aware bouncer (`/connect/github`) instead of handing the user a raw WorkOS Pipes URL. Slack-clicked Connect links land in browsers without an active AuthKit session and previously hit WorkOS' generic "Something went wrong" page; the bouncer requires auth (bouncing to `/auth/login` first if needed) and mints a fresh Pipes URL on the click so the token can't go stale between message and click.
+
+Member Hub Connections card gains a Disconnect button backed by a new `DELETE /api/me/connected-accounts/github` route, useful for re-testing the connect flow.

--- a/server/public/membership/hub.html
+++ b/server/public/membership/hub.html
@@ -2091,7 +2091,10 @@
               <strong>GitHub</strong>
               <div style="${copyStyle}">Connected${github.login ? ` as <code>@${escapeHtml(github.login)}</code>` : ''}. Addie can file issues as you on <code>adcontextprotocol/adcp</code>.</div>
             </div>
-            <span style="${statusStyle}">✓ Connected</span>
+            <div style="display:flex; align-items:center; gap:var(--space-3);">
+              <span style="${statusStyle}">✓ Connected</span>
+              <button type="button" class="btn btn-secondary" onclick="disconnectGitHub(this)">Disconnect</button>
+            </div>
           </div>`;
       } else if (github.unavailable) {
         githubRow = `
@@ -2133,6 +2136,26 @@
         btn.disabled = false;
         btn.textContent = original;
         alert('Could not start GitHub connection. Please try again in a moment.');
+      }
+    }
+
+    async function disconnectGitHub(btn) {
+      if (!confirm('Disconnect GitHub? Addie will no longer be able to file issues on your behalf until you reconnect.')) return;
+      const original = btn.textContent;
+      btn.disabled = true;
+      btn.textContent = 'Disconnecting...';
+      try {
+        const res = await fetch('/api/me/connected-accounts/github', {
+          method: 'DELETE',
+          credentials: 'include',
+        });
+        if (!res.ok) throw new Error('Failed to disconnect GitHub');
+        window.location.href = '/member-hub';
+      } catch (err) {
+        console.error(err);
+        btn.disabled = false;
+        btn.textContent = original;
+        alert('Could not disconnect GitHub. Please try again in a moment.');
       }
     }
 

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -71,7 +71,7 @@ import { sendIntroductionEmail } from '../../notifications/email.js';
 import { v4 as uuidv4 } from 'uuid';
 import * as relationshipDb from '../../db/relationship-db.js';
 import * as personEvents from '../../db/person-events-db.js';
-import { getGitHubAccessToken, getGitHubAuthorizeUrl } from '../../services/pipes.js';
+import { getGitHubAccessToken } from '../../services/pipes.js';
 import { BrandDatabase } from '../../db/brand-db.js';
 import { issueDomainChallenge, verifyDomainChallenge } from '../../services/brand-claim.js';
 import { getWorkos } from '../../auth/workos-client.js';
@@ -5074,26 +5074,19 @@ export function createMemberToolHandlers(
     }
 
     if (tokenResult.status !== 'ok') {
-      const returnTo = `${baseUrl}/member-hub?connected=github`;
-      let authorizeUrl: string;
-      try {
-        authorizeUrl = await getGitHubAuthorizeUrl(workosUserId, returnTo);
-      } catch (error) {
-        logger.error({ err: error }, 'create_github_issue: Failed to build Pipes authorize URL');
-        return `GitHub connection is unavailable right now. Use \`draft_github_issue\` to generate a pre-filled link you can submit yourself. (Manage connections at ${manageConnectionsUrl}.)`;
-      }
+      const connectUrl = `${baseUrl}/connect/github?return_to=${encodeURIComponent('/member-hub?connected=github')}`;
 
       if (tokenResult.status === 'needs_reauthorization') {
         return [
           `Your GitHub connection needs a quick re-authorization (the scopes we need changed).`,
           '',
-          `**[Reconnect GitHub](${authorizeUrl})** — takes under a minute. Or ask me to use \`draft_github_issue\` and I'll give you a pre-filled link to submit yourself.`,
+          `**[Reconnect GitHub](${connectUrl})** — takes under a minute. Or ask me to use \`draft_github_issue\` and I'll give you a pre-filled link to submit yourself.`,
           '',
           `Manage connections any time at ${manageConnectionsUrl}.`,
         ].join('\n');
       }
       return [
-        `**[Connect GitHub](${authorizeUrl})** — one click and I'll file this under your GitHub account.`,
+        `**[Connect GitHub](${connectUrl})** — one click and I'll file this under your GitHub account.`,
         '',
         `Or ask me to use \`draft_github_issue\` and I'll give you a pre-filled link instead.`,
       ].join('\n');

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -34,7 +34,7 @@ import Stripe from "stripe";
 import { OrganizationDatabase, getUserSeatType, buildSubscriptionUpdate, TIER_PRESERVING_STATUSES, type SeatType, type MembershipTier } from "./db/organization-db.js";
 import { MemberDatabase } from "./db/member-db.js";
 import { ensureMemberProfilePublished } from "./services/member-profile-autopublish.js";
-import { getGitHubConnectedAccount, getGitHubAuthorizeUrl } from "./services/pipes.js";
+import { getGitHubConnectedAccount, getGitHubAuthorizeUrl, disconnectGitHub, buildPipesReturnTo } from "./services/pipes.js";
 import { BrandDatabase, resolveBrandFromJson } from "./db/brand-db.js";
 import { CatalogEventsDatabase } from "./db/catalog-events-db.js";
 import { AgentInventoryProfilesDatabase } from "./db/agent-inventory-profiles-db.js";
@@ -7107,21 +7107,40 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
     // POST /api/me/connected-accounts/github/authorize - Mint a WorkOS Pipes authorize URL for GitHub
     this.app.post('/api/me/connected-accounts/github/authorize', requireAuth, async (req, res) => {
       try {
-        const host = req.get('host') || '';
-        const protocol = req.protocol === 'http' && !host.startsWith('localhost') ? 'https' : req.protocol;
-        const DEFAULT_RETURN = '/member-hub?connected=github';
-        const requested = typeof req.body?.return_to === 'string' ? req.body.return_to : DEFAULT_RETURN;
-        const isSafeReturn = requested.startsWith('/')
-          && !requested.startsWith('//')
-          && !requested.includes('\\')
-          && !/[\r\n\t]/.test(requested);
-        const safeReturn = isSafeReturn ? requested : DEFAULT_RETURN;
-        const returnTo = `${protocol}://${host}${safeReturn}`;
+        const returnTo = buildPipesReturnTo(req.get('host') || '', req.protocol, req.body?.return_to);
         const url = await getGitHubAuthorizeUrl(req.user!.id, returnTo);
         res.json({ url });
       } catch (error) {
         logger.error({ err: error }, 'Failed to mint GitHub authorize URL');
         res.status(502).json({ error: 'Failed to start GitHub connection' });
+      }
+    });
+
+    // DELETE /api/me/connected-accounts/github - Disconnect the user's GitHub account from WorkOS Pipes
+    this.app.delete('/api/me/connected-accounts/github', requireAuth, async (req, res) => {
+      try {
+        const result = await disconnectGitHub(req.user!.id);
+        if (result.status === 'unavailable') {
+          return res.status(503).json({ error: 'Disconnect unavailable', reason: result.reason });
+        }
+        return res.json({ disconnected: true, was_connected: result.status === 'disconnected' });
+      } catch (error) {
+        logger.error({ err: error }, 'Failed to disconnect GitHub');
+        res.status(500).json({ error: 'Failed to disconnect GitHub' });
+      }
+    });
+
+    // GET /connect/github - Session-aware redirect that mints a fresh Pipes URL on click.
+    // Used by Addie/Slack messages so a stale or session-less click can't land on
+    // WorkOS' generic "couldn't complete the connection" error page.
+    this.app.get('/connect/github', requireAuth, async (req, res) => {
+      try {
+        const returnTo = buildPipesReturnTo(req.get('host') || '', req.protocol, req.query.return_to);
+        const url = await getGitHubAuthorizeUrl(req.user!.id, returnTo);
+        return res.redirect(302, url);
+      } catch (error) {
+        logger.error({ err: error }, 'Failed to start GitHub connect via /connect/github');
+        return res.status(502).send('Could not start GitHub connection. Please try again in a moment, or visit /member-hub to connect from there.');
       }
     });
 

--- a/server/src/services/pipes.ts
+++ b/server/src/services/pipes.ts
@@ -33,6 +33,29 @@ export async function getGitHubAccessToken(workosUserId: string): Promise<PipesT
   return { status: 'needs_reauthorization', missingScopes: [] };
 }
 
+/**
+ * Builds the absolute return URL we hand to WorkOS Pipes when the user finishes
+ * the OAuth dance. Validates the caller-supplied path so a Slack-clicked link
+ * (or any user-controlled `return_to`) cannot be rewritten into an open
+ * redirect to another origin. Shared by both the Member Hub `POST authorize`
+ * route and the `GET /connect/github` bouncer that Addie hands out.
+ */
+export function buildPipesReturnTo(
+  host: string,
+  protocol: string,
+  requested: unknown,
+  defaultPath = '/member-hub?connected=github',
+): string {
+  const candidate = typeof requested === 'string' ? requested : defaultPath;
+  const isSafe = candidate.startsWith('/')
+    && !candidate.startsWith('//')
+    && !candidate.includes('\\')
+    && !/[\r\n\t]/.test(candidate);
+  const safe = isSafe ? candidate : defaultPath;
+  const safeProtocol = protocol === 'http' && !host.startsWith('localhost') ? 'https' : protocol;
+  return `${safeProtocol}://${host}${safe}`;
+}
+
 export async function getGitHubAuthorizeUrl(workosUserId: string, returnTo: string): Promise<string> {
   const workos = getWorkos();
   const response = await workos.post<{ user_id: string; return_to: string }>(
@@ -72,6 +95,27 @@ export async function getGitHubConnectedAccount(workosUserId: string): Promise<C
     if (status === 404) return { status: 'not_connected' };
     const message = error instanceof Error ? error.message : String(error);
     logger.warn({ err: error, workosUserId }, 'Failed to look up Pipes connected account');
+    return { status: 'unavailable', reason: message };
+  }
+}
+
+export type DisconnectResult =
+  | { status: 'disconnected' }
+  | { status: 'not_connected' }
+  | { status: 'unavailable'; reason: string };
+
+export async function disconnectGitHub(workosUserId: string): Promise<DisconnectResult> {
+  const workos = getWorkos();
+  try {
+    await workos.delete(
+      `/user_management/users/${encodeURIComponent(workosUserId)}/connected_accounts/${GITHUB_PROVIDER}`,
+    );
+    return { status: 'disconnected' };
+  } catch (error) {
+    const status = (error as { status?: number; code?: number })?.status ?? (error as { code?: number })?.code;
+    if (status === 404) return { status: 'not_connected' };
+    const message = error instanceof Error ? error.message : String(error);
+    logger.warn({ err: error, workosUserId }, 'Failed to disconnect Pipes GitHub account');
     return { status: 'unavailable', reason: message };
   }
 }

--- a/server/tests/unit/connect-github-bouncer.test.ts
+++ b/server/tests/unit/connect-github-bouncer.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+const { mockGetAuthorizeUrl } = vi.hoisted(() => ({ mockGetAuthorizeUrl: vi.fn() }));
+
+vi.mock('../../src/services/pipes.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/services/pipes.js')>(
+    '../../src/services/pipes.js',
+  );
+  return {
+    ...actual,
+    getGitHubAuthorizeUrl: mockGetAuthorizeUrl,
+  };
+});
+
+const { getGitHubAuthorizeUrl, buildPipesReturnTo } = await import('../../src/services/pipes.js');
+
+/**
+ * Mounts the same bouncer logic that lives in http.ts on a tiny app so we can
+ * exercise the redirect/502 wiring without booting the full server. The
+ * production route uses the same `buildPipesReturnTo` + `getGitHubAuthorizeUrl`
+ * pair, so this stays in lock-step as long as those two stay the integration
+ * surface for the bouncer.
+ */
+function buildBouncerApp() {
+  const app = express();
+  // Stub requireAuth so we don't drag in the WorkOS session machinery.
+  app.use((req, _res, next) => {
+    (req as unknown as { user: { id: string } }).user = { id: 'user_test' };
+    next();
+  });
+  app.get('/connect/github', async (req, res) => {
+    try {
+      const returnTo = buildPipesReturnTo(req.get('host') || '', req.protocol, req.query.return_to);
+      const url = await getGitHubAuthorizeUrl(
+        (req as unknown as { user: { id: string } }).user.id,
+        returnTo,
+      );
+      return res.redirect(302, url);
+    } catch {
+      return res
+        .status(502)
+        .send('Could not start GitHub connection. Please try again in a moment, or visit /member-hub to connect from there.');
+    }
+  });
+  return app;
+}
+
+describe('GET /connect/github bouncer', () => {
+  beforeEach(() => {
+    mockGetAuthorizeUrl.mockReset();
+  });
+
+  it('302-redirects to a freshly minted Pipes URL on the click', async () => {
+    mockGetAuthorizeUrl.mockResolvedValueOnce('https://auth.example/data-integrations/abc/authorize-redirect');
+
+    const res = await request(buildBouncerApp())
+      .get('/connect/github')
+      .query({ return_to: '/member-hub?connected=github' });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('https://auth.example/data-integrations/abc/authorize-redirect');
+    // Pipes URL is minted on click using the verified session user, not at message-write time.
+    expect(mockGetAuthorizeUrl).toHaveBeenCalledWith('user_test', expect.stringContaining('/member-hub?connected=github'));
+  });
+
+  it('returns 502 with a user-friendly body when WorkOS Pipes is unavailable', async () => {
+    mockGetAuthorizeUrl.mockRejectedValueOnce(new Error('workos pipes 503'));
+
+    const res = await request(buildBouncerApp()).get('/connect/github');
+
+    expect(res.status).toBe(502);
+    expect(res.text).toContain('Could not start GitHub connection');
+    // The fallback should still point users at the Hub so they aren't dead-ended.
+    expect(res.text).toContain('/member-hub');
+  });
+
+  it('falls back to the default return_to path when the caller supplies an unsafe one', async () => {
+    mockGetAuthorizeUrl.mockResolvedValueOnce('https://auth.example/x');
+
+    await request(buildBouncerApp())
+      .get('/connect/github')
+      .query({ return_to: '//evil.example/owned' });
+
+    const [, returnTo] = mockGetAuthorizeUrl.mock.calls[0];
+    expect(returnTo).toContain('/member-hub?connected=github');
+    expect(returnTo).not.toContain('evil.example');
+  });
+});

--- a/server/tests/unit/pipes-connected-account.test.ts
+++ b/server/tests/unit/pipes-connected-account.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockGet } = vi.hoisted(() => ({ mockGet: vi.fn() }));
+const { mockGet, mockDelete } = vi.hoisted(() => ({ mockGet: vi.fn(), mockDelete: vi.fn() }));
 
 vi.mock('../../src/auth/workos-client.js', () => ({
-  getWorkos: () => ({ get: mockGet }),
+  getWorkos: () => ({ get: mockGet, delete: mockDelete }),
 }));
 
-const { getGitHubConnectedAccount } = await import('../../src/services/pipes.js');
+const { getGitHubConnectedAccount, disconnectGitHub, buildPipesReturnTo } = await import('../../src/services/pipes.js');
 
 describe('getGitHubConnectedAccount', () => {
   beforeEach(() => {
@@ -52,6 +52,88 @@ describe('getGitHubConnectedAccount', () => {
     mockGet.mockRejectedValueOnce(new Error('ECONNREFUSED'));
 
     const result = await getGitHubConnectedAccount('user_123');
+
+    expect(result.status).toBe('unavailable');
+    expect((result as { status: 'unavailable'; reason: string }).reason).toBeTruthy();
+  });
+});
+
+describe('buildPipesReturnTo', () => {
+  it('builds an absolute URL on top of host + protocol when the path is safe', () => {
+    expect(
+      buildPipesReturnTo('agenticadvertising.org', 'https', '/member-hub?connected=github'),
+    ).toBe('https://agenticadvertising.org/member-hub?connected=github');
+  });
+
+  it('falls back to the default path when the requested value is not a string', () => {
+    expect(
+      buildPipesReturnTo('agenticadvertising.org', 'https', undefined),
+    ).toBe('https://agenticadvertising.org/member-hub?connected=github');
+    expect(
+      buildPipesReturnTo('agenticadvertising.org', 'https', 42 as unknown),
+    ).toBe('https://agenticadvertising.org/member-hub?connected=github');
+  });
+
+  it.each([
+    ['protocol-relative', '//evil.example/owned'],
+    ['absolute http', 'http://evil.example/owned'],
+    ['backslash-escaped', '/foo\\..\\bar'],
+    ['CRLF injection', '/foo\r\nLocation: https://evil.example'],
+    ['tab', '/foo\tbar'],
+    ['relative path (no leading slash)', 'evil'],
+  ])('rejects unsafe return_to (%s) and falls back to default', (_label, payload) => {
+    expect(
+      buildPipesReturnTo('agenticadvertising.org', 'https', payload),
+    ).toBe('https://agenticadvertising.org/member-hub?connected=github');
+  });
+
+  it('upgrades plain http to https for non-localhost hosts', () => {
+    expect(
+      buildPipesReturnTo('agenticadvertising.org', 'http', '/foo'),
+    ).toBe('https://agenticadvertising.org/foo');
+  });
+
+  it('keeps http for localhost so dev still works', () => {
+    expect(
+      buildPipesReturnTo('localhost:3000', 'http', '/foo'),
+    ).toBe('http://localhost:3000/foo');
+  });
+
+  it('honors a caller-supplied default path', () => {
+    expect(
+      buildPipesReturnTo('agenticadvertising.org', 'https', undefined, '/somewhere-else'),
+    ).toBe('https://agenticadvertising.org/somewhere-else');
+  });
+});
+
+describe('disconnectGitHub', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns disconnected when WorkOS deletes the connected account', async () => {
+    mockDelete.mockResolvedValueOnce(undefined);
+
+    const result = await disconnectGitHub('user_123');
+
+    expect(mockDelete).toHaveBeenCalledWith('/user_management/users/user_123/connected_accounts/github');
+    expect(result).toEqual({ status: 'disconnected' });
+  });
+
+  it('returns not_connected when WorkOS returns 404', async () => {
+    const err = Object.assign(new Error('Not Found'), { status: 404 });
+    mockDelete.mockRejectedValueOnce(err);
+
+    const result = await disconnectGitHub('user_123');
+
+    expect(result).toEqual({ status: 'not_connected' });
+  });
+
+  it('returns unavailable when WorkOS returns a 5xx error', async () => {
+    const err = Object.assign(new Error('Service Unavailable'), { status: 503 });
+    mockDelete.mockRejectedValueOnce(err);
+
+    const result = await disconnectGitHub('user_123');
 
     expect(result.status).toBe('unavailable');
     expect((result as { status: 'unavailable'; reason: string }).reason).toBeTruthy();

--- a/tests/addie/member-tools.test.ts
+++ b/tests/addie/member-tools.test.ts
@@ -10,12 +10,11 @@ import type { MemberContext } from '../../server/src/addie/member-context.js';
 
 vi.mock('../../server/src/services/pipes.js', () => ({
   getGitHubAccessToken: vi.fn(),
-  getGitHubAuthorizeUrl: vi.fn(),
 }));
 
 // Import the tool definitions directly (no side effects)
 import { MEMBER_TOOLS, createMemberToolHandlers, extractAdcpVersion } from '../../server/src/addie/mcp/member-tools.js';
-import { getGitHubAccessToken, getGitHubAuthorizeUrl } from '../../server/src/services/pipes.js';
+import { getGitHubAccessToken } from '../../server/src/services/pipes.js';
 
 describe('MEMBER_TOOLS definitions', () => {
   it('exports an array of tools', () => {
@@ -329,13 +328,11 @@ describe('createMemberToolHandlers', () => {
 
     let fetchMock: ReturnType<typeof vi.fn>;
     const getTokenMock = vi.mocked(getGitHubAccessToken);
-    const getAuthorizeUrlMock = vi.mocked(getGitHubAuthorizeUrl);
 
     beforeEach(() => {
       fetchMock = vi.fn();
       vi.stubGlobal('fetch', fetchMock);
       getTokenMock.mockReset();
-      getAuthorizeUrlMock.mockReset();
     });
 
     afterEach(() => {
@@ -355,7 +352,6 @@ describe('createMemberToolHandlers', () => {
 
     it("leads with the Connect offer when user hasn't connected GitHub", async () => {
       getTokenMock.mockResolvedValue({ status: 'not_connected' });
-      getAuthorizeUrlMock.mockResolvedValue('https://workos.example/pipes/authorize/abc');
 
       const handlers = createMemberToolHandlers(loggedInContext);
       const handler = handlers.get('create_github_issue')!;
@@ -363,8 +359,10 @@ describe('createMemberToolHandlers', () => {
       const result = await handler({ title: 'T', body: 'B' });
 
       expect(getTokenMock).toHaveBeenCalledWith('user_abc');
-      expect(getAuthorizeUrlMock).toHaveBeenCalledWith('user_abc', expect.stringContaining('/member-hub'));
-      expect(result).toContain('[Connect GitHub](https://workos.example/pipes/authorize/abc)');
+      // Should surface our session-aware bouncer URL, not a raw WorkOS Pipes URL,
+      // so a Slack click that arrives without an active AuthKit session bounces
+      // through login first and mints a fresh Pipes URL on the click.
+      expect(result).toMatch(/\[Connect GitHub\]\([^)]*\/connect\/github\?return_to=/);
       expect(result).toContain('draft_github_issue');
       // Lead line should be the offer, not the failure reason.
       const firstLine = result.split('\n')[0];
@@ -374,7 +372,6 @@ describe('createMemberToolHandlers', () => {
 
     it('returns Reconnect URL when connection needs reauthorization', async () => {
       getTokenMock.mockResolvedValue({ status: 'needs_reauthorization', missingScopes: ['public_repo'] });
-      getAuthorizeUrlMock.mockResolvedValue('https://workos.example/pipes/authorize/xyz');
 
       const handlers = createMemberToolHandlers(loggedInContext);
       const handler = handlers.get('create_github_issue')!;
@@ -382,26 +379,12 @@ describe('createMemberToolHandlers', () => {
       const result = await handler({ title: 'T', body: 'B' });
 
       expect(result).toContain('re-authorization');
-      expect(result).toContain('[Reconnect GitHub](https://workos.example/pipes/authorize/xyz)');
+      expect(result).toMatch(/\[Reconnect GitHub\]\([^)]*\/connect\/github\?return_to=/);
       expect(fetchMock).not.toHaveBeenCalled();
     });
 
     it('gracefully degrades when Pipes getAccessToken throws', async () => {
       getTokenMock.mockRejectedValue(new Error('workos api down'));
-
-      const handlers = createMemberToolHandlers(loggedInContext);
-      const handler = handlers.get('create_github_issue')!;
-
-      const result = await handler({ title: 'T', body: 'B' });
-
-      expect(result).toContain('unavailable');
-      expect(result).toContain('draft_github_issue');
-      expect(fetchMock).not.toHaveBeenCalled();
-    });
-
-    it('gracefully degrades when Pipes authorize URL lookup fails', async () => {
-      getTokenMock.mockResolvedValue({ status: 'not_connected' });
-      getAuthorizeUrlMock.mockRejectedValue(new Error('workos unavailable'));
 
       const handlers = createMemberToolHandlers(loggedInContext);
       const handler = handlers.get('create_github_issue')!;


### PR DESCRIPTION
## Summary

Fixes Addie's "Connect GitHub" link failing with WorkOS' generic *"Something went wrong / We couldn't complete the connection"* error when clicked from Slack DMs.

**Root cause:** Addie was handing users a raw WorkOS Pipes authorize URL. Two latent issues bit the Slack-click path:

1. **Stale URL** — the `pending_auth` token has a TTL on WorkOS' side, so a click minutes after Addie wrote the message can already be expired.
2. **No session bounce** — Slack-clicked links open in browsers without an active AuthKit session, and WorkOS' hosted page can't proceed.

The Member Hub flow already worked because the user was authenticated when they clicked.

**Fix:** introduce a session-aware bouncer endpoint Addie hands out instead of the raw Pipes URL.

- `GET /connect/github` — `requireAuth` (bounces to `/auth/login?return_to=…` if no session), mints a *fresh* Pipes URL on the click, 302-redirects. URL can never go stale because it's minted on click, not at message-write time.
- `DELETE /api/me/connected-accounts/github` + Disconnect button on Member Hub Connections card — useful for re-testing the connect flow.
- `buildPipesReturnTo(host, protocol, requested, defaultPath?)` extracted to `services/pipes.ts` and shared between the existing `POST /api/me/connected-accounts/github/authorize` and the new bouncer, so return_to validation can't drift between the two.

WorkOS endpoint for disconnect verified against the [official Pipes Connected Account reference](https://workos.com/docs/reference/pipes/connected-account): `DELETE /user_management/users/{user_id}/connected_accounts/{provider}`.

## Test plan

- [x] Unit: `buildPipesReturnTo` happy path + 6 unsafe-input fallbacks (CRLF, protocol-relative, backslash, tab, no-leading-slash, http→https upgrade, localhost stays http)
- [x] Unit: `disconnectGitHub` success / 404 / 5xx cases (mocks `workos.delete` at the SDK seam)
- [x] Supertest: `GET /connect/github` 302 with fresh URL, 502 with user-friendly body when WorkOS Pipes is unavailable, unsafe `return_to` falls back to default
- [x] Updated existing `create_github_issue` tests to assert the bouncer URL instead of the raw Pipes URL
- [x] `npx tsc -p server/tsconfig.json --noEmit` clean
- [ ] Manual: connect from Member Hub still works, disconnect button works, Addie's Slack flow now bounces correctly through `/connect/github`

## Reviewers

Internally reviewed by `code-reviewer` and `security-reviewer` agents. Security: ship-as-is; no high or medium findings. Code: no blockers; the test gap and dedupe items raised by the reviewer are both addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)