### PR TITLE
feat(schemas): committed_metrics_supported capability flag

### DIFF
--- a/.changeset/committed-metrics-capability-flag.md
+++ b/.changeset/committed-metrics-capability-flag.md
@@ -1,0 +1,33 @@
+---
+"adcontextprotocol": minor
+---
+
+Add `committed_metrics_supported` capability flag to
+`media-buy-features.json`. Closes the buyer-side detection gap from
+#3510 where absence of `committed_metrics` was indistinguishable
+between 'seller didn't snapshot' and 'seller doesn't have snapshot
+infrastructure.' Closes #3517.
+
+**Why one flag (not two).** Per the unified metric-accountability
+design (#3576), `committed_metrics` is a single array carrying both
+standard and vendor-defined entries. The flag inherits that unification —
+one flag declares the seller's snapshot capability across the whole
+contract surface.
+
+**MUST timing — atomic.** Sellers declaring this flag `true` MUST
+populate `committed_metrics` on every `create_media_buy` response AND
+MUST honor append-only mid-flight metric additions via `update_media_buy`.
+The MUST ships with the flag, not as a future tightening — advisory-only
+flags leave the audit gap exploitable, defeating the purpose.
+
+**Placement choice — Option A (extend `media-buy-features.json`).**
+Matches the existing `property_list_filtering` / `catalog_management`
+precedent. Buyers can pass it as a `required_features` filter on
+`get_products` to narrow the catalog to snapshot-supporting sellers —
+that side effect is the design intent, not a bug.
+
+**Backwards compatibility.** Optional and additive. Sellers without
+the flag are unchanged; buyers ignore the flag if they don't filter on
+snapshot support.
+
+Closes #3517.

--- a/static/schemas/source/core/media-buy-features.json
+++ b/static/schemas/source/core/media-buy-features.json
@@ -16,6 +16,10 @@
     "catalog_management": {
       "type": "boolean",
       "description": "Supports sync_catalogs task for catalog feed management with platform review and approval"
+    },
+    "committed_metrics_supported": {
+      "type": "boolean",
+      "description": "Seller has per-package snapshot infrastructure for the reporting contract. When true, the seller MUST populate `package.committed_metrics` on every `create_media_buy` response and MUST honor append-only mid-flight metric additions via `update_media_buy`. The unified `committed_metrics` array (per the metric-accountability design) covers both standard and vendor-defined metric entries, so a single flag is load-bearing. Buyers filtering on this flag are detecting 'this seller can stamp the reporting contract,' which closes the audit gap from PR #3510 where absence of `committed_metrics` was indistinguishable between 'didn't snapshot' and 'snapshot infrastructure not implemented.'"
     }
   },
   "additionalProperties": {


### PR DESCRIPTION
## Summary

Add `committed_metrics_supported` boolean to `media-buy-features.json`. Closes the buyer-side detection gap from PR #3510 — absence of `committed_metrics` on a buy response was indistinguishable between "seller didn't snapshot this buy" (missing infra, fine) and "seller chose not to snapshot" (adversarial). Closes #3517.

## Design choices

**One flag (not two).** With the unified `committed_metrics` array (per #3576) covering both standard and vendor-defined entries, one snapshot capability = one flag. No need for separate `committed_vendor_metrics_supported`.

**MUST timing — atomic with the flag.** Sellers declaring `true` MUST populate `committed_metrics` on every `create_media_buy` response AND MUST honor append-only mid-flight metric additions via `update_media_buy`. The MUST ships now, not as a future tightening — advisory-only flags leave the audit gap exploitable, defeating the purpose.

**Placement — extend `media-buy-features.json` (Option A).** Matches the existing `property_list_filtering` / `catalog_management` precedent. Buyers can pass it as a `required_features` filter on `get_products` to narrow the catalog to snapshot-supporting sellers — that side effect is the design intent, not a bug.

## Backwards compatibility

Optional and additive. Sellers without the flag are unchanged; buyers ignore the flag if they don't filter on snapshot support.

## Interaction with #3576

This PR depends conceptually on the unified metric-accountability design (#3576) which is open for WG review. The flag's MUST refers to the unified `committed_metrics` shape. If #3576 lands first, this flag's MUST is straightforward. If this lands first, the MUST briefly references the parallel-array shape from #3510 and re-anchors after #3576 merges. Either order works; this PR's surface (one flag in media-buy-features.json) doesn't conflict with #3576's surface (committed_metrics shape on package + missing_metrics on delivery).

## Test plan

- [x] `npm run build:schemas` — clean
- [x] `npm run test:schemas` — 7/7
- [x] `npm run test:examples` — 34/34
- [x] `npm run typecheck` — clean

Closes #3517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)