### PR TITLE
fix(training-agent): wire PostgresStateStore (root cause of tenant init fast-reject)

### DIFF
--- a/.changeset/training-agent-tenant-init-diagnostics.md
+++ b/.changeset/training-agent-tenant-init-diagnostics.md
@@ -1,0 +1,19 @@
+---
+---
+
+fix(training-agent): surface tenant registry init failures + boot-phase timing
+
+Wraps `await holder.get()` in `tenantMcpHandler` with a `try/catch` that
+logs the rejection (message, name, stack, cause) and returns a JSON-RPC
+503 instead of letting the unhandled rejection escape to Express's
+default error handler — which produced an HTML 500 with no JSON body
+and no log entry tying the error to the rejected promise. The
+post-deploy smoke had been catching the symptom for several deploys
+without enough context to identify the cause.
+
+Also adds boot-phase timing in `createRegistryHolder` so each phase is
+visible: registry construction, per-tenant config build, per-tenant
+register elapsed, and aggregate totals. Init takes ~14ms locally; the
+new logs let us see which phase is blowing up the budget on a fresh
+Fly machine. Per-tenant register failures are logged with stack before
+re-throwing so a single bad tenant doesn't hide behind `Promise.all`.

--- a/.changeset/wire-postgres-state-store.md
+++ b/.changeset/wire-postgres-state-store.md
@@ -1,0 +1,22 @@
+---
+---
+
+fix(training-agent): wire PostgresStateStore so tenant init stops fast-rejecting in production
+
+Root cause confirmed via the diagnostic logging from #4067: every fresh
+Fly machine logs `createAdcpServer: in-memory state store refused
+outside {NODE_ENV=test, NODE_ENV=development}` for all six tenants
+within ~13ms of boot. SDK 6.0.1 hard-refuses the module-singleton
+`InMemoryStateStore` for multi-tenant deployments — and we never wired
+a non-default store, so every `register()` throws and the registry
+stays uninitialized indefinitely.
+
+Adds `pickStateStore()` mirroring the existing `pickTaskRegistry()`
+policy: `PostgresStateStore` in production, `InMemoryStateStore`
+elsewhere. Re-throws on prod-pool init failure rather than falling back
+(falling back would just re-trip the same SDK guard with extra confusion).
+
+Migration `466_adcp_state.sql` — verbatim from the SDK's
+`ADCP_STATE_MIGRATION` constant. Idempotent
+(`CREATE TABLE IF NOT EXISTS`); runs once via `release_command` before
+machine rolls.

--- a/server/src/db/migrations/466_adcp_state.sql
+++ b/server/src/db/migrations/466_adcp_state.sql
@@ -1,0 +1,37 @@
+-- Postgres-backed state store for the multi-tenant training-agent runtime.
+--
+-- The SDK's `createAdcpServer` defaults to an in-memory module-singleton
+-- state store, which 6.0.1 hard-refuses under `NODE_ENV=production` for
+-- multi-tenant deployments — process-shared state would leak across
+-- resolved tenants. Without this table the registry init throws six
+-- times (one per tenant) on a fresh Fly machine and every tenant route
+-- returns 500 until first restart heals nothing.
+--
+-- This migration is the SDK-shipped DDL from `ADCP_STATE_MIGRATION`
+-- (verbatim — do not edit). Wiring happens in
+-- `server/src/training-agent/tenants/registry.ts` via
+-- `new PostgresStateStore(getPool())`.
+--
+-- Idempotent (CREATE TABLE IF NOT EXISTS + ADD COLUMN IF NOT EXISTS).
+-- Safe to re-run if the SDK's migration is bumped, with the caveat that
+-- schema-widening changes will need their own follow-up migration.
+
+CREATE TABLE IF NOT EXISTS adcp_state (
+  collection    TEXT NOT NULL,
+  id            TEXT NOT NULL,
+  data          JSONB NOT NULL,
+  version       INTEGER NOT NULL DEFAULT 1,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  PRIMARY KEY (collection, id)
+);
+
+ALTER TABLE adcp_state
+  ADD COLUMN IF NOT EXISTS version INTEGER NOT NULL DEFAULT 1;
+
+CREATE INDEX IF NOT EXISTS idx_adcp_state_collection
+  ON adcp_state(collection);
+
+CREATE INDEX IF NOT EXISTS idx_adcp_state_updated
+  ON adcp_state(updated_at);

