### PR TITLE
fix(addie): rate-limit POST /api/addie/video/session/:conversationName/end

### DIFF
--- a/.changeset/fix-tavus-end-rate-limiter.md
+++ b/.changeset/fix-tavus-end-rate-limiter.md
@@ -1,0 +1,8 @@
+---
+---
+
+fix(addie): add per-user rate limiter to POST /api/addie/video/session/:conversationName/end
+
+The end-session endpoint was missing the `endRateLimiter` that guards the adjacent
+session-creation endpoint. Adds a 10 req/min per-user cap (IP fallback) using the same
+`CachedPostgresStore` pattern as `sessionRateLimiter`. Closes #3946.

--- a/server/src/routes/tavus.ts
+++ b/server/src/routes/tavus.ts
@@ -326,6 +326,18 @@ const sessionRateLimiter = rateLimit({
   legacyHeaders: false,
 });
 
+// End-session cap — generous relative to session creation (sessionRateLimiter: 5/min)
+// but bounded so a single user cannot hammer the Tavus API key.
+const endRateLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 10,
+  store: new CachedPostgresStore("tavus-end:"),
+  keyGenerator: (req) => (req as Request & { user?: { id: string } }).user?.id || ipKeyGenerator(req.ip || ""),
+  message: { error: "Too many requests" },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 export function createTavusRouter() {
   // Page router: serves GET /video and GET /video/lab.
   // Both routes go through serveHtmlWithConfig so the global app config and
@@ -353,7 +365,7 @@ export function createTavusRouter() {
   // End an active Tavus conversation. Releases the concurrent-conversation
   // slot immediately so a new session can be created. Auth: must be the
   // user who created the thread (or an AAO admin).
-  apiRouter.post("/session/:conversationName/end", optionalAuth, async (req, res) => {
+  apiRouter.post("/session/:conversationName/end", optionalAuth, endRateLimiter, async (req, res) => {
     if (!req.user) {
       return res.status(401).json({ error: "Authentication required" });
     }


### PR DESCRIPTION
Closes #3946

The `POST /api/addie/video/session/:conversationName/end` endpoint was missing a per-user rate limiter despite hitting the Tavus API on every request. The adjacent session-create endpoint (`POST /session`) already has `sessionRateLimiter` (5 req/min/user). This PR adds `endRateLimiter` (10 req/min/user, IP fallback) using the same `express-rate-limit` + `CachedPostgresStore` pattern, capping worst-case Tavus API hammering per user while leaving ample headroom for testing loops.

**Non-breaking justification:** adds middleware to an existing route with no change to request/response shape; returns 429 only when a single user exceeds 10 end-calls per minute, which no legitimate flow reaches.

**Pre-PR review:**
- code-reviewer: approved — no blockers. Two pre-existing nits noted: (1) unauthenticated callers consume IP-keyed bucket before the 401 fires (matches `sessionRateLimiter` pattern, class-wide); (2) 429 body shape inconsistency between `llmRateLimiter` and session/end limiters (pre-existing).
- internal-tools-strategist: approved — `max: 10` correct relative to `sessionRateLimiter` 5/min cap; `"tavus-end:"` store prefix correctly isolated. One nit: IPv6 /64 masking gap on IP fallback path (pre-existing, end-session endpoint requires auth anyway so IP fallback is rarely exercised).

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01WVJSff2drkMFVZgkrrEcm3

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVJSff2drkMFVZgkrrEcm3)_