### PR TITLE
fix(training-agent): wire seed.creative_format on /sales tenant

### DIFF
--- a/.changeset/sales-seed-creative-format.md
+++ b/.changeset/sales-seed-creative-format.md
@@ -1,0 +1,27 @@
+---
+---
+
+fix(training-agent): wire seed.creative_format on /sales tenant
+
+`pagination_integrity_creative_formats` is a universal storyboard gated on `list_creative_formats`. The tool catalog advertises `list_creative_formats` on `sales`, `creative`, and `creative-builder` — the SDK auto-registers it whenever a tenant claims a creative archetype — but `buildSalesComplyConfig` only registered the seed adapters relevant to the sales-track storyboards (`product`, `pricing_option`, `media_buy`, `creative`). The `creative_format` slot was missing.
+
+Result: `seed_creative_format` calls on `/sales/mcp` hit the SDK dispatcher's `if (!store.seedCreativeFormat) return UNKNOWN_SCENARIO` branch and returned `success: false` before the v5 handler's LOCAL_SCENARIOS pre-handler could service them. The storyboard's `seed_format_1` step graded "Expected true, got false" and cascaded — pagination steps that depended on the seed succeeding skipped.
+
+Wires the adapter consistently with `/creative` and `/creative-builder`:
+
+```ts
+seed: {
+  ...
+  creative_format: cast(seedAdapter('seed_creative_format')),
+},
+```
+
+Floor lift on /sales:
+
+| Tenant  | Old (post-#4061) | New | Delta |
+|---------|------------------|-----|-------|
+| /sales  | 64 / 248         | 65 / 252 | +1 / +4 |
+
+Files: `server/src/training-agent/tenants/comply.ts`, `.github/workflows/training-agent-storyboards.yml`, `scripts/run-storyboards-matrix.sh`.
+
+Closes one of the three remaining storyboard regressions surfaced after the #3965 cluster work.

--- a/.github/workflows/training-agent-storyboards.yml
+++ b/.github/workflows/training-agent-storyboards.yml
@@ -52,8 +52,8 @@ jobs:
             min_clean_storyboards: 66
             min_passing_steps: 54
           - tenant: sales
-            min_clean_storyboards: 64
-            min_passing_steps: 248
+            min_clean_storyboards: 65
+            min_passing_steps: 252
           - tenant: governance
             min_clean_storyboards: 65
             min_passing_steps: 101

--- a/scripts/run-storyboards-matrix.sh
+++ b/scripts/run-storyboards-matrix.sh
@@ -21,7 +21,7 @@ bash "${SCRIPT_DIR}/overlay-compliance-cache.sh" || true
 # .github/workflows/training-agent-storyboards.yml.
 TENANTS=(
   "signals:66:54"
-  "sales:64:248"
+  "sales:65:252"
   "governance:65:101"
   "creative:66:114"
   "creative-builder:60:96"

--- a/server/src/training-agent/tenants/comply.ts
+++ b/server/src/training-agent/tenants/comply.ts
@@ -198,6 +198,13 @@ export function buildSalesComplyConfig(): ComplyControllerConfig {
       pricing_option: cast(seedAdapter('seed_pricing_option')),
       media_buy: cast(seedAdapter('seed_media_buy')),
       creative: cast(seedAdapter('seed_creative')),
+      // /sales advertises list_creative_formats (the SDK auto-registers it for
+      // any tenant claiming a creative archetype) so the universal
+      // pagination_integrity_creative_formats storyboard fires here too. The
+      // seed adapter routes through the v5 handler's LOCAL_SCENARIOS path,
+      // populating the process-global seeded format pool that
+      // list_creative_formats reads.
+      creative_format: cast(seedAdapter('seed_creative_format')),
     },
     force: {
       media_buy_status: cast(forceAdapter('force_media_buy_status')),


### PR DESCRIPTION
## Summary

`pagination_integrity_creative_formats` is a universal storyboard gated on `list_creative_formats`. The tool catalog advertises `list_creative_formats` on `sales`, `creative`, and `creative-builder` (the SDK auto-registers it whenever a tenant claims a creative archetype), but `buildSalesComplyConfig` only registered the seed adapters relevant to the sales-track storyboards (`product`, `pricing_option`, `media_buy`, `creative`). The `creative_format` slot was missing.

Result: `seed_creative_format` calls on `/sales/mcp` hit the SDK dispatcher's `if (!store.seedCreativeFormat) return UNKNOWN_SCENARIO` branch and returned `success: false` before the v5 handler's LOCAL_SCENARIOS pre-handler could service them. The `seed_format_1` storyboard step graded "Expected true, got false" and downstream pagination steps skipped.

```ts
seed: {
  ...
  creative_format: cast(seedAdapter('seed_creative_format')),
},
```

Floor lift on /sales:

| Tenant  | Old (post-#4061) | New | Delta |
|---------|------------------|-----|-------|
| /sales  | 64 / 248         | 65 / 252 | +1 / +4 |

Other tenants flat — `/creative` and `/creative-builder` already wire the adapter via `buildCreativeComplyConfig`, and the rest don't claim `list_creative_formats`.

## Test plan

- [x] Local matrix run — all six tenants pass new floors
- [ ] CI matrix run on PR
- [ ] `pagination_integrity_creative_formats` storyboard now passes 5P/0F on /sales

🤖 Generated with [Claude Code](https://claude.com/claude-code)