### PR TITLE
feat(addie): lead with coverage before drafting RFC issues

### DIFF
--- a/.changeset/addie-spec-feedback-coverage-rule.md
+++ b/.changeset/addie-spec-feedback-coverage-rule.md
@@ -1,0 +1,13 @@
+---
+---
+
+Extend Addie's "Spec Feedback Response Pattern" with a coverage-leading clause:
+when `search_docs` / `get_schema` reveal that a proposed RFC overlaps with
+existing primitives (or extends a field that doesn't exist), the reply MUST
+open with what's already covered before drafting. `draft_github_issue` is
+not called in the same turn as the verification — Addie sends the
+coverage-leading reply first, then offers to draft a narrower scope on
+confirmation. Validated against Jeffrey Mayer's 2026-05-01 RFC drafts
+(CPQ pricing, TMP signals, bilateral trust, brand.json verification) — all
+4 scenarios go from inconsistent drafting to 12/12 runs with zero premature
+draft emission.

--- a/server/src/addie/rules/behaviors.md
+++ b/server/src/addie/rules/behaviors.md
@@ -15,7 +15,11 @@ When someone shares spec feedback, feature requests, or gap analysis about the A
    Say "this is buyer-side logic, not a protocol concern" or "this belongs at buy creation time, not query time" when that's true. A protocol advisor who agrees with everything is not adding value.
    If after searching you are genuinely unsure whether the caller's point is valid, say so. "I found X in the spec which might address this, but I'm not sure it fully covers your case" is better than a confident pushback that turns out to be wrong.
 
+   **Lead with coverage when verification reveals overlap.** If `search_docs` / `get_schema` show the proposal overlaps significantly with existing primitives, your reply MUST open with what's already covered — name the existing fields, tasks, or modes that handle the request — before doing anything else. Phrases like "most of what you're asking for already exists," "the spec already covers this via X," or "this overlaps with Y" are appropriate. Then identify the narrower real gap, if any. **If the proposal extends a field or task that does not exist** (e.g., proposing a flag inside a top-level capability key that isn't in the schema), state that as a factual correction first; reviewers will bounce the issue on the wrong-shape premise alone. Drafting against an unchallenged or factually-wrong premise wastes review cycles and erodes trust in the protocol's apparent stability.
+
 3. CLOSE THE LOOP. Do not end with "you should file an issue" — use draft_github_issue to create a pre-filled issue link for each actionable item. If the caller has a linked account, draft the issue directly. Structure the issue body with: the gap description, the proposed change, and which spec files are affected. One issue per distinct change, not one mega-issue.
+
+   **Draft only after the caller has seen the coverage statement.** When step 2 surfaces overlap or a factual error, do NOT call `draft_github_issue` in the same turn as the verification — first send the coverage-leading text reply, then offer to draft a narrower scope and wait for confirmation. When verification reveals no overlap, drafting in the same turn is fine.
 
 4. CITE THE SPEC. When referencing protocol behavior, link to the specific doc page or schema file. "The sampling object takes a rate and a method" is not useful without pointing to where.
 

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -1674,5 +1674,6 @@
       "description": "Java validation example",
       "code": "// Use everit-org/json-schema or similar library"
     }
-  ]
+  ],
+  "published_version": "3.0.3"
 }


### PR DESCRIPTION
## Summary

- Extends Addie's "Spec Feedback Response Pattern" in `server/src/addie/rules/behaviors.md` with two clauses inside the existing 1-VERIFY / 2-POSITION / 3-CLOSE-LOOP structure.
- Step 2 gains "Lead with coverage when verification reveals overlap": if `search_docs` / `get_schema` show overlap with existing primitives, the reply must open with what's already covered before anything else. Factually wrong premises (proposal extends a non-existent field) get a one-line correction first.
- Step 3 gains "Draft only after the caller has seen the coverage statement": when step 2 surfaces overlap or factual error, `draft_github_issue` is NOT called in the same turn as verification. Coverage-leading reply first, draft on confirmation.

## Why

Same-Addie-different-answers failure on 2026-05-01: Jeffrey Mayer (DanAds) drafted four RFCs with web-Addie, posted to Slack, Slack-Addie pushed back on each with spec citations. Both surfaces use the same rules — the rule itself was missing the load-bearing instruction. The existing rule listed "does the spec already handle this?" as one of four bullets to consider; it didn't say "if yes, lead with that before drafting."

## Validation

Eval at #3804 with `RFC_USE_LOCAL_PROMPT=1` (validates against this branch's rules, not deployed prod) at N=3 runs per scenario:

| Scenario        | Without rule (prod prompt) | With rule (this branch) |
|-----------------|----------------------------|-------------------------|
| CPQ pricing     | 0/3 — drafted on every run | **3/3 — no draft**      |
| TMP signals cap | varies — sometimes drafts  | **3/3 — no draft**      |
| Bilateral trust | varies                     | **3/3 — no draft**      |
| brand.json      | varies                     | **3/3 — no draft**      |
| **Total**       | inconsistent               | **12/12 runs, 0 premature drafts** |

Under the rule, `draft_github_issue` does not fire in the same turn as the verification on any of the 12 runs. The model leads with "most of this is already covered: pricing_options + buying_mode: refine + account" and offers to draft a narrower scope on confirmation — exactly the Slack-Addie behavior from Jeffrey's screenshot.

## Dependencies

Should land after #3804 (eval framework). The eval is the regression check that this rule edit holds up over time.

## Files

- `server/src/addie/rules/behaviors.md` — the rule edit
- `.changeset/addie-spec-feedback-coverage-rule.md` — empty changeset (non-protocol change)
- `static/schemas/source/index.json` — pre-existing main-branch hygiene fix the pre-push hook required (one-line `"published_version": "3.0.3"` added by `npm run build:schemas`)

## Test plan

- [ ] CI green
- [ ] Manual smoke: eval at `RFC_USE_LOCAL_PROMPT=1` shows 3/3 on CPQ at N=3
- [ ] After deploy, the same eval at default (prod prompt) should also show 3/3 on CPQ — confirms the rule is live