### PR TITLE
fix(registry): trust live origin over stale AAO opt-in on publisher page

### DIFF
--- a/.changeset/fix-publisher-page-trust-live-origin.md
+++ b/.changeset/fix-publisher-page-trust-live-origin.md
@@ -1,0 +1,4 @@
+---
+---
+
+`/api/registry/publisher` now trusts the publisher's live `/.well-known/adagents.json` over a stale `hosted_properties` opt-in row when computing `hosting.mode`. A publisher who once opted into AAO hosting and later migrated to self-hosting was being reported as `aao_hosted` indefinitely; the route now reads `authoritative_location` from the cached origin response and only reports `aao_hosted` when the publisher's stub actually points at AAO. Properties surfaced through the federated index now carry `source: "adagents_json"` (instead of the misleading hardcoded `"discovered"`) when the publisher's adagents.json validates. Stale `brand_json` rows older than an hour bypass the auto-crawl debounce so popular publishers whose `brand.json` went live after the first crawl don't stay stuck on `unknown`. The publisher page also honors a `?return=` query parameter (same-origin / localhost only) to render a back link when opened from a partner storefront.

--- a/server/public/publisher-home.html
+++ b/server/public/publisher-home.html
@@ -275,6 +275,17 @@
     <script src="/nav.js"></script>
 
     <div class="container">
+      <!-- "Return to" affordance. The publisher page is sometimes opened
+           from a partner storefront / dev environment via ?return=<url>;
+           without a back link the visitor has nothing to click after
+           seeing what AAO has on file. The link is rendered only for
+           same-origin URLs (or http://localhost in dev) so a malicious
+           URL in the query string can't repurpose this as an open
+           redirect. -->
+      <div id="return-link" class="hidden" style="margin-bottom: var(--space-3); font-size: var(--text-sm);">
+        <a id="return-link-anchor" href="#" style="color: var(--color-text-muted); text-decoration: none;">&larr; <span id="return-link-label">Back</span></a>
+      </div>
+
       <div id="loading-state" class="loading-state">
         <div class="spinner"></div>
         <p>Loading publisher data&hellip;</p>
@@ -391,6 +402,34 @@
         if (m) return decodeURIComponent(m[1]);
         const params = new URLSearchParams(window.location.search);
         return params.get('domain') || '';
+      }
+
+      // Render the "← Back" link from ?return=<url>. Allowlist:
+      // same-origin OR localhost over http (dev). Anything else is
+      // dropped silently — the param can be tampered with by an
+      // attacker, so an unknown target must NOT be linked.
+      function renderReturnLink() {
+        const params = new URLSearchParams(window.location.search);
+        const raw = params.get('return');
+        if (!raw) return;
+        let target;
+        try {
+          target = new URL(raw, window.location.origin);
+        } catch {
+          return;
+        }
+        const sameOrigin = target.origin === window.location.origin;
+        const isLocalhostDev =
+          (target.protocol === 'http:' || target.protocol === 'https:')
+          && (target.hostname === 'localhost' || target.hostname === '127.0.0.1');
+        if (!sameOrigin && !isLocalhostDev) return;
+        const anchor = document.getElementById('return-link-anchor');
+        const label = document.getElementById('return-link-label');
+        const wrap = document.getElementById('return-link');
+        if (!anchor || !label || !wrap) return;
+        anchor.href = target.href;
+        label.textContent = sameOrigin ? 'Back' : `Back to ${target.host}`;
+        wrap.classList.remove('hidden');
       }
 
       function appUser() {
@@ -1007,6 +1046,7 @@
         }
       }
 
+      renderReturnLink();
       load();
     </script>
   </body>

--- a/server/public/publisher-home.html
+++ b/server/public/publisher-home.html
@@ -405,9 +405,12 @@
       }
 
       // Render the "← Back" link from ?return=<url>. Allowlist:
