### PR TITLE
feat(addie): orgMemberships in person memory — multi-org disambiguation (#3582 PR3)

### DIFF
--- a/.changeset/org-memberships-in-memory.md
+++ b/.changeset/org-memberships-in-memory.md
@@ -1,0 +1,4 @@
+---
+---
+
+`RelationshipContext` now includes `orgMemberships: OrgMembership[]` — every WorkOS org a person belongs to with role, seat_type, provisioning_source, joined_at, and is_paying_member. The existing `profile.company` field is one (LIMIT 1) and conflated "the org we picked" with "the org being asked about." The new field answers "is this person in org X?" cleanly. Surfaced in Addie's prompt (### Org memberships section, rendered when person belongs to multiple orgs OR has admin role / community-only seat / verified-domain provisioning), in the admin /admin/relationships/:personId page, and in the get_person_memory tool output. Live-thread sampling found this exact gap on the Triton Digital and Affinity Answers escalations where Addie conflated Slack-presence with WorkOS org membership.

--- a/server/public/admin-relationship-detail.html
+++ b/server/public/admin-relationship-detail.html
@@ -174,6 +174,32 @@
       return `<div class="card"><h2>Membership</h2><dl class="kv">${lines.join('')}</dl></div>`;
     }
 
+    function renderOrgMemberships(ctx) {
+      if (!ctx.orgMemberships?.length) {
+        return `<div class="card"><h2>Org memberships</h2><p class="empty">Not a WorkOS member of any org.</p></div>`;
+      }
+      const items = ctx.orgMemberships.map((m) => {
+        const tags = [];
+        tags.push(`<span class="pill muted">${escapeHtml(m.role || 'member')}</span>`);
+        if (m.seat_type === 'community_only') tags.push(`<span class="pill muted">community-only</span>`);
+        if (m.is_paying_member) tags.push(`<span class="pill green">paying</span>`);
+        if (m.provisioning_source) tags.push(`<span class="pill muted">via ${escapeHtml(m.provisioning_source)}</span>`);
+        return `
+          <li>
+            <div>
+              <a href="/admin/accounts/${escapeHtml(m.workos_organization_id)}">${escapeHtml(m.org_name)}</a>
+              <span class="meta">(${escapeHtml(m.workos_organization_id)})</span>
+            </div>
+            <div class="invitation-meta" style="margin-top: 4px;">
+              ${tags.join(' ')}
+              <span class="meta"> · joined ${fmtDate(m.joined_at)}</span>
+            </div>
+          </li>
+        `;
+      }).join('');
+      return `<div class="card"><h2>Org memberships (${ctx.orgMemberships.length})</h2><ul class="row-list">${items}</ul></div>`;
+    }
+
     function renderEngagement(ctx) {
       const r = ctx.relationship;
       return `
@@ -263,6 +289,7 @@
         const html =
           renderIdentity(ctx) +
           renderMembership(ctx) +
+          renderOrgMemberships(ctx) +
           renderEngagement(ctx) +
           renderPreferences(ctx) +
           renderInvites(ctx) +

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -8305,6 +8305,24 @@ Use add_committee_leader to assign a leader.`;
       }
       lines.push('');
 
+      // Per-org memberships — every WorkOS org this person belongs to.
+      // Use this to answer "is this person in org X?" — `company` above is
+      // one (LIMIT 1) and conflates "the org we picked" with "the org being
+      // asked about."
+      if (ctx.orgMemberships.length > 0) {
+        lines.push(`### Org memberships (${ctx.orgMemberships.length})`);
+        for (const m of ctx.orgMemberships) {
+          const tags: string[] = [m.role ?? 'member'];
+          if (m.seat_type === 'community_only') tags.push('community-only seat');
+          if (m.is_paying_member) tags.push('paying');
+          if (m.provisioning_source) tags.push(`via ${m.provisioning_source}`);
+          lines.push(
+            `- ${m.org_name} (${m.workos_organization_id}) — ${tags.join(', ')}`
+          );
+        }
+        lines.push('');
+      }
+
       lines.push(`### Engagement`);
       lines.push(`- stage: ${r.stage} (since ${r.stage_changed_at.toISOString().slice(0, 10)})`);
       lines.push(`- sentiment: ${r.sentiment_trend}`);

