### PR TITLE
docs(storyboard-schema): document task_completion. prefix for context_outputs

### DIFF
--- a/.changeset/storyboard-schema-task-completion-prefix.md
+++ b/.changeset/storyboard-schema-task-completion-prefix.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs(storyboard-schema): document the `task_completion.<inner>` prefix for `context_outputs[].path`. When the immediate response is a non-terminal task envelope (`submitted`/`working`/`input-required`), the runner polls `tasks/get` until terminal and resolves the suffix against the completion artifact's `data` — needed for captures like seller-assigned `media_buy_id` on IO-signing flows. Requires runner >= adcp-client v6.7. Closes #3950.

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -403,6 +403,21 @@
 #             storyboard run)
 #       path: string (JSON path against this step's response body, e.g.
 #             "media_buy_id", "accounts[0].account_id", "plans[0].plan_id")
+#
+#   Special path prefix `task_completion.<inner>`: when the immediate response
+#   is a non-terminal task envelope (status `submitted` / `working` /
+#   `input-required`, carrying a `task_id`), the runner polls `tasks/get`
+#   until the task reaches a terminal state and resolves `<inner>` against
+#   the completion artifact's `data` instead of the immediate response. Use
+#   for captures whose value only exists on the completion artifact — e.g.
+#   the seller-assigned `media_buy_id` on an IO-signing / async-signed HITL
+#   flow where `create_media_buy` returns `submitted` and the ID lands on
+#   the completion artifact. Without the prefix, the literal key
+#   `task_completion` is looked up on the immediate response, which fails
+#   as `capture_path_not_resolvable`. Requires runner >= adcp-client v6.7;
+#   older runners treat the prefix as a literal key. See adcp-client#1417
+#   (rationale) and adcp-client#1426 (implementation).
+#
 #   Runner behavior:
 #   - Captures occur AFTER the step's validations pass. A failed step MUST NOT
 #     populate the context accumulator — downstream $context.<name> references


### PR DESCRIPTION
## Summary
- Documents the `task_completion.<inner>` prefix for `context_outputs[].path` in the storyboard schema reference.
- When the immediate response is a non-terminal task envelope (`submitted` / `working` / `input-required`), the runner polls `tasks/get` until terminal and resolves the suffix against the completion artifact's `data` instead of the immediate response — needed for captures whose value only exists on the artifact (e.g. seller-assigned `media_buy_id` on IO-signing / async-signed HITL flows).
- Calls out the `>= adcp-client v6.7` runner requirement and the silent-miscapture failure mode on older runners.

## Scope

Comment-only update to `static/compliance/source/universal/storyboard-schema.yaml`. Runner implementation already shipped in [adcp-client#1426](https://github.com/adcontextprotocol/adcp-client/pull/1426); this PR just declares the syntax in the source-of-truth schema doc that downstream caches sync from.

## Follow-up (not in this PR)

`scripts/lint-storyboard-context-output-paths.cjs` resolves `path` against the response schema, so the first storyboard to actually use `task_completion.media_buy_id` will hit `path_not_in_schema`. No storyboard uses the prefix yet, so it's not blocking anything today; teaching the lint to strip the prefix and resolve the suffix against the completion artifact's response branch is a separate change.

Closes #3950.

## Test plan
- [ ] CI: schema sync + storyboard lints stay green (no behavioral change).