### PR TITLE
docs(logger): document three-tier failure-handling model

### DIFF
--- a/.changeset/docs-logger-three-tier-convention.md
+++ b/.changeset/docs-logger-three-tier-convention.md
@@ -1,0 +1,10 @@
+---
+---
+
+Extend the `logger` JSDoc convention added in #3650 with the three-tier failure-handling model that emerged across PRs #3578, #3622, #3648, #3664, and #3672:
+
+- Tier 1 — `logger.error` — unexpected failures that page on-call
+- Tier 2 — `logger.warn` (no escalation) — expected third-party state we accept
+- Tier 3 — `logger.warn` + `createEscalation({ category: 'needs_human_action', dedup_key })` — actionable but not page-worthy, lands in the escalation queue with collapse semantics
+
+Docs-only. Future authors writing tool handlers or third-party-API wrappers now have a single reference for which tier to pick. Example call site for tier 3: `slack/client.ts:inviteToChannel`.

--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -197,16 +197,34 @@ export function createLogger(context: string | Record<string, unknown>) {
  * - error: Unexpected failures — operation failed but app continues
  * - fatal: Critical errors (app cannot continue)
  *
- * IMPORTANT: `logger.error()` and `logger.fatal()` (level >= 50) trigger the
- * Slack `#aao-errors` alert and a PostHog `$exception` capture via the pino
- * hook in this file (and `notifyErrorChannel` in `utils/posthog.ts`). Use
- * `error` for failures that should page an operator. For *expected* failures
- * — third-party 4xx, validation errors, anything where the caller already
- * returns a friendly user-facing message — use `warn` so the alert path is
- * not taken.
+ * # Three-tier failure handling
  *
- * Tool handlers in `addie/mcp/` are the most common source of confusion:
- * if your handler catches a failure and returns a "Failed to do X" string
- * to the user, that should be `logger.warn`, not `logger.error`. Reserve
- * `error` for catch blocks of network/parse failures that "shouldn't happen".
+ * The pino hook in this file forwards `error+` to Slack `#aao-errors` and
+ * PostHog `$exception` (via `notifyErrorChannel` in `utils/posthog.ts`).
+ * `warn` and below stay in stdout / OTel only. Operational signals that
+ * need human action but not paging go through the escalation queue
+ * (`db/escalation-db.ts`). Pick the right tier:
+ *
+ * 1. **`logger.error`** — *unexpected* failure that pages on-call.
+ *    Network glitches in catch blocks, unexpected exception types,
+ *    "this should never happen" assertions. Default for true bugs.
+ *
+ * 2. **`logger.warn`** (no escalation) — *expected* third-party state
+ *    we accept and shrug at. Deactivated Slack user, archived channel,
+ *    GitHub 404 on a cleaned-up resource, validation 4xx whose caller
+ *    already returns a friendly user-facing message. No human action.
+ *
+ * 3. **`logger.warn` + `createEscalation({ category: 'needs_human_action',
+ *    dedup_key: '...' })`** — *actionable but not page-worthy.* Bot is
+ *    not in a Slack channel it's being asked to invite users to (someone
+ *    has to invite the bot or fix the calling code). User OAuth token is
+ *    missing required scopes (user has to reconnect). Use a stable
+ *    `dedup_key` so repeat occurrences fold into one open escalation;
+ *    see `addie_escalations.dedup_key` (migration 459) and the example
+ *    in `slack/client.ts:inviteToChannel`.
+ *
+ * Tool handlers in `addie/mcp/` are the most common place to get this
+ * wrong: a handler that catches a failure and returns a "Failed to do X"
+ * string to the user should be tier 2 or 3, not tier 1. Reserve
+ * `logger.error` for the truly-unexpected case.
  */


### PR DESCRIPTION
## Summary

Extends the `logger` JSDoc convention added in #3650 with the third tier that emerged across this session's noise cleanup (PRs #3578 → #3672).

## The model

| Tier | Code | When |
|------|------|------|
| 1 | `logger.error` | Unexpected — pages on-call via `#aao-errors` + PostHog `$exception` |
| 2 | `logger.warn` | Expected third-party state we shrug at (deactivated user, archived channel) |
| 3 | `logger.warn` + `createEscalation({ category: 'needs_human_action', dedup_key })` | Actionable but not page-worthy — lands in the escalation queue, dedup_key collapses repeats |

## Why

After the convention doc in #3650, we discovered that "expected failure" splits into "shrug" vs "needs human action eventually." Without the third tier in the JSDoc, a future author has to read PR history to figure out the right pattern for a Slack `not_in_channel`-style condition.

Example call site for tier 3 lives in `slack/client.ts:inviteToChannel` (added in #3672).

## Test plan

- [x] Pre-commit (`test:unit + test-dynamic-imports + typecheck`) — passed
- [x] Docs-only change to JSDoc; no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)