### PR TITLE
ci(storyboards): ratchet floors up to capture #3976's lift

### DIFF
--- a/.changeset/3965-floor-ratchet-after-listcreativeformats.md
+++ b/.changeset/3965-floor-ratchet-after-listcreativeformats.md
@@ -1,0 +1,17 @@
+---
+---
+
+ci(storyboards): ratchet floors up to capture #3976's lift on /creative and /creative-builder
+
+#3976 wired `listCreativeFormats` on the v6 `/creative` and `/creative-builder` platforms but explicitly deferred floor changes to avoid conflict with #3974. Now that both have merged, raise the floors.
+
+| Tenant            | #3974 floor | This PR | Delta |
+|-------------------|-------------|---------|-------|
+| /creative         | 56 / 69     | 64 / 79 | +8 clean / +10 passed |
+| /creative-builder | 52 / 51     | 58 / 61 | +6 clean / +10 passed |
+
+Files: `.github/workflows/training-agent-storyboards.yml`, `scripts/run-storyboards-matrix.sh` (kept in sync per the existing pattern).
+
+After this lands, /creative is at pre-bump baseline (was 58, now 64). /creative-builder is +3 over pre-bump (was 55, now 58). The remaining residue across all tenants is in Classes A (SDK gap, adcp-client#1455), C (predates the bump), and E (force_create_media_buy_arm — needs reproducer).
+
+The ratchet pattern this PR exemplifies — multiple lower→raise cycles per cluster — is itself flagged as a meta-issue in #3977 (\"ratchet-only floors with explicit waivers instead of lower-then-raise\"). Out of scope for this PR; just noting the precedent.

--- a/.github/workflows/training-agent-storyboards.yml
+++ b/.github/workflows/training-agent-storyboards.yml
@@ -55,11 +55,11 @@ jobs:
             min_clean_storyboards: 63
             min_passing_steps: 66
           - tenant: creative
-            min_clean_storyboards: 56
-            min_passing_steps: 69
+            min_clean_storyboards: 64
+            min_passing_steps: 79
           - tenant: creative-builder
-            min_clean_storyboards: 52
-            min_passing_steps: 51
+            min_clean_storyboards: 58
+            min_passing_steps: 61
           - tenant: brand
             min_clean_storyboards: 65
             min_passing_steps: 14

--- a/scripts/run-storyboards-matrix.sh
+++ b/scripts/run-storyboards-matrix.sh
@@ -23,8 +23,8 @@ TENANTS=(
   "signals:65:23"
   "sales:62:212"
   "governance:63:66"
-  "creative:56:69"
-  "creative-builder:52:51"
+  "creative:64:79"
+  "creative-builder:58:61"
   "brand:65:14"
 )
 


### PR DESCRIPTION
Floors raise after #3976 (listCreativeFormats wiring) merged. Was deferred from #3976 to avoid conflicts with #3974's floor raises.

| Tenant | Before | After | Delta |
|---|---|---|---|
| /creative | 56 / 69 | **64 / 79** | +8 clean / +10 passed |
| /creative-builder | 52 / 51 | **58 / 61** | +6 / +10 |

After this:
- /creative is at pre-bump baseline (58 → 64).
- /creative-builder is +3 over pre-bump (55 → 58).
- Other tenants unchanged (already at observed values from #3974).

Closes the ratchet-up tail of the #3965 cluster. Remaining residue across all tenants is in Classes A (adcp-client#1455 SDK gap), C (signed_requests /mcp-strict — predates bump), E (force_create_media_buy_arm — needs reproducer).

The lower→raise→fix→raise pattern this PR exemplifies is itself a meta-issue tracked in #3977 (ratchet-only floors with explicit waivers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)