### PR TITLE
chore(verification): stage 6 cleanup — docs, refactor, audit comment

### DIFF
--- a/.changeset/per-version-badges-stage6-cleanup.md
+++ b/.changeset/per-version-badges-stage6-cleanup.md
@@ -1,0 +1,20 @@
+---
+"adcontextprotocol": patch
+---
+
+verification: cleanup follow-ups after #3524 ships.
+
+**Docs.** `docs/building/aao-verified.mdx` was last updated for the orthogonal-axes framing (#3536) but didn't mention the per-version model that #3524 just shipped. Updated:
+
+- New "Per-version badges" section explaining that each badge is identified by `(agent, role, AdCP version)`, agents can hold parallel-version badges, and version-pinned vs. legacy URL behavior.
+- "Display" section now documents both URL shapes (`/badge/{role}.svg` auto-upgrade and `/badge/{role}/{version}.svg` version-pinned), with examples for each.
+- JWT claim block adds `adcp_version` and explicit verifier guidance ("verifiers MUST check `adcp_version` against the AdCP version they care about" — closes the cross-version replay concern raised in the Stage 2 security review).
+- "Registry filter" section gains a "brand.json enrichment" subsection documenting the `aao_verification.badges[]` array, the `roles[]` / `modes_by_role` deprecation notice, and the AdCP 4.0 removal target.
+
+**Refactor (testability).** `enrichAgentEntries`'s shaping logic was a closure inside the brand.json route handler — unreachable from unit tests. Extracted to `services/aao-verification-enrichment.ts` as `buildAaoVerificationBlock(badges)`. The route handler keeps the JSON traversal and assignment; the builder is a pure function with 14 new unit tests covering empty input, single-badge, multi-version dedupe (caller-ordering preserved), modes_by_role flattening (the "buyer pinned to 3.0 sees the wrong contract" footgun), adcp_version shape filtering (defense in depth), and the deprecation notice content. Code-review nit on PR #3604.
+
+**Trivia.** `PROTOCOL_LABELS` in `dashboard-agents.html` gained a comment pinning the invariant that label values must not end in "Agent" (otherwise `${protocol} Agent${versionSegment}` would produce "Media Buy Agent Agent 3.1"). DX expert nit from #3603.
+
+What this PR does NOT change:
+- Wire format on any surface — the brand.json enrichment output is byte-for-byte identical to what shipped in #3604.
+- Panel UX — role grouping and "show all versions" disclosure (#3603) explicitly defer until parallel-version badges land in production and we have real buyer feedback to design against.

--- a/docs/building/aao-verified.mdx
+++ b/docs/building/aao-verified.mdx
@@ -221,12 +221,18 @@ The token claims:
   "iat": 1745510400,
   "exp": 1748102400,
   "role": "media-buy",
+  "adcp_version": "3.0",
   "verified_specialisms": ["sales-broadcast-tv", "sales-guaranteed"],
-  "verification_modes": ["spec"]
+  "verification_modes": ["spec"],
+  "protocol_version": "3.0.0"
 }
 ```
 
-`verification_modes` is the array of axes earned. `["spec"]` until (Live) lights up; `["spec", "live"]` thereafter for agents that enroll. The registry API is authoritative for real-time status; the JWT is a 30-day cacheable proof.
+`adcp_version` is the AdCP release this badge was issued against (`MAJOR.MINOR`). Pairs with the `(agent_url, role, adcp_version)` identity used by the badge URL routes. **Verifiers MUST check `adcp_version` against the AdCP version they care about** — a 3.0 token presented as proof of 3.1 conformance is not authoritative. The signed claim is shape-validated at signing time (`^[1-9][0-9]*\.[0-9]+$`); verifiers SHOULD apply the same regex defensively.
+
+`verification_modes` is the array of axes earned. `["spec"]` until (Live) lights up; `["spec", "live"]` thereafter for agents that enroll. `protocol_version` is the full semver of the spec build the badge was tested against — informational metadata for support and audits.
+
+The registry API is authoritative for real-time status; the JWT is a 30-day cacheable proof.
 
 ## Lifecycle
 
@@ -259,23 +265,46 @@ A seller MAY hold:
 
 The two axes are evaluated independently. A storyboard regression revokes (Spec) without affecting (Live); an observability check failure revokes (Live) without affecting (Spec). Sellers can earn either in either order.
 
+## Per-version badges
+
+Each badge is identified by **(agent, role, AdCP version)** — a third axis on top of (Spec) and (Live). An agent can hold parallel badges across AdCP releases. For example, a media-buy agent that ships an upgrade for AdCP 3.1 might hold both:
+
+- `AAO Verified Media Buy Agent 3.0 (Spec)` — earned earlier, still valid
+- `AAO Verified Media Buy Agent 3.1 (Spec + Live)` — earned after upgrading
+
+Each version is evaluated independently. A 3.0 storyboard regression revokes the 3.0 badge without touching 3.1, and vice versa. Membership lapse revokes every version of an agent's badges atomically (the trust mark is agent-level, not version-level).
+
+The badge label embeds the AdCP version inline between the role and the qualifier: `Media Buy Agent 3.1 (Spec + Live)`.
+
 ## Display
 
 ### SVG badge
 
+Two URL shapes:
+
 ```
+# Legacy: auto-upgrades to the highest active version
 https://agenticadvertising.org/api/registry/agents/{url-encoded-agent-url}/badge/{role}.svg
+
+# Version-pinned: freezes on a specific AdCP release
+https://agenticadvertising.org/api/registry/agents/{url-encoded-agent-url}/badge/{role}/{adcp-version}.svg
 ```
 
-Returns a shields.io-style SVG with `Content-Security-Policy: script-src 'none'` and 5-minute caching. Renders teal when verified, grey when not. The qualifier in parens reflects the current verification axes. Unknown agents, unknown roles, and revoked badges all return a grey "Not Verified" variant — the URL never 404s, which makes it safe to embed.
+Buyers who want auto-upgrade behavior (the embedded image flips from `Media Buy Agent 3.0 (Spec)` to `Media Buy Agent 3.1 (Spec + Live)` automatically when the agent earns 3.1) embed the legacy URL. Buyers who want to call out "verified for AdCP 3.0" specifically embed the version-pinned URL.
+
+Both return a shields.io-style SVG with `Content-Security-Policy: script-src 'none'` and 5-minute caching. Renders teal when verified, grey when not. Unknown agents, unknown roles, and revoked badges all return a grey "Not Verified" variant — the URL never 404s, which makes it safe to embed. Version-pinned URLs at versions the agent never earned also return "Not Verified" (vs. the legacy URL, which shows the current best mark).
 
 ### Embed snippet
 
 ```bash
+# Legacy (auto-upgrading)
 curl https://agenticadvertising.org/api/registry/agents/{url-encoded-agent-url}/badge/media-buy/embed
+
+# Version-pinned
+curl https://agenticadvertising.org/api/registry/agents/{url-encoded-agent-url}/badge/media-buy/3.0/embed
 ```
 
-Returns HTML and Markdown snippets that wrap the SVG in a link back to the agent's AAO registry listing. Safe for READMEs, docs, landing pages, and social profiles. As an agent's verification axes change, embedded badges automatically reflect the current state — no embed swap needed when (Live) lights up.
+Returns HTML and Markdown snippets that wrap the SVG in a link back to the agent's AAO registry listing. Safe for READMEs, docs, landing pages, and social profiles. As an agent's verification axes or AdCP versions change, the legacy embed automatically reflects the current state — no embed swap needed when (Live) lights up or when the agent ships a new AdCP version.
 
 ### Registry filter
 
@@ -286,6 +315,28 @@ The agent registry surfaces filters on either axis independently:
 - **"Show me agents with both"** → filter by both
 
 Both queries are valid. Buyers comparing options use (Live); orchestrator developers integrating new agents use (Spec).
+
+### brand.json enrichment
+
+When AAO serves brand.json data for a registered brand, agent entries get an `aao_verification` block with full per-version detail:
+
+```json
+"aao_verification": {
+  "verified": true,
+  "verified_at": "2026-04-29T12:34:56.000Z",
+  "badges": [
+    { "role": "media-buy", "adcp_version": "3.1", "verification_modes": ["spec", "live"], "verified_at": "..." },
+    { "role": "media-buy", "adcp_version": "3.0", "verification_modes": ["spec"], "verified_at": "..." }
+  ],
+  "roles": ["media-buy"],
+  "modes_by_role": { "media-buy": ["spec", "live"] },
+  "deprecation_notice": "roles[] and modes_by_role reflect the highest-version badge per role only. A buyer pinned to a specific AdCP version SHOULD read badges[] and filter by adcp_version. Both fields will be removed in AdCP 4.0."
+}
+```
+
+`badges[]` is the canonical shape — one entry per `(role, adcp_version)`, ordered version-DESC. Buyers pinned to a specific AdCP version MUST filter by `adcp_version` rather than reading `modes_by_role` (which flattens to the highest-version entry per role and could mislead a 3.0 buyer into thinking the agent runs Live for them when only the 3.1 badge has Live).
+
+`roles[]` and `modes_by_role` are kept as **deprecated aliases** for one release. **Removal target: AdCP 4.0.**
 
 ## How to claim each qualifier
 

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -1508,6 +1508,12 @@
     // pointing at the docs.
     function renderVerificationPanel(cs, agentUrl, hasAuth) {
       const badges = Array.isArray(cs && cs.verified_badges) ? cs.verified_badges : [];
+      // Audit-comment from #3603: values MUST NOT end in "Agent" or
+      // any equivalent suffix that would collide when appended below
+      // (e.g. "${protocol} Agent" → "Media Buy Agent Agent" if a label
+      // ever became "Media Buy Agent"). Current values are noun
+      // phrases ending in the AdCP-protocol noun. If you add a new
+      // protocol, keep this invariant.
       const PROTOCOL_LABELS = {
         'media-buy': 'Media Buy', 'creative': 'Creative',
         'signals': 'Signals', 'governance': 'Governance',

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -31,6 +31,7 @@ import { getPublicJwks } from "../services/verification-token.js";
 import { renderBadgeSvg, VALID_BADGE_ROLES } from "../services/badge-svg.js";
 import { resolveOwnerMembership } from "../services/membership-tiers.js";
 import { isValidAdcpVersionShape } from "../services/adcp-taxonomy.js";
+import { buildAaoVerificationBlock } from "../services/aao-verification-enrichment.js";
 import { PUBLIC_TEST_AGENT } from "../config/test-agent.js";
 import * as policiesDb from "../db/policies-db.js";
 import { createLogger } from "../logger.js";
@@ -2728,42 +2729,13 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
   });
 
   /**
-   * Shape contract for the `aao_verification` block this enrichment
-   * appends to brand.json agent entries. Public buyer-facing surface;
-   * documented here so future contributors don't drift the wire format.
-   *
-   *   `verified`         — boolean: any active badge exists
-   *   `verified_at`      — ISO timestamp of the most-recent state change
-   *                        across any badge
-   *   `badges[]`         — canonical per-(role, version) detail. Order is
-   *                        preserved from the underlying API's
-   *                        `adcp_version DESC, role` sort. Adding future
-   *                        axes won't change the array shape (#3524 Q6).
-   *   `roles[]`          — DEPRECATED alias: distinct roles, highest
-   *                        badge per role. Removal target: AdCP 4.0.
-   *   `modes_by_role`    — DEPRECATED alias: highest-version modes per
-   *                        role. Removal target: AdCP 4.0.
-   *   `deprecation_notice` — Travels with the data so long-tail crawlers
-   *                          see the warning even without release notes.
-   */
-  interface AaoVerificationBlock {
-    verified: true;
-    verified_at: string;
-    badges: Array<{
-      role: string;
-      adcp_version: string | null;
-      verification_modes: string[];
-      verified_at: string;
-    }>;
-    roles: string[];
-    modes_by_role: Record<string, string[]>;
-    deprecation_notice: string;
-  }
-
-  /**
    * Enrich brand.json agent entries with AAO verification status.
-   * Scans data for agent URLs and appends `aao_verification` (shape
-   * documented above as `AaoVerificationBlock`) where badges exist.
+   * Scans data for agent URLs and appends an `aao_verification`
+   * block where badges exist. The block's shape is the contract
+   * documented at {@link buildAaoVerificationBlock} in
+   * services/aao-verification-enrichment.ts — the route handler
+   * is the I/O layer; the builder is the unit-testable shaping
+   * logic.
    */
   async function enrichBrandDataWithVerification(data: unknown): Promise<unknown> {
     if (!data || typeof data !== 'object') return data;
@@ -2803,53 +2775,9 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       const rec = obj as Record<string, unknown>;
       if (typeof rec.url === 'string' && typeof rec.type === 'string') {
         const badges = badgeMap.get(rec.url as string);
-        if (badges && badges.length > 0) {
-          // bulkGetActiveBadges orders by `agent_url, adcp_version DESC,
-          // role`, so for any given agent the first occurrence of each
-          // role in the iteration is the highest-version badge for that
-          // role. Roles can interleave (e.g. media-buy 3.1, creative
-          // 3.1, media-buy 3.0) — `if (!byRole.has)` picks correctly.
-          const byRole = new Map<typeof badges[number]['role'], typeof badges[number]>();
-          for (const badge of badges) {
-            if (!byRole.has(badge.role)) byRole.set(badge.role, badge);
-          }
-          const dedupedBadges = Array.from(byRole.values());
-          // Per-version badges array — the canonical shape going forward.
-          // One entry per (role, adcp_version), preserving the API's
-          // version-DESC ordering. Defense-in-depth: gate adcp_version
-          // through the same shape regex used by /compliance and
-          // /verification — brand.json is the public buyer-facing
-          // surface, so any future code path that bypasses the DB CHECK
-          // (raw SQL backfill, restored snapshot) MUST NOT leak through.
-          const badgesArray = badges.map(b => ({
-            role: b.role,
-            adcp_version: isValidAdcpVersionShape(b.adcp_version) ? b.adcp_version : null,
-            verification_modes: b.verification_modes,
-            verified_at: b.verified_at.toISOString(),
-          }));
-          const aaoVerification: AaoVerificationBlock = {
-            verified: true,
-            // Newest verification across any (role, version) — the most
-            // recent state change for the agent.
-            verified_at: dedupedBadges[0].verified_at.toISOString(),
-            // Canonical: full per-(role, version) detail. Per Q6 of
-            // #3524's resolved decisions, this is the forward-compat
-            // shape — adding future axes won't change the array.
-            badges: badgesArray,
-            // Deprecated aliases kept for one release. Highest-version
-            // badge per role; reflects "the current best mark." A
-            // buyer pinned to AdCP 3.0 reading `modes_by_role: { x:
-            // ['spec', 'live'] }` could wrongly conclude their 3.0
-            // traffic gets Live when in fact only 3.1 has Live. The
-            // deprecation_notice ships alongside the data so a long-
-            // tail crawler that doesn't track release notes still sees
-            // the warning. Removal target: AdCP 4.0 (≥6 months from
-            // this PR's merge per the cadence policy in #2359).
-            roles: dedupedBadges.map(b => b.role),
-            modes_by_role: Object.fromEntries(dedupedBadges.map(b => [b.role, b.verification_modes])),
-            deprecation_notice: 'roles[] and modes_by_role reflect the highest-version badge per role only. A buyer pinned to a specific AdCP version SHOULD read badges[] and filter by adcp_version. Both fields will be removed in AdCP 4.0.',
-          };
-          rec.aao_verification = aaoVerification;
+        const block = badges ? buildAaoVerificationBlock(badges) : null;
+        if (block) {
+          rec.aao_verification = block;
         }
       }
       if (rec.agents && Array.isArray(rec.agents)) rec.agents.forEach(enrichAgentEntries);

