### PR TITLE
ops(observability): audit_log_insert_failed metric (closes #3574)

### DIFF
--- a/.changeset/audit-log-insert-failed-metric.md
+++ b/.changeset/audit-log-insert-failed-metric.md
@@ -1,0 +1,6 @@
+---
+---
+
+ops(observability): emit `audit_log_insert_failed` PostHog metric when `type_reclassification_log` insert is swallowed
+
+The audit-log insert helper (`server/src/db/type-reclassification-log-db.ts`) intentionally swallows DB errors so observability never blocks a profile save / crawler promote / backfill row write. Until now the only signal of a failed insert was a `warn` log line — fragile to alert on. The catch block now also emits `captureEvent("server-metrics", "audit_log_insert_failed", { source, error_class })`, where `error_class` is the 2-char SQLSTATE class (e.g. `'23'` for integrity violations, `'08'` for connection failures) or `'unknown'` when the thrown error is not a pg error. SREs can now alert on `audit_log_insert_failed > 0 over 5m` and the future audit-log query UI can trust the volume signal. Closes #3574.

--- a/server/src/db/type-reclassification-log-db.ts
+++ b/server/src/db/type-reclassification-log-db.ts
@@ -50,15 +50,19 @@ export async function insertTypeReclassification(
       ]
     );
   } catch (err) {
-    // PostgreSQL SQLSTATE codes are 5 chars; the first 2 are the error class
-    // (e.g. '23' = integrity_constraint_violation, '08' = connection_exception).
-    // The class is what ops actually alerts on — the full code is too granular.
+    // PostgreSQL SQLSTATE codes are exactly 5 chars; the first 2 are the error
+    // class (e.g. '23' = integrity_constraint_violation, '08' = connection_
+    // exception). The class is what ops actually alerts on — the full code is
+    // too granular. Anything that isn't a well-formed SQLSTATE is 'unknown'.
     const pgCode = (err as { code?: unknown })?.code;
     const errorClass =
-      typeof pgCode === 'string' && pgCode.length >= 2
+      typeof pgCode === 'string' && pgCode.length === 5
         ? pgCode.slice(0, 2)
         : 'unknown';
 
+    // Deliberately not labeled by agent_url / member_id — unbounded cardinality
+    // would blow up PostHog event volume. The {source × error_class} cross
+    // product is the alertable shape; the warn log below carries per-row detail.
     captureEvent('server-metrics', 'audit_log_insert_failed', {
       source: entry.source,
       error_class: errorClass,

--- a/server/src/db/type-reclassification-log-db.ts
+++ b/server/src/db/type-reclassification-log-db.ts
@@ -12,6 +12,7 @@
  */
 import { query } from './client.js';
 import { createLogger } from '../logger.js';
+import { captureEvent } from '../utils/posthog.js';
 
 const log = createLogger('type-reclassification-log');
 
@@ -49,6 +50,20 @@ export async function insertTypeReclassification(
       ]
     );
   } catch (err) {
+    // PostgreSQL SQLSTATE codes are 5 chars; the first 2 are the error class
+    // (e.g. '23' = integrity_constraint_violation, '08' = connection_exception).
+    // The class is what ops actually alerts on — the full code is too granular.
+    const pgCode = (err as { code?: unknown })?.code;
+    const errorClass =
+      typeof pgCode === 'string' && pgCode.length >= 2
+        ? pgCode.slice(0, 2)
+        : 'unknown';
+
+    captureEvent('server-metrics', 'audit_log_insert_failed', {
+      source: entry.source,
+      error_class: errorClass,
+    });
+
     log.warn(
       {
         err,

--- a/server/tests/unit/type-reclassification-log-db.test.ts
+++ b/server/tests/unit/type-reclassification-log-db.test.ts
@@ -136,6 +136,25 @@ describe('insertTypeReclassification', () => {
     );
   });
 
+  it('falls back to error_class="unknown" when the pg code is not a well-formed 5-char SQLSTATE', async () => {
+    // SQLSTATE is exactly 5 chars by spec — anything else is malformed and
+    // labeling it with a truncated prefix would be misleading on a dashboard.
+    const malformed = Object.assign(new Error('weird driver'), { code: 'XYZ' });
+    mockedQuery.mockRejectedValueOnce(malformed);
+
+    await insertTypeReclassification({
+      agentUrl: 'https://a',
+      newType: 'sales',
+      source: 'backfill_script',
+    });
+
+    expect(mockedCaptureEvent).toHaveBeenCalledWith(
+      'server-metrics',
+      'audit_log_insert_failed',
+      { source: 'backfill_script', error_class: 'unknown' }
+    );
+  });
+
   it('does not emit the failure metric on a successful insert', async () => {
     await insertTypeReclassification({
       agentUrl: 'https://a',

--- a/server/tests/unit/type-reclassification-log-db.test.ts
+++ b/server/tests/unit/type-reclassification-log-db.test.ts
@@ -4,10 +4,16 @@ vi.mock('../../src/db/client.js', () => ({
   query: vi.fn(),
 }));
 
+vi.mock('../../src/utils/posthog.js', () => ({
+  captureEvent: vi.fn(),
+}));
+
 import { insertTypeReclassification } from '../../src/db/type-reclassification-log-db.js';
 import { query } from '../../src/db/client.js';
+import { captureEvent } from '../../src/utils/posthog.js';
 
 const mockedQuery = vi.mocked(query);
+const mockedCaptureEvent = vi.mocked(captureEvent);
 
 describe('insertTypeReclassification', () => {
   beforeEach(() => {
@@ -94,6 +100,50 @@ describe('insertTypeReclassification', () => {
         source: 'member_write',
       })
     ).resolves.toBeUndefined();
+  });
+
+  it('emits audit_log_insert_failed metric with pg error class on DB failure', async () => {
+    // Simulate a pg integrity constraint violation (SQLSTATE class 23).
+    const pgErr = Object.assign(new Error('duplicate key'), { code: '23505' });
+    mockedQuery.mockRejectedValueOnce(pgErr);
+
+    await insertTypeReclassification({
+      agentUrl: 'https://a',
+      newType: 'sales',
+      source: 'crawler_promote',
+    });
+
+    expect(mockedCaptureEvent).toHaveBeenCalledWith(
+      'server-metrics',
+      'audit_log_insert_failed',
+      { source: 'crawler_promote', error_class: '23' }
+    );
+  });
+
+  it('falls back to error_class="unknown" when the thrown error has no pg code', async () => {
+    mockedQuery.mockRejectedValueOnce(new Error('connection lost'));
+
+    await insertTypeReclassification({
+      agentUrl: 'https://a',
+      newType: 'sales',
+      source: 'member_write',
+    });
+
+    expect(mockedCaptureEvent).toHaveBeenCalledWith(
+      'server-metrics',
+      'audit_log_insert_failed',
+      { source: 'member_write', error_class: 'unknown' }
+    );
+  });
+
+  it('does not emit the failure metric on a successful insert', async () => {
+    await insertTypeReclassification({
+      agentUrl: 'https://a',
+      newType: 'sales',
+      source: 'member_write',
+    });
+
+    expect(mockedCaptureEvent).not.toHaveBeenCalled();
   });
 
   it('accepts each documented source value', async () => {


### PR DESCRIPTION
## Summary

- Closes #3574. The audit-log insert helper (`server/src/db/type-reclassification-log-db.ts`) intentionally swallows DB errors so a failed audit write never blocks the caller's primary intent (member-profile save / crawler promote / backfill row). Until now, the only signal of a swallowed insert was a `warn` log line — fragile to alert on.
- Adds a PostHog metric in the catch block: `captureEvent("server-metrics", "audit_log_insert_failed", { source, error_class })`. `error_class` is the 2-char SQLSTATE class (e.g. `'23'` for integrity violations, `'08'` for connection failures) — the class, not the full 5-char code, is what ops alerts on. Falls back to `'unknown'` when the thrown error has no pg `.code`.
- Pairs with #3567 (the table itself, merged today) and the future audit-log query admin UI, both of which assume audit-log volume is reliable. Ops can now alert on `audit_log_insert_failed > 0 over 5m`.

## Why this metrics surface

The triage on #3574 noted there's no `metrics.increment()` helper in this repo — the canonical metrics layer is PostHog via `captureEvent()` (see `server/src/middleware/request-metrics.ts:43`). This PR uses that same pattern.

## Test plan

- [x] `npx vitest run tests/unit/type-reclassification-log-db.test.ts` — 9/9 pass (6 existing + 3 new)
  - emits `error_class: '23'` from a `code: '23505'` error
  - falls back to `error_class: 'unknown'` for plain `Error`
  - does **not** emit on a successful insert
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `precommit` hook (full unit suite + dynamic-import check + callapi state-change + typecheck) — clean

## Out of scope

- Alerting policy / Grafana dashboard — runbook concern, per the issue.
- A standalone metrics framework — this repo already has PostHog; no new infrastructure needed.