### PR TITLE
fix(addie): align is_member/is_paying_member with canonical MEMBER_FILTER

### DIFF
--- a/.changeset/fix-canonical-member-predicate.md
+++ b/.changeset/fix-canonical-member-predicate.md
@@ -1,0 +1,6 @@
+---
+---
+
+fix(addie): align is_member/is_paying_member predicates in relationship-context.ts with canonical MEMBER_FILTER
+
+A canceled-but-still-in-period subscription was read as paying in Addie's context. Both loadCompanyInfo and loadOrgMemberships now fetch subscription_canceled_at and delegate to a shared isPayingMembership() helper in org-filters.ts, matching every other membership gate in the system.

--- a/server/src/addie/services/relationship-context.ts
+++ b/server/src/addie/services/relationship-context.ts
@@ -4,6 +4,7 @@ import { getMemberCapabilities, hasRelevantUpcomingEvents } from '../../db/outbo
 import * as certDb from '../../db/certification-db.js';
 import { computeUserTier, type TierName } from '../../services/user-journey.js';
 import { createLogger } from '../../logger.js';
+import { isPayingMembership } from '../../db/org-filters.js';
 
 const logger = createLogger('relationship-context');
 import type { PersonRelationship } from '../../db/relationship-db.js';
@@ -258,9 +259,10 @@ async function loadCompanyInfo(
       company_types: string[];
       persona: string | null;
       subscription_status: string | null;
+      subscription_canceled_at: Date | null;
       prospect_owner: string | null;
     }>(
-      `SELECT o.name, o.company_types, o.persona, o.subscription_status, o.prospect_owner
+      `SELECT o.name, o.company_types, o.persona, o.subscription_status, o.subscription_canceled_at, o.prospect_owner
        FROM organizations o
        JOIN organization_memberships om ON om.workos_organization_id = o.workos_organization_id
        WHERE om.workos_user_id = $1
@@ -275,7 +277,7 @@ async function loadCompanyInfo(
       name: row.name,
       type: row.company_types?.[0] ?? 'unknown',
       persona: row.persona ?? undefined,
-      is_member: row.subscription_status === 'active',
+      is_member: isPayingMembership(row),
       is_addie_prospect: row.prospect_owner !== null,
     };
   }
