### PR TITLE
fix(billing): drop over-deep Stripe expand in /sync, fetch product per-sub

### DIFF
--- a/.changeset/sync-product-fetch-fallback.md
+++ b/.changeset/sync-product-fetch-fallback.md
@@ -1,0 +1,10 @@
+---
+---
+
+Fix /sync founding-cohort recovery — drop over-deep Stripe expand, fetch product per-sub.
+
+Hotfix on top of #3850. The previous attempt expanded `data.items.data.price.product` on `subscriptions.list`, which is 5 levels deep and still over Stripe's 4-level expansion limit. /sync continued to fail for every org.
+
+New approach: list subs without product expansion (the `lookup_key` fast path is enough for the modern cohort), and only when no sub has a recognized lookup_key, fall back to retrieving the product per candidate via `stripe.products.retrieve` to check `metadata.category=membership`. Founding-era subs (Adzymic, Advertible, Bidcliq, Equativ — May 2026) recover through this path; modern subs cost zero extra round-trips.
+
+New `pickMembershipSubWithProductFetch` async helper. Sync `pickMembershipSub` is unchanged for callers (integrity invariants) that walk every sub on the account and can't afford per-sub Stripe round-trips.

--- a/server/src/billing/membership-prices.ts
+++ b/server/src/billing/membership-prices.ts
@@ -74,3 +74,47 @@ export function pickMembershipSub(subscriptions: readonly Stripe.Subscription[])
   if (memberships.length === 0) return null;
   return memberships.find((s) => s.status === 'active') ?? memberships[0];
 }
+
+/**
+ * Async picker that falls back to a per-product metadata fetch when
+ * `lookup_key` doesn't match. Founding-era subs lack the lookup_key
+ * convention, but the path Stripe needs to expand for product metadata
+ * (`subscriptions.data.items.data.price.product`) exceeds the 4-level
+ * expansion limit on `subscriptions.list`. So when the fast lookup_key
+ * pass yields nothing, fall back to retrieving the product for each
+ * candidate sub with one extra round-trip per non-matching sub.
+ *
+ * Synchronous `pickMembershipSub` remains the right call for invariants
+ * that walk every sub on the account (cheap by lookup_key, no per-sub
+ * fetches at scale). This async variant is for the admin `/sync` path
+ * where we want to repair a single org's row.
+ */
+export async function pickMembershipSubWithProductFetch(
+  subscriptions: readonly Stripe.Subscription[],
+  fetchProduct: (productId: string) => Promise<Stripe.Product | Stripe.DeletedProduct>,
+): Promise<Stripe.Subscription | null> {
+  const fast = pickMembershipSub(subscriptions);
+  if (fast) return fast;
+
+  // Fall back to product-metadata classification on subs whose price
+  // has a `product` id but no membership lookup_key.
+  const candidates: Stripe.Subscription[] = [];
+  for (const sub of subscriptions) {
+    const price = sub.items.data[0]?.price;
+    if (!price) continue;
+    const productId = typeof price.product === 'string' ? price.product : null;
+    if (!productId) continue;
+    try {
+      const product = await fetchProduct(productId);
+      if (isMembershipProductByMetadata(product)) {
+        candidates.push(sub);
+      }
+    } catch {
+      // Skip a sub whose product can't be retrieved; the lookup-key path
+      // already returned nothing for it. We don't want one bad fetch to
+      // tank the whole sync.
+    }
+  }
+  if (candidates.length === 0) return null;
+  return candidates.find((s) => s.status === 'active') ?? candidates[0];
+}

--- a/server/src/routes/admin/accounts-billing.ts
+++ b/server/src/routes/admin/accounts-billing.ts
@@ -19,7 +19,7 @@ import {
   buildSubscriptionUpdate,
 } from "../../db/organization-db.js";
 import { stripe } from "../../billing/stripe-client.js";
-import { pickMembershipSub } from "../../billing/membership-prices.js";
+import { pickMembershipSubWithProductFetch } from "../../billing/membership-prices.js";
 
 const logger = createLogger("admin-accounts-billing");
 
