### PR TITLE
ci(storyboards): fall back to @adcp/client compliance cache path on 3.0.x (closes #4000)

### DIFF
--- a/.changeset/4000-storyboard-overlay-package-rename.md
+++ b/.changeset/4000-storyboard-overlay-package-rename.md
@@ -1,0 +1,14 @@
+---
+---
+
+ci(storyboards): fall back to `@adcp/client` compliance cache path on 3.0.x (closes #4000)
+
+The training-agent storyboard workflow's `Overlay in-repo compliance source onto SDK cache` step looked for the SDK's compliance cache only at `node_modules/@adcp/sdk/compliance/cache`. That path is the post-rename location used on `main`; on 3.0.x the package is still `@adcp/client` and the cache lives at `node_modules/@adcp/client/compliance/cache`.
+
+The check silently skipped the overlay on every 3.0.x run (`SDK compliance cache not found under node_modules/@adcp/sdk/compliance/cache — skipping overlay`). With the overlay skipped, the storyboard runner read the SDK's frozen 3.0.0 snapshot — which doesn't carry the `fixtures:` block or `controller_seeding: true` flag those storyboards need. Pre-flight `comply_test_controller.seed_product` was never invoked, leaving 11 storyboards failing with `PRODUCT_NOT_FOUND` (or similarly-shaped seed-prerequisite errors): `sales_guaranteed`, `sales_broadcast_tv`, `media_buy_seller`, `media_buy_seller/delivery_reporting`, `media_buy_seller/governance_approved`, `creative_generative/seller`, `governance_delivery_monitor`, `governance_spend_authority`, `idempotency`, `brand_baseline`, `brand_rights`.
+
+The forward-merge from `main` (which moved the path to `@adcp/sdk` in `5.23.0`) didn't get reverted on 3.0.x at the workflow level, even though the package dependency stayed pinned to `@adcp/client@5.21.1`. PR #3893 (admin-merged 2026-05-02) was the first 3.0.x PR that triggered this CI under the renamed path; the storyboard CI has been failing on 3.0.x since.
+
+Fix: try the new path first, fall back to the old one. Both branches converge on a single workflow file that works regardless of which package the SDK is installed as. Local repro after the fix: 11/11 previously-failing storyboards pass (`sales_guaranteed ✓ 11P`, `sales_broadcast_tv ✓ 13P`, `brand_rights ✓ 6P`, `governance_delivery_monitor ✓ 12P`, `governance_spend_authority ✓ 9P`, all media_buy_seller scenarios `✓`, etc.).
+
+Empty changeset — CI workflow change, no protocol surface affected.

--- a/.github/workflows/training-agent-storyboards.yml
+++ b/.github/workflows/training-agent-storyboards.yml
@@ -105,12 +105,34 @@ jobs:
           # 5.13 moved the cache dir from `latest` to the AdCP version
           # string (e.g. `3.0.0`). 5.23.0 renamed the package
           # `@adcp/client` -> `@adcp/sdk` and the compliance bundle moved
-          # with it. Resolve whichever subdir exists so the overlay step
-          # doesn't have to bump with every SDK release.
-          CACHE_ROOT="node_modules/@adcp/sdk/compliance/cache"
+          # with it. main is on `@adcp/sdk`; 3.0.x is still on `@adcp/client`.
+          # Try the new path first, fall back to the old one — without this
+          # fallback, 3.0.x silently skipped the overlay (the SDK rename was
+          # forward-merged to the workflow without reverting on 3.0.x), and
+          # every storyboard fell back to the SDK's frozen 3.0.0 snapshot
+          # which doesn't carry the `fixtures:` block. Result: pre-flight
+          # `comply_test_controller.seed_product` was never invoked, leaving
+          # `sales_guaranteed`, `sales_broadcast_tv`, `media_buy_seller`,
+          # `media_buy_seller/delivery_reporting`,
+          # `media_buy_seller/governance_approved`,
+          # `creative_generative/seller`, `governance_delivery_monitor`,
+          # `governance_spend_authority`, `idempotency`, `brand_baseline`
+          # and `brand_rights` all failing with PRODUCT_NOT_FOUND or
+          # similarly-shaped seed-prerequisite errors.
+          CACHE_ROOT=""
+          for candidate in node_modules/@adcp/sdk/compliance/cache node_modules/@adcp/client/compliance/cache; do
+            if [ -d "$candidate" ]; then
+              CACHE_ROOT="$candidate"
+              break
+            fi
+          done
+          if [ -z "$CACHE_ROOT" ]; then
+            echo "::warning::SDK compliance cache not found under @adcp/sdk or @adcp/client — skipping overlay"
+            exit 0
+          fi
           DST=$(find "$CACHE_ROOT" -mindepth 1 -maxdepth 1 -type d | head -1)
           if [ -z "$DST" ] || [ ! -d "$DST" ]; then
-            echo "::warning::SDK compliance cache not found under $CACHE_ROOT — skipping overlay"
+            echo "::warning::SDK compliance cache empty under $CACHE_ROOT — skipping overlay"
             exit 0
           fi
           echo "Overlaying onto $DST"


### PR DESCRIPTION
## Summary

Fixes the 3.0.x storyboard CI baseline. The workflow's overlay step was silently no-op'ing on every 3.0.x run because it looked for the SDK compliance cache at \`node_modules/@adcp/sdk/compliance/cache\` (main's post-rename path) but 3.0.x still ships \`@adcp/client@5.21.1\`. With the overlay skipped, the storyboard runner read the SDK's frozen 3.0.0 snapshot — which has no \`fixtures:\` block or \`controller_seeding: true\` flag — so pre-flight \`comply_test_controller.seed_product\` was never invoked.

Result: 11 storyboards have been failing with \`PRODUCT_NOT_FOUND\` (or similarly-shaped seed-prerequisite errors) on 3.0.x's CI baseline since the workflow forward-merge from main:

- \`sales_guaranteed\`, \`sales_broadcast_tv\`
- \`media_buy_seller\`, \`media_buy_seller/delivery_reporting\`, \`media_buy_seller/governance_approved\`
- \`creative_generative/seller\`
- \`governance_delivery_monitor\`, \`governance_spend_authority\`
- \`idempotency\`, \`brand_baseline\`, \`brand_rights\`

## Investigation

Reproduced locally and traced through the SDK runner:

1. Storyboard runner calls \`runControllerSeeding(client, storyboard, options, context)\` for each storyboard. Without the overlay, the loaded storyboard object has \`hasFixtures: false\` and \`prerequisitesControllerSeeding: undefined\` because the YAML loader reads from the SDK's frozen \`compliance/cache/3.0.0/\` snapshot, which was synced before fixtures were added.
2. The seed loop short-circuits on \`storyboard.prerequisites?.controller_seeding !== true\`, returning \`null\`.
3. Every storyboard's \`create_media_buy\` (or equivalent) then can't find products like \`sports_preroll_q2_guaranteed\` or \`outdoor_display_q2\`, since those products only exist in the local repo's \`fixtures.products\` block — not in the SDK's static catalog (\`product-factory.ts\` aliases only define \`test-product\`, \`sports_ctv_q2\`, \`outdoor_ctv_q2\`, \`local_display_dynamic\`).

The CI's overlay step was supposed to copy \`static/compliance/source/\` onto the SDK cache before each run to bring fixtures into the runner's view. The step was operating correctly on \`main\` (where the cache is at \`@adcp/sdk/compliance/cache\`); the path predicate just hadn't been generalized for 3.0.x's \`@adcp/client\` location.

## Fix

Try the new path first (\`@adcp/sdk\`), fall back to the old one (\`@adcp/client\`). Both branches now converge on a single workflow file that works regardless of which package the SDK is installed as.

## Verification

Applied the workflow's new overlay logic locally (against the actual \`@adcp/client@5.21.1\` install) and ran each previously-failing storyboard:

\`\`\`
sales_guaranteed                     ✓ 11P / 0S / 0N/A
sales_broadcast_tv                   ✓ 13P / 0S / 0N/A
brand_baseline                       ✓ 3P / 0S / 0N/A
brand_rights                         ✓ 6P / 0S / 0N/A
brand_rights/governance_denied       ✓ 4P / 1S / 0N/A
idempotency                          ✓ 8P / 0S / 0N/A
creative_generative                  ✓ 10P / 1S / 0N/A
creative_generative/seller           ✓ 14P / 0S / 0N/A
governance_delivery_monitor          ✓ 12P / 0S / 0N/A
governance_spend_authority           ✓ 9P / 0S / 0N/A
governance_spend_authority/denied    ✓ 3P / 0S / 0N/A
media_buy_seller                     ✓ 14P / 0S / 0N/A
media_buy_seller/delivery_reporting  ✓ 9P / 0S / 0N/A
media_buy_seller/governance_approved ✓ 8P / 1S / 0N/A
\`\`\`

11/11 previously-failing storyboards now pass.

## Test plan

- [x] Local repro: confirmed all 11 storyboards fail without the workflow change, pass with it
- [ ] CI green on this PR — verifies the fix in the actual CI environment
- [ ] After merge, the next 3.0.x PR's storyboard CI run should be green

## Refs

- adcontextprotocol/adcp#4000 — issue this PR closes
- adcontextprotocol/adcp#3893 — first 3.0.x PR admin-merged through the silent storyboard CI breakage
- \`@adcp/client\` 5.23.0 — SDK rename to \`@adcp/sdk\` (post-3.0.x cutover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)