### PR TITLE
feat(addie): wire person-memory fields into Addie's prompt (#3582 PR2)

### DIFF
--- a/.changeset/memory-prompt-swap.md
+++ b/.changeset/memory-prompt-swap.md
@@ -1,0 +1,4 @@
+---
+---
+
+`formatContextForPrompt` now renders the four memory fields added in #3659 — `Account linked` flag inline in the header, plus `### Preferences`, `### Open membership invites`, `### Recent threads` sections. Empty sections are omitted; `opted_out: true` renders a "do not contact" warning. This is the consumer-side swap that makes the consolidator's new fields actually reach Addie's prompt on every conversation.

--- a/server/src/addie/services/relationship-context.ts
+++ b/server/src/addie/services/relationship-context.ts
@@ -528,6 +528,19 @@ async function loadJourneyContext(workosUserId: string): Promise<JourneyContext 
 // =====================================================
 
 /**
+ * Render a date as a short human-readable relative phrase ("in 5 days",
+ * "3 days ago", "today"). Used in prompt sections so Addie reads dates
+ * the way a human would, not as ISO timestamps.
+ */
+function formatRelativeDate(d: Date): string {
+  const diffMs = d.getTime() - Date.now();
+  const days = Math.round(diffMs / 86400000);
+  if (days === 0) return 'today';
+  if (days > 0) return `in ${days} day${days === 1 ? '' : 's'}`;
+  return `${-days} day${-days === 1 ? '' : 's'} ago`;
+}
+
+/**
  * Format relationship context as markdown for injection into Addie's system prompt.
  * Used by both the engagement planner and the conversation handler.
  */
@@ -555,9 +568,48 @@ export function formatContextForPrompt(ctx: RelationshipContext): string {
     lines.push(`**Member**: ${profile.company.is_member ? 'Yes' : 'No'}`);
   }
 
+  lines.push(`**Account linked**: ${ctx.identity.account_linked ? 'Yes' : 'No'}`);
   lines.push(`**Interactions**: ${r.interaction_count} messages across ${channelList}`);
   lines.push(`**Sentiment**: ${r.sentiment_trend}`);
   lines.push(`**Last contact**: Addie ${lastAddieContact}, them ${lastPersonContact}`);
+
+  // Preferences — render when any signal is non-default. opted_out is
+  // load-bearing (Addie must not message them); contact_preference and
+  // marketing_opt_in shape channel/timing decisions.
+  const prefs = ctx.preferences;
+  const showPrefs =
+    prefs.opted_out ||
+    prefs.contact_preference !== null ||
+    prefs.marketing_opt_in !== null;
+  if (showPrefs) {
+    lines.push('');
+    lines.push('### Preferences');
+    if (prefs.opted_out) {
+      lines.push('- ⚠️ **Opted out** — do not contact');
+    }
+    if (prefs.contact_preference) {
+      lines.push(`- Preferred channel: ${prefs.contact_preference}`);
+    }
+    if (prefs.marketing_opt_in === true) {
+      lines.push('- Marketing opt-in: yes');
+    } else if (prefs.marketing_opt_in === false) {
+      lines.push('- Marketing opt-in: no');
+    }
+  }
+
+  // Open invites — pending or expired membership invites for this email.
+  // High-value signal: Pubx-shaped "they have an invite waiting" cases.
+  if (ctx.invites.length > 0) {
+    lines.push('');
+    lines.push('### Open membership invites');
+    for (const inv of ctx.invites) {
+      const expRel = formatRelativeDate(inv.expires_at);
+      const orgLabel = inv.org_name ?? inv.org_id;
+      lines.push(
+        `- [${inv.status}] ${inv.lookup_key} at ${orgLabel} — expires ${expRel}`
+      );
+    }
+  }
 
   // Capabilities
   const capLines = formatCapabilitiesForPrompt(profile.capabilities);