-      // same-origin OR localhost over http (dev). Anything else is
-      // dropped silently — the param can be tampered with by an
-      // attacker, so an unknown target must NOT be linked.
+      // same-origin (production) OR http(s)://localhost / 127.0.0.1
+      // (dev). Anything else is dropped silently — the param can be
+      // tampered with by an attacker, so an unknown target must NOT be
+      // linked. javascript:/data:/file: schemes fail both checks: their
+      // URL.origin is "null" (not same-origin) and their protocol is
+      // not http(s) (not localhost).
       function renderReturnLink() {
         const params = new URLSearchParams(window.location.search);
         const raw = params.get('return');

--- a/server/src/db/federated-index-db.ts
+++ b/server/src/db/federated-index-db.ts
@@ -685,6 +685,7 @@ export class FederatedIndexDatabase {
       `WITH unioned AS (
          SELECT id, property_id, publisher_domain, property_type, name,
                 identifiers, tags, discovered_at, last_validated, expires_at,
+                source_type,
                 0 AS src_priority
            FROM discovered_properties
           WHERE publisher_domain = $1
@@ -709,6 +710,10 @@ export class FederatedIndexDatabase {
            cp.created_at AS discovered_at,
            p.last_validated AS last_validated,
            p.expires_at AS expires_at,
+           -- Catalog rows here come from publishers.adagents_json JSONB
+           -- (see WHERE p.source_type = 'adagents_json' below). They are
+           -- by construction adagents_json-sourced.
+           'adagents_json'::text AS source_type,
            1 AS src_priority
            FROM publishers p
           CROSS JOIN LATERAL jsonb_array_elements(
@@ -726,7 +731,8 @@ export class FederatedIndexDatabase {
        ), deduped AS (
          SELECT DISTINCT ON (publisher_domain, name, property_type)
                 id, property_id, publisher_domain, property_type, name,
-                identifiers, tags, discovered_at, last_validated, expires_at
+                identifiers, tags, discovered_at, last_validated, expires_at,
+                source_type
            FROM unioned
           ORDER BY publisher_domain, name, property_type, src_priority
        )

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -5797,6 +5797,11 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       // share the same fire-stamp — otherwise `||` short-circuits past
       // shouldAutoCrawl's side-effect and the next request would re-fire
       // immediately, pinning a popular publisher's crawl rate to QPS.
+      // The fire-stamp is intentionally consumed BEFORE the SSRF gate
+      // below: a domain that fails validateCrawlDomain (private IP,
+      // unresolvable host) still occupies the debounce slot for ~5min,
+      // which is the desired DoS-resistance — an attacker probing
+      // hosts cannot bypass the debounce by sending stale-row signals.
       const debouncePassed = shouldAutoCrawl(domain);
       const staleBypass = !debouncePassed && brandRowStale;
       if (staleBypass) markAutoCrawlFired(domain);
@@ -5893,24 +5898,30 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         delegation_type?: "direct" | "delegated" | "ad_network";
       };
 
-      // Provenance: when the publisher's adagents.json validates, every
-      // federated-index row for this domain came either from that file
-      // or from a crawl that subsequently confirmed it — surface
-      // `adagents_json` so the page reads "from your adagents.json"
-      // instead of the misleading "found by crawler" label that the old
-      // hardcoded `discovered` produced. Without a valid adagents.json
-      // the rows can only come from sales-agent claims or external
-      // discovery, which is honestly `discovered`.
-      const indexedSource: "adagents_json" | "discovered" =
-        adagentsValid === true ? "adagents_json" : "discovered";
-      let projectedProperties: ProjectedProperty[] = properties.map(p => ({
-        id: p.property_id,
-        type: p.property_type,
-        name: p.name,
-        identifiers: p.identifiers,
-        tags: p.tags,
-        source: indexedSource,
-      }));
+      // Provenance: surface the underlying `source_type` per row rather
+      // than synthesizing a single label from the publisher's overall
+      // adagents-validity. `discovered_properties` is written by two
+      // paths today: the crawler tags rows `source_type='adagents_json'`,
+      // and `hosted-property-sync` tags AAO-hosted publisher manifests
+      // `source_type='aao_hosted'`. Both are publisher-attested and map
+      // to the schema's `adagents_json` value (the page reads "from your
+      // adagents.json"). Anything without a recognized source_type
+      // falls back to `discovered` — crawler-derived data without a
+      // first-party provenance claim.
+      let projectedProperties: ProjectedProperty[] = properties.map(p => {
+        const source: "adagents_json" | "discovered" =
+          p.source_type === "adagents_json" || p.source_type === "aao_hosted"
+            ? "adagents_json"
+            : "discovered";
+        return {
+          id: p.property_id,
+          type: p.property_type,
+          name: p.name,
+          identifiers: p.identifiers,
+          tags: p.tags,
+          source,
+        };
+      });
 
       // Fallback: if the federated index has nothing for this domain, hydrate
       // from the publisher's brand.json so that publishers who already

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -80,6 +80,7 @@ import type { HealthChecker } from "../health.js";
 import type { CrawlerService } from "../crawler.js";
 import type { CapabilityDiscovery } from "../capabilities.js";
 import { aaoHostedBrandJsonUrl, aaoHostedAdagentsJsonUrl, expectedAdagentsJsonUrl } from "../config/aao.js";
+import { canonicalTargetUri } from "@adcp/sdk/signing";
 import { fetchBrandData, isBrandfetchConfigured, ENRICHMENT_CACHE_MAX_AGE_MS } from "../services/brandfetch.js";
 import { extractPublisherPropertiesFromBrandJson } from "../services/brand-json-properties.js";
 import { syncHostedPropertyToFederatedIndex } from "../services/hosted-property-sync.js";
@@ -5728,13 +5729,23 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       const memberDb = new MemberDatabase();
       const federatedIndex = crawler.getFederatedIndex();
 
-      const [profile, properties, authorizations, adagentsValid, hostedProperty, brandRow] = await Promise.all([
+      const [profile, properties, authorizations, adagentsValid, hostedProperty, brandRow, cachedAdagentsManifest] = await Promise.all([
         memberDb.getProfileByDomain(domain),
         federatedIndex.getPropertiesForDomain(domain),
         federatedIndex.getAuthorizationsForDomain(domain),
         federatedIndex.hasValidAdagents(domain),
         propertyDb.getHostedPropertyByDomain(domain),
         brandDb.getDiscoveredBrandByDomain(domain),
+        // Read the publisher's own /.well-known response back from the
+        // overlay so we can tell a full self-hosted document (no
+        // authoritative_location) from a stub that points at AAO. The
+        // crawler caches the original response on `publishers.adagents_json`
+        // BEFORE following authoritative_location for validation, so this
+        // row preserves the stub vs. inline distinction we need.
+        query<{ adagents_json: Record<string, unknown> | null }>(
+          `SELECT adagents_json FROM publishers WHERE domain = $1 AND source_type = 'adagents_json' LIMIT 1`,
+          [domain],
+        ).then(r => r.rows[0]?.adagents_json ?? null),
       ]);
 
       // Auto-crawl on view: if we've never crawled this domain (adagents
@@ -5769,8 +5780,27 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       // as "already crawled" and refusing to retry — leaving publishers
       // who actually serve a brand.json forever marked as missing one.
       const brandNeverCrawled = !brandRow || !brandRow.has_brand_manifest;
+      // Bypass the per-domain auto-crawl debounce when the brand row is
+      // stale-without-manifest for >1h. Without this, a heavily-trafficked
+      // publisher whose brand.json went live AFTER our first crawl gets
+      // stuck on `unknown` indefinitely — every visit lands inside the
+      // 5-minute debounce window started by some prior visitor.
+      const STALE_BRAND_BYPASS_MS = 60 * 60 * 1000;
+      const brandRowStale = !!(
+        brandRow
+        && !brandRow.has_brand_manifest
+        && brandRow.last_validated
+        && Date.now() - brandRow.last_validated.getTime() > STALE_BRAND_BYPASS_MS
+      );
       let autoCrawlTriggered = false;
-      if ((adagentsNeverCrawled || brandNeverCrawled) && shouldAutoCrawl(domain)) {
+      // Capture the debounce result first so the brand-stale bypass can
+      // share the same fire-stamp — otherwise `||` short-circuits past
+      // shouldAutoCrawl's side-effect and the next request would re-fire
+      // immediately, pinning a popular publisher's crawl rate to QPS.
+      const debouncePassed = shouldAutoCrawl(domain);
+      const staleBypass = !debouncePassed && brandRowStale;
+      if (staleBypass) markAutoCrawlFired(domain);
+      if ((adagentsNeverCrawled || brandNeverCrawled) && (debouncePassed || staleBypass)) {
         // Re-validate: returns null on private/loopback/link-local IPs
         // and rejects unresolvable hostnames. We accept the result of
         // validateCrawlDomain only when it returns the same domain we
@@ -5802,30 +5832,53 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         ? { slug: profile.slug, display_name: profile.display_name }
         : null;
 
-      // Hosting state. `aao_hosted` when a public hosted-property row
-      // exists for this domain (publisher hosts a stub at their own
-      // /.well-known whose `authoritative_location` points at AAO's
-      // canonical document). `self` when the publisher's own /.well-known
-      // returned a valid adagents.json. `self_invalid` when the publisher
-      // has /.well-known but it failed validation — distinct from `none`
-      // because it's a fixable misconfiguration rather than absence.
-      const aaoHosted = !!(hostedProperty && hostedProperty.is_public);
+      // Hosting state. Live origin wins: if the publisher's own
+      // /.well-known/adagents.json validates AND its body isn't a stub
+      // pointing back at AAO's hosted URL, mode = `self` regardless of
+      // whether a hosted_properties opt-in row still exists. Publishers
+      // who opt into AAO hosting and later migrate to self-hosting were
+      // previously stuck on `aao_hosted` because the hosted-properties
+      // row never auto-revokes (#wonderstruck.org).
+      //
+      // `aao_hosted` requires either (a) the live origin's adagents.json
+      // is a stub whose `authoritative_location` canonicalizes to our
+      // hosted URL, or (b) the origin file is missing/invalid AND the
+      // publisher previously opted into hosting — in which case AAO's
+      // hosted document acts as a backup the publisher can choose to
+      // surface via DNS/redirect. `self_invalid` keeps the
+      // fixable-misconfiguration distinction from absence (`none`).
+      const aaoOptedIn = !!(hostedProperty && hostedProperty.is_public);
+      const stubAuthLocRaw =
+        cachedAdagentsManifest && typeof (cachedAdagentsManifest as Record<string, unknown>).authoritative_location === 'string'
+          ? ((cachedAdagentsManifest as Record<string, unknown>).authoritative_location as string)
+          : null;
+      const stubPointsAtAao = (() => {
+        if (!stubAuthLocRaw) return false;
+        try {
+          return canonicalTargetUri(stubAuthLocRaw) === canonicalTargetUri(aaoHostedAdagentsJsonUrl(domain));
+        } catch {
+          return false;
+        }
+      })();
+      const hostingMode: "self" | "self_invalid" | "aao_hosted" | "none" = (
+        adagentsValid === true && stubPointsAtAao ? "aao_hosted"
+        : adagentsValid === true ? "self"
+        : aaoOptedIn ? "aao_hosted"
+        : adagentsValid === false ? "self_invalid"
+        : "none"
+      );
+      const isAaoHosted = hostingMode === "aao_hosted";
       const hosting = {
-        mode: (
-          aaoHosted ? "aao_hosted"
-          : adagentsValid === true ? "self"
-          : adagentsValid === false ? "self_invalid"
-          : "none"
-        ) as "self" | "self_invalid" | "aao_hosted" | "none",
-        hosted_url: aaoHosted ? aaoHostedAdagentsJsonUrl(domain) : undefined,
+        mode: hostingMode,
+        hosted_url: isAaoHosted ? aaoHostedAdagentsJsonUrl(domain) : undefined,
         expected_url: expectedAdagentsJsonUrl(domain),
         // Only meaningful for AAO-hosted publishers — surface the
         // verifier's last result so callers can tell origin-attested
         // hosting from intent-only hosting.
-        origin_verified_at: aaoHosted && hostedProperty?.origin_verified_at
+        origin_verified_at: isAaoHosted && hostedProperty?.origin_verified_at
           ? hostedProperty.origin_verified_at.toISOString()
           : null,
-        origin_last_checked_at: aaoHosted && hostedProperty?.origin_last_checked_at
+        origin_last_checked_at: isAaoHosted && hostedProperty?.origin_last_checked_at
           ? hostedProperty.origin_last_checked_at.toISOString()
           : null,
       };
@@ -5840,13 +5893,23 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         delegation_type?: "direct" | "delegated" | "ad_network";
       };
 
+      // Provenance: when the publisher's adagents.json validates, every
+      // federated-index row for this domain came either from that file
+      // or from a crawl that subsequently confirmed it — surface
+      // `adagents_json` so the page reads "from your adagents.json"
+      // instead of the misleading "found by crawler" label that the old
+      // hardcoded `discovered` produced. Without a valid adagents.json
+      // the rows can only come from sales-agent claims or external
+      // discovery, which is honestly `discovered`.
+      const indexedSource: "adagents_json" | "discovered" =
+        adagentsValid === true ? "adagents_json" : "discovered";
       let projectedProperties: ProjectedProperty[] = properties.map(p => ({
         id: p.property_id,
         type: p.property_type,
         name: p.name,
         identifiers: p.identifiers,
         tags: p.tags,
-        source: "discovered",
+        source: indexedSource,
       }));
 
       // Fallback: if the federated index has nothing for this domain, hydrate
@@ -7050,6 +7113,13 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     if (last && Date.now() - last < AUTO_CRAWL_DEBOUNCE_MS) return false;
     autoCrawlLastFired.set(domain, Date.now());
     return true;
+  }
+  // Stamp the debouncer for a manually-orchestrated bypass (e.g. stale
+  // brand row that we want to re-trigger out of band). Lets the caller
+  // share the per-domain fire-stamp so they don't flood the crawler on
+  // each subsequent request while the bypass condition remains true.
+  function markAutoCrawlFired(domain: string): void {
+    autoCrawlLastFired.set(domain, Date.now());
   }
 
   // Periodic cleanup of stale rate limit entries to prevent memory

--- a/server/tests/integration/registry-publisher-brand-json-hydration.test.ts
+++ b/server/tests/integration/registry-publisher-brand-json-hydration.test.ts
@@ -71,6 +71,8 @@ import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
 import { runMigrations } from '../../src/db/migrate.js';
 import { BrandDatabase } from '../../src/db/brand-db.js';
 import { PropertyDatabase } from '../../src/db/property-db.js';
+import { PublisherDatabase } from '../../src/db/publisher-db.js';
+import { aaoHostedAdagentsJsonUrl } from '../../src/config/aao.js';
 
 const DOMAIN_SUFFIX = '.registry-baseline.example';
 const DOMAIN_PREFIX = 'brand-hydrate-';
@@ -83,6 +85,7 @@ describe('Registry publisher endpoint — brand.json hydration', () => {
   let pool: Pool;
   let brandDb: BrandDatabase;
   let propertyDb: PropertyDatabase;
+  let publisherDb: PublisherDatabase;
 
   const DOMAIN_LIKE = `${DOMAIN_PREFIX}%${DOMAIN_SUFFIX}`;
 
@@ -93,6 +96,7 @@ describe('Registry publisher endpoint — brand.json hydration', () => {
       'DELETE FROM discovered_properties WHERE publisher_domain LIKE $1',
       [DOMAIN_LIKE]
     );
+    await pool.query('DELETE FROM publishers WHERE domain LIKE $1', [DOMAIN_LIKE]);
   }
 
   beforeAll(async () => {
@@ -103,6 +107,7 @@ describe('Registry publisher endpoint — brand.json hydration', () => {
     await runMigrations();
     brandDb = new BrandDatabase();
     propertyDb = new PropertyDatabase();
+    publisherDb = new PublisherDatabase();
     server = new HTTPServer();
     await server.start(0);
     app = (server as unknown as { app: unknown }).app;
@@ -323,7 +328,10 @@ describe('Registry publisher endpoint — brand.json hydration', () => {
     });
   });
 
-  it('reports hosting.mode=aao_hosted with hosted_url when a public hosted property exists', async () => {
+  it('reports hosting.mode=aao_hosted when a public hosted property exists and origin is not yet serving', async () => {
+    // Pure intent-only opt-in: publisher created a hosted_properties row
+    // but their /.well-known has not yet been crawled successfully.
+    // AAO's hosted document acts as the canonical source.
     await propertyDb.createHostedProperty({
       publisher_domain: PUB_AAO_HOSTED,
       adagents_json: { authorized_agents: [], properties: [] },
@@ -340,5 +348,105 @@ describe('Registry publisher endpoint — brand.json hydration', () => {
       hosted_url: `https://agenticadvertising.org/publisher/${PUB_AAO_HOSTED}/.well-known/adagents.json`,
       expected_url: `https://${PUB_AAO_HOSTED}/.well-known/adagents.json`,
     });
