### PR TITLE
fix(training-agent): thread brand_domain through updateMediaBuy and read-side v6 wrappers

### DIFF
--- a/.changeset/fix-update-media-buy-session-key.md
+++ b/.changeset/fix-update-media-buy-session-key.md
@@ -1,0 +1,25 @@
+---
+---
+
+fix(training-agent): update_media_buy on cancelled buy returns INVALID_STATE not MEDIA_BUY_NOT_FOUND
+
+Closes #4083. The v6 `SalesPlatform.updateMediaBuy` wrapper was missing the
+`brand_domain` session-key threading that `syncCreatives` already carries. The
+v6 SDK resolves `account.brand.domain` into `ctx.account.ctx_metadata.brand_domain`
+but does not re-inject it into the `patch` object, so `sessionKeyFromArgs` in
+the v5 handler resolved to `open:default` while the buy lived in
+`open:<brand-domain>`. The `pause_canceled_buy` storyboard step therefore got
+`MEDIA_BUY_NOT_FOUND` instead of `INVALID_STATE`.
+
+**Changes:**
+
+- `v6-sales-platform.ts`: extract `brandDomainFromCtx` helper; thread
+  `brand.domain` into args for `updateMediaBuy`, `getMediaBuyDelivery`,
+  `getMediaBuys`, and `listCreatives`; use the helper in the existing
+  `syncCreatives` fix to remove the inline copy.
+- `task-handlers.ts`: remove unreachable secondary re-cancel guard inside
+  `handleUpdateMediaBuy` (lines 2726-2733) that returned `INVALID_STATE`
+  on a re-cancel instead of the required `NOT_CANCELLABLE`. The primary
+  terminal-state check at line 2703 already handles re-cancels correctly
+  before this branch could ever execute; the dead code was a latent
+  spec-violation if the invariant were ever relaxed.

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -2723,14 +2723,6 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
   // Media buy cancellation
   const isCanceled = req.canceled === true;
   if (isCanceled) {
-    if (mb.canceledAt) {
-      return {
-        errors: [{
-          code: 'INVALID_STATE',
-          message: `Media buy ${mb.mediaBuyId} is already canceled (canceled_at ${mb.canceledAt}) and cannot be canceled again.`,
-        }],
-      };
-    }
     const reason = req.cancellation_reason;
     mb.canceledAt = now;
     mb.canceledBy = 'buyer';

--- a/server/src/training-agent/v6-sales-platform.ts
+++ b/server/src/training-agent/v6-sales-platform.ts
@@ -49,6 +49,18 @@ function buildTrainingCtx(account: { authInfo?: { principal?: string } } | undef
   };
 }
 
+/**
+ * Extract the brand domain from a resolved v6 Account so v5 handlers can
+ * derive the correct session key via sessionKeyFromArgs. The v6 SDK resolves
+ * `account.brand.domain` into `ctx_metadata.brand_domain` on the Account
+ * object but does NOT re-inject it into domain-level args (req / filter /
+ * patch), so handlers that rely on sessionKeyFromArgs need it threaded in
+ * explicitly. Same fix as syncCreatives — see comment there.
+ */
+function brandDomainFromCtx(account: unknown): string | undefined {
+  return (account as { ctx_metadata?: { brand_domain?: string } } | undefined)?.ctx_metadata?.brand_domain;
+}
+
 
 /**
  * v5 → v6 envelope translator. v5 handlers return `{ errors: [...] }` for
@@ -180,19 +192,18 @@ export class TrainingSalesPlatform
     },
 
     updateMediaBuy: async (buyId, patch, ctx) => {
-      const args = { media_buy_id: buyId, ...(patch as unknown as Record<string, unknown>) };
+      const brandDomain = brandDomainFromCtx(ctx.account);
+      // brand placed after patch spread so it takes precedence over any brand
+      // field the SDK might include in patch.
+      const args = brandDomain
+        ? { media_buy_id: buyId, ...(patch as unknown as Record<string, unknown>), brand: { domain: brandDomain } }
+        : { media_buy_id: buyId, ...(patch as unknown as Record<string, unknown>) };
       const v5Result = await handleUpdateMediaBuy(args as ToolArgs, buildTrainingCtx(ctx.account));
       return translateV5Result(v5Result);
     },
 
     syncCreatives: async (creatives, ctx) => {
-      // Thread brand domain through so `sessionKeyFromArgs` in the v5
-      // handler resolves to the same session the test-controller seeded
-      // creative_policy against. Without this, sync_creatives lands in
-      // `open:default` while the seeded products live on `open:<brand>`,
-      // and `aggregateCreativePolicy` returns null — provenance
-      // enforcement silently no-ops.
-      const brandDomain = (ctx.account as { ctx_metadata?: { brand_domain?: string } } | undefined)?.ctx_metadata?.brand_domain;
+      const brandDomain = brandDomainFromCtx(ctx.account);
       const args = brandDomain ? { creatives, brand: { domain: brandDomain } } : { creatives };
       const v5Result = await handleSyncCreatives(args as unknown as ToolArgs, buildTrainingCtx(ctx.account));
       // v5 returns wire-wrapped `{ creatives: [...] }`; v6 SalesPlatform
@@ -202,13 +213,21 @@ export class TrainingSalesPlatform
     },
 
     getMediaBuyDelivery: async (filter, ctx) => {
-      const result = await handleGetMediaBuyDelivery(filter as ToolArgs, buildTrainingCtx(ctx.account));
+      const brandDomain = brandDomainFromCtx(ctx.account);
+      const args = brandDomain
+        ? { ...(filter as unknown as Record<string, unknown>), brand: { domain: brandDomain } }
+        : filter;
+      const result = await handleGetMediaBuyDelivery(args as ToolArgs, buildTrainingCtx(ctx.account));
       return translateV5Result(result);
     },
 
     // Optional read-side methods.
     getMediaBuys: async (req, ctx) => {
-      const result = await handleGetMediaBuys(req as ToolArgs, buildTrainingCtx(ctx.account));
+      const brandDomain = brandDomainFromCtx(ctx.account);
+      const args = brandDomain
+        ? { ...(req as unknown as Record<string, unknown>), brand: { domain: brandDomain } }
+        : req;
+      const result = await handleGetMediaBuys(args as ToolArgs, buildTrainingCtx(ctx.account));
       return translateV5Result(result);
     },
 
@@ -218,7 +237,11 @@ export class TrainingSalesPlatform
     },
 
     listCreatives: async (req, ctx) => {
-      const result = await handleListCreatives(req as ToolArgs, buildTrainingCtx(ctx.account));
+      const brandDomain = brandDomainFromCtx(ctx.account);
+      const args = brandDomain
+        ? { ...(req as unknown as Record<string, unknown>), brand: { domain: brandDomain } }
+        : req;
+      const result = await handleListCreatives(args as ToolArgs, buildTrainingCtx(ctx.account));
       return translateV5Result(result);
     },
 

--- a/server/src/training-agent/v6-sales-platform.ts
+++ b/server/src/training-agent/v6-sales-platform.ts
@@ -58,9 +58,8 @@ function buildTrainingCtx(account: { authInfo?: { principal?: string } } | undef
  * explicitly. Same fix as syncCreatives — see comment there.
  */
 function brandDomainFromCtx(account: unknown): string | undefined {
-  return (account as { ctx_metadata?: { brand_domain?: string } } | undefined)?.ctx_metadata?.brand_domain;
+  return (account as { ctx_metadata?: TrainingSalesMeta } | undefined)?.ctx_metadata?.brand_domain;
 }
