### PR TITLE
fix(slack): warn (not error) on routine Slack API conditions

### DIFF
--- a/.changeset/quiet-slack-expected-errors.md
+++ b/.changeset/quiet-slack-expected-errors.md
@@ -1,0 +1,9 @@
+---
+---
+
+Stop paging on routine Slack API conditions in `server/src/slack/client.ts`. Two specific call sites that fired `:rotating_light: System error: slack-client` alerts today get downgraded to `warn` when the underlying Slack error is a known third-party state, not a server failure:
+
+- `getSlackUser`: `user_not_found` (deactivated/deleted users, stale message references) → `warn`. The function already returns `null` for the caller to handle.
+- `inviteToChannel`: `not_in_channel`, `channel_not_found`, `is_archived`, `user_is_restricted`, `user_is_ultra_restricted`, `user_disabled` → `warn`. Caller already gets `{ ok: false, error }` and decides what to do; bot-not-in-channel is normal Slack behavior, not a system failure.
+
+Other paths in the file still log at `error` for unknown failures. Follows the convention added in the `logger` JSDoc.

--- a/server/src/slack/client.ts
+++ b/server/src/slack/client.ts
@@ -240,7 +240,14 @@ export async function getSlackUser(userId: string): Promise<SlackUser | null> {
     });
     return response.user;
   } catch (error) {
-    logger.error({ error, userId }, 'Failed to get Slack user');
+    // user_not_found is routine — deactivated/deleted users, stale references
+    // from old messages, cross-workspace IDs. Don't page on it.
+    const message = error instanceof Error ? error.message : '';
+    const expected = message.includes('user_not_found');
+    logger[expected ? 'warn' : 'error'](
+      { error, userId },
+      'Failed to get Slack user',
+    );
     return null;
   }
 }
@@ -1114,15 +1121,26 @@ export async function inviteToChannel(
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
 
-    // These Slack errors are expected and not actionable
+    // Slack errors that mean the invite was a no-op success (already member, self-invite)
     if (errorMessage.includes('already_in_channel') || errorMessage.includes('cant_invite_self')) {
       return { ok: true };
     }
 
-    logger.error(
-      error instanceof Error ? error : new Error(errorMessage),
-      'Failed to invite users to channel (channelId=%s)',
-      channelId,
+    // Slack errors that are routine and not actionable: bot isn't in the channel,
+    // channel was archived/deleted, target user is restricted/disabled. Log at
+    // warn — caller already gets `{ ok: false, error }` and decides what to do.
+    const expected = [
+      'not_in_channel',
+      'channel_not_found',
+      'is_archived',
+      'user_is_restricted',
+      'user_is_ultra_restricted',
+      'user_disabled',
+    ].some((code) => errorMessage.includes(code));
+
+    logger[expected ? 'warn' : 'error'](
+      { err: error instanceof Error ? error : new Error(errorMessage), channelId },
+      'Failed to invite users to channel',
     );
     return { ok: false, error: errorMessage };
   }


### PR DESCRIPTION
## Summary

Stop paging on routine Slack API conditions — three alerts today (3:59, 6:55, 6:57 AM UTC) were `:rotating_light: *System error: slack-client*` for what are normal third-party states.

## What was paging

| Time | Where | Slack error | Why it's not a system failure |
|------|-------|-------------|-------------------------------|
| 03:59 | `inviteToChannel` (`slack/client.ts:1122`) | `not_in_channel` | Bot isn't in the channel yet — the caller's job to handle |
| 06:55 | `getSlackUser` (`slack/client.ts:243`) | `user_not_found` | Deactivated/deleted user, or stale reference from an old message |
| 06:57 | `getSlackUser` | `user_not_found` | Same |

Both functions already do the right thing (return `null` / `{ ok: false, error }`); only the log level was wrong.

## Fix

- `getSlackUser`: log `user_not_found` at `warn`, everything else still `error`.
- `inviteToChannel`: log `not_in_channel`, `channel_not_found`, `is_archived`, `user_is_restricted`, `user_is_ultra_restricted`, `user_disabled` at `warn`. Unknown failures still `error`.

Follows the `logger.error` vs `logger.warn` convention added in #3650's JSDoc — `error` level triggers Slack `#aao-errors` and PostHog `$exception`, so it should be reserved for unexpected, page-worthy failures.

## Out of scope

There are 11 other `logger.error` sites in `slack/client.ts` (and many more across `addie/mcp/*`). Triaging the lot would be a much bigger PR with a lot of judgment calls about which Slack codes are "routine" per call site. This PR fixes only the three that fired today; the rest will follow as alerts surface, which is the lower-risk way to grade them.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] Pre-commit (`test:unit + test-dynamic-imports + typecheck`) — passed
- [ ] Watch `#aao-errors` for absence of system-error alerts on `not_in_channel` / `user_not_found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)