### PR TITLE
fix(addie): ban fabricated ticket numbers / "team has been notified" claims (#3720)

### DIFF
--- a/.changeset/ban-fake-ticket-claims.md
+++ b/.changeset/ban-fake-ticket-claims.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix #3720. Addie was telling users "the team has been notified (ticket #228)" without ever calling `escalate_to_admin`. The post-message lint at `claude-client.ts` already covered fake invoice/DM/escalation-resolved claims but missed ticket-creation and "team has been notified"/"I've flagged this" patterns. Added four new patterns covering those, exported `detectHallucinatedAction` so the patterns are unit-testable, and strengthened the constraint in `addie/rules/constraints.md` to call out fake escalations and fake GitHub issue filings explicitly. `escalate_to_admin` is in the always-available tool set, so there's no excuse for claiming an escalation without making the call.

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -161,7 +161,7 @@ function buildMultimodalContentBlocks(
  * Action-claiming patterns mapped to the tools that should back them up.
  * Hoisted to module scope to avoid re-allocation on every response.
  */
-const HALLUCINATION_PATTERNS: ReadonlyArray<{ pattern: RegExp; expectedTools: string[] }> = [
+export const HALLUCINATION_PATTERNS: ReadonlyArray<{ pattern: RegExp; expectedTools: string[] }> = [
   { pattern: /invoice\s+(?:resent|sent)\s+successfully/i, expectedTools: ['resend_invoice', 'send_invoice', 'send_payment_request'] },
   { pattern: /(?:successfully\s+)?resent\s+(?:the\s+)?invoice/i, expectedTools: ['resend_invoice', 'send_invoice', 'send_payment_request'] },
   { pattern: /(?:billing\s+)?email\s+(?:updated|changed)\s+successfully/i, expectedTools: ['update_billing_email'] },
@@ -171,6 +171,15 @@ const HALLUCINATION_PATTERNS: ReadonlyArray<{ pattern: RegExp; expectedTools: st
   { pattern: /(?:I'?ve\s+|I\s+)?(?:created|generated|sent)\s+(?:a\s+)?payment\s+link/i, expectedTools: ['create_payment_link'] },
   { pattern: /(?:I'?ve\s+|I\s+)?(?:sent|delivered)\s+(?:a\s+)?(?:DM|direct message|notification)/i, expectedTools: ['send_member_dm', 'resolve_escalation'] },
   { pattern: /(?:I'?ve\s+|I\s+)?added\s+\S+(?:\s+\S+){0,5}\s+to\s+the\s+(?:meeting|call|series)/i, expectedTools: ['add_meeting_attendee'] },
+  // Fake-escalation patterns. `escalate_to_admin` is in the always-available
+  // tool set, so claiming an escalation/notification was made without firing
+  // it is the same class of fabrication as the rest. Real GitHub-issue tools
+  // count too because Addie sometimes describes filing a ticket as creating
+  // an issue.
+  { pattern: /ticket\s+#?\d+/i, expectedTools: ['escalate_to_admin', 'create_github_issue', 'draft_github_issue'] },
+  { pattern: /(?:the\s+)?team\s+(?:has\s+been\s+|will\s+be\s+|is\s+being\s+)notified/i, expectedTools: ['escalate_to_admin'] },
+  { pattern: /I'?ve\s+(?:flagged|escalated|notified)\s+(?:this|the\s+team|the\s+admins?)/i, expectedTools: ['escalate_to_admin'] },
+  { pattern: /(?:I'?ve\s+|I\s+just\s+)?(?:created|opened|filed)\s+(?:a\s+)?(?:support\s+)?(?:ticket|issue)\b/i, expectedTools: ['escalate_to_admin', 'create_github_issue', 'draft_github_issue'] },
 ];
 
 /**
@@ -178,7 +187,7 @@ const HALLUCINATION_PATTERNS: ReadonlyArray<{ pattern: RegExp; expectedTools: st
  * Returns a flag reason if the text claims to have completed an action
  * but no corresponding tool was actually called AND succeeded.
  */
-function detectHallucinatedAction(text: string, toolExecutions: ToolExecution[]): string | null {
+export function detectHallucinatedAction(text: string, toolExecutions: ToolExecution[]): string | null {
   for (const { pattern, expectedTools } of HALLUCINATION_PATTERNS) {
     if (pattern.test(text)) {
       // Check that a matching tool was called AND succeeded (not just called)

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -176,10 +176,17 @@ export const HALLUCINATION_PATTERNS: ReadonlyArray<{ pattern: RegExp; expectedTo
   // it is the same class of fabrication as the rest. Real GitHub-issue tools
   // count too because Addie sometimes describes filing a ticket as creating
   // an issue.
-  { pattern: /ticket\s+#?\d+/i, expectedTools: ['escalate_to_admin', 'create_github_issue', 'draft_github_issue'] },
+  //
+  // The two creation-verb patterns require a first-person subject so we
+  // don't fire on "see ticket 42" or "Stripe opened a ticket on your behalf"
+  // — those are informational, not fabricated actions. The "team notified"
+  // pattern stays loose because it's the primary signal for the original
+  // failure shape ("Done — the team has been notified (ticket #228)") where
+  // no other pattern fits the punctuation context.
+  { pattern: /(?:I'?ve|I\s+just|I)\s+(?:created|opened|filed|generated)\s+(?:a\s+)?(?:support\s+)?ticket\s+#?\d+/i, expectedTools: ['escalate_to_admin', 'create_github_issue', 'draft_github_issue'] },
   { pattern: /(?:the\s+)?team\s+(?:has\s+been\s+|will\s+be\s+|is\s+being\s+)notified/i, expectedTools: ['escalate_to_admin'] },
   { pattern: /I'?ve\s+(?:flagged|escalated|notified)\s+(?:this|the\s+team|the\s+admins?)/i, expectedTools: ['escalate_to_admin'] },
-  { pattern: /(?:I'?ve\s+|I\s+just\s+)?(?:created|opened|filed)\s+(?:a\s+)?(?:support\s+)?(?:ticket|issue)\b/i, expectedTools: ['escalate_to_admin', 'create_github_issue', 'draft_github_issue'] },
+  { pattern: /(?:I'?ve|I\s+just)\s+(?:created|opened|filed)\s+(?:a\s+)?(?:support\s+)?(?:ticket|issue)\b/i, expectedTools: ['escalate_to_admin', 'create_github_issue', 'draft_github_issue'] },
 ];
 
 /**

--- a/server/src/addie/rules/constraints.md
+++ b/server/src/addie/rules/constraints.md
@@ -53,6 +53,8 @@ Actions that REQUIRE a tool call before claiming success:
 - Sending DMs or notifications → send_member_dm must succeed
 - Creating payment links → create_payment_link must succeed
 - Scheduling meetings → schedule_meeting must succeed
+- **Escalating to a human / opening a ticket → escalate_to_admin must succeed.** `escalate_to_admin` is in the always-available tool set; if you intend to escalate, you must call it. Do NOT say "the team has been notified," "I've flagged this," "I've escalated this," "ticket #N created," or anything that implies a human will see the conversation, unless `escalate_to_admin` actually fired in this turn. Do NOT invent ticket numbers.
+- **Filing a GitHub issue or PR → create_github_issue (or draft_github_issue) must succeed.** Same rule: don't say "I've opened an issue" or "I've filed a ticket" without the tool call.
 - Any other state-changing operation
 
 If a tool is not available, say "I don't have a tool to do that right now" and escalate.

--- a/server/tests/unit/addie-hallucination-patterns.test.ts
+++ b/server/tests/unit/addie-hallucination-patterns.test.ts
@@ -77,6 +77,36 @@ describe('detectHallucinatedAction — fake escalations (#3720)', () => {
     expect(detectHallucinatedAction('The team will be notified shortly.', []))
       .toMatch(/Possible hallucinated action/);
   });
+
+  test('does NOT flag bare ticket reference without a creation verb', () => {
+    expect(detectHallucinatedAction('See ticket #3720 for details.', []))
+      .toBeNull();
+    expect(detectHallucinatedAction('You mentioned ticket 42 in the last message.', []))
+      .toBeNull();
+  });
+
+  test('does NOT flag third-party narration of a ticket creation', () => {
+    expect(detectHallucinatedAction(
+      'Stripe opened a ticket on your behalf last week.',
+      [],
+    )).toBeNull();
+    expect(detectHallucinatedAction(
+      'GitHub filed an issue for the regression yesterday.',
+      [],
+    )).toBeNull();
+  });
+
+  test('still flags first-person "I created ticket #N" with creation verb', () => {
+    expect(detectHallucinatedAction("I've created ticket #228 for you.", []))
+      .toMatch(/Possible hallucinated action/);
+    expect(detectHallucinatedAction('I just opened ticket 99.', []))
+      .toMatch(/Possible hallucinated action/);
+  });
+
+  test('Greg-thread shape (the original repro) still trips the lint', () => {
+    const greg = 'Done — the team has been notified (ticket #228) and will track down the invoice and resend it to admin@example.com.';
+    expect(detectHallucinatedAction(greg, [])).toMatch(/Possible hallucinated action/);
+  });
 });
 
 describe('HALLUCINATION_PATTERNS coverage', () => {

--- a/server/tests/unit/addie-hallucination-patterns.test.ts
+++ b/server/tests/unit/addie-hallucination-patterns.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect } from 'vitest';
+import {
+  detectHallucinatedAction,
+  HALLUCINATION_PATTERNS,
+} from '../../src/addie/claude-client.js';
+
+type ToolExecution = {
+  tool_name: string;
+  tool_use_id: string;
+  is_error?: boolean;
+  result?: unknown;
+};
+
+const ok = (tool: string): ToolExecution => ({
+  tool_name: tool,
+  tool_use_id: `tu_${tool}`,
+  is_error: false,
+});
+const err = (tool: string): ToolExecution => ({
+  tool_name: tool,
+  tool_use_id: `tu_${tool}_err`,
+  is_error: true,
+});
+
+describe('detectHallucinatedAction — fake escalations (#3720)', () => {
+  test('flags "ticket #228" with no escalate_to_admin call', () => {
+    const text = 'Done — the team has been notified (ticket #228).';
+    expect(detectHallucinatedAction(text, [])).toMatch(/Possible hallucinated action/);
+  });
+
+  test('flags "team has been notified" with no escalate_to_admin call', () => {
+    expect(detectHallucinatedAction('the team has been notified', []))
+      .toMatch(/Possible hallucinated action/);
+  });
+
+  test('flags "I\'ve flagged this" with no escalate_to_admin call', () => {
+    expect(detectHallucinatedAction("I've flagged this for the team.", []))
+      .toMatch(/Possible hallucinated action/);
+  });
+
+  test('flags "I\'ve opened a ticket" with no escalate_to_admin / GitHub-issue call', () => {
+    expect(detectHallucinatedAction("I've opened a support ticket for you.", []))
+      .toMatch(/Possible hallucinated action/);
+  });
+
+  test('does NOT flag escalation language when escalate_to_admin succeeded', () => {
+    const text = 'The team has been notified.';
+    expect(detectHallucinatedAction(text, [ok('escalate_to_admin')])).toBeNull();
+  });
+
+  test('does NOT flag ticket language when create_github_issue succeeded', () => {
+    expect(detectHallucinatedAction("I've filed an issue for you.", [ok('create_github_issue')]))
+      .toBeNull();
+  });
+
+  test('flags fake escalation even if a different tool succeeded', () => {
+    // Calling search_docs is not a substitute for actually escalating.
+    expect(detectHallucinatedAction('the team has been notified', [ok('search_docs')]))
+      .toMatch(/Possible hallucinated action/);
+  });
+
+  test('flags fake escalation when escalate_to_admin was called but errored', () => {
+    expect(detectHallucinatedAction('the team has been notified', [err('escalate_to_admin')]))
+      .toMatch(/Possible hallucinated action/);
+  });
+
+  test('does not match "ticket" outside the action-claim shape', () => {
+    // "submit a ticket" is informational instruction, not a claim of having done so.
+    // Pattern requires a number after "ticket" or specific creation verbs.
+    expect(detectHallucinatedAction(
+      'You can submit a ticket through the support portal.',
+      [],
+    )).toBeNull();
+  });
+
+  test('matches "team will be notified" passive future-tense too', () => {
+    expect(detectHallucinatedAction('The team will be notified shortly.', []))
+      .toMatch(/Possible hallucinated action/);
+  });
+});
+
+describe('HALLUCINATION_PATTERNS coverage', () => {
+  test('every pattern has a non-empty expectedTools list', () => {
+    for (const { pattern, expectedTools } of HALLUCINATION_PATTERNS) {
+      expect(expectedTools.length, `Pattern ${pattern.source} has no expected tools`).toBeGreaterThan(0);
+    }
+  });
+
+  test('every pattern is case-insensitive', () => {
+    for (const { pattern } of HALLUCINATION_PATTERNS) {
+      expect(pattern.flags, `Pattern ${pattern.source} should be case-insensitive`).toContain('i');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3720.

Addie's existing post-message lint at `server/src/addie/claude-client.ts` already covers fake invoice/DM/escalation-resolved claims, but missed the pattern from the issue — fabricated ticket numbers + "the team has been notified." Add four lint patterns covering:

- `ticket #N`
- `team has been notified` / `team will be notified`
- `I've flagged this for the team`
- `I've opened/filed a ticket/issue`

…each backed by `escalate_to_admin` (and the GitHub-issue tools where applicable). `escalate_to_admin` is in the always-available tool set, so there is no excuse for claiming an escalation without making the call.

Strengthen `server/src/addie/rules/constraints.md` "Never Claim Unexecuted Actions" with two new bullets:
- escalation/ticket claims require `escalate_to_admin`
- GitHub-issue claims require `create_github_issue` / `draft_github_issue`

Export `detectHallucinatedAction` + `HALLUCINATION_PATTERNS` so the lint logic is unit-testable; previously no test coverage.

## Test plan

- [x] New unit suite `server/tests/unit/addie-hallucination-patterns.test.ts` — 12 cases covering each new pattern (positive + negative + matching tool present + matching tool errored)
- [x] `tsc --project server/tsconfig.json --noEmit` clean
- [ ] Manual: re-run a billing question in a Slack channel — confirm Addie either calls `escalate_to_admin` or refuses with "I don't have a tool for that right now," and never fabricates a ticket number

## Related

- #3724 (sister incident — billing-tooling fixes for the same Greg-thread root cause)
- #3721 (sister Addie issue — silent send_invoice failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
