### PR TITLE
spec: /.well-known/adcp-agents.json for multi-agent topology discovery

### DIFF
--- a/.changeset/well-known-adcp-agents-manifest.md
+++ b/.changeset/well-known-adcp-agents-manifest.md
@@ -1,0 +1,27 @@
+---
+"adcontextprotocol": minor
+---
+
+feat(spec): `/.well-known/adcp-agents.json` for multi-agent topology discovery (#3895)
+
+Defines a new origin-scoped well-known endpoint that enumerates every AdCP agent served from a host — `agent_id`, `url`, `transport`, `specialisms[]`, and an optional informational `auth_hint`. Lets buyers and conformance runners learn an operator's full multi-agent topology in a single fetch instead of reading a Notion page or hardcoding tenant lists.
+
+**Why.** Today a publisher running sales / signals / governance / creative / brand on one origin has no standard way to advertise the full set. `/.well-known/agent-card.json` describes one agent at a time; `/.well-known/adagents.json` covers authorization, not topology. The training agent demonstrated the gap with a custom `_training_agent_tenants` extension on `adagents.json` — useful but non-standard.
+
+**What's in this PR**
+
+- New schema: `static/schemas/source/adcp-agents.json`. Required: `version`, `agents[]` (each with `agent_id`, `url`, `transport`, `specialisms[]`). Optional: `agents[].auth_hint`, `agents[].description`, `contact`, `last_updated`. `transport` is an open string with documented common values (`"mcp"`, `"a2a"`) so future transports don't require a schema-breaking change. `agents[].url` is `https://`-only with explicit consumer rules for origin-binding and SSRF defence. `agents[]` capped at 256, `specialisms[]` at 64. `additionalProperties: true` elsewhere for forward compatibility.
+- Schema registered in `static/schemas/source/index.json` next to `adagents` and `brand` with `file_location: "/.well-known/adcp-agents.json"`.
+- New doc: `docs/protocol/multi-agent-discovery.mdx`. Covers shape, fields, `auth_hint` common values, relation to `agent-card.json` / `adagents.json` / `brand.json` / `oauth-authorization-server`, the discovery chain (linked into [Calling an agent](/docs/protocol/calling-an-agent#discovery-chain)), and a reconciliation table that names `adagents.json` as authoritative for "can this agent sell my inventory?" and the agent-card as authoritative when URL/transport disagree. Includes a Consumer Requirements section: HTTPS-only in production, blocking RFC 1918 / loopback / metadata addresses, origin-binding before sending credentials cross-origin, URL canonicalization before comparison, and a 1 MB body cap. Caching and error-semantics section covers missing-manifest fallback to single-agent, malformed-manifest non-blocking degradation, and `X-Forwarded-Host` cache-poisoning guidance. Wired into both navigations in `docs.json`.
+- Reference implementation: training agent serves `/.well-known/adcp-agents.json` listing all six tenants (`sales`, `signals`, `governance`, `creative`, `creative-builder`, `brand`). The pre-existing `_training_agent_tenants` extension on `adagents.json` stays in place — it carries tenants that don't fit the `authorized_agents` discriminator (governance / creative / creative-builder / brand) — with its comment pointing at the standard endpoint.
+- Smoke test added in `server/src/training-agent/tenants/tenant-smoke.test.ts` verifying the manifest enumerates every tenant with the right key/URL/transport.
+
+**`auth_hint`** is an open string with documented common values (`shared_bearer`, `per_agent_bearer`, `oauth`). `none` was deliberately dropped from the suggested vocabulary to remove a downgrade footgun — a buyer that uses the hint to decide whether to attach credentials would silently send unauthenticated requests on a hostile manifest. The schema and doc now require consumers MUST NOT use `auth_hint` to make credential-attachment decisions; that policy belongs to the consumer's trust configuration for the target origin.
+
+**Out of scope (filed as follow-ups)**
+
+- Per-agent signed manifests — TLS chain trust on the origin is sufficient for v1.
+- Capability-aware filtering at the manifest level — operators advertise full claims, runners fetch each agent's `get_adcp_capabilities` for per-tool detail.
+- Versioning beyond a top-level `version` field; future revisions will be additive within the `1.x` line.
+
+Closes #3895.

--- a/docs.json
+++ b/docs.json
@@ -103,6 +103,7 @@
                   "docs/protocol/architecture",
                   "docs/protocol/required-tasks",
                   "docs/protocol/calling-an-agent",
+                  "docs/protocol/multi-agent-discovery",
                   "docs/protocol/format-references",
                   {
                     "group": "Understanding AdCP",
@@ -621,6 +622,7 @@
               "docs/protocol/architecture",
               "docs/protocol/required-tasks",
               "docs/protocol/calling-an-agent",
+              "docs/protocol/multi-agent-discovery",
               "docs/protocol/format-references",
               {
                 "group": "Understanding AdCP",

--- a/docs/protocol/multi-agent-discovery.mdx
+++ b/docs/protocol/multi-agent-discovery.mdx
@@ -1,0 +1,159 @@
+---
+title: Multi-agent topology discovery
+sidebarTitle: Multi-agent discovery
+description: "/.well-known/adcp-agents.json — origin-scoped manifest enumerating every AdCP agent served from a host. Lets buyers and conformance runners learn the full multi-agent topology in a single fetch."
+"og:title": "AdCP — Multi-agent topology discovery"
+---
+
+# Multi-agent topology discovery
+
+A single AdCP origin often serves several agents — a sales agent at `/sales`, signals at `/signals`, governance at `/governance`, creative at `/creative`. `/.well-known/adcp-agents.json` is the standard machine-readable way for that operator to advertise which agents are live, what each one's URL is, and which [specialisms](/docs/protocol/required-tasks) each one claims.
+
+A single-agent operator MAY publish a one-entry manifest — the value to tooling is consistent: discovery is one fetch instead of "ask the operator for a doc."
+
+## Endpoint
+
+```
+GET /.well-known/adcp-agents.json
+```
+
+- MUST be readable without authentication (parity with `/.well-known/agent-card.json` and `/.well-known/adagents.json`).
+- For privacy, operators MAY return only public/test agents from this endpoint and gate production agents behind authenticated discovery on a different path.
+- Origin-scoped per RFC 5785 — a host serves one manifest covering every agent on that origin, regardless of path prefix.
+- On multi-tenant deployments where each tenant lives at its own subdomain, the manifest at `tenant-X.host` MUST contain only that tenant's agents and MUST NOT include `agent_id`, `description`, or `contact` values that disclose other tenants. Treat all manifest fields as public.
+
+## Shape
+
+```json
+{
+  "$schema": "/schemas/adcp-agents.json",
+  "version": "1.0",
+  "agents": [
+    {
+      "agent_id": "sales",
+      "url": "https://example.com/sales/mcp",
+      "transport": "mcp",
+      "specialisms": ["sales-non-guaranteed", "sales-guaranteed"],
+      "auth_hint": "shared_bearer"
+    },
+    {
+      "agent_id": "signals",
+      "url": "https://example.com/signals/mcp",
+      "transport": "mcp",
+      "specialisms": ["signal-marketplace", "signal-owned"],
+      "auth_hint": "shared_bearer"
+    },
+    {
+      "agent_id": "governance",
+      "url": "https://example.com/governance/mcp",
+      "transport": "mcp",
+      "specialisms": [
+        "governance-spend-authority",
+        "governance-delivery-monitor",
+        "property-lists",
+        "collection-lists",
+        "content-standards"
+      ]
+    }
+  ],
+  "contact": { "name": "Example Publisher Ad Ops", "email": "adops@example.com" },
+  "last_updated": "2026-05-02T00:00:00Z"
+}
+```
+
+### Fields
+
+| Field | Required | Description |
+|---|---|---|
+| `version` | Required | Manifest version (`"1.0"` for this revision). Consumers SHOULD ignore unknown top-level fields rather than fail on a future minor revision. A future `2.x` will be served at a different well-known path or signalled via media-type parameter. |
+| `agents[]` | Required | Every AdCP agent served from this origin. One entry per endpoint. Max 256. |
+| `agents[].agent_id` | Required | Stable, operator-defined identifier for this agent within the manifest (e.g. `sales`, `signals`). Lowercase alphanumeric with hyphens/underscores, 1–64 characters, no leading/trailing separator. Unique within `agents[]`. |
+| `agents[].url` | Required | Agent endpoint URL. `https://` only in production. For MCP, the streamable-HTTP URL clients POST to (typically ending in `/mcp`). For A2A, the agent's base URL (the agent-card lives at `<url>/.well-known/agent-card.json`). |
+| `agents[].transport` | Required | Wire protocol — common values `"mcp"`, `"a2a"`. Open string; new transports may be added. Consumers SHOULD treat unknown values as unsupported rather than fail. Both MCP and A2A share AdCP semantics ([Calling an agent](/docs/protocol/calling-an-agent)). |
+| `agents[].specialisms` | Required | AdCP specialisms this agent currently implements. See [Required tasks by protocol](/docs/protocol/required-tasks) for the canonical list. Operators MUST list only specialisms whose required tasks the agent supports at publication time. Max 64. |
+| `agents[].auth_hint` | Optional | Informational hint for tooling. Common values below. Consumers MUST NOT use this to decide whether to attach credentials. |
+| `agents[].description` | Optional | Human-readable description, surfaced in operator UIs and conformance reports. Max 500 chars. Treat as public. |
+| `contact` | Optional | Operator contact information. When present, `contact.name` is required; `contact.email` and `contact.url` are optional. |
+| `last_updated` | Optional | ISO 8601 timestamp of the manifest's last change. |
+
+### `auth_hint` common values
+
+The hint is informational only — the actual auth contract is negotiated out-of-band. Buyers MUST NOT treat `auth_hint` as authoritative, and MUST NOT use it to decide whether to attach credentials (that decision belongs to the consumer's configured trust policy for the target origin).
+
+| Value | Meaning |
+|---|---|
+| `shared_bearer` | One bearer token works across every agent on this origin. |
+| `per_agent_bearer` | Each agent needs its own bearer token. |
+| `oauth` | OAuth 2.1 flow — see [`/.well-known/oauth-authorization-server`](https://datatracker.ietf.org/doc/html/rfc8414). |
+
+Operators MAY publish other values; tooling that doesn't recognise a value SHOULD fall back to "ask the operator".
+
+## Consumer requirements
+
+Manifests come from arbitrary origins. A misimplemented or compromised origin can publish URLs that point anywhere. Consumers walking this manifest MUST:
+
+- **HTTPS-only in production.** Reject any `agents[].url` that is not `https://` outside an explicit opt-in to a localhost/sandbox origin.
+- **Block private and metadata addresses.** Reject URLs that resolve (after DNS) to RFC 1918 ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`), loopback (`127.0.0.0/8`, `::1`), link-local (`169.254.0.0/16`, `fe80::/10`), or cloud-metadata addresses (`169.254.169.254`, `metadata.google.internal`, `fd00:ec2::254`). This includes redirect targets if HTTP redirects are followed.
+- **Enforce origin binding.** A URL listed in this manifest is trusted only for the origin that served the manifest. Before sending credentials or making a transactional call to an `agents[].url` whose origin differs from the manifest origin, consumers MUST independently verify authorization via the target publisher's [`/.well-known/adagents.json`](/docs/governance/property/adagents) — the manifest is a discovery hint, not a trust anchor for cross-origin agents.
+- **Canonicalize before comparing.** When comparing `agents[].url` against an `adagents.json` entry, brand registry lookup, or any other authorization signal, apply the [AdCP URL canonicalization rules](/docs/reference/url-canonicalization). Two URLs that differ only in case, default port, or unreserved-character percent-encoding are the same agent.
+- **Cap the response.** Manifests SHOULD parse under a 1 MB body cap; reject larger responses outright.
+
+## Reconciliation with neighbouring well-known files
+
+| Question | Authoritative source |
+|---|---|
+| What agents does this operator run? | `/.well-known/adcp-agents.json` (this file) |
+| What does a specific agent advertise to A2A clients? | `<agent-url>/.well-known/agent-card.json` |
+| Can a given agent sell my (a publisher's) inventory? | The publisher's [`/.well-known/adagents.json`](/docs/governance/property/adagents) — **always**. Listing in `adcp-agents.json` does not imply authorization. |
+| What is the correct URL or transport for an agent? | When `adcp-agents.json` and the agent's `agent-card.json` disagree on URL or transport, the agent-card wins. The manifest is a hint; the agent's self-description is canonical. |
+
+| Endpoint | Scope | Purpose |
+|---|---|---|
+| `/.well-known/adcp-agents.json` | **Multi-agent topology** for one origin | "What agents does this operator run, and where?" |
+| `/.well-known/agent-card.json` | **One agent's** A2A descriptor | "What does this single agent advertise to A2A clients?" Per-agent. For multi-agent operators this card describes one agent at a time and is fetched at each agent's base URL. |
+| `/.well-known/adagents.json` | **Publisher-side authorization** for inventory and signals | "Which sales/signals agents am I authorising to represent my properties or signals?" Orthogonal to topology discovery. |
+| `/.well-known/brand.json` | **Brand identity** for one domain | Orthogonal — declares brand identity, not agent topology. |
+| `/.well-known/oauth-authorization-server` | **OAuth metadata** | Orthogonal — RFC 8414. Used when `auth_hint` is `oauth`. |
+
+## Discovery chain
+
+`adcp-agents.json` answers *what agents exist*, not *how to call them*. Once a buyer has picked an agent URL, they walk the standard chain documented in [Calling an AdCP agent](/docs/protocol/calling-an-agent#discovery-chain):
+
+1. Pick the agent for the specialism you need from `/.well-known/adcp-agents.json`.
+2. **Agent card** (A2A) or **`tools/list`** (MCP) — returns tool *names*. AdCP MCP servers do not publish per-tool parameter schemas in `tools/list`; don't infer shape from there.
+3. **`get_adcp_capabilities`** — supported protocols, AdCP versions, and feature flags.
+4. **`get_schema(tool_name)`** *(when exposed; pending standardization in [#3057](https://github.com/adcontextprotocol/adcp/issues/3057))* — JSON Schema for a specific tool's request/response.
+5. **Bundled schemas** — every published AdCP version ships JSON Schemas signed via Sigstore; let your SDK's loader find them rather than hardcoding paths.
+
+Capability-aware filtering at the manifest level (e.g. "only list agents that support `create_media_buy`") is intentionally out of scope. The `specialisms[]` claim is enough to route, and `get_adcp_capabilities` is the canonical truth for per-tool support.
+
+## Caching and error semantics
+
+- **Cache-Control.** Public/test manifests MAY use `public, max-age=300`. Production manifests that include any non-public agents SHOULD use `private, max-age=60` and `Vary: Authorization` if the response varies on auth.
+- **Missing manifest (404).** Consumers SHOULD fall back to fetching `/.well-known/agent-card.json` at the same origin and treating the operator as a single-agent deployment. The absence of the manifest is not an error.
+- **Malformed JSON or schema-invalid manifest.** Consumers MUST NOT block startup on this fetch; treat parse / validation failure as "no topology hint available" and degrade to single-agent fallback or operator-supplied configuration.
+- **Cache poisoning via `X-Forwarded-Host`.** Operators serving the manifest behind a reverse proxy MUST either set the manifest's host explicitly (e.g. via a `BASE_URL` config) or trust forwarded-host headers only from known proxies. A misconfigured edge that echoes attacker-controlled `X-Forwarded-Host` into emitted `agents[].url` becomes a cache-poisoning vector.
+
+## For tooling authors
+
+Common consumers:
+
+- **Buyers** — replace "ask the publisher for a doc" with one fetch. Cache the manifest with a short TTL; respect `Cache-Control` in production.
+- **Conformance runners** — `adcp storyboard run --discover https://publisher.example` can replace `--agents-map` for the common case where a publisher hosts a multi-agent topology.
+- **AAO Verified** — certification can verify a publisher's declared topology in one fetch; per-specialism capability verification still happens via `get_adcp_capabilities` against each listed agent.
+
+When parsing, ignore unknown top-level fields and unknown fields inside `agents[].*` — the schema declares `additionalProperties: true` so operators MAY add custom metadata without breaking consumers.
+
+## Out of scope (v1)
+
+- **Per-agent signed manifests.** TLS chain trust on the origin is sufficient for v1; per-entry signatures may follow.
+- **Capability-aware filtering at the manifest level.** Operators advertise full claims; runners fetch each agent's `get_adcp_capabilities` for the per-specialism detail.
+- **Versioning beyond a top-level `version` field.** Future revisions are additive within the `1.x` line; a `2.x` revision will be served at a different well-known path or signalled via media-type parameter.
+
+## Related
+
+- [Calling an AdCP agent](/docs/protocol/calling-an-agent) — the discovery chain after you've picked an agent URL.
+- [Required tasks by protocol](/docs/protocol/required-tasks) — canonical specialism names.
+- [`get_adcp_capabilities`](/docs/protocol/get_adcp_capabilities) — first call against any newly discovered agent.
+- [`adagents.json`](/docs/governance/property/adagents) — publisher-side authorization, the trust anchor for cross-origin agent calls.
+- [URL canonicalization](/docs/reference/url-canonicalization) — required when comparing manifest URLs against any authorization signal.

--- a/server/src/training-agent/index.ts
+++ b/server/src/training-agent/index.ts
@@ -317,6 +317,32 @@ export function createTrainingAgentRouter(): Router {
     res.json(getPublicJwks());
   });
 
+  // Multi-agent topology manifest — RFC 5785 well-known, origin-scoped.
+  // Lists every per-specialism tenant served from this origin in a single
+  // fetch. See docs/protocol/multi-agent-discovery and
+  // static/schemas/source/adcp-agents.json.
+  router.get('/.well-known/adcp-agents.json', (req: Request, res: Response) => {
+    const baseUrl = getBaseUrl(req);
+    const agentUrl = `${baseUrl}${req.baseUrl}`;
+    res.setHeader('Cache-Control', 'public, max-age=300');
+    res.json({
+      $schema: '/schemas/adcp-agents.json',
+      version: '1.0',
+      agents: TENANT_IDS.map(tenantId => ({
+        agent_id: tenantId,
+        url: `${agentUrl}/${tenantId}/mcp`,
+        transport: 'mcp' as const,
+        specialisms: TENANT_SPECIALISMS[tenantId],
+        auth_hint: 'shared_bearer',
+      })),
+      contact: {
+        name: 'AdCP Training Agent',
+        url: 'https://adcontextprotocol.org',
+      },
+      last_updated: STARTUP_TIME,
+    });
+  });
+
   // adagents.json discovery. Schema-conformant per
   // `static/schemas/source/adagents.json`:
   //   - `authorized_agents[]` is a discriminated union — sales agents use
@@ -380,10 +406,11 @@ export function createTrainingAgentRouter(): Router {
         first_party: { name: 'First-party signals', description: 'Publisher subscriber and CDP audience signals' },
       },
       // Custom extension (allowed under schema's additionalProperties:true).
-      // Lists all six per-specialism tenants so a developer hitting
-      // adagents.json gets the full multi-tenant picture in one request —
-      // even for tenants that don't fit the schema's authorized_agents
-      // discriminator (governance, creative, creative-builder, brand).
+      // Lists per-specialism tenants alongside the standard authorization
+      // entries — including tenants that don't fit the schema's
+      // authorized_agents discriminator (governance, creative,
+      // creative-builder, brand). Standard topology discovery is at
+      // /.well-known/adcp-agents.json above.
       _training_agent_tenants: TENANT_IDS.map(tenantId => ({
         tenant_id: tenantId,
         url: `${agentUrl}/${tenantId}/mcp`,

--- a/server/src/training-agent/tenants/tenant-smoke.test.ts
+++ b/server/src/training-agent/tenants/tenant-smoke.test.ts
@@ -66,6 +66,28 @@ describe('tenant routing smoke', () => {
     }
   }, 15000);
 
+  it('serves /.well-known/adcp-agents.json with every tenant', async () => {
+    const { baseUrl, close } = await bootServer();
+    try {
+      const r = await fetch(`${baseUrl}/.well-known/adcp-agents.json`);
+      expect(r.status).toBe(200);
+      const body = await r.json() as {
+        version: string;
+        agents: Array<{ agent_id: string; url: string; transport: string; specialisms: string[] }>;
+      };
+      expect(body.version).toBe('1.0');
+      expect(Array.isArray(body.agents)).toBe(true);
+      const ids = body.agents.map(a => a.agent_id).sort();
+      expect(ids).toEqual(['brand', 'creative', 'creative-builder', 'governance', 'sales', 'signals']);
+      const sales = body.agents.find(a => a.agent_id === 'sales');
+      expect(sales?.transport).toBe('mcp');
+      expect(sales?.url).toMatch(/\/sales\/mcp$/);
+      expect(sales?.specialisms).toContain('sales-non-guaranteed');
+    } finally {
+      await close();
+    }
+  }, 15000);
+
   it('dispatches /signals/mcp tools/list and returns only signals-tenant tools', async () => {
     const { baseUrl, close } = await bootServer();
     try {

--- a/static/schemas/source/adcp-agents.json
+++ b/static/schemas/source/adcp-agents.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/adcp-agents.json",
+  "title": "AdCP Multi-Agent Topology Manifest",
+  "description": "Origin-scoped manifest enumerating every AdCP agent served from a host. Hosted at /.well-known/adcp-agents.json. Lets buyers, conformance runners, and tooling discover the full multi-agent topology of a publisher (or any AdCP operator) in a single fetch instead of probing tenant URLs out-of-band. Complements /.well-known/agent-card.json (single-agent A2A descriptor) and /.well-known/adagents.json (publisher-side agent authorization). MUST be readable without authentication. Operators MAY expose only public/test agents and gate production agents behind authenticated discovery on a different path.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "JSON Schema identifier for this manifest"
+    },
+    "version": {
+      "type": "string",
+      "description": "Manifest version. Use semver-compatible strings (e.g. '1.0'). Consumers SHOULD ignore unknown top-level fields rather than fail on version mismatch.",
+      "pattern": "^[0-9]+\\.[0-9]+(\\.[0-9]+)?$"
+    },
+    "agents": {
+      "type": "array",
+      "description": "Every AdCP agent served from this origin. An agent is a single specialism-bearing endpoint — a multi-agent operator publishes one entry per endpoint, even when several share infrastructure. Capability-aware filtering (which agent supports which task) is out of scope for this manifest; consumers fetch each agent's get_adcp_capabilities for that detail.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "agent_id": {
+            "type": "string",
+            "description": "Stable, operator-defined identifier for this agent within the manifest. Used by tooling to refer to a specific agent (e.g. 'sales', 'signals', 'governance'). MUST be unique within the agents[] array. Lowercase alphanumeric with hyphens and underscores; no leading/trailing separators; 1-64 characters.",
+            "pattern": "^[a-z0-9](?:[a-z0-9_-]*[a-z0-9])?$",
+            "minLength": 1,
+            "maxLength": 64
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "pattern": "^https://",
+            "description": "Agent endpoint URL. MUST use https:// in production (consumers MAY accept http:// only when running against a localhost/sandbox origin and explicitly opted in). For MCP transport this is the streamable-HTTP URL clients POST to (typically ending in /mcp). For A2A transport this is the agent's base URL — the A2A agent-card lives at <url>/.well-known/agent-card.json. Callers comparing URLs against an authorization registry MUST canonicalize per the AdCP URL canonicalization rules, not byte-equality. See docs/reference/url-canonicalization. Consumers MUST verify each url's origin matches the manifest's origin OR is independently authorized via the target's adagents.json before sending credentials or transactional calls."
+          },
+          "transport": {
+            "type": "string",
+            "description": "Wire protocol the agent speaks. Common values: 'mcp' (Streamable HTTP / Model Context Protocol), 'a2a' (Agent-to-Agent). Other values may be added as new transports are standardised — consumers SHOULD treat unknown values as unsupported rather than fail. Both MCP and A2A share AdCP semantics — see docs/protocol/calling-an-agent.",
+            "minLength": 1,
+            "maxLength": 64
+          },
+          "specialisms": {
+            "type": "array",
+            "description": "AdCP specialisms this agent currently implements (e.g. 'sales-non-guaranteed', 'signal-marketplace', 'governance-spend-authority', 'creative-template'). The full list of recognised specialisms is documented at docs/protocol/required-tasks. Operators MUST list only specialisms whose required tasks the agent supports at the time of publication. Consumers MAY route by specialism without further verification, and MAY independently confirm via get_adcp_capabilities when stronger guarantees are needed.",
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128
+            },
+            "minItems": 1,
+            "maxItems": 64,
+            "uniqueItems": true
+          },
+          "auth_hint": {
+            "type": "string",
+            "description": "Optional, informational hint to help tooling render auth setup guidance. Common values: 'shared_bearer' (one token works across all agents on this origin), 'per_agent_bearer' (each agent needs its own token), 'oauth' (OAuth 2.1 flow, see /.well-known/oauth-authorization-server). The actual auth contract is negotiated out-of-band. Consumers MUST NOT use auth_hint to decide whether to attach credentials — that decision belongs to the consumer's configured trust policy for the target origin.",
+            "minLength": 1,
+            "maxLength": 64
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional human-readable description of what this agent is for, surfaced in operator UIs and conformance reports.",
+            "minLength": 1,
+            "maxLength": 500
+          }
+        },
+        "required": ["agent_id", "url", "transport", "specialisms"],
+        "additionalProperties": true
+      },
+      "minItems": 1,
+      "maxItems": 256
+    },
+    "contact": {
+      "type": "object",
+      "description": "Optional contact information for the operator publishing this manifest.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Operator name (e.g. 'Example Publisher Ad Ops')",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "email": {
+          "type": "string",
+          "format": "email",
+          "description": "Contact email for questions about this manifest"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Operator URL — typically a docs or developer-portal page"
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": true
+    },
+    "last_updated": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp indicating when this manifest was last updated."
+    }
+  },
+  "required": ["version", "agents"],
+  "additionalProperties": true,
+  "examples": [
+    {
+      "$schema": "/schemas/adcp-agents.json",
+      "version": "1.0",
+      "agents": [
+        {
+          "agent_id": "sales",
+          "url": "https://example.com/sales/mcp",
+          "transport": "mcp",
+          "specialisms": ["sales-non-guaranteed", "sales-guaranteed"],
+          "auth_hint": "shared_bearer"
+        },
+        {
+          "agent_id": "signals",
+          "url": "https://example.com/signals/mcp",
+          "transport": "mcp",
+          "specialisms": ["signal-marketplace", "signal-owned"],
+          "auth_hint": "shared_bearer"
+        },
+        {
+          "agent_id": "governance",
+          "url": "https://example.com/governance/mcp",
+          "transport": "mcp",
+          "specialisms": [
+            "governance-spend-authority",
+            "governance-delivery-monitor",
+            "property-lists",
+            "collection-lists",
+            "content-standards"
+          ],
+          "auth_hint": "shared_bearer"
+        },
+        {
+          "agent_id": "creative",
+          "url": "https://example.com/creative/mcp",
+          "transport": "mcp",
+          "specialisms": ["creative-ad-server"]
+        }
+      ],
+      "contact": {
+        "name": "Example Publisher Ad Ops",
+        "email": "adops@example.com"
+      },
+      "last_updated": "2026-05-02T00:00:00Z"
+    }
+  ]
+}

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -1504,6 +1504,12 @@
       "file_location": "/.well-known/adagents.json",
       "purpose": "Declares authorized agents. Publishers use it for sales agent authorization over properties. Data providers use it to publish signal catalogs and authorize signals agents to resell their data."
     },
+    "adcp-agents": {
+      "description": "Multi-agent topology manifest — enumerates every AdCP agent served from an origin, with URLs, transports, and claimed specialisms",
+      "$ref": "/schemas/adcp-agents.json",
+      "file_location": "/.well-known/adcp-agents.json",
+      "purpose": "Lets buyers and conformance runners discover an operator's full multi-agent topology in a single fetch. Complements per-agent agent-card.json (single agent) and adagents.json (publisher-side authorization)."
+    },
     "brand": {
       "description": "Brand identity claim file format specification",
       "$ref": "/schemas/brand.json",


### PR DESCRIPTION
## Summary

- Defines `/.well-known/adcp-agents.json` — origin-scoped manifest enumerating every AdCP agent on a host (`agent_id`, `url`, `transport`, `specialisms[]`, optional informational `auth_hint`). Single fetch replaces the "Notion page or CSV" hop for buyers and conformance runners.
- New schema (`static/schemas/source/adcp-agents.json`) registered next to `adagents` and `brand`. New doc (`docs/protocol/multi-agent-discovery.mdx`) wired into both navs in `docs.json`.
- Reference implementation: training agent serves the manifest at `test-agent.adcontextprotocol.org/.well-known/adcp-agents.json` listing all six tenants. Pre-existing `_training_agent_tenants` extension on `adagents.json` stays in place — it carries tenants that don't fit the `authorized_agents` discriminator (governance / creative / creative-builder / brand).

## Spec design notes

- **`transport` is an open string** (common values `mcp`, `a2a`) so future transports — including TMP wires currently in build — don't require a schema-breaking change. Consumers SHOULD treat unknown values as unsupported rather than fail.
- **`agents[].url` is `https://`-only** with explicit consumer rules: HTTPS in production, block RFC 1918 / loopback / link-local / cloud-metadata addresses, verify origin matches the manifest origin OR is independently authorized via the target's `adagents.json` before sending credentials cross-origin.
- **`specialisms[]` is MUST-implement** — operators list only specialisms whose required tasks the agent supports at publication time. Consumers MAY route by specialism without further verification, MAY confirm via `get_adcp_capabilities` for stronger guarantees.
- **`auth_hint` is informational only.** `none` was deliberately dropped from the suggested vocabulary to remove a downgrade footgun. Consumers MUST NOT use `auth_hint` to decide whether to attach credentials.
- **`agent_id`** instead of `key` per spec-guidelines (no generic field names) and consistency with the rest of AdCP's `_id`-suffix convention.
- **Caps**: `agents[]` ≤ 256, `specialisms[]` ≤ 64, individual fields bounded.

## Reconciliation rules (in the doc)

| Question | Authoritative source |
|---|---|
| What agents does this operator run? | `/.well-known/adcp-agents.json` |
| Can a given agent sell my inventory? | The publisher's `/.well-known/adagents.json` — always. Listing here does not imply authorization. |
| What is the correct URL or transport for an agent? | When the manifest and the agent's `agent-card.json` disagree, the agent-card wins. |

## Out of scope (filed as follow-ups)

- Per-agent signed manifests — TLS chain trust is sufficient for v1.
- Capability-aware filtering at the manifest level.
- Versioning beyond top-level `version`; future revisions additive within `1.x`.

## Test plan

- [x] `npm run test:schemas` — 7/7 passed
- [x] `npm run test:examples` — 36/36 passed
- [x] `npm run test:json-schema` — 256/256 passed
- [x] `npx vitest run server/src/training-agent/tenants/tenant-smoke.test.ts` — 3/3 passed (existing 2 + new manifest test)
- [x] `tsc --noEmit --project server/tsconfig.json` — clean
- [x] `npm run build:schemas` — schema appears in `dist/schemas/latest/adcp-agents.json`
- [x] `npm run build:protocol-tarball` — packaged

Closes #3895.

🤖 Generated with [Claude Code](https://claude.com/claude-code)