### PR TITLE
feat(aao): add refresh button to publisher page hero

### DIFF
--- a/.changeset/aao-publisher-refresh-button.md
+++ b/.changeset/aao-publisher-refresh-button.md
@@ -1,0 +1,20 @@
+---
+---
+
+Add a "Refresh now" button to the publisher self-service page hero. The
+publisher page only auto-crawls on first view (when no validation row
+exists, or a stub row without a brand manifest). Once both files are
+populated, nothing re-triggers the crawl — so a publisher who updates
+their `adagents.json` or `brand.json` had no way to invalidate the
+cached registry view.
+
+The button hits the existing `/api/registry/crawl-request` endpoint, so
+it inherits the per-domain rate limit (60s) and per-member hourly limit
+already in place. Logged-out users see a "Sign in to refresh" CTA
+instead of a public trigger — the endpoint is auth-gated server-side, so
+exposing a public button would just produce 401s.
+
+On 202 the hero subtitle switches to a refreshing-state and the page
+re-loads after 4s (same cadence as the auto-crawl-on-view flow). On 429
+the button shows a wait timer and the subtitle reports the retry-after
+window. On 401/403 the user is redirected to login.

--- a/server/public/publisher-home.html
+++ b/server/public/publisher-home.html
@@ -526,14 +526,79 @@
         } else if (!haveAnything) {
           heroActions.push(`<a class="primary" href="/login?return_to=${encodeURIComponent(window.location.pathname)}">Sign in to claim</a>`);
         }
+        // Refresh button. Re-running a crawl is the only way to pick up a
+        // change to the publisher's adagents.json or brand.json — the page
+        // only auto-crawls on the first view, so without this button a
+        // publisher who updates their file has no way to invalidate the
+        // cached row. Logged-in users hit the auth-gated crawl endpoint
+        // directly; logged-out users get a sign-in CTA so we don't expose
+        // a public refresh trigger.
+        if (user) {
+          heroActions.push(`<button type="button" class="secondary" id="hero-refresh" data-domain="${escapeHtml(data.domain)}">Refresh now</button>`);
+        } else {
+          heroActions.push(`<a class="secondary" href="/login?return_to=${encodeURIComponent(window.location.pathname)}">Sign in to refresh</a>`);
+        }
         heroActions.push(`<a class="secondary" href="/adagents-landing">What is adagents.json?</a>`);
         actions.innerHTML = heroActions.join('');
+
+        const refreshBtn = document.getElementById('hero-refresh');
+        if (refreshBtn) refreshBtn.addEventListener('click', () => triggerRefresh(data.domain));
 
         // Auto-refresh when the server told us a crawl is in flight.
         // 4 seconds is enough for a single-domain crawl in most cases;
         // larger budgets risk the user navigating away.
         if (data.auto_crawl_triggered) {
           setTimeout(() => load(), 4000);
+        }
+      }
+
+      // Manual refresh — re-runs the crawl for this domain. Called by the
+      // "Refresh now" button in the hero. Auth-gated server-side, so we
+      // expect this only fires for logged-in users (the renderHero gate
+      // hides the button otherwise). On success we swap the hero into
+      // its checking-state and reload the publisher data after a short
+      // delay, the same shape as auto-crawl-on-view.
+      async function triggerRefresh(domain) {
+        const btn = document.getElementById('hero-refresh');
+        const subtitle = document.getElementById('hero-subtitle');
+        if (btn) {
+          btn.disabled = true;
+          btn.textContent = 'Refreshing…';
+        }
+        try {
+          const res = await fetch('/api/registry/crawl-request', {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ domain }),
+          });
+          if (res.status === 202) {
+            if (subtitle) subtitle.textContent = 'Refreshing — fetching your files now.';
+            // Same cadence as auto_crawl_triggered. Crawl is async on the
+            // server, so 4s is the empirical sweet spot for a single domain.
+            setTimeout(() => load(), 4000);
+            return;
+          }
+          if (res.status === 429) {
+            const body = await res.json().catch(() => ({}));
+            const wait = Number.isFinite(body.retry_after) ? Math.max(1, Math.ceil(body.retry_after)) : 60;
+            if (subtitle) subtitle.textContent = `Just refreshed — try again in ${wait}s.`;
+            if (btn) {
+              btn.textContent = `Wait ${wait}s`;
+              setTimeout(() => { btn.disabled = false; btn.textContent = 'Refresh now'; }, wait * 1000);
+            }
+            return;
+          }
+          if (res.status === 401 || res.status === 403) {
+            window.location.href = `/login?return_to=${encodeURIComponent(window.location.pathname)}`;
+            return;
+          }
+          const body = await res.json().catch(() => ({}));
+          if (subtitle) subtitle.textContent = body.error ? `Refresh failed: ${body.error}` : 'Refresh failed — please try again.';
+          if (btn) { btn.disabled = false; btn.textContent = 'Refresh now'; }
+        } catch (err) {
+          if (subtitle) subtitle.textContent = 'Refresh failed — check your connection.';
+          if (btn) { btn.disabled = false; btn.textContent = 'Refresh now'; }
         }
       }
 

