### PR TITLE
fix(billing): notify new member with actual paid amount, not list price

### DIFF
--- a/.changeset/notify-actual-paid-amount.md
+++ b/.changeset/notify-actual-paid-amount.md
@@ -1,0 +1,4 @@
+---
+---
+
+"New Member!" Slack notification now reports the actual subscribed amount post-discount, not the catalog list price. Plan line shows list + discount when they differ ("Member ($15,000 list, $5,000 discount)"); Status line distinguishes Paid vs Invoice sent (Net N, not yet paid) vs Payment failed. Voise Tech-shaped checkout-with-coupon will now read "$10,000.00/year — Member ($15,000 list, $5,000 discount) — Paid" instead of the misleading "$15,000.00/year — Partner".

--- a/server/src/billing/handle-subscription-created.ts
+++ b/server/src/billing/handle-subscription-created.ts
@@ -21,6 +21,7 @@ import type { Logger } from 'pino';
 import type { Pool } from 'pg';
 import type { OrganizationDatabase, Organization } from '../db/organization-db.js';
 import { resolveWorkosUserForSubscription } from './resolve-subscription-user.js';
+import { buildSubscriptionSummary, type SubscriptionSummary } from './subscription-summary.js';
 
 export interface ActivationAdminContext {
   userEmail: string;
@@ -44,8 +45,12 @@ export interface HandleSubscriptionCreatedArgs {
     customerEmail: string;
     productName?: string;
     amount?: number;
+    listAmount?: number;
+    discountSummary?: string;
     currency?: string;
     interval?: string;
+    paymentStatus?: SubscriptionSummary['paymentStatus'];
+    invoiceTermsDays?: number;
   }) => Promise<boolean>;
 }
 
@@ -264,8 +269,12 @@ export async function handleSubscriptionCreated(
     customerEmail: userEmail,
     productName: productInfo.productName,
     amount: productInfo.amount,
-    currency: subscription.currency,
+    listAmount: productInfo.listAmount,
+    discountSummary: productInfo.discountSummary,
+    currency: productInfo.currency ?? subscription.currency,
     interval: productInfo.interval,
+    paymentStatus: productInfo.paymentStatus,
+    invoiceTermsDays: productInfo.invoiceTermsDays,
   }).catch((err) => logger.error({ err }, 'Failed to send Slack notification'));
 
   return activationAdminContext;
@@ -275,22 +284,6 @@ async function fetchProductInfo(
   stripe: Stripe,
   subscription: Stripe.Subscription,
   logger: Logger,
-): Promise<{ productName?: string; amount?: number; interval?: string }> {
-  const firstItem = subscription.items?.data?.[0];
-  if (!firstItem?.price) return {};
-
-  const amount = firstItem.price.unit_amount || undefined;
-  const interval = firstItem.price.recurring?.interval;
-  let productName: string | undefined;
-
-  if (firstItem.price.product) {
-    try {
-      const product = (await stripe.products.retrieve(firstItem.price.product as string)) as Stripe.Product;
-      productName = product.name;
-    } catch (err) {
-      logger.debug({ err }, 'Failed to retrieve Stripe product metadata (non-critical)');
-    }
-  }
-
-  return { productName, amount, interval };
+): Promise<SubscriptionSummary> {
+  return buildSubscriptionSummary(stripe, subscription, logger);
 }

