### PR TITLE
docs(reference/migration): fix url_type tracking_pixel → role: impression_tracker in creatives.mdx

### DIFF
--- a/.changeset/fix-migration-creatives-tracker-pixel-typo.md
+++ b/.changeset/fix-migration-creatives-tracker-pixel-typo.md
@@ -1,0 +1,6 @@
+---
+---
+
+docs(reference/migration): fix `url_type` "tracking_pixel" → `role: "impression_tracker"` in creatives.mdx
+
+The asset discovery example in the v2→v3 migration guide used `"url_type": "tracking_pixel"` inside a requirements block — wrong on two counts: `url_type` is not a field of `url-asset-requirements.json` (it belongs on the manifest-side asset payload), and `tracking_pixel` is not a valid `url-asset-type.json` enum value. The correct representation for this URL slot's constraint is `"role": "impression_tracker"`, using the `role` enum from `url-asset-requirements.json`. Closes #3692.

--- a/docs/reference/migration/creatives.mdx
+++ b/docs/reference/migration/creatives.mdx
@@ -14,7 +14,7 @@ AdCP 3.0 makes three breaking changes to creative handling: the `FormatCategory`
 ### What changed
 
 | v2 field | v3 field | Change type |
-|----------|----------|-------------|
+|----------|----------|-----------|
 | `type` on format objects (FormatCategory enum) | Removed | Deleted |
 | `format_types` filter on `list_creative_formats` / `get_products` | Removed | Deleted |
 
@@ -58,7 +58,7 @@ Replace `format_types` filters with `asset_types` (what the format needs) or `fo
 ### What changed
 
 | v2 field | v3 field | Change type |
-|----------|----------|-------------|
+|----------|----------|-----------|
 | `creative_ids` (string array) | `creative_assignments` (object array) | Replaced |
 
 ### Simple migration (equal weights)
@@ -163,7 +163,7 @@ Each assignment object:
 ### What changed
 
 | v2 field | v3 field | Change type |
-|----------|----------|-------------|
+|----------|----------|-----------|
 | `assets_required` (string array) | `assets` (object array) | Replaced |
 | `preview_image` | `format_card` | Replaced |
 
@@ -210,7 +210,7 @@ Each assignment object:
       "asset_type": "url",
       "required": false,
       "requirements": {
-        "url_type": "tracking_pixel"
+        "role": "impression_tracker"
       }
     }
   ]


### PR DESCRIPTION
Closes #3692

The asset discovery example at `docs/reference/migration/creatives.mdx:213` used `"url_type": "tracking_pixel"` inside a `requirements` block — wrong on two counts: `url_type` is not a property of `url-asset-requirements.json` (it lives on the manifest-side asset payload in `url-asset.json`), and `tracking_pixel` is not a valid `url-asset-type.json` enum value (valid: `clickthrough` / `tracker_pixel` / `tracker_script`). The correct constraint for this URL slot in a format definition is `"role": "impression_tracker"`, using the `role` enum from `url-asset-requirements.json`. This goes in the same direction as #3670 / #3671 / #3673 — aligning migration docs with actual schema shapes so sellers following the docs produce conformant output.

**Non-breaking justification:** docs-only change; no schema or wire format was modified. `url-asset-requirements.json` already has `additionalProperties: true`, so the old example validated silently but with no enforced semantic. The fix corrects the teaching example to use the schema-correct field.

**Note on `dist/docs/` occurrences:** `grep` finds five matching strings in `dist/docs/3.0.{0,1,2}/` and `dist/docs/3.0.0-rc.{1,2}/`. These are immutable versioned snapshots generated by `release-docs.yml` on each publish and are intentionally left unchanged — they are the historical record of what shipped, not source files.

**Pre-PR review:**
- docs-expert: approved — `"role": "impression_tracker"` is the correct field and value per `url-asset-requirements.json`; blocker from first pass (wrong field) resolved in second pass; no remaining blockers
- code-reviewer: approved — `tracker_pixel` enum value confirmed correct; `--empty` changeset correct for docs-only; `dist/docs/` occurrences are release snapshots, intentionally out of scope

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01XUwgQ1QoFMErF3k5A65AeJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUwgQ1QoFMErF3k5A65AeJ)_