### PR TITLE
fix(scripts): initialize database pool in backfill-primary-brand-domain

### DIFF
--- a/.changeset/backfill-script-init-db.md
+++ b/.changeset/backfill-script-init-db.md
@@ -1,0 +1,4 @@
+---
+---
+
+Initialize the database pool in `backfill-primary-brand-domain.ts` (matches the convention of other prod-runnable scripts in `server/src/scripts/`). Without this, the script crashed on first `getPool()` call.

--- a/server/src/scripts/backfill-primary-brand-domain.ts
+++ b/server/src/scripts/backfill-primary-brand-domain.ts
@@ -19,7 +19,8 @@
  * Prerequisites: DATABASE_URL set.
  */
 
-import { getPool } from '../db/client.js';
+import { initializeDatabase, getPool, closeDatabase } from '../db/client.js';
+import { getDatabaseConfig } from '../config.js';
 import {
   assertClaimableBrandDomain,
   canonicalizeBrandDomain,
@@ -36,6 +37,12 @@ interface Candidate {
 }
 
 async function main(): Promise<void> {
+  const dbConfig = getDatabaseConfig();
+  if (!dbConfig) {
+    console.error('DATABASE_URL is required');
+    process.exit(1);
+  }
+  initializeDatabase(dbConfig);
   const pool = getPool();
 
   const result = await pool.query<{ workos_organization_id: string; domain: string }>(
@@ -110,8 +117,10 @@ async function main(): Promise<void> {
 }
 
 main()
+  .then(() => closeDatabase())
   .then(() => process.exit(0))
-  .catch((err) => {
+  .catch(async (err) => {
     console.error(err);
+    await closeDatabase().catch(() => {});
     process.exit(1);
   });


### PR DESCRIPTION
## Summary

Tiny fix — call \`initializeDatabase(getDatabaseConfig())\` before \`getPool()\`, matching the convention of other prod-runnable scripts in \`server/src/scripts/\` (\`generate-perspective-heroes.ts\`, \`backfill-member-announcements.ts\`, \`backfill-invite-events.ts\`).

Caught when running the script via \`fly ssh\` post-deploy of #4161 — script crashed with \`Database not initialized\`.

## Test plan

- [x] Local integration suite still passes (6 tests)
- [x] Typecheck clean
- [ ] After merge: re-run on prod via \`fly ssh\` to actually execute the backfill (was the goal of #4157 + #4161).

🤖 Generated with [Claude Code](https://claude.com/claude-code)