### PR TITLE
fix(server): treat all-silent comply tracks as passing, not degraded

### DIFF
--- a/.changeset/fix-silent-tracks-compliance-status.md
+++ b/.changeset/fix-silent-tracks-compliance-status.md
@@ -1,0 +1,33 @@
+---
+---
+
+fix(server): treat all-silent comply tracks as passing, not degraded (closes #4065)
+
+The `@adcp/sdk/testing` `comply()` function returns `overall_status: 'partial'` when every
+track is `'silent'` (all scenarios passed with no advisory observations — the best possible
+outcome). The server mapped `'partial'` → `ComplianceStatus: 'degraded'`, causing the
+compliance dashboard to show "Degraded" for fully-clean agents.
+
+**Root cause:** `complianceResultToDbInput()` called `mapOverallStatus(result.overall_status)`
+which blindly forwarded the SDK's `'partial'` to the DB. `computeStatus('partial')` then
+returned `'degraded'`.
+
+**Fix:** Added `effectiveRunStatus()` which checks whether all active (non-skip) tracks are
+`'pass'` or `'silent'` before falling through to `mapOverallStatus`. When all tracks are
+passing/silent, it overrides to `'passing'` and zeroes out `tracks_partial` so the stored
+run record stays consistent.
+
+**Frontend:** Track pills in `agents.html` and `dashboard-agents.html` (card view and history
+panel) mapped `'silent'` to the skip CSS class (gray). Fixed to use the pass class (green) in
+all four locations.
+
+**Secondary gap (not fixed here):** `member-tools.ts:3533` records
+`overall_passed: result.overall_status === 'passing'` using the raw SDK string, which stays
+`'partial'` for all-silent runs. The `quality_evaluation` test-run record will incorrectly
+store `overall_passed: false` until a follow-up PR fixes `evaluate_agent_quality`'s
+`recordTest` call. Tracked as a known gap.
+
+**Downstream effects of the fix (correct behavior):**
+- Streak accumulation now works for all-silent agents (`streak_days` advances correctly)
+- `last_passed_at` is now set on all-silent heartbeats (was NULL, blocking badge eligibility)
+- Compliance notifications no longer false-fire for agents with clean-but-silent runs

--- a/server/public/agents.html
+++ b/server/public/agents.html
@@ -746,7 +746,7 @@
                 if (trackEntries.length > 0) {
                     complianceHtml += '<div class="track-pills">';
                     for (const [track, status] of trackEntries) {
-                        const pillClass = status === 'pass' ? 'track-pill--pass'
+                        const pillClass = status === 'pass' || status === 'silent' ? 'track-pill--pass'
                             : status === 'fail' ? 'track-pill--fail'
                             : status === 'partial' ? 'track-pill--partial'
                             : 'track-pill--skip';
@@ -1008,7 +1008,7 @@
                 let trackPillsHtml = '';
                 const tracks = cs.tracks || {};
                 for (const [track, status] of Object.entries(tracks).filter(([, s]) => s !== 'skip' && s !== 'expected')) {
-                    const pillClass = status === 'pass' ? 'track-pill--pass'
+                    const pillClass = status === 'pass' || status === 'silent' ? 'track-pill--pass'
                         : status === 'fail' ? 'track-pill--fail'
                         : status === 'partial' ? 'track-pill--partial'
                         : 'track-pill--skip';

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -1424,7 +1424,7 @@
         const clickableTrackPills = Object.entries(tracks)
           .filter(([, status]) => status !== 'skip' && status !== 'expected')
           .map(([track, status]) => {
-          const cls = status === 'pass' ? 'agent-track--pass'
+          const cls = status === 'pass' || status === 'silent' ? 'agent-track--pass'
             : status === 'fail' ? 'agent-track--fail'
             : status === 'partial' ? 'agent-track--partial'
             : 'agent-track--skip';
@@ -2599,7 +2599,7 @@
             return;
           }
 
-          const statusLabel = trackData.status === 'pass' ? 'Passing'
+          const statusLabel = trackData.status === 'pass' || trackData.status === 'silent' ? 'Passing'
             : trackData.status === 'fail' ? 'Failing'
             : trackData.status === 'partial' ? 'Partial' : trackData.status;
 
@@ -2670,7 +2670,7 @@
             let runTracks = '';
             if (run.tracks_json) {
               for (const t of run.tracks_json) {
-                const cls = t.status === 'pass' ? 'agent-track--pass'
+                const cls = t.status === 'pass' || t.status === 'silent' ? 'agent-track--pass'
                   : t.status === 'fail' ? 'agent-track--fail'
                   : t.status === 'partial' ? 'agent-track--partial'
                   : 'agent-track--skip';

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -1504,7 +1504,7 @@
         const clickableTrackPills = Object.entries(tracks)
           .filter(([, status]) => status !== 'skip' && status !== 'expected')
           .map(([track, status]) => {
-          const cls = status === 'pass' ? 'agent-track--pass'
+          const cls = status === 'pass' || status === 'silent' ? 'agent-track--pass'
             : status === 'fail' ? 'agent-track--fail'
             : status === 'partial' ? 'agent-track--partial'
             : 'agent-track--skip';
@@ -2858,7 +2858,7 @@
             return;
           }
 
-          const statusLabel = trackData.status === 'pass' ? 'Passing'
+          const statusLabel = trackData.status === 'pass' || trackData.status === 'silent' ? 'Passing'
             : trackData.status === 'fail' ? 'Failing'
             : trackData.status === 'partial' ? 'Partial' : trackData.status;
 
@@ -2944,7 +2944,7 @@
             let runTracks = '';
             if (run.tracks_json) {
               for (const t of run.tracks_json) {
-                const cls = t.status === 'pass' ? 'agent-track--pass'
+                const cls = t.status === 'pass' || t.status === 'silent' ? 'agent-track--pass'
                   : t.status === 'fail' ? 'agent-track--fail'
                   : t.status === 'partial' ? 'agent-track--partial'
                   : 'agent-track--skip';

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -222,6 +222,41 @@ function mapOverallStatus(status: string): OverallRunStatus {
   }
 }
 
+/**
+ * Derive the effective overall status and track counters from a ComplianceResult.
+ *
+ * The SDK reports overall_status='partial' when every track returns 'silent' (all
+ * scenarios passed with no advisory observations — the best possible outcome).
+ * 'partial' maps to ComplianceStatus='degraded', which is wrong for a fully-clean
+ * run. When all active (non-skip) tracks are 'pass' or 'silent', override to
+ * 'passing' and recompute track counters so DB records stay consistent.
+ */
+function effectiveRunStatus(result: ComplianceResult): {
+  overall_status: OverallRunStatus;
+  tracks_passed: number;
+  tracks_failed: number;
+  tracks_partial: number;
+} {
+  const activeTracks = result.tracks.filter((t: TrackResult) => t.status !== 'skip');
+  if (
+    activeTracks.length > 0 &&
+    activeTracks.every((t: TrackResult) => t.status === 'pass' || t.status === 'silent')
+  ) {
+    return {
+      overall_status: 'passing',
+      tracks_passed: activeTracks.length,
+      tracks_failed: 0,
+      tracks_partial: 0,
+    };
+  }
+  return {
+    overall_status: mapOverallStatus(result.overall_status),
+    tracks_passed: result.summary.tracks_passed,
+    tracks_failed: result.summary.tracks_failed,
+    tracks_partial: result.summary.tracks_partial,
+  };
+}
+
 // ── Storyboard Status Derivation ─────────────────────────────────
 
 /**
@@ -488,17 +523,19 @@ export function complianceResultToDbInput(
     duration_ms: t.duration_ms,
   }));
 
+  const { overall_status, tracks_passed, tracks_failed, tracks_partial } = effectiveRunStatus(result);
+
   return {
     agent_url: agentUrl,
     lifecycle_stage: lifecycleStage,
-    overall_status: mapOverallStatus(result.overall_status),
+    overall_status,
     headline: result.summary.headline,
     total_duration_ms: result.total_duration_ms,
     tracks_json: tracksJson,
-    tracks_passed: result.summary.tracks_passed,
-    tracks_failed: result.summary.tracks_failed,
+    tracks_passed,
+    tracks_failed,
     tracks_skipped: result.summary.tracks_skipped,
-    tracks_partial: result.summary.tracks_partial,
+    tracks_partial,
     agent_profile_json: result.agent_profile,
     observations_json: result.observations,
     triggered_by: triggeredBy,

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -220,6 +220,41 @@ function mapOverallStatus(status: string): OverallRunStatus {
   }
 }
 
+/**
+ * Derive the effective overall status and track counters from a ComplianceResult.
+ *
+ * The SDK reports overall_status='partial' when every track returns 'silent' (all
+ * scenarios passed with no advisory observations — the best possible outcome).
+ * 'partial' maps to ComplianceStatus='degraded', which is wrong for a fully-clean
+ * run. When all active (non-skip) tracks are 'pass' or 'silent', override to
+ * 'passing' and recompute track counters so DB records stay consistent.
+ */
+function effectiveRunStatus(result: ComplianceResult): {
+  overall_status: OverallRunStatus;
+  tracks_passed: number;
+  tracks_failed: number;
+  tracks_partial: number;
+} {
+  const activeTracks = result.tracks.filter((t: TrackResult) => t.status !== 'skip');
+  if (
+    activeTracks.length > 0 &&
+    activeTracks.every((t: TrackResult) => t.status === 'pass' || t.status === 'silent')
+  ) {
+    return {
+      overall_status: 'passing',
+      tracks_passed: activeTracks.length,
+      tracks_failed: 0,
+      tracks_partial: 0,
+    };
+  }
+  return {
+    overall_status: mapOverallStatus(result.overall_status),
+    tracks_passed: result.summary.tracks_passed,
+    tracks_failed: result.summary.tracks_failed,
+    tracks_partial: result.summary.tracks_partial,
+  };
+}
+
 // ── Storyboard Status Derivation ─────────────────────────────────
 
 /**
@@ -523,17 +558,19 @@ export function complianceResultToDbInput(
     duration_ms: t.duration_ms,
   }));
 
+  const { overall_status, tracks_passed, tracks_failed, tracks_partial } = effectiveRunStatus(result);
+
   return {
     agent_url: agentUrl,
     lifecycle_stage: lifecycleStage,
-    overall_status: mapOverallStatus(result.overall_status),
+    overall_status,
     headline: result.summary.headline,
     total_duration_ms: result.total_duration_ms,
     tracks_json: tracksJson,
-    tracks_passed: result.summary.tracks_passed,
-    tracks_failed: result.summary.tracks_failed,
+    tracks_passed,
+    tracks_failed,
     tracks_skipped: result.summary.tracks_skipped,
-    tracks_partial: result.summary.tracks_partial,
+    tracks_partial,
     agent_profile_json: result.agent_profile,
     observations_json: result.observations,
     triggered_by: triggeredBy,

--- a/server/tests/unit/compliance-testing-effective-run-status.test.ts
+++ b/server/tests/unit/compliance-testing-effective-run-status.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@adcp/sdk/testing', () => ({
+  setAgentTesterLogger: vi.fn(),
+  comply: vi.fn(),
+  loadComplianceIndex: vi.fn(() => ({ specialisms: [] })),
+  SAMPLE_BRIEFS: [],
+  getBriefsByVertical: vi.fn(() => []),
+}));
+
+vi.mock('../../src/services/storyboards.js', () => ({
+  getStoryboard: vi.fn(() => null),
+  getAllStoryboards: vi.fn(() => []),
+}));
+
+vi.mock('../../src/services/adcp-taxonomy.js', () => ({
+  isStableSpecialism: vi.fn(() => true),
+}));
+
+import { complianceResultToDbInput } from '../../src/addie/services/compliance-testing.js';
+
+function makeTrack(status: string, scenarioCount = 3) {
+  return {
+    track: status === 'skip' ? 'governance' : 'core',
+    label: status === 'skip' ? 'Governance' : 'Core',
+    status,
+    duration_ms: 1000,
+    scenarios: Array.from({ length: scenarioCount }, (_, i) => ({
+      scenario: `scenario_${i}`,
+      overall_passed: status !== 'fail',
+      steps: [],
+    })),
+  };
+}
+
+function makeResult(tracks: ReturnType<typeof makeTrack>[], overallStatus = 'partial') {
+  const nonSkip = tracks.filter(t => t.status !== 'skip');
+  const passed = nonSkip.filter(t => t.status === 'pass' || t.status === 'silent').length;
+  const failed = nonSkip.filter(t => t.status === 'fail').length;
+  const partial = nonSkip.filter(t => t.status === 'partial').length;
+  return {
+    overall_status: overallStatus,
+    tracks,
+    summary: {
+      headline: 'Test headline',
+      tracks_passed: passed,
+      tracks_failed: failed,
+      tracks_partial: partial,
+      tracks_skipped: tracks.filter(t => t.status === 'skip').length,
+    },
+    total_duration_ms: 2000,
+    agent_profile: { name: 'test-agent', tools: [] },
+    observations: [],
+  };
+}
+
+describe('complianceResultToDbInput — effectiveRunStatus', () => {
+  it('promotes all-silent to passing with zero partial/failed counters', () => {
+    const result = makeResult([makeTrack('silent'), makeTrack('silent')], 'partial');
+    const out = complianceResultToDbInput(result as any, 'https://agent.example.com/mcp', 'production');
+
+    expect(out.overall_status).toBe('passing');
+    expect(out.tracks_passed).toBe(2);
+    expect(out.tracks_failed).toBe(0);
+    expect(out.tracks_partial).toBe(0);
+  });
+
+  it('promotes mixed pass+silent to passing', () => {
+    const result = makeResult([makeTrack('pass'), makeTrack('silent')], 'partial');
+    const out = complianceResultToDbInput(result as any, 'https://agent.example.com/mcp', 'production');
+
+    expect(out.overall_status).toBe('passing');
+    expect(out.tracks_passed).toBe(2);
+    expect(out.tracks_failed).toBe(0);
+    expect(out.tracks_partial).toBe(0);
+  });
+
+  it('does not promote when at least one track fails', () => {
+    const result = makeResult([makeTrack('silent'), makeTrack('fail')], 'partial');
+    const out = complianceResultToDbInput(result as any, 'https://agent.example.com/mcp', 'production');
+
+    expect(out.overall_status).toBe('partial');
+    expect(out.tracks_passed).toBe(0);
+    expect(out.tracks_failed).toBe(1);
+    expect(out.tracks_partial).toBe(0);
+  });
+
+  it('ignores skip tracks when deciding promotion', () => {
+    const result = makeResult([makeTrack('silent'), makeTrack('skip')], 'partial');
+    const out = complianceResultToDbInput(result as any, 'https://agent.example.com/mcp', 'production');
+
+    expect(out.overall_status).toBe('passing');
+    expect(out.tracks_passed).toBe(1);
+  });
+
+  it('does not promote when all tracks are skipped (no active tracks)', () => {
+    const result = makeResult([makeTrack('skip'), makeTrack('skip')], 'partial');
+    const out = complianceResultToDbInput(result as any, 'https://agent.example.com/mcp', 'production');
+
+    // No active tracks — falls through to mapOverallStatus('partial') → 'partial'
+    expect(out.overall_status).toBe('partial');
+  });
+});

--- a/server/tests/unit/compliance-testing-effective-run-status.test.ts
+++ b/server/tests/unit/compliance-testing-effective-run-status.test.ts
@@ -80,7 +80,9 @@ describe('complianceResultToDbInput — effectiveRunStatus', () => {
     const out = complianceResultToDbInput(result as any, 'https://agent.example.com/mcp', 'production');
 
     expect(out.overall_status).toBe('partial');
-    expect(out.tracks_passed).toBe(0);
+    // tracks_passed counts pass + silent per SDK summary semantics; the silent
+    // track contributes 1 even though the overall verdict isn't promoted.
+    expect(out.tracks_passed).toBe(1);
     expect(out.tracks_failed).toBe(1);
     expect(out.tracks_partial).toBe(0);
   });


### PR DESCRIPTION
Closes #4065

## Summary

When `comply()` returns `silent` for every track (all scenarios passed, zero failures — the best possible outcome), the SDK reports `overall_status: 'partial'`. The server mapped `'partial'` → `ComplianceStatus: 'degraded'`, so the dashboard showed "Compliance: Degraded" for fully-clean agents.

Added `effectiveRunStatus()` in `compliance-testing.ts` to intercept at the DB-adapter boundary: when all active (non-skip) tracks are `'pass'` or `'silent'`, override to `'passing'` and recompute `tracks_passed`, `tracks_failed`, and `tracks_partial` so stored run records stay consistent. The SDK result itself is untouched. Frontend: five locations in `agents.html` and `dashboard-agents.html` (card, detail modal, history panel, track-detail drawer) now map `'silent'` track pills to the pass CSS class.

**Non-breaking justification:** Server-internal status computation correction. No schema, API, or protocol changes. ComplianceStatus values are unchanged; only their mapping from SDK output is corrected. Existing DB records stay as-is until the next heartbeat cycle.

**Downstream effects (all correct behavior):**
- Streak accumulation now works for all-silent agents (`streak_days` advances correctly)
- `last_passed_at` is now set on all-silent heartbeats (was NULL, blocking badge eligibility)
- Compliance notifications no longer false-fire for agents with clean-but-silent runs

**Known secondary gap (not fixed here):** `member-tools.ts:3533` records `overall_passed: result.overall_status === 'passing'` using the raw SDK string, which stays `'partial'` for all-silent runs. The `quality_evaluation` tool's `recordTest` call will incorrectly store `overall_passed: false` until a follow-up PR.

**Deploy consideration:** Agents currently stored as `status='degraded'` due to this bug will trigger a one-time "recovery" status notification on their next heartbeat post-deploy (transition `degraded → passing`). This is a one-off spurious recovery DM, not a regression notification. Operators receiving it may be briefly confused; the message will show correct data about the agent's healthy state.

## Pre-PR review

First review pass (before addressing blockers):

- **code-reviewer:** Found 5 locations needing `silent` mapping (not 4), flagged missing unit tests for `effectiveRunStatus`, and flagged `tracks_failed` inconsistency. All addressed.
- **internal-tools-strategist:** Flagged recovery notification risk on first post-deploy heartbeat (documented above as deploy consideration). Confirmed `silent = passing` display is semantically correct; streak/`last_passed_at` fix is correct and load-bearing.

Fixes applied after first pass:
- Added 5th `silent` → `'Passing'` mapping in dashboard-agents.html track-detail drawer (line 2602)
- Added `tracks_failed: 0` to the override branch of `effectiveRunStatus`
- Added unit tests (`server/tests/unit/compliance-testing-effective-run-status.test.ts`) covering: all-silent, mixed pass+silent, at-least-one-fail, skip-track exclusion, all-skip no-promotion

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_014sRTVL1uWrZJUj6TiJWcBS

---
_Generated by [Claude Code](https://claude.ai/code/session_014sRTVL1uWrZJUj6TiJWcBS)_