### PR TITLE
fix(server): per-IP rate limit on unauthenticated registry-read endpoints

### DIFF
--- a/.changeset/registry-read-rate-limit.md
+++ b/.changeset/registry-read-rate-limit.md
@@ -1,0 +1,23 @@
+---
+---
+
+fix(server): per-IP rate limit on unauthenticated registry-read endpoints, closes #4112
+
+Adds two rate limiters to `server/src/middleware/rate-limit.ts` and applies them across the six
+unauthenticated registry endpoints that previously had no per-IP cap:
+
+- `registryPublisherRateLimiter` — 20 req/min on `GET /api/registry/publisher`, which fans out
+  to up to 50 DB queries per request (agent-rollup cap from PR #4106). Matches the ceiling of
+  `bulkResolveRateLimiter` (20 req/min × up to 100 domains) for comparable worst-case DB load.
+- `registryReadRateLimiter` — 60 req/min shared across `GET /api/registry/operator`,
+  `GET /api/registry/publisher/authorization`, `GET /api/registry/publishers`, and all
+  `GET /api/registry/lookup/*` variants. These issue a small fixed number of queries per call.
+
+Both use `CachedPostgresStore` (in-memory increment, 15 s Postgres flush) for cross-pod sync
+without saturating the connection pool on high-frequency anonymous reads, matching the pattern
+used by `notificationRateLimiter` and `agentReadRateLimiter`.
+
+Note: two other unauthenticated registry endpoints — `/api/registry/stats` and
+`/api/registry/agents` — were not in scope for this issue. A follow-up should evaluate
+whether they also need caps, particularly `/api/registry/agents` which supports optional
+fan-out query params (`health`, `capabilities`, `compliance`).

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -494,6 +494,67 @@ export const contentFetchUrlRateLimiter = rateLimit({
 });
 
 /**
+ * Rate limiter for the unauthenticated /api/registry/publisher endpoint.
+ * Tighter than the generic registry read limit because each request fans out
+ * to up to 50 DB queries (per-agent rollup cap from PR #4106). At 20 req/min
+ * the worst-case load per IP is ~1,000 DB queries/min — comparable to
+ * bulkResolveRateLimiter (20 × 100 domains).
+ */
+export const registryPublisherRateLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+  store: new CachedPostgresStore('reg-pub:'),
+  keyGenerator: generateKey,
+  validate: { keyGeneratorIpFallback: false },
+  handler: (req: Request, res: Response) => {
+    logger.warn({
+      ip: req.ip,
+      path: req.path,
+    }, 'Rate limit exceeded for registry publisher lookup');
+
+    // Static retryAfter is intentional here — callers are external scripts,
+    // not a UI countdown, so the full window ceiling is a sufficient hint.
+    res.status(429).json({
+      error: 'Too many requests',
+      message: 'Registry publisher rate limit exceeded. Please try again later.',
+      retryAfter: 60,
+    });
+  },
+});
+
+/**
+ * Rate limiter for unauthenticated registry read endpoints other than
+ * /api/registry/publisher: /api/registry/publishers, /api/registry/operator,
+ * /api/registry/publisher/authorization, and /api/registry/lookup/*. These
+ * issue a small fixed number of DB queries per call, so a more generous
+ * ceiling is appropriate: 60 req/min while still bounding anonymous
+ * enumeration.
+ */
+export const registryReadRateLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  store: new CachedPostgresStore('reg-read:'),
+  keyGenerator: generateKey,
+  validate: { keyGeneratorIpFallback: false },
+  handler: (req: Request, res: Response) => {
+    logger.warn({
+      ip: req.ip,
+      path: req.path,
+    }, 'Rate limit exceeded for registry read');
+
+    res.status(429).json({
+      error: 'Too many requests',
+      message: 'Registry lookup rate limit exceeded. Please try again later.',
+      retryAfter: 60,
+    });
+  },
+});
+
+/**
  * Rate limiter for logo uploads
  * Limits: 10 uploads per hour per user
  */

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -18,7 +18,7 @@ import { query } from "../db/client.js";
 import { resolvePrimaryOrganization } from "../db/users-db.js";
 import * as manifestRefsDb from "../db/manifest-refs-db.js";
 import { isUuid } from "../utils/uuid.js";
