### PR TITLE
fix(registry): reconcile agent rows on crawl so removals propagate

### DIFF
--- a/.changeset/registry-publisher-agent-removal-reconcile.md
+++ b/.changeset/registry-publisher-agent-removal-reconcile.md
@@ -1,0 +1,4 @@
+---
+---
+
+The crawler now reconciles authorized-agent rows after every successful adagents.json fetch — agents that were in a prior crawl but are no longer in the freshly-fetched manifest get hard-deleted from the legacy `agent_publisher_authorizations` table and soft-deleted (`deleted_at`) from `catalog_agent_authorizations`. Both writers were upsert-only previously, which meant an agent removed from a publisher's `/.well-known/adagents.json` lingered in the federated index forever. `agent_claim` rows and rows attested by other writers (`evidence != 'adagents_json'`) are untouched — those belong to a different publisher's discovery flow and a removal from one manifest must not erase another's claims.

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -5,7 +5,7 @@ import { FederatedIndexService } from "./federated-index.js";
 import { AdAgentsManager } from "./adagents-manager.js";
 import { BrandManager } from "./brand-manager.js";
 import { BrandDatabase } from "./db/brand-db.js";
-import { PublisherDatabase, type AdagentsManifest } from "./db/publisher-db.js";
+import { PublisherDatabase, canonicalizeAgentUrl, type AdagentsManifest } from "./db/publisher-db.js";
 import { MemberDatabase } from "./db/member-db.js";
 import { CapabilityDiscovery } from "./capabilities.js";
 import { HealthChecker } from "./health.js";
@@ -405,6 +405,7 @@ export class CrawlerService {
                 authorizedAgent.property_ids
               );
             }
+            await this.reconcileLegacyAdagentsAgents(pubConfig.domain, validation.raw_data as AdagentsManifest);
           } else {
             log.debug({ domain: pubConfig.domain }, 'No valid adagents.json');
           }
@@ -458,6 +459,7 @@ export class CrawlerService {
                 authorizedAgent.property_ids
               );
             }
+            await this.reconcileLegacyAdagentsAgents(domain, validation.raw_data as AdagentsManifest);
           }
         } catch (err) {
           log.error({ domain, err }, 'Failed to process domain');
@@ -656,6 +658,26 @@ export class CrawlerService {
       await this.publisherDb.upsertAdagentsCache({ domain, manifest });
     } catch (err) {
       log.warn({ domain, err: err instanceof Error ? err.message : err }, 'Publisher cache write failed');
+    }
+  }
+
+  /**
+   * Reconcile legacy adagents_json authorization rows for a publisher
+   * after a successful crawl: agents that were in a prior manifest but
+   * are no longer in the freshly-fetched one get hard-deleted from the
+   * legacy table. The catalog-side reconcile happens inside
+   * upsertAdagentsCache. agent_claim rows are untouched. Best-effort —
+   * a reconcile failure must not abort the rest of the crawl.
+   */
+  private async reconcileLegacyAdagentsAgents(domain: string, manifest: AdagentsManifest): Promise<void> {
+    const entries = Array.isArray(manifest.authorized_agents) ? manifest.authorized_agents : [];
+    const canonical = entries
+      .map(e => (e?.url && typeof e.url === 'string' ? canonicalizeAgentUrl(e.url) : null))
+      .filter((c): c is string => !!c);
+    try {
+      await this.federatedIndex.reconcileAdagentsAuthorizations(domain, canonical);
+    } catch (err) {
+      log.warn({ domain, err: err instanceof Error ? err.message : err }, 'Adagents legacy reconcile failed');
     }
   }
 
@@ -907,6 +929,7 @@ export class CrawlerService {
           authorizedAgent.property_ids
         );
       }
+      await this.reconcileLegacyAdagentsAgents(domain, validation.raw_data as AdagentsManifest);
 
       // Produce per-domain events
       if (this.eventsDb) {
@@ -1075,6 +1098,7 @@ export class CrawlerService {
         authorizedAgent.property_ids
       );
     }
