### PR TITLE
fix(compliance): inventory_list_targeting — add sandbox:true to account fixtures

### DIFF
--- a/.changeset/inventory-list-targeting-sandbox-fixture.md
+++ b/.changeset/inventory-list-targeting-sandbox-fixture.md
@@ -1,0 +1,12 @@
+---
+---
+
+fix(compliance): inventory_list_targeting — add `sandbox: true` to account fixtures
+
+The 5 account blocks across this scenario use the brand+operator natural-key variant of `AccountReference` but omit the `sandbox` flag. Sellers whose `accounts.resolve` has separate code paths for sandbox vs production refs end up routing `create_media_buy` and `get_media_buys` through different account-id namespaces, which breaks `mediaBuyStore` backfill of `targeting_overlay` and fails `verify_create_persisted` / `verify_update_persisted`.
+
+Setting `sandbox: true` on every account block keeps both create and get on the sandbox path, the round-trip becomes consistent, and the storyboard exercises what it intended to: targeting persistence across the create / get / update lifecycle.
+
+Non-protocol (storyboard fixture only). No version bump.
+
+Refs: adcp-client#1487 — follow-up to fix the underlying enricher asymmetry upstream so future storyboard authors don't trip the same wire.

--- a/static/compliance/source/protocols/media-buy/scenarios/inventory_list_targeting.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/inventory_list_targeting.yaml
@@ -68,6 +68,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
+            sandbox: true
 
           context:
             correlation_id: "inventory_list_targeting--get_products_brief"
@@ -112,6 +113,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
+            sandbox: true
           idempotency_key: "inventory-list-targeting-create-v1"
           start_time: "2026-07-01T00:00:00Z"
           end_time: "2026-09-30T23:59:59Z"
@@ -169,6 +171,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
+            sandbox: true
           media_buy_ids:
             - "$context.media_buy_id"
 
@@ -212,6 +215,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
+            sandbox: true
           media_buy_id: "$context.media_buy_id"
           packages:
             - package_id: "$context.package_id"
@@ -248,6 +252,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
+            sandbox: true
           media_buy_ids:
             - "$context.media_buy_id"
 


### PR DESCRIPTION
## Summary

The 5 account blocks across this scenario use the brand+operator natural-key variant of `AccountReference` but omit the `sandbox` flag. Sellers whose `accounts.resolve` has separate code paths for sandbox vs production refs (the conventional shape — see the worked `hello_seller_adapter_guaranteed` in `@adcp/sdk`) end up routing `create_media_buy` and `get_media_buys` through **different account-id namespaces**:

- `create_media_buy` enricher (in the SDK runner's `FIXTURE_AWARE_ENRICHERS`): builds the request from scratch via `resolveAccount(options)`, which inherits `sandbox: true` from the test-kit. Adapter routes to its sandbox namespace.
- `get_media_buys` enricher: returns only `{ media_buy_ids: [...] }`; the request-builder then merges the storyboard fixture's `account`, which has **no sandbox flag**. Adapter routes to its production namespace.

Different `accountId`s → framework-side `mediaBuyStore` can't backfill `targeting_overlay` onto `get_media_buys` responses → `property_list` / `collection_list` assertions in `verify_create_persisted` and `verify_update_persisted` fail with `Expected ..., got undefined`.

Setting `sandbox: true` on every account block keeps both create and get on the sandbox path, the round-trip becomes consistent, and the storyboard exercises what it intended to: targeting persistence across the create / get / update lifecycle.

## Reproduction

Boot \`hello_seller_adapter_guaranteed\` from \`@adcp/sdk\` 6.7+ and run \`adcp storyboard run http://127.0.0.1:<port>/mcp media_buy_seller/inventory_list_targeting\`. \`verify_create_persisted/get_after_create\` and \`verify_update_persisted/get_after_swap\` fail.

Adapter-side trace before fix:

\`\`\`
[mediaBuyStore.persistFromCreate] sandbox_net_acmeoutdoor media_buy_id=ord_28c6 ...
[mediaBuyStore.backfill]          net_acmeoutdoor          buys=1
\`\`\`

Different namespaces → no echo. After fix, both resolve to \`sandbox_net_acmeoutdoor\` and the store backfills correctly.

## Refs

- \`adcontextprotocol/adcp-client#1415\` — SDK side: \`createMediaBuyStore\` shipped auto-echo plumbing in \`dda2a77e\`. This fixture fix closes the last gap needed for the worked example to pass without an \`EXPECTED_FAILURES\` allowlist.
- \`adcontextprotocol/adcp-client\` commit \`5fd83f17\` (#1453) — \`Account.mode\` trust boundary that splits the sandbox-vs-production routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)