### PR TITLE
fix(addie): stop Sage passing demo.example.com as brand_id in C2 demos

### DIFF
--- a/.changeset/fix-c2-brand-demo-domain-instruction.md
+++ b/.changeset/fix-c2-brand-demo-domain-instruction.md
@@ -1,0 +1,11 @@
+---
+---
+
+Fix C2 sandbox brand demo: Sage was passing demo.example.com as a brand_id to
+get_brand_identity (REFERENCE_NOT_FOUND), because the system prompt emitted
+"Use brand domain demo.example.com for the account" unconditionally for all
+active modules. Removed the unconditional instruction; made the per-lesson demo
+block emit tool-specific guidance (buyer domain only for acquire_rights/sync_accounts,
+brand_id reminder only for get_brand_identity). Also de-hardcoded the get_products
+reference in the generic teaching rules so non-sales-track modules don't get
+wrong tool guidance.

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.04.6';
+export const CODE_VERSION = '2026.05.1';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -507,7 +507,7 @@ export async function buildCertificationContext(
   lines.push('- First turn: greet the learner and ask about their background. Never run tools on the first turn.');
   lines.push('- NEVER re-ask something the learner already told you. If they said "I work at an audio SSP" do NOT later ask "are you on the buy side or sell side?" — they already told you (sell side, SSP). If they said "I run programmatic at an agency" do NOT ask "what is your role?" This is the #1 complaint from learners. Before asking ANY question about the learner, check: did they already answer this? If yes, use what they said.');
   lines.push('- If you research the learner\'s company, USE that knowledge — never ask them to explain what their company does. Instead, weave it into your teaching: "Given that Acme is an audio SSP, how would you..." Asking someone about their own company after you already looked it up feels like surveillance, not personalization.');
-  lines.push('- Run ONE live demo (get_products against the sandbox training agent) on turn 2-3. Do not wait for the learner to ask. Show, then discuss. After the initial demo, do NOT keep running demos every turn — use the demo result as a reference point for teaching.');
+  lines.push('- If the module has sandbox demo scenarios listed below: run ONE live demo using the first scenario\'s tool on turn 2-3. Do not wait for the learner to ask. Show, then discuss. After the initial demo, do NOT keep running demos every turn — use the demo result as a reference point for teaching.');
   lines.push('- Use concrete, specific language. Never use abstract terms without grounding them. Say "evaluate whether a placement fits" not "reason about impressions."');
   lines.push('- Only assess what you actually taught in the conversation. Never test doc-only details or claim "we covered this" if you didn\'t.');
   lines.push('- If a demo fails, pivot immediately. Never offer the same failed demo twice.');
@@ -517,7 +517,7 @@ export async function buildCertificationContext(
   lines.push('');
   lines.push('**Mastery model**: There is no failing — teach until the learner masters every objective, then complete the module. Never share scores or percentages with the learner. Internal scores are for admin analytics only.');
   lines.push('');
-  lines.push('**Mastery fast-track (CHECK EVERY TURN after turn 3)**: Teaching and assessment serve different purposes. Teaching is for the learner; assessment is for the credential. After each learner response, ask: "Has this learner given correct, detailed answers to 3+ concepts without needing correction?" If YES: (1) STOP running demos — no more get_products calls, (2) SAY SO: "You clearly know this material — I\'m going to skip the tutorial and have you demonstrate the remaining concepts directly," (3) for each remaining concept, ask ONE targeted demonstration question (scenario-based, teach-back, or "walk me through") that produces auditable evidence of competency. The conversation transcript is the audit trail — the learner\'s own words showing they understand each dimension. Same scoring rubric, same dimension requirements, same minimum engagement — just no unnecessary instruction. Continuing to teach or demo after someone has demonstrated mastery is the #1 learner complaint.');
+  lines.push('**Mastery fast-track (CHECK EVERY TURN after turn 3)**: Teaching and assessment serve different purposes. Teaching is for the learner; assessment is for the credential. After each learner response, ask: "Has this learner given correct, detailed answers to 3+ concepts without needing correction?" If YES: (1) STOP running demos — no more sandbox tool calls, (2) SAY SO: "You clearly know this material — I\'m going to skip the tutorial and have you demonstrate the remaining concepts directly," (3) for each remaining concept, ask ONE targeted demonstration question (scenario-based, teach-back, or "walk me through") that produces auditable evidence of competency. The conversation transcript is the audit trail — the learner\'s own words showing they understand each dimension. Same scoring rubric, same dimension requirements, same minimum engagement — just no unnecessary instruction. Continuing to teach or demo after someone has demonstrated mastery is the #1 learner complaint.');
 
   lines.push('**Protocol accuracy (non-negotiable)**: When a learner asks about protocol details (field definitions, message flows, terminology, agent roles), use search_docs or search_repos to verify before answering. Never construct protocol answers from general knowledge. If you cannot verify, say "I need to check that" and search. Teaching mode does not override accuracy — a wrong answer during certification is worse than saying "let me look that up."');
   lines.push('');
@@ -554,7 +554,6 @@ export async function buildCertificationContext(
   lines.push('');
   lines.push('**Sandbox training agent**:');
   lines.push(formatTenantBlock(tenants));
-  lines.push('Use brand domain "demo.example.com" for the account.');
 
   // Inject cross-module learner profile from completed modules
   if (userId) {
@@ -1434,6 +1433,13 @@ export function createCertificationToolHandlers(
             lines.push(`Expected outcome: ${ds.expected_outcome}`);
             lines.push('');
           });
+          const scenarioTools = lp.demo_scenarios.flatMap(ds => ds.tools);
+          if (scenarioTools.some(t => ['acquire_rights', 'sync_accounts'].includes(t))) {
+            lines.push('For acquire_rights / sync_accounts buyer.domain: use "demo.example.com".');
+          }
+          if (scenarioTools.includes('get_brand_identity')) {
+            lines.push('For get_brand_identity: pass a brand_id from the tool\'s "Available brands" list — not a domain name.');
+          }
         }
       }
 
@@ -1555,7 +1561,13 @@ export function createCertificationToolHandlers(
           lp.demo_scenarios.forEach(ds => {
             lines.push(`- ${ds.description} (tools: ${ds.tools.join(', ')})`);
           });
-          lines.push('Use brand domain "demo.example.com" for the account.');
+          const scenarioTools = lp.demo_scenarios.flatMap(ds => ds.tools);
+          if (scenarioTools.some(t => ['acquire_rights', 'sync_accounts'].includes(t))) {
+            lines.push('For acquire_rights / sync_accounts buyer.domain: use "demo.example.com".');
+          }
+          if (scenarioTools.includes('get_brand_identity')) {
+            lines.push('For get_brand_identity: pass a brand_id from the tool\'s "Available brands" list — not a domain name.');
+          }
           lines.push('');
         }
       }


