### PR TITLE
fix(training-agent): wire Postgres task registry — production hotfix

### DIFF
--- a/.changeset/training-agent-postgres-task-registry.md
+++ b/.changeset/training-agent-postgres-task-registry.md
@@ -1,0 +1,10 @@
+---
+---
+
+Hotfix: per-tenant POSTs returned HTTP 500 in production after the multi-tenant migration (#3713) deployed. SDK 6.0 refuses the default in-memory task registry under `NODE_ENV=production`, and we never passed an explicit `taskRegistry` — registry init threw at first request, every per-tenant POST surfaced as `Internal Server Error`. Legacy `/mcp` was unaffected (uses the v5 `createTrainingAgentServer` path).
+
+Wire `createPostgresTaskRegistry({ pool: getPool() })` into the tenant registry's default server options. Test/dev fall back to `createInMemoryTaskRegistry()` because the test harness doesn't initialize the postgres pool. Production failure is fail-loud-with-fallback: if the pool is missing or the migration hasn't run, log error and fall back to in-memory rather than booting broken.
+
+Postgres-backed registry is also the correct choice independently of the SDK guard — the AAO app runs multiple Fly machines, and the in-memory registry is process-local. A buyer creating a media buy on machine A and polling on machine B would otherwise see task-not-found on ~50% of polls.
+
+Migration `463_adcp_decisioning_tasks.sql` is the SDK-shipped DDL from `getDecisioningTaskRegistryMigration()` (verbatim — `CREATE TABLE IF NOT EXISTS adcp_decisioning_tasks` plus two supporting indexes). Idempotent.

--- a/server/src/db/migrations/463_adcp_decisioning_tasks.sql
+++ b/server/src/db/migrations/463_adcp_decisioning_tasks.sql
@@ -1,0 +1,47 @@
+-- Postgres-backed task registry for the v6 DecisioningPlatform runtime.
+--
+-- The SDK's `createAdcpServerFromPlatform` defaults to an in-memory task
+-- registry, which is process-local — buyer creates a media buy on Fly
+-- machine A, polls status on machine B, sees "task not found". We're
+-- multi-instance, so this fails ~50% of the time on any async/HITL flow.
+--
+-- This migration is the SDK-shipped DDL from
+-- `getDecisioningTaskRegistryMigration()` (verbatim — do not edit). Wiring
+-- happens in `server/src/training-agent/tenants/registry.ts` via
+-- `createPostgresTaskRegistry({ pool: getPool() })`.
+--
+-- Idempotent (CREATE TABLE IF NOT EXISTS); safe to re-run if the SDK's
+-- migration is bumped, with the caveat that constraint widening (e.g. the
+-- 6.1 status-state widening) will need its own follow-up migration when
+-- the SDK ships it.
+
+CREATE TABLE IF NOT EXISTS adcp_decisioning_tasks (
+  task_id         TEXT PRIMARY KEY,
+  tool            TEXT NOT NULL,
+  account_id      TEXT NOT NULL,
+  status          TEXT NOT NULL DEFAULT 'submitted',
+  status_message  TEXT,
+  result          JSONB,
+  error           JSONB,
+  progress        JSONB,
+  has_webhook     BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT adcp_decisioning_tasks_valid_status CHECK (
+    -- Framework-written values: 'submitted' (initial), 'working'
+    -- (after first updateProgress() call), 'completed' / 'failed'
+    -- (terminal). The other 5 spec-defined states ('input-required',
+    -- 'canceled', 'rejected', 'auth-required', 'unknown') are reserved
+    -- for adopter-emitted transitions via the v6.1
+    -- `taskRegistry.transition()` API; the v6.1 migration will widen
+    -- this CHECK.
+    status IN ('submitted', 'working', 'completed', 'failed')
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_adcp_decisioning_tasks_account_id
+  ON adcp_decisioning_tasks(account_id);
+
+CREATE INDEX IF NOT EXISTS idx_adcp_decisioning_tasks_status_created
+  ON adcp_decisioning_tasks(status, created_at);

--- a/server/src/training-agent/tenants/registry.ts
+++ b/server/src/training-agent/tenants/registry.ts
@@ -26,9 +26,13 @@
 import type { Request } from 'express';
 import {
   createTenantRegistry,
+  createPostgresTaskRegistry,
+  createInMemoryTaskRegistry,
   type TenantRegistry,
+  type TaskRegistry,
   type CreateAdcpServerFromPlatformOptions,
 } from '@adcp/sdk/server';
+import { getPool } from '../../db/client.js';
 import { getIdempotencyStore, scopedPrincipal } from '../idempotency.js';
 import { getWebhookSigningMaterial } from '../webhooks.js';
 import { buildSignalsTenantConfig } from './signals.js';
@@ -120,12 +124,41 @@ export function resolveTenantHost(_req: Request): string {
   return CANONICAL_HOST;
 }
 
+/**
+ * Pick the task registry based on env. Production / staging-like envs MUST
+ * use Postgres — we run multiple Fly machines and an in-memory registry
+ * would lose task state across instances (buyer creates a media buy on
+ * machine A, polls on machine B, sees task-not-found). Test / dev fall back
+ * to in-memory: tests don't initialize the postgres pool and the SDK's
+ * `getPool()` throws if called before `initializeDatabase()`.
+ *
+ * Migration for `adcp_decisioning_tasks` lives at
+ * `server/src/db/migrations/463_adcp_decisioning_tasks.sql`.
+ */
+function pickTaskRegistry(): TaskRegistry {
+  const isProd = process.env.NODE_ENV === 'production';
+  if (!isProd) {
+    return createInMemoryTaskRegistry();
+  }
+  try {
+    return createPostgresTaskRegistry({ pool: getPool() });
+  } catch (err) {
+    logger.error(
+      { err },
+      'Postgres task registry init failed in production — falling back to in-memory. ' +
+        'Multi-instance task polling will be flaky. Verify migration 463 ran and DATABASE_URL is set.',
+    );
+    return createInMemoryTaskRegistry();
+  }
+}
+
 function buildDefaultServerOptions(): CreateAdcpServerFromPlatformOptions {
   return {
     name: 'adcp-training-agent',
     version: '1.0.0',
     idempotency: getIdempotencyStore(),
     webhooks: getWebhookSigningMaterial(),
+    taskRegistry: pickTaskRegistry(),
     mergeSeam: 'log-once',
     validation: { requests: 'off', responses: 'off' },
     // F11 — accept loopback push_notification_config.url in non-production.


### PR DESCRIPTION
## Summary

Production hotfix for the multi-tenant migration (#3713). Per-tenant POSTs returned HTTP 500 — SDK 6.0 refuses the default in-memory task registry under `NODE_ENV=production`, and we never passed an explicit `taskRegistry`.

## Symptom

After #3713 + #3714 deployed:

- ✓ `GET /sales/mcp` → 405 (handler registered, doesn't hit registry)
- ✓ `GET /.well-known/adagents.json` → 200 with all 6 tenants in `_training_agent_tenants`
- ✓ `POST /mcp` (legacy alias) → 200, full tools list (uses v5 path, no SDK 6.0 task registry)
- ✗ `POST /signals/mcp` → **500 Internal Server Error**
- ✗ `POST /<any-tenant>/mcp` → **500 Internal Server Error**

## Fix

`createPostgresTaskRegistry({ pool: getPool() })` for production; `createInMemoryTaskRegistry()` for test/dev.

This is the right fix independent of the SDK guard. The AAO app runs **multiple Fly machines** — an in-memory task registry is process-local. A buyer who creates a media buy on machine A and polls on machine B would otherwise see task-not-found on ~50% of async-flow polls.

Production fallback is fail-loud-with-warning: if the pool is missing or migration 463 hasn't run, log error and fall back to in-memory. Single-instance deployments keep working; multi-instance gets a flag to fix the deploy.

## Migration

`server/src/db/migrations/463_adcp_decisioning_tasks.sql` — the SDK-shipped DDL from `getDecisioningTaskRegistryMigration()` verbatim. Idempotent (`CREATE TABLE IF NOT EXISTS`).

## Test plan

- [x] TypeScript clean
- [x] 382/382 tests passing (5 test files: demo-key, webhooks, legacy-mcp, tool-catalog-drift, training-agent unit)
- [x] Storyboard sanity: signals 59/61 clean, sales 57/61 clean — equal to or above the post-migration baseline
- [ ] After deploy: `curl -s -X POST https://test-agent.adcontextprotocol.org/signals/mcp -H "Authorization: Bearer 1v8tAhASaUYYp4odoQ1PnMpdqNaMiTrCRqYo9OJp6IQ" -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'` returns 200 with a tools array including `get_signals` and `activate_signal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)