### PR TITLE
feat(aao): publisher page celebrates what's there + auto-crawl on view

### DIFF
--- a/.changeset/publisher-page-celebrate-files-and-auto-crawl.md
+++ b/.changeset/publisher-page-celebrate-files-and-auto-crawl.md
@@ -59,3 +59,30 @@ Playwright across three persona states (brand-only, AAO-hosted,
 cold visitor) — hero cards render correctly, hosting panel auto-opens
 when nothing's set up and stays collapsed when there's a working
 record. Zero console errors.
+
+Security review fixes
+---------------------
+
+Two Must Fix items from the security review addressed:
+
+1. **SSRF gate on auto-crawl**: auto-crawl now runs `validateCrawlDomain`
+   (DNS resolution + private-IP check) before invoking the crawler.
+   Previously, an unauthenticated `?domain=internal.svc.cluster.local`
+   could turn into an internal-network probe via AAO's egress.
+2. **IP rate limit**: `/api/registry/publisher` now uses the existing
+   `agentReadRateLimiter` (240 req/min per IP, IPv6 /64-masked).
+   Previously, an attacker iterating distinct hostnames could turn AAO
+   into an HTTP probe-from-the-cloud reflector.
+
+Plus reviewer-flagged correctness fixes: `crawlSingleDomain` already
+calls `scanBrandForDomain` internally so we no longer double-fire,
+cleanup-interval threshold is now 2× the debounce window to avoid the
+boundary race that let domains re-fire mid-window, IP is logged on
+auto-crawl warnings.
+
+Out of scope (filed as #4129): migrate `adagents-manager` and
+`brand-manager` from plain axios to `safeFetch` for connect-time DNS-
+rebind defense. This PR's `validateCrawlDomain` gate catches the obvious
+internal-name case but `safeFetch`'s connect-time `lookup` hook is
+needed to close the rebind TOCTOU window. Out of scope here because it
+touches the scheduled-crawler call sites too.

--- a/.changeset/publisher-page-celebrate-files-and-auto-crawl.md
+++ b/.changeset/publisher-page-celebrate-files-and-auto-crawl.md
@@ -1,0 +1,61 @@
+---
+---
+
+Publisher page now leads with what AAO actually found at the publisher's
+origin, and a human visit triggers an auto-crawl when we don't have
+fresh data. Setup advice is demoted into a collapsible panel.
+
+Why
+---
+
+The previous page led with hosting-model framing ("AAO-hosted",
+"Self-hosted", "Not yet configured") even when the publisher already
+had a working `adagents.json` and `brand.json`. The actual signal a
+publisher (or a buyer) wants to see is "you have a valid adagents.json,
+N agents are authorized" — celebrate the record, not lecture about
+hosting models.
+
+What changed
+------------
+
+**API**
+- New `files: { adagents_json: { status, expected_url }, brand_json:
+  { status, name? } }` block on `/api/registry/publisher`. Status is
+  one of `valid` / `invalid` / `unknown` / `checking` (or
+  `present` / `unknown` / `checking` for brand).
+- New `auto_crawl_triggered: true` flag set when the request kicked off
+  a background fetch of the publisher's `/.well-known/adagents.json`
+  and `/.well-known/brand.json`. Debounced 5min/domain so a tight
+  refresh loop doesn't hammer the crawler.
+- Auto-crawl fires when `adagents_valid === null` (never crawled) OR
+  no brand record exists. Fire-and-forget — the response returns
+  immediately.
+
+**Page (`/publisher/:domain`)**
+- New hero "What we found at this domain" panel as the page lead.
+  Renders one card per file we checked: green check + counts when
+  valid, red ! with validation errors link when invalid, spinner when
+  checking, neutral em-dash with builder CTA when never set up.
+- Hosting setup details now live in a `<details>` collapsed by default
+  when the publisher already has a working file; auto-expanded when
+  `mode === 'none'` or `'self_invalid'` so setup advice stays visible
+  for publishers who need it.
+- Page polls itself ~4s after an auto-crawl trigger so the spinner
+  cards refresh into real content without a manual reload.
+- The cold-state "explainer" banner is retired — the hero panel
+  handles cold-visitor context inline alongside the file cards.
+
+Tests
+-----
+
+2 new integration tests: auto-crawl flag set on first lookup of an
+unknown domain, debounce on second hit, files.brand_json.status mirrors
+the brand record. 56 total pass across the related set.
+
+Smoke
+-----
+
+Playwright across three persona states (brand-only, AAO-hosted,
+cold visitor) — hero cards render correctly, hosting panel auto-opens
+when nothing's set up and stays collapsed when there's a working
+record. Zero console errors.

--- a/server/public/publisher-home.html
+++ b/server/public/publisher-home.html
@@ -174,6 +174,73 @@
         border: var(--border-1) solid var(--color-border);
       }
 
