### PR TITLE
fix(addie): ban fabricated escalation claims and ticket numbers

### DIFF
--- a/.changeset/addie-fabricated-escalation-lint.md
+++ b/.changeset/addie-fabricated-escalation-lint.md
@@ -1,0 +1,26 @@
+---
+---
+
+fix(addie): ban fabricated ticket numbers and "team has been notified" claims
+
+Addie fabricated "Done — the team has been notified (ticket #228)" in a real
+conversation when no escalate_to_admin tool call was made. Fixes two gaps:
+
+1. **New hallucination-detect patterns** — extracted HALLUCINATION_PATTERNS and
+   detectHallucinatedAction to standalone `hallucination-detect.ts` module (testable
+   without DB deps). Added three new patterns covering ticket/issue creation claims,
+   "team has been notified" (active and passive voice), and "I've flagged/escalated
+   this" — all mapped to escalate_to_admin (and create_github_issue / send_member_dm
+   where applicable). Patterns are anchored with verb-of-action or first-person
+   subjects to avoid false positives on bare ticket number references.
+
+2. **constraints.md** — expanded the "Never Claim Unexecuted Actions" section to
+   explicitly name escalate_to_admin with its specific fabrication patterns, removing
+   reliance on the vague "Any other state-changing operation" catch-all.
+
+3. **Unit tests** — new `claude-client-hallucination.test.ts` covering all three new
+   pattern groups, false-positive avoidance cases, and failed-tool does-not-clear behavior.
+
+Bumps CODE_VERSION to 2026.05.1.
+
+Closes #3720.

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -22,6 +22,7 @@ import { notifyToolError } from './error-notifier.js';
 import { ToolError } from './tool-error.js';
 import { checkCostCap, recordCost, formatCapExceededMessage } from './claude-cost-tracker.js';
 import { applyResponsePipeline } from './response-postprocess.js';
+import { detectHallucinatedAction } from './hallucination-detect.js';
 
 type ToolHandler = (input: Record<string, unknown>) => Promise<string>;
 
@@ -157,42 +158,6 @@ function buildMultimodalContentBlocks(
   return { content: contentBlocks, summary };
 }
 
