### PR TITLE
fix(account-linking): call WorkOS before DB swap on set-primary-email

### DIFF
--- a/.changeset/fix-account-link-primary-workos-first.md
+++ b/.changeset/fix-account-link-primary-workos-first.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix `PUT /api/me/linked-emails/primary` to call WorkOS before mutating the database, so a WorkOS rejection no longer leaves `users.email` and `organization_memberships.email` ahead of WorkOS. WorkOS email-collision errors (including the previously-unhandled `GenericServerException: This email is not available.`) are now classified by a dedicated `isEmailUnavailable` helper and surfaced as a friendly 409 instead of a generic 500.

--- a/server/src/routes/account-linking-errors.ts
+++ b/server/src/routes/account-linking-errors.ts
@@ -1,0 +1,18 @@
+// WorkOS surfaces email-collision rejections in several shapes: an
+// `email_already_exists` / `email_not_available` code, a 409, or — as seen
+// in production — a `GenericServerException` with status 422 and message
+// "This email is not available." A bare 422 alone is NOT enough: WorkOS
+// returns 422 for many unrelated validation failures, so we require a
+// message match too.
+export function isEmailUnavailable(error: any): boolean {
+  if (!error) return false;
+  if (error.code === 'email_already_exists' || error.code === 'email_not_available') return true;
+  if (error.status === 409) return true;
+  const message = typeof error.message === 'string' ? error.message.toLowerCase() : '';
+  const messageMatches =
+    message.includes('email is not available') ||
+    message.includes('email already exists') ||
+    message.includes('email already in use');
+  if (error.status === 422 && messageMatches) return true;
+  return messageMatches;
+}

--- a/server/src/routes/account-linking.ts
+++ b/server/src/routes/account-linking.ts
@@ -8,6 +8,7 @@ import { mergeUsers } from '../db/user-merge-db.js';
 import { sendEmailLinkVerification } from '../notifications/email.js';
 import { getWorkos } from '../auth/workos-client.js';
 import { CachedPostgresStore } from '../middleware/pg-rate-limit-store.js';
+import { isEmailUnavailable } from './account-linking-errors.js';
 
 const logger = createLogger('account-linking');
 
