### PR TITLE
fix(registry): re-crawl when cached manifest diverges from federated index

### DIFF
--- a/.changeset/registry-publisher-index-divergence-recrawl.md
+++ b/.changeset/registry-publisher-index-divergence-recrawl.md
@@ -1,0 +1,4 @@
+---
+---
+
+`/api/registry/publisher` now detects when the cached origin manifest in `publishers.adagents_json` declares an `authorized_agents` URL that the federated index doesn't carry, and triggers a re-crawl on visit when the row is older than the auto-crawl bypass window. This recovers from the wonderstruck-shaped failure where a per-agent upsert silently fails (or the publisher adds an agent after the cache was last written) and an anonymous visitor's view stays stuck on a stale agent list. Gated on `last_validated >1h` so an in-flight crawl isn't preempted.

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -5729,7 +5729,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       const memberDb = new MemberDatabase();
       const federatedIndex = crawler.getFederatedIndex();
 
-      const [profile, properties, authorizations, adagentsValid, hostedProperty, brandRow, cachedAdagentsManifest] = await Promise.all([
+      const [profile, properties, authorizations, adagentsValid, hostedProperty, brandRow, cachedAdagentsRow] = await Promise.all([
         memberDb.getProfileByDomain(domain),
         federatedIndex.getPropertiesForDomain(domain),
         federatedIndex.getAuthorizationsForDomain(domain),
@@ -5742,11 +5742,18 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         // crawler caches the original response on `publishers.adagents_json`
         // BEFORE following authoritative_location for validation, so this
         // row preserves the stub vs. inline distinction we need.
-        query<{ adagents_json: Record<string, unknown> | null }>(
-          `SELECT adagents_json FROM publishers WHERE domain = $1 AND source_type = 'adagents_json' LIMIT 1`,
+        // `last_validated` lets us detect cache/index drift: if the
+        // cached manifest declares agents that aren't in the federated
+        // index AND we haven't re-crawled in over an hour, trigger a
+        // re-crawl on visit so an anonymous publisher visit picks up
+        // their newly-added agents without needing to sign in.
+        query<{ adagents_json: Record<string, unknown> | null; last_validated: Date | null }>(
+          `SELECT adagents_json, last_validated FROM publishers WHERE domain = $1 AND source_type = 'adagents_json' LIMIT 1`,
           [domain],
-        ).then(r => r.rows[0]?.adagents_json ?? null),
+        ).then(r => r.rows[0] ?? null),
       ]);
+      const cachedAdagentsManifest = cachedAdagentsRow?.adagents_json ?? null;
+      const cachedAdagentsLastValidated = cachedAdagentsRow?.last_validated ?? null;
 
       // Auto-crawl on view: if we've never crawled this domain (adagents
       // never seen, brand never seen), kick off background fetches so a
@@ -5785,15 +5792,44 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       // publisher whose brand.json went live AFTER our first crawl gets
       // stuck on `unknown` indefinitely — every visit lands inside the
       // 5-minute debounce window started by some prior visitor.
-      const STALE_BRAND_BYPASS_MS = 60 * 60 * 1000;
+      const STALE_BYPASS_MS = 60 * 60 * 1000;
       const brandRowStale = !!(
         brandRow
         && !brandRow.has_brand_manifest
         && brandRow.last_validated
-        && Date.now() - brandRow.last_validated.getTime() > STALE_BRAND_BYPASS_MS
+        && Date.now() - brandRow.last_validated.getTime() > STALE_BYPASS_MS
+      );
+      // Index-divergence bypass: when the cached origin manifest
+      // declares an authorized_agents URL that the federated index
+      // doesn't carry, the last crawl either partially failed (the
+      // cache write succeeded but a per-agent upsert threw and was
+      // swallowed by the per-domain catch in crawler.ts) or the
+      // publisher added an agent after we cached the file. Either way,
+      // a re-crawl resolves it. Gated on >1h so transient writes don't
+      // trip on a crawl in flight.
+      const cachedAuthorizedAgents = Array.isArray(
+        (cachedAdagentsManifest as { authorized_agents?: unknown[] } | null)?.authorized_agents,
+      )
+        ? (cachedAdagentsManifest as { authorized_agents: unknown[] }).authorized_agents
+        : [];
+      const canonicalizeAgentUrl = (u: string) => u.trim().toLowerCase().replace(/\/+$/, '');
+      const cachedAgentUrls = new Set<string>(
+        cachedAuthorizedAgents
+          .map(a => (a && typeof (a as { url?: unknown }).url === 'string' ? canonicalizeAgentUrl((a as { url: string }).url) : null))
+          .filter((u): u is string => !!u),
+      );
+      const indexAgentUrls = new Set<string>(
+        authorizations.map(a => canonicalizeAgentUrl(a.agent_url)),
+      );
+      const indexMissingAgents = [...cachedAgentUrls].filter(u => !indexAgentUrls.has(u));
+      const indexDivergedAndStale = !!(
+        adagentsValid === true
+        && indexMissingAgents.length > 0
+        && cachedAdagentsLastValidated
+        && Date.now() - cachedAdagentsLastValidated.getTime() > STALE_BYPASS_MS
       );
       let autoCrawlTriggered = false;
-      // Capture the debounce result first so the brand-stale bypass can
+      // Capture the debounce result first so the stale-row bypass can
       // share the same fire-stamp — otherwise `||` short-circuits past
       // shouldAutoCrawl's side-effect and the next request would re-fire
       // immediately, pinning a popular publisher's crawl rate to QPS.
@@ -5803,9 +5839,10 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       // which is the desired DoS-resistance — an attacker probing
       // hosts cannot bypass the debounce by sending stale-row signals.
       const debouncePassed = shouldAutoCrawl(domain);
-      const staleBypass = !debouncePassed && brandRowStale;
+      const staleBypass = !debouncePassed && (brandRowStale || indexDivergedAndStale);
       if (staleBypass) markAutoCrawlFired(domain);
-      if ((adagentsNeverCrawled || brandNeverCrawled) && (debouncePassed || staleBypass)) {
+      const shouldFireCrawl = adagentsNeverCrawled || brandNeverCrawled || indexDivergedAndStale;
+      if (shouldFireCrawl && (debouncePassed || staleBypass)) {
         // Re-validate: returns null on private/loopback/link-local IPs
         // and rejects unresolvable hostnames. We accept the result of
         // validateCrawlDomain only when it returns the same domain we
@@ -5819,8 +5856,18 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         }
         if (crawlSafe) {
           autoCrawlTriggered = true;
-          if (adagentsNeverCrawled) {
-            // crawlSingleDomain handles brand internally too.
+          if (adagentsNeverCrawled || indexDivergedAndStale) {
+            // crawlSingleDomain re-runs the adagents.json fetch and
+            // re-projects authorized_agents into the index, recovering
+            // any per-agent upsert that silently failed last time.
+            // Handles brand internally too.
+            if (indexDivergedAndStale) {
+              logger.info({
+                domain,
+                missing_agents: indexMissingAgents.length,
+                cached_total: cachedAgentUrls.size,
+              }, 'Auto-crawl: federated index missing agents declared in cached manifest — re-running');
+            }
             crawler.crawlSingleDomain(domain).catch((err: Error) => {
               logger.warn({ err, domain, ip: req.ip }, 'Auto-crawl (adagents) failed');
             });

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -5812,14 +5812,21 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       )
         ? (cachedAdagentsManifest as { authorized_agents: unknown[] }).authorized_agents
         : [];
-      const canonicalizeAgentUrl = (u: string) => u.trim().toLowerCase().replace(/\/+$/, '');
+      // Reuse the writer's canonicalizer (publisher-db.ts:96) instead of
+      // a local lambda — it also rejects '*'-embedded URLs and
+      // whitespace/control chars that the lambda would have admitted as
+      // false-positive divergence signals (the writer drops those rows
+      // entirely, so a row whose stored canonical doesn't exist must
+      // not appear in the diff).
       const cachedAgentUrls = new Set<string>(
         cachedAuthorizedAgents
           .map(a => (a && typeof (a as { url?: unknown }).url === 'string' ? canonicalizeAgentUrl((a as { url: string }).url) : null))
           .filter((u): u is string => !!u),
       );
       const indexAgentUrls = new Set<string>(
-        authorizations.map(a => canonicalizeAgentUrl(a.agent_url)),
+        authorizations
+          .map(a => canonicalizeAgentUrl(a.agent_url))
+          .filter((u): u is string => !!u),
       );
       const indexMissingAgents = [...cachedAgentUrls].filter(u => !indexAgentUrls.has(u));
       const indexDivergedAndStale = !!(
@@ -5827,6 +5834,14 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         && indexMissingAgents.length > 0
         && cachedAdagentsLastValidated
         && Date.now() - cachedAdagentsLastValidated.getTime() > STALE_BYPASS_MS
+        // Even when the divergence + staleness gates clear, refuse to
+        // re-fire the crawl more than once per hour per domain. The
+        // divergence condition can persist across many requests until the
+        // crawl finishes; without this ceiling, an attacker could keep
+        // re-triggering crawls against any victim domain in a stuck
+        // diverged state. The ceiling stamps on first fire so a single
+        // visit per hour suffices to drive recovery.
+        && shouldFireDivergenceCrawl(domain)
       );
       let autoCrawlTriggered = false;
       // Capture the debounce result first so the stale-row bypass can
@@ -5866,6 +5881,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
                 domain,
                 missing_agents: indexMissingAgents.length,
                 cached_total: cachedAgentUrls.size,
+                index_total: indexAgentUrls.size,
               }, 'Auto-crawl: federated index missing agents declared in cached manifest — re-running');
             }
             crawler.crawlSingleDomain(domain).catch((err: Error) => {
@@ -7180,6 +7196,24 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     autoCrawlLastFired.set(domain, Date.now());
   }
 
+  // Divergence-bypass ceiling. The index-divergence trigger persists
+  // across requests until the crawl finishes — without a longer-window
+  // ceiling, an attacker hitting `/api/registry/publisher?domain=victim`
+  // once per 5min could sustain ~12 outbound /.well-known fetches/hour
+  // against any victim whose AAO row is in the diverged-and-stale state.
+  // The 5-minute auto-crawl debounce blunts but doesn't eliminate this
+  // (one request per debounce window is enough to keep firing). Cap the
+  // divergence path at one fire/hour/domain so the bypass cannot exceed
+  // normal crawl cadence even when the trigger condition is permanent.
+  const divergenceLastFired = new Map<string, number>();
+  const DIVERGENCE_CEILING_MS = 60 * 60 * 1000;
+  function shouldFireDivergenceCrawl(domain: string): boolean {
+    const last = divergenceLastFired.get(domain);
+    if (last && Date.now() - last < DIVERGENCE_CEILING_MS) return false;
+    divergenceLastFired.set(domain, Date.now());
+    return true;
+  }
+
   // Periodic cleanup of stale rate limit entries to prevent memory
   // growth. Eviction threshold is INTENTIONALLY larger than the debounce
   // window — if cleanup deleted an entry at exactly `windowMs`, the next
@@ -7195,6 +7229,9 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     }
     for (const [domain, timestamp] of autoCrawlLastFired) {
       if (now - timestamp > 2 * AUTO_CRAWL_DEBOUNCE_MS) autoCrawlLastFired.delete(domain);
+    }
+    for (const [domain, timestamp] of divergenceLastFired) {
+      if (now - timestamp > 2 * DIVERGENCE_CEILING_MS) divergenceLastFired.delete(domain);
     }
   }, CRAWL_RATE_LIMIT_MS);
   rateLimitCleanupInterval.unref(); // Don't prevent process exit