--- a/server/src/services/aao-verification-enrichment.ts
+++ b/server/src/services/aao-verification-enrichment.ts
@@ -1,0 +1,82 @@
+/**
+ * Pure builder for the `aao_verification` block that brand.json
+ * enrichment appends to agent entries. Extracted from the route
+ * handler in registry-api.ts so the dedupe + ordering + version-shape
+ * filtering logic has a unit-testable surface.
+ *
+ * The wire format is documented as {@link AaoVerificationBlock}
+ * inline at the call site (registry-api.ts) — that's the contract
+ * brand.json consumers see. This file is the implementation; the
+ * call site is the public-API boundary.
+ */
+
+import type { AgentVerificationBadge } from '../db/compliance-db.js';
+import { isValidAdcpVersionShape } from './adcp-taxonomy.js';
+
+export interface AaoVerificationBadgeEntry {
+  role: string;
+  adcp_version: string | null;
+  verification_modes: string[];
+  verified_at: string;
+}
+
+export interface AaoVerificationBlock {
+  verified: true;
+  verified_at: string;
+  badges: AaoVerificationBadgeEntry[];
+  roles: string[];
+  modes_by_role: Record<string, string[]>;
+  deprecation_notice: string;
+}
+
+/**
+ * Static deprecation notice that ships alongside the legacy alias
+ * fields so a long-tail crawler that doesn't track release notes
+ * still sees the warning. Removal target: AdCP 4.0.
+ */
+export const AAO_VERIFICATION_DEPRECATION_NOTICE =
+  'roles[] and modes_by_role reflect the highest-version badge per role only. ' +
+  'A buyer pinned to a specific AdCP version SHOULD read badges[] and filter by ' +
+  'adcp_version. Both fields will be removed in AdCP 4.0.';
+
+/**
+ * Build the `aao_verification` block from a non-empty list of active
+ * badges for one agent. Returns `null` if the input is empty so the
+ * caller can decide whether to omit the field entirely.
+ *
+ * Input ordering must match `bulkGetActiveBadges`'s sort
+ * (`agent_url, adcp_version DESC, role`). The function picks the
+ * first occurrence of each role as that role's highest-version
+ * badge — relies on the caller to deliver in the right order.
+ *
+ * Defense-in-depth: every `adcp_version` in the output array is
+ * gated through `isValidAdcpVersionShape`. A poisoned DB row that
+ * bypassed the CHECK constraint (raw SQL backfill, restored
+ * snapshot, replication slot replay) MUST NOT leak through to the
+ * public buyer-facing brand.json surface.
+ */
+export function buildAaoVerificationBlock(
+  badges: readonly AgentVerificationBadge[],
+): AaoVerificationBlock | null {
+  if (badges.length === 0) return null;
+
+  const byRole = new Map<AgentVerificationBadge['role'], AgentVerificationBadge>();
+  for (const badge of badges) {
+    if (!byRole.has(badge.role)) byRole.set(badge.role, badge);
+  }
+  const dedupedBadges = Array.from(byRole.values());
+
+  return {
+    verified: true,
+    verified_at: dedupedBadges[0].verified_at.toISOString(),
+    badges: badges.map(b => ({
+      role: b.role,
+      adcp_version: isValidAdcpVersionShape(b.adcp_version) ? b.adcp_version : null,
+      verification_modes: b.verification_modes,
+      verified_at: b.verified_at.toISOString(),
+    })),
+    roles: dedupedBadges.map(b => b.role),
+    modes_by_role: Object.fromEntries(dedupedBadges.map(b => [b.role, b.verification_modes])),
+    deprecation_notice: AAO_VERIFICATION_DEPRECATION_NOTICE,
+  };
+}

