### PR TITLE
feat(verification): brand.json + /verification per-version detail (#3524 stage 5)

### DIFF
--- a/.changeset/per-version-badges-stage5-brand-json.md
+++ b/.changeset/per-version-badges-stage5-brand-json.md
@@ -1,0 +1,46 @@
+---
+---
+
+backend(verification): brand.json + /verification carry per-version badge detail. Stage 5 of #3524 — the final stage.
+
+## What ships
+
+`aao_verification` blocks served via brand.json enrichment now include a `badges[]` array — one entry per `(role, adcp_version)` with full per-version detail:
+
+\`\`\`jsonc
+"aao_verification": {
+  "verified": true,
+  "verified_at": "2026-04-30T...",
+  "badges": [
+    { "role": "media-buy", "adcp_version": "3.1", "verification_modes": ["spec", "live"], "verified_at": "..." },
+    { "role": "media-buy", "adcp_version": "3.0", "verification_modes": ["spec"], "verified_at": "..." }
+  ],
+  "roles": ["media-buy"],
+  "modes_by_role": { "media-buy": ["spec", "live"] }
+}
+\`\`\`
+
+`badges[]` is the canonical forward-compat shape (Q6 of [#3524's resolved decisions](https://github.com/adcontextprotocol/adcp/issues/3524#issuecomment-4348265184)). One entry per parallel-version badge; preserved order matches the API's version-DESC sort. Adding future axes to a badge (e.g. a third verification mode) doesn't change the array shape.
+
+`roles[]` and `modes_by_role` are kept as deprecated aliases for one release. Their values reflect "the current best mark" — highest-version badge per role. Clients reading them today keep working when parallel-version badges ship; new clients should read `badges[]` for the full picture. **Removal target: AdCP 4.0.**
+
+## /verification endpoint
+
+`GET /api/registry/agents/{url}/verification` (decentralized public verifier surface) now includes `adcp_version` on each `badges[]` entry. Validated through the same shape regex the API uses for the `/compliance` endpoint (defense in depth — a poisoned DB row returns `null` rather than passing through unchecked).
+
+## What this PR does NOT change
+
+- `verified_at` semantics: still the most-recent-state-change timestamp across any badge.
+- `verified` boolean: still true when any active badge exists.
+- Wire format on the badge JWTs (already carries `adcp_version` via Stage 2).
+- Badge issuance, heartbeat fan-out, SVG rendering, panel UX — all upstream of brand.json enrichment.
+
+## Stage tracker
+
+- ✓ Stage 1 (#3568) — data model + per-version isolation
+- ✓ Stage 2 (#3579) — heartbeat fan-out + JWT `adcp_version` claim
+- ✓ Stage 3 (#3595) — badge SVG version segment + version-pinned URLs
+- ✓ Stage 4 (#3600) — verification panel renders per-version rows
+- ✓ Stage 5 (this PR) — brand.json + /verification carry per-version detail
+
+#3524 is fully shipped after this PR. Deferred panel polish tracked in #3603.

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -2709,8 +2709,42 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
   });
 
   /**
+   * Shape contract for the `aao_verification` block this enrichment
+   * appends to brand.json agent entries. Public buyer-facing surface;
+   * documented here so future contributors don't drift the wire format.
+   *
+   *   `verified`         — boolean: any active badge exists
+   *   `verified_at`      — ISO timestamp of the most-recent state change
+   *                        across any badge
+   *   `badges[]`         — canonical per-(role, version) detail. Order is
+   *                        preserved from the underlying API's
+   *                        `adcp_version DESC, role` sort. Adding future
+   *                        axes won't change the array shape (#3524 Q6).
+   *   `roles[]`          — DEPRECATED alias: distinct roles, highest
+   *                        badge per role. Removal target: AdCP 4.0.
+   *   `modes_by_role`    — DEPRECATED alias: highest-version modes per
+   *                        role. Removal target: AdCP 4.0.
+   *   `deprecation_notice` — Travels with the data so long-tail crawlers
+   *                          see the warning even without release notes.
+   */
+  interface AaoVerificationBlock {
+    verified: true;
+    verified_at: string;
+    badges: Array<{
+      role: string;
+      adcp_version: string | null;
+      verification_modes: string[];
+      verified_at: string;
+    }>;
+    roles: string[];
+    modes_by_role: Record<string, string[]>;
+    deprecation_notice: string;
+  }
+
+  /**
    * Enrich brand.json agent entries with AAO verification status.
-   * Scans data for agent URLs and appends aao_verification where badges exist.
+   * Scans data for agent URLs and appends `aao_verification` (shape
+   * documented above as `AaoVerificationBlock`) where badges exist.
    */
   async function enrichBrandDataWithVerification(data: unknown): Promise<unknown> {
     if (!data || typeof data !== 'object') return data;
@@ -2751,9 +2785,11 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       if (typeof rec.url === 'string' && typeof rec.type === 'string') {
         const badges = badgeMap.get(rec.url as string);
         if (badges && badges.length > 0) {
-          // bulkGetActiveBadges already orders by adcp_version DESC
-          // numerically (Stage 1), so iterating in order gives us the
-          // newest version per role first.
+          // bulkGetActiveBadges orders by `agent_url, adcp_version DESC,
+          // role`, so for any given agent the first occurrence of each
+          // role in the iteration is the highest-version badge for that
+          // role. Roles can interleave (e.g. media-buy 3.1, creative
+          // 3.1, media-buy 3.0) — `if (!byRole.has)` picks correctly.
           const byRole = new Map<typeof badges[number]['role'], typeof badges[number]>();
           for (const badge of badges) {
             if (!byRole.has(badge.role)) byRole.set(badge.role, badge);
@@ -2761,16 +2797,18 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           const dedupedBadges = Array.from(byRole.values());
           // Per-version badges array — the canonical shape going forward.
           // One entry per (role, adcp_version), preserving the API's
-          // version-DESC ordering. Buyers consuming brand.json see the
-          // full version history; clients that only care about the
-          // current state read modes_by_role.
+          // version-DESC ordering. Defense-in-depth: gate adcp_version
+          // through the same shape regex used by /compliance and
+          // /verification — brand.json is the public buyer-facing
+          // surface, so any future code path that bypasses the DB CHECK
+          // (raw SQL backfill, restored snapshot) MUST NOT leak through.
           const badgesArray = badges.map(b => ({
             role: b.role,
-            adcp_version: b.adcp_version,
+            adcp_version: isValidAdcpVersionShape(b.adcp_version) ? b.adcp_version : null,
             verification_modes: b.verification_modes,
             verified_at: b.verified_at.toISOString(),
           }));
-          rec.aao_verification = {
+          const aaoVerification: AaoVerificationBlock = {
             verified: true,
             // Newest verification across any (role, version) — the most
             // recent state change for the agent.
@@ -2779,14 +2817,20 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
             // #3524's resolved decisions, this is the forward-compat
             // shape — adding future axes won't change the array.
             badges: badgesArray,
-            // Deprecated alias kept for one release. Highest-version
-            // badge per role; reflects "the current best mark." Clients
-            // reading modes_by_role today keep working when parallel-
-            // version badges ship; clients reading badges get the full
-            // picture. Removal target: AdCP 4.0.
+            // Deprecated aliases kept for one release. Highest-version
+            // badge per role; reflects "the current best mark." A
+            // buyer pinned to AdCP 3.0 reading `modes_by_role: { x:
+            // ['spec', 'live'] }` could wrongly conclude their 3.0
+            // traffic gets Live when in fact only 3.1 has Live. The
+            // deprecation_notice ships alongside the data so a long-
+            // tail crawler that doesn't track release notes still sees
+            // the warning. Removal target: AdCP 4.0 (≥6 months from
+            // this PR's merge per the cadence policy in #2359).
             roles: dedupedBadges.map(b => b.role),
             modes_by_role: Object.fromEntries(dedupedBadges.map(b => [b.role, b.verification_modes])),
+            deprecation_notice: 'roles[] and modes_by_role reflect the highest-version badge per role only. A buyer pinned to a specific AdCP version SHOULD read badges[] and filter by adcp_version. Both fields will be removed in AdCP 4.0.',
           };
+          rec.aao_verification = aaoVerification;
         }
       }
       if (rec.agents && Array.isArray(rec.agents)) rec.agents.forEach(enrichAgentEntries);

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -2751,25 +2751,41 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       if (typeof rec.url === 'string' && typeof rec.type === 'string') {
         const badges = badgeMap.get(rec.url as string);
         if (badges && badges.length > 0) {
-          // Once an agent holds parallel-version badges (Stage 2+),
-          // bulkGetActiveBadges returns multiple rows per role. Dedupe
-          // here by role, keeping the highest-version badge — that's
-          // what the Q3 decision says the public mark should reflect.
           // bulkGetActiveBadges already orders by adcp_version DESC
-          // numerically, so the first row per role is the highest.
+          // numerically (Stage 1), so iterating in order gives us the
+          // newest version per role first.
           const byRole = new Map<typeof badges[number]['role'], typeof badges[number]>();
           for (const badge of badges) {
             if (!byRole.has(badge.role)) byRole.set(badge.role, badge);
           }
           const dedupedBadges = Array.from(byRole.values());
+          // Per-version badges array — the canonical shape going forward.
+          // One entry per (role, adcp_version), preserving the API's
+          // version-DESC ordering. Buyers consuming brand.json see the
+          // full version history; clients that only care about the
+          // current state read modes_by_role.
+          const badgesArray = badges.map(b => ({
+            role: b.role,
+            adcp_version: b.adcp_version,
+            verification_modes: b.verification_modes,
+            verified_at: b.verified_at.toISOString(),
+          }));
           rec.aao_verification = {
             verified: true,
-            roles: dedupedBadges.map(b => b.role),
-            // Per-role verification axes. ['spec'] today; will include
-            // 'live' when canonical campaigns are healthy. Stage 5
-            // adds a richer `badges[]` array with per-version detail.
-            modes_by_role: Object.fromEntries(dedupedBadges.map(b => [b.role, b.verification_modes])),
+            // Newest verification across any (role, version) — the most
+            // recent state change for the agent.
             verified_at: dedupedBadges[0].verified_at.toISOString(),
+            // Canonical: full per-(role, version) detail. Per Q6 of
+            // #3524's resolved decisions, this is the forward-compat
+            // shape — adding future axes won't change the array.
+            badges: badgesArray,
+            // Deprecated alias kept for one release. Highest-version
+            // badge per role; reflects "the current best mark." Clients
+            // reading modes_by_role today keep working when parallel-
+            // version badges ship; clients reading badges get the full
+            // picture. Removal target: AdCP 4.0.
+            roles: dedupedBadges.map(b => b.role),
+            modes_by_role: Object.fromEntries(dedupedBadges.map(b => [b.role, b.verification_modes])),
           };
         }
       }
@@ -4057,6 +4073,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         verified: badges.length > 0,
         badges: badges.map(b => ({
           role: b.role,
+          adcp_version: isValidAdcpVersionShape(b.adcp_version) ? b.adcp_version : null,
           verified_at: b.verified_at.toISOString(),
           verified_specialisms: b.verified_specialisms,
           verification_modes: b.verification_modes,


### PR DESCRIPTION
## Summary

**Final stage of [#3524](https://github.com/adcontextprotocol/adcp/issues/3524).** brand.json enrichment and the public `/verification` endpoint now carry per-version badge detail.

## What ships

### brand.json `aao_verification` block

\`\`\`jsonc
"aao_verification": {
  "verified": true,
  "verified_at": "2026-04-30T...",
  "badges": [
    { "role": "media-buy", "adcp_version": "3.1", "verification_modes": ["spec", "live"], "verified_at": "..." },
    { "role": "media-buy", "adcp_version": "3.0", "verification_modes": ["spec"], "verified_at": "..." }
  ],
  "roles": ["media-buy"],
  "modes_by_role": { "media-buy": ["spec", "live"] }
}
\`\`\`

\`badges[]\` is the canonical forward-compat shape (Q6 of the [resolved decisions](https://github.com/adcontextprotocol/adcp/issues/3524#issuecomment-4348265184)). One entry per parallel-version badge; preserved order matches the API's version-DESC sort. Adding future axes won't change the array shape.

\`roles[]\` and \`modes_by_role\` are kept as **deprecated aliases for one release**. Values reflect "the current best mark" — highest-version badge per role. Clients reading them today keep working when parallel-version badges ship. **Removal target: AdCP 4.0.**

### /verification endpoint

\`GET /api/registry/agents/{url}/verification\` (the decentralized public verifier surface) now includes \`adcp_version\` on each \`badges[]\` entry. Validated through the same shape regex the \`/compliance\` endpoint uses for defense in depth — a poisoned DB row returns \`null\` rather than passing through unchecked.

## Live verification

Tested locally with seeded parallel-version badges:

\`\`\`bash
$ curl /api/registry/agents/https%3A%2F%2Fbuyer.acme-adtech.dev/verification | jq .badges
[
  { "role": "media-buy", "adcp_version": "3.1", "verification_modes": ["spec","live"], ... },
  { "role": "media-buy", "adcp_version": "3.0", "verification_modes": ["spec"], ... }
]
\`\`\`

## What this PR does NOT change

- \`verified_at\` semantics — still the most-recent-state-change timestamp across any badge
- \`verified\` boolean — still true when any active badge exists
- Wire format on the badge JWTs (already carries \`adcp_version\` via Stage 2)
- Badge issuance, heartbeat fan-out, SVG rendering, panel UX — all upstream of brand.json enrichment

## Stage tracker (closing #3524)

- ✓ Stage 1 (#3568) — data model + per-version isolation
- ✓ Stage 2 (#3579) — heartbeat fan-out + JWT \`adcp_version\` claim
- ✓ Stage 3 (#3595) — badge SVG version segment + version-pinned URLs
- ✓ Stage 4 (#3600) — verification panel renders per-version rows
- ✓ Stage 5 (this PR) — brand.json + /verification carry per-version detail

After this PR merges, **#3524 is fully shipped**. Deferred panel polish (role grouping, "show all versions" disclosure when 4+ badges, PROTOCOL_LABELS audit) tracked in #3603.

## Test plan

- [x] 131/131 unit tests pass
- [x] TypeScript typecheck clean
- [x] Live `/verification` endpoint returns `adcp_version` on each badge with proper shape validation

Closes #3524.

🤖 Generated with [Claude Code](https://claude.com/claude-code)