### PR TITLE
fix(registry): tighten metric_id+accreditation filter to per-metric semantics

### DIFF
--- a/.changeset/fix-per-metric-filter-semantics.md
+++ b/.changeset/fix-per-metric-filter-semantics.md
@@ -1,0 +1,14 @@
+---
+---
+
+fix(registry): tighten metric_id+accreditation filter to per-metric semantics
+
+When both `metric_id` and `accreditation` are passed to `/api/registry/agents`,
+the same `metrics[]` element must now satisfy both constraints simultaneously.
+Previously, independent JSONB containment predicates allowed loose cross-metric
+matching (a vendor with `attention_units` on one metric and MRC accreditation on
+a different metric would falsely match). Cross-product AND semantics apply for
+multiple values: every `(metric_id, accreditation)` pair requires a dedicated
+metrics element.
+
+Also documents the combined-filter semantics in `docs/registry/index.mdx`.

--- a/docs/registry/index.mdx
+++ b/docs/registry/index.mdx
@@ -165,8 +165,19 @@ This returns every measurement agent the registry knows about — registered via
 | Param | Match | Notes |
 |-------|-------|-------|
 | `metric_id=attention_units` | Exact match on `metrics[].metric_id` | Repeatable; multiple values are OR'd within the param. |
-| `accreditation=MRC` | Exact match on `metrics[].accreditations[].accrediting_body` | Repeatable. Vendor-asserted — `verified_by_aao` is always `false` in the response; renderers should mark these as vendor claims, not AAO endorsements. |
+| `accreditation=MRC` | Exact match on `metrics[].accreditations[].accrediting_body` | Repeatable; OR'd when used alone, but cross-product AND'd with `metric_id` when both params are present (see below). Vendor-asserted — `verified_by_aao` is always `false` in the response; renderers should mark these as vendor claims, not AAO endorsements. |
 | `q=attention` | Case-insensitive substring on `metric_id` | v1 scope: metric_id only. Max 64 chars; SQL wildcards (`%`, `_`) rejected. Description/standard fuzzy search is a follow-up. |
