### PR TITLE
fix(compliance): remove payload_must_contain over-fit; extend identifier_paths echo across 4 storyboards

### DIFF
--- a/.changeset/fix-compliance-payload-must-contain-identifier-echo.md
+++ b/.changeset/fix-compliance-payload-must-contain-identifier-echo.md
@@ -1,0 +1,4 @@
+---
+---
+
+Remove Meta-shape `payload_must_contain` over-fit from 3 storyboards (sales-social, audience-sync, signal-marketplace) and extend cross-step `identifier_paths` echo to signal-marketplace, sales-non-guaranteed, creative-ad-server, and audience-sync delete step. Non-protocol change — storyboard conformance harness only.

--- a/static/compliance/source/specialisms/audience-sync/index.yaml
+++ b/static/compliance/source/specialisms/audience-sync/index.yaml
@@ -291,9 +291,8 @@ phases:
             value: "audience_sync--delete_audience"
             description: "Context correlation_id returned unchanged"
           # Anti-façade: an adapter that returns a shape-valid delete response without
-          # forwarding the deletion to its upstream user graph fails this check.
-          # The audience_id is the same literal used in create_audience, so the echo
-          # confirms the specific test audience was the deletion target.
+          # forwarding the deletion to its upstream user graph fails this check. The
+          # identifier echo confirms the upstream call carries the correct audience ID.
           - check: upstream_traffic
             description: "delete_audience caused upstream traffic propagating the deletion to the upstream user graph"
             min_count: 1

--- a/static/compliance/source/specialisms/audience-sync/index.yaml
+++ b/static/compliance/source/specialisms/audience-sync/index.yaml
@@ -248,9 +248,6 @@ phases:
             identifier_paths:
               - "audiences[*].add[*].hashed_email"
               - "audiences[*].add[*].external_id"
-            payload_must_contain:
-              - path: "users[*].hashed_email"
-                match: present
       - id: delete_audience
         title: "Delete test audience"
         narrative: |
@@ -293,3 +290,12 @@ phases:
             path: "context.correlation_id"
             value: "audience_sync--delete_audience"
             description: "Context correlation_id returned unchanged"
+          # Anti-façade: an adapter that returns a shape-valid delete response without
+          # forwarding the deletion to its upstream user graph fails this check.
+          # The audience_id is the same literal used in create_audience, so the echo
+          # confirms the specific test audience was the deletion target.
+          - check: upstream_traffic
+            description: "delete_audience caused upstream traffic propagating the deletion to the upstream user graph"
+            min_count: 1
+            identifier_paths:
+              - "audiences[*].audience_id"

--- a/static/compliance/source/specialisms/creative-ad-server/index.yaml
+++ b/static/compliance/source/specialisms/creative-ad-server/index.yaml
@@ -264,9 +264,11 @@ phases:
           # Ad Manager, Kevel, Equativ, FreeWheel) — the storyboard asserts
           # "an upstream call happened" rather than naming a platform.
           - check: upstream_traffic
-            description: "build_creative caused upstream traffic to the ad server"
+            description: "build_creative caused upstream traffic to the ad server carrying the creative_id"
             min_count: 1
             endpoint_pattern: "POST *"
+            identifier_paths:
+              - "creative_id"
   - id: track_delivery
     title: "Track creative delivery"
     narrative: |

--- a/static/compliance/source/specialisms/sales-non-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-non-guaranteed/index.yaml
@@ -384,6 +384,14 @@ phases:
             path: "context.correlation_id"
             value: "sales_non_guaranteed--update_media_buy"
             description: "Context correlation_id returned unchanged"
+          # Anti-façade: a real update propagates bid/budget changes to the upstream
+          # auction platform. An adapter returning shape-valid responses without touching
+          # upstream fails this check. No identifier_paths here — media_buy_id is
+          # seller-assigned (dynamic context variable, not a buyer-supplied literal).
+          - check: upstream_traffic
+            description: "update_media_buy caused upstream traffic applying the bid/budget changes"
+            min_count: 1
+            endpoint_pattern: "POST *"
   - id: delivery
     title: "Delivery and auction metrics"
     narrative: |

--- a/static/compliance/source/specialisms/sales-social/index.yaml
+++ b/static/compliance/source/specialisms/sales-social/index.yaml
@@ -252,9 +252,6 @@ phases:
             identifier_paths:
               - "audiences[*].add[*].hashed_email"
               - "audiences[*].add[*].external_id"
-            payload_must_contain:
-              - path: "users[*].hashed_email"
-                match: present
   - id: creative_push
     title: "Native creative sync"
     narrative: |

--- a/static/compliance/source/specialisms/signal-marketplace/index.yaml
+++ b/static/compliance/source/specialisms/signal-marketplace/index.yaml
@@ -314,8 +314,8 @@ phases:
           pricing_option_id: "$context.first_signal_pricing_option_id"
           destinations:
             - type: "platform"
