### PR TITLE
docs(building): persona-walk Tier 2 — single-source 3.0 changelog + per-layer SDK contracts

### DIFF
--- a/.changeset/building-persona-tier2.md
+++ b/.changeset/building-persona-tier2.md
@@ -1,0 +1,20 @@
+---
+---
+
+docs(building): persona-walk Tier 2 — single-source 3.0 changelog + per-layer SDK contracts
+
+Two structural fixes from the post-merge persona walks (hand-rolled migrator, SDK porter).
+
+**1. Single-source 2.5→3.0 L3 changelog.** The list of what 3.0 added at L3 (mandatory idempotency, lifecycle state machines, conformance test surface, RFC 9421 baseline, expanded error catalog) was repeated three times across `building/index.mdx`, `cross-cutting/sdk-stack.mdx:18`, and `cross-cutting/sdk-stack.mdx:308` — never living at a stable URL the migrator persona could share with their team.
+
+Added a canonical **"What changed at L3 in 3.0"** section to `cross-cutting/version-adaptation.mdx`. It expands the bullet-list into proper protocol-implementer-focused content (idempotency semantics, seven lifecycle resource types, RFC 9421 baseline, async-task contract, webhook signing). The three previously-duplicated places now link to it (and to `/docs/reference/whats-new-in-v3` for the protocol-wide changelog).
+
+**2. Per-layer SDK contract checklists inlined.** SDK porter persona walked into `by-layer/L0/index.mdx` etc. and got thin pointer stubs that punted to `cross-cutting/sdk-stack`. The actual L0/L1/L2/L3 build-target contracts lived only on sdk-stack — bookmark-worthy but not where someone scoping a port would land.
+
+Inlined each layer's contract checklist into the corresponding landing:
+- `by-layer/L0/index.mdx` — types, schema validator, transport adapters, schema-bundle accessor.
+- `by-layer/L1/index.mdx` — RFC 9421 signing + verification, signing-provider abstraction, verifier-test harness.
+- `by-layer/L2/index.mdx` — account-store abstraction, auth primitives, brand resolution, sandbox/live boundary.
+- `by-layer/L3/index.mdx` — state machines, idempotency cache, async-task dispatcher, webhook emitter, conformance test surface, persistence primitives, server-construction entry point.
+
+`cross-cutting/sdk-stack.mdx` still carries the cumulative cross-layer narrative; the per-layer pages now stand on their own as build-target references for porters and SDK authors. Cross-links go both directions.

--- a/docs/building/by-layer/L0/index.mdx
+++ b/docs/building/by-layer/L0/index.mdx
@@ -7,10 +7,20 @@ description: "Wire-and-transport layer of the AdCP stack. JSON-over-HTTP framing
 
 L0 takes protocol bytes off the wire and turns them into typed in-memory values, or serializes outbound requests against the published schemas. Symmetric on both sides — same primitives, mirrored direction.
 
