### PR TITLE
fix(registry): reconcile aao_hosted properties on re-sync via source_type

### DIFF
--- a/.changeset/fix-hosted-property-source-reconciliation.md
+++ b/.changeset/fix-hosted-property-source-reconciliation.md
@@ -1,0 +1,4 @@
+---
+---
+
+Hosted-property sync now fully reconciles `discovered_properties` rows it owns. Previously the sync was additive-only because `discovered_properties` had no way to distinguish hosted-written rows from crawler-written rows. This fix uses the existing `source_type` column (added in migration 202) — the sync writes `source_type='aao_hosted'` on upsert and deletes stale `aao_hosted` rows on re-sync. Crawler rows (`source_type='adagents_json'`) are never touched. A publisher who removes a property from their hosted manifest will now see it disappear from the publisher page on the next sync rather than persisting indefinitely.

--- a/server/src/db/federated-index-db.ts
+++ b/server/src/db/federated-index-db.ts
@@ -76,6 +76,7 @@ export interface DiscoveredProperty {
   name: string;
   identifiers: PropertyIdentifier[];
   tags?: string[];
+  source_type?: 'adagents_json' | 'aao_hosted';
   discovered_at?: Date;
   last_validated?: Date;
   expires_at?: Date;
@@ -548,8 +549,8 @@ export class FederatedIndexDatabase {
   async upsertProperty(property: DiscoveredProperty): Promise<DiscoveredProperty> {
     const result = await query<DiscoveredProperty>(
       `INSERT INTO discovered_properties (
-         property_id, publisher_domain, property_type, name, identifiers, tags, expires_at
-       ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+         property_id, publisher_domain, property_type, name, identifiers, tags, source_type, expires_at
+       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
        ON CONFLICT (publisher_domain, name, property_type) DO UPDATE SET
          property_id = COALESCE(EXCLUDED.property_id, discovered_properties.property_id),
          identifiers = EXCLUDED.identifiers,
@@ -564,6 +565,7 @@ export class FederatedIndexDatabase {
         property.name,
         JSON.stringify(property.identifiers),
         property.tags || [],
+        property.source_type || 'adagents_json',
         property.expires_at || null,
       ]
     );

--- a/server/src/services/hosted-property-sync.ts
+++ b/server/src/services/hosted-property-sync.ts
@@ -107,6 +107,11 @@ export async function syncHostedPropertyToFederatedIndex(
   // crawler-written row ('adagents_json'), source_type is NOT updated —
   // the crawler's origin-verified label wins. Reconciliation below deletes
   // rows we own (source_type='aao_hosted') that are no longer in the manifest.
+  //
+  // We push the key before the try/catch (safe-side choice): if the upsert
+  // fails transiently, the row is still kept out of the delete set this pass,
+  // giving the next sync a chance to re-upsert it. The alternative (push on
+  // success only) would delete DB rows on transient errors and risk data loss.
   const validPropertyKeys: Array<{ name: string; property_type: string }> = [];
   for (const p of properties) {
     if (typeof p.name !== 'string' || !p.name) continue;

--- a/server/src/services/hosted-property-sync.ts
+++ b/server/src/services/hosted-property-sync.ts
@@ -23,11 +23,13 @@
  *    this publisher_domain. We own that source label exclusively;
  *    crawler-written `adagents_json` rows for the same domain are left
  *    untouched (they represent verified origin facts).
- *  - Properties: additive only. `discovered_properties` has no source
- *    column, so we cannot safely distinguish hosted-written rows from
- *    crawler-written rows. Removed properties persist until manually
- *    cleared. Tracked as a follow-up — adding a `source` column to
- *    `discovered_properties` would let us reconcile here too.
+ *  - Properties: full reconcile, scoped to `source_type='aao_hosted'`.
+ *    We write `source_type='aao_hosted'` on upsert; the crawler writes
+ *    `source_type='adagents_json'`. On conflict (same publisher_domain,
+ *    name, property_type), source_type is NOT updated — the crawler's
+ *    origin-verified label wins and the row is not managed by hosted
+ *    reconciliation. Rows exclusively written by this sync are deleted
+ *    when the manifest drops them.
  *  - Publisher row: keyed by stable sentinel (`AAO_HOSTED_SENTINEL`) so
  *    re-syncs collapse to the same row regardless of which agent is first
  *    in the manifest.
@@ -49,6 +51,7 @@ export const AAO_HOSTED_SENTINEL = 'aao://hosted';
 
 export interface HostedSyncResult {
   properties_synced: number;
+  properties_removed: number;
   agents_synced: number;
   authorizations_reconciled: number;
   authorizations_removed: number;
@@ -87,6 +90,7 @@ export async function syncHostedPropertyToFederatedIndex(
 ): Promise<HostedSyncResult> {
   const result: HostedSyncResult = {
     properties_synced: 0,
+    properties_removed: 0,
     agents_synced: 0,
     authorizations_reconciled: 0,
     authorizations_removed: 0,
@@ -99,17 +103,22 @@ export async function syncHostedPropertyToFederatedIndex(
   const agents = readAgents(adagents);
   const properties = readProperties(adagents);
 
-  // Properties: additive upsert (see file-level comment for why removal
-  // is not yet supported).
+  // Properties: upsert with source_type='aao_hosted'. On conflict with a
+  // crawler-written row ('adagents_json'), source_type is NOT updated —
+  // the crawler's origin-verified label wins. Reconciliation below deletes
+  // rows we own (source_type='aao_hosted') that are no longer in the manifest.
+  const validPropertyKeys: Array<{ name: string; property_type: string }> = [];
   for (const p of properties) {
     if (typeof p.name !== 'string' || !p.name) continue;
     const propType = typeof p.type === 'string' && p.type ? p.type : 'website';
+    validPropertyKeys.push({ name: p.name, property_type: propType });
     try {
       await fedDb.upsertProperty({
         property_id: typeof p.property_id === 'string' ? p.property_id : undefined,
         publisher_domain: domain,
         property_type: propType,
         name: p.name,
+        source_type: 'aao_hosted',
         identifiers: Array.isArray(p.identifiers)
           ? (p.identifiers as Array<{ type: string; value: string }>)
           : [],
@@ -120,6 +129,38 @@ export async function syncHostedPropertyToFederatedIndex(
       result.errors++;
       logger.warn({ err, domain, name: p.name }, 'Failed to upsert hosted property row');
     }
+  }
+
+  // Reconcile: delete (publisher_domain, source_type='aao_hosted') rows not
+  // in the current manifest, keyed on (name, property_type) to match the
+  // upsert conflict target. Crawler rows (source_type='adagents_json') are
+  // never touched. When the manifest is empty, delete all aao_hosted rows.
+  try {
+    const removeResult = validPropertyKeys.length > 0
+      ? await query(
+          `DELETE FROM discovered_properties
+            WHERE publisher_domain = $1
+              AND source_type = 'aao_hosted'
+              AND NOT EXISTS (
+                SELECT 1 FROM UNNEST($2::text[], $3::text[]) AS m(mn, mt)
+                 WHERE m.mn = discovered_properties.name
+                   AND m.mt = discovered_properties.property_type
+              )`,
+          [
+            domain,
+            validPropertyKeys.map(k => k.name),
+            validPropertyKeys.map(k => k.property_type),
+          ],
+        )
+      : await query(
+          `DELETE FROM discovered_properties
+            WHERE publisher_domain = $1 AND source_type = 'aao_hosted'`,
+          [domain],
+        );
+    result.properties_removed = removeResult.rowCount ?? 0;
+  } catch (err) {
+    result.errors++;
+    logger.warn({ err, domain }, 'Failed to reconcile hosted properties');
   }
 
   // Agents: upsert each, then reconcile authorizations.

--- a/server/tests/integration/hosted-property-fed-index-sync.test.ts
+++ b/server/tests/integration/hosted-property-fed-index-sync.test.ts
@@ -221,6 +221,102 @@ describe('Hosted property → federated index sync', () => {
     expect(res.body.authorized_agents[0].url).toBe(AGENT_X);
   });
 
+  it('reconciles properties on re-sync: properties removed from the manifest are deleted', async () => {
+    const initial = await propertyDb.createHostedProperty({
+      publisher_domain: PUB,
+      adagents_json: {
+        authorized_agents: [{ url: AGENT_X }],
+        properties: [
+          { type: 'website', name: PUB },
+          { type: 'mobile_app', name: `${PUB} app` },
+        ],
+      },
+      is_public: true,
+      source_type: 'community',
+    });
+    await syncHostedPropertyToFederatedIndex(initial);
+
+    // Sanity: both properties present.
+    let res = await request(app).get(
+      `/api/registry/publisher?domain=${encodeURIComponent(PUB)}`
+    );
+    expect(res.body.properties).toHaveLength(2);
+
+    // Re-sync with only one property — the other should be removed.
+    await pool.query(
+      `UPDATE hosted_properties SET adagents_json = $2 WHERE publisher_domain = $1`,
+      [PUB, JSON.stringify({
+        authorized_agents: [{ url: AGENT_X }],
+        properties: [{ type: 'website', name: PUB }],
+      })],
+    );
+    const updated = await propertyDb.getHostedPropertyByDomain(PUB);
+    if (!updated) throw new Error('expected hosted property to exist');
+    const result = await syncHostedPropertyToFederatedIndex(updated);
+    expect(result.properties_removed).toBe(1);
+
+    res = await request(app).get(
+      `/api/registry/publisher?domain=${encodeURIComponent(PUB)}`
+    );
+    expect(res.body.properties).toHaveLength(1);
+    expect(res.body.properties[0].name).toBe(PUB);
+  });
+
+  it('removes all aao_hosted properties when the manifest is emptied', async () => {
+    const initial = await propertyDb.createHostedProperty({
+      publisher_domain: PUB,
+      adagents_json: {
+        authorized_agents: [{ url: AGENT_X }],
+        properties: [{ type: 'website', name: PUB }],
+      },
+      is_public: true,
+      source_type: 'community',
+    });
+    await syncHostedPropertyToFederatedIndex(initial);
+
+    await pool.query(
+      `UPDATE hosted_properties SET adagents_json = $2 WHERE publisher_domain = $1`,
+      [PUB, JSON.stringify({ authorized_agents: [{ url: AGENT_X }], properties: [] })],
+    );
+    const updated = await propertyDb.getHostedPropertyByDomain(PUB);
+    if (!updated) throw new Error('expected hosted property to exist');
+    const result = await syncHostedPropertyToFederatedIndex(updated);
+    expect(result.properties_removed).toBe(1);
+
+    const res = await request(app).get(
+      `/api/registry/publisher?domain=${encodeURIComponent(PUB)}`
+    );
+    expect(res.body.properties).toHaveLength(0);
+  });
+
+  it('does not remove crawler-written properties when reconciling hosted rows', async () => {
+    // Simulate a crawler-written row by inserting with source_type='adagents_json'
+    await pool.query(
+      `INSERT INTO discovered_properties (publisher_domain, property_type, name, identifiers, source_type)
+       VALUES ($1, 'website', $2, '[]', 'adagents_json')
+       ON CONFLICT (publisher_domain, name, property_type) DO NOTHING`,
+      [PUB, `${PUB}-crawler-only`],
+    );
+
+    const hosted = await propertyDb.createHostedProperty({
+      publisher_domain: PUB,
+      adagents_json: {
+        authorized_agents: [{ url: AGENT_X }],
+        properties: [],  // empty — should not delete the crawler row
+      },
+      is_public: true,
+      source_type: 'community',
+    });
+    const result = await syncHostedPropertyToFederatedIndex(hosted);
+    expect(result.properties_removed).toBe(0);  // crawler row is untouched
+
+    const { rows } = await pool.query<{ name: string }>(
+      `SELECT name FROM discovered_properties WHERE publisher_domain = $1 AND source_type = 'adagents_json'`,
+      [PUB],
+    );
+    expect(rows.some(r => r.name === `${PUB}-crawler-only`)).toBe(true);
+  });
+
   it('skips entries without required fields without throwing', async () => {
     const hosted = await propertyDb.createHostedProperty({
       publisher_domain: PUB,


### PR DESCRIPTION
Refs #4111

## Summary

Publishers who remove a property from their hosted manifest were seeing it persist on the publisher page until manually cleared. The hosted-property sync was additive-only because `discovered_properties` had no usable source marker.

This PR uses the existing `source_type TEXT DEFAULT 'adagents_json'` column (added in migration 202) rather than adding a new `source` column as originally proposed. The hosted sync now writes `source_type='aao_hosted'` on upsert and deletes stale `aao_hosted` rows on re-sync. Crawler rows (`source_type='adagents_json'`) are never touched.

**Implementation note vs. original issue:** Issue #4111 proposed adding a new `source` column with `'crawler'`/`'aao_hosted'` vocabulary. Migration 202 already added `source_type TEXT DEFAULT 'adagents_json'` to `discovered_properties`, and two registry queries (`getAllPropertiesForRegistry`, `getPropertyRegistryStats`) already filter on `source_type = 'adagents_json'`. Adding a second column would leave the table with two overlapping origin-tracking columns with different vocabularies. This PR extends the existing column instead.

**Non-breaking justification:** No new columns or tables. The only SQL change is that `upsertProperty` now explicitly passes `source_type` (defaulting to `'adagents_json'` when not provided), so the DB value is set explicitly rather than via the column default. Existing caller behaviour is unchanged. Crawler rows remain `source_type='adagents_json'`.

**Key design decisions:**

- Unique constraint stays at `(publisher_domain, name, property_type)` — no change. A property present in both the crawler index and a hosted manifest keeps its crawler-sourced row (`adagents_json`); the hosted sync's reconciliation won't touch it. This is intentional: the crawler's origin-verified label wins.
- `source_type` is NOT in the `ON CONFLICT DO UPDATE SET` — ensuring the crawler's `adagents_json` label is never downgraded.
- Reconciliation keys on `(name, property_type)` pairs, not `property_id` (which is nullable). Uses a `UNNEST`-based composite exclusion to correctly handle properties sharing a name across types.
- `validPropertyKeys.push` runs before the `try/catch` (documented in code): if an upsert fails transiently, the key stays in the keep-set so the stale DB row is not deleted on this pass — giving the next sync a chance to re-upsert. The safe-side choice.

**Known limitation (pre-existing, not introduced here):** The full sync function does not run inside a transaction. The existing authorization reconciliation has the same architecture. A concurrent sync for the same domain could race. In practice the sync is triggered by single-actor publisher updates; wrapping the full function in a transaction is a follow-up that requires refactoring `FederatedIndexDatabase` to accept a transaction-scoped client.

## Changes

- `server/src/db/federated-index-db.ts`: Add `source_type?: 'adagents_json' | 'aao_hosted'` to `DiscoveredProperty` interface; update `upsertProperty` SQL to write `source_type` explicitly.
- `server/src/services/hosted-property-sync.ts`: Pass `source_type: 'aao_hosted'` in upsert calls; add property reconciliation (mirroring the existing auth reconciliation); add `properties_removed` to `HostedSyncResult`; update file-level reconciliation semantics comment.
- `server/tests/integration/hosted-property-fed-index-sync.test.ts`: Three new integration tests — partial reconcile, empty-manifest full clear, crawler-row isolation.

## Pre-PR review

- code-reviewer: approved — no blockers; noted push-before-upsert ordering (addressed with explanatory comment), UNNEST composite exclusion correct
- internal-tools-strategist: approved correctness of UNNEST exclusion and empty-manifest branch; flagged concurrency gap (pre-existing, documented above)

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01BrwStUhPtFoxWMRkWMvytQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrwStUhPtFoxWMRkWMvytQ)_