-import { bulkResolveRateLimiter, brandCreationRateLimiter, storyboardEvalRateLimiter, storyboardStepRateLimiter, agentReadRateLimiter } from "../middleware/rate-limit.js";
+import { bulkResolveRateLimiter, brandCreationRateLimiter, storyboardEvalRateLimiter, storyboardStepRateLimiter, agentReadRateLimiter, registryPublisherRateLimiter, registryReadRateLimiter } from "../middleware/rate-limit.js";
 import { listStoryboards, getStoryboard, getTestKitForStoryboard } from "../services/storyboards.js";
 import {
   comply,
@@ -5623,7 +5623,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
 
   // ── Publishers ──────────────────────────────────────────────────
 
-  router.get("/registry/publishers", async (_req, res) => {
+  router.get("/registry/publishers", registryReadRateLimiter, async (_req, res) => {
     try {
       const federatedIndex = crawler.getFederatedIndex();
       const publishers = await federatedIndex.listAllPublishers();
@@ -5647,7 +5647,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
 
   // ── Lookups & Authorization ───────────────────────────────────
 
-  router.get("/registry/operator", optAuth, async (req, res) => {
+  router.get("/registry/operator", registryReadRateLimiter, optAuth, async (req, res) => {
     const rawDomain = req.query.domain as string;
     if (!rawDomain) {
       return res.status(400).json({ error: "Missing required query param: domain" });
@@ -5711,7 +5711,10 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     }
   });
 
-  router.get("/registry/publisher", agentReadRateLimiter, async (req, res) => {
+  // 20 req/min/IP — tighter than the generic agentReadRateLimiter (240/min)
+  // because each request fans out to up to 50 DB queries (per-agent rollup
+  // cap from #4106). Matches bulkResolveRateLimiter's worst-case ceiling.
+  router.get("/registry/publisher", registryPublisherRateLimiter, async (req, res) => {
     const rawDomain = req.query.domain as string;
     if (!rawDomain) {
       return res.status(400).json({ error: "Missing required query param: domain" });
@@ -5968,7 +5971,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     }
   });
 
-  router.get("/registry/publisher/authorization", async (req, res) => {
+  router.get("/registry/publisher/authorization", registryReadRateLimiter, async (req, res) => {
     const rawDomain = req.query.domain as string;
     const rawAgent = req.query.agent as string;
     if (!rawDomain || !rawAgent) {
@@ -6035,7 +6038,10 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     }
   });
 
-  router.get("/registry/lookup/domain/:domain", async (req, res) => {
+  router.get("/registry/lookup/domain/:domain", registryReadRateLimiter, async (req, res) => {
+    // Deprecation headers (RFC 8594) — this endpoint is superseded by
+    // /api/registry/publisher per #4115. Kept here through the rate
+    // limit so deprecated callers still get a 429 if they hammer it.
     res.setHeader("Deprecation", "true");
     res.setHeader("Link", `</api/registry/publisher?domain=${encodeURIComponent(req.params.domain)}>; rel="successor-version"`);
     try {
@@ -6049,7 +6055,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     }
   });
 
-  router.get("/registry/lookup/property", async (req, res) => {
+  router.get("/registry/lookup/property", registryReadRateLimiter, async (req, res) => {
     const { type, value } = req.query;
 
     if (!type || !value) {
@@ -6066,7 +6072,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     }
   });
 
-  router.get("/registry/lookup/agent/:agentUrl/domains", async (req, res) => {
+  router.get("/registry/lookup/agent/:agentUrl/domains", registryReadRateLimiter, async (req, res) => {
     try {
       const federatedIndex = crawler.getFederatedIndex();
       const agentUrl = decodeURIComponent(req.params.agentUrl);


### PR DESCRIPTION
Closes #4112

## Summary

Adds per-IP rate limiting to all unauthenticated registry-read endpoints. PR #4106 capped the per-agent rollup fan-out on `/api/registry/publisher` at 50 DB queries per request; without an IP cap a single caller could sustain arbitrary QPS against that amplification surface. This PR closes that gap.

Two rate limiters are added to `server/src/middleware/rate-limit.ts` and applied across seven routes in `server/src/routes/registry-api.ts`:

| Limiter | Limit | Endpoints |
|---|---|---|
| `registryPublisherRateLimiter` | 20 req/min | `GET /api/registry/publisher` (up to 50 DB queries/req) |
| `registryReadRateLimiter` | 60 req/min | `GET /api/registry/publishers`, `/registry/operator`, `/registry/publisher/authorization`, `/registry/lookup/domain/:domain`, `/registry/lookup/property`, `/registry/lookup/agent/:agentUrl/domains` |

The 20 req/min ceiling on the publisher endpoint matches `bulkResolveRateLimiter` (20 req/min × up to 100 domains) for a comparable worst-case DB load of ~1,000 queries/min per IP. Both limiters use `CachedPostgresStore` with unique key prefixes (`reg-pub:`, `reg-read:`) for cross-pod sync without per-request DB writes.

**Non-breaking justification:** adds protective middleware only; adds no new fields, removes no endpoints, changes no response shapes. Existing callers at normal QPS (well under 1 req/sec) are unaffected.

## Known gaps (tracked for follow-up)

- `/api/registry/stats` and `/api/registry/agents` are also unauthenticated and uncapped. `/registry/agents` in particular supports optional fan-out query params (`health`, `capabilities`, `compliance`) and warrants a follow-up issue. These were explicitly out of scope in #4112.
- The `CachedPostgresStore` 15 s flush window means up to N pods × cap requests can occur before cross-pod enforcement. This is a pre-existing property of all existing rate limiters and is acceptable for this surface.

**Pre-PR review:**
- code-reviewer: approved — no blockers; nits addressed (wrong message copy fixed, JSDoc updated, changeset corrected)
- internal-tools-strategist: approved — correct store choice, correct middleware ordering (before `optAuth` on operator route), no over-application

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_016u6MATEkkrNygNheHguYza

---
_Generated by [Claude Code](https://claude.ai/code/session_016u6MATEkkrNygNheHguYza)_