### PR TITLE
feat(registry): preserve member-declared 'buying' type — closes #3549

### DIFF
--- a/.changeset/preserve-member-buying-type.md
+++ b/.changeset/preserve-member-buying-type.md
@@ -1,0 +1,4 @@
+---
+---
+
+Preserve member-declared `buying` agent type through the null-inferred snapshot override path. Buy-side agents structurally don't expose AdCP tools (they CALL them), so passive probe inference always returns `unknown` for them — without this carve-out, member-set `type: 'buying'` was silently squashed to `unknown` on first probe. Smuggle protection still holds for sales/creative/signals (those types are squashed to `unknown` when the snapshot can't classify, since the probe WOULD classify them when reachable). Closes #3549.

--- a/server/src/capabilities.ts
+++ b/server/src/capabilities.ts
@@ -430,8 +430,14 @@ export class CapabilityDiscovery {
    * properties for buyers to call; buy-side agents typically do NOT
    * advertise those (they call them). So advertising SALES_TOOLS maps to
    * type 'sales'. Buy-side agents are not reliably typed from this signal
-   * and return 'unknown' until a stronger source (e.g. member self-
-   * registration) sets the type.
+   * and return 'unknown' here.
+   *
+   * The `'buying'` value in `AgentType` is preserved exclusively through
+   * member self-declaration. `resolveAgentTypes` in `routes/member-profiles.ts`
+   * carries member-set `'buying'` through the null-inferred-snapshot
+   * override (closes #3549). Inference here intentionally never returns
+   * `'buying'` because no passive probe signal can distinguish a buy-side
+   * agent from a broken/empty MCP server.
    */
   private inferAgentType(tools: ToolCapability[]): 'sales' | 'creative' | 'signals' | 'unknown' {
     const toolNames = new Set(tools.map((t) => t.name.toLowerCase()));

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -46,19 +46,29 @@ const logger = createLogger("member-profile-routes");
 /**
  * Server-authoritative agent type for issue #3495.
  *
- * Three cases, in priority order:
+ * Four cases, in priority order:
  *
  * 1. We have a capability snapshot AND its inferred_type is a valid
  *    AgentType — use it. This is ground truth from the crawler probe.
  *
- * 2. We have a snapshot but inferred_type is null (probe failed,
- *    OAuth-required, or all tools were unrecognised) — force 'unknown'.
- *    Deliberately do NOT fall back to the client's value here: a
- *    snapshot row with null inferred_type means "we tried and could not
- *    classify", which is exactly the case where a malicious client could
- *    smuggle a wrong type. Trust silence over the client.
+ * 2. Snapshot exists but inferred_type is null (probe failed,
+ *    OAuth-required, or all tools were unrecognised) AND the client
+ *    self-declared `buying` — preserve `buying`. Buy-side agents
+ *    structurally do not expose AdCP tools (they CALL them as clients),
+ *    so the probe-based inference cannot detect them. The member's
+ *    self-declaration is the only signal we have. Smuggling protection
+ *    still holds for sales/creative/signals because the probe WILL
+ *    classify those when reachable; this carve-out is exactly `buying`,
+ *    the only type that cannot be fabricated by a passive probe. See
+ *    issue #3549.
  *
- * 3. No snapshot at all (URL has never been probed) — fall back to the
+ * 3. Any other snapshot-but-null-inferred case — force `unknown`.
+ *    Deliberately do NOT fall back to the client's value here: a
+ *    snapshot row with null inferred_type means "we tried and could
+ *    not classify", which is exactly the case where a malicious client
+ *    could smuggle a non-`buying` type. Trust silence over the client.
+ *
+ * 4. No snapshot at all (URL has never been probed) — fall back to the
  *    client's value, but only if it validates against the AgentType
  *    enum. Drop legacy strings like 'buyer' / 'seller' to 'unknown' so
  *    they cannot land in JSONB.
@@ -88,9 +98,19 @@ export async function resolveAgentTypes(agents: unknown): Promise<unknown> {
       if (inferred && isValidAgentType(inferred)) {
         return { ...a, type: inferred as AgentType };
       }
-      // Snapshot exists but probe couldn't classify the agent. Reject the
-      // client's claimed type: a probed-but-unknown URL is the exact attack
-      // window for type smuggling.
+      // Snapshot exists but probe couldn't classify the agent. Carve-out
+      // for `buying`: buy-side agents are CLIENTS of AdCP, not servers —
+      // they call sales/creative/signals tools, they do not expose them.
+      // A passive probe therefore cannot infer `buying` from tool surface,
+      // and the member's self-declaration is the only signal. Preserve it.
+      // Smuggling protection still holds: a malicious client claiming
+      // sales/creative/signals on an unreachable agent still gets squashed
+      // to `unknown` below.
+      if (a.type === 'buying') {
+        return { ...a, type: 'buying' as AgentType };
+      }
+      // Any other claimed type with a null-inferred snapshot — reject and
+      // force unknown. This is the type-smuggling window.
       return { ...a, type: 'unknown' as AgentType };
     }
     // No snapshot — trust validated client value, drop the rest.

--- a/server/tests/unit/resolve-agent-types-buying.test.ts
+++ b/server/tests/unit/resolve-agent-types-buying.test.ts
@@ -1,0 +1,123 @@
+// Pin the `buying` carve-out in resolveAgentTypes (closes #3549).
+//
+// Buy-side agents are CLIENTS of AdCP, not servers — they call sales /
+// creative / signals tools, they don't expose them. The probe-based
+// inference therefore cannot detect type=buying; only member self-
+// declaration can. resolveAgentTypes carries member-set `buying` through
+// the null-inferred-snapshot override path, while still squashing other
+// claimed types to `unknown` in that path (smuggle protection).
+//
+// Coverage matrix:
+//   1. snapshot inferred=sales,    client=buying  → sales (probe wins)
+//   2. snapshot inferred=null,     client=buying  → buying (carve-out)
+//   3. snapshot inferred=null,     client=sales   → unknown (smuggle blocked)
+//   4. snapshot inferred=null,     client=creative → unknown (smuggle blocked)
+//   5. snapshot inferred=null,     client=signals  → unknown (smuggle blocked)
+//   6. no snapshot,                client=buying  → buying (case 4 path)
+//   7. no snapshot,                client=buyer   → unknown (legacy string)
+
+import { describe, it, expect, vi } from 'vitest';
+
+// vi.hoisted lifts the mock state above vi.mock's hoisted factory so
+// the factory can reference it. Without hoisted, we'd hit TDZ.
+const { __mockBulkGetImpl } = vi.hoisted(() => ({
+  __mockBulkGetImpl: vi.fn(async (_urls: string[]) => new Map()),
+}));
+
+vi.mock('../../src/db/agent-snapshot-db.js', () => ({
+  AgentSnapshotDatabase: class {
+    bulkGetCapabilities = __mockBulkGetImpl;
+  },
+}));
+
+// member-profiles.ts transitively imports WorkOS via auth middleware. Mock
+// WorkOS as a class so `new WorkOS(...)` returns a stub — env-var-shim
+// approaches don't work because ESM imports are hoisted above any module-
+// level `process.env.X = ...` assignment. Same pattern as #3558's reprobe
+// test mock.
+vi.mock('@workos-inc/node', () => ({
+  WorkOS: class {
+    userManagement = {};
+    organizations = {};
+  },
+  WorkOSNode: class {
+    userManagement = {};
+    organizations = {};
+  },
+}));
+
+import { resolveAgentTypes } from '../../src/routes/member-profiles.js';
+
+type Agent = { url: string; type?: string };
+
+function snapshot(inferred: string | null) {
+  return { inferred_type: inferred };
+}
+
+describe('resolveAgentTypes — buying carve-out (#3549)', () => {
+  it('snapshot inferred=sales overrides client=buying (probe wins)', async () => {
+    __mockBulkGetImpl.mockResolvedValueOnce(new Map([
+      ['https://a.example', snapshot('sales')],
+    ]));
+    const out = await resolveAgentTypes([
+      { url: 'https://a.example', type: 'buying' } as Agent,
+    ]);
+    expect((out as Agent[])[0].type).toBe('sales');
+  });
+
+  it('snapshot inferred=null + client=buying preserves buying', async () => {
+    __mockBulkGetImpl.mockResolvedValueOnce(new Map([
+      ['https://a.example', snapshot(null)],
+    ]));
+    const out = await resolveAgentTypes([
+      { url: 'https://a.example', type: 'buying' } as Agent,
+    ]);
+    expect((out as Agent[])[0].type).toBe('buying');
+  });
+
+  it('snapshot inferred=null + client=sales squashes to unknown (smuggle blocked)', async () => {
+    __mockBulkGetImpl.mockResolvedValueOnce(new Map([
+      ['https://a.example', snapshot(null)],
+    ]));
+    const out = await resolveAgentTypes([
+      { url: 'https://a.example', type: 'sales' } as Agent,
+    ]);
+    expect((out as Agent[])[0].type).toBe('unknown');
+  });
+
+  it('snapshot inferred=null + client=creative squashes to unknown', async () => {
+    __mockBulkGetImpl.mockResolvedValueOnce(new Map([
+      ['https://a.example', snapshot(null)],
+    ]));
+    const out = await resolveAgentTypes([
+      { url: 'https://a.example', type: 'creative' } as Agent,
+    ]);
+    expect((out as Agent[])[0].type).toBe('unknown');
+  });
+
+  it('snapshot inferred=null + client=signals squashes to unknown', async () => {
+    __mockBulkGetImpl.mockResolvedValueOnce(new Map([
+      ['https://a.example', snapshot(null)],
+    ]));
+    const out = await resolveAgentTypes([
+      { url: 'https://a.example', type: 'signals' } as Agent,
+    ]);
+    expect((out as Agent[])[0].type).toBe('unknown');
+  });
+
+  it('no snapshot + client=buying preserves buying (case 4 path)', async () => {
+    __mockBulkGetImpl.mockResolvedValueOnce(new Map());
+    const out = await resolveAgentTypes([
+      { url: 'https://a.example', type: 'buying' } as Agent,
+    ]);
+    expect((out as Agent[])[0].type).toBe('buying');
+  });
+
+  it('no snapshot + legacy string=buyer drops to unknown', async () => {
+    __mockBulkGetImpl.mockResolvedValueOnce(new Map());
+    const out = await resolveAgentTypes([
+      { url: 'https://a.example', type: 'buyer' } as Agent,
+    ]);
+    expect((out as Agent[])[0].type).toBe('unknown');
+  });
+});


### PR DESCRIPTION
Closes #3549.

Decision: keep `buying` in `AgentType` AND make member self-declaration of `buying` actually stick.

## The bug

Buy-side agents are CLIENTS of AdCP, not servers — they call sales / creative / signals tools, they don't expose them. The probe-based inference in `CapabilityDiscovery.inferAgentType` therefore always returns `'unknown'` for them. There's no passive signal that distinguishes a buying agent from a broken/empty MCP server.

`resolveAgentTypes` in `routes/member-profiles.ts` was overriding member-set `type: 'buying'` → `'unknown'` on first probe, because case 2 of the priority chain ("snapshot exists but inferred_type is null") squashed EVERY non-inferred type to `'unknown'` for smuggle protection. Right intent, wrong polarity for `buying`.

## The fix

Carve out `'buying'` specifically from the squash-to-unknown path. Member-declared `'buying'` is preserved when the snapshot can't classify; all other claimed types (sales / creative / signals) are still squashed to `'unknown'` on a null-inferred snapshot.

**Why this is safe:**

- Sales / creative / signals agents DO expose AdCP tools — when reachable, the probe will classify them. A snapshot row with null `inferred_type` means probe failed OR all tools unrecognised; in either case, the client claiming `'sales'` against a non-classifying snapshot is the smuggle window we're protecting against.
- `'buying'` is structurally exempt: no probe signature distinguishes buying from non-AdCP. A malicious actor claiming `'buying'` against a real sales agent still gets squashed when the probe DOES classify it (case 1 wins over case 2).

## What changed

| File | Change |
|---|---|
| `server/src/routes/member-profiles.ts` | `resolveAgentTypes` carves out `'buying'` in the snapshot-but-null-inferred branch. Docstring expanded from 3 cases to 4 explaining rationale. |
| `server/src/capabilities.ts` | `inferAgentType` docstring updated to reference the carve-out path. Inference itself unchanged — still never returns `'buying'`. |
| `server/tests/unit/resolve-agent-types-buying.test.ts` | New file. 7/7 pass. |

## Coverage matrix (pinned by the new test file)

| # | snapshot | client | result | reason |
|---|---|---|---|---|
| 1 | inferred=`sales` | `buying` | `sales` | probe wins |
| 2 | inferred=null | `buying` | `buying` | **carve-out** |
| 3 | inferred=null | `sales` | `unknown` | smuggle blocked |
| 4 | inferred=null | `creative` | `unknown` | smuggle blocked |
| 5 | inferred=null | `signals` | `unknown` | smuggle blocked |
| 6 | no snapshot | `buying` | `buying` | case 4 (validated) |
| 7 | no snapshot | `buyer` | `unknown` | legacy string drop |

## Test plan

- [x] New: `server/tests/unit/resolve-agent-types-buying.test.ts` — 7/7 pass.
- [x] `npx tsc --noEmit -p server/tsconfig.json` — clean.
- [x] Pre-commit hooks green.

## Backwards compatibility

Non-breaking. No on-the-wire schema change. The only behavior change: member-declared `type: 'buying'` now sticks across probes — previously silently squashed to `'unknown'`, which was the bug. Any consumer reading `agent.type` that expected only `sales | creative | signals | unknown` was already wrong: `'buying'` has been a valid `AgentType` all along (see `types.ts:1`, `registry.ts:512`).

## Out of scope

- Inferring `'buying'` from a probe signal (intentionally not done — no reliable signal exists; would misclassify broken agents).
- UI treatment for `'buying'` agents in the registry.
- `?type=buying` query param on `/api/registry/agents` — separate issue if/when buying agents register and we want filtered views.
- Pairs with #3563 (`?source=`) and #3565 (`endorsed_by_publisher_member`) but no merge-order dependency.