### PR TITLE
docs(building): persona-walk Tier 1 fixes — six day-1 friction points

### DIFF
--- a/.changeset/building-persona-tier1.md
+++ b/.changeset/building-persona-tier1.md
@@ -1,0 +1,20 @@
+---
+---
+
+docs(building): persona-walk Tier 1 fixes — six day-1 friction points
+
+Six fixes from the post-merge persona walks (greenfield buy-side dev, greenfield seller, hand-rolled migrator, SDK porter, evaluator/CTO).
+
+1. **Live test agent on `build-a-caller.mdx`.** Buy-side persona stalled at hour 1: every code block used `https://sales.example.com` placeholder with no real URL to call. Added a Tip callout near the top pointing at `https://test-agent.adcontextprotocol.org` (with per-domain endpoints) — `getAdcpCapabilities()` works without auth, so day-1 success unblocked.
+
+2. **Inline-define `account.operator` and `brand.domain` on first use.** Both pages used `'sales.example'` as a placeholder without explaining what string goes there. Buy-side persona couldn't make first call. Inline-glossed on `build-a-caller.mdx:115` and `calling-an-agent.mdx:46`.
+
+3. **Fixed broken anchor on `migrate-from-hand-rolled.mdx:10`.** Pointed at `#three-questions-to-pick-your-layer` (old structure); index now uses `#two-checks-before-you-start`. Defensive readers test links — broken anchor on the second sentence eroded trust for the migrator persona.
+
+4. **`L4/index.mdx` updated to reflect Phase 3.** Listed only `build-an-agent` and `migrate-from-hand-rolled`; missing `build-a-caller` and `choose-your-sdk` (added in Phase 3 PR #4031). Removed the "later docs phase" caveat. Added `choose-your-sdk` as the first listed page (the SDK choice gates everything else).
+
+5. **5th Card on `building/index.mdx`: "Run a prebuilt agent."** Greenfield seller persona with a 2-engineer team had to dig three levels deep to find their right answer (self-host Prebid SalesAgent or partner with a managed platform). Added the small-team path as a peer Card. Also tightened the "2–8 minutes" framing on the Build an agent card to flag that it covers the protocol layer only — full going-live scope on `operating-an-agent`.
+
+6. **Specialism decision rubric on `build-an-agent.mdx`.** Seller persona couldn't tell `sales-guaranteed` vs `sales-proposal-mode` from the bare table. Added a 3-bullet decision rubric naming the buying motion that maps to each (IO + rate card → guaranteed; real-time auction → non-guaranteed; per-buy negotiation → proposal-mode).
+
+These are the Tier 1 ship-blockers from the persona walks. Tier 2 (extract 2.5→3.0 changelog, inline per-layer SDK contracts into `by-layer/L*/index.mdx` stubs) ships in a separate PR.

--- a/docs/building/by-layer/L4/build-a-caller.mdx
+++ b/docs/building/by-layer/L4/build-a-caller.mdx
@@ -11,6 +11,10 @@ If you're building the **buy side** — a DSP, planning tool, agentic client, or
 **Spec-level reference vs build-shaped guide.** This page walks you through the build. The wire-level invariants — every rule that applies to every mutating call — live at [Calling an AdCP agent](/docs/protocol/calling-an-agent). Read it once before going to production; refer back whenever you're debugging a wire-shape error.
 </Note>
 
+<Tip>
+**Try it against a live agent.** AAO runs a public test agent at `https://test-agent.adcontextprotocol.org` with per-domain endpoints — `/sales/mcp`, `/creative/mcp`, `/signals/mcp`, `/governance/mcp`. Point your client at the matching endpoint and `getAdcpCapabilities()` works without auth. Use it to verify your install before pointing at a real seller.
+</Tip>
+
 ## Install the SDK
 
 The same SDKs that ship server primitives also ship the calling client. Install one and you have both.
@@ -112,7 +116,7 @@ const buy = await client.createMediaBuy({
 Two things worth knowing on the first call:
 
 - **Generate a fresh `idempotency_key` per logical operation.** Same key on retry → server replays the same response. Fresh key after a failure creates duplicate buys. See the [Idempotency rules](/docs/protocol/calling-an-agent#idempotency-replay-vs-new-operation).
-- **`account` is a discriminated `oneOf`.** Pick one variant (`{account_id}` or `{brand, operator}`) and send only its required fields. Merging them fails both. See [`account` is `oneOf`](/docs/protocol/calling-an-agent#account-is-oneof--pick-exactly-one-variant).
+- **`account` is a discriminated `oneOf`.** Pick one variant (`{account_id}` from `sync_accounts` / `list_accounts`, or `{brand, operator}` as the natural key — `brand.domain` is the buyer's brand domain, `operator` is the seller agent's deployment hostname or brand.json identifier) and send only its required fields. Merging them fails both. See [`account` is `oneOf`](/docs/protocol/calling-an-agent#account-is-oneof--pick-exactly-one-variant).
 
 ## Handle the three response shapes
 

--- a/docs/building/by-layer/L4/build-an-agent.mdx
+++ b/docs/building/by-layer/L4/build-an-agent.mdx
@@ -105,6 +105,13 @@ Each agent declares its `supported_protocols` (domains) and `specialisms` on `ge
 | `build-signals-agent` | `["signals"]` | `signal-owned`, `signal-marketplace` |
 | `build-creative-agent` | `["creative"]` | `creative-ad-server`, `creative-template` |
 
+**Picking a sales specialism:**
+- **`sales-guaranteed`** — you sell with IO approval against rate cards or fixed CPMs. Direct-sold CTV, premium video, broadcast TV, OOH.
+- **`sales-non-guaranteed`** — you sell on a real-time auction with floor pricing. Programmatic display, OLV, audio.
+- **`sales-proposal-mode`** — you negotiate per-buy (custom pricing, custom packages, custom terms), no rate card. Premium publisher direct, sponsorship, native at scale.
+
+You can claim more than one if you genuinely operate that way — but each claim adds a storyboard you must pass. Claim only what you sell. See the [Compliance Catalog](/docs/building/verification/compliance-catalog) for the full taxonomy and per-specialism storyboards.
+
 Building a **brand rights** agent (licensing talent, music, stock media)? There's no skill today — see the [Brand Protocol docs](/docs/brand-protocol) and claim `brand-rights` under the `brand` domain.
 
 See the [Compliance Catalog](/docs/building/verification/compliance-catalog) for every domain and specialism with its storyboard and status (stable, preview, deprecated).

--- a/docs/building/by-layer/L4/index.mdx
+++ b/docs/building/by-layer/L4/index.mdx
@@ -11,7 +11,7 @@ See the [SDK stack reference](/docs/building/cross-cutting/sdk-stack) for what e
 
 ## Pages in this layer
 
+- **[Choose your SDK](/docs/building/by-layer/L4/choose-your-sdk)** — language coverage matrix, install commands, package exports, CLI tools. Start here if you haven't picked an SDK.
 - **[Build an agent](/docs/building/by-layer/L4/build-an-agent)** — server side. Point a coding agent at a skill file; get a storyboard-compliant AdCP agent.
+- **[Build a caller](/docs/building/by-layer/L4/build-a-caller)** — client side. Install the SDK, discover the agent, make calls, handle responses, ingest reporting.
 - **[Migrate from hand-rolled](/docs/building/by-layer/L4/migrate-from-hand-rolled)** — already running an AdCP agent built before the SDKs were mature? Swap one layer at a time.
-
-For the caller (client) side, see [Calling an agent](/docs/protocol/calling-an-agent) — a build-shaped guide for the caller will land in a later docs phase.

--- a/docs/building/by-layer/L4/migrate-from-hand-rolled.mdx
+++ b/docs/building/by-layer/L4/migrate-from-hand-rolled.mdx
@@ -7,7 +7,7 @@ description: "Incremental migration path for adopters with a working AdCP agent 
 
 This guide is for adopters with a **working AdCP agent in production** who want to move to an official SDK without a flag-day rewrite. Your agent serves real traffic; you have engineers who built the current stack and will defend it; you can't afford a multi-week freeze. The path is incremental — swap one layer at a time, ship after each step, re-certify as you go.
 
-If you're greenfield, you're in the wrong doc — see [Build an Agent](/docs/building/by-layer/L4/build-an-agent). If you're still deciding whether to migrate at all, see [Where to start, Q3](/docs/building#three-questions-to-pick-your-layer).
+If you're greenfield, you're in the wrong doc — see [Build an Agent](/docs/building/by-layer/L4/build-an-agent). If you're still deciding whether to migrate at all, see the [hand-rolled re-evaluation check](/docs/building#two-checks-before-you-start) on the building overview.
 
 ## 0. Inventory what you own today
 

--- a/docs/building/index.mdx
+++ b/docs/building/index.mdx
@@ -32,10 +32,13 @@ For ~95% of adopters: **start at L4 with the full-stack SDK in your language.**
 
 <CardGroup cols={2}>
   <Card title="Build an agent" icon="server" href="/docs/building/by-layer/L4/build-an-agent">
-    Server side. Point a coding agent at a skill file, get a storyboard-compliant AdCP agent in 2–8 minutes.
+    Server side, with engineering capacity. Point a coding agent at a skill file, get a storyboard-compliant AdCP agent in 2–8 minutes (protocol layer only — see [Operating an agent](/docs/building/operating/operating-an-agent) for the full going-live scope).
   </Card>
   <Card title="Build a caller" icon="phone" href="/docs/building/by-layer/L4/build-a-caller">
     Client side. Install the SDK, write the calls, handle async responses and errors, ingest reporting. Weeks-of-handler-glue scope, not months.
+  </Card>
+  <Card title="Run a prebuilt agent" icon="cube" href="/docs/building/operating/operating-an-agent">
+    Small team or no engineering capacity. Self-host Prebid SalesAgent, or partner with a managed platform that runs an AdCP agent on your behalf. Configuration over code.
   </Card>
   <Card title="Migrate from hand-rolled" icon="code-merge" href="/docs/building/by-layer/L4/migrate-from-hand-rolled">
     Already running an AdCP agent built before the SDKs were mature? Swap one layer at a time, with conflict modes, per-step rollback, and intermediate states that pass conformance.

--- a/docs/protocol/calling-an-agent.mdx
+++ b/docs/protocol/calling-an-agent.mdx
@@ -43,6 +43,8 @@ Missing the key → `adcp_error.code: 'VALIDATION_ERROR'` with `/idempotency_key
 "account": { "account_id": "seller_assigned_id" }
 
 // variant 1: by natural key (brand + operator, optional sandbox)
+//   brand.domain — the buyer's brand domain (e.g., advertiser website)
+//   operator     — the seller agent's deployment hostname / brand.json identifier
 "account": { "brand": { "domain": "acme.com" }, "operator": "sales.example" }
 ```
 


### PR DESCRIPTION
## Summary

Six fixes from the post-merge persona walks (greenfield buy-side dev, greenfield seller, hand-rolled migrator, SDK porter, evaluator/CTO).

1. **Live test agent on `build-a-caller.mdx`** — buy-side persona stalled at hour 1: every code block used `https://sales.example.com` with no real URL to call. Added a Tip callout pointing at `https://test-agent.adcontextprotocol.org`.
2. **Inline-define `account.operator` and `brand.domain` on first use** in `build-a-caller.mdx` and `calling-an-agent.mdx`.
3. **Fixed broken anchor on `migrate-from-hand-rolled.mdx:10`** (pointed at stale heading).
4. **`L4/index.mdx` updated to reflect Phase 3** — added `build-a-caller` and `choose-your-sdk`, removed the "later phase" caveat.
5. **5th Card on `building/index.mdx`: "Run a prebuilt agent"** — small-team seller path surfaced as a peer.
6. **Specialism decision rubric on `build-an-agent.mdx`** — 3-bullet guidance mapping buying motion to specialism.

Tier 2 (2.5→3.0 changelog extraction; per-layer SDK contracts into `by-layer/L*/index.mdx`) ships next.

## Test plan

- [x] `mintlify broken-links` passes
- [x] Changeset present

🤖 Generated with [Claude Code](https://claude.com/claude-code)