### PR TITLE
fix(storyboard): capture rights_id from acquire_rights response (closes #3892)

### DIFF
--- a/.changeset/fix-brand-rights-storyboard-rights-id-capture.md
+++ b/.changeset/fix-brand-rights-storyboard-rights-id-capture.md
@@ -1,0 +1,6 @@
+---
+---
+
+Fix `acquire_rights` step in brand-rights storyboard: capture `rights_id` from the response, not `rights_grant_id`.
+
+`brand/acquire-rights-response.json` defines the field as `rights_id`, but the storyboard YAML was authored against an earlier `rights_grant_id` naming and never reconciled. Spec-compliant brand-rights agents passed `response_schema` validation but failed `context_outputs` capture, which cascade-skipped `rights_enforcement`. The storyboard-internal context key (`rights_grant_id`) is preserved so no other steps need updates. Also corrects the step's `expected:` prose to match (`rights_id` + `status: acquired`). Closes #3892.

--- a/static/compliance/source/specialisms/brand-rights/index.yaml
+++ b/static/compliance/source/specialisms/brand-rights/index.yaml
@@ -237,8 +237,8 @@ phases:
         stateful: true
         expected: |
           Return the acquired rights grant:
-          - rights_grant_id: unique identifier
-          - status: active
+          - rights_id: unique identifier
+          - status: acquired
           - Generation credentials
           - Expiration date and usage limits
           - Terms and constraints
@@ -270,7 +270,7 @@ phases:
           context:
             correlation_id: "brand_rights--acquire_rights"
         context_outputs:
-          - path: "rights_grant_id"
+          - path: "rights_id"
             key: "rights_grant_id"
 
         validations:


### PR DESCRIPTION
## Summary

- `brand-rights/rights_acquisition` storyboard captured `rights_grant_id` from the `acquire_rights` response, but `brand/acquire-rights-response.json` defines the field as `rights_id`. Spec-compliant agents passed `response_schema` validation but failed `context_outputs` capture, which cascade-skipped `rights_enforcement`.
- Update `static/compliance/source/specialisms/brand-rights/index.yaml`:
  - `acquire_rights.context_outputs[0].path`: `rights_grant_id` → `rights_id` (storyboard-internal key `rights_grant_id` preserved, so no other steps need updates).
  - `expected:` prose corrected to `rights_id` + `status: acquired`.

Closes #3892.

## Test plan

- [ ] Storyboard run against a spec-compliant brand-rights agent: `brand_rights/rights_acquisition` and `brand_rights/rights_enforcement` both pass.
- [ ] Existing brand-rights validations still hold (`field_present rights_id`, context echo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)