### PR TITLE
fix(tests): unbreak tool_use integration tests merged in #3637

### DIFF
--- a/.changeset/fix-broken-tool-use-integration-tests.md
+++ b/.changeset/fix-broken-tool-use-integration-tests.md
@@ -1,0 +1,9 @@
+---
+---
+
+Fix broken integration tests merged in #3637 (Build Check was cancelled at merge so these landed unverified). Five issues:
+
+- `brand-classifier-route.test.ts` and `brand-enrichment-route.test.ts`: `SUFFIX = '${pid}_${Date.now()}'` produced underscored test domains, which `enrichBrand` rejected via its `/^[a-z0-9.-]+\.[a-z]{2,}$/` regex → route returned 500. Switch separator to hyphen.
+- `property-enhancement-function.test.ts`: mocked `AdAgentsManager` with `vi.fn().mockImplementation(...)`, but the production code calls `new AdAgentsManager()`. `vi.fn` returns a function, not a constructor. Replace with a real class.
+- `prospect-triage-function.test.ts`: `triageEmailDomain` calls `logTriageDecision(...)` fire-and-forget (intentional — avoids blocking callers on a log write), so the test's `SELECT` raced the `INSERT`. Add a small `awaitTriageLog` poll helper instead of changing the production call to `await` (which would alter caller-visible latency).
+- `member-context.ts > "renders next_event with title and days-until"` (pre-existing flake from #3621-era): `Math.floor((starts_at - now) / 86_400_000)` flipped "in 5 days" to "in 4 days" when a sub-millisecond gap accrued between the test setting `starts_at` and the formatter computing the diff. Switch to `Math.round` — also semantically correct (an event 4.7 days away should render as "in 5 days", not "in 4 days").

--- a/server/src/addie/member-context.ts
+++ b/server/src/addie/member-context.ts
@@ -1571,7 +1571,10 @@ export function formatMemberContextForPrompt(context: MemberContext, channel: 'w
   // Upcoming registered event — context for time-bound discussions.
   if (context.next_event) {
     const e = context.next_event;
-    const days = Math.floor(
+    // Round to the nearest day so a sub-millisecond gap between the caller
+    // setting starts_at and us computing the diff doesn't flip "in 5 days"
+    // to "in 4 days".
+    const days = Math.round(
       (e.starts_at.getTime() - Date.now()) / (24 * 60 * 60 * 1000)
     );
     lines.push('');

--- a/server/tests/integration/brand-classifier-route.test.ts
+++ b/server/tests/integration/brand-classifier-route.test.ts
@@ -71,7 +71,9 @@ import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
 import { runMigrations } from '../../src/db/migrate.js';
 import { setupBrandEnrichmentRoutes } from '../../src/routes/admin/brand-enrichment.js';
 
-const SUFFIX = `${process.pid}_${Date.now()}`;
+// Hyphen separator: brand-enrichment validates the domain against
+// /^[a-z0-9.-]+\.[a-z]{2,}$/ — underscores are rejected.
+const SUFFIX = `${process.pid}-${Date.now()}`;
 const TEST_DOMAIN = `classifier-route-${SUFFIX}.example.com`;
 
 function classifyBrandResponse(input: unknown) {

--- a/server/tests/integration/brand-enrichment-route.test.ts
+++ b/server/tests/integration/brand-enrichment-route.test.ts
@@ -73,7 +73,9 @@ import { initializeDatabase, closeDatabase, query } from '../../src/db/client.js
 import { runMigrations } from '../../src/db/migrate.js';
 import { setupBrandEnrichmentRoutes } from '../../src/routes/admin/brand-enrichment.js';
 
-const SUFFIX = `${process.pid}_${Date.now()}`;
+// Hyphen separator: brand-enrichment validates the domain against
+// /^[a-z0-9.-]+\.[a-z]{2,}$/ — underscores are rejected.
+const SUFFIX = `${process.pid}-${Date.now()}`;
 const HOUSE_DOMAIN = `house-${SUFFIX}.example.com`;
 const SUB_A = `sub-a-${SUFFIX}.example.com`;
 const SUB_B = `sub-b-${SUFFIX}.example.com`;

--- a/server/tests/integration/property-enhancement-function.test.ts
+++ b/server/tests/integration/property-enhancement-function.test.ts
@@ -35,11 +35,13 @@ vi.mock('@anthropic-ai/sdk', () => {
 });
 
 // adagentsManager is instantiated at module scope in property-enhancement.ts;
-// the class mock must be in place before the module loads.
+// the class mock must be in place before the module loads. AdAgentsManager
+// is invoked with `new`, so the mock has to be a real class — `vi.fn()`
+// returns a function, not a constructor.
 vi.mock('../../src/adagents-manager.js', () => ({
-  AdAgentsManager: vi.fn().mockImplementation(() => ({
-    validateDomain: mocks.validateDomain,
-  })),
+  AdAgentsManager: class {
+    validateDomain = mocks.validateDomain;
+  },
 }));
 
 vi.mock('whoiser', () => ({

--- a/server/tests/integration/prospect-triage-function.test.ts
+++ b/server/tests/integration/prospect-triage-function.test.ts
@@ -73,13 +73,36 @@ import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
 import { runMigrations } from '../../src/db/migrate.js';
 import { triageEmailDomain } from '../../src/services/prospect-triage.js';
 
-const SUFFIX = `${process.pid}_${Date.now()}`;
+// Hyphen separator: triage doesn't validate domain format itself but
+// downstream code may, and matching the other integration tests' convention
+// keeps log lines greppable.
+const SUFFIX = `${process.pid}-${Date.now()}`;
 const TEST_DOMAIN = `triage-test-${SUFFIX}.co`;
 
 function assessProspectResponse(input: unknown) {
   return {
     content: [{ type: 'tool_use', name: 'assess_prospect', id: 'toolu_test', input }],
   };
+}
+
+// triageEmailDomain calls logTriageDecision fire-and-forget (line ~449
+// of prospect-triage.ts) so the INSERT is racing the SELECT. Poll briefly
+// instead of awaiting, since changing the prod call to await would alter
+// caller-visible latency.
+async function awaitTriageLog<T>(
+  pool: Pool,
+  domain: string,
+  selectSql: string,
+  timeoutMs = 2000,
+): Promise<{ rows: T[] }> {
+  const deadline = Date.now() + timeoutMs;
+  let last: { rows: T[] } = { rows: [] };
+  while (Date.now() < deadline) {
+    last = await pool.query<T>(selectSql, [domain]);
+    if (last.rows.length > 0) return last;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return last;
 }
 
 describe('triageEmailDomain — assessWithClaude tool_use output → TriageResult + log contract', () => {
@@ -130,14 +153,15 @@ describe('triageEmailDomain — assessWithClaude tool_use output → TriageResul
 
     // prospect_triage_log row must exist and carry the same values —
     // the log write is the only DB side effect at this layer.
-    const row = await pool.query<{
+    const row = await awaitTriageLog<{
       action: string;
       owner: string;
       priority: string;
       reason: string;
     }>(
+      pool,
+      TEST_DOMAIN,
       'SELECT action, owner, priority, reason FROM prospect_triage_log WHERE domain = $1',
-      [TEST_DOMAIN],
     );
     expect(row.rows).toHaveLength(1);
     expect(row.rows[0].action).toBe('create');
@@ -165,9 +189,10 @@ describe('triageEmailDomain — assessWithClaude tool_use output → TriageResul
 
     expect(result.priority).toBe('standard');
 
-    const row = await pool.query<{ priority: string }>(
+    const row = await awaitTriageLog<{ priority: string }>(
+      pool,
+      TEST_DOMAIN,
       'SELECT priority FROM prospect_triage_log WHERE domain = $1',
-      [TEST_DOMAIN],
     );
     expect(row.rows[0].priority).toBe('standard');
   });


### PR DESCRIPTION
## Summary

Build Check has been red on main since #3637 merged with cancelled CI. Five issues — four broken tests + one pre-existing flake — fixed forward. All 44 tests across the affected suites pass locally.

## What was broken

| File | Issue | Fix |
|------|-------|-----|
| `brand-classifier-route.test.ts` | `SUFFIX = '${pid}_${Date.now()}'` → underscored domain → `enrichBrand` rejects via regex → 500 | Switch separator to hyphen |
| `brand-enrichment-route.test.ts` | Same underscore issue | Switch separator to hyphen |
| `property-enhancement-function.test.ts` | `vi.fn().mockImplementation(...)` is not a constructor; production calls `new AdAgentsManager()` | Mock with a real class |
| `prospect-triage-function.test.ts` | `triageEmailDomain` calls `logTriageDecision(...)` fire-and-forget; SELECT raced INSERT | Add a small `awaitTriageLog` poll helper (don't change production behavior) |
| `member-context.ts > next_event` | `Math.floor((starts_at - now) / 86_400_000)` flipped "in 5 days" → "in 4 days" on sub-millisecond gap | `Math.round` — also semantically correct |

## Why the production code change for `next_event`

The pre-existing flake is pure UX: an event 4.7 days from now should render "in 5 days", not "in 4 days". The test author set `starts_at = now + 5 days` and expected "in 5 days"; the formatter raced `Date.now()` and floored. Switching to `Math.round` fixes both the flake and the user-visible rounding behavior.

## Test plan

- [x] All 5 affected suites pass locally (44/44 tests, ran with `WORKOS_API_KEY=sk_test_dummy WORKOS_CLIENT_ID=client_test_dummy DATABASE_URL=...`)
- [x] Pre-commit (`test:unit + test-dynamic-imports + typecheck`) — green
- [ ] Verify Build Check goes green on this PR

## Related

- #3637 introduced the broken tests (CI was cancelled at merge)
- #3622, #3648, #3650 are unrelated to the test breakage but landed on the same red main

🤖 Generated with [Claude Code](https://claude.com/claude-code)