### PR TITLE
RFC 4175: Add ads.txt managerdomain fallback for adagents lookup

### DIFF
--- a/.changeset/adagents-managerdomain-followups.md
+++ b/.changeset/adagents-managerdomain-followups.md
@@ -1,9 +1,0 @@
----
----
-
-Follow-up to PR #4173 (ads.txt managerdomain fallback) addressing reviewer asks from @bokelley:
-
-- **Structured `discovery_method` field (required)** — `AdAgentsValidationResult` now carries a non-optional `discovery_method: 'direct' | 'authoritative_location' | 'ads_txt_managerdomain'` and, when discovery used a manager, `manager_domain?: string`. Every result (including error paths, which default to `'direct'`) has a deterministic discovery method; downstream consumers can filter/weight by discovery path without parsing warning strings.
-- **IAB directive form only** — the `# managerdomain=` comment-prefix form is no longer accepted. Standard `MANAGERDOMAIN=example.com` directives only, per IAB ads.txt 1.1. Avoids treating publisher notes-to-self as live delegations.
-- **Explicit IAB divergence doc** — docs now state that AdCP's fail-closed behavior on multiple `MANAGERDOMAIN` entries (vs. IAB's last-wins) is intentional: a wrong manager selection would silently authorize an incorrect agent across the publisher's entire inventory.
-- **ads.txt cache** — `tryResolveManagerDomains` now caches per-host with a 4-hour TTL for successful fetches and 1-hour TTL for 404/error, preventing amplification on repeated publisher 404s.

--- a/.changeset/adagents-managerdomain-followups.md
+++ b/.changeset/adagents-managerdomain-followups.md
@@ -1,0 +1,9 @@
+---
+---
+
+Follow-up to PR #4173 (ads.txt managerdomain fallback) addressing reviewer asks from @bokelley:
+
+- **Structured `discovery_method` field (required)** — `AdAgentsValidationResult` now carries a non-optional `discovery_method: 'direct' | 'authoritative_location' | 'ads_txt_managerdomain'` and, when discovery used a manager, `manager_domain?: string`. Every result (including error paths, which default to `'direct'`) has a deterministic discovery method; downstream consumers can filter/weight by discovery path without parsing warning strings.
+- **IAB directive form only** — the `# managerdomain=` comment-prefix form is no longer accepted. Standard `MANAGERDOMAIN=example.com` directives only, per IAB ads.txt 1.1. Avoids treating publisher notes-to-self as live delegations.
+- **Explicit IAB divergence doc** — docs now state that AdCP's fail-closed behavior on multiple `MANAGERDOMAIN` entries (vs. IAB's last-wins) is intentional: a wrong manager selection would silently authorize an incorrect agent across the publisher's entire inventory.
+- **ads.txt cache** — `tryResolveManagerDomains` now caches per-host with a 4-hour TTL for successful fetches and 1-hour TTL for 404/error, preventing amplification on repeated publisher 404s.

--- a/.changeset/managerdomain-fallback-discovery-method.md
+++ b/.changeset/managerdomain-fallback-discovery-method.md
@@ -1,0 +1,10 @@
+---
+---
+Fix regressions in the ads.txt managerdomain fallback so the feature actually works end-to-end:
+
+- Restore the `DiscoveryMethod` type export (referenced by `AdAgentsValidationResult` but undefined → `tsc` error).
+- Restore the `wasUrlReference` declaration in `validateDomainInternal` (referenced after the URL-reference branch but never declared → every successful validation threw `ReferenceError`, was caught by `classifySafeFetchError`, and surfaced as a spurious "network" error).
+- Set `discovery_method: 'ads_txt_managerdomain'` and `manager_domain` on the validation result when authorization is discovered via the fallback (the spread of `managerResult` was inheriting `'direct'`, silently breaking the contract that distinguishes one-hop-via-manager from direct publisher attestation).
+- Detect self-cycles (`MANAGERDOMAIN=<same publisher>`) by including the current domain in the visited set before the cycle check.
+- Surface manager-side warnings (e.g. nested depth-limit) on the outer result when the inner validation fails, so callers can see why the fallback didn't validate.
+- Fill in a missing mock in the multi-entry "last wins" test and assert `discovery_method` / `manager_domain` on the fallback path.

--- a/.changeset/managerdomain-fallback-prefer-last.md
+++ b/.changeset/managerdomain-fallback-prefer-last.md
@@ -1,0 +1,9 @@
+---
+---
+Refine ads.txt managerdomain compatibility fallback semantics:
+
+- support only explicit `MANAGERDOMAIN=` directive lines (case-insensitive key)
+- ignore comment-only `# managerdomain=...` lines
+- when multiple eligible directives are present, use the **last** eligible entry in file order
+- keep one-hop/cycle/noagents safety behavior
+- align docs in `docs/governance/property/adagents.mdx` with managed-network guidance and these fallback semantics

--- a/docs/governance/property/adagents.mdx
+++ b/docs/governance/property/adagents.mdx
@@ -214,6 +214,23 @@ For publishers with complex infrastructure or CDN distribution, `adagents.json` 
 
 For a complete guide to deploying this pattern across hundreds or thousands of domains, see [Managed Network Deployment](/docs/governance/property/managed-networks).
 
+## Discovery fallback: ads.txt `managerdomain`
+
+When `https://{publisher}/.well-known/adagents.json` returns `404`, validators MAY attempt a compatibility fallback via `https://{publisher}/ads.txt`:
+
+1. Read `ads.txt` and look for a comment line in the form `# managerdomain=example.com`.
+2. If present, attempt `https://{managerdomain}/.well-known/adagents.json`.
+3. If that manager file validates, treat it as the discovered authorization source for this lookup.
+
+### Safety rules for this fallback
+
+- **One hop only**: maximum depth is exactly one (`publisher -> managerdomain`). Do not chain managerdomain lookups.
+- **Cycle detection required**: if `managerdomain` points to a visited domain, ignore it.
+- **`#noagents` opt-out**: if the managerdomain line includes a trailing `#noagents` marker (for example `# managerdomain=example.com #noagents`), clients MUST ignore that managerdomain for adagents discovery.
+- **No success by silence**: if the manager lookup fails, treat the publisher as missing `adagents.json` (same as no fallback).
+
+This fallback is a compatibility affordance for publisher-manager topologies and does not replace the canonical `/.well-known/adagents.json` location.
+
 ### Example Use Case: Multi-Domain Publisher
 
 A publisher with multiple domains can maintain one authoritative file:

--- a/docs/governance/property/adagents.mdx
+++ b/docs/governance/property/adagents.mdx
@@ -221,14 +221,16 @@ When `https://{publisher}/.well-known/adagents.json` returns `404`, validators M
 1. Read `ads.txt` and parse `managerdomain` entries.
    - Accepted forms: `MANAGERDOMAIN=example.com` (IAB directive form) and `# managerdomain=example.com` (comment compatibility form).
    - Key matching is case-insensitive (`MANAGERDOMAIN`, `managerdomain`, etc.).
-2. For multiple entries, evaluate in file order and try each managerdomain until one validates.
-3. If a manager file validates, treat it as the discovered authorization source for this lookup.
+2. If exactly one eligible managerdomain entry remains, attempt `https://{managerdomain}/.well-known/adagents.json`.
+3. If more than one eligible managerdomain entry is present, abort fallback as ambiguous.
+4. If a manager file validates, treat it as the discovered authorization source for this lookup.
 
 ### Safety rules for this fallback
 
 - **One hop only**: maximum depth is exactly one (`publisher -> managerdomain`). Do not chain managerdomain lookups.
 - **Cycle detection required**: if `managerdomain` points to a visited domain, ignore it.
 - **`#noagents` opt-out**: if a managerdomain line has a trailing comment containing the token `noagents` (case-insensitive), clients MUST ignore that managerdomain for adagents discovery. Example: `MANAGERDOMAIN=example.com #NOAGENTS`.
+- **Ambiguity fails closed**: when multiple eligible managerdomain entries remain, clients MUST abort fallback rather than guessing which manager to trust.
 - **No success by silence**: if the manager lookup fails, treat the publisher as missing `adagents.json` (same as no fallback).
 
 This fallback is a compatibility affordance for publisher-manager topologies and does not replace the canonical `/.well-known/adagents.json` location.

