### PR TITLE
fix(billing): cap Stripe coupon names + filter retired tiers and show org discounts in invite modal

### DIFF
--- a/.changeset/fix-admin-invite-modal-and-coupon-name-truncation.md
+++ b/.changeset/fix-admin-invite-modal-and-coupon-name-truncation.md
@@ -1,0 +1,8 @@
+---
+---
+
+Fix three admin-billing issues that surfaced together when unblocking a discounted founding-member invoice:
+
+- **Stripe coupon name overflow.** `createOrgDiscount` built `${orgName} - ${discountDescription}` with no length cap, so org names longer than ~25 chars produced names exceeding Stripe's 40-char limit and the call 400'd with `Invalid string … must be at most 40 characters`. Added a `buildOrgCouponName` helper that normalizes whitespace and truncates the org portion so the composite always fits.
+- **Send Membership Invitation modal still surfaced retired founding tiers.** The modal called `/api/admin/products` (the unfiltered catalog), bypassing the April-1 founding-member cutoff that lives in `getProductsForCustomer`. Added `GET /api/admin/orgs/:orgId/invite-products` that runs through the cutoff filter and switched the modal to it.
+- **Modal ignored org discounts when displaying prices.** Builder shows as $3,000 even when the org has a $500 discount on file. The new endpoint also returns the org's discount fields so the modal renders `~~$3,000~~ $2,500 (-$500 off)`. Warns the admin if the org has a discount but no Stripe coupon attached (so the actual invoice would charge the sticker price).

--- a/server/public/admin-account-detail.html
+++ b/server/public/admin-account-detail.html
@@ -3796,14 +3796,24 @@
       // When the org has a discount on file but no Stripe coupon was created
       // (e.g., coupon-creation failed), the displayed net price won't match
       // what Stripe actually charges. Surface that mismatch up front so the
-      // admin can fix the coupon before sending.
+      // admin can fix the coupon before sending — banner shifts to a warning
+      // palette in that case so the visual matches the message.
       const discountBanner = invoiceOrgDiscount
