### PR TITLE
feat(registry): promote brand.json relationship to delegation_type on hydrated properties

### DIFF
--- a/.changeset/brand-json-delegation-type-hydration.md
+++ b/.changeset/brand-json-delegation-type-hydration.md
@@ -1,0 +1,14 @@
+---
+---
+
+Adds `delegation_type` as a structured field on brand.json-hydrated publisher
+properties in `/api/registry/publisher`. The field mirrors adagents.json's
+`delegation_type` enum (`direct`/`delegated`/`ad_network`) so agentic buyers
+can filter by delegation relationship without parsing `relationship:` tag prefixes.
+
+`owned` properties have no `delegation_type` — ownership has no adagents.json
+counterpart for bilateral verification and is implicit from the publisher
+declaring the property in their own brand.json.
+
+The `relationship:` tag is retained for backward compat and marked deprecated
+in the `PublisherPropertySchema` OpenAPI description.

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -5827,6 +5827,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         identifiers?: Array<{ type: string; value: string }>;
         tags?: string[];
         source: "adagents_json" | "discovered" | "brand_json";
+        delegation_type?: "direct" | "delegated" | "ad_network";
       };
 
       let projectedProperties: ProjectedProperty[] = properties.map(p => ({

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -564,10 +564,17 @@ const PublisherPropertySchema = z.object({
   type: z.string().optional(),
   name: z.string().optional(),
   identifiers: z.array(PropertyIdentifierSchema).optional(),
-  tags: z.array(z.string()).optional(),
+  tags: z.array(z.string()).optional().openapi({
+    description:
+      "Arbitrary string tags on this property. The `relationship:` prefix tag (e.g. `relationship:owned`) is deprecated in favour of the `delegation_type` field and will be removed in a future release.",
+  }),
   source: z.enum(["adagents_json", "discovered", "brand_json"]).optional().openapi({
     description:
       "Where this property came from. `adagents_json`/`discovered` come from the federated index (publisher's own adagents.json or crawler discovery). `brand_json` is hydrated from the publisher's brand.json when no federated-index data exists yet.",
+  }),
+  delegation_type: z.enum(["direct", "delegated", "ad_network"]).optional().openapi({
+    description:
+      "Delegation relationship declared in brand.json. Populated only when `source` is `brand_json` — for `adagents_json` and `discovered` sources the authoritative value is on the matching `authorized_agents` entry. Mirrors adagents.json `delegation_type` for bilateral verification: `direct` = publisher treats this as a direct buying path, even if a third party operates the software; `delegated` = a rep firm or manager is authorized to sell on the publisher's behalf (operator-declared, unilateral until corroborated by the publisher's adagents.json); `ad_network` = sold as part of a network/exchange package. `owned` properties have no `delegation_type` — ownership is implicit and has no adagents.json counterpart.",
   }),
 });
 

--- a/server/src/services/brand-json-properties.ts
+++ b/server/src/services/brand-json-properties.ts
@@ -17,6 +17,7 @@ export interface PublisherPropertyFromBrandJson {
   identifiers: Array<{ type: string; value: string }>;
   tags: string[];
   source: "brand_json";
+  delegation_type?: "direct" | "delegated" | "ad_network";
 }
 
 interface RawBrandJsonProperty {
@@ -38,6 +39,14 @@ function readPropertyArray(value: unknown): RawBrandJsonProperty[] {
  * the result is the first N unique identifiers in document order.
  */
 const MAX_BRAND_JSON_PROPERTIES = 5000;
+
+// Known brand.json relationship values. Only these are emitted as tags or
+// delegation_type to guard against arbitrary input from publisher-controlled
+// manifests. "owned" has no adagents.json delegation_type counterpart so it
+// is tag-only; the other three are also surfaced as a structured field.
+const KNOWN_RELATIONSHIPS = ["owned", "direct", "delegated", "ad_network"] as const;
+const DELEGATION_TYPES = ["direct", "delegated", "ad_network"] as const;
+type DelegationType = (typeof DELEGATION_TYPES)[number];
 
 /**
  * Inferred identifier shape for a property type. brand.json's `identifier`
@@ -67,8 +76,19 @@ export function extractPublisherPropertiesFromBrandJson(
     const propType = typeof p.type === "string" && p.type ? p.type : "website";
     const relationship = typeof p.relationship === "string" ? p.relationship : undefined;
 
+    // Only emit a tag for known relationship values — relationship is from
+    // a publisher-controlled manifest and must not flow through unvalidated.
+    const knownRelationship = KNOWN_RELATIONSHIPS.includes(
+      relationship as (typeof KNOWN_RELATIONSHIPS)[number],
+    )
+      ? relationship
+      : undefined;
     const tags: string[] = [];
-    if (relationship) tags.push(`relationship:${relationship}`);
+    if (knownRelationship) tags.push(`relationship:${knownRelationship}`);
+
+    const delegation_type = DELEGATION_TYPES.includes(relationship as DelegationType)
+      ? (relationship as DelegationType)
+      : undefined;
 
     seen.set(id, {
       type: propType,
@@ -76,6 +96,7 @@ export function extractPublisherPropertiesFromBrandJson(
       identifiers: deriveIdentifiers(propType, id),
       tags,
       source: "brand_json",
+      delegation_type,
     });
     return true;
   }

--- a/server/tests/unit/brand-json-properties.test.ts
+++ b/server/tests/unit/brand-json-properties.test.ts
@@ -23,7 +23,27 @@ describe('extractPublisherPropertiesFromBrandJson', () => {
       tags: ['relationship:owned'],
       source: 'brand_json',
     });
+    // 'owned' has no adagents.json counterpart — delegation_type is not set
+    expect(result[0].delegation_type).toBeUndefined();
     expect(result[1].tags).toEqual(['relationship:direct']);
+    expect(result[1].delegation_type).toBe('direct');
+  });
+
+  it('maps relationship to delegation_type for bilateral-verification values', () => {
+    const result = extractPublisherPropertiesFromBrandJson({
+      properties: [
+        { identifier: 'a.example', type: 'website', relationship: 'direct' },
+        { identifier: 'b.example', type: 'website', relationship: 'delegated' },
+        { identifier: 'c.example', type: 'website', relationship: 'ad_network' },
+        { identifier: 'd.example', type: 'website', relationship: 'owned' },
+        { identifier: 'e.example', type: 'website' },
+      ],
+    });
+    expect(result[0].delegation_type).toBe('direct');
+    expect(result[1].delegation_type).toBe('delegated');
+    expect(result[2].delegation_type).toBe('ad_network');
+    expect(result[3].delegation_type).toBeUndefined();
+    expect(result[4].delegation_type).toBeUndefined();
   });
 
   it('extracts brands[].properties[] (house manifest shape)', () => {
@@ -34,6 +54,17 @@ describe('extractPublisherPropertiesFromBrandJson', () => {
       ],
     });
     expect(result.map((p) => p.name)).toEqual(['a.example', 'b.example']);
+  });
+
+  it('maps delegation_type through brands[].properties[] (house manifest shape)', () => {
+    const result = extractPublisherPropertiesFromBrandJson({
+      brands: [
+        { name: 'Sub A', properties: [{ identifier: 'a.example', type: 'website', relationship: 'delegated' }] },
+        { name: 'Sub B', properties: [{ identifier: 'b.example', type: 'website', relationship: 'owned' }] },
+      ],
+    });
+    expect(result[0].delegation_type).toBe('delegated');
+    expect(result[1].delegation_type).toBeUndefined();
   });
 
   it('dedupes the same identifier across top-level and house shapes', () => {


### PR DESCRIPTION
Closes #4116

## Summary

PR #4106 hydrates brand.json properties into `/api/registry/publisher` but maps the `relationship` field to a string tag (`relationship:owned`) instead of a typed field. This PR adds `delegation_type?: "direct" | "delegated" | "ad_network"` to the brand.json-hydrated property shape, matching the adagents.json `delegation_type` enum so agentic buyers can filter by delegation relationship without parsing tag prefixes.

`owned` is intentionally excluded from `delegation_type`: brand.json `relationship: "owned"` has no adagents.json `delegation_type` counterpart (ownership is implicit from the publisher authoring their own manifest — there is no publisher-side confirmation step). The `relationship:` tag is retained for backward compat and marked deprecated in the OpenAPI description; tag removal is a follow-up.

Also hardens the tag emission path: the `relationship` field is publisher-controlled input and was previously written to tags unvalidated. Both the tag and `delegation_type` are now gated on membership in the known set of four enum values.

## Non-breaking justification

Adds optional `delegation_type` field to `PublisherPropertyFromBrandJson`, `ProjectedProperty`, and `PublisherPropertySchema`. All three changes are purely additive — existing callers that do not read the new field are unaffected. The `relationship:` tag continues to be emitted. Changeset is `--empty` (server-side registry API, not the published AdCP protocol spec in `static/schemas/source/`).

## Design note: `owned` → omit vs map to `direct`

The protocol expert recommended omitting `owned` (no bilateral-verification counterpart). The product expert raised mapping `owned` → `direct` as an alternative (functionally equivalent for buyer decision logic). This PR takes the conservative path (omit). If @bokelley prefers the `direct` mapping, it's a one-line change in `brand-json-properties.ts`.

## Pre-PR review

- **code-reviewer**: approved — no blockers after fixes; nit: `it.each` table for delegation_type test (noted, not blocking)
- **ad-tech-protocol-expert**: approved — non-breaking additive field; `direct` description corrected to match adagents.json canonical wording; source-scoping claim corrected to "populated only when" rather than "only present on"

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_014GS4dUJP2SGqhbHyZp9Qfu

---
_Generated by [Claude Code](https://claude.ai/code/session_014GS4dUJP2SGqhbHyZp9Qfu)_