### PR TITLE
test(server): add route-level integration tests for migrated tool_use services

### DIFF
--- a/.changeset/add-tool-use-service-integration-tests.md
+++ b/.changeset/add-tool-use-service-integration-tests.md
@@ -1,0 +1,4 @@
+---
+---
+
+test(server): add route-level integration tests for migrated tool_use services (issue #3621)

--- a/server/tests/integration/brand-classifier-route.test.ts
+++ b/server/tests/integration/brand-classifier-route.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Integration test: classifyBrand tool_use output → DB write contract.
+ *
+ * POST /api/admin/brand-enrichment/domain/:domain calls enrichBrand() which
+ * calls classifyBrand(). This test pins that the route correctly propagates
+ * the classify_brand tool_use output (keller_type, house_domain, confidence,
+ * related_domains) into the brands DB row.
+ *
+ * Gap from testing-expert review on PR #3611 (issue #3621): if the return
+ * shape of classifyBrand drifted (e.g. dropping related_domains or collapsing
+ * confidence to an unexpected value), the unit tests would pass but
+ * autoLinkByVerifiedDomain — which reads keller_type + confidence to gate
+ * brand-hierarchy membership inheritance — would silently receive bad data.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import type { Pool } from 'pg';
+
+const mocks = vi.hoisted(() => ({
+  anthropicCreate: vi.fn(),
+  isBrandfetchConfigured: vi.fn<[], boolean>(),
+  fetchBrandData: vi.fn(),
+  downloadAndCacheLogos: vi.fn(),
+}));
+
+vi.mock('@anthropic-ai/sdk', () => {
+  class FakeAnthropic {
+    messages = { create: mocks.anthropicCreate };
+  }
+  class APIError extends Error {}
+  class APIConnectionError extends Error {}
+  return { default: FakeAnthropic, APIError, APIConnectionError };
+});
+
+vi.mock('../../src/middleware/auth.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/middleware/auth.js')>()),
+  requireAuth: (req: any, _res: any, next: any) => {
+    req.user = { id: 'user_classifier_test', email: 'admin@test.example', is_admin: true };
+    next();
+  },
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock('../../src/services/brandfetch.js', () => ({
+  isBrandfetchConfigured: mocks.isBrandfetchConfigured,
+  fetchBrandData: mocks.fetchBrandData,
+  ENRICHMENT_CACHE_MAX_AGE_MS: 86_400_000,
+}));
+
+vi.mock('../../src/services/logo-cdn.js', () => ({
+  downloadAndCacheLogos: mocks.downloadAndCacheLogos,
+}));
+
+vi.mock('../../src/db/registry-requests-db.js', () => ({
+  registryRequestsDb: {
+    markResolved: vi.fn().mockResolvedValue(undefined),
+    listUnresolved: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock('../../src/services/enrichment.js', () => ({
+  enrichOrganization: vi.fn().mockResolvedValue({ success: false }),
+}));
+
+vi.mock('../../src/services/lusha.js', () => ({
+  isLushaConfigured: () => false,
+}));
+
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { setupBrandEnrichmentRoutes } from '../../src/routes/admin/brand-enrichment.js';
+
+const SUFFIX = `${process.pid}_${Date.now()}`;
+const TEST_DOMAIN = `classifier-route-${SUFFIX}.example.com`;
+
+function classifyBrandResponse(input: unknown) {
+  return {
+    content: [{ type: 'tool_use', name: 'classify_brand', id: 'toolu_test', input }],
+  };
+}
+
+// Minimal Brandfetch response with enough fields to pass enrichBrand's guards
+const BRANDFETCH_RESULT = {
+  success: true,
+  highQuality: true,
+  manifest: {
+    name: 'Acme Corp',
+    description: 'A fictional test brand',
+    url: `https://${TEST_DOMAIN}`,
+    logos: [],
+    colors: [],
+    fonts: [],
+  },
+  company: { industries: ['technology'] },
+  raw: { links: [] },
+};
+
+describe('POST /api/admin/brand-enrichment/domain/:domain — classifyBrand contract', () => {
+  let pool: Pool;
+  let app: express.Application;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+
+    const apiRouter = express.Router();
+    setupBrandEnrichmentRoutes(apiRouter);
+    app = express();
+    app.use(express.json());
+    app.use('/api/admin', apiRouter);
+  }, 60_000);
+
+  afterAll(async () => {
+    await pool.query('DELETE FROM brands WHERE domain = $1', [TEST_DOMAIN]);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await pool.query('DELETE FROM brands WHERE domain = $1', [TEST_DOMAIN]);
+    process.env.ANTHROPIC_API_KEY = 'test-key';
+    mocks.anthropicCreate.mockReset();
+    mocks.isBrandfetchConfigured.mockReturnValue(true);
+    mocks.fetchBrandData.mockResolvedValue(BRANDFETCH_RESULT);
+    mocks.downloadAndCacheLogos.mockResolvedValue([]);
+    // Fail fast: any test that arms a specific resolve will override this
+    mocks.anthropicCreate.mockRejectedValue(
+      new Error('anthropic.messages.create was not stubbed for this test'),
+    );
+  });
+
+  it('writes keller_type, house_domain, confidence, and related_domains to the brands row', async () => {
+    mocks.anthropicCreate.mockResolvedValueOnce(
+      classifyBrandResponse({
+        keller_type: 'sub_brand',
+        house_domain: 'pinnacle.example.com',
+        parent_brand: 'Pinnacle Corp',
+        canonical_domain: TEST_DOMAIN,
+        related_domains: ['acme-sub.example.com', 'acme-other.example.com'],
+        confidence: 'high',
+        reasoning: 'Sub-brand of Pinnacle under a fictional corporate parent.',
+      }),
+    );
+
+    const res = await request(app).post(
+      `/api/admin/brand-enrichment/domain/${TEST_DOMAIN}`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('enriched');
+
+    const row = await pool.query<{
+      keller_type: string;
+      house_domain: string;
+      brand_manifest: Record<string, unknown>;
+    }>(
+      'SELECT keller_type, house_domain, brand_manifest FROM brands WHERE domain = $1',
+      [TEST_DOMAIN],
+    );
+
+    expect(row.rows).toHaveLength(1);
+    expect(row.rows[0].keller_type).toBe('sub_brand');
+    expect(row.rows[0].house_domain).toBe('pinnacle.example.com');
+
+    // brand_manifest.classification is written by enrichBrand from the classifier
+    // output. related_domains here is the canary: if the return shape dropped it,
+    // the manifest would have an empty array or undefined instead.
+    const classification = row.rows[0].brand_manifest
+      ?.classification as Record<string, unknown> | undefined;
+    expect(classification?.confidence).toBe('high');
+    expect(classification?.related_domains).toEqual([
+      'acme-sub.example.com',
+      'acme-other.example.com',
+    ]);
+  });
+
+  it('succeeds and saves the brand without a classification when ANTHROPIC_API_KEY is absent', async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+
+    const res = await request(app).post(
+      `/api/admin/brand-enrichment/domain/${TEST_DOMAIN}`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('enriched');
+    expect(res.body.classification).toBeUndefined();
+
+    const row = await pool.query<{ keller_type: string | null }>(
+      'SELECT keller_type FROM brands WHERE domain = $1',
+      [TEST_DOMAIN],
+    );
+    expect(row.rows[0].keller_type).toBeNull();
+    expect(mocks.anthropicCreate).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/integration/brand-enrichment-route.test.ts
+++ b/server/tests/integration/brand-enrichment-route.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Integration test: expandHouse discover_sub_brands tool_use output → DB write contract.
+ *
+ * POST /api/admin/brand-enrichment/expand-house/:domain calls expandHouse(),
+ * which uses the discover_sub_brands tool to discover sub-brands and seeds
+ * each one as a brands row.
+ *
+ * Gap from testing-expert review on PR #3611 (issue #3621): if the brands
+ * array shape in discover_sub_brands drifted (e.g. keller_type dropped to
+ * undefined), expandHouse would seed brands with wrong keller_type or silently
+ * skip rows, with no unit test catching the serialization gap between the
+ * tool_use output and the DB write.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import type { Pool } from 'pg';
+
+const mocks = vi.hoisted(() => ({
+  anthropicCreate: vi.fn(),
+}));
+
+vi.mock('@anthropic-ai/sdk', () => {
+  class FakeAnthropic {
+    messages = { create: mocks.anthropicCreate };
+  }
+  class APIError extends Error {}
+  class APIConnectionError extends Error {}
+  return { default: FakeAnthropic, APIError, APIConnectionError };
+});
+
+vi.mock('../../src/middleware/auth.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/middleware/auth.js')>()),
+  requireAuth: (req: any, _res: any, next: any) => {
+    req.user = { id: 'user_enrichment_test', email: 'admin@test.example', is_admin: true };
+    next();
+  },
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+}));
+
+// Brandfetch is not used when enrich:false — mock the configured check
+// to avoid the 503 short-circuit path on the expand-house route.
+vi.mock('../../src/services/brandfetch.js', () => ({
+  isBrandfetchConfigured: () => true,
+  fetchBrandData: vi.fn(),
+  ENRICHMENT_CACHE_MAX_AGE_MS: 86_400_000,
+}));
+
+vi.mock('../../src/services/logo-cdn.js', () => ({
+  downloadAndCacheLogos: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../../src/db/registry-requests-db.js', () => ({
+  registryRequestsDb: {
+    markResolved: vi.fn().mockResolvedValue(undefined),
+    listUnresolved: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock('../../src/services/enrichment.js', () => ({
+  enrichOrganization: vi.fn().mockResolvedValue({ success: false }),
+}));
+
+vi.mock('../../src/services/lusha.js', () => ({
+  isLushaConfigured: () => false,
+}));
+
+vi.mock('../../src/services/brand-classifier.js', () => ({
+  classifyBrand: vi.fn().mockResolvedValue(null),
+}));
+
+import { initializeDatabase, closeDatabase, query } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { setupBrandEnrichmentRoutes } from '../../src/routes/admin/brand-enrichment.js';
+
+const SUFFIX = `${process.pid}_${Date.now()}`;
+const HOUSE_DOMAIN = `house-${SUFFIX}.example.com`;
+const SUB_A = `sub-a-${SUFFIX}.example.com`;
+const SUB_B = `sub-b-${SUFFIX}.example.com`;
+
+function discoverSubBrandsResponse(brands: unknown[]) {
+  return {
+    content: [
+      { type: 'tool_use', name: 'discover_sub_brands', id: 'toolu_test', input: { brands } },
+    ],
+  };
+}
+
+describe('POST /api/admin/brand-enrichment/expand-house/:domain — discover_sub_brands contract', () => {
+  let pool: Pool;
+  let app: express.Application;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+
+    const apiRouter = express.Router();
+    setupBrandEnrichmentRoutes(apiRouter);
+    app = express();
+    app.use(express.json());
+    app.use('/api/admin', apiRouter);
+  }, 60_000);
+
+  afterAll(async () => {
+    await pool.query(
+      'DELETE FROM brands WHERE domain IN ($1, $2, $3)',
+      [HOUSE_DOMAIN, SUB_A, SUB_B],
+    );
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await pool.query(
+      'DELETE FROM brands WHERE domain IN ($1, $2, $3)',
+      [HOUSE_DOMAIN, SUB_A, SUB_B],
+    );
+    // Seed the house brand — expandHouse throws if the house is not found
+    // or if keller_type is neither 'master' nor 'independent'.
+    await pool.query(
+      `INSERT INTO brands (domain, brand_name, source_type, keller_type, has_brand_manifest, created_at, updated_at)
+       VALUES ($1, 'Nova House', 'enriched', 'master', true, NOW(), NOW())`,
+      [HOUSE_DOMAIN],
+    );
+
+    process.env.ANTHROPIC_API_KEY = 'test-key';
+    mocks.anthropicCreate.mockReset();
+    mocks.anthropicCreate.mockRejectedValue(
+      new Error('anthropic.messages.create was not stubbed for this test'),
+    );
+  });
+
+  it('seeds sub-brand rows with house_domain and keller_type from discover_sub_brands output', async () => {
+    mocks.anthropicCreate.mockResolvedValueOnce(
+      discoverSubBrandsResponse([
+        { brand_name: 'Pinnacle Sub', domain: SUB_A, keller_type: 'sub_brand' },
+        { brand_name: 'Nova Endorsed', domain: SUB_B, keller_type: 'endorsed' },
+      ]),
+    );
+
+    const res = await request(app)
+      .post(`/api/admin/brand-enrichment/expand-house/${HOUSE_DOMAIN}`)
+      .send({ enrich: false, delay_ms: 0 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.discovered).toBe(2);
+    expect(res.body.seeded).toBe(2);
+
+    // Sub-brands must be in the DB with the correct house_domain and keller_type.
+    // If the brands array shape drifted, these assertions fail without any route
+    // error — the service would silently seed nothing or seed with wrong types.
+    const rows = await query<{ domain: string; keller_type: string; house_domain: string }>(
+      'SELECT domain, keller_type, house_domain FROM brands WHERE domain IN ($1, $2) ORDER BY domain',
+      [SUB_A, SUB_B],
+    );
+
+    expect(rows.rows).toHaveLength(2);
+    const subA = rows.rows.find((r) => r.domain === SUB_A);
+    const subB = rows.rows.find((r) => r.domain === SUB_B);
+
+    expect(subA?.keller_type).toBe('sub_brand');
+    expect(subA?.house_domain).toBe(HOUSE_DOMAIN);
+    expect(subB?.keller_type).toBe('endorsed');
+    expect(subB?.house_domain).toBe(HOUSE_DOMAIN);
+  });
+
+  it('returns 500 and seeds no brands when the model omits the tool_use block', async () => {
+    mocks.anthropicCreate.mockResolvedValueOnce({
+      content: [{ type: 'text', text: 'I cannot list sub-brands.' }],
+    });
+
+    const res = await request(app)
+      .post(`/api/admin/brand-enrichment/expand-house/${HOUSE_DOMAIN}`)
+      .send({ enrich: false, delay_ms: 0 });
+
+    expect(res.status).toBe(500);
+
+    const rows = await query<{ domain: string }>(
+      'SELECT domain FROM brands WHERE house_domain = $1',
+      [HOUSE_DOMAIN],
+    );
+    expect(rows.rows).toHaveLength(0);
+  });
+});

--- a/server/tests/integration/property-enhancement-function.test.ts
+++ b/server/tests/integration/property-enhancement-function.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Integration test: analyzeProperty tool_use output → hosted_properties DB write contract.
+ *
+ * enhanceProperty() calls analyzeProperty(), which uses the analyze_property
+ * tool_use pattern. This test pins that the tool_use output is correctly written
+ * into the hosted_properties row's adagents_json.ext.enhancement.ai_analysis field.
+ *
+ * There is no HTTP route for enhanceProperty — it is only called by the MCP
+ * property-tools handler. The test exercises the function directly, using the
+ * real DB for the createHostedProperty write and mocking external services
+ * (Anthropic, WHOIS, adagents validation, Addie review trigger).
+ *
+ * Gap from testing-expert review on PR #3611 (issue #3621): if the ai_analysis
+ * shape from analyzeProperty drifted (e.g. likely_inventory_types becoming
+ * undefined), the unit tests would pass but the hosted_properties row would
+ * silently carry a malformed ext.enhancement block.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import type { Pool } from 'pg';
+
+const mocks = vi.hoisted(() => ({
+  anthropicCreate: vi.fn(),
+  validateDomain: vi.fn(),
+  whoisDomain: vi.fn(),
+  reviewNewRecord: vi.fn(),
+}));
+
+vi.mock('@anthropic-ai/sdk', () => {
+  class FakeAnthropic {
+    messages = { create: mocks.anthropicCreate };
+  }
+  class APIError extends Error {}
+  class APIConnectionError extends Error {}
+  return { default: FakeAnthropic, APIError, APIConnectionError };
+});
+
+// adagentsManager is instantiated at module scope in property-enhancement.ts;
+// the class mock must be in place before the module loads.
+vi.mock('../../src/adagents-manager.js', () => ({
+  AdAgentsManager: vi.fn().mockImplementation(() => ({
+    validateDomain: mocks.validateDomain,
+  })),
+}));
+
+vi.mock('whoiser', () => ({
+  whoisDomain: mocks.whoisDomain,
+}));
+
+vi.mock('../../src/addie/mcp/registry-review.js', () => ({
+  reviewNewRecord: mocks.reviewNewRecord,
+}));
+
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { enhanceProperty } from '../../src/services/property-enhancement.js';
+
+const SUFFIX = `${process.pid}_${Date.now()}`;
+const TEST_DOMAIN = `prop-enhance-${SUFFIX}.example.com`;
+
+function analyzePropertyResponse(input: unknown) {
+  return {
+    content: [{ type: 'tool_use', name: 'analyze_property', id: 'toolu_test', input }],
+  };
+}
+
+describe('enhanceProperty — analyzeProperty tool_use output → hosted_properties contract', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  }, 60_000);
+
+  afterAll(async () => {
+    await pool.query('DELETE FROM hosted_properties WHERE publisher_domain = $1', [TEST_DOMAIN]);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await pool.query('DELETE FROM hosted_properties WHERE publisher_domain = $1', [TEST_DOMAIN]);
+    process.env.ANTHROPIC_API_KEY = 'test-key';
+    mocks.anthropicCreate.mockReset();
+    mocks.validateDomain.mockResolvedValue({ valid: false });
+    mocks.whoisDomain.mockResolvedValue({});
+    mocks.reviewNewRecord.mockResolvedValue(undefined);
+    mocks.anthropicCreate.mockRejectedValue(
+      new Error('anthropic.messages.create was not stubbed for this test'),
+    );
+  });
+
+  it('writes is_publisher and likely_inventory_types from analyze_property output to ext.enhancement', async () => {
+    mocks.anthropicCreate.mockResolvedValueOnce(
+      analyzePropertyResponse({
+        is_publisher: true,
+        likely_inventory_types: ['display', 'video'],
+        structural_subdomain_note: null,
+        confidence: 'high',
+        reasoning: 'Domain pattern and name suggest a media publisher.',
+      }),
+    );
+
+    const result = await enhanceProperty(TEST_DOMAIN, 'system:test');
+
+    expect(result.submitted_to_registry).toBe(true);
+    expect(result.already_exists).toBe(false);
+
+    // Assert the shape written to the DB row, not just the return value.
+    // If likely_inventory_types drifted to undefined in analyzeProperty's
+    // return, the manifest would silently lose the array here.
+    const row = await pool.query<{ adagents_json: Record<string, unknown> }>(
+      'SELECT adagents_json FROM hosted_properties WHERE publisher_domain = $1',
+      [TEST_DOMAIN],
+    );
+    expect(row.rows).toHaveLength(1);
+
+    const aiAnalysis = (
+      (row.rows[0].adagents_json?.ext as Record<string, unknown>)
+        ?.enhancement as Record<string, unknown>
+    )?.ai_analysis as Record<string, unknown> | undefined;
+
+    expect(aiAnalysis?.is_publisher).toBe(true);
+    expect(aiAnalysis?.likely_inventory_types).toEqual(['display', 'video']);
+    expect(aiAnalysis?.confidence).toBe('high');
+  });
+
+  it('writes is_publisher=false correctly when the model classifies a non-publisher domain', async () => {
+    mocks.anthropicCreate.mockResolvedValueOnce(
+      analyzePropertyResponse({
+        is_publisher: false,
+        likely_inventory_types: [],
+        structural_subdomain_note: null,
+        confidence: 'high',
+        reasoning: 'Domain pattern suggests a SaaS tool, not a publisher.',
+      }),
+    );
+
+    await enhanceProperty(TEST_DOMAIN, 'system:test');
+
+    const row = await pool.query<{ adagents_json: Record<string, unknown> }>(
+      'SELECT adagents_json FROM hosted_properties WHERE publisher_domain = $1',
+      [TEST_DOMAIN],
+    );
+    const aiAnalysis = (
+      (row.rows[0].adagents_json?.ext as Record<string, unknown>)
+        ?.enhancement as Record<string, unknown>
+    )?.ai_analysis as Record<string, unknown> | undefined;
+
+    expect(aiAnalysis?.is_publisher).toBe(false);
+    expect(aiAnalysis?.likely_inventory_types).toEqual([]);
+  });
+});

--- a/server/tests/integration/prospect-triage-function.test.ts
+++ b/server/tests/integration/prospect-triage-function.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Integration test: assessWithClaude assess_prospect tool_use output →
+ * TriageResult + prospect_triage_log DB write contract.
+ *
+ * triageEmailDomain() calls assessWithClaude(), which uses the assess_prospect
+ * tool_use pattern. This test pins that the tool_use output (action, owner,
+ * priority) is correctly mapped into the returned TriageResult and that
+ * logTriageDecision() writes a matching row to prospect_triage_log.
+ *
+ * There is no admin HTTP route for prospect triage — the entry points are
+ * triageAndNotify (webhook) and triageAndCreateProspect (batch job). The test
+ * exercises triageEmailDomain() directly to isolate the Anthropic contract.
+ *
+ * Gap from testing-expert review on PR #3611 (issue #3621): if the assess_prospect
+ * tool_use response shape drifted (e.g. action returning undefined), the unit
+ * tests would pass but triageAndCreateProspect would silently create a prospect
+ * with action=undefined, defeating the create/skip decision logic.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import type { Pool } from 'pg';
+
+const mocks = vi.hoisted(() => ({
+  anthropicCreate: vi.fn(),
+  resolveOrgByDomain: vi.fn(),
+  isFreeEmailDomain: vi.fn(),
+}));
+
+vi.mock('@anthropic-ai/sdk', () => {
+  class FakeAnthropic {
+    messages = { create: mocks.anthropicCreate };
+  }
+  class APIError extends Error {}
+  class APIConnectionError extends Error {}
+  return { default: FakeAnthropic, APIError, APIConnectionError };
+});
+
+vi.mock('../../src/db/domain-resolution-db.js', () => ({
+  resolveOrgByDomain: mocks.resolveOrgByDomain,
+}));
+
+vi.mock('../../src/utils/email-domain.js', () => ({
+  isFreeEmailDomain: mocks.isFreeEmailDomain,
+}));
+
+vi.mock('../../src/services/lusha.js', () => ({
+  isLushaConfigured: () => false,
+}));
+
+vi.mock('../../src/services/enrichment.js', () => ({
+  enrichDomain: vi.fn().mockResolvedValue({ success: false }),
+}));
+
+// Silence Slack notification side effects — fire-and-forget rejections
+// from unmocked notification calls can cause Vitest to flag unhandled
+// promise rejections and fail otherwise-passing tests.
+vi.mock('../../src/notifications/prospect.js', () => ({
+  notifyNewProspect: vi.fn().mockResolvedValue(undefined),
+  notifyAliasMatch: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/db/system-settings-db.js', () => ({
+  getSetting: vi.fn().mockResolvedValue({ enabled: true }),
+  SETTING_KEYS: { PROSPECT_TRIAGE_ENABLED: 'prospect_triage_enabled' },
+}));
+
+// Defensive: account-management-db is imported at module scope by prospect-triage.ts
+// and would fire against the real DB if handleSkipSideEffects were reached.
+vi.mock('../../src/db/account-management-db.js', () => ({
+  createActionItem: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { triageEmailDomain } from '../../src/services/prospect-triage.js';
+
+const SUFFIX = `${process.pid}_${Date.now()}`;
+const TEST_DOMAIN = `triage-test-${SUFFIX}.co`;
+
+function assessProspectResponse(input: unknown) {
+  return {
+    content: [{ type: 'tool_use', name: 'assess_prospect', id: 'toolu_test', input }],
+  };
+}
+
+describe('triageEmailDomain — assessWithClaude tool_use output → TriageResult + log contract', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  }, 60_000);
+
+  afterAll(async () => {
+    await pool.query('DELETE FROM prospect_triage_log WHERE domain = $1', [TEST_DOMAIN]);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await pool.query('DELETE FROM prospect_triage_log WHERE domain = $1', [TEST_DOMAIN]);
+    process.env.ANTHROPIC_API_KEY = 'test-key';
+    mocks.anthropicCreate.mockReset();
+    // Default: domain is not a free-email provider and is not yet tracked.
+    mocks.isFreeEmailDomain.mockReturnValue(false);
+    mocks.resolveOrgByDomain.mockResolvedValue(null);
+    mocks.anthropicCreate.mockRejectedValue(
+      new Error('anthropic.messages.create was not stubbed for this test'),
+    );
+  });
+
+  it('maps action:create + owner:addie + priority:high from tool_use into TriageResult and log row', async () => {
+    mocks.anthropicCreate.mockResolvedValueOnce(
+      assessProspectResponse({
+        action: 'create',
+        reason: 'ad_tech_vendor',
+        owner: 'addie',
+        priority: 'high',
+        verdict: 'Pinnacle Media is a well-known ad tech company. Fits the membership profile.',
+        company_name: 'Pinnacle Media',
+        company_type: 'publisher',
+      }),
+    );
+
+    const result = await triageEmailDomain(TEST_DOMAIN, { source: 'test' });
+
+    expect(result.action).toBe('create');
+    expect(result.owner).toBe('addie');
+    expect(result.priority).toBe('high');
+
+    // prospect_triage_log row must exist and carry the same values —
+    // the log write is the only DB side effect at this layer.
+    const row = await pool.query<{
+      action: string;
+      owner: string;
+      priority: string;
+      reason: string;
+    }>(
+      'SELECT action, owner, priority, reason FROM prospect_triage_log WHERE domain = $1',
+      [TEST_DOMAIN],
+    );
+    expect(row.rows).toHaveLength(1);
+    expect(row.rows[0].action).toBe('create');
+    expect(row.rows[0].owner).toBe('addie');
+    expect(row.rows[0].priority).toBe('high');
+    expect(row.rows[0].reason).toBe('ad_tech_vendor');
+  });
+
+  it('defaults priority to "standard" when assess_prospect omits the priority field', async () => {
+    // priority is not in assess_prospect's required schema fields — the service
+    // defaults it to 'standard'. This case proves the default survives through
+    // triageEmailDomain and into the log row.
+    mocks.anthropicCreate.mockResolvedValueOnce(
+      assessProspectResponse({
+        action: 'create',
+        reason: 'media_company',
+        owner: 'addie',
+        // priority intentionally absent
+        verdict: 'Nova Brands is a media company.',
+        company_name: 'Nova Brands',
+      }),
+    );
+
+    const result = await triageEmailDomain(TEST_DOMAIN, { source: 'test' });
+
+    expect(result.priority).toBe('standard');
+
+    const row = await pool.query<{ priority: string }>(
+      'SELECT priority FROM prospect_triage_log WHERE domain = $1',
+      [TEST_DOMAIN],
+    );
+    expect(row.rows[0].priority).toBe('standard');
+  });
+
+  it('returns action:skip without an Anthropic call when the domain resolves to an existing org', async () => {
+    // resolveOrgByDomain returning non-null means the domain is already tracked.
+    // The service must short-circuit before calling assessWithClaude.
+    mocks.resolveOrgByDomain.mockResolvedValueOnce({
+      orgId: 'org_existing_123',
+      matchedDomain: TEST_DOMAIN,
+      method: 'exact',
+    });
+
+    const result = await triageEmailDomain(TEST_DOMAIN, { source: 'test' });
+
+    expect(result.action).toBe('skip');
+    expect(result.reason).toBe('already_tracked');
+    expect(mocks.anthropicCreate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3621.

Adds four integration tests that pin the **tool_use output → DB write contract** for the four services migrated to typed `input_schema` tool invocations in PR #3611. Without these tests, a drift in the tool_use response shape (e.g. `action` returning `undefined`) would let unit tests pass while silently persisting malformed data to the DB.

- `brand-classifier-route.test.ts` — `POST /api/admin/brand-enrichment/domain/:domain` → `brands` row has `keller_type`, `house_domain`, `confidence`, `related_domains` from `classify_brand` tool output
- `brand-enrichment-route.test.ts` — `POST /api/admin/brand-enrichment/expand-house/:domain` → `brands` rows seeded with correct `house_domain` + `keller_type` from `discover_sub_brands` output; also covers the tool_use-missing → 500 path
- `property-enhancement-function.test.ts` — `enhanceProperty()` (no HTTP route; called from MCP tool) → `hosted_properties.adagents_json.ext.enhancement.ai_analysis` written from `analyze_property` output
- `prospect-triage-function.test.ts` — `triageEmailDomain()` (no HTTP route; called from webhooks/batch) → `TriageResult` + `prospect_triage_log` row match `assess_prospect` output; covers priority default and early-skip path

## Pattern

All four files follow the `brand-properties-parse.test.ts` SDK-layer mock pattern:
- `vi.hoisted()` + `vi.mock('@anthropic-ai/sdk', FakeAnthropic)` with a shared `mocks.anthropicCreate` spy
- Fail-fast default (`mockRejectedValue`) overridden per test with `mockResolvedValueOnce`
- PID+timestamp domain suffixes for parallel-safe isolation
- Real DB (migrations + pool) with `beforeEach`/`afterAll` cleanup
- Primary assertions are DB reads after the route/function call, not just response body checks

## Notes

- `closeDatabase()` in `afterAll` is the pre-existing shared-pool pattern used throughout `server/tests/integration/`. The integration test runner (`vitest run server/tests/integration`) has no `fileParallelism: false` — this is a systemic risk carried forward from existing files, not introduced here.
- `property-enhancement-function.test.ts` mocks `whoiser` with only the named `whoisDomain` export (the source uses `const { whoisDomain } = await import('whoiser')`); the `default.whoisDomain` key was removed after pre-PR review.
- `prospect-triage-function.test.ts` pre-emptively mocks `account-management-db.js` (`createActionItem`) even though none of the three test cases reach `handleSkipSideEffects`, guarding against future test additions that exercise that path.

## Test plan

- [ ] `npm run test:server-integration -- --reporter=verbose brand-classifier-route` passes with DB running
- [ ] `npm run test:server-integration -- --reporter=verbose brand-enrichment-route` passes
- [ ] `npm run test:server-integration -- --reporter=verbose property-enhancement-function` passes
- [ ] `npm run test:server-integration -- --reporter=verbose prospect-triage-function` passes
- [ ] No existing integration tests regress

https://claude.ai/code/session_01RFAvM1RBMzagDAcy5hxZEW

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFAvM1RBMzagDAcy5hxZEW)_