### PR TITLE
feat(schemas): plays scalar — close forecast↔delivery asymmetry

### DIFF
--- a/.changeset/plays-scalar.md
+++ b/.changeset/plays-scalar.md
@@ -1,0 +1,29 @@
+---
+"adcontextprotocol": minor
+---
+
+Add `plays` scalar to `delivery-metrics.json` and `available-metric.json` —
+closes a forecast↔delivery asymmetry where `plays` was declared as a
+forecastable metric (`forecastable-metric.json:23`, `forecast-point.json:38`)
+but absent from delivery reporting. Closes #3516.
+
+**The shape.** Top-level `type: number, minimum: 0`. Description
+cross-references the forecast-side definition and explicitly distinguishes
+from `dooh_metrics.loop_plays` (per-screen rotation count) and
+`impressions` (multiplied audience figure). Used for DOOH and broadcast
+inventory where buyers reconcile against forecast `plays`.
+
+Why top-level (Option A) over nesting in `dooh_metrics` (Option B):
+
+- Forecast side declares `plays` at the same level as `impressions` /
+  `views` (top-level on `forecast-point`); reconciliation pairs cleanly
+  when the delivery-side field mirrors that placement
+- Used for broadcast inventory too (not DOOH-only), so confining to
+  `dooh_metrics` would force a separate field for non-DOOH plays
+- Matches the type convention of other top-level count scalars
+  (`type: number`, not the `integer` used inside `dooh_metrics`)
+
+**Test plan** — `build:schemas`, `test:schemas`, `test:examples`,
+`typecheck` all green.
+
+Closes #3516.

--- a/docs/media-buy/media-buys/optimization-reporting.mdx
+++ b/docs/media-buy/media-buys/optimization-reporting.mdx
@@ -159,6 +159,7 @@ Buyers receive the intersection of both. `impressions` and `spend` are always re
 - **`downloads`**: Audio/podcast downloads (IAB Podcast Measurement Technical Guidelines methodology); distinct from `views`
 - **`units_sold`**: Items sold attributed to delivery (retail-media commerce scalar; distinct from `conversions` — one transaction may carry multiple units; attribution-window declared via `measurement_terms`)
 - **`new_to_brand_units`**: Unit-volume parallel to `new_to_brand_rate` — count of units sold to first-time brand buyers
+- **`plays`**: Raw play count for DOOH/broadcast inventory (mirrors `forecastable-metric.plays`); distinct from `dooh_metrics.loop_plays` (per-screen rotation) and `impressions` (multiplied audience figure)
 
 Buyers can optionally request a subset via `requested_metrics` to reduce payload size and focus on relevant KPIs.
 

--- a/static/schemas/source/core/delivery-metrics.json
+++ b/static/schemas/source/core/delivery-metrics.json
@@ -73,6 +73,11 @@
       "description": "Leads generated (convenience alias for by_event_type where event_type='lead')",
       "minimum": 0
     },
+    "plays": {
+      "type": "number",
+      "description": "Number of times the ad creative was displayed on a DOOH screen or played in a loop. Raw play count before any impression multiplier is applied. Mirrors `forecastable-metric.json`'s `plays` token for forecast↔delivery reconciliation. Distinct from `dooh_metrics.loop_plays` (per-screen rotation count) and from `impressions` (multiplied audience figure). Used for DOOH and broadcast inventory where buyers reconcile against forecast `plays`.",
+      "minimum": 0
+    },
     "by_event_type": {
       "type": "array",
       "description": "Conversion metrics broken down by event type. Spend-derived metrics (ROAS, CPA) are only available at the package/totals level since spend cannot be attributed to individual event types.",

--- a/static/schemas/source/enums/available-metric.json
+++ b/static/schemas/source/enums/available-metric.json
@@ -34,6 +34,7 @@
     "cpm",
     "downloads",
     "units_sold",
-    "new_to_brand_units"
+    "new_to_brand_units",
+    "plays"
   ]
 }


### PR DESCRIPTION
## Summary

Add `plays` to `delivery-metrics.json` (top-level, `type: number`) and `available-metric.json` enum. Closes the forecast↔delivery asymmetry where `plays` was declared as a forecastable metric (`forecastable-metric.json:23`, `forecast-point.json:38`) but absent from delivery reporting. Closes #3516.

## Why top-level (Option A)

- **Cross-side reconciliation:** forecast side declares `plays` at the same level as `impressions`/`views` on `forecast-point`. Mirroring placement on the delivery side makes forecast↔delivery reconciliation a 1:1 pairing.
- **Broadcast inventory uses this too**, not just DOOH. Confining to `dooh_metrics` would force a separate field for broadcast plays.
- **Type matches other top-level scalars** — `number`, not the `integer` used inside `dooh_metrics`.

## Distinct from neighbors

- `dooh_metrics.loop_plays` — per-screen rotation count (a screen plays the same creative N times in a loop). `plays` is the campaign-level total across all screens.
- `impressions` — multiplied audience figure (one play × screen audience = many impressions). `plays` is the raw play count before any audience multiplier.

Both distinctions are spelled out in the schema description.

## Backwards compatibility

Optional and additive. Existing reports without `plays` stay conformant.

## Test plan

- [x] `npm run build:schemas` — clean
- [x] `npm run test:schemas` — 7/7
- [x] `npm run test:examples` — 34/34
- [x] `npm run typecheck` — clean

Closes #3516.

🤖 Generated with [Claude Code](https://claude.com/claude-code)