+  });
+
+  it('reports hosting.mode=self when origin self-hosts a valid full doc despite a stale AAO opt-in row', async () => {
+    // Wonderstruck-shaped regression: a publisher who once opted into
+    // AAO hosting and later migrated to self-hosting must surface as
+    // `self`, not `aao_hosted`. The hosted_properties row never
+    // auto-revokes — the live origin file is the authoritative signal.
+    const pub = `migrated-self-${Date.now()}.registry-baseline.example`;
+    await propertyDb.createHostedProperty({
+      publisher_domain: pub,
+      adagents_json: { authorized_agents: [], properties: [] },
+      is_public: true,
+      source_type: 'community',
+    });
+    // Live origin serves a valid full document (no authoritative_location).
+    await publisherDb.upsertAdagentsCache({
+      domain: pub,
+      manifest: {
+        authorized_agents: [
+          { url: 'https://agent.example.com', authorized_for: 'display' },
+        ],
+        properties: [
+          {
+            property_type: 'website',
+            name: 'Main site',
+            identifiers: [{ type: 'domain', value: pub }],
+          },
+        ],
+      },
+    });
+
+    const res = await request(app).get(`/api/registry/publisher?domain=${encodeURIComponent(pub)}`);
+    expect(res.status).toBe(200);
+    expect(res.body.hosting.mode).toBe('self');
+    expect(res.body.hosting.hosted_url).toBeUndefined();
+    expect(res.body.adagents_valid).toBe(true);
+  });
+
+  it('reports hosting.mode=aao_hosted when origin serves a stub with authoritative_location pointing at AAO', async () => {
+    // Spec-conformant AAO hosting flow: publisher's /.well-known
+    // returns a stub whose authoritative_location resolves to AAO's
+    // hosted URL. Crawler caches the original (stub) response, the
+    // route detects the pointer and reports aao_hosted.
+    const pub = `stub-points-aao-${Date.now()}.registry-baseline.example`;
+    await propertyDb.createHostedProperty({
+      publisher_domain: pub,
+      adagents_json: { authorized_agents: [], properties: [] },
+      is_public: true,
+      source_type: 'community',
+    });
+    await publisherDb.upsertAdagentsCache({
+      domain: pub,
+      manifest: {
+        authoritative_location: aaoHostedAdagentsJsonUrl(pub),
+        authorized_agents: [],
+        properties: [],
+      },
+    });
+
+    const res = await request(app).get(`/api/registry/publisher?domain=${encodeURIComponent(pub)}`);
+    expect(res.status).toBe(200);
+    expect(res.body.hosting.mode).toBe('aao_hosted');
+    expect(res.body.hosting.hosted_url).toBe(aaoHostedAdagentsJsonUrl(pub));
+  });
+
+  it('tags federated-index properties with source=adagents_json when the publisher serves a valid adagents.json', async () => {
+    // Wonderstruck-shaped regression: properties listed in the live
+    // adagents.json were being labelled `discovered` (i.e. "found by
+    // crawler"), erasing the fact that the publisher explicitly
+    // declared them. With a valid adagents.json present, the federated
+    // index entries are by definition adagents_json-sourced.
+    const pub = `props-from-adagents-${Date.now()}.registry-baseline.example`;
+    await publisherDb.upsertAdagentsCache({
+      domain: pub,
+      manifest: {
+        authorized_agents: [
+          { url: 'https://agent.example.com', authorized_for: 'display' },
+        ],
+        properties: [
+          {
+            property_type: 'website',
+            name: 'Main site',
+            identifiers: [{ type: 'domain', value: pub }],
+          },
+        ],
+      },
+    });
+    // Plant a federated-index row so the route's primary
+    // getPropertiesForDomain path returns something to project.
+    await pool.query(
+      `INSERT INTO discovered_properties
+         (publisher_domain, property_type, name, identifiers, tags, source_type)
+       VALUES ($1, 'website', 'Main site', $2::jsonb, ARRAY[]::text[], 'adagents_json')`,
+      [pub, JSON.stringify([{ type: 'domain', value: pub }])],
+    );
+
+    const res = await request(app).get(`/api/registry/publisher?domain=${encodeURIComponent(pub)}`);
+    expect(res.status).toBe(200);
+    expect(res.body.properties).toHaveLength(1);
+    expect(res.body.properties[0].source).toBe('adagents_json');
   });
 });

