### PR TITLE
feat(aao): signed envelope on AAO-hosted adagents.json

### DIFF
--- a/.changeset/aao-hosted-adagents-signed-envelope.md
+++ b/.changeset/aao-hosted-adagents-signed-envelope.md
@@ -1,0 +1,54 @@
+---
+---
+
+AAO-hosted adagents.json documents now carry an `_aao_envelope` field
+with an Ed25519-signed JWS attesting AAO provenance. Closes #4110.
+
+The TLS chain on `aao.scope3.com/publisher/{domain}/.well-known/adagents.json`
+ends at AAO rather than the publisher, which strict buy-side verifiers
+treat as a soft trust signal. The envelope adds a second attestation
+channel: AAO signs the document body with a published key, so a
+verifier with AAO's JWKS can confirm provenance independently of TLS.
+
+Envelope shape:
+
+```json
+{
+  "authorized_agents": [...],
+  "properties": [...],
+  "_aao_envelope": {
+    "jws": "<compact JWT — payload IS the canonical document body>",
+    "key_id": "aao-document-1",
+    "issued_at": "2026-05-05T00:00:00Z",
+    "expires_at": "2026-05-12T00:00:00Z",
+    "publisher_domain": "example.com",
+    "verification": "Decode the JWS; payload is canonical; verify against /.well-known/jwks.json (kid=aao-document-1, adcp_use=aao-document-signing); confirm iss/aud/sub."
+  }
+}
+```
+
+Verifier recipe: decode `envelope.jws`, treat its JWT payload as the
+canonical document, verify the signature against the JWKS at
+`/.well-known/jwks.json` (kid=`aao-document-1`,
+adcp_use=`aao-document-signing`), confirm `iss=https://aao.org`,
+`aud=aao-hosted-adagents`, `sub` matches the publisher_domain in the
+URL.
+
+New env vars (Fly secrets in production):
+
+- `AAO_DOCUMENT_SIGNING_PRIVATE_KEY` — base64-encoded PKCS8 PEM, Ed25519
+- `AAO_DOCUMENT_SIGNING_PUBLIC_KEY` — base64-encoded SPKI PEM, Ed25519
+
+When unset, hosted documents are served unsigned (existing behaviour) —
+the route falls through gracefully so dev / non-signing deployments
+continue to work.
+
+The published JWKS at `/.well-known/jwks.json` now lists three keys
+(request-signing, webhook-signing, aao-document-signing) when the
+envelope key is configured. Otherwise it lists the existing two.
+
+Origin verification (#4109) is the next step — AAO-signed envelope
+attests AAO hosts the document; origin verification will let us promote
+the corresponding `agent_publisher_authorizations` rows from
+`source='aao_hosted'` to `source='adagents_json'` once the publisher's
+own /.well-known confirms the redirect.

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -19,6 +19,7 @@ import { createLogger, processRole } from "./logger.js";
 import { CapabilityDiscovery } from "./capabilities.js";
 import { inferDiagnosticAgentType } from "./lib/diagnostic-agent-type-inference.js";
 import { getPublicSigningJwks } from "./security/jwks.js";
+import { signHostedAdagentsDocument } from "./services/aao-document-signer.js";
 import { PublisherTracker } from "./publishers.js";
 import { PropertiesService } from "./properties.js";
 import { AdAgentsManager } from "./adagents-manager.js";
@@ -3051,10 +3052,20 @@ export class HTTPServer {
         if (!hosted || !hosted.is_public) {
           return res.status(404).json({ error: 'No AAO-hosted adagents.json for this domain', domain });
         }
+        // Embed an AAO-signed envelope so verifiers have a provenance
+        // signal that doesn't depend on the TLS chain (which terminates
+        // at AAO). The JWS payload IS the canonical document body —
+        // verifiers decode the JWT and trust that payload over the outer
+        // wrapper. When signing is disabled (no env keys), we fall back
+        // to serving the unsigned document; existing consumers continue
+        // to work.
+        const body = { ...(hosted.adagents_json || {}) } as Record<string, unknown>;
+        const envelope = await signHostedAdagentsDocument(body, domain);
+        if (envelope) body._aao_envelope = envelope;
         res.setHeader('Content-Type', 'application/json');
         res.setHeader('Access-Control-Allow-Origin', '*');
         res.setHeader('Cache-Control', 'public, max-age=300');
-        return res.json(hosted.adagents_json);
+        return res.json(body);
       } catch (error) {
         logger.error({ error }, 'Failed to serve hosted adagents.json');
         return res.status(500).json({ error: 'Failed to serve adagents.json' });

--- a/server/src/security/jwks.ts
+++ b/server/src/security/jwks.ts
@@ -13,12 +13,14 @@
  */
 
 import { createPublicKey } from 'node:crypto';
+import type { JWK } from 'jose';
 import {
   REQUEST_SIGNING_PUBLIC_KEY_PEM,
   REQUEST_SIGNING_KID,
   WEBHOOK_SIGNING_PUBLIC_KEY_PEM,
   WEBHOOK_SIGNING_KID,
 } from './expected-public-key.js';
+import { getDocumentSigningJwk } from '../services/aao-document-signer.js';
 
 interface PublicJwk {
   kty: string;
@@ -34,14 +36,34 @@ interface PublicJwk {
 let cached: { keys: PublicJwk[] } | null = null;
 
 export function getPublicSigningJwks(): { keys: PublicJwk[] } {
-  if (cached) return cached;
-  cached = {
-    keys: [
-      pemToAdcpJwk(REQUEST_SIGNING_PUBLIC_KEY_PEM, REQUEST_SIGNING_KID, 'request-signing'),
-      pemToAdcpJwk(WEBHOOK_SIGNING_PUBLIC_KEY_PEM, WEBHOOK_SIGNING_KID, 'webhook-signing'),
-    ],
+  // The static request/webhook JWKs are derived once and cached. The
+  // document-signing JWK is conditionally appended each call so the JWKS
+  // accurately reflects whether the env-based signing key is loaded
+  // (otherwise dev / non-signing deployments would publish a phantom key).
+  if (!cached) {
+    cached = {
+      keys: [
+        pemToAdcpJwk(REQUEST_SIGNING_PUBLIC_KEY_PEM, REQUEST_SIGNING_KID, 'request-signing'),
+        pemToAdcpJwk(WEBHOOK_SIGNING_PUBLIC_KEY_PEM, WEBHOOK_SIGNING_KID, 'webhook-signing'),
+      ],
+    };
+  }
+  const documentJwk = getDocumentSigningJwk();
+  if (!documentJwk) return cached;
+  // Best-effort cast: jose's JWK type widens to include all fields, but
+  // our published shape is narrower. The signer guarantees the four
+  // OKP/Ed25519 fields plus `adcp_use` so the cast is safe at runtime.
+  const docKey: PublicJwk = {
+    kty: documentJwk.kty as string,
+    crv: documentJwk.crv as string,
+    x: documentJwk.x as string,
+    kid: documentJwk.kid as string,
+    alg: documentJwk.alg as string,
+    use: documentJwk.use as string,
+    adcp_use: (documentJwk as JWK & { adcp_use: string }).adcp_use,
+    key_ops: ['verify'],
   };
-  return cached;
+  return { keys: [...cached.keys, docKey] };
 }
 
 function pemToAdcpJwk(pem: string, kid: string, adcpUse: 'request-signing' | 'webhook-signing'): PublicJwk {

--- a/server/src/services/aao-document-signer.ts
+++ b/server/src/services/aao-document-signer.ts
@@ -1,0 +1,200 @@
+/**
+ * AAO Document Signer — JWS envelope for AAO-hosted adagents.json documents.
+ *
+ * When AAO hosts a publisher's adagents.json (`aao.scope3.com/publisher/
+ * {domain}/.well-known/adagents.json`), the TLS chain ends at AAO rather
+ * than the publisher. Strict buy-side verifiers (TTD/DV360 verification,
+ * IAB compliance scans) treat that as a soft trust signal because
+ * adagents.json's value proposition rests on "the publisher's own
+ * DNS+TLS attests this list."
+ *
+ * This signer adds a second attestation channel: AAO signs the document
+ * body with a published key. The signed envelope is embedded in the
+ * served document as `_aao_envelope.jws`. A verifier with AAO's JWKS can
+ * confirm provenance independently of the TLS chain.
+ *
+ * Key separation: AdCP receivers enforce key purpose at the JWK
+ * `adcp_use` field (per docs/guides/SIGNING-GUIDE.md § Key separation).
+ * This service publishes an `adcp_use='aao-document-signing'` key,
+ * distinct from request-signing / webhook-signing / aao-verification.
+ *
+ * Envelope shape (verifier recipe):
+ *   1. Decode envelope.jws (compact JWT). The JWT payload IS the
+ *      canonical adagents.json document body.
+ *   2. Verify the JWT signature against the JWKS published at
+ *      `/.well-known/jwks.json` with `kid` from the protected header
+ *      and `adcp_use='aao-document-signing'`.
+ *   3. Validate claims: `iss=https://aao.org`, `aud=aao-hosted-adagents`,
+ *      `sub` matches the publisher_domain in the URL path, `exp` not
+ *      passed, `iat` not in the future.
+ *   4. Trust the JWT payload as the canonical document.
+ *
+ * Disabled when the env keys are unset — the route falls back to
+ * serving the unsigned document (existing behaviour). This keeps dev
+ * boots working without the secret material.
+ */
+
+import * as jose from 'jose';
+import { randomUUID } from 'node:crypto';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('aao-document-signer');
+
+const ISSUER = 'https://aao.org';
+const AUDIENCE = 'aao-hosted-adagents';
+const ALG = 'EdDSA';
+const KID = 'aao-document-1';
+const ADCP_USE = 'aao-document-signing';
+/** Documents are short-lived to bound replay risk on a stale signature. */
+const ENVELOPE_LIFETIME_SECONDS = 7 * 24 * 60 * 60; // 7 days
+
+let signingKey: jose.CryptoKey | undefined;
+let verifyingKey: jose.CryptoKey | undefined;
+let publicJwk: jose.JWK | undefined;
+let initAttempted = false;
+let initInFlight: Promise<boolean> | null = null;
+
+export interface AaoDocumentEnvelope {
+  jws: string;
+  key_id: string;
+  issued_at: string;
+  expires_at: string;
+  publisher_domain: string;
+  verification: string;
+}
+
+/**
+ * Initialize keys from environment. Call once at server startup.
+ *
+ * Expects AAO_DOCUMENT_SIGNING_PRIVATE_KEY (base64-encoded PKCS8 PEM,
+ * Ed25519) and AAO_DOCUMENT_SIGNING_PUBLIC_KEY (base64-encoded SPKI PEM).
+ * If unset, signing is disabled and the hosted route serves the
+ * unsigned document.
+ *
+ * Returns true if keys initialized successfully, false otherwise.
+ */
+export async function initAaoDocumentSigningKey(): Promise<boolean> {
+  if (initInFlight) return initInFlight;
+  if (initAttempted) return !!signingKey;
+  initInFlight = doInit();
+  const result = await initInFlight;
+  initInFlight = null;
+  initAttempted = true;
+  return result;
+}
+
+async function doInit(): Promise<boolean> {
+  const privateKeyB64 = process.env.AAO_DOCUMENT_SIGNING_PRIVATE_KEY;
+  const publicKeyB64 = process.env.AAO_DOCUMENT_SIGNING_PUBLIC_KEY;
+
+  if (!privateKeyB64 || !publicKeyB64) {
+    logger.info('AAO document signing keys not configured — hosted documents will be served unsigned');
+    return false;
+  }
+
+  try {
+    const privatePem = Buffer.from(privateKeyB64, 'base64').toString('utf8');
+    const publicPem = Buffer.from(publicKeyB64, 'base64').toString('utf8');
+    signingKey = await jose.importPKCS8(privatePem, ALG);
+    verifyingKey = await jose.importSPKI(publicPem, ALG);
+    publicJwk = await jose.exportJWK(verifyingKey);
+    publicJwk.alg = ALG;
+    publicJwk.use = 'sig';
+    publicJwk.kid = KID;
+    (publicJwk as jose.JWK & { adcp_use: string }).adcp_use = ADCP_USE;
+    logger.info({ kid: KID, adcp_use: ADCP_USE }, 'AAO document signing key initialized');
+    return true;
+  } catch (err) {
+    logger.error({ err }, 'Failed to initialize AAO document signing key');
+    return false;
+  }
+}
+
+/**
+ * Sign an adagents.json document body for a given publisher_domain.
+ * Returns the full envelope object to embed in the served document, or
+ * null when signing is disabled.
+ *
+ * The JWT payload is the document body itself — verifiers decode the
+ * JWT and use that payload as canonical, avoiding any JSON-canonicalization
+ * fragility around the outer wrapper.
+ */
+export async function signHostedAdagentsDocument(
+  body: Record<string, unknown>,
+  publisherDomain: string,
+): Promise<AaoDocumentEnvelope | null> {
+  // Lazy init on first call. Idempotent — concurrent first-callers share
+  // a single init promise. Subsequent calls return immediately.
+  if (!signingKey && !initAttempted) await initAaoDocumentSigningKey();
+  if (!signingKey) return null;
+  const now = Math.floor(Date.now() / 1000);
+  const exp = now + ENVELOPE_LIFETIME_SECONDS;
+
+  const jws = await new jose.SignJWT(body as jose.JWTPayload)
+    .setProtectedHeader({ alg: ALG, kid: KID, typ: 'JWT' })
+    .setIssuer(ISSUER)
+    .setSubject(publisherDomain)
+    .setAudience(AUDIENCE)
+    .setJti(randomUUID())
+    .setIssuedAt(now)
+    .setExpirationTime(exp)
+    .sign(signingKey);
+
+  return {
+    jws,
+    key_id: KID,
+    issued_at: new Date(now * 1000).toISOString(),
+    expires_at: new Date(exp * 1000).toISOString(),
+    publisher_domain: publisherDomain,
+    verification:
+      `Decode envelope.jws (compact JWT) — its payload is the canonical document. ` +
+      `Verify the signature against /.well-known/jwks.json (kid=${KID}, adcp_use=${ADCP_USE}). ` +
+      `Confirm iss=${ISSUER}, aud=${AUDIENCE}, sub matches the publisher_domain in the request URL.`,
+  };
+}
+
+/**
+ * Verify an envelope's JWS and return the canonical payload, or null on
+ * any failure (signature, claims, expiry). Exposed for tests and for
+ * future origin-verification flows that need to confirm a hosted
+ * document came from us.
+ */
+export async function verifyHostedAdagentsDocument(
+  jws: string,
+  expectedPublisherDomain: string,
+): Promise<Record<string, unknown> | null> {
+  if (!verifyingKey) return null;
+  try {
+    const { payload } = await jose.jwtVerify(jws, verifyingKey, {
+      issuer: ISSUER,
+      audience: AUDIENCE,
+      subject: expectedPublisherDomain,
+    });
+    return payload as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns the public JWK for the document-signing key, or null when not
+ * initialized. Consumed by the JWKS publication path so the canonical
+ * `/.well-known/jwks.json` advertises the key alongside the request- and
+ * webhook-signing keys.
+ */
+export function getDocumentSigningJwk(): jose.JWK | null {
+  return publicJwk ?? null;
+}
+
+export function isAaoDocumentSigningEnabled(): boolean {
+  return !!signingKey;
+}
+
+/** @internal Reset module state for testing. */
+export function _resetForTesting(): void {
+  signingKey = undefined;
+  verifyingKey = undefined;
+  publicJwk = undefined;
+  initAttempted = false;
+  initInFlight = null;
+}

--- a/server/tests/integration/publisher-hosted-adagents-route.test.ts
+++ b/server/tests/integration/publisher-hosted-adagents-route.test.ts
@@ -13,6 +13,16 @@ vi.hoisted(() => {
   process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
 });
 
+// Generate ephemeral signing keys for the AAO document signer so the
+// route emits an `_aao_envelope`. The keys are set BEFORE imports so
+// the lazy init inside the signer picks them up on first call.
+async function generateSigningKeysAndSetEnv(): Promise<void> {
+  const { generateKeyPair, exportPKCS8, exportSPKI } = await import('jose');
+  const { publicKey, privateKey } = await generateKeyPair('EdDSA', { crv: 'Ed25519', extractable: true });
+  process.env.AAO_DOCUMENT_SIGNING_PRIVATE_KEY = Buffer.from(await exportPKCS8(privateKey), 'utf8').toString('base64');
+  process.env.AAO_DOCUMENT_SIGNING_PUBLIC_KEY = Buffer.from(await exportSPKI(publicKey), 'utf8').toString('base64');
+}
+
 vi.mock('../../src/middleware/auth.js', async () => {
   const actual = await vi.importActual<Record<string, unknown>>(
     '../../src/middleware/auth.js'
@@ -106,7 +116,54 @@ describe('AAO-hosted /publisher/{domain}/.well-known/adagents.json', () => {
     expect(res.status).toBe(200);
     expect(res.headers['content-type']).toMatch(/^application\/json/);
     expect(res.headers['access-control-allow-origin']).toBe('*');
-    expect(res.body).toEqual(adagents);
+    // Body wraps the adagents.json content; envelope may or may not be
+    // present depending on whether signing keys were configured. The
+    // adagents fields must always round-trip.
+    expect(res.body).toMatchObject(adagents);
+  });
+
+  it('embeds an _aao_envelope when document-signing keys are configured', async () => {
+    await generateSigningKeysAndSetEnv();
+    // Reset signer state so the lazy init re-reads env vars from this test.
+    const { _resetForTesting } = await import('../../src/services/aao-document-signer.js');
+    _resetForTesting();
+
+    const adagents = {
+      authorized_agents: [{ url: 'https://agent.example.com', authorized_for: 'all' }],
+      properties: [{ type: 'website', name: PUB_PUBLIC }],
+    };
+    await propertyDb.createHostedProperty({
+      publisher_domain: PUB_PUBLIC,
+      adagents_json: adagents,
+      is_public: true,
+      source_type: 'community',
+    });
+
+    const res = await request(app).get(
+      `/publisher/${encodeURIComponent(PUB_PUBLIC)}/.well-known/adagents.json`
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject(adagents);
+    expect(res.body._aao_envelope).toBeDefined();
+    expect(res.body._aao_envelope).toMatchObject({
+      key_id: 'aao-document-1',
+      publisher_domain: PUB_PUBLIC,
+    });
+    expect(typeof res.body._aao_envelope.jws).toBe('string');
+    expect(res.body._aao_envelope.jws.split('.').length).toBe(3);
+
+    // Verify the JWS round-trips: the payload IS the canonical document.
+    const { jwtVerify, importJWK } = await import('jose');
+    const { getDocumentSigningJwk } = await import('../../src/services/aao-document-signer.js');
+    const jwk = getDocumentSigningJwk();
+    expect(jwk).not.toBeNull();
+    const key = await importJWK(jwk!, 'EdDSA');
+    const { payload } = await jwtVerify(res.body._aao_envelope.jws, key, {
+      issuer: 'https://aao.org',
+      audience: 'aao-hosted-adagents',
+      subject: PUB_PUBLIC,
+    });
+    expect(payload).toMatchObject(adagents);
   });
 
   it('returns 404 when the hosted property exists but is_public=false', async () => {

--- a/server/tests/unit/aao-document-signer.test.ts
+++ b/server/tests/unit/aao-document-signer.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit coverage for the AAO document signer. Generates ephemeral
+ * Ed25519 keys per test, sets the env vars the signer reads, then
+ * exercises the round-trip: sign → embed envelope → verify → recover
+ * canonical payload.
+ */
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import { generateKeyPair, exportJWK, jwtVerify, importJWK } from 'jose';
+import {
+  signHostedAdagentsDocument,
+  verifyHostedAdagentsDocument,
+  initAaoDocumentSigningKey,
+  isAaoDocumentSigningEnabled,
+  getDocumentSigningJwk,
+  _resetForTesting,
+} from '../../src/services/aao-document-signer.js';
+
+async function generateAndSetKeys(): Promise<void> {
+  const { publicKey, privateKey } = await generateKeyPair('EdDSA', { crv: 'Ed25519', extractable: true });
+  // jose's exportPKCS8/exportSPKI return PEM strings. The signer expects
+  // base64-encoded PEM (env-var pattern), so wrap them.
+  const { exportPKCS8, exportSPKI } = await import('jose');
+  const privatePem = await exportPKCS8(privateKey);
+  const publicPem = await exportSPKI(publicKey);
+  process.env.AAO_DOCUMENT_SIGNING_PRIVATE_KEY = Buffer.from(privatePem, 'utf8').toString('base64');
+  process.env.AAO_DOCUMENT_SIGNING_PUBLIC_KEY = Buffer.from(publicPem, 'utf8').toString('base64');
+}
+
+describe('AAO document signer', () => {
+  beforeEach(() => {
+    _resetForTesting();
+    delete process.env.AAO_DOCUMENT_SIGNING_PRIVATE_KEY;
+    delete process.env.AAO_DOCUMENT_SIGNING_PUBLIC_KEY;
+  });
+
+  it('returns null when env keys are not configured', async () => {
+    const result = await signHostedAdagentsDocument({ authorized_agents: [] }, 'example.com');
+    expect(result).toBeNull();
+    expect(isAaoDocumentSigningEnabled()).toBe(false);
+    expect(getDocumentSigningJwk()).toBeNull();
+  });
+
+  describe('with ephemeral keys', () => {
+    beforeAll(async () => {
+      await generateAndSetKeys();
+    });
+
+    beforeEach(async () => {
+      _resetForTesting();
+      await generateAndSetKeys();
+      await initAaoDocumentSigningKey();
+    });
+
+    it('signs a document and the JWS payload round-trips back to the input body', async () => {
+      const body = {
+        $schema: 'https://example/adagents.json',
+        authorized_agents: [{ url: 'https://agent.example', authorized_for: 'all' }],
+        properties: [{ type: 'website', name: 'example.com' }],
+      };
+      const env = await signHostedAdagentsDocument(body, 'example.com');
+      expect(env).not.toBeNull();
+      expect(env?.key_id).toBe('aao-document-1');
+      expect(env?.publisher_domain).toBe('example.com');
+      expect(env?.jws.split('.').length).toBe(3); // header.payload.signature
+
+      const recovered = await verifyHostedAdagentsDocument(env!.jws, 'example.com');
+      expect(recovered).not.toBeNull();
+      expect(recovered).toMatchObject(body);
+    });
+
+    it('rejects verification when sub does not match the expected publisher_domain', async () => {
+      const env = await signHostedAdagentsDocument({ authorized_agents: [] }, 'real.example');
+      expect(env).not.toBeNull();
+      const result = await verifyHostedAdagentsDocument(env!.jws, 'attacker.example');
+      expect(result).toBeNull();
+    });
+
+    it('exposes the public JWK with adcp_use=aao-document-signing for JWKS publication', () => {
+      const jwk = getDocumentSigningJwk();
+      expect(jwk).not.toBeNull();
+      expect(jwk).toMatchObject({
+        kty: 'OKP',
+        crv: 'Ed25519',
+        alg: 'EdDSA',
+        use: 'sig',
+        kid: 'aao-document-1',
+        adcp_use: 'aao-document-signing',
+      });
+    });
+
+    it('JWS protected header carries the kid an external verifier needs', async () => {
+      const env = await signHostedAdagentsDocument({ authorized_agents: [] }, 'example.com');
+      expect(env).not.toBeNull();
+      const headerB64 = env!.jws.split('.')[0];
+      const header = JSON.parse(Buffer.from(headerB64, 'base64url').toString('utf8'));
+      expect(header).toMatchObject({ alg: 'EdDSA', kid: 'aao-document-1', typ: 'JWT' });
+    });
+
+    it('appears in the canonical JWKS publication alongside request- and webhook-signing keys', async () => {
+      const { getPublicSigningJwks, resetJwksForTests } = await import('../../src/security/jwks.js');
+      resetJwksForTests();
+      const jwks = getPublicSigningJwks();
+      const kids = jwks.keys.map((k) => k.kid);
+      expect(kids).toContain('aao-document-1');
+      const docKey = jwks.keys.find((k) => k.kid === 'aao-document-1');
+      expect(docKey?.adcp_use).toBe('aao-document-signing');
+      expect(docKey?.kty).toBe('OKP');
+      expect(docKey?.crv).toBe('Ed25519');
+    });
+
+    it('an external verifier can verify the JWS using only the published JWK', async () => {
+      // Mimics what a buy-side verifier would do: fetch JWKS, find the
+      // key by kid, verify the JWS without any AAO server-side helper.
+      const body = { authorized_agents: [{ url: 'https://agent.example' }] };
+      const env = await signHostedAdagentsDocument(body, 'example.com');
+      expect(env).not.toBeNull();
+      const jwk = getDocumentSigningJwk()!;
+      const externalKey = await importJWK(jwk, 'EdDSA');
+      const { payload } = await jwtVerify(env!.jws, externalKey, {
+        issuer: 'https://aao.org',
+        audience: 'aao-hosted-adagents',
+        subject: 'example.com',
+      });
+      expect(payload).toMatchObject(body);
+    });
+  });
+});


### PR DESCRIPTION
Closes #4110.

## Summary

AAO-hosted `adagents.json` documents now carry an `_aao_envelope` field with an Ed25519-signed JWS attesting AAO provenance. Closes the buy-side trust gap that #4106's expert reviewers flagged: TLS terminates at AAO on hosted documents, and strict verifiers treat that as a soft trust signal. The signed envelope is a second attestation channel independent of the TLS chain.

## Envelope shape

```json
{
  "authorized_agents": [...],
  "properties": [...],
  "_aao_envelope": {
    "jws": "<compact JWT — payload IS the canonical document body>",
    "key_id": "aao-document-1",
    "issued_at": "2026-05-05T00:00:00Z",
    "expires_at": "2026-05-12T00:00:00Z",
    "publisher_domain": "example.com",
    "verification": "<inline recipe>"
  }
}
```

## Verifier recipe

1. Decode `envelope.jws` (compact JWT). The JWT payload IS the canonical document body.
2. Verify the signature against the JWKS at `/.well-known/jwks.json` (`kid=aao-document-1`, `adcp_use=aao-document-signing`).
3. Confirm claims: `iss=https://aao.org`, `aud=aao-hosted-adagents`, `sub` matches the publisher_domain in the URL.
4. Trust the JWT payload as the canonical document.

## Key separation

Per the AdCP signing rule (one `cryptoKeyVersion` per signing purpose; receivers enforce at the JWK `adcp_use` field), this introduces a distinct `aao-document-signing` purpose. The published JWKS at `/.well-known/jwks.json` now lists three keys when the document-signing key is configured: `request-signing`, `webhook-signing`, `aao-document-signing`.

## New env vars (Fly secrets in production)

- `AAO_DOCUMENT_SIGNING_PRIVATE_KEY` — base64-encoded PKCS8 PEM, Ed25519
- `AAO_DOCUMENT_SIGNING_PUBLIC_KEY` — base64-encoded SPKI PEM, Ed25519

When unset, hosted documents are served unsigned (existing behaviour). The route falls through gracefully so dev / non-signing deployments continue to work.

## Out of scope (tracked separately)

- **#4109** — Origin verification flow. AAO-signed envelope attests "AAO is hosting this document"; origin verification will let us promote `agent_publisher_authorizations` rows from `source='aao_hosted'` to `source='adagents_json'` once the publisher's `/.well-known` confirms the redirect.

## Test plan

- [x] `npm run typecheck` clean
- [x] 77 tests across the related set: 6 new unit tests for the signer (round-trip, sub-mismatch rejection, JWS header inspection, JWKS publication, external-verifier round-trip), 1 new integration test on the hosted route (envelope present, JWS verifies, payload matches served body)
- [x] Pre-existing tests for the unsigned fallback path still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)