### PR TITLE
feat(addie): extract working-group membership service (#3736 part 1)

### DIFF
--- a/.changeset/working-group-membership-service.md
+++ b/.changeset/working-group-membership-service.md
@@ -1,0 +1,16 @@
+---
+---
+
+Extract a `working-group-membership-service` shared by the route handlers and Addie tools, fixing three Addie tools that have been silently broken since CSRF tightening:
+
+- `join_working_group` — was returning *"this is a private working group"* for public groups (production-confirmed across multiple users this April).
+- `express_council_interest` — was throwing on every call.
+- `withdraw_council_interest` — was throwing on every call.
+
+Root cause is the same loopback-CSRF pattern fixed for `probe_adcp_agent` / `check_publisher_authorization` in PR #3716: `callApi('POST', …)` from Addie hit our own CSRF middleware before reaching the route. Rather than route around CSRF, the route handlers and the Addie tools now both consume `joinWorkingGroup` / `expressCommitteeInterest` / `withdrawCommitteeInterest` directly. Service throws a discriminated `WorkingGroupMembershipError` (`group_not_found` / `group_private` / `community_only_seat_blocked` / `already_member` / `no_interest_recorded`) so each adapter renders the right HTTP status / chat message — no HTTP-status guessing.
+
+Side effects (community points, badge checks, leader notifications, Slack channel auto-invite, Addie welcome DM) live in the service so they fire regardless of caller surface, and a future drift between web and chat surfaces is impossible.
+
+Also extracts two cache-only modules (`addie/member-context-cache.ts` and `addie/admin-status-cache.ts`) so callers that just need to invalidate caches can do so without dragging in `middleware/auth` (WorkOS module-load) or `addie/services/engagement-planner` (Anthropic module-load). Keeps the unit-test import graph small and stops `admin-tools` from being a chokepoint.
+
+Tracks issue #3736 (3 of 7 tools fixed; document/post tools follow in a second PR, then `callApi` POST/PUT/DELETE lockdown).

--- a/server/src/addie/admin-status-cache.ts
+++ b/server/src/addie/admin-status-cache.ts
@@ -1,0 +1,59 @@
+/**
+ * Admin-status cache primitives for both Slack and web admin lookups.
+ *
+ * Extracted from `mcp/admin-tools.ts` so callers that only need to
+ * invalidate (route handlers, services, account/membership flows) don't
+ * have to pull in the entire admin-tools module — which transitively
+ * loads relationship-orchestrator, engagement-planner, and instantiates
+ * Anthropic at module load. Keeps the unit-test import graph small and
+ * stops admin-tools from being a chokepoint that pulls Anthropic into
+ * unrelated dependency chains.
+ *
+ * The cache values themselves stay private here — only invalidation is
+ * exported. Read paths still live in admin-tools.ts where they belong.
+ */
+
+const slackAdminStatusCache = new Map<string, { isAdmin: boolean; expiresAt: number }>();
+const webAdminStatusCache = new Map<string, { isAdmin: boolean; expiresAt: number }>();
+
+export function getSlackAdminStatusCache(): Map<string, { isAdmin: boolean; expiresAt: number }> {
+  return slackAdminStatusCache;
+}
+
+export function getWebAdminStatusCache(): Map<string, { isAdmin: boolean; expiresAt: number }> {
+  return webAdminStatusCache;
+}
+
+/**
+ * Invalidate Slack admin status cache. Pass no argument to clear the
+ * entire cache (used when admin assignments change for an unknown set of
+ * users).
+ */
+export function invalidateSlackAdminStatusCache(slackUserId?: string): void {
+  if (slackUserId) {
+    slackAdminStatusCache.delete(slackUserId);
+  } else {
+    slackAdminStatusCache.clear();
+  }
+}
+
+/**
+ * Invalidate web (WorkOS) admin status cache. Pass no argument to clear
+ * the entire cache.
+ */
+export function invalidateWebAdminStatusCache(workosUserId?: string): void {
+  if (workosUserId) {
+    webAdminStatusCache.delete(workosUserId);
+  } else {
+    webAdminStatusCache.clear();
+  }
+}
+
+/**
+ * Clear both caches. Used when an admin role change invalidates Slack
+ * and web entries simultaneously.
+ */
+export function invalidateAllAdminStatusCaches(): void {
+  slackAdminStatusCache.clear();
+  webAdminStatusCache.clear();
+}

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -143,7 +143,10 @@ const KITCHEN_CABINET_SLUG = 'kitchen-cabinet';
 
 // Cache for admin status checks - admin status rarely changes
 const ADMIN_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
-const adminStatusCache = new Map<string, { isAdmin: boolean; expiresAt: number }>();
+// Shared cache module — invalidators can be called without dragging the
+// rest of admin-tools (and its Anthropic-instantiating dependencies)
+// into unrelated import graphs.
+const adminStatusCache = getSlackAdminStatusCache();
 
 /**
  * Check if a Slack user is an admin
@@ -191,30 +194,15 @@ export async function isSlackUserAAOAdmin(slackUserId: string): Promise<boolean>
   }
 }
 
-/**
- * Invalidate admin status cache for a Slack user (call when admin membership changes)
- */
-export function invalidateAdminStatusCache(slackUserId?: string): void {
-  if (slackUserId) {
-    adminStatusCache.delete(slackUserId);
-  } else {
-    adminStatusCache.clear();
-  }
-}
+// Re-export Slack/web admin invalidators from the shared cache module so
+// existing imports of `admin-tools` keep working while new callers can
+// import directly from `admin-status-cache` to avoid this file's heavy
+// transitive dependencies.
+import { invalidateSlackAdminStatusCache, invalidateWebAdminStatusCache } from '../admin-status-cache.js';
+export { invalidateSlackAdminStatusCache as invalidateAdminStatusCache, invalidateWebAdminStatusCache };
 
 // Cache for web user admin status (keyed by WorkOS user ID)
-const webAdminStatusCache = new Map<string, { isAdmin: boolean; expiresAt: number }>();
-
-/**
- * Invalidate web admin status cache for a user (call when admin membership changes)
- */
-export function invalidateWebAdminStatusCache(workosUserId?: string): void {
-  if (workosUserId) {
-    webAdminStatusCache.delete(workosUserId);
-  } else {
-    webAdminStatusCache.clear();
-  }
-}
+const webAdminStatusCache = getWebAdminStatusCache();
 
 /**
  * Invalidate all admin caches (both Slack and web)
@@ -224,6 +212,11 @@ export function invalidateAllAdminCaches(): void {
   webAdminStatusCache.clear();
   webCouncilStatusCache.clear();
 }
+
+// Surface the shared-cache helpers so admin-tools' module graph stays
+// authoritative (other files can either import from admin-tools or from
+// admin-status-cache directly — both reach the same Maps).
+import { getSlackAdminStatusCache, getWebAdminStatusCache } from '../admin-status-cache.js';
 
 // Cache for web user kitchen-cabinet council status (keyed by WorkOS user ID)
 const webCouncilStatusCache = new Map<string, { isCouncil: boolean; expiresAt: number }>();

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -89,6 +89,12 @@ import {
 import { sendMembershipInviteEmail } from '../../notifications/email.js';
 import { mergeOrganizations, previewMerge, type StripeCustomerResolution } from '../../db/org-merge-db.js';
 import { getWorkos } from '../../auth/workos-client.js';
+import {
+  getSlackAdminStatusCache,
+  getWebAdminStatusCache,
+  invalidateSlackAdminStatusCache,
+  invalidateWebAdminStatusCache,
+} from '../admin-status-cache.js';
 import { DomainDataState } from '@workos-inc/node';
 import { processInteraction, type InteractionContext } from '../services/interaction-analyzer.js';
 import {
@@ -197,8 +203,7 @@ export async function isSlackUserAAOAdmin(slackUserId: string): Promise<boolean>
 // Re-export Slack/web admin invalidators from the shared cache module so
 // existing imports of `admin-tools` keep working while new callers can
 // import directly from `admin-status-cache` to avoid this file's heavy
-// transitive dependencies.
-import { invalidateSlackAdminStatusCache, invalidateWebAdminStatusCache } from '../admin-status-cache.js';
+// transitive dependencies. (Single import block at top — see line ~91.)
 export { invalidateSlackAdminStatusCache as invalidateAdminStatusCache, invalidateWebAdminStatusCache };
 
 // Cache for web user admin status (keyed by WorkOS user ID)
@@ -213,10 +218,6 @@ export function invalidateAllAdminCaches(): void {
   webCouncilStatusCache.clear();
 }
 
-// Surface the shared-cache helpers so admin-tools' module graph stays
-// authoritative (other files can either import from admin-tools or from
-// admin-status-cache directly — both reach the same Maps).
-import { getSlackAdminStatusCache, getWebAdminStatusCache } from '../admin-status-cache.js';
 
 // Cache for web user kitchen-cabinet council status (keyed by WorkOS user ID)
 const webCouncilStatusCache = new Map<string, { isCouncil: boolean; expiresAt: number }>();

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -63,6 +63,12 @@ import { canonicalizeBrandDomain } from '../../services/identifier-normalization
 import { ComplianceDatabase } from '../../db/compliance-db.js';
 import { AgentSnapshotDatabase } from '../../db/agent-snapshot-db.js';
 import { AgentValidator } from '../../validator.js';
+import {
+  joinWorkingGroup as joinWorkingGroupService,
+  expressCommitteeInterest as expressCommitteeInterestService,
+  withdrawCommitteeInterest as withdrawCommitteeInterestService,
+  WorkingGroupMembershipError,
+} from '../../services/working-group-membership-service.js';
 import { getPool, query } from '../../db/client.js';
 import { MemberSearchAnalyticsDatabase } from '../../db/member-search-analytics-db.js';
 import { OrganizationDatabase } from '../../db/organization-db.js';
@@ -1619,32 +1625,30 @@ export function createMemberToolHandlers(
     }
 
     const slug = input.slug as string;
-
-    // Check group visibility before attempting to join
-    const groupResult = await callApi('GET', `/api/working-groups/${slug}`, memberContext);
-    if (groupResult.ok) {
-      const groupData = groupResult.data as { working_group: { is_private?: boolean; name?: string } };
-      if (groupData.working_group?.is_private) {
-        return `"${groupData.working_group.name || slug}" is a private working group that requires an invitation. Use request_working_group_invitation to request access.`;
+    const wu = memberContext.workos_user;
+    try {
+      const result = await joinWorkingGroupService({
+        user: { id: wu.workos_user_id, email: wu.email, firstName: wu.first_name, lastName: wu.last_name },
+        slug,
+      });
+      return `Successfully joined the "${result.groupName}" working group! You can now participate in discussions and see group posts.`;
+    } catch (error) {
+      if (error instanceof WorkingGroupMembershipError) {
+        if (error.is('group_not_found')) {
+          return `Working group "${slug}" not found. Use list_working_groups to see available groups.`;
+        }
+        if (error.is('group_private')) {
+          return `"${error.meta.groupName}" is a private working group that requires an invitation. Use request_working_group_invitation to request access.`;
+        }
+        if (error.is('community_only_seat_blocked')) {
+          return `Joining "${error.meta.groupName}" requires a contributor seat. Ask your org admin to upgrade your access.`;
+        }
+        if (error.is('already_member')) {
+          return `You're already a member of the "${error.meta.groupName}" working group!`;
+        }
       }
+      throw new ToolError(`Failed to join working group: ${error instanceof Error ? error.message : String(error)}`);
     }
-
-    const result = await callApi('POST', `/api/working-groups/${slug}/join`, memberContext);
-
-    if (!result.ok) {
-      if (result.status === 403) {
-        return `Cannot join "${slug}" — this is a private working group. Use request_working_group_invitation to request access.`;
-      }
-      if (result.status === 404) {
-        return `Working group "${slug}" not found. Use list_working_groups to see available groups.`;
-      }
-      if (result.status === 409) {
-        return `You're already a member of the "${slug}" working group!`;
-      }
-      throw new ToolError(`Failed to join working group: ${result.error}`);
-    }
-
-    return `Successfully joined the "${slug}" working group! You can now participate in discussions and see group posts.`;
   });
 
   handlers.set('request_working_group_invitation', async (input) => {
@@ -1730,24 +1734,20 @@ export function createMemberToolHandlers(
     }
 
     const slug = input.slug as string;
-    const validInterestLevels = ['participant', 'leader'];
-    const interestLevel = validInterestLevels.includes(input.interest_level as string)
-      ? (input.interest_level as string)
-      : 'participant';
-
-    const result = await callApi('POST', `/api/working-groups/${slug}/interest`, memberContext, {
-      interest_level: interestLevel,
-    });
-
-    if (!result.ok) {
-      if (result.status === 404) {
+    const wu = memberContext.workos_user;
+    try {
+      const result = await expressCommitteeInterestService({
+        user: { id: wu.workos_user_id, email: wu.email, firstName: wu.first_name, lastName: wu.last_name },
+        slug,
+        interestLevel: input.interest_level as string | undefined,
+      });
+      return `Thanks for your interest in ${result.groupName}! We'll let you know when it launches.`;
+    } catch (error) {
+      if (error instanceof WorkingGroupMembershipError && error.is('group_not_found')) {
         return `Could not find a council or committee with slug "${slug}". Use list_working_groups with type "council" to see available councils.`;
       }
-      throw new ToolError(`Failed to express interest: ${result.error}`);
+      throw new ToolError(`Failed to express interest: ${error instanceof Error ? error.message : String(error)}`);
     }
-
-    const data = result.data as { message?: string };
-    return data.message || `You've expressed interest! We'll notify you when this council launches.`;
   });
 
   handlers.set('withdraw_council_interest', async (input) => {
@@ -1756,22 +1756,24 @@ export function createMemberToolHandlers(
     }
 
     const slug = input.slug as string;
-
-    const result = await callApi('DELETE', `/api/working-groups/${slug}/interest`, memberContext);
-
-    if (!result.ok) {
-      if (result.status === 404) {
-        const data = result.data as { error?: string };
-        if (data?.error === 'No interest found') {
+    const wu = memberContext.workos_user;
+    try {
+      const result = await withdrawCommitteeInterestService({
+        user: { id: wu.workos_user_id, email: wu.email, firstName: wu.first_name, lastName: wu.last_name },
+        slug,
+      });
+      return `You have withdrawn your interest in ${result.groupName}. You won't be notified when this council launches.`;
+    } catch (error) {
+      if (error instanceof WorkingGroupMembershipError) {
+        if (error.is('no_interest_recorded')) {
           return `You haven't expressed interest in "${slug}". No action needed.`;
         }
-        return `Could not find a council or committee with slug "${slug}".`;
+        if (error.is('group_not_found')) {
+          return `Could not find a council or committee with slug "${slug}".`;
+        }
       }
-      throw new ToolError(`Failed to withdraw interest: ${result.error}`);
+      throw new ToolError(`Failed to withdraw interest: ${error instanceof Error ? error.message : String(error)}`);
     }
-
-    const data = result.data as { message?: string };
-    return data.message || `You've withdrawn your interest. You won't be notified when this council launches.`;
   });
 
   handlers.set('get_my_council_interests', async () => {

--- a/server/src/addie/member-context-cache.ts
+++ b/server/src/addie/member-context-cache.ts
@@ -1,0 +1,57 @@
+/**
+ * Member-context cache primitives.
+ *
+ * Extracted from `member-context.ts` so callers that only need to invalidate
+ * the cache (route handlers, the membership service) don't have to pull in
+ * `middleware/auth.ts` and its WorkOS module-load side effects. Keeps the
+ * unit-test import graph clean.
+ *
+ * The cache itself stores the resolved MemberContext keyed on slack user id,
+ * with a 30-minute TTL — context data is rarely-changing, and we invalidate
+ * explicitly on specific events (membership changes, profile updates, etc.).
+ */
+
+import type { MemberContext } from './member-context.js';
+
+const MEMBER_CONTEXT_CACHE_TTL_MS = 30 * 60 * 1000;
+
+interface CachedEntry {
+  context: MemberContext;
+  timestamp: number;
+}
+
+const memberContextCache = new Map<string, CachedEntry>();
+
+export function getCachedMemberContext(slackUserId: string): MemberContext | null {
+  const cached = memberContextCache.get(slackUserId);
+  if (!cached) return null;
+
+  const age = Date.now() - cached.timestamp;
+  if (age > MEMBER_CONTEXT_CACHE_TTL_MS) {
+    memberContextCache.delete(slackUserId);
+    return null;
+  }
+
+  return cached.context;
+}
+
+export function setCachedMemberContext(slackUserId: string, context: MemberContext): void {
+  memberContextCache.set(slackUserId, { context, timestamp: Date.now() });
+}
+
+/**
+ * Invalidate cached context for a user. Call after membership changes,
+ * profile updates, or anywhere else the cached value would be stale.
+ * No-op when the user isn't cached.
+ *
+ * Pass no argument to clear the entire cache (used by tools that change
+ * data spanning multiple users — e.g. a working-group leader change
+ * affects every member of that WG).
+ */
+export function invalidateMemberContextCache(slackUserId?: string): void {
+  if (slackUserId) {
+    memberContextCache.delete(slackUserId);
+  } else {
+    memberContextCache.clear();
+  }
+}

--- a/server/src/addie/member-context.ts
+++ b/server/src/addie/member-context.ts
@@ -249,44 +249,16 @@ async function fetchCommunityProfile(
   };
 }
 