--- a/server/src/addie/services/relationship-context.ts
+++ b/server/src/addie/services/relationship-context.ts
@@ -50,6 +50,14 @@ export interface RelationshipContext {
   invites: InviteSummary[];
   /** Last few threads with this person across surfaces (titled when known). */
   recentThreads: ThreadSummary[];
+  /**
+   * Every WorkOS org this person belongs to (versus `profile.company` which
+   * is one). Empty when the person isn't WorkOS-linked. Use this to answer
+   * "is this person in org X?" — the live-thread sample showed Addie
+   * conflating "in Slack" with "in WorkOS org Y" because she only had
+   * `profile.company` to work with.
+   */
+  orgMemberships: OrgMembership[];
 }
 
 export interface IdentityFlags {
@@ -81,6 +89,23 @@ export interface ThreadSummary {
   message_count: number;
   last_message_at: Date;
   created_at: Date;
+}
+
+/**
+ * Per-org membership for a person. The existing `profile.company` field is
+ * the LIMIT 1 join — sufficient for most queries but loses information for
+ * people who belong to multiple orgs, and conflates "the org we picked" with
+ * "the org being asked about." This surface is the explicit answer to "what
+ * orgs does this person belong to, and in what capacity."
+ */
+export interface OrgMembership {
+  workos_organization_id: string;
+  org_name: string;
+  role: 'admin' | 'member' | null;
+  seat_type: 'contributor' | 'community_only' | null;
+  provisioning_source: string | null;
+  is_paying_member: boolean;
+  joined_at: Date;
 }
 
 export interface CrossSurfaceMessage {
@@ -125,8 +150,18 @@ export async function loadRelationshipContext(
   const { slack_user_id, workos_user_id, prospect_org_id, email } = relationship;
 
   // Fan out all independent queries in parallel
-  const [messages, capabilities, company, certification, community, journey, invites, marketingOptIn, recentThreads] =
-    await Promise.all([
+  const [
+    messages,
+    capabilities,
+    company,
+    certification,
+    community,
+    journey,
+    invites,
+    marketingOptIn,
+    recentThreads,
+    orgMemberships,
+  ] = await Promise.all([
       // Recent messages across all surfaces
       loadRecentMessages(personId),
 
@@ -157,6 +192,9 @@ export async function loadRelationshipContext(
 
       // Recent thread index (titles where set + channel + last_message_at)
       loadRecentThreads(personId),
+
+      // All WorkOS orgs this person belongs to (multi-org / role / seat_type)
+      workos_user_id ? loadOrgMemberships(workos_user_id) : Promise.resolve([]),
     ]);
 
   return {
@@ -181,6 +219,7 @@ export async function loadRelationshipContext(
     },
     invites,
     recentThreads,
+    orgMemberships,
   };
 }
 
@@ -412,6 +451,48 @@ async function loadMarketingOptIn(workosUserId: string): Promise<boolean | null>
   }
 }
 
+async function loadOrgMemberships(workosUserId: string): Promise<OrgMembership[]> {
+  try {
+    const result = await query<{
+      workos_organization_id: string;
+      org_name: string;
+      role: string | null;
+      seat_type: string | null;
+      provisioning_source: string | null;
+      subscription_status: string | null;
+      created_at: Date;
+    }>(
+      `SELECT om.workos_organization_id,
+              o.name AS org_name,
+              om.role,
+              om.seat_type,
+              om.provisioning_source,
+              o.subscription_status,
+              om.created_at
+       FROM organization_memberships om
+       JOIN organizations o ON o.workos_organization_id = om.workos_organization_id
+       WHERE om.workos_user_id = $1
+       ORDER BY om.created_at DESC`,
+      [workosUserId]
+    );
+    return result.rows.map((r) => ({
+      workos_organization_id: r.workos_organization_id,
+      org_name: r.org_name,
+      role: r.role === 'admin' || r.role === 'member' ? r.role : null,
+      seat_type:
+        r.seat_type === 'contributor' || r.seat_type === 'community_only'
+          ? r.seat_type
+          : null,
+      provisioning_source: r.provisioning_source,
+      is_paying_member: r.subscription_status === 'active',
+      joined_at: new Date(r.created_at),
+    }));
+  } catch (err) {
+    logger.error({ err, workosUserId }, 'Failed to load org memberships');
+    return [];
+  }
+}
+
 async function loadRecentThreads(personId: string): Promise<ThreadSummary[]> {
   try {
     const result = await query<{
@@ -594,6 +675,37 @@ export function formatContextForPrompt(ctx: RelationshipContext): string {
       lines.push('- Marketing opt-in: yes');
     } else if (prefs.marketing_opt_in === false) {
       lines.push('- Marketing opt-in: no');
+    }
+  }
+
+  // Org memberships — every WorkOS org this person belongs to. The header
+  // line above shows one company; this section answers "is this person in
+  // org X" for any org. High-value when an admin asks about a colleague at
+  // a specific org and Addie needs to disambiguate Slack-presence from
+  // formal WorkOS membership (the Triton / Affinity Answers pattern).
+  // Only render when the person belongs to multiple orgs OR has an
+  // off-primary signal worth surfacing (admin role, community_only seat,
+  // verified-domain provisioning).
+  if (ctx.orgMemberships.length > 0) {
+    const showAlways =
+      ctx.orgMemberships.length > 1 ||
+      ctx.orgMemberships.some(
+        (m) => m.role === 'admin' || m.seat_type === 'community_only' || m.provisioning_source === 'verified_domain'
+      );
+    if (showAlways) {
+      lines.push('');
+      lines.push('### Org memberships');
+      for (const m of ctx.orgMemberships) {
+        const parts: string[] = [];
+        parts.push(m.role ?? 'member');
+        if (m.seat_type === 'community_only') parts.push('community-only seat');
+        if (m.is_paying_member) parts.push('paying');
+        if (m.provisioning_source) parts.push(`via ${m.provisioning_source}`);
+        const joined = m.joined_at.toISOString().split('T')[0];
+        lines.push(
+          `- **${m.org_name}** (${m.workos_organization_id}) — ${parts.join(', ')}, joined ${joined}`
+        );
+      }
     }
   }
 

--- a/server/tests/integration/person-memory.test.ts
+++ b/server/tests/integration/person-memory.test.ts
@@ -28,8 +28,11 @@ async function cleanup() {
   await query('DELETE FROM addie_thread_messages WHERE thread_id IN (SELECT thread_id FROM addie_threads WHERE person_id IN (SELECT id FROM person_relationships WHERE email LIKE $1))', [`%@${TEST_DOMAIN}`]);
   await query('DELETE FROM addie_threads WHERE person_id IN (SELECT id FROM person_relationships WHERE email LIKE $1)', [`%@${TEST_DOMAIN}`]);
   await query('DELETE FROM membership_invites WHERE workos_organization_id = $1', [ORG_PUBX]);
+  // Multi-org fixture rows (used by the orgMemberships test) — clean here
+  // so a mid-test failure self-heals on the next run.
+  await query(`DELETE FROM organization_memberships WHERE workos_user_id LIKE 'user_pm_%'`);
   await query('DELETE FROM person_relationships WHERE email LIKE $1', [`%@${TEST_DOMAIN}`]);
-  await query('DELETE FROM organizations WHERE workos_organization_id = $1', [ORG_PUBX]);
+  await query(`DELETE FROM organizations WHERE workos_organization_id IN ($1, 'org_pm_multi_a', 'org_pm_multi_b')`, [ORG_PUBX]);
 }
 
 describe('person memory (loadRelationshipContext additions)', () => {
@@ -160,11 +163,71 @@ describe('person memory (loadRelationshipContext additions)', () => {
     expect(ctx.recentThreads[2].title).toBe('first thread');
   });
 
-  it('returns empty arrays for sparse persons (no invites, no threads)', async () => {
+  it('returns empty arrays for sparse persons (no invites, no threads, no orgs)', async () => {
     const personId = await resolvePersonId({ email: `sparse@${TEST_DOMAIN}` });
     const ctx = await loadRelationshipContext(personId);
     expect(ctx.invites).toEqual([]);
     expect(ctx.recentThreads).toEqual([]);
+    expect(ctx.orgMemberships).toEqual([]);
     expect(ctx.preferences.marketing_opt_in).toBeNull();
+  });
+
+  it('orgMemberships returns empty for persons with no workos_user_id', async () => {
+    const personId = await resolvePersonId({ email: `slack-only@${TEST_DOMAIN}` });
+    await query(
+      `UPDATE person_relationships SET slack_user_id = $1 WHERE id = $2`,
+      ['U0SLACKONLY', personId]
+    );
+    const ctx = await loadRelationshipContext(personId);
+    expect(ctx.orgMemberships).toEqual([]);
+  });
+
+  it('orgMemberships surfaces every WorkOS org with role + seat_type + provisioning_source', async () => {
+    const personId = await resolvePersonId({ email: `multi-org@${TEST_DOMAIN}` });
+    const workosUserId = 'user_pm_multi_org';
+    await query(
+      `UPDATE person_relationships SET workos_user_id = $1 WHERE id = $2`,
+      [workosUserId, personId]
+    );
+    await query(
+      `INSERT INTO organizations (workos_organization_id, name, email_domain, subscription_status, created_at, updated_at)
+       VALUES ($1, $2, $3, 'active', NOW(), NOW()), ($4, $5, $3, NULL, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO UPDATE SET subscription_status = EXCLUDED.subscription_status`,
+      [
+        'org_pm_multi_a',
+        'Acme',
+        TEST_DOMAIN,
+        'org_pm_multi_b',
+        'Other Co',
+      ]
+    );
+    await query(
+      `INSERT INTO organization_memberships
+         (workos_user_id, workos_organization_id, email, role, seat_type, provisioning_source, created_at)
+       VALUES
+         ($1, 'org_pm_multi_a', $2, 'admin',  'contributor',     'verified_domain', NOW() - INTERVAL '90 days'),
+         ($1, 'org_pm_multi_b', $2, 'member', 'community_only',  'invited',         NOW() - INTERVAL '7 days')
+       ON CONFLICT (workos_user_id, workos_organization_id) DO NOTHING`,
+      [workosUserId, `multi-org@${TEST_DOMAIN}`]
+    );
+
+    const ctx = await loadRelationshipContext(personId);
+    expect(ctx.orgMemberships).toHaveLength(2);
+
+    // Sorted by joined_at desc — Other Co (7 days) before Acme (90 days)
+    expect(ctx.orgMemberships[0].org_name).toBe('Other Co');
+    expect(ctx.orgMemberships[0].role).toBe('member');
+    expect(ctx.orgMemberships[0].seat_type).toBe('community_only');
+    expect(ctx.orgMemberships[0].provisioning_source).toBe('invited');
+    expect(ctx.orgMemberships[0].is_paying_member).toBe(false);
+
+    expect(ctx.orgMemberships[1].org_name).toBe('Acme');
+    expect(ctx.orgMemberships[1].role).toBe('admin');
+    expect(ctx.orgMemberships[1].seat_type).toBe('contributor');
+    expect(ctx.orgMemberships[1].provisioning_source).toBe('verified_domain');
+    expect(ctx.orgMemberships[1].is_paying_member).toBe(true);
+    // Cleanup is handled by the file-level cleanup() helper (which knows
+    // about the user_pm_% / org_pm_multi_% fixtures) so a mid-test failure
+    // self-heals on the next run.
   });
 });

--- a/server/tests/unit/format-context-for-prompt.test.ts
+++ b/server/tests/unit/format-context-for-prompt.test.ts
@@ -51,6 +51,7 @@ function fixtureContext(overrides: Partial<RelationshipContext> = {}): Relations
     },
     invites: [],
     recentThreads: [],
+    orgMemberships: [],
     ...overrides,
   };
 }
@@ -188,6 +189,81 @@ describe('formatContextForPrompt — new memory sections', () => {
       })
     );
     expect(out).toContain('aao_membership_professional at org_no_name');
+  });
+
+  it('omits Org memberships for a single-org member with no special signals', () => {
+    const out = formatContextForPrompt(
+      fixtureContext({
+        orgMemberships: [
+          {
+            workos_organization_id: 'org_only',
+            org_name: 'Solo Co',
+            role: 'member',
+            seat_type: 'contributor',
+            provisioning_source: 'webhook',
+            is_paying_member: true,
+            joined_at: new Date('2026-01-01'),
+          },
+        ],
+      })
+    );
+    // Single org with no admin role / community-only seat / verified-domain
+    // signal — covered by the existing Company line in the header, no need
+    // for a separate section.
+    expect(out).not.toContain('### Org memberships');
+  });
+
+  it('renders Org memberships when the person belongs to multiple WorkOS orgs', () => {
+    const out = formatContextForPrompt(
+      fixtureContext({
+        orgMemberships: [
+          {
+            workos_organization_id: 'org_a',
+            org_name: 'Acme',
+            role: 'admin',
+            seat_type: 'contributor',
+            provisioning_source: 'verified_domain',
+            is_paying_member: true,
+            joined_at: new Date('2026-01-01'),
+          },
+          {
+            workos_organization_id: 'org_b',
+            org_name: 'Other Co',
+            role: 'member',
+            seat_type: 'community_only',
+            provisioning_source: 'invited',
+            is_paying_member: false,
+            joined_at: new Date('2026-04-01'),
+          },
+        ],
+      })
+    );
+    expect(out).toContain('### Org memberships');
+    expect(out).toContain('Acme');
+    expect(out).toContain('admin');
+    expect(out).toContain('community-only seat');
+    expect(out).toContain('via verified_domain');
+    expect(out).toContain('paying');
+  });
+
+  it('renders Org memberships even with single org when role/seat/provisioning warrants it', () => {
+    const out = formatContextForPrompt(
+      fixtureContext({
+        orgMemberships: [
+          {
+            workos_organization_id: 'org_solo_admin',
+            org_name: 'Solo Admin Co',
+            role: 'admin',
+            seat_type: 'contributor',
+            provisioning_source: 'webhook',
+            is_paying_member: true,
+            joined_at: new Date('2026-01-01'),
+          },
+        ],
+      })
+    );
+    expect(out).toContain('### Org memberships');
+    expect(out).toContain('Solo Admin Co');
   });
 
   it('renders all four new sections together for a fully-populated person', () => {


### PR DESCRIPTION
## Summary

Adds `orgMemberships: OrgMembership[]` to `RelationshipContext` — every WorkOS org a person belongs to with role, seat_type, provisioning_source, joined_at, is_paying_member. Surfaced in Addie's prompt, the admin relationship page, and the `get_person_memory` tool.

## Why this exists

Live-thread sampling after PR2 (#3667) merged found a recurring shape:

- **Triton Digital × Raphaël** (web, admin asking): "promote my colleague to admin." Addie's first answer was wrong — said Raphaël wasn't linked. Two turns of back-and-forth before she correctly identified that he's on Slack but not formally a member of the WorkOS org.
- **Affinity Answers × Vivek** (Slack, admin asking): "Vivek has a website account but isn't actually a member of the Affinity Answers org in WorkOS." Same shape.
- The original **Pubx** escalation that started the whole chain.

Root cause: `profile.company` is one (LIMIT 1) and answers "what company is this person at." With only that field available, Addie can't disambiguate "person belongs to org A" from "person is in Slack workspace where org A's domain is verified." She'd need explicit per-org membership state.

## What's rendered

- **Prompt** (`formatContextForPrompt`): `### Org memberships` block, signal-gated. Shows when person has multiple orgs OR has admin role / community-only seat / verified-domain provisioning. Single-org-no-signal members get the existing Company line in the header instead — no duplication, lean prompt.
- **Admin UI** (`/admin/relationships/:personId`): card after Membership listing each org with role + seat_type pills + paying flag + provisioning source + joined date. Each org links to `/admin/accounts/:orgId`.
- **Addie tool** (`get_person_memory`): `### Org memberships (N)` section between Membership and Engagement, same shape with all the tags inline.

Examples from live smoke (multi-org test fixture):
```
### Org memberships
- **OtherCo** (org_orgmem_b) — member, community-only seat, via invited, joined 2026-04-23
- **Acme** (org_orgmem_a) — admin, paying, via verified_domain, joined 2026-01-30
```

## Test plan

- [x] `npm run typecheck` clean
- [x] 3 new integration tests (sparse-person empty, slack-only-no-workos empty, multi-org with all signals)
- [x] 3 new unit tests for prompt rendering (single-org-no-signals omit, multi-org renders, single-org-with-signal renders)
- [x] All 21 person-memory tests pass together
- [x] Live docker smoke: API endpoint + Addie tool + formatContextForPrompt all surface the new field with role + seat_type + provisioning_source

## Reviewer feedback

- **code-reviewer** caught:
  - Test cleanup at end of `it` block could leak fixture rows on failure → moved into the file-level `cleanup()` helper so a mid-test failure self-heals
  - `is_paying_member` predicate diverges from canonical `MEMBER_FILTER` (`subscription_canceled_at` also matters) → same gap as the existing `profile.company.is_member`; filed #3677 to fix both call sites together rather than expand this PR's scope

## Companion / chain

- #3605, #3625, #3644 — invite chain (merged)
- #3651 — inbound text persistence (merged)
- #3659 — person-memory consolidator (merged)
- #3667 — wire memory into prompt (merged)
- #3675 — multi-tool filter (merged) — used for the live sampling that motivated this PR
- **This PR** — orgMemberships data
- **#3677** — predicate-consistency follow-up (filed)
- **Next:** `provision_signin_for_member_colleague` tool that uses this data to fix the actual Triton / Affinity Answers / Pubx escalation flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)