### PR TITLE
fix(compliance): correct wire-placement assertions in governance denial storyboards

### DIFF
--- a/.changeset/governance-denial-wire-placement-storyboards.md
+++ b/.changeset/governance-denial-wire-placement-storyboards.md
@@ -1,0 +1,14 @@
+---
+---
+
+Fix compliance storyboards to exercise GOVERNANCE_DENIED wire-placement rule.
+
+The `brand_rights/governance_denied` scenario previously asserted `error_code: GOVERNANCE_DENIED`
+on `acquire_rights`, which is the wrong wire shape: that task defines an `AcquireRightsRejected`
+arm enforced by `not: { required: [errors] }` at the schema layer, so governance denial must
+route through the rejection arm (status: rejected, reason populated, errors[] absent) with
+transport staying at HTTP 200 / MCP `isError: false`.
+
+Updated the scenario to assert the correct Case-1 shape. Updated the
+`media_buy_seller/governance_denied` scenario's error_code description to document the
+Case-2 wire-placement rule (create_media_buy has no rejection arm).

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
@@ -167,6 +167,9 @@ phases:
         expected: |
           The buy is rejected because governance denied — the $50K buy exceeds
           the plan's $10K budget. The seller propagates the denial with findings.
+          Wire placement (Case 2): create_media_buy has no structured rejection arm,
+          so GOVERNANCE_DENIED goes to errors[].code + adcp_error.code. Transport
+          failure markers flip: HTTP 4xx / MCP isError: true / A2A failed.
         sample_request:
           brand:
             domain: "acmeoutdoor.example"
@@ -188,4 +191,4 @@ phases:
         validations:
           - check: error_code
             value: "GOVERNANCE_DENIED"
-            description: "Error code indicates governance denial"
+            description: "Error code indicates governance denial — Case-2 wire placement: create_media_buy has no rejection arm, so GOVERNANCE_DENIED surfaces via errors[].code or adcp_error.code (per the two-layer model in error-handling.mdx)"

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
@@ -201,4 +201,4 @@ phases:
         validations:
           - check: error_code
             value: "GOVERNANCE_DENIED"
-            description: "Error code indicates governance denial"
+            description: "Error code indicates governance denial — Case-2 wire placement: create_media_buy has no rejection arm, so GOVERNANCE_DENIED surfaces via errors[].code or adcp_error.code (per the two-layer model in error-handling.mdx)"

--- a/static/compliance/source/specialisms/brand-rights/scenarios/governance_denied.yaml
+++ b/static/compliance/source/specialisms/brand-rights/scenarios/governance_denied.yaml
@@ -155,18 +155,23 @@ phases:
             description: "Response matches get-rights-response.json schema"
 
       - id: acquire_rights_denied
-        title: "acquire_rights — governance denies"
+        title: "acquire_rights — governance denies via rejection arm"
         task: acquire_rights
         schema_ref: "brand/acquire-rights-request.json"
         response_schema_ref: "brand/acquire-rights-response.json"
         doc_ref: "/brand-protocol/tasks/acquire_rights"
-        expect_error: true
-        negative_path: payload_well_formed
+        expected_arm: "rejected"
         stateful: true
         expected: |
-          Brand agent rejects with:
-          - code: GOVERNANCE_DENIED
-          - findings propagated from the governance agent
+          Brand agent returns the AcquireRightsRejected arm — NOT errors[]:
+          - status: rejected (discriminator)
+          - reason populated, propagating governance findings
+          - errors[] absent (the schema enforces this via not: { required: [errors] })
+          - adcp_error absent
+          - Transport stays at HTTP 200 / MCP isError: false — governance denial
+            on acquire_rights is a structured business outcome, not a transport
+            error. GOVERNANCE_DENIED does NOT appear in errors[] or adcp_error
+            when the task defines a rejection arm.
 
         sample_request:
           account:
@@ -195,9 +200,22 @@ phases:
           context:
             correlation_id: "brand_rights--governance_denied--acquire"
         validations:
-          - check: error_code
-            value: "GOVERNANCE_DENIED"
-            description: "Error code is GOVERNANCE_DENIED"
+          - check: response_schema
+            description: "Response matches acquire-rights-response.json, enforcing not: { required: [errors] } on the rejected arm"
+          - check: field_value
+            path: "status"
+            value: "rejected"
+            description: "Rejection arm discriminator present — governance denial routes through the structured arm, not errors[]"
+          - check: field_present
+            path: "reason"
+            description: "reason populated — propagates governance findings to the buyer"
+          - check: field_absent
+            path: "errors"
+            description: "errors[] absent — GOVERNANCE_DENIED MUST NOT dual-emit on acquire_rights; rejection arm IS the canonical denial shape"
           - check: field_present
             path: "context"
-            description: "Response echoes back the context object even on errors"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "brand_rights--governance_denied--acquire"
+            description: "Context correlation_id returned unchanged"

--- a/static/compliance/source/specialisms/brand-rights/scenarios/governance_denied.yaml
+++ b/static/compliance/source/specialisms/brand-rights/scenarios/governance_denied.yaml
@@ -166,12 +166,9 @@ phases:
           Brand agent returns the AcquireRightsRejected arm — NOT errors[]:
           - status: rejected (discriminator)
           - reason populated, propagating governance findings
