### PR TITLE
fix(identity): include auth_workos_user_id in audit log details for non-primary bindings

### DIFF
--- a/.changeset/audit-log-auth-identity.md
+++ b/.changeset/audit-log-auth-identity.md
@@ -1,0 +1,4 @@
+---
+---
+
+Include `auth_workos_user_id` in audit log details for non-primary identity bindings so forensic review can determine which bound email performed each action.

--- a/server/src/db/organization-db.ts
+++ b/server/src/db/organization-db.ts
@@ -176,6 +176,8 @@ export interface AuditLogEntry {
   resource_type: string;
   resource_id: string;
   details: Record<string, any>;
+  /** The actual authenticated WorkOS user when id-swap is in effect (non-primary binding). Merged into details automatically by recordAuditLog. */
+  auth_workos_user_id?: string;
 }
 
 /**
@@ -1036,6 +1038,9 @@ export class OrganizationDatabase {
    */
   async recordAuditLog(entry: AuditLogEntry): Promise<void> {
     const pool = getPool();
+    const details = entry.auth_workos_user_id
+      ? { ...entry.details, auth_workos_user_id: entry.auth_workos_user_id }
+      : entry.details;
     await pool.query(
       `INSERT INTO registry_audit_log (workos_organization_id, workos_user_id, action, resource_type, resource_id, details)
        VALUES ($1, $2, $3, $4, $5, $6)`,
@@ -1045,7 +1050,7 @@ export class OrganizationDatabase {
         entry.action,
         entry.resource_type,
         entry.resource_id,
-        JSON.stringify(entry.details),
+        JSON.stringify(details),
       ]
     );
   }

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -4720,10 +4720,30 @@ export class HTTPServer {
               userName = 'System';
             }
 
+            // When id-swap was in effect, also resolve the auth credential's display name
+            let authUserName: string | undefined;
+            const authUserId = (entry.details as Record<string, unknown>)?.auth_workos_user_id as string | undefined;
+            if (authUserId && workos) {
+              const cachedAuth = getCachedUser(authUserId);
+              if (cachedAuth) {
+                authUserName = cachedAuth.displayName;
+              } else {
+                try {
+                  const authUser = await workos.userManagement.getUser(authUserId);
+                  const displayName = authUser.email || `${authUser.firstName} ${authUser.lastName}`.trim() || 'Unknown';
+                  authUserName = displayName;
+                  setCachedUser(authUserId, displayName);
+                } catch (err) {
+                  logger.warn({ err, userId: authUserId }, 'Failed to fetch auth user name for audit log');
+                }
+              }
+            }
+
             return {
               ...entry,
               organization_name: organizationName,
               user_name: userName,
+              ...(authUserName !== undefined && { auth_user_name: authUserName }),
             };
           })
         );
