### PR TITLE
fix(merge): repoint addie_threads/person_events before deleting secondary's person_relationship

### DIFF
--- a/.changeset/fix-user-merge-person-relationship-fk.md
+++ b/.changeset/fix-user-merge-person-relationship-fk.md
@@ -1,0 +1,6 @@
+---
+---
+
+Fix `mergeUsers` failing with FK 23503 (`addie_threads_person_id_fkey`) when both users have a `person_relationships` row. Repoint `addie_threads.person_id` and `person_events.person_id` to the primary's relationship before deleting the secondary's row, so the addie thread history follows the merge and `person_events` aren't silently CASCADE-deleted.
+
+Also adds three previously-missing tables to the merge — `agent_test_runs`, `certification_expectations`, and `addie_prompt_telemetry` — so merged accounts no longer leak rows under the secondary's `workos_user_id`.

--- a/server/src/db/user-merge-db.ts
+++ b/server/src/db/user-merge-db.ts
@@ -86,6 +86,9 @@ export async function previewUserMerge(
       { name: 'seat_upgrade_requests', col: 'workos_user_id' },
       { name: 'user_email_aliases', col: 'workos_user_id' },
       { name: 'email_link_tokens', col: 'primary_workos_user_id' },
+      { name: 'agent_test_runs', col: 'workos_user_id' },
+      { name: 'certification_expectations', col: 'workos_user_id' },
+      { name: 'addie_prompt_telemetry', col: 'workos_user_id' },
     ];
 
     for (const table of tables) {
@@ -249,12 +252,42 @@ export async function mergeUsers(
       rows_skipped_duplicate: secondaryPrefs.rows.length,
     });
 
-    // person_relationships: UNIQUE(workos_user_id) — keep primary's, delete secondary's
-    const primaryRelExists = await client.query(
-      `SELECT 1 FROM person_relationships WHERE workos_user_id = $1`,
+    // person_relationships: UNIQUE(workos_user_id) — keep primary's, delete
+    // secondary's. addie_threads.person_id and person_events.person_id are
+    // FKs to person_relationships.id; repoint them to the primary's row before
+    // the DELETE so addie_threads doesn't block with a 23503 (no CASCADE) and
+    // person_events doesn't silently CASCADE-delete the secondary's history.
+    const primaryRel = await client.query<{ id: string }>(
+      `SELECT id FROM person_relationships WHERE workos_user_id = $1`,
       [primaryUserId]
     );
-    if (primaryRelExists.rows.length > 0) {
+    if (primaryRel.rows.length > 0) {
+      const primaryRelId = primaryRel.rows[0].id;
+      const secondaryRel = await client.query<{ id: string }>(
+        `SELECT id FROM person_relationships WHERE workos_user_id = $1`,
+        [secondaryUserId]
+      );
+      const secondaryRelId = secondaryRel.rows[0]?.id;
+      if (secondaryRelId) {
+        const threadsMoved = await client.query(
+          `UPDATE addie_threads SET person_id = $1 WHERE person_id = $2 RETURNING 1`,
+          [primaryRelId, secondaryRelId]
+        );
+        const eventsMoved = await client.query(
+          `UPDATE person_events SET person_id = $1 WHERE person_id = $2 RETURNING 1`,
+          [primaryRelId, secondaryRelId]
+        );
+        summary.tables_merged.push({
+          table_name: 'addie_threads',
+          rows_moved: threadsMoved.rows.length,
+          rows_skipped_duplicate: 0,
+        });
+        summary.tables_merged.push({
+          table_name: 'person_events',
+          rows_moved: eventsMoved.rows.length,
+          rows_skipped_duplicate: 0,
+        });
+      }
       const deleted = await client.query(
         `DELETE FROM person_relationships WHERE workos_user_id = $1 RETURNING 1`,
         [secondaryUserId]
@@ -265,6 +298,8 @@ export async function mergeUsers(
         rows_skipped_duplicate: deleted.rows.length,
       });
     } else {
+      // Primary has no person_relationships row — UPDATE keeps the same .id,
+      // so addie_threads / person_events pointers stay valid automatically.
       await mergeWithUpdate('person_relationships');
     }
 
@@ -341,6 +376,12 @@ export async function mergeUsers(
     await mergeWithUpdate('certification_attempts');
     await mergeWithUpdate('teaching_checkpoints');
     await mergeWithUpdate('certification_learner_feedback');
+    await mergeWithUpdate('agent_test_runs');
+    await mergeWithUpdate('certification_expectations');
+
+    // addie_prompt_telemetry: PK(workos_user_id, rule_id) — keep primary's
+    // counters where both have a row for the same rule, otherwise move.
+    await mergeWithConflict('addie_prompt_telemetry', 'rule_id');
     await mergeWithUpdate('flagged_conversations', 'reviewed_by');
     await mergeWithUpdate('email_contacts');
     await mergeWithUpdate('email_events');
@@ -620,6 +661,9 @@ export async function mergeUsers(
           tables_affected: summary.tables_merged
             .filter(t => t.rows_moved > 0 || t.rows_skipped_duplicate > 0)
             .map(t => t.table_name),
+          tables_merged: summary.tables_merged.filter(
+            t => t.rows_moved > 0 || t.rows_skipped_duplicate > 0
+          ),
         }),
       ]
     );