-        ? `
-          <div style="padding: var(--space-2); margin-bottom: var(--space-3); background: var(--color-success-50, #ecfdf5); border: 1px solid var(--color-success-200, #a7f3d0); border-radius: var(--radius-md); font-size: var(--text-xs);">
-            Org discount on file: <strong>${escapeHtml(invoiceOrgDiscount.label)}</strong>${invoiceOrgDiscount.reason ? ` (${escapeHtml(invoiceOrgDiscount.reason)})` : ''}.
-            ${!invoiceOrgDiscount.has_stripe_coupon ? '<br><span style="color: var(--color-error-600);">⚠ No Stripe coupon attached — invoice will charge the sticker price unless a coupon is created first.</span>' : ''}
-          </div>
-        `
+        ? (() => {
+            const couponMissing = !invoiceOrgDiscount.has_stripe_coupon;
+            const bg = couponMissing ? 'var(--color-warning-50)' : 'var(--color-success-50)';
+            const border = couponMissing ? 'var(--color-warning-200)' : 'var(--color-success-200)';
+            const reason = invoiceOrgDiscount.reason ? ` (${escapeHtml(invoiceOrgDiscount.reason)})` : '';
+            const warning = couponMissing
+              ? '<br><span style="color: var(--color-error-600);">⚠ No Stripe coupon attached — invoice will charge the sticker price unless a coupon is created first.</span>'
+              : '';
+            return `
+              <div style="padding: var(--space-2); margin-bottom: var(--space-3); background: ${bg}; border: 1px solid ${border}; border-radius: var(--radius-md); font-size: var(--text-xs);">
+                Org discount on file: <strong>${escapeHtml(invoiceOrgDiscount.label)}</strong>${reason}.
+                ${warning}
+              </div>
+            `;
+          })()
         : '';
 
       container.innerHTML = discountBanner + products.map((product, index) => {

--- a/server/public/admin-account-detail.html
+++ b/server/public/admin-account-detail.html
@@ -3732,9 +3732,11 @@
 
     let selectedInvoiceProduct = null;
     let invoiceProductsData = [];
+    let invoiceOrgDiscount = null;
 
     function openInvoiceModal() {
       selectedInvoiceProduct = null;
+      invoiceOrgDiscount = null;
 
       document.getElementById('invoiceOrgName').textContent = `For: ${accountData?.name || 'Unknown'}`;
       document.getElementById('invoiceProducts').innerHTML = 'Loading products...';
@@ -3755,11 +3757,12 @@
 
     async function loadInvoiceProducts() {
       try {
-        const response = await fetch('/api/admin/products');
+        const response = await fetch(`/api/admin/orgs/${encodeURIComponent(accountId)}/invite-products`);
         if (!response.ok) throw new Error('Failed to load products');
 
         const data = await response.json();
-        invoiceProductsData = data.products.filter(p => p.is_invoiceable);
+        invoiceProductsData = (data.products || []).filter(p => p.is_invoiceable);
+        invoiceOrgDiscount = data.orgDiscount || null;
 
         renderInvoiceProducts(invoiceProductsData);
       } catch (error) {
@@ -3767,6 +3770,17 @@
         document.getElementById('invoiceProducts').innerHTML =
           '<p style="color: var(--color-error-600);">Failed to load products. Please try again.</p>';
       }
+    }
+
+    function applyOrgDiscount(amountCents) {
+      if (!invoiceOrgDiscount) return amountCents;
+      if (invoiceOrgDiscount.discount_percent != null) {
+        return Math.round(amountCents * (1 - invoiceOrgDiscount.discount_percent / 100));
+      }
+      if (invoiceOrgDiscount.discount_amount_cents != null) {
+        return Math.max(0, amountCents - invoiceOrgDiscount.discount_amount_cents);
+      }
+      return amountCents;
     }
 
     function renderInvoiceProducts(products) {
@@ -3777,9 +3791,30 @@
         return;
       }
 
-      container.innerHTML = products.map((product, index) => {
-        const fmt = (cents) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(cents / 100);
-        const price = fmt(product.amount_cents);
+      const fmt = (cents) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(cents / 100);
+
+      // When the org has a discount on file but no Stripe coupon was created
+      // (e.g., coupon-creation failed), the displayed net price won't match
+      // what Stripe actually charges. Surface that mismatch up front so the
+      // admin can fix the coupon before sending.
+      const discountBanner = invoiceOrgDiscount
+        ? `
+          <div style="padding: var(--space-2); margin-bottom: var(--space-3); background: var(--color-success-50, #ecfdf5); border: 1px solid var(--color-success-200, #a7f3d0); border-radius: var(--radius-md); font-size: var(--text-xs);">
+            Org discount on file: <strong>${escapeHtml(invoiceOrgDiscount.label)}</strong>${invoiceOrgDiscount.reason ? ` (${escapeHtml(invoiceOrgDiscount.reason)})` : ''}.
+            ${!invoiceOrgDiscount.has_stripe_coupon ? '<br><span style="color: var(--color-error-600);">⚠ No Stripe coupon attached — invoice will charge the sticker price unless a coupon is created first.</span>' : ''}
+          </div>
+        `
+        : '';
+
+      container.innerHTML = discountBanner + products.map((product, index) => {
+        const sticker = fmt(product.amount_cents);
+        const net = applyOrgDiscount(product.amount_cents);
+        const showNet = invoiceOrgDiscount && net !== product.amount_cents;
+        const priceLine = showNet
+          ? `<span style="text-decoration: line-through; color: var(--color-text-muted);">${sticker}</span>
+             <span style="color: var(--color-brand); font-weight: var(--font-semibold); margin-left: var(--space-1);">${fmt(net)}</span>
+             <span style="font-size: var(--text-xs); color: var(--color-text-muted); margin-left: var(--space-1);">(${escapeHtml(invoiceOrgDiscount.label)})</span>`
+          : `<span style="color: var(--color-brand); font-weight: var(--font-semibold);">${sticker}</span>`;
         const interval = product.billing_interval ? `/${product.billing_interval}` : '';
         const displayName = escapeHtml(product.display_name || product.product_name);
         const description = product.description ? escapeHtml(product.description) : '';
@@ -3799,7 +3834,7 @@
           " onmouseover="this.style.borderColor='var(--color-brand)'" onmouseout="this.style.borderColor='var(--color-border)'">
             <strong>${displayName}</strong>
             <br>
-            <span style="color: var(--color-brand); font-weight: var(--font-semibold);">${price}${interval}</span>
+            ${priceLine}${interval ? `<span style="color: var(--color-text-muted);">${interval}</span>` : ''}
             ${description ? `<br><span style="font-size: var(--text-xs); color: var(--color-text-muted);">${description}</span>` : ''}
           </button>
         `;
@@ -3818,15 +3853,21 @@
 
     function selectInvoiceProduct(product) {
       const displayName = product.display_name || product.product_name;
+      const netCents = applyOrgDiscount(product.amount_cents);
       selectedInvoiceProduct = {
         lookupKey: product.lookup_key,
         productName: displayName,
-        amountCents: product.amount_cents
+        amountCents: netCents,
+        stickerCents: product.amount_cents,
       };
 
       const fmt = (cents) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(cents / 100);
-      const price = fmt(product.amount_cents);
-      const priceHtml = `<span style="color: var(--color-brand);">${price}</span>`;
+      const showNet = invoiceOrgDiscount && netCents !== product.amount_cents;
+      const priceHtml = showNet
+        ? `<span style="text-decoration: line-through; color: var(--color-text-muted);">${fmt(product.amount_cents)}</span>
+           <span style="color: var(--color-brand); margin-left: var(--space-1);">${fmt(netCents)}</span>
+           <span style="font-size: var(--text-xs); color: var(--color-text-muted); margin-left: var(--space-1);">(${escapeHtml(invoiceOrgDiscount.label)})</span>`
+        : `<span style="color: var(--color-brand);">${fmt(product.amount_cents)}</span>`;
 
       document.getElementById('selectedProductDisplay').innerHTML = `
         <strong>${escapeHtml(displayName)}</strong> - ${priceHtml}

--- a/server/public/admin-accounts.html
+++ b/server/public/admin-accounts.html
@@ -1905,10 +1905,12 @@
     // Invoice
     let invoiceOrgId = null;
     let selectedInvoiceProduct = null;
+    let invoiceOrgDiscount = null;
 
     function openInvoiceForAccount(orgId, orgName) {
       invoiceOrgId = orgId;
       selectedInvoiceProduct = null;
+      invoiceOrgDiscount = null;
 
       document.getElementById('invoiceOrgName').textContent = `For: ${orgName}`;
       document.getElementById('invoiceProducts').innerHTML = 'Loading products...';
@@ -1924,17 +1926,29 @@
 
     async function loadInvoiceProducts() {
       try {
-        const response = await manageFetch('/api/admin/products');
+        const response = await manageFetch(`/api/admin/orgs/${encodeURIComponent(invoiceOrgId)}/invite-products`);
         if (!response.ok) throw new Error('Failed to load products');
 
         const data = await response.json();
-        const invoiceableProducts = data.products.filter(p => p.is_invoiceable);
+        const invoiceableProducts = (data.products || []).filter(p => p.is_invoiceable);
+        invoiceOrgDiscount = data.orgDiscount || null;
         renderInvoiceProducts(invoiceableProducts);
       } catch (error) {
         console.error('Error loading products:', error);
         document.getElementById('invoiceProducts').innerHTML =
           '<p style="color: var(--color-error-600);">Failed to load products. Please try again.</p>';
       }
+    }
+
+    function applyOrgDiscount(amountCents) {
+      if (!invoiceOrgDiscount) return amountCents;
+      if (invoiceOrgDiscount.discount_percent != null) {
+        return Math.round(amountCents * (1 - invoiceOrgDiscount.discount_percent / 100));
+      }
+      if (invoiceOrgDiscount.discount_amount_cents != null) {
+        return Math.max(0, amountCents - invoiceOrgDiscount.discount_amount_cents);
+      }
+      return amountCents;
     }
 
     function renderInvoiceProducts(products) {
@@ -1945,35 +1959,63 @@
         return;
       }
 
-      container.innerHTML = products.map(product => {
-        const price = new Intl.NumberFormat('en-US', {
-          style: 'currency',
-          currency: 'USD'
-        }).format(product.amount_cents / 100);
+      const fmt = (cents) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(cents / 100);
 
+      const discountBanner = invoiceOrgDiscount
+        ? (() => {
+            const couponMissing = !invoiceOrgDiscount.has_stripe_coupon;
+            const bg = couponMissing ? 'var(--color-warning-50)' : 'var(--color-success-50)';
+            const border = couponMissing ? 'var(--color-warning-200)' : 'var(--color-success-200)';
+            const reason = invoiceOrgDiscount.reason ? ` (${escapeHtml(invoiceOrgDiscount.reason)})` : '';
+            const warning = couponMissing
+              ? '<br><span style="color: var(--color-error-600);">⚠ No Stripe coupon attached — invoice will charge the sticker price unless a coupon is created first.</span>'
+              : '';
+            return `
+              <div style="padding: var(--space-2); margin-bottom: var(--space-3); background: ${bg}; border: 1px solid ${border}; border-radius: var(--radius-md); font-size: var(--text-xs);">
+                Org discount on file: <strong>${escapeHtml(invoiceOrgDiscount.label)}</strong>${reason}.
+                ${warning}
+              </div>
+            `;
+          })()
+        : '';
+
+      container.innerHTML = discountBanner + products.map(product => {
+        const sticker = fmt(product.amount_cents);
+        const net = applyOrgDiscount(product.amount_cents);
+        const showNet = invoiceOrgDiscount && net !== product.amount_cents;
+        const priceLine = showNet
+          ? `<span style="text-decoration: line-through; color: var(--color-text-muted);">${sticker}</span>
+             <span class="product-price" style="margin-left: var(--space-1);">${fmt(net)}</span>
+             <span style="font-size: var(--text-xs); color: var(--color-text-muted); margin-left: var(--space-1);">(${escapeHtml(invoiceOrgDiscount.label)})</span>`
+          : `<span class="product-price">${sticker}</span>`;
         const interval = product.billing_interval ? `/${product.billing_interval}` : '';
+        const netForCallback = showNet ? net : product.amount_cents;
 
         return `
-          <button type="button" class="product-select-btn" onclick="selectInvoiceProduct('${escapeHtml(product.lookup_key)}', '${escapeHtml(product.display_name || product.product_name)}', ${product.amount_cents})">
+          <button type="button" class="product-select-btn" onclick="selectInvoiceProduct('${escapeHtml(product.lookup_key)}', '${escapeHtml(product.display_name || product.product_name)}', ${netForCallback}, ${product.amount_cents})">
             <strong>${escapeHtml(product.display_name || product.product_name)}</strong>
             <br>
-            <span class="product-price">${price}${interval}</span>
+            ${priceLine}${interval ? `<span class="product-tiers">${interval}</span>` : ''}
             ${product.description ? `<br><span class="product-tiers">${escapeHtml(product.description)}</span>` : ''}
           </button>
         `;
       }).join('');
     }
 
-    function selectInvoiceProduct(lookupKey, productName, amountCents) {
-      selectedInvoiceProduct = { lookupKey, productName, amountCents };
+    function selectInvoiceProduct(lookupKey, productName, amountCents, stickerCents) {
+      selectedInvoiceProduct = { lookupKey, productName, amountCents, stickerCents: stickerCents ?? amountCents };
 
-      const price = new Intl.NumberFormat('en-US', {
-        style: 'currency',
-        currency: 'USD'
-      }).format(amountCents / 100);
+      const fmt = (cents) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(cents / 100);
+      const sticker = stickerCents ?? amountCents;
+      const showNet = invoiceOrgDiscount && amountCents !== sticker;
+      const priceHtml = showNet
+        ? `<span style="text-decoration: line-through; color: var(--color-text-muted);">${fmt(sticker)}</span>
+           <span style="color: var(--color-brand); margin-left: var(--space-1);">${fmt(amountCents)}</span>
+           <span style="font-size: var(--text-xs); color: var(--color-text-muted); margin-left: var(--space-1);">(${escapeHtml(invoiceOrgDiscount.label)})</span>`
+        : `<span style="color: var(--color-brand);">${fmt(amountCents)}</span>`;
 
       document.getElementById('selectedProductDisplay').innerHTML = `
-        <strong>${escapeHtml(productName)}</strong> - <span style="color: var(--color-brand);">${price}</span>
+        <strong>${escapeHtml(productName)}</strong> - ${priceHtml}
       `;
 
       document.getElementById('invoiceProductSection').style.display = 'none';

--- a/server/src/billing/stripe-client.ts
+++ b/server/src/billing/stripe-client.ts
@@ -2275,17 +2275,28 @@ export async function createPromotionCode(input: CreatePromotionCodeInput): Prom
   }
 }
 
-// Stripe enforces a 40-character cap on coupon.name; longer values 400 with
-// "Invalid string … must be at most 40 characters". Build the name by
-// normalizing whitespace in the org portion and truncating it so the
-// "{orgName} - {discountDescription}" composite fits.
+// Stripe enforces a 40-character cap on coupon.name (counted in UTF-16 code
+// units). Build the name by stripping unsafe control/format chars (RTL marks,
+// ZWJ, etc.), collapsing whitespace, then walking the org name code-point by
+// code-point until adding another would push the composite over the cap —
+// avoids landing mid-surrogate on emoji/CJK names.
 const STRIPE_COUPON_NAME_MAX = 40;
 export function buildOrgCouponName(orgName: string, discountDescription: string): string {
-  const normalizedOrg = orgName.replace(/\s+/g, ' ').trim();
+  const normalizedOrg = orgName
+    .replace(/[\p{Cc}\p{Cf}]/gu, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!normalizedOrg) {
+    return discountDescription.slice(0, STRIPE_COUPON_NAME_MAX);
+  }
   const suffix = ` - ${discountDescription}`;
-  const maxOrgLen = Math.max(0, STRIPE_COUPON_NAME_MAX - suffix.length);
-  const shortOrg = normalizedOrg.slice(0, maxOrgLen).trim();
-  return `${shortOrg}${suffix}`.slice(0, STRIPE_COUPON_NAME_MAX);
+  const orgBudget = Math.max(0, STRIPE_COUPON_NAME_MAX - suffix.length);
+  let shortOrg = '';
+  for (const ch of normalizedOrg) {
+    if (shortOrg.length + ch.length > orgBudget) break;
+    shortOrg += ch;
+  }
+  return `${shortOrg.trim()}${suffix}`;
 }
 
 /**

--- a/server/src/billing/stripe-client.ts
+++ b/server/src/billing/stripe-client.ts
@@ -2275,6 +2275,19 @@ export async function createPromotionCode(input: CreatePromotionCodeInput): Prom
   }
 }
 
+// Stripe enforces a 40-character cap on coupon.name; longer values 400 with
+// "Invalid string … must be at most 40 characters". Build the name by
+// normalizing whitespace in the org portion and truncating it so the
+// "{orgName} - {discountDescription}" composite fits.
+const STRIPE_COUPON_NAME_MAX = 40;
+export function buildOrgCouponName(orgName: string, discountDescription: string): string {
+  const normalizedOrg = orgName.replace(/\s+/g, ' ').trim();
+  const suffix = ` - ${discountDescription}`;
+  const maxOrgLen = Math.max(0, STRIPE_COUPON_NAME_MAX - suffix.length);
+  const shortOrg = normalizedOrg.slice(0, maxOrgLen).trim();
+  return `${shortOrg}${suffix}`.slice(0, STRIPE_COUPON_NAME_MAX);
+}
+
 /**
  * Create a coupon and promotion code for a specific organization
  * Generates a unique code based on org name
@@ -2310,7 +2323,7 @@ export async function createOrgDiscount(
 
   // Create the coupon
   const coupon = await createCoupon({
-    name: `${orgName} - ${discountDescription}`,
+    name: buildOrgCouponName(orgName, discountDescription),
     percent_off: options.percent_off,
     amount_off_cents: options.amount_off_cents,
     duration: options.duration || 'forever',

--- a/server/src/routes/billing.ts
+++ b/server/src/routes/billing.ts
@@ -14,6 +14,7 @@ import { getPool } from "../db/client.js";
 import {
   stripe,
   getBillingProducts,
+  getProductsForCustomer,
   createProduct,
   updateProductMetadata,
   archiveProduct,
@@ -177,6 +178,51 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
       });
     }
   });
+
+  // GET /api/admin/orgs/:orgId/invite-products
+  // Catalog scoped to the Send Membership Invitation flow: applies the
+  // founding-member cutoff (so retired tiers don't surface after April 1) and
+  // attaches the org's discount fields so the UI can render a net-of-discount
+  // price instead of the raw Stripe sticker.
+  apiRouter.get(
+    "/orgs/:orgId/invite-products",
+    requireAuth,
+    requireAdmin,
+    async (req, res) => {
+      try {
+        const { orgId } = req.params;
+        const orgDb = new OrganizationDatabase();
+        const org = await orgDb.getOrganization(orgId);
+        if (!org) {
+          return res.status(404).json({ error: "Organization not found" });
+        }
+
+        const products = await getProductsForCustomer({ invoiceableOnly: true });
+
+        const hasPercent =
+          org.discount_percent !== null && org.discount_percent !== undefined;
+        const hasAmount =
+          org.discount_amount_cents !== null &&
+          org.discount_amount_cents !== undefined;
+        const orgDiscount = hasPercent || hasAmount
+          ? {
+              discount_percent: hasPercent ? org.discount_percent : null,
+              discount_amount_cents: hasAmount ? org.discount_amount_cents : null,
+              label: hasPercent
+                ? `${org.discount_percent}% off`
+                : `$${((org.discount_amount_cents ?? 0) / 100).toFixed(2)} off`,
+              has_stripe_coupon: !!org.stripe_coupon_id,
+              reason: org.discount_reason ?? null,
+            }
+          : null;
+
+        res.json({ products, orgDiscount });
+      } catch (error) {
+        logger.error({ err: error }, "Error fetching invite products for org");
+        res.status(500).json({ error: "Failed to fetch invite products" });
+      }
+    }
+  );
 
   // POST /api/admin/products - Create a new product
   apiRouter.post("/products", requireAuth, requireAdmin, async (req, res) => {

--- a/tests/billing/stripe-client.test.ts
+++ b/tests/billing/stripe-client.test.ts
@@ -1031,4 +1031,42 @@ describe('stripe-client', () => {
         .toBe('aao_membership_corporate_under5m');
     });
   });
+
+  describe('buildOrgCouponName', () => {
+    test('keeps short org names intact', async () => {
+      const { buildOrgCouponName } = await import('../../server/src/billing/stripe-client.js');
+      expect(buildOrgCouponName('Acme Inc', '$500.00 off'))
+        .toBe('Acme Inc - $500.00 off');
+    });
+
+    test('truncates long org names so total stays at most 40 chars', async () => {
+      const { buildOrgCouponName } = await import('../../server/src/billing/stripe-client.js');
+      // Real-world repro: a long org name plus " - $500.00 off" overflowed Stripe's 40-char cap
+      const result = buildOrgCouponName(
+        'The Omnichannel Network Exchange  O-N-X',
+        '$500.00 off',
+      );
+      expect(result.length).toBeLessThanOrEqual(40);
+      expect(result.endsWith(' - $500.00 off')).toBe(true);
+    });
+
+    test('collapses internal whitespace runs in the org name', async () => {
+      const { buildOrgCouponName } = await import('../../server/src/billing/stripe-client.js');
+      expect(buildOrgCouponName('Acme    \t  Inc', '10% off'))
+        .toBe('Acme Inc - 10% off');
+    });
+
+    test('handles a percent discount description', async () => {
+      const { buildOrgCouponName } = await import('../../server/src/billing/stripe-client.js');
+      const result = buildOrgCouponName('Some Very Long Company Name LLC International', '25% off');
+      expect(result.length).toBeLessThanOrEqual(40);
+      expect(result.endsWith(' - 25% off')).toBe(true);
+    });
+
+    test('falls back to suffix-only when org name is empty', async () => {
+      const { buildOrgCouponName } = await import('../../server/src/billing/stripe-client.js');
+      expect(buildOrgCouponName('', '$500.00 off'))
+        .toBe(' - $500.00 off');
+    });
+  });
 });

--- a/tests/billing/stripe-client.test.ts
+++ b/tests/billing/stripe-client.test.ts
@@ -1063,10 +1063,35 @@ describe('stripe-client', () => {
       expect(result.endsWith(' - 25% off')).toBe(true);
     });
 
-    test('falls back to suffix-only when org name is empty', async () => {
+    test('falls back to discount description alone when org name is empty', async () => {
       const { buildOrgCouponName } = await import('../../server/src/billing/stripe-client.js');
       expect(buildOrgCouponName('', '$500.00 off'))
-        .toBe(' - $500.00 off');
+        .toBe('$500.00 off');
+    });
+
+    test('treats whitespace-only org names as empty', async () => {
+      const { buildOrgCouponName } = await import('../../server/src/billing/stripe-client.js');
+      expect(buildOrgCouponName('   \t\n', '10% off'))
+        .toBe('10% off');
+    });
+
+    test('strips bidi and zero-width format characters', async () => {
+      const { buildOrgCouponName } = await import('../../server/src/billing/stripe-client.js');
+      // U+202E (RTL override) and U+200B (zero-width space) must not survive
+      const result = buildOrgCouponName('Acme‮​ Inc', '$500.00 off');
+      expect(result).toBe('Acme Inc - $500.00 off');
+      expect(/[‪-‮​-‍]/.test(result)).toBe(false);
+    });
+
+    test('slices by code points so emoji and CJK names are not split mid-surrogate', async () => {
+      const { buildOrgCouponName } = await import('../../server/src/billing/stripe-client.js');
+      // Each "🚀" is a UTF-16 surrogate pair; a string-byte slice could halve one.
+      const orgName = '🚀'.repeat(20);
+      const result = buildOrgCouponName(orgName, '$500.00 off');
+      expect(result.length).toBeLessThanOrEqual(40);
+      // Re-encoding the result must round-trip — no lone surrogates.
+      expect(result).toBe(result.normalize('NFC'));
+      expect(result.endsWith(' - $500.00 off')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

Three fixes that surfaced together while unblocking a discounted founding-member invoice:

1. **Stripe coupon name overflow.** `createOrgDiscount` built `${orgName} - ${discountDescription}` with no length cap. Org names longer than ~25 chars produced names that exceeded Stripe's 40-char limit and the call 400'd with `Invalid string … must be at most 40 characters`. Added `buildOrgCouponName` helper that normalizes whitespace and truncates the org portion so the composite always fits. Hit in real life when an admin tried to grant an org a $500 discount.
2. **Send Membership Invitation modal still showed retired founding-member tiers.** The modal called `/api/admin/products` — the unfiltered catalog — bypassing the April-1 founding-member cutoff that lives in `getProductsForCustomer`. Added `GET /api/admin/orgs/:orgId/invite-products` that runs through the cutoff filter, and switched the modal to it.
3. **Modal ignored org discounts when displaying prices.** Builder showed as $3,000 even when the org had a $500 discount on file. The new endpoint also returns the org's discount fields so the modal renders `~~$3,000~~ $2,500 (-$500.00 off)`. Warns the admin when a discount exists on the org row but no Stripe coupon is attached — in that case the actual invoice would charge the sticker price.

Adjacent issues from the same incident (Addie phantom-tool / silent-failure behavior) are tracked separately in #3720 and #3721; this PR sticks to the billing-tooling bugs.

## Test plan

- [x] `npx vitest run tests/billing/` — 130 pass, including 5 new `buildOrgCouponName` cases (preserves short names, truncates long ones to ≤ 40, collapses whitespace, percent-discount path, empty-org fallback)
- [x] `tsc --project server/tsconfig.json --noEmit` clean
- [ ] Manual: open Send Membership Invitation modal on an account post-April-1 — confirm only Explorer/Professional/Builder/Member/Leader appear (no `aao_membership_corporate_under5m` / `_5m` / `_50m`)
- [ ] Manual: open the same modal for an org with a `$500.00 off` discount — confirm strikethrough sticker + net price + discount label render
- [ ] Manual: same org but with `stripe_coupon_id = null` — confirm the warning banner appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