--- a/server/src/billing/subscription-summary.ts
+++ b/server/src/billing/subscription-summary.ts
@@ -1,0 +1,174 @@
+/**
+ * Build a rich subscription summary for the "New Member!" Slack notification.
+ *
+ * The earlier `fetchProductInfo` returned `price.unit_amount` — the catalog
+ * list price, ignoring any coupon. So Voise Tech's $5K-discounted Member tier
+ * was announced at $15,000 even though Sabarish only paid $10K. This helper
+ * returns the *actual* amount (post-discount) plus payment status so admins
+ * can tell at a glance whether the invoice has been collected.
+ *
+ * Reads:
+ *   - subscription.items[0].price (catalog amount + interval)
+ *   - subscription.latest_invoice (fetched inline; the webhook payload only
+ *     ships the id, not the expanded object). Discount cents and payment
+ *     status both come from the invoice — that's the source of truth for
+ *     what the customer is actually being charged this period.
+ */
+
+import type Stripe from 'stripe';
+import type { Logger } from 'pino';
+
+export interface SubscriptionSummary {
+  /** Stripe product name, e.g. "AAO Membership". */
+  productName?: string;
+  /**
+   * What the customer is actually paying this period, in cents. Falls back
+   * to `price.unit_amount` if the invoice can't be fetched. Always reflects
+   * any discount applied at the invoice level.
+   */
+  amount?: number;
+  /** Catalog price before discount. Only set when it differs from `amount`. */
+  listAmount?: number;
+  /**
+   * One-line summary of the discount, e.g. "$5,000 discount". Empty when
+   * there's no discount on the invoice.
+   */
+  discountSummary?: string;
+  currency?: string;
+  /** Stripe billing interval — 'year' / 'month' / etc. */
+  interval?: string;
+  /**
+   * Where the first invoice currently sits.
+   *   'paid'                  — fully paid (charge_automatically + card OK,
+   *                             OR send_invoice that was paid)
+   *   'invoice_sent_pending'  — invoice sent for manual payment, not paid yet
+   *   'payment_failed'        — uncollectible / void
+   *   'payment_pending'       — invoice in 'open' on charge_automatically
+   *                             (rare, e.g. async payment method)
+   *   'unknown'               — couldn't fetch the invoice
+   */
+  paymentStatus?: 'paid' | 'invoice_sent_pending' | 'payment_failed' | 'payment_pending' | 'unknown';
+  /** For send_invoice mode: days from invoice creation to due_date. 0 = "due upon receipt". */
+  invoiceTermsDays?: number;
+}
+
+export async function buildSubscriptionSummary(
+  stripe: Stripe,
+  subscription: Stripe.Subscription,
+  logger: Logger,
+): Promise<SubscriptionSummary> {
+  const firstItem = subscription.items?.data?.[0];
+  if (!firstItem?.price) return {};
+
+  const listAmount = firstItem.price.unit_amount ?? undefined;
+  const interval = firstItem.price.recurring?.interval;
+  const currency = subscription.currency ?? firstItem.price.currency;
+
+  let productName: string | undefined;
+  if (firstItem.price.product) {
+    try {
+      const product = (await stripe.products.retrieve(
+        firstItem.price.product as string,
+      )) as Stripe.Product;
+      productName = product.name;
+    } catch (err) {
+      logger.debug({ err }, 'Failed to retrieve Stripe product metadata (non-critical)');
+    }
+  }
+
+  // Try to use the actual invoice for the most precise amount + discount +
+  // payment status. Webhook payloads ship `latest_invoice` as an id, not an
+  // expanded object — re-fetch it inline.
+  const latestInvoiceRef = subscription.latest_invoice;
+  let invoice: Stripe.Invoice | null = null;
+  if (typeof latestInvoiceRef === 'string') {
+    try {
+      invoice = await stripe.invoices.retrieve(latestInvoiceRef);
+    } catch (err) {
+      logger.warn(
+        { err, subscriptionId: subscription.id, invoiceId: latestInvoiceRef },
+        'Failed to fetch latest invoice for subscription summary; falling back to list price',
+      );
+    }
+  } else if (latestInvoiceRef && typeof latestInvoiceRef === 'object') {
+    invoice = latestInvoiceRef as Stripe.Invoice;
+  }
+
+  if (!invoice) {
+    return {
+      productName,
+      amount: listAmount,
+      currency,
+      interval,
+      paymentStatus: 'unknown',
+    };
+  }
+
+  const actualAmount = invoiceAmountForDisplay(invoice);
+  const discountCents = totalDiscountCents(invoice);
+  const discountSummary = discountCents > 0 ? `${formatCents(discountCents, currency)} discount` : undefined;
+  const showList =
+    listAmount !== undefined &&
+    actualAmount !== undefined &&
+    listAmount !== actualAmount;
+
+  return {
+    productName,
+    amount: actualAmount ?? listAmount,
+    listAmount: showList ? listAmount : undefined,
+    discountSummary,
+    currency,
+    interval,
+    paymentStatus: classifyInvoiceStatus(invoice),
+    invoiceTermsDays: computeInvoiceTermsDays(invoice),
+  };
+}
+
+/**
+ * Pick the right "what they're paying this period" number off the invoice.
+ * Prefer `amount_paid` once paid; fall back to `total` (post-discount, post-tax)
+ * for unpaid open/draft invoices.
+ */
+function invoiceAmountForDisplay(invoice: Stripe.Invoice): number | undefined {
+  if (invoice.amount_paid && invoice.amount_paid > 0) return invoice.amount_paid;
+  if (typeof invoice.total === 'number') return invoice.total;
+  if (typeof invoice.amount_due === 'number') return invoice.amount_due;
+  return undefined;
+}
+
+function totalDiscountCents(invoice: Stripe.Invoice): number {
+  const entries = invoice.total_discount_amounts;
+  if (!entries || entries.length === 0) return 0;
+  return entries.reduce((sum, e) => sum + (e.amount || 0), 0);
+}
+
+function classifyInvoiceStatus(
+  invoice: Stripe.Invoice,
+): SubscriptionSummary['paymentStatus'] {
+  const status = invoice.status;
+  const collection = invoice.collection_method;
+
+  if (status === 'paid') return 'paid';
+  if (status === 'open' && collection === 'send_invoice') return 'invoice_sent_pending';
+  if (status === 'open' && collection === 'charge_automatically') return 'payment_pending';
+  if (status === 'uncollectible') return 'payment_failed';
+  if (status === 'void') return 'payment_failed';
+  // 'draft' or null: not enough signal to call it; treat as unknown.
+  return 'unknown';
+}
+
+function computeInvoiceTermsDays(invoice: Stripe.Invoice): number | undefined {
+  if (invoice.collection_method !== 'send_invoice') return undefined;
+  if (!invoice.due_date) return 0; // due upon receipt
+  if (!invoice.created) return undefined;
+  const seconds = invoice.due_date - invoice.created;
+  return Math.max(0, Math.round(seconds / 86400));
+}
+
+function formatCents(cents: number, currency: string | undefined): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: (currency ?? 'usd').toUpperCase(),
+    maximumFractionDigits: 0,
+  }).format(cents / 100);
+}

