### PR TITLE
feat(registry): add POST /api/me/member-profile to bootstrap a member profile via REST

### DIFF
--- a/.changeset/aao-member-profile-bootstrap-hardening.md
+++ b/.changeset/aao-member-profile-bootstrap-hardening.md
@@ -1,0 +1,13 @@
+---
+---
+
+fix(registry): harden the `POST /api/me/member-profile` REST bootstrap surface
+
+Follow-up to `aao-member-profile-bootstrap-impl.md`. The bootstrap handler that change shipped wrote org-level fields and accepted membership tiers without billing or audit trail — fine for the spec contract, risky for a public REST surface a third-party app can hit with only a user's OAuth token. This change closes four concrete gaps:
+
+- **Paid `membership_tier` values are now rejected with `400 "Paid tier requires checkout"`.** The endpoint previously accepted `company_leader` etc. and wrote the value straight to `organizations.membership_tier`. Any downstream code path that gates entitlements on `membership_tier` directly (rather than `subscription_status`) could be fooled into granting paid features without billing. The body now only accepts `individual_academic` (the free Explorer baseline) or omitted; paid tiers must come through Stripe checkout, where the webhook stamps the tier on the org row.
+- **Org metadata writes are now first-time-only.** `organization_name`, `company_type`, `revenue_tier`, `membership_tier` are written to the organization row only when the field is currently null. If a value is already set (e.g. an admin curated it via the dashboard), the body value is silently ignored and the response surfaces a `metadata_unchanged` warning naming the affected fields. Without this gate, any caller with a matching email domain could clobber admin-curated metadata on subsequent bootstrap calls.
+- **The bootstrap path is rate-limited.** New `memberProfileBootstrapRateLimiter` middleware applies the same envelope as `orgCreationRateLimiter` (15 failed attempts per hour per user; successful calls don't count). The limiter `skip`s requests whose body matches the legacy dashboard `display_name`+`slug` shape, so the `/community/profile-edit` and `/member-profile.html` flows keep their prior unmetered behavior.
+- **Audit log entry on success.** Successful bootstraps now write a `member_profile_bootstrapped` row to `registry_audit_log` with the affected user, the slug, the corporate domain, and which org-level fields were updated vs. ignored. Org-level mutations through this surface are now attributable.
+
+Spec updated to document each constraint (paid-tier 400, metadata-unchanged warning, rate-limit envelope) so callers can see them without reading the implementation.

--- a/.changeset/aao-member-profile-bootstrap-impl.md
+++ b/.changeset/aao-member-profile-bootstrap-impl.md
@@ -1,0 +1,18 @@
+---
+---
+
+feat(registry): implement the `POST /api/me/member-profile` REST bootstrap handler
+
+Companion to the spec landed in `aao-member-profile-create-endpoint.md` — that change defined the contract but explicitly punted the backend implementation. This change wires it up.
+
+The route at `/api/me/member-profile` already had a handler used by the dashboard's profile-edit page (body shape: `display_name`, `slug`, agents, …; `409` on conflict). Rather than break that flow, the POST handler now dispatches on body shape: when the request body matches the spec contract (`organization_name` + `corporate_domain`, no `display_name`/`slug`), the new bootstrap branch runs; otherwise the existing dashboard handler runs unchanged.
+
+The bootstrap branch:
+
+- validates `organization_name`, `company_type`, `corporate_domain`, optional `revenue_tier`/`membership_tier`/`primary_brand_domain` against the actual `COMPANY_TYPE_VALUES`, `VALID_REVENUE_TIERS`, `VALID_MEMBERSHIP_TIERS` constants used elsewhere in the codebase;
+- enforces the email-domain invariant (rejects personal email domains and any mismatch between the caller's verified email domain and the supplied `corporate_domain`);
+- resolves the target org from `?org=` or the caller's primary WorkOS organization (admin/owner only);
+- returns `200` with a `profile_already_exists` warning when a profile already exists for the org, instead of `409`, matching the spec's idempotency contract;
+- on first-time create, persists `organization_name`/`company_type`/`revenue_tier`/`membership_tier` on the organization row, inserts an email-verified record into `organization_domains`, generates a unique slug, creates the member profile (`is_public: false` by default — the visibility PUT is the explicit knob for going public), records the marketing opt-in best-effort, and returns the spec-shape `MemberProfile` body.
+
+Also corrects the published OpenAPI to match the actual database value sets — the original spec listed enum values (`MemberCompanyType: dsp/ssp/measurement/identity/infrastructure/...`, `MemberRevenueTier: 1m_to_10m/...`, `membership_tier: free/builder/professional`) that don't exist anywhere in the codebase. Replaced with the real values: `[adtech, agency, brand, publisher, data, ai, other]`, `[under_1m, 1m_5m, 5m_50m, 50m_250m, 250m_1b, 1b_plus]`, and `[individual_professional, individual_academic, company_standard, company_icl, company_leader]`. `membership_tier` on the response is now optional (omitted entirely for orgs on the free Explorer baseline) since `null` is the predominant state.

--- a/.changeset/aao-member-profile-create-endpoint.md
+++ b/.changeset/aao-member-profile-create-endpoint.md
@@ -1,0 +1,14 @@
+---
+---
+
+feat(registry): add `POST /api/me/member-profile` to bootstrap an organization member profile via REST
+
+Two existing registry endpoints (`GET /api/me/agents`, `POST /api/me/agents`) already advertise — in their `404` error descriptions — that callers should "create one via `POST /api/me/member-profile`". Until now that endpoint has only been reachable via the AAO dashboard's `/onboarding` form, which means downstream registry consumers (e.g. the Scope3 storefront's "Connect agents" dialog) cannot complete the sign-up→register-agent flow without dropping the user into a new tab on agenticadvertising.org.
+
+This change adds the OpenAPI definition for both `GET /api/me/member-profile` (canonical "do I have a profile yet?" check) and `POST /api/me/member-profile` (first-time onboarding via REST). Body shape mirrors the dashboard's existing form: `organization_name`, `company_type`, `revenue_tier?`, `corporate_domain`, `primary_brand_domain?`, `marketing_opt_in?`, `membership_tier?`. Same domain-match invariant as the dashboard form (caller's email domain must equal `corporate_domain`; personal-email domains rejected).
+
+Idempotent on `(organization_id, corporate_domain)` so a second call returns `200` with the existing profile rather than `409` — keeps client retry logic simple.
+
+This is a **spec-only** change — the backend implementation is tracked separately in #TBD. Spec lands first so registry API consumers can build against the contract while the implementation is in flight.
+
+Surfaced by: scope3data/agentic-api#2178 (Scope3 storefront "Connect agents" dialog needs to register AAO members natively, no iframe / popup).

--- a/package-lock.json
+++ b/package-lock.json
@@ -873,6 +873,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -919,6 +920,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1502,6 +1504,7 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
       "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -3716,7 +3719,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
       "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@mintlify/prebuild/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -4764,7 +4768,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
       "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@mintlify/scraping/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -5173,6 +5178,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -5529,6 +5535,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -5861,8 +5868,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/colors/-/colors-3.0.0.tgz",
       "integrity": "sha512-FUOsGBkHrYJwCSEtWRCIfQbZG7q1e6DgxCIOe1SUQzDe/7rXXeA47s8yCn6fuTNQAj1Zq4oTFi9Yjp3wzElcxg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -6608,6 +6614,7 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
       "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
         "@radix-ui/react-compose-refs": "1.1.2",
