### PR TITLE
fix(aao): migrate adagents/brand validators from axios to safeFetch

### DIFF
--- a/.changeset/aao-safefetch-migration.md
+++ b/.changeset/aao-safefetch-migration.md
@@ -1,0 +1,16 @@
+---
+---
+
+Migrate AAO adagents.json + brand.json validators from `axios` to the
+SSRF-defended `safeFetch` (issue #4129).
+
+The publisher endpoint went unauthenticated-reachable in PR #4128, so the
+4 axios sites in `adagents-manager.ts` (adagents fetch, authoritative
+fetch, agent-card probe, MCP preflight) and the 1 site in
+`brand-manager.ts` (brand.json fetch) were SSRF-able via auto-crawl.
+
+`safeFetch` was extended to support POST with a body for the MCP
+preflight, and a `safeFetchAxiosLike` adapter returns the
+`{status, data, headers}` shape the call sites already expected — keeping
+the migration mechanical and the SSRF guarantees uniform across all
+outbound publisher-triggered fetches.

--- a/server/src/adagents-manager.ts
+++ b/server/src/adagents-manager.ts
@@ -1,6 +1,6 @@
-import axios from 'axios';
 import { PropertyDefinition, PlacementDefinition } from './types.js';
 import { AAO_UA_VALIDATOR } from './config/user-agents.js';
+import { safeFetchAxiosLike } from './utils/url-security.js';
 
 export interface ValidationError {
   field: string;
@@ -170,16 +170,18 @@ export class AdAgentsManager {
     };
 
     try {
-      // Fetch the adagents.json file
-      // CodeQL: URL is constructed from domain input, validated to https protocol above
-      const response = await axios.get(url, { // lgtm[js/request-forgery]
-        timeout: 10000,
+      // Fetch the adagents.json file via safeFetch — connect-time DNS-
+      // rebind defense + private-IP / loopback / link-local block via
+      // the SSRF-safe dispatcher in utils/url-security.ts. The previous
+      // axios call was suppressed with `lgtm[js/request-forgery]` but
+      // had none of those guarantees once the publisher endpoint became
+      // unauthenticated and reachable on view (see PR #4128 / issue #4129).
+      const response = await safeFetchAxiosLike(url, {
+        timeoutMs: 10000,
         headers: {
           'Accept': 'application/json',
-          'User-Agent': AAO_UA_VALIDATOR
+          'User-Agent': AAO_UA_VALIDATOR,
         },
-        validateStatus: () => true, // Don't throw on non-2xx status codes
-        responseType: 'arraybuffer',
       });
 
       result.status_code = response.status;
@@ -238,32 +240,21 @@ export class AdAgentsManager {
       result.valid = result.errors.length === 0;
 
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        if (error.code === 'ENOTFOUND' || error.code === 'ECONNREFUSED') {
-          result.errors.push({
-            field: 'connection',
-            message: `Cannot connect to ${normalizedDomain}`,
-            severity: 'error'
-          });
-        } else if (error.code === 'ECONNABORTED') {
-          result.errors.push({
-            field: 'timeout',
-            message: 'Request timed out after 10 seconds',
-            severity: 'error'
-          });
-        } else {
-          result.errors.push({
-            field: 'network',
-            message: error.message,
-            severity: 'error'
-          });
-        }
+      // safeFetch surfaces AbortError on timeout, TypeError on
+      // network failure, and a thrown `Error` for SSRF gate rejection
+      // (private IP / loopback / link-local). Classify into the same
+      // user-visible buckets the previous axios-shaped code emitted.
+      const err = error as Error & { name?: string; cause?: { code?: string } };
+      const code = err.cause?.code;
+      const msg = err.message ?? '';
+      if (err.name === 'AbortError' || /aborted|timeout/i.test(msg)) {
+        result.errors.push({ field: 'timeout', message: 'Request timed out after 10 seconds', severity: 'error' });
+      } else if (code === 'ENOTFOUND' || code === 'ECONNREFUSED' || /ENOTFOUND|ECONNREFUSED|EAI_/i.test(msg)) {
+        result.errors.push({ field: 'connection', message: `Cannot connect to ${normalizedDomain}`, severity: 'error' });
+      } else if (msg) {
+        result.errors.push({ field: 'network', message: msg, severity: 'error' });
       } else {
-        result.errors.push({
-          field: 'unknown',
-          message: 'Unknown error occurred',
-          severity: 'error'
-        });
+        result.errors.push({ field: 'unknown', message: 'Unknown error occurred', severity: 'error' });
       }
     }
 
@@ -310,15 +301,16 @@ export class AdAgentsManager {
         return null;
       }
 
-      // Fetch the authoritative file
-      const response = await axios.get(url, {
-        timeout: 10000,
+      // Fetch the authoritative file. safeFetch follows redirects with
+      // per-hop SSRF validation, which matters more here than on the
+      // /.well-known fetch — the authoritative_location URL was named
+      // by the publisher and could redirect anywhere.
+      const response = await safeFetchAxiosLike(url, {
+        timeoutMs: 10000,
         headers: {
           'Accept': 'application/json',
-          'User-Agent': AAO_UA_VALIDATOR
+          'User-Agent': AAO_UA_VALIDATOR,
         },
-        validateStatus: () => true,
-        responseType: 'arraybuffer',
       });
 
       if (response.status !== 200) {
@@ -359,19 +351,12 @@ export class AdAgentsManager {
 
       return authData as AdAgentsJsonInline;
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        result.errors.push({
-          field: 'authoritative_location',
-          message: `Failed to fetch authoritative file: ${error.message}`,
-          severity: 'error'
-        });
-      } else {
-        result.errors.push({
-          field: 'authoritative_location',
-          message: 'Unknown error fetching authoritative file',
-          severity: 'error'
-        });
-      }
+      const msg = (error as Error)?.message;
+      result.errors.push({
+        field: 'authoritative_location',
+        message: msg ? `Failed to fetch authoritative file: ${msg}` : 'Unknown error fetching authoritative file',
+        severity: 'error',
+      });
       return null;
     }
   }
@@ -1225,29 +1210,38 @@ export class AdAgentsManager {
 
     for (const endpoint of cardEndpoints) {
       try {
-        // CodeQL: agentUrl is from DB registry, used for protocol validation
-        const response = await axios.get(endpoint, { // lgtm[js/request-forgery]
-          timeout: 3000, // Keep short for responsive UX
+        // Agent URL comes from the DB registry but agent operators
+        // control DNS for their hostname; safeFetch's connect-time
+        // dispatcher closes the rebind window.
+        const response = await safeFetchAxiosLike(endpoint, {
+          timeoutMs: 3000, // Keep short for responsive UX
           headers: {
             'Accept': 'application/json',
-            'User-Agent': AAO_UA_VALIDATOR
+            'User-Agent': AAO_UA_VALIDATOR,
           },
-          validateStatus: () => true
         });
 
         result.response_time_ms = Date.now() - startTime;
         result.status_code = response.status;
 
         if (response.status === 200) {
-          result.card_data = response.data;
+          // Decode the buffer as UTF-8 and parse as JSON. axios used
+          // to do this for us via content-type sniffing; safeFetch
+          // returns raw bytes so the parse + content-type check are
+          // explicit.
+          const contentType = response.headers['content-type'] ?? '';
+          const isJsonContentType = contentType.includes('application/json');
+          let parsed: unknown = null;
+          try {
+            parsed = JSON.parse(Buffer.from(response.data).toString('utf-8'));
+          } catch {
+            // parsed stays null; falls through to the "not JSON" branch
+          }
+          result.card_data = parsed;
           result.card_endpoint = endpoint;
 
-          // Check content-type header
-          const contentType = String(response.headers['content-type'] ?? '');
-          const isJsonContentType = contentType.includes('application/json');
-
           // Basic validation of card structure
-          if (typeof response.data === 'object' && response.data !== null) {
+          if (typeof parsed === 'object' && parsed !== null) {
             if (!isJsonContentType) {
               result.errors.push(`Endpoint returned JSON data but with content-type: ${contentType}. Should be application/json`);
               result.valid = false;
@@ -1288,15 +1282,15 @@ export class AdAgentsManager {
     // First, do a preflight HTTP check to detect 401 errors
     // The @adcp/sdk library wraps 401s in generic errors, so we need to detect them directly
     try {
-      // CodeQL: agentUrl is from DB registry, used for protocol validation
-      const preflightResponse = await axios.post(agentUrl, // lgtm[js/request-forgery]
-        { jsonrpc: '2.0', method: 'initialize', params: {}, id: 1 },
-        {
-          timeout: 3000,
-          headers: { 'Content-Type': 'application/json' },
-          validateStatus: () => true // Accept all status codes
-        }
-      );
+      // safeFetch with method=POST + body — same SSRF defenses as the
+      // GET path, plus method/body rewriting on redirect (POST→GET on
+      // 301/302/303 with body dropped, preserved on 307/308).
+      const preflightResponse = await safeFetchAxiosLike(agentUrl, {
+        method: 'POST',
+        timeoutMs: 3000,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', params: {}, id: 1 }),
+      });
 
       if (preflightResponse.status === 401) {
         result.response_time_ms = Date.now() - startTime;

--- a/server/src/adagents-manager.ts
+++ b/server/src/adagents-manager.ts
@@ -1,6 +1,6 @@
 import { PropertyDefinition, PlacementDefinition } from './types.js';
 import { AAO_UA_VALIDATOR } from './config/user-agents.js';
-import { safeFetchAxiosLike } from './utils/url-security.js';
+import { safeFetchAxiosLike, classifySafeFetchError } from './utils/url-security.js';
 
 export interface ValidationError {
   field: string;
@@ -203,7 +203,7 @@ export class AdAgentsManager {
       // Decode as UTF-8 regardless of Content-Type charset declaration
       let adagentsData: unknown;
       try {
-        const text = Buffer.from(response.data as Buffer).toString('utf-8');
+        const text = response.data.toString('utf-8');
         adagentsData = JSON.parse(text);
       } catch {
         result.errors.push({
@@ -240,22 +240,8 @@ export class AdAgentsManager {
       result.valid = result.errors.length === 0;
 
     } catch (error) {
-      // safeFetch surfaces AbortError on timeout, TypeError on
-      // network failure, and a thrown `Error` for SSRF gate rejection
-      // (private IP / loopback / link-local). Classify into the same
-      // user-visible buckets the previous axios-shaped code emitted.
-      const err = error as Error & { name?: string; cause?: { code?: string } };
-      const code = err.cause?.code;
-      const msg = err.message ?? '';
-      if (err.name === 'AbortError' || /aborted|timeout/i.test(msg)) {
-        result.errors.push({ field: 'timeout', message: 'Request timed out after 10 seconds', severity: 'error' });
-      } else if (code === 'ENOTFOUND' || code === 'ECONNREFUSED' || /ENOTFOUND|ECONNREFUSED|EAI_/i.test(msg)) {
-        result.errors.push({ field: 'connection', message: `Cannot connect to ${normalizedDomain}`, severity: 'error' });
-      } else if (msg) {
-        result.errors.push({ field: 'network', message: msg, severity: 'error' });
-      } else {
-        result.errors.push({ field: 'unknown', message: 'Unknown error occurred', severity: 'error' });
-      }
+      const classified = classifySafeFetchError(error, normalizedDomain);
+      result.errors.push({ ...classified, severity: 'error' });
     }
 
     return result;
@@ -328,7 +314,7 @@ export class AdAgentsManager {
       // Decode as UTF-8 regardless of Content-Type charset declaration
       let authData: unknown;
       try {
-        const text = Buffer.from(response.data as Buffer).toString('utf-8');
+        const text = response.data.toString('utf-8');
         authData = JSON.parse(text);
       } catch {
         result.errors.push({

--- a/server/src/brand-manager.ts
+++ b/server/src/brand-manager.ts
@@ -1,5 +1,5 @@
-import axios from 'axios';
 import { Cache } from './cache.js';
+import { safeFetchAxiosLike } from './utils/url-security.js';
 import type {
   LocalizedName,
   BrandProperty,
@@ -164,15 +164,16 @@ export class BrandManager {
     };
 
     try {
-      // CodeQL: URL is constructed as https://{domain}/.well-known/brand.json
-      const response = await axios.get(url, { // lgtm[js/request-forgery]
-        timeout: 10000,
+      // safeFetch: SSRF-defended fetch (private-IP / DNS-rebind / per-hop
+      // redirect validation). Replaces a previously `lgtm`-suppressed
+      // axios.get that became unauthenticated-reachable via the
+      // /api/registry/publisher auto-crawl path (PR #4128 / issue #4129).
+      const response = await safeFetchAxiosLike(url, {
+        timeoutMs: 10000,
         headers: {
           Accept: 'application/json',
           'User-Agent': AAO_UA_VALIDATOR,
         },
-        validateStatus: () => true,
-        responseType: 'arraybuffer',
       });
 
       result.status_code = response.status;
@@ -234,32 +235,21 @@ export class BrandManager {
 
       result.valid = result.errors.length === 0;
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        if (error.code === 'ENOTFOUND' || error.code === 'ECONNREFUSED') {
-          result.errors.push({
-            field: 'connection',
-            message: `Cannot connect to ${normalizedDomain}`,
-            severity: 'error',
-          });
-        } else if (error.code === 'ECONNABORTED') {
-          result.errors.push({
-            field: 'timeout',
-            message: 'Request timed out after 10 seconds',
-            severity: 'error',
-          });
-        } else {
-          result.errors.push({
-            field: 'network',
-            message: error.message,
-            severity: 'error',
-          });
-        }
+      // safeFetch surfaces AbortError on timeout, TypeError on network
+      // failure, and a thrown `Error` for SSRF-gate rejection (private
+      // IP / loopback / link-local). Classify into the same buckets the
+      // previous axios-shaped code emitted.
+      const err = error as Error & { name?: string; cause?: { code?: string } };
+      const code = err.cause?.code;
+      const msg = err.message ?? '';
+      if (err.name === 'AbortError' || /aborted|timeout/i.test(msg)) {
+        result.errors.push({ field: 'timeout', message: 'Request timed out after 10 seconds', severity: 'error' });
+      } else if (code === 'ENOTFOUND' || code === 'ECONNREFUSED' || /ENOTFOUND|ECONNREFUSED|EAI_/i.test(msg)) {
+        result.errors.push({ field: 'connection', message: `Cannot connect to ${normalizedDomain}`, severity: 'error' });
+      } else if (msg) {
+        result.errors.push({ field: 'network', message: msg, severity: 'error' });
       } else {
-        result.errors.push({
-          field: 'unknown',
-          message: 'Unknown error occurred',
-          severity: 'error',
-        });
+        result.errors.push({ field: 'unknown', message: 'Unknown error occurred', severity: 'error' });
       }
     }
 

--- a/server/src/brand-manager.ts
+++ b/server/src/brand-manager.ts
@@ -1,5 +1,5 @@
 import { Cache } from './cache.js';
-import { safeFetchAxiosLike } from './utils/url-security.js';
+import { safeFetchAxiosLike, classifySafeFetchError } from './utils/url-security.js';
 import type {
   LocalizedName,
   BrandProperty,
@@ -195,7 +195,7 @@ export class BrandManager {
 
       let brandData: unknown;
       try {
-        const text = Buffer.from(response.data as Buffer).toString('utf-8');
+        const text = response.data.toString('utf-8');
         brandData = JSON.parse(text);
       } catch {
         result.errors.push({
@@ -235,22 +235,8 @@ export class BrandManager {
 
       result.valid = result.errors.length === 0;
     } catch (error) {
-      // safeFetch surfaces AbortError on timeout, TypeError on network
-      // failure, and a thrown `Error` for SSRF-gate rejection (private
-      // IP / loopback / link-local). Classify into the same buckets the
-      // previous axios-shaped code emitted.
-      const err = error as Error & { name?: string; cause?: { code?: string } };
-      const code = err.cause?.code;
-      const msg = err.message ?? '';
-      if (err.name === 'AbortError' || /aborted|timeout/i.test(msg)) {
-        result.errors.push({ field: 'timeout', message: 'Request timed out after 10 seconds', severity: 'error' });
-      } else if (code === 'ENOTFOUND' || code === 'ECONNREFUSED' || /ENOTFOUND|ECONNREFUSED|EAI_/i.test(msg)) {
-        result.errors.push({ field: 'connection', message: `Cannot connect to ${normalizedDomain}`, severity: 'error' });
-      } else if (msg) {
-        result.errors.push({ field: 'network', message: msg, severity: 'error' });
-      } else {
-        result.errors.push({ field: 'unknown', message: 'Unknown error occurred', severity: 'error' });
-      }
+      const classified = classifySafeFetchError(error, normalizedDomain);
+      result.errors.push({ ...classified, severity: 'error' });
     }
 
     // Cache the result

--- a/server/src/utils/url-security.ts
+++ b/server/src/utils/url-security.ts
@@ -38,16 +38,58 @@ if (proxyEnvVars.length > 0) {
 }
 
 /**
+ * Canonicalize an IPv6 address to 8 lowercase hex groups with no `::`
+ * shorthand and no leading zeros — `0:0:0:0:0:0:0:1`, not `::1` or
+ * `0000:0000:...:0001`. Returns null for non-IPv6 input.
+ *
+ * Used by `isPrivateHostname` to make prefix matching robust against
+ * shorthand variants of the same address (e.g. expanded `::1`, padded
+ * `0000:...:0001`, deprecated site-local `fec0::1`). The previous
+ * literal-string checks (`hostname === '::1'`) only caught the canonical
+ * shorthand, leaving the expanded forms as an SSRF bypass.
+ */
+function canonicalizeIPv6(addr: string): string | null {
+  if (isIP(addr) !== 6) return null;
+  // Strip zone id (`fe80::1%eth0`) — the address bytes are what matter.
+  const noZone = addr.split('%')[0];
+  let parts: string[];
+  if (noZone.includes('::')) {
+    const sides = noZone.split('::');
+    if (sides.length !== 2) return null;
+    const left = sides[0] ? sides[0].split(':') : [];
+    const right = sides[1] ? sides[1].split(':') : [];
+    // IPv4-mapped (e.g. ::ffff:1.2.3.4) keeps the dotted-quad as the last group;
+    // expand into two 16-bit groups.
+    const last = right[right.length - 1];
+    if (last && last.includes('.')) {
+      const v4 = last.split('.').map(Number);
+      if (v4.length !== 4 || v4.some((n) => !Number.isFinite(n) || n < 0 || n > 255)) return null;
+      right.splice(-1, 1, ((v4[0] << 8) | v4[1]).toString(16), ((v4[2] << 8) | v4[3]).toString(16));
+    }
+    const fill = 8 - left.length - right.length;
+    if (fill < 0) return null;
+    parts = [...left, ...new Array(fill).fill('0'), ...right];
+  } else {
+    parts = noZone.split(':');
+    // Tail might be embedded IPv4 (e.g. 0:0:0:0:0:ffff:1.2.3.4).
+    const last = parts[parts.length - 1];
+    if (last && last.includes('.')) {
+      const v4 = last.split('.').map(Number);
+      if (v4.length !== 4 || v4.some((n) => !Number.isFinite(n) || n < 0 || n > 255)) return null;
+      parts.splice(-1, 1, ((v4[0] << 8) | v4[1]).toString(16), ((v4[2] << 8) | v4[3]).toString(16));
+    }
+  }
+  if (parts.length !== 8) return null;
+  return parts.map((p) => parseInt(p, 16).toString(16)).join(':');
+}
+
+/**
  * Check if a hostname or IP address points to a private/internal network.
  * Used to prevent SSRF attacks in server-side fetch operations.
  */
 export function isPrivateHostname(hostname: string): boolean {
   if (!hostname || hostname === 'localhost') return true;
   if (hostname.endsWith('.local') || hostname.endsWith('.internal')) return true;
-
-  // IPv4-mapped IPv6 (e.g., ::ffff:127.0.0.1)
-  const v4mapped = hostname.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
-  if (v4mapped) return isPrivateHostname(v4mapped[1]);
 
   // IPv4 private/reserved ranges
   if (/^0\./.test(hostname)) return true;           // 0.0.0.0/8 (routes to localhost on many systems)
@@ -58,11 +100,30 @@ export function isPrivateHostname(hostname: string): boolean {
   if (/^169\.254\./.test(hostname)) return true;     // 169.254.0.0/16 link-local
   if (/^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./.test(hostname)) return true; // 100.64.0.0/10 CGNAT
 
-  // IPv6 loopback and private
-  if (hostname === '::1' || hostname === '::') return true;
-  // fe80: link-local, fc00:/fd00: ULA (unique local address) ranges
-  if (hostname.startsWith('fe80:') || hostname.startsWith('fc00:') || hostname.startsWith('fd00:')) {
-    return true;
+  // IPv6: canonicalize first so all shorthands of the same address compare
+  // equal. Without this, `::1` is caught but `0:0:0:0:0:0:0:1` and
+  // `0000:0000:0000:0000:0000:0000:0000:0001` slip through, and ULAs like
+  // `fc12::1` (only `fc00:` was matched) and link-local `fe81::1`
+  // (only `fe80:` was matched) bypass too.
+  const canonical = canonicalizeIPv6(hostname);
+  if (canonical) {
+    const groups = canonical.split(':').map((g) => parseInt(g, 16));
+    // ::, ::1, and any other IPv6 loopback in the all-zeros + tail-bit prefix
+    if (groups.slice(0, 7).every((n) => n === 0) && (groups[7] === 0 || groups[7] === 1)) return true;
+    // IPv4-mapped IPv6 (::ffff:x.y.z.w) — dotted form is in groups[6:7].
+    if (
+      groups.slice(0, 5).every((n) => n === 0) &&
+      groups[5] === 0xffff
+    ) {
+      const v4 = `${(groups[6] >> 8) & 0xff}.${groups[6] & 0xff}.${(groups[7] >> 8) & 0xff}.${groups[7] & 0xff}`;
+      if (isPrivateHostname(v4)) return true;
+    }
+    // fe80::/10 link-local — first group is fe80..febf
+    if ((groups[0] & 0xffc0) === 0xfe80) return true;
+    // fc00::/7 unique local address — first group is fc00..fdff
+    if ((groups[0] & 0xfe00) === 0xfc00) return true;
+    // fec0::/10 deprecated site-local (RFC 3879) — first group is fec0..feff
+    if ((groups[0] & 0xffc0) === 0xfec0) return true;
   }
 
   return false;
@@ -276,6 +337,8 @@ export function buildSsrfSafeDispatcher(): Dispatcher {
  * SNI/cert verification continue to use the original hostname, so TLS still
  * authenticates the public cert.
  */
+const DEFAULT_MAX_REQUEST_BYTES = 64 * 1024;
+
 export async function safeFetch(
   url: string,
   options?: {
@@ -283,6 +346,7 @@ export async function safeFetch(
     maxRedirects?: number;
     method?: 'GET' | 'HEAD' | 'POST';
     body?: string | Uint8Array;
+    maxRequestBytes?: number;
     signal?: AbortSignal;
   },
 ): Promise<Response> {
@@ -293,6 +357,7 @@ export async function safeFetch(
   const maxRedirects = options?.maxRedirects ?? 5;
   const method = options?.method ?? 'GET';
   const body = options?.body;
+  const maxRequestBytes = options?.maxRequestBytes ?? DEFAULT_MAX_REQUEST_BYTES;
   const signal = options?.signal;
   const dispatcher = buildSsrfSafeDispatcher();
 
@@ -304,6 +369,15 @@ export async function safeFetch(
   // GET/HEAD with a body is malformed per HTTP semantics; same.
   if ((method === 'GET' || method === 'HEAD') && body !== undefined) {
     throw new Error(`safeFetch ${method} cannot carry a body`);
+  }
+  // Bound the request body so a future caller can't pass a multi-MB blob to a
+  // hostile redirect target (DoS / amplification). The default 64KB covers
+  // every current call site (MCP preflight is ~80 bytes) with headroom.
+  if (body !== undefined) {
+    const size = typeof body === 'string' ? Buffer.byteLength(body, 'utf-8') : body.byteLength;
+    if (size > maxRequestBytes) {
+      throw new Error(`safeFetch body exceeds ${maxRequestBytes} byte cap (got ${size})`);
+    }
   }
 
   // The dispatcher's `lookup` re-checks the resolved IP at TCP connect time —
@@ -334,9 +408,21 @@ export async function safeFetch(
     // and node-fetch's defaults. 307/308 preserve the method.
     const redirectMethod = (response.status === 307 || response.status === 308) ? method : (method === 'POST' ? 'GET' : method);
     const redirectBody = redirectMethod === method ? body : undefined;
+    // When the body is dropped on POST→GET, the request-body headers we
+    // copied from the original request (Content-Type, Content-Length) no
+    // longer describe the payload and would leak the original intent to
+    // the redirect target. Strip them on body-drop redirects.
+    const redirectHeaders = redirectBody === undefined && body !== undefined
+      ? Object.fromEntries(
+          Object.entries(headers).filter(([k]) => {
+            const lower = k.toLowerCase();
+            return lower !== 'content-type' && lower !== 'content-length';
+          }),
+        )
+      : headers;
     response = await fetch(sanitizeUrl(redirectUrl), {
       method: redirectMethod,
-      headers,
+      headers: redirectHeaders,
       body: redirectBody,
       redirect: 'manual',
       signal,
@@ -365,9 +451,9 @@ export async function safeFetch(
  * cover well-known files; callers that download larger content should
  * stream from `safeFetch` directly).
  */
-export interface SafeFetchAxiosLike<T = Buffer> {
+export interface SafeFetchAxiosLike {
   status: number;
-  data: T;
+  data: Buffer;
   headers: Record<string, string>;
 }
 
@@ -383,7 +469,7 @@ export async function safeFetchAxiosLike(
     maxResponseBytes?: number;
     maxRedirects?: number;
   },
-): Promise<SafeFetchAxiosLike<Buffer>> {
+): Promise<SafeFetchAxiosLike> {
   const controller = new AbortController();
   const timeoutMs = options?.timeoutMs ?? 10_000;
   const cap = options?.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
@@ -424,4 +510,47 @@ export async function safeFetchAxiosLike(
   } finally {
     clearTimeout(timer);
   }
+}
+
+/**
+ * Classify a thrown error from `safeFetch` / `safeFetchAxiosLike` into the
+ * user-visible buckets the AAO validators emit. Centralised so the regex
+ * patterns and SSRF-gate detection stay consistent across call sites.
+ *
+ * Buckets:
+ *   - `timeout`    — AbortError from the timeout signal, or message matches /aborted|timeout/i.
+ *   - `connection` — DNS / ECONNREFUSED, OR the SSRF gate rejected the host
+ *     (private/loopback/link-local). Bucketing SSRF rejection here rather
+ *     than echoing the exact message avoids leaking internal-network probe
+ *     intent to unauthenticated callers.
+ *   - `network`    — anything else with a message.
+ *   - `unknown`    — message-less error.
+ */
+export type SafeFetchErrorField = 'timeout' | 'connection' | 'network' | 'unknown';
+
+export function classifySafeFetchError(
+  error: unknown,
+  domain: string,
+): { field: SafeFetchErrorField; message: string } {
+  const err = error as Error & { name?: string; cause?: { code?: string; message?: string } };
+  const code = err.cause?.code;
+  const msg = err.message ?? '';
+  const causeMsg = err.cause?.message ?? '';
+  const combined = `${msg} ${causeMsg}`;
+
+  if (err.name === 'AbortError' || /aborted|timeout/i.test(combined)) {
+    return { field: 'timeout', message: 'Request timed out' };
+  }
+  if (
+    code === 'ENOTFOUND' ||
+    code === 'ECONNREFUSED' ||
+    /ENOTFOUND|ECONNREFUSED|EAI_/i.test(combined) ||
+    /private or internal/i.test(combined)
+  ) {
+    return { field: 'connection', message: `Cannot connect to ${domain}` };
+  }
+  if (msg) {
+    return { field: 'network', message: msg };
+  }
+  return { field: 'unknown', message: 'Unknown error occurred' };
 }

--- a/server/src/utils/url-security.ts
+++ b/server/src/utils/url-security.ts
@@ -278,7 +278,13 @@ export function buildSsrfSafeDispatcher(): Dispatcher {
  */
 export async function safeFetch(
   url: string,
-  options?: { headers?: Record<string, string>; maxRedirects?: number; method?: 'GET' | 'HEAD'; signal?: AbortSignal },
+  options?: {
+    headers?: Record<string, string>;
+    maxRedirects?: number;
+    method?: 'GET' | 'HEAD' | 'POST';
+    body?: string | Uint8Array;
+    signal?: AbortSignal;
+  },
 ): Promise<Response> {
   const parsedUrl = new URL(url);
   await validateFetchUrl(parsedUrl);
@@ -286,8 +292,19 @@ export async function safeFetch(
   const headers = options?.headers ?? {};
   const maxRedirects = options?.maxRedirects ?? 5;
   const method = options?.method ?? 'GET';
+  const body = options?.body;
   const signal = options?.signal;
   const dispatcher = buildSsrfSafeDispatcher();
+
+  // POST without a body would surprise downstream agent endpoints; reject
+  // up-front rather than emit an empty-body request.
+  if (method === 'POST' && body === undefined) {
+    throw new Error('safeFetch POST requires a body');
+  }
+  // GET/HEAD with a body is malformed per HTTP semantics; same.
+  if ((method === 'GET' || method === 'HEAD') && body !== undefined) {
+    throw new Error(`safeFetch ${method} cannot carry a body`);
+  }
 
   // The dispatcher's `lookup` re-checks the resolved IP at TCP connect time —
   // a hostile DNS server cannot rebind to a private IP between validation and dial.
@@ -298,6 +315,7 @@ export async function safeFetch(
   let response = await fetch(sanitizeUrl(parsedUrl), {
     method,
     headers,
+    body,
     redirect: 'manual',
     signal,
     // Node fetch accepts undici dispatcher; types aren't on the standard RequestInit.
@@ -309,9 +327,17 @@ export async function safeFetch(
     if (!location) throw new Error('Redirect with no Location header');
     // Pre-flight check on the redirect hop, then dial through the same SSRF-safe dispatcher.
     const redirectUrl = await validateRedirectTarget(location, parsedUrl);
+    // Per RFC 7231 §6.4.4 a 303 ALWAYS rewrites to GET; for 301/302 most
+    // clients also rewrite for non-idempotent verbs even though the spec
+    // only mandates user confirmation. We rewrite POST→GET on 301/302/303
+    // and drop the body, matching axios's `redirect: 'follow'` behaviour
+    // and node-fetch's defaults. 307/308 preserve the method.
+    const redirectMethod = (response.status === 307 || response.status === 308) ? method : (method === 'POST' ? 'GET' : method);
+    const redirectBody = redirectMethod === method ? body : undefined;
     response = await fetch(sanitizeUrl(redirectUrl), {
-      method,
+      method: redirectMethod,
       headers,
+      body: redirectBody,
       redirect: 'manual',
       signal,
       dispatcher,
@@ -319,4 +345,83 @@ export async function safeFetch(
   }
 
   return response;
+}
+
+/**
+ * Convenience wrapper around `safeFetch` that returns an axios-shaped
+ * `{status, data, headers}` triple. Used by call sites being migrated
+ * off `axios.get` — preserves their parsing semantics (response data
+ * as `Buffer` so callers can decode UTF-8 themselves regardless of the
+ * server-declared charset, matching the previous `responseType:
+ * 'arraybuffer'` behaviour) without forcing each one to also rewrite
+ * its post-fetch logic.
+ *
+ * `validateStatus` is the axios escape hatch for "don't throw on
+ * non-2xx" — `safeFetch` already doesn't throw on non-2xx, so this
+ * helper just hands the status back. Callers that previously branched
+ * on `response.status` continue to work unchanged.
+ *
+ * Body is bounded by `maxResponseBytes` (default 10 MB to comfortably
+ * cover well-known files; callers that download larger content should
+ * stream from `safeFetch` directly).
+ */
+export interface SafeFetchAxiosLike<T = Buffer> {
+  status: number;
+  data: T;
+  headers: Record<string, string>;
+}
+
+const DEFAULT_MAX_RESPONSE_BYTES = 10 * 1024 * 1024;
+
+export async function safeFetchAxiosLike(
+  url: string,
+  options?: {
+    method?: 'GET' | 'HEAD' | 'POST';
+    headers?: Record<string, string>;
+    body?: string | Uint8Array;
+    timeoutMs?: number;
+    maxResponseBytes?: number;
+    maxRedirects?: number;
+  },
+): Promise<SafeFetchAxiosLike<Buffer>> {
+  const controller = new AbortController();
+  const timeoutMs = options?.timeoutMs ?? 10_000;
+  const cap = options?.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await safeFetch(url, {
+      method: options?.method,
+      headers: options?.headers,
+      body: options?.body,
+      maxRedirects: options?.maxRedirects,
+      signal: controller.signal,
+    });
+
+    // Stream-read up to `cap` bytes so a large response can't OOM the
+    // process. Throws when the body exceeds cap so the caller sees an
+    // error rather than a silently truncated body.
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    const reader = res.body?.getReader();
+    if (reader) {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        total += value.byteLength;
+        if (total > cap) {
+          await reader.cancel();
+          throw new Error(`Response exceeded ${cap} bytes`);
+        }
+        chunks.push(value);
+      }
+    }
+    const data = Buffer.concat(chunks);
+
+    const headers: Record<string, string> = {};
+    res.headers.forEach((v, k) => { headers[k.toLowerCase()] = v; });
+
+    return { status: res.status, data, headers };
+  } finally {
+    clearTimeout(timer);
+  }
 }

--- a/server/tests/unit/adagents-manager.test.ts
+++ b/server/tests/unit/adagents-manager.test.ts
@@ -441,14 +441,18 @@ describe('AdAgentsManager', () => {
 
       mockedSafeFetch.mockResolvedValue({
         status: 200,
-        data: { name: 'Agent' },
+        data: buf({ name: 'Agent' }),
         headers: { 'content-type': 'text/plain' },
       });
 
       const results = await manager.validateAgentCards(agents);
 
       expect(results[0].valid).toBe(false);
-      expect(results[0].errors.some(e => e.includes('content-type'))).toBe(true);
+      // SUT must hit the "JSON parsed but wrong content-type" branch (parsed
+      // is an object, content-type isn't application/json) — not the
+      // "couldn't parse at all" fallback. Pin the exact message so the test
+      // doesn't silently start passing through the wrong path.
+      expect(results[0].errors.some(e => e.includes('Should be application/json'))).toBe(true);
     }, 10000);
 
     it('detects HTML instead of JSON', async () => {
@@ -485,13 +489,17 @@ describe('AdAgentsManager', () => {
 
       mockedSafeFetch.mockResolvedValue({
         status: 200,
-        data: { name: 'Agent' },
+        data: buf({ name: 'Agent' }),
         headers: { 'content-type': 'application/json' },
       });
 
       const results = await manager.validateAgentCards(agents);
 
       expect(results).toHaveLength(2);
+      // Pin valid:true so the parallel test exercises the JSON-parse success
+      // path, not a silently-broken Buffer.from(plainObject) fallback.
+      expect(results[0].valid).toBe(true);
+      expect(results[1].valid).toBe(true);
       expect(results[0].agent_url).toBe('https://agent1.example.com');
       expect(results[1].agent_url).toBe('https://agent2.example.com');
     });

--- a/server/tests/unit/adagents-manager.test.ts
+++ b/server/tests/unit/adagents-manager.test.ts
@@ -1,13 +1,38 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+vi.mock('../../src/utils/url-security.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/utils/url-security.js')>();
+  return {
+    ...actual,
+    safeFetchAxiosLike: vi.fn(),
+  };
+});
+
+// Mock @adcp/sdk so MCP validation doesn't try a real network connect.
+// The MCP path dynamically imports the SDK; without this mock, a missing
+// agent test waits on the SDK's connect-then-timeout (5s) plus library
+// init overhead, which can blow the test timeout.
+vi.mock('@adcp/sdk', () => {
+  class AdCPClient {
+    constructor() {}
+    agent() {
+      return {
+        getAgentInfo: () => Promise.reject(new Error('mock: MCP unreachable')),
+      };
+    }
+  }
+  return {
+    AdCPClient,
+    is401Error: () => false,
+  };
+});
+
 import { AdAgentsManager } from '../../src/adagents-manager.js';
 import type { AuthorizedAgent, AdAgentsJson } from '../../src/types.js';
-import axios from 'axios';
+import { safeFetchAxiosLike } from '../../src/utils/url-security.js';
 
-// Mock axios
-vi.mock('axios');
-const mockedAxios = vi.mocked(axios, true);
+const mockedSafeFetch = vi.mocked(safeFetchAxiosLike);
 
-// Helper: simulate arraybuffer response (how axios delivers data with responseType: 'arraybuffer')
 function buf(data: unknown): Buffer {
   return Buffer.from(JSON.stringify(data));
 }
@@ -17,11 +42,7 @@ describe('AdAgentsManager', () => {
 
   beforeEach(() => {
     manager = new AdAgentsManager();
-    vi.clearAllMocks();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
+    mockedSafeFetch.mockReset();
   });
 
   describe('validateDomain', () => {
@@ -37,7 +58,7 @@ describe('AdAgentsManager', () => {
         last_updated: new Date().toISOString(),
       };
 
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
         data: buf(validAdAgents),
         headers: { 'content-type': 'application/json' },
@@ -53,7 +74,7 @@ describe('AdAgentsManager', () => {
     });
 
     it('normalizes domain by removing protocol', async () => {
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
         data: buf({ authorized_agents: [{ url: 'https://agent.example.com', authorized_for: 'Test' }] }),
         headers: { 'content-type': 'application/json' },
@@ -66,7 +87,7 @@ describe('AdAgentsManager', () => {
     });
 
     it('normalizes domain by removing trailing slash', async () => {
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
         data: buf({ authorized_agents: [{ url: 'https://agent.example.com', authorized_for: 'Test' }] }),
         headers: { 'content-type': 'application/json' },
@@ -78,7 +99,7 @@ describe('AdAgentsManager', () => {
     });
 
     it('detects missing adagents.json (404)', async () => {
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 404,
         data: '<html>Not Found</html>',
         headers: { 'content-type': 'text/html' },
@@ -93,11 +114,11 @@ describe('AdAgentsManager', () => {
     });
 
     it('handles network connection errors', async () => {
-      mockedAxios.get.mockRejectedValue({
-        isAxiosError: true,
-        code: 'ENOTFOUND',
-      });
-      mockedAxios.isAxiosError = vi.fn().mockReturnValue(true);
+      mockedSafeFetch.mockRejectedValue(
+        Object.assign(new Error('getaddrinfo ENOTFOUND nonexistent.example.com'), {
+          cause: { code: 'ENOTFOUND' },
+        })
+      );
 
       const result = await manager.validateDomain('nonexistent.example.com');
 
@@ -106,11 +127,9 @@ describe('AdAgentsManager', () => {
     });
 
     it('handles request timeout', async () => {
-      mockedAxios.get.mockRejectedValue({
-        isAxiosError: true,
-        code: 'ECONNABORTED',
-      });
-      mockedAxios.isAxiosError = vi.fn().mockReturnValue(true);
+      mockedSafeFetch.mockRejectedValue(
+        Object.assign(new Error('The operation was aborted'), { name: 'AbortError' })
+      );
 
       const result = await manager.validateDomain('slow.example.com');
 
@@ -119,7 +138,7 @@ describe('AdAgentsManager', () => {
     });
 
     it('detects missing authorized_agents field', async () => {
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
         data: buf({ $schema: 'https://adcontextprotocol.org/schemas/v2/adagents.json' }),
         headers: { 'content-type': 'application/json' },
@@ -132,7 +151,7 @@ describe('AdAgentsManager', () => {
     });
 
     it('detects invalid authorized_agents type', async () => {
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
         data: buf({ authorized_agents: 'not an array' }),
         headers: { 'content-type': 'application/json' },
@@ -145,7 +164,7 @@ describe('AdAgentsManager', () => {
     });
 
     it('warns about missing optional $schema field', async () => {
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
         data: buf({ authorized_agents: [{ url: 'https://agent.example.com', authorized_for: 'Test' }] }),
         headers: { 'content-type': 'application/json' },
@@ -158,7 +177,7 @@ describe('AdAgentsManager', () => {
     });
 
     it('warns about missing last_updated field', async () => {
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
         data: buf({ authorized_agents: [{ url: 'https://agent.example.com', authorized_for: 'Test' }] }),
         headers: { 'content-type': 'application/json' },
@@ -173,7 +192,7 @@ describe('AdAgentsManager', () => {
 
   describe('validateAgent', () => {
     it('validates required url field', async () => {
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
         data: buf({ authorized_agents: [{ authorized_for: 'Test' }] }),
         headers: { 'content-type': 'application/json' },
@@ -186,7 +205,7 @@ describe('AdAgentsManager', () => {
     });
 
     it('validates url is a valid URL', async () => {
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
         data: buf({
           authorized_agents: [
@@ -206,7 +225,7 @@ describe('AdAgentsManager', () => {
     });
 
     it('requires HTTPS for agent URLs', async () => {
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
         data: buf({
           authorized_agents: [
@@ -226,7 +245,7 @@ describe('AdAgentsManager', () => {
     });
 
     it('validates required authorized_for field', async () => {
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
         data: buf({
           authorized_agents: [
@@ -245,7 +264,7 @@ describe('AdAgentsManager', () => {
     });
 
     it('validates authorized_for is not empty', async () => {
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
         data: buf({
           authorized_agents: [
@@ -266,7 +285,7 @@ describe('AdAgentsManager', () => {
     });
 
     it('validates authorized_for length constraint', async () => {
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
         data: buf({
           authorized_agents: [
@@ -286,7 +305,7 @@ describe('AdAgentsManager', () => {
     });
 
     it('validates property_ids is an array', async () => {
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
         data: buf({
           authorized_agents: [
@@ -307,7 +326,7 @@ describe('AdAgentsManager', () => {
     });
 
     it('warns about duplicate agent URLs', async () => {
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
         data: buf({
           authorized_agents: [
@@ -340,12 +359,12 @@ describe('AdAgentsManager', () => {
         },
       ];
 
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
-        data: {
+        data: buf({
           name: 'Test Agent',
           capabilities: ['media-buy'],
-        },
+        }),
         headers: { 'content-type': 'application/json' },
       });
 
@@ -366,7 +385,7 @@ describe('AdAgentsManager', () => {
       ];
 
       let callCount = 0;
-      mockedAxios.get.mockImplementation((url) => {
+      mockedSafeFetch.mockImplementation((url) => {
         callCount++;
         if (url === 'https://agent.example.com/.well-known/agent-card.json') {
           return Promise.resolve({
@@ -377,7 +396,7 @@ describe('AdAgentsManager', () => {
         }
         return Promise.resolve({
           status: 200,
-          data: { name: 'Agent' },
+          data: buf({ name: 'Agent' }),
           headers: { 'content-type': 'application/json' },
         });
       });
@@ -396,10 +415,13 @@ describe('AdAgentsManager', () => {
         },
       ];
 
-      mockedAxios.get.mockResolvedValue({
-        status: 404,
-        data: {},
-        headers: {},
+      // A2A endpoints (GET) return 404, MCP preflight (POST) fails so the
+      // MCP path bails out before the live @adcp/sdk import.
+      mockedSafeFetch.mockImplementation(async (_url, opts) => {
+        if (opts?.method === 'POST') {
+          throw new Error('Network error');
+        }
+        return { status: 404, data: buf({}), headers: {} };
       });
 
       const results = await manager.validateAgentCards(agents);
@@ -407,7 +429,7 @@ describe('AdAgentsManager', () => {
       expect(results[0].valid).toBe(false);
       // Error is prefixed with A2A: since both protocols are tried
       expect(results[0].errors.some(e => e.includes('No agent card found'))).toBe(true);
-    }, 10000);
+    }, 20000);
 
     it('detects wrong content-type for agent card', async () => {
       const agents: AuthorizedAgent[] = [
@@ -417,7 +439,7 @@ describe('AdAgentsManager', () => {
         },
       ];
 
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
         data: { name: 'Agent' },
         headers: { 'content-type': 'text/plain' },
@@ -437,9 +459,9 @@ describe('AdAgentsManager', () => {
         },
       ];
 
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
-        data: '<html><body>Website</body></html>',
+        data: Buffer.from('<html><body>Website</body></html>'),
         headers: { 'content-type': 'text/html' },
       });
 
@@ -461,7 +483,7 @@ describe('AdAgentsManager', () => {
         },
       ];
 
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
         data: { name: 'Agent' },
         headers: { 'content-type': 'application/json' },
@@ -556,7 +578,7 @@ describe('AdAgentsManager', () => {
       };
 
       let callCount = 0;
-      mockedAxios.get.mockImplementation((url) => {
+      mockedSafeFetch.mockImplementation((url) => {
         callCount++;
         if (url.includes('/.well-known/adagents.json')) {
           return Promise.resolve({
@@ -582,7 +604,7 @@ describe('AdAgentsManager', () => {
     });
 
     it('rejects non-HTTPS authoritative locations', async () => {
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
         data: buf({
           authoritative_location: 'http://insecure.example.com/adagents.json',
@@ -597,7 +619,7 @@ describe('AdAgentsManager', () => {
     });
 
     it('rejects invalid authoritative locations', async () => {
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
         data: buf({
           authoritative_location: 'not-a-valid-url',
@@ -616,7 +638,7 @@ describe('AdAgentsManager', () => {
         authoritative_location: 'https://cdn.example.com/adagents.json',
       };
 
-      mockedAxios.get.mockImplementation((url) => {
+      mockedSafeFetch.mockImplementation((url) => {
         if (url.includes('/.well-known/adagents.json')) {
           return Promise.resolve({
             status: 200,
@@ -647,7 +669,7 @@ describe('AdAgentsManager', () => {
         authoritative_location: 'https://cdn2.example.com/adagents.json',
       };
 
-      mockedAxios.get.mockImplementation((url) => {
+      mockedSafeFetch.mockImplementation((url) => {
         if (url.includes('/.well-known/adagents.json')) {
           return Promise.resolve({
             status: 200,
@@ -675,7 +697,7 @@ describe('AdAgentsManager', () => {
         authoritative_location: 'https://cdn.example.com/adagents.json',
       };
 
-      mockedAxios.get.mockImplementation((url) => {
+      mockedSafeFetch.mockImplementation((url) => {
         if (url.includes('/.well-known/adagents.json')) {
           return Promise.resolve({
             status: 200,
@@ -683,13 +705,9 @@ describe('AdAgentsManager', () => {
             headers: { 'content-type': 'application/json' },
           });
         } else {
-          return Promise.reject({
-            isAxiosError: true,
-            message: 'Network error',
-          });
+          return Promise.reject(new Error('Network error'));
         }
       });
-      mockedAxios.isAxiosError = vi.fn().mockReturnValue(true);
 
       const result = await manager.validateDomain('example.com');
 
@@ -707,17 +725,16 @@ describe('AdAgentsManager', () => {
         },
       ];
 
-      // A2A endpoints return 404, MCP preflight returns 200 with valid JSON-RPC
-      mockedAxios.get.mockResolvedValue({
-        status: 404,
-        data: {},
-        headers: {},
-      });
-      // MCP preflight POST returns non-401 so it continues to the AdCPClient path
-      mockedAxios.post.mockResolvedValue({
-        status: 200,
-        data: { jsonrpc: '2.0', result: {} },
-        headers: { 'content-type': 'application/json' },
+      // A2A endpoints (GET) return 404, MCP preflight (POST) returns 200 with valid JSON-RPC
+      mockedSafeFetch.mockImplementation(async (_url, opts) => {
+        if (opts?.method === 'POST') {
+          return {
+            status: 200,
+            data: buf({ jsonrpc: '2.0', result: {} }),
+            headers: { 'content-type': 'application/json' },
+          };
+        }
+        return { status: 404, data: buf({}), headers: {} };
       });
 
       // vi.doMock does not intercept dynamic imports inside the SUT.
@@ -740,14 +757,13 @@ describe('AdAgentsManager', () => {
         },
       ];
 
-      // A2A endpoints return 404
-      mockedAxios.get.mockResolvedValue({
-        status: 404,
-        data: {},
-        headers: {},
+      // A2A endpoints (GET) return 404, MCP preflight (POST) fails
+      mockedSafeFetch.mockImplementation(async (_url, opts) => {
+        if (opts?.method === 'POST') {
+          throw new Error('Network error');
+        }
+        return { status: 404, data: buf({}), headers: {} };
       });
-      // MCP preflight POST fails
-      mockedAxios.post.mockRejectedValue(new Error('Network error'));
 
       const results = await manager.validateAgentCards(agents);
 
@@ -771,7 +787,7 @@ describe('AdAgentsManager', () => {
       expect(result.valid).toBe(true);
       expect(result.errors).toHaveLength(0);
       expect(result.domain).toBe('proposed');
-      expect(mockedAxios.get).not.toHaveBeenCalled();
+      expect(mockedSafeFetch).not.toHaveBeenCalled();
     });
 
     it('detects invalid agents in proposal', () => {
@@ -807,7 +823,7 @@ describe('AdAgentsManager', () => {
   describe('Signals Support', () => {
     describe('validateSignal', () => {
       it('validates a valid binary signal', async () => {
-        mockedAxios.get.mockResolvedValue({
+        mockedSafeFetch.mockResolvedValue({
           status: 200,
           data: buf({
             authorized_agents: [
@@ -832,7 +848,7 @@ describe('AdAgentsManager', () => {
       });
 
       it('validates a valid categorical signal', async () => {
-        mockedAxios.get.mockResolvedValue({
+        mockedSafeFetch.mockResolvedValue({
           status: 200,
           data: buf({
             authorized_agents: [
@@ -857,7 +873,7 @@ describe('AdAgentsManager', () => {
       });
 
       it('validates a valid numeric signal with range', async () => {
-        mockedAxios.get.mockResolvedValue({
+        mockedSafeFetch.mockResolvedValue({
           status: 200,
           data: buf({
             authorized_agents: [
@@ -882,7 +898,7 @@ describe('AdAgentsManager', () => {
       });
 
       it('detects missing signal id', async () => {
-        mockedAxios.get.mockResolvedValue({
+        mockedSafeFetch.mockResolvedValue({
           status: 200,
           data: buf({
             authorized_agents: [
@@ -905,7 +921,7 @@ describe('AdAgentsManager', () => {
       });
 
       it('detects invalid signal id pattern', async () => {
-        mockedAxios.get.mockResolvedValue({
+        mockedSafeFetch.mockResolvedValue({
           status: 200,
           data: buf({
             authorized_agents: [
@@ -929,7 +945,7 @@ describe('AdAgentsManager', () => {
       });
 
       it('detects missing signal name', async () => {
-        mockedAxios.get.mockResolvedValue({
+        mockedSafeFetch.mockResolvedValue({
           status: 200,
           data: buf({
             authorized_agents: [
@@ -952,7 +968,7 @@ describe('AdAgentsManager', () => {
       });
 
       it('detects invalid value_type', async () => {
-        mockedAxios.get.mockResolvedValue({
+        mockedSafeFetch.mockResolvedValue({
           status: 200,
           data: buf({
             authorized_agents: [
@@ -976,7 +992,7 @@ describe('AdAgentsManager', () => {
       });
 
       it('warns about categorical signal without allowed_values', async () => {
-        mockedAxios.get.mockResolvedValue({
+        mockedSafeFetch.mockResolvedValue({
           status: 200,
           data: buf({
             authorized_agents: [
@@ -1000,7 +1016,7 @@ describe('AdAgentsManager', () => {
       });
 
       it('validates numeric signal range min > max', async () => {
-        mockedAxios.get.mockResolvedValue({
+        mockedSafeFetch.mockResolvedValue({
           status: 200,
           data: buf({
             authorized_agents: [
@@ -1025,7 +1041,7 @@ describe('AdAgentsManager', () => {
       });
 
       it('validates standard signal category', async () => {
-        mockedAxios.get.mockResolvedValue({
+        mockedSafeFetch.mockResolvedValue({
           status: 200,
           data: buf({
             authorized_agents: [
@@ -1050,7 +1066,7 @@ describe('AdAgentsManager', () => {
       });
 
       it('warns about non-standard signal category', async () => {
-        mockedAxios.get.mockResolvedValue({
+        mockedSafeFetch.mockResolvedValue({
           status: 200,
           data: buf({
             authorized_agents: [
@@ -1075,7 +1091,7 @@ describe('AdAgentsManager', () => {
       });
 
       it('errors when signal category is not a string', async () => {
-        mockedAxios.get.mockResolvedValue({
+        mockedSafeFetch.mockResolvedValue({
           status: 200,
           data: buf({
             authorized_agents: [
@@ -1102,7 +1118,7 @@ describe('AdAgentsManager', () => {
 
     describe('signal_tags validation', () => {
       it('validates valid signal_tags', async () => {
-        mockedAxios.get.mockResolvedValue({
+        mockedSafeFetch.mockResolvedValue({
           status: 200,
           data: buf({
             authorized_agents: [
@@ -1124,7 +1140,7 @@ describe('AdAgentsManager', () => {
       });
 
       it('warns about signal tags used but not defined', async () => {
-        mockedAxios.get.mockResolvedValue({
+        mockedSafeFetch.mockResolvedValue({
           status: 200,
           data: buf({
             authorized_agents: [
@@ -1144,7 +1160,7 @@ describe('AdAgentsManager', () => {
       });
 
       it('detects duplicate signal IDs', async () => {
-        mockedAxios.get.mockResolvedValue({
+        mockedSafeFetch.mockResolvedValue({
           status: 200,
           data: buf({
             authorized_agents: [
@@ -1167,7 +1183,7 @@ describe('AdAgentsManager', () => {
 
     describe('signal authorization types', () => {
       it('validates signal_ids authorization type', async () => {
-        mockedAxios.get.mockResolvedValue({
+        mockedSafeFetch.mockResolvedValue({
           status: 200,
           data: buf({
             authorized_agents: [
@@ -1192,7 +1208,7 @@ describe('AdAgentsManager', () => {
       });
 
       it('validates signal_tags authorization type', async () => {
-        mockedAxios.get.mockResolvedValue({
+        mockedSafeFetch.mockResolvedValue({
           status: 200,
           data: buf({
             authorized_agents: [
@@ -1219,7 +1235,7 @@ describe('AdAgentsManager', () => {
       });
 
       it('warns when signal_ids authorization has no matching signals', async () => {
-        mockedAxios.get.mockResolvedValue({
+        mockedSafeFetch.mockResolvedValue({
           status: 200,
           data: buf({
             authorized_agents: [
@@ -1244,7 +1260,7 @@ describe('AdAgentsManager', () => {
       });
 
       it('warns when signal_ids authorization type but no signal_ids array', async () => {
-        mockedAxios.get.mockResolvedValue({
+        mockedSafeFetch.mockResolvedValue({
           status: 200,
           data: buf({
             authorized_agents: [
@@ -1265,7 +1281,7 @@ describe('AdAgentsManager', () => {
       });
 
       it('errors when signal_ids is not an array', async () => {
-        mockedAxios.get.mockResolvedValue({
+        mockedSafeFetch.mockResolvedValue({
           status: 200,
           data: buf({
             authorized_agents: [

--- a/server/tests/unit/brand-manager-cache.test.ts
+++ b/server/tests/unit/brand-manager-cache.test.ts
@@ -1,10 +1,17 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import axios from 'axios';
-import { BrandManager } from '../../src/brand-manager.js';
 
-// Mock axios
-vi.mock('axios');
-const mockedAxios = vi.mocked(axios, true);
+vi.mock('../../src/utils/url-security.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/utils/url-security.js')>();
+  return {
+    ...actual,
+    safeFetchAxiosLike: vi.fn(),
+  };
+});
+
+import { BrandManager } from '../../src/brand-manager.js';
+import { safeFetchAxiosLike } from '../../src/utils/url-security.js';
+
+const mockedSafeFetch = vi.mocked(safeFetchAxiosLike);
 
 describe('BrandManager caching', () => {
   let manager: BrandManager;
@@ -36,7 +43,7 @@ describe('BrandManager caching', () => {
         ],
       };
 
-      mockedAxios.get.mockResolvedValueOnce({
+      mockedSafeFetch.mockResolvedValueOnce({
         status: 200,
         data: Buffer.from(JSON.stringify(mockBrandJson)),
       });
@@ -44,19 +51,19 @@ describe('BrandManager caching', () => {
       // First call - should fetch
       const result1 = await manager.validateDomain('acme.com');
       expect(result1.valid).toBe(true);
-      expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+      expect(mockedSafeFetch).toHaveBeenCalledTimes(1);
 
       // Second call - should use cache
       const result2 = await manager.validateDomain('acme.com');
       expect(result2.valid).toBe(true);
-      expect(mockedAxios.get).toHaveBeenCalledTimes(1); // Still 1
+      expect(mockedSafeFetch).toHaveBeenCalledTimes(1); // Still 1
 
       // Results should be identical
       expect(result1.variant).toBe(result2.variant);
     });
 
     it('caches failed lookups separately', async () => {
-      mockedAxios.get.mockResolvedValueOnce({
+      mockedSafeFetch.mockResolvedValueOnce({
         status: 404,
         data: null,
       });
@@ -64,12 +71,12 @@ describe('BrandManager caching', () => {
       // First call - should fetch and fail
       const result1 = await manager.validateDomain('missing.com');
       expect(result1.valid).toBe(false);
-      expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+      expect(mockedSafeFetch).toHaveBeenCalledTimes(1);
 
       // Second call - should use failed lookup cache
       const result2 = await manager.validateDomain('missing.com');
       expect(result2.valid).toBe(false);
-      expect(mockedAxios.get).toHaveBeenCalledTimes(1); // Still 1
+      expect(mockedSafeFetch).toHaveBeenCalledTimes(1); // Still 1
     });
 
     it('bypasses cache with skipCache option', async () => {
@@ -89,18 +96,18 @@ describe('BrandManager caching', () => {
         ],
       };
 
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
         data: Buffer.from(JSON.stringify(mockBrandJson)),
       });
 
       // First call
       await manager.validateDomain('fresh.com');
-      expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+      expect(mockedSafeFetch).toHaveBeenCalledTimes(1);
 
       // Second call with skipCache - should fetch again
       await manager.validateDomain('fresh.com', { skipCache: true });
-      expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+      expect(mockedSafeFetch).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -125,7 +132,7 @@ describe('BrandManager caching', () => {
         ],
       };
 
-      mockedAxios.get.mockResolvedValueOnce({
+      mockedSafeFetch.mockResolvedValueOnce({
         status: 200,
         data: Buffer.from(JSON.stringify(mockBrandJson), 'utf-8'),
       });
@@ -157,7 +164,7 @@ describe('BrandManager caching', () => {
         ],
       };
 
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
         data: Buffer.from(JSON.stringify(mockBrandJson)),
       });
@@ -174,11 +181,11 @@ describe('BrandManager caching', () => {
       const result2 = await manager.resolveBrand('example.com');
       expect(result2).not.toBeNull();
       expect(result2?.brand_name).toBe('Example');
-      expect(mockedAxios.get).not.toHaveBeenCalled(); // Should not fetch
+      expect(mockedSafeFetch).not.toHaveBeenCalled(); // Should not fetch
     });
 
     it('caches null results for failed resolutions', async () => {
-      mockedAxios.get.mockResolvedValueOnce({
+      mockedSafeFetch.mockResolvedValueOnce({
         status: 404,
         data: null,
       });
@@ -192,7 +199,7 @@ describe('BrandManager caching', () => {
       // Second call - should use cache (no fetch)
       const result2 = await manager.resolveBrand('notfound.com');
       expect(result2).toBeNull();
-      expect(mockedAxios.get).not.toHaveBeenCalled();
+      expect(mockedSafeFetch).not.toHaveBeenCalled();
     });
 
     it('bypasses cache with skipCache option', async () => {
@@ -212,7 +219,7 @@ describe('BrandManager caching', () => {
         ],
       };
 
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
         data: Buffer.from(JSON.stringify(mockBrandJson)),
       });
@@ -224,7 +231,7 @@ describe('BrandManager caching', () => {
 
       // Second call with skipCache
       await manager.resolveBrand('bypass.com', { skipCache: true });
-      expect(mockedAxios.get).toHaveBeenCalled();
+      expect(mockedSafeFetch).toHaveBeenCalled();
     });
   });
 
@@ -246,7 +253,7 @@ describe('BrandManager caching', () => {
         ],
       };
 
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
         data: Buffer.from(JSON.stringify(mockBrandJson)),
       });
@@ -285,7 +292,7 @@ describe('BrandManager caching', () => {
         ],
       };
 
-      mockedAxios.get.mockResolvedValue({
+      mockedSafeFetch.mockResolvedValue({
         status: 200,
         data: Buffer.from(JSON.stringify(mockBrandJson)),
       });

--- a/server/tests/unit/url-security-dns-rebind.test.ts
+++ b/server/tests/unit/url-security-dns-rebind.test.ts
@@ -162,11 +162,33 @@ describe('isPrivateHostname (regression coverage for the surfaces ssrfSafeLookup
     expect(isPrivateHostname(host)).toBe(true);
   });
 
+  // IPv6 shorthands that previously bypassed because the literal-string check
+  // (`hostname === '::1'`) didn't match expanded / zero-padded forms, and
+  // because the `startsWith('fc00:')` / `startsWith('fe80:')` prefixes only
+  // covered one address out of each /7 or /10 block.
+  it.each([
+    ['0:0:0:0:0:0:0:1'],          // expanded ::1
+    ['0000:0000:0000:0000:0000:0000:0000:0001'], // fully zero-padded ::1
+    ['0:0:0:0:0:0:0:0'],          // expanded ::
+    ['0:0:0:0:0:ffff:7f00:1'],    // expanded ::ffff:127.0.0.1
+    ['fe81::1'],                  // fe80::/10 — second address in block
+    ['febf::1'],                  // fe80::/10 — last address in block
+    ['fc12::1'],                  // fc00::/7 ULA — middle of block
+    ['fdff::1'],                  // fc00::/7 ULA — last address in block
+    ['fec0::1'],                  // fec0::/10 deprecated site-local
+    ['feff::1'],                  // fec0::/10 last address
+    ['fe80::1%eth0'],             // zone-id stripped before classification
+  ])('flags %s as private (IPv6 canonicalization)', (host) => {
+    expect(isPrivateHostname(host)).toBe(true);
+  });
+
   it.each([
     ['93.184.216.34'],
     ['172.66.147.243'], // outside 172.16/12, public
     ['8.8.8.8'],
     ['example.com'],
+    ['2001:4860:4860::8888'],     // public IPv6 (Google DNS) — must not match private blocks
+    ['ff00::1'],                  // multicast — not private, separate concern
   ])('does not flag %s as private', (host) => {
     expect(isPrivateHostname(host)).toBe(false);
   });


### PR DESCRIPTION
Closes #4129.

## Why

PR #4128 made `/api/registry/publisher` unauthenticated-reachable and added an auto-crawl-on-view path. That promoted 4 axios sites in `adagents-manager.ts` and 1 in `brand-manager.ts` from "internal-only" to "user-triggerable outbound fetch" — i.e. an SSRF surface where an attacker controls both DNS and the response.

Those calls were previously suppressed with `lgtm[js/request-forgery]` (acceptable when the publisher endpoint required auth and the inputs were vetted). Once the endpoint went unauthenticated, the suppression no longer reflected reality.

## What

Migrate the 5 sites to `safeFetch` (private-IP / DNS-rebind / per-hop redirect validation):

- `adagents-manager.ts`: adagents.json fetch, authoritative-location follow, agent-card probe, MCP preflight
- `brand-manager.ts`: brand.json fetch

Two extensions to `url-security.ts` to keep the migration mechanical:
1. `safeFetch` now supports `method: 'POST'` with a body — needed for the MCP preflight. Method/body rewriting on redirect: POST→GET on 301/302/303 with body dropped, preserved on 307/308 (per RFC 7231).
2. `safeFetchAxiosLike` adapter returns `{status, data: Buffer, headers}` — the shape the call sites already expected.

Error handling switches from `axios.isAxiosError` to a name/cause pattern matching the same user-visible buckets (timeout / connection / network / unknown).

## Test plan

- [x] Unit tests pass (`vitest run tests/unit/adagents-manager.test.ts tests/unit/brand-manager-cache.test.ts` — 72/72)
- [x] Typecheck clean
- [x] Pre-commit hook (lint + dynamic-import + callApi-state-change + typecheck) green
- [ ] CI: full integration suite + lint
- [ ] Verify SSRF gate trips on private-IP target (manual check post-deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)