### PR TITLE
fix(billing): re-throw on transient revenue_events INSERT failure (closes #3693)

### DIFF
--- a/.changeset/revenue-events-throw-on-transient.md
+++ b/.changeset/revenue-events-throw-on-transient.md
@@ -1,0 +1,10 @@
+---
+---
+
+fix(billing): re-throw on transient revenue_events INSERT failure (closes #3693).
+
+Two webhook handlers were swallowing all errors when inserting into `revenue_events` and returning 200 — Stripe never retried, so transient DB errors silently lost paid revenue. The UNIQUE constraint on `stripe_invoice_id` makes the legitimate-retry case safe (PG `23505` = duplicate Stripe re-fire), but it was also masking real transient failures.
+
+Now distinguishes by error code: `23505` swallowed (legitimate dedupe), everything else re-thrown so Stripe retries with backoff. Applied at `http.ts:4180-4239` (`invoice.paid`) and `http.ts:4400-4458` (`invoice.payment_failed`).
+
+The third site (`charge.refunded` at line 4480) uses `stripe_charge_id` which is NOT a UNIQUE column on `revenue_events`. Cannot apply the 23505 pattern there until a schema migration adds the constraint. Kept the swallow with a comment explaining the gap. Follow-up tracked.

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -4222,12 +4222,26 @@ export class HTTPServer {
                   ]
                 );
               } catch (revenueError) {
-                logger.error({
-                  err: revenueError,
-                  orgId: org.workos_organization_id,
-                  invoiceId: invoice.id,
-                }, 'Failed to insert revenue event');
-                // Continue processing - don't fail the webhook
+                // PG code 23505 = unique_violation. revenue_events.stripe_invoice_id
+                // is UNIQUE, so a duplicate INSERT here means Stripe re-fired the
+                // same invoice.paid event — safe to swallow (the row already exists).
+                // Any other error (transient DB blip, statement timeout) means the
+                // row was lost; re-throw so Stripe retries with backoff. Without
+                // this, swallowing transient errors silently dropped paid revenue
+                // (#3693).
+                if ((revenueError as { code?: string })?.code === '23505') {
+                  logger.info(
+                    { orgId: org.workos_organization_id, invoiceId: invoice.id },
+                    'revenue_events INSERT hit UNIQUE on stripe_invoice_id; duplicate event ignored',
+                  );
+                } else {
+                  logger.error({
+                    err: revenueError,
+                    orgId: org.workos_organization_id,
+                    invoiceId: invoice.id,
+                  }, 'Failed to insert revenue event — re-throwing so Stripe retries');
+                  throw revenueError;
+                }
               }
 
               // Store subscription line items for subscriptions
@@ -4438,12 +4452,22 @@ export class HTTPServer {
                   invoiceId: invoice.id,
                 }, 'Failed payment event recorded');
               } catch (revenueError) {
-                logger.error({
-                  err: revenueError,
-                  orgId: org.workos_organization_id,
-                  invoiceId: invoice.id,
-                }, 'Failed to insert failed payment event');
-                // Continue processing - don't fail the webhook
+                // Same dedup pattern as the invoice.paid INSERT above:
+                // 23505 = duplicate Stripe retry, swallow safely; otherwise
+                // re-throw so the transient failure gets retried (#3693).
+                if ((revenueError as { code?: string })?.code === '23505') {
+                  logger.info(
+                    { orgId: org.workos_organization_id, invoiceId: invoice.id },
+                    'failed-payment revenue_events INSERT hit UNIQUE; duplicate event ignored',
+                  );
+                } else {
+                  logger.error({
+                    err: revenueError,
+                    orgId: org.workos_organization_id,
+                    invoiceId: invoice.id,
+                  }, 'Failed to insert failed payment event — re-throwing so Stripe retries');
+                  throw revenueError;
+                }
               }
 
               // Send Slack notification for failed payment
@@ -4514,12 +4538,19 @@ export class HTTPServer {
                     refundAmount: charge.amount_refunded,
                   }, 'Refund event recorded');
                 } catch (revenueError) {
+                  // Refund INSERTs use stripe_charge_id which is NOT a UNIQUE
+                  // column on revenue_events. Until that constraint is added
+                  // (separate migration), we cannot distinguish "Stripe retry"
+                  // from "transient error" by error code. Keep the swallow
+                  // here so retries don't dup, document the gap. Tracked for
+                  // a follow-up: add UNIQUE (stripe_charge_id) WHERE
+                  // revenue_type = 'refund', then apply the 23505 pattern
+                  // used for invoice-based events above (#3693 follow-up).
                   logger.error({
                     err: revenueError,
                     orgId: org.workos_organization_id,
                     chargeId: charge.id,
-                  }, 'Failed to insert refund event');
-                  // Continue processing - don't fail the webhook
+                  }, 'Failed to insert refund event (silent — needs schema follow-up to throw safely)');
                 }
               }
             }


### PR DESCRIPTION
## Summary

Closes #3693 (the first of three triage follow-ups from #3691).

Two webhook handlers were swallowing all errors when inserting into `revenue_events` and returning 200 — Stripe never retried, so transient DB errors silently lost paid revenue. Now distinguishes legitimate Stripe-retry duplicates (PG `23505` unique_violation) from real transient failures (re-throws so Stripe retries with backoff).

## Sites fixed

- `http.ts:4180-4239` — `invoice.paid` revenue_events INSERT
- `http.ts:4400-4458` — `invoice.payment_failed` revenue_events INSERT

```diff
} catch (revenueError) {
-  logger.error({...}, 'Failed to insert revenue event');
-  // Continue processing - don't fail the webhook
+  if ((revenueError as { code?: string })?.code === '23505') {
+    logger.info(...,'duplicate event ignored');
+  } else {
+    logger.error({...}, 'Failed to insert revenue event — re-throwing so Stripe retries');
+    throw revenueError;
+  }
}
```

## Out of scope (follow-up): refund site

The third site at `http.ts:4480` (`charge.refunded`) uses `stripe_charge_id` which is NOT a UNIQUE column on `revenue_events`. The 23505 pattern is unsafe there until a schema migration adds the constraint (recommend partial index `UNIQUE (stripe_charge_id) WHERE revenue_type = 'refund'`).

Kept the swallow with a comment explaining the gap. Per the security-reviewer's M3 finding, refunds older than Stripe's listable window never reconcile via the existing backfill admin tool — the refund-side schema follow-up is needed eventually.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Existing `admin-sync-revenue-backfill` integration tests still pass (4/4)
- [x] Pre-commit hook (unit + dynamic imports + typecheck) passes
- [ ] Manual: trigger an `invoice.paid` webhook against a customer; assert 200; trigger again with same `event.id`; assert 200 + only one revenue_events row (UNIQUE caught)
- [ ] Manual: simulate a transient pool error during the INSERT; assert 5xx + Stripe retries

## Refs

- Issue: #3693
- Catch-block audit context: #3691
- Lazy reconcile (covers customer impact): #3663

🤖 Generated with [Claude Code](https://claude.com/claude-code)