@@ -8496,7 +8503,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.96.2.tgz",
       "integrity": "sha512-hzI6cTVh4KNRk8UtoIBS7Lv9g6BnJPXvBKsvYH1aGWvv0347jT3BnSvztOE+kD76XGvZnRC/t6qdW1CaIfwCeA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -8702,6 +8708,7 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -8829,6 +8836,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -9192,6 +9200,7 @@
       "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9260,6 +9269,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10452,8 +10462,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/clean-stack": {
       "version": "4.2.0",
@@ -11089,8 +11098,7 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/csv-parse": {
       "version": "6.2.1",
@@ -11468,7 +11476,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1595872.tgz",
       "integrity": "sha512-kRfgp8vWVjBu/fbYCiVFiOqsCk3CrMKEo3WbgGT2NXK2dG7vawWPBljixajVgGK9II8rDO9G0oD0zLt3I1daRg==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -12414,6 +12423,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -14560,6 +14570,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -14859,6 +14870,7 @@
       "integrity": "sha512-2CbJAa7XeziZYe6pDS5RVLirRY28iSGMQuEV8jRU5NQsONQNfcR/BZHHc9vkMg2lGYTHTM2pskxC1YmY28p6bQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.2.0",
         "ansi-escapes": "^7.0.0",
@@ -15937,6 +15949,7 @@
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -19274,6 +19287,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -19538,6 +19552,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -20294,6 +20309,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21341,6 +21357,7 @@
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -21479,8 +21496,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",
@@ -23064,6 +23080,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -23257,6 +23274,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -23430,6 +23448,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -23513,6 +23532,7 @@
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -23989,6 +24009,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -24770,6 +24791,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -134,6 +134,46 @@ export const orgCreationRateLimiter = rateLimit({
 });
 
 /**
+ * Rate limiter for the public REST bootstrap path on `POST /api/me/member-profile`.
+ * Same envelope as `orgCreationRateLimiter` — 15 failed attempts per hour per
+ * user, successful calls don't count — but `skip`s requests whose body does
+ * not match the bootstrap shape so the legacy dashboard profile-create path
+ * (`display_name` + `slug`) keeps its prior unmetered behavior.
+ */
+export const memberProfileBootstrapRateLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 15,
+  skipSuccessfulRequests: true,
+  standardHeaders: true,
+  legacyHeaders: false,
+  store: new CachedPostgresStore('mp-bootstrap:'),
+  keyGenerator: generateKey,
+  validate: { keyGeneratorIpFallback: false },
+  skip: (req) => {
+    const body = (req as any).body;
+    if (!body || typeof body !== 'object') return true;
+    const isBootstrapShape =
+      typeof body.organization_name === 'string'
+      && typeof body.corporate_domain === 'string'
+      && typeof body.display_name !== 'string'
+      && typeof body.slug !== 'string';
+    return !isBootstrapShape;
+  },
+  handler: (req: Request, res: Response) => {
+    logger.warn({
+      userId: (req as any).user?.id,
+      ip: req.ip,
+      path: req.path,
+    }, 'Rate limit exceeded for member-profile bootstrap');
+    res.status(429).json({
+      error: 'Too many requests',
+      message: 'Too many member-profile bootstrap attempts. Please wait an hour and try again.',
+      retryAfter: Math.ceil(60 * 60),
+    });
+  },
+});
+
+/**
  * Rate limiter for brand creation (community submissions)
  * Limits: 60 submissions per hour per user/IP
  */

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -134,6 +134,29 @@ export const orgCreationRateLimiter = rateLimit({
 });
 
 /**
+ * True when the request body matches the public REST bootstrap shape on
+ * `POST /api/me/member-profile`: `organization_name` + `corporate_domain`
+ * present, `display_name` + `slug` absent. The bootstrap rate limiter keys
+ * off this so the legacy dashboard profile-edit body (which carries
+ * `display_name` + `slug` and full profile fields) bypasses the limiter
+ * and keeps its prior unmetered behavior.
+ *
+ * Exported so the rule can be unit-tested directly — bypassing the test
+ * suite's standard `vi.mock` of the limiter — and so any new caller that
+ * needs the same dispatch decision uses the same predicate.
+ */
+export function isMemberProfileBootstrapBody(body: unknown): boolean {
+  if (!body || typeof body !== 'object') return false;
+  const b = body as Record<string, unknown>;
+  return (
+    typeof b.organization_name === 'string'
+    && typeof b.corporate_domain === 'string'
+    && typeof b.display_name !== 'string'
+    && typeof b.slug !== 'string'
+  );
+}
+
+/**
  * Rate limiter for the public REST bootstrap path on `POST /api/me/member-profile`.
  * Same envelope as `orgCreationRateLimiter` — 15 failed attempts per hour per
  * user, successful calls don't count — but `skip`s requests whose body does
@@ -149,16 +172,7 @@ export const memberProfileBootstrapRateLimiter = rateLimit({
   store: new CachedPostgresStore('mp-bootstrap:'),
   keyGenerator: generateKey,
   validate: { keyGeneratorIpFallback: false },
-  skip: (req) => {
-    const body = (req as any).body;
-    if (!body || typeof body !== 'object') return true;
-    const isBootstrapShape =
-      typeof body.organization_name === 'string'
-      && typeof body.corporate_domain === 'string'
-      && typeof body.display_name !== 'string'
-      && typeof body.slug !== 'string';
-    return !isBootstrapShape;
-  },
+  skip: (req) => !isMemberProfileBootstrapBody((req as any).body),
   handler: (req: Request, res: Response) => {
     logger.warn({
       userId: (req as any).user?.id,

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -27,6 +27,14 @@ import { COMPANY_TYPE_VALUES } from "../config/company-types.js";
 import { getCompanyDomain } from "../utils/email-domain.js";
 import { emailPrefsDb } from "../db/email-preferences-db.js";
 import { slugify } from "../services/collection-feed-sync.js";
+import { memberProfileBootstrapRateLimiter } from "../middleware/rate-limit.js";
+
+// Membership tiers a caller may set via the REST bootstrap body. Paid tiers
+// (`individual_professional`, `company_*`) require a successful Stripe
+// checkout — accepting them here would let a caller stamp a paid tier on
+// the org row without billing, fooling any downstream gate that reads
+// `membership_tier` directly without also checking `subscription_status`.
+const BOOTSTRAP_ALLOWED_MEMBERSHIP_TIERS = ['individual_academic'] as const;
 import { VALID_MEMBER_OFFERINGS, isValidAgentVisibility, isValidAgentType } from "../types.js";
 import type { MemberBrandInfo, AgentVisibility, AgentConfig, AgentType } from "../types.js";
 import type { CrawlerService } from "../crawler.js";
@@ -305,11 +313,25 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
           message: `revenue_tier must be one of: ${VALID_REVENUE_TIERS.join(', ')}`,
         });
       }
-      if (membership_tier !== undefined && (typeof membership_tier !== 'string' || !(VALID_MEMBERSHIP_TIERS as readonly string[]).includes(membership_tier))) {
-        return res.status(400).json({
-          error: 'Invalid membership_tier',
-          message: `membership_tier must be one of: ${VALID_MEMBERSHIP_TIERS.join(', ')}`,
-        });
+      if (membership_tier !== undefined) {
+        if (typeof membership_tier !== 'string' || !(VALID_MEMBERSHIP_TIERS as readonly string[]).includes(membership_tier)) {
+          return res.status(400).json({
+            error: 'Invalid membership_tier',
+            message: `membership_tier must be one of: ${VALID_MEMBERSHIP_TIERS.join(', ')}`,
+          });
+        }
+        // Paid tiers cannot be claimed via this endpoint — they require a
+        // successful Stripe checkout. Accepting `company_leader` etc. here
+        // would write the tier to the org row without billing, and any
+        // downstream gate that reads `membership_tier` directly (rather
+        // than `subscription_status`) could be fooled into granting paid
+        // entitlements. Direct callers to the dashboard /membership page.
+        if (!(BOOTSTRAP_ALLOWED_MEMBERSHIP_TIERS as readonly string[]).includes(membership_tier)) {
+          return res.status(400).json({
+            error: 'Paid tier requires checkout',
+            message: `membership_tier '${membership_tier}' requires a Stripe checkout session — it cannot be claimed via this endpoint. Either omit, set 'individual_academic', or complete checkout via /membership and let the webhook stamp the paid tier on the org.`,
+          });
+        }
       }
       let normalizedBrandDomain: string | null = null;
       if (primary_brand_domain !== undefined && primary_brand_domain !== null && primary_brand_domain !== '') {
@@ -416,14 +438,39 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       // First-time bootstrap: persist the org metadata captured on the form,
       // then ensure the corporate domain is recorded as verified (so brand
       // resolution + the agent endpoints work), then create the profile.
-      const orgUpdates: Record<string, unknown> = { name: trimmedName };
-      if (typeof company_type === 'string') orgUpdates.company_type = company_type;
-      if (typeof revenue_tier === 'string') orgUpdates.revenue_tier = revenue_tier;
-      if (typeof membership_tier === 'string') orgUpdates.membership_tier = membership_tier;
-      try {
-        await orgDb.updateOrganization(targetOrgId, orgUpdates);
-      } catch (err) {
-        logger.warn({ err, orgId: targetOrgId }, 'Failed to update org metadata during member-profile bootstrap');
+      //
+      // Org metadata writes are first-time-only. If a field is already set
+      // (e.g. an admin set `company_type` via the dashboard, or the org
+      // was bootstrapped in a prior call), we do not overwrite — we surface
+      // a `metadata_unchanged` warning instead so the caller knows their
+      // body value was ignored. Without this gate, any caller with a
+      // matching email domain could clobber org-level fields a workspace
+      // admin had already curated.
+      const existingOrg = await orgDb.getOrganization(targetOrgId);
+      const orgUpdates: Record<string, unknown> = {};
+      const metadataIgnored: string[] = [];
+      const considerField = (
+        bodyValue: unknown,
+        column: 'name' | 'company_type' | 'revenue_tier' | 'membership_tier',
+      ): void => {
+        if (bodyValue === undefined || bodyValue === null || bodyValue === '') return;
+        const currentValue = existingOrg ? (existingOrg as any)[column] : null;
+        if (currentValue === null || currentValue === undefined || currentValue === '') {
+          (orgUpdates as any)[column] = bodyValue;
+        } else if (currentValue !== bodyValue) {
+          metadataIgnored.push(column);
+        }
+      };
+      considerField(trimmedName, 'name');
+      considerField(company_type, 'company_type');
+      considerField(revenue_tier, 'revenue_tier');
+      considerField(membership_tier, 'membership_tier');
+      if (Object.keys(orgUpdates).length > 0) {
+        try {
+          await orgDb.updateOrganization(targetOrgId, orgUpdates);
+        } catch (err) {
+          logger.warn({ err, orgId: targetOrgId }, 'Failed to update org metadata during member-profile bootstrap');
+        }
       }
 
       // Mirror the email-verified domain insert from the org creation path.
@@ -470,6 +517,32 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
         }
       }
 
+      // Audit-log the bootstrap so org-level mutations (verified domain
+      // insert, metadata writes) are attributable. Failures here must not
+      // roll back the profile create — the row is already on disk and the
+      // call has materially succeeded — so we log-and-swallow.
+      try {
+        await orgDb.recordAuditLog({
+          workos_organization_id: targetOrgId,
+          workos_user_id: user.id,
+          action: 'member_profile_bootstrapped',
+          resource_type: 'member_profile',
+          resource_id: profile.id,
+          details: {
+            slug,
+            corporate_domain: corporateDomain,
+            updated_fields: Object.keys(orgUpdates),
+            ignored_fields: metadataIgnored,
+            ...(typeof company_type === 'string' ? { company_type } : {}),
+            ...(typeof revenue_tier === 'string' ? { revenue_tier } : {}),
+            ...(typeof membership_tier === 'string' ? { membership_tier } : {}),
+            ...(typeof marketing_opt_in === 'boolean' ? { marketing_opt_in } : {}),
+          },
+        });
+      } catch (err) {
+        logger.warn({ err, orgId: targetOrgId, profileId: profile.id }, 'Failed to write audit log for member-profile bootstrap');
+      }
+
       invalidateMemberContextCache();
 
       const refreshedOrg = await orgDb.getOrganization(targetOrgId);
@@ -478,10 +551,22 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
         orgId: targetOrgId,
         slug,
         durationMs: Date.now() - startTime,
+        metadataIgnored,
       }, 'POST /api/me/member-profile (bootstrap) completed');
+
+      const warnings: Array<Record<string, unknown>> = [];
+      if (metadataIgnored.length > 0) {
+        warnings.push({
+          code: 'metadata_unchanged',
+          fields: metadataIgnored,
+          message:
+            'Some org metadata fields were already set on the organization and were not overwritten. Update them via the dashboard or PUT /api/organizations/:orgId if you need to change them.',
+        });
+      }
 
       return res.status(201).json({
         profile: toSpecMemberProfile(profile, refreshedOrg, corporateDomain),
+        ...(warnings.length ? { warnings } : {}),
       });
     } catch (error) {
       logger.error({ err: error, durationMs: Date.now() - startTime }, 'POST /api/me/member-profile (bootstrap) error');
@@ -587,8 +672,10 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
     }
   });
 
-  // POST /api/me/member-profile - Create member profile for current user's organization
-  router.post('/', requireAuth, async (req, res) => {
+  // POST /api/me/member-profile - Create member profile for current user's organization.
+  // The bootstrap rate limiter `skip`s legacy `display_name`+`slug` bodies, so
+  // the dashboard profile-edit flow keeps its prior unmetered behavior.
+  router.post('/', requireAuth, memberProfileBootstrapRateLimiter, async (req, res) => {
     const startTime = Date.now();
     logger.info({ userId: req.user?.id, org: req.query.org }, 'POST /api/me/member-profile started');
     // Dispatch on body shape: the public REST bootstrap contract

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -18,11 +18,15 @@ import { query, getPool } from "../db/client.js";
 import { MemberDatabase } from "../db/member-db.js";
 import { BrandDatabase, resolveBrandFromJson } from "../db/brand-db.js";
 import { BrandManager } from "../brand-manager.js";
-import { OrganizationDatabase, hasApiAccess, readMembershipTierFromClient, resolveMembershipTier } from "../db/organization-db.js";
+import { OrganizationDatabase, hasApiAccess, readMembershipTierFromClient, resolveMembershipTier, VALID_REVENUE_TIERS, VALID_MEMBERSHIP_TIERS } from "../db/organization-db.js";
 import { OrgKnowledgeDatabase } from "../db/org-knowledge-db.js";
 import { autoLinkByVerifiedDomain } from "../db/membership-db.js";
 import { resolvePrimaryOrganization } from "../db/users-db.js";
 import { AAO_HOST } from "../config/aao.js";
+import { COMPANY_TYPE_VALUES } from "../config/company-types.js";
+import { getCompanyDomain } from "../utils/email-domain.js";
+import { emailPrefsDb } from "../db/email-preferences-db.js";
+import { slugify } from "../services/collection-feed-sync.js";
 import { VALID_MEMBER_OFFERINGS, isValidAgentVisibility, isValidAgentType } from "../types.js";
 import type { MemberBrandInfo, AgentVisibility, AgentConfig, AgentType } from "../types.js";
 import type { CrawlerService } from "../crawler.js";
@@ -205,6 +209,288 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
   const { workos, memberDb, brandDb, orgDb, invalidateMemberContextCache } = config;
   const router = Router();
 
+  // Domain-shape regex for corporate_domain — same coarse "looks-like-a-domain"
+  // check used in the org-creation path. Tighter validation (TLD presence,
+  // length per label) is applied implicitly by the email-domain match below.
+  const DOMAIN_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/;
+
+  // Render the spec MemberProfile shape from the DB profile + organization
+  // rows. This is the response shape documented in
+  // static/openapi/registry.yaml#MemberProfile — distinct from the legacy
+  // dashboard JSON which exposes the raw member_profiles row (display_name,
+  // slug, etc.). Required fields: organization_id, organization_name,
+  // company_type, corporate_domain, created_at, agents.
+  function toSpecMemberProfile(
+    profile: any,
+    org: any,
+    corporateDomain: string,
+  ): Record<string, unknown> {
+    const created = profile?.created_at instanceof Date
+      ? profile.created_at.toISOString()
+      : profile?.created_at;
+    return {
+      organization_id: profile.workos_organization_id,
+      organization_name: org?.name ?? profile.display_name,
+      company_type: org?.company_type ?? null,
+      ...(org?.revenue_tier ? { revenue_tier: org.revenue_tier } : {}),
+      corporate_domain: corporateDomain,
+      ...(profile.primary_brand_domain
+        ? { primary_brand_domain: profile.primary_brand_domain }
+        : {}),
+      ...(org?.membership_tier ? { membership_tier: org.membership_tier } : {}),
+      created_at: created,
+      agents: Array.isArray(profile.agents) ? profile.agents : [],
+    };
+  }
+
+  // Pick a unique slug from the organization name. Mirrors the helper in
+  // services/member-profile-autopublish.ts but kept inline so the bootstrap
+  // path doesn't import a publish-side module.
+  async function pickAvailableSlug(orgName: string): Promise<string> {
+    const base = slugify(orgName) || 'member';
+    if (await memberDb.isSlugAvailable(base)) return base;
+    for (let i = 2; i <= 99; i++) {
+      const candidate = `${base}-${i}`;
+      if (await memberDb.isSlugAvailable(candidate)) return candidate;
+    }
+    return `${base}-${Date.now()}`;
+  }
+
+  // POST /api/me/member-profile bootstrap path. Documented contract in
+  // static/openapi/registry.yaml. Idempotent on the (org, profile) pair:
+  // re-posting against an org that already has a profile returns 200 with
+  // the existing profile and a `profile_already_exists` warning, NOT 409 —
+  // the dashboard create flow returns 409 by design (caller should switch
+  // to PUT), but the REST bootstrap surface is consumed by automation that
+  // benefits from retry-friendly idempotency.
+  async function handleBootstrapMemberProfile(req: any, res: any, startTime: number) {
+    try {
+      const user = req.user!;
+      const requestedOrgId = req.query.org as string | undefined;
+      const {
+        organization_name,
+        company_type,
+        revenue_tier,
+        corporate_domain,
+        primary_brand_domain,
+        marketing_opt_in,
+        membership_tier,
+      } = req.body as Record<string, unknown>;
+
+      const trimmedName = typeof organization_name === 'string' ? organization_name.trim() : '';
+      if (!trimmedName || trimmedName.length > 200) {
+        return res.status(400).json({
+          error: 'Invalid organization_name',
+          message: 'organization_name is required and must be 1-200 characters',
+        });
+      }
+      if (typeof company_type !== 'string' || !(COMPANY_TYPE_VALUES as readonly string[]).includes(company_type)) {
+        return res.status(400).json({
+          error: 'Invalid company_type',
+          message: `company_type must be one of: ${COMPANY_TYPE_VALUES.join(', ')}`,
+        });
+      }
+      const corporateDomain = typeof corporate_domain === 'string'
+        ? corporate_domain.toLowerCase().trim()
+        : '';
+      if (!corporateDomain || corporateDomain.length > 253 || !DOMAIN_RE.test(corporateDomain)) {
+        return res.status(400).json({
+          error: 'Invalid corporate_domain',
+          message: 'corporate_domain must be a valid domain like "acme.com"',
+        });
+      }
+      if (revenue_tier !== undefined && (typeof revenue_tier !== 'string' || !(VALID_REVENUE_TIERS as readonly string[]).includes(revenue_tier))) {
+        return res.status(400).json({
+          error: 'Invalid revenue_tier',
+          message: `revenue_tier must be one of: ${VALID_REVENUE_TIERS.join(', ')}`,
+        });
+      }
+      if (membership_tier !== undefined && (typeof membership_tier !== 'string' || !(VALID_MEMBERSHIP_TIERS as readonly string[]).includes(membership_tier))) {
+        return res.status(400).json({
+          error: 'Invalid membership_tier',
+          message: `membership_tier must be one of: ${VALID_MEMBERSHIP_TIERS.join(', ')}`,
+        });
+      }
+      let normalizedBrandDomain: string | null = null;
+      if (primary_brand_domain !== undefined && primary_brand_domain !== null && primary_brand_domain !== '') {
+        if (typeof primary_brand_domain !== 'string') {
+          return res.status(400).json({
+            error: 'Invalid primary_brand_domain',
+            message: 'primary_brand_domain must be a string',
+          });
+        }
+        const candidate = primary_brand_domain.toLowerCase().trim();
+        if (!candidate || candidate.length > 253 || !DOMAIN_RE.test(candidate)) {
+          return res.status(400).json({
+            error: 'Invalid primary_brand_domain',
+            message: 'primary_brand_domain must be a valid domain like "acme.com"',
+          });
+        }
+        normalizedBrandDomain = candidate;
+      }
+
+      // Email-domain match. getCompanyDomain returns null for personal-email
+      // domains (gmail.com, yahoo.com, etc.) — those cannot bootstrap a
+      // corporate profile. Mismatch between the verified email domain and
+      // the supplied corporate_domain is also rejected.
+      const userCompanyDomain = getCompanyDomain(user.email);
+      if (!userCompanyDomain) {
+        return res.status(403).json({
+          error: 'Personal email domain',
+          message: 'Personal email domains cannot register a corporate member profile. Sign in with a corporate email and try again.',
+        });
+      }
+      if (userCompanyDomain !== corporateDomain) {
+        return res.status(403).json({
+          error: 'Domain mismatch',
+          message: `corporate_domain must match your email domain (${userCompanyDomain}).`,
+        });
+      }
+
+      // Resolve target org. Mirrors the legacy POST resolver below.
+      let targetOrgId: string;
+      const isDevUserProfile = isDevModeEnabled()
+        && Object.values(DEV_USERS).some(du => du.id === user.id)
+        && requestedOrgId?.startsWith('org_dev_');
+      if (isDevUserProfile) {
+        const localOrg = await orgDb.getOrganization(requestedOrgId!);
+        if (!localOrg) {
+          return res.status(404).json({
+            error: 'Organization not found',
+            message: 'The requested organization does not exist',
+          });
+        }
+        targetOrgId = requestedOrgId!;
+      } else {
+        let memberships = await workos!.userManagement.listOrganizationMemberships({
+          userId: user.id,
+        });
+        const linked = await autoLinkByVerifiedDomain(workos!, user.id, user.email);
+        if (linked) {
+          memberships = await workos!.userManagement.listOrganizationMemberships({
+            userId: user.id,
+          });
+        }
+        if (memberships.data.length === 0) {
+          return res.status(404).json({
+            error: 'No organization',
+            message: 'User is not a member of any organization. Create one via POST /api/organizations first.',
+          });
+        }
+        if (requestedOrgId) {
+          const membership = memberships.data.find(m => m.organizationId === requestedOrgId);
+          if (!membership) {
+            return res.status(403).json({
+              error: 'Not authorized',
+              message: 'User is not a member of the requested organization',
+            });
+          }
+          const role = membership.role?.slug || 'member';
+          if (role !== 'admin' && role !== 'owner') {
+            return res.status(403).json({
+              error: 'Not authorized',
+              message: 'Only admins and owners can create member profiles',
+            });
+          }
+          targetOrgId = requestedOrgId;
+        } else {
+          targetOrgId = memberships.data[0].organizationId;
+        }
+      }
+
+      // Idempotency: existing profile → 200 with current state and a warning,
+      // not 409. Documented in the spec as the retry-safe behavior.
+      const existingProfile = await memberDb.getProfileByOrgId(targetOrgId);
+      if (existingProfile) {
+        const existingOrg = await orgDb.getOrganization(targetOrgId);
+        logger.info({ userId: user.id, orgId: targetOrgId, durationMs: Date.now() - startTime }, 'POST /api/me/member-profile (bootstrap) idempotent hit');
+        return res.status(200).json({
+          profile: toSpecMemberProfile(existingProfile, existingOrg, corporateDomain),
+          warnings: [{
+            code: 'profile_already_exists',
+            message: 'Member profile already exists for this organization; no fields were mutated.',
+          }],
+        });
+      }
+
+      // First-time bootstrap: persist the org metadata captured on the form,
+      // then ensure the corporate domain is recorded as verified (so brand
+      // resolution + the agent endpoints work), then create the profile.
+      const orgUpdates: Record<string, unknown> = { name: trimmedName };
+      if (typeof company_type === 'string') orgUpdates.company_type = company_type;
+      if (typeof revenue_tier === 'string') orgUpdates.revenue_tier = revenue_tier;
+      if (typeof membership_tier === 'string') orgUpdates.membership_tier = membership_tier;
+      try {
+        await orgDb.updateOrganization(targetOrgId, orgUpdates);
+      } catch (err) {
+        logger.warn({ err, orgId: targetOrgId }, 'Failed to update org metadata during member-profile bootstrap');
+      }
+
+      // Mirror the email-verified domain insert from the org creation path.
+      // ON CONFLICT DO NOTHING is safe — if another org already owns the
+      // domain we leave the existing record alone (admin-resolvable) and
+      // continue creating the profile so the caller isn't blocked.
+      const pool = getPool();
+      try {
+        await pool.query(
+          `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source)
+           VALUES ($1, $2, true, true, 'email_verification')
+           ON CONFLICT (domain) DO NOTHING`,
+          [targetOrgId, corporateDomain],
+        );
+      } catch (err) {
+        logger.warn({ err, orgId: targetOrgId, domain: corporateDomain }, 'Failed to write organization_domains during bootstrap');
+      }
+
+      const slug = await pickAvailableSlug(trimmedName);
+
+      const profile = await memberDb.createProfile({
+        workos_organization_id: targetOrgId,
+        display_name: trimmedName,
+        slug,
+        ...(normalizedBrandDomain ? { primary_brand_domain: normalizedBrandDomain } : {}),
+        // Default privacy posture for a bootstrapped profile is private —
+        // the caller can flip is_public via PUT /api/me/member-profile/visibility
+        // once they have an active subscription. The legacy POST path applies
+        // the same gating; this surface deliberately doesn't accept is_public.
+        is_public: false,
+        show_in_carousel: false,
+      });
+
+      // Best-effort marketing opt-in record. Failures must not block bootstrap.
+      if (typeof marketing_opt_in === 'boolean') {
+        try {
+          await emailPrefsDb.setMarketingOptInIfNotSet({
+            workos_user_id: user.id,
+            email: user.email,
+            optIn: marketing_opt_in,
+          });
+        } catch (err) {
+          logger.warn({ err, userId: user.id }, 'Failed to record marketing opt-in during bootstrap');
+        }
+      }
+
+      invalidateMemberContextCache();
+
+      const refreshedOrg = await orgDb.getOrganization(targetOrgId);
+      logger.info({
+        profileId: profile.id,
+        orgId: targetOrgId,
+        slug,
+        durationMs: Date.now() - startTime,
+      }, 'POST /api/me/member-profile (bootstrap) completed');
+
+      return res.status(201).json({
+        profile: toSpecMemberProfile(profile, refreshedOrg, corporateDomain),
+      });
+    } catch (error) {
+      logger.error({ err: error, durationMs: Date.now() - startTime }, 'POST /api/me/member-profile (bootstrap) error');
+      return res.status(500).json({
+        error: 'Failed to create member profile',
+      });
+    }
+  }
+
   // GET /api/me/member-profile - Get current user's organization's member profile
   router.get('/', requireAuth, async (req, res) => {
     const startTime = Date.now();
@@ -305,6 +591,22 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
   router.post('/', requireAuth, async (req, res) => {
     const startTime = Date.now();
     logger.info({ userId: req.user?.id, org: req.query.org }, 'POST /api/me/member-profile started');
+    // Dispatch on body shape: the public REST bootstrap contract
+    // (organization_name + corporate_domain, no display_name) is documented in
+    // static/openapi/registry.yaml#CreateMemberProfileInput. The legacy
+    // dashboard profile-edit flow (display_name + slug) keeps its original
+    // handler below so /community/profile-edit and /member-profile.html stay
+    // wired to the existing semantics (409 on conflict, full profile body).
+    if (
+      req.body
+      && typeof req.body === 'object'
+      && typeof (req.body as any).organization_name === 'string'
+      && typeof (req.body as any).corporate_domain === 'string'
+      && typeof (req.body as any).display_name !== 'string'
+      && typeof (req.body as any).slug !== 'string'
+    ) {
+      return handleBootstrapMemberProfile(req, res, startTime);
+    }
     try {
       const user = req.user!;
       const requestedOrgId = req.query.org as string | undefined;

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -27,7 +27,10 @@ import { COMPANY_TYPE_VALUES } from "../config/company-types.js";
 import { getCompanyDomain } from "../utils/email-domain.js";
 import { emailPrefsDb } from "../db/email-preferences-db.js";
 import { slugify } from "../services/collection-feed-sync.js";
-import { memberProfileBootstrapRateLimiter } from "../middleware/rate-limit.js";
+import {
+  isMemberProfileBootstrapBody,
+  memberProfileBootstrapRateLimiter,
+} from "../middleware/rate-limit.js";
 
 // Membership tiers a caller may set via the REST bootstrap body. Paid tiers
 // (`individual_professional`, `company_*`) require a successful Stripe
@@ -422,12 +425,29 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
 
       // Idempotency: existing profile → 200 with current state and a warning,
       // not 409. Documented in the spec as the retry-safe behavior.
+      // Source `corporate_domain` for the response from the org's primary
+      // verified domain row, not from whatever the caller sent. A multi-domain
+      // org may legitimately have multiple email-domain memberships; echoing
+      // the caller's value would leak that detail and could mislead the
+      // caller about which domain actually owns their profile.
+      const resolvePrimaryDomain = async (orgId: string, fallback: string): Promise<string> => {
+        const r = await getPool().query<{ domain: string }>(
+          `SELECT domain FROM organization_domains
+           WHERE workos_organization_id = $1 AND is_primary = true AND verified = true
+           ORDER BY domain ASC
+           LIMIT 1`,
+          [orgId],
+        );
+        return r.rows[0]?.domain ?? fallback;
+      };
+
       const existingProfile = await memberDb.getProfileByOrgId(targetOrgId);
       if (existingProfile) {
         const existingOrg = await orgDb.getOrganization(targetOrgId);
+        const primaryDomain = await resolvePrimaryDomain(targetOrgId, corporateDomain);
         logger.info({ userId: user.id, orgId: targetOrgId, durationMs: Date.now() - startTime }, 'POST /api/me/member-profile (bootstrap) idempotent hit');
         return res.status(200).json({
-          profile: toSpecMemberProfile(existingProfile, existingOrg, corporateDomain),
+          profile: toSpecMemberProfile(existingProfile, existingOrg, primaryDomain),
           warnings: [{
             code: 'profile_already_exists',
             message: 'Member profile already exists for this organization; no fields were mutated.',
@@ -448,7 +468,16 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       // admin had already curated.
       const existingOrg = await orgDb.getOrganization(targetOrgId);
       const orgUpdates: Record<string, unknown> = {};
-      const metadataIgnored: string[] = [];
+      const metadataIgnoredApiFields: string[] = [];
+      // Map DB column → public API field name. Callers know about
+      // `organization_name`, not the underlying `organizations.name` column;
+      // the response-side warning must speak the API's vocabulary.
+      const COLUMN_TO_API_FIELD: Record<string, string> = {
+        name: 'organization_name',
+        company_type: 'company_type',
+        revenue_tier: 'revenue_tier',
+        membership_tier: 'membership_tier',
+      };
       const considerField = (
         bodyValue: unknown,
         column: 'name' | 'company_type' | 'revenue_tier' | 'membership_tier',
@@ -458,7 +487,7 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
         if (currentValue === null || currentValue === undefined || currentValue === '') {
           (orgUpdates as any)[column] = bodyValue;
         } else if (currentValue !== bodyValue) {
-          metadataIgnored.push(column);
+          metadataIgnoredApiFields.push(COLUMN_TO_API_FIELD[column]);
         }
       };
       considerField(trimmedName, 'name');
@@ -473,18 +502,35 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
         }
       }
 
-      // Mirror the email-verified domain insert from the org creation path.
-      // ON CONFLICT DO NOTHING is safe — if another org already owns the
-      // domain we leave the existing record alone (admin-resolvable) and
-      // continue creating the profile so the caller isn't blocked.
+      // Mirror the email-verified domain insert from the org creation path,
+      // but check for a pre-existing claim explicitly so we can surface a
+      // `domain_already_claimed` warning rather than silently no-op'ing
+      // the link-up. Without this, a caller from acme.com whose domain
+      // is already bound to a different org would walk away with a profile
+      // on this org and no domain link — half-broken state, no signal.
+      // We still create the profile so programmatic callers aren't blocked
+      // on an admin-resolvable issue.
       const pool = getPool();
+      let domainConflictOrgId: string | null = null;
       try {
-        await pool.query(
-          `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source)
-           VALUES ($1, $2, true, true, 'email_verification')
-           ON CONFLICT (domain) DO NOTHING`,
-          [targetOrgId, corporateDomain],
+        const existingDomain = await pool.query<{ workos_organization_id: string }>(
+          `SELECT workos_organization_id FROM organization_domains WHERE LOWER(domain) = LOWER($1)`,
+          [corporateDomain],
         );
+        if (existingDomain.rows.length === 0) {
+          await pool.query(
+            `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source)
+             VALUES ($1, $2, true, true, 'email_verification')
+             ON CONFLICT (domain) DO NOTHING`,
+            [targetOrgId, corporateDomain],
+          );
+        } else if (existingDomain.rows[0].workos_organization_id !== targetOrgId) {
+          domainConflictOrgId = existingDomain.rows[0].workos_organization_id;
+          logger.warn(
+            { orgId: targetOrgId, conflictOrgId: domainConflictOrgId, domain: corporateDomain },
+            'Bootstrap: corporate_domain already linked to a different org; profile created without domain link',
+          );
+        }
       } catch (err) {
         logger.warn({ err, orgId: targetOrgId, domain: corporateDomain }, 'Failed to write organization_domains during bootstrap');
       }
@@ -517,6 +563,45 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
         }
       }
 
+      // Record Terms-of-Service and Privacy-Policy acceptance from the
+      // request context, mirroring the org-creation flow. The OpenAPI body
+      // documents `marketing_opt_in` as "Independent of Terms of Service
+      // consent (which is required and recorded server-side from the
+      // request context)" — without this block that claim is fiction.
+      // Best-effort; an audit-row failure must not roll back a successful
+      // profile create.
+      try {
+        const tosAgreement = await orgDb.getCurrentAgreementByType('terms_of_service');
+        const privacyAgreement = await orgDb.getCurrentAgreementByType('privacy_policy');
+        const ipAddress = req.ip
+          || (typeof req.headers['x-forwarded-for'] === 'string' ? (req.headers['x-forwarded-for'] as string) : 'unknown');
+        const userAgent = (req.headers['user-agent'] as string) || 'unknown';
+        if (tosAgreement) {
+          await orgDb.recordUserAgreementAcceptance({
+            workos_user_id: user.id,
+            email: user.email,
+            agreement_type: 'terms_of_service',
+            agreement_version: tosAgreement.version,
+            ip_address: ipAddress,
+            user_agent: userAgent,
+            workos_organization_id: targetOrgId,
+          });
+        }
+        if (privacyAgreement) {
+          await orgDb.recordUserAgreementAcceptance({
+            workos_user_id: user.id,
+            email: user.email,
+            agreement_type: 'privacy_policy',
+            agreement_version: privacyAgreement.version,
+            ip_address: ipAddress,
+            user_agent: userAgent,
+            workos_organization_id: targetOrgId,
+          });
+        }
+      } catch (err) {
+        logger.warn({ err, userId: user.id, orgId: targetOrgId }, 'Failed to record ToS / privacy-policy acceptance during bootstrap');
+      }
+
       // Audit-log the bootstrap so org-level mutations (verified domain
       // insert, metadata writes) are attributable. Failures here must not
       // roll back the profile create — the row is already on disk and the
@@ -532,7 +617,8 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
             slug,
             corporate_domain: corporateDomain,
             updated_fields: Object.keys(orgUpdates),
-            ignored_fields: metadataIgnored,
+            ignored_fields: metadataIgnoredApiFields,
+            domain_conflict_org_id: domainConflictOrgId,
             ...(typeof company_type === 'string' ? { company_type } : {}),
             ...(typeof revenue_tier === 'string' ? { revenue_tier } : {}),
             ...(typeof membership_tier === 'string' ? { membership_tier } : {}),
@@ -546,26 +632,36 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       invalidateMemberContextCache();
 
       const refreshedOrg = await orgDb.getOrganization(targetOrgId);
+      const primaryDomain = await resolvePrimaryDomain(targetOrgId, corporateDomain);
       logger.info({
         profileId: profile.id,
         orgId: targetOrgId,
         slug,
         durationMs: Date.now() - startTime,
-        metadataIgnored,
+        metadataIgnoredApiFields,
+        domainConflictOrgId,
       }, 'POST /api/me/member-profile (bootstrap) completed');
 
       const warnings: Array<Record<string, unknown>> = [];
-      if (metadataIgnored.length > 0) {
+      if (metadataIgnoredApiFields.length > 0) {
         warnings.push({
           code: 'metadata_unchanged',
-          fields: metadataIgnored,
+          fields: metadataIgnoredApiFields,
           message:
             'Some org metadata fields were already set on the organization and were not overwritten. Update them via the dashboard or PUT /api/organizations/:orgId if you need to change them.',
         });
       }
+      if (domainConflictOrgId) {
+        warnings.push({
+          code: 'domain_already_claimed',
+          domain: corporateDomain,
+          message:
+            `corporate_domain '${corporateDomain}' is already linked to a different organization, so it was not attached to this profile's organization. The profile was created, but registry surfaces that resolve via the verified domain (e.g. brand.json publish) won't reflect it. Email support@agenticadvertising.org to resolve the domain ownership.`,
+        });
+      }
 
       return res.status(201).json({
-        profile: toSpecMemberProfile(profile, refreshedOrg, corporateDomain),
+        profile: toSpecMemberProfile(profile, refreshedOrg, primaryDomain),
         ...(warnings.length ? { warnings } : {}),
       });
     } catch (error) {
@@ -684,14 +780,7 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
     // dashboard profile-edit flow (display_name + slug) keeps its original
     // handler below so /community/profile-edit and /member-profile.html stay
     // wired to the existing semantics (409 on conflict, full profile body).
-    if (
-      req.body
-      && typeof req.body === 'object'
-      && typeof (req.body as any).organization_name === 'string'
-      && typeof (req.body as any).corporate_domain === 'string'
-      && typeof (req.body as any).display_name !== 'string'
-      && typeof (req.body as any).slug !== 'string'
-    ) {
+    if (isMemberProfileBootstrapBody(req.body)) {
       return handleBootstrapMemberProfile(req, res, startTime);
     }
     try {

--- a/server/tests/integration/member-profile-bootstrap.test.ts
+++ b/server/tests/integration/member-profile-bootstrap.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Integration tests for the REST bootstrap path on `POST /api/me/member-profile`.
+ *
+ * The legacy dashboard flow (display_name + slug body) is unaffected by this
+ * dispatch and remains covered by other suites. This file exercises only the
+ * spec-shape branch documented in static/openapi/registry.yaml.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+
+vi.mock('../../src/middleware/auth.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/middleware/auth.js')>(
+    '../../src/middleware/auth.js',
+  );
+  return {
+    ...actual,
+    requireAuth: (_req: any, _res: any, next: any) => next(),
+  };
+});
+
+import express from 'express';
+import request from 'supertest';
+import type { Pool } from 'pg';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { MemberDatabase } from '../../src/db/member-db.js';
+import { OrganizationDatabase } from '../../src/db/organization-db.js';
+import { BrandDatabase } from '../../src/db/brand-db.js';
+import { createMemberProfileRouter } from '../../src/routes/member-profiles.js';
+
+const TEST_PREFIX = 'org_member_profile_boot';
+
+describe('POST /api/me/member-profile (REST bootstrap)', () => {
+  let pool: Pool;
+  let app: express.Application;
+  let memberDb: MemberDatabase;
+  let orgDb: OrganizationDatabase;
+  let brandDb: BrandDatabase;
+  let currentUserEmail = 'owner@acme.example';
+  let currentUserId = 'user_boot_owner';
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString:
+        process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_registry',
+      max: 5,
+    });
+    await runMigrations();
+
+    memberDb = new MemberDatabase();
+    orgDb = new OrganizationDatabase();
+    brandDb = new BrandDatabase();
+
+    app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).user = {
+        id: currentUserId,
+        email: currentUserEmail,
+        firstName: 'Test',
+        lastName: 'User',
+      };
+      next();
+    });
+
+    const fakeWorkos = {
+      userManagement: {
+        listOrganizationMemberships: async ({ userId }: { userId: string }) => {
+          const rows = await pool.query<{ workos_organization_id: string; role: string }>(
+            `SELECT workos_organization_id, role FROM organization_memberships WHERE workos_user_id = $1`,
+            [userId],
+          );
+          return {
+            data: rows.rows.map((r) => ({
+              userId,
+              organizationId: r.workos_organization_id,
+              status: 'active' as const,
+              role: { slug: r.role || 'owner' },
+            })),
+          };
+        },
+      },
+      organizations: {
+        getOrganization: async (orgId: string) => {
+          const row = await pool.query<{ name: string }>(
+            `SELECT name FROM organizations WHERE workos_organization_id = $1`,
+            [orgId],
+          );
+          return { id: orgId, name: row.rows[0]?.name ?? 'Unknown' };
+        },
+      },
+    } as any;
+
+    app.use(
+      '/api/me/member-profile',
+      createMemberProfileRouter({
+        memberDb,
+        brandDb,
+        orgDb,
+        workos: fakeWorkos,
+        invalidateMemberContextCache: () => {},
+      }),
+    );
+  });
+
+  afterAll(async () => {
+    await pool.query(`DELETE FROM organization_domains WHERE workos_organization_id LIKE $1`, [
+      `${TEST_PREFIX}%`,
+    ]);
+    await pool.query(`DELETE FROM member_profiles WHERE workos_organization_id LIKE $1`, [
+      `${TEST_PREFIX}%`,
+    ]);
+    await pool.query(`DELETE FROM organization_memberships WHERE workos_organization_id LIKE $1`, [
+      `${TEST_PREFIX}%`,
+    ]);
+    await pool.query(`DELETE FROM organizations WHERE workos_organization_id LIKE $1`, [
+      `${TEST_PREFIX}%`,
+    ]);
+    await closeDatabase();
+  });
+
+  async function seedOrg(orgId: string) {
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+       VALUES ($1, $2, false, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO UPDATE SET name = EXCLUDED.name`,
+      [orgId, 'Placeholder Co'],
+    );
+    await pool.query(
+      `INSERT INTO organization_memberships (workos_user_id, workos_organization_id, role, email, created_at, updated_at)
+       VALUES ($1, $2, 'owner', $3, NOW(), NOW())
+       ON CONFLICT (workos_user_id, workos_organization_id) DO UPDATE SET role = 'owner'`,
+      [currentUserId, orgId, currentUserEmail],
+    );
+  }
+
+  beforeEach(async () => {
+    currentUserEmail = 'owner@acme.example';
+    currentUserId = 'user_boot_owner';
+    await pool.query(`DELETE FROM organization_domains WHERE workos_organization_id LIKE $1`, [
+      `${TEST_PREFIX}%`,
+    ]);
+    await pool.query(`DELETE FROM member_profiles WHERE workos_organization_id LIKE $1`, [
+      `${TEST_PREFIX}%`,
+    ]);
+    await pool.query(`DELETE FROM organization_memberships WHERE workos_organization_id LIKE $1`, [
+      `${TEST_PREFIX}%`,
+    ]);
+    await pool.query(`DELETE FROM organizations WHERE workos_organization_id LIKE $1`, [
+      `${TEST_PREFIX}%`,
+    ]);
+  });
+
+  it('creates a profile and persists org metadata + verified domain on first call (201)', async () => {
+    const orgId = `${TEST_PREFIX}_create`;
+    await seedOrg(orgId);
+
+    const res = await request(app)
+      .post('/api/me/member-profile')
+      .send({
+        organization_name: 'Acme Media',
+        company_type: 'publisher',
+        revenue_tier: '5m_50m',
+        corporate_domain: 'acme.example',
+        primary_brand_domain: 'acme.example',
+        marketing_opt_in: true,
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.profile).toMatchObject({
+      organization_id: orgId,
+      organization_name: 'Acme Media',
+      company_type: 'publisher',
+      revenue_tier: '5m_50m',
+      corporate_domain: 'acme.example',
+      primary_brand_domain: 'acme.example',
+      agents: [],
+    });
+    expect(typeof res.body.profile.created_at).toBe('string');
+
+    const orgRow = await pool.query<{ name: string; company_type: string; revenue_tier: string }>(
+      `SELECT name, company_type, revenue_tier FROM organizations WHERE workos_organization_id = $1`,
+      [orgId],
+    );
+    expect(orgRow.rows[0]).toMatchObject({
+      name: 'Acme Media',
+      company_type: 'publisher',
+      revenue_tier: '5m_50m',
+    });
+
+    const domainRow = await pool.query<{ verified: boolean; source: string }>(
+      `SELECT verified, source FROM organization_domains WHERE workos_organization_id = $1 AND domain = $2`,
+      [orgId, 'acme.example'],
+    );
+    expect(domainRow.rows[0]).toMatchObject({ verified: true, source: 'email_verification' });
+  });
+
+  it('is idempotent — second call returns 200 with profile_already_exists warning', async () => {
+    const orgId = `${TEST_PREFIX}_idempotent`;
+    await seedOrg(orgId);
+
+    const first = await request(app)
+      .post('/api/me/member-profile')
+      .send({
+        organization_name: 'Acme Idempotent',
+        company_type: 'publisher',
+        corporate_domain: 'acme.example',
+      });
+    expect(first.status).toBe(201);
+
+    const second = await request(app)
+      .post('/api/me/member-profile')
+      .send({
+        organization_name: 'Acme Idempotent',
+        company_type: 'publisher',
+        corporate_domain: 'acme.example',
+      });
+    expect(second.status).toBe(200);
+    expect(second.body.profile.organization_id).toBe(orgId);
+    expect(second.body.warnings).toEqual([
+      expect.objectContaining({ code: 'profile_already_exists' }),
+    ]);
+  });
+
+  it('rejects personal email domains with 403', async () => {
+    currentUserEmail = 'user@gmail.com';
+    currentUserId = 'user_boot_personal';
+    const orgId = `${TEST_PREFIX}_personal`;
+    await seedOrg(orgId);
+
+    const res = await request(app)
+      .post('/api/me/member-profile')
+      .send({
+        organization_name: 'Acme',
+        company_type: 'publisher',
+        corporate_domain: 'acme.example',
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('Personal email domain');
+  });
+
+  it('rejects domain mismatch with 403', async () => {
+    currentUserEmail = 'owner@acme.example';
+    const orgId = `${TEST_PREFIX}_mismatch`;
+    await seedOrg(orgId);
+
+    const res = await request(app)
+      .post('/api/me/member-profile')
+      .send({
+        organization_name: 'Other Co',
+        company_type: 'publisher',
+        corporate_domain: 'other.example',
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('Domain mismatch');
+  });
+
+  it('rejects unknown company_type with 400', async () => {
+    const orgId = `${TEST_PREFIX}_badtype`;
+    await seedOrg(orgId);
+
+    const res = await request(app)
+      .post('/api/me/member-profile')
+      .send({
+        organization_name: 'Acme',
+        company_type: 'not_a_real_type',
+        corporate_domain: 'acme.example',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Invalid company_type');
+  });
+
+  it('returns 404 when caller has no organization', async () => {
+    currentUserId = 'user_boot_orphan';
+    currentUserEmail = 'orphan@acme.example';
+
+    const res = await request(app)
+      .post('/api/me/member-profile')
+      .send({
+        organization_name: 'Acme',
+        company_type: 'publisher',
+        corporate_domain: 'acme.example',
+      });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('No organization');
+  });
+
+  it('still routes legacy display_name + slug bodies to the original handler', async () => {
+    const orgId = `${TEST_PREFIX}_legacy`;
+    await seedOrg(orgId);
+
+    const res = await request(app)
+      .post('/api/me/member-profile')
+      .send({
+        display_name: 'Legacy Profile',
+        slug: 'legacy-profile-boot',
+      });
+
+    // Legacy handler returns 201 + the raw DB profile shape (display_name,
+    // slug). We don't assert the full body — only that the bootstrap branch
+    // didn't intercept (no organization_id at top level of profile).
+    expect(res.status).toBe(201);
+    expect(res.body.profile.display_name).toBe('Legacy Profile');
+    expect(res.body.profile.slug).toBe('legacy-profile-boot');
+    expect(res.body.profile.organization_id).toBeUndefined();
+  });
+});

--- a/server/tests/integration/member-profile-bootstrap.test.ts
+++ b/server/tests/integration/member-profile-bootstrap.test.ts
@@ -17,6 +17,20 @@ vi.mock('../../src/middleware/auth.js', async () => {
   };
 });
 
+// Bypass the bootstrap rate limiter — its CachedPostgresStore would otherwise
+// retain state across tests in the same suite and across suites in the same
+// process. Each individual test still exercises the limiter's `skip` rule
+// (legacy bodies vs. bootstrap bodies) implicitly through the route dispatch.
+vi.mock('../../src/middleware/rate-limit.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/middleware/rate-limit.js')>(
+    '../../src/middleware/rate-limit.js',
+  );
+  return {
+    ...actual,
+    memberProfileBootstrapRateLimiter: (_req: any, _res: any, next: any) => next(),
+  };
+});
+
 import express from 'express';
 import request from 'supertest';
 import type { Pool } from 'pg';
@@ -112,18 +126,29 @@ describe('POST /api/me/member-profile (REST bootstrap)', () => {
     await pool.query(`DELETE FROM organization_memberships WHERE workos_organization_id LIKE $1`, [
       `${TEST_PREFIX}%`,
     ]);
+    await pool.query(`DELETE FROM registry_audit_log WHERE workos_organization_id LIKE $1`, [
+      `${TEST_PREFIX}%`,
+    ]);
     await pool.query(`DELETE FROM organizations WHERE workos_organization_id LIKE $1`, [
       `${TEST_PREFIX}%`,
     ]);
     await closeDatabase();
   });
 
-  async function seedOrg(orgId: string) {
+  async function seedOrg(
+    orgId: string,
+    overrides: Partial<{ name: string; company_type: string | null; revenue_tier: string | null; membership_tier: string | null }> = {},
+  ) {
+    const name = overrides.name ?? 'Acme Media';
     await pool.query(
-      `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
-       VALUES ($1, $2, false, NOW(), NOW())
-       ON CONFLICT (workos_organization_id) DO UPDATE SET name = EXCLUDED.name`,
-      [orgId, 'Placeholder Co'],
+      `INSERT INTO organizations (workos_organization_id, name, is_personal, company_type, revenue_tier, membership_tier, created_at, updated_at)
+       VALUES ($1, $2, false, $3, $4, $5, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO UPDATE SET
+         name = EXCLUDED.name,
+         company_type = EXCLUDED.company_type,
+         revenue_tier = EXCLUDED.revenue_tier,
+         membership_tier = EXCLUDED.membership_tier`,
+      [orgId, name, overrides.company_type ?? null, overrides.revenue_tier ?? null, overrides.membership_tier ?? null],
     );
     await pool.query(
       `INSERT INTO organization_memberships (workos_user_id, workos_organization_id, role, email, created_at, updated_at)
@@ -136,6 +161,9 @@ describe('POST /api/me/member-profile (REST bootstrap)', () => {
   beforeEach(async () => {
     currentUserEmail = 'owner@acme.example';
     currentUserId = 'user_boot_owner';
+    await pool.query(`DELETE FROM registry_audit_log WHERE workos_organization_id LIKE $1`, [
+      `${TEST_PREFIX}%`,
+    ]);
     await pool.query(`DELETE FROM organization_domains WHERE workos_organization_id LIKE $1`, [
       `${TEST_PREFIX}%`,
     ]);
@@ -286,6 +314,124 @@ describe('POST /api/me/member-profile (REST bootstrap)', () => {
 
     expect(res.status).toBe(404);
     expect(res.body.error).toBe('No organization');
+  });
+
+  it('rejects paid membership_tier values with 400', async () => {
+    const orgId = `${TEST_PREFIX}_paid_tier`;
+    await seedOrg(orgId);
+
+    const res = await request(app)
+      .post('/api/me/member-profile')
+      .send({
+        organization_name: 'Acme',
+        company_type: 'publisher',
+        corporate_domain: 'acme.example',
+        membership_tier: 'company_leader',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Paid tier requires checkout');
+
+    const orgRow = await pool.query<{ membership_tier: string | null }>(
+      `SELECT membership_tier FROM organizations WHERE workos_organization_id = $1`,
+      [orgId],
+    );
+    expect(orgRow.rows[0].membership_tier).toBeNull();
+  });
+
+  it('accepts the free Explorer tier (individual_academic)', async () => {
+    const orgId = `${TEST_PREFIX}_free_tier`;
+    await seedOrg(orgId);
+
+    const res = await request(app)
+      .post('/api/me/member-profile')
+      .send({
+        organization_name: 'Acme',
+        company_type: 'publisher',
+        corporate_domain: 'acme.example',
+        membership_tier: 'individual_academic',
+      });
+
+    expect(res.status).toBe(201);
+
+    const orgRow = await pool.query<{ membership_tier: string | null }>(
+      `SELECT membership_tier FROM organizations WHERE workos_organization_id = $1`,
+      [orgId],
+    );
+    expect(orgRow.rows[0].membership_tier).toBe('individual_academic');
+  });
+
+  it('does not overwrite pre-existing org metadata; surfaces metadata_unchanged warning', async () => {
+    const orgId = `${TEST_PREFIX}_no_overwrite`;
+    await seedOrg(orgId, {
+      name: 'Pre-Curated Co',
+      company_type: 'agency',
+      revenue_tier: '50m_250m',
+    });
+
+    const res = await request(app)
+      .post('/api/me/member-profile')
+      .send({
+        organization_name: 'Programmatic Override',
+        company_type: 'publisher',
+        revenue_tier: '5m_50m',
+        corporate_domain: 'acme.example',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.warnings).toEqual([
+      expect.objectContaining({
+        code: 'metadata_unchanged',
+        fields: expect.arrayContaining(['name', 'company_type', 'revenue_tier']),
+      }),
+    ]);
+
+    const orgRow = await pool.query<{ name: string; company_type: string; revenue_tier: string }>(
+      `SELECT name, company_type, revenue_tier FROM organizations WHERE workos_organization_id = $1`,
+      [orgId],
+    );
+    expect(orgRow.rows[0]).toMatchObject({
+      name: 'Pre-Curated Co',
+      company_type: 'agency',
+      revenue_tier: '50m_250m',
+    });
+
+    // The response profile reflects the persisted org row, not the body.
+    expect(res.body.profile.organization_name).toBe('Pre-Curated Co');
+    expect(res.body.profile.company_type).toBe('agency');
+  });
+
+  it('writes a member_profile_bootstrapped audit log entry on success', async () => {
+    const orgId = `${TEST_PREFIX}_audit`;
+    await seedOrg(orgId);
+
+    const res = await request(app)
+      .post('/api/me/member-profile')
+      .send({
+        organization_name: 'Acme Audit',
+        company_type: 'publisher',
+        corporate_domain: 'acme.example',
+      });
+    expect(res.status).toBe(201);
+
+    const auditRows = await pool.query<{ action: string; workos_user_id: string; resource_type: string; details: any }>(
+      `SELECT action, workos_user_id, resource_type, details FROM registry_audit_log WHERE workos_organization_id = $1 AND action = 'member_profile_bootstrapped'`,
+      [orgId],
+    );
+    expect(auditRows.rows).toHaveLength(1);
+    expect(auditRows.rows[0]).toMatchObject({
+      action: 'member_profile_bootstrapped',
+      workos_user_id: currentUserId,
+      resource_type: 'member_profile',
+    });
+    const details = typeof auditRows.rows[0].details === 'string'
+      ? JSON.parse(auditRows.rows[0].details)
+      : auditRows.rows[0].details;
+    expect(details).toMatchObject({
+      corporate_domain: 'acme.example',
+      company_type: 'publisher',
+    });
+    expect(typeof details.slug).toBe('string');
   });
 
   it('still routes legacy display_name + slug bodies to the original handler', async () => {

--- a/server/tests/integration/member-profile-bootstrap.test.ts
+++ b/server/tests/integration/member-profile-bootstrap.test.ts
@@ -379,12 +379,21 @@ describe('POST /api/me/member-profile (REST bootstrap)', () => {
       });
 
     expect(res.status).toBe(201);
-    expect(res.body.warnings).toEqual([
-      expect.objectContaining({
-        code: 'metadata_unchanged',
-        fields: expect.arrayContaining(['name', 'company_type', 'revenue_tier']),
-      }),
-    ]);
+    expect(res.body.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'metadata_unchanged',
+          // Field names are translated from DB columns to public API field
+          // names — `organizations.name` surfaces as `organization_name`,
+          // matching the CreateMemberProfileInput shape.
+          fields: expect.arrayContaining([
+            'organization_name',
+            'company_type',
+            'revenue_tier',
+          ]),
+        }),
+      ]),
+    );
 
     const orgRow = await pool.query<{ name: string; company_type: string; revenue_tier: string }>(
       `SELECT name, company_type, revenue_tier FROM organizations WHERE workos_organization_id = $1`,
@@ -486,14 +495,25 @@ describe('POST /api/me/member-profile (REST bootstrap)', () => {
   it('records ToS and Privacy-Policy acceptance against the bootstrapping user + org', async () => {
     const orgId = `${TEST_PREFIX}_tos`;
     await seedOrg(orgId);
+    // Clear any prior acceptance rows for this user — the
+    // user_agreement_acceptances ON CONFLICT (user, type, version) DO NOTHING
+    // would otherwise silently skip the test write if a previous run wrote
+    // the same tuple.
+    await pool.query(`DELETE FROM user_agreement_acceptances WHERE workos_user_id = $1`, [currentUserId]);
 
     // Ensure the agreements table has a row for each type so the bootstrap
     // path has a version to attach. ON CONFLICT noop keeps the test
     // hermetic — CI environments may already have rows for these types.
+    //
+    // Versions MUST be dot-separated numerics: getCurrentAgreementByType
+    // sorts via `string_to_array(version, '.')::int[]`, which throws on
+    // any non-numeric segment. Use a 9999.x version so this test row wins
+    // the "current" lookup against any production seeds without depending
+    // on insertion order.
     await pool.query(
       `INSERT INTO agreements (agreement_type, version, text, effective_date)
-       VALUES ('terms_of_service', 'test-tos-1', 'tos test body', NOW()),
-              ('privacy_policy', 'test-pp-1', 'pp test body', NOW())
+       VALUES ('terms_of_service', '9999.1', 'tos test body', NOW()),
+              ('privacy_policy', '9999.2', 'pp test body', NOW())
        ON CONFLICT (agreement_type, version) DO NOTHING`,
     );
 

--- a/server/tests/integration/member-profile-bootstrap.test.ts
+++ b/server/tests/integration/member-profile-bootstrap.test.ts
@@ -434,6 +434,94 @@ describe('POST /api/me/member-profile (REST bootstrap)', () => {
     expect(typeof details.slug).toBe('string');
   });
 
+  it('surfaces domain_already_claimed warning when corporate_domain belongs to a different org', async () => {
+    const orgId = `${TEST_PREFIX}_dom_conflict`;
+    const otherOrgId = `${TEST_PREFIX}_dom_owner`;
+    await seedOrg(orgId);
+    // Seed the other org first and bind the domain to it.
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+       VALUES ($1, $2, false, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO UPDATE SET name = EXCLUDED.name`,
+      [otherOrgId, 'Domain Owner Co'],
+    );
+    await pool.query(
+      `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source)
+       VALUES ($1, 'acme.example', true, true, 'email_verification')
+       ON CONFLICT (domain) DO UPDATE SET workos_organization_id = EXCLUDED.workos_organization_id`,
+      [otherOrgId],
+    );
+
+    const res = await request(app)
+      .post('/api/me/member-profile')
+      .send({
+        organization_name: 'Acme Conflict',
+        company_type: 'publisher',
+        corporate_domain: 'acme.example',
+      });
+
+    // Profile is created so the caller isn't blocked by an admin-resolvable
+    // issue, but the domain is NOT relinked and the conflict is surfaced.
+    expect(res.status).toBe(201);
+    expect(res.body.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'domain_already_claimed',
+          domain: 'acme.example',
+        }),
+      ]),
+    );
+
+    // Verify the existing domain row was not reassigned.
+    const domainRow = await pool.query<{ workos_organization_id: string }>(
+      `SELECT workos_organization_id FROM organization_domains WHERE domain = 'acme.example'`,
+    );
+    expect(domainRow.rows[0].workos_organization_id).toBe(otherOrgId);
+
+    // Cleanup
+    await pool.query(`DELETE FROM organization_domains WHERE workos_organization_id = $1`, [otherOrgId]);
+    await pool.query(`DELETE FROM organizations WHERE workos_organization_id = $1`, [otherOrgId]);
+  });
+
+  it('records ToS and Privacy-Policy acceptance against the bootstrapping user + org', async () => {
+    const orgId = `${TEST_PREFIX}_tos`;
+    await seedOrg(orgId);
+
+    // Ensure the agreements table has a row for each type so the bootstrap
+    // path has a version to attach. ON CONFLICT noop keeps the test
+    // hermetic — CI environments may already have rows for these types.
+    await pool.query(
+      `INSERT INTO agreements (agreement_type, version, text, effective_date)
+       VALUES ('terms_of_service', 'test-tos-1', 'tos test body', NOW()),
+              ('privacy_policy', 'test-pp-1', 'pp test body', NOW())
+       ON CONFLICT (agreement_type, version) DO NOTHING`,
+    );
+
+    const res = await request(app)
+      .post('/api/me/member-profile')
+      .set('User-Agent', 'BootstrapTest/1.0')
+      .set('X-Forwarded-For', '203.0.113.42')
+      .send({
+        organization_name: 'Acme ToS',
+        company_type: 'publisher',
+        corporate_domain: 'acme.example',
+      });
+    expect(res.status).toBe(201);
+
+    const acceptanceRows = await pool.query<{ agreement_type: string; user_agent: string }>(
+      `SELECT agreement_type, user_agent FROM user_agreement_acceptances
+       WHERE workos_user_id = $1 AND workos_organization_id = $2`,
+      [currentUserId, orgId],
+    );
+    const types = acceptanceRows.rows.map((r) => r.agreement_type).sort();
+    expect(types).toContain('terms_of_service');
+    expect(types).toContain('privacy_policy');
+    expect(acceptanceRows.rows.every((r) => r.user_agent === 'BootstrapTest/1.0')).toBe(true);
+
+    // Cleanup
+    await pool.query(`DELETE FROM user_agreement_acceptances WHERE workos_user_id = $1`, [currentUserId]);
+  });
+
   it('still routes legacy display_name + slug bodies to the original handler', async () => {
     const orgId = `${TEST_PREFIX}_legacy`;
     await seedOrg(orgId);

--- a/server/tests/unit/member-profile-bootstrap-skip-rule.test.ts
+++ b/server/tests/unit/member-profile-bootstrap-skip-rule.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Unit test for the bootstrap rate-limiter skip predicate.
+ *
+ * The integration suite at server/tests/integration/member-profile-bootstrap.test.ts
+ * mocks `memberProfileBootstrapRateLimiter` to a no-op so it can exercise
+ * the route without a Postgres-backed limit store; that means the limiter's
+ * dispatch contract — "rate-limit bootstrap-shape bodies, skip everything
+ * else" — is not exercised end-to-end. This file pins the rule directly,
+ * bypassing the express-rate-limit machinery.
+ */
+import { describe, it, expect } from 'vitest';
+import { isMemberProfileBootstrapBody } from '../../src/middleware/rate-limit.js';
+
+describe('isMemberProfileBootstrapBody', () => {
+  it('returns true for a minimal bootstrap body', () => {
+    expect(
+      isMemberProfileBootstrapBody({
+        organization_name: 'Acme',
+        corporate_domain: 'acme.example',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true for a full bootstrap body with optional fields', () => {
+    expect(
+      isMemberProfileBootstrapBody({
+        organization_name: 'Acme',
+        company_type: 'publisher',
+        revenue_tier: '5m_50m',
+        corporate_domain: 'acme.example',
+        primary_brand_domain: 'acme.example',
+        marketing_opt_in: true,
+        membership_tier: 'individual_academic',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false for the legacy dashboard body (display_name + slug)', () => {
+    expect(
+      isMemberProfileBootstrapBody({
+        display_name: 'Acme Profile',
+        slug: 'acme',
+        tagline: 'we make ads',
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false for a hybrid body (organization_name + display_name) — defers to the legacy handler', () => {
+    expect(
+      isMemberProfileBootstrapBody({
+        organization_name: 'Acme',
+        corporate_domain: 'acme.example',
+        display_name: 'Acme Profile',
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when slug alone is present alongside bootstrap fields', () => {
+    expect(
+      isMemberProfileBootstrapBody({
+        organization_name: 'Acme',
+        corporate_domain: 'acme.example',
+        slug: 'acme',
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false for empty / non-object bodies', () => {
+    expect(isMemberProfileBootstrapBody({})).toBe(false);
+    expect(isMemberProfileBootstrapBody(undefined)).toBe(false);
+    expect(isMemberProfileBootstrapBody(null)).toBe(false);
+    expect(isMemberProfileBootstrapBody('not-an-object')).toBe(false);
+    expect(isMemberProfileBootstrapBody(42)).toBe(false);
+  });
+
+  it('returns false when only one of the two required fields is a string', () => {
+    expect(
+      isMemberProfileBootstrapBody({
+        organization_name: 'Acme',
+      }),
+    ).toBe(false);
+    expect(
+      isMemberProfileBootstrapBody({
+        corporate_domain: 'acme.example',
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when the required fields are present but not strings', () => {
+    expect(
+      isMemberProfileBootstrapBody({
+        organization_name: 42,
+        corporate_domain: 'acme.example',
+      }),
+    ).toBe(false);
+    expect(
+      isMemberProfileBootstrapBody({
+        organization_name: 'Acme',
+        corporate_domain: { hostname: 'acme.example' },
+      }),
+    ).toBe(false);
+  });
+});

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -1911,18 +1911,19 @@ components:
         membership_tier:
           type: string
           enum:
-            - individual_professional
             - individual_academic
-            - company_standard
-            - company_icl
-            - company_leader
-          description: Initial membership tier. Defaults to no tier (free Explorer) if omitted. Paid tiers (`company_*`, `individual_professional`) require billing details to be configured on the AAO dashboard via Stripe checkout before activation.
+          description: |-
+            Initial membership tier. Only `individual_academic` (the free Explorer baseline) is accepted on this endpoint — paid tiers must come through a Stripe checkout session via the AAO `/membership` dashboard, and the webhook stamps the paid tier on the org row. Sending a paid tier value here returns `400 "Paid tier requires checkout"`.
       required:
         - organization_name
         - company_type
         - corporate_domain
       description: |-
         Request body for `POST /api/me/member-profile`. Creates the organization member profile that backs the per-agent registry endpoints. Fails with `403` if the caller's email domain does not match `corporate_domain`.
+
+        Org metadata fields (`organization_name`, `company_type`, `revenue_tier`, `membership_tier`) are written to the organization row **only when the field is currently null**. If a value is already set (e.g. an admin curated it via the dashboard), the body value is silently ignored and the response surfaces a `metadata_unchanged` warning naming the affected fields. This prevents a programmatic bootstrap from clobbering admin-curated metadata on subsequent calls.
+
+        The endpoint is rate-limited at 15 failed attempts per hour per user — successful calls do not count. The legacy `display_name`+`slug` body shape (used by the AAO dashboard profile-edit form) bypasses the rate limit and the bootstrap flow entirely; that shape continues to return `409` on conflict and writes the full profile body as before.
     MemberProfile:
       type: object
       properties:
@@ -7274,7 +7275,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/MemberProfileResponse"
         "400":
-          description: Missing or invalid required field (e.g. malformed `corporate_domain`, blank `organization_name`).
+          description: |-
+            One of: missing or invalid required field (`organization_name`, `company_type`, `corporate_domain`); malformed `corporate_domain`; or `membership_tier` is set to a paid tier (`individual_professional`, `company_*`) — those require a Stripe checkout session and cannot be claimed via this endpoint.
           content:
             application/json:
               schema:
@@ -7293,7 +7295,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
         "429":
-          description: Rate limit exceeded (this endpoint is rate-limited per IP to prevent abuse).
+          description: Rate limit exceeded (15 failed attempts per hour per user; successful calls do not count).
           content:
             application/json:
               schema:

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -1865,24 +1865,23 @@ components:
     MemberCompanyType:
       type: string
       enum:
-        - publisher
-        - advertiser
+        - adtech
         - agency
-        - dsp
-        - ssp
-        - measurement
-        - identity
-        - infrastructure
+        - brand
+        - publisher
+        - data
+        - ai
         - other
       description: Coarse classification of the member organization's role in the open ad ecosystem. Drives default verification badges and the member profile's display category.
     MemberRevenueTier:
       type: string
       enum:
         - under_1m
-        - 1m_to_10m
-        - 10m_to_100m
-        - 100m_to_1b
-        - over_1b
+        - 1m_5m
+        - 5m_50m
+        - 50m_250m
+        - 250m_1b
+        - 1b_plus
       description: Annual revenue band, USD. Used for tier-based pricing and aggregated industry stats; not exposed on the public profile.
     CreateMemberProfileInput:
       type: object
@@ -1912,10 +1911,12 @@ components:
         membership_tier:
           type: string
           enum:
-            - free
-            - builder
-            - professional
-          description: Initial membership tier. Defaults to `free` if omitted. Tiers above `free` may require billing details to be configured on the AAO dashboard before activation.
+            - individual_professional
+            - individual_academic
+            - company_standard
+            - company_icl
+            - company_leader
+          description: Initial membership tier. Defaults to no tier (free Explorer) if omitted. Paid tiers (`company_*`, `individual_professional`) require billing details to be configured on the AAO dashboard via Stripe checkout before activation.
       required:
         - organization_name
         - company_type
@@ -1943,9 +1944,12 @@ components:
         membership_tier:
           type: string
           enum:
-            - free
-            - builder
-            - professional
+            - individual_professional
+            - individual_academic
+            - company_standard
+            - company_icl
+            - company_leader
+          description: Active membership tier. Omitted entirely when the org has no tier set (free Explorer).
         created_at:
           type: string
           format: date-time
@@ -1959,7 +1963,6 @@ components:
         - organization_name
         - company_type
         - corporate_domain
-        - membership_tier
         - created_at
         - agents
       description: The member profile shape returned from `POST /api/me/member-profile` and `GET /api/me/member-profile`.

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -1862,6 +1862,114 @@ components:
           type: string
           format: uri
       description: Request body for `PATCH /api/me/agents/{url}`. The `url` field cannot be changed via PATCH; re-register at the new URL and DELETE the old entry instead.
+    MemberCompanyType:
+      type: string
+      enum:
+        - publisher
+        - advertiser
+        - agency
+        - dsp
+        - ssp
+        - measurement
+        - identity
+        - infrastructure
+        - other
+      description: Coarse classification of the member organization's role in the open ad ecosystem. Drives default verification badges and the member profile's display category.
+    MemberRevenueTier:
+      type: string
+      enum:
+        - under_1m
+        - 1m_to_10m
+        - 10m_to_100m
+        - 100m_to_1b
+        - over_1b
+      description: Annual revenue band, USD. Used for tier-based pricing and aggregated industry stats; not exposed on the public profile.
+    CreateMemberProfileInput:
+      type: object
+      properties:
+        organization_name:
+          type: string
+          minLength: 1
+          maxLength: 200
+          description: Display name for the organization (shown on the member profile and in the registry catalog).
+          example: Acme Media
+        company_type:
+          $ref: "#/components/schemas/MemberCompanyType"
+        revenue_tier:
+          $ref: "#/components/schemas/MemberRevenueTier"
+        corporate_domain:
+          type: string
+          description: "Canonical domain for the organization. Must match the email domain of the authenticated caller (e.g. an `@acme.com` user can only create a profile for `acme.com`). Personal email domains (gmail.com, yahoo.com, etc.) are rejected — register as an individual via the dashboard onboarding instead."
+          example: acme.com
+        primary_brand_domain:
+          type: string
+          description: The brand domain whose `brand.json` will reflect this profile's `public` agents. Optional at creation; required before any agent can be set to `visibility: \"public\"`.
+          example: acme.com
+        marketing_opt_in:
+          type: boolean
+          default: false
+          description: Whether the caller agreed to receive AAO marketing communications. Independent of Terms of Service consent (which is required and recorded server-side from the request context).
+        membership_tier:
+          type: string
+          enum:
+            - free
+            - builder
+            - professional
+          description: Initial membership tier. Defaults to `free` if omitted. Tiers above `free` may require billing details to be configured on the AAO dashboard before activation.
+      required:
+        - organization_name
+        - company_type
+        - corporate_domain
+      description: |-
+        Request body for `POST /api/me/member-profile`. Creates the organization member profile that backs the per-agent registry endpoints. Fails with `403` if the caller's email domain does not match `corporate_domain`.
+    MemberProfile:
+      type: object
+      properties:
+        organization_id:
+          type: string
+          description: WorkOS organization id for the new profile.
+          example: org_01HXZAB123
+        organization_name:
+          type: string
+          example: Acme Media
+        company_type:
+          $ref: "#/components/schemas/MemberCompanyType"
+        revenue_tier:
+          $ref: "#/components/schemas/MemberRevenueTier"
+        corporate_domain:
+          type: string
+        primary_brand_domain:
+          type: string
+        membership_tier:
+          type: string
+          enum:
+            - free
+            - builder
+            - professional
+        created_at:
+          type: string
+          format: date-time
+        agents:
+          type: array
+          items:
+            $ref: "#/components/schemas/MemberAgent"
+          description: Convenience snapshot of registered agents — initially empty for a freshly created profile. Use `GET /api/me/agents` for the canonical list.
+      required:
+        - organization_id
+        - organization_name
+        - company_type
+        - corporate_domain
+        - membership_tier
+        - created_at
+        - agents
+      description: The member profile shape returned from `POST /api/me/member-profile` and `GET /api/me/member-profile`.
+    MemberProfileResponse:
+      type: object
+      properties:
+        profile:
+          $ref: "#/components/schemas/MemberProfile"
+      required:
+        - profile
 paths:
   /api:
     get:
@@ -7076,9 +7184,122 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /api/me/member-profile:
+    get:
+      operationId: getMemberProfile
+      summary: Get my member profile
+      description: |-
+        Return the organization member profile for the caller's primary org (or `?org=` if supplied). This is the canonical "do I have a member profile yet?" check — clients hitting `404` from `GET /api/me/agents` should call this to confirm before prompting onboarding.
+      tags:
+        - Member Profile
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: WorkOS organization id to act on. Defaults to the caller's primary organization.
+            example: org_01HXZAB123
+          required: false
+          name: org
+          in: query
+      responses:
+        "200":
+          description: Member profile.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MemberProfileResponse"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: "`?org=` was supplied but the caller is not a member of that organization."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No member profile exists yet — create one via `POST /api/me/member-profile`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      operationId: createMemberProfile
+      summary: Create my member profile
+      description: |-
+        Bootstrap a new organization member profile. This is the **first-time onboarding** call that has historically been reachable only through the AAO dashboard's `/onboarding` form — making it a public REST surface lets registry API consumers (e.g. SSP/publisher integrations like the Scope3 storefront) drive the entire registration flow programmatically, without iframes or cross-domain redirects.
+
+        The caller must already be authenticated via OAuth (the user's own WorkOS session). The profile is created on the caller's primary WorkOS organization unless `?org=` is supplied; in either case, the caller's email domain must match `corporate_domain` (personal email domains like gmail.com / yahoo.com are rejected).
+
+        Idempotent on `(organization_id, corporate_domain)`: re-posting for an organization that already has a profile returns `200` with the existing profile and a `profile_already_exists` warning, instead of `409`.
+
+        Once the profile exists, follow up with `POST /api/me/agents` to register agents.
+      tags:
+        - Member Profile
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: WorkOS organization id to act on. Defaults to the caller's primary organization.
+            example: org_01HXZAB123
+          required: false
+          name: org
+          in: query
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateMemberProfileInput"
+      responses:
+        "200":
+          description: A profile already exists for this organization; the existing profile is returned and no fields are mutated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MemberProfileResponse"
+        "201":
+          description: Member profile created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MemberProfileResponse"
+        "400":
+          description: Missing or invalid required field (e.g. malformed `corporate_domain`, blank `organization_name`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: |-
+            One of: `?org=` was supplied but the caller is not a member of that organization; or the caller's email domain does not match the supplied `corporate_domain`; or the caller's email is on a personal-email domain (gmail.com, yahoo.com, etc.) and cannot create a corporate profile.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded (this endpoint is rate-limited per IP to prevent abuse).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 tags:
   - name: Member Agents
     description: Register, list, update, and remove agents on the caller's organization member profile. Authenticated programmatic surface for CI / scripts that don't want to round-trip the full member profile.
+  - name: Member Profile
+    description: Bootstrap and inspect the organization member profile. The profile is the prerequisite for the per-agent endpoints under `Member Agents`.
   - name: Brand Resolution
     description: Resolve advertiser domains to canonical brand identities.
   - name: Property Resolution

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -1921,7 +1921,11 @@ components:
       description: |-
         Request body for `POST /api/me/member-profile`. Creates the organization member profile that backs the per-agent registry endpoints. Fails with `403` if the caller's email domain does not match `corporate_domain`.
 
-        Org metadata fields (`organization_name`, `company_type`, `revenue_tier`, `membership_tier`) are written to the organization row **only when the field is currently null**. If a value is already set (e.g. an admin curated it via the dashboard), the body value is silently ignored and the response surfaces a `metadata_unchanged` warning naming the affected fields. This prevents a programmatic bootstrap from clobbering admin-curated metadata on subsequent calls.
+        Org metadata fields (`organization_name`, `company_type`, `revenue_tier`, `membership_tier`) are written to the organization row **only when the field is currently null**. If a value is already set (e.g. an admin curated it via the dashboard), the body value is silently ignored and the response surfaces a `metadata_unchanged` warning naming the affected API fields. This prevents a programmatic bootstrap from clobbering admin-curated metadata on subsequent calls.
+
+        If `corporate_domain` is already linked to a different organization (e.g. an earlier bootstrap on a sibling org), the profile is still created on the requested organization but the domain is **not** attached, and the response surfaces a `domain_already_claimed` warning naming the affected domain. Registry surfaces that depend on the verified domain (brand.json publish, brand resolution) will not reflect the profile until support resolves the conflict.
+
+        The caller's Terms-of-Service and Privacy-Policy acceptance is recorded server-side from the request context (`X-Forwarded-For` IP + User-Agent), against the current published agreement version, against the target organization. There is no opt-out — calling this endpoint is the consent.
 
         The endpoint is rate-limited at 15 failed attempts per hour per user — successful calls do not count. The legacy `display_name`+`slug` body shape (used by the AAO dashboard profile-edit form) bypasses the rate limit and the bootstrap flow entirely; that shape continues to return `409` on conflict and writes the full profile body as before.
     MemberProfile:


### PR DESCRIPTION
## Why

Two existing registry endpoints (`GET /api/me/agents`, `POST /api/me/agents`) already advertise — in their `404` error descriptions — that callers should "create one via `POST /api/me/member-profile`". Until now that endpoint has only been reachable via the AAO dashboard's `/onboarding` form, which forces every downstream registry consumer to drop the user into a new tab on agenticadvertising.org before they can register an agent.

The agent registration REST surface is incomplete without it: every native client we've tried building hits a `404 no_member_profile`, has no REST recovery path, and has to either iframe the dashboard (which doesn't work because `/onboarding` redirects through Google OAuth which refuses iframing) or open a new tab (popup-blocked silently in modern browsers).

## What Changed

Adds OpenAPI definitions for both:

- `GET /api/me/member-profile` — canonical "do I have a profile yet?" check. Lets clients distinguish "no profile" (call POST) from "no agents yet" (registry catalog is just empty).
- `POST /api/me/member-profile` — first-time onboarding via REST. Body shape mirrors the dashboard's existing `/onboarding` form: `organization_name`, `company_type`, `revenue_tier?`, `corporate_domain`, `primary_brand_domain?`, `marketing_opt_in?`, `membership_tier?`.

New schemas:
- `CreateMemberProfileInput` — body for POST
- `MemberProfile` — returned shape (organization_id, name, type, tier, agents snapshot, ...)
- `MemberProfileResponse` — standard envelope
- `MemberCompanyType` — coarse classification (publisher, advertiser, agency, dsp, ssp, measurement, identity, infrastructure, other)
- `MemberRevenueTier` — annual revenue band (under_1m … over_1b)

New tag: `Member Profile`.

## Invariants kept identical to the dashboard form

- Caller's email domain must equal `corporate_domain` (`@acme.com` user → `acme.com` profile only).
- Personal-email domains (gmail.com, yahoo.com, …) → `403`.
- Idempotent on `(organization_id, corporate_domain)` — second call returns `200` with the existing profile rather than `409`. Keeps client retry logic trivial.
- Rate-limited per IP (`429`) to prevent abuse.


## Bigger ask

The deeper "right shape" question for AAO: should an OAuth-authenticated WorkOS organization automatically have a member profile? Today the profile is a redundant data layer on top of the WorkOS org — the OAuth flow already gives AAO `organization_id`, and `corporate_domain` can be derived from the user's email. Asking every API consumer to call a separate `POST /api/me/member-profile` to bootstrap is bureaucratic friction that the dashboard hides for human users but that programmatic consumers can't hide from the publishers calling them.

I think AAO should auto-create the profile on first OAuth sign-in (with sensible defaults — `company_type: "other"`, `membership_tier: "free"`) and treat the dashboard's `/onboarding` form as a *profile-update* form, not a *profile-create* form. That eliminates the gating 404s entirely and is one less concept for every downstream client to model.

## Test Plan

- [x] OpenAPI 3.1 lint: spec parses (no `$ref` resolution failures, no orphan schemas).
- [ ] Backend impl + integration tests — separate PR.