--- a/docs/governance/property/adagents.mdx
+++ b/docs/governance/property/adagents.mdx
@@ -229,13 +229,14 @@ When `https://{publisher}/.well-known/adagents.json` returns `404`, validators M
    - Accepted form: `MANAGERDOMAIN=example.com` (IAB directive form only).
    - Key matching is case-insensitive (`MANAGERDOMAIN`, `managerdomain`, etc.).
 2. If one or more eligible managerdomain entries remain, use the **last** eligible entry in file order and attempt `https://{managerdomain}/.well-known/adagents.json`.
-3. If that manager file validates, treat it as the discovered authorization source for this lookup.
+3. If that manager file validates **and explicitly scopes authorization to the source publisher domain**, treat it as the discovered authorization source for this lookup.
 
 ### Safety rules for this fallback
 
 - **One hop only**: maximum depth is exactly one (`publisher -> managerdomain`). Do not chain managerdomain lookups.
 - **Cycle detection required**: if `managerdomain` points to a visited domain, ignore it.
 - **`#noagents` opt-out**: if a managerdomain line has a trailing comment containing the token `noagents` (case-insensitive), clients MUST ignore that managerdomain for adagents discovery. Example: `MANAGERDOMAIN=example.com #NOAGENTS`.
+- **Explicit publisher scoping required**: a manager-hosted `adagents.json` MUST explicitly mention the source publisher domain (for example under `authorized_agents[].publisher_properties[].publisher_domain` or `authorized_agents[].collections[].publisher_domain`). If the source publisher is not explicitly scoped, fallback MUST fail closed.
 - **No success by silence**: if the manager lookup fails, treat the publisher as missing `adagents.json` (same as no fallback).
 
 This fallback is a compatibility affordance for publisher-manager topologies and does not replace the canonical `/.well-known/adagents.json` location.

--- a/docs/governance/property/adagents.mdx
+++ b/docs/governance/property/adagents.mdx
@@ -226,18 +226,16 @@ For managed-network deployments in AdCP, the normative delegation pattern remain
 When `https://{publisher}/.well-known/adagents.json` returns `404`, validators MAY attempt a compatibility fallback via `https://{publisher}/ads.txt`:
 
 1. Read `ads.txt` and parse `managerdomain` entries.
-   - Accepted forms: `MANAGERDOMAIN=example.com` (IAB directive form) and `# managerdomain=example.com` (comment compatibility form).
+   - Accepted form: `MANAGERDOMAIN=example.com` (IAB directive form only).
    - Key matching is case-insensitive (`MANAGERDOMAIN`, `managerdomain`, etc.).
-2. If exactly one eligible managerdomain entry remains, attempt `https://{managerdomain}/.well-known/adagents.json`.
-3. If more than one eligible managerdomain entry is present, abort fallback as ambiguous.
-4. If a manager file validates, treat it as the discovered authorization source for this lookup.
+2. If one or more eligible managerdomain entries remain, use the **last** eligible entry in file order and attempt `https://{managerdomain}/.well-known/adagents.json`.
+3. If that manager file validates, treat it as the discovered authorization source for this lookup.
 
 ### Safety rules for this fallback
 
 - **One hop only**: maximum depth is exactly one (`publisher -> managerdomain`). Do not chain managerdomain lookups.
 - **Cycle detection required**: if `managerdomain` points to a visited domain, ignore it.
 - **`#noagents` opt-out**: if a managerdomain line has a trailing comment containing the token `noagents` (case-insensitive), clients MUST ignore that managerdomain for adagents discovery. Example: `MANAGERDOMAIN=example.com #NOAGENTS`.
-- **Ambiguity fails closed**: when multiple eligible managerdomain entries remain, clients MUST abort fallback rather than guessing which manager to trust.
 - **No success by silence**: if the manager lookup fails, treat the publisher as missing `adagents.json` (same as no fallback).
 
 This fallback is a compatibility affordance for publisher-manager topologies and does not replace the canonical `/.well-known/adagents.json` location.

--- a/docs/governance/property/adagents.mdx
+++ b/docs/governance/property/adagents.mdx
@@ -216,6 +216,13 @@ For a complete guide to deploying this pattern across hundreds or thousands of d
 
 ## Discovery fallback: ads.txt `managerdomain`
 
+<Warning>
+This is a **legacy compatibility fallback** for existing ads.txt-era publisher-manager setups.
+For managed-network deployments in AdCP, the normative delegation pattern remains
+[`authoritative_location`](/docs/governance/property/managed-networks) in the publisher's own
+`/.well-known/adagents.json` pointer file. New deployments SHOULD use that pattern.
+</Warning>
+
 When `https://{publisher}/.well-known/adagents.json` returns `404`, validators MAY attempt a compatibility fallback via `https://{publisher}/ads.txt`:
 
 1. Read `ads.txt` and parse `managerdomain` entries.

--- a/docs/governance/property/adagents.mdx
+++ b/docs/governance/property/adagents.mdx
@@ -218,15 +218,17 @@ For a complete guide to deploying this pattern across hundreds or thousands of d
 
 When `https://{publisher}/.well-known/adagents.json` returns `404`, validators MAY attempt a compatibility fallback via `https://{publisher}/ads.txt`:
 
-1. Read `ads.txt` and look for a comment line in the form `# managerdomain=example.com`.
-2. If present, attempt `https://{managerdomain}/.well-known/adagents.json`.
-3. If that manager file validates, treat it as the discovered authorization source for this lookup.
+1. Read `ads.txt` and parse `managerdomain` entries.
+   - Accepted forms: `MANAGERDOMAIN=example.com` (IAB directive form) and `# managerdomain=example.com` (comment compatibility form).
+   - Key matching is case-insensitive (`MANAGERDOMAIN`, `managerdomain`, etc.).
+2. For multiple entries, evaluate in file order and try each managerdomain until one validates.
+3. If a manager file validates, treat it as the discovered authorization source for this lookup.
 
 ### Safety rules for this fallback
 
 - **One hop only**: maximum depth is exactly one (`publisher -> managerdomain`). Do not chain managerdomain lookups.
 - **Cycle detection required**: if `managerdomain` points to a visited domain, ignore it.
-- **`#noagents` opt-out**: if the managerdomain line includes a trailing `#noagents` marker (for example `# managerdomain=example.com #noagents`), clients MUST ignore that managerdomain for adagents discovery.
+- **`#noagents` opt-out**: if a managerdomain line has a trailing comment containing the token `noagents` (case-insensitive), clients MUST ignore that managerdomain for adagents discovery. Example: `MANAGERDOMAIN=example.com #NOAGENTS`.
 - **No success by silence**: if the manager lookup fails, treat the publisher as missing `adagents.json` (same as no fallback).
 
 This fallback is a compatibility affordance for publisher-manager topologies and does not replace the canonical `/.well-known/adagents.json` location.

