### PR TITLE
feat(spec): add sponsored-intelligence to AdCPSpecialism enum

### DIFF
--- a/.changeset/sponsored-intelligence-specialism.md
+++ b/.changeset/sponsored-intelligence-specialism.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": minor
+---
+
+Add `sponsored-intelligence` to `AdCPSpecialism` enum as a preview specialism.
+
+The four SI lifecycle tasks (`si_get_offering`, `si_initiate_session`, `si_send_message`, `si_terminate_session`) have been in the spec since 3.0. This change adds the corresponding specialism ID so SDK v6 can define a `SponsoredIntelligencePlatform` interface using the same `RequiredPlatformsFor<S>` dispatch pattern as all other specialisms.
+
+Ships as `status: preview` because the underlying SI schemas carry `x-status: experimental`. The compliance runner produces no stable pass/fail verdict until schemas graduate. Consistent with the preview-specialism pattern established for other experimental surfaces.

--- a/server/src/services/adcp-taxonomy.ts
+++ b/server/src/services/adcp-taxonomy.ts
@@ -108,7 +108,8 @@ export type AdcpSpecialism =
   | 'sales-social'
   | 'signal-marketplace'
   | 'signal-owned'
-  | 'signed-requests';
+  | 'signed-requests'
+  | 'sponsored-intelligence';
 
 export const ADCP_SPECIALISMS: readonly AdcpSpecialism[] = [
   'audience-sync',
@@ -131,6 +132,7 @@ export const ADCP_SPECIALISMS: readonly AdcpSpecialism[] = [
   'signal-marketplace',
   'signal-owned',
   'signed-requests',
+  'sponsored-intelligence',
 ];
 
 /** Per-specialism status derived from compliance catalog frontmatter. */

--- a/server/tests/unit/adcp-taxonomy.test.ts
+++ b/server/tests/unit/adcp-taxonomy.test.ts
@@ -33,18 +33,18 @@ describe('adcp-taxonomy enum sync', () => {
 });
 
 describe('specialism status', () => {
-  // No specialisms are currently marked `status: preview` in the compliance catalog —
-  // earlier preview specialisms (sales-exchange, sales-retail-media, sales-streaming-tv,
-  // measurement-verification) were removed from the enum entirely rather than retained
-  // behind a status flag. The preview mechanism remains in place for future use.
-
-  it('treats all current specialisms as stable', () => {
+  it('treats stable specialisms as stable', () => {
     expect(isStableSpecialism('sales-broadcast-tv')).toBe(true);
     expect(isStableSpecialism('creative-template')).toBe(true);
     expect(isStableSpecialism('property-lists')).toBe(true);
     expect(isStableSpecialism('collection-lists')).toBe(true);
     expect(isStableSpecialism('signed-requests')).toBe(true);
     expect(isStableSpecialism('governance-aware-seller')).toBe(true);
+  });
+
+  it('treats sponsored-intelligence as preview (first live preview specialism)', () => {
+    expect(isStableSpecialism('sponsored-intelligence')).toBe(false);
+    expect(getSpecialismStatus('sponsored-intelligence')).toBe('preview');
   });
 
   it('treats unknown specialisms as stable (safe default)', () => {

--- a/static/compliance/source/specialisms/sponsored-intelligence/index.yaml
+++ b/static/compliance/source/specialisms/sponsored-intelligence/index.yaml
@@ -1,0 +1,87 @@
+id: sponsored_intelligence
+version: "1.0.0"
+status: preview
+title: "Sponsored intelligence platform"
+protocol: sponsored-intelligence
+category: sponsored_intelligence
+summary: "Conversational ad platform implementing the SI session lifecycle (si_get_offering, si_initiate_session, si_send_message, si_terminate_session)."
+track: si
+
+narrative: |
+  You run an AI platform that supports sponsored intelligence — conversational ad experiences
+  embedded in AI-powered search, chat, or assistant products. A buyer agent connects to
+  discover what SI offerings are available, initiate a session, exchange messages, and
+  terminate cleanly.
+
+  Agents claiming this specialism must declare sponsored_intelligence in supported_protocols
+  alongside the specialism entry in get_adcp_capabilities. The SI session lifecycle is
+  fundamentally conversational: the buyer provides context and the platform weaves sponsored
+  content into AI responses in a transparent and relevant way.
+
+  This specialism is marked preview because the underlying SI schemas carry x-status: experimental.
+  The compliance runner produces no stable pass/fail verdict until the schemas graduate.
+
+agent:
+  interaction_model: si_platform
+  capabilities:
+    - sponsored_intelligence
+  examples:
+    - "Conversational AI platform with sponsored content"
+    - "AI assistant with brand-sponsored responses"
+
+caller:
+  role: buyer_agent
+  example: "Nova Motors (advertiser)"
+
+prerequisites:
+  description: |
+    The caller needs brand context and campaign parameters for SI. The test kit provides
+    a sample brand (Nova Motors) with signal definitions suitable for conversational
+    ad experiences.
+  test_kit: "test-kits/nova-motors.yaml"
+
+requires_scenarios:
+  - si_baseline
+
+phases:
+  - id: capability_discovery
+    title: "Capability discovery"
+    narrative: |
+      The buyer calls get_adcp_capabilities to verify the agent declares both the
+      sponsored_intelligence protocol and the sponsored-intelligence specialism.
+      Both must be present for a conforming SI specialism claim.
+
+    steps:
+      - id: get_capabilities
+        title: "Check agent capabilities"
+        narrative: |
+          Verify that the agent declares sponsored_intelligence in supported_protocols
+          and sponsored-intelligence in specialisms. The specialism claim without the
+          parent protocol declaration is invalid per the AdCP compliance contract.
+        task: get_adcp_capabilities
+        schema_ref: "protocol/get-adcp-capabilities-request.json"
+        response_schema_ref: "protocol/get-adcp-capabilities-response.json"
+        doc_ref: "/protocol/get_adcp_capabilities"
+        comply_scenario: capability_discovery
+        stateful: false
+        expected: |
+          Return capabilities declaring:
+          - sponsored_intelligence in supported_protocols
+          - sponsored-intelligence in specialisms
+          - The sponsored_intelligence capability block fully populated
+        sample_request:
+          context:
+            correlation_id: "sponsored_intelligence--get_capabilities"
+        validations:
+          - check: response_schema
+            description: "Response matches get-adcp-capabilities-response.json schema"
+          - check: field_present
+            path: "supported_protocols"
+            description: "Agent declares supported protocols"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "sponsored_intelligence--get_capabilities"
+            description: "Context correlation_id returned unchanged"

--- a/static/schemas/source/enums/specialism.json
+++ b/static/schemas/source/enums/specialism.json
@@ -29,7 +29,8 @@
     "sales-social",
     "signal-marketplace",
     "signal-owned",
-    "signed-requests"
+    "signed-requests",
+    "sponsored-intelligence"
   ],
   "enumDescriptions": {
     "audience-sync": "Syncs buyer-provided audience segments into a platform for activation",
@@ -51,6 +52,7 @@
     "sales-social": "Social media advertising platform with self-service flows",
     "signal-marketplace": "Marketplace signal agent reselling third-party data",
     "signal-owned": "Owned signal agent exposing first-party segments",
-    "signed-requests": "DEPRECATED in 3.1 — reclassified to /compliance/{version}/universal/signed-requests.yaml. Advertise request_signing.supported: true in get_adcp_capabilities; this enum value is retained until 4.0 for backward compat but is no longer needed. See https://github.com/adcontextprotocol/adcp/issues/3075 (reclassification) and https://github.com/adcontextprotocol/adcp/issues/3078 (4.0 enum removal)."
+    "signed-requests": "DEPRECATED in 3.1 — reclassified to /compliance/{version}/universal/signed-requests.yaml. Advertise request_signing.supported: true in get_adcp_capabilities; this enum value is retained until 4.0 for backward compat but is no longer needed. See https://github.com/adcontextprotocol/adcp/issues/3075 (reclassification) and https://github.com/adcontextprotocol/adcp/issues/3078 (4.0 enum removal).",
+    "sponsored-intelligence": "Sponsored intelligence platform — conversational ad experiences embedded in AI-powered search, chat, or assistant products. Agents claiming this specialism implement the SI session lifecycle (si_get_offering, si_initiate_session, si_send_message, si_terminate_session) and declare sponsored_intelligence in supported_protocols. Preview specialism — underlying schemas are x-status: experimental; storyboard produces no stable pass/fail verdict until schemas graduate."
   }
 }


### PR DESCRIPTION
Closes #3961

Adds `sponsored-intelligence` as a preview specialism in `AdCPSpecialism`, closing the asymmetry between the SI protocol declaration (`supported_protocols: ['sponsored_intelligence']`) and the specialism registry. The four SI lifecycle tasks (`si_get_offering`, `si_initiate_session`, `si_send_message`, `si_terminate_session`) have been in the spec since 3.0 — this gives them a specialism ID so SDK v6 can define `SponsoredIntelligencePlatform` using the same `RequiredPlatformsFor<S>` dispatch pattern as all other specialisms.

**Non-breaking justification:** Adds a new enum value appended to the end of `AdCPSpecialism`; existing agents are unaffected; specialism claims are opt-in; the protocol declaration (`sponsored_intelligence` in `supported_protocols`) continues to coexist unchanged.

**Three-location atomic update** required to satisfy the `adcp-taxonomy.test.ts` parity check:
1. `static/schemas/source/enums/specialism.json` — new enum value + `enumDescriptions` entry
2. `server/src/services/adcp-taxonomy.ts` — new `AdcpSpecialism` union member + `ADCP_SPECIALISMS` array entry
3. `static/compliance/source/specialisms/sponsored-intelligence/index.yaml` — new preview storyboard with `requires_scenarios: [si_baseline]`

**Ships as `status: preview`** because the underlying SI schemas carry `x-status: experimental`. The compliance runner produces no stable pass/fail verdict until schemas graduate. Consistent with the preview-specialism pattern established for other experimental surfaces. Fits the #2511 (re-add preview specialisms) wave in 3.1.

The storyboard has a single `capability_discovery` phase verifying both `sponsored_intelligence` in `supported_protocols` and `sponsored-intelligence` in `specialisms`. The full SI session lifecycle (offering discovery → session lifecycle) is pulled in via `requires_scenarios: [si_baseline]`. This is intentional for a preview storyboard — the lifecycle is already covered by the protocol-level baseline; the specialism adds the coexistence invariant check.

**Nit (not addressed here):** The protocol-level SI storyboard at `static/compliance/source/protocols/sponsored-intelligence/index.yaml` uses real company names in `agent.examples` which violates the playbook's no-real-brands rule. Separate cleanup warranted — not in scope for this enum-addition PR.

**Pre-PR review:**
- ad-tech-protocol-expert: approved — non-breaking per spec; one blocker found and fixed (`requires_scenarios` must reference storyboard `id: si_baseline`, not filesystem path `protocols/sponsored-intelligence`)
- code-reviewer: approved — one blocker found and fixed (stale comment + missing preview assertion in `adcp-taxonomy.test.ts`); remaining findings are nits or already-resolved (the `requires_scenarios` path fix was applied before their review ran)

> **Triage-managed PR.** This bot does not currently iterate on review comments or PR conversation threads (only on the source issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` → fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121) for context.

Session: https://claude.ai/code/session_015vM78ky3xSqQj4FMqEZmDe