### PR TITLE
ci(release): forward-merge package.json --ours, not --theirs (3.0.x backport)

### DIFF
--- a/.agents/playbook.md
+++ b/.agents/playbook.md
@@ -252,7 +252,7 @@ Default flow when a fix is needed in both lines:
    git cherry-pick <main-sha>
    git push origin 3.0.x
    ```
-3. The forward-merge workflow (`.github/workflows/forward-merge-3.0.yml`) opens a PR back to `main` whenever `3.0.x` updates. Merging it is a near-no-op (the cherry-pick is already in `main`) but keeps the lines provably in sync. The workflow auto-resolves conflicts on always-divergent paths (`package.json` / `package-lock.json` → take 3.0.x's; `.changeset/*.md` → preserve main's; `dist/*`, `CHANGELOG.md`, `static/schemas/source/index.json` → take 3.0.x's) and post-merge skips the PR if the result has no tree change vs `main` (which happens after a squash-merge of an earlier forward-merge). Conflicts on any path outside that allowlist fail the workflow loud and need manual resolution — they indicate a playbook violation (a change on 3.0.x that wasn't first cherry-picked from main).
+3. The forward-merge workflow (`.github/workflows/forward-merge-3.0.yml`) opens a PR back to `main` whenever `3.0.x` updates. Merging it is a near-no-op (the cherry-pick is already in `main`) but keeps the lines provably in sync. The workflow auto-resolves conflicts on always-divergent paths (`package.json` / `package-lock.json` → preserve main's; `.changeset/*.md` → preserve main's; `dist/*`, `CHANGELOG.md`, `static/schemas/source/index.json` → take 3.0.x's) and post-merge skips the PR if the result has no tree change vs `main` (which happens after a squash-merge of an earlier forward-merge). Conflicts on any path outside that allowlist fail the workflow loud and need manual resolution — they indicate a playbook violation (a change on 3.0.x that wasn't first cherry-picked from main).
 
 #### Patch eligibility
 

--- a/.changeset/forward-merge-package-json-ours.md
+++ b/.changeset/forward-merge-package-json-ours.md
@@ -1,0 +1,15 @@
+---
+---
+
+`forward-merge-3.0.yml` auto-resolution rule for `package.json` and `package-lock.json` changes from `--theirs` to `--ours` (preserve main's state).
+
+The original `--theirs` rule worked when main and 3.0.x diverged only on the version field. But main may have structural changes that 3.0.x doesn't — concrete case: main's `@adcp/client@5.21.1` was renamed to `@adcp/sdk@5.25.1` while 3.0.x kept the old name. Wholesale `--theirs` stripped main's package rename, leaving `package.json` and `package-lock.json` out of sync, which broke `npm ci` on the auto-PR.
+
+`--ours` is safer because:
+- Main's pre-mode tracking is independent of 3.0.x's version field. The next pre-mode cut produces `3.1.0-beta.X` from accumulated changesets regardless of starting version.
+- The release artifacts (`dist/{schemas,compliance,protocol}/X.Y.Z/`) DO flow forward via the `dist/*` allowlist entry, so consumers fetching pinned versions still get them.
+- Main's structural changes (package renames, new deps, new test scripts) are preserved.
+
+Trade-off: main's `package.json` version doesn't reflect 3.0.x's latest release. Acceptable — the version field on main isn't authoritative while pre-mode is active.
+
+Companion playbook update so the documented rule matches the new behavior.

--- a/.github/workflows/forward-merge-3.0.yml
+++ b/.github/workflows/forward-merge-3.0.yml
@@ -116,16 +116,26 @@ jobs:
                       ;;
                   esac
                   ;;
-                # package.json: take 3.0.x's wholesale. The version field
-                # is the structural conflict (3.0.x is one patch ahead of
-                # main after each release); other fields SHOULD be in sync
-                # if the playbook is followed (changes land on main first,
-                # cherry-picked to 3.0.x). If main has unique additions
-                # that 3.0.x doesn't, those came from a missing cherry-pick
-                # — the PR review surfaces the loss in the diff and the
-                # follow-up is a re-add commit on main.
+                # package.json / package-lock.json: keep main's (--ours).
+                # The original rule was --theirs (propagate 3.0.x's version
+                # bump) but that loses main's structural changes. Concrete
+                # case: main's `@adcp/client` was renamed to `@adcp/sdk`
+                # while 3.0.x kept the old name. --theirs stripped the
+                # rename + lock file, breaking `npm ci` on the auto-PR.
+                # --ours is safer because:
+                #   - Main's pre-mode tracking is independent of 3.0.x's
+                #     version. Next pre-mode cut produces 3.1.0-beta.X from
+                #     accumulated changesets regardless of base version.
+                #   - The release artifacts (dist/{schemas,compliance,
+                #     protocol}/X.Y.Z/) DO flow forward via the dist/* rule,
+                #     so consumers fetching pinned versions get them.
+                #   - Main's structural changes (package renames, new deps,
+                #     new test scripts) are preserved.
+                # Trade-off: main's package.json version doesn't reflect
+                # 3.0.x's latest release. Acceptable; the version state is
+                # never authoritative on main while pre-mode is active.
                 package.json|package-lock.json)
-                  git checkout --theirs -- "$f"
+                  git checkout --ours -- "$f"
                   git add -- "$f"
                   ;;
                 # Schema source index files carry version metadata that gets
@@ -225,8 +235,10 @@ jobs:
             Conflicts on these always-divergent paths are resolved
             automatically (see workflow source for rationale):
 
-            - `package.json` / `package-lock.json` → take 3.0.x's (version
-              propagates; main's pre-mode tracking is independent)
+            - `package.json` / `package-lock.json` → preserve main's
+              (main's pre-mode tracking is independent of 3.0.x's version,
+              and main may carry structural changes — package renames,
+              new deps — that 3.0.x doesn't)
             - `.changeset/*.md` / `.changeset/pre.json` → preserve main's
               state (main consumes changesets on its own beta schedule)
             - `static/schemas/source/index.json`,
@@ -246,9 +258,10 @@ jobs:
             - [ ] No 3.1-line work has been pulled in by accident (would
                   indicate the merge picked up something unintended)
             - [ ] If the merge commit message says "(auto-resolved
-                  divergent metadata)", spot-check `package.json` for any
-                  main-unique scripts/deps that may have been overwritten
-                  (a missed cherry-pick to 3.0.x — re-add as a follow-up)
+                  divergent metadata)", confirm `package.json` /
+                  `package-lock.json` reflect main's state (the workflow
+                  preserves --ours; 3.0.x's version bump intentionally
+                  doesn't propagate)
             - [ ] CI green
 
             ## Source


### PR DESCRIPTION
Cherry-pick of #3807 (`7bd8588f00`) to 3.0.x. The workflow file lives on the ref that triggers the workflow run; pushing to 3.0.x reads the YAML from 3.0.x's HEAD, so this needs to land here too for the rule fix to actually apply on 3.0.x → main forward-merges.

Same change set as #3807, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)