### PR TITLE
feat(escalations): operational escalations with dedup_key + slack not_in_channel

### DIFF
--- a/.changeset/operational-escalation-dedup.md
+++ b/.changeset/operational-escalation-dedup.md
@@ -1,0 +1,10 @@
+---
+---
+
+Add operational escalations with deduplication, and route Slack `not_in_channel` to that path so the signal stays visible without paging.
+
+**Schema (migration 459):** new `dedup_key TEXT` column on `addie_escalations`, plus a partial unique index on `(dedup_key) WHERE dedup_key IS NOT NULL AND status IN ('open','acknowledged','in_progress')`. Lets the same key be reused once the prior escalation is resolved.
+
+**`createEscalation`:** accepts an optional `dedup_key`. If an open/acknowledged/in-progress escalation already exists with that key, returns the existing row instead of inserting. Falls back through the partial unique index if a race causes a 23505.
+
+**`inviteToChannel` (Slack):** when Slack returns `not_in_channel`, fire-and-forget creates an escalation with `category='needs_human_action'`, `priority='low'`, `dedup_key='slack:not_in_channel:${channelId}'`. The bot needs to be invited (or the calling code needs to stop) — actionable, but not page-worthy. Other expected Slack codes (`channel_not_found`, `is_archived`, `user_disabled`, etc.) stay at `warn` only — they're user-side, not operator-side.

--- a/server/src/db/escalation-db.ts
+++ b/server/src/db/escalation-db.ts
@@ -57,6 +57,10 @@ export interface Escalation {
   github_issue_url: string | null;
   github_issue_number: number | null;
   github_issue_repo: string | null;
+  /** Optional collapse key for operational escalations — repeat occurrences
+   *  with the same key are folded into the existing open escalation rather
+   *  than creating a new one. See `createEscalation` and migration 459. */
+  dedup_key: string | null;
   created_at: Date;
   updated_at: Date;
 }
