### PR TITLE
fix(org-merge): surface 500-response details on /api/admin/cleanup/merge

### DIFF
--- a/.changeset/fix-org-merge-domain-conflict.md
+++ b/.changeset/fix-org-merge-domain-conflict.md
@@ -1,0 +1,13 @@
+---
+---
+
+Surface the actual error in `/api/admin/cleanup/merge` 500 responses.
+
+The merge route caught any error and returned `{"error": "Internal server error"}` with no detail. Admins running merges via curl had no idea which step failed, whether the txn rolled back, or what to retry. May 2026 Media.net-2 cleanup lost ~30min on this — the merge endpoint kept returning a bare 500 with no diagnostic, even after the secondary org had successfully been deleted.
+
+Now:
+- 500 response includes `details` with the underlying error message.
+- Log line includes `name`, `stack`, `cause`, `primary_org_id`, `secondary_org_id`.
+- Destructure of req.body moved out of the try-block so the catch path can reference which org pair was being merged.
+
+(I also tried to fix what I thought was a `UNIQUE(domain)` conflict in `org-merge-db.ts` but the schema makes that state unreachable — two rows can't both own the same domain. Reverted that part. The real failure mode for Media.net-2 was something else, and we couldn't see it because the route was swallowing errors. After this lands, next merge failure will surface the actual cause.)

--- a/server/src/routes/admin/cleanup.ts
+++ b/server/src/routes/admin/cleanup.ts
@@ -273,15 +273,21 @@ export function setupCleanupRoutes(apiRouter: Router): void {
 
   // POST /api/admin/cleanup/merge - Execute organization merge
   apiRouter.post("/cleanup/merge", requireAuth, requireAdmin, async (req, res) => {
-    try {
-      const { primary_org_id, secondary_org_id, stripe_customer_resolution } = req.body;
+    // Pull org ids out before the try-block so the 500 catch path can
+    // log them. Without this, an error thrown inside the try (where the
+    // destructure used to live) leaves the catch with no idea which
+    // pair was being merged — admins running curl get a bare "Internal
+    // server error" with no diagnostic context.
+    const { primary_org_id, secondary_org_id, stripe_customer_resolution } = req.body;
 
-      if (!primary_org_id || !secondary_org_id) {
-        return res.status(400).json({
-          error: "Missing parameters",
-          message: "Both 'primary_org_id' and 'secondary_org_id' are required",
-        });
-      }
+    if (!primary_org_id || !secondary_org_id) {
+      return res.status(400).json({
+        error: "Missing parameters",
+        message: "Both 'primary_org_id' and 'secondary_org_id' are required",
+      });
+    }
+
+    try {
 
       // Validate stripe_customer_resolution if provided
       const validResolutions: StripeCustomerResolution[] = ['keep_primary', 'use_secondary', 'keep_both_unlinked'];
@@ -320,7 +326,18 @@ export function setupCleanupRoutes(apiRouter: Router): void {
 
       res.json(result);
     } catch (error) {
-      logger.error({ err: error }, "Error executing merge");
+      logger.error(
+        {
+          err: error,
+          errMessage: error instanceof Error ? error.message : String(error),
+          errName: error instanceof Error ? error.name : undefined,
+          errStack: error instanceof Error ? error.stack : undefined,
+          errCause: error instanceof Error ? (error as Error & { cause?: unknown }).cause : undefined,
+          primary_org_id,
+          secondary_org_id,
+        },
+        "Error executing merge",
+      );
 
       // Return 400 for validation errors (e.g., personal workspace merge attempts, Stripe conflicts)
       if (error instanceof Error && (
@@ -334,8 +351,15 @@ export function setupCleanupRoutes(apiRouter: Router): void {
         });
       }
 
+      // 500 path: surface the underlying message in `details` so admins
+      // running merges via curl don't have to dig through Fly logs to
+      // see whether the merge rolled back or which step failed. (May
+      // 2026: Media.net-2 cleanup returned a bare "Internal server
+      // error" with no log entry visible from the caller side, hiding
+      // the real cause for ~30min.)
       res.status(500).json({
         error: "Internal server error",
+        details: error instanceof Error ? error.message : String(error),
       });
     }
   });


### PR DESCRIPTION
## Summary

The merge route caught any error and returned `{"error": "Internal server error"}` with no detail. Admins running merges via curl had no way to see which step failed, whether the txn rolled back, or what to retry. May 2026 Media.net-2 cleanup lost ~30min on this — the merge kept returning a bare 500 even though the secondary was actually being deleted.

## What changed

- **500 response now includes `details`** with the underlying error message.
- **Log line includes** `name`, `stack`, `cause`, `primary_org_id`, `secondary_org_id`.
- **Destructure moved out of the try-block** so the catch path has the org pair in scope (currently `primary_org_id` and `secondary_org_id` were declared inside the try, leaving the catch with no idea which pair was being merged).

## What I initially tried and reverted

I first wrote a defensive `INSERT ... ON CONFLICT DO NOTHING` change to `org-merge-db.ts` and an integration test, on the theory that the Media.net-2 failure was a `organization_domains` UNIQUE conflict. The integration test failed in CI on its own setup — and looking at the schema (`UNIQUE(domain)` not `UNIQUE(workos_organization_id, domain)`), the state I was trying to defend against is unreachable. Reverted that part.

The real failure mode is still unknown — we couldn't see it because the route was swallowing errors. After this lands, the next merge failure will surface the actual cause and we can fix that.

## Test plan

- [x] 140 unit tests pass (no functional change to merge logic)
- [x] Typecheck clean
- [x] Precommit hook passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)