### PR TITLE
feat(addie): conformance Socket Mode — storyboard runner + Addie chat tools

### DIFF
--- a/.changeset/conformance-addie-tools.md
+++ b/.changeset/conformance-addie-tools.md
@@ -1,0 +1,4 @@
+---
+---
+
+feat(addie): conformance Socket Mode chat tools (PR #3 of 3) — `issue_conformance_token` and `run_conformance_against_my_agent`. Adopters mapped to a WorkOS organization can ask Addie for a token, paste it into their `@adcp/sdk/server` ConformanceClient, then have Addie run a storyboard against their dev MCP server with results rendered as a markdown report in chat. Gated on `CONFORMANCE_SOCKET_ENABLED=1` so the chat surface stays dark until ops opts in. Server-side WS plumbing (PR #1) and storyboard runner adapter (PR #2) remain always-wired.

--- a/.changeset/conformance-storyboard-runner.md
+++ b/.changeset/conformance-storyboard-runner.md
@@ -1,0 +1,4 @@
+---
+---
+
+feat(addie): conformance Socket Mode — storyboard runner adapter (PR #2 of 3). Adds `runStoryboardViaConformanceSocket(orgId, storyboardId)` that resolves a live conformance session, wraps its MCP client as an `AgentClient` via the SDK's existing `AgentClient.fromMCPClient` factory, and dispatches to the standard storyboard runner via the `_client` injection seam. Zero changes to existing storyboard infrastructure; this is a separate runner that picks the same storyboards from the same registry. PR #3 adds the Addie chat tools that consume it.

--- a/docs.json
+++ b/docs.json
@@ -193,6 +193,7 @@
                       "docs/building/verification/conformance",
                       "docs/building/verification/compliance-catalog",
                       "docs/building/verification/validate-your-agent",
+                      "docs/building/verification/addie-socket-mode",
                       "docs/building/verification/grading",
                       "docs/building/verification/get-test-ready",
                       "docs/building/verification/aao-verified"

--- a/docs/building/verification/addie-socket-mode.mdx
+++ b/docs/building/verification/addie-socket-mode.mdx
@@ -1,0 +1,196 @@
+---
+title: Pair-program with Addie (Socket Mode)
+sidebarTitle: Pair with Addie
+description: "Connect your dev/staging AdCP agent to Addie via outbound WebSocket so she can run storyboards against it conversationally. No public DNS, no ngrok, no inbound exposure."
+"og:title": "AdCP — Pair-program with Addie"
+---
+
+**Status**: Available in preview behind `CONFORMANCE_SOCKET_ENABLED`
+**Last updated**: May 4, 2026
+
+When you're building an AdCP agent, the most useful loop is: run a storyboard against your in-progress server, see what fails, fix it, run again. Until now that meant standing up a public sandbox endpoint with TLS, DNS, auth, and firewall config — a real lift before you've written meaningful code, and a non-trivial security review at larger orgs.
+
+**Pair-programming with Addie via Socket Mode** collapses that to: install one library, paste a token, connect outbound. Addie sees your dev agent like any other AdCP server — no inbound exposure, no public surface — and can run any compliance storyboard against it in chat.
+
+## When to use Socket Mode (and when not to)
+
+| Use Socket Mode when… | Use the public-endpoint path when… |
+|---|---|
+| You're building or refactoring an agent and want fast feedback | You're ready for AAO's [(Spec) heartbeat](/docs/building/aao-verified) on a stable test endpoint |
+| Your dev agent runs on `localhost`, a Codespace, or behind a firewall | Your platform exposes a public test endpoint anyway |
+| You want Addie to run multiple storyboards interactively in chat | You want unattended, scheduled compliance runs |
+| You're a small team without infra to expose a sandbox endpoint | You operate at scale and prefer batch CI |
+
+Socket Mode is **not** a replacement for AAO Verified. Once your agent is stable, expose a real test endpoint and let the AAO heartbeat run continuously — that's what earns the public **AAO Verified (Spec)** badge. Socket Mode is the dev-loop channel before you get there (and after, when you're iterating on changes).
+
+<Note>
+**Dev/staging only by design.** Socket Mode is gated to non-production deployments, the same constraint as `comply_test_controller` per [adcp#3986](https://github.com/adcontextprotocol/adcp/issues/3986). Production agents do not expose this channel and AAO never enrolls production deployments via Socket Mode.
+</Note>
+
+## What you need
+
+1. **An AdCP MCP server you're actively developing.** It can be incomplete — that's the point. The simplest case is a JS/TS process running on your laptop with the MCP SDK installed.
+2. **An AAO account.** The conformance channel is bound to your WorkOS organization, so you need to be signed in to a member or trial org. Anonymous chat with Addie cannot use Socket Mode.
+3. **`@adcp/sdk` ≥ 6.9** in your dev project. The `ConformanceClient` primitive ships from `@adcp/sdk/server`.
+4. **Network egress to `addie.agenticadvertising.org` over WebSockets (port 443).** No inbound rules needed.
+
+That's it. No public DNS, no firewall changes, no ngrok, no certificate provisioning.
+
+## The five-minute setup
+
+### Step 1 — Ask Addie for a token
+
+In your Addie chat session, ask:
+
+> Give me a fresh conformance token
+
+Addie returns shell exports plus a copy-paste integration snippet:
+
+```
+**Conformance token issued.** Bound to your organization, expires in 1h.
+
+Paste these into your dev environment and start the conformance client:
+
+export ADCP_CONFORMANCE_URL=wss://addie.agenticadvertising.org/conformance/connect
+export ADCP_CONFORMANCE_TOKEN=eyJ…
+
+Three-line integration with @adcp/sdk ≥ 6.9: …
+```
+
+Tokens expire in one hour. When yours runs out, just ask Addie for a new one — there's no refresh endpoint by design.
+
+### Step 2 — Wire `ConformanceClient` into your dev server
+
+Three lines added to your existing AdCP server bootstrap:
+
+```ts
+import { ConformanceClient } from '@adcp/sdk/server';
+import { mcpServer } from './my-mcp-server';
+
+const conformance = new ConformanceClient({
+  url: process.env.ADCP_CONFORMANCE_URL!,
+  token: process.env.ADCP_CONFORMANCE_TOKEN!,
+  server: mcpServer,
+});
+
+await conformance.start();
+```
+
+`mcpServer` is the same `Server` instance you'd connect to `StreamableHTTPServerTransport` for normal traffic — no separate setup, no parallel server. `ConformanceClient` exposes it bidirectionally over the outbound WebSocket; Addie sees a normal MCP server on the other end.
+
+If you don't have an AdCP server yet, fork the [`hello_seller_adapter_social` example](https://github.com/adcontextprotocol/adcp-client/blob/main/examples/hello_seller_adapter_social.ts) — it's a worked starting point with the SDK's `createAdcpServerFromPlatform` helper.
+
+### Step 3 — Confirm the connection
+
+Run your dev server with the token and URL exported. You should see a status line:
+
+```
+[conformance] status=connecting
+[conformance] status=connected
+```
+
+Once `status=connected` lands, Addie has a live MCP client pointed at your dev server. The session stays open until you stop the process or your token expires.
+
+### Step 4 — Run a storyboard from chat
+
+Back in Addie chat:
+
+> Run `media_buy_state_machine` against my agent
+
+Addie dispatches the storyboard through the open socket and renders the result as a markdown report in chat:
+
+```
+### Conformance result — Media buy state machine lifecycle (media_buy_state_machine)
+
+**Overall:** ✅ PASSED
+**Steps passed/failed/skipped:** 8 / 0 / 1
+**Duration:** 1240 ms
+
+#### ✓ Capability discovery
+- ✓ passed — Check agent capabilities
+
+#### ✓ Create a media buy
+- ✓ passed — Discover products for media buy
+- ✓ passed — Create the test media buy
+
+#### ✓ Valid state transitions
+- ✓ passed — Pause the media buy
+- ✓ passed — Resume the media buy
+- ✓ passed — Cancel the media buy
+…
+```
+
+Failing steps include trimmed error text so you can fix in place and re-run without leaving the chat. Iterate until green.
+
+You can run any storyboard in the [Compliance Catalog](/docs/building/compliance-catalog) this way — sales, creative, signals, governance, signed requests, etc. Ask Addie what's available if you're not sure: *"What conformance storyboards apply to a sales agent?"*
+
+## What Addie can do once you're connected
+
+Beyond storyboard runs, the live MCP channel lets Addie:
+
+- **Diagnose failing steps interactively** — when a step fails, ask "why?" and Addie can re-call the same tool with different inputs to narrow the root cause
+- **Validate capability declarations** — *"Does my `get_adcp_capabilities` claim what I actually implement?"*
+- **Walk lifecycle states** — if you've wired `comply_test_controller`, Addie can drive deterministic state transitions and observe the results
+- **Suggest fixes against your real wire output** — *"Your `error_code` field is missing on this rejection — here's the fix"* — based on bytes she just saw, not generic advice
+
+## Privacy & safety
+
+The Socket Mode channel is built to keep the surface narrow:
+
+- **Dev/staging only.** Production deployments must not expose this channel — same deployment-scoped rule as `comply_test_controller` ([adcp#3986](https://github.com/adcontextprotocol/adcp/issues/3986)).
+- **Outbound from you.** Your dev box opens the connection to Addie. Addie has no way to reach into your network.
+- **Session-scoped.** You start the client; it runs until you stop the process. No persistent tunnel, no daemon.
+- **Org-scoped.** The token's WorkOS org claim is the only tenant boundary. Other orgs cannot reach your agent over the channel.
+- **Disconnect anytime.** Kill the client process and the socket closes; Addie's session for your org evicts immediately.
+- **What Addie sees stays in your Addie context.** Same data-handling posture as anything else you tell her in chat.
+
+If you'd prefer to inspect the channel yourself, the wire format is plain JSON-RPC 2.0 frames (the same shape MCP already uses) over `wss://`. Run `wscat` against the URL with your token and you'll see exactly what Addie sees.
+
+## Troubleshooting
+
+### Addie says "you're not mapped to an organization"
+
+You're chatting with Addie anonymously or your account isn't bound to a WorkOS org yet. Sign in to your member or trial org and try again.
+
+### `status=error` on connect; the server logs `401 Unauthorized`
+
+Token expired (1h TTL) or wrong token. Ask Addie for a fresh one. If a new token also 401s, your AAO membership may not have the conformance entitlement enabled — check your org's plan.
+
+### Storyboard report shows step 1 failed with `unknown tool get_adcp_capabilities`
+
+Your dev MCP server doesn't yet implement `get_adcp_capabilities`. That's the discovery tool every AdCP agent must expose. Implement it before running any storyboard — see [`get_adcp_capabilities`](/docs/protocol/get_adcp_capabilities) for the response shape.
+
+### Addie says "no conformance connection is live for your org"
+
+The socket isn't open. Either you haven't started the client yet, or it disconnected. Restart `ConformanceClient` and confirm `status=connected` before asking Addie to run anything.
+
+### Socket connects but every storyboard step skips
+
+Your `get_adcp_capabilities` response declares specialisms you haven't implemented. The runner skips steps that don't match the declared surface. Either implement the tools or trim the declaration.
+
+### How do I know what Addie is doing on the channel?
+
+The `onStatus` callback exposes every state transition (`connecting`, `connected`, `disconnected`, `error`). Pipe it to your dev logs:
+
+```ts
+new ConformanceClient({
+  url, token, server: mcpServer,
+  onStatus: (status, detail) => {
+    console.log(`[conformance] status=${status}`,
+      detail?.attempt ? `attempt=${detail.attempt}` : '',
+      detail?.error ? `error=${detail.error.message}` : '');
+  },
+});
+```
+
+For tool-level visibility, log inside your `setRequestHandler` callbacks — Addie's calls land there exactly like normal MCP traffic.
+
+## Reference
+
+- [`@adcp/sdk/server` `ConformanceClient`](https://github.com/adcontextprotocol/adcp-client/blob/main/src/lib/server/socket-mode/conformance-client.ts) — adopter-side primitive
+- [`get_adcp_capabilities`](/docs/protocol/get_adcp_capabilities) — the discovery tool every storyboard starts with
+- [Compliance Catalog](/docs/building/compliance-catalog) — full list of available storyboards
+- [Get Test-Ready](/docs/building/get-test-ready) — what your agent needs in place before any storyboard can pass
+- [AAO Verified](/docs/building/aao-verified) — the public trust mark you graduate to once your agent is stable
+- Channel design: [adcp#3991](https://github.com/adcontextprotocol/adcp/issues/3991)
+- Deployment-scoped controller rule: [adcp#3986](https://github.com/adcontextprotocol/adcp/issues/3986)

--- a/scripts/smoke-conformance-training-agent.ts
+++ b/scripts/smoke-conformance-training-agent.ts
@@ -1,0 +1,182 @@
+/**
+ * Full Socket Mode loop against the local training agent.
+ *
+ * Flow:
+ *   1. Issue a conformance token directly (skips the WorkOS-auth step)
+ *   2. Spin up a "proxy adopter" — an MCP server whose request handlers
+ *      forward every tools/list and tools/call to the locally running
+ *      training agent's `/api/training-agent/sales/mcp` HTTP endpoint
+ *   3. Connect that proxy via @adcp/sdk/server ConformanceClient
+ *   4. Trigger `runStoryboardViaConformanceSocket` from inside the dev
+ *      server via the dev-only `_debug/run-storyboard` endpoint
+ *   5. Print the storyboard result
+ *
+ * What this proves: the training agent's storyboard conformance carries
+ * over Socket Mode unchanged. Whatever it passes/fails over HTTP, it
+ * passes/fails over the WS-backed path.
+ *
+ * Prereqs:
+ *   - Dev server running (`npm run start`)
+ *   - CONFORMANCE_JWT_SECRET set
+ *
+ * Run:
+ *   npx tsx --import dotenv/config scripts/smoke-conformance-training-agent.ts
+ */
+
+import 'dotenv/config';
+import { Server as MCPServer } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { ConformanceClient } from '@adcp/sdk/server';
+
+import { issueConformanceToken } from '../server/src/conformance/index.js';
+
+const PORT = process.env.CONDUCTOR_PORT ?? '55020';
+const TRAINING_URL = `http://localhost:${PORT}/api/training-agent/sales/mcp`;
+const TRAINING_TOKEN =
+  process.env.PUBLIC_TEST_AGENT_TOKEN ??
+  '1v8tAhASaUYYp4odoQ1PnMpdqNaMiTrCRqYo9OJp6IQ';
+const CONFORMANCE_WS_URL = `ws://127.0.0.1:${PORT}/conformance/connect`;
+const ORG_ID = 'org_socket_smoke';
+const STORYBOARD_ID = process.argv[2] ?? 'media_buy_state_machine';
+
+function banner(s: string): void {
+  console.log('\n' + '─'.repeat(72) + '\n  ' + s + '\n' + '─'.repeat(72));
+}
+
+let nextRpcId = 100;
+
+async function forwardToTrainingAgent(method: string, params: unknown): Promise<unknown> {
+  const id = nextRpcId++;
+  const body = JSON.stringify({ jsonrpc: '2.0', id, method, params });
+  const res = await fetch(TRAINING_URL, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream',
+      authorization: `Bearer ${TRAINING_TOKEN}`,
+    },
+    body,
+  });
+  if (!res.ok) {
+    throw new Error(`training agent HTTP ${res.status}: ${await res.text().catch(() => '')}`);
+  }
+  const text = await res.text();
+  // SSE responses begin with `event:` / `data:` lines; pick the first JSON
+  // payload. Otherwise the body is plain JSON.
+  const sseMatch = text.match(/^data: (.*)$/m);
+  const payload = sseMatch ? JSON.parse(sseMatch[1]) : JSON.parse(text);
+  if (payload.error) {
+    const err = new Error(payload.error.message ?? 'unknown error');
+    (err as Error & { code?: number }).code = payload.error.code;
+    throw err;
+  }
+  return payload.result;
+}
+
+function buildProxyServer(): MCPServer {
+  const server = new MCPServer(
+    { name: 'training-agent-socket-proxy', version: '0.0.1' },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return (await forwardToTrainingAgent('tools/list', {})) as {
+      tools: Array<{ name: string; description?: string; inputSchema: unknown }>;
+    };
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    return (await forwardToTrainingAgent('tools/call', req.params)) as {
+      content: Array<{ type: 'text'; text: string }>;
+    };
+  });
+
+  return server;
+}
+
+async function main(): Promise<void> {
+  if (!process.env.CONFORMANCE_JWT_SECRET) {
+    console.error('CONFORMANCE_JWT_SECRET not set — abort');
+    process.exit(1);
+  }
+
+  banner('1. Issuing token + connecting proxy adopter via @adcp/sdk 6.9');
+  const { token } = issueConformanceToken(ORG_ID);
+  console.log(`  token (${token.slice(0, 32)}…)`);
+  console.log(`  proxy will forward to ${TRAINING_URL}`);
+
+  const proxy = new ConformanceClient({
+    url: CONFORMANCE_WS_URL,
+    token,
+    server: buildProxyServer(),
+    reconnect: false,
+    onStatus: (s, d) =>
+      console.log(`  [proxy] status=${s}${d?.error ? ` error=${d.error.message}` : ''}`),
+  });
+  await proxy.start();
+
+  banner(`2. Triggering "${STORYBOARD_ID}" via /api/conformance/_debug/run-storyboard`);
+  // Static admin key is configured on this server; it bypasses WorkOS but
+  // still satisfies requireAuth for dev-only debug endpoints.
+  const adminKey = process.env.ADMIN_API_KEY;
+  if (!adminKey) throw new Error('ADMIN_API_KEY not in env — needed to authenticate the debug trigger');
+
+  const triggerRes = await fetch(`http://localhost:${PORT}/api/conformance/_debug/run-storyboard`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${adminKey}`,
+    },
+    body: JSON.stringify({ org_id: ORG_ID, storyboard_id: STORYBOARD_ID }),
+  });
+
+  if (!triggerRes.ok) {
+    console.error('  trigger failed:', triggerRes.status, await triggerRes.text());
+    await proxy.close();
+    process.exit(1);
+  }
+
+  const result = await triggerRes.json() as {
+    storyboard_id: string;
+    storyboard_title: string;
+    overall_passed: boolean;
+    passed_count: number;
+    failed_count: number;
+    skipped_count: number;
+    total_duration_ms: number;
+    phases: Array<{
+      phase_id: string;
+      phase_title: string;
+      passed: boolean;
+      steps: Array<{ step_id: string; title: string; passed: boolean; skipped?: boolean; error?: string }>;
+    }>;
+  };
+
+  banner('3. Result');
+  console.log(`  Storyboard: ${result.storyboard_title} (${result.storyboard_id})`);
+  console.log(`  Overall:    ${result.overall_passed ? '✅ PASSED' : '❌ FAILED'}`);
+  console.log(`  Steps:      ${result.passed_count} passed / ${result.failed_count} failed / ${result.skipped_count} skipped`);
+  console.log(`  Duration:   ${result.total_duration_ms} ms\n`);
+  for (const phase of result.phases) {
+    console.log(`  ${phase.passed ? '✓' : '✗'} ${phase.phase_title}`);
+    for (const step of phase.steps) {
+      const tag = step.skipped ? '⊘' : step.passed ? '✓' : '✗';
+      console.log(`     ${tag} ${step.title}`);
+      if (!step.passed && !step.skipped && step.error) {
+        const trimmed = step.error.length > 200 ? step.error.slice(0, 200) + '…' : step.error;
+        console.log(`        error: ${trimmed}`);
+      }
+    }
+  }
+
+  await proxy.close();
+  banner(result.overall_passed ? 'PASS' : 'storyboard ran end-to-end via Socket Mode (failures are training-agent bugs, not transport bugs)');
+}
+
+main().catch((err) => {
+  console.error('FAILED:', err);
+  process.exit(1);
+});

--- a/scripts/smoke-conformance.ts
+++ b/scripts/smoke-conformance.ts
@@ -1,0 +1,174 @@
+/**
+ * End-to-end smoke test for Addie Socket Mode (PRs #4007/#4051/#4054).
+ *
+ * Spins up:
+ *   - The server-side conformance WS upgrade + token route (PR #1)
+ *   - A real adopter using @adcp/sdk/server ConformanceClient (the
+ *     published library, post adcp-client#1506 / @adcp/sdk 6.9)
+ *
+ * Exercises:
+ *   - Token issuance via direct call (PR #1 token primitive)
+ *   - Outbound WS connect from adopter (the SDK's ConformanceClient)
+ *   - Session registration in the conformance store (PR #1 ws-route)
+ *   - Storyboard runner adapter dispatch (PR #2)
+ *   - Addie chat tool handlers (PR #3) — both `issue_conformance_token`
+ *     and `run_conformance_against_my_agent`
+ *
+ * The demo adopter only implements `ping` and `echo` — not real AdCP
+ * tools — so the storyboard run is expected to fail at "tool not
+ * found." That's the right signal for this smoke: "the runner
+ * dispatched into the WS-backed client and got a real failure back,"
+ * not "the storyboard passed."
+ *
+ * Run:
+ *   npx tsx --env-file .env.local scripts/smoke-conformance.ts
+ */
+
+import 'dotenv/config';
+import { createServer } from 'node:http';
+import express from 'express';
+import { Server as MCPServer } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { ConformanceClient } from '@adcp/sdk/server';
+
+import {
+  attachConformanceWS,
+  buildConformanceTokenRouter,
+  conformanceSessions,
+  issueConformanceToken,
+} from '../server/src/conformance/index.js';
+import { createConformanceToolHandlers } from '../server/src/addie/mcp/conformance-tools.js';
+import type { MemberContext } from '../server/src/addie/member-context.js';
+
+const ORG_ID = 'org_smoke_test';
+const STORYBOARD_ID = 'media_buy_state_machine';
+
+function fakeMemberContext(): MemberContext {
+  return {
+    is_mapped: true,
+    is_member: true,
+    organization: {
+      workos_organization_id: ORG_ID,
+      name: 'Smoke Test Org',
+      subscription_status: 'active',
+      is_personal: false,
+      membership_tier: 'professional',
+    },
+  } as unknown as MemberContext;
+}
+
+function buildAdopterServer(): MCPServer {
+  const server = new MCPServer(
+    { name: 'smoke-adopter', version: '0.0.1' },
+    { capabilities: { tools: {} } },
+  );
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+      { name: 'ping', description: 'health', inputSchema: { type: 'object', properties: {} } },
+    ],
+  }));
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    if (req.params.name === 'ping') return { content: [{ type: 'text', text: 'pong' }] };
+    throw new Error(`unknown tool ${req.params.name}`);
+  });
+  return server;
+}
+
+function banner(s: string): void {
+  console.log('\n' + '─'.repeat(72) + '\n  ' + s + '\n' + '─'.repeat(72));
+}
+
+async function main(): Promise<void> {
+  if (!process.env.CONFORMANCE_JWT_SECRET) {
+    console.error('CONFORMANCE_JWT_SECRET not set in .env.local — aborting');
+    process.exit(1);
+  }
+
+  banner('1. Standing up server with PR #1 routes attached');
+  const app = express();
+  app.use('/api/conformance', buildConformanceTokenRouter());
+  const httpServer = createServer(app);
+  attachConformanceWS(httpServer);
+  await new Promise<void>((resolve) =>
+    httpServer.listen(0, '127.0.0.1', () => resolve()),
+  );
+  const addr = httpServer.address();
+  const port = typeof addr === 'object' && addr ? addr.port : 0;
+  const wsUrl = `ws://127.0.0.1:${port}/conformance/connect`;
+  console.log(`  ✓ HTTP+WS server listening on ${port}`);
+  console.log(`  ✓ WS endpoint: ${wsUrl}`);
+
+  banner('2. PR #3 — calling issue_conformance_token Addie tool');
+  const ctx = fakeMemberContext();
+  const handlers = createConformanceToolHandlers(ctx);
+  const tokenChat = await handlers.get('issue_conformance_token')!({});
+  console.log('  ↓ Addie response:');
+  console.log(tokenChat.split('\n').map((l) => '    ' + l).join('\n'));
+  if (!/Conformance token issued/.test(tokenChat)) {
+    throw new Error('issue_conformance_token did not return expected markdown');
+  }
+  console.log('  ✓ Tool returned a valid token + url + expiry');
+
+  banner('3. PR #1 — issuing a token directly for the adopter to consume');
+  const issued = issueConformanceToken(ORG_ID);
+  console.log(`  ✓ Token (${issued.token.slice(0, 24)}…)  ttl=${issued.ttlSeconds}s`);
+
+  banner('4. PR #1 — adopter connects via @adcp/sdk/server ConformanceClient (6.9)');
+  const adopterServer = buildAdopterServer();
+  const adopter = new ConformanceClient({
+    url: wsUrl,
+    token: issued.token,
+    server: adopterServer,
+    reconnect: false,
+    onStatus: (s, d) => {
+      const tag = d?.error ? ` error=${d.error.message}` : '';
+      console.log(`  [adopter] status=${s}${tag}`);
+    },
+  });
+  await adopter.start();
+
+  // wait briefly for session to land in the store
+  const deadline = Date.now() + 2000;
+  while (!conformanceSessions.get(ORG_ID) && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  const session = conformanceSessions.get(ORG_ID);
+  if (!session) throw new Error('session never registered');
+  console.log(`  ✓ Session registered: ${session.transport.sessionId}`);
+
+  banner('5. PR #2 + PR #3 — running a storyboard via Addie chat tool');
+  console.log(`  Asking Addie to run "${STORYBOARD_ID}" against the connected adopter…`);
+  console.log('  (the demo adopter only implements `ping`, so the storyboard will FAIL at');
+  console.log('   first-tool dispatch — that\'s expected and proves the runner reached the');
+  console.log('   WS-backed adopter.)\n');
+  const runChat = await handlers.get('run_conformance_against_my_agent')!({
+    storyboard_id: STORYBOARD_ID,
+  });
+  console.log('  ↓ Addie response:');
+  console.log(runChat.split('\n').map((l) => '    ' + l).join('\n'));
+
+  banner('6. Cleanup');
+  await adopter.close();
+  await new Promise((r) => setTimeout(r, 100));
+  await conformanceSessions.closeAll();
+  await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  console.log('  ✓ Adopter disconnected, sessions cleared, server closed');
+
+  banner('SMOKE PASSED — full Socket Mode stack works end-to-end');
+  console.log('\nWhat just happened:');
+  console.log('  • PR #1: token issued, WS upgrade authenticated, session registered');
+  console.log('  • @adcp/sdk 6.9 ConformanceClient: outbound WS, MCP initialize handshake');
+  console.log('  • PR #3: Addie tool produced shell-export markdown; chat runner returned a');
+  console.log('    real storyboard report (failures are expected for the ping-only demo)');
+  console.log('  • PR #2: runner adapter wrapped session.mcpClient as AgentClient and');
+  console.log('    dispatched into the storyboard machinery — confirmed by the failure');
+  console.log('    coming back from the adopter side, not from the SDK upstream.\n');
+}
+
+main().catch((err) => {
+  console.error('\nSMOKE FAILED:', err);
+  process.exit(1);
+});

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -80,6 +80,10 @@ import {
   createAuthGraderToolHandlers,
 } from './mcp/auth-grader-tools.js';
 import {
+  CONFORMANCE_TOOLS,
+  createConformanceToolHandlers,
+} from './mcp/conformance-tools.js';
+import {
   MEETING_TOOLS,
   createMeetingToolHandlers,
   canScheduleMeetings,
@@ -980,6 +984,20 @@ async function createUserScopedTools(
     allHandlers.set(name, handler);
   }
   logger.debug('Addie Bolt: Auth grader tools enabled');
+
+  // Conformance Socket Mode — issue tokens + run storyboards against an
+  // adopter dev/staging MCP server connected outbound to Addie. Gated
+  // behind CONFORMANCE_SOCKET_ENABLED so the chat surface stays dark
+  // until ops opts in. Server-side WS plumbing is always wired (see
+  // server/src/conformance/) — this flag only controls Addie's offer.
+  if (process.env.CONFORMANCE_SOCKET_ENABLED === '1' && memberContext) {
+    const conformanceHandlers = createConformanceToolHandlers(memberContext);
+    allTools.push(...CONFORMANCE_TOOLS);
+    for (const [name, handler] of conformanceHandlers) {
+      allHandlers.set(name, handler);
+    }
+    logger.debug('Addie Bolt: Conformance Socket Mode tools enabled');
+  }
 
   // Check if user is AAO admin (based on aao-admin working group membership)
   const userIsAdmin = slackUserId ? await isSlackUserAAOAdmin(slackUserId) : false;

--- a/server/src/addie/mcp/conformance-tools.ts
+++ b/server/src/addie/mcp/conformance-tools.ts
@@ -1,0 +1,239 @@
+/**
+ * Addie tools for the conformance Socket Mode channel.
+ *
+ * Two tools, both bound to the caller's WorkOS organization:
+ *
+ *   - `issue_conformance_token` — mint a fresh JWT the adopter pastes
+ *     into their `@adcp/sdk/server` ConformanceClient config.
+ *   - `run_conformance_against_my_agent` — once the adopter has
+ *     connected, run a storyboard against their dev MCP server and
+ *     return a markdown report.
+ *
+ * Both tools require the caller to be mapped to a WorkOS organization
+ * (memberContext.organization). Anonymous chats can't issue tokens or
+ * run storyboards because the org binding is what scopes the socket
+ * to a single tenant.
+ *
+ * Gated behind CONFORMANCE_SOCKET_ENABLED=1 at registration time —
+ * see bolt-app.ts. The env-gate is intentional: it lets us land the
+ * server-side plumbing dark and turn on the chat surface separately.
+ */
+
+import type { AddieTool } from '../types.js';
+import type { MemberContext } from '../member-context.js';
+import {
+  issueConformanceToken,
+  conformanceSessions,
+  runStoryboardViaConformanceSocket,
+  ConformanceNotConnectedError,
+  StoryboardNotFoundError,
+} from '../../conformance/index.js';
+import type { StoryboardResult } from '@adcp/sdk/testing';
+import { createLogger } from '../../logger.js';
+
+const logger = createLogger('addie-conformance-tools');
+
+function publicWsUrl(): string {
+  const explicit = process.env.CONFORMANCE_WS_PUBLIC_URL;
+  if (explicit) return explicit;
+  const base = process.env.PUBLIC_BASE_URL ?? 'http://localhost:3000';
+  return base.replace(/^http/, 'ws') + '/conformance/connect';
+}
+
+function resolveOrgId(memberContext: MemberContext): string | null {
+  return memberContext.organization?.workos_organization_id ?? null;
+}
+
+function notMappedHint(): string {
+  return [
+    "**Can't issue a conformance token — you're not mapped to an organization.**",
+    '',
+    'The conformance Socket Mode channel scopes connections per WorkOS organization, so we need to know which org owns the dev environment that\'ll be on the other end of the socket.',
+    '',
+    'Sign in with your AAO account (or finish org provisioning if you just signed up) and try again.',
+  ].join('\n');
+}
+
+function notConnectedHint(orgId: string): string {
+  return [
+    `**No conformance connection is live for your org (${orgId}).**`,
+    '',
+    'To run conformance against your dev agent:',
+    '',
+    '1. Get a fresh token by asking me to `issue_conformance_token` (or POST `/api/conformance/token`).',
+    '2. In your dev environment, install `@adcp/sdk` ≥ 6.9 and start the conformance client:',
+    '',
+    '```ts',
+    "import { ConformanceClient } from '@adcp/sdk/server';",
+    "import { mcpServer } from './my-mcp-server';",
+    '',
+    'const client = new ConformanceClient({',
+    `  url: '${publicWsUrl()}',`,
+    '  token: process.env.ADCP_CONFORMANCE_TOKEN!,',
+    '  server: mcpServer,',
+    '});',
+    'await client.start();',
+    '```',
+    '',
+    '3. Once you see `status=connected` in your console, ask me to run conformance again.',
+  ].join('\n');
+}
+
+function formatStoryboardResult(result: StoryboardResult): string {
+  const overall = result.overall_passed ? '✅ PASSED' : '❌ FAILED';
+  const lines = [
+    `### Conformance result — ${result.storyboard_title} (${result.storyboard_id})`,
+    '',
+    `**Overall:** ${overall}`,
+    `**Steps passed/failed/skipped:** ${result.passed_count} / ${result.failed_count} / ${result.skipped_count}`,
+    `**Duration:** ${result.total_duration_ms} ms`,
+    '',
+  ];
+
+  for (const phase of result.phases) {
+    lines.push(`#### ${phase.passed ? '✓' : '✗'} ${phase.phase_title}`);
+    for (const step of phase.steps) {
+      const tag = step.skipped ? '⊘ skipped' : step.passed ? '✓ passed' : '✗ failed';
+      lines.push(`- ${tag} — ${step.title}`);
+      if (!step.passed && !step.skipped) {
+        const errMsg = (step as unknown as { error?: string }).error;
+        if (errMsg) {
+          const trimmed = errMsg.length > 240 ? errMsg.slice(0, 240) + '…' : errMsg;
+          lines.push(`  - error: ${trimmed}`);
+        }
+      }
+    }
+    lines.push('');
+  }
+
+  if (result.failed_count > 0) {
+    lines.push('Run again after fixing the failing steps. Adopter-side disconnects in the middle of a run currently fail in-flight steps — restart the conformance client and re-run.');
+  }
+
+  return lines.join('\n');
+}
+
+export const CONFORMANCE_TOOLS: AddieTool[] = [
+  {
+    name: 'issue_conformance_token',
+    description:
+      "Issue a short-lived JWT (1h TTL) the adopter pastes into their `@adcp/sdk/server` ConformanceClient config to connect their dev/staging MCP server outbound to Addie's conformance channel. The token is bound to the caller's WorkOS organization. Use this when the user is building an AdCP agent and wants Addie to run conformance/compliance tests against their dev environment without exposing it publicly. Returns the token, the WebSocket URL, and the expiry time.",
+    usage_hints:
+      'use for "give me a conformance token", "I want to test my AdCP agent with Addie", "how do I connect my dev agent to you", or any "Addie pair-program my agent" framing. Pair with run_conformance_against_my_agent once the adopter has the client running.',
+    input_schema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+  {
+    name: 'run_conformance_against_my_agent',
+    description:
+      'Run a compliance storyboard against the adopter MCP server connected to this Addie session via Socket Mode. The adopter must have started `@adcp/sdk/server` ConformanceClient with a token issued in this same chat session — the channel routes by WorkOS organization id. Returns a markdown report with phase/step pass/fail/skipped status and trimmed error text on failures. Use this after the user confirms their conformance client shows `status=connected`.',
+    usage_hints:
+      'use for "run conformance on my agent", "test my agent against media-buy storyboards", "check my creative agent compliance". Requires a live conformance connection — if there isn\'t one, the tool returns a hint pointing the user at issue_conformance_token first.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        storyboard_id: {
+          type: 'string',
+          description:
+            'The storyboard id to run (e.g. `media_buy_state_machine`). Use list_storyboards (in agent_testing) to discover available ids if the user is unsure.',
+        },
+      },
+      required: ['storyboard_id'],
+    },
+  },
+];
+
+export function createConformanceToolHandlers(
+  memberContext: MemberContext,
+): Map<string, (args: Record<string, unknown>) => Promise<string>> {
+  const handlers = new Map<string, (args: Record<string, unknown>) => Promise<string>>();
+
+  handlers.set('issue_conformance_token', async () => {
+    const orgId = resolveOrgId(memberContext);
+    if (!orgId) return notMappedHint();
+
+    let issued;
+    try {
+      issued = issueConformanceToken(orgId);
+    } catch (err) {
+      logger.error({ err, orgId }, 'issue_conformance_token failed');
+      return [
+        '**Error issuing token.**',
+        '',
+        'The conformance channel is not configured on this Addie instance (CONFORMANCE_JWT_SECRET is missing). Reach out in #aao-engineering.',
+      ].join('\n');
+    }
+
+    const url = publicWsUrl();
+    const expiresAtIso = new Date(issued.expiresAt * 1000).toISOString();
+    return [
+      '**Conformance token issued.** Bound to your organization, expires in 1h.',
+      '',
+      'Paste these into your dev environment and start the conformance client:',
+      '',
+      '```sh',
+      `export ADCP_CONFORMANCE_URL=${url}`,
+      `export ADCP_CONFORMANCE_TOKEN=${issued.token}`,
+      '```',
+      '',
+      `Expires at: \`${expiresAtIso}\``,
+      '',
+      'Three-line integration with `@adcp/sdk` ≥ 6.9:',
+      '',
+      '```ts',
+      "import { ConformanceClient } from '@adcp/sdk/server';",
+      "import { mcpServer } from './my-mcp-server';",
+      '',
+      'const client = new ConformanceClient({',
+      '  url: process.env.ADCP_CONFORMANCE_URL!,',
+      '  token: process.env.ADCP_CONFORMANCE_TOKEN!,',
+      '  server: mcpServer,',
+      '});',
+      'await client.start();',
+      '```',
+      '',
+      'Once your console shows `status=connected`, ask me to run conformance against your agent.',
+    ].join('\n');
+  });
+
+  handlers.set('run_conformance_against_my_agent', async (input) => {
+    const orgId = resolveOrgId(memberContext);
+    if (!orgId) return notMappedHint();
+
+    const storyboardId = typeof input.storyboard_id === 'string' ? input.storyboard_id : '';
+    if (!storyboardId) {
+      return '**`storyboard_id` is required.** Try `media_buy_state_machine` for a sales agent or list storyboards via the `agent_testing` toolset.';
+    }
+
+    if (!conformanceSessions.get(orgId)) {
+      return notConnectedHint(orgId);
+    }
+
+    try {
+      const result = await runStoryboardViaConformanceSocket(orgId, storyboardId);
+      return formatStoryboardResult(result);
+    } catch (err) {
+      if (err instanceof ConformanceNotConnectedError) {
+        return notConnectedHint(orgId);
+      }
+      if (err instanceof StoryboardNotFoundError) {
+        return [
+          `**Unknown storyboard:** \`${storyboardId}\`.`,
+          '',
+          'I list available storyboards via the `agent_testing` toolset — try \`list_storyboards\` first if you\'re not sure which id to use.',
+        ].join('\n');
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error({ err: message, orgId, storyboardId }, 'run_conformance_against_my_agent failed');
+      return [
+        `**Error running conformance:** ${message.slice(0, 500)}`,
+        '',
+        'If the adopter-side socket disconnected mid-run, restart the conformance client and try again.',
+      ].join('\n');
+    }
+  });
+
+  return handlers;
+}

--- a/server/src/addie/tool-sets.ts
+++ b/server/src/addie/tool-sets.ts
@@ -192,6 +192,12 @@ export const TOOL_SETS: Record<string, ToolSet> = {
     ],
   },
 
+  agent_conformance: {
+    name: 'agent_conformance',
+    description: 'Run AdCP compliance storyboards against the user\'s own dev/staging MCP server via Addie\'s Socket Mode channel — outbound WebSocket from the adopter to Addie, no public DNS or ngrok needed. Use when the user wants to test their own AdCP agent during development. Requires the user to be mapped to a WorkOS organization. Tools issue a session-bound token and then run a storyboard against the connected adopter agent.',
+    tools: ['issue_conformance_token', 'run_conformance_against_my_agent'],
+  },
+
   adcp_operations: {
     name: 'adcp_operations',
     description: 'Execute AdCP protocol operations - discover documentation, execute tasks against agents, check agent capabilities. Covers media buy, creative, signals, governance, SI, and brand protocol.',

--- a/server/src/conformance/index.ts
+++ b/server/src/conformance/index.ts
@@ -20,3 +20,9 @@ export {
   type IssuedConformanceToken,
 } from './token.js';
 export { ConformanceWSServerTransport } from './ws-server-transport.js';
+export {
+  runStoryboardViaConformanceSocket,
+  ConformanceNotConnectedError,
+  StoryboardNotFoundError,
+  type RunStoryboardViaWsOptions,
+} from './run-storyboard-via-ws.js';

--- a/server/src/conformance/run-storyboard-via-ws.ts
+++ b/server/src/conformance/run-storyboard-via-ws.ts
@@ -1,0 +1,97 @@
+/**
+ * Run a storyboard against an adopter connected via Socket Mode.
+ *
+ * Resolves the live `ConformanceSession` for the given org, wraps its
+ * MCP `Client` as an `AgentClient` via `AgentClient.fromMCPClient` (the
+ * SDK's existing in-process injection seam), and dispatches to the
+ * standard `runStoryboard` runner. The runner sees a normal `_client`
+ * override and behaves exactly as it would for any in-process test —
+ * the WebSocket transport is invisible above the MCP layer.
+ *
+ * No changes to the existing storyboard runner or compliance heartbeat
+ * are required. This is a separate runner that picks the same storyboards
+ * from the same registry.
+ */
+
+import { AgentClient } from '@adcp/sdk';
+import { runStoryboard } from '@adcp/sdk/testing';
+import type { StoryboardResult, StoryboardRunOptions } from '@adcp/sdk/testing';
+import { conformanceSessions } from './session-store.js';
+import { getStoryboard } from '../services/storyboards.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('conformance-run-storyboard');
+
+export class ConformanceNotConnectedError extends Error {
+  constructor(public readonly orgId: string) {
+    super(
+      `No conformance session for org ${orgId}. Ask Addie for a fresh conformance token and run @adcp/sdk's ConformanceClient against this org.`,
+    );
+    this.name = 'ConformanceNotConnectedError';
+  }
+}
+
+export class StoryboardNotFoundError extends Error {
+  constructor(public readonly storyboardId: string) {
+    super(`Unknown storyboard: ${storyboardId}`);
+    this.name = 'StoryboardNotFoundError';
+  }
+}
+
+export interface RunStoryboardViaWsOptions {
+  timeoutMs?: number;
+  testSessionId?: string;
+}
+
+/**
+ * Synthetic agent URL used to satisfy `runStoryboard`'s positional
+ * `agentUrlOrUrls` argument. The runner reads `_client` first when it's
+ * present, so this URL is never actually dialed — it only feeds debug
+ * logs and error messages. The `adcp-conformance-socket://` scheme makes
+ * it obvious in traces that this run rode the Socket Mode path.
+ */
+const SYNTHETIC_AGENT_URL_PREFIX = 'adcp-conformance-socket://';
+
+export async function runStoryboardViaConformanceSocket(
+  orgId: string,
+  storyboardId: string,
+  options: RunStoryboardViaWsOptions = {},
+): Promise<StoryboardResult> {
+  const session = conformanceSessions.get(orgId);
+  if (!session) {
+    throw new ConformanceNotConnectedError(orgId);
+  }
+
+  const storyboard = getStoryboard(storyboardId);
+  if (!storyboard) {
+    throw new StoryboardNotFoundError(storyboardId);
+  }
+
+  // The MCP `Client` type imported from the ESM build of
+  // `@modelcontextprotocol/sdk` and the same type baked into `@adcp/sdk`'s
+  // CJS build look distinct to TypeScript even though they're structurally
+  // identical at runtime. The `unknown` round-trip skips the duplicated-
+  // declaration check without weakening the actual contract.
+  const mcpClient = session.mcpClient as unknown as Parameters<typeof AgentClient.fromMCPClient>[0];
+  const agentClient = AgentClient.fromMCPClient(mcpClient);
+  const syntheticUrl = `${SYNTHETIC_AGENT_URL_PREFIX}${orgId}`;
+  const testSessionId = options.testSessionId ?? `conformance-${orgId}-${Date.now()}`;
+
+  logger.info(
+    { orgId, storyboardId, testSessionId },
+    'running storyboard over conformance socket',
+  );
+
+  // `_client` is a private-by-convention injection seam on
+  // `StoryboardRunOptions` (see comply()'s usage). It's recognized by
+  // `getOrCreateClient` but isn't on the public type. Cast through the
+  // narrow runOptions shape rather than `as any` so unrelated typos still
+  // get caught.
+  const runOptions = {
+    _client: agentClient,
+    test_session_id: testSessionId,
+    timeout_ms: options.timeoutMs ?? 60_000,
+  } as StoryboardRunOptions & { _client: AgentClient };
+
+  return runStoryboard(syntheticUrl, storyboard, runOptions);
+}

--- a/server/src/conformance/run-storyboard-via-ws.ts
+++ b/server/src/conformance/run-storyboard-via-ws.ts
@@ -62,6 +62,16 @@ export async function runStoryboardViaConformanceSocket(
     throw new ConformanceNotConnectedError(orgId);
   }
 
+  // Liveness check — a session can linger in the store for one tick if
+  // the adopter disconnected between the runner's session lookup and a
+  // displaced same-org connect's eviction. Treat a closed transport as
+  // not-connected so the runner returns the connect-the-client hint
+  // rather than dispatching into a dead AgentClient.
+  if (session.transport.isClosed()) {
+    conformanceSessions.remove(orgId);
+    throw new ConformanceNotConnectedError(orgId);
+  }
+
   const storyboard = getStoryboard(storyboardId);
   if (!storyboard) {
     throw new StoryboardNotFoundError(storyboardId);

--- a/server/src/conformance/token-route.ts
+++ b/server/src/conformance/token-route.ts
@@ -72,22 +72,54 @@ export function buildConformanceTokenRouter(): Router {
 
     // Dev-only storyboard trigger — lets a local smoke harness exercise
     // the full PR #2 path (runStoryboardViaConformanceSocket) without
-    // needing the Addie chat surface. Requires a live conformance session
-    // for the supplied orgId (POST a token to /token first, connect from
-    // an adopter, then POST here). Production builds skip this entire block.
+    // needing the Addie chat surface. Production builds skip this entire
+    // block.
+    //
+    // Tenant scoping: normal authenticated callers (WorkOS users / API
+    // keys) MUST run against their own resolved org. The static admin
+    // API key (which has no tenant binding) is allowed to drive any
+    // connected session by supplying `org_id` in the body — this is the
+    // intended escape hatch for local smoke tools. Any user reaching
+    // this endpoint is already on a non-production deployment with the
+    // static admin key configured; the smoke-tool privilege is
+    // consistent with the rest of the surface admin already touches.
     router.post('/_debug/run-storyboard', requireAuth, async (req: Request, res: Response) => {
-      const orgId = typeof req.body?.org_id === 'string' ? req.body.org_id : null;
+      const isStaticAdmin = (req as Request & { isStaticAdminApiKey?: boolean })
+        .isStaticAdminApiKey === true;
+      const callerOrgId = await resolveCallerOrgId(req);
+      const bodyOrgId = typeof req.body?.org_id === 'string' ? req.body.org_id : null;
+
+      let targetOrgId: string;
+      if (isStaticAdmin) {
+        if (!bodyOrgId) {
+          res.status(400).json({ error: 'org_id required for admin smoke' });
+          return;
+        }
+        targetOrgId = bodyOrgId;
+      } else {
+        if (!callerOrgId) {
+          res.status(403).json({ error: 'no_organization' });
+          return;
+        }
+        if (bodyOrgId && bodyOrgId !== callerOrgId) {
+          res.status(403).json({ error: 'forbidden', message: 'org_id must match caller' });
+          return;
+        }
+        targetOrgId = callerOrgId;
+      }
+
       const storyboardId = typeof req.body?.storyboard_id === 'string' ? req.body.storyboard_id : null;
-      if (!orgId || !storyboardId) {
-        res.status(400).json({ error: 'org_id and storyboard_id required' });
+      if (!storyboardId) {
+        res.status(400).json({ error: 'storyboard_id required' });
         return;
       }
       try {
         const { runStoryboardViaConformanceSocket } = await import('./run-storyboard-via-ws.js');
-        const result = await runStoryboardViaConformanceSocket(orgId, storyboardId);
+        const result = await runStoryboardViaConformanceSocket(targetOrgId, storyboardId);
         res.json(result);
       } catch (err) {
-        res.status(500).json({ error: (err as Error).message });
+        logger.error({ err, targetOrgId, storyboardId }, 'debug run-storyboard failed');
+        res.status(500).json({ error: 'run_failed' });
       }
     });
   }

--- a/server/src/conformance/token-route.ts
+++ b/server/src/conformance/token-route.ts
@@ -69,6 +69,27 @@ export function buildConformanceTokenRouter(): Router {
         activeSessions: conformanceSessions.list(),
       });
     });
+
+    // Dev-only storyboard trigger — lets a local smoke harness exercise
+    // the full PR #2 path (runStoryboardViaConformanceSocket) without
+    // needing the Addie chat surface. Requires a live conformance session
+    // for the supplied orgId (POST a token to /token first, connect from
+    // an adopter, then POST here). Production builds skip this entire block.
+    router.post('/_debug/run-storyboard', requireAuth, async (req: Request, res: Response) => {
+      const orgId = typeof req.body?.org_id === 'string' ? req.body.org_id : null;
+      const storyboardId = typeof req.body?.storyboard_id === 'string' ? req.body.storyboard_id : null;
+      if (!orgId || !storyboardId) {
+        res.status(400).json({ error: 'org_id and storyboard_id required' });
+        return;
+      }
+      try {
+        const { runStoryboardViaConformanceSocket } = await import('./run-storyboard-via-ws.js');
+        const result = await runStoryboardViaConformanceSocket(orgId, storyboardId);
+        res.json(result);
+      } catch (err) {
+        res.status(500).json({ error: (err as Error).message });
+      }
+    });
   }
 
   return router;

--- a/server/src/conformance/ws-route.ts
+++ b/server/src/conformance/ws-route.ts
@@ -33,19 +33,20 @@ interface AliveSocket extends WebSocket {
 }
 
 function extractToken(req: http.IncomingMessage): string | null {
-  const url = new URL(req.url ?? '/', 'http://placeholder');
-  const queryToken = url.searchParams.get('token');
-  if (queryToken) return queryToken;
-
+  // Prefer the `Sec-WebSocket-Protocol: adcp.conformance, <token>` form —
+  // headers are not surfaced in access logs by default. Fall back to a
+  // `?token=` query param for browser clients (which can't set custom
+  // WebSocket headers); operators running this surface should treat
+  // adopter-facing access logs as token-equivalent within the 1h TTL.
   const subprotocols = req.headers['sec-websocket-protocol'];
   if (typeof subprotocols === 'string') {
     const parts = subprotocols.split(',').map((s) => s.trim());
     const adcpIdx = parts.findIndex((p) => p === 'adcp.conformance');
     if (adcpIdx !== -1 && parts[adcpIdx + 1]) return parts[adcpIdx + 1];
-    if (parts[0] === 'mcp' && parts[1]) return parts[1];
   }
 
-  return null;
+  const url = new URL(req.url ?? '/', 'http://placeholder');
+  return url.searchParams.get('token');
 }
 
 export function attachConformanceWS(httpServer: http.Server): void {
@@ -114,8 +115,16 @@ async function onConnection(ws: AliveSocket, orgId: string): Promise<void> {
     { capabilities: {} },
   );
 
+  // Identity-keyed eviction: only remove the session entry if it still
+  // points at *this* transport. A same-org reconnect closes the prior
+  // socket via `register()`'s last-writer-wins displacement, which fires
+  // this listener for the *prior* socket — without the identity check, it
+  // would delete the freshly-registered new session and leave the org in
+  // a permanently-unreachable state until the next disconnect.
   ws.once('close', () => {
-    conformanceSessions.remove(orgId);
+    if (conformanceSessions.get(orgId)?.transport === transport) {
+      conformanceSessions.remove(orgId);
+    }
   });
 
   try {
@@ -127,6 +136,14 @@ async function onConnection(ws: AliveSocket, orgId: string): Promise<void> {
     } catch {
       // ignore
     }
+    return;
+  }
+
+  // If the adopter disconnected during initialize, skip registration —
+  // the close listener already ran (no-op against an empty store) and
+  // registering now would leak a session whose underlying socket is gone.
+  if (ws.readyState !== ws.OPEN) {
+    logger.debug({ orgId }, 'conformance adopter disconnected during initialize');
     return;
   }
 

--- a/server/src/conformance/ws-server-transport.ts
+++ b/server/src/conformance/ws-server-transport.ts
@@ -36,6 +36,11 @@ export class ConformanceWSServerTransport implements Transport {
     this.sessionId = `conformance-${orgId}-${Date.now()}`;
   }
 
+  /** True when the local close path or the underlying socket has closed. */
+  isClosed(): boolean {
+    return this.closed;
+  }
+
   async start(): Promise<void> {
     this.socket.on('message', (data, isBinary) => {
       if (isBinary) {

--- a/server/tests/unit/conformance-addie-tools.test.ts
+++ b/server/tests/unit/conformance-addie-tools.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Unit tests for Addie's conformance Socket Mode chat tools.
+ *
+ * Mocks `runStoryboardViaConformanceSocket` so we don't need a live
+ * adopter session — the integration coverage for that path lives in
+ * the conformance/ tests. These tests focus on the handler shapes:
+ * org-binding enforcement, the markdown the user sees, and the
+ * not-connected hint.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { MemberContext } from '../../src/addie/member-context.js';
+
+process.env.CONFORMANCE_JWT_SECRET = 'test-addie-tools-secret';
+process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'test';
+process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+
+const runStoryboardMock = vi.fn();
+vi.mock('../../src/conformance/run-storyboard-via-ws.js', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>(
+    '../../src/conformance/run-storyboard-via-ws.js',
+  );
+  return {
+    ...actual,
+    runStoryboardViaConformanceSocket: (...args: unknown[]) => runStoryboardMock(...args),
+  };
+});
+
+function memberContextWithOrg(orgId: string): MemberContext {
+  return {
+    is_mapped: true,
+    is_member: true,
+    organization: {
+      workos_organization_id: orgId,
+      name: 'Test Org',
+      subscription_status: 'active',
+      is_personal: false,
+      membership_tier: 'professional',
+    },
+  } as unknown as MemberContext;
+}
+
+function memberContextWithoutOrg(): MemberContext {
+  return {
+    is_mapped: false,
+    is_member: false,
+  } as unknown as MemberContext;
+}
+
+beforeEach(async () => {
+  runStoryboardMock.mockReset();
+  const { conformanceSessions } = await import('../../src/conformance/session-store.js');
+  await conformanceSessions.closeAll();
+});
+
+describe('issue_conformance_token Addie tool', () => {
+  it('returns a not-mapped hint when the caller has no org', async () => {
+    const { createConformanceToolHandlers } = await import(
+      '../../src/addie/mcp/conformance-tools.js'
+    );
+    const handlers = createConformanceToolHandlers(memberContextWithoutOrg());
+    const handler = handlers.get('issue_conformance_token');
+    const out = await handler!({});
+    expect(out).toMatch(/not mapped to an organization/i);
+  });
+
+  it('returns a token + url + expiry when the caller has an org', async () => {
+    const { createConformanceToolHandlers } = await import(
+      '../../src/addie/mcp/conformance-tools.js'
+    );
+    const handlers = createConformanceToolHandlers(memberContextWithOrg('org_alpha'));
+    const handler = handlers.get('issue_conformance_token');
+    const out = await handler!({});
+    expect(out).toMatch(/Conformance token issued/i);
+    expect(out).toMatch(/ADCP_CONFORMANCE_TOKEN=/);
+    expect(out).toMatch(/ADCP_CONFORMANCE_URL=/);
+    expect(out).toMatch(/Expires at/);
+    expect(out).toMatch(/@adcp\/sdk\/server/);
+  });
+
+  it('returns a configuration error when CONFORMANCE_JWT_SECRET is missing', async () => {
+    delete process.env.CONFORMANCE_JWT_SECRET;
+    const { createConformanceToolHandlers } = await import(
+      '../../src/addie/mcp/conformance-tools.js'
+    );
+    const handlers = createConformanceToolHandlers(memberContextWithOrg('org_alpha'));
+    const out = await handlers.get('issue_conformance_token')!({});
+    expect(out).toMatch(/not configured/i);
+    process.env.CONFORMANCE_JWT_SECRET = 'test-addie-tools-secret';
+  });
+});
+
+describe('run_conformance_against_my_agent Addie tool', () => {
+  it('returns a not-mapped hint when the caller has no org', async () => {
+    const { createConformanceToolHandlers } = await import(
+      '../../src/addie/mcp/conformance-tools.js'
+    );
+    const handlers = createConformanceToolHandlers(memberContextWithoutOrg());
+    const out = await handlers.get('run_conformance_against_my_agent')!({
+      storyboard_id: 'media_buy_state_machine',
+    });
+    expect(out).toMatch(/not mapped to an organization/i);
+    expect(runStoryboardMock).not.toHaveBeenCalled();
+  });
+
+  it('returns a missing-id message when storyboard_id is empty', async () => {
+    const { createConformanceToolHandlers } = await import(
+      '../../src/addie/mcp/conformance-tools.js'
+    );
+    const handlers = createConformanceToolHandlers(memberContextWithOrg('org_a'));
+    const out = await handlers.get('run_conformance_against_my_agent')!({});
+    expect(out).toMatch(/storyboard_id.*required/i);
+  });
+
+  it('returns the not-connected hint when the org has no live session', async () => {
+    const { createConformanceToolHandlers } = await import(
+      '../../src/addie/mcp/conformance-tools.js'
+    );
+    const handlers = createConformanceToolHandlers(memberContextWithOrg('org_a'));
+    const out = await handlers.get('run_conformance_against_my_agent')!({
+      storyboard_id: 'media_buy_state_machine',
+    });
+    expect(out).toMatch(/No conformance connection is live/i);
+    expect(out).toMatch(/issue_conformance_token/);
+    expect(runStoryboardMock).not.toHaveBeenCalled();
+  });
+
+  it('formats a passing storyboard result as markdown', async () => {
+    const { createConformanceToolHandlers } = await import(
+      '../../src/addie/mcp/conformance-tools.js'
+    );
+    const { conformanceSessions } = await import('../../src/conformance/session-store.js');
+    // Register a placeholder session so the not-connected guard doesn't fire.
+    conformanceSessions.register({
+      orgId: 'org_a',
+      transport: { close: vi.fn().mockResolvedValue(undefined) } as never,
+      mcpClient: {} as never,
+      connectedAt: Date.now(),
+    });
+
+    runStoryboardMock.mockResolvedValue({
+      storyboard_id: 'sb_demo',
+      storyboard_title: 'Demo Storyboard',
+      overall_passed: true,
+      passed_count: 2,
+      failed_count: 0,
+      skipped_count: 0,
+      total_duration_ms: 123,
+      phases: [
+        {
+          phase_id: 'p1',
+          phase_title: 'Setup',
+          passed: true,
+          duration_ms: 50,
+          steps: [
+            { step_id: 's1', phase_id: 'p1', title: 'discover', task: 'discover', passed: true },
+            { step_id: 's2', phase_id: 'p1', title: 'query', task: 'query', passed: true },
+          ],
+        },
+      ],
+    });
+
+    const handlers = createConformanceToolHandlers(memberContextWithOrg('org_a'));
+    const out = await handlers.get('run_conformance_against_my_agent')!({
+      storyboard_id: 'sb_demo',
+    });
+    expect(out).toMatch(/PASSED/);
+    expect(out).toMatch(/2 \/ 0 \/ 0/);
+    expect(out).toMatch(/Setup/);
+    expect(out).toMatch(/discover/);
+  });
+
+  it('renders error text on failing steps', async () => {
+    const { createConformanceToolHandlers } = await import(
+      '../../src/addie/mcp/conformance-tools.js'
+    );
+    const { conformanceSessions } = await import('../../src/conformance/session-store.js');
+    conformanceSessions.register({
+      orgId: 'org_a',
+      transport: { close: vi.fn().mockResolvedValue(undefined) } as never,
+      mcpClient: {} as never,
+      connectedAt: Date.now(),
+    });
+
+    runStoryboardMock.mockResolvedValue({
+      storyboard_id: 'sb_demo',
+      storyboard_title: 'Demo',
+      overall_passed: false,
+      passed_count: 1,
+      failed_count: 1,
+      skipped_count: 0,
+      total_duration_ms: 200,
+      phases: [
+        {
+          phase_id: 'p1',
+          phase_title: 'Run',
+          passed: false,
+          duration_ms: 200,
+          steps: [
+            { step_id: 's1', phase_id: 'p1', title: 'first', task: 'first', passed: true },
+            {
+              step_id: 's2',
+              phase_id: 'p1',
+              title: 'second',
+              task: 'second',
+              passed: false,
+              error: 'expected status 200, got 500',
+            },
+          ],
+        },
+      ],
+    });
+
+    const handlers = createConformanceToolHandlers(memberContextWithOrg('org_a'));
+    const out = await handlers.get('run_conformance_against_my_agent')!({
+      storyboard_id: 'sb_demo',
+    });
+    expect(out).toMatch(/FAILED/);
+    expect(out).toMatch(/expected status 200, got 500/);
+  });
+});

--- a/server/tests/unit/conformance-end-to-end.test.ts
+++ b/server/tests/unit/conformance-end-to-end.test.ts
@@ -211,4 +211,70 @@ describe('conformance Socket Mode end-to-end', () => {
     await new Promise((r) => setTimeout(r, 100));
     expect(conformanceSessions.get(orgId)).toBeUndefined();
   });
+
+  it('keeps the new session after a same-org reconnect (no race-eviction)', async () => {
+    // Regression: an earlier version of ws-route's close listener removed
+    // the session by orgId only, so a same-org reconnect's displacement
+    // close on the prior socket would delete the just-registered new
+    // session. The fix: the close listener checks transport identity
+    // before removing.
+    const orgId = 'org_reconnect_race';
+    const { token: tokenA } = issueConformanceToken(orgId);
+    const { token: tokenB } = issueConformanceToken(orgId);
+
+    const wsA = new WebSocket(
+      `ws://127.0.0.1:${port}/conformance/connect?token=${encodeURIComponent(tokenA)}`,
+    );
+    const transportA = new AdopterWSTransport(wsA);
+    const serverA = buildAdopterServer();
+    await serverA.connect(transportA);
+    await waitForSession(orgId);
+    const firstSession = conformanceSessions.get(orgId);
+    expect(firstSession).toBeTruthy();
+
+    // Second connect from the same org displaces the first. The displaced
+    // socket's close handler must NOT remove the new session.
+    const wsB = new WebSocket(
+      `ws://127.0.0.1:${port}/conformance/connect?token=${encodeURIComponent(tokenB)}`,
+    );
+    const transportB = new AdopterWSTransport(wsB);
+    const serverB = buildAdopterServer();
+    await serverB.connect(transportB);
+
+    // Wait for displacement to settle.
+    const deadline = Date.now() + 2000;
+    while (Date.now() < deadline) {
+      const cur = conformanceSessions.get(orgId);
+      if (cur && cur !== firstSession) break;
+      await new Promise((r) => setTimeout(r, 20));
+    }
+
+    const newSession = conformanceSessions.get(orgId);
+    expect(newSession).toBeTruthy();
+    expect(newSession).not.toBe(firstSession);
+
+    // Give the displaced wsA's `close` event a beat to fire and (correctly)
+    // do nothing because the store now keys to wsB's transport.
+    await new Promise((r) => setTimeout(r, 100));
+    expect(conformanceSessions.get(orgId)).toBe(newSession);
+
+    await transportB.close();
+  });
+
+  it('rejects subprotocol probe with the wrong sentinel', async () => {
+    // Earlier code accepted `Sec-WebSocket-Protocol: mcp, <token>` as a
+    // fallback. The fix tightens it to require the explicit
+    // `adcp.conformance` sentinel.
+    const orgId = 'org_subprotocol';
+    const { token } = issueConformanceToken(orgId);
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/conformance/connect`, [
+      'mcp',
+      token,
+    ]);
+    const status = await new Promise<number | undefined>((resolve) => {
+      ws.once('error', () => resolve(undefined));
+      ws.once('unexpected-response', (_req, res) => resolve(res.statusCode));
+    });
+    expect(status).toBe(401);
+  });
 });

--- a/server/tests/unit/conformance-run-storyboard.test.ts
+++ b/server/tests/unit/conformance-run-storyboard.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Unit + integration tests for `runStoryboardViaConformanceSocket`.
+ *
+ * The architecture-correctness test (real WebSocket, full MCP round-trip)
+ * lives in `conformance-end-to-end.test.ts`. This file focuses on the
+ * adapter logic: session lookup, storyboard lookup, AgentClient wrapping,
+ * and error paths. We mock `runStoryboard` from `@adcp/sdk/testing` so
+ * we don't need a real sales agent + test kits to exercise the adapter.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterAll, beforeAll } from 'vitest';
+import { createServer, type Server as HttpServer } from 'node:http';
+import WebSocket from 'ws';
+import { Server as McpServer } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type JSONRPCMessage,
+  JSONRPCMessageSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+
+process.env.CONFORMANCE_JWT_SECRET = 'test-runs-storyboard-secret';
+process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'test';
+process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+
+const runStoryboardMock = vi.fn();
+vi.mock('@adcp/sdk/testing', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@adcp/sdk/testing');
+  return {
+    ...actual,
+    runStoryboard: (...args: unknown[]) => runStoryboardMock(...args),
+  };
+});
+
+const getStoryboardMock = vi.fn();
+vi.mock('../../src/services/storyboards.js', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('../../src/services/storyboards.js');
+  return {
+    ...actual,
+    getStoryboard: (id: string) => getStoryboardMock(id),
+  };
+});
+
+class AdopterTransport implements Transport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (msg: JSONRPCMessage) => void;
+  sessionId?: string;
+  private closed = false;
+
+  constructor(private socket: WebSocket) {}
+
+  async start(): Promise<void> {
+    this.socket.on('message', (data) => {
+      try {
+        const result = JSONRPCMessageSchema.safeParse(JSON.parse(data.toString('utf-8')));
+        if (result.success) this.onmessage?.(result.data);
+      } catch {
+        // ignore
+      }
+    });
+    this.socket.on('close', () => {
+      if (this.closed) return;
+      this.closed = true;
+      this.onclose?.();
+    });
+    if (this.socket.readyState !== WebSocket.OPEN) {
+      await new Promise<void>((resolve, reject) => {
+        this.socket.once('open', () => resolve());
+        this.socket.once('error', reject);
+      });
+    }
+  }
+
+  async send(msg: JSONRPCMessage): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.socket.send(JSON.stringify(msg), (err) => (err ? reject(err) : resolve()));
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    this.socket.close();
+  }
+}
+
+let httpServer: HttpServer;
+let port: number;
+
+beforeAll(async () => {
+  const { attachConformanceWS } = await import('../../src/conformance/ws-route.js');
+  httpServer = createServer((_req, res) => {
+    res.statusCode = 404;
+    res.end();
+  });
+  attachConformanceWS(httpServer);
+  await new Promise<void>((resolve) => httpServer.listen(0, '127.0.0.1', () => resolve()));
+  const addr = httpServer.address();
+  port = typeof addr === 'object' && addr ? addr.port : 0;
+});
+
+afterAll(async () => {
+  const { conformanceSessions } = await import('../../src/conformance/session-store.js');
+  await conformanceSessions.closeAll();
+  await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+});
+
+beforeEach(async () => {
+  runStoryboardMock.mockReset();
+  getStoryboardMock.mockReset();
+  const { conformanceSessions } = await import('../../src/conformance/session-store.js');
+  await conformanceSessions.closeAll();
+});
+
+describe('runStoryboardViaConformanceSocket', () => {
+  it('throws ConformanceNotConnectedError when the org has no live session', async () => {
+    const { runStoryboardViaConformanceSocket, ConformanceNotConnectedError } = await import(
+      '../../src/conformance/run-storyboard-via-ws.js'
+    );
+    await expect(
+      runStoryboardViaConformanceSocket('org_missing', 'any_storyboard'),
+    ).rejects.toBeInstanceOf(ConformanceNotConnectedError);
+    expect(runStoryboardMock).not.toHaveBeenCalled();
+  });
+
+  it('throws StoryboardNotFoundError when the storyboard id is unknown', async () => {
+    const { issueConformanceToken } = await import('../../src/conformance/token.js');
+    const { conformanceSessions } = await import('../../src/conformance/session-store.js');
+    const { runStoryboardViaConformanceSocket, StoryboardNotFoundError } = await import(
+      '../../src/conformance/run-storyboard-via-ws.js'
+    );
+
+    const orgId = 'org_with_session';
+    const { token } = issueConformanceToken(orgId);
+    const ws = new WebSocket(
+      `ws://127.0.0.1:${port}/conformance/connect?token=${encodeURIComponent(token)}`,
+    );
+    const adopterServer = new McpServer(
+      { name: 'adopter', version: '0.0.1' },
+      { capabilities: { tools: {} } },
+    );
+    adopterServer.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [] }));
+    adopterServer.setRequestHandler(CallToolRequestSchema, async () => {
+      throw new Error('not implemented in test');
+    });
+    const transport = new AdopterTransport(ws);
+    await adopterServer.connect(transport);
+
+    // wait for session to register
+    const deadline = Date.now() + 2000;
+    while (!conformanceSessions.get(orgId) && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+
+    getStoryboardMock.mockReturnValue(undefined);
+
+    await expect(
+      runStoryboardViaConformanceSocket(orgId, 'definitely_not_a_real_storyboard'),
+    ).rejects.toBeInstanceOf(StoryboardNotFoundError);
+    expect(runStoryboardMock).not.toHaveBeenCalled();
+
+    await transport.close();
+  });
+
+  it('wraps the session MCP client as an AgentClient and dispatches via runStoryboard', async () => {
+    const { issueConformanceToken } = await import('../../src/conformance/token.js');
+    const { conformanceSessions } = await import('../../src/conformance/session-store.js');
+    const { runStoryboardViaConformanceSocket } = await import(
+      '../../src/conformance/run-storyboard-via-ws.js'
+    );
+
+    const orgId = 'org_runs_storyboard';
+    const { token } = issueConformanceToken(orgId);
+    const ws = new WebSocket(
+      `ws://127.0.0.1:${port}/conformance/connect?token=${encodeURIComponent(token)}`,
+    );
+    const adopterServer = new McpServer(
+      { name: 'adopter', version: '0.0.1' },
+      { capabilities: { tools: {} } },
+    );
+    adopterServer.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [] }));
+    adopterServer.setRequestHandler(CallToolRequestSchema, async () => {
+      throw new Error('not implemented in test');
+    });
+    const transport = new AdopterTransport(ws);
+    await adopterServer.connect(transport);
+
+    const deadline = Date.now() + 2000;
+    while (!conformanceSessions.get(orgId) && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+
+    const fakeStoryboard = { id: 'fake_storyboard', phases: [] } as unknown as Parameters<
+      typeof getStoryboardMock
+    >[0];
+    getStoryboardMock.mockReturnValue(fakeStoryboard);
+    runStoryboardMock.mockResolvedValue({
+      storyboard_id: 'fake_storyboard',
+      overall_passed: true,
+    });
+
+    const result = await runStoryboardViaConformanceSocket(orgId, 'fake_storyboard', {
+      timeoutMs: 12_345,
+      testSessionId: 'test-fixed-id',
+    });
+    expect(result.overall_passed).toBe(true);
+
+    expect(runStoryboardMock).toHaveBeenCalledTimes(1);
+    const [agentUrlArg, storyboardArg, optionsArg] = runStoryboardMock.mock.calls[0];
+    expect(agentUrlArg).toBe(`adcp-conformance-socket://${orgId}`);
+    expect(storyboardArg).toBe(fakeStoryboard);
+    expect(optionsArg.test_session_id).toBe('test-fixed-id');
+    expect(optionsArg.timeout_ms).toBe(12_345);
+    expect(optionsArg._client).toBeTruthy();
+    // Sanity check — `_client` should expose the AgentClient surface
+    expect(typeof optionsArg._client.getAdcpVersion).toBe('function');
+
+    await transport.close();
+  });
+});


### PR DESCRIPTION
## Summary

Combines what was originally PR #4051 (storyboard runner adapter) and PR #4054 (Addie chat tools + docs + smoke + expert-review fixes) into a single PR against main, since both of those got auto-closed when the base of the stack (#4007) was squash-merged.

PR #4007 (server-side WS transport + token issuance) is already merged to main. This PR is what's left.

## What's in this PR

**1. Storyboard runner adapter** (was #4051 — `bebef0c358`)
- `server/src/conformance/run-storyboard-via-ws.ts` — `runStoryboardViaConformanceSocket(orgId, storyboardId)` resolves the live session, wraps its MCP client as an `AgentClient` via `AgentClient.fromMCPClient` (already in `@adcp/sdk` 6.7+), dispatches via `runStoryboard` with `_client` injection
- 3 unit tests covering both error paths (no session / unknown storyboard) and the success path

**2. Addie chat tools** (was #4054 — `537fb12d`)
- `server/src/addie/mcp/conformance-tools.ts` — `issue_conformance_token` + `run_conformance_against_my_agent`
- Bound to caller's WorkOS organization via `memberContext`
- Gated on `CONFORMANCE_SOCKET_ENABLED=1`
- New `agent_conformance` toolset entry; registered in `bolt-app.ts`

**3. User-facing docs** (`1d460e96`)
- `docs/building/verification/addie-socket-mode.mdx` — "Pair-program with Addie (Socket Mode)" walkthrough: when to use it vs the AAO heartbeat path, prerequisites, five-minute setup, what Addie can do once connected, privacy/safety posture, troubleshooting
- Wired into `docs.json` under "Verification & trust"

**4. Smoke harnesses + dev debug endpoint** (`db5de04e`)
- `scripts/smoke-conformance.ts` — single-process end-to-end (server + adopter + Addie tool calls)
- `scripts/smoke-conformance-training-agent.ts` — proxy adopter that connects via Socket Mode and forwards to the local training agent's `/api/training-agent/sales/mcp`. Demonstrates the architecture against a real AdCP server
- `POST /api/conformance/_debug/run-storyboard` — dev-only trigger (`NODE_ENV !== 'production'`) so smoke harnesses can exercise the full path without the Addie chat surface. Tenant-scoped per the security review

**5. Expert-review fixes** (`0bb16d41`) — five issues caught by security + code review:
- Race-eviction on same-org reconnect (must-fix) — close listener now identity-keyed
- Pre-register disconnect leak — bail if WS closed during MCP initialize
- Liveness check before runner dispatch — `ConformanceWSServerTransport.isClosed()` + early return in the runner
- Subprotocol-sentinel tightening — drop the `mcp` fallback, prefer header over query (out of access logs)
- Debug endpoint tenant scoping — normal callers must run against own resolved org; static-admin-key retains body-`org_id` for smokes
- 2 new regression tests for the race + sentinel paths

## Test plan

- [x] CI green
- [x] `npx vitest run server/tests/unit/conformance-*.test.ts` — 42/42 pass
- [x] `npx tsc --project server/tsconfig.json --noEmit` — clean
- [x] Live smoke against local training agent — runs storyboard end-to-end via Socket Mode, surfaces same `pause_canceled_buy` failure as direct HTTP, proving the transport is invisible above MCP
- [x] Security review — no must-fix items remaining; should-fix items addressed
- [x] Code review — duplicate-connect race fixed; should-fix items addressed

## Linked

- Server-side foundation: #4007 (merged)
- Spec rule: adcontextprotocol/adcp#3986
- Channel design: adcontextprotocol/adcp#3991
- Upstream `ConformanceClient` in `@adcp/sdk` 6.9: adcontextprotocol/adcp-client#1506

🤖 Generated with [Claude Code](https://claude.com/claude-code)