### PR TITLE
feat(aao): publisher self-service — /publisher/:domain page, API rollup, hosted adagents.json

### DIFF
--- a/.changeset/aao-hosted-adagents-json-route.md
+++ b/.changeset/aao-hosted-adagents-json-route.md
@@ -1,0 +1,9 @@
+---
+---
+
+Adds `GET /publisher/{domain}/.well-known/adagents.json`. Returns the
+canonical adagents.json document for publishers who opted into AAO hosting
+(public hosted-property row). Other publishers / unknown domains 404.
+
+Lets a publisher choose between pasting the snippet on their own site and
+pointing a CNAME / redirect at AAO's hosted URL.

--- a/.changeset/hosted-property-fed-index-sync.md
+++ b/.changeset/hosted-property-fed-index-sync.md
@@ -13,10 +13,24 @@ public hosted property into `discovered_properties`,
 `/api/properties/save` (create + edit) and the Addie approval /
 enrichment path.
 
+Trust-label split: sync writes `source='aao_hosted'` (new value), NOT
+`source='adagents_json'`. `adagents_json` is reserved for rows where the
+publisher's origin actually serves the document (crawler-verified,
+including via the `authoritative_location` stub pattern). Until origin
+verification happens, AAO-hosted authorization is the publisher's stated
+intent — not an origin-attested claim. The agent rollup surfaces this
+to callers via the `source` field, and the publisher page renders
+"AAO-hosted (origin not yet verified)" on those rows.
+
 Reconciliation semantics:
-- `agent_publisher_authorizations` rows are fully reconciled — agents
-  removed from the manifest are deleted (we own the `source='adagents_json'`
-  label for this domain when AAO hosts).
+- `agent_publisher_authorizations` rows are fully reconciled, scoped to
+  `source='aao_hosted'` for this publisher_domain. Crawler-written
+  `adagents_json` rows for the same domain are left untouched (they
+  represent verified origin facts).
+- `discovered_publishers.has_valid_adagents` is NOT set by the sync —
+  that flag means the publisher's origin actually serves a valid
+  document, which AAO hosting alone does not establish. The crawler is
+  the only writer that should flip it.
 - `discovered_publishers` row uses a stable AAO sentinel value
   (`aao://hosted`) for `discovered_by_agent` so re-syncs collapse to one
   row regardless of agent ordering.

--- a/.changeset/hosted-property-fed-index-sync.md
+++ b/.changeset/hosted-property-fed-index-sync.md
@@ -1,0 +1,41 @@
+---
+---
+
+Hosted properties now propagate into the federated index. Previously, when
+a publisher opted into AAO-hosted adagents.json (a public
+`hosted_properties` row), the agents and properties declared in its
+`adagents_json` lived in isolation — `/api/registry/publisher` would
+report 0 agents for that domain even though the canonical document AAO
+served said otherwise. New `services/hosted-property-sync.ts` mirrors a
+public hosted property into `discovered_properties`,
+`discovered_agents`, `agent_publisher_authorizations`, and
+`discovered_publishers`. Wired into the three primary write paths:
+`/api/properties/save` (create + edit) and the Addie approval /
+enrichment path.
+
+Reconciliation semantics:
+- `agent_publisher_authorizations` rows are fully reconciled — agents
+  removed from the manifest are deleted (we own the `source='adagents_json'`
+  label for this domain when AAO hosts).
+- `discovered_publishers` row uses a stable AAO sentinel value
+  (`aao://hosted`) for `discovered_by_agent` so re-syncs collapse to one
+  row regardless of agent ordering.
+- `discovered_properties` is additive only — the table has no source
+  column, so we cannot safely distinguish hosted-written rows from
+  crawler-written rows. Removed properties persist until manually cleared.
+  Tracked as a follow-up.
+
+Also: rate-limit the per-agent rollup on `/api/registry/publisher` to
+50 agents per request to bound fan-out on an unauthenticated endpoint.
+Above the cap, agents are returned without rollup data and a
+`rollup_truncated: true` flag — call `/api/registry/publisher/authorization`
+for the per-agent count.
+
+Also: domain shape validation on `/publisher/:domain/.well-known/adagents.json`,
+agent URL canonicalization on `/api/registry/publisher/authorization`,
+brand.json walker capped at 5000 entries, identifiers preserved (not
+dropped) for non-website brand.json types.
+
+Finally: when `adagents_valid: false` on `/publisher/{domain}`, the badge
+exposes a "why?" link that fetches `/api/adagents/validate` and inlines
+the structured error list.

--- a/.changeset/hosted-property-fed-index-sync.md
+++ b/.changeset/hosted-property-fed-index-sync.md
@@ -27,9 +27,28 @@ Reconciliation semantics:
 
 Also: rate-limit the per-agent rollup on `/api/registry/publisher` to
 50 agents per request to bound fan-out on an unauthenticated endpoint.
-Above the cap, agents are returned without rollup data and a
-`rollup_truncated: true` flag — call `/api/registry/publisher/authorization`
-for the per-agent count.
+Above the cap, agents are returned without rollup data and
+`rollup_truncated: { cap, total_agents }` exposes the cap + full count so
+callers can decide whether to fan out individual calls to
+`/api/registry/publisher/authorization`. Each rollup entry carries a
+`publisher_wide: boolean` flag so callers can distinguish a synthesized
+"N of N" (publisher-wide authorization) from real property-level rows.
+
+Also: when all properties are brand.json-hydrated (no adagents.json
+claim has been made), the per-agent rollup is suppressed entirely —
+otherwise we'd over-claim that agents are authorized for properties no
+adagents.json has actually scoped to them.
+
+Also: hosting copy switched from CNAME / 301-redirect framing to the
+spec-conformant `authoritative_location` stub pattern (publisher hosts
+a small stub at their own /.well-known with `authoritative_location`
+pointing at the AAO URL). Buyers fetch the publisher's origin
+(preserving their TLS chain) and follow the pointer. Buy-side trust
+caveat surfaced in the AAO-hosted panel copy.
+
+Also: new `self_invalid` hosting mode distinguishes "publisher has a
+file at /.well-known but it failed validation" from "publisher has no
+file" — different agent decisions, different UI affordance.
 
 Also: domain shape validation on `/publisher/:domain/.well-known/adagents.json`,
 agent URL canonicalization on `/api/registry/publisher/authorization`,

--- a/.changeset/publisher-authorization-endpoint.md
+++ b/.changeset/publisher-authorization-endpoint.md
@@ -1,0 +1,12 @@
+---
+---
+
+Adds `GET /api/registry/publisher/authorization?domain=X&agent=Y`. Returns
+`{ publisher_domain, agent_url, authorized: N, total: M, publisher_wide,
+source, authorized_for, unauthorized_properties[] }` so an external caller
+can ask the focused question "is this agent authorized for this publisher,
+and for which properties" without pulling the full `/api/registry/publisher`
+payload.
+
+404 when the agent has no authorization (publisher-wide or property-level)
+for the domain.

--- a/.changeset/publisher-home-hosting-and-ux.md
+++ b/.changeset/publisher-home-hosting-and-ux.md
@@ -1,0 +1,20 @@
+---
+---
+
+Publisher self-service page (`/publisher/{domain}`) gets state-aware UX:
+
+- `/api/registry/publisher` now returns a `hosting: { mode, hosted_url?,
+  expected_url }` block — `aao_hosted` when AAO serves the canonical
+  document, `self` when the publisher serves it from their own domain,
+  `none` when no adagents.json is configured.
+- New "adagents.json hosting" panel renders setup instructions per mode
+  (CNAME / paste-snippet for self-host; canonical URL for AAO-hosted;
+  generate / set-up paths for unconfigured).
+- Cold-visitor explainer banner appears only when nothing is registered;
+  surfaces "Sign in to claim" or "Claim this domain" depending on auth.
+- Empty-agents-with-properties state renders a contextual help callout
+  explaining that brand.json (what you publish) and adagents.json (who can
+  sell it) are separate documents — addresses Sasha's confusion path.
+- Each agent row is now click-to-expand: drill-down fetches the
+  `/api/registry/publisher/authorization` endpoint and shows which
+  properties that agent is authorized for vs not.

--- a/.changeset/publisher-hydrate-from-brand-json.md
+++ b/.changeset/publisher-hydrate-from-brand-json.md
@@ -1,0 +1,12 @@
+---
+---
+
+`/api/registry/publisher` now falls back to the publisher's brand.json when
+the federated index has no properties for the domain. brand.json
+`properties[]` (top-level or `brands[].properties[]`) is mapped into the
+publisher payload and tagged with `source: "brand_json"` so callers can tell
+where each property came from. The same payload now also tags
+federated-index properties with `source: "discovered"`.
+
+Eliminates the "0 properties" first-touch experience for publishers who
+already declared their inventory in brand.json.

--- a/.changeset/publisher-per-agent-property-rollup.md
+++ b/.changeset/publisher-per-agent-property-rollup.md
@@ -1,0 +1,12 @@
+---
+---
+
+Each agent in `/api/registry/publisher` now carries a property authorization
+rollup: `properties_authorized` (count of this publisher's properties the
+agent can sell) and `properties_total` (total properties the publisher
+exposes). When property-level authorization rows exist, the count is the
+intersection; when only publisher-wide authorization exists, the count
+equals the total.
+
+Lets a caller render "X of Y properties authorized for [agent URL]" without
+re-walking the property graph.

--- a/.changeset/publisher-self-service-page.md
+++ b/.changeset/publisher-self-service-page.md
@@ -1,0 +1,12 @@
+---
+---
+
+Adds a unified publisher self-service page at `/publisher/{domain}`. The
+page calls `/api/registry/publisher` and renders: AAO-member status,
+adagents.json validity, properties (with source badges:
+`adagents_json` / `discovered` / `brand_json`), and authorized agents with
+the new "X of Y properties authorized" rollup. Empty state guides
+publishers toward declaring inventory or pointing AAO at their brand.json.
+
+Edit-properties button deep-links to the existing property editor at
+`/property/view/{domain}`.

