### PR TITLE
docs(compliance): document task_completion.<inner> prefix for context_outputs.path

### DIFF
--- a/.changeset/docs-task-completion-prefix-context-outputs.md
+++ b/.changeset/docs-task-completion-prefix-context-outputs.md
@@ -1,0 +1,10 @@
+---
+---
+
+docs(compliance): document task_completion.<inner> prefix for context_outputs.path
+
+Adds a missing bullet to the storyboard-schema.yaml context_outputs runner-behavior
+block explaining the task_completion.<inner> path prefix introduced in adcp-client v6.7
+(adcp-client#1426). Documents the polling behavior, the result payload field, and
+grading on non-success terminal statuses (failed/canceled/rejected →
+capture_path_not_resolvable). No wire format changes; YAML comments only.

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -416,6 +416,16 @@
 #     grade as skipped with reason: prerequisite_failed citing this step.
 #     See runner-output-contract.yaml > validation_result for the output shape.
 #   - The accumulator is storyboard-run-scoped; values do not leak across runs.
+#   - Special path prefix `task_completion.<inner>`: when the immediate
+#     response is a non-terminal task envelope (status submitted/working,
+#     with a task_id), the runner polls `tasks/get` until the task exits
+#     {submitted, working}. On `completed`: resolves <inner> against the
+#     `result` payload; a missing path grades this step as
+#     capture_path_not_resolvable. On any other status (failed, canceled,
+#     rejected, auth-required, input-required, unknown): `result` is absent;
+#     the capture grades as capture_path_not_resolvable on this step;
+#     downstream $context.<name> references grade as prerequisite_failed
+#     citing this step. See adcp-client#1426 for the implementation.
 #
 # context_inputs: array of ContextInput objects (optional — inject captured
 #   context values into the request at a specific path AFTER the per-task


### PR DESCRIPTION
Closes #3950

Adds a missing runner-behavior bullet to `static/compliance/source/universal/storyboard-schema.yaml` documenting the `task_completion.<inner>` path prefix introduced in adcp-client v6.7 (adcp-client#1426). Without this, storyboard authors writing `task_completion.media_buy_id` against an older runner get a silent `capture_path_not_resolvable` rather than the intended async-completion capture, with no schema-level explanation of why.

**Non-breaking justification:** YAML comments only — no schema structure, no wire format, no enum, no field added or removed. Existing storyboards using plain JSON paths are unaffected. Changeset is `--empty`.

**Pre-PR review:**
- code-reviewer: approved — correct insertion point, indentation matches surrounding bullets, no JSON Schema updates needed (context_outputs is spec'd in storyboard-schema.yaml only). Nit: poll-timeout semantics not documented (out of scope for this PR; tracked in adcp-client#1432).
- ad-tech-protocol-expert: approved — `result` field reference correct per tasks-get-response.json; `input-required` correctly excluded from polling triggers (it is paused-for-user-input, not transparently pollable); all non-`completed` terminal statuses covered via enumeration (failed, canceled, rejected, auth-required, input-required, unknown). Nit: `include_result` flag precision on the `result`-present claim (minor; the comment addresses the storyboard-author audience, not implementors of the polling loop).

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01FM9345KAdknRskpf1cMCFn

---
_Generated by [Claude Code](https://claude.ai/code/session_01FM9345KAdknRskpf1cMCFn)_