### PR TITLE
docs(registry): surface measurement-vendor discovery via existing endpoint

### DIFF
--- a/.changeset/measurement-vendor-discovery-docs.md
+++ b/.changeset/measurement-vendor-discovery-docs.md
@@ -1,0 +1,8 @@
+---
+---
+
+Surface measurement-vendor discovery in the registry docs. Closes #3503.
+
+The federated agent index already supports `GET /api/registry/agents?type=measurement` — that's the existing answer to "which vendors offer measurement?" The docs now call this out explicitly with a measurement-vendor subsection that links to the [vendor-metric extensions surface](/docs/media-buy/media-buys/optimization-reporting#vendor-defined-metrics) and explains the buyer-agent use case.
+
+The full ask in #3503 (per-metric catalog + category aggregation) requires a brand.json schema decision about where the per-metric list lives. That's split out as #3586 (needs WG signal) — the schema work is decoupled from this docs surfacing.

--- a/docs/registry/index.mdx
+++ b/docs/registry/index.mdx
@@ -126,11 +126,23 @@ All sources produce the same resolution response structure. To get full brand id
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/registry/agents` | List all agents (filter by type, with enrichment) |
+| GET | `/api/registry/agents` | List all agents — filter by type (`?type=brand|rights|measurement|governance|creative|sales|buying|signals`); merges registered (member-declared) and discovered (crawled) sources, registered takes precedence |
 | GET | `/api/registry/agents/search` | Search agents by inventory profile (auth required) |
 | GET | `/api/registry/publishers` | List all publishers |
 | GET | `/api/registry/stats` | Registry statistics |
 | POST | `/api/registry/crawl-request` | Request re-crawl of a publisher domain (auth required) |
+
+#### Measurement-vendor discovery
+
+To discover measurement vendors specifically (Adelaide-style attention, Scope3-style emissions, Nielsen DAR, IAS/DV custom quality, etc.), filter the agent list by `type=measurement`:
+
+```bash
+curl "https://agenticadvertising.org/api/registry/agents?type=measurement"
+```
+
+This returns every measurement agent the registry knows about — registered via member profiles plus discovered through crawling brand.json declarations. Use this to populate buyer-agent vendor catalogs for the [vendor-metric extensions surface](/docs/media-buy/media-buys/optimization-reporting#vendor-defined-metrics) when buyers request cross-vendor metric availability.
+
+**Current limitation — per-metric catalog not yet structured.** The registry knows *which* agents do measurement, but not *which specific metrics* each one offers. Buyer agents that want to filter on `category="attention"` or `metric_id="attention_units"` across vendors must currently call each vendor's measurement agent for capability details. A structured per-metric catalog on brand.json's `agents[type='measurement']` declarations is tracked under [#3586](https://github.com/adcontextprotocol/adcp/issues/3586).
 
 ### Change Feed
 


### PR DESCRIPTION
## Summary

Docs-only surfacing of the existing `/api/registry/agents?type=measurement` endpoint for measurement-vendor discovery. Closes #3503.

## What was actually needed

#3503 asked for an AAO-side index of measurement vendors. The federated agent index already supports filtering by type — `GET /api/registry/agents?type=measurement` lists every measurement agent the registry knows about (member-registered + crawled). The endpoint just wasn't surfaced explicitly for the measurement use case.

## What this PR adds

A `Measurement-vendor discovery` subsection under Agent Discovery in `docs/registry/index.mdx` that:
- Documents the curl call for buyer agents
- Links to the [vendor-metric extensions surface](/docs/media-buy/media-buys/optimization-reporting#vendor-defined-metrics) so the buyer-side use case is connected
- Calls out the current limitation explicitly: per-metric catalog not yet structured, follow-up tracked at #3586

## What's deferred to #3586

The full #3503 ask included **per-vendor metric catalogs** and **category aggregation** ("which vendors offer attention?"). That requires a brand.json schema decision about where the per-metric list lives:

- Option A: extend `brand.json` `agents[type='measurement']` with a `metrics` array
- Option B: separate measurement-agent capability response (parallel to `get_adcp_capabilities`)
- Option C: hybrid

This is a WG-relevant schema conversation, not a code-only PR. Split out as #3586 with `needs-wg-review`.

## Backwards compatibility

Docs-only. No schema changes, no API changes.

Closes #3503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)