### PR TITLE
spec(envelope): add adcp_error + envelope-aware lint resolution

### DIFF
--- a/.changeset/envelope-adcp-error-and-aware-lint.md
+++ b/.changeset/envelope-adcp-error-and-aware-lint.md
@@ -1,0 +1,24 @@
+---
+"adcontextprotocol": minor
+---
+
+spec(envelope): add `adcp_error` to `protocol-envelope.json` + envelope-aware lint resolution
+
+The `protocol-envelope.json` schema already declared `replayed`, `status`, `task_id`, `context_id`, `governance_context`, etc. — and explicitly states (line 5): "Task response schemas should NOT include these fields - they are protocol-level concerns." Storyboards correctly assert on envelope-level fields (`path: "replayed"`, `path: "adcp_error"`), but the validations-path lint walked only the per-task `response_schema_ref` and never the envelope, so those assertions were stuck behind allowlist entries.
+
+Two changes here:
+
+1. **Schema:** add `adcp_error: $ref core/error.json` to `protocol-envelope.json`, mirroring the field's normative description in `error-handling.mdx#envelope-vs-payload-errors-the-two-layer-model`. The envelope already had `replayed` for the parallel transport-level idempotency-replay indicator; `adcp_error` is the corresponding transport-level error signal that fatal task failures populate alongside the payload's `errors[]`. The envelope schema previously omitted it — a documentation/schema drift this closes.
+
+2. **Lint:** `lint-storyboard-validations-paths.cjs` now falls back to `protocol-envelope.json` when a path's first segment isn't found in the response schema. Replaces the storyboard-by-storyboard allowlist for envelope-level paths with structural resolution. Both `replayed` (3 entries) and `adcp_error` (1 entry) now resolve cleanly; allowlist drops to zero.
+
+### What this PR is NOT doing
+
+The protocol-expert review pushed back on the original direction (adding `replayed` to `create-media-buy-response.json` for "consistency" with 8 mutating-task payload schemas that already define it). Those 8 schemas are themselves violating the envelope contract — they redundantly declare envelope fields at the payload level, contradicting `protocol-envelope.json:5`. Removing `replayed` from those 8 schemas is a separate spec cleanup PR (deprecation-window question for any SDK currently reading off the payload).
+
+### Test plan
+
+- [x] `npm run test:schemas` (clean — `adcp_error` field validates as a valid `$ref`)
+- [x] `npm run test:storyboard-validations-paths` (13 tests pass; 3 new cases lock in envelope-aware resolution and the "first segment must match an envelope property for fallback to fire" rule)
+- [x] `npm run test:examples`
+- [x] Lint runs clean across all 82 storyboard files with an empty allowlist

