### PR TITLE
feat(addie): add invite lifecycle event types to PersonEventType + backfill

### DIFF
--- a/.changeset/invite-lifecycle-person-events.md
+++ b/.changeset/invite-lifecycle-person-events.md
@@ -1,0 +1,4 @@
+---
+---
+
+feat(addie): add invite_sent/accepted/expired/revoked PersonEventType values; wire into all three invite DB callers; add hourly expired-invite sweep and backfill script (closes #3588)

--- a/scripts/backfill-invite-events.ts
+++ b/scripts/backfill-invite-events.ts
@@ -1,0 +1,205 @@
+/**
+ * One-shot backfill: walk membership_invites and write the corresponding
+ * person_events rows using the original timestamps.
+ *
+ * Safe to re-run: skips any invite whose token_prefix already appears in
+ * person_events for the matching person and event type.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-invite-events.ts [--dry-run]
+ */
+
+import { config } from 'dotenv';
+config({ path: '.env.local' });
+
+import pg from 'pg';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
+
+async function resolveOrCreatePerson(email: string, client: pg.PoolClient): Promise<string | null> {
+  const existing = await client.query<{ id: string }>(
+    `SELECT id FROM person_relationships WHERE email = $1 LIMIT 1`,
+    [email]
+  );
+  if (existing.rows.length > 0) return existing.rows[0].id;
+
+  // Create a website-only relationship — same as resolvePersonId({ email }) does.
+  const created = await client.query<{ id: string }>(
+    `INSERT INTO person_relationships (email, source)
+     VALUES ($1, 'website')
+     ON CONFLICT (email) WHERE email IS NOT NULL DO UPDATE SET email = EXCLUDED.email
+     RETURNING id`,
+    [email]
+  );
+  return created.rows[0]?.id ?? null;
+}
+
+async function eventExists(
+  personId: string,
+  eventType: string,
+  tokenPrefix: string,
+  client: pg.PoolClient
+): Promise<boolean> {
+  const result = await client.query(
+    `SELECT 1 FROM person_events
+     WHERE person_id = $1
+       AND event_type = $2
+       AND data->>'token_prefix' = $3
+     LIMIT 1`,
+    [personId, eventType, tokenPrefix]
+  );
+  return result.rows.length > 0;
+}
+
+async function main(): Promise<void> {
+  console.log(`Starting invite event backfill${DRY_RUN ? ' (DRY RUN)' : ''}…`);
+
+  const client = await pool.connect();
+  try {
+    const invites = await client.query<{
+      token: string;
+      contact_email: string;
+      workos_organization_id: string;
+      lookup_key: string;
+      invited_by_user_id: string;
+      created_at: Date;
+      accepted_at: Date | null;
+      accepted_by_user_id: string | null;
+      invoice_id: string | null;
+      revoked_at: Date | null;
+      revoked_by_user_id: string | null;
+      expires_at: Date;
+    }>(`SELECT * FROM membership_invites ORDER BY created_at ASC`);
+
+    console.log(`Found ${invites.rows.length} invites`);
+
+    let written = 0;
+    let skipped = 0;
+
+    for (const inv of invites.rows) {
+      const tokenPrefix = inv.token.slice(0, 8) + '...';
+      const personId = DRY_RUN ? 'dry-run' : await resolveOrCreatePerson(inv.contact_email, client);
+      if (!personId) {
+        console.warn(`  SKIP ${tokenPrefix}: could not resolve person for ${inv.contact_email}`);
+        skipped++;
+        continue;
+      }
+
+      // invite_sent
+      const sentExists = DRY_RUN ? false : await eventExists(personId, 'invite_sent', tokenPrefix, client);
+      if (!sentExists) {
+        if (!DRY_RUN) {
+          await client.query(
+            `INSERT INTO person_events (person_id, event_type, data, occurred_at)
+             VALUES ($1, 'invite_sent', $2, $3)`,
+            [
+              personId,
+              JSON.stringify({
+                token_prefix: tokenPrefix,
+                lookup_key: inv.lookup_key,
+                expires_at: inv.expires_at,
+                invited_by_user_id: inv.invited_by_user_id,
+                org_id: inv.workos_organization_id,
+              }),
+              inv.created_at,
+            ]
+          );
+        }
+        console.log(`  WRITE invite_sent  ${tokenPrefix} ${inv.contact_email} @ ${inv.created_at.toISOString()}`);
+        written++;
+      } else {
+        skipped++;
+      }
+
+      // invite_accepted
+      if (inv.accepted_at && inv.accepted_by_user_id) {
+        const acceptedExists = DRY_RUN ? false : await eventExists(personId, 'invite_accepted', tokenPrefix, client);
+        if (!acceptedExists) {
+          if (!DRY_RUN) {
+            await client.query(
+              `INSERT INTO person_events (person_id, event_type, data, occurred_at)
+               VALUES ($1, 'invite_accepted', $2, $3)`,
+              [
+                personId,
+                JSON.stringify({
+                  token_prefix: tokenPrefix,
+                  accepted_by_user_id: inv.accepted_by_user_id,
+                  invoice_id: inv.invoice_id,
+                  org_id: inv.workos_organization_id,
+                }),
+                inv.accepted_at,
+              ]
+            );
+          }
+          console.log(`  WRITE invite_accepted ${tokenPrefix} @ ${inv.accepted_at.toISOString()}`);
+          written++;
+        } else {
+          skipped++;
+        }
+      }
+
+      // invite_revoked
+      if (inv.revoked_at && inv.revoked_by_user_id) {
+        const revokedExists = DRY_RUN ? false : await eventExists(personId, 'invite_revoked', tokenPrefix, client);
+        if (!revokedExists) {
+          if (!DRY_RUN) {
+            await client.query(
+              `INSERT INTO person_events (person_id, event_type, data, occurred_at)
+               VALUES ($1, 'invite_revoked', $2, $3)`,
+              [
+                personId,
+                JSON.stringify({
+                  token_prefix: tokenPrefix,
+                  revoked_by_user_id: inv.revoked_by_user_id,
+                  org_id: inv.workos_organization_id,
+                }),
+                inv.revoked_at,
+              ]
+            );
+          }
+          console.log(`  WRITE invite_revoked  ${tokenPrefix} @ ${inv.revoked_at.toISOString()}`);
+          written++;
+        } else {
+          skipped++;
+        }
+      }
+
+      // invite_expired (no accepted_at, no revoked_at, past expires_at)
+      if (!inv.accepted_at && !inv.revoked_at && inv.expires_at < new Date()) {
+        const expiredExists = DRY_RUN ? false : await eventExists(personId, 'invite_expired', tokenPrefix, client);
+        if (!expiredExists) {
+          if (!DRY_RUN) {
+            await client.query(
+              `INSERT INTO person_events (person_id, event_type, data, occurred_at)
+               VALUES ($1, 'invite_expired', $2, $3)`,
+              [
+                personId,
+                JSON.stringify({
+                  token_prefix: tokenPrefix,
+                  org_id: inv.workos_organization_id,
+                }),
+                inv.expires_at,
+              ]
+            );
+          }
+          console.log(`  WRITE invite_expired  ${tokenPrefix} @ ${inv.expires_at.toISOString()}`);
+          written++;
+        } else {
+          skipped++;
+        }
+      }
+    }
+
+    console.log(`\nDone. written=${written} skipped=${skipped}${DRY_RUN ? ' (dry run — no writes)' : ''}`);
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('Backfill failed:', err);
+  process.exit(1);
+});

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -80,6 +80,8 @@ import {
 } from '../../billing/stripe-client.js';
 import { createMembershipInvite } from '../../db/membership-invites-db.js';
 import { sendMembershipInviteEmail } from '../../notifications/email.js';
+import { resolvePersonId } from '../../db/relationship-db.js';
+import { recordEvent } from '../../db/person-events-db.js';
 import { mergeOrganizations, previewMerge, type StripeCustomerResolution } from '../../db/org-merge-db.js';
 import { getWorkos } from '../../auth/workos-client.js';
 import { DomainDataState } from '@workos-inc/node';
@@ -3290,6 +3292,21 @@ export function createAdminToolHandlers(
           },
           'Addie sent membership invite (admin tool)',
         );
