### PR TITLE
docs(building): SDK stack reference + decision page + version-adaptation + hand-rolled migration

### DIFF
--- a/.changeset/sdk-stack-doc-set.md
+++ b/.changeset/sdk-stack-doc-set.md
@@ -1,0 +1,22 @@
+---
+---
+
+docs(building): SDK stack reference + decision page + version-adaptation guide + hand-rolled migration guide
+
+Adds four pages to docs/building/ that orient adopters around how much of L0–L3 they inherit from an AdCP SDK vs. write themselves. Targets two recurring wrong conclusions:
+
+1. Early implementers who built before the SDKs were mature and have a frozen-in-time picture of "what an SDK does" — most of L3 (state machines, idempotency, conformance test surface, RFC 9421, expanded error catalog) was added with AdCP 3.0.
+2. New implementers who treat AdCP as a thin protocol and don't see the L0–L3 scope.
+
+New pages:
+
+- `docs/building/sdk-stack.mdx` — full L0–L4 reference: layers, what an SDK at each layer should provide, version-adaptation summary, per-component cost decomposition, "what early implementers underestimate" punch list, and the live SDK coverage matrix (`@adcp/sdk` 6.7.0 GA, Python `adcp` 4.x in flight, `adcp-go` in dev).
+- `docs/building/where-to-start.mdx` — short decision page. Three questions, recommended path for ~95% of adopters, "what you give up by going lower" cost table.
+- `docs/building/version-adaptation.mdx` — three-mechanism reference: per-call `adcpVersion` pinning, SDK-major co-existence imports, on-wire `supported_versions` + `VERSION_UNSUPPORTED` envelope + typed pre-flight throw.
+- `docs/building/migrate-from-hand-rolled.mdx` — eight-section incremental migration guide: inventory, spec-compliance-first, lowest-risk swap order, six conflict modes (idempotency, account-mode, webhook signing, state-machine drift, webhook transport, schema validation), intermediate-conformance states, per-step rollback playbook + 2 a.m. recipe, multi-buyer worked example, what-you-can-leave-hand-rolled, version drift, when-not-to-migrate.
+
+Wiring: docs.json nav (both occurrences) and docs/building/index.mdx Quick Start now route through the decision page.
+
+Cross-links into existing spec pages: lifecycle, idempotency, error handling, RFC 9421 implementation, comply_test_controller, conformance, sandbox, versioning.
+
+Reviewed in flight by DX and docs experts; persona-tested by three builder archetypes (early SSP implementer, greenfield startup builder, SSP product manager) — verdicts: EVALUATE → ADOPT (pilot), ADOPT (conviction tightened), EVALUATE FURTHER → GO to pilot.

--- a/docs.json
+++ b/docs.json
@@ -116,8 +116,12 @@
                       "docs/building/understanding/industry-landscape"
                     ]
                   },
+                  "docs/building/where-to-start",
+                  "docs/building/sdk-stack",
                   "docs/building/schemas-and-sdks",
                   "docs/building/build-an-agent",
+                  "docs/building/migrate-from-hand-rolled",
+                  "docs/building/version-adaptation",
                   "docs/building/get-test-ready",
                   "docs/building/validate-your-agent",
                   "docs/building/grading",
@@ -635,8 +639,12 @@
                   "docs/building/understanding/industry-landscape"
                 ]
               },
+              "docs/building/where-to-start",
+              "docs/building/sdk-stack",
               "docs/building/schemas-and-sdks",
               "docs/building/build-an-agent",
+              "docs/building/migrate-from-hand-rolled",
+              "docs/building/version-adaptation",
               "docs/building/get-test-ready",
               "docs/building/validate-your-agent",
               "docs/building/grading",

--- a/docs/building/index.mdx
+++ b/docs/building/index.mdx
@@ -12,6 +12,10 @@ description: "Build with AdCP: integration guides for MCP and A2A protocols, aut
 
 This section provides everything you need to understand, integrate, and build robust systems with AdCP.
 
+<Note>
+**New here?** Start with [Where to start](/docs/building/where-to-start) — a short decision page that picks the right entry point based on what you're building (caller, agent, or both) and how much of the protocol you want to inherit. The [SDK stack reference](/docs/building/sdk-stack) is the deep-dive on what each layer of an AdCP SDK provides.
+</Note>
+
 ## Learning Path
 
 <CardGroup cols={3}>
@@ -31,6 +35,14 @@ This section provides everything you need to understand, integrate, and build ro
 **Want a coding agent to build it for you?**
 
 - [Build an Agent](/docs/building/build-an-agent) - Point a coding agent at a skill file, get a storyboard-compliant agent in minutes
+
+**Already have a hand-rolled agent in production?**
+
+- [Migrate from a hand-rolled agent](/docs/building/migrate-from-hand-rolled) — incremental swap-one-layer-at-a-time path, with conflict modes, per-step rollback, and intermediate states that pass conformance
+
+**Talking to peers on a different spec version?**
+
+- [Version Adaptation](/docs/building/version-adaptation) — per-call pinning, co-existence imports, on-wire `VERSION_UNSUPPORTED` negotiation
 
 **Already know which protocol you're using?**
 

