### PR TITLE
feat(invites): emit person_events for membership invitation lifecycle (#3588)

### DIFF
--- a/.changeset/invite-lifecycle-events.md
+++ b/.changeset/invite-lifecycle-events.md
@@ -1,0 +1,4 @@
+---
+---
+
+Membership invitation lifecycle is now reflected on the recipient's `person_events` timeline. Sending, accepting, and revoking an invite each emit an event keyed to a stable `invite_id` UUID; an hourly sweep emits `invite_expired` events for invites that pass their `expires_at` without acceptance or revocation. A backfill script populates events for existing invites. Foundation for surfacing invite history in the admin UI and for Addie's memory layer (issue #3588).

--- a/server/src/addie/jobs/invite-expiry-sweep.ts
+++ b/server/src/addie/jobs/invite-expiry-sweep.ts
@@ -1,0 +1,118 @@
+/**
+ * Invite expiry sweep — emits invite_expired person_events for membership
+ * invites whose expires_at has passed and that were never accepted or revoked.
+ *
+ * Run hourly. Idempotent via the partial unique index on
+ * person_events (event_type, data->>'invite_id') from migration 458, so
+ * overlapping runs and crashed-mid-batch retries are safe.
+ *
+ * occurred_at is set to the invite's expires_at (logical truth — the moment
+ * the state actually became "expired"), not the wall clock when the sweep
+ * detected it. data.detected_at carries the wall-clock time for ops
+ * dashboards that need to track sweep latency.
+ */
+
+import { query } from '../../db/client.js';
+import { resolvePersonId } from '../../db/relationship-db.js';
+import { recordInviteEvent } from '../../db/person-events-db.js';
+import { logger } from '../../logger.js';
+
+const log = logger.child({ module: 'invite-expiry-sweep' });
+
+interface ExpiredInviteRow {
+  id: string;
+  token: string;
+  workos_organization_id: string;
+  lookup_key: string;
+  contact_email: string;
+  expires_at: Date;
+}
+
+export interface InviteExpirySweepResult {
+  candidates: number;
+  emitted: number;
+  resolveFailures: number;
+  recordFailures: number;
+}
+
+export async function runInviteExpirySweep(): Promise<InviteExpirySweepResult> {
+  const detectedAt = new Date();
+
+  const result = await query<ExpiredInviteRow>(
+    `SELECT mi.id, mi.token, mi.workos_organization_id, mi.lookup_key,
+            mi.contact_email, mi.expires_at
+     FROM membership_invites mi
+     WHERE mi.expires_at < NOW()
+       AND mi.accepted_at IS NULL
+       AND mi.revoked_at IS NULL
+       AND NOT EXISTS (
+         SELECT 1 FROM person_events pe
+         WHERE pe.event_type = 'invite_expired'
+           AND pe.data->>'invite_id' = mi.id::text
+       )
+     ORDER BY mi.expires_at ASC
+     LIMIT 500`
+  );
+
+  const candidates = result.rows.length;
+  if (candidates === 0) {
+    log.debug('Invite expiry sweep ran, no candidates');
+    return { candidates: 0, emitted: 0, resolveFailures: 0, recordFailures: 0 };
+  }
+
+  let emitted = 0;
+  let resolveFailures = 0;
+  let recordFailures = 0;
+
+  for (const row of result.rows) {
+    let personId: string;
+    try {
+      personId = await resolvePersonId({ email: row.contact_email });
+    } catch (err) {
+      resolveFailures += 1;
+      log.warn(
+        {
+          err,
+          inviteId: row.id,
+          orgId: row.workos_organization_id,
+          contactEmail: row.contact_email,
+        },
+        'Failed to resolve person for expired invite — will retry on next sweep'
+      );
+      continue;
+    }
+
+    try {
+      await recordInviteEvent(personId, 'invite_expired', row.id, {
+        occurredAt: row.expires_at,
+        data: {
+          token_prefix: row.token.slice(0, 8),
+          org_id: row.workos_organization_id,
+          lookup_key: row.lookup_key,
+          expired_at: row.expires_at.toISOString(),
+          detected_at: detectedAt.toISOString(),
+        },
+      });
+      emitted += 1;
+    } catch (err) {
+      recordFailures += 1;
+      log.warn(
+        {
+          err,
+          inviteId: row.id,
+          orgId: row.workos_organization_id,
+        },
+        'Failed to write invite_expired event — will retry on next sweep'
+      );
+    }
+  }
+
+  if (emitted > 0 || resolveFailures > 0 || recordFailures > 0) {
+    log.info(
+      { candidates, emitted, resolveFailures, recordFailures },
+      'Invite expiry sweep completed'
+    );
+  }
+
+  return { candidates, emitted, resolveFailures, recordFailures };
+}

--- a/server/src/addie/jobs/job-definitions.ts
+++ b/server/src/addie/jobs/job-definitions.ts
@@ -42,6 +42,7 @@ import { runComplianceHeartbeatJob } from './compliance-heartbeat.js';
 import { runShadowEvaluatorJob } from './shadow-evaluator.js';
 import { runKnowledgeGapCloserJob } from './knowledge-gap-closer.js';
 import { runEscalationTriageJob } from './escalation-triage.js';
+import { runInviteExpirySweep } from './invite-expiry-sweep.js';
 import { generateNetworkConsistencyReports } from '../../services/network-consistency-reporter.js';
 import { eventsDb } from '../../db/events-db.js';
 import { runEventRecapNudgeJob } from './event-recap-nudge.js';
@@ -150,6 +151,19 @@ export function registerAllJobs(): void {
     runner: runSummaryGeneratorJob,
     options: { batchSize: 10 },
     shouldLogResult: (r) => r.summariesGenerated > 0,
+  });
+
+  // Invite expiry sweep (#3588) — emits invite_expired person_events for
+  // membership invites whose expires_at has passed without accept/revoke.
+  // Runs hourly; idempotent via partial unique index on person_events.
+  jobScheduler.register({
+    name: 'invite-expiry-sweep',
+    description: 'Invite expiry sweep',
+    interval: { value: 60, unit: 'minutes' },
+    initialDelay: { value: 5, unit: 'minutes' },
+    runner: runInviteExpirySweep,
+    shouldLogResult: (r) =>
+      r.emitted > 0 || r.resolveFailures > 0 || r.recordFailures > 0,
   });
 
   // Channel privacy audit (#2849) — daily backstop for the send-time

--- a/server/src/db/membership-invites-db.ts
+++ b/server/src/db/membership-invites-db.ts
@@ -1,10 +1,13 @@
 import { randomBytes } from 'node:crypto';
 import { query } from './client.js';
 import { createLogger } from '../logger.js';
+import { resolvePersonId } from './relationship-db.js';
+import { recordInviteEvent } from './person-events-db.js';
 
 const logger = createLogger('membership-invites-db');
 
 export interface MembershipInvite {
+  id: string;
   token: string;
   workos_organization_id: string;
   lookup_key: string;
@@ -83,6 +86,17 @@ export async function createMembershipInvite(
     },
     'Membership invite created'
   );
+
+  await emitInviteEvent('invite_sent', created, {
+    occurredAt: created.created_at,
+    extra: {
+      lookup_key: created.lookup_key,
+      contact_name: created.contact_name,
+      expires_at: created.expires_at.toISOString(),
+      invited_by_user_id: created.invited_by_user_id,
+    },
+  });
+
   return created;
 }
 
