### PR TITLE
docs(creative-channels): fix url_type "tracker" → "tracker_pixel" (#2986)

### DIFF
--- a/.changeset/fix-url-type-tracker-pixel-channel-docs.md
+++ b/.changeset/fix-url-type-tracker-pixel-channel-docs.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs(creative-channels): replace invalid `"url_type": "tracker"` with `"url_type": "tracker_pixel"` in display, audio, carousels, and DOOH channel docs to match the `url-asset-type.json` enum (`clickthrough` / `tracker_pixel` / `tracker_script`). Addresses adcp#2986 step 1 (3.0.x docs cleanup).

--- a/docs/creative/channels/audio.mdx
+++ b/docs/creative/channels/audio.mdx
@@ -176,7 +176,7 @@ Multi-segment audio assembled dynamically:
     },
     "impression_tracker": {
       "asset_type": "url",
-      "url_type": "tracker",
+      "url_type": "tracker_pixel",
       "url": "https://track.brand.com/imp?buy={MEDIA_BUY_ID}&station={APP_BUNDLE}&cb={CACHEBUSTER}"
     },
     "landing_url": {
@@ -199,7 +199,7 @@ Multi-segment audio assembled dynamically:
   "assets": {
     "vast_url": {
       "asset_type": "url",
-      "url_type": "tracker",
+      "url_type": "tracker_pixel",
       "url": "https://ad-server.brand.com/audio-vast?campaign={MEDIA_BUY_ID}&cb={CACHEBUSTER}"
     }
   }

--- a/docs/creative/channels/carousels.mdx
+++ b/docs/creative/channels/carousels.mdx
@@ -670,7 +670,7 @@ https://track.brand.com/view?buy={MEDIA_BUY_ID}&item={CAROUSEL_INDEX}&total={CAR
     },
     "impression_tracker": {
       "asset_type": "url",
-      "url_type": "tracker",
+      "url_type": "tracker_pixel",
       "url": "https://track.brand.com/imp?buy={MEDIA_BUY_ID}&cb={CACHEBUSTER}"
     }
   }

--- a/docs/creative/channels/display.mdx
+++ b/docs/creative/channels/display.mdx
@@ -213,7 +213,7 @@ Display formats in AdCP include:
     },
     "impression_tracker": {
       "asset_type": "url",
-      "url_type": "tracker",
+      "url_type": "tracker_pixel",
       "url": "https://track.brand.com/imp?buy={MEDIA_BUY_ID}&cb={CACHEBUSTER}"
     }
   }

--- a/docs/creative/channels/dooh.mdx
+++ b/docs/creative/channels/dooh.mdx
@@ -43,7 +43,7 @@ DOOH formats differ from other digital formats:
     {
       "asset_id": "impression_tracker",
       "asset_type": "url",
-      "url_type": "tracker",
+      "url_type": "tracker_pixel",
       "required": true
     }
   ]
@@ -75,7 +75,7 @@ DOOH formats differ from other digital formats:
     {
       "asset_id": "impression_tracker",
       "asset_type": "url",
-      "url_type": "tracker",
+      "url_type": "tracker_pixel",
       "required": true
     }
   ]
@@ -109,7 +109,7 @@ DOOH formats differ from other digital formats:
     {
       "asset_id": "impression_tracker",
       "asset_type": "url",
-      "url_type": "tracker",
+      "url_type": "tracker_pixel",
       "required": true
     }
   ]
@@ -124,7 +124,7 @@ DOOH formats use impression trackers (often called "proof-of-play") to verify wh
 {
   "asset_id": "impression_tracker",
   "asset_type": "url",
-  "url_type": "tracker",
+  "url_type": "tracker_pixel",
   "required": true,
   "requirements": {
     "required_macros": [
@@ -158,7 +158,7 @@ The mechanics are identical to digital impression tracking - it's just a URL tha
     },
     "impression_tracker": {
       "asset_type": "url",
-      "url_type": "tracker",
+      "url_type": "tracker_pixel",
       "url": "https://track.brand.com/pop?buy={MEDIA_BUY_ID}&screen={SCREEN_ID}&venue={VENUE_TYPE}&ts={PLAY_TIMESTAMP}&lat={VENUE_LAT}&long={VENUE_LONG}"
     }
   }
@@ -184,7 +184,7 @@ The mechanics are identical to digital impression tracking - it's just a URL tha
     },
     "impression_tracker": {
       "asset_type": "url",
-      "url_type": "tracker",
+      "url_type": "tracker_pixel",
       "url": "https://track.brand.com/pop?buy={MEDIA_BUY_ID}&screen={SCREEN_ID}&ts={PLAY_TIMESTAMP}"
     }
   }


### PR DESCRIPTION
## Summary

Replaces all 10 occurrences of the invalid `"url_type": "tracker"` value across the display, audio, carousels, and DOOH channel docs with `"url_type": "tracker_pixel"` to match the [`url-asset-type.json`](static/schemas/source/enums/url-asset-type.json) enum (`clickthrough` / `tracker_pixel` / `tracker_script`).

Step 1 of the three-step rollout proposed by Nastassia Fulconis on #2986:

1. **3.0.x docs cleanup** ← this PR
2. **3.1**: SHOULD on `url_type` + role-based fallback when format declared `url-asset-requirements.role` + clarify mechanism-vs-purpose distinction (separate PR)
3. **4.0**: required (separate PR; depends on #2 landing first)

## What changed

| File | Occurrences |
|---|---|
| `docs/creative/channels/audio.mdx` | 2 |
| `docs/creative/channels/carousels.mdx` | 1 |
| `docs/creative/channels/display.mdx` | 1 |
| `docs/creative/channels/dooh.mdx` | 6 |

All sites are impression trackers or a VAST URL — `tracker_pixel` matches the original docs intent. The VAST URL (`audio.mdx:202`) is stylistically iffy — it's pointing to ad-server XML, not a 1×1 pixel — but that's a separate design question covered by RFC #2915 (`vast_tracker` / `daast_tracker` asset types). Not in scope here.

## Out of scope (intentional)

- `dist/docs/3.0.2/creative/channels/*` still carries the old value. The 3.0.2 snapshot was taken on 2026-04-29 (#3617). Backporting to a frozen release snapshot is a separate decision; this PR fixes the live source so the next snapshot picks up the corrected value.
- Schema work for `url_type` requirement + `role` reconciliation (3.1 / 4.0 tracks) is separate.

## Test plan

- [x] No remaining `"url_type": "tracker"` in `docs/`
- [x] All replacements use the canonical enum value `tracker_pixel`
- [x] Precommit hooks pass (vitest unit, dynamic imports, typecheck)
- [ ] Mintlify renders the channel docs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)