### PR TITLE
fix(spec): quote MemberProfile.primary_brand_domain so Mintlify can parse the OpenAPI

### DIFF
--- a/.changeset/fix-openapi-yaml-parse-error.md
+++ b/.changeset/fix-openapi-yaml-parse-error.md
@@ -1,0 +1,16 @@
+---
+---
+
+fix(spec): quote MemberProfile.primary_brand_domain description so Mintlify can parse the OpenAPI
+
+The description was authored as an unquoted plain YAML scalar containing both `\"public\"` (backslash escapes that only have meaning inside a double-quoted scalar) and `: ` (colon-space, a YAML key/value separator). Mintlify's OpenAPI extractor errors with `bad indentation of a mapping entry (1905:178)` and silently gives up on the whole file. With no parsed OpenAPI, every `/docs/registry/api-reference/<tag>/<op>` link in the prose docs reports as broken — cascading into ~10 false-positive broken-link reports any time `.husky/pre-push` triggers the Mintlify scan.
+
+Fix: quote the description and drop the now-unnecessary backslash escapes by writing `visibility: public` plainly inside the backtick code span. No content change.
+
+**Why now:** `.husky/pre-push` only runs the broken-links scan when a branch's diff range includes a `DOC_PATHS`-matching file. Branches that don't touch docs/addie/Mintlify configs silently skip it; `main` itself never runs the hook on push. A recent feature branch rebased against a `main` with `server/src/addie/mcp/*.ts` churn, expanded its diff range, and tripped the hook for the first time — surfacing this latent parse error.
+
+**Followups worth filing separately:**
+
+- `.husky/pre-push` should diff against `origin/main`, not `@{u}` — so a rebase doesn't expand the trigger surface to include unrelated commits already on `main`.
+- CI should run `mintlify broken-links` on `main` so latent docs breakage doesn't accumulate.
+- `static/openapi/registry.yaml` is partially hand-edited (PR #4130's `/api/me/member-profile` paths and Member* schemas are not in Zod source) and partially regenerated. Running `npm run build:openapi` against current Zod source produces a YAML where the `lookupDomain` operation summary is `Domain lookup (deprecated)` (Zod source) instead of `Domain lookup` (current YAML). Picking one source of truth would close the drift.

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -1902,7 +1902,7 @@ components:
           example: acme.com
         primary_brand_domain:
           type: string
-          description: The brand domain whose `brand.json` will reflect this profile's `public` agents. Optional at creation; required before any agent can be set to `visibility: \"public\"`.
+          description: "The brand domain whose `brand.json` will reflect this profile's `public` agents. Optional at creation; required before any agent can be set to `visibility: public`."
           example: acme.com
         marketing_opt_in:
           type: boolean


### PR DESCRIPTION
## Summary

One-line YAML quote fix for a latent parse error on `main` that's been silently breaking the `mintlify broken-links` scan.

The `MemberProfile.primary_brand_domain.description` was authored as an unquoted plain YAML scalar containing both `\"public\"` (backslash escapes — only meaningful inside a double-quoted scalar) and `: ` (colon-space — YAML key/value separator). Mintlify's OpenAPI extractor errors with `bad indentation of a mapping entry (1905:178)` and silently gives up on the whole file. With no parsed OpenAPI, every `/docs/registry/api-reference/<tag>/<op>` link in the prose docs reports as broken — cascades into ~10 false-positive broken-link reports any time `.husky/pre-push` triggers the Mintlify scan.

```yaml
# before
description: The brand domain whose `brand.json` will reflect this profile's `public` agents. Optional at creation; required before any agent can be set to `visibility: \"public\"`.

# after
description: "The brand domain whose `brand.json` will reflect this profile's `public` agents. Optional at creation; required before any agent can be set to `visibility: public`."
```

No content change.

## Why now

`.husky/pre-push` only runs the broken-links scan when a branch's diff range against the upstream tracking ref includes a `DOC_PATHS`-matching file (regex covers `docs/`, `mintlify-docs/`, `mint.json`, `server/src/addie/rules/`, `server/src/addie/.*\.ts$`, etc.). Branches that don't touch any of those silently skip the scan; `main` itself never runs the hook on push.

A recent feature branch (#4141) rebased against a `main` with `server/src/addie/mcp/*.ts` churn, which expanded its diff range to include addie files and tripped the hook for the first time. The global Mintlify scan then surfaced this latent parse error, plus a handful of cascade false-positives.

## Out of scope (filed as followups)

- **`.husky/pre-push` should diff against `origin/main`, not `@{u}`** — so a rebase doesn't expand the trigger surface to include unrelated commits already on `main`.
- **CI should run `mintlify broken-links` on `main`** so latent docs breakage can't accumulate undetected.
- **`static/openapi/registry.yaml` is partially hand-edited and partially regenerated.** PR #4130's `/api/me/member-profile` paths and `Member*` schemas live in YAML only, not Zod source. Running `npm run build:openapi` against current Zod produces a YAML where `lookupDomain` has summary `Domain lookup (deprecated)` (Zod) vs `Domain lookup` (current YAML). Picking one source of truth and migrating the hand-edits to Zod would close the drift.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `git push` pre-push hook — `success no broken links found` ✅ (this PR's push transcript)
- [ ] CI on this branch