### PR TITLE
fix(billing): re-throw on demotePublicAgentsOnTierDowngrade failure (closes #3694)

### DIFF
--- a/.changeset/demote-throw-on-tier-downgrade.md
+++ b/.changeset/demote-throw-on-tier-downgrade.md
@@ -1,0 +1,12 @@
+---
+---
+
+fix(billing): re-throw on demotePublicAgentsOnTierDowngrade failure (closes #3694).
+
+When an org's tier downgrade flips it from a tier with API access to one without, `demotePublicAgentsOnTierDowngrade` must demote any `public`-marked agents to `members_only` and strip them from the org's brand.json — otherwise they stay publicly listed on a tier that doesn't allow it (silent entitlement leak).
+
+The call site at `http.ts:3792` was wrapped in a try/catch that logged the failure and continued. A transient DB error during demotion would silently leave the org with stale public agents until the next tier change.
+
+Hoists the demote call outside the swallow-on-error block, alongside the core subscription UPDATE — they're a pair (the UPDATE writes the new tier; demote enforces the corresponding agent visibility). The helper is idempotent on retry (`FOR UPDATE` on member_profiles row; returns null when no public agents remain), so a Stripe retry that re-fires the tier-downgrade webhook does the right thing.
+
+Closes the second of the three follow-ups identified in the #3691 catch-block audit.

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -3775,32 +3775,35 @@ export class HTTPServer {
                   org.workos_organization_id,
                 ]
               );
+
+              // Tier-downgrade enforcement is part of the entitlement write,
+              // not a downstream side effect. If the UPDATE flips an org from
+              // a tier with API access to one without, we MUST also demote
+              // any agents currently marked `public` — otherwise they remain
+              // publicly listed on a tier that doesn't allow it (silent
+              // entitlement leak). The helper is idempotent on retry
+              // (FOR UPDATE on member_profiles; no-ops if no public agents
+              // remain). Hoisted outside the swallow-on-error block so a
+              // transient failure here re-throws and Stripe retries (#3694).
+              if (oldTier && oldTier !== subUpdate.membership_tier) {
+                const { demotePublicAgentsOnTierDowngrade } = await import('./services/agent-visibility-enforcement.js');
+                await demotePublicAgentsOnTierDowngrade(
+                  org.workos_organization_id,
+                  oldTier as MembershipTier,
+                  (subUpdate.membership_tier ?? null) as MembershipTier | null,
+                );
+              }
             }
 
-            // Downstream side effects: tier-change enforcement, notifications,
-            // welcome email, autopublish, .deleted audit + activities. The
-            // existing pattern is "log + alert + continue" because some of
-            // these are non-idempotent (Slack, activity inserts) and a Stripe
-            // retry would refire them. Failures here are visible via
-            // notifySystemError; the column UPDATE that drives entitlement
-            // already happened above.
+            // Downstream side effects: notifications, welcome email,
+            // autopublish, .deleted audit + activities. The existing pattern
+            // is "log + alert + continue" because some of these are
+            // non-idempotent (Slack, activity inserts) and a Stripe retry
+            // would refire them. Failures here are visible via
+            // notifySystemError; the column UPDATE + tier-downgrade
+            // enforcement that drive entitlement already happened above.
             try {
               if (org && !suppressOrgUpdate && subUpdate) {
-                // Enforce the visibility gate for any tier change, including
-                // full cancellation (new tier becomes null). The helper is a
-                // no-op when the new tier still has API access.
-                if (oldTier && oldTier !== subUpdate.membership_tier) {
-                  const { demotePublicAgentsOnTierDowngrade } = await import('./services/agent-visibility-enforcement.js');
-                  try {
-                    await demotePublicAgentsOnTierDowngrade(
-                      org.workos_organization_id,
-                      oldTier as MembershipTier,
-                      (subUpdate.membership_tier ?? null) as MembershipTier | null,
-                    );
-                  } catch (err) {
-                    logger.warn({ err, orgId: org.workos_organization_id }, 'Failed to demote public agents on tier downgrade');
-                  }
-                }
 
                 // Detect tier change and notify admins
                 if (subUpdate.membership_tier && oldTier && subUpdate.membership_tier !== oldTier) {


### PR DESCRIPTION
## Summary

Closes #3694 (the second of three triage follow-ups from #3691).

When a Stripe webhook flips an org from a tier with API access to one without, `demotePublicAgentsOnTierDowngrade` must demote any `public`-marked agents to `members_only` and strip them from the org's brand.json — otherwise they stay publicly listed on a tier that doesn't allow public agents (silent entitlement leak).

The call site at `http.ts:3792` was wrapped in a `try/catch` that logged and continued. A transient DB error during demotion would silently leave stale public agents until the next tier change.

## Why hoist instead of just removing the inner try/catch

The previous structure had the demote call **inside** the outer swallow-on-error try, so removing the inner catch alone would let errors propagate to the outer swallow. Hoists the demote call outside that block, alongside the core subscription UPDATE — they're an entitlement pair:
- UPDATE writes the new `membership_tier` to the org row
- demote enforces the corresponding agent visibility on `member_profiles` + `brand.json`

Either failing alone leaves a coherent state; both completing or both retrying is the correct behavior.

## Idempotency check

Verified that `demotePublicAgentsOnTierDowngrade` is safe to re-run after partial completion:
- Reads `member_profiles` row with `FOR UPDATE`
- If no `public`-visibility agents remain → returns null (no-op)
- Brand.json clear at line 119+ is also idempotent — filters by demoted URLs, no write if `remaining.length === currentAgents.length`

A Stripe retry that re-fires the tier-downgrade webhook will be a no-op if the previous attempt completed the agent visibility writes.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Existing 10 webhook integration tests still pass (`admin-sync-revenue-backfill`, `admin-stripe-link-unlink`)
- [x] Pre-commit hook passes
- [ ] Manual: simulate transient pool error during demote → assert webhook returns 5xx → Stripe retries → second attempt completes successfully

## Refs

- Issue: #3694
- Catch-block audit context: #3691
- Sibling fix: #3697 (revenue_events silent-swallow, in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)