### PR TITLE
ci(release): auto-upload protocol tarball to GitHub Release

### DIFF
--- a/.changeset/release-workflow-tarball-upload.md
+++ b/.changeset/release-workflow-tarball-upload.md
@@ -1,0 +1,8 @@
+---
+---
+
+Auto-attach `dist/protocol/${VERSION}.tgz` (plus `.sha256`, `.sig`, `.crt` sidecars) to the GitHub Release that `changesets/action` creates. `createGithubReleases: true` only writes the changelog body; files were never uploaded automatically.
+
+v3.0.0's assets were uploaded by hand on 2026-04-22; v3.0.1 / v3.0.2 / v3.0.3 all shipped with empty asset lists despite the tarballs being committed to `dist/protocol/` by the release pipeline. Adopters who pin via the release URL (`gh release download v3.0.3 -p '*.tgz'`) hit 404. New step uploads them via `gh release upload --clobber` gated on `steps.changesets.outputs.published == 'true'` so it only fires on actual tag-and-release runs, not Version Packages PR-creation runs.
+
+Companion backfill (manual `gh release upload` for v3.0.1 / v3.0.2 / v3.0.3 from the existing `dist/protocol/` tree) handled separately.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,3 +69,37 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      # Attach the protocol tarball + signature sidecars to the GitHub
+      # Release that changesets/action just created. `createGithubReleases:
+      # true` only writes the changelog body — files have to be uploaded
+      # separately. The `published` output is the canonical signal that a
+      # tag-and-release just happened on this run (not a Version Packages
+      # PR-creation run, where `published` is false).
+      #
+      # Tarballs and sidecars (.sha256, .sig, .crt) are written to
+      # dist/protocol/${VERSION}.tgz{,.sha256,.sig,.crt} by `npm run version`
+      # earlier in this job (build-protocol-tarball + sign-protocol-tarball).
+      # Without this step the artifacts ship to the repo's dist/ tree but
+      # are never attached as Release assets, leaving adopters who pin via
+      # release URL with a 404. v3.0.0 had assets only because they were
+      # uploaded manually; v3.0.1, v3.0.2, v3.0.3 all shipped empty.
+      - name: Upload protocol tarball to GitHub Release
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v${VERSION}"
+          TARBALL="dist/protocol/${VERSION}.tgz"
+          if [ ! -f "${TARBALL}" ]; then
+            echo "::error::Tarball not found at ${TARBALL}. Did npm run version fail upstream?"
+            exit 1
+          fi
+          gh release upload "${TAG}" \
+            "${TARBALL}" \
+            "${TARBALL}.sha256" \
+            "${TARBALL}.sig" \
+            "${TARBALL}.crt" \
+            --clobber


### PR DESCRIPTION
## Summary

\`changesets/action@v1\`'s \`createGithubReleases: true\` only writes the changelog body — files aren't attached automatically. The release pipeline produces \`dist/protocol/\${VERSION}.tgz\` (plus \`.sha256\`, \`.sig\`, \`.crt\` sidecars from the cosign signing step) and commits them to the repo's \`dist/\` tree, but no step uploads them as Release assets.

## Symptom

| Tag | \`dist/protocol/X.Y.Z.tgz\` in repo? | GitHub Release assets |
|---|---|---|
| v3.0.0 | yes | **4** (manually uploaded by @bokelley on 2026-04-22) |
| v3.0.1 | yes | **0** |
| v3.0.2 | yes | **0** |
| v3.0.3 | yes | **0** |

Adopters who pin via the release URL (\`gh release download v3.0.3 -p '*.tgz'\` or fetching the asset URL programmatically) hit 404 for three consecutive releases. The cosign signature lives next to the tarball in \`dist/\` but consumers can't access either through the standard Release distribution channel.

## Fix

Adds a \`Upload protocol tarball to GitHub Release\` step after \`changesets/action\`, gated on \`steps.changesets.outputs.published == 'true'\` so it only fires on tag-and-release runs, not Version Packages PR-creation runs. Uses \`gh release upload --clobber\` so retried runs don't error on existing assets.

\`\`\`yaml
- name: Upload protocol tarball to GitHub Release
  if: steps.changesets.outputs.published == 'true'
  env:
    GH_TOKEN: \${{ steps.app-token.outputs.token }}
  run: |
    set -euo pipefail
    VERSION=\$(node -p "require('./package.json').version")
    TAG="v\${VERSION}"
    TARBALL="dist/protocol/\${VERSION}.tgz"
    if [ ! -f "\${TARBALL}" ]; then
      echo "::error::Tarball not found at \${TARBALL}. Did npm run version fail upstream?"
      exit 1
    fi
    gh release upload "\${TAG}" \\
      "\${TARBALL}" \\
      "\${TARBALL}.sha256" \\
      "\${TARBALL}.sig" \\
      "\${TARBALL}.crt" \\
      --clobber
\`\`\`

The token is the \`aao-release-bot[bot]\` GitHub App installation token already minted earlier in the job (used by checkout and by changesets/action) — same identity that creates the Release entry, so the upload is logically part of the same release operation.

## Backfill

The three missing releases (v3.0.1 / v3.0.2 / v3.0.3) have their tarballs committed at \`dist/protocol/\` on the 3.0.x branch already. I'll backfill them via \`gh release upload\` from the local checkout once this PR merges (or before — they're idempotent against \`--clobber\`). Tracked separately so this PR is small.

## Test plan

- [ ] CI green on this branch
- [ ] After merge: next release on main (or 3.0.x) creates a v\${VERSION} Release with all 4 assets attached
- [ ] Backfill v3.0.1 / v3.0.2 / v3.0.3 release pages with their committed tarballs

## Forward-merge considerations

- This change applies to both lines (main and 3.0.x). After merge to main, will cherry-pick to 3.0.x — landing on main first per \`.agents/playbook.md\` § Release lines.
- 3.0.x's next release (after the cherry-pick lands) would be the first to have automatic asset upload working from end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)