### PR TITLE
feat(member-profiles): audit trail for founding member grants

### DIFF
--- a/.changeset/founding-member-audit-columns.md
+++ b/.changeset/founding-member-audit-columns.md
@@ -1,0 +1,20 @@
+---
+---
+
+Audit trail for `member_profiles.is_founding_member` (closes #4014).
+
+Adds three columns — `founding_member_source`
+(`auto_pre_cutoff` | `manual_grandfather`), `founding_member_granted_at`,
+`founding_member_granted_reason` — and backfills auto-grants from `created_at`
+plus the one known manual grandfather (Affinity Answers, 2026-05-03).
+
+The admin update paths (HTTP `PUT /api/admin/member-profiles/:id` and the
+Addie `update_member_profile` MCP tool) now reject `is_founding_member: true`
+without a `founding_member_source`, stamp `granted_at` server-side (callers
+can't backdate provenance), and clear the audit metadata on revoke.
+Non-admin update paths strip the new fields the same way they strip
+`is_founding_member`.
+
+Out of scope (follow-ups): coupling the badge grant to the Stripe pricing
+override, and broadening `founding_member_source` beyond the two current
+categories.

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -30,6 +30,7 @@ import { WorkingGroupDatabase } from '../../db/working-group-db.js';
 import { getPool, escapeLikePattern } from '../../db/client.js';
 import { MemberSearchAnalyticsDatabase } from '../../db/member-search-analytics-db.js';
 import { MemberDatabase } from '../../db/member-db.js';
+import { normalizeFoundingMemberGrant, foundingMemberFieldsTouched } from '../../services/founding-member-grant.js';
 import { BrandDatabase } from '../../db/brand-db.js';
 import {
   getPendingInvoices,
@@ -1456,7 +1457,16 @@ For logo changes, use update_member_logo instead.`,
         },
         is_public: { type: 'boolean', description: 'Whether profile is visible in the public member directory.' },
         show_in_carousel: { type: 'boolean', description: 'Whether profile appears in the homepage carousel.' },
-        is_founding_member: { type: 'boolean', description: 'Whether this member has founding member status. Admin-only. Use to grant founding status to members who joined late due to billing or other issues.' },
+        is_founding_member: { type: 'boolean', description: 'Whether this member has founding member status. Admin-only. Setting true requires founding_member_source.' },
+        founding_member_source: {
+          type: 'string',
+          enum: ['auto_pre_cutoff', 'manual_grandfather'],
+          description: 'Provenance for the founding member flag. Use "manual_grandfather" for admin overrides outside the auto-cutoff window.',
+        },
+        founding_member_granted_reason: {
+          type: 'string',
+          description: 'Free-text reason for a manual grandfather grant (e.g., "site issues blocked pre-deadline enrollment"). Recorded for audit.',
+        },
       },
     },
   },
@@ -7929,7 +7939,25 @@ Use add_committee_leader to assign a leader.`;
 
       if (input.is_founding_member !== undefined) {
         updates.is_founding_member = input.is_founding_member;
-        updatedFields.push('is_founding_member');
+      }
+      if (input.founding_member_source !== undefined) {
+        updates.founding_member_source = input.founding_member_source;
+      }
+      if (input.founding_member_granted_reason !== undefined) {
+        updates.founding_member_granted_reason = input.founding_member_granted_reason;
+      }
+
+      const foundingError = normalizeFoundingMemberGrant(updates);
+      if (foundingError) {
+        return `❌ ${foundingError.message}`;
+      }
+      // Mirror everything the helper actually wrote — including the
+      // server-set granted_at and any cleared metadata on revoke — so the
+      // user-facing report doesn't lie about which columns changed.
+      for (const field of foundingMemberFieldsTouched(updates)) {
+        if (!updatedFields.includes(field)) {
+          updatedFields.push(field);
+        }
       }
 
       if (updatedFields.length === 0) {

--- a/server/src/db/member-db.ts
+++ b/server/src/db/member-db.ts
@@ -175,6 +175,9 @@ export class MemberDatabase {
       is_public: 'is_public',
       show_in_carousel: 'show_in_carousel',
       is_founding_member: 'is_founding_member',
+      founding_member_source: 'founding_member_source',
+      founding_member_granted_at: 'founding_member_granted_at',
+      founding_member_granted_reason: 'founding_member_granted_reason',
     };
 
     const setClauses: string[] = [];

--- a/server/src/db/migrations/465_founding_member_audit_columns.sql
+++ b/server/src/db/migrations/465_founding_member_audit_columns.sql
@@ -1,0 +1,42 @@
+-- Audit trail for member_profiles.is_founding_member.
+-- The flag was being set both automatically (created_at < cutoff) and
+-- manually (admin override) with no way to distinguish the two.
+
+ALTER TABLE member_profiles
+  ADD COLUMN IF NOT EXISTS founding_member_source TEXT
+    CHECK (founding_member_source IN ('auto_pre_cutoff', 'manual_grandfather')),
+  ADD COLUMN IF NOT EXISTS founding_member_granted_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS founding_member_granted_reason TEXT;
+
+-- Backfill auto-grants: every existing founding member whose profile
+-- predates the 2026-04-01 cutoff was set by migration 147/180.
+UPDATE member_profiles
+SET founding_member_source = 'auto_pre_cutoff',
+    founding_member_granted_at = created_at
+WHERE is_founding_member = TRUE
+  AND created_at < '2026-04-01'::timestamptz
+  AND founding_member_source IS NULL;
+
+-- Backfill the one known manual grandfather (Affinity Answers, flipped
+-- 2026-05-03 after Vivek reported pre-deadline site issues). Idempotent
+-- via the workos_organization_id match plus the IS NULL guard.
+UPDATE member_profiles
+SET founding_member_source = 'manual_grandfather',
+    founding_member_granted_at = '2026-05-03T18:22:35Z'::timestamptz,
+    founding_member_granted_reason = 'Pre-deadline enrollment blocked by site issues; grandfathered per Vivek/Affinity Answers'
+WHERE workos_organization_id = 'org_01KKBDJPRJ7WDX4W4MASFN33Y0'
+  AND is_founding_member = TRUE
+  AND founding_member_source IS NULL;
+
+-- Defensive: any remaining flagged row with no source is a manual grant
+-- whose context has been lost. Mark it as manual with a self-documenting
+-- reason so the audit row isn't indistinguishable from a real grant later.
+UPDATE member_profiles
+SET founding_member_source = 'manual_grandfather',
+    founding_member_granted_at = COALESCE(founding_member_granted_at, updated_at),
+    founding_member_granted_reason = COALESCE(
+      founding_member_granted_reason,
+      'backfill: pre-migration manual grant; original context not recorded'
+    )
+WHERE is_founding_member = TRUE
+  AND founding_member_source IS NULL;

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -37,6 +37,7 @@ import { createEscalation } from "../db/escalation-db.js";
 import { insertTypeReclassification } from "../db/type-reclassification-log-db.js";
 import { recordProfilePublishedIfNeeded } from "../services/profile-publish-event.js";
 import { gateAgentVisibilityForCaller, type VisibilityWarning } from "../services/agent-visibility-gate.js";
+import { normalizeFoundingMemberGrant } from "../services/founding-member-grant.js";
 
 const orgKnowledgeDb = new OrgKnowledgeDatabase();
 const snapshotDb = new AgentSnapshotDatabase();
@@ -661,6 +662,9 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       delete updates.updated_at;
       delete updates.featured; // Only admins can set featured
       delete updates.is_founding_member; // Only admins can set founding status
+      delete updates.founding_member_source;
+      delete updates.founding_member_granted_at;
+      delete updates.founding_member_granted_reason;
 
       // Enforce the tier gate on agent visibility so bulk-profile updates
       // cannot bypass the per-agent PATCH. Non-API-access callers may only
@@ -1850,6 +1854,14 @@ export function createAdminMemberProfileRouter(config: MemberProfileRoutesConfig
       delete updates.workos_organization_id;
       delete updates.created_at;
       delete updates.updated_at;
+
+      const foundingError = normalizeFoundingMemberGrant(updates);
+      if (foundingError) {
+        return res.status(400).json({
+          error: 'Invalid founding member update',
+          message: foundingError.message,
+        });
+      }
 
       // Even an admin caller cannot pin an agent type that contradicts the
       // probed capability snapshot — see resolveAgentTypes() + issue #3495.

--- a/server/src/services/founding-member-grant.ts
+++ b/server/src/services/founding-member-grant.ts
@@ -1,0 +1,92 @@
+import type { UpdateMemberProfileInput } from '../types.js';
+
+export type FoundingMemberSource = 'auto_pre_cutoff' | 'manual_grandfather';
+
+const VALID_SOURCES: readonly FoundingMemberSource[] = [
+  'auto_pre_cutoff',
+  'manual_grandfather',
+];
+
+export interface FoundingMemberGrantError {
+  code: 'missing_source' | 'invalid_source' | 'orphan_metadata';
+  message: string;
+}
+
+/**
+ * Normalize a member-profile update so that the founding-member audit
+ * columns stay coherent with the boolean flag.
+ *
+ * Rules:
+ *   - is_founding_member=true requires founding_member_source. granted_at
+ *     is always set server-side to NOW() (callers can't backdate it).
+ *   - is_founding_member=false clears source/granted_at/reason so a future
+ *     re-grant carries fresh provenance instead of stale metadata.
+ *   - Sending source/granted_reason without flipping is_founding_member
+ *     in the same call is rejected — the boolean is the source of truth.
+ *
+ * Mutates `updates` in place. Returns null on success, an error object on
+ * validation failure. The list of fields actually written by this helper
+ * is exposed via {@link foundingMemberFieldsTouched} so callers (e.g. the
+ * MCP tool's "updated fields" report) can mirror what landed in the DB.
+ */
+export function normalizeFoundingMemberGrant(
+  updates: UpdateMemberProfileInput
+): FoundingMemberGrantError | null {
+  const hasFlag = updates.is_founding_member !== undefined;
+  const hasMetadata =
+    updates.founding_member_source !== undefined ||
+    updates.founding_member_granted_reason !== undefined;
+
+  if (!hasFlag && !hasMetadata) {
+    return null;
+  }
+
+  if (!hasFlag && hasMetadata) {
+    return {
+      code: 'orphan_metadata',
+      message:
+        'founding_member_source / granted_reason can only be set together with is_founding_member.',
+    };
+  }
+
+  if (updates.is_founding_member === true) {
+    const source = updates.founding_member_source;
+    if (!source) {
+      return {
+        code: 'missing_source',
+        message:
+          'founding_member_source is required when granting founding member status. Use "manual_grandfather" for admin overrides.',
+      };
+    }
+    if (!VALID_SOURCES.includes(source)) {
+      return {
+        code: 'invalid_source',
+        message: `founding_member_source must be one of: ${VALID_SOURCES.join(', ')}.`,
+      };
+    }
+    updates.founding_member_granted_at = new Date();
+    return null;
+  }
+
+  // is_founding_member === false: revoke and clear audit metadata.
+  updates.founding_member_source = null;
+  updates.founding_member_granted_at = null;
+  updates.founding_member_granted_reason = null;
+  return null;
+}
+
+/**
+ * Names of the founding-member columns this helper may have written into
+ * `updates` (after a successful normalize). For MCP-style "updated fields"
+ * reports that need to mirror what actually landed.
+ */
+export function foundingMemberFieldsTouched(
+  updates: UpdateMemberProfileInput
+): string[] {
+  return [
+    'is_founding_member',
+    'founding_member_source',
+    'founding_member_granted_at',
+    'founding_member_granted_reason',
+  ].filter((k) => k in updates);
+}

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -744,6 +744,9 @@ export interface MemberProfile {
   show_in_carousel: boolean;
   featured: boolean;
   is_founding_member: boolean;
+  founding_member_source: 'auto_pre_cutoff' | 'manual_grandfather' | null;
+  founding_member_granted_at: Date | null;
+  founding_member_granted_reason: string | null;
   created_at: Date;
   updated_at: Date;
 }
@@ -795,6 +798,14 @@ export interface UpdateMemberProfileInput {
   is_public?: boolean;
   show_in_carousel?: boolean;
   is_founding_member?: boolean;
+  founding_member_source?: 'auto_pre_cutoff' | 'manual_grandfather' | null;
+  founding_member_granted_reason?: string | null;
+  /**
+   * Server-set on grant; not accepted from API callers (would let an admin
+   * backdate provenance). The helper writes NOW() on grant and NULL on revoke.
+   * Migrations bypass this by writing the column directly.
+   */
+  founding_member_granted_at?: Date | null;
 }
 
 export interface ListMemberProfilesOptions {

--- a/server/tests/integration/member-db.test.ts
+++ b/server/tests/integration/member-db.test.ts
@@ -444,4 +444,94 @@ describe('MemberDatabase Integration Tests', () => {
       expect(notAvailable).toBe(false);
     });
   });
+
+  describe('founding member audit columns', () => {
+    it('round-trips source / granted_at / granted_reason via updateProfile', async () => {
+      const orgId = createTestOrgId('founding_audit');
+      await createTestOrg(orgId);
+
+      const created = await memberDb.createProfile({
+        workos_organization_id: orgId,
+        display_name: 'Founding Audit Co',
+        slug: 'founding-audit-co',
+      });
+
+      expect(created.is_founding_member).toBe(false);
+      expect(created.founding_member_source).toBeNull();
+      expect(created.founding_member_granted_at).toBeNull();
+      expect(created.founding_member_granted_reason).toBeNull();
+
+      const grantedAt = new Date('2026-05-03T18:22:35Z');
+      const updated = await memberDb.updateProfile(created.id, {
+        is_founding_member: true,
+        founding_member_source: 'manual_grandfather',
+        founding_member_granted_at: grantedAt,
+        founding_member_granted_reason: 'site issues blocked enrollment',
+      });
+
+      expect(updated).not.toBeNull();
+      expect(updated!.is_founding_member).toBe(true);
+      expect(updated!.founding_member_source).toBe('manual_grandfather');
+      expect(updated!.founding_member_granted_reason).toBe('site issues blocked enrollment');
+      // updateProfile is the raw db layer (no normalization helper here),
+      // so the timestamp the caller passed lands as-is. Server-set NOW()
+      // semantics live in normalizeFoundingMemberGrant; the route/MCP
+      // tests cover that path.
+      expect(new Date(updated!.founding_member_granted_at!).toISOString()).toBe(grantedAt.toISOString());
+    });
+
+    it('CHECK constraint rejects an unknown source', async () => {
+      const orgId = createTestOrgId('founding_check');
+      await createTestOrg(orgId);
+      const created = await memberDb.createProfile({
+        workos_organization_id: orgId,
+        display_name: 'Check Co',
+        slug: 'check-co',
+      });
+
+      await expect(
+        pool.query(
+          `UPDATE member_profiles SET founding_member_source = 'bogus' WHERE id = $1`,
+          [created.id]
+        )
+      ).rejects.toThrow();
+    });
+
+    it('migration backfill predicates classify a synthetic auto-grant correctly', async () => {
+      const orgId = createTestOrgId('backfill_auto');
+      await createTestOrg(orgId);
+
+      // Insert a row that mimics a pre-cutoff founding member with the
+      // audit columns left null (the state migration 465 expects to find
+      // when it runs against a DB that was already past migration 180).
+      const inserted = await pool.query<{ id: string }>(
+        `INSERT INTO member_profiles
+           (workos_organization_id, display_name, slug,
+            is_founding_member, created_at,
+            founding_member_source, founding_member_granted_at, founding_member_granted_reason)
+         VALUES ($1, $2, $3, TRUE, '2026-03-15T00:00:00Z'::timestamptz, NULL, NULL, NULL)
+         RETURNING id`,
+        [orgId, 'Backfill Auto Co', 'backfill-auto-co']
+      );
+      const id = inserted.rows[0].id;
+
+      // Re-run the same predicate the migration uses for auto_pre_cutoff.
+      await pool.query(
+        `UPDATE member_profiles
+         SET founding_member_source = 'auto_pre_cutoff',
+             founding_member_granted_at = created_at
+         WHERE id = $1
+           AND is_founding_member = TRUE
+           AND created_at < '2026-04-01'::timestamptz
+           AND founding_member_source IS NULL`,
+        [id]
+      );
+
+      const after = await memberDb.getProfileById(id);
+      expect(after!.founding_member_source).toBe('auto_pre_cutoff');
+      expect(new Date(after!.founding_member_granted_at!).toISOString()).toBe(
+        '2026-03-15T00:00:00.000Z'
+      );
+    });
+  });
 });

--- a/server/tests/unit/founding-member-grant.test.ts
+++ b/server/tests/unit/founding-member-grant.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeFoundingMemberGrant,
+  foundingMemberFieldsTouched,
+} from '../../src/services/founding-member-grant.js';
+import type { UpdateMemberProfileInput } from '../../src/types.js';
+
+describe('normalizeFoundingMemberGrant', () => {
+  it('is a no-op when no founding fields are present', () => {
+    const updates: UpdateMemberProfileInput = { display_name: 'X' };
+    const err = normalizeFoundingMemberGrant(updates);
+    expect(err).toBeNull();
+    expect(updates).toEqual({ display_name: 'X' });
+  });
+
+  it('rejects is_founding_member=true without a source', () => {
+    const updates: UpdateMemberProfileInput = { is_founding_member: true };
+    const err = normalizeFoundingMemberGrant(updates);
+    expect(err?.code).toBe('missing_source');
+  });
+
+  it('accepts a valid manual_grandfather grant and stamps granted_at server-side', () => {
+    const before = Date.now();
+    const updates: UpdateMemberProfileInput = {
+      is_founding_member: true,
+      founding_member_source: 'manual_grandfather',
+      founding_member_granted_reason: 'site issues blocked enrollment',
+    };
+    const err = normalizeFoundingMemberGrant(updates);
+    expect(err).toBeNull();
+    expect(updates.founding_member_source).toBe('manual_grandfather');
+    expect(updates.founding_member_granted_at).toBeInstanceOf(Date);
+    const grantedAt = (updates.founding_member_granted_at as Date).getTime();
+    expect(grantedAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it('overrides any caller-supplied granted_at to prevent backdating', () => {
+    const backdated = new Date('2026-03-01T00:00:00Z');
+    const before = Date.now();
+    const updates: UpdateMemberProfileInput = {
+      is_founding_member: true,
+      founding_member_source: 'manual_grandfather',
+      founding_member_granted_at: backdated,
+    };
+    const err = normalizeFoundingMemberGrant(updates);
+    expect(err).toBeNull();
+    const stamped = updates.founding_member_granted_at as Date;
+    expect(stamped.getTime()).toBeGreaterThanOrEqual(before);
+    expect(stamped.getTime()).not.toBe(backdated.getTime());
+  });
+
+  it('rejects an unknown source value', () => {
+    const updates = {
+      is_founding_member: true,
+      founding_member_source: 'bogus' as unknown as 'manual_grandfather',
+    } satisfies UpdateMemberProfileInput;
+    const err = normalizeFoundingMemberGrant(updates);
+    expect(err?.code).toBe('invalid_source');
+  });
+
+  it('clears audit metadata when revoking founding status', () => {
+    const updates: UpdateMemberProfileInput = {
+      is_founding_member: false,
+      founding_member_source: 'manual_grandfather',
+      founding_member_granted_reason: 'no longer applies',
+    };
+    const err = normalizeFoundingMemberGrant(updates);
+    expect(err).toBeNull();
+    expect(updates.founding_member_source).toBeNull();
+    expect(updates.founding_member_granted_at).toBeNull();
+    expect(updates.founding_member_granted_reason).toBeNull();
+  });
+
+  it('rejects orphaned audit metadata without an is_founding_member flag', () => {
+    const updates: UpdateMemberProfileInput = {
+      founding_member_source: 'manual_grandfather',
+    };
+    const err = normalizeFoundingMemberGrant(updates);
+    expect(err?.code).toBe('orphan_metadata');
+  });
+});
+
+describe('foundingMemberFieldsTouched', () => {
+  it('lists every founding column the helper wrote on grant', () => {
+    const updates: UpdateMemberProfileInput = {
+      is_founding_member: true,
+      founding_member_source: 'manual_grandfather',
+      founding_member_granted_reason: 'because',
+    };
+    normalizeFoundingMemberGrant(updates);
+    expect(foundingMemberFieldsTouched(updates).sort()).toEqual([
+      'founding_member_granted_at',
+      'founding_member_granted_reason',
+      'founding_member_source',
+      'is_founding_member',
+    ]);
+  });
+
+  it('lists the cleared columns on revoke', () => {
+    const updates: UpdateMemberProfileInput = { is_founding_member: false };
+    normalizeFoundingMemberGrant(updates);
+    expect(foundingMemberFieldsTouched(updates).sort()).toEqual([
+      'founding_member_granted_at',
+      'founding_member_granted_reason',
+      'founding_member_source',
+      'is_founding_member',
+    ]);
+  });
+
+  it('returns an empty list when nothing founding-related was set', () => {
+    const updates: UpdateMemberProfileInput = { display_name: 'X' };
+    normalizeFoundingMemberGrant(updates);
+    expect(foundingMemberFieldsTouched(updates)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #4014. Adds `founding_member_source` / `founding_member_granted_at` / `founding_member_granted_reason` to `member_profiles` so manual grandfather grants are distinguishable from the automatic pre-cutoff backfill.

The two admin write paths — HTTP `PUT /api/admin/member-profiles/:id` and the Addie `update_member_profile` MCP tool — now go through `normalizeFoundingMemberGrant`, which:

- Rejects `is_founding_member: true` without a `founding_member_source`.
- Stamps `granted_at` server-side (callers can't backdate provenance).
- Clears all three audit columns on revoke so a future re-grant carries fresh metadata.

Migration 465 backfills auto-grants from `created_at`, plus the one known manual case (Affinity Answers, 2026-05-03), with a defensive sweep for any other in-the-wild manual grants whose context is lost.

## Review feedback addressed

Three experts reviewed the pre-commit diff. Material changes from their feedback:

- **Security review (MED):** dropped client-supplied `granted_at` from the API surface; helper always sets `NOW()`. Backdating closed.
- **Code review:** MCP tool's "updated fields" report now mirrors helper-injected writes via `foundingMemberFieldsTouched()`. Added test for the auto-stamp and revoke-clear cases.
- **Code review:** defensive backfill sweep now writes a self-documenting reason (`'backfill: pre-migration manual grant; original context not recorded'`) so audit rows aren't indistinguishable from real grants later.
- **Code review:** added integration test for the auto_pre_cutoff backfill predicate.

## Out of scope (follow-ups)

- **Badge ↔ Stripe pricing coupling:** the Stripe locked-in price override is a separate system. A future `grantFoundingMember()` workflow should atomically apply both (raised by adtech-product expert; deferred to keep this PR focused on audit).
- **Broader `source` taxonomy:** the two-value enum (`auto_pre_cutoff` | `manual_grandfather`) covers today's cases. When a third reason emerges (e.g. `partner_comp`, `working_group_chair`), widen the CHECK constraint in one ALTER.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Unit tests: 10 / 10 pass (`tests/unit/founding-member-grant.test.ts`)
- [x] Integration tests: 27 / 27 pass (`tests/integration/member-db.test.ts`)
- [ ] Migration 465 runs cleanly on a fresh prod-like DB with the existing Founding rows and the one in-prod Affinity Answers row already flipped (CI release_command will exercise this on Fly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)