### PR TITLE
fix(brandfetch): retry 5xx/429 and warn on transient upstream errors

### DIFF
--- a/.changeset/brandfetch-504-retry-and-warn.md
+++ b/.changeset/brandfetch-504-retry-and-warn.md
@@ -1,0 +1,4 @@
+---
+---
+
+Brandfetch upstream 5xx/429 responses now retry with exponential backoff and log at `warn` instead of `error`. Transient timeouts (e.g. 504 on `/brands/enrich`) no longer page on-call via the `#aao-errors` Slack hook.

--- a/server/src/services/brandfetch.ts
+++ b/server/src/services/brandfetch.ts
@@ -226,8 +226,16 @@ export async function fetchBrandData(domain: string): Promise<BrandfetchEnrichme
         return result;
       }
 
+      const isRetryableStatus = response.status === 429 || (response.status >= 500 && response.status < 600);
+      if (isRetryableStatus && attempt < BRANDFETCH_MAX_RETRIES) {
+        const delay = BRANDFETCH_RETRY_DELAY_MS * Math.pow(2, attempt);
+        logger.warn({ status: response.status, domain: normalizedDomain, attempt, delay }, 'Brandfetch transient error, retrying');
+        await new Promise(resolve => setTimeout(resolve, delay));
+        continue;
+      }
+
       if (response.status !== 200) {
-        logger.error({ status: response.status, domain: normalizedDomain }, 'Brandfetch API error');
+        logger.warn({ status: response.status, domain: normalizedDomain }, 'Brandfetch API non-2xx response');
         return {
           success: false,
           domain: normalizedDomain,
@@ -240,7 +248,7 @@ export async function fetchBrandData(domain: string): Promise<BrandfetchEnrichme
         const text = Buffer.from(response.data as Buffer).toString('utf-8');
         data = JSON.parse(text) as BrandfetchResponse;
       } catch {
-        logger.error({ domain: normalizedDomain }, 'Brandfetch returned invalid JSON');
+        logger.warn({ domain: normalizedDomain }, 'Brandfetch returned invalid JSON');
         return {
           success: false,
           domain: normalizedDomain,
@@ -270,7 +278,7 @@ export async function fetchBrandData(domain: string): Promise<BrandfetchEnrichme
       }
 
       const message = error instanceof Error ? error.message : 'Unknown error';
-      logger.error({ error, domain: normalizedDomain, attempt }, 'Brandfetch fetch error');
+      logger.warn({ error, domain: normalizedDomain, attempt }, 'Brandfetch fetch failed after retries');
       return {
         success: false,
         domain: normalizedDomain,

--- a/server/tests/unit/brandfetch-retry.test.ts
+++ b/server/tests/unit/brandfetch-retry.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import axios, { AxiosError } from 'axios';
+
+vi.mock('axios');
+const mockedAxios = vi.mocked(axios, true);
+
+const ORIGINAL_API_KEY = process.env.BRANDFETCH_API_KEY;
+
+beforeEach(() => {
+  process.env.BRANDFETCH_API_KEY = 'test-key';
+  vi.clearAllMocks();
+  vi.resetModules();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  if (ORIGINAL_API_KEY === undefined) {
+    delete process.env.BRANDFETCH_API_KEY;
+  } else {
+    process.env.BRANDFETCH_API_KEY = ORIGINAL_API_KEY;
+  }
+});
+
+async function loadFresh() {
+  const mod = await import('../../src/services/brandfetch.js');
+  mod.clearCache();
+  return mod;
+}
+
+function bufferOf(payload: unknown): Buffer {
+  return Buffer.from(JSON.stringify(payload));
+}
+
+function successPayload(domain: string) {
+  return bufferOf({ id: 'x', name: 'Acme', domain, claimed: true, verified: true });
+}
+
+describe('fetchBrandData retry behavior', () => {
+  it('retries on 504 then succeeds', async () => {
+    const { fetchBrandData } = await loadFresh();
+
+    mockedAxios.get
+      .mockResolvedValueOnce({ status: 504, data: Buffer.from('Gateway timeout') })
+      .mockResolvedValueOnce({ status: 200, data: successPayload('acme.com') });
+
+    const promise = fetchBrandData('acme.com');
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    expect(result.manifest?.name).toBe('Acme');
+    expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries on 502 and 503', async () => {
+    const { fetchBrandData } = await loadFresh();
+
+    mockedAxios.get
+      .mockResolvedValueOnce({ status: 502, data: Buffer.from('Bad gateway') })
+      .mockResolvedValueOnce({ status: 503, data: Buffer.from('Service unavailable') })
+      .mockResolvedValueOnce({ status: 200, data: successPayload('acme.com') });
+
+    const promise = fetchBrandData('acme.com');
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries on 429 (rate limit)', async () => {
+    const { fetchBrandData } = await loadFresh();
+
+    mockedAxios.get
+      .mockResolvedValueOnce({ status: 429, data: Buffer.from('Too many requests') })
+      .mockResolvedValueOnce({ status: 200, data: successPayload('acme.com') });
+
+    const promise = fetchBrandData('acme.com');
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries on network timeout (ECONNABORTED)', async () => {
+    const { fetchBrandData } = await loadFresh();
+
+    const timeoutError = Object.assign(new Error('timeout'), {
+      isAxiosError: true,
+      code: 'ECONNABORTED',
+    }) as AxiosError;
+    mockedAxios.isAxiosError.mockImplementation((err: unknown): err is AxiosError =>
+      typeof err === 'object' && err !== null && (err as { isAxiosError?: boolean }).isAxiosError === true
+    );
+
+    mockedAxios.get
+      .mockRejectedValueOnce(timeoutError)
+      .mockResolvedValueOnce({ status: 200, data: successPayload('acme.com') });
+
+    const promise = fetchBrandData('acme.com');
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns failure (no retry) on 404', async () => {
+    const { fetchBrandData } = await loadFresh();
+
+    mockedAxios.get.mockResolvedValueOnce({ status: 404, data: Buffer.from('Not found') });
+
+    const result = await fetchBrandData('missing.com');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('not found');
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns failure (no retry) on non-retryable 4xx like 401', async () => {
+    const { fetchBrandData } = await loadFresh();
+
+    mockedAxios.get.mockResolvedValueOnce({ status: 401, data: Buffer.from('Unauthorized') });
+
+    const result = await fetchBrandData('acme.com');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('401');
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns failure after exhausting retries on persistent 504', async () => {
+    const { fetchBrandData } = await loadFresh();
+
+    mockedAxios.get.mockResolvedValue({ status: 504, data: Buffer.from('Gateway timeout') });
+
+    const promise = fetchBrandData('366.com');
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('504');
+    // Initial attempt + 2 retries = 3 calls
+    expect(mockedAxios.get).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Brandfetch 504s on `/brands/enrich` (e.g. domain `366.com`) were logging at `logger.error`, which the pino hook in `server/src/logger.ts:202` forwards to Slack `#aao-errors` and pages on-call. The original code only retried network/timeout errors, not HTTP 5xx/429.
- Added 5xx/429 to the retryable status set inside the existing exponential-backoff loop (max 2 retries).
- Downgraded `logger.error` → `logger.warn` for non-2xx responses, invalid JSON, and the exhausted-retry catch path. Per the logger playbook (`logger.ts:191-229`), tier-2 `warn` (no escalation) is correct for "expected third-party state" the caller already gracefully handles via a structured failure result.

## Test plan
- [x] `npx vitest run server/tests/unit/brandfetch-retry.test.ts` — 7 new tests, all pass: retries on 504/502/503/429/ECONNABORTED, no retry on 404 or 401, exhausts retries on persistent 504. Uses fake timers, ~700ms total.
- [x] `npx vitest run server/tests/unit/brandfetch-cache.test.ts server/tests/unit/brandfetch-quality.test.ts` — 22/22 existing tests still pass.
- [x] Pre-commit `npm run test:unit && test:test-dynamic-imports && test:callapi-state-change && typecheck` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)