### PR TITLE
ci(storyboards): skip two SDK-blocked steps on /sales, ratchet floor

### DIFF
--- a/.changeset/sales-known-failing-skips.md
+++ b/.changeset/sales-known-failing-skips.md
@@ -1,0 +1,24 @@
+---
+---
+
+ci(storyboards): skip two SDK-blocked steps on /sales, ratchet floor
+
+Two storyboard steps on `/sales` fail on framework-routed sellers due to SDK gaps that need upstream fixes. Adding both to `KNOWN_FAILING_STEPS` so the runner reports them as skipped (with the source-of-truth issue link) rather than failed.
+
+**Step 1: `media_buy_seller/create_media_buy_async/create_media_buy_submitted`** — adcp-client#1554
+
+The v5 `createMediaBuy` handler returns a hand-rolled `{ status: 'submitted', task_id }` envelope when the `force_create_media_buy_arm` directive is set. The v6 framework's projector rejects that shape (`from-platform.js:1438`) — the only way into the submitted arm is via `ctx.handoffToTask(fn)`, which assigns a framework-issued task_id. The test-controller directive requires the seller to return the **caller-supplied** task_id, so `handoffToTask` cannot satisfy the contract until the SDK exposes a `{ task_id }` overload.
+
+**Step 2: `media_buy_seller/vendor_metric_accountability/get_delivery_with_vendor_metrics`** — adcp-client#1552
+
+The SDK storyboard runner drops extension params (e.g. `vendor_metric_values`) from `comply_test_controller` requests before they reach the wire. The agent's `simulate_delivery` handler never sees the array, so the downstream `get_media_buy_delivery` assertion finds nothing on `by_package[].vendor_metric_values`. This is a pure runner gap — the spec declares `params` as passthrough.
+
+Floor lift on /sales: 65→67 clean storyboards (each skipped step lets its parent storyboard count as clean).
+
+| Tenant  | Old | New | Delta |
+|---------|-----|-----|-------|
+| /sales  | 65 / 252 | 67 / 252 | +2 / 0 |
+
+Files: `server/tests/manual/run-storyboards.ts` (skip entries), `.github/workflows/training-agent-storyboards.yml`, `scripts/run-storyboards-matrix.sh`.
+
+Once the upstream SDK fixes ship, drop the entries and ratchet the floor again.

--- a/.github/workflows/training-agent-storyboards.yml
+++ b/.github/workflows/training-agent-storyboards.yml
@@ -52,7 +52,7 @@ jobs:
             min_clean_storyboards: 66
             min_passing_steps: 54
           - tenant: sales
-            min_clean_storyboards: 65
+            min_clean_storyboards: 67
             min_passing_steps: 252
           - tenant: governance
             min_clean_storyboards: 65

--- a/scripts/run-storyboards-matrix.sh
+++ b/scripts/run-storyboards-matrix.sh
@@ -21,7 +21,7 @@ bash "${SCRIPT_DIR}/overlay-compliance-cache.sh" || true
 # .github/workflows/training-agent-storyboards.yml.
 TENANTS=(
   "signals:66:54"
-  "sales:65:252"
+  "sales:67:252"
   "governance:65:101"
   "creative:66:114"
   "creative-builder:60:96"

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -136,7 +136,25 @@ const KNOWN_FAILING_STORYBOARDS: ReadonlyMap<string, string> = new Map([
  * upstream issue and skipping the whole storyboard would lose passing
  * coverage. Track every entry with a linked issue.
  */
-const KNOWN_FAILING_STEPS: ReadonlyMap<string, string> = new Map([]);
+const KNOWN_FAILING_STEPS: ReadonlyMap<string, string> = new Map([
+  // The v5 createMediaBuy handler returns a hand-rolled
+  // `{ status: 'submitted', task_id }` envelope when the
+  // `force_create_media_buy_arm` directive is set. The v6 framework's
+  // projector rejects that shape (`from-platform.js:1438`) — the only
+  // way into the submitted arm is via `ctx.handoffToTask(fn)`, which
+  // assigns a framework-issued task_id. The test-controller directive
+  // requires the seller to return the CALLER-supplied task_id, so
+  // `handoffToTask` cannot satisfy the contract until the SDK exposes
+  // a `{ task_id }` overload. Tracked at adcp-client#1554.
+  ['media_buy_seller/create_media_buy_async/create_media_buy_submitted', 'adcp-client#1554 — handoffToTask needs caller-supplied task_id overload to satisfy force_create_media_buy_arm contract'],
+  // The SDK storyboard runner drops extension params (e.g.
+  // `vendor_metric_values`) from `comply_test_controller` requests
+  // before they reach the wire — the agent's `simulate_delivery`
+  // handler never sees the array, so the downstream
+  // get_media_buy_delivery assertion finds nothing on
+  // `by_package[].vendor_metric_values`. Tracked at adcp-client#1552.
+  ['media_buy_seller/vendor_metric_accountability/get_delivery_with_vendor_metrics', 'adcp-client#1552 — runner drops vendor_metric_values from comply_test_controller params before wire'],
+]);
 
 function isApplicable(sb: Storyboard): boolean {
   if (filter && !sb.id.includes(filter) && !(sb.category ?? '').includes(filter)) return false;


### PR DESCRIPTION
## Summary

Two storyboard steps on `/sales` fail on framework-routed sellers due to SDK gaps. Adding both to `KNOWN_FAILING_STEPS` with linked source-of-truth issues so the runner reports them as skipped rather than failed; ratcheting the /sales floor to capture the lift.

**Step 1: `media_buy_seller/create_media_buy_async/create_media_buy_submitted`** — adcp-client#1554

The v5 `createMediaBuy` handler returns a hand-rolled `{ status: 'submitted', task_id }` envelope when the `force_create_media_buy_arm` directive is set. The v6 framework's projector (`from-platform.js:1438`) rejects that shape — the only path into the submitted arm is `ctx.handoffToTask(fn)`, which assigns a framework-issued task_id. The test-controller directive requires the seller to return the **caller-supplied** task_id (so the runner can assert against `forced.task_id`), which `handoffToTask` cannot satisfy until the SDK exposes a `{ task_id }` overload.

**Step 2: `media_buy_seller/vendor_metric_accountability/get_delivery_with_vendor_metrics`** — adcp-client#1552

The SDK runner drops extension params (e.g. `vendor_metric_values`) from `comply_test_controller` requests before they hit the wire. The agent's `simulate_delivery` handler never sees the array, so the downstream delivery assertion finds nothing on `by_package[].vendor_metric_values`. Pure runner gap — the spec declares `params` as passthrough.

Floor lift on /sales:

| Tenant  | Old | New | Delta |
|---------|-----|-----|-------|
| /sales  | 65 / 252 | 67 / 252 | +2 / 0 |

Both skipped storyboards (`create_media_buy_async`, `vendor_metric_accountability`) now grade clean — only one step is skipped per storyboard; the rest pass.

Other tenants flat — these storyboards are sales-only.

## Test plan

- [x] Local matrix run — all six tenants pass new floors
- [ ] CI matrix run on PR
- [ ] Once adcp-client#1552 + adcp-client#1554 ship: drop the skip entries, ratchet floor again

🤖 Generated with [Claude Code](https://claude.com/claude-code)