### PR TITLE
fix(addie): name both GitHub surfaces with exact URLs in member-context prompt

### DIFF
--- a/.changeset/addie-github-link-prompt-clarify-two-surfaces.md
+++ b/.changeset/addie-github-link-prompt-clarify-two-surfaces.md
@@ -1,0 +1,4 @@
+---
+---
+
+When the user has no `github_username` on their community profile, Addie's member-context prompt now names both GitHub surfaces with their exact URLs instead of one ambiguous nudge: profile-display field at `https://agenticadvertising.org/account` and OAuth connection at `https://agenticadvertising.org/connect/github` (the bouncer added in #3577). Reduces the chance of Addie paraphrasing the path and handing users a URL that doesn't exist.

--- a/server/src/addie/member-context.ts
+++ b/server/src/addie/member-context.ts
@@ -1479,7 +1479,12 @@ export function formatMemberContextForPrompt(context: MemberContext, channel: 'w
     if (context.community_profile.github_username) {
       lines.push(`GitHub: ${context.community_profile.github_username}`);
     } else {
-      lines.push('GitHub: Not linked. If they mention GitHub repos or issues, suggest linking their GitHub username at https://agenticadvertising.org/account to make it visible on their community profile.');
+      lines.push([
+        'GitHub: Not linked. There are TWO distinct GitHub surfaces — keep them separate, and use the exact URLs below (do not paraphrase to /dashboard, /settings, etc.):',
+        '  (1) Public profile display — to show their GitHub handle on their community profile page, send them to https://agenticadvertising.org/account.',
+        '  (2) OAuth connection — to let you file issues on adcontextprotocol/adcp under their GitHub identity, send them to https://agenticadvertising.org/connect/github (this bounces through login if needed and starts the WorkOS Pipes OAuth flow).',
+        'When the user asks you to file an issue, the create_github_issue tool already surfaces the (2) Connect link automatically — show its full output. Only mention these URLs explicitly when the user asks how to connect outside of filing an issue.',
+      ].join('\n'));
     }
   }
 

--- a/server/tests/unit/member-context.test.ts
+++ b/server/tests/unit/member-context.test.ts
@@ -682,7 +682,9 @@ describe('community_profile formatting', () => {
     expect(result).toContain('Community profile: Not yet public');
     expect(result).toContain('Encourage them to visit');
     expect(result).toContain('GitHub: Not linked');
-    expect(result).toContain('suggest linking their GitHub username');
+    // Both surfaces must be named with exact URLs so Addie has nothing to paraphrase.
+    expect(result).toContain('https://agenticadvertising.org/account');
+    expect(result).toContain('https://agenticadvertising.org/connect/github');
   });
 
   it('should show GitHub nudge when username is missing on public profile', () => {
@@ -706,7 +708,8 @@ describe('community_profile formatting', () => {
     const result = formatMemberContextForPrompt(context);
     expect(result).toContain('Community profile: Public');
     expect(result).toContain('GitHub: Not linked');
-    expect(result).toContain('/account');
+    expect(result).toContain('https://agenticadvertising.org/account');
+    expect(result).toContain('https://agenticadvertising.org/connect/github');
   });
 
   describe('coverage of CTA-producing context blocks', () => {


### PR DESCRIPTION
## Summary

Real-world Addie response in Slack:

> I don't have account linking or settings tools available in this conversation, but you can connect your GitHub account directly: **https://agenticadvertising.org/dashboard/settings**

`/dashboard/settings` does not exist. Addie hallucinated it from one ambiguous line in her member-context prompt.

The line at `server/src/addie/member-context.ts:1482` was:

> "GitHub: Not linked. If they mention GitHub repos or issues, suggest linking their GitHub username at https://agenticadvertising.org/account to make it visible on their community profile."

Two problems:

1. With the new `/connect/github` bouncer added in #3577, there are now **two distinct GitHub surfaces** — profile-display (`/account`) and OAuth connection (`/connect/github`) — and the prompt only named one. Addie was forced to guess for the other.
2. The line was paraphrase-able. The LLM rewrote `/account` into `/dashboard/settings`.

## What this PR does

Replaces the single line with an explicit two-surface block that:

- Names both surfaces with exact URLs.
- Pairs each surface with its intent (profile display vs. OAuth-to-file-issues).
- Instructs Addie not to paraphrase the path (e.g. into `/dashboard`, `/settings`).
- Reminds Addie that for the issue-filing intent, the `create_github_issue` tool already surfaces the Connect link automatically — these explicit URLs are only for when the user asks how to connect outside of filing.

Updated assertions in `server/tests/unit/member-context.test.ts` to require both URLs in the rendered prompt.

## Test plan

- [x] `npx vitest run server/tests/unit/member-context.test.ts` — 35 passed
- [x] Local typecheck via husky pre-commit
- [ ] Manual: re-ask Addie about linking GitHub in Slack and confirm she points at one of the two real URLs, not a hallucinated path

Note: This is a prompt fix, not a code-path change. No new routes, no new tools, no behavioral change for the `create_github_issue` flow. The `/account` and `/connect/github` URLs both already exist in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)