--- a/docs/building/migrate-from-hand-rolled.mdx
+++ b/docs/building/migrate-from-hand-rolled.mdx
@@ -1,0 +1,224 @@
+---
+title: Migrate from a hand-rolled agent
+sidebarTitle: Migrate from hand-rolled
+description: "Incremental migration path for adopters with a working AdCP agent in production. Inventory step, lowest-risk-first swap order, conflict modes (idempotency, account-mode, webhook signing, state-machine drift), per-step rollback playbook, intermediate states that pass conformance, and when not to migrate."
+"og:title": "AdCP — Migrate from a hand-rolled agent"
+---
+
+This guide is for adopters with a **working AdCP agent in production** who want to move to an official SDK without a flag-day rewrite. Your agent serves real traffic; you have engineers who built the current stack and will defend it; you can't afford a multi-week freeze. The path is incremental — swap one layer at a time, ship after each step, re-certify as you go.
+
+If you're greenfield, you're in the wrong doc — see [Build an Agent](/docs/building/build-an-agent). If you're still deciding whether to migrate at all, see [Where to start, Q3](/docs/building/where-to-start#three-questions-to-pick-your-layer).
+
+## 0. Inventory what you own today
+
+Before swapping anything, write down what your hand-rolled stack provides at each layer of [the AdCP stack](/docs/building/sdk-stack). Use the L0–L3 checklists in that doc as the rubric. Mark each row: *shipped* / *partial* / *not yet*.
+
+This determines order of operations. The lowest-risk swap is usually the layer where you have the **least** coverage today, because there's the least existing behavior to reconcile.
+
+## 1. Get to spec compliance first, before changing any code
+
+Single most important step:
+
+1. Stand up a **mock-mode account** in your agent. (If you don't have the live/sandbox/mock distinction yet, see [Account-mode mismatch](#account-mode-mismatch) below — add the flag at your boundary first.)
+2. Route mock-mode traffic to the reference mock-server.
+3. Run the AdCP storyboards against your agent (see [Conformance](/docs/building/conformance) and [Validate Your Agent](/docs/building/validate-your-agent)).
+4. Read the pass/fail report.
+
+The failure list is your migration backlog, ordered. It converts "I think the SDK adds value" into "here are the storyboards we fail and which L3 component each one points at." Without this step you're buying an SDK based on a sales pitch instead of measured gap.
+
+You may discover you're more conformant than you thought (in which case the migration is smaller than you expected) or less (in which case the case for adopting the SDK strengthens). Either outcome is useful.
+
+## 2. Order of operations (lowest risk first)
+
+Recommended swap order:
+
+1. **Conformance test surface** ([`comply_test_controller`](/docs/building/implementation/comply-test-controller)). Pure additive — mock-mode traffic now goes through the SDK; live traffic untouched. Earns spec-compliance certification on the spot.
+2. **Error code catalog**. Replace your error-envelope construction with the SDK's error builders. Recovery classifications and code precedence (e.g., `NOT_CANCELLABLE` over `INVALID_STATE`) come for free. See [Error handling](/docs/building/implementation/error-handling).
+3. **Idempotency cache**. Riskiest swap — see [Two idempotency caches in series](#two-idempotency-caches-in-series). Spec contract: [Idempotency](/docs/building/implementation/security#idempotency).
+4. **Async-task store + dispatcher**. Adopt the SDK's `task_id` + terminal-artifact contract. Often touches your worker queue. See [Task lifecycle](/docs/building/implementation/task-lifecycle).
+5. **State machines**, one resource at a time. MediaBuy first ([lifecycle reference](/docs/media-buy/media-buys/lifecycle)) if it's where you spend the most maintenance time. Re-run lifecycle storyboards after each.
+6. **Webhook emission** (signed, retried, idempotent). Independent of 1–5; can be parallelized. See [Webhooks](/docs/building/implementation/webhooks).
+7. **RFC 9421 signing + verification**. Independent of everything above; can be parallelized. See [Security implementation](/docs/building/implementation/security).
+8. **Auth / account store**. Last. Your hand-rolled L2 probably encodes business decisions that don't move easily.
+
+You can stop at any step. Adopting at L3 (steps 1–6) without L2 is a perfectly valid endpoint — your auth layer keeps doing what it does, the SDK takes over protocol semantics. See [What you can leave hand-rolled](#5-what-you-can-leave-hand-rolled).
+
+## 3. Conflict modes to watch for
+
+These are the "two stacks fighting each other" failure modes that make incremental migration painful if you don't see them coming.
+
+### Two idempotency caches in series
+
+Your existing cache fields requests at the perimeter; the SDK's cache fields requests at the protocol boundary. Symptoms: same `idempotency_key` returns different envelopes depending on which cache hit first; cross-payload reuse is detected by one and not the other.
+
+**Resolution.** Pick one, retire the other. Usually retire yours — the SDK's enforces the *no-payload-echo* invariant on `IDEMPOTENCY_CONFLICT` (stolen-key read-oracle threat) and the cross-payload conflict detection that the spec mandates. If you need to keep your storage backend (Redis, Postgres), point the SDK's cache contract at it as a custom backend instead of forking the SDK.
+
+### Account-mode mismatch
+
+The SDK distinguishes `live` / `sandbox` / `mock` accounts (see [Sandbox](/docs/media-buy/advanced-topics/sandbox)). If your hand-rolled stack lacks the distinction, mock-mode storyboards may dispatch to live handlers. Symptoms: storyboards mutate production state; conformance certification refuses to dispatch.
+
+**Resolution.** Add the account-mode flag at your boundary before adopting the SDK's conformance controller. The `comply_test_controller` refuses to run against any account that isn't sandbox or mock — that refusal is a feature, not a bug.
+
+### Webhook signature ownership
+
+If both stacks try to sign outbound webhooks, the receiver sees two `Signature` headers (or one wins and the other is silently overwritten by the proxy). Either way, signatures don't verify.
+
+**Resolution.** Pick one signer at the boundary; usually the SDK's, since it tracks key rotation against the public key registry and handles the RFC 9421 canonicalization correctly. Keep your KMS-backed key material; configure the SDK's signing-provider abstraction to use it.
+
+### State machine drift
+
+Your hand-rolled state machine probably has edges the SDK rejects (e.g., direct `pending_creatives → completed` skipping `active`, or `active → canceled` without distinguishing the `NOT_CANCELLABLE` vs `INVALID_STATE` precedence). Symptoms: lifecycle storyboards fail with `INVALID_STATE` where you expected to succeed.
+
+**Resolution.** Run the lifecycle storyboards against your agent *before* swapping the state machine. Reconcile your edge set to the spec — fix obvious bugs, file spec issues for ambiguities. Then swap the SDK's state machine in; it'll enforce what you just hand-converged on.
+
+### Webhook delivery transport
+
+If your queue/worker stack delivers webhooks today, the SDK's emitter would double-deliver if you wire it on without retiring yours. Symptoms: receivers see duplicate idempotency keys with the same payload at slightly different times.
+
+**Resolution.** The SDK builds the envelope; how you ship it is yours. Configure the SDK to hand off to your existing transport instead of running its built-in HTTP delivery — that's the seam.
+
+### Schema validation collisions
+
+If you validate inbound payloads against your own schema bundle, and the SDK validates again at its boundary, you get either duplicate work (cheap) or contradictory verdicts (a real bug — your bundle drifted from the published schemas).
+
+**Resolution.** Retire your local validator after the SDK is in. While both run, treat any discrepancy as your bundle being stale, not the SDK being wrong.
+
+## 4. Intermediate states that pass conformance
+
+After each step, you can re-run mock-mode storyboards and re-certify. You don't need to finish the migration to claim conformance — you only need to pass the storyboards at whatever cut-line the SDK's conformance suite enforces.
+
+| After step | What you have | Conformance status |
+|---|---|---|
+| 1 | Conformance controller wired; agent unchanged | **Spec compliance** (mock-mode storyboards run against your unchanged L3) |
+| 2 | + SDK error envelopes | Same; better recovery semantics |
+| 3 | + SDK idempotency | Same; tighter security on cross-payload reuse |
+| 4 | + SDK async-task contract | Same; uniform task lifecycle |
+| 5 | + SDK state machines | Same; transition validation no longer your problem |
+| 6 | + SDK webhook envelope | Same; signed, retried, dedup-keyed |
+| 7 | + SDK signing | **Live compliance** (when that storyboard set ships) |
+| 8 | + SDK account store | Full L4-on-SDK |
+
+You ship after each step. Production traffic stays up.
+
+### Rollback per step
+
+Every step in the swap order should be reversible inside ~5 minutes. The general pattern: each swap is a **feature-flagged switch between your hand-rolled component and the SDK's**, not a deletion. You ship the swap behind a per-account flag, observe, then flip the default. Rollback is the same flag in the other direction.
+
+What to plan for, swap by swap:
+
+| Step | Revert mechanism | What state may have leaked | First thing to verify on rollback |
+|---|---|---|---|
+| 1. Conformance controller | Disable the SDK route on mock-mode accounts | None — mock-mode is sandbox-only by design | Mock storyboards still pass against your hand-rolled L3 |
+| 2. Error envelopes | Flip back to your error builder | Outbound envelopes from the swap window may carry SDK-shape error codes; downstream consumers that key off your old codes may have logged them | Your error-monitoring dashboard is reading the right envelope shape again |
+| 3. Idempotency cache | Flip back to your cache | **Both caches saw traffic during the swap window.** Same `idempotency_key` may now exist in both stores with different envelopes. After rollback, your cache is authoritative; flush the SDK's cache on revert | No `IDEMPOTENCY_CONFLICT` storms from the dual-cache window |
+| 4. Async-task contract | Flip back to your task store | Outstanding tasks that started under the SDK's contract may have a different terminal-artifact shape than your worker expects | Drain or abort tasks created during the swap window before the revert lands |
+| 5. State machines | Flip back to your state machine | The SDK may have rejected transitions your machine would have accepted (or vice versa). Affected resources are in a state your code may not know how to advance | Run a one-shot reconciliation query: "any resources in a state that's legal under both machines? Any in a state that's only legal under one?" |
+| 6. Webhook envelope | Flip back to your emitter | Receivers got SDK-shape webhooks during the swap window. They may have already acked. Don't re-emit on rollback | Your dedup table accepts both old and new `idempotency_key` shapes (transitional) |
+| 7. RFC 9421 signing | Flip back to your signer | Receivers got SDK-signed webhooks/responses during the window. Their key registry must still resolve your old `keyid` | Your old `keyid` is still published in your JWKS |
+| 8. Account store | Flip back to your store | Account resolution decisions made under the SDK's store may have routed traffic to different tenants than your store would have | Run a reconciliation on accounts that were resolved during the swap window before fully reverting |
+
+### The 2 a.m. production failure
+
+If swap N fails in production at 2 a.m., the on-call recipe:
+
+1. **Flip the per-account flag back** to your hand-rolled component for the affected accounts (or globally if you can't isolate the blast radius). This is the only step required to stop the bleeding.
+2. **Confirm the leakage row** above for that step. Most steps leave residual state somewhere — note what it is so the morning debug doesn't start cold.
+3. **Don't rerun the conformance suite mid-incident.** It runs against mock-mode; production failures are a different signal.
+4. **File the incident against the swap step**, not against the SDK in general. The migration guide's swap-order is the unit of investigation; the SDK's coverage matrix is downstream of that.
+
+**Don't plan for irreversible swaps.** If a step doesn't fit the flag-and-flip pattern (e.g., a destructive schema migration), do it as a separate, named project — not as part of the swap order.
+
+## 5. What you can leave hand-rolled
+
+The SDK is opinionated where the spec is opinionated, and pluggable where it isn't. You don't have to give up your existing infra:
+
+- **Signing provider.** Keep your KMS integration. The SDK accepts a custom signer.
+- **Account store.** Keep your multi-tenant routing. The SDK's account-store interface is the seam.
+- **Idempotency backend.** Keep your Redis / Postgres. The SDK's cache contract is pluggable.
+- **Webhook delivery transport.** Keep your queue. The SDK builds the envelope; how you ship it is yours.
+- **Schema validation library.** Keep your validator if you want; the SDK uses its own at its boundary, not yours.
+
+If your hand-rolled stack has good answers to these, swap them in as **configuration**, not as forks.
+
+## 6. Versioning during the migration
+
+Two version axes you'll be juggling:
+
+- **Spec version of your buyers.** A migration is a great moment to add per-call `adcpVersion` pinning so you stop forking handlers by buyer-version. See [Version Adaptation](/docs/building/version-adaptation).
+- **SDK version.** Don't migrate to a legacy import path as a final state — migrate *through* it. The legacy subpath exists so you can adopt one specialism at a time on the new entry point while the rest stays on the old one. Greenfield code in the same project uses the new framework directly.
+
+### Worked example: two buyers, mid-swap
+
+You're on step 3 (idempotency), buyer A is on AdCP 2.5, buyer B is on AdCP 3.0. You've adopted the SDK's controller, error envelopes, and idempotency cache for the accounts you've cut over. Buyer A is mid-flight to the SDK; buyer B is greenfield on the SDK.
+
+Your inbound side: identify each peer's spec version up front (from the agent registry, the agent card, or the `adcp_version` field if present), pin `adcpVersion` on the agent / per call, and let the SDK adapt the wire shape. Example with `@adcp/sdk`:
+
+```ts
+import { ADCPMultiAgentClient } from '@adcp/sdk';
+
+const buyerA = new ADCPMultiAgentClient([{
+  id: 'buyer-a',
+  agent_uri: 'https://buyer-a.example.com/mcp/',
+  protocol: 'mcp',
+  auth_token: process.env.BUYER_A_TOKEN,
+  adcpVersion: 'v2.5',  // ← per-agent pin, no fork in handlers
+}]);
+
+const buyerB = new ADCPMultiAgentClient([{
+  id: 'buyer-b',
+  agent_uri: 'https://buyer-b.example.com/a2a',
+  protocol: 'a2a',
+  auth_token: process.env.BUYER_B_TOKEN,
+  adcpVersion: '3.0.5', // ← canonical / current
+}]);
+```
+
+Your outbound (server) side, declaring what *you* accept:
+
+```ts
+import { createAdcpServer } from '@adcp/sdk/server';
+
+createAdcpServer({
+  capabilities: {
+    major_versions: [2, 3],
+    supported_versions: ['v2.5', '3.0.5'],
+  },
+  // …handlers, all on the canonical 3.0 shape;
+  // 2.5 callers are translated by adapters at the SDK boundary.
+});
+```
+
+What this looks like for one call from each buyer, mid-step-3:
+
+| | Buyer A (2.5 wire) | Buyer B (3.0 wire) |
+|---|---|---|
+| **Inbound shape** | 2.5 `create_media_buy` | 3.0 `create_media_buy` |
+| **Adapter does** | Translates 2.5 → 3.0 shape | Pass-through |
+| **Your handler sees** | 3.0 typed object | 3.0 typed object (same) |
+| **Idempotency cache** | SDK's (you're on step 3) | SDK's |
+| **Error envelope** | SDK's, translated back to 2.5 on outbound | SDK's |
+| **Outbound shape** | 2.5 (translated by adapter on the way out) | 3.0 |
+
+One handler codebase. Two wire versions. Both buyers see the envelope shape they expect. Adopting `adcpVersion` pinning at step 3 is cheap — most of the version work is in the adapter modules, which the SDK already ships.
+
+If you fall back (rollback step 3 to your hand-rolled cache), buyer A still goes through the SDK's translation adapters — the version machinery and the idempotency machinery are independent. You don't re-fork your handler code on rollback.
+
+## 7. When to *not* migrate
+
+If your agent serves a frozen wire surface for a small set of named buyers and your engineers spend ~zero time on protocol maintenance, the migration ROI is low. Reasonable holds:
+
+- You're on AdCP 2.5, none of your buyers want 3.x, and you're willing to deprecate when they do.
+- Your conformance gap (from step 1) is small enough to fix in place without adopting the SDK.
+- You have a hard regulatory or operational reason for owning every layer end-to-end.
+
+In those cases, do step 1 anyway — route mock-mode through the reference mock-server for spec compliance certification — and revisit the migration question at AdCP 4.0 or when your buyer mix moves.
+
+The migration is for adopters whose **maintenance load is real and growing**. The cost claim ([~3–4 person-months for L0–L3 from scratch](/docs/building/sdk-stack#why-sdks-matter-more-in-adcp-than-in-eg-http)) is what you're *buying back* by adopting incrementally — but only if that maintenance load actually exists.
+
+## See also
+
+- [The AdCP stack](/docs/building/sdk-stack) — layered architecture reference
+- [Where to start](/docs/building/where-to-start) — decision page
+- [Version Adaptation](/docs/building/version-adaptation) — three-mechanism reference
+- [Conformance](/docs/building/conformance) — how the storyboard suite grades your agent
+- [Build an Agent](/docs/building/build-an-agent) — greenfield path; useful as a reference for what the L4-on-SDK end state looks like

--- a/docs/building/sdk-stack.mdx
+++ b/docs/building/sdk-stack.mdx
@@ -1,0 +1,293 @@
+---
+title: The AdCP stack
+sidebarTitle: SDK stack reference
+description: "Layered reference for AdCP implementers. The five layers (L0 wire, L1 signing, L2 auth, L3 protocol semantics, L4 business logic), what each layer contains, what an SDK at each layer should provide, how SDKs absorb version drift, and what 'from scratch' actually signs you up for."
+"og:title": "AdCP — The AdCP stack"
+---
+
+Two audiences keep arriving at the same wrong conclusion:
+
+1. **Early implementers** who built before the SDKs were mature, looked at what the SDK shipped at the time, and decided to roll their own. Most of what the SDKs provide today didn't exist when they made that call — so their mental model of "what an SDK does" is frozen at AdCP 2.5 and a few hundred lines of transport glue.
+2. **New implementers** who say *"I'll build my own AdCP agent from scratch — I don't need an SDK."* AdCP looks like a thin protocol from the outside; from the inside, by the time a buyer's `create_media_buy` reaches business logic, it has crossed five distinct layers of protocol concern, each non-trivial and each governed by a published spec contract.
+
+This page names the layers, says what each one contains, says what an SDK at each layer should provide, says how the SDK absorbs **version drift** (spec version, SDK version, and per-peer version) so adopters don't, and is honest about what *"from scratch"* signs you up for. Audience: AdCP implementers in any language — whether you're building an agent, authoring an SDK, or evaluating one.
+
+## The five layers
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  L4 — Business logic                                        │ ← yours, always
+│  Inventory forecasting, pricing, creative review, upstream  │
+│  ad-server calls (GAM/FreeWheel/Kevel/etc.). The agent's    │
+│  competitive surface — what makes your agent yours.         │
+├─────────────────────────────────────────────────────────────┤
+│  L3 — Protocol semantics                                    │
+│  Lifecycle state machines, idempotency, error code catalog, │ ┐
+│  transition validation (NOT_CANCELLABLE vs INVALID_STATE),  │ │
+│  async-task contract, webhook emission, conformance test    │ │ what an
+│  surface, response envelope shaping.                        │ │ AdCP SDK
+├─────────────────────────────────────────────────────────────┤ │ provides
+│  L2 — Auth & registry                                       │ │
+│  Agent identity verification, brand resolution, AAO bridge, │ │
+│  multi-tenant account resolution, principal scoping,        │ │
+│  sandbox-vs-live account routing.                           │ │
+├─────────────────────────────────────────────────────────────┤ │
+│  L1 — Identity & signing                                    │ │
+│  RFC 9421 HTTP message signatures, public-key registries,   │ │
+│  signature verification, key rotation handling.             │ │
+├─────────────────────────────────────────────────────────────┤ ┘
+│  L0 — Wire & transport                                      │
+│  Bytes on the wire. JSON-over-HTTP framing, MCP message     │
+│  envelopes, A2A SSE streams, JSON schema validation,        │
+│  language-native type generation from the spec.             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### L0 — Wire & transport
+
+What it does: takes protocol bytes off the wire and turns them into typed in-memory values. Schema validation catches malformed payloads at the door.
+
+What's in it:
+
+- HTTP routing (or stdio for MCP-over-stdio).
+- MCP message framing (`tools/call` envelope, JSON-RPC 2.0).
+- A2A SSE event streams.
+- JSON schema validation against the spec's `*.json` files (see [Schemas and SDKs](/docs/building/schemas-and-sdks)).
+- Type generation: producing language-native types from the spec's schemas, so application code is statically checked.
+
+If you only have L0, you have a parser. The buyer's `create_media_buy` is a typed object on your stack — and you have to do everything else yourself.
+
+### L1 — Identity & signing
+
+What it does: cryptographically verifies that the request came from who the headers claim it did, and that the body wasn't modified in transit. See [Security model](/docs/building/understanding/security-model) and the [implementation profile](/docs/building/implementation/security).
+
+What's in it:
+
+- RFC 9421 HTTP message signatures (`Signature-Input`, `Signature` headers).
+- Public-key resolution from agent registries (or operator-published JWKS).
+- Signature verification against the canonicalized request.
+- Replay-window enforcement (`created` / `expires` parameters).
+- Key rotation: handling `keyid` changes without dropping in-flight requests.
+
+If you have L0+L1, you know who's calling you. You still don't know *what* they're allowed to do.
+
+### L2 — Auth & registry
+
+What it does: turns a verified identity into a scoped principal — which buyer, which brand, which advertiser account, which sandbox-vs-live tier. See [Accounts](/docs/accounts/overview) and [Calling an agent](/docs/protocol/calling-an-agent).
+
+What's in it:
+
+- Agent registry lookup (resolving agent metadata from a published [agent card](/docs/protocol/calling-an-agent)).
+- Brand resolution: mapping the requesting agent to a buyer brand / advertiser identity via [Brand Protocol](/docs/brand-protocol).
+- AAO ([AdCP Authorization Object](/docs/aao)) bridge for delegated authority chains.
+- Multi-tenant account resolution: the same wire request maps to different accounts depending on the principal.
+- Sandbox-vs-live account flagging — see [Sandbox](/docs/media-buy/advanced-topics/sandbox).
+- Permission scoping: which AdCP tools this principal is allowed to call.
+
+If you have L0+L1+L2, you have a verified, scoped principal asking to do something. You still don't know if the *something* is legal in the current state.
+
+### L3 — Protocol semantics
+
+What it does: enforces what AdCP *means*. The wire shape is well-formed (L0); the caller is authentic (L1) and authorized (L2); now: is the request legal given the current state of the world?
+
+What's in it:
+
+- **Lifecycle state machines** — `MediaBuy` ([reference](/docs/media-buy/media-buys/lifecycle)), `Creative`, `Account`, `SISession`, `CatalogItem`, `Proposal`, `Audience`. Each with legal edges defined by the spec.
+- **Transition validation** — enforce the legal edges per resource; emit `NOT_CANCELLABLE` for cancel-attempts against a state that forbids it; `INVALID_STATE` for other illegal moves. The cancellation-specific code takes precedence over the generic one whenever the attempted action is a cancel.
+- **Idempotency** — `idempotency_key` required on every mutating tool; same key replays the cached response within TTL; cross-payload reuse fails with `IDEMPOTENCY_CONFLICT` (with no payload echo, per the stolen-key read-oracle threat model). See the [idempotency profile](/docs/building/implementation/security#idempotency).
+- **Error code catalog** — codes with recovery semantics (`transient` / `correctable` / `terminal`). Choosing the right code is part of the spec contract. See [Error handling](/docs/building/implementation/error-handling).
+- **Async-task contract** — tools that don't complete synchronously return a `task_id`; clients poll or receive webhook callbacks; the task's terminal artifact carries the original tool's response shape. See [Task lifecycle](/docs/building/implementation/task-lifecycle).
+- **Webhook emission** — state changes notify subscribed buyers, with retry, idempotency, and signature. See [Webhooks](/docs/building/implementation/webhooks).
+- **Conformance test surface** — `comply_test_controller` (sandbox-only) exposes `seed_*` / `force_*` / `simulate_*` so storyboards can drive state deterministically. See [comply_test_controller](/docs/building/implementation/comply-test-controller) and [Conformance](/docs/building/conformance).
+- **Response envelope** — `context`, `task_id`, `status` field, error envelope shape, `adcp_version` echo, capability advertisement.
+
+If you have L0+L1+L2+L3, you have a complete AdCP protocol implementation. You still haven't done any business logic.
+
+### L4 — Business logic
+
+This is what makes your agent yours.
+
+What's in it:
+
+- Inventory forecasting against your real ad server.
+- Pricing logic, deal terms, contract semantics.
+- Creative review policy (brand safety, format compliance).
+- Upstream calls to GAM / FreeWheel / Kevel / Yahoo / your in-house decisioning engine.
+- Optimization, pacing, fraud detection — anything that differentiates your inventory from a competitor's.
+
+This is the layer an AdCP SDK leaves to you, **and only this layer**.
+
+## What an SDK at each layer should provide
+
+Implementer-facing checklist. An SDK that claims coverage of layer L*n* should expose, at minimum, the primitives below. Adopters use this as a self-evaluation tool when picking an SDK; SDK authors use it as a build target.
+
+### L0 coverage
+
+- Generated language-native types from the published JSON schemas (one type per request/response pair, plus shared resource types).
+- A schema validator wired against the bundled schemas — so adopters can validate inbound and outbound payloads without hand-rolling the schema-loading dance.
+- Transport adapters for at least one of \{MCP, A2A\}; ideally both. These typically wrap upstream protocol SDKs rather than reimplementing them.
+- A schema-bundle accessor that finds the right schema files for the active AdCP version without forcing the adopter to hardcode paths.
+
+### L1 coverage
+
+- RFC 9421 message-signature signing for outbound requests.
+- RFC 9421 verification for inbound requests, including replay-window enforcement on `created` / `expires` and `keyid`-based key lookup.
+- A pluggable signing-provider abstraction: in-process keys for development, KMS / HSM providers for production.
+- Test fixtures or a verifier-test harness so adopters can assert their signing wiring is correct without booting a full agent.
+
+### L2 coverage
+
+- An account-store abstraction that resolves an authenticated principal to a scoped account, with hooks for multi-tenant routing.
+- Authentication primitives for at least API-key and bearer-token shapes, plus a way to compose them.
+- Brand-resolution / agent-registry lookup (or a documented extension point if the SDK doesn't ship it natively).
+- The sandbox-vs-live account flag, enforced at the SDK boundary so the conformance-test surface refuses to dispatch on production accounts.
+
+### L3 coverage
+
+- Lifecycle state-machine graphs for all spec-defined resources, with a transition-assertion primitive that emits the spec-correct error code (`NOT_CANCELLABLE` / `INVALID_STATE` / etc.).
+- Idempotency cache with cross-payload conflict detection and the no-payload-echo invariant on `IDEMPOTENCY_CONFLICT` envelopes.
+- Async-task store + dispatcher: tools opt into async; the SDK returns `task_id`, accepts polling, and emits the terminal artifact.
+- Webhook emitter: signed, retried, idempotent.
+- The conformance test surface (`comply_test_controller`), wired to drive state deterministically when the resolved account is in sandbox or mock mode (and rejected otherwise).
+- Per-resource persistence primitives that handle the spec's echo contracts.
+- Server-construction entry point that ties all of the above together with sane defaults.
+
+### L4 coverage
+
+Out of scope for any SDK. The adopter writes this.
+
+## SDK coverage varies
+
+Different language SDKs cover different subsets of L0–L3. There is no single SDK every implementer must use; what matters is that an implementation reaches the [conformance bar](/docs/building/conformance) at L3, regardless of how much hand-rolling it took to get there.
+
+Within a given language, the full-stack SDK is the default starting point. The layered model in this doc exists to explain what you'd be reimplementing if you went lower (special-purpose proxies, custom-stack integrations) or ported the SDK to a new language — not to suggest there's a meaningful win in starting lower for a typical agent build.
+
+### Current SDK coverage
+
+Snapshot of what each official SDK ships today. Refresh this table on SDK majors and on AdCP spec revs.
+
+*Last updated: 2026-05-03 — `@adcp/sdk` 6.7.0 GA on npm; `adcp` (Python) 4.x in flight; `adcp-go` in active development.*
+
+| SDK | Version | L0 | L1 | L2 | L3 | Adopter writes |
+|---|---|---|---|---|---|---|
+| **`@adcp/sdk`** (TypeScript) — [adcontextprotocol/adcp-client](https://github.com/adcontextprotocol/adcp-client) | 6.7.0 GA | ✅ | ✅ | ✅ | ✅ | L4 only |
+| **`adcp`** (Python) — [adcontextprotocol/adcp-client-python](https://github.com/adcontextprotocol/adcp-client-python) | 4.x in flight | ✅ | ⚠️ | ⚠️ | ⚠️ | Row to refresh on 4.0 GA |
+| **`adcp-go`** — [adcontextprotocol/adcp-go](https://github.com/adcontextprotocol/adcp-go) | dev | ⚠️ | ❌ | ❌ | ❌ | Types + transport only today; L1–L3 in scope |
+
+Legend: ✅ shipped · ⚠️ partial / in flight · ❌ not yet covered.
+
+What "shipped" means at each layer is the L0–L3 checklist above — these rows should not claim ✅ until every checklist item is satisfied in the published SDK build. For coverage detail beyond this snapshot, see each SDK's repo.
+
+For shape comparison purposes, here are the three coverage archetypes an SDK can land in regardless of language:
+
+| Archetype | L0 | L1 | L2 | L3 | Adopter writes |
+|---|---|---|---|---|---|
+| Full-stack SDK | ✅ | ✅ | ✅ | ✅ | L4 only |
+| Transport + signing only | ✅ | ✅ | ⚠️ | ❌ | L2 + L3 + L4 |
+| Types-only / generated bindings | ✅ | ❌ | ❌ | ❌ | L1 + L2 + L3 + L4 |
+
+The choice is a tradeoff between leverage and control. A full-stack SDK ships you the most code for free but couples you to its choices. A transport-only SDK gives you maximum control but signs you up for months of L1–L3 work before you can certify. Most production adopters want the full stack with the option to swap individual layers (custom signing provider, custom account store, custom idempotency backend) — which a well-architected full-stack SDK exposes as configuration, not as a fork.
+
+## Where can you start?
+
+You can implement at any layer. The lower you start, the more you build.
+
+| Starting layer | What you write | What's done for you |
+|---|---|---|
+| L0 (from scratch) | All five layers | Nothing |
+| L1 (you have a JSON-over-HTTP toolkit) | L1+L2+L3+L4 | L0 (parser, schema validation) |
+| L2 (you have HTTP signatures via a library) | L2+L3+L4 | L0+L1 |
+| L3 (you have an auth/registry library) | L3+L4 | L0+L1+L2 |
+| L4 (you use a full-stack AdCP SDK) | L4 only | L0+L1+L2+L3 |
+
+A full-stack AdCP SDK lifts you to L4. You implement upstream calls. The SDK threads the protocol envelope around them. Pick one if your team's value-add is L4 differentiation; build lower if you have a specific reason — and budget for the L1–L3 scope honestly.
+
+See [Where to start](/docs/building/where-to-start) for a short decision page that picks an entry point based on what you're building.
+
+## Why SDKs matter more in AdCP than in (e.g.) HTTP
+
+A common comparison: *"HTTP is a protocol. People build HTTP servers from scratch all the time. Why would AdCP be different?"*
+
+The answer is layer L3. HTTP's protocol semantics are minimal — methods, status codes, headers. A from-scratch HTTP server can ship in a weekend with an off-the-shelf parser.
+
+AdCP's L3 is large:
+
+- **State machines** — 7 resource types with published lifecycle graphs.
+- **Async tasks** — every mutating tool can be sync or async; the contract for which terminal artifact closes the task is non-trivial.
+- **Idempotency** — cache, replay, conflict, TTL — all wired correctly.
+- **Error catalog** — codes with recovery classification. Picking the wrong one fails [conformance](/docs/building/conformance).
+- **Conformance test surface** — storyboards drive your state via the [`comply_test_controller`](/docs/building/implementation/comply-test-controller) tool. You ship a non-trivial controller surface.
+- **Webhook emission** — signed, retried, idempotent.
+
+A from-scratch AdCP agent is **~3–4 person-months of L3 work alone**, before any L4 differentiation. The breakdown, for one senior engineer to a mock-mode conformance bar, is roughly:
+
+| L3 component | Honest estimate |
+|---|---|
+| 7 lifecycle state machines (define edges, validate transitions, emit the right `NOT_CANCELLABLE` / `INVALID_STATE` codes) | ~1 week each = **6–7 weeks** |
+| Idempotency cache (cross-payload conflict detection + no-payload-echo invariant) | **1 week** |
+| Async-task store + dispatcher (correct terminal-artifact contract per tool) | **1–2 weeks** |
+| Error-code catalog wiring (recovery classification, code precedence) | **1–2 weeks** |
+| `comply_test_controller` conformance surface (`seed_*` / `force_*` / `simulate_*`) | **1–2 weeks** |
+| Webhook emission (signed, retried, idempotent, dedup-keyed) | **1 week** |
+| RFC 9421 signing + verification + replay-window + key rotation (counted separately as L1, but commonly bundled in the same scope) | **2–3 weeks** |
+| Integration, conformance debugging, spec re-reading | **2–3 weeks** |
+
+That's **~14–18 weeks**, depending on team familiarity with HTTP message-signatures and lifecycle modeling. The estimate **excludes version-adaptation work** — every spec rev that adds a tool, an edge, or an error code adds rows to a translation matrix you carry forever. SDK adopters get those for free; from-scratch implementers pay them every release.
+
+Most teams that say *"I'll build from scratch"* count the wire shape (L0) and underestimate L3 by an order of magnitude.
+
+## Version adaptation
+
+Three "version" axes move at the same time, and an SDK's job is to keep them from colliding inside your business logic:
+
+| Axis | Example | What changes when it moves |
+|---|---|---|
+| **Spec version** | AdCP `2.5 → 3.0.5 → 3.1` | Wire shapes, error codes, lifecycle states, new tools |
+| **SDK version** | SDK `5.x → 6.x` | API surface, ergonomics, compile-time guarantees |
+| **Peer version (per call)** | Buyer at v3.0, seller at v2.5 | A single conversation crosses versions; payloads need translation |
+
+A from-scratch agent has to handle all three by hand. SDKs ship three concrete mechanisms so adopters don't:
+
+1. **Per-call spec-version pinning.** Set `adcpVersion` (or the language equivalent) on an agent; the SDK runs requests and responses through adapter modules so handler code stays on the canonical (current) shape regardless of what the peer speaks.
+2. **SDK-major migration via co-existence imports.** Bumping an SDK major doesn't force a same-day rewrite — the prior major's surface remains available alongside the new entry point. Migrate one specialism at a time.
+3. **Wire-level negotiation.** Every request carries `adcp_major_version`; servers declare what they support and return `VERSION_UNSUPPORTED` (a recovery-classified error) if the caller is out of range.
+
+Code-level recipes per mechanism live in [Version Adaptation](/docs/building/version-adaptation). For the spec-side rules, see [Versioning](/docs/reference/versioning).
+
+### Why this matters
+
+Versioning in AdCP is **continuous, not episodic**. Once 3.1 ships, you'll be talking to 3.0 and 3.1 callers simultaneously, indefinitely. Without translation adapters this is a fork in your codebase. With them it's a constructor flag.
+
+The spec itself has already done one of these crossings. **2.5 → 3.0** added mandatory idempotency, the [`comply_test_controller`](/docs/building/implementation/comply-test-controller) conformance surface, published lifecycle state machines, RFC 9421 signatures as a baseline, and an expanded error catalog with recovery classifications. A from-scratch 2.5 agent was tractable; a from-scratch 3.0 agent is the [~3–4 person-month L3 build](#why-sdks-matter-more-in-adcp-than-in-eg-http) decomposed above.
+
+The from-scratch path that worked for 2.5 doesn't scale to 3.0, and 3.0 isn't where the spec stops. SDKs exist because L3 grew faster than implementers could hand-roll, and the version-adaptation surface keeps growing each release.
+
+## What early implementers underestimate
+
+Rough order of pain, for adopters who built before the SDKs covered much:
+
+1. **L3 is most of the work.** State machines, idempotency, error catalog, async tasks — ~3–4 person-months before any L4 differentiation. See the [decomposition](#why-sdks-matter-more-in-adcp-than-in-eg-http) for per-component weeks.
+2. **Conformance is L3-driven.** Storyboards probe state transitions and error shapes (see [Conformance](/docs/building/conformance)). Without an SDK's transition validators you re-derive the spec from test failures.
+3. **Versioning compounds.** Each spec rev that adds a tool, a lifecycle edge, or an error code is a new translation row your adapters carry. Bypassing the SDK means owning that matrix forever.
+4. **RFC 9421 + key rotation is its own project.** Signing providers, KMS integration, replay windows — none of which moves the needle on your L4 differentiation.
+5. **The mock-server is shared infrastructure.** SDKs wire mock-mode dispatch to it for free. Hand-rolled implementations either skip mock-mode (and lose spec-compliance certification) or rebuild it.
+
+If you built early, the honest move is to re-evaluate the SDKs against this list — not against the version you remember. The [migration guide](/docs/building/migrate-from-hand-rolled) walks the swap-one-layer-at-a-time path: which layer to swap first, what conflict modes to watch for, and which intermediate states still pass conformance.
+
+## What this means for compliance
+
+Two kinds of compliance, both shaped by the layered model:
+
+- **Spec compliance (L3 protocol test)** — does the implementation satisfy the AdCP wire contract? Storyboards walk the state machines, exercise the error codes, test the async-task contract. The adopter's upstream is irrelevant. Runs against **mock-mode** accounts: the agent forwards every tool call to the reference mock-server. This certifies the SDK's (or hand-rolled implementation's) L3 layer.
+- **Live compliance (full-stack test, planned)** — does the actually deployed agent (adopter's L4 code against their test infra) behave correctly under storyboards end-to-end? Runs against **sandbox-mode** accounts: the adopter's code path is exercised, not the mock. This certifies that L0–L3 plus the adopter's upstream combined produce the right wire behavior.
+
+The reference mock-server is the **spec-compliance oracle** — a black-box AdCP agent that storyboards run against. All language SDKs forward mock-mode traffic to it over HTTP, so the reference path is shared across the ecosystem. The mock-server is SDK-independent: a hand-rolled L0–L3 implementation can pass spec compliance by routing its own mock-flavored accounts to the same mock-server and verifying storyboard pass/fail against its own L3 wire behavior.
+
+## TL;DR
+
+- AdCP has five layers; the spec lives at L0–L3, your agent lives at L4.
+- "From scratch" means implementing L0–L3 yourself. That's a lot — see the [per-component breakdown](#why-sdks-matter-more-in-adcp-than-in-eg-http).
+- A full-stack AdCP SDK lifts you to L4. You write business logic; the SDK handles the protocol. Different language SDKs cover different subsets of L0–L3; pick one that matches how much of the protocol you want to inherit — see the [coverage matrix](#current-sdk-coverage).
+- **Version adaptation is an SDK feature, not an adopter project.** Per-call spec-version adapters, co-existence imports across SDK majors, and on-wire `adcp_major_version` negotiation let you talk to peers on any supported version without forking your handlers. Hand-rolled agents inherit the entire translation matrix forever.
+- Compliance comes in two flavors: **spec compliance** (mock-mode, protocol-only, L3 reference test) and **live compliance** (sandbox-mode, full-stack, L0–L4 end-to-end; planned).
+- If you built before the SDKs were mature, the value of staying hand-rolled is now measured against today's SDKs, not the ones you evaluated in 2.5.

--- a/docs/building/sdk-stack.mdx
+++ b/docs/building/sdk-stack.mdx
@@ -5,6 +5,10 @@ description: "Layered reference for AdCP implementers. The five layers (L0 wire,
 "og:title": "AdCP — The AdCP stack"
 ---
 
+<Note>
+**AdCP is the transaction and control plane** — planning, deal creation, creative submission, reporting. Impression-time decisioning happens in adjacent protocols ([TMP](/docs/trusted-match), RTB, VAST). AdCP latency budgets are seconds, often async-by-design — not the millisecond budgets you'd expect from a serve-time protocol. If you came here looking for a serve-time auction surface, you want [TMP](/docs/trusted-match).
+</Note>
+
 Two audiences keep arriving at the same wrong conclusion:
 
 1. **Early implementers** who built before the SDKs were mature, looked at what the SDK shipped at the time, and decided to roll their own. Most of what the SDKs provide today didn't exist when they made that call — so their mental model of "what an SDK does" is frozen at AdCP 2.5 and a few hundred lines of transport glue.
@@ -186,6 +190,17 @@ For shape comparison purposes, here are the three coverage archetypes an SDK can
 | Transport + signing only | ✅ | ✅ | ⚠️ | ❌ | L2 + L3 + L4 |
 | Types-only / generated bindings | ✅ | ❌ | ❌ | ❌ | L1 + L2 + L3 + L4 |
 
+### Hosted implementations
+
+Different shape from an SDK: a **deployable agent** you run rather than a library you import. Adopters configure rather than code. Useful when you want an AdCP surface in front of an existing system without writing handler code yourself.
+
+| Implementation | Maintainer | Stack | Notes |
+|---|---|---|---|
+| **AdCP mock-server** | spec maintainers | Reference | The black-box AdCP agent storyboards run against. All language SDKs forward mock-mode traffic to it; shared infrastructure for [spec compliance](/docs/building/conformance). |
+| **Prebid SalesAgent** | [Prebid community](https://github.com/prebid/prebid-server) | Python | Open-source seller-side AdCP agent. Publishers run it as their AdCP-facing implementation; hand-rolled at L0–L3 today, evolving alongside the official SDKs. |
+
+Hosted implementations satisfy the same L3 conformance bar that SDKs do — the spec is implementation-agnostic. The difference is operational shape: a hosted implementation is a service you deploy and configure, an SDK is code you compile into your own service.
+
 The choice is a tradeoff between leverage and control. A full-stack SDK ships you the most code for free but couples you to its choices. A transport-only SDK gives you maximum control but signs you up for months of L1–L3 work before you can certify. Most production adopters want the full stack with the option to swap individual layers (custom signing provider, custom account store, custom idempotency backend) — which a well-architected full-stack SDK exposes as configuration, not as a fork.
 
 ## Where can you start?
@@ -233,6 +248,8 @@ A from-scratch AdCP agent is **~3–4 person-months of L3 work alone**, before a
 | Integration, conformance debugging, spec re-reading | **2–3 weeks** |
 
 That's **~14–18 weeks**, depending on team familiarity with HTTP message-signatures and lifecycle modeling. The estimate **excludes version-adaptation work** — every spec rev that adds a tool, an edge, or an error code adds rows to a translation matrix you carry forever. SDK adopters get those for free; from-scratch implementers pay them every release.
+
+This is a single-engineer-to-mock-conformance estimate. **At publisher / large-platform scale, multiply by ~2× to ~3×** for SRE, security review, KMS / HSM integration with existing key infrastructure, load testing, and on-call burden — none of which is L3 spec work, all of which is real cost before the surface is production-grade.
 
 Most teams that say *"I'll build from scratch"* count the wire shape (L0) and underestimate L3 by an order of magnitude.
 

--- a/docs/building/version-adaptation.mdx
+++ b/docs/building/version-adaptation.mdx
@@ -1,0 +1,186 @@
+---
+title: Version Adaptation
+sidebarTitle: Version Adaptation
+description: "Three version axes move at the same time when you ship an AdCP agent — spec version, SDK version, and per-peer version. SDKs ship three concrete mechanisms (per-call pinning, co-existence imports, on-wire negotiation) so adopters don't carry the translation matrix in handler code."
+"og:title": "AdCP — Version Adaptation"
+---
+
+Three versions move at the same time when you ship an AdCP agent or client:
+
+| Axis | Example | What changes |
+|---|---|---|
+| **Spec version** | AdCP `2.5 → 3.0.5 → 3.1` | Wire shapes, error codes, lifecycle states, new tools |
+| **SDK version** | SDK `5.x → 6.x` | API surface, ergonomics, compile-time guarantees |
+| **Peer version** (per call) | Buyer at v3.0, seller at v2.5 | A single conversation crosses versions |
+
+Official SDKs ship three concrete mechanisms so adopters don't carry the translation matrix in handler code. This page is the recipe per mechanism. For the conceptual background see the [SDK stack — Version adaptation section](/docs/building/sdk-stack#version-adaptation). For the spec-side rules see [Versioning](/docs/reference/versioning).
+
+## Mechanism 1 — Pin the spec version per call
+
+Use this when you're a **client** talking to a peer that's pinned to an older (or newer beta) spec version. The SDK runs your request and the peer's response through adapter modules so your handler code stays on the canonical (current) shape.
+
+### Pin the version on a single agent
+
+JavaScript / TypeScript (`@adcp/sdk`):
+
+```ts
+import { ADCPMultiAgentClient } from '@adcp/sdk';
+
+const client = ADCPMultiAgentClient.simple(
+  'https://legacy-agent.example.com/mcp/',
+  {
+    authToken: process.env.AGENT_TOKEN,
+    adcpVersion: 'v2.5', // ← pin here
+  },
+);
+
+const agent = client.agent('default-agent');
+const result = await agent.getProducts({ brief: 'CTV inventory' });
+```
+
+Python and Go SDKs expose the same mechanism under their idiomatic call sites — see each SDK's repo. The shape is consistent: per-agent or per-call version pin, validated at construction time, with adapter modules translating to/from the canonical shape transparently.
+
+### Validate the version up front
+
+`adcpVersion` (or the language equivalent) is validated at construction time. The SDK only accepts versions whose **schema bundle ships with the build** — if the bundle isn't present (e.g., you pinned a beta channel that hasn't been synced into your installed SDK), construction throws a typed configuration error with a pointer to the schema-sync tooling.
+
+To see what your installed SDK actually has bundled, query the SDK's compatibility-list export — every official SDK exposes one. For the spec-side authoritative list of what each AdCP version means on the wire, see [`schemas/`](https://github.com/adcontextprotocol/adcp/tree/main/dist/schemas).
+
+### What the adapters actually do
+
+Each SDK ships per-tool adapter modules — pure shape translations (field renames, default population, structural reshaping). The SDK applies them transparently when the version pin is set; your handler sees the current shape regardless of which version the peer speaks.
+
+When AdCP 3.1 ships and you bump the SDK, a new adapter folder appears for the now-legacy 3.0. Your handlers don't move.
+
+## Mechanism 2 — Migrate SDK majors via co-existence
+
+Use this when you bump your SDK from one major to the next and don't want to rewrite every handler the day you upgrade. Each SDK keeps the prior major's surface available alongside the new entry point.
+
+### Example: `@adcp/sdk` 5.x → 6.x
+
+In v6.0, the v5 entry point was hard-removed from the top-level export. Existing v5 code keeps working by swapping one import path:
+
+```ts
+// v5 code — change only the import path
+import { createAdcpServer } from '@adcp/sdk/server/legacy/v5';
+
+serve(() => createAdcpServer({
+  name: 'My Agent',
+  version: '1.0.0',
+  // …existing v5 handler bag — unchanged
+}));
+```
+
+Greenfield code in the same project uses the v6 entry point side by side:
+
+```ts
+import { createAdcpServerFromPlatform } from '@adcp/sdk/server';
+
+const platform = new MyPlatform(); // implements DecisioningPlatform
+const server = createAdcpServerFromPlatform(platform, {
+  name: 'my-agent',
+  version: '1.0.0',
+});
+```
+
+Both compile, both run, both pass conformance. You migrate one handler — or one specialism — at a time. The legacy subpath is a documented co-existence path, not a deprecation warning.
+
+Other-language SDKs follow the same pattern: prior-major surfaces remain importable from a versioned subpath alongside the current entry point. Check each SDK's release notes for the specific import paths.
+
+### When to actually migrate
+
+Stay on the legacy surface as long as it keeps compiling and passing [conformance](/docs/building/conformance). Migrate a specialism when you want the new features (compile-time specialism enforcement, capability projection, idempotency / signing / async-task / status-normalization pre-wiring on greenfield code). There's no rush.
+
+## Mechanism 3 — Wire-level negotiation
+
+Use this when you're a **server** and you want to be explicit about which spec versions you accept.
+
+### Declare what you support
+
+`supported_versions` (release-precision strings) and/or `major_versions` go on your agent's capability declaration. Use release-precision strings — `'3.0.5'`, `'3.1.0'` — not the legacy aliases (`'v2.5'`, `'v3'`) used for client-side pinning. A 3.x server with no v2.5 handler logic should not declare `'v2.5'` here — its 2.5 callers go through *client-side* adapters at the buyer end, not the server's accepted-version set.
+
+Example with `@adcp/sdk` (lower-level handler-bag API):
+
+```ts
+import { createAdcpServer } from '@adcp/sdk/server';
+
+const server = createAdcpServer({
+  name: 'My Agent',
+  version: '1.0.0',
+  capabilities: {
+    major_versions: [3],
+    supported_versions: ['3.0.5', '3.1.0'],
+    // …other capability fields
+  },
+  // …handlers
+});
+```
+
+The union of `supported_versions` (parsed to majors) and `major_versions` defines the seller's accepted set on inbound `adcp_major_version` / `adcp_version` claims. See [Versioning — version negotiation](/docs/reference/versioning#version-negotiation) for the spec rules and the bidirectional negotiation flow introduced in 3.1.
+
+### What happens on a mismatch
+
+If a buyer's request carries an `adcp_major_version` (or `adcp_version`) that isn't in the accepted set, the SDK returns a `VERSION_UNSUPPORTED` error envelope. The envelope echoes the seller's `supported_versions` so the buyer can downgrade their pin without an out-of-band lookup. See [VERSION_UNSUPPORTED error data](/docs/reference/versioning#version-unsupported-error-data) for the envelope shape.
+
+### Buyer side: two surfaces
+
+There are two places version mismatch can surface on the client, and they fire in different conditions:
+
+**1. Pre-flight typed exception.** When the client already has the peer's capabilities cached and knows up front that the call won't go through, the SDK throws a typed `VersionUnsupportedError` (or language equivalent) *before* sending the request. Catch it from the call site:
+
+```ts
+import { VersionUnsupportedError } from '@adcp/sdk';
+
+try {
+  const result = await agent.getProducts({ brief: '…' });
+} catch (err) {
+  if (err instanceof VersionUnsupportedError) {
+    // peer doesn't support this call at the pinned version —
+    // re-pin adcpVersion or switch agents
+  }
+  throw err;
+}
+```
+
+**2. `VERSION_UNSUPPORTED` envelope from the wire.** When the mismatch is only detected on the server side (e.g., the buyer's `adcp_major_version` parses different than the buyer's `adcp_version` string), the response carries a typed `VERSION_UNSUPPORTED` error envelope that echoes the seller's `supported_versions`:
+
+```ts
+const result = await agent.getProducts({ brief: '…' });
+
+if (!result.success && result.adcpError?.code === 'VERSION_UNSUPPORTED') {
+  const supported = result.adcpError.details?.supported_versions ?? [];
+  // pick a version you also support, then re-issue with adcpVersion pinned
+}
+```
+
+`VERSION_UNSUPPORTED` is recovery-classified `correctable` — clients that handle it programmatically retry against a supported version.
+
+This is the third mechanism rather than a fallback to the first: negotiation tells you *what's possible*; per-call pinning tells the SDK *which one to use*.
+
+## Putting it together
+
+A typical multi-version production setup:
+
+1. **Server**: declare `supported_versions: ['3.0.5', '3.1.0']` in capabilities. The SDK accepts both on the wire and returns `VERSION_UNSUPPORTED` to anyone outside the set. (Only declare a version your handlers actually satisfy.)
+2. **Client (per peer)**: pin `adcpVersion` (e.g., `'v2.5'`) based on what the registry or peer's capabilities advertise. The client-side adapters translate the wire shape so your application code stays on the current spec.
+3. **SDK upgrades**: bump the SDK on your schedule; switch to the new entry point per specialism over time; keep the rest on the legacy import until you're ready.
+
+The combined effect: **one handler codebase, three version axes, no fork.**
+
+## What this saves you from building
+
+A from-scratch agent has to:
+
+- Maintain a translation matrix between every spec version it claims to support, and update it every time a release ships.
+- Hand-roll API stability across its own internal refactors.
+- Implement the negotiation handshake (`adcp_major_version` parsing, `adcp_version` cross-checks, `VERSION_UNSUPPORTED` envelope shaping with the supported-versions echo).
+- Keep its conformance test surface in sync as new versions ship.
+
+Each of these compounds at every spec revision. SDKs absorb them so your team's effort goes into L4 differentiation, not into versioning plumbing.
+
+## See also
+
+- [The AdCP stack](/docs/building/sdk-stack) — layered architecture reference
+- [Where to start](/docs/building/where-to-start) — decision page
+- [Versioning](/docs/reference/versioning) — spec-side version rules
+- [Migrate from a hand-rolled agent](/docs/building/migrate-from-hand-rolled) — when adopting a stack with mid-flight buyers on different spec versions

--- a/docs/building/where-to-start.mdx
+++ b/docs/building/where-to-start.mdx
@@ -1,0 +1,72 @@
+---
+title: Where to start
+sidebarTitle: Where to start
+description: "Decision page for AdCP implementers. Pick the right entry point — caller, agent, or SDK author — based on what you're building and how much of the protocol you want to inherit. Three questions, recommended path, and a 'what you give up by going lower' cost table."
+"og:title": "AdCP — Where to start"
+---
+
+You're about to write AdCP code. Before picking a tutorial, answer this: **how much of the protocol do you want to inherit, and how much do you want to write yourself?**
+
+This page is the decision. The [SDK stack reference](/docs/building/sdk-stack) is the reasoning. [Build an Agent](/docs/building/build-an-agent) and [Schemas and SDKs](/docs/building/schemas-and-sdks) are the next clicks once you've chosen.
+
+## The five layers, in one paragraph
+
+Every AdCP request crosses five layers between the wire and your business logic:
+
+- **L0** — wire: bytes, JSON, schema validation, type generation.
+- **L1** — signing: RFC 9421 message signatures, key rotation.
+- **L2** — auth & registry: principal resolution, multi-tenant routing.
+- **L3** — protocol semantics: lifecycle state machines, idempotency, error catalog, async tasks, conformance test surface, webhooks.
+- **L4** — your business logic: inventory, pricing, creative review, upstream ad-server calls.
+
+A full-stack SDK ships L0–L3 and leaves L4 to you. Picking a starting layer = picking how much of L0–L3 you take on yourself.
+
+## Where can you start?
+
+You can enter at any layer. The lower you start, the more of the protocol you write yourself — [see the layer table](/docs/building/sdk-stack#where-can-you-start) for the full breakdown of "what you write vs. what's done for you" at each entry point.
+
+A from-scratch L0 → L3 build is roughly **3–4 person-months** before any L4 differentiation — [see the per-component breakdown](/docs/building/sdk-stack#why-sdks-matter-more-in-adcp-than-in-eg-http) — and that scope grows every time the spec revs. Within a given language, the full-stack SDK is the default entry point; the layered model exists to explain what you'd be reimplementing if you went lower or ported to a new language.
+
+## Three questions to pick your layer
+
+**1. Are you building a caller, an agent, or both?**
+
+- **Caller only** (a buyer-side app calling existing agents) → start at L4 with [Calling an agent](/docs/protocol/calling-an-agent) and the [Schemas and SDKs](/docs/building/schemas-and-sdks) overview. The client API is small; you don't own L1–L3 at all.
+- **Agent (server)** → keep reading; the rest of this page is for you.
+- **Both** → start with the agent decision below; the client side is additive.
+
+**2. What's your team's value-add?**
+
+- **Inventory, pricing, creative review, decisioning** (i.e., L4) → start at L4. Your competitive surface is what you build on top of the protocol, not the protocol itself. → [Build an Agent](/docs/building/build-an-agent).
+- **You are an SDK author / language porter, building a special-purpose proxy, or integrating into a stack that already owns L0–L2** → start lower and build up. The [SDK stack reference](/docs/building/sdk-stack) tells you what each layer must provide.
+- **Anything else** → start at L4. Going lower is rarely the win it looks like — see [what you give up](#what-you-give-up-by-going-lower) for the concrete scope. If you can name a specific reason to go lower, go ahead; otherwise default to L4 and reach down only when you hit a wall you can name.
+
+**3. Do you already have a working agent built before the SDKs were mature?**
+
+If yes: re-evaluate against [today's SDK coverage](/docs/building/sdk-stack#current-sdk-coverage), not the SDK you remember. Most of L3 (lifecycle state machines, idempotency, the conformance test surface, RFC 9421 baseline, expanded error catalog) was added with AdCP 3.0. Hand-rolled 2.5 agents inherit the entire delta — and the [version-adaptation surface](/docs/building/version-adaptation) that lets a 3.x agent talk to a 2.5 caller without forking handler code. The [migration guide](/docs/building/migrate-from-hand-rolled) walks the swap-one-layer-at-a-time path: which layer to swap first, what conflict modes to watch for (idempotency, account-mode, webhook signing), and which intermediate states still pass [conformance](/docs/building/conformance).
+
+## Recommended path
+
+For ~95% of adopters: **start at L4 with the full-stack SDK in your language.**
+
+- New agent → [Build an Agent](/docs/building/build-an-agent).
+- New caller → [Calling an agent](/docs/protocol/calling-an-agent) + [Schemas and SDKs](/docs/building/schemas-and-sdks).
+- **Already have a hand-rolled agent in production →** [Migrate from a hand-rolled agent](/docs/building/migrate-from-hand-rolled).
+- Talking to peers on a different spec version → [Version Adaptation](/docs/building/version-adaptation).
+
+For the small set of adopters going lower (porting an SDK to a new language, building a special-purpose proxy, integrating into an existing stack that owns L0–L2 already): start with the [SDK stack reference](/docs/building/sdk-stack) — it's the reference for what each layer must satisfy to reach the [conformance bar](/docs/building/conformance).
+
+## What you give up by going lower
+
+| You skip | Cost |
+|---|---|
+| L0 (use a generic JSON toolkit) | Hand-roll the schema validation matrix, the MCP/A2A transport adapters, the per-version type bundles. ~weeks. |
+| L1 (use a generic crypto library) | Build the RFC 9421 canonicalization, replay-window enforcement, key-rotation handling, KMS integration. ~month. |
+| L2 (own your own auth) | Build principal resolution, brand resolution, sandbox/live routing, account scoping. ~month. |
+| L3 (own protocol semantics) | Build seven lifecycle state machines with legal-edge enforcement, idempotency cache with cross-payload conflict detection, async-task store + dispatcher, webhook emitter, the [`comply_test_controller`](/docs/building/implementation/comply-test-controller) conformance surface, and pick the right error code for every failure mode. **Most of the SDK's value is here.** ~3 months minimum. |
+
+L4 is yours regardless of where you start. The choice is how much of L0–L3 you want to own forever, including the version-adaptation work each new spec rev brings.
+
+## Still not sure?
+
+Read [the SDK stack reference](/docs/building/sdk-stack). It walks each layer end-to-end, names what an SDK at each layer must provide, and covers the version-adaptation model in detail. Then come back here and pick a starting layer.


### PR DESCRIPTION
## Summary

Adds four pages to `docs/building/` that orient AdCP adopters around how much of L0–L3 they inherit from an SDK vs. write themselves. Targets two recurring wrong conclusions:

1. **Early implementers** who built before the SDKs were mature and have a frozen-in-time picture of "what an SDK does." Most of L3 (lifecycle state machines, idempotency, conformance test surface, RFC 9421, expanded error catalog) was added with AdCP 3.0.
2. **New implementers** who treat AdCP as a thin protocol and don't see the L0–L3 scope.

## What's in it

**Four new pages** (all language-agnostic; cross-link into the spec):

- **`docs/building/sdk-stack.mdx`** — L0–L4 layered reference. Each layer: what it does, what's in it, what an SDK at that layer should provide, what you give up by skipping it. Includes the **live SDK coverage matrix** (`@adcp/sdk` 6.7.0 GA, Python `adcp` 4.x in flight, `adcp-go` in active dev), **per-component cost decomposition** (~14–18 weeks for one senior eng to mock-mode conformance), and the "what early implementers underestimate" punch list.
- **`docs/building/where-to-start.mdx`** — short decision page. Three questions (caller vs. agent / value-add / pre-existing hand-rolled), recommended path for ~95% of adopters, "what you give up by going lower" cost table.
- **`docs/building/version-adaptation.mdx`** — code-level recipes for the three version-handling mechanisms:
  1. Per-call `adcpVersion` pinning + bundle-gated runtime acceptance
  2. SDK-major co-existence imports (`@adcp/sdk/server/legacy/v5` and equivalents)
  3. Wire-level `supported_versions` declaration with `VERSION_UNSUPPORTED` envelope and typed pre-flight throw
- **`docs/building/migrate-from-hand-rolled.mdx`** — eight-section incremental migration guide for adopters with a working agent in production. Inventory step, lowest-risk-first swap order, **six conflict modes** (idempotency, account-mode, webhook signing, state-machine drift, webhook transport, schema validation), **per-step rollback playbook** with 2 a.m. on-call recipe, multi-buyer worked example, intermediate conformance states, when-not-to-migrate.

**Wiring:**

- `docs.json` navigation: entries added in both top-level occurrences.
- `docs/building/index.mdx`: top-of-page callout to where-to-start; Quick Start now routes hand-rolled adopters and multi-version peers.

Cross-links to existing spec pages: [lifecycle](/docs/media-buy/media-buys/lifecycle), [idempotency](/docs/building/implementation/security#idempotency), [error handling](/docs/building/implementation/error-handling), [RFC 9421](/docs/building/implementation/security), [comply_test_controller](/docs/building/implementation/comply-test-controller), [conformance](/docs/building/conformance), [sandbox](/docs/media-buy/advanced-topics/sandbox), [versioning](/docs/reference/versioning).

## Reviewed by

- **DX expert** + **docs expert** in flight: caught signature/semantics errors in code samples, redundant tables, the broken `protocol-overview.md` link, the "no single SDK" / "95% start at L4" tone tension. All addressed.
- **Three builder personas** walked the doc set as their archetype:
  - *Early implementer (frozen-at-2.5 SSP eng):* EVALUATE → **ADOPT** (pilot steps 1–2 next sprint). Moved by storyboard-as-backlog framing, no-payload-echo security argument, and the "you can stop at step 6" exit clause.
  - *Greenfield builder (skeptical staff eng):* ADOPT → **ADOPT, conviction tightened.** Cost decomposition closed the "trust me" gap.
  - *SSP product manager:* EVALUATE FURTHER → **GO to pilot.** Migration guide §5 ("what you can leave hand-rolled") killed the eng-leads-will-say-we-lose-flexibility objection.

## Note on prior PR

A TypeScript-flavored version of these docs was merged to `adcontextprotocol/adcp-client#1437` earlier today. That was the wrong target — these docs belong on the protocol site where the audience that needs them actually lands. The adcp-client PR can either stand as an SDK-specific implementer's guide or be reverted; this PR is the canonical, language-agnostic version intended for the protocol docs site.

## Test plan

- [ ] All four pages render in Mintlify with correct frontmatter
- [ ] Internal links resolve (`/docs/building/sdk-stack`, `/docs/building/where-to-start`, `/docs/building/version-adaptation`, `/docs/building/migrate-from-hand-rolled`, plus all the spec-page cross-links)
- [ ] `docs.json` nav renders the four new entries in the Building section
- [ ] No broken anchors in the cost-decomposition / coverage-matrix in-page links

🤖 Generated with [Claude Code](https://claude.com/claude-code)