### PR DESCRIPTION
Closes #4074

During certification module C2 (Brand Protocol), the system prompt unconditionally appended `"Use brand domain "demo.example.com" for the account."` for **all** active modules. When C2 was active, Sage interpreted `demo.example.com` as the `brand_id` for `get_brand_identity`, which expects roster IDs like `daan_janssen` — returning `REFERENCE_NOT_FOUND` and falling back to spec-only teaching.

**Root cause:** `buildCertificationContext` (line 557) appended the buyer-domain hint with no module guard. For brand-track modules, Sage conflated "brand domain" with `get_brand_identity`'s `brand_id` parameter.

**Changes:**
- Remove the unconditional `demo.example.com` instruction from the top-level sandbox-agent block (line 557)
- In both `start_certification_module` and `get_certification_module` demo-scenario blocks (already gated on `lp.demo_scenarios?.length`): emit buyer-domain guidance only when `acquire_rights`/`sync_accounts` is in the scenario tools; emit `brand_id`-roster guidance only when `get_brand_identity` is in the tools
- De-hardcode the `get_products` reference in the generic teaching rule (line 510) so non-sales-track modules get correct tool guidance; add "if the module has demo scenarios" guard
- Replace `no more get_products calls` → `no more sandbox tool calls` in the mastery fast-track rule for consistency
- Bump `CODE_VERSION` → `2026.05.1` for the `buildCertificationContext` behavior change

**Non-breaking justification:** server-side Addie system-prompt change only; no schema, protocol, or wire format touched. Changeset is `--empty`.

**Pre-PR review:**
- code-reviewer: approved — flagged two blockers (missing guard in `get_certification_module` handler; `CODE_VERSION` not bumped), both fixed before this PR was opened. One nit (symmetry in `.includes` vs `.some`) surfaced in PR body.
- education-expert: approved — confirmed `daan_janssen` is the correct C2 canonical example; flagged one blocker (line 510 fires for modules with no demo_scenarios), fixed. IACET-relevant: broken demo constitutes mismatch between stated and delivered instruction.

**Nits (not fixed, noted for follow-up):**
- `c2_ex3` success criteria don't include a step that calls `get_brand_identity` with `authorized: true` to demonstrate the `available_fields` pattern — minor criterion-coverage gap (separate issue)
- `scenarioTools.includes('get_brand_identity')` vs `.some(t => t === 'get_brand_identity')` — minor style inconsistency, not functional

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_019qaFNRgQ5bht7PNJpgHmiR

---
_Generated by [Claude Code](https://claude.ai/code/session_019qaFNRgQ5bht7PNJpgHmiR)_