### PR TITLE
test(addie): RFC-drafting grader + Jeffrey-Mayer replay scenarios

### DIFF
--- a/.changeset/eval-rfc-drafting-grader.md
+++ b/.changeset/eval-rfc-drafting-grader.md
@@ -1,0 +1,15 @@
+---
+---
+
+Add RFC-drafting grader and Jeffrey-Mayer scenario fixtures to the qualitative
+replay runner. Catches the same-Addie-different-answers failure mode where
+web-Addie drafts a GitHub issue from a member's framing without verifying the
+gap against the spec, then a different surface (Slack) corrects it. Runs as
+`REPLAY_FILTER=rfc npx tsx server/tests/qualitative/replay-prod-scenarios.ts`.
+
+The grader scores three independent dimensions per scenario — router tool-set
+selection, in-conversation tool calls (search_docs / get_schema), and response
+substance (field citations + premise pushback) — so a fix shows up in exactly
+one dimension and regressions are localizable. Stub spec tools live next to
+the grader so the runner can measure tool use without standing up real MCP
+infrastructure.

--- a/server/src/addie/testing/rfc-grader.ts
+++ b/server/src/addie/testing/rfc-grader.ts
@@ -70,6 +70,21 @@ const PUSHBACK_MARKERS = [
   'factual error',
   'premise',
   'reframe',
+  // softer-but-clear pushback that still signals "you're partly wrong"
+  'overlaps',
+  'overlap with',
+  'most of this',
+  'most of what',
+  'most of the',
+  'partly addressed',
+  'partly covered',
+  'partially covered',
+  'narrower',
+  // direct correction language
+  "isn't a",
+  'is not a',
+  'no trusted_match',
+  'no direct_sold_signals',
 ];
 
 export function gradeRfcRun(

--- a/server/src/addie/testing/rfc-grader.ts
+++ b/server/src/addie/testing/rfc-grader.ts
@@ -1,0 +1,259 @@
+/**
+ * RFC-drafting grader.
+ *
+ * Scores Addie's behavior when a member asks her to draft an RFC / GitHub
+ * issue against the AdCP spec. The failure mode this grader is designed to
+ * catch: Addie drafts the issue using the caller's framing without verifying
+ * the gap against the spec, then a second instance (different surface, same
+ * agent) does the verification work and contradicts the first.
+ *
+ * Three dimensions are scored independently — a single boolean per scenario
+ * masks which of these moved.
+ *
+ *   1. Router selection — did the router pick `knowledge` (so search_docs is
+ *      reachable)? This is the primary upstream cause of the failure.
+ *   2. Tool use — did Sonnet actually call search_docs / get_schema before
+ *      emitting a draft? Reachability is necessary but not sufficient.
+ *   3. Response substance — did the response cite real spec fields, push
+ *      back on the premise when warranted, and avoid emitting a fully-formed
+ *      draft block before any verification turn?
+ *
+ * Used by replay-prod-scenarios.ts for scenarios tagged `category: 'rfc'`.
+ * Lives alongside shape-grader.ts and stays dependency-free.
+ */
+
+export interface RfcExpectations {
+  /** Tool sets the router MUST include for this scenario. Subset match. */
+  expectedToolSets?: string[];
+  /** Tool names that MUST appear in tool_use blocks before any text response. */
+  expectedToolCalls?: string[];
+  /** Schema fields/concepts that should appear verbatim in the response text. */
+  expectedFieldCitations?: string[];
+  /**
+   * If true, the caller's premise contains a factual error and Addie should
+   * push back rather than draft. Detected by absence of a draft_github_issue
+   * tool_use AND presence of corrective language.
+   */
+  shouldRefusePremise?: boolean;
+}
+
+export interface RfcRunObservations {
+  /** Tool sets selected by the router. */
+  routerToolSets: string[];
+  /** Tool names called by Sonnet across all turns, in order. */
+  toolCalls: string[];
+  /** Final text response (last assistant turn after all tool loops). */
+  finalText: string;
+  /** Whether draft_github_issue was called at any point. */
+  draftEmitted: boolean;
+}
+
+export interface RfcGrade {
+  routerOk: boolean;
+  toolCallsOk: boolean;
+  citationsOk: boolean;
+  premiseOk: boolean;
+  passed: boolean;
+  failures: string[];
+}
+
+const PUSHBACK_MARKERS = [
+  'already',
+  "doesn't exist",
+  'does not exist',
+  'no such',
+  'not in the spec',
+  'already in the spec',
+  'already covered',
+  'already addressed',
+  'already supported',
+  'factual error',
+  'premise',
+  'reframe',
+];
+
+export function gradeRfcRun(
+  expect: RfcExpectations,
+  obs: RfcRunObservations,
+): RfcGrade {
+  const failures: string[] = [];
+
+  // 1. Router tool sets — every expected set must be present.
+  let routerOk = true;
+  if (expect.expectedToolSets && expect.expectedToolSets.length > 0) {
+    const missing = expect.expectedToolSets.filter(
+      (s) => !obs.routerToolSets.includes(s),
+    );
+    if (missing.length > 0) {
+      routerOk = false;
+      failures.push(
+        `router missing expected tool sets: [${missing.join(', ')}] (got [${obs.routerToolSets.join(', ')}])`,
+      );
+    }
+  }
+
+  // 2. Tool calls — every expected tool must appear in the call list.
+  let toolCallsOk = true;
+  if (expect.expectedToolCalls && expect.expectedToolCalls.length > 0) {
+    const missingCalls = expect.expectedToolCalls.filter(
+      (t) => !obs.toolCalls.includes(t),
+    );
+    if (missingCalls.length > 0) {
+      toolCallsOk = false;
+      failures.push(
+        `expected tool calls not made: [${missingCalls.join(', ')}] (called [${obs.toolCalls.join(', ')}])`,
+      );
+    }
+  }
+
+  // 3. Field citations — at least one expected field/concept must appear.
+  let citationsOk = true;
+  if (expect.expectedFieldCitations && expect.expectedFieldCitations.length > 0) {
+    const text = obs.finalText.toLowerCase();
+    const found = expect.expectedFieldCitations.filter((f) =>
+      text.includes(f.toLowerCase()),
+    );
+    if (found.length === 0) {
+      citationsOk = false;
+      failures.push(
+        `no expected field citation in response (looked for: [${expect.expectedFieldCitations.join(', ')}])`,
+      );
+    }
+  }
+
+  // 4. Premise pushback — when the caller's premise is factually wrong.
+  let premiseOk = true;
+  if (expect.shouldRefusePremise) {
+    const text = obs.finalText.toLowerCase();
+    const pushedBack = PUSHBACK_MARKERS.some((m) => text.includes(m));
+    if (obs.draftEmitted && !pushedBack) {
+      premiseOk = false;
+      failures.push(
+        'emitted draft without pushing back on factually-wrong premise',
+      );
+    } else if (!pushedBack) {
+      premiseOk = false;
+      failures.push(
+        'no pushback language in response (premise contains factual error)',
+      );
+    }
+  }
+
+  return {
+    routerOk,
+    toolCallsOk,
+    citationsOk,
+    premiseOk,
+    passed: routerOk && toolCallsOk && citationsOk && premiseOk,
+    failures,
+  };
+}
+
+/**
+ * Stub tool definitions for tool-use measurement. The runner gives Sonnet
+ * these definitions so it CAN call search_docs / get_schema — what we're
+ * measuring is whether it does. Stubs return canned data so the agent can
+ * make progress past the tool turn. Keep the surface minimal: anything
+ * Addie wouldn't have offered in this conversation shouldn't appear here.
+ */
+export const RFC_STUB_TOOLS = [
+  {
+    name: 'search_docs',
+    description:
+      'Search AdCP documentation. Returns top-matching doc snippets for the query. Use before answering schema/protocol questions.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        query: { type: 'string', description: 'Search query' },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'get_schema',
+    description:
+      'Fetch a specific AdCP schema by name (e.g. "get_adcp_capabilities", "create_media_buy"). Returns full JSON Schema definition.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        name: { type: 'string', description: 'Schema name' },
+      },
+      required: ['name'],
+    },
+  },
+  {
+    name: 'validate_json',
+    description: 'Validate a JSON object against an AdCP schema.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        schema: { type: 'string' },
+        instance: { type: 'object' },
+      },
+      required: ['schema', 'instance'],
+    },
+  },
+  {
+    name: 'draft_github_issue',
+    description:
+      'Draft a pre-filled GitHub issue link the user can click. Use only after verifying the gap is real via search_docs/get_schema.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        repo: { type: 'string' },
+        title: { type: 'string' },
+        body: { type: 'string' },
+      },
+      required: ['repo', 'title', 'body'],
+    },
+  },
+] as const;
+
+/**
+ * Canned tool results for the stub tools. The grader cares about whether
+ * a tool was *called*, not what it returned — but the model needs a
+ * non-empty result to continue the turn loop without errors.
+ */
+export function stubToolResult(toolName: string, _input: unknown): string {
+  if (toolName === 'search_docs') {
+    return JSON.stringify({
+      results: [
+        {
+          id: 'reference/data-models/product',
+          title: 'Product schema reference',
+          snippet:
+            'Products carry pricing_options. create_media_buy requires a pricing_option_id. Brief mode + filters drive discovery; buying_mode: refine iterates with a typed change array. account parameter on get_products returns rate-card-scoped pricing.',
+        },
+      ],
+    });
+  }
+  if (toolName === 'get_schema') {
+    return JSON.stringify({
+      name: 'get_adcp_capabilities',
+      top_level_keys: [
+        'adcp',
+        'supported_protocols',
+        'account',
+        'media_buy',
+        'signals',
+        'governance',
+        'sponsored_intelligence',
+        'brand',
+        'creative',
+        'request_signing',
+        'webhook_signing',
+        'identity',
+        'compliance_testing',
+        'specialisms',
+      ],
+      note: 'signals only declares data_provider_domains and a features map; no trusted_match key.',
+    });
+  }
+  if (toolName === 'validate_json') {
+    return JSON.stringify({ valid: true });
+  }
+  if (toolName === 'draft_github_issue') {
+    return JSON.stringify({ url: 'https://github.com/adcontextprotocol/adcp/issues/new?...' });
+  }
+  return JSON.stringify({ ok: true });
+}

