### PR TITLE
feat(training-agent): wire BuyerAgentRegistry on all v6 tenants + sandbox-mode adaptation for SDK 6.8.0

### DIFF
--- a/.changeset/buyer-agent-registry-migration.md
+++ b/.changeset/buyer-agent-registry-migration.md
@@ -1,0 +1,30 @@
+---
+---
+
+feat(training-agent): wire BuyerAgentRegistry on all v6 tenants — `ctx.agent.billing_capabilities` populated end-to-end
+
+Phase 1 BuyerAgentRegistry adoption (per `adcp-client#1269`). Unblocked by SDK 6.8.0's `extra`-forwarding fix for `ResolveBuyerAgentByCredential` (the issue I filed at `adcp-client#1484`, fix shipped as `adcp-client#1488`).
+
+**What landed:**
+
+1. **SDK pin bumped to `^6.8.0`.**
+
+2. **Bearer authenticator stamps `extra: { demo_token: token }`** on the AuthPrincipal returned for `demo-*` test bearers (`server/src/training-agent/index.ts`). The token doesn't survive `AdcpCredential` normalization (api_key carries `key_id: SHA-256(token)`); `extra` is the documented escape hatch for prefix-based test conventions.
+
+3. **New `buyer-agent-registry.ts`** — `BuyerAgentRegistry.bearerOnly` resolver that reads `extra.demo_token`, delegates to `commercial-relationships.ts` for the principal → relationship lookup (single source of truth), and returns a `BuyerAgent` record with the appropriate `billing_capabilities` Set. Unrecognized credentials return `null` (uniform-response rule). Signed credentials are refused per the `bearerOnly` factory's posture.
+
+4. **All six v6 tenant platforms wire `agentRegistry: trainingBuyerAgentRegistry`** — sales, signals (in `v6-platform.ts`), governance, creative, creative-builder, brand. The framework calls `agentRegistry.resolve(authInfo)` once per request before `accounts.resolve` and threads the resolved record through `ctx.agent` to platform handlers.
+
+5. **No gate-logic changes.** `commercial-relationships.ts` remains the source of truth and the legacy `/mcp` path keeps consuming it via `handleSyncAccounts`. The v6 platforms now ALSO have `ctx.agent.billing_capabilities` populated — forward-compat for SDK Phase 2 (`adcp-client#1292`) when framework-level enforcement of `BILLING_NOT_PERMITTED_FOR_AGENT` ships and reads from `ctx.agent` directly.
+
+**Why delegate to `commercial-relationships.ts` instead of inlining.** Both the legacy `/mcp` path (via `handleSyncAccounts`) and the v6 path (via `ctx.agent`) need consistent gate decisions. Two source-of-truth modules drift over time. Single delegation through `getCommercialRelationship(principal)` keeps both consumers reading the same data; when SDK Phase 2 lands, the v6 path's manual gate consultation can collapse and `commercial-relationships.ts` becomes a private adapter for the registry.
+
+**Tests.**
+
+- 6 new unit tests in `buyer-agent-registry.test.ts` — passthrough/agent-billable prefix resolution, unrecognized prefix → null, missing extra → null, non-string extra → null, http_sig credential → null (bearerOnly rejection).
+- Existing `sync-accounts-gates.test.ts` (4 base + 6 per-tenant + 1 unauth = 11 tests) and `account-handlers.test.ts` (22 tests) all pass — proves the gate logic still fires correctly under the new wiring.
+- Full server suite: 3156 passed, 42 skipped, 0 failed (excluding one pre-existing flaky LLM test).
+
+**SDK 6.8.0 sandbox-mode adaptation (related fix bundled).** SDK 6.8.0 added a new `comply_test_controller` gate that requires resolved accounts to be in sandbox or mock mode (`isSandboxOrMockAccount` in `@adcp/sdk/server`). The training-agent operates as a public sandbox by design but didn't communicate that on the wire — `accounts.resolve` returned Account records without `sandbox: true`. With the new gate, every comply controller call would FORBIDDEN-reject. Fixed by adding `sandbox: true` to all six v6 platforms' `accounts.resolve` return values (both the `ref == null` synthetic-public-sandbox path and the brand/operator-resolved path). Pre-push storyboard floors confirm: all six tenants now meet baselines; without this fix the SDK bump would regress every comply-controller-using storyboard.
+
+**Phase 2 outlook.** When SDK Phase 2 ships framework-level enforcement, the only remaining work is to delete the gate logic from `account-handlers.ts` and let the framework reject `BILLING_NOT_PERMITTED_FOR_AGENT` against `ctx.agent.billing_capabilities` directly. The `commercial-relationships.ts` module stays as the registry's data source.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.0.3",
       "dependencies": {
-        "@adcp/sdk": "^6.7.0",
+        "@adcp/sdk": "^6.8.0",
         "@anthropic-ai/sdk": "^0.91.1",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -122,9 +122,9 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-6.7.0.tgz",
-      "integrity": "sha512-BH5rSZvyqZodgDnPuG+0gX2MKv6I7xqYvtzFbvWHjzI8F3KmhVru1V770pZ4j8SrFWDm+K5OWdsjmhnvL0KJtg==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-6.8.0.tgz",
+      "integrity": "sha512-UULRlfip6pez5O8az7mNC2yKmgC1m/cNLxi19AoSL+bOW6Yhq5AdTS5mtvCNE9dhu/krfPZKB0jV3GNqyH5b9g==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "dev:docs": "node scripts/dev-docs.mjs"
   },
   "dependencies": {
-    "@adcp/sdk": "^6.7.0",
+    "@adcp/sdk": "^6.8.0",
     "@anthropic-ai/sdk": "^0.91.1",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",

--- a/server/src/training-agent/buyer-agent-registry.test.ts
+++ b/server/src/training-agent/buyer-agent-registry.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit test: trainingBuyerAgentRegistry resolves the right BuyerAgent
+ * for each demo-bearer prefix family. Companion to the
+ * sync-accounts-gates integration test, which exercises the framework's
+ * end-to-end path; this test pins the resolver's prefix → billing_capabilities
+ * mapping in isolation so a regression on the data shape surfaces here
+ * before it surfaces against the framework.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { AdcpCredential } from '@adcp/sdk/server';
+import { trainingBuyerAgentRegistry } from './buyer-agent-registry.js';
+
+// Synthesize a BuyerAgentResolveInput as the framework would construct it
+// from a `verifyApiKey({ verify })` callback that stamped extra:
+// { demo_token: <token> } on its returned AuthPrincipal.
+function input(
+  token: string | undefined,
+  kind: AdcpCredential['kind'] = 'api_key',
+): { credential: AdcpCredential; extra?: Record<string, unknown> } {
+  const credential: AdcpCredential =
+    kind === 'api_key'
+      ? { kind: 'api_key', key_id: `sha256:hash-of-${token}` }
+      : kind === 'oauth'
+        ? { kind: 'oauth', client_id: 'unused', scopes: [] }
+        : { kind: 'http_sig', keyid: 'unused', agent_url: 'unused', verified_at: 0 };
+  return token === undefined
+    ? { credential }
+    : { credential, extra: { demo_token: token } };
+}
+
+describe('trainingBuyerAgentRegistry', () => {
+  it('passthrough-only token → BuyerAgent with billing_capabilities {operator}', async () => {
+    const agent = await trainingBuyerAgentRegistry.resolve(
+      input('demo-billing-passthrough-v1'),
+    );
+    expect(agent).not.toBeNull();
+    expect(agent?.status).toBe('active');
+    expect([...(agent?.billing_capabilities ?? [])].sort()).toEqual(['operator']);
+    expect(agent?.agent_url).toContain('demo/demo-billing-passthrough-v1');
+  });
+
+  it('agent-billable token → BuyerAgent with billing_capabilities {operator, agent, advertiser}', async () => {
+    const agent = await trainingBuyerAgentRegistry.resolve(
+      input('demo-billing-agent-billable-v1'),
+    );
+    expect(agent).not.toBeNull();
+    expect(agent?.status).toBe('active');
+    expect([...(agent?.billing_capabilities ?? [])].sort()).toEqual([
+      'advertiser',
+      'agent',
+      'operator',
+    ]);
+  });
+
+  it('unrecognized demo prefix → null (uniform-response rule)', async () => {
+    // demo-* token that doesn't match any known commercial-relationship
+    // prefix family. Resolver returns null, framework leaves ctx.agent
+    // undefined, no per-agent gate fires.
+    const agent = await trainingBuyerAgentRegistry.resolve(
+      input('demo-unrecognized-v1'),
+    );
+    expect(agent).toBeNull();
+  });
+
+  it('missing extra.demo_token → null', async () => {
+    // Static-key authenticators (TRAINING_AGENT_TOKEN /
+    // PUBLIC_TEST_AGENT_TOKEN) don't stamp demo_token; resolver returns
+    // null and falls through. No commercial relationship inferred for
+    // production-shaped principals — security posture matches
+    // commercial-relationships.ts.
+    const agent = await trainingBuyerAgentRegistry.resolve(input(undefined));
+    expect(agent).toBeNull();
+  });
+
+  it('non-string extra.demo_token → null (defensive type-check)', async () => {
+    // Adopter-supplied extra is Record<string, unknown> — the resolver
+    // shape-checks before using.
+    const agent = await trainingBuyerAgentRegistry.resolve({
+      credential: { kind: 'api_key', key_id: 'sha256:x' },
+      extra: { demo_token: 12345 as unknown as string },
+    });
+    expect(agent).toBeNull();
+  });
+
+  it('http_sig credential → null (bearerOnly factory rejects signed traffic)', async () => {
+    // The training-agent uses bearerOnly; signed traffic is refused at
+    // the registry layer regardless of extra. Documented behavior of
+    // BuyerAgentRegistry.bearerOnly per the SDK factory's posture.
+    const agent = await trainingBuyerAgentRegistry.resolve(
+      input('demo-billing-passthrough-v1', 'http_sig'),
+    );
+    expect(agent).toBeNull();
+  });
+});

--- a/server/src/training-agent/buyer-agent-registry.ts
+++ b/server/src/training-agent/buyer-agent-registry.ts
@@ -1,0 +1,90 @@
+/**
+ * Per-buyer-agent identity registry for the v6 per-tenant platforms.
+ * Phase 1 of `adcp-client#1269` (shipped in @adcp/sdk@6.7.0); the
+ * `extra`-forwarding fix that lets us migrate prefix-based bearer
+ * conventions shipped in @adcp/sdk@6.8.0 (`adcp-client#1488`).
+ *
+ * **What this resolver does.** Given a request's `AdcpCredential` and
+ * the `extra` bag the bearer authenticator stamped on the AuthPrincipal,
+ * looks up the buyer agent's commercial relationship with the seller
+ * (passthrough_only / agent_billable) and returns a `BuyerAgent` record
+ * with the appropriate `billing_capabilities` Set. The framework
+ * threads the resolved record through `ctx.agent` to platform handlers
+ * (`accounts.upsert`, `getProducts`, etc.) — read-side handlers that
+ * want to gate on commercial state consult `ctx.agent.billing_capabilities`
+ * directly, no separate lookup needed.
+ *
+ * **Why bearerOnly.** The training-agent's auth chain is bearer-shaped
+ * (`verifyApiKey` static keys + dynamic `demo-*` prefix matcher). No
+ * signed-request path. `signingOnly` would refuse all traffic;
+ * `bearerOnly` accepts api_key kind and rejects http_sig, matching
+ * the deployment posture.
+ *
+ * **Why `extra.demo_token`.** `ResolveBuyerAgentByCredential` receives
+ * `AdcpCredential` whose `api_key` variant carries `key_id: SHA-256(token)`
+ * — the raw bearer is intentionally hashed at the framework boundary.
+ * That makes prefix-based test conventions (`demo-billing-passthrough-*`
+ * → passthrough_only) impossible to match from `key_id` alone (the
+ * prefix space is infinite by design). The bearer authenticator at
+ * `index.ts:84` stamps `extra: { demo_token: token }` on the returned
+ * AuthPrincipal; @adcp/sdk@6.8.0's `attachAuthInfo` forwards it through
+ * to `BuyerAgentResolveInput.extra`, which `bearerOnly` passes as the
+ * second arg to this resolver.
+ *
+ * **Source of truth.** Delegates to `commercial-relationships.ts` for
+ * the principal → relationship lookup so both consumers — legacy `/mcp`
+ * via `handleSyncAccounts` and v6 per-tenant routes via `ctx.agent` —
+ * read the same data. When SDK Phase 2 ships framework-level
+ * enforcement of `BILLING_NOT_PERMITTED_FOR_AGENT` against
+ * `ctx.agent.billing_capabilities`, this delegation can collapse —
+ * the gate logic in `account-handlers.ts` becomes redundant with the
+ * framework's check.
+ *
+ * **Sandbox-only is unset.** The training-agent's demo agents operate
+ * against the public-sandbox account; they don't carry the `sandbox_only`
+ * gate that production test credentials would use. Real sellers wiring
+ * BuyerAgentRegistry SHOULD set `sandbox_only: true` on their test-
+ * environment agents per the field's docstring (defense-in-depth: a
+ * leaked test credential is bounded to sandbox accounts).
+ */
+
+import { BuyerAgentRegistry, type BuyerAgent } from '@adcp/sdk/server';
+import { getCommercialRelationship } from './commercial-relationships.js';
+
+const TRAINING_AGENT_BASE_URL = 'https://training-agent.adcontextprotocol.org';
+
+const PASSTHROUGH_BILLING_CAPABILITIES = new Set(['operator'] as const);
+const AGENT_BILLABLE_BILLING_CAPABILITIES = new Set([
+  'operator',
+  'agent',
+  'advertiser',
+] as const);
+
+export const trainingBuyerAgentRegistry = BuyerAgentRegistry.bearerOnly({
+  resolveByCredential: async (credential, extra) => {
+    if (credential.kind !== 'api_key') return null;
+    const token = extra?.demo_token;
+    if (typeof token !== 'string') return null;
+
+    const principal = `static:demo:${token}`;
+    const relationship = getCommercialRelationship(principal);
+    if (!relationship) return null;
+
+    const billing_capabilities =
+      relationship === 'passthrough_only'
+        ? PASSTHROUGH_BILLING_CAPABILITIES
+        : AGENT_BILLABLE_BILLING_CAPABILITIES;
+
+    const agent: BuyerAgent = {
+      // Stable agent_url per token. Real sellers would use the buyer's
+      // canonical agent URL from their onboarding ledger; the training
+      // agent synthesizes a per-token URL so log/audit lines distinguish
+      // demo callers without colliding.
+      agent_url: `${TRAINING_AGENT_BASE_URL}/demo/${token}`,
+      display_name: `Demo ${relationship.replace('_', ' ')} agent (${token})`,
+      status: 'active',
+      billing_capabilities,
+    };
+    return agent;
+  },
+});

--- a/server/src/training-agent/index.ts
+++ b/server/src/training-agent/index.ts
@@ -82,7 +82,16 @@ function buildBearerAuthenticator(): Authenticator | null {
   authenticators.push(verifyApiKey({
     verify: (token) => {
       if (!DEMO_TEST_KIT_KEY_PATTERN.test(token)) return null;
-      return { principal: `static:demo:${token}` };
+      // `extra.demo_token` flows through to BuyerAgentResolveInput.extra
+      // (per @adcp/sdk@6.8.0 attachAuthInfo / bearerOnly forwarding) so
+      // the BuyerAgentRegistry in buyer-agent-registry.ts can recognize
+      // the prefix family. The raw bearer doesn't survive AdcpCredential
+      // normalization (api_key carries SHA-256 hashed `key_id`); `extra`
+      // is the documented escape hatch for prefix-based test conventions.
+      return {
+        principal: `static:demo:${token}`,
+        extra: { demo_token: token },
+      };
     },
   }));
   if (workos) {

--- a/server/src/training-agent/v6-brand-platform.ts
+++ b/server/src/training-agent/v6-brand-platform.ts
@@ -23,6 +23,7 @@ import {
   handleUpdateRights,
 } from './brand-handlers.js';
 import { syncAccountsUpsert } from './v6-account-helpers.js';
+import { trainingBuyerAgentRegistry } from './buyer-agent-registry.js';
 import type { ToolArgs, TrainingContext } from './types.js';
 
 interface TrainingBrandMeta {
@@ -75,6 +76,7 @@ const trainingBrandAccounts: AccountStore<TrainingBrandMeta> = {
         name: 'Public Sandbox',
         status: 'active',
         ctx_metadata: {},
+        sandbox: true,
         authInfo: { kind: 'public' },
       };
     }
@@ -92,6 +94,7 @@ const trainingBrandAccounts: AccountStore<TrainingBrandMeta> = {
       ...(brandDomain != null && { brand: { domain: brandDomain } }),
       ...('operator' in ref && typeof ref.operator === 'string' && { operator: ref.operator }),
       ctx_metadata: { brand_domain: brandDomain },
+      sandbox: true,
       authInfo: { kind: 'api_key' },
     };
   },
@@ -116,6 +119,7 @@ export class TrainingBrandPlatform
 
   statusMappers = {};
   accounts: AccountStore<TrainingBrandMeta> = trainingBrandAccounts;
+  agentRegistry = trainingBuyerAgentRegistry;
 
   brandRights: BrandRightsPlatform<TrainingBrandMeta> = {
     getBrandIdentity: async (req, ctx) => {

--- a/server/src/training-agent/v6-creative-builder-platform.ts
+++ b/server/src/training-agent/v6-creative-builder-platform.ts
@@ -27,6 +27,7 @@ import {
   handleSyncCreatives,
 } from './task-handlers.js';
 import { syncAccountsUpsert } from './v6-account-helpers.js';
+import { trainingBuyerAgentRegistry } from './buyer-agent-registry.js';
 import type { ToolArgs, TrainingContext } from './types.js';
 
 interface TrainingCreativeBuilderMeta {
@@ -79,6 +80,7 @@ const trainingBuilderAccounts: AccountStore<TrainingCreativeBuilderMeta> = {
         name: 'Public Sandbox',
         status: 'active',
         ctx_metadata: {},
+        sandbox: true,
         authInfo: { kind: 'public' },
       };
     }
@@ -96,6 +98,7 @@ const trainingBuilderAccounts: AccountStore<TrainingCreativeBuilderMeta> = {
       ...(brandDomain != null && { brand: { domain: brandDomain } }),
       ...('operator' in ref && typeof ref.operator === 'string' && { operator: ref.operator }),
       ctx_metadata: { brand_domain: brandDomain },
+      sandbox: true,
       authInfo: { kind: 'api_key' },
     };
   },
@@ -117,6 +120,7 @@ export class TrainingCreativeBuilderPlatform
 
   statusMappers = {};
   accounts: AccountStore<TrainingCreativeBuilderMeta> = trainingBuilderAccounts;
+  agentRegistry = trainingBuyerAgentRegistry;
 
   creative: CreativeBuilderPlatform<TrainingCreativeBuilderMeta> = {
     buildCreative: async (req, ctx) => {

--- a/server/src/training-agent/v6-creative-platform.ts
+++ b/server/src/training-agent/v6-creative-platform.ts
@@ -24,6 +24,7 @@ import {
   handleSyncCreatives,
 } from './task-handlers.js';
 import { syncAccountsUpsert } from './v6-account-helpers.js';
+import { trainingBuyerAgentRegistry } from './buyer-agent-registry.js';
 import type { ToolArgs, TrainingContext } from './types.js';
 
 interface TrainingCreativeMeta {
@@ -76,6 +77,7 @@ const trainingCreativeAccounts: AccountStore<TrainingCreativeMeta> = {
         name: 'Public Sandbox',
         status: 'active',
         ctx_metadata: {},
+        sandbox: true,
         authInfo: { kind: 'public' },
       };
     }
@@ -93,6 +95,7 @@ const trainingCreativeAccounts: AccountStore<TrainingCreativeMeta> = {
       ...(brandDomain != null && { brand: { domain: brandDomain } }),
       ...('operator' in ref && typeof ref.operator === 'string' && { operator: ref.operator }),
       ctx_metadata: { brand_domain: brandDomain },
+      sandbox: true,
       authInfo: { kind: 'api_key' },
     };
   },
@@ -114,6 +117,7 @@ export class TrainingCreativePlatform
 
   statusMappers = {};
   accounts: AccountStore<TrainingCreativeMeta> = trainingCreativeAccounts;
+  agentRegistry = trainingBuyerAgentRegistry;
 
   creative: CreativeAdServerPlatform<TrainingCreativeMeta> = {
     buildCreative: async (req, ctx) => {

--- a/server/src/training-agent/v6-governance-platform.ts
+++ b/server/src/training-agent/v6-governance-platform.ts
@@ -50,6 +50,7 @@ import {
   handleValidateContentDelivery,
 } from './content-standards-handlers.js';
 import { syncAccountsUpsert } from './v6-account-helpers.js';
+import { trainingBuyerAgentRegistry } from './buyer-agent-registry.js';
 import type { ToolArgs, TrainingContext } from './types.js';
 
 interface TrainingGovernanceMeta {
@@ -102,6 +103,7 @@ const trainingGovernanceAccounts: AccountStore<TrainingGovernanceMeta> = {
         name: 'Public Sandbox',
         status: 'active',
         ctx_metadata: {},
+        sandbox: true,
         authInfo: { kind: 'public' },
       };
     }
@@ -119,6 +121,7 @@ const trainingGovernanceAccounts: AccountStore<TrainingGovernanceMeta> = {
       ...(brandDomain != null && { brand: { domain: brandDomain } }),
       ...('operator' in ref && typeof ref.operator === 'string' && { operator: ref.operator }),
       ctx_metadata: { brand_domain: brandDomain },
+      sandbox: true,
       authInfo: { kind: 'api_key' },
     };
   },
@@ -146,6 +149,7 @@ export class TrainingGovernancePlatform
 
   statusMappers = {};
   accounts: AccountStore<TrainingGovernanceMeta> = trainingGovernanceAccounts;
+  agentRegistry = trainingBuyerAgentRegistry;
 
   campaignGovernance: CampaignGovernancePlatform<TrainingGovernanceMeta> = {
     syncPlans: async (req, ctx) => {

--- a/server/src/training-agent/v6-platform.ts
+++ b/server/src/training-agent/v6-platform.ts
@@ -21,6 +21,7 @@ import {
 } from '@adcp/sdk/server';
 import { handleGetSignals, handleActivateSignal } from './task-handlers.js';
 import { syncAccountsUpsert } from './v6-account-helpers.js';
+import { trainingBuyerAgentRegistry } from './buyer-agent-registry.js';
 import type { ToolArgs, TrainingContext } from './types.js';
 
 export interface TrainingConfig {
@@ -51,6 +52,7 @@ const trainingAccounts: AccountStore<TrainingMeta> = {
         name: 'Public Sandbox',
         status: 'active',
         ctx_metadata: {},
+        sandbox: true,
         authInfo: { kind: 'public' },
       };
     }
@@ -68,6 +70,7 @@ const trainingAccounts: AccountStore<TrainingMeta> = {
       ...(brandDomain != null && { brand: { domain: brandDomain } }),
       ...('operator' in ref && typeof ref.operator === 'string' && { operator: ref.operator }),
       ctx_metadata: { brand_domain: brandDomain },
+      sandbox: true,
       authInfo: { kind: 'api_key' },
     };
   },
@@ -156,6 +159,8 @@ export class TrainingPlatform implements DecisioningPlatform<TrainingConfig, Tra
   statusMappers = {};
 
   accounts: AccountStore<TrainingMeta> = trainingAccounts;
+
+  agentRegistry = trainingBuyerAgentRegistry;
 
   signals: SignalsPlatform<TrainingMeta> = {
     getSignals: async (req, ctx) => {

--- a/server/src/training-agent/v6-sales-platform.ts
+++ b/server/src/training-agent/v6-sales-platform.ts
@@ -29,6 +29,7 @@ import {
 } from './task-handlers.js';
 import { handleProvidePerformanceFeedback } from './catalog-event-handlers.js';
 import { syncAccountsUpsert } from './v6-account-helpers.js';
+import { trainingBuyerAgentRegistry } from './buyer-agent-registry.js';
 import type { ToolArgs, TrainingContext } from './types.js';
 
 interface TrainingSalesMeta {
@@ -100,6 +101,7 @@ const trainingSalesAccounts: AccountStore<TrainingSalesMeta> = {
         name: 'Public Sandbox',
         status: 'active',
         ctx_metadata: {},
+        sandbox: true,
         authInfo: { kind: 'public' },
       };
     }
@@ -117,6 +119,7 @@ const trainingSalesAccounts: AccountStore<TrainingSalesMeta> = {
       ...(brandDomain != null && { brand: { domain: brandDomain } }),
       ...('operator' in ref && typeof ref.operator === 'string' && { operator: ref.operator }),
       ctx_metadata: { brand_domain: brandDomain },
+      sandbox: true,
       authInfo: { kind: 'api_key' },
     };
   },
@@ -160,6 +163,7 @@ export class TrainingSalesPlatform
 
   statusMappers = {};
   accounts: AccountStore<TrainingSalesMeta> = trainingSalesAccounts;
+  agentRegistry = trainingBuyerAgentRegistry;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   sales: SalesPlatform<TrainingSalesMeta> = {


### PR DESCRIPTION
## Summary

Phase 1 BuyerAgentRegistry adoption (per [adcp-client#1269](https://github.com/adcontextprotocol/adcp-client/issues/1269)). Unblocked by SDK 6.8.0's `extra`-forwarding fix — issue [#1484](https://github.com/adcontextprotocol/adcp-client/issues/1484) (filed earlier in this session) → PR [#1488](https://github.com/adcontextprotocol/adcp-client/pull/1488) → shipped in 6.8.0.

Also bundles the **SDK 6.8.0 sandbox-mode adaptation**: 6.8.0 added a new `comply_test_controller` gate (`isSandboxOrMockAccount`) that requires resolved accounts to be in sandbox/mock mode. Training-agent operates as a public sandbox by design but didn't communicate that on the wire. Without this fix, the SDK bump alone would FORBIDDEN-reject every comply-controller storyboard. Pre-push storyboard floors confirm: all six tenants meet baselines after the fix.

## What landed

1. **SDK pin bumped to `^6.8.0`.**
2. **Bearer authenticator stamps `extra: { demo_token: token }`** on the AuthPrincipal returned for `demo-*` test bearers (`server/src/training-agent/index.ts`). The token doesn't survive `AdcpCredential` normalization (`api_key.key_id` is SHA-256 hashed); `extra` is the documented escape hatch for prefix-based test conventions.
3. **New `buyer-agent-registry.ts`** — `BuyerAgentRegistry.bearerOnly` resolver that reads `extra.demo_token`, delegates to `commercial-relationships.ts` for the principal → relationship lookup, and returns a `BuyerAgent` record with the appropriate `billing_capabilities` Set.
4. **All six v6 tenant platforms wire `agentRegistry: trainingBuyerAgentRegistry`.** The framework calls `agentRegistry.resolve(authInfo)` once per request before `accounts.resolve` and threads the resolved record through `ctx.agent` to platform handlers — forward-compat for SDK Phase 2 framework-level enforcement.
5. **`sandbox: true` added to all `accounts.resolve` return values** across the six v6 platforms (both `ref == null` synthetic-public-sandbox and brand/operator-resolved paths). Required by SDK 6.8.0's new comply_test_controller gate.

**No gate-logic changes.** `commercial-relationships.ts` remains the source of truth; legacy `/mcp` keeps consuming it via `handleSyncAccounts`. The v6 path now also has `ctx.agent.billing_capabilities` populated.

## Tests

- 6 new unit tests in `buyer-agent-registry.test.ts` covering all branches (passthrough/agent-billable prefix resolution, unrecognized prefix → null, missing extra → null, defensive type-checks, http_sig refusal).
- Existing `sync-accounts-gates.test.ts` (11 tests) and `account-handlers.test.ts` (22 tests) all pass — proves gate logic still fires correctly.
- **Pre-push storyboard floors: all six tenants meet baselines** (signals: 65 clean / 70 steps; sales: 65/74; governance: 64/70; creative: 65/83; creative-builder: 59/65; brand: 65/14).
- Targeted suite: 39/39 pass.
- Typecheck clean.

## Phase 2 outlook

When SDK Phase 2 ships framework-level enforcement, the only remaining work is to delete the gate logic from `account-handlers.ts` and let the framework reject `BILLING_NOT_PERMITTED_FOR_AGENT` against `ctx.agent.billing_capabilities` directly. `commercial-relationships.ts` stays as the registry's data source.

## Cross-links

- [adcp-client#1484](https://github.com/adcontextprotocol/adcp-client/issues/1484) — issue filed for the bearer-path gap (closed)
- [adcp-client#1488](https://github.com/adcontextprotocol/adcp-client/pull/1488) — SDK fix (merged, in 6.8.0)
- [adcp#3984](https://github.com/adcontextprotocol/adcp/pull/3984) — v6 `accounts.upsert` wiring (merged, prerequisite for this work)
- [adcp#3851](https://github.com/adcontextprotocol/adcp/pull/3851) — original gate implementation (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)