### PR TITLE
chore(3.0.x): cherry-pick + adapt 7 spec fixes from main (#3784)

### DIFF
--- a/.changeset/auth-required-prose-tightening-3.0.x.md
+++ b/.changeset/auth-required-prose-tightening-3.0.x.md
@@ -1,0 +1,18 @@
+---
+"adcontextprotocol": patch
+---
+
+spec(errors): tighten `AUTH_REQUIRED` prose to warn on retry storms (3.0.x prose-only backport of #3739)
+
+`AUTH_REQUIRED` conflates two operationally distinct cases — credentials missing (genuinely correctable) and credentials presented but rejected (terminal — needs human rotation). A buyer agent treating both as `correctable` will retry-loop on revoked tokens, hammering seller SSO endpoints in a pattern indistinguishable from a brute-force probe.
+
+The 3.1 line splits this into `AUTH_MISSING` and `AUTH_INVALID` (#3739). 3.0.x cannot adopt the split — adding new enum values violates the maintenance line's semver rules. This change is the prose-only backport: the wire code stays `AUTH_REQUIRED` with `recovery: correctable`, but the description and `enumMetadata.suggestion` now spell out the two sub-cases and the SHOULD-NOT-auto-retry rule for the rejected-credential case. SDKs running against 3.0.x sellers can apply the operational distinction at the application layer.
+
+Updates:
+
+- `static/schemas/source/enums/error-code.json` — `enumDescriptions.AUTH_REQUIRED` and `enumMetadata.AUTH_REQUIRED.suggestion` rewritten to call out both sub-cases and the retry-storm risk; cross-references the 3.1 split.
+- `docs/building/implementation/error-handling.mdx` — adds an `AUTH_REQUIRED sub-cases` callout under the Authentication and Access table; updates the example switch to branch on whether credentials were attached.
+
+Wire format unchanged. No new enum values. No recovery classification change at the structured level. Senders that already emit `AUTH_REQUIRED` keep working; receivers gain the documented sub-case discipline.
+
+Closes the 3.0.x portion of #3730. The full split lands in 3.1.0 via #3739.

--- a/.changeset/error-details-pascalcase-titles.md
+++ b/.changeset/error-details-pascalcase-titles.md
@@ -1,0 +1,23 @@
+---
+---
+
+spec(schemas): Title Case titles on error-details schemas (partial fix for #3145)
+
+Six `static/schemas/source/error-details/*.json` files carry SCREAMING_SNAKE titles that propagate awkwardly through `json-schema-to-typescript` into `@adcp/client`'s public type surface (e.g., `RATE_LIMITEDDetails_ScopeValues`). Renames to Title Case with spaces, matching the precedent set by PR #3149 for `rate-limited.json`:
+
+| File | Old title | New title |
+|---|---|---|
+| `account-setup-required.json` | `ACCOUNT_SETUP_REQUIRED Details` | `Account Setup Required Details` |
+| `audience-too-small.json` | `AUDIENCE_TOO_SMALL Details` | `Audience Too Small Details` |
+| `budget-too-low.json` | `BUDGET_TOO_LOW Details` | `Budget Too Low Details` |
+| `conflict.json` | `CONFLICT Details` | `Conflict Details` |
+| `creative-rejected.json` | `CREATIVE_REJECTED Details` | `Creative Rejected Details` |
+| `policy-violation.json` | `POLICY_VIOLATION Details` | `Policy Violation Details` |
+
+`rate-limited.json` (`Rate Limited Details`) and `vendor-error-codes.json` (`Vendor Error Code Registry`) already used this style.
+
+`json-schema-to-typescript` strips whitespace when generating TypeScript identifiers, so codegen output is `AccountSetupRequiredDetails` etc. — same as the no-spaces form would produce. The spaces are kept in source so the directory's 8 files share one style (precedent set by #3149).
+
+Schema `$id` values (the wire identifiers) are unchanged. The `title` field is non-normative per JSON Schema draft-07 §10.1 — it controls only docgen / codegen output. No wire-format change.
+
+**Partial fix**: this addresses the SCREAMING_SNAKE half of #3145. The other half — `Foo1`-suffixed enum dupes (`AgeVerificationMethod1`, `BriefAsset1`, `VASTAsset1`, `DAASTAsset1`, `CatalogAsset1`) — is downstream codegen behavior in `json-schema-to-typescript` reaching the same enum through different schema paths. The shared `$ref` is already in place upstream, so the dedup needs SDK-side post-process renaming. Tracked SDK-side (will be opened as a follow-up after this and the related VALIDATION_ERROR `issues[]` PR land).

--- a/.changeset/error-issues-array.md
+++ b/.changeset/error-issues-array.md
@@ -1,0 +1,19 @@
+---
+"adcontextprotocol": minor
+---
+
+spec(error): standardize VALIDATION_ERROR `issues[]` as a normative field on `core/error.json`
+
+Closes #3059. Adds an optional top-level `issues` array to the standard error envelope, normalizing what `@adcp/client` (and prospectively `adcp-go` / `adcp-client-python` / hand-rolled sellers) already need for multi-field validation rejections.
+
+**Why minor**: new optional field on a published schema (`core/error.json`). Existing senders/receivers stay conformant — the field is additive. Receivers that ignore unknown fields keep working; receivers that look for it gain a richer pointer map without parsing `message` text.
+
+**Shape**: each entry is `{ pointer (RFC 6901), message, keyword, schemaPath? }`. `schemaPath` MAY be omitted in production to avoid fingerprinting `oneOf` branch selection on adversarial payloads.
+
+**Backward compatibility with `field` (singular)**: when both are present, sellers SHOULD set `field` to `issues[0].pointer`. Pre-3.1 consumers reading only `field` get the first failure; 3.1+ consumers prefer the top-level `issues`.
+
+**`details.issues` mirror**: sellers MAY mirror `issues[]` into `details.issues` for backward compat with consumers reading from `details`. New consumers should prefer top-level.
+
+Updates:
+- `static/schemas/source/core/error.json` — adds `issues` property with item shape
+- `docs/building/implementation/error-handling.mdx` — adds `issues` to the error-envelope field table; clarifies `field`/`issues` interaction

--- a/.changeset/error-issues-array.md
+++ b/.changeset/error-issues-array.md
@@ -1,5 +1,5 @@
 ---
-"adcontextprotocol": minor
+"adcontextprotocol": patch
 ---
 
 spec(error): standardize VALIDATION_ERROR `issues[]` as a normative field on `core/error.json`

--- a/.changeset/fix-audience-sync-stateful-flag.md
+++ b/.changeset/fix-audience-sync-stateful-flag.md
@@ -1,0 +1,6 @@
+---
+---
+
+Fix `discover_account` step in audience-sync storyboard: flip `stateful: false` → `stateful: true`.
+
+The step's own narrative states "The account_id is captured for use in subsequent audience operations," yet `stateful: false` told the SDK runner not to count a passing result as establishing state. Explicit-mode adopters saw `sync_audiences` cascade-skip with `prerequisite_failed` even after `list_accounts` passed. This aligns audience-sync with the identical declaration in the `sales-social` storyboard and with the SDK runner's cascade-resolution behavior (adcp-client#1130).

--- a/.changeset/fix-rate-limited-schema-title.md
+++ b/.changeset/fix-rate-limited-schema-title.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix `title` in `error-details/rate-limited.json` from `"RATE_LIMITED Details"` to `"Rate Limited Details"`. The JSON Schema `title` annotation is non-normative; no validation or wire-format change. This corrects the generated TypeScript type name from `RATE_LIMITEDDetails` to `RateLimitedDetails` in downstream codegen consumers (see adcp-client#942 for the SDK alias layer).

--- a/.changeset/tool-error-specialism-manifest.md
+++ b/.changeset/tool-error-specialism-manifest.md
@@ -1,8 +1,12 @@
 ---
-"adcontextprotocol": minor
+"adcontextprotocol": patch
 ---
 
-spec(manifest): publish `manifest.json` + structured `enumMetadata` to stop SDK drift (adcp#3725)
+spec(manifest): publish `manifest.json` + structured `enumMetadata` to stop SDK drift (adcp#3725) — 3.0.x backport
+
+Hand-cherry-picked from #3738 onto 3.0.x. The original `enumMetadata` block on `main` references three error codes (`SCOPE_INSUFFICIENT`, `READ_ONLY_SCOPE`, `FIELD_NOT_PERMITTED`) that don't exist in 3.0.x's enum; this version trims those entries so the structured metadata covers exactly the 45 codes 3.0.x ships. The build-time lint enforces that coverage invariant — there is no way to silently drift `enumMetadata` away from the published `enum`.
+
+Patch-bump rationale: pure additive metadata block on a published schema, plus a new buildable artifact. No new wire fields, no enum value additions, no breaking changes for any conformant 3.0 agent.
 
 Adds two additive artifacts to every released schema bundle:
 

--- a/.changeset/tool-error-specialism-manifest.md
+++ b/.changeset/tool-error-specialism-manifest.md
@@ -1,0 +1,16 @@
+---
+"adcontextprotocol": minor
+---
+
+spec(manifest): publish `manifest.json` + structured `enumMetadata` to stop SDK drift (adcp#3725)
+
+Adds two additive artifacts to every released schema bundle:
+
+1. **`enums/error-code.json` gains an `enumMetadata` block.** Every error code now carries structured `recovery` (correctable | transient | terminal) and `suggestion` fields. SDKs MUST consume this block instead of parsing `Recovery: X` prose out of `enumDescriptions`. A build-time lint rejects any drift between the structured value and the prose. Root cause for adcp-client#1135 (17 missing codes, 3 wrong recovery classifications shipped in TS SDK for over a year).
+2. **`manifest.json` at `/schemas/{version}/manifest.json` (and `/schemas/latest/manifest.json` for nightly codegen).** Single canonical artifact listing every tool (with `protocol`, `mutating`, `request_schema`, `response_schema`, `async_response_schemas`, `specialisms`), every error code (with `recovery`, `description`, `suggestion`), an `error_code_policy` block (defining `default_unknown_recovery` so SDKs handle non-spec codes from non-conforming sellers correctly), and every storyboard specialism (with `protocol`, `entry_point_tools`, `exercised_tools`). Validates against `/schemas/{version}/manifest.schema.json`. Generated deterministically from existing source — no new authored content. Lets SDKs derive their internal tool/error tables from one place at codegen time instead of hand-transcribing the spec.
+
+`mutating` is derived using the same classifier the idempotency-key lint enforces (single source of truth — manifest and lint can never disagree). The read-only verb pattern was tightened in the process: it now anchors at the start so tools like `create-collection-list` and `delete-property-list` are no longer mis-classified as read-only because they happen to contain `-list-` mid-name. `search-` was added as a read-only verb.
+
+Specialisms expose two distinct tool sets per #3725 review feedback: `entry_point_tools` (the curated minimal contract from `index.yaml.required_tools` — what the spec asserts implementers MUST ship) and `exercised_tools` (the full surface — union of own phases and every linked scenario, derived by walking `phases[].steps[].task` and resolving `requires_scenarios`). SDK authors should size their tool registration against `exercised_tools` to ensure they handle every call the conformance kit will make.
+
+Migration: SDKs targeting 3.0.x continue to work unchanged — `enumDescriptions` and the existing `index.json` are retained verbatim. SDKs targeting 3.1+ should switch to `enumMetadata` for error recovery and `manifest.json` for tool/specialism enumeration. The prose "Recovery: X" sentence embedded in each `enumDescriptions` value is stripped from the manifest's per-code `description` to avoid double-encoding; it remains in `enumDescriptions` for the human-readable narrative until a future minor formally deprecates it. Until then, the lint guarantees both surfaces stay synchronized.

--- a/.changeset/url-type-should-and-role-fallback.md
+++ b/.changeset/url-type-should-and-role-fallback.md
@@ -1,5 +1,5 @@
 ---
-"adcontextprotocol": minor
+"adcontextprotocol": patch
 ---
 
 spec(url-asset): add SHOULD on `url_type`, role-based fallback, and mechanism-vs-purpose clarification (#2986 step 2)

--- a/.changeset/url-type-should-and-role-fallback.md
+++ b/.changeset/url-type-should-and-role-fallback.md
@@ -1,0 +1,16 @@
+---
+"adcontextprotocol": minor
+---
+
+spec(url-asset): add SHOULD on `url_type`, role-based fallback, and mechanism-vs-purpose clarification (#2986 step 2)
+
+`url_type` was optional with no fallback rule, so a conformant URL asset that omitted it left receivers guessing — buyers would either pick a default mechanism (with bad blast-radius if a clickthrough fired as a pixel) or refuse to render. Two parallel vocabularies (`url-asset-type` mechanism: 3 values; `url-asset-requirements.role` purpose: 6 values) compounded the confusion because the docs treated them as the same thing.
+
+This change:
+
+- Adds a top-level description on `url-asset` stating senders SHOULD include `url_type` on every URL asset, and defining the receiver fallback: when `url_type` is absent, receivers SHOULD fall back to the format's `url-asset-requirements.role` (clickthrough/landing_page → `clickthrough` mechanism; *_tracker roles → `tracker_pixel`); when neither is present, receivers MAY reject rather than guess.
+- Updates the `url_type` property description to frame it explicitly as the receiver's invocation mechanism, and points at the role fallback for senders that omit it.
+- Updates `url-asset-requirements.role` description to call out the mechanism-vs-purpose distinction (a `click_tracker` slot validly accepts a `tracker_pixel` URL).
+- Rewrites `docs/creative/asset-types.mdx` URL Asset section, replacing the old "you only need to supply the `url` value" guidance and the incorrect enum list (`impression_tracker`/`video_tracker`/`landing_page` — those were the requirement-side `role` values, not `url_type` values) with the actual `clickthrough`/`tracker_pixel`/`tracker_script` enum, the SHOULD note, and the role fallback table.
+
+Wire format unchanged. Existing senders that already include `url_type` are unaffected. Senders that omit `url_type` continue to validate but now have explicit receiver semantics; in 4.0 we plan to make `url_type` required (separate change). Closes step 2 of the rollout proposed on adcp#2986.

--- a/dist/compliance/3.0.0/specialisms/audience-sync/index.yaml
+++ b/dist/compliance/3.0.0/specialisms/audience-sync/index.yaml
@@ -111,7 +111,7 @@ phases:
         schema_ref: "account/list-accounts-request.json"
         response_schema_ref: "account/list-accounts-response.json"
         doc_ref: "/accounts/tasks/list_accounts"
-        stateful: false
+        stateful: true
         expected: |
           Return at least one account with:
           - account_id: platform-assigned identifier

--- a/dist/compliance/3.0.1/specialisms/audience-sync/index.yaml
+++ b/dist/compliance/3.0.1/specialisms/audience-sync/index.yaml
@@ -111,7 +111,7 @@ phases:
         schema_ref: "account/list-accounts-request.json"
         response_schema_ref: "account/list-accounts-response.json"
         doc_ref: "/accounts/tasks/list_accounts"
-        stateful: false
+        stateful: true
         expected: |
           Return at least one account with:
           - account_id: platform-assigned identifier

--- a/docs/building/implementation/error-handling.mdx
+++ b/docs/building/implementation/error-handling.mdx
@@ -168,12 +168,36 @@ Non-normative implementation note: a single-query pattern like `SELECT ... WHERE
 
 | Code | Recovery | Description | Resolution |
 |------|----------|-------------|------------|
-| `AUTH_REQUIRED` | correctable | Authentication is required or credentials are invalid | Provide credentials via auth header |
+| `AUTH_REQUIRED` | correctable | Authentication is required, or presented credentials were rejected | See *AUTH_REQUIRED sub-cases* below |
 | `ACCOUNT_NOT_FOUND` | terminal | Account reference could not be resolved | Verify via `list_accounts` or contact seller |
 | `ACCOUNT_SETUP_REQUIRED` | correctable | Account needs setup before use | Check `details.setup` for URL or instructions |
 | `ACCOUNT_AMBIGUOUS` | correctable | Natural key resolves to multiple accounts | Pass explicit `account_id` or a more specific natural key |
 | `ACCOUNT_PAYMENT_REQUIRED` | terminal | Outstanding balance requires payment | Buyer must resolve billing |
 | `ACCOUNT_SUSPENDED` | terminal | Account has been suspended | Contact seller to resolve |
+
+#### `AUTH_REQUIRED` sub-cases
+
+`AUTH_REQUIRED` shares one wire code across two operationally distinct cases that agents MUST handle differently:
+
+| Sub-case | Behavior | Why |
+|---|---|---|
+| Credentials missing | Provide credentials and retry once. | Genuinely correctable from inside the agent loop. |
+| Credentials presented but rejected (expired / revoked / malformed signature) | Do **not** auto-retry. Escalate to operator for credential rotation. | Re-presenting a rejected credential against an SSO endpoint creates retry-storm patterns indistinguishable from brute-force probes. The seller's fraud detection may rate-limit, suspend, or alert on the calling agent. |
+
+A future minor release splits this code into `AUTH_MISSING` (correctable) and `AUTH_INVALID` (terminal). Until then, agents SHOULD branch on whether credentials were actually attached to the failing request:
+
+```javascript
+case 'AUTH_REQUIRED':
+  if (!requestHadCredentials) {
+    // Sub-case (a) — provide credentials and retry.
+    await refreshCredentials();
+    return retry();
+  }
+  // Sub-case (b) — credentials were presented and rejected.
+  // Treat as terminal at the application layer; surface to operator.
+  console.error('Credential rejected — needs human rotation:', error.message);
+  throw error;
+```
 
 ### Request Validation
 
@@ -338,8 +362,13 @@ async function handleAdcpError(error) {
   // Fall back to error code matching
   switch (error.code) {
     case 'AUTH_REQUIRED':
-      await refreshCredentials();
-      return retry();
+      // Two sub-cases share this code; see "AUTH_REQUIRED sub-cases" above.
+      if (!error.requestHadCredentials) {
+        await refreshCredentials();
+        return retry();
+      }
+      // Credentials were presented and rejected — terminal at app layer.
+      throw error;
 
     case 'INVALID_REQUEST':
       console.error('Validation error:', error);

--- a/docs/building/implementation/error-handling.mdx
+++ b/docs/building/implementation/error-handling.mdx
@@ -131,9 +131,10 @@ These fields are defined by the [`error.json`](https://adcontextprotocol.org/sch
 | `message` | string | Yes | Human-readable error description |
 | `recovery` | string | No | Agent recovery classification: `transient`, `correctable`, or `terminal` |
 | `retry_after` | number | No | Seconds to wait before retrying (transient errors) |
-| `field` | string | No | Field path that caused the error (e.g., `packages[0].targeting`) |
+| `field` | string | No | Field path in JSONPath-lite format (e.g., `packages[0].targeting`). When `issues` is present, sellers MUST set this to `issues[0].pointer` translated from RFC 6901 to JSONPath-lite (e.g., `/packages/0/targeting` → `packages[0].targeting`). Will be deprecated in a future major version. |
+| `issues` | array | No | Structured list of validation failures, drawn from JSON Schema validator output. Each entry carries `pointer` (RFC 6901, matches Ajv's `instancePath`), `message`, `keyword` (the JSON Schema keyword that rejected — `required` / `type` / `format` / etc.), and optional `schemaPath`. Use on `VALIDATION_ERROR` and any other code where multiple fields were rejected at once. **`schemaPath` SHOULD NOT be emitted on production-facing endpoints** — it leaks which `oneOf` branch the validator selected, a probe oracle for adversarial callers crafting payloads against polymorphic unions. Sellers MAY emit in dev/sandbox modes. |
 | `suggestion` | string | No | Suggested fix for the error |
-| `details` | object | No | Additional context-specific information |
+| `details` | object | No | Additional context-specific information. Sellers MAY mirror `issues[]` here as `details.issues` for backward compatibility with pre-3.1 consumers; new consumers SHOULD prefer the top-level `issues` field. |
 
 ## Standard Error Codes
 

--- a/docs/creative/asset-types.mdx
+++ b/docs/creative/asset-types.mdx
@@ -126,29 +126,72 @@ Text content for headlines, descriptions, CTAs, etc.
 
 ### URL Asset
 
-Links for clickthroughs, tracking, and landing pages.
+Links for clickthroughs, tracking, and landing pages. Two related but distinct fields describe a URL asset:
+
+- **`url_type`** (on the manifest asset) — the **mechanism** the receiver uses to invoke this URL.
+- **`url-asset-requirements.role`** (on the format) — the **purpose** this URL slot serves in the creative.
+
+A slot can be `click_tracker` (purpose) and accept a `tracker_pixel` (mechanism) URL — those describe different things.
+
+#### Manifest-side: `url_type` (mechanism)
+
+Senders **SHOULD** include `url_type` on every URL asset. The valid values are:
+
+| Value | Mechanism |
+|---|---|
+| `clickthrough` | User-click destination (landing page or ad-tech redirector) |
+| `tracker_pixel` | Fires HTTP GET, expects 1×1 pixel or 204 response (impression / event / 3P trackers) |
+| `tracker_script` | Loads as a `<script>` tag — measurement SDKs (OMID verification, native event trackers using `method: 2`) |
 
 ```json
 {
   "asset_type": "url",
-  "required": true,
-  "url_type": "clickthrough",
-  "must_be_https": true,
-  "tracking_macros_supported": true
+  "url_type": "tracker_pixel",
+  "url": "https://track.brand.com/imp?cb={CACHEBUSTER}"
 }
 ```
 
-**Properties:**
-- `url_type`: The purpose of the URL (used only in format requirements):
-  - `clickthrough` - User clicks this URL (may redirect through ad tech platforms before reaching destination)
-  - `impression_tracker` - Fires in background (returns 1x1 pixel, JavaScript snippet, or 204 No Content)
-  - `video_tracker` - Video ad tracking URL (for VAST, video events, etc.)
-  - `landing_page` - Landing page URL
-- `must_be_https`: Whether HTTPS is required
-- `allowed_domains`: List of allowed domains (if restricted)
-- `tracking_macros_supported`: Whether URL macros are supported
+{/* Fallback table mirrors static/schemas/source/core/assets/url-asset.json top-level description. The schema description is the normative source for conformance tools — keep this table in sync if you edit either side. */}
 
-**Note**: The `url_type` field is only used in format requirements to specify how the URL will be used. When providing URLs in creative manifests, you only need to supply the `url` value - the `asset_id` already indicates the semantic purpose (e.g., `impression_tracker`, `video_start_tracker`, `landing_url`).
+If `url_type` is **absent**, receivers SHOULD fall back to the format's `url-asset-requirements.role`:
+
+| `role` (format) | Fallback `url_type` (mechanism) |
+|---|---|
+| `clickthrough`, `landing_page` | `clickthrough` |
+| `impression_tracker`, `click_tracker` | `tracker_pixel` |
+| `viewability_tracker` | `tracker_script` — OMID and equivalent verification SDKs **require** a `<script>` tag; firing them as a pixel produces no measurement |
+| `third_party_tracker` | **No safe fallback.** Mechanism is integration-specific (DV/IAS ship both pixel and script forms). Receivers MAY reject or warn. |
+
+If neither `url_type` nor a format-side `role` is available, receivers MUST NOT silently pick a mechanism — firing a clickthrough URL as a pixel (or vice versa) silently corrupts measurement and breaks the user flow. Receivers SHOULD reject the manifest.
+
+> **VAST/DAAST URLs are not URL assets.** A URL pointing to ad-server XML markup is parsed, not GET-fired. Use `asset_type: "vast"` with `delivery_type: "url"` for VAST tags, and the dedicated tracker types (`vast_tracker` / `daast_tracker`) once those land per [RFC #2915](https://github.com/adcontextprotocol/adcp/issues/2915). A VAST tag declared as `asset_type: "url"` with `url_type: "tracker_pixel"` is non-conformant under these mechanism semantics.
+
+> **Migration cue for sellers.** If your tooling previously emitted only `{asset_type: "url", url: ...}` (per the older docs), you can keep doing so through 3.x — but plan to add `url_type` before 4.0, when this field becomes required.
+
+#### Format-side: `role` (purpose)
+
+In format requirements, `role` declares what the URL slot is for:
+
+```json
+{
+  "asset_type": "url",
+  "asset_id": "impression_tracker",
+  "required": true,
+  "requirements": {
+    "role": "impression_tracker",
+    "protocols": ["https"]
+  }
+}
+```
+
+`role` enum: `clickthrough`, `landing_page`, `impression_tracker`, `click_tracker`, `viewability_tracker`, `third_party_tracker`.
+
+#### Other URL-asset-requirements properties
+
+- `protocols`: Allowed schemes (`https`, `http`)
+- `allowed_domains`: List of allowed hostnames
+- `max_length`: Maximum URL length
+- `macro_support`: Whether macro substitution is permitted
 
 ### Audio Asset
 

--- a/docs/creative/formats.mdx
+++ b/docs/creative/formats.mdx
@@ -319,7 +319,12 @@ This unified approach helps creative tools and AI agents understand the full cap
 
 ### Third-Party Tracker Support
 
-Whether a format supports third-party measurement is determined by whether its `assets` array includes a tracker slot — an asset with `asset_type: "url"` and `url_type: "tracker_pixel"` or `"tracker_script"`. Buyer agents should check this before assigning creatives that require third-party verification.
+Whether a format supports third-party measurement is determined by whether its `assets` array includes a tracker slot. A tracker slot is any asset with `asset_type: "url"` AND either:
+
+- `url_type: "tracker_pixel"` or `url_type: "tracker_script"` (mechanism-side declaration), OR
+- `requirements.role` of `impression_tracker`, `click_tracker`, `viewability_tracker`, or `third_party_tracker` (purpose-side declaration; the slot accepts a tracker URL even if the format author declares the role rather than the mechanism)
+
+Buyer agents should check this before assigning creatives that require third-party verification.
 
 Most digital formats (display, video, CTV, audio, DOOH) include an optional `impression_tracker` asset. Formats without a tracker slot — such as broadcast TV spots — do not support creative-level pixel tracking. Measurement for these formats comes from external sources (panel data, set-top box telemetry) declared in the product's `billing_measurement` terms, not from creative-embedded pixels.
 

--- a/scripts/build-schemas.cjs
+++ b/scripts/build-schemas.cjs
@@ -142,7 +142,13 @@ function ensureDir(dir) {
 // Otherwise the schema's top-level `required` array MUST include
 // `idempotency_key`.
 
-const READ_ONLY_VERB_PATTERN = /(^|-)(get|list|check|validate|preview)-/;
+// Read-only verb pattern. Anchored to the start so tools like
+// `create-collection-list-request.json` aren't mis-classified as read-only
+// because they happen to contain `-list-` mid-name. An optional single-word
+// domain prefix (e.g., `si-get-`, `tasks-list-`) is allowed; the prefix MUST
+// be a single hyphen-free token, ruling out compound names like
+// `create-collection-list-`.
+const READ_ONLY_VERB_PATTERN = /^(?:[a-z]+-)?(get|list|check|validate|preview|search)-/;
 const NON_OPERATION_ALLOWLIST = new Set([
   // Embedded input types / utility request shapes that aren't operations
   // themselves — they're referenced via $ref from operation schemas.
@@ -171,6 +177,22 @@ function isNonMutatingRequestBasename(basename) {
 function hasNaturallyIdempotentMarker(schema) {
   const haystack = String(schema.$comment || '') + ' ' + String(schema.description || '');
   return /naturally idempotent/i.test(haystack);
+}
+
+// Classify a request schema as mutating or non-mutating using the same rules
+// the lint enforces. Returns true if the operation mutates state.
+//
+// Read-only verb basenames (get-/list-/check-/validate-/preview-) and the
+// NON_OPERATION_ALLOWLIST entries are non-mutating utility shapes.
+// Anything else is a state-changing operation: it MUST either declare
+// idempotency_key in `required` or carry a "naturally idempotent" marker
+// (which means it uses a different idempotency key like session_id).
+// Both forms are mutating; the lint above guarantees one of them is present.
+//
+// Used by both lintMutatingRequestsRequireIdempotencyKey and the manifest
+// generator — single source of truth for "is this a mutating tool?".
+function classifyRequestMutating(filePath) {
+  return !isNonMutatingRequestBasename(path.basename(filePath));
 }
 
 function lintMutatingRequestsRequireIdempotencyKey(sourceDir) {
@@ -210,6 +232,188 @@ function lintMutatingRequestsRequireIdempotencyKey(sourceDir) {
       `  A) Add "idempotency_key" to the top-level "required" array (the common case — any create/update/delete/sync/activate/submit operation).\n` +
       `  B) If the operation is genuinely read-only, rename the schema file to start with get-/list-/check-/validate-/preview- (or add it to NON_OPERATION_ALLOWLIST in scripts/build-schemas.cjs if it's a core utility).\n` +
       `  C) If the operation is naturally idempotent by some other key (e.g., session_id), add the phrase "naturally idempotent" to the schema's description or $comment, matching the pattern in sponsored-intelligence/si-terminate-session-request.json.`
+    );
+  }
+}
+
+// ── Error code enumMetadata coverage lint ─────────────────────────────────
+//
+// Every value in enums/error-code.json `enum` MUST have a structured
+// `enumMetadata[code]` entry with `recovery` (one of correctable/transient/
+// terminal) and `suggestion` (string remediation hint). This lint stops the
+// recovery-classification drift that bit the TS SDK (adcp-client#1135 — 17
+// missing codes, 3 wrong recovery values that ran for over a year because
+// SDKs were hand-curating from `enumDescriptions` prose).
+//
+// We also cross-check that the structured `recovery` matches the prose
+// `Recovery: X` in `enumDescriptions` — if either side drifts, the build
+// fails. SDKs MUST consume `enumMetadata` going forward; `enumDescriptions`
+// remains the human-readable narrative.
+//
+// See adcp#3725 for the full proposal and rationale.
+
+const VALID_RECOVERY_VALUES = new Set(['correctable', 'transient', 'terminal']);
+const RECOVERY_PROSE_PATTERN = /Recovery:\s*(correctable|transient|terminal)\b/i;
+
+function lintErrorCodeEnumMetadata(sourceDir) {
+  const errorCodePath = path.join(sourceDir, 'enums', 'error-code.json');
+  const schema = JSON.parse(fs.readFileSync(errorCodePath, 'utf8'));
+  const violations = [];
+
+  if (!Array.isArray(schema.enum) || schema.enum.length === 0) {
+    throw new Error(`Schema enumMetadata lint: enums/error-code.json has no \`enum\` array.`);
+  }
+  if (!schema.enumMetadata || typeof schema.enumMetadata !== 'object') {
+    throw new Error(
+      `Schema enumMetadata lint: enums/error-code.json is missing the \`enumMetadata\` block.\n` +
+      `Add an enumMetadata object with one entry per code: { "<CODE>": { "recovery": "...", "suggestion": "..." } }.`
+    );
+  }
+
+  const enumCodes = new Set(schema.enum);
+  const metaCodes = new Set(
+    Object.keys(schema.enumMetadata).filter(k => !k.startsWith('$'))
+  );
+
+  for (const code of enumCodes) {
+    const meta = schema.enumMetadata[code];
+    if (!meta || typeof meta !== 'object') {
+      violations.push(`  ${code}: missing enumMetadata entry`);
+      continue;
+    }
+    if (!VALID_RECOVERY_VALUES.has(meta.recovery)) {
+      violations.push(`  ${code}: enumMetadata.recovery="${meta.recovery}" — must be correctable | transient | terminal`);
+    }
+    if (typeof meta.suggestion !== 'string' || meta.suggestion.length === 0) {
+      violations.push(`  ${code}: enumMetadata.suggestion missing or empty`);
+    }
+
+    // Cross-check structured recovery against the prose in enumDescriptions.
+    // If they disagree, one of them is wrong — bail and let the author fix it.
+    const prose = schema.enumDescriptions && schema.enumDescriptions[code];
+    if (typeof prose === 'string') {
+      const m = prose.match(RECOVERY_PROSE_PATTERN);
+      if (m && m[1].toLowerCase() !== meta.recovery) {
+        violations.push(
+          `  ${code}: enumMetadata.recovery="${meta.recovery}" disagrees with prose "Recovery: ${m[1]}" in enumDescriptions`
+        );
+      }
+    }
+  }
+
+  for (const code of metaCodes) {
+    if (!enumCodes.has(code)) {
+      violations.push(`  ${code}: enumMetadata entry has no matching enum value (typo or stale entry?)`);
+    }
+  }
+
+  if (violations.length > 0) {
+    throw new Error(
+      `Schema enumMetadata lint: ${violations.length} issue(s) in enums/error-code.json.\n\n` +
+      violations.join('\n') +
+      `\n\nSee adcp#3725. SDKs depend on enumMetadata to classify error recovery — drift here ships ` +
+      `as recovery bugs in every downstream SDK.`
+    );
+  }
+}
+
+// ── Vendor metric semantic uniqueness lint ────────────────────────────────
+//
+// The reporting-capabilities.json `vendor_metrics` array and the
+// delivery-metrics.json `vendor_metric_values` array both carry a semantic
+// uniqueness key `(vendor.domain, vendor.brand_id, metric_id)`. JSON Schema
+// `uniqueItems` was deliberately omitted because BrandRef carries optional
+// fields whose absence/presence defeats deep-equal (e.g., `{domain:"x"}` and
+// `{domain:"x",brand_id:"y"}` are structurally different objects even if they
+// describe the same brand). This lint enforces the MUST constraint by
+// normalizing the semantic tuple and checking for duplicates.
+//
+// Key normalization: use `|`-delimited string `domain|brand_id|metric_id`.
+// The `|` separator is safe because domain (`[a-z0-9.-]`), brand_id
+// (`[a-z0-9_]`), and metric_id (`[a-z][a-z0-9_]*`) cannot contain `|`. Absent
+// brand_id normalizes to "" (empty string) — the empty string is distinct from
+// any valid brand_id so `{domain:"x"}` and `{domain:"x",brand_id:""}` cannot
+// collide with each other. This normalization is documented so the storyboard
+// runner's future `field_unique_by_keys` implementation must match it.
+//
+// Scan surfaces:
+//   1. `examples` arrays inside JSON schema files (at any depth).
+//   2. TypeScript training-agent fixtures (`server/src/training-agent/**/*.ts`)
+//      are explicitly called out in issue #3502 but currently contain no vendor
+//      metric data. TS scanning would require a parser — deferred until a
+//      fixture adds vendor metrics, at which point build failures will surface
+//      the gap. See #3502 item 1 for the tracking comment.
+
+/**
+ * Recursively collect all `examples` values that contain vendor metric arrays.
+ * Returns an array of { schemaPath, arrayField, tuples[] } objects.
+ */
+function collectVendorMetricExamples(obj, schemaPath, out = []) {
+  if (!obj || typeof obj !== 'object') return out;
+  if (Array.isArray(obj)) {
+    for (const item of obj) collectVendorMetricExamples(item, schemaPath, out);
+    return out;
+  }
+  // If this object has vendor_metric_values or vendor_metrics, scan them.
+  for (const field of ['vendor_metric_values', 'vendor_metrics']) {
+    const arr = obj[field];
+    if (!Array.isArray(arr) || arr.length < 2) continue;
+    const tuples = [];
+    for (const entry of arr) {
+      if (!entry || typeof entry !== 'object' || !entry.vendor) continue;
+      const domain = typeof entry.vendor.domain === 'string' ? entry.vendor.domain : '';
+      const brandId = typeof entry.vendor.brand_id === 'string' ? entry.vendor.brand_id : '';
+      const metricId = typeof entry.metric_id === 'string' ? entry.metric_id : '';
+      tuples.push(`${domain}|${brandId}|${metricId}`);
+    }
+    if (tuples.length > 0) out.push({ schemaPath, arrayField: field, tuples });
+  }
+  // Recurse into all object values (handles nested examples inside `examples` arrays, etc.).
+  for (const val of Object.values(obj)) collectVendorMetricExamples(val, schemaPath, out);
+  return out;
+}
+
+function lintVendorMetricSemanticUniqueness(sourceDir) {
+  const violations = [];
+
+  function walk(d) {
+    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+      const p = path.join(d, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'extensions' || entry.name === 'bundled') continue;
+        walk(p);
+        continue;
+      }
+      if (!entry.name.endsWith('.json')) continue;
+      let schema;
+      try { schema = JSON.parse(fs.readFileSync(p, 'utf8')); }
+      catch { continue; }
+      // Collect from top-level `examples` array and from any nested examples.
+      const exampleValues = collectVendorMetricExamples(schema, path.relative(sourceDir, p));
+      for (const { schemaPath, arrayField, tuples } of exampleValues) {
+        const seen = new Set();
+        for (const tuple of tuples) {
+          if (seen.has(tuple)) {
+            violations.push({ schemaPath, arrayField, tuple });
+          }
+          seen.add(tuple);
+        }
+      }
+    }
+  }
+
+  walk(sourceDir);
+
+  if (violations.length > 0) {
+    const lines = violations.map(v =>
+      `  ${v.schemaPath} — ${v.arrayField}: duplicate tuple "${v.tuple}" (key: domain|brand_id|metric_id)`
+    );
+    throw new Error(
+      `Vendor metric uniqueness lint: ${violations.length} duplicate tuple(s) found in schema examples.\n\n` +
+      lines.join('\n') +
+      `\n\nFix: each (vendor.domain, vendor.brand_id, metric_id) tuple MUST appear at most once per array.\n` +
+      `See static/schemas/source/core/reporting-capabilities.json and delivery-metrics.json for the\n` +
+      `normative uniqueness constraint. Issue: adcontextprotocol/adcp#3502.`
     );
   }
 }
@@ -434,6 +638,329 @@ function buildExtensions(sourceDir, targetDir, version) {
     included: validExtensions.length,
     extensions: validExtensions.map(e => e.namespace)
   };
+}
+
+// ── Manifest generation (adcp#3725) ───────────────────────────────────────
+//
+// Emit a single manifest.json artifact per version that gives SDKs a
+// machine-readable view of every tool, error code, and specialism — the
+// metadata each SDK currently hand-rolls and drifts on.
+//
+// Tool name derivation: the basename `<name>-request.json` → tool name
+// `<name>` with hyphens converted to underscores. The matching response
+// is `<name>-response.json`; async variants follow the same prefix.
+//
+// Protocol derivation: the source directory name. Tools at the source
+// root (none today, but reserved) are intentionally excluded — every tool
+// must live under a protocol directory.
+//
+// `mutating`: classifyRequestMutating() — same logic the idempotency-key
+// lint enforces, so manifest and lint can never disagree.
+//
+// `error_codes`: derived from enums/error-code.json's enum + enumMetadata
+// + enumDescriptions. The lint above guarantees these are in sync.
+//
+// `specialisms`: derived from static/compliance/source/specialisms/*/
+// index.yaml. Each specialism contributes:
+//   - entry_point_tools: the curated `required_tools` from index.yaml — the
+//     minimal contract the spec asserts implementers MUST ship.
+//   - exercised_tools: the full set of tools called across the specialism's
+//     own phases[].steps[].task plus every scenario in requires_scenarios
+//     (resolved via scenario.id from the compliance source tree).
+// SDKs use entry_point_tools to gate "did I declare the right specialism?"
+// and exercised_tools to gate "does my agent answer every call the
+// conformance kit will make?". The two sets are usually distinct;
+// shipping only entry_point_tools (#3725 review feedback) was misleading.
+// Inverse mapping (tool → specialisms[]) is folded back onto each tool
+// based on exercised_tools, since that's the surface SDK authors care about.
+
+// Keep this set in sync with the `protocol` enum in
+// static/schemas/source/manifest.schema.json. Adding a protocol surface
+// requires updating both — the script enum gates which directories are
+// scanned for tools; the meta-schema enum gates which protocol values are
+// valid in the emitted manifest.
+const MANIFEST_PROTOCOLS = new Set([
+  'media-buy', 'signals', 'governance', 'account', 'creative',
+  'brand', 'content-standards', 'property', 'collection',
+  'sponsored-intelligence', 'protocol', 'compliance', 'tmp', 'a2ui'
+]);
+
+// Strip the `Recovery: <verdict>(...).` sentence from an error-code
+// description. The structured `recovery` and `suggestion` fields carry the
+// same semantic — emitting the prose verbatim in the manifest would force
+// SDKs to choose between two surfaces.
+//
+// Three patterns occur in the corpus:
+//   1) `Recovery: <verdict>.`              — bare verdict + period
+//   2) `Recovery: <verdict> (...).`         — parenthetical suggestion + period
+//   3) `Recovery: <verdict> <clause>.`      — clause continuation to end of string
+//
+// (1) and (2) preserve any content after the Recovery sentence (e.g.
+// REFERENCE_NOT_FOUND's uniform-response MUST summary that follows
+// `Recovery: correctable.`). (3) only ever runs to end of string in the
+// corpus; no description has additional sentences after a clause-style
+// Recovery continuation.
+function stripRecoveryProse(desc) {
+  if (typeof desc !== 'string') return desc;
+  // Patterns 1+2: verdict optionally followed by a balanced (single-level)
+  // parenthetical, then a period. The parenthetical may contain dotted
+  // identifiers — match `[^)]*` to consume everything up to the closing
+  // paren regardless of internal periods.
+  const verdictThenPeriod = /\s*Recovery:\s*(?:correctable|transient|terminal)(?:\s*\([^)]*\))?\.\s*/;
+  if (verdictThenPeriod.test(desc)) {
+    return desc.replace(verdictThenPeriod, ' ').replace(/\s{2,}/g, ' ').trim();
+  }
+  // Pattern 3: clause continuation. Strip from `Recovery:` to end of string.
+  const clauseToEnd = /\s*Recovery:\s*(?:correctable|transient|terminal)\b[\s\S]+$/;
+  return desc.replace(clauseToEnd, '').replace(/\s{2,}/g, ' ').trim();
+}
+
+// Build a Map<scenarioId, Set<task>> by walking the entire compliance source
+// tree. Mirrors the resolution model used by lint-storyboard-branch-sets.cjs:
+// a `requires_scenarios` entry names a scenario's `id` field (e.g.
+// `media_buy_seller/refine_products`), and the runner finds the scenario by
+// id, not by file path.
+function indexScenarioTasks(repoRoot) {
+  const yaml = require('js-yaml');
+  const sourceRoot = path.join(repoRoot, 'static', 'compliance', 'source');
+  const index = new Map();
+  if (!fs.existsSync(sourceRoot)) return index;
+
+  function walk(dir) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(p);
+        continue;
+      }
+      if (!entry.name.endsWith('.yaml')) continue;
+      let doc;
+      try { doc = yaml.load(fs.readFileSync(p, 'utf8')); }
+      catch { continue; }
+      if (!doc || typeof doc !== 'object' || typeof doc.id !== 'string') continue;
+      if (!Array.isArray(doc.phases)) continue;
+      index.set(doc.id, collectTasksFromPhases(doc.phases));
+    }
+  }
+  walk(sourceRoot);
+  return index;
+}
+
+// Walk a storyboard's phases and collect the tasks an agent MUST handle to
+// pass conformance for that storyboard. Steps with `requires_tool: <X>` are
+// conditional — the runner only executes them if the agent claims tool X —
+// so they're optional surface and intentionally excluded here. Without that
+// filter, optional test-harness tools (e.g. comply_test_controller, gated
+// across many storyboards) would propagate to every specialism's
+// exercised_tools and overstate the required surface.
+function collectTasksFromPhases(phases) {
+  const tasks = new Set();
+  if (!Array.isArray(phases)) return tasks;
+  for (const phase of phases) {
+    if (!phase || !Array.isArray(phase.steps)) continue;
+    for (const step of phase.steps) {
+      if (!step || typeof step.task !== 'string' || step.task.length === 0) continue;
+      if (step.requires_tool) continue;
+      tasks.add(step.task);
+    }
+  }
+  return tasks;
+}
+
+function loadSpecialisms(repoRoot) {
+  const yaml = require('js-yaml');
+  const specialismsDir = path.join(repoRoot, 'static', 'compliance', 'source', 'specialisms');
+  if (!fs.existsSync(specialismsDir)) return [];
+
+  const scenarioIndex = indexScenarioTasks(repoRoot);
+
+  const out = [];
+  for (const entry of fs.readdirSync(specialismsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const indexPath = path.join(specialismsDir, entry.name, 'index.yaml');
+    if (!fs.existsSync(indexPath)) continue;
+    const doc = yaml.load(fs.readFileSync(indexPath, 'utf8'));
+    if (!doc || typeof doc !== 'object') continue;
+
+    const entryPointTools = Array.isArray(doc.required_tools) ? doc.required_tools : [];
+    const exercised = new Set(entryPointTools);
+
+    // Tools called directly by this specialism's own phases.
+    for (const t of collectTasksFromPhases(doc.phases)) exercised.add(t);
+
+    // Tools called by every linked scenario.
+    if (Array.isArray(doc.requires_scenarios)) {
+      for (const scenarioId of doc.requires_scenarios) {
+        if (typeof scenarioId !== 'string') continue;
+        const scenarioTasks = scenarioIndex.get(scenarioId);
+        if (!scenarioTasks) {
+          throw new Error(
+            `Manifest generation: specialism "${doc.id || entry.name}" requires_scenarios entry ` +
+            `"${scenarioId}" does not match any scenario id in the compliance source tree. ` +
+            `Either fix the reference or add the missing scenario file.`
+          );
+        }
+        for (const t of scenarioTasks) exercised.add(t);
+      }
+    }
+
+    out.push({
+      id: doc.id || entry.name,
+      protocol: doc.protocol || null,
+      title: doc.title || null,
+      entry_point_tools: entryPointTools,
+      exercised_tools: Array.from(exercised).sort()
+    });
+  }
+  return out;
+}
+
+function discoverTools(sourceDir) {
+  const tools = [];
+  const entries = fs.readdirSync(sourceDir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (!MANIFEST_PROTOCOLS.has(entry.name)) continue;
+    const protocol = entry.name;
+    const protoDir = path.join(sourceDir, entry.name);
+    const files = fs.readdirSync(protoDir, { withFileTypes: true });
+    for (const f of files) {
+      if (!f.isFile()) continue;
+      if (!f.name.endsWith('-request.json')) continue;
+      // Skip embedded utility request shapes — they're not standalone tools.
+      // Authors adding a new utility shape under a protocol directory MUST
+      // add it to NON_OPERATION_ALLOWLIST or the manifest will emit it as
+      // a tool name, which would surface in every SDK's generated client.
+      if (NON_OPERATION_ALLOWLIST.has(f.name)) continue;
+      const toolBase = f.name.replace(/-request\.json$/, '');
+      const toolName = toolBase.replace(/-/g, '_');
+      const requestPath = path.join(protoDir, f.name);
+      const responseName = `${toolBase}-response.json`;
+      const responsePath = path.join(protoDir, responseName);
+      if (!fs.existsSync(responsePath)) {
+        // A request with no matching response is a bug, not a tool — surface it.
+        throw new Error(
+          `Manifest generation: ${protocol}/${f.name} has no matching response schema (${responseName}). ` +
+          `Either add the response file or move the request out of the protocol directory.`
+        );
+      }
+      const mutating = classifyRequestMutating(requestPath);
+
+      const asyncVariants = files
+        .filter(g => g.isFile() && g.name.startsWith(`${toolBase}-async-response-`) && g.name.endsWith('.json'))
+        .map(g => `${protocol}/${g.name}`)
+        .sort();
+
+      tools.push({
+        name: toolName,
+        protocol,
+        mutating,
+        request_schema: `${protocol}/${f.name}`,
+        response_schema: `${protocol}/${responseName}`,
+        async_response_schemas: asyncVariants
+      });
+    }
+  }
+  // Sort tools alphabetically by name for stable output.
+  tools.sort((a, b) => a.name.localeCompare(b.name));
+  return tools;
+}
+
+function buildManifest(sourceDir, urlVersion, semverVersion, repoRoot) {
+  // Tools.
+  const tools = discoverTools(sourceDir);
+
+  // Specialisms — and the inverse tool→specialisms[] map. The inverse uses
+  // `exercised_tools` (the union of own phases + linked scenarios) because
+  // that's the surface SDK authors care about: "if I'm implementing
+  // sales_guaranteed, every tool the conformance kit will call".
+  const specialismsRaw = loadSpecialisms(repoRoot);
+  const toolToSpecialisms = new Map();
+  for (const sp of specialismsRaw) {
+    for (const t of sp.exercised_tools) {
+      if (!toolToSpecialisms.has(t)) toolToSpecialisms.set(t, []);
+      toolToSpecialisms.get(t).push(sp.id);
+    }
+  }
+  for (const tool of tools) {
+    const sp = toolToSpecialisms.get(tool.name);
+    if (sp && sp.length > 0) tool.specialisms = sp.slice().sort();
+  }
+
+  // Error codes — pull from enums/error-code.json (enum + enumMetadata +
+  // enumDescriptions). The lint guarantees these three are in sync; here
+  // we just merge them into a per-code object for the manifest.
+  //
+  // The description is the enumDescriptions string with the trailing
+  // `Recovery: X (suggestion)` prose stripped — that semantic now lives
+  // structurally in `recovery` and `suggestion`, and we don't want SDK
+  // consumers to see it twice.
+  const errorCodeSchema = JSON.parse(
+    fs.readFileSync(path.join(sourceDir, 'enums', 'error-code.json'), 'utf8')
+  );
+  const errorCodes = {};
+  for (const code of errorCodeSchema.enum) {
+    const meta = errorCodeSchema.enumMetadata[code];
+    const desc = stripRecoveryProse(errorCodeSchema.enumDescriptions[code]);
+    errorCodes[code] = {
+      recovery: meta.recovery,
+      description: desc,
+      suggestion: meta.suggestion
+    };
+  }
+
+  // Specialism block.
+  const specialisms = {};
+  for (const sp of specialismsRaw.slice().sort((a, b) => a.id.localeCompare(b.id))) {
+    specialisms[sp.id] = {
+      protocol: sp.protocol,
+      ...(sp.title ? { title: sp.title } : {}),
+      entry_point_tools: sp.entry_point_tools.slice().sort(),
+      exercised_tools: sp.exercised_tools.slice()
+    };
+  }
+
+  // Tool block — keyed by tool name.
+  const toolsObj = {};
+  for (const t of tools) {
+    toolsObj[t.name] = {
+      protocol: t.protocol,
+      mutating: t.mutating,
+      request_schema: t.request_schema,
+      response_schema: t.response_schema,
+      async_response_schemas: t.async_response_schemas,
+      ...(t.specialisms ? { specialisms: t.specialisms } : {})
+    };
+  }
+
+  return {
+    $schema: `/schemas/${urlVersion}/manifest.schema.json`,
+    adcp_version: semverVersion,
+    generated_at: new Date().toISOString(),
+    tools: toolsObj,
+    error_code_policy: {
+      default_unknown_recovery: 'transient',
+      note: "Sellers MAY return platform-specific codes that are not listed in error_codes. Agents MUST classify unknown codes as default_unknown_recovery and SHOULD retry with backoff before surfacing to the operator. Throwing on an unknown code is non-conformant client behavior."
+    },
+    error_codes: errorCodes,
+    specialisms
+  };
+}
+
+function writeManifest(sourceDir, targetDir, urlVersion, semverVersion, repoRoot) {
+  const manifest = buildManifest(sourceDir, urlVersion, semverVersion, repoRoot);
+  fs.writeFileSync(
+    path.join(targetDir, 'manifest.json'),
+    JSON.stringify(manifest, null, 2) + '\n',
+    'utf8'
+  );
+  const stats = {
+    tools: Object.keys(manifest.tools).length,
+    mutating: Object.values(manifest.tools).filter(t => t.mutating).length,
+    error_codes: Object.keys(manifest.error_codes).length,
+    specialisms: Object.keys(manifest.specialisms).length
+  };
+  return stats;
 }
 
 function copyAndTransformSchemas(sourceDir, targetDir, version) {
@@ -968,6 +1495,20 @@ async function main() {
   // latent spec bug that silently bypasses the storyboard-level lint.
   lintMutatingRequestsRequireIdempotencyKey(SOURCE_DIR);
 
+  // Lint vendor metric uniqueness: enforce the semantic uniqueness key
+  // (vendor.domain, vendor.brand_id, metric_id) documented in
+  // reporting-capabilities.json and delivery-metrics.json. JSON Schema
+  // uniqueItems was deliberately omitted because BrandRef's optional
+  // fields defeat deep-equal; this build-time check enforces the MUST
+  // constraint on example payloads embedded in schema files. Issue #3502.
+  lintVendorMetricSemanticUniqueness(SOURCE_DIR);
+
+  // Lint error-code enumMetadata coverage: every enum value MUST have a
+  // structured recovery classification, and that classification MUST agree
+  // with the "Recovery: X" prose in enumDescriptions. Stops the
+  // hand-transcribed-recovery drift bug (adcp#3725).
+  lintErrorCodeEnumMetadata(SOURCE_DIR);
+
   // Update source registry version
   updateSourceRegistry(version);
 
@@ -996,6 +1537,10 @@ async function main() {
       console.log(`   ✓ Included ${extResult.included}/${extResult.total} extensions: ${extResult.extensions.join(', ') || 'none'}`);
     }
 
+    // Generate the canonical tool/error/specialism manifest (adcp#3725).
+    const manifestStats = writeManifest(SOURCE_DIR, versionDir, version, version, path.join(__dirname, '..'));
+    console.log(`📑 Generated manifest.json (${manifestStats.tools} tools, ${manifestStats.mutating} mutating, ${manifestStats.error_codes} error codes, ${manifestStats.specialisms} specialisms)`);
+
     // Generate bundled schemas for release
     const bundledDir = path.join(versionDir, 'bundled');
     console.log(`📦 Generating bundled schemas to dist/schemas/${version}/bundled/`);
@@ -1016,6 +1561,9 @@ async function main() {
 
     // Build extensions for latest (using full version for filtering)
     buildExtensions(SOURCE_DIR, latestDir, version);
+
+    // Manifest for latest/.
+    writeManifest(SOURCE_DIR, latestDir, 'latest', version, path.join(__dirname, '..'));
 
     // Generate bundled schemas for latest
     const latestBundledDir = path.join(latestDir, 'bundled');
@@ -1072,6 +1620,10 @@ async function main() {
     } else {
       console.log(`   ✓ Included ${extResult.included}/${extResult.total} extensions: ${extResult.extensions.join(', ') || 'none'}`);
     }
+
+    // Generate the canonical tool/error/specialism manifest (adcp#3725).
+    const manifestStats = writeManifest(SOURCE_DIR, latestDir, 'latest', version, path.join(__dirname, '..'));
+    console.log(`📑 Generated manifest.json (${manifestStats.tools} tools, ${manifestStats.mutating} mutating, ${manifestStats.error_codes} error codes, ${manifestStats.specialisms} specialisms)`);
 
     // Generate bundled schemas for latest
     const bundledDir = path.join(latestDir, 'bundled');

--- a/static/compliance/source/specialisms/audience-sync/index.yaml
+++ b/static/compliance/source/specialisms/audience-sync/index.yaml
@@ -111,7 +111,7 @@ phases:
         schema_ref: "account/list-accounts-request.json"
         response_schema_ref: "account/list-accounts-response.json"
         doc_ref: "/accounts/tasks/list_accounts"
-        stateful: false
+        stateful: true
         expected: |
           Return at least one account with:
           - account_id: platform-assigned identifier

--- a/static/schemas/source/core/assets/url-asset.json
+++ b/static/schemas/source/core/assets/url-asset.json
@@ -2,7 +2,8 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/core/assets/url-asset.json",
   "title": "URL Asset",
-  "description": "URL reference asset",
+  "$comment": "Fallback table is also rendered in docs/creative/asset-types.mdx (URL Asset section). Keep the two in sync — schema description is the normative source for conformance tools; mdx is the human-readable copy.",
+  "description": "URL reference asset. `url_type` declares the mechanism a receiver uses to invoke the URL (clickthrough vs. tracker_pixel vs. tracker_script) and is distinct from the URL's purpose, which the format declares in `url-asset-requirements.role` (clickthrough, landing_page, impression_tracker, click_tracker, viewability_tracker, third_party_tracker). Senders SHOULD include `url_type` on every URL asset. When `url_type` is absent, receivers SHOULD fall back to the format's `url-asset-requirements.role` per this mapping: clickthrough/landing_page → `clickthrough`; impression_tracker/click_tracker → `tracker_pixel`; viewability_tracker → `tracker_script` (OMID and equivalent verification SDKs require a <script> tag — firing them as a pixel produces no measurement); third_party_tracker → no safe fallback (mechanism is integration-specific — DV/IAS ship both pixel and script forms — receivers MAY reject or warn). When neither `url_type` nor a format-side `role` is available, receivers MUST NOT silently pick a mechanism; they SHOULD reject the manifest. Note: VAST/DAAST tag URLs are not URL assets — use `asset_type: \"vast\"` (or the dedicated tracker types pending RFC #2915), not `asset_type: \"url\"` with a tracker_pixel mechanism.",
   "type": "object",
   "properties": {
     "asset_type": {
@@ -17,7 +18,7 @@
     },
     "url_type": {
       "$ref": "/schemas/enums/url-asset-type.json",
-      "description": "Type of URL asset: 'clickthrough' for user click destination (landing page), 'tracker_pixel' for impression/event tracking via HTTP request (fires GET, expects pixel/204 response), 'tracker_script' for measurement SDKs that must load as <script> tag (OMID verification, native event trackers using method:2)"
+      "description": "Mechanism a receiver uses to invoke this URL (distinct from purpose, which lives in `url-asset-requirements.role`): `clickthrough` for user click destination (landing page), `tracker_pixel` for impression/event tracking via HTTP request (fires GET, expects pixel/204 response), `tracker_script` for measurement SDKs that must load as a <script> tag (OMID verification, native event trackers using method:2). SHOULD be present on every URL asset; senders that omit it force the receiver into the role-based fallback described in this schema's top-level description."
     },
     "description": {
       "type": "string",

--- a/static/schemas/source/core/error.json
+++ b/static/schemas/source/core/error.json
@@ -17,7 +17,7 @@
     },
     "field": {
       "type": "string",
-      "description": "Field path associated with the error (e.g., 'packages[0].targeting')"
+      "description": "Field path associated with the error in JSONPath-lite format (e.g., 'packages[0].targeting'). When `issues[]` is also present, sellers MUST set this to `issues[0].pointer` translated from RFC 6901 to JSONPath-lite (e.g., '/packages/0/targeting' → 'packages[0].targeting') so pre-3.1 consumers reading `field` only get deterministic behavior. Will be deprecated in a future major version in favor of `issues[].pointer`."
     },
     "suggestion": {
       "type": "string",
@@ -29,9 +29,36 @@
       "minimum": 1,
       "maximum": 3600
     },
+    "issues": {
+      "type": "array",
+      "description": "Structured list of validation failures. Primary use is `VALIDATION_ERROR`, where multi-field rejections are common and `field` (singular) cannot carry the full pointer map. MAY appear on other error codes that reject multiple fields at once. When `issues` is present, sellers MUST also populate `field` from `issues[0]` for backward compatibility with pre-3.1 consumers that read `field` only — translating the RFC 6901 `pointer` format to the JSONPath-lite format `field` uses (e.g., `/packages/0/targeting` → `packages[0].targeting`). MUST (not SHOULD) so consumers reading `field` get deterministic behavior across sellers — the cost is one line of dual-write per seller; the cost of SHOULD is a long tail of seller-A-vs-seller-B inconsistency. Future major versions will deprecate `field` in favor of `issues[].pointer`.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "pointer": {
+            "type": "string",
+            "description": "RFC 6901 JSON Pointer to the offending field in the request payload (e.g., '/packages/0/targeting/geo_countries/2'). Format chosen to match Ajv's native validation output (`instancePath`); standardized and unambiguous on keys containing `/` or `~`. NOTE: this differs from the legacy top-level `field` which uses JSONPath-lite (`packages[0].targeting.geo_countries[2]`). When sellers populate `field` from `issues[0].pointer` for backward compatibility (see `field` description), they MUST translate the format — `/packages/0/x` → `packages[0].x`. Future major versions will deprecate `field` in favor of `issues[].pointer`."
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable description of why this specific field was rejected."
+          },
+          "keyword": {
+            "type": "string",
+            "description": "Schema keyword that rejected the payload, drawn from the JSON Schema vocabulary (e.g., 'required', 'type', 'format', 'enum', 'pattern', 'minimum', 'maxLength'). Matches the keyword names emitted by JSON Schema validators (Ajv, jsonschema, etc.) so agents can pattern-match on rejection class without parsing message text. Implementers SHOULD use the validator's native keyword name; do not invent custom values here."
+          },
+          "schemaPath": {
+            "type": "string",
+            "description": "Optional. Path inside the schema that rejected the payload (e.g., '#/properties/packages/items/properties/targeting/oneOf/1'). Sellers SHOULD NOT emit on production-facing endpoints — `schemaPath` leaks which `oneOf` branch the validator selected before semantic rejection, which is a probe oracle for adversarial callers crafting payloads against polymorphic unions. Sellers MAY emit in dev/sandbox modes where the diagnostic value outweighs the fingerprinting risk."
+          }
+        },
+        "required": ["pointer", "message", "keyword"],
+        "additionalProperties": true
+      }
+    },
     "details": {
       "type": "object",
-      "description": "Additional task-specific error details",
+      "description": "Additional task-specific error details. Sellers MAY mirror `issues[]` here as `details.issues` for backward compatibility with pre-3.1 consumers reading from `details`; new consumers SHOULD prefer the top-level `issues` field.",
       "additionalProperties": true
     },
     "recovery": {

--- a/static/schemas/source/core/requirements/url-asset-requirements.json
+++ b/static/schemas/source/core/requirements/url-asset-requirements.json
@@ -8,7 +8,7 @@
     "role": {
       "type": "string",
       "enum": ["clickthrough", "landing_page", "impression_tracker", "click_tracker", "viewability_tracker", "third_party_tracker"],
-      "description": "Standard role for this URL asset. Use this to constrain which purposes are valid for this URL slot. Complements asset_role (which is a human-readable label) by providing a machine-readable enum."
+      "description": "Purpose this URL slot serves in the format — distinct from `url_type` on the manifest-side asset (which declares the receiver's invocation mechanism). A slot can be `click_tracker` (purpose) and accept a `tracker_pixel` (mechanism) URL, or `clickthrough` (purpose) and accept a `clickthrough` (mechanism) URL. Complements `asset_role` (human-readable label) by providing a machine-readable enum and serves as the receiver's fallback signal when a manifest URL asset omits `url_type`."
     },
     "protocols": {
       "type": "array",

--- a/static/schemas/source/enums/error-code.json
+++ b/static/schemas/source/enums/error-code.json
@@ -96,6 +96,204 @@
     "VERSION_UNSUPPORTED": "The declared adcp_major_version is not supported by this seller. Recovery: correctable (call get_adcp_capabilities without adcp_major_version to discover supported major_versions, then retry with a supported version).",
     "CAMPAIGN_SUSPENDED": "Campaign governance has been suspended pending human review; the governance agent MUST reject `check_governance` and `report_plan_outcome` calls on the affected plan until the escalation is resolved. Distinct from `ACCOUNT_SUSPENDED` (account-wide) — this is scoped to a single plan/campaign. Recovery: transient (wait for the escalation to resolve; contact the plan operator if the suspension persists).",
     "GOVERNANCE_UNAVAILABLE": "A registered governance agent is unreachable (timeout, network error, or repeated failure) and the seller cannot obtain a governance decision for the spend-commit. Distinct from `GOVERNANCE_DENIED` (agent reachable and explicitly denied). Recovery: transient (retry with backoff; if the agent remains unreachable, the buyer MUST contact the plan's governance operator — the seller MUST NOT proceed with the media buy without a valid decision).",
-    "PERMISSION_DENIED": "The authenticated caller is not authorized for the requested action under the seller's own policies, or a required signed credential (e.g., a `governance_context` token on a spend-commit) is missing, fails verification, or was issued for a different plan, seller, or phase. Distinct from `AUTH_REQUIRED` (no credentials presented) and `GOVERNANCE_DENIED` (governance agent denied). Recovery: correctable (call `check_governance` to mint a valid token, or contact the seller to resolve the underlying permission)."
+    "PERMISSION_DENIED": "The authenticated caller is not authorized for the requested action under the seller's own policies, or a required signed credential (e.g., a `governance_context` token on a spend-commit) is missing, fails verification, or was issued for a different plan, seller, or phase. Distinct from `AUTH_REQUIRED` (no credentials presented) and `GOVERNANCE_DENIED` (governance agent denied). Recovery: correctable (call `check_governance` to mint a valid token, or contact the seller to resolve the underlying permission).",
+    "SCOPE_INSUFFICIENT": "The authenticated caller is not authorized for the invoked task — the task is not in the caller's `allowed_tasks` for this account (discoverable via the `authorization` object on sync_accounts / list_accounts responses). Distinct from `PERMISSION_DENIED` (generic authz failure, often credential-shaped) by being narrowly about task-level scope. Sellers SHOULD populate `error.details.introspection_hint` pointing at where the caller can re-read its scope (strawman: `{ task: 'list_accounts', account: {...} }`). Recovery: correctable in the sense that the request can be re-sent after the scope is broadened, but the agent cannot broaden its own scope — this requires operator intervention, and agents SHOULD surface rather than auto-retry.",
+    "READ_ONLY_SCOPE": "The caller's scope is read-only; the invoked task would mutate state and was rejected. Distinct from `SCOPE_INSUFFICIENT` (task not in scope at all) — the task is in some scopes this seller supports, just not this caller's. Recovery: correctable but not agent-autonomous — use a non-mutating alternative, or surface to the operator to request a scope that permits mutation.",
+    "FIELD_NOT_PERMITTED": "A request field is not in the caller's `field_scopes` allowlist for this task. Sellers declaring `field_scopes` on the account's `authorization` object MUST reject any request that sets a non-allowlisted field with this code. Distinct from `VALIDATION_ERROR` (schema/business-rule violation) — the field is valid, just not writable by this caller. `error.field` MUST identify the exact offending field path (e.g., `packages[0].budget`); when multiple fields are disallowed, sellers SHOULD return one error per field, or MAY enumerate them in `error.details.fields`. Recovery: correctable and agent-autonomous — agent may drop the disallowed field(s) and retry."
+  },
+  "enumMetadata": {
+    "$comment": "Structured recovery classification and remediation hints for each error code. SDKs MUST consume this block instead of parsing 'Recovery: X' from enumDescriptions prose. Each entry is { recovery, suggestion }. recovery is one of: correctable (caller can fix and retry), transient (retry with backoff), terminal (no autonomous recovery — operator intervention required). enumDescriptions is retained for human readability and will continue to carry the canonical narrative; the recovery classification embedded in that prose is normative and MUST match the value here.",
+    "INVALID_REQUEST": {
+      "recovery": "correctable",
+      "suggestion": "check request parameters and fix"
+    },
+    "AUTH_REQUIRED": {
+      "recovery": "correctable",
+      "suggestion": "provide credentials via auth header"
+    },
+    "RATE_LIMITED": {
+      "recovery": "transient",
+      "suggestion": "retry after the retry_after interval"
+    },
+    "SERVICE_UNAVAILABLE": {
+      "recovery": "transient",
+      "suggestion": "retry with exponential backoff"
+    },
+    "POLICY_VIOLATION": {
+      "recovery": "correctable",
+      "suggestion": "review policy requirements in the error details"
+    },
+    "PRODUCT_NOT_FOUND": {
+      "recovery": "correctable",
+      "suggestion": "remove invalid IDs and retry, or re-discover with get_products"
+    },
+    "PRODUCT_UNAVAILABLE": {
+      "recovery": "correctable",
+      "suggestion": "choose a different product"
+    },
+    "PROPOSAL_EXPIRED": {
+      "recovery": "correctable",
+      "suggestion": "re-discover with get_products to get a fresh proposal"
+    },
+    "BUDGET_TOO_LOW": {
+      "recovery": "correctable",
+      "suggestion": "increase budget or check capabilities.media_buy.limits"
+    },
+    "CREATIVE_REJECTED": {
+      "recovery": "correctable",
+      "suggestion": "revise the creative per the seller's advertising_policies"
+    },
+    "UNSUPPORTED_FEATURE": {
+      "recovery": "correctable",
+      "suggestion": "check get_adcp_capabilities and remove unsupported fields"
+    },
+    "AUDIENCE_TOO_SMALL": {
+      "recovery": "correctable",
+      "suggestion": "broaden targeting or upload more audience members"
+    },
+    "ACCOUNT_NOT_FOUND": {
+      "recovery": "terminal",
+      "suggestion": "verify account via list_accounts or contact seller"
+    },
+    "ACCOUNT_SETUP_REQUIRED": {
+      "recovery": "correctable",
+      "suggestion": "check details.setup for URL or instructions"
+    },
+    "ACCOUNT_AMBIGUOUS": {
+      "recovery": "correctable",
+      "suggestion": "pass explicit account_id or a more specific natural key"
+    },
+    "ACCOUNT_PAYMENT_REQUIRED": {
+      "recovery": "terminal",
+      "suggestion": "buyer must resolve billing"
+    },
+    "ACCOUNT_SUSPENDED": {
+      "recovery": "terminal",
+      "suggestion": "contact seller to resolve suspension"
+    },
+    "COMPLIANCE_UNSATISFIED": {
+      "recovery": "correctable",
+      "suggestion": "choose a format that supports the required disclosure positions and persistence modes, or remove the disclosure requirement"
+    },
+    "GOVERNANCE_DENIED": {
+      "recovery": "correctable",
+      "suggestion": "restructure the buy, escalate to human spending authority, or contact the governance agent for details"
+    },
+    "BUDGET_EXHAUSTED": {
+      "recovery": "terminal",
+      "suggestion": "buyer must add funds or increase budget cap"
+    },
+    "BUDGET_EXCEEDED": {
+      "recovery": "correctable",
+      "suggestion": "reduce requested amount or increase budget allocation"
+    },
+    "CONFLICT": {
+      "recovery": "transient",
+      "suggestion": "re-read the resource and retry with current state"
+    },
+    "IDEMPOTENCY_CONFLICT": {
+      "recovery": "correctable",
+      "suggestion": "use a fresh UUID v4 for the new request, or resend the exact original payload to get the cached response"
+    },
+    "IDEMPOTENCY_EXPIRED": {
+      "recovery": "correctable",
+      "suggestion": "perform a natural-key check to determine whether the original request succeeded; if no evidence of success, generate a fresh idempotency_key for a new attempt"
+    },
+    "CREATIVE_DEADLINE_EXCEEDED": {
+      "recovery": "correctable",
+      "suggestion": "check creative_deadline via get_media_buys before submitting changes, or negotiate a deadline extension with the seller"
+    },
+    "INVALID_STATE": {
+      "recovery": "correctable",
+      "suggestion": "check current status via get_media_buys and adjust request"
+    },
+    "MEDIA_BUY_NOT_FOUND": {
+      "recovery": "correctable",
+      "suggestion": "verify media_buy_id or buyer_ref"
+    },
+    "NOT_CANCELLABLE": {
+      "recovery": "correctable",
+      "suggestion": "check the seller's cancellation policy or contact the seller"
+    },
+    "PACKAGE_NOT_FOUND": {
+      "recovery": "correctable",
+      "suggestion": "verify package_id or buyer_ref via get_media_buys"
+    },
+    "CREATIVE_NOT_FOUND": {
+      "recovery": "correctable",
+      "suggestion": "verify creative_id via list_creatives, or sync_creatives to register it"
+    },
+    "SIGNAL_NOT_FOUND": {
+      "recovery": "correctable",
+      "suggestion": "verify signal_id via get_signals, or confirm the signal is available from this agent"
+    },
+    "REFERENCE_NOT_FOUND": {
+      "recovery": "correctable",
+      "suggestion": "verify the referenced identifier exists and is accessible to the caller"
+    },
+    "SESSION_NOT_FOUND": {
+      "recovery": "correctable",
+      "suggestion": "initiate a new session via si_initiate_session"
+    },
+    "PLAN_NOT_FOUND": {
+      "recovery": "correctable",
+      "suggestion": "verify plan_id via sync_plans, or register the plan first"
+    },
+    "SESSION_TERMINATED": {
+      "recovery": "correctable",
+      "suggestion": "initiate a new session via si_initiate_session"
+    },
+    "VALIDATION_ERROR": {
+      "recovery": "correctable",
+      "suggestion": "review error details and fix field values"
+    },
+    "PRODUCT_EXPIRED": {
+      "recovery": "correctable",
+      "suggestion": "re-discover with get_products to find current inventory"
+    },
+    "PROPOSAL_NOT_COMMITTED": {
+      "recovery": "correctable",
+      "suggestion": "finalize the proposal first using get_products with buying_mode 'refine' and action 'finalize'"
+    },
+    "IO_REQUIRED": {
+      "recovery": "correctable",
+      "suggestion": "review the proposal's insertion_order, accept terms, and include io_acceptance on create_media_buy"
+    },
+    "TERMS_REJECTED": {
+      "recovery": "correctable",
+      "suggestion": "adjust the proposed terms and retry, or omit measurement_terms to accept the product's defaults"
+    },
+    "REQUOTE_REQUIRED": {
+      "recovery": "correctable",
+      "suggestion": "re-negotiate via get_products in 'refine' mode against the existing proposal_id to obtain a fresh quote, then resubmit against the new proposal_id"
+    },
+    "VERSION_UNSUPPORTED": {
+      "recovery": "correctable",
+      "suggestion": "re-pin to a release in supported_versions and retry, or call get_adcp_capabilities without a version pin to discover supported_versions"
+    },
+    "CAMPAIGN_SUSPENDED": {
+      "recovery": "transient",
+      "suggestion": "wait for the escalation to resolve; contact the plan operator if the suspension persists"
+    },
+    "GOVERNANCE_UNAVAILABLE": {
+      "recovery": "transient",
+      "suggestion": "retry with backoff; if the agent remains unreachable, the buyer MUST contact the plan's governance operator"
+    },
+    "PERMISSION_DENIED": {
+      "recovery": "correctable",
+      "suggestion": "call check_governance to mint a valid token, or contact the seller to resolve the underlying permission"
+    },
+    "SCOPE_INSUFFICIENT": {
+      "recovery": "correctable",
+      "suggestion": "the agent cannot broaden its own scope — surface to the operator rather than auto-retry"
+    },
+    "READ_ONLY_SCOPE": {
+      "recovery": "correctable",
+      "suggestion": "use a non-mutating alternative, or surface to the operator to request a scope that permits mutation"
+    },
+    "FIELD_NOT_PERMITTED": {
+      "recovery": "correctable",
+      "suggestion": "drop the disallowed field(s) and retry"
+    }
   }
 }

--- a/static/schemas/source/enums/error-code.json
+++ b/static/schemas/source/enums/error-code.json
@@ -53,7 +53,7 @@
   ],
   "enumDescriptions": {
     "INVALID_REQUEST": "Request is malformed, missing required fields, or violates schema constraints. Recovery: correctable (check request parameters and fix).",
-    "AUTH_REQUIRED": "Authentication is required to access this resource. Recovery: correctable (provide credentials via auth header).",
+    "AUTH_REQUIRED": "Authentication is required, or presented credentials were rejected. Two operational sub-cases share this code: (a) credentials missing — agent provides credentials and retries; (b) credentials presented but rejected (expired / revoked / malformed signature) — agent SHOULD NOT auto-retry, since re-presenting a rejected credential against an SSO endpoint creates retry-storm patterns indistinguishable from brute-force probes. In sub-case (b) the agent SHOULD escalate to operator for credential rotation rather than loop. A future minor release splits this code into AUTH_MISSING (correctable) and AUTH_INVALID (terminal); agents handling 3.0.x sellers SHOULD apply the same operational distinction at the application layer. Recovery: correctable (provide credentials via auth header — but only when the credential was missing, not when it was presented and rejected).",
     "RATE_LIMITED": "Request rate exceeded. Retry after the retry_after interval. Recovery: transient.",
     "SERVICE_UNAVAILABLE": "Seller service is temporarily unavailable. Retry with exponential backoff. Recovery: transient.",
     "POLICY_VIOLATION": "Request violates the seller's content or advertising policies. Recovery: correctable (review policy requirements in the error details).",
@@ -106,7 +106,7 @@
     },
     "AUTH_REQUIRED": {
       "recovery": "correctable",
-      "suggestion": "provide credentials via auth header"
+      "suggestion": "provide credentials via auth header on missing-credential case; do NOT auto-retry on presented-but-rejected credentials — escalate to operator for credential rotation (3.1+ splits this into AUTH_MISSING / AUTH_INVALID)"
     },
     "RATE_LIMITED": {
       "recovery": "transient",

--- a/static/schemas/source/enums/error-code.json
+++ b/static/schemas/source/enums/error-code.json
@@ -96,10 +96,7 @@
     "VERSION_UNSUPPORTED": "The declared adcp_major_version is not supported by this seller. Recovery: correctable (call get_adcp_capabilities without adcp_major_version to discover supported major_versions, then retry with a supported version).",
     "CAMPAIGN_SUSPENDED": "Campaign governance has been suspended pending human review; the governance agent MUST reject `check_governance` and `report_plan_outcome` calls on the affected plan until the escalation is resolved. Distinct from `ACCOUNT_SUSPENDED` (account-wide) — this is scoped to a single plan/campaign. Recovery: transient (wait for the escalation to resolve; contact the plan operator if the suspension persists).",
     "GOVERNANCE_UNAVAILABLE": "A registered governance agent is unreachable (timeout, network error, or repeated failure) and the seller cannot obtain a governance decision for the spend-commit. Distinct from `GOVERNANCE_DENIED` (agent reachable and explicitly denied). Recovery: transient (retry with backoff; if the agent remains unreachable, the buyer MUST contact the plan's governance operator — the seller MUST NOT proceed with the media buy without a valid decision).",
-    "PERMISSION_DENIED": "The authenticated caller is not authorized for the requested action under the seller's own policies, or a required signed credential (e.g., a `governance_context` token on a spend-commit) is missing, fails verification, or was issued for a different plan, seller, or phase. Distinct from `AUTH_REQUIRED` (no credentials presented) and `GOVERNANCE_DENIED` (governance agent denied). Recovery: correctable (call `check_governance` to mint a valid token, or contact the seller to resolve the underlying permission).",
-    "SCOPE_INSUFFICIENT": "The authenticated caller is not authorized for the invoked task — the task is not in the caller's `allowed_tasks` for this account (discoverable via the `authorization` object on sync_accounts / list_accounts responses). Distinct from `PERMISSION_DENIED` (generic authz failure, often credential-shaped) by being narrowly about task-level scope. Sellers SHOULD populate `error.details.introspection_hint` pointing at where the caller can re-read its scope (strawman: `{ task: 'list_accounts', account: {...} }`). Recovery: correctable in the sense that the request can be re-sent after the scope is broadened, but the agent cannot broaden its own scope — this requires operator intervention, and agents SHOULD surface rather than auto-retry.",
-    "READ_ONLY_SCOPE": "The caller's scope is read-only; the invoked task would mutate state and was rejected. Distinct from `SCOPE_INSUFFICIENT` (task not in scope at all) — the task is in some scopes this seller supports, just not this caller's. Recovery: correctable but not agent-autonomous — use a non-mutating alternative, or surface to the operator to request a scope that permits mutation.",
-    "FIELD_NOT_PERMITTED": "A request field is not in the caller's `field_scopes` allowlist for this task. Sellers declaring `field_scopes` on the account's `authorization` object MUST reject any request that sets a non-allowlisted field with this code. Distinct from `VALIDATION_ERROR` (schema/business-rule violation) — the field is valid, just not writable by this caller. `error.field` MUST identify the exact offending field path (e.g., `packages[0].budget`); when multiple fields are disallowed, sellers SHOULD return one error per field, or MAY enumerate them in `error.details.fields`. Recovery: correctable and agent-autonomous — agent may drop the disallowed field(s) and retry."
+    "PERMISSION_DENIED": "The authenticated caller is not authorized for the requested action under the seller's own policies, or a required signed credential (e.g., a `governance_context` token on a spend-commit) is missing, fails verification, or was issued for a different plan, seller, or phase. Distinct from `AUTH_REQUIRED` (no credentials presented) and `GOVERNANCE_DENIED` (governance agent denied). Recovery: correctable (call `check_governance` to mint a valid token, or contact the seller to resolve the underlying permission)."
   },
   "enumMetadata": {
     "$comment": "Structured recovery classification and remediation hints for each error code. SDKs MUST consume this block instead of parsing 'Recovery: X' from enumDescriptions prose. Each entry is { recovery, suggestion }. recovery is one of: correctable (caller can fix and retry), transient (retry with backoff), terminal (no autonomous recovery — operator intervention required). enumDescriptions is retained for human readability and will continue to carry the canonical narrative; the recovery classification embedded in that prose is normative and MUST match the value here.",
@@ -282,18 +279,6 @@
     "PERMISSION_DENIED": {
       "recovery": "correctable",
       "suggestion": "call check_governance to mint a valid token, or contact the seller to resolve the underlying permission"
-    },
-    "SCOPE_INSUFFICIENT": {
-      "recovery": "correctable",
-      "suggestion": "the agent cannot broaden its own scope — surface to the operator rather than auto-retry"
-    },
-    "READ_ONLY_SCOPE": {
-      "recovery": "correctable",
-      "suggestion": "use a non-mutating alternative, or surface to the operator to request a scope that permits mutation"
-    },
-    "FIELD_NOT_PERMITTED": {
-      "recovery": "correctable",
-      "suggestion": "drop the disallowed field(s) and retry"
     }
   }
 }

