### PR TITLE
feat(training-agent): implement provenance enforcement (provenance_requirements + accepted_verifiers + PROVENANCE_* codes)

### DIFF
--- a/.changeset/training-agent-provenance-enforcement.md
+++ b/.changeset/training-agent-provenance-enforcement.md
@@ -1,0 +1,36 @@
+---
+---
+
+feat(training-agent): implement provenance enforcement for creative_policy (#3777)
+
+Implements `creative_policy.{provenance_required, provenance_requirements, accepted_verifiers}`
+enforcement in the training agent so the `creative_sales_agent/provenance_enforcement`
+conformance storyboard passes.
+
+**`handleGetProducts`:** seeded products (from `comply_test_controller seed_product`) are
+now included in responses via `overlaySeededProducts`. Seeded products that score zero on
+brief-mode keyword matching are prepended to the result so storyboard field-value checks
+can inspect their `creative_policy` fields.
+
+**`handleSyncCreatives`:** structural enforcement derived from seeded products'
+`creative_policy` runs before persisting each creative:
+1. Verifier allowlist check (PROVENANCE_VERIFIER_NOT_ACCEPTED) — fires first per spec
+   "cross-check before any outbound call" requirement
+2. PROVENANCE_REQUIRED — no provenance object when `provenance_required: true`
+3. Field-level checks with short-circuit: PROVENANCE_DIGITAL_SOURCE_TYPE_MISSING,
+   PROVENANCE_DISCLOSURE_MISSING, PROVENANCE_EMBEDDED_MISSING
+
+Per-creative failures use `action: 'failed'` with `errors[]` (already in sync-creatives-response.json
+schema); the creative is not persisted to session state.
+
+Removes `creative_sales_agent/provenance_enforcement` from `KNOWN_FAILING_STORYBOARDS`.
+
+Note: `sync_creatives` has no `product_id` field, so per-product enforcement is not possible.
+The implementation uses union semantics across all seeded products' verifier allowlists — a
+known training-agent simplification documented in a code comment. In single-product storyboards
+(the typical case) union === intersection.
+
+Note: `.github/workflows/training-agent-storyboards.yml` thresholds (`min_clean_storyboards`,
+`min_passing_steps`) need a human bump — the routine cannot edit `.github/**`.
+
+Closes #3777.

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -421,7 +421,8 @@ interface CreativeDeliveryEntry {
 /** Sync creative result entry. */
 interface SyncCreativeResult {
   creative_id: string;
-  action: 'created' | 'updated';
+  action: 'created' | 'updated' | 'failed';
+  errors?: TaskError[];
 }
 
 /** Creative assignment result. */
@@ -1023,7 +1024,10 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext) {
   const buyingMode = req.buying_mode || 'brief';
   const session = await getSession(sessionKeyFromArgs(req, ctx.mode, ctx.userId, ctx.moduleId));
 
-  let products: Product[] = getCatalog().map(cp => ({ ...cp.product }));
+  const productMap = new Map(getCatalog().map(cp => [cp.product.product_id, cp.product]));
+  overlaySeededProducts(session, productMap);
+  const seededProductIds = new Set(session.complyExtensions.seededProducts.keys());
+  let products: Product[] = [...productMap.values()];
 
   // Apply filters
   if (req.filters) {
@@ -1090,6 +1094,17 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext) {
         ...cp.product,
         brief_relevance: 'Suggested product — no direct keyword match with your brief.',
       }));
+    }
+
+    // Seeded products may score zero on keywords (no name/description by default) but
+    // must always appear so storyboard field-value checks can inspect their creative_policy
+    // and other fixture fields. Prepend any that the scorer dropped.
+    if (seededProductIds.size > 0) {
+      const inResults = new Set(products.map(p => p.product_id));
+      const missed = [...seededProductIds]
+        .map(id => productMap.get(id))
+        .filter((p): p is Product => p !== undefined && !inResults.has(p.product_id));
+      if (missed.length > 0) products = [...missed, ...products];
     }
   }
 
@@ -2095,6 +2110,34 @@ export async function handleSyncCreatives(args: ToolArgs, ctx: TrainingContext) 
   const validFormatIds = new Set(getFormats().map(f => f.format_id.id));
   const ownAgentUrlCanonical = canonicalizeAgentUrl(getAgentUrl());
 
