### PR TITLE
fix(training-agent): bump @adcp/sdk to 6.11.0, drop both KNOWN_FAILING_STEPS

### DIFF
--- a/.changeset/sdk-6-11-bump-zero-skips.md
+++ b/.changeset/sdk-6-11-bump-zero-skips.md
@@ -1,0 +1,29 @@
+---
+---
+
+fix(training-agent): bump @adcp/sdk to 6.11.0, drop both KNOWN_FAILING_STEPS
+
+6.11.0 ships the two SDK gaps surfaced after the #3965 cluster work — both filed and closed within hours of being identified:
+
+- **adcp-client#1554** — `ctx.handoffToTask(fn, options)` now accepts `TaskHandoffOptions.task_id`. Lets the seller pass a caller-supplied task id through to the framework's submitted-arm projection (required by the `force_create_media_buy_arm` test directive).
+- **adcp-client#1552** — the SDK's `simulate_delivery` dispatcher now spreads params verbatim, so extension fields like `vendor_metric_values` reach the seller's adapter instead of being silently dropped.
+
+Wires both fixes:
+
+- `v6-sales-platform.ts:createMediaBuy` detects the v5 handler's submitted-arm envelope (returned when `force_create_media_buy_arm` is set) and routes it through `ctx.handoffToTask(fn, { task_id })` with the directive's task_id. The handoff fn is a no-op-with-throw because the test directive only asserts on the immediate submitted envelope; production sellers register a real completion handler.
+- Drops both `KNOWN_FAILING_STEPS` entries — both storyboards now pass cleanly with no skips.
+
+Floor lifts (step counts move when previously-skipped steps now pass):
+
+| Tenant            | Old | New | Delta |
+|-------------------|-----|-----|-------|
+| /sales            | 67 / 252 | 67 / 258 | flat / +6 |
+| /governance       | 65 / 101 | 65 / 102 | flat / +1 |
+| /creative         | 66 / 114 | 66 / 118 | flat / +4 |
+| /creative-builder | 60 / 96  | 60 / 100 | flat / +4 |
+| /signals          | 66 / 54  | 66 / 54  | flat |
+| /brand            | 66 / 45  | 66 / 45  | flat |
+
+All six tenants pass with zero failing steps and zero known-failing skips. The conformance suite is fully green on the framework path.
+
+Files: `package.json`, `package-lock.json`, `server/src/training-agent/v6-sales-platform.ts`, `server/tests/manual/run-storyboards.ts`, `.github/workflows/training-agent-storyboards.yml`, `scripts/run-storyboards-matrix.sh`.

--- a/.github/workflows/training-agent-storyboards.yml
+++ b/.github/workflows/training-agent-storyboards.yml
@@ -53,16 +53,16 @@ jobs:
             min_passing_steps: 54
           - tenant: sales
             min_clean_storyboards: 67
-            min_passing_steps: 252
+            min_passing_steps: 258
           - tenant: governance
             min_clean_storyboards: 65
-            min_passing_steps: 101
+            min_passing_steps: 102
           - tenant: creative
             min_clean_storyboards: 66
-            min_passing_steps: 114
+            min_passing_steps: 118
           - tenant: creative-builder
             min_clean_storyboards: 60