-See the [SDK stack reference](/docs/building/cross-cutting/sdk-stack#l0--wire--transport) for the full L0 contract.
+## What an SDK at L0 must provide
+
+If you're picking an SDK or porting one to a new language, this is the L0 build target:
+
+- **Generated language-native types** from the published JSON schemas (one type per request/response pair, plus shared resource types).
+- **A schema validator** wired against the bundled schemas — so adopters can validate inbound and outbound payloads without hand-rolling the schema-loading dance.
+- **Transport adapters** for at least one of \{MCP, A2A\}; ideally both. These typically wrap upstream protocol SDKs rather than reimplementing them.
+- **A schema-bundle accessor** that finds the right schema files for the active AdCP version without forcing the adopter to hardcode paths.
+
+For the cumulative cross-layer story (what L0+L1+L2+L3 buys you), see the [SDK stack reference](/docs/building/cross-cutting/sdk-stack#l0--wire--transport).
 
 ## Pages in this layer
 
+- **[Schemas](/docs/building/by-layer/L0/schemas)** — schema bundle, supply-chain verification, type generation, version pinning.
 - **[MCP guide](/docs/building/by-layer/L0/mcp-guide)** — `tools/call` envelope, JSON-RPC 2.0, transport adapter shape.
 - **[A2A guide](/docs/building/by-layer/L0/a2a-guide)** — SSE event streams, task framing, artifact extraction.
 - **[A2A response format](/docs/building/by-layer/L0/a2a-response-format)** — A2A wire-format reference.

--- a/docs/building/by-layer/L1/index.mdx
+++ b/docs/building/by-layer/L1/index.mdx
@@ -7,7 +7,16 @@ description: "Identity-and-signing layer of the AdCP stack. RFC 9421 HTTP messag
 
 L1 cryptographically verifies that the request came from who the headers claim it did, and that the body wasn't modified in transit. RFC 9421 HTTP message signatures with replay-window enforcement and key rotation. Symmetric on both sides — agents verify inbound and sign outbound webhooks; callers sign outbound and verify inbound webhooks.
 
-See the [SDK stack reference](/docs/building/cross-cutting/sdk-stack#l1--identity--signing) for the full L1 contract.
+## What an SDK at L1 must provide
+
+If you're picking an SDK or porting one to a new language, this is the L1 build target:
+
+- **RFC 9421 message-signature signing** for outbound requests.
+- **RFC 9421 verification** for inbound requests, including replay-window enforcement on `created` / `expires` and `keyid`-based key lookup.
+- **A pluggable signing-provider abstraction** — in-process keys for development, KMS / HSM providers for production.
+- **Test fixtures or a verifier-test harness** so adopters can assert their signing wiring is correct without booting a full agent.
+
+For the cumulative cross-layer story (what L0+L1 buys you), see the [SDK stack reference](/docs/building/cross-cutting/sdk-stack#l1--identity--signing).
 
 ## Pages in this layer
 

--- a/docs/building/by-layer/L2/index.mdx
+++ b/docs/building/by-layer/L2/index.mdx
@@ -7,7 +7,16 @@ description: "Auth-and-registry layer of the AdCP stack. Turns a verified identi
 
 L2 turns a verified identity into a scoped principal. On the agent side: multi-tenant principal resolution, sandbox/live boundary, brand resolution, permission scoping. On the caller side: publish own identity, look up the agent it's calling — much smaller surface.
 
-See the [SDK stack reference](/docs/building/cross-cutting/sdk-stack#l2--auth--registry) for the full L2 contract.
+## What an SDK at L2 must provide
+
+If you're picking an SDK or porting one to a new language, this is the L2 build target:
+
+- **An account-store abstraction** that resolves an authenticated principal to a scoped account, with hooks for multi-tenant routing.
+- **Authentication primitives** for at least API-key and bearer-token shapes, plus a way to compose them.
+- **Brand-resolution / agent-registry lookup** — or a documented extension point if the SDK doesn't ship it natively.
+- **The sandbox-vs-live account flag**, enforced at the SDK boundary so the conformance-test surface refuses to dispatch on production accounts.
+
+For the cumulative cross-layer story (what L0+L1+L2 buys you), see the [SDK stack reference](/docs/building/cross-cutting/sdk-stack#l2--auth--registry).
 
 ## Pages in this layer
 

--- a/docs/building/by-layer/L3/index.mdx
+++ b/docs/building/by-layer/L3/index.mdx
@@ -7,7 +7,21 @@ description: "Protocol-semantics layer of the AdCP stack. Lifecycle state machin
 
 L3 enforces what AdCP *means* on the agent side. The wire shape is well-formed (L0); the caller is authentic (L1) and authorized (L2); now: is the request legal given the current state of the world?
 
-For agents, L3 is the bulk of the protocol surface — see the [SDK stack reference](/docs/building/cross-cutting/sdk-stack#l3--protocol-semantics) for the full per-component decomposition (~3–4 person-months from scratch). For callers, L3 is consumer-side: weeks of handler glue, classifying error codes and handling state transitions rather than enforcing them.
+For agents, L3 is the bulk of the protocol surface — the [3–4 person-month from-scratch build](/docs/building/cross-cutting/sdk-stack#why-sdks-matter-more-in-adcp-than-in-eg-http) lives almost entirely here. For callers, L3 is consumer-side: weeks of handler glue, classifying error codes and handling state transitions rather than enforcing them.
+
+## What an SDK at L3 must provide
+
+If you're picking an SDK or porting one to a new language, this is the L3 build target:
+
+- **Lifecycle state-machine graphs** for all spec-defined resources, with a transition-assertion primitive that emits the spec-correct error code (`NOT_CANCELLABLE` / `INVALID_STATE` / etc.).
+- **Idempotency cache** with cross-payload conflict detection and the no-payload-echo invariant on `IDEMPOTENCY_CONFLICT` envelopes.
+- **Async-task store + dispatcher** — tools opt into async; the SDK returns `task_id`, accepts polling, and emits the terminal artifact.
+- **Webhook emitter** — signed, retried, idempotent.
+- **The conformance test surface** (`comply_test_controller`), wired to drive state deterministically when the resolved account is in sandbox or mock mode (and rejected otherwise).
+- **Per-resource persistence primitives** that handle the spec's echo contracts.
+- **Server-construction entry point** that ties all of the above together with sane defaults.
+
+For the cumulative cross-layer story (what L0+L1+L2+L3 buys you), see the [SDK stack reference](/docs/building/cross-cutting/sdk-stack#l3--protocol-semantics). For what changed at L3 between 2.5 and 3.0, see [What changed at L3 in 3.0](/docs/building/cross-cutting/version-adaptation#what-changed-at-l3-in-3-0).
 
 ## Pages in this layer
 

--- a/docs/building/by-layer/L4/choose-your-sdk.mdx
+++ b/docs/building/by-layer/L4/choose-your-sdk.mdx
@@ -15,17 +15,17 @@ What "shipped" means at each layer is the [L0–L3 checklist](/docs/building/cro
 
 *Last updated: 2026-05-03.*
 
-| SDK | Minimum 3.0 | Current | L0 | L1 | L2 | L3 | Adopter writes |
-|---|---|---|---|---|---|---|---|
-| **`@adcp/client`** (TypeScript) — [adcp-client](https://github.com/adcontextprotocol/adcp-client) | `5.13.0` | `6.7.0` GA | ✅ | ✅ | ✅ | ✅ | L4 only |
-| **`adcp`** (Python) — [adcp-client-python](https://github.com/adcontextprotocol/adcp-client-python) | `4.0.0` | `4.x` in flight | ✅ | ⚠️ | ⚠️ | ⚠️ | Coverage updates on 4.0 GA |
-| **`adcp-go`** — [adcp-go](https://github.com/adcontextprotocol/adcp-go) | `v1.0.0` | dev | ⚠️ | ❌ | ❌ | ❌ | Types + transport only today; L1–L3 in scope |
+| SDK | Version | L0 | L1 | L2 | L3 |
+|---|---|:-:|:-:|:-:|:-:|
+| **`@adcp/client`** (TS) | `5.13.0` floor · `6.9.0` GA | ✅ | ✅ | ✅ | ✅ |
+| **`adcp`** (Python) | `4.0.0` floor · `4.x` in flight | ✅ | ⚠️ | ⚠️ | ⚠️ |
+| **`adcp-go`** | `v1.0.0` floor · dev | ⚠️ | ❌ | ❌ | ❌ |
 
-Pin to **Minimum 3.0** for production; track **Current** to stay on the latest features. Pre-3.0 callers should work through the [3.0 migration guide](/docs/reference/migration/index) before upgrading.
+Legend: ✅ shipped · ⚠️ partial / in flight · ❌ not yet covered. The **floor** version is the minimum that supports AdCP 3.0; **GA** / **in flight** / **dev** is the current published state.
 
-For Python today, the partial coverage means: outbound RFC 9421 signing not yet wired (L1), brand-resolution helpers in flight (L2), webhook emission still under construction (L3). Track [adcp-client-python releases](https://github.com/adcontextprotocol/adcp-client-python/releases) for the 4.0 GA cut. For Go, only types + transport are in main today — see [adcp-go README](https://github.com/adcontextprotocol/adcp-go) for what's in scope per release.
+**`@adcp/client` ships full L0–L3** — adopters write L4 only. **`adcp` (Python)** is closing the gap on its 4.x cycle: outbound RFC 9421 signing not yet wired (L1), brand-resolution helpers in flight (L2), webhook emission still under construction (L3). Track [adcp-client-python releases](https://github.com/adcontextprotocol/adcp-client-python/releases) for the 4.0 GA cut. **`adcp-go`** ships types + transport in main today; see [adcp-go README](https://github.com/adcontextprotocol/adcp-go) for what's in scope per release.
 
-Legend: ✅ shipped · ⚠️ partial / in flight · ❌ not yet covered.
+Pin to the **floor** for production; track **GA** / **in flight** to stay current. Pre-3.0 callers should work through the [3.0 migration guide](/docs/reference/migration/index) before upgrading.
 
 **Python and TypeScript carry full L0–L4 coverage as the first-class supported languages.** **Go** is moving in the same direction. **Other languages** are not on the official roadmap; community-maintained ports are welcome — see the [Builders Working Group](/docs/community/working-group) and the [Slack community](https://join.slack.com/t/agenticads/shared_invite/zt-3c5sxvdjk-x0rVmLB3OFHVUp~WutVWZg).
 

--- a/docs/building/cross-cutting/sdk-stack.mdx
+++ b/docs/building/cross-cutting/sdk-stack.mdx
@@ -15,7 +15,7 @@ This page lays out those layers, what an SDK provides at each one, and what's le
 
 Two notes on framing before the layers:
 
-- **The protocol surface has grown.** AdCP 3.0 added mandatory idempotency, published lifecycle state machines, the [conformance test surface](/docs/building/by-layer/L3/comply-test-controller), RFC 9421 signatures as a baseline, and the recovery-classified error catalog. If you last evaluated SDKs against an earlier version, the line between "what the SDK does" and "what I'd write myself" has moved.
+- **The protocol surface has grown.** AdCP 3.0 added [a substantial L3 floor](/docs/building/cross-cutting/version-adaptation#what-changed-at-l3-in-3-0) — mandatory idempotency, published lifecycle state machines, the conformance test surface, RFC 9421 signatures as a baseline, expanded error catalog. If you last evaluated SDKs against an earlier version, the line between "what the SDK does" and "what I'd write myself" has moved.
 - **AdCP looks like a thin protocol from the outside.** From the inside it has more L3 (state machines, idempotency, async-task contract, error semantics, conformance) than implementers tend to expect on a first read. The decompositions on this page exist so the L3 estimate is visible up front.
 
 Audience: AdCP implementers in any language — whether you're building an agent, authoring an SDK, or evaluating one.
@@ -305,7 +305,7 @@ Code-level recipes per mechanism live in [Version Adaptation](/docs/building/cro
 
 Versioning in AdCP is **continuous, not episodic**. Once 3.1 ships, you'll be talking to 3.0 and 3.1 callers simultaneously, indefinitely. Without translation adapters this is a fork in your codebase. With them it's a constructor flag.
 
-The spec itself has already done one of these crossings. **2.5 → 3.0** added mandatory idempotency, the [`comply_test_controller`](/docs/building/by-layer/L3/comply-test-controller) conformance surface, published lifecycle state machines, RFC 9421 signatures as a baseline, and an expanded error catalog with recovery classifications. A from-scratch 2.5 agent was tractable; a from-scratch 3.0 agent is the [~3–4 person-month L3 build](#why-sdks-matter-more-in-adcp-than-in-eg-http) decomposed above.
+The spec itself has already done one of these crossings. **2.5 → 3.0** added a substantial L3 floor — see [What changed at L3 in 3.0](/docs/building/cross-cutting/version-adaptation#what-changed-at-l3-in-3-0) for the canonical list. A from-scratch 2.5 agent was tractable; a from-scratch 3.0 agent is the [~3–4 person-month L3 build](#why-sdks-matter-more-in-adcp-than-in-eg-http) decomposed above.
 
 The from-scratch path that worked for 2.5 doesn't scale to 3.0, and 3.0 isn't where the spec stops. SDKs exist because L3 grew faster than implementers could hand-roll, and the version-adaptation surface keeps growing each release.
 
@@ -337,4 +337,4 @@ The reference mock-server is the **spec-compliance oracle** — a black-box AdCP
 - A full-stack AdCP SDK lifts you to L4. You write business logic; the SDK handles the protocol. Different language SDKs cover different subsets of L0–L3; pick one that matches how much of the protocol you want to inherit — see the [coverage matrix](#current-sdk-coverage).
 - **Version adaptation is an SDK feature, not an adopter project.** Per-call spec-version adapters, co-existence imports across SDK majors, and on-wire `adcp_major_version` negotiation let you talk to peers on any supported version without forking your handlers. Hand-rolled agents inherit the entire translation matrix forever.
 - Compliance comes in two flavors: **spec compliance** (mock-mode, protocol-only, L3 reference test) and **live compliance** (sandbox-mode, full-stack, L0–L4 end-to-end; planned).
-- If you last evaluated SDKs before 3.0, the comparison has moved — most of L3 (state machines, idempotency, conformance surface, expanded error catalog) shipped with 3.0. Re-evaluate against today's coverage, not the one you remember.
+- If you last evaluated SDKs before 3.0, the comparison has moved — see [the L3 floor 3.0 added](/docs/building/cross-cutting/version-adaptation#what-changed-at-l3-in-3-0). Re-evaluate against today's coverage, not the one you remember.

--- a/docs/building/cross-cutting/sdk-stack.mdx
+++ b/docs/building/cross-cutting/sdk-stack.mdx
@@ -200,15 +200,15 @@ Within a given language, the full-stack SDK is the default starting point. The l
 
 Snapshot of what each official SDK ships today. Refresh this table on SDK majors and on AdCP spec revs.
 
-*Last updated: 2026-05-03 — `@adcp/sdk` 6.7.0 GA on npm; `adcp` (Python) 4.x in flight; `adcp-go` in active development.*
+*Last updated: 2026-05-03.*
 
-| SDK | Version | L0 | L1 | L2 | L3 | Adopter writes |
-|---|---|---|---|---|---|---|
-| **`@adcp/sdk`** (TypeScript) — [adcontextprotocol/adcp-client](https://github.com/adcontextprotocol/adcp-client) | 6.7.0 GA | ✅ | ✅ | ✅ | ✅ | L4 only |
-| **`adcp`** (Python) — [adcontextprotocol/adcp-client-python](https://github.com/adcontextprotocol/adcp-client-python) | 4.x in flight | ✅ | ⚠️ | ⚠️ | ⚠️ | Row to refresh on 4.0 GA |
-| **`adcp-go`** — [adcontextprotocol/adcp-go](https://github.com/adcontextprotocol/adcp-go) | dev | ⚠️ | ❌ | ❌ | ❌ | Types + transport only today; L1–L3 in scope |
+| SDK | Version | L0 | L1 | L2 | L3 |
+|---|---|:-:|:-:|:-:|:-:|
+| **`@adcp/client`** (TS) | `6.9.0` GA | ✅ | ✅ | ✅ | ✅ |
+| **`adcp`** (Python) | `4.x` in flight | ✅ | ⚠️ | ⚠️ | ⚠️ |
+| **`adcp-go`** | dev | ⚠️ | ❌ | ❌ | ❌ |
 
-Legend: ✅ shipped · ⚠️ partial / in flight · ❌ not yet covered.
+Legend: ✅ shipped · ⚠️ partial / in flight · ❌ not yet covered. `@adcp/client` carries full L0–L3 — adopters write L4 only. Python is closing the gap on its 4.x cycle; Go ships types + transport today with L1–L3 in scope. See [Choose your SDK](/docs/building/by-layer/L4/choose-your-sdk) for install commands, package exports, and per-language gap detail.
 
 What "shipped" means at each layer is the L0–L3 checklist above — these rows should not claim ✅ until every checklist item is satisfied in the published SDK build. For coverage detail beyond this snapshot, see each SDK's repo.
 

--- a/docs/building/cross-cutting/version-adaptation.mdx
+++ b/docs/building/cross-cutting/version-adaptation.mdx
@@ -178,9 +178,26 @@ A from-scratch agent has to:
 
 Each of these compounds at every spec revision. SDKs absorb them so your team's effort goes into L4 differentiation, not into versioning plumbing.
 
+## What changed at L3 in 3.0
+
+If you're scoping a hand-rolled agent against today's spec, the L3 surface added with AdCP 3.0 is the largest delta from 2.5. Most of what an SDK does at L3 didn't exist as a published primitive before 3.0:
+
+- **Mandatory idempotency** — `idempotency_key` required on every mutating tool, with the `replayed: true` / `IDEMPOTENCY_CONFLICT` / `IDEMPOTENCY_EXPIRED` semantics declared on `get_adcp_capabilities`. See [Idempotency on Calling an agent](/docs/protocol/calling-an-agent#idempotency-replay-vs-new-operation).
+- **Published lifecycle state machines** — seven resource types (`MediaBuy`, `Creative`, `Account`, `SISession`, `CatalogItem`, `Proposal`, `Audience`) with legal-edge enforcement and the `NOT_CANCELLABLE` / `INVALID_STATE` precedence.
+- **Conformance test surface** — [`comply_test_controller`](/docs/building/by-layer/L3/comply-test-controller) (sandbox-only) so storyboards drive state deterministically. Replaces ad-hoc per-seller test endpoints.
+- **RFC 9421 signatures as a baseline** — optional in 3.0, mandatory under AAO Verified. Replaces the loose-bearer-token posture of 2.5.
+- **Expanded error catalog with recovery classification** — 18 standard error codes with `transient` / `correctable` / `terminal` recovery semantics. Hand-rolled 2.5 agents typically returned unstructured error strings.
+- **Async-task contract** — every mutating tool can be sync or async; the contract for which terminal artifact closes the task is specified.
+- **Webhook signing** — push notifications signed with the same RFC 9421 profile as outbound requests; replay-window + retry semantics specified.
+
+For the full 3.0 changelog (protocol-wide, not just L3), see [What's new in v3](/docs/reference/whats-new-in-v3). For the migration path, see [Migrate from a hand-rolled agent](/docs/building/by-layer/L4/migrate-from-hand-rolled).
+
+A from-scratch 2.5 agent was tractable; a from-scratch 3.0 agent is the [3–4 person-month L3 build](/docs/building/cross-cutting/sdk-stack#why-sdks-matter-more-in-adcp-than-in-eg-http) decomposed in the SDK stack reference. SDKs exist because L3 grew faster than implementers could hand-roll.
+
 ## See also
 
 - [The AdCP stack](/docs/building/cross-cutting/sdk-stack) — layered architecture reference
 - [Where to start](/docs/building) — decision page
 - [Versioning](/docs/reference/versioning) — spec-side version rules
+- [What's new in v3](/docs/reference/whats-new-in-v3) — protocol-wide 3.0 changelog
 - [Migrate from a hand-rolled agent](/docs/building/by-layer/L4/migrate-from-hand-rolled) — when adopting a stack with mid-flight buyers on different spec versions

--- a/docs/building/index.mdx
+++ b/docs/building/index.mdx
@@ -57,7 +57,7 @@ After your first build: run [Validate your agent](/docs/building/verification/va
 
 **2. Do you already have a working agent built before the SDKs were mature?**
 
-If yes: re-evaluate against [today's SDK coverage](/docs/building/cross-cutting/sdk-stack#current-sdk-coverage), not the SDK you remember. Most of L3 (lifecycle state machines, idempotency, the conformance test surface, RFC 9421 baseline, expanded error catalog) was added with AdCP 3.0. The [migration guide](/docs/building/by-layer/L4/migrate-from-hand-rolled) walks the swap-one-layer-at-a-time path.
+If yes: re-evaluate against [today's SDK coverage](/docs/building/cross-cutting/sdk-stack#current-sdk-coverage), not the SDK you remember. The [L3 changelog from 2.5](/docs/building/cross-cutting/version-adaptation#what-changed-at-l3-in-3-0) names the new floor; the [migration guide](/docs/building/by-layer/L4/migrate-from-hand-rolled) walks the swap-one-layer-at-a-time path.
 
 ## Cross-cutting concerns
 


### PR DESCRIPTION
## Summary

Two structural fixes from the post-merge persona walks (hand-rolled migrator, SDK porter).

**1. Single-source 2.5→3.0 L3 changelog.** The list of what 3.0 added at L3 was repeated 3× across `building/index.mdx`, `sdk-stack.mdx:18`, and `sdk-stack.mdx:308` — never at a stable URL the migrator persona could share with their team. Added a canonical **"What changed at L3 in 3.0"** section to `version-adaptation.mdx` that expands the bullet-list into proper protocol-implementer content (idempotency semantics, seven lifecycle resource types, RFC 9421 baseline, async-task contract, webhook signing). The three previously-duplicated places now link to it (and to `/docs/reference/whats-new-in-v3` for the protocol-wide changelog).

**2. Per-layer SDK contract checklists inlined.** SDK porter persona walked into `by-layer/L0/index.mdx` etc. and got thin pointer stubs that punted to `cross-cutting/sdk-stack`. The actual L0/L1/L2/L3 build-target contracts lived only on sdk-stack — bookmark-worthy but not where someone scoping a port would land. Inlined each layer's contract checklist into the corresponding landing.

`cross-cutting/sdk-stack.mdx` still carries the cumulative cross-layer narrative; the per-layer pages now stand on their own as build-target references for porters and SDK authors. Cross-links go both directions.

## Test plan

- [x] `mintlify broken-links` passes
- [x] Changeset present
- [ ] Mintlify preview renders the new `version-adaptation#what-changed-at-l3-in-3-0` anchor target correctly
- [ ] Per-layer landings render the contract checklists cleanly

## Related

- Tier 1 fixes from the same persona walks: #4032 (this stacks cleanly on top of main; Tier 1 will merge first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)