### PR TITLE
feat(addie-admin): render shadow shape badges + source-distinct labels

### DIFF
--- a/.changeset/admin-shadow-shape-panel.md
+++ b/.changeset/admin-shadow-shape-panel.md
@@ -1,0 +1,22 @@
+---
+---
+
+Render shape regressions and source-distinct labeling on the admin-addie
+shadow eval panel:
+
+- Pill-style badges for `shadow_eval_shape` violations on both Addie's
+  response and the longest human reply (length_cap, default_template,
+  structured_heavy, comprehensive_dump, signin_opener, ritual:phrase),
+  with response word counts and ratio-to-expected.
+- Distinct panel header per `shadow_eval_source`: "Corrected Capture" for
+  threads where Addie posted and a human corrected, "Shadow Evaluation"
+  for the suppression case where Addie was kept silent.
+- Caveat line: "Corpus is selected for human intervention — counts here
+  are not a global rate." Prevents reviewers from miscomputing prevalence
+  from the corrected-capture corpus.
+- Side-by-side comparison label switches from "ADDIE WOULD HAVE SAID" to
+  "ADDIE'S ACTUAL RESPONSE" when source is corrected-capture (the field
+  holds her real reply, not a re-generated shadow).
+
+API path unchanged — `/api/admin/addie/threads/:id` already returns the
+full thread context, so the new fields are exposed without server work.

--- a/server/public/admin-addie.html
+++ b/server/public/admin-addie.html
@@ -3334,7 +3334,7 @@
         const shapeRow = shadowShape ? `
             <div style="display: flex; flex-wrap: wrap; gap: var(--space-2); margin-top: var(--space-2); padding-top: var(--space-2); border-top: 1px solid var(--color-border-subtle, #e5e7eb);">
               <div style="display: flex; flex-direction: column; gap: var(--space-1);">
-                <div style="font-size: var(--text-xs); font-weight: 600; color: var(--color-text-muted);">ADDIE SHAPE (${shadowShape.shadow?.word_count ?? '?'} words, ratio ${(shadowShape.shadow?.ratio_to_expected ?? 0).toFixed(2)})</div>
+                <div style="font-size: var(--text-xs); font-weight: 600; color: var(--color-text-muted);">ADDIE SHAPE (${shadowShape.shadow?.word_count ?? '?'} words, ratio ${shadowShape.shadow?.ratio_to_expected != null ? shadowShape.shadow.ratio_to_expected.toFixed(2) : '?'})</div>
                 <div style="display: flex; flex-wrap: wrap; gap: var(--space-1);">
                   ${shapeBadges(shadowShape.shadow?.violations)}
                 </div>

--- a/server/public/admin-addie.html
+++ b/server/public/admin-addie.html
@@ -3293,17 +3293,72 @@
           </div>
         ` : '';
 
-        // Shadow evaluation panel (if present in thread context)
+        // Shadow evaluation panel (if present in thread context).
+        //
+        // Two distinct evaluation flows land in this same context object,
+        // distinguished by shadow_eval_source:
+        //   - 'addie_corrected_capture' — Addie POSTED a response and a human
+        //     followed up with a correction. shadow_eval_shadow_response holds
+        //     Addie's actual response (not a re-generated shadow).
+        //   - default (suppression) — Addie was suppressed because humans got
+        //     there first; shadow_eval_shadow_response is what she WOULD have
+        //     said.
+        //
+        // shadow_eval_shape carries the deterministic shape grader output
+        // for both Addie and the longest human response. Render it as
+        // pill-style badges so reviewers can see why a thread fired without
+        // expanding the response comparison.
         const shadowEval = data.context?.shadow_eval_status === 'complete' ? data.context : null;