--- a/server/tests/integration/registry-publisher-brand-json-hydration.test.ts
+++ b/server/tests/integration/registry-publisher-brand-json-hydration.test.ts
@@ -449,4 +449,26 @@ describe('Registry publisher endpoint — brand.json hydration', () => {
     expect(res.body.properties).toHaveLength(1);
     expect(res.body.properties[0].source).toBe('adagents_json');
   });
+
+  it('tags aao_hosted federated-index properties as adagents_json (publisher-attested via AAO hosting)', async () => {
+    // hosted-property-sync writes discovered_properties rows with
+    // source_type='aao_hosted' for publishers using AAO hosting. Both
+    // 'adagents_json' and 'aao_hosted' are publisher-attested and
+    // collapse to the schema's `adagents_json` value at the API
+    // surface — neither should bleed through as the schema-level
+    // `discovered` (which means "crawler-derived without first-party
+    // attestation").
+    const pub = `props-aao-hosted-${Date.now()}.registry-baseline.example`;
+    await pool.query(
+      `INSERT INTO discovered_properties
+         (publisher_domain, property_type, name, identifiers, tags, source_type)
+       VALUES ($1, 'website', 'Main site', $2::jsonb, ARRAY[]::text[], 'aao_hosted')`,
+      [pub, JSON.stringify([{ type: 'domain', value: pub }])],
+    );
+
+    const res = await request(app).get(`/api/registry/publisher?domain=${encodeURIComponent(pub)}`);
+    expect(res.status).toBe(200);
+    expect(res.body.properties).toHaveLength(1);
+    expect(res.body.properties[0].source).toBe('adagents_json');
+  });
 });


