### PR TITLE
fix(addie): extend OAuth prompt to buyer-tool handlers; fix retry copy

### DIFF
--- a/.changeset/oauth-prompt-extend-to-buyer-tools-and-correct-retry-copy.md
+++ b/.changeset/oauth-prompt-extend-to-buyer-tools-and-correct-retry-copy.md
@@ -1,0 +1,15 @@
+---
+---
+
+Extend the click-to-authorize prompt to the three remaining buyer-tool handlers
+(`compare_media_kit`, `test_rfp_response`, `test_io_execution`) so an OAuth-only
+seller agent stops paging `#aao-errors`. Same pattern as #4160 — detect the
+typed `AuthenticationRequiredError` (or its string form on per-brief
+Promise.all results), demote the log to `warn`, and surface a
+`/api/oauth/agent/start` link.
+
+Also corrects misleading copy in `run_adcp_task`'s OAuth prompt: the OAuth
+callback (`agent-oauth.ts:444-457`) saves tokens and redirects but never replays
+`pendingRequest`, so the previous "After you authorize, I'll automatically retry
+your request" was a lie. Now reads "After you authorize, ask me to run `<task>`
+again." matches the four sibling handlers.

--- a/server/src/addie/mcp/adcp-tools.ts
+++ b/server/src/addie/mcp/adcp-tools.ts
@@ -770,7 +770,7 @@ export function createAdcpToolHandlers(
               `**Error:** OAuth authorization required\n\n` +
               `The agent at \`${agentUrl}\` requires OAuth authentication.\n\n` +
               `**[Click here to authorize this agent](${authUrl})**\n\n` +
-              `After you authorize, I'll automatically retry your request.`
+              `After you authorize, ask me to run \`${task}\` again.`
             );
           }
         }

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -4445,6 +4445,32 @@ export function createMemberToolHandlers(
         }
       }));
 
+      // OAuth on the agent makes every brief fail identically. Short-circuit
+      // before rendering an N-brief failure report the user can't act on.
+      // Inner per-brief catch swallows the throw and stashes err.message —
+      // string detection is how we recognize it post-Promise.all.
+      if (briefResults.length > 0 && briefResults.every(r => isOAuthRequiredErrorMessage(r.error))) {
+        logger.warn(
+          { agentUrl: resolved.resolvedUrl },
+          'compare_media_kit: agent requires authentication',
+        );
+        const authorizeUrl = await buildAgentOAuthAuthorizeUrl(
+          resolved.resolvedUrl,
+          organizationId,
+          agentContextDb,
+        );
+        if (authorizeUrl) {
+          return (
+            `**OAuth authorization required**\n\n` +
+            `The agent at \`${resolved.resolvedUrl}\` requires OAuth authentication ` +
+            `before I can compare its products against the media kit.\n\n` +
+            `**[Click here to authorize this agent](${authorizeUrl})**\n\n` +
+            `After you authorize, ask me to try again.`
+          );
+        }
+        return `Agent at ${resolved.resolvedUrl} requires authentication. Use \`save_agent\` to store credentials first, then try again.`;
+      }
+
       // Aggregate across all briefs
       const allChannelsFound = new Set<string>();
       const allFormatsFound = new Set<string>();
@@ -4519,11 +4545,31 @@ export function createMemberToolHandlers(
 
       return output;
     } catch (error) {
-      logger.error({ error, agentUrl: resolved.resolvedUrl }, 'Addie: compare_media_kit failed');
-      const msg = error instanceof Error ? error.message : 'Unknown error';
-      if (msg.includes('401') || msg.includes('Unauthorized') || msg.includes('authentication')) {
+      if (isOAuthRequiredError(error)) {
+        logger.warn(
+          { agentUrl: resolved.resolvedUrl, hasOAuth: error instanceof AuthenticationRequiredError && error.hasOAuth },
+          'compare_media_kit: agent requires authentication',
+        );
+        if (error instanceof AuthenticationRequiredError && error.hasOAuth) {
+          const authorizeUrl = await buildAgentOAuthAuthorizeUrl(
+            resolved.resolvedUrl,
+            organizationId,
+            agentContextDb,
+          );
+          if (authorizeUrl) {
+            return (
+              `**OAuth authorization required**\n\n` +
+              `The agent at \`${resolved.resolvedUrl}\` requires OAuth authentication ` +
+              `before I can compare its products against the media kit.\n\n` +
+              `**[Click here to authorize this agent](${authorizeUrl})**\n\n` +
+              `After you authorize, ask me to try again.`
+            );
+          }
+        }
         return `Agent at ${resolved.resolvedUrl} requires authentication. Use \`save_agent\` to store credentials first, then try again.`;
       }
+      logger.error({ error, agentUrl: resolved.resolvedUrl }, 'Addie: compare_media_kit failed');
+      const msg = error instanceof Error ? error.message : 'Unknown error';
       throw new ToolError(`Failed to compare media kit for ${resolved.resolvedUrl}: ${msg}`);
     }
   });
