### PR TITLE
feat(addie): persist inbound message text on person_events.message_received (#3580)

### DIFF
--- a/.changeset/persist-inbound-text.md
+++ b/.changeset/persist-inbound-text.md
@@ -1,0 +1,4 @@
+---
+---
+
+`message_received` person_events now persist the inbound text alongside `text_length` (mirroring what `message_sent` already stores). This unblocks "find this thread, see what's missing"-shaped diagnostics — Addie can now read the full conversation from her own timeline instead of seeing only outbound messages. Web chat writes use `inputValidation.sanitized` so the entry inherits the existing prompt-injection / flagging pipeline; Slack writes use the same sanitized variant. A 64KB byte cap with a `truncated: true` flag prevents a single large paste from inflating timeline reads. Closes #3580.

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -271,12 +271,16 @@ function resolveSpeakerDisplayName(mc: MemberContext | null | undefined): string
 /**
  * Record a person's inbound message in the relationship system.
  * Resets unreplied_outreach_count, derives sentiment, and logs the event.
+ *
+ * The text passed here should already be sanitized by `sanitizeInput()` so we
+ * inherit the prompt-injection / flagging pipeline rather than persisting the
+ * raw payload. Capped at 64KB by capEventText.
  */
 async function recordPersonInboundMessage(
   slackUserId: string,
   channel: 'slack' | 'email' | 'web',
   source: string,
-  textLength: number
+  text: string
 ): Promise<void> {
   try {
     const personId = await relationshipDb.resolvePersonId({ slack_user_id: slackUserId });
@@ -284,7 +288,7 @@ async function recordPersonInboundMessage(
     await relationshipDb.deriveSentiment(personId);
     await personEvents.recordEvent(personId, 'message_received', {
       channel,
-      data: { source, text_length: textLength },
+      data: personEvents.buildMessageReceivedData(text, source),
     });
   } catch (error) {
     // Not all Slack users have person_relationships records yet — that's OK
@@ -1445,7 +1449,7 @@ async function handleUserMessage({
   const inputValidation = sanitizeInput(messageText || '');
 
   // Record inbound message in the relationship system (resets unreplied count, derives sentiment)
-  recordPersonInboundMessage(userId, 'slack', 'assistant_thread', (messageText || '').length);
+  recordPersonInboundMessage(userId, 'slack', 'assistant_thread', inputValidation.sanitized);
 
   // Set status with rotating loading messages
   try {
@@ -3109,7 +3113,7 @@ async function handleDirectMessage(
   logger.info({ userId, channelId }, 'Addie Bolt: Processing direct message');
 
   // Record inbound message in the relationship system (resets unreplied count, derives sentiment)
-  recordPersonInboundMessage(userId, 'slack', 'dm', messageText.length);
+  recordPersonInboundMessage(userId, 'slack', 'dm', inputValidation.sanitized);
 
   // Get member context
   let memberContext: MemberContext | null = null;

--- a/server/src/addie/handler.ts
+++ b/server/src/addie/handler.ts
@@ -591,7 +591,7 @@ export async function handleAssistantMessage(
       });
     personEvents.recordEvent(personId, 'message_received', {
       channel: 'slack',
-      data: { source: 'dm', text_length: textWithResolvedMentions.length },
+      data: personEvents.buildMessageReceivedData(inputValidation.sanitized, 'dm'),
     }).catch(err => logger.warn({ err, personId }, 'Addie: Failed to record message_received event'));
   }
 

--- a/server/src/db/person-events-db.ts
+++ b/server/src/db/person-events-db.ts
@@ -54,6 +54,55 @@ export interface PersonEvent {
 // ---------------------------------------------------------------------------
 
 /**
+ * Cap stored message text at 64KB (UTF-8 byte count). Slack messages are
+ * theoretically capped at 40KB by the platform; web chat has no upstream
+ * limit. Matching the limit here keeps a single 50KB paste from inflating
+ * timeline reads. Returns the (possibly truncated) text and a flag.
+ *
+ * `original_length` is the JS `string.length` of the input — UTF-16 code
+ * units, not bytes or codepoints. This matches the `text_length` convention
+ * already in use across `message_sent` and prior `message_received` writes;
+ * it does NOT match the cap units (the cap is in bytes, length is in code
+ * units). For an emoji-heavy payload, length will exceed byte count / 4.
+ */
+const MAX_EVENT_TEXT_BYTES = 64 * 1024;
+
+export function capEventText(text: string): {
+  text: string;
+  truncated: boolean;
+  original_length: number;
+} {
+  const original_length = text.length;
+  const buf = Buffer.from(text, 'utf8');
+  if (buf.byteLength <= MAX_EVENT_TEXT_BYTES) {
+    return { text, truncated: false, original_length };
+  }
+  // Truncate on a UTF-8 boundary
+  const trimmed = buf.subarray(0, MAX_EVENT_TEXT_BYTES).toString('utf8');
+  return { text: trimmed, truncated: true, original_length };
+}
+
+/**
+ * Build the `data` payload for a `message_received` event from a sanitized
+ * inbound text plus the source label (e.g. 'dm', 'web_chat'). Centralizes the
+ * cap + text + text_length + truncated shape so the four write sites
+ * (Slack handler, Slack bolt-app DM/assistant-thread, two web chat handlers)
+ * stay in lockstep.
+ */
+export function buildMessageReceivedData(
+  text: string,
+  source: string
+): Record<string, unknown> {
+  const capped = capEventText(text);
+  return {
+    source,
+    text: capped.text,
+    text_length: capped.original_length,
+    ...(capped.truncated ? { truncated: true } : {}),
+  };
+}
+
+/**
  * Record a person event. Append-only — never updates or deletes.
  */
 export async function recordEvent(

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -829,7 +829,7 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
           await relationshipDb.deriveSentiment(personId);
           await personEvents.recordEvent(personId, 'message_received', {
             channel: 'web',
-            data: { source: 'web_chat', text_length: message.length },
+            data: personEvents.buildMessageReceivedData(inputValidation.sanitized, 'web_chat'),
           });
         } catch {
           // Not all web users have person_relationships records — that's OK
@@ -1117,7 +1117,10 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
           await relationshipDb.deriveSentiment(personId);
           await personEvents.recordEvent(personId, 'message_received', {
             channel: 'web',
-            data: { source: 'web_chat_stream', text_length: message.length },
+            data: personEvents.buildMessageReceivedData(
+              inputValidation.sanitized,
+              'web_chat_stream'
+            ),
           });
         } catch {
           // Not all web users have person_relationships records

--- a/server/tests/integration/inbound-message-text.test.ts
+++ b/server/tests/integration/inbound-message-text.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Integration test for #3580: inbound message text persistence.
+ *
+ * Verifies that a `message_received` row written through the canonical path
+ * (recordEvent + capEventText) round-trips through getPersonTimeline with the
+ * text intact, and that older rows without `text` continue to read cleanly
+ * (backward compatibility).
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { initializeDatabase, closeDatabase, query } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { capEventText, recordEvent, getPersonTimeline } from '../../src/db/person-events-db.js';
+import { resolvePersonId } from '../../src/db/relationship-db.js';
+
+const TEST_DOMAIN = 'inbound-text-test.example.com';
+
+async function cleanup() {
+  await query(
+    `DELETE FROM person_events
+     WHERE person_id IN (SELECT id FROM person_relationships WHERE email LIKE $1)`,
+    [`%@${TEST_DOMAIN}`]
+  );
+  await query('DELETE FROM person_relationships WHERE email LIKE $1', [`%@${TEST_DOMAIN}`]);
+}
+
+describe('inbound message_received text persistence', () => {
+  beforeAll(async () => {
+    initializeDatabase({
+      connectionString:
+        process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+    await cleanup();
+  }, 60000);
+
+  afterAll(async () => {
+    await cleanup();
+    await closeDatabase();
+  });
+
+  beforeEach(cleanup);
+
+  it('stores inbound text on message_received and reads it back via getPersonTimeline', async () => {
+    const personId = await resolvePersonId({ email: `tej@${TEST_DOMAIN}` });
+
+    const original = 'Hi Addie — my colleagues can\'t log in. Can you help?';
+    const capped = capEventText(original);
+
+    await recordEvent(personId, 'message_received', {
+      channel: 'slack',
+      data: {
+        source: 'dm',
+        text: capped.text,
+        text_length: capped.original_length,
+      },
+    });
+
+    const events = await getPersonTimeline(personId, {
+      eventTypes: ['message_received'],
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].data).toMatchObject({
+      source: 'dm',
+      text: original,
+      text_length: original.length,
+    });
+    expect(events[0].data.truncated).toBeUndefined();
+  });
+
+  it('flags truncated when text exceeds the byte cap', async () => {
+    const personId = await resolvePersonId({ email: `big@${TEST_DOMAIN}` });
+
+    const huge = 'x'.repeat(70 * 1024);
+    const capped = capEventText(huge);
+
+    await recordEvent(personId, 'message_received', {
+      channel: 'web',
+      data: {
+        source: 'web_chat',
+        text: capped.text,
+        text_length: capped.original_length,
+        ...(capped.truncated ? { truncated: true } : {}),
+      },
+    });
+
+    const events = await getPersonTimeline(personId, {
+      eventTypes: ['message_received'],
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].data.truncated).toBe(true);
+    expect((events[0].data.text as string).length).toBeLessThanOrEqual(64 * 1024);
+    expect(events[0].data.text_length).toBe(70 * 1024);
+  });
+
+  it('reads pre-existing rows that have text_length but no text (backward compat)', async () => {
+    const personId = await resolvePersonId({ email: `legacy@${TEST_DOMAIN}` });
+
+    // Simulate an old row written before this PR — text_length only
+    await recordEvent(personId, 'message_received', {
+      channel: 'slack',
+      data: { source: 'dm', text_length: 42 },
+    });
+
+    const events = await getPersonTimeline(personId, {
+      eventTypes: ['message_received'],
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0].data.text_length).toBe(42);
+    expect(events[0].data.text).toBeUndefined();
+  });
+});

--- a/server/tests/unit/cap-event-text.test.ts
+++ b/server/tests/unit/cap-event-text.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildMessageReceivedData,
+  capEventText,
+} from '../../src/db/person-events-db.js';
+
+describe('capEventText', () => {
+  it('returns short text unchanged', () => {
+    const r = capEventText('hello world');
+    expect(r.text).toBe('hello world');
+    expect(r.truncated).toBe(false);
+    expect(r.original_length).toBe(11);
+  });
+
+  it('returns the empty string unchanged', () => {
+    const r = capEventText('');
+    expect(r.text).toBe('');
+    expect(r.truncated).toBe(false);
+    expect(r.original_length).toBe(0);
+  });
+
+  it('does not truncate text exactly at the byte cap', () => {
+    const text = 'a'.repeat(64 * 1024); // 64KB ASCII = 64KB bytes
+    const r = capEventText(text);
+    expect(r.truncated).toBe(false);
+    expect(r.text.length).toBe(64 * 1024);
+    expect(r.original_length).toBe(64 * 1024);
+  });
+
+  it('truncates and flags when text exceeds the byte cap', () => {
+    const text = 'a'.repeat(64 * 1024 + 100);
+    const r = capEventText(text);
+    expect(r.truncated).toBe(true);
+    expect(r.text.length).toBeLessThanOrEqual(64 * 1024);
+    expect(r.original_length).toBe(64 * 1024 + 100);
+  });
+
+  it('preserves UTF-8 boundaries when truncating', () => {
+    // 4-byte emoji × 20000 = 80,000 bytes (exceeds 64KB cap).
+    // Note: JS string.length is UTF-16 code units, so '🎯'.length === 2.
+    const text = '🎯'.repeat(20000);
+    const r = capEventText(text);
+    expect(r.truncated).toBe(true);
+    // Round-trip through utf-8 must succeed (no broken multi-byte char)
+    expect(() => Buffer.from(r.text, 'utf8').toString('utf8')).not.toThrow();
+    expect(r.original_length).toBe(text.length);
+  });
+
+  it('reports original length via character count, not byte count', () => {
+    // A 2-byte char × 100 chars = 200 bytes but 100 chars
+    const text = 'é'.repeat(100);
+    const r = capEventText(text);
+    expect(r.original_length).toBe(100);
+    expect(r.truncated).toBe(false);
+  });
+});
+
+describe('buildMessageReceivedData', () => {
+  it('builds the canonical shape for a short message', () => {
+    const data = buildMessageReceivedData('hello there', 'dm');
+    expect(data).toEqual({
+      source: 'dm',
+      text: 'hello there',
+      text_length: 11,
+    });
+    expect(data).not.toHaveProperty('truncated');
+  });
+
+  it('flags truncated for an oversize message', () => {
+    const data = buildMessageReceivedData('z'.repeat(70 * 1024), 'web_chat');
+    expect(data.source).toBe('web_chat');
+    expect(data.text_length).toBe(70 * 1024);
+    expect(data.truncated).toBe(true);
+    expect((data.text as string).length).toBeLessThanOrEqual(64 * 1024);
+  });
+});


### PR DESCRIPTION
## Summary

`message_received` person_events now persist the inbound text alongside `text_length`, mirroring what `message_sent` already stores. This unblocks "find this thread, see what's missing"-shaped diagnostics — Addie can now read full conversations from her own timeline instead of seeing only her outbound side.

Two new helpers in `server/src/db/person-events-db.ts`:

- **`capEventText(text)`** — 64KB UTF-8 byte cap with UTF-8-boundary-safe truncation. Returns `{text, truncated, original_length}`.
- **`buildMessageReceivedData(text, source)`** — canonical data shape used by all four message_received writers, so they stay in lockstep.

Four call sites updated to pass `inputValidation.sanitized`:
- `server/src/addie/handler.ts` — Slack DM (primary)
- `server/src/addie/bolt-app.ts` — Slack DM + assistant thread (`recordPersonInboundMessage`)
- `server/src/routes/addie-chat.ts` — web chat non-streaming + streaming

## Why this exists

The Pubx escalation: Lukasz DMs Addie about colleagues who can't log in. Addie's own timeline records `message_received: { text_length: 158 }` — she has zero ability to read what the human said. With #3582 (memory layer) on the horizon and this gap exposed across half a dozen diagnostic flows, fixing it now removes the cleanest blocker.

## Design highlights from review

- **Plain text, not redacted** — same trust boundary and same admin-gated readers as `message_sent`. Asymmetric behavior would mean Addie sees her own words but not the human's.
- **`inputValidation.sanitized`, not raw** — security-reviewer's catch. The web chat already produces the sanitized variant for thread storage; storing it on person_events too means the prompt-injection / flagging pipeline applies uniformly.
- **64KB byte cap** — Slack messages are platform-capped at 40KB, web chat is unbounded. The cap prevents a single 50KB paste from inflating timeline reads. Truncation respects UTF-8 boundaries.
- **`text_length` semantics**: stays as JS `string.length` (UTF-16 code units) for consistency with the existing convention across `message_sent` and prior `message_received` writes. Documented explicitly in the helper docstring.

## Test plan

- [x] `npm run typecheck` clean
- [x] 8 unit tests for `capEventText` + `buildMessageReceivedData` (cap behavior, UTF-8 boundaries, truncation flagging, original_length semantics)
- [x] 3 integration tests for write+read round-trip via `getPersonTimeline` (happy path, truncation, backward compat with old text-length-only rows)
- [x] All 36 invite-chain integration tests still pass (no cross-talk)

## Expert reviews run before merge

- **security-reviewer** — fix-now applied: use `inputValidation.sanitized` so writes inherit the existing sanitize pipeline. PII / retention / GDPR cleared (same boundary as `message_sent`, ON DELETE CASCADE from migration 397). One follow-up flagged: apply the same cap convention to `message_sent` (out of scope, file separately).
- **code-reviewer** — caught a missed fourth call site in `handler.ts:592` (would have left the primary Slack DM path unchanged), surfaced the 4-site repetition that justified the `buildMessageReceivedData` helper, flagged `original_length` units (documented in the docstring rather than renamed — preserves existing `text_length` convention).

## Companion / chain

- #3588 — Invite lifecycle events (foundation, merged)
- #3625 — Admin UI Invitations panel (merged)
- #3644 — Addie invite-management tools (merged)
- #3582 — Person-level memory layer (next, builds on this)

## Backward compat

Old rows that have `text_length` but no `text` continue to read cleanly via `getPersonTimeline` (test included). No migration needed; existing inbound bodies are unrecoverable from our own storage but Slack/web channels still hold them at their original sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)