### PR TITLE
docs(compliance): add sales-specialism decision tree

### DIFF
--- a/.changeset/docs-specialism-decision-tree.md
+++ b/.changeset/docs-specialism-decision-tree.md
@@ -1,0 +1,14 @@
+---
+---
+
+docs(compliance): add sales-specialism decision tree and deprecate sales-proposal-mode in docs (closes #4038)
+
+Adopters had no consolidated guide for choosing the right `sales-*` specialism — the only option was to read every specialism's narrative block and triangulate. A wrong claim wastes the adopter's first compliance run by grading them against storyboards their architecture doesn't support.
+
+Changes:
+
+- **`compliance-catalog.mdx`** — adds `## Choosing a sales specialism` section (using `<Steps>`) between the media-buy specialism table and `## How to claim`. The tree resolves adopters to `sales-broadcast-tv`, `sales-catalog-driven`, `sales-social`, `sales-guaranteed`, or `sales-non-guaranteed` in three steps, covers the multi-specialism case (hybrid guaranteed + auction platforms), and explains the `media_buy.supports_proposals` capability flag with JSON examples. Also fixes the `sales-proposal-mode` status row from `stable` to `deprecated`.
+
+- **`build-an-agent.mdx`** — removes `sales-proposal-mode` from the typical-specialisms table for `build-seller-agent` and rewrites the "Picking a sales specialism" section to link to the new decision tree and surface the `supports_proposals` flag.
+
+- **`get-test-ready.mdx`** — updates the example `get_adcp_capabilities` response: replaces `sales-proposal-mode` with `sales-guaranteed` + `media_buy.supports_proposals: true`, and fixes `"media-buy"` → `"media_buy"` in `supported_protocols` (wire form is snake_case).

--- a/docs/building/by-layer/L4/build-an-agent.mdx
+++ b/docs/building/by-layer/L4/build-an-agent.mdx
@@ -192,7 +192,7 @@ media_buy_seller (9 steps)
 </Warning>
 
 <Tip>
-Each skill includes variant storyboards for different business models — non-guaranteed, guaranteed with approval, proposal mode, and more. Run `npx @adcp/client@latest storyboard list` to see all available storyboards.
+Each skill includes variant storyboards for different business models — non-guaranteed, guaranteed with approval, direct-buy guaranteed, and more. Run `npx @adcp/client@latest storyboard list` to see all available storyboards.
 </Tip>
 
 See **[Validate Your Agent](/docs/building/verification/validate-your-agent)** for the full testing workflow — debugging failing steps, running compliance checks, and validating interactively through Addie.

--- a/docs/building/by-layer/L4/build-an-agent.mdx
+++ b/docs/building/by-layer/L4/build-an-agent.mdx
@@ -99,18 +99,18 @@ Each agent declares its `supported_protocols` (domains) and `specialisms` on `ge
 
 | Skill | Typical `supported_protocols` | Typical `specialisms` (pick one or combine) |
 |---|---|---|
-| `build-seller-agent` | `["media_buy", "creative"]` | `sales-guaranteed`, `sales-non-guaranteed`, `sales-proposal-mode` |
+| `build-seller-agent` | `["media_buy", "creative"]` | `sales-guaranteed`, `sales-non-guaranteed` |
 | `build-generative-seller-agent` | `["media_buy", "creative"]` | `creative-generative` + `sales-non-guaranteed` |
 | `build-retail-media-agent` | `["media_buy", "creative"]` | `sales-catalog-driven` |
 | `build-signals-agent` | `["signals"]` | `signal-owned`, `signal-marketplace` |
 | `build-creative-agent` | `["creative"]` | `creative-ad-server`, `creative-template` |
 
-**Picking a sales specialism:**
-- **`sales-guaranteed`** — you sell with IO approval against rate cards or fixed CPMs. Direct-sold CTV, premium video, broadcast TV, OOH.
-- **`sales-non-guaranteed`** — you sell on a real-time auction with floor pricing. Programmatic display, OLV, audio.
-- **`sales-proposal-mode`** — you negotiate per-buy (custom pricing, custom packages, custom terms), no rate card. Premium publisher direct, sponsorship, native at scale.
+**Picking a sales specialism:** See [Choosing a sales specialism](/docs/building/verification/compliance-catalog#choosing-a-sales-specialism) in the Compliance Catalog for the full decision tree. Quick reference:
+- **`sales-guaranteed`** — IO approval, fixed pricing. Set `media_buy.supports_proposals: true` if you support RFP/proposal flows; `false` (or omit) for direct-buy only.
+- **`sales-non-guaranteed`** — auction / PMP.
+- **`sales-broadcast-tv`**, **`sales-catalog-driven`**, **`sales-social`** — channel-specific; see the decision tree.
 
-You can claim more than one if you genuinely operate that way — but each claim adds a storyboard you must pass. Claim only what you sell. See the [Compliance Catalog](/docs/building/verification/compliance-catalog) for the full taxonomy and per-specialism storyboards.
+You can claim more than one. See the [Compliance Catalog](/docs/building/verification/compliance-catalog) for the full taxonomy and per-specialism storyboards.
 
 Building a **brand rights** agent (licensing talent, music, stock media)? There's no skill today — see the [Brand Protocol docs](/docs/brand-protocol) and claim `brand-rights` under the `brand` domain.
 

--- a/docs/building/verification/compliance-catalog.mdx
+++ b/docs/building/verification/compliance-catalog.mdx
@@ -91,7 +91,7 @@ Specialisms are grouped below by parent protocol.
 |-----------|--------|---------|
 | `sales-guaranteed` | stable | Guaranteed media buys with human IO approval |
 | `sales-non-guaranteed` | stable | Non-guaranteed auction-based media buys |
-| `sales-proposal-mode` | stable | Media buys negotiated via proposal acceptance |
+| `sales-proposal-mode` | deprecated | **Deprecated in 3.1.** Drop this claim and replace with `sales-guaranteed` + `media_buy.supports_proposals: true`. See [#3823](https://github.com/adcontextprotocol/adcp/issues/3823). |
 | `sales-catalog-driven` | stable | Catalog-driven commerce with conversion tracking |
 | `sales-broadcast-tv` | stable | Broadcast linear TV with guaranteed inventory and FCC cancellation rules |
 | `sales-social` | stable | Social media advertising platform with self-service flows |
@@ -105,6 +105,75 @@ Specialisms are grouped below by parent protocol.
 <Note>
 `audience-sync` moved from the `governance` protocol to `media-buy` to match its tool family. If your agent claims `audience-sync` but only declares `governance` in `supported_protocols`, add `media_buy` to `supported_protocols` — the runner now expects the media-buy baseline to run alongside the audience-sync storyboard.
 </Note>
+
+## Choosing a sales specialism
+
+The `sales-*` specialisms are not mutually exclusive — a hybrid platform with both a guaranteed direct desk and an auction floor should claim both `sales-guaranteed` and `sales-non-guaranteed`. Follow the steps below to resolve your claim.
+
+<Warning>
+**`sales-proposal-mode` is deprecated in 3.1.** Do not claim it for new agents. Existing agents that declare it must drop it entirely and replace it with `sales-guaranteed` + `media_buy.supports_proposals: true` in `get_adcp_capabilities`. See [#3823](https://github.com/adcontextprotocol/adcp/issues/3823).
+</Warning>
+
+<Steps>
+
+<Step title="Is your inventory channel-specific?">
+
+Three specialisms apply to specific delivery channels. They have their own storyboards and are not substitutes for the purchase-model specialisms — if you sell outside these channels (or alongside them), also follow Steps 2–3.
+
+| If you operate… | Claim |
+|---|---|
+| Broadcast linear TV with FCC cancellation rules | `sales-broadcast-tv` |
+| Catalog-driven dynamic ads (product listings, restaurant menus, hotel listings, local commerce) | `sales-catalog-driven` |
+| Social platform with platform-managed creative | `sales-social` |
+
+If none apply, skip to Step 2.
+
+</Step>
+
+<Step title="What purchase model do you support?">
+
+| If you sell… | Claim |
+|---|---|
+| Guaranteed media (IO approval, fixed pricing) | `sales-guaranteed` → see Step 3 |
+| Auction / PMP non-guaranteed | `sales-non-guaranteed` |
+| Both guaranteed and non-guaranteed | `sales-guaranteed` + `sales-non-guaranteed` |
+
+</Step>
+
+<Step title="Set media_buy.supports_proposals (sales-guaranteed only)">
+
+`media_buy.supports_proposals` is a boolean in the `media_buy` capabilities block of your `get_adcp_capabilities` response. It gates whether the `proposal_finalize` compliance scenario runs.
+
+| If you… | Set |
+|---|---|
+| Accept RFPs, generate proposals, and finalize to committed status before IO | `media_buy.supports_proposals: true` |
+| Sell direct-buy guaranteed only (auction PG, retail SKU, quoted-rate — no RFP flow) | `media_buy.supports_proposals: false` (or omit — default is `false`) |
+
+```jsonc
+// Full-service guaranteed seller — proposal lifecycle graded
+{
+  "supported_protocols": ["media_buy"],
+  "specialisms": ["sales-guaranteed"],
+  "media_buy": {
+    "supports_proposals": true
+  }
+}
+```
+
+```jsonc
+// Direct-buy guaranteed seller — proposal scenario skipped as capability_unsupported
+{
+  "supported_protocols": ["media_buy"],
+  "specialisms": ["sales-guaranteed"],
+  "media_buy": {
+    "supports_proposals": false
+  }
+}
+```
+
+</Step>
+
+</Steps>
 
 ### creative
 

--- a/docs/building/verification/compliance-catalog.mdx
+++ b/docs/building/verification/compliance-catalog.mdx
@@ -106,6 +106,41 @@ Specialisms are grouped below by parent protocol.
 `audience-sync` moved from the `governance` protocol to `media-buy` to match its tool family. If your agent claims `audience-sync` but only declares `governance` in `supported_protocols`, add `media_buy` to `supported_protocols` — the runner now expects the media-buy baseline to run alongside the audience-sync storyboard.
 </Note>
 
+### creative
+
+| Specialism | Status | Purpose |
+|-----------|--------|---------|
+| `creative-ad-server` | stable | Creative ad server with tag-based delivery |
+| `creative-generative` | stable | Generative creative agent producing assets on demand |
+| `creative-template` | stable | Creative template and transformation agent |
+
+### signals
+
+| Specialism | Status | Purpose |
+|-----------|--------|---------|
+| `signal-owned` | stable | Owned signal agent exposing first-party segments |
+| `signal-marketplace` | stable | Marketplace signal agent reselling third-party data |
+
+### governance
+
+| Specialism | Status | Purpose |
+|-----------|--------|---------|
+| `content-standards` | stable | Content standards enforcement (brand safety, policy compliance) |
+| `property-lists` | stable | Property list governance — curated inclusion and exclusion lists for targeting and delivery compliance |
+| `collection-lists` | stable | Collection list governance — curated inclusion and exclusion lists of content programs (shows, series, podcasts) for program-level brand safety |
+| `governance-delivery-monitor` | stable | Campaign delivery monitoring with drift detection |
+| `governance-spend-authority` | stable | Conditional spend approval and human-in-the-loop governance |
+
+<Note>
+**Coming in 3.1.** `measurement-verification` (third-party viewability, attribution, brand-safety, and SI-outcome verification) is scheduled for 3.1 under a dedicated `measurement` protocol.
+</Note>
+
+### brand
+
+| Specialism | Status | Purpose |
+|-----------|--------|---------|
+| `brand-rights` | stable | Brand identity and rights licensing (talent, music, stock media) |
+
 ## Choosing a sales specialism
 
 The `sales-*` specialisms are not mutually exclusive — a hybrid platform with both a guaranteed direct desk and an auction floor should claim both `sales-guaranteed` and `sales-non-guaranteed`. Follow the steps below to resolve your claim.
@@ -118,15 +153,13 @@ The `sales-*` specialisms are not mutually exclusive — a hybrid platform with 
 
 <Step title="Is your inventory channel-specific?">
 
-Three specialisms apply to specific delivery channels. They have their own storyboards and are not substitutes for the purchase-model specialisms — if you sell outside these channels (or alongside them), also follow Steps 2–3.
+Three specialisms apply to specific delivery channels and have their own storyboards. If you only sell one of these channel types, claim only the matching specialism. If you also sell general display or video inventory outside these channels, continue to Step 2.
 
 | If you operate… | Claim |
 |---|---|
 | Broadcast linear TV with FCC cancellation rules | `sales-broadcast-tv` |
 | Catalog-driven dynamic ads (product listings, restaurant menus, hotel listings, local commerce) | `sales-catalog-driven` |
 | Social platform with platform-managed creative | `sales-social` |
-
-If none apply, skip to Step 2.
 
 </Step>
 
@@ -174,41 +207,6 @@ If none apply, skip to Step 2.
 </Step>
 
 </Steps>
-
-### creative
-
-| Specialism | Status | Purpose |
-|-----------|--------|---------|
-| `creative-ad-server` | stable | Creative ad server with tag-based delivery |
-| `creative-generative` | stable | Generative creative agent producing assets on demand |
-| `creative-template` | stable | Creative template and transformation agent |
-
-### signals
-
-| Specialism | Status | Purpose |
-|-----------|--------|---------|
-| `signal-owned` | stable | Owned signal agent exposing first-party segments |
-| `signal-marketplace` | stable | Marketplace signal agent reselling third-party data |
-
-### governance
-
-| Specialism | Status | Purpose |
-|-----------|--------|---------|
-| `content-standards` | stable | Content standards enforcement (brand safety, policy compliance) |
-| `property-lists` | stable | Property list governance — curated inclusion and exclusion lists for targeting and delivery compliance |
-| `collection-lists` | stable | Collection list governance — curated inclusion and exclusion lists of content programs (shows, series, podcasts) for program-level brand safety |
-| `governance-delivery-monitor` | stable | Campaign delivery monitoring with drift detection |
-| `governance-spend-authority` | stable | Conditional spend approval and human-in-the-loop governance |
-
-<Note>
-**Coming in 3.1.** `measurement-verification` (third-party viewability, attribution, brand-safety, and SI-outcome verification) is scheduled for 3.1 under a dedicated `measurement` protocol.
-</Note>
-
-### brand
-
-| Specialism | Status | Purpose |
-|-----------|--------|---------|
-| `brand-rights` | stable | Brand identity and rights licensing (talent, music, stock media) |
 
 ## How to claim
 

--- a/docs/building/verification/compliance-catalog.mdx
+++ b/docs/building/verification/compliance-catalog.mdx
@@ -106,6 +106,41 @@ Specialisms are grouped below by parent protocol.
 `audience-sync` moved from the `governance` protocol to `media-buy` to match its tool family. If your agent claims `audience-sync` but only declares `governance` in `supported_protocols`, add `media_buy` to `supported_protocols` — the runner now expects the media-buy baseline to run alongside the audience-sync storyboard.
 </Note>
 
+### creative
+
+| Specialism | Status | Purpose |
+|-----------|--------|---------|
+| `creative-ad-server` | stable | Creative ad server with tag-based delivery |
+| `creative-generative` | stable | Generative creative agent producing assets on demand |
+| `creative-template` | stable | Creative template and transformation agent |
+
+### signals
+
+| Specialism | Status | Purpose |
+|-----------|--------|---------|
+| `signal-owned` | stable | Owned signal agent exposing first-party segments |
+| `signal-marketplace` | stable | Marketplace signal agent reselling third-party data |
+
+### governance
+
+| Specialism | Status | Purpose |
+|-----------|--------|---------|
+| `content-standards` | stable | Content standards enforcement (brand safety, policy compliance) |
+| `property-lists` | stable | Property list governance — curated inclusion and exclusion lists for targeting and delivery compliance |
+| `collection-lists` | stable | Collection list governance — curated inclusion and exclusion lists of content programs (shows, series, podcasts) for program-level brand safety |
+| `governance-delivery-monitor` | stable | Campaign delivery monitoring with drift detection |
+| `governance-spend-authority` | stable | Conditional spend approval and human-in-the-loop governance |
+
+<Note>
+**Coming in 3.1.** `measurement-verification` (third-party viewability, attribution, brand-safety, and SI-outcome verification) is scheduled for 3.1 under a dedicated `measurement` protocol.
+</Note>
+
+### brand
+
+| Specialism | Status | Purpose |
+|-----------|--------|---------|
+| `brand-rights` | stable | Brand identity and rights licensing (talent, music, stock media) |
+
 ## Choosing a sales specialism
 
 The `sales-*` specialisms are not mutually exclusive — a hybrid platform with both a guaranteed direct desk and an auction floor should claim both `sales-guaranteed` and `sales-non-guaranteed`. Follow the steps below to resolve your claim.
@@ -118,15 +153,13 @@ The `sales-*` specialisms are not mutually exclusive — a hybrid platform with 
 
 <Step title="Is your inventory channel-specific?">
 
-Three specialisms apply to specific delivery channels. They have their own storyboards and are not substitutes for the purchase-model specialisms — if you sell outside these channels (or alongside them), also follow Steps 2–3.
+Three specialisms apply to specific delivery channels and have their own storyboards. If you only sell one of these channel types, claim only the matching specialism. If you also sell general display or video inventory outside these channels, continue to Step 2.
 
 | If you operate… | Claim |
 |---|---|
 | Broadcast linear TV with FCC cancellation rules | `sales-broadcast-tv` |
 | Catalog-driven dynamic ads (product listings, restaurant menus, hotel listings, local commerce) | `sales-catalog-driven` |
 | Social platform with platform-managed creative | `sales-social` |
-
-If none apply, skip to Step 2.
 
 </Step>
 

--- a/docs/building/verification/get-test-ready.mdx
+++ b/docs/building/verification/get-test-ready.mdx
@@ -23,7 +23,7 @@ You ship these three surfaces. The runner owns storyboard selection, fixture ord
 
 `get_adcp_capabilities` is how the runner picks which storyboards apply to you. It is also the [conformance](/docs/building/verification/conformance) contract: you are promising to pass every storyboard that matches what you declare.
 
-The example below is for a full-service guaranteed seller (proposal lifecycle enabled). A direct-buy guaranteed seller would set `media_buy.supports_proposals: false` (or omit it). A broadcast-TV seller would claim `sales-broadcast-tv`; a creative-only agent would claim the `creative` protocol with `creative-hosting` or `creative-generative` specialisms; a signals provider would claim `signals`. The pattern is the same: declare only what you actually implement.
+The example below is for a full-service guaranteed seller (proposal lifecycle enabled). A direct-buy guaranteed seller would set `media_buy.supports_proposals: false` (or omit it). A broadcast-TV seller would claim `sales-broadcast-tv`; a creative-only agent would claim the `creative` protocol with `creative-ad-server` or `creative-generative` specialisms; a signals provider would claim `signals`. The pattern is the same: declare only what you actually implement.
 
 ```json
 {

--- a/docs/building/verification/get-test-ready.mdx
+++ b/docs/building/verification/get-test-ready.mdx
@@ -23,12 +23,15 @@ You ship these three surfaces. The runner owns storyboard selection, fixture ord
 
 `get_adcp_capabilities` is how the runner picks which storyboards apply to you. It is also the [conformance](/docs/building/verification/conformance) contract: you are promising to pass every storyboard that matches what you declare.
 
-The example below is for a guaranteed + proposal seller. A broadcast-TV seller would claim `sales-broadcast-tv`; a creative-only agent would claim the `creative` protocol with `creative-hosting` or `creative-generative` specialisms; a signals provider would claim `signals`. The pattern is the same: declare only what you actually implement.
+The example below is for a full-service guaranteed seller (proposal lifecycle enabled). A direct-buy guaranteed seller would set `media_buy.supports_proposals: false` (or omit it). A broadcast-TV seller would claim `sales-broadcast-tv`; a creative-only agent would claim the `creative` protocol with `creative-hosting` or `creative-generative` specialisms; a signals provider would claim `signals`. The pattern is the same: declare only what you actually implement.
 
 ```json
 {
-  "supported_protocols": ["media-buy", "creative"],
-  "specialisms": ["sales-guaranteed", "sales-proposal-mode"],
+  "supported_protocols": ["media_buy", "creative"],
+  "specialisms": ["sales-guaranteed"],
+  "media_buy": {
+    "supports_proposals": true
+  },
   "account": {
     "sandbox": true,
     "require_operator_auth": false

--- a/docs/learning/specialist/media-buy.mdx
+++ b/docs/learning/specialist/media-buy.mdx
@@ -23,7 +23,7 @@ Agents in the `media_buy` domain declare specific flows they support via the `sp
 |---|---|---|
 | `sales-guaranteed` | stable | Guaranteed media buys with human IO approval |
 | `sales-non-guaranteed` | stable | Non-guaranteed auction-based media buys |
-| `sales-proposal-mode` | stable | Media buys negotiated via proposal acceptance |
+| `sales-proposal-mode` | deprecated | **Deprecated in 3.1.** Replace with `sales-guaranteed` + `media_buy.supports_proposals: true`. |
 | `sales-catalog-driven` | stable | Catalog-driven commerce with conversion tracking |
 | `sales-broadcast-tv` | stable | Broadcast linear TV with guaranteed inventory and FCC cancellation rules |
 | `sales-social` | stable | Social media advertising platform with self-service flows |

--- a/docs/learning/tracks/publisher.mdx
+++ b/docs/learning/tracks/publisher.mdx
@@ -208,7 +208,7 @@ Declare `media_buy` in `supported_protocols` and choose the specialism that matc
 
 - `sales-guaranteed` — guaranteed with human IO approval
 - `sales-non-guaranteed` — auction-based
-- `sales-proposal-mode` — proposal-negotiated
+- `sales-proposal-mode` — **deprecated in 3.1**; use `sales-guaranteed` + `media_buy.supports_proposals: true` instead
 - `sales-catalog-driven` — catalog-driven commerce with conversion tracking
 - `sales-broadcast-tv` — broadcast linear TV
 - `sales-social` — social platform with self-service flows


### PR DESCRIPTION
Closes #4038

Sell-side adopters had no single source of truth for choosing a `sales-*` specialism — the only path was to read every storyboard narrative and triangulate. A wrong claim wastes the adopter's first compliance run by grading them against storyboards their architecture doesn't support.

This PR adds a `## Choosing a sales specialism` three-step decision tree (`<Steps>`) to `compliance-catalog.mdx`, placed after `### brand` and before `## How to claim`. The tree resolves adopters to `sales-broadcast-tv`, `sales-catalog-driven`, `sales-social`, `sales-guaranteed`, or `sales-non-guaranteed`; covers the multi-specialism case (hybrid guaranteed + auction platforms); and explains the `media_buy.supports_proposals` capability flag with `jsonc` wire examples. It also corrects `sales-proposal-mode` status from `stable` → `deprecated` in four files (`compliance-catalog.mdx`, `learning/specialist/media-buy.mdx`, `learning/tracks/publisher.mdx`, `build-an-agent.mdx`), and fixes a pre-existing `creative-hosting` → `creative-ad-server` typo in `get-test-ready.mdx`.

**Non-breaking justification:** adds a new doc section and corrects status labels/example JSON; no schema, storyboard, or enum values changed. Existing clients unaffected.

**Pre-PR review:**
- code-reviewer: approved — fixed two blockers (commented `json` fences → `jsonc`; two learning-docs files showed `sales-proposal-mode` as `stable`)
- docs-expert: approved — fixed two additional blockers (Step 1 caveat implied broadcast-only sellers must also claim `sales-guaranteed`; `build-an-agent.mdx` Tip block still said "proposal mode"); also moved section to correct `##`-level position after all `###` specialism subsections

**Nits (not blocking, left for human reviewer):**
- Step 3 title `Set media_buy.supports_proposals (sales-guaranteed only)` mixes case conventions — can be polished to `Configure media_buy.supports_proposals`

---

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout 4041` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_017tXWUzFaMeS77vRFinT25W