### PR TITLE
feat(addie-video): neutral filler pool + video-lab toggle

### DIFF
--- a/.changeset/addie-video-neutral-fillers.md
+++ b/.changeset/addie-video-neutral-fillers.md
@@ -1,0 +1,4 @@
+---
+---
+
+Replace Tavus video filler pool with neutral conversational openers ("So...", "Well...", "Hmm...", "Funny enough...", etc.) instead of "Great question..." / "Good question..." ritual praise, which reads as canned across a session. Add a "Disable filler phrases" advanced toggle in `video-lab.html` that persists `thread.context.disable_fillers` so the LLM endpoint skips the pre-roll entirely.

--- a/server/public/video-lab.html
+++ b/server/public/video-lab.html
@@ -485,6 +485,10 @@
             <input type="checkbox" id="opt-greenscreen">
             <label for="opt-greenscreen">Greenscreen background <span class="hint-inline">(transparent — useful for keynote compositing)</span></label>
           </div>
+          <div class="setting-row checkbox">
+            <input type="checkbox" id="opt-disable-fillers">
+            <label for="opt-disable-fillers">Disable filler phrases <span class="hint-inline">(skip the "So..." / "Hmm..." opener Tavus speaks while the model is thinking — adds a brief pause before responses)</span></label>
+          </div>
           <div class="setting-row">
             <label for="opt-language">Language</label>
             <select id="opt-language">
@@ -575,6 +579,7 @@
       durationMin: 25,
       greenscreen: false,
       language: '',
+      disableFillers: false,
     };
 
     function loadSettings() {
@@ -596,6 +601,7 @@
         durationMin: Number(document.getElementById('opt-duration').value) || 25,
         greenscreen: document.getElementById('opt-greenscreen').checked,
         language: document.getElementById('opt-language').value,
+        disableFillers: document.getElementById('opt-disable-fillers').checked,
       };
     }
     function applySettingsToForm(s) {
@@ -605,6 +611,7 @@
       document.getElementById('opt-duration-display').textContent = String(s.durationMin || 25);
       document.getElementById('opt-greenscreen').checked = !!s.greenscreen;
       document.getElementById('opt-language').value = s.language || '';
+      document.getElementById('opt-disable-fillers').checked = !!s.disableFillers;
     }
     function persistSettingsFromForm() {
       const s = readSettingsFromForm();
@@ -712,6 +719,7 @@
         maxDurationSec: formSettings.durationMin ? formSettings.durationMin * 60 : undefined,
         greenscreen: formSettings.greenscreen || undefined,
         language: formSettings.language || undefined,
+        disableFillers: formSettings.disableFillers || undefined,
       };
       const sentKeys = Object.keys(body).filter((k) => body[k] !== undefined);
       log('info', `POST /api/addie/video/session${sentKeys.length ? ` (settings: ${sentKeys.join(', ')})` : ''}`);