-              platform: "the-trade-desk"
-              account: "agency-123-ttd"
+              platform: "pinnacle-dsp"
+              account: "agency-123-pd"
           idempotency_key: "$generate:uuid_v4#signal_marketplace_activate_platform"
           context:
             correlation_id: "signal_marketplace--activate_on_platform"
@@ -354,9 +354,8 @@ phases:
             min_count: 1
             endpoint_pattern: "POST *"
             since: search_by_spec
-            payload_must_contain:
-              - path: "segment_id"
-                match: present
+            identifier_paths:
+              - "signal_agent_segment_id"
   - id: agent_activation
     title: "Activate on a sales agent"
     narrative: |


### PR DESCRIPTION
Closes #3969

## Summary

Two coupled fixes to the 5 storyboards that adopted `upstream_traffic` in #3962.

**Part A — Remove Meta-shape `payload_must_contain` over-fit (3 storyboards)**

`sales-social/sync_audiences` and `audience-sync/create_audience` declared `payload_must_contain: [{path: "users[*].hashed_email"}]`, which assumes Google Customer Match / Meta CAPI nesting. TikTok, Snap, and Pinterest use completely different path shapes — these adopters' conformance runs were failing the check despite forwarding identifiers correctly. `identifier_paths` already provides shape-agnostic value-echo verification (asserts the supplied value appears at any depth); `payload_must_contain` added only a shape constraint that's redundant in the best case and a false positive in every non-Meta case.

`signal-marketplace/activate_on_platform` had the same problem with `payload_must_contain: [{path: "segment_id"}]` — TTD-shaped, fails Xandr, Amazon DSP, Yahoo DSP, and others. Replaced with `identifier_paths: ["signal_agent_segment_id"]` (schema spec confirms identifier_paths resolves from the post-substitution request, so the context-resolved segment ID is extracted correctly).

Also replaced real brand name `the-trade-desk` / `agency-123-ttd` with fictional `pinnacle-dsp` / `agency-123-pd` per playbook.

**Part B — Extend cross-step `identifier_paths` echo (4 storyboards)**

`sales-social` was the only storyboard using the cross-step pattern (same `hashed_email` value asserted in both `sync_audiences` and `log_event` upstream traffic). Extended the pattern:

- **signal-marketplace/activate_on_platform**: `identifier_paths: ["signal_agent_segment_id"]` replaces `payload_must_contain` (see Part A)
- **creative-ad-server/build_tag**: added `identifier_paths: ["creative_id"]` to existing `upstream_traffic` check
- **audience-sync/delete_audience**: new `upstream_traffic` check with `identifier_paths: ["audiences[*].audience_id"]` (method-agnostic — no `endpoint_pattern` since deletion APIs vary by platform)
- **sales-non-guaranteed/update_media_buy**: bare `upstream_traffic` check (no `identifier_paths` — `media_buy_id` is seller-assigned, `$context.*` value, not a buyer-supplied literal; bare check verifies upstream propagation happened)

## Non-breaking justification

All changes are to the conformance harness (`static/compliance/source/specialisms/`), not published schemas or task definitions.

- **Part A (removals)**: relaxing assertions — previously failing (non-Meta) adopters become passing; Meta adopters are unaffected since `identifier_paths` covers their values.
- **Part B (additions)**: additive `upstream_traffic` checks grade `not_applicable` for any adopter not advertising `query_upstream_traffic` via `list_scenarios`. Only opt-in adopters see stricter checks. `upstream_traffic` was introduced in #3962 (recent); no conformant implementation was relying on the absence of these assertions.
- Changeset: `--empty` (conformance harness, not published protocol spec).

## Pre-PR review

- **ad-tech-protocol-expert**: approved — correct removal of shape-specific over-fit; `identifier_paths` is strictly stronger; found 2 blockers (both fixed): `endpoint_pattern: "POST *"` on delete_audience → removed (method-agnostic); `since: create_media_buy` on update_media_buy → removed (included create traffic, defeating the check; default window "since this step's request" is correct).
- **code-reviewer**: approved — confirmed `identifier_paths` resolves post-substitution values (runner-output-contract.yaml line 395); nit on overclaiming comment (fixed). Raised `since: create_media_buy` as "missing" based on original diff; protocol expert explicitly flagged its presence as a **blocker** (widens window to include create traffic). Current state — no `since` — is the correct resolution per spec (storyboard-schema.yaml lines 1110-1124).

> **Triage-managed PR.** This bot does not currently iterate on review comments or PR conversation threads (only on the source issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` → fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121) for context.

Session: https://claude.ai/code/session_01Tmvr85NJQwDR9QWEciSZk7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tmvr85NJQwDR9QWEciSZk7)_