### PR TITLE
fix(billing): drop over-deep Stripe expand at three sister sites of /sync

### DIFF
--- a/.changeset/stripe-expand-depth-sister-sites.md
+++ b/.changeset/stripe-expand-depth-sister-sites.md
@@ -7,4 +7,6 @@ Drop over-deep Stripe expand at three sister sites the /sync hotfix (#3853) didn
 - `stripe-sub-reflected-in-org-row` invariant — `data.items.data.price.product` (5 levels) on `subscriptions.list`. The integrity check threw on every run, so the Lina/Adzymic-class detection wasn't actually firing. Drop expand; classify by lookup_key with a per-product `products.retrieve` fallback (cached across the run) for founding-era subs.
 - `/api/admin/backfill-revenue` — `subscriptions.data.items.data.price.product` (6 levels) on `customers.retrieve`. Whole loop crashed per customer. Replace with `subscriptions.list` + `pickMembershipSubWithProductFetch`, mirroring the /sync fix.
 
-Adds shared helper `isMembershipSubWithProductFetch` in `billing/membership-prices` for the per-sub filter case.
+Adds shared helper `isMembershipSubWithProductFetch` in `billing/membership-prices` for the per-sub filter case, with direct unit tests covering the cache-hit and fetch-failure paths.
+
+Also: bumps `/api/admin/backfill-revenue` `subscriptions.list` cap to 100 (matches the dedup helper; the prior 10 could silently truncate a customer's membership sub), and expands `data.customer` (2 levels, safe) on the invariant's `subscriptions.list` so the orphan-customer violation populates `customer_email` for triage instead of always serializing null. Founding-era invariant tests rewritten to pass `product` as a string id and assert `products.retrieve` is called — the prior inline-object shape masked the real Stripe response and the new fetch fallback path.

--- a/.changeset/stripe-expand-depth-sister-sites.md
+++ b/.changeset/stripe-expand-depth-sister-sites.md
@@ -1,0 +1,10 @@
+---
+---
+
+Drop over-deep Stripe expand at three sister sites the /sync hotfix (#3853) didn't reach. All three had been throwing on Stripe's 4-level expand limit:
+
+- `dedup-on-subscription-created` — `data.items.data.price.product` (5 levels) on `subscriptions.list`. The catch swallowed the error and fell through to `no_duplicate`, silently disabling the cross-path duplicate-subscription guard from #3245. Drop the product leg of the expand; tier label degrades to `lookup_key` (already the existing fallback).
+- `stripe-sub-reflected-in-org-row` invariant — `data.items.data.price.product` (5 levels) on `subscriptions.list`. The integrity check threw on every run, so the Lina/Adzymic-class detection wasn't actually firing. Drop expand; classify by lookup_key with a per-product `products.retrieve` fallback (cached across the run) for founding-era subs.
+- `/api/admin/backfill-revenue` — `subscriptions.data.items.data.price.product` (6 levels) on `customers.retrieve`. Whole loop crashed per customer. Replace with `subscriptions.list` + `pickMembershipSubWithProductFetch`, mirroring the /sync fix.
+
+Adds shared helper `isMembershipSubWithProductFetch` in `billing/membership-prices` for the per-sub filter case.

--- a/server/src/audit/integrity/invariants/stripe-sub-reflected-in-org-row.ts
+++ b/server/src/audit/integrity/invariants/stripe-sub-reflected-in-org-row.ts
@@ -32,7 +32,7 @@
  */
 import type Stripe from 'stripe';
 import type { Invariant, InvariantContext, InvariantResult, Violation } from '../types.js';
-import { isMembershipSub } from '../../../billing/membership-prices.js';
+import { isMembershipSubWithProductFetch } from '../../../billing/membership-prices.js';
 
 /**
  * Stripe statuses that grant entitlement at AAO. Mirrors the gate logic
@@ -97,21 +97,26 @@ export const stripeSubReflectedInOrgRowInvariant: Invariant = {
     // Cheaper than walking customers (2N+ calls) and bounded by the count of
     // live entitling subs, which is small at AAO scale.
     //
-    // Expand the price's product so `isMembershipSub` can fall back to
-    // `metadata.category='membership'` for founding-era prices that lack
-    // the `aao_membership_*` lookup_key convention. Without expansion those
-    // legacy subs (Adzymic, Advertible, Bidcliq, Equativ — May 2026)
-    // slipped through this filter and were invisible to the orphan-customer
-    // detection downstream.
+    // No expand — the path Stripe needs for product metadata
+    // (`data.items.data.price.product`) is 5 levels deep and over the
+    // 4-level limit, which made this invariant throw on every run. Walk
+    // the list with the lookup_key fast path; founding-era subs that
+    // lack the `aao_membership_*` convention fall through to a per-product
+    // `products.retrieve` (cached) so legacy prices (Adzymic, Advertible,
+    // Bidcliq, Equativ — May 2026) still classify as membership.
     const memberSubs: Stripe.Subscription[] = [];
+    const productCache = new Map<string, Stripe.Product | Stripe.DeletedProduct>();
     for (const status of ['active', 'trialing'] as const) {
       for await (const sub of stripe.subscriptions.list({
         status,
         limit: 100,
-        expand: ['data.items.data.price.product'],
       })) {
-        if (!isMembershipSub(sub)) continue;
-        memberSubs.push(sub);
+        const isMember = await isMembershipSubWithProductFetch(
+          sub,
+          (productId) => stripe.products.retrieve(productId),
+          productCache,
+        );
+        if (isMember) memberSubs.push(sub);
       }
     }
 

--- a/server/src/audit/integrity/invariants/stripe-sub-reflected-in-org-row.ts
+++ b/server/src/audit/integrity/invariants/stripe-sub-reflected-in-org-row.ts
@@ -97,19 +97,25 @@ export const stripeSubReflectedInOrgRowInvariant: Invariant = {
     // Cheaper than walking customers (2N+ calls) and bounded by the count of
     // live entitling subs, which is small at AAO scale.
     //
-    // No expand — the path Stripe needs for product metadata
-    // (`data.items.data.price.product`) is 5 levels deep and over the
-    // 4-level limit, which made this invariant throw on every run. Walk
-    // the list with the lookup_key fast path; founding-era subs that
-    // lack the `aao_membership_*` convention fall through to a per-product
-    // `products.retrieve` (cached) so legacy prices (Adzymic, Advertible,
-    // Bidcliq, Equativ — May 2026) still classify as membership.
+    // No `data.items.data.price.product` expand — the path Stripe needs for
+    // product metadata is 5 levels deep and over the 4-level limit, which
+    // made this invariant throw on every run. Walk the list with the
+    // lookup_key fast path; founding-era subs that lack the `aao_membership_*`
+    // convention fall through to a per-product `products.retrieve` (cached)
+    // so legacy prices (Adzymic, Advertible, Bidcliq, Equativ — May 2026)
+    // still classify as membership.
+    //
+    // `data.customer` (2 levels) is expanded so the orphan-customer
+    // violation can surface the customer's email for triage. Without it,
+    // `customer_email` always serializes null and admins have to click
+    // through to the Stripe Dashboard by id to know who to link.
     const memberSubs: Stripe.Subscription[] = [];
     const productCache = new Map<string, Stripe.Product | Stripe.DeletedProduct>();
     for (const status of ['active', 'trialing'] as const) {
       for await (const sub of stripe.subscriptions.list({
         status,
         limit: 100,
+        expand: ['data.customer'],
       })) {
         const isMember = await isMembershipSubWithProductFetch(
           sub,

--- a/server/src/billing/dedup-on-subscription-created.ts
+++ b/server/src/billing/dedup-on-subscription-created.ts
@@ -108,13 +108,20 @@ export async function dedupOnSubscriptionCreated(args: DedupArgs): Promise<Dedup
 
   let liveSubs: Stripe.Subscription[];
   try {
-    // Expand latest_invoice (for paid status) and product (for tier label
-    // in the customer email). limit: 100 is Stripe's max per page.
+    // Expand latest_invoice for paid status. The product expansion that
+    // used to ride alongside it (`data.items.data.price.product`) is 5
+    // levels deep and exceeds Stripe's 4-level expand limit, which broke
+    // every dedup check silently — the catch fell through to no_duplicate
+    // and the cross-path race guard never ran. `tierLabelForSub` already
+    // falls back to `price.lookup_key` (which comes back inline), so the
+    // customer-email tier label still reads correctly on lookup-keyed
+    // prices; founding-era prices without a lookup_key degrade to null
+    // (rare on the dedup path — those orgs don't double-checkout).
     const list = await stripe.subscriptions.list({
       customer: customerId,
       status: 'all',
       limit: 100,
-      expand: ['data.latest_invoice', 'data.items.data.price.product'],
+      expand: ['data.latest_invoice'],
     });
     if (list.has_more) {
       logger.warn(

--- a/server/src/billing/membership-prices.ts
+++ b/server/src/billing/membership-prices.ts
@@ -118,3 +118,31 @@ export async function pickMembershipSubWithProductFetch(
   if (candidates.length === 0) return null;
   return candidates.find((s) => s.status === 'active') ?? candidates[0];
 }
+
+/**
+ * Per-sub variant of the same fast-path / product-fetch pattern. Used
+ * when walking a stream of subs (the `stripe-sub-reflected-in-org-row`
+ * invariant) where we filter rather than pick. `productCache` is shared
+ * across calls so a Stripe product backing many founding-era subs costs
+ * one `products.retrieve`, not one per sub.
+ */
+export async function isMembershipSubWithProductFetch(
+  sub: Stripe.Subscription,
+  fetchProduct: (productId: string) => Promise<Stripe.Product | Stripe.DeletedProduct>,
+  productCache?: Map<string, Stripe.Product | Stripe.DeletedProduct>,
+): Promise<boolean> {
+  if (isMembershipSub(sub)) return true;
+  const price = sub.items.data[0]?.price;
+  if (!price) return false;
+  const productId = typeof price.product === 'string' ? price.product : null;
+  if (!productId) return false;
+  const cached = productCache?.get(productId);
+  if (cached) return isMembershipProductByMetadata(cached);
+  try {
+    const product = await fetchProduct(productId);
+    productCache?.set(productId, product);
+    return isMembershipProductByMetadata(product);
+  } catch {
+    return false;
+  }
+}

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -31,6 +31,7 @@ import { stripe, STRIPE_WEBHOOK_SECRET, createStripeCustomer, createCustomerPort
 import { handleSubscriptionCreated, type ActivationAdminContext } from "./billing/handle-subscription-created.js";
 import { resolveOrgForStripeCustomer } from "./billing/webhook-helpers.js";
 import { dedupOnSubscriptionCreated } from "./billing/dedup-on-subscription-created.js";
+import { pickMembershipSubWithProductFetch } from "./billing/membership-prices.js";
 import Stripe from "stripe";
 import { OrganizationDatabase, getUserSeatType, buildSubscriptionUpdate, TIER_PRESERVING_STATUSES, type SeatType, type MembershipTier } from "./db/organization-db.js";
 import { MemberDatabase } from "./db/member-db.js";
@@ -5216,30 +5217,38 @@ export class HTTPServer {
         let subscriptionsFailed = 0;
         let customersSkipped = 0; // Deleted or missing customers
         if (stripe) {
+          const stripeClient = stripe;
           for (const [customerId, workosOrgId] of customerOrgMap) {
             try {
-              // Get customer with subscriptions and expanded price/product data in single API call
-              const customer = await stripe.customers.retrieve(customerId, {
-                expand: ['subscriptions.data.items.data.price.product'],
-              });
+              // Confirm the customer still exists / isn't deleted. Don't
+              // expand subscriptions here — `subscriptions.data.items.data.price.product`
+              // is 6 levels and exceeds Stripe's 4-level expand limit, which
+              // crashed every customer in this loop.
+              const customer = await stripeClient.customers.retrieve(customerId);
 
               if ('deleted' in customer && customer.deleted) {
                 customersSkipped++;
                 continue;
               }
 
-              const subscriptions = (customer as Stripe.Customer).subscriptions;
-              if (!subscriptions || subscriptions.data.length === 0) {
-                continue;
-              }
+              // List subs separately. Price comes back inline (lookup_key,
+              // unit_amount, etc.); founding-era prices that need product
+              // metadata are resolved by per-sub `products.retrieve` inside
+              // pickMembershipSubWithProductFetch.
+              const subsResult = await stripeClient.subscriptions.list({
+                customer: customerId,
+                status: 'all',
+                limit: 10,
+              });
 
-              // Get the first active subscription (already has expanded items)
-              const subscription = subscriptions.data[0];
+              const subscription = await pickMembershipSubWithProductFetch(
+                subsResult.data,
+                (productId) => stripeClient.products.retrieve(productId),
+              );
               if (!subscription || !(TIER_PRESERVING_STATUSES as readonly string[]).includes(subscription.status)) {
                 continue;
               }
 
-              // Get primary subscription item directly from expanded data
               const primaryItem = subscription.items.data[0];
               if (!primaryItem) {
                 continue;

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -5234,11 +5234,13 @@ export class HTTPServer {
               // List subs separately. Price comes back inline (lookup_key,
               // unit_amount, etc.); founding-era prices that need product
               // metadata are resolved by per-sub `products.retrieve` inside
-              // pickMembershipSubWithProductFetch.
+              // pickMembershipSubWithProductFetch. limit: 100 matches the
+              // dedup helper — a customer with more lifetime subs than the
+              // cap could have its membership sub silently truncated out.
               const subsResult = await stripeClient.subscriptions.list({
                 customer: customerId,
                 status: 'all',
-                limit: 10,
+                limit: 100,
               });
 
               const subscription = await pickMembershipSubWithProductFetch(

--- a/server/tests/unit/billing/membership-prices.test.ts
+++ b/server/tests/unit/billing/membership-prices.test.ts
@@ -11,6 +11,7 @@ import {
   isMembershipLookupKey,
   isMembershipProductByMetadata,
   isMembershipSub,
+  isMembershipSubWithProductFetch,
   pickMembershipSub,
   pickMembershipSubWithProductFetch,
 } from '../../../src/billing/membership-prices.js';
@@ -245,6 +246,74 @@ describe('pickMembershipSubWithProductFetch', () => {
     ];
     const result = await pickMembershipSubWithProductFetch(subs, fetchProduct);
     expect(result).toBeNull();
+    expect(fetchProduct).not.toHaveBeenCalled();
+  });
+});
+
+describe('isMembershipSubWithProductFetch', () => {
+  it('returns true for a lookup_key match without invoking fetchProduct', async () => {
+    const fetchProduct = vi.fn();
+    const sub = fakeSub({ lookup_key: 'aao_membership_explorer_50', product: 'prod_x' });
+    expect(await isMembershipSubWithProductFetch(sub, fetchProduct)).toBe(true);
+    expect(fetchProduct).not.toHaveBeenCalled();
+  });
+
+  it('returns true via metadata fallback when lookup_key is missing', async () => {
+    const fetchProduct = vi.fn().mockResolvedValue({
+      id: 'prod_founding', metadata: { category: 'membership' },
+    });
+    const sub = fakeSub({ lookup_key: null, product: 'prod_founding' });
+    expect(await isMembershipSubWithProductFetch(sub, fetchProduct)).toBe(true);
+    expect(fetchProduct).toHaveBeenCalledWith('prod_founding');
+  });
+
+  it('returns false when neither lookup_key nor product metadata classifies as membership', async () => {
+    const fetchProduct = vi.fn().mockResolvedValue({
+      id: 'prod_event', metadata: { category: 'event' },
+    });
+    const sub = fakeSub({ lookup_key: null, product: 'prod_event' });
+    expect(await isMembershipSubWithProductFetch(sub, fetchProduct)).toBe(false);
+  });
+
+  it('uses the cache when present — second call on same product id does not fetch', async () => {
+    const fetchProduct = vi.fn().mockResolvedValue({
+      id: 'prod_founding', metadata: { category: 'membership' },
+    });
+    const cache = new Map();
+    const sub1 = fakeSub({ id: 'sub_a', lookup_key: null, product: 'prod_founding' });
+    const sub2 = fakeSub({ id: 'sub_b', lookup_key: null, product: 'prod_founding' });
+    expect(await isMembershipSubWithProductFetch(sub1, fetchProduct, cache)).toBe(true);
+    expect(await isMembershipSubWithProductFetch(sub2, fetchProduct, cache)).toBe(true);
+    expect(fetchProduct).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false silently on fetch error — never throws', async () => {
+    // Documented trade-off: a transient Stripe error misclassifies a
+    // founding-era sub as non-membership for one audit run, rather than
+    // failing the whole audit. The audit re-runs; persistent failures
+    // surface via Stripe-side ops, not by throwing here.
+    const fetchProduct = vi.fn().mockRejectedValue(new Error('Stripe transient'));
+    const sub = fakeSub({ lookup_key: null, product: 'prod_flaky' });
+    expect(await isMembershipSubWithProductFetch(sub, fetchProduct)).toBe(false);
+  });
+
+  it('returns false when sub has no price', async () => {
+    const fetchProduct = vi.fn();
+    const sub = { items: { data: [] } } as unknown as Stripe.Subscription;
+    expect(await isMembershipSubWithProductFetch(sub, fetchProduct)).toBe(false);
+    expect(fetchProduct).not.toHaveBeenCalled();
+  });
+
+  it('returns false when product is already expanded but non-membership (no fetch)', async () => {
+    // Mirrors the invariant test at the same site: when a caller did expand
+    // the product inline and it's an event/non-membership, the sync path of
+    // isMembershipSub already returned false and we should not refetch.
+    const fetchProduct = vi.fn();
+    const sub = fakeSub({
+      lookup_key: null,
+      product: { id: 'prod_event', metadata: { category: 'event' } },
+    });
+    expect(await isMembershipSubWithProductFetch(sub, fetchProduct)).toBe(false);
     expect(fetchProduct).not.toHaveBeenCalled();
   });
 });

--- a/server/tests/unit/integrity/invariants.test.ts
+++ b/server/tests/unit/integrity/invariants.test.ts
@@ -22,6 +22,7 @@ const mockPoolQuery = vi.fn();
 const mockStripeCustomersRetrieve = vi.fn();
 const mockStripeSubsList = vi.fn();
 const mockStripeSubsRetrieve = vi.fn();
+const mockStripeProductsRetrieve = vi.fn();
 const mockWorkosListMemberships = vi.fn();
 
 function makeCtx(): InvariantContext {
@@ -30,6 +31,7 @@ function makeCtx(): InvariantContext {
     stripe: {
       customers: { retrieve: mockStripeCustomersRetrieve },
       subscriptions: { list: mockStripeSubsList, retrieve: mockStripeSubsRetrieve },
+      products: { retrieve: mockStripeProductsRetrieve },
     } as unknown as InvariantContext['stripe'],
     workos: {
       userManagement: { listOrganizationMemberships: mockWorkosListMemberships },
@@ -47,6 +49,7 @@ beforeEach(() => {
   mockStripeCustomersRetrieve.mockReset();
   mockStripeSubsList.mockReset();
   mockStripeSubsRetrieve.mockReset();
+  mockStripeProductsRetrieve.mockReset();
   mockWorkosListMemberships.mockReset();
 });
 
@@ -506,18 +509,27 @@ describe('stripe-sub-reflected-in-org-row', () => {
     // category=membership metadata. Pre-fix this filter excluded them; the
     // orphan-customer detection downstream never saw them, so admins had no
     // signal that paying customers weren't linked to AAO orgs.
+    //
+    // `product` is a string id here, matching what Stripe actually returns
+    // post the expand-depth fix. The invariant resolves it via the
+    // `isMembershipSubWithProductFetch` fallback (one `products.retrieve`).
     const sub = membershipSub({
       id: 'sub_bidcliq',
       customer: 'cus_bidcliq',
       lookup_key: null,
       unit_amount: 250000,
-      product: { id: 'prod_founding_smb', metadata: { category: 'membership' } },
+      product: 'prod_founding_smb',
     });
     mockSubsListWith([sub]);
+    mockStripeProductsRetrieve.mockResolvedValueOnce({
+      id: 'prod_founding_smb',
+      metadata: { category: 'membership' },
+    });
     mockPoolQuery.mockResolvedValueOnce({ rows: [] }); // no AAO org linked to cus_bidcliq
 
     const result = await stripeSubReflectedInOrgRowInvariant.check(makeCtx());
 
+    expect(mockStripeProductsRetrieve).toHaveBeenCalledWith('prod_founding_smb');
     expect(result.checked).toBe(1);
     expect(result.violations).toHaveLength(1);
     expect(result.violations[0].severity).toBe('warning');
@@ -538,18 +550,66 @@ describe('stripe-sub-reflected-in-org-row', () => {
       customer: 'cus_equativ',
       lookup_key: null,
       unit_amount: 1000000,
-      product: { id: 'prod_founding_corp', metadata: { category: 'membership' } },
+      product: 'prod_founding_corp',
     });
     mockSubsListWith([sub]);
+    mockStripeProductsRetrieve.mockResolvedValueOnce({
+      id: 'prod_founding_corp',
+      metadata: { category: 'membership' },
+    });
     mockPoolQuery.mockResolvedValueOnce({ rows: [] });
 
     const result = await stripeSubReflectedInOrgRowInvariant.check(makeCtx());
 
+    expect(mockStripeProductsRetrieve).toHaveBeenCalledWith('prod_founding_corp');
     expect(result.checked).toBe(1);
     expect(result.violations).toHaveLength(1);
     expect(result.violations[0].severity).toBe('warning');
     expect(result.violations[0].subject_id).toBe('cus_equativ');
     expect(result.violations[0].details?.unit_amount).toBe(1000000);
+  });
+
+  it('caches product fetches across subs that share a product id (one retrieve, not N)', async () => {
+    // Two founding-era subs on the same Stripe product. The per-run
+    // productCache in the invariant should fold them into a single
+    // products.retrieve. Without the cache, an account with the
+    // Startup/SMB cohort would multiply Stripe API calls per audit run.
+    const sub1 = membershipSub({
+      id: 'sub_a', customer: 'cus_a', lookup_key: null, product: 'prod_founding_smb',
+    });
+    const sub2 = membershipSub({
+      id: 'sub_b', customer: 'cus_b', lookup_key: null, product: 'prod_founding_smb',
+    });
+    mockSubsListWith([sub1, sub2]);
+    mockStripeProductsRetrieve.mockResolvedValueOnce({
+      id: 'prod_founding_smb',
+      metadata: { category: 'membership' },
+    });
+    mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+
+    const result = await stripeSubReflectedInOrgRowInvariant.check(makeCtx());
+
+    expect(mockStripeProductsRetrieve).toHaveBeenCalledTimes(1);
+    expect(result.checked).toBe(2);
+    expect(result.violations).toHaveLength(2);
+  });
+
+  it('skips a sub whose product fetch fails (Stripe transient) — does not throw the whole audit', async () => {
+    // Founding-era sub whose products.retrieve rejects. The helper swallows
+    // and returns false; invariant continues. Behavior trade-off: a flaky
+    // Stripe momentarily hides a real founding-era sub from the audit run,
+    // but the next run will catch it. Worse alternative would be throwing
+    // and losing the rest of the audit's findings.
+    const sub = membershipSub({
+      id: 'sub_flaky', customer: 'cus_flaky', lookup_key: null, product: 'prod_flaky',
+    });
+    mockSubsListWith([sub]);
+    mockStripeProductsRetrieve.mockRejectedValueOnce(new Error('Stripe transient'));
+
+    const result = await stripeSubReflectedInOrgRowInvariant.check(makeCtx());
+
+    expect(result.checked).toBe(0);
+    expect(result.violations).toEqual([]);
   });
 
   it('does not flag a row with subscription_status="past_due" — dunning still grants entitlement', async () => {


### PR DESCRIPTION
## Summary

The /sync hotfix in #3853 replaced its over-deep `data.items.data.price.product` expand with a separate `subscriptions.list` + per-product fetch. Three sister sites still had the broken pattern and were silently failing on Stripe's 4-level expand limit:

- **`dedup-on-subscription-created.ts:117`** — 5-level expand on `subscriptions.list`. The `try/catch` swallowed the Stripe error and fell through to `no_duplicate`, silently disabling the cross-path duplicate-subscription guard from #3245. **Highest impact** — dedup hasn't been running since the expand limit shipped.
- **`stripe-sub-reflected-in-org-row` invariant** — 5-level expand on `subscriptions.list`. Threw on every run, so the Lina/Adzymic-class detection wasn't firing.
- **`/api/admin/backfill-revenue` (http.ts:5223)** — 6-level `subscriptions.data.items.data.price.product` on `customers.retrieve`. Whole loop crashed per customer.

The pattern at all three is: drop the over-deep expand, classify by `lookup_key` with a per-product `products.retrieve` fallback (cached) for founding-era prices that lack the `aao_membership_*` convention. Same shape as #3853.

Adds shared helper `isMembershipSubWithProductFetch` in `billing/membership-prices` (per-sub filter case, sibling to existing `pickMembershipSubWithProductFetch`).

The Slack alert that prompted this (`admin-accounts-billing` source, `data.items.data.price.product` in the message) was probably from before #3853 deployed — the /sync route in current main can no longer trigger that error. But the three sister sites would have started surfacing it once exercised.

## Test plan

- [x] `npx vitest run tests/unit/billing tests/unit/integrity` — 111 passed
- [x] `tsc --noEmit` clean
- [ ] Manual: hit `POST /api/admin/accounts/:orgId/sync` against an org with a real Stripe customer in dev (no regression vs. #3853)
- [ ] Manual: trigger an integrity audit run, confirm `stripe-sub-reflected-in-org-row` returns results instead of throwing
- [ ] Manual: run `/api/admin/backfill-revenue` against a small customer set in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)