-            min_passing_steps: 96
+            min_passing_steps: 100
           - tenant: brand
             min_clean_storyboards: 66
             min_passing_steps: 45

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.0.3",
       "dependencies": {
-        "@adcp/sdk": "^6.9.0",
+        "@adcp/sdk": "^6.11.0",
         "@anthropic-ai/sdk": "^0.91.1",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -122,9 +122,9 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-6.9.0.tgz",
-      "integrity": "sha512-FI8x+SHj1p1c29V0SQ1WUL00H3EeCo2DI+rQP5+aIjD3wauVyq0Tt5XydORw/dTz4BGX61/2r/e5x1ujRj0Pxw==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-6.11.0.tgz",
+      "integrity": "sha512-FZbMxELHVBfEoVomhQUlvS3My7LtYIxD4w+MrofSdtKjmYVX7/f9x2347WxGcY1+kqBxHNtaHoAyMdGr8YXiFw==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "dev:docs": "node scripts/dev-docs.mjs"
   },
   "dependencies": {
-    "@adcp/sdk": "^6.9.0",
+    "@adcp/sdk": "^6.11.0",
     "@anthropic-ai/sdk": "^0.91.1",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",

--- a/scripts/overlay-compliance-cache.sh
+++ b/scripts/overlay-compliance-cache.sh
@@ -21,7 +21,27 @@ SRC="${SRC:-static/compliance/source}"
 # and the compliance bundle moved with it. Resolve whichever subdir
 # exists so the overlay doesn't have to bump with every SDK release.
 CACHE_ROOT="node_modules/@adcp/sdk/compliance/cache"
-DST=$(find "$CACHE_ROOT" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | head -1)
+# SDK 6.11+ ships a `<version>.previous` sibling alongside `<version>` for
+# downgrade rollback. The runner reads from `<version>` (per ADCP_VERSION),
+# so the overlay MUST target that one — `find ... | head -1` picked
+# `.previous` non-deterministically on Linux ext4 in CI and left the live
+# cache with the SDK-bundled YAML.
+#
+# Strategy: read the SDK's pinned version from `node_modules/@adcp/sdk/ADCP_VERSION`
+# when present (canonical source of truth — the runner reads it the same way),
+# else fall back to the first non-`.previous` cache subdir.
+ADCP_VERSION_FILE="node_modules/@adcp/sdk/ADCP_VERSION"
+if [ -f "$ADCP_VERSION_FILE" ]; then
+  PINNED_VERSION=$(tr -d '[:space:]' < "$ADCP_VERSION_FILE")
+  DST="$CACHE_ROOT/$PINNED_VERSION"
+else
+  # Sort so the canonical version comes before `.previous` (the dot makes
+  # `.previous` lexicographically larger). Filter out `.previous` defensively.
+  DST=$(find "$CACHE_ROOT" -mindepth 1 -maxdepth 1 -type d 2>/dev/null \
+    | grep -v '\.previous$' \
+    | sort \
+    | head -1)
+fi
 
 if [ -z "$DST" ] || [ ! -d "$DST" ]; then
   echo "warning: SDK compliance cache not found under $CACHE_ROOT — skipping overlay"

--- a/scripts/run-storyboards-matrix.sh
+++ b/scripts/run-storyboards-matrix.sh
@@ -21,10 +21,10 @@ bash "${SCRIPT_DIR}/overlay-compliance-cache.sh" || true
 # .github/workflows/training-agent-storyboards.yml.
 TENANTS=(
   "signals:66:54"
-  "sales:67:252"
-  "governance:65:101"
-  "creative:66:114"
-  "creative-builder:60:96"
+  "sales:67:258"
+  "governance:65:102"
+  "creative:66:118"
+  "creative-builder:60:100"
   "brand:66:45"
 )
 

--- a/server/src/training-agent/v6-sales-platform.ts
+++ b/server/src/training-agent/v6-sales-platform.ts
@@ -176,6 +176,37 @@ export class TrainingSalesPlatform
 
     createMediaBuy: async (req, ctx) => {
       const v5Result = await handleCreateMediaBuy(req as ToolArgs, buildTrainingCtx(ctx.account));
+      // Detect the submitted-arm envelope the v5 handler returns when the
+      // `force_create_media_buy_arm` test-controller directive is set.
+      // The framework's projector rejects hand-rolled
+      // `{ status: 'submitted', task_id }` shapes — the only path into
+      // the submitted arm is `ctx.handoffToTask`. Pass the directive's
+      // task_id through `TaskHandoffOptions.task_id` so the response
+      // echoes the caller-supplied id (adcp-client#1554, SDK 6.11+).
+      // The handoff fn throws because the test directive only asserts
+      // on the immediate submitted envelope; no buyer polls completion
+      // in this scenario, so the throw surfaces a clean error if anyone
+      // ever does.
+      if (
+        v5Result &&
+        typeof v5Result === 'object' &&
+        (v5Result as { status?: unknown }).status === 'submitted' &&
+        typeof (v5Result as { task_id?: unknown }).task_id === 'string'
+      ) {
+        const submitted = v5Result as { task_id: string; message?: string };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return ctx.handoffToTask(
+          async () => {
+            throw new AdcpError('NOT_IMPLEMENTED', {
+              recovery: 'terminal',
+              message:
+                'force_create_media_buy_arm directive issued the submitted envelope; ' +
+                'the test directive does not register a completion handler.',
+            });
+          },
+          { task_id: submitted.task_id },
+        ) as any;
+      }
       return translateV5Result(v5Result);
     },
 

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -136,25 +136,7 @@ const KNOWN_FAILING_STORYBOARDS: ReadonlyMap<string, string> = new Map([
  * upstream issue and skipping the whole storyboard would lose passing
  * coverage. Track every entry with a linked issue.
  */
-const KNOWN_FAILING_STEPS: ReadonlyMap<string, string> = new Map([
-  // The v5 createMediaBuy handler returns a hand-rolled
-  // `{ status: 'submitted', task_id }` envelope when the
-  // `force_create_media_buy_arm` directive is set. The v6 framework's
-  // projector rejects that shape (`from-platform.js:1438`) — the only
-  // way into the submitted arm is via `ctx.handoffToTask(fn)`, which
-  // assigns a framework-issued task_id. The test-controller directive
-  // requires the seller to return the CALLER-supplied task_id, so
-  // `handoffToTask` cannot satisfy the contract until the SDK exposes
-  // a `{ task_id }` overload. Tracked at adcp-client#1554.
-  ['media_buy_seller/create_media_buy_async/create_media_buy_submitted', 'adcp-client#1554 — handoffToTask needs caller-supplied task_id overload to satisfy force_create_media_buy_arm contract'],
-  // The SDK storyboard runner drops extension params (e.g.
-  // `vendor_metric_values`) from `comply_test_controller` requests
-  // before they reach the wire — the agent's `simulate_delivery`
-  // handler never sees the array, so the downstream
-  // get_media_buy_delivery assertion finds nothing on
-  // `by_package[].vendor_metric_values`. Tracked at adcp-client#1552.
-  ['media_buy_seller/vendor_metric_accountability/get_delivery_with_vendor_metrics', 'adcp-client#1552 — runner drops vendor_metric_values from comply_test_controller params before wire'],
-]);
+const KNOWN_FAILING_STEPS: ReadonlyMap<string, string> = new Map([]);
 
 function isApplicable(sb: Storyboard): boolean {
   if (filter && !sb.id.includes(filter) && !(sb.category ?? '').includes(filter)) return false;


### PR DESCRIPTION
## Summary

6.11.0 ships the two SDK gaps surfaced during the #3965 cluster work — both filed and closed within hours of being identified:

- **adcp-client#1554** — `ctx.handoffToTask(fn, options)` now accepts `TaskHandoffOptions.task_id`. Lets the seller pass a caller-supplied task id through to the framework's submitted-arm projection (required by the `force_create_media_buy_arm` test directive).
- **adcp-client#1552** — the SDK's `simulate_delivery` dispatcher now spreads params verbatim, so extension fields like `vendor_metric_values` reach the seller's adapter instead of being silently dropped.

Wires both fixes:

- `v6-sales-platform.ts:createMediaBuy` detects the v5 handler's submitted-arm envelope (returned when `force_create_media_buy_arm` is set) and routes it through `ctx.handoffToTask(fn, { task_id })` with the directive's task_id. The handoff fn is a no-op-with-throw because the test directive only asserts on the immediate submitted envelope; production sellers register a real completion handler.
- Drops both `KNOWN_FAILING_STEPS` entries — both storyboards now pass cleanly with no skips.

Floor lifts (step counts move when previously-skipped steps now pass):

| Tenant            | Old | New | Delta |
|-------------------|-----|-----|-------|
| /sales            | 67 / 252 | 67 / 258 | flat / +6 |
| /governance       | 65 / 101 | 65 / 102 | flat / +1 |
| /creative         | 66 / 114 | 66 / 118 | flat / +4 |
| /creative-builder | 60 / 96  | 60 / 100 | flat / +4 |
| /signals          | 66 / 54  | 66 / 54  | flat |
| /brand            | 66 / 45  | 66 / 45  | flat |

**All six tenants pass with zero failing steps and zero known-failing skips.** The conformance suite is fully green on the framework path.

## Test plan

- [x] Local matrix run — all six tenants pass new floors
- [ ] CI matrix run on PR
- [ ] vendor_metric_accountability + create_media_buy_async storyboards now grade clean end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)