### PR TITLE
feat(schema): add produced_by to format.assets[] to distinguish input/output slots

### DIFF
--- a/.changeset/format-assets-produced-by.md
+++ b/.changeset/format-assets-produced-by.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": minor
+---
+
+Add `produced_by` enum to `format.assets[]` slots to distinguish buyer-provided inputs from creative-agent-generated outputs.
+
+`produced_by: 'buyer'` (default, backward-compatible) means the buyer provides the asset in `build_creative` input requests. `produced_by: 'build_creative'` means the creative agent generates the asset in the response; buyers MUST NOT include it in input requests, and implementations MUST reject requests that supply a value for such a slot.
+
+Added to both `baseIndividualAsset` and `baseGroupAsset` definitions. Resolves conformance ambiguity in adapters that currently declare output slots using `required: false` because no better discriminator existed. Closes #4021.

--- a/static/schemas/source/core/format.json
+++ b/static/schemas/source/core/format.json
@@ -23,7 +23,14 @@
         },
         "required": {
           "type": "boolean",
-          "description": "Whether this asset is required (true) or optional (false). Required assets must be provided for a valid creative. Optional assets enhance the creative but are not mandatory."
+          "default": false,
+          "description": "Whether this asset is required (true) or optional (false). Required assets must be provided for a valid creative. Optional assets enhance the creative but are not mandatory. Only applies to buyer-provided slots (produced_by: 'buyer')."
+        },
+        "produced_by": {
+          "type": "string",
+          "enum": ["buyer", "build_creative"],
+          "default": "buyer",
+          "description": "Who produces this asset. 'buyer' (default) means the buyer provides this asset in build_creative input requests. 'build_creative' means the creative agent generates this asset in the response; buyers MUST NOT include it in input requests, and implementations MUST reject build_creative requests that supply a value for this slot."
         },
         "overlays": {
           "type": "array",
@@ -31,7 +38,14 @@
           "items": { "$ref": "/schemas/core/overlay.json" }
         }
       },
-      "required": ["item_type", "asset_id", "asset_type", "required"]
+      "required": ["item_type", "asset_id", "asset_type", "required"],
+      "if": {
+        "properties": { "produced_by": { "const": "build_creative" } },
+        "required": ["produced_by"]
+      },
+      "then": {
+        "properties": { "required": { "const": false } }
+      }
     },
     "baseGroupAsset": {
       "type": "object",
@@ -46,8 +60,14 @@
         },
         "required": {
           "type": "boolean",
-          "description": "Whether this asset is required within each repetition of the group",
+          "description": "Whether this asset is required within each repetition of the group. Only applies to buyer-provided slots (produced_by: 'buyer').",
           "default": false
+        },
+        "produced_by": {
+          "type": "string",
+          "enum": ["buyer", "build_creative"],
+          "default": "buyer",
+          "description": "Who produces this asset. 'buyer' (default) means the buyer provides this asset in build_creative input requests. 'build_creative' means the creative agent generates this asset in the response; buyers MUST NOT include it in input requests, and implementations MUST reject build_creative requests that supply a value for this slot."
         },
         "overlays": {
           "type": "array",
@@ -55,7 +75,14 @@
           "items": { "$ref": "/schemas/core/overlay.json" }
         }
       },
-      "required": ["asset_id", "asset_type", "required"]
+      "required": ["asset_id", "asset_type", "required"],
+      "if": {
+        "properties": { "produced_by": { "const": "build_creative" } },
+        "required": ["produced_by"]
+      },
+      "then": {
+        "properties": { "required": { "const": false } }
+      }
     }
   },
   "properties": {
@@ -195,7 +222,7 @@
     },
     "assets": {
       "type": "array",
-      "description": "Array of all assets supported for this format. Each asset is identified by its asset_id, which must be used as the key in creative manifests. Use the 'required' boolean on each asset to indicate whether it's mandatory.",
+      "description": "Array of all assets supported for this format. Each asset is identified by its asset_id, which must be used as the key in creative manifests. Use the 'required' boolean on each asset to indicate whether it's mandatory. Use 'produced_by' to distinguish slots the buyer provides in build_creative requests ('buyer', default) from slots the creative agent generates in the response ('build_creative').",
       "items": {
         "oneOf": [
           {


### PR DESCRIPTION
Closes #4021

## Summary

Adds optional `produced_by: enum ["buyer", "build_creative"]` with default `"buyer"` to both `baseIndividualAsset` and `baseGroupAsset` in `static/schemas/source/core/format.json`.

This resolves a conformance ambiguity where creative adapters had to declare output slots (assets the `build_creative` agent generates, not the buyer) using `required: false` — the only legal expression available in 3.0.x. Buyer agents reading `produced_by: "build_creative"` on a slot now know they MUST NOT supply it in `build_creative` input requests; agents receiving such a slot in input MUST return an error.

The change covers both `baseIndividualAsset` (individual asset slots) and `baseGroupAsset` (slots within repeatable groups). An `if/then` constraint is added to both defs to enforce `required: false` when `produced_by: "build_creative"`, preventing the undefined `required: true + build_creative` state. `default: false` is also added to `baseIndividualAsset.required` for symmetry with `baseGroupAsset`.

`render_time` (for impression-serving-time DCO assets) is intentionally deferred — there is no current AdCP task boundary for that lifecycle phase.

## Non-breaking justification

Adds optional fields (`produced_by`) with backward-compatible defaults (`"buyer"`). All existing `format.assets[]` declarations that omit `produced_by` are treated as `produced_by: "buyer"` by consumers — no existing format or manifest changes required. The `if/then` constraint only fires when `produced_by` is explicitly set to `"build_creative"`, which is new usage.

## Nits (not fixed)

- The normative "MUST NOT / MUST reject" language lives in the `description` string, which JSON Schema validators do not enforce. Enforcement is delegated to the adapter validation layer (consistent with how `build_creative` error handling works today). A follow-up issue should add a distinct `OUTPUT_ONLY_ASSET_PROVIDED` error code to `build_creative`'s error table for unambiguous implementation guidance.

## Pre-PR review

- **code-reviewer:** approved — JSON Schema Draft-07 valid, `if/then` pattern matches existing `parameters_from_format_id`/`dimensions` precedent in the same file, `default: false` symmetry resolved. Nit: normative language in description is unenforced by validators (acknowledged above).
- **ad-tech-protocol-expert:** approved — `produced_by` enum maps to OpenRTB 2.6 §3.2.7 and Native 1.2 §4.2 named-role precedent; `if/then` constraint prevents undefined dual-boolean state; `minor` changeset bump confirmed correct. Nit: description wording for MUST-subject (acknowledged above).

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID}

---
_Generated by [Claude Code](https://claude.ai/code/session_01XnswebF2rnC1GZDxsSSya1)_