-          - errors[] absent (the schema enforces this via not: { required: [errors] })
-          - adcp_error absent
+          - errors[] absent (schema-enforced via not: { required: [errors] })
           - Transport stays at HTTP 200 / MCP isError: false — governance denial
-            on acquire_rights is a structured business outcome, not a transport
-            error. GOVERNANCE_DENIED does NOT appear in errors[] or adcp_error
-            when the task defines a rejection arm.
+            on acquire_rights is a structured business outcome, not a transport error
 
         sample_request:
           account:
@@ -201,7 +198,7 @@ phases:
             correlation_id: "brand_rights--governance_denied--acquire"
         validations:
           - check: response_schema
-            description: "Response matches acquire-rights-response.json, enforcing not: { required: [errors] } on the rejected arm"
+            description: "Response validates against acquire-rights-response.json"
           - check: field_value
             path: "status"
             value: "rejected"

--- a/static/compliance/source/specialisms/brand-rights/scenarios/governance_denied.yaml
+++ b/static/compliance/source/specialisms/brand-rights/scenarios/governance_denied.yaml
@@ -165,11 +165,12 @@ phases:
             description: "Response matches get-rights-response.json schema"
 
       - id: acquire_rights_denied
-        title: "acquire_rights — governance denies"
+        title: "acquire_rights — governance denies via rejection arm"
         task: acquire_rights
         schema_ref: "brand/acquire-rights-request.json"
         response_schema_ref: "brand/acquire-rights-response.json"
         doc_ref: "/brand-protocol/tasks/acquire_rights"
+        expected_arm: "rejected"
         stateful: true
         expected: |
           Brand agent returns the canonical denial shape for a task with a structured rejection arm:
@@ -216,6 +217,13 @@ phases:
           - check: field_present
             path: "reason"
             description: "Rejection arm carries the operator-readable reason (governance findings propagated verbatim per wire-placement guidance)"
+          - check: field_absent
+            path: "errors"
+            description: "errors[] absent — GOVERNANCE_DENIED MUST NOT dual-emit on acquire_rights; rejection arm IS the canonical denial shape"
           - check: field_present
             path: "context"
             description: "Response echoes back the context object on the rejection arm"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "brand_rights--governance_denied--acquire"
+            description: "Context correlation_id returned unchanged"


### PR DESCRIPTION
Closes #3998

## Summary

The `brand_rights/governance_denied` storyboard scenario was asserting `expect_error: true` + `check: error_code, value: GOVERNANCE_DENIED` on `acquire_rights`. Per the GOVERNANCE_DENIED wire-placement rule (landed in #3929), tasks that define a structured rejection arm MUST use that arm — not `errors[]`. `AcquireRightsRejected` carries `not: { required: [errors] }` at the schema layer, so the prior storyboard was grading a schema-violating response shape as passing for any brand agent that had run the `brand_rights` specialism suite.

**What changes:**

1. **`brand_rights/scenarios/governance_denied.yaml` — fixes Case 1 (acquire_rights):**
   - Removes `expect_error: true` and `negative_path: payload_well_formed`
   - Adds `expected_arm: "rejected"` for correct path-resolution lint scoping
   - Replaces `check: error_code, value: GOVERNANCE_DENIED` with rejection-arm assertions:
     - `check: response_schema` — enforces `not: { required: [errors] }` on the Rejected arm
     - `check: field_value path: status value: rejected` — arm discriminator
     - `check: field_present path: reason` — governance findings propagated
     - `check: field_absent path: errors` — explicit dual-emission guard
     - `check: field_value path: context.correlation_id` — context echo

2. **`media-buy/scenarios/governance_denied.yaml` — documents Case 2 (create_media_buy):**
   - Updates `expected:` block to document the Case-2 wire-placement rule explicitly (no rejection arm → `errors[].code` + `adcp_error.code`, transport failure markers flip)
   - Updates `error_code` description to reference the two-layer model

**Non-breaking justification:** Both changes are purely in storyboard YAML assertions. They correct incorrect test expectations to match spec-required behavior; no schema, task definition, or protocol surface is changed.

**Case 3 (negative/violation test) — deferred:** The issue also requested a fixture that populates both the rejection arm AND `errors[]` and asserts schema validation rejects it. This cannot be implemented as a live storyboard step (the runner has no mechanism to force a seller to emit an invalid response shape). It belongs as a test vector in `static/compliance/source/test-vectors/acquire-rights-response/negative/` and is tracked for a follow-up.

**Pre-PR review:**
- ad-tech-protocol-expert: approved — wire-placement rule enforcement is protocol-correct; `adcp_error absent` on rejection-arm responses is normative per `protocol-envelope.json`; `expected_arm: "rejected"` added per authoring guide
- code-reviewer: approved — YAML valid; `field_absent` is in `authored_check_kinds`; `field_present: errors` dropped from media-buy scenario in favor of the existing shape-agnostic `error_code` check

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01QW7uzhT3g9LEVMX9y6Ew1R

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW7uzhT3g9LEVMX9y6Ew1R)_