### PR TITLE
fix(addie): emit tool_error person events on billing-tool refusals (closes #3721)

### DIFF
--- a/.changeset/billing-tool-error-events.md
+++ b/.changeset/billing-tool-error-events.md
@@ -1,0 +1,4 @@
+---
+---
+
+Closes #3721. Every refusal path in `send_invoice`, `confirm_send_invoice`, and `create_payment_link` now emits a `tool_error` person event with `{ tool, reason, lookup_key, org_id?, error? }` so admins can audit silent failures from the timeline. Resolves person_id from MemberContext (workos_user → slack_user fallback) at the tool boundary; recording is best-effort and never blocks the user-facing refusal. Adds `tool_error` to the `PersonEventType` union and 5 unit tests covering the new behavior.

--- a/server/src/addie/mcp/billing-tools.ts
+++ b/server/src/addie/mcp/billing-tools.ts
@@ -26,9 +26,60 @@ import {
   type BillingProduct,
 } from '../../billing/stripe-client.js';
 import { OrganizationDatabase } from '../../db/organization-db.js';
+import {
+  getRelationshipByWorkosId,
+  getRelationshipBySlackId,
+} from '../../db/relationship-db.js';
+import { recordEvent } from '../../db/person-events-db.js';
 
 const logger = createLogger('addie-billing-tools');
 const orgDb = new OrganizationDatabase();
+
+/**
+ * Resolve a person_id from a MemberContext, preferring workos_user (the more
+ * stable identifier) and falling back to slack_user. Returns null when the
+ * caller is genuinely anonymous — in that case `recordToolError` no-ops, so
+ * tool refusals are still safe to instrument blindly.
+ */
+async function resolvePersonId(ctx?: MemberContext | null): Promise<string | null> {
+  const workosId = ctx?.workos_user?.workos_user_id;
+  if (workosId) {
+    const rel = await getRelationshipByWorkosId(workosId);
+    if (rel) return rel.id;
+  }
+  const slackId = ctx?.slack_user?.slack_user_id;
+  if (slackId) {
+    const rel = await getRelationshipBySlackId(slackId);
+    if (rel) return rel.id;
+  }
+  return null;
+}
+
+/**
+ * Record a `tool_error` person event for an Addie billing-tool refusal.
+ * Best-effort — failures here log a warning but never throw, so a buggy
+ * recorder never blocks the user-facing refusal message.
+ *
+ * `data` keys are intentionally narrow (tool, reason, lookup_key, …) — admins
+ * read these from the timeline, and any user-supplied free text would
+ * effectively land in admin context.
+ */
+async function recordToolError(
+  ctx: MemberContext | null | undefined,
+  tool: string,
+  reason: string,
+  data: Record<string, unknown> = {},
+): Promise<void> {
+  try {
+    const personId = await resolvePersonId(ctx);
+    if (!personId) return;
+    await recordEvent(personId, 'tool_error', {
+      data: { tool, reason, ...data },
+    });
+  } catch (err) {
+    logger.warn({ err, tool, reason }, 'Failed to record tool_error event');
+  }
+}
 
 /**
  * Tool definitions for billing operations
@@ -246,12 +297,14 @@ export function createBillingToolHandlers(memberContext?: MemberContext | null):
     const orgId = memberContext?.organization?.workos_organization_id;
 
     if (!workosUserId || !memberEmail) {
+      await recordToolError(memberContext, 'create_payment_link', 'not_signed_in', { lookup_key: lookupKey });
       return JSON.stringify({
         success: false,
         error: 'Cannot create a payment link without a signed-in account. Ask the user to sign in at https://agenticadvertising.org first, then try again.',
       });
     }
     if (!orgId) {
+      await recordToolError(memberContext, 'create_payment_link', 'no_workspace', { lookup_key: lookupKey });
       return JSON.stringify({
         success: false,
         error: 'This user has an account but no workspace yet. They need to complete onboarding at https://agenticadvertising.org/dashboard to create their workspace before a payment link can be generated.',
@@ -263,6 +316,7 @@ export function createBillingToolHandlers(memberContext?: MemberContext | null):
     try {
       const priceId = await getPriceByLookupKey(lookupKey);
       if (!priceId) {
+        await recordToolError(memberContext, 'create_payment_link', 'unknown_lookup_key', { lookup_key: lookupKey, org_id: orgId });
         return JSON.stringify({
           success: false,
           error: `No product matches lookup_key "${lookupKey}". Call find_membership_products first, then pass the exact lookup_key from the result.`,
@@ -295,6 +349,7 @@ export function createBillingToolHandlers(memberContext?: MemberContext | null):
       });
 
       if (!session) {
+        await recordToolError(memberContext, 'create_payment_link', 'stripe_not_configured', { lookup_key: lookupKey, org_id: orgId });
         return JSON.stringify({
           success: false,
           error: 'Stripe is not configured. Please contact support.',
@@ -309,6 +364,7 @@ export function createBillingToolHandlers(memberContext?: MemberContext | null):
     } catch (error) {
       logger.error({ error }, 'Addie: Error creating payment link');
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      await recordToolError(memberContext, 'create_payment_link', 'exception', { lookup_key: lookupKey, org_id: orgId, error: errorMessage });
       return JSON.stringify({
         success: false,
         error: `Failed to create payment link: ${errorMessage}`,
@@ -327,6 +383,7 @@ export function createBillingToolHandlers(memberContext?: MemberContext | null):
     const memberEmail = memberContext?.workos_user?.email;
     const orgId = memberContext?.organization?.workos_organization_id;
     if (!memberEmail || !orgId) {
+      await recordToolError(memberContext, 'send_invoice', 'not_signed_in_or_no_workspace', { lookup_key: lookupKey });
       return JSON.stringify({
         success: false,
         error: 'Cannot preview an invoice without a signed-in member and a workspace. Ask the user to sign in at https://agenticadvertising.org first.',
@@ -364,6 +421,7 @@ export function createBillingToolHandlers(memberContext?: MemberContext | null):
       });
 
       if (!preview) {
+        await recordToolError(memberContext, 'send_invoice', 'product_not_found_or_stripe_unconfigured', { lookup_key: lookupKey, org_id: orgId });
         return JSON.stringify({
           success: false,
           error: 'Product not found or Stripe is not configured.',
@@ -388,6 +446,8 @@ export function createBillingToolHandlers(memberContext?: MemberContext | null):
       });
     } catch (error) {
       logger.error({ error }, 'Addie: Error previewing invoice');
+      const message = error instanceof Error ? error.message : 'unknown';
+      await recordToolError(memberContext, 'send_invoice', 'exception', { lookup_key: lookupKey, org_id: orgId, error: message });
       return JSON.stringify({
         success: false,
         error: 'Failed to preview invoice. Please try again.',
@@ -406,6 +466,7 @@ export function createBillingToolHandlers(memberContext?: MemberContext | null):
     const memberEmail = memberContext?.workos_user?.email;
     const orgId = memberContext?.organization?.workos_organization_id;
     if (!memberEmail || !orgId) {
+      await recordToolError(memberContext, 'confirm_send_invoice', 'not_signed_in_or_no_workspace', { lookup_key: lookupKey });
       return JSON.stringify({
         success: false,
         error: 'Cannot send an invoice without a signed-in member and a workspace. Ask the user to sign in at https://agenticadvertising.org first.',
@@ -425,6 +486,7 @@ export function createBillingToolHandlers(memberContext?: MemberContext | null):
     }
 
     if (!org) {
+      await recordToolError(memberContext, 'confirm_send_invoice', 'org_not_loaded', { lookup_key: lookupKey, org_id: orgId });
       return JSON.stringify({
         success: false,
         error: 'Could not load your organization. Please contact finance@agenticadvertising.org.',
@@ -432,6 +494,7 @@ export function createBillingToolHandlers(memberContext?: MemberContext | null):
     }
 
     if (!org.billing_address || !org.billing_address.line1) {
+      await recordToolError(memberContext, 'confirm_send_invoice', 'missing_billing_address', { lookup_key: lookupKey, org_id: orgId });
       return JSON.stringify({
         success: false,
         error: 'Your organization does not have a billing address on file. Please add one in the dashboard at https://agenticadvertising.org/dashboard/membership before requesting an invoice.',
@@ -467,6 +530,7 @@ export function createBillingToolHandlers(memberContext?: MemberContext | null):
       });
 
       if (!result) {
+        await recordToolError(memberContext, 'confirm_send_invoice', 'send_returned_null', { lookup_key: lookupKey, org_id: orgId });
         return JSON.stringify({
           success: false,
           error: 'Failed to send invoice. Stripe may not be configured or the product was not found.',
@@ -484,6 +548,7 @@ export function createBillingToolHandlers(memberContext?: MemberContext | null):
     } catch (error) {
       logger.error({ error }, 'Addie: Error sending invoice');
       const message = error instanceof Error ? error.message : 'Failed to send invoice. Please try again.';
+      await recordToolError(memberContext, 'confirm_send_invoice', 'exception', { lookup_key: lookupKey, org_id: orgId, error: message });
       return JSON.stringify({
         success: false,
         error: message,

--- a/server/src/addie/mcp/billing-tools.ts
+++ b/server/src/addie/mcp/billing-tools.ts
@@ -55,14 +55,42 @@ async function resolvePersonId(ctx?: MemberContext | null): Promise<string | nul
   return null;
 }
 
+/** Length cap for any user/LLM-supplied string we persist into event data. */
+const MAX_EVENT_STRING_LEN = 256;
+
+/**
+ * Sanitize a value for storage in `tool_error` event data. Strips Stripe-style
+ * identifiers and email addresses out of free-text — the timeline is admin-
+ * readable, and Stripe error messages routinely embed customer email,
+ * `cus_*` / `sub_*` / `pi_*` IDs, and card last-4 fragments. Errors are best
+ * diagnosed from the `tool` + `reason` slug + product key, not from a raw SDK
+ * message. Length-capped so an attacker-influenced `lookup_key` (LLM-supplied)
+ * can't bloat the timeline.
+ */
+function sanitizeEventValue(v: unknown): unknown {
+  if (typeof v !== 'string') return v;
+  return v
+    .replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, '[email]')
+    .replace(/\b(cus|sub|pi|in|ch|src|card|seti|tok)_[A-Za-z0-9]+\b/g, '[$1_id]')
+    .slice(0, MAX_EVENT_STRING_LEN);
+}
+
+function sanitizeEventData(data: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(data)) {
+    out[k] = sanitizeEventValue(v);
+  }
+  return out;
+}
+
 /**
  * Record a `tool_error` person event for an Addie billing-tool refusal.
  * Best-effort — failures here log a warning but never throw, so a buggy
  * recorder never blocks the user-facing refusal message.
  *
- * `data` keys are intentionally narrow (tool, reason, lookup_key, …) — admins
- * read these from the timeline, and any user-supplied free text would
- * effectively land in admin context.
+ * All string values in `data` pass through `sanitizeEventValue` so a Stripe
+ * SDK message or an LLM-supplied lookup_key cannot smuggle PII or oversize
+ * content into the admin-readable timeline.
  */
 async function recordToolError(
   ctx: MemberContext | null | undefined,
@@ -74,7 +102,7 @@ async function recordToolError(
     const personId = await resolvePersonId(ctx);
     if (!personId) return;
     await recordEvent(personId, 'tool_error', {
-      data: { tool, reason, ...data },
+      data: { tool, reason, ...sanitizeEventData(data) },
     });
   } catch (err) {
     logger.warn({ err, tool, reason }, 'Failed to record tool_error event');
@@ -382,8 +410,15 @@ export function createBillingToolHandlers(memberContext?: MemberContext | null):
 
     const memberEmail = memberContext?.workos_user?.email;
     const orgId = memberContext?.organization?.workos_organization_id;
-    if (!memberEmail || !orgId) {
-      await recordToolError(memberContext, 'send_invoice', 'not_signed_in_or_no_workspace', { lookup_key: lookupKey });
+    if (!memberEmail) {
+      await recordToolError(memberContext, 'send_invoice', 'not_signed_in', { lookup_key: lookupKey });
+      return JSON.stringify({
+        success: false,
+        error: 'Cannot preview an invoice without a signed-in member and a workspace. Ask the user to sign in at https://agenticadvertising.org first.',
+      });
+    }
+    if (!orgId) {
+      await recordToolError(memberContext, 'send_invoice', 'no_workspace', { lookup_key: lookupKey });
       return JSON.stringify({
         success: false,
         error: 'Cannot preview an invoice without a signed-in member and a workspace. Ask the user to sign in at https://agenticadvertising.org first.',
@@ -465,8 +500,15 @@ export function createBillingToolHandlers(memberContext?: MemberContext | null):
 
     const memberEmail = memberContext?.workos_user?.email;
     const orgId = memberContext?.organization?.workos_organization_id;
-    if (!memberEmail || !orgId) {
-      await recordToolError(memberContext, 'confirm_send_invoice', 'not_signed_in_or_no_workspace', { lookup_key: lookupKey });
+    if (!memberEmail) {
+      await recordToolError(memberContext, 'confirm_send_invoice', 'not_signed_in', { lookup_key: lookupKey });
+      return JSON.stringify({
+        success: false,
+        error: 'Cannot send an invoice without a signed-in member and a workspace. Ask the user to sign in at https://agenticadvertising.org first.',
+      });
+    }
+    if (!orgId) {
+      await recordToolError(memberContext, 'confirm_send_invoice', 'no_workspace', { lookup_key: lookupKey });
       return JSON.stringify({
         success: false,
         error: 'Cannot send an invoice without a signed-in member and a workspace. Ask the user to sign in at https://agenticadvertising.org first.',

--- a/server/src/db/person-events-db.ts
+++ b/server/src/db/person-events-db.ts
@@ -37,7 +37,8 @@ export type PersonEventType =
   | 'invite_sent'           // membership invite emailed to recipient
   | 'invite_accepted'       // recipient signed in and accepted
   | 'invite_revoked'        // admin revoked before accept
-  | 'invite_expired';       // expires_at passed without accept/revoke (sweep)
+  | 'invite_expired'        // expires_at passed without accept/revoke (sweep)
+  | 'tool_error';           // an Addie tool refused / errored — data carries { tool, reason, ... }
 
 export interface PersonEvent {
   id: number;

--- a/tests/addie/billing-tools.test.ts
+++ b/tests/addie/billing-tools.test.ts
@@ -599,7 +599,6 @@ describe('billing-tools', () => {
     });
 
     test('send_invoice without a signed-in member emits tool_error and refuses', async () => {
-      const billingTools = await import('../../server/src/addie/mcp/billing-tools.js');
       // Anonymous-on-Slack: no workos_user, but slack_user is present.
       const slackOnly: MemberContext = {
         is_mapped: false,

--- a/tests/addie/billing-tools.test.ts
+++ b/tests/addie/billing-tools.test.ts
@@ -4,13 +4,30 @@
 import { describe, test, expect, vi, beforeEach, type Mock } from 'vitest';
 import type { MemberContext } from '../../server/src/addie/member-context.js';
 
-const { mockGetOrganization, mockSearchOrganizations, mockGetOrCreateStripeCustomer } = vi.hoisted(() => {
+const {
+  mockGetOrganization,
+  mockSearchOrganizations,
+  mockGetOrCreateStripeCustomer,
+  mockGetRelationshipByWorkosId,
+  mockGetRelationshipBySlackId,
+  mockRecordEvent,
+} = vi.hoisted(() => {
   const mockGetOrganization = vi.fn<any>();
   const mockSearchOrganizations = vi.fn<any>();
   const mockGetOrCreateStripeCustomer = vi.fn<any>().mockImplementation(
     async (_orgId: string, createFn: () => Promise<string | null>) => createFn()
   );
-  return { mockGetOrganization, mockSearchOrganizations, mockGetOrCreateStripeCustomer };
+  const mockGetRelationshipByWorkosId = vi.fn<any>();
+  const mockGetRelationshipBySlackId = vi.fn<any>();
+  const mockRecordEvent = vi.fn<any>().mockResolvedValue(undefined);
+  return {
+    mockGetOrganization,
+    mockSearchOrganizations,
+    mockGetOrCreateStripeCustomer,
+    mockGetRelationshipByWorkosId,
+    mockGetRelationshipBySlackId,
+    mockRecordEvent,
+  };
 });
 
 // Mock the stripe-client module
@@ -33,6 +50,16 @@ vi.mock('../../server/src/db/organization-db.js', () => {
     },
   };
 });
+
+// Mock relationship + person-events modules so refusal-path tool_error
+// emission doesn't try to hit a real DB pool.
+vi.mock('../../server/src/db/relationship-db.js', () => ({
+  getRelationshipByWorkosId: mockGetRelationshipByWorkosId,
+  getRelationshipBySlackId: mockGetRelationshipBySlackId,
+}));
+vi.mock('../../server/src/db/person-events-db.js', () => ({
+  recordEvent: mockRecordEvent,
+}));
 
 /** Member context with an organization for payment link tests */
 const mockMemberContext: MemberContext = {
@@ -556,6 +583,129 @@ describe('billing-tools', () => {
       expect(toolNames).toContain('create_payment_link');
       expect(toolNames).toContain('send_invoice');
       expect(toolNames).toContain('confirm_send_invoice');
+    });
+  });
+
+  // #3721 — every billing-tool refusal must leave a tool_error person event
+  // so admins can debug failures from the timeline. Without these, send_invoice
+  // can fail silently the way it did during the original incident.
+  describe('refusal paths emit tool_error events', () => {
+    const personId = 'person_test_abc';
+
+    beforeEach(() => {
+      mockGetRelationshipByWorkosId.mockResolvedValue({ id: personId });
+      mockGetRelationshipBySlackId.mockResolvedValue(null);
+      mockRecordEvent.mockResolvedValue(undefined);
+    });
+
+    test('send_invoice without a signed-in member emits tool_error and refuses', async () => {
+      const billingTools = await import('../../server/src/addie/mcp/billing-tools.js');
+      // Anonymous-on-Slack: no workos_user, but slack_user is present.
+      const slackOnly: MemberContext = {
+        is_mapped: false,
+        is_member: false,
+        slack_linked: true,
+        slack_user: { slack_user_id: 'U_GREG', display_name: 'Greg', email: null },
+      } as any;
+      mockGetRelationshipByWorkosId.mockResolvedValue(null);
+      mockGetRelationshipBySlackId.mockResolvedValue({ id: personId });
+
+      const { createBillingToolHandlers } = await import('../../server/src/addie/mcp/billing-tools.js');
+      const handlers = createBillingToolHandlers(slackOnly);
+
+      const result = JSON.parse(await handlers.get('send_invoice')({ lookup_key: 'aao_membership_explorer_50' }));
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/sign in/i);
+
+      expect(mockRecordEvent).toHaveBeenCalledWith(
+        personId,
+        'tool_error',
+        expect.objectContaining({
+          data: expect.objectContaining({
+            tool: 'send_invoice',
+            reason: 'not_signed_in_or_no_workspace',
+            lookup_key: 'aao_membership_explorer_50',
+          }),
+        }),
+      );
+    });
+
+    test('confirm_send_invoice without a billing address emits tool_error', async () => {
+      mockGetOrganization.mockResolvedValue({
+        workos_organization_id: 'org_test_123',
+        name: 'Test Corp',
+        billing_address: null,
+      });
+      const { createBillingToolHandlers } = await import('../../server/src/addie/mcp/billing-tools.js');
+      const handlers = createBillingToolHandlers(mockMemberContext);
+
+      const result = JSON.parse(await handlers.get('confirm_send_invoice')({
+        lookup_key: 'aao_membership_explorer_50',
+      }));
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/billing address/i);
+
+      expect(mockRecordEvent).toHaveBeenCalledWith(
+        personId,
+        'tool_error',
+        expect.objectContaining({
+          data: expect.objectContaining({
+            tool: 'confirm_send_invoice',
+            reason: 'missing_billing_address',
+            org_id: 'org_test_123',
+          }),
+        }),
+      );
+    });
+
+    test('create_payment_link with bad lookup_key emits tool_error', async () => {
+      const stripeMock = await import('../../server/src/billing/stripe-client.js');
+      (stripeMock.getPriceByLookupKey as any).mockResolvedValue(null);
+
+      const { createBillingToolHandlers } = await import('../../server/src/addie/mcp/billing-tools.js');
+      const handlers = createBillingToolHandlers(mockMemberContext);
+
+      const result = JSON.parse(await handlers.get('create_payment_link')({
+        lookup_key: 'bogus_key_does_not_exist',
+      }));
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/No product matches/i);
+
+      expect(mockRecordEvent).toHaveBeenCalledWith(
+        personId,
+        'tool_error',
+        expect.objectContaining({
+          data: expect.objectContaining({
+            tool: 'create_payment_link',
+            reason: 'unknown_lookup_key',
+            lookup_key: 'bogus_key_does_not_exist',
+          }),
+        }),
+      );
+    });
+
+    test('truly anonymous caller with no relationship row no-ops gracefully (no event)', async () => {
+      mockGetRelationshipByWorkosId.mockResolvedValue(null);
+      mockGetRelationshipBySlackId.mockResolvedValue(null);
+
+      const { createBillingToolHandlers } = await import('../../server/src/addie/mcp/billing-tools.js');
+      const handlers = createBillingToolHandlers(null);
+
+      const result = JSON.parse(await handlers.get('send_invoice')!({ lookup_key: 'aao_membership_explorer_50' }));
+      expect(result.success).toBe(false);
+      expect(mockRecordEvent).not.toHaveBeenCalled();
+    });
+
+    test('recordEvent throwing does not break the user-facing refusal', async () => {
+      mockRecordEvent.mockRejectedValueOnce(new Error('DB pool exhausted'));
+
+      const { createBillingToolHandlers } = await import('../../server/src/addie/mcp/billing-tools.js');
+      const noEmail: MemberContext = { ...mockMemberContext, workos_user: undefined } as any;
+      const handlers = createBillingToolHandlers(noEmail);
+
+      const result = JSON.parse(await handlers.get('send_invoice')!({ lookup_key: 'foo' }));
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/sign in/i);
     });
   });
 });

--- a/tests/addie/billing-tools.test.ts
+++ b/tests/addie/billing-tools.test.ts
@@ -623,7 +623,7 @@ describe('billing-tools', () => {
         expect.objectContaining({
           data: expect.objectContaining({
             tool: 'send_invoice',
-            reason: 'not_signed_in_or_no_workspace',
+            reason: 'not_signed_in',
             lookup_key: 'aao_membership_explorer_50',
           }),
         }),
@@ -697,15 +697,74 @@ describe('billing-tools', () => {
     });
 
     test('recordEvent throwing does not break the user-facing refusal', async () => {
+      // Use a slack-only ctx so resolvePersonId returns a real id and recordEvent
+      // is actually invoked (and then throws). The previous shape resolved to null
+      // and silently skipped recordEvent, never exercising the throw safety net.
+      const slackOnly: MemberContext = {
+        is_mapped: false,
+        is_member: false,
+        slack_linked: true,
+        slack_user: { slack_user_id: 'U_THROW', display_name: 'Throw', email: null },
+      } as any;
+      mockGetRelationshipByWorkosId.mockResolvedValue(null);
+      mockGetRelationshipBySlackId.mockResolvedValue({ id: personId });
       mockRecordEvent.mockRejectedValueOnce(new Error('DB pool exhausted'));
 
       const { createBillingToolHandlers } = await import('../../server/src/addie/mcp/billing-tools.js');
-      const noEmail: MemberContext = { ...mockMemberContext, workos_user: undefined } as any;
-      const handlers = createBillingToolHandlers(noEmail);
+      const handlers = createBillingToolHandlers(slackOnly);
 
       const result = JSON.parse(await handlers.get('send_invoice')!({ lookup_key: 'foo' }));
       expect(result.success).toBe(false);
       expect(result.error).toMatch(/sign in/i);
+      expect(mockRecordEvent).toHaveBeenCalledTimes(1);
+    });
+
+    test('sanitizes Stripe-style identifiers and email out of error data', async () => {
+      mockGetOrganization.mockResolvedValue({
+        workos_organization_id: 'org_test_123',
+        name: 'Test Corp',
+        billing_address: { line1: '1 Way' },
+      });
+      const stripeMock = await import('../../server/src/billing/stripe-client.js');
+      // Simulate a Stripe error message that embeds PII — email + customer id.
+      (stripeMock.createAndSendInvoice as any).mockRejectedValue(
+        new Error('No such customer: cus_ABC123 for victim@example.com'),
+      );
+
+      const { createBillingToolHandlers } = await import('../../server/src/addie/mcp/billing-tools.js');
+      const handlers = createBillingToolHandlers(mockMemberContext);
+
+      await handlers.get('confirm_send_invoice')!({ lookup_key: 'aao_membership_explorer_50' });
+
+      const call = mockRecordEvent.mock.calls.find(
+        ([, type, opts]: any[]) => type === 'tool_error' && opts.data.reason === 'exception',
+      );
+      expect(call, 'expected an exception-path tool_error event').toBeTruthy();
+      const errString = call![2].data.error as string;
+      expect(errString).not.toContain('victim@example.com');
+      expect(errString).not.toContain('cus_ABC123');
+      expect(errString).toMatch(/\[email\]/);
+      expect(errString).toMatch(/\[cus_id\]/);
+    });
+
+    test('caps oversized lookup_key in event data', async () => {
+      // confirm_send_invoice with a missing billing address fires a refusal
+      // after the ctx is fully populated, so recordToolError actually writes.
+      mockGetOrganization.mockResolvedValue({
+        workos_organization_id: 'org_test_123',
+        name: 'Test Corp',
+        billing_address: null,
+      });
+      const huge = 'a'.repeat(1024);
+      const { createBillingToolHandlers } = await import('../../server/src/addie/mcp/billing-tools.js');
+      const handlers = createBillingToolHandlers(mockMemberContext);
+
+      await handlers.get('confirm_send_invoice')!({ lookup_key: huge });
+
+      const call = mockRecordEvent.mock.calls[0];
+      expect(call).toBeTruthy();
+      const stored = call![2].data.lookup_key as string;
+      expect(stored.length).toBeLessThanOrEqual(256);
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #3721 (the part deferred from #3856).

Every refusal path in `send_invoice`, `confirm_send_invoice`, and `create_payment_link` now emits a `tool_error` person event with `{ tool, reason, lookup_key, org_id?, error? }`. The original Greg-thread incident left zero trace in `person_events`; this closes that gap so admins can debug silent failures from the relationship timeline.

## Changes

- **`server/src/db/person-events-db.ts`**: add `tool_error` to the `PersonEventType` union.
- **`server/src/addie/mcp/billing-tools.ts`**:
  - `resolvePersonId(ctx)` resolves person_id from MemberContext (workos_user_id → slack_user_id fallback) at the tool boundary so we don't need to plumb person_id through context-building sites.
  - `recordToolError(ctx, tool, reason, data)` is best-effort and try/catch-wrapped — a buggy recorder never blocks the user-facing refusal message.
  - Wired into 13 refusal paths with distinct `reason` slugs:
    - `not_signed_in`, `no_workspace`, `unknown_lookup_key`, `stripe_not_configured`, `exception` (create_payment_link)
    - `not_signed_in_or_no_workspace`, `product_not_found_or_stripe_unconfigured`, `exception` (send_invoice)
    - `not_signed_in_or_no_workspace`, `org_not_loaded`, `missing_billing_address`, `send_returned_null`, `exception` (confirm_send_invoice)
- **`tests/addie/billing-tools.test.ts`**: add 5 unit tests covering the new emission shape, slack-only fallback, anonymous-no-event, and the safety contract that recordEvent throwing does not break the refusal.

## Test plan

- [x] `npx vitest run tests/addie/billing-tools.test.ts` — 25 pass (20 existing + 5 new)
- [x] `tsc --project server/tsconfig.json --noEmit` clean
- [ ] Manual: in production, induce a send_invoice refusal (sign in to a workspace with no billing address, ask Addie to send an invoice) and check the person's timeline shows the `tool_error` event with `reason: "missing_billing_address"`.

## Related

- #3856 — empty-turn safeguard (the model-layer half of #3721)
- #3724 — billing-tooling fixes from the original incident
- #3855 — banned fabricated ticket numbers (sister Addie issue)

Together with #3856 these ensure no future Greg gets a silent refusal that nobody can debug — model-layer empty turns get logged, and tool-layer refusals leave structured events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
