### PR TITLE
fix(server): repair tool_use integration tests broken in #3637

### DIFF
--- a/.changeset/fix-tool-use-integration-test-failures.md
+++ b/.changeset/fix-tool-use-integration-test-failures.md
@@ -1,0 +1,29 @@
+---
+---
+
+Fix three integration-test failures introduced in #3637 (tool_use route
+contract tests) that were breaking the `Server integration tests` job on
+`main`.
+
+- **`property-enhancement-function.test.ts`**: the `AdAgentsManager` mock
+  used `vi.fn().mockImplementation(() => ({...}))`, which returns an arrow
+  function — and `property-enhancement.ts` instantiates with
+  `new AdAgentsManager()`. Arrow functions cannot be called with `new`, so
+  the test failed at module load with `TypeError: () => ({...}) is not a
+  constructor`. Replaced with a `class FakeAdAgentsManager { ... }`.
+
+- **`brand-classifier-route.test.ts`** and
+  **`brand-enrichment-route.test.ts`**: `SUFFIX` used `${process.pid}_${Date.now()}`,
+  putting an underscore into the test domain. `enrichBrand` and the seed
+  loop in `expandHouse` validate against `^[a-z0-9.-]+\.[a-z]{2,}$`
+  (underscores are invalid per RFC 1035) and returned
+  `{status: 'failed', error: 'Invalid domain format'}` — yielding HTTP 500
+  where the tests expected 200, and seeded=0 sub-brands where they expected
+  2. Switched separator to a hyphen.
+
+- **`prospect-triage-function.test.ts`** flakiness (not in the original
+  failure list but reproducibly fails ~1-2/3 runs): `triageEmailDomain`
+  fired `logTriageDecision` without awaiting, so the test could query
+  `prospect_triage_log` before the `INSERT` landed. `logTriageDecision`
+  swallows its own errors, so awaiting it is contract-preserving and
+  cannot cause triage to fail. Removed the redundant outer `.catch`.

--- a/server/src/services/prospect-triage.ts
+++ b/server/src/services/prospect-triage.ts
@@ -445,10 +445,10 @@ export async function triageEmailDomain(
     companyType: enrichedCompanyType || assessment.company_type || undefined,
   };
 
-  // 6. Log the decision (including skips)
-  logTriageDecision(normalizedDomain, result, context?.source, wasEnriched).catch((err) => {
-    logger.error({ err, domain: normalizedDomain }, 'Failed to log triage decision');
-  });
+  // 6. Log the decision (including skips). Awaited so callers can rely on the
+  // log row existing when this function returns; logTriageDecision swallows its
+  // own errors, so awaiting cannot cause triage to fail.
+  await logTriageDecision(normalizedDomain, result, context?.source, wasEnriched);
 
   return result;
 }

--- a/server/tests/integration/brand-classifier-route.test.ts
+++ b/server/tests/integration/brand-classifier-route.test.ts
@@ -71,7 +71,9 @@ import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
 import { runMigrations } from '../../src/db/migrate.js';
 import { setupBrandEnrichmentRoutes } from '../../src/routes/admin/brand-enrichment.js';
 
