### PR TITLE
ci(release): bridge cherry-pick divergence in forward-merge workflow

### DIFF
--- a/.changeset/forward-merge-cherry-pick-divergence-bridge.md
+++ b/.changeset/forward-merge-cherry-pick-divergence-bridge.md
@@ -1,0 +1,13 @@
+---
+---
+
+`forward-merge-3.0.yml` adds a temporary `--ours` allowlist for two files where 3.0.x has a hand-adapted prose-only backport of #3739 and main has the full enum split:
+
+- `docs/building/implementation/error-handling.mdx`
+- `static/schemas/source/enums/error-code.json`
+
+Without this rule, every routine forward-merge from 3.0.x → main rediscovers the divergence and fails loud — squash-merges of prior forward-merges (the only merge style this repo allows) don't advance git's merge-base, so the conflict surfaces every time.
+
+Marked as temporary in the workflow comments; remove when 3.1.0 cuts and main no longer has the in-flight enum split. See adcontextprotocol/adcp#3784 / #3789 for cherry-pick context.
+
+Companion update to the auto-PR body so reviewers see the bridge entry exists.

--- a/.github/workflows/forward-merge-3.0.yml
+++ b/.github/workflows/forward-merge-3.0.yml
@@ -166,6 +166,29 @@ jobs:
                   git checkout --theirs -- "$f"
                   git add -- "$f"
                   ;;
+                # Known cherry-pick divergence: 3.0.x has #3789's prose-only
+                # backport of #3739 (AUTH_REQUIRED tightening); main has the
+                # full enum split (adds AUTH_MISSING / AUTH_INVALID codes
+                # that can't ship to 3.0.x without breaking the patch
+                # contract). Main's version is the more advanced state and
+                # main's content should win on every forward-merge until
+                # 3.1.0 cuts and replaces both.
+                #
+                # Without this rule, every forward-merge from 3.0.x → main
+                # rediscovers the divergence — squash-merges of prior
+                # forward-merges don't advance the merge-base, so git keeps
+                # seeing 3.0.x's version vs main's version and conflicting.
+                # This rule short-circuits the conflict permanently.
+                #
+                # When 3.1.0 ships and main no longer has the in-flight
+                # enum split (the work has been released), remove this
+                # block. It's a temporary bridge across a known content
+                # divergence, not a permanent allowlist entry.
+                # See adcontextprotocol/adcp#3784 / #3789 for context.
+                docs/building/implementation/error-handling.mdx|static/schemas/source/enums/error-code.json)
+                  git checkout --ours -- "$f"
+                  git add -- "$f"
+                  ;;
                 *)
                   UNEXPECTED="$UNEXPECTED $f"
                   ;;
@@ -247,6 +270,11 @@ jobs:
             - `CHANGELOG.md` → take 3.0.x's (main's next Version Packages
               cut prepends its own beta entries above)
             - `dist/*` → take 3.0.x's (versioned release artifacts)
+            - `docs/building/implementation/error-handling.mdx`,
+              `static/schemas/source/enums/error-code.json` → preserve
+              main's. Temporary bridge across a known cherry-pick
+              divergence (#3789's prose-only backport of #3739); remove
+              when 3.1.0 cuts.
 
             Any conflict outside this list fails the workflow loud — needs
             manual resolution and indicates a playbook violation (a change


### PR DESCRIPTION
Final piece to make 3.0.4's forward-merge auto-succeed without manual intervention.

## What this fixes

After #3807 fixed the \`package.json\` rule and #3806 reconciled main's content via \`--ours\`, the forward-merge workflow STILL failed on the next 3.0.x push (run \`25250265030\`). Same two files conflict:

- \`docs/building/implementation/error-handling.mdx\`
- \`static/schemas/source/enums/error-code.json\`

These are the cherry-pick divergence from #3789's prose-only backport of #3739. **#3806's manual \`--ours\` resolution didn't make these go away** because the squash-merge that landed #3806 didn't advance git's merge-base. Every subsequent merge of 3.0.x rediscovers the same divergence.

## Why squash-merges don't help here

Repo settings disallow merge commits (only squash + rebase allowed). So:

1. \`#3806\` ran \`git merge origin/3.0.x\` locally, took \`--ours\` for the two files, committed
2. PR #3806 squash-merged onto main: created a single commit with main's content but lost the merge-commit linking 3.0.x's tip
3. \`git merge-base origin/main origin/3.0.x\` still resolves to a commit BEFORE the divergence
4. Next \`git merge origin/3.0.x\` re-encounters the conflict on those two files

The post-merge \`git diff --quiet\` skip we added in #3794 would have caught this, but it never runs because the workflow fails at the auto-resolution UNEXPECTED step before reaching the diff check.

## The fix: bridge the known divergence

Add the two specific files to the workflow's case statement with \`--ours\` resolution. Comment block in the workflow explains:

- Why these two files specifically (cherry-pick divergence from #3789)
- Why \`--ours\` is correct (main has the more advanced enum-split treatment)
- Why this is **temporary** — remove when 3.1.0 cuts

This is a targeted bridge, not a generic "always take ours" rule. Anything outside the explicit allowlist still fails loud.

## Effect on 3.0.4

After this lands AND gets cherry-picked to 3.0.x, the next forward-merge (after #3799 cuts 3.0.4) will:

- Auto-resolve \`package.json\` / \`package-lock.json\` → preserve main's (#3807's rule)
- Auto-resolve \`.changeset/*.md\` → preserve main's
- Auto-resolve \`dist/{schemas,compliance,protocol}/3.0.4/\` → take 3.0.x's (new files, no real conflict)
- Auto-resolve \`error-handling.mdx\` and \`error-code.json\` → preserve main's (this PR)

No remaining conflicts → workflow opens the auto-PR. PR is a near-no-op (since main already has the content via #3806) and the post-merge \`git diff --quiet\` may even skip the PR entirely. Either way: **no human intervention required**.

## Next steps after merge

1. Cherry-pick this to 3.0.x so the workflow file is updated there too (workflow runs from the trigger ref's YAML)
2. Then user can merge VP PR #3799 (3.0.4) and watch forward-merge auto-succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)