### PR TITLE
audit: detect Stripe→DB drift (Lina-class missed-webhook) (closes detect path of #3623)

### DIFF
--- a/.changeset/stripe-sub-reflected-in-org-row-invariant.md
+++ b/.changeset/stripe-sub-reflected-in-org-row-invariant.md
@@ -1,0 +1,6 @@
+---
+---
+
+audit: add `stripe-sub-reflected-in-org-row` integrity invariant.
+
+Walks Stripe (active + trialing membership subs), flags orgs whose row doesn't reflect the live Stripe state — the inverse direction of the existing `org-row-matches-live-stripe-sub`. Catches the missed-`customer.subscription.created` failure mode that left a paying member blocked from entitlement for ~40 days. Detect-only; auto-remediation is a separate follow-up. Orphan Stripe customers (paid sub, no AAO org link) are flagged as `warning`, never auto-linked. Closes detect path of #3623.

--- a/server/src/audit/integrity/README.md
+++ b/server/src/audit/integrity/README.md
@@ -69,7 +69,7 @@ The runner executes invariants sequentially. One throwing doesn't cancel the oth
 
 - **Auto-remediation.** Phase 1 detects; humans decide. Auto-fix is Phase 3+.
 - **Real-time monitoring.** Webhooks remain the primary sync mechanism. Invariants catch what webhooks miss.
-- **Stripe-customer enumeration.** We walk AAO orgs and check Stripe for each. Catching orphans on the *Stripe* side (customers with no AAO row) requires the inverse walk and is Phase 3+.
+- **Auto-link of orphan Stripe customers.** `stripe-sub-reflected-in-org-row` walks Stripe and flags subs whose customer has no AAO org. It does **not** auto-link them — that path inherits a known dedup vulnerability in `createStripeCustomer` and is a hijack-to-membership vector if automated. A human admin links via `POST /api/admin/billing/customers/:customerId/link`.
 - **Replace `POST /api/admin/accounts/:orgId/sync`.** That endpoint is for explicit single-org reconciliation. Invariants tell you which orgs to sync.
 
 ## Reference

--- a/server/src/audit/integrity/invariants/index.ts
+++ b/server/src/audit/integrity/invariants/index.ts
@@ -13,6 +13,7 @@ import { stripeCustomerOrgMetadataBidirectionalInvariant } from './stripe-custom
 import { oneActiveStripeSubPerOrgInvariant } from './one-active-stripe-sub-per-org.js';
 import { stripeCustomerResolvesInvariant } from './stripe-customer-resolves.js';
 import { orgRowMatchesLiveStripeSubInvariant } from './org-row-matches-live-stripe-sub.js';
+import { stripeSubReflectedInOrgRowInvariant } from './stripe-sub-reflected-in-org-row.js';
 import { workosMembershipRowExistsInWorkosInvariant } from './workos-membership-row-exists-in-workos.js';
 import { usersHavePrimaryOrganizationInvariant } from './users-have-primary-organization.js';
 
@@ -23,6 +24,7 @@ export const ALL_INVARIANTS: readonly Invariant[] = [
   oneActiveStripeSubPerOrgInvariant,
   stripeCustomerResolvesInvariant,
   orgRowMatchesLiveStripeSubInvariant,
+  stripeSubReflectedInOrgRowInvariant,
   workosMembershipRowExistsInWorkosInvariant,
 ];
 

--- a/server/src/audit/integrity/invariants/stripe-sub-reflected-in-org-row.ts
+++ b/server/src/audit/integrity/invariants/stripe-sub-reflected-in-org-row.ts
@@ -1,0 +1,187 @@
+/**
+ * Invariant: every paid membership subscription that is live in Stripe is
+ * reflected in the AAO `organizations` row for its linked org. Catches the
+ * inverse direction from `org-row-matches-live-stripe-sub`: that one starts
+ * at orgs we already think are subscribed and verifies Stripe agrees. This
+ * one starts at Stripe and verifies our DB caught up.
+ *
+ * Motivating incident: a member paid for Professional, Stripe recorded the
+ * subscription as `active`, the customer was correctly linked to her org —
+ * but `customer.subscription.created` never updated the org row. She had
+ * `subscription_status: NULL` for ~40 days while Stripe billed her, and was
+ * blocked from paid certification content the whole time.
+ *
+ * Detect-only by design. The framework's auto-remediation policy lives at
+ * Phase 3+; for now violations are surfaced for an admin to act on via
+ * `POST /api/admin/accounts/:orgId/sync`. The orphan-customer branch
+ * (Stripe customer with paid sub, not linked to any org) is intentionally
+ * not auto-linked — that path inherits the email-based dedup vulnerability
+ * in `createStripeCustomer` and is a Stripe-customer-hijack-to-membership
+ * attack vector if automated.
+ */
+import type Stripe from 'stripe';
+import type { Invariant, InvariantContext, InvariantResult, Violation } from '../types.js';
+
+/**
+ * Subscriptions whose price `lookup_key` starts with one of these prefixes
+ * are membership subs that drive entitlement. Anything else (one-off
+ * invoice line items, test products, future non-membership subs) is out of
+ * scope — we don't want to flag drift on a non-membership sub.
+ */
+const MEMBERSHIP_LOOKUP_KEY_PREFIXES = ['aao_membership_', 'aao_invoice_'] as const;
+
+/**
+ * Stripe statuses that grant entitlement at AAO. Mirrors the gate logic
+ * elsewhere in the codebase. `past_due` keeps access during dunning; the
+ * customer hasn't lost access just because a payment retry is pending.
+ */
+const ENTITLED_STATUSES = new Set<Stripe.Subscription.Status>(['active', 'trialing', 'past_due']);
+
+function isMembershipPrice(lookupKey: string | null | undefined): boolean {
+  if (!lookupKey) return false;
+  return MEMBERSHIP_LOOKUP_KEY_PREFIXES.some((p) => lookupKey.startsWith(p));
+}
+
+function customerIdOf(sub: Stripe.Subscription): string {
+  return typeof sub.customer === 'string' ? sub.customer : sub.customer.id;
+}
+
+function priceFieldsOf(sub: Stripe.Subscription): {
+  lookup_key: string | null;
+  unit_amount: number | null;
+} {
+  const price = sub.items.data[0]?.price;
+  return {
+    lookup_key: price?.lookup_key ?? null,
+    unit_amount: price?.unit_amount ?? null,
+  };
+}
+
+interface OrgRow {
+  workos_organization_id: string;
+  name: string;
+  stripe_customer_id: string;
+  subscription_status: string | null;
+  stripe_subscription_id: string | null;
+}
+
+export const stripeSubReflectedInOrgRowInvariant: Invariant = {
+  name: 'stripe-sub-reflected-in-org-row',
+  description:
+    'Every membership subscription that is active or trialing in Stripe is reflected in the org row for its linked customer. Catches missed `customer.subscription.created` and `customer.subscription.updated` webhooks that leave a paying member with no entitlement in our DB.',
+  severity: 'critical',
+  async check(ctx: InvariantContext): Promise<InvariantResult> {
+    const { pool, stripe, logger } = ctx;
+    const violations: Violation[] = [];
+
+    // Two list calls, server-side filtered, regardless of customer count.
+    // Cheaper than walking customers (2N+ calls) and bounded by the count of
+    // live entitling subs, which is small at AAO scale.
+    const memberSubs: Stripe.Subscription[] = [];
+    for (const status of ['active', 'trialing'] as const) {
+      for await (const sub of stripe.subscriptions.list({ status, limit: 100 })) {
+        const { lookup_key } = priceFieldsOf(sub);
+        if (!isMembershipPrice(lookup_key)) continue;
+        memberSubs.push(sub);
+      }
+    }
+
+    if (memberSubs.length === 0) {
+      return { checked: 0, violations: [] };
+    }
+
+    const customerIds = Array.from(new Set(memberSubs.map(customerIdOf)));
+
+    const orgsResult = await pool.query<OrgRow>(
+      `SELECT workos_organization_id, name, stripe_customer_id,
+              subscription_status, stripe_subscription_id
+         FROM organizations
+        WHERE stripe_customer_id = ANY($1::text[])`,
+      [customerIds],
+    );
+    const customerToOrg = new Map<string, OrgRow>(
+      orgsResult.rows.map((r) => [r.stripe_customer_id, r]),
+    );
+
+    for (const sub of memberSubs) {
+      const customerId = customerIdOf(sub);
+      const { lookup_key, unit_amount } = priceFieldsOf(sub);
+      const org = customerToOrg.get(customerId);
+
+      if (!org) {
+        // Stripe customer holds a paid membership sub but has no AAO org
+        // pointing at it. Could be: (a) abandoned-checkout customer that got
+        // re-used, (b) customer linked to org that was later merged/deleted,
+        // (c) test-mode bleed (shouldn't happen in live env), (d) a real
+        // org-link that needs a human admin to make.
+        //
+        // Severity is `warning`, not `critical`: no AAO user is being denied
+        // entitlement (there's no AAO user attached). Auto-linking on email
+        // or metadata is unsafe — `createStripeCustomer`'s dedup lookups have
+        // a known collision path that an attacker could exploit by getting
+        // their Stripe-customer email matched to a victim's org.
+        violations.push({
+          invariant: 'stripe-sub-reflected-in-org-row',
+          severity: 'warning',
+          subject_type: 'customer',
+          subject_id: customerId,
+          message:
+            `Stripe customer ${customerId} holds ${sub.status} membership subscription ${sub.id} ` +
+            `(${lookup_key ?? 'no lookup_key'}) but is not linked to any AAO organization.`,
+          details: {
+            stripe_subscription_id: sub.id,
+            stripe_status: sub.status,
+            lookup_key,
+            unit_amount,
+            customer_email:
+              typeof sub.customer === 'string' || sub.customer.deleted
+                ? null
+                : sub.customer.email,
+          },
+          remediation_hint:
+            'Use the admin UI to link this customer to its org via POST /api/admin/billing/customers/:customerId/link. Do not auto-link — that path is a Stripe-customer-hijack vector.',
+        });
+        continue;
+      }
+
+      // Healthy: row reflects Stripe entitlement. No-op.
+      if (org.subscription_status && ENTITLED_STATUSES.has(org.subscription_status as Stripe.Subscription.Status)) {
+        continue;
+      }
+
+      // Lina-class: paying customer is being denied access. Stripe says
+      // entitled, our DB does not.
+      violations.push({
+        invariant: 'stripe-sub-reflected-in-org-row',
+        severity: 'critical',
+        subject_type: 'organization',
+        subject_id: org.workos_organization_id,
+        message:
+          `Org "${org.name}" has paid membership subscription ${sub.id} live in Stripe ` +
+          `(${sub.status}) but DB row shows subscription_status=${JSON.stringify(org.subscription_status)}. ` +
+          `Member is incorrectly being denied entitlement.`,
+        details: {
+          org_name: org.name,
+          stripe_customer_id: customerId,
+          stripe_subscription_id: sub.id,
+          stripe_status: sub.status,
+          db_subscription_status: org.subscription_status,
+          db_stripe_subscription_id: org.stripe_subscription_id,
+          lookup_key,
+          unit_amount,
+        },
+        remediation_hint:
+          `POST /api/admin/accounts/${org.workos_organization_id}/sync to pull fresh state from Stripe and unblock the member. Investigate why the customer.subscription.created/updated webhook didn't fire (Stripe dashboard webhook delivery log).`,
+      });
+    }
+
+    if (memberSubs.length > 0 && violations.length > 0) {
+      logger.warn(
+        { invariant: 'stripe-sub-reflected-in-org-row', total_subs: memberSubs.length, violations: violations.length },
+        'Stripe→DB reconciliation found drift',
+      );
+    }
+
+    return { checked: memberSubs.length, violations };
+  },
+};

--- a/server/tests/unit/integrity/invariants.test.ts
+++ b/server/tests/unit/integrity/invariants.test.ts
@@ -10,11 +10,12 @@ import { stripeCustomerOrgMetadataBidirectionalInvariant } from '../../../src/au
 import { oneActiveStripeSubPerOrgInvariant } from '../../../src/audit/integrity/invariants/one-active-stripe-sub-per-org.js';
 import { stripeCustomerResolvesInvariant } from '../../../src/audit/integrity/invariants/stripe-customer-resolves.js';
 import { orgRowMatchesLiveStripeSubInvariant } from '../../../src/audit/integrity/invariants/org-row-matches-live-stripe-sub.js';
+import { stripeSubReflectedInOrgRowInvariant } from '../../../src/audit/integrity/invariants/stripe-sub-reflected-in-org-row.js';
 import { workosMembershipRowExistsInWorkosInvariant } from '../../../src/audit/integrity/invariants/workos-membership-row-exists-in-workos.js';
 import { ALL_INVARIANTS, getInvariantByName } from '../../../src/audit/integrity/invariants/index.js';
 import type { InvariantContext } from '../../../src/audit/integrity/types.js';
 
-const EXPECTED_INVARIANT_COUNT = 6;
+const EXPECTED_INVARIANT_COUNT = 7;
 
 const mockPoolQuery = vi.fn();
 const mockStripeCustomersRetrieve = vi.fn();
@@ -342,6 +343,185 @@ describe('org-row-matches-live-stripe-sub', () => {
     expect(result.violations).toHaveLength(1);
     expect(result.violations[0].severity).toBe('critical');
     expect(result.violations[0].message).toContain('non-existent');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// stripe-sub-reflected-in-org-row
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('stripe-sub-reflected-in-org-row', () => {
+  function membershipSub(overrides: Partial<{
+    id: string;
+    status: 'active' | 'trialing' | 'past_due' | 'canceled' | 'incomplete';
+    customer: string;
+    lookup_key: string;
+    unit_amount: number;
+  }> = {}) {
+    return {
+      id: overrides.id ?? 'sub_1',
+      status: overrides.status ?? 'active',
+      customer: overrides.customer ?? 'cus_1',
+      items: {
+        data: [{
+          price: {
+            lookup_key: overrides.lookup_key ?? 'aao_membership_professional_250',
+            unit_amount: overrides.unit_amount ?? 25000,
+          },
+        }],
+      },
+    };
+  }
+
+  /**
+   * `for await ... of stripe.subscriptions.list(...)` consumes the auto-paginating
+   * iterator. Mock returns an async-iterable. First call ⇒ active subs, second ⇒ trialing.
+   */
+  function mockSubsListWith(activeSubs: unknown[], trialingSubs: unknown[] = []): void {
+    mockStripeSubsList
+      .mockImplementationOnce(() => ({
+        async *[Symbol.asyncIterator]() { for (const s of activeSubs) yield s; },
+      }))
+      .mockImplementationOnce(() => ({
+        async *[Symbol.asyncIterator]() { for (const s of trialingSubs) yield s; },
+      }));
+  }
+
+  it('passes when every live membership sub is reflected in its org row', async () => {
+    mockSubsListWith([membershipSub()]);
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{
+        workos_organization_id: 'org_1',
+        name: 'Acme',
+        stripe_customer_id: 'cus_1',
+        subscription_status: 'active',
+        stripe_subscription_id: 'sub_1',
+      }],
+    });
+
+    const result = await stripeSubReflectedInOrgRowInvariant.check(makeCtx());
+
+    expect(result.checked).toBe(1);
+    expect(result.violations).toEqual([]);
+  });
+
+  it('flags Lina-shape: paid sub live in Stripe, DB row has subscription_status NULL', async () => {
+    mockSubsListWith([membershipSub({ id: 'sub_lina', customer: 'cus_lina' })]);
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{
+        workos_organization_id: 'org_lina',
+        name: "Lina Georg's Workspace",
+        stripe_customer_id: 'cus_lina',
+        subscription_status: null,
+        stripe_subscription_id: null,
+      }],
+    });
+
+    const result = await stripeSubReflectedInOrgRowInvariant.check(makeCtx());
+
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].severity).toBe('critical');
+    expect(result.violations[0].subject_type).toBe('organization');
+    expect(result.violations[0].subject_id).toBe('org_lina');
+    expect(result.violations[0].message).toContain('denied entitlement');
+    expect(result.violations[0].details?.db_subscription_status).toBeNull();
+    expect(result.violations[0].details?.stripe_status).toBe('active');
+    expect(result.violations[0].remediation_hint).toContain('/api/admin/accounts/org_lina/sync');
+  });
+
+  it('flags trialing subs the same way as active', async () => {
+    mockSubsListWith([], [membershipSub({ status: 'trialing', id: 'sub_t', customer: 'cus_t' })]);
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{
+        workos_organization_id: 'org_t',
+        name: 'Trial Co',
+        stripe_customer_id: 'cus_t',
+        subscription_status: null,
+        stripe_subscription_id: null,
+      }],
+    });
+
+    const result = await stripeSubReflectedInOrgRowInvariant.check(makeCtx());
+
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].severity).toBe('critical');
+    expect(result.violations[0].details?.stripe_status).toBe('trialing');
+  });
+
+  it('flags orphan customer (paid sub, no AAO org linked) as warning, not critical', async () => {
+    mockSubsListWith([membershipSub({ id: 'sub_orphan', customer: 'cus_orphan' })]);
+    mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+
+    const result = await stripeSubReflectedInOrgRowInvariant.check(makeCtx());
+
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].severity).toBe('warning');
+    expect(result.violations[0].subject_type).toBe('customer');
+    expect(result.violations[0].subject_id).toBe('cus_orphan');
+    expect(result.violations[0].message).toContain('not linked to any AAO organization');
+    expect(result.violations[0].remediation_hint).toContain('Do not auto-link');
+  });
+
+  it('skips non-membership subs (other product lookup_keys)', async () => {
+    mockSubsListWith([
+      membershipSub({ id: 'sub_one_off', lookup_key: 'aao_event_summit_2026', customer: 'cus_evt' }),
+    ]);
+    // The DB query should not even be issued for non-membership subs — they're filtered before the SQL.
+    // But if the implementation issues it anyway, return empty so we still see no violation.
+    mockPoolQuery.mockResolvedValue({ rows: [] });
+
+    const result = await stripeSubReflectedInOrgRowInvariant.check(makeCtx());
+
+    expect(result.checked).toBe(0);
+    expect(result.violations).toEqual([]);
+  });
+
+  it('skips subs with no lookup_key (probably misconfigured)', async () => {
+    const sub = membershipSub();
+    (sub.items.data[0].price as { lookup_key: string | null }).lookup_key = null;
+    mockSubsListWith([sub]);
+    mockPoolQuery.mockResolvedValue({ rows: [] });
+
+    const result = await stripeSubReflectedInOrgRowInvariant.check(makeCtx());
+
+    expect(result.checked).toBe(0);
+    expect(result.violations).toEqual([]);
+  });
+
+  it('does not flag a row with subscription_status="past_due" — dunning still grants entitlement', async () => {
+    mockSubsListWith([membershipSub({ status: 'active', customer: 'cus_pd' })]);
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{
+        workos_organization_id: 'org_pd',
+        name: 'PastDue Co',
+        stripe_customer_id: 'cus_pd',
+        subscription_status: 'past_due',
+        stripe_subscription_id: 'sub_1',
+      }],
+    });
+
+    const result = await stripeSubReflectedInOrgRowInvariant.check(makeCtx());
+
+    expect(result.violations).toEqual([]);
+  });
+
+  it('flags a row that drifted to "canceled" while Stripe still says active', async () => {
+    mockSubsListWith([membershipSub({ customer: 'cus_drift' })]);
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{
+        workos_organization_id: 'org_drift',
+        name: 'Drift Co',
+        stripe_customer_id: 'cus_drift',
+        subscription_status: 'canceled',
+        stripe_subscription_id: 'sub_1',
+      }],
+    });
+
+    const result = await stripeSubReflectedInOrgRowInvariant.check(makeCtx());
+
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].severity).toBe('critical');
+    expect(result.violations[0].details?.db_subscription_status).toBe('canceled');
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a new integrity invariant `stripe-sub-reflected-in-org-row` that walks Stripe (active + trialing membership subs) and flags orgs whose row doesn't reflect the live Stripe state. The inverse direction of the existing `org-row-matches-live-stripe-sub`.

