### PR TITLE
feat(admin): multi-tool filter on /admin/addie threads list

### DIFF
--- a/.changeset/threads-multi-tool-filter.md
+++ b/.changeset/threads-multi-tool-filter.md
@@ -1,0 +1,4 @@
+---
+---
+
+`/admin/addie` threads filter now accepts a comma-separated list of tools (`?tool=A,B,C`) — backed by a Postgres array-overlap query rather than a single `= ANY` lookup. Adds a "Person tools" preset button on the threads page that filters to threads that called any person-shaped Addie tool (`lookup_person`, `get_person_memory`, `get_account`, `diagnose_signin_block`, `list_invites_for_org`, `resend_invite`, `revoke_invite`). Useful for sampling Addie's reasoning over individual people in one click instead of cycling through seven separate filters. Single-tool form still works.

--- a/server/public/admin-addie.html
+++ b/server/public/admin-addie.html
@@ -1562,6 +1562,7 @@
           <select id="threads-tool-filter" style="min-width: 150px; padding: var(--space-2); border: var(--border-1) solid var(--color-gray-300); border-radius: var(--radius);">
             <option value="">All Tools</option>
           </select>
+          <button class="btn btn-secondary" onclick="filterPersonTools()" title="Filter to threads that called any person-shaped tool">Person tools</button>
           <button id="threads-search-btn" class="btn btn-primary" onclick="loadThreads()">Search</button>
           <button class="btn btn-secondary" onclick="clearThreadsSearch()">Clear</button>
         </div>
@@ -2434,7 +2435,38 @@
     function clearThreadsSearch() {
       document.getElementById('threads-search-text').value = '';
       document.getElementById('threads-search-user').value = '';
-      document.getElementById('threads-tool-filter').value = '';
+      const tf = document.getElementById('threads-tool-filter');
+      // Drop any preset option we may have injected and reset to All Tools
+      const preset = tf.querySelector('option[data-preset="person"]');
+      if (preset) preset.remove();
+      tf.value = '';
+      loadThreads();
+    }
+
+    // Filter threads to those that called any person-shaped Addie tool. The
+    // route accepts a comma-separated list as ?tool=A,B,C — we inject the
+    // composite as a synthetic option on the existing dropdown so the rest
+    // of the search flow doesn't need to know about presets.
+    const PERSON_TOOLS = [
+      'lookup_person',
+      'get_person_memory',
+      'get_account',
+      'diagnose_signin_block',
+      'list_invites_for_org',
+      'resend_invite',
+      'revoke_invite',
+    ];
+    function filterPersonTools() {
+      const tf = document.getElementById('threads-tool-filter');
+      let preset = tf.querySelector('option[data-preset="person"]');
+      if (!preset) {
+        preset = document.createElement('option');
+        preset.dataset.preset = 'person';
+        preset.textContent = 'Person tools (preset)';
+        preset.value = PERSON_TOOLS.join(',');
+        tf.insertBefore(preset, tf.firstChild?.nextSibling || null);
+      }
+      tf.value = preset.value;
       loadThreads();
     }
 

--- a/server/src/addie/thread-service.ts
+++ b/server/src/addie/thread-service.ts
@@ -261,7 +261,10 @@ export interface ThreadListFilters {
   offset?: number;
   // Search filters
   search_text?: string;
+  /** Single tool name to filter by. For multi-tool, use tool_names. */
   tool_name?: string;
+  /** Filter to threads that called any of these tools. Wins over tool_name when both set. */
+  tool_names?: string[];
   user_search?: string;
 }
 
