### PR TITLE
fix(member-profile): make backfill script prod-runnable + dry-run default

### DIFF
--- a/.changeset/backfill-script-prod-runnable.md
+++ b/.changeset/backfill-script-prod-runnable.md
@@ -1,0 +1,4 @@
+---
+---
+
+Move `backfill-primary-brand-domain.ts` to `server/src/scripts/` so it ships in `dist/scripts/` and is runnable on prod via `fly ssh`. Default to dry-run (require explicit `--apply` to write). Add a personal-org test pinning that brand-identity auto-populate is intentionally not gated on `is_personal`.

--- a/server/src/scripts/backfill-primary-brand-domain.ts
+++ b/server/src/scripts/backfill-primary-brand-domain.ts
@@ -8,20 +8,27 @@
  * going forward; this script catches profiles created before that change
  * landed.
  *
- * Usage:
- *   npx tsx server/scripts/backfill-primary-brand-domain.ts --dry-run
- *   npx tsx server/scripts/backfill-primary-brand-domain.ts
+ * Usage (dev):
+ *   npx tsx server/src/scripts/backfill-primary-brand-domain.ts            # dry-run
+ *   npx tsx server/src/scripts/backfill-primary-brand-domain.ts --apply    # write
+ *
+ * Usage (prod, via fly ssh):
+ *   fly ssh console -a adcp-docs -C 'node /app/dist/scripts/backfill-primary-brand-domain.js'           # dry-run
+ *   fly ssh console -a adcp-docs -C 'node /app/dist/scripts/backfill-primary-brand-domain.js --apply'   # write
  *
  * Prerequisites: DATABASE_URL set.
  */
 
-import { getPool } from '../src/db/client.js';
+import { getPool } from '../db/client.js';
 import {
   assertClaimableBrandDomain,
   canonicalizeBrandDomain,
-} from '../src/services/identifier-normalization.js';
+} from '../services/identifier-normalization.js';
 
-const dryRun = process.argv.includes('--dry-run');
+// Default to dry-run; require explicit `--apply` to write. Cheap insurance
+// against an operator running the script while wired to the wrong DATABASE_URL.
+const apply = process.argv.includes('--apply');
+const dryRun = !apply;
 
 interface Candidate {
   org_id: string;
@@ -91,8 +98,9 @@ async function main(): Promise<void> {
     setCount += 1;
   }
 
+  console.log(`Mode:    ${dryRun ? 'DRY-RUN (use --apply to write)' : 'APPLY (writing changes)'}`);
   console.log(`Scanned: ${scanned} profiles with NULL primary_brand_domain and ≥1 verified WorkOS domain`);
-  console.log(`Set:     ${setCount}${dryRun ? ' (dry-run)' : ''}`);
+  console.log(`Set:     ${setCount}${dryRun ? ' (would set)' : ''}`);
   console.log(`Skipped (non-claimable): ${skippedNonClaimable}`);
   console.log(`Skipped (ambiguous, ≥2 claimable): ${skippedAmbiguous}`);
   if (ambiguous.length > 0) {

--- a/server/tests/integration/workos-domain-auto-primary.test.ts
+++ b/server/tests/integration/workos-domain-auto-primary.test.ts
@@ -130,6 +130,35 @@ describe('WorkOS verified-domain → member_profiles.primary_brand_domain', () =
     expect(row.rows[0].primary_brand_domain).toBeNull();
   });
 
+  it('still auto-populates for a personal org (brand identity ≠ org-membership inference)', async () => {
+    // Pin the explicit decision: a personal-tier user verifying a domain
+    // SHOULD get primary_brand_domain set on their profile. The
+    // squeeze-prevention concern (which gates is_primary on
+    // organization_domains for personal orgs) is about org-membership
+    // inference, not brand identity. An Individual Professional CAN own
+    // and verify a brand — that's the entire purpose of the tier. If
+    // someone later adds `if (isPersonal) return` to the auto-populate
+    // path, this test fails and they have to revisit the rationale.
+    await pool.query(
+      `UPDATE organizations SET is_personal = true WHERE workos_organization_id = $1`,
+      [TEST_ORG],
+    );
+    await seedProfile(pool, null);
+
+    await upsertOrganizationDomain({
+      id: 'od_test_personal',
+      organization_id: TEST_ORG,
+      domain: 'wkos-brand-primary-personal.test',
+      state: 'verified',
+    });
+
+    const row = await pool.query(
+      `SELECT primary_brand_domain FROM member_profiles WHERE workos_organization_id = $1`,
+      [TEST_ORG],
+    );
+    expect(row.rows[0].primary_brand_domain).toBe('wkos-brand-primary-personal.test');
+  });
+
   it('does not auto-populate when the domain is pending (not yet verified)', async () => {
     await seedProfile(pool, null);
 


### PR DESCRIPTION
## Summary

Three small fixes to the backfill script from #4157:

- **Move to `server/src/scripts/`** — the prior `server/scripts/` path was excluded from `server/tsconfig.json`'s include glob, so the script never compiled into `dist/` and was unreachable on prod. Confirmed via `fly ssh` (got `ERR_MODULE_NOT_FOUND`). All other prod-runnable backfills live under `server/src/scripts/`.
- **Default to dry-run** (require explicit `--apply` to write). Security review nit; cheap insurance against operator wiring to the wrong DATABASE_URL.
- **Personal-org test** — pins the explicit decision that brand-identity auto-populate is NOT gated on `is_personal`. Code review nit; future change that adds `if (isPersonal) return` will fail this test and have to revisit the rationale.

## Test plan

- [x] Local integration suite passes (6 tests)
- [x] Typecheck clean
- [ ] After merge: deploy lands `dist/scripts/backfill-primary-brand-domain.js` on prod; run via `fly ssh console -a adcp-docs -C 'node /app/dist/scripts/backfill-primary-brand-domain.js'` for dry-run, then `--apply` to write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)