### PR TITLE
fix(billing): backfill organizations.email_domain for orphaned prospect orgs

### DIFF
--- a/.changeset/backfill-org-email-domain.md
+++ b/.changeset/backfill-org-email-domain.md
@@ -1,0 +1,4 @@
+---
+---
+
+Backfill `organizations.email_domain` from `organization_domains` on non-personal orgs where the column was left NULL by the WorkOS webhook race. Catches the population of "orphaned" prospect orgs that fall outside `findPayingOrgForDomain`'s auto-link path because no `email_domain` is set, even though a verified `organization_domains` row exists. Idempotent; only fills NULL/empty values.

--- a/server/src/db/migrations/468_backfill_org_email_domain.sql
+++ b/server/src/db/migrations/468_backfill_org_email_domain.sql
@@ -1,0 +1,36 @@
+-- Backfill organizations.email_domain from organization_domains.
+--
+-- Why: prospect/sales-discovered orgs created via routes/admin/domains.ts
+-- and OrganizationDatabase.createOrganization were inserted with
+-- email_domain NULL. The column was meant to be filled by the WorkOS
+-- `organization.updated` webhook, but if that webhook never fires (or
+-- fires before the row is committed) the column stays NULL forever and
+-- later @domain signups can never auto-link to the org.
+--
+-- This migration mirrors the canonical domain from organization_domains:
+--   1) prefer is_primary = true
+--   2) then verified = true
+--   3) then any row, oldest first
+-- Only applies to non-personal orgs (personal-tier email_domain is
+-- intentionally NULL — see workos-webhooks.ts:587-596).
+--
+-- Idempotent: only updates rows where email_domain IS NULL or ''.
+
+UPDATE organizations o
+SET
+  email_domain = chosen.domain,
+  updated_at = NOW()
+FROM (
+  SELECT DISTINCT ON (od.workos_organization_id)
+    od.workos_organization_id,
+    LOWER(od.domain) AS domain
+  FROM organization_domains od
+  ORDER BY
+    od.workos_organization_id,
+    od.is_primary DESC,
+    od.verified DESC,
+    od.created_at ASC
+) AS chosen
+WHERE o.workos_organization_id = chosen.workos_organization_id
+  AND o.is_personal = FALSE
+  AND (o.email_domain IS NULL OR o.email_domain = '');