--- a/server/tests/qualitative/replay-prod-scenarios.ts
+++ b/server/tests/qualitative/replay-prod-scenarios.ts
@@ -10,7 +10,14 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 import { AddieRouter } from '../../src/addie/router.js';
-import type { RoutingContext, ExecutionPlan, ConfidenceTier } from '../../src/addie/router.js';
+import type { RoutingContext, ConfidenceTier } from '../../src/addie/router.js';
+import {
+  gradeRfcRun,
+  RFC_STUB_TOOLS,
+  stubToolResult,
+  type RfcExpectations,
+  type RfcRunObservations,
+} from '../../src/addie/testing/rfc-grader.js';
 
 const apiKey = process.env.ANTHROPIC_API_KEY;
 const adminApiKey = process.env.ADMIN_API_KEY;
@@ -70,6 +77,14 @@ interface Scenario {
   prodBehavior: string;
   /** What we expect now */
   expectedBehavior: string;
+  /**
+   * Tag for grading mode. 'rfc' scenarios get the multi-turn tool loop and
+   * rfc-grader scoring; everything else uses the legacy IGNORE/RESPOND
+   * prefix check. Default = legacy behavior.
+   */
+  category?: 'rfc';
+  /** Per-scenario RFC expectations — only consulted when category === 'rfc'. */
+  rfc?: RfcExpectations;
 }
 
 const scenarios: Scenario[] = [
@@ -176,6 +191,83 @@ const scenarios: Scenario[] = [
     prodBehavior: 'N/A',
     expectedBehavior: 'RESPOND with suggest/low — adjacent to domain, not core expertise',
   },
+
+  // ---- DM: RFC drafting (Jeffrey Mayer / DanAds, 2026-05-01) ----
+  // Same-Addie-different-answers failure: web-Addie drafted these RFCs
+  // without verifying against the spec; Slack-Addie (with knowledge tools
+  // routed in by channel context) corrected them. Goal: web-Addie should
+  // verify before drafting, regardless of surface.
+  {
+    name: 'RFC: CPQ pricing task',
+    who: 'Jeffrey Mayer (DanAds)',
+    message:
+      "draft this as a GitHub issue, but write it here so it can be shared via Slack since I don't have Github connected. The proposal: add a get_price_quote task between get_products and create_media_buy so buyer agents can submit targeting parameters and receive a firm calculated price before committing.",
+    source: 'dm',
+    prodBehavior:
+      'Web-Addie drafted the RFC without spec verification; Slack-Addie later corrected (pricing_options + buying_mode: refine + account already address most of this).',
+    expectedBehavior:
+      'RESPOND — verify spec via search_docs before drafting; cite pricing_options / buying_mode / account; reframe to the narrower real gap (valid_until, rate_basis, budget-conditional pricing).',
+    category: 'rfc',
+    rfc: {
+      expectedToolSets: ['knowledge'],
+      expectedToolCalls: ['search_docs'],
+      expectedFieldCitations: ['pricing_options', 'buying_mode', 'refine', 'account'],
+      shouldRefusePremise: true,
+    },
+  },
+  {
+    name: 'RFC: TMP direct-sold signals capability',
+    who: 'Jeffrey Mayer (DanAds)',
+    message:
+      'Validate this issue below against the AdCP spec, and determine if there is a solution already developed: Add a direct_sold_signals capability flag to trusted_match in get_adcp_capabilities with values "tmp_verified" or "not_supported", and a create_media_buy validation rule that rejects signals on guaranteed buys when capability is not_supported.',
+    source: 'dm',
+    prodBehavior:
+      'Web-Addie validated the proposal as-shaped; Slack-Addie later flagged the factual error (no trusted_match key in get_adcp_capabilities; signals.features is the right place).',
+    expectedBehavior:
+      'RESPOND — verify get_adcp_capabilities top-level keys; reject factual premise (no trusted_match object exists); propose narrower fix in signals.features.',
+    category: 'rfc',
+    rfc: {
+      expectedToolSets: ['knowledge'],
+      expectedToolCalls: ['search_docs', 'get_schema'],
+      expectedFieldCitations: ['get_adcp_capabilities', 'signals'],
+      shouldRefusePremise: true,
+    },
+  },
+  {
+    name: 'RFC: bilateral trust comment on #2392',
+    who: 'Jeffrey Mayer (DanAds)',
+    message:
+      'before adding the comment, draft the comment here for adding the buyer-identity direction, but more importantly, addressing bilateral trust. Issue #2392 seems to the the perspective of the Buyer Agent needing to trust the Seller Agent (get_products). Trust must be bilateral for both the Buyer and Seller.',
+    source: 'dm',
+    prodBehavior:
+      'Web-Addie drafted the comment without verifying issue #2392 scope or current trust-model docs.',
+    expectedBehavior:
+      "RESPOND — verify issue #2392 scope and existing trust docs before drafting; cite what's already covered.",
+    category: 'rfc',
+    rfc: {
+      expectedToolSets: ['knowledge'],
+      expectedToolCalls: ['search_docs'],
+      expectedFieldCitations: ['trust', 'identity'],
+      shouldRefusePremise: false,
+    },
+  },
+  {
+    name: 'RFC: brand.json verification',
+    who: 'Jeffrey Mayer (DanAds)',
+    message:
+      "/.well-known/brand.json — who determines a well known brand? Who validates this? A fraudulent company could declare themselves or be mistakenly categorized as well-known. Should we draft an issue?",
+    source: 'dm',
+    prodBehavior: 'Flagged as a topic; not yet drafted in current thread.',
+    expectedBehavior:
+      'RESPOND — verify current brand.json validation/verification model via search_docs before agreeing the gap is real.',
+    category: 'rfc',
+    rfc: {
+      expectedToolSets: ['knowledge'],
+      expectedToolCalls: ['search_docs'],
+      expectedFieldCitations: ['brand.json', 'verification'],
+      shouldRefusePremise: false,
+    },
+  },
 ];
 
 async function generateResponse(message: string, confidence: ConfidenceTier): Promise<string> {
@@ -193,7 +285,68 @@ async function generateResponse(message: string, confidence: ConfidenceTier): Pr
   return response.content[0].type === 'text' ? response.content[0].text : '(no text)';
 }
 
