### PR TITLE
fix(addie): route OAuth-required agent failures to authorize flow

### DIFF
--- a/.changeset/route-oauth-required-to-authorize-flow.md
+++ b/.changeset/route-oauth-required-to-authorize-flow.md
@@ -1,0 +1,14 @@
+---
+---
+
+Route OAuth-required agent failures to the click-to-authorize flow instead of `#aao-errors`.
+
+`/api/discover-agent` and Addie's `evaluate_agent_quality`, `recommend_storyboards`,
+`run_storyboard`, and `run_storyboard_step` were treating `AuthenticationRequiredError`
+as a system fault and `logger.error`-ing it, so every probe of an OAuth-only seller
+platform paged the error Slack channel every five minutes.
+
+Now those handlers detect the typed `AuthenticationRequiredError` (and the string forms
+`comply()` returns inside step results), demote the log to `warn`, and surface a
+`[Click here to authorize this agent](…)` link that points at `/api/oauth/agent/start`.
+The shared logic lives in `server/src/routes/helpers/agent-oauth-prompt.ts`.

--- a/server/src/addie/mcp/adcp-tools.ts
+++ b/server/src/addie/mcp/adcp-tools.ts
@@ -20,6 +20,7 @@ import type { AddieTool } from '../types.js';
 import type { MemberContext } from '../member-context.js';
 import { AgentContextDatabase } from '../../db/agent-context-db.js';
 import { AuthenticationRequiredError } from '@adcp/sdk';
+import { buildAgentOAuthAuthorizeUrl } from '../../routes/helpers/agent-oauth-prompt.js';
 import { TRAINING_AGENT_HOSTNAMES } from '../../training-agent/config.js';
 
 // Tool handler type (matches claude-client.ts internal type)
