### PR TITLE
feat(onboarding): claim flow for sales-touched prospect orgs at signup

### DIFF
--- a/.changeset/claim-prospect-org.md
+++ b/.changeset/claim-prospect-org.md
@@ -1,0 +1,4 @@
+---
+---
+
+Surface sales-touched prospect orgs at signup. When `/auth/callback` resolves a user with zero memberships, look up an unmembered prospect org owned by their email domain and redirect to `/onboarding.html?claim_org=<id>` with a "Claim this organization" banner. New `POST /api/organizations/:orgId/claim` endpoint completes the claim under a row lock with anti-hijack guards: domain match, no active subscription, zero existing members. Closes the gap that left Voise Tech employees on personal workspaces while their company's prospect org sat orphaned.

--- a/server/public/onboarding.html
+++ b/server/public/onboarding.html
@@ -450,6 +450,20 @@
         <div id="invitationsList"></div>
       </div>
 
+      <!-- Claim a sales-touched prospect org by domain -->
+      <div id="claimOrgSection" class="invitations-section" style="display: none;">
+        <h3>We've been tracking your company</h3>
+        <p style="color: var(--color-text-secondary); margin-bottom: var(--space-3); font-size: var(--text-sm);">
+          A record exists for <strong id="claimOrgName"></strong> based on your email domain. Claim it to consolidate the work
+          our team's already done, or skip and we'll create a separate workspace.
+        </p>
+        <div style="display: flex; gap: var(--space-3); align-items: center;">
+          <button class="btn" id="claimOrgButton">Claim this organization</button>
+          <a href="#" id="claimOrgSkip" style="color: var(--color-text-secondary); font-size: var(--text-sm);">Skip and continue with a fresh workspace</a>
+        </div>
+        <div id="claimOrgError" class="error" style="display: none; margin-top: var(--space-3);"></div>
+      </div>
+
       <!-- Step 1: Individual vs Company Selection -->
       <div id="step1Section" class="options">
         <p style="color: var(--color-text-secondary); margin-bottom: var(--space-4); font-size: var(--text-sm);">Are you joining as an individual or on behalf of a company?</p>
@@ -915,6 +929,8 @@
             loadInvitations(),
             loadJoinableOrganizations()
           ]);
+          // Surface ?claim_org= banner from /auth/callback domain match
+          showClaimOrgBannerIfPresent();
         }
 
         // Show main content
@@ -956,6 +972,53 @@
       } catch (error) {
         console.error('Failed to load invitations:', error);
       }
+    }
+
+    function showClaimOrgBannerIfPresent() {
+      const params = new URLSearchParams(window.location.search);
+      const claimOrg = params.get('claim_org');
+      const claimOrgName = params.get('claim_org_name');
+      if (!claimOrg) return;
+
+      const section = document.getElementById('claimOrgSection');
+      const nameEl = document.getElementById('claimOrgName');
+      const button = document.getElementById('claimOrgButton');
+      const skip = document.getElementById('claimOrgSkip');
+      const errorEl = document.getElementById('claimOrgError');
+      if (!section || !nameEl || !button || !skip || !errorEl) return;
+
+      nameEl.textContent = claimOrgName || 'your organization';
+      section.style.display = 'block';
+
+      button.addEventListener('click', async () => {
+        button.disabled = true;
+        button.textContent = 'Claiming...';
+        errorEl.style.display = 'none';
+        try {
+          const response = await fetch('/api/organizations/' + encodeURIComponent(claimOrg) + '/claim', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+          });
+          const data = await response.json().catch(() => ({}));
+          if (!response.ok) {
+            throw new Error(data.message || 'Claim failed');
+          }
+          window.location.href = '/dashboard';
+        } catch (err) {
+          errorEl.textContent = err.message || 'Failed to claim organization. Please contact support.';
+          errorEl.style.display = 'block';
+          button.disabled = false;
+          button.textContent = 'Claim this organization';
+        }
+      });
+
+      skip.addEventListener('click', (e) => {
+        e.preventDefault();
+        // Strip query params — user opted out, treat the rest of onboarding normally.
+        history.replaceState(null, '', window.location.pathname);
+        section.style.display = 'none';
+      });
     }
 
     async function loadJoinableOrganizations() {

--- a/server/src/db/org-filters.ts
+++ b/server/src/db/org-filters.ts
@@ -498,3 +498,101 @@ export async function findPayingOrgForDomain(domain: string): Promise<DomainOwne
     return null;
   }
 }
