### PR TITLE
spec(capabilities): relax identity.additionalProperties to true (3.0.x)

### DIFF
--- a/.changeset/relax-identity-additional-properties-3.0.x.md
+++ b/.changeset/relax-identity-additional-properties-3.0.x.md
@@ -1,0 +1,11 @@
+---
+"adcontextprotocol": patch
+---
+
+spec(capabilities): relax `identity.additionalProperties` to `true` on `get-adcp-capabilities-response`
+
+Forward-compat fix for 3.0.x. The `identity` object was schema-closed (`additionalProperties: false`), so any operator that adopted a forward-compatible field — notably `identity.brand_json_url` from #3690, which was always intended to be readable by 3.0-pinned implementers without a schema bump — would have its capabilities response rejected by strict 3.0 validators (e.g., `@adcp/sdk`'s `createAdcpServer` default).
+
+Mirrors the `additionalProperties: true` already shipped on `main` post-#3690. Strictly additive: the closed property list (`per_principal_key_isolation`, `key_origins`, `compromise_notification`) is unchanged; receivers that ignore unknown fields keep working; receivers that look for new identity fields gain forward-compat without waiting for a 3.x bump.
+
+The forward-compat narrative in `security.mdx` ("3.0-pinned implementers can adopt the field today without bumping") depends on this relaxation being live in shipped schemas — without it, the spec advice contradicts the schema.

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -948,7 +948,7 @@
           "additionalProperties": false
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "compliance_testing": {
       "type": "object",


### PR DESCRIPTION
## Summary

Forward-compat fix for 3.0.x. Flips `identity.additionalProperties` from `false` → `true` on `get-adcp-capabilities-response.json` so 3.0-pinned operators can adopt forward-compatible fields (notably `identity.brand_json_url` from #3690) without their capabilities response being rejected by strict 3.0 validators (e.g., `@adcp/sdk`'s `createAdcpServer` default).

`main` already has this relaxation post-#3690 — this PR mirrors it onto 3.0.x so the spec's adoption guidance ("3.0-pinned implementers can adopt the field today without bumping", `security.mdx`) actually matches what shipped 3.0 schemas validate.

Strictly additive: the closed property list (`per_principal_key_isolation`, `key_origins`, `compromise_notification`) is unchanged. Receivers that ignore unknown fields keep working; receivers that look for new identity fields gain forward-compat without waiting for a 3.1 bump.

## What this does NOT do

- Does **not** add `brand_json_url` to the 3.0.x schema. AdCP doesn't backport new schema fields to patch releases. Adopters who write `identity.brand_json_url` today will pass 3.0 validation (because of this PR) and get full schema-level recognition once they pin to 3.1+.

## Changeset

`patch` bump (`adcontextprotocol`) — schema relaxation, no breaking change.

## Test plan

- [ ] Existing 3.0.x storyboards pass `response_schema` validation against `get-adcp-capabilities-response`.
- [ ] An `identity` block with an unknown forward-compat field (e.g., `brand_json_url`) validates against the 3.0.x source schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)