@@ -143,6 +157,15 @@ export async function markMembershipInviteAccepted(
     },
     'Membership invite accepted'
   );
+
+  await emitInviteEvent('invite_accepted', updated, {
+    extra: {
+      lookup_key: updated.lookup_key,
+      accepted_by_user_id: acceptedByUserId,
+      invoice_id: invoiceId,
+    },
+  });
+
   return updated;
 }
 
@@ -150,6 +173,9 @@ export async function revokeMembershipInvite(
   token: string,
   revokedByUserId: string
 ): Promise<MembershipInvite | null> {
+  const existing = await getMembershipInviteByToken(token);
+  const previousStatus = existing ? inviteStatus(existing) : null;
+
   const result = await query<MembershipInvite>(
     `UPDATE membership_invites
      SET revoked_at = NOW(),
@@ -160,5 +186,59 @@ export async function revokeMembershipInvite(
      RETURNING *`,
     [token, revokedByUserId]
   );
-  return result.rows[0] || null;
+  const revoked = result.rows[0] || null;
+  if (!revoked) {
+    return null;
+  }
+
+  await emitInviteEvent('invite_revoked', revoked, {
+    extra: {
+      lookup_key: revoked.lookup_key,
+      revoked_by_user_id: revokedByUserId,
+      previous_status: previousStatus,
+    },
+  });
+
+  return revoked;
+}
+
+/**
+ * Resolve the recipient and emit a person_event for an invite lifecycle change.
+ *
+ * Person resolution failure must not abort the underlying invite operation —
+ * the membership_invites row is the source of truth; the event log is history.
+ * We log a warning and continue.
+ */
+async function emitInviteEvent(
+  eventType: 'invite_sent' | 'invite_accepted' | 'invite_revoked',
+  invite: MembershipInvite,
+  options: {
+    occurredAt?: Date;
+    extra: Record<string, unknown>;
+  }
+): Promise<void> {
+  try {
+    const personId = await resolvePersonId({
+      email: invite.contact_email,
+    });
+    await recordInviteEvent(personId, eventType, invite.id, {
+      occurredAt: options.occurredAt,
+      data: {
+        token_prefix: invite.token.slice(0, 8),
+        org_id: invite.workos_organization_id,
+        ...options.extra,
+      },
+    });
+  } catch (err) {
+    logger.warn(
+      {
+        err,
+        eventType,
+        inviteId: invite.id,
+        orgId: invite.workos_organization_id,
+        contactEmail: invite.contact_email,
+      },
+      'Failed to record invite event — invite operation succeeded'
+    );
+  }
 }

