### PR TITLE
feat(admin): add brand-claim verify endpoint for missed-webhook recovery

### DIFF
--- a/.changeset/admin-brand-claim-verify-endpoint.md
+++ b/.changeset/admin-brand-claim-verify-endpoint.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add `POST /api/admin/organizations/:orgId/brand-claim/verify` for admin-triggered brand-claim sync. Wraps the existing `verifyDomainChallenge` service with an explicit orgId so it can be invoked with `ADMIN_API_KEY` to recover from missed `organization_domain.verified` webhooks (e.g. WorkOS dashboard manual flips that didn't propagate). When WorkOS already reports the domain as verified, the service short-circuits the DNS check and runs `applyVerifiedBrandClaim` directly.

--- a/server/src/routes/admin/domains.ts
+++ b/server/src/routes/admin/domains.ts
@@ -19,6 +19,8 @@ import {
 import { linkContactsByDomain } from "../../db/contacts-db.js";
 import { resolveOrgsByDomains } from "../../db/domain-resolution-db.js";
 import { complete, isLLMConfigured } from "../../utils/llm.js";
+import { BrandDatabase } from "../../db/brand-db.js";
+import { verifyDomainChallenge } from "../../services/brand-claim.js";
 
 const slackDb = new SlackDatabase();
 const logger = createLogger("admin-domains");
@@ -1155,6 +1157,53 @@ export function setupDomainRoutes(
           error: "Internal server error",
           message: "Unable to fetch organization domains",
         });
+      }
+    }
+  );
+
+  // POST /api/admin/organizations/:orgId/brand-claim/verify
+  // Force-sync the brand registry from WorkOS for an org's domain. Wraps the
+  // same verifyDomainChallenge service the user-facing /api/me/member-profile
+  // route uses, but takes orgId explicitly so it can be invoked with the
+  // ADMIN_API_KEY for orgs the caller doesn't belong to.
+  //
+  // Recovery path for cases where WorkOS shows the domain as `verified` but
+  // the local `brands` row wasn't written — e.g. a missed
+  // organization_domain.verified webhook. The verify service short-circuits
+  // on isVerifiedState and runs applyVerifiedBrandClaim directly, so no DNS
+  // round-trip is needed.
+  apiRouter.post(
+    "/organizations/:orgId/brand-claim/verify",
+    requireAuth,
+    requireAdmin,
+    async (req, res) => {
+      const { orgId } = req.params;
+      const rawDomain = (req.body?.domain as string | undefined) ?? "";
+      const adoptPriorManifest = req.body?.adopt_prior_manifest === true;
+      if (!workos) {
+        return res.status(503).json({ error: "WorkOS not configured" });
+      }
+      if (!rawDomain) {
+        return res.status(400).json({ error: "domain is required" });
+      }
+      try {
+        const result = await verifyDomainChallenge({
+          workos,
+          brandDb: new BrandDatabase(),
+          orgId,
+          rawDomain,
+          adoptPriorManifest,
+        });
+        if (!result.ok) {
+          const status = result.code === "no_challenge" ? 404
+            : result.code === "still_pending" ? 400
+            : 500;
+          return res.status(status).json(result);
+        }
+        return res.json(result);
+      } catch (error) {
+        logger.error({ err: error, orgId, domain: rawDomain }, "Admin brand-claim verify failed");
+        return res.status(500).json({ error: "Internal server error" });
       }
     }
   );


### PR DESCRIPTION
## Summary

Adds `POST /api/admin/organizations/:orgId/brand-claim/verify` so admins can force-sync the local brand registry from WorkOS state via `ADMIN_API_KEY`. Wraps the existing `verifyDomainChallenge` service untouched — when WorkOS already reports `state: verified`, the service short-circuits the DNS check (`brand-claim.ts:248-250`) and runs `applyVerifiedBrandClaim` directly.

## Why

Today the only way to land a verified domain in our `brands` table is:
1. The user calls `POST /api/me/member-profile/brand-claim/verify` themselves, OR
2. WorkOS delivers the `organization_domain.verified` webhook and we process it

We discovered (escalation #302, vastlint.org) a case where WorkOS reports the domain as `verified` but our local DB never received the webhook — confirmed via `GET /api/admin/organizations/:orgId/domains`:

```json
{
  "domains": [],
  "workos_domains": [{ "domain": "vastlint.org", "state": "verified" }]
}
```

PostHog has zero `workos-webhooks` errors / signature failures in the last 7 days, so we didn't reject the event — it never reached us. The webhook subscription IS configured for `organization_domain.verified` in the WorkOS dashboard. Most likely cause: dashboard-flipped verifications don't always emit the webhook the same way API-triggered ones do. The comment at `workos-webhooks.ts:602-603` claiming the webhook is a guaranteed backstop overstates the actual behavior.

This endpoint closes the gap without depending on webhook reliability.

## Body

```json
{
  "domain": "vastlint.org",
  "adopt_prior_manifest": false  // optional, only relevant if a prior orphaned manifest exists
}
```

Returns the same shape as the user-facing `/brand-claim/verify` route on success; status codes mirror the service result codes (400 still_pending, 404 no_challenge, 500 workos_error).

## Test plan

- [x] Typecheck clean
- [x] All existing brand-claim unit tests still pass (16/16)
- [x] Full `npm run test:unit` green via precommit (864 tests, 45 files)
- [ ] Live: hit `POST /api/admin/organizations/org_01KQN9EZH03BPMJ6BXM51DQ1ZD/brand-claim/verify` with `{"domain":"vastlint.org"}` after deploy → expect `brands` row to be created and `brand_mapped: true` on Alex's account view

## Follow-ups (out of scope)

- The `workos-webhooks.ts:602-603` comment claims dashboard-flipped domains "are the ONLY writer" via `markBrandDomainVerified`. Empirical evidence here disagrees — worth filing as a separate bug + tightening the comment, or investigating WorkOS delivery semantics for dashboard flips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)