### PR TITLE
test(server): standardize integration-test SUFFIX on hyphen separator

### DIFF
--- a/.changeset/standardize-test-suffix-hyphen-separator.md
+++ b/.changeset/standardize-test-suffix-hyphen-separator.md
@@ -1,0 +1,17 @@
+---
+---
+
+Standardize the integration-test `SUFFIX` separator on a hyphen across the
+remaining three test files that still used `${process.pid}_${Date.now()}`.
+
+Follow-up to #3656, which switched `brand-classifier-route`,
+`brand-enrichment-route`, and `prospect-triage-function` to a hyphen separator
+because their test domains were getting rejected by `enrichBrand`'s RFC 1035
+regex. Three other test files used the same underscore pattern but happened to
+pass today — `property-enhancement-function.test.ts`,
+`brand-properties-parse.test.ts`, and `addie-brand-property-tools.test.ts` —
+because their domains skip any regex-validating code path. Latent traps for
+the next test that adds a real route call.
+
+Hyphen-separator across the board removes the trap and matches the established
+convention. No behavior change for code paths that don't validate.

--- a/server/tests/integration/addie-brand-property-tools.test.ts
+++ b/server/tests/integration/addie-brand-property-tools.test.ts
@@ -48,7 +48,9 @@ import { createBrandPropertyToolHandlers } from '../../src/addie/mcp/brand-prope
 import type { MemberContext } from '../../src/addie/member-context.js';
 
 // PID + timestamp suffix prevents FK collisions when suites run in parallel.
-const SUFFIX = `${process.pid}_${Date.now()}`;
+// Hyphen separator: keeps `TEST_DOMAIN` valid per RFC 1035 in case any future
+// code path validates the test domain against a regex.
+const SUFFIX = `${process.pid}-${Date.now()}`;
 const TEST_DOMAIN = `addie-prop-${SUFFIX}.example.com`;
 const OWNER_ORG = `org_addie_owner_${SUFFIX}`;
 const OUTSIDER_ORG = `org_addie_outsider_${SUFFIX}`;

--- a/server/tests/integration/brand-properties-parse.test.ts
+++ b/server/tests/integration/brand-properties-parse.test.ts
@@ -65,8 +65,9 @@ import { createBrandFeedsRouter } from '../../src/routes/brand-feeds.js';
 // in parallel with any other integration test that touches organizations,
 // users, or brands tables. The suite's beforeEach DELETEs are scoped to
 // these specific keys, so a sibling worker running concurrently can't be
-// trampled.
-const SUFFIX = `${process.pid}_${Date.now()}`;
+// trampled. Hyphen separator: keeps `TEST_DOMAIN` valid per RFC 1035 in
+// case any future code path validates the test domain against a regex.
+const SUFFIX = `${process.pid}-${Date.now()}`;
 const TEST_DOMAIN = `parse-test-${SUFFIX}.example.com`;
 const OWNER_ORG = `org_parse_owner_${SUFFIX}`;
 const OUTSIDER_ORG = `org_parse_outsider_${SUFFIX}`;

--- a/server/tests/integration/property-enhancement-function.test.ts
+++ b/server/tests/integration/property-enhancement-function.test.ts
@@ -56,7 +56,10 @@ import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
 import { runMigrations } from '../../src/db/migrate.js';
 import { enhanceProperty } from '../../src/services/property-enhancement.js';
 
-const SUFFIX = `${process.pid}_${Date.now()}`;
+// Hyphen separator: keeps `TEST_DOMAIN` valid per RFC 1035 in case any future
+// code path validates the test domain against a regex (matches the convention
+// used by brand-classifier-route, brand-enrichment-route, and prospect-triage).
+const SUFFIX = `${process.pid}-${Date.now()}`;
 const TEST_DOMAIN = `prop-enhance-${SUFFIX}.example.com`;
 
 function analyzePropertyResponse(input: unknown) {


### PR DESCRIPTION
## Summary

Follow-up to #3656. Three integration test files still used `\${process.pid}_\${Date.now()}` (underscore separator) for their PID+timestamp SUFFIX:

- `server/tests/integration/property-enhancement-function.test.ts`
- `server/tests/integration/brand-properties-parse.test.ts`
- `server/tests/integration/addie-brand-property-tools.test.ts`

Underscores are invalid in domain names per RFC 1035. These three pass today because their `TEST_DOMAIN` never hits a regex-validating code path — property-enhancement skips validation; brand-properties-parse and addie-brand-property-tools mock the routes that would. But the next test that adds a real `enrichBrand` / `expandHouse` call would rediscover the same bug #3656 just fixed.

Switched to a hyphen across the board to match the convention established in #3656 (`brand-classifier-route`, `brand-enrichment-route`, `prospect-triage`). No behavior change for the existing tests — org/user IDs are still opaque strings, just with a hyphen instead of an underscore in the suffix.

Surfaced as a follow-up nit during the `code-reviewer` and `nodejs-testing-expert` reviews of #3655 (closed as superseded by #3656). Both flagged these three files as latent traps.

## Verification

- 39/39 tests pass across the three affected files locally.
- Pre-commit (typecheck + unit tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)