### PR TITLE
fix(auth): cross-domain logout from adcontextprotocol.org actually logs out

### DIFF
--- a/.changeset/fix-aao-logout-cross-domain.md
+++ b/.changeset/fix-aao-logout-cross-domain.md
@@ -1,0 +1,8 @@
+---
+---
+
+Fix: Log out from `adcontextprotocol.org` now actually logs the user out.
+
+Previously, `/auth/logout` on the AdCP domain only cleared the AdCP-side cookies and redirected to `/`. The session bridge would then re-pull the still-valid AAO session and restore the user's cookies, making logout a no-op.
+
+The handler now mirrors the existing `/auth/login` and `/auth/signup` pattern: when on the AdCP domain, it clears AdCP-side cookies and redirects to `https://agenticadvertising.org/auth/logout?return_to=<adcp-url>` so the AAO session is revoked at WorkOS. AAO's logout accepts an AdCP `return_to` (validated via `isAllowedAdcpUrl`) and bounces the user back. After bouncing back, the bridge sees no AAO session, sets `bridge-checked`, and renders the logged-out nav.

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -6746,6 +6746,37 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
         return res.redirect('/');
       }
 
+      const clearAdcpCookies = () => {
+        res.clearCookie('wos-session', {
+          httpOnly: true,
+          secure: process.env.NODE_ENV === 'production' && !ALLOW_INSECURE_COOKIES,
+          sameSite: 'lax',
+          path: '/',
+        });
+        res.clearCookie('bridge-checked', {
+          httpOnly: true,
+          secure: process.env.NODE_ENV === 'production' && !ALLOW_INSECURE_COOKIES,
+          sameSite: 'lax',
+          path: '/',
+        });
+      };
+
+      // If on AdCP domain, the canonical session lives on AAO. Clearing AdCP-side
+      // cookies isn't enough — the bridge would re-pull a still-valid AAO session
+      // and the user would appear logged in again. Clear AdCP cookies, then bounce
+      // to AAO's logout so the AAO session is revoked too.
+      if (this.isAdcpDomain(req)) {
+        clearAdcpCookies();
+        const aaoReturnTo = `https://${req.get('host')}/`;
+        return res.redirect(`https://agenticadvertising.org/auth/logout?return_to=${encodeURIComponent(aaoReturnTo)}`);
+      }
+
+      // Validate return_to: only allow AdCP URLs (so AdCP can chain logout through AAO)
+      const requestedReturnTo = req.query.return_to as string | undefined;
+      const safeReturnTo = requestedReturnTo && HTTPServer.isAllowedAdcpUrl(requestedReturnTo)
+        ? requestedReturnTo
+        : '/';
+
       try {
         const sessionCookie = req.cookies['wos-session'];
 
@@ -6774,36 +6805,15 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
           }
         }
 
-        // Clear the session and bridge-checked cookies
-        res.clearCookie('wos-session', {
-          httpOnly: true,
-          secure: process.env.NODE_ENV === 'production' && !ALLOW_INSECURE_COOKIES,
-          sameSite: 'lax',
-          path: '/',
-        });
-        res.clearCookie('bridge-checked', {
-          httpOnly: true,
-          secure: process.env.NODE_ENV === 'production' && !ALLOW_INSECURE_COOKIES,
-          sameSite: 'lax',
-          path: '/',
-        });
-        res.redirect('/');
+        clearAdcpCookies();
+        // CodeQL: safeReturnTo validated by isAllowedAdcpUrl (or defaulted to '/')
+        res.redirect(safeReturnTo); // lgtm[js/server-side-unvalidated-url-redirection]
       } catch (error) {
         logger.error({ err: error }, 'Error during logout');
         // Still clear cookies and redirect even if revocation failed
-        res.clearCookie('wos-session', {
-          httpOnly: true,
-          secure: process.env.NODE_ENV === 'production' && !ALLOW_INSECURE_COOKIES,
-          sameSite: 'lax',
-          path: '/',
-        });
-        res.clearCookie('bridge-checked', {
-          httpOnly: true,
-          secure: process.env.NODE_ENV === 'production' && !ALLOW_INSECURE_COOKIES,
-          sameSite: 'lax',
-          path: '/',
-        });
-        res.redirect('/');
+        clearAdcpCookies();
+        // CodeQL: safeReturnTo validated by isAllowedAdcpUrl (or defaulted to '/')
+        res.redirect(safeReturnTo); // lgtm[js/server-side-unvalidated-url-redirection]
       }
     });
 


### PR DESCRIPTION
## Summary
- `/auth/logout` on `adcontextprotocol.org` was a no-op: it cleared AdCP-side cookies, redirected to `/`, and the session bridge immediately re-pulled the still-valid AAO session, restoring login state.
- Mirrors the existing `/auth/login` and `/auth/signup` cross-domain redirect pattern (server/src/http.ts:6068, :6181): when on the AdCP domain, clear AdCP-side cookies and bounce to AAO's `/auth/logout` with a `return_to` back to AdCP so the AAO session is actually revoked at WorkOS.
- AAO's `/auth/logout` now accepts a `return_to` query param, validated through the existing `HTTPServer.isAllowedAdcpUrl` guard to prevent open-redirect.

## Test plan
- [ ] Log in on `agenticadvertising.org`, navigate to `adcontextprotocol.org`, click **Log out** → land on `adcontextprotocol.org` logged out, and refreshing `agenticadvertising.org` also shows logged out.
- [ ] Log out directly from `agenticadvertising.org` (no `return_to`) → redirects to `/`.
- [ ] Log out from `agenticadvertising.org` with a non-AdCP `return_to` → falls back to `/` (open-redirect guard).
- [ ] Dev mode logout still works (clears `dev-session` cookie, redirects to `/`).