### PR TITLE
spec(schemas): add discriminator hints to const-property oneOf unions (adcp#3917)

### DIFF
--- a/.changeset/oneof-const-discriminator-hints.md
+++ b/.changeset/oneof-const-discriminator-hints.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": patch
+---
+
+Add `discriminator: { propertyName }` to 17 `oneOf` unions in `static/schemas/source/` whose variants already declare the same required property as a `const` with distinct string values.
+
+Affected schemas: `adagents.json`, `compliance/comply-test-controller-response.json`, `content-standards/artifact.json`, `core/activation-key.json`, `core/creative-item.json`, `core/deployment.json`, `core/destination.json`, `core/optimization-goal.json` (3 unions), `core/requirements/catalog-field-binding.json` (2 unions), `core/signal-pricing.json`, `creative/preview-creative-response.json`, `creative/preview-render.json`.
+
+Non-breaking: the OpenAPI `discriminator` keyword is ignored by JSON Schema 2020-12 validators that don't recognize it; the existing `const`-property pattern remains the source of truth. Codegen targets that respect the keyword (msgspec, openapi-typescript, datamodel-code-generator) now emit a properly-narrowed union without per-variant casts. Tracking: adcp#3917.

--- a/.changeset/oneof-const-discriminator-hints.md
+++ b/.changeset/oneof-const-discriminator-hints.md
@@ -2,7 +2,7 @@
 "adcontextprotocol": patch
 ---
 
-Add `discriminator: { propertyName }` to 17 `oneOf` unions in `static/schemas/source/` whose variants already declare the same required property as a `const` with distinct string values.
+Add `discriminator: { propertyName }` to 16 `oneOf` unions in `static/schemas/source/` whose variants already declare the same required property as a `const` with distinct string values, and tighten `scripts/audit-oneof.mjs` to assert that any `discriminator.propertyName=X` is backed by every non-ref variant declaring `properties.X` as required const with distinct values.
 
 Affected schemas: `adagents.json`, `compliance/comply-test-controller-response.json`, `content-standards/artifact.json`, `core/activation-key.json`, `core/creative-item.json`, `core/deployment.json`, `core/destination.json`, `core/optimization-goal.json` (3 unions), `core/requirements/catalog-field-binding.json` (2 unions), `core/signal-pricing.json`, `creative/preview-creative-response.json`, `creative/preview-render.json`.
 

--- a/scripts/audit-oneof.mjs
+++ b/scripts/audit-oneof.mjs
@@ -146,6 +146,38 @@ function classify(oneOfArr, parentSchema, sourceFile) {
   }
 
   if (parentSchema && parentSchema.discriminator && parentSchema.discriminator.propertyName) {
+    const key = parentSchema.discriminator.propertyName;
+    // Enforce that every variant actually declares `properties.<key>` as a const
+    // (or single-element enum) and lists it in `required`, with distinct values
+    // across variants. Otherwise the discriminator hint is unbacked — exactly
+    // the two-sources-of-truth failure mode we want to prevent.
+    // Trust nested-union and pure-ref variants — their target may carry the
+    // const further down. We only catch the failure mode where a non-ref
+    // variant declares no const for the discriminator key, OR a const
+    // collides with another variant (the two-sources-of-truth drift).
+    const seen = new Set();
+    const violations = [];
+    for (let i = 0; i < variants.length; i++) {
+      const v = variants[i];
+      if (v.info.refOnly === 'nested-union' || v.info.refOnly === true) continue;
+      const prop = (v.info.properties || {})[key];
+      const constVal = prop && prop.const !== undefined ? prop.const : Array.isArray(prop?.enum) && prop.enum.length === 1 ? prop.enum[0] : undefined;
+      const isRequired = (v.info.required || []).includes(key);
+      if (constVal === undefined || !isRequired) {
+        violations.push(`${i}:missing const+required for "${key}"`);
+        continue;
+      }
+      const k = JSON.stringify(constVal);
+      if (seen.has(k)) violations.push(`${i}:duplicate "${key}" value ${k}`);
+      seen.add(k);
+    }
+    if (violations.length) {
+      return {
+        kind: 'dangerous',
+        variants,
+        note: `discriminator.propertyName="${key}" is set but unbacked: ${violations.join(' | ')}`,
+      };
+    }
     return {
       kind: 'discriminated',
       discriminator: parentSchema.discriminator.propertyName,

--- a/static/schemas/source/adagents.json
+++ b/static/schemas/source/adagents.json
@@ -153,6 +153,9 @@
           "type": "array",
           "description": "Array of sales agents authorized to make inventory from this file available to buyers. Authorization can be scoped to specific properties, collections, countries, and time windows, with optional delegation metadata indicating whether the path is direct, delegated, or network-mediated.",
           "items": {
+            "discriminator": {
+              "propertyName": "authorization_type"
+            },
             "oneOf": [
               {
                 "type": "object",

--- a/static/schemas/source/compliance/comply-test-controller-response.json
+++ b/static/schemas/source/compliance/comply-test-controller-response.json
@@ -480,6 +480,9 @@
               "timestamp"
             ],
             "additionalProperties": false,
+            "discriminator": {
+              "propertyName": "attestation_mode"
+            },
             "oneOf": [
               {
                 "title": "RawAttestation",

--- a/static/schemas/source/content-standards/artifact.json
+++ b/static/schemas/source/content-standards/artifact.json
@@ -41,6 +41,9 @@
       "description": "Artifact assets in document flow order - text blocks, images, video, audio",
       "maxItems": 200,
       "items": {
+        "discriminator": {
+          "propertyName": "type"
+        },
         "oneOf": [
           {
             "type": "object",
@@ -281,6 +284,9 @@
     "asset_access": {
       "type": "object",
       "description": "Authentication for accessing secured asset URLs",
+      "discriminator": {
+        "propertyName": "method"
+      },
       "oneOf": [
         {
           "type": "object",

--- a/static/schemas/source/core/activation-key.json
+++ b/static/schemas/source/core/activation-key.json
@@ -4,6 +4,9 @@
   "title": "Activation Key",
   "description": "Universal identifier for using a signal on a destination platform. Can be either a segment ID or a key-value pair depending on the platform's targeting mechanism.",
   "type": "object",
+  "discriminator": {
+    "propertyName": "type"
+  },
   "oneOf": [
     {
       "properties": {

--- a/static/schemas/source/core/creative-item.json
+++ b/static/schemas/source/core/creative-item.json
@@ -3,6 +3,9 @@
   "$id": "/schemas/core/creative-item.json",
   "title": "Creative Item",
   "description": "Item within a multi-asset creative format. Used for carousel products, native ad components, and other formats composed of multiple distinct elements.",
+  "discriminator": {
+    "propertyName": "asset_kind"
+  },
   "oneOf": [
     {
       "type": "object",

--- a/static/schemas/source/core/deployment.json
+++ b/static/schemas/source/core/deployment.json
@@ -3,6 +3,9 @@
   "$id": "/schemas/core/deployment.json",
   "title": "Deployment",
   "description": "A signal deployment to a specific deployment target with activation status and key",
+  "discriminator": {
+    "propertyName": "type"
+  },
   "oneOf": [
     {
       "type": "object",

--- a/static/schemas/source/core/destination.json
+++ b/static/schemas/source/core/destination.json
@@ -3,6 +3,9 @@
   "$id": "/schemas/core/destination.json",
   "title": "Destination",
   "description": "A deployment target where signals can be activated (DSP, sales agent, etc.)",
+  "discriminator": {
+    "propertyName": "type"
+  },
   "oneOf": [
     {
       "type": "object",

--- a/static/schemas/source/core/optimization-goal.json
+++ b/static/schemas/source/core/optimization-goal.json
@@ -3,6 +3,9 @@
   "$id": "/schemas/core/optimization-goal.json",
   "title": "Optimization Goal",
   "description": "A single optimization target for a package. Packages accept an array of optimization_goals. When multiple goals are present, priority determines which the seller focuses on — 1 is highest priority (primary goal); higher numbers are secondary. Duplicate priority values result in undefined seller behavior.",
+  "discriminator": {
+    "propertyName": "kind"
+  },
   "oneOf": [
     {
       "type": "object",
@@ -51,6 +54,9 @@
         },
         "target": {
           "description": "Target for this metric. When omitted, the seller optimizes for maximum metric volume within budget.",
+          "discriminator": {
+            "propertyName": "kind"
+          },
           "oneOf": [
             {
               "type": "object",
@@ -124,6 +130,9 @@
         },
         "target": {
           "description": "Target cost or return for this event goal. When omitted, the seller optimizes for maximum conversion count within budget — regardless of whether value_field is present on event sources. The presence of value_field alone does not change the optimization objective; it only makes value available for reporting. An explicit target of maximize_value or per_ad_spend is required to steer toward value.",
+          "discriminator": {
+            "propertyName": "kind"
+          },
           "oneOf": [
             {
               "type": "object",

--- a/static/schemas/source/core/requirements/catalog-field-binding.json
+++ b/static/schemas/source/core/requirements/catalog-field-binding.json
@@ -45,6 +45,9 @@
       "additionalProperties": true
     }
   },
+  "discriminator": {
+    "propertyName": "kind"
+  },
   "oneOf": [
     { "$ref": "#/definitions/ScalarBinding" },
     { "$ref": "#/definitions/AssetPoolBinding" },
@@ -66,6 +69,9 @@
           "type": "array",
           "description": "Scalar and asset pool bindings that apply within each repetition of the group. Nested catalog_group bindings are not permitted.",
           "items": {
+            "discriminator": {
+              "propertyName": "kind"
+            },
             "oneOf": [
               { "$ref": "#/definitions/ScalarBinding" },
               { "$ref": "#/definitions/AssetPoolBinding" }

--- a/static/schemas/source/core/signal-pricing.json
+++ b/static/schemas/source/core/signal-pricing.json
@@ -4,6 +4,9 @@
   "title": "Vendor Pricing",
   "description": "Pricing model for a vendor service. Discriminated by model: 'cpm' (fixed CPM), 'percent_of_media' (percentage of spend with optional CPM cap), 'flat_fee' (fixed charge per reporting period), 'per_unit' (fixed price per unit of work), or 'custom' (escape hatch for models not covered by the enumerated forms — requires a description and structured metadata).",
   "type": "object",
+  "discriminator": {
+    "propertyName": "model"
+  },
   "oneOf": [
     {
       "title": "CpmPricing",

--- a/static/schemas/source/creative/preview-creative-response.json
+++ b/static/schemas/source/creative/preview-creative-response.json
@@ -8,6 +8,9 @@
       "$ref": "/schemas/core/version-envelope.json"
     }
   ],
+  "discriminator": {
+    "propertyName": "response_type"
+  },
   "oneOf": [
     {
       "title": "PreviewCreativeSingleResponse",

--- a/static/schemas/source/creative/preview-render.json
+++ b/static/schemas/source/creative/preview-render.json
@@ -3,6 +3,9 @@
   "$id": "/schemas/creative/preview-render.json",
   "title": "Preview Render",
   "description": "A single rendered piece of a creative preview with discriminated output format",
+  "discriminator": {
+    "propertyName": "output_format"
+  },
   "oneOf": [
     {
       "type": "object",


### PR DESCRIPTION
## Summary

Step 2 of the discriminator audit plan from #3917. Adds `discriminator: { propertyName }` to 16 `oneOf` unions in `static/schemas/source/` whose variants already declare the same required property as a `const` with distinct string values. Also tightens the audit walker to enforce that any `discriminator.propertyName=X` is *backed* by every non-ref variant declaring `properties.X` as required const — preventing a two-sources-of-truth drift where the keyword sits without the structural narrowing.

**Non-breaking** — the OpenAPI `discriminator` keyword is ignored by JSON Schema 2020-12 validators that don't recognize it. Existing `const`-property narrowing remains the source of truth. Codegen targets that respect the keyword (msgspec, openapi-typescript, datamodel-code-generator) now emit a properly-narrowed union without per-variant casts.

## Affected schemas (16 unions, 15 hoists across 12 files)

- `adagents.json` (`authorization_type`)
- `compliance/comply-test-controller-response.json` (`attestation_mode`)
- `content-standards/artifact.json` (`type`, `method`)
- `core/activation-key.json` (`type`)
- `core/creative-item.json` (`asset_kind`)
- `core/deployment.json` (`type`)
- `core/destination.json` (`type`)
- `core/optimization-goal.json` (`kind` × 3)
- `core/requirements/catalog-field-binding.json` (`kind` × 2)
- `core/signal-pricing.json` (`model`)
- `creative/preview-creative-response.json` (`response_type`)
- `creative/preview-render.json` (`output_format`)

## Walker tightening

`scripts/audit-oneof.mjs` now treats `discriminator.propertyName=X` as ✗ if any non-ref variant fails to declare `properties.X` as required const, or if two variants share the same const value. Nested-union and pure-ref variants are trusted (their target may carry the const further down). This guards the failure mode the protocol expert flagged: a future author could add `discriminator.propertyName=X` without the const, weakening validation for non-OpenAPI consumers.

## Deferred to follow-ups

- **Boolean discriminators** (`get-adcp-capabilities-response.json` `supported`, `update-content-standards-response.json` `success`) — Ajv requires unique-string values
- **Cross-file ref-only variants** (`core/format.json` `assets/items` → `asset_type`, `core/pricing-option.json` → `pricing_model`) — Ajv discriminator support doesn't follow cross-file `$ref`. (Within-file `#/definitions` refs work fine and are already deployed in `catalog-field-binding.json`.)

## Test plan

- [x] `node scripts/audit-oneof.mjs` — 36 ✓ unchanged (these were already classified ✓ via const)
- [x] Walker drift test: temporarily setting `discriminator.propertyName="wrong_key"` on `core/activation-key.json` correctly trips ✗ with a clear "missing const+required" message
- [x] Pre-existing `core/assets/asset-union.json` and `core/offering-asset-group.json` (which use nested-union ref variants) still pass — the invariant trusts nested-union targets
- [x] `npm run test:json-schema` (257/0)
- [x] `npm run test:schemas` (7/0)
- [x] `npm run test:composed` (26/0)
- [x] `npm run test:oneof-discriminators` — passes against committed baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)