### PR TITLE
docs: title storyboards page so docs search finds it

### DIFF
--- a/.changeset/storyboard-validate-page-title.md
+++ b/.changeset/storyboard-validate-page-title.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs: retitle "Validate Your Agent" to "Validate your agent using storyboards" so Mintlify search surfaces it for the query "storyboards" instead of the troubleshooting page.

--- a/docs/building/validate-your-agent.mdx
+++ b/docs/building/validate-your-agent.mdx
@@ -1,8 +1,8 @@
 ---
-title: Validate Your Agent
+title: Validate your agent using storyboards
 sidebarTitle: Validate Your Agent
 description: "Test your AdCP agent with storyboards — from the CLI or through Addie."
-"og:title": "AdCP — Validate Your Agent"
+"og:title": "AdCP — Validate your agent using storyboards"
 ---
 
 Once your agent is running, validate it before going live. Storyboards exercise a specific workflow end-to-end — media buy creation, creative sync, signals discovery. Each storyboard defines the exact tool call sequence a buyer agent makes and validates every response shape.


### PR DESCRIPTION
## Summary

- Searching docs.adcontextprotocol.org for "storyboards" returned `storyboard-troubleshooting` first, because no other page had "storyboards" in its title.
- The canonical "how do I use storyboards" page (`docs/building/validate-your-agent.mdx`) was titled "Validate Your Agent" — Mintlify search couldn't tell it was the storyboards page.
- Retitle to "Validate your agent using storyboards" (page title + og:title only). Sidebar label and file path are unchanged, so all inbound links keep working.

## Test plan

- [ ] After deploy, search docs for "storyboards" — `validate-your-agent` should rank above `storyboard-troubleshooting`.
- [ ] Sidebar still reads "Validate Your Agent" in the Building > Conformance group.
- [ ] Existing inbound links from `building/index.mdx`, `conformance.mdx`, `get-test-ready.mdx`, and `storyboard-troubleshooting.mdx` still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)