@@ -213,18 +214,46 @@ export function createAccountLinkingRouter(): Router {
 
       const oldPrimary = req.user!.email;
 
-      // DB-first, then WorkOS: if WorkOS fails we rollback cleanly.
-      // If WorkOS succeeds but COMMIT fails (extremely rare), the user.updated
-      // webhook will re-sync the email from WorkOS on the next event.
-      let aliasEmail: string;
+      // Verify the alias exists before touching WorkOS so we don't change
+      // WorkOS state for an email the user hasn't actually verified.
+      const aliasRead = await query(
+        `SELECT email FROM user_email_aliases
+         WHERE workos_user_id = $1 AND LOWER(email) = $2 AND verified_at IS NOT NULL`,
+        [userId, normalizedEmail]
+      );
+      if (aliasRead.rows.length === 0) {
+        return res.status(404).json({ error: 'Email is not linked to your account' });
+      }
+      const aliasEmail: string = aliasRead.rows[0].email;
+
+      // WorkOS first (source of truth for auth). If WorkOS rejects, our DB is
+      // unchanged and we surface a clear error.
+      //
+      // If WorkOS accepts but the local swap below fails, `users.email` and
+      // `organization_memberships.email` will eventually re-sync via the
+      // user.updated webhook. The `user_email_aliases` table is NOT touched
+      // by the webhook, so a partial failure here can leave the alias list
+      // stale (the new email remains as a verified alias, the old primary
+      // is not recorded). UNIQUE(LOWER(email)) on aliases prevents anyone
+      // else from claiming the abandoned email; cleanup is manual.
+      try {
+        await getWorkos().userManagement.updateUser({ userId, email: aliasEmail });
+      } catch (workosError: any) {
+        if (isEmailUnavailable(workosError)) {
+          return res.status(409).json({ error: 'This email is already associated with another account in our auth system' });
+        }
+        throw workosError;
+      }
+
       const pool = getPool();
       const client = await pool.connect();
       try {
         await client.query('BEGIN');
 
-        // Lock and verify the alias belongs to this user
+        // Re-lock and re-verify in case the alias changed between the read
+        // above and now.
         const alias = await client.query(
-          `SELECT id, email FROM user_email_aliases
+          `SELECT email FROM user_email_aliases
            WHERE workos_user_id = $1 AND LOWER(email) = $2 AND verified_at IS NOT NULL
            FOR UPDATE`,
           [userId, normalizedEmail]
@@ -232,24 +261,26 @@ export function createAccountLinkingRouter(): Router {
 
         if (alias.rows.length === 0) {
           await client.query('ROLLBACK');
-          return res.status(404).json({ error: 'Email is not linked to your account' });
+          // WorkOS already points at the new email; the user.updated webhook
+          // will re-sync users.email and organization_memberships.email. The
+          // alias table will remain stale until manual cleanup.
+          logger.warn(
+            { userId, normalizedEmail },
+            'Alias disappeared between WorkOS update and DB swap; users.email will reconcile via webhook, aliases need manual cleanup'
+          );
+          return res.status(409).json({ error: 'Email link state changed; please refresh and try again' });
         }
 
-        aliasEmail = alias.rows[0].email;
-
-        // Update users table with the new primary email
         await client.query(
           `UPDATE users SET email = $1, updated_at = NOW() WHERE workos_user_id = $2`,
           [aliasEmail, userId]
         );
 
-        // Remove the new primary from aliases
         await client.query(
           `DELETE FROM user_email_aliases WHERE workos_user_id = $1 AND LOWER(email) = $2`,
           [userId, normalizedEmail]
         );
 
-        // Add old primary as an alias
         await client.query(
           `INSERT INTO user_email_aliases (workos_user_id, email)
            VALUES ($1, $2)
@@ -257,7 +288,6 @@ export function createAccountLinkingRouter(): Router {
           [userId, oldPrimary]
         );
 
-        // Update organization_memberships to reflect new email
         await client.query(
           `UPDATE organization_memberships SET email = $1, updated_at = NOW()
            WHERE workos_user_id = $2`,
@@ -272,14 +302,6 @@ export function createAccountLinkingRouter(): Router {
         client.release();
       }
 
-      // Update WorkOS (source of truth for auth) AFTER the transaction is
-      // committed and the connection is released. This avoids holding a DB
-      // connection idle while waiting on an external network call.
-      // If WorkOS rejects the update the outer catch handles the error;
-      // the DB change is already committed, and the user.updated webhook
-      // will re-sync on the next WorkOS event if needed.
-      await getWorkos().userManagement.updateUser({ userId, email: aliasEmail });
-
       logger.info(
         { userId, oldPrimary, newPrimary: aliasEmail },
         'Primary email changed'
@@ -287,10 +309,6 @@ export function createAccountLinkingRouter(): Router {
 
       return res.json({ status: 'primary_updated', primary_email: aliasEmail });
     } catch (error: any) {
-      // WorkOS may reject the email update (e.g. email already taken in WorkOS)
-      if (error?.code === 'email_already_exists' || error?.status === 409) {
-        return res.status(409).json({ error: 'This email is already associated with another account in our auth system' });
-      }
       logger.error({ error }, 'Failed to set primary email');
       return res.status(500).json({ error: 'Failed to update primary email' });
     }

--- a/server/tests/unit/set-primary-email.test.ts
+++ b/server/tests/unit/set-primary-email.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
+import { isEmailUnavailable } from '../../src/routes/account-linking-errors.js';
 
 /**
  * Static analysis test for the set-primary-email endpoint.
@@ -53,14 +54,60 @@ describe('Set primary email endpoint', () => {
     expect(source).toMatch(/FOR UPDATE/);
   });
 
-  it('does WorkOS update after DB transaction to avoid holding connections during network calls', () => {
-    const commitIdx = source.indexOf("'COMMIT'");
+  it('updates WorkOS before the DB swap so a WorkOS rejection leaves DB state untouched', () => {
+    const beginIdx = source.indexOf("'BEGIN'");
     const workosIdx = source.indexOf('getWorkos().userManagement.updateUser');
-    expect(workosIdx).toBeGreaterThan(commitIdx);
+    expect(workosIdx).toBeGreaterThan(-1);
+    expect(beginIdx).toBeGreaterThan(-1);
+    expect(workosIdx).toBeLessThan(beginIdx);
+  });
+
+  it('classifies WorkOS rejections via isEmailUnavailable and returns a friendly 409', () => {
+    expect(source).toMatch(/isEmailUnavailable\(workosError\)/);
+    expect(source).toMatch(/already associated with another account/);
   });
 
   it('rolls back on error', () => {
     expect(source).toMatch(/ROLLBACK/);
+  });
+});
+
+describe('isEmailUnavailable', () => {
+  it('matches WorkOS GenericServerException with "This email is not available" message', () => {
+    expect(isEmailUnavailable({
+      name: 'GenericServerException',
+      status: 422,
+      message: 'This email is not available.',
+    })).toBe(true);
+  });
+
+  it('matches by code regardless of status', () => {
+    expect(isEmailUnavailable({ code: 'email_already_exists' })).toBe(true);
+    expect(isEmailUnavailable({ code: 'email_not_available' })).toBe(true);
+  });
+
+  it('matches a 409 conflict response', () => {
+    expect(isEmailUnavailable({ status: 409, message: 'Conflict' })).toBe(true);
+  });
+
+  it('does NOT match a bare 422 with an unrelated validation message', () => {
+    expect(isEmailUnavailable({
+      status: 422,
+      message: 'Password does not meet complexity requirements.',
+    })).toBe(false);
+  });
+
+  it('does NOT match a generic server error', () => {
+    expect(isEmailUnavailable({ status: 500, message: 'Internal server error' })).toBe(false);
+  });
+
+  it('does NOT match a vague "email already verified" message', () => {
+    expect(isEmailUnavailable({ status: 422, message: 'Email already verified' })).toBe(false);
+  });
+
+  it('returns false for null/undefined', () => {
+    expect(isEmailUnavailable(null)).toBe(false);
+    expect(isEmailUnavailable(undefined)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- Reorders `PUT /api/me/linked-emails/primary` to call WorkOS *before* the DB swap, so a WorkOS rejection no longer leaves `users.email` / `organization_memberships.email` ahead of WorkOS.
- Classifies WorkOS email-collision errors via a new `isEmailUnavailable` helper (codes, 409, or 422 + message match) and returns a friendly **409** instead of a generic 500.
- Adds a small pure-helper module (`account-linking-errors.ts`) so the classifier can be unit-tested without dragging in `auth.ts`'s top-level WorkOS init.

## Background

Production hit:

```
Failed to set primary email: This email is not available.
GenericServerException: This email is not available.
  at WorkOSNode.handleHttpError ...
  at async UserManagement.updateUser ...
```

This is WorkOS rejecting an email-update because another WorkOS user already holds that address. With the old DB-first ordering, the swap was already committed by the time WorkOS rejected — so `users.email` pointed at the new address while WorkOS still pointed at the old one. The route also caught only `email_already_exists` / status 409, so this `GenericServerException` fell through to a generic 500.

## What changed

`server/src/routes/account-linking.ts`
- Read alias (no lock) → `getWorkos().userManagement.updateUser` → if rejected, return 409 with a clear message; if accepted, open transaction with `FOR UPDATE` re-check → swap → COMMIT.
- If the alias disappears between the read and the FOR UPDATE re-check, log a warn and 409. `users.email` and `organization_memberships.email` will reconcile via the `user.updated` webhook; `user_email_aliases` won't (the comment now says so explicitly).

`server/src/routes/account-linking-errors.ts` (new)
- Pure helper `isEmailUnavailable(error)`. Bare 422 is **not** enough — WorkOS returns 422 for many unrelated validation failures. Status 422 only triggers when the message matches "email is not available" / "email already exists" / "email already in use".

`server/tests/unit/set-primary-email.test.ts`
- Static-analysis assertion flipped: WorkOS update must come **before** `BEGIN`, not after `COMMIT`.
- New unit tests for `isEmailUnavailable` (matches the prod error shape, doesn't false-positive on a 422 password-policy error or "email already verified").

## Reviewer notes

- Both `code-reviewer` and `security-reviewer` ran before this PR. Substantive feedback addressed: tightened classifier (no bare 422, no loose `email already`), corrected the misleading "webhook will reconcile" comment to call out that aliases need manual cleanup, added real unit tests for the classifier.
- Pre-existing items left out of scope (flagged by reviewers): rate-limiter keyed only by IP rather than user; no dedicated audit-log row for primary-email change.

## Test plan

- [x] `npx vitest run server/tests/unit/set-primary-email.test.ts` — 21 pass
- [x] `npx tsc -p server/tsconfig.json --noEmit` — clean
- [x] Pre-commit hook (full unit suite + dynamic-imports + typecheck) — pass
- [ ] CI green
- [ ] Smoke: linked-emails primary swap on staging with a real WorkOS-collision target

🤖 Generated with [Claude Code](https://claude.com/claude-code)