### PR TITLE
fix(member-profile): surface load errors instead of blank page

### DIFF
--- a/.changeset/fix-member-profile-blank-on-error.md
+++ b/.changeset/fix-member-profile-blank-on-error.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix /member-profile rendering a blank page when the load API call fails. The `showError` helper wrote into `#error-message`, which lives inside the form container that stays `display: none` until a profile loads — so any load-time failure (timeout, 5xx, 403, JS exception in `populateForm`) was invisible. `showError` now routes to the top-level `#error-container` while the form is hidden, and surfaces the underlying error message instead of a generic "please try again".

--- a/server/public/member-profile.html
+++ b/server/public/member-profile.html
@@ -1456,9 +1456,14 @@
       } catch (error) {
         console.error('Load profile error:', error);
         document.getElementById('loading').style.display = 'none';
-        const msg = error.name === 'AbortError'
-          ? 'The server is taking too long to respond. Please try again in a moment.'
-          : 'Failed to load your profile. Please try again.';
+        let msg;
+        if (error.name === 'AbortError') {
+          msg = 'The server is taking too long to respond. Please try again in a moment.';
+        } else if (error.message) {
+          msg = error.message;
+        } else {
+          msg = 'Failed to load your profile. Please try again.';
+        }
         showError(msg);
       }
     }
@@ -2841,7 +2846,17 @@
     }
 
     function showError(message) {
-      const el = document.getElementById('error-message');
+      // #error-message lives inside #profile-form, which is display:none until
+      // a profile loads. Routing load-time errors there silently hides them.
+      // Fall back to the top-level #error-container when the form is hidden.
+      const form = document.getElementById('profile-form');
+      const formVisible = form && form.style.display !== 'none';
+      const el = formVisible
+        ? document.getElementById('error-message')
+        : document.getElementById('error-container');
+      if (!formVisible) {
+        el.className = 'alert alert-error';
+      }
       el.textContent = message;
       el.style.display = 'block';
       el.scrollIntoView({ behavior: 'smooth', block: 'center' });

--- a/server/public/member-profile.html
+++ b/server/public/member-profile.html
@@ -746,7 +746,7 @@
   <div class="container">
     <div id="loading" class="loading">Loading your profile...</div>
 
-    <div id="error-container" style="display: none;"></div>
+    <div id="error-container" role="alert" style="display: none;"></div>
 
     <div id="no-profile" class="card no-profile" style="display: none;">
       <h2>Create Your Member Profile</h2>
@@ -2859,7 +2859,11 @@
       }
       el.textContent = message;
       el.style.display = 'block';
-      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      // Only scroll for in-form errors; #error-container sits at the top of
+      // the page where scrolling would push the nav off-screen.
+      if (formVisible) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
     }
 
     function hideMessages() {


### PR DESCRIPTION
## Summary

- `/member-profile` rendered a blank page on any load failure. `showError` wrote into `#error-message`, which lives inside `#profile-form` (`display: none` until a profile loads), so timeouts, 5xx, 403, and `populateForm` exceptions were all invisible.
- Route load-time errors to the top-level `#error-container` instead, and pass through the underlying error message rather than a generic "please try again".

## Context

Reported by Audrey Lopez (Propulso) — escalation #312. Active Founding member; her published listing renders fine, but `/member-profile?org=org_01KKHJPQ8YC81W1QATNHF8NYQE` (and the dashboard "Edit Profile" button) showed a blank page. Fly's log buffer is too short to catch her specific failure after the fact; this fix makes whatever is failing visible to her on the next attempt and to support going forward.

## Test plan

- [ ] Manual: load `/member-profile` with the dev server stopped — confirm an error banner renders instead of a blank page.
- [ ] Manual: load `/member-profile?org=org_does_not_exist` while signed in — confirm the 403/404 message surfaces.
- [ ] Manual: ask Audrey to retry and report whichever error now shows up; use that to target the underlying server-side fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)