### PR TITLE
fix(billing): catch partial-truth subscription rows that misrender as Explorer

### DIFF
--- a/.changeset/lockdown-partial-truth-tier-rows.md
+++ b/.changeset/lockdown-partial-truth-tier-rows.md
@@ -1,0 +1,15 @@
+---
+---
+
+Lock down partial-truth subscription rows that misrender as Explorer / upgrade-to-Professional.
+
+Background — Adzymic / Travis Teo (May 2026): a founding-member org row had `subscription_status='active'` but NULL `subscription_price_lookup_key`, NULL `stripe_subscription_id`, NULL `subscription_amount`. Tier resolution returned null, so `dashboard-organization.html` fell back to `DEFAULT_TIER` (label "Explorer") and rendered "Upgrade to Professional — $250/yr" to a paying corporate member. Five+ founding-era orgs were in the same state. Both existing Stripe-side invariants and the `lazy-reconcile` heal path treated `status='active'` as proof of full sync, so neither flagged or repaired the rows.
+
+Changes:
+
+- **New invariant** `every-entitled-org-has-resolvable-tier` (critical, DB-only). Walks every org with entitled `subscription_status` and asserts `resolveMembershipTier()` returns non-null. Backstop on the function the dashboard and Addie's prompt rules consume — catches the Adzymic shape and any future schema drift that leaves a class of entitled orgs unresolvable.
+- **Tightened `stripe-sub-reflected-in-org-row`** healthy predicate to require entitled status AND populated `stripe_subscription_id` AND populated tier-resolving product fields (lookup_key non-null OR amount > 0). Previously skipped partial-truth rows on status alone.
+- **Tightened `lazy-reconcile.ts` guard** with the same predicate, plus broadened the UPDATE WHERE clause so heals can write when the row is partial-truth (not only when status is null).
+- **Dashboard fallback fix** in `server/public/dashboard-organization.html`: when `membership_tier` is null but the user is a member, render a neutral "Active membership" state and skip the upgrade teaser. Never silently fall through to `individual_academic` (the Explorer/Professional upsell path).
+- **One-shot reconciliation script** `scripts/incidents/2026-05-heal-partial-truth-tier-rows.ts` — calls the new invariant, lists violations, and POSTs `/api/admin/accounts/:orgId/sync` for each. Defaults to `--dry-run`; pass `--execute` to heal.
+- Tests: Adzymic-shape regression cases for the new invariant, the tightened `stripe-sub-reflected-in-org-row`, and `attemptStripeReconciliation`.

--- a/scripts/incidents/2026-05-heal-partial-truth-tier-rows.ts
+++ b/scripts/incidents/2026-05-heal-partial-truth-tier-rows.ts
@@ -57,6 +57,13 @@ interface InvariantRunReport {
   violations: Violation[];
 }
 
