### PR TITLE
docs(spec): comply_test_controller is deployment-scoped, not request-gated

### DIFF
--- a/.changeset/comply-controller-deployment-scoped.md
+++ b/.changeset/comply-controller-deployment-scoped.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs(spec): tighten `comply_test_controller` visibility rule to deployment-scoped — production deployments MUST NOT expose the tool on any surface (`tools/list`, `compliance_testing` block in `get_adcp_capabilities`, dispatch). Live-mode probes get unknown-tool, not FORBIDDEN. Closes adcontextprotocol/adcp#3986.

--- a/docs/building/implementation/comply-test-controller.mdx
+++ b/docs/building/implementation/comply-test-controller.mdx
@@ -25,13 +25,15 @@ Without a test controller, compliance testing is observational: fire an action, 
 
 ## Sandbox gating
 
-Sellers MUST NOT include `comply_test_controller` in the `tools/list` response for production connections. The tool should only appear when the connection is established with sandbox credentials (a sandbox API key, a sandbox OAuth scope, or a sandbox URL). This ensures production context windows are not taxed by test-only tooling and prevents accidental state manipulation.
+Sellers MUST NOT expose `comply_test_controller` on production deployments — to anyone, on any surface. The tool MUST be absent from `tools/list`, the `compliance_testing` block MUST be absent from `get_adcp_capabilities`, and dispatch MUST return an unknown-tool error if a caller probes by name. A production deployment that exposes the tool is non-conformant regardless of whether dispatch is gated. Sellers expose `comply_test_controller` only on sandbox/staging deployments; any principal that can authenticate to such a deployment can call it.
 
-The mechanism for provisioning sandbox credentials is seller-specific and out of scope for this spec. Sellers MUST document their sandbox access mechanism so storyboard runners can connect appropriately.
+Sellers MAY run a single deployment with mixed sandbox/live principals and project the tool per-principal — gating `tools/list` and capability projection on the resolved account's mode — but this is an implementation pattern, not the canonical model. The canonical pattern is two deployments: one production (no controller wired), one sandbox/staging (controller wired for all comers).
+
+The mechanism for provisioning sandbox credentials and for separating production from sandbox/staging deployments is seller-specific and out of scope for this spec. Sellers MUST document their sandbox access mechanism so storyboard runners can connect appropriately.
 
 The storyboard runner SHOULD verify that `comply_test_controller` is absent from `tools/list` on a production connection as a basic safety check.
 
-If a `comply_test_controller` call references a non-sandbox account, the controller MUST return `FORBIDDEN`. Sandbox gating is enforced per-request on the account reference, not just at tool registration time — the tool may be listed in a sandbox connection, but the caller could still reference a production account in the params.
+A live-mode principal probing `comply_test_controller` by name MUST receive the transport's standard unknown-tool error — byte-identical to a seller that does not implement the tool. `FORBIDDEN` is reserved for the in-sandbox case where the caller is authorized to call the controller but `params` reference a non-sandbox account; sandbox gating is enforced per-request on the account reference, not just at tool registration time.
 
 ## Tool definition
 

--- a/docs/building/implementation/comply-test-controller.mdx
+++ b/docs/building/implementation/comply-test-controller.mdx
@@ -25,15 +25,17 @@ Without a test controller, compliance testing is observational: fire an action, 
 
 ## Sandbox gating
 
-Sellers MUST NOT expose `comply_test_controller` on production deployments — to anyone, on any surface. The tool MUST be absent from `tools/list`, the `compliance_testing` block MUST be absent from `get_adcp_capabilities`, and dispatch MUST return an unknown-tool error if a caller probes by name. A production deployment that exposes the tool is non-conformant regardless of whether dispatch is gated. Sellers expose `comply_test_controller` only on sandbox/staging deployments; any principal that can authenticate to such a deployment can call it.
+Sellers MUST NOT expose `comply_test_controller` on production deployments — to anyone, on any surface. The tool MUST be absent from `tools/list` (MCP) and from the agent card's `skills[]` (A2A); the `compliance_testing` block MUST be absent from `get_adcp_capabilities`; dispatch MUST return the transport's standard unknown-tool error (e.g., JSON-RPC `-32601 Method not found` for MCP, the unknown-skill rejection for A2A) — indistinguishable from the same-transport response of a seller that does not implement the tool. A production deployment that exposes the tool on any of these surfaces is non-conformant regardless of whether dispatch is gated.
 
