### PR TITLE
feat(addie): conformance Socket Mode storyboard runner adapter

### DIFF
--- a/.changeset/conformance-storyboard-runner.md
+++ b/.changeset/conformance-storyboard-runner.md
@@ -1,0 +1,4 @@
+---
+---
+
+feat(addie): conformance Socket Mode — storyboard runner adapter (PR #2 of 3). Adds `runStoryboardViaConformanceSocket(orgId, storyboardId)` that resolves a live conformance session, wraps its MCP client as an `AgentClient` via the SDK's existing `AgentClient.fromMCPClient` factory, and dispatches to the standard storyboard runner via the `_client` injection seam. Zero changes to existing storyboard infrastructure; this is a separate runner that picks the same storyboards from the same registry. PR #3 adds the Addie chat tools that consume it.

--- a/server/src/conformance/index.ts
+++ b/server/src/conformance/index.ts
@@ -20,3 +20,9 @@ export {
   type IssuedConformanceToken,
 } from './token.js';
 export { ConformanceWSServerTransport } from './ws-server-transport.js';
+export {
+  runStoryboardViaConformanceSocket,
+  ConformanceNotConnectedError,
+  StoryboardNotFoundError,
+  type RunStoryboardViaWsOptions,
+} from './run-storyboard-via-ws.js';

--- a/server/src/conformance/run-storyboard-via-ws.ts
+++ b/server/src/conformance/run-storyboard-via-ws.ts
@@ -1,0 +1,97 @@
+/**
+ * Run a storyboard against an adopter connected via Socket Mode.
+ *
+ * Resolves the live `ConformanceSession` for the given org, wraps its
+ * MCP `Client` as an `AgentClient` via `AgentClient.fromMCPClient` (the
+ * SDK's existing in-process injection seam), and dispatches to the
+ * standard `runStoryboard` runner. The runner sees a normal `_client`
+ * override and behaves exactly as it would for any in-process test —
+ * the WebSocket transport is invisible above the MCP layer.
+ *
+ * No changes to the existing storyboard runner or compliance heartbeat
+ * are required. This is a separate runner that picks the same storyboards
+ * from the same registry.
+ */
+
+import { AgentClient } from '@adcp/sdk';
+import { runStoryboard } from '@adcp/sdk/testing';
+import type { StoryboardResult, StoryboardRunOptions } from '@adcp/sdk/testing';
+import { conformanceSessions } from './session-store.js';
+import { getStoryboard } from '../services/storyboards.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('conformance-run-storyboard');
+
+export class ConformanceNotConnectedError extends Error {
+  constructor(public readonly orgId: string) {
+    super(
+      `No conformance session for org ${orgId}. Ask Addie for a fresh conformance token and run @adcp/sdk's ConformanceClient against this org.`,
+    );
+    this.name = 'ConformanceNotConnectedError';
+  }
+}
+
+export class StoryboardNotFoundError extends Error {
+  constructor(public readonly storyboardId: string) {
+    super(`Unknown storyboard: ${storyboardId}`);
+    this.name = 'StoryboardNotFoundError';
+  }
+}
+
+export interface RunStoryboardViaWsOptions {
+  timeoutMs?: number;
+  testSessionId?: string;
+}
+
+/**
+ * Synthetic agent URL used to satisfy `runStoryboard`'s positional
+ * `agentUrlOrUrls` argument. The runner reads `_client` first when it's
+ * present, so this URL is never actually dialed — it only feeds debug
+ * logs and error messages. The `adcp-conformance-socket://` scheme makes
+ * it obvious in traces that this run rode the Socket Mode path.
+ */
+const SYNTHETIC_AGENT_URL_PREFIX = 'adcp-conformance-socket://';
+
+export async function runStoryboardViaConformanceSocket(
+  orgId: string,
+  storyboardId: string,
+  options: RunStoryboardViaWsOptions = {},
+): Promise<StoryboardResult> {
+  const session = conformanceSessions.get(orgId);
+  if (!session) {
+    throw new ConformanceNotConnectedError(orgId);
+  }
+
+  const storyboard = getStoryboard(storyboardId);
+  if (!storyboard) {
+    throw new StoryboardNotFoundError(storyboardId);
+  }
+
+  // The MCP `Client` type imported from the ESM build of
+  // `@modelcontextprotocol/sdk` and the same type baked into `@adcp/sdk`'s
+  // CJS build look distinct to TypeScript even though they're structurally
+  // identical at runtime. The `unknown` round-trip skips the duplicated-
+  // declaration check without weakening the actual contract.
+  const mcpClient = session.mcpClient as unknown as Parameters<typeof AgentClient.fromMCPClient>[0];
+  const agentClient = AgentClient.fromMCPClient(mcpClient);
+  const syntheticUrl = `${SYNTHETIC_AGENT_URL_PREFIX}${orgId}`;
+  const testSessionId = options.testSessionId ?? `conformance-${orgId}-${Date.now()}`;
+
+  logger.info(
+    { orgId, storyboardId, testSessionId },
+    'running storyboard over conformance socket',
+  );
+
+  // `_client` is a private-by-convention injection seam on
+  // `StoryboardRunOptions` (see comply()'s usage). It's recognized by
+  // `getOrCreateClient` but isn't on the public type. Cast through the
+  // narrow runOptions shape rather than `as any` so unrelated typos still
+  // get caught.
+  const runOptions = {
+    _client: agentClient,
+    test_session_id: testSessionId,
+    timeout_ms: options.timeoutMs ?? 60_000,
+  } as StoryboardRunOptions & { _client: AgentClient };
+
+  return runStoryboard(syntheticUrl, storyboard, runOptions);
+}

--- a/server/tests/unit/conformance-run-storyboard.test.ts
+++ b/server/tests/unit/conformance-run-storyboard.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Unit + integration tests for `runStoryboardViaConformanceSocket`.
+ *
+ * The architecture-correctness test (real WebSocket, full MCP round-trip)
+ * lives in `conformance-end-to-end.test.ts`. This file focuses on the
+ * adapter logic: session lookup, storyboard lookup, AgentClient wrapping,
+ * and error paths. We mock `runStoryboard` from `@adcp/sdk/testing` so
+ * we don't need a real sales agent + test kits to exercise the adapter.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterAll, beforeAll } from 'vitest';
+import { createServer, type Server as HttpServer } from 'node:http';
+import WebSocket from 'ws';
+import { Server as McpServer } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type JSONRPCMessage,
+  JSONRPCMessageSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+
+process.env.CONFORMANCE_JWT_SECRET = 'test-runs-storyboard-secret';
+process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'test';
+process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+
+const runStoryboardMock = vi.fn();
+vi.mock('@adcp/sdk/testing', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@adcp/sdk/testing');
+  return {
+    ...actual,
+    runStoryboard: (...args: unknown[]) => runStoryboardMock(...args),
+  };
+});
+
+const getStoryboardMock = vi.fn();
+vi.mock('../../src/services/storyboards.js', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('../../src/services/storyboards.js');
+  return {
+    ...actual,
+    getStoryboard: (id: string) => getStoryboardMock(id),
+  };
+});
+
+class AdopterTransport implements Transport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (msg: JSONRPCMessage) => void;
+  sessionId?: string;
+  private closed = false;
+
+  constructor(private socket: WebSocket) {}
+
+  async start(): Promise<void> {
+    this.socket.on('message', (data) => {
+      try {
+        const result = JSONRPCMessageSchema.safeParse(JSON.parse(data.toString('utf-8')));
+        if (result.success) this.onmessage?.(result.data);
+      } catch {
+        // ignore
+      }
+    });
+    this.socket.on('close', () => {
+      if (this.closed) return;
+      this.closed = true;
+      this.onclose?.();
+    });
+    if (this.socket.readyState !== WebSocket.OPEN) {
+      await new Promise<void>((resolve, reject) => {
+        this.socket.once('open', () => resolve());
+        this.socket.once('error', reject);
+      });
+    }
+  }
+
+  async send(msg: JSONRPCMessage): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.socket.send(JSON.stringify(msg), (err) => (err ? reject(err) : resolve()));
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    this.socket.close();
+  }
+}
+
+let httpServer: HttpServer;
+let port: number;
+
+beforeAll(async () => {
+  const { attachConformanceWS } = await import('../../src/conformance/ws-route.js');
+  httpServer = createServer((_req, res) => {
+    res.statusCode = 404;
+    res.end();
+  });
+  attachConformanceWS(httpServer);
+  await new Promise<void>((resolve) => httpServer.listen(0, '127.0.0.1', () => resolve()));
+  const addr = httpServer.address();
+  port = typeof addr === 'object' && addr ? addr.port : 0;
+});
+
+afterAll(async () => {
+  const { conformanceSessions } = await import('../../src/conformance/session-store.js');
+  await conformanceSessions.closeAll();
+  await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+});
+
+beforeEach(async () => {
+  runStoryboardMock.mockReset();
+  getStoryboardMock.mockReset();
+  const { conformanceSessions } = await import('../../src/conformance/session-store.js');
+  await conformanceSessions.closeAll();
+});
+
+describe('runStoryboardViaConformanceSocket', () => {
+  it('throws ConformanceNotConnectedError when the org has no live session', async () => {
+    const { runStoryboardViaConformanceSocket, ConformanceNotConnectedError } = await import(
+      '../../src/conformance/run-storyboard-via-ws.js'
+    );
+    await expect(
+      runStoryboardViaConformanceSocket('org_missing', 'any_storyboard'),
+    ).rejects.toBeInstanceOf(ConformanceNotConnectedError);
+    expect(runStoryboardMock).not.toHaveBeenCalled();
+  });
+
+  it('throws StoryboardNotFoundError when the storyboard id is unknown', async () => {
+    const { issueConformanceToken } = await import('../../src/conformance/token.js');
+    const { conformanceSessions } = await import('../../src/conformance/session-store.js');
+    const { runStoryboardViaConformanceSocket, StoryboardNotFoundError } = await import(
+      '../../src/conformance/run-storyboard-via-ws.js'
+    );
+
+    const orgId = 'org_with_session';
+    const { token } = issueConformanceToken(orgId);
+    const ws = new WebSocket(
+      `ws://127.0.0.1:${port}/conformance/connect?token=${encodeURIComponent(token)}`,
+    );
+    const adopterServer = new McpServer(
+      { name: 'adopter', version: '0.0.1' },
+      { capabilities: { tools: {} } },
+    );
+    adopterServer.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [] }));
+    adopterServer.setRequestHandler(CallToolRequestSchema, async () => {
+      throw new Error('not implemented in test');
+    });
+    const transport = new AdopterTransport(ws);
+    await adopterServer.connect(transport);
+
+    // wait for session to register
+    const deadline = Date.now() + 2000;
+    while (!conformanceSessions.get(orgId) && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+
+    getStoryboardMock.mockReturnValue(undefined);
+
+    await expect(
+      runStoryboardViaConformanceSocket(orgId, 'definitely_not_a_real_storyboard'),
+    ).rejects.toBeInstanceOf(StoryboardNotFoundError);
+    expect(runStoryboardMock).not.toHaveBeenCalled();
+
+    await transport.close();
+  });
+
+  it('wraps the session MCP client as an AgentClient and dispatches via runStoryboard', async () => {
+    const { issueConformanceToken } = await import('../../src/conformance/token.js');
+    const { conformanceSessions } = await import('../../src/conformance/session-store.js');
+    const { runStoryboardViaConformanceSocket } = await import(
+      '../../src/conformance/run-storyboard-via-ws.js'
+    );
+
+    const orgId = 'org_runs_storyboard';
+    const { token } = issueConformanceToken(orgId);
+    const ws = new WebSocket(
+      `ws://127.0.0.1:${port}/conformance/connect?token=${encodeURIComponent(token)}`,
+    );
+    const adopterServer = new McpServer(
+      { name: 'adopter', version: '0.0.1' },
+      { capabilities: { tools: {} } },
+    );
+    adopterServer.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [] }));
+    adopterServer.setRequestHandler(CallToolRequestSchema, async () => {
+      throw new Error('not implemented in test');
+    });
+    const transport = new AdopterTransport(ws);
+    await adopterServer.connect(transport);
+
+    const deadline = Date.now() + 2000;
+    while (!conformanceSessions.get(orgId) && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+
+    const fakeStoryboard = { id: 'fake_storyboard', phases: [] } as unknown as Parameters<
+      typeof getStoryboardMock
+    >[0];
+    getStoryboardMock.mockReturnValue(fakeStoryboard);
+    runStoryboardMock.mockResolvedValue({
+      storyboard_id: 'fake_storyboard',
+      overall_passed: true,
+    });
+
+    const result = await runStoryboardViaConformanceSocket(orgId, 'fake_storyboard', {
+      timeoutMs: 12_345,
+      testSessionId: 'test-fixed-id',
+    });
+    expect(result.overall_passed).toBe(true);
+
+    expect(runStoryboardMock).toHaveBeenCalledTimes(1);
+    const [agentUrlArg, storyboardArg, optionsArg] = runStoryboardMock.mock.calls[0];
+    expect(agentUrlArg).toBe(`adcp-conformance-socket://${orgId}`);
+    expect(storyboardArg).toBe(fakeStoryboard);
+    expect(optionsArg.test_session_id).toBe('test-fixed-id');
+    expect(optionsArg.timeout_ms).toBe(12_345);
+    expect(optionsArg._client).toBeTruthy();
+    // Sanity check — `_client` should expose the AgentClient surface
+    expect(typeof optionsArg._client.getAdcpVersion).toBe('function');
+
+    await transport.close();
+  });
+});


