### PR TITLE
fix(brand-builder): strict Content-Encoding + parallel-safe test fixtures

### DIFF
--- a/.changeset/brand-properties-parse-content-encoding-strict.md
+++ b/.changeset/brand-properties-parse-content-encoding-strict.md
@@ -1,0 +1,8 @@
+---
+---
+
+Reject responses with `Content-Encoding ≠ identity|absent` on the smart-paste property parse URL fetch path. The compression-bomb defense in PR #3396 sends `Accept-Encoding: identity` to disable undici's auto-decompression — but if a hostile server ignores the header and ships gzip/br/deflate anyway, undici still decodes the body and the byte counter measures decompressed bytes, leaving the 1MB cap circumventable by a high-ratio bomb. The route now checks the response's `Content-Encoding` header and returns a 400 if anything other than `identity` (or absent) is present, so a non-cooperative server is rejected before any reading happens.
+
+Also derives test fixture IDs from `process.pid + Date.now()` so the suite can run in parallel with other integration tests touching `organizations`/`users`/`brands` without FK-conflict races. Suggested by nodejs-testing-expert review on PR #3396.
+
+5 new test cases pin the strict reject for gzip/br/deflate (case-insensitively), and confirm an explicit `Content-Encoding: identity` is still accepted.

--- a/server/src/routes/brand-feeds.ts
+++ b/server/src/routes/brand-feeds.ts
@@ -334,6 +334,16 @@ export function createBrandFeedsRouter(config: { brandDb: BrandDatabase }) {
         if (!fetchResponse.body) {
           return res.status(400).json({ error: 'URL returned no body' });
         }
+        // Defense-in-depth for the compression-bomb path: if the server
+        // ignored our `Accept-Encoding: identity` request and shipped gzip
+        // (or br/deflate) anyway, undici auto-decodes and the byte counter
+        // measures decompressed bytes — a high-ratio bomb still spikes
+        // memory before the cap fires. Reject any non-identity encoding
+        // outright.
+        const contentEncoding = fetchResponse.headers.get('content-encoding')?.toLowerCase().trim();
+        if (contentEncoding && contentEncoding !== 'identity') {
+          return res.status(400).json({ error: 'URL response uses unsupported content-encoding' });
+        }
         // Stream with a hard byte cap — Content-Length alone is not reliable for chunked responses.
         const decoder = new TextDecoder();
         const chunks: string[] = [];

--- a/server/tests/integration/brand-properties-parse.test.ts
+++ b/server/tests/integration/brand-properties-parse.test.ts
@@ -61,11 +61,17 @@ import { runMigrations } from '../../src/db/migrate.js';
 import { BrandDatabase } from '../../src/db/brand-db.js';
 import { createBrandFeedsRouter } from '../../src/routes/brand-feeds.js';
 
-const TEST_DOMAIN = 'parse-test.example.com';
-const OWNER_ORG = 'org_parse_owner_001';
-const OUTSIDER_ORG = 'org_parse_outsider_002';
-const OWNER_USER = 'user_parse_owner';
-const OUTSIDER_USER = 'user_parse_outsider';
+// PID + timestamp suffixed IDs prevent FK collisions when this suite runs
+// in parallel with any other integration test that touches organizations,
+// users, or brands tables. The suite's beforeEach DELETEs are scoped to
+// these specific keys, so a sibling worker running concurrently can't be
+// trampled.
+const SUFFIX = `${process.pid}_${Date.now()}`;
+const TEST_DOMAIN = `parse-test-${SUFFIX}.example.com`;
+const OWNER_ORG = `org_parse_owner_${SUFFIX}`;
+const OUTSIDER_ORG = `org_parse_outsider_${SUFFIX}`;
+const OWNER_USER = `user_parse_owner_${SUFFIX}`;
+const OUTSIDER_USER = `user_parse_outsider_${SUFFIX}`;
 
 // Build a Messages.create response that looks like the model invoked
 // `extract_properties` with the supplied args. The route reads
@@ -441,9 +447,17 @@ describe('POST /api/brands/:domain/properties/parse', () => {
   // ─── URL fetch path coverage ────────────────────────────────────────
 
   // Build a Response-like object with a streamable body.
-  function streamingResponse(opts: { ok?: boolean; status?: number; body?: string | null }) {
-    const { ok = true, status = 200, body } = opts;
-    if (body === null) return { ok, status, body: null } as unknown as Response;
+  function streamingResponse(opts: {
+    ok?: boolean;
+    status?: number;
+    body?: string | null;
+    headers?: Record<string, string>;
+  }) {
+    const { ok = true, status = 200, body, headers = {} } = opts;
+    const respHeaders = new Headers(headers);
+    if (body === null) {
+      return { ok, status, body: null, headers: respHeaders } as unknown as Response;
+    }
     const encoder = new TextEncoder();
     const bytes = encoder.encode(body ?? '');
     const stream = new ReadableStream<Uint8Array>({
@@ -452,7 +466,7 @@ describe('POST /api/brands/:domain/properties/parse', () => {
         controller.close();
       },
     });
-    return { ok, status, body: stream } as unknown as Response;
+    return { ok, status, body: stream, headers: respHeaders } as unknown as Response;
   }
 
   it('happy URL path streams body and parses identifiers', async () => {
@@ -513,6 +527,40 @@ describe('POST /api/brands/:domain/properties/parse', () => {
     expect(res.status).toBe(400);
     expect(res.body.error).toBe('Could not fetch URL');
     expect(res.body.error).not.toMatch(/ECONNREFUSED|10\.0\.0/);
+  });
+
+  it.each(['gzip', 'br', 'deflate', 'GZIP'] as const)(
+    'rejects URL responses that ship with Content-Encoding=%s (compression-bomb defense)',
+    async (encoding) => {
+      mocks.validateFetchUrl.mockResolvedValueOnce(undefined);
+      // Server ignores our `Accept-Encoding: identity` request and ships
+      // a compressed response. The route must reject before reading.
+      mocks.safeFetch.mockResolvedValueOnce(
+        streamingResponse({ body: 'real.example', headers: { 'content-encoding': encoding } }),
+      );
+
+      const res = await request(app)
+        .post(`/api/brands/${TEST_DOMAIN}/properties/parse`)
+        .send({ input: 'https://example.org/list.csv', input_type: 'url' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/content-encoding/i);
+      expect(mocks.anthropicCreate).not.toHaveBeenCalled();
+    },
+  );
+
+  it('accepts an explicit Content-Encoding: identity response', async () => {
+    mocks.validateFetchUrl.mockResolvedValueOnce(undefined);
+    mocks.safeFetch.mockResolvedValueOnce(
+      streamingResponse({ body: 'a.example', headers: { 'content-encoding': 'identity' } }),
+    );
+    mocks.anthropicCreate.mockResolvedValueOnce(toolUseResponse({ properties: [] }));
+
+    const res = await request(app)
+      .post(`/api/brands/${TEST_DOMAIN}/properties/parse`)
+      .send({ input: 'https://example.org/list.csv', input_type: 'url' });
+
+    expect(res.status).toBe(200);
   });
 
   it('sends Accept-Encoding: identity to disable compression auto-decode (compression-bomb defense)', async () => {


### PR DESCRIPTION
Followups to #3396 from the post-merge expert reviews.

## What ships

**1. Strict `Content-Encoding` check on the parse URL fetch path** (`server/src/routes/brand-feeds.ts`)

The compression-bomb defense in #3396 sends `Accept-Encoding: identity` to disable undici's auto-decompression. The expert review flagged a residual gap: a hostile server can ignore that header and ship `gzip`/`br`/`deflate` anyway — undici still decodes, and the 1MB streaming cap measures decompressed bytes, leaving a high-ratio bomb path open.

Now rejects any response where `Content-Encoding` is set to anything other than `identity` (or absent) before reading the body.

**2. PID + timestamp suffixed test fixture IDs** (`server/tests/integration/brand-properties-parse.test.ts`)

Hardcoded constants like `org_parse_owner_001` collide with sibling integration suites under parallel execution. Suffix with `process.pid + Date.now()` so each worker gets isolated rows. Suggested by the nodejs-testing-expert pass on #3396.

## Tests

31 cases passing (was 26). 5 new:
- 4 cases for `Content-Encoding ∈ {gzip, br, deflate, GZIP}` rejection (case-insensitive)
- 1 case for explicit `Content-Encoding: identity` acceptance

## Followups not in scope (will file separately)

- **DNS-rebind TOCTOU** in `safeFetch` — between `validateFetchUrl` (DNS resolve #1) and `fetch()` (DNS resolve #2), a short-TTL hostile DNS record can return public→private. Cross-cutting fix requires a custom undici dispatcher; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)