### PR TITLE
fix(compliance): seed governance_agent_url default via storyboard-root context: block

### DIFF
--- a/.changeset/seed-governance-agent-url-context.md
+++ b/.changeset/seed-governance-agent-url-context.md
@@ -1,0 +1,4 @@
+---
+---
+
+Seed `governance_agent_url` default in governance storyboards via storyboard-root `context:` block so `storyboard run` no longer SKIPs the `sync_governance` step when no explicit context is provided. Fixes #3913.

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_approved.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_approved.yaml
@@ -18,7 +18,11 @@ narrative: |
   approves. The seller must confirm the buy normally.
 
   By default, the governance agent is the training agent at test-agent.adcontextprotocol.org.
-  Override with --governance-agent-url to use a custom governance agent.
+  Override by supplying a different `governance_agent_url` in the run's initial context
+  (e.g., via `--context` on `adcp storyboard run` once the CLI supports it).
+
+context:
+  governance_agent_url: "https://test-agent.adcontextprotocol.org"
 
 agent:
   interaction_model: media_buy_seller

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_conditions.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_conditions.yaml
@@ -19,7 +19,11 @@ narrative: |
   in its response.
 
   By default, the governance agent is the training agent at test-agent.adcontextprotocol.org.
-  Override with --governance-agent-url to use a custom governance agent.
+  Override by supplying a different `governance_agent_url` in the run's initial context
+  (e.g., via `--context` on `adcp storyboard run` once the CLI supports it).
+
+context:
+  governance_agent_url: "https://test-agent.adcontextprotocol.org"
 
 agent:
   interaction_model: media_buy_seller

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
@@ -19,7 +19,11 @@ narrative: |
   the denial back to the buyer.
 
   By default, the governance agent is the training agent at test-agent.adcontextprotocol.org.
-  Override with --governance-agent-url to use a custom governance agent.
+  Override by supplying a different `governance_agent_url` in the run's initial context
+  (e.g., via `--context` on `adcp storyboard run` once the CLI supports it).
+
+context:
+  governance_agent_url: "https://test-agent.adcontextprotocol.org"
 
 agent:
   interaction_model: media_buy_seller

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_denied_recovery.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_denied_recovery.yaml
@@ -20,7 +20,11 @@ narrative: |
   correct it.
 
   By default, the governance agent is the training agent at test-agent.adcontextprotocol.org.
-  Override with --governance-agent-url to use a custom governance agent.
+  Override by supplying a different `governance_agent_url` in the run's initial context
+  (e.g., via `--context` on `adcp storyboard run` once the CLI supports it).
+
+context:
+  governance_agent_url: "https://test-agent.adcontextprotocol.org"
 
 agent:
   interaction_model: media_buy_seller

--- a/static/compliance/source/specialisms/brand-rights/scenarios/governance_denied.yaml
+++ b/static/compliance/source/specialisms/brand-rights/scenarios/governance_denied.yaml
@@ -22,7 +22,11 @@ narrative: |
   propagated from the governance agent.
 
   By default, the governance agent is the training agent at test-agent.adcontextprotocol.org.
-  Override with --governance-agent-url to use a custom governance agent.
+  Override by supplying a different `governance_agent_url` in the run's initial context
+  (e.g., via `--context` on `adcp storyboard run` once the CLI supports it).
+
+context:
+  governance_agent_url: "https://test-agent.adcontextprotocol.org"
 
 agent:
   interaction_model: brand_rights_holder

--- a/static/compliance/source/specialisms/signal-marketplace/scenarios/governance_denied.yaml
+++ b/static/compliance/source/specialisms/signal-marketplace/scenarios/governance_denied.yaml
@@ -21,7 +21,11 @@ narrative: |
   from the governance agent.
 
   By default, the governance agent is the training agent at test-agent.adcontextprotocol.org.
