### PR TITLE
fix(compliance): chain proposal_id through proposal_finalize storyboard

### DIFF
--- a/.changeset/proposal-finalize-context-chain.md
+++ b/.changeset/proposal-finalize-context-chain.md
@@ -1,0 +1,6 @@
+---
+---
+
+**conformance**: chain `proposal_id` through `media_buy_seller/proposal_finalize` storyboard.
+
+The `brief_with_proposals` step now captures `proposals[0].proposal_id` via `context_outputs`, and the downstream `refine_proposal` / `finalize_proposal` / `accept_proposal` steps reference it as `$context.proposal_id` instead of the hardcoded placeholder `balanced_reach_q2`. Sellers that mint runtime `proposal_id` values (uuids, db rowids) can now pass the full lifecycle — previously the literal placeholder reached the wire and 404'd against any stateful upstream. Closes #4086.

--- a/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
@@ -102,6 +102,10 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
 
+        context_outputs:
+          - path: "proposals[0].proposal_id"
+            key: "proposal_id"
+
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -141,7 +145,7 @@ phases:
           buying_mode: "refine"
           refine:
             - scope: "proposal"
-              proposal_id: "balanced_reach_q2"
+              proposal_id: "$context.proposal_id"
               ask: "Shift 60% of budget to CTV. Drop the display product and redistribute that budget to video."
             - scope: "request"
               ask: "All products must support frequency capping at 3 per day."
@@ -188,7 +192,7 @@ phases:
           buying_mode: "refine"
           refine:
             - scope: "proposal"
-              proposal_id: "balanced_reach_q2"
+              proposal_id: "$context.proposal_id"
               action: "finalize"
           account:
             brand:
@@ -234,7 +238,7 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
             sandbox: true
-          proposal_id: "balanced_reach_q2"
+          proposal_id: "$context.proposal_id"
           total_budget:
             amount: 50000
             currency: "USD"


### PR DESCRIPTION
## Summary

Closes #4086.

The `media_buy_seller/proposal_finalize` storyboard previously sent the literal placeholder `balanced_reach_q2` from `sample_request` for `refine_proposal`, `finalize_proposal`, and `accept_proposal`. Sellers that mint runtime `proposal_id` values (uuids, db rowids) hit a 404 against any stateful upstream — only catalog-mode adapters with stable IDs could pass.

This change wires the missing context chain:

- **`brief_with_proposals` / `get_products_brief`** — adds `context_outputs` capturing `proposals[0].proposal_id` as `$context.proposal_id`.
- **`refine_proposal` / `finalize_proposal` / `accept_proposal`** — replaces the hardcoded `"balanced_reach_q2"` literals with `"$context.proposal_id"` in `sample_request`, matching the canonical chaining pattern used by `inventory_list_targeting.yaml` and friends.

Used `$context.<name>` in-place substitution (the schema's preferred path, line 477-489 of `static/compliance/source/universal/storyboard-schema.yaml`) rather than `context_inputs`, since the get_products SDK builder preserves `refine[].proposal_id` from `sample_request` (the issue confirms the literal currently reaches the wire).

## Backport

Same bug exists on `3.0.x` in the source yaml. Cherry-pick PR follows separately.

## Test plan

- [x] `node scripts/lint-storyboard-context-output-paths.cjs` — clean for our file
- [x] `node scripts/lint-storyboard-sample-request-schema.cjs` — clean
- [x] `node scripts/lint-storyboard-context-entity.cjs` — clean
- [x] `node scripts/build-compliance.cjs` — builds successfully
- [ ] Re-run adcp-client #1557 reference adapter (`hello_seller_adapter_proposal_mode.ts`) against `latest/` and confirm `get_products_refine` passes; drop `EXPECTED_FAILURES` allowlist entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)