+interface SyncResponse {
+  success?: boolean;
+  stripe?: { success?: boolean; subscription?: { status?: string }; error?: string };
+  workos?: { success?: boolean; error?: string };
+  updated?: boolean;
+}
+
 async function adminGet<T>(path: string): Promise<T> {
   const res = await fetch(`${ADMIN_BASE_URL}${path}`, {
     headers: { Authorization: `Bearer ${ADMIN_API_KEY}` },
@@ -112,18 +119,29 @@ async function main(): Promise<void> {
 
   console.log('\nSyncing each org from Stripe...');
   let healed = 0;
+  let stripeSkipped = 0;
   let failed = 0;
   for (const v of violations) {
     try {
-      const result = await adminPost<{ success: boolean }>(
-        `/api/admin/accounts/${v.subject_id}/sync`,
+      // adminPost throws on non-2xx, so reaching here means the endpoint accepted
+      // the call. The endpoint's `success` field is true only when both WorkOS
+      // *and* Stripe sub-syncs succeeded; for orgs with no live Stripe sub the
+      // Stripe branch returns success=true with an "error" message instead. We
+      // care that the sync ran without HTTP error, then surface what changed.
+      const result = await adminPost<SyncResponse>(
+        `/api/admin/accounts/${encodeURIComponent(v.subject_id)}/sync`,
       );
-      if (result.success) {
+      if (result.updated) {
         healed++;
-        console.log(`  ✓ ${v.subject_id} synced`);
+        const status = result.stripe?.subscription?.status;
+        console.log(`  ✓ ${v.subject_id} synced${status ? ` (status=${status})` : ''}`);
       } else {
-        failed++;
-        console.log(`  ✗ ${v.subject_id} sync returned success=false: ${JSON.stringify(result)}`);
+        // Sync ran but didn't write — usually means no live Stripe sub and no
+        // paid membership invoice (legacy hand-rolled deals). These need
+        // manual tier setting; the script can't heal them.
+        stripeSkipped++;
+        const reason = result.stripe?.error ?? 'no Stripe data to write';
+        console.log(`  ~ ${v.subject_id} not updated: ${reason}`);
       }
     } catch (err) {
       failed++;
@@ -131,7 +149,9 @@ async function main(): Promise<void> {
     }
   }
 
-  console.log(`\nHealed ${healed}/${violations.length} (${failed} failed).`);
+  console.log(
+    `\nHealed ${healed}, skipped ${stripeSkipped} (no Stripe data), failed ${failed}, total ${violations.length}.`,
+  );
   console.log('Re-run the invariant to confirm — orgs with no Stripe subscription');
   console.log('at all (legacy hand-rolled deals) will still need manual tier setting.');
 }

--- a/scripts/incidents/2026-05-heal-partial-truth-tier-rows.ts
+++ b/scripts/incidents/2026-05-heal-partial-truth-tier-rows.ts
@@ -1,0 +1,142 @@
+/**
+ * Heal partial-truth subscription rows surfaced by the
+ * `every-entitled-org-has-resolvable-tier` invariant.
+ *
+ * Background — Adzymic / Travis Teo (May 2026): founding-member org rows had
+ * `subscription_status='active'` but NULL `subscription_price_lookup_key`,
+ * NULL `stripe_subscription_id`, NULL `subscription_amount`. The tier
+ * resolver returned null; the dashboard rendered "Explorer" and prompted
+ * the customer to upgrade to Professional. Five+ founding-era corporate
+ * orgs were in this state.
+ *
+ * The fix in `lazy-reconcile.ts` heals these rows on next paywall touch,
+ * but customers shouldn't have to bump into a paywall to get the right
+ * dashboard. This script walks the invariant's violations and POSTs to
+ * `/api/admin/accounts/:orgId/sync` for each, which re-pulls the customer's
+ * Stripe subscriptions and writes the lookup_key into the row.
+ *
+ * Defaults to --dry-run (lists the orgs, no sync calls). Pass --execute
+ * to actually sync.
+ *
+ * Usage:
+ *   ADMIN_BASE_URL=https://agenticadvertising.org \
+ *   ADMIN_API_KEY=... \
+ *   npx tsx scripts/incidents/2026-05-heal-partial-truth-tier-rows.ts            # dry run
+ *
+ *   ADMIN_BASE_URL=https://agenticadvertising.org \
+ *   ADMIN_API_KEY=... \
+ *   npx tsx scripts/incidents/2026-05-heal-partial-truth-tier-rows.ts --execute  # live
+ */
+
+const ADMIN_BASE_URL = process.env.ADMIN_BASE_URL?.replace(/\/+$/, '');
+const ADMIN_API_KEY = process.env.ADMIN_API_KEY;
+
+if (!ADMIN_BASE_URL) {
+  console.error('ADMIN_BASE_URL not set (e.g. https://agenticadvertising.org)');
+  process.exit(1);
+}
+if (!ADMIN_API_KEY) {
+  console.error('ADMIN_API_KEY not set');
+  process.exit(1);
+}
+
+const execute = process.argv.includes('--execute');
+const dryRun = !execute;
+
+interface Violation {
+  invariant: string;
+  severity: string;
+  subject_type: string;
+  subject_id: string;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+interface InvariantRunReport {
+  total_violations: number;
+  violations: Violation[];
+}
+
+async function adminGet<T>(path: string): Promise<T> {
+  const res = await fetch(`${ADMIN_BASE_URL}${path}`, {
+    headers: { Authorization: `Bearer ${ADMIN_API_KEY}` },
+  });
+  if (!res.ok) {
+    throw new Error(`GET ${path} → ${res.status} ${await res.text()}`);
+  }
+  return (await res.json()) as T;
+}
+
+async function adminPost<T>(path: string): Promise<T> {
+  const res = await fetch(`${ADMIN_BASE_URL}${path}`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${ADMIN_API_KEY}` },
+  });
+  if (!res.ok) {
+    throw new Error(`POST ${path} → ${res.status} ${await res.text()}`);
+  }
+  return (await res.json()) as T;
+}
+
+async function main(): Promise<void> {
+  console.log(`Mode: ${dryRun ? 'DRY RUN' : 'EXECUTE'}`);
+  console.log(`Admin: ${ADMIN_BASE_URL}\n`);
+
+  console.log('Running every-entitled-org-has-resolvable-tier invariant...');
+  const report = await adminGet<InvariantRunReport>(
+    '/api/admin/integrity/check/every-entitled-org-has-resolvable-tier',
+  );
+
+  const violations = report.violations.filter(
+    (v) => v.invariant === 'every-entitled-org-has-resolvable-tier',
+  );
+
+  console.log(`Found ${violations.length} partial-truth orgs.\n`);
+  if (violations.length === 0) return;
+
+  for (const v of violations) {
+    const d = v.details ?? {};
+    console.log(`- ${v.subject_id} (${d.org_name ?? '?'})`);
+    console.log(
+      `    status=${JSON.stringify(d.subscription_status)} ` +
+        `lookup_key=${JSON.stringify(d.subscription_price_lookup_key)} ` +
+        `amount=${JSON.stringify(d.subscription_amount)} ` +
+        `sub_id=${JSON.stringify(d.stripe_subscription_id)}`,
+    );
+  }
+
+  if (dryRun) {
+    console.log('\nDry run — no sync calls issued. Pass --execute to heal.');
+    return;
+  }
+
+  console.log('\nSyncing each org from Stripe...');
+  let healed = 0;
+  let failed = 0;
+  for (const v of violations) {
+    try {
+      const result = await adminPost<{ success: boolean }>(
+        `/api/admin/accounts/${v.subject_id}/sync`,
+      );
+      if (result.success) {
+        healed++;
+        console.log(`  ✓ ${v.subject_id} synced`);
+      } else {
+        failed++;
+        console.log(`  ✗ ${v.subject_id} sync returned success=false: ${JSON.stringify(result)}`);
+      }
+    } catch (err) {
+      failed++;
+      console.log(`  ✗ ${v.subject_id} threw: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  console.log(`\nHealed ${healed}/${violations.length} (${failed} failed).`);
+  console.log('Re-run the invariant to confirm — orgs with no Stripe subscription');
+  console.log('at all (legacy hand-rolled deals) will still need manual tier setting.');
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/server/public/dashboard-organization.html
+++ b/server/public/dashboard-organization.html
@@ -1084,6 +1084,11 @@
     }
 
     function renderUpgradeTeaser(tierKey, orgId, healthData, orgRole) {
+      // Tier unresolved — paying member with NULL membership_tier. Don't
+      // render any upgrade prompt; that's how the Adzymic incident surfaced
+      // (Explorer-fallback drove a Professional upsell to a corporate member).
+      if (!tierKey) return '';
+
       const canUpgrade = orgRole === 'owner' || orgRole === 'admin';
       const teaser = NEXT_TIER_TEASER[tierKey];
       if (!teaser) {
@@ -1149,18 +1154,41 @@
       const el = document.getElementById('hub-content');
       el.style.display = 'block';
 
-      const tier = TIER_DETAILS[membership_tier] || DEFAULT_TIER;
+      // When membership_tier is null but the user is a member (is_member=true
+      // is implied — the page only renders for org members), the row is in a
+      // partial-truth state we shouldn't paper over with an Explorer/
+      // Professional upsell. Render a neutral "Active membership" state and
+      // skip the upgrade teaser. The `every-entitled-org-has-resolvable-tier`
+      // invariant flags these rows so an admin can heal them.
+      const tierUnresolved = !membership_tier;
+      const tier = tierUnresolved
+        ? { label: 'Active membership', contributor: 0, community: 0, price: 'Tier pending sync' }
+        : (TIER_DETAILS[membership_tier] || DEFAULT_TIER);
       const usage = seat_usage || { contributor: 0, community_only: 0 };
       const communityLimit = tier.community === -1 ? '&infin;' : tier.community;
-      const isFreeTier = !membership_tier || membership_tier === 'individual_academic';
-      const tierKey = membership_tier || 'individual_academic';
+      const isFreeTier = !tierUnresolved && membership_tier === 'individual_academic';
+      // Pass null when unresolved so renderUpgradeTeaser hides it; never
+      // silently default to 'individual_academic'.
+      const tierKey = tierUnresolved ? null : membership_tier;
       const valueSummary = TIER_VALUE_SUMMARY[tier.label] || '';
+
+      if (tierUnresolved) {
+        try {
+          console.error('[dashboard-organization] membership_tier unresolved for entitled org', { orgId });
+        } catch (_) { /* console may be unavailable */ }
+      }
 
       // Build team cert progress if available
       const teamCertHtml = certSummary ? renderTeamCertProgress(certSummary) : '';
 
-      // Membership card: simplified for free users, detailed for paid
-      const membershipCardContent = isFreeTier ? `
+      // Membership card: simplified for free users, detailed for paid,
+      // neutral for tier-unresolved (don't claim seat counts we don't know).
+      const membershipCardContent = tierUnresolved ? `
+        <div style="padding: var(--space-4); background: var(--color-warning-50, var(--color-success-50)); border-radius: var(--radius-lg);">
+          <div style="font-size: var(--text-lg); font-weight: var(--font-bold); color: var(--color-text-heading);">Active membership</div>
+          <div style="font-size: var(--text-xs); color: var(--color-text-secondary); margin-top: var(--space-1);">Your tier is pending a billing sync. <a href="mailto:support@agenticadvertising.org">Contact support</a> if this persists.</div>
+        </div>
+      ` : isFreeTier ? `
         <div style="padding: var(--space-4); background: var(--color-success-50); border-radius: var(--radius-lg);">
           <div style="font-size: var(--text-lg); font-weight: var(--font-bold); color: var(--color-text-heading);">1 community seat</div>
           <div style="font-size: var(--text-xs); color: var(--color-text-secondary); margin-top: var(--space-1);">Addie, certification, and training access</div>

--- a/server/public/dashboard-organization.html
+++ b/server/public/dashboard-organization.html
@@ -1184,7 +1184,7 @@
       // Membership card: simplified for free users, detailed for paid,
       // neutral for tier-unresolved (don't claim seat counts we don't know).
       const membershipCardContent = tierUnresolved ? `
-        <div style="padding: var(--space-4); background: var(--color-warning-50, var(--color-success-50)); border-radius: var(--radius-lg);">
+        <div style="padding: var(--space-4); background: var(--color-bg-muted, var(--color-bg-subtle, #f6f6f6)); border-radius: var(--radius-lg); border-left: 3px solid var(--color-text-muted);">
           <div style="font-size: var(--text-lg); font-weight: var(--font-bold); color: var(--color-text-heading);">Active membership</div>
           <div style="font-size: var(--text-xs); color: var(--color-text-secondary); margin-top: var(--space-1);">Your tier is pending a billing sync. <a href="mailto:support@agenticadvertising.org">Contact support</a> if this persists.</div>
         </div>

--- a/server/src/audit/integrity/invariants/every-entitled-org-has-resolvable-tier.ts
+++ b/server/src/audit/integrity/invariants/every-entitled-org-has-resolvable-tier.ts
@@ -1,0 +1,92 @@
+/**
+ * Invariant: every org with an entitled subscription_status must produce a
+ * non-null tier from `resolveMembershipTier()`. This is a backstop on the
+ * function the dashboard and Addie's prompt rules actually consume — if it
+ * returns null for a paying member, the UI silently falls through to the
+ * Explorer / `individual_academic` upsell path and prompts them to upgrade
+ * to Professional.
+ *
+ * Motivating incident — Adzymic / Travis Teo (May 2026): founding-member
+ * org row had `subscription_status='active'` but NULL `subscription_price_lookup_key`
+ * and NULL `subscription_amount`. The Stripe-side invariants didn't fire
+ * (sub_id was NULL, so the row was filtered out of `org-row-matches-live-stripe-sub`;
+ * the `stripe-sub-reflected-in-org-row` healthy predicate treated active
+ * status as "reflected"). The tier resolver returned null. The dashboard
+ * rendered "Explorer" and "Upgrade to Professional — $250/yr" to a paying
+ * corporate member.
+ *
+ * This invariant tests the resolver directly, so it doesn't care *why* the
+ * row is unresolvable (NULL columns today, future schema drift tomorrow).
+ * If a future change leaves a class of entitled orgs unresolvable, this
+ * fires before any UI code makes a member-facing mistake.
+ *
+ * Severity: critical. Member-visible misclassification is at least as bad
+ * as denied entitlement — it actively insults paying customers.
+ */
+import type { Invariant, InvariantContext, InvariantResult, Violation } from '../types.js';
+import {
+  resolveMembershipTier,
+  MEMBERSHIP_TIER_COLUMNS,
+  type MembershipTierRow,
+} from '../../../db/organization-db.js';
+
+const ENTITLED_STATUSES = new Set<string>(['active', 'trialing', 'past_due']);
+
+interface OrgRow extends MembershipTierRow {
+  workos_organization_id: string;
+  name: string;
+  stripe_customer_id: string | null;
+  stripe_subscription_id: string | null;
+}
+
+export const everyEntitledOrgHasResolvableTierInvariant: Invariant = {
+  name: 'every-entitled-org-has-resolvable-tier',
+  description:
+    'Every org with an entitled subscription_status (active, trialing, past_due) must produce a non-null membership tier from resolveMembershipTier(). Tests the function the dashboard and Addie consume, so it catches partial-truth rows the Stripe-side invariants miss — most notably founding-era orgs with status=active but NULL lookup_key/amount, which the dashboard misrenders as Explorer.',
+  severity: 'critical',
+  async check(ctx: InvariantContext): Promise<InvariantResult> {
+    const { pool } = ctx;
+    const violations: Violation[] = [];
+
+    const result = await pool.query<OrgRow>(
+      `SELECT workos_organization_id, name, stripe_customer_id, stripe_subscription_id,
+              ${MEMBERSHIP_TIER_COLUMNS.join(', ')}
+         FROM organizations
+        WHERE subscription_status = ANY($1::text[])`,
+      [Array.from(ENTITLED_STATUSES)],
+    );
+
+    for (const org of result.rows) {
+      const tier = resolveMembershipTier(org);
+      if (tier !== null) continue;
+
+      violations.push({
+        invariant: 'every-entitled-org-has-resolvable-tier',
+        severity: 'critical',
+        subject_type: 'organization',
+        subject_id: org.workos_organization_id,
+        message:
+          `Org "${org.name}" has subscription_status=${JSON.stringify(org.subscription_status)} ` +
+          `but resolveMembershipTier() returned null. Dashboard will render the wrong tier ` +
+          `(Explorer fallback) and may prompt the member to upgrade.`,
+        details: {
+          org_name: org.name,
+          stripe_customer_id: org.stripe_customer_id,
+          stripe_subscription_id: org.stripe_subscription_id,
+          subscription_status: org.subscription_status,
+          subscription_price_lookup_key: org.subscription_price_lookup_key,
+          subscription_amount: org.subscription_amount,
+          subscription_interval: org.subscription_interval,
+          membership_tier_column: org.membership_tier,
+          is_personal: org.is_personal,
+        },
+        remediation_hint:
+          `POST /api/admin/accounts/${org.workos_organization_id}/sync to re-pull Stripe state ` +
+          `and populate subscription_price_lookup_key. If the row has no Stripe subscription ` +
+          `(legacy founding deal), set membership_tier directly via admin tooling.`,
+      });
+    }
+
+    return { checked: result.rows.length, violations };
+  },
+};

--- a/server/src/audit/integrity/invariants/every-entitled-org-has-resolvable-tier.ts
+++ b/server/src/audit/integrity/invariants/every-entitled-org-has-resolvable-tier.ts
@@ -67,8 +67,9 @@ export const everyEntitledOrgHasResolvableTierInvariant: Invariant = {
         subject_id: org.workos_organization_id,
         message:
           `Org "${org.name}" has subscription_status=${JSON.stringify(org.subscription_status)} ` +
-          `but resolveMembershipTier() returned null. Dashboard will render the wrong tier ` +
-          `(Explorer fallback) and may prompt the member to upgrade.`,
+          `but resolveMembershipTier() returned null. Dashboard renders a neutral ` +
+          `"tier pending sync" state instead of the actual tier; Addie's prompt ` +
+          `rules treat the org as untiered.`,
         details: {
           org_name: org.name,
           stripe_customer_id: org.stripe_customer_id,

--- a/server/src/audit/integrity/invariants/index.ts
+++ b/server/src/audit/integrity/invariants/index.ts
@@ -16,10 +16,12 @@ import { orgRowMatchesLiveStripeSubInvariant } from './org-row-matches-live-stri
 import { stripeSubReflectedInOrgRowInvariant } from './stripe-sub-reflected-in-org-row.js';
 import { workosMembershipRowExistsInWorkosInvariant } from './workos-membership-row-exists-in-workos.js';
 import { usersHavePrimaryOrganizationInvariant } from './users-have-primary-organization.js';
+import { everyEntitledOrgHasResolvableTierInvariant } from './every-entitled-org-has-resolvable-tier.js';
 
 export const ALL_INVARIANTS: readonly Invariant[] = [
   // DB-only checks first (no external API calls).
   usersHavePrimaryOrganizationInvariant,
+  everyEntitledOrgHasResolvableTierInvariant,
   stripeCustomerOrgMetadataBidirectionalInvariant,
   oneActiveStripeSubPerOrgInvariant,
   stripeCustomerResolvesInvariant,

--- a/server/src/audit/integrity/invariants/stripe-sub-reflected-in-org-row.ts
+++ b/server/src/audit/integrity/invariants/stripe-sub-reflected-in-org-row.ts
@@ -5,11 +5,22 @@
  * at orgs we already think are subscribed and verifies Stripe agrees. This
  * one starts at Stripe and verifies our DB caught up.
  *
- * Motivating incident: a member paid for Professional, Stripe recorded the
- * subscription as `active`, the customer was correctly linked to her org —
- * but `customer.subscription.created` never updated the org row. She had
- * `subscription_status: NULL` for ~40 days while Stripe billed her, and was
- * blocked from paid certification content the whole time.
+ * "Reflected" means the row's `subscription_status` is entitled AND its
+ * `stripe_subscription_id` and tier-resolving product fields
+ * (`subscription_price_lookup_key` or `subscription_amount`) are populated.
+ * Status alone is not enough: a row with `status='active'` but NULL
+ * stripe_subscription_id / NULL lookup_key passes the gate but leaves the
+ * tier resolver returning null, which the dashboard renders as an
+ * Explorer/upgrade-to-Professional upsell to a paying member.
+ *
+ * Motivating incidents:
+ *   - Lina (Apr 2026): paid Professional, Stripe `active`, but
+ *     `customer.subscription.created` never updated the row. `subscription_status`
+ *     stayed NULL for ~40 days while she was blocked from paid content.
+ *   - Adzymic (May 2026): founding-member row had `subscription_status='active'`
+ *     manually set, but `stripe_subscription_id` / `subscription_price_lookup_key`
+ *     stayed NULL. Tier resolver returned null; dashboard rendered "Explorer"
+ *     and "Upgrade to Professional" to a paying corporate member.
  *
  * Detect-only by design. The framework's auto-remediation policy lives at
  * Phase 3+; for now violations are surfaced for an admin to act on via
@@ -51,12 +62,32 @@ interface OrgRow {
   stripe_customer_id: string;
   subscription_status: string | null;
   stripe_subscription_id: string | null;
+  subscription_price_lookup_key: string | null;
+  subscription_amount: number | null;
+}
+
+/**
+ * "Reflected in the org row" means more than `subscription_status` being set.
+ * The tier resolver and the dashboard depend on `stripe_subscription_id` and
+ * a tier-resolving product field (`subscription_price_lookup_key` or
+ * `subscription_amount`). A row with `status='active'` but those NULL is the
+ * partial-truth state founding-era orgs sat in for months: entitled by gate,
+ * but the dashboard renders an Explorer/upgrade-to-Professional teaser
+ * because tier resolves to null. Treat the row as reflected only when all
+ * three conditions hold.
+ */
+function isReflected(org: OrgRow): boolean {
+  if (!org.subscription_status) return false;
+  if (!ENTITLED_STATUSES.has(org.subscription_status as Stripe.Subscription.Status)) return false;
+  if (!org.stripe_subscription_id) return false;
+  if (!org.subscription_price_lookup_key && (org.subscription_amount ?? 0) <= 0) return false;
+  return true;
 }
 
 export const stripeSubReflectedInOrgRowInvariant: Invariant = {
   name: 'stripe-sub-reflected-in-org-row',
   description:
-    'Every membership subscription that is active or trialing in Stripe is reflected in the org row for its linked customer. Catches missed `customer.subscription.created` and `customer.subscription.updated` webhooks that leave a paying member with no entitlement in our DB.',
+    'Every membership subscription that is active or trialing in Stripe is fully reflected in the org row for its linked customer — entitled status PLUS populated stripe_subscription_id and tier-resolving product fields. Catches missed webhooks (Lina-class) and partial-truth rows where status was set manually but Stripe data never synced (Adzymic-class).',
   severity: 'critical',
   async check(ctx: InvariantContext): Promise<InvariantResult> {
     const { pool, stripe, logger } = ctx;
@@ -82,7 +113,8 @@ export const stripeSubReflectedInOrgRowInvariant: Invariant = {
 
     const orgsResult = await pool.query<OrgRow>(
       `SELECT workos_organization_id, name, stripe_customer_id,
-              subscription_status, stripe_subscription_id
+              subscription_status, stripe_subscription_id,
+              subscription_price_lookup_key, subscription_amount
          FROM organizations
         WHERE stripe_customer_id = ANY($1::text[])`,
       [customerIds],
@@ -133,21 +165,32 @@ export const stripeSubReflectedInOrgRowInvariant: Invariant = {
       }
 
       // Healthy: row reflects Stripe entitlement. No-op.
-      if (org.subscription_status && ENTITLED_STATUSES.has(org.subscription_status as Stripe.Subscription.Status)) {
+      if (isReflected(org)) {
         continue;
       }
 
-      // Lina-class: paying customer is being denied access. Stripe says
-      // entitled, our DB does not.
+      // Lina-class (status NULL) or Adzymic-class (status active but key fields
+      // NULL — tier resolver returns null, dashboard renders bogus upsell).
+      // Both surface as critical: a paying customer is either denied access or
+      // shown a Professional-upgrade teaser instead of their real tier.
+      const isPartialTruth =
+        org.subscription_status &&
+        ENTITLED_STATUSES.has(org.subscription_status as Stripe.Subscription.Status);
+
       violations.push({
         invariant: 'stripe-sub-reflected-in-org-row',
         severity: 'critical',
         subject_type: 'organization',
         subject_id: org.workos_organization_id,
-        message:
-          `Org "${org.name}" has paid membership subscription ${sub.id} live in Stripe ` +
-          `(${sub.status}) but DB row shows subscription_status=${JSON.stringify(org.subscription_status)}. ` +
-          `Member is incorrectly being denied entitlement.`,
+        message: isPartialTruth
+          ? `Org "${org.name}" has paid membership subscription ${sub.id} live in Stripe ` +
+            `(${sub.status}) but DB row is partial-truth: status=${JSON.stringify(org.subscription_status)}, ` +
+            `stripe_subscription_id=${JSON.stringify(org.stripe_subscription_id)}, ` +
+            `lookup_key=${JSON.stringify(org.subscription_price_lookup_key)}. ` +
+            `Tier resolver returns null, dashboard renders the wrong upsell.`
+          : `Org "${org.name}" has paid membership subscription ${sub.id} live in Stripe ` +
+            `(${sub.status}) but DB row shows subscription_status=${JSON.stringify(org.subscription_status)}. ` +
+            `Member is incorrectly being denied entitlement.`,
         details: {
           org_name: org.name,
           stripe_customer_id: customerId,
@@ -155,6 +198,9 @@ export const stripeSubReflectedInOrgRowInvariant: Invariant = {
           stripe_status: sub.status,
           db_subscription_status: org.subscription_status,
           db_stripe_subscription_id: org.stripe_subscription_id,
+          db_subscription_price_lookup_key: org.subscription_price_lookup_key,
+          db_subscription_amount: org.subscription_amount,
+          partial_truth: !!isPartialTruth,
           lookup_key,
           unit_amount,
         },

--- a/server/src/billing/lazy-reconcile.ts
+++ b/server/src/billing/lazy-reconcile.ts
@@ -54,6 +54,29 @@ interface OrgRow {
   stripe_customer_id: string | null;
   subscription_status: string | null;
   subscription_canceled_at: Date | null;
+  stripe_subscription_id: string | null;
+  subscription_price_lookup_key: string | null;
+  subscription_amount: number | null;
+}
+
+/**
+ * "Fully synced" requires status entitled AND product fields populated. A row
+ * with `subscription_status='active'` but NULL `stripe_subscription_id` /
+ * `subscription_price_lookup_key` is a partial-truth: entitled enough to pass
+ * gate checks, but missing the data the tier resolver and dashboard need.
+ *
+ * Founding-member rows lived in this state for months — admin set status
+ * manually but the Stripe sub never wrote its lookup_key into the org row.
+ * The `every-entitled-org-has-resolvable-tier` invariant catches them now,
+ * but lazy-reconcile is the cheap heal path: treating partial-truth as
+ * "already entitled" leaves the row stuck. Only skip when the row is
+ * actually complete.
+ */
+function isFullySynced(org: OrgRow): boolean {
+  if (!org.subscription_status || !ENTITLED_STATUSES.has(org.subscription_status)) return false;
+  if (!org.stripe_subscription_id) return false;
+  if (org.subscription_price_lookup_key === null && (org.subscription_amount ?? 0) <= 0) return false;
+  return true;
 }
 
 export interface LazyReconcileDeps {
@@ -76,7 +99,8 @@ export async function attemptStripeReconciliation(
   const { pool, stripe, logger } = deps;
 
   const orgResult = await pool.query<OrgRow>(
-    `SELECT workos_organization_id, stripe_customer_id, subscription_status, subscription_canceled_at
+    `SELECT workos_organization_id, stripe_customer_id, subscription_status, subscription_canceled_at,
+            stripe_subscription_id, subscription_price_lookup_key, subscription_amount
        FROM organizations
       WHERE workos_organization_id = $1`,
     [orgId],
@@ -84,7 +108,7 @@ export async function attemptStripeReconciliation(
   const org = orgResult.rows[0];
   if (!org) return { healed: false, reason: 'org_not_found' };
 
-  if (org.subscription_status && ENTITLED_STATUSES.has(org.subscription_status)) {
+  if (isFullySynced(org)) {
     return { healed: false, reason: 'already_entitled' };
   }
 
@@ -116,10 +140,11 @@ export async function attemptStripeReconciliation(
 
   const price = sub.items.data[0]?.price;
 
-  // `WHERE subscription_status IS NULL OR = 'none'` makes the write a no-op
-  // if a webhook beat us to it. We deliberately do not overwrite an existing
-  // active/canceled/etc. status — the webhook is the source of truth for
-  // those transitions; lazy reconcile only fills in the gap.
+  // The WHERE clause only writes when the row is still in a partial-truth
+  // state (no entitled status, or status set but key product fields missing).
+  // If a webhook beat us to a fully-synced state between our read and write,
+  // the update is a no-op — the webhook is the source of truth for live
+  // transitions; lazy reconcile only fills gaps.
   const updated = await pool.query(
     `UPDATE organizations
        SET subscription_status = $1,
@@ -132,7 +157,12 @@ export async function attemptStripeReconciliation(
            subscription_price_lookup_key = $8,
            updated_at = NOW()
      WHERE workos_organization_id = $9
-       AND (subscription_status IS NULL OR subscription_status = 'none')
+       AND (
+         subscription_status IS NULL
+         OR subscription_status = 'none'
+         OR stripe_subscription_id IS NULL
+         OR (subscription_price_lookup_key IS NULL AND COALESCE(subscription_amount, 0) <= 0)
+       )
      RETURNING workos_organization_id`,
     [
       sub.status,

--- a/server/tests/unit/billing/lazy-reconcile.test.ts
+++ b/server/tests/unit/billing/lazy-reconcile.test.ts
@@ -137,8 +137,11 @@ describe('attemptStripeReconciliation', () => {
 
     expect(result.healed).toBe(true);
     expect(mockCustomersRetrieve).toHaveBeenCalledTimes(1);
+    // Match the lookup_key in the UPDATE params without depending on positional
+    // index — adjacent tests in this file pattern-match on call shape, not
+    // positional binding, so a future param reorder doesn't silently invert.
     const updateParams = mockQuery.mock.calls[1][1] as unknown[];
-    expect(updateParams[7]).toBe('aao_membership_corporate_under5m'); // lookup_key written
+    expect(updateParams).toContain('aao_membership_corporate_under5m');
   });
 
   it('heals when status=active but only stripe_subscription_id is missing (lookup_key set)', async () => {

--- a/server/tests/unit/billing/lazy-reconcile.test.ts
+++ b/server/tests/unit/billing/lazy-reconcile.test.ts
@@ -33,6 +33,9 @@ function fakeOrg(overrides: Partial<{
   stripe_customer_id: string | null;
   subscription_status: string | null;
   subscription_canceled_at: Date | null;
+  stripe_subscription_id: string | null;
+  subscription_price_lookup_key: string | null;
+  subscription_amount: number | null;
 }> = {}) {
   // `'key' in overrides` preserves explicit null (vs ?? which would
   // substitute the default for null too).
@@ -41,6 +44,12 @@ function fakeOrg(overrides: Partial<{
     stripe_customer_id: 'stripe_customer_id' in overrides ? overrides.stripe_customer_id : 'cus_x',
     subscription_status: 'subscription_status' in overrides ? overrides.subscription_status : null,
     subscription_canceled_at: overrides.subscription_canceled_at ?? null,
+    stripe_subscription_id:
+      'stripe_subscription_id' in overrides ? overrides.stripe_subscription_id : null,
+    subscription_price_lookup_key:
+      'subscription_price_lookup_key' in overrides ? overrides.subscription_price_lookup_key : null,
+    subscription_amount:
+      'subscription_amount' in overrides ? overrides.subscription_amount : null,
   };
 }
 
@@ -90,14 +99,66 @@ describe('attemptStripeReconciliation', () => {
     expect(mockQuery.mock.calls[1][0]).toMatch(/UPDATE organizations/);
   });
 
-  it('skips when org already has an entitled subscription_status', async () => {
-    mockQuery.mockResolvedValueOnce({ rows: [fakeOrg({ subscription_status: 'active' })] });
+  it('skips when org is fully synced (entitled status AND populated sub_id + lookup_key)', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [fakeOrg({
+        subscription_status: 'active',
+        stripe_subscription_id: 'sub_existing',
+        subscription_price_lookup_key: 'aao_membership_professional_250',
+        subscription_amount: 25000,
+      })],
+    });
 
     const result = await attemptStripeReconciliation('org_x', makeDeps());
 
     expect(result).toEqual({ healed: false, reason: 'already_entitled' });
     expect(mockCustomersRetrieve).not.toHaveBeenCalled();
     expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('heals Adzymic-shape: status=active but stripe_subscription_id and lookup_key NULL', async () => {
+    // The partial-truth case that founding-era rows sat in for months.
+    // Pre-fix this returned 'already_entitled' on the status check alone.
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [fakeOrg({
+          subscription_status: 'active',
+          stripe_subscription_id: null,
+          subscription_price_lookup_key: null,
+          subscription_amount: null,
+        })],
+      })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ workos_organization_id: 'org_x' }] });
+    mockCustomersRetrieve.mockResolvedValueOnce(
+      fakeCustomerWithSubs([fakeMembershipSub({ lookup_key: 'aao_membership_corporate_under5m' })]),
+    );
+
+    const result = await attemptStripeReconciliation('org_x', makeDeps());
+
+    expect(result.healed).toBe(true);
+    expect(mockCustomersRetrieve).toHaveBeenCalledTimes(1);
+    const updateParams = mockQuery.mock.calls[1][1] as unknown[];
+    expect(updateParams[7]).toBe('aao_membership_corporate_under5m'); // lookup_key written
+  });
+
+  it('heals when status=active but only stripe_subscription_id is missing (lookup_key set)', async () => {
+    // Less common partial state, but still a sync gap. Either field missing
+    // means lazy-reconcile should fill it in.
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [fakeOrg({
+          subscription_status: 'active',
+          stripe_subscription_id: null,
+          subscription_price_lookup_key: 'aao_membership_explorer_50',
+          subscription_amount: 5000,
+        })],
+      })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ workos_organization_id: 'org_x' }] });
+    mockCustomersRetrieve.mockResolvedValueOnce(fakeCustomerWithSubs([fakeMembershipSub()]));
+
+    const result = await attemptStripeReconciliation('org_x', makeDeps());
+
+    expect(result.healed).toBe(true);
   });
 
   it('skips when org has no Stripe customer id', async () => {

--- a/server/tests/unit/integrity/invariants.test.ts
+++ b/server/tests/unit/integrity/invariants.test.ts
@@ -667,7 +667,7 @@ describe('every-entitled-org-has-resolvable-tier', () => {
     expect(result.violations[0].severity).toBe('critical');
     expect(result.violations[0].subject_type).toBe('organization');
     expect(result.violations[0].subject_id).toBe('org_adzymic');
-    expect(result.violations[0].message).toContain('Explorer');
+    expect(result.violations[0].message).toContain('tier pending sync');
     expect(result.violations[0].details?.subscription_status).toBe('active');
     expect(result.violations[0].details?.subscription_price_lookup_key).toBeNull();
     expect(result.violations[0].remediation_hint).toContain('/sync');

--- a/server/tests/unit/integrity/invariants.test.ts
+++ b/server/tests/unit/integrity/invariants.test.ts
@@ -12,10 +12,11 @@ import { stripeCustomerResolvesInvariant } from '../../../src/audit/integrity/in
 import { orgRowMatchesLiveStripeSubInvariant } from '../../../src/audit/integrity/invariants/org-row-matches-live-stripe-sub.js';
 import { stripeSubReflectedInOrgRowInvariant } from '../../../src/audit/integrity/invariants/stripe-sub-reflected-in-org-row.js';
 import { workosMembershipRowExistsInWorkosInvariant } from '../../../src/audit/integrity/invariants/workos-membership-row-exists-in-workos.js';
+import { everyEntitledOrgHasResolvableTierInvariant } from '../../../src/audit/integrity/invariants/every-entitled-org-has-resolvable-tier.js';
 import { ALL_INVARIANTS, getInvariantByName } from '../../../src/audit/integrity/invariants/index.js';
 import type { InvariantContext } from '../../../src/audit/integrity/types.js';
 
-const EXPECTED_INVARIANT_COUNT = 7;
+const EXPECTED_INVARIANT_COUNT = 8;
 
 const mockPoolQuery = vi.fn();
 const mockStripeCustomersRetrieve = vi.fn();
@@ -396,6 +397,8 @@ describe('stripe-sub-reflected-in-org-row', () => {
         stripe_customer_id: 'cus_1',
         subscription_status: 'active',
         stripe_subscription_id: 'sub_1',
+        subscription_price_lookup_key: 'aao_membership_professional_250',
+        subscription_amount: 25000,
       }],
     });
 
@@ -497,6 +500,8 @@ describe('stripe-sub-reflected-in-org-row', () => {
         stripe_customer_id: 'cus_pd',
         subscription_status: 'past_due',
         stripe_subscription_id: 'sub_1',
+        subscription_price_lookup_key: 'aao_membership_professional_250',
+        subscription_amount: 25000,
       }],
     });
 
@@ -575,5 +580,235 @@ describe('workos-membership-row-exists-in-workos', () => {
     });
 
     expect(mockPoolQuery).toHaveBeenCalledWith(expect.any(String), [50]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// every-entitled-org-has-resolvable-tier
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('every-entitled-org-has-resolvable-tier', () => {
+  function row(overrides: Partial<{
+    workos_organization_id: string;
+    name: string;
+    stripe_customer_id: string | null;
+    stripe_subscription_id: string | null;
+    membership_tier: string | null;
+    subscription_status: string | null;
+    subscription_price_lookup_key: string | null;
+    subscription_amount: number | null;
+    subscription_interval: string | null;
+    is_personal: boolean;
+  }> = {}) {
+    // `'key' in overrides` preserves explicit null in test fixtures; `??`
+    // would substitute the default when the caller intentionally passed
+    // null (the Adzymic-shape case).
+    return {
+      workos_organization_id: overrides.workos_organization_id ?? 'org_1',
+      name: overrides.name ?? 'Acme',
+      stripe_customer_id: 'stripe_customer_id' in overrides ? overrides.stripe_customer_id : 'cus_1',
+      stripe_subscription_id:
+        'stripe_subscription_id' in overrides ? overrides.stripe_subscription_id : 'sub_1',
+      membership_tier: 'membership_tier' in overrides ? overrides.membership_tier : null,
+      subscription_status:
+        'subscription_status' in overrides ? overrides.subscription_status : 'active',
+      subscription_price_lookup_key:
+        'subscription_price_lookup_key' in overrides
+          ? overrides.subscription_price_lookup_key
+          : 'aao_membership_professional_250',
+      subscription_amount:
+        'subscription_amount' in overrides ? overrides.subscription_amount : 25000,
+      subscription_interval:
+        'subscription_interval' in overrides ? overrides.subscription_interval : 'year',
+      is_personal: overrides.is_personal ?? false,
+    };
+  }
+
+  it('passes when every entitled org resolves to a non-null tier', async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [
+        row({ membership_tier: 'company_standard' }),
+        row({
+          workos_organization_id: 'org_2',
+          name: 'Builder Co',
+          membership_tier: null, // null column but lookup_key resolves
+          subscription_price_lookup_key: 'aao_membership_corporate_under5m',
+        }),
+      ],
+    });
+
+    const result = await everyEntitledOrgHasResolvableTierInvariant.check(makeCtx());
+
+    expect(result.checked).toBe(2);
+    expect(result.violations).toEqual([]);
+  });
+
+  it('flags Adzymic-shape: status=active but lookup_key/amount/sub_id all null', async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [
+        row({
+          workos_organization_id: 'org_adzymic',
+          name: 'Adzymic',
+          stripe_subscription_id: null,
+          membership_tier: null,
+          subscription_status: 'active',
+          subscription_price_lookup_key: null,
+          subscription_amount: null,
+          subscription_interval: null,
+          is_personal: false,
+        }),
+      ],
+    });
+
+    const result = await everyEntitledOrgHasResolvableTierInvariant.check(makeCtx());
+
+    expect(result.checked).toBe(1);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].severity).toBe('critical');
+    expect(result.violations[0].subject_type).toBe('organization');
+    expect(result.violations[0].subject_id).toBe('org_adzymic');
+    expect(result.violations[0].message).toContain('Explorer');
+    expect(result.violations[0].details?.subscription_status).toBe('active');
+    expect(result.violations[0].details?.subscription_price_lookup_key).toBeNull();
+    expect(result.violations[0].remediation_hint).toContain('/sync');
+  });
+
+  it('flags trialing and past_due rows with NULL product fields the same way', async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [
+        row({
+          workos_organization_id: 'org_trial',
+          name: 'Trial Co',
+          subscription_status: 'trialing',
+          subscription_price_lookup_key: null,
+          subscription_amount: null,
+          stripe_subscription_id: null,
+        }),
+        row({
+          workos_organization_id: 'org_pd',
+          name: 'PastDue Co',
+          subscription_status: 'past_due',
+          subscription_price_lookup_key: null,
+          subscription_amount: null,
+          stripe_subscription_id: null,
+        }),
+      ],
+    });
+
+    const result = await everyEntitledOrgHasResolvableTierInvariant.check(makeCtx());
+    expect(result.violations).toHaveLength(2);
+    expect(result.violations.every((v) => v.severity === 'critical')).toBe(true);
+  });
+
+  it('does not flag when membership_tier column itself is set, even if lookup_key is null', async () => {
+    // Backfill 332 set membership_tier directly from amount-based inference;
+    // those rows resolve via the cached column even when lookup_key is null.
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [
+        row({
+          membership_tier: 'company_icl',
+          subscription_price_lookup_key: null,
+          subscription_amount: 1000000,
+        }),
+      ],
+    });
+
+    const result = await everyEntitledOrgHasResolvableTierInvariant.check(makeCtx());
+    expect(result.violations).toEqual([]);
+  });
+
+  it('does not query non-entitled rows', async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+
+    await everyEntitledOrgHasResolvableTierInvariant.check(makeCtx());
+
+    const [, params] = mockPoolQuery.mock.calls[0] as [string, unknown[]];
+    expect(params[0]).toEqual(expect.arrayContaining(['active', 'trialing', 'past_due']));
+    // The query must filter to entitled statuses; canceled/incomplete rows
+    // shouldn't be in scope.
+    expect(params[0]).not.toContain('canceled');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// stripe-sub-reflected-in-org-row — Adzymic-shape regression
+// (existing tests above cover Lina-shape with status=NULL; this one covers
+//  partial-truth where status='active' but key fields are NULL.)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('stripe-sub-reflected-in-org-row partial-truth', () => {
+  function membershipSub(overrides: Partial<{
+    id: string;
+    status: 'active' | 'trialing' | 'past_due' | 'canceled' | 'incomplete';
+    customer: string;
+    lookup_key: string;
+    unit_amount: number;
+  }> = {}) {
+    return {
+      id: overrides.id ?? 'sub_1',
+      status: overrides.status ?? 'active',
+      customer: overrides.customer ?? 'cus_1',
+      items: {
+        data: [{
+          price: {
+            lookup_key: overrides.lookup_key ?? 'aao_membership_corporate_under5m',
+            unit_amount: overrides.unit_amount ?? 250000,
+          },
+        }],
+      },
+    };
+  }
+
+  function mockSubsListWith(activeSubs: unknown[], trialingSubs: unknown[] = []): void {
+    mockStripeSubsList
+      .mockImplementationOnce(() => ({
+        async *[Symbol.asyncIterator]() { for (const s of activeSubs) yield s; },
+      }))
+      .mockImplementationOnce(() => ({
+        async *[Symbol.asyncIterator]() { for (const s of trialingSubs) yield s; },
+      }));
+  }
+
+  it('flags Adzymic-shape: status=active in DB but stripe_subscription_id and lookup_key NULL', async () => {
+    mockSubsListWith([membershipSub({ id: 'sub_adz', customer: 'cus_adz' })]);
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{
+        workos_organization_id: 'org_adz',
+        name: 'Adzymic',
+        stripe_customer_id: 'cus_adz',
+        subscription_status: 'active',
+        stripe_subscription_id: null,
+        subscription_price_lookup_key: null,
+        subscription_amount: null,
+      }],
+    });
+
+    const result = await stripeSubReflectedInOrgRowInvariant.check(makeCtx());
+
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].severity).toBe('critical');
+    expect(result.violations[0].subject_id).toBe('org_adz');
+    expect(result.violations[0].message).toContain('partial-truth');
+    expect(result.violations[0].details?.partial_truth).toBe(true);
+    expect(result.violations[0].details?.db_subscription_status).toBe('active');
+    expect(result.violations[0].details?.db_subscription_price_lookup_key).toBeNull();
+  });
+
+  it('does not flag a row with status=active AND populated lookup_key + sub_id (fully reflected)', async () => {
+    mockSubsListWith([membershipSub({ customer: 'cus_ok' })]);
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{
+        workos_organization_id: 'org_ok',
+        name: 'OK Co',
+        stripe_customer_id: 'cus_ok',
+        subscription_status: 'active',
+        stripe_subscription_id: 'sub_1',
+        subscription_price_lookup_key: 'aao_membership_corporate_under5m',
+        subscription_amount: 250000,
+      }],
+    });
+
+    const result = await stripeSubReflectedInOrgRowInvariant.check(makeCtx());
+    expect(result.violations).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Founding-member orgs (e.g. Adzymic, escalation #300) sat in a state where `subscription_status='active'` but `stripe_subscription_id`, `subscription_price_lookup_key`, and `subscription_amount` were all NULL. The tier resolver returned null, and `dashboard-organization.html` fell back to `DEFAULT_TIER` (label "Explorer") and rendered "Upgrade to Professional — \$250/yr" to a paying corporate member.

Both existing Stripe-side invariants (`stripe-sub-reflected-in-org-row`, `org-row-matches-live-stripe-sub`) and the `lazy-reconcile` heal path treated `status='active'` as proof of full sync, so neither flagged or repaired the rows. Five+ founding-era corporate orgs were in the same state.

## What changed

- **New invariant** `every-entitled-org-has-resolvable-tier` (critical, DB-only). Walks every org with entitled `subscription_status` and asserts `resolveMembershipTier()` returns non-null. Backstop on the function the dashboard and Addie's prompt rules consume — catches the Adzymic shape and any future schema drift.
- **Tightened `stripe-sub-reflected-in-org-row`** healthy predicate: status entitled AND `stripe_subscription_id` non-null AND tier-resolving product field populated (`lookup_key` non-null OR `amount > 0`).
- **Tightened `lazy-reconcile`** read-side guard with the same predicate, plus broadened the UPDATE WHERE clause so heals can write when the row is partial-truth.
- **Dashboard fallback fix** (`server/public/dashboard-organization.html`): when `membership_tier` is null but the user is a member, render a neutral "Active membership" state and skip the upgrade teaser. Never silently default to `individual_academic`.
- **One-shot reconciliation script** `scripts/incidents/2026-05-heal-partial-truth-tier-rows.ts` — calls the new invariant, lists violations, POSTs `/api/admin/accounts/:orgId/sync` for each. Defaults to dry-run.
- **Tests**: Adzymic-shape regression cases for the new invariant, the tightened `stripe-sub-reflected-in-org-row`, and `attemptStripeReconciliation`.

## Test plan

- [x] `npx vitest run tests/unit/integrity/ tests/unit/billing/` — 87 tests pass, including new Adzymic-shape regressions
- [x] `tsc --noEmit` clean
- [x] Precommit hook (full unit suite + typecheck + dynamic imports) passed
- [ ] After merge: run the one-shot script in dry-run mode against prod to confirm the violation list, then `--execute` to heal the founding cohort
- [ ] After merge: hit `GET /api/admin/integrity/check/every-entitled-org-has-resolvable-tier` post-heal to confirm zero violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)