### PR TITLE
fix(billing): /sync Stripe expansion depth + observable error logging

### DIFF
--- a/.changeset/sync-stripe-expand-depth-fix.md
+++ b/.changeset/sync-stripe-expand-depth-fix.md
@@ -1,0 +1,10 @@
+---
+---
+
+Fix `/api/admin/accounts/:orgId/sync` — Stripe expansion depth + observable error logging.
+
+Hotfix on top of #3829: I asked Stripe to expand `subscriptions.data.items.data.price.product` on `customers.retrieve`, which is 6 levels deep and exceeds Stripe's 4-level expansion limit. Every /sync call against an org with a Stripe customer threw and returned a generic "Failed to sync from Stripe" with no log line.
+
+- Drop the deep expand on `customers.retrieve` (just confirms the customer isn't deleted).
+- Fetch subscriptions separately via `stripe.subscriptions.list({ expand: ['data.items.data.price.product'] })` — only 4 levels deep from the subscriptions resource, within Stripe's limit. The expansion is what makes `isMembershipSub`'s metadata fallback work for founding-era prices.
+- Log the actual error on the catch path so the next regression like this surfaces in admin logs instead of being invisible.

--- a/server/src/routes/admin/accounts-billing.ts
+++ b/server/src/routes/admin/accounts-billing.ts
@@ -134,15 +134,13 @@ export function setupAccountsBillingRoutes(
         if (org.stripe_customer_id) {
           if (stripe) {
             try {
-              // Expand the price's product so isMembershipSub can fall back
-              // to product metadata (`category=membership`) for founding-era
-              // prices that lack the aao_membership_ lookup_key convention.
-              const customer = await stripe.customers.retrieve(
-                org.stripe_customer_id,
-                {
-                  expand: ["subscriptions.data.items.data.price.product"],
-                }
-              );
+              // First, confirm the customer exists / isn't deleted. We
+              // intentionally don't expand subscriptions here — pushing
+              // `subscriptions.data.items.data.price.product` through
+              // `customers.retrieve` exceeds Stripe's 4-level expansion
+              // depth and the call throws (May 2026 — broke /sync for
+              // every org until the depth was reduced).
+              const customer = await stripe.customers.retrieve(org.stripe_customer_id);
 
               if (customer.deleted) {
                 syncResults.stripe = {
@@ -150,7 +148,18 @@ export function setupAccountsBillingRoutes(
                   error: "Customer has been deleted",
                 };
               } else {
-                const subscriptions = (customer as Stripe.Customer).subscriptions;
+                // Fetch subscriptions separately so we can expand
+                // `data.items.data.price.product` — that path is only 4
+                // levels deep from `subscriptions.list`, within Stripe's
+                // limit. The expansion is what makes `isMembershipSub`'s
+                // metadata fallback work for founding-era prices that
+                // lack the aao_membership_ lookup_key convention.
+                const subsResult = await stripe.subscriptions.list({
+                  customer: org.stripe_customer_id,
+                  status: 'all',
+                  limit: 10,
+                  expand: ['data.items.data.price.product'],
+                });
 
                 // Filter to membership subs before picking. A customer with a
                 // non-membership sub (one-off products, future ancillary subs)
@@ -159,9 +168,7 @@ export function setupAccountsBillingRoutes(
                 // guarantee ordering of `subscriptions.data`. Falls through to
                 // the invoice-fallback branch below when no membership sub is
                 // found, preserving prior behavior for invoice-billed orgs.
-                const subscription = subscriptions
-                  ? pickMembershipSub(subscriptions.data)
-                  : null;
+                const subscription = pickMembershipSub(subsResult.data);
 
                 if (subscription) {
                   // Use the canonical writer so /sync, the webhook handler,
@@ -420,6 +427,13 @@ export function setupAccountsBillingRoutes(
                 }
               }
             } catch (error) {
+              // Log the actual error so future regressions like the May 2026
+              // 4-level-expand-depth issue surface in admin logs instead of
+              // silently returning a generic message.
+              logger.error(
+                { err: error, orgId, customerId: org.stripe_customer_id },
+                "Failed to sync from Stripe",
+              );
               syncResults.stripe = {
                 success: false,
                 error: "Failed to sync from Stripe",

--- a/server/tests/integration/admin-sync-revenue-backfill.test.ts
+++ b/server/tests/integration/admin-sync-revenue-backfill.test.ts
@@ -53,34 +53,46 @@ const mocks = vi.hoisted(() => {
     for (const item of items) yield item;
   }
 
+  // Shared sub fixture used by both customers.retrieve (legacy callsites)
+  // and subscriptions.list (post-#3850 /sync uses this to expand
+  // price.product for the metadata-fallback path).
+  const FAKE_SUB = {
+    id: 'sub_backfill_test_001',
+    status: 'active',
+    current_period_end: Math.floor(Date.now() / 1000) + 86400 * 365,
+    canceled_at: null,
+    items: {
+      data: [{
+        price: {
+          unit_amount: 250000,
+          currency: 'usd',
+          recurring: { interval: 'year' },
+          // /sync filters to membership subs by lookup_key prefix
+          // (`aao_membership_*` / `aao_invoice_*`) or product
+          // metadata.category=membership for founding-era prices.
+          lookup_key: 'aao_membership_professional_250',
+          product: 'prod_backfill_test_001',
+        },
+      }],
+    },
+  };
+
   return {
     FAKE_INVOICE,
+    FAKE_SUB,
     mockInvoicesList: vi.fn().mockImplementation(() => fakeInvoiceIterator([FAKE_INVOICE])),
     mockCustomersRetrieve: vi.fn().mockResolvedValue({
       id: 'cus_test_backfill',
       deleted: false,
-      subscriptions: {
-        data: [{
-          id: 'sub_backfill_test_001',
-          status: 'active',
-          current_period_end: Math.floor(Date.now() / 1000) + 86400 * 365,
-          canceled_at: null,
-          items: {
-            data: [{
-              price: {
-                unit_amount: 250000,
-                currency: 'usd',
-                recurring: { interval: 'year' },
-                // /sync filters to membership subs by lookup_key prefix
-                // (`aao_membership_*` / `aao_invoice_*`) so a non-membership
-                // sub doesn't overwrite a paying member's row. Real Stripe
-                // membership prices always carry a lookup_key.
-                lookup_key: 'aao_membership_professional_250',
-              },
-            }],
-          },
-        }],
-      },
+      subscriptions: { data: [FAKE_SUB] },
+    }),
+    // Post-#3850: /sync fetches subscriptions separately so it can expand
+    // price.product 4 levels deep without exceeding Stripe's customer-
+    // retrieve depth limit. Mock returns a list-shaped response.
+    mockSubscriptionsList: vi.fn().mockResolvedValue({
+      data: [FAKE_SUB],
+      has_more: false,
+      object: 'list',
     }),
     mockProductsRetrieve: vi.fn().mockResolvedValue({
       id: 'prod_backfill_test_001',
@@ -89,12 +101,13 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-const { FAKE_INVOICE, mockInvoicesList, mockCustomersRetrieve, mockProductsRetrieve } = mocks;
+const { FAKE_INVOICE, mockInvoicesList, mockCustomersRetrieve, mockSubscriptionsList, mockProductsRetrieve } = mocks;
 
 vi.mock('../../src/billing/stripe-client.js', () => ({
   stripe: {
     customers: { retrieve: mocks.mockCustomersRetrieve },
     invoices: { list: mocks.mockInvoicesList },
+    subscriptions: { list: mocks.mockSubscriptionsList },
     products: { retrieve: mocks.mockProductsRetrieve },
     webhooks: {
       constructEvent: vi.fn().mockImplementation((body: any) => {


### PR DESCRIPTION
## Summary

Hotfix on top of #3829. I asked Stripe to expand `subscriptions.data.items.data.price.product` on `customers.retrieve`, which is 6 levels deep and exceeds Stripe's 4-level expansion limit. Every /sync call against an org with a Stripe customer threw and returned a generic "Failed to sync from Stripe" with no log line — the regression was invisible.

Caught after merging #3829 when re-running /sync against Adzymic returned `success: false`.

## What changed

- **Drop the deep expand on `customers.retrieve`** — that call now just confirms the customer isn't deleted.
- **Fetch subscriptions separately** via `stripe.subscriptions.list({ customer, expand: ['data.items.data.price.product'] })`. That path is only 4 levels deep from the subscriptions resource, within Stripe's limit. The expansion is what makes `isMembershipSub`'s metadata fallback work for founding-era prices.
- **Log the actual error** on the /sync catch path so the next regression like this surfaces in admin logs.

## Test plan

- [x] `npm run typecheck` clean
- [x] Precommit hook (full unit suite + typecheck + dynamic imports) passed
- [ ] After merge: re-run /sync against Adzymic — row should now show populated `stripe_subscription_id`, `subscription_price_lookup_key`, `membership_tier`
- [ ] After merge: hit `GET /api/admin/integrity/check/every-entitled-org-has-resolvable-tier` to confirm Adzymic clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)