-  Override with --governance-agent-url to use a custom governance agent.
+  Override by supplying a different `governance_agent_url` in the run's initial context
+  (e.g., via `--context` on `adcp storyboard run` once the CLI supports it).
+
+context:
+  governance_agent_url: "https://test-agent.adcontextprotocol.org"
 
 agent:
   interaction_model: marketplace_catalog

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -196,6 +196,29 @@
 # See `docs/contributing/storyboard-authoring.md` for the author-workflow
 # side of kit selection.
 #
+# context: object (optional — initial values seeded into the runner's context
+#   accumulator before any step executes. Keys become $context.<key> references
+#   available throughout the storyboard run. Use this field to provide
+#   per-storyboard defaults for values that vary by operator topology (e.g.,
+#   a governance agent URL the runner can override at invocation time once the
+#   CLI supports --context on `storyboard run`).
+#
+#   Example:
+#     context:
+#       governance_agent_url: "https://test-agent.adcontextprotocol.org"
+#
+#   Precedence in the context accumulator (highest to lowest):
+#     1. Step `context_outputs:` captures (populated after a step passes)
+#     2. THIS field (storyboard-root `context:` block, fixed at run start)
+#     3. Test-kit substitutions where explicitly scoped into context
+#
+#   Values MUST be scalars (strings, numbers, booleans — JSON scalar types).
+#   Object and array values are not supported here — capture structured values
+#   from step responses via `context_outputs:` instead.
+#
+#   See "Context accumulator and substitution" below for the full precedence
+#   contract, runner substitution rules, and unresolved-substitution grading.)
+#
 # phases: array of Phase objects
 #
 # --- Phase ---


### PR DESCRIPTION
Closes #3913

Six governance storyboards (`sync_governance` steps in media-buy, brand-rights, and signal-marketplace scenarios) referenced `$context.governance_agent_url` in their `sample_request` payloads but never seeded it. Runners emitted `SKIP: unresolved context variables from prior steps: governance_agent_url`, causing the downstream steps to run without a registered governance binding and the storyboard to produce false negatives even against spec-correct agents. This PR adds a storyboard-root `context:` block to each affected YAML seeding the training-agent URL as the default, and formally adds the `context:` field to the top-level spec section in `storyboard-schema.yaml` (it was only described in the accumulator prose, not the field list). Narratives updated to remove the reference to a non-existent `--governance-agent-url` CLI flag.

**Non-breaking justification:** adds an optional `context:` block (new field, no wire change); all existing runners that do not implement accumulator source 2 simply ignore it — the SKIP behaviour is unchanged for those runners, which is the same as today. Runners that do implement source 2 (per the 3.0.5 spec) will now resolve the variable and exercise the step as intended.

**Note — 3.0.x cherry-pick recommended:** The `dist/compliance/3.0.1`–`3.0.5` versioned snapshots are frozen and still carry the unresolved `$context.governance_agent_url`. Adopters pinned to a 3.0.x dist (including the `bokelley/hello-adapters-gov-rights` adapter that surfaced this issue at 3.0.5) need this cherry-picked to `3.0.x` and a new patch release cut to see the fix in a versioned snapshot.

**Sibling-repo-fix-needed: adcp-client** — `adcp storyboard run` lacks a `--context KEY=VALUE` flag (single-step has `--context JSON` but full run mode does not). Adopters who need to override `governance_agent_url` to point at their own governance agent currently cannot do so without editing the storyboard YAML. The `context:` block default unblocks the training-agent path; the CLI flag is needed for the custom-agent path.

**Pre-PR review:**
- ad-tech-protocol-expert: approved — field placement correct, scalar-only constraint accurate, training-agent URL matches existing narratives; no blockers
- code-reviewer: approved — logic sound, all 6 storyboards patched, schema doc consistent, changeset correctly `--empty`; flagged 3.0.x frozen-dist gap (noted above)

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_019r8L5mpimhpvn5NDBUbzjt

---
_Generated by [Claude Code](https://claude.ai/code/session_019r8L5mpimhpvn5NDBUbzjt)_