### PR DESCRIPTION
## Summary

PR #2 of three for **Addie Socket Mode**. PR #1 ([#4007](https://github.com/adcontextprotocol/adcp/pull/4007)) added the server-side WS plumbing and session store; this PR adds the runner that lets Addie execute a storyboard against a connected adopter session.

> Stacked on \`bokelley/conformance-socket-mode-server\` — base = #4007. Will rebase onto main once #4007 lands.

## Architecture

The adapter is small (~80 LOC) because the SDK already gives us everything we need:

- **`AgentClient.fromMCPClient(mcpClient)`** — in-process injection factory the SDK has shipped since 6.7. Wraps any pre-connected MCP `Client` into an `AgentClient` that the storyboard runner consumes via `_client` (the same path `comply()` uses internally).
- **`runStoryboard(agentUrl, storyboard, options)`** — the existing runner. We pass a placeholder \`adcp-conformance-socket://<orgId>\` URL plus \`_client: agentClient\`, and the runner happily ignores the URL and dispatches via the injected client.

Net result: zero changes to \`server/src/services/storyboards.ts\`, \`server/src/addie/services/compliance-testing.ts\`, or \`server/src/addie/jobs/compliance-heartbeat.ts\`. The conformance runner is a separate function that picks storyboards from the same registry. Heartbeat keeps its URL-based path for production agents; this runner serves the dev/staging Socket Mode path.

## What's in this PR

- \`server/src/conformance/run-storyboard-via-ws.ts\` — the adapter. Throws \`ConformanceNotConnectedError\` when no live session for the org, \`StoryboardNotFoundError\` when storyboard id is unknown.
- \`server/src/conformance/index.ts\` — re-exports the new function.
- \`server/tests/unit/conformance-run-storyboard.test.ts\` — 3 tests covering both error paths and the success path. The success test stands up a real WebSocket connection (proving the wiring is end-to-end) but mocks \`runStoryboard\` itself so we can inspect the AgentClient and options the adapter passes through, without needing a real sales agent + test kits to actually run a storyboard.

Total: ~80 LOC of adapter + ~200 LOC of tests.

## Why mock \`runStoryboard\` in the integration test

A truly end-to-end "run a real storyboard against a real adopter" test requires the adopter MCP server to implement enough AdCP tools to satisfy a real storyboard, plus a test kit with brand identity and fixtures. That's a sales-agent-stub-worth of setup for what is fundamentally a thin adapter test.

The architecture-correctness test (real WS, full MCP round-trip with \`tools/list\` + \`tools/call\`) already exists in PR #1's \`conformance-end-to-end.test.ts\`. This PR's tests fill the layer above: confirm the adapter looks up the session, wraps the MCP client, and calls \`runStoryboard\` with the right \`_client\`. The two test files together prove the full path.

## Sequencing

1. **PR #1 (#4007)** — server transport + token issuance + prototype adopter
2. **This PR** — storyboard runner adapter
3. **PR #3** — Addie chat tools (\`issue_conformance_token\`, \`run_conformance_against_my_agent\`), gated on \`CONFORMANCE_SOCKET_ENABLED=1\`

## Test plan

- [ ] CI green
- [ ] \`npx vitest run server/tests/unit/conformance-run-storyboard.test.ts\` — 3 tests pass locally
- [ ] Combined with PR #1's e2e test, the full path is exercised: adopter connects → session registers → runner finds session → wraps MCP client → invokes storyboard runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)