+  // Derive effective provenance policy from seeded products. sync_creatives has no
+  // product_id field, so per-product enforcement is not possible. Union semantics for
+  // acceptedVerifiers is a training-agent simplification: in multi-product sessions the
+  // union is more permissive than per-product; in single-product storyboards (the typical
+  // case) union === intersection.
+  let provenanceRequired = false;
+  let requireDigitalSourceType = false;
+  let requireDisclosureMetadata = false;
+  let requireEmbeddedProvenance = false;
+  const acceptedVerifierUrls = new Set<string>();
+  for (const fixture of session.complyExtensions.seededProducts.values()) {
+    const cp = (fixture as Record<string, unknown>).creative_policy as Record<string, unknown> | undefined;
+    if (!cp) continue;
+    if (cp.provenance_required === true) provenanceRequired = true;
+    const reqs = cp.provenance_requirements as Record<string, unknown> | undefined;
+    if (reqs?.require_digital_source_type === true) requireDigitalSourceType = true;
+    if (reqs?.require_disclosure_metadata === true) requireDisclosureMetadata = true;
+    if (reqs?.require_embedded_provenance === true) requireEmbeddedProvenance = true;
+    const verifiers = cp.accepted_verifiers as Array<Record<string, unknown>> | undefined;
+    if (Array.isArray(verifiers)) {
+      for (const v of verifiers) {
+        if (typeof v.agent_url === 'string') acceptedVerifierUrls.add(canonicalizeAgentUrl(v.agent_url));
+      }
+    }
+  }
+  const hasProvenancePolicy = provenanceRequired || requireDigitalSourceType
+    || requireDisclosureMetadata || requireEmbeddedProvenance || acceptedVerifierUrls.size > 0;
+
   const results: SyncCreativeResult[] = [];
   for (const creative of req.creatives) {
     if (!creative.creative_id) {
@@ -2133,6 +2176,73 @@ export async function handleSyncCreatives(args: ToolArgs, ctx: TrainingContext) 
           message: `Unknown format_id "${formatId.id}". Use list_creative_formats to see available formats.`,
         }] as TaskError[],
       };
