### PR TITLE
docs(logger): document level convention re Slack/PostHog hook

### DIFF
--- a/.changeset/docs-logger-level-convention.md
+++ b/.changeset/docs-logger-level-convention.md
@@ -1,0 +1,6 @@
+---
+---
+
+Document the level convention in `server/src/logger.ts` JSDoc: `error`/`fatal` (level >= 50) trigger Slack `#aao-errors` alerts and PostHog `$exception` capture via the pino hook, so they should be reserved for unexpected, page-worthy failures. For *expected* failures with a graceful user-facing fallback (third-party 4xx, validation errors, etc.), use `warn` so the alert path is not taken.
+
+This is a docs-only change to give future authors and reviewers a clear reference for the `logger.error` vs `logger.warn` decision. The same anti-pattern triggered the original `:rotating_light: System error: unknown` Slack noise that PRs #3578 / #3622 / #3648 fixed.

--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -193,7 +193,20 @@ export function createLogger(context: string | Record<string, unknown>) {
  * - trace: Very detailed, low-level information (usually disabled)
  * - debug: Debugging information (enabled in development)
  * - info: Normal operation messages (default in production)
- * - warn: Warning messages (potential issues)
- * - error: Error messages (operation failed but app continues)
+ * - warn: Warning messages (potential issues, expected failures with a graceful fallback)
+ * - error: Unexpected failures — operation failed but app continues
  * - fatal: Critical errors (app cannot continue)
+ *
+ * IMPORTANT: `logger.error()` and `logger.fatal()` (level >= 50) trigger the
+ * Slack `#aao-errors` alert and a PostHog `$exception` capture via the pino
+ * hook in this file (and `notifyErrorChannel` in `utils/posthog.ts`). Use
+ * `error` for failures that should page an operator. For *expected* failures
+ * — third-party 4xx, validation errors, anything where the caller already
+ * returns a friendly user-facing message — use `warn` so the alert path is
+ * not taken.
+ *
+ * Tool handlers in `addie/mcp/` are the most common source of confusion:
+ * if your handler catches a failure and returns a "Failed to do X" string
+ * to the user, that should be `logger.warn`, not `logger.error`. Reserve
+ * `error` for catch blocks of network/parse failures that "shouldn't happen".
  */


### PR DESCRIPTION
## Summary

Document in `server/src/logger.ts` JSDoc that `logger.error` / `logger.fatal` (level ≥ 50) trigger the `#aao-errors` Slack alert and PostHog `$exception` capture via the pino hook in this file (and `notifyErrorChannel` in `utils/posthog.ts`).

Authors writing tool handlers should use:
- **`error`** for unexpected, page-worthy failures (network/parse failures in catch blocks that "shouldn't happen")
- **`warn`** for expected failures that already return a graceful user-facing fallback (third-party 4xx, validation errors, "issue not found", etc.)

This is the convention I learned the hard way fixing the `:rotating_light: System error: unknown` Slack noise in PRs #3578, #3622, and #3648. Codifying it next to the existing log-level guide so future authors and reviewers have a clear reference.

## Audit data

178 `logger.error` call sites currently exist across `server/src/addie/mcp/*.ts`. Top files:

| count | file |
|------:|------|
| 78 | `addie/mcp/admin-tools.ts` |
| 27 | `addie/mcp/member-tools.ts` |
| 15 | `addie/mcp/certification-tools.ts` |
| 6 | `mcp/si-host-tools.ts`, `mcp/moltbook-tools.ts`, `mcp/knowledge-search.ts`, `mcp/billing-tools.ts` |

Many are legitimate (catch blocks for unexpected failures), some are likely the user-driven-failure-with-graceful-fallback anti-pattern. Triage will follow as alerts surface in `#aao-errors`. No automated downgrade in this PR — that's judgment-dependent and would have a high false-positive rate as a lint rule.

## Test plan

- [x] Pre-commit (`test:unit + test-dynamic-imports + typecheck`) — passed
- [x] Docs-only change to JSDoc; no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)