### PR TITLE
fix(server): add rate limiter to POST /api/content/fetch-url

### DIFF
--- a/.changeset/fix-fetch-url-rate-limiter.md
+++ b/.changeset/fix-fetch-url-rate-limiter.md
@@ -1,0 +1,6 @@
+---
+---
+
+Add rate limiter to `POST /api/content/fetch-url` (URL metadata auto-fill endpoint). The endpoint was previously unbounded: each call allocates a new `undici.Agent` and makes an outbound HTTP request, making it a resource-exhaustion path for authenticated users. Limit set to 30 requests per 15 minutes per user via `PostgresStore` (synchronous DB write, enforced consistently across all pods). Non-breaking: under-limit requests are unaffected.
+
+Follow-up tracked: `response.text()` at the call site buffers the full response body with no size cap — a separate concern not introduced here.

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -1,7 +1,7 @@
 import rateLimit from 'express-rate-limit';
 import type { Request, Response } from 'express';
 import { createLogger } from '../logger.js';
-import { CachedPostgresStore } from './pg-rate-limit-store.js';
+import { CachedPostgresStore, PostgresStore } from './pg-rate-limit-store.js';
 
 const logger = createLogger('rate-limit');
 
@@ -393,6 +393,39 @@ export const adminContentWriteRateLimiter = rateLimit({
     res.status(429).json({
       error: 'Too many requests',
       message: 'Admin content write rate limit exceeded. Please try again later.',
+      retryAfter: Math.ceil(15 * 60),
+    });
+  },
+});
+
+/**
+ * Rate limiter for the fetch-url endpoint (URL metadata auto-fill).
+ * Limits: 30 fetches per 15 minutes per user.
+ *
+ * Uses PostgresStore (synchronous DB write per request) rather than
+ * CachedPostgresStore because each call already allocates a new undici Agent
+ * and makes an outbound HTTP request. The extra DB round-trip is negligible,
+ * and it ensures the cap is enforced consistently across all pods without the
+ * 15-second in-memory flush window that CachedPostgresStore uses.
+ */
+export const contentFetchUrlRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  store: new PostgresStore('content-fetch-url:'),
+  keyGenerator: generateKey,
+  validate: { keyGeneratorIpFallback: false },
+  handler: (req: Request, res: Response) => {
+    logger.warn({
+      userId: (req as any).user?.id,
+      ip: req.ip,
+      path: req.path,
+    }, 'Rate limit exceeded for URL fetch');
+
+    res.status(429).json({
+      error: 'Too many requests',
+      message: 'URL fetch rate limit exceeded. Please try again later.',
       retryAfter: Math.ceil(15 * 60),
     });
   },

--- a/server/src/routes/content.ts
+++ b/server/src/routes/content.ts
@@ -12,7 +12,7 @@ import { Router } from 'express';
 import multer from 'multer';
 import { createLogger } from '../logger.js';
 import { requireAuth } from '../middleware/auth.js';
-import { contentProposeRateLimiter } from '../middleware/rate-limit.js';
+import { contentProposeRateLimiter, contentFetchUrlRateLimiter } from '../middleware/rate-limit.js';
 import { getPool } from '../db/client.js';
 import { isWebUserAAOAdmin } from '../addie/mcp/admin-tools.js';
 import { sendChannelMessage } from '../slack/client.js';
@@ -1118,7 +1118,7 @@ export function createContentRouter(): Router {
   });
 
   // POST /api/content/fetch-url - Fetch URL metadata for auto-fill
-  router.post('/fetch-url', requireAuth, async (req, res) => {
+  router.post('/fetch-url', requireAuth, contentFetchUrlRateLimiter, async (req, res) => {
     try {
       const { url } = req.body;
 


### PR DESCRIPTION
Refs #3619

## Summary

`POST /api/content/fetch-url` was the only user-triggered content endpoint without a rate limiter. Each call allocates a new `undici.Agent` and makes an outbound HTTP request — creating an authenticated resource-exhaustion path. A burst of calls before GC reclaims Agents amplifies memory growth proportional to in-flight + recently-completed calls.

This PR adds `contentFetchUrlRateLimiter`: 30 requests per 15 minutes per user. Uses `PostgresStore` (synchronous DB write) rather than `CachedPostgresStore` to ensure the cap is enforced consistently across all pods from request one — `CachedPostgresStore`'s 15-second in-memory flush window would otherwise allow a burst of `30 × N pods` before any pod sees a 429.

**Non-breaking justification:** adds middleware to an existing route; under-limit requests are unaffected.

**Known follow-up (out of scope here):** `response.text()` at the call site buffers the full response body with no size cap. Tracked in #3619.

**Pre-PR review:**
- code-reviewer: approved — no blockers; nit on hardcoded `retryAfter` is consistent with existing pattern across this file
- security-reviewer: approved (second pass) — PostgresStore switch resolves the burst-window gap from first pass; fail-open during DB startup is a known pre-existing trade-off shared by all limiters

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_018yz2qW6htFNgoFseUsHeXZ

---
_Generated by [Claude Code](https://claude.ai/code/session_018yz2qW6htFNgoFseUsHeXZ)_