--- a/server/src/training-agent/tenants/registry.ts
+++ b/server/src/training-agent/tenants/registry.ts
@@ -204,32 +204,58 @@ export function createRegistryHolder(): RegistryHolder {
       if (registry) return registry;
       if (pendingInit) return pendingInit;
       const promise = (async () => {
+        const t0 = Date.now();
+        logger.info('Tenant registry init starting');
         const hostBase = buildHostBaseUrl();
         const reg = createTenantRegistry({
           defaultServerOptions: buildDefaultServerOptions(),
           jwksValidator: noopJwksValidator,
           autoValidate: true,
         });
-        const signals = buildSignalsTenantConfig(hostBase);
-        const sales = buildSalesTenantConfig(hostBase);
-        const governance = buildGovernanceTenantConfig(hostBase);
-        const creative = buildCreativeTenantConfig(hostBase);
-        const creativeBuilder = buildCreativeBuilderTenantConfig(hostBase);
-        const brand = buildBrandTenantConfig(hostBase);
+        const tCreate = Date.now();
+        const configs = [
+          { id: 'signals', cfg: buildSignalsTenantConfig(hostBase) },
+          { id: 'sales', cfg: buildSalesTenantConfig(hostBase) },
+          { id: 'governance', cfg: buildGovernanceTenantConfig(hostBase) },
+          { id: 'creative', cfg: buildCreativeTenantConfig(hostBase) },
+          { id: 'creative-builder', cfg: buildCreativeBuilderTenantConfig(hostBase) },
+          { id: 'brand', cfg: buildBrandTenantConfig(hostBase) },
+        ] as const;
+        const tConfigs = Date.now();
         // awaitFirstValidation:true blocks until the no-op validator
         // promotes the tenant to 'healthy'. Without it the first request
         // would race the background validation and see 'pending' (refused
         // traffic) for the first ~10ms.
-        await Promise.all([
-          reg.register(signals.tenantId, signals.config, { awaitFirstValidation: true }),
-          reg.register(sales.tenantId, sales.config, { awaitFirstValidation: true }),
-          reg.register(governance.tenantId, governance.config, { awaitFirstValidation: true }),
-          reg.register(creative.tenantId, creative.config, { awaitFirstValidation: true }),
-          reg.register(creativeBuilder.tenantId, creativeBuilder.config, { awaitFirstValidation: true }),
-          reg.register(brand.tenantId, brand.config, { awaitFirstValidation: true }),
-        ]);
+        await Promise.all(
+          configs.map(async ({ id, cfg }) => {
+            const start = Date.now();
+            try {
+              await reg.register(cfg.tenantId, cfg.config, { awaitFirstValidation: true });
+              logger.info({ tenantId: id, elapsedMs: Date.now() - start }, 'Tenant registered');
+            } catch (err) {
+              logger.error(
+                {
+                  err,
+                  errMessage: err instanceof Error ? err.message : String(err),
+                  errStack: err instanceof Error ? err.stack : undefined,
+                  tenantId: id,
+                  elapsedMs: Date.now() - start,
+                },
+                'Tenant register failed',
+              );
+              throw err;
+            }
+          }),
+        );
         logger.info(
-          { hostBase, tenants: ['signals', 'sales', 'governance', 'creative', 'creative-builder', 'brand'] },
+          {
+            hostBase,
+            createMs: tCreate - t0,
+            configBuildMs: tConfigs - tCreate,
+            registerMs: Date.now() - tConfigs,
+            totalMs: Date.now() - t0,
+            tenants: configs.map(c => c.id),
+          },
           'Tenant registry initialized',
         );
         registry = reg;

--- a/server/src/training-agent/tenants/registry.ts
+++ b/server/src/training-agent/tenants/registry.ts
@@ -28,6 +28,9 @@ import {
   createTenantRegistry,
   createPostgresTaskRegistry,
   createInMemoryTaskRegistry,
+  InMemoryStateStore,
+  PostgresStateStore,
+  type AdcpStateStore,
   type TenantRegistry,
   type TaskRegistry,
   type CreateAdcpServerFromPlatformOptions,
@@ -145,6 +148,38 @@ function pickTaskRegistry(): TaskRegistry {
   }
 }
 
+/**
+ * Pick the state store. Mirrors `pickTaskRegistry` policy: Postgres in
+ * production, in-memory in dev/test.
+ *
+ * SDK 6.0.1 hard-refuses the module-singleton `InMemoryStateStore`
+ * default outside `{NODE_ENV=test, development}` because multi-tenant
+ * deployments would silently share state across resolved tenants. Each
+ * tenant `register()` runs `createAdcpServer` for that tenant's platform
+ * and trips this guard if `stateStore` is absent. Wire `PostgresStateStore`
+ * in production; fall back to a fresh `InMemoryStateStore` per
+ * registry-construction in dev/test (matches the legacy v5 default and
+ * keeps tests isolated).
+ *
+ * Migration: `server/src/db/migrations/466_adcp_state.sql`.
+ */
+function pickStateStore(): AdcpStateStore {
+  const isProd = process.env.NODE_ENV === 'production';
+  if (!isProd) {
+    return new InMemoryStateStore();
+  }
+  try {
+    return new PostgresStateStore(getPool());
+  } catch (err) {
+    logger.error(
+      { err },
+      'Postgres state store init failed in production. Verify migration 466 ran and DATABASE_URL is set. ' +
+        'Falling back to in-memory will trip the SDK production guard — re-throwing.',
+    );
+    throw err;
+  }
+}
+
 function buildDefaultServerOptions(): CreateAdcpServerFromPlatformOptions {
   return {
     name: 'adcp-training-agent',
@@ -152,6 +187,7 @@ function buildDefaultServerOptions(): CreateAdcpServerFromPlatformOptions {
     idempotency: getIdempotencyStore(),
     webhooks: getWebhookSigningMaterial(),
     taskRegistry: pickTaskRegistry(),
+    stateStore: pickStateStore(),
     mergeSeam: 'log-once',
     validation: { requests: 'off', responses: 'off' },
     // F11 — accept loopback push_notification_config.url in non-production.

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -65,14 +65,11 @@ function tenantMcpHandler(holder: RegistryHolder, tenantId: string) {
     }
 
     const host = resolveTenantHost(req);
-    let registry;
-    try {
-      registry = await holder.get();
-    } catch (err) {
-      // Surfacing the rejection here is what made #3854/#3869-class bugs
-      // visible. Without this, init failures escape to Express's default
-      // error handler — the smoke sees an HTML 500 with no JSON body and
-      // no log entry tying the error to the rejected promise.
+    const registry = await holder.get().catch((err: unknown) => {
+      // Surfacing the rejection here is what makes #3854 / #3869-class
+      // init bugs visible. Without it the rejection escapes to Express's
+      // default error handler — the smoke sees an HTML 500 with no JSON
+      // body and no log entry tying the error to the rejected promise.
       logger.error(
         {
           err,
@@ -85,13 +82,20 @@ function tenantMcpHandler(holder: RegistryHolder, tenantId: string) {
         },
         'tenant registry init rejected — request failed before dispatch',
       );
+      // 503 + Retry-After matches the SDK's documented contract for
+      // pending tenants (`tenant-registry.d.ts`: "host transport should
+      // respond 503 + Retry-After"). 5s is short enough that the smoke's
+      // 8s retry catches a transient warmup, long enough for a fresh
+      // Fly machine to finish per-tenant register.
+      res.setHeader('Retry-After', '5');
       res.status(503).json({
         jsonrpc: '2.0',
         id: null,
         error: { code: -32000, message: 'Tenant registry warming up; retry shortly' },
       });
-      return;
-    }
+      return null;
+    });
+    if (registry === null) return;
     const resolved = registry.resolveByRequest(host, `/${tenantId}/mcp`);
     if (!resolved) {
       logger.warn(

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -65,7 +65,33 @@ function tenantMcpHandler(holder: RegistryHolder, tenantId: string) {
     }
 
     const host = resolveTenantHost(req);
-    const registry = await holder.get();
+    let registry;
+    try {
+      registry = await holder.get();
+    } catch (err) {
+      // Surfacing the rejection here is what made #3854/#3869-class bugs
+      // visible. Without this, init failures escape to Express's default
+      // error handler — the smoke sees an HTML 500 with no JSON body and
+      // no log entry tying the error to the rejected promise.
+      logger.error(
+        {
+          err,
+          errMessage: err instanceof Error ? err.message : String(err),
+          errName: err instanceof Error ? err.name : undefined,
+          errStack: err instanceof Error ? err.stack : undefined,
+          errCause: err instanceof Error ? (err as Error & { cause?: unknown }).cause : undefined,
+          tenantId,
+          host,
+        },
+        'tenant registry init rejected — request failed before dispatch',
+      );
+      res.status(503).json({
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: -32000, message: 'Tenant registry warming up; retry shortly' },
+      });
+      return;
+    }
     const resolved = registry.resolveByRequest(host, `/${tenantId}/mcp`);
     if (!resolved) {
       logger.warn(
@@ -164,7 +190,13 @@ export function mountTenantRoutes(
   // the next request retries.
   holder.get().catch((err) => {
     logger.error(
-      { err },
+      {
+        err,
+        errMessage: err instanceof Error ? err.message : String(err),
+        errName: err instanceof Error ? err.name : undefined,
+        errStack: err instanceof Error ? err.stack : undefined,
+        errCause: err instanceof Error ? (err as Error & { cause?: unknown }).cause : undefined,
+      },
       'Eager tenant registry init failed at boot; per-request init will retry',
     );
   });


### PR DESCRIPTION
## Summary

The diagnostic logging from #4067 caught it on first deploy:

```
createAdcpServer: in-memory state store refused outside
{NODE_ENV=test, NODE_ENV=development}
```

All six tenant `register()` calls fail within ~13ms of boot. SDK 6.0.1 hard-refuses the module-singleton `InMemoryStateStore` for multi-tenant deployments — and we never wired a non-default `stateStore` in `defaultServerOptions`. Every `createAdcpServer` call inside `register()` threw, `Promise.all` rejected, `holder.get()` rejected, and tenant routes returned 503 indefinitely (HTML 500 before #4067).

## What changed

1. **`pickStateStore()`** in `server/src/training-agent/tenants/registry.ts` mirrors `pickTaskRegistry()`: `PostgresStateStore` in production, `InMemoryStateStore` in dev/test. Re-throws on prod-pool failure rather than falling back (in-memory fallback would just re-trip the SDK guard).
2. Wires `stateStore: pickStateStore()` into `buildDefaultServerOptions()`.
3. **Migration `466_adcp_state.sql`** — verbatim from the SDK's `ADCP_STATE_MIGRATION` constant. Idempotent (`CREATE TABLE IF NOT EXISTS` + `ADD COLUMN IF NOT EXISTS`); runs once via Fly's `release_command` before machines roll.

## Test plan

- [x] `npx tsc -p server/tsconfig.json --noEmit` clean
- [x] `tenant-smoke.test.ts` + `sync-accounts-gates.test.ts` 14/14 pass
- [x] Training-agent integration suite 25/25 pass
- [x] Reviewed by `code-reviewer` and `python-expert` — no blockers
- [ ] After merge: deploy completes; smoke returns 200/401/403 (not 503); fly logs show `Tenant registry initialized` with `totalMs` < 1s

## Rollback

If the migration succeeds but the wiring trips: revert this PR (the registry change), then `DROP TABLE adcp_state` via psql. Reverting the registry without dropping the table is also safe — the table just sits empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)