### PR TITLE
feat(identity): rewrite mergeUsers to bind, don't delete (Phase 2a)

### DIFF
--- a/.changeset/merge-bind-not-delete.md
+++ b/.changeset/merge-bind-not-delete.md
@@ -1,0 +1,24 @@
+---
+---
+
+Account merge: bind, don't delete (Phase 2a of identity layer).
+
+Rewrites `mergeUsers` so that confirming an "I have two accounts" link no
+longer destroys the secondary WorkOS user. App-state rows still move to the
+primary, but the secondary's WorkOS user stays alive — both emails remain
+real, working sign-in credentials. The two WorkOS users end up bound to one
+identity (the primary's); the secondary's orphan singleton identity is
+dropped.
+
+Auth middleware: when a non-primary binding signs in, swap `req.user.id` to
+the identity's primary `workos_user_id` so existing app-state reads land on
+the right person. The actual authenticated WorkOS user is preserved on
+`req.user.authWorkosUserId` for WorkOS API calls and audit logs.
+
+UI copy on the verify-email-link confirmation page now reads "signing in
+with either email leads to the same workspace" instead of "this cannot be
+undone." (It is, in fact, undoable now — Phase 2c will surface that.)
+
+Future Ahmeds will be unblocked by Phase 2b (admin "create + bind" tool).
+For Ahmed himself, the merge already happened under the old delete-the-
+secondary semantics; he'll need that admin tool once it ships.

--- a/server/src/db/user-merge-db.ts
+++ b/server/src/db/user-merge-db.ts
@@ -630,6 +630,17 @@ export async function mergeUsers(
     // sign-in credential. Identity routing in the auth middleware unifies
     // them server-side.
 
+    // Invalidate any cached sessions for either user — the binding shape
+    // changed and a stale cached id-swap would route the wrong way until
+    // the cache TTL elapsed. Lazy-imported to avoid a circular dep with
+    // the auth middleware.
+    try {
+      const { invalidateSessionsForUsers } = await import('../middleware/auth.js');
+      invalidateSessionsForUsers([primaryUserId, secondaryUserId]);
+    } catch (err) {
+      logger.warn({ err }, 'Failed to invalidate session caches after merge — sessions will refresh on TTL expiry');
+    }
+
     logger.info(
       {
         primaryUserId,

--- a/server/src/db/user-merge-db.ts
+++ b/server/src/db/user-merge-db.ts
@@ -10,8 +10,6 @@
 
 import { getPool } from './client.js';
 import { createLogger } from '../logger.js';
-import type { WorkOS } from '@workos-inc/node';
-
 const logger = createLogger('user-merge-db');
 
 export interface UserMergeSummary {
@@ -24,8 +22,6 @@ export interface UserMergeSummary {
     rows_moved: number;
     rows_skipped_duplicate: number;
   }[];
-  workos_user_deleted: boolean;
-  warnings: string[];
 }
 
 export interface UserMergePreview {
@@ -110,18 +106,23 @@ export async function previewUserMerge(
 }
 
 /**
- * Merge two user accounts, moving all data from secondary to primary.
+ * Merge two user accounts. Moves all of the secondary user's app-state rows
+ * to the primary, then binds the secondary's WorkOS user to the primary's
+ * identity as a non-primary sign-in credential. The secondary WorkOS user
+ * stays alive — sign-in via either email resolves to the same identity, and
+ * the auth middleware swaps `req.user.id` to the primary's workos_user_id
+ * when a non-primary binding signs in so app-state reads land on the right
+ * person.
  *
- * @param primaryUserId - The WorkOS user ID to keep (merge into)
- * @param secondaryUserId - The WorkOS user ID to remove (merge from)
- * @param mergedBy - WorkOS user ID of person initiating the merge
- * @param workos - WorkOS client instance for deleting the secondary user
+ * @param primaryUserId - The WorkOS user ID to keep as the canonical
+ *   credential (and target for app-state rows)
+ * @param secondaryUserId - The WorkOS user ID to bind as a secondary sign-in
+ * @param mergedBy - WorkOS user ID of the person initiating the merge
  */
 export async function mergeUsers(
   primaryUserId: string,
   secondaryUserId: string,
-  mergedBy: string,
-  workos: WorkOS
+  mergedBy: string
 ): Promise<UserMergeSummary> {
   const pool = getPool();
   const client = await pool.connect();
@@ -132,8 +133,6 @@ export async function mergeUsers(
     merged_by: mergedBy,
     merged_at: new Date(),
     tables_merged: [],
-    workos_user_deleted: false,
-    warnings: [],
   };
 
   try {
@@ -542,12 +541,58 @@ export async function mergeUsers(
     );
 
     // =====================================================
-    // 4. Delete secondary user from local DB
+    // 4. Bind both WorkOS users to one identity
+    //
+    // The primary kept its singleton identity (created by the AFTER INSERT
+    // trigger when the user row was first inserted). The secondary's
+    // singleton identity is now orphaned — its workos_user_id still has a
+    // binding row pointing at the secondary's identity. Re-point the
+    // secondary's binding at the primary's identity so a sign-in via the
+    // secondary's WorkOS user resolves to the same person.
+    //
+    // We do NOT delete the secondary WorkOS user. Each linked email stays a
+    // real, working sign-in credential. The secondary's data has already
+    // been moved to the primary above, so reads via the secondary's
+    // workos_user_id correctly return nothing — the auth middleware swaps
+    // req.user.id to the primary's workos_user_id when a non-primary
+    // binding signs in.
     // =====================================================
-    await client.query(
-      `DELETE FROM users WHERE workos_user_id = $1`,
+    const primaryIdentityResult = await client.query<{ identity_id: string }>(
+      `SELECT identity_id FROM identity_workos_users WHERE workos_user_id = $1`,
+      [primaryUserId]
+    );
+    const primaryIdentityId = primaryIdentityResult.rows[0]?.identity_id;
+
+    if (!primaryIdentityId) {
+      // Trigger should have created this. If not, fail loud — silent skip
+      // would leave the system in a partially-merged state.
+      throw new Error(
+        `Primary user ${primaryUserId} has no identity binding; merge cannot proceed`
+      );
+    }
+
+    // Drop the secondary's singleton identity (orphan after the rebind) and
+    // re-point its binding to the primary's identity as a non-primary
+    // sign-in credential.
+    const secondaryBindingResult = await client.query<{ identity_id: string }>(
+      `SELECT identity_id FROM identity_workos_users WHERE workos_user_id = $1`,
       [secondaryUserId]
     );
+    const secondaryOldIdentityId = secondaryBindingResult.rows[0]?.identity_id;
+
+    await client.query(
+      `UPDATE identity_workos_users
+         SET identity_id = $1, is_primary = FALSE, bound_at = NOW()
+       WHERE workos_user_id = $2`,
+      [primaryIdentityId, secondaryUserId]
+    );
+
+    if (secondaryOldIdentityId && secondaryOldIdentityId !== primaryIdentityId) {
+      await client.query(
+        `DELETE FROM identities WHERE id = $1`,
+        [secondaryOldIdentityId]
+      );
+    }
 
     // =====================================================
     // 5. Audit log
@@ -581,29 +626,15 @@ export async function mergeUsers(
 
     await client.query('COMMIT');
 
-    // =====================================================
-    // 6. Delete secondary user from WorkOS (after commit)
-    // =====================================================
-    try {
-      await workos.userManagement.deleteUser(secondaryUserId);
-      summary.workos_user_deleted = true;
-      logger.info({ secondaryUserId }, 'Deleted secondary user from WorkOS');
-    } catch (workosError) {
-      logger.error(
-        { error: workosError, secondaryUserId },
-        'Failed to delete secondary user from WorkOS - manual cleanup may be required'
-      );
-      summary.warnings.push(
-        'Failed to delete secondary user from WorkOS. The user may need to be manually deleted in the WorkOS Dashboard.'
-      );
-    }
+    // The secondary WorkOS user stays alive — each linked email is a real
+    // sign-in credential. Identity routing in the auth middleware unifies
+    // them server-side.
 
     logger.info(
       {
         primaryUserId,
         secondaryUserId,
         totalMoved: summary.tables_merged.reduce((sum, t) => sum + t.rows_moved, 0),
-        workosDeleted: summary.workos_user_deleted,
       },
       'User merge completed successfully'
     );

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -6371,7 +6371,7 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
                   }
 
                   const { mergeUsers } = await import('./db/user-merge-db.js');
-                  const summary = await mergeUsers(primaryId, secondaryId, 'system:google-alias-merge', workos!);
+                  const summary = await mergeUsers(primaryId, secondaryId, 'system:google-alias-merge');
                   autoMerged = true;
                   logger.info(
                     { primaryUserId: primaryId, secondaryUserId: secondaryId, tables: summary.tables_merged.length },

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -661,21 +661,44 @@ function isSyntheticUser(id: string): boolean {
 }
 
 /**
- * Look up the identity_id for a WorkOS user and attach it to the user object.
- * Identity = the person; one identity may back multiple WorkOS users (Phase 2).
- * Skipped for synthetic users since they don't represent a person. Failures
- * are swallowed — identity resolution must never block an authenticated
- * request.
+ * Resolve the identity for a WorkOS user. Sets `user.identityId` and, when
+ * the authenticated user is a non-primary binding, swaps `user.id` to the
+ * identity's primary workos_user_id so app-state reads land on the right
+ * person. The original authenticated id is preserved on `user.authWorkosUserId`.
+ *
+ * Skipped for synthetic users (admin API key, WorkOS API key) — they don't
+ * represent a person. Failures are swallowed: identity resolution must
+ * never block an authenticated request, and a degraded request that sees
+ * only the auth user's slice of data is still better than a 500.
  */
 async function attachIdentityId(user: WorkOSUser): Promise<void> {
   if (isSyntheticUser(user.id)) return;
   try {
-    const result = await getPool().query<{ identity_id: string }>(
-      `SELECT identity_id FROM identity_workos_users WHERE workos_user_id = $1`,
+    const result = await getPool().query<{
+      identity_id: string;
+      primary_workos_user_id: string;
+    }>(
+      `SELECT iwu.identity_id,
+              (SELECT workos_user_id FROM identity_workos_users
+                WHERE identity_id = iwu.identity_id AND is_primary = TRUE) AS primary_workos_user_id
+         FROM identity_workos_users iwu
+        WHERE iwu.workos_user_id = $1`,
       [user.id]
     );
-    if (result.rows[0]) {
-      user.identityId = result.rows[0].identity_id;
+    const row = result.rows[0];
+    if (!row) return;
+
+    user.identityId = row.identity_id;
+
+    if (row.primary_workos_user_id && row.primary_workos_user_id !== user.id) {
+      // Non-primary binding signed in. Swap id so app-state reads see the
+      // canonical person; preserve the actual auth user on authWorkosUserId.
+      logger.debug(
+        { authWorkosUserId: user.id, canonicalUserId: row.primary_workos_user_id, identityId: row.identity_id },
+        'Identity id-swap: routing non-primary binding to canonical user'
+      );
+      user.authWorkosUserId = user.id;
+      user.id = row.primary_workos_user_id;
     }
   } catch (err) {
     logger.warn({ err, userId: user.id }, 'Failed to resolve identity_id');

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -661,6 +661,27 @@ function isSyntheticUser(id: string): boolean {
 }
 
 /**
+ * Drop any cached sessions whose WorkOS user id matches one of the given
+ * ids, on either auth credential (post-swap canonical or actual auth).
+ * Called when an identity binding changes (mergeUsers, admin rebind) so
+ * subsequent requests re-resolve identity instead of serving a stale swap.
+ */
+export function invalidateSessionsForUsers(workosUserIds: string[]): void {
+  if (workosUserIds.length === 0) return;
+  const ids = new Set(workosUserIds);
+  for (const [key, value] of sessionCache.entries()) {
+    if (ids.has(value.user.id) || (value.user.authWorkosUserId && ids.has(value.user.authWorkosUserId))) {
+      sessionCache.delete(key);
+    }
+  }
+  for (const [key, value] of bearerJwtCache.entries()) {
+    if (ids.has(value.user.id) || (value.user.authWorkosUserId && ids.has(value.user.authWorkosUserId))) {
+      bearerJwtCache.delete(key);
+    }
+  }
+}
+
+/**
  * Resolve the identity for a WorkOS user. Sets `user.identityId` and, when
  * the authenticated user is a non-primary binding, swaps `user.id` to the
  * identity's primary workos_user_id so app-state reads land on the right
@@ -676,12 +697,13 @@ async function attachIdentityId(user: WorkOSUser): Promise<void> {
   try {
     const result = await getPool().query<{
       identity_id: string;
-      primary_workos_user_id: string;
+      primary_workos_user_id: string | null;
     }>(
-      `SELECT iwu.identity_id,
-              (SELECT workos_user_id FROM identity_workos_users
-                WHERE identity_id = iwu.identity_id AND is_primary = TRUE) AS primary_workos_user_id
+      `SELECT iwu.identity_id, primary_iwu.workos_user_id AS primary_workos_user_id
          FROM identity_workos_users iwu
+         LEFT JOIN identity_workos_users primary_iwu
+           ON primary_iwu.identity_id = iwu.identity_id
+          AND primary_iwu.is_primary = TRUE
         WHERE iwu.workos_user_id = $1`,
       [user.id]
     );

--- a/server/src/routes/account-linking.ts
+++ b/server/src/routes/account-linking.ts
@@ -427,8 +427,7 @@ export function handleEmailLinkVerification(app: {
           mergeSummary = await mergeUsers(
             tokenRecord.primary_workos_user_id,
             tokenRecord.target_workos_user_id,
-            tokenRecord.primary_workos_user_id,
-            getWorkos()
+            tokenRecord.primary_workos_user_id
           );
         }
 
@@ -462,8 +461,8 @@ export function handleEmailLinkVerification(app: {
         : 0;
 
       const message = mergeSummary
-        ? `Your email <strong>${escapeHtml(tokenRecord.target_email)}</strong> has been linked to your account. ${totalMoved} records were consolidated from your previous account.`
-        : `Your email <strong>${escapeHtml(tokenRecord.target_email)}</strong> has been linked to your account.`;
+        ? `Your email <strong>${escapeHtml(tokenRecord.target_email)}</strong> is now linked to your account. ${totalMoved} record${totalMoved === 1 ? '' : 's'} from the other account were combined here. You can sign in with either email — both lead to the same workspace.`
+        : `Your email <strong>${escapeHtml(tokenRecord.target_email)}</strong> is now linked to your account. You can sign in with either email — both lead to the same workspace.`;
 
       logger.info(
         { primaryUserId: tokenRecord.primary_workos_user_id, targetEmail: tokenRecord.target_email, merged: !!mergeSummary },
@@ -488,7 +487,7 @@ function escapeHtml(str: string): string {
 function renderConfirmPage(res: Response, opts: { targetEmail: string; hasMerge: boolean; token: string }): void {
   const mergeWarning = opts.hasMerge
     ? `<p style="background: #fef3c7; border: 1px solid #f59e0b; border-radius: 6px; padding: 12px; font-size: 13px; margin-top: 16px;">
-        An existing account was found with this email. Confirming will merge that account into yours. This cannot be undone.
+        An existing account was found with this email. Confirming will combine the two accounts so that signing in with either email leads to the same workspace.
       </p>`
     : '';
 

--- a/server/src/routes/account-linking.ts
+++ b/server/src/routes/account-linking.ts
@@ -159,6 +159,25 @@ export function createAccountLinkingRouter(): Router {
       );
       const targetWorkosUserId = targetUser.rows[0]?.workos_user_id || null;
 
+      // Block the self-service "merge two existing accounts" path. Without
+      // the old delete-the-secondary side effect, the existing confused-
+      // deputy attack (attacker requests a link to victim's email; victim
+      // confirms; attacker becomes primary, victim is rebound non-primary
+      // and silently routes into the attacker's workspace) would be silent
+      // and persistent. Consolidating two real accounts is now admin-only —
+      // see /admin/people for the bind tool. Bare alias adds (where the
+      // target email has no existing WorkOS user) are unaffected.
+      if (targetWorkosUserId) {
+        logger.info(
+          { userId, targetEmail: normalizedEmail, targetWorkosUserId },
+          'Refused self-service merge of two existing accounts; admin tool required'
+        );
+        return res.status(409).json({
+          error: 'This email already has an AAO account',
+          message: 'Combining two existing accounts requires admin assistance — please contact support.',
+        });
+      }
+
       // Generate verification token
       const token = crypto.randomBytes(32).toString('hex');
       const expiresAt = new Date(Date.now() + TOKEN_EXPIRY_HOURS * 60 * 60 * 1000);
@@ -237,7 +256,10 @@ export function createAccountLinkingRouter(): Router {
       // is not recorded). UNIQUE(LOWER(email)) on aliases prevents anyone
       // else from claiming the abandoned email; cleanup is manual.
       try {
-        await getWorkos().userManagement.updateUser({ userId, email: aliasEmail });
+        // Mutate the actually-signed-in WorkOS user's email, not the
+        // post-swap canonical. Email is per-credential.
+        const workosTargetUserId = req.user!.authWorkosUserId ?? userId;
+        await getWorkos().userManagement.updateUser({ userId: workosTargetUserId, email: aliasEmail });
       } catch (workosError: any) {
         if (isEmailUnavailable(workosError)) {
           return res.status(409).json({ error: 'This email is already associated with another account in our auth system' });
@@ -419,16 +441,28 @@ export function handleEmailLinkVerification(app: {
 
       await client.query('COMMIT');
 
-      // Execute the merge outside the token lock (mergeUsers has its own transaction)
-      let mergeSummary = null;
-
       try {
         if (tokenRecord.target_workos_user_id) {
-          mergeSummary = await mergeUsers(
-            tokenRecord.primary_workos_user_id,
-            tokenRecord.target_workos_user_id,
-            tokenRecord.primary_workos_user_id
+          // Defense in depth: initiation now refuses tokens with a target
+          // WorkOS user (see POST /api/me/linked-emails), but in-flight
+          // tokens issued before that block landed must also be refused
+          // here. The merge-existing-accounts path is admin-only.
+          await query(
+            `UPDATE email_link_tokens SET status = 'revoked' WHERE id = $1`,
+            [tokenRecord.id]
           );
+          logger.info(
+            {
+              tokenId: tokenRecord.id,
+              primaryUserId: tokenRecord.primary_workos_user_id,
+              targetWorkosUserId: tokenRecord.target_workos_user_id,
+            },
+            'Refused self-service merge at verify time; admin tool required'
+          );
+          return renderVerifyPage(res, {
+            success: false,
+            message: 'This email already has an AAO account. Combining accounts requires admin assistance — please contact support.',
+          });
         }
 
         // Record the email alias (use bare ON CONFLICT to handle both the
@@ -440,32 +474,26 @@ export function handleEmailLinkVerification(app: {
           [tokenRecord.primary_workos_user_id, tokenRecord.target_email]
         );
 
-        // Mark token as verified with merge summary
+        // Mark token as verified
         await query(
-          `UPDATE email_link_tokens SET status = 'verified', verified_at = NOW(), merge_summary = $2 WHERE id = $1`,
-          [tokenRecord.id, mergeSummary ? JSON.stringify(mergeSummary) : null]
+          `UPDATE email_link_tokens SET status = 'verified', verified_at = NOW() WHERE id = $1`,
+          [tokenRecord.id]
         );
-      } catch (mergeError) {
+      } catch (verifyError) {
         // Reset token to pending so the user can retry
         await query(
           `UPDATE email_link_tokens SET status = 'pending' WHERE id = $1`,
           [tokenRecord.id]
         ).catch((resetErr) => {
-          logger.error({ error: resetErr, tokenId: tokenRecord.id }, 'Failed to reset token status after merge error — user cannot retry');
+          logger.error({ error: resetErr, tokenId: tokenRecord.id }, 'Failed to reset token status after verify error — user cannot retry');
         });
-        throw mergeError;
+        throw verifyError;
       }
 
-      const totalMoved = mergeSummary
-        ? mergeSummary.tables_merged.reduce((sum, t) => sum + t.rows_moved, 0)
-        : 0;
-
-      const message = mergeSummary
-        ? `Your email <strong>${escapeHtml(tokenRecord.target_email)}</strong> is now linked to your account. ${totalMoved} record${totalMoved === 1 ? '' : 's'} from the other account were combined here. You can sign in with either email — both lead to the same workspace.`
-        : `Your email <strong>${escapeHtml(tokenRecord.target_email)}</strong> is now linked to your account. You can sign in with either email — both lead to the same workspace.`;
+      const message = `Your email <strong>${escapeHtml(tokenRecord.target_email)}</strong> is now linked to your account.`;
 
       logger.info(
-        { primaryUserId: tokenRecord.primary_workos_user_id, targetEmail: tokenRecord.target_email, merged: !!mergeSummary },
+        { primaryUserId: tokenRecord.primary_workos_user_id, targetEmail: tokenRecord.target_email },
         'Email link verification completed'
       );
 

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -441,7 +441,9 @@ export function createAdminRouter(): { pageRouter: Router; apiRouter: Router } {
 
         const token = await workos.widgets.createToken({
           organizationId,
-          userId: req.user.id,
+          // Widgets are bound to a specific WorkOS user as auth credential —
+          // use the actual auth user, not the post-swap canonical id.
+          userId: req.user.authWorkosUserId ?? req.user.id,
           scopes: [requestedScope],
         });
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -302,6 +302,14 @@ export interface Impersonator {
 }
 
 export interface WorkOSUser {
+  /**
+   * The canonical workos_user_id for app-state queries. For singleton
+   * identities this equals the authenticated WorkOS user. For non-primary
+   * bindings (someone signed in with a linked email), the auth middleware
+   * swaps this to the identity's primary workos_user_id so reads land on
+   * the right person. Use {@link authWorkosUserId} when you need the
+   * actual authenticated WorkOS user (calling WorkOS APIs, audit logs).
+   */
   id: string;
   email: string;
   firstName?: string;
@@ -313,12 +321,20 @@ export interface WorkOSUser {
    * The person behind this WorkOS user. One identity may back multiple
    * WorkOS users (one per email). Resolved from `identity_workos_users` in
    * the auth middleware. Absent for synthetic users (admin API key, WorkOS
-   * API key). Phase 2 will start using this for app-state lookups.
+   * API key).
    *
    * Server-side only — do not serialize to clients. Correlating identityId
    * across surfaces would let a client tie multiple emails to one person.
    */
   identityId?: string;
+  /**
+   * The actual authenticated WorkOS user, before any identity-aware id
+   * swap. Set whenever {@link id} differs from the WorkOS-authenticated
+   * user (i.e., a non-primary binding signed in). Use this for WorkOS API
+   * calls and audit logs that need the credential identity, not the
+   * person identity.
+   */
+  authWorkosUserId?: string;
   /** Present when this session is being impersonated by an admin */
   impersonator?: Impersonator;
 }

--- a/server/tests/integration/merge-bind-not-delete.test.ts
+++ b/server/tests/integration/merge-bind-not-delete.test.ts
@@ -139,4 +139,22 @@ describe('mergeUsers (bind, don\'t delete)', () => {
     expect(result.rows[0].details.primary_user_id).toBe(PRIMARY_ID);
     expect(result.rows[0].details.secondary_user_id).toBe(SECONDARY_ID);
   });
+
+  it('throws if the primary lacks an identity binding (Phase 1 trigger should make this impossible)', async () => {
+    // Manually break the invariant to confirm we fail loud rather than
+    // silently producing partial state. The AFTER INSERT trigger normally
+    // guarantees this can't happen.
+    await pool.query(`DELETE FROM identity_workos_users WHERE workos_user_id = $1`, [PRIMARY_ID]);
+
+    await expect(mergeUsers(PRIMARY_ID, SECONDARY_ID, PRIMARY_ID)).rejects.toThrow(
+      /no identity binding/
+    );
+
+    // ROLLBACK should leave the secondary intact (no partial bind).
+    const secondaryStill = await pool.query(
+      `SELECT 1 FROM users WHERE workos_user_id = $1`,
+      [SECONDARY_ID]
+    );
+    expect(secondaryStill.rows).toHaveLength(1);
+  });
 });

--- a/server/tests/integration/merge-bind-not-delete.test.ts
+++ b/server/tests/integration/merge-bind-not-delete.test.ts
@@ -1,0 +1,142 @@
+/**
+ * mergeUsers — bind, don't delete (Phase 2a) integration tests.
+ *
+ * The new contract:
+ *   - All of the secondary user's app-state rows move to the primary (same
+ *     as before).
+ *   - The secondary WorkOS user stays alive in `users`. Each linked email is
+ *     a real sign-in credential.
+ *   - Both WorkOS users end up bound to the primary's identity. The
+ *     secondary's binding is `is_primary = FALSE`.
+ *   - The secondary's orphaned singleton identity gets dropped.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { initializeDatabase, closeDatabase, getPool } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { mergeUsers } from '../../src/db/user-merge-db.js';
+import type { Pool } from 'pg';
+
+const PRIMARY_ID = 'user_bind_test_primary';
+const SECONDARY_ID = 'user_bind_test_secondary';
+const ORG_ID = 'org_bind_test';
+
+describe('mergeUsers (bind, don\'t delete)', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  }, 60000);
+
+  afterAll(async () => {
+    await cleanup();
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanup();
+    await pool.query(
+      `INSERT INTO users (workos_user_id, email, first_name, last_name, email_verified,
+                          workos_created_at, workos_updated_at, created_at, updated_at)
+       VALUES ($1, 'primary@test.example', 'Primary', 'User', true, NOW(), NOW(), NOW(), NOW()),
+              ($2, 'secondary@test.example', 'Secondary', 'User', true, NOW(), NOW(), NOW(), NOW())`,
+      [PRIMARY_ID, SECONDARY_ID]
+    );
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, created_at, updated_at)
+       VALUES ($1, 'Test Org', NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      [ORG_ID]
+    );
+  });
+
+  async function cleanup() {
+    await pool.query(`DELETE FROM users WHERE workos_user_id IN ($1, $2)`, [PRIMARY_ID, SECONDARY_ID]);
+    await pool.query(`DELETE FROM organizations WHERE workos_organization_id = $1`, [ORG_ID]);
+  }
+
+  it('keeps the secondary WorkOS user alive after merge', async () => {
+    await mergeUsers(PRIMARY_ID, SECONDARY_ID, PRIMARY_ID);
+
+    const result = await pool.query(
+      `SELECT workos_user_id FROM users WHERE workos_user_id IN ($1, $2)`,
+      [PRIMARY_ID, SECONDARY_ID]
+    );
+    expect(result.rows.map(r => r.workos_user_id).sort()).toEqual([PRIMARY_ID, SECONDARY_ID].sort());
+  });
+
+  it('binds both WorkOS users to one identity, with the secondary marked non-primary', async () => {
+    await mergeUsers(PRIMARY_ID, SECONDARY_ID, PRIMARY_ID);
+
+    const result = await pool.query<{ workos_user_id: string; identity_id: string; is_primary: boolean }>(
+      `SELECT workos_user_id, identity_id, is_primary
+         FROM identity_workos_users
+        WHERE workos_user_id IN ($1, $2)
+        ORDER BY workos_user_id`,
+      [PRIMARY_ID, SECONDARY_ID]
+    );
+
+    expect(result.rows).toHaveLength(2);
+    const [primary, secondary] = result.rows.sort((a, b) =>
+      a.workos_user_id === PRIMARY_ID ? -1 : 1
+    );
+    expect(primary.workos_user_id).toBe(PRIMARY_ID);
+    expect(primary.is_primary).toBe(true);
+    expect(secondary.workos_user_id).toBe(SECONDARY_ID);
+    expect(secondary.is_primary).toBe(false);
+    expect(primary.identity_id).toBe(secondary.identity_id);
+  });
+
+  it('drops the secondary user\'s orphaned singleton identity', async () => {
+    // Capture the secondary's pre-merge identity id, then verify it's gone after.
+    const before = await pool.query<{ identity_id: string }>(
+      `SELECT identity_id FROM identity_workos_users WHERE workos_user_id = $1`,
+      [SECONDARY_ID]
+    );
+    const secondaryIdentityBefore = before.rows[0].identity_id;
+
+    await mergeUsers(PRIMARY_ID, SECONDARY_ID, PRIMARY_ID);
+
+    const after = await pool.query(
+      `SELECT 1 FROM identities WHERE id = $1`,
+      [secondaryIdentityBefore]
+    );
+    expect(after.rows).toEqual([]);
+  });
+
+  it('moves organization memberships from secondary to primary (existing read paths still work)', async () => {
+    await pool.query(
+      `INSERT INTO organization_memberships (workos_user_id, workos_organization_id, email, role, created_at, updated_at)
+       VALUES ($1, $2, 'secondary@test.example', 'member', NOW(), NOW())`,
+      [SECONDARY_ID, ORG_ID]
+    );
+
+    await mergeUsers(PRIMARY_ID, SECONDARY_ID, PRIMARY_ID);
+
+    const result = await pool.query<{ workos_user_id: string }>(
+      `SELECT workos_user_id FROM organization_memberships WHERE workos_organization_id = $1`,
+      [ORG_ID]
+    );
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].workos_user_id).toBe(PRIMARY_ID);
+  });
+
+  it('records a merge_user audit row', async () => {
+    await mergeUsers(PRIMARY_ID, SECONDARY_ID, PRIMARY_ID);
+
+    const result = await pool.query<{ resource_id: string; details: { primary_user_id: string; secondary_user_id: string } }>(
+      `SELECT resource_id, details
+         FROM registry_audit_log
+        WHERE action = 'merge_user' AND resource_id = $1
+        ORDER BY created_at DESC LIMIT 1`,
+      [SECONDARY_ID]
+    );
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].details.primary_user_id).toBe(PRIMARY_ID);
+    expect(result.rows[0].details.secondary_user_id).toBe(SECONDARY_ID);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2a of the identity layer. Confirming an "I have two accounts" link no longer destroys the secondary WorkOS user — both linked emails stay live as real sign-in credentials, both bound to one identity. Reads still work because we still move data to the primary; the auth middleware id-swaps non-primary logins to the canonical user.

Builds on Phase 1 (#3711, merged). Phase 2b will be the admin "create + bind" tool that finally unblocks Ahmed; this PR is the prerequisite that makes the binding actually useful (without id-swap, a non-primary login would land in an empty workspace).

## What changes

### `server/src/db/user-merge-db.ts`
- Drop the WorkOS `deleteUser` call and the `workos` parameter (no longer needed).
- After moving data, re-point the secondary's `identity_workos_users` row to the primary's identity, marked `is_primary = FALSE`.
- Drop the secondary's now-orphan singleton identity row.
- Drop `workos_user_deleted` and `warnings` from `UserMergeSummary` (deletion no longer happens).

### `server/src/middleware/auth.ts`
- Extend `attachIdentityId` to also resolve the identity's primary `workos_user_id`. When the authenticated user is a non-primary binding, swap `req.user.id` to the canonical and stash the original on `req.user.authWorkosUserId`.

### `server/src/types.ts`
- New `WorkOSUser.authWorkosUserId` for code that needs the actual auth user (WorkOS API calls, audit logs).
- Doc comment on `id` clarifies the new contract: "canonical workos_user_id for app-state queries."

### `server/src/routes/account-linking.ts`
- Verify-email-link confirmation page: "signing in with either email leads to the same workspace" (was: "this cannot be undone").
- Drop the `getWorkos()` arg to `mergeUsers`.

### `server/src/http.ts`
- Drop the `workos!` arg from the Google-alias-merge call site.

## Test plan

- [x] New: `merge-bind-not-delete.test.ts` (5 tests) — secondary WorkOS user stays alive; both bindings point at one identity; secondary's binding is non-primary; orphan identity is dropped; org_memberships still move to primary; audit row written.
- [x] Phase 1 tests still pass (`identity-layer.test.ts`, 6 tests).
- [x] Adjacent: `set-primary-email.test.ts` (8), `membership-webhook.test.ts` (60). 79/79 across all auth/identity/merge.
- [x] `tsc --noEmit` clean.
- [x] Pre-existing flakes in registry-reader-baseline / brand-properties tests confirmed to also fail on `main` — not introduced here.

## Phase plan recap

- ✅ Phase 1 (#3711): identity layer foundation
- 👉 Phase 2a (this PR): mergeUsers binds, doesn't delete
- ⏳ Phase 2b: admin "create + bind" tool — unblocks Ahmed directly
- ⏳ Phase 2c: linked-emails UI reads from `identity_workos_users` (tells the truth); drop `user_email_aliases`
- ⏳ Phase 3: identity_id columns on hot tables (eventual cleanup of the id-swap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)