### PR TITLE
ci(release): push forward-merge branch before peter-evans runs (3.0.x backport)

### DIFF
--- a/.changeset/forward-merge-push-before-peter-evans.md
+++ b/.changeset/forward-merge-push-before-peter-evans.md
@@ -1,0 +1,8 @@
+---
+---
+
+`forward-merge-3.0.yml`: push the `forward-merge/3.0.x` branch to origin **before** `peter-evans/create-pull-request@v8` runs. Discovered when 3.0.4's forward-merge ran for real for the first time — auto-resolution succeeded ("Auto-resolution complete", `skip=false`), then peter-evans failed with `fatal: ambiguous argument 'origin/forward-merge/3.0.x': unknown revision or path not in the working tree`.
+
+The action's internal `git reset --hard origin/forward-merge/3.0.x` step assumes the remote-tracking branch exists. On a first run (or after a stuck-PR cleanup that deleted the remote branch), it doesn't. Adding an explicit `git push --force origin HEAD:refs/heads/forward-merge/3.0.x` after the merge resolution establishes the remote ref so peter-evans's reset has somewhere to point.
+
+This was the last gap in the auto-resolution chain — with this in place, 3.0.4 (and every subsequent VP cut) auto-creates the forward-merge PR without human intervention.

--- a/.github/workflows/forward-merge-3.0.yml
+++ b/.github/workflows/forward-merge-3.0.yml
@@ -236,6 +236,15 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
+            # Push the branch to origin BEFORE peter-evans runs.
+            # peter-evans/create-pull-request@v8 internally runs
+            # `git reset --hard origin/forward-merge/3.0.x` as part of
+            # its branch-update flow and fails with "ambiguous argument"
+            # when the remote ref doesn't exist yet (first run, or after
+            # `delete-branch: false` left no remote ref). Pushing here
+            # establishes the remote-tracking branch so peter-evans's
+            # reset has something to point at.
+            git push --force origin "HEAD:refs/heads/forward-merge/3.0.x"
           fi
 
       - name: Create or update pull request


### PR DESCRIPTION
Cherry-pick of #3818 (`eebc48b5d6`) to 3.0.x. The workflow YAML runs from the trigger ref's HEAD, so the peter-evans-push fix needs to be on 3.0.x for it to apply on pushes to 3.0.x.

After this lands, the next VP cut on 3.0.x (e.g. 3.0.5) will auto-create the forward-merge PR without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)