-const SUFFIX = `${process.pid}_${Date.now()}`;
+// Hyphen separator — underscores are invalid in domain names (RFC 1035) and
+// `enrichBrand` rejects them with `Invalid domain format`.
+const SUFFIX = `${process.pid}-${Date.now()}`;
 const TEST_DOMAIN = `classifier-route-${SUFFIX}.example.com`;
 
 function classifyBrandResponse(input: unknown) {

--- a/server/tests/integration/brand-enrichment-route.test.ts
+++ b/server/tests/integration/brand-enrichment-route.test.ts
@@ -73,7 +73,9 @@ import { initializeDatabase, closeDatabase, query } from '../../src/db/client.js
 import { runMigrations } from '../../src/db/migrate.js';
 import { setupBrandEnrichmentRoutes } from '../../src/routes/admin/brand-enrichment.js';
 
-const SUFFIX = `${process.pid}_${Date.now()}`;
+// Hyphen separator — underscores are invalid in domain names (RFC 1035) and
+// the seed loop in `expandHouse` rejects them with the same regex `enrichBrand` uses.
+const SUFFIX = `${process.pid}-${Date.now()}`;
 const HOUSE_DOMAIN = `house-${SUFFIX}.example.com`;
 const SUB_A = `sub-a-${SUFFIX}.example.com`;
 const SUB_B = `sub-b-${SUFFIX}.example.com`;

--- a/server/tests/integration/property-enhancement-function.test.ts
+++ b/server/tests/integration/property-enhancement-function.test.ts
@@ -35,11 +35,12 @@ vi.mock('@anthropic-ai/sdk', () => {
 });
 
 // adagentsManager is instantiated at module scope in property-enhancement.ts;
-// the class mock must be in place before the module loads.
+// the class mock must be in place before the module loads. Must be a class (or
+// regular function) — arrow functions cannot be called with `new`.
 vi.mock('../../src/adagents-manager.js', () => ({
-  AdAgentsManager: vi.fn().mockImplementation(() => ({
-    validateDomain: mocks.validateDomain,
-  })),
+  AdAgentsManager: class FakeAdAgentsManager {
+    validateDomain = mocks.validateDomain;
+  },
 }));
 
 vi.mock('whoiser', () => ({


### PR DESCRIPTION
## Summary

Fixes three integration-test failures introduced in #3637 (route-level integration tests for the tool_use refactor) that have been breaking the `Server integration tests` CI job on `main`. Each had a distinct cause:

1. **`property-enhancement-function.test.ts`** — module-load `TypeError`. The `AdAgentsManager` mock used `vi.fn().mockImplementation(() => ({...}))`. The arrow function passed to `mockImplementation` cannot be called with `new`, but `property-enhancement.ts:18` does `new AdAgentsManager()` at module scope. Fix: replace with `class FakeAdAgentsManager { validateDomain = mocks.validateDomain }`.

2. **`brand-classifier-route.test.ts`** + **`brand-enrichment-route.test.ts`** — `SUFFIX` used `${process.pid}_${Date.now()}`. Underscores are invalid in domain names per RFC 1035, and both `enrichBrand` and the seed loop in `expandHouse` validate against `^[a-z0-9.-]+\.[a-z]{2,}$`. The route returned `{status: 'failed', error: 'Invalid domain format'}` — yielding HTTP 500 where the tests expected 200, and seeded=0 where they expected 2. Fix: hyphen separator.

3. **`prospect-triage-function.test.ts`** flakiness (not in the original CI failure list — that run got lucky — but reproducibly fails ~1-2/3 runs locally). `triageEmailDomain` fired `logTriageDecision` without awaiting, so the test queried `prospect_triage_log` before the `INSERT` landed. `logTriageDecision` already swallows its own errors internally, so awaiting it is contract-preserving and cannot cause triage to fail. Fix: `await` the call; remove the now-redundant outer `.catch()`.

## Why the production code change is safe

`logTriageDecision` (lines 247–267 of `prospect-triage.ts`) wraps its `pool.query` in try/catch and only logs warnings — awaiting cannot bubble new errors. All 3 callers of `triageEmailDomain` already `await` it; no caller depended on early return. The added latency is one synchronous INSERT into `prospect_triage_log` on a function that already does an Anthropic `messages.create` (~hundreds of ms), so it's noise.

The deeper signal: the test was correctly asserting on a side effect that the implementation was firing-and-forgetting. The contract should be "function returned" = "audit row exists." Awaiting aligns the implementation with that invariant.

## Verification

- All 4 test files pass locally (9/9 tests).
- `prospect-triage-function.test.ts` stable across 3 consecutive runs.
- Pre-commit (typecheck + unit tests) green.
- Reviewed by `code-reviewer` and `nodejs-testing-expert` agents — both say ship; no blockers.

## Out of scope (follow-up)

`brand-properties-parse.test.ts:69` and `addie-brand-property-tools.test.ts:51` still use `${process.pid}_${Date.now()}` underscore-SUFFIX. They pass today because their domains skip the RFC 1035 regex, but they're latent traps. Worth a separate issue to standardize hyphen-SUFFIX across all integration tests (or extract a shared helper). Not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)