### PR TITLE
fix(compliance): enrich sales_social storyboard with realistic payloads

### DIFF
--- a/.changeset/storyboard-payload-variety-sales-social.md
+++ b/.changeset/storyboard-payload-variety-sales-social.md
@@ -1,0 +1,4 @@
+---
+---
+
+Enrich `sales_social` storyboard payloads to catch façade adapters: add `add[]` hashed-identifier members to the `sync_audiences` step, add response validations for `action` and `uploaded_count`, add `user_match` to `log_event` events, and move `value`/`currency` into the correct `custom_data` wrapper. Closes #3785.

--- a/static/compliance/source/specialisms/sales-social/index.yaml
+++ b/static/compliance/source/specialisms/sales-social/index.yaml
@@ -208,6 +208,16 @@ phases:
             - audience_id: "outdoor_enthusiasts_25_54"
               name: "Outdoor enthusiasts 25-54"
               description: "Adults 25-54 interested in hiking, camping, and outdoor gear"
+              # Realistic add[] payload forces adapters to call the upstream
+              # audience-upload endpoint rather than returning shape-valid
+              # responses from an empty-members branch. Hash values are
+              # fictional test vectors distinct from audience-sync storyboard
+              # fixtures to avoid cross-storyboard collision in shared state backends.
+              add:
+                - external_id: "acme-user-0001"
+                  hashed_email: "a000000000000000000000000000000000000000000000000000000000000001"
+                - external_id: "acme-user-0002"
+                  hashed_phone: "b000000000000000000000000000000000000000000000000000000000000002"
 
           idempotency_key: "$generate:uuid_v4#sales_social_audience_sync_sync_audiences"
           context:
@@ -215,6 +225,12 @@ phases:
         validations:
           - check: response_schema
             description: "Response matches sync-audiences-response.json schema"
+          - check: field_present
+            path: "audiences[0].action"
+            description: "Audience result includes action (created or updated)"
+          - check: field_present
+            path: "audiences[0].uploaded_count"
+            description: "Audience result includes uploaded_count confirming identifiers were received"
 
           - check: field_present
             path: "context"
@@ -515,8 +531,15 @@ phases:
             - event_type: "purchase"
               event_id: "evt_trail_pro_001"
               event_time: "2026-04-05T14:30:00Z"
-              value: 149.99
-              currency: "USD"
+              # user_match prevents adapters from injecting synthetic
+              # placeholder identifiers to satisfy upstream required fields.
+              user_match:
+                hashed_email: "a000000000000000000000000000000000000000000000000000000000000001"
+              # value and currency belong in custom_data, not at the event
+              # top-level — event.json routes monetary fields through custom_data.
+              custom_data:
+                value: 149.99
+                currency: "USD"
 
           idempotency_key: "$generate:uuid_v4#sales_social_event_logging_log_event"
           context:


### PR DESCRIPTION
Closes #3785

Issue #3785 identifies two façade-permissive patterns in the `sales_social` storyboard that let LLM-built adapters pass compliance while never touching the upstream platform's API.

**Pattern 1 — `sync_audiences` with no `add[]` members:** The storyboard sent an audience definition with no `add` array, so the adapter's handler iterated over empty members, returned a shape-valid `{ audiences: [] }`, and the storyboard graded `overall_status: passing` — with zero hits to the upstream audience-upload endpoint.

**Pattern 2 — `log_event` with no user identifiers and misplaced monetary fields:** No `user_match` meant adapters could inject a synthetic placeholder hash to satisfy the upstream's required field, which the mock accepted. Additionally, `value` and `currency` were placed directly on the event object rather than inside `custom_data` — a schema-level bug where `additionalProperties: true` silently accepted the fields in the wrong place, meaning real upstreams never saw the purchase value.

## Changes

- **`sync_audiences` step:** adds `add[]` with two hashed-identifier members (one `hashed_email`, one `hashed_phone`), following the same pattern as the dedicated `audience_sync` specialism storyboard. Hash values use distinct trailing digits (`...0001`, `...0002`) vs the `audience_sync` storyboard (`...000`) to avoid cross-storyboard collision in shared state backends.
- **`sync_audiences` validations:** adds `field_present` checks for `audiences[0].action` and `audiences[0].uploaded_count`, so adapters must confirm receipt of the identifiers in their response.
- **`log_event` step:** adds `user_match.hashed_email` to the event (prevents synthetic placeholder injection), and moves `value`/`currency` from the event top-level into `custom_data` where `event-custom-data.json` defines them.

**Non-breaking justification:** all changes are additive enrichments to `sample_request` payloads and response validations. No schema is modified. Adapters that correctly implement `sync_audiences` (iterating `add[]`) and `log_event` (routing monetary fields through `custom_data`) already handle these payloads — only façade implementations that were skipping upstream calls will newly fail, which is the intended outcome.

**Note:** item 3 from the issue (cross-step upstream side-effect assertions requiring a new storyboard `check` type and runner support in adcp-client) is deferred — that's a separate RFC. A numeric-comparison check type (`field_gte`) to assert `uploaded_count >= 2` does not yet exist in the compliance runner; when it ships, the `sync_audiences` validations can be tightened further.

**Pre-PR review:**
- code-reviewer: approved — hash patterns valid, YAML indentation correct, `custom_data` placement matches schema, 1 nit (document `field_present` on optional `uploaded_count` is intentionally a hard assertion)
- ad-tech-protocol-expert: approved — non-breaking per spec, `value`/`currency` move is a bug fix not a normative change, `user_match` inclusion for behavioral completeness is correct compliance-suite practice

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01CFmJo5P78czUPmHZCEi7z6

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFmJo5P78czUPmHZCEi7z6)_