--- a/server/public/publisher-home.html
+++ b/server/public/publisher-home.html
@@ -57,6 +57,7 @@
       .badge-source-discovered    { background: #ede9fe; color: #5b21b6; }
       .badge-source-brand_json    { background: #fef3c7; color: #92400e; }
       .badge-source-agent_claim   { background: #f3e8ff; color: #6b21a8; }
+      .badge-source-aao_hosted    { background: #fef3c7; color: #92400e; }
       .badge-valid    { background: #d1fae5; color: #065f46; }
       .badge-invalid  { background: #fee2e2; color: #991b1b; }
       .badge-unknown  { background: var(--color-bg-subtle); color: var(--color-text-muted); }
@@ -487,6 +488,7 @@
         discovered: 'found by crawler',
         brand_json: 'from your brand.json',
         agent_claim: 'agent self-claim',
+        aao_hosted: 'AAO-hosted (origin not yet verified)',
       };
       function sourceLabel(s) {
         return SOURCE_LABELS[s] || s;

--- a/server/public/publisher-home.html
+++ b/server/public/publisher-home.html
@@ -5,6 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Publisher | AgenticAdvertising.org</title>
     <link rel="icon" href="/addie-icon.svg" type="image/svg+xml" />
+    <!-- Agent-discoverable JSON alternate. The href is filled in client-side
+         once the domain is resolved from the URL path; agents that follow
+         this link land on the rich /api/registry/publisher payload. -->
+    <link id="api-alternate" rel="alternate" type="application/json" href="" />
     <link rel="stylesheet" href="/design-system.css" />
     <link rel="stylesheet" href="/layout.css" />
     <style>
@@ -284,6 +288,12 @@
           </div>
         </div>
 
+        <!-- Lead-with-next-step card. Shown when the publisher has
+             properties on file but no authorized agents — typically because
+             their brand.json was hydrated but no adagents.json has been
+             written. Hidden otherwise. -->
+        <div id="next-step" class="hidden"></div>
+
         <div class="panel">
           <div class="panel-header">
             <div>
@@ -411,21 +421,30 @@
         const labels = {
           aao_hosted: 'AAO-hosted',
           self: 'Self-hosted',
+          self_invalid: 'Self-hosted (invalid)',
           none: 'Not yet configured',
         };
         const subtitles = {
-          aao_hosted: 'AAO serves the canonical adagents.json for this domain.',
-          self: 'This publisher serves adagents.json from their own domain.',
+          aao_hosted: 'AAO serves the canonical document via the publisher’s authoritative_location pointer.',
+          self: 'This publisher serves a valid adagents.json from their own domain.',
+          self_invalid: 'A file exists at /.well-known/adagents.json but failed validation.',
           none: 'No adagents.json is published for this domain yet.',
         };
         subtitle.textContent = subtitles[hosting.mode] || '';
-        badge.innerHTML = `<span class="badge badge-mode-${escapeHtml(hosting.mode)}">${escapeHtml(labels[hosting.mode] || hosting.mode)}</span>`;
+        const modeClass = hosting.mode === 'self_invalid' ? 'badge-invalid' : `badge-mode-${escapeHtml(hosting.mode)}`;
+        badge.innerHTML = `<span class="badge ${modeClass}">${escapeHtml(labels[hosting.mode] || hosting.mode)}</span>`;
 
         if (hosting.mode === 'aao_hosted') {
+          // Spec-conformant pattern: publisher hosts a stub at their own
+          // /.well-known/adagents.json with `authoritative_location` set
+          // to AAO's hosted URL. Bare CNAME / 301 redirect from /.well-known
+          // is not blessed by the spec and breaks strict buy-side
+          // verifiers (TLS chain ends at AAO instead of the publisher).
           detail.innerHTML = `
-            <p>Point your domain at AAO's hosted document, or copy the URL below into a CNAME / 301 redirect from your own <code>/.well-known/adagents.json</code>:</p>
+            <p>AAO serves the canonical adagents.json document at:</p>
             <code class="url-block">${escapeHtml(hosting.hosted_url || '')}</code>
-            <p>Buyers will continue to fetch <code>${escapeHtml(hosting.expected_url)}</code>; the redirect resolves transparently.</p>
+            <p>Recommended setup: place a small stub at <code>${escapeHtml(hosting.expected_url)}</code> with an <code>authoritative_location</code> field pointing to the AAO URL. Buyers fetch your origin (preserving your TLS chain) and follow the pointer to the AAO-served body.</p>
+            <p style="color: var(--color-text-muted); font-size: var(--text-xs); margin-top: var(--space-3);"><strong>Buy-side note:</strong> some strict verifiers may treat a bare CNAME/redirect to AAO as a soft trust signal because the TLS chain ends at AAO. The <code>authoritative_location</code> stub avoids that.</p>
           `;
           actions.innerHTML = `
             <a class="secondary" href="${escapeHtml(hosting.hosted_url || '#')}" target="_blank" rel="noopener">View hosted file</a>
@@ -433,23 +452,44 @@
           `;
         } else if (hosting.mode === 'self') {
           detail.innerHTML = `
-            <p>AAO crawls <code>${escapeHtml(hosting.expected_url)}</code> directly. Update that file to change which agents are authorized.</p>
+            <p>AAO fetches <code>${escapeHtml(hosting.expected_url)}</code> directly. Update that file to change which agents are authorized.</p>
           `;
           actions.innerHTML = `
             <a class="secondary" href="${escapeHtml(hosting.expected_url)}" target="_blank" rel="noopener">Open self-hosted file</a>
             <a class="secondary" href="/adagents/builder?domain=${encodeURIComponent(data.domain)}">Update adagents.json</a>
           `;
+        } else if (hosting.mode === 'self_invalid') {
+          detail.innerHTML = `
+            <p>AAO found a file at <code>${escapeHtml(hosting.expected_url)}</code> but it failed validation. Click "why?" next to the badge above for the structured error list.</p>
+            <p>This is a fixable misconfiguration, not a missing record — buyers may still see an "invalid" status until you correct the file.</p>
+          `;
+          actions.innerHTML = `
+            <a class="secondary" href="${escapeHtml(hosting.expected_url)}" target="_blank" rel="noopener">Open self-hosted file</a>
+            <a class="secondary" href="/adagents/builder?domain=${encodeURIComponent(data.domain)}">Re-generate adagents.json</a>
+          `;
         } else {
           detail.innerHTML = `
             <p>You have two options for publishing adagents.json:</p>
             <p>1. <strong>Self-host:</strong> generate the file and put it at <code>${escapeHtml(hosting.expected_url)}</code>. No account needed — but you control the file forever.</p>
-            <p>2. <strong>Let AAO host it</strong> <span style="color: var(--color-text-muted);">(requires free registration)</span>: we serve the canonical document and you point a CNAME or redirect at us. Switch back to self-hosting any time.</p>
+            <p>2. <strong>Let AAO host it</strong> <span style="color: var(--color-text-muted);">(requires free registration)</span>: we serve the canonical document. You place a small stub at your own <code>/.well-known/adagents.json</code> with an <code>authoritative_location</code> field pointing to AAO. Switch back to self-hosting by editing the stub.</p>
           `;
           actions.innerHTML = `
             <a class="primary" href="/adagents/builder?domain=${encodeURIComponent(data.domain)}">Generate adagents.json</a>
             <a class="secondary" href="/property/view/${encodeURIComponent(data.domain)}">Set up AAO hosting</a>
           `;
         }
+      }
+
+      // Plain-English source labels. The wire format uses protocol-internal
+      // strings; the page should not.
+      const SOURCE_LABELS = {
+        adagents_json: 'in your adagents.json',
+        discovered: 'found by crawler',
+        brand_json: 'from your brand.json',
+        agent_claim: 'agent self-claim',
+      };
+      function sourceLabel(s) {
+        return SOURCE_LABELS[s] || s;
       }
 
       function renderProperties(props) {
@@ -460,10 +500,10 @@
           subtitle.textContent = '0 properties';
           return;
         }
-        const sources = new Set(props.map((p) => p.source).filter(Boolean));
+        const sources = Array.from(new Set(props.map((p) => p.source).filter(Boolean)));
         subtitle.textContent =
           `${props.length} ${props.length === 1 ? 'property' : 'properties'}`
-          + (sources.size ? ' · sourced from ' + Array.from(sources).join(', ') : '');
+          + (sources.length ? ' · ' + sources.map(sourceLabel).join(', ') : '');
         body.innerHTML = props
           .map((p) => {
             const idents = (p.identifiers || [])
@@ -473,7 +513,7 @@
               .map((t) => `<span class="badge badge-unknown" title="${escapeHtml(t)}">${escapeHtml(t)}</span>`)
               .join('');
             const source = p.source
-              ? `<span class="badge badge-source-${escapeHtml(p.source)}">${escapeHtml(p.source.replace('_', '.'))}</span>`
+              ? `<span class="badge badge-source-${escapeHtml(p.source)}" title="${escapeHtml(p.source)}">${escapeHtml(sourceLabel(p.source))}</span>`
               : '';
             return `<div class="row">
               <div class="row-main">
@@ -493,24 +533,41 @@
       function renderAgents(domain, agents, properties) {
         const body = document.getElementById('agents-body');
         const help = document.getElementById('agents-help');
+        const nextStep = document.getElementById('next-step');
         if (!agents.length) {
           body.innerHTML = '';
-          // Contextual help: properties exist but no agents → most common
-          // confusing state for someone who came in via brand.json.
+          // When the publisher has properties (typically hydrated from
+          // brand.json) but no authorized agents, the most common reaction
+          // is "the page is broken — I declared everything." Lead with a
+          // standalone next-step card *above* the agents panel rather than
+          // bury an explanatory callout inside it.
+          const onlyBrandJson = properties && properties.length > 0
+            && properties.every((p) => p.source === 'brand_json');
           if (properties && properties.length > 0) {
-            help.classList.remove('hidden');
-            help.innerHTML = `<div class="help-callout">
-              <strong>No agents authorized yet.</strong> brand.json describes
-              <em>what</em> you publish — adagents.json declares <em>who</em>
-              can sell it. They are separate documents. Generate an
-              adagents.json above to authorize a sales agent.
-            </div>`;
+            help.classList.add('hidden');
+            if (nextStep) {
+              nextStep.classList.remove('hidden');
+              nextStep.innerHTML = `<div class="explainer" style="background: linear-gradient(135deg, var(--color-warning-50, #fef3c7) 0%, var(--color-bg-card) 100%);">
+                <h2>Next: declare who can sell this inventory</h2>
+                <p>${onlyBrandJson
+                  ? 'Your <code>brand.json</code> told us <em>what</em> you publish. <code>adagents.json</code> is a separate document that declares <em>who</em> is authorized to sell it. They are not the same record.'
+                  : 'You have properties on file but no authorized sales agents yet.'}
+                  Generate an <code>adagents.json</code> to authorize one or more agents — buyers consult that document to verify which agents may transact your inventory.</p>
+                <div class="cta-row">
+                  <a class="primary" href="/adagents/builder?domain=${encodeURIComponent(domain)}">Generate adagents.json</a>
+                  <a class="secondary" href="https://docs.adcontextprotocol.org/docs/governance/property/adagents" target="_blank" rel="noopener">Read the spec</a>
+                </div>
+              </div>`;
+            }
+            body.innerHTML = '<div class="empty">No authorized agents recorded yet — see the card above for next steps.</div>';
           } else {
             help.classList.add('hidden');
+            if (nextStep) nextStep.classList.add('hidden');
             body.innerHTML = '<div class="empty">No authorized agents recorded for this publisher yet.</div>';
           }
           return;
         }
+        if (nextStep) nextStep.classList.add('hidden');
         help.classList.add('hidden');
         body.innerHTML = agents
           .map((a, i) => {
@@ -589,6 +646,8 @@
           return;
         }
         document.title = `${domain} | AgenticAdvertising.org`;
+        const alt = document.getElementById('api-alternate');
+        if (alt) alt.setAttribute('href', `/api/registry/publisher?domain=${encodeURIComponent(domain)}`);
         try {
           const res = await fetch(`/api/registry/publisher?domain=${encodeURIComponent(domain)}`);
           if (!res.ok) {

--- a/server/public/publisher-home.html
+++ b/server/public/publisher-home.html
@@ -1,0 +1,637 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Publisher | AgenticAdvertising.org</title>
+    <link rel="icon" href="/addie-icon.svg" type="image/svg+xml" />
+    <link rel="stylesheet" href="/design-system.css" />
+    <link rel="stylesheet" href="/layout.css" />
+    <style>
+      body { padding-top: var(--nav-height); background: var(--color-surface); }
+      .container {
+        max-width: var(--container-lg);
+        margin: 0 auto;
+        padding: var(--space-8) var(--space-4);
+      }
+
+      .explainer {
+        background: linear-gradient(135deg, var(--color-primary-50, #eef2ff) 0%, var(--color-bg-card) 100%);
+        border: var(--border-1) solid var(--color-border);
+        border-radius: var(--radius-lg);
+        padding: var(--space-6);
+        margin-bottom: var(--space-6);
+      }
+      .explainer h2 { margin: 0 0 var(--space-2); font-size: var(--text-lg); }
+      .explainer p { margin: 0 0 var(--space-3); color: var(--color-text-muted); }
+      .explainer .cta-row { display: flex; gap: var(--space-3); flex-wrap: wrap; }
+
+      .header-card {
+        background: var(--color-bg-card);
+        border: var(--border-1) solid var(--color-border);
+        border-radius: var(--radius-lg);
+        padding: var(--space-6);
+        margin-bottom: var(--space-6);
+      }
+      .header-row {
+        display: flex; justify-content: space-between; align-items: flex-start;
+        flex-wrap: wrap; gap: var(--space-4);
+      }
+      .header-domain { font-family: var(--font-mono); font-size: var(--text-2xl); font-weight: var(--font-bold); }
+      .header-status {
+        display: flex; gap: var(--space-2); flex-wrap: wrap; align-items: center;
+      }
+
+      .badge {
+        display: inline-flex; align-items: center;
+        font-size: var(--text-xs); font-weight: var(--font-semibold);
+        padding: 4px 10px; border-radius: var(--radius-full);
+        text-transform: uppercase; letter-spacing: 0.04em;
+      }
+      .badge-member { background: var(--color-primary-100); color: var(--color-primary-800); }
+      .badge-source-adagents_json { background: #dbeafe; color: #1e40af; }
+      .badge-source-discovered    { background: #ede9fe; color: #5b21b6; }
+      .badge-source-brand_json    { background: #fef3c7; color: #92400e; }
+      .badge-source-agent_claim   { background: #f3e8ff; color: #6b21a8; }
+      .badge-valid    { background: #d1fae5; color: #065f46; }
+      .badge-invalid  { background: #fee2e2; color: #991b1b; }
+      .badge-unknown  { background: var(--color-bg-subtle); color: var(--color-text-muted); }
+      .badge-mode-aao_hosted { background: #d1fae5; color: #065f46; }
+      .badge-mode-self        { background: #dbeafe; color: #1e40af; }
+      .badge-mode-none        { background: var(--color-bg-subtle); color: var(--color-text-muted); }
+
+      .stats {
+        display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: var(--space-3); margin-top: var(--space-4);
+      }
+      .stat {
+        background: var(--color-bg-subtle);
+        border-radius: var(--radius-md);
+        padding: var(--space-3) var(--space-4);
+      }
+      .stat-value { font-size: var(--text-xl); font-weight: var(--font-bold); }
+      .stat-label { font-size: var(--text-xs); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.04em; }
+
+      .panel {
+        background: var(--color-bg-card);
+        border: var(--border-1) solid var(--color-border);
+        border-radius: var(--radius-lg);
+        margin-bottom: var(--space-6);
+        overflow: hidden;
+      }
+      .panel-header {
+        padding: var(--space-4) var(--space-6);
+        border-bottom: var(--border-1) solid var(--color-border);
+        display: flex; justify-content: space-between; align-items: center;
+        gap: var(--space-3); flex-wrap: wrap;
+      }
+      .panel-title { font-size: var(--text-base); font-weight: var(--font-semibold); }
+      .panel-subtitle { font-size: var(--text-sm); color: var(--color-text-muted); margin-top: 2px; }
+      .panel-body { padding: var(--space-2) 0; }
+
+      .row {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: var(--space-4);
+        padding: var(--space-3) var(--space-6);
+        border-bottom: var(--border-1) solid var(--color-border-light);
+      }
+      .row:last-child { border-bottom: none; }
+      .row-main { min-width: 0; }
+      .row-name { font-weight: var(--font-semibold); word-break: break-all; }
+      .row-meta {
+        font-size: var(--text-sm);
+        color: var(--color-text-muted);
+        margin-top: 2px;
+        display: flex; gap: var(--space-2); align-items: center; flex-wrap: wrap;
+      }
+      .row-side {
+        font-size: var(--text-sm);
+        color: var(--color-text-muted);
+        white-space: nowrap;
+        align-self: center;
+      }
+      .auth-fraction { font-weight: var(--font-semibold); color: var(--color-text); }
+
+      .agent-row {
+        cursor: pointer;
+        transition: var(--transition-colors);
+      }
+      .agent-row:hover { background: var(--color-bg-subtle); }
+      .agent-detail {
+        padding: var(--space-3) var(--space-6) var(--space-4);
+        background: var(--color-bg-subtle);
+        border-bottom: var(--border-1) solid var(--color-border-light);
+        font-size: var(--text-sm);
+      }
+      .agent-detail h4 {
+        font-size: var(--text-xs); text-transform: uppercase;
+        letter-spacing: 0.04em; color: var(--color-text-muted);
+        margin: 0 0 var(--space-2); font-weight: var(--font-semibold);
+      }
+      .agent-detail ul {
+        list-style: none; padding: 0; margin: 0 0 var(--space-3);
+      }
+      .agent-detail ul li {
+        padding: 4px 0; word-break: break-all;
+      }
+      .agent-detail .empty-mini { color: var(--color-text-muted); font-style: italic; }
+
+      .empty {
+        padding: var(--space-6); text-align: center;
+        color: var(--color-text-muted); font-size: var(--text-sm);
+      }
+      .help-callout {
+        margin: var(--space-3) var(--space-6) var(--space-4);
+        padding: var(--space-3) var(--space-4);
+        background: var(--color-bg-subtle);
+        border-left: 3px solid var(--color-brand);
+        border-radius: var(--radius-md);
+        font-size: var(--text-sm);
+        color: var(--color-text-secondary);
+      }
+      .help-callout strong { color: var(--color-text); }
+      .actions {
+        display: flex; gap: var(--space-3); flex-wrap: wrap;
+        padding: var(--space-4) var(--space-6);
+        background: var(--color-bg-subtle);
+        border-top: var(--border-1) solid var(--color-border);
+      }
+      .actions a, .actions button {
+        font-size: var(--text-sm); font-weight: var(--font-semibold);
+        padding: 8px 14px; border-radius: var(--radius-md);
+        text-decoration: none; cursor: pointer; border: none;
+      }
+      .actions .primary { background: var(--color-brand); color: white; }
+      .actions .secondary {
+        background: var(--color-bg-card);
+        color: var(--color-text);
+        border: var(--border-1) solid var(--color-border);
+      }
+
+      .hosting-detail {
+        padding: var(--space-4) var(--space-6);
+        font-size: var(--text-sm);
+      }
+      .hosting-detail p { margin: 0 0 var(--space-3); color: var(--color-text-secondary); }
+      .hosting-detail code {
+        display: inline-block;
+        background: var(--color-bg-subtle);
+        padding: 2px 8px; border-radius: var(--radius-sm);
+        font-family: var(--font-mono); font-size: var(--text-sm);
+        word-break: break-all;
+      }
+      .hosting-detail .url-block {
+        display: block;
+        padding: var(--space-2) var(--space-3);
+        margin-bottom: var(--space-2);
+      }
+
+      .loading-state, .error-state { padding: var(--space-12); text-align: center; }
+      .hidden { display: none !important; }
+      .spinner {
+        width: 24px; height: 24px; margin: 0 auto var(--space-3);
+        border: 3px solid var(--color-border);
+        border-top-color: var(--color-brand);
+        border-radius: 50%; animation: spin 0.7s linear infinite;
+      }
+      @keyframes spin { to { transform: rotate(360deg); } }
+    </style>
+  </head>
+  <body>
+    <div id="adcp-nav"></div>
+    <script src="/nav.js"></script>
+
+    <div class="container">
+      <div id="loading-state" class="loading-state">
+        <div class="spinner"></div>
+        <p>Loading publisher data&hellip;</p>
+      </div>
+
+      <div id="error-state" class="error-state hidden">
+        <h2 id="error-title">Publisher not found</h2>
+        <p id="error-message">We couldn't load this publisher.</p>
+      </div>
+
+      <div id="content" class="hidden">
+        <!-- Cold-visitor explainer (shown only when nothing is registered) -->
+        <div id="explainer" class="explainer hidden">
+          <h2>This is your publisher page on AAO</h2>
+          <p>
+            AgenticAdvertising.org is a public index of which AI sales agents
+            are authorized to sell each publisher's inventory. The
+            authoritative source is the <code>adagents.json</code> file you
+            publish on your own domain — AAO crawls and caches it so buyers
+            don't have to.
+          </p>
+          <p>
+            If you don't host your own yet, AAO can act as your registry of
+            record: you (or the community) declare your properties and
+            authorized agents here, and AAO serves the canonical document
+            until you're ready to take it over.
+          </p>
+          <div class="cta-row" id="explainer-ctas"></div>
+        </div>
+
+        <div class="header-card">
+          <div class="header-row">
+            <div>
+              <div class="header-domain" id="domain-title"></div>
+              <div id="member-line" style="margin-top: 4px; color: var(--color-text-muted); font-size: var(--text-sm);"></div>
+            </div>
+            <div class="header-status" id="status-badges"></div>
+          </div>
+          <div class="stats">
+            <div class="stat">
+              <div class="stat-value" id="stat-properties">0</div>
+              <div class="stat-label">Properties</div>
+            </div>
+            <div class="stat">
+              <div class="stat-value" id="stat-agents">0</div>
+              <div class="stat-label">Authorized agents</div>
+            </div>
+            <div class="stat">
+              <div class="stat-value" id="stat-source">&mdash;</div>
+              <div class="stat-label">Property source</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Hosting panel -->
+        <div class="panel">
+          <div class="panel-header">
+            <div>
+              <div class="panel-title">adagents.json hosting</div>
+              <div class="panel-subtitle" id="hosting-subtitle"></div>
+            </div>
+            <div id="hosting-mode-badge"></div>
+          </div>
+          <div class="hosting-detail" id="hosting-detail"></div>
+          <div class="actions" id="hosting-actions"></div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <div>
+              <div class="panel-title">Properties</div>
+              <div class="panel-subtitle" id="properties-subtitle"></div>
+            </div>
+          </div>
+          <div class="panel-body" id="properties-body"></div>
+          <div class="actions">
+            <a class="primary" id="edit-properties-link" href="#">Edit properties</a>
+            <a class="secondary" id="generate-adagents-link" href="/adagents/builder">Generate adagents.json</a>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <div>
+              <div class="panel-title">Authorized agents</div>
+              <div class="panel-subtitle">Click an agent to see which properties it can sell</div>
+            </div>
+          </div>
+          <div class="panel-body" id="agents-body"></div>
+          <div id="agents-help" class="hidden"></div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      const escapeHtml = (s) =>
+        String(s ?? '')
+          .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+
+      function getDomain() {
+        const path = window.location.pathname;
+        const m = path.match(/^\/publisher\/(.+?)\/?$/);
+        if (m) return decodeURIComponent(m[1]);
+        const params = new URLSearchParams(window.location.search);
+        return params.get('domain') || '';
+      }
+
+      function appUser() {
+        return (window.__APP_CONFIG__ && window.__APP_CONFIG__.user) || null;
+      }
+
+      function showError(title, message) {
+        document.getElementById('loading-state').classList.add('hidden');
+        document.getElementById('content').classList.add('hidden');
+        document.getElementById('error-state').classList.remove('hidden');
+        document.getElementById('error-title').textContent = title;
+        document.getElementById('error-message').textContent = message;
+      }
+
+      function renderStatusBadges(data) {
+        const el = document.getElementById('status-badges');
+        const parts = [];
+        if (data.member && data.member.slug) {
+          parts.push(`<span class="badge badge-member">Member</span>`);
+        }
+        if (data.adagents_valid === true) {
+          parts.push(`<span class="badge badge-valid">adagents.json valid</span>`);
+        } else if (data.adagents_valid === false) {
+          parts.push(`<span class="badge badge-invalid">adagents.json invalid</span>
+            <button id="show-validation-errors" type="button" style="margin-left: 6px; font-size: var(--text-xs); background: none; border: none; color: var(--color-brand); cursor: pointer; text-decoration: underline; padding: 0;">why?</button>`);
+        } else {
+          parts.push(`<span class="badge badge-unknown">adagents.json not yet crawled</span>`);
+        }
+        el.innerHTML = parts.join('');
+        const btn = document.getElementById('show-validation-errors');
+        if (btn) btn.addEventListener('click', () => showValidationDetail(data.domain));
+      }
+
+      async function showValidationDetail(domain) {
+        let detail = document.getElementById('validation-detail');
+        if (!detail) {
+          detail = document.createElement('div');
+          detail.id = 'validation-detail';
+          detail.className = 'help-callout';
+          detail.style.margin = 'var(--space-3) 0 0';
+          document.querySelector('.header-card').appendChild(detail);
+        } else if (!detail.classList.contains('hidden')) {
+          detail.classList.add('hidden');
+          return;
+        }
+        detail.classList.remove('hidden');
+        detail.innerHTML = '<em>Loading validation errors&hellip;</em>';
+        try {
+          const res = await fetch('/api/adagents/validate', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ domain }),
+          });
+          const body = await res.json();
+          const errors = (body && body.data && body.data.validation && body.data.validation.errors) || [];
+          if (!errors.length) {
+            detail.innerHTML = '<em>No structured errors returned. The fetch may have failed at the network layer — check that <code>' + escapeHtml(`https://${domain}/.well-known/adagents.json`) + '</code> is reachable.</em>';
+            return;
+          }
+          const list = errors
+            .slice(0, 8)
+            .map((e) => `<li><strong>${escapeHtml(e.field || 'document')}:</strong> ${escapeHtml(e.message || String(e))}</li>`)
+            .join('');
+          detail.innerHTML = `<strong>Validation errors</strong>
+            <ul style="margin: var(--space-2) 0 0; padding-left: var(--space-4);">${list}</ul>`;
+        } catch {
+          detail.innerHTML = '<em>Could not load validation detail.</em>';
+        }
+      }
+
+      function renderExplainer(data) {
+        // Only show the cold-visitor explainer when the page has nothing
+        // useful — no properties, no agents, no member, no valid adagents.
+        const isEmpty =
+          (!data.properties || data.properties.length === 0) &&
+          (!data.authorized_agents || data.authorized_agents.length === 0) &&
+          !data.member &&
+          data.hosting && data.hosting.mode === 'none';
+        const explainer = document.getElementById('explainer');
+        if (!isEmpty) { explainer.classList.add('hidden'); return; }
+        const user = appUser();
+        const ctas = [];
+        if (user) {
+          ctas.push(`<a class="primary" href="/property/view/${encodeURIComponent(data.domain)}">Claim this domain</a>`);
+        } else {
+          ctas.push(`<a class="primary" href="/login?return_to=${encodeURIComponent(window.location.pathname)}">Sign in to claim</a>`);
+        }
+        ctas.push(`<a class="secondary" href="/adagents-landing">What is adagents.json?</a>`);
+        document.getElementById('explainer-ctas').innerHTML = ctas.join('');
+        explainer.classList.remove('hidden');
+      }
+
+      function renderHosting(data) {
+        const hosting = data.hosting || { mode: 'none', expected_url: '' };
+        const subtitle = document.getElementById('hosting-subtitle');
+        const detail = document.getElementById('hosting-detail');
+        const badge = document.getElementById('hosting-mode-badge');
+        const actions = document.getElementById('hosting-actions');
+
+        const labels = {
+          aao_hosted: 'AAO-hosted',
+          self: 'Self-hosted',
+          none: 'Not yet configured',
+        };
+        const subtitles = {
+          aao_hosted: 'AAO serves the canonical adagents.json for this domain.',
+          self: 'This publisher serves adagents.json from their own domain.',
+          none: 'No adagents.json is published for this domain yet.',
+        };
+        subtitle.textContent = subtitles[hosting.mode] || '';
+        badge.innerHTML = `<span class="badge badge-mode-${escapeHtml(hosting.mode)}">${escapeHtml(labels[hosting.mode] || hosting.mode)}</span>`;
+
+        if (hosting.mode === 'aao_hosted') {
+          detail.innerHTML = `
+            <p>Point your domain at AAO's hosted document, or copy the URL below into a CNAME / 301 redirect from your own <code>/.well-known/adagents.json</code>:</p>
+            <code class="url-block">${escapeHtml(hosting.hosted_url || '')}</code>
+            <p>Buyers will continue to fetch <code>${escapeHtml(hosting.expected_url)}</code>; the redirect resolves transparently.</p>
+          `;
+          actions.innerHTML = `
+            <a class="secondary" href="${escapeHtml(hosting.hosted_url || '#')}" target="_blank" rel="noopener">View hosted file</a>
+            <a class="secondary" href="/property/view/${encodeURIComponent(data.domain)}">Manage hosted properties</a>
+          `;
+        } else if (hosting.mode === 'self') {
+          detail.innerHTML = `
+            <p>AAO crawls <code>${escapeHtml(hosting.expected_url)}</code> directly. Update that file to change which agents are authorized.</p>
+          `;
+          actions.innerHTML = `
+            <a class="secondary" href="${escapeHtml(hosting.expected_url)}" target="_blank" rel="noopener">Open self-hosted file</a>
+            <a class="secondary" href="/adagents/builder?domain=${encodeURIComponent(data.domain)}">Update adagents.json</a>
+          `;
+        } else {
+          detail.innerHTML = `
+            <p>You have two options for publishing adagents.json:</p>
+            <p>1. <strong>Self-host:</strong> generate the file and put it at <code>${escapeHtml(hosting.expected_url)}</code>. No account needed — but you control the file forever.</p>
+            <p>2. <strong>Let AAO host it</strong> <span style="color: var(--color-text-muted);">(requires free registration)</span>: we serve the canonical document and you point a CNAME or redirect at us. Switch back to self-hosting any time.</p>
+          `;
+          actions.innerHTML = `
+            <a class="primary" href="/adagents/builder?domain=${encodeURIComponent(data.domain)}">Generate adagents.json</a>
+            <a class="secondary" href="/property/view/${encodeURIComponent(data.domain)}">Set up AAO hosting</a>
+          `;
+        }
+      }
+
+      function renderProperties(props) {
+        const body = document.getElementById('properties-body');
+        const subtitle = document.getElementById('properties-subtitle');
+        if (!props.length) {
+          body.innerHTML = '<div class="empty">No properties registered yet. Add your inventory or point us at your brand.json.</div>';
+          subtitle.textContent = '0 properties';
+          return;
+        }
+        const sources = new Set(props.map((p) => p.source).filter(Boolean));
+        subtitle.textContent =
+          `${props.length} ${props.length === 1 ? 'property' : 'properties'}`
+          + (sources.size ? ' · sourced from ' + Array.from(sources).join(', ') : '');
+        body.innerHTML = props
+          .map((p) => {
+            const idents = (p.identifiers || [])
+              .map((i) => `<code>${escapeHtml(i.type)}=${escapeHtml(i.value)}</code>`)
+              .join(' ');
+            const tags = (p.tags || [])
+              .map((t) => `<span class="badge badge-unknown" title="${escapeHtml(t)}">${escapeHtml(t)}</span>`)
+              .join('');
+            const source = p.source
+              ? `<span class="badge badge-source-${escapeHtml(p.source)}">${escapeHtml(p.source.replace('_', '.'))}</span>`
+              : '';
+            return `<div class="row">
+              <div class="row-main">
+                <div class="row-name">${escapeHtml(p.name || p.id || '(unnamed)')}</div>
+                <div class="row-meta">
+                  <span>${escapeHtml(p.type || 'unknown')}</span>
+                  ${idents}
+                  ${tags}
+                </div>
+              </div>
+              <div class="row-side">${source}</div>
+            </div>`;
+          })
+          .join('');
+      }
+
+      function renderAgents(domain, agents, properties) {
+        const body = document.getElementById('agents-body');
+        const help = document.getElementById('agents-help');
+        if (!agents.length) {
+          body.innerHTML = '';
+          // Contextual help: properties exist but no agents → most common
+          // confusing state for someone who came in via brand.json.
+          if (properties && properties.length > 0) {
+            help.classList.remove('hidden');
+            help.innerHTML = `<div class="help-callout">
+              <strong>No agents authorized yet.</strong> brand.json describes
+              <em>what</em> you publish — adagents.json declares <em>who</em>
+              can sell it. They are separate documents. Generate an
+              adagents.json above to authorize a sales agent.
+            </div>`;
+          } else {
+            help.classList.add('hidden');
+            body.innerHTML = '<div class="empty">No authorized agents recorded for this publisher yet.</div>';
+          }
+          return;
+        }
+        help.classList.add('hidden');
+        body.innerHTML = agents
+          .map((a, i) => {
+            const auth = (typeof a.properties_authorized === 'number' && typeof a.properties_total === 'number')
+              ? `<span class="auth-fraction">${a.properties_authorized} of ${a.properties_total}</span> properties authorized`
+              : 'authorization scope unknown';
+            const sourceBadge = a.source
+              ? `<span class="badge badge-source-${escapeHtml(a.source)}">${escapeHtml(a.source.replace('_', '.'))}</span>`
+              : '';
+            const scope = a.authorized_for
+              ? `<span style="color: var(--color-text-muted);">${escapeHtml(a.authorized_for)}</span>`
+              : '';
+            return `<div class="agent-row row" data-agent-index="${i}" data-agent-url="${escapeHtml(a.url)}">
+              <div class="row-main">
+                <div class="row-name">${escapeHtml(a.url)}</div>
+                <div class="row-meta">${sourceBadge} ${scope}</div>
+              </div>
+              <div class="row-side">${auth}</div>
+            </div>
+            <div class="agent-detail hidden" id="agent-detail-${i}"></div>`;
+          })
+          .join('');
+        // Attach click handlers — toggle expand/collapse, lazy-load detail.
+        body.querySelectorAll('.agent-row').forEach((row) => {
+          row.addEventListener('click', () => toggleAgentDetail(domain, row));
+        });
+      }
+
+      const detailCache = new Map();
+
+      async function toggleAgentDetail(domain, rowEl) {
+        const idx = rowEl.getAttribute('data-agent-index');
+        const agentUrl = rowEl.getAttribute('data-agent-url');
+        const detail = document.getElementById(`agent-detail-${idx}`);
+        if (!detail.classList.contains('hidden')) {
+          detail.classList.add('hidden');
+          return;
+        }
+        if (!detailCache.has(agentUrl)) {
+          detail.innerHTML = '<div class="empty-mini">Loading authorization detail&hellip;</div>';
+          detail.classList.remove('hidden');
+          try {
+            const res = await fetch(
+              `/api/registry/publisher/authorization?domain=${encodeURIComponent(domain)}&agent=${encodeURIComponent(agentUrl)}`
+            );
+            if (res.ok) {
+              detailCache.set(agentUrl, await res.json());
+            } else {
+              detail.innerHTML = '<div class="empty-mini">Could not load authorization detail.</div>';
+              return;
+            }
+          } catch {
+            detail.innerHTML = '<div class="empty-mini">Could not load authorization detail.</div>';
+            return;
+          }
+        }
+        const data = detailCache.get(agentUrl);
+        if (data.publisher_wide) {
+          detail.innerHTML = `<div class="empty-mini">This agent has a publisher-wide authorization — it can sell every property under this domain.</div>`;
+        } else {
+          const unauth = (data.unauthorized_properties || [])
+            .map((p) => `<li>${escapeHtml(p.name || p.id || '(unnamed)')} <span style="color: var(--color-text-muted);">(${escapeHtml(p.type || 'unknown')})</span></li>`)
+            .join('');
+          detail.innerHTML = `
+            <h4>Authorized for ${data.authorized} of ${data.total} properties</h4>
+            ${unauth ? `<h4 style="margin-top: var(--space-3);">Not authorized for</h4><ul>${unauth}</ul>` : ''}
+          `;
+        }
+        detail.classList.remove('hidden');
+      }
+
+      async function load() {
+        const domain = getDomain();
+        if (!domain) {
+          showError('Missing domain', 'No publisher domain in the URL.');
+          return;
+        }
+        document.title = `${domain} | AgenticAdvertising.org`;
+        try {
+          const res = await fetch(`/api/registry/publisher?domain=${encodeURIComponent(domain)}`);
+          if (!res.ok) {
+            showError('Lookup failed', `Server returned ${res.status}.`);
+            return;
+          }
+          const data = await res.json();
+
+          document.getElementById('loading-state').classList.add('hidden');
+          document.getElementById('content').classList.remove('hidden');
+          document.getElementById('domain-title').textContent = data.domain;
+
+          const memberLine = document.getElementById('member-line');
+          if (data.member && data.member.display_name) {
+            memberLine.innerHTML = `Member: <a href="/m/${escapeHtml(data.member.slug)}">${escapeHtml(data.member.display_name)}</a>`;
+          } else {
+            memberLine.textContent = 'Not yet registered as an AAO member.';
+          }
+
+          renderStatusBadges(data);
+          renderExplainer(data);
+          renderHosting(data);
+
+          const props = Array.isArray(data.properties) ? data.properties : [];
+          const agents = Array.isArray(data.authorized_agents) ? data.authorized_agents : [];
+
+          document.getElementById('stat-properties').textContent = props.length;
+          document.getElementById('stat-agents').textContent = agents.length;
+          const sources = Array.from(new Set(props.map((p) => p.source).filter(Boolean)));
+          document.getElementById('stat-source').textContent = sources.length ? sources.join(', ') : '—';
+
+          renderProperties(props);
+          renderAgents(data.domain, agents, props);
+
+          document.getElementById('edit-properties-link').href =
+            `/property/view/${encodeURIComponent(data.domain)}`;
+        } catch (err) {
+          console.error(err);
+          showError('Lookup failed', 'Network error or server is unavailable.');
+        }
+      }
+
+      load();
+    </script>
+  </body>
+</html>

--- a/server/public/publishers.html
+++ b/server/public/publishers.html
@@ -272,7 +272,12 @@
 <header class="page-header">
   <h1>Properties</h1>
   <p>Search for your property or add it to get discovered by buying agents</p>
-  <div style="margin-top: var(--space-4);">
+  <form id="publisher-quick-lookup" style="margin-top: var(--space-4); display: flex; gap: var(--space-2); justify-content: center; flex-wrap: wrap; max-width: 520px; margin-left: auto; margin-right: auto;">
+    <input id="publisher-quick-lookup-input" type="text" placeholder="your-domain.com" required pattern="[a-zA-Z0-9.\-]+" autocomplete="off"
+      style="flex: 1 1 240px; padding: var(--space-2) var(--space-3); border: var(--border-1) solid var(--color-border); border-radius: var(--radius-md); font-family: var(--font-mono); font-size: var(--text-sm);" />
+    <button type="submit" style="padding: var(--space-2) var(--space-4); border: none; border-radius: var(--radius-md); background: var(--color-brand); color: white; font-weight: var(--font-semibold); cursor: pointer;">Open my publisher page</button>
+  </form>
+  <div style="margin-top: var(--space-3);">
     <a href="/adagents/builder" style="font-size: var(--text-sm); font-weight: var(--font-semibold); color: var(--color-brand); text-decoration: none;">Build an adagents.json &rarr;</a>
   </div>
 </header>
@@ -480,7 +485,7 @@
       const isAuthoritative = pub.source === 'adagents_json';
       const primary = getPrimaryIdentifier(pub);
       const linkDomain = pub.identifiers?.find(i => i.type === 'domain')?.value;
-      const href = linkDomain ? `/property/view/${encodeURIComponent(linkDomain)}` : null;
+      const href = linkDomain ? `/publisher/${encodeURIComponent(linkDomain)}` : null;
       const showTypeLabel = primary.type !== 'domain';
 
       // Additional identifiers as pills (skip duplicates of primary, max 3)
@@ -588,6 +593,13 @@
     if (!str) return '';
     return str.replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]);
   }
+
+  document.getElementById('publisher-quick-lookup')?.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const raw = document.getElementById('publisher-quick-lookup-input').value.trim().toLowerCase();
+    const stripped = raw.replace(/^https?:\/\//, '').replace(/\/$/, '').split('/')[0];
+    if (stripped) window.location.href = `/publisher/${encodeURIComponent(stripped)}`;
+  });
 </script>
 </body>
 </html>

