### PR TITLE
feat(brand-protocol): redirect_reason + redirect_effective_at on brand.json redirect variants

### DIFF
--- a/.changeset/redirect-ergonomics.md
+++ b/.changeset/redirect-ergonomics.md
@@ -1,0 +1,15 @@
+---
+"adcontextprotocol": minor
+---
+
+Add `redirect_reason` and `redirect_effective_at` to both redirect variants in `brand.json` (Authoritative Location Redirect and House Redirect).
+
+Today, when a brand.json transitions from a portfolio document to a redirect (e.g., during M&A — Dentsu becomes a House Redirect to WPP), DSPs / crawlers / prebid configs sit on stale cached state for whatever their TTL is. Free-text `note` is human-readable but not machine-parseable.
+
+`redirect_reason` is an enum (`acquisition`, `rebrand`, `regional`, `legacy`, `consolidation`, `other`) that consumers SHOULD use to inform cache TTL: in-transition reasons (`acquisition`, `rebrand`, `consolidation`) suggest the resolved target is moving and consumers SHOULD shorten cache TTL until stable; stable reasons (`regional`, `legacy`) keep standard caching.
+
+`redirect_effective_at` is an ISO 8601 timestamp telling caches "anything cached before this timestamp is stale" — consumers re-fetch through the redirect.
+
+Both fields are optional and additive. Existing redirect publishers continue to work unchanged.
+
+Motivated by review of the distributed brand.json RFC ([#3533](https://github.com/adcontextprotocol/adcp/pull/3533)) — the M&A migration story uses existing redirect variants, and this PR makes that ergonomic.

--- a/.changeset/redirect-ergonomics.md
+++ b/.changeset/redirect-ergonomics.md
@@ -6,9 +6,9 @@ Add `redirect_reason` and `redirect_effective_at` to both redirect variants in `
 
 Today, when a brand.json transitions from a portfolio document to a redirect (e.g., during M&A — Dentsu becomes a House Redirect to WPP), DSPs / crawlers / prebid configs sit on stale cached state for whatever their TTL is. Free-text `note` is human-readable but not machine-parseable.
 
-`redirect_reason` is an enum (`acquisition`, `rebrand`, `regional`, `legacy`, `consolidation`, `other`) that consumers SHOULD use to inform cache TTL: in-transition reasons (`acquisition`, `rebrand`, `consolidation`) suggest the resolved target is moving and consumers SHOULD shorten cache TTL until stable; stable reasons (`regional`, `legacy`) keep standard caching.
+`redirect_reason` is an enum (`acquisition`, `divestiture`, `rebrand`, `regional`, `legacy`, `consolidation`, `other`) that consumers SHOULD use to inform cache TTL: in-transition reasons (`acquisition`, `divestiture`, `rebrand`, `consolidation`) suggest the resolved target is moving and consumers SHOULD shorten cache TTL until stable; stable reasons (`regional`, `legacy`) keep standard caching.
 
-`redirect_effective_at` is an ISO 8601 timestamp telling caches "anything cached before this timestamp is stale" — consumers re-fetch through the redirect.
+`redirect_effective_at` is an ISO 8601 timestamp. Caches **MUST** treat any entry cached before this timestamp as stale and re-fetch through the redirect — this is the hard invariant that closes the cache-poisoning gap during transitions, regardless of TTL.
 
 Both fields are optional and additive. Existing redirect publishers continue to work unchanged.
 

--- a/docs/brand-protocol/brand-json.mdx
+++ b/docs/brand-protocol/brand-json.mdx
@@ -76,14 +76,17 @@ Both redirect variants accept optional `redirect_reason` and `redirect_effective
 
 | Value | Meaning | Caching guidance |
 |---|---|---|
-| `acquisition` | The owning entity was acquired (e.g., WPP buys Dentsu) | Shorten cache TTL until stable; many fields may move |
+| `acquisition` | The owning entity was acquired (e.g., one holdco buys another) | Shorten cache TTL until stable; many fields may move |
+| `divestiture` | The owning entity spun out or sold off | Shorten cache TTL until stable; new ownership chain |
 | `rebrand` | The brand or house renamed/repositioned | Shorten cache TTL until stable |
 | `consolidation` | Sub-brands consolidated into the target | Shorten cache TTL until stable |
 | `regional` | Regional/localized domain points to main house | Stable; standard caching |
 | `legacy` | Old domain that redirects to canonical | Stable; standard caching |
 | `other` | Reason not captured by the above | Free-text rationale belongs in `note` |
 
-`redirect_effective_at` (ISO 8601 timestamp) tells caches "anything cached before this timestamp is stale." Consumers SHOULD re-fetch through the redirect when their cached entry's timestamp is older than `redirect_effective_at`.
+`redirect_effective_at` (ISO 8601 timestamp) is the hard cache invariant: caches **MUST** treat any entry cached before this timestamp as stale and re-fetch through the redirect. The TTL-shortening guidance above is a SHOULD; this timestamp is a MUST and is the load-bearing fix for cache poisoning during M&A and other transitions.
+
+This is the brand.json analogue to the migration patterns in IAB Tech Lab's [ads.txt](https://iabtechlab.com/ads-txt/) (`OWNERDOMAIN`) and [sellers.json](https://iabtechlab.com/sellers-json/) (`seller_type`), which historically relied on out-of-band coordination — there was no machine-readable transition signal. `redirect_reason` + `redirect_effective_at` close that gap for brand.json.
 
 Example — acquisition redirect:
 

--- a/docs/brand-protocol/brand-json.mdx
+++ b/docs/brand-protocol/brand-json.mdx
@@ -40,6 +40,11 @@ Use this when:
 - CDN distribution is needed
 - Managed brand services
 
+Optional fields (shared with House Redirect — see [Redirect ergonomics](#redirect-ergonomics)):
+- `redirect_reason`: structured signal for cache handling (`acquisition`, `rebrand`, `regional`, `legacy`, `consolidation`, `other`)
+- `redirect_effective_at`: ISO timestamp when the redirect became effective
+- `note`: free-text rationale
+
 ### 2. House Redirect
 
 Points to the house domain that contains the full brand portfolio:
@@ -54,12 +59,43 @@ Points to the house domain that contains the full brand portfolio:
 
 Optional fields:
 - `region`: ISO 3166-1 alpha-2 country code (e.g., "CN")
-- `note`: Explanation text
+- `redirect_reason`: structured signal for cache handling (see [Redirect ergonomics](#redirect-ergonomics))
+- `redirect_effective_at`: ISO timestamp when the redirect became effective
+- `note`: free-text rationale
 
 Use this when:
 - Brand domain is owned by a larger house
 - Regional/localized domains point to main house
 - Legacy domains redirect to canonical
+
+### Redirect ergonomics
+
+Both redirect variants accept optional `redirect_reason` and `redirect_effective_at` to help consumers handle redirect transitions without sitting on stale cached state.
+
+`redirect_reason` is an enum:
+
+| Value | Meaning | Caching guidance |
+|---|---|---|
+| `acquisition` | The owning entity was acquired (e.g., WPP buys Dentsu) | Shorten cache TTL until stable; many fields may move |
+| `rebrand` | The brand or house renamed/repositioned | Shorten cache TTL until stable |
+| `consolidation` | Sub-brands consolidated into the target | Shorten cache TTL until stable |
+| `regional` | Regional/localized domain points to main house | Stable; standard caching |
+| `legacy` | Old domain that redirects to canonical | Stable; standard caching |
+| `other` | Reason not captured by the above | Free-text rationale belongs in `note` |
+
+`redirect_effective_at` (ISO 8601 timestamp) tells caches "anything cached before this timestamp is stale." Consumers SHOULD re-fetch through the redirect when their cached entry's timestamp is older than `redirect_effective_at`.
+
+Example — acquisition redirect:
+
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
+  "house": "wpp.com",
+  "redirect_reason": "acquisition",
+  "redirect_effective_at": "2026-04-15T00:00:00Z",
+  "note": "Acquired by WPP April 2026"
+}
+```
 
 ### 3. Brand Agent
 

--- a/static/schemas/source/brand.json
+++ b/static/schemas/source/brand.json
@@ -1297,6 +1297,20 @@
           "pattern": "^https://",
           "description": "HTTPS URL of the authoritative brand.json file"
         },
+        "redirect_reason": {
+          "type": "string",
+          "enum": ["acquisition", "rebrand", "regional", "legacy", "consolidation", "other"],
+          "description": "Optional structured signal indicating why this redirect was put in place. Consumers SHOULD use this to inform cache TTL decisions: 'acquisition' / 'rebrand' / 'consolidation' suggest the resolved target is in transition and consumers SHOULD shorten cache TTL until stable. 'regional' / 'legacy' suggest a stable redirect with no special cache handling needed. Free-text rationale belongs in 'note'."
+        },
+        "redirect_effective_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Optional timestamp when this redirect became effective. Caches SHOULD treat anything cached before this timestamp as stale and re-fetch."
+        },
+        "note": {
+          "type": "string",
+          "description": "Optional human-readable rationale for the redirect."
+        },
         "last_updated": { "type": "string", "format": "date-time" }
       },
       "required": ["authoritative_location"],
@@ -1317,7 +1331,20 @@
           "pattern": "^[A-Z]{2}$",
           "description": "ISO 3166-1 alpha-2 country code if this is a regional domain"
         },
-        "note": { "type": "string" },
+        "redirect_reason": {
+          "type": "string",
+          "enum": ["acquisition", "rebrand", "regional", "legacy", "consolidation", "other"],
+          "description": "Optional structured signal indicating why this redirect was put in place. Consumers SHOULD use this to inform cache TTL decisions: 'acquisition' / 'rebrand' / 'consolidation' suggest the resolved target is in transition and consumers SHOULD shorten cache TTL until stable. 'regional' / 'legacy' suggest a stable redirect with no special cache handling needed. Free-text rationale belongs in 'note'."
+        },
+        "redirect_effective_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Optional timestamp when this redirect became effective. Caches SHOULD treat anything cached before this timestamp as stale and re-fetch."
+        },
+        "note": {
+          "type": "string",
+          "description": "Optional human-readable rationale for the redirect."
+        },
         "last_updated": { "type": "string", "format": "date-time" }
       },
       "required": ["house"],

--- a/static/schemas/source/brand.json
+++ b/static/schemas/source/brand.json
@@ -1299,13 +1299,13 @@
         },
         "redirect_reason": {
           "type": "string",
-          "enum": ["acquisition", "rebrand", "regional", "legacy", "consolidation", "other"],
-          "description": "Optional structured signal indicating why this redirect was put in place. Consumers SHOULD use this to inform cache TTL decisions: 'acquisition' / 'rebrand' / 'consolidation' suggest the resolved target is in transition and consumers SHOULD shorten cache TTL until stable. 'regional' / 'legacy' suggest a stable redirect with no special cache handling needed. Free-text rationale belongs in 'note'."
+          "enum": ["acquisition", "divestiture", "rebrand", "regional", "legacy", "consolidation", "other"],
+          "description": "Optional structured signal indicating why this redirect was put in place. Consumers SHOULD use this to inform cache TTL decisions: 'acquisition' / 'divestiture' / 'rebrand' / 'consolidation' suggest the resolved target is in transition and consumers SHOULD shorten cache TTL until stable. 'regional' / 'legacy' suggest a stable redirect with no special cache handling needed. Free-text rationale belongs in 'note'."
         },
         "redirect_effective_at": {
           "type": "string",
           "format": "date-time",
-          "description": "Optional timestamp when this redirect became effective. Caches SHOULD treat anything cached before this timestamp as stale and re-fetch."
+          "description": "Optional timestamp when this redirect became effective. Caches MUST treat any entry cached before this timestamp as stale and re-fetch through the redirect."
         },
         "note": {
           "type": "string",
@@ -1333,13 +1333,13 @@
         },
         "redirect_reason": {
           "type": "string",
-          "enum": ["acquisition", "rebrand", "regional", "legacy", "consolidation", "other"],
-          "description": "Optional structured signal indicating why this redirect was put in place. Consumers SHOULD use this to inform cache TTL decisions: 'acquisition' / 'rebrand' / 'consolidation' suggest the resolved target is in transition and consumers SHOULD shorten cache TTL until stable. 'regional' / 'legacy' suggest a stable redirect with no special cache handling needed. Free-text rationale belongs in 'note'."
+          "enum": ["acquisition", "divestiture", "rebrand", "regional", "legacy", "consolidation", "other"],
+          "description": "Optional structured signal indicating why this redirect was put in place. Consumers SHOULD use this to inform cache TTL decisions: 'acquisition' / 'divestiture' / 'rebrand' / 'consolidation' suggest the resolved target is in transition and consumers SHOULD shorten cache TTL until stable. 'regional' / 'legacy' suggest a stable redirect with no special cache handling needed. Free-text rationale belongs in 'note'."
         },
         "redirect_effective_at": {
           "type": "string",
           "format": "date-time",
-          "description": "Optional timestamp when this redirect became effective. Caches SHOULD treat anything cached before this timestamp as stale and re-fetch."
+          "description": "Optional timestamp when this redirect became effective. Caches MUST treat any entry cached before this timestamp as stale and re-fetch through the redirect."
         },
         "note": {
           "type": "string",


### PR DESCRIPTION
Small additive PR. Both redirect variants in \`brand.json\` (Authoritative Location Redirect and House Redirect) gain two optional fields for handling transitional state cleanly.

## Motivation

When a brand.json transitions from a portfolio document to a redirect — typically during M&A (Dentsu becomes a House Redirect to WPP after acquisition) — DSPs / crawlers / prebid configs sit on stale cached state for whatever their TTL is. The existing \`note\` field is human-readable but not machine-parseable. Consumers can't trigger cache-busting on a structured signal.

Surfaced during review of the distributed brand.json RFC (#3533) — the M&A migration path leans on existing redirect variants, and this makes that ergonomic.

## Changes

\`brand.json\` schema additions (additive, no breaking change):

| Field | Type | Description |
|---|---|---|
| \`redirect_reason\` | enum | Optional. Values: \`acquisition\`, \`rebrand\`, \`regional\`, \`legacy\`, \`consolidation\`, \`other\` |
| \`redirect_effective_at\` | ISO timestamp | Optional. \"Anything cached before this is stale.\" |

Cache handling guidance (in spec text):
- In-transition reasons (\`acquisition\`, \`rebrand\`, \`consolidation\`) → SHOULD shorten cache TTL until stable
- Stable reasons (\`regional\`, \`legacy\`) → standard caching
- Consumers SHOULD re-fetch when cached entry's timestamp is older than \`redirect_effective_at\`

Free-text rationale stays in the existing \`note\` field.

## Example

```json
{
  \"\$schema\": \"https://adcontextprotocol.org/schemas/v3/brand.json\",
  \"house\": \"wpp.com\",
  \"redirect_reason\": \"acquisition\",
  \"redirect_effective_at\": \"2026-04-15T00:00:00Z\",
  \"note\": \"Acquired by WPP April 2026\"
}
```

## Validation
- [x] \`npm run build:schemas\` — compiles
- [x] \`npm run test:schemas\` — 7/7
- [x] \`npm run test:examples\` — 36/36
- [x] \`npm run test:json-schema\` — 257 \$schema-tagged JSON blocks validate
- [x] \`npm run check:owned-links\` — clean
- [x] \`npm run typecheck\` — clean
- [x] \`npm run test:unit\` — 864/864

## Test plan
- [ ] Spec-owner review of enum values (any other transitions to model?)
- [ ] Confirm \`other\` covers what we don't anticipate
- [ ] Ratify naming — \`redirect_reason\` vs \`redirect_kind\`?

🤖 Generated with [Claude Code](https://claude.com/claude-code)