### PR TITLE
fix(billing): resolve tier from product metadata.tier when lookup_key is locked

### DIFF
--- a/.changeset/tier-from-product-metadata.md
+++ b/.changeset/tier-from-product-metadata.md
@@ -1,0 +1,17 @@
+---
+---
+
+Resolve membership tier from Stripe product `metadata.tier` when `lookup_key` is locked.
+
+Founding-era prices are auto-created by Stripe (manual invoice lines, Payment Links) and have an immutable `lookup_key` field — Stripe rejects edits with "The price was created by Stripe automatically and cannot be updated." Combined with `unit_amount=0` (the year is prepaid via separate one-time invoice), the existing tier resolver had no signal to work with: `tierFromLookupKey(null)` returned null and `inferMembershipTier(0, ...)` returned null too.
+
+This adds a third path in `buildSubscriptionUpdate` that reads `product.metadata.tier`. Setting `tier: company_standard` on the Founding Startup/SMB **product** (its metadata is editable, unlike the price's lookup_key) now resolves Advertible-class orgs to Builder. Same pattern works for the Founding Corporate product → `tier: company_icl`.
+
+Resolver chain (priority order):
+1. `lookup_key` on price — modern convention, fastest
+2. `metadata.tier` on product — for founding-era prices with locked lookup_keys
+3. `unit_amount` + `interval` + `is_personal` inference — last resort, fails on $0 comp-style subs
+
+`pickMembershipSubWithProductFetch` now returns `{ sub, product? }` so callers (admin /sync, admin sync-stripe-customers) can pass the metadata to `buildSubscriptionUpdate` without a second `products.retrieve` round-trip. Webhook handlers continue to work — they receive subs with product expanded inline, and the resolver reads the metadata directly off `subscription.items.data[0].price.product` when no caller-supplied metadata is provided.
+
+Tests: 22 new cases in `build-subscription-update.test.ts` covering each branch of the chain, lookup_key precedence over metadata, status-gated behavior, and conservative rejection of unknown tier values.

--- a/server/src/billing/membership-prices.ts
+++ b/server/src/billing/membership-prices.ts
@@ -76,6 +76,19 @@ export function pickMembershipSub(subscriptions: readonly Stripe.Subscription[])
 }
 
 /**
+ * Result of `pickMembershipSubWithProductFetch`. The product is included
+ * when classification went through the metadata-fallback path so callers
+ * can read product-level signals (e.g., `metadata.tier`) without a
+ * second `products.retrieve` round-trip. `product` is undefined when
+ * the sub matched on the lookup_key fast path — the caller didn't
+ * fetch the product, so we don't have one to hand back.
+ */
+export interface PickedMembershipSub {
+  sub: Stripe.Subscription;
+  product?: Stripe.Product;
+}
+
+/**
  * Async picker that falls back to a per-product metadata fetch when
  * `lookup_key` doesn't match. Founding-era subs lack the lookup_key
  * convention, but the path Stripe needs to expand for product metadata
@@ -92,13 +105,13 @@ export function pickMembershipSub(subscriptions: readonly Stripe.Subscription[])
 export async function pickMembershipSubWithProductFetch(
   subscriptions: readonly Stripe.Subscription[],
   fetchProduct: (productId: string) => Promise<Stripe.Product | Stripe.DeletedProduct>,
-): Promise<Stripe.Subscription | null> {
+): Promise<PickedMembershipSub | null> {
   const fast = pickMembershipSub(subscriptions);
-  if (fast) return fast;
+  if (fast) return { sub: fast };
 
   // Fall back to product-metadata classification on subs whose price
   // has a `product` id but no membership lookup_key.
-  const candidates: Stripe.Subscription[] = [];
+  const candidates: PickedMembershipSub[] = [];
   for (const sub of subscriptions) {
     const price = sub.items.data[0]?.price;
     if (!price) continue;
@@ -106,8 +119,8 @@ export async function pickMembershipSubWithProductFetch(
     if (!productId) continue;
     try {
       const product = await fetchProduct(productId);
-      if (isMembershipProductByMetadata(product)) {
-        candidates.push(sub);
+      if (isMembershipProductByMetadata(product) && !('deleted' in product && product.deleted)) {
+        candidates.push({ sub, product: product as Stripe.Product });
       }
     } catch {
       // Skip a sub whose product can't be retrieved; the lookup-key path
@@ -116,7 +129,7 @@ export async function pickMembershipSubWithProductFetch(
     }
   }
   if (candidates.length === 0) return null;
-  return candidates.find((s) => s.status === 'active') ?? candidates[0];
+  return candidates.find((c) => c.sub.status === 'active') ?? candidates[0];
 }
 
 /**

--- a/server/src/db/organization-db.ts
+++ b/server/src/db/organization-db.ts
@@ -223,6 +223,29 @@ export function tierFromLookupKey(lookupKey: string | null | undefined): Members
 }
 
 /**
+ * Resolve tier from a Stripe product's `metadata.tier` field. Used for
+ * founding-era prices that Stripe auto-created (e.g., from manual invoice
+ * lines or Payment Links): the price's `lookup_key` is locked, so the
+ * tier convention had to move to the parent product. The product's
+ * metadata also carries `category=membership` for classification; this
+ * helper decodes the tier value separately.
+ *
+ * Returns null when metadata is missing, `tier` is unset, or the value
+ * isn't a recognized `MembershipTier`. Conservative on unknown strings
+ * so a typo on the Stripe side can't grant the wrong entitlement.
+ */
+export function tierFromProductMetadata(
+  metadata: Record<string, string> | null | undefined,
+): MembershipTier | null {
+  if (!metadata) return null;
+  const raw = metadata.tier;
+  if (!raw) return null;
+  return (VALID_MEMBERSHIP_TIERS as readonly string[]).includes(raw)
+    ? (raw as MembershipTier)
+    : null;
+}
+
+/**
  * Input shape for `resolveMembershipTier`. Kept as a named type so the
  * companion SQL helpers below can declare a matching row type, and so
  * a future resolver change that needs a new column surfaces every
@@ -342,6 +365,18 @@ export interface SubscriptionUpdatePayload {
 /**
  * Extract subscription fields from a Stripe subscription object.
  * Single source of truth for tier resolution — all write paths should use this.
+ *
+ * Tier resolver chain:
+ *   1. `lookup_key` on the price (fast path, modern convention)
+ *   2. `metadata.tier` on the product (for founding-era prices Stripe
+ *      auto-created with locked lookup_keys; metadata is editable on the
+ *      product so we move the convention there)
+ *   3. amount-based inference from price unit_amount + interval + is_personal
+ *
+ * The `productMetadata` arg is optional — webhook handlers that have an
+ * inline-expanded product on the sub get it for free; callers that fetch
+ * the product separately (admin /sync) pass it explicitly. Without it,
+ * the resolver gracefully falls through to amount inference.
  */
 export function buildSubscriptionUpdate(
   subscription: {
@@ -354,11 +389,12 @@ export function buildSubscriptionUpdate(
       currency: string;
       recurring: { interval: string } | null;
       id: string;
-      product: string | { id: string; name?: string };
+      product: string | { id: string; name?: string; metadata?: Record<string, string> };
       lookup_key: string | null;
     } }> };
   },
   isPersonal: boolean,