--- a/server/public/registry-nav.js
+++ b/server/public/registry-nav.js
@@ -34,8 +34,8 @@
     }
     // Detail pages under /brand/view highlight brands tab
     if (link.tab === 'brands' && path.startsWith('/brand/view')) return true;
-    // Detail pages under /property/view highlight properties tab
-    if (link.tab === 'properties' && path.startsWith('/property/view')) return true;
+    // Detail pages under /property/view or /publisher highlight properties tab
+    if (link.tab === 'properties' && (path.startsWith('/property/view') || path.startsWith('/publisher/'))) return true;
     // /policies standalone page
     if (link.tab === 'policies' && path === '/policies') return true;
     // /members standalone page

--- a/server/public/registry-tools.html
+++ b/server/public/registry-tools.html
@@ -171,6 +171,23 @@
   </header>
 
   <div class="tools-container">
+    <!-- Publisher lookup -->
+    <div class="standard-section">
+      <div class="standard-section__label">Publisher lookup</div>
+      <div class="standard-card">
+        <div class="standard-card__body">
+          <h3>Look up a publisher</h3>
+          <p>See which AI sales agents are authorized for a publisher's inventory, what properties they expose, and how their <code>adagents.json</code> is hosted. If you publish here, this is also where you manage your record.</p>
+          <form id="publisher-lookup-form" style="display: flex; gap: var(--space-3); margin-top: var(--space-4); flex-wrap: wrap;">
+            <input id="publisher-lookup-input" type="text" placeholder="example.com" required pattern="[a-zA-Z0-9.\-]+" autocomplete="off"
+              style="flex: 1 1 240px; padding: var(--space-2) var(--space-3); border: var(--border-1) solid var(--color-border); border-radius: var(--radius-md); font-family: var(--font-mono); font-size: var(--text-sm);" />
+            <button type="submit" class="action-primary" style="border: none; cursor: pointer;">Open publisher page</button>
+            <a href="/publishers" class="action-secondary">Browse all publishers</a>
+          </form>
+        </div>
+      </div>
+    </div>
+
     <!-- brand.json -->
     <div class="standard-section">
       <div class="standard-section__label">Well-known file standard</div>
@@ -225,5 +242,13 @@
   </div>
 
   <div id="adcp-footer"></div>
+  <script>
+    document.getElementById('publisher-lookup-form')?.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const raw = document.getElementById('publisher-lookup-input').value.trim().toLowerCase();
+      const stripped = raw.replace(/^https?:\/\//, '').replace(/\/$/, '').split('/')[0];
+      if (stripped) window.location.href = `/publisher/${encodeURIComponent(stripped)}`;
+    });
+  </script>
 </body>
 </html>

--- a/server/src/addie/mcp/property-tools.ts
+++ b/server/src/addie/mcp/property-tools.ts
@@ -14,6 +14,7 @@ import { registryRequestsDb } from '../../db/registry-requests-db.js';
 import { PropertyCheckService } from '../../services/property-check.js';
 import { PropertyCheckDatabase } from '../../db/property-check-db.js';
 import { enhanceProperty } from '../../services/property-enhancement.js';
+import { syncHostedPropertyToFederatedIndex } from '../../services/hosted-property-sync.js';
 import { fileDispute } from '../../services/catalog-governance.js';
 import type { DisputeType } from '../../db/catalog-disputes-db.js';
 import { AAO_HOST } from '../../config/aao.js';
@@ -437,6 +438,12 @@ export function createPropertyToolHandlers(): Map<string, (args: Record<string, 
           });
         }
 
