### PR TITLE
fix(addie): is_paying_member uses canonical MEMBER_FILTER (closes #3677)

### DIFF
--- a/.changeset/paying-member-predicate.md
+++ b/.changeset/paying-member-predicate.md
@@ -1,0 +1,4 @@
+---
+---
+
+`profile.company.is_member` and `orgMemberships[].is_paying_member` now use the canonical `MEMBER_FILTER` predicate (`subscription_status = 'active' AND subscription_canceled_at IS NULL`) — a canceled-but-still-in-period subscription correctly reads as not paying. Both call sites in `relationship-context.ts` now share an `isPayingMembership(row)` helper from `org-filters.ts`. Closes #3677.

--- a/server/src/addie/services/relationship-context.ts
+++ b/server/src/addie/services/relationship-context.ts
@@ -1,4 +1,5 @@
 import { query } from '../../db/client.js';
+import { isPayingMembership } from '../../db/org-filters.js';
 import * as relationshipDb from '../../db/relationship-db.js';
 import { getMemberCapabilities, hasRelevantUpcomingEvents } from '../../db/outbound-db.js';
 import * as certDb from '../../db/certification-db.js';
@@ -258,9 +259,11 @@ async function loadCompanyInfo(
       company_types: string[];
       persona: string | null;
       subscription_status: string | null;
+      subscription_canceled_at: Date | null;
       prospect_owner: string | null;
     }>(
-      `SELECT o.name, o.company_types, o.persona, o.subscription_status, o.prospect_owner
+      `SELECT o.name, o.company_types, o.persona, o.subscription_status,
+              o.subscription_canceled_at, o.prospect_owner
        FROM organizations o
        JOIN organization_memberships om ON om.workos_organization_id = o.workos_organization_id
        WHERE om.workos_user_id = $1
@@ -275,7 +278,7 @@ async function loadCompanyInfo(
       name: row.name,
       type: row.company_types?.[0] ?? 'unknown',
       persona: row.persona ?? undefined,
-      is_member: row.subscription_status === 'active',
+      is_member: isPayingMembership(row),
       is_addie_prospect: row.prospect_owner !== null,
     };
   }
@@ -286,9 +289,11 @@ async function loadCompanyInfo(
       company_types: string[];
       persona: string | null;
       subscription_status: string | null;
+      subscription_canceled_at: Date | null;
       prospect_owner: string | null;
     }>(
-      `SELECT name, company_types, persona, subscription_status, prospect_owner
+      `SELECT name, company_types, persona, subscription_status,
+              subscription_canceled_at, prospect_owner
        FROM organizations
        WHERE workos_organization_id = $1
        LIMIT 1`,
@@ -302,7 +307,7 @@ async function loadCompanyInfo(
       name: row.name,
       type: row.company_types?.[0] ?? 'unknown',
       persona: row.persona ?? undefined,
-      is_member: row.subscription_status === 'active',
+      is_member: isPayingMembership(row),
       is_addie_prospect: row.prospect_owner !== null,
     };
   }
@@ -460,6 +465,7 @@ async function loadOrgMemberships(workosUserId: string): Promise<OrgMembership[]
       seat_type: string | null;
       provisioning_source: string | null;
       subscription_status: string | null;
+      subscription_canceled_at: Date | null;
       created_at: Date;
     }>(
       `SELECT om.workos_organization_id,
@@ -468,6 +474,7 @@ async function loadOrgMemberships(workosUserId: string): Promise<OrgMembership[]
               om.seat_type,
               om.provisioning_source,
               o.subscription_status,
+              o.subscription_canceled_at,
               om.created_at
        FROM organization_memberships om
        JOIN organizations o ON o.workos_organization_id = om.workos_organization_id
@@ -484,7 +491,7 @@ async function loadOrgMemberships(workosUserId: string): Promise<OrgMembership[]
           ? r.seat_type
           : null,
       provisioning_source: r.provisioning_source,
-      is_paying_member: r.subscription_status === 'active',
+      is_paying_member: isPayingMembership(r),
       joined_at: new Date(r.created_at),
     }));
   } catch (err) {

--- a/server/src/db/org-filters.ts
+++ b/server/src/db/org-filters.ts
@@ -25,6 +25,19 @@ const logger = createLogger('org-filters');
 /** Organization has an active, non-canceled subscription */
 export const MEMBER_FILTER = `subscription_status = 'active' AND subscription_canceled_at IS NULL`;
 
+/**
+ * TS-side mirror of MEMBER_FILTER for callers that already have the row in
+ * memory and don't want to round-trip through SQL. A canceled-but-still-in-
+ * period subscription does NOT count as paying — the org has signaled they're
+ * leaving even though Stripe is still serving the period.
+ */
+export function isPayingMembership(row: {
+  subscription_status: string | null;
+  subscription_canceled_at: Date | null;
+}): boolean {
+  return row.subscription_status === 'active' && row.subscription_canceled_at === null;
+}
+
 /** Organization has at least one user (site account or Slack user) */
 export const HAS_USER = `(
   EXISTS (

--- a/server/tests/integration/person-memory.test.ts
+++ b/server/tests/integration/person-memory.test.ts
@@ -182,6 +182,47 @@ describe('person memory (loadRelationshipContext additions)', () => {
     expect(ctx.orgMemberships).toEqual([]);
   });
 
+  it('is_paying_member is false for a canceled-but-still-in-period subscription', async () => {
+    // A subscription that is `active` (Stripe still serving the period) but
+    // `subscription_canceled_at` is set has signaled they're leaving. The
+    // canonical MEMBER_FILTER excludes these — both loadCompanyInfo and
+    // loadOrgMemberships should agree.
+    const personId = await resolvePersonId({ email: `canceled@${TEST_DOMAIN}` });
+    const workosUserId = 'user_pm_canceled';
+    await query(
+      `UPDATE person_relationships SET workos_user_id = $1 WHERE id = $2`,
+      [workosUserId, personId]
+    );
+    await query(
+      `INSERT INTO organizations
+         (workos_organization_id, name, email_domain,
+          subscription_status, subscription_canceled_at, created_at, updated_at)
+       VALUES ($1, $2, $3, 'active', NOW() - INTERVAL '2 days', NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO UPDATE SET
+         subscription_status = EXCLUDED.subscription_status,
+         subscription_canceled_at = EXCLUDED.subscription_canceled_at`,
+      ['org_pm_multi_a', 'Canceling Co', TEST_DOMAIN]
+    );
+    await query(
+      `INSERT INTO organization_memberships
+         (workos_user_id, workos_organization_id, email, role, seat_type, created_at)
+       VALUES ($1, 'org_pm_multi_a', $2, 'member', 'contributor', NOW() - INTERVAL '90 days')
+       ON CONFLICT (workos_user_id, workos_organization_id) DO NOTHING`,
+      [workosUserId, `canceled@${TEST_DOMAIN}`]
+    );
+
+    const ctx = await loadRelationshipContext(personId);
+
+    // profile.company answers "what company is this person at?" with the
+    // strict member predicate
+    expect(ctx.profile.company?.name).toBe('Canceling Co');
+    expect(ctx.profile.company?.is_member).toBe(false);
+
+    // orgMemberships agrees: same predicate, same answer
+    expect(ctx.orgMemberships).toHaveLength(1);
+    expect(ctx.orgMemberships[0].is_paying_member).toBe(false);
+  });
+
   it('orgMemberships surfaces every WorkOS org with role + seat_type + provisioning_source', async () => {
     const personId = await resolvePersonId({ email: `multi-org@${TEST_DOMAIN}` });
     const workosUserId = 'user_pm_multi_org';


### PR DESCRIPTION
## Summary

`profile.company.is_member` and `orgMemberships[].is_paying_member` both derived "paying" status as `subscription_status === 'active'` — the loose form. Project canonical predicate (`server/src/db/org-filters.ts` `MEMBER_FILTER`) is `active AND subscription_canceled_at IS NULL`. A canceled-but-still-in-period subscription would have read as paying through both consolidator paths but failed every other AAO membership gate.

## Fix

- New `isPayingMembership(row)` helper in `org-filters.ts` next to `MEMBER_FILTER` — TS-side mirror, same predicate, in-memory. Avoids two divergent inline definitions.
- `loadCompanyInfo` (both the workos-user-join path and prospect-org-id path) pull `subscription_canceled_at` and call the helper.
- `loadOrgMemberships` SELECT + mapping use the same helper.

## What I deliberately left alone

`http.ts:6434` and `admin-tools.ts:2347 / :2434` use the loose form too, but they answer a different question — "is this person currently entitled to member benefits" — where a canceled-but-still-in-period org might intentionally still count (Stripe is still serving the period). Different semantics, separate decision. Out of scope.

## Test plan

- [x] `npm run typecheck` clean
- [x] New integration test "is_paying_member is false for a canceled-but-still-in-period subscription" — seeds an org with `subscription_status='active'` AND `subscription_canceled_at` set, asserts both `profile.company.is_member` and `orgMemberships[0].is_paying_member` are `false`
- [x] All 8 person-memory integration tests pass together (existing 7 + new canceled-period test)

## Closes

#3677 — flagged by code-reviewer on PR #3678 (orgMemberships in person memory). Pre-existing inconsistency; could have been deferred but the fix is small and the divergence was already documented in two places.

🤖 Generated with [Claude Code](https://claude.com/claude-code)