### PR TITLE
fix(schema): make account.supported_billing conditional on media_buy protocol

### DIFF
--- a/.changeset/fix-capabilities-billing-conditional-requirement.md
+++ b/.changeset/fix-capabilities-billing-conditional-requirement.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix `account.supported_billing` schema: require it only when `media_buy` is in `supported_protocols`, not unconditionally for all agents. Adds root-level `allOf` if/then guard following the existing `sync-plans-request.json` pattern. Non-media-buy agent authors should note that `supported_billing` was previously enforced on any `account` block — SDKs using code generators that drop draft-07 `if/then` (openapi-typescript, zod-to-json-schema, quicktype) should add a runtime guard to require `supported_billing` when `account` is present and `media_buy` is declared.

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -91,7 +91,7 @@
     },
     "account": {
       "type": "object",
-      "description": "Account management capabilities. Describes how accounts are established, what billing models are supported, and whether an account is required before browsing products.",
+      "description": "Account management capabilities. Required when media_buy is in supported_protocols; optional otherwise. Describes how accounts are established, what billing models are supported, and whether an account is required before browsing products.",
       "properties": {
         "require_operator_auth": {
           "type": "boolean",
@@ -126,12 +126,11 @@
           "description": "Whether this seller supports sandbox accounts for testing. Buyers can provision a sandbox account via sync_accounts with sandbox: true, and all requests using that account_id will be treated as sandbox — no real platform calls or spend.",
           "default": false
         }
-      },
-      "required": ["supported_billing"]
+      }
     },
     "media_buy": {
       "type": "object",
-      "description": "Media-buy protocol capabilities. Expected when media_buy is in supported_protocols. Sellers declaring media_buy should also include account with supported_billing.",
+      "description": "Media-buy protocol capabilities. Expected when media_buy is in supported_protocols. Sellers declaring media_buy MUST include account with supported_billing.",
       "properties": {
         "supported_pricing_models": {
           "type": "array",
@@ -1024,6 +1023,27 @@
   "required": [
     "adcp",
     "supported_protocols"
+  ],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "supported_protocols": {
+            "type": "array",
+            "contains": { "const": "media_buy" }
+          }
+        },
+        "required": ["supported_protocols"]
+      },
+      "then": {
+        "required": ["account"],
+        "properties": {
+          "account": {
+            "required": ["supported_billing"]
+          }
+        }
+      }
+    }
   ],
   "additionalProperties": true
 }


### PR DESCRIPTION
Closes #3746

## Summary

The `get_adcp_capabilities` response schema required `account.supported_billing` unconditionally for all agents, even those that don't declare `media_buy` in `supported_protocols`. The field has no semantics outside of media buying (operator-pays / advertiser-pays arrangements), and the schema's own description already stated "Expected when media_buy is in supported_protocols." This mismatch caused every non-media-buy agent (signals, creative, governance, brand, SI, measurement) that included an `account` block to fail schema validation on a single irrelevant field, which cascades into SDK v2-downgrade loops and storyboard failures across the board.

**Changes:**
1. Removes `"required": ["supported_billing"]` from the `account` object definition — it was enforced unconditionally on any agent that included an `account` block.
2. Adds a root-level `allOf` `if/then` constraint: `account` and `account.supported_billing` are required only when `supported_protocols` contains `"media_buy"`. Uses the same `contains: { const: "..." }` + `required: [...]` guard pattern as `governance/sync-plans-request.json`.
3. Updates `account.description` to surface the conditional rule at first read.
4. Updates `media_buy.description` from "should include" to "MUST include" — the `if/then` now normatively enforces it.

**Non-breaking justification:** Relaxes a constraint for non-media-buy agents (they may now omit `supported_billing` from an `account` block without failing validation). Preserves the constraint for media-buy agents via the `then` branch. Any conformant 3.0.0 media-buy implementation already satisfies the new MUST — the description established the expectation; the schema constraint now aligns with it.

**Code-generator note:** draft-07 `if/then` is dropped by openapi-typescript, zod-to-json-schema, datamodel-code-generator pre-0.25, and quicktype. SDK generator targets should add a runtime guard requiring `supported_billing` when `media_buy` is declared and `account` is present. (The same caveat already applies to `adcp.idempotency`'s `oneOf` in this schema per its existing inline comment.)

## Pre-PR review

- **code-reviewer:** approved — JSON Schema draft-07 valid, `allOf` placement correct, `then.properties.account.required` correctly overlays root `account` definition; redundant `required: ["supported_protocols"]` guard inside `if` is harmless (root-level `required` already enforces it); `patch` changeset level correct.
- **ad-tech-protocol-expert:** approved — non-breaking per spec; `then.properties.account` type guard technically redundant given root-level `"type": "object"` on `account` (and the established repo pattern in `sync-plans-request.json` doesn't add type guards either); description nits addressed in this diff.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01VE9kbAjX6nAmAruFXbUeka

---
_Generated by [Claude Code](https://claude.ai/code/session_01VE9kbAjX6nAmAruFXbUeka)_