### PR TITLE
refactor: Anthropic tool_use sweep across structured-extraction services

### DIFF
--- a/.changeset/claude-tool-use-sweep.md
+++ b/.changeset/claude-tool-use-sweep.md
@@ -1,0 +1,25 @@
+---
+---
+
+Anthropic tool_use sweep across structured-extraction services. Completes the
+pattern adoption that #3396 (smart-paste property parse) started: each
+migrated caller defines a tool with `input_schema`, sets `tool_choice` to
+force it, and reads `tool_use.input` directly — no `JSON.parse` of free-form
+text, no fence-stripping regex, no prompt-injection surface from text-output
+parsing.
+
+Converted callers (one commit each):
+
+- `server/src/services/property-enhancement.ts` — `analyze_property` tool
+  (publisher assessment)
+- `server/src/services/brand-classifier.ts` — `classify_brand` tool (Keller
+  architecture; auth-relevant via autoLinkByVerifiedDomain)
+- `server/src/services/prospect-triage.ts` — `assess_prospect` tool
+  (action / owner / priority / company_type enums)
+- `server/src/services/brand-enrichment.ts` — `discover_sub_brands` tool
+  (house expansion)
+
+Each migration ships a unit test pinning: tool definition with the right
+`input_schema` enums, `tool_choice` forces the tool, defensive fall-through
+when the model returns no `tool_use` block, and the runtime allowlist still
+bounds the result.

--- a/server/src/services/brand-classifier.ts
+++ b/server/src/services/brand-classifier.ts
@@ -59,16 +59,10 @@ Key distinctions:
 - A brand that IS the top-level house should have house_domain = null and keller_type = "master".
 - If you're unsure about the corporate domain, set confidence to "medium" or "low".
 
