### PR TITLE
docs(protocol): design principles + capabilities explorer

### DIFF
--- a/.changeset/protocol-design-principles.md
+++ b/.changeset/protocol-design-principles.md
@@ -1,0 +1,17 @@
+---
+---
+
+Add `docs/protocol/design-principles.mdx` (the meta-protocol — load-bearing
+principles behind AdCP's design with explicit "what this rules out" and
+"when you'd be right to push" clauses) and `docs/protocol/capabilities-explorer.mdx`
+(browsable view of the get_adcp_capabilities response schema with per-node
+"propose extension here" links pre-filled with the path). Surface
+spec-guidelines.md in nav. Demonstrate the "why this shape" callout pattern
+on `get_products` and `get_adcp_capabilities` task pages.
+
+The principles page names the surface contradictions we know about
+(`media_buy.execution.trusted_match` location, `axe_integrations` survival
+in v3, three top-level "things this agent does" lists, three signing-related
+top-level keys, the trust substrate gap to 4.0) — the principles are
+credible only to the extent we're honest about where the surface still
+violates them.

--- a/docs.json
+++ b/docs.json
@@ -101,6 +101,9 @@
                     ]
                   },
                   "docs/protocol/architecture",
+                  "docs/protocol/design-principles",
+                  "docs/protocol/capabilities-explorer",
+                  "docs/spec-guidelines",
                   "docs/protocol/required-tasks",
                   "docs/protocol/calling-an-agent",
                   "docs/protocol/format-references",

--- a/docs/media-buy/task-reference/get_products.mdx
+++ b/docs/media-buy/task-reference/get_products.mdx
@@ -7,6 +7,10 @@ testable: true
 
 Discover available advertising products based on campaign requirements using natural language briefs or structured filters.
 
