### PR TITLE
ci(release): auto-upload protocol tarball to GitHub Release (3.0.x backport)

### DIFF
--- a/.changeset/release-workflow-tarball-upload.md
+++ b/.changeset/release-workflow-tarball-upload.md
@@ -1,0 +1,8 @@
+---
+---
+
+Auto-attach `dist/protocol/${VERSION}.tgz` (plus `.sha256`, `.sig`, `.crt` sidecars) to the GitHub Release that `changesets/action` creates. `createGithubReleases: true` only writes the changelog body; files were never uploaded automatically.
+
+v3.0.0's assets were uploaded by hand on 2026-04-22; v3.0.1 / v3.0.2 / v3.0.3 all shipped with empty asset lists despite the tarballs being committed to `dist/protocol/` by the release pipeline. Adopters who pin via the release URL (`gh release download v3.0.3 -p '*.tgz'`) hit 404. New step uploads them via `gh release upload --clobber` gated on `steps.changesets.outputs.published == 'true'` so it only fires on actual tag-and-release runs, not Version Packages PR-creation runs.
+
+Companion backfill (manual `gh release upload` for v3.0.1 / v3.0.2 / v3.0.3 from the existing `dist/protocol/` tree) handled separately.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,3 +69,37 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      # Attach the protocol tarball + signature sidecars to the GitHub
+      # Release that changesets/action just created. `createGithubReleases:
+      # true` only writes the changelog body — files have to be uploaded
+      # separately. The `published` output is the canonical signal that a
+      # tag-and-release just happened on this run (not a Version Packages
+      # PR-creation run, where `published` is false).
+      #
+      # Tarballs and sidecars (.sha256, .sig, .crt) are written to
+      # dist/protocol/${VERSION}.tgz{,.sha256,.sig,.crt} by `npm run version`
+      # earlier in this job (build-protocol-tarball + sign-protocol-tarball).
+      # Without this step the artifacts ship to the repo's dist/ tree but
+      # are never attached as Release assets, leaving adopters who pin via
+      # release URL with a 404. v3.0.0 had assets only because they were
+      # uploaded manually; v3.0.1, v3.0.2, v3.0.3 all shipped empty.
+      - name: Upload protocol tarball to GitHub Release
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v${VERSION}"
+          TARBALL="dist/protocol/${VERSION}.tgz"
+          if [ ! -f "${TARBALL}" ]; then
+            echo "::error::Tarball not found at ${TARBALL}. Did npm run version fail upstream?"
+            exit 1
+          fi
+          gh release upload "${TAG}" \
+            "${TARBALL}" \
+            "${TARBALL}.sha256" \
+            "${TARBALL}.sig" \
+            "${TARBALL}.crt" \
+            --clobber


### PR DESCRIPTION
Cherry-pick of #3786 (\`ba0fc5002c\`) from main to 3.0.x.

So 3.0.x's next release (3.0.4) automatically attaches \`dist/protocol/\${VERSION}.tgz\` plus \`.sha256\`, \`.sig\`, \`.crt\` sidecars to the GitHub Release, instead of shipping with empty asset lists like v3.0.1 / v3.0.2 / v3.0.3 did.

## Backfill already done

The three missing 3.0.x releases were backfilled manually via \`gh release upload\`:

| Tag | Assets attached |
|---|---|
| v3.0.1 | 4 (.tgz, .sha256, .sig, .crt) |
| v3.0.2 | 4 |
| v3.0.3 | 4 |

SHA256 verified against committed sidecars before upload.

## Why backport

3.0.x is the active maintenance line (currently at 3.0.3); pinned adopters cut the next 3.0.4 from this branch. Without this fix on 3.0.x, the next 3.0.4 release ships with empty asset lists again until the auto-forward-merge brings the workflow change across — and forward-merges have been brittle (see #3783, manually resolved).

Per \`.agents/playbook.md\` § Release lines: \"Conformance harness / release tooling — always patch-eligible.\" Workflow-only change, no spec impact.

## Test plan

- [ ] CI green
- [ ] After merge: 3.0.x's next Version Packages cut → release auto-attaches the 4 assets to the new tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)