+
+        resolvePersonId({ email: normalizedEmail })
+          .then((personId) =>
+            recordEvent(personId, 'invite_sent', {
+              data: {
+                token_prefix: invite.token.slice(0, 8) + '...',
+                lookup_key: invite.lookup_key,
+                expires_at: invite.expires_at,
+                invited_by_user_id: adminUserId,
+                org_id: org.workos_organization_id,
+              },
+              occurredAt: invite.created_at,
+            })
+          )
+          .catch((err) => logger.warn({ err }, 'Failed to record invite_sent person event'));
 
         return response;
       } catch (err) {

--- a/server/src/db/person-events-db.ts
+++ b/server/src/db/person-events-db.ts
@@ -33,7 +33,14 @@ export type PersonEventType =
   | 'email_bounced'
   | 'slack_dm_delivered'
   | 'preference_changed'
-  | 'admin_nudge_requested';
+  | 'admin_nudge_requested'
+  // Membership invitation lifecycle — written to the recipient's timeline.
+  // token_prefix is the first 8 chars of the invite token (correlation handle).
+  // lookup_key is the membership-tier identifier (e.g. "founding_member").
+  | 'invite_sent'
+  | 'invite_accepted'
+  | 'invite_expired'
+  | 'invite_revoked';
 
 export interface PersonEvent {
   id: number;

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -8690,6 +8690,11 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
           }).catch(err => logger.warn({ err }, 'Failed to start auto-provision digest'));
         }
 
