### PR TITLE
fix(addie): save_agent must not silently skip the dashboard write

### DIFF
--- a/.changeset/fix-save-agent-silent-profile-no-op.md
+++ b/.changeset/fix-save-agent-silent-profile-no-op.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix(addie): `save_agent` no longer silently no-ops when the org has no member profile yet. The handler now auto-creates a private member profile (via the new `ensureMemberProfileExists` helper) before adding the agent, and the user-facing response reports honestly when the dashboard write fails instead of always claiming success. Closes the case behind escalation #309 where Warren Fernandes saw "✅ added to your dashboard" but the agent was missing on `/dashboard/agents`.

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -58,6 +58,7 @@ import {
   getPendingProposals,
 } from '../../db/industry-feeds-db.js';
 import { MemberDatabase } from '../../db/member-db.js';
+import { ensureMemberProfileExists } from '../../services/member-profile-autopublish.js';
 import { updateBrandIdentity, BrandIdentityError } from '../../services/brand-identity.js';
 import { canonicalizeBrandDomain } from '../../services/identifier-normalization.js';
 import { ComplianceDatabase } from '../../db/compliance-db.js';
@@ -5388,38 +5389,57 @@ export function createMemberToolHandlers(
       clientCredentials = parsed.creds;
     }
 
-    async function ensureAgentInProfile(displayName: string): Promise<void> {
-      if (!saveOrgId) return;
+    type ProfileWriteStatus =
+      | { ok: true; createdProfile: boolean }
+      | { ok: false; reason: string };
+
+    async function ensureAgentInProfile(displayName: string): Promise<ProfileWriteStatus> {
+      if (!saveOrgId) return { ok: false, reason: 'no-org-id' };
       try {
-        const profile = await memberDb.getProfileByOrgId(saveOrgId);
-        if (profile) {
-          const agents = profile.agents || [];
-          const existing = agents.find((a: any) => a.url === agentUrl);
-          if (!existing) {
-            // Default to members_only, not public. The public directory
-            // requires an API-access tier (Professional+); defaulting to
-            // 'public' here lets Addie implicitly publish an agent for an
-            // Explorer-tier caller who hasn't been tier-gated. Members_only
-            // keeps the agent discoverable to peer members with API access
-            // and lets the owner promote to public through the explicit,
-            // tier-checked /publish route when eligible.
-            agents.push({
-              url: agentUrl,
-              name: displayName,
-              visibility: 'members_only',
-              ...(healthCheckUrl ? { health_check_url: healthCheckUrl } : {}),
-            });
-            await memberDb.updateProfile(profile.id, { agents });
-          } else if (clearHealthCheckUrl && (existing as any).health_check_url) {
-            delete (existing as any).health_check_url;
-            await memberDb.updateProfile(profile.id, { agents });
-          } else if (healthCheckUrl && (existing as any).health_check_url !== healthCheckUrl) {
-            (existing as any).health_check_url = healthCheckUrl;
-            await memberDb.updateProfile(profile.id, { agents });
+        let profile = await memberDb.getProfileByOrgId(saveOrgId);
+        let createdProfile = false;
+        if (!profile) {
+          const orgName = memberContext?.organization?.name;
+          if (!orgName) {
+            return { ok: false, reason: 'no-org-name' };
           }
+          const result = await ensureMemberProfileExists({
+            orgId: saveOrgId,
+            orgName,
+            source: 'addie:save_agent',
+          });
+          profile = result.profile;
+          createdProfile = result.created;
         }
+
+        const agents = profile.agents || [];
+        const existing = agents.find((a: any) => a.url === agentUrl);
+        if (!existing) {
+          // Default to members_only, not public. The public directory
+          // requires an API-access tier (Professional+); defaulting to
+          // 'public' here lets Addie implicitly publish an agent for an
+          // Explorer-tier caller who hasn't been tier-gated. Members_only
+          // keeps the agent discoverable to peer members with API access
+          // and lets the owner promote to public through the explicit,
+          // tier-checked /publish route when eligible.
+          agents.push({
+            url: agentUrl,
+            name: displayName,
+            visibility: 'members_only',
+            ...(healthCheckUrl ? { health_check_url: healthCheckUrl } : {}),
+          });
+          await memberDb.updateProfile(profile.id, { agents });
+        } else if (clearHealthCheckUrl && (existing as any).health_check_url) {
+          delete (existing as any).health_check_url;
+          await memberDb.updateProfile(profile.id, { agents });
+        } else if (healthCheckUrl && (existing as any).health_check_url !== healthCheckUrl) {
+          (existing as any).health_check_url = healthCheckUrl;
+          await memberDb.updateProfile(profile.id, { agents });
+        }
+        return { ok: true, createdProfile };
       } catch (err) {
-        logger.warn({ err, agentUrl }, 'Addie: failed to add agent to member profile');
+        logger.warn({ err, agentUrl, orgId: saveOrgId }, 'Addie: failed to add agent to member profile');
+        return { ok: false, reason: err instanceof Error ? err.message : 'unknown error' };
       }
     }
 
@@ -5440,7 +5460,7 @@ export function createMemberToolHandlers(
         }
         context = await agentContextDb.getById(context.id);
 
-        await ensureAgentInProfile(agentName || context?.agent_name || new URL(agentUrl).hostname);
+        const profileStatus = await ensureAgentInProfile(agentName || context?.agent_name || new URL(agentUrl).hostname);
 
         let response = `✅ Updated saved agent: **${context?.agent_name || agentUrl}**\n\n`;
         if (authToken) {
@@ -5451,6 +5471,9 @@ export function createMemberToolHandlers(
         if (clientCredentials) {
           response += `🔐 OAuth client-credentials saved securely for token endpoint ${clientCredentials.token_endpoint}\n`;
           response += `_The client secret is encrypted and will never be shown again. The SDK exchanges and refreshes at test time._\n`;
+        }
+        if (!profileStatus.ok) {
+          response += `\n⚠️ Credentials are saved, but I couldn't update your dashboard listing right now (${profileStatus.reason}). The team has been notified.`;
         }
         return response;
       }
@@ -5474,7 +5497,7 @@ export function createMemberToolHandlers(
         context = await agentContextDb.getById(context.id);
       }
 
-      await ensureAgentInProfile(agentName || new URL(agentUrl).hostname);
+      const profileStatus = await ensureAgentInProfile(agentName || new URL(agentUrl).hostname);
 
       let response = `✅ Saved agent: **${context?.agent_name || agentUrl}**\n\n`;
       response += `**URL:** ${agentUrl}\n`;
@@ -5488,7 +5511,11 @@ export function createMemberToolHandlers(
         response += `\n🔐 OAuth client-credentials saved securely for token endpoint ${clientCredentials.token_endpoint}\n`;
         response += `_The client secret is encrypted and will never be shown again. The SDK exchanges and refreshes at test time._\n`;
       }
-      response += `\nThe agent has been added to your dashboard with **members_only** visibility — other Professional-tier members can discover it, but it won't appear in the public directory. To publish publicly, use the dashboard publish flow (requires a Professional or higher subscription). When you test this agent, I'll automatically use the saved credentials.`;
+      if (profileStatus.ok) {
+        response += `\nThe agent has been added to your dashboard with **members_only** visibility — other Professional-tier members can discover it, but it won't appear in the public directory. To publish publicly, use the dashboard publish flow (requires a Professional or higher subscription). When you test this agent, I'll automatically use the saved credentials.`;
+      } else {
+        response += `\n⚠️ The credentials are saved on the backend, but I couldn't add this agent to your dashboard listing right now (${profileStatus.reason}). The team has been notified — please check back shortly, or use the dashboard's manual register flow at https://agenticadvertising.org/dashboard/agents.`;
+      }
 
       return response;
     } catch (error) {

--- a/server/src/services/member-profile-autopublish.ts
+++ b/server/src/services/member-profile-autopublish.ts
@@ -13,6 +13,7 @@
 
 import { createLogger } from '../logger.js';
 import { MemberDatabase } from '../db/member-db.js';
+import type { MemberProfile } from '../types.js';
 import { recordProfilePublishedIfNeeded } from './profile-publish-event.js';
 import { slugify } from './collection-feed-sync.js';
 
@@ -122,6 +123,57 @@ export async function ensureMemberProfilePublished(params: {
   }
 
   throw new Error(`Failed to auto-publish member profile for org ${orgId} after ${MAX_CREATE_RETRIES} attempts`);
+}
+
+/**
+ * Ensure a member_profile row exists for the given org without publishing it.
+ *
+ * Used by paths that need to attach data to the profile (e.g. registering an
+ * agent through Addie's `save_agent` tool) but must not flip the org into the
+ * public directory. The Stripe-webhook autopublish path remains the only
+ * place that sets `is_public: true`.
+ *
+ * Returns the existing profile when one is present; otherwise creates a
+ * minimal private profile with a unique slug. Throws on persistent failure
+ * so the caller can surface an honest error rather than silently no-op.
+ */
+export async function ensureMemberProfileExists(params: {
+  orgId: string;
+  orgName: string;
+  source: string;
+}): Promise<{ profile: MemberProfile; created: boolean }> {
+  const { orgId, orgName, source } = params;
+
+  const memberDb = new MemberDatabase();
+  const existing = await memberDb.getProfileByOrgId(orgId);
+  if (existing) return { profile: existing, created: false };
+
+  if (!orgName || !orgName.trim()) {
+    throw new Error(`Cannot create member profile for org ${orgId} — no org name available`);
+  }
+
+  for (let attempt = 1; attempt <= MAX_CREATE_RETRIES; attempt++) {
+    const slug = await pickAvailableSlug(orgName, memberDb);
+    try {
+      const created = await memberDb.createProfile({
+        workos_organization_id: orgId,
+        display_name: orgName,
+        slug,
+        is_public: false,
+      });
+      logger.info({ orgId, profileId: created.id, slug, source }, 'Auto-created private member profile');
+      return { profile: created, created: true };
+    } catch (err) {
+      if (!isUniqueViolation(err)) throw err;
+
+      const concurrent = await memberDb.getProfileByOrgId(orgId);
+      if (concurrent) return { profile: concurrent, created: false };
+
+      logger.warn({ orgId, attempt, source }, 'Slug collision creating private profile — retrying');
+    }
+  }
+
+  throw new Error(`Failed to create member profile for org ${orgId} after ${MAX_CREATE_RETRIES} attempts`);
 }
 
 async function pickAvailableSlug(orgName: string, memberDb: MemberDatabase): Promise<string> {


### PR DESCRIPTION
## Summary

- `save_agent` was silently no-op'ing the dashboard write when an org had no `member_profiles` row, while still returning `✅ added to your dashboard`. The `agent_contexts` row landed, the JSONB list the dashboard reads stayed empty, and `list_saved_agents` agreed with itself — so even Addie's own follow-up troubleshooting confirmed the agent "is saved." This is the failure mode behind escalation #309 (Warren Fernandes / Medianet).
- New `ensureMemberProfileExists` helper creates a private (`is_public: false`) profile with a unique slug when none exists, reusing the same retry/conflict-resolution logic as `ensureMemberProfilePublished`. Stripe-webhook autopublish remains the only path that flips a profile public.
- `ensureAgentInProfile` now returns a `ProfileWriteStatus`; both `save_agent` response branches surface the real outcome instead of unconditionally claiming success.

## How it happened

1. `agentContextDb.create(...)` writes the row keyed on `organization_id`.
2. `ensureAgentInProfile` calls `getProfileByOrgId(saveOrgId)` — returns `null` for orgs without a profile.
3. Old code: `if (profile) { … }` — branch silently skipped, surrounding `try/catch` swallowed any throw to a `logger.warn`.
4. Response message printed `_The agent has been added to your dashboard…_` regardless.

For #309, Warren's org `org_01KDV7ZJ41KASBC3DX098ZAZ4Z` had no `member_profiles` row at all; agent context was written but the dashboard list (sourced from `member_profiles.agents`) had nothing to show. Forward-fix data patch ran separately and reconciled #309.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `tests/unit/addie` — 320 / 320 passing
- [x] `tests/unit/mcp-eval-tools.test.ts` — 23 / 23 passing
- [x] Pre-commit hook (full unit suite + dynamic-imports + callapi-state-change + typecheck) green
- [ ] Manual: register an agent via Addie for an org with no profile → verify a private profile is created and the agent appears on `/dashboard/agents`
- [ ] Manual: simulate a profile-write failure → verify the user-facing message reflects the failure honestly

## Not in this PR

The "Org ID: 80fa04d3-…" UUID Addie generated when *describing* escalation #309 in a downstream admin chat is a hallucination from the admin/triage path, not from the escalation tool itself. Worth a separate ticket if we want to harden grounding there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)