### PR TITLE
chore(ipr): backfill stuck signatures from URL-guard window

### DIFF
--- a/.changeset/ipr-backfill-stuck-signers.md
+++ b/.changeset/ipr-backfill-stuck-signers.md
@@ -1,0 +1,10 @@
+---
+---
+
+`signatures/ipr-signatures.json`: backfill two contributors whose `I have read the IPR Policy` comments fired during the window when `scripts/ipr/check-and-record.mjs`'s `LEDGER_REMOTE_PATTERN` was rejecting bare-URL origins (broken since `actions/checkout@v6` switched to credential-helper auth; fixed in #3532). Without this backfill, both signers would need to re-comment to trigger a fresh `issue_comment` run, since the workflow does not replay historical comments.
+
+Entries:
+- `erik-sv` (id 39309912) — adcontextprotocol/adcp#3468, comment 4338051086
+- `katiecooperco` (id 86127745) — adcontextprotocol/adcp#3484, comment 4338909329 (Katie's earliest signature; #3531 is a re-roll)
+
+Audit performed via comment search for the exact agreement phrase across all repos using the IPR workflow; only these two signers had comments without ledger entries.

--- a/signatures/ipr-signatures.json
+++ b/signatures/ipr-signatures.json
@@ -261,6 +261,24 @@
       "repo": "adcontextprotocol/adcp-client",
       "pullRequestNo": 647,
       "comment_id": 4280739898
+    },
+    {
+      "name": "erik-sv",
+      "id": 39309912,
+      "created_at": "2026-04-28T18:29:20Z",
+      "method": "pr_comment",
+      "repo": "adcontextprotocol/adcp",
+      "pullRequestNo": 3468,
+      "comment_id": 4338051086
+    },
+    {
+      "name": "katiecooperco",
+      "id": 86127745,
+      "created_at": "2026-04-28T20:42:56Z",
+      "method": "pr_comment",
+      "repo": "adcontextprotocol/adcp",
+      "pullRequestNo": 3484,
+      "comment_id": 4338909329
     }
   ]
 }


### PR DESCRIPTION
## Summary

Two contributors signed the IPR Policy during the window when `scripts/ipr/check-and-record.mjs` `LEDGER_REMOTE_PATTERN` was rejecting bare-URL git remotes (broken since `actions/checkout@v6` switched to credential-helper auth; fixed in #3532). Their `issue_comment` workflow runs failed at the URL guard, so the comments stayed on the PR but the ledger entries were never written.

| signer | comment | PR | timestamp |
|---|---|---|---|
| `erik-sv` (id 39309912) | [4338051086](https://github.com/adcontextprotocol/adcp/pull/3468#issuecomment-4338051086) | #3468 | 2026-04-28T18:29:20Z |
| `katiecooperco` (id 86127745) | [4338909329](https://github.com/adcontextprotocol/adcp/pull/3484#issuecomment-4338909329) | #3484 | 2026-04-28T20:42:56Z |

Katie has a second comment on #3531 (the re-roll of #3484) at 2026-04-29T18:41:21Z; the policy is signed once per contributor so I recorded the earliest agreement.

## Why backfill (vs. asking signers to re-comment)

The workflow only fires on new `issue_comment: created` events — it does not replay historical comments. So without backfill, both signers would need to re-comment, and #3468 in particular (a third-party contributor's PR) would sit stuck waiting on awareness.

Audit was thorough: searched for the exact agreement phrase across `adcontextprotocol/{adcp,adcp-client,adcp-client-python,adcp-go}` and `prebid/salesagent`, fetched all matching PRs' comments, and diffed authors against `signedContributors[].id`. Only these two signers had stuck comments.

## Follow-ups in flight

- #3635 — replace `LEDGER_REMOTE_PATTERN` regex with `URL.parse()` + add regression test pinning the URL matrix

## Test plan

- [x] Diff shape matches existing entries (name, id, created_at, method, repo, pullRequestNo, comment_id)
- [x] Sort order preserved (`created_at` ascending, then `name`) — matches `sortContributors` in `scripts/ipr/signatures.mjs`
- [x] Ledger goes from 28 → 30 entries
- [ ] After merge, `pull_request_target` runs on #3531 and #3468 should flip the IPR check to ✅ via `hasSigned()` lookup

🤖 Generated with [Claude Code](https://claude.com/claude-code)