### PR TITLE
fix(brand-claim): recover from stale WorkOS domain entries with null token/prefix

### DIFF
--- a/.changeset/fix-brand-claim-stale-workos-domain-null-token.md
+++ b/.changeset/fix-brand-claim-stale-workos-domain-null-token.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix brand-claim silent failure when existing WorkOS domain entry has null verificationToken or verificationPrefix. The idempotent pre-check now deletes the stale row and falls through to a fresh create rather than returning the unusable row as ok:true.

--- a/server/src/services/brand-claim.ts
+++ b/server/src/services/brand-claim.ts
@@ -134,17 +134,44 @@ export async function issueDomainChallenge(input: {
     const existing = await workos.organizations.getOrganization(orgId);
     const existingDomain = existing.domains.find(d => d.domain.toLowerCase() === domain);
     if (existingDomain) {
-      return {
-        ok: true,
-        domain,
-        workos_domain_id: existingDomain.id,
-        state: String(existingDomain.state),
-        verification_strategy: existingDomain.verificationStrategy ?? null,
-        verification_token: existingDomain.verificationToken ?? null,
-        verification_prefix: existingDomain.verificationPrefix ?? null,
-        already_verified: isVerifiedState(existingDomain.state),
-        prior_manifest_exists: priorManifestExists,
-      };
+      if (!isVerifiedState(existingDomain.state) &&
+          (existingDomain.verificationToken == null || existingDomain.verificationPrefix == null)) {
+        // Stale row: pending entry without a usable challenge token. WorkOS can
+        // return this when a domain was created in a different flow or abandoned
+        // mid-creation. Delete it so the create path issues a fresh challenge.
+        // (The SDK types verificationToken as string|undefined; == null catches both.)
+        logger.warn(
+          { orgId, domain, existingDomainId: existingDomain.id, state: existingDomain.state },
+          'brand-claim: stale domain entry with null token/prefix — deleting to allow re-issue',
+        );
+        try {
+          await workos.organizationDomains.deleteOrganizationDomain(existingDomain.id);
+        } catch (deleteErr: any) {
+          const deleteStatus = deleteErr?.status ?? deleteErr?.response?.status;
+          if (deleteStatus !== 404 && deleteStatus !== 410) {
+            logger.error(
+              { err: deleteErr, orgId, domain, existingDomainId: existingDomain.id },
+              'brand-claim: failed to delete stale domain entry',
+            );
+            return { ok: false, code: 'workos_error', message: 'Failed to clear stale domain entry before re-issuing challenge.' };
+          }
+          // 404/410: concurrent request already deleted it — fall through to create
+          logger.warn({ orgId, domain }, 'brand-claim: stale domain already deleted by a concurrent request');
+        }
+        // Fall through to create path below
+      } else {
+        return {
+          ok: true,
+          domain,
+          workos_domain_id: existingDomain.id,
+          state: String(existingDomain.state),
+          verification_strategy: existingDomain.verificationStrategy ?? null,
+          verification_token: existingDomain.verificationToken ?? null,
+          verification_prefix: existingDomain.verificationPrefix ?? null,
+          already_verified: isVerifiedState(existingDomain.state),
+          prior_manifest_exists: priorManifestExists,
+        };
+      }
     }
   } catch (err) {
     logger.warn({ err, orgId }, 'brand-claim: org pre-check failed, will attempt create');

--- a/server/tests/unit/brand-claim-service.test.ts
+++ b/server/tests/unit/brand-claim-service.test.ts
@@ -17,6 +17,7 @@ type WorkOSStub = {
   organizations: { getOrganization: ReturnType<typeof vi.fn> };
   organizationDomains: {
     createOrganizationDomain: ReturnType<typeof vi.fn>;
+    deleteOrganizationDomain: ReturnType<typeof vi.fn>;
     verifyOrganizationDomain: ReturnType<typeof vi.fn>;
   };
 };
@@ -24,6 +25,7 @@ type WorkOSStub = {
 function makeWorkos(overrides: Partial<{
   getOrganization: any;
   createOrganizationDomain: any;
+  deleteOrganizationDomain: any;
   verifyOrganizationDomain: any;
 }> = {}): WorkOSStub {
   return {
@@ -32,6 +34,7 @@ function makeWorkos(overrides: Partial<{
     },
     organizationDomains: {
       createOrganizationDomain: overrides.createOrganizationDomain ?? vi.fn(),
+      deleteOrganizationDomain: overrides.deleteOrganizationDomain ?? vi.fn().mockResolvedValue(undefined),
       verifyOrganizationDomain: overrides.verifyOrganizationDomain ?? vi.fn(),
     },
   };
@@ -135,6 +138,136 @@ describe('issueDomainChallenge', () => {
     });
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.already_verified).toBe(true);
+  });
+
+  it('deletes stale entry and re-issues when existing domain has null verificationToken', async () => {
+    const freshCreate = {
+      id: 'dom_fresh',
+      state: 'pending',
+      verificationStrategy: 'dns',
+      verificationToken: 'tok_new',
+      verificationPrefix: '_workos-challenge',
+    };
+    const deleteFn = vi.fn().mockResolvedValue(undefined);
+    const workos = makeWorkos({
+      getOrganization: vi.fn().mockResolvedValue({
+        domains: [{
+          id: 'dom_stale',
+          domain: DOMAIN,
+          state: 'pending',
+          verificationStrategy: 'dns',
+          verificationToken: null,
+          verificationPrefix: '_workos-challenge',
+        }],
+      }),
+      deleteOrganizationDomain: deleteFn,
+      createOrganizationDomain: vi.fn().mockResolvedValue(freshCreate),
+    });
+    const result = await issueDomainChallenge({
+      workos: workos as any,
+      brandDb: makeBrandDb(),
+      orgId: ORG,
+      rawDomain: DOMAIN,
+    });
+    expect(deleteFn).toHaveBeenCalledWith('dom_stale');
+    expect(workos.organizationDomains.createOrganizationDomain).toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.verification_token).toBe('tok_new');
+      expect(result.workos_domain_id).toBe('dom_fresh');
+    }
+  });
+
+  it('deletes stale entry and re-issues when existing domain has null verificationPrefix', async () => {
+    const freshCreate = {
+      id: 'dom_fresh2',
+      state: 'pending',
+      verificationStrategy: 'dns',
+      verificationToken: 'tok_new2',
+      verificationPrefix: '_workos-challenge',
+    };
+    const deleteFn = vi.fn().mockResolvedValue(undefined);
+    const workos = makeWorkos({
+      getOrganization: vi.fn().mockResolvedValue({
+        domains: [{
+          id: 'dom_stale2',
+          domain: DOMAIN,
+          state: 'pending',
+          verificationStrategy: 'dns',
+          verificationToken: 'tok_old',
+          verificationPrefix: null,
+        }],
+      }),
+      deleteOrganizationDomain: deleteFn,
+      createOrganizationDomain: vi.fn().mockResolvedValue(freshCreate),
+    });
+    const result = await issueDomainChallenge({
+      workos: workos as any,
+      brandDb: makeBrandDb(),
+      orgId: ORG,
+      rawDomain: DOMAIN,
+    });
+    expect(deleteFn).toHaveBeenCalledWith('dom_stale2');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.verification_token).toBe('tok_new2');
+  });
+
+  it('returns workos_error when delete of stale entry fails with a non-404 status', async () => {
+    const workos = makeWorkos({
+      getOrganization: vi.fn().mockResolvedValue({
+        domains: [{
+          id: 'dom_stale3',
+          domain: DOMAIN,
+          state: 'pending',
+          verificationStrategy: 'dns',
+          verificationToken: null,
+          verificationPrefix: null,
+        }],
+      }),
+      deleteOrganizationDomain: vi.fn().mockRejectedValue({ status: 500 }),
+    });
+    const result = await issueDomainChallenge({
+      workos: workos as any,
+      brandDb: makeBrandDb(),
+      orgId: ORG,
+      rawDomain: DOMAIN,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('workos_error');
+    expect(workos.organizationDomains.createOrganizationDomain).not.toHaveBeenCalled();
+  });
+
+  it('falls through to create when delete returns 404 (concurrent request already deleted)', async () => {
+    const freshCreate = {
+      id: 'dom_fresh3',
+      state: 'pending',
+      verificationStrategy: 'dns',
+      verificationToken: 'tok_concurrent',
+      verificationPrefix: '_workos-challenge',
+    };
+    const workos = makeWorkos({
+      getOrganization: vi.fn().mockResolvedValue({
+        domains: [{
+          id: 'dom_stale4',
+          domain: DOMAIN,
+          state: 'pending',
+          verificationStrategy: 'dns',
+          verificationToken: null,
+          verificationPrefix: null,
+        }],
+      }),
+      deleteOrganizationDomain: vi.fn().mockRejectedValue({ status: 404 }),
+      createOrganizationDomain: vi.fn().mockResolvedValue(freshCreate),
+    });
+    const result = await issueDomainChallenge({
+      workos: workos as any,
+      brandDb: makeBrandDb(),
+      orgId: ORG,
+      rawDomain: DOMAIN,
+    });
+    expect(workos.organizationDomains.createOrganizationDomain).toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.verification_token).toBe('tok_concurrent');
   });
 
   it('disambiguates 422 collision via organization_domain_already_used code', async () => {


### PR DESCRIPTION
Closes #3953

When `issueDomainChallenge` found an existing pending domain entry in WorkOS that had `null` `verificationToken` or `verificationPrefix`, it returned the stale row as `ok: true`. The caller then rendered `"Issued a challenge for {domain} but WorkOS didn't return a DNS record to publish — that's unusual."` with no user recovery path. Every retry hit the same deterministic code path. Unsticking required manual admin deletion of the WorkOS domain row in the console (escalation #302, vastlint.org). The idempotent pre-check now detects this broken state, deletes the stale row (with 404/410 tolerance for concurrent requests), and falls through to a fresh `createOrganizationDomain` call so a usable token and prefix are returned. Verified entries are untouched — the guard only fires when `!isVerifiedState(state)`.

**Non-breaking justification:** purely server-side behavioral fix; no API contract, schema, or protocol definition changes. Changeset is `--empty`.

**Pre-PR review:**
- code-reviewer: approved — inner try/catch correctly insulates outer getOrganization catch; `== null` is right (SDK types token as `string|undefined`); changeset front-matter correct. Nits: (1) `toHaveBeenCalledWith({ organizationId: ORG, domain: DOMAIN })` assertion missing in the two stale-delete tests; (2) no test for `state: verified, token: null` to prove the isVerifiedState guard blocks the delete path. Neither is a CI blocker.
- internal-tools-strategist: approved — programmatic delete is safe (verified rows can't satisfy the null-token guard); warn log is structured adequately for PostHog queries; follow-up: instrument a `brand_claim_stale_domain_deleted` PostHog event to track production frequency.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout 3953` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01Cy3qQbLTEqJ4dd7xyXPe79

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy3qQbLTEqJ4dd7xyXPe79)_