### PR TITLE
fix(training-agent): surface tenant registry init failures + boot-phase timing

### DIFF
--- a/.changeset/training-agent-tenant-init-diagnostics.md
+++ b/.changeset/training-agent-tenant-init-diagnostics.md
@@ -1,0 +1,19 @@
+---
+---
+
+fix(training-agent): surface tenant registry init failures + boot-phase timing
+
+Wraps `await holder.get()` in `tenantMcpHandler` with a `try/catch` that
+logs the rejection (message, name, stack, cause) and returns a JSON-RPC
+503 instead of letting the unhandled rejection escape to Express's
+default error handler — which produced an HTML 500 with no JSON body
+and no log entry tying the error to the rejected promise. The
+post-deploy smoke had been catching the symptom for several deploys
+without enough context to identify the cause.
+
+Also adds boot-phase timing in `createRegistryHolder` so each phase is
+visible: registry construction, per-tenant config build, per-tenant
+register elapsed, and aggregate totals. Init takes ~14ms locally; the
+new logs let us see which phase is blowing up the budget on a fresh
+Fly machine. Per-tenant register failures are logged with stack before
+re-throwing so a single bad tenant doesn't hide behind `Promise.all`.

--- a/server/src/training-agent/tenants/registry.ts
+++ b/server/src/training-agent/tenants/registry.ts
@@ -204,32 +204,58 @@ export function createRegistryHolder(): RegistryHolder {
       if (registry) return registry;
       if (pendingInit) return pendingInit;
       const promise = (async () => {
+        const t0 = Date.now();
+        logger.info('Tenant registry init starting');
         const hostBase = buildHostBaseUrl();
         const reg = createTenantRegistry({
           defaultServerOptions: buildDefaultServerOptions(),
           jwksValidator: noopJwksValidator,
           autoValidate: true,
         });
-        const signals = buildSignalsTenantConfig(hostBase);
-        const sales = buildSalesTenantConfig(hostBase);
-        const governance = buildGovernanceTenantConfig(hostBase);
-        const creative = buildCreativeTenantConfig(hostBase);
-        const creativeBuilder = buildCreativeBuilderTenantConfig(hostBase);
-        const brand = buildBrandTenantConfig(hostBase);
+        const tCreate = Date.now();
+        const configs = [
+          { id: 'signals', cfg: buildSignalsTenantConfig(hostBase) },
+          { id: 'sales', cfg: buildSalesTenantConfig(hostBase) },
+          { id: 'governance', cfg: buildGovernanceTenantConfig(hostBase) },
+          { id: 'creative', cfg: buildCreativeTenantConfig(hostBase) },
+          { id: 'creative-builder', cfg: buildCreativeBuilderTenantConfig(hostBase) },
+          { id: 'brand', cfg: buildBrandTenantConfig(hostBase) },
+        ] as const;
+        const tConfigs = Date.now();
         // awaitFirstValidation:true blocks until the no-op validator
         // promotes the tenant to 'healthy'. Without it the first request
         // would race the background validation and see 'pending' (refused
         // traffic) for the first ~10ms.
-        await Promise.all([
-          reg.register(signals.tenantId, signals.config, { awaitFirstValidation: true }),
-          reg.register(sales.tenantId, sales.config, { awaitFirstValidation: true }),
-          reg.register(governance.tenantId, governance.config, { awaitFirstValidation: true }),
-          reg.register(creative.tenantId, creative.config, { awaitFirstValidation: true }),
-          reg.register(creativeBuilder.tenantId, creativeBuilder.config, { awaitFirstValidation: true }),
-          reg.register(brand.tenantId, brand.config, { awaitFirstValidation: true }),
-        ]);
+        await Promise.all(
+          configs.map(async ({ id, cfg }) => {
+            const start = Date.now();
+            try {
+              await reg.register(cfg.tenantId, cfg.config, { awaitFirstValidation: true });
+              logger.info({ tenantId: id, elapsedMs: Date.now() - start }, 'Tenant registered');
+            } catch (err) {
+              logger.error(
+                {
+                  err,
+                  errMessage: err instanceof Error ? err.message : String(err),
+                  errStack: err instanceof Error ? err.stack : undefined,
+                  tenantId: id,
+                  elapsedMs: Date.now() - start,
+                },
+                'Tenant register failed',
+              );
+              throw err;
+            }
+          }),
+        );
         logger.info(
-          { hostBase, tenants: ['signals', 'sales', 'governance', 'creative', 'creative-builder', 'brand'] },
+          {
+            hostBase,
+            createMs: tCreate - t0,
+            configBuildMs: tConfigs - tCreate,
+            registerMs: Date.now() - tConfigs,
+            totalMs: Date.now() - t0,
+            tenants: configs.map(c => c.id),
+          },
           'Tenant registry initialized',
         );
         registry = reg;

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -65,14 +65,11 @@ function tenantMcpHandler(holder: RegistryHolder, tenantId: string) {
     }
 
     const host = resolveTenantHost(req);
-    let registry;
-    try {
-      registry = await holder.get();
-    } catch (err) {
-      // Surfacing the rejection here is what made #3854/#3869-class bugs
-      // visible. Without this, init failures escape to Express's default
-      // error handler — the smoke sees an HTML 500 with no JSON body and
-      // no log entry tying the error to the rejected promise.
+    const registry = await holder.get().catch((err: unknown) => {
+      // Surfacing the rejection here is what makes #3854 / #3869-class
+      // init bugs visible. Without it the rejection escapes to Express's
+      // default error handler — the smoke sees an HTML 500 with no JSON
+      // body and no log entry tying the error to the rejected promise.
       logger.error(
         {
           err,
@@ -85,13 +82,20 @@ function tenantMcpHandler(holder: RegistryHolder, tenantId: string) {
         },
         'tenant registry init rejected — request failed before dispatch',
       );
+      // 503 + Retry-After matches the SDK's documented contract for
+      // pending tenants (`tenant-registry.d.ts`: "host transport should
+      // respond 503 + Retry-After"). 5s is short enough that the smoke's
+      // 8s retry catches a transient warmup, long enough for a fresh
+      // Fly machine to finish per-tenant register.
+      res.setHeader('Retry-After', '5');
       res.status(503).json({
         jsonrpc: '2.0',
         id: null,
         error: { code: -32000, message: 'Tenant registry warming up; retry shortly' },
       });
-      return;
-    }
+      return null;
+    });
+    if (registry === null) return;
     const resolved = registry.resolveByRequest(host, `/${tenantId}/mcp`);
     if (!resolved) {
       logger.warn(

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -65,7 +65,33 @@ function tenantMcpHandler(holder: RegistryHolder, tenantId: string) {
     }
 
     const host = resolveTenantHost(req);
-    const registry = await holder.get();
+    let registry;
+    try {
+      registry = await holder.get();
+    } catch (err) {
+      // Surfacing the rejection here is what made #3854/#3869-class bugs
+      // visible. Without this, init failures escape to Express's default
+      // error handler — the smoke sees an HTML 500 with no JSON body and
+      // no log entry tying the error to the rejected promise.
+      logger.error(
+        {
+          err,
+          errMessage: err instanceof Error ? err.message : String(err),
+          errName: err instanceof Error ? err.name : undefined,
+          errStack: err instanceof Error ? err.stack : undefined,
+          errCause: err instanceof Error ? (err as Error & { cause?: unknown }).cause : undefined,
+          tenantId,
+          host,
+        },
+        'tenant registry init rejected — request failed before dispatch',
+      );
+      res.status(503).json({
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: -32000, message: 'Tenant registry warming up; retry shortly' },
+      });
+      return;
+    }
     const resolved = registry.resolveByRequest(host, `/${tenantId}/mcp`);
     if (!resolved) {
       logger.warn(
@@ -164,7 +190,13 @@ export function mountTenantRoutes(
   // the next request retries.
   holder.get().catch((err) => {
     logger.error(
-      { err },
+      {
+        err,
+        errMessage: err instanceof Error ? err.message : String(err),
+        errName: err instanceof Error ? err.name : undefined,
+        errStack: err instanceof Error ? err.stack : undefined,
+        errCause: err instanceof Error ? (err as Error & { cause?: unknown }).cause : undefined,
+      },
       'Eager tenant registry init failed at boot; per-request init will retry',
     );
   });


### PR DESCRIPTION
## Summary

The post-deploy smoke has been failing on `/sales/mcp` … `/brand/mcp` for several deploys with HTTP 500 + HTML body. Two prior attempts (#4060 eager init, #4062 block listen) did not move the needle — #4062 was reverted because the listener didn't bind within Fly's `--wait-timeout 300s`.

The smoke's HTML body is the giveaway: that's Express 5's default error handler, which fires only when an unhandled rejection escapes the route handler. Looking at `tenantMcpHandler`, `await holder.get()` sits **outside** the try/catch — so any tenant-registry init rejection becomes an HTML 500 with no JSON body, no log entry, and no clue why.

This PR adds the diagnostic surface we should have had from the start:

- Wrap `await holder.get()` in `try/catch`. Log the rejection with `errMessage`, `errName`, `errStack`, `errCause`, `tenantId`, `host`. Return JSON-RPC 503 instead of HTML 500.
- Widen the eager-mount `.catch()` so the boot-time rejection is also logged with full error metadata, not just `{ err }` (which pino-serializes to a few fields).
- Add boot-phase timing in `createRegistryHolder` — registry construction, config build, per-tenant `register()` elapsed, and aggregate totals. Per-tenant register failures log a stack before re-throwing so a single bad tenant doesn't hide behind `Promise.all`.

Init runs ~14ms locally (visible in the new log). The next failed deploy will tell us which phase is blowing the budget on a fresh Fly machine — DNS, JWKS, `buildServer` schema work, or something else.

## Test plan

- [x] `npx tsc -p server/tsconfig.json --noEmit` passes
- [x] `npx vitest run server/src/training-agent/tenants/tenant-smoke.test.ts` — 3/3 pass
- [ ] After merge: watch the next deploy's `flyctl logs --app adcp-docs --no-tail` for either `Tenant registry initialized` (with phase timings) or `Tenant register failed` / `tenant registry init rejected — request failed before dispatch` (with stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)