+        // Hourly sweep: write invite_expired events for newly-expired invites.
+        import('./scheduled/invite-expired-sweep.js').then(({ startInviteExpiredSweep }) => {
+          startInviteExpiredSweep();
+        }).catch(err => logger.warn({ err }, 'Failed to start invite-expired sweep'));
+
         // Start Luma calendar sync (catches events missed by webhooks)
         import('./luma/sync.js').then(({ startLumaSync }) => {
           startLumaSync();
@@ -8744,6 +8749,10 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
 
       import('./scheduled/auto-provision-digest.js').then(({ stopAutoProvisionDigest }) => {
         stopAutoProvisionDigest();
+      }).catch(() => {});
+
+      import('./scheduled/invite-expired-sweep.js').then(({ stopInviteExpiredSweep }) => {
+        stopInviteExpiredSweep();
       }).catch(() => {});
 
       import('./luma/sync.js').then(({ stopLumaSync }) => {

--- a/server/src/routes/admin/accounts.ts
+++ b/server/src/routes/admin/accounts.ts
@@ -27,6 +27,8 @@ import {
   revokeMembershipInvite,
 } from "../../db/membership-invites-db.js";
 import { sendMembershipInviteEmail } from "../../notifications/email.js";
+import { resolvePersonId } from "../../db/relationship-db.js";
+import { recordEvent } from "../../db/person-events-db.js";
 import { createProspect, updateProspect } from "../../services/prospect.js";
 import {
   loadDraftAndState,
@@ -2844,6 +2846,24 @@ export function setupAccountRoutes(
           "Admin sent membership invitation"
         );
 
+        // Record invite_sent on the recipient's person timeline.
+        // resolvePersonId creates a website-only relationship if the prospect
+        // hasn't yet signed in — consistent with the "everyone is an account" invariant.
+        resolvePersonId({ email: normalizedEmail })
+          .then((personId) =>
+            recordEvent(personId, 'invite_sent', {
+              data: {
+                token_prefix: invite.token.slice(0, 8) + '...',
+                lookup_key: invite.lookup_key,
+                expires_at: invite.expires_at,
+                invited_by_user_id: invite.invited_by_user_id,
+                org_id: orgId,
+              },
+              occurredAt: invite.created_at,
+            })
+          )
+          .catch((err) => logger.warn({ err }, 'Failed to record invite_sent person event'));
+
         res.json({
           success: true,
           invite: {
@@ -2914,6 +2934,20 @@ export function setupAccountRoutes(
             message: "Invite is already accepted, revoked, or does not exist.",
           });
         }
+
+        resolvePersonId({ email: revoked.contact_email })
+          .then((personId) =>
+            recordEvent(personId, 'invite_revoked', {
+              data: {
+                token_prefix: revoked.token.slice(0, 8) + '...',
+                revoked_by_user_id: req.user!.id,
+                org_id: revoked.workos_organization_id,
+              },
+              occurredAt: revoked.revoked_at ?? new Date(),
+            })
+          )
+          .catch((err) => logger.warn({ err }, 'Failed to record invite_revoked person event'));
+
         res.json({ success: true, token: revoked.token });
       } catch (error) {
         logger.error({ err: error }, "Error revoking invitation");

--- a/server/src/routes/invites.ts
+++ b/server/src/routes/invites.ts
@@ -31,6 +31,8 @@ import {
 } from '../billing/active-subscription-guard.js';
 import { withOrgIntakeLock } from '../billing/org-intake-lock.js';
 import * as referralDb from '../db/referral-codes-db.js';
+import { resolvePersonId } from '../db/relationship-db.js';
+import { recordEvent } from '../db/person-events-db.js';
 
 const logger = createLogger('invites-routes');
 const orgDb = new OrganizationDatabase();
@@ -345,6 +347,22 @@ export function createInvitesRouter(): Router {
         },
         'Membership invite accepted'
       );
+
+      // Record invite_accepted on the accepting user's timeline. Use only
+      // workos_user_id so we don't force-merge the invite contact_email with
+      // the authenticated account (those may be different addresses).
+      resolvePersonId({ workos_user_id: user.id })
+        .then((personId) =>
+          recordEvent(personId, 'invite_accepted', {
+            data: {
+              token_prefix: token.slice(0, 8) + '...',
+              accepted_by_user_id: user.id,
+              invoice_id: invoiceResult.invoiceId,
+              org_id: org.workos_organization_id,
+            },
+          })
+        )
+        .catch((err) => logger.warn({ err }, 'Failed to record invite_accepted person event'));
 
       res.json({
         success: true,

--- a/server/src/scheduled/invite-expired-sweep.ts
+++ b/server/src/scheduled/invite-expired-sweep.ts
@@ -1,0 +1,89 @@
+/**
+ * Periodic sweep that writes invite_expired person events for membership
+ * invites that have passed their expiry date without being accepted or revoked.
+ *
+ * Idempotent: only writes an event for an invite if no invite_expired event
+ * with the same token_prefix already exists on that person's timeline.
+ */
+
+import { createLogger } from '../logger.js';
+import { query } from '../db/client.js';
+import { resolvePersonId } from '../db/relationship-db.js';
+import { recordEvent } from '../db/person-events-db.js';
+
+const logger = createLogger('invite-expired-sweep');
+
+const SWEEP_INTERVAL_MS = 60 * 60 * 1000; // hourly
+
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+export function startInviteExpiredSweep(): void {
+  if (intervalId) return;
+
+  runSweep().catch((err) => logger.error({ err }, 'invite-expired sweep failed on startup'));
+
+  intervalId = setInterval(() => {
+    runSweep().catch((err) => logger.error({ err }, 'invite-expired sweep failed'));
+  }, SWEEP_INTERVAL_MS);
+
+  logger.info('invite-expired sweep started');
+}
+
+export function stopInviteExpiredSweep(): void {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+}
+
+async function runSweep(): Promise<void> {
+  // Find expired invites that don't yet have an invite_expired person event.
+  // token_prefix (first 8 chars + '...') is the correlation key stored in data.
+  // Idempotency guard checks person_events directly by (event_type, token_prefix)
+  // rather than joining through person_relationships. That JOIN would break after
+  // an identity merge: the loser row is deleted so the email lookup returns nothing,
+  // causing the sweep to re-write a duplicate on every subsequent run.
+  const result = await query<{
+    token: string;
+    contact_email: string;
+    workos_organization_id: string;
+    expires_at: Date;
+  }>(
+    `SELECT mi.token, mi.contact_email, mi.workos_organization_id, mi.expires_at
+     FROM membership_invites mi
+     WHERE mi.expires_at < NOW()
+       AND mi.expires_at > NOW() - INTERVAL '365 days'
+       AND mi.accepted_at IS NULL
+       AND mi.revoked_at IS NULL
+       AND NOT EXISTS (
+         SELECT 1 FROM person_events pe2
+         WHERE pe2.event_type = 'invite_expired'
+           AND pe2.data->>'token_prefix' = LEFT(mi.token, 8) || '...'
+       )
+     ORDER BY mi.expires_at ASC
+     LIMIT 500`,
+    []
+  );
+
+  if (result.rows.length === 0) return;
+
+  logger.info({ count: result.rows.length }, 'Writing invite_expired events');
+
+  for (const row of result.rows) {
+    try {
+      const personId = await resolvePersonId({ email: row.contact_email });
+      await recordEvent(personId, 'invite_expired', {
+        data: {
+          token_prefix: row.token.slice(0, 8) + '...',
+          org_id: row.workos_organization_id,
+        },
+        occurredAt: row.expires_at,
+      });
+    } catch (err) {
+      logger.warn(
+        { err, tokenPrefix: row.token.slice(0, 8) + '...' },
+        'Failed to write invite_expired event for one invite'
+      );
+    }
+  }
+}


### PR DESCRIPTION
Closes #3588

Adds four new `PersonEventType` values and wires them into all three invite call sites so recipients' person timelines record the full invitation lifecycle. Foundation for #3581 (admin UI Invitations panel) and #3582 (Addie memory layer).

## Changes

**`server/src/db/person-events-db.ts`** — Four new values appended to `PersonEventType`:
- `invite_sent` — written when a `membership_invites` row is created
- `invite_accepted` — written when `markMembershipInviteAccepted` succeeds
- `invite_expired` — written by a periodic sweep for unaccepted/unrevoked expired rows
- `invite_revoked` — written when `revokeMembershipInvite` succeeds

**`server/src/routes/admin/accounts.ts`** — Fire-and-forget `invite_sent` (on invite creation) and `invite_revoked` (on revoke) after each DB write succeeds. Uses `resolvePersonId({ email })` to create a website-only person record if the prospect hasn't yet signed in — consistent with the "everyone is an account" invariant.

**`server/src/routes/invites.ts`** — Fire-and-forget `invite_accepted` after `markMembershipInviteAccepted`. Uses only `workos_user_id` (not the invite contact email) to avoid force-merging distinct identity records if the accepting user authenticated with a different address.

**`server/src/addie/mcp/admin-tools.ts`** — Same `invite_sent` wiring for Addie's `send_invite` tool path.

**`server/src/scheduled/invite-expired-sweep.ts`** — New hourly sweep. Idempotency guard checks `person_events` directly by `(event_type, token_prefix)` — avoids the post-identity-merge duplicate problem that a `JOIN person_relationships` guard would have. Bounded to the last 365 days; LIMIT 500 per run.

**`server/src/http.ts`** — Registers the sweep in the worker-process startup and shutdown paths.

**`scripts/backfill-invite-events.ts`** — One-shot backfill. Walks `membership_invites`, resolves or creates a person record per email, writes all four event types using original timestamps. Safe to re-run (skips token_prefixes already present in `person_events`). Supports `--dry-run`.

## Non-breaking justification

All changes are additive: four enum values appended to `PersonEventType`, new fire-and-forget side effects on existing DB functions, a new scheduled task, and a new script. No existing behavior is modified; existing clients unaffected.

## Event data shapes

```
invite_sent:     { token_prefix, lookup_key, expires_at, invited_by_user_id, org_id }
invite_accepted: { token_prefix, accepted_by_user_id, invoice_id, org_id }
invite_expired:  { token_prefix, org_id }
invite_revoked:  { token_prefix, revoked_by_user_id, org_id }
```

`token_prefix` = first 8 chars + `'...'` (same truncation the logger uses — no full token in the event log). `lookup_key` = membership-tier identifier (e.g. `"founding_member"`).

## Notes / nits not fixed

- `invoice_id` in `invite_accepted` data: confirm data-retention policy treats `person_events` the same as billing records, or strip to `invoice_id_present: true`.
- `token_prefix` helper could be extracted to a shared util (8× repeated across 4 files).

## Pre-PR review

- code-reviewer: approved — fire-and-forget pattern correct for non-critical timeline writes; sweep idempotency guard verified merge-safe; backfill ON CONFLICT partial-index WHERE clause added; `resolvePersonId` identity-merge risk fixed by using `workos_user_id`-only on accept path
- internal-tools-strategist: approved — sweep approach operationally sound; UI scope correctly delegated to #3581; person resolution at route/service layer (not DB layer)

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01GrKJAWVMN7GMyDcfmmFziS

---
_Generated by [Claude Code](https://claude.ai/code/session_01GrKJAWVMN7GMyDcfmmFziS)_