### PR TITLE
ci(release): backport forward-merge auto-resolution to 3.0.x (#3794)

### DIFF
--- a/.agents/playbook.md
+++ b/.agents/playbook.md
@@ -232,6 +232,79 @@ Only use `patch`/`minor`/`major` when the change affects the published AdCP prot
 - **MINOR**: Add optional fields, new enum values, new tasks
 - **MAJOR**: Remove/rename fields, change types, remove enum values
 
+### Release lines
+
+AdCP runs two release lines simultaneously:
+
+- **`main`** → next minor (currently `3.1.0-beta.N` while in pre mode; see `.changeset/pre.json`)
+- **`3.0.x`** → patches to the current minor (`3.0.2`, `3.0.3`, …)
+
+Branch naming follows `<major>.<minor>.x` to match the existing `2.6.x` precedent. No `release/` prefix.
+
+#### Cherry-pick convention
+
+Default flow when a fix is needed in both lines:
+
+1. Author lands on `main` first (normal PR flow)
+2. After merge, cherry-pick to `3.0.x`:
+   ```bash
+   git checkout 3.0.x && git pull
+   git cherry-pick <main-sha>
+   git push origin 3.0.x
+   ```
+3. The forward-merge workflow (`.github/workflows/forward-merge-3.0.yml`) opens a PR back to `main` whenever `3.0.x` updates. Merging it is a near-no-op (the cherry-pick is already in `main`) but keeps the lines provably in sync. The workflow auto-resolves conflicts on always-divergent paths (`package.json` / `package-lock.json` → take 3.0.x's; `.changeset/*.md` → preserve main's; `dist/*`, `CHANGELOG.md`, `static/schemas/source/index.json` → take 3.0.x's) and post-merge skips the PR if the result has no tree change vs `main` (which happens after a squash-merge of an earlier forward-merge). Conflicts on any path outside that allowlist fail the workflow loud and need manual resolution — they indicate a playbook violation (a change on 3.0.x that wasn't first cherry-picked from main).
+
+#### Patch eligibility
+
+For each surface a PR touches, the corresponding rule must hold. A PR touching multiple surfaces must satisfy all relevant rules.
+
+**Stable schemas** — no new fields, no renamed fields, no new enum values, no new error codes, no new normative requirements. Clarifications are patch-eligible only when both:
+1. The prior spec was demonstrably silent or ambiguous on the input (not just unstated), AND
+2. Any conformant 3.0.0 implementation of the surrounding behavior would already satisfy the new MUST.
+
+If a previously-conformant implementation could fail the clause, it's a new requirement and ships in `3.1.x` only. (This is the IETF errata vs. bis test.)
+
+**Experimental surfaces** (governance, TMP, anything `x-status: experimental`) — additive changes are always patch-eligible without notice. Breaking changes follow the 6-week notice rule in `docs/reference/experimental-status.mdx` and therefore ship in the next minor, not a patch.
+
+**Conformance harness** (`comply_test_controller`, storyboards, `runner-output.json`) — additive scenarios, additive `comply_test_controller` enum values, new universal storyboards, and additive `runner-output.json` step kinds are patch-eligible. Renaming or repurposing existing step kinds is not.
+
+**Non-normative docs and release tooling** — always patch-eligible. Includes typo fixes, link corrections, example updates, runbook changes.
+
+**Normative docs** (security guidance, idempotency rules, error semantics, signing/transport behavior, `.well-known` files like `adagents.json`/`brand.json` schemas) — follow the stable-schemas rule above. "It's just docs" doesn't apply when the docs change required behavior.
+
+**Never patch-eligible** (per `docs/reference/experimental-status.mdx`):
+- Transport-layer changes (MCP, A2A, REST envelope semantics)
+- Auth profile changes (RFC 9728, OAuth scopes)
+- Signing profile changes (RFC 9421 covered components, JWS algorithms)
+
+These are version-level concerns. Security fixes ship as out-of-band advisories or in the next minor.
+
+If unsure, default to `--empty` and discuss whether the change belongs on `3.0.x` at all. Many fixes are stable-only and ship in `3.1.x` only.
+
+#### Pre mode (beta releases)
+
+`.changeset/pre.json` puts main in **pre mode** — every Version Packages cut produces `3.1.0-beta.N` instead of `3.1.0`. This is a deliberate safety net: if a `minor` changeset slips into `main` accidentally, it ships as a beta drop, not as 3.1.0 stable.
+
+To exit pre mode and cut 3.1.0 stable:
+
+```bash
+npx changeset pre exit   # deletes .changeset/pre.json
+git add -A && git commit -m "chore(release): exit pre mode for 3.1.0 stable cut"
+# open PR, land it
+```
+
+Next Version Packages cut after the exit PR merges produces `3.1.0` stable.
+
+#### App-token convention
+
+`release.yml`, `release-docs.yml`, and `forward-merge-3.0.yml` mint a GitHub App installation token via `actions/create-github-app-token@v3` (secrets `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`) instead of using the default `GITHUB_TOKEN`. App-token-triggered events (push, PR open, release publish) DO fire downstream workflows; `GITHUB_TOKEN`-triggered events don't (GitHub's recursion-blocking rule). Without this swap, the Version Packages PR's required CI never fires, the release-docs snapshot is never created on `release: published`, and the auto-snapshot PR's required CI never fires either.
+
+#### Runbooks
+
+- `.agents/shortcuts/cut-patch.md` — cutting a `3.0.X` patch
+- `.agents/shortcuts/cut-beta.md` — cutting a `3.1.0-beta.N` and exiting pre mode for 3.1.0 stable
+- `.agents/shortcuts/cut-major.md` — cutting a major (4.0 when its time comes)
+
 ### Addie Code Version
 When making significant changes to Addie's core logic, bump `CODE_VERSION` in `server/src/addie/config-version.ts`.
 

