### PR TITLE
chore(addie): drop retired context-1m-2025-08-07 beta header

### DIFF
--- a/.changeset/drop-1m-context-beta-header.md
+++ b/.changeset/drop-1m-context-beta-header.md
@@ -1,0 +1,8 @@
+---
+---
+
+server(addie): drop `context-1m-2025-08-07` beta header now that 1M context is GA on Sonnet 4.6 / Opus 4.6+
+
+Anthropic retired the `context-1m-2025-08-07` beta on Sonnet 4 / Sonnet 4.5 (requests >200K on those models now error) and made 1M context generally available on Sonnet 4.6 and Opus 4.6+. Addie already runs on Sonnet 4.6 (primary) and Opus 4.7 (depth), so the explicit beta flag is no longer required — and keeping it risks a stray request being routed to a retired model and rejected.
+
+Removes `CONTEXT_1M_BETA`, `MODELS_SUPPORTING_1M_CONTEXT`, `getModelBetas()`, and the `CLAUDE_DISABLE_1M_CONTEXT` opt-out from `server/src/config/models.ts`, and drops the corresponding spread in `server/src/addie/claude-client.ts` for both the non-streaming and streaming `client.beta.messages` calls. The streaming call still uses the `beta` namespace because `web-search-2025-03-05` is passed there.

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -10,7 +10,7 @@ import { logger } from '../logger.js';
 import type { AddieTool } from './types.js';
 import { ADDIE_FALLBACK_PROMPT, ADDIE_TOOL_REFERENCE, buildMessageTurnsWithMetadata } from './prompts.js';
 import { AddieDatabase } from '../db/addie-db.js';
-import { AddieModelConfig, getModelBetas } from '../config/models.js';
+import { AddieModelConfig } from '../config/models.js';
 import { getCurrentConfigVersionId } from './config-version.js';
 import { loadRules, invalidateRulesCache } from './rules/index.js';
 import { isMultimodalContent, extractMultimodalContent, isAllowedImageType, type FileReadResult } from './mcp/url-tools.js';
@@ -674,7 +674,7 @@ export class AddieClaudeClient {
               }] : []),
             ],
             messages,
-            betas: ['web-search-2025-03-05', ...getModelBetas(effectiveModel)],
+            betas: ['web-search-2025-03-05'],
           }),
           { maxRetries: 3, initialDelayMs: 1000 },
           'processMessage'
@@ -1261,16 +1261,12 @@ export class AddieClaudeClient {
 
         while (!streamSucceeded && streamRetryCount <= maxStreamRetries) {
           try {
-            // Use streaming API (beta namespace so we can pass `betas`,
-            // e.g. 1M-context on supported depth-tier models).
-            const modelBetas = getModelBetas(effectiveModel);
             const stream = this.client.beta.messages.stream({
               model: effectiveModel,
               max_tokens: 4096,
               system: systemBlocks,
               tools: customTools,
               messages,
-              ...(modelBetas.length > 0 ? { betas: modelBetas } : {}),
             });
 
             // Process stream events

--- a/server/src/config/models.ts
+++ b/server/src/config/models.ts
@@ -49,40 +49,6 @@ export const ModelConfig = {
 } as const;
 
 /**
- * Anthropic beta flag that unlocks the 1M-token context window on
- * supported Claude models. Passed via the `betas` array on the
- * `/v1/messages` beta endpoint (NOT as a suffix on the model ID).
- */
-export const CONTEXT_1M_BETA = 'context-1m-2025-08-07';
-
-/**
- * Models that currently support the 1M context beta. Opus 4.7 is the
- * depth-tier default; Sonnet 4.6 supports it too. Extend this list as
- * Anthropic enables 1M on additional models.
- */
-const MODELS_SUPPORTING_1M_CONTEXT = new Set<string>([
-  'claude-opus-4-7',
-  'claude-sonnet-4-6',
-]);
-
-/**
- * Returns additional Anthropic `betas` flags that should be enabled for
- * the given model. Currently: 1M context on depth-tier models.
- *
- * Opt out per-model with `CLAUDE_DISABLE_1M_CONTEXT=true`.
- */
-export function getModelBetas(model: string): string[] {
-  const betas: string[] = [];
-  if (
-    process.env.CLAUDE_DISABLE_1M_CONTEXT !== 'true' &&
-    MODELS_SUPPORTING_1M_CONTEXT.has(model)
-  ) {
-    betas.push(CONTEXT_1M_BETA);
-  }
-  return betas;
-}
-
-/**
  * Addie-specific model configuration
  * Separate env var for backwards compatibility
  */


### PR DESCRIPTION
## Summary

- Anthropic retired the `context-1m-2025-08-07` beta on Sonnet 4 / Sonnet 4.5 (>200K requests on those models now error) and made 1M context **GA** on Sonnet 4.6 and Opus 4.6+.
- Addie already runs on Sonnet 4.6 (primary) and Opus 4.7 (depth), so the explicit beta flag is now redundant on every model we use — and keeping it is a footgun if a future env override pinned `CLAUDE_MODEL_PRIMARY` back to a retired Sonnet.
- Removes `CONTEXT_1M_BETA`, `MODELS_SUPPORTING_1M_CONTEXT`, `getModelBetas()`, and the `CLAUDE_DISABLE_1M_CONTEXT` opt-out from `server/src/config/models.ts`, and drops the corresponding spread in both the non-streaming and streaming `client.beta.messages` calls in `server/src/addie/claude-client.ts`. Web search still uses the `betas` array (`web-search-2025-03-05`) in the non-streaming path; the streaming path stays on the `beta` namespace because the rest of the client lives there.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — passes (storyboard lints, schemas, compliance, protocol tarball)
- [x] Pre-commit hook (`npm run test:unit && npm run test:test-dynamic-imports && npm run typecheck`) green
- [ ] CI green
- [ ] Manual: confirm Addie chat still answers a long-context turn on Sonnet 4.6 in staging (no `betas` rejection from the API)

## Out of scope (flagged but not touched)

- `server/src/utils/token-limiter.ts` — `MODEL_CONTEXT_LIMITS` lists `claude-opus-4-6` and `claude-sonnet-4-6` at 1M but is missing `claude-opus-4-7` (the depth model), so the depth tier currently falls back to the 200K default. Pre-existing inconsistency, unrelated to the beta retirement.
- `claude-sonnet-4-5` pricing entry stays — Sonnet 4.5 still works at ≤200K and historical cost rows may reference it.