-Sellers MAY run a single deployment with mixed sandbox/live principals and project the tool per-principal — gating `tools/list` and capability projection on the resolved account's mode — but this is an implementation pattern, not the canonical model. The canonical pattern is two deployments: one production (no controller wired), one sandbox/staging (controller wired for all comers).
+The canonical pattern is two deployments: one production (no controller wired), one sandbox/staging (controller wired for all comers). Sellers expose `comply_test_controller` only on sandbox/staging deployments; any principal that can authenticate to such a deployment can call it.
+
+Sellers MAY instead run a single deployment with mixed sandbox/live principals and project the tool per-principal, gating on the resolved account's mode. This is an implementation pattern, not the canonical model. Sellers picking this pattern MUST gate all three surfaces consistently: `tools/list` (or `skills[]`), the `compliance_testing` capability block, and dispatch. Partial projection — e.g., gating `tools/list` but leaving the `compliance_testing` block visible to live principals, or returning `FORBIDDEN` (rather than unknown-tool) to a live principal who probes by name — is non-conformant; it reopens the discovery side channel that deployment-scoping closes.
+
+`FORBIDDEN` is reserved for the in-sandbox case where the caller is authorized to call the controller but `params` reference a non-sandbox account. Sandbox gating is enforced per-request on the account reference, not just at tool registration time.
 
 The mechanism for provisioning sandbox credentials and for separating production from sandbox/staging deployments is seller-specific and out of scope for this spec. Sellers MUST document their sandbox access mechanism so storyboard runners can connect appropriately.
 
-The storyboard runner SHOULD verify that `comply_test_controller` is absent from `tools/list` on a production connection as a basic safety check.
-
-A live-mode principal probing `comply_test_controller` by name MUST receive the transport's standard unknown-tool error — byte-identical to a seller that does not implement the tool. `FORBIDDEN` is reserved for the in-sandbox case where the caller is authorized to call the controller but `params` reference a non-sandbox account; sandbox gating is enforced per-request on the account reference, not just at tool registration time.
+The storyboard runner MUST treat the presence of `comply_test_controller` in `tools/list` (or `skills[]`) or the presence of the `compliance_testing` block in `get_adcp_capabilities` on a connection it believes is production as a hard conformance failure.
 
 ## Tool definition
 
@@ -715,7 +717,7 @@ The runner distinguishes three outcome categories in deterministic mode:
 
 ### For sellers
 
