### PR TITLE
feat(jobs): daily orphan-org audit

### DIFF
--- a/.changeset/orphan-org-audit.md
+++ b/.changeset/orphan-org-audit.md
@@ -1,0 +1,4 @@
+---
+---
+
+Daily orphan-org audit job. Surfaces non-personal orgs missing `email_domain` (and therefore unable to auto-link future @domain signups via `findPayingOrgForDomain`) but with evidence of a sales/discovery touch (Stripe customer, prospect_source, etc.). Posts a structured log + Slack summary to the prospect channel; flags regressions when fresh orphans appear in the last 24h. Catches future leaks in the at-INSERT hardening within a day instead of months.

--- a/server/src/addie/jobs/job-definitions.ts
+++ b/server/src/addie/jobs/job-definitions.ts
@@ -55,6 +55,7 @@ import {
 } from './announcement-trigger.js';
 import { runSpecInsightPostJob } from './spec-insight-post.js';
 import { runChannelPrivacyAudit, type ChannelPrivacyAuditResult } from './channel-privacy-audit.js';
+import { runOrphanOrgAudit, type OrphanOrgAuditResult } from './orphan-org-audit.js';
 import { NotificationDatabase } from '../../db/notification-db.js';
 import { notifyUser } from '../../notifications/notification-service.js';
 import { createLogger } from '../../logger.js';
@@ -181,6 +182,19 @@ export function registerAllJobs(): void {
     runner: runChannelPrivacyAudit,
     shouldLogResult: (r: ChannelPrivacyAuditResult) =>
       r.drifted.length > 0 || r.unknown.length > 0,
+  });
+
+  // Orphan org audit — daily backstop for the at-INSERT hardening
+  // (admin/domains.ts + createOrganization). Surfaces non-personal orgs
+  // missing email_domain so a future regression in those write paths is
+  // caught in a day instead of months.
+  jobScheduler.register({
+    name: 'orphan-org-audit',
+    description: 'Orphan org audit',
+    interval: { value: 24, unit: 'hours' },
+    initialDelay: { value: 15, unit: 'minutes' },
+    runner: runOrphanOrgAudit,
+    shouldLogResult: (r: OrphanOrgAuditResult) => r.total > 0,
   });
 
   // Relationship orchestrator - continues member relationships across channels

