### PR TITLE
chore(server): deprecate /api/registry/lookup/domain/:domain in favor of /api/registry/publisher

### DIFF
--- a/.changeset/deprecate-lookup-domain-endpoint.md
+++ b/.changeset/deprecate-lookup-domain-endpoint.md
@@ -1,0 +1,13 @@
+---
+---
+
+chore(server): deprecate `/api/registry/lookup/domain/:domain` in favor of `/api/registry/publisher` (refs #4115)
+
+Marks the older domain-lookup endpoint as deprecated in the OpenAPI spec and adds `Deprecation: true` + `Link` response headers so machine and human consumers both see the migration signal before removal.
+
+Changes:
+- `deprecated: true` on the `lookupDomain` OpenAPI path item in `registry-api.ts`
+- Updated description to reference `/api/registry/publisher?domain=X` with a note that this endpoint will be removed in a future release
+- `Deprecation: true` and `Link: </api/registry/publisher>; rel="successor-version"` headers on every response from the route handler (RFC 8594)
+
+Internal callers (`mcp-tools.ts`, `addie/mcp/directory-tools.ts`) call `federatedIndex.lookupDomain()` directly and are tracked for migration in #4115 as follow-up work.

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -642,8 +642,11 @@ registry.registerPath({
   method: "get",
   path: "/api/registry/lookup/domain/{domain}",
   operationId: "lookupDomain",
-  summary: "Domain lookup",
-  description: "Find all agents authorized for a given publisher domain.",
+  summary: "Domain lookup (deprecated)",
+  description:
+    "**Deprecated.** Use `/api/registry/publisher?domain=X` for richer data including hosting state, " +
+    "per-agent rollup, and brand.json fallback. This endpoint will be removed in a future release.",
+  deprecated: true,
   tags: ["Authorization Lookups"],
   request: { params: z.object({ domain: z.string().openapi({ example: "examplepub.com" }) }) },
   responses: {
@@ -5857,6 +5860,8 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
   });
 
   router.get("/registry/lookup/domain/:domain", async (req, res) => {
+    res.setHeader("Deprecation", "true");
+    res.setHeader("Link", `</api/registry/publisher?domain=${encodeURIComponent(req.params.domain)}>; rel="successor-version"`);
     try {
       const federatedIndex = crawler.getFederatedIndex();
       const domain = req.params.domain;


### PR DESCRIPTION
Refs #4115

Marks `GET /api/registry/lookup/domain/:domain` as deprecated so both spec-reading agents and runtime API consumers see the migration signal before the route is removed. The richer `GET /api/registry/publisher?domain=X` endpoint (added in #4106) is now the canonical target.

**Non-breaking justification:** `deprecated: true` in OpenAPI is advisory; the response headers (`Deprecation`, `Link`) are additive and do not change the response body or status codes. Existing callers continue to work.

**Changes:**
- `deprecated: true` + updated summary/description on the `lookupDomain` OpenAPI path item pointing agents to `/api/registry/publisher?domain=X`
- `Deprecation: true` response header (RFC 8594) on every response from the handler
- `Link: </api/registry/publisher?domain={domain}>; rel="successor-version"` header with the caller's domain pre-filled for actionable migration signal

**Internal callers deferred:** `server/src/mcp-tools.ts` (line 1076) and `server/src/addie/mcp/directory-tools.ts` (line 277) call `federatedIndex.lookupDomain()` directly (not the HTTP route). The `mcp-tools.ts` caller has non-trivial enrichment fallback logic; both migrations are tracked in #4115 as follow-up.

**Pre-PR review:**
- code-reviewer: approved — non-breaking header additions; Link header includes domain param per RFC 8594 actionability guidance (1 nit noted: headers fire on both success and error paths — intentional, matches codebase pattern)
- adtech-product-expert: approved — deprecation mechanics correct; description accurately reflects richer endpoint capabilities confirmed in `server/src/schemas/registry.ts` (`hosting`, per-agent rollup, `brand_json` source enum); static YAML snapshot was stale

> **Triage-managed PR.** This bot does not currently iterate on review comments or PR conversation threads (only on the source issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` → fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121) for context.

Session: https://claude.ai/code/session_01ARhEx3VJfAQnX4BzKiPQSb

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARhEx3VJfAQnX4BzKiPQSb)_