### PR TITLE
feat(addie): add_member_to_org tool — closes the org-membership action loop

### DIFF
--- a/.changeset/add-member-to-org-tool.md
+++ b/.changeset/add-member-to-org-tool.md
@@ -1,0 +1,4 @@
+---
+---
+
+Addie can now act on org-membership diagnoses via a new `add_member_to_org` admin tool. Wraps the existing `POST /api/organizations/:orgId/members/by-email` endpoint, which handles four states automatically: invites new users, adds existing WorkOS users to the org, updates roles, or no-ops if already correct. Required args: `email`, `org_id`. Optional: `role` (default `member`), `seat_type` (default `community_only`). Closes the action half of the Pubx / Triton / Affinity Answers escalation pattern — `diagnose_signin_block` returns the verdict, `add_member_to_org` is the verb. No new endpoint, no service refactor — direct internal HTTP wrapper authenticated via `ADMIN_API_KEY`.

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -592,6 +592,35 @@ Actions:
       required: ['token', 'org_id'],
     },
   },
+  {
+    name: 'add_member_to_org',
+    description:
+      'Use when an admin or owner asks to add, invite, or promote a colleague on a paying org. Also the action to take when diagnose_signin_block returns needs_invite for an authorized requester. Handles four states automatically: invites new users (no WorkOS account yet), adds existing users to the org, updates roles, or no-ops if already correct. Do NOT use to remove members (no removal path), to change your own role, or for personal workspaces. Returns one of: invited, member_added, role_updated, no_change.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        email: {
+          type: 'string',
+          description: 'Email of the colleague to add or promote',
+        },
+        org_id: {
+          type: 'string',
+          description: 'WorkOS organization ID (org_…) to add them to',
+        },
+        role: {
+          type: 'string',
+          enum: ['member', 'admin', 'owner'],
+          description: 'Role to assign. Default: member. Note: owner can only be assigned by another owner or AAO super-admin; new invites always go out as member regardless and must be promoted after acceptance.',
+        },
+        seat_type: {
+          type: 'string',
+          enum: ['contributor', 'community_only'],
+          description: 'Seat type. Default: community_only. Contributors get Slack/working-groups/councils; community-only get Addie/certification/training.',
+        },
+      },
+      required: ['email', 'org_id'],
+    },
+  },
 
   // ============================================
   // INDUSTRY FEED MANAGEMENT TOOLS