+    }
+
+    // Provenance structural enforcement against seeded products' creative_policy
+    if (hasProvenancePolicy) {
+      const provenance = (creative as Record<string, unknown>).provenance as Record<string, unknown> | undefined;
+      const embeddedProv = (provenance?.embedded_provenance as Array<Record<string, unknown>> | undefined) ?? [];
+      const watermarksList = (provenance?.watermarks as Array<Record<string, unknown>> | undefined) ?? [];
+      let provenanceError: TaskError | undefined;
+
+      // 1. Verifier allowlist — MUST precede structural checks (spec: "cross-check before any outbound call")
+      if (acceptedVerifierUrls.size > 0) {
+        for (const entry of [...embeddedProv, ...watermarksList]) {
+          const va = entry.verify_agent as Record<string, unknown> | undefined;
+          if (typeof va?.agent_url === 'string' && !acceptedVerifierUrls.has(canonicalizeAgentUrl(va.agent_url))) {
+            provenanceError = {
+              code: 'PROVENANCE_VERIFIER_NOT_ACCEPTED',
+              message: 'verify_agent.agent_url is not in the seller\'s accepted_verifiers. Replace with an on-list URL from get_products.',
+              field: `creatives[${results.length}].provenance.embedded_provenance[*].verify_agent.agent_url`,
+              recovery: 'correctable',
+            };
+            break;
+          }
+        }
+      }
+
+      // 2. Structural checks — first failure short-circuits remaining checks for this creative
+      if (!provenanceError && provenanceRequired && !provenance) {
+        provenanceError = {
+          code: 'PROVENANCE_REQUIRED',
+          message: 'Seller requires provenance metadata. Attach a provenance object and resubmit.',
+          field: `creatives[${results.length}].provenance`,
+          recovery: 'correctable',
+        };
+      }
+      if (!provenanceError && provenance) {
+        if (requireDigitalSourceType && !provenance.digital_source_type) {
+          provenanceError = {
+            code: 'PROVENANCE_DIGITAL_SOURCE_TYPE_MISSING',
+            message: 'Seller requires provenance.digital_source_type.',
+            field: `creatives[${results.length}].provenance.digital_source_type`,
+            recovery: 'correctable',
+          };
+        } else if (requireDisclosureMetadata) {
+          const disc = provenance.disclosure as Record<string, unknown> | undefined;
+          const jurisdictions = disc?.jurisdictions as unknown[] | undefined;
+          if (disc?.required === undefined || (disc.required === true && !jurisdictions?.length)) {
+            provenanceError = {
+              code: 'PROVENANCE_DISCLOSURE_MISSING',
+              message: 'Seller requires provenance.disclosure.required, and jurisdictions when required is true.',
+              field: `creatives[${results.length}].provenance.disclosure`,
+              recovery: 'correctable',
+            };
+          }
+        } else if (requireEmbeddedProvenance && !embeddedProv.length) {
+          provenanceError = {
+            code: 'PROVENANCE_EMBEDDED_MISSING',
+            message: 'Seller requires at least one embedded_provenance entry.',
+            field: `creatives[${results.length}].provenance.embedded_provenance`,
+            recovery: 'correctable',
+          };
+        }
+      }
+
+      if (provenanceError) {
+        results.push({ creative_id: creativeId, action: 'failed', errors: [provenanceError] });
+        continue;
+      }
     }
 
     const existing = session.creatives.has(creativeId);

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -2123,11 +2123,14 @@ export async function handleSyncCreatives(args: ToolArgs, ctx: TrainingContext) 
   for (const fixture of session.complyExtensions.seededProducts.values()) {
     const cp = (fixture as Record<string, unknown>).creative_policy as Record<string, unknown> | undefined;
     if (!cp) continue;
-    if (cp.provenance_required === true) provenanceRequired = true;
-    const reqs = cp.provenance_requirements as Record<string, unknown> | undefined;
-    if (reqs?.require_digital_source_type === true) requireDigitalSourceType = true;
-    if (reqs?.require_disclosure_metadata === true) requireDisclosureMetadata = true;
-    if (reqs?.require_embedded_provenance === true) requireEmbeddedProvenance = true;
+    if (cp.provenance_required === true) {
+      provenanceRequired = true;
+      // Spec: receivers MUST ignore provenance_requirements when provenance_required is false or absent
+      const reqs = cp.provenance_requirements as Record<string, unknown> | undefined;
+      if (reqs?.require_digital_source_type === true) requireDigitalSourceType = true;
+      if (reqs?.require_disclosure_metadata === true) requireDisclosureMetadata = true;
+      if (reqs?.require_embedded_provenance === true) requireEmbeddedProvenance = true;
+    }
     const verifiers = cp.accepted_verifiers as Array<Record<string, unknown>> | undefined;
     if (Array.isArray(verifiers)) {
       for (const v of verifiers) {
@@ -2187,13 +2190,17 @@ export async function handleSyncCreatives(args: ToolArgs, ctx: TrainingContext) 
 
       // 1. Verifier allowlist — MUST precede structural checks (spec: "cross-check before any outbound call")
       if (acceptedVerifierUrls.size > 0) {
-        for (const entry of [...embeddedProv, ...watermarksList]) {
+        const verifierEntries = [
+          ...embeddedProv.map((e, i) => ({ entry: e, path: `creatives[${results.length}].provenance.embedded_provenance[${i}].verify_agent.agent_url` })),
+          ...watermarksList.map((e, i) => ({ entry: e, path: `creatives[${results.length}].provenance.watermarks[${i}].verify_agent.agent_url` })),
+        ];
+        for (const { entry, path } of verifierEntries) {
           const va = entry.verify_agent as Record<string, unknown> | undefined;
           if (typeof va?.agent_url === 'string' && !acceptedVerifierUrls.has(canonicalizeAgentUrl(va.agent_url))) {
             provenanceError = {
               code: 'PROVENANCE_VERIFIER_NOT_ACCEPTED',
               message: 'verify_agent.agent_url is not in the seller\'s accepted_verifiers. Replace with an on-list URL from get_products.',
-              field: `creatives[${results.length}].provenance.embedded_provenance[*].verify_agent.agent_url`,
+              field: path,
               recovery: 'correctable',
             };
             break;

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -113,15 +113,6 @@ const KNOWN_FAILING_STORYBOARDS: ReadonlyMap<string, string> = new Map([
   // Tracked upstream as adcp#3429; remove once the storyboard is migrated to
   // `envelope_field_present` AND the framework wraps capabilities responses.
   ['v3_envelope_integrity', 'adcp-client#1045 / adcp#3429 — storyboard asserts envelope status, framework capabilities tool returns unenveloped payload'],
-  // The storyboard exercises creative_policy.{provenance_required,
-  // provenance_requirements, accepted_verifiers} round-tripping through
-  // get_products and the PROVENANCE_*_MISSING / PROVENANCE_VERIFIER_NOT_ACCEPTED
-  // rejection paths on sync_creatives. The training agent has no provenance
-  // enforcement yet — get_products doesn't surface the seeded creative_policy
-  // fields and sync_creatives accepts every submission. Three step validations
-  // fail against the reference implementation. Tracked as adcp#3777; remove
-  // this entry once the training agent enforces provenance per the spec.
-  ['creative_sales_agent/provenance_enforcement', 'adcp#3777 — training agent does not yet enforce creative_policy.provenance_requirements / accepted_verifiers (no PROVENANCE_* rejection paths in sync_creatives)'],
 ]);
 
 /**


### PR DESCRIPTION
Closes #3777

Implements `creative_policy.{provenance_required, provenance_requirements, accepted_verifiers}` enforcement in the training agent so the `creative_sales_agent/provenance_enforcement` conformance storyboard passes (was failing 3 of 5 step validations).

## Changes

### `handleGetProducts` (`task-handlers.ts`)

Seeded products (from `comply_test_controller seed_product`) are now included in `get_products` responses via `overlaySeededProducts`. Previously only the static catalog was used. Seeded products that score zero on brief-mode keyword matching (they have no `name`/`description` by default) are prepended to the result so storyboard `field_value` checks on `products[0].creative_policy.*` pass.

### `handleSyncCreatives` (`task-handlers.ts`)

Structural provenance enforcement derived from all seeded products' `creative_policy`. Checks run in spec order before persisting each creative:

1. **Verifier allowlist** (`PROVENANCE_VERIFIER_NOT_ACCEPTED`) — fires first per spec "cross-check before any outbound call" requirement; compares canonicalized `verify_agent.agent_url` against the accepted set
2. **Presence** (`PROVENANCE_REQUIRED`) — fires when `provenance_required: true` and no provenance object
3. **Field-level** (`PROVENANCE_DIGITAL_SOURCE_TYPE_MISSING`, `PROVENANCE_DISCLOSURE_MISSING`, `PROVENANCE_EMBEDDED_MISSING`) — gated on `provenance_required: true` per spec MUST-ignore rule for `provenance_requirements` when `provenance_required` is false/absent; short-circuits at first failure

Per-creative failures use `action: 'failed'` with `errors[]` (already in the `sync-creatives-response.json` schema enum; not persisted to session).

`SyncCreativeResult` type widened to include `'failed'` and optional `errors`.

### `run-storyboards.ts`

Removes `creative_sales_agent/provenance_enforcement` from `KNOWN_FAILING_STORYBOARDS`.

## Non-breaking justification

Adds enforcement only when seeded products have `provenance_required: true` in `creative_policy`. Static catalog products have no such field. Sessions without seeded products are unaffected — `hasProvenancePolicy` is false and the enforcement block is a no-op. The `action: 'failed'` path was already defined in the schema.

## Known simplification

`sync_creatives` has no `product_id` field, so per-product enforcement is not possible. `acceptedVerifiers` uses union semantics across all seeded products — documented in a code comment. In single-product storyboards (the typical case) union === intersection.

## Out of scope / follow-up needed

- **`.github/workflows/training-agent-storyboards.yml` thresholds** (`min_clean_storyboards`, `min_passing_steps`) need a human bump after this merges — the routine cannot edit `.github/**`. The storyboard adds 4 steps (1 new clean storyboard).
- **`PROVENANCE_CLAIM_CONTRADICTED`** (truth-of-claim via `get_creative_features` against an on-list governance agent) is out of scope per the issue; the structural-rejection codes are sufficient to make the storyboard pass.

## Pre-PR review

- **code-reviewer**: approved — no blockers; two nits noted above (`provenance_requirements` MUST-ignore rule fixed before this PR opened; accurate `field` path for watermarks vs embedded_provenance fixed before this PR opened)
- **ad-tech-protocol-expert**: approved — non-breaking per spec; enforcement logic, field paths, check ordering, and disclosure check condition all correct

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_013AgZkVzoaN9YBEJp3FeBk8

---
_Generated by [Claude Code](https://claude.ai/code/session_013AgZkVzoaN9YBEJp3FeBk8)_