@@ -582,6 +634,24 @@ export function formatContextForPrompt(ctx: RelationshipContext): string {
         ? msg.content.slice(0, 200) + '...'
         : msg.content;
       lines.push(`**${msg.channel} ${date}** ${msg.role}: ${truncated}`);
+    }
+  }
+
+  // Recent threads — index of past threads with this person across surfaces.
+  // Different from "Recent conversation" above (which shows raw messages);
+  // this surfaces older threads Addie can reference without flooding the
+  // prompt. Placed after capabilities + conversation since this is a soft
+  // index, not a decision-shaping signal.
+  if (ctx.recentThreads.length > 0) {
+    lines.push('');
+    lines.push('### Recent threads');
+    for (const t of ctx.recentThreads) {
+      const lastRel = formatRelativeDate(t.last_message_at);
+      const msgPlural = t.message_count === 1 ? 'message' : 'messages';
+      const titlePart = t.title ? ` "${t.title}"` : '';
+      lines.push(
+        `- [${t.channel}]${titlePart} — ${t.message_count} ${msgPlural}, last ${lastRel}`
+      );
     }
   }
 
@@ -627,9 +697,8 @@ export function formatCapabilitiesForPrompt(caps: MemberCapabilities | null): st
 
   const lines: string[] = [];
 
