### PR TITLE
fix(compliance): scope requires_io_approval to guaranteed products in sales_guaranteed storyboard

### DIFF
--- a/.changeset/sales-guaranteed-fixture-and-narrative-clarification.md
+++ b/.changeset/sales-guaranteed-fixture-and-narrative-clarification.md
@@ -1,0 +1,9 @@
+---
+---
+
+Fix skill/storyboard contradiction in sales_guaranteed: add non-guaranteed fixture products
+and clarify that requires_io_approval is scoped to delivery_type: guaranteed creates only.
+The four shared seller scenarios (measurement_terms_rejected, pending_creatives_to_start,
+inventory_list_targeting, invalid_transitions) require synchronous creates against
+non-guaranteed products; without these fixtures a blind agent following the seller skill
+fails all four. Closes #3822.

--- a/static/compliance/source/specialisms/sales-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-guaranteed/index.yaml
@@ -40,6 +40,15 @@ narrative: |
   is modelled entirely at the A2A task layer; there is no interim "pending_approval" media buy
   status (that value only exists on Account.status, not MediaBuy.status).
 
+  The requires_io_approval capability is scoped to creates that reference products with
+  delivery_type: guaranteed (those in this storyboard's primary fixtures). Four of the
+  general seller scenarios included via requires_scenarios — measurement_terms_rejected,
+  pending_creatives_to_start, inventory_list_targeting, and invalid_transitions — use
+  open-ended product briefs and must complete creates synchronously, returning a media_buy_id
+  directly rather than a task envelope. This storyboard seeds non-guaranteed fixture products
+  so those four scenarios have a synchronous-create path available. A seller whose catalog
+  contains only guaranteed products will fail those four shared scenarios.
+
 agent:
   interaction_model: media_buy_seller
   capabilities:
@@ -65,6 +74,22 @@ prerequisites:
 
 fixtures:
   products:
+    # Non-guaranteed products listed first so open-brief get_products calls (used by
+    # requires_scenarios) resolve to products[0] as a non-guaranteed product, enabling
+    # synchronous creates. The four shared scenarios (measurement_terms_rejected,
+    # pending_creatives_to_start, inventory_list_targeting, invalid_transitions) capture
+    # products[0].product_id and must get a non-guaranteed ID to complete synchronously.
+    - product_id: "display_outdoor_non_guaranteed"
+      delivery_type: "non_guaranteed"
+      channels: ["display"]
+      format_ids:
+        - id: "display_300x250"
+    - product_id: "video_outdoor_non_guaranteed"
+      delivery_type: "non_guaranteed"
+      channels: ["video"]
+      format_ids:
+        - id: "video_30s"
+    # Guaranteed products used by the main storyboard phases (hardcoded in sample_requests).
     - product_id: "sports_preroll_q2_guaranteed"
       delivery_type: "guaranteed"
       channels: ["video"]
@@ -76,6 +101,16 @@ fixtures:
       format_ids:
         - id: "video_30s"
   pricing_options:
+    - product_id: "display_outdoor_non_guaranteed"
+      pricing_option_id: "cpm_display_non_guaranteed"
+      pricing_model: "cpm"
+      currency: "USD"
+      floor_price: 5.0
+    - product_id: "video_outdoor_non_guaranteed"
+      pricing_option_id: "cpm_video_non_guaranteed"
+      pricing_model: "cpm"
+      currency: "USD"
+      floor_price: 12.0
     - product_id: "sports_preroll_q2_guaranteed"
       pricing_option_id: "cpm_guaranteed_fixed"
       pricing_model: "cpm"

--- a/static/compliance/source/specialisms/sales-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-guaranteed/index.yaml
@@ -51,6 +51,15 @@ narrative: |
   (auction PG, retail SKU, quoted-rate) declare `supports_proposals: false`; full-service
   guaranteed sellers declare `true`.
 
+  The requires_io_approval capability is scoped to creates that reference products with
+  delivery_type: guaranteed (those in this storyboard's primary fixtures). Four of the
+  general seller scenarios included via requires_scenarios — measurement_terms_rejected,
+  pending_creatives_to_start, inventory_list_targeting, and invalid_transitions — use
+  open-ended product briefs and must complete creates synchronously, returning a media_buy_id
+  directly rather than a task envelope. This storyboard seeds non-guaranteed fixture products
+  so those four scenarios have a synchronous-create path available. A seller whose catalog
+  contains only guaranteed products will fail those four shared scenarios.
+
 agent:
   interaction_model: media_buy_seller
   capabilities:
@@ -76,6 +85,22 @@ prerequisites:
 
 fixtures:
   products:
+    # Non-guaranteed products listed first so open-brief get_products calls (used by
+    # requires_scenarios) resolve to products[0] as a non-guaranteed product, enabling
+    # synchronous creates. The four shared scenarios (measurement_terms_rejected,
+    # pending_creatives_to_start, inventory_list_targeting, invalid_transitions) capture
+    # products[0].product_id and must get a non-guaranteed ID to complete synchronously.
+    - product_id: "display_outdoor_non_guaranteed"
+      delivery_type: "non_guaranteed"
+      channels: ["display"]
+      format_ids:
+        - id: "display_300x250"
+    - product_id: "video_outdoor_non_guaranteed"
+      delivery_type: "non_guaranteed"
+      channels: ["video"]
+      format_ids:
+        - id: "video_30s"
+    # Guaranteed products used by the main storyboard phases (hardcoded in sample_requests).
     - product_id: "sports_preroll_q2_guaranteed"
       delivery_type: "guaranteed"
       channels: ["video"]
@@ -87,6 +112,16 @@ fixtures:
       format_ids:
         - id: "video_30s"
   pricing_options:
+    - product_id: "display_outdoor_non_guaranteed"
+      pricing_option_id: "cpm_display_non_guaranteed"
+      pricing_model: "cpm"
+      currency: "USD"
+      floor_price: 5.0
+    - product_id: "video_outdoor_non_guaranteed"
+      pricing_option_id: "cpm_video_non_guaranteed"
+      pricing_model: "cpm"
+      currency: "USD"
+      floor_price: 12.0
     - product_id: "sports_preroll_q2_guaranteed"
       pricing_option_id: "cpm_guaranteed_fixed"
       pricing_model: "cpm"


### PR DESCRIPTION
Refs #3822

The `sales_guaranteed` storyboard had a two-part defect reported in #3822: (1) the narrative did not clarify that `requires_io_approval` applies only to guaranteed-product creates, causing skill authors to treat it as a global flag and return task envelopes for every `create_media_buy`; (2) the fixture catalog contained only guaranteed products, so the four shared scenarios that capture `products[0]` from an open brief (`measurement_terms_rejected`, `pending_creatives_to_start`, `inventory_list_targeting`, `invalid_transitions`) would always resolve to a guaranteed product — hitting IO-approval even after the skill is corrected.

This PR fixes the storyboard side only. The primary fix (updating `skills/build-seller-agent/SKILL.md` line 102 in adcp-client to differentiate guaranteed-product creates from non-guaranteed ones) is a cross-repo change tracked in the triage comment on #3822.

**Non-breaking justification:** Purely additive — new fixture products and pricing options appended; narrative text extended. No existing step, validation, phase, or product removed or renamed. Existing conformant sellers unaffected.

**Changes:**
- Narrative: adds a paragraph naming the four scenarios that require synchronous `media_buy_id`, scoping `requires_io_approval` to `delivery_type: guaranteed` products
- Fixtures: adds `display_outdoor_non_guaranteed` and `video_outdoor_non_guaranteed` products with CPM floor pricing, listed **first** so open-brief `get_products` calls resolve `products[0]` to a non-guaranteed product

**Pre-PR review:**
- code-reviewer: approved — fixture structure matches `sales_non_guaranteed` convention; ordering blocker (non-guaranteed products must be first) caught and fixed pre-merge
- docs-expert: approved — narrative accuracy blocker (incorrect "resolve to" claim) caught and fixed; narrative now names the four specific scenarios and uses accurate scoping language

**Note (nit, not blocking):** `delivery_reporting` is also in `requires_scenarios` and has its own guaranteed-typed fixture products; its `create_media_buy` step implicitly expects synchronous `media_buy_id` (via `$context.media_buy_id` in the downstream `simulate_delivery` step). This is a pre-existing gap not introduced here, tracked separately.

> **Triage-managed PR.** This bot does not currently iterate on review comments or PR conversation threads (only on the source issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` → fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121) for context.

Session: https://claude.ai/code/session_01EfiPHRgFHWT2QSThmnkJoZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EfiPHRgFHWT2QSThmnkJoZ)_