### PR TITLE
feat(admin): founding member audit trail

### DIFF
--- a/.changeset/founding-member-audit-trail.md
+++ b/.changeset/founding-member-audit-trail.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add audit trail columns for founding member flag overrides on member_profiles (server only — no protocol impact).

--- a/server/src/db/member-db.ts
+++ b/server/src/db/member-db.ts
@@ -175,6 +175,10 @@ export class MemberDatabase {
       is_public: 'is_public',
       show_in_carousel: 'show_in_carousel',
       is_founding_member: 'is_founding_member',
+      founding_member_source: 'founding_member_source',
+      founding_member_granted_at: 'founding_member_granted_at',
+      founding_member_granted_reason: 'founding_member_granted_reason',
+      founding_member_granted_by: 'founding_member_granted_by',
     };
 
     const setClauses: string[] = [];

--- a/server/src/db/migrations/465_founding_member_audit_trail.sql
+++ b/server/src/db/migrations/465_founding_member_audit_trail.sql
@@ -1,0 +1,32 @@
+-- Add audit trail for founding member flag overrides on member_profiles.
+-- Resolves issue #4014: is_founding_member was auto-set by migrations 147/180
+-- with no record of who flipped it manually, when, or why.
+
+ALTER TABLE member_profiles
+  ADD COLUMN IF NOT EXISTS founding_member_source TEXT
+    CHECK (founding_member_source IN ('auto_pre_cutoff', 'manual_grandfather')),
+  ADD COLUMN IF NOT EXISTS founding_member_granted_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS founding_member_granted_reason TEXT,
+  ADD COLUMN IF NOT EXISTS founding_member_granted_by TEXT;
+
+-- Backfill all auto-granted founding members (created before the cutoff date).
+-- Guard on source IS NULL makes this idempotent if the migration re-runs.
+UPDATE member_profiles
+SET
+  founding_member_source = 'auto_pre_cutoff',
+  founding_member_granted_at = created_at
+WHERE is_founding_member = TRUE
+  AND created_at < '2026-04-01'::timestamptz
+  AND founding_member_source IS NULL;
+
+-- Backfill the one known manual grandfather (grandfathered 2026-05-03
+-- after pre-deadline site issues blocked enrollment).
+-- UUID and timestamp confirmed by repo owner in issue #4014.
+UPDATE member_profiles
+SET
+  founding_member_source = 'manual_grandfather',
+  founding_member_granted_at = '2026-05-03T18:22:35Z'::timestamptz,
+  founding_member_granted_reason = 'site issues blocked pre-deadline enrollment'
+WHERE id = 'b05f2b5a-aae8-4c72-b7d5-c7ffc8977988'
+  AND is_founding_member = TRUE
+  AND founding_member_source IS NULL;

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -1851,6 +1851,30 @@ export function createAdminMemberProfileRouter(config: MemberProfileRoutesConfig
       delete updates.created_at;
       delete updates.updated_at;
 
+      // founding_member_granted_by and founding_member_granted_at are set
+      // server-side below — strip any body-supplied values to prevent spoofing.
+      delete updates.founding_member_granted_by;
+      delete updates.founding_member_granted_at;
+
+      // Audit trail for is_founding_member grants
+      if (updates.is_founding_member === true) {
+        // Default to 'manual_grandfather' so existing callers that set the flag
+        // without a source continue to work (backward compatibility).
+        if (updates.founding_member_source == null) {
+          updates.founding_member_source = 'manual_grandfather';
+        }
+        // Block auto_pre_cutoff from being written via the API —
+        // that value is reserved for automated migrations (147/180/465).
+        if (updates.founding_member_source === 'auto_pre_cutoff') {
+          return res.status(400).json({
+            error: 'Invalid founding_member_source',
+            message: "auto_pre_cutoff is reserved for automated migrations. Use 'manual_grandfather' for admin grants.",
+          });
+        }
+        updates.founding_member_granted_by = req.user!.id;
+        updates.founding_member_granted_at = new Date();
+      }
+
       // Even an admin caller cannot pin an agent type that contradicts the
       // probed capability snapshot — see resolveAgentTypes() + issue #3495.
       if (Array.isArray(updates.agents)) {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -744,6 +744,10 @@ export interface MemberProfile {
   show_in_carousel: boolean;
   featured: boolean;
   is_founding_member: boolean;
+  founding_member_source?: string;
+  founding_member_granted_at?: Date;
+  founding_member_granted_reason?: string;
+  founding_member_granted_by?: string;
   created_at: Date;
   updated_at: Date;
 }
@@ -795,6 +799,11 @@ export interface UpdateMemberProfileInput {
   is_public?: boolean;
   show_in_carousel?: boolean;
   is_founding_member?: boolean;
+  founding_member_source?: string;
+  founding_member_granted_reason?: string;
+  // Set server-side from req.user — never accepted from request body
+  founding_member_granted_by?: string;
+  founding_member_granted_at?: Date | string;
 }
 
 export interface ListMemberProfilesOptions {


### PR DESCRIPTION
Closes #4014

Adds an audit trail for `member_profiles.is_founding_member` manual overrides so future admins can distinguish auto-grants (migration-driven) from manual grandfathering decisions.

## What changed

**Migration 465** adds four nullable columns to `member_profiles`:

| Column | Type | Purpose |
|---|---|---|
| `founding_member_source` | `TEXT CHECK IN ('auto_pre_cutoff', 'manual_grandfather')` | Distinguishes auto-grant vs manual |
| `founding_member_granted_at` | `TIMESTAMPTZ` | When the status was set |
| `founding_member_granted_reason` | `TEXT` | Free-text rationale |
| `founding_member_granted_by` | `TEXT` | WorkOS user ID of granting admin (server-side only) |

Backfills on migration run:
- All rows where `is_founding_member = TRUE AND created_at < 2026-04-01` → `source = 'auto_pre_cutoff'`, `granted_at = created_at`
- One known manual grandfather (UUID from issue #4014, verified by @bokelley) → `source = 'manual_grandfather'`, `granted_at = 2026-05-03T18:22:35Z`, reason set

Both UPDATE statements are guarded with `AND founding_member_source IS NULL` for idempotency.

**Admin PUT route** (`server/src/routes/member-profiles.ts:1851`):
- `founding_member_granted_by` and `founding_member_granted_at` stripped from request body (prevent spoofing)
- When `is_founding_member: true` is set: defaults `source` to `'manual_grandfather'` (backward compat for existing callers), blocks `'auto_pre_cutoff'` via API (migrations only), captures `granted_by = req.user!.id` and `granted_at = new Date()` server-side

**Non-breaking justification:** All four new columns are nullable with no DEFAULT; existing INSERT/UPDATE paths are unaffected. The route-level validation is backward-compatible (missing source defaults to `'manual_grandfather'`).

## Notes (from pre-PR review)

- `founding_member_granted_by` stores a WorkOS user ID, consistent with the `set_by_user_id` pattern used elsewhere in this codebase (e.g. `type_reclassification_log`). If cross-referencing by email is needed, that's a follow-up.
- Revocation tracking (setting `is_founding_member: false`) is not in scope for this issue — the issue asks only about grant provenance. Follow-up if needed.
- Admin UI surfacing of `founding_member_source` is deferred per the issue ("optional, but cheap once the data is there").
- Post-migration verification: `SELECT id, founding_member_source FROM member_profiles WHERE is_founding_member = TRUE AND founding_member_source IS NULL` should return 0 rows after migration 465 runs.

## Pre-PR review

- code-reviewer: approved — migration idempotency guard added, null-safety fixed, type consistency aligned (`new Date()` not `.toISOString()`)
- internal-tools-strategist: approved — Option A correctly scoped; revocation tracking and email denormalization noted as follow-ups, not blockers for this issue's stated scope

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01Gd19avtPzkW362ahfkpfhe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gd19avtPzkW362ahfkpfhe)_