### PR TITLE
docs(training-agent): point examples at per-specialism tenant URLs

### DIFF
--- a/.changeset/training-agent-docs-per-tenant.md
+++ b/.changeset/training-agent-docs-per-tenant.md
@@ -1,0 +1,15 @@
+---
+---
+
+Update training agent URL references in docs to per-tenant endpoints. Follows the multi-tenant split shipped in `7974aeccd8`.
+
+URL mapping by content focus:
+- Quickstart, media-buy task references, generic auth examples → `/sales/mcp`
+- Signals specialist module + ecosystem reference → `/signals/mcp`
+- Governance specialist module → `/governance/mcp`
+- Creative specialist module → `/creative/mcp` default, with notes pointing at `/creative-builder/mcp` and `/sales/mcp` for the lab exercises that target those agents
+- Sponsored Intelligence specialist module → stays on legacy `/mcp` (multi-specialism lab, no dedicated SI tenant)
+
+Spec doc `specs/brand-protocol-sandbox-agent.md` prose updated to describe the multi-tenant architecture.
+
+The legacy `https://test-agent.adcontextprotocol.org/mcp` URL keeps working via the back-compat alias mounted in the same release.

--- a/docs/building/integration/authentication.mdx
+++ b/docs/building/integration/authentication.mdx
@@ -134,7 +134,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
 const transport = new StreamableHTTPClientTransport(
-  new URL('https://test-agent.adcontextprotocol.org/mcp'),
+  new URL('https://test-agent.adcontextprotocol.org/sales/mcp'),
   {
     requestInit: {
       headers: {
@@ -153,7 +153,7 @@ from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
 
 async with streamablehttp_client(
-    "https://test-agent.adcontextprotocol.org/mcp",
+    "https://test-agent.adcontextprotocol.org/sales/mcp",
     headers={"Authorization": "Bearer YOUR_TOKEN_HERE"}
 ) as (read, write):
     async with ClientSession(read, write) as session:
@@ -295,14 +295,14 @@ The public test agent accepts a shared token — no signup required:
 
 ```bash
 export ADCP_AUTH_TOKEN="1v8tAhASaUYYp4odoQ1PnMpdqNaMiTrCRqYo9OJp6IQ"
-export AGENT_URL="https://test-agent.adcontextprotocol.org/mcp"
+export AGENT_URL="https://test-agent.adcontextprotocol.org/sales/mcp"
 ```
 
 Configure your client with this token:
 
 ```json
 {
-  "agent_uri": "https://test-agent.adcontextprotocol.org/mcp",
+  "agent_uri": "https://test-agent.adcontextprotocol.org/sales/mcp",
   "protocol": "mcp",
   "auth": {
     "type": "bearer",

--- a/docs/contributing/testable-examples-demo.md
+++ b/docs/contributing/testable-examples-demo.md
@@ -42,7 +42,7 @@ asyncio.run(list_formats())
 
 ```bash
 uvx adcp \
-  https://test-agent.adcontextprotocol.org/mcp \
+  https://test-agent.adcontextprotocol.org/creative/mcp \
   list_creative_formats \
   '{}' \
   --auth $ADCP_AUTH_TOKEN

--- a/docs/contributing/testable-snippets.md
+++ b/docs/contributing/testable-snippets.md
@@ -116,7 +116,7 @@ Each testable snippet should:
 import { AdcpClient } from '@adcp/client';
 
 const client = new AdcpClient({
-  agentUrl: 'https://test-agent.adcontextprotocol.org/mcp',
+  agentUrl: 'https://test-agent.adcontextprotocol.org/sales/mcp',
   protocol: 'mcp',
   bearerToken: 'sk_your_api_key_here'
 });
@@ -179,7 +179,7 @@ Each testable snippet should demonstrate ONE concept:
 import { AdcpClient } from '@adcp/client';
 
 const client = new AdcpClient({
-  agentUrl: 'https://test-agent.adcontextprotocol.org/mcp',
+  agentUrl: 'https://test-agent.adcontextprotocol.org/sales/mcp',
   protocol: 'mcp',
   bearerToken: 'sk_your_api_key_here'
 });

--- a/docs/learning/specialist/creative.mdx
+++ b/docs/learning/specialist/creative.mdx
@@ -114,17 +114,18 @@ The following `specialisms` fall under the `creative` domain. Each has its own c
 
 ## Connecting to the test agent
 
-Lab exercises run against the public test agent. Use the shared token — no signup required:
+Lab exercises run against the public test agent. Use the shared token — no signup required. The creative module spans three agent surfaces; start with the ad server (the most common path) and switch URLs when an exercise calls for a different agent type.
 
 ```bash
 export ADCP_AUTH_TOKEN="1v8tAhASaUYYp4odoQ1PnMpdqNaMiTrCRqYo9OJp6IQ"
-# Ad-server workflow (exercises 2 and 4) — `/creative/mcp`
 export AGENT_URL="https://test-agent.adcontextprotocol.org/creative/mcp"
-# Stateless transformation / template agent (exercises 1 and 5):
-#   https://test-agent.adcontextprotocol.org/creative-builder/mcp
-# Push-and-preview against a sales agent (exercise 3):
-#   https://test-agent.adcontextprotocol.org/sales/mcp
 ```
+
+| Agent surface | URL | Used in |
+|---|---|---|
+| Creative ad server | `https://test-agent.adcontextprotocol.org/creative/mcp` | Exercises 2, 4 |
+| Stateless transformation / template agent | `https://test-agent.adcontextprotocol.org/creative-builder/mcp` | Exercises 1, 5 |
+| Sales agent (push-and-preview) | `https://test-agent.adcontextprotocol.org/sales/mcp` | Exercise 3 |
 
 See the [Quickstart](/docs/quickstart) for a walkthrough of your first call.
 

--- a/docs/learning/specialist/creative.mdx
+++ b/docs/learning/specialist/creative.mdx
@@ -118,7 +118,12 @@ Lab exercises run against the public test agent. Use the shared token — no sig
 
 ```bash
 export ADCP_AUTH_TOKEN="1v8tAhASaUYYp4odoQ1PnMpdqNaMiTrCRqYo9OJp6IQ"
-export AGENT_URL="https://test-agent.adcontextprotocol.org/mcp"
+# Ad-server workflow (exercises 2 and 4) — `/creative/mcp`
+export AGENT_URL="https://test-agent.adcontextprotocol.org/creative/mcp"
+# Stateless transformation / template agent (exercises 1 and 5):
+#   https://test-agent.adcontextprotocol.org/creative-builder/mcp
+# Push-and-preview against a sales agent (exercise 3):
+#   https://test-agent.adcontextprotocol.org/sales/mcp
 ```
 
 See the [Quickstart](/docs/quickstart) for a walkthrough of your first call.

--- a/docs/learning/specialist/governance.mdx
+++ b/docs/learning/specialist/governance.mdx
@@ -145,7 +145,7 @@ Lab exercises run against the public test agent. Use the shared token — no sig
 
 ```bash
 export ADCP_AUTH_TOKEN="1v8tAhASaUYYp4odoQ1PnMpdqNaMiTrCRqYo9OJp6IQ"
-export AGENT_URL="https://test-agent.adcontextprotocol.org/mcp"
+export AGENT_URL="https://test-agent.adcontextprotocol.org/governance/mcp"
 ```
 
 See the [Quickstart](/docs/quickstart) for a walkthrough of your first call.

--- a/docs/learning/specialist/media-buy.mdx
+++ b/docs/learning/specialist/media-buy.mdx
@@ -114,7 +114,7 @@ Lab exercises run against the public test agent. Use the shared token — no sig
 
 ```bash
 export ADCP_AUTH_TOKEN="1v8tAhASaUYYp4odoQ1PnMpdqNaMiTrCRqYo9OJp6IQ"
-export AGENT_URL="https://test-agent.adcontextprotocol.org/mcp"
+export AGENT_URL="https://test-agent.adcontextprotocol.org/sales/mcp"
 ```
 
 See the [Quickstart](/docs/quickstart) for a walkthrough of your first call.

--- a/docs/learning/specialist/signals.mdx
+++ b/docs/learning/specialist/signals.mdx
@@ -92,7 +92,7 @@ Lab exercises run against the public test agent. Use the shared token — no sig
 
 ```bash
 export ADCP_AUTH_TOKEN="1v8tAhASaUYYp4odoQ1PnMpdqNaMiTrCRqYo9OJp6IQ"
-export AGENT_URL="https://test-agent.adcontextprotocol.org/mcp"
+export AGENT_URL="https://test-agent.adcontextprotocol.org/signals/mcp"
 ```
 
 See the [Quickstart](/docs/quickstart) for a walkthrough of your first call.

--- a/docs/learning/specialist/sponsored-intelligence.mdx
+++ b/docs/learning/specialist/sponsored-intelligence.mdx
@@ -91,7 +91,7 @@ In 3.0, Sponsored Intelligence was promoted from a specialism to a full protocol
 
 ## Connecting to the test agent
 
-Lab exercises run against the public test agent. Use the shared token — no signup required:
+Lab exercises run against the public test agent. Sponsored Intelligence labs span creative generation, governance, and SI Chat Protocol surfaces — there is no dedicated SI tenant, so use the multi-specialism legacy endpoint:
 
 ```bash
 export ADCP_AUTH_TOKEN="1v8tAhASaUYYp4odoQ1PnMpdqNaMiTrCRqYo9OJp6IQ"

--- a/docs/learning/specialist/sponsored-intelligence.mdx
+++ b/docs/learning/specialist/sponsored-intelligence.mdx
@@ -91,7 +91,7 @@ In 3.0, Sponsored Intelligence was promoted from a specialism to a full protocol
 
 ## Connecting to the test agent
 
-Lab exercises run against the public test agent. Sponsored Intelligence labs span creative generation, governance, and SI Chat Protocol surfaces — there is no dedicated SI tenant, so use the multi-specialism legacy endpoint:
+Lab exercises run against the public test agent. Sponsored Intelligence labs span creative generation, governance, and SI Chat Protocol surfaces — use the multi-specialism endpoint that exposes every tool on a single URL:
 
 ```bash
 export ADCP_AUTH_TOKEN="1v8tAhASaUYYp4odoQ1PnMpdqNaMiTrCRqYo9OJp6IQ"

--- a/docs/media-buy/task-reference/create_media_buy.mdx
+++ b/docs/media-buy/task-reference/create_media_buy.mdx
@@ -145,7 +145,7 @@ asyncio.run(create_campaign())
 
 ```bash CLI test=false
 npx @adcp/client@latest \
-  https://test-agent.adcontextprotocol.org/mcp \
+  https://test-agent.adcontextprotocol.org/sales/mcp \
   create_media_buy \
   '{"brand":{"domain":"acmecorp.com"},"packages":[{"product_id":"prod_d979b543","pricing_option_id":"cpm_usd_auction","format_ids":[{"agent_url":"https://creative.adcontextprotocol.org","id":"display_300x250_image"}],"budget":30000,"bid_price":5.00},{"product_id":"prod_e8fd6012","pricing_option_id":"cpm_usd_auction","format_ids":[{"agent_url":"https://creative.adcontextprotocol.org","id":"display_300x250_html"}],"budget":20000,"bid_price":4.50}],"start_time":"2025-06-01T00:00:00Z","end_time":"2025-08-31T23:59:59Z"}' \
   --auth $ADCP_AUTH_TOKEN

--- a/docs/media-buy/task-reference/get_products.mdx
+++ b/docs/media-buy/task-reference/get_products.mdx
@@ -66,7 +66,7 @@ asyncio.run(discover_products())
 
 ```bash CLI
 uvx adcp \
-  https://test-agent.adcontextprotocol.org/mcp \
+  https://test-agent.adcontextprotocol.org/sales/mcp \
   get_products \
   '{"buying_mode":"brief","brief":"Premium athletic footwear with innovative cushioning","brand":{"domain":"acmecorp.com"}}' \
   --auth $ADCP_AUTH_TOKEN
@@ -809,7 +809,7 @@ asyncio.run(discover_commerce_products())
 
 ```bash CLI
 uvx adcp \
-  https://test-agent.adcontextprotocol.org/mcp \
+  https://test-agent.adcontextprotocol.org/sales/mcp \
   get_products \
   '{"buying_mode":"wholesale","brand":{"domain":"acmecorp.com"},"catalog":{"type":"product","tags":["ketchup","organic"],"category":"food/condiments"},"filters":{"channels":["retail_media"]}}' \
   --auth $ADCP_AUTH_TOKEN

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -24,6 +24,8 @@ export ADCP_AUTH_TOKEN="1v8tAhASaUYYp4odoQ1PnMpdqNaMiTrCRqYo9OJp6IQ"
 export AGENT_URL="https://test-agent.adcontextprotocol.org/sales/mcp"
 ```
 
+The test agent is path-routed: `/sales/mcp` serves media-buy tools (this quickstart's path), and sibling URLs serve the other specialisms — `/signals/mcp`, `/governance/mcp`, `/creative/mcp`, `/creative-builder/mcp`, `/brand/mcp`. Hit [`/.well-known/adagents.json`](https://test-agent.adcontextprotocol.org/.well-known/adagents.json) for the full tenant + tool list.
+
 For your own API key (org-scoped, usage tracking), create one at the [AAO dashboard](https://agenticadvertising.org/dashboard/api-keys).
 
 ## 1. Discover products

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -21,7 +21,7 @@ Use the public test token to get started immediately — no signup required:
 
 ```bash
 export ADCP_AUTH_TOKEN="1v8tAhASaUYYp4odoQ1PnMpdqNaMiTrCRqYo9OJp6IQ"
-export AGENT_URL="https://test-agent.adcontextprotocol.org/mcp"
+export AGENT_URL="https://test-agent.adcontextprotocol.org/sales/mcp"
 ```
 
 For your own API key (org-scoped, usage tracking), create one at the [AAO dashboard](https://agenticadvertising.org/dashboard/api-keys).
@@ -279,7 +279,7 @@ import { AdCPClient } from '@adcp/client';
 const client = new AdCPClient([{
   id: 'test',
   name: 'Test Agent',
-  agent_uri: 'https://test-agent.adcontextprotocol.org/mcp',
+  agent_uri: 'https://test-agent.adcontextprotocol.org/sales/mcp',
   protocol: 'mcp',
   auth_token: process.env.ADCP_AUTH_TOKEN,
 }]);

--- a/docs/signals/ecosystem.mdx
+++ b/docs/signals/ecosystem.mdx
@@ -514,7 +514,7 @@ To participate as a destination platform, you'd implement the receiving side: ac
 
 ## Try it hands-on
 
-The training agent at `https://test-agent.adcontextprotocol.org/mcp` includes sandbox signal providers covering automotive data, geo/mobility, retail purchase data, identity/demographics, publisher contextual signals, and CDP audiences.
+The training agent's signals tenant at `https://test-agent.adcontextprotocol.org/signals/mcp` includes sandbox signal providers covering automotive data, geo/mobility, retail purchase data, identity/demographics, publisher contextual signals, and CDP audiences.
 
 Use `get_signals` to discover signals and `activate_signal` to activate them — all in sandbox mode with no real data or cost.
 

--- a/specs/brand-protocol-sandbox-agent.md
+++ b/specs/brand-protocol-sandbox-agent.md
@@ -4,7 +4,7 @@ Spec for an embedded brand protocol agent that Addie invokes during certificatio
 
 ## Context
 
-The existing training agent (`server/src/training-agent/`) is a standalone MCP server exposed at `/api/training-agent/mcp`. It handles media-buy tasks (get_products, create_media_buy, etc.) with deterministic responses from in-memory seed data. External agents connect to it over HTTP.
+The existing training agent (`server/src/training-agent/`) is a multi-tenant MCP server exposed at six per-specialism endpoints under `/api/training-agent/<tenant>/mcp` (`sales`, `signals`, `governance`, `creative`, `creative-builder`, `brand`), with the legacy `/api/training-agent/mcp` URL preserved as a back-compat alias. The `brand` tenant handles brand protocol tasks (get_brand_identity, get_rights, acquire_rights) with deterministic responses from in-memory seed data. External agents connect to it over HTTP.
 
 The brand protocol sandbox agent is different. It does not need to be an external MCP server. It is a set of Addie tools that return canned brand protocol responses from in-memory seed data. Addie calls these tools during certification modules C2, C3, and specialist exams, the same way she calls `search_docs` or `get_products` today.
 


### PR DESCRIPTION
## Summary

Updates 13 docs/specs files to point training-agent examples at the per-specialism tenant URLs introduced in #3713. Stacked on top of #3713 so the URLs resolve when docs ship.

**URL mapping by content focus**
- Quickstart, media-buy task references, generic auth examples → `/sales/mcp`
- Signals specialist module + ecosystem reference → `/signals/mcp`
- Governance specialist module → `/governance/mcp`
- Creative specialist module → `/creative/mcp` default, with a per-exercise URL table for the labs that hit `/creative-builder/mcp` and `/sales/mcp`
- Sponsored Intelligence specialist module → stays on legacy `/mcp` (multi-specialism lab, no dedicated SI tenant)

**Quickstart callout** — one-line note explaining the test agent is path-routed and pointing at `/.well-known/adagents.json` for the full tenant + tool registry. DX-expert review flagged this as the highest-impact change for new developers.

**Spec doc** — `specs/brand-protocol-sandbox-agent.md` prose updated to describe the multi-tenant architecture (was still describing the single-URL legacy training agent).

## Why stacked on #3713

The docs URLs only resolve when the multi-tenant routing is deployed. Merging #3713 first ensures `https://test-agent.adcontextprotocol.org/sales/mcp` (etc.) responds before docs reference it. The legacy `/mcp` URL keeps working via the back-compat alias from the same release for the SI doc that intentionally stays on it.

## Test plan

- [x] All affected docs pages retain their original structure; only URLs / one new callout / one prose paragraph changed
- [ ] Docs site builds cleanly (Mintlify build runs in CI)
- [ ] Manual review: spot-check rendered pages match intent (especially creative.mdx URL table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)