### PR TITLE
ci(release): extend forward-merge allowlist for known 3.1-track divergences

### DIFF
--- a/.changeset/extend-forward-merge-allowlist.md
+++ b/.changeset/extend-forward-merge-allowlist.md
@@ -1,0 +1,10 @@
+---
+---
+
+ci(release): extend forward-merge auto-resolution for known 3.1-track divergences
+
+Adds four files to the auto-resolved set in `forward-merge-3.0.yml`, all routed to `--ours` (main): `training-agent-storyboards.yml`, `runner-output-contract.yaml`, `core/error.json`, `get-adcp-capabilities-response.json`. Same bridge pattern as the existing AUTH_REQUIRED rule (#3811) — main has 3.1-track additions in these files that 3.0.x can't adopt within the patch contract; without the short-circuit, every forward-merge re-discovers the divergence.
+
+Discovered on the 3.0.5 forward-merge, which required manual resolution (#3902). Future 3.0.x patch forward-merges will now auto-open without these five recurring conflicts.
+
+`storyboard-schema.yaml` is intentionally LEFT in the manual-resolution path — both lines legitimately add new doc blocks (3.0.x added `default_agent` in 3.0.5; main has CANONICAL CHECK ENUM additions), and `git checkout --ours` silently drops clean-merged 3.0.x additions. Hybrid resolution needs a human.

--- a/.github/workflows/forward-merge-3.0.yml
+++ b/.github/workflows/forward-merge-3.0.yml
@@ -189,6 +189,46 @@ jobs:
                   git checkout --ours -- "$f"
                   git add -- "$f"
                   ;;
+                # Known 3.1-track divergences: main has additions that 3.0.x
+                # cannot adopt within the patch contract. Same rationale as
+                # the AUTH_REQUIRED bridge above — main is the more advanced
+                # state, 3.0.x's content here is the older shape, and
+                # squash-merges of prior forward-merges don't advance the
+                # merge-base so the conflict resurfaces every push without
+                # this short-circuit.
+                #
+                # - .github/workflows/training-agent-storyboards.yml: main
+                #   extracted overlay logic to scripts/overlay-compliance-
+                #   cache.sh (#3793-era refactor); 3.0.x still inlines it.
+                # - static/compliance/source/universal/runner-output-contract.yaml:
+                #   main has forward-compat narrative for unrecognized
+                #   `check` kinds and additional grading-code coverage.
+                # - static/schemas/source/core/error.json: main has #3875's
+                #   schema_id + discriminator additions on issues[] entries.
+                # - static/schemas/source/protocol/get-adcp-capabilities-response.json:
+                #   main has the 3.1+ measurement capability block plus the
+                #   identity.additionalProperties:true relaxation that 3.0.x
+                #   adopted in 3.0.5 (#3896). Both shapes converged on the
+                #   identity flip; main's superset wins.
+                #
+                # Remove these entries when 3.1.0 ships and main absorbs the
+                # 3.0.x line — these are temporary bridges, not permanent
+                # allowlist entries. First observed on the 3.0.5 forward-
+                # merge (manual resolution: PR #3902).
+                .github/workflows/training-agent-storyboards.yml|static/compliance/source/universal/runner-output-contract.yaml|static/schemas/source/core/error.json|static/schemas/source/protocol/get-adcp-capabilities-response.json)
+                  git checkout --ours -- "$f"
+                  git add -- "$f"
+                  ;;
+                # static/compliance/source/universal/storyboard-schema.yaml
+                # is intentionally NOT auto-resolved. The file is the doc-
+                # comment authoring schema; both lines legitimately add new
+                # field documentation (3.0.x added `default_agent` in 3.0.5
+                # via #3897; main has its own additions like the CANONICAL
+                # CHECK ENUM block). `git checkout --ours -- <file>` would
+                # silently drop 3.0.x's clean-merged additions, so any
+                # conflict here needs human attention to merge both sides'
+                # new doc blocks. Falls through to the UNEXPECTED handler
+                # below by design.
                 *)
                   UNEXPECTED="$UNEXPECTED $f"
                   ;;


### PR DESCRIPTION
## Summary

Extends the auto-resolution allowlist in `.github/workflows/forward-merge-3.0.yml` so future 3.0.x patch forward-merges don't re-discover the same five conflicts that required manual resolution on the 3.0.5 cut (#3902).

Four files routed to `--ours` (main):

| File | Why main wins |
|---|---|
| `.github/workflows/training-agent-storyboards.yml` | Main extracted overlay logic to `scripts/overlay-compliance-cache.sh`; 3.0.x still inlines it. |
| `static/compliance/source/universal/runner-output-contract.yaml` | Main has forward-compat narrative for unrecognized `check` kinds + extra grading-code coverage. |
| `static/schemas/source/core/error.json` | Main has #3875's `schema_id` + `discriminator` additions on `issues[]` entries. |
| `static/schemas/source/protocol/get-adcp-capabilities-response.json` | Main has the 3.1+ `measurement` capability block plus `identity.additionalProperties: true` (which 3.0.x adopted in 3.0.5 via #3896 — the flip is now consensus). |

Same bridge pattern as the existing `error-handling.mdx` / `error-code.json` rule from #3811 — main is the more advanced state, 3.0.x can't adopt the additions within the patch contract, and squash-merges of prior forward-merges don't advance the merge-base so the conflict resurfaces every push.

## What's NOT in the allowlist

`static/compliance/source/universal/storyboard-schema.yaml` is intentionally left in the manual-resolution path. Both lines legitimately add new doc blocks (3.0.x added `default_agent` in 3.0.5; main has CANONICAL CHECK ENUM additions). `git checkout --ours` would silently drop 3.0.x's clean-merged additions on every forward-merge, which is unacceptable for an authoring schema. Hybrid resolution needs a human — the workflow's UNEXPECTED-conflict handler is the right behavior here.

## Removal note

Per the existing precedent in the script, these are **temporary bridges, not permanent allowlist entries**. Remove the new block when 3.1.0 ships and main no longer carries the in-flight additions — the work will have been released and 3.0.x's older shape will no longer be load-bearing.

## Test plan

- [ ] Next 3.0.x patch (3.0.6) — forward-merge workflow auto-opens a PR without manual intervention.
- [ ] If `storyboard-schema.yaml` is touched on 3.0.6, the workflow still fails loud and routes to manual resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)