### PR TITLE
docs(building): replace ASCII layer diagram on /sdk-stack with mermaid

### DIFF
--- a/.changeset/sdk-stack-diagram-mermaid.md
+++ b/.changeset/sdk-stack-diagram-mermaid.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs(building): replace ASCII stack diagram on /building/sdk-stack with a Mermaid flowchart — the L0–L4 layers now render as nested subgraphs ("yours, always" wrapping L4, "what an AdCP SDK provides" wrapping L0–L3) instead of monospaced box-drawing that broke alignment on narrower viewports.

--- a/docs/building/sdk-stack.mdx
+++ b/docs/building/sdk-stack.mdx
@@ -18,33 +18,25 @@ This page names the layers, says what each one contains, says what an SDK at eac
 
 ## The five layers
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│  L4 — Business logic                                        │ ← yours, always
-│  Inventory forecasting, pricing, creative review, upstream  │
-│  ad-server calls (GAM/FreeWheel/Kevel/etc.). The agent's    │
-│  competitive surface — what makes your agent yours.         │
-├─────────────────────────────────────────────────────────────┤
-│  L3 — Protocol semantics                                    │
-│  Lifecycle state machines, idempotency, error code catalog, │ ┐
-│  transition validation (NOT_CANCELLABLE vs INVALID_STATE),  │ │
-│  async-task contract, webhook emission, conformance test    │ │ what an
-│  surface, response envelope shaping.                        │ │ AdCP SDK
-├─────────────────────────────────────────────────────────────┤ │ provides
-│  L2 — Auth & registry                                       │ │
-│  Agent identity verification, brand resolution, AAO bridge, │ │
-│  multi-tenant account resolution, principal scoping,        │ │
-│  sandbox-vs-live account routing.                           │ │
-├─────────────────────────────────────────────────────────────┤ │
-│  L1 — Identity & signing                                    │ │
-│  RFC 9421 HTTP message signatures, public-key registries,   │ │
-│  signature verification, key rotation handling.             │ │
-├─────────────────────────────────────────────────────────────┤ ┘
-│  L0 — Wire & transport                                      │
-│  Bytes on the wire. JSON-over-HTTP framing, MCP message     │
-│  envelopes, A2A SSE streams, JSON schema validation,        │
-│  language-native type generation from the spec.             │
-└─────────────────────────────────────────────────────────────┘
+```mermaid
+%%{init: {"flowchart": {"htmlLabels": true, "wrappingWidth": 9999}, "themeVariables": {"fontSize": "14px"}}}%%
+flowchart TB
+    subgraph yours["yours, always"]
+        L4["<b>L4 — Business logic</b><br/>Inventory forecasting · pricing · creative review · upstream ad-server calls<br/>(GAM / FreeWheel / Kevel / your decisioning engine)<br/><i>The agent's competitive surface — what makes your agent yours</i>"]
+    end
+
+    subgraph sdk["what an AdCP SDK provides"]
+        direction TB
+        L3["<b>L3 — Protocol semantics</b><br/>Lifecycle state machines · idempotency · error catalog · transition validation<br/>Async-task contract · webhook emission · conformance surface · response envelope"]
+        L2["<b>L2 — Auth &amp; registry</b><br/>Agent identity verification · brand resolution · AAO bridge<br/>Multi-tenant account resolution · principal scoping · sandbox-vs-live routing"]
+        L1["<b>L1 — Identity &amp; signing</b><br/>RFC 9421 HTTP message signatures · public-key registries<br/>Signature verification · replay-window enforcement · key rotation"]
+        L0["<b>L0 — Wire &amp; transport</b><br/>JSON-over-HTTP framing · MCP message envelopes · A2A SSE streams<br/>JSON schema validation · language-native type generation"]
+        L3 ~~~ L2
+        L2 ~~~ L1
+        L1 ~~~ L0
+    end
+
+    L4 ~~~ L3
 ```
 
 ### L0 — Wire & transport


### PR DESCRIPTION
## Summary
- The hand-drawn box-art on [/docs/building/sdk-stack](https://docs.adcontextprotocol.org/docs/building/sdk-stack) relied on monospaced rendering and broke alignment on narrower viewports.
- Replaces it with a Mermaid `flowchart TB`: two `subgraph`s — **`yours, always`** wraps L4, **`what an AdCP SDK provides`** wraps L3→L0 — so the SDK boundary is conveyed by grouping rather than a sidebar bracket.
- Per-diagram init directive (`wrappingWidth: 9999`, `fontSize: 14px`) lets each layer fit the content column on one or two lines instead of ribbon-wrapping into 4–5 lines at 346px.

## Test plan
- [x] Booted `mintlify dev` locally and rendered `/docs/building/sdk-stack` — Mermaid SVG renders at 706×736, no syntax errors, bold layer headers and italics render via `<b>`/`<i>` tags.
- [ ] Reviewer eyeball on the live docs preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)