@@ -76,6 +80,10 @@ export interface EscalationInput {
   addie_context?: string;
   perspective_id?: string;
   perspective_slug?: string;
+  /** Collapse key for operational escalations. If an open / acknowledged /
+   *  in-progress escalation already exists with the same key, the insert
+   *  is a no-op and `createEscalation` returns the existing row. */
+  dedup_key?: string;
 }
 
 export interface EscalationFilters {
@@ -88,35 +96,67 @@ export interface EscalationFilters {
 // ============== Escalation Operations ==============
 
 /**
- * Create a new escalation
+ * Create a new escalation. If `dedup_key` is set and an open, acknowledged,
+ * or in-progress escalation already exists with the same key, returns that
+ * existing row instead of creating a new one. Migration 459 backs this with
+ * a partial unique index, so concurrent inserts from a race are caught at
+ * the DB layer too.
  */
 export async function createEscalation(input: EscalationInput): Promise<Escalation> {
+  if (input.dedup_key) {
+    const existing = await readOpenEscalationByDedupKey(input.dedup_key);
+    if (existing) return existing;
+  }
+
+  try {
+    const result = await query<Escalation>(
+      `INSERT INTO addie_escalations (
+        thread_id, message_id, slack_user_id, workos_user_id, user_display_name,
+        user_email, user_slack_handle,
+        category, priority, summary, original_request, addie_context,
+        perspective_id, perspective_slug, dedup_key
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+      RETURNING *`,
+      [
+        input.thread_id || null,
+        input.message_id || null,
+        input.slack_user_id || null,
+        input.workos_user_id || null,
+        input.user_display_name || null,
+        input.user_email || null,
+        input.user_slack_handle || null,
+        input.category,
+        input.priority || 'normal',
+        input.summary,
+        input.original_request || null,
+        input.addie_context || null,
+        input.perspective_id || null,
+        input.perspective_slug || null,
+        input.dedup_key || null,
+      ]
+    );
+    return result.rows[0];
+  } catch (err) {
+    // Race: another caller inserted the same dedup_key between our SELECT
+    // and INSERT. The partial unique index from migration 459 raised 23505;
+    // re-read and return the row that won.
+    if (input.dedup_key && (err as { code?: string })?.code === '23505') {
+      const existing = await readOpenEscalationByDedupKey(input.dedup_key);
+      if (existing) return existing;
+    }
+    throw err;
+  }
+}
+
+async function readOpenEscalationByDedupKey(dedupKey: string): Promise<Escalation | null> {
   const result = await query<Escalation>(
-    `INSERT INTO addie_escalations (
-      thread_id, message_id, slack_user_id, workos_user_id, user_display_name,
-      user_email, user_slack_handle,
-      category, priority, summary, original_request, addie_context,
-      perspective_id, perspective_slug
-    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-    RETURNING *`,
-    [
-      input.thread_id || null,
-      input.message_id || null,
-      input.slack_user_id || null,
-      input.workos_user_id || null,
-      input.user_display_name || null,
-      input.user_email || null,
-      input.user_slack_handle || null,
-      input.category,
-      input.priority || 'normal',
-      input.summary,
-      input.original_request || null,
-      input.addie_context || null,
-      input.perspective_id || null,
-      input.perspective_slug || null,
-    ]
+    `SELECT * FROM addie_escalations
+     WHERE dedup_key = $1
+       AND status IN ('open', 'acknowledged', 'in_progress')
+     LIMIT 1`,
+    [dedupKey],
   );
-  return result.rows[0];
+  return result.rows[0] ?? null;
 }
 
 /**

--- a/server/src/db/migrations/459_addie_escalation_dedup_key.sql
+++ b/server/src/db/migrations/459_addie_escalation_dedup_key.sql
@@ -1,0 +1,12 @@
+-- Add dedup_key to addie_escalations for operational escalations
+-- (e.g., Slack 'not_in_channel' for channel X) so we don't create a new
+-- escalation for every occurrence. The partial unique index lets the
+-- same key be used again once the prior escalation is resolved/closed.
+
+ALTER TABLE addie_escalations
+  ADD COLUMN dedup_key TEXT;
+
+CREATE UNIQUE INDEX idx_escalations_dedup_open
+  ON addie_escalations (dedup_key)
+  WHERE dedup_key IS NOT NULL
+    AND status IN ('open', 'acknowledged', 'in_progress');

--- a/server/src/slack/client.ts
+++ b/server/src/slack/client.ts
@@ -8,6 +8,7 @@
 import { createLogger } from '../logger.js';
 import { SlackDatabase } from '../db/slack-db.js';
 import { WorkingGroupDatabase } from '../db/working-group-db.js';
+import { createEscalation } from '../db/escalation-db.js';
 import type {
   SlackUser,
   SlackChannel,
@@ -1142,6 +1143,27 @@ export async function inviteToChannel(
       { err: error instanceof Error ? error : new Error(errorMessage), channelId },
       'Failed to invite users to channel',
     );
+
+    // not_in_channel is actionable — someone has to invite the bot or fix
+    // the calling code. Create a deduplicated operational escalation so the
+    // signal stays in the queue without paging anyone. Other expected codes
+    // are user-side (restricted account, archived channel) and don't need
+    // operator action. Fire-and-forget so a DB blip doesn't break Slack flow.
+    if (errorMessage.includes('not_in_channel')) {
+      void createEscalation({
+        category: 'needs_human_action',
+        priority: 'low',
+        summary: `Slack: bot is not in channel \`${channelId}\` and was asked to invite ${userIds.length} user(s) there. Either invite the bot to the channel or fix the calling code so it stops trying.`,
+        addie_context: `Slack API error: not_in_channel\nchannelId: ${channelId}\nuserIds: ${userIds.join(', ')}`,
+        dedup_key: `slack:not_in_channel:${channelId}`,
+      }).catch((escalationErr) => {
+        logger.warn(
+          { err: escalationErr, channelId },
+          'Failed to record operational escalation for not_in_channel',
+        );
+      });
+    }
+
     return { ok: false, error: errorMessage };
   }
 }

--- a/server/tests/integration/escalation-dedup.test.ts
+++ b/server/tests/integration/escalation-dedup.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Integration test for the dedup_key behavior added in migration 459.
+ *
+ * Operational escalations (e.g. "Slack bot is not in channel X") need to
+ * collapse repeat occurrences into a single open escalation rather than
+ * filling the queue with a new row per Slack call. Same dedup_key + open
+ * status returns the existing row; once that escalation is resolved the
+ * key is re-usable.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import type { Pool } from 'pg';
+import { initializeDatabase, closeDatabase, query } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { createEscalation } from '../../src/db/escalation-db.js';
+
+const SUFFIX = `${process.pid}-${Date.now()}`;
+const DEDUP_KEY = `test:slack:not_in_channel:C-${SUFFIX}`;
+
+describe('createEscalation dedup_key behavior', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString:
+        process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  }, 60_000);
+
+  afterAll(async () => {
+    await pool.query('DELETE FROM addie_escalations WHERE dedup_key LIKE $1', [
+      `test:%${SUFFIX}`,
+    ]);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await pool.query('DELETE FROM addie_escalations WHERE dedup_key LIKE $1', [
+      `test:%${SUFFIX}`,
+    ]);
+  });
+
+  it('first call with a fresh dedup_key creates a new escalation', async () => {
+    const e = await createEscalation({
+      category: 'needs_human_action',
+      summary: `Slack bot needs invite to channel ${SUFFIX}`,
+      dedup_key: DEDUP_KEY,
+    });
+    expect(e.id).toBeGreaterThan(0);
+    expect(e.dedup_key).toBe(DEDUP_KEY);
+    expect(e.status).toBe('open');
+  });
+
+  it('second call with the same dedup_key returns the existing open escalation', async () => {
+    const first = await createEscalation({
+      category: 'needs_human_action',
+      summary: 'first summary',
+      dedup_key: DEDUP_KEY,
+    });
+
+    const second = await createEscalation({
+      category: 'needs_human_action',
+      summary: 'second summary (should be ignored)',
+      dedup_key: DEDUP_KEY,
+    });
+
+    expect(second.id).toBe(first.id);
+    // Existing summary preserved — repeat callers don't get to overwrite.
+    expect(second.summary).toBe('first summary');
+
+    const rows = await query<{ count: string }>(
+      'SELECT COUNT(*)::text AS count FROM addie_escalations WHERE dedup_key = $1',
+      [DEDUP_KEY],
+    );
+    expect(rows.rows[0].count).toBe('1');
+  });
+
+  it('reuses dedup_key once the prior escalation is resolved', async () => {
+    const first = await createEscalation({
+      category: 'needs_human_action',
+      summary: 'first',
+      dedup_key: DEDUP_KEY,
+    });
+
+    await pool.query(
+      `UPDATE addie_escalations SET status = 'resolved', resolved_at = NOW() WHERE id = $1`,
+      [first.id],
+    );
+
+    const second = await createEscalation({
+      category: 'needs_human_action',
+      summary: 'second after resolution',
+      dedup_key: DEDUP_KEY,
+    });
+
+    expect(second.id).not.toBe(first.id);
+    expect(second.summary).toBe('second after resolution');
+    expect(second.status).toBe('open');
+  });
+
+  it('inserts without dedup_key behave normally — multiple rows allowed', async () => {
+    const a = await createEscalation({
+      category: 'needs_human_action',
+      summary: `no-dedup test A ${SUFFIX}`,
+    });
+    const b = await createEscalation({
+      category: 'needs_human_action',
+      summary: `no-dedup test B ${SUFFIX}`,
+    });
+    expect(a.id).not.toBe(b.id);
+    expect(a.dedup_key).toBeNull();
+    expect(b.dedup_key).toBeNull();
+
+    // Cleanup these rows since they don't match the SUFFIX dedup_key cleanup
+    await pool.query('DELETE FROM addie_escalations WHERE id IN ($1, $2)', [
+      a.id,
+      b.id,
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an operational-escalation path so actionable-but-not-page-worthy signals stay visible in the escalation queue without firing `:rotating_light: System error` alerts.

Closes the gap from #3664: Slack `not_in_channel` was previously a `logger.error` (paging) → I downgraded it to `warn` (silent), but the right answer is **warn + deduplicated escalation** because the bot does need to be invited (or the calling code needs to stop).

## What's in here

**Schema (migration 459):**
- `ALTER TABLE addie_escalations ADD COLUMN dedup_key TEXT`
- Partial unique index on `dedup_key` where `status IN ('open','acknowledged','in_progress')` — same key reusable once the prior escalation closes.

**`createEscalation`:**
- Optional `dedup_key`. SELECT-before-INSERT returns the existing row if one is open. Try/catch on 23505 handles the concurrent-insert race.

**`inviteToChannel` (slack/client.ts):**
- On `not_in_channel`: warn log (no page) + fire-and-forget `createEscalation` with `category='needs_human_action'`, `priority='low'`, `dedup_key='slack:not_in_channel:${channelId}'`.
- Caller still gets `{ ok: false, error }`. DB blip in escalation creation does not affect Slack flow.
- Other expected Slack codes (`channel_not_found`, `is_archived`, `user_disabled`, etc.) stay at warn-only — those are user-side, not operator-side.

## Why escalations and not just warn

Three categories of failure now have clear semantics:
- **`error`** — unexpected; pages on-call via `#aao-errors` Slack alert.
- **`warn` (no escalation)** — third-party state we accept and shrug at (deactivated user, archived channel).
- **`warn` + escalation** — actionable; needs human action but not on-call. Lands in the existing escalation queue/admin UI for batch triage.

## Test plan

- [x] New integration test (`escalation-dedup.test.ts`) — 4 cases: fresh key inserts, repeat key returns existing row, key reuse after resolve, no-dedup_key behaves normally
- [x] All 31 existing escalation tests pass
- [x] Pre-commit (`test:unit + test-dynamic-imports + typecheck`) — green
- [ ] Verify in `#aao-errors` after deploy: no more `not_in_channel` system-error alerts; escalations appear in admin queue when the bot hits the condition

🤖 Generated with [Claude Code](https://claude.com/claude-code)