--- a/scripts/lint-storyboard-validations-paths.cjs
+++ b/scripts/lint-storyboard-validations-paths.cjs
@@ -101,6 +101,28 @@ function loadSchema(ref) {
 }
 
 /**
+ * `core/protocol-envelope.json` defines the fields wrapping every task
+ * response — `status`, `task_id`, `context_id`, `replayed`, `adcp_error`,
+ * `governance_context`, `push_notification_config`, etc. The envelope's
+ * top-level description explicitly states "Task response schemas should
+ * NOT include these fields - they are protocol-level concerns," so they
+ * never appear in the per-task response schemas this lint walks.
+ *
+ * Storyboards do assert on envelope fields (e.g., `path: "replayed"`,
+ * `path: "adcp_error"`), so the resolver falls back to the envelope when
+ * a top-level segment isn't found in the response schema. Only the FIRST
+ * segment is matched against the envelope — once we descend into an
+ * envelope property, further resolution proceeds normally.
+ */
+const ENVELOPE_REF = 'core/protocol-envelope.json';
+
+function isEnvelopeProperty(name) {
+  const envelope = loadSchema(ENVELOPE_REF);
+  if (!envelope || !envelope.properties) return false;
+  return Object.prototype.hasOwnProperty.call(envelope.properties, name);
+}
+
+/**
  * A node is a "pure extension point" when it declares `additionalProperties:
  * true` AND has no `properties` / `items` / composite variants. Examples:
  * `core/context.json` (opaque correlation data, by spec design) and
@@ -183,6 +205,20 @@ function* findStepsWithValidations(node, trail) {
   }
 }
 
+function pathResolvesAgainstResponseOrEnvelope(schema, segments) {
+  if (pathResolves(schema, segments)) return true;
+  // Fall back to the protocol envelope. Storyboards address envelope-level
+  // fields with bare top-level names (e.g., `replayed`, `adcp_error`,
+  // `status`), so we only consult the envelope when the FIRST segment
+  // matches an envelope property; subsequent segments resolve through
+  // the envelope's own definition of that field.
+  if (segments.length > 0 && isEnvelopeProperty(segments[0])) {
+    const envelope = loadSchema(ENVELOPE_REF);
+    if (envelope && pathResolves(envelope, segments)) return true;
+  }
+  return false;
+}
+
 function lintDoc(doc, filePath, allowlist = []) {
   const violations = [];
   if (!doc) return violations;
@@ -204,7 +240,7 @@ function lintDoc(doc, filePath, allowlist = []) {
       const rawPath = v.path;
       if (typeof rawPath !== 'string' || rawPath.length === 0) continue;
       const segments = parsePath(rawPath);
-      if (pathResolves(schema, segments)) continue;
+      if (pathResolvesAgainstResponseOrEnvelope(schema, segments)) continue;
       if (isAllowlisted(allowlist, filePath, step.stepId, rawPath)) continue;
       violations.push({
         rule: 'path_not_in_schema',
@@ -280,11 +316,14 @@ if (require.main === module) main();
 module.exports = {
   RULE_MESSAGES,
   PATH_BEARING_CHECKS,
+  ENVELOPE_REF,
   lint,
   lintDoc,
   loadSchema,
   loadAllowlist,
+  isEnvelopeProperty,
   pathResolves,
+  pathResolvesAgainstResponseOrEnvelope,
   parsePath,
   formatMessage,
 };

--- a/scripts/storyboard-validations-paths-allowlist.json
+++ b/scripts/storyboard-validations-paths-allowlist.json
@@ -1,29 +1,4 @@
 {
-  "$comment": "Per-storyboard exceptions for lint-storyboard-validations-paths.cjs. Each entry MUST carry a `reason` explaining why the lint can't statically verify the path against the response schema. Re-review during spec changes — if the runtime convention or envelope feature gets first-class schema treatment, remove the entry.",
-  "allowlist": [
-    {
-      "file": "static/compliance/source/universal/idempotency.yaml",
-      "step": "create_media_buy_initial",
-      "path": "replayed",
-      "reason": "`replayed` is the seller's idempotency-replay indicator (true on a replay, absent or false on a fresh request). The response schema declares `additionalProperties: true` and does not define `replayed` explicitly — it's a runtime convention idempotency-replay testing depends on. Lifting requires either (a) adding `replayed` to the spec response schema, or (b) the runner exposing a typed replay-detection check that doesn't go through path validation. Tracked separately."
-    },
-    {
-      "file": "static/compliance/source/universal/idempotency.yaml",
-      "step": "create_media_buy_replay",
-      "path": "replayed",
-      "reason": "Same as create_media_buy_initial — `replayed` is the seller's idempotency-replay indicator, runtime convention not in the spec schema."
-    },
-    {
-      "file": "static/compliance/source/universal/idempotency.yaml",
-      "step": "create_media_buy_fresh_key",
-      "path": "replayed",
-      "reason": "Same as create_media_buy_initial — `replayed` is the seller's idempotency-replay indicator, runtime convention not in the spec schema."
-    },
-    {
-      "file": "static/compliance/source/universal/schema-validation.yaml",
-      "step": "reversed_dates",
-      "path": "adcp_error",
-      "reason": "`adcp_error` is the envelope-level error field (transport layer per error-handling.mdx#envelope-vs-payload-errors-the-two-layer-model), not a payload-level field on the response schema. The runner extracts `adcp_error` from the transport envelope (MCP `structuredContent.adcp_error`, A2A artifact DataPart) — payload-schema validation can't reach it. Lifting requires the lint to recognize a small set of envelope-level path prefixes (`adcp_error.*`) and validate them against `core/error.json` directly."
-    }
-  ]
+  "$comment": "Per-storyboard exceptions for lint-storyboard-validations-paths.cjs. Each entry MUST carry a `reason` explaining why the lint can't statically verify the path against the response schema or envelope. Re-review during spec changes.",
+  "allowlist": []
 }

--- a/static/schemas/source/core/protocol-envelope.json
+++ b/static/schemas/source/core/protocol-envelope.json
@@ -32,6 +32,10 @@
       "description": "Set to true when this response is a cached replay returned for an idempotency_key that was already processed. Set to false (or omitted) when the request was executed fresh. Buyers use this to distinguish cached replays from new executions — matters for billing reconciliation, audit logs, and any downstream system that assumes exactly-once event semantics. Only present on responses to mutating requests that carry idempotency_key.",
       "default": false
     },
+    "adcp_error": {
+      "$ref": "/schemas/core/error.json",
+      "description": "Transport-envelope error signal for fatal task failures. Per the two-layer model in `error-handling.mdx#envelope-vs-payload-errors-the-two-layer-model`, a fatal task failure SHOULD populate both this envelope-level field AND the payload's `errors[]` array — the envelope carries a typed, extractable error so MCP/A2A clients can dispatch without re-parsing the payload, while the payload's structured `errors[]` remains the canonical normative shape. Non-fatal warnings populate ONLY `payload.errors[]` with `severity: warning` — the envelope MUST NOT carry `adcp_error` for non-failures."
+    },
     "push_notification_config": {
       "$ref": "/schemas/core/push-notification-config.json",
       "description": "Push notification configuration for async task updates (A2A and REST protocols). Echoed from the request to confirm webhook settings. Specifies URL, authentication scheme (Bearer or HMAC-SHA256), and credentials. MCP uses progress notifications instead of webhooks."

--- a/tests/lint-storyboard-validations-paths.test.cjs
+++ b/tests/lint-storyboard-validations-paths.test.cjs
@@ -24,9 +24,11 @@ const {
   lint,
   lintDoc,
   pathResolves,
+  pathResolvesAgainstResponseOrEnvelope,
   parsePath,
   loadSchema,
   loadAllowlist,
+  isEnvelopeProperty,
   PATH_BEARING_CHECKS,
 } = require('../scripts/lint-storyboard-validations-paths.cjs');
 
@@ -169,6 +171,51 @@ test('pathResolves descends through error.json $ref for errors[0].code', () => {
   const schema = loadSchema('media-buy/create-media-buy-response.json');
   assert.equal(pathResolves(schema, parsePath('errors[0].code')), true);
   assert.equal(pathResolves(schema, parsePath('errors[0].field')), true);
+});
+
+test('envelope-aware resolution: replayed and adcp_error resolve via protocol-envelope.json', () => {
+  // Both fields are defined on core/protocol-envelope.json (replayed line 30,
+  // adcp_error added in this PR). The envelope's top-level description states
+  // "Task response schemas should NOT include these fields - they are
+  // protocol-level concerns," so they don't appear on per-task response
+  // schemas. The lint falls back to the envelope when a top-level segment
+  // isn't found in the payload schema.
+  const schema = loadSchema('media-buy/create-media-buy-response.json');
+  assert.equal(
+    pathResolvesAgainstResponseOrEnvelope(schema, parsePath('replayed')),
+    true,
+    'replayed should resolve via envelope fallback',
+  );
+  assert.equal(
+    pathResolvesAgainstResponseOrEnvelope(schema, parsePath('adcp_error.code')),
+    true,
+    'adcp_error.code should resolve via envelope fallback into core/error.json',
+  );
+  assert.equal(
+    pathResolvesAgainstResponseOrEnvelope(schema, parsePath('status')),
+    true,
+    'status should resolve via envelope fallback',
+  );
+});
+
+test('isEnvelopeProperty identifies envelope fields', () => {
+  assert.equal(isEnvelopeProperty('replayed'), true);
+  assert.equal(isEnvelopeProperty('adcp_error'), true);
+  assert.equal(isEnvelopeProperty('status'), true);
+  assert.equal(isEnvelopeProperty('task_id'), true);
+  assert.equal(isEnvelopeProperty('context_id'), true);
+  assert.equal(isEnvelopeProperty('made_up_field'), false);
+});
+
+test('envelope fallback only fires when first segment is an envelope property', () => {
+  // A typo on a non-envelope-shaped path should still fail — the envelope
+  // fallback is keyed on the first segment matching an envelope property.
+  const schema = loadSchema('media-buy/create-media-buy-response.json');
+  assert.equal(
+    pathResolvesAgainstResponseOrEnvelope(schema, parsePath('definitely_not_real')),
+    false,
+    'non-envelope typos should still fail',
+  );
 });
 
 test('PATH_BEARING_CHECKS is the documented set', () => {


### PR DESCRIPTION
## Summary

Phase 2c follow-up from #3918 — but with a redirect after protocol-expert review caught a contract violation in the original direction.

\`protocol-envelope.json\` already declared \`replayed\`, \`status\`, \`task_id\`, \`context_id\`, and \`governance_context\` — and at line 5 explicitly states "Task response schemas should NOT include these fields - they are protocol-level concerns." Storyboards correctly assert on envelope-level fields (\`path: "replayed"\`, \`path: "adcp_error"\`), but the validations-path lint walked only the per-task \`response_schema_ref\`, so those assertions were stuck behind allowlist entries.

Two changes here:

1. **Schema:** add \`adcp_error: $ref core/error.json\` to \`protocol-envelope.json\`, mirroring the field's normative description in \`error-handling.mdx#envelope-vs-payload-errors-the-two-layer-model\`. The envelope already had \`replayed\` for the parallel transport-level idempotency-replay indicator; \`adcp_error\` is the corresponding transport-level error signal that fatal task failures populate alongside the payload's \`errors[]\`. The envelope schema previously omitted it — a doc/schema drift this closes.
2. **Lint:** \`lint-storyboard-validations-paths.cjs\` now falls back to \`protocol-envelope.json\` when a path's first segment isn't found in the response schema. Replaces the storyboard-by-storyboard allowlist for envelope-level paths with structural resolution. Both \`replayed\` (3 entries) and \`adcp_error\` (1 entry) now resolve; allowlist drops to zero.

## What this PR is NOT doing

The original direction was adding \`replayed\` to \`create-media-buy-response.json\` for "consistency" with 8 mutating-task payload schemas that already define it. The protocol expert correctly flagged that those 8 schemas are themselves violating the envelope contract — they redundantly declare envelope-level fields at the payload level. Removing them is a separate cleanup PR (deprecation-window question for any SDK currently reading off the payload).

## Expert review summary

Reviewed by ad-tech-protocol-expert (twice). First review caught the contract violation. Second review on the redirected scope cleared with no must-fixes:

- \`adcp_error: $ref core/error.json\` is sound. \`error.json\` has no \`severity\` field (the fatal-vs-warning distinction lives in prose, not schema), so it's directly usable at envelope level — no field-stripping needed. All other fields (\`code\`, \`message\`, \`recovery\`, \`retry_after\`, \`field\`, \`issues[]\`, \`details\`, \`suggestion\`) make sense at envelope level.
- Envelope-fallback granularity is right: keyed on first-segment match against \`Object.keys(envelope.properties)\`, so a typo still fails. \`adcp_error.code\` correctly descends into \`error.json\`'s \`code\` field; \`made_up_field\` returns false.

## Test plan

- [x] \`npm run test:storyboard-validations-paths\` (13 tests pass; 3 new for envelope fallback / \`isEnvelopeProperty\` / first-segment-only granularity)
- [x] \`npm run test:schemas\` (envelope schema validates with the \`$ref\` addition)
- [x] \`npm run test:examples\`
- [x] Lint runs clean across 82 storyboard files with empty allowlist
- [x] Local pre-push storyboard floor matrix passing

## Follow-ups identified

1. **Mirror envelope-aware resolution into \`lint-storyboard-context-output-paths.cjs\`** for parity. Hoist the resolver into a shared helper so a third lint doesn't re-implement it.
2. **Remove \`replayed\` from the 8 payload schemas that wrongly duplicate it** (property lists, collection lists, \`sync_plans\`, \`report_plan_outcome\`). Needs deprecation-window analysis for any SDK currently reading off the payload.
3. **Cross-task \`replayed\` consistency on the 10 mutating responses that don't have it** is moot under the envelope-only model — the field already applies uniformly via the envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)