-  lines.push(caps.account_linked
-    ? '- \u2713 Account linked'
-    : '- \u2717 Account not linked');
+  // Note: account_linked is rendered inline in the header (formatContextForPrompt),
+  // sourced from ctx.identity. Don't duplicate it here.
 
   lines.push(caps.profile_complete
     ? '- \u2713 Profile complete'

--- a/server/tests/unit/format-context-for-prompt.test.ts
+++ b/server/tests/unit/format-context-for-prompt.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatContextForPrompt,
+  type RelationshipContext,
+} from '../../src/addie/services/relationship-context.js';
+import type { PersonRelationship } from '../../src/db/relationship-db.js';
+
+function fixtureRelationship(overrides: Partial<PersonRelationship> = {}): PersonRelationship {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    slack_user_id: 'U0FAKE001',
+    workos_user_id: 'user_fake_001',
+    email: 'tej@example.com',
+    prospect_org_id: null,
+    display_name: 'Tej Test',
+    stage: 'participating',
+    stage_changed_at: new Date('2026-01-01T00:00:00Z'),
+    last_addie_message_at: new Date('2026-04-29T10:00:00Z'),
+    last_person_message_at: new Date('2026-04-29T10:30:00Z'),
+    last_interaction_channel: 'slack',
+    next_contact_after: null,
+    contact_preference: null,
+    slack_dm_channel_id: null,
+    slack_dm_thread_ts: null,
+    sentiment_trend: 'positive',
+    interaction_count: 12,
+    unreplied_outreach_count: 0,
+    opted_out: false,
+    created_at: new Date('2026-01-01T00:00:00Z'),
+    updated_at: new Date('2026-04-29T10:30:00Z'),
+    ...overrides,
+  } as PersonRelationship;
+}
+
+function fixtureContext(overrides: Partial<RelationshipContext> = {}): RelationshipContext {
+  return {
+    relationship: fixtureRelationship(),
+    recentMessages: [],
+    profile: {
+      capabilities: null,
+      company: null,
+    },
+    certification: null,
+    journey: undefined,
+    community: undefined,
+    identity: { account_linked: true, has_slack: true, has_email: true },
+    preferences: {
+      contact_preference: null,
+      opted_out: false,
+      marketing_opt_in: null,
+    },
+    invites: [],
+    recentThreads: [],
+    ...overrides,
+  };
+}
+
+describe('formatContextForPrompt — new memory sections', () => {
+  it('renders Account linked inline in the header', () => {
+    const out = formatContextForPrompt(fixtureContext());
+    expect(out).toContain('**Account linked**: Yes');
+  });
+
+  it('renders Account linked: No when account not linked', () => {
+    const out = formatContextForPrompt(
+      fixtureContext({
+        identity: { account_linked: false, has_slack: true, has_email: true },
+      })
+    );
+    expect(out).toContain('**Account linked**: No');
+  });
+
+  it('omits Preferences section when no signals are set', () => {
+    const out = formatContextForPrompt(fixtureContext());
+    expect(out).not.toContain('### Preferences');
+  });
+
+  it('renders Preferences with opted_out warning when opted out', () => {
+    const out = formatContextForPrompt(
+      fixtureContext({
+        preferences: { contact_preference: null, opted_out: true, marketing_opt_in: null },
+      })
+    );
+    expect(out).toContain('### Preferences');
+    expect(out).toContain('Opted out');
+    expect(out).toContain('do not contact');
+  });
+
+  it('renders contact_preference and marketing_opt_in when set', () => {
+    const out = formatContextForPrompt(
+      fixtureContext({
+        preferences: {
+          contact_preference: 'slack',
+          opted_out: false,
+          marketing_opt_in: true,
+        },
+      })
+    );
+    expect(out).toContain('### Preferences');
+    expect(out).toContain('Preferred channel: slack');
+    expect(out).toContain('Marketing opt-in: yes');
+    expect(out).not.toContain('Opted out');
+  });
+
+  it('omits Open invites section when no invites', () => {
+    const out = formatContextForPrompt(fixtureContext());
+    expect(out).not.toContain('### Open membership invites');
+  });
+
+  it('renders Open invites with status and relative expiry', () => {
+    const out = formatContextForPrompt(
+      fixtureContext({
+        invites: [
+          {
+            org_id: 'org_pubx',
+            org_name: 'Pubx',
+            lookup_key: 'aao_membership_professional',
+            status: 'pending',
+            created_at: new Date(Date.now() - 86400000 * 2),
+            expires_at: new Date(Date.now() + 86400000 * 12),
+            invited_by_user_id: 'user_admin',
+          },
+          {
+            org_id: 'org_pubx',
+            org_name: 'Pubx',
+            lookup_key: 'aao_membership_professional',
+            status: 'expired',
+            created_at: new Date(Date.now() - 86400000 * 30),
+            expires_at: new Date(Date.now() - 86400000 * 3),
+            invited_by_user_id: 'user_admin',
+          },
+        ],
+      })
+    );
+    expect(out).toContain('### Open membership invites');
+    expect(out).toContain('[pending] aao_membership_professional at Pubx — expires in 12 days');
+    expect(out).toContain('[expired] aao_membership_professional at Pubx — expires 3 days ago');
+  });
+
+  it('omits Recent threads section when empty', () => {
+    const out = formatContextForPrompt(fixtureContext());
+    expect(out).not.toContain('### Recent threads');
+  });
+
+  it('renders Recent threads with title, channel, and last_active', () => {
+    const out = formatContextForPrompt(
+      fixtureContext({
+        recentThreads: [
+          {
+            thread_id: 'thr1',
+            channel: 'slack',
+            title: 'colleague invitations',
+            message_count: 4,
+            last_message_at: new Date(Date.now() - 86400000),
+            created_at: new Date(Date.now() - 86400000 * 5),
+          },
+          {
+            thread_id: 'thr2',
+            channel: 'web',
+            title: null,
+            message_count: 1,
+            last_message_at: new Date(Date.now() - 86400000 * 4),
+            created_at: new Date(Date.now() - 86400000 * 4),
+          },
+        ],
+      })
+    );
+    expect(out).toContain('### Recent threads');
+    expect(out).toContain('[slack] "colleague invitations" — 4 messages, last 1 day ago');
+    // Untitled thread renders without the title clause; pluralization respects count.
+    expect(out).toContain('[web] — 1 message, last 4 days ago');
+  });
+
+  it('uses org_id when org_name is null', () => {
+    const out = formatContextForPrompt(
+      fixtureContext({
+        invites: [
+          {
+            org_id: 'org_no_name',
+            org_name: null,
+            lookup_key: 'aao_membership_professional',
+            status: 'pending',
+            created_at: new Date(),
+            expires_at: new Date(Date.now() + 86400000 * 5),
+            invited_by_user_id: 'user_admin',
+          },
+        ],
+      })
+    );
+    expect(out).toContain('aao_membership_professional at org_no_name');
+  });
+
+  it('renders all four new sections together for a fully-populated person', () => {
+    const out = formatContextForPrompt(
+      fixtureContext({
+        preferences: {
+          contact_preference: 'slack',
+          opted_out: false,
+          marketing_opt_in: true,
+        },
+        invites: [
+          {
+            org_id: 'org_pubx',
+            org_name: 'Pubx',
+            lookup_key: 'aao_membership_professional',
+            status: 'pending',
+            created_at: new Date(Date.now() - 86400000),
+            expires_at: new Date(Date.now() + 86400000 * 14),
+            invited_by_user_id: 'user_admin',
+          },
+        ],
+        recentThreads: [
+          {
+            thread_id: 'thr1',
+            channel: 'slack',
+            title: 'colleague invitations',
+            message_count: 4,
+            last_message_at: new Date(Date.now() - 86400000),
+            created_at: new Date(Date.now() - 86400000 * 2),
+          },
+        ],
+      })
+    );
+    expect(out).toContain('**Account linked**: Yes');
+    expect(out).toContain('### Preferences');
+    expect(out).toContain('### Open membership invites');
+    expect(out).toContain('### Recent threads');
+  });
+});