--- a/server/src/addie/jobs/orphan-org-audit.ts
+++ b/server/src/addie/jobs/orphan-org-audit.ts
@@ -1,0 +1,203 @@
+/**
+ * Daily audit of orphaned prospect organizations.
+ *
+ * "Orphaned" = a non-personal org with no email_domain, no subscription, no
+ * members, but evidence of having gone through a sales/discovery path (Stripe
+ * customer, prospect_source, prospect_status, or prospect_contact_email). Real-
+ * world driver: Voise Tech Ltd was created 2026-02-13 with a Stripe customer
+ * and zero email_domain, sat invisible for 80 days while @voisetech.com
+ * employees signed up to personal workspaces because findPayingOrgForDomain
+ * (org-filters.ts:438-454) couldn't auto-link them.
+ *
+ * Migration 468 backfilled the existing population; the at-INSERT hardening
+ * stops new ones being created. This audit is the durable safety net: if a
+ * future code path reintroduces the leak, this job surfaces it within a day
+ * instead of months later when a customer emails about a "broken Stripe link."
+ */
+
+import { getPool } from '../../db/client.js';
+import { getProspectChannel, getAdminChannel } from '../../db/system-settings-db.js';
+import { sendChannelMessage } from '../../slack/client.js';
+import { createLogger } from '../../logger.js';
+
+const logger = createLogger('orphan-org-audit');
+
+export interface OrphanOrg {
+  workos_organization_id: string;
+  name: string;
+  created_at: Date;
+  has_stripe_customer: boolean;
+  prospect_source: string | null;
+  prospect_status: string | null;
+  prospect_contact_email: string | null;
+}
+
+export interface OrphanOrgAuditResult {
+  total: number;
+  newSinceLastAudit: number;
+  oldestCreatedAt: Date | null;
+  examples: OrphanOrg[];
+  summaryPosted: boolean;
+}
+
+/**
+ * Find non-personal orgs that are missing the auto-link prerequisites yet show
+ * signs of a sales/discovery touch. Limited to a representative sample so we
+ * can show admins something actionable without flooding the channel.
+ */
+async function findOrphans(limit = 25): Promise<OrphanOrg[]> {
+  const pool = getPool();
+  const result = await pool.query<{
+    workos_organization_id: string;
+    name: string;
+    created_at: Date;
+    has_stripe_customer: boolean;
+    prospect_source: string | null;
+    prospect_status: string | null;
+    prospect_contact_email: string | null;
+  }>(
+    `SELECT
+       o.workos_organization_id,
+       o.name,
+       o.created_at,
+       (o.stripe_customer_id IS NOT NULL) AS has_stripe_customer,
+       o.prospect_source,
+       o.prospect_status,
+       o.prospect_contact_email
+     FROM organizations o
+     LEFT JOIN organization_memberships m
+       ON m.workos_organization_id = o.workos_organization_id
+     WHERE o.is_personal = FALSE
+       AND (o.email_domain IS NULL OR o.email_domain = '')
+       AND o.subscription_status IS NULL
+       AND m.workos_user_id IS NULL
+       AND (o.stripe_customer_id IS NOT NULL
+            OR o.prospect_source IS NOT NULL
+            OR o.prospect_status IS NOT NULL
+            OR o.prospect_contact_email IS NOT NULL)
+     GROUP BY o.workos_organization_id
+     ORDER BY o.created_at ASC
+     LIMIT $1`,
+    [limit],
+  );
+  return result.rows;
+}
+
+async function countAll(): Promise<{ total: number; oldest: Date | null }> {
+  const pool = getPool();
+  const result = await pool.query<{ total: string; oldest: Date | null }>(
+    `SELECT COUNT(DISTINCT o.workos_organization_id)::text AS total,
+            MIN(o.created_at) AS oldest
+     FROM organizations o
+     LEFT JOIN organization_memberships m
+       ON m.workos_organization_id = o.workos_organization_id
+     WHERE o.is_personal = FALSE
+       AND (o.email_domain IS NULL OR o.email_domain = '')
+       AND o.subscription_status IS NULL
+       AND m.workos_user_id IS NULL
+       AND (o.stripe_customer_id IS NOT NULL
+            OR o.prospect_source IS NOT NULL
+            OR o.prospect_status IS NOT NULL
+            OR o.prospect_contact_email IS NOT NULL)`,
+  );
+  const row = result.rows[0];
+  return { total: Number(row?.total ?? 0), oldest: row?.oldest ?? null };
+}
+
+async function countNewSince(since: Date): Promise<number> {
+  const pool = getPool();
+  const result = await pool.query<{ n: string }>(
+    `SELECT COUNT(DISTINCT o.workos_organization_id)::text AS n
+     FROM organizations o
+     LEFT JOIN organization_memberships m
+       ON m.workos_organization_id = o.workos_organization_id
+     WHERE o.is_personal = FALSE
+       AND (o.email_domain IS NULL OR o.email_domain = '')
+       AND o.subscription_status IS NULL
+       AND m.workos_user_id IS NULL
+       AND o.created_at >= $1
+       AND (o.stripe_customer_id IS NOT NULL
+            OR o.prospect_source IS NOT NULL
+            OR o.prospect_status IS NOT NULL
+            OR o.prospect_contact_email IS NOT NULL)`,
+    [since],
+  );
+  return Number(result.rows[0]?.n ?? 0);
+}
+
+function formatExamples(examples: OrphanOrg[]): string[] {
+  return examples.slice(0, 10).map((o) => {
+    const sourceBits = [
+      o.has_stripe_customer ? 'stripe' : null,
+      o.prospect_source,
+      o.prospect_contact_email ? 'has-contact' : null,
+    ].filter(Boolean);
+    const ageDays = Math.floor((Date.now() - o.created_at.getTime()) / 86400000);
+    return `• \`${o.workos_organization_id}\` "${o.name}" — ${ageDays}d old, ${sourceBits.join(', ')}`;
+  });
+}
+
+export async function runOrphanOrgAudit(): Promise<OrphanOrgAuditResult> {
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+  const [counts, examples, newSinceLastAudit] = await Promise.all([
+    countAll(),
+    findOrphans(),
+    countNewSince(since),
+  ]);
+
+  const result: OrphanOrgAuditResult = {
+    total: counts.total,
+    newSinceLastAudit,
+    oldestCreatedAt: counts.oldest,
+    examples,
+    summaryPosted: false,
+  };
+
+  logger.info(
+    {
+      event: 'orphan_org_audit',
+      total: result.total,
+      newSinceLastAudit: result.newSinceLastAudit,
+      oldestCreatedAt: result.oldestCreatedAt,
+    },
+    `Orphan org audit: ${result.total} total, ${result.newSinceLastAudit} new in last 24h`,
+  );
+
+  if (result.total === 0) {
+    return result;
+  }
+
+  // Slack alert when there are any orphans, OR specifically when fresh ones
+  // appeared in the last 24 hours (a regression signal — at-INSERT hardening
+  // is supposed to prevent this entirely).
+  const prospect = await getProspectChannel();
+  const admin = await getAdminChannel();
+  const channelId = prospect.channel_id || admin.channel_id;
+  if (!channelId) return result;
+
+  const lines: string[] = [
+    `:warning: *Orphan org audit* — ${result.total} prospect org(s) cannot auto-link signups`,
+  ];
+  if (result.newSinceLastAudit > 0) {
+    lines.push(
+      `*${result.newSinceLastAudit} appeared in the last 24h* — likely a regression in at-INSERT hardening (admin/domains.ts or createOrganization).`,
+    );
+  }
+  if (result.oldestCreatedAt) {
+    const ageDays = Math.floor((Date.now() - result.oldestCreatedAt.getTime()) / 86400000);
+    lines.push(`Oldest: ${ageDays}d old.`);
+  }
+  if (result.examples.length > 0) {
+    lines.push('', '*Sample* (oldest first):');
+    lines.push(...formatExamples(result.examples));
+  }
+  lines.push(
+    '',
+    'These rows have a Stripe customer / prospect_source but no email_domain — `findPayingOrgForDomain` cannot link future @domain signups. Backfill `email_domain` and a verified `organization_domains` row to unblock.',
+  );
+
+  const sendResult = await sendChannelMessage(channelId, { text: lines.join('\n') });
+  result.summaryPosted = sendResult.ok;
+  return result;
+}

