### PR TITLE
fix(registry): canonicalize agent_url before registered/discovered collapse (closes #3573)

### DIFF
--- a/.changeset/canonicalize-agent-url-collapse.md
+++ b/.changeset/canonicalize-agent-url-collapse.md
@@ -1,0 +1,22 @@
+---
+---
+
+fix(registry): canonicalize agent_url at federated-index merge + discovered writes (closes #3573)
+
+The registered/discovered collapse in `listAllAgents` and `lookupDomain`
+keyed on raw `agent_url` strings. A registered `https://agent.example/`
+and a discovered `https://agent.example` would surface as two separate
+entries instead of collapsing to the registered row.
+
+Read-side (`server/src/federated-index.ts`): map keys + lookups now go
+through the existing `canonicalizeAgentUrl` helper (lowercase, trailing
+slash stripped) so case- and slash-only differences collapse.
+
+Write-side (`recordAgentFromAdagentsJson`, `recordPublisherFromAgent`,
+`updateAgentMetadata`): canonicalize before persisting so legacy
+`discovered_agents` and `agent_publisher_authorizations` rows match the
+shape the catalog-side already enforces. Forward-only — existing rows
+are not migrated.
+
+Tests pin slash collapse, host-case collapse, and that scheme mismatch
+(http vs https) intentionally does NOT collapse.

--- a/server/src/federated-index.ts
+++ b/server/src/federated-index.ts
@@ -1,6 +1,14 @@
 import { FederatedIndexDatabase, type DiscoveredAgent, type DiscoveredPublisher, type AgentPublisherAuthorization, type DiscoveredProperty, type PropertyIdentifier, type PublisherPropertySelector } from './db/federated-index-db.js';
 import { MemberDatabase } from './db/member-db.js';
+import { canonicalizeAgentUrl } from './db/publisher-db.js';
 import type { FederatedAgent, FederatedPublisher, DomainLookupResult, AgentType } from './types.js';
+
+// Local helper: canonicalize for in-memory collapse (lowercase scheme/host,
+// trailing slash stripped). Falls back to the raw value when canonicalization
+// returns null so we never silently drop a row from the merged view.
+function collapseKey(url: string): string {
+  return canonicalizeAgentUrl(url) ?? url;
+}
 
 /**
  * Service layer for federated agent/publisher discovery.
@@ -69,7 +77,10 @@ export class FederatedIndexService {
         const agentType = agentConfig.type || 'unknown';
         if (type && agentType !== type) continue;
 
-        registeredAgents.set(agentConfig.url, {
+        // Key on the canonical form (lowercase, trailing slash stripped) so
+        // a registered `https://agent.example/` collapses with a discovered
+        // `https://agent.example`. Issue #3573.
+        registeredAgents.set(collapseKey(agentConfig.url), {
           url: agentConfig.url,
           name: agentConfig.name || profile.display_name,
           type: agentType as FederatedAgent['type'],
@@ -96,7 +107,7 @@ export class FederatedIndexService {
     const result: FederatedAgent[] = Array.from(registeredAgents.values());
 
     for (const discovered of discoveredAgents) {
-      if (registeredAgents.has(discovered.agent_url)) {
+      if (registeredAgents.has(collapseKey(discovered.agent_url))) {
         continue; // Skip if already registered
       }
 
@@ -205,7 +216,10 @@ export class FederatedIndexService {
     for (const profile of profiles) {
       for (const agentConfig of profile.agents || []) {
         if (agentConfig.visibility === 'public') {
-          registeredAgentUrls.set(agentConfig.url, {
+          // Key on canonical form so trailing-slash / case differences
+          // between registered and discovered/claim agent_url still
+          // resolve to the registered member. Issue #3573.
+          registeredAgentUrls.set(collapseKey(agentConfig.url), {
             slug: profile.slug,
             display_name: profile.display_name,
           });
@@ -218,7 +232,7 @@ export class FederatedIndexService {
     const authorizedAgents = authorizations
       .filter(auth => auth.source === 'adagents_json')
       .map(auth => {
-        const member = registeredAgentUrls.get(auth.agent_url);
+        const member = registeredAgentUrls.get(collapseKey(auth.agent_url));
         return {
           url: auth.agent_url,
           authorized_for: auth.authorized_for,
@@ -230,7 +244,7 @@ export class FederatedIndexService {
     // Get sales agents claiming this domain
     const claims = await this.db.getSalesAgentsClaimingDomain(domain);
     const salesAgentsClaiming = claims.map(claim => {
-      const member = registeredAgentUrls.get(claim.discovered_by_agent);
+      const member = registeredAgentUrls.get(collapseKey(claim.discovered_by_agent));
       return {
         url: claim.discovered_by_agent,
         source: member ? 'registered' as const : 'discovered' as const,
@@ -297,6 +311,12 @@ export class FederatedIndexService {
 
   /**
    * Record an agent discovered from an adagents.json file.
+   *
+   * Canonicalizes agent_url at the entry point (lowercase, trailing
+   * slash stripped) so legacy `discovered_agents` and
+   * `agent_publisher_authorizations` rows store the same shape the
+   * catalog-side already enforces. Forward-only — existing rows are not
+   * migrated. Issue #3573.
    */
   async recordAgentFromAdagentsJson(
     agentUrl: string,
@@ -304,16 +324,19 @@ export class FederatedIndexService {
     authorizedFor?: string,
     propertyIds?: string[]
   ): Promise<void> {
+    const canonical = canonicalizeAgentUrl(agentUrl);
+    if (!canonical) return; // Skip unusable URLs (whitespace, embedded '*', empty)
+
     // Record the agent
     await this.db.upsertAgent({
-      agent_url: agentUrl,
+      agent_url: canonical,
       source_type: 'adagents_json',
       source_domain: publisherDomain,
     });
 
     // Record the authorization
     await this.db.upsertAuthorization({
-      agent_url: agentUrl,
+      agent_url: canonical,
       publisher_domain: publisherDomain,
       authorized_for: authorizedFor,
       property_ids: propertyIds,
@@ -323,21 +346,27 @@ export class FederatedIndexService {
 
   /**
    * Record a publisher discovered from a sales agent's list_authorized_properties.
+   *
+   * Canonicalizes agent_url for the legacy authorization row so it
+   * collapses with adagents.json-side records. Issue #3573.
    */
   async recordPublisherFromAgent(
     domain: string,
     salesAgentUrl: string,
     hasValidAdagents?: boolean
   ): Promise<void> {
+    const canonicalAgent = canonicalizeAgentUrl(salesAgentUrl);
     await this.db.upsertPublisher({
       domain,
-      discovered_by_agent: salesAgentUrl,
+      discovered_by_agent: canonicalAgent ?? salesAgentUrl,
       has_valid_adagents: hasValidAdagents,
     });
 
+    if (!canonicalAgent) return;
+
     // Also record the claim (unverified authorization)
     await this.db.upsertAuthorization({
-      agent_url: salesAgentUrl,
+      agent_url: canonicalAgent,
       publisher_domain: domain,
       source: 'agent_claim',
     });
@@ -350,7 +379,7 @@ export class FederatedIndexService {
     agentUrl: string,
     metadata: { name?: string; agent_type?: string; protocol?: string }
   ): Promise<void> {
-    await this.db.updateAgentMetadata(agentUrl, metadata);
+    await this.db.updateAgentMetadata(canonicalizeAgentUrl(agentUrl) ?? agentUrl, metadata);
   }
 
   /**

--- a/server/tests/unit/registry-discovered-endorsement.test.ts
+++ b/server/tests/unit/registry-discovered-endorsement.test.ts
@@ -252,6 +252,116 @@ describe('FederatedIndexService.listAllAgents — endorsed_by_publisher_member',
     expect(agents[0].endorsed_by_publisher_member).toBeUndefined();
   });
 
+  it('collapses registered + discovered when only the trailing slash differs (issue #3573)', async () => {
+    // Pin: a registered agent stored as `https://shared.agent.example.com/`
+    // (with trailing slash) collides with a discovered row recorded as
+    // `https://shared.agent.example.com` (no slash). They must surface
+    // as a single registered row, not two.
+    setupProfilesAndDiscovered({
+      profiles: [
+        {
+          slug: 'acme',
+          display_name: 'Acme',
+          agents: [
+            {
+              url: 'https://shared.agent.example.com/',
+              visibility: 'public',
+              type: 'sales',
+              name: 'Acme Agent',
+            },
+          ],
+        },
+      ],
+      discoveredAgents: [
+        {
+          agent_url: 'https://shared.agent.example.com',
+          source_type: 'adagents_json',
+          source_domain: 'pub.example.com',
+          name: 'Acme Agent',
+          agent_type: 'sales',
+          protocol: 'mcp',
+        },
+      ],
+    });
+
+    const svc = new FederatedIndexService();
+    const agents = await svc.listAllAgents();
+
+    expect(agents).toHaveLength(1);
+    expect(agents[0].source).toBe('registered');
+  });
+
+  it('collapses registered + discovered when only host case differs (issue #3573)', async () => {
+    setupProfilesAndDiscovered({
+      profiles: [
+        {
+          slug: 'acme',
+          display_name: 'Acme',
+          agents: [
+            {
+              url: 'https://Shared.Agent.Example.com/mcp',
+              visibility: 'public',
+              type: 'sales',
+              name: 'Acme Agent',
+            },
+          ],
+        },
+      ],
+      discoveredAgents: [
+        {
+          agent_url: 'https://shared.agent.example.com/mcp',
+          source_type: 'adagents_json',
+          source_domain: 'pub.example.com',
+          name: 'Acme Agent',
+          agent_type: 'sales',
+          protocol: 'mcp',
+        },
+      ],
+    });
+
+    const svc = new FederatedIndexService();
+    const agents = await svc.listAllAgents();
+
+    expect(agents).toHaveLength(1);
+    expect(agents[0].source).toBe('registered');
+  });
+
+  it('does NOT collapse on scheme mismatch — http vs https are different security postures (issue #3573)', async () => {
+    setupProfilesAndDiscovered({
+      profiles: [
+        {
+          slug: 'acme',
+          display_name: 'Acme',
+          agents: [
+            {
+              url: 'https://shared.agent.example.com/mcp',
+              visibility: 'public',
+              type: 'sales',
+              name: 'Acme Agent',
+            },
+          ],
+        },
+      ],
+      discoveredAgents: [
+        {
+          agent_url: 'http://shared.agent.example.com/mcp',
+          source_type: 'adagents_json',
+          source_domain: 'pub.example.com',
+          name: 'Acme Agent',
+          agent_type: 'sales',
+          protocol: 'mcp',
+        },
+      ],
+    });
+
+    const svc = new FederatedIndexService();
+    const agents = await svc.listAllAgents();
+
+    expect(agents).toHaveLength(2);
+    const sources = agents.map((a) => a.source).sort();
+    expect(sources).toEqual(['discovered', 'registered']);
+  });
+
   it('uses authorization publisher_domain over discovered.source_domain when present', async () => {
     // First-auth from bulkGetFirstAuthForAgents takes precedence in
     // populating discovered_from.publisher_domain. The endorsement lookup


### PR DESCRIPTION
Closes #3573. Refs #3565 (the blocker, now merged).

The registered-vs-discovered collapse in `FederatedIndexService.listAllAgents` and `lookupDomain` keyed on `agent_url` as a raw string. A registered `https://agent.example/` and a discovered `https://agent.example` would surface as two separate entries instead of collapsing to the registered row.

Read-side and write-side are now consistent with the catalog-side, which already uses `canonicalizeAgentUrl` (`server/src/db/publisher-db.ts:96`).

## What changed

- `server/src/federated-index.ts`
  - New `collapseKey()` helper wraps the existing `canonicalizeAgentUrl` for in-memory map keys (lowercase, trailing slash stripped; raw fallback so we never silently drop a row).
  - `listAllAgents`: `registeredAgents` Map keyed on canonical form; `discovered.agent_url` canonicalized for the lookup.
  - `lookupDomain`: same treatment for `registeredAgentUrls` Map and the auth/claim member-resolution lookups.
  - `recordAgentFromAdagentsJson` / `recordPublisherFromAgent` / `updateAgentMetadata`: canonicalize once at the entry point so legacy `discovered_agents` and `agent_publisher_authorizations` rows store the same shape the catalog-side already enforces. Forward-only — existing rows are not migrated, per the issue's out-of-scope note.
- `server/tests/unit/registry-discovered-endorsement.test.ts` — three new pins:
  - registered `https://shared.agent.example.com/` collapses with discovered `https://shared.agent.example.com`.
  - case-only host difference collapses (`Shared.Agent.Example.com` vs lowercase).
  - scheme mismatch (`http` vs `https`) intentionally does NOT collapse — different security posture.
- `.changeset/canonicalize-agent-url-collapse.md` — empty changeset (server-only fix, no protocol bump).

## Test plan

- [x] `npx vitest run server/tests/unit/registry-discovered-endorsement.test.ts` — 9/9 pass (6 existing + 3 new).
- [x] `npm run typecheck` — clean.
- [x] Pre-commit hook (test:unit + test:test-dynamic-imports + test:callapi-state-change + typecheck) — green.
- [ ] CI green.

## Out of scope

- Migration of existing non-canonical rows in `discovered_agents` / `agent_publisher_authorizations` — issue explicitly defers; the canonicalization is forward-only. Could be a one-off cleanup PR if a sweep finds collisions.
- Member-profile write path (`routes/member-profiles.ts`): registered agent URLs still flow in verbatim from user input. Read-side canonicalization handles the collapse, so the user-visible bug is fixed without changing the user-facing contract on what gets stored.
- Cross-registration (e.g. `example.com` vs `www.example.com`) — separate identity question.