### PR TITLE
fix(compliance): chain proposal_id through proposal_finalize storyboard (3.0.x)

### DIFF
--- a/.changeset/proposal-finalize-context-chain.md
+++ b/.changeset/proposal-finalize-context-chain.md
@@ -1,0 +1,6 @@
+---
+---
+
+**conformance**: chain `proposal_id` through `media_buy_seller/proposal_finalize` storyboard.
+
+The `brief_with_proposals` step now captures `proposals[0].proposal_id` via `context_outputs`, and the downstream `refine_proposal` / `finalize_proposal` / `accept_proposal` steps reference it as `$context.proposal_id` instead of the hardcoded placeholder `balanced_reach_q2`. Sellers that mint runtime `proposal_id` values (uuids, db rowids) can now pass the full lifecycle — previously the literal placeholder reached the wire and 404'd against any stateful upstream. Closes #4086.

--- a/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
@@ -98,6 +98,10 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
 
+        context_outputs:
+          - path: "proposals[0].proposal_id"
+            key: "proposal_id"
+
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -137,7 +141,7 @@ phases:
           buying_mode: "refine"
           refine:
             - scope: "proposal"
-              proposal_id: "balanced_reach_q2"
+              proposal_id: "$context.proposal_id"
               ask: "Shift 60% of budget to CTV. Drop the display product and redistribute that budget to video."
             - scope: "request"
               ask: "All products must support frequency capping at 3 per day."
@@ -184,7 +188,7 @@ phases:
           buying_mode: "refine"
           refine:
             - scope: "proposal"
-              proposal_id: "balanced_reach_q2"
+              proposal_id: "$context.proposal_id"
               action: "finalize"
           account:
             brand:
@@ -230,7 +234,7 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
             sandbox: true
-          proposal_id: "balanced_reach_q2"
+          proposal_id: "$context.proposal_id"
           total_budget:
             amount: 50000
             currency: "USD"


### PR DESCRIPTION
## Summary

Cherry-pick of #4091 to `3.0.x`. Closes #4086 on the supported line.

The `media_buy_seller/proposal_finalize` storyboard sent the literal placeholder `balanced_reach_q2` from `sample_request` for `refine_proposal`, `finalize_proposal`, and `accept_proposal`. Sellers that mint runtime `proposal_id` values (uuids, db rowids) hit a 404 against any stateful upstream. This PR captures `proposals[0].proposal_id` from `brief_with_proposals` via `context_outputs` and consumes it as `$context.proposal_id` in the three downstream steps.

## Why backport

- 3.0.x is the supported line — proposal-mode sellers certifying against `latest/` need this to pass `refine_proposal` against any non-catalog upstream.
- Conformance-yaml only — no schema or protocol semantics shift. Low risk to cherry-pick.
- Frozen `dist/compliance/3.0.0..3.0.6/` snapshots are intentionally left untouched. The fix flows into the next 3.0.x release via the normal build.

## Test plan

- [x] Cherry-pick applied cleanly with `git cherry-pick`.
- [x] `node scripts/lint-storyboard-sample-request-schema.cjs` — clean
- [x] `node scripts/lint-storyboard-context-entity.cjs` — clean
- [x] `node scripts/build-compliance.cjs` — builds successfully

## Related

- Upstream: #4091 (cherry-picked from)
- Issue: #4086
- Consumer: adcp-client #1557 reference adapter — drops `EXPECTED_FAILURES` allowlist for `get_products_refine` once a 3.0.x release picks this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)