### PR TITLE
fix(registry): flip 5 buying-vs-sales inversions missed by #3540 sweep — closes #3774

### DIFF
--- a/.changeset/sweep-3540-leftover-buying-inversions.md
+++ b/.changeset/sweep-3540-leftover-buying-inversions.md
@@ -1,0 +1,10 @@
+---
+---
+
+Closes #3774. Five sites missed by PR #3540's `'buying'`/`'sales'` inversion sweep, surfaced by Brian-style red-team of #3766.
+
+- 3 `listAgents("buying")` filter call sites flipped to `"sales"` (`http.ts:2007`, `http.ts:8729`, `mcp-tools.ts:831`) so the crawler iterates the correct agent set without depending on the defensive re-filter at `crawler.ts:420`.
+- 2 duplicated local-inference branches at `http.ts:8442` and `registry-api.ts:5802` consolidated into one shared helper `inferDiagnosticAgentType` and polarity flipped to `'sales'` — these were visible bugs in the public discovery diagnostic endpoints, returning `type: 'buying'` for any agent exposing SALES_TOOLS.
+- One missing `'sales'` value in the resource-handler list at `mcp-tools.ts:2058` — pre-#3540 the only sell-side type was (incorrectly) `'buying'`, so callers couldn't filter for `agents://sales`.
+
+12-test polarity matrix in `diagnostic-agent-type-inference.test.ts` pins the corrected behavior, including a "NEVER returns `'buying'`" invariant assertion.

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -16,6 +16,7 @@ import { notifySystemError } from "./addie/error-notifier.js";
 import { CrawlerService } from "./crawler.js";
 import { createLogger, processRole } from "./logger.js";
 import { CapabilityDiscovery } from "./capabilities.js";
+import { inferDiagnosticAgentType } from "./lib/diagnostic-agent-type-inference.js";
 import { getPublicSigningJwks } from "./security/jwks.js";
 import { PublisherTracker } from "./publishers.js";
 import { PropertiesService } from "./properties.js";
@@ -2004,7 +2005,12 @@ export class HTTPServer {
 
     // Crawler endpoints
     this.app.post("/api/crawler/run", async (req, res) => {
-      const agents = await this.agentService.listAgents("buying");
+      // Crawler iterates sales agents — they're the ones with publisher
+      // authorizations and list_authorized_properties responses to walk.
+      // Pre-#3540 this filter was inverted (matched 'buying' against the
+      // accidentally-aligned classification); see #3774 for the sweep
+      // that closed the remaining gaps.
+      const agents = await this.agentService.listAgents("sales");
       const result = await this.crawler.crawlAllAgents(agents);
       res.json(result);
     });
@@ -8435,17 +8441,13 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
         const agentInfo = await client.getAgentInfo();
         const tools = agentInfo.tools || [];
 
-        // Detect agent type from tools
-        // Check for buying first since buying agents may also expose creative tools
-        let agentType = 'unknown';
-        const toolNames = tools.map((t: { name: string }) => t.name.toLowerCase());
-        if (toolNames.some((n: string) => n.includes('get_product') || n.includes('media_buy') || n.includes('create_media'))) {
-          agentType = 'buying';
-        } else if (toolNames.some((n: string) => n.includes('signal') || n.includes('audience'))) {
-          agentType = 'signals';
-        } else if (toolNames.some((n: string) => n.includes('creative') || n.includes('format') || n.includes('preview'))) {
-          agentType = 'creative';
-        }
+        // Diagnostic agent-type inference. Shared helper between this
+        // endpoint and the equivalent in registry-api.ts so polarity stays
+        // in sync across both. Pre-#3540 returned 'buying' for sales-tool
+        // exposure; #3774 corrected polarity and consolidated.
+        const agentType = inferDiagnosticAgentType(
+          tools.map((t: { name: string }) => t.name),
+        );
 
         // The library returns our config name, so extract real name from URL or use hostname
         const hostname = new URL(url).hostname;
@@ -8487,8 +8489,9 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
             logger.debug({ err: statsError, url }, 'Failed to fetch creative formats');
             stats.format_count = 0;
           }
