### PR TITLE
fix(addie): replace GET-loopback callApi with service layer for three auth-gated tools

### DIFF
--- a/.changeset/fix-get-loopback-auth-read-services.md
+++ b/.changeset/fix-get-loopback-auth-read-services.md
@@ -1,0 +1,18 @@
+---
+---
+
+Fix three Addie GET-loopback tools that silently 401 against `requireAuth` routes — service-layer extraction (issue #3748, read-tool variant of #3736).
+
+**Root cause:** `callApi('GET', '/api/me/…', memberContext)` constructs an HTTP request with no auth credentials (no session cookie, no bearer). The routes at `GET /api/me/working-groups`, `GET /api/me/working-groups/interests`, and `GET /api/me/content` all use `requireAuth` middleware, which returns 401. Members asking Addie about their own data see _"Authentication required"_ instead of their actual data.
+
+**Fix — same service-layer pattern as PRs #3741 / #3743 / #3747:**
+
+- `get_my_working_groups` → calls `WorkingGroupDatabase.getWorkingGroupsForUser(userId)` directly (`wgDb` was already instantiated at module scope in `member-tools.ts`).
+- `get_my_council_interests` → new `WorkingGroupDatabase.getCouncilInterestsForUser(userId)` method; route updated to use it too, eliminating the duplicated inline `pool.query`.
+- `get_my_content` → new `services/member-content-service.ts` (`listContentForUser`) shared by both the Addie tool (no pageview enrichment, `isAdmin: false`) and the web route (`listContentForWebUser` wrapper that resolves `isAdmin` and enables pageviews).
+
+The `relationship` filter is preserved in application code inside the service (cannot be pushed to SQL — the `is_author / is_proposer / is_lead` columns are computed expressions, not stored values).
+
+Bumps `CODE_VERSION` to `2026.05.1` (tool implementation change).
+
+**Deferred:** the optional `callApi('GET', '/api/me/…')` lint rule extension (see issue #3748 acceptance criteria) is a follow-on — it needs `/api/me/` scoping to avoid false positives on the 8 public-route GET callers that are unaffected.

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.04.6';
+export const CODE_VERSION = '2026.05.1';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -95,6 +95,7 @@ import { issueDomainChallenge, verifyDomainChallenge } from '../../services/bran
 import { getWorkos } from '../../auth/workos-client.js';
 import { resolveUserRole } from '../../utils/resolve-user-role.js';
 import { recordAgentTestRun } from '../../db/agent-test-db.js';
+import { listContentForUser } from '../../services/member-content-service.js';
 
 const memberDb = new MemberDatabase();
 const agentContextDb = new AgentContextDatabase();
@@ -1732,19 +1733,7 @@ export function createMemberToolHandlers(
       return 'You need to be logged in to see your working groups. Please log in at https://agenticadvertising.org/dashboard first.';
     }
 
-    const result = await callApi('GET', '/api/me/working-groups', memberContext);
-
-    if (!result.ok) {
-      throw new ToolError(`Failed to fetch your working groups: ${result.error}`);
-    }
-
-    const data = result.data as { working_groups: Array<{
-      name: string;
-      slug: string;
-      committee_type: string;
-      is_private: boolean;
-    }> };
-    const groups = data.working_groups;
+    const groups = await wgDb.getWorkingGroupsForUser(memberContext.workos_user.workos_user_id);
 
     if (!groups || groups.length === 0) {
       return "You're not a member of any working groups yet. Use list_working_groups to find groups to join!";
@@ -1815,18 +1804,7 @@ export function createMemberToolHandlers(
       return 'You need to be logged in to see your council interests. Please log in at https://agenticadvertising.org/dashboard first.';
     }
 
-    const result = await callApi('GET', '/api/me/working-groups/interests', memberContext);
-
-    if (!result.ok) {
-      throw new ToolError(`Failed to fetch your council interests: ${result.error}`);
-    }
-
-    const interests = result.data as Array<{
-      committee_name: string;
-      slug: string;
-      interest_level: string;
-      created_at: string;
-    }>;
+    const interests = await wgDb.getCouncilInterestsForUser(memberContext.workos_user.workos_user_id);
 
     if (interests.length === 0) {
       return "You haven't expressed interest in any councils yet. Use list_working_groups with type \"council\" to see available councils!";
@@ -2805,35 +2783,25 @@ export function createMemberToolHandlers(
     const collection = input.collection as string | undefined;
     const relationship = input.relationship as string | undefined;
 
-    // Build query string
-    const params = new URLSearchParams();
-    if (status && status !== 'all') params.set('status', status);
-    if (collection) params.set('collection', collection);
-    if (relationship) params.set('relationship', relationship);
+    // Call the service directly — no HTTP loopback (issue #3748).
+    // isAdmin: false because Addie tools are always scoped to the authenticated
+    // member; includePageviews: false because the tool never renders pageview counts.
+    const serviceResult = await listContentForUser({
+      userId: memberContext.workos_user.workos_user_id,
+      isAdmin: false,
+      status,
+      collection,
+      relationship,
+      includePageviews: false,
+    });
 
-    const queryString = params.toString() ? `?${params.toString()}` : '';
-    const result = await callApi('GET', `/api/me/content${queryString}`, memberContext);
-
-    if (!result.ok) {
-      throw new ToolError(`Failed to fetch your content: ${result.error}`);
+    if (!serviceResult.ok) {
+      throw new ToolError(
+        `Invalid status filter. Must be one of: ${serviceResult.validStatuses.join(', ')}, or 'all'`,
+      );
     }
 
-    const data = result.data as {
-      items: Array<{
-        id: string;
-        slug: string;
-        title: string;
-        status: string;
-        content_type: string;
-        collection: { type: string; committee_name?: string; committee_slug?: string };
-        relationships: string[];
-        authors: Array<{ display_name: string }>;
-        published_at?: string;
-        created_at: string;
-      }>;
-    };
-
-    if (data.items.length === 0) {
+    if (serviceResult.items.length === 0) {
       let response = "You don't have any content yet.\n\n";
       response += 'Use `propose_content` to create your first article or perspective!';
       return response;
@@ -2842,8 +2810,8 @@ export function createMemberToolHandlers(
     let response = `## Your Content\n\n`;
 
     // Group by status
-    const byStatus: Record<string, typeof data.items> = {};
-    for (const item of data.items) {
+    const byStatus: Record<string, typeof serviceResult.items> = {};
+    for (const item of serviceResult.items) {
       if (!byStatus[item.status]) byStatus[item.status] = [];
       byStatus[item.status].push(item);
     }

--- a/server/src/db/working-group-db.ts
+++ b/server/src/db/working-group-db.ts
@@ -1039,6 +1039,31 @@ export class WorkingGroupDatabase {
   }
 
   /**
+   * Get all councils/committees the user has expressed interest in.
+   *
+   * Shared by GET /api/me/working-groups/interests (route) and the
+   * get_my_council_interests Addie tool so both surfaces return identical
+   * data without an HTTP loopback (issue #3748).
+   */
+  async getCouncilInterestsForUser(userId: string): Promise<Array<{
+    interest_level: string;
+    created_at: string;
+    committee_name: string;
+    slug: string;
+    committee_type: string;
+  }>> {
+    const result = await query(
+      `SELECT ci.interest_level, ci.created_at, wg.name as committee_name, wg.slug, wg.committee_type
+       FROM committee_interest ci
+       JOIN working_groups wg ON wg.id = ci.working_group_id
+       WHERE ci.workos_user_id = $1
+       ORDER BY ci.created_at DESC`,
+      [userId]
+    );
+    return result.rows;
+  }
+
+  /**
    * Get all working groups that users from an organization are members of
    * (for displaying on org member profiles)
    */

--- a/server/src/routes/committees.ts
+++ b/server/src/routes/committees.ts
@@ -2844,18 +2844,8 @@ export function createCommitteeRouters(): {
   userApiRouter.get('/interests', requireAuth, async (req: Request, res: Response) => {
     try {
       const user = req.user!;
-      const pool = getPool();
-
-      const result = await pool.query(
-        `SELECT ci.interest_level, ci.created_at, wg.name as committee_name, wg.slug, wg.committee_type
-         FROM committee_interest ci
-         JOIN working_groups wg ON wg.id = ci.working_group_id
-         WHERE ci.workos_user_id = $1
-         ORDER BY ci.created_at DESC`,
-        [user.id]
-      );
-
-      res.json(result.rows);
+      const interests = await workingGroupDb.getCouncilInterestsForUser(user.id);
+      res.json(interests);
     } catch (error) {
       logger.error({ err: error }, 'Get user council interests error');
       res.status(500).json({

--- a/server/src/routes/content.ts
+++ b/server/src/routes/content.ts
@@ -23,7 +23,7 @@ import { escapeSlackText } from '../utils/slack-escape.js';
 import { computeJourneyStage } from '../addie/services/journey-computation.js';
 import { CommunityDatabase } from '../db/community-db.js';
 import { createAsset } from '../db/perspective-asset-db.js';
-import { fetchPathPageviewCounts } from '../services/posthog-query.js';
+import { listContentForWebUser } from '../services/member-content-service.js';
 import { safeFetch } from '../utils/url-security.js';
 import { generateIllustration } from '../services/illustration-generator.js';
 import { createIllustration, approveIllustration } from '../db/illustration-db.js';
@@ -1390,138 +1390,17 @@ export function createMyContentRouter(): Router {
       const collection = req.query.collection as string | undefined;
       const relationship = req.query.relationship as string | undefined;
       const limit = Math.min(parseInt(req.query.limit as string) || 50, 100);
-      const pool = getPool();
 
-      // Get committees user leads (for "owner" relationship)
-      const leaderResult = await pool.query(
-        `SELECT working_group_id FROM working_group_leaders WHERE user_id = $1`,
-        [user.id]
-      );
-      const ledCommitteeIds = leaderResult.rows.map(r => r.working_group_id);
+      const result = await listContentForWebUser(user.id, { status, collection, relationship, limit });
 
-      // Admins can see every perspective here so they can edit anything
-      // (including content that predates them, has no proposer, or belongs to a
-      // committee they don't lead). Relationships are still computed so the UI
-      // can still distinguish their own contributions.
-      const userIsAdmin = await isWebUserAAOAdmin(user.id);
-
-      // Build the query
-      let query = `
-        SELECT DISTINCT ON (p.id)
-          p.id, p.slug, p.content_type, p.title, p.subtitle, p.category, p.excerpt,
-          p.content, p.tags, p.featured_image_url,
-          p.external_url, p.external_site_name, p.status, p.published_at,
-          p.created_at, p.updated_at, p.working_group_id, p.proposer_user_id,
-          wg.name as committee_name, wg.slug as committee_slug,
-          -- Determine relationships
-          CASE WHEN p.proposer_user_id = $1 THEN true ELSE false END as is_proposer,
-          CASE WHEN EXISTS (SELECT 1 FROM content_authors ca WHERE ca.perspective_id = p.id AND ca.user_id = $1) THEN true ELSE false END as is_author,
-          CASE WHEN p.working_group_id = ANY($2) THEN true ELSE false END as is_lead,
-          -- Get authors
-          (SELECT json_agg(json_build_object(
-            'user_id', ca.user_id,
-            'display_name', ca.display_name,
-            'display_title', ca.display_title
-          ) ORDER BY ca.display_order)
-          FROM content_authors ca WHERE ca.perspective_id = p.id) as authors
-        FROM perspectives p
-        LEFT JOIN working_groups wg ON wg.id = p.working_group_id
-        WHERE (
-          $3::boolean = true
-          OR p.proposer_user_id = $1
-          OR EXISTS (SELECT 1 FROM content_authors ca WHERE ca.perspective_id = p.id AND ca.user_id = $1)
-          OR p.working_group_id = ANY($2)
-        )
-      `;
-      const params: (string | string[] | number | boolean)[] = [user.id, ledCommitteeIds, userIsAdmin];
-
-      // Apply filters
-      if (status && status !== 'all') {
-        const validStatuses = ['draft', 'pending_review', 'published', 'archived', 'rejected'];
-        if (!validStatuses.includes(status)) {
-          return res.status(400).json({
-            error: 'Invalid status',
-            message: `status must be one of: ${validStatuses.join(', ')}, or 'all'`,
-          });
-        }
-        params.push(status);
-        query += ` AND p.status = $${params.length}`;
+      if (!result.ok) {
+        return res.status(400).json({
+          error: 'Invalid status',
+          message: `status must be one of: ${result.validStatuses.join(', ')}, or 'all'`,
+        });
       }
 
-      if (collection) {
-        if (collection === 'personal') {
-          query += ` AND p.working_group_id IS NULL`;
-        } else {
-          // Assume it's a committee slug
-          params.push(collection);
-          query += ` AND wg.slug = $${params.length}`;
-        }
-      }
-
-      query += ` ORDER BY p.id, p.created_at DESC`;
-      params.push(limit);
-      query += ` LIMIT $${params.length}`;
-
-      const result = await pool.query(query, params);
-
-      // Format response with relationships
-      const items = result.rows.map(row => {
-        const relationships: string[] = [];
-        if (row.is_author) relationships.push('author');
-        if (row.is_proposer) relationships.push('proposer');
-        if (row.is_lead) relationships.push('owner');
-
-        return {
-          id: row.id,
-          slug: row.slug,
-          title: row.title,
-          subtitle: row.subtitle,
-          content_type: row.content_type,
-          category: row.category,
-          excerpt: row.excerpt,
-          content: row.content,
-          tags: row.tags,
-          featured_image_url: row.featured_image_url,
-          external_url: row.external_url,
-          external_site_name: row.external_site_name,
-          status: row.status,
-          collection: {
-            type: row.working_group_id ? 'committee' : 'personal',
-            committee_name: row.committee_name,
-            committee_slug: row.committee_slug,
-          },
-          relationships,
-          authors: row.authors || [],
-          published_at: row.published_at,
-          created_at: row.created_at,
-          updated_at: row.updated_at,
-        };
-      }).filter(item => {
-        // Apply relationship filter if specified
-        if (!relationship) return true;
-        return item.relationships.includes(relationship);
-      });
-
-      const publishedPaths = items
-        .filter(item => item.status === 'published' && typeof item.slug === 'string' && item.slug.length > 0)
-        .map(item => `/perspectives/${item.slug}`);
-
-      const pageviewCounts = await fetchPathPageviewCounts(publishedPaths, 30);
-
-      const itemsWithPerformance = items.map(item => {
-        if (item.status !== 'published' || !item.slug || !pageviewCounts) {
-          return item;
-        }
-
-        return {
-          ...item,
-          performance: {
-            pageviews_last_30d: pageviewCounts[`/perspectives/${item.slug}`] ?? 0,
-          },
-        };
-      });
-
-      res.json({ items: itemsWithPerformance });
+      res.json({ items: result.items });
     } catch (error) {
       logger.error({ err: error }, 'GET /api/me/content error');
       res.status(500).json({

--- a/server/src/services/member-content-service.ts
+++ b/server/src/services/member-content-service.ts
@@ -1,0 +1,211 @@
+/**
+ * Member content service.
+ *
+ * Shared by:
+ *  - GET /api/me/content                (web/API)
+ *  - get_my_content Addie tool          (chat)
+ *
+ * Centralises the query so the route and Addie tool produce identical results
+ * and can't drift apart. Replaces a previous server-to-self HTTP loopback in
+ * `callApi` that was rejected by `requireAuth` middleware (issue #3748).
+ *
+ * IMPORTANT: `userId` must be the authenticated user's own id. This function
+ * does not perform impersonation — passing a different user's id will return
+ * that user's content without access control. The callers (route via `req.user`
+ * and Addie tool via `memberContext.workos_user`) both enforce this invariant.
+ */
+
+import { getPool } from '../db/client.js';
+import { fetchPathPageviewCounts } from './posthog-query.js';
+import { isWebUserAAOAdmin } from '../addie/mcp/admin-tools.js';
+
+export interface ContentItem {
+  id: string;
+  slug: string;
+  title: string;
+  subtitle: string | null;
+  content_type: string;
+  category: string | null;
+  excerpt: string | null;
+  content: string | null;
+  tags: string[] | null;
+  featured_image_url: string | null;
+  external_url: string | null;
+  external_site_name: string | null;
+  status: string;
+  collection: {
+    type: 'committee' | 'personal';
+    committee_name: string | null;
+    committee_slug: string | null;
+  };
+  relationships: string[];
+  authors: Array<{ user_id: string; display_name: string; display_title: string | null }>;
+  published_at: string | null;
+  created_at: string;
+  updated_at: string;
+  performance?: { pageviews_last_30d: number };
+}
+
+export interface ListContentForUserOptions {
+  userId: string;
+  /** Pass isWebUserAAOAdmin(userId) from the route; always false from Addie tool. */
+  isAdmin: boolean;
+  status?: string;
+  collection?: string;
+  relationship?: string;
+  limit?: number;
+  /** Set true for the web route (PostHog enrichment); false for Addie (skips external I/O). */
+  includePageviews?: boolean;
+}
+
+export type ListContentForUserResult =
+  | { ok: true; items: ContentItem[] }
+  | { ok: false; error: 'invalid_status'; validStatuses: string[] };
+
+export async function listContentForUser(
+  opts: ListContentForUserOptions,
+): Promise<ListContentForUserResult> {
+  const { userId, isAdmin, status, collection, relationship } = opts;
+  const limit = Math.min(opts.limit ?? 50, 100);
+  const includePageviews = opts.includePageviews ?? false;
+  const pool = getPool();
+
+  // Get committees user leads (for "owner" relationship)
+  const leaderResult = await pool.query(
+    `SELECT working_group_id FROM working_group_leaders WHERE user_id = $1`,
+    [userId]
+  );
+  const ledCommitteeIds = leaderResult.rows.map((r: { working_group_id: string }) => r.working_group_id);
+
+  // Build the query
+  let sqlQuery = `
+    SELECT DISTINCT ON (p.id)
+      p.id, p.slug, p.content_type, p.title, p.subtitle, p.category, p.excerpt,
+      p.content, p.tags, p.featured_image_url,
+      p.external_url, p.external_site_name, p.status, p.published_at,
+      p.created_at, p.updated_at, p.working_group_id, p.proposer_user_id,
+      wg.name as committee_name, wg.slug as committee_slug,
+      -- Determine relationships
+      CASE WHEN p.proposer_user_id = $1 THEN true ELSE false END as is_proposer,
+      CASE WHEN EXISTS (SELECT 1 FROM content_authors ca WHERE ca.perspective_id = p.id AND ca.user_id = $1) THEN true ELSE false END as is_author,
+      CASE WHEN p.working_group_id = ANY($2) THEN true ELSE false END as is_lead,
+      -- Get authors
+      (SELECT json_agg(json_build_object(
+        'user_id', ca.user_id,
+        'display_name', ca.display_name,
+        'display_title', ca.display_title
+      ) ORDER BY ca.display_order)
+      FROM content_authors ca WHERE ca.perspective_id = p.id) as authors
+    FROM perspectives p
+    LEFT JOIN working_groups wg ON wg.id = p.working_group_id
+    WHERE (
+      $3::boolean = true
+      OR p.proposer_user_id = $1
+      OR EXISTS (SELECT 1 FROM content_authors ca WHERE ca.perspective_id = p.id AND ca.user_id = $1)
+      OR p.working_group_id = ANY($2)
+    )
+  `;
+  const params: (string | string[] | number | boolean)[] = [userId, ledCommitteeIds, isAdmin];
+
+  // Apply filters
+  if (status && status !== 'all') {
+    const validStatuses = ['draft', 'pending_review', 'published', 'archived', 'rejected'];
+    if (!validStatuses.includes(status)) {
+      return { ok: false, error: 'invalid_status', validStatuses };
+    }
+    params.push(status);
+    sqlQuery += ` AND p.status = $${params.length}`;
+  }
+
+  if (collection) {
+    if (collection === 'personal') {
+      sqlQuery += ` AND p.working_group_id IS NULL`;
+    } else {
+      params.push(collection);
+      sqlQuery += ` AND wg.slug = $${params.length}`;
+    }
+  }
+
+  sqlQuery += ` ORDER BY p.id, p.created_at DESC`;
+  params.push(limit);
+  sqlQuery += ` LIMIT $${params.length}`;
+
+  const result = await pool.query(sqlQuery, params);
+
+  // Format response with relationships
+  // The `relationship` filter is applied here in application code because the
+  // relationship columns are computed expressions (is_author, is_proposer,
+  // is_lead), not stored values — they cannot be pushed into the WHERE clause.
+  const items: ContentItem[] = result.rows.map((row: Record<string, unknown>) => {
+    const relationships: string[] = [];
+    if (row.is_author) relationships.push('author');
+    if (row.is_proposer) relationships.push('proposer');
+    if (row.is_lead) relationships.push('owner');
+
+    return {
+      id: row.id as string,
+      slug: row.slug as string,
+      title: row.title as string,
+      subtitle: row.subtitle as string | null,
+      content_type: row.content_type as string,
+      category: row.category as string | null,
+      excerpt: row.excerpt as string | null,
+      content: row.content as string | null,
+      tags: row.tags as string[] | null,
+      featured_image_url: row.featured_image_url as string | null,
+      external_url: row.external_url as string | null,
+      external_site_name: row.external_site_name as string | null,
+      status: row.status as string,
+      collection: {
+        type: row.working_group_id ? 'committee' : 'personal',
+        committee_name: row.committee_name as string | null,
+        committee_slug: row.committee_slug as string | null,
+      },
+      relationships,
+      authors: (row.authors as Array<{ user_id: string; display_name: string; display_title: string | null }>) || [],
+      published_at: row.published_at as string | null,
+      created_at: row.created_at as string,
+      updated_at: row.updated_at as string,
+    };
+  }).filter((item: ContentItem) => {
+    if (!relationship) return true;
+    return item.relationships.includes(relationship);
+  });
+
+  if (!includePageviews) {
+    return { ok: true, items };
+  }
+
+  // Pageview enrichment — only for the web route path (Addie skips this I/O).
+  const publishedPaths = items
+    .filter(item => item.status === 'published' && typeof item.slug === 'string' && item.slug.length > 0)
+    .map(item => `/perspectives/${item.slug}`);
+
+  const pageviewCounts = await fetchPathPageviewCounts(publishedPaths, 30);
+
+  const itemsWithPerformance = items.map(item => {
+    if (item.status !== 'published' || !item.slug || !pageviewCounts) {
+      return item;
+    }
+    return {
+      ...item,
+      performance: {
+        pageviews_last_30d: pageviewCounts[`/perspectives/${item.slug}`] ?? 0,
+      },
+    };
+  });
+
+  return { ok: true, items: itemsWithPerformance };
+}
+
+/**
+ * Convenience wrapper for the web route — resolves `isAdmin` from the DB so
+ * callers don't have to import `isWebUserAAOAdmin` separately.
+ */
+export async function listContentForWebUser(
+  userId: string,
+  opts: Omit<ListContentForUserOptions, 'userId' | 'isAdmin' | 'includePageviews'>,
+): Promise<ListContentForUserResult> {
+  const isAdmin = await isWebUserAAOAdmin(userId);
+  return listContentForUser({ ...opts, userId, isAdmin, includePageviews: true });
+}

--- a/tests/addie/member-tools.test.ts
+++ b/tests/addie/member-tools.test.ts
@@ -753,6 +753,8 @@ describe('createMemberToolHandlers', () => {
     const userScopedTools = [
       'join_working_group',
       'get_my_working_groups',
+      'get_my_council_interests',
+      'get_my_content',
       'get_my_profile',
       'update_my_profile',
       'get_company_listing',


### PR DESCRIPTION
Closes #3748

## Summary

Three Addie tools silently return "Authentication required" in production because `callApi('GET', '/api/me/…', memberContext)` makes an HTTP request with no credentials — no session cookie, no bearer — and the routes use `requireAuth` middleware.

This is the **read-tool variant** of #3736: same loopback-without-creds pattern, different middleware (auth instead of CSRF). Fixes all three using the service-layer extraction pattern established by PRs #3741 / #3743 / #3747.

| Tool | Old path | New path |
|---|---|---|
| `get_my_working_groups` | `callApi('GET', '/api/me/working-groups')` → 401 | `wgDb.getWorkingGroupsForUser(userId)` (method already existed) |
| `get_my_council_interests` | `callApi('GET', '/api/me/working-groups/interests')` → 401 | `wgDb.getCouncilInterestsForUser(userId)` (new DB method) |
| `get_my_content` | `callApi('GET', '/api/me/content?…')` → 401 | `listContentForUser({userId, isAdmin: false, …})` (new service) |

### `get_my_council_interests`
Added `WorkingGroupDatabase.getCouncilInterestsForUser(userId)` — a pure read with a JOIN, no side effects. Belongs in the DB class alongside `getWorkingGroupsForUser` / `getCommitteesLedByUser`. Updated `GET /api/me/working-groups/interests` route to use it too, eliminating the duplicated inline `pool.query`.

### `get_my_content`
New `services/member-content-service.ts` with `listContentForUser({userId, isAdmin, status?, collection?, relationship?, limit?, includePageviews?})`. Design decisions:
- `isAdmin` is a caller-declared parameter, not resolved inside the service — the service has no concept of "current session." Route passes `isWebUserAAOAdmin(userId)`; Addie tool passes `false` (correct: `get_my_content` is "content where I have a relationship," not "all content").
- `relationship` filter preserved in application code — `is_author / is_proposer / is_lead` are computed columns, not stored values; they cannot be pushed into the WHERE clause.
- `includePageviews: false` for Addie path — the tool formatter never renders `performance.pageviews_last_30d`, so the PostHog round-trip is unnecessary I/O.
- `listContentForWebUser(userId, opts)` convenience wrapper for the route: resolves `isAdmin` and enables pageviews.

## Non-breaking justification

Server-side behavior fix only. No schema changes, no API contract changes, no new capabilities. `callApi` remains GET-only (the state-change lockdown from PR #3747 is unchanged). No `system bearer` or `X-Addie-Effective-User` capability introduced.

## Pre-PR review

- **code-reviewer:** approved — no blockers. Nits: `DISTINCT ON (p.id)` is a no-op (pre-existing, faithfully carried over); `content` body fetched but unused in Addie path (pre-existing behavior, follow-on opportunity); auth-gate test matrix was missing `get_my_council_interests` and `get_my_content` (fixed in second commit).
- **internal-tools-strategist:** approved — `isAdmin: false` is the right semantic choice for `get_my_content`; `listContentForWebUser` wrapper split is correct; `isWebUserAAOAdmin` import direction is pre-existing architecture debt, not introduced here.

## Nits surfaced (tracked, not fixed here)

- `DISTINCT ON (p.id)` in the extracted SQL is a no-op (primary key, no fan-out from the LEFT JOIN). Correctness holds; minor planner overhead only at large volumes. Follow-on.
- Full `p.content` body is fetched on the Addie path but the formatter ignores it. Not a context-window risk (raw object never serialized into prompt). Follow-on.
- Handler-level tests for the three fixed tools (spy on `wgDb` / `listContentForUser`). Not a regression risk since the prior behavior was a silent 401. Follow-on per playbook Priority 5.
- Optional `callApi('GET', '/api/me/…')` lint rule (issue #3748 acceptance criteria, last checkbox): deferred — needs `/api/me/` scoping to avoid false positives on the 8 public-route GET callers. Separate issue.

> **Triage-managed PR.** This bot does not currently iterate on review comments or PR conversation threads (only on the source issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` → fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121) for context.

Session: https://claude.ai/code/session_016BDFCCcT1f5pSkVcaqiYQw

---
_Generated by [Claude Code](https://claude.ai/code/session_016BDFCCcT1f5pSkVcaqiYQw)_