### PR TITLE
fix(aao): re-trigger brand crawl on stub rows without manifest

### DIFF
--- a/.changeset/recrawl-empty-brand-stub.md
+++ b/.changeset/recrawl-empty-brand-stub.md
@@ -1,0 +1,16 @@
+---
+---
+
+Auto-crawl on `/api/registry/publisher` now re-triggers when a stub
+brand row exists without a manifest. Brian found wonderstruck.org
+serving a valid brand.json at /.well-known/brand.json but the publisher
+page reporting "no brand.json yet" — root cause was a previous crawl
+having written a brand row with `has_brand_manifest=false` (the
+discovery path stamps `brand_name=domain` even when the manifest fetch
+fails). The `brandNeverCrawled` heuristic was reading "row exists" as
+"already checked," refusing to retry.
+
+Fix: `brandNeverCrawled` is now `!brandRow || !brandRow.has_brand_manifest`,
+so empty stubs are eligible for re-crawl. Also: `files.brand_json.name`
+is now suppressed when there's no real manifest — a domain-literal
+placeholder is misleading.

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -5761,7 +5761,14 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       // crawl. The IP-keyed `agentReadRateLimiter` mounted above bounds
       // the breadth of distinct-domain enumeration too.
       const adagentsNeverCrawled = adagentsValid === null;
-      const brandNeverCrawled = !brandRow;
+      // "Stub without manifest" counts as never-crawled for re-crawl
+      // purposes: a previous crawl may have written a brand row whose
+      // brand_name comes from the publisher's domain literal (the
+      // discovery path stamps that even when the manifest fetch failed)
+      // but never landed a brand_manifest. We were treating those rows
+      // as "already crawled" and refusing to retry — leaving publishers
+      // who actually serve a brand.json forever marked as missing one.
+      const brandNeverCrawled = !brandRow || !brandRow.has_brand_manifest;
       let autoCrawlTriggered = false;
       if ((adagentsNeverCrawled || brandNeverCrawled) && shouldAutoCrawl(domain)) {
         // Re-validate: returns null on private/loopback/link-local IPs
@@ -5918,10 +5925,17 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           expected_url: hosting.expected_url,
         } as { status: 'valid' | 'invalid' | 'unknown' | 'checking'; expected_url: string },
         brand_json: {
-          status: brandRow
-            ? (brandRow.has_brand_manifest ? 'present' : 'unknown')
-            : (autoCrawlTriggered ? 'checking' : 'unknown'),
-          name: brandRow?.brand_name,
+          // `present` = a row exists with a manifest. `checking` =
+          // we just kicked off a crawl (either no row, or a stub
+          // without a manifest from a prior failed crawl). `unknown`
+          // = row exists with no manifest and we didn't re-trigger
+          // (debounced).
+          status: brandRow?.has_brand_manifest
+            ? 'present'
+            : autoCrawlTriggered
+              ? 'checking'
+              : 'unknown',
+          name: brandRow?.has_brand_manifest ? brandRow.brand_name : undefined,
         } as { status: 'present' | 'unknown' | 'checking'; name?: string },
       };
 

--- a/server/tests/integration/registry-publisher-brand-json-hydration.test.ts
+++ b/server/tests/integration/registry-publisher-brand-json-hydration.test.ts
@@ -225,6 +225,32 @@ describe('Registry publisher endpoint — brand.json hydration', () => {
     );
   });
 
+  it('re-triggers brand crawl when a stub row exists without a manifest', async () => {
+    // Set up a brand row that mirrors the production state we saw on
+    // wonderstruck.org: brand row exists (the discovery path stamps a
+    // brand_name from the domain literal), but has_brand_manifest is
+    // false because a prior crawl came up empty. The auto-crawl logic
+    // must NOT treat this as "already crawled" — the publisher's
+    // origin may now actually serve a brand.json that we never picked
+    // up. Re-trigger and surface `checking`.
+    const stubDomain = `stub-no-manifest-${Date.now()}.registry-baseline.example`;
+    await brandDb.upsertDiscoveredBrand({
+      domain: stubDomain,
+      brand_name: stubDomain, // domain-literal placeholder, no real metadata
+      source_type: 'community',
+      has_brand_manifest: false,
+    });
+
+    const res = await request(app).get(`/api/registry/publisher?domain=${encodeURIComponent(stubDomain)}`);
+    expect(res.status).toBe(200);
+    expect(res.body.auto_crawl_triggered).toBe(true);
+    // Status reflects the in-flight re-crawl.
+    expect(res.body.files.brand_json.status).toBe('checking');
+    // Name is suppressed when there's no real manifest — the
+    // domain-literal placeholder is misleading.
+    expect(res.body.files.brand_json.name).toBeUndefined();
+  });
+
   it('reports hosting.mode=none when no adagents.json is configured', async () => {
     const res = await request(app).get(
       `/api/registry/publisher?domain=${encodeURIComponent(PUB_BRAND_ONLY)}`


### PR DESCRIPTION
## Summary

Brian reported `wonderstruck.org` serving a valid `brand.json` at `/.well-known/brand.json` but the publisher page at `/publisher/wonderstruck.org` reporting "no brand.json yet." Root-caused to a stub row in `brands` from a prior failed crawl.

**Production state:**
```
files.brand_json: {
  status: "unknown",
  name: "wonderstruck.org"   // domain-literal placeholder, not real metadata
}
```

But `https://wonderstruck.org/.well-known/brand.json` returns HTTP 200 with valid JSON.

## What was wrong

The auto-crawl logic read `brandNeverCrawled = !brandRow`. When a previous crawl wrote a stub row (the discovery path stamps `brand_name=domain literal` even when manifest fetch failed), the logic treated it as "already crawled" and refused to retry — forever.

## Fix

```diff
- const brandNeverCrawled = !brandRow;
+ const brandNeverCrawled = !brandRow || !brandRow.has_brand_manifest;
```

Also: `files.brand_json.name` is now suppressed when `has_brand_manifest=false`. The domain-literal placeholder ("Identified as wonderstruck.org") was misleading — only emit `name` when there's actual manifest content.

## Test plan

- [x] `npm run typecheck` clean
- [x] New test: stub row with `has_brand_manifest=false` → `auto_crawl_triggered=true`, `files.brand_json.status='checking'`, `name=undefined`
- [x] Existing tests still pass (10/10 in this file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)