--- a/server/public/publisher-home.html
+++ b/server/public/publisher-home.html
@@ -324,7 +324,7 @@
           <div class="panel-header">
             <div>
               <div class="panel-title" id="hero-title">What we found at this domain</div>
-              <div class="panel-subtitle" id="hero-subtitle"></div>
+              <div class="panel-subtitle" id="hero-subtitle" aria-live="polite"></div>
             </div>
           </div>
           <div class="hero-cards" id="hero-cards"></div>
@@ -534,7 +534,7 @@
         // directly; logged-out users get a sign-in CTA so we don't expose
         // a public refresh trigger.
         if (user) {
-          heroActions.push(`<button type="button" class="secondary" id="hero-refresh" data-domain="${escapeHtml(data.domain)}">Refresh now</button>`);
+          heroActions.push(`<button type="button" class="secondary" id="hero-refresh">Refresh now</button>`);
         } else {
           heroActions.push(`<a class="secondary" href="/login?return_to=${encodeURIComponent(window.location.pathname)}">Sign in to refresh</a>`);
         }
@@ -558,12 +558,32 @@
       // hides the button otherwise). On success we swap the hero into
       // its checking-state and reload the publisher data after a short
       // delay, the same shape as auto-crawl-on-view.
+      //
+      // In-flight guard: a hero re-render (triggered by `auto_crawl_triggered`
+      // or a successful refresh) replaces #hero-refresh in the DOM. A pending
+      // call would write to a detached node, and a second click on the new
+      // node would race with the first. The flag short-circuits the second.
+      let refreshInFlight = false;
       async function triggerRefresh(domain) {
+        if (refreshInFlight) return;
+        refreshInFlight = true;
         const btn = document.getElementById('hero-refresh');
         const subtitle = document.getElementById('hero-subtitle');
+        // Restore-button helper. Reads the current hero-refresh node every
+        // time so we always touch the live DOM, even if the hero was
+        // re-rendered while the request was pending.
+        const restoreButton = (text = 'Refresh now') => {
+          const cur = document.getElementById('hero-refresh');
+          if (cur) { cur.disabled = false; cur.textContent = text; }
+        };
+        const setSubtitle = (text) => {
+          const cur = document.getElementById('hero-subtitle');
+          if (cur) cur.textContent = text;
+        };
         if (btn) {
           btn.disabled = true;
           btn.textContent = 'Refreshing…';
+          btn.setAttribute('aria-busy', 'true');
         }
         try {
           const res = await fetch('/api/registry/crawl-request', {
@@ -573,20 +593,35 @@
             body: JSON.stringify({ domain }),
           });
           if (res.status === 202) {
-            if (subtitle) subtitle.textContent = 'Refreshing — fetching your files now.';
+            setSubtitle('Refreshing — fetching your files now.');
             // Same cadence as auto_crawl_triggered. Crawl is async on the
             // server, so 4s is the empirical sweet spot for a single domain.
-            setTimeout(() => load(), 4000);
+            // load() handles its own UI on success — but if it fails (network
+            // drop, server 500), the subtitle would be stuck on
+            // "Refreshing…" with no button. Restore on failure.
+            setTimeout(async () => {
+              try {
+                await load();
+              } catch (loadErr) {
+                console.warn('Refresh load() failed', loadErr);
+                setSubtitle('Refresh sent — reload the page to see updates.');
+                restoreButton();
+              } finally {
+                refreshInFlight = false;
+              }
+            }, 4000);
             return;
           }
           if (res.status === 429) {
             const body = await res.json().catch(() => ({}));
             const wait = Number.isFinite(body.retry_after) ? Math.max(1, Math.ceil(body.retry_after)) : 60;
-            if (subtitle) subtitle.textContent = `Just refreshed — try again in ${wait}s.`;
-            if (btn) {
-              btn.textContent = `Wait ${wait}s`;
-              setTimeout(() => { btn.disabled = false; btn.textContent = 'Refresh now'; }, wait * 1000);
-            }
+            setSubtitle(`Just refreshed — try again in ${wait}s.`);
+            if (btn) btn.textContent = `Wait ${wait}s`;
+            setTimeout(() => {
+              restoreButton();
+              setSubtitle('Here’s what AAO has on file for this domain.');
+              refreshInFlight = false;
+            }, wait * 1000);
             return;
           }
           if (res.status === 401 || res.status === 403) {
@@ -594,11 +629,14 @@
             return;
           }
           const body = await res.json().catch(() => ({}));
-          if (subtitle) subtitle.textContent = body.error ? `Refresh failed: ${body.error}` : 'Refresh failed — please try again.';
-          if (btn) { btn.disabled = false; btn.textContent = 'Refresh now'; }
+          setSubtitle(body.error ? `Refresh failed: ${body.error}` : 'Refresh failed — please try again.');
+          restoreButton();
+          refreshInFlight = false;
         } catch (err) {
-          if (subtitle) subtitle.textContent = 'Refresh failed — check your connection.';
-          if (btn) { btn.disabled = false; btn.textContent = 'Refresh now'; }
+          console.warn('Refresh fetch failed', err);
+          setSubtitle('Refresh failed — check your connection.');
+          restoreButton();
+          refreshInFlight = false;
         }
       }
 


