### PR TITLE
fix(billing): clear subscription state on unlink + filter membership sub on link (#3623 step 4)

### DIFF
--- a/.changeset/relink-admin-fixes.md
+++ b/.changeset/relink-admin-fixes.md
@@ -1,0 +1,10 @@
+---
+---
+
+fix(billing): clear subscription state on unlink + filter membership sub on link (#3623 step 4).
+
+Two bugs in the admin Stripe-customer link/unlink endpoints surfaced by the Lina/HYPD/Yoshihiko investigation:
+
+1. **`POST /api/admin/stripe-customers/:customerId/unlink`** was setting `stripe_customer_id = NULL` but leaving every other `subscription_*` column intact. After unlink, the org row continued to show as a paying member with no Stripe link — entitlement gates would silently grant access on stale state until a webhook fired (which never does, since the customer is gone). Now clears `stripe_subscription_id`, `subscription_status`, `subscription_amount`, `subscription_interval`, `subscription_current_period_end`, `subscription_canceled_at`, `subscription_product_id`, `subscription_product_name`, `subscription_price_id`, `subscription_price_lookup_key`, and invalidates the membership cache.
+
+2. **`POST /api/admin/stripe-customers/:customerId/link`** had the same `subscriptions.data[0]` bug as `/sync` (fixed in #3646) — picks the first sub regardless of whether it's a membership sub. Now uses `pickMembershipSub` to filter.

--- a/server/src/routes/billing.ts
+++ b/server/src/routes/billing.ts
@@ -768,6 +768,30 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
               );
               subscriptionSynced = true;
               invalidateMembershipCache(org_id);
+            } else if (previousCustomerId) {
+              // Force-replace path with no membership sub on the new
+              // customer: clear the subscription state that came from the
+              // previous customer. Without this, the org keeps stale
+              // `subscription_status='active'` etc. derived from a
+              // customer it's no longer linked to.
+              await pool.query(
+                `UPDATE organizations SET
+                    stripe_subscription_id = NULL,
+                    subscription_status = NULL,
+                    subscription_amount = NULL,
+                    subscription_interval = NULL,
+                    subscription_current_period_end = NULL,
+                    subscription_canceled_at = NULL,
+                    subscription_product_id = NULL,
+                    subscription_product_name = NULL,
+                    subscription_price_id = NULL,
+                    subscription_price_lookup_key = NULL,
+                    membership_tier = NULL,
+                    updated_at = NOW()
+                 WHERE workos_organization_id = $1`,
+                [org_id],
+              );
+              invalidateMembershipCache(org_id);
             }
           }
         } catch (syncError) {
@@ -775,6 +799,31 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
           logger.warn({ err: syncError, customerId, org_id }, "Failed to sync subscription data during link");
         }
       }
