### PR TITLE
feat(verification): badge SVG version segment + version-pinned URLs (#3524 stage 3)

### DIFF
--- a/.changeset/per-version-badges-stage3-svg-and-routes.md
+++ b/.changeset/per-version-badges-stage3-svg-and-routes.md
@@ -16,7 +16,7 @@ New version-pinned URL: **`/api/registry/agents/{url}/badge/{role}/{version}.svg
 
 Parallel embed endpoint: **`/api/registry/agents/{url}/badge/{role}/{version}/embed`** returns HTML/Markdown snippets that point at the version-pinned SVG, with alt text including the version (`AAO Verified Media Buy Agent 3.0`).
 
-Validation: `^[1-9][0-9]{0,3}\.[0-9]{1,3}$` on the route, identical shape to the JWT signer and DB CHECK. Bounded length defends against pathological URLs filling logs. Invalid version → 400 with a clear error message.
+Validation: `^[1-9][0-9]{0,3}\.[0-9]{1,3}$` on the route boundary — shape-identical to the JWT signer and DB CHECK, but length-bounded at the public surface so pathological URLs can't fill logs. The render-path filter inside `renderBadgeSvg` is shape-only (`^[1-9][0-9]*\.[0-9]+$`) since its callers are already gated by the route or come from the DB CHECK. Invalid version → 400 with a clear error message.
 
 Defense-in-depth in `renderBadgeSvg`: a malformed `adcpVersion` drops from the rendered label rather than failing the image. Unlike the JWT signer (which fails closed because a partial token is a downgrade vector), a missing badge image is worse for the buyer than a less-specific one — so the SVG renders verified-without-version when the value can't be trusted.
 

--- a/.changeset/per-version-badges-stage3-svg-and-routes.md
+++ b/.changeset/per-version-badges-stage3-svg-and-routes.md
@@ -1,0 +1,31 @@
+---
+---
+
+backend(verification): badge SVG version segment + version-pinned URLs. Stage 3 of #3524.
+
+Badge labels now embed the AdCP release between the role and the qualifier:
+
+| Before | After |
+|---|---|
+| `Media Buy Agent (Spec)` | `Media Buy Agent 3.0 (Spec)` |
+| `Media Buy Agent (Spec + Live)` | `Media Buy Agent 3.1 (Spec + Live)` |
+
+The legacy URL `/badge/{role}.svg` keeps working — it serves the highest active version's badge and the embedded image auto-upgrades when an agent earns a newer version. Embedded badges in the wild keep their stable URL.
+
+New version-pinned URL: **`/api/registry/agents/{url}/badge/{role}/{version}.svg`** lets buyers freeze on a specific release. Returns the (Spec)/(Live) qualifier earned at exactly that version, or "Not Verified" if the agent never earned a badge there. Path-segment form (not query string) for clean shields.io-style cache keys.
+
+Parallel embed endpoint: **`/api/registry/agents/{url}/badge/{role}/{version}/embed`** returns HTML/Markdown snippets that point at the version-pinned SVG, with alt text including the version (`AAO Verified Media Buy Agent 3.0`).
+
+Validation: `^[1-9][0-9]{0,3}\.[0-9]{1,3}$` on the route, identical shape to the JWT signer and DB CHECK. Bounded length defends against pathological URLs filling logs. Invalid version → 400 with a clear error message.
+
+Defense-in-depth in `renderBadgeSvg`: a malformed `adcpVersion` drops from the rendered label rather than failing the image. Unlike the JWT signer (which fails closed because a partial token is a downgrade vector), a missing badge image is worse for the buyer than a less-specific one — so the SVG renders verified-without-version when the value can't be trusted.
+
+ETag: `${role}-${version}-${modes}` so the cache invalidates on version transitions and qualifier changes.
+
+8 new tests cover the version segment: embed-when-set, omit-when-absent, drop-on-malformed (SQL-injection-shaped), reject-leading-zero, reject-full-semver, double-digit minor preservation, and "Not Verified" labels never carry a version.
+
+What this PR does NOT change:
+
+- Verification panel still renders one row per role. **Stage 4** splits into one row per (role, version).
+- brand.json enrichment shape unchanged. **Stage 5** adds the `badges[]` array with version detail.
+- The legacy non-versioned embed URL keeps working unchanged.

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -4002,6 +4002,23 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
 
   // ── Badge SVG (public) ──────────────────────────────────────────
 
+  // Same shape constraint the JWT signer and DB CHECK use. Routes that
+  // accept a :version path segment validate before hitting the DB so we
+  // don't 404-vs-400 distinguish between "no badge at this version" and
+  // "this isn't a version string." Hard cap on length defends against
+  // pathological URLs filling logs.
+  const VALID_ADCP_VERSION_RE = /^[1-9][0-9]{0,3}\.[0-9]{1,3}$/;
+
+  function setBadgeSvgHeaders(res: import("express").Response, etag: string) {
+    res.setHeader("Content-Type", "image/svg+xml");
+    res.setHeader("Content-Security-Policy", "script-src 'none'");
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("Cache-Control", "public, max-age=300, s-maxage=300, stale-while-revalidate=60");
+    // ETag covers role, version, and the mode set so a transition (e.g.
+    // add 'live', upgrade to 3.1) invalidates caches for the badge URL.
+    res.setHeader("ETag", etag);
+  }
+
   router.get("/registry/agents/:encodedUrl/badge/:role.svg", async (req, res) => {
     try {
       const agentUrl = decodeURIComponent(req.params.encodedUrl);
@@ -4013,26 +4030,26 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         return res.status(400).json({ error: `Invalid role "${role}". Valid roles: ${VALID_BADGE_ROLES.join(', ')}` });
       }
 
-      // getHighestVersionActiveBadge returns the highest-version active +
-      // degraded badge. A degraded badge
-      // (within 48-hour grace period) still renders as verified -- the grace
-      // period is invisible to the public. Revocation only happens after 48h.
+      // Legacy URL: serves the highest-version active+degraded badge.
+      // Embedded badges in the wild auto-upgrade to the most recent
+      // version the agent has earned without changing the URL. The
+      // version-pinned URL `/badge/:role/:version.svg` (below) lets
+      // buyers freeze a specific version.
       let modes: string[] = [];
+      let adcpVersion: string | undefined;
       try {
         const badge = await complianceDb.getHighestVersionActiveBadge(agentUrl, role as any);
-        if (badge) modes = badge.verification_modes;
+        if (badge) {
+          modes = badge.verification_modes;
+          adcpVersion = badge.adcp_version;
+        }
       } catch {
         // Table may not exist yet
       }
 
-      const svg = renderBadgeSvg(role, modes);
-      res.setHeader("Content-Type", "image/svg+xml");
-      res.setHeader("Content-Security-Policy", "script-src 'none'");
-      res.setHeader("X-Content-Type-Options", "nosniff");
-      res.setHeader("Cache-Control", "public, max-age=300, s-maxage=300, stale-while-revalidate=60");
-      // ETag covers both role and the mode set so a transition (e.g. add 'live')
-      // invalidates caches for the badge URL.
-      res.setHeader("ETag", `"${role}-${modes.slice().sort().join('-') || 'nv'}"`);
+      const svg = renderBadgeSvg(role, modes, { adcpVersion });
+      const etag = `"${role}-${adcpVersion ?? 'any'}-${modes.slice().sort().join('-') || 'nv'}"`;
+      setBadgeSvgHeaders(res, etag);
       res.send(svg);
     } catch (error) {
       logger.error({ err: error, path: req.path }, "Failed to render badge SVG");
@@ -4040,7 +4057,75 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     }
   });
 
+  // Version-pinned badge URL — buyers who want to freeze on a specific
+  // AdCP release embed this instead of the legacy `/badge/:role.svg`.
+  // Returns the (Spec)/(Live) qualifier earned at exactly this version,
+  // or "Not Verified" if the agent never earned a badge at this version.
+  router.get("/registry/agents/:encodedUrl/badge/:role/:version.svg", async (req, res) => {
+    try {
+      const agentUrl = decodeURIComponent(req.params.encodedUrl);
+      const role = req.params.role;
+      const version = req.params.version;
+      if (!validateAgentUrlParam(agentUrl)) {
+        return res.status(400).send("Invalid agent URL");
+      }
+      if (!VALID_BADGE_ROLES.includes(role as any)) {
+        return res.status(400).json({ error: `Invalid role "${role}". Valid roles: ${VALID_BADGE_ROLES.join(', ')}` });
+      }
+      if (!VALID_ADCP_VERSION_RE.test(version)) {
+        return res.status(400).json({ error: `Invalid version "${version}". Expected MAJOR.MINOR (e.g. "3.0").` });
+      }
+
+      let modes: string[] = [];
+      try {
+        const badge = await complianceDb.getActiveBadge(agentUrl, role as any, version);
+        if (badge) modes = badge.verification_modes;
+      } catch {
+        // Table may not exist yet
+      }
+
+      const svg = renderBadgeSvg(role, modes, { adcpVersion: version });
+      const etag = `"${role}-${version}-${modes.slice().sort().join('-') || 'nv'}"`;
+      setBadgeSvgHeaders(res, etag);
+      res.send(svg);
+    } catch (error) {
+      logger.error({ err: error, path: req.path }, "Failed to render version-pinned badge SVG");
+      res.status(500).send("Failed to render badge");
+    }
+  });
+
   // ── Embeddable Badge (public) ──────────────────────────────────
+
+  // Escape URLs for safe interpolation into markdown (parens/brackets break link syntax)
+  const escapeMdUrl = (url: string) => url.replace(/[()[\]]/g, (ch) => `%${ch.charCodeAt(0).toString(16).toUpperCase()}`);
+  // Convert kebab-case role ("media-buy") to Title Case ("Media Buy") for embed alt text.
+  const roleLabelForEmbed = (role: string) =>
+    role.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+
+  function buildEmbedResponse(args: {
+    agentUrl: string;
+    role: string;
+    badgeSvgUrl: string;
+    altText: string;
+    verified: boolean;
+    adcpVersion?: string;
+  }) {
+    const baseUrl = process.env.PUBLIC_BASE_URL || 'https://agenticadvertising.org';
+    const encodedUrl = encodeURIComponent(args.agentUrl);
+    const registryUrl = `${baseUrl}/registry/agents/${encodedUrl}`;
+    const html = `<a href="${escapeHtml(registryUrl)}" target="_blank" rel="noopener noreferrer"><img src="${escapeHtml(args.badgeSvgUrl)}" alt="${escapeHtml(args.altText)}" loading="lazy" height="20" /></a>`;
+    const markdown = `[![${args.altText}](${escapeMdUrl(args.badgeSvgUrl)})](${escapeMdUrl(registryUrl)})`;
+    return {
+      agent_url: args.agentUrl,
+      role: args.role,
+      verified: args.verified,
+      ...(args.adcpVersion && { adcp_version: args.adcpVersion }),
+      badge_svg_url: args.badgeSvgUrl,
+      registry_url: registryUrl,
+      html,
+      markdown,
+    };
+  }
 
   router.get("/registry/agents/:encodedUrl/badge/:role/embed", async (req, res) => {
     try {
@@ -4054,9 +4139,11 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       }
 
       let verified = false;
+      let adcpVersion: string | undefined;
       try {
         const badge = await complianceDb.getHighestVersionActiveBadge(agentUrl, role as any);
         verified = !!badge;
+        adcpVersion = badge?.adcp_version;
       } catch {
         // Table may not exist yet
       }
@@ -4064,26 +4151,54 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       const baseUrl = process.env.PUBLIC_BASE_URL || 'https://agenticadvertising.org';
       const encodedUrl = encodeURIComponent(agentUrl);
       const badgeSvgUrl = `${baseUrl}/api/registry/agents/${encodedUrl}/badge/${role}.svg`;
-      const registryUrl = `${baseUrl}/registry/agents/${encodedUrl}`;
-      // Convert kebab-case domain to Title Case (e.g. "media-buy" → "Media Buy")
-      const roleLabel = role.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+      // Embed alt text omits the version segment intentionally — the
+      // legacy URL auto-upgrades, so a buyer who copies this snippet
+      // gets the newest version's image without changing the alt text
+      // they pasted into their site.
+      const altText = `AAO Verified ${roleLabelForEmbed(role)} Agent`;
 
-      // Escape URLs for safe interpolation into markdown (parens/brackets break link syntax)
-      const escapeMdUrl = (url: string) => url.replace(/[()[\]]/g, (ch) => `%${ch.charCodeAt(0).toString(16).toUpperCase()}`);
-      const html = `<a href="${escapeHtml(registryUrl)}" target="_blank" rel="noopener noreferrer"><img src="${escapeHtml(badgeSvgUrl)}" alt="${escapeHtml(`AAO Verified ${roleLabel} Agent`)}" loading="lazy" height="20" /></a>`;
-      const markdown = `[![AAO Verified ${roleLabel} Agent](${escapeMdUrl(badgeSvgUrl)})](${escapeMdUrl(registryUrl)})`;
-
-      res.json({
-        agent_url: agentUrl,
-        role,
-        verified,
-        badge_svg_url: badgeSvgUrl,
-        registry_url: registryUrl,
-        html,
-        markdown,
-      });
+      res.json(buildEmbedResponse({ agentUrl, role, badgeSvgUrl, altText, verified, adcpVersion }));
     } catch (error) {
       logger.error({ err: error, path: req.path }, "Failed to generate embed code");
+      res.status(500).json({ error: "Failed to generate embed code" });
+    }
+  });
+
+  // Version-pinned embed — renders snippets that point at the
+  // version-specific SVG URL. Buyers who want to call out "verified
+  // for AdCP 3.0" specifically (e.g., during a 3.1 transition) embed
+  // this instead of the legacy `/badge/:role/embed`.
+  router.get("/registry/agents/:encodedUrl/badge/:role/:version/embed", async (req, res) => {
+    try {
+      const agentUrl = decodeURIComponent(req.params.encodedUrl);
+      const role = req.params.role;
+      const version = req.params.version;
+      if (!validateAgentUrlParam(agentUrl)) {
+        return res.status(400).json({ error: "Invalid agent URL" });
+      }
+      if (!VALID_BADGE_ROLES.includes(role as any)) {
+        return res.status(400).json({ error: `Invalid role "${role}". Valid roles: ${VALID_BADGE_ROLES.join(', ')}` });
+      }
+      if (!VALID_ADCP_VERSION_RE.test(version)) {
+        return res.status(400).json({ error: `Invalid version "${version}". Expected MAJOR.MINOR (e.g. "3.0").` });
+      }
+
+      let verified = false;
+      try {
+        const badge = await complianceDb.getActiveBadge(agentUrl, role as any, version);
+        verified = !!badge;
+      } catch {
+        // Table may not exist yet
+      }
+
+      const baseUrl = process.env.PUBLIC_BASE_URL || 'https://agenticadvertising.org';
+      const encodedUrl = encodeURIComponent(agentUrl);
+      const badgeSvgUrl = `${baseUrl}/api/registry/agents/${encodedUrl}/badge/${role}/${version}.svg`;
+      const altText = `AAO Verified ${roleLabelForEmbed(role)} Agent ${version}`;
+
+      res.json(buildEmbedResponse({ agentUrl, role, badgeSvgUrl, altText, verified, adcpVersion: version }));
+    } catch (error) {
+      logger.error({ err: error, path: req.path }, "Failed to generate version-pinned embed code");
       res.status(500).json({ error: "Failed to generate embed code" });
     }
   });

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -1540,6 +1540,64 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
+  path: "/api/registry/agents/{encodedUrl}/badge/{role}/{version}.svg",
+  operationId: "getAgentBadgeVersionedSvg",
+  summary: "Get version-pinned agent verification badge SVG",
+  description: "Returns an SVG badge image scoped to a specific AdCP release (MAJOR.MINOR, e.g. '3.0'). Buyers who want to call out 'verified for 3.0' embed this instead of the legacy `/badge/{role}.svg` (which auto-upgrades to the highest active version). Renders 'Not Verified' when the agent never earned a badge at this version.",
+  tags: ["Agent Compliance"],
+  request: {
+    params: z.object({
+      encodedUrl: z.string().openapi({ description: "URL-encoded agent URL" }),
+      role: z.string().openapi({ description: "Badge role (media-buy, creative, signals, governance, brand, sponsored-intelligence)" }),
+      version: z.string().openapi({ description: "AdCP release as MAJOR.MINOR (e.g. '3.0', '3.1')" }),
+    }),
+  },
+  responses: {
+    200: { description: "SVG badge image", content: { "image/svg+xml": { schema: z.string() } } },
+    400: { description: "Invalid agent URL, role, or version", content: { "application/json": { schema: ErrorSchema } } },
+    500: { description: "Server error" },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/registry/agents/{encodedUrl}/badge/{role}/{version}/embed",
+  operationId: "getAgentBadgeVersionedEmbed",
+  summary: "Get version-pinned embeddable badge code",
+  description: "Returns HTML and Markdown embed snippets that point at the version-pinned SVG. Alt text includes the version (e.g. 'AAO Verified Media Buy Agent 3.0'). Buyers who want to freeze on a specific AdCP release embed these instead of the legacy `/badge/{role}/embed`.",
+  tags: ["Agent Compliance"],
+  request: {
+    params: z.object({
+      encodedUrl: z.string().openapi({ description: "URL-encoded agent URL" }),
+      role: z.string().openapi({ description: "Badge role" }),
+      version: z.string().openapi({ description: "AdCP release as MAJOR.MINOR" }),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Embed code",
+      content: {
+        "application/json": {
+          schema: z.object({
+            agent_url: z.string(),
+            role: z.string(),
+            verified: z.boolean(),
+            adcp_version: z.string().optional(),
+            badge_svg_url: z.string(),
+            registry_url: z.string(),
+            html: z.string(),
+            markdown: z.string(),
+          }),
+        },
+      },
+    },
+    400: { description: "Invalid agent URL, role, or version", content: { "application/json": { schema: ErrorSchema } } },
+    500: { description: "Server error", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: "get",
   path: "/api/registry/agents/{encodedUrl}/storyboard-status",
   operationId: "getAgentStoryboardStatus",
   summary: "Get agent storyboard status",
@@ -4019,12 +4077,12 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     res.setHeader("ETag", etag);
   }
 
-  router.get("/registry/agents/:encodedUrl/badge/:role.svg", async (req, res) => {
+  router.get("/registry/agents/:encodedUrl/badge/:role.svg", agentReadRateLimiter, async (req, res) => {
     try {
       const agentUrl = decodeURIComponent(req.params.encodedUrl);
       const role = req.params.role;
       if (!validateAgentUrlParam(agentUrl)) {
-        return res.status(400).send("Invalid agent URL");
+        return res.status(400).json({ error: "Invalid agent URL" });
       }
       if (!VALID_BADGE_ROLES.includes(role as any)) {
         return res.status(400).json({ error: `Invalid role "${role}". Valid roles: ${VALID_BADGE_ROLES.join(', ')}` });
@@ -4048,7 +4106,13 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       }
 
       const svg = renderBadgeSvg(role, modes, { adcpVersion });
-      const etag = `"${role}-${adcpVersion ?? 'any'}-${modes.slice().sort().join('-') || 'nv'}"`;
+      // ETag-safe version: filter the DB value through the same shape
+      // regex renderBadgeSvg uses. A poisoned row with control characters
+      // (CR/LF, NUL) would otherwise crash the response with
+      // ERR_INVALID_CHAR when Node serializes the header. Falls back to
+      // 'nv' (matching the modes-empty sentinel) for missing/malformed.
+      const etagVersion = adcpVersion && /^[1-9][0-9]*\.[0-9]+$/.test(adcpVersion) ? adcpVersion : 'nv';
+      const etag = `"${role}-${etagVersion}-${modes.slice().sort().join('-') || 'nv'}"`;
       setBadgeSvgHeaders(res, etag);
       res.send(svg);
     } catch (error) {
@@ -4061,13 +4125,13 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
   // AdCP release embed this instead of the legacy `/badge/:role.svg`.
   // Returns the (Spec)/(Live) qualifier earned at exactly this version,
   // or "Not Verified" if the agent never earned a badge at this version.
-  router.get("/registry/agents/:encodedUrl/badge/:role/:version.svg", async (req, res) => {
+  router.get("/registry/agents/:encodedUrl/badge/:role/:version.svg", agentReadRateLimiter, async (req, res) => {
     try {
       const agentUrl = decodeURIComponent(req.params.encodedUrl);
       const role = req.params.role;
       const version = req.params.version;
       if (!validateAgentUrlParam(agentUrl)) {
-        return res.status(400).send("Invalid agent URL");
+        return res.status(400).json({ error: "Invalid agent URL" });
       }
       if (!VALID_BADGE_ROLES.includes(role as any)) {
         return res.status(400).json({ error: `Invalid role "${role}". Valid roles: ${VALID_BADGE_ROLES.join(', ')}` });
@@ -4098,6 +4162,11 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
 
   // Escape URLs for safe interpolation into markdown (parens/brackets break link syntax)
   const escapeMdUrl = (url: string) => url.replace(/[()[\]]/g, (ch) => `%${ch.charCodeAt(0).toString(16).toUpperCase()}`);
+  // Escape markdown alt text. Today altText is built from kebab-cased
+  // role + numeric version so it's safe — but a future caller that
+  // incorporates user-controlled text would otherwise be one
+  // unescaped `]` away from breaking the link syntax. Forward defense.
+  const escapeMdAltText = (text: string) => text.replace(/([\\\[\]])/g, '\\$1');
   // Convert kebab-case role ("media-buy") to Title Case ("Media Buy") for embed alt text.
   const roleLabelForEmbed = (role: string) =>
     role.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
@@ -4114,7 +4183,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     const encodedUrl = encodeURIComponent(args.agentUrl);
     const registryUrl = `${baseUrl}/registry/agents/${encodedUrl}`;
     const html = `<a href="${escapeHtml(registryUrl)}" target="_blank" rel="noopener noreferrer"><img src="${escapeHtml(args.badgeSvgUrl)}" alt="${escapeHtml(args.altText)}" loading="lazy" height="20" /></a>`;
-    const markdown = `[![${args.altText}](${escapeMdUrl(args.badgeSvgUrl)})](${escapeMdUrl(registryUrl)})`;
+    const markdown = `[![${escapeMdAltText(args.altText)}](${escapeMdUrl(args.badgeSvgUrl)})](${escapeMdUrl(registryUrl)})`;
     return {
       agent_url: args.agentUrl,
       role: args.role,
@@ -4127,7 +4196,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     };
   }
 
-  router.get("/registry/agents/:encodedUrl/badge/:role/embed", async (req, res) => {
+  router.get("/registry/agents/:encodedUrl/badge/:role/embed", agentReadRateLimiter, async (req, res) => {
     try {
       const agentUrl = decodeURIComponent(req.params.encodedUrl);
       const role = req.params.role;
@@ -4168,7 +4237,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
   // version-specific SVG URL. Buyers who want to call out "verified
   // for AdCP 3.0" specifically (e.g., during a 3.1 transition) embed
   // this instead of the legacy `/badge/:role/embed`.
-  router.get("/registry/agents/:encodedUrl/badge/:role/:version/embed", async (req, res) => {
+  router.get("/registry/agents/:encodedUrl/badge/:role/:version/embed", agentReadRateLimiter, async (req, res) => {
     try {
       const agentUrl = decodeURIComponent(req.params.encodedUrl);
       const role = req.params.role;

--- a/server/src/services/badge-svg.ts
+++ b/server/src/services/badge-svg.ts
@@ -1,16 +1,29 @@
 /**
  * SVG badge rendering for AAO Verified agents.
  *
- * Generates shields.io-style badges: "AAO Verified | Media Buy Agent (Spec)"
+ * Generates shields.io-style badges: "AAO Verified | Media Buy Agent 3.0 (Spec)"
  * with the AAO teal color scheme.
  *
- * The qualifier in parens conveys *which axes of verification* the agent has
- * earned: (Spec) means protocol storyboards pass, (Live) means AAO has observed
- * real production traffic via canonical campaigns. An agent can have either or
+ * The version segment between the role and the qualifier conveys *which AdCP
+ * release* the badge was issued against (3.0, 3.1, ...). The qualifier in
+ * parens conveys *which axes of verification* the agent has earned: (Spec)
+ * means protocol storyboards pass, (Live) means AAO has observed real
+ * production traffic via canonical campaigns. An agent can have either or
  * both, e.g. "(Spec + Live)". An empty modes array renders "Not Verified".
  */
 
 import { ADCP_PROTOCOLS, VERIFICATION_MODES, isVerificationMode } from './adcp-taxonomy.js';
+
+/**
+ * Shape constraint for AdCP versions in badge labels. Same regex the JWT
+ * signer enforces — a poisoned DB row that smuggled a non-MAJOR.MINOR
+ * value drops the version from the rendered label rather than letting
+ * arbitrary text reach a public-facing image. The badge still renders
+ * (verified-without-version) so a degraded DB row doesn't blank a buyer's
+ * embedded badge — that's the security/UX trade-off for this surface,
+ * versus the JWT signer which fails closed.
+ */
+const ADCP_VERSION_RE = /^[1-9][0-9]*\.[0-9]+$/;
 
 // Re-exported for backward compatibility — canonical home is adcp-taxonomy.ts.
 export { VERIFICATION_MODES };
@@ -91,7 +104,22 @@ function formatModes(modes: readonly string[]): string {
     .join(' + ');
 }
 
-export function renderBadgeSvg(role: string, modes: readonly string[] = []): string {
+export interface RenderBadgeSvgOptions {
+  /**
+   * AdCP release this badge was issued against, MAJOR.MINOR (e.g. '3.0').
+   * Embeds in the message as `Media Buy Agent 3.0 (Spec)`. Validated
+   * against the same regex as the DB CHECK and JWT signer; a malformed
+   * value renders without the version segment rather than failing the
+   * whole image (#3524 stage 3).
+   */
+  adcpVersion?: string;
+}
+
+export function renderBadgeSvg(
+  role: string,
+  modes: readonly string[] = [],
+  options: RenderBadgeSvgOptions = {},
+): string {
   // Filter to known modes — unknown values from corrupted DB rows or
   // tampered input don't reach public badge text.
   const safeModes = modes.filter(isVerificationMode);
@@ -99,8 +127,17 @@ export function renderBadgeSvg(role: string, modes: readonly string[] = []): str
   const isVerified = safeModes.length > 0;
   const roleLabel = ROLE_LABELS[role] || escapeXml(role);
   const qualifier = formatModes(safeModes);
+  // Same shape filter as the JWT signer. A malformed adcp_version drops
+  // from the rendered label without failing the badge — degraded display
+  // is acceptable for an embedded SVG, where a missing image would be
+  // worse for the buyer.
+  const safeVersion = options.adcpVersion && ADCP_VERSION_RE.test(options.adcpVersion)
+    ? options.adcpVersion
+    : undefined;
+  // Role + optional version: "Media Buy Agent" or "Media Buy Agent 3.0".
+  const verifiedRoleSegment = safeVersion ? `${roleLabel} ${safeVersion}` : roleLabel;
   const message = isVerified
-    ? (qualifier ? `${roleLabel} (${qualifier})` : roleLabel)
+    ? (qualifier ? `${verifiedRoleSegment} (${qualifier})` : verifiedRoleSegment)
     : 'Not Verified';
   const messageBg = isVerified ? AAO_TEAL : NOT_VERIFIED_BG;
   const idSuffix = `${escapeXml(role)}-${isVerified ? 'v' : 'nv'}`;

--- a/server/tests/unit/badge-issuance.test.ts
+++ b/server/tests/unit/badge-issuance.test.ts
@@ -278,6 +278,36 @@ describe('processAgentBadges — per-AdCP-version isolation (#3524 stage 1)', ()
     expect(revokeCalls.every(call => call[3] === 'Membership lapsed')).toBe(true);
   });
 
+  it('multi-version revoke transition: 3.0 revoked while 3.1 active should leave 3.1 untouched', async () => {
+    // Security review concern: the legacy /badge/{role}.svg URL serves
+    // the highest-version active badge. If 3.0 is revoked (storyboard
+    // failure past 48h grace) while 3.1 is active, the legacy URL
+    // upgrades to 3.1 — that's the desired behavior. This test pins
+    // the invariant that a 3.0 run revoking 3.0 doesn't touch the 3.1
+    // badge, leaving the highest-version-picker free to upgrade.
+    const existing = [
+      makeBadge('media-buy', 'degraded', 49 * 60 * 60 * 1000, ['spec'], '3.0'), // past grace
+      makeBadge('media-buy', 'active', 0, ['spec'], '3.1'),
+    ];
+    const db = makeMockDb(existing);
+
+    await processAgentBadges(
+      db,
+      'https://example.com/mcp',
+      ['sales-broadcast-tv'],
+      [makeStatus('sales_broadcast_tv', 'failing')],
+      false,
+      'org_test',
+      '3.0',
+    );
+
+    const revokeCalls = (db.revokeBadge as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    // Only 3.0 should be revoked under this run; 3.1 stays untouched.
+    const revokedTuples = revokeCalls.map(call => `${call[1]}@${call[2]}`);
+    expect(revokedTuples).toContain('media-buy@3.0');
+    expect(revokedTuples).not.toContain('media-buy@3.1');
+  });
+
   it('partial overlap: issuing a new role at 3.0 does not touch creative@3.1', async () => {
     // Code-reviewer requested case: agent has media-buy@3.0 and creative@3.1.
     // A 3.0 run that issues creative for the first time at 3.0 must not

--- a/server/tests/unit/badge-svg.test.ts
+++ b/server/tests/unit/badge-svg.test.ts
@@ -88,3 +88,56 @@ describe('renderBadgeSvg', () => {
     expect(svg).toContain('<title>AAO Verified: Media Buy Agent (Spec)</title>');
   });
 });
+
+describe('renderBadgeSvg — adcp_version segment (#3524 stage 3)', () => {
+  it('embeds the version between the role and the qualifier', () => {
+    const svg = renderBadgeSvg('media-buy', ['spec'], { adcpVersion: '3.0' });
+    expect(svg).toContain('Media Buy Agent 3.0 (Spec)');
+    expect(svg).toContain('aria-label="AAO Verified: Media Buy Agent 3.0 (Spec)"');
+  });
+
+  it('renders Media Buy Agent 3.1 (Spec + Live)', () => {
+    const svg = renderBadgeSvg('media-buy', ['spec', 'live'], { adcpVersion: '3.1' });
+    expect(svg).toContain('Media Buy Agent 3.1 (Spec + Live)');
+  });
+
+  it('omits the version when not provided (legacy callers)', () => {
+    const svg = renderBadgeSvg('media-buy', ['spec']);
+    expect(svg).toContain('Media Buy Agent (Spec)');
+    expect(svg).not.toContain('Media Buy Agent 3.');
+  });
+
+  it('drops the version segment when malformed (degraded display, not failure)', () => {
+    // Unlike the JWT signer (which fails closed), the badge renders
+    // verified-without-version on a malformed value — a missing image
+    // is worse for the buyer than a less-specific one.
+    const svg = renderBadgeSvg('media-buy', ['spec'], { adcpVersion: 'evil; DROP' });
+    expect(svg).toContain('Media Buy Agent (Spec)');
+    expect(svg).not.toContain('evil');
+    expect(svg).not.toContain('DROP');
+  });
+
+  it('drops a version with leading-zero major', () => {
+    const svg = renderBadgeSvg('media-buy', ['spec'], { adcpVersion: '0.5' });
+    expect(svg).toContain('Media Buy Agent (Spec)');
+    expect(svg).not.toContain('0.5');
+  });
+
+  it('drops a full-semver value (use protocol_version metadata, not the badge)', () => {
+    const svg = renderBadgeSvg('media-buy', ['spec'], { adcpVersion: '3.0.0' });
+    expect(svg).toContain('Media Buy Agent (Spec)');
+    expect(svg).not.toContain('3.0.0');
+  });
+
+  it('renders double-digit minors without truncation', () => {
+    const svg = renderBadgeSvg('media-buy', ['spec'], { adcpVersion: '3.10' });
+    expect(svg).toContain('Media Buy Agent 3.10 (Spec)');
+  });
+
+  it('still renders Not Verified when modes is empty even with a version provided', () => {
+    const svg = renderBadgeSvg('media-buy', [], { adcpVersion: '3.0' });
+    expect(svg).toContain('Not Verified');
+    // Version segment should not appear in the not-verified label.
+    expect(svg).not.toContain('3.0');
+  });
+});


### PR DESCRIPTION
## Summary

Stage 3 of [#3524](https://github.com/adcontextprotocol/adcp/issues/3524). Badges and embed code can now carry an explicit AdCP version.

| Before | After |
|---|---|
| \`Media Buy Agent (Spec)\` | \`Media Buy Agent 3.0 (Spec)\` |
| \`Media Buy Agent (Spec + Live)\` | \`Media Buy Agent 3.1 (Spec + Live)\` |

The legacy URL \`/badge/{role}.svg\` still works — it serves the highest active version, so embedded badges in the wild auto-upgrade as agents earn newer versions.

## New routes

- **\`GET /api/registry/agents/{url}/badge/{role}/{version}.svg\`** — version-pinned SVG. Returns the (Spec)/(Live) qualifier earned at exactly that version, or "Not Verified" if the agent never earned a badge there.
- **\`GET /api/registry/agents/{url}/badge/{role}/{version}/embed\`** — version-pinned embed snippets (HTML + Markdown). Alt text includes the version: \`AAO Verified Media Buy Agent 3.0\`.

Path-segment form (not query string) for clean shields.io-style cache keys. Version validates against \`^[1-9][0-9]{0,3}\.[0-9]{1,3}$\` at the route boundary so 400-on-invalid is distinguishable from 200-no-badge.

## What does NOT change

- **Verification panel** still renders one row per role — Stage 4 splits into one row per (role, version).
- **brand.json enrichment** shape unchanged — Stage 5 adds the \`badges[]\` array with version detail.
- **Legacy \`/badge/{role}.svg\` and \`/badge/{role}/embed\`** keep working unchanged (just gain a version segment in the rendered label when a badge exists).

## Defense in depth

\`renderBadgeSvg\` validates \`adcpVersion\` against the same regex as the JWT signer. A malformed value drops from the rendered label rather than failing the image. Asymmetry vs. the JWT signer (which fails closed) is deliberate: a missing badge image is worse for the buyer than a less-specific one. ETag covers \`role + version + modes\` so cache invalidates on transitions.

## Test plan

- [x] 8 new unit tests for the version segment in \`renderBadgeSvg\`: embed-when-set, omit-when-absent, drop-on-malformed (SQL-injection-shaped), reject-leading-zero major, reject-full-semver, double-digit minor preservation, "Not Verified" labels never carry a version
- [x] 130/130 unit tests pass total
- [x] TypeScript typecheck clean

## Stage tracker

- ✓ Stage 1 (#3568) — data model + per-version isolation
- ✓ Stage 2 (#3579) — heartbeat fan-out + JWT \`adcp_version\` claim
- ✓ Stage 3 (this PR) — badge SVG version segment + version-pinned URLs
- ⏳ Stage 4 — verification panel renders one row per (role, version)
- ⏳ Stage 5 — brand.json \`badges[]\` array

🤖 Generated with [Claude Code](https://claude.com/claude-code)