### PR DESCRIPTION
## Summary

PR1 (#3659) extended `RelationshipContext` with four memory fields — `identity`, `preferences`, `invites`, `recentThreads` — but `formatContextForPrompt` only knew the original 6 fields. So the consolidator's work was dark code: every Slack DM through `handler.ts:296` calls `loadRelationshipContext`, but the new fields never reached Addie's prompt.

This PR is the consumer-side swap. Addie's behavior actually changes after this lands.

**Rendered into the prompt:**

- `**Account linked**: Yes/No` inline in the relationship header (sourced from `ctx.identity`, deduped from the older capabilities checklist where it was also rendered)
- `### Preferences` — only when `opted_out` is true, `contact_preference` is set, or `marketing_opt_in` is known. Opted-out renders a "do not contact" warning.
- `### Open membership invites` — only when non-empty; surfaces pending and expired invites with phrases like "expires in 12 days" / "expires 3 days ago"
- `### Recent threads` — only when non-empty; placed below capabilities + conversation since it's a soft index, not a decision-shaping signal

Empty sections are omitted to keep the prompt lean.

## Why this is a separate PR from #3659

Architect's framing: ship the read primitive + diagnostic surfaces first (admin page + Addie tool), validate the shape, then swap the prompt. PR2 is the swap. The two PRs split correctly because:

- PR1 was risk-free (read-only, new code paths)
- PR2 changes Addie's behavior on every conversation, so it deserves its own review surface and rollback path

## Test plan

- [x] `npm run typecheck` clean
- [x] 11 new unit tests in `format-context-for-prompt.test.ts` covering each section's render logic, omission cases, plural-1 edge case, untitled-thread fallback, and a fully-populated person
- [x] Live docker smoke: rendered the prompt through `loadRelationshipContext` + `formatContextForPrompt` against a seeded person; output includes all four sections in the expected positions and rendering

## Expert reviews

- **code-reviewer** caught the real issues:
  - Duplicate `Account linked` rendering (header + capabilities checklist) — dropped from capabilities, kept inline in header where it's always present
  - Section ordering — moved `Recent threads` below capabilities + conversation; decision-shaping signals (Preferences, Open invites) stay near the top
  - `(untitled)` string was noise — render now skips the title clause entirely when null
  - `1 messages` pluralization bug — fixed
  - Token budget for `recentThreads` flagged as a follow-up: gate by surface (proactive outreach vs reactive reply) once we have live data on impact. PR3 territory.

## Companion / chain

Closes the consumer side of #3582:
- #3605 — Invite lifecycle events (foundation, merged)
- #3625 — Admin Invitations panel (merged)
- #3644 — Addie invite tools (merged)
- #3651 — Persist inbound text (merged)
- #3659 — Memory consolidator + admin view + Addie tool (merged)
- **This PR** — prompt swap (consumer)
- **Next:** memory eval suite + live-thread sampling to measure whether Addie's behavior actually improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)