### PR TITLE
triage: silent on already-final-state comments

### DIFF
--- a/.agents/routines/triage-prompt.md
+++ b/.agents/routines/triage-prompt.md
@@ -917,10 +917,29 @@ body is in `<<<UNTRUSTED_ISSUE_BODY>>>`.
    the issue forward — Execute PR or Flag-for-review per
    standard outcome rules.
 5. If substantive but the issue is already in a final state
-   (PR drafted, deferred with linkage, flagged for human): post
-   a brief acknowledgment that the comment was read and either
-   (a) routes the new info to the open PR, (b) refreshes the
-   defer reasoning, or (c) confirms the human-flag still stands.
+   (PR drafted, deferred with linkage, flagged for human):
+   **silent by default.** A read-receipt is noise — the issue's
+   state already reflects the prior decision. Comment **only** when
+   the new info would materially change the disposition: it
+   invalidates the prior defer reason, surfaces a new blocker,
+   reopens a question the prior triage thought was settled, or
+   asks a direct question the human-flag can't answer alone. In
+   those cases, treat the comment as a re-trigger and re-run the
+   relevant experts (rule 3) — don't just acknowledge.
+
+   **Anti-patterns — never post these:**
+   - "Acknowledged — noted." / "Cross-repo trackers noted."
+   - "Standing by for CI green before merge."
+   - "Decision noted; this PR stands as documented."
+   - Any comment whose function is to announce that the routine
+     read the thread. Reading the thread is invisible work; if
+     there's nothing to add, leave the silence intact.
+
+   The author already sees from the issue state (open PR linked,
+   deferred label applied, ready-for-human comment posted) that
+   the routine engaged. A second comment confirming receipt
+   dilutes the threads where the routine actually has something
+   to say.
 6. Never reply to your own previous comments (workflow filters
    most cases, but the routine should also self-check via the
    `Triaged by Claude Code` footer). Never reply to bot authors.

--- a/.changeset/triage-silent-on-final-state.md
+++ b/.changeset/triage-silent-on-final-state.md
@@ -1,0 +1,9 @@
+---
+---
+
+triage routine: silent by default when a substantive comment lands on an
+already-final-state issue (PR drafted, deferred with linkage, flagged for
+human). Read-receipts ("acknowledged — noted", "standing by for CI green")
+add no signal and dilute the threads where triage has something to say.
+Engagement now requires the new info to actually change the disposition;
+in that case the routine re-runs experts rather than posting a bare ack.


### PR DESCRIPTION
## Summary

Cuts read-receipt noise from the triage routine. The Comment-engagement branch for already-final-state issues (PR drafted, deferred with linkage, flagged for human) was posting brief acknowledgments — "Acknowledged — cross-repo trackers noted. Standing by for CI green" (#3906), "Acknowledged — decision noted; this PR stands as documented" (#3934) — that announced the routine had read the thread without adding signal.

The routine now stays silent on those threads by default. Engagement requires the new info to actually change the disposition; in that case the comment is treated as a re-trigger and the relevant experts re-run (rule 3) instead of a bare acknowledgment.

Anti-pattern examples are spelled out so the routine has concrete cases of what *not* to write.

## What this kills vs. preserves

**Killed (no signal):**
- "Acknowledged — cross-repo trackers noted. Standing by for CI green before merge." (#3906)
- "Acknowledged — decision noted. #3935 carries the outer oneOf restructure; this PR stands as documented." (#3934)

**Preserved (real work):**
- Multi-expert classification + blocked-on chains (#3936, #3926, #3908)
- Substantive analysis comments like the 524-schema oneOf audit on #3917
- Re-runs that genuinely change the prior decision (rule 3 path, untouched)

## Test plan
- [ ] On next `comment.created` run on a final-state issue with a non-substantive ack-shaped comment: routine silent.
- [ ] On next `comment.created` run where the new comment invalidates a prior defer: routine re-runs experts and posts updated synthesis (rule 3 path).
- [ ] First-pass triage (`auto.opened`) unchanged — substantive classification comments continue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)