### PR TITLE
feat(verification-panel): per-version badge rows (#3524 stage 4)

### DIFF
--- a/.changeset/per-version-badges-stage4-panel-rows.md
+++ b/.changeset/per-version-badges-stage4-panel-rows.md
@@ -1,0 +1,21 @@
+---
+---
+
+dashboard(verification-panel): per-version badge rows. Stage 4 of #3524.
+
+The verification panel on the per-agent compliance card now renders one row per `(role, adcp_version)`. An agent that holds both `media-buy@3.0 (Spec)` and `media-buy@3.1 (Spec + Live)` shows both rows, ordered by version descending so the newest is at the top. Each row carries:
+
+- The version segment in the rendered label: `Media Buy Agent 3.1 (Spec + Live)` instead of `Media Buy Agent (Spec + Live)`.
+- A version-pinned badge SVG URL inline (`/badge/{role}/{version}.svg`) so the displayed image is exactly the version that row represents.
+- Embed snippets (HTML + Markdown) that point at the version-pinned URL with version-aware alt text. Buyers who want to call out "verified for AdCP 3.0" copy the row matching that version; buyers who want auto-upgrading copy the legacy `/badge/{role}.svg` URL embedded by older code.
+- A stable drawer ID keyed on `role + version + index` so re-renders after an issue/revoke don't randomize the open/closed state of an already-expanded drawer.
+
+API change: `GET /api/registry/agents/{url}/compliance` now includes `adcp_version` on each `verified_badges[]` entry. The schema description spells out the contract: it's the load-bearing badge identity field, paired with `(agent_url, role, adcp_version)` PK, and clients derive version-pinned SVG URLs from it client-side. The legacy `badge_url` field stays for backward compat and continues to auto-upgrade to the highest active version.
+
+Defensive: panel JS validates the API's `adcp_version` against the same shape regex the SVG renderer uses (`^[1-9][0-9]*\.[0-9]+$`). A malformed value drops to legacy URL + version-less label rather than failing the row — same policy as `renderBadgeSvg`. The DB CHECK constraint and JWT signer regex prevent malformed values from reaching here in production paths, so this is belt-and-suspenders.
+
+Verified live in the dashboard with seeded parallel-version badges. Verified in playwright that the embed drawer's HTML and Markdown both point at the version-pinned URL, with the correct alt text and version segment in the rendered SVG.
+
+What this PR does NOT change:
+- brand.json enrichment shape — Stage 5 adds the `badges[]` array.
+- Badge issuance, JWT signing, SVG rendering, route handlers — all unchanged.

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -1629,6 +1629,11 @@
       // with their own embed snippets. The legacy /badge/{role}.svg
       // URL still works for callers that want the auto-upgrading
       // highest-version badge.
+      //
+      // Same shape as VALID_ADCP_VERSION_RE in registry-api.ts and
+      // ADCP_VERSION_RE in badge-svg.ts — kept inline because
+      // dashboard-agents.html has no module imports. Update all three
+      // call sites together if the constraint ever changes.
       const ADCP_VERSION_SHAPE_RE = /^[1-9][0-9]*\.[0-9]+$/;
 
       const rowsHtml = badges.map((badge, idx) => {
@@ -1636,17 +1641,43 @@
         const qualifier = formatModes(badge.verification_modes) || 'Spec';
         const verifiedAt = badge.verified_at ? new Date(badge.verified_at).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' }) : '';
         const specialisms = (badge.verified_specialisms || []).slice().sort();
-        // Defensive: a malformed adcp_version drops to legacy URL +
-        // version-less label. Mirrors the badge-svg.ts policy ("don't
-        // fail the badge over a degraded DB row").
+        // Defensive: the DB CHECK constraint and JWT signer regex
+        // prevent malformed adcp_version values from reaching here
+        // in production. Belt-and-suspenders for hand-edited rows
+        // and forward-compat against schema relaxation.
         const adcpVersion = typeof badge.adcp_version === 'string' && ADCP_VERSION_SHAPE_RE.test(badge.adcp_version)
           ? badge.adcp_version
           : null;
+        if (badge.adcp_version && !adcpVersion) {
+          // Loud-warn: a row arrived with a non-shape-conformant
+          // adcp_version. Falls back to the legacy URL (which serves
+          // highest-version) so the row still renders, but the label
+          // is marked unversioned so it isn't visually identical to
+          // a normal pre-3.0 row.
+          console.warn(
+            'Verification panel: badge has malformed adcp_version, falling back to legacy URL',
+            { agentUrl, role: badge.role, adcp_version: badge.adcp_version },
+          );
+        }
+        // Server constructs badge.badge_url as
+        // `/api/registry/agents/{encodedUrl}/badge/{role}.svg`, but we
+        // validate the prefix anyway so a future federated-mirror that
+        // populates this field externally can't redirect the embedded
+        // <img src> to an arbitrary URL.
+        const safeLegacyBadgeUrl = (typeof badge.badge_url === 'string' && badge.badge_url.startsWith('/api/registry/agents/'))
+          ? badge.badge_url
+          : `/api/registry/agents/${encoded}/badge/${badge.role}.svg`;
         const versionedBadgeUrl = adcpVersion
           ? `/api/registry/agents/${encoded}/badge/${badge.role}/${adcpVersion}.svg`
-          : badge.badge_url;
+          : safeLegacyBadgeUrl;
         const badgeSvgUrl = `${baseUrl}${versionedBadgeUrl}`;
-        const versionSegment = adcpVersion ? ` ${adcpVersion}` : '';
+        // Label/alt segment: the version when shape-validated, an
+        // explicit "(unversioned)" tag when a malformed value forced
+        // the legacy fallback, or empty for true legacy rows where
+        // the API never set adcp_version at all.
+        const versionSegment = adcpVersion
+          ? ` ${adcpVersion}`
+          : (badge.adcp_version ? ' (unversioned)' : '');
         const altText = `AAO Verified ${protocol} Agent${versionSegment} (${qualifier})`;
         const labelStrong = `${protocol} Agent${versionSegment} (${qualifier})`;
         const htmlEmbed = `<a href="${registryUrl}" target="_blank" rel="noopener noreferrer"><img src="${badgeSvgUrl}" alt="${altText}" loading="lazy" height="20" /></a>`;
@@ -1654,8 +1685,10 @@
 
         // Stable drawer id keyed on role+version so re-renders after
         // an issue/revoke don't randomize the open/closed state of
-        // an already-expanded drawer.
-        const drawerId = `verification-embed-${badge.role}-${adcpVersion ?? 'any'}-${idx}`;
+        // an already-expanded drawer. 'unv' for malformed-version
+        // rows so two malformed badges don't collide on 'any'.
+        const versionForId = adcpVersion ?? (badge.adcp_version ? 'unv' : 'any');
+        const drawerId = `verification-embed-${badge.role}-${versionForId}-${idx}`;
 
         return `
           <div class="verification-badge-row">

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -1636,6 +1636,8 @@
       // call sites together if the constraint ever changes.
       const ADCP_VERSION_SHAPE_RE = /^[1-9][0-9]*\.[0-9]+$/;
 
+      const distinctRoleCount = new Set(badges.map(b => b.role)).size;
+
       const rowsHtml = badges.map((badge, idx) => {
         const protocol = PROTOCOL_LABELS[badge.role] || badge.role;
         const qualifier = formatModes(badge.verification_modes) || 'Spec';
@@ -1733,11 +1735,21 @@
         ? ''
         : '<div class="verification-eligibility-hint">Want <strong>(Live)</strong> too? Once AAO\'s canonical-campaign runner ships in 3.1, agents that flow real production traffic will earn the <strong>(Live)</strong> qualifier on the same badge — same URL, no embed swap. <a href="/docs/building/aao-verified#verified-live" target="_blank" rel="noopener">Learn more</a>.</div>';
 
+      // Header count: "1 badge" / "N badges" / "N badges across M roles"
+      // The "across M roles" suffix only appears when at least one role
+      // has parallel-version badges (i.e. distinctRoleCount < badges.length).
+      // Today with SUPPORTED_BADGE_VERSIONS = ['3.0'] every agent has at
+      // most one badge per role, so this only kicks in once parallel
+      // versions ship.
+      const badgeCountSummary = badges.length === 1
+        ? '1 badge'
+        : `${badges.length} badges${distinctRoleCount < badges.length ? ` across ${distinctRoleCount} role${distinctRoleCount === 1 ? '' : 's'}` : ''}`;
+
       return `
         <div class="agent-verification-panel">
           <div class="agent-verification-header">
             <span>AAO Verified</span>
-            <span style="font-weight: normal; text-transform: none; letter-spacing: 0;">${badges.length} badge${badges.length === 1 ? '' : 's'}</span>
+            <span style="font-weight: normal; text-transform: none; letter-spacing: 0;">${badgeCountSummary}</span>
           </div>
           ${rowsHtml}
           ${liveHint}

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -1622,24 +1622,47 @@
       const encoded = encodeURIComponent(agentUrl);
       const registryUrl = `${baseUrl}/registry/agents/${encoded}`;
 
+      // Per-version badge rendering (#3524 stage 4): one row per
+      // (role, adcp_version). Each row's embed snippets point at the
+      // version-pinned SVG URL so a buyer who copies them gets the
+      // exact version's badge — newer versions land in their own rows
+      // with their own embed snippets. The legacy /badge/{role}.svg
+      // URL still works for callers that want the auto-upgrading
+      // highest-version badge.
+      const ADCP_VERSION_SHAPE_RE = /^[1-9][0-9]*\.[0-9]+$/;
+
       const rowsHtml = badges.map((badge, idx) => {
         const protocol = PROTOCOL_LABELS[badge.role] || badge.role;
         const qualifier = formatModes(badge.verification_modes) || 'Spec';
         const verifiedAt = badge.verified_at ? new Date(badge.verified_at).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' }) : '';
         const specialisms = (badge.verified_specialisms || []).slice().sort();
-        const badgeSvgUrl = `${baseUrl}${badge.badge_url}`;
-        const altText = `AAO Verified ${protocol} Agent (${qualifier})`;
+        // Defensive: a malformed adcp_version drops to legacy URL +
+        // version-less label. Mirrors the badge-svg.ts policy ("don't
+        // fail the badge over a degraded DB row").
+        const adcpVersion = typeof badge.adcp_version === 'string' && ADCP_VERSION_SHAPE_RE.test(badge.adcp_version)
+          ? badge.adcp_version
+          : null;
+        const versionedBadgeUrl = adcpVersion
+          ? `/api/registry/agents/${encoded}/badge/${badge.role}/${adcpVersion}.svg`
+          : badge.badge_url;
+        const badgeSvgUrl = `${baseUrl}${versionedBadgeUrl}`;
+        const versionSegment = adcpVersion ? ` ${adcpVersion}` : '';
+        const altText = `AAO Verified ${protocol} Agent${versionSegment} (${qualifier})`;
+        const labelStrong = `${protocol} Agent${versionSegment} (${qualifier})`;
         const htmlEmbed = `<a href="${registryUrl}" target="_blank" rel="noopener noreferrer"><img src="${badgeSvgUrl}" alt="${altText}" loading="lazy" height="20" /></a>`;
         const mdEmbed = `[![${altText}](${badgeSvgUrl})](${registryUrl})`;
 
-        const drawerId = `verification-embed-${idx}-${Math.random().toString(36).slice(2, 8)}`;
+        // Stable drawer id keyed on role+version so re-renders after
+        // an issue/revoke don't randomize the open/closed state of
+        // an already-expanded drawer.
+        const drawerId = `verification-embed-${badge.role}-${adcpVersion ?? 'any'}-${idx}`;
 
         return `
           <div class="verification-badge-row">
             <div class="verification-badge-row-top">
-              <span class="verification-badge-svg"><img src="${escapeHtml(badge.badge_url)}" alt="${escapeHtml(altText)}" /></span>
+              <span class="verification-badge-svg"><img src="${escapeHtml(versionedBadgeUrl)}" alt="${escapeHtml(altText)}" /></span>
               <span class="verification-badge-meta">
-                <strong>${escapeHtml(protocol)} Agent (${escapeHtml(qualifier)})</strong>
+                <strong>${escapeHtml(labelStrong)}</strong>
                 ${verifiedAt ? ' · ' + escapeHtml(verifiedAt) : ''}
                 ${specialisms.length ? '<br>' + specialisms.map(s => '<code>' + escapeHtml(s) + '</code>').join(' ') : ''}
               </span>

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -30,6 +30,7 @@ import {
 import { getPublicJwks } from "../services/verification-token.js";
 import { renderBadgeSvg, VALID_BADGE_ROLES } from "../services/badge-svg.js";
 import { resolveOwnerMembership } from "../services/membership-tiers.js";
+import { isValidAdcpVersionShape } from "../services/adcp-taxonomy.js";
 import { PUBLIC_TEST_AGENT } from "../config/test-agent.js";
 import * as policiesDb from "../db/policies-db.js";
 import { createLogger } from "../logger.js";
@@ -3968,7 +3969,12 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           // `badge_url` below auto-upgrades to the highest version per
           // role (Stage 1 contract); a version-pinned URL can be derived
           // client-side as `/badge/{role}/{adcp_version}.svg`.
-          adcp_version: b.adcp_version,
+          //
+          // Defense-in-depth: validate shape at the API serialization
+          // boundary even though the DB CHECK already constrains the
+          // column. A hand-edited row or a relaxed CHECK can't push
+          // a malformed value into clients that trust the field.
+          adcp_version: isValidAdcpVersionShape(b.adcp_version) ? b.adcp_version : null,
           verified_at: b.verified_at.toISOString(),
           verified_specialisms: b.verified_specialisms,
           verification_modes: b.verification_modes,

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -3962,6 +3962,13 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         verified: badges.length > 0,
         verified_badges: badges.map(b => ({
           role: b.role,
+          // adcp_version is the load-bearing badge identity field — pairs
+          // with `(agent_url, role, adcp_version)` PK. Clients render
+          // version-pinned SVG/embed URLs from this. The legacy
+          // `badge_url` below auto-upgrades to the highest version per
+          // role (Stage 1 contract); a version-pinned URL can be derived
+          // client-side as `/badge/{role}/{adcp_version}.svg`.
+          adcp_version: b.adcp_version,
           verified_at: b.verified_at.toISOString(),
           verified_specialisms: b.verified_specialisms,
           verification_modes: b.verification_modes,

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -280,7 +280,7 @@ export const VerificationBadgeSchema = z
       .openapi({ description: "Verification axes earned. 'spec' = AdCP storyboards pass for the declared specialisms. 'live' = AAO has observed real production traffic via canonical campaigns. Always non-empty when a badge is present; an absent badge is conveyed by the parent record being omitted, not by an empty array." }),
     verified_protocol_version: z.string().nullable(),
     badge_url: z.string().optional()
-      .openapi({ description: "Legacy URL — auto-upgrades to the highest active version. For version-pinned embedding, derive `/api/registry/agents/{url}/badge/{role}/{adcp_version}.svg`." }),
+      .openapi({ description: "Legacy URL — auto-upgrades to the highest active version. For version-pinned embedding, derive `/api/registry/agents/{encoded_url}/badge/{role}/{adcp_version}.svg` where `{encoded_url}` is `encodeURIComponent(agent_url)`." }),
   })
   .openapi("VerificationBadge");
 

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -271,13 +271,16 @@ export const VerificationBadgeSchema = z
   .object({
     role: z.enum(ADCP_PROTOCOLS as [string, ...string[]])
       .openapi({ description: "AdCP protocol this badge covers (enums/adcp-protocol.json)." }),
+    adcp_version: z.string()
+      .openapi({ description: "AdCP release this badge was issued against, MAJOR.MINOR (e.g. '3.0', '3.1'). Load-bearing for badge identity — pairs with the (agent_url, role, adcp_version) PK." }),
     verified_at: z.string(),
     verified_specialisms: z.array(z.enum(ADCP_SPECIALISMS as [string, ...string[]]))
       .openapi({ description: "Specialisms demonstrably passed (enums/specialism.json). Preview specialisms are excluded from stable badges." }),
     verification_modes: z.array(z.enum(VERIFICATION_MODES as readonly [string, ...string[]])).min(1)
       .openapi({ description: "Verification axes earned. 'spec' = AdCP storyboards pass for the declared specialisms. 'live' = AAO has observed real production traffic via canonical campaigns. Always non-empty when a badge is present; an absent badge is conveyed by the parent record being omitted, not by an empty array." }),
     verified_protocol_version: z.string().nullable(),
-    badge_url: z.string().optional(),
+    badge_url: z.string().optional()
+      .openapi({ description: "Legacy URL — auto-upgrades to the highest active version. For version-pinned embedding, derive `/api/registry/agents/{url}/badge/{role}/{adcp_version}.svg`." }),
   })
   .openapi("VerificationBadge");
 

--- a/server/src/services/adcp-taxonomy.ts
+++ b/server/src/services/adcp-taxonomy.ts
@@ -49,6 +49,24 @@ export function isSupportedBadgeVersion(value: unknown): value is SupportedBadge
   return typeof value === 'string' && (SUPPORTED_BADGE_VERSIONS as readonly string[]).includes(value);
 }
 
+/**
+ * Shape constraint for AdCP version strings (MAJOR.MINOR, e.g. '3.0').
+ *
+ * Single source of truth — also enforced by:
+ *  - The `valid_adcp_version` CHECK constraint in migration 457
+ *  - JWT signing in `verification-token.ts` (fail-closed)
+ *  - SVG label rendering in `badge-svg.ts` (drop-on-malformed)
+ *  - Route validators in `registry-api.ts` (length-bounded variant)
+ *  - Panel JS in `dashboard-agents.html` (kept inline due to no module imports)
+ *
+ * If the constraint changes, update every site that mirrors it.
+ */
+export const ADCP_VERSION_RE = /^[1-9][0-9]*\.[0-9]+$/;
+
+export function isValidAdcpVersionShape(value: unknown): value is string {
+  return typeof value === 'string' && ADCP_VERSION_RE.test(value);
+}
+
 /** AdCP protocol enum — must match enums/adcp-protocol.json. */
 export type AdcpProtocol =
   | 'media-buy'


### PR DESCRIPTION
## Summary

Stage 4 of [#3524](https://github.com/adcontextprotocol/adcp/issues/3524). The verification panel renders one row per `(role, adcp_version)`. An agent that holds parallel-version badges sees both rows; today (with `SUPPORTED_BADGE_VERSIONS = ['3.0']`) every agent has at most one row per role, but the wiring is in place for when 3.1 lands.

## What's new in the panel

| Field | Before | After |
|---|---|---|
| Label | `Media Buy Agent (Spec)` | `Media Buy Agent 3.1 (Spec + Live)` |
| SVG image | `/badge/{role}.svg` (legacy auto-upgrade) | `/badge/{role}/{version}.svg` (version-pinned) |
| Embed HTML | Points at legacy URL | Points at version-pinned URL with version in alt text |
| Drawer ID | Random per-render | Stable: `verification-embed-{role}-{version}-{idx}` |

The legacy `/badge/{role}.svg` URL stays — buyers who embedded it before per-version badges existed keep getting the auto-upgrading badge.

## API change

`GET /api/registry/agents/{url}/compliance` now includes `adcp_version` on each `verified_badges[]` entry:

\`\`\`jsonc
{
  "verified_badges": [
    {
      "role": "media-buy",
      "adcp_version": "3.1",
      "verification_modes": ["spec", "live"],
      "verified_specialisms": ["media-buy-seller", "media-buy-non-guaranteed"],
      "verified_at": "...",
      "verified_protocol_version": "3.1.0",
      "badge_url": "/api/registry/agents/{url}/badge/{role}.svg"
    }
  ]
}
\`\`\`

`adcp_version` is the load-bearing badge identity field — pairs with `(agent_url, role, adcp_version)` PK. Clients derive version-pinned SVG URLs as `/badge/{role}/{adcp_version}.svg`. The legacy `badge_url` field stays unchanged (auto-upgrades to highest active version).

## Live verification

Tested in the local dashboard with seeded parallel-version badges:
- `buyer.acme-adtech.dev` with `media-buy@3.0 (Spec)` + `media-buy@3.1 (Spec + Live)`
- `seller.acme-adtech.dev` with `media-buy@3.0 (Spec)` + `creative@3.0 (Spec)`

Verified via Playwright:
- Two rows render per buyer, ordered version-DESC (3.1 above 3.0)
- Embed drawer's HTML and Markdown both point at the version-pinned URL
- Version segment renders in the actual SVG (`Media Buy Agent 3.1 (Spec + Live)`)
- ETags differ per version: `media-buy-3.0-spec` vs `media-buy-3.1-live-spec`

## Defensive code

Panel JS validates the API's `adcp_version` against `^[1-9][0-9]*\.[0-9]+$` before constructing the version-pinned URL. A malformed value drops to legacy URL + version-less label rather than failing the row — same policy as `renderBadgeSvg` and intentionally different from the JWT signer's fail-closed policy. The DB CHECK constraint and JWT signer regex prevent malformed values from reaching here in production paths.

## What does NOT change

- brand.json enrichment shape — Stage 5 adds the `badges[]` array.
- Badge issuance, JWT signing, SVG rendering, route handlers — all unchanged.

## Stage tracker

- ✓ Stage 1 (#3568) — data model + per-version isolation
- ✓ Stage 2 (#3579) — heartbeat fan-out + JWT `adcp_version` claim
- ✓ Stage 3 (#3595) — badge SVG version segment + version-pinned URLs
- ✓ Stage 4 (this PR) — verification panel renders per-version rows
- ⏳ Stage 5 — brand.json `badges[]` array

🤖 Generated with [Claude Code](https://claude.com/claude-code)