### PR TITLE
feat(billing): lazy reconcile on certification paywall hit (#3623 step 3)

### DIFF
--- a/.changeset/lazy-reconcile-paywall.md
+++ b/.changeset/lazy-reconcile-paywall.md
@@ -1,0 +1,12 @@
+---
+---
+
+feat(billing): lazy reconcile on certification paywall hit (#3623 step 3).
+
+When a Stripe customer is re-linked between orgs (admin audit, support fix-up) without subscription state being transferred to the new org row, the user shows up as a non-member at the next paywall hit despite holding an active membership in Stripe. Three real cases observed in production (Lina/HYPD/Yoshihiko, all manually fixed via `/sync`).
+
+Adds `attemptStripeReconciliation(orgId)` in `server/src/billing/lazy-reconcile.ts`. The four certification gates (`get_certification_module`, `start_certification_module`, `test_out_modules`, `start_certification_exam`) now call `ensureMembership()` before denying — which lazy-heals from Stripe when the org has a `stripe_customer_id` but no `subscription_status` and Stripe holds an active membership sub. The user clicking the paywall is the trigger; they never see the drift.
+
+Idempotent: `WHERE subscription_status IS NULL OR = 'none'` ensures concurrent webhook writes always win. Filters via `pickMembershipSub` so a non-membership sub stacked alongside doesn't pollute the heal. Doesn't write attestation/audit/activity rows — the webhook handler is the canonical place for those side effects (paywall click is action-signal, not fresh consent).
+
+Verified end-to-end against the sandbox `lina_class` fixture: drift detected → heal succeeds → row populated. Re-run on healed row → idempotent no-op (`already_entitled`).

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ skills/*/schemas/
 
 # Stripe webhook secret (dynamically generated)
 .stripe-webhook-secret
+.stripe-key
 test-results/
 tests/screenshots/
 

--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -21,10 +21,13 @@ function safeSubscriptionStatus(status: string | null | undefined): string | nul
 import * as certDb from '../../db/certification-db.js';
 import { isUuid } from '../../utils/uuid.js';
 import { query } from '../../db/client.js';
+import { getPool } from '../../db/client.js';
 import { createLogger } from '../../logger.js';
 import { notifySpecialistCredential } from '../jobs/credential-digest.js';
 import { TRAINING_AGENT_URL } from '../../training-agent/config.js';
 import { ToolError } from '../tool-error.js';
+import { stripe } from '../../billing/stripe-client.js';
+import { attemptStripeReconciliation } from '../../billing/lazy-reconcile.js';
 
 const logger = createLogger('certification-tools');
 
@@ -1185,13 +1188,55 @@ export const MODULE_RESOURCES: Record<string, { label: string; url: string }[]> 
 type ToolHandler = (input: Record<string, unknown>) => Promise<string>;
 
 export function createCertificationToolHandlers(
-  memberContext: MemberContext | null,
+  initialMemberContext: MemberContext | null,
   options?: { threadId?: string },
 ): Map<string, ToolHandler> {
   const handlers = new Map<string, ToolHandler>();
 
+  // Mutable across heal attempts so a successful lazy-reconcile during this
+  // handler set's lifetime is visible to subsequent calls in the same turn.
+  // The next conversation turn rebuilds memberContext from the DB and
+  // reflects any heals naturally.
+  let memberContext = initialMemberContext;
+
   const getUserId = (): string | null => {
     return memberContext?.workos_user?.workos_user_id || null;
+  };
+
+  /**
+   * Lazy reconcile path: when a paywall gate is about to deny but the org
+   * holds an active membership in Stripe, pull state from Stripe and
+   * self-heal the org row. Returns true if the user is now (or already
+   * was) a member.
+   *
+   * Catches drift introduced by post-webhook customer-relink flows and
+   * (rarer) missed webhooks. The user clicking on a paid feature is the
+   * trigger that surfaces the latent state — they never see the drift.
+   */
+  const ensureMembership = async (): Promise<boolean> => {
+    if (memberContext?.is_member) return true;
+    const orgId = memberContext?.organization?.workos_organization_id;
+    if (!orgId || !stripe) return false;
+
+    const result = await attemptStripeReconciliation(orgId, {
+      pool: getPool(),
+      stripe,
+      logger,
+    });
+
+    if (!result.healed) return false;
+
+    if (memberContext?.organization) {
+      memberContext = {
+        ...memberContext,
+        is_member: true,
+        organization: {
+          ...memberContext.organization,
+          subscription_status: result.subscriptionStatus,
+        },
+      };
+    }
+    return true;
   };
 
   // ----- list_certification_tracks -----
@@ -1287,8 +1332,8 @@ export function createCertificationToolHandlers(
       const mod = await certDb.getModule(moduleId);
       if (!mod) return `Module "${moduleId}" not found. Use list_certification_tracks to see available modules.`;
 
-      // Check access
-      if (!mod.is_free && !memberContext?.is_member) {
+      // Check access — try lazy heal before denying.
+      if (!mod.is_free && !(await ensureMembership())) {
         return membershipRequiredMessage(moduleId, memberContext);
       }
 
@@ -1372,7 +1417,7 @@ export function createCertificationToolHandlers(
       const mod = await certDb.getModule(moduleId);
       if (!mod) return `Module "${moduleId}" not found.`;
 
-      if (!mod.is_free && !memberContext?.is_member) {
+      if (!mod.is_free && !(await ensureMembership())) {
         return membershipRequiredMessage(moduleId, memberContext);
       }
 
@@ -1706,7 +1751,7 @@ export function createCertificationToolHandlers(
         const mod = moduleMap.get(id);
         return mod && !mod.is_free;
       });
-      if (paidModules.length > 0 && !memberContext?.is_member) {
+      if (paidModules.length > 0 && !(await ensureMembership())) {
         return membershipRequiredMessage(paidModules[0], memberContext);
       }
 
@@ -1765,7 +1810,7 @@ export function createCertificationToolHandlers(
         return `"${moduleId}" is not a capstone module. Valid specialist modules: S1 (Media Buy), S2 (Creative), S3 (Signals), S4 (Governance), S5 (Generative Advertising).`;
       }
 
-      if (!memberContext?.is_member) {
+      if (!(await ensureMembership())) {
         return membershipRequiredMessage(moduleId, memberContext);
       }
 

--- a/server/src/billing/lazy-reconcile.ts
+++ b/server/src/billing/lazy-reconcile.ts
@@ -1,0 +1,176 @@
+/**
+ * Lazy reconciliation: when a paywall gate is about to deny a request from
+ * an org that has a `stripe_customer_id` but no `subscription_status`, pull
+ * fresh state from Stripe and self-heal the org row before the deny fires.
+ *
+ * Catches a real drift class observed in production: a Stripe customer can
+ * be re-linked between orgs (admin audit, support fix-up) without the
+ * subscription state being transferred to the new org's row. The webhook
+ * fired correctly against the old org; the new org's row is silently null
+ * even though the customer holds an active membership sub. Lazy
+ * reconciliation surfaces those cases at the moment of customer impact —
+ * the user clicking on a paid feature is the trigger — so the customer
+ * never sees the drift.
+ *
+ * Deliberate scope:
+ *  - Only writes the subscription_* columns on the org row.
+ *  - Does NOT write `agreement_signed_at`, `user_agreement_acceptances`,
+ *    or `org_activities` rows. The webhook handler (handle-subscription-created)
+ *    is the canonical place for those side effects, and it's keyed off
+ *    `pending_agreement_user_id` set at checkbox-click time. A user clicking
+ *    a paywall is action-signal but not a fresh consent event.
+ *  - Idempotent: `WHERE subscription_status IS NULL` guards against
+ *    overwriting a status set by a webhook that landed between read and write.
+ *  - Safe to call on every paywall hit; only does Stripe work when the org
+ *    actually looks drifted.
+ */
+import type { Pool } from 'pg';
+import type Stripe from 'stripe';
+import type { Logger } from 'pino';
+import { pickMembershipSub } from './membership-prices.js';
+
+/**
+ * Stripe statuses that grant entitlement at AAO. Mirrors the gate logic
+ * in `org-filters.ts:resolveEffectiveMembership` and the integrity
+ * invariant. `past_due` keeps access during dunning.
+ */
+const ENTITLED_STATUSES = new Set<string>(['active', 'trialing', 'past_due']);
+
+export type LazyReconcileResult =
+  | { healed: true; reason: 'healed_from_stripe'; subscriptionStatus: string }
+  | { healed: false; reason: LazyReconcileSkipReason };
+
+export type LazyReconcileSkipReason =
+  | 'org_not_found'
+  | 'already_entitled'
+  | 'no_stripe_customer'
+  | 'stripe_error'
+  | 'customer_deleted'
+  | 'no_membership_sub'
+  | 'sub_not_entitled';
+
+interface OrgRow {
+  workos_organization_id: string;
+  stripe_customer_id: string | null;
+  subscription_status: string | null;
+  subscription_canceled_at: Date | null;
+}
+
+export interface LazyReconcileDeps {
+  pool: Pool;
+  stripe: Stripe;
+  logger: Logger;
+}
+
+/**
+ * Attempt to heal an org row from Stripe state.
+ *
+ * Returns `{ healed: true, ... }` only if the row went from "no live
+ * subscription" to a written entitlement. Returns `{ healed: false, reason }`
+ * for every skip path so callers can log the reason without taking action.
+ */
+export async function attemptStripeReconciliation(
+  orgId: string,
+  deps: LazyReconcileDeps,
+): Promise<LazyReconcileResult> {
+  const { pool, stripe, logger } = deps;
+
+  const orgResult = await pool.query<OrgRow>(
+    `SELECT workos_organization_id, stripe_customer_id, subscription_status, subscription_canceled_at
+       FROM organizations
+      WHERE workos_organization_id = $1`,
+    [orgId],
+  );
+  const org = orgResult.rows[0];
+  if (!org) return { healed: false, reason: 'org_not_found' };
+
+  if (org.subscription_status && ENTITLED_STATUSES.has(org.subscription_status)) {
+    return { healed: false, reason: 'already_entitled' };
+  }
+
+  if (!org.stripe_customer_id) {
+    return { healed: false, reason: 'no_stripe_customer' };
+  }
+
+  let customer: Stripe.Customer | Stripe.DeletedCustomer;
+  try {
+    customer = await stripe.customers.retrieve(org.stripe_customer_id, {
+      expand: ['subscriptions'],
+    });
+  } catch (err) {
+    logger.warn(
+      { err, orgId, customerId: org.stripe_customer_id },
+      'lazy-reconcile: stripe.customers.retrieve failed; deferring heal',
+    );
+    return { healed: false, reason: 'stripe_error' };
+  }
+
+  if (customer.deleted) {
+    return { healed: false, reason: 'customer_deleted' };
+  }
+
+  const subs = (customer as Stripe.Customer).subscriptions?.data ?? [];
+  const sub = pickMembershipSub(subs);
+  if (!sub) return { healed: false, reason: 'no_membership_sub' };
+  if (!ENTITLED_STATUSES.has(sub.status)) return { healed: false, reason: 'sub_not_entitled' };
+
+  const price = sub.items.data[0]?.price;
+
+  // `WHERE subscription_status IS NULL OR = 'none'` makes the write a no-op
+  // if a webhook beat us to it. We deliberately do not overwrite an existing
+  // active/canceled/etc. status — the webhook is the source of truth for
+  // those transitions; lazy reconcile only fills in the gap.
+  const updated = await pool.query(
+    `UPDATE organizations
+       SET subscription_status = $1,
+           stripe_subscription_id = $2,
+           subscription_amount = $3,
+           subscription_currency = $4,
+           subscription_interval = $5,
+           subscription_current_period_end = $6,
+           subscription_canceled_at = $7,
+           subscription_price_lookup_key = $8,
+           updated_at = NOW()
+     WHERE workos_organization_id = $9
+       AND (subscription_status IS NULL OR subscription_status = 'none')
+     RETURNING workos_organization_id`,
+    [
+      sub.status,
+      sub.id,
+      price?.unit_amount ?? null,
+      price?.currency ?? 'usd',
+      price?.recurring?.interval ?? null,
+      sub.current_period_end ? new Date(sub.current_period_end * 1000) : null,
+      sub.canceled_at ? new Date(sub.canceled_at * 1000) : null,
+      price?.lookup_key ?? null,
+      orgId,
+    ],
+  );
+
+  if (updated.rowCount === 0) {
+    // A webhook arrived between our read and write. The webhook is more
+    // authoritative; treat as already-entitled.
+    logger.info(
+      { orgId, customerId: org.stripe_customer_id, subId: sub.id },
+      'lazy-reconcile: row was already updated by a concurrent webhook; deferring',
+    );
+    return { healed: false, reason: 'already_entitled' };
+  }
+
+  logger.info(
+    {
+      orgId,
+      customerId: org.stripe_customer_id,
+      subId: sub.id,
+      lookupKey: price?.lookup_key ?? null,
+      stripeStatus: sub.status,
+    },
+    'lazy-reconcile: healed missing subscription_status from Stripe',
+  );
+
+  return {
+    healed: true,
+    reason: 'healed_from_stripe',
+    subscriptionStatus: sub.status,
+  };
+}

--- a/server/tests/unit/billing/lazy-reconcile.test.ts
+++ b/server/tests/unit/billing/lazy-reconcile.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for `attemptStripeReconciliation` — the lazy heal path that
+ * surfaces drift between Stripe and our org row at the moment a paywall
+ * gate would otherwise deny.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type Stripe from 'stripe';
+import { attemptStripeReconciliation } from '../../../src/billing/lazy-reconcile.js';
+
+const mockQuery = vi.fn();
+const mockCustomersRetrieve = vi.fn();
+
+function makeDeps() {
+  return {
+    pool: { query: mockQuery } as any,
+    stripe: {
+      customers: { retrieve: mockCustomersRetrieve },
+    } as unknown as Stripe,
+    logger: {
+      info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+      debug: vi.fn(), trace: vi.fn(), fatal: vi.fn(),
+      child: vi.fn().mockReturnThis(),
+    } as any,
+  };
+}
+
+beforeEach(() => {
+  mockQuery.mockReset();
+  mockCustomersRetrieve.mockReset();
+});
+
+function fakeOrg(overrides: Partial<{
+  stripe_customer_id: string | null;
+  subscription_status: string | null;
+  subscription_canceled_at: Date | null;
+}> = {}) {
+  // `'key' in overrides` preserves explicit null (vs ?? which would
+  // substitute the default for null too).
+  return {
+    workos_organization_id: 'org_x',
+    stripe_customer_id: 'stripe_customer_id' in overrides ? overrides.stripe_customer_id : 'cus_x',
+    subscription_status: 'subscription_status' in overrides ? overrides.subscription_status : null,
+    subscription_canceled_at: overrides.subscription_canceled_at ?? null,
+  };
+}
+
+function fakeCustomerWithSubs(subs: unknown[]): Stripe.Customer {
+  return {
+    id: 'cus_x',
+    deleted: false,
+    subscriptions: { data: subs },
+  } as unknown as Stripe.Customer;
+}
+
+function fakeMembershipSub(overrides: Partial<{
+  id: string;
+  status: Stripe.Subscription.Status;
+  lookup_key: string | null;
+  unit_amount: number;
+}> = {}) {
+  return {
+    id: overrides.id ?? 'sub_x',
+    status: overrides.status ?? 'active',
+    current_period_end: 9999999999,
+    canceled_at: null,
+    items: {
+      data: [{
+        price: {
+          unit_amount: overrides.unit_amount ?? 25000,
+          currency: 'usd',
+          recurring: { interval: 'year' },
+          lookup_key: 'lookup_key' in overrides ? overrides.lookup_key : 'aao_membership_professional_250',
+        },
+      }],
+    },
+  };
+}
+
+describe('attemptStripeReconciliation', () => {
+  it('heals an org row when Stripe customer has an active membership sub', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [fakeOrg({ subscription_status: null })] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ workos_organization_id: 'org_x' }] });
+    mockCustomersRetrieve.mockResolvedValueOnce(fakeCustomerWithSubs([fakeMembershipSub()]));
+
+    const result = await attemptStripeReconciliation('org_x', makeDeps());
+
+    expect(result.healed).toBe(true);
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    expect(mockQuery.mock.calls[1][0]).toMatch(/UPDATE organizations/);
+  });
+
+  it('skips when org already has an entitled subscription_status', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [fakeOrg({ subscription_status: 'active' })] });
+
+    const result = await attemptStripeReconciliation('org_x', makeDeps());
+
+    expect(result).toEqual({ healed: false, reason: 'already_entitled' });
+    expect(mockCustomersRetrieve).not.toHaveBeenCalled();
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips when org has no Stripe customer id', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [fakeOrg({ stripe_customer_id: null })] });
+
+    const result = await attemptStripeReconciliation('org_x', makeDeps());
+
+    expect(result).toEqual({ healed: false, reason: 'no_stripe_customer' });
+    expect(mockCustomersRetrieve).not.toHaveBeenCalled();
+  });
+
+  it('skips when Stripe customer is deleted', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [fakeOrg()] });
+    mockCustomersRetrieve.mockResolvedValueOnce({ id: 'cus_x', deleted: true });
+
+    const result = await attemptStripeReconciliation('org_x', makeDeps());
+
+    expect(result).toEqual({ healed: false, reason: 'customer_deleted' });
+  });
+
+  it('skips when Stripe customer has no membership sub', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [fakeOrg()] });
+    mockCustomersRetrieve.mockResolvedValueOnce(
+      fakeCustomerWithSubs([fakeMembershipSub({ lookup_key: 'aao_event_ticket' })]),
+    );
+
+    const result = await attemptStripeReconciliation('org_x', makeDeps());
+
+    expect(result).toEqual({ healed: false, reason: 'no_membership_sub' });
+  });
+
+  it('skips when membership sub is not in an entitled status (incomplete)', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [fakeOrg()] });
+    mockCustomersRetrieve.mockResolvedValueOnce(
+      fakeCustomerWithSubs([fakeMembershipSub({ status: 'incomplete' })]),
+    );
+
+    const result = await attemptStripeReconciliation('org_x', makeDeps());
+
+    expect(result).toEqual({ healed: false, reason: 'sub_not_entitled' });
+  });
+
+  it('treats trialing as entitled and heals', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [fakeOrg()] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ workos_organization_id: 'org_x' }] });
+    mockCustomersRetrieve.mockResolvedValueOnce(
+      fakeCustomerWithSubs([fakeMembershipSub({ status: 'trialing' })]),
+    );
+
+    const result = await attemptStripeReconciliation('org_x', makeDeps());
+
+    expect(result.healed).toBe(true);
+    if (result.healed) expect(result.subscriptionStatus).toBe('trialing');
+  });
+
+  it('multi-sub: picks the membership sub even when stacked with non-membership', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [fakeOrg()] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ workos_organization_id: 'org_x' }] });
+    mockCustomersRetrieve.mockResolvedValueOnce(
+      fakeCustomerWithSubs([
+        fakeMembershipSub({ id: 'sub_event', lookup_key: 'aao_event_ticket' }),
+        fakeMembershipSub({ id: 'sub_member', lookup_key: 'aao_membership_explorer_50' }),
+      ]),
+    );
+
+    const result = await attemptStripeReconciliation('org_x', makeDeps());
+
+    expect(result.healed).toBe(true);
+    // The UPDATE was called with the membership sub's id at param 2 (stripe_subscription_id).
+    const updateParams = mockQuery.mock.calls[1][1] as unknown[];
+    expect(updateParams[1]).toBe('sub_member');
+  });
+
+  it('reports already_entitled when a concurrent webhook beat the heal write (rowCount=0)', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [fakeOrg()] })
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] });  // WHERE clause filtered out
+    mockCustomersRetrieve.mockResolvedValueOnce(fakeCustomerWithSubs([fakeMembershipSub()]));
+
+    const result = await attemptStripeReconciliation('org_x', makeDeps());
+
+    expect(result).toEqual({ healed: false, reason: 'already_entitled' });
+  });
+
+  it('returns stripe_error and does not write when Stripe call throws', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [fakeOrg()] });
+    mockCustomersRetrieve.mockRejectedValueOnce(new Error('rate limit'));
+
+    const result = await attemptStripeReconciliation('org_x', makeDeps());
+
+    expect(result).toEqual({ healed: false, reason: 'stripe_error' });
+    expect(mockQuery).toHaveBeenCalledTimes(1);  // only the SELECT, no UPDATE
+  });
+
+  it('returns org_not_found when the org id does not exist', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const result = await attemptStripeReconciliation('org_missing', makeDeps());
+
+    expect(result).toEqual({ healed: false, reason: 'org_not_found' });
+    expect(mockCustomersRetrieve).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

When a Stripe customer is re-linked between orgs (admin audit, support fix-up) without subscription state being transferred to the new org row, the user appears as a non-member at the next paywall hit despite holding an active membership in Stripe. **The four certification gates now lazy-heal from Stripe before denying.** The user clicking the paywall is the trigger; they never see the drift.

## Diagnosis

Three real cases observed in production: Lina (`cus_UF4bV…`), HYPD (`cus_TajjN…`), Yoshihiko (`cus_Tpzj…`). All three already manually fixed during the investigation that motivated this work (see #3627 and #3643 PR descriptions). 

The Stripe-side investigation revealed these are **not missed-webhook bugs**. Stripe customer metadata explicitly records `relinked_at` / `previous_workos_organization_id` for at least one (Lina). The original `customer.subscription.created` webhook fired correctly against the *original* org. Some later admin process re-linked the customer to a different org but didn't transfer subscription state to the new org's row.

This makes lazy reconciliation the right shape (instead of the cron auto-remediation we were originally scoping):

| Failure mode | Cron auto-remediate | Lazy reconcile on paywall |
|---|---|---|
| Missed webhook | ✅ catches | ✅ catches |
| Customer relinked, state not transferred | ✅ catches | ✅ catches |
| Customer-impact latency | up to 1 hour | < 1 second |
| Notification cascade misfires (welcome DM weeks late) | risk | none — no welcome cascade |
| Legal: backfilled attestation without click-through | risk | n/a — no attestation written |

Lazy reconcile dominates on every axis at AAO's scale.

## What changed

1. New module `server/src/billing/lazy-reconcile.ts` exporting `attemptStripeReconciliation(orgId, deps)`.
   - Reads org row; skips if already entitled or no `stripe_customer_id`
   - Pulls customer + active subs from Stripe, filters via `pickMembershipSub` (from #3646)
   - `UPDATE … WHERE subscription_status IS NULL OR = 'none'` — concurrent webhook writes always win
   - Returns `{ healed, reason }` for caller logging
   - Only writes the subscription_* columns; deliberately not attestation/audit/activity rows

2. `server/src/addie/mcp/certification-tools.ts`:
   - `memberContext` is now a `let` so successful heals are visible to subsequent calls in the same handler turn
   - New `ensureMembership()` helper wraps the heal call
   - Four gates (`get_certification_module`, `start_certification_module`, `test_out_modules`, `start_certification_exam`) call `ensureMembership()` before denying

3. `.gitignore`: adds `.stripe-key` (live Stripe key file).

## What it deliberately doesn't do

- **No attestation/audit/activity writes.** The webhook handler (`handle-subscription-created.ts`) is the canonical place for those side effects, keyed off `pending_agreement_user_id` from checkbox-click time. A paywall click is action-signal but not fresh consent. Lazy reconcile heals the entitlement gate; legal records remain a webhook concern.
- **No reverse direction.** `(NULL|none) → entitled` only; never overwrites an existing `active`/`canceled`/etc. status.
- **No cron.** Per the diagnosis above and expert review converged in this thread, the cron design was overengineering — lazy reconcile delivers the customer-impact fix without the architectural lift.

## Verification

End-to-end against the sandbox `lina_class` fixture (#3643):

```
=== Before heal ===
{ subscription_status: null, stripe_subscription_id: null }

=== Running heal ===
result: { healed: true, reason: 'healed_from_stripe', subscriptionStatus: 'trialing' }

=== After heal ===
{ subscription_status: 'trialing', stripe_subscription_id: 'sub_…', amount: 25000, lookup_key: 'aao_membership_professional_250' }

=== Re-run on healed row (idempotency) ===
result: { healed: false, reason: 'already_entitled' }
```

## Test plan

- [x] 11-case unit test for `attemptStripeReconciliation`: happy path, all skip reasons, multi-sub correct picking (the data[0] regression class), concurrent-webhook race, transient Stripe error, trialing-as-entitled
- [x] Existing 67 tests in `tests/unit/integrity/` and `tests/unit/billing/` still pass
- [x] `npx tsc --noEmit` clean
- [x] Pre-commit hook passes (unit + dynamic imports + typecheck)
- [x] End-to-end manual test against sandbox `lina_class` fixture
- [ ] Reviewer: pull a recent membership-required Addie escalation; if the org has `stripe_customer_id IS NOT NULL`, the heal would fire on the next gate hit

## Refs

- Detect (#3627), sandbox (#3643), `data[0]` fix (#3646) — all merged
- This PR is Path B step 3 in the work originally scoped as cron auto-remediation; pivoted to lazy heal after expert review converged on this shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)