### PR TITLE
docs(governance): five → six domains in overview (closes #3985)

### DIFF
--- a/.changeset/governance-overview-six-domains.md
+++ b/.changeset/governance-overview-six-domains.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs(governance): fix "five domains" → "six domains" in overview to match the six cards rendered (closes #3985).

--- a/docs/governance/overview.mdx
+++ b/docs/governance/overview.mdx
@@ -259,7 +259,7 @@ Every step in this walkthrough reflects a principle from the [Embedded Human Jud
 
 ## Protocol domains
 
-The Governance Protocol covers five domains:
+The Governance Protocol covers six domains:
 
 <CardGroup cols={2}>
   <Card title="Policy registry" icon="book" href="/docs/governance/policy-registry">


### PR DESCRIPTION
## Summary
- The governance overview lists six domain cards (policy registry, property, collection, content standards, creative, campaign) but the lead-in sentence still said "five domains".
- Update the prose to match what's actually rendered.

Closes #3985.

## Test plan
- [x] Visual: lead-in count now matches the six `<Card>` children in the `CardGroup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)