### PR TITLE
fix(addie): rename Member hub → Your hub + name 3 GitHub surfaces in prompt

### DIFF
--- a/.changeset/your-hub-rename-and-three-github-surfaces.md
+++ b/.changeset/your-hub-rename-and-three-github-surfaces.md
@@ -1,0 +1,4 @@
+---
+---
+
+Rename the `/member-hub` page label from "Member hub" to "Your hub" so the personal-dashboard framing matches what the page actually is (it greets "Welcome back, [firstName]" and is entirely about the signed-in user — "member" was reading as organizational). URL stays at `/member-hub` for back-compat. Also fixes Addie's GitHub guidance: `urls.md` and `member-context.ts` now name three distinct surfaces — `/account` (Social-links text field for community profile display), `/member-hub` (Connections card with Connect/Disconnect button), `/connect/github` (session-aware bouncer that starts the OAuth flow on click) — so Addie stops sending users to `/account` when they ask to disconnect. Filed #3705 for the broader Slack ↔ web session-bridging gap (separate concern).

--- a/server/public/dashboard-organization.html
+++ b/server/public/dashboard-organization.html
@@ -790,7 +790,7 @@
   <div class="hub-container">
     <div id="hub-loading" class="hub-loading">
       <div class="spinner"></div>
-      <p>Loading your member hub...</p>
+      <p>Loading...</p>
     </div>
 
     <div id="hub-content" style="display: none;"></div>

--- a/server/public/membership/hub.html
+++ b/server/public/membership/hub.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Member hub - AgenticAdvertising.org</title>
+  <title>Your hub - AgenticAdvertising.org</title>
   <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <style>
@@ -1341,7 +1341,7 @@
   <div class="hub-container">
     <div id="hub-loading" class="hub-loading">
       <div class="spinner"></div>
-      <p>Loading your member hub...</p>
+      <p>Loading your hub...</p>
     </div>
 
     <div id="hub-content" style="display: none;"></div>
@@ -1399,8 +1399,8 @@
               : githubRes.ok ? await githubRes.json() : { connected: false };
             document.getElementById('hub-loading').innerHTML =
               '<div class="hub-empty-panel">' +
-              '<div class="hub-kicker">My hub</div>' +
-              '<h1>Your member hub will light up once you join a workspace</h1>' +
+              '<div class="hub-kicker">Your hub</div>' +
+              '<h1>Your hub will light up once you join a workspace</h1>' +
               '<p>You can still explore membership plans, browse the community, and decide how you want to participate before joining.</p>' +
               '<div class="hub-empty-actions">' +
               '<a href="/membership" class="btn btn-primary">Explore membership</a>' +
@@ -1441,7 +1441,7 @@
       } catch (err) {
         console.error('Hub load error:', err);
         document.getElementById('hub-loading').innerHTML =
-          '<p>Failed to load member hub. <a href="/member-hub">Try again</a></p>';
+          '<p>Failed to load your hub. <a href="/member-hub">Try again</a></p>';
       }
     }
 
@@ -1573,7 +1573,7 @@
         <!-- Header -->
         <div class="hub-header">
           <div class="hub-hero-card">
-            <div class="hub-kicker">My hub</div>
+            <div class="hub-kicker">Your hub</div>
             <h1>Welcome back, ${escapeHtml(firstName)}.</h1>
             <p class="hub-lede">This is your home base for membership progress, profile momentum, and the next things worth doing inside AgenticAdvertising.org.</p>
             <div class="hub-header-meta">

