### PR TITLE
chore(codeowners): use @adcontextprotocol/maintainers team

### DIFF
--- a/.changeset/codeowners-maintainers-team.md
+++ b/.changeset/codeowners-maintainers-team.md
@@ -1,0 +1,4 @@
+---
+---
+
+Update CODEOWNERS to use the @adcontextprotocol/maintainers team instead of a single individual reviewer, so any maintainer can approve PRs touching agent infrastructure, workflows, schemas, and release tooling.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,12 +9,12 @@
 # Agent infrastructure: prompts, context snapshots, setup scripts.
 # A prompt-injection attack would try to rewrite these to expand the
 # agent's capabilities; CODEOWNERS forces a human in the loop.
-/.agents/                   @bokelley
-/.github/                   @bokelley
-/.github/workflows/         @bokelley
+/.agents/                   @adcontextprotocol/maintainers
+/.github/                   @adcontextprotocol/maintainers
+/.github/workflows/         @adcontextprotocol/maintainers
 
 # Protocol schemas — the source of truth the spec is built from.
-/static/schemas/source/     @bokelley
+/static/schemas/source/     @adcontextprotocol/maintainers
 
 # Release tooling.
-/.changeset/                @bokelley
+/.changeset/                @adcontextprotocol/maintainers


### PR DESCRIPTION
## Summary

- Replaces single-individual reviewer (`@bokelley`) with the `@adcontextprotocol/maintainers` team across all CODEOWNERS path entries
- Any maintainer can now approve PRs touching agent infrastructure (`/.agents/`, `/.github/`, `/.github/workflows/`), protocol schemas (`/static/schemas/source/`), and release tooling (`/.changeset/`)

## Why

Spreads review load and unblocks PRs when a single owner is unavailable, while preserving the human-in-the-loop guarantee for prompt-injection-sensitive paths.

## Test plan

- [ ] Confirm the `maintainers` team has write access to the repo (required for team-based CODEOWNERS to function)
- [ ] Open a follow-up PR touching one of these paths and verify the maintainers team is auto-requested for review