### PR TITLE
fix(addie): include content column when queueing community articles

### DIFF
--- a/.changeset/fix-community-articles-null-content.md
+++ b/.changeset/fix-community-articles-null-content.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix NOT NULL violation when queueing community-shared articles from Slack. `queueCommunityArticle` was omitting `content` from its INSERT into `addie_knowledge`, but the column is `NOT NULL`. Now inserts `''` as a placeholder, matching the pattern used by other pending-fetch insert paths (RSS curator, queueResourceForIndexing). Content gets filled in once the fetcher processes the URL.

--- a/server/src/addie/services/community-articles.ts
+++ b/server/src/addie/services/community-articles.ts
@@ -105,6 +105,7 @@ export async function queueCommunityArticle(params: {
     `INSERT INTO addie_knowledge (
        title,
        category,
+       content,
        source_url,
        fetch_url,
        source_type,
@@ -115,6 +116,7 @@ export async function queueCommunityArticle(params: {
      ) VALUES (
        'Community shared article',
        'Industry News',
+       '',
        $1,
        $1,
        'community',


### PR DESCRIPTION
## Summary

Fixes production error from the addie-bolt-app:

```
null value in column "content" of relation "addie_knowledge" violates not-null constraint
```

`queueCommunityArticle` (`server/src/addie/services/community-articles.ts:105`) was omitting the `content` column from its INSERT, but `addie_knowledge.content` is `NOT NULL` (migration 040). When a Slack user shared an article URL in a managed channel, the INSERT crashed before the fetcher had a chance to populate content.

## Fix

Insert `''` as a placeholder for `content`, matching the pattern already used by other pending-fetch insert paths:
- `addie-db.ts:586` (`queueResourceForIndexing`)
- `content-curator.ts:498` (RSS curator pending entries)

The content fetcher fills the column in when it processes the URL.

## Test plan

- [ ] Verify community article share in a managed Slack channel no longer throws
- [ ] Confirm fetched content populates correctly once fetcher runs