### PR TITLE
feat(registry): add optional `tracks_silent` to ComplianceRun schema

### DIFF
--- a/.changeset/add-tracks-silent-compliance-run.md
+++ b/.changeset/add-tracks-silent-compliance-run.md
@@ -1,0 +1,25 @@
+---
+"adcontextprotocol": minor
+---
+
+feat(registry): add optional `tracks_silent` to `ComplianceRun` schema
+
+Adds an optional `tracks_silent: integer` field to `ComplianceRun` in
+`openapi/registry.yaml`, alongside the existing `tracks_passed`,
+`tracks_failed`, `tracks_skipped`, and `tracks_partial` fields.
+
+`tracks_silent` counts tracks where every observation-based invariant ran
+but received no lifecycle resource events during the run — configured but
+not exercised. Counting these separately from `tracks_passed` lets
+dashboards avoid over-crediting silent tracks as real protection.
+
+The field is **optional** (not in `required:`) for back-compat with runs
+persisted before SDK 6.4.0 (`adcp-client#1163`), which widened
+`TrackStatus` with `'silent'` and started emitting `tracks_silent` in
+`ComplianceSummary`. Without this schema addition, downstream services
+deserialize pre-existing runs with `tracks_silent: undefined` and cannot
+render silent rows distinctly.
+
+Non-breaking: adds an optional field; existing consumers unaffected.
+
+Closes #3752.

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -1418,6 +1418,14 @@ components:
           type: integer
         tracks_partial:
           type: integer
+        tracks_silent:
+          type: integer
+          description: |-
+            Tracks that were configured and executed but produced no
+            lifecycle resource events during the run. Counted separately
+            from tracks_passed so dashboards can avoid over-crediting
+            silent tracks as real protection. Optional for back-compat
+            with runs persisted before SDK 6.4.
         tracks_json: {}
         total_duration_ms:
           type:


### PR DESCRIPTION
Closes #3752

## Summary

Adds `tracks_silent: integer` (optional, not in `required:`) to `ComplianceRun` in `static/openapi/registry.yaml`, alongside the existing `tracks_passed`, `tracks_failed`, `tracks_skipped`, and `tracks_partial` fields.

`adcp-client` 6.4.0 ([adcp-client#1163](https://github.com/adcontextprotocol/adcp-client/pull/1163)) widened `TrackStatus` with `'silent'` and started emitting `tracks_silent` in `ComplianceSummary`. Without this schema addition, downstream services deserialize persisted runs with `tracks_silent: undefined` and dashboards cannot render silent rows distinctly from passing ones.

The field is **optional** (omitted from `required:`) for back-compat with runs persisted before SDK 6.4. Companion grader-rendering work is tracked separately in [#2834](https://github.com/adcontextprotocol/adcp/issues/2834).

**Non-breaking justification:** Adds an optional field to an existing object schema. Existing consumers and pre-6.4 persisted runs are unaffected; the field is absent (not null, not required) for old data.

**Changeset:** `minor` per the playbook ("MINOR: Add optional fields, new enum values, new tasks"). A pre-PR reviewer flagged this as `patch`; the playbook is explicit, so `minor` stands — reviewer can override if policy has changed.

**Build note:** Full `npm run build` could not be validated in this environment (4,133 pre-existing TS errors in `url-security.ts`/`validator.ts`, missing `js-yaml` dep). `node scripts/build-schemas.cjs` passed cleanly against the changed file.

**Follow-ons (nits, not blocking):**
- `TrackStatus` in `server/src/db/compliance-db.ts:15` does not yet include `'silent'`; needs updating before the grader (adcp#2834) emits per-track silent statuses.
- `tracks_*` peer fields have no `minimum: 0`; could be backfilled across all five fields in a follow-up.

## Pre-PR review

- **code-reviewer:** approved (1 nit: `minimum: 0` asymmetry; 1 disputed point: `minor` vs `patch` bump — resolved by playbook)
- **ad-tech-protocol-expert:** approved — non-breaking per spec; description is normative and unambiguous for downstream implementors

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01Ms8zMvPqV8XDWfGa5Ma6nV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ms8zMvPqV8XDWfGa5Ma6nV)_