### PR TITLE
fix(brand-claim): recreate org-domain when existing entry has null verification token

### DIFF
--- a/.changeset/fix-brand-claim-recreate-null-token.md
+++ b/.changeset/fix-brand-claim-recreate-null-token.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix `request_brand_domain_challenge` returning silent `workos_error` when the WorkOS org already had a non-verified domain entry with null `verificationToken`/`verificationPrefix`. The pre-check now deletes the broken entry and falls through to a fresh create, so the user receives a usable DNS TXT record instead of looping on the same error. Closes #3953.

--- a/server/src/services/brand-claim.ts
+++ b/server/src/services/brand-claim.ts
@@ -130,21 +130,41 @@ export async function issueDomainChallenge(input: {
   // Idempotent re-issue: if the domain is already attached to this org
   // (pending or verified), surface the existing challenge instead of
   // creating a new one. WorkOS would reject the duplicate create anyway.
+  // Exception: a non-verified entry with null verificationToken/Prefix is
+  // broken state — there's no DNS record the user can publish, and every
+  // retry would echo nulls back. Delete and recreate so the user gets a
+  // fresh, usable challenge.
   try {
     const existing = await workos.organizations.getOrganization(orgId);
     const existingDomain = existing.domains.find(d => d.domain.toLowerCase() === domain);
     if (existingDomain) {
-      return {
-        ok: true,
-        domain,
-        workos_domain_id: existingDomain.id,
-        state: String(existingDomain.state),
-        verification_strategy: existingDomain.verificationStrategy ?? null,
-        verification_token: existingDomain.verificationToken ?? null,
-        verification_prefix: existingDomain.verificationPrefix ?? null,
-        already_verified: isVerifiedState(existingDomain.state),
-        prior_manifest_exists: priorManifestExists,
-      };
+      const verified = isVerifiedState(existingDomain.state);
+      const tokenMissing = !existingDomain.verificationToken || !existingDomain.verificationPrefix;
+      if (!verified && tokenMissing) {
+        logger.warn(
+          { orgId, domain, existingDomainId: existingDomain.id, state: String(existingDomain.state) },
+          'brand-claim: existing org-domain has null verification token/prefix; deleting to recreate',
+        );
+        try {
+          await workos.organizationDomains.deleteOrganizationDomain(existingDomain.id);
+        } catch (err) {
+          logger.error({ err, orgId, domain, existingDomainId: existingDomain.id }, 'brand-claim: failed to delete broken existing org-domain');
+          return { ok: false, code: 'workos_error', message: 'Failed to clear a broken pending challenge for this domain. Try again or contact support.' };
+        }
+        // Fall through to the create branch below.
+      } else {
+        return {
+          ok: true,
+          domain,
+          workos_domain_id: existingDomain.id,
+          state: String(existingDomain.state),
+          verification_strategy: existingDomain.verificationStrategy ?? null,
+          verification_token: existingDomain.verificationToken ?? null,
+          verification_prefix: existingDomain.verificationPrefix ?? null,
+          already_verified: verified,
+          prior_manifest_exists: priorManifestExists,
+        };
+      }
     }
   } catch (err) {
     logger.warn({ err, orgId }, 'brand-claim: org pre-check failed, will attempt create');

--- a/server/tests/unit/brand-claim-service.test.ts
+++ b/server/tests/unit/brand-claim-service.test.ts
@@ -18,6 +18,7 @@ type WorkOSStub = {
   organizationDomains: {
     createOrganizationDomain: ReturnType<typeof vi.fn>;
     verifyOrganizationDomain: ReturnType<typeof vi.fn>;
+    deleteOrganizationDomain: ReturnType<typeof vi.fn>;
   };
 };
 
@@ -25,6 +26,7 @@ function makeWorkos(overrides: Partial<{
   getOrganization: any;
   createOrganizationDomain: any;
   verifyOrganizationDomain: any;
+  deleteOrganizationDomain: any;
 }> = {}): WorkOSStub {
   return {
     organizations: {
@@ -33,6 +35,7 @@ function makeWorkos(overrides: Partial<{
     organizationDomains: {
       createOrganizationDomain: overrides.createOrganizationDomain ?? vi.fn(),
       verifyOrganizationDomain: overrides.verifyOrganizationDomain ?? vi.fn(),
+      deleteOrganizationDomain: overrides.deleteOrganizationDomain ?? vi.fn().mockResolvedValue(undefined),
     },
   };
 }
@@ -112,6 +115,97 @@ describe('issueDomainChallenge', () => {
       expect(result.already_verified).toBe(false);
     }
     expect(workos.organizationDomains.createOrganizationDomain).not.toHaveBeenCalled();
+  });
+
+  it('deletes and recreates when existing pending domain has null verification token (#3953)', async () => {
+    const deleteFn = vi.fn().mockResolvedValue(undefined);
+    const createFn = vi.fn().mockResolvedValue({
+      id: 'dom_fresh',
+      state: 'pending',
+      verificationStrategy: 'dns',
+      verificationToken: 'tok_fresh',
+      verificationPrefix: '_workos-challenge',
+    });
+    const workos = makeWorkos({
+      getOrganization: vi.fn().mockResolvedValue({
+        domains: [{
+          id: 'dom_broken',
+          domain: DOMAIN,
+          state: 'pending',
+          verificationStrategy: 'dns',
+          verificationToken: null,
+          verificationPrefix: null,
+        }],
+      }),
+      deleteOrganizationDomain: deleteFn,
+      createOrganizationDomain: createFn,
+    });
+    const result = await issueDomainChallenge({
+      workos: workos as any,
+      brandDb: makeBrandDb(),
+      orgId: ORG,
+      rawDomain: DOMAIN,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.workos_domain_id).toBe('dom_fresh');
+      expect(result.verification_token).toBe('tok_fresh');
+      expect(result.verification_prefix).toBe('_workos-challenge');
+    }
+    expect(deleteFn).toHaveBeenCalledWith('dom_broken');
+    expect(createFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns workos_error when deleting a broken existing domain fails (#3953)', async () => {
+    const deleteFn = vi.fn().mockRejectedValue(new Error('delete failed'));
+    const createFn = vi.fn();
+    const workos = makeWorkos({
+      getOrganization: vi.fn().mockResolvedValue({
+        domains: [{
+          id: 'dom_broken',
+          domain: DOMAIN,
+          state: 'pending',
+          verificationToken: null,
+          verificationPrefix: null,
+        }],
+      }),
+      deleteOrganizationDomain: deleteFn,
+      createOrganizationDomain: createFn,
+    });
+    const result = await issueDomainChallenge({
+      workos: workos as any,
+      brandDb: makeBrandDb(),
+      orgId: ORG,
+      rawDomain: DOMAIN,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('workos_error');
+    expect(createFn).not.toHaveBeenCalled();
+  });
+
+  it('preserves verified short-circuit even when token is null (treats as already-verified, no delete)', async () => {
+    const deleteFn = vi.fn();
+    const workos = makeWorkos({
+      getOrganization: vi.fn().mockResolvedValue({
+        domains: [{
+          id: 'dom_v',
+          domain: DOMAIN,
+          state: 'verified',
+          verificationToken: null,
+          verificationPrefix: null,
+        }],
+      }),
+      deleteOrganizationDomain: deleteFn,
+    });
+    const result = await issueDomainChallenge({
+      workos: workos as any,
+      brandDb: makeBrandDb(),
+      orgId: ORG,
+      rawDomain: DOMAIN,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.already_verified).toBe(true);
+    expect(deleteFn).not.toHaveBeenCalled();
   });
 
   it('flags already_verified when existing domain state is verified', async () => {


### PR DESCRIPTION
## Summary

Fixes #3953.

When `request_brand_domain_challenge` (Addie tool) or `POST /api/me/member-profile/brand-claim/issue` was called for a domain already attached to the caller's WorkOS org but with null `verificationToken`/`verificationPrefix`, the idempotent pre-check echoed the stale row verbatim. The caller rendered `workos_error: WorkOS didn't return a DNS record` and every retry hit the same deterministic path with no recovery — no error was logged anywhere because the create branch never ran.

Confirmed in production via PostHog log search: zero `brand-claim` errors during Alex Sekowski's vastlint.org claim attempts despite repeated `workos_error` responses to the user. Required a manual WorkOS dashboard delete to unstick.

## Change

`server/src/services/brand-claim.ts` — when the pre-check finds a non-verified entry with a missing token or prefix, delete it via `workos.organizationDomains.deleteOrganizationDomain(id)` and fall through to the create branch. Verified entries short-circuit unchanged.

A `warn` log is emitted on detection so we can monitor frequency, and an `error` log is emitted if the delete itself fails (returning `workos_error` to the caller in that case).

## Test plan

- [x] Unit test: existing-domain branch with null `verificationToken` → SDK delete called, then create called, fresh token returned (`#3953` test added)
- [x] Unit test: existing-domain branch in verified state with null token → unchanged short-circuit, no delete/create
- [x] Unit test: SDK delete fails → returns `workos_error`, no create attempted
- [x] All existing `brand-claim-service.test.ts` cases still pass (19/19)

🤖 Generated with [Claude Code](https://claude.com/claude-code)