### PR TITLE
3.0.6 follow-up cherry-picks: task_completion. prefix docs + comply_test_controller deployment-scope clarification

### DIFF
--- a/.changeset/comply-controller-deployment-scoped.md
+++ b/.changeset/comply-controller-deployment-scoped.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs(spec): tighten `comply_test_controller` visibility rule to deployment-scoped — production deployments MUST NOT expose the tool on any surface (`tools/list`, `compliance_testing` block in `get_adcp_capabilities`, dispatch). Live-mode probes get unknown-tool, not FORBIDDEN. Closes adcontextprotocol/adcp#3986.

--- a/.changeset/storyboard-schema-task-completion-prefix.md
+++ b/.changeset/storyboard-schema-task-completion-prefix.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs(storyboard-schema): document the `task_completion.<inner>` prefix for `context_outputs[].path`. When the immediate response is a non-terminal task envelope (`submitted`/`working`/`input-required`), the runner polls `tasks/get` until terminal and resolves the suffix against the completion artifact's `data` — needed for captures like seller-assigned `media_buy_id` on IO-signing flows. Requires runner >= adcp-client v6.7. Closes #3950.

--- a/docs/building/implementation/comply-test-controller.mdx
+++ b/docs/building/implementation/comply-test-controller.mdx
@@ -25,13 +25,17 @@ Without a test controller, compliance testing is observational: fire an action, 
 
 ## Sandbox gating
 
-Sellers MUST NOT include `comply_test_controller` in the `tools/list` response for production connections. The tool should only appear when the connection is established with sandbox credentials (a sandbox API key, a sandbox OAuth scope, or a sandbox URL). This ensures production context windows are not taxed by test-only tooling and prevents accidental state manipulation.
+Sellers MUST NOT expose `comply_test_controller` on production deployments — to anyone, on any surface. The tool MUST be absent from `tools/list` (MCP) and from the agent card's `skills[]` (A2A); the `compliance_testing` block MUST be absent from `get_adcp_capabilities`; dispatch MUST return the transport's standard unknown-tool error (e.g., JSON-RPC `-32601 Method not found` for MCP, the unknown-skill rejection for A2A) — indistinguishable from the same-transport response of a seller that does not implement the tool. A production deployment that exposes the tool on any of these surfaces is non-conformant regardless of whether dispatch is gated.
 
-The mechanism for provisioning sandbox credentials is seller-specific and out of scope for this spec. Sellers MUST document their sandbox access mechanism so storyboard runners can connect appropriately.
+The canonical pattern is two deployments: one production (no controller wired), one sandbox/staging (controller wired for all comers). Sellers expose `comply_test_controller` only on sandbox/staging deployments; any principal that can authenticate to such a deployment can call it.
 
-The storyboard runner SHOULD verify that `comply_test_controller` is absent from `tools/list` on a production connection as a basic safety check.
+Sellers MAY instead run a single deployment with mixed sandbox/live principals and project the tool per-principal, gating on the resolved account's mode. This is an implementation pattern, not the canonical model. Sellers picking this pattern MUST gate all three surfaces consistently: `tools/list` (or `skills[]`), the `compliance_testing` capability block, and dispatch. Partial projection — e.g., gating `tools/list` but leaving the `compliance_testing` block visible to live principals, or returning `FORBIDDEN` (rather than unknown-tool) to a live principal who probes by name — is non-conformant; it reopens the discovery side channel that deployment-scoping closes.
 
-If a `comply_test_controller` call references a non-sandbox account, the controller MUST return `FORBIDDEN`. Sandbox gating is enforced per-request on the account reference, not just at tool registration time — the tool may be listed in a sandbox connection, but the caller could still reference a production account in the params.
+`FORBIDDEN` is reserved for the in-sandbox case where the caller is authorized to call the controller but `params` reference a non-sandbox account. Sandbox gating is enforced per-request on the account reference, not just at tool registration time.
+
+The mechanism for provisioning sandbox credentials and for separating production from sandbox/staging deployments is seller-specific and out of scope for this spec. Sellers MUST document their sandbox access mechanism so storyboard runners can connect appropriately.
+
+The storyboard runner MUST treat the presence of `comply_test_controller` in `tools/list` (or `skills[]`) or the presence of the `compliance_testing` block in `get_adcp_capabilities` on a connection it believes is production as a hard conformance failure.
 
 ## Tool definition
 
