### PR TITLE
feat(identity): identity layer foundation (Phase 1)

### DIFF
--- a/.changeset/identity-layer-phase-1.md
+++ b/.changeset/identity-layer-phase-1.md
@@ -1,0 +1,18 @@
+---
+---
+
+Add identity layer foundation (Phase 1, no functional change).
+
+A WorkOS user is one credential bundle for one email. An "identity" is the
+person — and a person can have multiple emails, each backed by its own WorkOS
+user. Today every user is its own singleton identity. Phase 2 will rewrite
+the account-merge flow to bind multiple WorkOS users to one identity instead
+of deleting the secondary user, so that "linked emails" actually work for
+sign-in (each email is a real WorkOS user) and our DB becomes a truthful
+cache of WorkOS state.
+
+Migration 460 adds `identities` and `identity_workos_users`, backfills 1:1
+from `users`, and installs an AFTER INSERT trigger so any new user
+automatically gets a singleton identity. Auth middleware now resolves
+`identityId` on `req.user` for real users (synthetic admin/API-key users skip
+it). No app code reads `identityId` yet.

--- a/server/src/db/migrations/460_identities.sql
+++ b/server/src/db/migrations/460_identities.sql
@@ -1,0 +1,72 @@
+-- Identity layer (Phase 1).
+--
+-- An "identity" is the person; a WorkOS user is one credential bundle for one
+-- email. Today every user is a singleton identity. Phase 2 will rewrite
+-- mergeUsers to bind multiple WorkOS users to a single identity instead of
+-- deleting the secondary user, so that "linked emails" actually work for
+-- sign-in (each email is a real WorkOS user) and the local DB becomes a
+-- truthful cache of WorkOS state.
+--
+-- This migration adds the tables, backfills 1:1 from `users`, and installs an
+-- AFTER INSERT trigger so any new user automatically gets a singleton
+-- identity. No app code reads identity_id yet — that comes in Phase 2.
+
+CREATE TABLE identities (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- workos_user_id PK enforces "one WorkOS user belongs to exactly one identity".
+-- Multiple rows with the same identity_id model "this person has multiple
+-- sign-in emails" (each email is its own WorkOS user).
+CREATE TABLE identity_workos_users (
+  workos_user_id VARCHAR(255) PRIMARY KEY REFERENCES users(workos_user_id) ON DELETE CASCADE,
+  identity_id UUID NOT NULL REFERENCES identities(id) ON DELETE CASCADE,
+  is_primary BOOLEAN NOT NULL DEFAULT FALSE,
+  bound_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_identity_workos_users_identity ON identity_workos_users(identity_id);
+
+-- Exactly one primary WorkOS user per identity.
+CREATE UNIQUE INDEX idx_identity_workos_users_one_primary
+  ON identity_workos_users(identity_id) WHERE is_primary = TRUE;
+
+-- Backfill: one identity per existing user, marked primary. Use a transient
+-- column to pair each new identity row with its source user in a single
+-- set-based pass.
+ALTER TABLE identities ADD COLUMN _backfill_workos_user_id VARCHAR(255);
+
+INSERT INTO identities (id, _backfill_workos_user_id)
+SELECT gen_random_uuid(), workos_user_id FROM users;
+
+INSERT INTO identity_workos_users (workos_user_id, identity_id, is_primary)
+SELECT _backfill_workos_user_id, id, TRUE
+FROM identities
+WHERE _backfill_workos_user_id IS NOT NULL;
+
+ALTER TABLE identities DROP COLUMN _backfill_workos_user_id;
+
+-- Auto-create a singleton identity when a new user is inserted. Fires on
+-- AFTER INSERT only — ON CONFLICT DO UPDATE upserts that update the existing
+-- row fire AFTER UPDATE instead, which is correct (the existing user already
+-- has an identity).
+CREATE OR REPLACE FUNCTION ensure_identity_for_user() RETURNS TRIGGER AS $$
+DECLARE
+  new_identity_id UUID;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM identity_workos_users WHERE workos_user_id = NEW.workos_user_id
+  ) THEN
+    INSERT INTO identities DEFAULT VALUES RETURNING id INTO new_identity_id;
+    INSERT INTO identity_workos_users (workos_user_id, identity_id, is_primary)
+    VALUES (NEW.workos_user_id, new_identity_id, TRUE);
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_ensure_identity_for_user
+AFTER INSERT ON users
+FOR EACH ROW EXECUTE FUNCTION ensure_identity_for_user();

--- a/server/src/db/migrations/460_identities.sql
+++ b/server/src/db/migrations/460_identities.sql
@@ -13,8 +13,7 @@
 
 CREATE TABLE identities (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 -- workos_user_id PK enforces "one WorkOS user belongs to exactly one identity".
@@ -35,7 +34,8 @@ CREATE UNIQUE INDEX idx_identity_workos_users_one_primary
 
 -- Backfill: one identity per existing user, marked primary. Use a transient
 -- column to pair each new identity row with its source user in a single
--- set-based pass.
+-- set-based pass. Set-based is fine at current users-table size (low tens of
+-- thousands); batch past ~100k.
 ALTER TABLE identities ADD COLUMN _backfill_workos_user_id VARCHAR(255);
 
 INSERT INTO identities (id, _backfill_workos_user_id)

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -652,6 +652,28 @@ function hasValidAdminApiKey(req: Request): boolean {
 }
 
 /**
+ * Look up the identity_id for a WorkOS user and attach it to the user object.
+ * Identity = the person; one identity may back multiple WorkOS users (Phase 2).
+ * Skipped for synthetic users (admin API key, WorkOS API key) since they don't
+ * represent a person. Failures are swallowed — identity resolution must never
+ * block an authenticated request.
+ */
+async function attachIdentityId(user: WorkOSUser): Promise<void> {
+  if (user.id === 'admin_api_key' || user.id.startsWith('api_key_')) return;
+  try {
+    const result = await getPool().query<{ identity_id: string }>(
+      `SELECT identity_id FROM identity_workos_users WHERE workos_user_id = $1`,
+      [user.id]
+    );
+    if (result.rows[0]) {
+      user.identityId = result.rows[0].identity_id;
+    }
+  } catch (err) {
+    logger.warn({ err, userId: user.id }, 'Failed to resolve identity_id');
+  }
+}
+
+/**
  * Middleware to require authentication
  * Checks for WorkOS session cookie and loads user info
  * Also accepts WorkOS API keys as Bearer token for programmatic access
@@ -734,6 +756,7 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
       logger.warn({ err: banError, userId: jwtAuth.user.id, path: req.path }, 'Ban check failed — allowing request through');
     }
 
+    await attachIdentityId(req.user);
     return next();
   }
 
@@ -748,6 +771,7 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
       if (devConfig) {
         (req.user as unknown as Record<string, unknown>).isMember = devConfig.isMember;
       }
+      await attachIdentityId(req.user);
       return next();
     }
     // No dev session - redirect to dev login page
@@ -1041,6 +1065,9 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
         'Impersonation session detected'
       );
     }
+
+    // Resolve identityId once before caching so cache hits inherit it.
+    await attachIdentityId(user);
 
     // Cache the validated session
     sessionCache.set(cacheKey, {

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -652,14 +652,23 @@ function hasValidAdminApiKey(req: Request): boolean {
 }
 
 /**
+ * True if `id` is a synthetic user (static admin API key or per-org WorkOS
+ * API key). Synthetic users don't represent a person, so they have no
+ * identity binding.
+ */
+function isSyntheticUser(id: string): boolean {
+  return id === 'admin_api_key' || id.startsWith('api_key_');
+}
+
+/**
  * Look up the identity_id for a WorkOS user and attach it to the user object.
  * Identity = the person; one identity may back multiple WorkOS users (Phase 2).
- * Skipped for synthetic users (admin API key, WorkOS API key) since they don't
- * represent a person. Failures are swallowed — identity resolution must never
- * block an authenticated request.
+ * Skipped for synthetic users since they don't represent a person. Failures
+ * are swallowed — identity resolution must never block an authenticated
+ * request.
  */
 async function attachIdentityId(user: WorkOSUser): Promise<void> {
-  if (user.id === 'admin_api_key' || user.id.startsWith('api_key_')) return;
+  if (isSyntheticUser(user.id)) return;
   try {
     const result = await getPool().query<{ identity_id: string }>(
       `SELECT identity_id FROM identity_workos_users WHERE workos_user_id = $1`,
@@ -1322,6 +1331,7 @@ export async function requireAdmin(req: Request, res: Response, next: NextFuncti
       if (mockUser) {
         req.user = mockUser;
         req.accessToken = 'dev-mode-token';
+        await attachIdentityId(req.user);
       }
     }
 
@@ -1757,6 +1767,11 @@ export async function optionalAuth(req: Request, res: Response, next: NextFuncti
           'Impersonation session detected (optional auth)'
         );
       }
+
+      // Resolve identityId before caching — sessionCache is shared with
+      // requireAuth, so skipping it here would let an optionalAuth request
+      // poison subsequent requireAuth cache hits with identityId=undefined.
+      await attachIdentityId(user);
 
       // Cache the validated session
       sessionCache.set(cacheKey, {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -314,6 +314,9 @@ export interface WorkOSUser {
    * WorkOS users (one per email). Resolved from `identity_workos_users` in
    * the auth middleware. Absent for synthetic users (admin API key, WorkOS
    * API key). Phase 2 will start using this for app-state lookups.
+   *
+   * Server-side only — do not serialize to clients. Correlating identityId
+   * across surfaces would let a client tie multiple emails to one person.
    */
   identityId?: string;
   /** Present when this session is being impersonated by an admin */

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -309,6 +309,13 @@ export interface WorkOSUser {
   emailVerified: boolean;
   createdAt: string;
   updatedAt: string;
+  /**
+   * The person behind this WorkOS user. One identity may back multiple
+   * WorkOS users (one per email). Resolved from `identity_workos_users` in
+   * the auth middleware. Absent for synthetic users (admin API key, WorkOS
+   * API key). Phase 2 will start using this for app-state lookups.
+   */
+  identityId?: string;
   /** Present when this session is being impersonated by an admin */
   impersonator?: Impersonator;
 }

--- a/server/tests/integration/identity-layer.test.ts
+++ b/server/tests/integration/identity-layer.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Identity layer (Phase 1) integration tests.
+ *
+ * Exercises migration 460_identities against a real PostgreSQL instance:
+ *   - Backfill creates one identity per existing user, marked primary.
+ *   - AFTER INSERT trigger creates a singleton identity for new users.
+ *   - workos_user_id is unique across identity_workos_users (one user → one identity).
+ *   - The "exactly one primary per identity" partial unique index holds.
+ *   - Deleting a user CASCADE-removes its binding (identity row may orphan in
+ *     Phase 1; Phase 2 cleans this up by changing mergeUsers to bind, not delete).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import type { Pool } from 'pg';
+
+const TEST_USER_PREFIX = 'user_identity_test_';
+
+describe('Identity layer (migration 460)', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  }, 60000);
+
+  afterAll(async () => {
+    await pool.query(`DELETE FROM users WHERE workos_user_id LIKE $1`, [`${TEST_USER_PREFIX}%`]);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await pool.query(`DELETE FROM users WHERE workos_user_id LIKE $1`, [`${TEST_USER_PREFIX}%`]);
+  });
+
+  async function insertUser(suffix: string, email: string): Promise<string> {
+    const userId = `${TEST_USER_PREFIX}${suffix}`;
+    await pool.query(
+      `INSERT INTO users (workos_user_id, email, first_name, last_name, email_verified,
+                          workos_created_at, workos_updated_at, created_at, updated_at)
+       VALUES ($1, $2, 'Test', 'User', true, NOW(), NOW(), NOW(), NOW())`,
+      [userId, email]
+    );
+    return userId;
+  }
+
+  describe('backfill', () => {
+    it('every existing user has exactly one identity_workos_users row marked primary', async () => {
+      const result = await pool.query(`
+        SELECT u.workos_user_id,
+               COUNT(iwu.workos_user_id) AS binding_count,
+               COUNT(*) FILTER (WHERE iwu.is_primary) AS primary_count
+        FROM users u
+        LEFT JOIN identity_workos_users iwu ON iwu.workos_user_id = u.workos_user_id
+        GROUP BY u.workos_user_id
+        HAVING COUNT(iwu.workos_user_id) <> 1 OR COUNT(*) FILTER (WHERE iwu.is_primary) <> 1
+        LIMIT 5
+      `);
+      expect(result.rows).toEqual([]);
+    });
+
+    it('the transient backfill column has been dropped', async () => {
+      const result = await pool.query(`
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'identities' AND column_name = '_backfill_workos_user_id'
+      `);
+      expect(result.rows).toEqual([]);
+    });
+  });
+
+  describe('AFTER INSERT trigger', () => {
+    it('creates a singleton identity for a newly inserted user', async () => {
+      const userId = await insertUser('new1', 'new1@test.example');
+
+      const result = await pool.query<{ identity_id: string; is_primary: boolean }>(
+        `SELECT identity_id, is_primary FROM identity_workos_users WHERE workos_user_id = $1`,
+        [userId]
+      );
+
+      expect(result.rows).toHaveLength(1);
+      expect(result.rows[0].is_primary).toBe(true);
+      expect(result.rows[0].identity_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    });
+
+    it('does not double-create on idempotent re-upsert', async () => {
+      const userId = await insertUser('upsert1', 'upsert1@test.example');
+
+      // Same INSERT shape as upsertUser() in workos-webhooks.ts — ON CONFLICT
+      // routes through AFTER UPDATE, not AFTER INSERT, so the trigger should
+      // not fire again.
+      await pool.query(
+        `INSERT INTO users (workos_user_id, email, first_name, last_name, email_verified,
+                            workos_created_at, workos_updated_at, created_at, updated_at)
+         VALUES ($1, $2, 'Test', 'User2', true, NOW(), NOW(), NOW(), NOW())
+         ON CONFLICT (workos_user_id) DO UPDATE SET last_name = EXCLUDED.last_name, updated_at = NOW()`,
+        [userId, 'upsert1@test.example']
+      );
+
+      const result = await pool.query(
+        `SELECT COUNT(*)::int AS n FROM identity_workos_users WHERE workos_user_id = $1`,
+        [userId]
+      );
+      expect(result.rows[0].n).toBe(1);
+    });
+  });
+
+  describe('invariants', () => {
+    it('rejects a second primary binding on the same identity', async () => {
+      const userA = await insertUser('inv_a', 'inv_a@test.example');
+      const userB = await insertUser('inv_b', 'inv_b@test.example');
+
+      const aIdent = await pool.query<{ identity_id: string }>(
+        `SELECT identity_id FROM identity_workos_users WHERE workos_user_id = $1`,
+        [userA]
+      );
+
+      // Trying to bind userB to userA's identity as ALSO primary should violate
+      // the partial unique index.
+      await expect(
+        pool.query(
+          `UPDATE identity_workos_users SET identity_id = $1, is_primary = TRUE
+           WHERE workos_user_id = $2`,
+          [aIdent.rows[0].identity_id, userB]
+        )
+      ).rejects.toThrow(/idx_identity_workos_users_one_primary|unique/i);
+    });
+
+    it('CASCADE-removes the binding when a user is deleted', async () => {
+      const userId = await insertUser('cascade1', 'cascade1@test.example');
+
+      await pool.query(`DELETE FROM users WHERE workos_user_id = $1`, [userId]);
+
+      const result = await pool.query(
+        `SELECT 1 FROM identity_workos_users WHERE workos_user_id = $1`,
+        [userId]
+      );
+      expect(result.rows).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of decoupling **person** from **WorkOS user** so that "linked emails" can stop being a local-only fiction.

A WorkOS user is one credential bundle for one email — that's WorkOS's data model and we won't fight it. An *identity* is the person, and may back multiple WorkOS users (one per email). Today every user is its own singleton identity. Phase 2 will rewrite `mergeUsers` to **bind** multiple WorkOS users to one identity instead of deleting the secondary user, so that each linked email is a real WorkOS user that actually works for sign-in and our local DB becomes a truthful cache of WorkOS state.

This PR is **no functional change.** No app code reads `identityId` yet.

## What's in here

- **Migration `460_identities.sql`**: adds `identities` and `identity_workos_users`, backfills 1:1 from `users`, installs an `AFTER INSERT` trigger that auto-creates a singleton identity for any new user. The trigger fires on `INSERT` only — `ON CONFLICT DO UPDATE` upserts route through `AFTER UPDATE`, which is correct (existing users already have an identity).
- **`WorkOSUser.identityId?: string`** on the type (server/src/types.ts).
- **Auth middleware** resolves `identityId` from `identity_workos_users` and attaches it to `req.user` for real users (skipped for synthetic admin / WorkOS-API-key users). Resolved once per session miss; cached. JWT and dev-mode paths also resolve.

## Why now

Escalation #298 (Ahmed Karim, Kyber1) surfaced that today's `mergeUsers` deletes the secondary WorkOS user but only records the email locally. The "Linked emails" UI implies you can sign in with any of them — you can't, because WorkOS doesn't know about the alias. The right fix is to stop deleting WorkOS users on merge; instead, bind both to one identity. That requires the identity layer to exist first.

## Test plan

- [x] Migration runs cleanly (verified locally; backfill is set-based via a transient column).
- [x] Backfill invariant: every existing user has exactly one `identity_workos_users` row marked primary.
- [x] Trigger creates a singleton identity for newly inserted users.
- [x] `ON CONFLICT DO UPDATE` upsert does not double-fire the trigger.
- [x] Partial unique index rejects a second primary binding on the same identity.
- [x] `DELETE FROM users` cascades to remove the binding.
- [x] `set-primary-email.test.ts` and `membership-webhook.test.ts` still pass (68/68) — no regression in adjacent flows.
- [x] `npx tsc --noEmit` clean.

## Phase 2 preview (separate PR)

- Rewrite `mergeUsers` → bind both WorkOS users to one identity, no deletion.
- "Linked emails" UI shows real WorkOS users, each working for sign-in.
- Critical tables (organization_memberships, learner_progress, certification_attempts, person_relationships) start dual-writing `identity_id`.
- Admin tool: "create new WorkOS user for `<email>`, bind to existing identity" — fixes the Ahmed class of escalation directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)