-Respond with ONLY valid JSON (no markdown fences):
-{
-  "keller_type": "master|sub_brand|endorsed|independent",
-  "house_domain": "corporate parent domain or null",
-  "parent_brand": "parent brand name or null",
-  "canonical_domain": "primary consumer domain for this brand",
-  "related_domains": ["other known domains for this entity"],
-  "confidence": "high|medium|low",
-  "reasoning": "one sentence explanation"
-}`;
+Call classify_brand with your assessment.`;
+
+const VALID_KELLER_TYPES: ReadonlyArray<KellerType> = ['master', 'sub_brand', 'endorsed', 'independent'];
+const VALID_CONFIDENCE: ReadonlyArray<'high' | 'medium' | 'low'> = ['high', 'medium', 'low'];
 
 /**
  * Classify a brand's architecture using Sonnet.
@@ -92,22 +86,65 @@ export async function classifyBrand(
   }, null, 2);
 
   try {
+    // Anthropic tool_use with input_schema: the model emits typed args matching
+    // the schema rather than free-form JSON text. Confidence + keller_type are
+    // auth-relevant (autoLinkByVerifiedDomain gates membership inheritance on
+    // confidence='high'), so the schema enum + the runtime allowlist below are
+    // both load-bearing.
     const response = await getClient().messages.create({
       model: ModelConfig.primary,
       max_tokens: 300,
+      tools: [
+        {
+          name: 'classify_brand',
+          description: 'Record the brand architecture classification.',
+          input_schema: {
+            type: 'object',
+            properties: {
+              keller_type: { type: 'string', enum: VALID_KELLER_TYPES as unknown as string[] },
+              house_domain: {
+                type: ['string', 'null'],
+                description: 'Corporate parent domain or null',
+              },
+              parent_brand: {
+                type: ['string', 'null'],
+                description: 'Parent brand name or null',
+              },
+              canonical_domain: {
+                type: 'string',
+                description: 'Primary consumer domain for this brand',
+              },
+              related_domains: {
+                type: 'array',
+                items: { type: 'string' },
+                description: 'Other known domains for this entity',
+              },
+              confidence: { type: 'string', enum: VALID_CONFIDENCE as unknown as string[] },
+              reasoning: { type: 'string', description: 'One sentence explanation' },
+            },
+            required: ['keller_type', 'canonical_domain', 'confidence', 'reasoning'],
+          },
+        },
+      ],
+      tool_choice: { type: 'tool', name: 'classify_brand' },
       messages: [{
         role: 'user',
         content: `${CLASSIFY_PROMPT}\n\nBrand data:\n${brandContext}`,
       }],
     });
 
-    const text = response.content[0].type === 'text' ? response.content[0].text : '';
-    const cleaned = text.replace(/^```(?:json)?\s*\n?/m, '').replace(/\n?```\s*$/m, '').trim();
-    const parsed = JSON.parse(cleaned) as BrandClassification;
+    const toolUse = response.content.find(
+      (block) => block.type === 'tool_use' && block.name === 'classify_brand',
+    );
+    if (!toolUse || toolUse.type !== 'tool_use') {
+      logger.warn({ domain }, 'Brand classifier: model did not invoke classify_brand');
+      return null;
+    }
+    const parsed = toolUse.input as Partial<BrandClassification>;
 
-    // Validate keller_type
-    const validTypes: KellerType[] = ['master', 'sub_brand', 'endorsed', 'independent'];
-    if (!validTypes.includes(parsed.keller_type)) {
+    // Validate keller_type. Schema enum should prevent this at the SDK layer
+    // but the runtime allowlist is the load-bearing defense (auth-relevant).
+    if (!parsed.keller_type || !VALID_KELLER_TYPES.includes(parsed.keller_type)) {
       logger.warn({ domain, keller_type: parsed.keller_type }, 'Invalid keller_type from classifier');
       return null;
     }
@@ -121,8 +158,7 @@ export async function classifyBrand(
     // inheritance in autoLinkByVerifiedDomain). A prompt-injected response
     // setting "confidence": "extreme" or any other unexpected value should
     // collapse to 'low' rather than be persisted as-is.
-    const validConfidence: ReadonlyArray<'high' | 'medium' | 'low'> = ['high', 'medium', 'low'];
-    const confidence: 'high' | 'medium' | 'low' = validConfidence.includes(parsed.confidence as never)
+    const confidence: 'high' | 'medium' | 'low' = VALID_CONFIDENCE.includes(parsed.confidence as never)
       ? (parsed.confidence as 'high' | 'medium' | 'low')
       : 'low';
 
@@ -136,7 +172,6 @@ export async function classifyBrand(
       reasoning: parsed.reasoning || '',
     };
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
     logger.error({ err, domain }, 'Brand classification failed');
     return null;
   }

--- a/server/src/services/brand-enrichment.ts
+++ b/server/src/services/brand-enrichment.ts
@@ -483,12 +483,9 @@ Rules:
 - Focus on the top consumer brands — aim for completeness but prioritize well-known brands
 - Domains must be real, active consumer websites
 
-Respond with ONLY valid JSON (no markdown fences):
-{
-  "brands": [
-    { "brand_name": "Tide", "domain": "tide.com", "keller_type": "sub_brand" }
-  ]
-}`;
+Call discover_sub_brands with the list.`;
+
+const VALID_SUB_KELLER_TYPES = ['sub_brand', 'endorsed'] as const;
 
 /**
  * Use Sonnet to discover sub-brands for a house, then seed and enrich each one.
@@ -527,26 +524,53 @@ export async function expandHouse(houseDomain: string, options: {
   }
 
   const anthropic = new Anthropic();
+  // Anthropic tool_use with input_schema: the model emits typed args matching
+  // the schema rather than free-form JSON text. The keller_type schema enum
+  // constrains values to {sub_brand, endorsed}; the upsert defaults to
+  // 'sub_brand' for any drift.
   const response = await anthropic.messages.create({
     model: ModelConfig.primary,
     max_tokens: 4096,
+    tools: [
+      {
+        name: 'discover_sub_brands',
+        description: 'List the consumer/product brands owned by the corporate house.',
+        input_schema: {
+          type: 'object',
+          properties: {
+            brands: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  brand_name: { type: 'string' },
+                  domain: { type: 'string' },
+                  keller_type: { type: 'string', enum: VALID_SUB_KELLER_TYPES as unknown as string[] },
+                },
+                required: ['brand_name', 'domain', 'keller_type'],
+              },
+            },
+          },
+          required: ['brands'],
+        },
+      },
+    ],
+    tool_choice: { type: 'tool', name: 'discover_sub_brands' },
     messages: [{
       role: 'user',
       content: `${DISCOVER_PROMPT}\n\nCompany: ${houseName}\nCorporate domain: ${houseDomain}\nIndustries: ${((house.brand_manifest?.company as Record<string, unknown>)?.industries as string[] | undefined)?.join(', ') || 'unknown'}`,
     }],
   });
 
-  const text = response.content[0].type === 'text' ? response.content[0].text : '';
-  const cleaned = text.replace(/^```(?:json)?\s*\n?/m, '').replace(/\n?```\s*$/m, '').trim();
-
-  let discovered: DiscoveredSubBrand[];
-  try {
-    const parsed = JSON.parse(cleaned);
-    discovered = Array.isArray(parsed.brands) ? parsed.brands : [];
-  } catch {
-    logger.error({ houseDomain, text: cleaned.slice(0, 200) }, 'Failed to parse Sonnet response');
+  const toolUse = response.content.find(
+    (block) => block.type === 'tool_use' && block.name === 'discover_sub_brands',
+  );
+  if (!toolUse || toolUse.type !== 'tool_use') {
+    logger.error({ houseDomain }, 'House expansion: model did not invoke discover_sub_brands');
     throw new Error('Failed to parse brand discovery response');
   }
+  const parsed = toolUse.input as { brands?: DiscoveredSubBrand[] };
+  const discovered: DiscoveredSubBrand[] = Array.isArray(parsed.brands) ? parsed.brands : [];
 
   logger.info({ houseDomain, count: discovered.length }, 'Discovered sub-brands');
 

--- a/server/src/services/property-enhancement.ts
+++ b/server/src/services/property-enhancement.ts
@@ -89,39 +89,68 @@ Given only the domain name, assess:
 2. What inventory types would it likely carry (display, video, audio, ctv, etc.)?
 3. If it appears to be a subdomain, is it likely a structural subdomain with distinct editorial identity (e.g., sports.example.com) or just a technical subdomain (e.g., cdn.example.com, api.example.com)?
 
-Respond with ONLY valid JSON (no markdown fences):
-{
-  "is_publisher": true|false,
-  "likely_inventory_types": ["display", "video", ...],
-  "structural_subdomain_note": "explanation if subdomain, null if apex domain or not structural",
-  "confidence": "high|medium|low",
-  "reasoning": "one sentence"
-}`;
+Call analyze_property with your assessment.`;
 
-async function analyzeProperty(domain: string): Promise<PropertyAiAnalysis | null> {
+const VALID_CONFIDENCE = ['high', 'medium', 'low'] as const;
+
+export async function analyzeProperty(domain: string): Promise<PropertyAiAnalysis | null> {
   if (!process.env.ANTHROPIC_API_KEY) {
     return null;
   }
 
   try {
+    // Anthropic tool_use with input_schema: the model emits typed args matching
+    // the schema rather than free-form text we'd have to parse. The runtime
+    // filter below stays as defense-in-depth.
     const response = await getClient().messages.create({
       model: ModelConfig.fast,
       max_tokens: 256,
+      tools: [
+        {
+          name: 'analyze_property',
+          description: 'Record the publisher assessment for the domain.',
+          input_schema: {
+            type: 'object',
+            properties: {
+              is_publisher: { type: 'boolean' },
+              likely_inventory_types: {
+                type: 'array',
+                items: { type: 'string' },
+                description: 'e.g. display, video, audio, ctv, native',
+              },
+              structural_subdomain_note: {
+                type: ['string', 'null'],
+                description: 'Explanation if subdomain; null if apex or not structural',
+              },
+              confidence: { type: 'string', enum: VALID_CONFIDENCE as unknown as string[] },
+              reasoning: { type: 'string', description: 'One sentence' },
+            },
+            required: ['is_publisher', 'likely_inventory_types', 'confidence', 'reasoning'],
+          },
+        },
+      ],
+      tool_choice: { type: 'tool', name: 'analyze_property' },
       messages: [{ role: 'user', content: `${ANALYZE_PROMPT}\n\nDomain: ${domain}` }],
     });
 
-    const text = response.content[0]?.type === 'text' ? response.content[0].text : '';
-    const cleaned = text.replace(/^```(?:json)?\s*\n?/m, '').replace(/\n?```\s*$/m, '').trim();
-    const parsed = JSON.parse(cleaned) as PropertyAiAnalysis;
+    const toolUse = response.content.find(
+      (block) => block.type === 'tool_use' && block.name === 'analyze_property',
+    );
+    if (!toolUse || toolUse.type !== 'tool_use') {
+      logger.debug({ domain }, 'Property AI analysis: model did not invoke analyze_property');
+      return null;
+    }
+    const parsed = toolUse.input as Partial<PropertyAiAnalysis>;
 
-    const validConfidence = new Set<string>(['high', 'medium', 'low']);
     return {
       is_publisher: Boolean(parsed.is_publisher),
       likely_inventory_types: Array.isArray(parsed.likely_inventory_types)
         ? parsed.likely_inventory_types.filter((t): t is string => typeof t === 'string')
         : [],
       structural_subdomain_note: parsed.structural_subdomain_note || null,
-      confidence: validConfidence.has(parsed.confidence) ? parsed.confidence as 'high' | 'medium' | 'low' : 'low',
+      confidence: VALID_CONFIDENCE.includes(parsed.confidence as never)
+        ? (parsed.confidence as 'high' | 'medium' | 'low')
+        : 'low',
       reasoning: parsed.reasoning || '',
     };
   } catch (err) {

--- a/server/src/services/prospect-triage.ts
+++ b/server/src/services/prospect-triage.ts
@@ -59,18 +59,7 @@ Your job is to assess email domains to determine if the associated company shoul
 AgenticAdvertising.org members include companies in these categories:
 ${getCompanyTypesDocumentation()}
 
-**Respond with JSON only. No markdown, no explanation.**
-
-Response schema:
-{
-  "action": "skip" | "create",
-  "reason": "brief reason for your decision (one sentence)",
-  "owner": "addie" | "human",
-  "priority": "high" | "standard",
-  "verdict": "two-sentence summary of who this company is and why they are or aren't a good fit",
-  "company_name": "your best guess at the company name based on the domain or enrichment data",
-  "company_type": "adtech" | "agency" | "brand" | "publisher" | "data" | "ai" | "other" | null
-}
+Call assess_prospect with your assessment.
 
 **action: "skip"** when:
 - The company is clearly not in the ad tech / digital media ecosystem
@@ -280,7 +269,7 @@ async function logTriageDecision(
 
 // ─── Claude assessment ─────────────────────────────────────────────────────
 
-async function assessWithClaude(
+export async function assessWithClaude(
   domain: string,
   enrichmentContext: string
 ): Promise<ClaudeTriageResponse> {
@@ -298,34 +287,58 @@ async function assessWithClaude(
 
   const client = new Anthropic({ apiKey });
 
+  // Anthropic tool_use with input_schema: enums on action / owner / priority /
+  // company_type constrain the model output at the SDK layer. The runtime
+  // company_type allowlist below remains as defense-in-depth.
   const response = await client.messages.create({
     model: ModelConfig.fast,
     max_tokens: 512,
     system: TRIAGE_SYSTEM_PROMPT,
+    tools: [
+      {
+        name: 'assess_prospect',
+        description: 'Record the prospect assessment for the domain.',
+        input_schema: {
+          type: 'object',
+          properties: {
+            action: { type: 'string', enum: ['skip', 'create'] },
+            reason: { type: 'string', description: 'Brief reason for your decision (one sentence)' },
+            owner: { type: 'string', enum: ['addie', 'human'] },
+            priority: { type: 'string', enum: ['high', 'standard'] },
+            verdict: {
+              type: 'string',
+              description: 'Two-sentence summary of who this company is and whether they fit',
+            },
+            company_name: {
+              type: 'string',
+              description: 'Best guess at the company name from the domain or enrichment data',
+            },
+            company_type: {
+              type: ['string', 'null'],
+              enum: [...COMPANY_TYPE_VALUES, null] as unknown as string[],
+            },
+          },
+          required: ['action', 'reason', 'owner', 'verdict'],
+        },
+      },
+    ],
+    tool_choice: { type: 'tool', name: 'assess_prospect' },
     messages: [{
       role: 'user',
       content: `Assess this email domain as a potential prospect:\n\nDomain: ${domain}\n\n${enrichmentContext}`,
     }],
   });
 
-  const textBlock = response.content.find(b => b.type === 'text');
-  if (!textBlock || textBlock.type !== 'text') {
-    throw new Error('No text response from Claude');
+  const toolUse = response.content.find(
+    (b) => b.type === 'tool_use' && b.name === 'assess_prospect',
+  );
+  if (!toolUse || toolUse.type !== 'tool_use') {
+    throw new Error('Triage: model did not invoke assess_prospect');
   }
+  const parsed = toolUse.input as ClaudeTriageResponse;
 
-  // Strip markdown code fences if present
-  const text = textBlock.text.trim();
-  const jsonMatch = text.match(/```(?:json)?\s*([\s\S]*?)\s*```/) ?? text.match(/(\{[\s\S]*\})/);
-  const jsonStr = jsonMatch ? jsonMatch[1] : text;
-
-  let parsed: ClaudeTriageResponse;
-  try {
-    parsed = JSON.parse(jsonStr) as ClaudeTriageResponse;
-  } catch (parseErr) {
-    throw new Error(`Claude returned malformed JSON: ${parseErr instanceof Error ? parseErr.message : String(parseErr)}. Raw: ${jsonStr.slice(0, 200)}`);
-  }
-
-  // Ensure company_type is a known value
+  // Defense-in-depth: company_type allowlist (schema enum should already
+  // bound this, but the runtime check guards against schema drift).
   if (parsed.company_type && !COMPANY_TYPE_VALUES.includes(parsed.company_type as (typeof COMPANY_TYPE_VALUES)[number])) {
     parsed.company_type = null;
   }

--- a/server/tests/unit/brand-classifier-tool-use.test.ts
+++ b/server/tests/unit/brand-classifier-tool-use.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Pins the Anthropic tool_use contract for brand-classifier.classifyBrand.
+ *
+ * Auth-relevant fields (keller_type, confidence, house_domain) flow into
+ * autoLinkByVerifiedDomain, which inherits child-brand employees into a
+ * paying parent org's WorkOS membership. The tool_use schema + runtime
+ * allowlists below are the load-bearing defense.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { BrandfetchEnrichmentResult } from '../../src/services/brandfetch.js';
+
+const mocks = vi.hoisted(() => ({
+  anthropicCreate: vi.fn(),
+}));
+
+vi.mock('@anthropic-ai/sdk', () => {
+  class FakeAnthropic {
+    messages = { create: mocks.anthropicCreate };
+  }
+  class APIError extends Error {}
+  return { default: FakeAnthropic, APIError };
+});
+
+function toolUseResponse(input: unknown) {
+  return {
+    content: [
+      { type: 'tool_use', name: 'classify_brand', id: 'toolu_test', input },
+    ],
+  };
+}
+
+const SAMPLE_BRAND_DATA: BrandfetchEnrichmentResult = {
+  success: true,
+  manifest: {
+    name: 'Apple',
+    description: 'Apple makes computers and phones',
+    url: 'https://apple.com',
+    logos: [],
+    colors: [],
+    fonts: [],
+  },
+  company: { industries: ['technology'] },
+  raw: { links: [] },
+} as unknown as BrandfetchEnrichmentResult;
+
+describe('classifyBrand: tool_use contract', () => {
+  let classifyBrand: typeof import('../../src/services/brand-classifier.js').classifyBrand;
+
+  beforeEach(async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key';
+    mocks.anthropicCreate.mockReset();
+    vi.resetModules();
+    ({ classifyBrand } = await import('../../src/services/brand-classifier.js'));
+  });
+
+  it('ships classify_brand with input_schema constraining keller_type and confidence', async () => {
+    mocks.anthropicCreate.mockResolvedValueOnce(
+      toolUseResponse({
+        keller_type: 'master',
+        house_domain: null,
+        parent_brand: null,
+        canonical_domain: 'apple.com',
+        related_domains: [],
+        confidence: 'high',
+        reasoning: 'Top-level corporate brand',
+      }),
+    );
+
+    await classifyBrand('apple.com', SAMPLE_BRAND_DATA);
+
+    expect(mocks.anthropicCreate).toHaveBeenCalledOnce();
+    const call = mocks.anthropicCreate.mock.calls[0][0];
+
+    expect(call.tools).toHaveLength(1);
+    expect(call.tools[0].name).toBe('classify_brand');
+    const schema = call.tools[0].input_schema;
+    expect(schema.properties.keller_type.enum).toEqual(['master', 'sub_brand', 'endorsed', 'independent']);
+    expect(schema.properties.confidence.enum).toEqual(['high', 'medium', 'low']);
+    expect(call.tool_choice).toEqual({ type: 'tool', name: 'classify_brand' });
+  });
+
+  it('reads tool_use.input directly into the classification result', async () => {
+    mocks.anthropicCreate.mockResolvedValueOnce(
+      toolUseResponse({
+        keller_type: 'sub_brand',
+        house_domain: 'disney.com',
+        parent_brand: 'Disney',
+        canonical_domain: 'disneyplus.com',
+        related_domains: ['disney.com'],
+        confidence: 'high',
+        reasoning: 'Disney+ is a Disney sub-brand',
+      }),
+    );
+
+    const result = await classifyBrand('disneyplus.com', SAMPLE_BRAND_DATA);
+    expect(result).toEqual({
+      keller_type: 'sub_brand',
+      house_domain: 'disney.com',
+      parent_brand: 'Disney',
+      canonical_domain: 'disneyplus.com',
+      related_domains: ['disney.com'],
+      confidence: 'high',
+      reasoning: 'Disney+ is a Disney sub-brand',
+    });
+  });
+
+  it('returns null when the model does not emit a tool_use block (defensive)', async () => {
+    mocks.anthropicCreate.mockResolvedValueOnce({
+      content: [{ type: 'text', text: 'I refuse to use the tool' }],
+    });
+
+    const result = await classifyBrand('apple.com', SAMPLE_BRAND_DATA);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when keller_type is not in the runtime allowlist', async () => {
+    // Schema enum prevents this at the SDK layer. Runtime allowlist is the
+    // load-bearing defense (keller_type drives brand-hierarchy inheritance).
+    mocks.anthropicCreate.mockResolvedValueOnce(
+      toolUseResponse({
+        keller_type: 'something_made_up',
+        canonical_domain: 'apple.com',
+        confidence: 'high',
+        reasoning: 'whatever',
+      }),
+    );
+
+    const result = await classifyBrand('apple.com', SAMPLE_BRAND_DATA);
+    expect(result).toBeNull();
+  });
+
+  it('collapses an out-of-allowlist confidence value to "low" (auth-relevant)', async () => {
+    // confidence='high' is what gates membership inheritance in
+    // autoLinkByVerifiedDomain. Any unrecognised value must collapse to 'low'.
+    mocks.anthropicCreate.mockResolvedValueOnce(
+      toolUseResponse({
+        keller_type: 'master',
+        canonical_domain: 'apple.com',
+        confidence: 'extreme',
+        reasoning: 'whatever',
+      }),
+    );
+
+    const result = await classifyBrand('apple.com', SAMPLE_BRAND_DATA);
+    expect(result?.confidence).toBe('low');
+  });
+
+  it('returns null and skips the LLM call when ANTHROPIC_API_KEY is unset', async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    vi.resetModules();
+    const mod = await import('../../src/services/brand-classifier.js');
+    const result = await mod.classifyBrand('apple.com', SAMPLE_BRAND_DATA);
+    expect(result).toBeNull();
+    expect(mocks.anthropicCreate).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/brand-enrichment-expand-house-tool-use.test.ts
+++ b/server/tests/unit/brand-enrichment-expand-house-tool-use.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Pins the Anthropic tool_use contract for brand-enrichment.expandHouse:
+ *   - Ships the discover_sub_brands tool with input_schema (keller_type
+ *     enum bounds returned brands to {sub_brand, endorsed})
+ *   - Forces the tool via tool_choice
+ *   - Reads tool_use.input directly (no JSON.parse, no fence stripping)
+ *   - Defensive throw when the model returns no tool_use block
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  anthropicCreate: vi.fn(),
+  getDiscoveredBrandByDomain: vi.fn(),
+  upsertDiscoveredBrand: vi.fn(),
+  query: vi.fn(),
+  registryRequestsMarkResolved: vi.fn(),
+}));
+
+vi.mock('@anthropic-ai/sdk', () => {
+  class FakeAnthropic {
+    messages = { create: mocks.anthropicCreate };
+  }
+  class APIError extends Error {}
+  return { default: FakeAnthropic, APIError };
+});
+
+vi.mock('../../src/db/brand-db.js', () => ({
+  brandDb: {
+    getDiscoveredBrandByDomain: mocks.getDiscoveredBrandByDomain,
+    upsertDiscoveredBrand: mocks.upsertDiscoveredBrand,
+    deleteDiscoveredBrand: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/db/registry-requests-db.js', () => ({
+  registryRequestsDb: {
+    markResolved: mocks.registryRequestsMarkResolved,
+    listUnresolved: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock('../../src/db/client.js', () => ({
+  getPool: () => ({ query: vi.fn().mockResolvedValue({ rows: [] }) }),
+  query: mocks.query,
+}));
+
+vi.mock('../../src/services/brandfetch.js', () => ({
+  fetchBrandData: vi.fn(),
+  isBrandfetchConfigured: () => false,
+  ENRICHMENT_CACHE_MAX_AGE_MS: 86_400_000,
+}));
+
+vi.mock('../../src/services/logo-cdn.js', () => ({
+  downloadAndCacheLogos: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../../src/services/brand-classifier.js', () => ({
+  classifyBrand: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../../src/services/enrichment.js', () => ({
+  enrichOrganization: vi.fn(),
+}));
+
+vi.mock('../../src/services/lusha.js', () => ({
+  isLushaConfigured: () => false,
+}));
+
+function toolUseResponse(input: unknown) {
+  return {
+    content: [
+      { type: 'tool_use', name: 'discover_sub_brands', id: 'toolu_test', input },
+    ],
+  };
+}
+
+describe('expandHouse: tool_use contract', () => {
+  let expandHouse: typeof import('../../src/services/brand-enrichment.js').expandHouse;
+
+  beforeEach(async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key';
+    mocks.anthropicCreate.mockReset();
+    mocks.getDiscoveredBrandByDomain.mockReset();
+    mocks.upsertDiscoveredBrand.mockReset();
+    mocks.query.mockReset();
+    mocks.registryRequestsMarkResolved.mockReset();
+
+    // Default house: a master brand
+    mocks.getDiscoveredBrandByDomain.mockResolvedValue({
+      domain: 'pg.com',
+      brand_name: 'P&G',
+      keller_type: 'master',
+      brand_manifest: { company: { industries: ['cpg'] } },
+    });
+    mocks.query.mockResolvedValue({ rows: [] }); // no existing sub-brands
+    mocks.upsertDiscoveredBrand.mockResolvedValue({});
+
+    vi.resetModules();
+    ({ expandHouse } = await import('../../src/services/brand-enrichment.js'));
+  });
+
+  it('ships discover_sub_brands with input_schema constraining keller_type', async () => {
+    mocks.anthropicCreate.mockResolvedValueOnce(
+      toolUseResponse({ brands: [] }),
+    );
+
+    await expandHouse('pg.com', { enrichAfterSeed: false });
+
+    expect(mocks.anthropicCreate).toHaveBeenCalledOnce();
+    const call = mocks.anthropicCreate.mock.calls[0][0];
+
+    expect(call.tools).toHaveLength(1);
+    expect(call.tools[0].name).toBe('discover_sub_brands');
+    const schema = call.tools[0].input_schema;
+    expect(schema.properties.brands.items.properties.keller_type.enum).toEqual([
+      'sub_brand',
+      'endorsed',
+    ]);
+    expect(call.tool_choice).toEqual({ type: 'tool', name: 'discover_sub_brands' });
+  });
+
+  it('reads tool_use.input directly and seeds each discovered brand', async () => {
+    mocks.anthropicCreate.mockResolvedValueOnce(
+      toolUseResponse({
+        brands: [
+          { brand_name: 'Tide', domain: 'tide.com', keller_type: 'endorsed' },
+          { brand_name: 'Gillette', domain: 'gillette.com', keller_type: 'endorsed' },
+        ],
+      }),
+    );
+
+    const result = await expandHouse('pg.com', { enrichAfterSeed: false });
+
+    expect(result.discovered).toBe(2);
+    expect(result.seeded).toBe(2);
+    expect(mocks.upsertDiscoveredBrand).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws when the model does not emit a tool_use block (defensive)', async () => {
+    mocks.anthropicCreate.mockResolvedValueOnce({
+      content: [{ type: 'text', text: 'I refuse' }],
+    });
+
+    await expect(expandHouse('pg.com', { enrichAfterSeed: false })).rejects.toThrow(
+      /Failed to parse brand discovery response/,
+    );
+  });
+});

--- a/server/tests/unit/property-enhancement-tool-use.test.ts
+++ b/server/tests/unit/property-enhancement-tool-use.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Pins the Anthropic tool_use contract for property-enhancement.analyzeProperty:
+ *   - Ships the analyze_property tool with input_schema (confidence enum)
+ *   - Forces the tool via tool_choice
+ *   - Reads tool_use.input directly (no JSON.parse, no fence stripping)
+ *   - Defensive fall-through when the model returns no tool_use block
+ *   - Runtime confidence allowlist still bounds bogus enum values
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  anthropicCreate: vi.fn(),
+}));
+
+vi.mock('@anthropic-ai/sdk', () => {
+  class FakeAnthropic {
+    messages = { create: mocks.anthropicCreate };
+  }
+  class APIError extends Error {}
+  return { default: FakeAnthropic, APIError };
+});
+
+// AdAgentsManager and PropertyDatabase are constructed at import time but are
+// not exercised by analyzeProperty.
+vi.mock('../../src/adagents-manager.js', () => ({
+  AdAgentsManager: class {
+    validateDomain = vi.fn();
+  },
+}));
+vi.mock('../../src/db/property-db.js', () => ({
+  PropertyDatabase: class {
+    getHostedPropertyByDomain = vi.fn();
+    createHostedProperty = vi.fn();
+  },
+}));
+vi.mock('../../src/addie/mcp/registry-review.js', () => ({
+  reviewNewRecord: vi.fn().mockResolvedValue(undefined),
+}));
+
+function toolUseResponse(input: unknown) {
+  return {
+    content: [
+      { type: 'tool_use', name: 'analyze_property', id: 'toolu_test', input },
+    ],
+  };
+}
+
+describe('analyzeProperty: tool_use contract', () => {
+  let analyzeProperty: typeof import('../../src/services/property-enhancement.js').analyzeProperty;
+
+  beforeEach(async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key';
+    mocks.anthropicCreate.mockReset();
+    vi.resetModules();
+    ({ analyzeProperty } = await import('../../src/services/property-enhancement.js'));
+  });
+
+  it('ships analyze_property with input_schema and forces it via tool_choice', async () => {
+    mocks.anthropicCreate.mockResolvedValueOnce(
+      toolUseResponse({
+        is_publisher: true,
+        likely_inventory_types: ['display', 'video'],
+        confidence: 'high',
+        reasoning: 'Major news site with ad inventory',
+      }),
+    );
+
+    await analyzeProperty('example.com');
+
+    expect(mocks.anthropicCreate).toHaveBeenCalledOnce();
+    const call = mocks.anthropicCreate.mock.calls[0][0];
+
+    expect(call.tools).toHaveLength(1);
+    expect(call.tools[0].name).toBe('analyze_property');
+    const schema = call.tools[0].input_schema;
+    expect(schema.type).toBe('object');
+    expect(schema.required).toEqual(
+      expect.arrayContaining(['is_publisher', 'likely_inventory_types', 'confidence', 'reasoning']),
+    );
+    expect(schema.properties.confidence.enum).toEqual(['high', 'medium', 'low']);
+    expect(call.tool_choice).toEqual({ type: 'tool', name: 'analyze_property' });
+  });
+
+  it('reads tool_use.input directly into the analysis result', async () => {
+    mocks.anthropicCreate.mockResolvedValueOnce(
+      toolUseResponse({
+        is_publisher: true,
+        likely_inventory_types: ['display'],
+        structural_subdomain_note: null,
+        confidence: 'medium',
+        reasoning: 'Looks like a real publisher',
+      }),
+    );
+
+    const result = await analyzeProperty('example.com');
+    expect(result).toEqual({
+      is_publisher: true,
+      likely_inventory_types: ['display'],
+      structural_subdomain_note: null,
+      confidence: 'medium',
+      reasoning: 'Looks like a real publisher',
+    });
+  });
+
+  it('returns null when the model does not emit a tool_use block (defensive)', async () => {
+    // tool_choice forces the tool, so this path is defensive — it only fires
+    // if the model refuses or the SDK shape changes upstream.
+    mocks.anthropicCreate.mockResolvedValueOnce({
+      content: [{ type: 'text', text: 'I refuse to use the tool' }],
+    });
+
+    const result = await analyzeProperty('example.com');
+    expect(result).toBeNull();
+  });
+
+  it('collapses an out-of-allowlist confidence value to "low" (defense-in-depth)', async () => {
+    // Schema enum should prevent this at the SDK layer; the runtime filter is
+    // the load-bearing defense.
+    mocks.anthropicCreate.mockResolvedValueOnce(
+      toolUseResponse({
+        is_publisher: true,
+        likely_inventory_types: ['display'],
+        confidence: 'extreme',
+        reasoning: 'whatever',
+      }),
+    );
+
+    const result = await analyzeProperty('example.com');
+    expect(result?.confidence).toBe('low');
+  });
+
+  it('returns null and skips the LLM call when ANTHROPIC_API_KEY is unset', async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    vi.resetModules();
+    const mod = await import('../../src/services/property-enhancement.js');
+    const result = await mod.analyzeProperty('example.com');
+    expect(result).toBeNull();
+    expect(mocks.anthropicCreate).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/prospect-triage-tool-use.test.ts
+++ b/server/tests/unit/prospect-triage-tool-use.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Pins the Anthropic tool_use contract for prospect-triage.assessWithClaude:
+ *   - Ships the assess_prospect tool with input_schema (action / owner /
+ *     priority / company_type enums)
+ *   - Forces the tool via tool_choice
+ *   - Reads tool_use.input directly (no JSON.parse, no fence stripping)
+ *   - Defensive throw when the model returns no tool_use block (callers
+ *     already catch this and return action='skip', reason='assessment_error')
+ *   - Runtime company_type allowlist still bounds bogus enum values
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  anthropicCreate: vi.fn(),
+}));
+
+vi.mock('@anthropic-ai/sdk', () => {
+  class FakeAnthropic {
+    messages = { create: mocks.anthropicCreate };
+  }
+  class APIError extends Error {}
+  return { default: FakeAnthropic, APIError };
+});
+
+// db/client and other DB imports are pulled in transitively. Stub them so the
+// module loads without a live pool.
+vi.mock('../../src/db/client.js', () => ({
+  getPool: () => ({ query: vi.fn().mockResolvedValue({ rows: [] }) }),
+}));
+
+vi.mock('../../src/db/system-settings-db.js', () => ({
+  getSetting: vi.fn().mockResolvedValue(null),
+  SETTING_KEYS: { PROSPECT_TRIAGE_ENABLED: 'prospect_triage_enabled' },
+}));
+
+function toolUseResponse(input: unknown) {
+  return {
+    content: [
+      { type: 'tool_use', name: 'assess_prospect', id: 'toolu_test', input },
+    ],
+  };
+}
+
+describe('assessWithClaude: tool_use contract', () => {
+  let assessWithClaude: typeof import('../../src/services/prospect-triage.js').assessWithClaude;
+
+  beforeEach(async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key';
+    mocks.anthropicCreate.mockReset();
+    vi.resetModules();
+    ({ assessWithClaude } = await import('../../src/services/prospect-triage.js'));
+  });
+
+  it('ships assess_prospect with input_schema constraining action/owner/priority/company_type', async () => {
+    mocks.anthropicCreate.mockResolvedValueOnce(
+      toolUseResponse({
+        action: 'create',
+        reason: 'Mid-market ad tech',
+        owner: 'addie',
+        priority: 'high',
+        verdict: 'Programmatic vendor in our target segment',
+        company_name: 'Example AdTech',
+        company_type: 'adtech',
+      }),
+    );
+
+    await assessWithClaude('example.com', 'Industry: Advertising');
+
+    expect(mocks.anthropicCreate).toHaveBeenCalledOnce();
+    const call = mocks.anthropicCreate.mock.calls[0][0];
+
+    expect(call.tools).toHaveLength(1);
+    expect(call.tools[0].name).toBe('assess_prospect');
+    const schema = call.tools[0].input_schema;
+    expect(schema.properties.action.enum).toEqual(['skip', 'create']);
+    expect(schema.properties.owner.enum).toEqual(['addie', 'human']);
+    expect(schema.properties.priority.enum).toEqual(['high', 'standard']);
+    // company_type enum should mirror COMPANY_TYPE_VALUES + null fallback
+    expect(schema.properties.company_type.enum).toEqual(
+      expect.arrayContaining(['adtech', 'agency', 'brand', 'publisher', 'data', 'ai', 'other']),
+    );
+    expect(call.tool_choice).toEqual({ type: 'tool', name: 'assess_prospect' });
+  });
+
+  it('reads tool_use.input directly into the triage response', async () => {
+    mocks.anthropicCreate.mockResolvedValueOnce(
+      toolUseResponse({
+        action: 'create',
+        reason: 'Programmatic vendor',
+        owner: 'addie',
+        priority: 'standard',
+        verdict: 'Mid-market ad tech',
+        company_name: 'Example',
+        company_type: 'adtech',
+      }),
+    );
+
+    const result = await assessWithClaude('example.com', '');
+    expect(result).toEqual({
+      action: 'create',
+      reason: 'Programmatic vendor',
+      owner: 'addie',
+      priority: 'standard',
+      verdict: 'Mid-market ad tech',
+      company_name: 'Example',
+      company_type: 'adtech',
+    });
+  });
+
+  it('throws when the model does not emit a tool_use block (defensive)', async () => {
+    // tool_choice forces the tool, so this is defensive. Callers
+    // (triageEmailDomain) catch the throw and return action='skip',
+    // reason='assessment_error'.
+    mocks.anthropicCreate.mockResolvedValueOnce({
+      content: [{ type: 'text', text: 'I refuse' }],
+    });
+
+    await expect(assessWithClaude('example.com', '')).rejects.toThrow(/did not invoke assess_prospect/);
+  });
+
+  it('collapses an out-of-allowlist company_type to null (defense-in-depth)', async () => {
+    mocks.anthropicCreate.mockResolvedValueOnce(
+      toolUseResponse({
+        action: 'create',
+        reason: 'Some reason',
+        owner: 'addie',
+        priority: 'standard',
+        verdict: 'verdict text',
+        company_name: 'Example',
+        company_type: 'crystal_ball',
+      }),
+    );
+
+    const result = await assessWithClaude('example.com', '');
+    expect(result.company_type).toBeNull();
+  });
+
+  it('defaults priority to "standard" when missing or out of allowlist', async () => {
+    mocks.anthropicCreate.mockResolvedValueOnce(
+      toolUseResponse({
+        action: 'create',
+        reason: 'Some reason',
+        owner: 'addie',
+        verdict: 'verdict',
+        company_name: 'Example',
+      }),
+    );
+
+    const result = await assessWithClaude('example.com', '');
+    expect(result.priority).toBe('standard');
+  });
+
+  it('returns the no-Claude fallback when ANTHROPIC_API_KEY is unset', async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    vi.resetModules();
+    const mod = await import('../../src/services/prospect-triage.js');
+    const result = await mod.assessWithClaude('example.com', '');
+    expect(result.reason).toBe('claude_not_configured');
+    expect(mocks.anthropicCreate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Sweep adopting the Anthropic `tool_use` + `input_schema` pattern that PR #3396 introduced for the smart-paste property parse endpoint. Each migrated caller defines a tool with `input_schema`, sets `tool_choice: { type: 'tool', name: '...' }` to force it, and reads `tool_use.input` directly — eliminating the `JSON.parse` / fence-stripping / regex-extraction class of bug *and* closing the prompt-injection surface that came with text-output parsing.

One commit per converted file so any single conversion can be reverted independently if real-model behaviour diverges.

### Converted

- `server/src/services/property-enhancement.ts` — `analyze_property` tool (publisher assessment, confidence enum)
- `server/src/services/brand-classifier.ts` — `classify_brand` tool (auth-relevant via `autoLinkByVerifiedDomain`; keller_type + confidence enums)
- `server/src/services/prospect-triage.ts` — `assess_prospect` tool (action / owner / priority / company_type enums)
- `server/src/services/brand-enrichment.ts` — `discover_sub_brands` tool (house expansion; keller_type enum)

Each migration ships a unit test that pins: tool definition with the right `input_schema` enums, `tool_choice` forces the tool, defensive fall-through when the model returns no `tool_use` block, and the runtime allowlist still bounds the result.

### Surveyed but not migrated

- `server/src/utils/llm.ts`, `server/src/utils/batch.ts` — generic completion / batch helpers that return free-form text by design.
- `server/src/routes/webhooks.ts` — `extractInsightsWithClaude` returns a 2-4 sentence insight summary; not JSON-parsed.
- `server/src/routes/addie-admin.ts` — diagnosis endpoint returns a free-form analysis string.
- `server/src/services/prospect-cleanup.ts` — already uses `tool_use` (multi-turn agent loop with explicit tools); final response is intentional prose.
- `server/src/addie/**` — explicitly out of scope per the brief (Addie's main chat router is a complex orchestration path).

## Test plan

- [x] `npm run typecheck` from repo root
- [x] `vitest run` for the four new unit test files (20/20 pass)
- [ ] Real-model smoke check after merge — the canonical example (#3396) is already running this pattern in production for the property-parse endpoint, so the SDK contract is exercised live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)