### PR TITLE
ci(deploy): smoke training-agent tenants after rolling restart

### DIFF
--- a/.changeset/deploy-smoke-training-agent-tenants.md
+++ b/.changeset/deploy-smoke-training-agent-tenants.md
@@ -1,0 +1,6 @@
+---
+---
+
+Post-deploy smoke step that POSTs `tools/list` to each training-agent tenant URL (`/sales`, `/signals`, `/governance`, `/creative`, `/creative-builder`, `/brand`) plus the legacy `/mcp` alias and fails the deploy if any return a non-200/401 status. Closes #3878.
+
+Two recent hotfixes (#3854, #3869) shipped clean through CI but caused production outages because the failure modes were `NODE_ENV=production`-gated: `createInMemoryTaskRegistry` throwing on init, and `noopJwksValidator` throwing under a now-removed prod guard that left every tenant `disabled`. Both surfaced as 404 ("Tenant not registered") or 5xx on per-tenant POSTs — failure modes that happen *before* auth, so an unauthenticated `tools/list` is sufficient to detect them. 401 is treated as healthy (registry resolved, just no token); only 404, 5xx, and timeouts are deploy-fatal.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,23 +104,47 @@ jobs:
             "/brand/mcp"
             "/mcp"
           )
-          fail=0
-          for path in "${paths[@]}"; do
-            url="${base}${path}"
-            code=$(curl -sS -o /tmp/smoke-body -w '%{http_code}' \
+          # Build curl args once. Omit the Authorization header when the secret
+          # is unset so a strict-bearer-format server can't 400 us into a false
+          # deploy failure — we accept 401 as healthy anyway.
+          auth_args=()
+          if [ -n "${PUBLIC_TEST_AGENT_TOKEN:-}" ]; then
+            auth_args=(-H "Authorization: Bearer ${PUBLIC_TEST_AGENT_TOKEN}")
+          fi
+          # Single attempt against one URL. Echoes the HTTP code; body in /tmp/smoke-body.
+          probe() {
+            local url="$1"
+            curl -sS -o /tmp/smoke-body -w '%{http_code}' \
               -X POST \
-              -H "Authorization: Bearer ${PUBLIC_TEST_AGENT_TOKEN:-unset}" \
+              "${auth_args[@]}" \
               -H "Content-Type: application/json" \
               -H "Accept: application/json, text/event-stream" \
               --max-time 15 \
               -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
-              "${url}" || echo "000")
+              "${url}" || echo "000"
+          }
+          # Retry once on transient failure. Both bug modes we care about (#3854,
+          # #3869) are deterministic — a healthy tenant won't blip on retry, but
+          # a Cloudflare/Fly edge wobble during rolling-restart settle might.
+          fail=0
+          for path in "${paths[@]}"; do
+            url="${base}${path}"
+            code=$(probe "${url}")
             case "${code}" in
               200|401)
                 echo "✅ ${path} → ${code}"
+                continue
+                ;;
+            esac
+            echo "⏳ ${path} → ${code}, retrying in 8s…"
+            sleep 8
+            code=$(probe "${url}")
+            case "${code}" in
+              200|401)
+                echo "✅ ${path} → ${code} (after retry)"
                 ;;
               *)
-                echo "::error::Tenant smoke failed: ${path} returned HTTP ${code}"
+                echo "::error::Tenant smoke failed: ${path} returned HTTP ${code} (twice)"
                 echo "Body (first 500 chars):"
                 head -c 500 /tmp/smoke-body || true
                 echo ""

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,6 +80,59 @@ jobs:
 
           echo "✅ All web/worker machines running the same image"
 
+      # Smoke each training-agent tenant URL after the rolling restart.
+      # Catches production-only failures that don't surface in CI: SDK
+      # init guards that throw under NODE_ENV=production (PR #3869),
+      # in-memory task registry refusal (PR #3854), missing migrations,
+      # etc. Both failure modes return 404 ("Tenant not registered") or
+      # 5xx — both happen *before* auth, so an unauthenticated request
+      # is sufficient: a healthy MCP endpoint returns 200 (when the
+      # public token is set) or 401 (when it isn't). 4xx other than 401
+      # and any 5xx are deploy-fatal.
+      - name: Smoke training-agent tenants
+        env:
+          PUBLIC_TEST_AGENT_TOKEN: ${{ secrets.PUBLIC_TEST_AGENT_TOKEN }}
+        run: |
+          set -uo pipefail
+          base="https://test-agent.adcontextprotocol.org"
+          paths=(
+            "/sales/mcp"
+            "/signals/mcp"
+            "/governance/mcp"
+            "/creative/mcp"
+            "/creative-builder/mcp"
+            "/brand/mcp"
+            "/mcp"
+          )
+          fail=0
+          for path in "${paths[@]}"; do
+            url="${base}${path}"
+            code=$(curl -sS -o /tmp/smoke-body -w '%{http_code}' \
+              -X POST \
+              -H "Authorization: Bearer ${PUBLIC_TEST_AGENT_TOKEN:-unset}" \
+              -H "Content-Type: application/json" \
+              -H "Accept: application/json, text/event-stream" \
+              --max-time 15 \
+              -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+              "${url}" || echo "000")
+            case "${code}" in
+              200|401)
+                echo "✅ ${path} → ${code}"
+                ;;
+              *)
+                echo "::error::Tenant smoke failed: ${path} returned HTTP ${code}"
+                echo "Body (first 500 chars):"
+                head -c 500 /tmp/smoke-body || true
+                echo ""
+                fail=1
+                ;;
+            esac
+          done
+          if [ "${fail}" -ne 0 ]; then
+            echo "::error::One or more training-agent tenants failed post-deploy smoke. Recent failures of this kind: PR #3854 (in-memory task registry refused under NODE_ENV=production), PR #3869 (noopJwksValidator threw under NODE_ENV=production, marking tenants disabled). Inspect Fly logs: flyctl logs --app <app>."
+            exit 1
+          fi
+
       - name: Clean up stale console machines
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary

Closes #3878. Adds a post-deploy smoke step to `.github/workflows/deploy.yml` that POSTs `tools/list` to each training-agent tenant URL (`/sales`, `/signals`, `/governance`, `/creative`, `/creative-builder`, `/brand`) plus the legacy `/mcp` alias and fails the deploy on 404/5xx/timeout.

## Why

Two recent hotfixes shipped clean through CI but caused production outages:

- **#3854** — `createInMemoryTaskRegistry` throws under `NODE_ENV=production`. CI ran in-memory and passed; production crashed on every per-tenant POST.
- **#3869** — `noopJwksValidator` had a `NODE_ENV=production` guard that threw at validation time, marking every tenant `disabled`; `resolveByRequest` returned null and every per-tenant POST 404'd.

Both gates were `NODE_ENV=production`-specific, so neither surfaced in staging, the storyboard matrix, or vitest. Both were caught only by manual smoke after the rolling restart.

## How

The bug modes (`Tenant not registered` 404 / registry init 5xx) happen *before* auth, so unauthenticated `tools/list` is sufficient to detect them. The smoke accepts `200` (token configured + healthy) and `401` (token absent + healthy) as pass; everything else fails the deploy. Exits with `::error::` annotations and the response body for diagnosis.

## Test plan

- [ ] Deploy workflow run on this PR (or follow-up to main) reaches the smoke step and reports `✅` for all 7 paths.
- [ ] Verified locally: `curl` against each tenant URL returns 200 with `result.tools` populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)