+      /* Hero "what we found" card grid. */
+      .hero-files {
+        background: linear-gradient(135deg, var(--color-primary-50, #eef2ff) 0%, var(--color-bg-card) 60%);
+      }
+      .hero-cards {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: var(--space-4);
+        padding: var(--space-4) var(--space-6) var(--space-2);
+      }
+      .file-card {
+        background: var(--color-bg-card);
+        border: var(--border-1) solid var(--color-border);
+        border-radius: var(--radius-md);
+        padding: var(--space-4);
+        display: flex;
+        gap: var(--space-3);
+        align-items: flex-start;
+      }
+      .file-card .file-icon {
+        font-size: var(--text-2xl);
+        line-height: 1;
+        width: 32px; height: 32px;
+        display: flex; align-items: center; justify-content: center;
+        flex-shrink: 0;
+      }
+      .file-card.is-good .file-icon { color: #16a34a; }
+      .file-card.is-bad .file-icon  { color: #dc2626; }
+      .file-card.is-checking .file-icon { color: var(--color-text-muted); }
+      .file-card.is-empty .file-icon { color: var(--color-text-muted); }
+      .file-card .file-body { min-width: 0; flex: 1; }
+      .file-card h3 {
+        margin: 0 0 4px;
+        font-size: var(--text-base);
+        font-weight: var(--font-semibold);
+      }
+      .file-card p {
+        margin: 0 0 var(--space-2);
+        color: var(--color-text-secondary);
+        font-size: var(--text-sm);
+      }
+      .file-card .file-stats {
+        display: flex; gap: var(--space-3);
+        font-size: var(--text-xs); color: var(--color-text-muted);
+        text-transform: uppercase; letter-spacing: 0.04em;
+        margin-top: var(--space-2);
+      }
+      .file-card .file-stats strong {
+        font-size: var(--text-sm);
+        color: var(--color-text);
+        display: block;
+        text-transform: none;
+        letter-spacing: 0;
+        font-weight: var(--font-bold);
+      }
+      .file-card code {
+        background: var(--color-bg-subtle);
+        padding: 1px 6px;
+        border-radius: var(--radius-sm);
+        font-size: var(--text-xs);
+        word-break: break-all;
+      }
+
+      .hosting-details summary { list-style: none; }
+      .hosting-details summary::-webkit-details-marker { display: none; }
+      .hosting-details[open] summary { border-bottom: var(--border-1) solid var(--color-border); }
+
       .hosting-detail {
         padding: var(--space-4) var(--space-6);
         font-size: var(--text-sm);
@@ -246,34 +313,38 @@
             </div>
             <div class="header-status" id="status-badges"></div>
           </div>
-          <div class="stats">
-            <div class="stat">
-              <div class="stat-value" id="stat-properties">0</div>
-              <div class="stat-label">Properties</div>
-            </div>
-            <div class="stat">
-              <div class="stat-value" id="stat-agents">0</div>
-              <div class="stat-label">Authorized agents</div>
-            </div>
-            <div class="stat">
-              <div class="stat-value" id="stat-source">&mdash;</div>
-              <div class="stat-label">Property source</div>
-            </div>
-          </div>
         </div>
 
-        <!-- Hosting panel -->
-        <div class="panel">
+        <!-- Hero "what we have" — the page is ABOUT the publisher's
+             actual files, not setup advice. Renders one card per file
+             we've checked, with check / cross / spinner depending on
+             state. When auto-crawl is in flight the cards show a
+             "Checking..." state and the page polls for a refresh. -->
+        <div class="panel hero-files" id="hero-files">
           <div class="panel-header">
+            <div>
+              <div class="panel-title" id="hero-title">What we found at this domain</div>
+              <div class="panel-subtitle" id="hero-subtitle"></div>
+            </div>
+          </div>
+          <div class="hero-cards" id="hero-cards"></div>
+          <div class="actions" id="hero-actions"></div>
+        </div>
+
+        <!-- Hosting setup details — collapsed by default once a working
+             record exists. Surfaces the authoritative_location stub copy
+             and the AAO-hosted URL when relevant. -->
+        <details class="panel hosting-details" id="hosting-details">
+          <summary class="panel-header" id="hosting-summary" style="cursor: pointer;">
             <div>
               <div class="panel-title">adagents.json hosting</div>
               <div class="panel-subtitle" id="hosting-subtitle"></div>
             </div>
             <div id="hosting-mode-badge"></div>
-          </div>
+          </summary>
           <div class="hosting-detail" id="hosting-detail"></div>
           <div class="actions" id="hosting-actions"></div>
-        </div>
+        </details>
 
         <div class="panel">
           <div class="panel-header">
@@ -334,6 +405,138 @@
         document.getElementById('error-message').textContent = message;
       }
 
+      // Render the hero "what we found" cards. State-driven: each card
+      // gets is-good / is-bad / is-checking / is-empty class, and the
+      // copy celebrates what's there rather than lecturing about
+      // hosting models.
+      function renderHero(data) {
+        const files = data.files || {};
+        const subtitle = document.getElementById('hero-subtitle');
+        const cards = document.getElementById('hero-cards');
+        const actions = document.getElementById('hero-actions');
+        const propsCount = (data.properties || []).length;
+        const agentsCount = (data.authorized_agents || []).length;
+
+        // Subtitle reflects the overall posture.
+        const adagents = files.adagents_json || { status: 'unknown' };
+        const brand = files.brand_json || { status: 'unknown' };
+        const allChecking = adagents.status === 'checking' && brand.status === 'checking';
+        const anyChecking = adagents.status === 'checking' || brand.status === 'checking';
+        const haveAnything = adagents.status === 'valid' || brand.status === 'present';
+
+        if (allChecking) {
+          subtitle.textContent = 'Checking your domain — this takes a few seconds.';
+        } else if (haveAnything) {
+          subtitle.textContent = 'Here’s what AAO has on file for this domain.';
+        } else if (anyChecking) {
+          subtitle.textContent = 'Checking now…';
+        } else {
+          subtitle.textContent = 'We didn’t find an adagents.json or brand.json on this domain.';
+        }
+
+        const cardsHtml = [];
+
+        // adagents.json card
+        if (adagents.status === 'valid') {
+          cardsHtml.push(`
+            <div class="file-card is-good">
+              <div class="file-icon">✓</div>
+              <div class="file-body">
+                <h3>You have an <code>adagents.json</code></h3>
+                <p>AAO fetched a valid file at <code>${escapeHtml(adagents.expected_url || '')}</code>. Buyers will find it there.</p>
+                <div class="file-stats">
+                  <div><strong>${agentsCount}</strong>${agentsCount === 1 ? ' authorized agent' : ' authorized agents'}</div>
+                  <div><strong>${propsCount}</strong>${propsCount === 1 ? ' property' : ' properties'}</div>
+                </div>
+              </div>
+            </div>`);
+        } else if (adagents.status === 'invalid') {
+          cardsHtml.push(`
+            <div class="file-card is-bad">
+              <div class="file-icon">!</div>
+              <div class="file-body">
+                <h3><code>adagents.json</code> failed validation</h3>
+                <p>A file exists at <code>${escapeHtml(adagents.expected_url || '')}</code> but it didn’t parse cleanly. Click “why?” below to see the structured errors.</p>
+                <button id="hero-show-validation" type="button" style="font-size: var(--text-xs); background: none; border: none; color: var(--color-brand); cursor: pointer; text-decoration: underline; padding: 0;">Show validation errors</button>
+              </div>
+            </div>`);
+        } else if (adagents.status === 'checking') {
+          cardsHtml.push(`
+            <div class="file-card is-checking">
+              <div class="file-icon"><div class="spinner" style="width:16px;height:16px;border-width:2px;"></div></div>
+              <div class="file-body">
+                <h3>Looking for <code>adagents.json</code>…</h3>
+                <p>Fetching <code>${escapeHtml(adagents.expected_url || '')}</code> now. This page will refresh in a few seconds.</p>
+              </div>
+            </div>`);
+        } else {
+          cardsHtml.push(`
+            <div class="file-card is-empty">
+              <div class="file-icon">—</div>
+              <div class="file-body">
+                <h3>No <code>adagents.json</code> yet</h3>
+                <p>Buyers fetch <code>${escapeHtml(adagents.expected_url || '')}</code> to learn which AI sales agents you’ve authorized to sell your inventory.</p>
+                <a href="/adagents/builder?domain=${encodeURIComponent(data.domain)}" style="font-size: var(--text-sm); color: var(--color-brand); font-weight: var(--font-semibold); text-decoration: none;">Generate adagents.json →</a>
+              </div>
+            </div>`);
+        }
+
+        // brand.json card
+        if (brand.status === 'present') {
+          cardsHtml.push(`
+            <div class="file-card is-good">
+              <div class="file-icon">✓</div>
+              <div class="file-body">
+                <h3>You have a <code>brand.json</code></h3>
+                <p>${brand.name ? `Identified as <strong>${escapeHtml(brand.name)}</strong>. ` : ''}Buyers fetch <code>https://${escapeHtml(data.domain)}/.well-known/brand.json</code> to learn what your brand looks like and what inventory you publish.</p>
+              </div>
+            </div>`);
+        } else if (brand.status === 'checking') {
+          cardsHtml.push(`
+            <div class="file-card is-checking">
+              <div class="file-icon"><div class="spinner" style="width:16px;height:16px;border-width:2px;"></div></div>
+              <div class="file-body">
+                <h3>Looking for <code>brand.json</code>…</h3>
+                <p>Checking <code>https://${escapeHtml(data.domain)}/.well-known/brand.json</code> now.</p>
+              </div>
+            </div>`);
+        } else {
+          cardsHtml.push(`
+            <div class="file-card is-empty">
+              <div class="file-icon">—</div>
+              <div class="file-body">
+                <h3>No <code>brand.json</code> yet</h3>
+                <p>A <code>brand.json</code> tells AI agents what your brand is, what it looks like, and what inventory you publish. It complements <code>adagents.json</code>.</p>
+                <a href="/brand/builder?domain=${encodeURIComponent(data.domain)}" style="font-size: var(--text-sm); color: var(--color-brand); font-weight: var(--font-semibold); text-decoration: none;">Build brand.json →</a>
+              </div>
+            </div>`);
+        }
+
+        cards.innerHTML = cardsHtml.join('');
+
+        // Wire up the validation-detail button if present.
+        const vbtn = document.getElementById('hero-show-validation');
+        if (vbtn) vbtn.addEventListener('click', () => showValidationDetail(data.domain));
+
+        // Hero footer actions: claim CTA or "edit my record" depending on auth.
+        const user = appUser();
+        const heroActions = [];
+        if (user) {
+          heroActions.push(`<a class="primary" href="/property/view/${encodeURIComponent(data.domain)}">Manage this record</a>`);
+        } else if (!haveAnything) {
+          heroActions.push(`<a class="primary" href="/login?return_to=${encodeURIComponent(window.location.pathname)}">Sign in to claim</a>`);
+        }
+        heroActions.push(`<a class="secondary" href="/adagents-landing">What is adagents.json?</a>`);
+        actions.innerHTML = heroActions.join('');
+
+        // Auto-refresh when the server told us a crawl is in flight.
+        // 4 seconds is enough for a single-domain crawl in most cases;
+        // larger budgets risk the user navigating away.
+        if (data.auto_crawl_triggered) {
+          setTimeout(() => load(), 4000);
+        }
+      }
+
       function renderStatusBadges(data) {
         const el = document.getElementById('status-badges');
         const parts = [];
@@ -391,29 +594,29 @@
       }
 
       function renderExplainer(data) {
-        // Only show the cold-visitor explainer when the page has nothing
-        // useful — no properties, no agents, no member, no valid adagents.
-        const isEmpty =
-          (!data.properties || data.properties.length === 0) &&
-          (!data.authorized_agents || data.authorized_agents.length === 0) &&
-          !data.member &&
-          data.hosting && data.hosting.mode === 'none';
-        const explainer = document.getElementById('explainer');
-        if (!isEmpty) { explainer.classList.add('hidden'); return; }
-        const user = appUser();
-        const ctas = [];
-        if (user) {
-          ctas.push(`<a class="primary" href="/property/view/${encodeURIComponent(data.domain)}">Claim this domain</a>`);
-        } else {
-          ctas.push(`<a class="primary" href="/login?return_to=${encodeURIComponent(window.location.pathname)}">Sign in to claim</a>`);
-        }
-        ctas.push(`<a class="secondary" href="/adagents-landing">What is adagents.json?</a>`);
-        document.getElementById('explainer-ctas').innerHTML = ctas.join('');
-        explainer.classList.remove('hidden');
+        // The hero "what we found" panel now covers the cold-state
+        // explainer's job — celebrating what's there, or leading with
+        // a clear next step when nothing's there. Keep this function
+        // around as a no-op so existing call sites don't break, but
+        // don't render the old banner.
+        document.getElementById('explainer')?.classList.add('hidden');
+        void data;
       }
 
       function renderHosting(data) {
         const hosting = data.hosting || { mode: 'none', expected_url: '' };
+        // Auto-expand the hosting details panel when the page is in
+        // "set this up" mode — i.e., nothing's hosted yet. When the
+        // publisher already has a working file, leave the panel
+        // collapsed so the page leads with what's there.
+        const details = document.getElementById('hosting-details');
+        if (details) {
+          if (hosting.mode === 'none' || hosting.mode === 'self_invalid') {
+            details.setAttribute('open', '');
+          } else {
+            details.removeAttribute('open');
+          }
+        }
         const subtitle = document.getElementById('hosting-subtitle');
         const detail = document.getElementById('hosting-detail');
         const badge = document.getElementById('hosting-mode-badge');
@@ -671,15 +874,24 @@
 
           renderStatusBadges(data);
           renderExplainer(data);
+          renderHero(data);
           renderHosting(data);
 
           const props = Array.isArray(data.properties) ? data.properties : [];
           const agents = Array.isArray(data.authorized_agents) ? data.authorized_agents : [];
 
-          document.getElementById('stat-properties').textContent = props.length;
-          document.getElementById('stat-agents').textContent = agents.length;
+          // Stats moved into the per-file hero cards (renderHero); the
+          // old standalone stats block has been removed. Update any
+          // remaining stat-* nodes only if they exist (defensive — old
+          // markup may persist in cached pages).
+          const setStat = (id, value) => {
+            const el = document.getElementById(id);
+            if (el) el.textContent = value;
+          };
+          setStat('stat-properties', String(props.length));
+          setStat('stat-agents', String(agents.length));
           const sources = Array.from(new Set(props.map((p) => p.source).filter(Boolean)));
-          document.getElementById('stat-source').textContent = sources.length ? sources.join(', ') : '—';
+          setStat('stat-source', sources.length ? sources.join(', ') : '—');
 
           renderProperties(props);
           renderAgents(data.domain, agents, props);

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -5636,13 +5636,37 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       const memberDb = new MemberDatabase();
       const federatedIndex = crawler.getFederatedIndex();
 
-      const [profile, properties, authorizations, adagentsValid, hostedProperty] = await Promise.all([
+      const [profile, properties, authorizations, adagentsValid, hostedProperty, brandRow] = await Promise.all([
         memberDb.getProfileByDomain(domain),
         federatedIndex.getPropertiesForDomain(domain),
         federatedIndex.getAuthorizationsForDomain(domain),
         federatedIndex.hasValidAdagents(domain),
         propertyDb.getHostedPropertyByDomain(domain),
+        brandDb.getDiscoveredBrandByDomain(domain),
       ]);
+
+      // Auto-crawl on view: if we've never crawled this domain (adagents
+      // never seen, brand never seen), kick off background fetches so a
+      // human visiting this page acts as the trigger to populate the
+      // record. Debounced per-domain so a tight refresh loop or a
+      // popular domain doesn't hammer the crawler. Fire-and-forget; the
+      // page polls / refreshes to pick up fresh data.
+      const adagentsNeverCrawled = adagentsValid === null;
+      const brandNeverCrawled = !brandRow;
+      let autoCrawlTriggered = false;
+      if ((adagentsNeverCrawled || brandNeverCrawled) && shouldAutoCrawl(domain)) {
+        autoCrawlTriggered = true;
+        if (adagentsNeverCrawled) {
+          crawler.crawlSingleDomain(domain).catch((err: Error) => {
+            logger.warn({ err, domain }, 'Auto-crawl (adagents) failed');
+          });
+        }
+        if (brandNeverCrawled) {
+          crawler.scanBrandForDomain(domain).catch((err: Error) => {
+            logger.warn({ err, domain }, 'Auto-crawl (brand) failed');
+          });
+        }
+      }
 
       const member = profile
         ? { slug: profile.slug, display_name: profile.display_name }
@@ -5744,11 +5768,36 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         }),
       );
 
+      // What-we-have summary. The page leads with "you have an
+      // adagents.json" / "you have a brand.json" — this block exposes
+      // that signal so the client doesn't have to derive it from a
+      // cocktail of nullable flags.
+      const files = {
+        adagents_json: {
+          status: adagentsNeverCrawled
+            ? (autoCrawlTriggered ? 'checking' : 'unknown')
+            : adagentsValid === true
+              ? 'valid'
+              : adagentsValid === false
+                ? 'invalid'
+                : 'unknown',
+          // url where the publisher's own /.well-known sits
+          expected_url: hosting.expected_url,
+        } as { status: 'valid' | 'invalid' | 'unknown' | 'checking'; expected_url: string },
+        brand_json: {
+          status: brandRow
+            ? (brandRow.has_brand_manifest ? 'present' : 'unknown')
+            : (autoCrawlTriggered ? 'checking' : 'unknown'),
+          name: brandRow?.brand_name,
+        } as { status: 'present' | 'unknown' | 'checking'; name?: string },
+      };
+
       res.json({
         domain,
         member,
         adagents_valid: adagentsValid,
         hosting,
+        files,
         properties: projectedProperties,
         authorized_agents: authorizations.map(a => {
           if (skipRollup) {
@@ -5782,6 +5831,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         rollup_truncated: rollupTruncatedLen
           ? { cap: PER_AGENT_ROLLUP_CAP, total_agents: authorizations.length }
           : undefined,
+        auto_crawl_triggered: autoCrawlTriggered || undefined,
       });
     } catch (error) {
       logger.error({ err: error, path: req.path }, "Publisher lookup failed");
@@ -6836,6 +6886,20 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
   const CRAWL_RATE_LIMIT_MS = 5 * 60 * 1000;  // 5 minutes per domain
   const MEMBER_CRAWL_LIMIT = 30;               // 30 requests per member per hour
   const MEMBER_CRAWL_WINDOW_MS = 60 * 60 * 1000;
+
+  // Auto-crawl-on-view debouncer. Distinct from the manual /crawl-request
+  // path so a publisher visiting their own page can re-trigger the crawl
+  // a few minutes later without bumping the user-initiated rate limit.
+  // Fires anonymously (no member context); per-domain only.
+  const autoCrawlLastFired = new Map<string, number>();
+  const AUTO_CRAWL_DEBOUNCE_MS = 5 * 60 * 1000;
+  function shouldAutoCrawl(domain: string): boolean {
+    const last = autoCrawlLastFired.get(domain);
+    if (last && Date.now() - last < AUTO_CRAWL_DEBOUNCE_MS) return false;
+    autoCrawlLastFired.set(domain, Date.now());
+    return true;
+  }
+
   // Periodic cleanup of stale rate limit entries to prevent memory growth
   const rateLimitCleanupInterval = setInterval(() => {
     const now = Date.now();
@@ -6844,6 +6908,9 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     }
     for (const [member, state] of memberCrawlCounts) {
       if (now - state.windowStart > MEMBER_CRAWL_WINDOW_MS) memberCrawlCounts.delete(member);
+    }
+    for (const [domain, timestamp] of autoCrawlLastFired) {
+      if (now - timestamp > AUTO_CRAWL_DEBOUNCE_MS) autoCrawlLastFired.delete(domain);
     }
   }, CRAWL_RATE_LIMIT_MS);
   rateLimitCleanupInterval.unref(); // Don't prevent process exit

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -5622,7 +5622,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     }
   });
 
-  router.get("/registry/publisher", async (req, res) => {
+  router.get("/registry/publisher", agentReadRateLimiter, async (req, res) => {
     const rawDomain = req.query.domain as string;
     if (!rawDomain) {
       return res.status(400).json({ error: "Missing required query param: domain" });
@@ -5651,20 +5651,51 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       // record. Debounced per-domain so a tight refresh loop or a
       // popular domain doesn't hammer the crawler. Fire-and-forget; the
       // page polls / refreshes to pick up fresh data.
+      //
+      // SSRF gate: feed the domain through `validateCrawlDomain` (DNS
+      // resolution + private-IP check) before invoking the crawler.
+      // Without this gate, `?domain=internal.svc.cluster.local` would
+      // turn an unauthenticated GET into an internal-network probe via
+      // AAO's egress. The manual crawl-request endpoint already does
+      // this; auto-crawl was missing the same gate.
+      //
+      // `crawlSingleDomain` already invokes `scanBrandForDomain`
+      // internally (crawler.ts), so we only call the brand scan
+      // standalone when adagents was already crawled but brand wasn't —
+      // otherwise we'd double-fetch /.well-known/brand.json.
+      //
+      // NOTE: the per-domain debouncer is process-local. Behind a load
+      // balancer the first request to each instance can fire its own
+      // crawl. The IP-keyed `agentReadRateLimiter` mounted above bounds
+      // the breadth of distinct-domain enumeration too.
       const adagentsNeverCrawled = adagentsValid === null;
       const brandNeverCrawled = !brandRow;
       let autoCrawlTriggered = false;
       if ((adagentsNeverCrawled || brandNeverCrawled) && shouldAutoCrawl(domain)) {
-        autoCrawlTriggered = true;
-        if (adagentsNeverCrawled) {
-          crawler.crawlSingleDomain(domain).catch((err: Error) => {
-            logger.warn({ err, domain }, 'Auto-crawl (adagents) failed');
-          });
+        // Re-validate: returns null on private/loopback/link-local IPs
+        // and rejects unresolvable hostnames. We accept the result of
+        // validateCrawlDomain only when it returns the same domain we
+        // already validated — any rewrite would mean a discrepancy.
+        let crawlSafe = false;
+        try {
+          const validated = await validateCrawlDomain(domain);
+          crawlSafe = validated === domain;
+        } catch (err) {
+          logger.debug({ err, domain }, 'Auto-crawl skipped — validateCrawlDomain rejected');
         }
-        if (brandNeverCrawled) {
-          crawler.scanBrandForDomain(domain).catch((err: Error) => {
-            logger.warn({ err, domain }, 'Auto-crawl (brand) failed');
-          });
+        if (crawlSafe) {
+          autoCrawlTriggered = true;
+          if (adagentsNeverCrawled) {
+            // crawlSingleDomain handles brand internally too.
+            crawler.crawlSingleDomain(domain).catch((err: Error) => {
+              logger.warn({ err, domain, ip: req.ip }, 'Auto-crawl (adagents) failed');
+            });
+          } else if (brandNeverCrawled) {
+            // adagents already crawled, only the brand is missing.
+            crawler.scanBrandForDomain(domain).catch((err: Error) => {
+              logger.warn({ err, domain, ip: req.ip }, 'Auto-crawl (brand) failed');
+            });
+          }
         }
       }
 
@@ -6900,17 +6931,21 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     return true;
   }
 
-  // Periodic cleanup of stale rate limit entries to prevent memory growth
+  // Periodic cleanup of stale rate limit entries to prevent memory
+  // growth. Eviction threshold is INTENTIONALLY larger than the debounce
+  // window — if cleanup deleted an entry at exactly `windowMs`, the next
+  // request could re-fire immediately, eliminating the debounce. 2× the
+  // window keeps real-world callers safely inside the debounce.
   const rateLimitCleanupInterval = setInterval(() => {
     const now = Date.now();
     for (const [domain, timestamp] of crawlRequestRateLimits) {
-      if (now - timestamp > CRAWL_RATE_LIMIT_MS) crawlRequestRateLimits.delete(domain);
+      if (now - timestamp > 2 * CRAWL_RATE_LIMIT_MS) crawlRequestRateLimits.delete(domain);
     }
     for (const [member, state] of memberCrawlCounts) {
       if (now - state.windowStart > MEMBER_CRAWL_WINDOW_MS) memberCrawlCounts.delete(member);
     }
     for (const [domain, timestamp] of autoCrawlLastFired) {
-      if (now - timestamp > AUTO_CRAWL_DEBOUNCE_MS) autoCrawlLastFired.delete(domain);
+      if (now - timestamp > 2 * AUTO_CRAWL_DEBOUNCE_MS) autoCrawlLastFired.delete(domain);
     }
   }, CRAWL_RATE_LIMIT_MS);
   rateLimitCleanupInterval.unref(); // Don't prevent process exit

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -604,12 +604,33 @@ const PublisherHostingSchema = z.object({
   }),
 });
 
+const PublisherFilesSchema = z.object({
+  adagents_json: z.object({
+    status: z.enum(["valid", "invalid", "unknown", "checking"]).openapi({
+      description:
+        "What we know about the publisher's adagents.json right now. `valid` = crawler fetched a parsing-and-shape-valid file. `invalid` = crawler fetched a file that failed validation. `unknown` = never crawled or last result is stale. `checking` = an auto-crawl was kicked off by this request; the page should poll for fresh data shortly.",
+    }),
+    expected_url: z.string().openapi({ description: "Where adagents.json should live on the publisher's own origin." }),
+  }),
+  brand_json: z.object({
+    status: z.enum(["present", "unknown", "checking"]).openapi({
+      description:
+        "What we know about the publisher's brand.json. `present` = a brand record with manifest data exists. `unknown` = no record yet. `checking` = an auto-crawl was kicked off.",
+    }),
+    name: z.string().optional(),
+  }),
+});
+
 export const PublisherLookupResultSchema = z
   .object({
     domain: z.string().openapi({ example: "voxmedia.com" }),
     member: MemberRefSchema.nullable(),
     adagents_valid: z.boolean().nullable(),
     hosting: PublisherHostingSchema,
+    files: PublisherFilesSchema.optional().openapi({
+      description:
+        "Plain-English summary of what AAO has found at the publisher's origin. The publisher page leads with this — `you have a valid adagents.json` is the primary signal, not `mode === self`. Optional in the schema for backwards compatibility; the handler always populates it.",
+    }),
     properties: z.array(PublisherPropertySchema),
     authorized_agents: z.array(PublisherAuthorizedAgentSchema),
     rollup_truncated: z.object({
@@ -618,6 +639,10 @@ export const PublisherLookupResultSchema = z
     }).optional().openapi({
       description:
         "Set when the publisher has more authorized agents than the per-agent rollup cap. Above the cap, agents beyond `cap` are returned without `properties_authorized` / `properties_total` / `publisher_wide`; call `/api/registry/publisher/authorization?domain=X&agent=Y` for the per-agent count. Lets a caller decide whether to fan out individual calls or stop reading.",
+    }),
+    auto_crawl_triggered: z.boolean().optional().openapi({
+      description:
+        "Set to `true` when this request triggered a background crawl of the publisher's origin (we hadn't crawled before). The client should refetch in ~3-5s to pick up fresh data. Debounced per-domain so a tight refresh loop won't keep firing crawls.",
     }),
   })
   .openapi("PublisherLookupResult");

--- a/server/tests/integration/registry-publisher-brand-json-hydration.test.ts
+++ b/server/tests/integration/registry-publisher-brand-json-hydration.test.ts
@@ -53,6 +53,19 @@ vi.mock('../../src/billing/stripe-client.js', () => ({
   createBillingPortalSession: vi.fn().mockResolvedValue(null),
 }));
 
+// Short-circuit the SSRF DNS check for the auto-crawl path. The
+// `.registry-baseline.example` test domains don't resolve to a public
+// IP (RFC 2606 reserved), so the production `validateCrawlDomain` would
+// reject them and skip auto-crawl. We want to exercise the auto-crawl
+// branch in tests, so the mock returns the input domain unchanged.
+vi.mock('../../src/utils/url-security.js', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('../../src/utils/url-security.js');
+  return {
+    ...actual,
+    validateCrawlDomain: async (domain: string) => domain.toLowerCase(),
+  };
+});
+
 import { HTTPServer } from '../../src/http.js';
 import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
 import { runMigrations } from '../../src/db/migrate.js';
@@ -224,6 +237,29 @@ describe('Registry publisher endpoint — brand.json hydration', () => {
     expect(res.body.hosting.hosted_url).toBeUndefined();
   });
 
+  it('does NOT auto-crawl when validateCrawlDomain rejects (SSRF gate)', async () => {
+    // Override the global mock for this one case. We want to exercise
+    // the path where the SSRF gate refuses the domain — auto-crawl
+    // should be skipped, no `auto_crawl_triggered` flag in the response.
+    const urlSecurity = await import('../../src/utils/url-security.js');
+    const original = urlSecurity.validateCrawlDomain;
+    (urlSecurity as unknown as { validateCrawlDomain: typeof original }).validateCrawlDomain = async () => {
+      throw new Error('Invalid host: test rejection');
+    };
+    try {
+      const ssrfTarget = `ssrf-target-${Date.now()}.registry-baseline.example`;
+      const res = await request(app).get(`/api/registry/publisher?domain=${encodeURIComponent(ssrfTarget)}`);
+      expect(res.status).toBe(200);
+      expect(res.body.auto_crawl_triggered).toBeUndefined();
+      // Status falls back to `unknown` (not `checking`) because the
+      // gate prevented us from kicking off any crawl.
+      expect(res.body.files.adagents_json.status).toBe('unknown');
+      expect(res.body.files.brand_json.status).toBe('unknown');
+    } finally {
+      (urlSecurity as unknown as { validateCrawlDomain: typeof original }).validateCrawlDomain = original;
+    }
+  });
+
   it('returns files.adagents_json.status=checking and auto_crawl_triggered=true on first lookup of an unknown domain', async () => {
     // No brand row, no hosted property, never crawled — first GET should
     // kick off an auto-crawl and surface the checking states.
@@ -232,8 +268,10 @@ describe('Registry publisher endpoint — brand.json hydration', () => {
     expect(res.status).toBe(200);
     expect(res.body.auto_crawl_triggered).toBe(true);
     expect(res.body.files).toBeDefined();
-    expect(['checking', 'unknown']).toContain(res.body.files.adagents_json.status);
-    expect(['checking', 'unknown']).toContain(res.body.files.brand_json.status);
+    // First hit: auto_crawl_triggered=true and the never-crawled files
+    // are reported as `checking` (not `unknown`).
+    expect(res.body.files.adagents_json.status).toBe('checking');
+    expect(res.body.files.brand_json.status).toBe('checking');
 
     // Second hit within the debounce window does NOT re-trigger.
     const res2 = await request(app).get(`/api/registry/publisher?domain=${encodeURIComponent(fresh)}`);

--- a/server/tests/integration/registry-publisher-brand-json-hydration.test.ts
+++ b/server/tests/integration/registry-publisher-brand-json-hydration.test.ts
@@ -224,6 +224,41 @@ describe('Registry publisher endpoint — brand.json hydration', () => {
     expect(res.body.hosting.hosted_url).toBeUndefined();
   });
 
+  it('returns files.adagents_json.status=checking and auto_crawl_triggered=true on first lookup of an unknown domain', async () => {
+    // No brand row, no hosted property, never crawled — first GET should
+    // kick off an auto-crawl and surface the checking states.
+    const fresh = `auto-crawl-${Date.now()}.registry-baseline.example`;
+    const res = await request(app).get(`/api/registry/publisher?domain=${encodeURIComponent(fresh)}`);
+    expect(res.status).toBe(200);
+    expect(res.body.auto_crawl_triggered).toBe(true);
+    expect(res.body.files).toBeDefined();
+    expect(['checking', 'unknown']).toContain(res.body.files.adagents_json.status);
+    expect(['checking', 'unknown']).toContain(res.body.files.brand_json.status);
+
+    // Second hit within the debounce window does NOT re-trigger.
+    const res2 = await request(app).get(`/api/registry/publisher?domain=${encodeURIComponent(fresh)}`);
+    expect(res2.status).toBe(200);
+    expect(res2.body.auto_crawl_triggered).toBeUndefined();
+  });
+
+  it('returns files.brand_json.status=present when a brand record exists', async () => {
+    await brandDb.upsertDiscoveredBrand({
+      domain: PUB_BRAND_ONLY,
+      brand_name: 'Sasha Media',
+      source_type: 'brand_json',
+      has_brand_manifest: true,
+      brand_manifest: { name: 'Sasha Media' },
+    });
+    const res = await request(app).get(
+      `/api/registry/publisher?domain=${encodeURIComponent(PUB_BRAND_ONLY)}`
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.files.brand_json).toMatchObject({
+      status: 'present',
+      name: 'Sasha Media',
+    });
+  });
+
   it('reports hosting.mode=aao_hosted with hosted_url when a public hosted property exists', async () => {
     await propertyDb.createHostedProperty({
       publisher_domain: PUB_AAO_HOSTED,


### PR DESCRIPTION
Brian's feedback on a screenshot of `/publisher/wonderstruck.org`: page leads with hosting-model framing ("ADAGENTS.JSON NOT YET CRAWLED", "0 properties", "0 authorized agents", a hosting panel about CNAME vs stub) even though wonderstruck.org probably HAS an adagents.json and brand.json — we just never crawled. **A human visit is a signal to crawl.** And the page should celebrate what's there, not lecture about hosting.

## What changed

**Page (`/publisher/:domain`)**
- New hero panel "What we found at this domain" leads the page. One card per file we checked, state-aware:
  - **Valid:** green check + "You have an adagents.json" / "You have a brand.json" with counts
  - **Invalid:** red `!` + "Show validation errors" link
  - **Checking:** spinner + "Looking for adagents.json…"
  - **Empty:** em-dash + builder CTA
- Hosting setup moved into a `<details>` panel. Auto-expanded for `mode='none'` / `'self_invalid'` so setup advice is visible when the publisher needs it. Collapsed otherwise.
- Page polls itself ~4s after an auto-crawl trigger so spinner cards refresh into real content without a manual reload.
- Cold-state explainer banner retired — the hero panel handles cold-visitor context inline.

**API (`/api/registry/publisher`)**
- New `files: { adagents_json: { status, expected_url }, brand_json: { status, name? } }` block. Status enums: `valid` / `invalid` / `unknown` / `checking` for adagents, `present` / `unknown` / `checking` for brand.
- New `auto_crawl_triggered: true` flag when the request kicked off a background fetch. Debounced 5min/domain.
- Auto-crawl fires when `adagents_valid === null` (never crawled) OR no brand record. Fire-and-forget — uses the existing `crawler.crawlSingleDomain` and `crawler.scanBrandForDomain`.

## Persona check

| Persona | Before | After |
|---|---|---|
| Sasha (brand.json only) | "0 properties · 0 agents" with hosting copy | "You have a brand.json" celebrated, "No adagents.json yet" with builder CTA |
| Cold visitor (nothing) | "0/0/—" + setup advice | Two spinner cards "Looking for…" while auto-crawl runs, refresh in 4s |
| Maria (just clicked) | Same dead page every visit | Auto-crawl finds whatever's there on first view |

Screenshots from playwright smoke at /tmp/hero-{sasha-brand-only,devraj-aao-hosted,cold-visitor}.png.

## Test plan

- [x] `npm run typecheck` clean
- [x] 56 tests pass across the related set, 2 new (auto-crawl flag + debounce, brand.json status mirroring)
- [x] Playwright smoke across three persona states — zero console errors
- [x] Auto-crawl debouncer caps fan-out (verified: second hit within window returns no flag)

## Related

- Independent of #4123 (CNAME removal — superseded by this rewrite anyway)
- Independent of #4124 (origin verification)
- Closes part of the spirit of #4106's persona walkthrough — the "celebrate what's there" gap was tier-1 visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)