--- a/server/src/notifications/billing.ts
+++ b/server/src/notifications/billing.ts
@@ -104,32 +104,102 @@ async function sendBillingNotification(
   }
 }
 
+export type NewSubscriptionPaymentStatus =
+  | 'paid'
+  | 'invoice_sent_pending'
+  | 'payment_failed'
+  | 'payment_pending'
+  | 'unknown';
+
 /**
- * Notify when a new subscription is created
+ * Notify when a new subscription is created. The amount field is the
+ * post-discount amount actually being billed — show list price + discount
+ * summary as a separate field when they differ. Status reflects whether
+ * the first invoice has been collected yet.
  */
 export async function notifyNewSubscription(data: {
   organizationName: string;
   customerEmail: string;
   productName?: string;
   amount?: number;
+  /** Catalog list price, only set when different from `amount`. Drives "(was $X)". */
+  listAmount?: number;
+  /** Free-text discount line, e.g. "$5,000 referral discount" or "20% off". */
+  discountSummary?: string;
   currency?: string;
   interval?: string;
+  paymentStatus?: NewSubscriptionPaymentStatus;
+  /** For send_invoice mode: days from invoice creation to due date. 0 = "due upon receipt". */
+  invoiceTermsDays?: number;
 }): Promise<boolean> {
   const intervalText = data.interval === 'year' ? '/year' : '/month';
-  const amountText = data.amount ? formatAmount(data.amount, data.currency) + intervalText : 'Custom';
+  const amountText = data.amount
+    ? formatAmount(data.amount, data.currency) + intervalText
+    : 'Custom';
+
+  const planText = formatPlanLine(data);
+  const statusText = formatPaymentStatus(data.paymentStatus, data.invoiceTermsDays);
+
+  const fields: Array<{ label: string; value: string }> = [
+    { label: 'Organization', value: data.organizationName },
+    { label: 'Email', value: maskEmail(data.customerEmail) },
+    { label: 'Plan', value: planText },
+    { label: 'Amount', value: amountText },
+  ];
+  if (statusText) {
+    fields.push({ label: 'Status', value: statusText });
+  }
 
   return sendBillingNotification(
     `New Member: ${data.organizationName}`,
-    [
-      headerBlock('New Member!'),
-      sectionBlock([
-        { label: 'Organization', value: data.organizationName },
-        { label: 'Email', value: maskEmail(data.customerEmail) },
-        { label: 'Plan', value: data.productName || 'Membership' },
-        { label: 'Amount', value: amountText },
-      ]),
-    ]
+    [headerBlock('New Member!'), sectionBlock(fields)],
   );
+}
+
+/**
+ * Plan field — shows the product name plus list price + discount summary
+ * when a discount was applied, so admins can see the framing at a glance.
+ */
+function formatPlanLine(data: {
+  productName?: string;
+  listAmount?: number;
+  discountSummary?: string;
+  currency?: string;
+}): string {
+  const base = data.productName || 'Membership';
+  if (data.listAmount && data.discountSummary) {
+    return `${base} (${formatAmount(data.listAmount, data.currency)} list, ${data.discountSummary})`;
+  }
+  if (data.discountSummary) {
+    return `${base} (${data.discountSummary})`;
+  }
+  return base;
+}
+
+function formatPaymentStatus(
+  status: NewSubscriptionPaymentStatus | undefined,
+  termsDays: number | undefined,
+): string | undefined {
+  switch (status) {
+    case 'paid':
+      return 'Paid';
+    case 'invoice_sent_pending': {
+      const terms =
+        termsDays === undefined
+          ? 'awaiting payment'
+          : termsDays === 0
+            ? 'Net 0 — due upon receipt, not yet paid'
+            : `Net ${termsDays}, not yet paid`;
+      return `Invoice sent (${terms})`;
+    }
+    case 'payment_pending':
+      return 'Charge pending — Stripe is processing the payment';
+    case 'payment_failed':
+      return 'Payment failed — admin action needed';
+    case 'unknown':
+    case undefined:
+      return undefined;
+  }
 }
 
 /**

--- a/server/tests/unit/subscription-summary.test.ts
+++ b/server/tests/unit/subscription-summary.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi } from 'vitest';
+import type Stripe from 'stripe';
+import { buildSubscriptionSummary } from '../../src/billing/subscription-summary.js';
+
+/** Minimal logger that swallows everything. */
+const noopLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+} as unknown as Parameters<typeof buildSubscriptionSummary>[2];
+
+function makeStripe(opts: {
+  invoice?: Partial<Stripe.Invoice> | null;
+  product?: Partial<Stripe.Product>;
+  invoiceFetchError?: boolean;
+} = {}): Stripe {
+  const invoicesRetrieve = vi.fn(async () => {
+    if (opts.invoiceFetchError) throw new Error('Stripe invoice fetch failed');
+    return opts.invoice as Stripe.Invoice;
+  });
+  const productsRetrieve = vi.fn(async () => (opts.product ?? { name: 'AAO Membership' }) as Stripe.Product);
+  return {
+    invoices: { retrieve: invoicesRetrieve },
+    products: { retrieve: productsRetrieve },
+  } as unknown as Stripe;
+}
+
+function makeSubscription(opts: {
+  unitAmount?: number;
+  interval?: 'year' | 'month';
+  latestInvoice?: string | Stripe.Invoice | null;
+  productId?: string;
+  currency?: string;
+} = {}): Stripe.Subscription {
+  return {
+    id: 'sub_test',
+    currency: opts.currency ?? 'usd',
+    latest_invoice: opts.latestInvoice ?? 'in_test',
+    items: {
+      data: [
+        {
+          price: {
+            unit_amount: opts.unitAmount ?? 1500000,
+            currency: opts.currency ?? 'usd',
+            recurring: { interval: opts.interval ?? 'year' },
+            product: opts.productId ?? 'prod_test',
+          },
+        },
+      ],
+    },
+  } as unknown as Stripe.Subscription;
+}
+
+describe('buildSubscriptionSummary', () => {
+  it('returns the actual paid amount and Paid status for a normal Member checkout', async () => {
+    const stripe = makeStripe({
+      invoice: {
+        amount_paid: 1500000,
+        total: 1500000,
+        amount_due: 0,
+        status: 'paid',
+        collection_method: 'charge_automatically',
+        total_discount_amounts: null,
+      },
+    });
+    const sub = makeSubscription({ unitAmount: 1500000 });
+
+    const result = await buildSubscriptionSummary(stripe, sub, noopLogger);
+
+    expect(result.amount).toBe(1500000);
+    expect(result.listAmount).toBeUndefined();
+    expect(result.discountSummary).toBeUndefined();
+    expect(result.paymentStatus).toBe('paid');
+    expect(result.invoiceTermsDays).toBeUndefined();
+  });
+
+  it('reports the post-discount amount and surfaces discount summary (Voise Tech case)', async () => {
+    const stripe = makeStripe({
+      invoice: {
+        amount_paid: 1000000,
+        total: 1000000,
+        amount_due: 0,
+        status: 'paid',
+        collection_method: 'charge_automatically',
+        total_discount_amounts: [{ amount: 500000, discount: 'di_test' }],
+      },
+    });
+    const sub = makeSubscription({ unitAmount: 1500000 });
+
+    const result = await buildSubscriptionSummary(stripe, sub, noopLogger);
+
+    expect(result.amount).toBe(1000000);
+    expect(result.listAmount).toBe(1500000);
+    expect(result.discountSummary).toBe('$5,000 discount');
+    expect(result.paymentStatus).toBe('paid');
+  });
+
+  it('shows Net 30 invoice_sent_pending for unpaid send_invoice subscription', async () => {
+    const created = 1_700_000_000;
+    const due = created + 30 * 86400;
+    const stripe = makeStripe({
+      invoice: {
+        amount_paid: 0,
+        total: 1000000,
+        amount_due: 1000000,
+        status: 'open',
+        collection_method: 'send_invoice',
+        created,
+        due_date: due,
+        total_discount_amounts: [{ amount: 500000, discount: 'di_test' }],
+      },
+    });
+    const sub = makeSubscription({ unitAmount: 1500000 });
+
+    const result = await buildSubscriptionSummary(stripe, sub, noopLogger);
+
+    expect(result.amount).toBe(1000000);
+    expect(result.listAmount).toBe(1500000);
+    expect(result.discountSummary).toBe('$5,000 discount');
+    expect(result.paymentStatus).toBe('invoice_sent_pending');
+    expect(result.invoiceTermsDays).toBe(30);
+  });
+
+  it('reports Net 0 (due upon receipt) when send_invoice has no due_date', async () => {
+    const stripe = makeStripe({
+      invoice: {
+        amount_paid: 0,
+        total: 1000000,
+        amount_due: 1000000,
+        status: 'open',
+        collection_method: 'send_invoice',
+        created: 1_700_000_000,
+        due_date: null,
+        total_discount_amounts: null,
+      },
+    });
+    const sub = makeSubscription({ unitAmount: 1000000 });
+
+    const result = await buildSubscriptionSummary(stripe, sub, noopLogger);
+
+    expect(result.paymentStatus).toBe('invoice_sent_pending');
+    expect(result.invoiceTermsDays).toBe(0);
+  });
+
+  it('falls back to list price and unknown status when invoice fetch fails', async () => {
+    const stripe = makeStripe({ invoiceFetchError: true });
+    const sub = makeSubscription({ unitAmount: 1500000 });
+
+    const result = await buildSubscriptionSummary(stripe, sub, noopLogger);
+
+    expect(result.amount).toBe(1500000);
+    expect(result.listAmount).toBeUndefined();
+    expect(result.discountSummary).toBeUndefined();
+    expect(result.paymentStatus).toBe('unknown');
+  });
+
+  it('classifies uncollectible/void invoices as payment_failed', async () => {
+    const stripe = makeStripe({
+      invoice: {
+        amount_paid: 0,
+        total: 1500000,
+        amount_due: 1500000,
+        status: 'uncollectible',
+        collection_method: 'charge_automatically',
+        total_discount_amounts: null,
+      },
+    });
+    const sub = makeSubscription({ unitAmount: 1500000 });
+
+    const result = await buildSubscriptionSummary(stripe, sub, noopLogger);
+
+    expect(result.paymentStatus).toBe('payment_failed');
+  });
+
+  it('classifies open invoice on charge_automatically as payment_pending (rare async flow)', async () => {
+    const stripe = makeStripe({
+      invoice: {
+        amount_paid: 0,
+        total: 1500000,
+        amount_due: 1500000,
+        status: 'open',
+        collection_method: 'charge_automatically',
+        total_discount_amounts: null,
+      },
+    });
+    const sub = makeSubscription({ unitAmount: 1500000 });
+
+    const result = await buildSubscriptionSummary(stripe, sub, noopLogger);
+
+    expect(result.paymentStatus).toBe('payment_pending');
+  });
+
+  it('returns empty summary when subscription has no items', async () => {
+    const stripe = makeStripe();
+    const sub = { id: 'sub_test', items: { data: [] } } as unknown as Stripe.Subscription;
+
+    const result = await buildSubscriptionSummary(stripe, sub, noopLogger);
+
+    expect(result).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

- Replace `price.unit_amount` (catalog list) with the latest invoice's actual paid amount, post-discount, in the "New Member!" Slack notification
- New `buildSubscriptionSummary` helper fetches `subscription.latest_invoice` (the webhook ships only the id) and reads amount + discount cents + payment status from the invoice
- Plan line shows list + discount when they differ ("Member ($15,000 list, $5,000 discount)")
- Status line distinguishes Paid / Invoice sent (Net N, not yet paid) / Payment pending / Payment failed
- For send_invoice mode, computes Net N from `due_date − created` (Net 0 when `due_date` is null = "due upon receipt")

## Why this matters

Voise Tech's $5K-discounted Member subscription was announced at "$15,000.00/year" because the notifier was reading the catalog price off the subscription's price object instead of the actual charged amount on the invoice. That's misleading both for finance (wrong amount) and for the team trying to track which discounts are working.

Brian's ask, verbatim: "if someone subscribes but haven't paid yet, this notification should say *'$10,000 subscription created ($5,000 discount for the member tier), invoice sent net zero, but not paid yet.'*" The Status line now does exactly that.

## Test plan

- [x] `tests/unit/subscription-summary.test.ts` — 8 tests cover: paid no-discount, paid with discount (Voise Tech case), Net 30 invoice_sent_pending, Net 0 due-upon-receipt, invoice fetch failure fallback, uncollectible/void → payment_failed, open + charge_automatically → payment_pending, empty subscription
- [x] Existing `tests/unit/handle-subscription-created.test.ts` (9 tests) still pass
- [x] Type check + pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)