### PR TITLE
docs(skill): correct issues[] field names + split spec-optional from SDK-synthesized

### DIFF
--- a/.changeset/skill-issues-fields-fix.md
+++ b/.changeset/skill-issues-fields-fix.md
@@ -1,0 +1,16 @@
+---
+---
+
+docs(skill): correct `issues[]` field names + split spec-optional from SDK-synthesized
+
+Follow-up to #3927. Three corrections to `skills/call-adcp-agent/SKILL.md`:
+
+1. **Casing.** `error.json` defines the wire field as `schema_id` (snake_case, line 54). #3927 documented it as `schemaId` — that shape is `@adcp/sdk`-normalized and breaks Python/Go/raw-HTTP callers reading the literal JSON. Renamed to `schema_id` in prose and the symptom-fix table; called out the SDK casing variance separately.
+
+2. **Category split.** `schema_id` and `discriminator` are spec-optional wire fields per `error.json`. `hint` and `allowedValues` are NOT in `error.json` — they're synthesized client-side by `@adcp/sdk` after parsing. Grouping all four under "implementation-dependent fields a validator may opt into" told non-TS callers to look for fields no AdCP seller emits. Split into two clearly-labeled tiers: spec-optional (sellers MAY emit) vs SDK-side enrichment (your SDK adds these locally, irrespective of seller).
+
+3. **Recovery order.** Restored `pointer` + `keyword` + `variants` as the unconditional one-step path; treats `discriminator` / `hint` / `schema_id` as shortcuts when present rather than required first reads. The previous front-loading made callers branch on optional fields that are absent on the long tail.
+
+Also fixed `discriminator` field shape in prose and table: items are `{property_name, value}` per `error.json:65-71`, not `{field, value}`.
+
+Doc-only. No wire-format change. Not for cherry-pick to `3.0.x` — `schema_id` and `discriminator` were added to `error.json` in #3875 (main only) and are not in 3.0.x's wire schema.

--- a/skills/call-adcp-agent/SKILL.md
+++ b/skills/call-adcp-agent/SKILL.md
@@ -115,17 +115,22 @@ Every validation failure produces:
 }
 ```
 
+**Required fields — every conformant validator surfaces these:**
+
 - `issues[].pointer` — RFC 6901 JSON Pointer to the field.
 - `issues[].keyword` — AJV keyword (`required`, `type`, `oneOf`, `anyOf`, `additionalProperties`, `format`, `enum`).
 - `issues[].variants` — when the keyword is `oneOf` or `anyOf`, each entry lists one variant's `required` + declared `properties`. **Pick ONE variant**, send only its `required` fields. This is the fastest recovery path when you didn't know the field was a union.
-- `issues[].discriminator` — _implementation-dependent._ When the validator picks a "best surviving variant" of a const-discriminated union, this is the `[{field, value}, …]` pairs that variant requires. Reads as the validator's verdict on which branch you were inferred to be targeting. Example: `discriminator: [{field: 'type', value: 'key_value'}]` plus `pointer: '/deployments/0/activation_key/key'` and `keyword: 'required'` means "you picked the `key_value` activation_key variant and it requires top-level `key` and `value`." Compound discriminators like `audience-selector`'s `(type, value_type)` produce two-entry arrays.
-- `issues[].schemaId` — _implementation-dependent._ `$id` of the rejecting schema. For tools served from the bundled tree this is usually the response root; for flat-tree tools it can land on the deeper sub-schema. Diagnostic only; the actionable lever is `discriminator` + `variants` + `pointer`.
-- `issues[].allowedValues` — _implementation-dependent._ Closed enum lists for `keyword: 'enum'` issues. Picking from this list closes the case in one round.
-- `issues[].hint` — _implementation-dependent._ One-sentence curated recipe for known shape gotchas: discriminator nesting (`activation_key`, VAST `delivery_type`), shape mismatches (`format_id` object, `budget` number, `signal_ids` provenance objects), and discriminator merging (`account`). When present, the hint is the most-direct fix path; read it before walking variants. Absent on the long tail — no hint just means there's no curated rule for the pattern.
 
-The four `_implementation-dependent_` fields are emitted by validators that opt into them; sellers running schema-strict validation libraries surface them, others may not. Treat them as additive: their presence shortens recovery; their absence just means falling back to `pointer` + `keyword` + `variants`.
+**Spec-optional wire fields — sellers MAY emit per `error.json`:**
 
-**Recovery order**: read `hint` first (when present, it's the validated fix path); then `discriminator` (names which branch to fix); then `variants` (lists every option if you're not in a branch); then `pointer` + `keyword` + `message` for the leaf fix. Patch and resend. Three attempts should cover every field.
+- `issues[].schema_id` — `$id` of the rejecting (sub-)schema (e.g. `/schemas/3.1.0/core/activation-key.json`). Diagnostic; the actionable lever is `discriminator` + `variants` + `pointer`. Sellers MUST omit when the rejection is against a private extension or pre-release element. See [error-handling.mdx](../docs/protocol/error-handling.mdx).
+- `issues[].discriminator` — `[{property_name, value}, …]` pairs identifying the const-discriminated `oneOf`/`anyOf` variant the validator selected from values present in the payload. Reads as "you targeted this branch; the missing/wrong fields are at the same level." Compound discriminators like `audience-selector`'s `(type, value_type)` produce two-entry arrays. Example: `discriminator: [{property_name: 'type', value: 'key_value'}]` plus `pointer: '/deployments/0/activation_key/key'` and `keyword: 'required'` means "you picked the `key_value` activation_key variant and it requires top-level `key` and `value`."
+
+Both fields are optional in the spec — their presence shortens recovery; their absence just means falling back to `pointer` + `keyword` + `variants`. They are wire-level: a Python or Go caller reading the raw JSON sees them as `schema_id` and `discriminator`. SDKs that normalize keys (e.g. `@adcp/sdk` camelCases to `schemaId`) surface the SDK-shaped name.
+
+**Recovery order:** patch the `pointer`s using `keyword` + `variants`, resend. If `discriminator` is present, prefer it — it names the branch directly so you don't have to walk `variants`. If `schema_id` is present, use it for diagnostic logging only. Three attempts should cover every field.
+
+> **SDK-side enrichment.** Some SDKs synthesize additional fields client-side after parsing — e.g. `@adcp/sdk` adds `hint` (one-sentence curated recipes for known shape gotchas) and `allowedValues` (closed enum lists for `keyword: 'enum'`). These are **not** wire fields and are not emitted by sellers; if you're not using that SDK, you won't see them regardless of the seller. When present, prefer them over walking `variants`. See your SDK's docs for the full list.
 
 ## Minimal working examples
 
@@ -231,8 +236,8 @@ Quick lookup before reading the full envelope. Match what you see in `adcp_error
 | Symptom | What it means | Fix |
 |---|---|---|
 | `keyword: 'oneOf'` with `variants[]` | Discriminated union — you sent fields from multiple variants, or none | Pick ONE variant from `variants[]`. Send only its `required` fields. |
