### PR TITLE
ci(release): un-exclude dist/compliance + forward-merge auto-resolution

### DIFF
--- a/.agents/playbook.md
+++ b/.agents/playbook.md
@@ -252,7 +252,7 @@ Default flow when a fix is needed in both lines:
    git cherry-pick <main-sha>
    git push origin 3.0.x
    ```
-3. The forward-merge workflow (`.github/workflows/forward-merge-3.0.yml`) opens a PR back to `main` whenever `3.0.x` updates. Merging it is a near-no-op (the cherry-pick is already in `main`) but keeps the lines provably in sync.
+3. The forward-merge workflow (`.github/workflows/forward-merge-3.0.yml`) opens a PR back to `main` whenever `3.0.x` updates. Merging it is a near-no-op (the cherry-pick is already in `main`) but keeps the lines provably in sync. The workflow auto-resolves conflicts on always-divergent paths (`package.json` / `package-lock.json` → take 3.0.x's; `.changeset/*.md` → preserve main's; `dist/*`, `CHANGELOG.md`, `static/schemas/source/index.json` → take 3.0.x's) and post-merge skips the PR if the result has no tree change vs `main` (which happens after a squash-merge of an earlier forward-merge). Conflicts on any path outside that allowlist fail the workflow loud and need manual resolution — they indicate a playbook violation (a change on 3.0.x that wasn't first cherry-picked from main).
 
 #### Patch eligibility
 

--- a/.changeset/release-pipeline-hardening.md
+++ b/.changeset/release-pipeline-hardening.md
@@ -1,0 +1,18 @@
+---
+---
+
+Two release-pipeline hardening fixes for 3.0.4 and beyond:
+
+**`.dockerignore` un-excludes `dist/compliance`**: previously `/compliance/{version}/` URLs returned 404 because the Docker build context excluded `dist/` with only `!dist/schemas` and `!dist/protocol` re-includes. Versioned compliance bundles never made it into the Fly image even though they were committed to the repo. SDK consumers fetching `compliance/cache/3.0.X/` URLs hit fresh-cache 404s. Adds `!dist/compliance` (with `dist/compliance/latest` re-excluded since it's regenerated in-container).
+
+**Forward-merge workflow auto-resolves divergent metadata**: the `forward-merge-3.0.yml` workflow's bare `git merge` failed every time on the same predictable conflicts (`package.json` version field bumped on each line, `.changeset/*.md` consumed differently, etc.) — manual resolution every release. Now the workflow:
+
+- Drops the brittle `git merge-base --is-ancestor` shortcut (returns false after squash-merges even when content is in main)
+- Attempts the merge; auto-resolves conflicts on an explicit allowlist:
+  - `package.json` / `package-lock.json` → take 3.0.x's (version propagates)
+  - `.changeset/*.md` / `.changeset/pre.json` → preserve main's (main consumes changesets on its own beta schedule)
+  - `static/schemas/source/index.json`, `static/schemas/source/registry/index.yaml`, `CHANGELOG.md`, `dist/*` → take 3.0.x's
+- Fails loud on any conflict outside that allowlist (indicates a playbook violation — a change on 3.0.x that wasn't first cherry-picked from main)
+- Post-merge `git diff --quiet origin/main HEAD` skip — if 3.0.x's content is already on main (e.g. via a prior squash-merge), the workflow exits cleanly without opening a PR
+
+Companion update to `.agents/playbook.md` § Release lines documenting the auto-resolution behavior. PR review checklist updated to spot main-unique `package.json` content that may have been overwritten (a missed cherry-pick).

--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,13 @@ dist
 dist/schemas/latest
 dist/schemas/v*
 dist/schemas/registry.*
+# Include committed versioned compliance bundles from git — the builder only
+# regenerates dist/compliance/latest/, but the Express server serves
+# /compliance/{version}/ from the committed tree. Without this un-exclude,
+# versioned URLs (/compliance/3.0.3/, /compliance/3.0.4/, etc.) 404 even
+# though the files are in the repo.
+!dist/compliance
+dist/compliance/latest
 # Include cosign-signed versioned tarballs from git — the builder only
 # regenerates latest.tgz, and re-signing requires OIDC creds we don't
 # have inside the Fly.io image build.

--- a/.github/workflows/forward-merge-3.0.yml
+++ b/.github/workflows/forward-merge-3.0.yml
@@ -78,6 +78,16 @@ jobs:
             echo "Merge completed without conflicts."
           else
             CONFLICTS=$(git diff --name-only --diff-filter=U)
+            # Guard: a non-zero merge with no surfaced conflicts means
+            # something other than a content conflict failed (hook
+            # rejection, refusing-to-merge-unrelated-histories, etc.).
+            # Bail loud rather than masking with the "nothing to resolve"
+            # success path below.
+            if [ -z "$CONFLICTS" ]; then
+              echo "::error::git merge failed but produced no conflicted files. Investigate manually."
+              git merge --abort 2>/dev/null || true
+              exit 1
+            fi
             echo "Conflicts to auto-resolve:"
             echo "$CONFLICTS"
 
@@ -98,7 +108,7 @@ jobs:
                   STATUS=$(git status --porcelain -- "$f" | head -c 2)
                   case "$STATUS" in
                     DU|DD|D*)
-                      git rm -f -- "$f" >/dev/null 2>&1 || true
+                      git rm -f -- "$f" >/dev/null
                       ;;
                     *)
                       git checkout --ours -- "$f"
@@ -134,12 +144,15 @@ jobs:
                   git checkout --theirs -- "$f"
                   git add -- "$f"
                   ;;
-                # dist/{schemas,compliance,protocol}/<version>/ are 3.0.x's
-                # release artifacts that main needs to serve at versioned URLs.
-                # Always take theirs — these directories are immutable per
-                # release and main only ever ADDS to its dist tree, never
-                # rewrites old versions.
-                dist/*)
+                # dist/{schemas,compliance,protocol,docs}/<version>/ are
+                # 3.0.x's release artifacts that main needs to serve at
+                # versioned URLs. Always take theirs — these directories
+                # are immutable per release and main only ever ADDS to its
+                # dist tree, never rewrites old versions. Explicit list
+                # rather than `dist/*` so future mutable subtrees under
+                # dist/ (e.g., a development-only dist/index.html) don't
+                # silently auto-resolve.
+                dist/schemas/*|dist/compliance/*|dist/protocol/*|dist/docs/*)
                   git checkout --theirs -- "$f"
                   git add -- "$f"
                   ;;
@@ -166,6 +179,20 @@ jobs:
 
             git commit --no-edit -m "$MERGE_MSG (auto-resolved divergent metadata)"
             echo "Auto-resolution complete."
+
+            # Surface the resolution shape inline so a reviewer sees what
+            # the workflow did without having to download the diff. Two
+            # views: per-file resolution status (already staged), and a
+            # focused package.json field-level diff (the one path where
+            # silent loss of main-unique scripts is a real concern).
+            echo ""
+            echo "::group::Post-resolution git status"
+            git status --short
+            echo "::endgroup::"
+            echo ""
+            echo "::group::package.json diff vs origin/main"
+            git diff origin/main HEAD -- package.json package-lock.json || true
+            echo "::endgroup::"
           fi
 
           # Did the merge actually change anything vs main? If 3.0.x's

--- a/.github/workflows/forward-merge-3.0.yml
+++ b/.github/workflows/forward-merge-3.0.yml
@@ -60,18 +60,8 @@ jobs:
       - name: Fetch 3.0.x
         run: git fetch origin 3.0.x
 
-      - name: Skip if 3.0.x already in main
-        id: ancestry
-        run: |
-          if git merge-base --is-ancestor origin/3.0.x origin/main; then
-            echo "3.0.x is already an ancestor of main; nothing to forward-merge."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Create forward-merge branch and merge
-        if: steps.ancestry.outputs.skip != 'true'
+        id: merge
         run: |
           set -e
           # Create the target branch BEFORE the merge so peter-evans sees
@@ -79,16 +69,117 @@ jobs:
           # diffs its branch: ref against base:, not the working tree).
           git checkout -B forward-merge/3.0.x origin/main
 
-          if ! git merge --no-ff origin/3.0.x \
-              -m "Forward-merge 3.0.x@$(git rev-parse --short origin/3.0.x) → main"; then
-            echo "::error::Merge conflict between 3.0.x and main. Resolve manually:"
-            echo "::error::  git checkout main && git merge origin/3.0.x"
-            git merge --abort
-            exit 1
+          # Attempt the merge. Conflicts are expected on a small set of
+          # divergent-by-design files (package.json version, .changeset/,
+          # CHANGELOG.md, dist/) — auto-resolved below. Anything else
+          # conflicting fails the workflow loud.
+          MERGE_MSG="Forward-merge 3.0.x@$(git rev-parse --short origin/3.0.x) → main"
+          if git merge --no-ff origin/3.0.x -m "$MERGE_MSG"; then
+            echo "Merge completed without conflicts."
+          else
+            CONFLICTS=$(git diff --name-only --diff-filter=U)
+            echo "Conflicts to auto-resolve:"
+            echo "$CONFLICTS"
+
+            UNEXPECTED=""
+            while IFS= read -r f; do
+              [ -z "$f" ] && continue
+              case "$f" in
+                # `.changeset/*.md` and `.changeset/pre.json`: preserve
+                # main's state. Main consumes changesets on its own pre-mode
+                # schedule (each Version Packages cut on main produces a
+                # 3.1.0-beta.X bump from accumulated changesets); 3.0.x
+                # consuming a changeset on its release line shouldn't
+                # silently delete the same file from main's pending pool.
+                # Use `git status --porcelain` to distinguish the conflict
+                # shape — `--ours` checkout fails when ours is the deleted
+                # side (delete/modify), so we route DU/DD to `git rm`.
+                .changeset/*.md|.changeset/pre.json)
+                  STATUS=$(git status --porcelain -- "$f" | head -c 2)
+                  case "$STATUS" in
+                    DU|DD|D*)
+                      git rm -f -- "$f" >/dev/null 2>&1 || true
+                      ;;
+                    *)
+                      git checkout --ours -- "$f"
+                      git add -- "$f"
+                      ;;
+                  esac
+                  ;;
+                # package.json: take 3.0.x's wholesale. The version field
+                # is the structural conflict (3.0.x is one patch ahead of
+                # main after each release); other fields SHOULD be in sync
+                # if the playbook is followed (changes land on main first,
+                # cherry-picked to 3.0.x). If main has unique additions
+                # that 3.0.x doesn't, those came from a missing cherry-pick
+                # — the PR review surfaces the loss in the diff and the
+                # follow-up is a re-add commit on main.
+                package.json|package-lock.json)
+                  git checkout --theirs -- "$f"
+                  git add -- "$f"
+                  ;;
+                # Schema source index files carry version metadata that gets
+                # regenerated on every release build (scripts/build-schemas.cjs
+                # populates published_version / adcp_version from package.json).
+                # Take theirs — values get overwritten on next release.
+                static/schemas/source/index.json|static/schemas/source/registry/index.yaml)
+                  git checkout --theirs -- "$f"
+                  git add -- "$f"
+                  ;;
+                # CHANGELOG.md: both lines prepend new entries via changesets;
+                # the merge will conflict at the top. Take theirs (3.0.x's
+                # CHANGELOG includes the canonical 3.0 line history); main's
+                # next Version Packages cut prepends its own entries above.
+                CHANGELOG.md)
+                  git checkout --theirs -- "$f"
+                  git add -- "$f"
+                  ;;
+                # dist/{schemas,compliance,protocol}/<version>/ are 3.0.x's
+                # release artifacts that main needs to serve at versioned URLs.
+                # Always take theirs — these directories are immutable per
+                # release and main only ever ADDS to its dist tree, never
+                # rewrites old versions.
+                dist/*)
+                  git checkout --theirs -- "$f"
+                  git add -- "$f"
+                  ;;
+                *)
+                  UNEXPECTED="$UNEXPECTED $f"
+                  ;;
+              esac
+            done <<< "$CONFLICTS"
+
+            if [ -n "$UNEXPECTED" ]; then
+              echo "::error::Forward-merge has unexpected conflicts that need manual resolution:$UNEXPECTED"
+              echo "::error::Resolve manually: git checkout main && git merge origin/3.0.x"
+              git merge --abort
+              exit 1
+            fi
+
+            # Anything still unmerged after auto-resolution? Should be empty.
+            REMAINING=$(git diff --name-only --diff-filter=U)
+            if [ -n "$REMAINING" ]; then
+              echo "::error::After auto-resolution, files still conflicted: $REMAINING"
+              git merge --abort
+              exit 1
+            fi
+
+            git commit --no-edit -m "$MERGE_MSG (auto-resolved divergent metadata)"
+            echo "Auto-resolution complete."
+          fi
+
+          # Did the merge actually change anything vs main? If 3.0.x's
+          # content already reached main via a prior squash-merge or
+          # cherry-pick, there's nothing to PR. Skip cleanly.
+          if git diff --quiet origin/main HEAD; then
+            echo "Forward-merge produced no tree change — main already has 3.0.x's content."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create or update pull request
-        if: steps.ancestry.outputs.skip != 'true'
+        if: steps.merge.outputs.skip != 'true'
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -102,18 +193,42 @@ jobs:
             3.0.x fixes. **Direction is one-way**: `3.0.x → main`. Never the
             reverse.
 
+            ## Auto-resolved divergent metadata
+
+            Conflicts on these always-divergent paths are resolved
+            automatically (see workflow source for rationale):
+
+            - `package.json` / `package-lock.json` → take 3.0.x's (version
+              propagates; main's pre-mode tracking is independent)
+            - `.changeset/*.md` / `.changeset/pre.json` → preserve main's
+              state (main consumes changesets on its own beta schedule)
+            - `static/schemas/source/index.json`,
+              `static/schemas/source/registry/index.yaml` → take 3.0.x's
+              (regenerated on next release build anyway)
+            - `CHANGELOG.md` → take 3.0.x's (main's next Version Packages
+              cut prepends its own beta entries above)
+            - `dist/*` → take 3.0.x's (versioned release artifacts)
+
+            Any conflict outside this list fails the workflow loud — needs
+            manual resolution and indicates a playbook violation (a change
+            on 3.0.x that wasn't first cherry-picked from main).
+
             ## Review checklist
 
             - [ ] Diff matches what you'd expect from the 3.0.x patches
             - [ ] No 3.1-line work has been pulled in by accident (would
                   indicate the merge picked up something unintended)
+            - [ ] If the merge commit message says "(auto-resolved
+                  divergent metadata)", spot-check `package.json` for any
+                  main-unique scripts/deps that may have been overwritten
+                  (a missed cherry-pick to 3.0.x — re-add as a follow-up)
             - [ ] CI green
 
             ## Source
 
             See `.github/workflows/forward-merge-3.0.yml` for the trigger
-            and merge logic. See `.agents/playbook.md` § Release lines for
-            the cherry-pick convention.
+            and auto-resolution logic. See `.agents/playbook.md` § Release
+            lines for the cherry-pick convention.
 
             🤖 Generated by `.github/workflows/forward-merge-3.0.yml`
           labels: forward-merge


### PR DESCRIPTION
## Summary

Two release-pipeline hardening fixes that bit us during the v3.0.3 cut today. Both target operational reliability for 3.0.4 and beyond.

## (1) \`.dockerignore\` un-excludes \`dist/compliance/\`

**Symptom**: \`/compliance/3.0.3/index.json\`, \`/compliance/3.0.2/index.json\`, even \`/compliance/3.0.0/index.json\` all return 404 from the live site, even though the files are committed to the repo.

**Root cause**: \`.dockerignore\` excludes \`dist/\` then re-includes \`!dist/schemas\` and \`!dist/protocol\`, but \*\*never \`!dist/compliance\`\*\*. The Docker build context strips every committed \`dist/compliance/{version}/\` tree, so the Fly image only ever has \`dist/compliance/latest/\` (regenerated by \`build:compliance\` inside the container). The Express \`mountComplianceRoutes\` handler in \`server/src/schemas-middleware.ts\` is fine — it's been wired up correctly the whole time. The files just aren't on disk.

**Fix**: add \`!dist/compliance\` un-include and re-exclude \`dist/compliance/latest\` (matches the existing pattern for \`!dist/schemas\` / \`dist/schemas/latest\`). Two-line change.

**Impact**: SDKs fetching \`compliance/cache/3.0.4/\` URLs after the next release will get the actual files instead of 404s. The \`provides_state_for\` field in v3.0.3's sales-social storyboard becomes URL-fetchable.

## (2) \`forward-merge-3.0.yml\` auto-resolves divergent metadata

**Symptom**: every forward-merge from 3.0.x → main fails with the same predictable conflicts. PR #3783 needed three manual resolutions (\`package.json\` version + test scripts, \`.changeset/fix-url-type-tracker-pixel-channel-docs.md\` add/add, \`static/schemas/source/index.json\` version fields) plus a manual \`git fetch --unshallow\` because the workflow's shallow checkout broke \`git merge-base\`.

**Root cause**: the workflow's design assumes Version Packages on each line produces neatly-mergeable trees. It doesn't — \`package.json\` versions diverge by definition (3.0.x bumps to 3.0.4, main is at 3.0.3 in pre-mode), \`.changeset/*.md\` files are consumed on different timelines, etc. After a squash-merge of an earlier forward-merge, \`git merge-base --is-ancestor\` returns false even though content is fully in main, so the workflow tries again and re-hits the same conflicts.

**Fix**: drop the \`is-ancestor\` shortcut; replace the bare \`git merge\` with auto-resolution on an explicit allowlist of always-divergent paths. Anything outside the allowlist fails loud (indicates a playbook violation — a 3.0.x change that wasn't first cherry-picked from main).

| Path | Resolution | Why |
|---|---|---|
| \`package.json\` / \`package-lock.json\` | take 3.0.x's | version propagates; main's pre-mode is independent |
| \`.changeset/*.md\` / \`.changeset/pre.json\` | preserve main's | main consumes changesets on its own beta schedule |
| \`static/schemas/source/index.json\` | take 3.0.x's | regenerated on every release build |
| \`static/schemas/source/registry/index.yaml\` | take 3.0.x's | same |
| \`CHANGELOG.md\` | take 3.0.x's | main's next VP cut prepends its own beta entries |
| \`dist/*\` | take 3.0.x's | versioned release artifacts main needs to serve |
| anything else | fail workflow | playbook violation; manual fix |

Post-merge: \`git diff --quiet origin/main HEAD\` — if no tree change, exit cleanly without opening a PR. Handles the post-squash-merge case where 3.0.x's content is already in main.

**Companion**: \`.agents/playbook.md\` § Release lines updated to document the auto-resolution behavior. PR review checklist now mentions spot-checking \`package.json\` for main-unique content that may have been overwritten by \`--theirs\`.

## Test plan

Both changes deploy automatically to the next push to main. Verify after merge:

- [ ] \`/compliance/3.0.3/index.json\` returns 200 from adcontextprotocol.org (currently 404)
- [ ] \`/compliance/3.0.3/specialisms/sales-social/index.yaml\` returns the YAML with \`provides_state_for: sync_accounts\` visible
- [ ] CI green on this PR
- [ ] Next \`Version Packages\` merge to 3.0.x triggers \`forward-merge-3.0.yml\` and either auto-merges cleanly or skips with "main already has 3.0.x's content"

## Why these matter for 3.0.4

The user asked: "a release on 3.0.4 will 'just work'?" — answer was "release itself yes, but compliance URLs will 404 and the forward-merge will need manual conflict resolution again." This PR closes both gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)