### PR TITLE
ci(storyboards): clean up two pre-existing lint failures

### DIFF
--- a/.changeset/lint-cleanups-list-accounts-brand-codes.md
+++ b/.changeset/lint-cleanups-list-accounts-brand-codes.md
@@ -1,0 +1,12 @@
+---
+---
+
+ci(storyboards): two pre-existing lint failures cleaned up
+
+Two unrelated lint failures that pre-dated #3918 work but blocked clean local runs:
+
+1. **`list_accounts` missing from storyboard-scoping classification.** `tests/lint-storyboard-scoping.test.cjs` enforces that every `HANDLER_MAP` task is classified in either `TENANT_SCOPED_TASKS` or `EXEMPT_FROM_LINT`. `list_accounts` was unclassified. It belongs in `EXEMPT_FROM_LINT` category (b) — global discovery for the caller. The request schema carries no scoping ID (it's the chicken-and-egg discovery call that produces the IDs other tasks consume), so requiring envelope-identity routing on it would be circular. Doc-comment expanded to explain the placement.
+
+2. **Non-canonical error codes in the brand-not-found storyboard, and a matching reference-implementation fix.** `static/compliance/source/protocols/brand/index.yaml`'s `get_brand_identity_unknown` step asserted `allowed_values: ["REFERENCE_NOT_FOUND", "brand_not_found", "BRAND_NOT_FOUND", "NOT_FOUND"]` — three legacy / non-spec values "tolerated for back-compat" per the storyboard's own description. `lint-error-codes.cjs` correctly flagged them as not-in-canonical-enum. The spec already commits to `REFERENCE_NOT_FOUND` as the canonical brand-not-found fallback (per `error-handling.mdx`), and the storyboard exists to gate against agent drift — tolerating non-canonical codes inside the gate is exactly the storyboard-author drift that #3918 closed. Switched the assertion to a single `value: "REFERENCE_NOT_FOUND"`.
+
+   The training-agent reference implementation was emitting `BRAND_NOT_FOUND` (with an in-code comment noting the conflict with `error-handling.mdx` and that "feedback was filed upstream to reconcile"). Updated `server/src/training-agent/brand-handlers.ts` to emit `REFERENCE_NOT_FOUND` with `field: "brand_id"`, matching the canonical fallback rule; updated the matching unit test in `tests/addie/brand-sandbox-tools.test.ts`; and tightened the brand-protocol error vocabulary in `skills/adcp-brand/SKILL.md` to point readers at `REFERENCE_NOT_FOUND` for brand / rights / pricing-option lookups (the rights/pricing handlers already emitted the canonical code; the SKILL was the only doc still naming the legacy three).

--- a/scripts/lint-storyboard-scoping.cjs
+++ b/scripts/lint-storyboard-scoping.cjs
@@ -80,8 +80,12 @@ const TENANT_SCOPED_TASKS = new Set([
  *     `sync_event_sources`.
  *
  * (b) Global discovery / catalog reads. `get_adcp_capabilities`,
- *     `list_creative_formats`, `get_brand_identity`, `get_rights`,
- *     `update_rights`, `comply_test_controller`.
+ *     `list_creative_formats`, `list_accounts`, `get_brand_identity`,
+ *     `get_rights`, `update_rights`, `comply_test_controller`. `list_accounts`
+ *     belongs here despite the per-tenant return shape — the request itself
+ *     carries no scoping ID (it's the chicken-and-egg discovery call that
+ *     produces the IDs other tasks consume), so envelope-identity routing
+ *     would be circular.
  *
  * (c) Identity implicit via one or more required globally-unique IDs in the
  *     request schema (either a single scalar or an `anyOf` across several ID
@@ -116,6 +120,7 @@ const EXEMPT_FROM_LINT = new Set([
   // (b) Global discovery
   'get_adcp_capabilities',
   'list_creative_formats',
+  'list_accounts',
   // (b) Global brand/rights catalog reads
   'get_brand_identity',
   'get_rights',

--- a/server/src/training-agent/brand-handlers.ts
+++ b/server/src/training-agent/brand-handlers.ts
@@ -670,13 +670,7 @@ export function handleGetBrandIdentity(
 
   const talent = BRAND_MAP.get(brandId);
   if (!talent) {
-    // BRAND_NOT_FOUND per the brand-protocol conformance suite
-    // (`@adcp/sdk/compliance/.../domains/brand/index.yaml` enumerates
-    // brand_not_found / BRAND_NOT_FOUND / NOT_FOUND as canonical) and
-    // skills/adcp-brand/SKILL.md. The universal error-handling.mdx puts
-    // brands in the REFERENCE_NOT_FOUND fallback list, which contradicts
-    // the brand-specific storyboard — feedback filed upstream to reconcile.
-    return { errors: [{ code: 'BRAND_NOT_FOUND', message: `No brand with id '${brandId}'` }] };
+    return { errors: [{ code: 'REFERENCE_NOT_FOUND', message: `No brand with id '${brandId}'`, field: 'brand_id' }] };
   }
 
   const requested = fields ?? [...ALL_FIELDS];

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -7320,7 +7320,7 @@ describe('get_brand_identity handler', () => {
       brand_id: 'does_not_exist',
     });
 
-    expect(result.code).toBe('BRAND_NOT_FOUND');
+    expect(result.code).toBe('REFERENCE_NOT_FOUND');
   });
 });
 

--- a/skills/adcp-brand/SKILL.md
+++ b/skills/adcp-brand/SKILL.md
@@ -194,9 +194,7 @@ Results: `acquired` (immediate), `pending_approval` (human review), or `rejected
 
 Common error codes:
 
-- `BRAND_NOT_FOUND`: Invalid brand_id
-- `RIGHTS_NOT_FOUND`: Invalid rights_id
-- `PRICING_OPTION_NOT_FOUND`: Invalid pricing_option_id
+- `REFERENCE_NOT_FOUND`: Invalid brand_id, rights_id, or pricing_option_id (brand-protocol resources use the universal not-found fallback per `error-handling.mdx`; brands lack a dedicated `*_NOT_FOUND` code)
 - `CATEGORY_CONFLICT`: Buyer brand conflicts with existing agreements
 - `GEOGRAPHIC_RESTRICTION`: Rights not available in requested countries
 - `AUTHORIZATION_REQUIRED`: Protected fields require OAuth

--- a/static/compliance/source/protocols/brand/index.yaml
+++ b/static/compliance/source/protocols/brand/index.yaml
@@ -156,9 +156,5 @@ phases:
         negative_path: payload_well_formed
         validations:
           - check: error_code
-            allowed_values:
-              - "REFERENCE_NOT_FOUND"
-              - "brand_not_found"
-              - "BRAND_NOT_FOUND"
-              - "NOT_FOUND"
-            description: "Error code indicates brand-not-found. REFERENCE_NOT_FOUND is the canonical fallback per error-handling.mdx (brands lack a dedicated *_NOT_FOUND code); the legacy lowercase / BRAND_NOT_FOUND / generic NOT_FOUND values are tolerated for back-compat."
+            value: "REFERENCE_NOT_FOUND"
+            description: "Error code indicates brand-not-found. REFERENCE_NOT_FOUND is the canonical fallback per error-handling.mdx (brands lack a dedicated *_NOT_FOUND code)."

--- a/tests/addie/brand-sandbox-tools.test.ts
+++ b/tests/addie/brand-sandbox-tools.test.ts
@@ -74,7 +74,7 @@ describe('brand protocol tools (training agent)', () => {
     it('returns error for unknown brand', async () => {
       const result = await call('get_brand_identity', { brand_id: 'nonexistent' });
       expect(result.errors).toBeDefined();
-      expect((result.errors as Array<{ code: string }>)[0].code).toBe('BRAND_NOT_FOUND');
+      expect((result.errors as Array<{ code: string }>)[0].code).toBe('REFERENCE_NOT_FOUND');
     });
 
     it('omits available_fields when talent lacks the requested authorized field', async () => {


### PR DESCRIPTION
## Summary

Two pre-existing lint failures unblocked, plus the matching reference-implementation fix.

### `list_accounts` missing from storyboard-scoping classification

`tests/lint-storyboard-scoping.test.cjs` enforces every `HANDLER_MAP` task is classified in either `TENANT_SCOPED_TASKS` or `EXEMPT_FROM_LINT`. `list_accounts` was unclassified.

It belongs in `EXEMPT_FROM_LINT` category (b) — global discovery for the caller. The request schema carries no scoping ID (it's the chicken-and-egg discovery call that produces the IDs other tasks consume), so requiring envelope-identity routing on it would be circular. Doc-comment expanded to explain the placement.

### Non-canonical error codes in the brand-not-found storyboard

`static/compliance/source/protocols/brand/index.yaml`'s `get_brand_identity_unknown` step asserted `allowed_values: ["REFERENCE_NOT_FOUND", "brand_not_found", "BRAND_NOT_FOUND", "NOT_FOUND"]` — three legacy / non-spec values "tolerated for back-compat" per the storyboard's own description. `lint-error-codes.cjs` correctly flagged them as not-in-canonical-enum.

The spec already commits to `REFERENCE_NOT_FOUND` as the canonical brand-not-found fallback (per `error-handling.mdx`), and the storyboard exists to gate against agent drift — tolerating non-canonical codes inside the gate is the storyboard-author drift that #3918 closed. Switched the assertion to a single `value: "REFERENCE_NOT_FOUND"`.

### Matching reference-implementation fix

The training-agent was emitting `BRAND_NOT_FOUND` (with an in-code comment noting the conflict with `error-handling.mdx` and that "feedback was filed upstream to reconcile" — this PR is that reconcile). Three pieces:

- `server/src/training-agent/brand-handlers.ts` — emit `REFERENCE_NOT_FOUND` with `field: "brand_id"`
- `tests/addie/brand-sandbox-tools.test.ts` — assertion updated to match
- `skills/adcp-brand/SKILL.md` — error-vocabulary section consolidated to `REFERENCE_NOT_FOUND` for brand / rights / pricing-option lookups (rights/pricing handlers already emitted the canonical code; the SKILL was the only doc still naming the legacy three)

Brand-tenant storyboard floors: `59 clean, 14 steps` floor → `64 clean, 14 steps` actual. Floor preserved across the change; locally validated via the `pre-push` hook's storyboard matrix.

## Test plan

- [x] `npm run test:storyboard-scoping` (3/3 pass; previously failed on the unclassified-task assertion)
- [x] `npm run test:error-codes` (clean; previously had 3 errors)
- [x] `npm run test:unit` (864 pass)
- [x] `npm run typecheck`
- [x] Local pre-push storyboard floor matrix (all 7 tenants meet floors after the training-agent fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)