### PR TITLE
feat(training-agent): implement BILLING_NOT_SUPPORTED scope: "account" sub-gate

### DIFF
--- a/.changeset/billing-account-scope-gate.md
+++ b/.changeset/billing-account-scope-gate.md
@@ -1,0 +1,26 @@
+---
+---
+
+feat(training-agent): implement BILLING_NOT_SUPPORTED `scope: "account"` sub-gate
+
+Closes the third remaining billing-gate follow-up: per-(operator, billing) restriction tested end-to-end. Distinct from the seller-wide capability gate (already implemented) and the per-buyer-agent gate (`BILLING_NOT_PERMITTED_FOR_AGENT`, also already implemented). Per the spec at [`error-details/billing-not-supported.json`](https://adcontextprotocol.org/schemas/v3/error-details/billing-not-supported.json):
+
+> `BILLING_NOT_SUPPORTED` with `error.details.scope: "account"` — "the seller's capability accepts the value generally but not for the specific operator on this account."
+
+**What landed:**
+
+1. New `account-billing-relationships.ts` — single helper `isPerAccountBillingRestricted(operator, billing)` keyed on operator domain. Documents the convention: operators whose domain ends in `-no-direct-billing.example` have no direct billing relationship for `billing: 'operator'`. Other billing models (`agent`, `advertiser`) don't depend on per-operator onboarding state. Real sellers would have richer per-(operator, brand, billing) data; the training-agent ships the simplest convention that exercises the sub-gate deterministically.
+
+2. `handleSyncAccounts` — new gate fires between the capability gate (`scope: "capability"`) and the per-buyer-agent gate (`BILLING_NOT_PERMITTED_FOR_AGENT`). Returns `BILLING_NOT_SUPPORTED` with `error.details.scope: "account"` and the supported_billing echo.
+
+3. **4 new unit tests** in `account-handlers.test.ts`:
+   - operator with no-direct-billing suffix → `BILLING_NOT_SUPPORTED scope: "account"`.
+   - same operator with `billing: agent` passes (gate is operator-billing-specific — scope discipline regression-pin).
+   - operator without the suffix passes (over-broadening regression-pin).
+   - composition: passthrough principal still gets per-agent rejection on `billing: agent` (gate-ordering regression-pin — account-scope gate doesn't apply because billing is `agent`, not `operator`).
+
+**Scope discipline.** The per-account gate is operator-scoped, not per-buyer-agent. It fires regardless of who's calling — even an agent-billable buyer agent submitting `billing: operator` for a no-direct-billing operator gets the same `scope: "account"` rejection. That mirrors real-world data: the operator's billing eligibility is a property of the seller's onboarding state with the operator, not of the agent representing the buyer.
+
+**Phase 2 outlook.** When SDK Phase 2 ships framework-level enforcement, both billing gates (`BILLING_NOT_PERMITTED_FOR_AGENT` per-agent and `BILLING_NOT_SUPPORTED scope: "account"` per-operator) become candidates for framework-side machinery — the agent-side gate via `ctx.agent.billing_capabilities` (already populated since #4026), the account-side via a parallel `ctx.account.billing_relationships` surface that doesn't yet exist. Until then, both stay adopter-side with the data sources colocated in `commercial-relationships.ts` (per-agent) and `account-billing-relationships.ts` (per-operator).
+
+26/26 unit tests pass; full server suite clean (3159 passed, 42 skipped) excluding two pre-existing flaky tests (`illustration-c2pa-wiring`, `addie-router LLM confidence tiers`).

--- a/server/src/training-agent/account-billing-relationships.ts
+++ b/server/src/training-agent/account-billing-relationships.ts
@@ -1,0 +1,67 @@
+/**
+ * Per-(operator, billing) commercial-relationship lookup for the
+ * BILLING_NOT_SUPPORTED `scope: "account"` sub-gate. Distinct surface
+ * from `commercial-relationships.ts` (which is keyed on the calling
+ * buyer agent's principal — a per-CALLER dimension) — this lookup is
+ * keyed on the OPERATOR + BILLING combo for THIS account.
+ *
+ * **Spec contract** (per `error-details/billing-not-supported.json`):
+ *
+ *   `BILLING_NOT_SUPPORTED` with `error.details.scope: "account"` —
+ *   "the seller's capability accepts the value generally but not for
+ *   the specific operator on this account."
+ *
+ * Real sellers maintain a per-(operator, brand) ledger of which
+ * billing models they have onboarded. The training-agent simulates this
+ * with a documented operator-domain convention so storyboards can
+ * deterministically exercise the sub-gate without per-test setup.
+ *
+ * **Convention.** Operators whose domain ends in `-no-direct-billing.example`
+ * are treated as having no direct billing relationship for `operator`
+ * billing — the seller's capability accepts `operator` (in
+ * `supported_billing`), but this specific operator can't be invoiced
+ * directly. `agent` and `advertiser` billing remain unrestricted —
+ * they don't depend on a per-account direct-billing relationship with
+ * the operator. Real sellers would have richer per-(operator, brand,
+ * billing) data; the training-agent ships the simplest convention that
+ * exercises the sub-gate.
+ *
+ * **Scope discipline.** This sub-gate is per-account (operator-scoped),
+ * NOT per-buyer-agent. It fires regardless of who's calling — even an
+ * agent-billable buyer agent submitting `billing: operator` for a
+ * no-direct-billing operator gets the same `scope: "account"` rejection.
+ * That mirrors real-world data: the operator's billing eligibility is
+ * a property of the seller's onboarding state with the operator, not
+ * of the agent representing the buyer.
+ *
+ * **Phase 2 outlook.** When SDK Phase 2 ships framework-level
+ * enforcement, both billing gates (`BILLING_NOT_PERMITTED_FOR_AGENT`
+ * per-agent and `BILLING_NOT_SUPPORTED` `scope: "account"`
+ * per-operator) become candidates for framework-side machinery
+ * — the agent-side gate via `ctx.agent.billing_capabilities`, the
+ * account-side via a parallel `ctx.account.billing_relationships`
+ * surface that doesn't yet exist. Until then, both stay adopter-side
+ * with the data sources colocated here and in
+ * `commercial-relationships.ts`.
+ */
+
+const NO_DIRECT_BILLING_OPERATOR_SUFFIX = '-no-direct-billing.example';
+
+/**
+ * Returns true when the (operator, billing) combination is restricted
+ * — the seller advertises the billing model in its capability but has
+ * no direct billing relationship for this operator.
+ *
+ * Today the convention only applies to `billing: 'operator'`. The other
+ * two billing models (`agent`, `advertiser`) don't depend on per-operator
+ * onboarding state — `agent` billing routes through the buyer agent's
+ * payments relationship; `advertiser` billing is direct to the
+ * advertiser regardless of which operator placed the buy.
+ */
+export function isPerAccountBillingRestricted(
+  operator: string,
+  billing: string,
+): boolean {
+  if (billing !== 'operator') return false;
+  return operator.endsWith(NO_DIRECT_BILLING_OPERATOR_SUFFIX);
+}

--- a/server/src/training-agent/account-handlers.ts
+++ b/server/src/training-agent/account-handlers.ts
@@ -11,6 +11,7 @@ import { sessionKeyFromArgs } from './state.js';
 import { getAgentUrl } from './config.js';
 import { encodeOffsetCursor, decodeOffsetCursor } from './pagination.js';
 import { getCommercialRelationship } from './commercial-relationships.js';
+import { isPerAccountBillingRestricted } from './account-billing-relationships.js';
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -397,6 +398,34 @@ export function handleSyncAccounts(args: ToolArgs, ctx: TrainingContext) {
           recovery: 'correctable',
           details: {
             scope: 'capability',
+            supported_billing: [...SUPPORTED_BILLINGS],
+          },
+        }],
+      });
+      continue;
+    }
+
+    // Per-account-relationship gate (BILLING_NOT_SUPPORTED, scope: "account").
+    // Distinct from the capability gate above: the seller's capability
+    // accepts the value, but the seller has no direct billing
+    // relationship for THIS specific operator on THIS account. See
+    // account-billing-relationships.ts for the operator-domain
+    // convention the training-agent uses to simulate per-(operator,
+    // billing) onboarding state. Recovery advice: same as the
+    // capability gate (try the next-most-permissive value the seller's
+    // supported_billing allows).
+    if (isPerAccountBillingRestricted(input.operator, input.billing)) {
+      results.push({
+        brand: input.brand,
+        operator: input.operator,
+        action: 'failed',
+        status: 'rejected',
+        errors: [{
+          code: 'BILLING_NOT_SUPPORTED',
+          message: `Operator '${input.operator}' has no direct billing relationship for '${input.billing}' billing. Try a different supported value.`,
+          recovery: 'correctable',
+          details: {
+            scope: 'account',
             supported_billing: [...SUPPORTED_BILLINGS],
           },
         }],

--- a/server/tests/unit/account-handlers.test.ts
+++ b/server/tests/unit/account-handlers.test.ts
@@ -255,6 +255,100 @@ describe('sync_accounts', () => {
     expect(errors[0].details.supported_billing).toEqual(['agent', 'operator', 'advertiser']);
   });
 
+  it('per-account gate: operator with no direct billing → BILLING_NOT_SUPPORTED scope: "account"', async () => {
+    // The training-agent's account-billing-relationships.ts treats any
+    // operator domain ending in `-no-direct-billing.example` as having
+    // no direct billing relationship for `billing: operator`. Submits
+    // expose the per-account sub-gate without the capability gate
+    // firing first (the value IS in supported_billing).
+    const { result } = await simulateCallTool(server, 'sync_accounts', {
+      accounts: [{
+        brand: { domain: 'acme.com' },
+        operator: 'agency.regional-no-direct-billing.example',
+        billing: 'operator',
+        sandbox: true,
+      }],
+    });
+
+    const acct = (result.accounts as Record<string, unknown>[])[0];
+    expect(acct.action).toBe('failed');
+    expect(acct.status).toBe('rejected');
+    const errors = acct.errors as Array<{
+      code: string;
+      recovery: string;
+      details: { scope: string; supported_billing: string[] };
+    }>;
+    expect(errors[0].code).toBe('BILLING_NOT_SUPPORTED');
+    expect(errors[0].recovery).toBe('correctable');
+    expect(errors[0].details.scope).toBe('account');
+    expect(errors[0].details.supported_billing).toEqual(['agent', 'operator', 'advertiser']);
+  });
+
+  it('per-account gate: same operator with billing: agent passes (gate is operator-billing-specific)', async () => {
+    // The convention only restricts `billing: operator` for no-direct-
+    // billing operators; agent and advertiser billing don't depend on
+    // per-operator onboarding state. This test pins the scope to the
+    // operator-billing combo so a future broadening doesn't silently
+    // break unrelated paths.
+    const { result } = await simulateCallTool(server, 'sync_accounts', {
+      accounts: [{
+        brand: { domain: 'acme.com' },
+        operator: 'agency.regional-no-direct-billing.example',
+        billing: 'agent',
+        sandbox: true,
+      }],
+    });
+
+    const acct = (result.accounts as Record<string, unknown>[])[0];
+    expect(acct.status).toBe('active');
+    expect(acct.billing).toBe('agent');
+  });
+
+  it('per-account gate: operator without the convention suffix passes', async () => {
+    // Pin: only operators ending in -no-direct-billing.example trigger
+    // the gate. This test guards against accidental over-broadening
+    // (e.g., a future regex tweak that matches "no-direct" anywhere).
+    const { result } = await simulateCallTool(server, 'sync_accounts', {
+      accounts: [{
+        brand: { domain: 'acme.com' },
+        operator: 'agency.no-direct-billing-but-not-suffix.example',
+        billing: 'operator',
+        sandbox: true,
+      }],
+    });
+
+    const acct = (result.accounts as Record<string, unknown>[])[0];
+    expect(acct.status).toBe('active');
+    expect(acct.billing).toBe('operator');
+  });
+
+  it('per-account gate composes with per-agent gate: passthrough principal still gets per-agent rejection on agent billing', async () => {
+    // Compositional test: a passthrough-only principal submitting
+    // billing: agent against a no-direct-billing operator gets the
+    // per-agent gate fire (account-scope gate doesn't apply because
+    // billing is `agent`, not `operator`). Confirms gate ordering
+    // doesn't hide the per-agent rejection.
+    const passthroughCtx: TrainingContext = {
+      mode: 'open',
+      principal: 'static:demo:demo-billing-passthrough-v1',
+    };
+    const passthroughServer = createTrainingAgentServer(passthroughCtx);
+
+    const { result } = await simulateCallTool(passthroughServer, 'sync_accounts', {
+      accounts: [{
+        brand: { domain: 'acme.com' },
+        operator: 'agency.regional-no-direct-billing.example',
+        billing: 'agent',
+        sandbox: true,
+      }],
+    });
+
+    const acct = (result.accounts as Record<string, unknown>[])[0];
+    expect(acct.status).toBe('rejected');
+    const errors = acct.errors as Array<{ code: string }>;
+    expect(errors[0].code).toBe('BILLING_NOT_PERMITTED_FOR_AGENT');
+  });
+
   it('passthrough-only principal: rejects billing: agent with BILLING_NOT_PERMITTED_FOR_AGENT', async () => {
     const passthroughCtx: TrainingContext = {
       mode: 'open',


### PR DESCRIPTION
## Summary

Closes the third remaining billing-gate follow-up. Distinct from the seller-wide capability gate (already implemented in [#3851](https://github.com/adcontextprotocol/adcp/pull/3851)) and the per-buyer-agent gate (`BILLING_NOT_PERMITTED_FOR_AGENT`, also in #3851). Per the spec at [`error-details/billing-not-supported.json`](https://adcontextprotocol.org/schemas/v3/error-details/billing-not-supported.json):

> `BILLING_NOT_SUPPORTED` with `error.details.scope: "account"` — "the seller's capability accepts the value generally but not for the specific operator on this account."

## What landed

1. **New `account-billing-relationships.ts`** — single helper `isPerAccountBillingRestricted(operator, billing)` keyed on operator domain. Convention: operators whose domain ends in `-no-direct-billing.example` have no direct billing relationship for `billing: 'operator'`. Other billing models (`agent`, `advertiser`) don't depend on per-operator onboarding state.

2. **`handleSyncAccounts`** wires the new gate between the capability gate (`scope: "capability"`) and the per-buyer-agent gate. Returns `BILLING_NOT_SUPPORTED` with `error.details.scope: "account"` + the `supported_billing` echo.

3. **4 new unit tests** in `account-handlers.test.ts`:
   - operator with `-no-direct-billing.example` suffix → `BILLING_NOT_SUPPORTED scope: "account"`
   - same operator with `billing: agent` passes (scope-discipline regression-pin: gate is operator-billing-specific)
   - operator without the suffix passes (over-broadening regression-pin)
   - composition: passthrough-only principal submitting `billing: agent` against a no-direct-billing operator still gets the per-agent rejection (gate-ordering regression-pin — account-scope gate doesn't apply because billing is `agent`, not `operator`)

## Scope discipline

The per-account gate is operator-scoped, not per-buyer-agent. It fires regardless of who's calling — even an agent-billable buyer agent submitting `billing: operator` for a no-direct-billing operator gets the same `scope: "account"` rejection. Mirrors real-world data: the operator's billing eligibility is a property of the seller's onboarding state with the operator, not of the agent representing the buyer.

## Phase 2 outlook

When SDK Phase 2 ships framework-level enforcement, both billing gates (`BILLING_NOT_PERMITTED_FOR_AGENT` per-agent and `BILLING_NOT_SUPPORTED scope: "account"` per-operator) become candidates for framework-side machinery — the agent-side gate via `ctx.agent.billing_capabilities` (already populated since [#4026](https://github.com/adcontextprotocol/adcp/pull/4026)), the account-side via a parallel `ctx.account.billing_relationships` surface that doesn't yet exist. Until then, both stay adopter-side with the data sources colocated in `commercial-relationships.ts` (per-agent) and `account-billing-relationships.ts` (per-operator).

## Tests

- 26/26 unit tests in `account-handlers.test.ts` pass (was 22 before this PR; +4 new).
- Full server suite: 3159 passed, 42 skipped, 0 failed (excluding two pre-existing flaky tests unrelated to this work — `illustration-c2pa-wiring` and `addie-router LLM confidence tiers`).
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)