### PR TITLE
fix(ipr): use aao-ipr-bot App token in ipr-agreement workflow

### DIFF
--- a/.changeset/fix-ipr-workflow-bot-token.md
+++ b/.changeset/fix-ipr-workflow-bot-token.md
@@ -1,0 +1,23 @@
+---
+---
+
+`ipr-agreement.yml` (adcp's own IPR workflow) now mints an installation
+token from the `aao-ipr-bot` GitHub App and uses it for both the checkout's
+persisted git credentials and the signature-recording script's API calls.
+
+**Why.** The `IPR signatures` branch ruleset on `main` requires PR + status
+checks for direct pushes, with bypass granted to org admins, repo admins,
+and the `aao-ipr-bot` App (integration `3500425`). The default
+`secrets.GITHUB_TOKEN` authenticates as `github-actions[bot]` (integration
+`15368`), which is not in the bypass list. Every push to append to
+`signatures/ipr-signatures.json` was being rejected with `GH013:
+Repository rule violations`, leaving the `IPR Policy / Signature` commit
+status pending and blocking PR merges (#3687, plus earlier signers
+backfilled in #3636).
+
+The cross-repo callable workflow `ipr-check-callable.yml` already uses
+this App-token pattern — adcp's own per-repo workflow just never got
+converted. This brings the two into alignment.
+
+**Secrets required (already configured at the org level).**
+`IPR_APP_ID` and `IPR_APP_PRIVATE_KEY`.

--- a/.github/workflows/ipr-agreement.yml
+++ b/.github/workflows/ipr-agreement.yml
@@ -32,11 +32,27 @@ jobs:
        github.event.issue.pull_request != null &&
        contains(github.event.comment.body, 'I have read the IPR Policy'))
     steps:
+      # The default GITHUB_TOKEN authenticates as github-actions[bot], which
+      # is not in the IPR-signatures ruleset bypass list — pushes to main get
+      # rejected by branch protection (GH013). The aao-ipr-bot App is in the
+      # bypass list, so we mint an installation token from it and use that
+      # for both the checkout's persisted credentials (git push) and the
+      # script's API calls. Same pattern as ipr-check-callable.yml.
+      - name: Mint AAO IPR Bot installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.IPR_APP_ID }}
+          private-key: ${{ secrets.IPR_APP_PRIVATE_KEY }}
+          owner: adcontextprotocol
+          repositories: adcp
+
       - name: Checkout default branch
         uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 1
+          token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true
 
       - name: Setup Node
@@ -46,5 +62,5 @@ jobs:
 
       - name: Check and record IPR signature
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: node scripts/ipr/check-and-record.mjs


### PR DESCRIPTION
## Summary

- Mint an installation token from the `aao-ipr-bot` GitHub App in `.github/workflows/ipr-agreement.yml` and use it for both the checkout's persisted git credentials and the script's GitHub API calls.
- Same App-token pattern that `ipr-check-callable.yml` already uses for sibling AAO repos — adcp's own per-repo workflow just never got converted.

## Why

The default `secrets.GITHUB_TOKEN` authenticates as `github-actions[bot]` (integration `15368`), which is **not** in the `IPR signatures` branch ruleset bypass list. Pushes to `main` from the IPR workflow get rejected with:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
- Changes must be made through a pull request.
- 6 of 6 required status checks are expected.
remote rejected ! HEAD -> main (push declined due to repository rule violations)
```

The `aao-ipr-bot` App (integration `3500425`) **is** in the bypass list. Switching to its installation token unblocks the signature ledger writes.

Concrete failure observed on #3687: signer commented "I have read the IPR Policy" at 2026-04-30 19:08:17, workflow run [25184252191](https://github.com/adcontextprotocol/adcp/actions/runs/25184252191) failed with `GH013` after exhausting all 5 rebase-retry attempts. Same root cause as the signers backfilled manually in #3636 (Erik, Katie).

## Prerequisites (already in place)

- `aao-ipr-bot` GitHub App installed on `adcontextprotocol` org (installation `126995854`)
- App is in the `IPR signatures` ruleset bypass list
- Org-level secrets `IPR_APP_ID` and `IPR_APP_PRIVATE_KEY` exist (created 5 days ago for the callable workflow)

## Test plan

- [ ] Merge this PR
- [ ] Watch the next IPR signing comment — the workflow should mint a token, push to `main`, and flip `IPR Policy / Signature` to success
- [ ] To unblock #3687 specifically: ask `@ohalushchak-exadel` to re-post `I have read the IPR Policy` so the `issue_comment` event re-fires with the fixed workflow
- [ ] Confirm the cross-repo callable workflow is unaffected (no shared edits to it; only `ipr-agreement.yml` changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)