### PR TITLE
fix(billing): /sync picks membership sub, not subscriptions.data[0] (#3623 step 2)

### DIFF
--- a/.changeset/sync-pick-membership-sub.md
+++ b/.changeset/sync-pick-membership-sub.md
@@ -1,0 +1,8 @@
+---
+---
+
+fix(billing): `/sync` picks the membership sub, not `subscriptions.data[0]`.
+
+`POST /api/admin/accounts/:orgId/sync` was reading `customer.subscriptions.data[0]` to derive the org's subscription state. Stripe doesn't guarantee subscription ordering — when a customer has a non-membership sub (one-off product, future ancillary sub) stacked alongside a real membership, the wrong sub could win and the org row would be overwritten with the non-membership sub's state.
+
+Verified against the sandbox `multi_sub` fixture: Stripe returns the non-membership sub first; old behavior picked it, new behavior picks the membership sub regardless of order. Extracts `pickMembershipSub` + `isMembershipLookupKey` into `server/src/billing/membership-prices.ts` so the integrity invariant and `/sync` share one predicate.

--- a/server/src/audit/integrity/invariants/stripe-sub-reflected-in-org-row.ts
+++ b/server/src/audit/integrity/invariants/stripe-sub-reflected-in-org-row.ts
@@ -21,14 +21,7 @@
  */
 import type Stripe from 'stripe';
 import type { Invariant, InvariantContext, InvariantResult, Violation } from '../types.js';
-
-/**
- * Subscriptions whose price `lookup_key` starts with one of these prefixes
- * are membership subs that drive entitlement. Anything else (one-off
- * invoice line items, test products, future non-membership subs) is out of
- * scope — we don't want to flag drift on a non-membership sub.
- */
-const MEMBERSHIP_LOOKUP_KEY_PREFIXES = ['aao_membership_', 'aao_invoice_'] as const;
+import { isMembershipLookupKey } from '../../../billing/membership-prices.js';
 
 /**
  * Stripe statuses that grant entitlement at AAO. Mirrors the gate logic
@@ -36,11 +29,6 @@ const MEMBERSHIP_LOOKUP_KEY_PREFIXES = ['aao_membership_', 'aao_invoice_'] as co
  * customer hasn't lost access just because a payment retry is pending.
  */
 const ENTITLED_STATUSES = new Set<Stripe.Subscription.Status>(['active', 'trialing', 'past_due']);
-
-function isMembershipPrice(lookupKey: string | null | undefined): boolean {
-  if (!lookupKey) return false;
-  return MEMBERSHIP_LOOKUP_KEY_PREFIXES.some((p) => lookupKey.startsWith(p));
-}
 
 function customerIdOf(sub: Stripe.Subscription): string {
   return typeof sub.customer === 'string' ? sub.customer : sub.customer.id;
@@ -81,7 +69,7 @@ export const stripeSubReflectedInOrgRowInvariant: Invariant = {
     for (const status of ['active', 'trialing'] as const) {
       for await (const sub of stripe.subscriptions.list({ status, limit: 100 })) {
         const { lookup_key } = priceFieldsOf(sub);
-        if (!isMembershipPrice(lookup_key)) continue;
+        if (!isMembershipLookupKey(lookup_key)) continue;
         memberSubs.push(sub);
       }
     }

--- a/server/src/billing/membership-prices.ts
+++ b/server/src/billing/membership-prices.ts
@@ -1,0 +1,51 @@
+/**
+ * Membership product / lookup_key helpers.
+ *
+ * AAO billing has many Stripe products and prices, but only a subset drive
+ * membership entitlement. The price `lookup_key` distinguishes them by
+ * convention — every membership price starts with `aao_membership_` or
+ * `aao_invoice_`. This module is the single source of truth for that
+ * convention; consumers should never re-encode the prefix list inline.
+ *
+ * Used by:
+ *  - the integrity invariant that walks Stripe subs (so we don't flag drift
+ *    on non-membership subs that don't drive entitlement)
+ *  - the admin `/sync` endpoint (so we don't pick a non-membership sub off
+ *    a customer that happens to have one + a real membership)
+ *  - the webhook handler when deciding whether subscription events update
+ *    membership state
+ */
+import type Stripe from 'stripe';
+
+/** Price `lookup_key` prefixes that mark membership-bearing subscriptions. */
+export const MEMBERSHIP_LOOKUP_KEY_PREFIXES = ['aao_membership_', 'aao_invoice_'] as const;
+
+/** True when `lookup_key` corresponds to a membership-driving price. */
+export function isMembershipLookupKey(lookupKey: string | null | undefined): boolean {
+  if (!lookupKey) return false;
+  return MEMBERSHIP_LOOKUP_KEY_PREFIXES.some((p) => lookupKey.startsWith(p));
+}
+
+/** True when the first item on a subscription is a membership-driving price. */
+export function isMembershipSub(sub: Stripe.Subscription): boolean {
+  return isMembershipLookupKey(sub.items.data[0]?.price?.lookup_key);
+}
+
+/**
+ * Pick the membership subscription off a customer's subscription list.
+ *
+ * Returns `null` when no item is a membership sub. When multiple match
+ * (which is a violation of `one-active-stripe-sub-per-org` — both can't
+ * legitimately drive entitlement) returns the first matching, preferring
+ * `active` over other live statuses for stability.
+ *
+ * Replaces the `subscriptions.data[0]` pattern that misbehaves when a
+ * customer has a non-membership sub stacked alongside a real membership —
+ * the order is not guaranteed by Stripe and the wrong pick can overwrite
+ * a paying member's row with a one-off product's status.
+ */
+export function pickMembershipSub(subscriptions: readonly Stripe.Subscription[]): Stripe.Subscription | null {
+  const memberships = subscriptions.filter(isMembershipSub);
+  if (memberships.length === 0) return null;
+  return memberships.find((s) => s.status === 'active') ?? memberships[0];
+}

--- a/server/src/routes/admin/accounts-billing.ts
+++ b/server/src/routes/admin/accounts-billing.ts
@@ -15,6 +15,7 @@ import { createLogger } from "../../logger.js";
 import { requireAuth, requireAdmin } from "../../middleware/auth.js";
 import { OrganizationDatabase, TIER_PRESERVING_STATUSES } from "../../db/organization-db.js";
 import { stripe } from "../../billing/stripe-client.js";
+import { pickMembershipSub } from "../../billing/membership-prices.js";
 
 const logger = createLogger("admin-accounts-billing");
 
@@ -140,8 +141,18 @@ export function setupAccountsBillingRoutes(
               } else {
                 const subscriptions = (customer as Stripe.Customer).subscriptions;
 
-                if (subscriptions && subscriptions.data.length > 0) {
-                  const subscription = subscriptions.data[0];
+                // Filter to membership subs before picking. A customer with a
+                // non-membership sub (one-off products, future ancillary subs)
+                // alongside a real membership would otherwise have its row
+                // overwritten with the wrong sub's state — Stripe doesn't
+                // guarantee ordering of `subscriptions.data`. Falls through to
+                // the invoice-fallback branch below when no membership sub is
+                // found, preserving prior behavior for invoice-billed orgs.
+                const subscription = subscriptions
+                  ? pickMembershipSub(subscriptions.data)
+                  : null;
+
+                if (subscription) {
                   const priceData = subscription.items.data[0]?.price;
 
                   await pool.query(
@@ -181,7 +192,9 @@ export function setupAccountsBillingRoutes(
                   };
                   syncResults.updated = true;
                 } else {
-                  // No subscription - check for paid membership invoices (manual invoice flow)
+                  // No live membership subscription on the customer (either
+                  // no subs at all, or only non-membership subs). Check for
+                  // paid membership invoices (manual invoice flow).
                   const invoices = await stripe.invoices.list({
                     customer: org.stripe_customer_id,
                     status: 'paid',

--- a/server/tests/integration/admin-sync-revenue-backfill.test.ts
+++ b/server/tests/integration/admin-sync-revenue-backfill.test.ts
@@ -71,6 +71,11 @@ const mocks = vi.hoisted(() => {
                 unit_amount: 250000,
                 currency: 'usd',
                 recurring: { interval: 'year' },
+                // /sync filters to membership subs by lookup_key prefix
+                // (`aao_membership_*` / `aao_invoice_*`) so a non-membership
+                // sub doesn't overwrite a paying member's row. Real Stripe
+                // membership prices always carry a lookup_key.
+                lookup_key: 'aao_membership_professional_250',
               },
             }],
           },

--- a/server/tests/unit/billing/membership-prices.test.ts
+++ b/server/tests/unit/billing/membership-prices.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for the membership-price predicate + sub picker shared between
+ * the integrity invariant, the /sync endpoint, and (future) the cron
+ * reconciler. The bug this prevents is the inline `subscriptions.data[0]`
+ * pattern that picks the wrong sub when a customer has a non-membership
+ * sub stacked alongside a real membership.
+ */
+import { describe, it, expect } from 'vitest';
+import type Stripe from 'stripe';
+import {
+  isMembershipLookupKey,
+  isMembershipSub,
+  pickMembershipSub,
+} from '../../../src/billing/membership-prices.js';
+
+function fakeSub(overrides: {
+  id?: string;
+  status?: Stripe.Subscription.Status;
+  lookup_key?: string | null;
+} = {}): Stripe.Subscription {
+  // 'lookup_key' in overrides preserves explicit null (vs ?? which would
+  // substitute the default for null too). Tests need to assert behavior
+  // against missing lookup_keys.
+  const lookupKey = 'lookup_key' in overrides ? overrides.lookup_key : 'aao_membership_professional_250';
+  return {
+    id: overrides.id ?? 'sub_x',
+    status: overrides.status ?? 'active',
+    items: {
+      data: [{
+        price: { lookup_key: lookupKey },
+      }],
+    },
+  } as unknown as Stripe.Subscription;
+}
+
+describe('isMembershipLookupKey', () => {
+  it.each([
+    ['aao_membership_explorer_50', true],
+    ['aao_membership_professional_250', true],
+    ['aao_membership_builder_3000', true],
+    ['aao_membership_member_15000', true],
+    ['aao_membership_leader_50000', true],
+    ['aao_invoice_corporate_2025', true],
+    ['aao_membership_individual_discounted', true],
+    ['aao_event_summit_2026', false],
+    ['some_other_product', false],
+    ['', false],
+    [null, false],
+    [undefined, false],
+  ])('lookup_key %j -> %j', (key, expected) => {
+    expect(isMembershipLookupKey(key)).toBe(expected);
+  });
+});
+
+describe('isMembershipSub', () => {
+  it('true when first item has a membership lookup_key', () => {
+    expect(isMembershipSub(fakeSub())).toBe(true);
+  });
+  it('false when first item has a non-membership lookup_key', () => {
+    expect(isMembershipSub(fakeSub({ lookup_key: 'aao_event_ticket' }))).toBe(false);
+  });
+  it('false when lookup_key is missing', () => {
+    expect(isMembershipSub(fakeSub({ lookup_key: null }))).toBe(false);
+  });
+});
+
+describe('pickMembershipSub', () => {
+  it('returns null on empty list', () => {
+    expect(pickMembershipSub([])).toBeNull();
+  });
+
+  it('returns null when no item is a membership sub', () => {
+    const subs = [
+      fakeSub({ id: 'sub_event', lookup_key: 'aao_event_ticket' }),
+      fakeSub({ id: 'sub_other', lookup_key: 'unrelated_product' }),
+    ];
+    expect(pickMembershipSub(subs)).toBeNull();
+  });
+
+  it('picks the membership sub when stacked with a non-membership sub (the data[0] bug)', () => {
+    // Order matters: non-membership listed first. data[0] would pick the wrong one.
+    const subs = [
+      fakeSub({ id: 'sub_event', lookup_key: 'aao_event_ticket' }),
+      fakeSub({ id: 'sub_member', lookup_key: 'aao_membership_explorer_50' }),
+    ];
+    expect(pickMembershipSub(subs)?.id).toBe('sub_member');
+  });
+
+  it('picks the membership sub when it appears first too', () => {
+    const subs = [
+      fakeSub({ id: 'sub_member', lookup_key: 'aao_membership_explorer_50' }),
+      fakeSub({ id: 'sub_event', lookup_key: 'aao_event_ticket' }),
+    ];
+    expect(pickMembershipSub(subs)?.id).toBe('sub_member');
+  });
+
+  it('prefers active over trialing when (anomalously) two membership subs exist', () => {
+    // This is itself a one-active-stripe-sub-per-org violation — the picker
+    // breaks the tie deterministically rather than letting Stripe ordering decide.
+    const subs = [
+      fakeSub({ id: 'sub_trial', status: 'trialing', lookup_key: 'aao_membership_explorer_50' }),
+      fakeSub({ id: 'sub_active', status: 'active', lookup_key: 'aao_membership_professional_250' }),
+    ];
+    expect(pickMembershipSub(subs)?.id).toBe('sub_active');
+  });
+
+  it('returns the trialing sub when no active membership exists', () => {
+    const subs = [
+      fakeSub({ id: 'sub_trial', status: 'trialing', lookup_key: 'aao_membership_explorer_50' }),
+    ];
+    expect(pickMembershipSub(subs)?.id).toBe('sub_trial');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a latent bug in `POST /api/admin/accounts/:orgId/sync` where `customer.subscriptions.data[0]` could pick a non-membership sub stacked alongside a real membership and overwrite the org row with the wrong state. Verified end-to-end against the sandbox `multi_sub` fixture from #3643.

## The bug

`server/src/routes/admin/accounts-billing.ts:144` (now fixed):

```typescript
const subscription = subscriptions.data[0];
```

Stripe doesn't guarantee subscription ordering. A customer who pays for a membership AND has any non-membership sub (one-off product, future ancillary sub) can end up with the wrong sub at index 0. `/sync` would then write the non-membership sub's `status`, `amount`, `lookup_key`, etc. to the org row — clobbering a paying member with a one-off product's state.

## Reproduction (against the sandbox shipped in #3643)

```
$ npx tsx -e "<query multi_sub fixture>"
All subs on multi_sub customer:
  sub_1TRr5VH3X7K0BEHzbyxcy0h9  status=trialing  lookup=aao_sandbox_event_ticket
  sub_1TRr5TH3X7K0BEHzBo4qxV1Y  status=trialing  lookup=aao_membership_explorer_50

OLD (subscriptions.data[0]):  picks sub_1TRr5V… lookup=aao_sandbox_event_ticket   ❌
NEW (pickMembershipSub):       picks sub_1TRr5T… lookup=aao_membership_explorer_50  ✓
```

Stripe returns the non-membership sub first; old `data[0]` would pick it.

## What changed

1. New module `server/src/billing/membership-prices.ts` — single source of truth for "is this a membership lookup_key" + sub-picker. Replaces the inline prefix-list in the integrity invariant and is called from `/sync`.

   - `isMembershipLookupKey(key)` — true when key starts with `aao_membership_` or `aao_invoice_`
   - `isMembershipSub(sub)` — true when first item is a membership-priced sub
   - `pickMembershipSub(subs)` — returns the membership sub, preferring `active` over other live statuses for stable tiebreak

2. `accounts-billing.ts:/sync` now calls `pickMembershipSub` instead of indexing `data[0]`. When no membership sub is found, falls through to the existing invoice-fallback branch (preserving prior behavior for invoice-billed orgs).

3. `stripe-sub-reflected-in-org-row` invariant (merged in #3627) refactored to import the shared helper. Behavior unchanged; just DRYs up the prefix list.

## What it deliberately doesn't do

- Doesn't refactor the invoice-fallback branch's inline check (line 202-211). That branch ALSO checks `productMetadata.category === 'membership'` which the helper doesn't model. Out of scope for this PR — separate cleanup if desired.
- Doesn't change webhook subscription-update handling in `http.ts:3725-3850`. That path receives a single subscription from Stripe directly; it doesn't pick from a list.
- Doesn't address the broader "auto-remediation skips agreement attestation" concern (security review H3 on #3623). That's step 3 of Path B — separate PR after this.

## Test plan

- [x] 21-case unit test on the helper: `npx vitest run tests/unit/billing/membership-prices.test.ts`
- [x] Existing integrity invariant tests still pass (46/46): `npx vitest run tests/unit/integrity/`
- [x] `npx tsc --noEmit` clean
- [x] Pre-commit hook (unit + dynamic imports + typecheck) passes
- [x] Manual verification against sandbox `multi_sub` fixture: bug reproduced + fix confirmed

## Refs

- Issue: #3623 (Path B step 2 of the cron auto-remediation work)
- Sandbox: #3643 (provides the `multi_sub` fixture this PR validates against)
- Detect path (Path A): #3627 (already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)