### PR TITLE
fix(security): warn at module load when HTTP(S)_PROXY env is set

### DIFF
--- a/.changeset/safefetch-proxy-env-warn.md
+++ b/.changeset/safefetch-proxy-env-warn.md
@@ -1,0 +1,6 @@
+---
+---
+
+Detect HTTP_PROXY / HTTPS_PROXY / lowercase variants at module load in `server/src/utils/url-security.ts` and log a warning. The DNS-rebind defense added in PR #3609 routes through undici's `Agent({ connect: { lookup } })` — but if the deploy environment routes outbound HTTP through a proxy and a future caller honors the env var (or wraps to `ProxyAgent`), the proxy becomes the DNS resolver and our lookup hook never fires.
+
+Closes #3620.

--- a/server/src/utils/url-security.ts
+++ b/server/src/utils/url-security.ts
@@ -2,6 +2,40 @@ import dns from 'dns/promises';
 import { lookup as dnsLookup, type LookupAddress, type LookupOptions } from 'dns';
 import { isIP, type LookupFunction } from 'net';
 import { Agent, type Dispatcher } from 'undici';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('url-security');
+
+/**
+ * The SSRF-safe dispatcher in `safeFetch` enforces private-IP rejection at TCP
+ * connect time via undici's `lookup` hook. That defense bypasses if the deploy
+ * environment routes outbound HTTP through a proxy (HTTP_PROXY / HTTPS_PROXY)
+ * — undici's standard `Agent` does not auto-route through `ProxyAgent`, but if
+ * a future caller wraps it OR a sibling library (e.g. axios, node-fetch
+ * shimmed elsewhere) honors these env vars, the proxy itself becomes the DNS
+ * resolver and our `lookup` hook is never invoked.
+ *
+ * Detect the env at module load and warn loudly. Operators can then verify the
+ * proxy enforces SSRF rules of its own, or unset the var on the path that
+ * calls `safeFetch`.
+ *
+ * Tracked from the post-#3609 security review (issue #3620).
+ */
+export function detectProxyEnv(): readonly string[] {
+  const set: string[] = [];
+  for (const name of ['HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy']) {
+    if (process.env[name]) set.push(name);
+  }
+  return set;
+}
+
+const proxyEnvVars = detectProxyEnv();
+if (proxyEnvVars.length > 0) {
+  logger.warn(
+    { vars: proxyEnvVars },
+    'safeFetch: proxy env var(s) detected — DNS-rebind defense is only safe if the proxy itself enforces SSRF rules. Verify or unset.',
+  );
+}
 
 /**
  * Check if a hostname or IP address points to a private/internal network.

--- a/server/tests/unit/url-security-proxy-detect.test.ts
+++ b/server/tests/unit/url-security-proxy-detect.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Pins the proxy-env detection in url-security.ts.
+ *
+ * Background: PR #3609 closed the DNS-rebind TOCTOU in `safeFetch` via undici's
+ * `Agent({ connect: { lookup } })`. The defense only holds if undici is the
+ * thing doing the connect — if HTTP_PROXY / HTTPS_PROXY is set in the deploy
+ * env and a future caller routes through `ProxyAgent` (or a sibling library
+ * honors these vars), the proxy becomes the DNS resolver and our `lookup`
+ * hook never fires.
+ *
+ * `detectProxyEnv()` returns the var names that are set, and the module-load
+ * IIFE in url-security.ts logs a warning when any are present. This test
+ * pins that detection function — a refactor that drops one of the vars from
+ * the watchlist will fail loudly here.
+ *
+ * Tracked from issue #3620 (followup security review on #3609).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { detectProxyEnv } from '../../src/utils/url-security.js';
+
+const PROXY_VARS = ['HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy'] as const;
+
+describe('detectProxyEnv', () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const v of PROXY_VARS) {
+      saved[v] = process.env[v];
+      delete process.env[v];
+    }
+  });
+
+  afterEach(() => {
+    for (const v of PROXY_VARS) {
+      if (saved[v] !== undefined) process.env[v] = saved[v];
+      else delete process.env[v];
+    }
+  });
+
+  it('returns empty when no proxy vars are set', () => {
+    expect(detectProxyEnv()).toEqual([]);
+  });
+
+  it.each(PROXY_VARS)('detects %s', (name) => {
+    process.env[name] = 'http://proxy.example:3128';
+    expect(detectProxyEnv()).toEqual([name]);
+  });
+
+  it('detects multiple vars set together', () => {
+    process.env.HTTP_PROXY = 'http://p:3128';
+    process.env.https_proxy = 'http://p:3128';
+    const result = detectProxyEnv();
+    expect(result).toContain('HTTP_PROXY');
+    expect(result).toContain('https_proxy');
+    expect(result).toHaveLength(2);
+  });
+
+  it('treats empty-string value as unset', () => {
+    process.env.HTTP_PROXY = '';
+    expect(detectProxyEnv()).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #3620.

## Summary

The DNS-rebind defense added in #3609 enforces private-IP rejection at TCP connect time via undici's `Agent({ connect: { lookup } })`. The defense holds only as long as undici is what makes the connection — if the deploy env sets `HTTP_PROXY` / `HTTPS_PROXY` (or the lowercase variants) and a future caller routes through `ProxyAgent`, OR a sibling library honors these vars, the proxy becomes the DNS resolver and our lookup hook is silently bypassed.

## Changes

- Detect all four common proxy env names at module load.
- Log a structured `logger.warn` listing the detected names and the threat.
- Export `detectProxyEnv()` so the watchlist is unit-testable.
- 5 new unit tests pin the detection.

## Validation

The warn is firing in the local test env (the npm safe-chain proxy sets `HTTPS_PROXY` to `http://localhost:59405`):

```
{"level":40,"module":"url-security","vars":["HTTPS_PROXY"],"msg":"safeFetch: proxy env var(s) detected — DNS-rebind defense is only safe if the proxy itself enforces SSRF rules. Verify or unset."}
```

That's exactly the type of state operators should be aware of.

## Why warn vs fail-closed

The issue offered both. Warn is the lighter touch — Fly prod does not currently set proxy env on `safeFetch` callers, so failing closed would only manufacture deploy breakage with no security upside. If we observe the warning in prod, we can upgrade to fail-closed in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)