### PR TITLE
fix(addie): create_github_issue prompts reauth when token has missing scopes

### DIFF
--- a/.changeset/fix-create-github-issue-missing-scopes.md
+++ b/.changeset/fix-create-github-issue-missing-scopes.md
@@ -1,0 +1,10 @@
+---
+---
+
+Fix `create_github_issue` to prompt reauth when the user's GitHub Pipes token is active but missing required scopes.
+
+The Pipes call returns `{ status, accessToken, scopes, missingScopes }`, but the handler only branched on `status !== 'ok'` — so users with a stale connection that lacked `public_repo` (or any scope we now require) silently called GitHub and got a 403 fallback message ("Failed to create issue (403). Use draft_github_issue…") instead of the "Reconnect GitHub" prompt that would actually fix it.
+
+Now: when `status === 'ok' && missingScopes.length > 0`, treat it the same as `needs_reauthorization` and surface the reconnect URL. Also logs `missingScopes` at `info` for observability so we can see which scope(s) Pipes is reporting missing.
+
+Diagnosed from real-user 403s in PostHog `$exception` events on 2026-04-29.

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -5082,10 +5082,19 @@ export function createMemberToolHandlers(
       return `GitHub connection is unavailable right now. Use \`draft_github_issue\` to generate a pre-filled link you can submit yourself. (Manage connections at ${manageConnectionsUrl}.)`;
     }
 
-    if (tokenResult.status !== 'ok') {
+    const tokenMissingScopes =
+      tokenResult.status === 'ok' && tokenResult.missingScopes.length > 0;
+
+    if (tokenResult.status !== 'ok' || tokenMissingScopes) {
       const connectUrl = `${baseUrl}/connect/github?return_to=${encodeURIComponent('/member-hub?connected=github')}`;
 
-      if (tokenResult.status === 'needs_reauthorization') {
+      if (tokenResult.status === 'needs_reauthorization' || tokenMissingScopes) {
+        if (tokenMissingScopes && tokenResult.status === 'ok') {
+          logger.info(
+            { workosUserId, missingScopes: tokenResult.missingScopes },
+            'create_github_issue: token is active but missing required scopes — prompting reauth',
+          );
+        }
         return [
           `Your GitHub connection needs a quick re-authorization (the scopes we need changed).`,
           '',

--- a/tests/addie/member-tools.test.ts
+++ b/tests/addie/member-tools.test.ts
@@ -383,6 +383,24 @@ describe('createMemberToolHandlers', () => {
       expect(fetchMock).not.toHaveBeenCalled();
     });
 
+    it('prompts reauth when token is active but missing required scopes', async () => {
+      getTokenMock.mockResolvedValue({
+        status: 'ok',
+        accessToken: 'gho_token_with_partial_scopes',
+        scopes: ['user:email'],
+        missingScopes: ['public_repo'],
+      });
+
+      const handlers = createMemberToolHandlers(loggedInContext);
+      const handler = handlers.get('create_github_issue')!;
+
+      const result = await handler({ title: 'T', body: 'B' });
+
+      expect(result).toContain('re-authorization');
+      expect(result).toMatch(/\[Reconnect GitHub\]\([^)]*\/connect\/github\?return_to=/);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
     it('gracefully degrades when Pipes getAccessToken throws', async () => {
       getTokenMock.mockRejectedValue(new Error('workos api down'));
 


### PR DESCRIPTION
## Summary

`create_github_issue` was silently calling the GitHub API with a token that didn't have the right scopes — users got a generic "Failed to create issue (403)" fallback instead of the reconnect prompt that would actually fix it.

## Root cause

`server/src/services/pipes.ts:9` returns `{ status, accessToken, scopes, missingScopes }` for the `'ok'` variant. The handler at `server/src/addie/mcp/member-tools.ts:5085` only branched on `status !== 'ok'` — `missingScopes` was unused. When WorkOS Pipes returned `{ status: 'ok', missingScopes: ['public_repo'] }` (e.g., for a user whose OAuth connection predates a scope change), we plowed ahead and let GitHub return 403.

## Diagnosis

PostHog `$exception` events on 2026-04-29 showed two 403s from `create_github_issue`, ~18 min apart, hitting `api.github.com/repos/adcontextprotocol/adcp/issues`. 403 (not 401) = token authenticated but lacked permission, which fits the missing-scope hypothesis. (We were unable to attribute these to a user because of the `module: unknown` bug fixed in #3578 / #3622.)

## Fix

When `status === 'ok' && missingScopes.length > 0`, route the user to the same reconnect path as `needs_reauthorization`. Also log `missingScopes` at `info` so operators can see *which* scope(s) Pipes is reporting missing.

## Test plan

- [x] New unit test covers the missing-scopes-on-active-token case
- [x] Existing tests for `not_connected`, `needs_reauthorization`, throw-on-getAccessToken, success path, 422 retry, and 500 fallback all still pass (55/55)
- [x] Pre-commit (`test:unit + test-dynamic-imports + typecheck`) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)