--- a/server/tests/integration/merge-bind-not-delete.test.ts
+++ b/server/tests/integration/merge-bind-not-delete.test.ts
@@ -54,6 +54,24 @@ describe('mergeUsers (bind, don\'t delete)', () => {
   });
 
   async function cleanup() {
+    // addie_threads.person_id has no CASCADE, and person_relationships has no
+    // FK to users(workos_user_id), so deleting users wouldn't reach either.
+    // Drop the threads first so the person_relationships DELETE can succeed.
+    await pool.query(
+      `DELETE FROM addie_threads
+        WHERE person_id IN (
+          SELECT id FROM person_relationships WHERE workos_user_id IN ($1, $2)
+        )`,
+      [PRIMARY_ID, SECONDARY_ID]
+    );
+    await pool.query(
+      `DELETE FROM person_relationships WHERE workos_user_id IN ($1, $2)`,
+      [PRIMARY_ID, SECONDARY_ID]
+    );
+    await pool.query(
+      `DELETE FROM addie_prompt_telemetry WHERE workos_user_id IN ($1, $2)`,
+      [PRIMARY_ID, SECONDARY_ID]
+    );
     await pool.query(`DELETE FROM users WHERE workos_user_id IN ($1, $2)`, [PRIMARY_ID, SECONDARY_ID]);
     await pool.query(`DELETE FROM organizations WHERE workos_organization_id = $1`, [ORG_ID]);
   }