@@ -8389,6 +8418,21 @@ Use add_committee_leader to assign a leader.`;
   // MEMBERSHIP INVITE HANDLERS
   // ============================================
 
+  function actionToHeader(action: string): string {
+    switch (action) {
+      case 'invited':
+        return 'Invitation sent';
+      case 'member_added':
+        return 'Added to org';
+      case 'role_updated':
+        return 'Role updated';
+      case 'no_change':
+        return 'No change';
+      default:
+        return 'Done';
+    }
+  }
+
   function formatRelativeDays(d: Date): string {
     const diffMs = d.getTime() - Date.now();
     const days = Math.round(diffMs / 86400000);
@@ -8619,6 +8663,113 @@ Use add_committee_leader to assign a leader.`;
     } catch (error) {
       logger.error({ error, orgId, token: token.slice(0, 8) }, 'Error revoking invite');
       return `❌ Failed to revoke: ${error instanceof Error ? error.message : 'Unknown error'}`;
+    }
+  });
+
+  handlers.set('add_member_to_org', async (input) => {
+    const email = ((input.email as string) || '').trim().toLowerCase();
+    const orgId = input.org_id as string;
+    const role = (input.role as string) ?? 'member';
+    const seatType = (input.seat_type as string) ?? 'community_only';
+
+    if (!email || !email.includes('@')) {
+      return '❌ email is required (a valid email address).';
+    }
+    if (!orgId || !orgId.startsWith('org_')) {
+      return '❌ org_id is required (org_…).';
+    }
+    if (!['member', 'admin', 'owner'].includes(role)) {
+      return `❌ role must be one of: member, admin, owner (got: ${role}).`;
+    }
+    if (!['contributor', 'community_only'].includes(seatType)) {
+      return `❌ seat_type must be one of: contributor, community_only (got: ${seatType}).`;
+    }
+
+    const adminUser = memberContext?.workos_user;
+    if (!adminUser) {
+      return '❌ Cannot add member — no signed-in admin context.';
+    }
+
+    const apiKey = process.env.ADMIN_API_KEY;
+    if (!apiKey) {
+      return '❌ ADMIN_API_KEY is not configured on the server.';
+    }
+    // Match the base-URL precedence used by member-tools.ts:getBaseUrl —
+    // BASE_URL (production) wins; otherwise PORT/CONDUCTOR_PORT for local.
+    const baseUrl =
+      process.env.BASE_URL ||
+      `http://localhost:${process.env.PORT || process.env.CONDUCTOR_PORT || '3000'}`;
+    const endpoint = `${baseUrl}/api/organizations/${encodeURIComponent(orgId)}/members/by-email`;
+
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({ email, role, seat_type: seatType }),
+        signal: AbortSignal.timeout(10000),
+      });
+      const data = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+      if (!response.ok) {
+        const errorMsg = (data.message as string) || (data.error as string) || `HTTP ${response.status}`;
+        logger.warn(
+          { status: response.status, orgId, email, error: errorMsg },
+          'add_member_to_org route returned non-OK'
+        );
+        return `❌ Failed to add ${email} to ${orgId}: ${errorMsg}`;
+      }
+
+      const action = data.action as string;
+      logger.info(
+        {
+          orgId,
+          email,
+          action,
+          role,
+          seatType,
+          adminUserId: adminUser.workos_user_id,
+        },
+        'Addie called add_member_to_org'
+      );
+
+      // Mirror the route's response shape rather than reflecting the input —
+      // e.g. the route may keep an existing seat_type when adding to an org
+      // the user already has a seat in.
+      const responseSeatType = (data.seat_type as string | undefined) ?? seatType;
+
+      let md = `## ${actionToHeader(action)}\n\n`;
+      md += `**Email:** ${email}\n`;
+      md += `**Org:** ${orgId}\n`;
+
+      if (action === 'invited') {
+        const invitation = data.invitation as Record<string, unknown> | undefined;
+        const expiresAt = invitation?.expires_at as string | undefined;
+        md += `**Invited as:** member (must be promoted after acceptance for higher roles)\n`;
+        md += `**Requested role:** ${role}\n`;
+        md += `**Seat type:** ${responseSeatType}\n`;
+        if (expiresAt) md += `**Invite expires:** ${expiresAt.slice(0, 10)}\n`;
+        if (invitation?.accept_invitation_url) {
+          md += `\nThey'll receive an email with a sign-up link.\n`;
+        }
+      } else if (action === 'member_added') {
+        md += `**Role:** ${role}\n`;
+        md += `**Seat type:** ${responseSeatType}\n`;
+        md += `\nThey already had a WorkOS account; added directly to the org.\n`;
+      } else if (action === 'role_updated') {
+        const previousRole = data.previous_role as string | null | undefined;
+        md += `**New role:** ${role}\n`;
+        md += `**Previous role:** ${previousRole ?? '(none)'}\n`;
+      } else if (action === 'no_change') {
+        md += `\nNo change — they already have role ${role}.\n`;
+      } else {
+        md += `**Action:** ${action ?? 'unknown'}\n`;
+      }
+      return md;
+    } catch (error) {
+      logger.error({ error, orgId, email }, 'Error calling members/by-email');
+      return `❌ Failed to add member: ${error instanceof Error ? error.message : 'Unknown error'}`;
     }
   });
 

--- a/server/tests/integration/admin-invite-tools.test.ts
+++ b/server/tests/integration/admin-invite-tools.test.ts
@@ -330,6 +330,50 @@ describe('admin invite tools', () => {
     });
   });
 
+  describe('add_member_to_org arg validation', () => {
+    let addMemberToOrg: (input: Record<string, unknown>) => Promise<string>;
+    beforeAll(() => {
+      const handlers = createAdminToolHandlers({
+        is_mapped: true,
+        is_member: true,
+        workos_user: {
+          workos_user_id: ADMIN_ID,
+          email: ADMIN_EMAIL,
+          first_name: 'Admin',
+          last_name: 'User',
+        },
+      });
+      addMemberToOrg = handlers.get('add_member_to_org')!;
+    });
+
+    it('rejects missing email', async () => {
+      expect(await addMemberToOrg({ org_id: ORG_PUBX })).toMatch(/email is required/);
+    });
+
+    it('rejects missing or malformed org_id', async () => {
+      expect(await addMemberToOrg({ email: 'x@y.com' })).toMatch(/org_id is required/);
+      expect(await addMemberToOrg({ email: 'x@y.com', org_id: 'not-an-org' })).toMatch(/org_id is required/);
+    });
+
+    it('rejects invalid role enum', async () => {
+      expect(
+        await addMemberToOrg({ email: 'x@y.com', org_id: ORG_PUBX, role: 'superadmin' })
+      ).toMatch(/role must be one of/);
+    });
+
+    it('rejects invalid seat_type enum', async () => {
+      expect(
+        await addMemberToOrg({ email: 'x@y.com', org_id: ORG_PUBX, seat_type: 'corporate' })
+      ).toMatch(/seat_type must be one of/);
+    });
+
+    it('refuses without admin context', async () => {
+      const handlers = createAdminToolHandlers(null);
+      const fn = handlers.get('add_member_to_org')!;
+      expect(await fn({ email: 'x@y.com', org_id: ORG_PUBX })).toMatch(/no signed-in admin/);
+    });
+  });
+
   // resend_invite happy-path requires Stripe-backed product validation, which
   // isn't seeded in the test DB. The existing /reinvite HTTP route test in
   // invite-events.test.ts covers the underlying revoke-then-create flow via