--- a/static/schemas/source/error-details/account-setup-required.json
+++ b/static/schemas/source/error-details/account-setup-required.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/error-details/account-setup-required.json",
-  "title": "ACCOUNT_SETUP_REQUIRED Details",
+  "title": "Account Setup Required Details",
   "description": "Recommended details shape for ACCOUNT_SETUP_REQUIRED errors. Provides setup URL and remaining steps.",
   "type": "object",
   "properties": {

--- a/static/schemas/source/error-details/audience-too-small.json
+++ b/static/schemas/source/error-details/audience-too-small.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/error-details/audience-too-small.json",
-  "title": "AUDIENCE_TOO_SMALL Details",
+  "title": "Audience Too Small Details",
   "description": "Recommended details shape for AUDIENCE_TOO_SMALL errors. Provides size thresholds so agents can broaden targeting.",
   "type": "object",
   "properties": {

--- a/static/schemas/source/error-details/budget-too-low.json
+++ b/static/schemas/source/error-details/budget-too-low.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/error-details/budget-too-low.json",
-  "title": "BUDGET_TOO_LOW Details",
+  "title": "Budget Too Low Details",
   "description": "Recommended details shape for BUDGET_TOO_LOW errors. Provides the seller's minimum budget so agents can adjust.",
   "type": "object",
   "properties": {

--- a/static/schemas/source/error-details/conflict.json
+++ b/static/schemas/source/error-details/conflict.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/error-details/conflict.json",
-  "title": "CONFLICT Details",
+  "title": "Conflict Details",
   "description": "Recommended details shape for CONFLICT errors. Provides version information so agents can re-read the resource and retry.",
   "type": "object",
   "properties": {

--- a/static/schemas/source/error-details/creative-rejected.json
+++ b/static/schemas/source/error-details/creative-rejected.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/error-details/creative-rejected.json",
-  "title": "CREATIVE_REJECTED Details",
+  "title": "Creative Rejected Details",
   "description": "Recommended details shape for CREATIVE_REJECTED errors. Provides policy reference and rejection reasons so agents can revise.",
   "type": "object",
   "properties": {

--- a/static/schemas/source/error-details/policy-violation.json
+++ b/static/schemas/source/error-details/policy-violation.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/error-details/policy-violation.json",
-  "title": "POLICY_VIOLATION Details",
+  "title": "Policy Violation Details",
   "description": "Recommended details shape for POLICY_VIOLATION errors. Provides policy reference and violated rules so agents can adjust requests.",
   "type": "object",
   "properties": {

--- a/static/schemas/source/manifest.schema.json
+++ b/static/schemas/source/manifest.schema.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/manifest.schema.json",
+  "title": "AdCP Manifest",
+  "description": "Machine-readable registry of every AdCP tool, error code, and specialism for a given AdCP version. SDKs consume this artifact at codegen time to derive their tool/error tables instead of hand-transcribing the spec. Replaces three categories of drift documented in adcp#3725: hand-rolled tool-by-protocol arrays, hand-classified error recovery, and hand-listed specialism→tool mappings.",
+  "type": "object",
+  "required": ["adcp_version", "generated_at", "tools", "error_codes", "error_code_policy", "specialisms"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Reference to this manifest meta-schema."
+    },
+    "adcp_version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+(-[A-Za-z0-9.-]+)?$",
+      "description": "Full semver of the AdCP release this manifest describes."
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 timestamp the manifest was generated. SDKs MAY use this for cache invalidation."
+    },
+    "tools": {
+      "type": "object",
+      "description": "Every tool the AdCP spec defines, keyed by tool name (the snake_case name used in MCP/A2A invocations).",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "required": ["protocol", "mutating", "request_schema", "response_schema", "async_response_schemas"],
+        "additionalProperties": false,
+        "properties": {
+          "protocol": {
+            "type": "string",
+            "description": "The protocol surface this tool belongs to. Derived from the source directory: media-buy, signals, governance, account, creative, brand, content-standards, property, collection, sponsored-intelligence, protocol, compliance, tmp.",
+            "enum": [
+              "media-buy",
+              "signals",
+              "governance",
+              "account",
+              "creative",
+              "brand",
+              "content-standards",
+              "property",
+              "collection",
+              "sponsored-intelligence",
+              "protocol",
+              "compliance",
+              "tmp",
+              "a2ui"
+            ]
+          },
+          "mutating": {
+            "type": "boolean",
+            "description": "True if invoking this tool with identical inputs more than once is unsafe — i.e., the tool changes server-side state. Mutating tools MUST declare an idempotency_key on the request schema (or carry an explicit `naturally idempotent` exemption marker in the schema's description). Read-only tools (verbs `get-`, `list-`, `check-`, `validate-`, `preview-`, `search-`) are safe to retry without an idempotency key."
+          },
+          "request_schema": {
+            "type": "string",
+            "description": "Path to the request schema, relative to the manifest's directory (e.g., 'media-buy/create-media-buy-request.json')."
+          },
+          "response_schema": {
+            "type": "string",
+            "description": "Path to the synchronous response schema, relative to the manifest's directory."
+          },
+          "async_response_schemas": {
+            "type": "array",
+            "description": "Paths to the tool's async response variants (typically -submitted, -working, -input-required). Empty array if the tool has no async surface. Buyer agents MUST handle every entry — a tool with async_response_schemas non-empty can return any of these from a non-final task state.",
+            "items": { "type": "string" }
+          },
+          "specialisms": {
+            "type": "array",
+            "description": "Specialism IDs that include this tool in their required_tools (or via inherited scenarios). Lets SDKs answer \"if I claim specialism X, which tools must I implement?\" without re-deriving from the compliance cache.",
+            "items": { "type": "string" }
+          },
+          "added_in": {
+            "type": "string",
+            "description": "Semver of the AdCP release that introduced this tool. Optional; absent means \"present since 1.0\"."
+          },
+          "deprecated_in": {
+            "type": "string",
+            "description": "Semver of the AdCP release that deprecated this tool. Absent means active."
+          }
+        }
+      }
+    },
+    "error_code_policy": {
+      "type": "object",
+      "description": "How SDKs should handle codes outside the standard set. The error vocabulary is open: sellers MAY return platform-specific codes that aren't in `error_codes`. Agents MUST fall back to `default_unknown_recovery` for unknown codes — they SHOULD NOT throw or treat unknown codes as malformed responses.",
+      "required": ["default_unknown_recovery", "note"],
+      "additionalProperties": false,
+      "properties": {
+        "default_unknown_recovery": {
+          "type": "string",
+          "enum": ["correctable", "transient", "terminal"],
+          "description": "The recovery classification an agent MUST apply to a code that is not present in this manifest's `error_codes` block. `transient` is the safe default — unknown codes from a non-conforming seller should be retried with backoff, not classified as fatal."
+        },
+        "note": {
+          "type": "string",
+          "description": "Human-readable summary of the open-set policy."
+        }
+      }
+    },
+    "error_codes": {
+      "type": "object",
+      "description": "Every standard error code in the AdCP error vocabulary, keyed by the SCREAMING_SNAKE code. Mirrors enums/error-code.json's enum + enumMetadata + enumDescriptions. Open-set: see error_code_policy for unknown-code handling.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "required": ["recovery", "description", "suggestion"],
+        "additionalProperties": false,
+        "properties": {
+          "recovery": {
+            "type": "string",
+            "enum": ["correctable", "transient", "terminal"],
+            "description": "How the caller should respond. correctable: fix the request and retry. transient: retry with backoff. terminal: no autonomous recovery — operator intervention required."
+          },
+          "description": {
+            "type": "string",
+            "description": "Human-readable description of the error. Sourced from enumDescriptions in enums/error-code.json."
+          },
+          "suggestion": {
+            "type": "string",
+            "description": "Short remediation hint a buyer agent can act on. Sourced from enumMetadata in enums/error-code.json."
+          },
+          "added_in": {
+            "type": "string",
+            "description": "Semver of the AdCP release that introduced this code. Optional."
+          }
+        }
+      }
+    },
+    "specialisms": {
+      "type": "object",
+      "description": "Every storyboard specialism declared in static/compliance/source/specialisms/, keyed by specialism ID. Lets SDKs declare which specialisms they implement and verify their tool surface covers the required tools.",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["protocol", "entry_point_tools", "exercised_tools"],
+        "additionalProperties": false,
+        "properties": {
+          "protocol": {
+            "type": "string",
+            "description": "The protocol surface this specialism belongs to. Sourced from index.yaml's `protocol` field. Note: this is the specialism's home protocol; individual `exercised_tools` may belong to other protocols (e.g., a sales-track specialism may exercise an account-protocol tool like sync_accounts)."
+          },
+          "title": {
+            "type": "string",
+            "description": "Human-readable title. Sourced from index.yaml's `title` field."
+          },
+          "entry_point_tools": {
+            "type": "array",
+            "description": "The minimal contract: tools the spec asserts an implementer MUST ship to claim this specialism. Sourced from index.yaml's `required_tools` field. An agent declaring this specialism in its capabilities MUST respond to every tool listed here.",
+            "items": { "type": "string" }
+          },
+          "exercised_tools": {
+            "type": "array",
+            "description": "The full surface the conformance kit will call: union of entry_point_tools, the specialism's own phases[].steps[].task, and every linked scenario's tasks. An agent declaring this specialism MUST be prepared to handle every call here, even though some are inherited via storyboard scenarios rather than declared in `required_tools`. Use this set to size your tool registration, not entry_point_tools.",
+            "items": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Cherry-picks Section A of #3784 onto the `3.0.x` maintenance line, plus a hand-adapted #3738 (manifest + enumMetadata) and a prose-only #3739 (AUTH_REQUIRED). SDKs (TS, Python, Go) pinned at 3.0.x today only get these fixes if they land here.

Closes #3784. Partially closes #3730 (the 3.0.x prose tightening; the full enum split remains a 3.1.0 change via #3739).

## What's included

| Original PR | Cherry-pick | Type | Notes |
|---|---|---|---|
| #3149 | `7970e27d` | doc-only `title` rename | Verbatim cherry-pick |
| #3562 | `09a85fdb` | additive optional `issues[]` field | Verbatim cherry-pick |
| #3566 | `f54b7858` | doc-only `title` renames (6 files) | Verbatim cherry-pick |
| #3671 | `b466ad69` | spec text + receiver fallback rule | Verbatim cherry-pick |
| #3710 | `3d013b3a` | compliance-suite stateful flag fix | Verbatim cherry-pick |
| #3738 | `0bedfdc3` + `abd296f7` | manifest.json + structured enumMetadata | Hand-adapted — see below |
| #3739 | `e60812e1` | AUTH_REQUIRED prose tightening | Prose-only backport — see below |

Plus a fix-up commit (`baa8c136`) that downgrades two cherry-picked changesets from `minor → patch` so the 3.0.x release pipeline emits 3.0.4 (not a minor bump off the maintenance line).

## #3738 hand-adaptation

The `enumMetadata` block on `main` references three error codes (`SCOPE_INSUFFICIENT`, `READ_ONLY_SCOPE`, `FIELD_NOT_PERMITTED`) that don't exist in 3.0.x's enum. Cherry-picking verbatim would have left orphan metadata entries, which the new `lintErrorCodeEnumMetadata` guardrail correctly refused to build.

`abd296f7` trims those three orphans from both `enumDescriptions` and `enumMetadata`. Counts now agree at 45 / 45 / 45 (vs. main's 48 / 48 / 48). Build emits 57 tools / 45 error codes / 19 specialisms in `manifest.json` (vs. main's 58 / 48 / 19 — delta matches the trim plus a tool added on main that's not on 3.0.x).

The lint guardrail itself is the load-bearing change: it ensures any future spec edit on 3.0.x cannot drift `enumMetadata` away from `enum`. The same guardrail is what flagged the orphans during the cherry-pick, so the value of shipping it on 3.0.x is direct.

## #3739 prose-only backport

`AUTH_REQUIRED` conflates two operationally distinct cases: credentials missing (genuinely correctable — agent provides creds and retries) vs. credentials presented but rejected (terminal — needs human credential rotation). The 3.1 line splits this via #3739; 3.0.x cannot adopt the split because adding new enum values violates the line's own semver rules (`spec-guidelines.md` "Minor version bump allowed: Adding new enum values").

`e60812e1` does the prose-only backport instead: same wire code, same `recovery: correctable` classification, but the description and `enumMetadata.suggestion` now spell out the two sub-cases and the SHOULD-NOT-auto-retry rule for the rejected-credential case. `error-handling.mdx` gets a sub-case callout and an updated example showing how to branch on whether credentials were attached.

This addresses the operator pain (retry storms on revoked tokens) on the line that's actually deployed, without pre-empting the 3.1.0 enum split.

## What this is NOT

Wire format unchanged. No new task definitions. No new enum values. No recovery classification changes. No breaking changes for any conformant 3.0 agent.

## Test plan

- [ ] CI passes on 3.0.x base (lint, snippets, broken-links, schema-link checks, error-handling lint, the new enumMetadata coverage lint)
- [ ] Reviewer confirms each cherry-pick is faithful to its source PR
- [ ] Reviewer confirms #3738 trim covers exactly the 3 orphans (`SCOPE_INSUFFICIENT`, `READ_ONLY_SCOPE`, `FIELD_NOT_PERMITTED`)
- [ ] Reviewer agrees with `minor → patch` changeset downgrades on the maintenance line
- [ ] Reviewer agrees with the prose-only #3739 framing for 3.0.x
- [ ] Manifest validates against `manifest.schema.json` after build (already verified locally — 57 tools / 45 codes / 19 specialisms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)