+    await this.reconcileLegacyAdagentsAgents(domain, validation.raw_data as AdagentsManifest);
 
     if (this.eventsDb) {
       await this.eventsDb.writeEvent({

--- a/server/src/db/federated-index-db.ts
+++ b/server/src/db/federated-index-db.ts
@@ -433,6 +433,44 @@ export class FederatedIndexDatabase {
   // ============================================
 
   /**
+   * Hard-delete legacy adagents_json authorization rows for a
+   * publisher whose canonical agent_url is no longer in the latest
+   * crawled manifest. Called once per domain after the per-agent
+   * upsert loop. agent_claim rows are untouched (they belong to a
+   * different publisher's discovery flow).
+   *
+   * `currentAgentUrls` is the canonical-form list — already trimmed,
+   * lowercased, and stripped of trailing slashes. The DELETE
+   * canonicalizes the stored agent_url with the same shape so a
+   * historical non-canonical row still matches.
+   */
+  async reconcileAdagentsAuthorizations(
+    publisherDomain: string,
+    currentAgentUrls: string[],
+  ): Promise<void> {
+    // Canonicalize both sides in SQL so a caller that forgets to
+    // canonicalize doesn't silently nuke every adagents_json row for
+    // the publisher. The stored side mirrors the writer's canonical
+    // form (lowercase, no trailing slash, '*' literal preserved); the
+    // input side runs the same shape.
+    await query(
+      `DELETE FROM agent_publisher_authorizations
+        WHERE publisher_domain = $1
+          AND source = 'adagents_json'
+          AND NOT (
+            CASE WHEN agent_url = '*' THEN '*'
+                 ELSE LOWER(RTRIM(BTRIM(agent_url), '/')) END
+            IN (
+              SELECT CASE WHEN u = '*' THEN '*'
+                          ELSE LOWER(RTRIM(BTRIM(u), '/')) END
+                FROM unnest($2::text[]) AS u
+            )
+          )`,
+      [publisherDomain, currentAgentUrls],
+    );
+  }
+
+  /**
    * Upsert a discovered agent
    */
   async upsertAgent(agent: DiscoveredAgent): Promise<DiscoveredAgent> {

--- a/server/src/db/federated-index-db.ts
+++ b/server/src/db/federated-index-db.ts
@@ -453,6 +453,14 @@ export class FederatedIndexDatabase {
     // the publisher. The stored side mirrors the writer's canonical
     // form (lowercase, no trailing slash, '*' literal preserved); the
     // input side runs the same shape.
+    //
+    // Cross-publisher safety: the DELETE is scoped by `publisher_domain`
+    // and `source='adagents_json'`. A NULL agent_url in any row would
+    // make the CASE expression NULL, the IN comparison NULL, and
+    // `NOT NULL` NULL — Postgres treats NULL as not-true so the row
+    // is preserved (fail-safe). The agent_url column is NOT NULL by
+    // schema (migration 025) so this is theoretical, but the canonical
+    // SQL pattern doesn't rely on the schema invariant.
     await query(
       `DELETE FROM agent_publisher_authorizations
         WHERE publisher_domain = $1

--- a/server/src/db/publisher-db.ts
+++ b/server/src/db/publisher-db.ts
@@ -210,6 +210,41 @@ export class PublisherDatabase {
         }
       }
 
+      // Reconcile: soft-delete catalog rows for agents that USED to be
+      // authorized by this manifest but no longer appear. Without this
+      // the writer is upsert-only and an agent removed from the
+      // publisher's adagents.json would linger in the index forever
+      // (the original wonderstruck-shaped follow-up bug). Scoped to
+      // writer-sourced rows (`evidence='adagents_json'`,
+      // `created_by='system'`) so promotions, agent_claim rows, and
+      // third-party-attested rows are untouched.
+      const currentCanonical = authEntries
+        .map(e => (e?.url && typeof e.url === 'string' ? canonicalizeAgentUrl(e.url) : null))
+        .filter((c): c is string => !!c);
+      // Catalog rows for this publisher live under either
+      //   publisher_domain = $1   (publisher-wide rows)
+      //   property_rid IN (catalog_properties.created_by='adagents_json:$1')
+      //   property_id_slug IS NOT NULL with created_by='adagents_json:$1' (slug-keyed)
+      // The OR-chain covers all three writer shapes.
+      await client.query(
+        `UPDATE catalog_agent_authorizations caa
+            SET deleted_at = NOW()
+          WHERE caa.evidence = 'adagents_json'
+            AND caa.created_by = 'system'
+            AND caa.deleted_at IS NULL
+            AND NOT (caa.agent_url_canonical = ANY($2::text[]))
+            AND (
+              caa.publisher_domain = $1
+              OR caa.property_rid IN (
+                SELECT property_rid FROM catalog_properties WHERE created_by = $3
+              )
+              OR (caa.property_id_slug IS NOT NULL AND caa.property_rid IN (
+                SELECT property_rid FROM catalog_properties WHERE created_by = $3
+              ))
+            )`,
+        [domain, currentCanonical, adagentsCreatedBy(domain)],
+      );
+
       await client.query('COMMIT');
     } catch (err) {
       await client.query('ROLLBACK');

--- a/server/src/federated-index.ts
+++ b/server/src/federated-index.ts
@@ -221,6 +221,29 @@ export class FederatedIndexService {
   }
 
   /**
+   * Reconcile the adagents_json authorization rows for a publisher
+   * after a successful crawl. Hard-deletes legacy rows where
+   * source='adagents_json' and the canonical agent_url is no longer in
+   * the manifest's authorized_agents list — this is how an agent that
+   * the publisher REMOVED from their /.well-known stops appearing in
+   * the federated index. agent_claim rows are untouched: a removal
+   * from one publisher's adagents.json must not erase the agent's
+   * own first-party claims of authorization elsewhere.
+   *
+   * The crawler must call this once per domain after the per-agent
+   * upsert loop. `currentAgentUrls` is the canonical-form (lowercased,
+   * trailing slashes stripped) list of agents in the freshly-crawled
+   * manifest; an empty list is valid and will delete every prior
+   * adagents_json row for the publisher.
+   */
+  async reconcileAdagentsAuthorizations(
+    publisherDomain: string,
+    currentAgentUrls: string[],
+  ): Promise<void> {
+    await this.db.reconcileAdagentsAuthorizations(publisherDomain, currentAgentUrls);
+  }
+
+  /**
    * Record a publisher discovered from a sales agent's list_authorized_properties.
    */
   async recordPublisherFromAgent(

--- a/server/tests/integration/registry-catalog-agent-auth-writer.test.ts
+++ b/server/tests/integration/registry-catalog-agent-auth-writer.test.ts
@@ -691,4 +691,79 @@ describe('catalog_agent_authorizations writer projection', () => {
       expect(rows[0].authorized_for).toBe('video');
     });
   });
+
+  // ──────────────────────────────────────────────────────────────────
+  // Reconcile: agents removed from a manifest must drop out of the
+  // catalog. Without the reconcile step inside upsertAdagentsCache the
+  // writer is upsert-only and a stale row would linger forever — this
+  // is the second wonderstruck-shaped follow-up bug.
+  // ──────────────────────────────────────────────────────────────────
+
+  describe('reconcile on re-crawl', () => {
+    it('soft-deletes catalog rows for agents the new manifest no longer authorizes', async () => {
+      // First crawl: two agents.
+      await publisherDb.upsertAdagentsCache({
+        domain: TEST_PUB,
+        manifest: manifest([
+          { url: TEST_AGENT_RAW, authorized_for: 'display' },
+          { url: OTHER_AGENT, authorized_for: 'video' },
+        ]),
+      });
+      const beforeRows = await pool.query<{ agent_url_canonical: string; deleted_at: Date | null }>(
+        `SELECT agent_url_canonical, deleted_at FROM catalog_agent_authorizations
+          WHERE publisher_domain = $1`,
+        [TEST_PUB],
+      );
+      expect(beforeRows.rows.filter(r => !r.deleted_at)).toHaveLength(2);
+
+      // Second crawl: publisher removed OTHER_AGENT.
+      await publisherDb.upsertAdagentsCache({
+        domain: TEST_PUB,
+        manifest: manifest([{ url: TEST_AGENT_RAW, authorized_for: 'display' }]),
+      });
+
+      const live = await pool.query<{ agent_url_canonical: string }>(
+        `SELECT agent_url_canonical FROM catalog_agent_authorizations
+          WHERE publisher_domain = $1 AND deleted_at IS NULL`,
+        [TEST_PUB],
+      );
+      expect(live.rows).toHaveLength(1);
+      expect(live.rows[0].agent_url_canonical).toBe(TEST_AGENT_CANON);
+
+      const tombstoned = await pool.query<{ agent_url_canonical: string }>(
+        `SELECT agent_url_canonical FROM catalog_agent_authorizations
+          WHERE publisher_domain = $1 AND deleted_at IS NOT NULL`,
+        [TEST_PUB],
+      );
+      expect(tombstoned.rows).toHaveLength(1);
+      expect(tombstoned.rows[0].agent_url_canonical).toBe(OTHER_AGENT);
+    });
+
+    it('does not touch agent_claim or community-evidence rows belonging to other writers', async () => {
+      // Plant an agent_claim-style row for OTHER_AGENT against TEST_PUB
+      // (different evidence + created_by than the writer-sourced rows).
+      // The reconcile must NOT remove this — it represents a different
+      // publisher's discovery flow attesting to OTHER_AGENT's authorization.
+      await pool.query(
+        `INSERT INTO catalog_agent_authorizations
+           (agent_url, agent_url_canonical, publisher_domain, evidence, created_by)
+         VALUES ($1, $2, $3, 'agent_claim', 'community')`,
+        [OTHER_AGENT, OTHER_AGENT, TEST_PUB],
+      );
+
+      // Writer cache: only TEST_AGENT_RAW.
+      await publisherDb.upsertAdagentsCache({
+        domain: TEST_PUB,
+        manifest: manifest([{ url: TEST_AGENT_RAW, authorized_for: 'display' }]),
+      });
+
+      const claimRow = await pool.query<{ deleted_at: Date | null }>(
+        `SELECT deleted_at FROM catalog_agent_authorizations
+          WHERE agent_url_canonical = $1 AND publisher_domain = $2 AND evidence = 'agent_claim'`,
+        [OTHER_AGENT, TEST_PUB],
+      );
+      expect(claimRow.rows).toHaveLength(1);
+      expect(claimRow.rows[0].deleted_at).toBeNull();
+    });
+  });
 });

--- a/server/tests/integration/registry-crawler-cache.test.ts
+++ b/server/tests/integration/registry-crawler-cache.test.ts
@@ -735,4 +735,89 @@ describe('Registry crawler cache (PR 2 of #3177)', () => {
       );
     });
   });
+
+  // ──────────────────────────────────────────────────────────────────
+  // Legacy-table reconcile: when a publisher removes an agent from
+  // their adagents.json, the federated index must drop the stale row.
+  // The crawler is upsert-only by default; reconcileAdagentsAuthorizations
+  // closes the loop. agent_claim rows are untouched — they belong to a
+  // different publisher's discovery flow and must survive the reconcile.
+  // ──────────────────────────────────────────────────────────────────
+
+  describe('legacy reconcile (agent_publisher_authorizations)', () => {
+    const REMOVED_AGENT = 'https://removed-agent.crawler-cache.example';
+    const KEPT_AGENT = TEST_AGENT;
+    const CLAIMING_AGENT = 'https://claim.crawler-cache.example';
+
+    beforeEach(async () => {
+      // Plant prior-crawl state: two adagents_json rows for TEST_DOMAIN
+      // plus an agent_claim row from a different agent. The reconcile
+      // should drop only REMOVED_AGENT.
+      await pool.query(
+        `INSERT INTO agent_publisher_authorizations (agent_url, publisher_domain, source)
+           VALUES ($1, $2, 'adagents_json'),
+                  ($3, $2, 'adagents_json'),
+                  ($4, $2, 'agent_claim')
+         ON CONFLICT DO NOTHING`,
+        [KEPT_AGENT, TEST_DOMAIN, REMOVED_AGENT, CLAIMING_AGENT],
+      );
+    });
+
+    afterAll(async () => {
+      await pool.query(
+        `DELETE FROM agent_publisher_authorizations WHERE publisher_domain = $1`,
+        [TEST_DOMAIN],
+      );
+    });
+
+    it('hard-deletes adagents_json rows for agents that disappeared from the manifest', async () => {
+      // Reconcile to current manifest with only KEPT_AGENT.
+      await federatedIndex.reconcileAdagentsAuthorizations(TEST_DOMAIN, [
+        // Canonical form: lowercase, no trailing slash.
+        KEPT_AGENT.toLowerCase().replace(/\/+$/, ''),
+      ]);
+
+      const remaining = await pool.query<{ agent_url: string; source: string }>(
+        `SELECT agent_url, source FROM agent_publisher_authorizations
+          WHERE publisher_domain = $1 ORDER BY source, agent_url`,
+        [TEST_DOMAIN],
+      );
+      // KEPT_AGENT (adagents_json) and CLAIMING_AGENT (agent_claim).
+      expect(remaining.rows).toHaveLength(2);
+      const adagents = remaining.rows.find(r => r.source === 'adagents_json');
+      const claim = remaining.rows.find(r => r.source === 'agent_claim');
+      expect(adagents?.agent_url).toBe(KEPT_AGENT);
+      expect(claim?.agent_url).toBe(CLAIMING_AGENT);
+    });
+
+    it('canonicalizes both stored and input urls so an un-canonical input still matches', async () => {
+      // Pass a non-canonical form (uppercase, trailing slash). The SQL
+      // canonicalizes both sides, so KEPT_AGENT must still survive.
+      // This is the safety net against a caller forgetting to
+      // canonicalize — without it, the DELETE would nuke every row.
+      await federatedIndex.reconcileAdagentsAuthorizations(TEST_DOMAIN, [
+        `${KEPT_AGENT.toUpperCase()}/`,
+      ]);
+
+      const adagents = await pool.query<{ agent_url: string }>(
+        `SELECT agent_url FROM agent_publisher_authorizations
+          WHERE publisher_domain = $1 AND source = 'adagents_json'`,
+        [TEST_DOMAIN],
+      );
+      expect(adagents.rows).toHaveLength(1);
+      expect(adagents.rows[0].agent_url).toBe(KEPT_AGENT);
+    });
+
+    it('removes all adagents_json rows when the manifest authorizes no agents', async () => {
+      await federatedIndex.reconcileAdagentsAuthorizations(TEST_DOMAIN, []);
+
+      const remaining = await pool.query<{ agent_url: string; source: string }>(
+        `SELECT agent_url, source FROM agent_publisher_authorizations
+          WHERE publisher_domain = $1`,
+        [TEST_DOMAIN],
+      );
+      expect(remaining.rows).toHaveLength(1);
+      expect(remaining.rows[0].source).toBe('agent_claim');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Stacked on top of #4150 → #4149. Closes the agent-*removal* gap in the federated-index correctness arc.

Both writers were upsert-only. When a publisher removed an agent from their `/.well-known/adagents.json`, the legacy `agent_publisher_authorizations` row stayed (hard-row), the catalog `catalog_agent_authorizations` row stayed live (no `deleted_at`), and both UNIONs kept surfacing the removed agent indefinitely. There was no path to reflect a removal short of someone manually deleting rows.

This PR adds reconcile to both writers:

- **Catalog**: inside `upsertAdagentsCache`'s transaction. Soft-deletes (`deleted_at = NOW()`) rows where `evidence='adagents_json'` AND `created_by='system'` AND the canonical `agent_url` is absent from the freshly-cached manifest. Rows from other writers (agent_claim, community, override) are untouched.
- **Legacy**: a new `reconcileAdagentsAuthorizations(domain, currentAgentUrls)` on `FederatedIndexService`, called by the crawler once per domain after the per-agent upsert loop. Hard-deletes `source='adagents_json'` rows whose canonical `agent_url` is no longer in the manifest. `agent_claim` rows are untouched.

The DELETE canonicalizes both stored and input urls in SQL — a safety net so a caller that forgets to canonicalize doesn't silently nuke every row.

All four crawler call-sites that cache an adagents.json now invoke the reconcile: registered-publisher loop, sales-agent-discovered loop, `crawlSingleDomain` (manual + auto-crawl path), and `crawlSingleDomainForCatalog`.

## Test plan

- [x] `vitest run tests/integration/registry-catalog-agent-auth-writer.test.ts` — 22 passed (2 new in 'reconcile on re-crawl')
- [x] `vitest run tests/integration/registry-crawler-cache.test.ts` — 18 passed (3 new in 'legacy reconcile')
- [x] `vitest run tests/integration/registry-publisher-brand-json-hydration.test.ts` — 15 passed
- [x] `vitest run tests/integration/{publisher-hosted-adagents-route,hosted-property-fed-index-sync,hosted-property-origin-verifier,registry-overlay-schema,registry-reader-baseline-properties,registry-reader-poisoned-manifest}.test.ts` — 70 passed
- [x] `tsc --noEmit` — clean
- [ ] Smoke after deploy: drop an agent from a test publisher's adagents.json, hit "Refresh now" on the publisher page, confirm the agent disappears from `authorized_agents` in the API response.

## Notes

- Stacked on #4150. Set base to `bokelley/fix-publisher-index-divergence` until that one merges.
- Catalog rows are soft-deleted (the table already supports `deleted_at`); the legacy table is hard-delete (no soft-delete column). Reader UNIONs already filter `deleted_at IS NULL`, so the catalog soft-delete is invisible to consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)