@@ -286,9 +288,10 @@ async function loadCompanyInfo(
       company_types: string[];
       persona: string | null;
       subscription_status: string | null;
+      subscription_canceled_at: Date | null;
       prospect_owner: string | null;
     }>(
-      `SELECT name, company_types, persona, subscription_status, prospect_owner
+      `SELECT name, company_types, persona, subscription_status, subscription_canceled_at, prospect_owner
        FROM organizations
        WHERE workos_organization_id = $1
        LIMIT 1`,
@@ -302,7 +305,7 @@ async function loadCompanyInfo(
       name: row.name,
       type: row.company_types?.[0] ?? 'unknown',
       persona: row.persona ?? undefined,
-      is_member: row.subscription_status === 'active',
+      is_member: isPayingMembership(row),
       is_addie_prospect: row.prospect_owner !== null,
     };
   }
@@ -460,6 +463,7 @@ async function loadOrgMemberships(workosUserId: string): Promise<OrgMembership[]
       seat_type: string | null;
       provisioning_source: string | null;
       subscription_status: string | null;
+      subscription_canceled_at: Date | null;
       created_at: Date;
     }>(
       `SELECT om.workos_organization_id,
@@ -468,6 +472,7 @@ async function loadOrgMemberships(workosUserId: string): Promise<OrgMembership[]
               om.seat_type,
               om.provisioning_source,
               o.subscription_status,
+              o.subscription_canceled_at,
               om.created_at
        FROM organization_memberships om
        JOIN organizations o ON o.workos_organization_id = om.workos_organization_id
@@ -484,7 +489,7 @@ async function loadOrgMemberships(workosUserId: string): Promise<OrgMembership[]
           ? r.seat_type
           : null,
       provisioning_source: r.provisioning_source,
-      is_paying_member: r.subscription_status === 'active',
+      is_paying_member: isPayingMembership(r),
       joined_at: new Date(r.created_at),
     }));
   } catch (err) {

--- a/server/src/db/org-filters.ts
+++ b/server/src/db/org-filters.ts
@@ -120,6 +120,14 @@ export const NOT_MEMBER_ALIASED = `NOT (${MEMBER_FILTER_ALIASED})`;
 
 export type OrgTier = 'member' | 'engaged' | 'registered' | 'prospect';
 
+/** TypeScript predicate matching the SQL MEMBER_FILTER — use wherever is_member/is_paying_member is derived in application code. */
+export function isPayingMembership(row: {
+  subscription_status: string | null;
+  subscription_canceled_at: Date | null;
+}): boolean {
+  return row.subscription_status === 'active' && row.subscription_canceled_at === null;
+}
+
 /**
  * Determine the tier for an organization based on its data
  * This is for TypeScript logic, not SQL queries

--- a/server/tests/unit/org-filters-membership.test.ts
+++ b/server/tests/unit/org-filters-membership.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { isPayingMembership } from '../../src/db/org-filters.js';
+
+describe('isPayingMembership', () => {
+  it('returns true for active, non-canceled subscription', () => {
+    expect(isPayingMembership({ subscription_status: 'active', subscription_canceled_at: null })).toBe(true);
+  });
+
+  it('returns false for active but canceled subscription (canceled-but-in-period)', () => {
+    expect(isPayingMembership({ subscription_status: 'active', subscription_canceled_at: new Date() })).toBe(false);
+  });
+
+  it('returns false for null subscription_status', () => {
+    expect(isPayingMembership({ subscription_status: null, subscription_canceled_at: null })).toBe(false);
+  });
+
+  it('returns false for non-active status', () => {
+    expect(isPayingMembership({ subscription_status: 'canceled', subscription_canceled_at: null })).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #3677

Both `loadCompanyInfo` and `loadOrgMemberships` in `relationship-context.ts` derived "paying member" status using only `subscription_status === 'active'`, missing the `subscription_canceled_at IS NULL` guard that `MEMBER_FILTER` and every other membership gate in the system requires. A canceled-but-still-in-billing-period org was shown as a paying member in Addie's prompt context, causing misdiagnosis in outreach decisions and renewal nudge suppression.

**Non-breaking justification:** Server-side data correctness fix only. No public API, schema, or wire format changes. `is_member`/`is_paying_member` are internal Addie context fields used only in prompt injection and the `get_person_memory` tool — tightening the predicate corrects the data Addie reasons over; it doesn't change any interface shape or gate a downstream consumer relies on.

**Changes:**
- `org-filters.ts`: exports `isPayingMembership(row)` — the TypeScript mirror of `MEMBER_FILTER`, co-located with the SQL constant it mirrors
- `relationship-context.ts`: all three derivation sites (`loadCompanyInfo` × 2, `loadOrgMemberships`) now fetch `subscription_canceled_at`, declare it in the query type literal, and call `isPayingMembership()` instead of the inline single-condition check
- `org-filters-membership.test.ts`: 4 unit tests covering the active/non-canceled (true), canceled-but-active (false), null status (false), and non-active status (false) cases

**Known follow-up (not in scope here):** `server/src/addie/services/journey-computation.ts:97` has the same class of bug (`has_subscription: row.subscription_status === 'active'` without the `subscription_canceled_at` guard). Filed separately or can be folded into a follow-up.

**Pre-PR review:**
- code-reviewer: approved — all three SELECT queries and type literals updated, helper location correct, unit test covers the critical canceled-but-active case; one nit on `!x` vs `=== null` consistency noted
- adtech-product-expert: approved — aligning with `MEMBER_FILTER` is correct; no product reason to keep the looser predicate; access-during-billing-period is an entitlement-layer concern, not a membership-truth concern

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_019ZtN7LqoFkcUTGGB9HEFPS

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZtN7LqoFkcUTGGB9HEFPS)_