### PR TITLE
fix(dashboard-agents): unblock Test OAuth loop + honest opt-out controls

### DIFF
--- a/.changeset/fix-agent-oauth-resource-indicator.md
+++ b/.changeset/fix-agent-oauth-resource-indicator.md
@@ -1,0 +1,10 @@
+---
+---
+
+fix(dashboard-agents): unblock Test-your-agent OAuth loop and stop lying about scheduled checks
+
+Two fixes for the `/dashboard/agents` page:
+
+1. **OAuth `resource` indicator (RFC 8707).** The Test-your-agent flow was looping users back to "Connect via OAuth" after a successful authorization. Tokens were being saved correctly, but the issued access token's `aud` claim didn't match the MCP resource server, so the agent rejected every subsequent bearer-token request with a 401 — which the storyboard probe re-classified as `needs_oauth`, sending the user right back to the same prompt. Per the MCP authorization spec (2025-06+), the authorization request and the token exchange must include a `resource` parameter (RFC 8707). We now compute the canonical resource URI from the agent URL and forward it on both legs of the flow, plus advertise `scope` from the discovered metadata when present.
+
+2. **Honest opt-out UX.** The "Every 12h" interval dropdown stayed enabled even when the agent was `opted_out`, suggesting scheduled checks would run when the heartbeat actually skips opted-out agents entirely. Disable both the Pause toggle and the interval dropdown when `compliance_opt_out = true`, and surface a "monitoring opted out" hint pointing to the "Show on registry" toggle as the way to re-enable.

--- a/package-lock.json
+++ b/package-lock.json
@@ -869,6 +869,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -915,6 +916,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1498,6 +1500,7 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
       "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -3712,7 +3715,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
       "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@mintlify/prebuild/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -4760,7 +4764,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
       "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@mintlify/scraping/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -5169,6 +5174,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -5525,6 +5531,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -5857,8 +5864,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/colors/-/colors-3.0.0.tgz",
       "integrity": "sha512-FUOsGBkHrYJwCSEtWRCIfQbZG7q1e6DgxCIOe1SUQzDe/7rXXeA47s8yCn6fuTNQAj1Zq4oTFi9Yjp3wzElcxg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -6604,6 +6610,7 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
       "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
         "@radix-ui/react-compose-refs": "1.1.2",
