### PR TITLE
fix(compliance): audience-sync discover_account stateful: false → true

### DIFF
--- a/.changeset/fix-audience-sync-stateful-flag.md
+++ b/.changeset/fix-audience-sync-stateful-flag.md
@@ -1,0 +1,6 @@
+---
+---
+
+Fix `discover_account` step in audience-sync storyboard: flip `stateful: false` → `stateful: true`.
+
+The step's own narrative states "The account_id is captured for use in subsequent audience operations," yet `stateful: false` told the SDK runner not to count a passing result as establishing state. Explicit-mode adopters saw `sync_audiences` cascade-skip with `prerequisite_failed` even after `list_accounts` passed. This aligns audience-sync with the identical declaration in the `sales-social` storyboard and with the SDK runner's cascade-resolution behavior (adcp-client#1130).

--- a/dist/compliance/3.0.0/specialisms/audience-sync/index.yaml
+++ b/dist/compliance/3.0.0/specialisms/audience-sync/index.yaml
@@ -111,7 +111,7 @@ phases:
         schema_ref: "account/list-accounts-request.json"
         response_schema_ref: "account/list-accounts-response.json"
         doc_ref: "/accounts/tasks/list_accounts"
-        stateful: false
+        stateful: true
         expected: |
           Return at least one account with:
           - account_id: platform-assigned identifier

--- a/dist/compliance/3.0.1/specialisms/audience-sync/index.yaml
+++ b/dist/compliance/3.0.1/specialisms/audience-sync/index.yaml
@@ -111,7 +111,7 @@ phases:
         schema_ref: "account/list-accounts-request.json"
         response_schema_ref: "account/list-accounts-response.json"
         doc_ref: "/accounts/tasks/list_accounts"
-        stateful: false
+        stateful: true
         expected: |
           Return at least one account with:
           - account_id: platform-assigned identifier

--- a/static/compliance/source/specialisms/audience-sync/index.yaml
+++ b/static/compliance/source/specialisms/audience-sync/index.yaml
@@ -111,7 +111,7 @@ phases:
         schema_ref: "account/list-accounts-request.json"
         response_schema_ref: "account/list-accounts-response.json"
         doc_ref: "/accounts/tasks/list_accounts"
-        stateful: false
+        stateful: true
         expected: |
           Return at least one account with:
           - account_id: platform-assigned identifier


### PR DESCRIPTION
Closes #3707

The `discover_account` step (`list_accounts` task) in the audience-sync storyboard was declared `stateful: false`, but the step's own narrative says "The account_id is captured for use in subsequent audience operations." The SDK runner (adcp-client#1130) uses `stateful: true` to count a passing step as establishing cascade state for downstream phase resolution. With `stateful: false`, explicit-mode adopters (`account.require_operator_auth: true`) saw `sync_audiences` steps cascade-skip with `prerequisite_failed` even after `list_accounts` passed. This PR corrects the flag in source and both committed dist snapshots, aligning audience-sync with the identical `stateful: true` declaration in the `sales-social` sibling storyboard.

**Non-breaking justification:** This corrects a storyboard metadata flag — it does not change any schema, task definition, or wire format. The fix relaxes cascade behavior: test runs that were completing successfully continue to pass; explicit-mode runs that were incorrectly failing now pass. No conformant implementation is broken.

**Pre-PR review:**
- code-reviewer: approved — no blockers; `--empty` changeset confirmed correct for non-protocol-spec change; source and both dist snapshots consistent
- ad-tech-protocol-expert: semantically sound; raises one question for the human reviewer: whether this warrants a `patch` changeset vs `--empty` (the playbook's explicit list — "schemas, task definitions, API reference" — excludes storyboard metadata, suggesting `--empty` is correct, but the expert notes `stateful` flips observable runner behavior)

**Note on `dist/3.0.0/`:** Both `dist/compliance/3.0.1/` and `dist/compliance/3.0.0/` carry the bug and are committed to `main`. Both are updated here. A cherry-pick to `3.0.x` after merge will propagate the `3.0.1/` fix to the patch branch.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout 3708` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_019ZJXyeQYrRZc17UqcW2yDf

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZJXyeQYrRZc17UqcW2yDf)_