### PR TITLE
spec(conventions): reserve ctx_metadata as adapter-internal round-trip key (#3640)

### DIFF
--- a/.changeset/reserve-ctx-metadata-adapter-key.md
+++ b/.changeset/reserve-ctx-metadata-adapter-key.md
@@ -1,0 +1,11 @@
+---
+"adcontextprotocol": patch
+---
+
+spec(conventions): reserve `ctx_metadata` as adapter-internal round-trip key
+
+Reserves the top-level key `ctx_metadata` on AdCP resource objects (Product, MediaBuy, Package, Creative, AudienceSegment, Signal, RightsGrant) as a publisher-to-SDK round-trip cache for adapter-internal state. SDKs MUST strip the key before wire egress and MUST emit a warning-level log entry when stripping, so operators can detect accidental collisions with existing adapter code. Buyers never see this field.
+
+The convention is non-binding at the wire level — these resources already declare `additionalProperties: true` so existing payloads remain valid. The reservation locks the keyword name before two SDKs converge on it accidentally and ship divergent semantics. PropertyList and CollectionList are out of scope (`additionalProperties: false`) until a follow-up PR widens those schemas.
+
+Closes #3640.

--- a/docs/spec-guidelines.md
+++ b/docs/spec-guidelines.md
@@ -235,6 +235,39 @@ The rule to apply: if the name asks "which vendor-equivalent version of somethin
 - Vendor names in **example blocks** (email addresses, sample IDs) are fine.
 - When uncertain, ask: "Is this field or value representing *one vendor's version of something the protocol already has a general concept for*?" If yes, it belongs under `ext.{vendor}`.
 
+## Reserved SDK-Internal Keys
+
+**RULE**: The top-level key `ctx_metadata` is reserved on AdCP resource objects as an adapter-internal round-trip cache for state that an SDK or platform adapter needs to carry across calls but that buyers MUST NOT see or rely on. Adapters MUST strip `ctx_metadata` from any payload before wire egress, and MUST emit a warning-level log entry when stripping, so operators can detect accidental key collisions with custom adapter code.
+
+**Why**: Platform adapters (e.g. Google Ad Manager, Kevel, custom seller infrastructure) often need to associate adapter-internal identifiers — GAM ad-unit IDs, key-value pairs, placement IDs — with AdCP resources that the buyer-facing SDK returns. The reference Prebid `salesagent` Python implementation uses an `implementation_config` JSON column on its Product model for exactly this purpose. Without a reserved name, every SDK invents its own (`implementation_config`, `_internal`, `sdk_state`, etc.); a fourth SDK then collides with one of them, or two SDKs converging on the same name produce ambiguous semantics. One reserved name removes the coordination problem.
+
+**Scope**: The reservation applies to AdCP resource objects whose schemas declare `additionalProperties: true` — including `Product`, `MediaBuy`, `Package`, `Creative`, `AudienceSegment`, `Signal`, and `RightsGrant`. `PropertyList` and `CollectionList` declare `additionalProperties: false` and are out of scope until a follow-up PR widens those schemas.
+
+**Distinction from neighboring conventions**:
+
+- `ext.{vendor}` — vendor-namespaced, **buyer-visible**, travels on the wire. Use for vendor-specific data the buyer should see (e.g. `ext.gam.line_item_id`).
+- `context` — caller-echoed correlation data, also wire-visible.
+- `ctx_metadata` — **adapter-internal only**, MUST be stripped before egress, never reaches the buyer.
+
+**Adapter conformance**:
+
+```
+1. Read ctx_metadata from inbound resource (publisher → SDK direction).
+2. Carry it in adapter-local state.
+3. Before serializing the resource for wire egress (SDK → buyer direction):
+   a. Remove the ctx_metadata key.
+   b. If the key was present and non-empty, emit a warning-level log:
+      "stripping reserved ctx_metadata before egress on <resource_type>"
+4. Buyer-facing surfaces MUST NOT expose ctx_metadata in any documentation,
+   typed shape, or example.
+```
+
+**Reviewer checklist**:
+
+- Reject any spec, schema, or example that promotes `ctx_metadata` as a buyer-readable field.
+- Reject any SDK contribution that surfaces `ctx_metadata` in a buyer-facing typed return.
+- Accept SDK code that reads/writes `ctx_metadata` as adapter-internal state, provided the egress-strip + warning-log path is in place.
+
 ## Breaking Changes
 
 ### What Constitutes a Breaking Change

--- a/docs/spec-guidelines.md
+++ b/docs/spec-guidelines.md
@@ -237,16 +237,18 @@ The rule to apply: if the name asks "which vendor-equivalent version of somethin
 
 ## Reserved SDK-Internal Keys
 
-**RULE**: The top-level key `ctx_metadata` is reserved on AdCP resource objects as an adapter-internal round-trip cache for state that an SDK or platform adapter needs to carry across calls but that buyers MUST NOT see or rely on. Adapters MUST strip `ctx_metadata` from any payload before wire egress, and MUST emit a warning-level log entry when stripping, so operators can detect accidental key collisions with custom adapter code.
+**RULE**: The top-level key `ctx_metadata` is reserved on AdCP resource objects as an adapter-internal round-trip cache for state that an SDK or platform adapter needs to carry across calls but that buyers MUST NOT see or rely on. Adapters MUST strip `ctx_metadata` from any payload before wire egress. When the key was present and non-empty at strip time, adapters MUST emit a warning-level log entry so operators can detect accidental key collisions with custom adapter code. (An empty or absent `ctx_metadata` is silent — only a non-empty value triggers the warning.)
 
 **Why**: Platform adapters (e.g. Google Ad Manager, Kevel, custom seller infrastructure) often need to associate adapter-internal identifiers — GAM ad-unit IDs, key-value pairs, placement IDs — with AdCP resources that the buyer-facing SDK returns. The reference Prebid `salesagent` Python implementation uses an `implementation_config` JSON column on its Product model for exactly this purpose. Without a reserved name, every SDK invents its own (`implementation_config`, `_internal`, `sdk_state`, etc.); a fourth SDK then collides with one of them, or two SDKs converging on the same name produce ambiguous semantics. One reserved name removes the coordination problem.
 
-**Scope**: The reservation applies to AdCP resource objects whose schemas declare `additionalProperties: true` — including `Product`, `MediaBuy`, `Package`, `Creative`, `AudienceSegment`, `Signal`, and `RightsGrant`. `PropertyList` and `CollectionList` declare `additionalProperties: false` and are out of scope until a follow-up PR widens those schemas.
+**Scope**: The reservation applies to AdCP resource objects whose schemas declare `additionalProperties: true` — including `Product`, `MediaBuy`, `Package`, `Creative`, `AudienceSegment`, `Signal`, and `RightsGrant`. The reservation travels with the resource wherever it appears: top-level in a response envelope, nested inside another resource (e.g. `Package` inside `MediaBuy`), or inside an array of resources (e.g. each element of `products: Product[]`). Adapters MUST strip the key from every occurrence before egress, not just the outermost one.
+
+`PropertyList` and `CollectionList` declare `additionalProperties: false` and are out of scope until a follow-up PR widens those schemas; until then, adapters needing round-trip state for those resources should track it out-of-band.
 
 **Distinction from neighboring conventions**:
 
 - `ext.{vendor}` — vendor-namespaced, **buyer-visible**, travels on the wire. Use for vendor-specific data the buyer should see (e.g. `ext.gam.line_item_id`).
-- `context` — caller-echoed correlation data, also wire-visible.
+- `context` / `context_id` — caller-echoed correlation data, also wire-visible. Despite the prefix-match, `ctx_metadata` is not a sub-namespace of these — they are unrelated concepts and travel on different layers.
 - `ctx_metadata` — **adapter-internal only**, MUST be stripped before egress, never reaches the buyer.
 
 **Adapter conformance**:


### PR DESCRIPTION
Closes #3640.

## Summary

Reserves `ctx_metadata` as a top-level adapter-internal round-trip cache key on AdCP resource objects (Product, MediaBuy, Package, Creative, AudienceSegment, Signal, RightsGrant). SDKs MUST strip the key before wire egress and MUST emit a warning-level log when stripping. Buyers never see the field.

The convention is non-binding at the wire level — these resources already declare `additionalProperties: true`, so existing payloads remain valid. The reservation locks the keyword name before two SDKs converge on it accidentally and ship divergent semantics.

## Implements Option A from triage

The triage on #3640 surfaced that PropertyList and CollectionList declare `additionalProperties: false`, contradicting the wire-compat claim in the issue body. Two paths were offered:

- **Option A** — narrow to 7 resources + MUST-warn-on-strip, follow-up PR to widen PropertyList/CollectionList.
- **Option B** — route via `ext._sdk` namespace.

This PR is Option A. PropertyList and CollectionList are explicitly called out as out of scope; widening their schemas is a separate change.

## Files changed

- `docs/spec-guidelines.md` — adds new "Reserved SDK-Internal Keys" section after Platform Agnosticism (33 lines).
- `.changeset/reserve-ctx-metadata-adapter-key.md` — `patch` bump.

## What's NOT changed

- No schema files touched. Existing `additionalProperties: true` already permits the key.
- No wire format change. The convention only governs SDK adapter behavior.

## Test plan

- [ ] CI passes (lint, snippets, broken-links, schema-link checks)
- [ ] Reviewer confirms convention text matches Option A from triage
- [ ] Follow-up issue tracked for PropertyList/CollectionList schema widening

🤖 Generated with [Claude Code](https://claude.com/claude-code)