--- a/.changeset/release-pipeline-hardening.md
+++ b/.changeset/release-pipeline-hardening.md
@@ -1,0 +1,18 @@
+---
+---
+
+Two release-pipeline hardening fixes for 3.0.4 and beyond:
+
+**`.dockerignore` un-excludes `dist/compliance`**: previously `/compliance/{version}/` URLs returned 404 because the Docker build context excluded `dist/` with only `!dist/schemas` and `!dist/protocol` re-includes. Versioned compliance bundles never made it into the Fly image even though they were committed to the repo. SDK consumers fetching `compliance/cache/3.0.X/` URLs hit fresh-cache 404s. Adds `!dist/compliance` (with `dist/compliance/latest` re-excluded since it's regenerated in-container).
+
+**Forward-merge workflow auto-resolves divergent metadata**: the `forward-merge-3.0.yml` workflow's bare `git merge` failed every time on the same predictable conflicts (`package.json` version field bumped on each line, `.changeset/*.md` consumed differently, etc.) — manual resolution every release. Now the workflow:
+
+- Drops the brittle `git merge-base --is-ancestor` shortcut (returns false after squash-merges even when content is in main)
+- Attempts the merge; auto-resolves conflicts on an explicit allowlist:
+  - `package.json` / `package-lock.json` → take 3.0.x's (version propagates)
+  - `.changeset/*.md` / `.changeset/pre.json` → preserve main's (main consumes changesets on its own beta schedule)
+  - `static/schemas/source/index.json`, `static/schemas/source/registry/index.yaml`, `CHANGELOG.md`, `dist/*` → take 3.0.x's
+- Fails loud on any conflict outside that allowlist (indicates a playbook violation — a change on 3.0.x that wasn't first cherry-picked from main)
+- Post-merge `git diff --quiet origin/main HEAD` skip — if 3.0.x's content is already on main (e.g. via a prior squash-merge), the workflow exits cleanly without opening a PR
+
+Companion update to `.agents/playbook.md` § Release lines documenting the auto-resolution behavior. PR review checklist updated to spot main-unique `package.json` content that may have been overwritten (a missed cherry-pick).

--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,13 @@ dist
 dist/schemas/latest
 dist/schemas/v*
 dist/schemas/registry.*
+# Include committed versioned compliance bundles from git — the builder only
+# regenerates dist/compliance/latest/, but the Express server serves
+# /compliance/{version}/ from the committed tree. Without this un-exclude,
+# versioned URLs (/compliance/3.0.3/, /compliance/3.0.4/, etc.) 404 even
+# though the files are in the repo.
+!dist/compliance
+dist/compliance/latest
 # Include cosign-signed versioned tarballs from git — the builder only
 # regenerates latest.tgz, and re-signing requires OIDC creds we don't
 # have inside the Fly.io image build.

--- a/.github/workflows/forward-merge-3.0.yml
+++ b/.github/workflows/forward-merge-3.0.yml
@@ -60,18 +60,8 @@ jobs:
       - name: Fetch 3.0.x
         run: git fetch origin 3.0.x
 
-      - name: Skip if 3.0.x already in main
-        id: ancestry
-        run: |
-          if git merge-base --is-ancestor origin/3.0.x origin/main; then
-            echo "3.0.x is already an ancestor of main; nothing to forward-merge."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Create forward-merge branch and merge
-        if: steps.ancestry.outputs.skip != 'true'
+        id: merge
         run: |
           set -e
           # Create the target branch BEFORE the merge so peter-evans sees
@@ -79,16 +69,144 @@ jobs:
           # diffs its branch: ref against base:, not the working tree).
           git checkout -B forward-merge/3.0.x origin/main
 
-          if ! git merge --no-ff origin/3.0.x \
-              -m "Forward-merge 3.0.x@$(git rev-parse --short origin/3.0.x) → main"; then
-            echo "::error::Merge conflict between 3.0.x and main. Resolve manually:"
-            echo "::error::  git checkout main && git merge origin/3.0.x"
-            git merge --abort
-            exit 1
+          # Attempt the merge. Conflicts are expected on a small set of
+          # divergent-by-design files (package.json version, .changeset/,
+          # CHANGELOG.md, dist/) — auto-resolved below. Anything else
+          # conflicting fails the workflow loud.
+          MERGE_MSG="Forward-merge 3.0.x@$(git rev-parse --short origin/3.0.x) → main"
+          if git merge --no-ff origin/3.0.x -m "$MERGE_MSG"; then
+            echo "Merge completed without conflicts."
+          else
+            CONFLICTS=$(git diff --name-only --diff-filter=U)
+            # Guard: a non-zero merge with no surfaced conflicts means
+            # something other than a content conflict failed (hook
+            # rejection, refusing-to-merge-unrelated-histories, etc.).
+            # Bail loud rather than masking with the "nothing to resolve"
+            # success path below.
+            if [ -z "$CONFLICTS" ]; then
+              echo "::error::git merge failed but produced no conflicted files. Investigate manually."
+              git merge --abort 2>/dev/null || true
+              exit 1
+            fi
+            echo "Conflicts to auto-resolve:"
+            echo "$CONFLICTS"
+
+            UNEXPECTED=""
+            while IFS= read -r f; do
+              [ -z "$f" ] && continue
+              case "$f" in
+                # `.changeset/*.md` and `.changeset/pre.json`: preserve
+                # main's state. Main consumes changesets on its own pre-mode
+                # schedule (each Version Packages cut on main produces a
+                # 3.1.0-beta.X bump from accumulated changesets); 3.0.x
+                # consuming a changeset on its release line shouldn't
+                # silently delete the same file from main's pending pool.
+                # Use `git status --porcelain` to distinguish the conflict
+                # shape — `--ours` checkout fails when ours is the deleted
+                # side (delete/modify), so we route DU/DD to `git rm`.
+                .changeset/*.md|.changeset/pre.json)
+                  STATUS=$(git status --porcelain -- "$f" | head -c 2)
+                  case "$STATUS" in
+                    DU|DD|D*)
+                      git rm -f -- "$f" >/dev/null
+                      ;;
+                    *)
+                      git checkout --ours -- "$f"
+                      git add -- "$f"
+                      ;;
+                  esac
+                  ;;
+                # package.json: take 3.0.x's wholesale. The version field
+                # is the structural conflict (3.0.x is one patch ahead of
+                # main after each release); other fields SHOULD be in sync
+                # if the playbook is followed (changes land on main first,
+                # cherry-picked to 3.0.x). If main has unique additions
+                # that 3.0.x doesn't, those came from a missing cherry-pick
+                # — the PR review surfaces the loss in the diff and the
+                # follow-up is a re-add commit on main.
+                package.json|package-lock.json)
+                  git checkout --theirs -- "$f"
+                  git add -- "$f"
+                  ;;
+                # Schema source index files carry version metadata that gets
+                # regenerated on every release build (scripts/build-schemas.cjs
+                # populates published_version / adcp_version from package.json).
+                # Take theirs — values get overwritten on next release.
+                static/schemas/source/index.json|static/schemas/source/registry/index.yaml)
+                  git checkout --theirs -- "$f"
+                  git add -- "$f"
+                  ;;
+                # CHANGELOG.md: both lines prepend new entries via changesets;
+                # the merge will conflict at the top. Take theirs (3.0.x's
+                # CHANGELOG includes the canonical 3.0 line history); main's
+                # next Version Packages cut prepends its own entries above.
+                CHANGELOG.md)
+                  git checkout --theirs -- "$f"
+                  git add -- "$f"
+                  ;;
+                # dist/{schemas,compliance,protocol,docs}/<version>/ are
+                # 3.0.x's release artifacts that main needs to serve at
+                # versioned URLs. Always take theirs — these directories
+                # are immutable per release and main only ever ADDS to its
+                # dist tree, never rewrites old versions. Explicit list
+                # rather than `dist/*` so future mutable subtrees under
+                # dist/ (e.g., a development-only dist/index.html) don't
+                # silently auto-resolve.
+                dist/schemas/*|dist/compliance/*|dist/protocol/*|dist/docs/*)
+                  git checkout --theirs -- "$f"
+                  git add -- "$f"
+                  ;;
+                *)
+                  UNEXPECTED="$UNEXPECTED $f"
+                  ;;
+              esac
+            done <<< "$CONFLICTS"
+
+            if [ -n "$UNEXPECTED" ]; then
+              echo "::error::Forward-merge has unexpected conflicts that need manual resolution:$UNEXPECTED"
+              echo "::error::Resolve manually: git checkout main && git merge origin/3.0.x"
+              git merge --abort
+              exit 1
+            fi
+
+            # Anything still unmerged after auto-resolution? Should be empty.
+            REMAINING=$(git diff --name-only --diff-filter=U)
+            if [ -n "$REMAINING" ]; then
+              echo "::error::After auto-resolution, files still conflicted: $REMAINING"
+              git merge --abort
+              exit 1
+            fi
+
+            git commit --no-edit -m "$MERGE_MSG (auto-resolved divergent metadata)"
+            echo "Auto-resolution complete."
+
+            # Surface the resolution shape inline so a reviewer sees what
+            # the workflow did without having to download the diff. Two
+            # views: per-file resolution status (already staged), and a
+            # focused package.json field-level diff (the one path where
+            # silent loss of main-unique scripts is a real concern).
+            echo ""
+            echo "::group::Post-resolution git status"
+            git status --short
+            echo "::endgroup::"
+            echo ""
+            echo "::group::package.json diff vs origin/main"
+            git diff origin/main HEAD -- package.json package-lock.json || true
+            echo "::endgroup::"
+          fi
+
+          # Did the merge actually change anything vs main? If 3.0.x's
+          # content already reached main via a prior squash-merge or
+          # cherry-pick, there's nothing to PR. Skip cleanly.
+          if git diff --quiet origin/main HEAD; then
+            echo "Forward-merge produced no tree change — main already has 3.0.x's content."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create or update pull request
-        if: steps.ancestry.outputs.skip != 'true'
+        if: steps.merge.outputs.skip != 'true'
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -102,18 +220,42 @@ jobs:
             3.0.x fixes. **Direction is one-way**: `3.0.x → main`. Never the
             reverse.
 
+            ## Auto-resolved divergent metadata
+
+            Conflicts on these always-divergent paths are resolved
+            automatically (see workflow source for rationale):
+
+            - `package.json` / `package-lock.json` → take 3.0.x's (version
+              propagates; main's pre-mode tracking is independent)
+            - `.changeset/*.md` / `.changeset/pre.json` → preserve main's
+              state (main consumes changesets on its own beta schedule)
+            - `static/schemas/source/index.json`,
+              `static/schemas/source/registry/index.yaml` → take 3.0.x's
+              (regenerated on next release build anyway)
+            - `CHANGELOG.md` → take 3.0.x's (main's next Version Packages
+              cut prepends its own beta entries above)
+            - `dist/*` → take 3.0.x's (versioned release artifacts)
+
+            Any conflict outside this list fails the workflow loud — needs
+            manual resolution and indicates a playbook violation (a change
+            on 3.0.x that wasn't first cherry-picked from main).
+
             ## Review checklist
 
             - [ ] Diff matches what you'd expect from the 3.0.x patches
             - [ ] No 3.1-line work has been pulled in by accident (would
                   indicate the merge picked up something unintended)
+            - [ ] If the merge commit message says "(auto-resolved
+                  divergent metadata)", spot-check `package.json` for any
+                  main-unique scripts/deps that may have been overwritten
+                  (a missed cherry-pick to 3.0.x — re-add as a follow-up)
             - [ ] CI green
 
             ## Source
 
             See `.github/workflows/forward-merge-3.0.yml` for the trigger
-            and merge logic. See `.agents/playbook.md` § Release lines for
-            the cherry-pick convention.
+            and auto-resolution logic. See `.agents/playbook.md` § Release
+            lines for the cherry-pick convention.
 
             🤖 Generated by `.github/workflows/forward-merge-3.0.yml`
           labels: forward-merge


### PR DESCRIPTION
Cherry-pick of #3794 (\`8a864b338d\`) from main to 3.0.x.

## Why

Workflow files under \`.github/workflows/\` execute the version of the YAML on the **ref that triggered them**. The forward-merge workflow runs on push to \`3.0.x\`, which means it reads \`.github/workflows/forward-merge-3.0.yml\` from 3.0.x's HEAD — not main's. The auto-resolution + .dockerignore fix landed on main in #3794 doesn't apply until it's also on 3.0.x.

This was confirmed empirically immediately after #3794 merged: the next push to 3.0.x (the v3.0.4 cherry-pick batch from #3789) triggered the OLD workflow logic and failed with the expected \`add/add\` conflicts on \`.changeset/*.md\` plus content conflict on \`docs/building/implementation/error-handling.mdx\`.

## What's included

The full #3794 commit (squash-merged on main as \`8a864b338d\`):

- \`.dockerignore\` — \`!dist/compliance\` + re-exclude \`dist/compliance/latest\` (so versioned URLs serve)
- \`.github/workflows/forward-merge-3.0.yml\` — auto-resolution on the always-divergent allowlist + post-merge \`git diff --quiet\` skip + reviewer-visibility log groups
- \`.agents/playbook.md\` — Release lines section documenting the auto-resolution behavior
- \`.changeset/release-pipeline-hardening.md\` — empty changeset describing both fixes

Conflict resolution during the cherry-pick: \`.agents/playbook.md\` had the entire "Release lines" section incoming-only (it was added on main but didn't exist on 3.0.x). Resolved by accepting the incoming section verbatim — that's what the cherry-pick was designed to bring across.

## After this lands

The next 3.0.x push (or the next Version Packages merge → 3.0.4) will run the new auto-resolution workflow logic. The previous failed run (\`25239101023\`) can be re-run via \`workflow_dispatch\` to confirm the fix works on the existing 3.0.x HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)