@@ -4747,11 +4793,31 @@ export function createMemberToolHandlers(
 
       return output;
     } catch (error) {
-      logger.error({ error, agentUrl }, 'Addie: test_rfp_response failed');
-      const msg = (error instanceof Error ? error.message : 'Unknown error').slice(0, 500);
-      if (msg.includes('401') || msg.includes('Unauthorized') || msg.includes('authentication')) {
+      if (isOAuthRequiredError(error)) {
+        logger.warn(
+          { agentUrl, hasOAuth: error instanceof AuthenticationRequiredError && error.hasOAuth },
+          'test_rfp_response: agent requires authentication',
+        );
+        if (error instanceof AuthenticationRequiredError && error.hasOAuth) {
+          const authorizeUrl = await buildAgentOAuthAuthorizeUrl(
+            resolved.resolvedUrl,
+            organizationId,
+            agentContextDb,
+          );
+          if (authorizeUrl) {
+            return (
+              `**OAuth authorization required**\n\n` +
+              `The agent at \`${resolved.resolvedUrl}\` requires OAuth authentication ` +
+              `before I can test the RFP response.\n\n` +
+              `**[Click here to authorize this agent](${authorizeUrl})**\n\n` +
+              `After you authorize, ask me to try again.`
+            );
+          }
+        }
         return `Agent at ${agentUrl} requires authentication. Use \`save_agent\` to store credentials first, then try again.`;
       }
+      logger.error({ error, agentUrl }, 'Addie: test_rfp_response failed');
+      const msg = (error instanceof Error ? error.message : 'Unknown error').slice(0, 500);
       throw new ToolError(`Failed to test RFP response for ${agentUrl}: <external_error>${msg}</external_error>`);
     }
   });
@@ -5126,11 +5192,31 @@ export function createMemberToolHandlers(
 
       return output;
     } catch (error) {
-      logger.error({ error, agentUrl }, 'Addie: test_io_execution failed');
-      const msg = (error instanceof Error ? error.message : 'Unknown error').slice(0, 500);
-      if (msg.includes('401') || msg.includes('Unauthorized') || msg.includes('authentication')) {
+      if (isOAuthRequiredError(error)) {
+        logger.warn(
+          { agentUrl, hasOAuth: error instanceof AuthenticationRequiredError && error.hasOAuth },
+          'test_io_execution: agent requires authentication',
+        );
+        if (error instanceof AuthenticationRequiredError && error.hasOAuth) {
+          const authorizeUrl = await buildAgentOAuthAuthorizeUrl(
+            resolved.resolvedUrl,
+            organizationId,
+            agentContextDb,
+          );
+          if (authorizeUrl) {
+            return (
+              `**OAuth authorization required**\n\n` +
+              `The agent at \`${resolved.resolvedUrl}\` requires OAuth authentication ` +
+              `before I can test the IO execution.\n\n` +
+              `**[Click here to authorize this agent](${authorizeUrl})**\n\n` +
+              `After you authorize, ask me to try again.`
+            );
+          }
+        }
         return `Agent at ${agentUrl} requires authentication. Use \`save_agent\` to store credentials first, then try again.`;
       }
+      logger.error({ error, agentUrl }, 'Addie: test_io_execution failed');
+      const msg = (error instanceof Error ? error.message : 'Unknown error').slice(0, 500);
       throw new ToolError(`Failed to test IO execution for ${agentUrl}: <external_error>${msg}</external_error>`);
     }
   });


### PR DESCRIPTION
## Summary

Follow-up to #4160. Three more handlers had the same `logger.error`-then-bubble pattern that paged `#aao-errors` for OAuth-required agents:

- `compare_media_kit` (`member-tools.ts:4520`)
- `test_rfp_response` (`member-tools.ts:4750`)
- `test_io_execution` (`member-tools.ts:5197`)

All three now detect `AuthenticationRequiredError`, demote the log to `warn`, and surface a `/api/oauth/agent/start` click-to-authorize link via the existing `buildAgentOAuthAuthorizeUrl` helper.

`compare_media_kit` runs N briefs in `Promise.all` and its inner per-brief catch swallows `AuthenticationRequiredError` into `err.message` — the outer catch never sees the typed error. Added a post-`Promise.all` short-circuit that recognizes the OAuth-everything-failed case via `isOAuthRequiredErrorMessage` on every `brief.error` and returns the click-to-authorize prompt instead of rendering an N-row failure report.

Also corrects misleading copy in `adcp-tools.ts run_adcp_task`: `agent-oauth.ts:444-457` saves tokens and redirects but never replays `pendingRequest`, so the previous "After you authorize, I'll automatically retry your request" was a lie. Now reads "ask me to run `<task>` again" matching the four sibling prompts. (Wiring actual replay is a separate, larger change — `pending_task` / `pending_params` are still persisted so the work isn't lost.)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Existing helper unit tests still pass (19/19 in `agent-oauth-prompt.test.ts` + `oauth-error-detection.test.ts`)
- [x] Pre-commit hooks (unit suite, dynamic-imports, callApi state, typecheck) green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)