### PR TITLE
fix(registry): label measurement and governance type filters

### DIFF
--- a/.changeset/fix-registry-type-filter-labels.md
+++ b/.changeset/fix-registry-type-filter-labels.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix registry page Type filter labels: Measurement and Governance buttons were both rendering as "Unclassified" because `typeLabel()` in `server/public/agents.html` was missing cases for those agent types and falling through to the default. Add explicit mappings so each button shows its correct label.

--- a/server/public/agents.html
+++ b/server/public/agents.html
@@ -610,6 +610,8 @@
         if (type === 'buying') return 'Buying';
         if (type === 'creative') return 'Creative';
         if (type === 'signals') return 'Signals';
+        if (type === 'measurement') return 'Measurement';
+        if (type === 'governance') return 'Governance';
         return 'Unclassified';
     }
 


### PR DESCRIPTION
## Summary

The Type filter row on the registry page (`/registry/`) was rendering "Unclassified (0)" twice. The cause: `typeLabel()` in `server/public/agents.html` only mapped `sales`, `buying`, `creative`, `signals` and fell through to `'Unclassified'` for everything else. Two buttons defined in the markup — `data-type="measurement"` and `data-type="governance"` — were getting overwritten with the fallback label on every render.

- Added explicit `measurement → 'Measurement'` and `governance → 'Governance'` cases to `typeLabel()` so each button shows its real name.
- No protocol/schema impact; empty changeset added per repo convention.

Fixing:
<img width="1250" height="510" alt="image" src="https://github.com/user-attachments/assets/2628c0c4-d4ce-4d71-9d1d-91bfa04bfe40" />