--- a/server/src/db/migrations/458_invite_event_indexes.sql
+++ b/server/src/db/migrations/458_invite_event_indexes.sql
@@ -1,0 +1,50 @@
+-- Migration: invite event lifecycle support
+--
+-- Adds two pieces that the per-person invite event log (issue #3588) needs:
+--
+-- 1. A stable surrogate key on membership_invites. The token is a credential
+--    (anyone holding it can accept the invite), so it is unsafe to use as the
+--    public reference in person_events. invite_id gives us a non-secret UUID
+--    that events and any future tooling can reference without leaking accept
+--    capability.
+--
+-- 2. A partial unique index on person_events for the four invite event types,
+--    keyed on data->>'invite_id'. This makes invite-event writes idempotent
+--    (ON CONFLICT DO NOTHING) without a NOT EXISTS pre-check, which is
+--    race-prone and unindexed.
+--
+-- Source-of-truth rule documented elsewhere: membership_invites holds the
+-- current state of an invite; person_events holds its history. Read the row
+-- to answer "is this expired now"; read the events to answer "what happened".
+
+-- ADD COLUMN with DEFAULT gen_random_uuid() is volatile, so PG rewrites
+-- the table under ACCESS EXCLUSIVE. This table is small in production
+-- (low hundreds of rows at most — verified before shipping); the rewrite
+-- and follow-on UNIQUE index build are quick. If the table grows
+-- substantially before this migration ships, split into:
+--   1. ADD COLUMN id UUID
+--   2. UPDATE ... SET id = gen_random_uuid() in batches
+--   3. ALTER COLUMN id SET NOT NULL, SET DEFAULT gen_random_uuid()
+--   4. CREATE UNIQUE INDEX CONCURRENTLY ... ; ADD CONSTRAINT ... USING INDEX
+ALTER TABLE membership_invites
+  ADD COLUMN IF NOT EXISTS id UUID NOT NULL DEFAULT gen_random_uuid();
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'membership_invites_id_key'
+  ) THEN
+    ALTER TABLE membership_invites
+      ADD CONSTRAINT membership_invites_id_key UNIQUE (id);
+  END IF;
+END $$;
+
+COMMENT ON COLUMN membership_invites.id IS
+  'Stable surrogate key. Use this (not token) when referring to an invite from outside the invites table — token is a credential.';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_person_events_invite_dedupe
+  ON person_events (event_type, (data->>'invite_id'))
+  WHERE event_type IN ('invite_sent', 'invite_accepted', 'invite_revoked', 'invite_expired');
+
+COMMENT ON INDEX idx_person_events_invite_dedupe IS
+  'Idempotency guard for invite-lifecycle events. Insert with ON CONFLICT DO NOTHING.';

--- a/server/src/db/person-events-db.ts
+++ b/server/src/db/person-events-db.ts
@@ -33,7 +33,11 @@ export type PersonEventType =
   | 'email_bounced'
   | 'slack_dm_delivered'
   | 'preference_changed'
-  | 'admin_nudge_requested';
+  | 'admin_nudge_requested'
+  | 'invite_sent'           // membership invite emailed to recipient
+  | 'invite_accepted'       // recipient signed in and accepted
+  | 'invite_revoked'        // admin revoked before accept
+  | 'invite_expired';       // expires_at passed without accept/revoke (sweep)
 
 export interface PersonEvent {
   id: number;
@@ -72,6 +76,40 @@ export async function recordEvent(
       options.occurredAt ?? null,
     ]
   );
