### PR TITLE
feat(compliance): add cascade_rules section to runner-output-contract.yaml

### DIFF
--- a/.changeset/sole-stateful-step-cascade-exemption.md
+++ b/.changeset/sole-stateful-step-cascade-exemption.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Lift sole-stateful-step cascade exemption into `runner-output-contract.yaml` as normative MUST language. The spec was previously silent on what happens when the sole stateful step in a phase grades `not_applicable`, `missing_tool`, or `missing_test_controller` — causing runner divergence (the TS SDK exempts the cascade; other runners may not). Adds a top-level `cascade_rules` section with `default_cascade` and `sole_stateful_step_exemption` rules. Also bumps the contract's own `version` field from `2.0.0` → `2.1.0`.

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -26,7 +26,7 @@
 # --- Schema definition ---
 
 id: runner_output_contract
-version: "2.0.0"
+version: "2.1.0"
 title: "Runner output contract"
 summary: "Required failure-detail shape that AdCP storyboard runners MUST emit so implementors can self-diagnose validation failures."
 
@@ -639,6 +639,71 @@ skip_result:
       consumers still see the specific cause. See
       DETAILED_SKIP_TO_CANONICAL in the conforming implementation for a
       concrete mapping.
+
+cascade_rules:
+  description: |
+    Rules governing when a runner MUST propagate `prerequisite_failed` to
+    downstream stateful steps and when it MUST NOT. These complement the
+    per-reason text in `skip_result.reasons`: the skip reason describes WHY
+    a step was skipped; cascade rules describe what effect that skip has on
+    later phases. Runners MUST evaluate these rules after per-step grading
+    completes, before downstream skip propagation runs.
+  default_cascade: |
+    When a stateful step produces `passed: false` (a genuine failure), or
+    skips with `prerequisite_failed`, `unsatisfied_contract`, or
+    `peer_branch_taken`, the runner MUST cascade `prerequisite_failed` to
+    downstream stateful phases so implementors know that dependent coverage
+    collapsed. Steps that skip with `peer_substituted` do NOT trigger the
+    cascade — the `provides_state_for` mechanism already waived it (see
+    `skip_result.reasons.peer_substituted`). Steps that skip with
+    `not_applicable`, `missing_tool`, or `missing_test_controller` do NOT
+    trigger the cascade when the `sole_stateful_step_exemption` below applies.
+  sole_stateful_step_exemption: |
+    When ALL of the following hold, the runner MUST NOT cascade
+    `prerequisite_failed` to downstream stateful phases:
+
+      1. The step grades `not_applicable`, `missing_tool`, or
+         `missing_test_controller`.
+      2. It is the sole stateful step in its phase (no other stateful step
+         exists in the same phase that could have established substitute state).
+      3. No same-phase peer step has declared `provides_state_for:
+         <this_step_id>`.
+
+    When these conditions are met, downstream phases evaluate independently —
+    their stateful steps do NOT receive `prerequisite_failed` from this step
+    and are graded on their own merits. The skipping step still emits its own
+    skip_result with the original reason (`not_applicable | missing_tool |
+    missing_test_controller`); the exemption suppresses only the cascade, not
+    the step's own skip reason.
+
+    Rationale: a sole stateful step has no peer that could have established
+    substitute state. The platform legitimately does not implement this pathway
+    (e.g., proposal-mode / implicit-account adopters that materialize account
+    state via the first `get_products` call rather than `sync_accounts`).
+    Cascading `prerequisite_failed` to all downstream stateful phases collapses
+    useful coverage on the framework paths the adopter does implement.
+
+    When the skipping step has at least one stateful peer in the phase, the
+    existing rules apply: `provides_state_for` declarations defer the cascade
+    (see `skip_result.reasons.peer_substituted`), and unrescued hard-missing
+    or real failures trip it.
+
+    Note on `not_applicable`: unlike `missing_tool` and
+    `missing_test_controller` (where the agent declared the specialism but
+    lacks the tool/controller), `not_applicable` means the agent did not
+    declare the specialism at all. The cascade exemption still applies because
+    the structural condition — no peer available to establish substitute state —
+    is identical. A sole-stateful-step `not_applicable` that cascades to all
+    downstream phases would collapse coverage for agents that legitimately omit
+    a pathway; the exemption prevents this collapse regardless of the specific
+    skip reason. Dashboard consumers that need to distinguish "agent does not
+    support the specialism" from "agent supports it via an alternate tool"
+    should read the step's `reason` field rather than inferring from whether
+    downstream phases ran.
+
+    References: adcp-client#1146 (original `not_applicable` exemption);
+    adcp-client#1545 (extension to `missing_tool` / `missing_test_controller`);
+    adcp-client-python#550 (adopter pattern that surfaced the cross-runner gap).
 
 run_summary:
   description: |


