### PR TITLE
chore(changesets): unescape jsonc fence in stage-5 changeset

### DIFF
--- a/.changeset/fix-changeset-jsonc-escapes.md
+++ b/.changeset/fix-changeset-jsonc-escapes.md
@@ -1,0 +1,11 @@
+---
+---
+
+chore(changesets): unescape backticks in `per-version-badges-stage5-brand-json.md`
+
+The Stage 5 changeset (PR #3604) was committed with `\`\`\`jsonc` (literal
+backslash-backticks) for its code fence. Mintlify's MDX pipeline runs
+acorn over `.changeset/*.md` files and emits a noisy `Could not parse
+expression with acorn` warning on every CI run. Replacing the escaped
+fence with a plain ` ```jsonc ` block clears the warning. No content
+change.

--- a/.changeset/per-version-badges-stage5-brand-json.md
+++ b/.changeset/per-version-badges-stage5-brand-json.md
@@ -7,7 +7,7 @@ backend(verification): brand.json + /verification carry per-version badge detail
 
 `aao_verification` blocks served via brand.json enrichment now include a `badges[]` array — one entry per `(role, adcp_version)` with full per-version detail:
 
-\`\`\`jsonc
+```jsonc
 "aao_verification": {
   "verified": true,
   "verified_at": "2026-04-30T...",
@@ -18,7 +18,7 @@ backend(verification): brand.json + /verification carry per-version badge detail
   "roles": ["media-buy"],
   "modes_by_role": { "media-buy": ["spec", "live"] }
 }
-\`\`\`
+```
 
 `badges[]` is the canonical forward-compat shape (Q6 of [#3524's resolved decisions](https://github.com/adcontextprotocol/adcp/issues/3524#issuecomment-4348265184)). One entry per parallel-version badge; preserved order matches the API's version-DESC sort. Adding future axes to a badge (e.g. a third verification mode) doesn't change the array shape.
 


### PR DESCRIPTION
## Summary

The Stage 5 brand.json changeset (added in #3604) was committed with `\`\`\`jsonc` (literal backslash-backticks) for its code fence. Mintlify's MDX pipeline runs acorn over `.changeset/*.md` files and emits this warning on every CI run:

```
parsing error ./.changeset/per-version-badges-stage5-brand-json.md:15:13 - Could not parse expression with acorn
```

The `Check for Broken Links` job continues past the warning (the `success no broken links found` line follows it), so this is not blocking — just noise on every PR.

Replacing the escaped fence with a plain ` ```jsonc ` block clears the warning. Documentation content unchanged.

## Test plan

- [x] `git diff` shows only fence-character changes
- [ ] `Check for Broken Links` CI passes without the acorn warning