### PR TITLE
feat(schema): add media_buy.supports_proposals capability flag

### DIFF
--- a/.changeset/supports-proposals-capability-flag.md
+++ b/.changeset/supports-proposals-capability-flag.md
@@ -1,0 +1,15 @@
+---
+"adcontextprotocol": minor
+---
+
+Add `media_buy.supports_proposals` capability flag to `get_adcp_capabilities` response (closes #3844).
+
+**Problem:** The `proposal_finalize` conformance storyboard had no capability gate, meaning every `sales-guaranteed` seller would eventually be required to grade against it — including auction-based PG, retail SKU, and quoted-rate direct-buy sellers that have no proposal engine.
+
+**Change:** `get-adcp-capabilities-response.json` gains an optional boolean `supports_proposals` under `media_buy`. When `true`, the seller commits to the full proposal lifecycle against the standard conformance brief: `buying_mode: 'brief'` returning `proposals[]`, `buying_mode: 'refine'` returning an updated proposal, and `buying_mode: 'refine'` with `action: 'finalize'` transitioning the proposal to committed status. When `false` or absent, the seller serves products directly without proposal abstraction.
+
+`static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml` gains a `requires_capability: { path: media_buy.supports_proposals, equals: true }` gate so the storyboard runner can skip the scenario as `capability_unsupported` for sellers that do not declare proposal support.
+
+**Non-breaking:** Fully additive. The field is optional with no default; `media_buy` has no `additionalProperties: false` constraint; existing `get_adcp_capabilities` responses and validators are unaffected. The storyboard `requires_capability` gate only adds skip paths — sellers that previously graded `proposal_finalize` as not applicable continue to do so.
+
+**Sequencing:** This is step 1 of the sales-proposal-mode deprecation path (#3823 item 4, #3840). Step 2 (adding `proposal_finalize` to `sales-guaranteed.requires_scenarios`) follows once the runner's `requires_capability` predicate is confirmed. Step 4 (4.0 removal of `sales-proposal-mode` enum value) follows at the next major.

--- a/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
@@ -7,6 +7,9 @@ track: media_buy
 required_tools:
   - get_products
   - create_media_buy
+requires_capability:
+  path: media_buy.supports_proposals
+  equals: true
 
 narrative: |
   Proposals are curated media plans that the seller generates alongside products. The buyer

--- a/static/compliance/source/specialisms/sales-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-guaranteed/index.yaml
@@ -43,15 +43,16 @@ narrative: |
   Proposal-driven workflows are part of guaranteed selling: most guaranteed deals start with
   an RFP/brief, generate a proposal with curated bundles and rationale, refine, finalize to
   committed status with firm pricing and an inventory hold, and then the buyer accepts via
-  create_media_buy. The `media_buy_seller/proposal_finalize` scenario covers that flow but
-  is NOT (yet) in this specialism's `requires_scenarios` because the storyboard runner
-  cannot currently grade it as `not_applicable` for sellers without proposal support — there
-  is no `requires_capability` path in `get_adcp_capabilities` for "this seller supports
-  proposals" (tracked at #3844). Until that capability flag exists, sellers that do
-  proposals should declare BOTH `sales-guaranteed` AND `sales-proposal-mode` through 3.x;
-  pure-direct-buy guaranteed sellers (auction PG, retail SKU) declare only `sales-guaranteed`.
-  At 4.0, with the capability flag in place, `proposal_finalize` joins `sales-guaranteed`'s
-  `requires_scenarios` and the `sales-proposal-mode` enum value is removed.
+  create_media_buy. The `media_buy_seller/proposal_finalize` scenario covers that flow and
+  declares `requires_capability: { path: media_buy.supports_proposals, equals: true }` (#3844)
+  so the runner can skip it as `capability_unsupported` for sellers without a proposal engine.
+  It is NOT (yet) in this specialism's `requires_scenarios` because the `requires_capability`
+  predicate must be confirmed as runner-supported before grading is safe to enforce. Until
+  step 2 of the deprecation path lands, sellers that do proposals should declare BOTH
+  `sales-guaranteed` AND `sales-proposal-mode` through 3.x; pure-direct-buy guaranteed
+  sellers (auction PG, retail SKU) declare only `sales-guaranteed` and omit
+  `supports_proposals` (or declare false). At 4.0, `proposal_finalize` joins
+  `sales-guaranteed`'s `requires_scenarios` and `sales-proposal-mode` is removed.
 
 agent:
   interaction_model: media_buy_seller

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -567,6 +567,10 @@
           },
           "additionalProperties": true
         },
+        "supports_proposals": {
+          "type": "boolean",
+          "description": "Whether this seller supports the full proposal lifecycle against the standard conformance brief: (1) buying_mode: 'brief' returns at least one entry in proposals[]; (2) buying_mode: 'refine' returns an updated proposal; (3) buying_mode: 'refine' with a refine[] entry of scope: 'proposal', action: 'finalize' transitions the proposal to committed status with firm pricing and an expires_at inventory hold window.\n\nThis is a behavioral commitment, not a feature inventory. The commitment is scoped to the standard conformance brief — sellers are not over-committed on arbitrary production briefs. A seller with a proposal engine that cannot reliably handle the conformance brief (e.g., asynchronous overnight proposal generation, or a proposal engine that does not recognize the conformance brief) MUST declare false or omit this field and skip the proposal-mode conformance scenario.\n\nWhen false or absent, the seller serves products directly without proposal abstraction, and buyers MUST NOT rely on proposals[] being present in get_products responses. Most guaranteed-deal sellers that run proposal-driven workflows (premium publishers, broadcast networks, CTV platforms) declare true; auction-based PG, retail SKU, and quoted-rate direct-buy sellers declare false."
+        },
         "content_standards": {
           "type": "object",
           "description": "Content standards implementation details. Presence of this object indicates the seller supports content_standards configuration including sampling rates and category filtering. Gives buyers pre-buy visibility into local evaluation and artifact delivery capabilities.",


### PR DESCRIPTION
Closes #3844

## Summary

Adds `media_buy.supports_proposals: boolean` (optional) to `get-adcp-capabilities-response.json`. When `true`, the seller commits to the full proposal lifecycle against the standard conformance brief — `buying_mode: 'brief'` returning `proposals[]`, `buying_mode: 'refine'` returning an updated proposal, and `buying_mode: 'refine'` with a proposal-scope `refine[]` entry of `action: 'finalize'` transitioning to committed status with firm pricing and an `expires_at` hold window. When `false` or absent, the seller serves products directly without proposal abstraction.

Also adds `requires_capability: { path: media_buy.supports_proposals, equals: true }` to `proposal_finalize.yaml` so the storyboard runner can skip the scenario as `capability_unsupported` for sellers that omit or negate the flag. Updates the `sales-guaranteed/index.yaml` narrative from "tracked at #3844 (pending)" to reflect that the flag has landed — the deferred step 2 (adding `proposal_finalize` to `requires_scenarios`) awaits runner confirmation of `requires_capability` predicate support.

This is step 1 of the `sales-proposal-mode` deprecation path (#3823 item 4, #3840): the capability flag gates the conformance scenario; step 2 folds `proposal_finalize` into `sales-guaranteed.requires_scenarios` once `requires_capability` evaluation is confirmed in the runner; step 4 removes the `sales-proposal-mode` enum at 4.0.

**Non-breaking justification:** `supports_proposals` is an optional field on `media_buy`, which has no `additionalProperties: false` constraint. Existing `get_adcp_capabilities` responses omitting the field remain valid. The `requires_capability` gate in `proposal_finalize.yaml` adds skip paths — sellers that did not grade this scenario continue not to. No enum values modified, no required fields added, no wire shape changed.

**Pre-PR review:**
- code-reviewer: approved — no blockers; flagged stale "tracked at #3844" narrative (fixed) and `action: 'finalize'` path accuracy in description (fixed); nit on `requires_capability` being undocumented in storyboard schema (acknowledged in PR body)
- ad-tech-protocol-expert: approved — correct placement in `media_buy` (not under `execution`); matches OpenRTB capability-flag precedent; description corrected to use `refine[].action: 'finalize'` path; `requires_capability` runner support noted as forward declaration pending step 2

**Open: `requires_capability` runner support.** The `requires_capability` predicate is not yet documented in `storyboard-schema.yaml` and runner support in `@adcp/sdk` could not be verified locally (package not installed). Adding the YAML field is harmless if the runner ignores unknown top-level keys — it documents the intent and becomes effective when runner support lands. `proposal_finalize` is not in `sales-guaranteed.requires_scenarios` yet, so no seller is currently graded against it regardless. Step 2 should explicitly confirm runner support before flipping `requires_scenarios`.

> **Triage-managed PR.** This bot does not currently iterate on review comments or PR conversation threads (only on the source issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` → fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121) for context.

Session: https://claude.ai/code/session_01JBXC7mSkYTjSv9SCnx2c12

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBXC7mSkYTjSv9SCnx2c12)_