### PR TITLE
fix(fixture): correct creative-ad-server pricing_options field names

### DIFF
--- a/.changeset/fix-creative-ad-server-pricing-fixture.md
+++ b/.changeset/fix-creative-ad-server-pricing-fixture.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix creative-ad-server fixture pricing_options fields to match vendor-pricing-option.json / signal-pricing.json CpmPricing variant: `pricing_model` → `model`, `rate` → `cpm`. Also corrects matching prose in the `expected` narrative block. Refs #3760.

--- a/static/compliance/source/specialisms/creative-ad-server/index.yaml
+++ b/static/compliance/source/specialisms/creative-ad-server/index.yaml
@@ -69,8 +69,8 @@ fixtures:
         id: "vast_30s"
       pricing_options:
         - pricing_option_id: "po_vast_30s_cpm"
-          pricing_model: "cpm"
-          rate: 0.50
+          model: "cpm"
+          cpm: 0.50
           currency: "USD"
 
 phases:
@@ -147,7 +147,7 @@ phases:
           - format_id referencing the creative's format
           - name and status (approved, pending_review, rejected)
           - concept_id grouping related creatives across sizes
-          - pricing_options array with pricing_option_id, model, rate, currency —
+          - pricing_options array with pricing_option_id, model, cpm, currency —
             only when your agent bills through AdCP and include_pricing=true with
             an account provided. Agents that bill out of band omit this field.
 


### PR DESCRIPTION
Refs #3760

## Summary

The creative-ad-server storyboard fixture at `static/compliance/source/specialisms/creative-ad-server/index.yaml` used wrong field names for its `pricing_options` entry. `creatives[].pricing_options[]` resolves via `vendor-pricing-option.json` → `signal-pricing.json`, whose `CpmPricing` variant requires `model` + `cpm` + `currency`. The fixture was using the product-side discriminator names (`pricing_model`, `rate`) instead.

**Non-breaking justification:** Only fixture seed data is changed. No JSON schema files, no task definitions, no normative docs are modified. The compliance build (`npm run build:compliance`) passes clean. The runtime ad-server already emits correct `model`/`cpm`/`currency` fields — the wrong fixture fields were being silently ignored by the controller seeding path (no AJV validation runs on seed data).

## Changes

```diff
-          pricing_model: "cpm"
+          model: "cpm"
-          rate: 0.50
+          cpm: 0.50
```

Also corrects the `expected:` prose in the `list_creatives` step which repeated the same `rate` mistake.

## Follow-up

The underlying reason this went undetected: `controller_seeding: true` fixture data is not run through AJV — it seeds `CreativeState` directly. A storyboard-level schema validation test for `creative-ad-server` would have caught this immediately (see adcp-client#778 for the open wiring ticket). This PR does not add that test; that's a separate effort.

## Pre-PR review

- **code-reviewer:** approved — fix is correct; changeset and prose fixes addressed (1 nit: no storyboard test, noted as follow-up)
- **ad-tech-protocol-expert:** approved — non-breaking per spec; `--empty` changeset confirmed; `vendor_pricing_option` vs `product_pricing_option` asymmetry is intentional

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01QgBMJjtFXgbXE9JuRZsY7M

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgBMJjtFXgbXE9JuRZsY7M)_