@@ -156,5 +174,83 @@ describe('mergeUsers (bind, don\'t delete)', () => {
       [SECONDARY_ID]
     );
     expect(secondaryStill.rows).toHaveLength(1);
+  });
+
+  it('repoints addie_threads and person_events to the primary\'s person_relationship before deleting the secondary\'s', async () => {
+    // Both users have a person_relationships row (the path that previously
+    // failed with FK 23503 on addie_threads_person_id_fkey).
+    const primaryRel = await pool.query<{ id: string }>(
+      `INSERT INTO person_relationships (workos_user_id, email, stage)
+       VALUES ($1, 'primary@test.example', 'exploring') RETURNING id`,
+      [PRIMARY_ID]
+    );
+    const secondaryRel = await pool.query<{ id: string }>(
+      `INSERT INTO person_relationships (workos_user_id, email, stage)
+       VALUES ($1, 'secondary@test.example', 'exploring') RETURNING id`,
+      [SECONDARY_ID]
+    );
+    const primaryRelId = primaryRel.rows[0].id;
+    const secondaryRelId = secondaryRel.rows[0].id;
+
+    // Thread keyed to secondary's person_relationship — the row that hit FK
+    // violations under the old code path.
+    const thread = await pool.query<{ thread_id: string }>(
+      `INSERT INTO addie_threads (channel, external_id, user_type, person_id)
+       VALUES ('slack', 'C_test_merge_pr', 'slack', $1) RETURNING thread_id`,
+      [secondaryRelId]
+    );
+    await pool.query(
+      `INSERT INTO person_events (person_id, event_type, data)
+       VALUES ($1, 'message_received', '{}'::jsonb)`,
+      [secondaryRelId]
+    );
+
+    await mergeUsers(PRIMARY_ID, SECONDARY_ID, PRIMARY_ID);
+
+    const threadAfter = await pool.query<{ person_id: string }>(
+      `SELECT person_id FROM addie_threads WHERE thread_id = $1`,
+      [thread.rows[0].thread_id]
+    );
+    expect(threadAfter.rows[0].person_id).toBe(primaryRelId);
+
+    const eventAfter = await pool.query<{ count: string }>(
+      `SELECT COUNT(*) as count FROM person_events WHERE person_id = $1 AND event_type = 'message_received'`,
+      [primaryRelId]
+    );
+    expect(parseInt(eventAfter.rows[0].count, 10)).toBe(1);
+
+    const secondaryRelAfter = await pool.query(
+      `SELECT 1 FROM person_relationships WHERE id = $1`,
+      [secondaryRelId]
+    );
+    expect(secondaryRelAfter.rows).toHaveLength(0);
+  });
+
+  it('merges addie_prompt_telemetry on (workos_user_id, rule_id), keeping primary\'s row when both have one for the same rule', async () => {
+    // Same rule on both — primary's counters survive, secondary's are dropped.
+    await pool.query(
+      `INSERT INTO addie_prompt_telemetry (workos_user_id, rule_id, shown_count, clicked_count)
+       VALUES ($1, 'shared_rule', 5, 2),
+              ($2, 'shared_rule', 9, 4),
+              ($2, 'unique_rule', 1, 0)`,
+      [PRIMARY_ID, SECONDARY_ID]
+    );
+
+    await mergeUsers(PRIMARY_ID, SECONDARY_ID, PRIMARY_ID);
+
+    const after = await pool.query<{ rule_id: string; shown_count: number; clicked_count: number }>(
+      `SELECT rule_id, shown_count, clicked_count FROM addie_prompt_telemetry
+       WHERE workos_user_id = $1 ORDER BY rule_id`,
+      [PRIMARY_ID]
+    );
+    expect(after.rows).toHaveLength(2);
+    expect(after.rows[0]).toMatchObject({ rule_id: 'shared_rule', shown_count: 5, clicked_count: 2 });
+    expect(after.rows[1]).toMatchObject({ rule_id: 'unique_rule', shown_count: 1, clicked_count: 0 });
+
+    const secondaryAfter = await pool.query(
+      `SELECT 1 FROM addie_prompt_telemetry WHERE workos_user_id = $1`,
+      [SECONDARY_ID]
+    );
+    expect(secondaryAfter.rows).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

- `mergeUsers` aborted with FK 23503 (`addie_threads_person_id_fkey`) when both users had a `person_relationships` row, since `addie_threads.person_id` has no CASCADE. `person_events.person_id` *does* CASCADE — silent history loss. Now repoints both FKs to the primary's PR row before the DELETE.
- Adds three previously-missing tables to the merge surface: `agent_test_runs`, `certification_expectations` (`mergeWithUpdate`), and `addie_prompt_telemetry` (`mergeWithConflict` on `rule_id`). The merge audit log details now include per-table row counts so a merge can be reverse-engineered without scraping logs.

## How we found it

Hit while running an admin consolidation in prod (`POST /api/admin/users/{primary}/credentials` with `consolidate: true`) to credit a cert from a personal Gmail to a work account. Transaction rolled back cleanly, no data damaged — but the merge was unusable for the common case where both accounts have person history.

## Audit

FKs to `person_relationships.id`: only `addie_threads.person_id` (no CASCADE — the bug) and `person_events.person_id` (CASCADE — silent data loss). Both now handled.

Tables with `workos_user_id` not previously covered by the merge: `agent_test_runs`, `certification_expectations`, `addie_prompt_telemetry`. Added. `registry_audit_log` deliberately left as historical actor record.

## Test plan

- [x] New regression test in `merge-bind-not-delete.test.ts`: both users with PRs, addie_thread + person_event keyed to secondary, asserts pointers move to primary's PR and merge succeeds.
- [x] New `addie_prompt_telemetry` conflict test: shared `rule_id` keeps primary's counters, secondary-only rule moves over.
- [x] All 22 existing merge-related integration tests pass (`merge-bind-not-delete`, `admin-bind-email`, `identity-layer`).
- [x] Server typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)