### PR TITLE
feat(addie): explainer-aware shape grader (closes #3660)

### DIFF
--- a/.changeset/explainer-aware-shape-grader.md
+++ b/.changeset/explainer-aware-shape-grader.md
@@ -1,0 +1,22 @@
+---
+---
+
+Make the shape grader explainer-aware so its prevalence numbers align
+with the Voice rule's explicit carve-out (closes #3660):
+
+- `classifyQuestion` adds an `isExplainer` flag and gives explainer-shape
+  questions a wider cap (500-word floor) so the grader stops flagging
+  policy-allowed verbosity as length_cap.
+- Detection is conservative: a "strong" prefix (`walk me through`,
+  `explain`) always passes. "Soft" prefixes (`what is`, `how does`,
+  `how is X different from Y`, `what's the difference`, `why does`,
+  `why do`) pass only when no transactional noun is present
+  (`cost`, `tier`, `billing`, `payment`, `register`, `member`, etc.).
+  Mirrors the counter-example list in identity.md Voice.
+- `shape-eval-prod-sample.ts` now reports an "actionable violation" rate
+  alongside the all-up rate, splitting explainer length_cap from
+  non-explainer length_cap. The actionable rate is what to track for
+  verbosity regressions; the all-up rate inflates with policy-allowed
+  explainer length.
+- Adds `good question` to `BANNED_RITUAL_LITERALS` — observed leaking
+  in the latest prod sample.

--- a/server/src/addie/response-postprocess.ts
+++ b/server/src/addie/response-postprocess.ts
@@ -43,6 +43,7 @@ const BANNED_RITUAL_LITERALS: readonly string[] = [
   "that's a fair question",
   "fair question",
   "great question",
+  "good question",
   "sharp question",
   "this is a sharp point",
   "to be clear",

--- a/server/src/addie/testing/shape-grader.ts
+++ b/server/src/addie/testing/shape-grader.ts
@@ -23,6 +23,16 @@ export interface QuestionShape {
   /** Question contains 'and', 'plus', 'also', or two question marks. */
   isMultiPart: boolean;
   /**
+   * True when the question is an explainer ("what is X?", "how is X
+   * different from Y?", "walk me through Z", architectural / why
+   * questions). These get a wider cap because identity.md's Voice rule
+   * explicitly allows long answers when the caller's understanding
+   * requires depth. Detection requires BOTH an explainer prefix AND no
+   * transactional noun ("cost", "tier", "billing", etc.) — so
+   * "what is the cost?" stays single-part transactional.
+   */
+  isExplainer: boolean;
+  /**
    * Calibrated word-count ceiling for a response of this shape, drawn from
    * response-style.md's word-count table:
    *   ≤15 words → 120
@@ -31,6 +41,9 @@ export interface QuestionShape {
    * Multi-part is a question-shape signal but does not by itself grant
    * extra word budget — response-style.md says each part still gets the
    * treatment its shape deserves, not that the budget compounds.
+   * Explainer questions get a floor of 500 (the strict-cap path is kept
+   * for non-explainer questions; explainers can run long without firing
+   * length_cap, matching the Voice rule's explicit carve-out).
    */
   expectedMaxWords: number;
 }
@@ -117,6 +130,55 @@ const SIGNIN_OPENER_PATTERNS: readonly string[] = [
 
 const OPENER_WINDOW_CHARS = 200;
 
+/**
+ * Explainer-question detection. Mirrors the carve-out identity.md's Voice
+ * rule encodes for the model: explainers ("what is X?", "how is X
+ * different from Y?", "walk me through Z") deserve verbosity when the
+ * caller's understanding requires it. Conservative implementation — must
+ * match BOTH an explainer prefix AND have no transactional noun. Better
+ * to occasionally miss a real explainer (the strict cap fires, reviewer
+ * dismisses) than silently allow essays on transactional questions phrased
+ * like explainers ("what is the cost?", "how is Builder different from
+ * Professional for billing?").
+ *
+ * The transactional noun list mirrors the counter-example list in the
+ * Voice section so the grader's carve-out matches the rule's carve-out.
+ */
+// "Strong" prefixes signal the caller is explicitly asking for depth.
+// "Walk me through X" or "explain X" presupposes a non-trivial answer
+// even when the noun is transactional ("walk me through registration"
+// is still an explainer — the caller wants the steps).
+const STRONG_EXPLAINER_PREFIX_RE = /^\s*(walk\s+me\s+through|explain)\b/i;
+
+// "Soft" prefixes can be either explainer or transactional depending on
+// the noun. "What is AdCP?" is explainer; "what is the cost?" is
+// transactional. The transactional-noun stoplist below disambiguates.
+// "what's" is the contracted form. "what is the difference between X
+// and Y" / "what's the difference between X and Y" is the same
+// explainer shape as "how is X different from Y".
+const SOFT_EXPLAINER_PREFIX_RE =
+  /^\s*(what\s+is|what's|what\s+are|how\s+does|how\s+do|how\s+is\s+[\w\s']+different|what(?:\s+is|'s|s)\s+the\s+difference|why\s+does|why\s+do)\b/i;
+
+// Transactional nouns and verbs whose presence means a soft-prefix
+// question is asking about an account/billing/membership/payment
+// mechanic rather than a concept. The list is intentionally broad —
+// false negatives (a real explainer slips past) just keep the strict
+// cap, which a reviewer can dismiss; false positives (transactional
+// question gets the wider cap) silently hide essay-shape on a question
+// that should have been short. Mirrors the counter-example list in
+// identity.md Voice section.
+const TRANSACTIONAL_NOUN_RE =
+  /\b(cost|costs|price|prices|fee|fees|tier|tiers|plan|plans|level|levels|deadline|deadlines|invoice|invoices|billing|payment|payments|pay|paid|paying|refund|refunds|profile|profiles|account|accounts|email|emails|password|passwords|login|seat|seats|quota|quotas|limit|limits|status|state|due|register|registered|registering|registers|registration|member|members|membership|subscribe|subscribes|subscribed|subscription|signup|sign-up|join|joining)\b/i;
+
+export function isExplainerQuestion(question: string): boolean {
+  if (STRONG_EXPLAINER_PREFIX_RE.test(question)) return true;
+  if (!SOFT_EXPLAINER_PREFIX_RE.test(question)) return false;
+  if (TRANSACTIONAL_NOUN_RE.test(question)) return false;
+  return true;
+}
+
+const EXPLAINER_CAP_FLOOR = 500;
+
 function countWords(s: string): number {
   if (!s) return 0;
   return s.trim().split(/\s+/).filter(Boolean).length;
@@ -150,12 +212,19 @@ export function classifyQuestion(question: string): QuestionShape {
   );
   const isMultiPart = questionMarks >= 2 || conjJoinsClauses;
 
-  let expectedMaxWords: number;
-  if (wordCount <= 15) expectedMaxWords = 120;
-  else if (wordCount <= 30) expectedMaxWords = 200;
-  else expectedMaxWords = Math.min(400, wordCount * 8);
+  const isExplainer = isExplainerQuestion(question);
 
-  return { wordCount, isMultiPart, expectedMaxWords };
+  let baseCap: number;
+  if (wordCount <= 15) baseCap = 120;
+  else if (wordCount <= 30) baseCap = 200;
+  else baseCap = Math.min(400, wordCount * 8);
+
+  // Explainers get a floor of 500 — the strict cap path stays for non-
+  // explainer questions, so the grader still flags essay-shape on sharp
+  // questions while letting genuine explainers run long without firing.
+  const expectedMaxWords = isExplainer ? Math.max(baseCap, EXPLAINER_CAP_FLOOR) : baseCap;
+
+  return { wordCount, isMultiPart, isExplainer, expectedMaxWords };
 }
 
 export function analyzeResponseShape(response: string): ResponseShape {

--- a/server/tests/manual/shape-eval-prod-sample.ts
+++ b/server/tests/manual/shape-eval-prod-sample.ts
@@ -131,8 +131,18 @@ interface Aggregate {
   responseWordsHist: { p10: number; p50: number; p90: number; min: number; max: number };
   ratioHist: { p10: number; p50: number; p90: number; min: number; max: number };
   multiPartCount: number;
+  explainerCount: number;
+  /** length_cap fires that occurred on non-explainer questions — the
+   *  metric to track for actual verbosity regressions. */
+  nonExplainerLengthCap: number;
+  /** length_cap fires that occurred on explainer questions — these are
+   *  policy-allowed (Voice rule) but still surfaced for visibility. */
+  explainerLengthCap: number;
   violationCounts: Record<string, number>;
   pairsWithAnyViolation: number;
+  /** Pairs with any violation that was NOT a policy-allowed explainer
+   *  length_cap. The actionable AnyViol rate. */
+  pairsWithActionableViolation: number;
 }
 
 function pct(part: number, whole: number): string {
@@ -155,8 +165,12 @@ function aggregate(pairs: SampledPair[]): Aggregate {
     responseWordsHist: { p10: 0, p50: 0, p90: 0, min: 0, max: 0 },
     ratioHist: { p10: 0, p50: 0, p90: 0, min: 0, max: 0 },
     multiPartCount: 0,
+    explainerCount: 0,
+    nonExplainerLengthCap: 0,
+    explainerLengthCap: 0,
     violationCounts: {},
     pairsWithAnyViolation: 0,
+    pairsWithActionableViolation: 0,
   };
   const qWords: number[] = [];
   const rWords: number[] = [];
@@ -167,7 +181,24 @@ function aggregate(pairs: SampledPair[]): Aggregate {
     rWords.push(p.response_words);
     ratios.push(p.shape.violations.ratioToExpected);
     if (p.shape.question.isMultiPart) out.multiPartCount++;
-    if (p.shape.violationLabels.length > 0) out.pairsWithAnyViolation++;
+    if (p.shape.question.isExplainer) out.explainerCount++;
+    if (p.shape.violations.exceededLengthCap) {
+      if (p.shape.question.isExplainer) {
+        out.explainerLengthCap++;
+      } else {
+        out.nonExplainerLengthCap++;
+      }
+    }
+    if (p.shape.violationLabels.length > 0) {
+      out.pairsWithAnyViolation++;
+      // Actionable = at least one violation that ISN'T a policy-allowed
+      // explainer length_cap. If the only violation is length_cap on an
+      // explainer, the Voice rule explicitly allows it; not actionable.
+      const onlyExplainerLength =
+        p.shape.question.isExplainer &&
+        p.shape.violationLabels.every((v) => v.startsWith('length_cap'));
+      if (!onlyExplainerLength) out.pairsWithActionableViolation++;
+    }
     for (const v of p.shape.violationLabels) {
       const bucket = v.includes('(') ? v.slice(0, v.indexOf('(')) : v.split(':')[0];
       out.violationCounts[bucket] = (out.violationCounts[bucket] || 0) + 1;
@@ -313,8 +344,14 @@ async function main() {
   console.log(`Response words   p10/p50/p90/max: ${agg.responseWordsHist.p10}/${agg.responseWordsHist.p50}/${agg.responseWordsHist.p90}/${agg.responseWordsHist.max}`);
   console.log(`Ratio to cap     p10/p50/p90/max: ${agg.ratioHist.p10.toFixed(2)}/${agg.ratioHist.p50.toFixed(2)}/${agg.ratioHist.p90.toFixed(2)}/${agg.ratioHist.max.toFixed(2)}`);
   console.log(`Multi-part questions: ${agg.multiPartCount} of ${agg.sampled} (${pct(agg.multiPartCount, agg.sampled)})`);
+  console.log(`Explainer questions:  ${agg.explainerCount} of ${agg.sampled} (${pct(agg.explainerCount, agg.sampled)}) — these get the wider 500-word cap`);
   console.log('');
   console.log(`Pairs with ANY shape violation: ${agg.pairsWithAnyViolation} of ${agg.sampled} (${pct(agg.pairsWithAnyViolation, agg.sampled)})`);
+  console.log(`Pairs with ACTIONABLE violation: ${agg.pairsWithActionableViolation} of ${agg.sampled} (${pct(agg.pairsWithActionableViolation, agg.sampled)}) — excludes policy-allowed explainer length_cap`);
+  console.log(`Length cap on non-explainer questions: ${agg.nonExplainerLengthCap} (${pct(agg.nonExplainerLengthCap, agg.sampled - agg.explainerCount)} of non-explainers)`);
+  if (agg.explainerLengthCap > 0) {
+    console.log(`Length cap on explainer questions: ${agg.explainerLengthCap} (${pct(agg.explainerLengthCap, agg.explainerCount)} of explainers — these are policy-allowed but flagged for visibility)`);
+  }
   if (Object.keys(agg.violationCounts).length > 0) {
     console.log('Violation bucket counts:');
     const sorted = Object.entries(agg.violationCounts).sort((a, b) => b[1] - a[1]);

--- a/server/tests/unit/addie/shape-grader.test.ts
+++ b/server/tests/unit/addie/shape-grader.test.ts
@@ -84,11 +84,91 @@ describe('classifyQuestion', () => {
 
   it('scales the cap with question length above 30 words, capped at 400', () => {
     const longQuestion =
-      'I want to walk through the full process of registering my seller agent for compliance monitoring including how to declare specialisms what storyboards run by default and what happens during the certification stage of the process please explain end to end?';
+      'I want to push through the full process of registering my seller agent for compliance monitoring including how to declare specialisms what storyboards run by default and what happens during the certification stage of the process please explain end to end?';
     const q = classifyQuestion(longQuestion);
     expect(q.wordCount).toBeGreaterThan(30);
     expect(q.expectedMaxWords).toBeGreaterThan(200);
     expect(q.expectedMaxWords).toBeLessThanOrEqual(400);
+  });
+});
+
+describe('classifyQuestion — explainer detection', () => {
+  it('flags "what is X?" as explainer with cap floor 500', () => {
+    const q = classifyQuestion('What is AdCP?');
+    expect(q.isExplainer).toBe(true);
+    expect(q.expectedMaxWords).toBe(500);
+  });
+
+  it('flags "how is X different from Y?" as explainer', () => {
+    const q = classifyQuestion('How is agentic advertising different from programmatic?');
+    expect(q.isExplainer).toBe(true);
+    expect(q.expectedMaxWords).toBe(500);
+  });
+
+  it('flags "walk me through X" as explainer', () => {
+    const q = classifyQuestion('Walk me through the brand.json registration flow.');
+    expect(q.isExplainer).toBe(true);
+    expect(q.expectedMaxWords).toBe(500);
+  });
+
+  it('flags "explain X" as explainer', () => {
+    const q = classifyQuestion('Explain the trust model in AdCP.');
+    expect(q.isExplainer).toBe(true);
+    expect(q.expectedMaxWords).toBe(500);
+  });
+
+  it('flags "why does X" as explainer', () => {
+    const q = classifyQuestion('Why does the registry use adagents.json?');
+    expect(q.isExplainer).toBe(true);
+    expect(q.expectedMaxWords).toBe(500);
+  });
+
+  it('does NOT flag transactional questions phrased like explainers', () => {
+    // "what is the cost" → cost is transactional → strict cap stays
+    expect(classifyQuestion('What is the AAO membership cost?').isExplainer).toBe(false);
+    expect(classifyQuestion('What is the deadline for the working group?').isExplainer).toBe(false);
+    expect(classifyQuestion('How is Builder different from Professional for billing?').isExplainer).toBe(false);
+    expect(classifyQuestion('What is my account status?').isExplainer).toBe(false);
+    expect(classifyQuestion('What is the refund policy?').isExplainer).toBe(false);
+  });
+
+  it('keeps the strict cap on transactional-explainer-shaped questions', () => {
+    const q = classifyQuestion('What is the AAO membership cost?');
+    expect(q.expectedMaxWords).toBe(120); // ≤15 words → strict cap
+  });
+
+  it('does NOT flag sharp-question-shaped questions as explainer', () => {
+    expect(classifyQuestion('Is AdCP just surveillance capitalism at AI speed?').isExplainer).toBe(false);
+    expect(classifyQuestion('Can I link my email?').isExplainer).toBe(false);
+    expect(classifyQuestion('Did Scope3 seed AAO?').isExplainer).toBe(false);
+  });
+
+  it('keeps Katie multi-part question as not-explainer (mostly transactional)', () => {
+    const katie =
+      'How does an agent get registered on the AAO registry? Do you have to pay and do you have to be an AAO member?';
+    const q = classifyQuestion(katie);
+    // The first sub-question doesn't match explainer prefix; the whole thing
+    // is transactional in spirit. Must NOT be flagged explainer.
+    expect(q.isExplainer).toBe(false);
+  });
+
+  it('a long explainer question stays an explainer', () => {
+    const q = classifyQuestion(
+      "What is AdCP and how does it work in the context of buyer agents, seller agents, and the registry, and what does it mean for an existing programmatic infrastructure to migrate?",
+    );
+    expect(q.isExplainer).toBe(true);
+    expect(q.expectedMaxWords).toBe(500);
+  });
+
+  it("flags \"what's the difference between X and Y\" as explainer", () => {
+    expect(classifyQuestion("what's the difference between AdCP and ARTF").isExplainer).toBe(true);
+    expect(classifyQuestion("What is the difference between buyer and seller agents?").isExplainer).toBe(true);
+  });
+
+  it('still rejects transactional phrasings of "what is the difference"', () => {
+    expect(
+      classifyQuestion('What is the difference between Builder and Professional billing?').isExplainer,
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #3660. The shape grader now matches the Voice rule's explicit explainer carve-out, so its prevalence numbers become directly actionable.

## What changed

- `classifyQuestion` adds `isExplainer` flag; explainers get a 500-word cap floor.
- Conservative two-tier detection mirrors the Voice rule's structure:
  - **Strong prefixes** (`walk me through`, `explain`) always pass — caller is explicitly asking for depth.
  - **Soft prefixes** (`what is`, `how does`, `how is X different from Y`, `what's the difference`, `why does`, `why do`) pass only when no transactional noun is present. Transactional list mirrors Voice counter-examples: `cost`, `tier`, `billing`, `payment`, `register`, `member`, etc.
- `shape-eval-prod-sample.ts` reports an **actionable** violation rate (excludes policy-allowed explainer length_cap) alongside the all-up rate.
- Bonus: adds `good question` to banned ritual literals after observing it leak in the latest prod sample.

## Why this matters

Pre-fix, the headline "50% length_cap" rate was uninterpretable — most of those were explainers the policy actively wants long. Post-fix, the actionable rate is what we measure variant changes against. The N=100 prod sample now reports:
- Explainer count: 6/100 (~6% of recent prod questions)
- Non-explainer length_cap: 48 (51% of non-explainers)
- Actionable violation rate: 56/100 — sharp questions where Addie wrote essays

Worst offenders post-fix are no longer "What is AdCP?" / "How is X different from Y?". They're now genuine essay-shape on sharp questions (e.g., "Did Scope3 seed AAO?" → 268 words, 2.23x over) — exactly the verbosity Brian was flagging.

## Test plan
- [x] 149 addie unit tests passing (14 new for explainer detection in both directions)
- [x] `npx tsc --noEmit` clean
- [x] Prod sample run on Sonnet with the new detection — confirms explainer detection rate (~6% of corpus) and surfaces the actionable subset

🤖 Generated with [Claude Code](https://claude.com/claude-code)