### PR TITLE
fix(training-agent): eager tenant registry init at server boot

### DIFF
--- a/.changeset/eager-tenant-registry-init.md
+++ b/.changeset/eager-tenant-registry-init.md
@@ -1,0 +1,15 @@
+---
+---
+
+Eagerly initialize the training-agent tenant registry at server boot.
+
+Every recent deploy has been failing the post-deploy smoke check on `/sales/mcp`, `/signals/mcp`, `/governance/mcp`, `/creative/mcp`, `/creative-builder/mcp`, and `/brand/mcp` — all returning HTTP 500 during a ~16s window after rolling deploy completes, then healing on their own. The smoke gives up and marks the deploy failed even though production is healthy minutes later.
+
+Root cause: `RegistryHolder` was lazy-initialized on first request. On a fresh Fly machine the 6-tenant registration burst takes 30–60s — longer than the smoke's 16s retry budget. The first probe to a tenant route lands while `register()` calls are still in flight, returns 500 (unhandled init promise resolution), and the retry 8s later catches it in the same state.
+
+Pre-warm the registry inside `mountTenantRoutes` so init starts at server boot, not first request. Per-request handlers continue to await `holder.get()`, which now reuses the in-flight or completed promise from the eager call. Two safety nets:
+
+- **Reject-clear**: `pendingInit` is reset on rejection so a transient init failure doesn't poison every subsequent request with the same rejected promise until machine restart.
+- **Eager-init failure logged, not crashed**: if the boot-time init throws, the error is logged and per-request init retries on the next call. Doesn't take down the server.
+
+Drops the unused `req` param from `RegistryHolder.get()` (the comment said it was vestigial; this confirms it).

