### PR TITLE
docs: document schema URL convention for MDX links

### DIFF
--- a/.changeset/docs-schema-link-convention.md
+++ b/.changeset/docs-schema-link-convention.md
@@ -1,0 +1,17 @@
+---
+---
+
+docs: document schema URL convention for MDX links
+
+Adds `docs/contributing/schema-links.md` explaining that Markdown hyperlinks
+to AdCP JSON schemas in `.mdx` files must use absolute
+`https://adcontextprotocol.org/schemas/v3/...` URLs — bare paths like
+`/schemas/enums/foo.json` fail the Mintlify broken-links checker. Documents
+the released-vs-unreleased decision rule, the `$schema`-vs-hyperlink
+distinction, and the two CI validators (`mintlify broken-links` and
+`check-schema-links.yml`) that enforce the convention.
+
+Also adds a one-line pointer to the new page in `CONTRIBUTING.md` and a `<Note>`
+cross-link in `docs/building/schemas-and-sdks.mdx`.
+
+Closes #3634.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,8 @@ Before contributing please see:
 ## Schema conventions
 Before adding or modifying schemas, read the [Specification Guidelines](https://github.com/adcontextprotocol/adcp/blob/main/docs/spec-guidelines.md). In particular, normative (non-`ext`) schema fields must not reference specific platforms or vendors by name — platform-specific fields belong in the `ext.{vendor}` namespace. Reviewers will flag violations.
 
+When **linking to a schema from an MDX doc**, use an absolute `https://adcontextprotocol.org/schemas/v3/...` URL — bare paths like `/schemas/enums/foo.json` fail the Mintlify link checker. See [Schema links in documentation](https://github.com/adcontextprotocol/adcp/blob/main/docs/contributing/schema-links.md) for the full convention and the two CI checks that enforce it.
+
 ## Examples and sample data
 Docs, storyboards, and test vectors use **fictional brands and entities only** — Acme Outdoor, Nova Motors, Pinnacle Agency, StreamHaus, and the other names in `static/compliance/source/test-kits/`. Real brand, agency, publisher, or vendor names do not appear in normative examples. See the editorial rule in [`CLAUDE.md`](https://github.com/adcontextprotocol/adcp/blob/main/CLAUDE.md) and the universal fictional-entity registry at `static/compliance/source/universal/fictional-entities.yaml`. Reviewers will flag real-brand usage in examples the same way they flag vendor leakage in schemas.
 

--- a/docs/building/schemas-and-sdks.mdx
+++ b/docs/building/schemas-and-sdks.mdx
@@ -228,6 +228,13 @@ AdCP uses semantic versioning. Choose the right path for your use case:
 
 The same version semantics apply to `/schemas`, `/compliance`, and `/protocol/{version}.tgz` — one release cuts all three.
 
+<Note>
+**Writing docs that link to schemas?** Markdown links in `.mdx` files must use
+absolute `https://adcontextprotocol.org/schemas/v3/...` URLs — bare paths like
+`/schemas/enums/foo.json` fail the Mintlify link checker. See
+[Schema links in documentation](/docs/contributing/schema-links).
+</Note>
+
 ### Production (Recommended)
 
 Pin to an exact version for stability:

--- a/docs/contributing/schema-links.md
+++ b/docs/contributing/schema-links.md
@@ -1,0 +1,96 @@
+---
+title: Schema links in documentation
+description: "How to link to AdCP JSON schemas from MDX documentation. Use absolute https:// URLs — bare paths fail the Mintlify link checker."
+"og:title": "AdCP — Schema links in documentation"
+---
+
+# Schema links in documentation
+
+When writing a Markdown hyperlink to an AdCP JSON schema inside an `.mdx` doc,
+use an **absolute `https://` URL** — never a bare `/schemas/...` path.
+
+The Mintlify broken-links checker (`mintlify broken-links`) validates links
+against pages in the docs site. Bare `/schemas/...` paths are not Mintlify
+pages; they are external artifacts served from `adcontextprotocol.org`. A bare
+path silently fails the checker with an unhelpful error:
+
+```
+found N broken links in N files
+docs/your-file.mdx
+ ⎿  /schemas/enums/viewability-standard.json
+```
+
+## Which URL to use
+
+### Released schemas
+
+Use the major version alias (`v3`) for schemas that exist in a released version
+under `dist/schemas/`:
+
+```markdown
+[`viewability-standard.json`](https://adcontextprotocol.org/schemas/v3/enums/viewability-standard.json)
+```
+
+**How to check if a schema is released:** look for it under the highest
+version directory for your major in `dist/schemas/` (e.g., `dist/schemas/3.0.1/`
+for v3). If it exists there, the schema is released — use the `/schemas/v3/` alias.
+
+### Unreleased schemas
+
+For schemas that exist only in `static/schemas/source/` (not yet in any
+`dist/schemas/` version), use the absolute URL with `/schemas/latest/` and
+include a comment so the link gets updated after the next release:
+
+```markdown
+<!-- Using /schemas/latest/: this schema is not yet in a released version.
+     Update to /schemas/v3/ after the next release. -->
+[`account-authorization.json`](https://adcontextprotocol.org/schemas/latest/core/account-authorization.json)
+```
+
+The `check-schema-links.yml` CI workflow flags stray `/schemas/latest/`
+references in docs so they do not accumulate after a release ships.
+
+## Version aliases
+
+| Alias | Resolves to |
+|---|---|
+| `/schemas/v3/` | Latest 3.x release |
+| `/schemas/v2/` | Latest 2.x release |
+| `/schemas/latest/` | Development version (`static/schemas/source/`) |
+
+## Common mistakes
+
+| Instead of... | Use... |
+|---|---|
+| `/schemas/enums/foo.json` | `https://adcontextprotocol.org/schemas/v3/enums/foo.json` |
+| `/schemas/latest/foo.json` (in stable docs) | `https://adcontextprotocol.org/schemas/v3/foo.json` |
+| `https://adcontextprotocol.org/schemas/v2/foo.json` in v3 docs | `https://adcontextprotocol.org/schemas/v3/foo.json` |
+
+## `$schema` fields vs. Markdown links
+
+This rule applies **only to Markdown hyperlinks** you write in `.mdx` files.
+It does **not** apply to `$schema` fields inside JSON code blocks:
+
+```json
+{
+  "$schema": "/schemas/v3/core/product.json"
+}
+```
+
+`$schema` values in JSON examples use bare paths intentionally — the dev server
+resolves them locally. These paths are not scanned by the Mintlify link checker.
+
+## CI checks that enforce this
+
+Two separate validators apply to schema URL references in docs:
+
+| Check | Trigger | What it catches |
+|---|---|---|
+| `mintlify broken-links` (pre-push + `broken-links.yml` CI) | Every push that touches docs | Bare `/schemas/...` paths in Markdown links |
+| `check-schema-links.yml` CI | PRs touching `docs/**/*.mdx` | Stale old-version aliases (`/schemas/v2/` in v3-era docs) and stray `/schemas/latest/` references |
+
+Both checks can fail independently on the same PR. If you fix one and see a
+new error, check the other.
+
+For the versioning model behind these aliases, see
+[Schemas and SDKs](/docs/building/schemas-and-sdks#schema-versioning).


### PR DESCRIPTION
Closes #3634

Contributors writing MDX docs naturally reach for bare `/schemas/enums/foo.json` paths when linking to a JSON schema — it's how schemas are referenced everywhere else in the repo (`$ref`, changeset text, commit messages). But the Mintlify broken-links checker rejects bare paths: they're not Mintlify pages, they're external artifacts. The correct convention (use absolute `https://adcontextprotocol.org/schemas/v3/...` URLs) existed only in `.agents/playbook.md`, invisible to contributors.

This PR adds the convention to contributor-facing docs in three places:

- **`docs/contributing/schema-links.md`** (new) — full guidance page following the existing `x-entity-annotation.md` / `testable-snippets.md` pattern. Covers released vs. unreleased schemas, the `$schema`-vs-hyperlink distinction, and both CI validators (`mintlify broken-links` + `check-schema-links.yml`).
- **`CONTRIBUTING.md`** — one-line pointer under "Schema conventions" linking to the new page.
- **`docs/building/schemas-and-sdks.mdx`** — `<Note>` cross-link at the Schema Versioning section, where contributors reading about schema URLs are most likely to need this guidance.

**Non-breaking justification:** adds new docs/content only; no schema, protocol, or API surface changed; existing consumers unaffected.

**Pre-PR review:**
- code-reviewer: approved — 2 blockers caught and fixed (stale `3.0.0-rc.3` version ref → `3.0.1`; released schema used as "unreleased" example → replaced with `core/account-authorization.json`); 1 nit (CONTRIBUTING.md link pattern) fixed; changeset verified
- docs-expert: approved — audience fit correct, structure follows existing contributing-docs pattern, cross-links adequate; same blockers caught and fixed

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01MzMHhmkVpMuiLTnCVLpJWx

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzMHhmkVpMuiLTnCVLpJWx)_