### PR TITLE
fix(compliance): sales_guaranteed/create_media_buy — use task_completion.media_buy_id context_outputs path

### DIFF
--- a/.changeset/sales-guaranteed-task-completion-path.md
+++ b/.changeset/sales-guaranteed-task-completion-path.md
@@ -1,0 +1,12 @@
+---
+---
+
+fix(compliance): sales_guaranteed/create_media_buy — use `task_completion.media_buy_id` `context_outputs` path
+
+The `create_media_buy` step in this storyboard exercises the spec-correct guaranteed-seller flow: returns an A2A task envelope (`status: 'submitted'`, no `media_buy_id` yet); the seller-assigned id only materializes on the eventual task-completion artifact after IO signing.
+
+The fixture's `context_outputs[0].path` was bare `"media_buy_id"`, which the runner resolves against the immediate submitted-arm response — where the field doesn't exist yet — producing `capture_path_not_resolvable` and breaking downstream phases that depend on `$context.media_buy_id`.
+
+Updates the path to `"task_completion.media_buy_id"` so the runner polls `tasks/get` and captures the seller-issued id from the terminal artifact, per the runner contract introduced in adcp-client#1426 (commit `3b21a15a`).
+
+Non-protocol (storyboard fixture only). No version bump.

--- a/static/compliance/source/specialisms/sales-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-guaranteed/index.yaml
@@ -327,7 +327,7 @@ phases:
             correlation_id: "sales_guaranteed--create_media_buy"
         context_outputs:
           - name: media_buy_id
-            path: "media_buy_id"
+            path: "task_completion.media_buy_id"
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"


### PR DESCRIPTION
## Summary

The \`create_media_buy\` step in this storyboard exercises the spec-correct guaranteed-seller flow: returns an A2A task envelope (\`status: 'submitted'\`, no \`media_buy_id\` yet); the seller-assigned id only materializes on the eventual task-completion artifact after IO signing.

The fixture's \`context_outputs[0].path\` is currently bare \`"media_buy_id"\`, which the runner resolves against the **immediate** submitted-arm response — where the field doesn't exist yet. That produces \`capture_path_not_resolvable\` and the storyboard fails downstream phases that rely on \`\$context.media_buy_id\`.

The runner's \`context_outputs.path\` resolution gained a \`task_completion.\` prefix in \`adcontextprotocol/adcp-client\` PR #1426 (commit \`3b21a15a\`). The prefix tells the runner: "poll \`tasks/get\` for the terminal task artifact, then resolve the rest of the path against the artifact data" rather than the immediate response.

This change updates the path from \`"media_buy_id"\` to \`"task_completion.media_buy_id"\` so the captured value is the terminal-state \`media_buy_id\` per the runner's intended contract.

## Reproduction

Boot \`hello_seller_adapter_guaranteed\` from \`@adcp/sdk\` 6.7+ and run \`adcp storyboard run http://127.0.0.1:<port>/mcp sales_guaranteed\`. The \`create_media_buy\` step fails with:

\`\`\`
context_outputs path "media_buy_id" (key "media_buy_id") did not resolve to a usable value
\`\`\`

After this fix the runner polls \`tasks/get\`, captures the seller-issued id from the terminal artifact, and downstream steps (e.g. \`confirm_active\`) resolve correctly.

## Refs

- \`adcontextprotocol/adcp-client#1417\` — runner-side bug filed against the storyboard runner; closed by PR #1426
- \`adcontextprotocol/adcp-client\` commit \`3b21a15a\` — runner-side fix introducing the \`task_completion.\` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)