### PR TITLE
ci(deploy): smoke accepts 403 (SDK v6 invalid-bearer status)

### DIFF
--- a/.changeset/deploy-smoke-accept-403.md
+++ b/.changeset/deploy-smoke-accept-403.md
@@ -1,0 +1,6 @@
+---
+---
+
+Hotfix for the deploy-smoke gate added in #3879. The first deploy that ran it tripped on every per-tenant URL: SDK v6's auth middleware returns `403 Forbidden` for an invalid bearer token (the gate's secret was misconfigured), where v5 returned `401 Unauthorized`. The smoke only accepted `200|401`, so all six per-tenant URLs failed and the deploy went red even though every tenant was healthy (verified out-of-band: 7/7 paths returned 200 with their expected tool counts using the documented public token).
+
+Accepts `403` alongside `200` and `401`. All three mean "registry resolved, MCP route alive" — which is what this smoke is checking. The bug modes it protects against (`404 Tenant not registered`, `5xx` registry init failure) happen before auth and are unaffected.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -106,7 +106,9 @@ jobs:
           )
           # Build curl args once. Omit the Authorization header when the secret
           # is unset so a strict-bearer-format server can't 400 us into a false
-          # deploy failure — we accept 401 as healthy anyway.
+          # deploy failure — we accept 401/403 as healthy anyway. (SDK v5 used
+          # 401 for invalid bearer; v6 uses 403. Both mean the registry resolved
+          # and the MCP route is alive, which is what this smoke is checking.)
           auth_args=()
           if [ -n "${PUBLIC_TEST_AGENT_TOKEN:-}" ]; then
             auth_args=(-H "Authorization: Bearer ${PUBLIC_TEST_AGENT_TOKEN}")
@@ -131,7 +133,7 @@ jobs:
             url="${base}${path}"
             code=$(probe "${url}")
             case "${code}" in
-              200|401)
+              200|401|403)
                 echo "✅ ${path} → ${code}"
                 continue
                 ;;
@@ -140,7 +142,7 @@ jobs:
             sleep 8
             code=$(probe "${url}")
             case "${code}" in
-              200|401)
+              200|401|403)
                 echo "✅ ${path} → ${code} (after retry)"
                 ;;
               *)


### PR DESCRIPTION
## Summary

Hotfix for the deploy-smoke gate added in #3879. The first deploy that ran it ([run 25260239509](https://github.com/adcontextprotocol/adcp/actions/runs/25260239509)) tripped on every per-tenant URL with HTTP 403 (twice, after retry).

Root cause: SDK v6's auth middleware returns `403 Forbidden` for an invalid bearer where v5 returned `401`. The smoke only accepted `200|401`, so a misconfigured `secrets.PUBLIC_TEST_AGENT_TOKEN` false-failed the deploy even though every tenant was healthy.

Out-of-band verification (with the documented public token from `server/src/config/test-agent.ts`):
```
/sales/mcp           → 200 (tools: 12)
/signals/mcp         → 200 (tools: 4)
/governance/mcp      → 200 (tools: 23)
/creative/mcp        → 200 (tools: 8)
/creative-builder/mcp → 200 (tools: 8)
/brand/mcp           → 200 (tools: 7)
/mcp                 → 200 (tools: 49)
```

## Why 403 is acceptable

200, 401, and 403 all prove the same thing the smoke is checking: registry resolved, MCP route alive. The bug modes this gate protects against (#3854 in-memory registry refusal, #3869 noop validator throw) manifest as `404 Tenant not registered` or `5xx`, both before auth — unaffected.

The code-reviewer flagged exactly this case during the review of #3879: *"if a future regression returns 403 before auth … this will fail the deploy when the tenant is actually healthy-but-blocked."* Same shape of false-positive.

## Follow-up (separate)

The `secrets.PUBLIC_TEST_AGENT_TOKEN` repo secret should be aligned with the value Fly serves so the smoke proves end-to-end auth (200) rather than just pre-auth health (401/403). Tracked separately, not blocking this hotfix.

## Test plan

- [ ] Merge → next deploy run shows `✅` for all 7 paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)