@@ -134,12 +134,11 @@ export function setupAccountsBillingRoutes(
         if (org.stripe_customer_id) {
           if (stripe) {
             try {
-              // First, confirm the customer exists / isn't deleted. We
-              // intentionally don't expand subscriptions here — pushing
-              // `subscriptions.data.items.data.price.product` through
-              // `customers.retrieve` exceeds Stripe's 4-level expansion
-              // depth and the call throws (May 2026 — broke /sync for
-              // every org until the depth was reduced).
+              // First, confirm the customer exists / isn't deleted. Don't
+              // ask Stripe to expand subscriptions deeply on this call —
+              // `subscriptions.data.items.data.price.product` is 6 levels
+              // deep and exceeds Stripe's 4-level expansion limit (May
+              // 2026: that broke /sync for every org).
               const customer = await stripe.customers.retrieve(org.stripe_customer_id);
 
               if (customer.deleted) {
@@ -148,17 +147,18 @@ export function setupAccountsBillingRoutes(
                   error: "Customer has been deleted",
                 };
               } else {
-                // Fetch subscriptions separately so we can expand
-                // `data.items.data.price.product` — that path is only 4
-                // levels deep from `subscriptions.list`, within Stripe's
-                // limit. The expansion is what makes `isMembershipSub`'s
-                // metadata fallback work for founding-era prices that
-                // lack the aao_membership_ lookup_key convention.
+                // List subs without product expansion (the price object
+                // comes back inline with lookup_key/unit_amount/etc., which
+                // is enough for the lookup_key fast path). For
+                // founding-era subs that lack the aao_membership_ prefix,
+                // pickMembershipSubWithProductFetch retrieves the product
+                // separately to check `metadata.category=membership` —
+                // one extra round-trip per non-matching candidate, which
+                // /sync (a manual admin action) can afford.
                 const subsResult = await stripe.subscriptions.list({
                   customer: org.stripe_customer_id,
                   status: 'all',
                   limit: 10,
-                  expand: ['data.items.data.price.product'],
                 });
 
                 // Filter to membership subs before picking. A customer with a
@@ -168,7 +168,13 @@ export function setupAccountsBillingRoutes(
                 // guarantee ordering of `subscriptions.data`. Falls through to
                 // the invoice-fallback branch below when no membership sub is
                 // found, preserving prior behavior for invoice-billed orgs.
-                const subscription = pickMembershipSub(subsResult.data);
+                // `stripe` is non-null inside this branch (guarded above)
+                // but TS narrowing doesn't carry through the closure.
+                const stripeClient = stripe;
+                const subscription = await pickMembershipSubWithProductFetch(
+                  subsResult.data,
+                  (productId) => stripeClient.products.retrieve(productId),
+                );
 
                 if (subscription) {
                   // Use the canonical writer so /sync, the webhook handler,

--- a/server/tests/integration/admin-sync-revenue-backfill.test.ts
+++ b/server/tests/integration/admin-sync-revenue-backfill.test.ts
@@ -54,8 +54,7 @@ const mocks = vi.hoisted(() => {
   }
 
   // Shared sub fixture used by both customers.retrieve (legacy callsites)
-  // and subscriptions.list (post-#3850 /sync uses this to expand
-  // price.product for the metadata-fallback path).
+  // and subscriptions.list (post-#3850 /sync uses subscriptions.list).
   const FAKE_SUB = {
     id: 'sub_backfill_test_001',
     status: 'active',
@@ -68,8 +67,9 @@ const mocks = vi.hoisted(() => {
           currency: 'usd',
           recurring: { interval: 'year' },
           // /sync filters to membership subs by lookup_key prefix
-          // (`aao_membership_*` / `aao_invoice_*`) or product
-          // metadata.category=membership for founding-era prices.
+          // (`aao_membership_*` / `aao_invoice_*`) — fast path. Founding-
+          // era subs lack the lookup_key and fall through to a product-
+          // metadata fetch via stripe.products.retrieve.
           lookup_key: 'aao_membership_professional_250',
           product: 'prod_backfill_test_001',
         },
@@ -86,9 +86,9 @@ const mocks = vi.hoisted(() => {
       deleted: false,
       subscriptions: { data: [FAKE_SUB] },
     }),
-    // Post-#3850: /sync fetches subscriptions separately so it can expand
-    // price.product 4 levels deep without exceeding Stripe's customer-
-    // retrieve depth limit. Mock returns a list-shaped response.
+    // /sync fetches subs separately. No deep expand — products are
+    // fetched per-sub via stripe.products.retrieve when the lookup_key
+    // path doesn't match (founding-era fallback).
     mockSubscriptionsList: vi.fn().mockResolvedValue({
       data: [FAKE_SUB],
       has_more: false,
@@ -97,6 +97,7 @@ const mocks = vi.hoisted(() => {
     mockProductsRetrieve: vi.fn().mockResolvedValue({
       id: 'prod_backfill_test_001',
       name: 'Pinnacle Media Annual Plan',
+      metadata: { category: 'membership' },
     }),
   };
 });

--- a/server/tests/unit/billing/membership-prices.test.ts
+++ b/server/tests/unit/billing/membership-prices.test.ts
@@ -5,13 +5,14 @@
  * pattern that picks the wrong sub when a customer has a non-membership
  * sub stacked alongside a real membership.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type Stripe from 'stripe';
 import {
   isMembershipLookupKey,
   isMembershipProductByMetadata,
   isMembershipSub,
   pickMembershipSub,
+  pickMembershipSubWithProductFetch,
 } from '../../../src/billing/membership-prices.js';
 
 function fakeSub(overrides: {
@@ -169,5 +170,81 @@ describe('pickMembershipSub', () => {
       }),
     ];
     expect(pickMembershipSub(subs)?.id).toBe('sub_founding');
+  });
+});
+
+describe('pickMembershipSubWithProductFetch', () => {
+  it('returns the lookup_key match without invoking fetchProduct (fast path)', async () => {
+    const fetchProduct = vi.fn();
+    const subs = [
+      fakeSub({ id: 'sub_member', lookup_key: 'aao_membership_explorer_50', product: 'prod_x' }),
+    ];
+    const result = await pickMembershipSubWithProductFetch(subs, fetchProduct);
+    expect(result?.id).toBe('sub_member');
+    expect(fetchProduct).not.toHaveBeenCalled();
+  });
+
+  it('falls back to product metadata when no lookup_key matches', async () => {
+    // Adzymic / Advertible / Bidcliq / Equativ shape: founding-era sub
+    // with no aao_membership_ lookup_key, but the product is tagged
+    // category=membership. The async picker fetches the product and
+    // recovers the classification.
+    const fetchProduct = vi.fn().mockResolvedValue({
+      id: 'prod_founding_corp',
+      metadata: { category: 'membership' },
+    });
+    const subs = [
+      fakeSub({ id: 'sub_founding', lookup_key: null, product: 'prod_founding_corp' }),
+    ];
+    const result = await pickMembershipSubWithProductFetch(subs, fetchProduct);
+    expect(result?.id).toBe('sub_founding');
+    expect(fetchProduct).toHaveBeenCalledWith('prod_founding_corp');
+  });
+
+  it('returns null when neither lookup_key nor product metadata matches', async () => {
+    const fetchProduct = vi.fn().mockResolvedValue({
+      id: 'prod_event',
+      metadata: { category: 'event' },
+    });
+    const subs = [
+      fakeSub({ id: 'sub_event', lookup_key: null, product: 'prod_event' }),
+    ];
+    const result = await pickMembershipSubWithProductFetch(subs, fetchProduct);
+    expect(result).toBeNull();
+  });
+
+  it('skips a candidate whose product fetch throws (does not crash the whole sync)', async () => {
+    // One bad fetch shouldn't tank the rest. The next candidate's product
+    // is a real membership; the picker should still find it.
+    const fetchProduct = vi.fn()
+      .mockRejectedValueOnce(new Error('Stripe transient'))
+      .mockResolvedValueOnce({
+        id: 'prod_founding',
+        metadata: { category: 'membership' },
+      });
+    const subs = [
+      fakeSub({ id: 'sub_bad', lookup_key: null, product: 'prod_bad' }),
+      fakeSub({ id: 'sub_good', lookup_key: null, product: 'prod_founding' }),
+    ];
+    const result = await pickMembershipSubWithProductFetch(subs, fetchProduct);
+    expect(result?.id).toBe('sub_good');
+  });
+
+  it('skips a sub whose price.product is not a string (already expanded by caller)', async () => {
+    // If a caller does expand the product inline, the sync function
+    // doesn't need a fetch — but pickMembershipSub (sync) would have
+    // caught it on the fast path. Here we cover the edge: expanded but
+    // non-membership. fetchProduct should not be called.
+    const fetchProduct = vi.fn();
+    const subs = [
+      fakeSub({
+        id: 'sub_expanded_event',
+        lookup_key: null,
+        product: { id: 'prod_event', metadata: { category: 'event' } },
+      }),
+    ];
+    const result = await pickMembershipSubWithProductFetch(subs, fetchProduct);
+    expect(result).toBeNull();
+    expect(fetchProduct).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Hotfix on top of #3850. The previous attempt expanded `data.items.data.price.product` on `subscriptions.list`, which is 5 levels deep and still over Stripe's 4-level expansion limit. /sync continued to fail with "Failed to sync from Stripe" for every org.

## What changed

New approach in `pickMembershipSubWithProductFetch` (async, `server/src/billing/membership-prices.ts`):
1. Try the `lookup_key` fast path first via the existing `pickMembershipSub` — covers the modern cohort with zero extra Stripe round-trips.
2. When no sub has a recognized `aao_membership_*` lookup_key, fall back to retrieving the product per candidate via `stripe.products.retrieve` and checking `metadata.category === "membership"`. Founding-era subs (Adzymic, Advertible, Bidcliq, Equativ — May 2026) recover through this path.

`/sync` (`server/src/routes/admin/accounts-billing.ts`) lists subs without any deep expand and uses the new helper.

Synchronous `pickMembershipSub` is unchanged — invariant callers that walk every sub on the AAO Stripe account can't afford per-sub round-trips.

## Test plan

- [x] 35 unit tests pass (added 5 new cases for `pickMembershipSubWithProductFetch`: fast-path, metadata-fallback, neither-matches, transient-failure resilience, already-expanded product)
- [x] Integration test for `/sync` revenue backfill updated to mock `stripe.subscriptions.list` and `stripe.products.retrieve`
- [x] Typecheck clean
- [ ] After merge: re-run /sync against Adzymic — row should now show populated `stripe_subscription_id`, `subscription_price_lookup_key`, `membership_tier`
- [ ] After merge: hit `GET /api/admin/integrity/check/every-entitled-org-has-resolvable-tier` to confirm Adzymic clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)