-| `discriminator: [{field, value}]` on a `required` issue | Validator inferred which branch you targeted; you missed required fields IN that branch | Read the `discriminator` pair, fill the missing required fields at the same level (don't nest under the discriminator field name). |
-| `hint:` field present on the issue | Validator matched a curated shape-gotcha rule | Apply the hint directly — it's the validated fix path. |
+| `discriminator: [{property_name, value}]` on a `required` issue | Seller's validator inferred which branch you targeted; you missed required fields IN that branch | Read the `discriminator` pair, fill the missing required fields at the same level (don't nest under the discriminator property name). |
+| `hint:` field present (SDK-side enrichment, not on the wire) | Your SDK matched a curated shape-gotcha rule | Apply the hint directly — it's the validated fix path. |
 | 2-3 `additionalProperties` errors at the same pointer | You merged `oneOf` variants (`` `{account_id, brand, operator, …}` ``) | Drop to one variant. Don't keep "extra" fields "for completeness". |
 | `keyword: 'required'`, `pointer: '/idempotency_key'` | Mutating tool, no UUID | Generate fresh UUID per logical operation. Reuse it on retries. |
 | `keyword: 'type'` or `additionalProperties` at `/budget` | Sent `{amount, currency}` | `budget` is a number. Currency is implied by `pricing_option_id`. |


### PR DESCRIPTION
## Summary

Follow-up to #3927. Three corrections to `skills/call-adcp-agent/SKILL.md`:

1. **`schemaId` → `schema_id`.** `static/schemas/source/core/error.json:54` defines the wire field as snake_case. The TS SDK camelCases on receive, but this skill is read by Python / Go / raw-HTTP callers too, who get a literal `KeyError` reaching for `schemaId`. The casing variance is now called out in one line so SDK users can still navigate.

2. **Spec-optional vs SDK-synthesized split.** `schema_id` and `discriminator` are wire fields per `error.json`. `hint` and `allowedValues` are **not** in `error.json` — they're synthesized by `@adcp/sdk` after parsing. Grouping all four as "implementation-dependent fields a validator may opt into emitting" told non-TS callers to look for fields no AdCP seller is obliged to emit. Split into two tiers with the SDK-side ones moved into a clearly-labeled callout.

3. **Recovery order.** Restored `pointer` + `keyword` + `variants` as the unconditional one-step path; treats `discriminator` / `hint` / `schema_id` as shortcuts when present rather than required first reads. The previous front-loading forced callers to branch on optional fields that are absent on the long tail.

Also fixes the `discriminator` item shape in prose and table — items are `{property_name, value}` per `error.json:65-71`, not `{field, value}`.

## Why

#3927 was self-merged 4 minutes after opening, before either expert review or the TypeScript Build check completed. Two follow-up reviews (ad-tech-protocol-expert, docs-expert) flagged the same three issues independently. Doc-only fix to bring the skill in line with the actual wire schema and the spec/SDK boundary.

## Risk

Low. Doc-only. No wire-format change. No schema change.

## 3.0.x

**Not for cherry-pick.** `schema_id` and `discriminator` were added to `error.json` in #3875 (main only) — `origin/3.0.x` still has only `schemaPath`. Documenting these fields in 3.0.x's SKILL.md would document fields no 3.0.5-conformant seller emits.

## Verification

- `skills/call-adcp-agent/SKILL.md` renders cleanly (Markdown + table syntax intact)
- Field names match `static/schemas/source/core/error.json` exactly
- Changeset present (`--empty`, doc-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)