--- a/server/tests/unit/aao-verification-enrichment.test.ts
+++ b/server/tests/unit/aao-verification-enrichment.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildAaoVerificationBlock,
+  AAO_VERIFICATION_DEPRECATION_NOTICE,
+} from '../../src/services/aao-verification-enrichment.js';
+import type { AgentVerificationBadge, BadgeRole } from '../../src/db/compliance-db.js';
+
+function makeBadge(overrides: Partial<AgentVerificationBadge> & {
+  role: BadgeRole;
+  adcp_version: string;
+}): AgentVerificationBadge {
+  return {
+    agent_url: 'https://example.com/mcp',
+    role: overrides.role,
+    adcp_version: overrides.adcp_version,
+    verified_at: overrides.verified_at ?? new Date('2026-04-01T00:00:00Z'),
+    verified_protocol_version: overrides.verified_protocol_version ?? `${overrides.adcp_version}.0`,
+    verified_specialisms: overrides.verified_specialisms ?? ['media-buy-seller'],
+    verification_modes: overrides.verification_modes ?? ['spec'],
+    verification_token: overrides.verification_token ?? null,
+    token_expires_at: overrides.token_expires_at ?? null,
+    membership_org_id: overrides.membership_org_id ?? 'org_test',
+    status: overrides.status ?? 'active',
+    revoked_at: overrides.revoked_at ?? null,
+    revocation_reason: overrides.revocation_reason ?? null,
+    created_at: overrides.created_at ?? new Date('2026-03-01T00:00:00Z'),
+    updated_at: overrides.updated_at ?? new Date('2026-04-01T00:00:00Z'),
+  };
+}
+
+describe('buildAaoVerificationBlock', () => {
+  it('returns null for an empty badge list', () => {
+    expect(buildAaoVerificationBlock([])).toBeNull();
+  });
+
+  it('builds a single-badge block with all expected fields', () => {
+    const block = buildAaoVerificationBlock([
+      makeBadge({ role: 'media-buy', adcp_version: '3.0' }),
+    ]);
+    expect(block).not.toBeNull();
+    expect(block!.verified).toBe(true);
+    expect(block!.badges).toHaveLength(1);
+    expect(block!.badges[0]).toMatchObject({
+      role: 'media-buy',
+      adcp_version: '3.0',
+      verification_modes: ['spec'],
+    });
+    expect(block!.roles).toEqual(['media-buy']);
+    expect(block!.modes_by_role).toEqual({ 'media-buy': ['spec'] });
+    expect(block!.deprecation_notice).toBe(AAO_VERIFICATION_DEPRECATION_NOTICE);
+  });
+
+  it('preserves input order in the badges[] array (caller is responsible for sort)', () => {
+    // Caller-provided order is version-DESC for media-buy, then creative
+    // at 3.1. We don't re-sort — caller's bulkGetActiveBadges already does.
+    const block = buildAaoVerificationBlock([
+      makeBadge({ role: 'media-buy', adcp_version: '3.1', verification_modes: ['spec', 'live'] }),
+      makeBadge({ role: 'creative', adcp_version: '3.1' }),
+      makeBadge({ role: 'media-buy', adcp_version: '3.0' }),
+    ]);
+    expect(block!.badges.map(b => `${b.role}@${b.adcp_version}`)).toEqual([
+      'media-buy@3.1',
+      'creative@3.1',
+      'media-buy@3.0',
+    ]);
+  });
+
+  it('dedupes by role for the legacy aliases, picking first occurrence per role', () => {
+    // Legacy aliases (roles, modes_by_role) reflect highest-version-per-
+    // role. Caller order determines "highest" — first occurrence wins.
+    const block = buildAaoVerificationBlock([
+      makeBadge({ role: 'media-buy', adcp_version: '3.1', verification_modes: ['spec', 'live'] }),
+      makeBadge({ role: 'creative', adcp_version: '3.0' }),
+      makeBadge({ role: 'media-buy', adcp_version: '3.0', verification_modes: ['spec'] }),
+    ]);
+    expect(block!.roles).toEqual(['media-buy', 'creative']);
+    // Highest-version media-buy modes preserved; 3.0's modes don't overwrite.
+    expect(block!.modes_by_role).toEqual({
+      'media-buy': ['spec', 'live'],
+      'creative': ['spec'],
+    });
+  });
+
+  it('badges[] preserves version detail that modes_by_role flattens away', () => {
+    // Buyer pinned to 3.0 reading modes_by_role would see "spec+live"
+    // — wrong for their version. badges[] surfaces the per-version
+    // truth so the buyer can filter correctly.
+    const block = buildAaoVerificationBlock([
+      makeBadge({ role: 'media-buy', adcp_version: '3.1', verification_modes: ['spec', 'live'] }),
+      makeBadge({ role: 'media-buy', adcp_version: '3.0', verification_modes: ['spec'] }),
+    ]);
+    const badge30 = block!.badges.find(b => b.adcp_version === '3.0');
+    const badge31 = block!.badges.find(b => b.adcp_version === '3.1');
+    expect(badge30!.verification_modes).toEqual(['spec']);
+    expect(badge31!.verification_modes).toEqual(['spec', 'live']);
+    // The flattened alias picks the highest version's modes.
+    expect(block!.modes_by_role['media-buy']).toEqual(['spec', 'live']);
+  });
+
+  it('verified_at is the first-deduped-badge timestamp (caller-ordered = newest)', () => {
+    const newest = new Date('2026-04-29T12:00:00Z');
+    const oldest = new Date('2026-01-15T08:00:00Z');
+    const block = buildAaoVerificationBlock([
+      makeBadge({ role: 'media-buy', adcp_version: '3.1', verified_at: newest }),
+      makeBadge({ role: 'media-buy', adcp_version: '3.0', verified_at: oldest }),
+    ]);
+    expect(block!.verified_at).toBe(newest.toISOString());
+  });
+
+  it('drops malformed adcp_version to null (defense in depth)', () => {
+    // DB CHECK + JWT signer regex prevent malformed values reaching
+    // here in production. This test pins the defense-in-depth behavior
+    // in case a future code path ever bypasses those (raw SQL backfill,
+    // restored snapshot, replication slot replay).
+    const block = buildAaoVerificationBlock([
+      makeBadge({ role: 'media-buy', adcp_version: 'evil; DROP TABLE' }),
+    ]);
+    expect(block!.badges[0].adcp_version).toBeNull();
+  });
+
+  it('drops adcp_version with leading-zero major to null', () => {
+    const block = buildAaoVerificationBlock([
+      makeBadge({ role: 'media-buy', adcp_version: '0.5' }),
+    ]);
+    expect(block!.badges[0].adcp_version).toBeNull();
+  });
+
+  it('drops full-semver value (3.0.0) — the field is MAJOR.MINOR only', () => {
+    const block = buildAaoVerificationBlock([
+      makeBadge({ role: 'media-buy', adcp_version: '3.0.0' as never }),
+    ]);
+    expect(block!.badges[0].adcp_version).toBeNull();
+  });
+
+  it('preserves double-digit minors (3.10) — numeric sort lesson from Stage 1', () => {
+    const block = buildAaoVerificationBlock([
+      makeBadge({ role: 'media-buy', adcp_version: '3.10' }),
+    ]);
+    expect(block!.badges[0].adcp_version).toBe('3.10');
+  });
+
+  it('verified is always literal true (never `verified: false` returned)', () => {
+    const block = buildAaoVerificationBlock([
+      makeBadge({ role: 'media-buy', adcp_version: '3.0' }),
+    ]);
+    // Type-level: AaoVerificationBlock['verified'] is the literal type
+    // `true`. Runtime: confirm.
+    expect(block!.verified).toBe(true);
+  });
+});
+
+describe('AAO_VERIFICATION_DEPRECATION_NOTICE', () => {
+  it('mentions both deprecated fields by name', () => {
+    expect(AAO_VERIFICATION_DEPRECATION_NOTICE).toContain('roles[]');
+    expect(AAO_VERIFICATION_DEPRECATION_NOTICE).toContain('modes_by_role');
+  });
+
+  it('directs readers to badges[] for per-version detail', () => {
+    expect(AAO_VERIFICATION_DEPRECATION_NOTICE).toContain('badges[]');
+  });
+
+  it('names the removal target', () => {
+    expect(AAO_VERIFICATION_DEPRECATION_NOTICE).toContain('AdCP 4.0');
+  });
+});