### PR DESCRIPTION
## Summary

The publisher page (`/publisher/<domain>`) was misreporting state for any publisher who opted into AAO hosting and later migrated to self-hosting — wonderstruck.org self-hosts a valid `adagents.json` + `brand.json`, but every visit showed them as `aao_hosted` and routed them to the AAO-hosted recipe instead of "you're set up correctly."

**Bugs fixed:**

- `hosting.mode` now honors the live origin. The route reads the cached origin response from `publishers.adagents_json` and only labels `aao_hosted` when the publisher's stub carries an `authoritative_location` pointing at AAO. Stale `hosted_properties` opt-in rows no longer override a valid self-hosted file.
- Properties from a valid adagents.json now surface as `source: "adagents_json"` (the page reads "from your adagents.json") instead of the misleading hardcoded `"discovered"` ("found by crawler").
- Stale `brand.json` rows older than an hour bypass the per-domain auto-crawl debounce, so popular publishers whose `brand.json` went live after the first crawl don't stay stuck on `unknown`.
- The publisher page honors a `?return=` query parameter (same-origin / localhost-dev only) and renders a back link — closing the loop for visitors arriving from a partner storefront / dev environment.

**Test coverage:** the existing integration test asserted the buggy behavior ("any public hosted-property row → `mode=aao_hosted`"). It's been split into three case-correct tests (intent-only opt-in, stale-opt-in + valid self-host, stub-with-`authoritative_location`) plus a regression test for property provenance.

Out of scope (separately tracked):
- Federated-index agent-count divergence detection (publishers who add an agent between crawls). Today's "Refresh now" button on the page already triggers a re-crawl that picks up the new agent.

## Test plan

- [x] `npx tsc --noEmit -p server/tsconfig.json` — clean
- [x] `vitest run tests/integration/registry-publisher-brand-json-hydration.test.ts` — 13 passed (3 new + 1 revised + 9 existing)
- [x] `vitest run tests/integration/publisher-hosted-adagents-route.test.ts tests/integration/hosted-property-fed-index-sync.test.ts tests/integration/hosted-property-origin-verifier.test.ts` — 21 passed
- [x] `vitest run tests/unit/{validator,adagents-manager,operator-publisher-lookup}.test.ts` — 82 passed
- [ ] Smoke: visit `/publisher/wonderstruck.org` after deploy and confirm `mode=self`, properties labelled "from your adagents.json"

🤖 Generated with [Claude Code](https://claude.com/claude-code)