-1. Gate `comply_test_controller` behind sandbox mode — it MUST NOT appear in `tools/list` for production connections
+1. Gate `comply_test_controller` at the deployment level — it MUST NOT appear in `tools/list` (or A2A `skills[]`), MUST NOT be advertised via the `compliance_testing` capability block, and MUST dispatch to unknown-tool on production deployments. See [Sandbox gating](#sandbox-gating) for the full rule.
 2. Reuse your production state machine logic — the controller should call the same internal transition functions, not bypass them
 3. Enforce transition rules — if `rejected` is terminal in production, `force_media_buy_status(rejected → active)` must fail via the controller too
 4. Reflect changes immediately — after a forced transition, the next `list_*` or `get_*` call must return the updated state

--- a/docs/protocol/get_adcp_capabilities.mdx
+++ b/docs/protocol/get_adcp_capabilities.mdx
@@ -502,7 +502,7 @@ Storyboard runners check for the `compliance_testing` block before running deter
 Agents that implement `comply_test_controller` SHOULD include the `compliance_testing` capability block and list supported scenarios. Agents that only support a subset of scenarios (e.g., media buy status but not SI sessions) declare only those scenarios — the runner skips unsupported ones.
 
 :::note
-Compliance testing requires sandbox mode. The `comply_test_controller` tool returns `FORBIDDEN` if the account is not in sandbox.
+Compliance testing is sandbox-only at the deployment level — production deployments MUST NOT advertise this block or expose `comply_test_controller` on any surface. `FORBIDDEN` is returned only when an in-sandbox caller passes `params` that reference a non-sandbox account; live-mode probes for the tool by name receive the transport's standard unknown-tool error. See [Sandbox gating](/docs/building/implementation/comply-test-controller#sandbox-gating).
 :::
 
 ### webhook_signing

--- a/docs/protocol/get_adcp_capabilities.mdx
+++ b/docs/protocol/get_adcp_capabilities.mdx
@@ -491,6 +491,8 @@ Array of metrics this measurement agent computes.
 
 Compliance testing capabilities. The presence of this block declares that the agent supports deterministic testing via [`comply_test_controller`](/docs/building/implementation/comply-test-controller). Omit the block if the agent does not support compliance testing.
 
+**Production deployments MUST NOT include this block.** `comply_test_controller` is sandbox-only at the deployment level; advertising the capability on a production endpoint is non-conformant even if dispatch is gated. See [Compliance test controller § Sandbox gating](/docs/building/implementation/comply-test-controller#sandbox-gating).
+
 | Field | Type | Description |
 |-------|------|-------------|
 | `scenarios` | string[] | Compliance testing scenarios this agent supports. Possible values: `force_creative_status`, `force_account_status`, `force_media_buy_status`, `force_session_status`, `simulate_delivery`, `simulate_budget_spend`, `seed_product`, `seed_pricing_option`, `seed_creative`, `seed_plan`, `seed_media_buy`. Runners MUST accept unknown scenario strings — new scenarios may be added in additive minor bumps. |


### PR DESCRIPTION
## Summary

Closes #3986. Tightens the `comply_test_controller` visibility rule from request-time prose to a deployment-scoped invariant:

- Production deployments MUST NOT expose `comply_test_controller` on any surface — `tools/list`, `get_adcp_capabilities.compliance_testing`, or dispatch.
- A production deployment that exposes the tool is non-conformant **regardless of whether dispatch is gated**. The previous rule only covered `tools/list` and left capability projection silent.
- Live-mode probes get the transport's standard unknown-tool error (byte-identical to a seller that does not implement the tool). `FORBIDDEN` is reserved for the in-sandbox case where `params` reference a non-sandbox account.
- Per-principal projection on a single deployment remains permitted as an implementation pattern, but the canonical model is two deployments (production with no controller wired, sandbox/staging with controller wired for all comers).

## What's changing

**`docs/building/implementation/comply-test-controller.mdx` § Sandbox gating** — replaced the request-scoped paragraph with a deployment-scoped one covering both discovery surfaces and the new error-code rule.

**`docs/protocol/get_adcp_capabilities.mdx` § `compliance_testing`** — added a one-paragraph cross-reference making the deployment-scoped rule explicit at the projection site.

## Why

The previous rule was "advertise unconditionally, gate at dispatch." That's both implementation-fragile (a seller with a buggy gate fails open silently) and a discovery side-channel (live-mode callers can still see "this seller has compliance_testing wired with scenarios […]"). Deployment-scoping closes both: production endpoints have nothing to leak, and there's no gate to mis-implement.

This also implies that AAO can't grade production deterministically — the controller isn't there, ever. The verifier-provisioning question moves to #3991, which proposes an outbound-WebSocket "conformance client" pattern (Slack Socket Mode shape) for sandbox grading without ngrok or public DNS.

## SDK posture

`@adcp/sdk` 6.7+ closes the *dispatch* surface via `Account.mode` (adcontextprotocol/adcp-client#1480). Under this rule, that gate stays — defense-in-depth, and it covers single-deployment adopters — but it's no longer the spec's primary model. Phase 5 SDK work to filter `tools/list` and capability projection by resolved account mode is still useful for adopters who run a single endpoint, but stops being a conformance requirement for separately-deployed adopters.

## Test plan

- [ ] CI green (lint/typecheck/storyboards)
- [ ] No tests reference the prose I changed (verified locally)
- [ ] No conformance tests assert that `compliance_testing` MUST appear on a production-flavored fixture (none found)

🤖 Generated with [Claude Code](https://claude.com/claude-code)