### PR TITLE
fix(compliance): clarify MCP envelope binding in v3_envelope_integrity storyboard

### DIFF
--- a/.changeset/fix-v3-envelope-integrity-mcp-narrative.md
+++ b/.changeset/fix-v3-envelope-integrity-mcp-narrative.md
@@ -1,0 +1,22 @@
+---
+---
+
+fix(compliance): clarify MCP transport envelope binding in v3_envelope_integrity storyboard
+
+The `v3_envelope_integrity/no_legacy_status_fields` step's narrative and
+expected block did not explain where `status` lives for MCP transport.
+Agent implementors seeing the `FAIL: Envelope carries the canonical v3
+status field` message from the compliance runner could incorrectly
+conclude the check is inapplicable to MCP agents.
+
+Updated the step narrative and `expected` block to explicitly document that:
+- For MCP agents, `status` MUST appear at the top level of `structuredContent`
+  (or the `content[0].text` JSON object for pre-2025-03-26 servers).
+- The extracted AdCP response IS the protocol envelope — `status` is not a
+  JSON-RPC result-level field; it lives inside the content alongside
+  task-specific fields.
+- An agent whose MCP response passes `response_schema` validation but omits
+  `status` is non-conformant: `get-adcp-capabilities-response.json` validates
+  only the task-specific payload fields, not the protocol envelope fields.
+
+Refs #3999.

--- a/static/compliance/source/universal/v3-envelope-integrity.yaml
+++ b/static/compliance/source/universal/v3-envelope-integrity.yaml
@@ -62,6 +62,18 @@ phases:
           The protocol-envelope.json schema's top-level `not: { anyOf: [...] }`
           constraint forbids either field, making this constraint detectable by
           any schema-aware validator without runner-specific primitives.
+
+          MCP transport note: the `status` field must appear at the top level of
+          `structuredContent` (or the first parseable `content[].text` JSON object
+          for older MCP servers) — it is NOT a JSON-RPC result-level field. The extracted AdCP
+          response IS the protocol envelope: `status` lives alongside task-specific
+          payload fields in the same flat object. The `get-adcp-capabilities-response.json`
+          schema validates only the task-specific fields (capabilities, context echo,
+          etc.) and does not cover protocol envelope fields like `status` — an agent
+          whose MCP response passes response_schema validation but omits `status` is
+          still non-conformant. See docs/building/implementation/mcp-response-extraction
+          for the normative MCP extraction algorithm and the expected structuredContent
+          shape, including the required `status` field at the top level.
         task: get_adcp_capabilities
         schema_ref: "protocol/get-adcp-capabilities-request.json"
         response_schema_ref: "protocol/get-adcp-capabilities-response.json"
@@ -69,13 +81,20 @@ phases:
         comply_scenario: envelope_integrity
         stateful: false
         expected: |
-          Response envelope:
+          Response envelope (all transports):
           - MUST contain status (the v3 canonical field)
           - MUST NOT contain task_status (v2 legacy, no v3 semantics)
           - MUST NOT contain response_status (v2 legacy, no v3 semantics)
           Both forbidden fields are blocked by the top-level `not: { anyOf: [...] }`
           constraint in protocol-envelope.json, so any schema-aware validator that
           validates the full protocol envelope will detect violations.
+
+          For MCP agents specifically: `status` MUST be present at the top level of
+          structuredContent (or the first parseable content[].text JSON object). It is not a JSON-RPC sibling
+          field — it lives inside the content payload, at the same level as the
+          task-specific response fields. An agent returning only the task payload
+          without `status` fails this check regardless of whether the payload itself
+          validates against the task response schema.
 
         sample_request:
           context:


### PR DESCRIPTION
Refs #3999

The `v3_envelope_integrity/no_legacy_status_fields` step narrative and `expected` block did not explain where `status` lives in MCP transport responses. Agent implementors reading only `get-adcp-capabilities-response.json` could include only the task-specific fields in their MCP `structuredContent`, omit `status`, pass the `response_schema` validation check, and then be confused by a failing `envelope_field_present: status` check.

**Root cause (from expert review):** The reporter's agent is non-conformant — it returns only the task payload in `structuredContent` without the required protocol envelope fields. The `response_schema` check passes because `get-adcp-capabilities-response.json` validates only the task-specific fields; `status` is a protocol envelope field not covered by that schema. The `envelope_field_present` check is correctly detecting the non-conformance. The fix is narrative clarification, not weakening the check.

The normative extraction algorithm at `docs/building/implementation/mcp-response-extraction` already shows `status` at the top level of `structuredContent`, but the storyboard didn't cross-reference it.

**Non-breaking justification:** Changes only `narrative:` and `expected:` text fields in the storyboard YAML. No check types, validation paths, or runner-contract fields are modified. The check remains `severity: required` — the conformance requirement is unchanged.

**Pre-PR review:**
- code-reviewer: approved — 1 blocker fixed (changed `content[0].text` → `content[].text` to match the normative extraction algorithm iterating all content items in order, not just item 0)
- ad-tech-protocol-expert: approved — flat `structuredContent` shape description is accurate per `static/test-vectors/mcp-response-extraction.json` and `mcp-response-extraction.mdx` line 87; nit noted (the merge step of envelope+payload into a flat object is not explained) as follow-up documentation debt

**Follow-up items (not in this PR):**
- `Sibling-repo-fix-needed: adcp-client` — the code reviewer noted that `envelope_field_present` may not correctly implement MCP extraction semantics (checking the extracted envelope vs. the raw JSON-RPC result). Should be verified in `@adcp/client` to confirm the check traverses the extracted `structuredContent` object per `mcp-response-extraction.mdx`. If the runner has a separate bug, a `severity: advisory` annotation may be needed in a follow-up.
- `lint-storyboard-validations-paths.cjs` — `envelope_field_present` is absent from `PATH_BEARING_CHECKS`; a typo in an `envelope_field_present` path would not be caught. Follow-up lint improvement.
- Seller integration guide could document the envelope+payload merge step that MCP agents must perform.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_017QfEu3mAJG9SQk6JUiBGrx

---
_Generated by [Claude Code](https://claude.ai/code/session_017QfEu3mAJG9SQk6JUiBGrx)_