### PR TITLE
docs(creative): document accounts filter item type as AccountRef[] in list_creatives

### DIFF
--- a/.changeset/list-creatives-accounts-type-doc.md
+++ b/.changeset/list-creatives-accounts-type-doc.md
@@ -1,4 +1,0 @@
----
----
-
-docs(creative): document `accounts` filter item type as `AccountRef[]` in `list_creatives` filtering options table. The type column previously showed `array` without indicating the item shape; the schema (`core/creative-filters.json`) uses `$ref: account-ref.json`. Follows the existing `AccountRef` link pattern used for the top-level `account` parameter in the same file.

--- a/.changeset/list-creatives-accounts-type-doc.md
+++ b/.changeset/list-creatives-accounts-type-doc.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs(creative): document `accounts` filter item type as `AccountRef[]` in `list_creatives` filtering options table. The type column previously showed `array` without indicating the item shape; the schema (`core/creative-filters.json`) uses `$ref: account-ref.json`. Follows the existing `AccountRef` link pattern used for the top-level `account` parameter in the same file.

--- a/.changeset/list-creatives-filter-types-doc.md
+++ b/.changeset/list-creatives-filter-types-doc.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs(creative): tighten type column in the `list_creatives` filtering options table to match `core/creative-filters.json`. `accounts` now shows `AccountRef[]` (was `array`), `format_ids` shows `FormatID[]` (was `format_id[]`, matching the casing used in `list_creative_formats`, `get_products`, and `create_media_buy`), and `statuses` links to `CreativeStatus` rather than the under-specified `string[]`. Docs only — no schema or wire-format change.

--- a/docs/creative/task-reference/list_creatives.mdx
+++ b/docs/creative/task-reference/list_creatives.mdx
@@ -55,8 +55,8 @@ The `filters` object supports these optional, composable filters:
 | Filter | Type | Description |
 |--------|------|-------------|
 | `accounts` | [AccountRef](/docs/building/integration/accounts-and-agents#account-references)[] | Filter by owning accounts |
-| `format_ids` | format_id[] | Filter by structured format IDs |
-| `statuses` | string[] | Filter by approval status |
+| `format_ids` | FormatID[] | Filter by structured format IDs |
+| `statuses` | [CreativeStatus](/docs/creative/specification#creative-status-lifecycle)[] | Filter by approval status |
 | `tags` | string[] | Filter by tags (all must match) |
 | `tags_any` | string[] | Filter by tags (any must match) |
 | `name_contains` | string | Case-insensitive name search |

--- a/docs/creative/task-reference/list_creatives.mdx
+++ b/docs/creative/task-reference/list_creatives.mdx
@@ -54,7 +54,7 @@ The `filters` object supports these optional, composable filters:
 
 | Filter | Type | Description |
 |--------|------|-------------|
-| `accounts` | array | Filter by owning accounts |
+| `accounts` | [AccountRef](/docs/building/integration/accounts-and-agents#account-references)[] | Filter by owning accounts |
 | `format_ids` | format_id[] | Filter by structured format IDs |
 | `statuses` | string[] | Filter by approval status |
 | `tags` | string[] | Filter by tags (all must match) |


### PR DESCRIPTION
Closes #4152

The filtering options table for `list_creatives` listed `accounts` as type `array` without documenting what the array items look like. The schema (`core/creative-filters.json`) defines `accounts.items` as `$ref: account-ref.json`, so the correct type is `AccountRef[]`. This fixes the table to match the established pattern already used for the top-level `account` parameter (line 48) and for `[VendorPricingOption](...)[]` (line 186) in the same file.

**Non-breaking justification:** docs-only change — updates a type annotation in an MDX table; no schema, no wire format, no exported type is affected. Existing consumers unaffected.

**Pre-PR review:**
- code-reviewer: approved — no blockers; nits noted (pre-existing `format_ids` / `statuses` type gaps in same table, out of scope for this PR)
- docs-expert: approved — correct schema match, established notation pattern, valid anchor link

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout 4153` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_018xKxQABDeFNP5qqYui2eSs

---
_Generated by [Claude Code](https://claude.ai/code/session_018xKxQABDeFNP5qqYui2eSs)_