+
+// =============================================================================
+// Find claimable prospect org for a domain (sales-touched but unmembered)
+// =============================================================================
+
+export interface ClaimableProspectOrg {
+  organization_id: string;
+  organization_name: string;
+  /** The domain row that matched (already lowercased). */
+  matched_domain: string;
+  /** True if the org has a Stripe customer (sales has touched it). */
+  has_stripe_customer: boolean;
+  /** When the prospect was created — surfaced in UI to give the user context. */
+  created_at: Date;
+}
+
+/**
+ * Find a non-personal org that the user could plausibly claim — a prospect
+ * org owned by a verified domain matching the user's email, with no existing
+ * members and no active subscription.
+ *
+ * Distinct from findPayingOrgForDomain: that helper is the auto-link path
+ * (silently joins the user to a paying org). This one is the user-prompted
+ * claim path: surface the unjoined prospect at signup so the user can choose
+ * to claim it instead of silently being routed to a personal workspace, the
+ * way Voise Tech's employees were.
+ *
+ * Anti-hijack guards:
+ *   - Only matches non-personal orgs.
+ *   - Only matches if the org has zero existing organization_memberships
+ *     rows. The first claimer becomes the owner; once anyone has joined, the
+ *     org is theirs to invite from.
+ *   - Only matches if the org has no active subscription (paying orgs are
+ *     handled by findPayingOrgForDomain's auto-link path).
+ *   - Domain match goes through organization_domains.verified=true OR
+ *     organizations.email_domain. We don't walk brand-hierarchy here —
+ *     prospect orgs don't have the trust gates a paying parent does.
+ *
+ * The caller (POST /api/organizations/:orgId/claim) re-validates these
+ * conditions transactionally before adding the WorkOS membership.
+ */
+export async function findClaimableProspectOrgForDomain(
+  domain: string,
+): Promise<ClaimableProspectOrg | null> {
+  const normalizedDomain = domain.trim().toLowerCase();
+  if (!normalizedDomain) return null;
+
+  const pool = getPool();
+
+  try {
+    const result = await pool.query<{
+      workos_organization_id: string;
+      name: string;
+      matched_domain: string;
+      has_stripe_customer: boolean;
+      created_at: Date;
+    }>(
+      `SELECT
+         o.workos_organization_id,
+         o.name,
+         LOWER(COALESCE(od.domain, o.email_domain)) AS matched_domain,
+         (o.stripe_customer_id IS NOT NULL) AS has_stripe_customer,
+         o.created_at
+       FROM organizations o
+       LEFT JOIN organization_domains od
+         ON od.workos_organization_id = o.workos_organization_id
+        AND LOWER(od.domain) = $1
+        AND od.verified = true
+       WHERE o.is_personal = FALSE
+         AND (LOWER(o.email_domain) = $1 OR od.workos_organization_id IS NOT NULL)
+         AND o.subscription_status IS NULL
+         AND NOT EXISTS (
+           SELECT 1 FROM organization_memberships m
+           WHERE m.workos_organization_id = o.workos_organization_id
+         )
+       ORDER BY o.created_at ASC
+       LIMIT 1`,
+      [normalizedDomain],
+    );
+
+    if (result.rows.length === 0) return null;
+
+    const row = result.rows[0];
+    return {
+      organization_id: row.workos_organization_id,
+      organization_name: row.name,
+      matched_domain: row.matched_domain,
+      has_stripe_customer: row.has_stripe_customer,
+      created_at: row.created_at,
+    };
+  } catch (error) {
+    logger.error(
+      { err: error, domain: normalizedDomain },
+      'Failed to find claimable prospect org for domain',
+    );
+    return null;
+  }
+}

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -75,7 +75,7 @@ import { createAddieChatRouter } from "./routes/addie-chat.js";
 import { createTavusRouter } from "./routes/tavus.js";
 import { createSiChatRoutes } from "./routes/si-chat.js";
 import { sendAccountLinkedMessage, invalidateMemberContextCache, isAddieBoltReady } from "./addie/index.js";
-import { invalidateMembershipCache } from "./db/org-filters.js";
+import { invalidateMembershipCache, findClaimableProspectOrgForDomain } from "./db/org-filters.js";
 import * as relationshipDb from "./db/relationship-db.js";
 import * as personEvents from "./db/person-events-db.js";
 import { isWebUserAAOAdmin } from "./addie/mcp/admin-tools.js";