@@ -756,40 +757,14 @@ export function createAdcpToolHandlers(
       // Handle AuthenticationRequiredError from @adcp/sdk (includes OAuth metadata)
       if (error instanceof AuthenticationRequiredError) {
         const organizationId = memberContext?.organization?.workos_organization_id;
-        if (organizationId && error.hasOAuth) {
-          try {
-            // Get or create agent context for OAuth flow
-            const baseUrl = new URL(agentUrl);
-            let agentContext = await agentContextDb.getByOrgAndUrl(organizationId, agentUrl);
-            if (!agentContext) {
-              agentContext = await agentContextDb.create({
-                organization_id: organizationId,
-                agent_url: agentUrl,
-                agent_name: baseUrl.hostname,
-                agent_type: 'unknown',
-                protocol: 'mcp',
-              });
-              logger.info({ agentUrl, agentContextId: agentContext.id }, 'Created agent context for OAuth');
-            }
-
-            // Build auth URL with pending request context for auto-retry
-            // Note: URLSearchParams handles encoding, so don't double-encode
-            // Strip bank details from params before URL serialization — bank data
-            // in URLs leaks to browser history, access logs, and referrer headers.
-            const safeParams = structuredClone(params);
-            for (const key of ['billing_entity', 'invoice_recipient'] as const) {
-              const obj = (safeParams as Record<string, unknown>)[key];
-              if (obj && typeof obj === 'object' && 'bank' in (obj as Record<string, unknown>)) {
-                delete (obj as Record<string, unknown>).bank;
-              }
-            }
-            const authParams = new URLSearchParams({
-              agent_context_id: agentContext.id,
-              pending_task: task,
-              pending_params: JSON.stringify(safeParams),
-            });
-            const authUrl = `${getBaseUrl()}/api/oauth/agent/start?${authParams.toString()}`;
-
+        if (error.hasOAuth) {
+          const authUrl = await buildAgentOAuthAuthorizeUrl(
+            agentUrl,
+            organizationId,
+            agentContextDb,
+            { pendingTask: task, pendingParams: params },
+          );
+          if (authUrl) {
             return (
               `**Task failed:** \`${task}\`\n\n` +
               `**Error:** OAuth authorization required\n\n` +
@@ -797,8 +772,6 @@ export function createAdcpToolHandlers(
               `**[Click here to authorize this agent](${authUrl})**\n\n` +
               `After you authorize, I'll automatically retry your request.`
             );
-          } catch (oauthSetupError) {
-            logger.debug({ error: oauthSetupError, agentUrl }, 'Failed to set up OAuth flow');
           }
         }
 

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -50,8 +50,11 @@ import {
   type StoryboardContext,
   type StoryboardStepResult,
 } from '@adcp/sdk/testing';
+import { AuthenticationRequiredError } from '@adcp/sdk';
 import { renderAllHintFixPlans } from '../services/storyboard-fix-plan.js';
 import { AgentContextDatabase, type OAuthClientCredentials } from '../../db/agent-context-db.js';
+import { buildAgentOAuthAuthorizeUrl, isOAuthRequiredError } from '../../routes/helpers/agent-oauth-prompt.js';
+import { isOAuthRequiredErrorMessage } from '../../routes/helpers/oauth-error-detection.js';
 import {
   findExistingProposalOrFeed,
   createFeedProposal,
@@ -353,12 +356,6 @@ function buildAuthOption(resolved: ResolvedAgentAuth): { type: 'bearer'; token: 
   }
 
   return { type: 'bearer', token: resolved.authToken };
-}
-
-function isAuthError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  const msg = error.message;
-  return msg.includes('401') || msg.includes('Unauthorized') || msg.includes('authentication');
 }
 
 /**
@@ -3523,6 +3520,43 @@ export function createMemberToolHandlers(
     try {
       const result = await comply(resolved.resolvedUrl, complyOptions);
 
+      // Surface OAuth-required short-circuit. comply() doesn't throw on auth
+      // failures — it pushes a `category: 'auth'` observation and runs a
+      // degraded profile (no discovered tools, every track skipped or
+      // failed). Without a click-to-authorize affordance, Addie tells the
+      // user "all tracks failed" instead of "click here to authorize".
+      // Anchor the regex on the SDK's exact phrasing
+      // (`@adcp/sdk/dist/lib/testing/compliance/comply.js:966`) so a hostile
+      // observation can't trigger a misdirected authorize prompt.
+      const oauthObs = result.observations.find(o =>
+        o.category === 'auth' && /^Agent requires OAuth/i.test(o.message),
+      );
+      if (oauthObs) {
+        logger.warn(
+          { agentUrl: resolved.resolvedUrl },
+          'evaluate_agent_quality: agent requires authentication',
+        );
+        const authorizeUrl = await buildAgentOAuthAuthorizeUrl(
+          resolved.resolvedUrl,
+          organizationId,
+          agentContextDb,
+        );
+        if (authorizeUrl) {
+          return (
+            `**OAuth authorization required**\n\n` +
+            `The agent at \`${resolved.resolvedUrl}\` requires OAuth authentication ` +
+            `before quality evaluation can run.\n\n` +
+            `**[Click here to authorize this agent](${authorizeUrl})**\n\n` +
+            `After you authorize, ask me to evaluate it again.`
+          );
+        }
+        return (
+          `**OAuth authorization required**\n\n` +
+          `The agent at \`${resolved.resolvedUrl}\` requires OAuth authentication. ` +
+          `An organization is needed to start the OAuth flow — sign in or create one, then retry.`
+        );
+      }
+
       // Record result if the user has an org with this agent saved
       if (organizationId) {
         try {
@@ -3660,10 +3694,33 @@ export function createMemberToolHandlers(
         );
       }
 
-      logger.error({ error, agentUrl: resolved.resolvedUrl }, 'Addie: evaluate_agent_quality failed');
-      if (msg.includes('401') || msg.includes('Unauthorized') || msg.includes('authentication')) {
+      // Auth-required is an expected agent state, not a system error — don't
+      // page #aao-errors via the pino → posthog hook. Surface a click-to-
+      // authorize prompt when the agent advertises OAuth.
+      if (isOAuthRequiredError(error)) {
+        logger.warn(
+          { agentUrl: resolved.resolvedUrl, hasOAuth: error instanceof AuthenticationRequiredError && error.hasOAuth },
+          'evaluate_agent_quality: agent requires authentication',
+        );
+        if (error instanceof AuthenticationRequiredError && error.hasOAuth) {
+          const authorizeUrl = await buildAgentOAuthAuthorizeUrl(
+            resolved.resolvedUrl,
+            organizationId,
+            agentContextDb,
+          );
+          if (authorizeUrl) {
+            return (
+              `**OAuth authorization required**\n\n` +
+              `The agent at \`${resolved.resolvedUrl}\` requires OAuth authentication.\n\n` +
+              `**[Click here to authorize this agent](${authorizeUrl})**\n\n` +
+              `After you authorize, ask me to evaluate it again.`
+            );
+          }
+        }
         return `Agent at ${resolved.resolvedUrl} requires authentication. Use \`save_agent\` to store credentials first, then try again.`;
       }
+
+      logger.error({ error, agentUrl: resolved.resolvedUrl }, 'Addie: evaluate_agent_quality failed');
       throw new ToolError(`Failed to evaluate agent quality for ${resolved.resolvedUrl}: ${msg}`);
     }
   });
@@ -3689,10 +3746,36 @@ export function createMemberToolHandlers(
         ...(authOption && { auth: authOption }),
       });
       profile = caps.profile;
-    } catch (error) {
-      if (isAuthError(error)) {
+
+      // testCapabilityDiscovery catches its own throws and surfaces them as
+      // step errors / capabilities_probe_error strings — the catch below
+      // only sees programmer errors. Detect OAuth here.
+      const probeOAuth =
+        isOAuthRequiredErrorMessage(profile?.capabilities_probe_error)
+          ? profile?.capabilities_probe_error
+          : caps.steps?.find(s => isOAuthRequiredErrorMessage(s.error))?.error;
+      if (probeOAuth) {
+        logger.warn(
+          { agentUrl: resolved.resolvedUrl },
+          'recommend_storyboards: agent requires authentication',
+        );
+        const authorizeUrl = await buildAgentOAuthAuthorizeUrl(
+          resolved.resolvedUrl,
+          organizationId,
+          agentContextDb,
+        );
+        if (authorizeUrl) {
+          return (
+            `**OAuth authorization required**\n\n` +
+            `The agent at \`${resolved.resolvedUrl}\` requires OAuth authentication ` +
+            `before I can recommend storyboards.\n\n` +
+            `**[Click here to authorize this agent](${authorizeUrl})**\n\n` +
+            `After you authorize, ask me again.`
+          );
+        }
         return `Agent at ${resolved.resolvedUrl} requires authentication. Use \`save_agent\` to store credentials first, then try again.`;
       }
+    } catch (error) {
       logger.warn({ err: error, agentUrl: resolved.resolvedUrl }, 'recommend_storyboards: capability probe failed');
       const reason = classifyProbeError(error);
       throw new ToolError(`Could not reach agent at ${resolved.resolvedUrl} (${probeReasonLabel(reason)}).`);
@@ -3941,6 +4024,34 @@ export function createMemberToolHandlers(
         ...(authOption && { auth: authOption }),
       });
 
+      // runStoryboard catches its own throws and surfaces them as step
+      // errors. Detect OAuth on the first failing step before rendering a
+      // long failure report the user can't act on.
+      const oauthStepError = result.phases
+        .flatMap(p => p.steps)
+        .find(s => isOAuthRequiredErrorMessage(s.error))?.error;
+      if (oauthStepError) {
+        logger.warn(
+          { agentUrl: resolved.resolvedUrl, storyboardId },
+          'run_storyboard: agent requires authentication',
+        );
+        const authorizeUrl = await buildAgentOAuthAuthorizeUrl(
+          resolved.resolvedUrl,
+          organizationId,
+          agentContextDb,
+        );
+        if (authorizeUrl) {
+          return (
+            `**OAuth authorization required**\n\n` +
+            `The agent at \`${resolved.resolvedUrl}\` requires OAuth authentication ` +
+            `before I can run storyboard \`${storyboardId}\`.\n\n` +
+            `**[Click here to authorize this agent](${authorizeUrl})**\n\n` +
+            `After you authorize, ask me to run it again.`
+          );
+        }
+        return `Agent at ${resolved.resolvedUrl} requires authentication. Use \`save_agent\` to store credentials first, then try again.`;
+      }
+
       // Record the run in agent_test_history when we have a saved
       // agent_context for this org+url. Mirrors evaluate_agent_quality's
       // pattern; powers the "agent not tested in 14d" prompt rule.
@@ -4042,9 +4153,6 @@ export function createMemberToolHandlers(
       return output;
     } catch (error) {
       logger.error({ error, agentUrl: resolved.resolvedUrl, storyboardId }, 'Addie: run_storyboard failed');
-      if (isAuthError(error)) {
-        return `Agent at ${resolved.resolvedUrl} requires authentication. Use \`save_agent\` to store credentials first, then try again.`;
-      }
       const msg = error instanceof Error ? error.message : 'Unknown error';
       throw new ToolError(`Failed to run storyboard ${storyboardId}: ${msg}`);
     }
@@ -4100,6 +4208,29 @@ export function createMemberToolHandlers(
         context,
         ...(authOption && { auth: authOption }),
       });
+
+      // runStoryboardStep catches its own throws and surfaces them as
+      // result.error strings. Detect OAuth before rendering.
+      if (isOAuthRequiredErrorMessage(result.error)) {
+        logger.warn(
+          { agentUrl: resolved.resolvedUrl, storyboardId, stepId },
+          'run_storyboard_step: agent requires authentication',
+        );
+        const authorizeUrl = await buildAgentOAuthAuthorizeUrl(
+          resolved.resolvedUrl,
+          organizationId,
+          agentContextDb,
+        );
+        if (authorizeUrl) {
+          return (
+            `**OAuth authorization required**\n\n` +
+            `The agent at \`${resolved.resolvedUrl}\` requires OAuth authentication.\n\n` +
+            `**[Click here to authorize this agent](${authorizeUrl})**\n\n` +
+            `After you authorize, ask me to run the step again.`
+          );
+        }
+        return `Agent at ${resolved.resolvedUrl} requires authentication. Use \`save_agent\` to store credentials first, then try again.`;
+      }
 
       let output = '';
       if (resolved.source === 'saved') output += '_Using saved credentials._\n\n';
@@ -4165,9 +4296,6 @@ export function createMemberToolHandlers(
       return output;
     } catch (error) {
       logger.error({ error, agentUrl: resolved.resolvedUrl, storyboardId, stepId }, 'Addie: run_storyboard_step failed');
-      if (isAuthError(error)) {
-        return `Agent at ${resolved.resolvedUrl} requires authentication. Use \`save_agent\` to store credentials first, then try again.`;
-      }
       const msg = error instanceof Error ? error.message : 'Unknown error';
       // Return step-not-found as a message so the AI can self-correct with valid step IDs
       if (msg.includes('not found in storyboard')) {

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -24,7 +24,7 @@ import { PropertiesService } from "./properties.js";
 import { AdAgentsManager } from "./adagents-manager.js";
 import { mountSchemasRoutes, mountComplianceRoutes, mountProtocolRoutes } from "./schemas-middleware.js";
 import { closeDatabase, getPool, healthCheck } from "./db/client.js";
-import { CreativeAgentClient, SingleAgentClient } from "@adcp/sdk";
+import { AuthenticationRequiredError, CreativeAgentClient, SingleAgentClient } from "@adcp/sdk";
 import type { Agent, AgentType, AgentWithStats, Company } from "./types.js";
 import { isValidAgentType, VALID_MEMBER_OFFERINGS, VALID_LEGAL_DOCUMENT_TYPES } from "./types.js";
 import type { Server } from "http";
@@ -140,6 +140,9 @@ import { BansDatabase } from "./db/bans-db.js";
 import { registryRequestsDb } from "./db/registry-requests-db.js";
 import { notifyRegistryEdit, notifyRegistryCreate, notifyRegistryRollback, notifyRegistryBan } from "./notifications/registry.js";
 import { reviewNewRecord, reviewRegistryEdit } from "./addie/mcp/registry-review.js";
+import { AgentContextDatabase } from "./db/agent-context-db.js";
+import { getWebMemberContext } from "./addie/member-context.js";
+import { buildAgentOAuthAuthorizeUrl } from "./routes/helpers/agent-oauth-prompt.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -8721,6 +8724,43 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
           stats,
         });
       } catch (error) {
+        // Auth-required is an expected agent state, not a system error. Log
+        // at warn so it doesn't page #aao-errors via the pino → posthog hook.
+        if (error instanceof AuthenticationRequiredError) {
+          logger.warn({ url, hasOAuth: error.hasOAuth }, 'Agent requires authentication');
+
+          let oauth_authorize_url: string | undefined;
+          if (error.hasOAuth) {
+            const userId = req.user?.id;
+            if (userId) {
+              try {
+                const memberContext = await getWebMemberContext(userId);
+                const orgId = memberContext?.organization?.workos_organization_id;
+                if (orgId) {
+                  const authorizeUrl = await buildAgentOAuthAuthorizeUrl(
+                    url,
+                    orgId,
+                    new AgentContextDatabase(),
+                    { returnTo: '/profile/edit' },
+                  );
+                  if (authorizeUrl) oauth_authorize_url = authorizeUrl;
+                }
+              } catch (memberCtxErr) {
+                logger.debug({ err: memberCtxErr, url }, 'Failed to build OAuth authorize URL');
+              }
+            }
+          }
+
+          return res.status(401).json({
+            error: 'authentication_required',
+            message: error.hasOAuth
+              ? 'This agent requires OAuth authorization.'
+              : 'This agent requires authentication. Save an auth token to continue.',
+            needs_oauth: error.hasOAuth,
+            ...(oauth_authorize_url && { oauth_authorize_url }),
+          });
+        }
+
         logger.error({ err: error, url }, 'Agent discovery error');
 
         if (error instanceof Error && error.name === 'TimeoutError') {

--- a/server/src/routes/helpers/agent-oauth-prompt.ts
+++ b/server/src/routes/helpers/agent-oauth-prompt.ts
@@ -1,0 +1,96 @@
+import { AuthenticationRequiredError } from '@adcp/sdk';
+import type { AgentContextDatabase } from '../../db/agent-context-db.js';
+import { isOAuthRequiredErrorMessage } from './oauth-error-detection.js';
+import { createLogger } from '../../logger.js';
+
+const logger = createLogger('agent-oauth-prompt');
+
+function getBaseUrl(): string {
+  if (process.env.BASE_URL) return process.env.BASE_URL;
+  const port = process.env.PORT || process.env.CONDUCTOR_PORT || '3000';
+  return `http://localhost:${port}`;
+}
+
+export interface OAuthPromptOptions {
+  /** AdCP task name for auto-retry after authorization (e.g. 'get_products'). */
+  pendingTask?: string;
+  /** AdCP task params for auto-retry after authorization. */
+  pendingParams?: Record<string, unknown>;
+  /** Where to land the user after a successful authorization. */
+  returnTo?: string;
+}
+
+/**
+ * Build the `/api/oauth/agent/start` URL for an agent that demands OAuth.
+ * Creates the `agent_contexts` row when one doesn't exist.
+ *
+ * Returns null when the caller can't initiate a flow (no organization, or
+ * the agent_contexts setup failed). The caller should fall back to a plain
+ * "auth required" message in that case.
+ */
+export async function buildAgentOAuthAuthorizeUrl(
+  agentUrl: string,
+  organizationId: string | undefined,
+  agentContextDb: AgentContextDatabase,
+  options: OAuthPromptOptions = {},
+): Promise<string | null> {
+  if (!organizationId) return null;
+  try {
+    const parsed = new URL(agentUrl);
+    let agentContext = await agentContextDb.getByOrgAndUrl(organizationId, agentUrl);
+    if (!agentContext) {
+      agentContext = await agentContextDb.create({
+        organization_id: organizationId,
+        agent_url: agentUrl,
+        agent_name: parsed.hostname,
+        agent_type: 'unknown',
+        protocol: 'mcp',
+      });
+      logger.info({ agentUrl, agentContextId: agentContext.id }, 'Created agent context for OAuth');
+    }
+
+    const params = new URLSearchParams({ agent_context_id: agentContext.id });
+    if (options.pendingTask) {
+      params.set('pending_task', options.pendingTask);
+      // PII in this URL leaks to browser history, the IdP referer, and any
+      // HTTP access log between the user's browser and our redirect target.
+      // AdCP's `BusinessEntity` carries tax_id, vat_id, registration_number,
+      // and contacts on the entity itself (not nested under `.bank`), so
+      // drop the whole `billing_entity` and `invoice_recipient` objects
+      // rather than blacklisting individual fields. The post-OAuth replay
+      // path can re-fetch these from server-side state when needed.
+      const safe = options.pendingParams ? structuredClone(options.pendingParams) : {};
+      delete (safe as Record<string, unknown>).billing_entity;
+      delete (safe as Record<string, unknown>).invoice_recipient;
+      params.set('pending_params', JSON.stringify(safe));
+    }
+    if (options.returnTo) {
+      params.set('return_to', options.returnTo);
+    }
+
+    return `${getBaseUrl()}/api/oauth/agent/start?${params.toString()}`;
+  } catch (error) {
+    logger.debug({ error, agentUrl }, 'Failed to build OAuth authorize URL');
+    return null;
+  }
+}
+
+/**
+ * Recognize "this agent demands OAuth" across the shapes the SDK exposes:
+ * - Typed `AuthenticationRequiredError` (which `NeedsAuthorizationError`
+ *   extends). Reliable when `@adcp/sdk` is a single copy in the dep graph
+ *   — verified via `npm ls @adcp/sdk --all`. Multiple copies would break
+ *   `instanceof`, which is why the regex fallback below exists.
+ * - `Error.message` matching the SDK's "requires OAuth authorization"
+ *   phrasing or an `AUTH_REQUIRED` payload code. The testing-SDK surfaces
+ *   (`comply()`, `runStoryboard()`, `runStoryboardStep()`,
+ *   `testCapabilityDiscovery()`) catch their own errors inside `runStep`
+ *   and preserve only `err.message` on the step result, so callers reading
+ *   step errors only ever see strings.
+ */
+export function isOAuthRequiredError(error: unknown): boolean {
+  if (error instanceof AuthenticationRequiredError) return true;
+  if (error instanceof Error) return isOAuthRequiredErrorMessage(error.message);
+  if (typeof error === 'string') return isOAuthRequiredErrorMessage(error);
+  return false;
+}

--- a/server/tests/unit/agent-oauth-prompt.test.ts
+++ b/server/tests/unit/agent-oauth-prompt.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import { AuthenticationRequiredError } from '@adcp/sdk';
+import {
+  buildAgentOAuthAuthorizeUrl,
+  isOAuthRequiredError,
+} from '../../src/routes/helpers/agent-oauth-prompt.js';
+import type { AgentContextDatabase } from '../../src/db/agent-context-db.js';
+
+type StubbedDb = Pick<AgentContextDatabase, 'getByOrgAndUrl' | 'create'>;
+
+function makeDb(): { [K in keyof StubbedDb]: ReturnType<typeof vi.fn> } {
+  return {
+    getByOrgAndUrl: vi.fn(),
+    create: vi.fn(),
+  };
+}
+
+const ORG = 'org_abc';
+const AGENT = 'https://seller-platform.example.com/mcp';
+
+describe('buildAgentOAuthAuthorizeUrl', () => {
+  let db: ReturnType<typeof makeDb>;
+  const ORIGINAL_BASE_URL = process.env.BASE_URL;
+
+  beforeEach(() => {
+    db = makeDb();
+    process.env.BASE_URL = 'https://aao.example.org';
+  });
+
+  afterAll(() => {
+    if (ORIGINAL_BASE_URL === undefined) delete process.env.BASE_URL;
+    else process.env.BASE_URL = ORIGINAL_BASE_URL;
+  });
+
+  const call = (organizationId: string | undefined, options?: Parameters<typeof buildAgentOAuthAuthorizeUrl>[3]) =>
+    buildAgentOAuthAuthorizeUrl(AGENT, organizationId, db as unknown as AgentContextDatabase, options);
+
+  it('returns null when there is no organization to scope the agent context to', async () => {
+    expect(await call(undefined)).toBeNull();
+    expect(db.getByOrgAndUrl).not.toHaveBeenCalled();
+    expect(db.create).not.toHaveBeenCalled();
+  });
+
+  it('reuses an existing agent context row', async () => {
+    db.getByOrgAndUrl.mockResolvedValueOnce({ id: 'ctx_existing' });
+
+    const url = await call(ORG);
+
+    expect(url).toBe('https://aao.example.org/api/oauth/agent/start?agent_context_id=ctx_existing');
+    expect(db.create).not.toHaveBeenCalled();
+  });
+
+  it('creates a new agent context when none exists', async () => {
+    db.getByOrgAndUrl.mockResolvedValueOnce(null);
+    db.create.mockResolvedValueOnce({ id: 'ctx_new' });
+
+    const url = await call(ORG);
+
+    expect(db.create).toHaveBeenCalledWith({
+      organization_id: ORG,
+      agent_url: AGENT,
+      agent_name: 'seller-platform.example.com',
+      agent_type: 'unknown',
+      protocol: 'mcp',
+    });
+    expect(url).toBe('https://aao.example.org/api/oauth/agent/start?agent_context_id=ctx_new');
+  });
+
+  it('threads pending_task and pending_params for auto-retry', async () => {
+    db.getByOrgAndUrl.mockResolvedValueOnce({ id: 'ctx1' });
+
+    const url = await call(ORG, {
+      pendingTask: 'get_products',
+      pendingParams: { brief: 'q4 holiday' },
+    });
+
+    expect(url).not.toBeNull();
+    const parsed = new URL(url!);
+    expect(parsed.searchParams.get('pending_task')).toBe('get_products');
+    expect(parsed.searchParams.get('pending_params')).toBe(JSON.stringify({ brief: 'q4 holiday' }));
+  });
+
+  it('drops billing_entity and invoice_recipient from pending_params before serializing into the URL', async () => {
+    db.getByOrgAndUrl.mockResolvedValueOnce({ id: 'ctx1' });
+
+    const url = await call(ORG, {
+      pendingTask: 'create_media_buy',
+      pendingParams: {
+        brief: 'campaign',
+        billing_entity: {
+          name: 'Acme Inc',
+          tax_id: 'SECRET-TAX',
+          vat_id: 'SECRET-VAT',
+          bank: { iban: 'SECRET-IBAN' },
+        },
+        invoice_recipient: {
+          email: 'ap@acme.com',
+          bank: { account: 'SECRET-ACCT' },
+        },
+      },
+    });
+
+    const parsed = new URL(url!);
+    const sentParams = JSON.parse(parsed.searchParams.get('pending_params')!);
+    expect(sentParams).toEqual({ brief: 'campaign' });
+    expect(JSON.stringify(sentParams)).not.toMatch(/SECRET/);
+  });
+
+  it('passes return_to through verbatim', async () => {
+    db.getByOrgAndUrl.mockResolvedValueOnce({ id: 'ctx1' });
+
+    const url = await call(ORG, { returnTo: '/profile/edit' });
+
+    expect(new URL(url!).searchParams.get('return_to')).toBe('/profile/edit');
+  });
+
+  it('returns null when context creation fails', async () => {
+    db.getByOrgAndUrl.mockResolvedValueOnce(null);
+    db.create.mockRejectedValueOnce(new Error('db down'));
+
+    expect(await call(ORG)).toBeNull();
+  });
+});
+
+describe('isOAuthRequiredError', () => {
+  it('matches AuthenticationRequiredError', () => {
+    const err = new AuthenticationRequiredError(AGENT, undefined, 'requires auth');
+    expect(isOAuthRequiredError(err)).toBe(true);
+  });
+
+  it('matches an Error whose message carries the SDK OAuth phrasing', () => {
+    const err = new Error(`Agent ${AGENT} requires OAuth authorization. Provide an OAuthFlowHandler.`);
+    expect(isOAuthRequiredError(err)).toBe(true);
+  });
+
+  it('matches an AUTH_REQUIRED protocol error string', () => {
+    expect(isOAuthRequiredError('AUTH_REQUIRED: please reauthorize')).toBe(true);
+  });
+
+  it('does not match a transport-level connection failure', () => {
+    expect(isOAuthRequiredError(new Error('Failed to discover MCP endpoint'))).toBe(false);
+    expect(isOAuthRequiredError('ETIMEDOUT')).toBe(false);
+  });
+
+  it('handles null/undefined safely', () => {
+    expect(isOAuthRequiredError(null)).toBe(false);
+    expect(isOAuthRequiredError(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- `/api/discover-agent` and four Addie tools (`evaluate_agent_quality`, `recommend_storyboards`, `run_storyboard`, `run_storyboard_step`) were treating `AuthenticationRequiredError` as a system fault and `logger.error`-ing it. The pino → posthog hook (`server/src/utils/posthog.ts:204`) forwards `error+` to `notifySystemError`, so every probe of an OAuth-only seller platform paged `#aao-errors` every five minutes.
- The `/api/oauth/agent/start` flow (`server/src/routes/agent-oauth.ts`) was already wired (RFC 8707 resource indicator, PKCE, dynamic registration, return-to-task auto-retry). `adcp-tools.ts run_adcp_task` already routed users into it via a click-to-authorize markdown link. The other callers didn't.
- New shared helper `server/src/routes/helpers/agent-oauth-prompt.ts` builds the authorize URL (creates the `agent_contexts` row when missing) and detects OAuth-required across both the typed `AuthenticationRequiredError` and the string forms the testing SDK leaves on step results — `testCapabilityDiscovery`, `runStoryboard`, and `runStoryboardStep` swallow throws inside `runStep` and surface only `err.message`. This was caught in expert review and adds detection on `caps.profile.capabilities_probe_error`, step-error scans across `result.phases`, and `result.error` respectively.
- `pending_params` strip now drops the entire `billing_entity` / `invoice_recipient` objects rather than only their `.bank` sub-objects, since AdCP's `BusinessEntity` carries `tax_id`, `vat_id`, `registration_number`, and contacts on the entity itself.
- `adcp-tools.ts run_adcp_task` refactored to consume the shared helper for consistency.
- OAuth-required is now logged at `warn` per the three-tier convention in `server/src/logger.ts:200-229` (expected user-actionable state, no Slack alert).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] New unit tests `server/tests/unit/agent-oauth-prompt.test.ts` — 12 tests including PII-stripping (`tax_id`, `vat_id`, bank fields all dropped from `pending_params`).
- [x] `oauth-error-detection.test.ts`, `conformance-run-storyboard.test.ts`, `resolve-user-agent-auth.test.ts` still pass.
- [x] Pre-commit hooks (unit suite, dynamic-imports, callApi state, typecheck) green.
- [ ] CI green.
- [ ] Smoke once deployed: `/api/discover-agent?url=<oauth-only agent>` returns 401 with `oauth_authorize_url` instead of 500, and `#aao-errors` stops getting `🚨 System error: http-server` posts about OAuth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)