+
+      // Forensic record of the entitlement-affecting admin action. Mirrors
+      // the audit row written by the unlink path. Force-replace is the
+      // riskier branch — it changes which Stripe customer drives this org's
+      // entitlement.
+      const orgDb = new OrganizationDatabase();
+      await orgDb.recordAuditLog({
+        workos_organization_id: org_id,
+        workos_user_id: req.user?.id ?? 'unknown',
+        action: previousCustomerId ? 'admin_stripe_link_replace' : 'admin_stripe_link',
+        resource_type: 'subscription',
+        resource_id: customerId,
+        details: {
+          stripe_customer_id: customerId,
+          ...(previousCustomerId && { previous_customer_id: previousCustomerId }),
+          subscription_synced: subscriptionSynced,
+          ...(subscriptionSyncError && { subscription_sync_error: subscriptionSyncError }),
+          admin_email: req.user?.email,
+        },
+      }).catch((err) => {
+        logger.error(
+          { err, customerId, org_id },
+          `Failed to record ${previousCustomerId ? 'admin_stripe_link_replace' : 'admin_stripe_link'} audit log entry`,
+        );
+      });
 
       logger.info(
         { customerId, orgId: org_id, orgName: org.name, adminEmail: req.user?.email, invoicesSynced, subscriptionSynced, subscriptionSyncError },
@@ -812,10 +861,18 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
 
     try {
       const pool = getPool();
+      const orgDb = new OrganizationDatabase();
 
-      // Find the org linked to this customer
-      const linkedOrg = await pool.query(
-        "SELECT workos_organization_id, name FROM organizations WHERE stripe_customer_id = $1",
+      // Snapshot prior state for the audit row, plus find the org.
+      const linkedOrg = await pool.query<{
+        workos_organization_id: string;
+        name: string;
+        subscription_status: string | null;
+        membership_tier: string | null;
+        stripe_subscription_id: string | null;
+      }>(
+        `SELECT workos_organization_id, name, subscription_status, membership_tier, stripe_subscription_id
+           FROM organizations WHERE stripe_customer_id = $1`,
         [customerId]
       );
 
@@ -824,6 +881,25 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
       }
 
       const org = linkedOrg.rows[0];
+
+      // Clear the Stripe customer's metadata.workos_organization_id BEFORE
+      // we null the DB link. Without this, a webhook that fires for this
+      // customer between the unlink and the next admin action would walk
+      // the metadata fallback in resolveOrgForStripeCustomer and silently
+      // re-link the org we just unlinked. (The link path already does this
+      // when force-replacing — mirror it here.)
+      if (stripe) {
+        try {
+          await stripe.customers.update(customerId, {
+            metadata: { workos_organization_id: '' },
+          });
+        } catch (err) {
+          logger.warn(
+            { err, customerId },
+            "Failed to clear workos_organization_id metadata on Stripe customer during unlink — webhook fallback may re-link",
+          );
+        }
+      }
 
       // Unlink the customer AND clear the org's subscription state. Without
       // this, the org row keeps `subscription_status='active'` etc. after
@@ -849,6 +925,29 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
         [customerId],
       );
       invalidateMembershipCache(org.workos_organization_id);
+
+      // Forensic record of the entitlement-affecting admin action. Without
+      // this, a compromised admin token could mass-unlink paying members
+      // with only structured-log evidence of the action.
+      await orgDb.recordAuditLog({
+        workos_organization_id: org.workos_organization_id,
+        workos_user_id: req.user?.id ?? 'unknown',
+        action: 'admin_stripe_unlink',
+        resource_type: 'subscription',
+        resource_id: customerId,
+        details: {
+          stripe_customer_id: customerId,
+          prior_subscription_status: org.subscription_status,
+          prior_stripe_subscription_id: org.stripe_subscription_id,
+          prior_membership_tier: org.membership_tier,
+          admin_email: req.user?.email,
+        },
+      }).catch((err) => {
+        logger.error(
+          { err, customerId, orgId: org.workos_organization_id },
+          "Failed to record admin_stripe_unlink audit log entry",
+        );
+      });
 
       logger.info(
         { customerId, orgId: org.workos_organization_id, orgName: org.name, adminEmail: req.user?.email },

--- a/server/src/routes/billing.ts
+++ b/server/src/routes/billing.ts
@@ -27,6 +27,7 @@ import {
 } from "../billing/stripe-client.js";
 import { OrganizationDatabase, buildSubscriptionUpdate } from "../db/organization-db.js";
 import { invalidateMembershipCache } from "../db/org-filters.js";
+import { pickMembershipSub } from "../billing/membership-prices.js";
 
 const logger = createLogger("billing-routes");
 
@@ -722,8 +723,15 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
 
           if (!('deleted' in customer && customer.deleted)) {
             const subscriptions = (customer as Stripe.Customer).subscriptions;
-            if (subscriptions && subscriptions.data.length > 0) {
-              const subscription = subscriptions.data[0];
+            // Filter to membership subs before picking. A customer with a
+            // non-membership sub stacked alongside a real membership would
+            // otherwise have its row overwritten with the wrong sub's state
+            // — Stripe doesn't guarantee `subscriptions.data` order. Same
+            // hardening as POST /api/admin/accounts/:orgId/sync (#3646).
+            const subscription = subscriptions
+              ? pickMembershipSub(subscriptions.data)
+              : null;
+            if (subscription) {
               const subUpdate = buildSubscriptionUpdate(subscription as any, org.is_personal ?? false);
 
               await pool.query(
@@ -817,8 +825,30 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
 
       const org = linkedOrg.rows[0];
 
-      // Unlink the customer
-      await pool.query("UPDATE organizations SET stripe_customer_id = NULL WHERE stripe_customer_id = $1", [customerId]);
+      // Unlink the customer AND clear the org's subscription state. Without
+      // this, the org row keeps `subscription_status='active'` etc. after
+      // the Stripe link has been severed — meaning the org continues to
+      // appear as a paying member with no Stripe customer attached. The
+      // entitlement gate would silently grant access on stale state until
+      // the next webhook (which never fires, since the customer is gone).
+      await pool.query(
+        `UPDATE organizations SET
+            stripe_customer_id = NULL,
+            stripe_subscription_id = NULL,
+            subscription_status = NULL,
+            subscription_amount = NULL,
+            subscription_interval = NULL,
+            subscription_current_period_end = NULL,
+            subscription_canceled_at = NULL,
+            subscription_product_id = NULL,
+            subscription_product_name = NULL,
+            subscription_price_id = NULL,
+            subscription_price_lookup_key = NULL,
+            updated_at = NOW()
+         WHERE stripe_customer_id = $1`,
+        [customerId],
+      );
+      invalidateMembershipCache(org.workos_organization_id);
 
       logger.info(
         { customerId, orgId: org.workos_organization_id, orgName: org.name, adminEmail: req.user?.email },


### PR DESCRIPTION
## Summary

Two bugs in the admin Stripe-customer link/unlink endpoints, both surfaced by the Lina/HYPD/Yoshihiko investigation in #3623.

## Bug 1: `/unlink` left orgs showing as paying members

`POST /api/admin/stripe-customers/:customerId/unlink` (`server/src/routes/billing.ts:798`) was:

```sql
UPDATE organizations SET stripe_customer_id = NULL WHERE stripe_customer_id = $1
```

Cleared the customer link but left every other `subscription_*` column intact. After an unlink:
- `subscription_status` still says `'active'`
- `stripe_subscription_id` still references the now-detached Stripe sub
- `effective_membership.is_member` still returns true
- Entitlement gates silently grant access until something fires another webhook — which never happens, because the customer is no longer attached

Fix: clear all subscription_* fields in the same UPDATE + invalidate the membership cache.

## Bug 2: `/link` had the same `data[0]` bug as `/sync`

Line 726 of the link endpoint had `const subscription = subscriptions.data[0]` — same bug as `/sync` fixed in #3646. A customer with a non-membership sub stacked alongside a real membership would get the wrong sub written to the org row. Now uses `pickMembershipSub` from `server/src/billing/membership-prices.ts`.

## Why this matters

The Stripe diagnosis (in #3663 PR description) showed that the production drift on Lina/HYPD/Yoshihiko wasn't from missed webhooks — it was from a one-off audit script (now gone) that re-linked Stripe customers between orgs without transferring subscription state. That script bypassed these admin endpoints. But the endpoints themselves had bugs that would have produced similar artifacts on any future force-relink-via-UI scenario:

- `/link` picks the wrong sub for multi-sub customers → wrong state written to new org
- `/unlink` doesn't clean up state → org left in zombie "member without customer" state

This PR closes those.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] 78 unit tests pass (5 test files)
- [x] Pre-commit hook (unit + dynamic imports + typecheck) passes
- [ ] Manual: in the sandbox, unlink the `lina_class` customer → verify `subscription_status`, `stripe_subscription_id`, `subscription_amount` all NULL; relink → verify state restored

## Refs

- Issue #3623 step 4 in the sequential plan
- Companion: #3646 (same `data[0]` bug fixed in `/sync`), #3663 (lazy reconcile on paywall hit — covers the customer-facing impact at runtime)
- Triggering investigation: Stripe metadata showed `relinked_at: 2026-04-25` on Lina's customer with no source-control trace of the script

🤖 Generated with [Claude Code](https://claude.com/claude-code)