@@ -7563,6 +7583,7 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
             await orgDb.recordAuditLog({
               workos_organization_id: organization_id,
               workos_user_id: user.id,
+              auth_workos_user_id: user.authWorkosUserId,
               action: 'member_added',
               resource_type: 'membership',
               resource_id: membership.id,
@@ -7639,6 +7660,7 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
         await orgDb.recordAuditLog({
           workos_organization_id: organization_id,
           workos_user_id: user.id,
+          auth_workos_user_id: user.authWorkosUserId,
           action: 'join_request_created',
           resource_type: 'join_request',
           resource_id: request.id,
@@ -7692,6 +7714,7 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
             await orgDb.recordAuditLog({
               workos_organization_id: organization_id,
               workos_user_id: user.id,
+              auth_workos_user_id: user.authWorkosUserId,
               action: 'join_request_auto_approved',
               resource_type: 'join_request',
               resource_id: request.id,

--- a/server/src/routes/admin/accounts-billing.ts
+++ b/server/src/routes/admin/accounts-billing.ts
@@ -532,6 +532,7 @@ export function setupAccountsBillingRoutes(
         await orgDb.recordAuditLog({
           workos_organization_id: orgId,
           workos_user_id: req.user!.id,
+          auth_workos_user_id: req.user!.authWorkosUserId,
           action: "organization_deleted",
           resource_type: "organization",
           resource_id: orgId,
@@ -738,6 +739,7 @@ export function setupAccountsBillingRoutes(
                 admin_email: req.user!.email,
                 reason: reason.trim(),
                 before_state: beforeState,
+                ...(req.user!.authWorkosUserId && { auth_workos_user_id: req.user!.authWorkosUserId }),
               }),
             ]
           );
@@ -1045,6 +1047,7 @@ export function setupAccountsBillingRoutes(
                 reason: reason.trim(),
                 before_state: beforeState,
                 after_state: afterState,
+                ...(req.user!.authWorkosUserId && { auth_workos_user_id: req.user!.authWorkosUserId }),
               }),
             ]
           );

--- a/server/src/routes/admin/accounts.ts
+++ b/server/src/routes/admin/accounts.ts
@@ -2505,6 +2505,7 @@ export function setupAccountRoutes(
         await orgDb.recordAuditLog({
           workos_organization_id: orgId,
           workos_user_id: req.user?.id || "admin",
+          auth_workos_user_id: req.user?.authWorkosUserId,
           action: "admin_member_role_changed",
           resource_type: "membership",
           resource_id: membershipId,

--- a/server/src/routes/admin/brand-enrichment.ts
+++ b/server/src/routes/admin/brand-enrichment.ts
@@ -510,6 +510,7 @@ export function setupBrandEnrichmentRoutes(apiRouter: Router): void {
                   prior_house_domain: priorRow.house_domain,
                   new_house_domain: house_domain || null,
                   admin_email: req.user!.email,
+                  ...(req.user!.authWorkosUserId && { auth_workos_user_id: req.user!.authWorkosUserId }),
                 }),
               ]
             );

--- a/server/src/routes/admin/cleanup.ts
+++ b/server/src/routes/admin/cleanup.ts
@@ -293,7 +293,7 @@ export function setupCleanupRoutes(apiRouter: Router): void {
       }
 
       const user = (req as any).user;
-      const userId = user?.id || "unknown";
+      const userId = user?.authWorkosUserId ?? user?.id ?? "unknown";
 
       logger.info(
         { primary_org_id, secondary_org_id, userId, stripe_customer_resolution },

--- a/server/src/routes/admin/users.ts
+++ b/server/src/routes/admin/users.ts
@@ -752,7 +752,7 @@ export function createAdminUsersRouter(): Router {
   // verification email is sent to the new address. Phase 3 may add one.
   router.post('/:userId/linked-emails', requireAuth, requireAdmin, async (req, res) => {
     const adminEmail = req.user!.email;
-    const adminUserId = req.user!.id;
+    const adminUserId = req.user!.authWorkosUserId ?? req.user!.id;
     const existingUserId = req.params.userId;
     const rawEmail = (req.body?.email as string | undefined)?.trim();
 

--- a/server/src/routes/billing.ts
+++ b/server/src/routes/billing.ts
@@ -808,6 +808,7 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
       await orgDb.recordAuditLog({
         workos_organization_id: org_id,
         workos_user_id: req.user?.id ?? 'unknown',
+        auth_workos_user_id: req.user?.authWorkosUserId,
         action: previousCustomerId ? 'admin_stripe_link_replace' : 'admin_stripe_link',
         resource_type: 'subscription',
         resource_id: customerId,
@@ -963,6 +964,7 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
       await orgDb.recordAuditLog({
         workos_organization_id: org.workos_organization_id,
         workos_user_id: req.user?.id ?? 'unknown',
+        auth_workos_user_id: req.user?.authWorkosUserId,
         action: 'admin_stripe_unlink',
         resource_type: 'subscription',
         resource_id: customerId,

--- a/server/src/routes/organizations.ts
+++ b/server/src/routes/organizations.ts
@@ -381,6 +381,7 @@ export function createOrganizationsRouter(): Router {
       await orgDb.recordAuditLog({
         workos_organization_id: orgId,
         workos_user_id: user.id,
+        auth_workos_user_id: user.authWorkosUserId,
         action: 'join_request_approved',
         resource_type: 'join_request',
         resource_id: requestId,
@@ -510,6 +511,7 @@ export function createOrganizationsRouter(): Router {
       await orgDb.recordAuditLog({
         workos_organization_id: orgId,
         workos_user_id: user.id,
+        auth_workos_user_id: user.authWorkosUserId,
         action: 'join_request_rejected',
         resource_type: 'join_request',
         resource_id: requestId,
@@ -725,6 +727,7 @@ export function createOrganizationsRouter(): Router {
       await orgDb.recordAuditLog({
         workos_organization_id: orgId,
         workos_user_id: user.id,
+        auth_workos_user_id: user.authWorkosUserId,
         action: 'brand_classification_report_filed',
         resource_type: 'brand',
         resource_id: subject_domain.toLowerCase(),
@@ -1032,6 +1035,7 @@ export function createOrganizationsRouter(): Router {
       await orgDb.recordAuditLog({
         workos_organization_id: orgId,
         workos_user_id: adminUser.id,
+        auth_workos_user_id: adminUser.authWorkosUserId,
         action: 'member_added',
         resource_type: 'membership',
         resource_id: membership.id,
@@ -1403,6 +1407,7 @@ export function createOrganizationsRouter(): Router {
             await orgDb.recordAuditLog({
               workos_organization_id: existingOrgId,
               workos_user_id: user.id,
+              auth_workos_user_id: user.authWorkosUserId,
               action: 'organization_adopted',
               resource_type: 'organization',
               resource_id: existingOrgId,
@@ -1542,6 +1547,7 @@ export function createOrganizationsRouter(): Router {
       await orgDb.recordAuditLog({
         workos_organization_id: workosOrgId,
         workos_user_id: user.id,
+        auth_workos_user_id: user.authWorkosUserId,
         action: 'organization_created',
         resource_type: 'organization',
         resource_id: workosOrgId,
@@ -1679,6 +1685,7 @@ export function createOrganizationsRouter(): Router {
       await orgDb.recordAuditLog({
         workos_organization_id: orgId,
         workos_user_id: user.id,
+        auth_workos_user_id: user.authWorkosUserId,
         action: 'organization_renamed',
         resource_type: 'organization',
         resource_id: orgId,
@@ -1845,6 +1852,7 @@ export function createOrganizationsRouter(): Router {
       await orgDb.recordAuditLog({
         workos_organization_id: orgId,
         workos_user_id: user.id,
+        auth_workos_user_id: user.authWorkosUserId,
         action: 'organization_settings_updated',
         resource_type: 'organization',
         resource_id: orgId,
@@ -1960,6 +1968,7 @@ export function createOrganizationsRouter(): Router {
       await orgDb.recordAuditLog({
         workos_organization_id: orgId,
         workos_user_id: user.id,
+        auth_workos_user_id: user.authWorkosUserId,
         action: 'organization_deleted',
         resource_type: 'organization',
         resource_id: orgId,
@@ -2175,6 +2184,7 @@ export function createOrganizationsRouter(): Router {
       await orgDb.recordAuditLog({
         workos_organization_id: orgId,
         workos_user_id: user.id,
+        auth_workos_user_id: user.authWorkosUserId,
         action: 'convert_to_team',
         resource_type: 'organization',
         resource_id: orgId,
@@ -2260,6 +2270,7 @@ export function createOrganizationsRouter(): Router {
       await orgDb.recordAuditLog({
         workos_organization_id: orgId,
         workos_user_id: user.id,
+        auth_workos_user_id: user.authWorkosUserId,
         action: 'convert_to_individual',
         resource_type: 'organization',
         resource_id: orgId,
@@ -2547,6 +2558,7 @@ export function createOrganizationsRouter(): Router {
       await orgDb.recordAuditLog({
         workos_organization_id: orgId,
         workos_user_id: user.id,
+        auth_workos_user_id: user.authWorkosUserId,
         action: 'member_invited',
         resource_type: 'invitation',
         resource_id: invitation.id,
@@ -2633,6 +2645,7 @@ export function createOrganizationsRouter(): Router {
       await orgDb.recordAuditLog({
         workos_organization_id: orgId,
         workos_user_id: user.id,
+        auth_workos_user_id: user.authWorkosUserId,
         action: 'invitation_revoked',
         resource_type: 'invitation',
         resource_id: invitationId,
@@ -2713,6 +2726,7 @@ export function createOrganizationsRouter(): Router {
       await orgDb.recordAuditLog({
         workos_organization_id: orgId,
         workos_user_id: user.id,
+        auth_workos_user_id: user.authWorkosUserId,
         action: 'invitation_resent',
         resource_type: 'invitation',
         resource_id: newInvitation.id,
@@ -2897,6 +2911,7 @@ export function createOrganizationsRouter(): Router {
         await orgDb.recordAuditLog({
           workos_organization_id: orgId,
           workos_user_id: user.id,
+          auth_workos_user_id: user.authWorkosUserId,
           action: 'member_invited',
           resource_type: 'invitation',
           resource_id: invitation.id,
@@ -3011,6 +3026,7 @@ export function createOrganizationsRouter(): Router {
         await orgDb.recordAuditLog({
           workos_organization_id: orgId,
           workos_user_id: user.id,
+          auth_workos_user_id: user.authWorkosUserId,
           action: 'member_added',
           resource_type: 'membership',
           resource_id: membership.id,
@@ -3137,6 +3153,7 @@ export function createOrganizationsRouter(): Router {
       await orgDb.recordAuditLog({
         workos_organization_id: orgId,
         workos_user_id: user.id,
+        auth_workos_user_id: user.authWorkosUserId,
         action: 'member_role_changed',
         resource_type: 'membership',
         resource_id: membershipId,
@@ -3312,6 +3329,7 @@ export function createOrganizationsRouter(): Router {
           await orgDb.recordAuditLog({
             workos_organization_id: orgId,
             workos_user_id: user.id,
+            auth_workos_user_id: user.authWorkosUserId,
             action: 'member_seat_type_changed',
             resource_type: 'membership',
             resource_id: membershipId,
@@ -3365,6 +3383,7 @@ export function createOrganizationsRouter(): Router {
         await orgDb.recordAuditLog({
           workos_organization_id: orgId,
           workos_user_id: user.id,
+          auth_workos_user_id: user.authWorkosUserId,
           action: 'member_role_changed',
           resource_type: 'membership',
           resource_id: membershipId,
@@ -3487,6 +3506,7 @@ export function createOrganizationsRouter(): Router {
       await orgDb.recordAuditLog({
         workos_organization_id: orgId,
         workos_user_id: user.id,
+        auth_workos_user_id: user.authWorkosUserId,
         action: 'member_removed',
         resource_type: 'membership',
         resource_id: membershipId,
@@ -3839,6 +3859,7 @@ export function createOrganizationsRouter(): Router {
       await orgDb.recordAuditLog({
         workos_organization_id: orgId,
         workos_user_id: user.id,
+        auth_workos_user_id: user.authWorkosUserId,
         action: 'seat_upgrade_requested',
         resource_type: 'seat_upgrade_request',
         resource_id: request.id,
@@ -3938,6 +3959,7 @@ export function createOrganizationsRouter(): Router {
       await orgDb.recordAuditLog({
         workos_organization_id: orgId,
         workos_user_id: user.id,
+        auth_workos_user_id: user.authWorkosUserId,
         action: 'seat_upgrade_approved',
         resource_type: 'seat_upgrade_request',
         resource_id: requestId,
@@ -4012,6 +4034,7 @@ export function createOrganizationsRouter(): Router {
       await orgDb.recordAuditLog({
         workos_organization_id: orgId,
         workos_user_id: user.id,
+        auth_workos_user_id: user.authWorkosUserId,
         action: 'seat_upgrade_denied',
         resource_type: 'seat_upgrade_request',
         resource_id: requestId,


### PR DESCRIPTION
Closes #3717

## Summary

PR #3715 introduced id-swap in the auth middleware: `req.user.id` is always the canonical workos_user_id, and `req.user.authWorkosUserId` holds the actual credential when a non-primary binding is signed in. Audit log inserts were recording only the canonical id, losing the forensic trail of which bound email performed each action. Phase 2b (#3722) ships today, creating the first non-singleton bindings — this fix needed to land immediately.

**What this PR does:**
- Adds `auth_workos_user_id?: string` to `AuditLogEntry` interface; `recordAuditLog` merges it into the `details` JSONB automatically (no schema migration — details is already `JSONB`)
- Updates all 32 `orgDb.recordAuditLog()` call sites that use `req.user.id` as the actor across `organizations.ts` (23 sites), `http.ts` (3), `accounts-billing.ts` (1), `accounts.ts` (1), `billing.ts` (2), and `brand-enrichment.ts` (1 inline SQL)
- Fixes 2 inline SQL sites in `accounts-billing.ts` to spread `auth_workos_user_id` conditionally into their `JSON.stringify` details
- Fixes `admin/users.ts`: the `adminUserId` passed to `mergeUsers` now uses `authWorkosUserId ?? id` so `merge_user` audit entries record the credential identity
- Fixes `admin/cleanup.ts`: same credential-id fix for `mergeOrganizations` actor
- Adds `auth_user_name` display enrichment to the admin audit log API endpoint (resolves the credential user via the existing WorkOS cache, guarded against `workos` being null in dev mode)

**Non-breaking justification:** All changes are additive to the `details` JSONB column. `workos_user_id` (= canonical) is unchanged for all routes except `merge_user` / `merge_organization`, where the actor column now records the credential id directly (consistent with how those two functions have always worked — the actor is passed by the caller, not extracted from the canonical id). No existing query is broken; the new field is absent from records written before this PR.

**Note on merge audit entries (`merge_user` / `merge_organization`):** For these two operations, `workos_user_id` stores the credential id directly (the caller passes it). This differs from the `details.auth_workos_user_id` pattern used everywhere else. The `auth_user_name` display enrichment will not fire for these entries (they don't store `auth_workos_user_id` in details). A follow-up could unify the pattern by adding an `authMergedBy?: string` parameter to both merge functions, but that is out of scope here.

**Note on `companyDb.recordAuditLog` sites (http.ts:7962, 8032):** These use a different audit table schema (`user_id` column, `metadata` JSONB) and are currently dead code. Not updated here; the `companyDb` audit surface should be handled separately when those endpoints are activated.

**Pre-PR review:**
- code-reviewer: approved — no blockers; 3 nits (double cast in http.ts, extract `formatWorkOSDisplayName` helper, add test case for id-swap scenario). Nits noted; not blocking.
- internal-tools-strategist: approved — both prior blockers resolved (AuditLogEntry centralization ✓, `auth_user_name` enrichment ✓); inline SQL sites acceptable due to transaction coupling.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_014nNk64VpVs3hLFS7xSPKdQ

---
_Generated by [Claude Code](https://claude.ai/code/session_014nNk64VpVs3hLFS7xSPKdQ)_