### PR TITLE
ci(storyboards): per-tenant probe_task override unblocks security_baseline on /signals

### DIFF
--- a/.changeset/signals-security-baseline.md
+++ b/.changeset/signals-security-baseline.md
@@ -1,0 +1,26 @@
+---
+---
+
+ci(storyboards): per-tenant probe_task override unblocks security_baseline on /signals
+
+`security_baseline.assert_mechanism` was failing on /signals because the shared `acme-outdoor.yaml` test-kit declares `auth.probe_task: list_creatives` — a tool /signals doesn't serve. Sending `list_creatives` to /signals returned "method not found" before the auth layer ran, and the runner reported "no auth mechanism verified."
+
+Override `auth.probe_task` per tenant when `TENANT_PATH` is set:
+
+```ts
+const PROBE_TASK_BY_TENANT: Record<string, string> = {
+  signals: 'get_signals',
+};
+```
+
+`get_signals` is on the SDK runner's allowlist of probe-safe tasks (auth-required, read-only, accept empty body) and is served by /signals. Other tenants keep the default `list_creatives`:
+- /sales, /creative, /creative-builder serve `list_creatives` directly — default works.
+- /governance and /brand don't serve any allowlisted tool, so `security_baseline` continues to fail there. The matrix floor absorbs this until either the runner's allowlist widens or the tenants gain an allowlisted tool.
+
+Floor lift on /signals:
+
+| Tenant   | Old | New | Delta |
+|----------|-----|-----|-------|
+| /signals | 66 / 54 | 67 / 58 | +1 / +4 |
+
+Files: `server/tests/manual/run-storyboards.ts`, `.github/workflows/training-agent-storyboards.yml`, `scripts/run-storyboards-matrix.sh`.

--- a/.github/workflows/training-agent-storyboards.yml
+++ b/.github/workflows/training-agent-storyboards.yml
@@ -49,8 +49,8 @@ jobs:
           # both fire correctly. Floors capture the +31 step lift per tenant
           # from the storyboard's positive + negative conformance vectors.
           - tenant: signals
-            min_clean_storyboards: 66
-            min_passing_steps: 54
+            min_clean_storyboards: 67
+            min_passing_steps: 58
           - tenant: sales
             min_clean_storyboards: 67
             min_passing_steps: 258

--- a/scripts/run-storyboards-matrix.sh
+++ b/scripts/run-storyboards-matrix.sh
@@ -20,7 +20,7 @@ bash "${SCRIPT_DIR}/overlay-compliance-cache.sh" || true
 # tenant:min_clean:min_passed — kept in sync with the matrix.include block in
 # .github/workflows/training-agent-storyboards.yml.
 TENANTS=(
-  "signals:66:54"
+  "signals:67:58"
   "sales:67:258"
   "governance:65:102"
   "creative:66:118"

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -174,11 +174,31 @@ function brandFromKit(kit: LoadedTestKit | undefined): StoryboardRunOptions['bra
 }
 
 /**
+ * Per-tenant probe-task override for security_baseline's auth probes.
+ *
+ * The shared test-kit (`acme-outdoor.yaml`) declares
+ * `auth.probe_task: list_creatives`. Tenants that serve `list_creatives`
+ * (sales, creative, creative-builder) work with the default. /signals
+ * doesn't serve it but does serve `get_signals` — both are on the SDK
+ * runner's allowlist of probe-safe tasks (auth-required, read-only,
+ * accept empty body). /governance and /brand have no allowlisted tool
+ * they actually serve, so security_baseline continues to fail there
+ * until the runner's allowlist widens or those tenants gain one of
+ * the allowlisted tools.
+ */
+const PROBE_TASK_BY_TENANT: Record<string, string> = {
+  signals: 'get_signals',
+};
+
+/**
  * Thread the test-kit's `auth.api_key` / `auth.probe_task` through to the
  * runner so `api_key_path` in security_baseline (and any future kit-gated
  * phase) executes instead of being skipped by `skip_if: "!test_kit.auth.api_key"`.
  * `probe_task` is required by the runner whenever `auth` is declared — surface
  * missing values as a hard failure rather than silently defaulting.
+ *
+ * When `TENANT_PATH` matches a known tenant, override `probe_task` with a
+ * tool that tenant actually serves (see `PROBE_TASK_BY_TENANT`).
  */
 function testKitOptionsFromKit(kit: LoadedTestKit | undefined): StoryboardRunOptions['test_kit'] | undefined {
   const auth = kit?.auth;
@@ -186,10 +206,12 @@ function testKitOptionsFromKit(kit: LoadedTestKit | undefined): StoryboardRunOpt
   if (!auth.probe_task) {
     throw new Error('test kit declares auth.api_key without auth.probe_task — required by runner');
   }
+  const tenantPath = process.env.TENANT_PATH;
+  const probeTask = (tenantPath && PROBE_TASK_BY_TENANT[tenantPath]) ?? auth.probe_task;
   return {
     auth: {
       ...(auth.api_key !== undefined && { api_key: auth.api_key }),
-      probe_task: auth.probe_task,
+      probe_task: probeTask,
     },
   };
 }


### PR DESCRIPTION
## Summary

`security_baseline.assert_mechanism` was failing on /signals because the shared `acme-outdoor.yaml` test-kit declares `auth.probe_task: list_creatives` — a tool /signals doesn't serve. Sending `list_creatives` to /signals returned "method not found" before the auth layer ran, and the runner reported "no auth mechanism verified."

Override `auth.probe_task` per tenant when `TENANT_PATH` is set:

```ts
const PROBE_TASK_BY_TENANT: Record<string, string> = {
  signals: 'get_signals',
};
```

`get_signals` is on the SDK runner's allowlist of probe-safe tasks (auth-required, read-only, accept empty body) and is served by /signals.

**Why only /signals:**
- /sales, /creative, /creative-builder serve `list_creatives` directly — default works.
- /governance and /brand don't serve any allowlisted tool (`list_creatives, get_media_buy_delivery, list_authorized_properties, get_signals, list_si_sessions`), so `security_baseline` continues to fail there. The matrix floor absorbs this until either the runner's allowlist widens or those tenants gain an allowlisted tool.

Floor lift on /signals:

| Tenant   | Old | New | Delta |
|----------|-----|-----|-------|
| /signals | 66 / 54 | 67 / 58 | +1 / +4 |

This lifts `security_baseline` on /signals from `0P / 1F / 6S` (failing) to `4P / 3S` (clean) — 4 phases now run that were previously skipped.

## Test plan

- [x] Local matrix run — all six tenants pass new floors
- [ ] CI matrix run on PR
- [ ] `security_baseline` on /signals: assert_mechanism + api_key_path + invalid_token + presence-gated probes all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)