--- a/server/src/addie/member-context.ts
+++ b/server/src/addie/member-context.ts
@@ -1482,10 +1482,11 @@ export function formatMemberContextForPrompt(context: MemberContext, channel: 'w
       lines.push(`GitHub: ${context.community_profile.github_username}`);
     } else {
       lines.push([
-        'GitHub: Not linked. There are TWO distinct GitHub surfaces — keep them separate, and use the exact URLs below (do not paraphrase to /dashboard, /settings, etc.). Render URLs per the URL Formatting rule (markdown link or bare URL only — never wrap in `**`/`*`).',
-        '  (1) Public profile display — to show their GitHub handle on their community profile page, send them to https://agenticadvertising.org/account.',
-        '  (2) OAuth connection — to let you file issues on adcontextprotocol/adcp under their GitHub identity, send them to https://agenticadvertising.org/connect/github (this bounces through login if needed and starts the WorkOS Pipes OAuth flow).',
-        'When the user asks you to file an issue, the create_github_issue tool already surfaces the (2) Connect link automatically — show its full output. Only mention these URLs explicitly when the user asks how to connect outside of filing an issue.',
+        'GitHub: Not linked. There are THREE distinct GitHub surfaces. Pick the one that matches the user\'s intent and use the exact URL — do not paraphrase. Render URLs per the URL Formatting rule (markdown link or bare URL only — never wrap in `**`/`*`).',
+        '  (a) Public-profile display — they want their GitHub handle to appear on their community profile page (text-field only, no OAuth): https://agenticadvertising.org/account (Social links section).',
+        '  (b) Connect / disconnect OAuth — they want to manage the WorkOS Pipes GitHub connection (e.g. "disconnect", "remove access", "reconnect"): https://agenticadvertising.org/member-hub (Connections card; one-click Disconnect button).',
+        '  (c) Start OAuth flow — they want to *begin* connecting GitHub right now from this conversation: https://agenticadvertising.org/connect/github (session-aware bouncer; bounces through login if needed and lands on the OAuth consent screen).',
+        'When the user asks you to file an issue, the create_github_issue tool already surfaces the (c) Connect link automatically — show its full output. Only mention these URLs explicitly when the user asks how to connect, disconnect, or manage GitHub outside of filing an issue.',
       ].join('\n'));
     }
   }

--- a/server/src/addie/rules/urls.md
+++ b/server/src/addie/rules/urls.md
@@ -15,8 +15,9 @@ are excluded from CI checks).
 - https://agenticadvertising.org/dashboard — Member dashboard (billing, settings, team)
 - https://agenticadvertising.org/dashboard#team — Team management and pending join requests
 - https://agenticadvertising.org/dashboard/membership — Membership and renewal management
-- https://agenticadvertising.org/account — Personal account settings, including the GitHub username field that surfaces on the user's community profile (display only, not OAuth)
-- https://agenticadvertising.org/connect/github — Session-aware bouncer that starts the WorkOS Pipes GitHub OAuth flow so Addie can file issues under the user's GitHub identity (different from `/account` — that one is just a profile-display field)
+- https://agenticadvertising.org/account — Personal account settings (form fields you type into: name, bio, expertise, social links, including the GitHub-username text field that surfaces on the user's community profile). NOT where the GitHub OAuth connection lives.
+- https://agenticadvertising.org/member-hub — "Your hub" — the personal dashboard (engagement, working group recs, profile completeness). Hosts the **Connections card** where users connect or disconnect GitHub OAuth (the one-click toggle backed by WorkOS Pipes). Use this URL when the user asks how to disconnect or manage their GitHub OAuth connection.
+- https://agenticadvertising.org/connect/github — Session-aware bouncer that starts the WorkOS Pipes GitHub OAuth flow on click. Use when the user wants to **start** an OAuth connection from a Slack-shared link; the Connections card on /member-hub is where they go to manage or disconnect afterward.
 - https://agenticadvertising.org/member-profile — Member profile, company description, and logo upload
 - https://agenticadvertising.org/community — Community hub
 - https://agenticadvertising.org/legal/terms — Terms of Service (canonical path; /terms redirects here)

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -2276,7 +2276,7 @@ export class HTTPServer {
       await this.serveHtmlWithConfig(req, res, 'members.html');
     });
 
-    // Member hub
+    // Your hub — personal dashboard (URL kept as /member-hub for back-compat)
     this.app.get("/member-hub", async (req, res) => {
       await this.serveHtmlWithConfig(req, res, 'membership/hub.html');
     });

