### PR TITLE
fix(addie): proper source attribution + downgrade GitHub-API-rejected logs

### DIFF
--- a/.changeset/fix-addie-github-issue-error-attribution.md
+++ b/.changeset/fix-addie-github-issue-error-attribution.md
@@ -1,0 +1,8 @@
+---
+---
+
+Fix Addie GitHub-issue tools error logging:
+
+- `server/src/addie/mcp/member-tools.ts` now uses `createLogger('addie-member-tools')` instead of the root logger, so Slack `#aao-errors` alerts get a proper `source` attribution instead of `unknown`.
+- `create_github_issue` now includes GitHub's truncated response body in the log context so operators can tell *why* GitHub rejected the request without having to reproduce.
+- Downgraded `create_github_issue`, `get_github_issue`, and `list_github_issues` GitHub-API-rejected logs from `error` to `warn`. Each handler already returns a graceful user-facing fallback, so a 4xx from GitHub should not page as a system error. Network/parse failures in those handlers stay at `error`.

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -11,7 +11,9 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import { logger } from '../../logger.js';
+import { createLogger } from '../../logger.js';
+
+const logger = createLogger('addie-member-tools');
 import { classifyProbeError, probeReasonLabel } from '../../utils/probe-error.js';
 import { validateExternalUrl } from '../../utils/url-security.js';
 import { parseOAuthClientCredentialsInput } from '../../routes/helpers/oauth-client-credentials-input.js';
@@ -5119,7 +5121,10 @@ export function createMemberToolHandlers(
 
       if (!response.ok) {
         const errorText = await response.text();
-        logger.error({ status: response.status, repo }, 'create_github_issue: GitHub API error');
+        logger.warn(
+          { status: response.status, repo, errorText: errorText.slice(0, 500) },
+          'create_github_issue: GitHub API error',
+        );
         if (response.status === 422 && errorText.includes('label')) {
           const retryResponse = await fetch(apiUrl, {
             method: 'POST',
@@ -5160,7 +5165,7 @@ export function createMemberToolHandlers(
         if (response.status === 404) {
           return `Issue #${issueNumber} not found in ${org}/${repo}.`;
         }
-        logger.error({ status: response.status, repo, issueNumber }, 'get_github_issue: GitHub API error');
+        logger.warn({ status: response.status, repo, issueNumber }, 'get_github_issue: GitHub API error');
         return githubErrorMessage(response, `read issue #${issueNumber}`);
       }
       const issue = await response.json() as {
@@ -5217,7 +5222,7 @@ export function createMemberToolHandlers(
             : `Comments (${comments.length})`;
           out += `\n---\n\n${wrapUntrusted(`${issue.html_url}#comments`, `### ${shownLabel}\n\n${commentBlock}`)}\n`;
         } else {
-          logger.error({ status: commentsResponse.status, repo, issueNumber }, 'get_github_issue: Failed to fetch comments');
+          logger.warn({ status: commentsResponse.status, repo, issueNumber }, 'get_github_issue: Failed to fetch comments');
         }
       }
       return out;
@@ -5260,7 +5265,7 @@ export function createMemberToolHandlers(
     try {
       const response = await fetch(apiUrl, { headers });
       if (!response.ok) {
-        logger.error({ status: response.status, repo }, 'list_github_issues: GitHub API error');
+        logger.warn({ status: response.status, repo }, 'list_github_issues: GitHub API error');
         return githubErrorMessage(response, 'list issues');
       }
       const data = await response.json() as {


### PR DESCRIPTION
## Summary

Fix Slack `#aao-errors` alerts firing as `:rotating_light: System error: unknown [web]` whenever Addie's GitHub-issue tools hit a 4xx from GitHub.

Three issues, all in `server/src/addie/mcp/member-tools.ts`:

1. **`source: unknown`** — file imported the root pino `logger` instead of `createLogger(...)`, so the pino `errorHook` → `notifyErrorChannel` path (in `server/src/utils/posthog.ts`) saw `module === undefined` and fell through to `module || 'unknown'`. Fixed by using `createLogger('addie-member-tools')`.
2. **Empty `errorText`** — the `create_github_issue` failure log threw away GitHub's response body, so operators couldn't tell *why* GitHub rejected the request. Now logs `errorText.slice(0, 500)`.
3. **Wrong log level** — `create_github_issue`, `get_github_issue`, and `list_github_issues` all logged at `error` for graceful 4xx responses. Each handler already returns a friendly user-facing fallback (`draft_github_issue` link, "issue not found", `githubErrorMessage(...)`), so a 4xx from GitHub should not page as a system error. Downgraded the GitHub-API-rejected logs to `warn` (level 40, below the `errorHook` threshold of 50). Network/parse failures in the catch blocks stay at `error`.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] Pre-commit (`npm run test:unit && test:test-dynamic-imports && typecheck`) — passed
- [ ] Visual confirmation in `#aao-errors` after merge that future GitHub-API-rejected calls no longer trigger system-error alerts (and that any unexpected `error`-level logs from this module now show `source: addie-member-tools`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)