+  productMetadata?: Record<string, string> | null,
 ): SubscriptionUpdatePayload {
   const priceData = subscription.items?.data?.[0]?.price;
   const amount = priceData?.unit_amount ?? null;
@@ -369,8 +405,15 @@ export function buildSubscriptionUpdate(
   const productId = typeof productRef === 'string' ? productRef : productRef?.id ?? null;
   const productName = typeof productRef === 'object' ? productRef?.name ?? null : null;
 
+  // Prefer caller-supplied metadata; otherwise read from an inline-expanded
+  // product object if present.
+  const effectiveMetadata = productMetadata
+    ?? (typeof productRef === 'object' ? productRef?.metadata ?? null : null);
+
   const membershipTier = (TIER_PRESERVING_STATUSES as readonly string[]).includes(subscription.status)
-    ? (tierFromLookupKey(lookupKey) ?? inferMembershipTier(amount, interval, isPersonal))
+    ? (tierFromLookupKey(lookupKey)
+        ?? tierFromProductMetadata(effectiveMetadata)
+        ?? inferMembershipTier(amount, interval, isPersonal))
     : null;
 
   return {

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -5265,15 +5265,15 @@ export class HTTPServer {
                 limit: 100,
               });
 
-              const subscription = await pickMembershipSubWithProductFetch(
+              const picked = await pickMembershipSubWithProductFetch(
                 subsResult.data,
                 (productId) => stripeClient.products.retrieve(productId),
               );
-              if (!subscription || !(TIER_PRESERVING_STATUSES as readonly string[]).includes(subscription.status)) {
+              if (!picked || !(TIER_PRESERVING_STATUSES as readonly string[]).includes(picked.sub.status)) {
                 continue;
               }
 
-              const primaryItem = subscription.items.data[0];
+              const primaryItem = picked.sub.items.data[0];
               if (!primaryItem) {
                 continue;
               }
@@ -5285,7 +5285,11 @@ export class HTTPServer {
               );
               const isPersonal = orgRow.rows[0]?.is_personal ?? true;
 
-              const subUpdate = buildSubscriptionUpdate(subscription as any, isPersonal);
+              const subUpdate = buildSubscriptionUpdate(
+                picked.sub as any,
+                isPersonal,
+                picked.product?.metadata ?? null,
+              );
 
               // Update organization with subscription details and tier
               await pool.query(

--- a/server/src/routes/admin/accounts-billing.ts
+++ b/server/src/routes/admin/accounts-billing.ts
@@ -171,21 +171,29 @@ export function setupAccountsBillingRoutes(
                 // `stripe` is non-null inside this branch (guarded above)
                 // but TS narrowing doesn't carry through the closure.
                 const stripeClient = stripe;
-                const subscription = await pickMembershipSubWithProductFetch(
+                const picked = await pickMembershipSubWithProductFetch(
                   subsResult.data,
                   (productId) => stripeClient.products.retrieve(productId),
                 );
 
-                if (subscription) {
+                if (picked) {
                   // Use the canonical writer so /sync, the webhook handler,
                   // and lazy-reconcile all produce identical row state. The
                   // prior inline UPDATE wrote only 6 fields, leaving
                   // stripe_subscription_id / lookup_key / product / tier
                   // NULL — which is how Adzymic ended up with status=active
                   // but unresolvable tier (May 2026 incident).
+                  //
+                  // Pass the picked product's metadata when present —
+                  // founding-era products carry `tier=<membership_tier>`
+                  // there because the auto-created price's lookup_key is
+                  // immutable in Stripe. Without this, tier resolution
+                  // falls through to amount inference, which fails for
+                  // $0 comp-style subs (Advertible — May 2026).
                   const payload = buildSubscriptionUpdate(
-                    subscription as Parameters<typeof buildSubscriptionUpdate>[0],
+                    picked.sub as Parameters<typeof buildSubscriptionUpdate>[0],
                     org.is_personal,
+                    picked.product?.metadata ?? null,
                   );
 
                   await pool.query(
@@ -227,8 +235,8 @@ export function setupAccountsBillingRoutes(
                       status: payload.subscription_status,
                       amount: payload.subscription_amount,
                       interval: payload.subscription_interval,
-                      current_period_end: subscription.current_period_end ?? null,
-                      canceled_at: subscription.canceled_at ?? null,
+                      current_period_end: picked.sub.current_period_end ?? null,
+                      canceled_at: picked.sub.canceled_at ?? null,
                     },
                   };
                   syncResults.updated = true;

--- a/server/tests/unit/billing/build-subscription-update.test.ts
+++ b/server/tests/unit/billing/build-subscription-update.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for the canonical Stripe-subscription writer:
+ * `buildSubscriptionUpdate` and the helpers that drive its tier resolution.
+ *
+ * The bug these tests prevent: founding-era prices that Stripe auto-created
+ * have an immutable `lookup_key` field (Stripe rejects edits) and zero
+ * `unit_amount`. The lookup_key fast path can't classify them and the
+ * amount-inference fallback returns null. Without a third path through
+ * product `metadata.tier`, every founding-cohort sync writes a partial-truth
+ * row with `membership_tier=null` and the dashboard renders the wrong tier
+ * (Adzymic, Advertible, May 2026).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildSubscriptionUpdate,
+  tierFromLookupKey,
+  tierFromProductMetadata,
+} from '../../../src/db/organization-db.js';
+
+function fakeSub(overrides: {
+  status?: string;
+  lookup_key?: string | null;
+  unit_amount?: number | null;
+  interval?: string | null;
+  product?: string | { id: string; name?: string; metadata?: Record<string, string> };
+} = {}) {
+  // 'key' in overrides preserves explicit null in fixtures.
+  const lookupKey = 'lookup_key' in overrides ? overrides.lookup_key : null;
+  const unitAmount = 'unit_amount' in overrides ? overrides.unit_amount : null;
+  const interval = 'interval' in overrides ? overrides.interval : 'year';
+  const product = 'product' in overrides ? overrides.product : 'prod_default';
+  return {
+    id: 'sub_test',
+    status: overrides.status ?? 'active',
+    current_period_end: 1234567890,
+    canceled_at: null,
+    items: {
+      data: [{
+        price: {
+          unit_amount: unitAmount,
+          currency: 'usd',
+          recurring: interval ? { interval } : null,
+          id: 'price_test',
+          product,
+          lookup_key: lookupKey,
+        },
+      }],
+    },
+  };
+}
+
+describe('tierFromLookupKey', () => {
+  it.each([
+    ['aao_membership_explorer_50', 'individual_academic'],
+    ['aao_membership_professional_250', 'individual_professional'],
+    ['aao_membership_builder_3000', 'company_standard'],
+    ['aao_membership_corporate_under5m', 'company_standard'],
+    ['aao_membership_corporate', 'company_icl'],
+    ['aao_membership_leader_50000', 'company_leader'],
+    ['aao_event_summit_2026', null],
+    ['', null],
+    [null, null],
+    [undefined, null],
+  ])('lookup_key %j -> %j', (key, expected) => {
+    expect(tierFromLookupKey(key)).toBe(expected);
+  });
+});
+
+describe('tierFromProductMetadata', () => {
+  it('returns the tier when metadata.tier is a valid MembershipTier', () => {
+    expect(tierFromProductMetadata({ tier: 'company_standard' })).toBe('company_standard');
+    expect(tierFromProductMetadata({ tier: 'individual_professional' })).toBe('individual_professional');
+    expect(tierFromProductMetadata({ tier: 'company_leader' })).toBe('company_leader');
+  });
+
+  it('returns null for unknown tier values (conservative on typos)', () => {
+    expect(tierFromProductMetadata({ tier: 'gold' })).toBeNull();
+    expect(tierFromProductMetadata({ tier: 'company_premium' })).toBeNull();
+    expect(tierFromProductMetadata({ tier: '' })).toBeNull();
+  });
+
+  it('returns null when tier is missing', () => {
+    expect(tierFromProductMetadata({ category: 'membership' })).toBeNull();
+    expect(tierFromProductMetadata({})).toBeNull();
+  });
+
+  it('returns null when metadata is null/undefined', () => {
+    expect(tierFromProductMetadata(null)).toBeNull();
+    expect(tierFromProductMetadata(undefined)).toBeNull();
+  });
+});
+
+describe('buildSubscriptionUpdate tier resolution', () => {
+  it('resolves via lookup_key (fast path)', () => {
+    const result = buildSubscriptionUpdate(
+      fakeSub({ lookup_key: 'aao_membership_professional_250', unit_amount: 25000 }) as never,
+      true,
+    );
+    expect(result.membership_tier).toBe('individual_professional');
+    expect(result.subscription_price_lookup_key).toBe('aao_membership_professional_250');
+  });
+
+  it('resolves via product metadata.tier when lookup_key is null (Advertible-shape)', () => {
+    // Founding Startup/SMB price: Stripe auto-created, lookup_key locked
+    // null, unit_amount is 0 because the year was prepaid via invoice.
+    // Without product metadata.tier, this row has no resolvable tier.
+    const result = buildSubscriptionUpdate(
+      fakeSub({ lookup_key: null, unit_amount: 0 }) as never,
+      false,
+      { category: 'membership', tier: 'company_standard' },
+    );
+    expect(result.membership_tier).toBe('company_standard');
+    expect(result.subscription_price_lookup_key).toBeNull();
+    expect(result.subscription_amount).toBe(0);
+  });
+
+  it('reads product metadata from inline-expanded product when caller did not pass it explicitly', () => {
+    // Webhook handlers receive subscription objects with product expanded
+    // inline; they shouldn't have to pass metadata as a separate arg.
+    const result = buildSubscriptionUpdate(
+      fakeSub({
+        lookup_key: null,
+        unit_amount: 0,
+        product: {
+          id: 'prod_founding',
+          metadata: { category: 'membership', tier: 'company_icl' },
+        },
+      }) as never,
+      false,
+    );
+    expect(result.membership_tier).toBe('company_icl');
+  });
+
+  it('prefers caller-supplied metadata over inline product metadata (admin /sync path)', () => {
+    // The /sync endpoint fetches the product separately and passes its
+    // metadata as the third arg. If the inline product on the sub has
+    // stale/different metadata, the fresh fetch wins.
+    const result = buildSubscriptionUpdate(
+      fakeSub({
+        lookup_key: null,
+        unit_amount: 0,
+        product: {
+          id: 'prod_founding',
+          metadata: { tier: 'company_standard' },
+        },
+      }) as never,
+      false,
+      { tier: 'company_icl' },
+    );
+    expect(result.membership_tier).toBe('company_icl');
+  });
+
+  it('falls through to amount inference when neither lookup_key nor metadata.tier is set', () => {
+    const result = buildSubscriptionUpdate(
+      fakeSub({ lookup_key: null, unit_amount: 25000, interval: 'year' }) as never,
+      true,  // is_personal
+    );
+    // 25000 cents = $250/yr → individual_professional via inference
+    expect(result.membership_tier).toBe('individual_professional');
+  });
+
+  it('lookup_key wins over metadata.tier when both are present', () => {
+    // If a price both has a lookup_key AND product metadata.tier, the
+    // lookup_key is authoritative — it's a per-price signal vs. the
+    // product-level fallback.
+    const result = buildSubscriptionUpdate(
+      fakeSub({
+        lookup_key: 'aao_membership_explorer_50',
+        unit_amount: 5000,
+      }) as never,
+      true,
+      { tier: 'company_leader' },  // metadata says leader, lookup_key says explorer
+    );
+    expect(result.membership_tier).toBe('individual_academic');  // lookup_key wins
+  });
+
+  it('returns null tier for non-entitled status even with valid lookup_key', () => {
+    // canceled subs don't grant entitlement regardless of how they'd
+    // classify if they were live.
+    const result = buildSubscriptionUpdate(
+      fakeSub({
+        status: 'canceled',
+        lookup_key: 'aao_membership_professional_250',
+        unit_amount: 25000,
+      }) as never,
+      true,
+    );
+    expect(result.membership_tier).toBeNull();
+  });
+
+  it('rejects invalid metadata.tier values without falling through to amount inference', () => {
+    // A typo like `tier=premium` should NOT silently let amount inference
+    // promote the row to a different tier. Resolver returns null for
+    // metadata.tier (typo) and continues to inference, which here gives
+    // company_standard for $250k cents annual / non-personal — correct
+    // behavior, just confirming the chain doesn't get stuck.
+    const result = buildSubscriptionUpdate(
+      fakeSub({
+        lookup_key: null,
+        unit_amount: 25000,
+        interval: 'year',
+        product: { id: 'prod_x', metadata: { tier: 'premium' } },
+      }) as never,
+      false,
+    );
+    // tier: 'premium' rejected → metadata path returns null → falls to
+    // inferMembershipTier(25000, 'year', false) → company_standard
+    // (annual >= 0, < 700000 = company_icl threshold)
+    expect(result.membership_tier).toBe('company_standard');
+  });
+});

--- a/server/tests/unit/billing/membership-prices.test.ts
+++ b/server/tests/unit/billing/membership-prices.test.ts
@@ -181,7 +181,7 @@ describe('pickMembershipSubWithProductFetch', () => {
       fakeSub({ id: 'sub_member', lookup_key: 'aao_membership_explorer_50', product: 'prod_x' }),
     ];
     const result = await pickMembershipSubWithProductFetch(subs, fetchProduct);
-    expect(result?.id).toBe('sub_member');
+    expect(result?.sub.id).toBe('sub_member');
     expect(fetchProduct).not.toHaveBeenCalled();
   });
 
@@ -198,7 +198,7 @@ describe('pickMembershipSubWithProductFetch', () => {
       fakeSub({ id: 'sub_founding', lookup_key: null, product: 'prod_founding_corp' }),
     ];
     const result = await pickMembershipSubWithProductFetch(subs, fetchProduct);
-    expect(result?.id).toBe('sub_founding');
+    expect(result?.sub.id).toBe('sub_founding');
     expect(fetchProduct).toHaveBeenCalledWith('prod_founding_corp');
   });
 
@@ -228,7 +228,7 @@ describe('pickMembershipSubWithProductFetch', () => {
       fakeSub({ id: 'sub_good', lookup_key: null, product: 'prod_founding' }),
     ];
     const result = await pickMembershipSubWithProductFetch(subs, fetchProduct);
-    expect(result?.id).toBe('sub_good');
+    expect(result?.sub.id).toBe('sub_good');
   });
 
   it('skips a sub whose price.product is not a string (already expanded by caller)', async () => {


### PR DESCRIPTION
## Summary

Founding-era Stripe prices are auto-created (manual invoice lines, Payment Links) and Stripe rejects lookup_key edits on them with: *"The price was created by Stripe automatically and cannot be updated."* Combined with `unit_amount=0` (the year is prepaid via separate one-time invoice), the existing tier resolver had no signal: `tierFromLookupKey(null)` returned null and `inferMembershipTier(0, ...)` returned null too. After a successful /sync, the row had populated `stripe_subscription_id` but `membership_tier=null` — Advertible-class state (May 2026).

The metadata on the **product** is editable in Stripe (unlike the price's lookup_key). Brian set `tier: company_standard` on the Founding Startup/SMB product. This PR teaches the resolver to read it.

## Resolver chain (priority order)
`buildSubscriptionUpdate` now resolves the tier through:
1. `lookup_key` on the price — modern convention, fastest
2. `metadata.tier` on the product — for founding-era prices with locked lookup_keys ← new
3. `unit_amount` + `interval` + `is_personal` inference — last resort, fails on $0 comp-style subs

Caller-supplied metadata wins over inline metadata, so the admin /sync (which fetches the product separately) overrides any stale inline metadata on the sub object.

## What changed

- **`server/src/db/organization-db.ts`** — new `tierFromProductMetadata()` helper, threaded into `buildSubscriptionUpdate` via an optional 3rd arg. Conservative: rejects unknown `tier` values, so a typo on the Stripe side can't grant the wrong entitlement.
- **`server/src/billing/membership-prices.ts`** — `pickMembershipSubWithProductFetch` now returns `{ sub, product? }`. The product is included when classification went through the metadata-fallback path so callers read product metadata without a second `products.retrieve`.
- **`server/src/routes/admin/accounts-billing.ts`** — /sync passes `picked.product?.metadata` to `buildSubscriptionUpdate`.
- **`server/src/http.ts`** — same pattern applied to the all-customers reconciliation loop.
- **22 new unit tests** in `build-subscription-update.test.ts` covering each branch of the chain, lookup_key precedence over metadata, status-gated behavior, and conservative rejection of unknown tier values.

## Test plan

- [x] 134 unit tests pass (billing + integrity)
- [x] `npm run typecheck` clean (after `npm install` to pick up `@adcp/sdk@^6.8.0` — main currently expects 6.8 but `node_modules` had 6.0; lockfile fix is in another PR)
- [x] Precommit hook passed
- [ ] After merge: re-run /sync against Advertible — row should now show `membership_tier=company_standard`
- [ ] After merge: hit `GET /api/admin/integrity/check/every-entitled-org-has-resolvable-tier` — Advertible should clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)