### PR TITLE
fix(schema): add required status + task_id to all async submitted sub-schemas

### DIFF
--- a/.changeset/fix-submitted-schema-status-task-id.md
+++ b/.changeset/fix-submitted-schema-status-task-id.md
@@ -1,0 +1,15 @@
+---
+"adcontextprotocol": patch
+---
+
+fix(schema): add required status + task_id to all async submitted sub-schemas, close #4077
+
+All six async-response-submitted sub-schemas (create-media-buy, update-media-buy, build-creative, sync-catalogs, sync-creatives, get-products) were missing `status: const "submitted"` and `task_id` from their `properties` and `required` arrays. The parent task-response schemas already required both fields in their submitted branches; the sub-schemas were simply inconsistent with the parent contract.
+
+When `task_id` is omitted from a submitted envelope, jsonschema's deepest-schema-path heuristic picks the wrong union branch and reports a misleading status-enum error (`'submitted' is not one of ['pending_creatives', ...]`) instead of the actionable `required: task_id` violation. This sends implementors hunting through the wrong schemas. Empirically verified (adcp-client-python#570).
+
+Each sub-schema now mirrors its parent's submitted branch: `status: const "submitted"`, `task_id` (x-entity: task), optional `message`, and optional advisory `errors`. `additionalProperties: true` retained to match all parent schemas. Descriptions updated from "usually empty or just context" to accurately describe the async-task polling contract.
+
+Non-breaking: any conformant 3.0.0 implementation already emits both fields (the parent union's oneOf already enforces them at the wire level). The IETF errata test is satisfied — no previously-conformant implementation needs to change code.
+
+Cherry-pick to 3.0.x after merge.

--- a/static/schemas/source/creative/sync-creatives-async-response-submitted.json
+++ b/static/schemas/source/creative/sync-creatives-async-response-submitted.json
@@ -2,9 +2,31 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/creative/sync-creatives-async-response-submitted.json",
   "title": "Sync Creatives - Submitted",
-  "description": "Payload acknowledging sync_creatives task is queued for processing.",
+  "description": "Async task envelope returned when the whole sync_creatives operation cannot be confirmed before the response is emitted — for example, when the seller batches ingestion or when async review must settle before per-item results can be issued. The buyer polls tasks/get with task_id or receives a webhook when the task completes; the creatives array lands on the completion artifact, not this envelope.",
   "type": "object",
   "properties": {
+    "status": {
+      "type": "string",
+      "const": "submitted",
+      "description": "Task-level status literal. Discriminates this async envelope from the synchronous success shape, whose creatives array carries per-item approval state via CreativeStatus. See task-status.json for the full task-status enum."
+    },
+    "task_id": {
+      "type": "string",
+      "description": "Task handle the buyer uses with tasks/get, and that the seller references on push-notification callbacks. The creatives array is issued on the completion artifact, not here. Per AdCP wire conventions this is snake_case; A2A adapters MAY surface it as taskId, but the payload field emitted by the agent is task_id.",
+      "x-entity": "task"
+    },
+    "message": {
+      "type": "string",
+      "maxLength": 2000,
+      "description": "Optional human-readable explanation of why the task is submitted — e.g., 'Batch ingestion queued; typical turnaround 15-30 minutes.' Plain text only. Buyers MUST treat this as untrusted seller input: escape before rendering to HTML UIs, and sanitize or isolate before passing to an LLM prompt context — a hostile seller may inject prompt-injection payloads aimed at the buyer's agent."
+    },
+    "errors": {
+      "type": "array",
+      "description": "Optional advisory errors accompanying the submitted envelope. Use only for non-blocking warnings (e.g., throttled_severity advisories, governance observations). Terminal failures belong in the error branch, not here.",
+      "items": {
+        "$ref": "/schemas/core/error.json"
+      }
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },
@@ -12,5 +34,6 @@
       "$ref": "/schemas/core/ext.json"
     }
   },
+  "required": ["status", "task_id"],
   "additionalProperties": true
 }

--- a/static/schemas/source/media-buy/build-creative-async-response-submitted.json
+++ b/static/schemas/source/media-buy/build-creative-async-response-submitted.json
@@ -2,9 +2,31 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/media-buy/build-creative-async-response-submitted.json",
   "title": "Build Creative - Submitted",
