### PR TITLE
spec(schemas): hoist pricing-option + format inner-asset discriminators (adcp#3917)

### DIFF
--- a/.changeset/oneof-deferred-discriminators.md
+++ b/.changeset/oneof-deferred-discriminators.md
@@ -1,0 +1,10 @@
+---
+"adcontextprotocol": patch
+---
+
+Add `discriminator: { propertyName }` to two more `oneOf` unions previously deferred from #3928:
+
+- `core/pricing-option.json` `#/oneOf` (`pricing_model`) — Ajv resolves the cross-file `$ref` to each `pricing-options/*-option.json` correctly when all schemas are pre-loaded; the deferral was based on a faulty isolated-compile test.
+- `core/format.json` `#/properties/assets/items/oneOf/14/properties/assets/items/oneOf` (`asset_type`) — required `asset_type` on each of the 12 inner variants directly so Ajv's discriminator support can find it without traversing `allOf`.
+
+The 15-variant outer oneOf at `#/properties/assets/items` is still deferred — it mixes `item_type: "individual"` (14 variants with `asset_type`) and `item_type: "repeatable_group"` (no `asset_type`), so a single discriminator key doesn't cover it without a structural restructure. Tracked separately. Same for the boolean-discriminator unions (`get-adcp-capabilities-response.json` `supported`, `update-content-standards-response.json` `success`) which need an enum migration. Tracking: adcp#3917.

--- a/scripts/oneof-discriminators.baseline.json
+++ b/scripts/oneof-discriminators.baseline.json
@@ -151,11 +151,6 @@
       "variants": 15,
       "note": "shared-required=[∅]; 0:req=[∅] | 1:req=[∅] | 2:req=[∅] | 3:req=[∅] | 4:req=[∅] | 5:req=[∅] | 6:req=[∅] | 7:req=[∅] | 8:req=[∅] | 9:req=[∅] | 10:req=[∅] | 11:req=[∅] | 12:req=[∅] | 13:req=[∅] | 14:req=[item_type,asset_group_id,required,min_count,max_count,assets]"
     },
-    "core/format.json##/properties/assets/items/oneOf/14/properties/assets/items/oneOf": {
-      "kind": "dangerous",
-      "variants": 12,
-      "note": "shared-required=[∅]; 0:req=[∅] | 1:req=[∅] | 2:req=[∅] | 3:req=[∅] | 4:req=[∅] | 5:req=[∅] | 6:req=[∅] | 7:req=[∅] | 8:req=[∅] | 9:req=[∅] | 10:req=[∅] | 11:req=[∅]"
-    },
     "core/format.json##/properties/renders/items/oneOf": {
       "kind": "narrowable",
       "variants": 2,
@@ -195,11 +190,6 @@
       "kind": "narrowable",
       "variants": 3,
       "note": "0:[creatives] | 1:[errors] | 2:[status,task_id]"
-    },
-    "error-details/agent-permission-denied.json##/oneOf": {
-      "kind": "narrowable",
-      "variants": 2,
-      "note": "0:[status] | 1:[reason]"
     },
     "governance/sync-plans-request.json##/properties/plans/items/properties/budget/oneOf": {
       "kind": "narrowable",

--- a/static/schemas/source/core/format.json
+++ b/static/schemas/source/core/format.json
@@ -378,6 +378,9 @@
                 "type": "array",
                 "description": "Assets within each repetition of this group",
                 "items": {
+                  "discriminator": {
+                    "propertyName": "asset_type"
+                  },
                   "oneOf": [
                     {
                       "title": "GroupImageAsset",
@@ -386,7 +389,8 @@
                       "properties": {
                         "asset_type": { "const": "image" },
                         "requirements": { "$ref": "/schemas/core/requirements/image-asset-requirements.json" }
-                      }
+                      },
+                      "required": ["asset_type"]
                     },
                     {
                       "title": "GroupVideoAsset",
@@ -395,7 +399,8 @@
                       "properties": {
                         "asset_type": { "const": "video" },
                         "requirements": { "$ref": "/schemas/core/requirements/video-asset-requirements.json" }
-                      }
+                      },
+                      "required": ["asset_type"]
                     },
                     {
                       "title": "GroupAudioAsset",
@@ -404,7 +409,8 @@
                       "properties": {
                         "asset_type": { "const": "audio" },
                         "requirements": { "$ref": "/schemas/core/requirements/audio-asset-requirements.json" }
-                      }
+                      },
+                      "required": ["asset_type"]
                     },
                     {
                       "title": "GroupTextAsset",
@@ -413,7 +419,8 @@
                       "properties": {
                         "asset_type": { "const": "text" },
                         "requirements": { "$ref": "/schemas/core/requirements/text-asset-requirements.json" }
-                      }
+                      },
+                      "required": ["asset_type"]
                     },
                     {
                       "title": "GroupMarkdownAsset",
@@ -422,7 +429,8 @@
                       "properties": {
                         "asset_type": { "const": "markdown" },
                         "requirements": { "$ref": "/schemas/core/requirements/markdown-asset-requirements.json" }
-                      }
+                      },
+                      "required": ["asset_type"]
                     },
                     {
                       "title": "GroupHtmlAsset",
@@ -431,7 +439,8 @@
                       "properties": {
                         "asset_type": { "const": "html" },
                         "requirements": { "$ref": "/schemas/core/requirements/html-asset-requirements.json" }
-                      }
+                      },
+                      "required": ["asset_type"]
                     },
                     {
                       "title": "GroupCssAsset",
@@ -440,7 +449,8 @@
                       "properties": {
                         "asset_type": { "const": "css" },
                         "requirements": { "$ref": "/schemas/core/requirements/css-asset-requirements.json" }
-                      }
+                      },
+                      "required": ["asset_type"]
                     },
                     {
                       "title": "GroupJavaScriptAsset",
@@ -449,7 +459,8 @@
                       "properties": {
                         "asset_type": { "const": "javascript" },
                         "requirements": { "$ref": "/schemas/core/requirements/javascript-asset-requirements.json" }
-                      }
+                      },
+                      "required": ["asset_type"]
                     },
                     {
                       "title": "GroupVastAsset",
@@ -458,7 +469,8 @@
                       "properties": {
                         "asset_type": { "const": "vast" },
                         "requirements": { "$ref": "/schemas/core/requirements/vast-asset-requirements.json" }
-                      }
+                      },
+                      "required": ["asset_type"]
                     },
                     {
                       "title": "GroupDaastAsset",
@@ -467,7 +479,8 @@
                       "properties": {
                         "asset_type": { "const": "daast" },
                         "requirements": { "$ref": "/schemas/core/requirements/daast-asset-requirements.json" }
-                      }
+                      },
+                      "required": ["asset_type"]
                     },
                     {
                       "title": "GroupUrlAsset",
@@ -476,7 +489,8 @@
                       "properties": {
                         "asset_type": { "const": "url" },
                         "requirements": { "$ref": "/schemas/core/requirements/url-asset-requirements.json" }
-                      }
+                      },
+                      "required": ["asset_type"]
                     },
                     {
                       "title": "GroupWebhookAsset",
@@ -485,7 +499,8 @@
                       "properties": {
                         "asset_type": { "const": "webhook" },
                         "requirements": { "$ref": "/schemas/core/requirements/webhook-asset-requirements.json" }
-                      }
+                      },
+                      "required": ["asset_type"]
                     }
                   ]
                 }