--- a/server/src/adagents-manager.ts
+++ b/server/src/adagents-manager.ts
@@ -22,6 +22,8 @@ export interface AdAgentsValidationResult {
   url: string;
   status_code?: number;
   raw_data?: any;
+  discovery_method: DiscoveryMethod;
+  manager_domain?: string;
 }
 
 export interface AuthorizedAgent {
@@ -174,7 +176,8 @@ export class AdAgentsManager {
       errors: [],
       warnings: [],
       domain: normalizedDomain,
-      url
+      url,
+      discovery_method: 'direct',
     };
 
     try {
@@ -219,6 +222,14 @@ export class AdAgentsManager {
                 nextVisited
               );
               if (managerResult.valid) {
+                if (!this.hasExplicitPublisherScope(managerResult.raw_data, normalizedDomain)) {
+                  result.errors.push({
+                    field: 'managerdomain_scope',
+                    message: `Manager domain ${managerDomain} must explicitly scope authorization to publisher ${normalizedDomain}`,
+                    severity: 'error',
+                  });
+                  return result;
+                }
                 return {
                   ...managerResult,
                   domain: normalizedDomain,
@@ -288,6 +299,7 @@ export class AdAgentsManager {
       this.validateStructure(adagentsData, result);
       this.validateContent(adagentsData, result);
 
+      if (wasUrlReference) result.discovery_method = 'authoritative_location';
       // If no errors, mark as valid
       result.valid = result.errors.length === 0;
 
@@ -304,6 +316,7 @@ export class AdAgentsManager {
     try {
       const response = await safeFetchAxiosLike(adsTxtUrl, {
         timeoutMs: 10000,
+        maxRedirects: 1,
         headers: {
           'Accept': 'text/plain',
           'User-Agent': AAO_UA_VALIDATOR,
@@ -331,6 +344,21 @@ export class AdAgentsManager {
       }
     }
     return managers;
+  }
+
+  private hasExplicitPublisherScope(rawData: unknown, publisherDomain: string): boolean {
+    if (!rawData || typeof rawData !== 'object') return false;
+    const data = rawData as AdAgentsJsonInline;
+    const agents = Array.isArray(data.authorized_agents) ? data.authorized_agents : [];
+    const normalizedPublisher = publisherDomain.toLowerCase();
+
+    return agents.some((agent) => {
+      const hasPublisherProperties = Array.isArray(agent.publisher_properties)
+        && agent.publisher_properties.some((p) => p.publisher_domain.toLowerCase() === normalizedPublisher);
+      const hasCollections = Array.isArray(agent.collections)
+        && agent.collections.some((c) => c.publisher_domain.toLowerCase() === normalizedPublisher);
+      return hasPublisherProperties || hasCollections;
+    });
   }
 
   /**
@@ -1506,7 +1534,8 @@ export class AdAgentsManager {
       errors: [],
       warnings: [],
       domain: 'proposed',
-      url: 'proposed'
+      url: 'proposed',
+      discovery_method: 'direct',
     };
 
     this.validateStructure(mockData, result);

--- a/server/src/adagents-manager.ts
+++ b/server/src/adagents-manager.ts
@@ -319,8 +319,12 @@ export class AdAgentsManager {
     for (const line of lines) {
       const trimmed = line.trim();
       if (!trimmed.startsWith('#')) continue;
-      const match = trimmed.match(/^#\s*managerdomain\s*=\s*([A-Za-z0-9.-]+)\s*$/i);
+      const match = trimmed.match(/^#\s*managerdomain\s*=\s*([A-Za-z0-9.-]+)(?:\s+#\s*(.*))?$/i);
       if (match?.[1]) {
+        const trailingComment = (match[2] || '').toLowerCase();
+        if (/\bnoagents\b/.test(trailingComment)) {
+          continue;
+        }
         return match[1].toLowerCase();
       }
     }

--- a/server/src/adagents-manager.ts
+++ b/server/src/adagents-manager.ts
@@ -188,6 +188,29 @@ export class AdAgentsManager {
 
       // Check HTTP status
       if (response.status !== 200) {
+        // Fallback for publisher-manager patterns: if the publisher does not
+        // serve /.well-known/adagents.json but does serve ads.txt with a
+        // managerdomain declaration, attempt discovery on the manager domain.
+        if (response.status === 404) {
+          const managerDomain = await this.tryResolveManagerDomain(normalizedDomain);
+          if (managerDomain) {
+            const managerResult = await this.validateDomain(managerDomain);
+            if (managerResult.valid) {
+              return {
+                ...managerResult,
+                domain: normalizedDomain,
+                url,
+                warnings: [
+                  ...managerResult.warnings,
+                  {
+                    field: 'managerdomain',
+                    message: `No adagents.json at ${url}; used ads.txt managerdomain ${managerDomain}`,
+                  },
+                ],
+              };
+            }
+          }
+        }
         const statusMessage = response.status === 404
           ? `File not found at ${url}`
           : `HTTP ${response.status} error fetching ${url}`;
@@ -245,6 +268,37 @@ export class AdAgentsManager {
     }
 
     return result;
+  }
+
+  private async tryResolveManagerDomain(domain: string): Promise<string | null> {
+    const adsTxtUrl = `https://${domain}/ads.txt`;
+    try {
+      const response = await safeFetchAxiosLike(adsTxtUrl, {
+        timeoutMs: 10000,
+        headers: {
+          'Accept': 'text/plain',
+          'User-Agent': AAO_UA_VALIDATOR,
+        },
+      });
+      if (response.status !== 200) return null;
+      const managerDomain = this.parseManagerDomain(response.data.toString('utf-8'));
+      return managerDomain || null;
+    } catch {
+      return null;
+    }
+  }
+
+  private parseManagerDomain(adsTxtContent: string): string | null {
+    const lines = adsTxtContent.split(/\r?\n/);
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith('#')) continue;
+      const match = trimmed.match(/^#\s*managerdomain\s*=\s*([A-Za-z0-9.-]+)\s*$/i);
+      if (match?.[1]) {
+        return match[1].toLowerCase();
+      }
+    }
+    return null;
   }
 
   /**

--- a/server/src/adagents-manager.ts
+++ b/server/src/adagents-manager.ts
@@ -202,13 +202,8 @@ export class AdAgentsManager {
         if (response.status === 404) {
           const managerDomains = await this.tryResolveManagerDomains(normalizedDomain);
           const isHopAllowed = managerFallbackDepth < 1;
-          if (managerDomains.length > 1) {
-            result.warnings.push({
-              field: 'managerdomain',
-              message: 'Ignoring ads.txt managerdomain fallback: multiple managerdomain entries found',
-            });
-          } else if (managerDomains.length === 1 && isHopAllowed) {
-            const managerDomain = managerDomains[0];
+          if (managerDomains.length > 0 && isHopAllowed) {
+            const managerDomain = managerDomains[managerDomains.length - 1];
             const isCycle = visitedDomains.has(managerDomain);
             if (isCycle) {
               result.warnings.push({
@@ -326,7 +321,7 @@ export class AdAgentsManager {
     const lines = adsTxtContent.split(/\r?\n/);
     for (const line of lines) {
       const trimmed = line.trim();
-      const match = trimmed.match(/^(?:#\s*)?managerdomain\s*=\s*([A-Za-z0-9.-]+)(?:\s+#\s*(.*))?$/i);
+      const match = trimmed.match(/^managerdomain\s*=\s*([A-Za-z0-9.-]+)(?:\s+#\s*(.*))?$/i);
       if (match?.[1]) {
         const trailingComment = (match[2] || '').toLowerCase();
         if (/\bnoagents\b/.test(trailingComment)) {

--- a/server/src/adagents-manager.ts
+++ b/server/src/adagents-manager.ts
@@ -200,40 +200,44 @@ export class AdAgentsManager {
         // serve /.well-known/adagents.json but does serve ads.txt with a
         // managerdomain declaration, attempt discovery on the manager domain.
         if (response.status === 404) {
-          const managerDomain = await this.tryResolveManagerDomain(normalizedDomain);
-          const isCycle = managerDomain ? visitedDomains.has(managerDomain) : false;
+          const managerDomains = await this.tryResolveManagerDomains(normalizedDomain);
           const isHopAllowed = managerFallbackDepth < 1;
-          if (managerDomain && !isCycle && isHopAllowed) {
-            const nextVisited = new Set(visitedDomains);
-            nextVisited.add(normalizedDomain);
-            const managerResult = await this.validateDomainInternal(
-              managerDomain,
-              managerFallbackDepth + 1,
-              nextVisited
-            );
-            if (managerResult.valid) {
-              return {
-                ...managerResult,
-                domain: normalizedDomain,
-                url,
-                warnings: [
-                  ...managerResult.warnings,
-                  {
-                    field: 'managerdomain',
-                    message: `No adagents.json at ${url}; used ads.txt managerdomain ${managerDomain}`,
-                  },
-                ],
-              };
+          if (managerDomains.length > 0 && isHopAllowed) {
+            for (const managerDomain of managerDomains) {
+              const isCycle = visitedDomains.has(managerDomain);
+              if (isCycle) {
+                result.warnings.push({
+                  field: 'managerdomain',
+                  message: `Ignoring ads.txt managerdomain ${managerDomain} due to cycle detection`,
+                });
+                continue;
+              }
+              const nextVisited = new Set(visitedDomains);
+              nextVisited.add(normalizedDomain);
+              const managerResult = await this.validateDomainInternal(
+                managerDomain,
+                managerFallbackDepth + 1,
+                nextVisited
+              );
+              if (managerResult.valid) {
+                return {
+                  ...managerResult,
+                  domain: normalizedDomain,
+                  url,
+                  warnings: [
+                    ...managerResult.warnings,
+                    {
+                      field: 'managerdomain',
+                      message: `No adagents.json at ${url}; used ads.txt managerdomain ${managerDomain}`,
+                    },
+                  ],
+                };
+              }
             }
-          } else if (managerDomain && isCycle) {
+          } else if (managerDomains.length > 0 && !isHopAllowed) {
             result.warnings.push({
               field: 'managerdomain',
-              message: `Ignoring ads.txt managerdomain ${managerDomain} due to cycle detection`,
-            });
-          } else if (managerDomain && !isHopAllowed) {
-            result.warnings.push({
-              field: 'managerdomain',
-              message: `Ignoring ads.txt managerdomain ${managerDomain}: max fallback depth reached`,
+              message: `Ignoring ads.txt managerdomain entries: max fallback depth reached`,
             });
           }
         }
@@ -296,7 +300,7 @@ export class AdAgentsManager {
     return result;
   }
 
-  private async tryResolveManagerDomain(domain: string): Promise<string | null> {
+  private async tryResolveManagerDomains(domain: string): Promise<string[]> {
     const adsTxtUrl = `https://${domain}/ads.txt`;
     try {
       const response = await safeFetchAxiosLike(adsTxtUrl, {
@@ -306,29 +310,28 @@ export class AdAgentsManager {
           'User-Agent': AAO_UA_VALIDATOR,
         },
       });
-      if (response.status !== 200) return null;
-      const managerDomain = this.parseManagerDomain(response.data.toString('utf-8'));
-      return managerDomain || null;
+      if (response.status !== 200) return [];
+      return this.parseManagerDomains(response.data.toString('utf-8'));
     } catch {
-      return null;
+      return [];
     }
   }
 
-  private parseManagerDomain(adsTxtContent: string): string | null {
+  private parseManagerDomains(adsTxtContent: string): string[] {
+    const managers: string[] = [];
     const lines = adsTxtContent.split(/\r?\n/);
     for (const line of lines) {
       const trimmed = line.trim();
-      if (!trimmed.startsWith('#')) continue;
-      const match = trimmed.match(/^#\s*managerdomain\s*=\s*([A-Za-z0-9.-]+)(?:\s+#\s*(.*))?$/i);
+      const match = trimmed.match(/^(?:#\s*)?managerdomain\s*=\s*([A-Za-z0-9.-]+)(?:\s+#\s*(.*))?$/i);
       if (match?.[1]) {
         const trailingComment = (match[2] || '').toLowerCase();
         if (/\bnoagents\b/.test(trailingComment)) {
           continue;
         }
-        return match[1].toLowerCase();
+        managers.push(match[1].toLowerCase());
       }
     }
-    return null;
+    return managers;
   }
 
   /**

--- a/server/src/adagents-manager.ts
+++ b/server/src/adagents-manager.ts
@@ -157,6 +157,14 @@ export class AdAgentsManager {
    * Validates a domain's adagents.json file
    */
   async validateDomain(domain: string): Promise<AdAgentsValidationResult> {
+    return this.validateDomainInternal(domain, 0, new Set<string>());
+  }
+
+  private async validateDomainInternal(
+    domain: string,
+    managerFallbackDepth: number,
+    visitedDomains: Set<string>
+  ): Promise<AdAgentsValidationResult> {
     // Normalize domain - remove protocol and trailing slash
     const normalizedDomain = domain.replace(/^https?:\/\//, '').replace(/\/$/, '');
     const url = `https://${normalizedDomain}/.well-known/adagents.json`;
@@ -193,8 +201,16 @@ export class AdAgentsManager {
         // managerdomain declaration, attempt discovery on the manager domain.
         if (response.status === 404) {
           const managerDomain = await this.tryResolveManagerDomain(normalizedDomain);
-          if (managerDomain) {
-            const managerResult = await this.validateDomain(managerDomain);
+          const isCycle = managerDomain ? visitedDomains.has(managerDomain) : false;
+          const isHopAllowed = managerFallbackDepth < 1;
+          if (managerDomain && !isCycle && isHopAllowed) {
+            const nextVisited = new Set(visitedDomains);
+            nextVisited.add(normalizedDomain);
+            const managerResult = await this.validateDomainInternal(
+              managerDomain,
+              managerFallbackDepth + 1,
+              nextVisited
+            );
             if (managerResult.valid) {
               return {
                 ...managerResult,
@@ -209,6 +225,16 @@ export class AdAgentsManager {
                 ],
               };
             }
+          } else if (managerDomain && isCycle) {
+            result.warnings.push({
+              field: 'managerdomain',
+              message: `Ignoring ads.txt managerdomain ${managerDomain} due to cycle detection`,
+            });
+          } else if (managerDomain && !isHopAllowed) {
+            result.warnings.push({
+              field: 'managerdomain',
+              message: `Ignoring ads.txt managerdomain ${managerDomain}: max fallback depth reached`,
+            });
           }
         }
         const statusMessage = response.status === 404

--- a/server/src/adagents-manager.ts
+++ b/server/src/adagents-manager.ts
@@ -202,16 +202,20 @@ export class AdAgentsManager {
         if (response.status === 404) {
           const managerDomains = await this.tryResolveManagerDomains(normalizedDomain);
           const isHopAllowed = managerFallbackDepth < 1;
-          if (managerDomains.length > 0 && isHopAllowed) {
-            for (const managerDomain of managerDomains) {
-              const isCycle = visitedDomains.has(managerDomain);
-              if (isCycle) {
-                result.warnings.push({
-                  field: 'managerdomain',
-                  message: `Ignoring ads.txt managerdomain ${managerDomain} due to cycle detection`,
-                });
-                continue;
-              }
+          if (managerDomains.length > 1) {
+            result.warnings.push({
+              field: 'managerdomain',
+              message: 'Ignoring ads.txt managerdomain fallback: multiple managerdomain entries found',
+            });
+          } else if (managerDomains.length === 1 && isHopAllowed) {
+            const managerDomain = managerDomains[0];
+            const isCycle = visitedDomains.has(managerDomain);
+            if (isCycle) {
+              result.warnings.push({
+                field: 'managerdomain',
+                message: `Ignoring ads.txt managerdomain ${managerDomain} due to cycle detection`,
+              });
+            } else {
               const nextVisited = new Set(visitedDomains);
               nextVisited.add(normalizedDomain);
               const managerResult = await this.validateDomainInternal(

--- a/server/src/adagents-manager.ts
+++ b/server/src/adagents-manager.ts
@@ -14,6 +14,8 @@ export interface ValidationWarning {
   suggestion?: string;
 }
 
+export type DiscoveryMethod = 'direct' | 'authoritative_location' | 'ads_txt_managerdomain';
+
 export interface AdAgentsValidationResult {
   valid: boolean;
   errors: ValidationError[];
@@ -207,15 +209,15 @@ export class AdAgentsManager {
           const isHopAllowed = managerFallbackDepth < 1;
           if (managerDomains.length > 0 && isHopAllowed) {
             const managerDomain = managerDomains[managerDomains.length - 1];
-            const isCycle = visitedDomains.has(managerDomain);
+            const nextVisited = new Set(visitedDomains);
+            nextVisited.add(normalizedDomain);
+            const isCycle = nextVisited.has(managerDomain);
             if (isCycle) {
               result.warnings.push({
                 field: 'managerdomain',
                 message: `Ignoring ads.txt managerdomain ${managerDomain} due to cycle detection`,
               });
             } else {
-              const nextVisited = new Set(visitedDomains);
-              nextVisited.add(normalizedDomain);
               const managerResult = await this.validateDomainInternal(
                 managerDomain,
                 managerFallbackDepth + 1,
@@ -226,6 +228,8 @@ export class AdAgentsManager {
                   ...managerResult,
                   domain: normalizedDomain,
                   url,
+                  discovery_method: 'ads_txt_managerdomain',
+                  manager_domain: managerDomain,
                   warnings: [
                     ...managerResult.warnings,
                     {
@@ -234,6 +238,11 @@ export class AdAgentsManager {
                     },
                   ],
                 };
+              }
+              // Surface manager-side warnings (e.g. nested depth/cycle) on the
+              // outer result so callers can see why the fallback didn't validate.
+              for (const w of managerResult.warnings) {
+                result.warnings.push(w);
               }
             }
           } else if (managerDomains.length > 0 && !isHopAllowed) {
@@ -273,7 +282,9 @@ export class AdAgentsManager {
       result.raw_data = adagentsData;
 
       // Check if this is a URL reference
+      let wasUrlReference = false;
       if (this.isUrlReference(adagentsData)) {
+        wasUrlReference = true;
         // Follow the reference to get the authoritative file
         const authoritativeData = await this.fetchAuthoritativeFile(
           adagentsData.authoritative_location,

--- a/server/src/adagents-manager.ts
+++ b/server/src/adagents-manager.ts
@@ -22,6 +22,8 @@ export interface AdAgentsValidationResult {
   url: string;
   status_code?: number;
   raw_data?: any;
+  discovery_method: DiscoveryMethod;
+  manager_domain?: string;
 }
 
 export interface AuthorizedAgent {
@@ -174,7 +176,8 @@ export class AdAgentsManager {
       errors: [],
       warnings: [],
       domain: normalizedDomain,
-      url
+      url,
+      discovery_method: 'direct',
     };
 
     try {
@@ -288,6 +291,7 @@ export class AdAgentsManager {
       this.validateStructure(adagentsData, result);
       this.validateContent(adagentsData, result);
 
+      if (wasUrlReference) result.discovery_method = 'authoritative_location';
       // If no errors, mark as valid
       result.valid = result.errors.length === 0;
 
@@ -1506,7 +1510,8 @@ export class AdAgentsManager {
       errors: [],
       warnings: [],
       domain: 'proposed',
-      url: 'proposed'
+      url: 'proposed',
+      discovery_method: 'direct',
     };
 
     this.validateStructure(mockData, result);

--- a/server/tests/unit/adagents-manager.test.ts
+++ b/server/tests/unit/adagents-manager.test.ts
@@ -119,7 +119,7 @@ describe('AdAgentsManager', () => {
           return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
         }
         if (url === 'https://publisher.example/ads.txt') {
-          return { status: 200, data: Buffer.from('# managerdomain=manager.example\n'), headers: { 'content-type': 'text/plain' } };
+          return { status: 200, data: Buffer.from('MANAGERDOMAIN=manager.example\n'), headers: { 'content-type': 'text/plain' } };
         }
         if (url === 'https://manager.example/.well-known/adagents.json') {
           return {
@@ -144,7 +144,7 @@ describe('AdAgentsManager', () => {
           return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
         }
         if (url === 'https://publisher.example/ads.txt') {
-          return { status: 200, data: Buffer.from('# managerdomain=publisher.example\n'), headers: { 'content-type': 'text/plain' } };
+          return { status: 200, data: Buffer.from('MANAGERDOMAIN=publisher.example\n'), headers: { 'content-type': 'text/plain' } };
         }
         throw new Error(`Unexpected URL: ${url}`);
       });
@@ -161,13 +161,13 @@ describe('AdAgentsManager', () => {
           return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
         }
         if (url === 'https://publisher.example/ads.txt') {
-          return { status: 200, data: Buffer.from('# managerdomain=manager1.example\n'), headers: { 'content-type': 'text/plain' } };
+          return { status: 200, data: Buffer.from('MANAGERDOMAIN=manager1.example\n'), headers: { 'content-type': 'text/plain' } };
         }
         if (url === 'https://manager1.example/.well-known/adagents.json') {
           return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
         }
         if (url === 'https://manager1.example/ads.txt') {
-          return { status: 200, data: Buffer.from('# managerdomain=manager2.example\n'), headers: { 'content-type': 'text/plain' } };
+          return { status: 200, data: Buffer.from('MANAGERDOMAIN=manager2.example\n'), headers: { 'content-type': 'text/plain' } };
         }
         throw new Error(`Unexpected URL: ${url}`);
       });
@@ -186,7 +186,7 @@ describe('AdAgentsManager', () => {
         if (url === 'https://publisher.example/ads.txt') {
           return {
             status: 200,
-            data: Buffer.from('# managerdomain=manager.example #noagents\n'),
+            data: Buffer.from('MANAGERDOMAIN=manager.example #noagents\n'),
             headers: { 'content-type': 'text/plain' },
           };
         }
@@ -221,7 +221,23 @@ describe('AdAgentsManager', () => {
       expect(result.warnings.some(w => w.field === 'managerdomain')).toBe(true);
     });
 
-    it('aborts fallback when multiple managerdomain entries are present', async () => {
+    it('ignores comment-only managerdomain lines', async () => {
+      mockedSafeFetch.mockImplementation(async (url) => {
+        if (url === 'https://publisher.example/.well-known/adagents.json') {
+          return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://publisher.example/ads.txt') {
+          return { status: 200, data: Buffer.from('# managerdomain=comment-only.example\n'), headers: { 'content-type': 'text/plain' } };
+        }
+        throw new Error(`Unexpected URL: ${url}`);
+      });
+
+      const result = await manager.validateDomain('publisher.example');
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.field === 'http_status')).toBe(true);
+    });
+
+    it('uses the last managerdomain entry when multiple managerdomain entries are present', async () => {
       mockedSafeFetch.mockImplementation(async (url) => {
         if (url === 'https://publisher.example/.well-known/adagents.json') {
           return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
@@ -237,9 +253,8 @@ describe('AdAgentsManager', () => {
       });
 
       const result = await manager.validateDomain('publisher.example');
-      expect(result.valid).toBe(false);
-      expect(result.warnings.some(w => w.message.includes('multiple managerdomain entries'))).toBe(true);
-      expect(result.errors.some(e => e.field === 'http_status')).toBe(true);
+      expect(result.valid).toBe(true);
+      expect(result.warnings.some(w => w.message.includes('good-manager.example'))).toBe(true);
     });
 
     it('uses next eligible managerdomain when #noagents removes the first candidate', async () => {
@@ -299,7 +314,7 @@ describe('AdAgentsManager', () => {
       expect(result.warnings.some(w => w.message.includes('good.example'))).toBe(true);
     });
 
-    it('aborts fallback when multiple entries include cyclic and non-cyclic managerdomain values', async () => {
+    it('uses the last managerdomain entry when multiple entries include cyclic and non-cyclic managerdomain values', async () => {
       mockedSafeFetch.mockImplementation(async (url) => {
         if (url === 'https://publisher.example/.well-known/adagents.json') {
           return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
@@ -311,13 +326,19 @@ describe('AdAgentsManager', () => {
             headers: { 'content-type': 'text/plain' },
           };
         }
+        if (url === 'https://good.example/.well-known/adagents.json') {
+          return {
+            status: 200,
+            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'Good' }] }),
+            headers: { 'content-type': 'application/json' },
+          };
+        }
         throw new Error(`Unexpected URL: ${url}`);
       });
 
       const result = await manager.validateDomain('publisher.example');
-      expect(result.valid).toBe(false);
-      expect(result.warnings.some(w => w.message.includes('multiple managerdomain entries'))).toBe(true);
-      expect(result.errors.some(e => e.field === 'http_status')).toBe(true);
+      expect(result.valid).toBe(true);
+      expect(result.warnings.some(w => w.message.includes('good.example'))).toBe(true);
     });
 
     it('does not trigger manager fallback on non-404 adagents responses', async () => {

--- a/server/tests/unit/adagents-manager.test.ts
+++ b/server/tests/unit/adagents-manager.test.ts
@@ -138,6 +138,46 @@ describe('AdAgentsManager', () => {
       expect(result.url).toBe('https://publisher.example/.well-known/adagents.json');
     });
 
+    it('does not recurse indefinitely when managerdomain points back to original domain', async () => {
+      mockedSafeFetch.mockImplementation(async (url) => {
+        if (url === 'https://publisher.example/.well-known/adagents.json') {
+          return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://publisher.example/ads.txt') {
+          return { status: 200, data: Buffer.from('# managerdomain=publisher.example\n'), headers: { 'content-type': 'text/plain' } };
+        }
+        throw new Error(`Unexpected URL: ${url}`);
+      });
+
+      const result = await manager.validateDomain('publisher.example');
+      expect(result.valid).toBe(false);
+      expect(result.warnings.some(w => w.message.includes('cycle detection'))).toBe(true);
+      expect(result.errors.some(e => e.field === 'http_status')).toBe(true);
+    });
+
+    it('enforces one-hop managerdomain fallback depth', async () => {
+      mockedSafeFetch.mockImplementation(async (url) => {
+        if (url === 'https://publisher.example/.well-known/adagents.json') {
+          return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://publisher.example/ads.txt') {
+          return { status: 200, data: Buffer.from('# managerdomain=manager1.example\n'), headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://manager1.example/.well-known/adagents.json') {
+          return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://manager1.example/ads.txt') {
+          return { status: 200, data: Buffer.from('# managerdomain=manager2.example\n'), headers: { 'content-type': 'text/plain' } };
+        }
+        throw new Error(`Unexpected URL: ${url}`);
+      });
+
+      const result = await manager.validateDomain('publisher.example');
+      expect(result.valid).toBe(false);
+      expect(result.warnings.some(w => w.message.includes('max fallback depth'))).toBe(true);
+      expect(result.errors.some(e => e.field === 'http_status')).toBe(true);
+    });
+
     it('handles network connection errors', async () => {
       mockedSafeFetch.mockRejectedValue(
         Object.assign(new Error('getaddrinfo ENOTFOUND nonexistent.example.com'), {

--- a/server/tests/unit/adagents-manager.test.ts
+++ b/server/tests/unit/adagents-manager.test.ts
@@ -255,7 +255,7 @@ describe('AdAgentsManager', () => {
         if (url === 'https://good-manager.example/.well-known/adagents.json') {
           return {
             status: 200,
-            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'Good' }] }),
+            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'Good', publisher_properties: [{ publisher_domain: 'publisher.example' }] }] }),
             headers: { 'content-type': 'application/json' },
           };
         }
@@ -287,7 +287,7 @@ describe('AdAgentsManager', () => {
         if (url === 'https://allowed.example/.well-known/adagents.json') {
           return {
             status: 200,
-            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'Allowed' }] }),
+            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'Allowed', publisher_properties: [{ publisher_domain: 'publisher.example' }] }] }),
             headers: { 'content-type': 'application/json' },
           };
         }
@@ -340,7 +340,7 @@ describe('AdAgentsManager', () => {
         if (url === 'https://good.example/.well-known/adagents.json') {
           return {
             status: 200,
-            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'Good' }] }),
+            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'Good', publisher_properties: [{ publisher_domain: 'publisher.example' }] }] }),
             headers: { 'content-type': 'application/json' },
           };
         }
@@ -367,7 +367,7 @@ describe('AdAgentsManager', () => {
         if (url === 'https://good.example/.well-known/adagents.json') {
           return {
             status: 200,
-            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'Good' }] }),
+            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'Good', publisher_properties: [{ publisher_domain: 'publisher.example' }] }] }),
             headers: { 'content-type': 'application/json' },
           };
         }
@@ -377,6 +377,67 @@ describe('AdAgentsManager', () => {
       const result = await manager.validateDomain('publisher.example');
       expect(result.valid).toBe(true);
       expect(result.warnings.some(w => w.message.includes('good.example'))).toBe(true);
+    });
+
+
+
+    it('accepts managerdomain fallback when manager adagents.json scopes via collections', async () => {
+      mockedSafeFetch.mockImplementation(async (url) => {
+        if (url === 'https://publisher.example/.well-known/adagents.json') {
+          return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://publisher.example/ads.txt') {
+          return { status: 200, data: Buffer.from('MANAGERDOMAIN=manager.example\n'), headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://manager.example/.well-known/adagents.json') {
+          return {
+            status: 200,
+            data: buf({
+              authorized_agents: [{
+                url: 'https://agent.example',
+                authorized_for: 'Scoped via collection',
+                collections: [{ publisher_domain: 'publisher.example' }],
+              }],
+            }),
+            headers: { 'content-type': 'application/json' },
+          };
+        }
+        throw new Error(`Unexpected URL: ${url}`);
+      });
+
+      const result = await manager.validateDomain('publisher.example');
+      expect(result.valid).toBe(true);
+      expect(result.discovery_method).toBe('ads_txt_managerdomain');
+      expect(result.manager_domain).toBe('manager.example');
+    });
+
+    it('rejects managerdomain fallback when manager adagents.json scopes a different publisher', async () => {
+      mockedSafeFetch.mockImplementation(async (url) => {
+        if (url === 'https://publisher.example/.well-known/adagents.json') {
+          return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://publisher.example/ads.txt') {
+          return { status: 200, data: Buffer.from('MANAGERDOMAIN=manager.example\n'), headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://manager.example/.well-known/adagents.json') {
+          return {
+            status: 200,
+            data: buf({
+              authorized_agents: [{
+                url: 'https://agent.example',
+                authorized_for: 'Wrong publisher',
+                publisher_properties: [{ publisher_domain: 'other-publisher.example' }],
+              }],
+            }),
+            headers: { 'content-type': 'application/json' },
+          };
+        }
+        throw new Error(`Unexpected URL: ${url}`);
+      });
+
+      const result = await manager.validateDomain('publisher.example');
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.field === 'managerdomain_scope')).toBe(true);
     });
 
     it('does not trigger manager fallback on non-404 adagents responses', async () => {

--- a/server/tests/unit/adagents-manager.test.ts
+++ b/server/tests/unit/adagents-manager.test.ts
@@ -113,6 +113,31 @@ describe('AdAgentsManager', () => {
       expect(result.raw_data).toBeUndefined(); // Don't include HTML error pages
     });
 
+    it('falls back to managerdomain adagents.json when origin adagents.json is missing and ads.txt declares managerdomain', async () => {
+      mockedSafeFetch.mockImplementation(async (url) => {
+        if (url === 'https://publisher.example/.well-known/adagents.json') {
+          return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://publisher.example/ads.txt') {
+          return { status: 200, data: Buffer.from('# managerdomain=manager.example\n'), headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://manager.example/.well-known/adagents.json') {
+          return {
+            status: 200,
+            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'All inventory' }] }),
+            headers: { 'content-type': 'application/json' },
+          };
+        }
+        throw new Error(`Unexpected URL: ${url}`);
+      });
+
+      const result = await manager.validateDomain('publisher.example');
+      expect(result.valid).toBe(true);
+      expect(result.warnings.some(w => w.field === 'managerdomain')).toBe(true);
+      expect(result.domain).toBe('publisher.example');
+      expect(result.url).toBe('https://publisher.example/.well-known/adagents.json');
+    });
+
     it('handles network connection errors', async () => {
       mockedSafeFetch.mockRejectedValue(
         Object.assign(new Error('getaddrinfo ENOTFOUND nonexistent.example.com'), {

--- a/server/tests/unit/adagents-manager.test.ts
+++ b/server/tests/unit/adagents-manager.test.ts
@@ -251,6 +251,109 @@ describe('AdAgentsManager', () => {
       expect(result.warnings.some(w => w.message.includes('good-manager.example'))).toBe(true);
     });
 
+    it('skips #noagents managerdomain entry and uses next eligible entry', async () => {
+      mockedSafeFetch.mockImplementation(async (url) => {
+        if (url === 'https://publisher.example/.well-known/adagents.json') {
+          return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://publisher.example/ads.txt') {
+          return {
+            status: 200,
+            data: Buffer.from('MANAGERDOMAIN=blocked.example #NOAGENTS\nMANAGERDOMAIN=allowed.example\n'),
+            headers: { 'content-type': 'text/plain' },
+          };
+        }
+        if (url === 'https://allowed.example/.well-known/adagents.json') {
+          return {
+            status: 200,
+            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'Allowed' }] }),
+            headers: { 'content-type': 'application/json' },
+          };
+        }
+        if (url === 'https://blocked.example/.well-known/adagents.json') {
+          throw new Error('blocked.example should be skipped due to #NOAGENTS');
+        }
+        throw new Error(`Unexpected URL: ${url}`);
+      });
+
+      const result = await manager.validateDomain('publisher.example');
+      expect(result.valid).toBe(true);
+      expect(result.warnings.some(w => w.message.includes('allowed.example'))).toBe(true);
+    });
+
+    it('ignores managerdomain lines with invalid host token and continues scanning', async () => {
+      mockedSafeFetch.mockImplementation(async (url) => {
+        if (url === 'https://publisher.example/.well-known/adagents.json') {
+          return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://publisher.example/ads.txt') {
+          return {
+            status: 200,
+            data: Buffer.from('MANAGERDOMAIN=https://bad.example\nMANAGERDOMAIN=good.example\n'),
+            headers: { 'content-type': 'text/plain' },
+          };
+        }
+        if (url === 'https://good.example/.well-known/adagents.json') {
+          return {
+            status: 200,
+            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'Good' }] }),
+            headers: { 'content-type': 'application/json' },
+          };
+        }
+        throw new Error(`Unexpected URL: ${url}`);
+      });
+
+      const result = await manager.validateDomain('publisher.example');
+      expect(result.valid).toBe(true);
+      expect(result.warnings.some(w => w.message.includes('good.example'))).toBe(true);
+    });
+
+    it('emits cycle warnings per entry and still tries later non-cyclic managerdomain entries', async () => {
+      mockedSafeFetch.mockImplementation(async (url) => {
+        if (url === 'https://publisher.example/.well-known/adagents.json') {
+          return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://publisher.example/ads.txt') {
+          return {
+            status: 200,
+            data: Buffer.from('MANAGERDOMAIN=publisher.example\nMANAGERDOMAIN=good.example\n'),
+            headers: { 'content-type': 'text/plain' },
+          };
+        }
+        if (url === 'https://good.example/.well-known/adagents.json') {
+          return {
+            status: 200,
+            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'Good' }] }),
+            headers: { 'content-type': 'application/json' },
+          };
+        }
+        throw new Error(`Unexpected URL: ${url}`);
+      });
+
+      const result = await manager.validateDomain('publisher.example');
+      expect(result.valid).toBe(true);
+      expect(result.warnings.some(w => w.message.includes('good.example'))).toBe(true);
+    });
+
+    it('does not trigger manager fallback on non-404 adagents responses', async () => {
+      let calledAdsTxt = false;
+      mockedSafeFetch.mockImplementation(async (url) => {
+        if (url === 'https://publisher.example/.well-known/adagents.json') {
+          return { status: 500, data: 'Server error', headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://publisher.example/ads.txt') {
+          calledAdsTxt = true;
+          return { status: 200, data: Buffer.from('MANAGERDOMAIN=good.example\n'), headers: { 'content-type': 'text/plain' } };
+        }
+        throw new Error(`Unexpected URL: ${url}`);
+      });
+
+      const result = await manager.validateDomain('publisher.example');
+      expect(result.valid).toBe(false);
+      expect(calledAdsTxt).toBe(false);
+      expect(result.errors.some(e => e.message.includes('HTTP 500'))).toBe(true);
+    });
+
     it('handles network connection errors', async () => {
       mockedSafeFetch.mockRejectedValue(
         Object.assign(new Error('getaddrinfo ENOTFOUND nonexistent.example.com'), {

--- a/server/tests/unit/adagents-manager.test.ts
+++ b/server/tests/unit/adagents-manager.test.ts
@@ -198,6 +198,59 @@ describe('AdAgentsManager', () => {
       expect(result.errors.some(e => e.field === 'http_status')).toBe(true);
     });
 
+    it('accepts MANAGERDOMAIN directive form (non-comment) case-insensitively', async () => {
+      mockedSafeFetch.mockImplementation(async (url) => {
+        if (url === 'https://publisher.example/.well-known/adagents.json') {
+          return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://publisher.example/ads.txt') {
+          return { status: 200, data: Buffer.from('MANAGERDOMAIN=Manager.Example\n'), headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://manager.example/.well-known/adagents.json') {
+          return {
+            status: 200,
+            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'All inventory' }] }),
+            headers: { 'content-type': 'application/json' },
+          };
+        }
+        throw new Error(`Unexpected URL: ${url}`);
+      });
+
+      const result = await manager.validateDomain('publisher.example');
+      expect(result.valid).toBe(true);
+      expect(result.warnings.some(w => w.field === 'managerdomain')).toBe(true);
+    });
+
+    it('tries multiple managerdomain entries in order until one validates', async () => {
+      mockedSafeFetch.mockImplementation(async (url) => {
+        if (url === 'https://publisher.example/.well-known/adagents.json') {
+          return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://publisher.example/ads.txt') {
+          return {
+            status: 200,
+            data: Buffer.from('MANAGERDOMAIN=bad-manager.example\nMANAGERDOMAIN=good-manager.example\n'),
+            headers: { 'content-type': 'text/plain' },
+          };
+        }
+        if (url === 'https://bad-manager.example/.well-known/adagents.json') {
+          return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://good-manager.example/.well-known/adagents.json') {
+          return {
+            status: 200,
+            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'All inventory' }] }),
+            headers: { 'content-type': 'application/json' },
+          };
+        }
+        throw new Error(`Unexpected URL: ${url}`);
+      });
+
+      const result = await manager.validateDomain('publisher.example');
+      expect(result.valid).toBe(true);
+      expect(result.warnings.some(w => w.message.includes('good-manager.example'))).toBe(true);
+    });
+
     it('handles network connection errors', async () => {
       mockedSafeFetch.mockRejectedValue(
         Object.assign(new Error('getaddrinfo ENOTFOUND nonexistent.example.com'), {

--- a/server/tests/unit/adagents-manager.test.ts
+++ b/server/tests/unit/adagents-manager.test.ts
@@ -71,6 +71,7 @@ describe('AdAgentsManager', () => {
       expect(result.domain).toBe('example.com');
       expect(result.url).toBe('https://example.com/.well-known/adagents.json');
       expect(result.status_code).toBe(200);
+      expect(result.discovery_method).toBe('direct');
     });
 
     it('normalizes domain by removing protocol', async () => {
@@ -124,7 +125,7 @@ describe('AdAgentsManager', () => {
         if (url === 'https://manager.example/.well-known/adagents.json') {
           return {
             status: 200,
-            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'All inventory' }] }),
+            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'All inventory', publisher_properties: [{ publisher_domain: 'publisher.example', selection_type: 'all' }] }] }),
             headers: { 'content-type': 'application/json' },
           };
         }
@@ -209,7 +210,7 @@ describe('AdAgentsManager', () => {
         if (url === 'https://manager.example/.well-known/adagents.json') {
           return {
             status: 200,
-            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'All inventory' }] }),
+            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'All inventory', publisher_properties: [{ publisher_domain: 'publisher.example', selection_type: 'all' }] }] }),
             headers: { 'content-type': 'application/json' },
           };
         }
@@ -285,6 +286,29 @@ describe('AdAgentsManager', () => {
       const result = await manager.validateDomain('publisher.example');
       expect(result.valid).toBe(true);
       expect(result.warnings.some(w => w.message.includes('allowed.example'))).toBe(true);
+    });
+
+    it('rejects managerdomain fallback when manager adagents.json does not explicitly scope to source publisher', async () => {
+      mockedSafeFetch.mockImplementation(async (url) => {
+        if (url === 'https://publisher.example/.well-known/adagents.json') {
+          return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://publisher.example/ads.txt') {
+          return { status: 200, data: Buffer.from('MANAGERDOMAIN=manager.example\n'), headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://manager.example/.well-known/adagents.json') {
+          return {
+            status: 200,
+            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'All inventory' }] }),
+            headers: { 'content-type': 'application/json' },
+          };
+        }
+        throw new Error(`Unexpected URL: ${url}`);
+      });
+
+      const result = await manager.validateDomain('publisher.example');
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.field === 'managerdomain_scope')).toBe(true);
     });
 
     it('ignores managerdomain lines with invalid host token and continues scanning', async () => {
@@ -856,6 +880,7 @@ describe('AdAgentsManager', () => {
       expect(callCount).toBe(2); // Two requests: initial + authoritative
       expect(result.valid).toBe(true);
       expect(result.errors).toHaveLength(0);
+      expect(result.discovery_method).toBe('authoritative_location');
     });
 
     it('rejects non-HTTPS authoritative locations', async () => {

--- a/server/tests/unit/adagents-manager.test.ts
+++ b/server/tests/unit/adagents-manager.test.ts
@@ -221,7 +221,7 @@ describe('AdAgentsManager', () => {
       expect(result.warnings.some(w => w.field === 'managerdomain')).toBe(true);
     });
 
-    it('tries multiple managerdomain entries in order until one validates', async () => {
+    it('aborts fallback when multiple managerdomain entries are present', async () => {
       mockedSafeFetch.mockImplementation(async (url) => {
         if (url === 'https://publisher.example/.well-known/adagents.json') {
           return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
@@ -233,25 +233,16 @@ describe('AdAgentsManager', () => {
             headers: { 'content-type': 'text/plain' },
           };
         }
-        if (url === 'https://bad-manager.example/.well-known/adagents.json') {
-          return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
-        }
-        if (url === 'https://good-manager.example/.well-known/adagents.json') {
-          return {
-            status: 200,
-            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'All inventory' }] }),
-            headers: { 'content-type': 'application/json' },
-          };
-        }
         throw new Error(`Unexpected URL: ${url}`);
       });
 
       const result = await manager.validateDomain('publisher.example');
-      expect(result.valid).toBe(true);
-      expect(result.warnings.some(w => w.message.includes('good-manager.example'))).toBe(true);
+      expect(result.valid).toBe(false);
+      expect(result.warnings.some(w => w.message.includes('multiple managerdomain entries'))).toBe(true);
+      expect(result.errors.some(e => e.field === 'http_status')).toBe(true);
     });
 
-    it('skips #noagents managerdomain entry and uses next eligible entry', async () => {
+    it('uses next eligible managerdomain when #noagents removes the first candidate', async () => {
       mockedSafeFetch.mockImplementation(async (url) => {
         if (url === 'https://publisher.example/.well-known/adagents.json') {
           return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
@@ -308,7 +299,7 @@ describe('AdAgentsManager', () => {
       expect(result.warnings.some(w => w.message.includes('good.example'))).toBe(true);
     });
 
-    it('emits cycle warnings per entry and still tries later non-cyclic managerdomain entries', async () => {
+    it('aborts fallback when multiple entries include cyclic and non-cyclic managerdomain values', async () => {
       mockedSafeFetch.mockImplementation(async (url) => {
         if (url === 'https://publisher.example/.well-known/adagents.json') {
           return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
@@ -320,19 +311,13 @@ describe('AdAgentsManager', () => {
             headers: { 'content-type': 'text/plain' },
           };
         }
-        if (url === 'https://good.example/.well-known/adagents.json') {
-          return {
-            status: 200,
-            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'Good' }] }),
-            headers: { 'content-type': 'application/json' },
-          };
-        }
         throw new Error(`Unexpected URL: ${url}`);
       });
 
       const result = await manager.validateDomain('publisher.example');
-      expect(result.valid).toBe(true);
-      expect(result.warnings.some(w => w.message.includes('good.example'))).toBe(true);
+      expect(result.valid).toBe(false);
+      expect(result.warnings.some(w => w.message.includes('multiple managerdomain entries'))).toBe(true);
+      expect(result.errors.some(e => e.field === 'http_status')).toBe(true);
     });
 
     it('does not trigger manager fallback on non-404 adagents responses', async () => {

--- a/server/tests/unit/adagents-manager.test.ts
+++ b/server/tests/unit/adagents-manager.test.ts
@@ -71,6 +71,7 @@ describe('AdAgentsManager', () => {
       expect(result.domain).toBe('example.com');
       expect(result.url).toBe('https://example.com/.well-known/adagents.json');
       expect(result.status_code).toBe(200);
+      expect(result.discovery_method).toBe('direct');
     });
 
     it('normalizes domain by removing protocol', async () => {
@@ -856,6 +857,7 @@ describe('AdAgentsManager', () => {
       expect(callCount).toBe(2); // Two requests: initial + authoritative
       expect(result.valid).toBe(true);
       expect(result.errors).toHaveLength(0);
+      expect(result.discovery_method).toBe('authoritative_location');
     });
 
     it('rejects non-HTTPS authoritative locations', async () => {

--- a/server/tests/unit/adagents-manager.test.ts
+++ b/server/tests/unit/adagents-manager.test.ts
@@ -178,6 +178,26 @@ describe('AdAgentsManager', () => {
       expect(result.errors.some(e => e.field === 'http_status')).toBe(true);
     });
 
+    it('ignores managerdomain when the managerdomain line has #noagents', async () => {
+      mockedSafeFetch.mockImplementation(async (url) => {
+        if (url === 'https://publisher.example/.well-known/adagents.json') {
+          return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://publisher.example/ads.txt') {
+          return {
+            status: 200,
+            data: Buffer.from('# managerdomain=manager.example #noagents\n'),
+            headers: { 'content-type': 'text/plain' },
+          };
+        }
+        throw new Error(`Unexpected URL: ${url}`);
+      });
+
+      const result = await manager.validateDomain('publisher.example');
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.field === 'http_status')).toBe(true);
+    });
+
     it('handles network connection errors', async () => {
       mockedSafeFetch.mockRejectedValue(
         Object.assign(new Error('getaddrinfo ENOTFOUND nonexistent.example.com'), {

--- a/server/tests/unit/adagents-manager.test.ts
+++ b/server/tests/unit/adagents-manager.test.ts
@@ -137,6 +137,8 @@ describe('AdAgentsManager', () => {
       expect(result.warnings.some(w => w.field === 'managerdomain')).toBe(true);
       expect(result.domain).toBe('publisher.example');
       expect(result.url).toBe('https://publisher.example/.well-known/adagents.json');
+      expect(result.discovery_method).toBe('ads_txt_managerdomain');
+      expect(result.manager_domain).toBe('manager.example');
     });
 
     it('does not recurse indefinitely when managerdomain points back to original domain', async () => {
@@ -250,11 +252,23 @@ describe('AdAgentsManager', () => {
             headers: { 'content-type': 'text/plain' },
           };
         }
+        if (url === 'https://good-manager.example/.well-known/adagents.json') {
+          return {
+            status: 200,
+            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'Good' }] }),
+            headers: { 'content-type': 'application/json' },
+          };
+        }
+        if (url === 'https://bad-manager.example/.well-known/adagents.json') {
+          throw new Error('bad-manager.example should not be tried; last entry wins');
+        }
         throw new Error(`Unexpected URL: ${url}`);
       });
 
       const result = await manager.validateDomain('publisher.example');
       expect(result.valid).toBe(true);
+      expect(result.discovery_method).toBe('ads_txt_managerdomain');
+      expect(result.manager_domain).toBe('good-manager.example');
       expect(result.warnings.some(w => w.message.includes('good-manager.example'))).toBe(true);
     });
 


### PR DESCRIPTION
Many publishers designate managerdomain as the entity responsible for ad sales; if this is defined one should look to it for adagents.json on 404

Refs #4175

Added clarification to prevent contradiction with #2169 

---

## Summary

Adds a one-hop discovery fallback for adagents. json via the ads. txt managerdomain declaration. When https://{publisher}/. well-known/adagents. json returns 404, validators may consult https://{publisher}/ads. txt for a managerdomain directive and, if present, attempt discovery on the manager domain. This is a compatibility affordance for publisher-manager topologies where a publisher has delegated ad sales operations (and, by extension, agent authorization) to a manager — common in managed networks, header bidding wrappers, and SSP-managed inventory. ## Why

Many publishers in managed-network arrangements don&#39;t host their own adagents. json — their manager does. Without a fallback, validators see a 404 and treat the publisher as missing authorization data entirely, even though a valid declaration exists one hop away.