--- a/server/tests/integration/registry-publisher-brand-json-hydration.test.ts
+++ b/server/tests/integration/registry-publisher-brand-json-hydration.test.ts
@@ -471,4 +471,114 @@ describe('Registry publisher endpoint — brand.json hydration', () => {
     expect(res.body.properties).toHaveLength(1);
     expect(res.body.properties[0].source).toBe('adagents_json');
   });
+
+  it('triggers a re-crawl when the cached manifest carries an agent the federated index is missing and the row is >1h old', async () => {
+    // Drift case: a previous crawl wrote the cache (publishers.adagents_json
+    // with 2 agents) but the per-agent upsert for one of them silently
+    // failed (or the publisher added the second agent after we cached the
+    // file). The federated index has only the first agent. An anonymous
+    // visit to /publisher/<domain> must re-trigger the crawl so the index
+    // catches up — without this, the publisher has no path to recovery
+    // that doesn't require signing in to hit "Refresh now."
+    const pub = `index-diverged-${Date.now()}.registry-baseline.example`;
+    const agentInIndex = 'https://agent-known.example';
+    const agentMissing = 'https://agent-missing.example';
+
+    // Write the publishers cache row directly. We deliberately bypass
+    // upsertAdagentsCache because that helper ALSO projects the manifest
+    // into catalog_agent_authorizations, which would seed the federated
+    // index with both agents and erase the divergence we're trying to
+    // simulate. The wonderstruck-shaped failure is exactly: cache has
+    // both agents, but only the legacy half (or only the catalog half)
+    // landed for one of them.
+    await pool.query(
+      `INSERT INTO publishers (domain, adagents_json, source_type, last_validated)
+       VALUES ($1, $2::jsonb, 'adagents_json', NOW() - INTERVAL '2 hours')`,
+      [
+        pub,
+        JSON.stringify({
+          authorized_agents: [
+            { url: agentInIndex, authorized_for: 'display' },
+            { url: agentMissing, authorized_for: 'display' },
+          ],
+          properties: [],
+        }),
+      ],
+    );
+
+    // Plant exactly one of the two agents in the legacy authorization
+    // table. The federated-index UNION reads legacy + catalog; with no
+    // catalog projection, the reader returns only this single agent —
+    // matching the production drift case.
+    await pool.query(
+      `INSERT INTO agent_publisher_authorizations (agent_url, publisher_domain, source)
+       VALUES ($1, $2, 'adagents_json')`,
+      [agentInIndex, pub],
+    );
+
+    // brand row exists with manifest so brand-staleness can't be the
+    // re-crawl reason — only divergence remains.
+    await brandDb.upsertDiscoveredBrand({
+      domain: pub,
+      brand_name: 'Index Diverged Co',
+      source_type: 'brand_json',
+      has_brand_manifest: true,
+      brand_manifest: { name: 'Index Diverged Co' },
+    });
+
+    const res = await request(app).get(`/api/registry/publisher?domain=${encodeURIComponent(pub)}`);
+    expect(res.status).toBe(200);
+    expect(res.body.adagents_valid).toBe(true);
+    expect(res.body.auto_crawl_triggered).toBe(true);
+    // Cleanup: the planted authorization will leak across tests
+    // otherwise (the LIKE delete in clearFixtures only catches by
+    // publisher_domain prefix, which works here).
+    await pool.query(
+      `DELETE FROM agent_publisher_authorizations WHERE publisher_domain = $1`,
+      [pub],
+    );
+  });
+
+  it('does NOT re-crawl on divergence when the cached manifest is fresh', async () => {
+    // Counterpart to the previous test: same shape (cache has 2 agents,
+    // index has 1) but last_validated is recent, so the in-flight crawl
+    // hasn't finished writing yet. We must not re-trigger and stomp on
+    // its writes.
+    const pub = `index-diverged-fresh-${Date.now()}.registry-baseline.example`;
+    await pool.query(
+      `INSERT INTO publishers (domain, adagents_json, source_type, last_validated)
+       VALUES ($1, $2::jsonb, 'adagents_json', NOW())`,
+      [
+        pub,
+        JSON.stringify({
+          authorized_agents: [
+            { url: 'https://agent-1.example', authorized_for: 'display' },
+            { url: 'https://agent-2.example', authorized_for: 'display' },
+          ],
+          properties: [],
+        }),
+      ],
+    );
+    await pool.query(
+      `INSERT INTO agent_publisher_authorizations (agent_url, publisher_domain, source)
+       VALUES ($1, $2, 'adagents_json')`,
+      ['https://agent-1.example', pub],
+    );
+    await brandDb.upsertDiscoveredBrand({
+      domain: pub,
+      brand_name: 'Fresh Diverged Co',
+      source_type: 'brand_json',
+      has_brand_manifest: true,
+      brand_manifest: { name: 'Fresh Diverged Co' },
+    });
+
+    const res = await request(app).get(`/api/registry/publisher?domain=${encodeURIComponent(pub)}`);
+    expect(res.status).toBe(200);
+    expect(res.body.adagents_valid).toBe(true);
+    expect(res.body.auto_crawl_triggered).toBeUndefined();
+    await pool.query(
+      `DELETE FROM agent_publisher_authorizations WHERE publisher_domain = $1`,
+      [pub],
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Stacked on top of #4149. Closes the second half of the wonderstruck-shaped failure: their `/.well-known/adagents.json` declares 2 agents but our federated index returns 1 — a per-agent projection silently failed on the last crawl, and an anonymous visitor has no recovery path that doesn't require signing in to hit "Refresh now."

The route now diffs the cached manifest's `authorized_agents` against the federated-index agent set. When the cache lists an agent the index is missing AND the publisher row was last validated more than an hour ago, trigger a re-crawl on visit — sharing the existing per-domain debounce fire-stamp so the crawler isn't flooded. The `>1h` gate keeps an in-flight crawl from being preempted by its own anonymous-visit side-effects.

## Test plan

- [x] `vitest run tests/integration/registry-publisher-brand-json-hydration.test.ts` — 15 passed (2 new + 13 existing)
- [x] `vitest run tests/integration/{publisher-hosted-adagents-route,hosted-property-fed-index-sync,hosted-property-origin-verifier,registry-publisher-brand-json-hydration}.test.ts` — 36 passed
- [x] `tsc --noEmit` — clean
- [ ] Smoke after deploy: visit `/publisher/wonderstruck.org` → response includes `auto_crawl_triggered: true`; revisit ~5s later → both agents listed

## Notes

- Stacked on #4149. Set base to `bokelley/fix-publisher-detail-page` until that one merges.
- Doesn't fix the orthogonal problem of agents being *removed* from the publisher's adagents.json — the crawler is still upsert-only and never deletes. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)