+        // Approval flips is_public=true; mirror the now-public document
+        // into the federated index. approveAndPublishProperty returns
+        // boolean only, so re-read the row to hand sync a typed object.
+        const approved = await propertyDb.getHostedPropertyByDomain(publisherDomain);
+        if (approved) await syncHostedPropertyToFederatedIndex(approved);
+
         return JSON.stringify({
           success: true,
           message: `Property "${publisherDomain}" approved and published to registry`,
@@ -452,6 +459,7 @@ export function createPropertyToolHandlers(): Map<string, (args: Record<string, 
         editor_email: 'addie@agenticadvertising.org',
         editor_name: 'Addie',
       });
+      await syncHostedPropertyToFederatedIndex(property);
 
       return JSON.stringify({
         success: true,
@@ -469,6 +477,7 @@ export function createPropertyToolHandlers(): Map<string, (args: Record<string, 
       is_public: true,
       review_status: 'approved',
     });
+    await syncHostedPropertyToFederatedIndex(saved);
 
     return JSON.stringify({
       success: true,

--- a/server/src/config/aao.ts
+++ b/server/src/config/aao.ts
@@ -3,3 +3,11 @@ export const AAO_HOST = 'agenticadvertising.org';
 export function aaoHostedBrandJsonUrl(domain: string): string {
   return `https://${AAO_HOST}/brands/${domain}/brand.json`;
 }
+
+export function aaoHostedAdagentsJsonUrl(domain: string): string {
+  return `https://${AAO_HOST}/publisher/${domain}/.well-known/adagents.json`;
+}
+
+export function expectedAdagentsJsonUrl(domain: string): string {
+  return `https://${domain}/.well-known/adagents.json`;
+}

--- a/server/src/db/federated-index-db.ts
+++ b/server/src/db/federated-index-db.ts
@@ -30,7 +30,21 @@ export interface DiscoveredPublisher {
 }
 
 /**
- * Agent-publisher authorization (from adagents.json or agent claims)
+ * Agent-publisher authorization.
+ *
+ * `source` distinguishes how strongly the row is attested:
+ *  - `adagents_json`: the publisher's origin actually serves a valid
+ *    adagents.json (either directly at /.well-known or via a stub with
+ *    `authoritative_location`). Origin-verified.
+ *  - `aao_hosted`: AAO is hosting the canonical document on the
+ *    publisher's behalf, but the publisher's origin has NOT been
+ *    verified to point at us yet. The hosted document represents the
+ *    publisher's intent; it does not yet carry the same trust weight as
+ *    an origin-verified row. Promotion to `adagents_json` requires a
+ *    successful round-trip fetch of the publisher's /.well-known.
+ *  - `agent_claim`: the agent claimed authorization via a
+ *    list_authorized_properties response; the publisher has not
+ *    confirmed it.
  */
 export interface AgentPublisherAuthorization {
   id?: string;
@@ -38,7 +52,7 @@ export interface AgentPublisherAuthorization {
   publisher_domain: string;
   authorized_for?: string;
   property_ids?: string[];
-  source: 'adagents_json' | 'agent_claim';
+  source: 'adagents_json' | 'aao_hosted' | 'agent_claim';
   discovered_at?: Date;
   last_validated?: Date;
 }

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -3024,6 +3024,51 @@ export class HTTPServer {
       await this.serveHtmlWithConfig(req, res, 'property-viewer.html');
     });
 
+    // GET /publisher/:domain/.well-known/adagents.json - AAO-hosted
+    // adagents.json for a publisher that has opted into AAO hosting. The
+    // publisher saves their authorized agents + properties via the hosted
+    // property flow; this endpoint serves the canonical document so the
+    // publisher can either paste the snippet at their own /.well-known
+    // path OR point a CNAME / redirect at AAO. Returns 404 unless a public
+    // hosted-property row exists. Must register before the /publisher
+    // wildcard route below.
+    this.app.get('/publisher/:domain/.well-known/adagents.json', async (req, res) => {
+      // Local domain shape check — keeps malformed input out of the DB
+      // lookup and out of structured logs / metrics. Mirrors the regex used
+      // by /api/registry/publisher (see routes/registry-api.ts:isValidDomain).
+      const validDomainRe = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/;
+      let domain: string;
+      try {
+        domain = decodeURIComponent(req.params.domain).toLowerCase();
+      } catch {
+        return res.status(400).json({ error: 'Malformed domain' });
+      }
+      if (domain.length > 253 || !validDomainRe.test(domain)) {
+        return res.status(400).json({ error: 'Invalid domain' });
+      }
+      try {
+        const hosted = await this.propertyDb.getHostedPropertyByDomain(domain);
+        if (!hosted || !hosted.is_public) {
+          return res.status(404).json({ error: 'No AAO-hosted adagents.json for this domain', domain });
+        }
+        res.setHeader('Content-Type', 'application/json');
+        res.setHeader('Access-Control-Allow-Origin', '*');
+        res.setHeader('Cache-Control', 'public, max-age=300');
+        return res.json(hosted.adagents_json);
+      } catch (error) {
+        logger.error({ error }, 'Failed to serve hosted adagents.json');
+        return res.status(500).json({ error: 'Failed to serve adagents.json' });
+      }
+    });
+
+    // GET /publisher/:domain - Unified publisher self-service page. Wildcard
+    // captures dots; the page reads the domain from the path and calls
+    // /api/registry/publisher to render properties + per-agent authorization
+    // rollup.
+    this.app.get('/publisher/*domain', async (req, res) => {
+      await this.serveHtmlWithConfig(req, res, 'publisher-home.html');
+    });
+
     // GET /brand/:id/brand.json - Serve hosted brand.json
     this.app.get('/brand/:id/brand.json', async (req, res) => {
       try {

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -79,7 +79,7 @@ import type { AdAgentsManager } from "../adagents-manager.js";
 import type { HealthChecker } from "../health.js";
 import type { CrawlerService } from "../crawler.js";
 import type { CapabilityDiscovery } from "../capabilities.js";
-import { AAO_HOST, aaoHostedBrandJsonUrl, aaoHostedAdagentsJsonUrl, expectedAdagentsJsonUrl } from "../config/aao.js";
+import { aaoHostedBrandJsonUrl, aaoHostedAdagentsJsonUrl, expectedAdagentsJsonUrl } from "../config/aao.js";
 import { fetchBrandData, isBrandfetchConfigured, ENRICHMENT_CACHE_MAX_AGE_MS } from "../services/brandfetch.js";
 import { extractPublisherPropertiesFromBrandJson } from "../services/brand-json-properties.js";
 import { syncHostedPropertyToFederatedIndex } from "../services/hosted-property-sync.js";

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -79,8 +79,10 @@ import type { AdAgentsManager } from "../adagents-manager.js";
 import type { HealthChecker } from "../health.js";
 import type { CrawlerService } from "../crawler.js";
 import type { CapabilityDiscovery } from "../capabilities.js";
-import { AAO_HOST, aaoHostedBrandJsonUrl } from "../config/aao.js";
+import { AAO_HOST, aaoHostedBrandJsonUrl, aaoHostedAdagentsJsonUrl, expectedAdagentsJsonUrl } from "../config/aao.js";
 import { fetchBrandData, isBrandfetchConfigured, ENRICHMENT_CACHE_MAX_AGE_MS } from "../services/brandfetch.js";
+import { extractPublisherPropertiesFromBrandJson } from "../services/brand-json-properties.js";
+import { syncHostedPropertyToFederatedIndex } from "../services/hosted-property-sync.js";
 import { PropertyCheckService } from "../services/property-check.js";
 import { PropertyCheckDatabase } from "../db/property-check-db.js";
 import { BulkPropertyCheckService } from "../services/bulk-property-check.js";
@@ -718,6 +720,47 @@ registry.registerPath({
   responses: {
     200: { description: "Publisher lookup result", content: { "application/json": { schema: PublisherLookupResultSchema } } },
     400: { description: "Missing domain", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/registry/publisher/authorization",
+  operationId: "lookupPublisherAgentAuthorization",
+  summary: "Per-agent authorization rollup",
+  description:
+    "Returns whether a given agent is authorized for a publisher domain and how many of the publisher's properties it can sell. When the agent has property-level authorization rows, the count is the intersection with the publisher's property set; when it only has a publisher-wide row, the count equals the total. Returns 404 when the agent has no authorization (publisher-wide or property-level) for the domain.",
+  tags: ["Authorization Lookups"],
+  request: {
+    query: z.object({
+      domain: z.string().openapi({ example: "voxmedia.com" }),
+      agent: z.string().openapi({ example: "https://sales.pubmatic.com/mcp" }),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Authorization rollup",
+      content: {
+        "application/json": {
+          schema: z.object({
+            publisher_domain: z.string(),
+            agent_url: z.string(),
+            authorized: z.number().int().nonnegative().openapi({ description: "Count of publisher's properties the agent can sell." }),
+            total: z.number().int().nonnegative().openapi({ description: "Total properties the publisher exposes." }),
+            publisher_wide: z.boolean().openapi({ description: "True when the agent has only a publisher-wide authorization (no property-level rows). In that case `authorized` equals `total`." }),
+            source: z.enum(["adagents_json", "agent_claim"]),
+            authorized_for: z.string().optional(),
+            unauthorized_properties: z.array(z.object({
+              id: z.string().optional(),
+              name: z.string().optional(),
+              type: z.string().optional(),
+            })).openapi({ description: "Properties the agent is NOT authorized for. Empty when publisher_wide is true." }),
+          }),
+        },
+      },
+    },
+    400: { description: "Missing domain or agent", content: { "application/json": { schema: ErrorSchema } } },
+    404: { description: "No authorization record for this agent on this publisher", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
 
@@ -3366,6 +3409,11 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           editor_name: `${req.user!.firstName || ""} ${req.user!.lastName || ""}`.trim() || req.user!.email,
         });
 
+        // Mirror the updated hosted document into the federated index so
+        // /api/registry/publisher reflects the new authorized agents +
+        // properties immediately. No-op when the property is not public.
+        await syncHostedPropertyToFederatedIndex(property);
+
         return res.json({
           success: true,
           message: `Property "${publisher_domain}" updated in registry (revision ${revision_number})`,
@@ -3379,6 +3427,12 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         adagents_json: adagentsJson,
         source_type: "community",
       });
+
+      // Sync runs on create even though the new row is private by default —
+      // when an admin later flips is_public=true via the approval flow, that
+      // path also calls sync. Call here too so the function is the one
+      // place we wire propagation, regardless of which write path runs first.
+      await syncHostedPropertyToFederatedIndex(saved);
 
       return res.json({
         success: true,
@@ -5573,37 +5627,198 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       const memberDb = new MemberDatabase();
       const federatedIndex = crawler.getFederatedIndex();
 
-      const [profile, properties, authorizations, adagentsValid] = await Promise.all([
+      const [profile, properties, authorizations, adagentsValid, hostedProperty] = await Promise.all([
         memberDb.getProfileByDomain(domain),
         federatedIndex.getPropertiesForDomain(domain),
         federatedIndex.getAuthorizationsForDomain(domain),
         federatedIndex.hasValidAdagents(domain),
+        propertyDb.getHostedPropertyByDomain(domain),
       ]);
 
       const member = profile
         ? { slug: profile.slug, display_name: profile.display_name }
         : null;
 
+      // Hosting state. `aao_hosted` only when a public hosted-property row
+      // exists for this domain (i.e. the publisher opted into AAO serving
+      // their adagents.json). `self` when the publisher has a valid live
+      // adagents.json. Otherwise `none`.
+      const aaoHosted = !!(hostedProperty && hostedProperty.is_public);
+      const hosting = {
+        mode: (aaoHosted ? "aao_hosted" : adagentsValid === true ? "self" : "none") as "self" | "aao_hosted" | "none",
+        hosted_url: aaoHosted ? aaoHostedAdagentsJsonUrl(domain) : undefined,
+        expected_url: expectedAdagentsJsonUrl(domain),
+      };
+
+      type ProjectedProperty = {
+        id?: string;
+        type?: string;
+        name?: string;
+        identifiers?: Array<{ type: string; value: string }>;
+        tags?: string[];
+        source: "adagents_json" | "discovered" | "brand_json";
+      };
+
+      let projectedProperties: ProjectedProperty[] = properties.map(p => ({
+        id: p.property_id,
+        type: p.property_type,
+        name: p.name,
+        identifiers: p.identifiers,
+        tags: p.tags,
+        source: "discovered",
+      }));
+
+      // Fallback: if the federated index has nothing for this domain, hydrate
+      // from the publisher's brand.json so that publishers who already
+      // declared their properties there don't see "0 properties". Hosted
+      // brand wins over discovered (hosted is owner-curated).
+      if (projectedProperties.length === 0) {
+        const hostedBrand = await brandDb.getHostedBrandByDomain(domain);
+        const manifest = hostedBrand?.brand_json
+          ?? (await brandDb.getDiscoveredBrandByDomain(domain))?.brand_manifest;
+        projectedProperties = extractPublisherPropertiesFromBrandJson(
+          manifest as Record<string, unknown> | null | undefined,
+        );
+      }
+
+      // Per-agent property authorization rollup. For each authorized agent
+      // we expose `properties_authorized: M of properties_total: N` so a
+      // caller (UI, downstream service) can render "X of Y authorized" without
+      // re-walking the property graph itself. Property-level rows present →
+      // intersection count. None present → publisher-wide authorization →
+      // count equals total. Brand.json-hydrated properties are not in the
+      // federated index yet, so per-agent counts collapse to total in that
+      // path — matches the semantic that hydrated properties are "best known"
+      // rather than authoritatively scoped per agent.
+      //
+      // Cap the fan-out: each agent triggers a non-trivial DB query and the
+      // endpoint is unauthenticated. A pathological hosted document with
+      // hundreds of authorized agents would otherwise turn a single anonymous
+      // request into hundreds of queries. Above the cap, return the agents
+      // without the rollup and a `truncated` flag so callers can hit
+      // `/api/registry/publisher/authorization` for individual checks.
+      const PER_AGENT_ROLLUP_CAP = 50;
+      const propertiesTotal = projectedProperties.length;
+      // `id` in the projection is the adagents.json slug; the federated
+      // index also exposes a stable database id on the source rows. Match on
+      // the database id to avoid false negatives when slugs collide or
+      // properties were discovered without an explicit slug.
+      const propertyDbIdSet = new Set(
+        properties.map(p => p.id).filter((id): id is string => Boolean(id)),
+      );
+      const rollupTruncated = authorizations.length > PER_AGENT_ROLLUP_CAP;
+      const agentsToRollup = rollupTruncated
+        ? authorizations.slice(0, PER_AGENT_ROLLUP_CAP)
+        : authorizations;
+      const agentPropertyCounts = new Map<string, number>();
+      await Promise.all(
+        agentsToRollup.map(async a => {
+          const agentProps = await federatedIndex.getPropertiesForAgent(a.agent_url);
+          const matching = agentProps.filter(
+            p => p.publisher_domain === domain && p.id && propertyDbIdSet.has(p.id),
+          );
+          agentPropertyCounts.set(a.agent_url, matching.length);
+        }),
+      );
+
       res.json({
         domain,
         member,
         adagents_valid: adagentsValid,
-        properties: properties.map(p => ({
-          id: p.property_id,
-          type: p.property_type,
-          name: p.name,
-          identifiers: p.identifiers,
-          tags: p.tags,
-        })),
-        authorized_agents: authorizations.map(a => ({
-          url: a.agent_url,
-          authorized_for: a.authorized_for,
-          source: a.source,
-        })),
+        hosting,
+        properties: projectedProperties,
+        authorized_agents: authorizations.map(a => {
+          const matched = agentPropertyCounts.get(a.agent_url);
+          if (matched === undefined) {
+            // Truncated: rollup not computed for this agent.
+            return {
+              url: a.agent_url,
+              authorized_for: a.authorized_for,
+              source: a.source,
+            };
+          }
+          // No property-level rows → publisher-wide → authorized for all.
+          const authorized = matched > 0 ? matched : propertiesTotal;
+          return {
+            url: a.agent_url,
+            authorized_for: a.authorized_for,
+            source: a.source,
+            properties_authorized: authorized,
+            properties_total: propertiesTotal,
+          };
+        }),
+        rollup_truncated: rollupTruncated || undefined,
       });
     } catch (error) {
       logger.error({ err: error, path: req.path }, "Publisher lookup failed");
       res.status(500).json({ error: "Publisher lookup failed" });
+    }
+  });
+
+  router.get("/registry/publisher/authorization", async (req, res) => {
+    const rawDomain = req.query.domain as string;
+    const rawAgent = req.query.agent as string;
+    if (!rawDomain || !rawAgent) {
+      return res.status(400).json({ error: "Missing required query params: domain, agent" });
+    }
+    try {
+      const domain = extractDomain(rawDomain);
+      if (!isValidDomain(domain)) {
+        return res.status(400).json({ error: "Invalid domain" });
+      }
+      // Canonicalize the agent URL the same way the writer does so trailing
+      // slashes and case-only variants don't yield false 404s.
+      const agentUrl = canonicalizeAgentUrl(rawAgent);
+      if (!agentUrl) {
+        return res.status(400).json({ error: "Invalid agent URL" });
+      }
+      const federatedIndex = crawler.getFederatedIndex();
+
+      const [properties, authorizations] = await Promise.all([
+        federatedIndex.getPropertiesForDomain(domain),
+        federatedIndex.getAuthorizationsForDomain(domain),
+      ]);
+
+      const auth = authorizations.find(a => canonicalizeAgentUrl(a.agent_url) === agentUrl);
+      if (!auth) {
+        return res.status(404).json({
+          error: "Agent has no authorization for this publisher",
+          domain,
+          agent_url: agentUrl,
+        });
+      }
+
+      const total = properties.length;
+      const propertyDbIdSet = new Set(
+        properties.map(p => p.id).filter((id): id is string => Boolean(id)),
+      );
+      const agentProps = await federatedIndex.getPropertiesForAgent(agentUrl);
+      const matched = agentProps.filter(
+        p => p.publisher_domain === domain && p.id && propertyDbIdSet.has(p.id),
+      );
+
+      const publisherWide = matched.length === 0;
+      const authorized = publisherWide ? total : matched.length;
+      const matchedIds = new Set(matched.map(p => p.id));
+      const unauthorized = publisherWide
+        ? []
+        : properties
+            .filter(p => !p.id || !matchedIds.has(p.id))
+            .map(p => ({ id: p.property_id, name: p.name, type: p.property_type }));
+
+      return res.json({
+        publisher_domain: domain,
+        agent_url: agentUrl,
+        authorized,
+        total,
+        publisher_wide: publisherWide,
+        source: auth.source,
+        authorized_for: auth.authorized_for,
+        unauthorized_properties: unauthorized,
+      });
+    } catch (error) {
+      logger.error({ err: error, path: req.path }, "Publisher authorization lookup failed");
+      return res.status(500).json({ error: "Publisher authorization lookup failed" });
     }
   });
 

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -710,7 +710,16 @@ registry.registerPath({
     "**This endpoint is unauthenticated and returns the same response shape for every caller.** " +
     "Compare to `/api/registry/operator`, where AAO membership tier and profile ownership unlock " +
     "additional agent visibility (`members_only`, `private`). AAO membership does not change the " +
-    "`/publisher` response today.",
+    "`/publisher` response today.\n\n" +
+    "**Property source precedence:** authoritative adagents.json properties win over crawler-discovered " +
+    "rows; both win over brand.json hydration. Each property carries a `source` field (`adagents_json` / " +
+    "`discovered` / `brand_json`).\n\n" +
+    "**Per-agent rollup:** each entry in `authorized_agents` may carry `properties_authorized` + " +
+    "`properties_total` + `publisher_wide`. The rollup is suppressed (fields absent) when (a) properties " +
+    "are entirely brand.json-hydrated — no adagents.json claim has been made — or (b) the publisher has " +
+    "more than 50 authorized agents (above-cap entries are returned without rollup; `rollup_truncated` " +
+    "is set with `{ cap, total_agents }`). Use `/api/registry/publisher/authorization?domain=X&agent=Y` " +
+    "for the per-agent count when the index rollup is absent.",
   tags: ["Authorization Lookups"],
   request: {
     query: z.object({
@@ -5639,13 +5648,21 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         ? { slug: profile.slug, display_name: profile.display_name }
         : null;
 
-      // Hosting state. `aao_hosted` only when a public hosted-property row
-      // exists for this domain (i.e. the publisher opted into AAO serving
-      // their adagents.json). `self` when the publisher has a valid live
-      // adagents.json. Otherwise `none`.
+      // Hosting state. `aao_hosted` when a public hosted-property row
+      // exists for this domain (publisher hosts a stub at their own
+      // /.well-known whose `authoritative_location` points at AAO's
+      // canonical document). `self` when the publisher's own /.well-known
+      // returned a valid adagents.json. `self_invalid` when the publisher
+      // has /.well-known but it failed validation — distinct from `none`
+      // because it's a fixable misconfiguration rather than absence.
       const aaoHosted = !!(hostedProperty && hostedProperty.is_public);
       const hosting = {
-        mode: (aaoHosted ? "aao_hosted" : adagentsValid === true ? "self" : "none") as "self" | "aao_hosted" | "none",
+        mode: (
+          aaoHosted ? "aao_hosted"
+          : adagentsValid === true ? "self"
+          : adagentsValid === false ? "self_invalid"
+          : "none"
+        ) as "self" | "self_invalid" | "aao_hosted" | "none",
         hosted_url: aaoHosted ? aaoHostedAdagentsJsonUrl(domain) : undefined,
         expected_url: expectedAdagentsJsonUrl(domain),
       };
@@ -5682,34 +5699,40 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       }
 
       // Per-agent property authorization rollup. For each authorized agent
-      // we expose `properties_authorized: M of properties_total: N` so a
-      // caller (UI, downstream service) can render "X of Y authorized" without
-      // re-walking the property graph itself. Property-level rows present →
-      // intersection count. None present → publisher-wide authorization →
-      // count equals total. Brand.json-hydrated properties are not in the
-      // federated index yet, so per-agent counts collapse to total in that
-      // path — matches the semantic that hydrated properties are "best known"
-      // rather than authoritatively scoped per agent.
+      // we expose `properties_authorized` + `properties_total` + a
+      // `publisher_wide` flag so a caller can tell whether the count came
+      // from real property-level rows (intersection) or was synthesized
+      // from a publisher-wide authorization (= total). Without
+      // `publisher_wide`, "12 of 12" is ambiguous between "this agent has
+      // 12 property rows" and "publisher-wide, count synthesized."
       //
-      // Cap the fan-out: each agent triggers a non-trivial DB query and the
-      // endpoint is unauthenticated. A pathological hosted document with
-      // hundreds of authorized agents would otherwise turn a single anonymous
-      // request into hundreds of queries. Above the cap, return the agents
-      // without the rollup and a `truncated` flag so callers can hit
-      // `/api/registry/publisher/authorization` for individual checks.
+      // Suppress the rollup entirely when all projected properties came
+      // from brand.json hydration — those are "we know this publisher
+      // owns these properties" facts, not authorization claims. Reporting
+      // "publisher-wide → N of N" would over-claim that the agent is
+      // authorized for properties no adagents.json has actually scoped to.
+      //
+      // Cap the fan-out: each agent triggers a non-trivial DB query and
+      // the endpoint is unauthenticated. Pathological hosted docs with
+      // hundreds of agents would otherwise turn a single anonymous
+      // request into hundreds of queries. Above the cap, agents are
+      // returned without rollup fields and `rollup_truncated` exposes
+      // the cap + total so callers can decide whether to fan out
+      // individual calls to /api/registry/publisher/authorization.
       const PER_AGENT_ROLLUP_CAP = 50;
       const propertiesTotal = projectedProperties.length;
-      // `id` in the projection is the adagents.json slug; the federated
-      // index also exposes a stable database id on the source rows. Match on
-      // the database id to avoid false negatives when slugs collide or
-      // properties were discovered without an explicit slug.
+      const allBrandJsonHydrated =
+        propertiesTotal > 0 && projectedProperties.every(p => p.source === "brand_json");
+      const skipRollup = allBrandJsonHydrated;
       const propertyDbIdSet = new Set(
         properties.map(p => p.id).filter((id): id is string => Boolean(id)),
       );
-      const rollupTruncated = authorizations.length > PER_AGENT_ROLLUP_CAP;
-      const agentsToRollup = rollupTruncated
-        ? authorizations.slice(0, PER_AGENT_ROLLUP_CAP)
-        : authorizations;
+      const rollupTruncatedLen = authorizations.length > PER_AGENT_ROLLUP_CAP;
+      const agentsToRollup = skipRollup
+        ? []
+        : rollupTruncatedLen
+          ? authorizations.slice(0, PER_AGENT_ROLLUP_CAP)
+          : authorizations;
       const agentPropertyCounts = new Map<string, number>();
       await Promise.all(
         agentsToRollup.map(async a => {
@@ -5728,6 +5751,13 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         hosting,
         properties: projectedProperties,
         authorized_agents: authorizations.map(a => {
+          if (skipRollup) {
+            return {
+              url: a.agent_url,
+              authorized_for: a.authorized_for,
+              source: a.source,
+            };
+          }
           const matched = agentPropertyCounts.get(a.agent_url);
           if (matched === undefined) {
             // Truncated: rollup not computed for this agent.
@@ -5738,16 +5768,20 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
             };
           }
           // No property-level rows → publisher-wide → authorized for all.
-          const authorized = matched > 0 ? matched : propertiesTotal;
+          const publisherWide = matched === 0;
+          const authorized = publisherWide ? propertiesTotal : matched;
           return {
             url: a.agent_url,
             authorized_for: a.authorized_for,
             source: a.source,
             properties_authorized: authorized,
             properties_total: propertiesTotal,
+            publisher_wide: publisherWide,
           };
         }),
-        rollup_truncated: rollupTruncated || undefined,
+        rollup_truncated: rollupTruncatedLen
+          ? { cap: PER_AGENT_ROLLUP_CAP, total_agents: authorizations.length }
+          : undefined,
       });
     } catch (error) {
       logger.error({ err: error, path: req.path }, "Publisher lookup failed");

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -577,23 +577,27 @@ const PublisherAuthorizedAgentSchema = z.object({
   source: z.enum(["adagents_json", "agent_claim"]),
   properties_authorized: z.number().int().nonnegative().optional().openapi({
     description:
-      "Count of this publisher's properties the agent is authorized to sell. When property-level authorizations exist, this is the intersection; otherwise it equals `properties_total` (publisher-wide authorization).",
+      "Count of this publisher's properties the agent is authorized to sell. Absent when `rollup_truncated` is set (call `/api/registry/publisher/authorization` for the per-agent count) or when properties are entirely brand.json-hydrated (no adagents.json claim has actually been made about them).",
   }),
   properties_total: z.number().int().nonnegative().optional().openapi({
-    description: "Total number of properties this publisher exposes through the registry. Same value across all agents in the response.",
+    description: "Total number of properties this publisher exposes through the registry. Same value across all agents in the response. Absent when `properties_authorized` is absent.",
+  }),
+  publisher_wide: z.boolean().optional().openapi({
+    description:
+      "True when the agent has only a publisher-wide authorization row and `properties_authorized` was synthesized as `properties_total`. False when the agent has property-level authorization rows. Absent when the rollup is absent.",
   }),
 });
 
 const PublisherHostingSchema = z.object({
-  mode: z.enum(["self", "aao_hosted", "none"]).openapi({
+  mode: z.enum(["self", "self_invalid", "aao_hosted", "none"]).openapi({
     description:
-      "Where this publisher's adagents.json lives. `self` = publisher hosts at their own /.well-known. `aao_hosted` = AAO serves the canonical document. `none` = no adagents.json configured yet.",
+      "Where this publisher's adagents.json lives. `self` = publisher hosts a valid file at their own /.well-known. `self_invalid` = publisher's /.well-known returns a file that fails validation (fixable misconfiguration, not absence). `aao_hosted` = the publisher hosts a stub at their own /.well-known whose `authoritative_location` points at AAO's canonical document. `none` = no adagents.json configured yet.",
   }),
   hosted_url: z.string().optional().openapi({
-    description: "Canonical AAO-hosted adagents.json URL when mode is `aao_hosted`.",
+    description: "Canonical AAO-hosted adagents.json URL. Present iff `mode === 'aao_hosted'`. Publishers reference this URL from their own /.well-known stub via the `authoritative_location` field (see https://docs.adcontextprotocol.org/docs/governance/property/adagents).",
   }),
   expected_url: z.string().openapi({
-    description: "Where adagents.json *should* live for this domain — the publisher's own /.well-known path.",
+    description: "Where adagents.json *should* live for this domain — the publisher's own /.well-known path. Always populated, regardless of `mode`.",
   }),
 });
 
@@ -605,9 +609,12 @@ export const PublisherLookupResultSchema = z
     hosting: PublisherHostingSchema,
     properties: z.array(PublisherPropertySchema),
     authorized_agents: z.array(PublisherAuthorizedAgentSchema),
-    rollup_truncated: z.boolean().optional().openapi({
+    rollup_truncated: z.object({
+      cap: z.number().int().positive().openapi({ description: "Maximum number of agents for which the rollup is computed in a single response." }),
+      total_agents: z.number().int().nonnegative().openapi({ description: "Total authorized-agent count for this publisher (the full population the cap was applied to)." }),
+    }).optional().openapi({
       description:
-        "Set to `true` when the publisher has more authorized agents than the per-agent rollup cap. Above the cap, agents are returned without `properties_authorized` / `properties_total`; call `/api/registry/publisher/authorization?domain=X&agent=Y` for the per-agent count.",
+        "Set when the publisher has more authorized agents than the per-agent rollup cap. Above the cap, agents beyond `cap` are returned without `properties_authorized` / `properties_total` / `publisher_wide`; call `/api/registry/publisher/authorization?domain=X&agent=Y` for the per-agent count. Lets a caller decide whether to fan out individual calls or stop reading.",
     }),
   })
   .openapi("PublisherLookupResult");

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -574,7 +574,10 @@ const PublisherPropertySchema = z.object({
 const PublisherAuthorizedAgentSchema = z.object({
   url: z.string(),
   authorized_for: z.string().optional(),
-  source: z.enum(["adagents_json", "agent_claim"]),
+  source: z.enum(["adagents_json", "aao_hosted", "agent_claim"]).openapi({
+    description:
+      "How strongly this authorization is attested. `adagents_json`: the publisher's origin actually serves a valid adagents.json (origin-verified). `aao_hosted`: AAO is hosting the canonical document on the publisher's behalf — represents publisher intent but origin has NOT been verified to redirect to AAO. `agent_claim`: the agent claimed it; publisher has not confirmed.",
+  }),
   properties_authorized: z.number().int().nonnegative().optional().openapi({
     description:
       "Count of this publisher's properties the agent is authorized to sell. Absent when `rollup_truncated` is set (call `/api/registry/publisher/authorization` for the per-agent count) or when properties are entirely brand.json-hydrated (no adagents.json claim has actually been made about them).",

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -565,12 +565,36 @@ const PublisherPropertySchema = z.object({
   name: z.string().optional(),
   identifiers: z.array(PropertyIdentifierSchema).optional(),
   tags: z.array(z.string()).optional(),
+  source: z.enum(["adagents_json", "discovered", "brand_json"]).optional().openapi({
+    description:
+      "Where this property came from. `adagents_json`/`discovered` come from the federated index (publisher's own adagents.json or crawler discovery). `brand_json` is hydrated from the publisher's brand.json when no federated-index data exists yet.",
+  }),
 });
 
 const PublisherAuthorizedAgentSchema = z.object({
   url: z.string(),
   authorized_for: z.string().optional(),
   source: z.enum(["adagents_json", "agent_claim"]),
+  properties_authorized: z.number().int().nonnegative().optional().openapi({
+    description:
+      "Count of this publisher's properties the agent is authorized to sell. When property-level authorizations exist, this is the intersection; otherwise it equals `properties_total` (publisher-wide authorization).",
+  }),
+  properties_total: z.number().int().nonnegative().optional().openapi({
+    description: "Total number of properties this publisher exposes through the registry. Same value across all agents in the response.",
+  }),
+});
+
+const PublisherHostingSchema = z.object({
+  mode: z.enum(["self", "aao_hosted", "none"]).openapi({
+    description:
+      "Where this publisher's adagents.json lives. `self` = publisher hosts at their own /.well-known. `aao_hosted` = AAO serves the canonical document. `none` = no adagents.json configured yet.",
+  }),
+  hosted_url: z.string().optional().openapi({
+    description: "Canonical AAO-hosted adagents.json URL when mode is `aao_hosted`.",
+  }),
+  expected_url: z.string().openapi({
+    description: "Where adagents.json *should* live for this domain — the publisher's own /.well-known path.",
+  }),
 });
 
 export const PublisherLookupResultSchema = z
@@ -578,8 +602,13 @@ export const PublisherLookupResultSchema = z
     domain: z.string().openapi({ example: "voxmedia.com" }),
     member: MemberRefSchema.nullable(),
     adagents_valid: z.boolean().nullable(),
+    hosting: PublisherHostingSchema,
     properties: z.array(PublisherPropertySchema),
     authorized_agents: z.array(PublisherAuthorizedAgentSchema),
+    rollup_truncated: z.boolean().optional().openapi({
+      description:
+        "Set to `true` when the publisher has more authorized agents than the per-agent rollup cap. Above the cap, agents are returned without `properties_authorized` / `properties_total`; call `/api/registry/publisher/authorization?domain=X&agent=Y` for the per-agent count.",
+    }),
   })
   .openapi("PublisherLookupResult");
 

--- a/server/src/services/brand-json-properties.ts
+++ b/server/src/services/brand-json-properties.ts
@@ -1,0 +1,100 @@
+/**
+ * Extract publisher-shaped properties from a brand.json manifest.
+ *
+ * brand.json may carry properties in two shapes:
+ *   - top-level `properties[]` (single-brand manifest, written by the
+ *     parse_brand_properties / import_brand_properties tools)
+ *   - `brands[].properties[]` (multi-brand house manifest, walked by the
+ *     network-consistency reporter)
+ *
+ * Both are accepted. Each property has `{ identifier, type?, relationship? }`.
+ * The result is shaped to match `PublisherPropertySchema` so callers of
+ * `/api/registry/publisher` see a consistent payload regardless of source.
+ */
+export interface PublisherPropertyFromBrandJson {
+  type: string;
+  name: string;
+  identifiers: Array<{ type: string; value: string }>;
+  tags: string[];
+  source: "brand_json";
+}
+
+interface RawBrandJsonProperty {
+  identifier?: unknown;
+  type?: unknown;
+  relationship?: unknown;
+}
+
+function readPropertyArray(value: unknown): RawBrandJsonProperty[] {
+  return Array.isArray(value) ? (value as RawBrandJsonProperty[]) : [];
+}
+
+/**
+ * Hard cap on the number of brand.json properties we'll walk per request.
+ * Brand.json is publisher- or community-controlled and has no inherent
+ * size limit — a house manifest with thousands of `brands[].properties[]`
+ * entries would otherwise stall the publisher endpoint. Excess entries
+ * are silently dropped after the cap; deduping happens before the cap, so
+ * the result is the first N unique identifiers in document order.
+ */
+const MAX_BRAND_JSON_PROPERTIES = 5000;
+
+/**
+ * Inferred identifier shape for a property type. brand.json's `identifier`
+ * field is a single string; we map it to the structured identifier shape
+ * the registry uses. For non-website types we don't know the canonical
+ * identifier kind (ios_bundle vs android_package vs roku_app_id, etc.),
+ * so we fall back to a generic `{type: <propType>, value: id}` pair so
+ * the value is preserved rather than dropped.
+ */
+function deriveIdentifiers(propType: string, id: string): Array<{ type: string; value: string }> {
+  if (propType === "website") return [{ type: "domain", value: id }];
+  return [{ type: propType, value: id }];
+}
+
+export function extractPublisherPropertiesFromBrandJson(
+  manifest: Record<string, unknown> | null | undefined,
+): PublisherPropertyFromBrandJson[] {
+  if (!manifest || typeof manifest !== "object") return [];
+
+  const seen = new Map<string, PublisherPropertyFromBrandJson>();
+
+  function ingest(p: RawBrandJsonProperty): boolean {
+    if (typeof p.identifier !== "string" || !p.identifier) return false;
+    const id = p.identifier.toLowerCase();
+    if (seen.has(id)) return false;
+
+    const propType = typeof p.type === "string" && p.type ? p.type : "website";
+    const relationship = typeof p.relationship === "string" ? p.relationship : undefined;
+
+    const tags: string[] = [];
+    if (relationship) tags.push(`relationship:${relationship}`);
+
+    seen.set(id, {
+      type: propType,
+      name: id,
+      identifiers: deriveIdentifiers(propType, id),
+      tags,
+      source: "brand_json",
+    });
+    return true;
+  }
+
+  // Walk top-level shape first, then house shape. Stop the moment we hit
+  // the cap so a maliciously oversized manifest can't burn CPU.
+  for (const p of readPropertyArray(manifest.properties)) {
+    if (seen.size >= MAX_BRAND_JSON_PROPERTIES) return Array.from(seen.values());
+    ingest(p);
+  }
+
+  const brands = Array.isArray(manifest.brands) ? manifest.brands : [];
+  for (const b of brands) {
+    if (!b || typeof b !== "object") continue;
+    for (const p of readPropertyArray((b as Record<string, unknown>).properties)) {
+      if (seen.size >= MAX_BRAND_JSON_PROPERTIES) return Array.from(seen.values());
+      ingest(p);
+    }
+  }
+
+  return Array.from(seen.values());
+}

--- a/server/src/services/hosted-property-sync.ts
+++ b/server/src/services/hosted-property-sync.ts
@@ -1,0 +1,183 @@
+/**
+ * Hosted-property → federated-index sync.
+ *
+ * `hosted_properties` is the authoritative table for publishers who let AAO
+ * serve their adagents.json. The federated index (`discovered_properties`,
+ * `discovered_agents`, `agent_publisher_authorizations`) is otherwise
+ * populated by the crawler walking external `/.well-known/adagents.json`
+ * files. Without this sync, AAO-hosted publishers would never appear in the
+ * agent authorization graph that powers `/api/registry/publisher` and the
+ * downstream lookups.
+ *
+ * Reconciliation semantics:
+ *  - Authorizations: full reconcile. We own `source='adagents_json'` rows
+ *    for this publisher_domain — the hosted document IS the publisher's
+ *    adagents.json claim, so any row not in the new manifest is removed.
+ *  - Properties: additive only. `discovered_properties` has no source
+ *    column, so we cannot safely distinguish hosted-written rows from
+ *    crawler-written rows. Removed properties persist until manually
+ *    cleared. Tracked as a follow-up — adding a `source` column to
+ *    `discovered_properties` would let us reconcile here too.
+ *  - Publisher row: keyed by stable sentinel (`AAO_HOSTED_SENTINEL`) so
+ *    re-syncs collapse to the same row regardless of which agent is first
+ *    in the manifest.
+ *
+ * Returns counts + a per-row failure count. Throws if everything failed —
+ * partial success is logged but does not bubble up, so callers see a
+ * structured result rather than a half-completed write that swallowed
+ * errors silently.
+ */
+import type { HostedProperty } from '../types.js';
+import { FederatedIndexDatabase } from '../db/federated-index-db.js';
+import { query } from '../db/client.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('hosted-property-sync');
+
+/** Stable `discovered_by_agent` value for AAO-hosted publisher rows. */
+export const AAO_HOSTED_SENTINEL = 'aao://hosted';
+
+export interface HostedSyncResult {
+  properties_synced: number;
+  agents_synced: number;
+  authorizations_reconciled: number;
+  authorizations_removed: number;
+  publisher_synced: boolean;
+  errors: number;
+}
+
+interface AdagentsAgent {
+  url?: unknown;
+  authorized_for?: unknown;
+}
+
+interface AdagentsProperty {
+  property_id?: unknown;
+  type?: unknown;
+  name?: unknown;
+  identifiers?: unknown;
+  tags?: unknown;
+}
+
+function readAgents(adagents: Record<string, unknown>): AdagentsAgent[] {
+  return Array.isArray(adagents.authorized_agents)
+    ? (adagents.authorized_agents as AdagentsAgent[])
+    : [];
+}
+
+function readProperties(adagents: Record<string, unknown>): AdagentsProperty[] {
+  return Array.isArray(adagents.properties)
+    ? (adagents.properties as AdagentsProperty[])
+    : [];
+}
+
+export async function syncHostedPropertyToFederatedIndex(
+  hosted: HostedProperty,
+  fedDb: FederatedIndexDatabase = new FederatedIndexDatabase(),
+): Promise<HostedSyncResult> {
+  const result: HostedSyncResult = {
+    properties_synced: 0,
+    agents_synced: 0,
+    authorizations_reconciled: 0,
+    authorizations_removed: 0,
+    publisher_synced: false,
+    errors: 0,
+  };
+  if (!hosted.is_public) return result;
+  const adagents = hosted.adagents_json || {};
+  const domain = hosted.publisher_domain.toLowerCase();
+  const agents = readAgents(adagents);
+  const properties = readProperties(adagents);
+
+  // Properties: additive upsert (see file-level comment for why removal
+  // is not yet supported).
+  for (const p of properties) {
+    if (typeof p.name !== 'string' || !p.name) continue;
+    const propType = typeof p.type === 'string' && p.type ? p.type : 'website';
+    try {
+      await fedDb.upsertProperty({
+        property_id: typeof p.property_id === 'string' ? p.property_id : undefined,
+        publisher_domain: domain,
+        property_type: propType,
+        name: p.name,
+        identifiers: Array.isArray(p.identifiers)
+          ? (p.identifiers as Array<{ type: string; value: string }>)
+          : [],
+        tags: Array.isArray(p.tags) ? (p.tags as string[]) : [],
+      });
+      result.properties_synced++;
+    } catch (err) {
+      result.errors++;
+      logger.warn({ err, domain, name: p.name }, 'Failed to upsert hosted property row');
+    }
+  }
+
+  // Agents: upsert each, then reconcile authorizations.
+  const validAgentUrls: string[] = [];
+  for (const a of agents) {
+    if (typeof a.url !== 'string' || !a.url) continue;
+    const agentUrl = a.url;
+    validAgentUrls.push(agentUrl);
+    try {
+      await fedDb.upsertAgent({
+        agent_url: agentUrl,
+        source_type: 'adagents_json',
+        source_domain: domain,
+      });
+      result.agents_synced++;
+      await fedDb.upsertAuthorization({
+        agent_url: agentUrl,
+        publisher_domain: domain,
+        authorized_for: typeof a.authorized_for === 'string' ? a.authorized_for : undefined,
+        source: 'adagents_json',
+      });
+      result.authorizations_reconciled++;
+    } catch (err) {
+      result.errors++;
+      logger.warn({ err, domain, agentUrl }, 'Failed to upsert hosted authorization row');
+    }
+  }
+
+  // Reconcile: delete any (publisher_domain, source='adagents_json') rows
+  // not in the current manifest. Hosted is authoritative for this source
+  // label, so stale crawler rows for the same source are also cleaned up.
+  try {
+    const removeResult = validAgentUrls.length > 0
+      ? await query(
+          `DELETE FROM agent_publisher_authorizations
+            WHERE publisher_domain = $1
+              AND source = 'adagents_json'
+              AND agent_url <> ALL($2::text[])`,
+          [domain, validAgentUrls],
+        )
+      : await query(
+          `DELETE FROM agent_publisher_authorizations
+            WHERE publisher_domain = $1 AND source = 'adagents_json'`,
+          [domain],
+        );
+    result.authorizations_removed = removeResult.rowCount ?? 0;
+  } catch (err) {
+    result.errors++;
+    logger.warn({ err, domain }, 'Failed to reconcile hosted authorizations');
+  }
+
+  // Publisher row, keyed on the stable sentinel — survives agent-list
+  // reordering and missing-agent edge cases without leaking duplicate rows.
+  try {
+    await fedDb.upsertPublisher({
+      domain,
+      discovered_by_agent: AAO_HOSTED_SENTINEL,
+      has_valid_adagents: true,
+    });
+    result.publisher_synced = true;
+  } catch (err) {
+    result.errors++;
+    logger.warn({ err, domain }, 'Failed to upsert hosted publisher row');
+  }
+
+  if (result.errors > 0 && result.properties_synced === 0 && result.agents_synced === 0) {
+    throw new Error(`Hosted property sync failed for ${domain}: ${result.errors} errors`);
+  }
+
+  return result;
+}

--- a/server/src/services/hosted-property-sync.ts
+++ b/server/src/services/hosted-property-sync.ts
@@ -9,10 +9,20 @@
  * agent authorization graph that powers `/api/registry/publisher` and the
  * downstream lookups.
  *
+ * Trust-label semantics:
+ *  - Sync writes `source='aao_hosted'` rows, NOT `source='adagents_json'`.
+ *    `adagents_json` is reserved for rows where the publisher's origin
+ *    actually serves the document (crawler-verified, including following
+ *    `authoritative_location` stubs). Until origin verification happens,
+ *    AAO-hosted authorization is the publisher's stated intent — not
+ *    an origin-attested claim. Mixing the two labels would over-claim
+ *    on the agent's behalf.
+ *
  * Reconciliation semantics:
- *  - Authorizations: full reconcile. We own `source='adagents_json'` rows
- *    for this publisher_domain — the hosted document IS the publisher's
- *    adagents.json claim, so any row not in the new manifest is removed.
+ *  - Authorizations: full reconcile, scoped to `source='aao_hosted'` for
+ *    this publisher_domain. We own that source label exclusively;
+ *    crawler-written `adagents_json` rows for the same domain are left
+ *    untouched (they represent verified origin facts).
  *  - Properties: additive only. `discovered_properties` has no source
  *    column, so we cannot safely distinguish hosted-written rows from
  *    crawler-written rows. Removed properties persist until manually
@@ -129,7 +139,10 @@ export async function syncHostedPropertyToFederatedIndex(
         agent_url: agentUrl,
         publisher_domain: domain,
         authorized_for: typeof a.authorized_for === 'string' ? a.authorized_for : undefined,
-        source: 'adagents_json',
+        // `aao_hosted` rather than `adagents_json` — the publisher's
+        // origin has not been verified yet. Promotion to the stronger
+        // label is an explicit verification step (future work).
+        source: 'aao_hosted',
       });
       result.authorizations_reconciled++;
     } catch (err) {
@@ -138,21 +151,22 @@ export async function syncHostedPropertyToFederatedIndex(
     }
   }
 
-  // Reconcile: delete any (publisher_domain, source='adagents_json') rows
-  // not in the current manifest. Hosted is authoritative for this source
-  // label, so stale crawler rows for the same source are also cleaned up.
+  // Reconcile: delete any (publisher_domain, source='aao_hosted') rows
+  // not in the current manifest. Scoped to `aao_hosted` only — we don't
+  // touch crawler-written `adagents_json` rows or `agent_claim` rows,
+  // both of which represent attestations we don't own.
   try {
     const removeResult = validAgentUrls.length > 0
       ? await query(
           `DELETE FROM agent_publisher_authorizations
             WHERE publisher_domain = $1
-              AND source = 'adagents_json'
+              AND source = 'aao_hosted'
               AND agent_url <> ALL($2::text[])`,
           [domain, validAgentUrls],
         )
       : await query(
           `DELETE FROM agent_publisher_authorizations
-            WHERE publisher_domain = $1 AND source = 'adagents_json'`,
+            WHERE publisher_domain = $1 AND source = 'aao_hosted'`,
           [domain],
         );
     result.authorizations_removed = removeResult.rowCount ?? 0;
@@ -163,11 +177,14 @@ export async function syncHostedPropertyToFederatedIndex(
 
   // Publisher row, keyed on the stable sentinel — survives agent-list
   // reordering and missing-agent edge cases without leaking duplicate rows.
+  // We deliberately do NOT set has_valid_adagents=true here — that flag
+  // means the publisher's origin actually serves a valid document, which
+  // hosted-on-AAO does not establish until origin verification happens.
+  // The crawler is the only writer that should flip has_valid_adagents.
   try {
     await fedDb.upsertPublisher({
       domain,
       discovered_by_agent: AAO_HOSTED_SENTINEL,
-      has_valid_adagents: true,
     });
     result.publisher_synced = true;
   } catch (err) {

--- a/server/tests/integration/hosted-property-fed-index-sync.test.ts
+++ b/server/tests/integration/hosted-property-fed-index-sync.test.ts
@@ -150,11 +150,11 @@ describe('Hosted property → federated index sync', () => {
     expect(agentsByUrl.get(AGENT_X)).toMatchObject({
       url: AGENT_X,
       authorized_for: 'all',
-      source: 'adagents_json',
+      source: 'aao_hosted',
     });
     expect(agentsByUrl.get(AGENT_Y)).toMatchObject({
       url: AGENT_Y,
-      source: 'adagents_json',
+      source: 'aao_hosted',
     });
   });
 

--- a/server/tests/integration/hosted-property-fed-index-sync.test.ts
+++ b/server/tests/integration/hosted-property-fed-index-sync.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Integration coverage for hosted-property → federated-index propagation.
+ *
+ * When a publisher opts into AAO hosting (a public hosted_properties row),
+ * the agents and properties declared in `adagents_json` must show up in
+ * `/api/registry/publisher` for that domain. Without this propagation,
+ * AAO-hosted publishers appear with 0 agents in discovery — even though
+ * the canonical adagents.json document AAO is serving says otherwise.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import type { Pool } from 'pg';
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'test';
+  process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+});
+
+vi.mock('../../src/middleware/auth.js', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>(
+    '../../src/middleware/auth.js'
+  );
+  const pass = (req: { user: unknown }, _res: unknown, next: () => void) => {
+    req.user = { id: 'user_test_hosted_sync', email: 'hosted-sync@test.com' };
+    next();
+  };
+  return {
+    ...actual,
+    requireAuth: pass,
+    requireAdmin: (_req: unknown, _res: unknown, next: () => void) => next(),
+  };
+});
+
+vi.mock('../../src/middleware/csrf.js', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>(
+    '../../src/middleware/csrf.js'
+  );
+  return {
+    ...actual,
+    csrfProtection: (_req: unknown, _res: unknown, next: () => void) => next(),
+  };
+});
+
+vi.mock('../../src/billing/stripe-client.js', () => ({
+  stripe: null,
+  getSubscriptionInfo: vi.fn().mockResolvedValue(null),
+  createStripeCustomer: vi.fn().mockResolvedValue(null),
+  createCustomerSession: vi.fn().mockResolvedValue(null),
+  createBillingPortalSession: vi.fn().mockResolvedValue(null),
+}));
+
+import { HTTPServer } from '../../src/http.js';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { PropertyDatabase } from '../../src/db/property-db.js';
+import { syncHostedPropertyToFederatedIndex } from '../../src/services/hosted-property-sync.js';
+
+const PUB = 'devraj-sync.registry-baseline.example';
+const AGENT_X = 'https://agent-x-sync.registry-baseline.example';
+const AGENT_Y = 'https://agent-y-sync.registry-baseline.example';
+const DOMAIN_LIKE = 'devraj-sync.%';
+const AGENT_LIKE_X = 'https://agent-%-sync.registry-baseline.example';
+
+describe('Hosted property → federated index sync', () => {
+  let server: HTTPServer;
+  let app: unknown;
+  let pool: Pool;
+  let propertyDb: PropertyDatabase;
+
+  async function clearFixtures() {
+    await pool.query(
+      `DELETE FROM agent_publisher_authorizations WHERE publisher_domain LIKE $1 OR agent_url LIKE $2`,
+      [DOMAIN_LIKE, AGENT_LIKE_X]
+    );
+    await pool.query('DELETE FROM discovered_properties WHERE publisher_domain LIKE $1', [DOMAIN_LIKE]);
+    await pool.query('DELETE FROM discovered_agents WHERE agent_url LIKE $1', [AGENT_LIKE_X]);
+    await pool.query('DELETE FROM discovered_publishers WHERE domain LIKE $1', [DOMAIN_LIKE]);
+    await pool.query('DELETE FROM hosted_properties WHERE publisher_domain LIKE $1', [DOMAIN_LIKE]);
+  }
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString:
+        process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+    propertyDb = new PropertyDatabase();
+    server = new HTTPServer();
+    await server.start(0);
+    app = (server as unknown as { app: unknown }).app;
+  });
+
+  afterAll(async () => {
+    await clearFixtures();
+    await server?.stop();
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await clearFixtures();
+  });
+
+  it('propagates a public hosted property into the federated index', async () => {
+    const adagents = {
+      authorized_agents: [
+        { url: AGENT_X, authorized_for: 'all' },
+        { url: AGENT_Y },
+      ],
+      properties: [
+        {
+          property_id: 'home',
+          type: 'website',
+          name: PUB,
+          identifiers: [{ type: 'domain', value: PUB }],
+          tags: ['flagship'],
+        },
+        {
+          property_id: 'mobile',
+          type: 'mobile_app',
+          name: `${PUB} app`,
+          identifiers: [{ type: 'ios_bundle', value: 'com.devraj.app' }],
+        },
+      ],
+    };
+
+    const hosted = await propertyDb.createHostedProperty({
+      publisher_domain: PUB,
+      adagents_json: adagents,
+      is_public: true,
+      source_type: 'community',
+    });
+    await syncHostedPropertyToFederatedIndex(hosted);
+
+    const res = await request(app).get(
+      `/api/registry/publisher?domain=${encodeURIComponent(PUB)}`
+    );
+    expect(res.status).toBe(200);
+
+    const propsByName = new Map<string, { type: string }>(
+      res.body.properties.map((p: { name: string }) => [p.name, p])
+    );
+    expect(propsByName.size).toBe(2);
+    expect(propsByName.get(PUB)?.type).toBe('website');
+    expect(propsByName.get(`${PUB} app`)?.type).toBe('mobile_app');
+
+    const agentsByUrl = new Map(
+      res.body.authorized_agents.map((a: { url: string }) => [a.url, a])
+    );
+    expect(agentsByUrl.size).toBe(2);
+    expect(agentsByUrl.get(AGENT_X)).toMatchObject({
+      url: AGENT_X,
+      authorized_for: 'all',
+      source: 'adagents_json',
+    });
+    expect(agentsByUrl.get(AGENT_Y)).toMatchObject({
+      url: AGENT_Y,
+      source: 'adagents_json',
+    });
+  });
+
+  it('does not propagate when is_public is false', async () => {
+    const hosted = await propertyDb.createHostedProperty({
+      publisher_domain: PUB,
+      adagents_json: {
+        authorized_agents: [{ url: AGENT_X }],
+        properties: [{ type: 'website', name: PUB }],
+      },
+      is_public: false,
+      source_type: 'community',
+    });
+    await syncHostedPropertyToFederatedIndex(hosted);
+
+    const res = await request(app).get(
+      `/api/registry/publisher?domain=${encodeURIComponent(PUB)}`
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.properties).toEqual([]);
+    expect(res.body.authorized_agents).toEqual([]);
+  });
+
+  it('reconciles authorizations on re-sync: agents removed from the manifest are deleted', async () => {
+    const initial = await propertyDb.createHostedProperty({
+      publisher_domain: PUB,
+      adagents_json: {
+        authorized_agents: [
+          { url: AGENT_X, authorized_for: 'all' },
+          { url: AGENT_Y },
+        ],
+        properties: [{ type: 'website', name: PUB }],
+      },
+      is_public: true,
+      source_type: 'community',
+    });
+    await syncHostedPropertyToFederatedIndex(initial);
+
+    // Sanity: both agents present.
+    let res = await request(app).get(
+      `/api/registry/publisher?domain=${encodeURIComponent(PUB)}`
+    );
+    expect(res.body.authorized_agents).toHaveLength(2);
+
+    // Re-sync with only one agent — the other should be removed.
+    await pool.query(
+      `UPDATE hosted_properties
+          SET adagents_json = $2
+        WHERE publisher_domain = $1`,
+      [PUB, JSON.stringify({
+        authorized_agents: [{ url: AGENT_X, authorized_for: 'all' }],
+        properties: [{ type: 'website', name: PUB }],
+      })],
+    );
+    const updated = await propertyDb.getHostedPropertyByDomain(PUB);
+    if (!updated) throw new Error('expected hosted property to exist');
+    const result = await syncHostedPropertyToFederatedIndex(updated);
+    expect(result.authorizations_removed).toBe(1);
+
+    res = await request(app).get(
+      `/api/registry/publisher?domain=${encodeURIComponent(PUB)}`
+    );
+    expect(res.body.authorized_agents).toHaveLength(1);
+    expect(res.body.authorized_agents[0].url).toBe(AGENT_X);
+  });
+
+  it('skips entries without required fields without throwing', async () => {
+    const hosted = await propertyDb.createHostedProperty({
+      publisher_domain: PUB,
+      adagents_json: {
+        authorized_agents: [{ url: AGENT_X }, { authorized_for: 'malformed' }],
+        properties: [
+          { type: 'website', name: PUB },
+          { type: 'website' /* no name */ },
+        ],
+      },
+      is_public: true,
+      source_type: 'community',
+    });
+    await expect(syncHostedPropertyToFederatedIndex(hosted)).resolves.not.toThrow();
+
+    const res = await request(app).get(
+      `/api/registry/publisher?domain=${encodeURIComponent(PUB)}`
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.properties).toHaveLength(1);
+    expect(res.body.authorized_agents).toHaveLength(1);
+  });
+});

--- a/server/tests/integration/publisher-hosted-adagents-route.test.ts
+++ b/server/tests/integration/publisher-hosted-adagents-route.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Integration coverage for AAO-hosted /.well-known/adagents.json. A
+ * publisher who opts into AAO hosting can either paste a snippet at their
+ * own /.well-known path or point a CNAME / redirect at AAO's hosted URL.
+ * This route serves the canonical document for the latter case.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import type { Pool } from 'pg';
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'test';
+  process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+});
+
+vi.mock('../../src/middleware/auth.js', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>(
+    '../../src/middleware/auth.js'
+  );
+  const pass = (req: { user: unknown }, _res: unknown, next: () => void) => {
+    req.user = { id: 'user_test_hosted_adagents', email: 'hosted-adagents@test.com' };
+    next();
+  };
+  return {
+    ...actual,
+    requireAuth: pass,
+    requireAdmin: (_req: unknown, _res: unknown, next: () => void) => next(),
+  };
+});
+
+vi.mock('../../src/middleware/csrf.js', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>(
+    '../../src/middleware/csrf.js'
+  );
+  return {
+    ...actual,
+    csrfProtection: (_req: unknown, _res: unknown, next: () => void) => next(),
+  };
+});
+
+vi.mock('../../src/billing/stripe-client.js', () => ({
+  stripe: null,
+  getSubscriptionInfo: vi.fn().mockResolvedValue(null),
+  createStripeCustomer: vi.fn().mockResolvedValue(null),
+  createCustomerSession: vi.fn().mockResolvedValue(null),
+  createBillingPortalSession: vi.fn().mockResolvedValue(null),
+}));
+
+import { HTTPServer } from '../../src/http.js';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { PropertyDatabase } from '../../src/db/property-db.js';
+
+const PUB_PUBLIC = 'hosted-adagents-public.registry-baseline.example';
+const PUB_PRIVATE = 'hosted-adagents-private.registry-baseline.example';
+const DOMAIN_LIKE = 'hosted-adagents-%.registry-baseline.example';
+
+describe('AAO-hosted /publisher/{domain}/.well-known/adagents.json', () => {
+  let server: HTTPServer;
+  let app: unknown;
+  let pool: Pool;
+  let propertyDb: PropertyDatabase;
+
+  async function clearFixtures() {
+    await pool.query('DELETE FROM hosted_properties WHERE publisher_domain LIKE $1', [DOMAIN_LIKE]);
+  }
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString:
+        process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+    propertyDb = new PropertyDatabase();
+    server = new HTTPServer();
+    await server.start(0);
+    app = (server as unknown as { app: unknown }).app;
+  });
+
+  afterAll(async () => {
+    await clearFixtures();
+    await server?.stop();
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await clearFixtures();
+  });
+
+  it('serves the hosted adagents.json when is_public=true', async () => {
+    const adagents = {
+      authorized_agents: [{ url: 'https://agent.example.com', authorized_for: 'all' }],
+      properties: [{ type: 'website', name: PUB_PUBLIC }],
+      contact: { name: 'Ops', email: 'ops@example.com' },
+    };
+    await propertyDb.createHostedProperty({
+      publisher_domain: PUB_PUBLIC,
+      adagents_json: adagents,
+      is_public: true,
+      source_type: 'community',
+    });
+
+    const res = await request(app).get(
+      `/publisher/${encodeURIComponent(PUB_PUBLIC)}/.well-known/adagents.json`
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/^application\/json/);
+    expect(res.headers['access-control-allow-origin']).toBe('*');
+    expect(res.body).toEqual(adagents);
+  });
+
+  it('returns 404 when the hosted property exists but is_public=false', async () => {
+    await propertyDb.createHostedProperty({
+      publisher_domain: PUB_PRIVATE,
+      adagents_json: { authorized_agents: [], properties: [] },
+      is_public: false,
+      source_type: 'community',
+    });
+
+    const res = await request(app).get(
+      `/publisher/${encodeURIComponent(PUB_PRIVATE)}/.well-known/adagents.json`
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when no hosted property exists for the domain', async () => {
+    const res = await request(app).get(
+      `/publisher/${encodeURIComponent(PUB_PUBLIC)}/.well-known/adagents.json`
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 for syntactically invalid domain input', async () => {
+    const res = await request(app).get(
+      `/publisher/${encodeURIComponent('not a domain!')}/.well-known/adagents.json`
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/server/tests/integration/registry-publisher-brand-json-hydration.test.ts
+++ b/server/tests/integration/registry-publisher-brand-json-hydration.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Integration coverage for brand.json hydration on /api/registry/publisher.
+ *
+ * Scenario: a publisher domain has nothing in the federated index (no
+ * adagents.json crawl, no discovered properties), but a brand.json with
+ * a populated `properties[]` exists in the brands table. The endpoint
+ * must hydrate properties from brand.json and tag them `source=brand_json`
+ * so callers can tell where the data came from.
+ *
+ * Fixtures use a `brand-hydrate-` prefix on a `.registry-baseline.example`
+ * suffix so we don't collide with the sibling reader-baseline test.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import type { Pool } from 'pg';
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'test';
+  process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+});
+
+const TEST_USER_ID = 'user_test_registry_brand_hydrate';
+vi.mock('../../src/middleware/auth.js', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>(
+    '../../src/middleware/auth.js'
+  );
+  const pass = (req: { user: unknown }, _res: unknown, next: () => void) => {
+    req.user = { id: TEST_USER_ID, email: 'registry-brand-hydrate@test.com' };
+    next();
+  };
+  return {
+    ...actual,
+    requireAuth: pass,
+    requireAdmin: (_req: unknown, _res: unknown, next: () => void) => next(),
+  };
+});
+
+vi.mock('../../src/middleware/csrf.js', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>(
+    '../../src/middleware/csrf.js'
+  );
+  return {
+    ...actual,
+    csrfProtection: (_req: unknown, _res: unknown, next: () => void) => next(),
+  };
+});
+
+vi.mock('../../src/billing/stripe-client.js', () => ({
+  stripe: null,
+  getSubscriptionInfo: vi.fn().mockResolvedValue(null),
+  createStripeCustomer: vi.fn().mockResolvedValue(null),
+  createCustomerSession: vi.fn().mockResolvedValue(null),
+  createBillingPortalSession: vi.fn().mockResolvedValue(null),
+}));
+
+import { HTTPServer } from '../../src/http.js';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { BrandDatabase } from '../../src/db/brand-db.js';
+import { PropertyDatabase } from '../../src/db/property-db.js';
+
+const DOMAIN_SUFFIX = '.registry-baseline.example';
+const DOMAIN_PREFIX = 'brand-hydrate-';
+const PUB_BRAND_ONLY = `${DOMAIN_PREFIX}sasha${DOMAIN_SUFFIX}`;
+const PUB_AAO_HOSTED = `${DOMAIN_PREFIX}aao-hosted${DOMAIN_SUFFIX}`;
+
+describe('Registry publisher endpoint — brand.json hydration', () => {
+  let server: HTTPServer;
+  let app: unknown;
+  let pool: Pool;
+  let brandDb: BrandDatabase;
+  let propertyDb: PropertyDatabase;
+
+  const DOMAIN_LIKE = `${DOMAIN_PREFIX}%${DOMAIN_SUFFIX}`;
+
+  async function clearFixtures() {
+    await pool.query('DELETE FROM hosted_properties WHERE publisher_domain LIKE $1', [DOMAIN_LIKE]);
+    await pool.query('DELETE FROM brands WHERE domain LIKE $1', [DOMAIN_LIKE]);
+    await pool.query(
+      'DELETE FROM discovered_properties WHERE publisher_domain LIKE $1',
+      [DOMAIN_LIKE]
+    );
+  }
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString:
+        process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+    brandDb = new BrandDatabase();
+    propertyDb = new PropertyDatabase();
+    server = new HTTPServer();
+    await server.start(0);
+    app = (server as unknown as { app: unknown }).app;
+  });
+
+  afterAll(async () => {
+    await clearFixtures();
+    await server?.stop();
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await clearFixtures();
+  });
+
+  it('hydrates properties from brand.json when the federated index is empty', async () => {
+    await brandDb.upsertDiscoveredBrand({
+      domain: PUB_BRAND_ONLY,
+      brand_name: 'Sasha Media',
+      source_type: 'brand_json',
+      has_brand_manifest: true,
+      brand_manifest: {
+        name: 'Sasha Media',
+        properties: [
+          { identifier: PUB_BRAND_ONLY, type: 'website', relationship: 'owned' },
+          {
+            identifier: `news.${PUB_BRAND_ONLY}`,
+            type: 'website',
+            relationship: 'direct',
+          },
+        ],
+      },
+    });
+
+    const res = await request(app).get(
+      `/api/registry/publisher?domain=${encodeURIComponent(PUB_BRAND_ONLY)}`
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.domain).toBe(PUB_BRAND_ONLY);
+    expect(res.body.properties).toHaveLength(2);
+
+    const propsByName = new Map<string, { source: string; type: string; identifiers: unknown[] }>(
+      res.body.properties.map((p: { name: string }) => [p.name, p])
+    );
+    const root = propsByName.get(PUB_BRAND_ONLY);
+    expect(root).toBeDefined();
+    expect(root?.source).toBe('brand_json');
+    expect(root?.type).toBe('website');
+    expect(root?.identifiers).toEqual([{ type: 'domain', value: PUB_BRAND_ONLY }]);
+
+    const news = propsByName.get(`news.${PUB_BRAND_ONLY}`);
+    expect(news?.source).toBe('brand_json');
+  });
+
+  it('returns empty properties when there is no brand.json and no federated-index data', async () => {
+    const res = await request(app).get(
+      `/api/registry/publisher?domain=${encodeURIComponent(PUB_BRAND_ONLY)}`
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.properties).toEqual([]);
+  });
+
+  it('does not hydrate from brand.json when brand_manifest has no properties', async () => {
+    await brandDb.upsertDiscoveredBrand({
+      domain: PUB_BRAND_ONLY,
+      brand_name: 'Sasha Media',
+      source_type: 'brand_json',
+      has_brand_manifest: true,
+      brand_manifest: { name: 'Sasha Media' },
+    });
+
+    const res = await request(app).get(
+      `/api/registry/publisher?domain=${encodeURIComponent(PUB_BRAND_ONLY)}`
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.properties).toEqual([]);
+  });
+
+  it('reports hosting.mode=none when no adagents.json is configured', async () => {
+    const res = await request(app).get(
+      `/api/registry/publisher?domain=${encodeURIComponent(PUB_BRAND_ONLY)}`
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.hosting).toMatchObject({
+      mode: 'none',
+      expected_url: `https://${PUB_BRAND_ONLY}/.well-known/adagents.json`,
+    });
+    expect(res.body.hosting.hosted_url).toBeUndefined();
+  });
+
+  it('reports hosting.mode=aao_hosted with hosted_url when a public hosted property exists', async () => {
+    await propertyDb.createHostedProperty({
+      publisher_domain: PUB_AAO_HOSTED,
+      adagents_json: { authorized_agents: [], properties: [] },
+      is_public: true,
+      source_type: 'community',
+    });
+
+    const res = await request(app).get(
+      `/api/registry/publisher?domain=${encodeURIComponent(PUB_AAO_HOSTED)}`
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.hosting).toMatchObject({
+      mode: 'aao_hosted',
+      hosted_url: `https://agenticadvertising.org/publisher/${PUB_AAO_HOSTED}/.well-known/adagents.json`,
+      expected_url: `https://${PUB_AAO_HOSTED}/.well-known/adagents.json`,
+    });
+  });
+});

--- a/server/tests/integration/registry-publisher-brand-json-hydration.test.ts
+++ b/server/tests/integration/registry-publisher-brand-json-hydration.test.ts
@@ -168,6 +168,50 @@ describe('Registry publisher endpoint — brand.json hydration', () => {
     expect(res.body.properties).toEqual([]);
   });
 
+  it('does NOT compute per-agent rollup when all properties are brand_json-sourced', async () => {
+    // Set up a brand.json hydration scenario AND an authorized agent.
+    // Without rollup suppression, the agent would be reported as
+    // authorized for N of N properties — over-claiming, since no
+    // adagents.json has actually scoped this agent to those properties.
+    await brandDb.upsertDiscoveredBrand({
+      domain: PUB_BRAND_ONLY,
+      brand_name: 'Sasha Media',
+      source_type: 'brand_json',
+      has_brand_manifest: true,
+      brand_manifest: {
+        name: 'Sasha Media',
+        properties: [
+          { identifier: PUB_BRAND_ONLY, type: 'website', relationship: 'owned' },
+        ],
+      },
+    });
+    // Plant an agent claim — without an adagents.json this is the only
+    // path agents can appear here.
+    await pool.query(
+      `INSERT INTO agent_publisher_authorizations (agent_url, publisher_domain, source)
+       VALUES ($1, $2, 'agent_claim')
+       ON CONFLICT DO NOTHING`,
+      ['https://claiming-agent.brand-hydrate.example', PUB_BRAND_ONLY],
+    );
+
+    const res = await request(app).get(
+      `/api/registry/publisher?domain=${encodeURIComponent(PUB_BRAND_ONLY)}`
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.properties).toHaveLength(1);
+    expect(res.body.authorized_agents).toHaveLength(1);
+    const agent = res.body.authorized_agents[0];
+    expect(agent.properties_authorized).toBeUndefined();
+    expect(agent.properties_total).toBeUndefined();
+    expect(agent.publisher_wide).toBeUndefined();
+
+    // Cleanup the planted authorization (other tests use the same domain).
+    await pool.query(
+      `DELETE FROM agent_publisher_authorizations WHERE agent_url = $1`,
+      ['https://claiming-agent.brand-hydrate.example'],
+    );
+  });
+
   it('reports hosting.mode=none when no adagents.json is configured', async () => {
     const res = await request(app).get(
       `/api/registry/publisher?domain=${encodeURIComponent(PUB_BRAND_ONLY)}`

--- a/server/tests/integration/registry-reader-baseline-public-endpoints.test.ts
+++ b/server/tests/integration/registry-reader-baseline-public-endpoints.test.ts
@@ -26,6 +26,14 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vites
 import request from 'supertest';
 import type { Pool } from 'pg';
 
+// Set WorkOS env before vi.mock factories run — auth.ts constructs WorkOS
+// at module load and the factory's vi.importActual triggers that load.
+// Hoisted block runs before mock factories regardless of file ordering.
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'test';
+  process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+});
+
 // Bypass WorkOS auth — the registry feed requires `requireAuth`. Stamp
 // every request with a fixed test user. Other public registry endpoints
 // use `optAuth` (no-op without a session), so the pass-through here is
@@ -288,19 +296,118 @@ describe('Registry reader baseline — public endpoints', () => {
       });
 
       // Authorized agents: includes both adagents_json and agent_claim
-      // sources, projected as {url, authorized_for, source}.
+      // sources, projected as {url, authorized_for, source}. Each agent
+      // also carries a per-publisher rollup of property authorization.
+      const agentsByUrl = new Map(
+        res.body.authorized_agents.map((a: { url: string }) => [a.url, a])
+      );
+      // AGENT_X: property-level row exists for `home` only → 1 of 2.
+      expect(agentsByUrl.get(AGENT_X)).toMatchObject({
+        url: AGENT_X,
+        authorized_for: 'all',
+        source: 'adagents_json',
+        properties_authorized: 1,
+        properties_total: 2,
+      });
+      // AGENT_Y: property-level row exists for `mobile` only → 1 of 2.
+      expect(agentsByUrl.get(AGENT_Y)).toMatchObject({
+        url: AGENT_Y,
+        source: 'agent_claim',
+        properties_authorized: 1,
+        properties_total: 2,
+      });
+    });
+
+    it('GET /api/registry/publisher reports publisher-wide auth as N of N', async () => {
+      // Drop AGENT_X's property-level row so only the publisher-wide
+      // authorization remains. The rollup should collapse to "all".
+      await pool.query(
+        `DELETE FROM agent_property_authorizations
+         WHERE agent_url = $1
+           AND property_id IN (
+             SELECT id FROM discovered_properties WHERE publisher_domain = $2
+           )`,
+        [AGENT_X, PUB_A]
+      );
+
+      const res = await request(app).get(
+        `/api/registry/publisher?domain=${encodeURIComponent(PUB_A)}`
+      );
+      expect(res.status).toBe(200);
       const agentsByUrl = new Map(
         res.body.authorized_agents.map((a: { url: string }) => [a.url, a])
       );
       expect(agentsByUrl.get(AGENT_X)).toMatchObject({
         url: AGENT_X,
-        authorized_for: 'all',
+        properties_authorized: 2,
+        properties_total: 2,
+      });
+    });
+
+    // ── /registry/publisher/authorization ──────────────────────────
+
+    it('GET /api/registry/publisher/authorization returns the per-property breakdown', async () => {
+      const res = await request(app).get(
+        `/api/registry/publisher/authorization?domain=${encodeURIComponent(PUB_A)}&agent=${encodeURIComponent(AGENT_X)}`
+      );
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        publisher_domain: PUB_A,
+        agent_url: AGENT_X,
+        authorized: 1,
+        total: 2,
+        publisher_wide: false,
         source: 'adagents_json',
       });
-      expect(agentsByUrl.get(AGENT_Y)).toMatchObject({
-        url: AGENT_Y,
-        source: 'agent_claim',
+      expect(res.body.unauthorized_properties).toHaveLength(1);
+      expect(res.body.unauthorized_properties[0]).toMatchObject({
+        name: 'Endpoint Mobile',
       });
+    });
+
+    it('GET /api/registry/publisher/authorization reports publisher-wide as N of N with no unauthorized list', async () => {
+      // Drop AGENT_X's property-level row → only publisher-wide remains.
+      await pool.query(
+        `DELETE FROM agent_property_authorizations
+         WHERE agent_url = $1
+           AND property_id IN (
+             SELECT id FROM discovered_properties WHERE publisher_domain = $2
+           )`,
+        [AGENT_X, PUB_A]
+      );
+
+      const res = await request(app).get(
+        `/api/registry/publisher/authorization?domain=${encodeURIComponent(PUB_A)}&agent=${encodeURIComponent(AGENT_X)}`
+      );
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        authorized: 2,
+        total: 2,
+        publisher_wide: true,
+        unauthorized_properties: [],
+      });
+    });
+
+    it('GET /api/registry/publisher/authorization 404s when the agent is not authorized', async () => {
+      const res = await request(app).get(
+        `/api/registry/publisher/authorization?domain=${encodeURIComponent(PUB_A)}&agent=${encodeURIComponent('https://unknown-agent.example')}`
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it('GET /api/registry/publisher/authorization returns 400 when params are missing', async () => {
+      const res = await request(app).get(
+        `/api/registry/publisher/authorization?domain=${encodeURIComponent(PUB_A)}`
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it('GET /api/registry/publisher/authorization tolerates trailing slash on agent URL', async () => {
+      const res = await request(app).get(
+        `/api/registry/publisher/authorization?domain=${encodeURIComponent(PUB_A)}&agent=${encodeURIComponent(AGENT_X + '/')}`
+      );
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ publisher_domain: PUB_A, authorized: 1, total: 2 });
     });
 
     // ── /registry/publishers ───────────────────────────────────────

--- a/server/tests/integration/registry-reader-baseline-public-endpoints.test.ts
+++ b/server/tests/integration/registry-reader-baseline-public-endpoints.test.ts
@@ -308,6 +308,7 @@ describe('Registry reader baseline — public endpoints', () => {
         source: 'adagents_json',
         properties_authorized: 1,
         properties_total: 2,
+        publisher_wide: false,
       });
       // AGENT_Y: property-level row exists for `mobile` only → 1 of 2.
       expect(agentsByUrl.get(AGENT_Y)).toMatchObject({
@@ -315,6 +316,7 @@ describe('Registry reader baseline — public endpoints', () => {
         source: 'agent_claim',
         properties_authorized: 1,
         properties_total: 2,
+        publisher_wide: false,
       });
     });
 
@@ -341,6 +343,7 @@ describe('Registry reader baseline — public endpoints', () => {
         url: AGENT_X,
         properties_authorized: 2,
         properties_total: 2,
+        publisher_wide: true,
       });
     });
 

--- a/server/tests/unit/brand-json-properties.test.ts
+++ b/server/tests/unit/brand-json-properties.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { extractPublisherPropertiesFromBrandJson } from '../../src/services/brand-json-properties.js';
+
+describe('extractPublisherPropertiesFromBrandJson', () => {
+  it('returns [] for null/undefined/empty manifest', () => {
+    expect(extractPublisherPropertiesFromBrandJson(null)).toEqual([]);
+    expect(extractPublisherPropertiesFromBrandJson(undefined)).toEqual([]);
+    expect(extractPublisherPropertiesFromBrandJson({})).toEqual([]);
+  });
+
+  it('extracts top-level properties[]', () => {
+    const result = extractPublisherPropertiesFromBrandJson({
+      properties: [
+        { identifier: 'Wonderstruck.org', type: 'website', relationship: 'owned' },
+        { identifier: 'community.wonderstruck.org', type: 'website', relationship: 'direct' },
+      ],
+    });
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      type: 'website',
+      name: 'wonderstruck.org',
+      identifiers: [{ type: 'domain', value: 'wonderstruck.org' }],
+      tags: ['relationship:owned'],
+      source: 'brand_json',
+    });
+    expect(result[1].tags).toEqual(['relationship:direct']);
+  });
+
+  it('extracts brands[].properties[] (house manifest shape)', () => {
+    const result = extractPublisherPropertiesFromBrandJson({
+      brands: [
+        { name: 'Sub A', properties: [{ identifier: 'a.example', type: 'website' }] },
+        { name: 'Sub B', properties: [{ identifier: 'b.example', type: 'website' }] },
+      ],
+    });
+    expect(result.map((p) => p.name)).toEqual(['a.example', 'b.example']);
+  });
+
+  it('dedupes the same identifier across top-level and house shapes', () => {
+    const result = extractPublisherPropertiesFromBrandJson({
+      properties: [{ identifier: 'shared.example', type: 'website' }],
+      brands: [{ properties: [{ identifier: 'shared.example', type: 'website' }] }],
+    });
+    expect(result).toHaveLength(1);
+  });
+
+  it('skips entries without an identifier', () => {
+    const result = extractPublisherPropertiesFromBrandJson({
+      properties: [
+        { type: 'website' },
+        { identifier: '', type: 'website' },
+        { identifier: 'ok.example', type: 'website' },
+      ],
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('ok.example');
+  });
+
+  it('preserves identifiers for non-website types using a generic type tag', () => {
+    const result = extractPublisherPropertiesFromBrandJson({
+      properties: [
+        { identifier: 'com.acme.app', type: 'mobile_app' },
+        { identifier: 'roku.acme.tv', type: 'ctv_app' },
+      ],
+    });
+    expect(result[0]).toMatchObject({
+      type: 'mobile_app',
+      identifiers: [{ type: 'mobile_app', value: 'com.acme.app' }],
+    });
+    expect(result[1]).toMatchObject({
+      type: 'ctv_app',
+      identifiers: [{ type: 'ctv_app', value: 'roku.acme.tv' }],
+    });
+  });
+
+  it('caps walking at MAX_BRAND_JSON_PROPERTIES (5000) to bound work on hostile manifests', () => {
+    const big = Array.from({ length: 6000 }, (_, i) => ({
+      identifier: `prop-${i}.example`,
+      type: 'website',
+    }));
+    const result = extractPublisherPropertiesFromBrandJson({ properties: big });
+    expect(result).toHaveLength(5000);
+  });
+
+  it('defaults type=website and omits relationship tag when missing', () => {
+    const result = extractPublisherPropertiesFromBrandJson({
+      properties: [{ identifier: 'plain.example' }],
+    });
+    expect(result[0]).toMatchObject({
+      type: 'website',
+      tags: [],
+      identifiers: [{ type: 'domain', value: 'plain.example' }],
+    });
+  });
+});

--- a/server/tests/unit/operator-publisher-lookup.test.ts
+++ b/server/tests/unit/operator-publisher-lookup.test.ts
@@ -178,4 +178,68 @@ describe('PublisherLookupResult schema', () => {
     const result = PublisherLookupResultSchema.safeParse(data);
     expect(result.success).toBe(true);
   });
+
+  it('validates self_invalid hosting mode', () => {
+    const data = {
+      domain: 'broken.example',
+      member: null,
+      adagents_valid: false,
+      hosting: {
+        mode: 'self_invalid' as const,
+        expected_url: 'https://broken.example/.well-known/adagents.json',
+      },
+      properties: [],
+      authorized_agents: [],
+    };
+    const result = PublisherLookupResultSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('validates per-agent publisher_wide flag', () => {
+    const data = {
+      domain: 'voxmedia.com',
+      member: null,
+      adagents_valid: true,
+      hosting: {
+        mode: 'self' as const,
+        expected_url: 'https://voxmedia.com/.well-known/adagents.json',
+      },
+      properties: [{ id: 'theverge', type: 'website', name: 'The Verge' }],
+      authorized_agents: [
+        {
+          url: 'https://agent-a.example',
+          source: 'adagents_json' as const,
+          properties_authorized: 1,
+          properties_total: 1,
+          publisher_wide: true,
+        },
+        {
+          url: 'https://agent-b.example',
+          source: 'adagents_json' as const,
+          properties_authorized: 0,
+          properties_total: 1,
+          publisher_wide: false,
+        },
+      ],
+    };
+    const result = PublisherLookupResultSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('validates rollup_truncated as { cap, total_agents }', () => {
+    const data = {
+      domain: 'big.example',
+      member: null,
+      adagents_valid: true,
+      hosting: {
+        mode: 'self' as const,
+        expected_url: 'https://big.example/.well-known/adagents.json',
+      },
+      properties: [],
+      authorized_agents: [],
+      rollup_truncated: { cap: 50, total_agents: 137 },
+    };
+    const result = PublisherLookupResultSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
 });

--- a/server/tests/unit/operator-publisher-lookup.test.ts
+++ b/server/tests/unit/operator-publisher-lookup.test.ts
@@ -96,6 +96,10 @@ describe('PublisherLookupResult schema', () => {
       domain: 'voxmedia.com',
       member: { slug: 'voxmedia', display_name: 'Vox Media' },
       adagents_valid: true,
+      hosting: {
+        mode: 'self' as const,
+        expected_url: 'https://voxmedia.com/.well-known/adagents.json',
+      },
       properties: [
         {
           id: 'theverge',
@@ -119,6 +123,7 @@ describe('PublisherLookupResult schema', () => {
     if (result.success) {
       expect(result.data.properties).toHaveLength(1);
       expect(result.data.authorized_agents).toHaveLength(1);
+      expect(result.data.hosting.mode).toBe('self');
     }
   });
 
@@ -127,6 +132,10 @@ describe('PublisherLookupResult schema', () => {
       domain: 'unknown.com',
       member: null,
       adagents_valid: false,
+      hosting: {
+        mode: 'none' as const,
+        expected_url: 'https://unknown.com/.well-known/adagents.json',
+      },
       properties: [],
       authorized_agents: [],
     };
@@ -140,6 +149,28 @@ describe('PublisherLookupResult schema', () => {
       domain: 'test.com',
       member: null,
       adagents_valid: null,
+      hosting: {
+        mode: 'none' as const,
+        expected_url: 'https://test.com/.well-known/adagents.json',
+      },
+      properties: [],
+      authorized_agents: [],
+    };
+
+    const result = PublisherLookupResultSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('validates aao_hosted mode with hosted_url', () => {
+    const data = {
+      domain: 'sasha-media.com',
+      member: null,
+      adagents_valid: null,
+      hosting: {
+        mode: 'aao_hosted' as const,
+        hosted_url: 'https://agenticadvertising.org/publisher/sasha-media.com/.well-known/adagents.json',
+        expected_url: 'https://sasha-media.com/.well-known/adagents.json',
+      },
       properties: [],
       authorized_agents: [],
     };

--- a/server/tests/unit/operator-publisher-lookup.test.ts
+++ b/server/tests/unit/operator-publisher-lookup.test.ts
@@ -179,6 +179,31 @@ describe('PublisherLookupResult schema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('validates aao_hosted source on agent rows (origin-not-verified label)', () => {
+    const data = {
+      domain: 'sasha-media.com',
+      member: null,
+      adagents_valid: null,
+      hosting: {
+        mode: 'aao_hosted' as const,
+        hosted_url: 'https://agenticadvertising.org/publisher/sasha-media.com/.well-known/adagents.json',
+        expected_url: 'https://sasha-media.com/.well-known/adagents.json',
+      },
+      properties: [],
+      authorized_agents: [
+        {
+          url: 'https://agent.example',
+          source: 'aao_hosted' as const,
+          properties_authorized: 0,
+          properties_total: 0,
+          publisher_wide: true,
+        },
+      ],
+    };
+    const result = PublisherLookupResultSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
   it('validates self_invalid hosting mode', () => {
     const data = {
       domain: 'broken.example',


### PR DESCRIPTION
## Summary

Three concrete asks from the AAO team plus the UX gaps surfaced during a persona walkthrough (Maria / Sasha / Devraj).

### What this is for

`AgenticAdvertising.org/publisher/{domain}` is now a usable page a publisher can land on cold or be deep-linked to from a buyer platform (e.g. Scope3) for "manage my inventory." It surfaces the publisher's adagents.json record (cached or AAO-hosted), their authorized agents with an X-of-Y property rollup, and their property declarations.

### API

- `/api/registry/publisher` — brand.json fallback when the federated index has nothing for a domain; per-agent `properties_authorized` / `properties_total` rollup (capped at 50, returns `rollup_truncated: true` above the cap to bound fan-out on this unauthenticated endpoint); `hosting: { mode, hosted_url?, expected_url }` block.
- `/api/registry/publisher/authorization?domain=X&agent=Y` — focused per-(publisher × agent) check with `unauthorized_properties[]`. Agent URL is canonicalized so trailing-slash variants don't 404.
- `GET /publisher/:domain/.well-known/adagents.json` — AAO-hosted publishers can paste the URL into a CNAME or 301 redirect from their own `/.well-known` path. 404 unless `hosted_properties.is_public = true`. Domain shape validated.

### UI

- New `/publisher/:domain` page — cache-first explainer, hosting panel with state-aware setup copy (self-host vs AAO-hosted vs not-yet-configured), source badges (`adagents_json` / `discovered` / `brand_json`), click-to-expand drill-down on agent rows, "why?" link on invalid adagents.json badge that surfaces validation errors inline.
- `/registry?tab=properties` (publishers.html) gets a "look up a publisher" form at the top; row links updated to point at `/publisher/:domain`.
- Sub-nav "Properties" tab highlights for both `/property/view/*` and `/publisher/*` paths.

### Hosted-property → federated-index sync

Public `hosted_properties` rows now propagate into `discovered_properties`, `discovered_agents`, `agent_publisher_authorizations`, and `discovered_publishers`. Without this, AAO-hosted publishers were invisible to `/api/registry/publisher` even though AAO was serving the canonical document.

- Authorizations are fully reconciled — rows we own with `source='adagents_json'` are deleted when the manifest drops them.
- Publisher row keyed on a stable AAO sentinel (`aao://hosted`) so re-syncs collapse to one row regardless of agent ordering.
- Properties remain additive only (`discovered_properties` has no source column to safely distinguish hosted vs crawler rows; tracked as a follow-up).

### Reviewer findings addressed

Both `code-reviewer` and `security-reviewer` ran on the diff. Must Fix and Should Fix items addressed in this PR:

- **DoS amplification** — capped per-agent rollup fan-out at 50, returns `rollup_truncated`.
- **Sync was additive-only** — authorizations now fully reconciled; properties limitation documented honestly.
- **Publisher row leaked on agent reordering** — switched to stable sentinel.
- **Domain validation missing** on hosted adagents.json route — added.
- **Agent URL not normalized** in authorization endpoint — canonicalized via the same writer-side function.
- **Sync errors swallowed** — now tracked, returned in `HostedSyncResult`, throws when nothing succeeded.
- **Brand.json walker unbounded** — capped at 5000 entries.
- **Identifiers dropped for non-website brand.json types** — preserved with generic `{type, value}`.

### Follow-ups (not in this PR)

- `discovered_properties.source` column to enable property-removal reconciliation in the hosted sync.
- Per-IP rate limit on `/api/registry/publisher` (broader change — touches existing routes too).
- End-to-end claim journey from `/publisher/:domain` (today the explainer's "Sign in to claim" CTA bounces to the existing editor).

## Test plan

- [x] `npm run typecheck` — clean
- [x] 49 tests pass: 4 new integration files + 1 new unit file + extensions to existing baseline
- [x] Playwright smoke across all three personas (cold / brand.json hydration / AAO-hosted with drill-down)
- [x] Manual: lookup form on Properties tab routes to `/publisher/:domain`, sub-nav highlight, hosting copy across all three modes, drill-down expands with publisher-wide vs partial coverage messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)