@@ -654,7 +657,7 @@ export class ThreadService {
     let paramIndex = 1;
 
     // Determine if we need to join with messages table for search/tool filtering
-    const needsMessageJoin = !!(filters.search_text || filters.tool_name);
+    const needsMessageJoin = !!(filters.search_text || filters.tool_name || (filters.tool_names && filters.tool_names.length > 0));
 
     // user_search matches across all identifiers an admin might describe a
     // person by — full name, Slack handle, real name, WorkOS first/last
@@ -727,8 +730,13 @@ export class ThreadService {
       params.push(`%${filters.search_text}%`);
     }
 
-    // Tool name filter (requires join, searches tools_used array)
-    if (filters.tool_name) {
+    // Tool name filter (requires join, searches tools_used array). When
+    // multiple tools are supplied, match threads that used any of them
+    // (array overlap). Single-tool form retained for backward compatibility.
+    if (filters.tool_names && filters.tool_names.length > 0) {
+      conditions.push(`m.tools_used && $${paramIndex++}::text[]`);
+      params.push(filters.tool_names);
+    } else if (filters.tool_name) {
       conditions.push(`$${paramIndex++} = ANY(m.tools_used)`);
       params.push(filters.tool_name);
     }

--- a/server/src/routes/addie-admin.ts
+++ b/server/src/routes/addie-admin.ts
@@ -428,6 +428,19 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
         search, tool, user_search
       } = req.query;
 
+      // ?tool=A or ?tool=A,B,C — single string, split into list when commas present.
+      // Cap each entry at 100 chars and the whole list at 20 entries to bound query cost.
+      let toolName: string | undefined;
+      let toolNames: string[] | undefined;
+      if (typeof tool === 'string' && tool.length > 0 && tool.length <= 2000) {
+        const parts = tool.split(',').map((s) => s.trim()).filter((s) => s.length > 0 && s.length <= 100);
+        if (parts.length > 1) {
+          toolNames = parts.slice(0, 20);
+        } else if (parts.length === 1) {
+          toolName = parts[0];
+        }
+      }
+
       const threads = await threadService.listThreads({
         channel: channel as ThreadChannel | undefined,
         flagged_only: flagged_only === "true",
@@ -440,7 +453,8 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
         offset: clampOffset(offset),
         // Search filters (with length limits to prevent performance issues)
         search_text: typeof search === 'string' && search.length <= 500 ? search : undefined,
-        tool_name: typeof tool === 'string' && tool.length <= 100 ? tool : undefined,
+        tool_name: toolName,
+        tool_names: toolNames,
         user_search: typeof user_search === 'string' && user_search.length <= 200 ? user_search : undefined,
       });
 


### PR DESCRIPTION
## Summary

`/admin/addie` threads filter now accepts a comma-separated list of tools and a "Person tools" preset button — small UX addition for sampling Addie's reasoning over a class of tools without cycling through seven separate filter passes.

- `?tool=A,B,C` parses into a list, matched via Postgres `tools_used && $1::text[]` (array overlap)
- Single-tool form (`?tool=A`) unchanged for backward compatibility
- New "Person tools" button on the page injects a synthetic option pre-filled with the seven person-shaped tools (`lookup_person`, `get_person_memory`, `get_account`, `diagnose_signin_block`, `list_invites_for_org`, `resend_invite`, `revoke_invite`)

## Why

Direct follow-on from the #3582 memory chain. After PR2 (#3667) wired the consolidator into Addie's prompt, the next step is reading live threads to validate whether the memory work changed Addie's behavior. The existing tool filter was single-select; sampling required either seven API passes or building a separate "sampling" admin page. This is a smaller, more honest fix.

## Test plan

- [x] `npm run typecheck` clean
- [x] Live docker test: seeded four threads with different `tools_used` arrays:
  - `?tool=lookup_person` → 1 result ✓
  - `?tool=lookup_person,get_account` → 2 results ✓
  - `?tool=send_message,lookup_person` → 2 results ✓
  - `?tool=missing_tool` → 0 results ✓
  - `?tool=` (empty) → all threads, no filter ✓

## Bounds

- Each comma-separated entry capped at 100 chars; list capped at 20 entries
- Total `tool` query string capped at 2000 chars
- Empty / whitespace-only entries filtered out

🤖 Generated with [Claude Code](https://claude.com/claude-code)