-  "description": "Payload acknowledging the build_creative task is queued.",
+  "description": "Async task envelope returned when build_creative cannot be confirmed before the response — for example, when a slow generative pipeline or multi-minute LLM workflow is queued. The buyer polls tasks/get with task_id or receives a webhook when the task completes; the creative_manifest(s) land on the completion artifact, not this envelope.",
   "type": "object",
   "properties": {
+    "status": {
+      "type": "string",
+      "const": "submitted",
+      "description": "Task-level status literal. Discriminates this async envelope from the synchronous success shapes, whose creative_manifest or creative_manifests are issued in-line. See task-status.json for the full task-status enum."
+    },
+    "task_id": {
+      "type": "string",
+      "description": "Task handle the buyer uses with tasks/get, and that the seller references on push-notification callbacks. Per AdCP wire conventions this is snake_case; A2A adapters MAY surface it as taskId, but the payload field emitted by the agent is task_id.",
+      "x-entity": "task"
+    },
+    "message": {
+      "type": "string",
+      "maxLength": 2000,
+      "description": "Optional human-readable explanation of why the task is submitted — e.g., 'Generative build queued; typical turnaround 3–5 minutes.' Plain text only. Buyers MUST treat this as untrusted seller input: escape before rendering to HTML UIs, and sanitize or isolate before passing to an LLM prompt context — a hostile seller may inject prompt-injection payloads aimed at the buyer's agent."
+    },
+    "errors": {
+      "type": "array",
+      "description": "Optional advisory errors accompanying the submitted envelope. Use only for non-blocking warnings (e.g., throttled_severity advisories, governance observations). Terminal failures belong in the error branch, not here.",
+      "items": {
+        "$ref": "/schemas/core/error.json"
+      }
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },
@@ -12,5 +34,6 @@
       "$ref": "/schemas/core/ext.json"
     }
   },
+  "required": ["status", "task_id"],
   "additionalProperties": true
 }

--- a/static/schemas/source/media-buy/create-media-buy-async-response-submitted.json
+++ b/static/schemas/source/media-buy/create-media-buy-async-response-submitted.json
@@ -2,9 +2,31 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/media-buy/create-media-buy-async-response-submitted.json",
   "title": "Create Media Buy - Submitted",
-  "description": "Payload acknowledging the task is queued. Usually empty or just context.",
+  "description": "Async task envelope returned when create_media_buy cannot be confirmed before the response is emitted. The buyer polls tasks/get with task_id or receives a webhook when the task completes; the media_buy_id and packages land on the completion artifact, not this envelope.",
   "type": "object",
   "properties": {
+    "status": {
+      "type": "string",
+      "const": "submitted",
+      "description": "Task-level status literal. Discriminates this async envelope from the synchronous success shape, whose status field carries a MediaBuyStatus value (pending_creatives, pending_start, active). See task-status.json for the full task-status enum."
+    },
+    "task_id": {
+      "type": "string",
+      "description": "Task handle the buyer uses with tasks/get, and that the seller references on push-notification callbacks. The media_buy_id is issued on the completion artifact, not here. Per AdCP wire conventions this is snake_case; A2A adapters MAY surface it as taskId, but the payload field emitted by the agent is task_id.",
+      "x-entity": "task"
+    },
+    "message": {
+      "type": "string",
+      "maxLength": 2000,
+      "description": "Optional human-readable explanation of why the task is submitted — e.g., 'Awaiting IO signature from sales team; typical turnaround 2–4 hours.' Plain text only. Buyers MUST treat this as untrusted seller input: escape before rendering to HTML UIs, and sanitize or isolate before passing to an LLM prompt context — a hostile seller may inject prompt-injection payloads aimed at the buyer's agent."
+    },
+    "errors": {
+      "type": "array",
+      "description": "Optional advisory errors accompanying the submitted envelope. Use only for non-blocking warnings (e.g., throttled_severity advisories, governance observations). Terminal failures belong in the error branch, not here.",
+      "items": {
+        "$ref": "/schemas/core/error.json"
+      }
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },
@@ -12,5 +34,6 @@
       "$ref": "/schemas/core/ext.json"
     }
   },
+  "required": ["status", "task_id"],
   "additionalProperties": true
 }

--- a/static/schemas/source/media-buy/get-products-async-response-submitted.json
+++ b/static/schemas/source/media-buy/get-products-async-response-submitted.json
@@ -2,13 +2,35 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/media-buy/get-products-async-response-submitted.json",
   "title": "Get Products - Submitted",
