### PR TITLE
docs(3.0.x-backport): url_type tracker → tracker_pixel (#2986, #3670)

### DIFF
--- a/.changeset/fix-url-type-tracker-pixel-channel-docs.md
+++ b/.changeset/fix-url-type-tracker-pixel-channel-docs.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+docs(creative-channels): replace invalid `"url_type": "tracker"` with `"url_type": "tracker_pixel"` in display, audio, carousels, and DOOH channel docs to match the `url-asset-type.json` enum (`clickthrough` / `tracker_pixel` / `tracker_script`). Addresses adcp#2986 step 1 (3.0.x docs cleanup). Wire format unchanged — the published schema enum already excluded `"tracker"`, so the channel docs were emitting an invalid value sellers could not validate against.

--- a/docs/creative/channels/audio.mdx
+++ b/docs/creative/channels/audio.mdx
@@ -176,7 +176,7 @@ Multi-segment audio assembled dynamically:
     },
     "impression_tracker": {
       "asset_type": "url",
-      "url_type": "tracker",
+      "url_type": "tracker_pixel",
       "url": "https://track.brand.com/imp?buy={MEDIA_BUY_ID}&station={APP_BUNDLE}&cb={CACHEBUSTER}"
     },
     "landing_url": {
@@ -199,7 +199,7 @@ Multi-segment audio assembled dynamically:
   "assets": {
     "vast_url": {
       "asset_type": "url",
-      "url_type": "tracker",
+      "url_type": "tracker_pixel",
       "url": "https://ad-server.brand.com/audio-vast?campaign={MEDIA_BUY_ID}&cb={CACHEBUSTER}"
     }
   }

--- a/docs/creative/channels/carousels.mdx
+++ b/docs/creative/channels/carousels.mdx
@@ -670,7 +670,7 @@ https://track.brand.com/view?buy={MEDIA_BUY_ID}&item={CAROUSEL_INDEX}&total={CAR
     },
     "impression_tracker": {
       "asset_type": "url",
-      "url_type": "tracker",
+      "url_type": "tracker_pixel",
       "url": "https://track.brand.com/imp?buy={MEDIA_BUY_ID}&cb={CACHEBUSTER}"
     }
   }

--- a/docs/creative/channels/display.mdx
+++ b/docs/creative/channels/display.mdx
@@ -213,7 +213,7 @@ Display formats in AdCP include:
     },
     "impression_tracker": {
       "asset_type": "url",
-      "url_type": "tracker",
+      "url_type": "tracker_pixel",
       "url": "https://track.brand.com/imp?buy={MEDIA_BUY_ID}&cb={CACHEBUSTER}"
     }
   }

--- a/docs/creative/channels/dooh.mdx
+++ b/docs/creative/channels/dooh.mdx
@@ -43,7 +43,7 @@ DOOH formats differ from other digital formats:
     {
       "asset_id": "impression_tracker",
       "asset_type": "url",
-      "url_type": "tracker",
+      "url_type": "tracker_pixel",
       "required": true
     }
   ]
@@ -75,7 +75,7 @@ DOOH formats differ from other digital formats:
     {
       "asset_id": "impression_tracker",
       "asset_type": "url",
-      "url_type": "tracker",
+      "url_type": "tracker_pixel",
       "required": true
     }
   ]
@@ -109,7 +109,7 @@ DOOH formats differ from other digital formats:
     {
       "asset_id": "impression_tracker",
       "asset_type": "url",
-      "url_type": "tracker",
+      "url_type": "tracker_pixel",
       "required": true
     }
   ]
@@ -124,7 +124,7 @@ DOOH formats use impression trackers (often called "proof-of-play") to verify wh
 {
   "asset_id": "impression_tracker",
   "asset_type": "url",
-  "url_type": "tracker",
+  "url_type": "tracker_pixel",
   "required": true,
   "requirements": {
     "required_macros": [
@@ -158,7 +158,7 @@ The mechanics are identical to digital impression tracking - it's just a URL tha
     },
     "impression_tracker": {
       "asset_type": "url",
-      "url_type": "tracker",
+      "url_type": "tracker_pixel",
       "url": "https://track.brand.com/pop?buy={MEDIA_BUY_ID}&screen={SCREEN_ID}&venue={VENUE_TYPE}&ts={PLAY_TIMESTAMP}&lat={VENUE_LAT}&long={VENUE_LONG}"
     }
   }
@@ -184,7 +184,7 @@ The mechanics are identical to digital impression tracking - it's just a URL tha
     },
     "impression_tracker": {
       "asset_type": "url",
-      "url_type": "tracker",
+      "url_type": "tracker_pixel",
       "url": "https://track.brand.com/pop?buy={MEDIA_BUY_ID}&screen={SCREEN_ID}&ts={PLAY_TIMESTAMP}"
     }
   }


### PR DESCRIPTION
## Summary

Cherry-picks #3670 (url_type docs fix) onto the \`3.0.x\` maintenance branch so the published 3.0.x docs reflect the canonical \`url-asset-type.json\` enum (\`clickthrough\` / \`tracker_pixel\` / \`tracker_script\`).

The 3.0.0 / 3.0.1 / 3.0.2 published docs at https://adcontextprotocol.org/docs/creative/channels/{audio,carousels,display,dooh} all emit \`"url_type": "tracker"\` — a value that has never existed in the schema enum. Sellers following the published docs produce manifests that fail validation. Aggregating with the patch changeset for a 3.0.3 cut.

## Changeset

\`patch\` bump on \`adcontextprotocol\` (matches the pattern from #3608's cherry-pick of #3461 + #3462 to 3.0.x).

## Wire format

**Unchanged.** The schema enum already excluded \`"tracker"\`; only the docs were drifted.

## Test plan

- [x] Cherry-pick clean from #3670's commit on main
- [x] Precommit hooks pass (vitest unit, dynamic imports, typecheck)
- [x] No remaining \`"url_type": "tracker"\` under \`docs/creative/channels/\`
- [ ] CI green
- [ ] When 3.0.3 cuts, published 3.0.3 docs render the corrected value

## Related

- Source PR on \`main\`: #3670 (this is its 3.0.x sibling)
- Issue: #2986 (Nastassia Fulconis's three-step rollout — this is step 1 for the 3.0.x maintenance line)
- Step 2 (3.1 SHOULD + role-based fallback): #3671

🤖 Generated with [Claude Code](https://claude.com/claude-code)