### PR TITLE
feat(addie): fix three silently-401ing GET loopback tools (closes #3748)

### DIFF
--- a/.changeset/addie-read-loopback-fix.md
+++ b/.changeset/addie-read-loopback-fix.md
@@ -1,0 +1,21 @@
+---
+---
+
+Fix three GET-loopback Addie tools that were silently returning "Authentication required" because `callApi` sends no credentials and the routes require auth (issue #3748):
+
+- `get_my_working_groups` — was failing for every signed-in member.
+- `get_my_council_interests` — same.
+- `get_my_content` — same.
+
+Same root-cause shape as the state-change loopback bug class (#3736), different middleware (auth instead of CSRF). Fixed with the same pattern: extract a service that both the route and the Addie tool consume directly.
+
+New service functions:
+- `listMyWorkingGroups({userId})` — added to `working-group-membership-service`.
+- `listMyCommitteeInterests({userId})` — added to `working-group-membership-service`.
+- `listMyContent({userId, status, collection, relationship, limit})` — new `services/my-content-service.ts`. Throws `MyContentError` with `invalid_status` discriminator so adapters render the right message.
+
+The content service needed admin-status detection (admins see all perspectives in their content list), and importing `isWebUserAAOAdmin` from `addie/mcp/admin-tools.ts` would have pulled `relationship-orchestrator` → `engagement-planner` → Anthropic into the test import graph (same chain that broke `claude-client-cost-gate` in PR #3741). Lifted the function into a thin `addie/admin-status-lookup.ts` module; `admin-tools.ts` re-exports for existing callers.
+
+Closes #3748. The Addie loopback bug class is now fully resolved end-to-end:
+- State-change side: closed by PRs #3716, #3741, #3743, #3747 (locked down).
+- Read side: closed by this PR.

--- a/server/src/addie/admin-status-lookup.ts
+++ b/server/src/addie/admin-status-lookup.ts
@@ -1,0 +1,53 @@
+/**
+ * Web admin-status lookup for AAO admins.
+ *
+ * Extracted from `mcp/admin-tools.ts` so callers that only need to
+ * check `is the WorkOS user an admin?` can do so without dragging in
+ * relationship-orchestrator → engagement-planner → Anthropic at module
+ * load. Same motivation as `member-context-cache.ts` and
+ * `admin-status-cache.ts` (PR #3741) — keep the test import graph
+ * small and stop `admin-tools` from being a chokepoint that pulls
+ * heavy services into unrelated chains.
+ *
+ * The function body is the same membership-against-`aao-admin` check
+ * the original lived in admin-tools.ts; admin-tools.ts now re-exports
+ * from here so existing callers keep working.
+ */
+
+import { createLogger } from '../logger.js';
+import { WorkingGroupDatabase } from '../db/working-group-db.js';
+import { getWebAdminStatusCache } from './admin-status-cache.js';
+
+const logger = createLogger('admin-status-lookup');
+
+const AAO_ADMIN_WORKING_GROUP_SLUG = 'aao-admin';
+const ADMIN_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+const wgDb = new WorkingGroupDatabase();
+
+export async function isWebUserAAOAdmin(workosUserId: string): Promise<boolean> {
+  const cache = getWebAdminStatusCache();
+  const cached = cache.get(workosUserId);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.isAdmin;
+  }
+
+  try {
+    const adminGroup = await wgDb.getWorkingGroupBySlug(AAO_ADMIN_WORKING_GROUP_SLUG);
+    if (!adminGroup) {
+      logger.warn('AAO Admin working group not found');
+      // Cache the negative result for a shorter time so a missing
+      // admin group doesn't pin everyone to non-admin for 30 minutes.
+      cache.set(workosUserId, { isAdmin: false, expiresAt: Date.now() + 5 * 60 * 1000 });
+      return false;
+    }
+
+    const isAdmin = await wgDb.isMember(adminGroup.id, workosUserId);
+    cache.set(workosUserId, { isAdmin, expiresAt: Date.now() + ADMIN_CACHE_TTL_MS });
+    logger.debug({ workosUserId, isAdmin }, 'Checked web user admin status');
+    return isAdmin;
+  } catch (error) {
+    logger.error({ error, workosUserId }, 'Error checking if web user is admin');
+    return false;
+  }
+}

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -252,42 +252,12 @@ export async function isWebUserAAOCouncil(workosUserId: string): Promise<boolean
   }
 }
 
-/**
- * Check if a web user is an AAO admin
- * Checks membership in aao-admin working group by WorkOS user ID
- * Results are cached for 30 minutes to reduce DB load
- */
-export async function isWebUserAAOAdmin(workosUserId: string): Promise<boolean> {
-  // Check cache first
-  const cached = webAdminStatusCache.get(workosUserId);
-  if (cached && cached.expiresAt > Date.now()) {
-    return cached.isAdmin;
-  }
-
-  try {
-    // Get the aao-admin working group
-    const adminGroup = await wgDb.getWorkingGroupBySlug(AAO_ADMIN_WORKING_GROUP_SLUG);
-
-    if (!adminGroup) {
-      logger.warn('AAO Admin working group not found');
-      // Cache the negative result for a shorter time to avoid repeated DB lookups
-      webAdminStatusCache.set(workosUserId, { isAdmin: false, expiresAt: Date.now() + 5 * 60 * 1000 });
-      return false;
-    }
-
-    // Check if the user is a member of the admin working group
-    const isAdmin = await wgDb.isMember(adminGroup.id, workosUserId);
-
-    // Cache the result
-    webAdminStatusCache.set(workosUserId, { isAdmin, expiresAt: Date.now() + ADMIN_CACHE_TTL_MS });
-
-    logger.debug({ workosUserId, isAdmin }, 'Checked web user admin status');
-    return isAdmin;
-  } catch (error) {
-    logger.error({ error, workosUserId }, 'Error checking if web user is admin');
-    return false;
-  }
-}
+// `isWebUserAAOAdmin` lives in `../admin-status-lookup.ts` so callers
+// that only need the admin check don't have to pull in this file's
+// heavy transitive dependencies (relationship-orchestrator →
+// engagement-planner → Anthropic). Re-exported here to keep existing
+// imports working.
+export { isWebUserAAOAdmin } from '../admin-status-lookup.js';
 
 
 /**

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -67,8 +67,11 @@ import {
   joinWorkingGroup as joinWorkingGroupService,
   expressCommitteeInterest as expressCommitteeInterestService,
   withdrawCommitteeInterest as withdrawCommitteeInterestService,
+  listMyWorkingGroups as listMyWorkingGroupsService,
+  listMyCommitteeInterests as listMyCommitteeInterestsService,
   WorkingGroupMembershipError,
 } from '../../services/working-group-membership-service.js';
+import { listMyContent as listMyContentService } from '../../services/my-content-service.js';
 import {
   createWorkingGroupPost as createWorkingGroupPostService,
   addCommitteeDocument as addCommitteeDocumentService,
@@ -1732,19 +1735,7 @@ export function createMemberToolHandlers(
       return 'You need to be logged in to see your working groups. Please log in at https://agenticadvertising.org/dashboard first.';
     }
 
-    const result = await callApi('GET', '/api/me/working-groups', memberContext);
-
-    if (!result.ok) {
-      throw new ToolError(`Failed to fetch your working groups: ${result.error}`);
-    }
-
-    const data = result.data as { working_groups: Array<{
-      name: string;
-      slug: string;
-      committee_type: string;
-      is_private: boolean;
-    }> };
-    const groups = data.working_groups;
+    const groups = await listMyWorkingGroupsService({ userId: memberContext.workos_user.workos_user_id });
 
     if (!groups || groups.length === 0) {
       return "You're not a member of any working groups yet. Use list_working_groups to find groups to join!";
@@ -1815,18 +1806,9 @@ export function createMemberToolHandlers(
       return 'You need to be logged in to see your council interests. Please log in at https://agenticadvertising.org/dashboard first.';
     }
 
-    const result = await callApi('GET', '/api/me/working-groups/interests', memberContext);
-
-    if (!result.ok) {
-      throw new ToolError(`Failed to fetch your council interests: ${result.error}`);
-    }
-
-    const interests = result.data as Array<{
-      committee_name: string;
-      slug: string;
-      interest_level: string;
-      created_at: string;
-    }>;
+    const interests = await listMyCommitteeInterestsService({
+      userId: memberContext.workos_user.workos_user_id,
+    });
 
     if (interests.length === 0) {
       return "You haven't expressed interest in any councils yet. Use list_working_groups with type \"council\" to see available councils!";
@@ -2805,33 +2787,17 @@ export function createMemberToolHandlers(
     const collection = input.collection as string | undefined;
     const relationship = input.relationship as string | undefined;
 
-    // Build query string
-    const params = new URLSearchParams();
-    if (status && status !== 'all') params.set('status', status);
-    if (collection) params.set('collection', collection);
-    if (relationship) params.set('relationship', relationship);
-
-    const queryString = params.toString() ? `?${params.toString()}` : '';
-    const result = await callApi('GET', `/api/me/content${queryString}`, memberContext);
-
-    if (!result.ok) {
-      throw new ToolError(`Failed to fetch your content: ${result.error}`);
+    let data;
+    try {
+      data = await listMyContentService({
+        userId: memberContext.workos_user.workos_user_id,
+        status,
+        collection,
+        relationship,
+      });
+    } catch (err) {
+      throw new ToolError(`Failed to fetch your content: ${err instanceof Error ? err.message : String(err)}`);
     }
-
-    const data = result.data as {
-      items: Array<{
-        id: string;
-        slug: string;
-        title: string;
-        status: string;
-        content_type: string;
-        collection: { type: string; committee_name?: string; committee_slug?: string };
-        relationships: string[];
-        authors: Array<{ display_name: string }>;
-        published_at?: string;
-        created_at: string;
-      }>;
-    };
 
     if (data.items.length === 0) {
       let response = "You don't have any content yet.\n\n";

--- a/server/src/routes/committees.ts
+++ b/server/src/routes/committees.ts
@@ -31,6 +31,8 @@ import {
   joinWorkingGroup as joinWorkingGroupService,
   expressCommitteeInterest as expressCommitteeInterestService,
   withdrawCommitteeInterest as withdrawCommitteeInterestService,
+  listMyWorkingGroups as listMyWorkingGroupsService,
+  listMyCommitteeInterests as listMyCommitteeInterestsService,
   WorkingGroupMembershipError,
 } from "../services/working-group-membership-service.js";
 import {
@@ -2816,7 +2818,7 @@ export function createCommitteeRouters(): {
   userApiRouter.get('/', requireAuth, async (req: Request, res: Response) => {
     try {
       const user = req.user!;
-      const groups = await workingGroupDb.getWorkingGroupsForUser(user.id);
+      const groups = await listMyWorkingGroupsService({ userId: user.id });
       res.json({ working_groups: groups });
     } catch (error) {
       logger.error({ err: error }, 'Get user working groups error');
@@ -2844,18 +2846,8 @@ export function createCommitteeRouters(): {
   userApiRouter.get('/interests', requireAuth, async (req: Request, res: Response) => {
     try {
       const user = req.user!;
-      const pool = getPool();
-
-      const result = await pool.query(
-        `SELECT ci.interest_level, ci.created_at, wg.name as committee_name, wg.slug, wg.committee_type
-         FROM committee_interest ci
-         JOIN working_groups wg ON wg.id = ci.working_group_id
-         WHERE ci.workos_user_id = $1
-         ORDER BY ci.created_at DESC`,
-        [user.id]
-      );
-
-      res.json(result.rows);
+      const rows = await listMyCommitteeInterestsService({ userId: user.id });
+      res.json(rows);
     } catch (error) {
       logger.error({ err: error }, 'Get user council interests error');
       res.status(500).json({

--- a/server/src/routes/content.ts
+++ b/server/src/routes/content.ts
@@ -28,6 +28,7 @@ import { safeFetch } from '../utils/url-security.js';
 import { generateIllustration } from '../services/illustration-generator.js';
 import { createIllustration, approveIllustration } from '../db/illustration-db.js';
 import { resolveEscalationsForPerspective } from '../db/escalation-db.js';
+import { listMyContent as listMyContentService, MyContentError } from '../services/my-content-service.js';
 
 const logger = createLogger('content-routes');
 
@@ -1389,144 +1390,21 @@ export function createMyContentRouter(): Router {
       const status = req.query.status as string | undefined;
       const collection = req.query.collection as string | undefined;
       const relationship = req.query.relationship as string | undefined;
-      const limit = Math.min(parseInt(req.query.limit as string) || 50, 100);
-      const pool = getPool();
-
-      // Get committees user leads (for "owner" relationship)
-      const leaderResult = await pool.query(
-        `SELECT working_group_id FROM working_group_leaders WHERE user_id = $1`,
-        [user.id]
-      );
-      const ledCommitteeIds = leaderResult.rows.map(r => r.working_group_id);
-
-      // Admins can see every perspective here so they can edit anything
-      // (including content that predates them, has no proposer, or belongs to a
-      // committee they don't lead). Relationships are still computed so the UI
-      // can still distinguish their own contributions.
-      const userIsAdmin = await isWebUserAAOAdmin(user.id);
-
-      // Build the query
-      let query = `
-        SELECT DISTINCT ON (p.id)
-          p.id, p.slug, p.content_type, p.title, p.subtitle, p.category, p.excerpt,
-          p.content, p.tags, p.featured_image_url,
-          p.external_url, p.external_site_name, p.status, p.published_at,
-          p.created_at, p.updated_at, p.working_group_id, p.proposer_user_id,
-          wg.name as committee_name, wg.slug as committee_slug,
-          -- Determine relationships
-          CASE WHEN p.proposer_user_id = $1 THEN true ELSE false END as is_proposer,
-          CASE WHEN EXISTS (SELECT 1 FROM content_authors ca WHERE ca.perspective_id = p.id AND ca.user_id = $1) THEN true ELSE false END as is_author,
-          CASE WHEN p.working_group_id = ANY($2) THEN true ELSE false END as is_lead,
-          -- Get authors
-          (SELECT json_agg(json_build_object(
-            'user_id', ca.user_id,
-            'display_name', ca.display_name,
-            'display_title', ca.display_title
-          ) ORDER BY ca.display_order)
-          FROM content_authors ca WHERE ca.perspective_id = p.id) as authors
-        FROM perspectives p
-        LEFT JOIN working_groups wg ON wg.id = p.working_group_id
-        WHERE (
-          $3::boolean = true
-          OR p.proposer_user_id = $1
-          OR EXISTS (SELECT 1 FROM content_authors ca WHERE ca.perspective_id = p.id AND ca.user_id = $1)
-          OR p.working_group_id = ANY($2)
-        )
-      `;
-      const params: (string | string[] | number | boolean)[] = [user.id, ledCommitteeIds, userIsAdmin];
-
-      // Apply filters
-      if (status && status !== 'all') {
-        const validStatuses = ['draft', 'pending_review', 'published', 'archived', 'rejected'];
-        if (!validStatuses.includes(status)) {
-          return res.status(400).json({
-            error: 'Invalid status',
-            message: `status must be one of: ${validStatuses.join(', ')}, or 'all'`,
-          });
-        }
-        params.push(status);
-        query += ` AND p.status = $${params.length}`;
-      }
-
-      if (collection) {
-        if (collection === 'personal') {
-          query += ` AND p.working_group_id IS NULL`;
-        } else {
-          // Assume it's a committee slug
-          params.push(collection);
-          query += ` AND wg.slug = $${params.length}`;
-        }
-      }
-
-      query += ` ORDER BY p.id, p.created_at DESC`;
-      params.push(limit);
-      query += ` LIMIT $${params.length}`;
-
-      const result = await pool.query(query, params);
-
-      // Format response with relationships
-      const items = result.rows.map(row => {
-        const relationships: string[] = [];
-        if (row.is_author) relationships.push('author');
-        if (row.is_proposer) relationships.push('proposer');
-        if (row.is_lead) relationships.push('owner');
-
-        return {
-          id: row.id,
-          slug: row.slug,
-          title: row.title,
-          subtitle: row.subtitle,
-          content_type: row.content_type,
-          category: row.category,
-          excerpt: row.excerpt,
-          content: row.content,
-          tags: row.tags,
-          featured_image_url: row.featured_image_url,
-          external_url: row.external_url,
-          external_site_name: row.external_site_name,
-          status: row.status,
-          collection: {
-            type: row.working_group_id ? 'committee' : 'personal',
-            committee_name: row.committee_name,
-            committee_slug: row.committee_slug,
-          },
-          relationships,
-          authors: row.authors || [],
-          published_at: row.published_at,
-          created_at: row.created_at,
-          updated_at: row.updated_at,
-        };
-      }).filter(item => {
-        // Apply relationship filter if specified
-        if (!relationship) return true;
-        return item.relationships.includes(relationship);
+      const limit = parseInt(req.query.limit as string);
+      const result = await listMyContentService({
+        userId: user.id,
+        status,
+        collection,
+        relationship,
+        limit: Number.isFinite(limit) ? limit : undefined,
       });
-
-      const publishedPaths = items
-        .filter(item => item.status === 'published' && typeof item.slug === 'string' && item.slug.length > 0)
-        .map(item => `/perspectives/${item.slug}`);
-
-      const pageviewCounts = await fetchPathPageviewCounts(publishedPaths, 30);
-
-      const itemsWithPerformance = items.map(item => {
-        if (item.status !== 'published' || !item.slug || !pageviewCounts) {
-          return item;
-        }
-
-        return {
-          ...item,
-          performance: {
-            pageviews_last_30d: pageviewCounts[`/perspectives/${item.slug}`] ?? 0,
-          },
-        };
-      });
-
-      res.json({ items: itemsWithPerformance });
+      res.json({ items: result.items });
     } catch (error) {
+      if (error instanceof MyContentError && error.is('invalid_status')) {
+        return res.status(400).json({ error: 'Invalid status', message: error.message });
+      }
       logger.error({ err: error }, 'GET /api/me/content error');
-      res.status(500).json({
-        error: 'Failed to get content',
-      });
+      res.status(500).json({ error: 'Failed to get content' });
     }
   });
 

--- a/server/src/routes/content.ts
+++ b/server/src/routes/content.ts
@@ -1401,7 +1401,10 @@ export function createMyContentRouter(): Router {
       res.json({ items: result.items });
     } catch (error) {
       if (error instanceof MyContentError && error.is('invalid_status')) {
-        return res.status(400).json({ error: 'Invalid status', message: error.message });
+        return res.status(400).json({
+          error: 'Invalid status',
+          message: `status must be one of: ${error.meta.valid.join(', ')}, or 'all'`,
+        });
       }
       logger.error({ err: error }, 'GET /api/me/content error');
       res.status(500).json({ error: 'Failed to get content' });

--- a/server/src/services/my-content-service.ts
+++ b/server/src/services/my-content-service.ts
@@ -14,16 +14,14 @@
  */
 
 import { getPool } from '../db/client.js';
-import { createLogger } from '../logger.js';
 import { isWebUserAAOAdmin } from '../addie/admin-status-lookup.js';
 import { fetchPathPageviewCounts } from './posthog-query.js';
-
-const logger = createLogger('my-content-service');
 
 export type MyContentStatus = 'draft' | 'pending_review' | 'published' | 'archived' | 'rejected';
 const VALID_STATUSES: readonly MyContentStatus[] = ['draft', 'pending_review', 'published', 'archived', 'rejected'];
 
 export type MyContentRelationship = 'author' | 'proposer' | 'owner';
+const VALID_RELATIONSHIPS: readonly MyContentRelationship[] = ['author', 'proposer', 'owner'];
 
 export interface MyContentItem {
   id: string;
@@ -102,7 +100,10 @@ export async function listMyContent({
       valid: VALID_STATUSES,
     });
   }
-  const cappedLimit = Math.min(typeof limit === 'number' && Number.isFinite(limit) ? limit : 50, 100);
+  // Match the original route's coercion (`parseInt(...) || 50`): any
+  // falsy or non-finite limit (including 0, NaN, negative numbers) is
+  // treated as "use the default 50". Then cap at 100.
+  const cappedLimit = Math.min(typeof limit === 'number' && Number.isFinite(limit) && limit > 0 ? limit : 50, 100);
 
   const pool = getPool();
 
@@ -165,7 +166,36 @@ export async function listMyContent({
   params.push(cappedLimit);
   queryText += ` LIMIT $${params.length}`;
 
-  const result = await pool.query(queryText, params);
+  // Type the row shape so PG-shape drift (e.g. tags becoming non-array,
+  // authors changing JSON shape) surfaces in TypeScript instead of
+  // silently passing through `satisfies` checks against `any`.
+  interface MyContentSqlRow {
+    id: string;
+    slug: string | null;
+    content_type: string;
+    title: string;
+    subtitle: string | null;
+    category: string | null;
+    excerpt: string | null;
+    content: string | null;
+    tags: string[] | null;
+    featured_image_url: string | null;
+    external_url: string | null;
+    external_site_name: string | null;
+    status: string;
+    published_at: Date | null;
+    created_at: Date;
+    updated_at: Date;
+    working_group_id: string | null;
+    proposer_user_id: string | null;
+    committee_name: string | null;
+    committee_slug: string | null;
+    is_proposer: boolean;
+    is_author: boolean;
+    is_lead: boolean;
+    authors: Array<{ user_id: string; display_name: string; display_title: string | null }> | null;
+  }
+  const result = await pool.query<MyContentSqlRow>(queryText, params);
 
   const items: MyContentItem[] = result.rows
     .map((row) => {
@@ -204,18 +234,16 @@ export async function listMyContent({
       return item.relationships.includes(relationship as MyContentRelationship);
     });
 
-  // Pageview enrichment — best-effort. PostHog being down should not
-  // gate the listing, just degrade the response.
+  // Pageview enrichment. Match the prior route handler's behavior
+  // exactly — let any PostHog error propagate to the caller, which
+  // surfaces as a 500 from the route or a tool error from the Addie
+  // adapter. Don't degrade silently here: if pageview data is
+  // unexpectedly empty, the operator should see it.
   const publishedPaths = items
     .filter((item) => item.status === 'published' && typeof item.slug === 'string' && item.slug.length > 0)
     .map((item) => `/perspectives/${item.slug}`);
 
-  let pageviewCounts: Record<string, number> | null = null;
-  try {
-    pageviewCounts = await fetchPathPageviewCounts(publishedPaths, 30);
-  } catch (err) {
-    logger.warn({ err }, 'Pageview enrichment failed; returning items without performance');
-  }
+  const pageviewCounts = await fetchPathPageviewCounts(publishedPaths, 30);
 
   const itemsWithPerformance = items.map((item) => {
     if (item.status !== 'published' || !item.slug || !pageviewCounts) {

--- a/server/src/services/my-content-service.ts
+++ b/server/src/services/my-content-service.ts
@@ -1,0 +1,233 @@
+/**
+ * "My content" listing service.
+ *
+ * Shared by:
+ *  - GET /api/me/content                                       (web/API)
+ *  - get_my_content Addie tool                                 (chat)
+ *
+ * Centralizes the perspectives query (relationships, status filtering,
+ * collection filtering, pageview enrichment) so the route and the Addie
+ * tool produce identical outcomes. Closes the read-loopback half of
+ * issue #3736 (filed as #3748): `callApi('GET', '/api/me/content', …)`
+ * sent no credentials and got 401 from `requireAuth` — the route's
+ * sole consumer for chat callers became unreachable.
+ */
+
+import { getPool } from '../db/client.js';
+import { createLogger } from '../logger.js';
+import { isWebUserAAOAdmin } from '../addie/admin-status-lookup.js';
+import { fetchPathPageviewCounts } from './posthog-query.js';
+
+const logger = createLogger('my-content-service');
+
+export type MyContentStatus = 'draft' | 'pending_review' | 'published' | 'archived' | 'rejected';
+const VALID_STATUSES: readonly MyContentStatus[] = ['draft', 'pending_review', 'published', 'archived', 'rejected'];
+
+export type MyContentRelationship = 'author' | 'proposer' | 'owner';
+
+export interface MyContentItem {
+  id: string;
+  slug: string | null;
+  title: string;
+  subtitle: string | null;
+  content_type: string;
+  category: string | null;
+  excerpt: string | null;
+  content: string | null;
+  tags: string[] | null;
+  featured_image_url: string | null;
+  external_url: string | null;
+  external_site_name: string | null;
+  status: string;
+  collection: {
+    type: 'committee' | 'personal';
+    committee_name: string | null;
+    committee_slug: string | null;
+  };
+  relationships: MyContentRelationship[];
+  authors: Array<{ user_id: string; display_name: string; display_title: string | null }>;
+  published_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+  performance?: { pageviews_last_30d: number };
+}
+
+export type MyContentErrorCode = 'invalid_status';
+
+export interface MyContentErrorMetaByCode {
+  invalid_status: { provided: string; valid: readonly string[] };
+}
+
+export class MyContentError<C extends MyContentErrorCode = MyContentErrorCode> extends Error {
+  constructor(
+    public readonly code: C,
+    message: string,
+    public readonly meta: MyContentErrorMetaByCode[C],
+  ) {
+    super(message);
+    this.name = 'MyContentError';
+  }
+
+  is<K extends MyContentErrorCode>(code: K): this is MyContentError<K> & { meta: MyContentErrorMetaByCode[K] } {
+    return (this.code as string) === (code as string);
+  }
+}
+
+export interface ListMyContentInput {
+  userId: string;
+  /** One of MyContentStatus, the literal 'all', or undefined (returns all). */
+  status?: string;
+  /** Committee slug, or 'personal' (no committee), or undefined. */
+  collection?: string;
+  /** 'author' | 'proposer' | 'owner' filter — applied after the SQL. */
+  relationship?: string;
+  /** Defaults to 50, capped at 100 to match the route. */
+  limit?: number;
+}
+
+export interface ListMyContentResult {
+  items: MyContentItem[];
+}
+
+export async function listMyContent({
+  userId,
+  status,
+  collection,
+  relationship,
+  limit,
+}: ListMyContentInput): Promise<ListMyContentResult> {
+  if (status !== undefined && status !== 'all' && !VALID_STATUSES.includes(status as MyContentStatus)) {
+    throw new MyContentError('invalid_status', `status must be one of: ${VALID_STATUSES.join(', ')}, or 'all'`, {
+      provided: status,
+      valid: VALID_STATUSES,
+    });
+  }
+  const cappedLimit = Math.min(typeof limit === 'number' && Number.isFinite(limit) ? limit : 50, 100);
+
+  const pool = getPool();
+
+  // Committees the user leads — feeds the "owner" relationship and the
+  // SQL WHERE clause that surfaces all content for those committees.
+  const leaderResult = await pool.query<{ working_group_id: string }>(
+    `SELECT working_group_id FROM working_group_leaders WHERE user_id = $1`,
+    [userId],
+  );
+  const ledCommitteeIds = leaderResult.rows.map((r) => r.working_group_id);
+
+  // Admins see every perspective so they can edit anything (including
+  // pre-existing content with no proposer or content from committees
+  // they don't lead). Relationships are still computed so the UI/chat
+  // can distinguish their own contributions.
+  const userIsAdmin = await isWebUserAAOAdmin(userId);
+
+  let queryText = `
+    SELECT DISTINCT ON (p.id)
+      p.id, p.slug, p.content_type, p.title, p.subtitle, p.category, p.excerpt,
+      p.content, p.tags, p.featured_image_url,
+      p.external_url, p.external_site_name, p.status, p.published_at,
+      p.created_at, p.updated_at, p.working_group_id, p.proposer_user_id,
+      wg.name as committee_name, wg.slug as committee_slug,
+      CASE WHEN p.proposer_user_id = $1 THEN true ELSE false END as is_proposer,
+      CASE WHEN EXISTS (SELECT 1 FROM content_authors ca WHERE ca.perspective_id = p.id AND ca.user_id = $1) THEN true ELSE false END as is_author,
+      CASE WHEN p.working_group_id = ANY($2) THEN true ELSE false END as is_lead,
+      (SELECT json_agg(json_build_object(
+        'user_id', ca.user_id,
+        'display_name', ca.display_name,
+        'display_title', ca.display_title
+      ) ORDER BY ca.display_order)
+      FROM content_authors ca WHERE ca.perspective_id = p.id) as authors
+    FROM perspectives p
+    LEFT JOIN working_groups wg ON wg.id = p.working_group_id
+    WHERE (
+      $3::boolean = true
+      OR p.proposer_user_id = $1
+      OR EXISTS (SELECT 1 FROM content_authors ca WHERE ca.perspective_id = p.id AND ca.user_id = $1)
+      OR p.working_group_id = ANY($2)
+    )
+  `;
+  const params: (string | string[] | number | boolean)[] = [userId, ledCommitteeIds, userIsAdmin];
+
+  if (status && status !== 'all') {
+    params.push(status);
+    queryText += ` AND p.status = $${params.length}`;
+  }
+
+  if (collection) {
+    if (collection === 'personal') {
+      queryText += ` AND p.working_group_id IS NULL`;
+    } else {
+      params.push(collection);
+      queryText += ` AND wg.slug = $${params.length}`;
+    }
+  }
+
+  queryText += ` ORDER BY p.id, p.created_at DESC`;
+  params.push(cappedLimit);
+  queryText += ` LIMIT $${params.length}`;
+
+  const result = await pool.query(queryText, params);
+
+  const items: MyContentItem[] = result.rows
+    .map((row) => {
+      const relationships: MyContentRelationship[] = [];
+      if (row.is_author) relationships.push('author');
+      if (row.is_proposer) relationships.push('proposer');
+      if (row.is_lead) relationships.push('owner');
+      return {
+        id: row.id,
+        slug: row.slug,
+        title: row.title,
+        subtitle: row.subtitle,
+        content_type: row.content_type,
+        category: row.category,
+        excerpt: row.excerpt,
+        content: row.content,
+        tags: row.tags,
+        featured_image_url: row.featured_image_url,
+        external_url: row.external_url,
+        external_site_name: row.external_site_name,
+        status: row.status,
+        collection: {
+          type: row.working_group_id ? 'committee' : 'personal',
+          committee_name: row.committee_name,
+          committee_slug: row.committee_slug,
+        },
+        relationships,
+        authors: row.authors || [],
+        published_at: row.published_at,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+      } satisfies MyContentItem;
+    })
+    .filter((item) => {
+      if (!relationship) return true;
+      return item.relationships.includes(relationship as MyContentRelationship);
+    });
+
+  // Pageview enrichment — best-effort. PostHog being down should not
+  // gate the listing, just degrade the response.
+  const publishedPaths = items
+    .filter((item) => item.status === 'published' && typeof item.slug === 'string' && item.slug.length > 0)
+    .map((item) => `/perspectives/${item.slug}`);
+
+  let pageviewCounts: Record<string, number> | null = null;
+  try {
+    pageviewCounts = await fetchPathPageviewCounts(publishedPaths, 30);
+  } catch (err) {
+    logger.warn({ err }, 'Pageview enrichment failed; returning items without performance');
+  }
+
+  const itemsWithPerformance = items.map((item) => {
+    if (item.status !== 'published' || !item.slug || !pageviewCounts) {
+      return item;
+    }
+    return {
+      ...item,
+      performance: {
+        pageviews_last_30d: pageviewCounts[`/perspectives/${item.slug}`] ?? 0,
+      },
+    };
+  });
+
+  return { items: itemsWithPerformance };
+}

--- a/server/src/services/working-group-membership-service.ts
+++ b/server/src/services/working-group-membership-service.ts
@@ -25,7 +25,7 @@
 import { getPool, query } from '../db/client.js';
 import { createLogger } from '../logger.js';
 import { WorkingGroupDatabase } from '../db/working-group-db.js';
-import type { WorkingGroupMembership } from '../types.js';
+import type { WorkingGroup, WorkingGroupMembership } from '../types.js';
 import { CommunityDatabase } from '../db/community-db.js';
 import { SlackDatabase } from '../db/slack-db.js';
 import { invalidateMemberContextCache } from '../addie/member-context-cache.js';
@@ -391,4 +391,45 @@ export async function withdrawCommitteeInterest({
     groupName: group.name,
     groupSlug: group.slug,
   };
+}
+
+// ─── Read paths ───────────────────────────────────────────────────────
+// These exist because Addie's `callApi('GET', '/api/me/…', …)` carries
+// no credentials and the routes require auth — so the Addie tools
+// silently 401'd in production. Both surfaces (route + chat) now
+// consume the service directly. No HTTP loopback. (See issue #3748.)
+
+export interface ListMyWorkingGroupsInput {
+  userId: string;
+}
+
+export async function listMyWorkingGroups({ userId }: ListMyWorkingGroupsInput): Promise<WorkingGroup[]> {
+  return workingGroupDb.getWorkingGroupsForUser(userId);
+}
+
+export interface CommitteeInterestRow {
+  committee_name: string;
+  slug: string;
+  committee_type: string;
+  interest_level: string;
+  created_at: Date;
+}
+
+export interface ListMyCommitteeInterestsInput {
+  userId: string;
+}
+
+export async function listMyCommitteeInterests({
+  userId,
+}: ListMyCommitteeInterestsInput): Promise<CommitteeInterestRow[]> {
+  const pool = getPool();
+  const result = await pool.query<CommitteeInterestRow>(
+    `SELECT ci.interest_level, ci.created_at, wg.name as committee_name, wg.slug, wg.committee_type
+     FROM committee_interest ci
+     JOIN working_groups wg ON wg.id = ci.working_group_id
+     WHERE ci.workos_user_id = $1
+     ORDER BY ci.created_at DESC`,
+    [userId],
+  );
+  return result.rows;
 }

--- a/server/tests/integration/content-my-content.test.ts
+++ b/server/tests/integration/content-my-content.test.ts
@@ -58,6 +58,16 @@ vi.mock('../../src/middleware/csrf.js', () => ({
 }));
 
 const adminState = { isAdmin: false };
+// Mock the lookup module directly. `my-content-service.ts` imports
+// `isWebUserAAOAdmin` from `addie/admin-status-lookup.js` (the thin
+// module created in PR #3758), so the test must intercept there.
+// `addie/mcp/admin-tools.js` re-exports for legacy callers, but ESM
+// re-exports are not call-routed through the original module — once
+// the consumer points at `admin-status-lookup`, that's what gets
+// resolved.
+vi.mock('../../src/addie/admin-status-lookup.js', () => ({
+  isWebUserAAOAdmin: vi.fn(async () => adminState.isAdmin),
+}));
 vi.mock('../../src/addie/mcp/admin-tools.js', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>;
   return {


### PR DESCRIPTION
## Summary

Closes #3748 — the read-side companion to #3736. Three Addie tools were silently failing with *"Authentication required"* in production for every signed-in member because `callApi` sends no credentials to `requireAuth`-protected routes:

| Tool | Route hit | What members saw |
|---|---|---|
| `get_my_working_groups` | `GET /api/me/working-groups` | *"Failed to fetch your working groups: Authentication required"* |
| `get_my_council_interests` | `GET /api/me/working-groups/interests` | tool throws |
| `get_my_content` | `GET /api/me/content?…` | tool throws |

Same root-cause shape as the state-change loopback bug class (#3736), different middleware (auth instead of CSRF). Fixed with the same pattern: extract a service that both the route and the Addie tool consume directly.

## What's in the PR

**Two thin functions added to the existing `working-group-membership-service`:**
- `listMyWorkingGroups({userId})` → wraps `WorkingGroupDatabase.getWorkingGroupsForUser`.
- `listMyCommitteeInterests({userId})` → wraps the SQL the route used to do inline.

**New service `services/my-content-service.ts`:**
- `listMyContent({userId, status, collection, relationship, limit})` — full perspectives query (relationship computation, status/collection filtering, pageview enrichment).
- Throws `MyContentError` with `invalid_status` discriminator so route + chat both render the right validation error.

**One supporting refactor — `addie/admin-status-lookup.ts`:**
- The content service needs `isWebUserAAOAdmin` (admins see all perspectives in their list).
- Importing it from `addie/mcp/admin-tools.ts` would pull `relationship-orchestrator → engagement-planner → Anthropic` into the test import graph — the chain that broke `claude-client-cost-gate` in PR #3741.
- Lifted the function into a thin module that has zero heavy transitive imports. `admin-tools.ts` re-exports for existing callers — no caller changes needed.

## Test plan

- [x] `tsc --noEmit` clean.
- [x] Root `tests/` unit suite: 849 passing.
- [x] Server unit suite: 2997 passing.
- [x] `npm run test:callapi-state-change` lint: 10/10 (the read tools never used POST/PUT/DELETE, only GET; those GETs are now gone, so the source tree is cleaner than before).
- [x] **Live end-to-end smoke against local docker** — all three previously-broken tools succeed:
  - `get_my_working_groups` → returns *"Your Working Group Memberships: Open Web Council"*
  - `get_my_council_interests` → returns *"Retail Media Council, Participant"*
  - `get_my_content` (no filters) → *"You don't have any content yet"* (correct empty state, not an error)
  - `get_my_content` (invalid_status) → friendly *"status must be one of: draft, pending_review, published, archived, rejected, or 'all'"*
  - `get_my_content` (status=published) → empty state, filter works

## Bug class fully closed

| | State-change side | Read side |
|---|---|---|
| Symptom | False outages, "private group" for public groups, "not a member" for actual members | "Authentication required" for every signed-in member |
| Trigger | callApi POST/PUT/DELETE → CSRF middleware | callApi GET → requireAuth middleware |
| Closed by | PRs #3716, #3741, #3743, #3747 (locked down at compile + runtime + lint) | This PR |

Issue #3736 was already closed; #3748 closes with this PR. The Addie loopback bug class can no longer regress: state-change tools are physically prevented at compile/runtime/lint, and all known authenticated-GET tools are migrated to direct service calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)