### PR TITLE
fix(addie): use organization_memberships in prospect-claim admin lookup

### DIFF
--- a/.changeset/fix-prospect-claim-org-memberships-table.md
+++ b/.changeset/fix-prospect-claim-org-memberships-table.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-Fix prospect claim in Slack — admin lookup query referenced non-existent `org_memberships` table; correct name is `organization_memberships`. Claiming an enterprise prospect via the Slack action button no longer 500s.
+Fix prospect claim in Slack and enforce admin gate. The admin lookup query referenced a non-existent `org_memberships` table (correct name: `organization_memberships`), so every claim attempt 500'd. Renaming the table also surfaced a latent issue: the computed `is_admin` flag was never enforced, so once the query succeeded, any linked Slack user could have claimed a prospect. Both are fixed: the query runs, and non-admins now get an ephemeral "Only AgenticAdvertising.org admins can claim prospects" reply.

--- a/.changeset/fix-prospect-claim-org-memberships-table.md
+++ b/.changeset/fix-prospect-claim-org-memberships-table.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix prospect claim in Slack — admin lookup query referenced non-existent `org_memberships` table; correct name is `organization_memberships`. Claiming an enterprise prospect via the Slack action button no longer 500s.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adcontextprotocol",
-  "version": "3.0.1",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adcontextprotocol",
-      "version": "3.0.1",
+      "version": "3.0.3",
       "dependencies": {
         "@adcp/sdk": "5.25.1",
         "@anthropic-ai/sdk": "^0.91.1",

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -2453,7 +2453,7 @@ async function handleProspectClaim({ ack, body, client }: any): Promise<void> {
     const userResult = await pool.query<{ workos_user_id: string; first_name: string; email: string; is_admin: boolean }>(
       `SELECT u.workos_user_id, u.first_name, u.email,
               EXISTS(
-                SELECT 1 FROM org_memberships om
+                SELECT 1 FROM organization_memberships om
                 WHERE om.workos_user_id = u.workos_user_id
                   AND om.workos_organization_id = (
                     SELECT workos_organization_id FROM organizations WHERE slug = 'agenticadvertising-org' LIMIT 1

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -2475,6 +2475,16 @@ async function handleProspectClaim({ ack, body, client }: any): Promise<void> {
 
     const user = userResult.rows[0];
 
+    if (!user.is_admin) {
+      await client.chat.postEphemeral({
+        channel: channelId,
+        user: userId,
+        text: 'Only AgenticAdvertising.org admins can claim prospects.',
+      });
+      logger.warn({ userId, workosUserId: user.workos_user_id, orgId }, 'Addie Bolt: Non-admin attempted prospect claim');
+      return;
+    }
+
     // Verify the org is still an active prospect
     const orgCheck = await pool.query<{ name: string; subscription_status: string | null; prospect_owner: string | null }>(
       `SELECT name, subscription_status, prospect_owner FROM organizations WHERE workos_organization_id = $1`,


### PR DESCRIPTION
## Summary

The Slack prospect-claim button handler (`handleProspectClaim` in `server/src/addie/bolt-app.ts`) queried a non-existent `org_memberships` table when verifying the claimer's admin status. The actual table is `organization_memberships`. Production was 500ing on every claim attempt:

```
relation "org_memberships" does not exist
  at handleProspectClaim (file:///app/dist/addie/bolt-app.js:2043:28)
```

Bug introduced in #1196 (prospect triage feature, Feb 2026); the typo went unnoticed because the admin-only path is rarely exercised in tests.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Pre-commit unit tests pass
- [ ] In Slack, click "Claim" on a prospect notification — confirm the user is set as `prospect_owner` and an ephemeral confirmation is posted (verify after deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)