-// Cache for member context to avoid repeated lookups for the same user
-// TTL of 30 minutes - user profile data rarely changes, and we invalidate on specific events
-const MEMBER_CONTEXT_CACHE_TTL_MS = 30 * 60 * 1000;
-const memberContextCache = new Map<string, { context: MemberContext; timestamp: number }>();
+// Cache primitives live in ./member-context-cache so callers that only
+// need to invalidate (route handlers, services) can do so without
+// pulling in middleware/auth's WorkOS module-load side effects.
+import {
+  getCachedMemberContext as getCachedContext,
+  setCachedMemberContext as setCachedContext,
+  invalidateMemberContextCache,
+} from './member-context-cache.js';
 
-/**
- * Get cached member context if still valid
- */
-function getCachedContext(slackUserId: string): MemberContext | null {
-  const cached = memberContextCache.get(slackUserId);
-  if (!cached) return null;
-
-  const age = Date.now() - cached.timestamp;
-  if (age > MEMBER_CONTEXT_CACHE_TTL_MS) {
-    memberContextCache.delete(slackUserId);
-    return null;
-  }
-
-  return cached.context;
-}
-
-/**
- * Cache member context for future lookups
- */
-function setCachedContext(slackUserId: string, context: MemberContext): void {
-  memberContextCache.set(slackUserId, { context, timestamp: Date.now() });
-}
-
-/**
- * Invalidate cached context for a user (call when user data changes)
- */
-export function invalidateMemberContextCache(slackUserId?: string): void {
-  if (slackUserId) {
-    memberContextCache.delete(slackUserId);
-  } else {
-    memberContextCache.clear();
-  }
-}
+export { invalidateMemberContextCache };
 
 /**
  * Member context for Addie to use when responding

--- a/server/src/routes/committees.ts
+++ b/server/src/routes/committees.ts
@@ -27,6 +27,12 @@ import { SlackDatabase } from "../db/slack-db.js";
 import { CommunityDatabase } from "../db/community-db.js";
 import multer from 'multer';
 import { sendWgWelcomeMessage } from "../addie/services/wg-welcome.js";
+import {
+  joinWorkingGroup as joinWorkingGroupService,
+  expressCommitteeInterest as expressCommitteeInterestService,
+  withdrawCommitteeInterest as withdrawCommitteeInterestService,
+  WorkingGroupMembershipError,
+} from "../services/working-group-membership-service.js";
 
 const logger = createLogger("committee-routes");
 
@@ -1163,162 +1169,43 @@ export function createCommitteeRouters(): {
     try {
       const { slug } = req.params;
       const user = req.user!;
-
-      const group = await workingGroupDb.getWorkingGroupBySlug(slug);
-
-      if (!group || group.status !== 'active') {
-        return res.status(404).json({
-          error: 'Working group not found',
-          message: `No working group found with slug: ${slug}`,
-        });
-      }
-
-      if (group.is_private) {
-        return res.status(403).json({
-          error: 'Private group',
-          message: 'This working group is private and requires an invitation to join',
-        });
-      }
-
-      // Community-only seats cannot join working groups or councils
-      const { getUserSeatType } = await import('../db/organization-db.js');
-      const seatType = await getUserSeatType(user.id);
-      if (seatType === 'community_only') {
-        // Look up user's org for seat request capability
-        const orgResult = await query<{ workos_organization_id: string }>(
-          'SELECT workos_organization_id FROM organization_memberships WHERE workos_user_id = $1 LIMIT 1',
-          [user.id]
-        );
-        const userOrgId = orgResult.rows[0]?.workos_organization_id;
-        const resourceType = group.committee_type === 'council' ? 'council' : 'working_group';
-
-        return res.status(403).json({
-          error: 'Contributor access required',
-          message: 'Working group membership requires a contributor seat. Ask your org admin to upgrade your access.',
-          can_request: !!userOrgId,
-          request_url: userOrgId ? `/api/organizations/${userOrgId}/seat-requests` : undefined,
-          request_body: userOrgId ? { resource_type: resourceType, resource_id: group.id, resource_name: group.name } : undefined,
-        });
-      }
-
-      const existingMembership = await workingGroupDb.getMembership(group.id, user.id);
-      if (existingMembership && existingMembership.status === 'active') {
-        return res.status(409).json({
-          error: 'Already a member',
-          message: 'You are already a member of this working group',
-        });
-      }
-
-      let orgId: string | undefined;
-      let orgName: string | undefined;
-      if (workos) {
-        try {
-          const memberships = await workos.userManagement.listOrganizationMemberships({
-            userId: user.id,
+      const result = await joinWorkingGroupService({
+        user: { id: user.id, email: user.email, firstName: user.firstName, lastName: user.lastName },
+        slug,
+      });
+      res.status(201).json({ success: true, membership: result.membership });
+    } catch (error) {
+      if (error instanceof WorkingGroupMembershipError) {
+        if (error.is('group_not_found')) {
+          return res.status(404).json({ error: 'Working group not found', message: error.message });
+        }
+        if (error.is('group_private')) {
+          return res.status(403).json({
+            error: 'Private group',
+            message: 'This working group is private and requires an invitation to join',
           });
-          if (memberships.data.length > 0) {
-            const org = await workos.organizations.getOrganization(memberships.data[0].organizationId);
-            orgId = org.id;
-            orgName = org.name;
-          }
-        } catch {
-          // Ignore org fetch errors
+        }
+        if (error.is('community_only_seat_blocked')) {
+          const { userOrgId, workingGroupId, groupName, resourceType } = error.meta;
+          return res.status(403).json({
+            error: 'Contributor access required',
+            message: 'Working group membership requires a contributor seat. Ask your org admin to upgrade your access.',
+            can_request: !!userOrgId,
+            request_url: userOrgId ? `/api/organizations/${userOrgId}/seat-requests` : undefined,
+            request_body: userOrgId
+              ? { resource_type: resourceType, resource_id: workingGroupId, resource_name: groupName }
+              : undefined,
+          });
+        }
+        if (error.is('already_member')) {
+          return res.status(409).json({
+            error: 'Already a member',
+            message: 'You are already a member of this working group',
+          });
         }
       }
-
-      const membership = await workingGroupDb.addMembership({
-        working_group_id: group.id,
-        workos_user_id: user.id,
-        user_email: user.email,
-        user_name: user.firstName && user.lastName
-          ? `${user.firstName} ${user.lastName}`
-          : user.email,
-        workos_organization_id: orgId,
-        user_org_name: orgName,
-        added_by_user_id: user.id,
-      });
-
-      invalidateMemberContextCache();
-      invalidateWebAdminStatusCache(user.id);
-
-      // Award community points + check badges (fire-and-forget)
-      const communityDb = new CommunityDatabase();
-      communityDb.awardPoints(user.id, 'wg_joined', 10, group.id, 'working_group').catch(err => {
-        logger.error({ err, userId: user.id }, 'Failed to award WG join points');
-      });
-      communityDb.checkAndAwardBadges(user.id, 'wg').catch(err => {
-        logger.error({ err, userId: user.id }, 'Failed to check WG badges');
-      });
-
-      // Notify group leaders with joiner context (fire-and-forget)
-      const joinerName = user.firstName && user.lastName
-        ? `${user.firstName} ${user.lastName}` : user.email;
-
-      if (group.leaders) {
-        // Escape Slack mrkdwn special chars in external data
-        const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-
-        (async () => {
-          // Gather joiner's other WG memberships for context
-          const otherWgNames: string[] = [];
-          try {
-            const joinerGroups = await workingGroupDb.getWorkingGroupsForUser(user.id);
-            for (const g of joinerGroups) {
-              if (g.id !== group.id) otherWgNames.push(g.name);
-            }
-          } catch {
-            // Non-critical — proceed without other WG context
-          }
-
-          const orgContext = orgName ? ` (${esc(orgName)})` : '';
-          const wgContext = otherWgNames.length > 0
-            ? `. Also active in ${otherWgNames.map(esc).join(', ')}`
-            : '';
-
-          for (const leader of group.leaders!) {
-            notifyUser({
-              recipientUserId: leader.canonical_user_id,
-              actorUserId: user.id,
-              type: 'wg_member_joined',
-              referenceId: group.id,
-              referenceType: 'working_group',
-              title: `${esc(joinerName)}${orgContext} joined ${esc(group.name)}${wgContext}`,
-              url: `/working-groups/${group.slug}`,
-            }).catch(err => logger.error({ err }, 'Failed to send WG join notification'));
-          }
-        })().catch(err => logger.error({ err }, 'Failed to build WG join notification context'));
-      }
-
-      // Auto-invite joiner to the group's Slack channel (fire-and-forget)
-      if (group.slack_channel_id) {
-        const slackDb = new SlackDatabase();
-        slackDb.getByWorkosUserId(user.id).then(mapping => {
-          if (mapping?.slack_user_id) {
-            return inviteToChannel(group.slack_channel_id!, [mapping.slack_user_id]);
-          }
-        }).catch(err => {
-          logger.error({ err, userId: user.id, channelId: group.slack_channel_id }, 'Failed to auto-invite to Slack channel');
-        });
-      }
-
-      // Send Addie welcome message with group context (fire-and-forget)
-      sendWgWelcomeMessage({
-        userId: user.id,
-        userEmail: user.email,
-        userName: joinerName,
-        workingGroupId: group.id,
-        workingGroupSlug: group.slug,
-        workingGroupName: group.name,
-      }).catch(err => {
-        logger.error({ err, userId: user.id }, 'Failed to send WG welcome message');
-      });
-
-      res.status(201).json({ success: true, membership });
-    } catch (error) {
       logger.error({ err: error }, 'Join working group error');
-      res.status(500).json({
-        error: 'Failed to join working group',
-      });
+      res.status(500).json({ error: 'Failed to join working group' });
     }
   });
 
@@ -1328,81 +1215,21 @@ export function createCommitteeRouters(): {
       const { slug } = req.params;
       const { interest_level: rawInterestLevel } = req.body;
       const user = req.user!;
-      const pool = getPool();
-
-      // Validate interest level
-      const validInterestLevels = ['participant', 'leader'] as const;
-      const interest_level = validInterestLevels.includes(rawInterestLevel)
-        ? rawInterestLevel
-        : 'participant';
-
-      const group = await workingGroupDb.getWorkingGroupBySlug(slug);
-
-      if (!group || group.status !== 'active') {
-        return res.status(404).json({
-          error: 'Committee not found',
-          message: `No committee found with slug: ${slug}`,
-        });
-      }
-
-      // Get user's org info if available
-      let orgId: string | undefined;
-      let orgName: string | undefined;
-      if (workos) {
-        try {
-          const memberships = await workos.userManagement.listOrganizationMemberships({
-            userId: user.id,
-          });
-          if (memberships.data.length > 0) {
-            const org = await workos.organizations.getOrganization(memberships.data[0].organizationId);
-            orgId = org.id;
-            orgName = org.name;
-          }
-        } catch {
-          // Ignore org fetch errors
-        }
-      }
-
-      const userName = user.firstName && user.lastName
-        ? `${user.firstName} ${user.lastName}`
-        : user.email;
-
-      // Upsert the interest record
-      await pool.query(
-        `INSERT INTO committee_interest (
-          working_group_id, workos_user_id, user_email, user_name,
-          workos_organization_id, user_org_name, interest_level
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7)
-        ON CONFLICT (working_group_id, workos_user_id) DO UPDATE SET
-          interest_level = COALESCE(EXCLUDED.interest_level, committee_interest.interest_level),
-          user_email = EXCLUDED.user_email,
-          user_name = EXCLUDED.user_name,
-          user_org_name = EXCLUDED.user_org_name`,
-        [
-          group.id,
-          user.id,
-          user.email,
-          userName,
-          orgId || null,
-          orgName || null,
-          interest_level,
-        ]
-      );
-
-      logger.info(
-        { workingGroupId: group.id, userId: user.id, interestLevel: interest_level },
-        'User expressed interest in committee'
-      );
-
+      const result = await expressCommitteeInterestService({
+        user: { id: user.id, email: user.email, firstName: user.firstName, lastName: user.lastName },
+        slug,
+        interestLevel: rawInterestLevel,
+      });
       res.status(201).json({
         success: true,
-        message: `Thanks for your interest in ${group.name}! We'll let you know when it launches.`,
+        message: `Thanks for your interest in ${result.groupName}! We'll let you know when it launches.`,
       });
     } catch (error) {
+      if (error instanceof WorkingGroupMembershipError && error.is('group_not_found')) {
+        return res.status(404).json({ error: 'Committee not found', message: error.message });
+      }
       logger.error({ err: error }, 'Express committee interest error');
-      res.status(500).json({
-        error: 'Failed to record interest',
-      });
+      res.status(500).json({ error: 'Failed to record interest' });
     }
   });
 
@@ -1450,45 +1277,25 @@ export function createCommitteeRouters(): {
     try {
       const { slug } = req.params;
       const user = req.user!;
-      const pool = getPool();
-
-      const group = await workingGroupDb.getWorkingGroupBySlug(slug);
-
-      if (!group) {
-        return res.status(404).json({
-          error: 'Committee not found',
-          message: `No committee found with slug: ${slug}`,
-        });
-      }
-
-      const result = await pool.query(
-        `DELETE FROM committee_interest
-         WHERE working_group_id = $1 AND workos_user_id = $2
-         RETURNING id`,
-        [group.id, user.id]
-      );
-
-      if (result.rowCount === 0) {
-        return res.status(404).json({
-          error: 'No interest found',
-          message: 'You have not expressed interest in this committee',
-        });
-      }
-
-      logger.info(
-        { workingGroupId: group.id, userId: user.id },
-        'User withdrew interest in committee'
-      );
-
+      const result = await withdrawCommitteeInterestService({
+        user: { id: user.id, email: user.email, firstName: user.firstName, lastName: user.lastName },
+        slug,
+      });
       res.json({
         success: true,
-        message: `You have withdrawn your interest in ${group.name}.`,
+        message: `You have withdrawn your interest in ${result.groupName}.`,
       });
     } catch (error) {
+      if (error instanceof WorkingGroupMembershipError) {
+        if (error.is('group_not_found')) {
+          return res.status(404).json({ error: 'Committee not found', message: error.message });
+        }
+        if (error.is('no_interest_recorded')) {
+          return res.status(404).json({ error: 'No interest found', message: error.message });
+        }
+      }
       logger.error({ err: error }, 'Withdraw committee interest error');
-      res.status(500).json({
-        error: 'Failed to withdraw interest',
-      });
+      res.status(500).json({ error: 'Failed to withdraw interest' });
     }
   });
 

--- a/server/src/routes/committees.ts
+++ b/server/src/routes/committees.ts
@@ -1177,7 +1177,10 @@ export function createCommitteeRouters(): {
     } catch (error) {
       if (error instanceof WorkingGroupMembershipError) {
         if (error.is('group_not_found')) {
-          return res.status(404).json({ error: 'Working group not found', message: error.message });
+          return res.status(404).json({
+            error: 'Working group not found',
+            message: `No working group found with slug: ${error.meta.slug}`,
+          });
         }
         if (error.is('group_private')) {
           return res.status(403).json({
@@ -1226,7 +1229,10 @@ export function createCommitteeRouters(): {
       });
     } catch (error) {
       if (error instanceof WorkingGroupMembershipError && error.is('group_not_found')) {
-        return res.status(404).json({ error: 'Committee not found', message: error.message });
+        return res.status(404).json({
+          error: 'Committee not found',
+          message: `No committee found with slug: ${error.meta.slug}`,
+        });
       }
       logger.error({ err: error }, 'Express committee interest error');
       res.status(500).json({ error: 'Failed to record interest' });
@@ -1288,10 +1294,16 @@ export function createCommitteeRouters(): {
     } catch (error) {
       if (error instanceof WorkingGroupMembershipError) {
         if (error.is('group_not_found')) {
-          return res.status(404).json({ error: 'Committee not found', message: error.message });
+          return res.status(404).json({
+            error: 'Committee not found',
+            message: `No committee found with slug: ${error.meta.slug}`,
+          });
         }
         if (error.is('no_interest_recorded')) {
-          return res.status(404).json({ error: 'No interest found', message: error.message });
+          return res.status(404).json({
+            error: 'No interest found',
+            message: 'You have not expressed interest in this committee',
+          });
         }
       }
       logger.error({ err: error }, 'Withdraw committee interest error');

--- a/server/src/services/working-group-membership-service.ts
+++ b/server/src/services/working-group-membership-service.ts
@@ -93,7 +93,10 @@ export class WorkingGroupMembershipError<
   is<K extends WorkingGroupMembershipErrorCode>(
     code: K,
   ): this is WorkingGroupMembershipError<K> & { meta: WorkingGroupMembershipErrorMetaByCode[K] } {
-    return (this.code as WorkingGroupMembershipErrorCode) === code;
+    // Generic-parameter comparison: TS treats `C` and `K` as independent
+    // type vars, so a direct `===` is rejected. The runtime check is
+    // sound — both sides are `WorkingGroupMembershipErrorCode` strings.
+    return (this.code as string) === (code as string);
   }
 }
 

--- a/server/src/services/working-group-membership-service.ts
+++ b/server/src/services/working-group-membership-service.ts
@@ -1,0 +1,391 @@
+/**
+ * Working-group membership service.
+ *
+ * Shared by:
+ *  - POST /api/working-groups/:slug/join                (web/API)
+ *  - POST /api/working-groups/:slug/interest            (web/API)
+ *  - DELETE /api/working-groups/:slug/interest          (web/API)
+ *  - join_working_group Addie tool                      (chat)
+ *  - express_council_interest Addie tool                (chat)
+ *  - withdraw_council_interest Addie tool               (chat)
+ *
+ * Centralizes the business logic so the route and the Addie tool produce
+ * identical outcomes (membership rows, side effects, error variants) and
+ * can't drift apart over time. Replaces a previous server-to-self HTTP
+ * loopback in `callApi` that was silently rejected by CSRF middleware
+ * (issue #3736); the route adapters and Addie adapters now both consume
+ * this module instead of routing through HTTP.
+ *
+ * Side effects (community points, badge checks, leader notifications,
+ * Slack channel auto-invite, Addie welcome DM) live here — they're part
+ * of "joining a working group", not part of "responding to an HTTP
+ * request" — so they fire regardless of caller surface.
+ */
+
+import { getPool, query } from '../db/client.js';
+import { createLogger } from '../logger.js';
+import { WorkingGroupDatabase } from '../db/working-group-db.js';
+import type { WorkingGroupMembership } from '../types.js';
+import { CommunityDatabase } from '../db/community-db.js';
+import { SlackDatabase } from '../db/slack-db.js';
+import { invalidateMemberContextCache } from '../addie/member-context-cache.js';
+import { invalidateWebAdminStatusCache } from '../addie/admin-status-cache.js';
+import { notifyUser } from '../notifications/notification-service.js';
+import { inviteToChannel } from '../slack/client.js';
+import { sendWgWelcomeMessage } from '../addie/services/wg-welcome.js';
+import { getUserSeatType } from '../db/organization-db.js';
+import { getWorkos } from '../auth/workos-client.js';
+
+const logger = createLogger('working-group-membership-service');
+
+const workingGroupDb = new WorkingGroupDatabase();
+
+/**
+ * Caller identity. Both route (`req.user`) and Addie tool
+ * (`memberContext.workos_user`) shape into this; the service doesn't
+ * care which surface invoked it.
+ */
+export interface WorkingGroupServiceUser {
+  id: string;
+  email: string;
+  firstName?: string | null;
+  lastName?: string | null;
+}
+
+/**
+ * Discriminated error codes — adapters render each to the right HTTP
+ * status / markdown reply. Avoids HTTP-status guessing on the consumer
+ * side, which is what bit us in the loopback bug.
+ */
+export type WorkingGroupMembershipErrorCode =
+  | 'group_not_found'
+  | 'group_private'
+  | 'community_only_seat_blocked'
+  | 'already_member'
+  | 'no_interest_recorded';
+
+export interface WorkingGroupMembershipErrorMetaByCode {
+  group_not_found: { slug: string };
+  group_private: { slug: string; groupName: string };
+  community_only_seat_blocked: {
+    slug: string;
+    groupName: string;
+    workingGroupId: string;
+    resourceType: 'council' | 'working_group';
+    userOrgId: string | null;
+  };
+  already_member: { slug: string; groupName: string };
+  no_interest_recorded: { slug: string; groupName: string };
+}
+
+export class WorkingGroupMembershipError<
+  C extends WorkingGroupMembershipErrorCode = WorkingGroupMembershipErrorCode,
+> extends Error {
+  constructor(
+    public readonly code: C,
+    message: string,
+    public readonly meta: WorkingGroupMembershipErrorMetaByCode[C],
+  ) {
+    super(message);
+    this.name = 'WorkingGroupMembershipError';
+  }
+
+  is<K extends WorkingGroupMembershipErrorCode>(
+    code: K,
+  ): this is WorkingGroupMembershipError<K> & { meta: WorkingGroupMembershipErrorMetaByCode[K] } {
+    return (this.code as WorkingGroupMembershipErrorCode) === code;
+  }
+}
+
+interface UserOrgContext {
+  orgId: string | undefined;
+  orgName: string | undefined;
+}
+
+/**
+ * Resolve the user's primary WorkOS organization, if any. Best-effort —
+ * a missing/erroring WorkOS lookup returns undefined for both fields and
+ * the caller proceeds (org context is decorative on memberships and
+ * notification copy).
+ */
+async function resolvePrimaryOrgContext(userId: string): Promise<UserOrgContext> {
+  let workos;
+  try {
+    workos = getWorkos();
+  } catch {
+    return { orgId: undefined, orgName: undefined };
+  }
+  try {
+    const memberships = await workos.userManagement.listOrganizationMemberships({ userId });
+    if (memberships.data.length === 0) return { orgId: undefined, orgName: undefined };
+    const org = await workos.organizations.getOrganization(memberships.data[0].organizationId);
+    return { orgId: org.id, orgName: org.name };
+  } catch {
+    return { orgId: undefined, orgName: undefined };
+  }
+}
+
+function userDisplayName(user: WorkingGroupServiceUser): string {
+  if (user.firstName && user.lastName) return `${user.firstName} ${user.lastName}`;
+  return user.email;
+}
+
+export interface JoinWorkingGroupInput {
+  user: WorkingGroupServiceUser;
+  slug: string;
+}
+
+export interface JoinWorkingGroupResult {
+  membership: WorkingGroupMembership;
+  groupId: string;
+  groupName: string;
+  groupSlug: string;
+}
+
+/**
+ * Add the caller to a public working group.
+ * Throws `WorkingGroupMembershipError` for every domain-level failure;
+ * unexpected errors propagate up and are handled by the caller.
+ */
+export async function joinWorkingGroup({ user, slug }: JoinWorkingGroupInput): Promise<JoinWorkingGroupResult> {
+  const group = await workingGroupDb.getWorkingGroupBySlug(slug);
+  if (!group || group.status !== 'active') {
+    throw new WorkingGroupMembershipError('group_not_found', `No working group found with slug: ${slug}`, { slug });
+  }
+
+  if (group.is_private) {
+    throw new WorkingGroupMembershipError('group_private', 'This working group is private and requires an invitation', {
+      slug: group.slug,
+      groupName: group.name,
+    });
+  }
+
+  // Community-only seats cannot join working groups or councils — they
+  // need a contributor seat upgrade. Surface enough metadata for the
+  // route to render a seat-request payload and the Addie tool to render
+  // a "ask your org admin" CTA.
+  const seatType = await getUserSeatType(user.id);
+  if (seatType === 'community_only') {
+    const orgRow = await query<{ workos_organization_id: string }>(
+      'SELECT workos_organization_id FROM organization_memberships WHERE workos_user_id = $1 LIMIT 1',
+      [user.id],
+    );
+    const userOrgId = orgRow.rows[0]?.workos_organization_id ?? null;
+    throw new WorkingGroupMembershipError(
+      'community_only_seat_blocked',
+      'Working group membership requires a contributor seat',
+      {
+        slug: group.slug,
+        groupName: group.name,
+        workingGroupId: group.id,
+        resourceType: group.committee_type === 'council' ? 'council' : 'working_group',
+        userOrgId,
+      },
+    );
+  }
+
+  const existingMembership = await workingGroupDb.getMembership(group.id, user.id);
+  if (existingMembership && existingMembership.status === 'active') {
+    throw new WorkingGroupMembershipError('already_member', 'Already a member', {
+      slug: group.slug,
+      groupName: group.name,
+    });
+  }
+
+  const { orgId, orgName } = await resolvePrimaryOrgContext(user.id);
+  const userName = userDisplayName(user);
+
+  const membership = await workingGroupDb.addMembership({
+    working_group_id: group.id,
+    workos_user_id: user.id,
+    user_email: user.email,
+    user_name: userName,
+    workos_organization_id: orgId,
+    user_org_name: orgName,
+    added_by_user_id: user.id,
+  });
+
+  invalidateMemberContextCache();
+  invalidateWebAdminStatusCache(user.id);
+
+  // Fire-and-forget side effects — these are part of the join action
+  // semantically, but a failure in any of them must not roll back the
+  // membership row. Each one logs its own error.
+  const communityDb = new CommunityDatabase();
+  communityDb.awardPoints(user.id, 'wg_joined', 10, group.id, 'working_group').catch((err) => {
+    logger.error({ err, userId: user.id }, 'Failed to award WG join points');
+  });
+  communityDb.checkAndAwardBadges(user.id, 'wg').catch((err) => {
+    logger.error({ err, userId: user.id }, 'Failed to check WG badges');
+  });
+
+  if (group.leaders) {
+    const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    void (async () => {
+      const otherWgNames: string[] = [];
+      try {
+        const joinerGroups = await workingGroupDb.getWorkingGroupsForUser(user.id);
+        for (const g of joinerGroups) {
+          if (g.id !== group.id) otherWgNames.push(g.name);
+        }
+      } catch {
+        // Non-critical — leaders still get notified, just without other-WG context.
+      }
+      const orgContext = orgName ? ` (${esc(orgName)})` : '';
+      const wgContext = otherWgNames.length > 0 ? `. Also active in ${otherWgNames.map(esc).join(', ')}` : '';
+      for (const leader of group.leaders!) {
+        notifyUser({
+          recipientUserId: leader.canonical_user_id,
+          actorUserId: user.id,
+          type: 'wg_member_joined',
+          referenceId: group.id,
+          referenceType: 'working_group',
+          title: `${esc(userName)}${orgContext} joined ${esc(group.name)}${wgContext}`,
+          url: `/working-groups/${group.slug}`,
+        }).catch((err) => logger.error({ err }, 'Failed to send WG join notification'));
+      }
+    })().catch((err) => logger.error({ err }, 'Failed to build WG join notification context'));
+  }
+
+  if (group.slack_channel_id) {
+    const slackDb = new SlackDatabase();
+    slackDb
+      .getByWorkosUserId(user.id)
+      .then((mapping) => {
+        if (mapping?.slack_user_id) {
+          return inviteToChannel(group.slack_channel_id!, [mapping.slack_user_id]);
+        }
+      })
+      .catch((err) => {
+        logger.error({ err, userId: user.id, channelId: group.slack_channel_id }, 'Failed to auto-invite to Slack channel');
+      });
+  }
+
+  sendWgWelcomeMessage({
+    userId: user.id,
+    userEmail: user.email,
+    userName,
+    workingGroupId: group.id,
+    workingGroupSlug: group.slug,
+    workingGroupName: group.name,
+  }).catch((err) => {
+    logger.error({ err, userId: user.id }, 'Failed to send WG welcome message');
+  });
+
+  return {
+    membership,
+    groupId: group.id,
+    groupName: group.name,
+    groupSlug: group.slug,
+  };
+}
+
+export type CommitteeInterestLevel = 'participant' | 'leader';
+
+export interface ExpressCommitteeInterestInput {
+  user: WorkingGroupServiceUser;
+  slug: string;
+  /** Defaults to 'participant' on invalid/missing input. */
+  interestLevel?: string;
+}
+
+export interface ExpressCommitteeInterestResult {
+  groupId: string;
+  groupName: string;
+  groupSlug: string;
+  interestLevel: CommitteeInterestLevel;
+}
+
+/**
+ * Record the caller's interest in a launching committee. Idempotent
+ * upsert — calling twice with different `interestLevel` updates the row.
+ */
+export async function expressCommitteeInterest({
+  user,
+  slug,
+  interestLevel,
+}: ExpressCommitteeInterestInput): Promise<ExpressCommitteeInterestResult> {
+  const validLevels: CommitteeInterestLevel[] = ['participant', 'leader'];
+  const level: CommitteeInterestLevel = validLevels.includes(interestLevel as CommitteeInterestLevel)
+    ? (interestLevel as CommitteeInterestLevel)
+    : 'participant';
+
+  const group = await workingGroupDb.getWorkingGroupBySlug(slug);
+  if (!group || group.status !== 'active') {
+    throw new WorkingGroupMembershipError('group_not_found', `No committee found with slug: ${slug}`, { slug });
+  }
+
+  const { orgId, orgName } = await resolvePrimaryOrgContext(user.id);
+  const userName = userDisplayName(user);
+
+  const pool = getPool();
+  await pool.query(
+    `INSERT INTO committee_interest (
+      working_group_id, workos_user_id, user_email, user_name,
+      workos_organization_id, user_org_name, interest_level
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+    ON CONFLICT (working_group_id, workos_user_id) DO UPDATE SET
+      interest_level = COALESCE(EXCLUDED.interest_level, committee_interest.interest_level),
+      user_email = EXCLUDED.user_email,
+      user_name = EXCLUDED.user_name,
+      user_org_name = EXCLUDED.user_org_name`,
+    [group.id, user.id, user.email, userName, orgId || null, orgName || null, level],
+  );
+
+  logger.info(
+    { workingGroupId: group.id, userId: user.id, interestLevel: level },
+    'User expressed interest in committee',
+  );
+
+  return {
+    groupId: group.id,
+    groupName: group.name,
+    groupSlug: group.slug,
+    interestLevel: level,
+  };
+}
+
+export interface WithdrawCommitteeInterestInput {
+  user: WorkingGroupServiceUser;
+  slug: string;
+}
+
+export interface WithdrawCommitteeInterestResult {
+  groupId: string;
+  groupName: string;
+  groupSlug: string;
+}
+
+export async function withdrawCommitteeInterest({
+  user,
+  slug,
+}: WithdrawCommitteeInterestInput): Promise<WithdrawCommitteeInterestResult> {
+  const group = await workingGroupDb.getWorkingGroupBySlug(slug);
+  if (!group) {
+    throw new WorkingGroupMembershipError('group_not_found', `No committee found with slug: ${slug}`, { slug });
+  }
+
+  const pool = getPool();
+  const result = await pool.query(
+    `DELETE FROM committee_interest
+     WHERE working_group_id = $1 AND workos_user_id = $2
+     RETURNING id`,
+    [group.id, user.id],
+  );
+
+  if (result.rowCount === 0) {
+    throw new WorkingGroupMembershipError(
+      'no_interest_recorded',
+      'You have not expressed interest in this committee',
+      { slug: group.slug, groupName: group.name },
+    );
+  }
+
+  logger.info({ workingGroupId: group.id, userId: user.id }, 'User withdrew interest in committee');
+
+  return {
+    groupId: group.id,
+    groupName: group.name,
+    groupSlug: group.slug,
+  };
+}