--- a/server/tests/integration/backfill-org-email-domain.test.ts
+++ b/server/tests/integration/backfill-org-email-domain.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Integration test for migration 468: backfill organizations.email_domain
+ * from organization_domains.
+ *
+ * Migration 468 has already run by the time this test seeds, so we re-execute
+ * its body against the seeded fixtures. This verifies the SQL the migration
+ * actually shipped, not a paraphrase.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import type { Pool } from 'pg';
+
+const ORG_PROSPECT = 'org_backfill_prospect_test';
+const ORG_PERSONAL = 'org_backfill_personal_test';
+const ORG_NO_DOMAINS = 'org_backfill_nodomains_test';
+const ORG_ALREADY_FILLED = 'org_backfill_filled_test';
+const ORG_MULTI_DOMAIN = 'org_backfill_multi_test';
+
+const TEST_ORGS = [ORG_PROSPECT, ORG_PERSONAL, ORG_NO_DOMAINS, ORG_ALREADY_FILLED, ORG_MULTI_DOMAIN];
+
+const MIGRATION_SQL = readFileSync(
+  resolve(__dirname, '../../src/db/migrations/468_backfill_org_email_domain.sql'),
+  'utf8',
+);
+
+async function cleanup(pool: Pool) {
+  await pool.query('DELETE FROM organization_domains WHERE workos_organization_id = ANY($1)', [TEST_ORGS]);
+  await pool.query('DELETE FROM organizations WHERE workos_organization_id = ANY($1)', [TEST_ORGS]);
+}
+
+async function seedOrg(
+  pool: Pool,
+  orgId: string,
+  opts: { is_personal?: boolean; email_domain?: string | null } = {},
+) {
+  await pool.query(
+    `INSERT INTO organizations (workos_organization_id, name, is_personal, email_domain, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, NOW(), NOW())
+     ON CONFLICT (workos_organization_id) DO UPDATE
+       SET is_personal = EXCLUDED.is_personal,
+           email_domain = EXCLUDED.email_domain`,
+    [orgId, `Org ${orgId}`, opts.is_personal ?? false, opts.email_domain ?? null],
+  );
+}
+
+async function seedDomain(
+  pool: Pool,
+  orgId: string,
+  domain: string,
+  opts: { is_primary?: boolean; verified?: boolean; created_at?: string } = {},
+) {
+  await pool.query(
+    `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, 'workos', COALESCE($5::timestamptz, NOW()), NOW())
+     ON CONFLICT (domain) DO UPDATE
+       SET is_primary = EXCLUDED.is_primary,
+           verified = EXCLUDED.verified,
+           workos_organization_id = $1`,
+    [orgId, domain, opts.is_primary ?? false, opts.verified ?? false, opts.created_at ?? null],
+  );
+}
+
+async function getEmailDomain(pool: Pool, orgId: string): Promise<string | null> {
+  const r = await pool.query<{ email_domain: string | null }>(
+    'SELECT email_domain FROM organizations WHERE workos_organization_id = $1',
+    [orgId],
+  );
+  return r.rows[0]?.email_domain ?? null;
+}
+
+describe('migration 468: backfill org email_domain', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  }, 60000);
+
+  afterAll(async () => {
+    await cleanup(pool);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanup(pool);
+  });
+
+  it('fills email_domain on a non-personal org from its single organization_domains row', async () => {
+    await seedOrg(pool, ORG_PROSPECT, { is_personal: false, email_domain: null });
+    await seedDomain(pool, ORG_PROSPECT, 'voisetech.test', { is_primary: true, verified: true });
+
+    await pool.query(MIGRATION_SQL);
+
+    expect(await getEmailDomain(pool, ORG_PROSPECT)).toBe('voisetech.test');
+  });
+
+  it('skips personal orgs even when they have an organization_domains row', async () => {
+    await seedOrg(pool, ORG_PERSONAL, { is_personal: true, email_domain: null });
+    await seedDomain(pool, ORG_PERSONAL, 'individual.test', { is_primary: true, verified: true });
+
+    await pool.query(MIGRATION_SQL);
+
+    expect(await getEmailDomain(pool, ORG_PERSONAL)).toBeNull();
+  });
+
+  it('leaves orgs with no organization_domains rows untouched (NULL stays NULL)', async () => {
+    await seedOrg(pool, ORG_NO_DOMAINS, { is_personal: false, email_domain: null });
+
+    await pool.query(MIGRATION_SQL);
+
+    expect(await getEmailDomain(pool, ORG_NO_DOMAINS)).toBeNull();
+  });
+
+  it('does not overwrite an already-populated email_domain', async () => {
+    await seedOrg(pool, ORG_ALREADY_FILLED, { is_personal: false, email_domain: 'existing.test' });
+    await seedDomain(pool, ORG_ALREADY_FILLED, 'different.test', { is_primary: true, verified: true });
+
+    await pool.query(MIGRATION_SQL);
+
+    expect(await getEmailDomain(pool, ORG_ALREADY_FILLED)).toBe('existing.test');
+  });
+
+  it('prefers is_primary=true over verified=true over oldest when multiple domains exist', async () => {
+    await seedOrg(pool, ORG_MULTI_DOMAIN, { is_personal: false, email_domain: null });
+    // Oldest, verified, but NOT primary
+    await seedDomain(pool, ORG_MULTI_DOMAIN, 'old-verified.test', {
+      is_primary: false, verified: true, created_at: '2020-01-01T00:00:00Z',
+    });
+    // Newer, primary, NOT verified — should still win on is_primary
+    await seedDomain(pool, ORG_MULTI_DOMAIN, 'newer-primary.test', {
+      is_primary: true, verified: false, created_at: '2024-01-01T00:00:00Z',
+    });
+
+    await pool.query(MIGRATION_SQL);
+
+    expect(await getEmailDomain(pool, ORG_MULTI_DOMAIN)).toBe('newer-primary.test');
+  });
+
+  it('is idempotent — second run does not change anything', async () => {
+    await seedOrg(pool, ORG_PROSPECT, { is_personal: false, email_domain: null });
+    await seedDomain(pool, ORG_PROSPECT, 'voisetech.test', { is_primary: true, verified: true });
+
+    await pool.query(MIGRATION_SQL);
+    const first = await getEmailDomain(pool, ORG_PROSPECT);
+    await pool.query(MIGRATION_SQL);
+    const second = await getEmailDomain(pool, ORG_PROSPECT);
+
+    expect(first).toBe('voisetech.test');
+    expect(second).toBe('voisetech.test');
+  });
+});


### PR DESCRIPTION
## Summary

- Migration 468 backfills `organizations.email_domain` from `organization_domains` for non-personal orgs where the column is NULL
- Closes the gap that orphaned Voise Tech Ltd (and likely others) — orgs created via `routes/admin/domains.ts` or `OrganizationDatabase.createOrganization` rely on the WorkOS `organization.updated` webhook to set `email_domain`. When the webhook misses, `findPayingOrgForDomain` (org-filters.ts:438-454) can never auto-link later @domain signups, and they silently land on personal workspaces

## Why this matters

Voise Tech Ltd was created 2026-02-13 with `email_domain=NULL`, sat empty for 80 days. When two @voisetech.com employees signed up on 2026-05-03, neither auto-joined the existing org. One then attempted to purchase Partner-tier through the dashboard — `/api/checkout-session` rejected with "Product not available for your organization" because his personal workspace can only buy individual-tier products.

This migration cleans up the existing population. A follow-up PR will harden the INSERT paths so new orgs can't reintroduce the leak.

## Test plan

- [x] New integration test `backfill-org-email-domain.test.ts` exercises the migration SQL directly with seeded fixtures, covering: single-domain backfill, personal-org skip, no-domains no-op, already-filled preservation, multi-domain priority (`is_primary` > `verified` > oldest), idempotency
- [x] Type check passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)