This is **Path A** of #3623 — detect-only. Path B (auto-remediation via webhook-equivalent code path) is a separate follow-up that needs to fix `subscriptions.data[0]` in `/sync` and add agreement-attestation/audit writes before it's safe to ship.

## Why

A real paying member ("Lina"/`twiegle@gmail.com`, org `org_01KM5NSVM6JECGPJNK1HZM1KNT`, Stripe customer `cus_UF4bVR6XyNSeSk`) paid \$250 for Professional on 2026-03-30. Stripe recorded the subscription as `active`. Customer was correctly linked to her org. But `customer.subscription.created` never updated the org row — `subscription_status` stayed `NULL` for ~40 days while she was being billed. She was blocked from paid certification content (S2 Creative Specialist) the whole time. Resolved manually by calling `POST /api/admin/accounts/:orgId/sync` once.

The existing invariant only checks orgs we *already think are subscribed* (`subscription_status IN ('active','trialing','past_due')`). Lina's row had `subscription_status = NULL`, so the existing invariant was structurally blind to her case.

## What it does

For each Stripe subscription with status `active` or `trialing` whose price `lookup_key` starts with `aao_membership_` or `aao_invoice_`:

- **Org row reflects entitlement** (`subscription_status` in active/trialing/past_due) → no-op.
- **Org row exists but doesn't reflect entitlement** → `critical` violation. Paying member is being denied access. Remediation hint points at `POST /api/admin/accounts/:orgId/sync`.
- **No AAO org linked to the customer** → `warning`, subject `customer`. Deliberately NOT auto-linked: that path inherits the email-dedup vulnerability in `createStripeCustomer` and would be a Stripe-customer-hijack-to-membership vector if automated.

