### PR TITLE
spec(compliance): pin endpoint_pattern wildcard grammar + downgrade non-JSON match modes to not_applicable (closes #3845)

### DIFF
--- a/.changeset/anti-facade-glob-substring-pinning.md
+++ b/.changeset/anti-facade-glob-substring-pinning.md
@@ -1,0 +1,17 @@
+---
+"adcontextprotocol": minor
+---
+
+spec(compliance): pin endpoint_pattern wildcard grammar + downgrade non-JSON match modes to not_applicable (closes #3845)
+
+Two implementation-surfaced ambiguities from runner-side adoption of #3816 (the anti-façade + cascade-attribution contract). Both are minor-but-load-bearing pins that affect cross-runner determinism on the same storyboard.
+
+**1. `endpoint_pattern` wildcard grammar.** `comply-test-controller-request.json` previously described `endpoint_pattern` as a "glob-style pattern" with no normative grammar. The `@adcp/sdk` runner picks the most permissive interpretation (`*` matches `/`-crossing, all other regex metacharacters escaped literally). A different runner could legitimately read "glob-style" and ship POSIX glob semantics where `*` doesn't cross `/` and `?` is single-char-any — same storyboard, different verdict. Pinned: `*` matches zero or more characters of any kind including `/`. No other characters have wildcard semantics — `?` is a literal question mark, `[`/`]` are literal brackets. Implementations MUST anchor the pattern (full-string match). Renamed "glob-style" → "wildcard" in the description so the grammar's intentional narrowness is obvious from the noun.
+
+**2. Non-JSON `payload_must_contain` match modes downgrade to `not_applicable`.** The earlier comment in `storyboard-schema.yaml` said the runner "falls back to substring matching for `match: present`" against non-JSON payloads (form-urlencoded, multipart, plain text). The `@adcp/sdk` runner implemented this as a terminal-key heuristic (extract `hashed_email` from `users[*].hashed_email`, substring-search the raw payload string). That creates false positives: a payload mentioning `hashed_email` anywhere — URL fragment, comment, unrelated metadata field — would pass the assertion. For an anti-façade contract specifically, false positives are exactly what lets façades pass.
+
+Per the option-(b) decision in #3845: ALL `payload_must_contain` match modes (`present` / `equals` / `contains_any`) now grade `not_applicable` against non-JSON `content_type`. Storyboards that need a "the upstream call carried this value" signal against non-JSON payloads use `identifier_paths` instead — that surface substring-searches storyboard-supplied VALUES (not path-derived strings), which is encoding-agnostic and doesn't suffer the false-positive surface.
+
+**Why both belong in spec, not runner docs.** #3816 explicitly framed itself as the load-bearing anti-façade contract that distinguishes a real adapter from a façade. Two compliant runners grading the same storyboard differently against the same agent (because of unspecified wildcard / substring semantics) means adopters can game whichever runner is more permissive. Pinning these is small but the divergence cost is high.
+
+**Cross-link:** SDK PR `adcontextprotocol/adcp-client#1289` is the runner-side adoption that surfaced both ambiguities; runner needs a follow-up alignment to drop the terminal-key fallback now that the spec downgrades non-JSON matches to `not_applicable`.

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -1041,11 +1041,30 @@
 #                              # parsePathWithWildcards from @adcp/sdk, which
 #                              # recognizes `[*]` only. Path matching only
 #                              # applies when recorded_calls[].content_type is
-#                              # JSON-shaped (application/json or *+json);
-#                              # against form-urlencoded, multipart, or other
-#                              # content types the runner falls back to
-#                              # substring matching for `match: present` and
-#                              # grades non-substring matches not_applicable.
+#                              # JSON-shaped — defined as `application/json`
+#                              # or any structured-syntax-suffix `*/*+json`
+#                              # per RFC 6839 §3.1 (e.g., `application/vnd.api+json`,
+#                              # `application/scim+json`). All other content
+#                              # types (form-urlencoded, multipart, plain text,
+#                              # newline-delimited JSON like `application/json-seq`,
+#                              # JSON Lines `application/jsonl`) take the non-
+#                              # JSON path. Against non-JSON ALL match modes
+#                              # (`present` / `equals` / `contains_any`) grade
+#                              # `not_applicable`. Earlier sketches downgraded
+#                              # `match: present` to a terminal-key substring
+#                              # search of the raw payload string; that
+#                              # heuristic creates false positives (a payload
+#                              # mentioning the key name in any context — URL
+#                              # fragment, comment, unrelated metadata field —
+#                              # would pass), which is exactly the anti-façade
+#                              # contract this surface exists to protect.
+#                              # Storyboards that need a "the upstream call
+#                              # carried this value" signal against non-JSON
+#                              # payloads use `identifier_paths` instead — that
+#                              # surface substring-searches storyboard-supplied
+#                              # VALUES (not path-derived strings), which is
+#                              # encoding-agnostic and doesn't suffer the
+#                              # false-positive surface.
 #                              # Shape:
 #                              #   - path: <dotted-with-[*] path>
 #                              #     match: present | equals | contains_any

--- a/static/schemas/source/compliance/comply-test-controller-request.json
+++ b/static/schemas/source/compliance/comply-test-controller-request.json
@@ -380,7 +380,7 @@
               },
               "endpoint_pattern": {
                 "type": "string",
-                "description": "Optional server-side filter; reduces response size. Glob-style pattern matched against `<METHOD> <URL>`, e.g. 'POST */audience/upload' or 'POST *'. When omitted, all recorded calls in the window are returned."
+                "description": "Optional server-side filter; reduces response size. Wildcard pattern matched against `<METHOD> <URL>`, e.g. 'POST */audience/upload' or 'POST *'. When omitted, all recorded calls in the window are returned. **Grammar (normative):** `*` matches zero or more characters of any kind including `/`. No other characters have wildcard semantics — `?` is a literal question mark, `[` and `]` are literal brackets, etc. There is no escape mechanism — `*` is always a wildcard; if literal-asterisk matching is required, callers omit `endpoint_pattern` and filter response-side. Implementations MUST anchor the pattern (full-string match, not substring search). This narrow grammar is intentional — `endpoint_pattern` exists to discriminate platform endpoints (e.g., `POST */audience/upload` vs `POST */events/log`), not to express full path-segment grammars. Cross-runner determinism depends on this pinning: a runner that ships POSIX-glob semantics (`*` per-segment, `?` single-char-any) would grade the same storyboard differently than a runner picking the more permissive single-wildcard reading."
               },
               "limit": {
                 "type": "integer",


### PR DESCRIPTION
## Summary

Closes [#3845](https://github.com/adcontextprotocol/adcp/issues/3845). Two implementation-surfaced ambiguities from runner-side adoption of [#3816](https://github.com/adcontextprotocol/adcp/pull/3816) (the anti-façade + cascade-attribution contract). Both are minor-but-load-bearing pins that affect cross-runner determinism on the same storyboard.

### 1. `endpoint_pattern` wildcard grammar

Was: "glob-style pattern" with no normative grammar. The `@adcp/sdk` runner picks the most permissive interpretation; a different runner could legitimately read "glob-style" and ship POSIX glob semantics.

Pinned:
- `*` matches zero or more characters of any kind including `/`.
- No other characters have wildcard semantics — `?` is literal, `[`/`]` are literal.
- No escape mechanism — `*` is always a wildcard. Callers needing literal-asterisk matching omit the field and filter response-side.
- Pattern MUST be anchored (full-string match, not substring search).

Renamed "glob-style" → "wildcard" in the description so the intentional narrowness is obvious from the noun.

### 2. Non-JSON `payload_must_contain` match modes downgrade to `not_applicable`

Was: "the runner falls back to substring matching for `match: present` against the raw string." `@adcp/sdk` implemented this as a terminal-key heuristic (extract `hashed_email` from `users[*].hashed_email`, substring-search the raw payload). For an anti-façade contract specifically, that creates exactly the false-positive surface the contract exists to prevent — a payload mentioning `hashed_email` in any context (URL fragment, comment, unrelated metadata field) would pass.

Per the option-(b) decision in #3845: ALL `payload_must_contain` match modes (`present` / `equals` / `contains_any`) now grade `not_applicable` against non-JSON `content_type`. Storyboards needing a non-JSON value-carried signal use `identifier_paths` — substring-searches storyboard-supplied VALUES (not path-derived strings), encoding-agnostic, no false-positive surface.

### 3. JSON-shape detection (additional pin from review)

Pinned per [RFC 6839 §3.1](https://www.rfc-editor.org/rfc/rfc6839#section-3.1): `application/json` or any structured-syntax-suffix `*/*+json` (e.g., `application/vnd.api+json`, `application/scim+json`). All other types — form-urlencoded, multipart, plain text, `application/json-seq`, `application/jsonl` — take the non-JSON path. Without this pin, runners would diverge on whether `json-seq`-style newline-delimited formats count as JSON-shaped.

## Why both belong in spec, not runner docs

#3816 explicitly framed itself as the load-bearing anti-façade contract that distinguishes a real adapter from a façade. Two compliant runners grading the same storyboard differently against the same agent (because of unspecified wildcard / substring semantics) means adopters can game whichever runner is more permissive. Pinning these is small but the divergence cost is high.

## Reviewed by

`ad-tech-protocol-expert`. Two SHOULD FIX additions caught before push:
- Escape semantics for `*` (no escape; `*` is always a wildcard).
- JSON-shape detection per RFC 6839 §3.1 (newline-delimited JSON formats explicitly take the non-JSON path).

Both addressed in the same commit.

## Cross-link

SDK PR [adcontextprotocol/adcp-client#1289](https://github.com/adcontextprotocol/adcp-client/pull/1289) is the runner-side adoption that surfaced both ambiguities; runner needs a follow-up alignment to drop the terminal-key fallback now that the spec downgrades non-JSON matches to `not_applicable`.

## Test plan

- [x] JSON parses cleanly.
- [x] All storyboard linters pass.
- [x] Universal-storyboard doc parity clean.
- [ ] CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)