--- a/server/tests/unit/member-context.test.ts
+++ b/server/tests/unit/member-context.test.ts
@@ -682,8 +682,9 @@ describe('community_profile formatting', () => {
     expect(result).toContain('Community profile: Not yet public');
     expect(result).toContain('Encourage them to visit');
     expect(result).toContain('GitHub: Not linked');
-    // Both surfaces must be named with exact URLs so Addie has nothing to paraphrase.
+    // All three surfaces must be named with exact URLs so Addie has nothing to paraphrase.
     expect(result).toContain('https://agenticadvertising.org/account');
+    expect(result).toContain('https://agenticadvertising.org/member-hub');
     expect(result).toContain('https://agenticadvertising.org/connect/github');
   });
 
@@ -709,6 +710,7 @@ describe('community_profile formatting', () => {
     expect(result).toContain('Community profile: Public');
     expect(result).toContain('GitHub: Not linked');
     expect(result).toContain('https://agenticadvertising.org/account');
+    expect(result).toContain('https://agenticadvertising.org/member-hub');
     expect(result).toContain('https://agenticadvertising.org/connect/github');
   });
 


### PR DESCRIPTION
## Summary

Two things wrong, one PR.

### 1. "Member hub" reads as organizational; the page is personal

`/member-hub` greets the user with *"Welcome back, [firstName]"* and is entirely about the signed-in user (engagement, working group recs, profile completeness, the Connections card with Connect/Disconnect for GitHub). Brian flagged the label as confusing tonight: *"why would my personal github user name be in member hub (or is that really user hub)?"*

Rename the **displayed label** to "Your hub" everywhere it shows — page title, kicker, loading copy, error copy. The **URL stays at `/member-hub`** so no bookmarks break and no internal redirect chains need rewiring. Second-person ("Your") matches the existing voice ("Welcome back" / "your home base for...").

The Connections card stays on this page — it's a one-click state toggle, the kind of action nudge that belongs on a dashboard, not an account-form-field page.

### 2. Addie sent users to `/account` when they asked to disconnect GitHub

Real exchange tonight (after #3700 deployed):
- Brian → "disconnect my GitHub"
- Addie → "go to https://agenticadvertising.org/account"
- Brian → opens /account, finds only the GitHub-username text field, no Connect/Disconnect UI → confused

Root cause: Addie's prompt only knew about **two** GitHub surfaces. The Connections card on `/member-hub` was added in #3577 but never named in `urls.md` or the member-context block.

Add `/member-hub` to `urls.md` and rewrite the GitHub block in `member-context.ts` so Addie has three clean pointers:

| Surface | URL | When to use |
|---|---|---|
| Social-links text field (display) | `/account` | "I want my GitHub handle on my profile page" |
| Connections card (manage/disconnect) | `/member-hub` | "I want to disconnect" / "manage my GitHub OAuth" |
| Session-aware bouncer (start OAuth) | `/connect/github` | "I want to connect right now from this Slack message" |

When the user asks Addie to file an issue, the `create_github_issue` tool already surfaces the bouncer URL automatically — the explicit URL guidance in the prompt is for the cases where the tool isn't running.

## Test plan

- [x] `npx vitest run server/tests/unit/member-context.test.ts` — 35 passed; both rendered-prompt tests now assert all three URLs are present.
- [x] `node scripts/check-owned-links.js` — all browser-facing links reachable.
- [x] `npx tsc -p server/tsconfig.json --noEmit` clean.
- [ ] Manual: visit `/member-hub` and confirm the page now reads "Your hub" in the title and kicker. Ask Addie to disconnect GitHub and confirm she points at `/member-hub`, not `/account`.

## Filed as follow-up

#3705 — bridge Slack ↔ web session so Addie-provided links don't force a re-login. Independent of this PR but composes well: once that ships, all three GitHub URLs become single-click from Slack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)