### PR TITLE
fix(training-agent): defer pickTaskRegistry pool lookup so prod uses Postgres on cold boot

### DIFF
--- a/.changeset/lazy-task-registry-pool.md
+++ b/.changeset/lazy-task-registry-pool.md
@@ -1,0 +1,27 @@
+---
+---
+
+fix(training-agent): defer pool lookup in pickTaskRegistry so production actually uses Postgres on cold boot
+
+Same boot-ordering issue the state-store fix in #4072 closed: `mountTenantRoutes()`
+runs before `initializeDatabase()`, so `getPool()` at construction throws
+"Database not initialized." `pickTaskRegistry`'s try/catch silently
+falls back to the in-memory task registry — meaning every cold-booted
+production machine has been running with `InMemoryTaskRegistry` since
+#463 shipped, defeating the whole point of `adcp_decisioning_tasks`.
+Buyer creates a media buy on machine A, polls on machine B, sees
+"task not found" with ~50% probability.
+
+Surfaced by the diagnostic logging from #4067 — the post-#4072 deploy
+log showed:
+
+```
+"Database not initialized" at pickTaskRegistry (registry.js:124)
+```
+
+immediately followed by the success path (state-store now lazy, so
+init completes — but task registry was already swapped to in-memory).
+
+Wrap the pool in the same lazy `PgQueryable` adapter `pickStateStore`
+uses. `getPool()` runs at first query, by which time the DB is up.
+The Postgres backend now actually gets used in production.

--- a/server/src/training-agent/tenants/registry.ts
+++ b/server/src/training-agent/tenants/registry.ts
@@ -125,8 +125,16 @@ export function resolveTenantHost(_req: Request): string {
  * use Postgres — we run multiple Fly machines and an in-memory registry
  * would lose task state across instances (buyer creates a media buy on
  * machine A, polls on machine B, sees task-not-found). Test / dev fall back
- * to in-memory: tests don't initialize the postgres pool and the SDK's
- * `getPool()` throws if called before `initializeDatabase()`.
+ * to in-memory: tests don't initialize the postgres pool.
+ *
+ * The pool is resolved lazily through a `PgQueryable` adapter so
+ * `getPool()` doesn't fire at construction. `mountTenantRoutes()` runs
+ * before `initializeDatabase()` in the boot order — calling `getPool()`
+ * eagerly threw "Database not initialized," and the catch silently
+ * downgraded production to the in-memory registry on every cold boot,
+ * defeating the whole point of the Postgres backend. Deferring the
+ * lookup to first query keeps construction safe and lets the Postgres
+ * registry actually be used after the DB is up.
  *
  * Migration for `adcp_decisioning_tasks` lives at
  * `server/src/db/migrations/463_adcp_decisioning_tasks.sql`.
@@ -136,16 +144,10 @@ function pickTaskRegistry(): TaskRegistry {
   if (!isProd) {
     return createInMemoryTaskRegistry();
   }
-  try {
-    return createPostgresTaskRegistry({ pool: getPool() });
-  } catch (err) {
-    logger.error(
-      { err },
-      'Postgres task registry init failed in production — falling back to in-memory. ' +
-        'Multi-instance task polling will be flaky. Verify migration 463 ran and DATABASE_URL is set.',
-    );
-    return createInMemoryTaskRegistry();
-  }
+  const lazyPool = {
+    query: (text: string, values?: unknown[]) => getPool().query(text, values),
+  };
+  return createPostgresTaskRegistry({ pool: lazyPool });
 }
 
 /**


### PR DESCRIPTION
## Summary

The diagnostic logging from #4067 + the state-store fix in #4072 surfaced a long-standing silent regression:

```
"Database not initialized" at pickTaskRegistry (registry.js:124)
```

Same root cause as #4072. `mountTenantRoutes()` runs before `initializeDatabase()`, so `getPool()` at construction throws. `pickTaskRegistry`'s try/catch silently downgrades to `InMemoryTaskRegistry` — meaning **every cold-booted production machine has been running with the in-memory registry since #463 shipped**, defeating the whole point of `adcp_decisioning_tasks`. Buyer creates a media buy on machine A, polls on machine B, sees "task not found" with ~50% probability.

## What changed

Wrap the pool in the same lazy `PgQueryable` adapter `pickStateStore` uses (#4072). `getPool()` runs at first query, not at construction; by then the DB is initialized.

```ts
const lazyPool = {
  query: (text: string, values?: unknown[]) => getPool().query(text, values),
};
return createPostgresTaskRegistry({ pool: lazyPool });
```

Drops the try/catch entirely — there's no scenario where construction can fail now, and a real DB error at first query should surface, not be swallowed.

## Test plan

- [x] `npx tsc -p server/tsconfig.json --noEmit` clean
- [x] tenant-smoke 3/3 pass
- [ ] After merge: deploy completes; fly logs show `Tenant registry initialized` with no preceding `Database not initialized` from pickTaskRegistry

🤖 Generated with [Claude Code](https://claude.com/claude-code)