### PR TITLE
fix(addie): stop URL wrapper at * " ' + ban phantom-tool-absence claims

### DIFF
--- a/.changeset/addie-url-wrap-stops-and-phantom-tool-claims.md
+++ b/.changeset/addie-url-wrap-stops-and-phantom-tool-claims.md
@@ -1,0 +1,4 @@
+---
+---
+
+Two fixes for Addie's GitHub Connect flow that re-surfaced after #3700 deployed. (1) `wrapUrlsForSlack` now stops the URL match at `*`/`"`/`'` so a model-emitted `**URL**` produces `**<URL>**` (Slack-explicit-link wrapper around just the URL) rather than `<URL**>` (asterisks swallowed into the link target — the production 404 root cause). Deterministic — doesn't depend on prompt compliance. (2) New constraint in `constraints.md` ("Never Claim Tools Are Unavailable Without Checking") with the GitHub-flow example, since the existing `behaviors.md` rule lives before dynamic context and bound less tightly than needed; constraints load last so the prohibition is more salient.

--- a/server/src/addie/rules/constraints.md
+++ b/server/src/addie/rules/constraints.md
@@ -26,6 +26,23 @@ Identity.md's "Honesty over confidence" section is the authority on this; the op
 
 This applies to every tool, not just search_docs: schema lookups, member directory, GitHub issue drafting, validation tools.
 
+## Never Claim Tools Are Unavailable Without Checking
+
+CRITICAL: Do NOT say things like "I don't have X tools available in this conversation" / "I don't have access to that capability right now" / "the X tools aren't loaded here." Your authoritative tool catalog is at the bottom of every prompt; if a tool isn't listed there, it doesn't exist — full stop. There is no per-conversation gating. Saying otherwise is a hallucination that erodes trust.
+
+If the user asks about a capability and you're not sure: check the catalog at the bottom of your prompt, or use `search_docs` with `"aao"` + the topic. Then answer with what you found, not with a phantom-absence claim.
+
+If the catalog genuinely has no tool for what they want, name a real alternative: a public URL from `urls.md`, the working-groups page, or — for the specific case of connecting GitHub — the canonical bouncer at https://agenticadvertising.org/connect/github (this URL is in `urls.md`, you can always cite it).
+
+Wrong:
+- "I don't have account linking tools available in this conversation."
+- "I can't generate the link programmatically right now."
+- "Settings tools aren't loaded here."
+
+Right:
+- "Account linking lives at https://agenticadvertising.org/connect/github — that bounces you through login and starts the OAuth flow."
+- "I checked the catalog — we have `get_account_link` for the Slack ↔ AAO link. For GitHub specifically, the connect URL is https://agenticadvertising.org/connect/github."
+
 ## Never Claim Unexecuted Actions
 CRITICAL: NEVER describe completing an action unless the corresponding tool was actually called AND returned a success result.
 

--- a/server/src/addie/security.ts
+++ b/server/src/addie/security.ts
@@ -213,12 +213,19 @@ export async function resolveSlackMentions(
 }
 
 /**
- * Wrap bare URLs in Slack explicit link format to preserve fragments.
+ * Wrap bare URLs in Slack explicit link format to preserve fragments and stop
+ * Slack's auto-linker from sweeping wrapping punctuation into the link target.
  *
- * Slack's auto-linker can drop URL fragments (the #... portion),
- * which breaks Stripe checkout URLs that require the fragment for the
- * encrypted session data. Wrapping in <url> ensures Slack preserves
- * the full URL including fragments.
+ * Slack's auto-linker has two failure modes:
+ *  1. It drops URL fragments (#...), which breaks Stripe checkout URLs that
+ *     require the fragment for the encrypted session data.
+ *  2. It includes trailing punctuation in the link target, so a model that
+ *     emits `**URL**` produces a click to `URL**` and 404s.
+ *
+ * Wrapping in `<url>` Slack-explicit-link syntax fixes both — but only if our
+ * URL boundary regex stops at the same characters Slack would otherwise use
+ * as wrappers. The character class below excludes whitespace and the
+ * characters that wrap URLs in chat output: `>`, `)`, backtick, `*`, `"`, `'`.
  *
  * Only wraps URLs not already inside Slack link syntax (< >).
  */