### PR DESCRIPTION
## Summary

Adds `add_member_to_org(email, org_id, role?, seat_type?)` Addie tool that wraps the existing `POST /api/organizations/:orgId/members/by-email` endpoint. The endpoint already does the four-state machine — invited / member_added / role_updated / no_change — so this PR is a thin internal HTTP wrapper, not a service refactor.

This closes the **action half** of the escalation pattern that motivated the whole memory chain:

- `diagnose_signin_block` → returns the verdict (data side)
- `orgMemberships` in memory → gives Addie the multi-org disambiguation she was missing (data side)
- **`add_member_to_org` → the verb** (this PR)

Now when an admin DMs Addie "add Raphaël to Triton as admin," she can act instead of escalating to humans.

## Why this is a thin wrapper

agentic-product-architect call: "wrap don't rebuild." `POST /members/by-email` already does:

- Authz (org admin/owner OR AAO super-admin via `ADMIN_API_KEY`)
- Four states (invite / add / update / no-op)
- Audit logging
- Seat type tracking
- Role caps (admins can't promote to owner)
- Rollback on partial failure

Tool just validates args, makes an internal POST with `Authorization: Bearer ${ADMIN_API_KEY}`, and renders the response.

## Tool description, exactly as Addie reads it

> Use when an admin or owner asks to add, invite, or promote a colleague on a paying org. Also the action to take when `diagnose_signin_block` returns `needs_invite` for an authorized requester. Handles four states automatically: invites new users (no WorkOS account yet), adds existing users to the org, updates roles, or no-ops if already correct. Do NOT use to remove members (no removal path), to change your own role, or for personal workspaces. Returns one of: invited, member_added, role_updated, no_change.

## Code-reviewer pickups (all fixed)

- **BASE_URL precedence (would have broken prod)** — invented `INTERNAL_API_BASE_URL` env var nothing else reads; in prod, `BASE_URL` is set and `PORT=8080`, my code would have skipped `BASE_URL` and tried `localhost:8080`. Aligned with `member-tools.ts:getBaseUrl` convention.
- **Variable shadow + dead var + camelCase** — `const url` shadowed an outer `url`; renamed to `endpoint` outer, dropped the dead inner.
- **Misleading `X-Addie-User-Id` header** — the route doesn't read it; comment was aspirational. Dropped.
- **Fabricated verdict in description** — claimed `diagnose_signin_block` returns `wrong_org`. It doesn't (only `needs_signin / needs_resend / needs_invite / needs_human`). Corrected.
- **Render the route's response seat_type** — not the input. The route may keep an existing seat_type when adding to an org the user already has a seat in.

## Test plan

- [x] `npm run typecheck` clean
- [x] 5 new arg-validation tests in `admin-invite-tools.test.ts` — missing email, malformed org_id, invalid role enum, invalid seat_type enum, no admin context
- [x] All 22 admin-invite-tools tests pass together
- [x] Live docker: tool reaches the route (confirmed via the WorkOS UnauthorizedException coming back through the wrapper — dummy WorkOS keys in dev). Real four-state machine outcomes covered by the route's own `member-by-email-policy.test.ts` with WorkOS mocked.

## Companion / chain

The Pubx escalation chain is now functionally complete:

| PR | Topic |
|---|---|
| #3605 | Invite events foundation |
| #3625 | Admin Invitations panel |
| #3644 | Addie invite tools (diagnose / list / resend / revoke) |
| #3651 | Persist inbound text |
| #3659 | Memory consolidator + admin view + tool |
| #3667 | Wire memory into prompt |
| #3675 | Multi-tool filter (used to sample threads) |
| #3678 | orgMemberships in memory |
| #3680 | Predicate consistency (#3677) |
| **This PR** | **add_member_to_org** — closes the action loop |

🤖 Generated with [Claude Code](https://claude.com/claude-code)