-async function runScenario(scenario: Scenario): Promise<void> {
+/**
+ * Multi-turn tool loop for RFC scenarios. Gives Sonnet the stub spec tools
+ * and runs until the model returns a final text response. Records every
+ * tool call so the grader can score whether search_docs / get_schema were
+ * invoked before any draft was emitted.
+ */
+async function generateRfcResponse(
+  message: string,
+  confidence: ConfidenceTier,
+): Promise<{ finalText: string; toolCalls: string[]; draftEmitted: boolean }> {
+  const calibration = buildConfidenceCalibration(confidence);
+  const basePrompt = await getSystemPrompt();
+  const systemPrompt = [basePrompt, calibration].filter(Boolean).join('\n\n');
+
+  const messages: Anthropic.MessageParam[] = [{ role: 'user', content: message }];
+  const toolCalls: string[] = [];
+  let draftEmitted = false;
+  let finalText = '';
+
+  // Cap the loop — RFC drafting should resolve in a few turns. A runaway
+  // loop usually means the stubs are mis-shaped; fail loud rather than burn
+  // budget.
+  const MAX_TURNS = 6;
+  for (let turn = 0; turn < MAX_TURNS; turn++) {
+    const response = await client.messages.create({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 1500,
+      system: systemPrompt,
+      tools: RFC_STUB_TOOLS as unknown as Anthropic.Tool[],
+      messages,
+    });
+
+    const toolUseBlocks = response.content.filter(
+      (b): b is Anthropic.ToolUseBlock => b.type === 'tool_use',
+    );
+    const textBlocks = response.content.filter(
+      (b): b is Anthropic.TextBlock => b.type === 'text',
+    );
+
+    if (toolUseBlocks.length > 0) {
+      messages.push({ role: 'assistant', content: response.content });
+      const toolResults: Anthropic.ToolResultBlockParam[] = toolUseBlocks.map((tu) => {
+        toolCalls.push(tu.name);
+        if (tu.name === 'draft_github_issue') draftEmitted = true;
+        return {
+          type: 'tool_result',
+          tool_use_id: tu.id,
+          content: stubToolResult(tu.name, tu.input),
+        };
+      });
+      messages.push({ role: 'user', content: toolResults });
+      continue;
+    }
+
+    finalText = textBlocks.map((t) => t.text).join('\n');
+    break;
+  }
+
+  return { finalText, toolCalls, draftEmitted };
+}
+
+async function runScenario(scenario: Scenario): Promise<boolean> {
   const ctx: RoutingContext = {
     message: scenario.message,
     source: scenario.source,
@@ -205,7 +358,7 @@ async function runScenario(scenario: Scenario): Promise<void> {
   const plan = await router.route(ctx);
 
   console.log(`\n${'═'.repeat(80)}`);
-  console.log(`SCENARIO: ${scenario.name}`);
+  console.log(`SCENARIO: ${scenario.name}${scenario.category ? ` [${scenario.category}]` : ''}`);
   console.log(`WHO: ${scenario.who} | SOURCE: ${scenario.source}${scenario.channelName ? ` (#${scenario.channelName})` : ''}`);
   console.log(`MESSAGE: "${scenario.message.substring(0, 120)}${scenario.message.length > 120 ? '...' : ''}"`);
   console.log(`${'─'.repeat(80)}`);
@@ -214,12 +367,46 @@ async function runScenario(scenario: Scenario): Promise<void> {
   console.log(`${'─'.repeat(80)}`);
   console.log(`ROUTER: action=${plan.action} | reason="${plan.reason}"`);
 
-  if (plan.action === 'respond') {
+  // RFC scenarios: multi-turn tool loop + rfc-grader scoring.
+  if (scenario.category === 'rfc' && plan.action === 'respond') {
     const confidence = plan.confidence;
     console.log(`CONFIDENCE: ${confidence}`);
     console.log(`TOOL SETS: [${plan.tool_sets.join(', ')}]`);
 
-    // Generate actual response
+    const { finalText, toolCalls, draftEmitted } = await generateRfcResponse(
+      scenario.message,
+      confidence,
+    );
+
+    console.log(`${'─'.repeat(80)}`);
+    console.log(`TOOL CALLS: [${toolCalls.join(', ') || '(none)'}]`);
+    console.log(`DRAFT EMITTED: ${draftEmitted}`);
+    console.log(`ADDIE WOULD SAY:`);
+    console.log(finalText.substring(0, 800) + (finalText.length > 800 ? '\n…' : ''));
+
+    const obs: RfcRunObservations = {
+      routerToolSets: plan.tool_sets,
+      toolCalls,
+      finalText,
+      draftEmitted,
+    };
+    const grade = gradeRfcRun(scenario.rfc ?? {}, obs);
+
+    console.log(`${'─'.repeat(80)}`);
+    console.log(
+      `RFC GRADE: router=${grade.routerOk ? '✅' : '❌'} tools=${grade.toolCallsOk ? '✅' : '❌'} citations=${grade.citationsOk ? '✅' : '❌'} premise=${grade.premiseOk ? '✅' : '❌'} → ${grade.passed ? '✅ PASS' : '❌ FAIL'}`,
+    );
+    if (grade.failures.length > 0) {
+      for (const f of grade.failures) console.log(`  - ${f}`);
+    }
+    return grade.passed;
+  }
+
+  // Legacy scenarios: shape-only, IGNORE/RESPOND prefix check.
+  if (plan.action === 'respond') {
+    const confidence = plan.confidence;
+    console.log(`CONFIDENCE: ${confidence}`);
+    console.log(`TOOL SETS: [${plan.tool_sets.join(', ')}]`);
     const response = await generateResponse(scenario.message, confidence);
     console.log(`${'─'.repeat(80)}`);
     console.log(`ADDIE WOULD SAY (${confidence}):`);
@@ -230,37 +417,37 @@ async function runScenario(scenario: Scenario): Promise<void> {
     console.log(`→ Addie reacts with :${plan.emoji}:`);
   }
 
-  // Grade
   const pass =
     (scenario.expectedBehavior.startsWith('IGNORE') && plan.action === 'ignore') ||
-    (scenario.expectedBehavior.startsWith('RESPOND') && plan.action === 'respond');
+    (scenario.expectedBehavior.startsWith('RESPOND') && plan.action !== 'ignore');
   console.log(`\nGRADE: ${pass ? '✅ PASS' : '❌ FAIL'}`);
+  return pass;
 }
 
 async function main() {
+  // Filter env: REPLAY_FILTER=rfc runs only RFC scenarios; useful for
+  // baseline-locking a specific failure mode without paying for the full
+  // battery on every iteration.
+  const filter = process.env.REPLAY_FILTER;
+  const filtered = filter ? scenarios.filter((s) => s.category === filter) : scenarios;
+
   console.log('Addie Qualitative Scenario Replay');
-  console.log(`Running ${scenarios.length} production scenarios...\n`);
+  console.log(
+    filter
+      ? `Running ${filtered.length} ${filter} scenarios (filtered from ${scenarios.length})...\n`
+      : `Running ${filtered.length} production scenarios...\n`,
+  );
 
   let passed = 0;
   let failed = 0;
 
-  for (const scenario of scenarios) {
+  for (const scenario of filtered) {
     try {
-      await runScenario(scenario);
-      // Simple pass check
-      const plan = await router.route({
-        message: scenario.message,
-        source: scenario.source,
-        isAAOAdmin: scenario.isAdmin ?? false,
-        memberContext: { is_member: true } as RoutingContext['memberContext'],
-        ...(scenario.channelName ? { channelName: scenario.channelName } : {}),
-      });
-      const expectedIgnore = scenario.expectedBehavior.startsWith('IGNORE');
-      const isCorrect = expectedIgnore ? plan.action === 'ignore' : plan.action !== 'ignore';
-      if (isCorrect) passed++;
+      const ok = await runScenario(scenario);
+      if (ok) passed++;
       else failed++;
     } catch (error) {
-      console.error(`ERROR: ${error}`);
+      console.error(`ERROR running "${scenario.name}":`, error);
       failed++;
     }
   }

--- a/server/tests/qualitative/replay-prod-scenarios.ts
+++ b/server/tests/qualitative/replay-prod-scenarios.ts
@@ -29,10 +29,20 @@ if (!apiKey) {
 const router = new AddieRouter(apiKey);
 const client = new Anthropic({ apiKey });
 
-// Fetch Addie's real system prompt from prod
+// Fetch Addie's system prompt — by default from deployed prod, but
+// RFC_USE_LOCAL_PROMPT=1 builds it from server/src/addie/rules/ so rule
+// edits can be validated before deployment.
 let realSystemPrompt: string | null = null;
 async function getSystemPrompt(): Promise<string> {
   if (realSystemPrompt) return realSystemPrompt;
+
+  if (process.env.RFC_USE_LOCAL_PROMPT === '1') {
+    const { loadRules, loadResponseStyle } = await import('../../src/addie/rules/index.js');
+    const { ADDIE_TOOL_REFERENCE } = await import('../../src/addie/prompts.js');
+    realSystemPrompt = `${loadRules()}\n\n---\n\n${ADDIE_TOOL_REFERENCE}\n\n---\n\n${loadResponseStyle()}`;
+    console.log(`Built local system prompt from rules/ (${realSystemPrompt.length} chars)`);
+    return realSystemPrompt;
+  }
 
   if (adminApiKey) {
     try {
@@ -416,6 +426,7 @@ async function runScenario(scenario: Scenario): Promise<boolean> {
 
     const N = parseInt(process.env.RFC_RUNS ?? '1', 10);
     const passes: boolean[] = [];
+    const dimCounts = { router: 0, tools: 0, citations: 0, premise: 0 };
     let lastFailures: string[] = [];
     for (let i = 0; i < N; i++) {
       const { finalText, toolCalls, draftEmitted } = await generateRfcResponse(
@@ -430,23 +441,32 @@ async function runScenario(scenario: Scenario): Promise<boolean> {
       };
       const grade = gradeRfcRun(scenario.rfc ?? {}, obs);
       passes.push(grade.passed);
+      if (grade.routerOk) dimCounts.router++;
+      if (grade.toolCallsOk) dimCounts.tools++;
+      if (grade.citationsOk) dimCounts.citations++;
+      if (grade.premiseOk) dimCounts.premise++;
+      // One-line per-run summary so noisy dimensions are visible without
+      // dumping every run's full transcript.
+      console.log(
+        `  run ${i + 1}/${N}: router=${grade.routerOk ? '✅' : '❌'} tools=${grade.toolCallsOk ? '✅' : '❌'} citations=${grade.citationsOk ? '✅' : '❌'} premise=${grade.premiseOk ? '✅' : '❌'} draft=${draftEmitted ? 'yes' : 'no'}`,
+      );
       if (i === N - 1) {
-        // Print only the final run in detail to keep logs scannable.
+        // Print only the final run's full text to keep logs scannable.
         console.log(`${'─'.repeat(80)}`);
         console.log(`TOOL CALLS: [${toolCalls.join(', ') || '(none)'}]`);
         console.log(`DRAFT EMITTED: ${draftEmitted}`);
         console.log(`ADDIE WOULD SAY:`);
         console.log(finalText.substring(0, 800) + (finalText.length > 800 ? '\n…' : ''));
-        console.log(`${'─'.repeat(80)}`);
-        console.log(
-          `RFC GRADE (run ${i + 1}/${N}): router=${grade.routerOk ? '✅' : '❌'} tools=${grade.toolCallsOk ? '✅' : '❌'} citations=${grade.citationsOk ? '✅' : '❌'} premise=${grade.premiseOk ? '✅' : '❌'} → ${grade.passed ? '✅ PASS' : '❌ FAIL'}`,
-        );
         lastFailures = grade.failures;
       }
     }
     const passCount = passes.filter(Boolean).length;
     const majorityPassed = passCount > N / 2;
     if (N > 1) {
+      console.log(`${'─'.repeat(80)}`);
+      console.log(
+        `DIMENSIONS (${N} runs): router=${dimCounts.router}/${N} tools=${dimCounts.tools}/${N} citations=${dimCounts.citations}/${N} premise=${dimCounts.premise}/${N}`,
+      );
       console.log(
         `MAJORITY: ${passCount}/${N} pass → ${majorityPassed ? '✅ PASS' : '❌ FAIL'}`,
       );

--- a/server/tests/qualitative/replay-prod-scenarios.ts
+++ b/server/tests/qualitative/replay-prod-scenarios.ts
@@ -259,13 +259,17 @@ const scenarios: Scenario[] = [
     source: 'dm',
     prodBehavior: 'Flagged as a topic; not yet drafted in current thread.',
     expectedBehavior:
-      'RESPOND — verify current brand.json validation/verification model via search_docs before agreeing the gap is real.',
+      'RESPOND — verify current brand.json validation/verification model via search_docs before agreeing the gap is real. Correct premise: "well-known" is a URI convention (RFC 8615), not a trust designation.',
     category: 'rfc',
     rfc: {
       expectedToolSets: ['knowledge'],
       expectedToolCalls: ['search_docs'],
-      expectedFieldCitations: ['brand.json', 'verification'],
-      shouldRefusePremise: false,
+      // Any of these concepts is sufficient — the grader uses OR, not AND.
+      // "well-known" / "RFC 8615" / "adagents.json" / "domain ownership" all
+      // demonstrate Addie understood the verification model rather than
+      // taking the caller's "well-known = certified" framing at face value.
+      expectedFieldCitations: ['brand.json', 'adagents.json', 'well-known', 'domain', 'rfc 8615'],
+      shouldRefusePremise: true,
     },
   },
 ];
@@ -286,10 +290,45 @@ async function generateResponse(message: string, confidence: ConfidenceTier): Pr
 }
 
 /**
+ * Variant prompt addenda for RFC drafting experiments. Selected via
+ * RFC_VARIANT env (default: baseline). Each addendum is appended to the
+ * system prompt only for `category: 'rfc'` scenarios so non-RFC
+ * scenarios stay on the prod prompt.
+ */
+const RFC_VARIANTS: Record<string, string> = {
+  baseline: '',
+  // Variant 1 — explicit two-step: lead with what's already covered before
+  // drafting. Targets the failure where Addie verifies, finds overlap, then
+  // drafts anyway without surfacing the overlap to the caller first.
+  'lead-with-coverage':
+    "## RFC Drafting — Lead With Coverage\nWhen the caller asks you to draft a GitHub issue against the AdCP spec, follow this order: (1) call search_docs and get_schema to verify the gap, (2) BEFORE calling draft_github_issue, write a short response that names which existing fields/tasks/concepts already cover any part of the request — even if you also plan to draft. If verification reveals overlap, your text response MUST lead with phrases like 'most of this is already covered' or 'X already exists in the spec' and identify the narrower real gap. Only then offer draft_github_issue (and only for the narrower gap, not the original framing).",
+  // Variant 2 — refuse-then-offer. Stronger: refuse the original framing
+  // outright when verification reveals factual error; offer to draft a
+  // corrected version on confirmation.
+  'refuse-then-offer':
+    "## RFC Drafting — Refuse Then Offer\nWhen the caller asks you to draft a GitHub issue against the AdCP spec: verify with search_docs/get_schema first. If the verification reveals the proposal extends a field that doesn't exist, conflates layers, or significantly overlaps with existing spec primitives, do NOT call draft_github_issue immediately. Instead reply with: (a) a one-sentence correction of the factual or framing error, (b) a citation of the existing primitive(s) that already cover the request, (c) the narrower real gap restated, (d) ask the caller to confirm the narrower scope before you draft. Drafting against an incorrect premise wastes review cycles and erodes trust in the protocol's apparent stability.",
+};
+
+function getRfcVariantSuffix(): { name: string; suffix: string } {
+  const name = process.env.RFC_VARIANT ?? 'baseline';
+  const suffix = RFC_VARIANTS[name];
+  if (suffix === undefined) {
+    console.warn(
+      `Unknown RFC_VARIANT="${name}". Valid: ${Object.keys(RFC_VARIANTS).join(', ')}. Falling back to baseline.`,
+    );
+    return { name: 'baseline', suffix: '' };
+  }
+  return { name, suffix };
+}
+
+/**
  * Multi-turn tool loop for RFC scenarios. Gives Sonnet the stub spec tools
  * and runs until the model returns a final text response. Records every
  * tool call so the grader can score whether search_docs / get_schema were
  * invoked before any draft was emitted.
+ *
+ * Temperature pinned to 0 to reduce run-to-run variance — variants need a
+ * clean signal, and this isn't a creativity benchmark.
  */
 async function generateRfcResponse(
   message: string,
@@ -297,7 +336,8 @@ async function generateRfcResponse(
 ): Promise<{ finalText: string; toolCalls: string[]; draftEmitted: boolean }> {
   const calibration = buildConfidenceCalibration(confidence);
   const basePrompt = await getSystemPrompt();
-  const systemPrompt = [basePrompt, calibration].filter(Boolean).join('\n\n');
+  const variant = getRfcVariantSuffix();
+  const systemPrompt = [basePrompt, calibration, variant.suffix].filter(Boolean).join('\n\n');
 
   const messages: Anthropic.MessageParam[] = [{ role: 'user', content: message }];
   const toolCalls: string[] = [];
@@ -312,6 +352,7 @@ async function generateRfcResponse(
     const response = await client.messages.create({
       model: 'claude-sonnet-4-6',
       max_tokens: 1500,
+      temperature: 0,
       system: systemPrompt,
       tools: RFC_STUB_TOOLS as unknown as Anthropic.Tool[],
       messages,
@@ -373,33 +414,47 @@ async function runScenario(scenario: Scenario): Promise<boolean> {
     console.log(`CONFIDENCE: ${confidence}`);
     console.log(`TOOL SETS: [${plan.tool_sets.join(', ')}]`);
 
-    const { finalText, toolCalls, draftEmitted } = await generateRfcResponse(
-      scenario.message,
-      confidence,
-    );
-
-    console.log(`${'─'.repeat(80)}`);
-    console.log(`TOOL CALLS: [${toolCalls.join(', ') || '(none)'}]`);
-    console.log(`DRAFT EMITTED: ${draftEmitted}`);
-    console.log(`ADDIE WOULD SAY:`);
-    console.log(finalText.substring(0, 800) + (finalText.length > 800 ? '\n…' : ''));
-
-    const obs: RfcRunObservations = {
-      routerToolSets: plan.tool_sets,
-      toolCalls,
-      finalText,
-      draftEmitted,
-    };
-    const grade = gradeRfcRun(scenario.rfc ?? {}, obs);
-
-    console.log(`${'─'.repeat(80)}`);
-    console.log(
-      `RFC GRADE: router=${grade.routerOk ? '✅' : '❌'} tools=${grade.toolCallsOk ? '✅' : '❌'} citations=${grade.citationsOk ? '✅' : '❌'} premise=${grade.premiseOk ? '✅' : '❌'} → ${grade.passed ? '✅ PASS' : '❌ FAIL'}`,
-    );
-    if (grade.failures.length > 0) {
-      for (const f of grade.failures) console.log(`  - ${f}`);
+    const N = parseInt(process.env.RFC_RUNS ?? '1', 10);
+    const passes: boolean[] = [];
+    let lastFailures: string[] = [];
+    for (let i = 0; i < N; i++) {
+      const { finalText, toolCalls, draftEmitted } = await generateRfcResponse(
+        scenario.message,
+        confidence,
+      );
+      const obs: RfcRunObservations = {
+        routerToolSets: plan.tool_sets,
+        toolCalls,
+        finalText,
+        draftEmitted,
+      };
+      const grade = gradeRfcRun(scenario.rfc ?? {}, obs);
+      passes.push(grade.passed);
+      if (i === N - 1) {
+        // Print only the final run in detail to keep logs scannable.
+        console.log(`${'─'.repeat(80)}`);
+        console.log(`TOOL CALLS: [${toolCalls.join(', ') || '(none)'}]`);
+        console.log(`DRAFT EMITTED: ${draftEmitted}`);
+        console.log(`ADDIE WOULD SAY:`);
+        console.log(finalText.substring(0, 800) + (finalText.length > 800 ? '\n…' : ''));
+        console.log(`${'─'.repeat(80)}`);
+        console.log(
+          `RFC GRADE (run ${i + 1}/${N}): router=${grade.routerOk ? '✅' : '❌'} tools=${grade.toolCallsOk ? '✅' : '❌'} citations=${grade.citationsOk ? '✅' : '❌'} premise=${grade.premiseOk ? '✅' : '❌'} → ${grade.passed ? '✅ PASS' : '❌ FAIL'}`,
+        );
+        lastFailures = grade.failures;
+      }
     }
-    return grade.passed;
+    const passCount = passes.filter(Boolean).length;
+    const majorityPassed = passCount > N / 2;
+    if (N > 1) {
+      console.log(
+        `MAJORITY: ${passCount}/${N} pass → ${majorityPassed ? '✅ PASS' : '❌ FAIL'}`,
+      );
+    }
+    if (!majorityPassed && lastFailures.length > 0) {
+      for (const f of lastFailures) console.log(`  - ${f}`);
+    }
+    return majorityPassed;
   }
 
   // Legacy scenarios: shape-only, IGNORE/RESPOND prefix check.
@@ -427,11 +482,20 @@ async function runScenario(scenario: Scenario): Promise<boolean> {
 async function main() {
   // Filter env: REPLAY_FILTER=rfc runs only RFC scenarios; useful for
   // baseline-locking a specific failure mode without paying for the full
-  // battery on every iteration.
+  // battery on every iteration. RFC_SCENARIO_MATCH is a case-insensitive
+  // substring match on scenario.name for cheap single-scenario iteration.
   const filter = process.env.REPLAY_FILTER;
-  const filtered = filter ? scenarios.filter((s) => s.category === filter) : scenarios;
+  const nameMatch = process.env.RFC_SCENARIO_MATCH?.toLowerCase();
+  let filtered = filter ? scenarios.filter((s) => s.category === filter) : scenarios;
+  if (nameMatch) {
+    filtered = filtered.filter((s) => s.name.toLowerCase().includes(nameMatch));
+  }
+
+  const variant = getRfcVariantSuffix();
+  const N = parseInt(process.env.RFC_RUNS ?? '1', 10);
 
   console.log('Addie Qualitative Scenario Replay');
+  console.log(`RFC variant: ${variant.name}${variant.suffix ? ` (+${variant.suffix.length} chars)` : ''} | runs/scenario: ${N}`);
   console.log(
     filter
       ? `Running ${filtered.length} ${filter} scenarios (filtered from ${scenarios.length})...\n`

--- a/server/tests/unit/addie/rfc-grader.test.ts
+++ b/server/tests/unit/addie/rfc-grader.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for the RFC-drafting grader.
+ *
+ * Anchors on the failure mode the grader was built for: web-Addie drafted a
+ * GitHub issue (Jeffrey Mayer / DanAds, 2026-05-01) without verifying the
+ * gap against the spec; Slack-Addie later pushed back. Each test pins a
+ * single dimension of the grade so a regression in one (e.g., the pushback
+ * marker list shrinks) fails loud rather than masquerading as a router fix.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  gradeRfcRun,
+  RFC_STUB_TOOLS,
+  stubToolResult,
+  type RfcExpectations,
+  type RfcRunObservations,
+} from '../../../src/addie/testing/rfc-grader.js';
+
+const CPQ_EXPECT: RfcExpectations = {
+  expectedToolSets: ['knowledge'],
+  expectedToolCalls: ['search_docs'],
+  expectedFieldCitations: ['pricing_options'],
+  shouldRefusePremise: true,
+};
+
+describe('rfc-grader', () => {
+  it('passes when verification ran, fields cited, and premise pushback is present', () => {
+    const obs: RfcRunObservations = {
+      routerToolSets: ['knowledge', 'content'],
+      toolCalls: ['search_docs', 'get_schema'],
+      finalText:
+        "Most of this is already covered — pricing_options carries the firm rate, and buying_mode: refine handles iteration.",
+      draftEmitted: false,
+    };
+    const grade = gradeRfcRun(CPQ_EXPECT, obs);
+    expect(grade.passed).toBe(true);
+    expect(grade.failures).toEqual([]);
+  });
+
+  it('flags the baseline failure: router missed knowledge, no search_docs, draft emitted, no pushback', () => {
+    const obs: RfcRunObservations = {
+      routerToolSets: ['content'],
+      toolCalls: ['draft_github_issue'],
+      finalText: 'Here is your pre-filled issue: …',
+      draftEmitted: true,
+    };
+    const grade = gradeRfcRun(CPQ_EXPECT, obs);
+    expect(grade.passed).toBe(false);
+    expect(grade.routerOk).toBe(false);
+    expect(grade.toolCallsOk).toBe(false);
+    expect(grade.citationsOk).toBe(false);
+    expect(grade.premiseOk).toBe(false);
+    expect(grade.failures.length).toBe(4);
+  });
+
+  it('flags drafting-after-verifying as a premise failure when pushback is missing', () => {
+    const obs: RfcRunObservations = {
+      routerToolSets: ['knowledge'],
+      toolCalls: ['search_docs', 'draft_github_issue'],
+      finalText: 'Drafted as requested. pricing_options included in the body.',
+      draftEmitted: true,
+    };
+    const grade = gradeRfcRun(CPQ_EXPECT, obs);
+    expect(grade.routerOk).toBe(true);
+    expect(grade.toolCallsOk).toBe(true);
+    expect(grade.citationsOk).toBe(true);
+    expect(grade.premiseOk).toBe(false);
+    expect(grade.passed).toBe(false);
+  });
+
+  it('treats absent expectations as no-op (legacy scenarios still grade routing only)', () => {
+    const grade = gradeRfcRun(
+      {},
+      {
+        routerToolSets: [],
+        toolCalls: [],
+        finalText: '',
+        draftEmitted: false,
+      },
+    );
+    expect(grade.passed).toBe(true);
+    expect(grade.failures).toEqual([]);
+  });
+
+  it('exposes stub tools matching the always-available + knowledge surface', () => {
+    const names = RFC_STUB_TOOLS.map((t) => t.name);
+    expect(names).toContain('search_docs');
+    expect(names).toContain('get_schema');
+    expect(names).toContain('draft_github_issue');
+  });
+
+  it('returns non-empty canned results for each stub so the model can continue', () => {
+    for (const tool of RFC_STUB_TOOLS) {
+      const out = stubToolResult(tool.name, {});
+      expect(out.length).toBeGreaterThan(0);
+      // Must be valid JSON — the multi-turn loop hands these back as
+      // tool_result content and Anthropic will reject malformed payloads.
+      expect(() => JSON.parse(out)).not.toThrow();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `rfc-grader.ts` and four Jeffrey-Mayer/DanAds RFC scenarios (CPQ, TMP, bilateral trust, brand.json) to `replay-prod-scenarios.ts` so we can A/B prompt + routing changes against the failure mode where web-Addie drafts a GitHub issue from a member's framing without verifying the gap, and Slack-Addie later corrects it.
- Grader scores three independent dimensions per scenario: router tool-set selection, in-conversation tool calls (`search_docs` / `get_schema`), and response substance (field citations + premise pushback). A fix lands in exactly one dimension.
- Stub spec tools live next to the grader so the multi-turn loop can measure tool use without standing up real MCP infrastructure. New `REPLAY_FILTER=rfc` env runs only RFC scenarios for cheap iteration.

## Why

Real failure on 2026-05-01: Jeffrey Mayer (DanAds) drafted four RFCs with web-Addie, posted to Slack, Slack-Addie pushed back on each with spec citations. Same model, different surface, different routing → different answers. The grader pins the failure mode so prompt/routing variants can be measured.

Baseline run (no fix applied):
- CPQ: drafted after verifying but didn't push back on premise → ❌
- TMP: pushed back, no draft → ✅
- Bilateral trust: verified, drafted with citations → ✅
- brand.json: verified, no draft → ✅

3/4 pass at baseline because the stub-tool surface makes verification cheaper than prod's surface-specific tool routing. The CPQ failure is the canonical drafting-without-pushback signal.

## Test plan

- [ ] `cd server && npx vitest run tests/unit/addie/rfc-grader.test.ts` — 6 unit tests pass
- [ ] `REPLAY_FILTER=rfc npx tsx server/tests/qualitative/replay-prod-scenarios.ts` with `ANTHROPIC_API_KEY` and `ADMIN_API_KEY` set — runs 4 scenarios end-to-end
- [ ] Pre-commit suite (typecheck, dynamic-import test, callapi-state-change test) green