### PR DESCRIPTION
## Summary

Cleanup follow-ups after [#3524](https://github.com/adcontextprotocol/adcp/issues/3524) shipped (Stages 1-5). No wire-format changes; brand.json output is byte-for-byte identical to what shipped in #3604.

## What ships

### 1. Docs update — `docs/building/aao-verified.mdx`

Last updated for the orthogonal-axes framing in #3536; didn't mention the per-version model that just shipped. Added:

- **New "Per-version badges" section** explaining `(agent, role, AdCP version)` as the badge identity, parallel-version badges, and how the legacy vs version-pinned URLs differ.
- **Display section** documents both URL shapes with examples (`/badge/{role}.svg` auto-upgrade and `/badge/{role}/{version}.svg` version-pinned), plus the corresponding embed endpoints.
- **JWT claim block** adds `adcp_version` and explicit verifier guidance: *"verifiers MUST check adcp_version against the AdCP version they care about"* — closes the cross-version replay concern raised in Stage 2's security review.
- **brand.json enrichment subsection** documents the `aao_verification.badges[]` array, the `roles[]` / `modes_by_role` deprecation policy, and the AdCP 4.0 removal target.

### 2. Refactor — extract `buildAaoVerificationBlock` for testability

Code-review nit on PR #3604: the shaping logic was a closure inside the brand.json route handler — unreachable from unit tests. Extracted to `services/aao-verification-enrichment.ts` as a pure function. The route handler keeps the JSON traversal and assignment.

**14 new unit tests** cover:
- Empty input → null
- Single-badge build
- Multi-version dedupe with caller-ordering preserved
- The "buyer pinned to 3.0 sees the wrong contract" footgun (`modes_by_role` flattens; `badges[]` doesn't)
- `adcp_version` shape filtering as defense in depth (DB CHECK is the real gate, but a hand-edited row or replication slot replay shouldn't leak)
- Leading-zero-major rejection, full-semver rejection, double-digit minor preservation
- Deprecation notice content invariants

### 3. PROTOCOL_LABELS audit comment — `dashboard-agents.html`

DX expert nit from #3603: the `\${protocol} Agent\${versionSegment}` label construction relies on `PROTOCOL_LABELS` values not ending in "Agent" (otherwise we'd get "Media Buy Agent Agent 3.1"). Added a comment pinning the invariant so a future contributor adding a new protocol doesn't break it accidentally.

## What this PR does NOT do

- **Panel role-grouping** (#3603's main item) explicitly defers until parallel-version badges land in production with real buyer feedback. Designing the layout against synthetic data would be premature.
- **Wire-format changes** — none. brand.json output is byte-for-byte identical.

## Test plan

- [x] 14 new unit tests for `buildAaoVerificationBlock`
- [x] 145/145 unit tests pass total (was 131)
- [x] TypeScript typecheck clean
- [x] Pre-commit hook green (image quality, etc.)

## Stage tracker (for context)

#3524 fully shipped:
- ✓ Stage 1 (#3568) — data model
- ✓ Stage 2 (#3579) — heartbeat fan-out + JWT
- ✓ Stage 3 (#3595) — SVG version segment + version-pinned URLs
- ✓ Stage 4 (#3600) — verification panel per-version rows
- ✓ Stage 5 (#3604) — brand.json + /verification detail
- ✓ Stage 6 (this PR) — docs + testability + audit comment

Open follow-up: #3603 (panel role-grouping, "show all versions" disclosure) — deferred until we have parallel-version data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)