### PR TITLE
fix(training-agent): defer state-store pool lookup so first-attempt boot succeeds

### DIFF
--- a/.changeset/lazy-state-store-pool.md
+++ b/.changeset/lazy-state-store-pool.md
@@ -1,0 +1,20 @@
+---
+---
+
+fix(training-agent): defer pool lookup in pickStateStore so first-attempt boot succeeds
+
+The state-store fix in #4071 unblocked deploys but exposed a boot-ordering
+race: `mountTenantRoutes()` runs before `initializeDatabase()`, so the
+eager `holder.get()` at boot calls `getPool()` and throws "Database not
+initialized." The eager-mount catch resets `pendingInit`, the next
+request retries, and by then the pool is up — so production heals
+within ~5s. Visible in the post-#4071 deploy logs:
+
+  T+0  init starting → "Database not initialized" (eager fail)
+  T+5  init starting → "Tenant registry initialized" totalMs=27 (heals)
+
+Wrap the pool in a lazy `PgQueryable` so `getPool()` runs at first query,
+not at construction. Construction now always succeeds; by the time a
+tool touches `ctx.store`, the pool is initialized regardless of mount
+order. Eliminates one round-trip of boot retry and the noisy first
+error.

--- a/server/src/training-agent/tenants/registry.ts
+++ b/server/src/training-agent/tenants/registry.ts
@@ -157,9 +157,13 @@ function pickTaskRegistry(): TaskRegistry {
  * deployments would silently share state across resolved tenants. Each
  * tenant `register()` runs `createAdcpServer` for that tenant's platform
  * and trips this guard if `stateStore` is absent. Wire `PostgresStateStore`
- * in production; fall back to a fresh `InMemoryStateStore` per
- * registry-construction in dev/test (matches the legacy v5 default and
- * keeps tests isolated).
+ * in production; use a fresh `InMemoryStateStore` in dev/test.
+ *
+ * The pool is resolved lazily through a `PgQueryable` adapter — calling
+ * `getPool()` at construction would fail because `mountTenantRoutes()`
+ * runs before `initializeDatabase()` in the boot order. Deferring the
+ * lookup to first query lets construction succeed; by the time a tool
+ * actually touches `ctx.store`, the pool is initialized.
  *
  * Migration: `server/src/db/migrations/466_adcp_state.sql`.
  */
@@ -168,16 +172,10 @@ function pickStateStore(): AdcpStateStore {
   if (!isProd) {
     return new InMemoryStateStore();
   }
-  try {
-    return new PostgresStateStore(getPool());
-  } catch (err) {
-    logger.error(
-      { err },
-      'Postgres state store init failed in production. Verify migration 466 ran and DATABASE_URL is set. ' +
-        'Falling back to in-memory will trip the SDK production guard — re-throwing.',
-    );
-    throw err;
-  }
+  const lazyPool = {
+    query: (text: string, values?: unknown[]) => getPool().query(text, values),
+  };
+  return new PostgresStateStore(lazyPool);
 }
 
 function buildDefaultServerOptions(): CreateAdcpServerFromPlatformOptions {


### PR DESCRIPTION
## Summary

The state-store wiring in #4071 unblocked deploys but exposed a boot-ordering race. `mountTenantRoutes()` runs before `initializeDatabase()`, so the eager `holder.get()` at boot calls `getPool()` and throws `Database not initialized`. The diagnostic logging from #4067 caught it cleanly:

```
T+0  init starting → "Database not initialized" (eager fail)
T+5  init starting → "Tenant registry initialized" totalMs=27 (heals)
```

The retry path papers over this within ~5s, but the noisy first error and the implicit dependency on retry timing are both unnecessary.

## What changed

Wrap the pool in a lazy `PgQueryable` so `getPool()` runs at first query, not at construction. Construction always succeeds; by the time a tool touches `ctx.store`, the pool is initialized regardless of mount order.

```ts
const lazyPool = {
  query: (text: string, values?: unknown[]) => getPool().query(text, values),
};
return new PostgresStateStore(lazyPool);
```

## Test plan

- [x] `npx tsc -p server/tsconfig.json --noEmit` clean
- [x] `tenant-smoke.test.ts` passes
- [ ] After merge: deploy completes; fly logs show `Tenant registry initialized` on first attempt with no preceding `Database not initialized` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)