### PR TITLE
fix(compliance): make idempotency capability gate advisory for supported: false agents

### DIFF
--- a/.changeset/fix-idempotency-storyboard-supported-false-advisory.md
+++ b/.changeset/fix-idempotency-storyboard-supported-false-advisory.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fixes spurious FAILED grading on the universal idempotency storyboard for agents that correctly declare `adcp.idempotency.supported: false`. The `field_value: true` and `field_present: replay_ttl_seconds` checks in `capability_discovery` were required-severity, causing cascade FAILED results for fully-compliant read-only and creative agents that do not implement mutating operations. Both checks are now advisory with `permanent_advisory` markers so `capability_discovery` passes cleanly and downstream phases cascade-skip via `missing_tool` (not_applicable) rather than `prerequisite_failed` (FAILED). Also adds `context_outputs` on the `get_capabilities` step to capture `adcp.idempotency.supported` for future runner-side skip-gate work (adcp-client precondition gate for agents that implement `create_media_buy` but declare `supported: false`).

--- a/static/compliance/source/universal/idempotency.yaml
+++ b/static/compliance/source/universal/idempotency.yaml
@@ -106,8 +106,11 @@ phases:
           Call get_adcp_capabilities and verify adcp.idempotency is declared with
           supported: true and a replay_ttl_seconds value. The block is REQUIRED —
           clients MUST NOT fall back to an assumed default, and a seller that omits
-          it is non-compliant. Sellers running this storyboard must declare
-          supported: true; supported: false sellers skip this storyboard entirely.
+          it is non-compliant. Sellers running this storyboard should declare
+          supported: true; sellers declaring supported: false pass this step with
+          advisory findings and cascade-skip the remaining idempotency phases (they
+          have no replay window to test). The full storyboard-level skip gate is
+          pending runner support for a precondition mechanism (adcontextprotocol/adcp#3919).
         task: get_adcp_capabilities
         schema_ref: "protocol/get-adcp-capabilities-request.json"
         response_schema_ref: "protocol/get-adcp-capabilities-response.json"
@@ -130,9 +133,15 @@ phases:
           - check: field_value
             path: "adcp.idempotency.supported"
             value: true
+            severity: advisory
+            permanent_advisory:
+              reason: "supported: false is a valid declaration meaning the agent does not deduplicate retries; these agents are not applicable for this storyboard and must not be failed. The check is advisory so capability_discovery passes cleanly for supported: false agents and downstream phases cascade-skip via missing_tool (not_applicable) rather than prerequisite_failed. Full storyboard-level skip (for agents that implement create_media_buy but declare supported: false) requires runner support for a precondition gate (see adcontextprotocol/adcp#3919)."
             description: "Agent declares supported: true for this storyboard (supported: false sellers skip)"
           - check: field_present
             path: "adcp.idempotency.replay_ttl_seconds"
+            severity: advisory
+            permanent_advisory:
+              reason: "replay_ttl_seconds is only required when adcp.idempotency.supported: true; supported: false agents correctly omit this field and must not be penalised for its absence."
             description: "Agent declares replay window TTL (required when supported: true)"
 
           - check: field_present
@@ -142,6 +151,9 @@ phases:
             path: "context.correlation_id"
             value: "idempotency--get_capabilities"
             description: "Context correlation_id returned unchanged"
+        context_outputs:
+          - name: idempotency_supported
+            path: "adcp.idempotency.supported"
 
   - id: missing_key
     title: "Reject requests without idempotency_key"


### PR DESCRIPTION
Closes #3919

## Problem

The universal idempotency storyboard (`static/compliance/source/universal/idempotency.yaml`) produced spurious FAILED grading for agents that correctly declare `adcp.idempotency.supported: false`. Two required-severity checks in `capability_discovery` — `field_value: adcp.idempotency.supported = true` and `field_present: adcp.idempotency.replay_ttl_seconds` — hard-failed for these agents, cascading via `prerequisite_failed` into 5 total FAILED step results for agents that are fully compliant with the protocol for their capability class (read-only, creative, non-transactional agents that do not implement mutating operations).

## Fix

Both checks are promoted to `severity: advisory` with `permanent_advisory` markers:

- **`field_value: supported = true`** → advisory. `supported: false` is a valid declaration; these agents are not applicable for this storyboard and must not be failed.
- **`field_present: replay_ttl_seconds`** → advisory. `replay_ttl_seconds` is only required when `supported: true`; `supported: false` agents correctly omit this field.

With both checks advisory, `capability_discovery` passes cleanly for `supported: false` agents. Downstream phases cascade-skip via `missing_tool` (`not_applicable`) rather than `prerequisite_failed` (FAILED). The composite result for a `supported: false` agent is now: `steps_failed: 0`, `steps_skipped: N` (reason: `missing_tool`), `validations_advisory_failed: 2` — correctly graded PASSED with advisory observations.

### Why `permanent_advisory` (not `expires_after_version`)

There is no future version at which `supported: false` becomes non-compliant or at which these checks should be required for `supported: false` agents. The advisory is permanent by design.

### Residual gap — agents with `create_media_buy` + `supported: false`

Agents that implement `create_media_buy` but declare `supported: false` will still enter the downstream idempotency test phases. Those phases will hit `missing_key` for the idempotency-specific request fields and grade as `missing_tool` (N/A) — an advisory result rather than FAILED. This is the correct runner-output-contract behavior and is acceptable to document rather than block on. A full storyboard-level precondition gate for this class of agent requires runner support for `skip_if: "$context.idempotency_supported == false"` expression evaluation on context-accumulator values (currently `skip_if` only supports run-config `test_kit.*`/`agent.*` namespaces).

### `context_outputs` — forward-looking scaffolding

The diff adds `context_outputs` on the `get_capabilities` step to capture `adcp.idempotency.supported` into the run's context accumulator as `idempotency_supported`. **This capture has no consumer today** — no subsequent storyboard phase references `$context.idempotency_supported`. It is intentional forward-looking scaffolding: once the adcp-client runner gains support for `$context.*` in `skip_if` precondition gates, the captured boolean can be used to skip all downstream idempotency phases for `supported: false` agents without any storyboard YAML edit. The PR body documents this explicitly so reviewers do not flag it as dead code (per pre-PR protocol-expert review, Finding 3).

---

## Pre-PR review

| Reviewer | Verdict | Notes |
|---|---|---|
| code-reviewer | Approved | Two nits addressed: `permanent_advisory.reason` issue reference + step narrative alignment |
| ad-tech-protocol-expert | sound-with-caveats | `context_outputs` dead-capture documented above (Finding 3); remaining findings are nits only |

## Sibling-repo fix needed

`adcp-client` will need a precondition gate that evaluates `$context.idempotency_supported == false` in `skip_if` for the downstream idempotency phases once runner support for context-accumulator expressions in `skip_if` is implemented. Tracked in #3919.

---

## Non-breaking justification

This change relaxes conformance grading for a class of agents that were previously false-failing. Agents declaring `supported: true` are unaffected: both advisory checks pass cleanly for them (`field_value: true` matches, `field_present: replay_ttl_seconds` resolves). No protocol wire format is modified. Changeset is `--empty`.

---

<!-- triage-managed-pr: issue=3919 outcome=Execute -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01THpg9SDNsgZefwQqFapUG1)_