@@ -8492,7 +8499,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.96.2.tgz",
       "integrity": "sha512-hzI6cTVh4KNRk8UtoIBS7Lv9g6BnJPXvBKsvYH1aGWvv0347jT3BnSvztOE+kD76XGvZnRC/t6qdW1CaIfwCeA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -8698,6 +8704,7 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -8825,6 +8832,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -9188,6 +9196,7 @@
       "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9256,6 +9265,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10448,8 +10458,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/clean-stack": {
       "version": "4.2.0",
@@ -11085,8 +11094,7 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/csv-parse": {
       "version": "6.2.1",
@@ -11464,7 +11472,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1595872.tgz",
       "integrity": "sha512-kRfgp8vWVjBu/fbYCiVFiOqsCk3CrMKEo3WbgGT2NXK2dG7vawWPBljixajVgGK9II8rDO9G0oD0zLt3I1daRg==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -12410,6 +12419,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -14556,6 +14566,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -14855,6 +14866,7 @@
       "integrity": "sha512-2CbJAa7XeziZYe6pDS5RVLirRY28iSGMQuEV8jRU5NQsONQNfcR/BZHHc9vkMg2lGYTHTM2pskxC1YmY28p6bQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.2.0",
         "ansi-escapes": "^7.0.0",
@@ -15933,6 +15945,7 @@
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -19270,6 +19283,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -19534,6 +19548,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -20290,6 +20305,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21337,6 +21353,7 @@
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -21475,8 +21492,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",
@@ -23060,6 +23076,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -23253,6 +23270,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -23426,6 +23444,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -23509,6 +23528,7 @@
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -23985,6 +24005,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -24766,6 +24787,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -1472,13 +1472,13 @@
               <div class="agent-meta-row-left">
                 <span>Last checked: ${escapeHtml(lastChecked)}</span>
                 <span class="agent-meta-sep" aria-hidden="true">·</span>
-                <label class="agent-toggle" title="Pause automated compliance and health checks">
-                  <input type="checkbox" class="monitoring-pause-toggle" data-agent-url="${escapeHtml(agent.url)}" ${cs.monitoring_paused ? 'checked' : ''}>
+                <label class="agent-toggle" title="${isPublic ? 'Pause automated compliance and health checks' : 'Re-enable monitoring (Show on registry) before pausing'}">
+                  <input type="checkbox" class="monitoring-pause-toggle" data-agent-url="${escapeHtml(agent.url)}" ${cs.monitoring_paused ? 'checked' : ''} ${isPublic ? '' : 'disabled'}>
                   <span class="agent-toggle-label">Pause</span>
                 </label>
-                <label class="agent-toggle" title="How often to re-run automated compliance checks">
+                <label class="agent-toggle" title="${isPublic ? 'How often to re-run automated compliance checks' : 'Monitoring is opted out — re-enable to schedule checks'}">
                   <span class="agent-toggle-label">Every</span>
-                  <select class="monitoring-interval-select agent-lifecycle-select" data-agent-url="${escapeHtml(agent.url)}" ${cs.monitoring_paused ? 'disabled' : ''}>
+                  <select class="monitoring-interval-select agent-lifecycle-select" data-agent-url="${escapeHtml(agent.url)}" ${(cs.monitoring_paused || !isPublic) ? 'disabled' : ''}>
                     <option value="6" ${(cs.check_interval_hours || 12) === 6 ? 'selected' : ''}>6h</option>
                     <option value="12" ${(cs.check_interval_hours || 12) === 12 ? 'selected' : ''}>12h</option>
                     <option value="24" ${(cs.check_interval_hours || 12) === 24 ? 'selected' : ''}>24h</option>
@@ -1487,7 +1487,7 @@
                     <option value="168" ${(cs.check_interval_hours || 12) === 168 ? 'selected' : ''}>Weekly</option>
                   </select>
                 </label>
-                ${cs.monitoring_paused ? '<span style="color: var(--color-warning-700, #b45309);">paused</span>' : ''}
+                ${!isPublic ? '<span style="color: var(--color-warning-700, #b45309);" title="Compliance opt-out skips this agent in the scheduled heartbeat. Tick \'Show on registry\' to re-enable.">monitoring opted out</span>' : (cs.monitoring_paused ? '<span style="color: var(--color-warning-700, #b45309);">paused</span>' : '')}
               </div>
               <div class="agent-meta-row-actions">
                 <button class="agent-connect-toggle agent-action-link" data-card-id="${cardId}" data-agent-url="${escapeHtml(agent.url)}">${hasAuth ? 'Update auth' : 'Connect agent'}</button>

--- a/server/src/db/agent-oauth-flows-db.ts
+++ b/server/src/db/agent-oauth-flows-db.ts
@@ -19,6 +19,9 @@ export interface PendingOAuthFlow {
   codeVerifier: string;
   redirectUri: string;
   agentUrl: string;
+  // RFC 8707 resource indicator forwarded into the token exchange so the
+  // issued access token's `aud` claim matches the MCP resource server.
+  resource?: string;
   pendingRequest?: {
     task: string;
     params: Record<string, unknown>;
@@ -35,6 +38,7 @@ interface StoredPendingOAuthFlow {
   codeVerifierIv: string;
   redirectUri: string;
   agentUrl: string;
+  resource?: string;
   pendingRequest?: {
     task: string;
     params: Record<string, unknown>;

--- a/server/src/routes/agent-oauth.ts
+++ b/server/src/routes/agent-oauth.ts
@@ -104,6 +104,28 @@ function generateState(): string {
 }
 
 /**
+ * Compute the RFC 8707 resource indicator for an agent URL.
+ *
+ * MCP servers (per the 2025-06+ authorization spec) reject access tokens
+ * whose `aud` claim doesn't match the MCP resource server. The resource
+ * indicator is the canonical agent URL (origin + path) with no query or
+ * fragment and no trailing slash on the path — see RFC 8707 §2 and the
+ * MCP authorization spec on canonicalization.
+ */
+function canonicalResourceForAgent(agentUrl: string): string | undefined {
+  try {
+    const u = new URL(agentUrl);
+    u.search = '';
+    u.hash = '';
+    let path = u.pathname;
+    if (path.length > 1 && path.endsWith('/')) path = path.slice(0, -1);
+    return `${u.origin}${path}`;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Exchange authorization code for tokens
  */
 async function exchangeCodeForTokens(
@@ -112,7 +134,8 @@ async function exchangeCodeForTokens(
   codeVerifier: string,
   redirectUri: string,
   clientId: string,
-  clientSecret?: string
+  clientSecret?: string,
+  resource?: string,
 ): Promise<OAuthTokens> {
   const params = new URLSearchParams({
     grant_type: 'authorization_code',
@@ -124,6 +147,10 @@ async function exchangeCodeForTokens(
 
   if (clientSecret) {
     params.set('client_secret', clientSecret);
+  }
+
+  if (resource) {
+    params.set('resource', resource);
   }
 
   const response = await fetch(tokenUrl, {
@@ -311,6 +338,13 @@ export function createAgentOAuthRouter(): Router {
       const { verifier, challenge } = generatePKCE();
       const state = generateState();
 
+      // RFC 8707 resource indicator. Required by MCP authorization spec
+      // (2025-06+) so the issued access token's `aud` claim matches the
+      // MCP resource server — without it, agents accept the OAuth flow
+      // but reject every subsequent bearer-token request, which surfaces
+      // to the user as "I authorized but Test still asks me to authorize".
+      const resource = canonicalResourceForAgent(agentContext.agent_url);
+
       // Store pending flow in PostgreSQL
       await agentOAuthFlowsDb.setPendingFlow(state, {
         agentContextId: agent_context_id,
@@ -319,6 +353,7 @@ export function createAgentOAuthRouter(): Router {
         codeVerifier: verifier,
         redirectUri,
         agentUrl: agentContext.agent_url,
+        ...(resource && { resource }),
         pendingRequest,
         returnTo,
       });
@@ -331,6 +366,12 @@ export function createAgentOAuthRouter(): Router {
       authUrl.searchParams.set('state', state);
       authUrl.searchParams.set('code_challenge', challenge);
       authUrl.searchParams.set('code_challenge_method', 'S256');
+      if (resource) {
+        authUrl.searchParams.set('resource', resource);
+      }
+      if (metadata.scopes_supported && metadata.scopes_supported.length > 0) {
+        authUrl.searchParams.set('scope', metadata.scopes_supported.join(' '));
+      }
 
       logger.info({ agentUrl: agentContext.agent_url, state }, 'Starting OAuth flow');
 
@@ -396,7 +437,8 @@ export function createAgentOAuthRouter(): Router {
         flow.codeVerifier,
         flow.redirectUri,
         client.client_id,
-        client.client_secret
+        client.client_secret,
+        flow.resource,
       );
 
       // Save tokens


### PR DESCRIPTION
## Summary

Two fixes for `/dashboard/agents` reported by Emma — the Test button was looping users back to "Connect via OAuth" after a successful authorization, and the "Every 12h" interval dropdown was lying about whether scheduled checks would actually run.

- **OAuth `resource` indicator (RFC 8707).** The agent OAuth flow was missing the `resource` parameter on both the authorization URL and the token exchange. Per the MCP authorization spec (2025-06+), MCP resource servers reject access tokens whose `aud` claim doesn't match them — so authorization "succeeded", tokens were saved, but every subsequent bearer request 401'd, which the storyboard probe re-classified as `needs_oauth`, looping the user. Now compute the canonical resource URI from the agent URL and forward it on both legs. Also forward `scope` from `metadata.scopes_supported` when advertised.
- **Honest opt-out UX.** When `compliance_opt_out = true`, the Pause toggle and interval `<select>` are now `disabled` and a `monitoring opted out` hint renders with a tooltip pointing at "Show on registry" as the way to re-enable. Heartbeat already hard-skips opted-out agents (`server/src/db/compliance-db.ts:528-530`); the UI just wasn't reflecting that.

## Test plan

- [ ] Authorize a fresh MCP agent (e.g. `agents.scope3.com/spotify`) via Test → confirm Test now returns the storyboard list instead of looping back to "Connect via OAuth".
- [ ] Inspect the saved token's `aud` claim (or the authorization URL in network tab) — confirm `resource=https://agents.scope3.com/spotify` is present.
- [ ] If the agent's `/.well-known/oauth-authorization-server` advertises `scopes_supported`, confirm `scope=...` is forwarded on the auth URL.
- [ ] Untick "Show on registry" on an agent → Pause toggle + interval dropdown become disabled, "monitoring opted out" hint appears.
- [ ] Re-tick "Show on registry" → controls re-enable, hint clears (the existing `swapAgentCard` re-render handles this).