@@ -713,7 +717,7 @@ The runner distinguishes three outcome categories in deterministic mode:
 
 ### For sellers
 
-1. Gate `comply_test_controller` behind sandbox mode — it MUST NOT appear in `tools/list` for production connections
+1. Gate `comply_test_controller` at the deployment level — it MUST NOT appear in `tools/list` (or A2A `skills[]`), MUST NOT be advertised via the `compliance_testing` capability block, and MUST dispatch to unknown-tool on production deployments. See [Sandbox gating](#sandbox-gating) for the full rule.
 2. Reuse your production state machine logic — the controller should call the same internal transition functions, not bypass them
 3. Enforce transition rules — if `rejected` is terminal in production, `force_media_buy_status(rejected → active)` must fail via the controller too
 4. Reflect changes immediately — after a forced transition, the next `list_*` or `get_*` call must return the updated state

--- a/docs/protocol/get_adcp_capabilities.mdx
+++ b/docs/protocol/get_adcp_capabilities.mdx
@@ -435,6 +435,8 @@ Policy registry integration capabilities. See [Policy Registry](/docs/governance
 
 Compliance testing capabilities. The presence of this block declares that the agent supports deterministic testing via [`comply_test_controller`](/docs/building/implementation/comply-test-controller). Omit the block if the agent does not support compliance testing.
 
+**Production deployments MUST NOT include this block.** `comply_test_controller` is sandbox-only at the deployment level; advertising the capability on a production endpoint is non-conformant even if dispatch is gated. See [Compliance test controller § Sandbox gating](/docs/building/implementation/comply-test-controller#sandbox-gating).
+
 | Field | Type | Description |
 |-------|------|-------------|
 | `scenarios` | string[] | Compliance testing scenarios this agent supports. Possible values: `force_creative_status`, `force_account_status`, `force_media_buy_status`, `force_session_status`, `simulate_delivery`, `simulate_budget_spend`, `seed_product`, `seed_pricing_option`, `seed_creative`, `seed_plan`, `seed_media_buy`. Runners MUST accept unknown scenario strings — new scenarios may be added in additive minor bumps. |
@@ -444,7 +446,7 @@ Storyboard runners check for the `compliance_testing` block before running deter
 Agents that implement `comply_test_controller` SHOULD include the `compliance_testing` capability block and list supported scenarios. Agents that only support a subset of scenarios (e.g., media buy status but not SI sessions) declare only those scenarios — the runner skips unsupported ones.
 
 :::note
-Compliance testing requires sandbox mode. The `comply_test_controller` tool returns `FORBIDDEN` if the account is not in sandbox.
+Compliance testing is sandbox-only at the deployment level — production deployments MUST NOT advertise this block or expose `comply_test_controller` on any surface. `FORBIDDEN` is returned only when an in-sandbox caller passes `params` that reference a non-sandbox account; live-mode probes for the tool by name receive the transport's standard unknown-tool error. See [Sandbox gating](/docs/building/implementation/comply-test-controller#sandbox-gating).
 :::
 
 ### webhook_signing

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -381,6 +381,21 @@
 #             storyboard run)
 #       path: string (JSON path against this step's response body, e.g.
 #             "media_buy_id", "accounts[0].account_id", "plans[0].plan_id")
+#
+#   Special path prefix `task_completion.<inner>`: when the immediate response
+#   is a non-terminal task envelope (status `submitted` / `working` /
+#   `input-required`, carrying a `task_id`), the runner polls `tasks/get`
+#   until the task reaches a terminal state and resolves `<inner>` against
+#   the completion artifact's `data` instead of the immediate response. Use
+#   for captures whose value only exists on the completion artifact — e.g.
+#   the seller-assigned `media_buy_id` on an IO-signing / async-signed HITL
+#   flow where `create_media_buy` returns `submitted` and the ID lands on
+#   the completion artifact. Without the prefix, the literal key
+#   `task_completion` is looked up on the immediate response, which fails
+#   as `capture_path_not_resolvable`. Requires runner >= adcp-client v6.7;
+#   older runners treat the prefix as a literal key. See adcp-client#1417
+#   (rationale) and adcp-client#1426 (implementation).
+#
 #   Runner behavior:
 #   - Captures occur AFTER the step's validations pass. A failed step MUST NOT
 #     populate the context accumulator — downstream $context.<name> references


### PR DESCRIPTION
## Summary

Two additional patch-level cherry-picks for the 3.0.6 line that I missed in the first pass (#3996). Both are pure documentation / spec-text fixes — no wire-format change.

## Cherry-picks

### \`docs(storyboard-schema): document task_completion. prefix for context_outputs\` (cherry-pick of #3955 / \`9c8aa76f24\`)

**Directly relevant to #3996.** That PR landed the \`sales_guaranteed/create_media_buy\` fixture fix that uses \`context_outputs[0].path: \"task_completion.media_buy_id\"\` — but 3.0.x's storyboard-schema.yaml has no documentation of what the \`task_completion.\` prefix means, so a contributor reading the fixture has nothing to anchor against. This adds the missing prose to \`static/compliance/source/universal/storyboard-schema.yaml\`. Documents the runner contract introduced in adcp-client#1426 (commit \`3b21a15a\`).

### \`docs(spec): comply_test_controller is deployment-scoped, not request-gated\` (cherry-pick of #3992 / \`c763226e30\`)

Patch-level spec correction. \`comply_test_controller\` is configured at deployment time (operator-controlled) rather than per-request — the docs previously implied the latter. Touches \`docs/building/implementation/comply-test-controller.mdx\` and \`docs/protocol/get_adcp_capabilities.mdx\`. Both files exist on 3.0.x and the cherry-pick auto-merged cleanly.

## Why these and not others

Audited recent \`main\` commits since v3.0.5 (May 2 23:25 UTC). Other candidates considered and not included:

- **#3987** (\`anti-facade-glob-substring-pinning\`) — spec(compliance): pin endpoint_pattern wildcard grammar + downgrade non-JSON match modes to \`not_applicable\`. The downgrade is a real adopter-affecting behavior change, so the minor framing is defensible. Leaving for 3.1.0.
- **#3962** (\`compliance-bump-sdk-67-and-upstream-traffic\`) — feat(compliance): bump @adcp/sdk to 6.7.0 + adopt upstream_traffic on 5 storyboards. Feature-flag adoption pattern; more invasive than a docs cherry-pick. Out of scope for 3.0.6.
- The 53 minor changesets queued on \`main\` — those go to 3.1.0 by design.

## Test plan

- [x] Schemas rebuild cleanly (\`node scripts/build-schemas.cjs\`)
- [x] Compliance bundle rebuilds cleanly (\`node scripts/build-compliance.cjs\`)
- [x] Both cherry-picks auto-merged with no conflicts
- [ ] CI green (storyboard CI baseline drift on 3.0.x is pre-existing per #3893; not blocking)
- [ ] After merge, changesets bot updates Version Packages PR #3933 with both new entries

## Refs

- adcontextprotocol/adcp#3996 — first round of 3.0.6 cherry-picks
- adcontextprotocol/adcp#3933 — open Version Packages PR for 3.0.6 (will pick up these entries)
- adcontextprotocol/adcp#3955 — \`main\`-side task_completion. prefix docs
- adcontextprotocol/adcp#3992 — \`main\`-side comply_test_controller scope correction
- adcontextprotocol/adcp#3950 — issue closed by #3955

🤖 Generated with [Claude Code](https://claude.com/claude-code)