### PR TITLE
fix(compliance): correct brand-rights storyboard acquire_rights field name drift

### DIFF
--- a/.changeset/fix-brand-rights-storyboard-rights-id-drift.md
+++ b/.changeset/fix-brand-rights-storyboard-rights-id-drift.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix `brand-rights` storyboard `acquire_rights` step capturing `rights_grant_id` instead of `rights_id`. The `context_outputs.path` was authored against a draft field name that was never reconciled with the published `brand/acquire-rights-response.json` schema. Also corrects `expected` prose (`rights_grant_id` → `rights_id`, `status: active` → `status: acquired`). Non-protocol change — storyboard YAML only.

--- a/static/compliance/source/specialisms/brand-rights/index.yaml
+++ b/static/compliance/source/specialisms/brand-rights/index.yaml
@@ -237,8 +237,8 @@ phases:
         stateful: true
         expected: |
           Return the acquired rights grant:
-          - rights_grant_id: unique identifier
-          - status: active
+          - rights_id: unique identifier
+          - status: acquired
           - Generation credentials
           - Expiration date and usage limits
           - Terms and constraints
@@ -270,7 +270,7 @@ phases:
           context:
             correlation_id: "brand_rights--acquire_rights"
         context_outputs:
-          - path: "rights_grant_id"
+          - path: "rights_id"
             key: "rights_grant_id"
 
         validations:


### PR DESCRIPTION
Closes #3892

The `acquire_rights` step in the brand-rights storyboard captured `rights_grant_id` from the response into context — a draft field name that was never reconciled with the published `brand/acquire-rights-response.json` schema. The `AcquireRightsAcquired` arm defines the field as `rights_id` (not `rights_grant_id`), so spec-conformant agents had the capture silently produce `null`, causing the `rights_enforcement` phase to cascade-skip on a prerequisite failure. The `expected` prose also referenced `rights_grant_id` and `status: active` (neither matching the schema). This PR corrects all three.

**Non-breaking justification:** change is confined to the storyboard compliance harness YAML; the wire protocol (`brand/acquire-rights-response.json`) is untouched and unchanged. No schema fields added, removed, or renamed.

**Pre-PR review:**
- code-reviewer: approved — no blockers. Noted that `key: "rights_grant_id"` (storyboard-internal alias) is intentionally kept to avoid colliding with `$context.rights_id` captured by the earlier `get_rights` step; the lint script (`scripts/lint-storyboard-context-entity.cjs:451`) accepts `key` and `name` as aliases, so this is correct. One nit: `key: "rights_grant_id"` is a dead slot (nothing downstream reads `$context.rights_grant_id`), but renaming it would be a separate cleanup.
- ad-tech-protocol-expert: approved — `rights_id` is the canonical grant identifier across all three `oneOf` arms; `status: acquired` matches the discriminant `const`; fix is non-breaking per AdCP spec.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01JQTS91nkfEAJ33jTuQEK6w

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQTS91nkfEAJ33jTuQEK6w)_