### PR TITLE
chore(http): drop boot-time WorkOS listOrganizations sync

### DIFF
--- a/.changeset/drop-boot-workos-org-sync.md
+++ b/.changeset/drop-boot-workos-org-sync.md
@@ -1,0 +1,4 @@
+---
+---
+
+Drop boot-time `OrganizationDatabase.syncFromWorkOS` call. The production WorkOS API key doesn't carry the workspace-level scope `listOrganizations` requires, so this call failed on every cold start with `UnauthorizedException: Could not authorize the request`, polluting the error stream. Orgs are created lazily via `ensureOrganizationExists` at first login and via the `organization.created` webhook, so the boot-time mirror is unnecessary. Closes #3954.

--- a/server/src/db/organization-db.ts
+++ b/server/src/db/organization-db.ts
@@ -1613,56 +1613,6 @@ export class OrganizationDatabase {
   }
 
   /**
-   * Sync organizations from WorkOS to local database.
-   * This should be called during server startup to ensure all WorkOS orgs exist locally.
-   * Only creates missing orgs - does not update existing ones.
-   */
-  async syncFromWorkOS(workos: WorkOS): Promise<{ synced: number; existing: number }> {
-    let synced = 0;
-    let existing = 0;
-
-    try {
-      // Paginate through all organizations from WorkOS (limit is per-page max)
-      let after: string | undefined;
-      do {
-        const orgs = await workos.organizations.listOrganizations({
-          limit: 100,
-          after,
-        });
-
-        for (const workosOrg of orgs.data) {
-          const localOrg = await this.getOrganization(workosOrg.id);
-
-          if (!localOrg) {
-            // organizations.name is VARCHAR(255); a few WorkOS orgs have
-            // longer names and would crash the whole sync on INSERT.
-            const name = workosOrg.name.slice(0, 255);
-            await this.createOrganization({
-              workos_organization_id: workosOrg.id,
-              name,
-            });
-            synced++;
-            logger.info({ orgId: workosOrg.id, name }, 'Synced organization from WorkOS');
-          } else {
-            existing++;
-          }
-        }
-
-        after = orgs.listMetadata?.after ?? undefined;
-      } while (after);
-
-      if (synced > 0) {
-        logger.info({ synced, existing }, 'WorkOS organization sync complete');
-      }
-
-      return { synced, existing };
-    } catch (error) {
-      logger.error({ error }, 'Failed to sync organizations from WorkOS');
-      throw error;
-    }
-  }
-
-  /**
    * Ensure a local organizations row exists for a WorkOS organization.
    * Fetches the org from WorkOS (for its name) and creates the local row if missing.
    * Safe to call on every login — cheap no-op when the row already exists.
@@ -1696,8 +1646,9 @@ export class OrganizationDatabase {
 
   /**
    * Sync Stripe customer IDs to local organization records.
-   * This should be called during server startup after WorkOS sync.
-   * Only updates orgs that exist locally but are missing stripe_customer_id.
+   * Called during server startup. Only updates orgs that already exist
+   * locally and are missing stripe_customer_id; orgs not yet present locally
+   * are skipped and will be filled in lazily on first login.
    */
   async syncStripeCustomers(): Promise<{ synced: number; skipped: number; conflicts: number }> {
     let synced = 0;
@@ -1711,7 +1662,8 @@ export class OrganizationDatabase {
       const localOrg = await this.getOrganization(workosOrgId);
 
       if (!localOrg) {
-        // Org doesn't exist locally - skip (WorkOS sync should have created it)
+        // Org doesn't exist locally yet — will be created lazily at first
+        // login via ensureOrganizationExists, then picked up on next sync.
         skipped++;
         continue;
       }

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -6529,8 +6529,9 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
         if (memberships.data.length > 0) {
           const primaryOrgId = memberships.data[0].organizationId;
           const userName = [user.firstName, user.lastName].filter(Boolean).join(' ') || user.email;
-          // Ensure the org exists locally first — startup sync can miss orgs
-          // created in WorkOS after boot, and org_activities FKs to organizations.
+          // Ensure the org row exists locally before recording — orgs are
+          // created lazily on first login (and via webhook), and
+          // org_activities FKs to organizations.
           orgDb.ensureOrganizationExists(workos!, primaryOrgId)
             .then(() => orgDb.recordUserLogin({
               workos_user_id: user.id,
@@ -8735,21 +8736,14 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
       ]);
     }
 
-    // Sync organizations from WorkOS and Stripe to local database (dev environment support)
+    // Sync Stripe customer IDs and seed dev data. Organizations are created
+    // lazily via ensureOrganizationExists at first login and via the
+    // organization.created WorkOS webhook — no boot-time WorkOS list sync is
+    // needed (and listOrganizations requires a workspace-level API scope our
+    // production key doesn't carry, so it always failed on cold start; #3954).
     if (AUTH_ENABLED && workos) {
       const orgDb = new OrganizationDatabase();
 
-      // Sync WorkOS organizations first
-      try {
-        const result = await orgDb.syncFromWorkOS(workos);
-        if (result.synced > 0) {
-          logger.info({ synced: result.synced, existing: result.existing }, 'Synced organizations from WorkOS');
-        }
-      } catch (error) {
-        logger.warn({ error }, 'Failed to sync organizations from WorkOS (non-fatal)');
-      }
-
-      // Then sync Stripe customer IDs (method handles errors gracefully)
       try {
         await orgDb.syncStripeCustomers();
       } catch (error) {


### PR DESCRIPTION
## Summary

Fixes #3954.

The boot-time `OrganizationDatabase.syncFromWorkOS` call was failing on every cold start with `UnauthorizedException: Could not authorize the request` — the production WorkOS API key isn't scoped for workspace-level `listOrganizations`. The outer call site demoted to a warn, but the inner `logger.error` inside `syncFromWorkOS` still emitted to PostHog on every boot.

Visible in PostHog `\$exception` events spanning at least 3 days (2026-05-01 → 2026-05-03).

## Why this is safe to remove

Org rows are created lazily on demand:

- **First login**: `http.ts:6534` calls `ensureOrganizationExists(workos, primaryOrgId)` before recording user activity
- **Webhook**: `routes/workos-webhooks.ts:896` handles `organization.created` events

The boot-time mirror was a defensive backfill that nothing structurally depends on. The Stripe sync that ran after it already handles the "org not in local DB yet" case (it skips, and gets re-synced on next boot once the lazy-create has run).

## Change

- `server/src/http.ts` — remove the `syncFromWorkOS` try/catch block; keep `syncStripeCustomers` and dev seeding
- `server/src/db/organization-db.ts` — delete the now-unused `syncFromWorkOS` method
- Stale comments updated to reflect the lazy-create model

## Test plan

- [x] `npx tsc --noEmit` clean for both modified files
- [x] Existing `brand-claim-service.test.ts` (16 tests) still pass
- [ ] After deploy: confirm no more `Failed to sync organizations from WorkOS` errors in PostHog
- [ ] After deploy: SSO login flow still works (creates org row lazily on first sign-in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)