+}
+
+export type InviteEventType = Extract<
+  PersonEventType,
+  'invite_sent' | 'invite_accepted' | 'invite_revoked' | 'invite_expired'
+>;
+
+/**
+ * Record a membership-invite lifecycle event, deduplicated on (event_type, invite_id).
+ * Safe to call repeatedly — relies on the partial unique index from migration 458.
+ * Returns true if a new row was inserted, false if the dedupe index skipped it.
+ */
+export async function recordInviteEvent(
+  personId: string,
+  eventType: InviteEventType,
+  inviteId: string,
+  options: {
+    data?: Record<string, unknown>;
+    occurredAt?: Date;
+  } = {}
+): Promise<boolean> {
+  const data = { ...(options.data ?? {}), invite_id: inviteId };
+  // The WHERE clause below must match the predicate of idx_person_events_invite_dedupe
+  // (migration 458) exactly — otherwise PG can't pick the partial unique index and
+  // the insert silently stops being idempotent. Keep both lists in lockstep.
+  const result = await query(
+    `INSERT INTO person_events (person_id, event_type, channel, data, occurred_at)
+     VALUES ($1, $2, 'system', $3::jsonb, COALESCE($4, NOW()))
+     ON CONFLICT (event_type, ((data->>'invite_id')))
+     WHERE event_type IN ('invite_sent', 'invite_accepted', 'invite_revoked', 'invite_expired')
+     DO NOTHING`,
+    [personId, eventType, JSON.stringify(data), options.occurredAt ?? null]
+  );
+  return (result.rowCount ?? 0) > 0;
 }
 
 /**

--- a/server/src/scripts/backfill-invite-events.ts
+++ b/server/src/scripts/backfill-invite-events.ts
@@ -1,0 +1,383 @@
+/**
+ * Backfill person_events rows for existing membership_invites.
+ *
+ * Issue: github.com/adcontextprotocol/adcp/issues/3588
+ *
+ * For every row in membership_invites we emit:
+ *   - invite_sent      at created_at
+ *   - invite_accepted  at accepted_at        (if accepted)
+ *   - invite_revoked   at revoked_at         (if revoked)
+ *   - invite_expired   at expires_at         (if expired and not otherwise terminal)
+ *
+ * Idempotency comes from the partial unique index on
+ * person_events (event_type, data->>'invite_id') from migration 458.
+ * INSERT uses ON CONFLICT DO NOTHING via recordInviteEvent — safe to re-run.
+ *
+ * ## Pre-flight
+ *
+ * The script first counts distinct invite emails that have no existing
+ * person_relationships row. Backfill will create one row per unique email
+ * via resolvePersonId (project invariant: everyone is an account). Operator
+ * must confirm with --yes before any writes happen.
+ *
+ * ## Usage
+ *
+ *   npx tsx server/src/scripts/backfill-invite-events.ts             # pre-flight only (no writes)
+ *   npx tsx server/src/scripts/backfill-invite-events.ts --yes       # write events
+ *   npx tsx server/src/scripts/backfill-invite-events.ts --yes --batch 200
+ *
+ * ## Env
+ *
+ *   DATABASE_URL  required
+ */
+
+import { closeDatabase, initializeDatabase, query } from '../db/client.js';
+import { resolvePersonId } from '../db/relationship-db.js';
+import { recordInviteEvent, type InviteEventType } from '../db/person-events-db.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('backfill-invite-events');
+
+interface Args {
+  yes: boolean;
+  batch: number;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { yes: false, batch: 100 };
+  for (let i = 2; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '--yes') {
+      args.yes = true;
+    } else if (a === '--batch') {
+      const raw = argv[++i];
+      const n = parseInt(raw, 10);
+      if (!Number.isFinite(n) || n <= 0) {
+        throw new Error(`--batch requires a positive integer, got: ${raw}`);
+      }
+      args.batch = n;
+    } else if (a === '--help' || a === '-h') {
+      console.log(
+        'Usage: npx tsx backfill-invite-events.ts [--yes] [--batch N]\n' +
+          '  (no flag)  pre-flight only, prints what would be written\n' +
+          '  --yes      write events\n' +
+          '  --batch N  page size (default 100)'
+      );
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown arg: ${a}`);
+    }
+  }
+  return args;
+}
+
+function describeDatabaseTarget(): string {
+  const url = process.env.DATABASE_URL ?? '';
+  try {
+    const parsed = new URL(url);
+    const dbname = parsed.pathname.replace(/^\//, '') || '(none)';
+    return `${parsed.host}/${dbname}`;
+  } catch {
+    return '(unparseable DATABASE_URL)';
+  }
+}
+
+async function ensureMigrationApplied(): Promise<void> {
+  const result = await query<{ exists: boolean }>(
+    `SELECT EXISTS (
+       SELECT 1 FROM information_schema.columns
+       WHERE table_name = 'membership_invites' AND column_name = 'id'
+     ) AS exists`
+  );
+  if (!result.rows[0]?.exists) {
+    throw new Error(
+      'Migration 458 has not run on this database — membership_invites.id is missing. Run migrations first.'
+    );
+  }
+}
+
+interface InviteRow {
+  id: string;
+  token: string;
+  workos_organization_id: string;
+  lookup_key: string;
+  contact_email: string;
+  contact_name: string | null;
+  invited_by_user_id: string;
+  created_at: Date;
+  expires_at: Date;
+  accepted_at: Date | null;
+  accepted_by_user_id: string | null;
+  invoice_id: string | null;
+  revoked_at: Date | null;
+  revoked_by_user_id: string | null;
+}
+
+interface Plan {
+  type: InviteEventType;
+  occurredAt: Date;
+  data: Record<string, unknown>;
+}
+
+function planEvents(row: InviteRow, now: Date): Plan[] {
+  const tokenPrefix = row.token.slice(0, 8);
+  const orgId = row.workos_organization_id;
+  const lookupKey = row.lookup_key;
+
+  const plans: Plan[] = [
+    {
+      type: 'invite_sent',
+      occurredAt: row.created_at,
+      data: {
+        token_prefix: tokenPrefix,
+        org_id: orgId,
+        lookup_key: lookupKey,
+        contact_name: row.contact_name,
+        expires_at: row.expires_at.toISOString(),
+        invited_by_user_id: row.invited_by_user_id,
+      },
+    },
+  ];
+
+  if (row.accepted_at) {
+    plans.push({
+      type: 'invite_accepted',
+      occurredAt: row.accepted_at,
+      data: {
+        token_prefix: tokenPrefix,
+        org_id: orgId,
+        lookup_key: lookupKey,
+        accepted_by_user_id: row.accepted_by_user_id,
+        invoice_id: row.invoice_id,
+      },
+    });
+  }
+  if (row.revoked_at) {
+    plans.push({
+      type: 'invite_revoked',
+      occurredAt: row.revoked_at,
+      data: {
+        token_prefix: tokenPrefix,
+        org_id: orgId,
+        lookup_key: lookupKey,
+        revoked_by_user_id: row.revoked_by_user_id,
+        previous_status: row.accepted_at
+          ? 'accepted'
+          : row.expires_at.getTime() <= row.revoked_at.getTime()
+            ? 'expired'
+            : 'pending',
+      },
+    });
+  }
+  if (
+    !row.accepted_at &&
+    !row.revoked_at &&
+    row.expires_at.getTime() <= now.getTime()
+  ) {
+    plans.push({
+      type: 'invite_expired',
+      occurredAt: row.expires_at,
+      data: {
+        token_prefix: tokenPrefix,
+        org_id: orgId,
+        lookup_key: lookupKey,
+        expired_at: row.expires_at.toISOString(),
+        detected_at: now.toISOString(),
+        backfilled: true,
+      },
+    });
+  }
+
+  return plans;
+}
+
+interface PreFlightStats {
+  totalInvites: number;
+  pendingInvites: number;
+  acceptedInvites: number;
+  revokedInvites: number;
+  expiredInvites: number;
+  expectedEvents: number;
+  ghostsToCreate: number;
+}
+
+async function preFlight(): Promise<PreFlightStats> {
+  const stateResult = await query<{
+    total: string;
+    pending: string;
+    accepted: string;
+    revoked: string;
+    expired: string;
+  }>(
+    `SELECT
+       COUNT(*) AS total,
+       COUNT(*) FILTER (
+         WHERE accepted_at IS NULL AND revoked_at IS NULL AND expires_at > NOW()
+       ) AS pending,
+       COUNT(*) FILTER (WHERE accepted_at IS NOT NULL) AS accepted,
+       COUNT(*) FILTER (WHERE revoked_at IS NOT NULL) AS revoked,
+       COUNT(*) FILTER (
+         WHERE accepted_at IS NULL AND revoked_at IS NULL AND expires_at <= NOW()
+       ) AS expired
+     FROM membership_invites`
+  );
+  const row = stateResult.rows[0] ?? {
+    total: '0', pending: '0', accepted: '0', revoked: '0', expired: '0',
+  };
+  const stats: PreFlightStats = {
+    totalInvites: Number(row.total),
+    pendingInvites: Number(row.pending),
+    acceptedInvites: Number(row.accepted),
+    revokedInvites: Number(row.revoked),
+    expiredInvites: Number(row.expired),
+    expectedEvents: 0,
+    ghostsToCreate: 0,
+  };
+  // Each invite contributes one invite_sent. Accepted/revoked/expired add a
+  // second event per invite (revoked may stack with expired in the DB but
+  // the script only emits one terminal event per row).
+  stats.expectedEvents =
+    stats.totalInvites +
+    stats.acceptedInvites +
+    stats.revokedInvites +
+    stats.expiredInvites;
+
+  const ghostsResult = await query<{ count: string }>(
+    `SELECT COUNT(DISTINCT mi.contact_email) AS count
+     FROM membership_invites mi
+     LEFT JOIN person_relationships pr
+       ON pr.email = mi.contact_email
+     WHERE pr.id IS NULL`
+  );
+  stats.ghostsToCreate = Number(ghostsResult.rows[0]?.count ?? 0);
+
+  console.log('--- pre-flight ---');
+  console.log(`Database target:                ${describeDatabaseTarget()}`);
+  console.log(`Total invites:                  ${stats.totalInvites}`);
+  console.log(`  pending:                      ${stats.pendingInvites}`);
+  console.log(`  accepted:                     ${stats.acceptedInvites}`);
+  console.log(`  revoked:                      ${stats.revokedInvites}`);
+  console.log(`  expired (not revoked):        ${stats.expiredInvites}`);
+  console.log(`Events to attempt:              ${stats.expectedEvents}`);
+  console.log(`person_relationships to create: ${stats.ghostsToCreate}`);
+  console.log('');
+  console.log(
+    'Each invite contributes one invite_sent; accepted/revoked/expired adds a'
+  );
+  console.log(
+    'second terminal event. Re-runs are idempotent (ON CONFLICT DO NOTHING).'
+  );
+  console.log('');
+  return stats;
+}
+
+async function run(): Promise<void> {
+  const args = parseArgs(process.argv);
+  const now = new Date();
+
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL is required');
+  }
+  initializeDatabase({ connectionString: databaseUrl });
+
+  await ensureMigrationApplied();
+  await preFlight();
+
+  if (!args.yes) {
+    console.log('Pre-flight only — pass --yes to write events.');
+    return;
+  }
+
+  let lastId: string | null = null;
+  let totalRows = 0;
+  let inserted = 0;
+  let skipped = 0;
+  let resolveFailures = 0;
+  let planFailures = 0;
+  let recordFailures = 0;
+
+  for (;;) {
+    const params: unknown[] = [args.batch];
+    let cursorClause = '';
+    if (lastId) {
+      params.push(lastId);
+      cursorClause = `WHERE id > $${params.length}`;
+    }
+    const result = await query<InviteRow>(
+      `SELECT id, token, workos_organization_id, lookup_key, contact_email,
+              contact_name, invited_by_user_id, created_at, expires_at,
+              accepted_at, accepted_by_user_id, invoice_id,
+              revoked_at, revoked_by_user_id
+       FROM membership_invites
+       ${cursorClause}
+       ORDER BY id ASC
+       LIMIT $1`,
+      params
+    );
+
+    if (result.rows.length === 0) break;
+
+    for (const row of result.rows) {
+      lastId = row.id;
+      totalRows += 1;
+
+      let personId: string;
+      try {
+        personId = await resolvePersonId({ email: row.contact_email });
+      } catch (err) {
+        resolveFailures += 1;
+        logger.warn(
+          { err, inviteId: row.id, contactEmail: row.contact_email },
+          'Failed to resolve person — skipping invite'
+        );
+        continue;
+      }
+
+      let plans: Plan[];
+      try {
+        plans = planEvents(row, now);
+      } catch (err) {
+        planFailures += 1;
+        logger.warn(
+          { err, inviteId: row.id },
+          'Failed to plan events for invite — skipping'
+        );
+        continue;
+      }
+
+      for (const plan of plans) {
+        try {
+          const wrote = await recordInviteEvent(personId, plan.type, row.id, {
+            occurredAt: plan.occurredAt,
+            data: plan.data,
+          });
+          if (wrote) inserted += 1;
+          else skipped += 1;
+        } catch (err) {
+          recordFailures += 1;
+          logger.warn(
+            { err, inviteId: row.id, type: plan.type },
+            'Failed to record invite event'
+          );
+        }
+      }
+    }
+  }
+
+  console.log('--- done ---');
+  console.log(`Invites processed:    ${totalRows}`);
+  console.log(`Events inserted:      ${inserted}`);
+  console.log(`Events skipped (dedupe / re-run): ${skipped}`);
+  console.log(`Resolve failures:     ${resolveFailures}`);
+  console.log(`Plan failures:        ${planFailures}`);
+  console.log(`Record failures:      ${recordFailures}`);
+}
+
+run()
+  .then(() => closeDatabase())
+  .catch(async (err) => {
+    logger.error({ err }, 'Backfill failed');
+    await closeDatabase();
+    process.exit(1);
+  });

--- a/server/tests/integration/invite-events.test.ts
+++ b/server/tests/integration/invite-events.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { initializeDatabase, closeDatabase, query } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import {
+  createMembershipInvite,
+  markMembershipInviteAccepted,
+  revokeMembershipInvite,
+} from '../../src/db/membership-invites-db.js';
+import { recordInviteEvent } from '../../src/db/person-events-db.js';
+import { resolvePersonId } from '../../src/db/relationship-db.js';
+import { runInviteExpirySweep } from '../../src/addie/jobs/invite-expiry-sweep.js';
+import type { Pool } from 'pg';
+
+const TEST_ORG_PREFIX = 'org_invite_events_test';
+const TEST_EMAIL_DOMAIN = 'invite-events-test.example.com';
+const TEST_ADMIN_ID = 'user_invite_events_admin';
+const TEST_ACCEPTOR_ID = 'user_invite_events_acceptor';
+
+interface InviteEventRow {
+  event_type: string;
+  occurred_at: Date;
+  data: Record<string, unknown>;
+}
+
+describe('invite lifecycle events', () => {
+  let pool: Pool;
+
+  const createTestOrg = async (orgId: string, name = 'Invite Events Test Org') => {
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, created_at, updated_at)
+       VALUES ($1, $2, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      [orgId, name]
+    );
+  };
+
+  const eventsForInvite = async (inviteId: string): Promise<InviteEventRow[]> => {
+    const result = await pool.query(
+      `SELECT event_type, occurred_at, data
+       FROM person_events
+       WHERE event_type IN ('invite_sent', 'invite_accepted', 'invite_revoked', 'invite_expired')
+         AND data->>'invite_id' = $1
+       ORDER BY occurred_at ASC`,
+      [inviteId]
+    );
+    return result.rows.map((row) => ({
+      event_type: row.event_type as string,
+      occurred_at: new Date(row.occurred_at as string),
+      data:
+        typeof row.data === 'string'
+          ? (JSON.parse(row.data as string) as Record<string, unknown>)
+          : (row.data as Record<string, unknown>),
+    }));
+  };
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString:
+        process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  }, 60000);
+
+  afterAll(async () => {
+    await pool.query(
+      `DELETE FROM person_events
+       WHERE person_id IN (
+         SELECT id FROM person_relationships WHERE email LIKE $1
+       )`,
+      [`%@${TEST_EMAIL_DOMAIN}`]
+    );
+    await pool.query('DELETE FROM person_relationships WHERE email LIKE $1', [
+      `%@${TEST_EMAIL_DOMAIN}`,
+    ]);
+    await pool.query(
+      'DELETE FROM membership_invites WHERE workos_organization_id LIKE $1',
+      [`${TEST_ORG_PREFIX}%`]
+    );
+    await pool.query('DELETE FROM organizations WHERE workos_organization_id LIKE $1', [
+      `${TEST_ORG_PREFIX}%`,
+    ]);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await pool.query(
+      `DELETE FROM person_events
+       WHERE person_id IN (
+         SELECT id FROM person_relationships WHERE email LIKE $1
+       )`,
+      [`%@${TEST_EMAIL_DOMAIN}`]
+    );
+    await pool.query('DELETE FROM person_relationships WHERE email LIKE $1', [
+      `%@${TEST_EMAIL_DOMAIN}`,
+    ]);
+    await pool.query(
+      'DELETE FROM membership_invites WHERE workos_organization_id LIKE $1',
+      [`${TEST_ORG_PREFIX}%`]
+    );
+    await pool.query('DELETE FROM organizations WHERE workos_organization_id LIKE $1', [
+      `${TEST_ORG_PREFIX}%`,
+    ]);
+  });
+
+  it('createMembershipInvite emits invite_sent at created_at with the right payload', async () => {
+    const orgId = `${TEST_ORG_PREFIX}_send`;
+    await createTestOrg(orgId);
+
+    const invite = await createMembershipInvite({
+      workos_organization_id: orgId,
+      lookup_key: 'aao_membership_professional',
+      contact_email: `sent@${TEST_EMAIL_DOMAIN}`,
+      contact_name: 'Sent User',
+      invited_by_user_id: TEST_ADMIN_ID,
+    });
+
+    const events = await eventsForInvite(invite.id);
+    expect(events).toHaveLength(1);
+    expect(events[0].event_type).toBe('invite_sent');
+    expect(events[0].occurred_at.getTime()).toBe(invite.created_at.getTime());
+    expect(events[0].data.invite_id).toBe(invite.id);
+    expect(events[0].data.token_prefix).toBe(invite.token.slice(0, 8));
+    expect(events[0].data.org_id).toBe(orgId);
+    expect(events[0].data.lookup_key).toBe('aao_membership_professional');
+    expect(events[0].data.contact_name).toBe('Sent User');
+    expect(events[0].data.invited_by_user_id).toBe(TEST_ADMIN_ID);
+  });
+
+  it('markMembershipInviteAccepted emits invite_accepted; duplicate accept does not duplicate the event', async () => {
+    const orgId = `${TEST_ORG_PREFIX}_accept`;
+    await createTestOrg(orgId);
+
+    const invite = await createMembershipInvite({
+      workos_organization_id: orgId,
+      lookup_key: 'aao_membership_professional',
+      contact_email: `accept@${TEST_EMAIL_DOMAIN}`,
+      invited_by_user_id: TEST_ADMIN_ID,
+    });
+
+    await markMembershipInviteAccepted(invite.token, TEST_ACCEPTOR_ID, 'in_accept_1');
+    await markMembershipInviteAccepted(invite.token, TEST_ACCEPTOR_ID, 'in_accept_2');
+
+    const events = await eventsForInvite(invite.id);
+    expect(events.map((e) => e.event_type)).toEqual(['invite_sent', 'invite_accepted']);
+    const accepted = events[1];
+    expect(accepted.data.accepted_by_user_id).toBe(TEST_ACCEPTOR_ID);
+    expect(accepted.data.invoice_id).toBe('in_accept_1');
+  });
+
+  it('revokeMembershipInvite captures previous_status: pending for a fresh invite', async () => {
+    const orgId = `${TEST_ORG_PREFIX}_revoke_pending`;
+    await createTestOrg(orgId);
+
+    const invite = await createMembershipInvite({
+      workos_organization_id: orgId,
+      lookup_key: 'aao_membership_professional',
+      contact_email: `revoke-pending@${TEST_EMAIL_DOMAIN}`,
+      invited_by_user_id: TEST_ADMIN_ID,
+    });
+
+    await revokeMembershipInvite(invite.token, TEST_ADMIN_ID);
+
+    const events = await eventsForInvite(invite.id);
+    expect(events.map((e) => e.event_type)).toEqual(['invite_sent', 'invite_revoked']);
+    expect(events[1].data.previous_status).toBe('pending');
+    expect(events[1].data.revoked_by_user_id).toBe(TEST_ADMIN_ID);
+  });
+
+  it('revokeMembershipInvite captures previous_status: expired for an already-expired invite', async () => {
+    const orgId = `${TEST_ORG_PREFIX}_revoke_expired`;
+    await createTestOrg(orgId);
+
+    const invite = await createMembershipInvite({
+      workos_organization_id: orgId,
+      lookup_key: 'aao_membership_professional',
+      contact_email: `revoke-expired@${TEST_EMAIL_DOMAIN}`,
+      invited_by_user_id: TEST_ADMIN_ID,
+    });
+    await pool.query(
+      `UPDATE membership_invites SET expires_at = NOW() - INTERVAL '1 day' WHERE id = $1`,
+      [invite.id]
+    );
+
+    await revokeMembershipInvite(invite.token, TEST_ADMIN_ID);
+
+    const events = await eventsForInvite(invite.id);
+    const revoked = events.find((e) => e.event_type === 'invite_revoked');
+    expect(revoked).toBeDefined();
+    expect(revoked!.data.previous_status).toBe('expired');
+  });
+
+  it('recordInviteEvent is idempotent for the same (event_type, invite_id)', async () => {
+    const orgId = `${TEST_ORG_PREFIX}_idem`;
+    await createTestOrg(orgId);
+
+    const invite = await createMembershipInvite({
+      workos_organization_id: orgId,
+      lookup_key: 'aao_membership_professional',
+      contact_email: `idem@${TEST_EMAIL_DOMAIN}`,
+      invited_by_user_id: TEST_ADMIN_ID,
+    });
+
+    const personId = await resolvePersonId({ email: invite.contact_email });
+    await recordInviteEvent(personId, 'invite_sent', invite.id, {
+      data: { token_prefix: invite.token.slice(0, 8), org_id: orgId },
+    });
+    await recordInviteEvent(personId, 'invite_sent', invite.id, {
+      data: { token_prefix: invite.token.slice(0, 8), org_id: orgId },
+    });
+
+    // The mutator already wrote one invite_sent at create time; manual re-writes
+    // must not duplicate.
+    const events = await eventsForInvite(invite.id);
+    expect(events.filter((e) => e.event_type === 'invite_sent')).toHaveLength(1);
+  });
+
+  it('sweep emits invite_expired with occurred_at = expires_at and is idempotent', async () => {
+    const orgId = `${TEST_ORG_PREFIX}_sweep`;
+    await createTestOrg(orgId);
+
+    const invite = await createMembershipInvite({
+      workos_organization_id: orgId,
+      lookup_key: 'aao_membership_professional',
+      contact_email: `sweep@${TEST_EMAIL_DOMAIN}`,
+      invited_by_user_id: TEST_ADMIN_ID,
+    });
+    await pool.query(
+      `UPDATE membership_invites SET expires_at = NOW() - INTERVAL '2 days' WHERE id = $1`,
+      [invite.id]
+    );
+    const expiredAtRow = await pool.query<{ expires_at: Date }>(
+      `SELECT expires_at FROM membership_invites WHERE id = $1`,
+      [invite.id]
+    );
+    const expectedExpiresAt = new Date(expiredAtRow.rows[0].expires_at);
+
+    const first = await runInviteExpirySweep();
+    expect(first.candidates).toBe(1);
+    expect(first.emitted).toBe(1);
+    expect(first.resolveFailures).toBe(0);
+    expect(first.recordFailures).toBe(0);
+
+    const events = await eventsForInvite(invite.id);
+    const expired = events.find((e) => e.event_type === 'invite_expired');
+    expect(expired).toBeDefined();
+    expect(expired!.occurred_at.getTime()).toBe(expectedExpiresAt.getTime());
+    expect(expired!.data.detected_at).toBeTypeOf('string');
+
+    const second = await runInviteExpirySweep();
+    // The just-handled invite must not appear as a candidate again.
+    const sweepedAgain = await eventsForInvite(invite.id);
+    expect(sweepedAgain.filter((e) => e.event_type === 'invite_expired')).toHaveLength(1);
+    expect(second.candidates).toBe(0);
+    expect(second.emitted).toBe(0);
+    expect(second.resolveFailures).toBe(0);
+    expect(second.recordFailures).toBe(0);
+  });
+
+  it('sweep ignores invites that are revoked or accepted', async () => {
+    const orgId = `${TEST_ORG_PREFIX}_sweep_terminal`;
+    await createTestOrg(orgId);
+
+    const revokedInvite = await createMembershipInvite({
+      workos_organization_id: orgId,
+      lookup_key: 'aao_membership_professional',
+      contact_email: `revoked@${TEST_EMAIL_DOMAIN}`,
+      invited_by_user_id: TEST_ADMIN_ID,
+    });
+    await pool.query(
+      `UPDATE membership_invites
+       SET expires_at = NOW() - INTERVAL '1 day',
+           revoked_at = NOW() - INTERVAL '12 hours',
+           revoked_by_user_id = $1
+       WHERE id = $2`,
+      [TEST_ADMIN_ID, revokedInvite.id]
+    );
+
+    const acceptedInvite = await createMembershipInvite({
+      workos_organization_id: orgId,
+      lookup_key: 'aao_membership_professional',
+      contact_email: `accepted@${TEST_EMAIL_DOMAIN}`,
+      invited_by_user_id: TEST_ADMIN_ID,
+    });
+    await pool.query(
+      `UPDATE membership_invites
+       SET expires_at = NOW() - INTERVAL '1 day',
+           accepted_at = NOW() - INTERVAL '12 hours',
+           accepted_by_user_id = $1,
+           invoice_id = 'in_accepted'
+       WHERE id = $2`,
+      [TEST_ACCEPTOR_ID, acceptedInvite.id]
+    );
+
+    await runInviteExpirySweep();
+
+    const revokedEvents = await eventsForInvite(revokedInvite.id);
+    expect(revokedEvents.find((e) => e.event_type === 'invite_expired')).toBeUndefined();
+    const acceptedEvents = await eventsForInvite(acceptedInvite.id);
+    expect(acceptedEvents.find((e) => e.event_type === 'invite_expired')).toBeUndefined();
+  });
+});

--- a/server/tests/integration/invite-events.test.ts
+++ b/server/tests/integration/invite-events.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
-import { initializeDatabase, closeDatabase, query } from '../../src/db/client.js';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
 import { runMigrations } from '../../src/db/migrate.js';
 import {
   createMembershipInvite,


### PR DESCRIPTION
## Summary

- Membership invitation lifecycle now lands on the recipient's `person_events` timeline: sending, accepting, and revoking each emit a typed event; an hourly sweep emits `invite_expired` for invites that pass their expiry without acceptance or revocation.
- Migration 458 adds an `id UUID` surrogate to `membership_invites` so the credential `token` never appears as a public reference, plus a partial unique index on `person_events (event_type, data->>'invite_id')` for race-safe `ON CONFLICT DO NOTHING` writes.
- Includes a backfill script (`server/src/scripts/backfill-invite-events.ts`) that's idempotent, has a real pre-flight breakdown (state counts, expected events, ghost-row count, target DB host), errors clearly on unknown args / missing migration, and reports `inserted` vs `skipped` so re-runs are obviously no-ops.

Foundation for #3581 (admin UI invite history + Addie tools), #3580 (inbound text persistence), and #3582 (Addie's person-level memory layer).

## Why this exists

Surfaced from a Pubx escalation: Lukasz reported two colleagues with "expired invitations" who couldn't log in. Investigation found that invites had no record on the recipients' `person_events` timeline at all — `createMembershipInvite` only wrote to `membership_invites` and a logger line. Admin UI also had no way to see invite state. This PR is the foundation: get the lifecycle into the timeline first; consumers (#3581) come next.

## Design highlights

- **`invite_id` UUID surrogate, not the token.** Token is a credential — anyone holding it can accept the invite. The new UUID is the safe public reference for events, admin UIs, and any future tooling.
- **Partial unique index for dedupe.** Race-safe `ON CONFLICT DO NOTHING` on `(event_type, data->>'invite_id')` for the four invite event types. Replaces a `NOT EXISTS` pre-check.
- **`occurred_at` semantics.** `invite_expired` events use `occurred_at = expires_at` (logical truth — the moment the state actually became expired) plus `data.detected_at` (sweep wall clock). Replay-safe; ops dashboards can still measure sweep latency from `data.detected_at`.
- **Source-of-truth rule.** `membership_invites` row holds *current state*; `person_events` holds *history*. Don't read events to ask "is this invite expired right now" — read the row. Documented in migration 458.
- **Eager person resolution.** `resolvePersonId({ email })` creates a `person_relationships` row at invite-send time if needed. Matches the project's "everyone is an account" invariant.

## Expert reviews run before merge

- **data-analyst** — major design changes adopted (surrogate key, partial unique index, `previous_status` capture, `occurred_at = expires_at`).
- **code-reviewer** ×2 — migration idempotency guard, `ON CONFLICT WHERE` predicate-drift comment, metric naming, test tightening.
- **nodejs-testing-expert** — dropped redundant tests, added explicit `occurred_at` and result-shape assertions.
- **security-reviewer** — no blockers. Verified `token_prefix` (8 hex of 256 bits) is safe, `invite_id` is non-authorization-bearing, eager person creation matches project invariant, no cross-tenant probe vector.
- **dx-expert** — applied 7 fix-now items: dropped redundant `--dry-run` flag, added DB-target printout, pre-flight breakdown by state, migration-applied check, throw on unknown args, `--batch` validation, per-row plan-failure handling, `inserted` vs `skipped` distinction.

## Companion issues

- #3580 — Persist inbound `message_received` text
- #3581 — Admin UI parity + Addie tools for invite lifecycle (this PR's main consumer)
- #3582 — Addie person-level memory layer
- #3596 — Sweep concurrency advisory lock (load-shaping follow-up)

## Test plan

- [x] `npm run typecheck` clean
- [x] 7 new integration tests pass (`server/tests/integration/invite-events.test.ts`)
- [x] 11 existing `membership-invites-db.test.ts` tests still pass (no regression)
- [x] Backfill script smoke test — pre-flight, --yes write, re-run idempotency (`0 inserted, 3 skipped`)
- [x] Backfill error paths — unknown arg → `Unknown arg: --dryrun`; bad batch → `--batch requires a positive integer`
- [x] **Live end-to-end against `docker compose up`**: migration 458 ran on boot, sweep job registered with 60-min interval, all four event types fired correctly through the compiled/deployed code, sweep idempotency verified (`candidates:0, emitted:0` on re-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)