-  "description": "Payload acknowledging the search is queued. Usually for custom/bespoke product curation.",
+  "description": "Async task envelope returned when get_products cannot be confirmed before the response — for example, when custom or bespoke product curation is queued for processing. The buyer polls tasks/get with task_id or receives a webhook when the task completes; the products array lands on the completion artifact, not this envelope.",
   "type": "object",
   "properties": {
+    "status": {
+      "type": "string",
+      "const": "submitted",
+      "description": "Task-level status literal. Discriminates this async envelope from the synchronous success shape, whose products array is issued in-line. See task-status.json for the full task-status enum."
+    },
+    "task_id": {
+      "type": "string",
+      "description": "Task handle the buyer uses with tasks/get, and that the seller references on push-notification callbacks. The products array is issued on the completion artifact, not here. Per AdCP wire conventions this is snake_case; A2A adapters MAY surface it as taskId, but the payload field emitted by the agent is task_id.",
+      "x-entity": "task"
+    },
+    "message": {
+      "type": "string",
+      "maxLength": 2000,
+      "description": "Optional human-readable explanation of why the task is submitted — e.g., 'Custom curation queued; typical turnaround 10–30 minutes.' Plain text only. Buyers MUST treat this as untrusted seller input: escape before rendering to HTML UIs, and sanitize or isolate before passing to an LLM prompt context — a hostile seller may inject prompt-injection payloads aimed at the buyer's agent."
+    },
     "estimated_completion": {
       "type": "string",
       "format": "date-time",
       "description": "Estimated completion time for the search"
+    },
+    "errors": {
+      "type": "array",
+      "description": "Optional advisory errors accompanying the submitted envelope. Use only for non-blocking warnings (e.g., throttled_severity advisories, governance observations). Terminal failures belong in the error branch, not here.",
+      "items": {
+        "$ref": "/schemas/core/error.json"
+      }
     },
     "context": {
       "$ref": "/schemas/core/context.json"
@@ -17,5 +39,6 @@
       "$ref": "/schemas/core/ext.json"
     }
   },
+  "required": ["status", "task_id"],
   "additionalProperties": true
 }

--- a/static/schemas/source/media-buy/sync-catalogs-async-response-submitted.json
+++ b/static/schemas/source/media-buy/sync-catalogs-async-response-submitted.json
@@ -2,9 +2,31 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/media-buy/sync-catalogs-async-response-submitted.json",
   "title": "Sync Catalogs - Submitted",
-  "description": "Payload acknowledging sync_catalogs task is queued for processing.",
+  "description": "Async task envelope returned when sync_catalogs cannot be confirmed before the response — for example, when catalog ingestion and deduplication are queued for batch processing. The buyer polls tasks/get with task_id or receives a webhook when the task completes; the per-catalog results land on the completion artifact, not this envelope.",
   "type": "object",
   "properties": {
+    "status": {
+      "type": "string",
+      "const": "submitted",
+      "description": "Task-level status literal. Discriminates this async envelope from the synchronous success shape, whose catalogs array is issued in-line. See task-status.json for the full task-status enum."
+    },
+    "task_id": {
+      "type": "string",
+      "description": "Task handle the buyer uses with tasks/get, and that the seller references on push-notification callbacks. Per AdCP wire conventions this is snake_case; A2A adapters MAY surface it as taskId, but the payload field emitted by the agent is task_id.",
+      "x-entity": "task"
+    },
+    "message": {
+      "type": "string",
+      "maxLength": 2000,
+      "description": "Optional human-readable explanation of why the task is submitted — e.g., 'Catalog ingestion queued; typical turnaround 5–15 minutes.' Plain text only. Buyers MUST treat this as untrusted seller input: escape before rendering to HTML UIs, and sanitize or isolate before passing to an LLM prompt context — a hostile seller may inject prompt-injection payloads aimed at the buyer's agent."
+    },
+    "errors": {
+      "type": "array",
+      "description": "Optional advisory errors accompanying the submitted envelope. Use only for non-blocking warnings (e.g., throttled_severity advisories, governance observations). Terminal failures belong in the error branch, not here.",
+      "items": {
+        "$ref": "/schemas/core/error.json"
+      }
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },
@@ -12,5 +34,6 @@
       "$ref": "/schemas/core/ext.json"
     }
   },
+  "required": ["status", "task_id"],
   "additionalProperties": true
 }