@@ -1007,7 +1015,7 @@
     document.addEventListener('DOMContentLoaded', async () => {
       // Restore advanced settings from localStorage and wire change persistence.
       applySettingsToForm(loadSettings());
-      ['opt-greeting', 'opt-context', 'opt-duration', 'opt-greenscreen', 'opt-language'].forEach((id) => {
+      ['opt-greeting', 'opt-context', 'opt-duration', 'opt-greenscreen', 'opt-language', 'opt-disable-fillers'].forEach((id) => {
         const el = document.getElementById(id);
         if (el) el.addEventListener('input', persistSettingsFromForm);
         if (el && (el.tagName === 'SELECT' || el.type === 'checkbox')) {

--- a/server/src/routes/tavus.ts
+++ b/server/src/routes/tavus.ts
@@ -458,6 +458,7 @@ export function createTavusRouter() {
         maxDurationSec?: number;
         greenscreen?: boolean;
         language?: string;
+        disableFillers?: boolean;
       };
       const greeting = typeof settings.greeting === "string" && settings.greeting.trim()
         ? settings.greeting.trim().slice(0, 500)
@@ -474,16 +475,19 @@ export function createTavusRouter() {
       const language = typeof settings.language === "string" && /^[a-z]{3,20}$/.test(settings.language)
         ? settings.language
         : undefined;
+      const disableFillers = settings.disableFillers === true;
 
       // Create a thread to track this video conversation
       const threadService = getThreadService();
+      const threadContext: Record<string, unknown> = { persona_id: personaId };
+      if (disableFillers) threadContext.disable_fillers = true;
       const thread = await threadService.getOrCreateThread({
         channel: "video",
         external_id: conversationName,
         user_type: "workos",
         user_id: req.user.id,
         user_display_name: displayName,
-        context: { persona_id: personaId },
+        context: threadContext,
       });
 
       // Tavus appends conversational_context to the system message sent to
@@ -600,6 +604,7 @@ export function createTavusRouter() {
     let memberRequestContext = "";
     let userDisplayName: string | null = null;
     let voiceUserId: string | null = null;
+    let voiceFillersDisabled = false;
     if (threadId) {
       const threadService = getThreadService();
       try {
@@ -607,6 +612,7 @@ export function createTavusRouter() {
         if (thread?.user_id && thread.channel === 'video') {
           userDisplayName = thread.user_display_name;
           voiceUserId = thread.user_id;
+          voiceFillersDisabled = thread.context?.disable_fillers === true;
           const result = await buildVoiceRequestTools(thread.user_id, threadId);
           voiceRequestTools = result.requestTools;
           memberRequestContext = result.requestContext;
@@ -691,16 +697,25 @@ export function createTavusRouter() {
 
     // For substantive questions, send a filler phrase immediately so Addie starts
     // speaking while the model processes. Tavus TTS picks this up with near-zero latency.
+    // Neutral conversational fillers — no ritual praise ("great question") which
+    // reads as canned across a session. video-lab.html exposes a toggle that sets
+    // thread.context.disable_fillers to skip this entirely for users who'd rather
+    // hear a half-second of silence than any preamble.
     const questionPattern = /\b(what|how|why|explain|tell me|describe|walk me through|can you|could you)\b/i;
     const rawMessage = currentMessage.slice(voicePrefix.length);
     const isSubstantive = rawMessage.length > 30 && questionPattern.test(rawMessage);
     let fullResponse = "";
-    if (isSubstantive) {
+    if (isSubstantive && !voiceFillersDisabled) {
       const fillers = [
-        "Good question... ",
-        "Great question... ",
         "So... ",
-        "That's a great question... ",
+        "Well... ",
+        "Hmm... ",
+        "Okay, so... ",
+        "Right... ",
+        "Let me think... ",
+        "Funny enough... ",
+        "Yeah, so... ",
+        "Alright... ",
       ];
       const filler = fillers[Math.floor(Math.random() * fillers.length)];
       sendChunk({ content: filler });

--- a/server/src/routes/tavus.ts
+++ b/server/src/routes/tavus.ts
@@ -711,7 +711,7 @@ export function createTavusRouter() {
         "Well... ",
         "Hmm... ",
         "Okay, so... ",
-        "Right... ",
+        "Sure... ",
         "Let me think... ",
         "Funny enough... ",
         "Yeah, so... ",


### PR DESCRIPTION
## Summary

- Replaces the Tavus video filler pool — `\"Great question...\"` / `\"Good question...\"` / `\"That's a great question...\"` — with neutral conversational openers (`\"So...\"`, `\"Well...\"`, `\"Hmm...\"`, `\"Okay, so...\"`, `\"Right...\"`, `\"Let me think...\"`, `\"Funny enough...\"`, `\"Yeah, so...\"`, `\"Alright...\"`). Same latency win for Tavus TTS, no ritual praise, much wider rotation so any one phrase rarely repeats inside a session.
- Adds a `\"Disable filler phrases\"` toggle in `video-lab.html` advanced settings. Persists `thread.context.disable_fillers`; the LLM endpoint skips the pre-roll entirely when set, accepting a half-second of silence in exchange for no preamble.
- Filler is still pre-roll only — never written to the stored transcript — so the ritual-phrase postprocessor and shape grader continue to see clean text.

Why: in thread `7f2a1e67`, voice-Addie spoke `\"Great question...\"` repeatedly (3 of 4 entries in the pool were praise variants), even though stored text is clean. Reads as canned across a session.

## Test plan

- [ ] Start a video-lab call → ask a substantive question (>30 chars, contains what/how/why/etc.) → confirm pre-roll is one of the new neutral fillers.
- [ ] Toggle `\"Disable filler phrases\"` in advanced settings, refresh, confirm checkbox state persists, start a call → no pre-roll on substantive questions, only the model's text.
- [ ] Confirm transcript at `/admin/addie/?thread=...` does not contain any filler text (filler is TTS-only).
- [ ] `/video` page (no advanced UI) still gets the default filler-on behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)