--- a/server/tests/unit/orphan-org-audit.test.ts
+++ b/server/tests/unit/orphan-org-audit.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/**
+ * Daily orphan-org audit. Mocks the DB pool + system-settings + slack
+ * client at the module seam — the value of this test is the orchestration
+ * (counting, formatting, conditional posting), not the SQL.
+ */
+
+const { mockPool, mockChannels, mockSend, mockLoggerInfo } = vi.hoisted(() => ({
+  mockPool: { query: vi.fn() },
+  mockChannels: {
+    getProspectChannel: vi.fn(),
+    getAdminChannel: vi.fn(),
+  },
+  mockSend: vi.fn(),
+  mockLoggerInfo: vi.fn(),
+}));
+
+vi.mock('../../src/db/client.js', () => ({
+  getPool: () => mockPool,
+}));
+
+vi.mock('../../src/db/system-settings-db.js', () => mockChannels);
+
+vi.mock('../../src/slack/client.js', () => ({
+  sendChannelMessage: mockSend,
+}));
+
+vi.mock('../../src/logger.js', () => ({
+  createLogger: () => ({
+    info: mockLoggerInfo,
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+  logger: { child: () => ({ info: mockLoggerInfo, warn: vi.fn(), error: vi.fn(), debug: vi.fn() }) },
+}));
+
+import { runOrphanOrgAudit } from '../../src/addie/jobs/orphan-org-audit.js';
+
+function seedZeroOrphans() {
+  // count all → 0
+  mockPool.query.mockResolvedValueOnce({ rows: [{ total: '0', oldest: null }] });
+  // examples → []
+  mockPool.query.mockResolvedValueOnce({ rows: [] });
+  // count new since → 0
+  mockPool.query.mockResolvedValueOnce({ rows: [{ n: '0' }] });
+}
+
+function seedOrphans(opts: {
+  total: number;
+  newSince: number;
+  exampleCount?: number;
+  oldest?: Date;
+}) {
+  const oldest = opts.oldest ?? new Date('2026-02-13T13:17:38Z');
+  mockPool.query.mockResolvedValueOnce({ rows: [{ total: String(opts.total), oldest }] });
+  const examples = Array.from({ length: opts.exampleCount ?? Math.min(opts.total, 3) }, (_, i) => ({
+    workos_organization_id: `org_orphan_${i}`,
+    name: `Orphan ${i}`,
+    created_at: new Date(oldest.getTime() + i * 86400000),
+    has_stripe_customer: i === 0,
+    prospect_source: 'slack_discovery',
+    prospect_status: 'prospect',
+    prospect_contact_email: null,
+  }));
+  mockPool.query.mockResolvedValueOnce({ rows: examples });
+  mockPool.query.mockResolvedValueOnce({ rows: [{ n: String(opts.newSince) }] });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockChannels.getProspectChannel.mockResolvedValue({ channel_id: 'C_prospect', channel_name: 'prospect' });
+  mockChannels.getAdminChannel.mockResolvedValue({ channel_id: 'C_admin', channel_name: 'admin' });
+  mockSend.mockResolvedValue({ ok: true, ts: '1.1' });
+});
+
+describe('runOrphanOrgAudit', () => {
+  it('does not post when there are zero orphans', async () => {
+    seedZeroOrphans();
+
+    const result = await runOrphanOrgAudit();
+
+    expect(result.total).toBe(0);
+    expect(result.summaryPosted).toBe(false);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('logs structured audit record regardless of outcome', async () => {
+    seedZeroOrphans();
+    await runOrphanOrgAudit();
+
+    const call = mockLoggerInfo.mock.calls.find(
+      (args: unknown[]) =>
+        typeof args[0] === 'object' &&
+        args[0] !== null &&
+        (args[0] as Record<string, unknown>).event === 'orphan_org_audit',
+    );
+    expect(call).toBeDefined();
+    expect((call![0] as Record<string, unknown>).total).toBe(0);
+  });
+
+  it('posts to prospect channel when total > 0', async () => {
+    seedOrphans({ total: 3, newSince: 0 });
+
+    const result = await runOrphanOrgAudit();
+
+    expect(result.total).toBe(3);
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    expect(mockSend.mock.calls[0][0]).toBe('C_prospect');
+    const text = (mockSend.mock.calls[0][1] as { text: string }).text;
+    expect(text).toContain('3 prospect org');
+  });
+
+  it('falls back to admin channel when prospect channel is unconfigured', async () => {
+    mockChannels.getProspectChannel.mockResolvedValue({ channel_id: null, channel_name: null });
+    seedOrphans({ total: 1, newSince: 0 });
+
+    const result = await runOrphanOrgAudit();
+
+    expect(result.summaryPosted).toBe(true);
+    expect(mockSend.mock.calls[0][0]).toBe('C_admin');
+  });
+
+  it('flags regression when orphans appeared in the last 24h', async () => {
+    seedOrphans({ total: 5, newSince: 2 });
+
+    await runOrphanOrgAudit();
+
+    const text = (mockSend.mock.calls[0][1] as { text: string }).text;
+    expect(text).toContain('2 appeared in the last 24h');
+    expect(text).toContain('regression');
+  });
+
+  it('skips Slack post when no channel is configured', async () => {
+    mockChannels.getProspectChannel.mockResolvedValue({ channel_id: null, channel_name: null });
+    mockChannels.getAdminChannel.mockResolvedValue({ channel_id: null, channel_name: null });
+    seedOrphans({ total: 2, newSince: 0 });
+
+    const result = await runOrphanOrgAudit();
+
+    expect(result.total).toBe(2);
+    expect(result.summaryPosted).toBe(false);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('formats examples with id, name, age, and source bits', async () => {
+    seedOrphans({ total: 1, newSince: 0, exampleCount: 1, oldest: new Date(Date.now() - 80 * 86400000) });
+
+    await runOrphanOrgAudit();
+
+    const text = (mockSend.mock.calls[0][1] as { text: string }).text;
+    expect(text).toContain('`org_orphan_0`');
+    expect(text).toContain('"Orphan 0"');
+    expect(text).toContain('80d old');
+    expect(text).toContain('stripe');
+  });
+});


### PR DESCRIPTION
## Summary

- New `orphan-org-audit` job runs daily, surfaces non-personal orgs that look sales-touched (Stripe customer / prospect_source) but are missing `email_domain` and therefore unreachable by `findPayingOrgForDomain`'s auto-link path
- Logs a structured `orphan_org_audit` event every run; posts a Slack summary to the prospect channel (admin fallback) only when the count is > 0
- Flags new-in-last-24h orphans as a regression signal, since the at-INSERT hardening in #4132 should prevent any new ones once both ship

## Why this matters

The Voise Tech root-cause was an invisible-for-80-days orphan. Migration 468 (#4131) cleans up the existing population; the at-INSERT hardening (#4132) closes the leak going forward. This is the durable safety net: if a new write path reintroduces the leak, this audit catches it within a day.

## Test plan

- [x] `tests/unit/orphan-org-audit.test.ts` — 7 tests cover zero-orphan no-op, structured log emission, prospect channel use, admin fallback, regression flagging, no-channel skip, example formatting (id / name / age / source bits)
- [x] Type check + pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)