### PR TITLE
chore(addie): log WorkOS Pipes authorize error fields on /connect/github

### DIFF
--- a/.changeset/diagnose-pipes-github-authorize-bad-request.md
+++ b/.changeset/diagnose-pipes-github-authorize-bad-request.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore(addie): widen WorkOS Pipes authorize error logging so admin-errors surfaces the WorkOS-side reason for `/connect/github` 400s. Diagnostic-only — no behavior change.

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -7422,12 +7422,24 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
     // Used by Addie/Slack messages so a stale or session-less click can't land on
     // WorkOS' generic "couldn't complete the connection" error page.
     this.app.get('/connect/github', requireAuth, async (req, res) => {
+      const reqHost = req.get('host') || '';
+      const reqProto = req.protocol;
+      const requestedReturnTo = typeof req.query.return_to === 'string' ? req.query.return_to : null;
       try {
-        const returnTo = buildPipesReturnTo(req.get('host') || '', req.protocol, req.query.return_to);
+        const returnTo = buildPipesReturnTo(reqHost, reqProto, req.query.return_to);
         const url = await getGitHubAuthorizeUrl(req.user!.id, returnTo);
         return res.redirect(302, url);
       } catch (error) {
-        logger.error({ err: error }, 'Failed to start GitHub connect via /connect/github');
+        logger.error(
+          {
+            err: error,
+            reqHost,
+            reqProto,
+            requestedReturnTo,
+            workosUserId: req.user?.id,
+          },
+          'Failed to start GitHub connect via /connect/github',
+        );
         return res.status(502).send('Could not start GitHub connection. Please try again in a moment, or visit /member-hub to connect from there.');
       }
     });

--- a/server/src/services/pipes.ts
+++ b/server/src/services/pipes.ts
@@ -58,17 +58,48 @@ export function buildPipesReturnTo(
 
 export async function getGitHubAuthorizeUrl(workosUserId: string, returnTo: string): Promise<string> {
   const workos = getWorkos();
-  const response = await workos.post<{ user_id: string; return_to: string }>(
-    `/data-integrations/${GITHUB_PROVIDER}/authorize`,
-    { user_id: workosUserId, return_to: returnTo },
-    {},
-  );
-  const data = (response && typeof response === 'object' && 'data' in response ? response.data : response) as { url?: string };
-  if (!data?.url) {
-    logger.error({ workosUserId, response }, 'Pipes authorize response missing url');
-    throw new Error('Pipes authorize response missing url');
+  let returnToHost = '';
+  try {
+    returnToHost = new URL(returnTo).host;
+  } catch {
+    // returnTo is unparseable; leave host empty so the log captures that fact
   }
-  return data.url;
+  try {
+    const response = await workos.post<{ user_id: string; return_to: string }>(
+      `/data-integrations/${GITHUB_PROVIDER}/authorize`,
+      { user_id: workosUserId, return_to: returnTo },
+      {},
+    );
+    const data = (response && typeof response === 'object' && 'data' in response ? response.data : response) as { url?: string };
+    if (!data?.url) {
+      logger.error({ workosUserId, returnToHost, response }, 'Pipes authorize response missing url');
+      throw new Error('Pipes authorize response missing url');
+    }
+    return data.url;
+  } catch (error) {
+    const e = error as {
+      status?: number;
+      requestID?: string;
+      error?: string;
+      errorDescription?: string;
+      rawData?: unknown;
+    };
+    logger.error(
+      {
+        err: error,
+        workosUserId,
+        returnToHost,
+        provider: GITHUB_PROVIDER,
+        workosStatus: e?.status,
+        workosRequestId: e?.requestID,
+        workosError: e?.error,
+        workosErrorDescription: e?.errorDescription,
+        workosRawData: e?.rawData,
+      },
+      'Pipes authorize request failed',
+    );
+    throw error;
+  }
 }
 
 export type ConnectedAccountResult =


### PR DESCRIPTION
## Why

`#admin-errors` has been showing recurring `OauthException: Error: Bad Request` from `getGitHubAuthorizeUrl` (server/src/services/pipes.ts), but the log line only carried `name + message`. The WorkOS SDK's `OauthException` actually carries `status`, `requestID`, `error`, `errorDescription`, and `rawData` — that's where the real reason lives (return_to allowlist miss vs. provider config vs. per-user issue). Without it we can't tell what to fix.

## What

Diagnostic-only widening of the error log. No behavior change for users.

- `services/pipes.ts:getGitHubAuthorizeUrl` — try/catch around `workos.post(.../data-integrations/github/authorize)`; on failure log `workosStatus`, `workosRequestId`, `workosError`, `workosErrorDescription`, `workosRawData`, plus the `returnToHost` and `provider` we sent. Re-throw.
- `http.ts` `/connect/github` handler — log the request `host`, `protocol`, caller-supplied `return_to` query, and `workosUserId` alongside the existing error.

Endpoint and body shape are confirmed correct against the auto-generated WorkOS Python SDK (`workos/workos-python` `_resource.py:authorize_data_integration` → `data-integrations/{slug}/authorize` with `{user_id, organization_id?, return_to?}`), so the failure is on the WorkOS side.

## Test plan
- [x] `npm run test:unit` (precommit) — green
- [x] `tsc --project server/tsconfig.json --noEmit` — green
- [x] `connect-github-bouncer.test.ts` — green
- [ ] After deploy, click `/connect/github` once on prod and grep admin-errors for `workosError`/`workosErrorDescription` to confirm the fields land. Then file a follow-up to fix the actual config (likely WorkOS Pipes return-URL allowlist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)