-/**
- * Action-claiming patterns mapped to the tools that should back them up.
- * Hoisted to module scope to avoid re-allocation on every response.
- */
-const HALLUCINATION_PATTERNS: ReadonlyArray<{ pattern: RegExp; expectedTools: string[] }> = [
-  { pattern: /invoice\s+(?:resent|sent)\s+successfully/i, expectedTools: ['resend_invoice', 'send_invoice', 'send_payment_request'] },
-  { pattern: /(?:successfully\s+)?resent\s+(?:the\s+)?invoice/i, expectedTools: ['resend_invoice', 'send_invoice', 'send_payment_request'] },
-  { pattern: /(?:billing\s+)?email\s+(?:updated|changed)\s+successfully/i, expectedTools: ['update_billing_email'] },
-  { pattern: /(?:I'?ve\s+|I\s+)?resolved\s+(?:the\s+)?escalation/i, expectedTools: ['resolve_escalation'] },
-  { pattern: /escalation\s+#?\d+\s+(?:has been\s+)?resolved/i, expectedTools: ['resolve_escalation'] },
-  { pattern: /meeting\s+(?:scheduled|created)\s+successfully/i, expectedTools: ['schedule_meeting'] },
-  { pattern: /(?:I'?ve\s+|I\s+)?(?:created|generated|sent)\s+(?:a\s+)?payment\s+link/i, expectedTools: ['create_payment_link'] },
-  { pattern: /(?:I'?ve\s+|I\s+)?(?:sent|delivered)\s+(?:a\s+)?(?:DM|direct message|notification)/i, expectedTools: ['send_member_dm', 'resolve_escalation'] },
-  { pattern: /(?:I'?ve\s+|I\s+)?added\s+\S+(?:\s+\S+){0,5}\s+to\s+the\s+(?:meeting|call|series)/i, expectedTools: ['add_meeting_attendee'] },
-];
-
-/**
- * Detect possible hallucinated actions in response text.
- * Returns a flag reason if the text claims to have completed an action
- * but no corresponding tool was actually called AND succeeded.
- */
-function detectHallucinatedAction(text: string, toolExecutions: ToolExecution[]): string | null {
-  for (const { pattern, expectedTools } of HALLUCINATION_PATTERNS) {
-    if (pattern.test(text)) {
-      // Check that a matching tool was called AND succeeded (not just called)
-      const hasSuccessfulTool = expectedTools.some(t =>
-        toolExecutions.some(exec => exec.tool_name === t && !exec.is_error)
-      );
-      if (!hasSuccessfulTool) {
-        return `Possible hallucinated action: text matches "${pattern.source}" but none of [${expectedTools.join(', ')}] succeeded`;
-      }
-    }
-  }
-
-  return null;
-}
 
 /** Default max tool iterations for regular users */
 export const DEFAULT_MAX_ITERATIONS = 10;

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.04.6';
+export const CODE_VERSION = '2026.05.1';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/hallucination-detect.ts
+++ b/server/src/addie/hallucination-detect.ts
@@ -1,0 +1,48 @@
+/**
+ * Hallucination detection for Addie responses.
+ * Extracted to a standalone module for testability.
+ */
+
+interface ToolExecutionRecord {
+  tool_name: string;
+  is_error: boolean;
+}
+
+/**
+ * Action-claiming patterns mapped to the tools that should back them up.
+ * A pattern fires when the response text matches but no expected tool succeeded.
+ */
+export const HALLUCINATION_PATTERNS: ReadonlyArray<{ pattern: RegExp; expectedTools: string[] }> = [
+  { pattern: /invoice\s+(?:resent|sent)\s+successfully/i, expectedTools: ['resend_invoice', 'send_invoice', 'send_payment_request'] },
+  { pattern: /(?:successfully\s+)?resent\s+(?:the\s+)?invoice/i, expectedTools: ['resend_invoice', 'send_invoice', 'send_payment_request'] },
+  { pattern: /(?:billing\s+)?email\s+(?:updated|changed)\s+successfully/i, expectedTools: ['update_billing_email'] },
+  { pattern: /(?:I'?ve\s+|I\s+)?resolved\s+(?:the\s+)?escalation/i, expectedTools: ['resolve_escalation'] },
+  { pattern: /escalation\s+#?\d+\s+(?:has been\s+)?resolved/i, expectedTools: ['resolve_escalation'] },
+  { pattern: /meeting\s+(?:scheduled|created)\s+successfully/i, expectedTools: ['schedule_meeting'] },
+  { pattern: /(?:I'?ve\s+|I\s+)?(?:created|generated|sent)\s+(?:a\s+)?payment\s+link/i, expectedTools: ['create_payment_link'] },
+  { pattern: /(?:I'?ve\s+|I\s+)?(?:sent|delivered)\s+(?:a\s+)?(?:DM|direct message|notification)/i, expectedTools: ['send_member_dm', 'resolve_escalation'] },
+  { pattern: /(?:I'?ve\s+|I\s+)?added\s+\S+(?:\s+\S+){0,5}\s+to\s+the\s+(?:meeting|call|series)/i, expectedTools: ['add_meeting_attendee'] },
+  // Escalation / ticket-creation claims — #3720
+  { pattern: /(?:I'?ve\s+|I\s+)?(?:created|opened|filed|submitted)\s+(?:a\s+)?(?:ticket|issue)(?:\s+#?\d+)?/i, expectedTools: ['escalate_to_admin', 'create_github_issue'] },
+  { pattern: /(?:I'?ve\s+|I\s+)(?:notified|alerted)\s+(?:the\s+)?team|(?:the\s+)?team\s+has\s+been\s+notified\b/i, expectedTools: ['escalate_to_admin'] },
+  { pattern: /I'?ve\s+(?:flagged|escalated)\s+(?:this|the\s+(?:issue|matter|request|team))|I'?ve\s+notified\s+the\s+team/i, expectedTools: ['escalate_to_admin', 'send_member_dm'] },
+];
+
+/**
+ * Detect possible hallucinated actions in response text.
+ * Returns a flag reason if the text claims to have completed an action
+ * but no corresponding tool was actually called AND succeeded.
+ */
+export function detectHallucinatedAction(text: string, toolExecutions: ToolExecutionRecord[]): string | null {
+  for (const { pattern, expectedTools } of HALLUCINATION_PATTERNS) {
+    if (pattern.test(text)) {
+      const hasSuccessfulTool = expectedTools.some(t =>
+        toolExecutions.some(exec => exec.tool_name === t && !exec.is_error)
+      );
+      if (!hasSuccessfulTool) {
+        return `Possible hallucinated action: text matches "${pattern.source}" but none of [${expectedTools.join(', ')}] succeeded`;
+      }
+    }
+  }
+  return null;
+}

--- a/server/src/addie/hallucination-detect.ts
+++ b/server/src/addie/hallucination-detect.ts
@@ -3,7 +3,7 @@
  * Extracted to a standalone module for testability.
  */
 
-interface ToolExecutionRecord {
+export interface ToolExecutionRecord {
   tool_name: string;
   is_error: boolean;
 }
@@ -23,8 +23,8 @@ export const HALLUCINATION_PATTERNS: ReadonlyArray<{ pattern: RegExp; expectedTo
   { pattern: /(?:I'?ve\s+|I\s+)?(?:sent|delivered)\s+(?:a\s+)?(?:DM|direct message|notification)/i, expectedTools: ['send_member_dm', 'resolve_escalation'] },
   { pattern: /(?:I'?ve\s+|I\s+)?added\s+\S+(?:\s+\S+){0,5}\s+to\s+the\s+(?:meeting|call|series)/i, expectedTools: ['add_meeting_attendee'] },
   // Escalation / ticket-creation claims — #3720
-  { pattern: /(?:I'?ve\s+|I\s+)?(?:created|opened|filed|submitted)\s+(?:a\s+)?(?:ticket|issue)(?:\s+#?\d+)?/i, expectedTools: ['escalate_to_admin', 'create_github_issue'] },
-  { pattern: /(?:I'?ve\s+|I\s+)(?:notified|alerted)\s+(?:the\s+)?team|(?:the\s+)?team\s+has\s+been\s+notified\b/i, expectedTools: ['escalate_to_admin'] },
+  { pattern: /(?:I'?ve\s+|I\s+)?(?:created|opened|filed|submitted)\s+(?:an?\s+)?(?:ticket|issue)(?:\s+#?\d+)?/i, expectedTools: ['escalate_to_admin', 'create_github_issue'] },
+  { pattern: /(?:I'?ve\s+|I\s+)(?:notified|alerted)\s+(?:the\s+)?team|(?:the\s+)?team\s+has\s+been\s+notified\b/i, expectedTools: ['escalate_to_admin', 'send_member_dm'] },
   { pattern: /I'?ve\s+(?:flagged|escalated)\s+(?:this|the\s+(?:issue|matter|request|team))|I'?ve\s+notified\s+the\s+team/i, expectedTools: ['escalate_to_admin', 'send_member_dm'] },
 ];
 

--- a/server/src/addie/rules/constraints.md
+++ b/server/src/addie/rules/constraints.md
@@ -44,7 +44,7 @@ Right:
 - "I checked the catalog — we have `get_account_link` for the Slack ↔ AAO link. For GitHub specifically, the connect URL is https://agenticadvertising.org/connect/github."
 
 ## Never Claim Unexecuted Actions
-CRITICAL: NEVER describe completing an action unless the corresponding tool was actually called AND returned a success result.
+CRITICAL: NEVER describe completing an action unless the corresponding tool was actually called AND returned a success result in this turn.
 
 Actions that REQUIRE a tool call before claiming success:
 - Sending or resending invoices → resend_invoice or send_invoice must succeed
@@ -53,11 +53,12 @@ Actions that REQUIRE a tool call before claiming success:
 - Sending DMs or notifications → send_member_dm must succeed
 - Creating payment links → create_payment_link must succeed
 - Scheduling meetings → schedule_meeting must succeed
+- Escalating to the team → escalate_to_admin must succeed — do NOT say "the team has been notified," "I've flagged this," "ticket #N created," or any equivalent unless escalate_to_admin fired and returned success in this turn. If escalate_to_admin appears unavailable, say so explicitly and do not claim the escalation happened.
 - Any other state-changing operation
 
 If a tool is not available, say "I don't have a tool to do that right now" and escalate.
-If a tool failed, say "That didn't work" and explain what happened.
-NEVER say "Done!" or "Success!" without a tool call backing it up.
+If a tool failed, report the failure explicitly: "That didn't work — [brief reason]."
+NEVER say "Done!", "Success!", or any past-tense completion claim without a tool call backing it up.
 
 ## Never Fabricate People or Names
 NEVER refer to a specific person by name unless:

--- a/server/tests/unit/addie/claude-client-hallucination.test.ts
+++ b/server/tests/unit/addie/claude-client-hallucination.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { detectHallucinatedAction, HALLUCINATION_PATTERNS } from '../../../src/addie/hallucination-detect.js';
+
+const NO_TOOLS: Array<{ tool_name: string; is_error: boolean }> = [];
+
+function succeeded(tool_name: string) {
+  return [{ tool_name, is_error: false }];
+}
+
+function failed(tool_name: string) {
+  return [{ tool_name, is_error: true }];
+}
+
+describe('detectHallucinatedAction — null when clean', () => {
+  it('returns null for text with no action claim', () => {
+    expect(detectHallucinatedAction('Let me look into that for you.', NO_TOOLS)).toBeNull();
+  });
+
+  it('returns null for empty text', () => {
+    expect(detectHallucinatedAction('', NO_TOOLS)).toBeNull();
+  });
+});
+
+describe('detectHallucinatedAction — ticket/issue creation patterns (#3720)', () => {
+  const cases = [
+    "I've created a ticket",
+    "I've created ticket #228",
+    "I've opened a ticket",
+    "I created a ticket for you",
+    "I've filed an issue",
+    "I've opened an issue",
+  ];
+
+  for (const text of cases) {
+    it(`fires on "${text}" when no tool succeeded`, () => {
+      expect(detectHallucinatedAction(text, NO_TOOLS)).not.toBeNull();
+    });
+
+    it(`clear on "${text}" when escalate_to_admin succeeded`, () => {
+      expect(detectHallucinatedAction(text, succeeded('escalate_to_admin'))).toBeNull();
+    });
+
+    it(`clear on "${text}" when create_github_issue succeeded`, () => {
+      expect(detectHallucinatedAction(text, succeeded('create_github_issue'))).toBeNull();
+    });
+  }
+
+  it('does NOT fire on bare ticket number reference (no creation verb)', () => {
+    expect(detectHallucinatedAction("I don't see ticket #228 in the system.", NO_TOOLS)).toBeNull();
+    expect(detectHallucinatedAction("Your reference number is ticket #45.", NO_TOOLS)).toBeNull();
+  });
+});
+
+describe('detectHallucinatedAction — team-notified patterns (#3720)', () => {
+  const firingCases = [
+    "I've notified the team",
+    "I notified the team",
+    "I've alerted the team",
+    "the team has been notified",
+    "The team has been notified and will follow up.",
+  ];
+
+  for (const text of firingCases) {
+    it(`fires on "${text}" when no tool succeeded`, () => {
+      expect(detectHallucinatedAction(text, NO_TOOLS)).not.toBeNull();
+    });
+
+    it(`clear on "${text}" when escalate_to_admin succeeded`, () => {
+      expect(detectHallucinatedAction(text, succeeded('escalate_to_admin'))).toBeNull();
+    });
+  }
+
+  it('does NOT fire on future-tense team notification promise', () => {
+    expect(detectHallucinatedAction("The team will be notified once the invoice is found.", NO_TOOLS)).toBeNull();
+  });
+});
+
+describe('detectHallucinatedAction — flagged/escalated patterns (#3720)', () => {
+  const firingCases = [
+    "I've flagged this",
+    "I've flagged the issue",
+    "I've escalated this",
+    "I've escalated the matter",
+    "I've escalated the team",
+    "I've notified the team",
+  ];
+
+  for (const text of firingCases) {
+    it(`fires on "${text}" when no tool succeeded`, () => {
+      expect(detectHallucinatedAction(text, NO_TOOLS)).not.toBeNull();
+    });
+
+    it(`clear on "${text}" when escalate_to_admin succeeded`, () => {
+      expect(detectHallucinatedAction(text, succeeded('escalate_to_admin'))).toBeNull();
+    });
+
+    it(`clear on "${text}" when send_member_dm succeeded`, () => {
+      expect(detectHallucinatedAction(text, succeeded('send_member_dm'))).toBeNull();
+    });
+  }
+});
+
+describe('detectHallucinatedAction — existing patterns still work', () => {
+  it('fires on "invoice resent successfully" without tool', () => {
+    expect(detectHallucinatedAction('Invoice resent successfully!', NO_TOOLS)).not.toBeNull();
+  });
+
+  it('clear on "invoice resent successfully" when send_invoice succeeded', () => {
+    expect(detectHallucinatedAction('Invoice resent successfully!', succeeded('send_invoice'))).toBeNull();
+  });
+
+  it('fires on DM claim without tool', () => {
+    expect(detectHallucinatedAction("I've sent a DM to that member.", NO_TOOLS)).not.toBeNull();
+  });
+});
+
+describe('detectHallucinatedAction — failed tool does not clear the flag', () => {
+  it('fires even when the expected tool was called but errored', () => {
+    const text = "I've created a ticket";
+    expect(detectHallucinatedAction(text, failed('escalate_to_admin'))).not.toBeNull();
+  });
+});
+
+describe('HALLUCINATION_PATTERNS coverage', () => {
+  it('contains all expected patterns', () => {
+    expect(HALLUCINATION_PATTERNS.length).toBeGreaterThanOrEqual(12);
+  });
+});

--- a/server/tests/unit/addie/claude-client-hallucination.test.ts
+++ b/server/tests/unit/addie/claude-client-hallucination.test.ts
@@ -68,6 +68,10 @@ describe('detectHallucinatedAction — team-notified patterns (#3720)', () => {
     it(`clear on "${text}" when escalate_to_admin succeeded`, () => {
       expect(detectHallucinatedAction(text, succeeded('escalate_to_admin'))).toBeNull();
     });
+
+    it(`clear on "${text}" when send_member_dm succeeded`, () => {
+      expect(detectHallucinatedAction(text, succeeded('send_member_dm'))).toBeNull();
+    });
   }
 
   it('does NOT fire on future-tense team notification promise', () => {


### PR DESCRIPTION
Closes #3720

Addie said "Done — the team has been notified (ticket #228)" in a real admin Slack DM without calling `escalate_to_admin`. The user waited weeks before coming back. This PR closes the two gaps that let it happen.

**What changed:**

1. **`hallucination-detect.ts` (new)** — Extracts `HALLUCINATION_PATTERNS` and `detectHallucinatedAction` from `claude-client.ts` into a standalone module with no DB dependencies (enabling unit tests). Adds three new patterns: ticket/issue creation claims (`I've created a ticket #228`), team-notification claims in active and passive voice (`the team has been notified`), and flagged/escalated claims (`I've flagged this`, `I've escalated this`). All new patterns use verb-of-action or first-person anchors to avoid false positives on bare ticket number references or informational sentences.

2. **`constraints.md`** — Expands the existing "Never Claim Unexecuted Actions" section to explicitly name `escalate_to_admin` with its concrete prohibited phrases, consistent with the existing tool-unavailability rule at line 58–59.

3. **`claude-client-hallucination.test.ts` (new)** — Unit tests covering all three new pattern groups, false-positive avoidance cases (bare ticket references, future-tense promises), and the failed-tool-does-not-clear invariant.

4. **`config-version.ts`** — Bumps `CODE_VERSION` to `2026.05.1` per playbook (claude-client.ts behavior change).

**Non-breaking justification:** Adds detection patterns and a constraint rule. No schema changes, no wire format changes, no public API changes. Downstream callers that already read `flagged`/`flag_reason` on `AddieResponse` gain more coverage; callers that ignore those fields are unaffected.

**Pre-PR review:**
- code-reviewer: approved — TypeScript structural subtype compatibility confirmed; no ReDoS risk in patterns; test coverage adequate. One blocker fixed (removed "always available; there is no excuse for skipping it" claim that contradicted the tool-unavailability rules).
- prompt-engineer: approved — "in this turn" addition is meaningful disambiguation; escalate_to_admin bullet closes the failure mode; the "always available" blocker was fixed before PR creation.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01VudaosZManze5MSziAwcUH

---
_Generated by [Claude Code](https://claude.ai/code/session_01VudaosZManze5MSziAwcUH)_