### PR TITLE
fix(org-merge): handle five RESTRICT FK tables blocking merges

### DIFF
--- a/.changeset/org-merge-restrict-fks.md
+++ b/.changeset/org-merge-restrict-fks.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix(org-merge): handle the five RESTRICT-FK tables that referenced `organizations(workos_organization_id)` without `ON DELETE` and were silently breaking merges. `mergeOrganizations` now reparents `agent_contexts`, `person_relationships`, `certification_goals`, `certification_expectations`, and `user_goal_history`, with conflict-aware reparenting (keep primary on `(org, agent_url)` / `(org, credential_id)` / `(org, email)`) for the unique-constrained ones. `previewMerge` now counts these tables too.

--- a/server/src/db/org-merge-db.ts
+++ b/server/src/db/org-merge-db.ts
@@ -12,6 +12,7 @@
 
 import { getPool } from './client.js';
 import { createLogger } from '../logger.js';
+import { encrypt, decrypt } from './encryption.js';
 import { WorkOS } from '@workos-inc/node';
 
 const logger = createLogger('org-merge-db');
@@ -635,18 +636,63 @@ export async function mergeOrganizations(
     // UNIQUE(organization_id, agent_url): keep primary's row on
     // conflict so its agent_test_history (ON DELETE CASCADE) survives;
     // secondary's history is removed when its row is deleted.
+    //
+    // Encrypted token columns are AES-256-GCM with a PBKDF2 key derived
+    // from organization_id (see ./encryption.ts). Reparenting requires
+    // decrypting with secondary salt and re-encrypting with primary salt,
+    // otherwise GCM auth-tag verification fails on every subsequent read
+    // and saved tokens become permanently unusable.
     // =====================================================
-    const agentContextsMoved = await client.query(
-      `UPDATE agent_contexts
-       SET organization_id = $1, updated_at = NOW()
-       WHERE organization_id = $2
+    const ENCRYPTED_AGENT_CONTEXT_FIELDS = [
+      ['auth_token_encrypted', 'auth_token_iv'],
+      ['oauth_access_token_encrypted', 'oauth_access_token_iv'],
+      ['oauth_refresh_token_encrypted', 'oauth_refresh_token_iv'],
+      ['oauth_client_secret_encrypted', 'oauth_client_secret_iv'],
+      ['oauth_cc_client_secret_encrypted', 'oauth_cc_client_secret_iv'],
+    ] as const;
+
+    const moveableRows = await client.query(
+      `SELECT id,
+              auth_token_encrypted, auth_token_iv,
+              oauth_access_token_encrypted, oauth_access_token_iv,
+              oauth_refresh_token_encrypted, oauth_refresh_token_iv,
+              oauth_client_secret_encrypted, oauth_client_secret_iv,
+              oauth_cc_client_secret_encrypted, oauth_cc_client_secret_iv
+       FROM agent_contexts
+       WHERE organization_id = $1
          AND NOT EXISTS (
            SELECT 1 FROM agent_contexts p
-           WHERE p.organization_id = $1 AND p.agent_url = agent_contexts.agent_url
-         )
-       RETURNING id`,
-      [primaryOrgId, secondaryOrgId]
+           WHERE p.organization_id = $2 AND p.agent_url = agent_contexts.agent_url
+         )`,
+      [secondaryOrgId, primaryOrgId]
     );
+
+    let agentContextsReencryptedFields = 0;
+    for (const row of moveableRows.rows) {
+      const setClauses: string[] = ['organization_id = $1', 'updated_at = NOW()'];
+      const values: (string | null)[] = [primaryOrgId];
+      let nextIdx = 2;
+
+      for (const [encCol, ivCol] of ENCRYPTED_AGENT_CONTEXT_FIELDS) {
+        const ciphertext = row[encCol];
+        const iv = row[ivCol];
+        if (ciphertext && iv) {
+          const plaintext = decrypt(ciphertext, iv, secondaryOrgId);
+          const reencrypted = encrypt(plaintext, primaryOrgId);
+          setClauses.push(`${encCol} = $${nextIdx++}`);
+          values.push(reencrypted.encrypted);
+          setClauses.push(`${ivCol} = $${nextIdx++}`);
+          values.push(reencrypted.iv);
+          agentContextsReencryptedFields++;
+        }
+      }
+
+      values.push(row.id);
+      await client.query(
+        `UPDATE agent_contexts SET ${setClauses.join(', ')} WHERE id = $${nextIdx}`,
+        values
+      );
+    }
 
     const agentContextsDeleted = await client.query(
       `DELETE FROM agent_contexts WHERE organization_id = $1 RETURNING id`,
@@ -655,9 +701,16 @@ export async function mergeOrganizations(
 
     summary.tables_merged.push({
       table_name: 'agent_contexts',
-      rows_moved: agentContextsMoved.rows.length,
+      rows_moved: moveableRows.rows.length,
       rows_skipped_duplicate: agentContextsDeleted.rows.length,
     });
+
+    if (agentContextsReencryptedFields > 0) {
+      logger.info(
+        { fields: agentContextsReencryptedFields, rows: moveableRows.rows.length },
+        'Re-encrypted agent_contexts token fields under primary org salt'
+      );
+    }
 
     if (agentContextsDeleted.rows.length > 0) {
       summary.warnings.push(

--- a/server/src/db/org-merge-db.ts
+++ b/server/src/db/org-merge-db.ts
@@ -631,6 +631,133 @@ export async function mergeOrganizations(
     });
 
     // =====================================================
+    // 20a. Merge agent_contexts
+    // UNIQUE(organization_id, agent_url): keep primary's row on
+    // conflict so its agent_test_history (ON DELETE CASCADE) survives;
+    // secondary's history is removed when its row is deleted.
+    // =====================================================
+    const agentContextsMoved = await client.query(
+      `UPDATE agent_contexts
+       SET organization_id = $1, updated_at = NOW()
+       WHERE organization_id = $2
+         AND NOT EXISTS (
+           SELECT 1 FROM agent_contexts p
+           WHERE p.organization_id = $1 AND p.agent_url = agent_contexts.agent_url
+         )
+       RETURNING id`,
+      [primaryOrgId, secondaryOrgId]
+    );
+
+    const agentContextsDeleted = await client.query(
+      `DELETE FROM agent_contexts WHERE organization_id = $1 RETURNING id`,
+      [secondaryOrgId]
+    );
+
+    summary.tables_merged.push({
+      table_name: 'agent_contexts',
+      rows_moved: agentContextsMoved.rows.length,
+      rows_skipped_duplicate: agentContextsDeleted.rows.length,
+    });
+
+    if (agentContextsDeleted.rows.length > 0) {
+      summary.warnings.push(
+        `${agentContextsDeleted.rows.length} duplicate agent_contexts from secondary org were deleted (primary already had the same agent_url) — their test history was removed`
+      );
+    }
+
+    // =====================================================
+    // 20b. Merge person_relationships.prospect_org_id
+    // No unique constraint on prospect_org_id — straight reparent.
+    // =====================================================
+    const personRelResult = await client.query(
+      `UPDATE person_relationships
+       SET prospect_org_id = $1, updated_at = NOW()
+       WHERE prospect_org_id = $2
+       RETURNING id`,
+      [primaryOrgId, secondaryOrgId]
+    );
+
+    summary.tables_merged.push({
+      table_name: 'person_relationships',
+      rows_moved: personRelResult.rows.length,
+      rows_skipped_duplicate: 0,
+    });
+
+    // =====================================================
+    // 20c. Merge certification_goals
+    // UNIQUE(workos_organization_id, credential_id): keep primary on conflict.
+    // =====================================================
+    const certGoalsMoved = await client.query(
+      `UPDATE certification_goals
+       SET workos_organization_id = $1, updated_at = NOW()
+       WHERE workos_organization_id = $2
+         AND NOT EXISTS (
+           SELECT 1 FROM certification_goals p
+           WHERE p.workos_organization_id = $1
+             AND p.credential_id = certification_goals.credential_id
+         )
+       RETURNING id`,
+      [primaryOrgId, secondaryOrgId]
+    );
+
+    const certGoalsDeleted = await client.query(
+      `DELETE FROM certification_goals WHERE workos_organization_id = $1 RETURNING id`,
+      [secondaryOrgId]
+    );
+
+    summary.tables_merged.push({
+      table_name: 'certification_goals',
+      rows_moved: certGoalsMoved.rows.length,
+      rows_skipped_duplicate: certGoalsDeleted.rows.length,
+    });
+
+    // =====================================================
+    // 20d. Merge certification_expectations
+    // UNIQUE(workos_organization_id, email): keep primary on conflict.
+    // =====================================================
+    const certExpMoved = await client.query(
+      `UPDATE certification_expectations
+       SET workos_organization_id = $1
+       WHERE workos_organization_id = $2
+         AND NOT EXISTS (
+           SELECT 1 FROM certification_expectations p
+           WHERE p.workos_organization_id = $1
+             AND p.email = certification_expectations.email
+         )
+       RETURNING id`,
+      [primaryOrgId, secondaryOrgId]
+    );
+
+    const certExpDeleted = await client.query(
+      `DELETE FROM certification_expectations WHERE workos_organization_id = $1 RETURNING id`,
+      [secondaryOrgId]
+    );
+
+    summary.tables_merged.push({
+      table_name: 'certification_expectations',
+      rows_moved: certExpMoved.rows.length,
+      rows_skipped_duplicate: certExpDeleted.rows.length,
+    });
+
+    // =====================================================
+    // 20e. Merge user_goal_history.prospect_org_id
+    // No unique constraint on this column — straight reparent.
+    // =====================================================
+    const goalHistoryResult = await client.query(
+      `UPDATE user_goal_history
+       SET prospect_org_id = $1
+       WHERE prospect_org_id = $2
+       RETURNING id`,
+      [primaryOrgId, secondaryOrgId]
+    );
+
+    summary.tables_merged.push({
+      table_name: 'user_goal_history',
+      rows_moved: goalHistoryResult.rows.length,
+      rows_skipped_duplicate: 0,
+    });
+
+    // =====================================================
     // 21. Merge prospect notes
     // =====================================================
     if (secondaryOrg.prospect_notes && secondaryOrg.prospect_notes.trim()) {
@@ -838,6 +965,11 @@ export async function previewMerge(
     { table: 'event_sponsorships', column: 'organization_id' },
     { table: 'user_agreement_acceptances', column: 'workos_organization_id' },
     { table: 'org_admin_group_dms', column: 'workos_organization_id' },
+    { table: 'agent_contexts', column: 'organization_id' },
+    { table: 'person_relationships', column: 'prospect_org_id' },
+    { table: 'certification_goals', column: 'workos_organization_id' },
+    { table: 'certification_expectations', column: 'workos_organization_id' },
+    { table: 'user_goal_history', column: 'prospect_org_id' },
   ];
 
   for (const { table, column } of tables) {

--- a/server/tests/integration/org-merge-agent-contexts.test.ts
+++ b/server/tests/integration/org-merge-agent-contexts.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { initializeDatabase, closeDatabase, getPool } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { mergeOrganizations } from '../../src/db/org-merge-db.js';
+import { encrypt, decrypt } from '../../src/db/encryption.js';
+import type { Pool } from 'pg';
+import type { WorkOS } from '@workos-inc/node';
+
+const PRIMARY_ORG = 'org_merge_ac_primary';
+const SECONDARY_ORG = 'org_merge_ac_secondary';
+const MERGED_BY = 'user_merge_ac_admin';
+
+// Stub WorkOS client — mergeOrganizations only calls organizations.deleteOrganization
+// after the local commit, so the stub just needs to no-op.
+const workosStub = {
+  organizations: {
+    deleteOrganization: async (_id: string) => {},
+  },
+} as unknown as WorkOS;
+
+describe('mergeOrganizations — agent_contexts re-encryption', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  }, 60000);
+
+  afterAll(async () => {
+    await cleanup();
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanup();
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, created_at, updated_at)
+       VALUES ($1, 'Primary', NOW(), NOW()),
+              ($2, 'Secondary', NOW(), NOW())`,
+      [PRIMARY_ORG, SECONDARY_ORG]
+    );
+  });
+
+  async function cleanup() {
+    await pool.query(`DELETE FROM agent_contexts WHERE organization_id IN ($1, $2)`, [PRIMARY_ORG, SECONDARY_ORG]);
+    await pool.query(`DELETE FROM organizations WHERE workos_organization_id IN ($1, $2)`, [PRIMARY_ORG, SECONDARY_ORG]);
+  }
+
+  it('re-encrypts auth tokens under the primary org salt so decrypt keeps working', async () => {
+    const TOKEN = 'sk-test-bearer-token-12345';
+    const sealed = encrypt(TOKEN, SECONDARY_ORG);
+
+    await pool.query(
+      `INSERT INTO agent_contexts (organization_id, agent_url, agent_name, auth_token_encrypted, auth_token_iv, auth_token_hint)
+       VALUES ($1, 'https://agent.example/mcp', 'Test', $2, $3, '****2345')`,
+      [SECONDARY_ORG, sealed.encrypted, sealed.iv]
+    );
+
+    await mergeOrganizations(PRIMARY_ORG, SECONDARY_ORG, MERGED_BY, workosStub);
+
+    const moved = await pool.query(
+      `SELECT auth_token_encrypted, auth_token_iv FROM agent_contexts WHERE organization_id = $1`,
+      [PRIMARY_ORG]
+    );
+    expect(moved.rows).toHaveLength(1);
+
+    // Old salt no longer works (proves we re-encrypted, not just moved bytes).
+    expect(() => decrypt(moved.rows[0].auth_token_encrypted, moved.rows[0].auth_token_iv, SECONDARY_ORG))
+      .toThrow();
+
+    // New salt round-trips to the original plaintext.
+    const recovered = decrypt(moved.rows[0].auth_token_encrypted, moved.rows[0].auth_token_iv, PRIMARY_ORG);
+    expect(recovered).toBe(TOKEN);
+  });
+
+  it('re-encrypts every populated OAuth token field, leaves NULLs alone', async () => {
+    const ACCESS = 'access-abc';
+    const REFRESH = 'refresh-def';
+    const access = encrypt(ACCESS, SECONDARY_ORG);
+    const refresh = encrypt(REFRESH, SECONDARY_ORG);
+
+    await pool.query(
+      `INSERT INTO agent_contexts (
+         organization_id, agent_url, agent_name,
+         oauth_access_token_encrypted, oauth_access_token_iv,
+         oauth_refresh_token_encrypted, oauth_refresh_token_iv
+       ) VALUES ($1, 'https://oauth.example/mcp', 'OAuth', $2, $3, $4, $5)`,
+      [SECONDARY_ORG, access.encrypted, access.iv, refresh.encrypted, refresh.iv]
+    );
+
+    await mergeOrganizations(PRIMARY_ORG, SECONDARY_ORG, MERGED_BY, workosStub);
+
+    const moved = await pool.query(
+      `SELECT oauth_access_token_encrypted, oauth_access_token_iv,
+              oauth_refresh_token_encrypted, oauth_refresh_token_iv,
+              oauth_client_secret_encrypted, oauth_client_secret_iv
+       FROM agent_contexts WHERE organization_id = $1`,
+      [PRIMARY_ORG]
+    );
+    expect(moved.rows).toHaveLength(1);
+    const row = moved.rows[0];
+
+    expect(decrypt(row.oauth_access_token_encrypted, row.oauth_access_token_iv, PRIMARY_ORG)).toBe(ACCESS);
+    expect(decrypt(row.oauth_refresh_token_encrypted, row.oauth_refresh_token_iv, PRIMARY_ORG)).toBe(REFRESH);
+    expect(row.oauth_client_secret_encrypted).toBeNull();
+    expect(row.oauth_client_secret_iv).toBeNull();
+  });
+
+  it('drops duplicate agent_url rows from secondary instead of conflicting on the unique key', async () => {
+    const URL = 'https://dup.example/mcp';
+    const primaryToken = encrypt('primary-token', PRIMARY_ORG);
+    const secondaryToken = encrypt('secondary-token', SECONDARY_ORG);
+
+    await pool.query(
+      `INSERT INTO agent_contexts (organization_id, agent_url, agent_name, auth_token_encrypted, auth_token_iv)
+       VALUES ($1, $3, 'Primary', $4, $5),
+              ($2, $3, 'Secondary', $6, $7)`,
+      [PRIMARY_ORG, SECONDARY_ORG, URL, primaryToken.encrypted, primaryToken.iv, secondaryToken.encrypted, secondaryToken.iv]
+    );
+
+    const summary = await mergeOrganizations(PRIMARY_ORG, SECONDARY_ORG, MERGED_BY, workosStub);
+
+    const remaining = await pool.query(
+      `SELECT auth_token_encrypted, auth_token_iv FROM agent_contexts WHERE agent_url = $1`,
+      [URL]
+    );
+    expect(remaining.rows).toHaveLength(1);
+    // Primary's row was kept (its token was never re-encrypted).
+    expect(decrypt(remaining.rows[0].auth_token_encrypted, remaining.rows[0].auth_token_iv, PRIMARY_ORG))
+      .toBe('primary-token');
+
+    const acSummary = summary.tables_merged.find(t => t.table_name === 'agent_contexts');
+    expect(acSummary?.rows_skipped_duplicate).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Org merge crashed with `agent_contexts_organization_id_fkey` when retiring a duplicate. Audited every FK to `organizations(workos_organization_id)` and found **five RESTRICT FKs** the merge was missing — same root cause, all latent.

| Table | Unique constraint | Strategy |
|---|---|---|
| `agent_contexts` | `(organization_id, agent_url)` | Reparent non-conflicts; delete dups (cascades `agent_test_history`) |
| `person_relationships` | none on `prospect_org_id` | Plain UPDATE |
| `certification_goals` | `(workos_organization_id, credential_id)` | Reparent non-conflicts; delete dups |
| `certification_expectations` | `(workos_organization_id, email)` | Reparent non-conflicts; delete dups |
| `user_goal_history` | none on `prospect_org_id` | Plain UPDATE |

For the three with composite uniques, primary wins on conflict so its history survives. `agent_contexts` dup deletion emits a warning since cascaded `agent_test_history` is unrecoverable. `previewMerge` table list extended.

## Test plan
- [x] typecheck clean
- [ ] retry merge of the two orgs that triggered the original error
- [ ] no regression on existing org-merge admin flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)