### PR TITLE
fix(registry-api): downgrade external agent fetch failures from error to warn

### DIFF
--- a/.changeset/agent-fetch-failures-warn-not-error.md
+++ b/.changeset/agent-fetch-failures-warn-not-error.md
@@ -1,0 +1,8 @@
+---
+---
+
+fix(registry-api): downgrade external agent fetch failures from error to warn
+
+`/public/agent-formats` and `/public/agent-products` were logging upstream-agent failures at `error` severity, which paged operators for problems we can't fix (e.g., a non-conformant third-party MCP agent that returns prose-wrapped JSON instead of `structuredContent`).
+
+These are upstream issues, not our system erroring — log at `warn` and return 502 (bad gateway) instead of 500 so it's clear who owns the fix.

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -5849,13 +5849,13 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         }),
       });
     } catch (error) {
-      logger.error({ err: error, url }, "Agent formats fetch error");
+      logger.warn({ err: error, url }, "Agent formats fetch failed");
 
       if (error instanceof Error && error.name === "TimeoutError") {
         return res.status(504).json({ error: "Connection timeout", message: "Agent did not respond within the timeout period" });
       }
 
-      return res.status(500).json({ error: "Failed to fetch formats" });
+      return res.status(502).json({ error: "Failed to fetch formats" });
     }
   });
 
@@ -5894,13 +5894,13 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         })),
       });
     } catch (error) {
-      logger.error({ err: error, url }, "Agent products fetch error");
+      logger.warn({ err: error, url }, "Agent products fetch failed");
 
       if (error instanceof Error && error.name === "TimeoutError") {
         return res.status(504).json({ error: "Connection timeout", message: "Agent did not respond within the timeout period" });
       }
 
-      return res.status(500).json({ error: "Failed to fetch products" });
+      return res.status(502).json({ error: "Failed to fetch products" });
     }
   });
 


### PR DESCRIPTION
## Summary

- `/public/agent-formats` and `/public/agent-products` were logging upstream-agent failures at `error` severity (paged on Celtra non-conformance this morning)
- These are upstream issues, not our system erroring — log at `warn`
- Return `502 Bad Gateway` instead of `500` so the failure attribution is correct

The triggering case: Celtra's MCP agent returns prose-wrapped JSON (`"Available Creative Formats:\n\n {...}"`) without `structuredContent`. The SDK correctly rejects this with `INVALID_RESPONSE`, but we were treating it as our own error.

## Test plan

- [x] `npm run test:unit` (precommit hook)
- [ ] Confirm Addie's error alerts no longer fire on Celtra fetch failures after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)