### PR TITLE
feat(member-profile): auto-populate primary_brand_domain from verified WorkOS domain

### DIFF
--- a/.changeset/auto-primary-brand-domain-from-workos.md
+++ b/.changeset/auto-primary-brand-domain-from-workos.md
@@ -1,0 +1,4 @@
+---
+---
+
+Auto-populate `member_profiles.primary_brand_domain` from a verified WorkOS email domain when the profile field is null and the domain is claimable. Closes the surprise where SSO members hit "Set your primary brand domain first" on the publish-agent path even though their email domain was the obvious brand identity. Existing brand-claim values are never clobbered. Backfill script `server/scripts/backfill-primary-brand-domain.ts` catches profiles created before this change. Publish-path error message is now actionable instead of terse.

--- a/server/scripts/backfill-primary-brand-domain.ts
+++ b/server/scripts/backfill-primary-brand-domain.ts
@@ -1,0 +1,109 @@
+/**
+ * Backfill `member_profiles.primary_brand_domain` from verified WorkOS domains.
+ *
+ * For each member_profile where `primary_brand_domain IS NULL`, find the org's
+ * verified, claimable WorkOS-sourced domain and set it. Skips ambiguous cases
+ * (multiple verified domains) so an admin can resolve those manually — the
+ * webhook auto-populate (workos-webhooks.ts) handles the single-domain case
+ * going forward; this script catches profiles created before that change
+ * landed.
+ *
+ * Usage:
+ *   npx tsx server/scripts/backfill-primary-brand-domain.ts --dry-run
+ *   npx tsx server/scripts/backfill-primary-brand-domain.ts
+ *
+ * Prerequisites: DATABASE_URL set.
+ */
+
+import { getPool } from '../src/db/client.js';
+import {
+  assertClaimableBrandDomain,
+  canonicalizeBrandDomain,
+} from '../src/services/identifier-normalization.js';
+
+const dryRun = process.argv.includes('--dry-run');
+
+interface Candidate {
+  org_id: string;
+  domains: string[];
+}
+
+async function main(): Promise<void> {
+  const pool = getPool();
+
+  const result = await pool.query<{ workos_organization_id: string; domain: string }>(
+    `SELECT mp.workos_organization_id, od.domain
+       FROM member_profiles mp
+       JOIN organization_domains od ON od.workos_organization_id = mp.workos_organization_id
+      WHERE mp.primary_brand_domain IS NULL
+        AND od.verified = true
+        AND od.source = 'workos'
+      ORDER BY mp.workos_organization_id, od.created_at ASC`,
+  );
+
+  const byOrg = new Map<string, string[]>();
+  for (const row of result.rows) {
+    const arr = byOrg.get(row.workos_organization_id) ?? [];
+    arr.push(row.domain);
+    byOrg.set(row.workos_organization_id, arr);
+  }
+
+  let scanned = 0;
+  let setCount = 0;
+  let skippedNonClaimable = 0;
+  let skippedAmbiguous = 0;
+  const sets: Array<{ org: string; domain: string }> = [];
+  const ambiguous: Candidate[] = [];
+
+  for (const [orgId, domains] of byOrg) {
+    scanned += 1;
+    const claimable = domains.filter((d) => {
+      try {
+        assertClaimableBrandDomain(canonicalizeBrandDomain(d));
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+    if (claimable.length === 0) {
+      skippedNonClaimable += 1;
+      continue;
+    }
+    if (claimable.length > 1) {
+      skippedAmbiguous += 1;
+      ambiguous.push({ org_id: orgId, domains: claimable });
+      continue;
+    }
+
+    const domain = claimable[0];
+    sets.push({ org: orgId, domain });
+
+    if (!dryRun) {
+      await pool.query(
+        `UPDATE member_profiles
+            SET primary_brand_domain = $1, updated_at = NOW()
+          WHERE workos_organization_id = $2
+            AND primary_brand_domain IS NULL`,
+        [domain, orgId]
+      );
+    }
+    setCount += 1;
+  }
+
+  console.log(`Scanned: ${scanned} profiles with NULL primary_brand_domain and ≥1 verified WorkOS domain`);
+  console.log(`Set:     ${setCount}${dryRun ? ' (dry-run)' : ''}`);
+  console.log(`Skipped (non-claimable): ${skippedNonClaimable}`);
+  console.log(`Skipped (ambiguous, ≥2 claimable): ${skippedAmbiguous}`);
+  if (ambiguous.length > 0) {
+    console.log('\nAmbiguous orgs needing manual resolution:');
+    for (const a of ambiguous) console.log(`  ${a.org_id}: ${a.domains.join(', ')}`);
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -820,7 +820,7 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
     actor: { user_id: string; email: string; name?: string }
   ): Promise<
     | { status: 404; body: { error: string } }
-    | { status: 400; body: { error: string } }
+    | { status: 400; body: { error: string; message?: string } }
     | { status: 403; body: { error: string; message: string } }
     | { status: 200; body: Record<string, unknown> }
   > {
@@ -912,7 +912,13 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       if (target === 'public') {
         if (!row.primary_brand_domain) {
           await client.query('ROLLBACK');
-          return { status: 400, body: { error: 'Set your primary brand domain first' } };
+          return {
+            status: 400,
+            body: {
+              error: 'brand_domain_required',
+              message: 'To list an agent publicly, your profile needs a primary brand domain. If you have a verified email domain in your organization (e.g. via SSO), it should auto-populate — otherwise, claim your brand domain in the Brand section of your profile.',
+            },
+          };
         }
         try {
           const parsed = new URL(agent.url);

--- a/server/src/routes/workos-webhooks.ts
+++ b/server/src/routes/workos-webhooks.ts
@@ -75,7 +75,7 @@ interface OrganizationDomainData {
  * WorkOS organization_domain event data
  * This is the full domain object from organization_domain.* events
  */
-interface OrganizationDomainEventData {
+export interface OrganizationDomainEventData {
   id: string;
   domain?: string;
   organization_id: string;
@@ -659,7 +659,7 @@ async function deleteOrganizationDomains(orgId: string): Promise<void> {
  * Upsert a single organization domain from organization_domain.* events
  * Uses transaction to prevent race conditions when setting primary domain
  */
-async function upsertOrganizationDomain(domainData: OrganizationDomainEventData & { domain: string }): Promise<void> {
+export async function upsertOrganizationDomain(domainData: OrganizationDomainEventData & { domain: string }): Promise<void> {
   const pool = getPool();
   const client = await pool.connect();
 
@@ -785,6 +785,32 @@ async function upsertOrganizationDomain(domainData: OrganizationDomainEventData 
           // Don't block the webhook on brand-registry sync errors — webhook
           // idempotency is the whole point. Subsequent events will retry.
           logger.error({ err, orgId: domainData.organization_id, domain: normalizedDomain }, 'Failed to sync verified domain to brand registry');
+        }
+
+        // Auto-populate `member_profiles.primary_brand_domain` when a member
+        // verifies a claimable domain via WorkOS and they haven't already
+        // staked a brand identity. Without this, members who verified a
+        // domain via SSO still hit the publish-agent gate that requires a
+        // primary brand domain — surprising for the common case where their
+        // email domain *is* their brand. Only writes when NULL so an
+        // intentional brand-claim (request_brand_domain_challenge / verify)
+        // pointing at a different domain is never clobbered.
+        try {
+          const updated = await pool.query(
+            `UPDATE member_profiles
+               SET primary_brand_domain = $1, updated_at = NOW()
+             WHERE workos_organization_id = $2
+               AND primary_brand_domain IS NULL`,
+            [normalizedDomain, domainData.organization_id]
+          );
+          if (updated.rowCount && updated.rowCount > 0) {
+            logger.info({
+              orgId: domainData.organization_id,
+              domain: normalizedDomain,
+            }, 'Auto-set primary_brand_domain on member_profile from verified WorkOS domain');
+          }
+        } catch (err) {
+          logger.error({ err, orgId: domainData.organization_id, domain: normalizedDomain }, 'Failed to auto-set primary_brand_domain on member_profile');
         }
       }
     }

--- a/server/tests/integration/workos-domain-auto-primary.test.ts
+++ b/server/tests/integration/workos-domain-auto-primary.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Integration tests for the WorkOS verified-domain → member_profiles
+ * auto-populate path. Verifies that when WorkOS marks a claimable domain
+ * verified, `member_profiles.primary_brand_domain` gets set when null,
+ * and is left alone when an existing brand-claim already pointed elsewhere.
+ *
+ * Driver: Media.net escalation (2026-05-06). Members with WorkOS-verified
+ * email domains were hitting the publish-agent gate that requires
+ * `primary_brand_domain`, even though their email domain was the obvious
+ * brand identity. Auto-populate closes that surprise.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { upsertOrganizationDomain } from '../../src/routes/workos-webhooks.js';
+import type { Pool } from 'pg';
+
+const TEST_ORG = 'org_wkos_brand_primary_test';
+const PROFILE_SLUG = 'wkos-brand-primary-test';
+
+async function cleanup(pool: Pool) {
+  await pool.query('DELETE FROM organization_domains WHERE workos_organization_id = $1', [TEST_ORG]);
+  await pool.query('DELETE FROM member_profiles WHERE workos_organization_id = $1', [TEST_ORG]);
+  await pool.query('DELETE FROM brands WHERE domain LIKE $1', ['wkos-brand-primary-%.test']);
+  await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [TEST_ORG]);
+}
+
+async function seedOrg(pool: Pool) {
+  await pool.query(
+    `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+     VALUES ($1, $2, false, NOW(), NOW())
+     ON CONFLICT (workos_organization_id) DO NOTHING`,
+    [TEST_ORG, 'Auto-Primary Test Co'],
+  );
+}
+
+async function seedProfile(pool: Pool, primaryBrandDomain: string | null) {
+  await pool.query(
+    `INSERT INTO member_profiles (workos_organization_id, slug, display_name, primary_brand_domain, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, NOW(), NOW())
+     ON CONFLICT (workos_organization_id) DO UPDATE
+       SET primary_brand_domain = EXCLUDED.primary_brand_domain, updated_at = NOW()`,
+    [TEST_ORG, PROFILE_SLUG, 'Auto-Primary Test Co', primaryBrandDomain],
+  );
+}
+
+describe('WorkOS verified-domain → member_profiles.primary_brand_domain', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  }, 60000);
+
+  afterAll(async () => {
+    await cleanup(pool);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanup(pool);
+    await seedOrg(pool);
+  });
+
+  it('auto-populates primary_brand_domain when null and the verified domain is claimable', async () => {
+    await seedProfile(pool, null);
+
+    await upsertOrganizationDomain({
+      id: 'od_test_1',
+      organization_id: TEST_ORG,
+      domain: 'wkos-brand-primary-1.test',
+      state: 'verified',
+    });
+
+    const row = await pool.query(
+      `SELECT primary_brand_domain FROM member_profiles WHERE workos_organization_id = $1`,
+      [TEST_ORG],
+    );
+    expect(row.rows[0].primary_brand_domain).toBe('wkos-brand-primary-1.test');
+  });
+
+  it('does NOT clobber an existing primary_brand_domain (intentional brand-claim wins)', async () => {
+    await seedProfile(pool, 'wkos-brand-primary-claimed.test');
+
+    await upsertOrganizationDomain({
+      id: 'od_test_2',
+      organization_id: TEST_ORG,
+      domain: 'wkos-brand-primary-different.test',
+      state: 'verified',
+    });
+
+    const row = await pool.query(
+      `SELECT primary_brand_domain FROM member_profiles WHERE workos_organization_id = $1`,
+      [TEST_ORG],
+    );
+    expect(row.rows[0].primary_brand_domain).toBe('wkos-brand-primary-claimed.test');
+  });
+
+  it('does not crash when no member_profile exists yet (UPDATE is a no-op)', async () => {
+    // No seedProfile — verifies the webhook tolerates the org-without-profile case.
+    await expect(
+      upsertOrganizationDomain({
+        id: 'od_test_3',
+        organization_id: TEST_ORG,
+        domain: 'wkos-brand-primary-noprofile.test',
+        state: 'verified',
+      }),
+    ).resolves.not.toThrow();
+  });
+
+  it('does not auto-populate from a non-claimable domain (e.g. shared platform)', async () => {
+    await seedProfile(pool, null);
+
+    // vercel.app is in SHARED_PLATFORM_DOMAINS — we should never let one
+    // org auto-claim a hosting platform domain as their brand identity.
+    await upsertOrganizationDomain({
+      id: 'od_test_4',
+      organization_id: TEST_ORG,
+      domain: 'vercel.app',
+      state: 'verified',
+    });
+
+    const row = await pool.query(
+      `SELECT primary_brand_domain FROM member_profiles WHERE workos_organization_id = $1`,
+      [TEST_ORG],
+    );
+    expect(row.rows[0].primary_brand_domain).toBeNull();
+  });
+
+  it('does not auto-populate when the domain is pending (not yet verified)', async () => {
+    await seedProfile(pool, null);
+
+    await upsertOrganizationDomain({
+      id: 'od_test_5',
+      organization_id: TEST_ORG,
+      domain: 'wkos-brand-primary-pending.test',
+      state: 'pending',
+    });
+
+    const row = await pool.query(
+      `SELECT primary_brand_domain FROM member_profiles WHERE workos_organization_id = $1`,
+      [TEST_ORG],
+    );
+    expect(row.rows[0].primary_brand_domain).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Auto-set `member_profiles.primary_brand_domain` when WorkOS verifies a claimable email domain on the org and the field is null. Closes the surprise where SSO members hit the publish-agent gate even though their email domain was the obvious brand identity.
- Backfill script for profiles created before this change.
- Improve the terse "Set your primary brand domain first" error to be actionable.

## Driver

Media.net escalation #321 — Warren had `media.net` verified via WorkOS but couldn't publish his sales agent. Root cause: `member_profiles.primary_brand_domain` was null and only the brand-domain-challenge flow (which requires publishing brand.json) ever wrote it. Members reasonably assumed "Verified" was the success state.

The fix mirrors what the WorkOS webhook already does for `organizations.email_domain` (auto-promote on first verified domain) and `brands` (mirror via `markBrandDomainVerified`) — extends the same idea to `member_profiles.primary_brand_domain`. Same gating (`assertClaimableBrandDomain`), so shared-platform domains can't auto-claim.

Existing brand-claim values are never clobbered — only writes when NULL. Cross-org disputes and adopt-vs-fresh manifest decisions still flow through `request_brand_domain_challenge` / `verify_brand_domain_challenge`.

## Out of scope (tracked separately)

- Member-facing Linked Domains UI (members currently can't self-manage domains — only admins can). Stage 2.
- Rationalizing the four overlapping "domain" columns (`organization_domains`, `organizations.email_domain`, `member_profiles.primary_brand_domain`, `brands.domain`). Stage 3 — wants design steer.
- WPP Media drift case (local sub_id with no Stripe-side match) — surfaced during cohort cleanup; different shape.

## Test plan

- [x] New integration test `server/tests/integration/workos-domain-auto-primary.test.ts` covers: claimable single domain → auto-populate, existing value preserved, no profile yet (no-op), shared-platform domain skipped, pending state skipped.
- [x] Existing typecheck + unit tests pass (precommit hook).
- [ ] After merge: run `npx tsx server/scripts/backfill-primary-brand-domain.ts --dry-run` against prod to preview, then without `--dry-run` to apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)