--- a/server/src/training-agent/tenants/registry.ts
+++ b/server/src/training-agent/tenants/registry.ts
@@ -187,7 +187,12 @@ function buildDefaultServerOptions(): CreateAdcpServerFromPlatformOptions {
  * a cached registry pinned to a stale port.
  */
 export interface RegistryHolder {
-  get(req: Request): Promise<TenantRegistry>;
+  /**
+   * Resolve the (possibly in-flight) tenant registry. Per-request handlers
+   * call this; the first caller triggers init, subsequent callers reuse
+   * the same promise.
+   */
+  get(): Promise<TenantRegistry>;
 }
 
 export function createRegistryHolder(): RegistryHolder {
@@ -195,11 +200,10 @@ export function createRegistryHolder(): RegistryHolder {
   let pendingInit: Promise<TenantRegistry> | null = null;
 
   return {
-    async get(req: Request): Promise<TenantRegistry> {
+    async get(): Promise<TenantRegistry> {
       if (registry) return registry;
       if (pendingInit) return pendingInit;
-      void req; // request only used for registry initialization timing; host is stable
-      pendingInit = (async () => {
+      const promise = (async () => {
         const hostBase = buildHostBaseUrl();
         const reg = createTenantRegistry({
           defaultServerOptions: buildDefaultServerOptions(),
@@ -231,7 +235,13 @@ export function createRegistryHolder(): RegistryHolder {
         registry = reg;
         return reg;
       })();
-      return pendingInit;
+      // Reset pendingInit on rejection so a transient init failure (e.g.,
+      // DNS hiccup during the no-op validator's first probe) doesn't
+      // poison every subsequent request with the same rejected promise
+      // until machine restart.
+      promise.catch(() => { pendingInit = null; });
+      pendingInit = promise;
+      return promise;
     },
   };
 }

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -65,7 +65,7 @@ function tenantMcpHandler(holder: RegistryHolder, tenantId: string) {
     }
 
     const host = resolveTenantHost(req);
-    const registry = await holder.get(req);
+    const registry = await holder.get();
     const resolved = registry.resolveByRequest(host, `/${tenantId}/mcp`);
     if (!resolved) {
       logger.warn(
@@ -148,6 +148,26 @@ export function mountTenantRoutes(
   middleware: TenantRouteMiddleware = {},
 ): void {
   const holder = createRegistryHolder();
+  // Eagerly start the 6-tenant registry init at mount time (server boot)
+  // instead of waiting for the first request. On a fresh Fly machine the
+  // cold init takes 30–60s — longer than the post-deploy smoke's 16s
+  // retry budget — which made every deploy fail the smoke even though
+  // production was healthy minutes later. Pre-warming shifts that work
+  // to before traffic arrives and lets the smoke catch real init bugs
+  // (#3854 in-memory task registry, #3869 noopJwksValidator under
+  // NODE_ENV=production) without false-failing on cold-start latency.
+  //
+  // The promise is fire-and-forget here: per-request handlers await the
+  // same in-flight promise via `holder.get()`, so a slow init still
+  // serves correctly — the eager call only ensures the work has started.
+  // Errors are logged; the holder resets `pendingInit` on rejection so
+  // the next request retries.
+  holder.get().catch((err) => {
+    logger.error(
+      { err },
+      'Eager tenant registry init failed at boot; per-request init will retry',
+    );
+  });
   const mw: RequestHandler[] = [];
   if (middleware.rateLimit) mw.push(middleware.rateLimit);
   if (middleware.requireAuth) mw.push(middleware.requireAuth);


### PR DESCRIPTION
## Summary

Every recent deploy has been failing the post-deploy smoke check on the training-agent tenant routes (`/sales/mcp`, `/signals/mcp`, `/governance/mcp`, `/creative/mcp`, `/creative-builder/mcp`, `/brand/mcp`) — all returning HTTP 500 during the ~16s window after rolling deploy completes, then healing on their own minutes later.

5 of the last 5 deploys have shown this pattern. Production is healthy throughout (warm machines serving traffic), but the failure noise hides real regressions and forces operators to manually verify each deploy.

## Root cause

`RegistryHolder` lazy-initialized on first request (`registry.ts:193`). On a fresh Fly machine the 6-tenant registration burst takes 30–60s — longer than the smoke's 16s retry budget. The smoke's initial probe + 8s retry both land while `register()` calls are still in flight, return 500 (the init promise hasn't resolved yet, the route handler can't get a registry to dispatch against), and the smoke gives up.

## What changed

- **Eager init in `mountTenantRoutes`**: triggers `holder.get()` once at mount time so the 6-tenant registration starts at server boot, not first request. Per-request handlers continue to await `holder.get()`, which now reuses the in-flight or completed promise from the eager call.
- **Reject-clear**: `pendingInit` is reset on rejection so a transient init failure doesn't poison every subsequent request with the same rejected promise until machine restart. Defense in depth — the existing code never reset, so a bad init at boot would have been permanently fatal until restart.
- **Eager-init failure logged, not crashed**: if the boot-time init throws, the error is logged and per-request init retries on the next call. Doesn't take down the server.
- **Drops unused `req` param** from `RegistryHolder.get()` — the comment said it was vestigial; confirmed by greppingall callers.

## What this catches that the smoke was meant to catch

The smoke step's comment names two prior incidents (#3854 in-memory task registry refused under NODE_ENV=production, #3869 noopJwksValidator threw under NODE_ENV=production). Both were deterministic init failures. With eager init, those would surface at server boot — visible in the Fly logs immediately, instead of dressed up as a smoke flake.

## Test plan

- [x] 377 training-agent unit/integration tests pass (full suite under `tests/unit/training-agent.test.ts` + `src/training-agent/`)
- [x] Tenant smoke tests pass (`src/training-agent/tenants/tenant-smoke.test.ts`)
- [x] Typecheck clean
- [x] Precommit hook passed
- [ ] After merge: deploy this PR and verify the post-deploy smoke step passes (no more `Tenant smoke failed: /<tenant>/mcp returned HTTP 500`)
- [ ] After merge: subsequent unrelated deploys also pass smoke (confirms the fix is durable, not specific to this PR's image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)