### PR TITLE
ci(storyboards): adopt isPureExtensionPoint in context-output-paths lint

### DIFF
--- a/.changeset/context-output-paths-pure-extension-point.md
+++ b/.changeset/context-output-paths-pure-extension-point.md
@@ -1,0 +1,14 @@
+---
+---
+
+ci(storyboards): adopt isPureExtensionPoint in lint-storyboard-context-output-paths
+
+Phase 2b follow-up from #3918's expert review on PR #3942 (the `validations[].path` lint). That PR introduced the `isPureExtensionPoint` rule for `pathResolves`: when a node has `additionalProperties: true` AND no `properties` / `items` / composite variants, accept any further segments. This handles `core/context.json` and `error.details` legitimately as opaque extension points.
+
+This PR adopts the same rule in `lint-storyboard-context-output-paths.cjs` so the two lints share consistent path-resolution semantics, and lifts the now-redundant `accounts[0].errors[0].details.suggested_billing` allowlist entry — `error.details` is a pure extension point under the rule, so the path resolves naturally.
+
+Net result: lints have aligned semantics, allowlist shrinks from 2 entries to 1 (the remaining `idempotency_key` echo entry stays — its target schema's root is a `oneOf` with defined properties, so it's not a pure extension point under the rule).
+
+Two new test cases added to lock in the semantics: one asserts `error.details.*` resolves via the pure-extension-point rule, the other asserts mixed schemas (like `si-get-offering-response.json`) stay strict so the `offering_id` typo from #3937 would still be caught.
+
+Companion to #3942 — the resolver code is intentionally duplicated across the two lints rather than extracted to a shared module. Their semantic scopes differ (capture-from-path vs. assert-on-path) and the duplication is small (~60 lines of `pathResolves` / `isPureExtensionPoint` / `parsePath` / `loadSchema`); shared module is a future refactor when a third lint surfaces.

--- a/scripts/lint-storyboard-context-output-paths.cjs
+++ b/scripts/lint-storyboard-context-output-paths.cjs
@@ -93,12 +93,38 @@ function loadSchema(ref) {
 }
 
 /**
+ * A node is a "pure extension point" when it declares `additionalProperties:
+ * true` AND has no `properties` / `items` / composite variants. Examples:
+ * `core/context.json` (opaque correlation data, by spec design) and
+ * `error.details` (additionalProperties: true because the structured shape
+ * lives in per-error-code `error-details/<code>.json` schemas selected at
+ * runtime). Once we descend into one of these, any remaining path segments
+ * are accepted — the spec deliberately does not constrain what lives below.
+ *
+ * Mixed schemas (declared `properties` AND `additionalProperties: true`) are
+ * NOT pure extension points — those use `additionalProperties: true` for
+ * forward-compat extension, not as an open container, so paths through them
+ * MUST hit defined properties.
+ *
+ * Mirrors the rule in `lint-storyboard-validations-paths.cjs`.
+ */
+function isPureExtensionPoint(node) {
+  if (!node || typeof node !== 'object') return false;
+  if (node.additionalProperties !== true) return false;
+  if (node.properties && Object.keys(node.properties).length > 0) return false;
+  if (node.items) return false;
+  if (Array.isArray(node.oneOf) || Array.isArray(node.anyOf) || Array.isArray(node.allOf)) return false;
+  return true;
+}
+
+/**
  * Walk a JSON Schema node to determine whether a dotted path resolves to
  * any defined element. Follows `$ref`, descends through `properties.<name>`
  * for object steps and `items` for numeric-index steps, and accepts any
  * variant of `oneOf` / `anyOf` / `allOf` that resolves. Returns true when
- * EVERY segment was either resolved by a defined property/items or accepted
- * by at least one composite variant.
+ * EVERY segment was either resolved by a defined property/items, accepted
+ * by at least one composite variant, or descended into a pure extension
+ * point (e.g., `core/context.json`, `error.details`).
  *
  * Empty path resolves trivially (the root itself exists).
  */
@@ -136,6 +162,8 @@ function pathResolves(node, segments, seen = new Set()) {
       if (pathResolves(variant, segments, seen)) return true;
     }
   }
+
+  if (isPureExtensionPoint(node)) return true;
 
   return false;
 }