--- a/tests/addie/member-tools.test.ts
+++ b/tests/addie/member-tools.test.ts
@@ -17,6 +17,7 @@ import { MEMBER_TOOLS, createMemberToolHandlers } from '../../server/src/addie/m
 import { getGitHubAccessToken } from '../../server/src/services/pipes.js';
 import { ComplianceDatabase } from '../../server/src/db/compliance-db.js';
 import { AgentSnapshotDatabase } from '../../server/src/db/agent-snapshot-db.js';
+import * as wgService from '../../server/src/services/working-group-membership-service.js';
 
 describe('MEMBER_TOOLS definitions', () => {
   it('exports an array of tools', () => {
@@ -644,6 +645,107 @@ describe('createMemberToolHandlers', () => {
       expect(result).toContain('88ms');
       expect(result).toContain('Tools advertised:** 1');
       expect(result).toContain('passing');
+    });
+  });
+
+  describe('working-group membership tools (service-backed)', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    const memberCtx = {
+      is_mapped: true,
+      is_member: true,
+      slack_linked: false,
+      workos_user: {
+        workos_user_id: 'user_test_123',
+        email: 'test@example.com',
+        first_name: 'Test',
+        last_name: 'User',
+      },
+    } as MemberContext;
+
+    it('join_working_group renders friendly success on a public group', async () => {
+      vi.spyOn(wgService, 'joinWorkingGroup').mockResolvedValue({
+        membership: {} as never,
+        groupId: 'wg_abc',
+        groupName: 'Media Buying Protocol',
+        groupSlug: 'media-buying-protocol-wg',
+      });
+      const handlers = createMemberToolHandlers(memberCtx);
+      const result = await handlers.get('join_working_group')!({ slug: 'media-buying-protocol-wg' });
+      expect(result).toContain('Successfully joined');
+      expect(result).toContain('Media Buying Protocol');
+    });
+
+    it('join_working_group disambiguates private vs not-found vs already-member by code, not status', async () => {
+      // Private group
+      vi.spyOn(wgService, 'joinWorkingGroup').mockRejectedValueOnce(
+        new wgService.WorkingGroupMembershipError('group_private', 'Private', { slug: 'sp', groupName: 'Specialists' }),
+      );
+      const handlers = createMemberToolHandlers(memberCtx);
+      let result = await handlers.get('join_working_group')!({ slug: 'sp' });
+      expect(result).toContain('Specialists');
+      expect(result).toContain('private');
+      expect(result).toContain('request_working_group_invitation');
+
+      // Not found
+      vi.spyOn(wgService, 'joinWorkingGroup').mockRejectedValueOnce(
+        new wgService.WorkingGroupMembershipError('group_not_found', 'No', { slug: 'nope' }),
+      );
+      result = await handlers.get('join_working_group')!({ slug: 'nope' });
+      expect(result).toContain('not found');
+      expect(result).toContain('list_working_groups');
+
+      // Already member
+      vi.spyOn(wgService, 'joinWorkingGroup').mockRejectedValueOnce(
+        new wgService.WorkingGroupMembershipError('already_member', 'Already', { slug: 'mb', groupName: 'Media Buying' }),
+      );
+      result = await handlers.get('join_working_group')!({ slug: 'mb' });
+      expect(result).toContain('already a member');
+      expect(result).toContain('Media Buying');
+
+      // Community-only seat blocker
+      vi.spyOn(wgService, 'joinWorkingGroup').mockRejectedValueOnce(
+        new wgService.WorkingGroupMembershipError('community_only_seat_blocked', 'Need contributor seat', {
+          slug: 'mb',
+          groupName: 'Media Buying',
+          workingGroupId: 'wg_abc',
+          resourceType: 'working_group',
+          userOrgId: 'org_1',
+        }),
+      );
+      result = await handlers.get('join_working_group')!({ slug: 'mb' });
+      expect(result).toContain('contributor seat');
+      expect(result).toContain('Media Buying');
+    });
+
+    it('express_council_interest returns the launch-pending message on success', async () => {
+      vi.spyOn(wgService, 'expressCommitteeInterest').mockResolvedValue({
+        groupId: 'wg_x',
+        groupName: 'Future Council',
+        groupSlug: 'future-council',
+        interestLevel: 'participant',
+      });
+      const handlers = createMemberToolHandlers(memberCtx);
+      const result = await handlers.get('express_council_interest')!({ slug: 'future-council', interest_level: 'participant' });
+      expect(result).toContain('Future Council');
+      expect(result.toLowerCase()).toContain("we'll let you know");
+    });
+
+    it('withdraw_council_interest distinguishes never-expressed from group-not-found', async () => {
+      vi.spyOn(wgService, 'withdrawCommitteeInterest').mockRejectedValueOnce(
+        new wgService.WorkingGroupMembershipError('no_interest_recorded', 'never', { slug: 'fc', groupName: 'Future Council' }),
+      );
+      const handlers = createMemberToolHandlers(memberCtx);
+      let result = await handlers.get('withdraw_council_interest')!({ slug: 'fc' });
+      expect(result).toContain("haven't expressed interest");
+
+      vi.spyOn(wgService, 'withdrawCommitteeInterest').mockRejectedValueOnce(
+        new wgService.WorkingGroupMembershipError('group_not_found', 'no group', { slug: 'nope' }),
+      );
+      result = await handlers.get('withdraw_council_interest')!({ slug: 'nope' });
+      expect(result).toContain('Could not find');
     });
   });
 


### PR DESCRIPTION
## Summary

First of three PRs fixing the bug class in #3736. This one fixes the **membership/interest** tools — the ones with production-confirmed user-visible regression. Documents/posts and the `callApi` lockdown follow in subsequent PRs.

The three tools fixed here have been silently broken since CSRF tightening. `callApi('POST', …)` from Addie hits our own CSRF middleware before the request leaves the box; the loopback gets a 403 and the handler maps it to a misleading domain-level message.

| Tool | What users saw | Now |
|---|---|---|
| `join_working_group` | *"this is a private working group"* — for public groups | renders the correct verdict per error code |
| `express_council_interest` | tool throws | success / disambiguated `group_not_found` |
| `withdraw_council_interest` | tool throws | success / disambiguated `group_not_found` / `no_interest_recorded` |

Production evidence in #3736 body: every April user trying to join a public WG via Addie (joohwa, bhushan, Greg ×2, james) was told the group was private. All five groups they were turned away from were `is_private: false`.

## Approach (option B from #3736)

Extract a shared `working-group-membership-service` that both the route handler and the Addie tool consume directly. No HTTP loopback. Service throws `WorkingGroupMembershipError` with discriminated codes (`group_not_found` / `group_private` / `community_only_seat_blocked` / `already_member` / `no_interest_recorded`) — adapters pattern-match on the code, no HTTP-status guessing.

Side effects (community points, badge checks, leader notifications, Slack channel auto-invite, Addie welcome DM) live in the service so they fire on every surface. A future drift between web and chat is impossible because there's only one implementation.

## Bonus: cache-module extraction

The new service needs to invalidate two caches (`member-context`, `web-admin-status`). Importing those invalidators from `addie/member-context.ts` and `addie/mcp/admin-tools.ts` would have dragged `middleware/auth` (WorkOS module-load) and `addie/services/relationship-orchestrator` → `engagement-planner` (Anthropic module-load) into the test import graph — which broke the `claude-client-cost-gate` unit test through a hoisting interaction.

Lifted both caches into `addie/member-context-cache.ts` and `addie/admin-status-cache.ts` — tiny modules with zero non-stdlib imports. Existing callers keep working via re-export from the original locations. This also stops `admin-tools` from being a permanent chokepoint that pulls Anthropic into unrelated dependency chains.

## Test plan

- [x] Unit: 4 new tests for `join_working_group` covering each error variant; 1 each for `express`/`withdraw`. Mock the service via `vi.spyOn`.
- [x] Existing 49 member-tools tests still pass (53 total).
- [x] Server unit suite (`server/tests/unit/`): 2997 passing.
- [x] Typecheck clean.
- [x] **Live end-to-end smoke against local docker** with a real Postgres + populated WG fixtures:
  - **Unknown slug** → *"Working group X not found. Use list_working_groups…"*
  - **Public group (open-web-council)** → *"Successfully joined the Open Web Council working group!"*
  - **Same group again** → *"You're already a member of the Open Web Council working group!"* (proves `already_member` code path)
  - **Unknown slug for express_interest** → *"Could not find a council or committee… use list_working_groups with type 'council'"*
  - **Unknown slug for withdraw_interest** → *"Could not find a council or committee with slug…"*

## What's deferred to follow-up PRs in #3736

- **PR 2**: documents/posts (`create_working_group_post`, `add_committee_document`, `update_committee_document`, `delete_committee_document`) — same pattern, separate domain.
- **PR 3**: lock down `callApi` POST/PUT/DELETE/PATCH (throw at runtime, fail CI) so future Addie tools physically cannot reintroduce the loopback bug class.

## Out of scope

- Existing private-group invitation flow stays unchanged.
- `request_working_group_invitation` already uses callApi GET only — works fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)