Two Stripe API calls (`subscriptions.list({status:'active'})`, `subscriptions.list({status:'trialing'})`), one DB query, regardless of customer count.

## What it deliberately doesn't do

- **Auto-remediate.** Phase 1 of the audit framework is detect-only. Path B / Phase 2 will add safe auto-remediation that goes through a webhook-equivalent code path (so agreement attestation, audit log, and activity records are written — the `/sync` endpoint skips those).
- **Auto-link orphan Stripe customers.** Hijack vector. Humans link via the existing admin tooling.
- **Reverse remediation** (downgrade access). Never. The invariant only flags entitlement *gaps*, not entitlement *excess*.
- **Filter by `subscription_status='canceled'` direction.** Out of scope for Path A. The existing invariant catches some of this; Path B will rationalize.

## Expert review pushback applied

- adtech / javascript-protocol-expert: don't reuse `customers.list` + invoice lookups (3N calls); use `subscriptions.list({status:'active'|'trialing'})` (2 calls). Done.
- security-reviewer: never auto-link orphan customers; the `/sync` endpoint skips agreement-attestation, so any auto-remediation must use a webhook-equivalent path (deferred to Path B). Done.
- data-analyst: at AAO scale (1,659 orgs, 146 active subs), single-shot run is ~7s with this shape; no cursor needed.

Severity model: `critical | warning | info`. The original issue text said `error`, which doesn't exist — corrected to `critical`.

## Test plan

- [x] Unit tests added covering: happy path, Lina shape (NULL DB row), trialing subs, orphan customer, non-membership filter, missing lookup_key, past_due-as-still-entitled, drift to canceled
- [x] `npx vitest run tests/unit/integrity/` → 46 passed
- [x] `npx tsc --noEmit` → clean
- [x] Pre-commit hook ran full unit + typecheck successfully
- [ ] Once merged + deployed: trigger `GET /api/admin/integrity/check/stripe-sub-reflected-in-org-row` against prod to surface any other Lina-class members currently being silently denied access (first-run discovery)

## Closes / refs

- Detect path of #3623 (auto-remediation is the second PR)
- Triggering escalation: Addie escalation #296 (2026-04-29)
- Companion track #3589 (entitlement reconciliation, separate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)