+
+**Combined filter semantics.** When both `metric_id` and `accreditation` are present, per-metric semantics apply: the same `metrics[]` element must satisfy both constraints simultaneously. A vendor with an `attention_units` metric and a separately MRC-accredited `viewability` metric does **not** match — only a vendor whose `attention_units` metric itself carries MRC accreditation does.
+
+With multiple values, every `(metric_id, accreditation)` pair must be satisfied by at least one metrics element. This is a cross-product AND, not an OR within accreditation:
+
+```bash
+# Vendor must have MRC-accredited attention_units AND MRC-accredited emissions
+curl "https://agenticadvertising.org/api/registry/agents?metric_id=attention_units&metric_id=emissions&accreditation=MRC"
+```
+
+Using multiple `accreditation` values alongside multiple `metric_id` values produces an all-pairs AND (`M × N` constraints) and typically returns few or no results. Prefer single `accreditation` with multiple `metric_id` values for discovery.
 
 ```bash
 # All vendors offering attention measurement

--- a/docs/registry/index.mdx
+++ b/docs/registry/index.mdx
@@ -164,8 +164,8 @@ This returns every measurement agent the registry knows about — registered via
 
 | Param | Match | Notes |
 |-------|-------|-------|
-| `metric_id=attention_units` | Exact match on `metrics[].metric_id` | Repeatable; multiple values are OR'd within the param. |
-| `accreditation=MRC` | Exact match on `metrics[].accreditations[].accrediting_body` | Repeatable; OR'd when used alone, but cross-product AND'd with `metric_id` when both params are present (see below). Vendor-asserted — `verified_by_aao` is always `false` in the response; renderers should mark these as vendor claims, not AAO endorsements. |
+| `metric_id=attention_units` | Exact match on `metrics[].metric_id` | Repeatable; multiple values are AND'd (vendor must carry all named metrics). |
+| `accreditation=MRC` | Exact match on `metrics[].accreditations[].accrediting_body` | Repeatable; multiple values are AND'd (vendor must carry all named accreditations). When combined with `metric_id`, a cross-product AND applies — see combined filter semantics below. Vendor-asserted — `verified_by_aao` is always `false` in the response; renderers should mark these as vendor claims, not AAO endorsements. |
 | `q=attention` | Case-insensitive substring on `metric_id` | v1 scope: metric_id only. Max 64 chars; SQL wildcards (`%`, `_`) rejected. Description/standard fuzzy search is a follow-up. |
 
 **Combined filter semantics.** When both `metric_id` and `accreditation` are present, per-metric semantics apply: the same `metrics[]` element must satisfy both constraints simultaneously. A vendor with an `attention_units` metric and a separately MRC-accredited `viewability` metric does **not** match — only a vendor whose `attention_units` metric itself carries MRC accreditation does.

--- a/server/src/db/agent-snapshot-db.ts
+++ b/server/src/db/agent-snapshot-db.ts
@@ -160,14 +160,29 @@ export class AgentSnapshotDatabase {
     const conditions: string[] = [`measurement_capabilities_json IS NOT NULL`];
     const params: unknown[] = [];
 
-    for (const id of filters.metric_ids ?? []) {
-      params.push(JSON.stringify({ metrics: [{ metric_id: id }] }));
-      conditions.push(`measurement_capabilities_json @> $${params.length}::jsonb`);
-    }
-
-    for (const body of filters.accreditations ?? []) {
-      params.push(JSON.stringify({ metrics: [{ accreditations: [{ accrediting_body: body }] }] }));
-      conditions.push(`measurement_capabilities_json @> $${params.length}::jsonb`);
+    if (filters.metric_ids?.length && filters.accreditations?.length) {
+      // Per-metric semantics: the same metrics element must satisfy both constraints.
+      // Cross-product AND: every (metric_id, accreditation) pair gets its own containment
+      // probe so each combination must be covered by at least one element in metrics[].
+      for (const id of filters.metric_ids) {
+        for (const body of filters.accreditations) {
+          params.push(
+            JSON.stringify({ metrics: [{ metric_id: id, accreditations: [{ accrediting_body: body }] }] }),
+          );
+          conditions.push(`measurement_capabilities_json @> $${params.length}::jsonb`);
+        }
+      }
+    } else {
+      for (const id of filters.metric_ids ?? []) {
+        params.push(JSON.stringify({ metrics: [{ metric_id: id }] }));
+        conditions.push(`measurement_capabilities_json @> $${params.length}::jsonb`);
+      }
+      for (const body of filters.accreditations ?? []) {
+        params.push(
+          JSON.stringify({ metrics: [{ accreditations: [{ accrediting_body: body }] }] }),
+        );
+        conditions.push(`measurement_capabilities_json @> $${params.length}::jsonb`);
+      }
     }
 
     if (filters.q) {

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -574,11 +574,11 @@ registry.registerPath({
       properties: z.enum(["true"]).optional(),
       compliance: z.enum(["true"]).optional(),
       metric_id: z.union([z.string(), z.array(z.string())]).optional().openapi({
-        description: "Measurement-vendor filter: exact match on `measurement.metrics[].metric_id`. Repeatable (each value is OR'd within the param, AND'd with other filters). Implies `type=measurement`.",
+        description: "Measurement-vendor filter: exact match on `measurement.metrics[].metric_id`. Repeatable; multiple values are AND'd (vendor must carry all named metrics). When combined with `accreditation`, a cross-product AND applies — each (metric_id, accreditation) pair must be covered by the same metrics element. Implies `type=measurement`.",
         example: "attention_units",
       }),
       accreditation: z.union([z.string(), z.array(z.string())]).optional().openapi({
-        description: "Measurement-vendor filter: exact match on `measurement.metrics[].accreditations[].accrediting_body` (e.g. `MRC`, `JIC`, `ARF`). Repeatable. Implies `type=measurement`. Accreditation claims are vendor-asserted; AAO does not independently verify (`verified_by_aao` is always `false` in the response).",
+        description: "Measurement-vendor filter: exact match on `measurement.metrics[].accreditations[].accrediting_body` (e.g. `MRC`, `JIC`, `ARF`). Repeatable; multiple values are AND'd. When combined with `metric_id`, a cross-product AND applies — see `metric_id` description. Implies `type=measurement`. Accreditation claims are vendor-asserted; AAO does not independently verify (`verified_by_aao` is always `false` in the response).",
         example: "MRC",
       }),
       q: z.string().max(64).optional().openapi({

--- a/server/tests/unit/agent-snapshot-db.test.ts
+++ b/server/tests/unit/agent-snapshot-db.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../src/db/client.js', () => ({
+  query: vi.fn(),
+  getClient: vi.fn(),
+}));
+
+import { AgentSnapshotDatabase } from '../../src/db/agent-snapshot-db.js';
+import { query } from '../../src/db/client.js';
+
+const mockedQuery = vi.mocked(query);
+
+function mockResult<T>(rows: T[]) {
+  return { rows, rowCount: rows.length, command: '', oid: 0, fields: [] };
+}
+
+describe('AgentSnapshotDatabase.filterMeasurementAgents', () => {
+  let db: AgentSnapshotDatabase;
+
+  beforeEach(() => {
+    db = new AgentSnapshotDatabase();
+    vi.clearAllMocks();
+  });
+
+  it('returns all measurement agents when no filters provided', async () => {
+    mockedQuery.mockResolvedValueOnce(mockResult([{ agent_url: 'https://a.example.com' }]));
+    const result = await db.filterMeasurementAgents({});
+    expect(result).toEqual(new Set(['https://a.example.com']));
+    const sql: string = mockedQuery.mock.calls[0][0] as string;
+    expect(sql).toContain('measurement_capabilities_json IS NOT NULL');
+    expect(sql).not.toContain('@>');
+  });
+
+  it('solo metric_id uses independent @> containment on metric_id only', async () => {
+    mockedQuery.mockResolvedValueOnce(mockResult([]));
+    await db.filterMeasurementAgents({ metric_ids: ['attention_units'] });
+    const sql: string = mockedQuery.mock.calls[0][0] as string;
+    const params = mockedQuery.mock.calls[0][1] as unknown[];
+    expect(sql).toContain('@>');
+    expect(JSON.parse(params[0] as string)).toEqual({ metrics: [{ metric_id: 'attention_units' }] });
+    expect(JSON.parse(params[0] as string)).not.toHaveProperty('metrics.0.accreditations');
+  });
+
+  it('solo accreditation uses independent @> containment on accreditation only', async () => {
+    mockedQuery.mockResolvedValueOnce(mockResult([]));
+    await db.filterMeasurementAgents({ accreditations: ['MRC'] });
+    const sql: string = mockedQuery.mock.calls[0][0] as string;
+    const params = mockedQuery.mock.calls[0][1] as unknown[];
+    expect(sql).toContain('@>');
+    expect(JSON.parse(params[0] as string)).toEqual({
+      metrics: [{ accreditations: [{ accrediting_body: 'MRC' }] }],
+    });
+  });
+
+  it('combined metric_id + accreditation uses per-metric nested containment (regression: must not use independent predicates)', async () => {
+    mockedQuery.mockResolvedValueOnce(mockResult([]));
+    await db.filterMeasurementAgents({ metric_ids: ['attention_units'], accreditations: ['MRC'] });
+    const params = mockedQuery.mock.calls[0][1] as unknown[];
+    // Must have exactly ONE extra param combining both constraints
+    expect(params).toHaveLength(1);
+    expect(JSON.parse(params[0] as string)).toEqual({
+      metrics: [{ metric_id: 'attention_units', accreditations: [{ accrediting_body: 'MRC' }] }],
+    });
+  });
+
+  it('cross-product: two metric_ids × one accreditation emits two per-pair probes (both ANDed)', async () => {
+    mockedQuery.mockResolvedValueOnce(mockResult([]));
+    await db.filterMeasurementAgents({
+      metric_ids: ['attention_units', 'emissions'],
+      accreditations: ['MRC'],
+    });
+    const params = mockedQuery.mock.calls[0][1] as unknown[];
+    expect(params).toHaveLength(2);
+    expect(JSON.parse(params[0] as string)).toEqual({
+      metrics: [{ metric_id: 'attention_units', accreditations: [{ accrediting_body: 'MRC' }] }],
+    });
+    expect(JSON.parse(params[1] as string)).toEqual({
+      metrics: [{ metric_id: 'emissions', accreditations: [{ accrediting_body: 'MRC' }] }],
+    });
+    const sql: string = mockedQuery.mock.calls[0][0] as string;
+    // Both probes must appear as AND conditions, not OR
+    const andCount = (sql.match(/ AND /g) ?? []).length;
+    expect(andCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it('cross-product: one metric_id × two accreditations emits two per-pair probes', async () => {
+    mockedQuery.mockResolvedValueOnce(mockResult([]));
+    await db.filterMeasurementAgents({
+      metric_ids: ['attention_units'],
+      accreditations: ['MRC', 'ABC'],
+    });
+    const params = mockedQuery.mock.calls[0][1] as unknown[];
+    expect(params).toHaveLength(2);
+    expect(JSON.parse(params[0] as string)).toEqual({
+      metrics: [{ metric_id: 'attention_units', accreditations: [{ accrediting_body: 'MRC' }] }],
+    });
+    expect(JSON.parse(params[1] as string)).toEqual({
+      metrics: [{ metric_id: 'attention_units', accreditations: [{ accrediting_body: 'ABC' }] }],
+    });
+  });
+
+  it('q filter uses jsonb_array_elements EXISTS regardless of other filters', async () => {
+    mockedQuery.mockResolvedValueOnce(mockResult([]));
+    await db.filterMeasurementAgents({ q: 'attention' });
+    const sql: string = mockedQuery.mock.calls[0][0] as string;
+    expect(sql).toContain('jsonb_array_elements');
+    expect(sql).toContain('ILIKE');
+  });
+});


### PR DESCRIPTION
Closes #3733

## Summary

When `/api/registry/agents` receives both `metric_id` and `accreditation` query params, the old implementation built independent JSONB `@>` containment predicates ANDed at SQL level. This allowed cross-metric false positives: a vendor with an `attention_units` metric (not MRC-accredited) **and** a separately MRC-accredited `viewability` metric would match `?metric_id=attention_units&accreditation=MRC`, even though no single metric satisfies both constraints.

**Fix:** When both params are present, `filterMeasurementAgents` now emits one combined JSONB containment probe per `(metric_id, accreditation)` pair — cross-product AND semantics. Each probe requires a **single metrics element** to carry both `metric_id` and the nested `accreditations[].accrediting_body`. Solo filters (only `metric_id` or only `accreditation`) are unchanged and still use the existing `@>` path.

**Also fixed (pre-existing docs error):** The `metric_id` table row and OpenAPI description incorrectly said multiple values were "OR'd within the param". The code has always AND'd them (vendor must carry all named metrics). Both are corrected here.

**Changeset:** `--empty` — this is a server-side query behavior fix; no AdCP protocol schema changes.

## Non-breaking justification

PR #3726 shipped this endpoint on 2026-05-01 (the same day this issue was filed). Zero production callers have observed the old behavior in steady state. The fix narrows results to what callers actually asked for; any agent using both params with the old code was getting false-positive vendors.

## Changes

| File | Change |
|---|---|
| `server/src/db/agent-snapshot-db.ts` | Cross-product combined containment when both `metric_ids` and `accreditations` are set |
| `docs/registry/index.mdx` | Documents combined-filter semantics; corrects `metric_id` table row from "OR'd" to "AND'd" |
| `server/src/routes/registry-api.ts` | Updates `metric_id` and `accreditation` OpenAPI descriptions to reflect AND semantics and cross-product note |
| `server/tests/unit/agent-snapshot-db.test.ts` | New: 7 regression tests covering solo filters, combined 1×1 (the core regression case), cross-product 2×1, cross-product 1×2, and `q` filter |

## Pre-PR review

- **code-reviewer:** approved — code logic correct, GIN index still used, no migration needed; flagged docs table contradiction (fixed in second commit)
- **adtech-product-expert:** approved — strict per-metric semantics matches real buyer workflows; confirmed AND semantics correct for solo multi-value params; flagged OpenAPI `metric_id` description still said "OR'd" (fixed in second commit)

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01WtFVR4EFu1UUuLN9PKGVfx

---
_Generated by [Claude Code](https://claude.ai/code/session_01WtFVR4EFu1UUuLN9PKGVfx)_