@@ -227,7 +234,7 @@ export function wrapUrlsForSlack(text: string): string {
   // Use negative lookbehind for < and ensure URL isn't followed by >
   // Also skip URLs inside backtick code spans
   return text.replace(
-    /(?<![<`])(https?:\/\/[^\s>)`]+)/g,
+    /(?<![<`])(https?:\/\/[^\s>)`*"']+)/g,
     (match, url, offset) => {
       // Check if we're inside a backtick code span
       const before = text.substring(0, offset);

--- a/server/tests/unit/slack-integration.test.ts
+++ b/server/tests/unit/slack-integration.test.ts
@@ -394,4 +394,29 @@ describe("wrapUrlsForSlack", () => {
     const text = "[Click here](https://example.com/checkout)";
     expect(wrapUrlsForSlack(text)).toBe("[Click here](<https://example.com/checkout>)");
   });
+
+  // The asterisk-wrapped-URL case observed in production: when Claude emitted
+  // `**https://...connect/github**`, Slack's auto-linker swept the trailing `**`
+  // into the link target and routed the click to `/connect/github*` — 404.
+  // The wrapper must stop the URL match at the trailing wrapping character so
+  // the asterisks stay outside `<...>`.
+  it("should not include trailing asterisks inside the wrapped URL", () => {
+    const text = "**https://example.com/path**";
+    expect(wrapUrlsForSlack(text)).toBe("**<https://example.com/path>**");
+  });
+
+  it("should not include a trailing single asterisk inside the wrapped URL", () => {
+    const text = "*https://example.com/path*";
+    expect(wrapUrlsForSlack(text)).toBe("*<https://example.com/path>*");
+  });
+
+  it("should not include trailing double quotes inside the wrapped URL", () => {
+    const text = 'See "https://example.com/path" for details';
+    expect(wrapUrlsForSlack(text)).toBe('See "<https://example.com/path>" for details');
+  });
+
+  it("should not include trailing single quotes inside the wrapped URL", () => {
+    const text = "See 'https://example.com/path' for details";
+    expect(wrapUrlsForSlack(text)).toBe("See '<https://example.com/path>' for details");
+  });
 });


### PR DESCRIPTION
## Summary

Two regressions visible in tonight's Slack transcript even after #3700 (the bold-URL prompt rule) shipped:

```
Addie: To connect GitHub so you can file issues directly through me, go here:
       **https://agenticadvertising.org/connect/github**

Brian: try again

Addie: I don't have account linking tools available in this conversation —
       I can't generate the link programmatically right now.
       Go to https://agenticadvertising.org/connect/github directly...
```

### Bug 1 — `wrapUrlsForSlack` still leaks trailing asterisks

`security.ts:225` — the URL boundary regex `[^\s>)\`]+` doesn't stop at `*`. So when Claude emits `**URL**`, the wrapper matches `URL**` and produces `<URL**>`. Slack honors the explicit-link wrapper, but the link target still contains the asterisks and the click 404s.

Fix: add `*`, `"`, `'` to the stop character class. Now `**URL**` → `**<URL>**` (asterisks remain plain text outside the wrap; URL inside is clean). **Deterministic — doesn't depend on prompt compliance.**

### Bug 2 — Addie claims tools are unavailable without checking

The retry message — *"I don't have account linking tools available in this conversation"* — is the **exact phrase already banned** at `behaviors.md:126`. The existing rule didn't bind tightly enough. behaviors.md loads before dynamic context (`rules/index.ts:23`); constraints.md loads after.

Fix: add a hard constraint *"Never Claim Tools Are Unavailable Without Checking"* to `constraints.md` with the production failure as the worked example, and concrete right/wrong patterns. This complements (doesn't duplicate) the existing "Tool Outcomes — Three Distinct Cases" rule, which covers tools that returned errors; the new rule covers the "didn't even check the catalog before claiming absence" failure mode.

## Test plan

- [x] `npx vitest run server/tests/unit/slack-integration.test.ts` — 48 passed (4 new cases for the `*`/`"`/`'` boundaries; existing 44 unchanged)
- [x] `node scripts/check-owned-links.js` — all browser-facing links reachable
- [x] `npx tsc -p server/tsconfig.json --noEmit` clean
- [ ] Manual: re-ask Addie about connecting GitHub in Slack and confirm the URL renders cleanly + she doesn't claim tools are unavailable in this conversation

## Why this layered approach

Bug 1 is deterministic — fix the wrapper and the URL class of bug never recurs regardless of model behavior. Bug 2 is best-effort prompt engineering — the constraint should bind much harder than the previous behaviors-level rule, but I'd add a runtime validator if it recurs (pattern-detect the prohibited phrases and either flag or rewrite). Holding off on the validator until we see whether the constraint promotion is enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)