--- a/static/schemas/source/core/pricing-option.json
+++ b/static/schemas/source/core/pricing-option.json
@@ -3,6 +3,9 @@
   "$id": "/schemas/core/pricing-option.json",
   "title": "Pricing Option",
   "description": "A pricing model option offered by a publisher for a product. Discriminated by pricing_model field. If fixed_price is present, it's fixed pricing. If absent, it's auction-based (floor_price and price_guidance optional). Bid-based auction models may also include max_bid as a boolean signal to interpret bid_price as a buyer ceiling instead of an exact honored price.",
+  "discriminator": {
+    "propertyName": "pricing_model"
+  },
   "oneOf": [
     {
       "$ref": "/schemas/pricing-options/cpm-option.json"


### PR DESCRIPTION
## Summary

Follow-up to #3928. Two of the items deferred there are actually safe with a tiny adjustment:

- **`core/pricing-option.json` `#/oneOf`** (`pricing_model`) — Ajv resolves the cross-file `$ref`s to `pricing-options/*-option.json` correctly when all schemas are pre-loaded via `addSchema()`. The original deferral was based on an isolated-compile test that didn't pre-load the targets. Verified with `tests/json-schema-validation.test.cjs` (Ajv `discriminator: true`, all 524 schemas registered).
- **`core/format.json` inner oneOf** at `#/properties/assets/items/oneOf/14/properties/assets/items` (`asset_type`) — Ajv's discriminator support does not follow `allOf` to find inherited `required`, so each of the 12 inner variants gains a direct `required: ["asset_type"]`. The const was already declared inline. Surgical text edit (no JSON.stringify reflow).

## Still deferred

- **Outer 15-variant oneOf at `#/properties/assets/items`** — mixes `item_type: "individual"` (14 variants with `asset_type`) and `item_type: "repeatable_group"` (no `asset_type`). No single discriminator key covers it without a two-tier restructure. Will file an issue.
- **Boolean discriminators** (`get-adcp-capabilities-response.json` `supported`, `update-content-standards-response.json` `success`) — Ajv requires unique-string values. Needs an enum migration; potentially breaking. Will file an issue.

## Walker behavior

After this change, the audit walker reports 37 ✓ / 37 ⚠ / 21 ✗ (was 36 / 38 / 22). The baseline is also ratcheted to drop the stale `error-details/agent-permission-denied.json##/oneOf` entry — that schema's oneOf was removed by #3906, so the baseline reference no longer matches.

## Test plan

- [x] `node scripts/audit-oneof.mjs` — 2 entries move ✗→✓ (format inner) and ✓-via-const → ✓-via-discriminator (pricing-option)
- [x] `npm run test:json-schema` (257/0)
- [x] `npm run test:schemas` (7/0)
- [x] `npm run test:composed` (26/0)
- [x] `npm run test:oneof-discriminators` — passes against ratcheted baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)