### PR TITLE
fix(addie): empty-turn safeguard — log + flag when model returns nothing (#3721 partial)

### DIFF
--- a/.changeset/empty-turn-safeguard.md
+++ b/.changeset/empty-turn-safeguard.md
@@ -1,0 +1,4 @@
+---
+---
+
+Partial fix for #3721 — empty-turn safeguard. When the model produces no text AND no successful tool calls, the user gets nothing back: the same UX as a transport drop, and the signature failure mode behind silent invoice-tool failures (the original Greg-thread incident). Added `detectEmptyTurn` next to `detectHallucinatedAction` in `server/src/addie/claude-client.ts`, wired both end-of-turn paths (regular + streaming) to log a warning and flag the response when this happens. Tool-error person events for the billing-tool refusal paths are still pending — that piece needs personId plumbing through `MemberContext` and is left for a follow-up.

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -1435,13 +1435,15 @@ export class AddieClaudeClient {
         if (currentResponse.stop_reason === 'end_turn') {
           totalToolExecutionMs = toolExecutions.reduce((sum, t) => sum + t.duration_ms, 0);
 
-          // Detect possible hallucinated actions (text claims success without successful tool calls)
-          const hallucinationReason = detectHallucinatedAction(fullText, toolExecutions);
+          // Run both detectors against the post-pipeline text — same as the
+          // non-stream path. If applyResponsePipeline strips the only text
+          // (e.g., scrubbed a refused-action sentence), that should look like
+          // an empty turn to the user, which is what we want to flag.
+          const pipelined = applyResponsePipeline(userMessage, fullText);
+          const hallucinationReason = detectHallucinatedAction(pipelined, toolExecutions);
           if (hallucinationReason) {
             logger.warn({ toolsUsed, reason: hallucinationReason }, 'Addie Stream: Possible hallucinated action detected');
           }
-
-          const pipelined = applyResponsePipeline(userMessage, fullText);
           const emptyTurnReason = detectEmptyTurn(pipelined, toolExecutions);
           if (emptyTurnReason) {
             logger.warn({ toolsUsed, toolExecutions: toolExecutions.length }, 'Addie Stream: Empty turn — no text and no successful tool calls');

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -194,6 +194,20 @@ function detectHallucinatedAction(text: string, toolExecutions: ToolExecution[])
   return null;
 }
 
+/**
+ * Empty-turn detector (#3721). The user gets nothing back when the model
+ * produces no text AND no successful tool calls — same UX as a transport
+ * drop, and the signature failure mode behind silent invoice-tool failures.
+ * Returns a reason string when this happens so the caller can flag + log it.
+ */
+export function detectEmptyTurn(text: string, toolExecutions: ToolExecution[]): string | null {
+  if (text.length > 0) return null;
+  const successful = toolExecutions.filter(t => !t.is_error).length;
+  if (successful > 0) return null;
+  const errored = toolExecutions.length - successful;
+  return `Empty turn: no text and no successful tool calls (toolExecutions=${toolExecutions.length}, errored=${errored})`;
+}
+
 /** Default max tool iterations for regular users */
 export const DEFAULT_MAX_ITERATIONS = 10;
 
@@ -788,6 +802,12 @@ export class AddieClaudeClient {
           logger.warn({ toolsUsed, reason: hallucinationReason }, 'Addie: Possible hallucinated action detected');
         }
 
+        const emptyTurnReason = detectEmptyTurn(text, toolExecutions);
+        if (emptyTurnReason) {
+          logger.warn({ toolsUsed, toolExecutions: toolExecutions.length }, 'Addie: Empty turn — no text and no successful tool calls');
+        }
+        const flagReason = hallucinationReason ?? emptyTurnReason;
+
         const finalUsage = {
           input_tokens: totalInputTokens,
           output_tokens: totalOutputTokens,
@@ -810,8 +830,8 @@ export class AddieClaudeClient {
           text,
           tools_used: toolsUsed,
           tool_executions: toolExecutions,
-          flagged: !!hallucinationReason,
-          flag_reason: hallucinationReason ?? undefined,
+          flagged: !!flagReason,
+          flag_reason: flagReason ?? undefined,
           active_rule_ids: undefined,
           config_version_id: configVersionId ?? undefined,
           timing: {
@@ -1421,16 +1441,23 @@ export class AddieClaudeClient {
             logger.warn({ toolsUsed, reason: hallucinationReason }, 'Addie Stream: Possible hallucinated action detected');
           }
 
+          const pipelined = applyResponsePipeline(userMessage, fullText);
+          const emptyTurnReason = detectEmptyTurn(pipelined, toolExecutions);
+          if (emptyTurnReason) {
+            logger.warn({ toolsUsed, toolExecutions: toolExecutions.length }, 'Addie Stream: Empty turn — no text and no successful tool calls');
+          }
+          const flagReason = hallucinationReason ?? emptyTurnReason;
+
           const streamUsage = buildStreamUsage();
           await chargeStreamCost(streamUsage);
           yield {
             type: 'done',
             response: {
-              text: applyResponsePipeline(userMessage, fullText),
+              text: pipelined,
               tools_used: toolsUsed,
               tool_executions: toolExecutions,
-              flagged: !!hallucinationReason,
-              flag_reason: hallucinationReason ?? undefined,
+              flagged: !!flagReason,
+              flag_reason: flagReason ?? undefined,
               active_rule_ids: undefined,
               config_version_id: configVersionId ?? undefined,
               timing: {

--- a/server/tests/unit/addie-empty-turn.test.ts
+++ b/server/tests/unit/addie-empty-turn.test.ts
@@ -1,0 +1,50 @@
+import { describe, test, expect } from 'vitest';
+import { detectEmptyTurn } from '../../src/addie/claude-client.js';
+
+type ToolExecution = {
+  tool_name: string;
+  tool_use_id: string;
+  is_error?: boolean;
+};
+
+const ok = (tool: string): ToolExecution => ({
+  tool_name: tool,
+  tool_use_id: `tu_${tool}`,
+  is_error: false,
+});
+const err = (tool: string): ToolExecution => ({
+  tool_name: tool,
+  tool_use_id: `tu_${tool}_err`,
+  is_error: true,
+});
+
+describe('detectEmptyTurn (#3721)', () => {
+  test('flags empty text + no tool calls — the silent-failure case', () => {
+    expect(detectEmptyTurn('', [])).toMatch(/Empty turn/);
+  });
+
+  test('flags empty text + only errored tool calls (the actual repro)', () => {
+    // Greg-thread shape: send_invoice was attempted, errored, and the model
+    // produced no text. User saw nothing.
+    expect(detectEmptyTurn('', [err('send_invoice')])).toMatch(/errored=1/);
+  });
+
+  test('does NOT flag when text is present, even with no tool calls', () => {
+    expect(detectEmptyTurn('here is your answer', [])).toBeNull();
+  });
+
+  test('does NOT flag when at least one tool call succeeded', () => {
+    // The user gets the tool result rendered downstream, not nothing.
+    expect(detectEmptyTurn('', [ok('search_docs')])).toBeNull();
+  });
+
+  test('does NOT flag mixed success + error', () => {
+    expect(detectEmptyTurn('', [ok('search_docs'), err('send_invoice')])).toBeNull();
+  });
+
+  test('reason includes counts so admins can debug from log lines', () => {
+    const reason = detectEmptyTurn('', [err('a'), err('b'), err('c')]);
+    expect(reason).toContain('toolExecutions=3');
+    expect(reason).toContain('errored=3');
+  });
+});


### PR DESCRIPTION
## Summary

Partial fix for #3721 — empty-turn safeguard.

When a turn produces no text AND no successful tool calls, the user gets literally nothing back — the same UX as a transport drop, and the signature failure mode behind the silent `send_invoice` failure that left the user waiting for an invoice that never came.

Adds `detectEmptyTurn` next to the existing `detectHallucinatedAction` helper in `server/src/addie/claude-client.ts`, wires it into both end-of-turn paths (non-streaming and streaming), logs `warn` when it fires, and surfaces a `flag_reason` on the response so downstream consumers can detect the case.

## Scope

#3721 also asked for `tool_error` person events on each billing-tool refusal path (`send_invoice`, `confirm_send_invoice`, `create_payment_link`). Deferring that to a follow-up:

- It needs `personId` plumbed through `MemberContext` (today the context only carries `workos_user_id`, and mapping that to `person_id` requires a `person_relationships` lookup at the tool boundary).
- The existing refusals already return non-empty user-facing messages — the JSON `{success:false, error:"..."}` shape that the model is supposed to surface. The empty-turn safeguard is the **catch-all** for cases where Addie still produces empty output around them, which is the actual failure mode from the original incident.

## Test plan

- [x] `server/tests/unit/addie-empty-turn.test.ts` — 6 cases: empty + no tools (the silent-failure shape), empty + only errored tools (Greg-thread shape), text present, mixed success/error, reason includes counts.
- [x] `tsc --project server/tsconfig.json --noEmit` clean.
- [ ] Manual: induce a tool error on send_invoice, confirm `Addie: Empty turn` warn fires (cannot reproduce locally without a real model call — relying on the unit test to pin the helper logic).

## Related

- #3724 (sister incident — billing-tooling fixes for the original Greg-thread root cause)
- #3855 (sister Addie issue — banned fabricated ticket numbers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
