### PR TITLE
feat(addie): extract working-group content service (#3736 part 2)

### DIFF
--- a/.changeset/working-group-content-service.md
+++ b/.changeset/working-group-content-service.md
@@ -14,4 +14,6 @@ Side effects (Slack channel notification on new posts and documents, document in
 
 The route's `isAllowedDocumentUrl` helper plus its three allowlist constants moved into the service so both consumers share a single SSRF allowlist for document URLs. The Addie tools keep a friendlier "Google only" pre-check that fires before the broader service-level allowlist — the service still re-validates as defense-in-depth.
 
+**Behavior note:** the new service narrows `content_type` on `POST /api/working-groups/:slug/posts` to the allowlist `'article' | 'link'` — anything else is coerced to `'article'`. The Slack notification helper has always required this shape, so any prior request that sent e.g. `'discussion'` was inserting a row into `perspectives` that the public surface couldn't render correctly anyway. Addie callers were already pre-mapping (`post_type === 'link' ? 'link' : 'article'`), so they're unaffected.
+
 Closes the addie-side half of issue #3736 — all 7 affected tools now go through service layers rather than the broken loopback. Part 3 (locking down `callApi` POST/PUT/DELETE/PATCH at runtime so future tools physically cannot reintroduce the bug class) follows in the next PR.

--- a/.changeset/working-group-content-service.md
+++ b/.changeset/working-group-content-service.md
@@ -1,0 +1,17 @@
+---
+---
+
+Extract a `working-group-content-service` shared by the route handlers and the four remaining Addie state-change tools that were silently CSRF-blocked via the loopback in `callApi`:
+
+- `create_working_group_post` — was returning *"You're not a member of {slug}"* for actual members.
+- `add_committee_document` — was returning *"You're not a member of {slug} committee"* for actual members.
+- `update_committee_document` — same misleading "not a member" error.
+- `delete_committee_document` — was returning *"You're not a leader of {slug}"* even when the user was a leader.
+
+Same pattern as #3736 part 1 (#3741): both the route and the Addie tool consume the service directly. Service throws `WorkingGroupContentError` with discriminated codes (`group_not_found`, `not_member`, `not_leader`, `leader_required_for_public_post`, `missing_required_fields`, `invalid_post_slug`, `invalid_document_url`, `invalid_document_id`, `document_not_found`, `duplicate_post_slug`) so adapters render the right HTTP status / chat message — no HTTP-status guessing.
+
+Side effects (Slack channel notification on new posts and documents, document indexing trigger, in-memory search-index refresh on update/delete) live in the service so they fire on every surface, web or chat.
+
+The route's `isAllowedDocumentUrl` helper plus its three allowlist constants moved into the service so both consumers share a single SSRF allowlist for document URLs. The Addie tools keep a friendlier "Google only" pre-check that fires before the broader service-level allowlist — the service still re-validates as defense-in-depth.
+
+Closes the addie-side half of issue #3736 — all 7 affected tools now go through service layers rather than the broken loopback. Part 3 (locking down `callApi` POST/PUT/DELETE/PATCH at runtime so future tools physically cannot reintroduce the bug class) follows in the next PR.

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -69,6 +69,14 @@ import {
   withdrawCommitteeInterest as withdrawCommitteeInterestService,
   WorkingGroupMembershipError,
 } from '../../services/working-group-membership-service.js';
+import {
+  createWorkingGroupPost as createWorkingGroupPostService,
+  addCommitteeDocument as addCommitteeDocumentService,
+  updateCommitteeDocument as updateCommitteeDocumentService,
+  deleteCommitteeDocument as deleteCommitteeDocumentService,
+  WorkingGroupContentError,
+} from '../../services/working-group-content-service.js';
+import type { CommitteeDocumentType } from '../../types.js';
 import { getPool, query } from '../../db/client.js';
 import { MemberSearchAnalyticsDatabase } from '../../db/member-search-analytics-db.js';
 import { OrganizationDatabase } from '../../db/organization-db.js';
@@ -2401,7 +2409,7 @@ export function createMemberToolHandlers(
       return 'Title is required to create a post.';
     }
 
-    // Generate post slug from title with timestamp for uniqueness
+    // Generate post slug from title with timestamp for uniqueness.
     const timestamp = Date.now().toString(36);
     const baseSlug = title
       .toLowerCase()
@@ -2410,32 +2418,46 @@ export function createMemberToolHandlers(
       .substring(0, 50);
     const postSlug = baseSlug ? `${baseSlug}-${timestamp}` : timestamp;
 
-    const body: Record<string, unknown> = {
-      title,
-      content,
-      content_type: postType,
-      post_slug: postSlug,
-    };
+    // Map Addie's `post_type` (discussion / link / etc.) onto the
+    // service's stricter `contentType` ('article' | 'link'). Discussion
+    // posts become articles in the perspectives table.
+    const contentType = postType === 'link' ? 'link' : 'article';
 
-    if (postType === 'link' && linkUrl) {
-      body.external_url = linkUrl;
-    }
-
-    const result = await callApi(
-      'POST',
-      `/api/working-groups/${slug}/posts`,
-      memberContext,
-      body
-    );
-
-    if (!result.ok) {
-      if (result.status === 403) {
-        return `You're not a member of the "${slug}" working group. Join it first using join_working_group.`;
+    const wu = memberContext.workos_user;
+    try {
+      await createWorkingGroupPostService({
+        user: { id: wu.workos_user_id, email: wu.email, firstName: wu.first_name, lastName: wu.last_name },
+        slug,
+        title,
+        postSlug,
+        content,
+        contentType,
+        externalUrl: postType === 'link' ? linkUrl : undefined,
+      });
+      return `✅ Post created successfully in the "${slug}" working group!\n\n**Title:** ${title}\n\nYour post is now visible to other working group members.`;
+    } catch (error) {
+      if (error instanceof WorkingGroupContentError) {
+        if (error.is('group_not_found')) {
+          return `Working group "${slug}" not found. Use list_working_groups to see available groups.`;
+        }
+        if (error.is('not_member')) {
+          return `You're not a member of the "${slug}" working group. Join it first using join_working_group.`;
+        }
+        if (error.is('leader_required_for_public_post')) {
+          return `Only committee leaders can create public (non-members-only) posts in "${slug}".`;
+        }
+        if (error.is('missing_required_fields')) {
+          return `Title and slug are required to create a post.`;
+        }
+        if (error.is('invalid_post_slug')) {
+          return `Generated post slug was invalid (must contain only lowercase letters, numbers, and hyphens). Try again with a different title.`;
+        }
+        if (error.is('duplicate_post_slug')) {
+          return `A post with this slug already exists in "${slug}". Try again with a different title.`;
+        }
       }
-      throw new ToolError(`Failed to create post: ${result.error}`);
+      throw new ToolError(`Failed to create post: ${error instanceof Error ? error.message : String(error)}`);
     }
-
-    return `✅ Post created successfully in the "${slug}" working group!\n\n**Title:** ${title}\n\nYour post is now visible to other working group members.`;
   });
 
   // ============================================
@@ -3003,48 +3025,57 @@ export function createMemberToolHandlers(
     const description = input.description as string | undefined;
     const isFeatured = input.is_featured as boolean | undefined;
 
-    // Validate URL is a Google domain
+    // Map URL hostname → CommitteeDocumentType. Service does its own
+    // SSRF allowlist check (broader than the Addie-side Google check
+    // below) — both run so the friendlier "Google only" error fires
+    // first for chat callers.
+    let documentType: CommitteeDocumentType;
     try {
       const url = new URL(documentUrl);
       const allowedDomains = ['docs.google.com', 'sheets.google.com', 'drive.google.com'];
       if (url.protocol !== 'https:' || !allowedDomains.includes(url.hostname)) {
         return `Invalid document URL. Only Google Docs, Sheets, and Drive URLs are supported (https://docs.google.com, sheets.google.com, or drive.google.com).`;
       }
+      // CodeQL: substring check is for document type categorization, not URL validation
+      documentType = url.hostname === 'sheets.google.com' ? 'google_sheet' : 'google_doc'; // lgtm[js/incomplete-url-substring-sanitization]
     } catch {
       return 'Invalid URL format. Please provide a valid Google Docs URL.';
     }
 
-    const result = await callApi(
-      'POST',
-      `/api/working-groups/${slug}/documents`,
-      memberContext,
-      {
+    const wu = memberContext.workos_user;
+    try {
+      await addCommitteeDocumentService({
+        user: { id: wu.workos_user_id, email: wu.email, firstName: wu.first_name, lastName: wu.last_name },
+        slug,
         title,
-        document_url: documentUrl,
+        documentUrl,
         description,
-        is_featured: isFeatured || false,
-        // CodeQL: substring check is for document type categorization, not URL validation
-        document_type: documentUrl.includes('sheets.google.com') ? 'google_sheet' : 'google_doc', // lgtm[js/incomplete-url-substring-sanitization]
+        documentType,
+        isFeatured: isFeatured ?? false,
+      });
+      let response = `✅ Document added to "${slug}"!\n\n`;
+      response += `**Title:** ${title}\n`;
+      response += `**URL:** ${documentUrl}\n\n`;
+      response += `The document will be automatically indexed and summarized within the hour. `;
+      response += `You can view it at https://agenticadvertising.org/working-groups/${slug}`;
+      return response;
+    } catch (error) {
+      if (error instanceof WorkingGroupContentError) {
+        if (error.is('group_not_found')) {
+          return `Committee "${slug}" not found. Use list_working_groups to see available committees.`;
+        }
+        if (error.is('not_member')) {
+          return `You're not a member of the "${slug}" committee. Only members and leaders can add documents.`;
+        }
+        if (error.is('missing_required_fields')) {
+          return `Title and document URL are required to add a document.`;
+        }
+        if (error.is('invalid_document_url')) {
+          return `That document URL isn't on the allowlist. Only Google Docs/Sheets/Drive plus PDFs/PPTX/XLSX/DOCX from trusted hosts are accepted.`;
+        }
       }
-    );
-
-    if (!result.ok) {
-      if (result.status === 403) {
-        return `You're not a member of the "${slug}" committee. Only members and leaders can add documents.`;
-      }
-      if (result.status === 404) {
-        return `Committee "${slug}" not found. Use list_working_groups to see available committees.`;
-      }
-      throw new ToolError(`Failed to add document: ${result.error}`);
+      throw new ToolError(`Failed to add document: ${error instanceof Error ? error.message : String(error)}`);
     }
-
-    let response = `✅ Document added to "${slug}"!\n\n`;
-    response += `**Title:** ${title}\n`;
-    response += `**URL:** ${documentUrl}\n\n`;
-    response += `The document will be automatically indexed and summarized within the hour. `;
-    response += `You can view it at https://agenticadvertising.org/working-groups/${slug}`;
-
-    return response;
   });
 
   handlers.set('list_committee_documents', async (input) => {
@@ -3106,64 +3137,70 @@ export function createMemberToolHandlers(
     const documentUrl = input.document_url as string | undefined;
     const isFeatured = input.is_featured as boolean | undefined;
 
-    // Validate UUID format before API call
-    if (!isUuid(documentId)) {
-      return 'Invalid document ID format. Use list_committee_documents to find valid document IDs.';
-    }
-
-    // Validate URL if provided
-    if (documentUrl) {
+    // Addie-side Google-only check produces a friendlier error than the
+    // service's broader "isn't on the allowlist" message. Service still
+    // re-validates as defense-in-depth.
+    let documentType: CommitteeDocumentType | undefined;
+    if (documentUrl !== undefined) {
       try {
         const url = new URL(documentUrl);
         const allowedDomains = ['docs.google.com', 'sheets.google.com', 'drive.google.com'];
         if (url.protocol !== 'https:' || !allowedDomains.includes(url.hostname)) {
           return `Invalid document URL. Only Google Docs, Sheets, and Drive URLs are supported (https://docs.google.com, sheets.google.com, or drive.google.com).`;
         }
+        // CodeQL: substring check is for document type categorization, not URL validation
+        documentType = url.hostname === 'sheets.google.com' ? 'google_sheet' : 'google_doc'; // lgtm[js/incomplete-url-substring-sanitization]
       } catch {
         return 'Invalid URL format. Please provide a valid Google Docs URL.';
       }
     }
 
-    // Build update payload with only provided fields
-    const updateData: Record<string, unknown> = {};
-    if (title !== undefined) updateData.title = title;
-    if (description !== undefined) updateData.description = description;
-    if (documentUrl !== undefined) {
-      updateData.document_url = documentUrl;
-      // CodeQL: substring check is for document type categorization, not URL validation
-      updateData.document_type = documentUrl.includes('sheets.google.com') ? 'google_sheet' : 'google_doc'; // lgtm[js/incomplete-url-substring-sanitization]
-    }
-    if (isFeatured !== undefined) updateData.is_featured = isFeatured;
-
-    if (Object.keys(updateData).length === 0) {
+    if (
+      title === undefined &&
+      description === undefined &&
+      documentUrl === undefined &&
+      isFeatured === undefined
+    ) {
       return 'No fields to update. Please provide at least one field to change (title, description, document_url, or is_featured).';
     }
 
-    const result = await callApi(
-      'PUT',
-      `/api/working-groups/${slug}/documents/${documentId}`,
-      memberContext,
-      updateData
-    );
-
-    if (!result.ok) {
-      if (result.status === 403) {
-        return `You're not a member of the "${slug}" committee. Only members and leaders can update documents.`;
+    const wu = memberContext.workos_user;
+    try {
+      const result = await updateCommitteeDocumentService({
+        user: { id: wu.workos_user_id, email: wu.email, firstName: wu.first_name, lastName: wu.last_name },
+        slug,
+        documentId,
+        title,
+        description,
+        documentUrl,
+        documentType,
+        isFeatured,
+      });
+      const docTitle = (result.document as { title?: string }).title || title || 'Document';
+      let response = `✅ Document updated!\n\n`;
+      response += `**${docTitle}** has been updated in "${slug}".\n\n`;
+      response += `View it at https://agenticadvertising.org/working-groups/${slug}`;
+      return response;
+    } catch (error) {
+      if (error instanceof WorkingGroupContentError) {
+        if (error.is('invalid_document_id')) {
+          return 'Invalid document ID format. Use list_committee_documents to find valid document IDs.';
+        }
+        if (error.is('group_not_found')) {
+          return `Committee "${slug}" not found. Use list_working_groups to see available committees.`;
+        }
+        if (error.is('document_not_found')) {
+          return `Document not found in "${slug}". Use list_committee_documents to find valid document IDs.`;
+        }
+        if (error.is('not_member')) {
+          return `You're not a member of the "${slug}" committee. Only members and leaders can update documents.`;
+        }
+        if (error.is('invalid_document_url')) {
+          return `That document URL isn't on the allowlist. Only Google Docs/Sheets/Drive plus PDFs/PPTX/XLSX/DOCX from trusted hosts are accepted.`;
+        }
       }
-      if (result.status === 404) {
-        return `Document not found. Either the committee "${slug}" doesn't exist or the document ID "${documentId}" is invalid.`;
-      }
-      throw new ToolError(`Failed to update document: ${result.error}`);
+      throw new ToolError(`Failed to update document: ${error instanceof Error ? error.message : String(error)}`);
     }
-
-    const data = result.data as { document?: { title: string } } | undefined;
-    const docTitle = data?.document?.title || title || 'Document';
-
-    let response = `✅ Document updated!\n\n`;
-    response += `**${docTitle}** has been updated in "${slug}".\n\n`;
-    response += `View it at https://agenticadvertising.org/working-groups/${slug}`;
-
-    return response;
   });
 
   handlers.set('delete_committee_document', async (input) => {
@@ -3174,28 +3211,31 @@ export function createMemberToolHandlers(
     const slug = input.committee_slug as string;
     const documentId = input.document_id as string;
 
-    // Validate UUID format before API call
-    if (!isUuid(documentId)) {
-      return 'Invalid document ID format. Use list_committee_documents to find valid document IDs.';
-    }
-
-    const result = await callApi(
-      'DELETE',
-      `/api/working-groups/${slug}/documents/${documentId}`,
-      memberContext
-    );
-
-    if (!result.ok) {
-      if (result.status === 403) {
-        return `You're not a leader of the "${slug}" committee. Only committee leaders can delete documents.`;
+    const wu = memberContext.workos_user;
+    try {
+      await deleteCommitteeDocumentService({
+        user: { id: wu.workos_user_id, email: wu.email, firstName: wu.first_name, lastName: wu.last_name },
+        slug,
+        documentId,
+      });
+      return `✅ Document removed from "${slug}".\n\nThe document will no longer be tracked or displayed on the committee page.`;
+    } catch (error) {
+      if (error instanceof WorkingGroupContentError) {
+        if (error.is('invalid_document_id')) {
+          return 'Invalid document ID format. Use list_committee_documents to find valid document IDs.';
+        }
+        if (error.is('group_not_found')) {
+          return `Committee "${slug}" not found. Use list_working_groups to see available committees.`;
+        }
+        if (error.is('document_not_found')) {
+          return `Document not found in "${slug}". Use list_committee_documents to find valid document IDs.`;
+        }
+        if (error.is('not_leader')) {
+          return `You're not a leader of the "${slug}" committee. Only committee leaders can delete documents.`;
+        }
       }
-      if (result.status === 404) {
-        return `Document not found. Either the committee "${slug}" doesn't exist or the document ID "${documentId}" is invalid.`;
-      }
-      throw new ToolError(`Failed to delete document: ${result.error}`);
+      throw new ToolError(`Failed to delete document: ${error instanceof Error ? error.message : String(error)}`);
     }
-
-    return `✅ Document removed from "${slug}".\n\nThe document will no longer be tracked or displayed on the committee page.`;
   });
 
   // ============================================

--- a/server/src/routes/committees.ts
+++ b/server/src/routes/committees.ts
@@ -1745,7 +1745,7 @@ export function createCommitteeRouters(): {
         if (error.is('invalid_document_url')) {
           return res.status(400).json({
             error: 'Invalid document URL',
-            message: 'Only Google Docs, Sheets, Drive URLs, and direct links to PDFs or PPTX files are supported',
+            message: 'Only Google Docs, Sheets, Drive URLs, and direct links to PDFs/PPTX/XLSX/DOCX from trusted hosts are supported',
           });
         }
         if (error.is('not_member')) {
@@ -1947,7 +1947,7 @@ export function createCommitteeRouters(): {
         if (error.is('invalid_document_url')) {
           return res.status(400).json({
             error: 'Invalid document URL',
-            message: 'Only Google Docs, Sheets, Drive URLs, and direct links to PDFs or PPTX files are supported',
+            message: 'Only Google Docs, Sheets, Drive URLs, and direct links to PDFs/PPTX/XLSX/DOCX from trusted hosts are supported',
           });
         }
         if (error.is('not_member')) {

--- a/server/src/routes/committees.ts
+++ b/server/src/routes/committees.ts
@@ -33,6 +33,13 @@ import {
   withdrawCommitteeInterest as withdrawCommitteeInterestService,
   WorkingGroupMembershipError,
 } from "../services/working-group-membership-service.js";
+import {
+  createWorkingGroupPost as createWorkingGroupPostService,
+  addCommitteeDocument as addCommitteeDocumentService,
+  updateCommitteeDocument as updateCommitteeDocumentService,
+  deleteCommitteeDocument as deleteCommitteeDocumentService,
+  WorkingGroupContentError,
+} from "../services/working-group-content-service.js";
 
 const logger = createLogger("committee-routes");
 
@@ -74,52 +81,9 @@ function checkReindexRateLimit(userId: string): boolean {
   return true;
 }
 
-// Allowed document URL patterns (whitelist approach to prevent SSRF)
-const ALLOWED_DOCUMENT_DOMAINS = [
-  'docs.google.com',
-  'drive.google.com',
-  'sheets.google.com',
-];
-
-// Trusted domains for direct file links (PDFs, presentations)
-const ALLOWED_FILE_HOSTING_DOMAINS = [
-  'drive.google.com',
-  'docs.google.com',
-  'storage.googleapis.com',
-  'dropbox.com',
-  'www.dropbox.com',
-  'dl.dropboxusercontent.com',
-  'onedrive.live.com',
-  '1drv.ms',
-  'agenticadvertising.org',
-  'www.agenticadvertising.org',
-];
-
-const ALLOWED_FILE_EXTENSIONS = ['.pdf', '.pptx', '.xlsx', '.docx'];
-
-function isAllowedDocumentUrl(url: string): boolean {
-  try {
-    const parsed = new URL(url);
-    if (parsed.protocol !== 'https:') {
-      return false;
-    }
-    // Allow trusted Google Docs/Sheets domains
-    if (ALLOWED_DOCUMENT_DOMAINS.includes(parsed.hostname)) {
-      return true;
-    }
-    // Allow PDF/PPTX only from trusted file hosting domains
-    const pathname = parsed.pathname.toLowerCase();
-    if (
-      ALLOWED_FILE_HOSTING_DOMAINS.includes(parsed.hostname) &&
-      ALLOWED_FILE_EXTENSIONS.some(ext => pathname.endsWith(ext))
-    ) {
-      return true;
-    }
-    return false;
-  } catch {
-    return false;
-  }
-}
+// Document URL allowlist + helper now live in
+// services/working-group-content-service so the route and the Addie
+// tool consume the same rules.
 
 // Valid committee types
 const VALID_COMMITTEE_TYPES = ['working_group', 'council', 'chapter', 'governance', 'industry_gathering'] as const;
@@ -1375,115 +1339,59 @@ export function createCommitteeRouters(): {
     try {
       const { slug } = req.params;
       const { title, content, content_type, category, excerpt, external_url, external_site_name, post_slug, is_members_only } = req.body;
-      const pool = getPool();
       const user = req.user!;
-
-      const group = await workingGroupDb.getWorkingGroupBySlug(slug);
-
-      if (!group || group.status !== 'active') {
-        return res.status(404).json({
-          error: 'Working group not found',
-          message: `No working group found with slug: ${slug}`,
-        });
-      }
-
-      const isMember = await workingGroupDb.isMember(group.id, user.id);
-      if (!isMember) {
-        return res.status(403).json({
-          error: 'Not a member',
-          message: 'You must be a member of this working group to post',
-        });
-      }
-
-      const isLeader = group.leaders?.some(l => l.canonical_user_id === user.id) ?? false;
-      // Non-leaders CANNOT opt out of members_only. Reject any explicit
-      // non-true value (`false`, `0`, `"false"`, `null`) with a 403 so the
-      // abuse signal surfaces in logs rather than being silently coerced.
-      // Omitting the field entirely is fine — we default to members-only.
-      if (!isLeader && is_members_only !== undefined && is_members_only !== true) {
-        return res.status(403).json({
-          error: 'Permission denied',
-          message: 'Only committee leaders can create public (non-members-only) posts in this working group. Submit via the Perspectives flow for editorial review instead.',
-        });
-      }
-      // For leaders, normalize the field to a strict boolean so a
-      // `0`/`"false"`/`null` value doesn't accidentally create a public
-      // post the leader didn't intend.
-      const finalMembersOnly = isLeader
-        ? (is_members_only === undefined ? true : Boolean(is_members_only))
-        : true;
-
-      if (!title || !post_slug) {
-        return res.status(400).json({
-          error: 'Missing required fields',
-          message: 'Title and slug are required',
-        });
-      }
-
-      const slugPattern = /^[a-z0-9-]+$/;
-      if (!slugPattern.test(post_slug)) {
-        return res.status(400).json({
-          error: 'Invalid slug',
-          message: 'Slug must contain only lowercase letters, numbers, and hyphens',
-        });
-      }
-
-      const authorName = user.firstName && user.lastName
-        ? `${user.firstName} ${user.lastName}`
-        : user.email;
-
-      const result = await pool.query(
-        `INSERT INTO perspectives (
-          working_group_id, slug, content_type, title, content, category, excerpt,
-          external_url, external_site_name, author_name, author_user_id,
-          status, published_at, is_members_only
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 'published', NOW(), $12)
-        RETURNING *`,
-        [
-          group.id,
-          post_slug,
-          content_type || 'article',
-          title,
-          content || null,
-          category || null,
-          excerpt || null,
-          external_url || null,
-          external_site_name || null,
-          authorName,
-          user.id,
-          finalMembersOnly,
-        ]
-      );
-
-      // Send Slack notification to the working group's channel
-      notifyPublishedPost({
-        slackChannelId: group.slack_channel_id ?? undefined,
-        workingGroupName: group.name,
-        workingGroupSlug: slug,
-        postTitle: title,
+      const result = await createWorkingGroupPostService({
+        user: { id: user.id, email: user.email, firstName: user.firstName, lastName: user.lastName },
+        slug,
+        title,
         postSlug: post_slug,
-        authorName,
-        contentType: content_type || 'article',
-        excerpt: excerpt || undefined,
-        externalUrl: external_url || undefined,
-        category: category || undefined,
-        isMembersOnly: finalMembersOnly,
-      }).catch(err => {
-        logger.warn({ err }, 'Failed to send Slack channel notification for working group post');
+        content,
+        contentType: content_type,
+        category,
+        excerpt,
+        externalUrl: external_url,
+        externalSiteName: external_site_name,
+        isMembersOnly: is_members_only,
       });
-
-      res.status(201).json({ post: result.rows[0] });
+      res.status(201).json({ post: result.post });
     } catch (error) {
-      logger.error({ err: error }, 'Create working group post error');
-      if (error instanceof Error && error.message.includes('duplicate key')) {
-        return res.status(409).json({
-          error: 'Slug already exists',
-          message: 'A post with this slug already exists in this working group',
-        });
+      if (error instanceof WorkingGroupContentError) {
+        if (error.is('group_not_found')) {
+          return res.status(404).json({
+            error: 'Working group not found',
+            message: `No working group found with slug: ${error.meta.slug}`,
+          });
+        }
+        if (error.is('not_member')) {
+          return res.status(403).json({
+            error: 'Not a member',
+            message: 'You must be a member of this working group to post',
+          });
+        }
+        if (error.is('leader_required_for_public_post')) {
+          return res.status(403).json({
+            error: 'Permission denied',
+            message: 'Only committee leaders can create public (non-members-only) posts in this working group. Submit via the Perspectives flow for editorial review instead.',
+          });
+        }
+        if (error.is('missing_required_fields')) {
+          return res.status(400).json({ error: 'Missing required fields', message: 'Title and slug are required' });
+        }
+        if (error.is('invalid_post_slug')) {
+          return res.status(400).json({
+            error: 'Invalid slug',
+            message: 'Slug must contain only lowercase letters, numbers, and hyphens',
+          });
+        }
+        if (error.is('duplicate_post_slug')) {
+          return res.status(409).json({
+            error: 'Slug already exists',
+            message: 'A post with this slug already exists in this working group',
+          });
+        }
       }
-      res.status(500).json({
-        error: 'Failed to create post',
-      });
+      logger.error({ err: error }, 'Create working group post error');
+      res.status(500).json({ error: 'Failed to create post' });
     }
   });
 
@@ -1809,97 +1717,45 @@ export function createCommitteeRouters(): {
       const { slug } = req.params;
       const { title, description, document_url, document_type, display_order, is_featured } = req.body;
       const user = req.user!;
-
-      const group = await workingGroupDb.getWorkingGroupBySlug(slug);
-      if (!group) {
-        return res.status(404).json({
-          error: 'Committee not found',
-          message: `No committee found with slug: ${slug}`,
-        });
-      }
-
-      if (!title || !document_url) {
-        return res.status(400).json({
-          error: 'Missing required fields',
-          message: 'Title and document_url are required',
-        });
-      }
-
-      // Strict URL validation to prevent SSRF - only allow trusted domains
-      if (!isAllowedDocumentUrl(document_url)) {
-        return res.status(400).json({
-          error: 'Invalid document URL',
-          message: 'Only Google Docs, Sheets, Drive URLs, and direct links to PDFs or PPTX files are supported',
-        });
-      }
-
-      const document = await workingGroupDb.createDocument({
-        working_group_id: group.id,
+      const result = await addCommitteeDocumentService({
+        user: { id: user.id, email: user.email, firstName: user.firstName, lastName: user.lastName },
+        slug,
         title,
+        documentUrl: document_url,
         description,
-        document_url,
-        document_type,
-        display_order: display_order ?? 0,
-        is_featured: is_featured ?? false,
-        added_by_user_id: user.id,
+        documentType: document_type,
+        displayOrder: display_order,
+        isFeatured: is_featured,
       });
-
-      logger.info({ documentId: document.id, groupSlug: slug, userId: user.id }, 'Committee document created');
-
-      // Notify the working group's Slack channel
-      if (group.slack_channel_id && isSlackConfigured()) {
-        const docTypeLabel = document_type === 'spreadsheet' ? 'Spreadsheet' : document_type === 'presentation' ? 'Presentation' : 'Document';
-        const userName = user.firstName && user.lastName
-          ? `${user.firstName} ${user.lastName}`
-          : user.email || 'A working group leader';
-        const appUrl = process.env.APP_URL || 'https://agenticadvertising.org';
-        const groupUrl = `${appUrl}/working-groups/${slug}`;
-        // Sanitize for Slack mrkdwn link syntax (pipe breaks <url|label>)
-        const safeTitle = title.replace(/[|<>]/g, '-');
-
-        sendChannelMessage(group.slack_channel_id, {
-          text: `📄 New ${docTypeLabel} added to ${group.name}: ${title}`,
-          blocks: [
-            {
-              type: 'header',
-              text: {
-                type: 'plain_text' as const,
-                text: `📄 New ${docTypeLabel} Added`,
-                emoji: true,
-              },
-            },
-            {
-              type: 'section',
-              text: {
-                type: 'mrkdwn' as const,
-                text: `*<${document_url}|${safeTitle}>*${description ? `\n${description}` : ''}`,
-              },
-            },
-            {
-              type: 'section',
-              text: {
-                type: 'mrkdwn' as const,
-                text: `Added by ${userName} · <${groupUrl}|View all ${group.name} resources>`,
-              },
-            },
-          ],
-        }).catch(err => {
-          logger.warn({ err, groupSlug: slug, documentId: document.id }, 'Failed to send Slack notification for new committee document');
-        });
-      }
-
-      const { file_data: _fd, last_content: _lc, ...documentMeta } = document;
-      res.status(201).json({ document: documentMeta });
-
-      // Index immediately so Addie can reference the document right away
-      reindexDocument(document.id)
-        .then(() => refreshWorkingGroupDocs())
-        .catch(err => logger.warn({ err, documentId: document.id }, 'Background indexing after document creation failed'));
+      res.status(201).json({ document: result.document });
     } catch (error) {
+      if (error instanceof WorkingGroupContentError) {
+        if (error.is('group_not_found')) {
+          return res.status(404).json({
+            error: 'Committee not found',
+            message: `No committee found with slug: ${error.meta.slug}`,
+          });
+        }
+        if (error.is('missing_required_fields')) {
+          return res.status(400).json({
+            error: 'Missing required fields',
+            message: 'Title and document_url are required',
+          });
+        }
+        if (error.is('invalid_document_url')) {
+          return res.status(400).json({
+            error: 'Invalid document URL',
+            message: 'Only Google Docs, Sheets, Drive URLs, and direct links to PDFs or PPTX files are supported',
+          });
+        }
+        if (error.is('not_member')) {
+          // requireWorkingGroupMember middleware blocks this in practice,
+          // but the service still returns it for in-process callers.
+          return res.status(403).json({ error: 'Not a member', message: 'Only committee members can add documents' });
+        }
+      }
       logger.error({ err: error }, 'Create committee document error');
-      res.status(500).json({
-        error: 'Failed to create document',
-      });
+      res.status(500).json({ error: 'Failed to create document' });
     }
   });
 
@@ -2061,61 +1917,45 @@ export function createCommitteeRouters(): {
     try {
       const { slug, documentId } = req.params;
       const { title, description, document_url, document_type, display_order, is_featured } = req.body;
-
-      if (!isUuid(documentId)) {
-        return res.status(400).json({
-          error: 'Invalid document ID',
-          message: 'Document ID must be a valid UUID',
-        });
-      }
-
-      const group = await workingGroupDb.getWorkingGroupBySlug(slug);
-      if (!group) {
-        return res.status(404).json({
-          error: 'Committee not found',
-          message: `No committee found with slug: ${slug}`,
-        });
-      }
-
-      const existingDoc = await workingGroupDb.getDocumentById(documentId);
-      if (!existingDoc || existingDoc.working_group_id !== group.id) {
-        return res.status(404).json({
-          error: 'Document not found',
-          message: 'Document not found in this committee',
-        });
-      }
-
-      // Validate URL if provided - strict validation to prevent SSRF
-      if (document_url && !isAllowedDocumentUrl(document_url)) {
-        return res.status(400).json({
-          error: 'Invalid document URL',
-          message: 'Only Google Docs, Sheets, Drive URLs, and direct links to PDFs or PPTX files are supported',
-        });
-      }
-
-      const document = await workingGroupDb.updateDocument(documentId, {
+      const user = req.user!;
+      const result = await updateCommitteeDocumentService({
+        user: { id: user.id, email: user.email, firstName: user.firstName, lastName: user.lastName },
+        slug,
+        documentId,
         title,
         description,
-        document_url,
-        document_type,
-        display_order,
-        is_featured,
+        documentUrl: document_url,
+        documentType: document_type,
+        displayOrder: display_order,
+        isFeatured: is_featured,
       });
-
-      if (!document) {
-        return res.status(404).json({ error: 'Document not found' });
-      }
-      const { file_data: _fd, last_content: _lc, ...documentMeta } = document;
-      res.json({ document: documentMeta });
-
-      // Refresh in-memory search index so Addie sees updated metadata
-      refreshWorkingGroupDocs()
-        .catch(err => logger.warn({ err, documentId }, 'Background refresh after document update failed'));
+      res.json({ document: result.document });
     } catch (error) {
+      if (error instanceof WorkingGroupContentError) {
+        if (error.is('invalid_document_id')) {
+          return res.status(400).json({ error: 'Invalid document ID', message: 'Document ID must be a valid UUID' });
+        }
+        if (error.is('group_not_found')) {
+          return res.status(404).json({
+            error: 'Committee not found',
+            message: `No committee found with slug: ${error.meta.slug}`,
+          });
+        }
+        if (error.is('document_not_found')) {
+          return res.status(404).json({ error: 'Document not found', message: 'Document not found in this committee' });
+        }
+        if (error.is('invalid_document_url')) {
+          return res.status(400).json({
+            error: 'Invalid document URL',
+            message: 'Only Google Docs, Sheets, Drive URLs, and direct links to PDFs or PPTX files are supported',
+          });
+        }
+        if (error.is('not_member')) {
+          return res.status(403).json({ error: 'Not a member', message: 'Only committee members can update documents' });
+        }
+      }
       logger.error({ err: error }, 'Update committee document error');
-      res.status(500).json({
-        error: 'Failed to update document',
-      });
+      res.status(500).json({ error: 'Failed to update document' });
     }
   });
 
@@ -2189,44 +2029,33 @@ export function createCommitteeRouters(): {
   publicApiRouter.delete('/:slug/documents/:documentId', requireAuth, requireWorkingGroupLeader, async (req: Request, res: Response) => {
     try {
       const { slug, documentId } = req.params;
-
-      if (!isUuid(documentId)) {
-        return res.status(400).json({
-          error: 'Invalid document ID',
-          message: 'Document ID must be a valid UUID',
-        });
-      }
-
-      const group = await workingGroupDb.getWorkingGroupBySlug(slug);
-      if (!group) {
-        return res.status(404).json({
-          error: 'Committee not found',
-          message: `No committee found with slug: ${slug}`,
-        });
-      }
-
-      const existingDoc = await workingGroupDb.getDocumentById(documentId);
-      if (!existingDoc || existingDoc.working_group_id !== group.id) {
-        return res.status(404).json({
-          error: 'Document not found',
-          message: 'Document not found in this committee',
-        });
-      }
-
-      await workingGroupDb.deleteDocument(documentId);
-
-      logger.info({ documentId, groupSlug: slug }, 'Committee document deleted');
-
-      res.json({ success: true });
-
-      // Remove from in-memory search index
-      refreshWorkingGroupDocs()
-        .catch(err => logger.warn({ err, documentId }, 'Background refresh after document delete failed'));
-    } catch (error) {
-      logger.error({ err: error }, 'Delete committee document error');
-      res.status(500).json({
-        error: 'Failed to delete document',
+      const user = req.user!;
+      await deleteCommitteeDocumentService({
+        user: { id: user.id, email: user.email, firstName: user.firstName, lastName: user.lastName },
+        slug,
+        documentId,
       });
+      res.json({ success: true });
+    } catch (error) {
+      if (error instanceof WorkingGroupContentError) {
+        if (error.is('invalid_document_id')) {
+          return res.status(400).json({ error: 'Invalid document ID', message: 'Document ID must be a valid UUID' });
+        }
+        if (error.is('group_not_found')) {
+          return res.status(404).json({
+            error: 'Committee not found',
+            message: `No committee found with slug: ${error.meta.slug}`,
+          });
+        }
+        if (error.is('document_not_found')) {
+          return res.status(404).json({ error: 'Document not found', message: 'Document not found in this committee' });
+        }
+        if (error.is('not_leader')) {
+          return res.status(403).json({ error: 'Not a leader', message: 'Only committee leaders can delete documents' });
+        }
+      }
+      logger.error({ err: error }, 'Delete committee document error');
+      res.status(500).json({ error: 'Failed to delete document' });
     }
   });
 

--- a/server/src/services/working-group-content-service.ts
+++ b/server/src/services/working-group-content-service.ts
@@ -1,0 +1,511 @@
+/**
+ * Working-group content service.
+ *
+ * Shared by:
+ *  - POST /api/working-groups/:slug/posts                      (web/API)
+ *  - POST /api/working-groups/:slug/documents                  (web/API)
+ *  - PUT  /api/working-groups/:slug/documents/:documentId      (web/API)
+ *  - DELETE /api/working-groups/:slug/documents/:documentId    (web/API)
+ *  - create_working_group_post Addie tool                      (chat)
+ *  - add_committee_document Addie tool                         (chat)
+ *  - update_committee_document Addie tool                      (chat)
+ *  - delete_committee_document Addie tool                      (chat)
+ *
+ * Centralizes membership/leader auth checks, URL allowlist validation,
+ * post + document side effects (Slack channel notification, doc index
+ * refresh) so the route and the Addie tool produce identical outcomes.
+ * Replaces a server-to-self HTTP loopback in callApi that was silently
+ * rejected by CSRF middleware (issue #3736).
+ */
+
+import { getPool } from '../db/client.js';
+import { createLogger } from '../logger.js';
+import { WorkingGroupDatabase } from '../db/working-group-db.js';
+import type { CommitteeDocument, CommitteeDocumentType } from '../types.js';
+import { notifyPublishedPost } from '../notifications/slack.js';
+import { sendChannelMessage, isSlackConfigured } from '../slack/client.js';
+import { reindexDocument } from '../addie/jobs/committee-document-indexer.js';
+import { refreshWorkingGroupDocs } from '../addie/mcp/docs-indexer.js';
+import { isUuid } from '../utils/uuid.js';
+import type { WorkingGroupServiceUser } from './working-group-membership-service.js';
+
+const logger = createLogger('working-group-content-service');
+
+const workingGroupDb = new WorkingGroupDatabase();
+
+// ─── URL allowlist for committee documents ────────────────────────────
+// Whitelist approach to prevent SSRF when crawling user-supplied
+// document URLs. Mirrors the previous in-route helper in committees.ts;
+// kept here so both the route and the Addie tool consume the same rules.
+
+const ALLOWED_DOCUMENT_DOMAINS = ['docs.google.com', 'drive.google.com', 'sheets.google.com'];
+const ALLOWED_FILE_HOSTING_DOMAINS = [
+  'drive.google.com',
+  'docs.google.com',
+  'storage.googleapis.com',
+  'dropbox.com',
+  'www.dropbox.com',
+  'dl.dropboxusercontent.com',
+  'onedrive.live.com',
+  '1drv.ms',
+  'agenticadvertising.org',
+  'www.agenticadvertising.org',
+];
+const ALLOWED_FILE_EXTENSIONS = ['.pdf', '.pptx', '.xlsx', '.docx'];
+
+export function isAllowedDocumentUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'https:') return false;
+    if (ALLOWED_DOCUMENT_DOMAINS.includes(parsed.hostname)) return true;
+    const pathname = parsed.pathname.toLowerCase();
+    if (
+      ALLOWED_FILE_HOSTING_DOMAINS.includes(parsed.hostname) &&
+      ALLOWED_FILE_EXTENSIONS.some((ext) => pathname.endsWith(ext))
+    ) {
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+// ─── Discriminated error variants ─────────────────────────────────────
+// One union covers post + document failures so callers can pattern-match
+// on `.code` instead of guessing from HTTP status (which is what bit us
+// in the loopback bug).
+
+export type WorkingGroupContentErrorCode =
+  | 'group_not_found'
+  | 'not_member'
+  | 'not_leader'
+  | 'leader_required_for_public_post'
+  | 'missing_required_fields'
+  | 'invalid_post_slug'
+  | 'invalid_document_url'
+  | 'invalid_document_id'
+  | 'document_not_found'
+  | 'duplicate_post_slug';
+
+export interface WorkingGroupContentErrorMetaByCode {
+  group_not_found: { slug: string };
+  not_member: { slug: string };
+  not_leader: { slug: string };
+  leader_required_for_public_post: { slug: string };
+  missing_required_fields: { slug: string; fields: string[] };
+  invalid_post_slug: { slug: string; postSlug: string };
+  invalid_document_url: { slug: string };
+  invalid_document_id: { slug: string; documentId: string };
+  document_not_found: { slug: string; documentId: string };
+  duplicate_post_slug: { slug: string; postSlug: string };
+}
+
+export class WorkingGroupContentError<
+  C extends WorkingGroupContentErrorCode = WorkingGroupContentErrorCode,
+> extends Error {
+  constructor(
+    public readonly code: C,
+    message: string,
+    public readonly meta: WorkingGroupContentErrorMetaByCode[C],
+  ) {
+    super(message);
+    this.name = 'WorkingGroupContentError';
+  }
+
+  is<K extends WorkingGroupContentErrorCode>(
+    code: K,
+  ): this is WorkingGroupContentError<K> & { meta: WorkingGroupContentErrorMetaByCode[K] } {
+    return (this.code as string) === (code as string);
+  }
+}
+
+function userDisplayName(user: WorkingGroupServiceUser): string {
+  if (user.firstName && user.lastName) return `${user.firstName} ${user.lastName}`;
+  return user.email;
+}
+
+// ─── Post creation ────────────────────────────────────────────────────
+
+export type WorkingGroupPostContentType = 'article' | 'link';
+const VALID_POST_CONTENT_TYPES: readonly WorkingGroupPostContentType[] = ['article', 'link'];
+
+export interface CreateWorkingGroupPostInput {
+  user: WorkingGroupServiceUser;
+  slug: string;
+  title: string;
+  postSlug: string;
+  content?: string | null;
+  /** Caller-provided content type. Anything outside the allowlist is coerced to 'article'. */
+  contentType?: string;
+  category?: string | null;
+  excerpt?: string | null;
+  externalUrl?: string | null;
+  externalSiteName?: string | null;
+  /** Defaults to true. Non-leaders cannot set this to false. */
+  isMembersOnly?: boolean;
+}
+
+export interface CreateWorkingGroupPostResult {
+  // Returns the perspectives row as-is — the route already shapes the
+  // response, and the Addie tool only needs title + slug for its message.
+  post: Record<string, unknown>;
+  groupName: string;
+  groupSlug: string;
+}
+
+export async function createWorkingGroupPost(input: CreateWorkingGroupPostInput): Promise<CreateWorkingGroupPostResult> {
+  const { user, slug, title, postSlug, content, contentType, category, excerpt, externalUrl, externalSiteName, isMembersOnly } = input;
+
+  const group = await workingGroupDb.getWorkingGroupBySlug(slug);
+  if (!group || group.status !== 'active') {
+    throw new WorkingGroupContentError('group_not_found', `No working group found with slug: ${slug}`, { slug });
+  }
+
+  const isMember = await workingGroupDb.isMember(group.id, user.id);
+  if (!isMember) {
+    throw new WorkingGroupContentError('not_member', 'You must be a member of this working group to post', { slug });
+  }
+
+  const isLeader = group.leaders?.some((l) => l.canonical_user_id === user.id) ?? false;
+
+  // Non-leaders cannot opt out of members-only. Reject any explicit
+  // non-true value so the abuse signal surfaces in logs rather than
+  // being silently coerced. Omitting the field is fine — defaults to
+  // members-only.
+  if (!isLeader && isMembersOnly !== undefined && isMembersOnly !== true) {
+    throw new WorkingGroupContentError(
+      'leader_required_for_public_post',
+      'Only committee leaders can create public (non-members-only) posts',
+      { slug },
+    );
+  }
+  const finalMembersOnly = isLeader ? (isMembersOnly === undefined ? true : Boolean(isMembersOnly)) : true;
+
+  const missing: string[] = [];
+  if (!title) missing.push('title');
+  if (!postSlug) missing.push('post_slug');
+  if (missing.length > 0) {
+    throw new WorkingGroupContentError('missing_required_fields', 'Title and slug are required', { slug, fields: missing });
+  }
+
+  const slugPattern = /^[a-z0-9-]+$/;
+  if (!slugPattern.test(postSlug)) {
+    throw new WorkingGroupContentError(
+      'invalid_post_slug',
+      'Slug must contain only lowercase letters, numbers, and hyphens',
+      { slug, postSlug },
+    );
+  }
+
+  const authorName = userDisplayName(user);
+  const pool = getPool();
+  const normalizedContentType: WorkingGroupPostContentType = VALID_POST_CONTENT_TYPES.includes(contentType as WorkingGroupPostContentType)
+    ? (contentType as WorkingGroupPostContentType)
+    : 'article';
+
+  let inserted;
+  try {
+    const result = await pool.query(
+      `INSERT INTO perspectives (
+        working_group_id, slug, content_type, title, content, category, excerpt,
+        external_url, external_site_name, author_name, author_user_id,
+        status, published_at, is_members_only
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 'published', NOW(), $12)
+      RETURNING *`,
+      [
+        group.id,
+        postSlug,
+        normalizedContentType,
+        title,
+        content || null,
+        category || null,
+        excerpt || null,
+        externalUrl || null,
+        externalSiteName || null,
+        authorName,
+        user.id,
+        finalMembersOnly,
+      ],
+    );
+    inserted = result.rows[0];
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('duplicate key')) {
+      throw new WorkingGroupContentError(
+        'duplicate_post_slug',
+        'A post with this slug already exists in this working group',
+        { slug, postSlug },
+      );
+    }
+    throw err;
+  }
+
+  // Slack channel notification — fire-and-forget, doesn't gate the response.
+  notifyPublishedPost({
+    slackChannelId: group.slack_channel_id ?? undefined,
+    workingGroupName: group.name,
+    workingGroupSlug: slug,
+    postTitle: title,
+    postSlug,
+    authorName,
+    contentType: normalizedContentType,
+    excerpt: excerpt || undefined,
+    externalUrl: externalUrl || undefined,
+    category: category || undefined,
+    isMembersOnly: finalMembersOnly,
+  }).catch((err) => {
+    logger.warn({ err }, 'Failed to send Slack channel notification for working group post');
+  });
+
+  return { post: inserted, groupName: group.name, groupSlug: group.slug };
+}
+
+// ─── Document add ─────────────────────────────────────────────────────
+
+export interface AddCommitteeDocumentInput {
+  user: WorkingGroupServiceUser;
+  slug: string;
+  title: string;
+  documentUrl: string;
+  description?: string;
+  documentType?: CommitteeDocumentType;
+  displayOrder?: number;
+  isFeatured?: boolean;
+}
+
+export interface AddCommitteeDocumentResult {
+  document: Omit<CommitteeDocument, 'file_data' | 'last_content'>;
+  groupName: string;
+  groupSlug: string;
+}
+
+export async function addCommitteeDocument(input: AddCommitteeDocumentInput): Promise<AddCommitteeDocumentResult> {
+  const { user, slug, title, documentUrl, description, documentType, displayOrder, isFeatured } = input;
+
+  const group = await workingGroupDb.getWorkingGroupBySlug(slug);
+  if (!group) {
+    throw new WorkingGroupContentError('group_not_found', `No committee found with slug: ${slug}`, { slug });
+  }
+
+  const isMember = await workingGroupDb.isMember(group.id, user.id);
+  if (!isMember) {
+    throw new WorkingGroupContentError('not_member', 'Only members can add documents to this committee', { slug });
+  }
+
+  const missing: string[] = [];
+  if (!title) missing.push('title');
+  if (!documentUrl) missing.push('document_url');
+  if (missing.length > 0) {
+    throw new WorkingGroupContentError('missing_required_fields', 'Title and document_url are required', {
+      slug,
+      fields: missing,
+    });
+  }
+
+  if (!isAllowedDocumentUrl(documentUrl)) {
+    throw new WorkingGroupContentError(
+      'invalid_document_url',
+      'Only Google Docs, Sheets, Drive URLs, and direct links to PDFs/PPTX/XLSX/DOCX from trusted hosts are supported',
+      { slug },
+    );
+  }
+
+  const document = await workingGroupDb.createDocument({
+    working_group_id: group.id,
+    title,
+    description,
+    document_url: documentUrl,
+    document_type: documentType,
+    display_order: displayOrder ?? 0,
+    is_featured: isFeatured ?? false,
+    added_by_user_id: user.id,
+  });
+
+  logger.info({ documentId: document.id, groupSlug: slug, userId: user.id }, 'Committee document created');
+
+  // Slack notification (fire-and-forget) and indexing trigger.
+  if (group.slack_channel_id && isSlackConfigured()) {
+    const docTypeLabel =
+      documentType === 'google_sheet' || documentType === 'xlsx'
+        ? 'Spreadsheet'
+        : documentType === 'pptx'
+          ? 'Presentation'
+          : 'Document';
+    const userName = userDisplayName(user) || 'A working group leader';
+    const appUrl = process.env.APP_URL || 'https://agenticadvertising.org';
+    const groupUrl = `${appUrl}/working-groups/${slug}`;
+    const safeTitle = title.replace(/[|<>]/g, '-');
+    sendChannelMessage(group.slack_channel_id, {
+      text: `📄 New ${docTypeLabel} added to ${group.name}: ${title}`,
+      blocks: [
+        {
+          type: 'header',
+          text: { type: 'plain_text' as const, text: `📄 New ${docTypeLabel} Added`, emoji: true },
+        },
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn' as const,
+            text: `*<${documentUrl}|${safeTitle}>*${description ? `\n${description}` : ''}`,
+          },
+        },
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn' as const,
+            text: `Added by ${userName} · <${groupUrl}|View all ${group.name} resources>`,
+          },
+        },
+      ],
+    }).catch((err) => {
+      logger.warn({ err, groupSlug: slug, documentId: document.id }, 'Failed to send Slack notification for new committee document');
+    });
+  }
+
+  // Index immediately so Addie can reference the document right away.
+  reindexDocument(document.id)
+    .then(() => refreshWorkingGroupDocs())
+    .catch((err) => logger.warn({ err, documentId: document.id }, 'Background indexing after document creation failed'));
+
+  const { file_data: _fd, last_content: _lc, ...documentMeta } = document;
+  return { document: documentMeta, groupName: group.name, groupSlug: group.slug };
+}
+
+// ─── Document update ──────────────────────────────────────────────────
+
+export interface UpdateCommitteeDocumentInput {
+  user: WorkingGroupServiceUser;
+  slug: string;
+  documentId: string;
+  title?: string;
+  description?: string;
+  documentUrl?: string;
+  documentType?: CommitteeDocumentType;
+  displayOrder?: number;
+  isFeatured?: boolean;
+}
+
+export interface UpdateCommitteeDocumentResult {
+  document: Omit<CommitteeDocument, 'file_data' | 'last_content'>;
+  groupName: string;
+  groupSlug: string;
+}
+
+export async function updateCommitteeDocument(
+  input: UpdateCommitteeDocumentInput,
+): Promise<UpdateCommitteeDocumentResult> {
+  const { user, slug, documentId, title, description, documentUrl, documentType, displayOrder, isFeatured } = input;
+
+  if (!isUuid(documentId)) {
+    throw new WorkingGroupContentError('invalid_document_id', 'Document ID must be a valid UUID', {
+      slug,
+      documentId,
+    });
+  }
+
+  const group = await workingGroupDb.getWorkingGroupBySlug(slug);
+  if (!group) {
+    throw new WorkingGroupContentError('group_not_found', `No committee found with slug: ${slug}`, { slug });
+  }
+
+  const isMember = await workingGroupDb.isMember(group.id, user.id);
+  if (!isMember) {
+    throw new WorkingGroupContentError('not_member', 'Only members can update documents in this committee', { slug });
+  }
+
+  const existingDoc = await workingGroupDb.getDocumentById(documentId);
+  if (!existingDoc || existingDoc.working_group_id !== group.id) {
+    throw new WorkingGroupContentError('document_not_found', 'Document not found in this committee', {
+      slug,
+      documentId,
+    });
+  }
+
+  if (documentUrl !== undefined && !isAllowedDocumentUrl(documentUrl)) {
+    throw new WorkingGroupContentError(
+      'invalid_document_url',
+      'Only Google Docs, Sheets, Drive URLs, and direct links to PDFs/PPTX/XLSX/DOCX from trusted hosts are supported',
+      { slug },
+    );
+  }
+
+  const document = await workingGroupDb.updateDocument(documentId, {
+    title,
+    description,
+    document_url: documentUrl,
+    document_type: documentType,
+    display_order: displayOrder,
+    is_featured: isFeatured,
+  });
+
+  if (!document) {
+    throw new WorkingGroupContentError('document_not_found', 'Document not found', { slug, documentId });
+  }
+
+  // Refresh in-memory search index so Addie sees updated metadata.
+  refreshWorkingGroupDocs().catch((err) =>
+    logger.warn({ err, documentId }, 'Background refresh after document update failed'),
+  );
+
+  const { file_data: _fd, last_content: _lc, ...documentMeta } = document;
+  return { document: documentMeta, groupName: group.name, groupSlug: group.slug };
+}
+
+// ─── Document delete ──────────────────────────────────────────────────
+
+export interface DeleteCommitteeDocumentInput {
+  user: WorkingGroupServiceUser;
+  slug: string;
+  documentId: string;
+}
+
+export interface DeleteCommitteeDocumentResult {
+  groupName: string;
+  groupSlug: string;
+}
+
+/**
+ * Delete requires committee leader privileges. Member-only callers get
+ * `not_leader` so adapters can route them to a leader or an editorial
+ * flow rather than guessing why deletion failed.
+ */
+export async function deleteCommitteeDocument(
+  input: DeleteCommitteeDocumentInput,
+): Promise<DeleteCommitteeDocumentResult> {
+  const { user, slug, documentId } = input;
+
+  if (!isUuid(documentId)) {
+    throw new WorkingGroupContentError('invalid_document_id', 'Document ID must be a valid UUID', {
+      slug,
+      documentId,
+    });
+  }
+
+  const group = await workingGroupDb.getWorkingGroupBySlug(slug);
+  if (!group) {
+    throw new WorkingGroupContentError('group_not_found', `No committee found with slug: ${slug}`, { slug });
+  }
+
+  const isLeader = await workingGroupDb.isLeader(group.id, user.id);
+  if (!isLeader) {
+    throw new WorkingGroupContentError('not_leader', 'Only committee leaders can delete documents', { slug });
+  }
+
+  const existingDoc = await workingGroupDb.getDocumentById(documentId);
+  if (!existingDoc || existingDoc.working_group_id !== group.id) {
+    throw new WorkingGroupContentError('document_not_found', 'Document not found in this committee', {
+      slug,
+      documentId,
+    });
+  }
+
+  await workingGroupDb.deleteDocument(documentId);
+  logger.info({ documentId, groupSlug: slug }, 'Committee document deleted');
+
+  // Remove from in-memory search index.
+  refreshWorkingGroupDocs().catch((err) =>
+    logger.warn({ err, documentId }, 'Background refresh after document delete failed'),
+  );
+
+  return { groupName: group.name, groupSlug: group.slug };
+}


### PR DESCRIPTION
## Summary

Part 2 of #3736 — fixes the remaining 4 of 7 silently-CSRF-blocked Addie state-change tools. PR #3741 covered membership/interest. This covers posts + documents.

| Tool | What members saw | Now |
|---|---|---|
| `create_working_group_post` | *"You're not a member of {slug}"* — even for actual members | success / structured error per code |
| `add_committee_document` | *"You're not a member of {slug} committee"* | success / structured error per code |
| `update_committee_document` | *"You're not a member"* / *"Document not found"* conflated | distinct `invalid_document_id` / `document_not_found` / `not_member` |
| `delete_committee_document` | *"You're not a leader of {slug}"* — even for actual leaders | leader-checked correctly via service |

## Approach

Same as part 1: extract a shared service, both surfaces consume it directly, errors are a discriminated union. New file `server/src/services/working-group-content-service.ts`:

- `createWorkingGroupPost` — runs the perspectives insert, leader-only `is_members_only` enforcement, post-slug validation, duplicate-key detection, and Slack channel notification.
- `addCommitteeDocument` — SSRF allowlist check, `WorkingGroupDatabase.createDocument`, Slack notification, immediate index trigger.
- `updateCommitteeDocument` — UUID + URL validation, ownership check (document belongs to that committee), update + index refresh.
- `deleteCommitteeDocument` — UUID validation, leader check, ownership check, delete + index refresh.

Errors as `WorkingGroupContentError` with codes: `group_not_found`, `not_member`, `not_leader`, `leader_required_for_public_post`, `missing_required_fields`, `invalid_post_slug`, `invalid_document_url`, `invalid_document_id`, `document_not_found`, `duplicate_post_slug`.

The route's `isAllowedDocumentUrl` helper + its three allowlist constants moved into the service so the route and Addie share a single SSRF allowlist. The Addie tools keep their friendlier Google-only pre-check (it fires before the broader service-level allowlist for chat callers). Service still re-validates — defense in depth.

## Test plan

- [x] Typecheck clean.
- [x] `tests/` unit suite: 849 passing.
- [x] `server/tests/unit/`: 2997 passing.
- [x] Lint (no-dynamic-project-import + no-reset-modules): clean.
- [x] **Live end-to-end smoke against local docker** — all 8 branches verified:
  - post unknown group → "Working group not found"
  - post success → "Post created successfully"
  - doc add unknown group → "Committee not found"
  - doc add bad URL → friendly Google-only message (Addie pre-check fires before service allowlist)
  - doc add success → "Document added"
  - doc update invalid id → "Invalid document ID format"
  - doc update no fields → "No fields to update"
  - doc delete not-leader → "You're not a leader" (real leader check, not CSRF)

## Closes the Addie-side half of #3736

All 7 affected tools now route through service layers. Part 3 (lock down `callApi` POST/PUT/DELETE/PATCH so future Addie tools physically cannot reintroduce the bug class) is the final follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)