-
 
 /**
  * v5 → v6 envelope translator. v5 handlers return `{ errors: [...] }` for


### PR DESCRIPTION
Closes #4083.

## Root cause

The v6 `SalesPlatform.updateMediaBuy` wrapper constructs its args as `{ media_buy_id: buyId, ...patch }`. The `patch` object from the SDK does not include `brand.domain`. `sessionKeyFromArgs` therefore resolved `open:default` while the buy was seeded under `open:<brand-domain>` — causing `getSession` to return empty state and the handler to return `MEDIA_BUY_NOT_FOUND` instead of `INVALID_STATE`.

The `syncCreatives` method already had the same fix applied; this PR extends it to the remaining methods and extracts a shared `brandDomainFromCtx` helper.

## Changes

**`v6-sales-platform.ts`**
- Add `brandDomainFromCtx(account)` helper — reads `ctx_metadata.brand_domain` (typed against `TrainingSalesMeta`) from the resolved v6 Account
- `updateMediaBuy`: spread `brand: { domain: brandDomain }` after the patch spread so it takes precedence
- `getMediaBuyDelivery`, `getMediaBuys`, `listCreatives`: same threading pattern
- `syncCreatives`: refactor inline cast to use `brandDomainFromCtx`

**`task-handlers.ts`**
- Remove unreachable secondary re-cancel guard inside `handleUpdateMediaBuy` (old lines 2726–2733) that returned `INVALID_STATE` on a re-cancel instead of the spec-required `NOT_CANCELLABLE`. The primary terminal-state check at line 2703 (`['canceled','rejected','completed'].includes(currentStatus)`) already handles re-cancels correctly before this branch could execute; the dead code was a latent spec violation.

## Error matrix after fix

| Scenario | Error code |
|---|---|
| `updateMediaBuy` on `canceled` buy (non-cancel patch) | `INVALID_STATE` |
| `updateMediaBuy` on `rejected` buy | `INVALID_STATE` |
| `updateMediaBuy` on `completed` buy | `INVALID_STATE` |
| Re-cancel a `canceled` buy (`canceled: true` patch) | `NOT_CANCELLABLE` |

Matches spec lines 150–151 of `docs/media-buy/specification.mdx`.

## Expert review

- **Protocol (ad-tech-protocol-expert)**: Verdict Sound — error matrix matches normative spec; brand threading mirrors the correct syncCreatives pattern.
- **Code (code-reviewer)**: All confirms; one issue resolved (use `TrainingSalesMeta` in `brandDomainFromCtx` cast instead of inline re-declaration).

## Test coverage

Existing unit tests at `server/tests/unit/training-agent.test.ts:6895–6952` cover terminal-state scenarios via the v5 path. The v6 wrapper path is exercised by the `media_buy_state_machine` compliance storyboard (step 7 `pause_canceled_buy`, step 9 `recancel_buy`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQKDbtK9Qai2EoCuxTFC3d)_