### PR DESCRIPTION
## Why

The publisher page only auto-crawls on first view (when no validation row exists, or a stub row without a brand manifest). Once both files are populated, nothing re-triggers a crawl — so a publisher who updates their `/.well-known/adagents.json` or `brand.json` had no way to invalidate the cached registry view. Brian flagged this when his change wasn't picked up after editing.

## What

Added a "Refresh now" button to the hero panel of the publisher self-service page. The button hits the existing `POST /api/registry/crawl-request` endpoint (auth-gated, per-domain 60s rate limit, per-member hourly limit).

Logged-out users get "Sign in to refresh" instead of a public trigger — the endpoint returns 401 without auth, so a public button would just produce errors. This matches Brian's preference for option 1 (auth-gated, simpler than introducing a new unauthenticated endpoint).

## UX

| Server response | Behavior |
|---|---|
| 202 Accepted | Hero subtitle → "Refreshing — fetching your files now", page re-loads after 4s (same cadence as auto-crawl-on-view) |
| 429 Too Many Requests | Button shows "Wait Ns" countdown, subtitle reports retry-after window |
| 401 / 403 | Redirect to `/login?return_to=...` |
| Other / network error | Subtitle reports the failure, button re-enables for retry |

CSRF is handled automatically by the global `csrf.js` shim that patches `fetch()` for state-changing methods.

## Test plan

- [x] Typecheck clean
- [x] Pre-commit hooks pass (test:unit, test:test-dynamic-imports, test:callapi-state-change, typecheck)
- [ ] Manual smoke: load `/publisher/<domain>` logged-in, click "Refresh now", verify 202 + 4s reload picks up fresh data
- [ ] Manual smoke: rapid-click → 429 with countdown
- [ ] Manual smoke: load logged-out, see "Sign in to refresh" instead of the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)