+<Info>
+**Why this shape.** Targeting, pricing, and curation are folded into one round-trip — the brief drives discovery, the publisher curates against it, and `pricing_options` carry firm prices the buyer commits against via `pricing_option_id`. We rejected a separate `get_price_quote` step between products and buy creation: it splits one expert decision into two underspecified ones and breaks the brief→curation contract. Iteration is `buying_mode: "refine"` with a typed change array — not a new task. → [Design principle: the brief drives discovery](/docs/protocol/design-principles#3-the-brief-drives-discovery-targeting-is-an-input-not-a-step).
+</Info>
+
 **Authentication**: Optional (returns limited results without credentials)
 
 **Response Time**: ~60 seconds (AI inference with back-end systems)

--- a/docs/protocol/capabilities-explorer.mdx
+++ b/docs/protocol/capabilities-explorer.mdx
@@ -1,0 +1,245 @@
+---
+title: Capabilities explorer
+sidebarTitle: Capabilities explorer
+description: "Browsable view of the get_adcp_capabilities response schema — every top-level domain, every sub-namespace, with anchors and 'propose extension here' links so new flags land in the right home."
+"og:title": "AdCP — Capabilities explorer"
+---
+
+# Capabilities explorer
+
+This page renders the actual top-level shape of the [`get_adcp_capabilities`](/docs/protocol/get_adcp_capabilities) response so you can find the right place for a new capability before you propose it. The most common reason an extension RFC gets bounced is wrong-shape: the proposal puts a flag at a level that doesn't match where similar flags already live. Walk the tree first.
+
+If you're here to draft an RFC, the workflow is:
+
+1. Find the closest existing top-level domain for your flag below.
+2. Drill into that domain's sub-namespaces (`features`, `execution`, etc.).
+3. If your flag fits an existing sub-namespace, propose it there. Use the **propose extension here** link at the relevant node — it pre-fills the issue title with the path.
+4. If nothing fits, scroll to **Before proposing a new top-level key** at the bottom and answer the gate questions in your RFC body.
+
+The authoritative schema lives at [`static/schemas/source/protocol/get-adcp-capabilities-response.json`](https://github.com/adcontextprotocol/adcp/blob/main/static/schemas/source/protocol/get-adcp-capabilities-response.json). The tree below is curated to one level deep for the rich domains; for the full nested shape, read the schema. See also [Design principles — capabilities are commitments, declared under existing buckets](/docs/protocol/design-principles#4-capabilities-are-commitments-declared-under-existing-buckets).
+
+---
+
+## Top-level domains
+
+The 14 domains below are the entire top-level surface of `get_adcp_capabilities`. Every capability flag eventually nests under one of these. New top-level keys are extremely rare and should not be the first move — see the gate questions at the end of this page.
+
+### `adcp` — core protocol identity
+
+Version negotiation, idempotency contract, build identifier.
+
+- **`supported_versions`** — release-precision strings (e.g. `"3.0"`, `"3.1-beta"`). Authoritative for buyer-side release pinning.
+- **`major_versions`** — DEPRECATED in favor of `supported_versions`; sellers MUST keep emitting through 3.x.
+- **`build_version`** — full semver build identifier; advisory metadata for buyer-side incident triage.
+- **`idempotency`** — discriminated union (`IdempotencySupported` / `IdempotencyUnsupported`) declaring replay semantics. **A declaration here is a commitment** — sellers that declare `supported: true` are probed by the conformance runner.
+
+[Propose an extension to `adcp`](https://github.com/adcontextprotocol/adcp/issues/new?title=Extend+adcp+capability:+%3Cflag%3E&body=Schema+location:+%60.adcp%60%0AExisting+keys:+supported_versions,+major_versions,+build_version,+idempotency%0A%0A%23%23+Proposal%0A%0A...%0A%0A%23%23+Why+this+belongs+under+%60adcp%60+and+not+a+new+top-level+key%0A%0A...&labels=rfc,capabilities)
+
+---
+
+### `supported_protocols` — which AdCP protocols this agent implements
+
+Array of protocol names. Each value commits the agent to (a) implement those tools and (b) pass the baseline compliance storyboard at `/compliance/{version}/protocols/{protocol}/`.
+
+Valid values cover `media_buy`, `creative`, `signals`, `governance`, `sponsored_intelligence`, `brand`, `accounts`, `measurement` (in development).
+
+[Propose a new protocol to add to `supported_protocols`](https://github.com/adcontextprotocol/adcp/issues/new?title=Add+protocol+to+supported_protocols:+%3Cname%3E&body=%23%23+Proposal%0A%0A...%0A%0A%23%23+Compliance+storyboard+plan%0A%0AHow+will+the+baseline+conformance+suite+exercise+this+protocol?+...&labels=rfc,capabilities,new-protocol)
+
+---
+
+### `account` — account establishment and billing
+
+How accounts are negotiated; whether one is required before product discovery; what billing models are supported.
+
+- **`required_for_products`** — boolean. If true, `get_products` requires an established account.
+- **`authorization_endpoint`** — OAuth/auth URL for account negotiation.
+- **`require_operator_auth`** — declares whether operator-level authentication is required.
+- **`supported_billing`** — array of billing models (e.g. `prepaid`, `monthly_invoice`).
+- **`account_financials`** — what financial data the seller exposes (credit limits, current balance, etc.).
+- **`sandbox`** — sandbox-account capabilities.
+
+[Propose an extension to `account`](https://github.com/adcontextprotocol/adcp/issues/new?title=Extend+account+capability:+%3Cflag%3E&body=Schema+location:+%60.account%60&labels=rfc,capabilities)
+
+---
+
+### `media_buy` — media buying capabilities
+
+The largest domain. Sub-namespaces are where most media-buying flags belong.
+
+- **`features`** — boolean feature flags (e.g. `inline_creative_management`, `property_list_filtering`, `catalog_management`, `committed_metrics_supported`). **Most new media-buy capability flags belong here.**
+- **`execution`** — technical execution capabilities. Contains `trusted_match` (TMP), `creative_specs` (VAST/MRAID/VPAID/SIMID versions), `targeting` (geo / audience / device / temporal), `axe_integrations` (deprecated). See note in [Design principles — Where the surface doesn't yet follow these](/docs/protocol/design-principles#where-the-surface-doesnt-yet-follow-these-principles) about the `trusted_match` placement.
+- **`audience_targeting`** — declared audience-targeting capabilities.
+- **`content_standards`** — content-standards enforcement capabilities.
+- **`conversion_tracking`** — conversion-tracking capabilities.
+- **`offline_delivery_protocols`** — supported offline delivery protocols (broadcast trafficking, etc.).
+- **`portfolio`** — portfolio-management capabilities.
+- **`reporting_delivery_methods`** — how reporting is delivered.
+- **`supported_pricing_models`** — array (CPM, CPC, CPCV, CPP, fixed, etc.).
+
+[Propose a flag for `media_buy.features`](https://github.com/adcontextprotocol/adcp/issues/new?title=Add+media_buy+feature:+%3Cflag%3E&body=Schema+location:+%60.media_buy.features%60%0A%0A%23%23+Proposal%0A%0A...%0A%0A%23%23+Why+a+feature+flag+and+not+a+new+task%0A%0A...%0A%0A%23%23+Conformance+probe%0A%0AHow+can+a+buyer+verify+this+capability+is+actually+honored?+...&labels=rfc,capabilities)
+
+[Propose an extension to `media_buy.execution`](https://github.com/adcontextprotocol/adcp/issues/new?title=Extend+media_buy.execution:+%3Cflag%3E&body=Schema+location:+%60.media_buy.execution%60%0AExisting+sub-keys:+trusted_match,+creative_specs,+targeting&labels=rfc,capabilities)
+
+---
+
+### `signals` — audience and contextual data activation
+
+Authorization scope and feature flags for the signals domain.
+
+- **`data_provider_domains`** — array of domains this signals agent is authorized to resell. Buyers fetch each provider's `adagents.json` to verify.
+- **`features`** — boolean feature flags. Currently `catalog_signals` (structured signal_id references). **Additional signals capability flags belong here**, not in a new top-level key. (E.g., a `signal_enforcement_on_guaranteed` flag for direct-sold targeting belongs at `signals.features`, not under `media_buy.execution.trusted_match`.)
+
+[Propose a flag for `signals.features`](https://github.com/adcontextprotocol/adcp/issues/new?title=Add+signals+feature:+%3Cflag%3E&body=Schema+location:+%60.signals.features%60%0A%0A%23%23+Proposal%0A%0A...%0A%0A%23%23+Conformance+probe%0A%0A...&labels=rfc,capabilities,signals)
+
+---
+
+### `governance` — governance protocol capabilities
+
+Property and creative governance capabilities.
+
+- **`property_features`** — what the governance agent does with property lists.
+- **`creative_features`** — what the governance agent does for creative review.
+- **`aggregation_window_days`** — how long the agent aggregates governance events.
+
+[Propose an extension to `governance`](https://github.com/adcontextprotocol/adcp/issues/new?title=Extend+governance+capability:+%3Cflag%3E&body=Schema+location:+%60.governance%60&labels=rfc,capabilities,governance)
+
+---
+
+### `sponsored_intelligence` — conversational brand experiences
+
+For agents that handle SI sessions.
+
+- **`endpoint`** — SI endpoint URL.
+- **`brand_url`** — brand identity URL.
+- **`capabilities`** — SI-specific capabilities (commerce handoff, voice, UI components, etc.).
+
+[Propose an extension to `sponsored_intelligence`](https://github.com/adcontextprotocol/adcp/issues/new?title=Extend+sponsored_intelligence+capability:+%3Cflag%3E&body=Schema+location:+%60.sponsored_intelligence%60&labels=rfc,capabilities)
+
+---
+
+### `brand` — brand protocol capabilities
+
+For brand agents.
+
+- **`description`** — agent description.
+- **`available_uses`** — what the brand data is licensed for.
+- **`generation_providers`** — supported generation providers.
+- **`right_types`** — right types the agent grants.
+- **`rights`** — concrete rights this agent issues.
+
+[Propose an extension to `brand`](https://github.com/adcontextprotocol/adcp/issues/new?title=Extend+brand+capability:+%3Cflag%3E&body=Schema+location:+%60.brand%60&labels=rfc,capabilities)
+
+---
+
+### `creative` — creative protocol capabilities
+
+For creative agents.
+
+- **`has_creative_library`** — whether the agent maintains a creative library.
+- **`supports_compliance`** — creative compliance scanning.
+- **`supports_generation`** — generative-creative capabilities.
+- **`supports_transformation`** — creative transformation capabilities.
+
+[Propose an extension to `creative`](https://github.com/adcontextprotocol/adcp/issues/new?title=Extend+creative+capability:+%3Cflag%3E&body=Schema+location:+%60.creative%60&labels=rfc,capabilities,creative)
+
+---
+
+### `request_signing` — RFC 9421 HTTP Signatures for incoming requests
+
+Optional in 3.0; capability-advertised so counterparties can opt into signing selectively.
+
+- **`supported`** — boolean.
+- **`required_for`** — array of operations where signing is required.
+- **`supported_for`** — array of operations where signing is supported.
+- **`warn_for`** — array of operations where unsigned requests produce warnings.
+- **`covers_content_digest`** — whether signatures cover the request body digest.
+
+[Propose an extension to `request_signing`](https://github.com/adcontextprotocol/adcp/issues/new?title=Extend+request_signing+capability:+%3Cflag%3E&body=Schema+location:+%60.request_signing%60&labels=rfc,capabilities,security)
+
+---
+
+### `webhook_signing` — RFC 9421 signing for outbound webhooks
+
+Top-level peer of `request_signing`.
+
+- **`supported`** — boolean.
+- **`profile`** — signing profile name.
+- **`algorithms`** — supported signature algorithms.
+- **`legacy_hmac_fallback`** — whether HMAC fallback is supported for legacy receivers.
+
+[Propose an extension to `webhook_signing`](https://github.com/adcontextprotocol/adcp/issues/new?title=Extend+webhook_signing+capability:+%3Cflag%3E&body=Schema+location:+%60.webhook_signing%60&labels=rfc,capabilities,security)
+
+---
+
+### `identity` — operator identity posture
+
+Key-scoping and compromise-response controls. Advisory in 3.x; required in 4.0.
+
+- **`per_principal_key_isolation`** — whether each principal has an isolated key.
+- **`key_origins`** — declared key-management origins.
+- **`compromise_notification`** — notification posture for key compromise events.
+
+[Propose an extension to `identity`](https://github.com/adcontextprotocol/adcp/issues/new?title=Extend+identity+capability:+%3Cflag%3E&body=Schema+location:+%60.identity%60&labels=rfc,capabilities,security)
+
+---
+
+### `measurement` — measurement capabilities (in development)
+
+Quantitative metrics about ad delivery, exposure, or effectiveness.
+
+- **`metrics`** — array of metric definitions this agent emits.
+
+The protocol surface beyond capabilities discovery (reporting, attribution tasks) lands in subsequent minors.
+
+[Propose an extension to `measurement`](https://github.com/adcontextprotocol/adcp/issues/new?title=Extend+measurement+capability:+%3Cflag%3E&body=Schema+location:+%60.measurement%60&labels=rfc,capabilities,measurement)
+
+---
+
+### `compliance_testing` — deterministic test scenarios
+
+Declares the agent supports `comply_test_controller` and which scenarios are honored.
+
+- **`scenarios`** — array of compliance scenario IDs the agent supports.
+
+[Propose an extension to `compliance_testing`](https://github.com/adcontextprotocol/adcp/issues/new?title=Extend+compliance_testing+capability:+%3Cflag%3E&body=Schema+location:+%60.compliance_testing%60&labels=rfc,capabilities,compliance)
+
+---
+
+### `specialisms` — kebab-case specialty IDs
+
+Optional. Specialty compliance claims (e.g., `creative-generative`, `sales-non-guaranteed`). Values are kebab-case enum IDs registered with the working group.
+
+[Propose a new specialism](https://github.com/adcontextprotocol/adcp/issues/new?title=Add+specialism:+%3Ckebab-case-id%3E&body=%23%23+Specialism+ID%0A%0A%3Ckebab-case-id%3E%0A%0A%23%23+What+it+claims%0A%0A...%0A%0A%23%23+Conformance+criteria%0A%0AHow+do+we+verify+an+agent+actually+meets+this+claim?+...&labels=rfc,capabilities,specialism)
+
+---
+
+## Things-this-agent-does that aren't a domain
+
+Three top-level lists carry capability metadata that doesn't fit a single protocol domain. The shape inconsistency between them is on the open list ([Design principles — Where the surface doesn't yet follow these](/docs/protocol/design-principles#where-the-surface-doesnt-yet-follow-these-principles)).
+
+- **`extensions_supported`** — array of extension namespaces this agent populates (`ext.{namespace}`).
+- **`experimental_features`** — array of experimental surface IDs this agent implements (e.g. `trusted_match.core`).
+- **`compliance_testing`** — covered above.
+
+---
+
+## Before proposing a new top-level key
+
+If your flag genuinely doesn't fit any of the 14 domains above, open the RFC — but answer these gate questions in the body. Most reviewers expect them. RFCs that ignore them tend to bounce.
+
+1. **Which existing top-level domain is closest?** Name it. Explain why your flag *isn't* an extension to that domain's `features`, `execution`, or other sub-namespaces.
+2. **Why isn't this an `ext.{vendor}` extension?** Vendor-specific behavior belongs in vendor namespaces ([spec-guidelines on platform agnosticism](/docs/spec-guidelines#platform-agnosticism)). Why is your flag normative across all implementers?
+3. **What's the conformance probe?** A capability declaration is a commitment, not an advertisement. How does the conformance runner verify a seller that declares your flag actually honors it?
+4. **What does this rule out?** What proposals does adding this top-level key make easier — and what does it make harder for someone scanning the top level a year from now?
+
+These are the same questions reviewers will ask. Answering them in the RFC saves a round-trip.
+
+[Propose a new top-level capability key (use only after answering the gate questions)](https://github.com/adcontextprotocol/adcp/issues/new?title=Propose+new+top-level+capability+key:+%3Cname%3E&body=%23%23+Proposed+top-level+key%0A%0A%3Cname%3E%0A%0A%23%23+Gate+questions%0A%0A**1.+Which+existing+top-level+domain+is+closest+and+why+isn%27t+this+an+extension+there?**%0A%0A...%0A%0A**2.+Why+isn%27t+this+an+%60ext.%7Bvendor%7D%60+extension?**%0A%0A...%0A%0A**3.+What%27s+the+conformance+probe?**%0A%0A...%0A%0A**4.+What+does+this+rule+out?**%0A%0A...&labels=rfc,capabilities,new-top-level-key)
+
+---
+
+## Related
+
+- [Design principles](/docs/protocol/design-principles) — the reasoning behind the capability surface shape.
+- [`get_adcp_capabilities` task reference](/docs/protocol/get_adcp_capabilities) — the response schema as documented per-field.
+- [Specification Guidelines](/docs/spec-guidelines) — type naming, enum design, vendor-neutral rule.

--- a/docs/protocol/design-principles.mdx
+++ b/docs/protocol/design-principles.mdx
@@ -1,0 +1,148 @@
+---
+title: How AdCP is designed
+sidebarTitle: Design principles
+description: "The load-bearing principles behind AdCP's design — what they rule out, when you'd be right to push back, and where the surface doesn't yet follow them."
+"og:title": "AdCP — Design principles"
+---
+
+# How AdCP is designed
+
+You don't need to read this page to use AdCP. You do need to read it to extend it.
+
+This is the meta-protocol — the philosophical framework behind the calls we made. Each principle is a load-bearing decision that shows up the moment someone proposes "just add this one field." We've made these calls deliberately, and we revisit them deliberately. The goal here is to give contributors enough context to either propose something that fits the existing shape or to argue, with both feet on the ground, for changing the shape itself.
+
+Two principles bounce most RFCs that reach the working group: **the schema is the spec** and **compose before adding a task**. They sit first because they're load-bearing for the rest. Five supporting principles follow. A "where the surface doesn't yet follow these" section at the end names the contradictions we know about — the principles are credible only to the extent that we're honest about them.
+
+Each principle has the same structure: the rule, why we chose it, what it rules out, and the exception path — when pushing back on the principle is the right move.
+
+---
+
+## The two principles that bounce most RFCs
+
+### 1. The schema is the spec
+
+Documentation describes; schemas decide. When documentation and schemas diverge, schemas win. A proposal that extends a field or task that does not exist in the schema is making two claims at once — that a thing exists, and that it should grow — and reviewers will bounce it on the first claim alone.
+
+**Why we chose it.** Generated SDKs come from schemas, conformance tests come from schemas, the registry comes from schemas. A doc page can lag for a release and the protocol still works; a schema change ships everywhere. The schema is also the only place we can enforce the cross-language guarantees AdCP claims (TypeScript, Python, Go all generate cleanly from one source). See [Specification Guidelines — Philosophy](/docs/spec-guidelines#philosophy) for the canonical version of this rule.
+
+**What this rules out.** Proposing a `direct_sold_signals` flag inside a `trusted_match` capability object in [`get_adcp_capabilities`](/docs/protocol/get_adcp_capabilities) when the schema's actual top-level keys are `adcp`, `supported_protocols`, `account`, `media_buy`, `signals`, `governance`, `sponsored_intelligence`, `brand`, `creative`, `request_signing`, `webhook_signing`, `identity`, `compliance_testing`, and `specialisms`. There is no `trusted_match` top-level key — and the right shape for the proposed flag is `signals.features.signal_enforcement_on_guaranteed`, not a new bucket. Reviewers bounce the issue on the wrong-shape premise alone, before evaluating the underlying idea — which may be perfectly good.
+
+**When you'd be right to push.** When the schema genuinely lacks a place to put your proposal. State that as the first claim, propose the new schema location with a path, and then propose the field. Two clear claims beat one fuzzy one.
+
+→ Use the [Capabilities explorer](/docs/protocol/capabilities-explorer) before proposing a new flag. It walks the actual schema tree.
+
+---
+
+### 2. Compose with existing primitives before adding a new task
+
+Every new top-level task is a permanent surface every implementer eventually has to reason about, even the ones who don't use it. Before proposing one, the question to answer is: can this be expressed via the existing tasks plus their existing modes? If yes, the proposal is a documentation gap (or a missing field) — not a new task.
+
+**Why we chose it.** Tasks are the protocol's coordination cost. Adding a task is the most expensive thing a contributor can ask for, because it lands on every sales agent, every buyer agent, every SDK, every test suite, every conformance row. Fields and modes compose; tasks don't. A protocol that grows by adding tasks every release ages into something only its authors can hold in their head.
+
+**What this rules out.** Proposing a `get_price_quote` task between [`get_products`](/docs/media-buy/task-reference/get_products) and [`create_media_buy`](/docs/media-buy/task-reference/create_media_buy) — a configure-price-quote step where the buyer submits targeting and the seller returns a firm rate. Most of what that proposal asks for already exists: account-scoped rate cards via `account`, firm prices via `pricing_options`, the `pricing_option_id` lock at commit time, and `buying_mode: "refine"` for the iteration loop. The "new task" framing assumes targeting and pricing are missing from discovery; they aren't.
+
+**When you'd be right to push.** When no composition reaches the desired semantics — when the proposal demands a state transition or a counterparty role no existing task can carry. The bar is high and that's intentional. Bring evidence: which existing task you tried to extend, why the extension didn't work, what the new task adds that an extension can't.
+
+---
+
+## Five supporting principles
+
+### 3. The brief drives discovery; targeting is an input, not a step
+
+Targeting is what the buyer wants. It's not a downstream filter on a generic catalog — it's what the seller curates *against*. Buyers send a brief (or `wholesale + filters`) to [`get_products`](/docs/media-buy/task-reference/get_products); the seller returns products already shaped for that intent, with pricing already scoped to the buyer's account via the `account` parameter. Iteration happens through `buying_mode: "refine"` with a typed change array — the round-trip is folded into discovery, not bolted on afterward.
+
+**Why we chose it.** A brief is the natural unit of buyer intent. The publisher knows their inventory, their audience, and their rate card better than any external taxonomy. Curating against the brief lets the seller bring all of that to the response in one round-trip, which is also the round-trip that produces the price. Splitting targeting and pricing across two tasks turns one expert decision into two underspecified ones.
+
+**What this rules out.** A separate quote step between products and buy creation. (See principle 2 — the same RFC fails both filters.)
+
+**When you'd be right to push.** When pricing depends on flight dates and total budget that the buyer hasn't committed yet — seasonality, volume tiers, sell-through-rate-driven yield. Or when the seller wants to issue a time-bound firm rate (`valid_until`) before commitment, distinct from indicative pricing options. Or when buyers need an auditable explanation of what drove the price (a `rate_basis` field). Those three are real gaps, and they're extensions to `pricing_options` and the discovery flow — not a new task.
+
+→ See [Targeting](/docs/media-buy/advanced-topics/targeting) for the brief-first model.
+
+---
+
+### 4. Capabilities are commitments, declared under existing buckets
+
+Two things, one principle. **Where capabilities live** in the schema: under existing top-level domains (`signals`, `media_buy`, `creative`, `governance`), not in new top-level keys. **What declaring a capability means**: an enforceable contract, not an advertisement. If a sales agent declares `idempotency.supported: true`, the conformance suite probes it and the contract is testable. Declarations cost something to make.
+
+**Why we chose it.** Top-level keys are the most visible part of the capabilities surface. Each one is a category every implementer scans on every read. Sub-namespacing keeps related capabilities discoverable together (`signals.features.X` belongs near `signals.data_provider_domains`) and keeps the top level scannable. Adding a top-level key for one flag is like adding a department to handle one form. And declarations need to be load-bearing to be useful: a flag the protocol can't enforce or test is a wish, not a contract.
+
+**What this rules out.** "Add a `trusted_match` top-level capability key" for a flag about how signals interact with guaranteed line items. The flag belongs in `signals.features` — a `signal_enforcement_on_guaranteed: "enforced" | "best_effort" | "not_supported"` enum, not a new bucket. Also: declaring a capability you don't actually support, hoping no one probes it. The conformance runner will.
+
+**Reviewer test.** Did the proposal cite the actual top-level keys in the schema today, and explain why none of them is the right home? If the proposal can't answer that question, it's not ready.
+
+→ The [Capabilities explorer](/docs/protocol/capabilities-explorer) renders the existing tree.
+
+---
+
+### 5. Trust is bilateral and `/.well-known`-rooted
+
+Trust in AdCP is bilateral and verifiable, not blessed by a registry. Sellers declare authorized buyers via [`adagents.json`](/docs/governance/property/adagents); buyers declare brand identity via [`brand.json`](/docs/brand-protocol/brand-json) at `/.well-known/brand.json`. Either party can resolve and verify the other's declarations. The [Registry](/docs/registry) helps with discovery and resolution; it does not gate participation. Every discovery hop is an HTTP GET against a deterministic path — the model ads.txt and sellers.json got right, deliberately reused.
+
+**Why we chose it.** Every centralized trust authority eventually becomes a tax. ads.txt and sellers.json got the model right: declarations are public and machine-readable; verification is bilateral; the network discovers truth without a single gatekeeper deciding who counts. AdCP follows that pattern deliberately — adding a "well-known brand registry" or a "verified buyer" tier would re-create the exact ad tech tax structure the protocol is meant to replace.
+
+**What this rules out.** Proposals that frame brand verification as a centralized validation problem — "who decides which brands are well-known?", "should AAO verify brand.json submissions before allowing them in the registry?" The premise is the error: `/.well-known/` is a [URI convention from RFC 8615](https://datatracker.ietf.org/doc/html/rfc8615), not a quality signal. A `brand.json` at a domain proves only that whoever controls that domain published it. Trust is built by composing that proof with adagents.json, account-level commercial relationships, and (when needed) signed requests — not by a third party blessing the brand list.
+
+**When you'd be right to push.** When you have evidence of a trust failure that bilateral declarations *demonstrably can't* address — not "what if a fraud declares themselves," but "here's a class of fraud the bilateral model misses, here's the cost, here's the smallest amount of centralization that closes it." Trust extensions are accepted; trust centralization needs receipts. The unresolved question on the substrate (CDN takeovers, DNS games, stale `/.well-known/` crawls) is real — see [Trust & Security](/docs/trust) for what AdCP provides versus what it explicitly does not.
+
+---
+
+### 6. Privacy is layered, not uniform
+
+[Trusted Match Protocol](/docs/trusted-match) has *structural* privacy — separated code paths, schema prohibitions on combining identity with context, decorrelation that's independently verifiable. Every other domain has *contractual* privacy — the parties exchanging data are bound by the account's terms or the user's consent. These are different mechanisms with different guarantees, and proposals that mix them produce confused features.
+
+**Why we chose it.** Structural privacy is expensive — it constrains the schema, requires separated infrastructure, and limits what compositions are possible. We pay that cost in TMP because TMP runs at impression time across mixed buyer/seller boundaries, where contractual confidentiality can't reach. Outside TMP, parties have already established a commercial relationship; a contract is the right unit of trust. Pretending the two are interchangeable means either over-engineering the contractual cases or under-protecting the structural ones.
+
+**What this rules out.** Proposing a "TMP-verified direct-sold targeting" capability that assumes TMP's privacy guarantees apply to direct-sold ad-server decisioning. They don't — TMP wasn't designed as the GAM/FreeWheel decisioning hook, and saying "no ad server supports TMP for direct-sold" is true but slightly misleading because that's not the layer TMP operates at. The honest framing is different: AdCP has no protocol-level mechanism to declare whether a seller can enforce signal-based targeting on guaranteed line items. That's a `signals.features` flag plus a [`create_media_buy`](/docs/media-buy/task-reference/create_media_buy) validation rule — a contractual-disclosure feature, not a structural-privacy one.
+
+**When you'd be right to push.** When you have a cross-domain privacy claim and you can name which mechanism applies. "This is a contractual feature, here's what's in the contract" or "this is a structural feature, here's the schema-level prohibition that makes it work." Vague privacy improvements tend to land on neither and end up in the wrong place.
+
+→ See [Architecture — Privacy posture across domains](/docs/protocol/architecture#privacy-posture-across-domains) for the per-domain mechanism table.
+
+---
+
+### 7. The protocol exposes seams; deployers wire decisions
+
+AdCP defines what fields exist and what guarantees the protocol makes about them. It does not define how a deployer's policy must be enforced, how a governance agent must decide, or what counts as a "good" buyer. This stance shows up in three places, and they share a single posture: **the protocol is realistic about how decisions actually happen — distributed across parties, asynchronous in time, human-checkable in process.**
+
+- *Capabilities are declared, not gated.* `check_governance` is a seam, not an enforcer. A seller that hasn't configured a governance agent will not call it; the protocol doesn't prevent a non-conformant seller from transacting. Schema-level enforcement exists but is rare and named (`fair_housing`, `fair_lending`, `fair_employment` in 3.0); the default is exposure, not coercion.
+- *Async is the default; sync is the optimization.* Every mutating task has `*-async-response-{submitted,working,input-required}.json` siblings. A protocol that pretends every operation is synchronous and atomic is one that breaks the moment a real workflow lands.
+- *Human review is architectural, not exceptional.* Any mutation can be taken async for human approval via the [task lifecycle](/docs/building/implementation/task-lifecycle); campaign governance provides a declarative buyer-side review channel. HITL composes with everything else — audit logs, governance checks, async responses — rather than being a special case bolted onto certain tasks.
+
+A related invariant lives at the account boundary: **account ownership, not creation surface, determines visibility.** Buys created outside AdCP still belong to the account they fall under, and surface in account-scoped queries. This prevents the shadow-ledger pattern that breaks every "API on top of an ad server."
+
+**Why we chose it.** A protocol that ships policy is a platform with extra steps. The credibility of an open standard is exactly its restraint about what it tries to decide. Deployer policy is also where context-specific judgment belongs — what's a brand-safety violation in one vertical is fine in another, and AdCP can't carry that nuance without picking sides.
+
+**What this rules out.** "The protocol should reject buys that don't match capability X." Most of the time the right answer is "the protocol should make capability X visible, and the deployer rejects the buy." Also: framing autonomy and oversight as opposites — "for agentic to truly work, X must be automated end-to-end." For most regulated and high-stakes operations, that's not what we want, and it's not what the protocol assumes.
+
+**When you'd be right to push.** When the asymmetry is bad enough that a per-deployer policy doesn't solve the coordination problem — when buyers and sellers can't economically agree on enforcement without a protocol-level rule. Schema-level enforcement is rare and earned; argue for it when you have it, not as the first move.
+
+→ See [Trust & Security — Governance](/docs/trust#governance) for what AdCP provides versus what it explicitly does not, and [Governance — Embedded human judgment](/docs/governance/embedded-human-judgment) for how HITL surfaces in the protocol.
+
+---
+
+## Where the surface doesn't yet follow these principles
+
+The principles are credible to the extent we name where the surface still violates them. These are known and tracked.
+
+**`media_buy.execution.trusted_match` (principle 4).** The capabilities schema places TMP-related flags inside `media_buy.execution.trusted_match`, while the architecture page treats TMP as a peer transaction domain alongside Media Buy, Creative, and Signals. A reviewer using these principles to evaluate proposals lands in conflicting answers about where TMP-shaped flags belong. The schema sub-namespacing was right (per principle 4); the parent location is the open question. RFCs proposing changes to TMP capability declarations should expect this to be on the table.
+
+**`axe_integrations` and `axe_include_segment` / `axe_exclude_segment` (principles 1 and the [vendor-neutral rule in spec-guidelines](/docs/spec-guidelines#platform-agnosticism)).** These survive in the v3 schema as normative fields. AXE is a Scope3-originated brand. By the spec-guidelines test, these should have moved to `ext.axe` or replaced cleanly by `trusted_match` before 3.0 GA. They reflect a deprecation in progress, not a stable shape — proposals that build on these fields should expect them to be moved.
+
+**Three top-level keys for "things this agent does that aren't a domain" (principle 4).** `compliance_testing`, `experimental_features`, and `extensions_supported` each carry related-but-shaped-differently capability metadata at the top level. A reviewer would ask why these aren't unified.
+
+**Three signing-related top-level keys (principle 4).** `request_signing`, `webhook_signing`, and `identity` (operator JWKS) are all signing infrastructure metadata. Three top-level keys for one concern is exactly the "scannable top level" cost the principle warns about.
+
+**The trust substrate (principle 5).** Trust in 3.x is trust-on-first-use, rooted in each counterparty's `/.well-known/` + DNS + CDN. Key transparency is deferred to 4.0. ads.txt and sellers.json have been gamed by exactly this attack class for years. The principle is right; the substrate isn't yet what the principle deserves. See [Trust & Security](/docs/trust) for the explicit gap statement.
+
+These are the surface contradictions a sharp third-party reviewer flags on a first read. The honest answer is that some are deprecation in progress, some are unresolved, and at least one (the trust substrate) is the load-bearing 4.0 work. Naming them here keeps the principles credible.
+
+---
+
+## How to use this page
+
+If you're drafting an RFC, work through the principles before you write the title. Most proposals that get bounced get bounced on one of the first two — proposing a field that doesn't exist (principle 1) or proposing a new task for a behavior already expressible via existing tasks plus modes (principle 2). The [Capabilities explorer](/docs/protocol/capabilities-explorer) renders the actual schema tree; check it before you propose a new top-level key.
+
+If you're reviewing an RFC, the principles double as a triage filter. A proposal that names which principle it's pushing back on, and why, is doing the work; a proposal that doesn't recognize a principle applies usually needs a coverage-leading reply before any drafting happens.
+
+The principles aren't immutable. Each one was chosen against a specific trade-off, and each is up for renegotiation when the trade-off shifts. But the renegotiation is the work of an RFC, not the side effect of one — argue for changing the rule explicitly, with the cost of the change named, before proposing the change that depends on it.

--- a/docs/protocol/get_adcp_capabilities.mdx
+++ b/docs/protocol/get_adcp_capabilities.mdx
@@ -7,6 +7,10 @@ testable: false
 
 Discover a seller's protocol support and capabilities across all AdCP protocols. This is the first call a buyer should make to understand what a seller supports.
 
+<Info>
+**Why this shape.** Capabilities are organized into ~14 top-level domain keys (one per protocol plus identity and signing infrastructure), with feature flags nested under each domain's `features`/`execution`/etc. sub-namespace. We rejected a flat capability list — it forces every implementer to scan an unbounded surface, and it removes the discoverability that comes from related flags sitting next to each other. New capability flags belong under existing domains, not in new top-level keys; declarations are commitments, not advertisements (the conformance runner probes them). → [Capabilities explorer](/docs/protocol/capabilities-explorer) walks the tree before you propose. → [Design principle: capabilities are commitments](/docs/protocol/design-principles#4-capabilities-are-commitments-declared-under-existing-buckets).
+</Info>
+
 **Response Time**: ~2 seconds (configuration lookup)
 
 **Purpose**:

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -1674,5 +1674,6 @@
       "description": "Java validation example",
       "code": "// Use everit-org/json-schema or similar library"
     }
-  ]
+  ],
+  "published_version": "3.0.3"
 }


### PR DESCRIPTION
## Summary

Adds two new pages and a callout pattern that together close the structural reason wrong-shape RFCs land in the working group.

- **`docs/protocol/design-principles.mdx`** — the meta-protocol page contributors and reviewers need to make and evaluate sound RFCs. Seven load-bearing principles. Each one: rule / why / what this rules out / when you'd be right to push. Honest about where the surface still violates them.
- **`docs/protocol/capabilities-explorer.mdx`** — browsable view of the `get_adcp_capabilities` response schema, walking every top-level domain to one sub-namespace deep, with per-node "propose extension here" GitHub issue links that pre-fill the schema path. Plus gate questions before proposing a new top-level key.
- **"Why this shape" callout** demonstrated on `get_products` and `get_adcp_capabilities` — three sentences citing the principle and the rejected alternative, at the top of the task reference. Pattern to roll out across all task pages.
- **`docs/spec-guidelines.md`** surfaced in the Protocol nav so the cross-links from the principles page resolve.

## Why

Origin: a four-RFC thread on 2026-05-01 where Jeffrey Mayer (DanAds) drafted CPQ pricing, TMP direct-sold signals, bilateral trust, and brand.json verification proposals — each of which got rebuffed in Slack on a wrong-shape premise (proposing a field that doesn't exist; proposing a new task for a behavior already expressible via existing tasks plus modes; framing trust as a centralization problem when the protocol's stance is bilateral). The pattern wasn't ignorance — the philosophy these proposals were missing was distributed across `trust.mdx`, `architecture.mdx`, `targeting.mdx`, and `spec-guidelines.md`, with no single place a contributor would land.

A four-agent third-party review of the protocol surface (ad-tech-protocol-expert, adtech-product-expert, docs-expert, dx-expert) converged on:
1. The design philosophy is unevenly legible — gold-standard rationale-at-the-point-of-friction in a few pages, none on most task references.
2. The single biggest structural reason wrong-shape RFCs happen: nested feature flags are private details of one schema file, while top-level keys get named everywhere. Proposals naturally land at the level the surface makes visible.
3. The principles page alone won't load-bear — it needs the capabilities-explorer (so the nested surface is as visible as the top level) and the per-task callout (so philosophy meets contributors at the point of friction).

## What's in scope vs. out of scope

**In scope:**
- The principles page, the capabilities explorer, two demo callouts.
- Naming five surface contradictions explicitly (`trusted_match` placement, `axe_integrations`, three top-level "things this agent does" lists, three signing-related top-level keys, the trust substrate gap to 4.0).

**Out of scope (followups):**
- Rolling the "why this shape" callout across all ~30 task reference pages — pattern is demonstrated; rollout is a sweep PR.
- Auto-generating the capabilities-explorer from the schema — current version is hand-curated to one level deep. If the schema sub-namespacing changes, the page needs an update.
- Resolving the named contradictions — those are RFCs in their own right (the page makes them explicit so they land in the queue).

## Test plan

- [x] `npm run test:docs-nav` — passes
- [ ] Mintlify preview renders both new pages
- [ ] Cross-links from design-principles to capabilities-explorer + spec-guidelines + per-task pages resolve
- [ ] CI green

## Files

- `docs/protocol/design-principles.mdx` (new)
- `docs/protocol/capabilities-explorer.mdx` (new)
- `docs/protocol/get_adcp_capabilities.mdx` (callout)
- `docs/media-buy/task-reference/get_products.mdx` (callout)
- `docs.json` (nav: principles + explorer + spec-guidelines surfaced)
- `.changeset/protocol-design-principles.md` (empty)
- `static/schemas/source/index.json` (pre-existing main hygiene fix the verify-version-sync hook required)