+        const isCorrected = shadowEval?.shadow_eval_source === 'addie_corrected_capture';
+        const shadowSourceLabel = isCorrected
+          ? 'Addie posted; human followed up with a correction'
+          : 'Addie was suppressed (human answered first)';
+        const addieResponseLabel = isCorrected
+          ? "ADDIE'S ACTUAL RESPONSE"
+          : 'ADDIE WOULD HAVE SAID';
+
+        // Map shape violation labels to badge styling. The grader emits
+        // strings like 'length_cap(243>200)', 'default_template',
+        // 'structured_heavy', 'comprehensive_dump', 'signin_opener',
+        // 'ritual:great question'. Render each as a flagged-style pill.
+        const shapeBadges = (labels) => {
+          if (!labels || labels.length === 0) {
+            return `<span class="badge badge-active">Shape OK</span>`;
+          }
+          return labels.map((l) =>
+            `<span class="badge badge-flagged" style="font-family: var(--font-mono); font-size: var(--text-xs);">${escapeHtml(l)}</span>`
+          ).join(' ');
+        };
+
+        const shadowShape = shadowEval?.shadow_eval_shape || null;
+        const shapeRow = shadowShape ? `
+            <div style="display: flex; flex-wrap: wrap; gap: var(--space-2); margin-top: var(--space-2); padding-top: var(--space-2); border-top: 1px solid var(--color-border-subtle, #e5e7eb);">
+              <div style="display: flex; flex-direction: column; gap: var(--space-1);">
+                <div style="font-size: var(--text-xs); font-weight: 600; color: var(--color-text-muted);">ADDIE SHAPE (${shadowShape.shadow?.word_count ?? '?'} words, ratio ${(shadowShape.shadow?.ratio_to_expected ?? 0).toFixed(2)})</div>
+                <div style="display: flex; flex-wrap: wrap; gap: var(--space-1);">
+                  ${shapeBadges(shadowShape.shadow?.violations)}
+                </div>
+              </div>
+              <div style="display: flex; flex-direction: column; gap: var(--space-1);">
+                <div style="font-size: var(--text-xs); font-weight: 600; color: var(--color-text-muted);">HUMAN SHAPE (${shadowShape.human?.word_count ?? '?'} words)</div>
+                <div style="display: flex; flex-wrap: wrap; gap: var(--space-1);">
+                  ${shapeBadges(shadowShape.human?.violations)}
+                </div>
+              </div>
+            </div>
+        ` : '';
+
         const shadowPanel = shadowEval ? `
           <div style="margin-bottom: var(--space-4); padding: var(--space-3); background: ${shadowEval.shadow_eval_result?.knowledge_gap ? 'var(--color-bg-danger, #fef2f2)' : 'var(--color-bg-success, #f0fdf4)'}; border: 1px solid ${shadowEval.shadow_eval_result?.knowledge_gap ? 'var(--color-border-danger, #fecaca)' : 'var(--color-border-success, #bbf7d0)'}; border-radius: var(--radius-md);">
-            <div style="display: flex; align-items: center; gap: var(--space-2); margin-bottom: var(--space-2);">
-              <strong style="font-size: var(--text-sm);">Shadow Evaluation</strong>
+            <div style="display: flex; align-items: center; gap: var(--space-2); margin-bottom: var(--space-1); flex-wrap: wrap;">
+              <strong style="font-size: var(--text-sm);">${isCorrected ? 'Corrected Capture' : 'Shadow Evaluation'}</strong>
               ${shadowEval.shadow_eval_result?.knowledge_gap
                 ? `<span class="badge badge-flagged">Knowledge Gap: ${escapeHtml(shadowEval.shadow_eval_result.gap_severity)}</span>`
                 : `<span class="badge badge-active">No Gap (${escapeHtml(shadowEval.shadow_eval_result?.shadow_quality || 'equivalent')})</span>`}
             </div>
+            <div style="font-size: var(--text-xs); color: var(--color-text-muted); margin-bottom: var(--space-2);">${escapeHtml(shadowSourceLabel)} · corpus is selected for human intervention — counts here are not a global rate</div>
             ${shadowEval.shadow_eval_result?.gap_details ? `<p style="margin: var(--space-2) 0; font-size: var(--text-sm); color: var(--color-text-default);">${escapeHtml(shadowEval.shadow_eval_result.gap_details)}</p>` : ''}
+            ${shapeRow}
             <details style="margin-top: var(--space-2);">
               <summary style="cursor: pointer; font-size: var(--text-sm); color: var(--color-text-muted);">Compare responses</summary>
               <div style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-3); margin-top: var(--space-2);">
@@ -3312,7 +3367,7 @@
                   <div style="font-size: var(--text-sm); white-space: pre-wrap; background: var(--color-bg-muted); padding: var(--space-2); border-radius: var(--radius-sm);">${escapeHtml(shadowEval.shadow_eval_human_response || 'N/A')}</div>
                 </div>
                 <div>
-                  <div style="font-size: var(--text-xs); font-weight: 600; margin-bottom: var(--space-1); color: var(--color-text-muted);">ADDIE WOULD HAVE SAID</div>
+                  <div style="font-size: var(--text-xs); font-weight: 600; margin-bottom: var(--space-1); color: var(--color-text-muted);">${addieResponseLabel}</div>
                   <div style="font-size: var(--text-sm); white-space: pre-wrap; background: var(--color-bg-muted); padding: var(--space-2); border-radius: var(--radius-sm);">${escapeHtml(shadowEval.shadow_eval_shadow_response || 'N/A')}</div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
Closes the third follow-up from the prompt-engineer review of #3601. The admin-addie shadow eval panel was rendering knowledge-gap signal but not the shape grader output the corrected-capture pipeline now persists, and was not differentiating between the two corpora that land in the same thread context.

## Changes (one file: \`server/public/admin-addie.html\`)
- **Shape badges**: every \`shadow_eval_shape.{shadow,human}.violations\` label renders as a pill — \`length_cap(243>200)\`, \`default_template\`, \`structured_heavy\`, \`comprehensive_dump\`, \`signin_opener\`, \`ritual:great question\`. Word counts and ratio-to-expected sit in the column header.
- **Source-distinct headers**: \`shadow_eval_source: 'addie_corrected_capture'\` → "Corrected Capture"; default → "Shadow Evaluation". A one-line subtitle clarifies which one applies on this thread.
- **Corpus caveat**: "Corpus is selected for human intervention — counts here are not a global rate." Prevents miscomputing prevalence.
- **Response-label fix**: side-by-side comparison shows "ADDIE'S ACTUAL RESPONSE" for corrected-capture (the stored value is her real reply) and "ADDIE WOULD HAVE SAID" for suppression (the stored value is a regenerated shadow).

## Test plan
- [x] Type-check clean (pre-commit hook).
- [ ] Visual check post-deploy: corrected-capture threads now show "Corrected Capture" header + shape badges; suppression threads show "Shadow Evaluation" + shape badges.
- [ ] Spot-check a thread where the grader fired multiple violations (e.g., \`length_cap\` + \`default_template\`) renders both badges side by side.

## Why now
\`shadow-corrected-capture\` job is running in production (every 30 min) since #3601 deployed. Without this rendering, the shape grader's output is invisible to anyone reviewing threads in the admin UI — the data is correct but unviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)