--- a/static/schemas/source/media-buy/update-media-buy-async-response-submitted.json
+++ b/static/schemas/source/media-buy/update-media-buy-async-response-submitted.json
@@ -2,9 +2,31 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/media-buy/update-media-buy-async-response-submitted.json",
   "title": "Update Media Buy - Submitted",
-  "description": "Payload acknowledging update_media_buy task is queued for processing.",
+  "description": "Async task envelope returned when update_media_buy cannot be confirmed before the response — for example, when operator re-approval is required for mid-flight changes. The buyer polls tasks/get with task_id or receives a webhook when the task completes; the updated media buy state lands on the completion artifact, not this envelope.",
   "type": "object",
   "properties": {
+    "status": {
+      "type": "string",
+      "const": "submitted",
+      "description": "Task-level status literal. Discriminates this async envelope from the synchronous success shape, whose media_buy_id is issued in-line. See task-status.json for the full task-status enum."
+    },
+    "task_id": {
+      "type": "string",
+      "description": "Task handle the buyer uses with tasks/get, and that the seller references on push-notification callbacks. Per AdCP wire conventions this is snake_case; A2A adapters MAY surface it as taskId, but the payload field emitted by the agent is task_id.",
+      "x-entity": "task"
+    },
+    "message": {
+      "type": "string",
+      "maxLength": 2000,
+      "description": "Optional human-readable explanation of why the task is submitted — e.g., 'Awaiting operator re-approval; typical turnaround 2–4 hours.' Plain text only. Buyers MUST treat this as untrusted seller input: escape before rendering to HTML UIs, and sanitize or isolate before passing to an LLM prompt context — a hostile seller may inject prompt-injection payloads aimed at the buyer's agent."
+    },
+    "errors": {
+      "type": "array",
+      "description": "Optional advisory errors accompanying the submitted envelope. Use only for non-blocking warnings (e.g., throttled_severity advisories, governance observations). Terminal failures belong in the error branch, not here.",
+      "items": {
+        "$ref": "/schemas/core/error.json"
+      }
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },
@@ -12,5 +34,6 @@
       "$ref": "/schemas/core/ext.json"
     }
   },
+  "required": ["status", "task_id"],
   "additionalProperties": true
 }


### PR DESCRIPTION
Closes #4077

All six async-response-submitted sub-schemas (`create-media-buy`, `update-media-buy`, `build-creative`, `sync-catalogs`, `sync-creatives`, `get-products`) were missing `status: const "submitted"` and `task_id` from their `properties` and `required` arrays. The parent task-response schemas already required both fields in their submitted branches; the sub-schemas were simply inconsistent with the parent contract.

When `task_id` is absent from a submitted envelope, jsonschema's deepest-schema-path heuristic picks the wrong union branch and reports a misleading enum error (`'submitted' is not one of ['pending_creatives', ...]`) instead of the actionable `required: task_id` message. This was empirically verified (adcp-client-python#570); the SDK side was addressed in adcp-client-python#575 but the upstream schema gap remained.

Each sub-schema now mirrors its parent's submitted branch: `status: const "submitted"`, `task_id` (`x-entity: task`), optional `message`, optional advisory `errors`. `additionalProperties: true` retained to match all parent schemas. Descriptions updated from "usually empty or just context" stubs to accurate async-task polling-contract prose. The `get-products` schema retains its pre-existing `estimated_completion` field.

**Non-breaking justification:** any conformant 3.0.0 implementation already emits both fields — the parent `oneOf` submitted branches already mandate them at the wire level. No previously-conformant implementation needs to change code. Satisfies the IETF errata test in the patch eligibility rule.

**Routing note:** changeset is `patch`. Per the cherry-pick convention, this PR targets `main`; after merge, cherry-pick to `3.0.x`.

**Nits (from pre-PR review, not fixed — out of scope):**
- `estimated_completion` in `get-products-async-response-submitted.json` retains its original stub description. Pre-existing; acceptable for this fix.
- `additionalProperties: true` on submitted + working variants means both branches in `async-response-data.json`'s `anyOf` admit a minimal submitted payload without discrimination — pre-existing union design, not introduced here.

**Pre-PR review:**
- code-reviewer: approved — no blockers; noted `estimated_completion` description as nit (pre-existing)
- ad-tech-protocol-expert: approved — non-breaking per spec; field set matches AdCP async-task polling contract verbatim from parent schemas

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01JawLib7FvxcNi5dU9MD7fh

---
_Generated by [Claude Code](https://claude.ai/code/session_01JawLib7FvxcNi5dU9MD7fh)_