### PR DESCRIPTION
Closes #4053

## Summary

The `runner-output-contract.yaml` spec was silent on cascade behavior when the sole stateful step in a phase grades `not_applicable`, `missing_tool`, or `missing_test_controller` with no same-phase peer declaring `provides_state_for`. This silence caused runner divergence: the TS SDK exempts the cascade (adcp-client#1146, adcp-client#1545); other runners (e.g., adcp-client-python) may cascade, producing different compliance grades on the same storyboard against the same adopter.

This PR adds a top-level `cascade_rules:` section with two normative sub-keys:

- **`default_cascade:`** — explicitly names which skip reasons DO trigger cascade (`prerequisite_failed`, `unsatisfied_contract`, `peer_branch_taken`, `passed: false`) and which do NOT (`peer_substituted`, and the new exemption).
- **`sole_stateful_step_exemption:`** — the new MUST NOT cascade rule: when a sole stateful step grades `not_applicable`/`missing_tool`/`missing_test_controller` with no `provides_state_for` peer, downstream phases evaluate independently. Includes rationale, the `not_applicable` semantic note, and SDK references.

Also bumps the contract's internal `version` field from `2.0.0` → `2.1.0` (new normative section; additive, not breaking for runners already implementing the exemption).

## Non-breaking justification

Adds a new top-level `cascade_rules:` section where the spec was previously silent. Runners that already implement the TS SDK's exemption (adcp-client) are unaffected. Runners that currently cascade in this case need to update — this is a new normative MUST, correctly versioned as `minor` targeting 3.1.x. Not a 3.0.x patch: the IETF errata test fails because not all conformant 3.0.x implementations currently satisfy the new MUST.

**Note — pre-existing source/dist version skew:** `dist/compliance/3.0.6/universal/runner-output-contract.yaml` carries `version: "1.1.0"` while the source is at `2.0.0` (now `2.1.0`). This is pre-existing debt from before this PR. A reviewer should confirm whether 3.0.6 was snapshotted before or after the 2.0.0 source bump, and whether a re-snapshot of the dist for 3.0.6 is needed.

**Note — structural convention:** `cascade_rules:` uses `description` + prose sub-keys (rules), rather than the `required_fields`/`optional_fields`/`reasons`/`notes` pattern used by other sections. This is intentional: `cascade_rules` contains behavioral rules for runner implementors, not field definitions. The departure is noted here so reviewers know it's deliberate.

**Note — local build environment:** The `npm install` step fails in this runner's environment (postinstall HTTP 403 on a transitive dep). The build gate could not be run locally. CI on GitHub should be treated as the authoritative build check for this PR before any merge consideration.

## Pre-PR review

- code-reviewer: approved — blockers fixed (removed undefined `peer_substitutes_for` synonym; added explicit `peer_substituted` no-cascade note to `default_cascade:`). Nits surfaced in PR body.
- ad-tech-protocol-expert: approved — three-condition predicate correctly specified; `default_cascade:` now covers `peer_substituted` omission; `not_applicable` semantic note is clear.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01Lcvhafxic3KJHqPXi6k33v

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lcvhafxic3KJHqPXi6k33v)_