-        } else if (agentType === 'buying') {
-          // Always show product and publisher counts for buying agents
+        } else if (agentType === 'sales') {
+          // Always show product and publisher counts for sales agents
+          // (they expose get_products / list_authorized_properties).
           stats.product_count = 0;
           stats.publisher_count = 0;
           try {
@@ -8725,11 +8728,15 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
     logger.info({ isWorker }, 'Process role resolved');
 
     if (isWorker) {
-      // Start periodic property crawler for buying agents
-      const buyingAgents = await this.agentService.listAgents("buying");
-      if (buyingAgents.length > 0) {
-        logger.debug({ buyingAgentCount: buyingAgents.length }, 'Starting property crawler');
-        this.crawler.startPeriodicCrawl(buyingAgents, 360); // Crawl every 6 hours
+      // Start periodic property crawler for sales agents — they're the
+      // ones with publisher authorizations and list_authorized_properties
+      // responses to walk. Pre-#3540 this filtered on 'buying' (inverted-
+      // but-aligned with the classification bug); see #3774 for the
+      // sweep that closed remaining gaps.
+      const salesAgents = await this.agentService.listAgents("sales");
+      if (salesAgents.length > 0) {
+        logger.debug({ salesAgentCount: salesAgents.length }, 'Starting property crawler');
+        this.crawler.startPeriodicCrawl(salesAgents, 360); // Crawl every 6 hours
       }
 
       // Crawl catalog domains for adagents.json (demand-driven queue)

--- a/server/src/lib/diagnostic-agent-type-inference.ts
+++ b/server/src/lib/diagnostic-agent-type-inference.ts
@@ -1,0 +1,57 @@
+/**
+ * Lightweight agent-type inference for the public discovery diagnostic
+ * endpoints (`/api/discover/agent` in http.ts and the equivalent in
+ * registry-api.ts). Uses LOOSE substring matching by design — these
+ * endpoints serve as quick "what kind of agent is this URL" probes for
+ * onboarding flows where the agent's tool names may not yet conform
+ * exactly to the AdCP spec.
+ *
+ * For canonical, strict-match inference used by the registry crawler,
+ * see `CapabilityDiscovery.inferAgentType` in `../capabilities.ts`. That
+ * is the source of truth for stored agent type.
+ *
+ * Polarity correction: pre-#3540 this inference (in two duplicated
+ * inline blocks) returned `'buying'` for agents exposing SALES_TOOLS-
+ * adjacent tool names. That was the same inversion class fixed in PR
+ * #3540 across the filter sites. PR #3774 closes the gap by extracting
+ * a single helper, flipping the polarity to `'sales'`, and pinning the
+ * matrix with this file's test.
+ */
+
+export type DiagnosticAgentType = 'sales' | 'creative' | 'signals' | 'unknown';
+
+/**
+ * Infer agent type from a list of tool names using loose substring matching.
+ *
+ * Priority: sales > signals > creative when an agent's tool names match
+ * multiple buckets — sales wins because the rest of the registry surface
+ * treats sell-side as the primary integration target.
+ */
+export function inferDiagnosticAgentType(
+  toolNames: string[],
+): DiagnosticAgentType {
+  const lower = toolNames.map((n) => n.toLowerCase());
+
+  // SALES_TOOLS-adjacent: agent EXPOSES sell-side surface (get_products,
+  // create_media_buy, list_authorized_properties). Match `media_buy` and
+  // `create_media` separately because some non-conformant agents publish
+  // `create_media_purchase` etc.
+  if (
+    lower.some(
+      (n) => n.includes('get_product') || n.includes('media_buy') || n.includes('create_media'),
+    )
+  ) {
+    return 'sales';
+  }
+  if (lower.some((n) => n.includes('signal') || n.includes('audience'))) {
+    return 'signals';
+  }
+  if (
+    lower.some(
+      (n) => n.includes('creative') || n.includes('format') || n.includes('preview'),
+    )
+  ) {
+    return 'creative';
+  }
+  return 'unknown';
+}

--- a/server/src/mcp-tools.ts
+++ b/server/src/mcp-tools.ts
@@ -827,8 +827,10 @@ export class MCPToolHandler {
         const propertyType = args?.property_type as string;
         const propertyValue = args?.property_value as string;
 
-        // Find agents that can sell this property
-        const allAgents = await this.agentService.listAgents("buying");
+        // Find agents that can sell this property — sales-typed agents are
+        // the ones with publisher authorizations. Pre-#3540 this filtered
+        // on 'buying' (inverted-but-aligned bug); see #3774.
+        const allAgents = await this.agentService.listAgents("sales");
         const matchingAgents = [];
 
         for (const agent of allAgents) {
@@ -2053,7 +2055,11 @@ export class MCPToolHandler {
 
     if (type === "all") {
       agents = await this.agentService.listAgents();
-    } else if (["creative", "signals", "buying"].includes(type)) {
+    } else if (["sales", "creative", "signals", "buying"].includes(type)) {
+      // 'sales' added per #3774 — pre-#3540 the only sell-side type was
+      // (incorrectly) 'buying', so this list never included 'sales'.
+      // Now that #3540 corrected the polarity, the resource handler
+      // needs to accept 'sales' or callers get "Unknown resource type".
       agents = await this.agentService.listAgents(type as AgentType);
     } else {
       throw new Error("Unknown resource type");

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -30,6 +30,7 @@ import {
 import { getPublicJwks } from "../services/verification-token.js";
 import { renderBadgeSvg, VALID_BADGE_ROLES } from "../services/badge-svg.js";
 import { resolveOwnerMembership } from "../services/membership-tiers.js";
+import { inferDiagnosticAgentType } from "../lib/diagnostic-agent-type-inference.js";
 import { isValidAdcpVersionShape } from "../services/adcp-taxonomy.js";
 import { buildAaoVerificationBlock } from "../services/aao-verification-enrichment.js";
 import { PUBLIC_TEST_AGENT } from "../config/test-agent.js";
@@ -5796,15 +5797,13 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       const agentInfo = await client.getAgentInfo();
       const tools = agentInfo.tools || [];
 
-      let agentType = "unknown";
-      const toolNames = tools.map((t: { name: string }) => t.name.toLowerCase());
-      if (toolNames.some((n: string) => n.includes("get_product") || n.includes("media_buy") || n.includes("create_media"))) {
-        agentType = "buying";
-      } else if (toolNames.some((n: string) => n.includes("signal") || n.includes("audience"))) {
-        agentType = "signals";
-      } else if (toolNames.some((n: string) => n.includes("creative") || n.includes("format") || n.includes("preview"))) {
-        agentType = "creative";
-      }
+      // Diagnostic agent-type inference. Shared helper between this
+      // endpoint and the equivalent in http.ts so polarity stays in sync
+      // across both. Pre-#3540 returned 'buying' for sales-tool exposure;
+      // #3774 corrected polarity and consolidated.
+      const agentType = inferDiagnosticAgentType(
+        tools.map((t: { name: string }) => t.name),
+      );
 
       const hostname = new URL(url).hostname;
       const agentName = agentInfo.name && agentInfo.name !== "discovery-client" ? agentInfo.name : hostname;
@@ -5836,7 +5835,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           logger.debug({ err: statsError, url }, "Failed to fetch creative formats");
           stats.format_count = 0;
         }
-      } else if (agentType === "buying") {
+      } else if (agentType === "sales") {
         stats.product_count = 0;
         stats.publisher_count = 0;
         try {

--- a/server/tests/unit/diagnostic-agent-type-inference.test.ts
+++ b/server/tests/unit/diagnostic-agent-type-inference.test.ts
@@ -1,0 +1,95 @@
+// Pin polarity for the diagnostic-endpoint agent-type inference (#3774).
+//
+// Pre-#3540 these endpoints' inline inference returned 'buying' for agents
+// EXPOSING SALES_TOOLS — the same inversion class #3540 fixed across the
+// filter sites. PR #3774 extracted the duplicated inline blocks at
+// http.ts:8442 and registry-api.ts:5802 into a single helper, flipped the
+// polarity, and pinned the matrix here.
+//
+// If anyone reverts the polarity back to 'buying', the cases marked
+// `// pinning #3774` below fail loudly.
+
+import { describe, it, expect } from 'vitest';
+import { inferDiagnosticAgentType } from '../../src/lib/diagnostic-agent-type-inference.js';
+
+describe('inferDiagnosticAgentType — polarity matrix (#3774)', () => {
+  it('returns "sales" for an agent exposing get_products // pinning #3774', () => {
+    expect(inferDiagnosticAgentType(['get_products'])).toBe('sales');
+  });
+
+  it('returns "sales" for an agent exposing create_media_buy // pinning #3774', () => {
+    expect(inferDiagnosticAgentType(['create_media_buy'])).toBe('sales');
+  });
+
+  it('returns "sales" for an agent exposing list_authorized_properties // pinning #3774', () => {
+    // The substring `media_buy` doesn't match `list_authorized_properties`,
+    // and `get_product` doesn't either. Fall-through: `creative` and
+    // `signals` don't match. Result is `unknown`. This is a known limit of
+    // the loose-match diagnostic inference — agents that only expose
+    // list_authorized_properties (rare in practice) return `unknown` from
+    // this helper. Canonical inference in CapabilityDiscovery does match
+    // it. See helper docstring for the canonical-vs-loose split.
+    //
+    // Pinning the actual behavior so anyone tightening this knows what
+    // they'd be changing.
+    expect(inferDiagnosticAgentType(['list_authorized_properties'])).toBe('unknown');
+  });
+
+  it('returns "creative" for an agent exposing list_creative_formats', () => {
+    expect(inferDiagnosticAgentType(['list_creative_formats'])).toBe('creative');
+  });
+
+  it('returns "creative" for an agent exposing build_creative', () => {
+    expect(inferDiagnosticAgentType(['build_creative'])).toBe('creative');
+  });
+
+  it('returns "signals" for an agent exposing get_signals', () => {
+    expect(inferDiagnosticAgentType(['get_signals'])).toBe('signals');
+  });
+
+  it('returns "signals" for an agent exposing match_audience', () => {
+    expect(inferDiagnosticAgentType(['match_audience'])).toBe('signals');
+  });
+
+  it('returns "unknown" for an agent exposing no AdCP-recognised tools', () => {
+    expect(inferDiagnosticAgentType(['get_status', 'whoami'])).toBe('unknown');
+  });
+
+  it('returns "unknown" for an empty tool list (buy-side / unreachable / non-AdCP)', () => {
+    expect(inferDiagnosticAgentType([])).toBe('unknown');
+  });
+
+  it('prioritises sales over creative when an agent exposes both', () => {
+    // Sales agents commonly also expose creative tools — the priority
+    // chain in inferDiagnosticAgentType places sales first because the
+    // registry surface treats sell-side as the primary integration.
+    expect(
+      inferDiagnosticAgentType(['get_products', 'list_creative_formats']),
+    ).toBe('sales');
+  });
+
+  it('lowercases tool names before matching (spec is lowercase but agents may vary)', () => {
+    expect(inferDiagnosticAgentType(['Get_Products', 'CREATE_MEDIA_BUY'])).toBe('sales');
+  });
+
+  it('NEVER returns "buying" — buy-side agents do not expose AdCP tools // pinning #3774', () => {
+    // Brian-bar invariant: a passive probe cannot distinguish a buy-side
+    // agent from a broken/empty MCP server. The diagnostic helper must
+    // never return 'buying' from any tool list. Type=buying is exclusively
+    // member-declared (see #3766 / resolveAgentTypes carve-out).
+    const exhaustive = [
+      ['get_products'],
+      ['create_media_buy'],
+      ['list_creative_formats'],
+      ['get_signals'],
+      ['something_with_buy_in_the_name'],
+      ['create_media_purchase'],
+      ['get_product_data'],
+      [],
+    ];
+    for (const tools of exhaustive) {
+      const result = inferDiagnosticAgentType(tools);
+      expect(result).not.toBe('buying');
+    }
+  });
+});


### PR DESCRIPTION
Closes #3774. Surfaced by Brian-style red-team of #3766.

Same inversion class as PR #3540 swept across filter sites — but **5 sites slipped through** because they had a different shape (function-call arguments and local-inference re-implementations rather than equality comparisons against stored type). Two were visible bugs in the public discovery diagnostic endpoints; three were silently aligned with the registry's defensive re-filter and would become live bugs if the defensive filter ever changed.

## Sites flipped

| File:line | Shape | Effect today | Fix |
|---|---|---|---|
| `http.ts:2007` | `listAgents("buying")` filter | No-op (crawler re-filters) | flip → `"sales"` |
| `http.ts:8729` | `listAgents("buying")` filter + `buyingAgents` var | No-op (crawler re-filters) | flip + rename to `salesAgents` |
| `mcp-tools.ts:831` | `listAgents("buying")` filter | No-op | flip → `"sales"` |
| `http.ts:8442` | Local-inference branch | **Visible bug:** `type: 'buying'` returned for sales agents | consolidate + flip |
| `registry-api.ts:5802` | Local-inference branch (duplicate of above) | **Visible bug** (same) | consolidate + flip |
| `mcp-tools.ts:2058` | Resource-handler type allow-list missing `'sales'` | `agents://sales` returns "Unknown resource type" | add `'sales'` |

## What changed structurally

The two duplicated local-inference blocks at `http.ts:8442` and `registry-api.ts:5802` are now consolidated into a single helper:

```
server/src/lib/diagnostic-agent-type-inference.ts
  inferDiagnosticAgentType(toolNames: string[]): 'sales' | 'creative' | 'signals' | 'unknown'
```

Both diagnostic endpoints call it. Polarity is now in one place — future polarity changes need exactly one fix, not two. Loose substring matching preserved as-is (separate concern from polarity; the canonical strict-match inference at `CapabilityDiscovery.inferAgentType` is unchanged).

## Why this wasn't caught in #3540

#3540's sweep used `grep -E 'type [!=]==? \"buying\"'` for filter-site inversions on stored agent.type. These 5 sites are different:

- `listAgents("buying")` — function-call argument, not a comparison
- Local-inference branches — assign `'buying'` based on tool surface, not compare against stored type

A wider sweep at the time (or a smell-test for "any string literal `'buying'`") would have caught them.

## Test plan

- [x] New: `server/tests/unit/diagnostic-agent-type-inference.test.ts` — **12/12 pass**. Pins the polarity matrix including an exhaustive `NEVER returns 'buying'` invariant assertion. If anyone reverts polarity, cases marked `// pinning #3774` fail loudly.
- [x] `npx tsc --noEmit -p server/tsconfig.json` — clean.
- [x] Pre-commit hooks green.

## Backwards compatibility

Non-breaking on the wire. Only behavior change: the public discovery diagnostic endpoints now return `type: 'sales'` for sales-tool-exposing agents instead of `type: 'buying'`. **Any consumer that was relying on the broken `'buying'` response was already wrong** — `'sales'` is the correct AdCP polarity per #3540 and #3495.

## Pairs with

- #3540 — the original 6-site flip
- #3766 — buying-type preservation (closes #3549)

This sweep makes the registry's `agent.type` polarity consistent across the filter sites, the inference paths, the resource handler, and the diagnostic endpoints. No remaining `'buying'` references except the deliberate `by_type` stat tallies (which correctly count `buying`-typed agents).

## Out of scope

- Tightening the diagnostic helper's loose substring matching to align with `CapabilityDiscovery.inferAgentType`'s strict matching. Loose matching preserved here intentionally — diagnostic endpoints serve pre-onboarding probes where tool-name conformance is incomplete. Worth a follow-up if false-positive rate becomes a concern.
- Replacing the diagnostic helper with the canonical inference helper (different match semantics — strict vs loose). Same follow-up.