@@ -6820,8 +6820,32 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
         // Redirect to dashboard or onboarding
         logger.debug({ returnTo, membershipCount: memberships.data.length }, 'Final redirect decision');
         if (memberships.data.length === 0) {
-          logger.debug('No organizations found, redirecting to onboarding');
-          res.redirect('/onboarding.html');
+          // Before sending the user to fresh-onboarding, check whether a
+          // sales-touched prospect org exists for their email domain that
+          // they could claim. Without this, @voisetech.com employees land
+          // on personal workspaces and the prospect org sits orphaned.
+          let onboardingPath = '/onboarding.html';
+          try {
+            const emailDomain = user.email.split('@')[1]?.toLowerCase();
+            if (emailDomain) {
+              const claimable = await findClaimableProspectOrgForDomain(emailDomain);
+              if (claimable) {
+                const params = new URLSearchParams({
+                  claim_org: claimable.organization_id,
+                  claim_org_name: claimable.organization_name,
+                });
+                onboardingPath = `/onboarding.html?${params.toString()}`;
+                logger.info(
+                  { workosUserId: user.id, email: user.email, claimOrg: claimable.organization_id },
+                  'Surfacing claimable prospect org at signup',
+                );
+              }
+            }
+          } catch (claimErr) {
+            logger.warn({ err: claimErr, email: user.email }, 'findClaimableProspectOrgForDomain failed; continuing without claim hint');
+          }
+          logger.debug({ onboardingPath }, 'No organizations found, redirecting to onboarding');
+          res.redirect(onboardingPath);
         } else {
           // If returnTo is an AdCP URL, bridge the session via auto-submitting form POST
           // so the user lands on AdCP already authenticated (session stays out of URL)

--- a/server/src/routes/organizations.ts
+++ b/server/src/routes/organizations.ts
@@ -16,6 +16,7 @@ import {
   getDevUser,
 } from "../middleware/auth.js";
 import { invitationRateLimiter, orgCreationRateLimiter } from "../middleware/rate-limit.js";
+import { invalidateMembershipCache } from "../db/org-filters.js";
 import { validateOrganizationName, validateEmail } from "../middleware/validation.js";
 import { OrganizationDatabase, CompanyType, RevenueTier, VALID_REVENUE_TIERS, VALID_MEMBERSHIP_TIERS, getSeatUsage, getSeatLimits, canAddSeat, getUserSeatType, resolveMembershipTier, checkAndUpdateSeatWarning, resetSeatWarningIfNeeded, createSeatUpgradeRequest, getSeatUpgradeRequest, listSeatUpgradeRequests, resolveSeatUpgradeRequest, hasPendingSeatRequest } from "../db/organization-db.js";
 import { COMPANY_TYPE_VALUES } from "../config/company-types.js";
@@ -2292,6 +2293,8 @@ export function createOrganizationsRouter(): Router {
   // user to WorkOS as the org's first member.
   //
   // Anti-hijack guards (re-checked inside a row lock):
+  //   - Caller's WorkOS email must be verified (the domain match is the
+  //     entire trust signal — an unverified email isn't a trust signal).
   //   - Org must be non-personal.
   //   - Org must have no active subscription (paying orgs auto-link via the
   //     verified-domain path; they're not "claimable").
@@ -2300,9 +2303,29 @@ export function createOrganizationsRouter(): Router {
   //     else can claim.
   //   - The user's verified WorkOS email domain must match the org's
   //     email_domain or a verified organization_domains row.
+  //
+  // Concurrency model: the row lock taken on the org persists for the full
+  // duration of the WorkOS createOrganizationMembership call. Two concurrent
+  // claims on the same org serialize on the lock — the second one observes
+  // the membership row inserted by the WorkOS webhook (or by a prior tx that
+  // hasn't committed yet) and falls through to the "already claimed" 409.
   router.post('/:orgId/claim', requireAuth, async (req, res) => {
     const user = req.user!;
     const { orgId } = req.params;
+
+    if (!user.emailVerified) {
+      return res.status(403).json({
+        error: 'Email not verified',
+        message: 'Verify your email before claiming an organization.',
+      });
+    }
+
+    if (!workos) {
+      return res.status(500).json({
+        error: 'Auth not configured',
+        message: 'WorkOS is not configured on this server',
+      });
+    }
 
     const userDomain = user.email.split('@')[1]?.toLowerCase();
     if (!userDomain) {
@@ -2315,6 +2338,7 @@ export function createOrganizationsRouter(): Router {
     const pool = getPool();
     const client = await pool.connect();
 
+    let claimResult: { ok: true } | { ok: false; status: number; body: Record<string, unknown> };
     try {
       await client.query('BEGIN');
 
@@ -2335,64 +2359,105 @@ export function createOrganizationsRouter(): Router {
 
       if (orgRows.rows.length === 0) {
         await client.query('ROLLBACK');
-        return res.status(404).json({ error: 'Organization not found' });
+        claimResult = { ok: false, status: 404, body: { error: 'Organization not found' } };
+      } else {
+        const org = orgRows.rows[0];
+
+        if (org.is_personal) {
+          await client.query('ROLLBACK');
+          claimResult = {
+            ok: false,
+            status: 400,
+            body: { error: 'Not claimable', message: 'Personal workspaces cannot be claimed' },
+          };
+        } else if (org.subscription_status) {
+          await client.query('ROLLBACK');
+          claimResult = {
+            ok: false,
+            status: 400,
+            body: {
+              error: 'Not claimable',
+              message: 'This organization already has an active subscription. Ask an existing member to invite you instead.',
+            },
+          };
+        } else {
+          // Domain-match check: user's email domain must equal email_domain
+          // OR appear as a verified organization_domains row.
+          const domainMatchRow = await client.query<{ matched: boolean }>(
+            `SELECT (
+               LOWER($2) = LOWER(COALESCE($3, ''))
+               OR EXISTS (
+                 SELECT 1 FROM organization_domains od
+                 WHERE od.workos_organization_id = $1
+                   AND LOWER(od.domain) = LOWER($2)
+                   AND od.verified = true
+               )
+             ) AS matched`,
+            [orgId, userDomain, org.email_domain],
+          );
+          if (!domainMatchRow.rows[0]?.matched) {
+            await client.query('ROLLBACK');
+            claimResult = {
+              ok: false,
+              status: 403,
+              body: {
+                error: 'Domain mismatch',
+                message: `Your email domain (${userDomain}) does not match this organization's verified domain.`,
+              },
+            };
+          } else {
+            // Anti-hijack: zero existing memberships.
+            const memberCount = await client.query<{ n: string }>(
+              `SELECT COUNT(*)::text AS n FROM organization_memberships
+               WHERE workos_organization_id = $1`,
+              [orgId],
+            );
+            if (Number(memberCount.rows[0]?.n ?? 0) > 0) {
+              await client.query('ROLLBACK');
+              claimResult = {
+                ok: false,
+                status: 409,
+                body: {
+                  error: 'Already claimed',
+                  message: 'This organization already has members. Ask an existing member to invite you.',
+                },
+              };
+            } else {
+              // Add the user to WorkOS *inside* the still-open tx so the row
+              // lock prevents a second concurrent claim from observing the
+              // empty membership table while we're mid-flight. Use 'admin' —
+              // the existing webhook auto-promotes the first admin to owner.
+              let workosFailed = false;
+              try {
+                await workos.userManagement.createOrganizationMembership({
+                  userId: user.id,
+                  organizationId: orgId,
+                  roleSlug: 'admin',
+                });
+              } catch (err: unknown) {
+                const code = (err as { code?: string } | null)?.code;
+                if (code === 'organization_membership_already_exists') {
+                  // Benign — they're already a member. Treat as success.
+                } else {
+                  logger.error({ err, orgId, userId: user.id }, 'WorkOS createOrganizationMembership failed during claim');
+                  workosFailed = true;
+                }
+              }
+              if (workosFailed) {
+                await client.query('ROLLBACK');
+                claimResult = {
+                  ok: false,
+                  status: 500,
+                  body: { error: 'Failed to add membership' },
+                };
+              } else {
+                await client.query('COMMIT');
+                claimResult = { ok: true };
+              }
+            }
+          }
+        }
       }
-
-      const org = orgRows.rows[0];
-
-      if (org.is_personal) {
-        await client.query('ROLLBACK');
-        return res.status(400).json({
-          error: 'Not claimable',
-          message: 'Personal workspaces cannot be claimed',
-        });
-      }
-
-      if (org.subscription_status) {
-        await client.query('ROLLBACK');
-        return res.status(400).json({
-          error: 'Not claimable',
-          message: 'This organization already has an active subscription. Ask an existing member to invite you instead.',
-        });
-      }
-
-      // Domain-match check: user's email domain must equal email_domain
-      // OR appear as a verified organization_domains row.
-      const domainMatchRow = await client.query<{ matched: boolean }>(
-        `SELECT (
-           LOWER($2) = LOWER(COALESCE($3, ''))
-           OR EXISTS (
-             SELECT 1 FROM organization_domains od
-             WHERE od.workos_organization_id = $1
-               AND LOWER(od.domain) = LOWER($2)
-               AND od.verified = true
-           )
-         ) AS matched`,
-        [orgId, userDomain, org.email_domain],
-      );
-      if (!domainMatchRow.rows[0]?.matched) {
-        await client.query('ROLLBACK');
-        return res.status(403).json({
-          error: 'Domain mismatch',
-          message: `Your email domain (${userDomain}) does not match this organization's verified domain.`,
-        });
-      }
-
-      // Anti-hijack: zero existing memberships.
-      const memberCount = await client.query<{ n: string }>(
-        `SELECT COUNT(*)::text AS n FROM organization_memberships
-         WHERE workos_organization_id = $1`,
-        [orgId],
-      );
-      if (Number(memberCount.rows[0]?.n ?? 0) > 0) {
-        await client.query('ROLLBACK');
-        return res.status(409).json({
-          error: 'Already claimed',
-          message: 'This organization already has members. Ask an existing member to invite you.',
-        });
-      }
-
-      await client.query('COMMIT');
     } catch (lockErr) {
       await client.query('ROLLBACK').catch(() => {});
       logger.error({ err: lockErr, orgId, userId: user.id }, 'Claim pre-validation failed');
@@ -2402,29 +2467,14 @@ export function createOrganizationsRouter(): Router {
       client.release();
     }
 
-    // Add the user to WorkOS. Use 'admin' since they're the first member —
-    // membership upsertion in the webhook auto-promotes the first admin to
-    // owner (#3856) so we don't need to set 'owner' directly here.
-    if (!workos) {
-      return res.status(500).json({
-        error: 'Auth not configured',
-        message: 'WorkOS is not configured on this server',
-      });
+    if (!claimResult.ok) {
+      return res.status(claimResult.status).json(claimResult.body);
     }
-    try {
-      await workos.userManagement.createOrganizationMembership({
-        userId: user.id,
-        organizationId: orgId,
-        roleSlug: 'admin',
-      });
-    } catch (err: unknown) {
-      const code = (err as { code?: string } | null)?.code;
-      if (code !== 'organization_membership_already_exists') {
-        logger.error({ err, orgId, userId: user.id }, 'WorkOS createOrganizationMembership failed during claim');
-        return res.status(500).json({ error: 'Failed to add membership' });
-      }
-      // Membership already exists — fall through and treat as success.
-    }
+
+    // Membership-resolution cache may have a stale "no membership" entry for
+    // this user/org pair. Drop it so the next request resolves the new
+    // membership without waiting for the WorkOS webhook to fire.
+    invalidateMembershipCache(orgId);
 
     await orgDb.recordAuditLog({
       workos_organization_id: orgId,

--- a/server/src/routes/organizations.ts
+++ b/server/src/routes/organizations.ts
@@ -2283,6 +2283,173 @@ export function createOrganizationsRouter(): Router {
     }
   });
 
+  // POST /api/organizations/:orgId/claim - Claim a sales-touched prospect org
+  //
+  // The auth/callback redirect surfaces a `?claim_org=<orgId>` hint to the
+  // onboarding page when an unowned prospect org matches the user's email
+  // domain (see findClaimableProspectOrgForDomain). This endpoint completes
+  // the claim: it re-validates the conditions transactionally and adds the
+  // user to WorkOS as the org's first member.
+  //
+  // Anti-hijack guards (re-checked inside a row lock):
+  //   - Org must be non-personal.
+  //   - Org must have no active subscription (paying orgs auto-link via the
+  //     verified-domain path; they're not "claimable").
+  //   - Org must have zero existing organization_memberships rows. The first
+  //     claimer becomes the de facto owner; once anyone has joined, no one
+  //     else can claim.
+  //   - The user's verified WorkOS email domain must match the org's
+  //     email_domain or a verified organization_domains row.
+  router.post('/:orgId/claim', requireAuth, async (req, res) => {
+    const user = req.user!;
+    const { orgId } = req.params;
+
+    const userDomain = user.email.split('@')[1]?.toLowerCase();
+    if (!userDomain) {
+      return res.status(400).json({
+        error: 'Invalid email',
+        message: 'Cannot determine email domain for claim verification',
+      });
+    }
+
+    const pool = getPool();
+    const client = await pool.connect();
+
+    try {
+      await client.query('BEGIN');
+
+      // Lock the org row so concurrent claims serialize cleanly.
+      const orgRows = await client.query<{
+        workos_organization_id: string;
+        name: string;
+        is_personal: boolean;
+        subscription_status: string | null;
+        email_domain: string | null;
+      }>(
+        `SELECT workos_organization_id, name, is_personal, subscription_status, email_domain
+         FROM organizations
+         WHERE workos_organization_id = $1
+         FOR UPDATE`,
+        [orgId],
+      );
+
+      if (orgRows.rows.length === 0) {
+        await client.query('ROLLBACK');
+        return res.status(404).json({ error: 'Organization not found' });
+      }
+
+      const org = orgRows.rows[0];
+
+      if (org.is_personal) {
+        await client.query('ROLLBACK');
+        return res.status(400).json({
+          error: 'Not claimable',
+          message: 'Personal workspaces cannot be claimed',
+        });
+      }
+
+      if (org.subscription_status) {
+        await client.query('ROLLBACK');
+        return res.status(400).json({
+          error: 'Not claimable',
+          message: 'This organization already has an active subscription. Ask an existing member to invite you instead.',
+        });
+      }
+
+      // Domain-match check: user's email domain must equal email_domain
+      // OR appear as a verified organization_domains row.
+      const domainMatchRow = await client.query<{ matched: boolean }>(
+        `SELECT (
+           LOWER($2) = LOWER(COALESCE($3, ''))
+           OR EXISTS (
+             SELECT 1 FROM organization_domains od
+             WHERE od.workos_organization_id = $1
+               AND LOWER(od.domain) = LOWER($2)
+               AND od.verified = true
+           )
+         ) AS matched`,
+        [orgId, userDomain, org.email_domain],
+      );
+      if (!domainMatchRow.rows[0]?.matched) {
+        await client.query('ROLLBACK');
+        return res.status(403).json({
+          error: 'Domain mismatch',
+          message: `Your email domain (${userDomain}) does not match this organization's verified domain.`,
+        });
+      }
+
+      // Anti-hijack: zero existing memberships.
+      const memberCount = await client.query<{ n: string }>(
+        `SELECT COUNT(*)::text AS n FROM organization_memberships
+         WHERE workos_organization_id = $1`,
+        [orgId],
+      );
+      if (Number(memberCount.rows[0]?.n ?? 0) > 0) {
+        await client.query('ROLLBACK');
+        return res.status(409).json({
+          error: 'Already claimed',
+          message: 'This organization already has members. Ask an existing member to invite you.',
+        });
+      }
+
+      await client.query('COMMIT');
+    } catch (lockErr) {
+      await client.query('ROLLBACK').catch(() => {});
+      logger.error({ err: lockErr, orgId, userId: user.id }, 'Claim pre-validation failed');
+      client.release();
+      return res.status(500).json({ error: 'Failed to validate claim' });
+    } finally {
+      client.release();
+    }
+
+    // Add the user to WorkOS. Use 'admin' since they're the first member —
+    // membership upsertion in the webhook auto-promotes the first admin to
+    // owner (#3856) so we don't need to set 'owner' directly here.
+    if (!workos) {
+      return res.status(500).json({
+        error: 'Auth not configured',
+        message: 'WorkOS is not configured on this server',
+      });
+    }
+    try {
+      await workos.userManagement.createOrganizationMembership({
+        userId: user.id,
+        organizationId: orgId,
+        roleSlug: 'admin',
+      });
+    } catch (err: unknown) {
+      const code = (err as { code?: string } | null)?.code;
+      if (code !== 'organization_membership_already_exists') {
+        logger.error({ err, orgId, userId: user.id }, 'WorkOS createOrganizationMembership failed during claim');
+        return res.status(500).json({ error: 'Failed to add membership' });
+      }
+      // Membership already exists — fall through and treat as success.
+    }
+
+    await orgDb.recordAuditLog({
+      workos_organization_id: orgId,
+      workos_user_id: user.id,
+      action: 'organization_claimed',
+      resource_type: 'organization',
+      resource_id: orgId,
+      details: {
+        claimed_via: 'self_claim',
+        email_domain: userDomain,
+      },
+    });
+
+    logger.info(
+      { orgId, userId: user.id, email: user.email },
+      'User claimed prospect org',
+    );
+
+    res.json({
+      success: true,
+      organization_id: orgId,
+      message: 'Organization claimed. You can now sign in to the dashboard.',
+    });
+  });
+
   // =========================================================================
   // TEAM MANAGEMENT
   // =========================================================================

--- a/server/tests/integration/claim-prospect-org.test.ts
+++ b/server/tests/integration/claim-prospect-org.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Route-level test for POST /api/organizations/:orgId/claim — the endpoint
+ * the auth/callback redirect lands a domain match against. Uses the same
+ * WorkOS-mock-via-class harness as join-request-approval.test.ts, then
+ * exercises the happy path plus each refusal branch under the row lock +
+ * WorkOS round-trip flow.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+
+const {
+  TEST_USER_ID,
+  TEST_ORG_PROSPECT,
+  TEST_ORG_PAYING,
+  TEST_ORG_HAS_MEMBER,
+  TEST_ORG_PERSONAL,
+  TEST_DOMAIN,
+  TEST_OTHER_DOMAIN,
+  mockCreateOrganizationMembership,
+} = vi.hoisted(() => {
+  process.env.WORKOS_API_KEY ||= 'sk_test_dummy_for_unit_tests';
+  process.env.WORKOS_CLIENT_ID ||= 'client_test_dummy_for_unit_tests';
+  process.env.WORKOS_COOKIE_PASSWORD ||= 'test-cookie-password-32chars-min-len-1234';
+  return {
+    TEST_USER_ID: 'user_claim_test',
+    TEST_ORG_PROSPECT: 'org_claim_route_prospect',
+    TEST_ORG_PAYING: 'org_claim_route_paying',
+    TEST_ORG_HAS_MEMBER: 'org_claim_route_hasmember',
+    TEST_ORG_PERSONAL: 'org_claim_route_personal',
+    TEST_DOMAIN: 'voiseclaim-route.test',
+    TEST_OTHER_DOMAIN: 'someoneelse.test',
+    mockCreateOrganizationMembership: vi.fn(),
+  };
+});
+
+vi.mock('@workos-inc/node', () => ({
+  WorkOS: class {
+    userManagement = {
+      createOrganizationMembership: mockCreateOrganizationMembership,
+      listOrganizationMemberships: vi.fn().mockResolvedValue({ data: [] }),
+      sendInvitation: vi.fn(),
+      getUser: vi.fn().mockResolvedValue({ id: TEST_USER_ID, email: `claimer@${TEST_DOMAIN}` }),
+    };
+    organizations = {
+      getOrganization: vi.fn().mockResolvedValue({ id: TEST_ORG_PROSPECT, name: 'Test Prospect' }),
+    };
+    adminPortal = {
+      generateLink: vi.fn().mockResolvedValue({ link: 'https://test-portal.workos.com' }),
+    };
+  },
+}));
+
+vi.mock('../../src/auth/workos-client.js', () => ({
+  workos: {
+    userManagement: {
+      createOrganizationMembership: mockCreateOrganizationMembership,
+      listOrganizationMemberships: vi.fn().mockResolvedValue({ data: [] }),
+      sendInvitation: vi.fn(),
+      getUser: vi.fn().mockResolvedValue({ id: TEST_USER_ID, email: `claimer@${TEST_DOMAIN}` }),
+    },
+    organizations: {
+      getOrganization: vi.fn().mockResolvedValue({ id: TEST_ORG_PROSPECT, name: 'Test Prospect' }),
+    },
+    adminPortal: {
+      generateLink: vi.fn().mockResolvedValue({ link: 'https://test-portal.workos.com' }),
+    },
+  },
+}));
+
+import { HTTPServer } from '../../src/http.js';
+import request from 'supertest';
+import { initializeDatabase, closeDatabase, getPool } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import type { Pool } from 'pg';
+
+let userOverride: { emailVerified?: boolean; email?: string } = {};
+
+vi.mock('../../src/middleware/auth.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/middleware/auth.js')>()),
+  requireAuth: (req: any, _res: any, next: any) => {
+    req.user = {
+      id: TEST_USER_ID,
+      email: userOverride.email ?? `claimer@${TEST_DOMAIN}`,
+      firstName: 'Claim',
+      lastName: 'Tester',
+      emailVerified: userOverride.emailVerified ?? true,
+      is_admin: false,
+    };
+    next();
+  },
+}));
+
+vi.mock('../../src/middleware/csrf.js', () => ({
+  csrfProtection: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock('../../src/billing/stripe-client.js', () => ({
+  stripe: null,
+  getSubscriptionInfo: vi.fn().mockResolvedValue(null),
+  createStripeCustomer: vi.fn().mockResolvedValue(null),
+  createCustomerSession: vi.fn().mockResolvedValue(null),
+  createBillingPortalSession: vi.fn().mockResolvedValue(null),
+}));
+
+const ALL_TEST_ORGS = [
+  TEST_ORG_PROSPECT,
+  TEST_ORG_PAYING,
+  TEST_ORG_HAS_MEMBER,
+  TEST_ORG_PERSONAL,
+];
+
+async function cleanup(pool: Pool) {
+  await pool.query('DELETE FROM organization_memberships WHERE workos_organization_id = ANY($1)', [ALL_TEST_ORGS]);
+  await pool.query('DELETE FROM registry_audit_log WHERE workos_organization_id = ANY($1)', [ALL_TEST_ORGS]);
+  await pool.query('DELETE FROM organization_domains WHERE workos_organization_id = ANY($1)', [ALL_TEST_ORGS]);
+  await pool.query('DELETE FROM organizations WHERE workos_organization_id = ANY($1)', [ALL_TEST_ORGS]);
+}
+
+async function seedProspect(pool: Pool, opts: {
+  orgId: string;
+  domain: string;
+  isPersonal?: boolean;
+  subscriptionStatus?: string | null;
+  hasMember?: boolean;
+}) {
+  await pool.query(
+    `INSERT INTO organizations (workos_organization_id, name, is_personal, email_domain, subscription_status, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, $5, NOW(), NOW())`,
+    [opts.orgId, `Org ${opts.orgId}`, opts.isPersonal ?? false, opts.domain, opts.subscriptionStatus ?? null],
+  );
+  if (opts.hasMember) {
+    await pool.query(
+      `INSERT INTO organization_memberships (workos_user_id, workos_organization_id, workos_membership_id, email, role, seat_type, created_at, updated_at, synced_at)
+       VALUES ($1, $2, $3, $4, 'owner', 'contributor', NOW(), NOW(), NOW())`,
+      ['user_existing_owner', opts.orgId, 'om_existing', `existing@${opts.domain}`],
+    );
+  }
+}
+
+describe('POST /api/organizations/:orgId/claim', () => {
+  let server: HTTPServer;
+  let app: any;
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+    server = new HTTPServer();
+    await server.start(0);
+    app = server.app;
+  }, 60000);
+
+  afterAll(async () => {
+    await cleanup(pool);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanup(pool);
+    mockCreateOrganizationMembership.mockReset();
+    mockCreateOrganizationMembership.mockResolvedValue({ id: 'om_new' });
+    userOverride = {};
+  });
+
+  it('happy path: claims an unmembered prospect, creates WorkOS membership, writes audit log', async () => {
+    await seedProspect(pool, { orgId: TEST_ORG_PROSPECT, domain: TEST_DOMAIN });
+
+    const res = await request(app).post(`/api/organizations/${TEST_ORG_PROSPECT}/claim`).send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.organization_id).toBe(TEST_ORG_PROSPECT);
+    expect(mockCreateOrganizationMembership).toHaveBeenCalledTimes(1);
+    expect(mockCreateOrganizationMembership).toHaveBeenCalledWith({
+      userId: TEST_USER_ID,
+      organizationId: TEST_ORG_PROSPECT,
+      roleSlug: 'admin',
+    });
+
+    const auditRows = await pool.query(
+      `SELECT action, details FROM registry_audit_log WHERE workos_organization_id = $1`,
+      [TEST_ORG_PROSPECT],
+    );
+    expect(auditRows.rows.length).toBe(1);
+    expect(auditRows.rows[0].action).toBe('organization_claimed');
+    expect(auditRows.rows[0].details).toMatchObject({ claimed_via: 'self_claim', email_domain: TEST_DOMAIN });
+  });
+
+  it('rejects unverified email with 403 (no WorkOS call, no audit row)', async () => {
+    userOverride = { emailVerified: false };
+    await seedProspect(pool, { orgId: TEST_ORG_PROSPECT, domain: TEST_DOMAIN });
+
+    const res = await request(app).post(`/api/organizations/${TEST_ORG_PROSPECT}/claim`).send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('Email not verified');
+    expect(mockCreateOrganizationMembership).not.toHaveBeenCalled();
+  });
+
+  it('rejects domain mismatch with 403', async () => {
+    userOverride = { email: `attacker@${TEST_OTHER_DOMAIN}` };
+    await seedProspect(pool, { orgId: TEST_ORG_PROSPECT, domain: TEST_DOMAIN });
+
+    const res = await request(app).post(`/api/organizations/${TEST_ORG_PROSPECT}/claim`).send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('Domain mismatch');
+    expect(mockCreateOrganizationMembership).not.toHaveBeenCalled();
+  });
+
+  it('rejects org with active subscription with 400', async () => {
+    await seedProspect(pool, {
+      orgId: TEST_ORG_PAYING,
+      domain: TEST_DOMAIN,
+      subscriptionStatus: 'active',
+    });
+
+    const res = await request(app).post(`/api/organizations/${TEST_ORG_PAYING}/claim`).send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Not claimable');
+    expect(mockCreateOrganizationMembership).not.toHaveBeenCalled();
+  });
+
+  it('rejects org that already has members with 409 (anti-hijack)', async () => {
+    await seedProspect(pool, {
+      orgId: TEST_ORG_HAS_MEMBER,
+      domain: TEST_DOMAIN,
+      hasMember: true,
+    });
+
+    const res = await request(app).post(`/api/organizations/${TEST_ORG_HAS_MEMBER}/claim`).send({});
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('Already claimed');
+    expect(mockCreateOrganizationMembership).not.toHaveBeenCalled();
+  });
+
+  it('rejects personal org with 400', async () => {
+    await seedProspect(pool, {
+      orgId: TEST_ORG_PERSONAL,
+      domain: TEST_DOMAIN,
+      isPersonal: true,
+    });
+
+    const res = await request(app).post(`/api/organizations/${TEST_ORG_PERSONAL}/claim`).send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Not claimable');
+    expect(mockCreateOrganizationMembership).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the org does not exist', async () => {
+    const res = await request(app).post(`/api/organizations/org_does_not_exist/claim`).send({});
+
+    expect(res.status).toBe(404);
+    expect(mockCreateOrganizationMembership).not.toHaveBeenCalled();
+  });
+
+  it('rolls back local state when WorkOS createOrganizationMembership fails', async () => {
+    mockCreateOrganizationMembership.mockRejectedValueOnce(new Error('WorkOS down'));
+    await seedProspect(pool, { orgId: TEST_ORG_PROSPECT, domain: TEST_DOMAIN });
+
+    const res = await request(app).post(`/api/organizations/${TEST_ORG_PROSPECT}/claim`).send({});
+
+    expect(res.status).toBe(500);
+    const auditRows = await pool.query(
+      `SELECT action FROM registry_audit_log WHERE workos_organization_id = $1`,
+      [TEST_ORG_PROSPECT],
+    );
+    expect(auditRows.rows.length).toBe(0);
+  });
+
+  it('treats organization_membership_already_exists as success (no double audit row)', async () => {
+    const alreadyExistsErr: Error & { code?: string } = new Error('already exists');
+    alreadyExistsErr.code = 'organization_membership_already_exists';
+    mockCreateOrganizationMembership.mockRejectedValueOnce(alreadyExistsErr);
+    await seedProspect(pool, { orgId: TEST_ORG_PROSPECT, domain: TEST_DOMAIN });
+
+    const res = await request(app).post(`/api/organizations/${TEST_ORG_PROSPECT}/claim`).send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});

--- a/server/tests/integration/find-claimable-prospect-org.test.ts
+++ b/server/tests/integration/find-claimable-prospect-org.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Integration tests for findClaimableProspectOrgForDomain — the auth/callback
+ * helper that surfaces sales-touched prospect orgs at signup so users can
+ * claim them instead of silently being routed to a personal workspace
+ * (Voise Tech failure mode).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { findClaimableProspectOrgForDomain } from '../../src/db/org-filters.js';
+import type { Pool } from 'pg';
+
+const ORG_PROSPECT_BY_EMAIL_DOMAIN = 'org_claim_prospect_email_test';
+const ORG_PROSPECT_BY_VERIFIED_DOMAIN = 'org_claim_prospect_verified_test';
+const ORG_PAYING = 'org_claim_paying_test';
+const ORG_HAS_MEMBERS = 'org_claim_has_members_test';
+const ORG_PERSONAL = 'org_claim_personal_test';
+
+const TEST_ORGS = [
+  ORG_PROSPECT_BY_EMAIL_DOMAIN,
+  ORG_PROSPECT_BY_VERIFIED_DOMAIN,
+  ORG_PAYING,
+  ORG_HAS_MEMBERS,
+  ORG_PERSONAL,
+];
+
+const VOISE_DOMAIN = 'voiseclaim.test';
+const ORPHAN_DOMAIN = 'orphan-noone-here.test';
+const PAYING_DOMAIN = 'paying-co.test';
+const ALREADY_CLAIMED_DOMAIN = 'claimed-co.test';
+const PERSONAL_DOMAIN = 'personal-only.test';
+
+async function cleanup(pool: Pool) {
+  await pool.query('DELETE FROM organization_memberships WHERE workos_organization_id = ANY($1)', [TEST_ORGS]);
+  await pool.query('DELETE FROM organization_domains WHERE workos_organization_id = ANY($1)', [TEST_ORGS]);
+  await pool.query('DELETE FROM organizations WHERE workos_organization_id = ANY($1)', [TEST_ORGS]);
+}
+
+async function seedOrg(
+  pool: Pool,
+  orgId: string,
+  opts: {
+    is_personal?: boolean;
+    email_domain?: string | null;
+    subscription_status?: string | null;
+  } = {},
+) {
+  await pool.query(
+    `INSERT INTO organizations (workos_organization_id, name, is_personal, email_domain, subscription_status, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
+     ON CONFLICT (workos_organization_id) DO UPDATE
+       SET is_personal = EXCLUDED.is_personal,
+           email_domain = EXCLUDED.email_domain,
+           subscription_status = EXCLUDED.subscription_status`,
+    [orgId, `Org ${orgId}`, opts.is_personal ?? false, opts.email_domain ?? null, opts.subscription_status ?? null],
+  );
+}
+
+async function seedDomain(pool: Pool, orgId: string, domain: string, verified = true) {
+  await pool.query(
+    `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source, created_at, updated_at)
+     VALUES ($1, $2, true, $3, 'workos', NOW(), NOW())
+     ON CONFLICT (domain) DO UPDATE
+       SET workos_organization_id = $1, verified = $3`,
+    [orgId, domain, verified],
+  );
+}
+
+async function seedMembership(pool: Pool, orgId: string) {
+  await pool.query(
+    `INSERT INTO organization_memberships (workos_user_id, workos_organization_id, workos_membership_id, email, role, seat_type, created_at, updated_at, synced_at)
+     VALUES ($1, $2, $3, $4, 'member', 'contributor', NOW(), NOW(), NOW())
+     ON CONFLICT DO NOTHING`,
+    ['user_existing_member', orgId, 'om_existing', 'existing@member.test'],
+  );
+}
+
+describe('findClaimableProspectOrgForDomain', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  }, 60000);
+
+  afterAll(async () => {
+    await cleanup(pool);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanup(pool);
+  });
+
+  afterEach(async () => {
+    await cleanup(pool);
+  });
+
+  it('returns null for a domain with no matching org', async () => {
+    expect(await findClaimableProspectOrgForDomain(ORPHAN_DOMAIN)).toBeNull();
+  });
+
+  it('matches a prospect org by organizations.email_domain', async () => {
+    await seedOrg(pool, ORG_PROSPECT_BY_EMAIL_DOMAIN, { email_domain: VOISE_DOMAIN });
+
+    const result = await findClaimableProspectOrgForDomain(VOISE_DOMAIN);
+
+    expect(result).not.toBeNull();
+    expect(result!.organization_id).toBe(ORG_PROSPECT_BY_EMAIL_DOMAIN);
+    expect(result!.matched_domain).toBe(VOISE_DOMAIN);
+  });
+
+  it('matches a prospect org by verified organization_domains row', async () => {
+    await seedOrg(pool, ORG_PROSPECT_BY_VERIFIED_DOMAIN);
+    await seedDomain(pool, ORG_PROSPECT_BY_VERIFIED_DOMAIN, VOISE_DOMAIN, true);
+
+    const result = await findClaimableProspectOrgForDomain(VOISE_DOMAIN);
+
+    expect(result).not.toBeNull();
+    expect(result!.organization_id).toBe(ORG_PROSPECT_BY_VERIFIED_DOMAIN);
+  });
+
+  it('does not match an unverified organization_domains row', async () => {
+    await seedOrg(pool, ORG_PROSPECT_BY_VERIFIED_DOMAIN);
+    await seedDomain(pool, ORG_PROSPECT_BY_VERIFIED_DOMAIN, VOISE_DOMAIN, false);
+
+    const result = await findClaimableProspectOrgForDomain(VOISE_DOMAIN);
+
+    expect(result).toBeNull();
+  });
+
+  it('does not match an org with an active subscription (auto-link path handles those)', async () => {
+    await seedOrg(pool, ORG_PAYING, { email_domain: PAYING_DOMAIN, subscription_status: 'active' });
+
+    const result = await findClaimableProspectOrgForDomain(PAYING_DOMAIN);
+
+    expect(result).toBeNull();
+  });
+
+  it('does not match an org that already has members (anti-hijack)', async () => {
+    await seedOrg(pool, ORG_HAS_MEMBERS, { email_domain: ALREADY_CLAIMED_DOMAIN });
+    await seedMembership(pool, ORG_HAS_MEMBERS);
+
+    const result = await findClaimableProspectOrgForDomain(ALREADY_CLAIMED_DOMAIN);
+
+    expect(result).toBeNull();
+  });
+
+  it('does not match a personal org even when the domain matches', async () => {
+    await seedOrg(pool, ORG_PERSONAL, { is_personal: true, email_domain: PERSONAL_DOMAIN });
+    // (personal orgs intentionally have email_domain NULL in production, but
+    // belt-and-braces — even if one slipped through, claiming it should fail.)
+
+    const result = await findClaimableProspectOrgForDomain(PERSONAL_DOMAIN);
+
+    expect(result).toBeNull();
+  });
+
+  it('normalizes the input domain (case + whitespace)', async () => {
+    await seedOrg(pool, ORG_PROSPECT_BY_EMAIL_DOMAIN, { email_domain: VOISE_DOMAIN });
+
+    const result = await findClaimableProspectOrgForDomain(`  ${VOISE_DOMAIN.toUpperCase()}  `);
+
+    expect(result).not.toBeNull();
+    expect(result!.organization_id).toBe(ORG_PROSPECT_BY_EMAIL_DOMAIN);
+  });
+});


### PR DESCRIPTION
## Summary

- `findClaimableProspectOrgForDomain` returns an unmembered prospect org owned by a domain (via `email_domain` or verified `organization_domains`) with no active subscription and no existing members
- `/auth/callback` redirect now surfaces the match as `?claim_org=<id>&claim_org_name=<name>` so onboarding can offer the claim
- New `POST /api/organizations/:orgId/claim` validates conditions under a `FOR UPDATE` row lock, then creates a WorkOS admin membership; anti-hijack guards catch domain mismatches, paying orgs, and orgs that already have a member
- `onboarding.html` banner is shown only when the query param is present — single CTA + a skip link that strips the params

## Why this matters

This is the user-facing fix for the Voise Tech root-cause. Their @voisetech.com employees signed up on May 3, the prospect org from Feb 13 was invisible to the auto-link path (no subscription), and they silently landed on personal workspaces. With this PR, the same scenario surfaces "We've been tracking voisetech.com — claim this organization" right on the onboarding page, with a single click to consolidate into the existing org (preserving the Stripe customer and any prior sales work).

## Test plan

- [x] `tests/integration/find-claimable-prospect-org.test.ts` — 8 tests cover null on no match, email_domain match, verified-domain-row match, unverified-row no-match, paying-org no-match, has-members no-match, personal-org no-match, normalization (case + whitespace)
- [x] Type check + pre-commit hooks pass
- [ ] Manual smoke: log in fresh as a domain whose prospect org exists; verify banner appears, claim succeeds, dashboard loads with the claimed org

🤖 Generated with [Claude Code](https://claude.com/claude-code)