--- a/scripts/storyboard-context-output-paths-allowlist.json
+++ b/scripts/storyboard-context-output-paths-allowlist.json
@@ -2,16 +2,10 @@
   "$comment": "Per-storyboard exceptions for lint-storyboard-context-output-paths.cjs. Each entry MUST carry a `reason` explaining why the lint can't statically verify the path against the response schema. Re-review during spec changes — if the polymorphism the lint can't follow gets first-class schema treatment, remove the entry.",
   "allowlist": [
     {
-      "file": "static/compliance/source/universal/billing-gate-dispatch.yaml",
-      "step": "sync_accounts_passthrough_rejects_agent",
-      "path": "accounts[0].errors[0].details.suggested_billing",
-      "reason": "Captures from `error.details.suggested_billing`, which is defined in `error-details/billing-not-permitted-for-agent.json` (the per-error-code details schema selected by `error.code`). The lint can't follow error-details polymorphism keyed on the runtime error code — `core/error.json` declares `details` as `additionalProperties: true` because the structured shape lives in the error-details schemas. Capture is spec-conformant; lifting this requires extending the lint to switch on sibling `error.code` values."
-    },
-    {
       "file": "static/compliance/source/universal/idempotency.yaml",
       "step": "create_media_buy_initial",
       "path": "idempotency_key",
-      "reason": "Captures the seller's echo of the request `idempotency_key` for replay-comparison in the next step. Response schemas declare `additionalProperties: true` and don't list `idempotency_key` explicitly — the echo is a runtime convention the storyboard depends on, not a spec requirement. Idempotency-replay testing inherently asserts on the echo; removing the convention would require redesigning how the runner threads request-side values into downstream comparisons."
+      "reason": "Captures the seller's echo of the request `idempotency_key` for replay-comparison in the next step. Response schemas have `oneOf` arms (so the root is not a pure extension point) and the arms don't list `idempotency_key` explicitly — the echo is a runtime convention the storyboard depends on, not a spec requirement. Idempotency-replay testing inherently asserts on the echo; removing the convention would require redesigning how the runner threads request-side values into downstream comparisons, or speccing `idempotency_key` as an optional response field."
     }
   ]
 }

--- a/tests/lint-storyboard-context-output-paths.test.cjs
+++ b/tests/lint-storyboard-context-output-paths.test.cjs
@@ -118,6 +118,30 @@ test('pathResolves treats bracket and dotted notation as equivalent for array in
   assert.equal(pathResolves(schema, parsePath('errors.0.code')), true);
 });
 
+test('pure extension points (error.details, context.*) accept any further segments', () => {
+  // sync-accounts-response defines accounts[].errors[] which $refs core/error.json,
+  // whose `details` is `additionalProperties: true` with no defined properties —
+  // a pure extension point because per-error-code structured details live in
+  // sibling `error-details/<code>.json` schemas, not on `core/error.json` itself.
+  const schema = loadSchema('account/sync-accounts-response.json');
+  assert.equal(
+    pathResolves(schema, parsePath('accounts[0].errors[0].details.suggested_billing')),
+    true,
+    'error.details.* should resolve via the pure-extension-point rule',
+  );
+});
+
+test('mixed schemas (declared properties + additionalProperties: true) stay strict', () => {
+  // si-get-offering-response.json has properties (offering, available, etc.)
+  // AND additionalProperties: true at the root. The additionalProperties is
+  // forward-compat extension, NOT an open container — the offering_id typo
+  // from #3937 was caught precisely because the lint stays strict here.
+  const schema = loadSchema('sponsored-intelligence/si-get-offering-response.json');
+  assert.equal(pathResolves(schema, parsePath('offering.offering_id')), true);
+  assert.equal(pathResolves(schema, parsePath('offering_id')), false);
+  assert.equal(pathResolves(schema, parsePath('not_a_real_field')), false);
+});
+
 test('parsePath accepts both bracket and dotted forms', () => {
   assert.deepEqual(parsePath('rights[0].rights_id'), ['rights', '0', 'rights_id']);
   assert.deepEqual(parsePath('rights.0.rights_id'), ['rights', '0', 'rights_id']);


### PR DESCRIPTION
## Summary

Phase 2b follow-up from #3918's expert review on PR #3942. That PR introduced the \`isPureExtensionPoint\` rule on the \`validations[].path\` lint — when a node has \`additionalProperties: true\` AND no \`properties\` / \`items\` / composite variants, accept any further segments. Handles \`core/context.json\` and \`error.details\` legitimately as opaque extension points.

This PR adopts the same rule in \`lint-storyboard-context-output-paths.cjs\` so the two lints share consistent path-resolution semantics, and lifts the now-redundant \`accounts[0].errors[0].details.suggested_billing\` allowlist entry.

## Net result

- Lints have aligned semantics
- Allowlist shrinks from 2 entries to 1 (the remaining \`idempotency_key\` echo entry stays — its target schema's root is a \`oneOf\` with defined properties, so it's not a pure extension point under the rule)
- Two new test cases lock in the semantics: \`error.details.*\` resolves via the rule, mixed schemas like \`si-get-offering-response.json\` stay strict so the \`offering_id\` typo from #3937 would still be caught

## Why not extract to a shared module

The two lints have semantically different scopes (capture-from-path vs. assert-on-path), and the duplicated surface is small (~60 lines of \`pathResolves\` / \`isPureExtensionPoint\` / \`parsePath\` / \`loadSchema\`). Extracting now forces a premature decision on shared interface. Future refactor when a third lint surfaces.

## Test plan

- [x] \`npm run test:storyboard-context-output-paths\` (11 tests pass — 9 existing + 2 new for pure-extension-point and mixed-schema strictness)
- [x] Lint runs clean on the source tree
- [x] Allowlist reduced; remaining entry has updated reason explaining why it doesn't qualify under the new rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)