### PR TITLE
feat(member-profile): self-service Linked Domains card (Stage 2 of #321)

### DIFF
--- a/.changeset/member-linked-domains-self-service.md
+++ b/.changeset/member-linked-domains-self-service.md
@@ -1,0 +1,4 @@
+---
+---
+
+Member self-service for org-linked domains: GET /api/me/organization/domains and PUT /api/me/organization/domains/:domain/primary. The PUT writes BOTH `organization_domains.is_primary` and `member_profiles.primary_brand_domain` in a single transaction so members don't have to know about the two-primary distinction. Adds a Linked Domains card to the member-profile UI for company orgs. Closes #4158 (Stage 2 of the domain-cleanup series). POST/DELETE deferred to a follow-up since they require WorkOS verification-flow integration.

--- a/server/public/member-profile.html
+++ b/server/public/member-profile.html
@@ -897,6 +897,20 @@
           </div>
           </div><!-- end photo-section -->
 
+          <!-- Linked Domains: WorkOS-verified domains owned by this org.
+               Self-service mirror of the admin "Linked Domains" card; lets
+               members switch the primary without filing a support ticket. -->
+          <div id="linked-domains-section" style="display: none;">
+            <h2>Linked Domains</h2>
+            <p style="color: var(--color-text-secondary); font-size: var(--text-sm); margin-bottom: var(--space-3);">
+              Domains your organization has verified via SSO. The primary domain drives auto-membership inference (employees signing up with this domain auto-link to your org) and seeds your brand identity.
+            </p>
+            <div id="linked-domains-list" style="margin-bottom: var(--space-4);"></div>
+            <p id="linked-domains-empty" style="display: none; color: var(--color-text-muted); font-size: var(--text-sm); padding: var(--space-3); background: var(--color-bg-subtle); border-radius: var(--radius-md);">
+              No verified domains yet. Domains are added through your SSO provider; once your IT verifies them via WorkOS, they'll appear here.
+            </p>
+          </div>
+
           <!-- Brand identity (companies only) -->
           <div id="logos-section">
           <h2>Brand identity</h2>
@@ -1696,6 +1710,83 @@
       });
     }
 
+    // ============================================================
+    // Linked Domains (self-service primary-domain switching)
+    // ============================================================
+
+    async function loadLinkedDomains() {
+      const section = document.getElementById('linked-domains-section');
+      try {
+        const resp = await fetch('/api/me/organization/domains', { credentials: 'include' });
+        if (!resp.ok) {
+          // Don't block the page on this — just leave the section hidden.
+          if (section) section.style.display = 'none';
+          return;
+        }
+        const data = await resp.json();
+        if (!data.domains || data.domains.length === 0) {
+          if (section) section.style.display = 'block';
+          document.getElementById('linked-domains-empty').style.display = 'block';
+          document.getElementById('linked-domains-list').innerHTML = '';
+          return;
+        }
+        if (section) section.style.display = 'block';
+        document.getElementById('linked-domains-empty').style.display = 'none';
+        renderLinkedDomains(data.domains);
+      } catch (err) {
+        if (section) section.style.display = 'none';
+      }
+    }
+
+    function renderLinkedDomains(domains) {
+      const list = document.getElementById('linked-domains-list');
+      list.innerHTML = domains.map(function(d) {
+        const verifiedBadge = d.verified
+          ? '<span style="display: inline-block; padding: 2px 8px; background: var(--color-success-100, #dcfce7); color: var(--color-success-700, #15803d); border-radius: var(--radius-sm); font-size: 11px; font-weight: var(--font-medium);">Verified</span>'
+          : '<span style="display: inline-block; padding: 2px 8px; background: var(--color-warning-100, #fef3c7); color: var(--color-warning-700, #b45309); border-radius: var(--radius-sm); font-size: 11px; font-weight: var(--font-medium);">Pending</span>';
+        const primaryBadge = d.is_primary
+          ? '<span style="display: inline-block; padding: 2px 8px; background: var(--color-brand-bg); color: var(--color-primary-700); border-radius: var(--radius-sm); font-size: 11px; font-weight: var(--font-semibold);">Primary</span>'
+          : '';
+        const sourceLabel = d.source ? '<span style="color: var(--color-text-muted); font-size: var(--text-xs);">' + escapeHtml(d.source) + '</span>' : '';
+        const action = (!d.is_primary && d.verified)
+          ? '<button type="button" onclick="setLinkedDomainPrimary(\'' + escapeHtml(d.domain) + '\', this)" style="padding: var(--space-2) var(--space-4); background: var(--color-bg-subtle); color: var(--color-text-secondary); border: 1px solid var(--color-border); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer;">Set Primary</button>'
+          : '';
+        return (
+          '<div style="display: flex; align-items: center; gap: var(--space-3); padding: var(--space-3) var(--space-4); background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: var(--radius-md); margin-bottom: var(--space-2);">' +
+            '<div style="font-weight: var(--font-medium); color: var(--color-text-heading); flex-grow: 1;">' + escapeHtml(d.domain) + '</div>' +
+            '<div style="display: flex; gap: var(--space-2); align-items: center;">' +
+              verifiedBadge + primaryBadge + sourceLabel +
+            '</div>' +
+            '<div style="margin-left: auto;">' + action + '</div>' +
+          '</div>'
+        );
+      }).join('');
+    }
+
+    async function setLinkedDomainPrimary(domain, btn) {
+      const originalText = btn ? btn.textContent : '';
+      if (btn) { btn.disabled = true; btn.textContent = 'Setting...'; }
+      try {
+        const resp = await fetch('/api/me/organization/domains/' + encodeURIComponent(domain) + '/primary', {
+          method: 'PUT',
+          credentials: 'include',
+        });
+        const data = await resp.json().catch(function() { return {}; });
+        if (!resp.ok) {
+          alert(data.message || data.error || 'Failed to set primary domain');
+          if (btn) { btn.disabled = false; btn.textContent = originalText; }
+          return;
+        }
+        // Reload both the domain list and the brand section since
+        // primary_brand_domain may have changed too.
+        await loadLinkedDomains();
+        if (typeof loadProfile === 'function') loadProfile();
+      } catch (err) {
+        alert('Failed to set primary domain: ' + err.message);
+        if (btn) { btn.disabled = false; btn.textContent = originalText; }
+      }
+    }
+
     async function verifyBrandNow(domain) {
       const btn = document.getElementById('brand-verify-btn');
       if (btn) { btn.textContent = 'Checking...'; btn.disabled = true; }
@@ -2242,6 +2333,12 @@
       }
       // Populate brand identity section
       populateBrandSection(profile);
+
+      // Populate Linked Domains section (companies only — for personal orgs
+      // there's nothing to switch between).
+      if (profile.is_personal === false || (profile.is_personal == null && profile.organization_type !== 'personal')) {
+        loadLinkedDomains();
+      }
       document.getElementById('contact_email').value = profile.contact_email || '';
       // Set phone and trigger formatting
       const phoneInput = document.getElementById('contact_phone');

--- a/server/public/member-profile.html
+++ b/server/public/member-profile.html
@@ -906,9 +906,6 @@
               Domains your organization has verified via SSO. The primary domain drives auto-membership inference (employees signing up with this domain auto-link to your org) and seeds your brand identity.
             </p>
             <div id="linked-domains-list" style="margin-bottom: var(--space-4);"></div>
-            <p id="linked-domains-empty" style="display: none; color: var(--color-text-muted); font-size: var(--text-sm); padding: var(--space-3); background: var(--color-bg-subtle); border-radius: var(--radius-md);">
-              No verified domains yet. Domains are added through your SSO provider; once your IT verifies them via WorkOS, they'll appear here.
-            </p>
           </div>
 
           <!-- Brand identity (companies only) -->
@@ -1719,19 +1716,18 @@
       try {
         const resp = await fetch('/api/me/organization/domains', { credentials: 'include' });
         if (!resp.ok) {
-          // Don't block the page on this — just leave the section hidden.
           if (section) section.style.display = 'none';
           return;
         }
         const data = await resp.json();
         if (!data.domains || data.domains.length === 0) {
-          if (section) section.style.display = 'block';
-          document.getElementById('linked-domains-empty').style.display = 'block';
-          document.getElementById('linked-domains-list').innerHTML = '';
+          // Personal orgs typically have 0 verified domains. Keep the section
+          // hidden rather than showing an empty-state — there's nothing
+          // actionable for them here.
+          if (section) section.style.display = 'none';
           return;
         }
         if (section) section.style.display = 'block';
-        document.getElementById('linked-domains-empty').style.display = 'none';
         renderLinkedDomains(data.domains);
       } catch (err) {
         if (section) section.style.display = 'none';

--- a/server/public/member-profile.html
+++ b/server/public/member-profile.html
@@ -2334,11 +2334,11 @@
       // Populate brand identity section
       populateBrandSection(profile);
 
-      // Populate Linked Domains section (companies only — for personal orgs
-      // there's nothing to switch between).
-      if (profile.is_personal === false || (profile.is_personal == null && profile.organization_type !== 'personal')) {
-        loadLinkedDomains();
-      }
+      // Populate Linked Domains section. The section starts hidden and
+      // loadLinkedDomains() reveals it only when the API returns ≥1 row,
+      // so personal orgs (which usually have 0 verified domains) silently
+      // stay hidden — no extra gating needed here.
+      loadLinkedDomains();
       document.getElementById('contact_email').value = profile.contact_email || '';
       // Set phone and trigger formatting
       const phoneInput = document.getElementById('contact_phone');

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -100,6 +100,7 @@ import { createContentRouter, createMyContentRouter } from "./routes/content.js"
 import { createMeetingRouters } from "./routes/meetings.js";
 import { createMemberProfileRouter, createAdminMemberProfileRouter } from "./routes/member-profiles.js";
 import { createMemberAgentsRouter } from "./routes/member-agents.js";
+import { createMeOrganizationDomainsRouter } from "./routes/me-organization-domains.js";
 import { createPublicPortraitRouter, createPortraitRouter, createAdminPortraitRouter } from "./routes/portraits.js";
 import { createCommunityRouters } from "./routes/community.js";
 import { createCertificationRouters } from "./routes/certification.js";
@@ -1227,6 +1228,13 @@ export class HTTPServer {
       invalidateMemberContextCache,
     });
     this.app.use('/api/me/agents', memberAgentsRouter);
+
+    // Member-facing self-service for org-linked domains.
+    const meOrganizationDomainsRouter = createMeOrganizationDomainsRouter({
+      workos,
+      invalidateMemberContextCache,
+    });
+    this.app.use('/api/me/organization/domains', meOrganizationDomainsRouter);
 
     // Mount portrait routes
     this.app.use('/api/portraits', createPublicPortraitRouter());

--- a/server/src/routes/me-organization-domains.ts
+++ b/server/src/routes/me-organization-domains.ts
@@ -142,13 +142,11 @@ export function createMeOrganizationDomainsRouter(
       try {
         normalizedDomain = canonicalizeBrandDomain(req.params.domain);
       } catch (err) {
-        return res.status(400).json({
-          error: 'invalid_domain',
-          message: err instanceof Error ? err.message : 'Invalid domain',
-        });
+        logger.warn({ err, raw: req.params.domain }, 'Rejected invalid domain in PUT primary');
+        return res.status(400).json({ error: 'invalid_domain' });
       }
       if (normalizedDomain.length > 253) {
-        return res.status(400).json({ error: 'invalid_domain', message: 'Domain too long' });
+        return res.status(400).json({ error: 'invalid_domain' });
       }
 
       const pool = getPool();

--- a/server/src/routes/me-organization-domains.ts
+++ b/server/src/routes/me-organization-domains.ts
@@ -1,0 +1,239 @@
+/**
+ * Member-facing self-service for the org's linked domains.
+ *
+ * Mirrors the admin Set-Primary affordance from `admin-account-detail.html`
+ * but scoped to the caller's own organization. The PUT path writes BOTH
+ * `organization_domains.is_primary` (org-membership inference primary) AND
+ * `member_profiles.primary_brand_domain` (brand-identity primary) when the
+ * domain is claimable, so members don't have to think about the two-primary
+ * distinction documented in the four-domain-columns audit.
+ *
+ * MVP scope: list + set-primary. Add (POST → WorkOS verification challenge)
+ * and remove (DELETE) deferred to a follow-up — the WorkOS-side wiring is
+ * materially more work than the read+set paths.
+ *
+ * Auth: WorkOS session OR Bearer API key (`requireAuth` handles both).
+ * Role: GET allows any member; PUT requires owner/admin.
+ */
+
+import { Router } from 'express';
+import type { WorkOS } from '@workos-inc/node';
+import { createLogger } from '../logger.js';
+import { requireAuth } from '../middleware/auth.js';
+import { resolvePrimaryOrganization } from '../db/users-db.js';
+import { resolveUserOrgMembership } from '../utils/resolve-user-org-membership.js';
+import { getPool } from '../db/client.js';
+import {
+  assertClaimableBrandDomain,
+  canonicalizeBrandDomain,
+} from '../services/identifier-normalization.js';
+
+const logger = createLogger('me-organization-domains');
+
+export interface MeOrganizationDomainsRouterConfig {
+  workos: WorkOS | null;
+  invalidateMemberContextCache: () => void;
+}
+
+export function createMeOrganizationDomainsRouter(
+  config: MeOrganizationDomainsRouterConfig,
+): Router {
+  const { workos, invalidateMemberContextCache } = config;
+  const router = Router();
+
+  async function resolveTargetOrgId(req: any, res: any): Promise<string | null> {
+    const requested = typeof req.query?.org === 'string' && req.query.org.length > 0
+      ? req.query.org
+      : null;
+
+    if (requested) {
+      const membership = await resolveUserOrgMembership(workos, req.user!.id, requested);
+      if (!membership) {
+        res.status(403).json({
+          error: 'Not authorized',
+          message: 'User is not a member of the requested organization',
+        });
+        return null;
+      }
+      return requested;
+    }
+
+    const primary = await resolvePrimaryOrganization(req.user!.id);
+    if (!primary) {
+      res.status(400).json({ error: 'No organization associated with this account' });
+      return null;
+    }
+    return primary;
+  }
+
+  // GET /api/me/organization/domains — list verified domains for the caller's org.
+  router.get('/', requireAuth, async (req, res) => {
+    try {
+      const orgId = await resolveTargetOrgId(req, res);
+      if (!orgId) return;
+
+      const pool = getPool();
+      const result = await pool.query<{
+        domain: string;
+        is_primary: boolean;
+        verified: boolean;
+        source: string;
+      }>(
+        `SELECT domain, is_primary, verified, source
+           FROM organization_domains
+          WHERE workos_organization_id = $1
+          ORDER BY is_primary DESC, created_at ASC`,
+        [orgId],
+      );
+
+      const profileRow = await pool.query<{ primary_brand_domain: string | null }>(
+        `SELECT primary_brand_domain FROM member_profiles WHERE workos_organization_id = $1`,
+        [orgId],
+      );
+      const brandPrimary = profileRow.rows[0]?.primary_brand_domain ?? null;
+
+      const domains = result.rows.map((row) => {
+        let claimable = false;
+        try {
+          assertClaimableBrandDomain(canonicalizeBrandDomain(row.domain));
+          claimable = true;
+        } catch {
+          claimable = false;
+        }
+        return {
+          domain: row.domain,
+          is_primary: row.is_primary,
+          verified: row.verified,
+          source: row.source,
+          is_brand_primary: brandPrimary === row.domain,
+          claimable,
+        };
+      });
+
+      return res.json({ domains, primary_brand_domain: brandPrimary });
+    } catch (err) {
+      logger.error({ err }, 'GET /api/me/organization/domains failed');
+      return res.status(500).json({ error: 'Failed to list domains' });
+    }
+  });
+
+  // PUT /api/me/organization/domains/:domain/primary — set primary domain.
+  // Writes BOTH organization_domains.is_primary AND member_profiles.primary_brand_domain
+  // (when the domain is claimable) in a single transaction so members can't end up
+  // with the two-primary fields out of sync.
+  router.put('/:domain/primary', requireAuth, async (req, res) => {
+    try {
+      const orgId = await resolveTargetOrgId(req, res);
+      if (!orgId) return;
+
+      // Role gate: owners/admins only. Members can read but not change.
+      const membership = await resolveUserOrgMembership(workos, req.user!.id, orgId);
+      if (!membership || (membership.role !== 'owner' && membership.role !== 'admin')) {
+        return res.status(403).json({
+          error: 'Not authorized',
+          message: 'Only owners and admins can change the primary domain',
+        });
+      }
+
+      const normalizedDomain = req.params.domain.toLowerCase().trim();
+      const pool = getPool();
+      const client = await pool.connect();
+
+      try {
+        await client.query('BEGIN');
+
+        // Verify the domain belongs to this org and is verified. We refuse to
+        // promote a pending/unverified row — letting an attacker set
+        // `pending` rows as primary would let them claim a domain via SSO
+        // before WorkOS confirms control.
+        const domainRow = await client.query<{ verified: boolean }>(
+          `SELECT verified FROM organization_domains
+            WHERE workos_organization_id = $1 AND domain = $2`,
+          [orgId, normalizedDomain],
+        );
+        if (domainRow.rowCount === 0) {
+          await client.query('ROLLBACK');
+          return res.status(404).json({ error: 'Domain not found for this organization' });
+        }
+        if (!domainRow.rows[0].verified) {
+          await client.query('ROLLBACK');
+          return res.status(400).json({
+            error: 'domain_not_verified',
+            message: 'The domain must be verified before it can be set as primary',
+          });
+        }
+
+        // Clear existing primary, set new primary, and update the
+        // denormalized organizations.email_domain in one transaction.
+        await client.query(
+          `UPDATE organization_domains SET is_primary = false, updated_at = NOW()
+            WHERE workos_organization_id = $1 AND is_primary = true`,
+          [orgId],
+        );
+        await client.query(
+          `UPDATE organization_domains SET is_primary = true, updated_at = NOW()
+            WHERE workos_organization_id = $1 AND domain = $2`,
+          [orgId, normalizedDomain],
+        );
+        await client.query(
+          `UPDATE organizations SET email_domain = $1, updated_at = NOW()
+            WHERE workos_organization_id = $2`,
+          [normalizedDomain, orgId],
+        );
+
+        // Coherent dual-write: also update member_profiles.primary_brand_domain
+        // when the domain is claimable. This is the bit the admin set-primary
+        // path doesn't do — and the cause of the Media.net escalation #321.
+        // Members shouldn't have to think about the two-primary distinction.
+        let brandPrimaryUpdated = false;
+        let claimable = false;
+        try {
+          assertClaimableBrandDomain(canonicalizeBrandDomain(normalizedDomain));
+          claimable = true;
+        } catch {
+          claimable = false;
+        }
+        if (claimable) {
+          const updated = await client.query(
+            `UPDATE member_profiles
+                SET primary_brand_domain = $1, updated_at = NOW()
+              WHERE workos_organization_id = $2`,
+            [normalizedDomain, orgId],
+          );
+          brandPrimaryUpdated = (updated.rowCount ?? 0) > 0;
+        }
+
+        await client.query('COMMIT');
+
+        if (brandPrimaryUpdated) invalidateMemberContextCache();
+
+        logger.info(
+          {
+            orgId,
+            domain: normalizedDomain,
+            actor: req.user!.id,
+            via_dev_bypass: membership.via_dev_bypass,
+            brand_primary_updated: brandPrimaryUpdated,
+          },
+          'Set primary domain via member self-service',
+        );
+
+        return res.json({
+          success: true,
+          primary_domain: normalizedDomain,
+          brand_primary_updated: brandPrimaryUpdated,
+        });
+      } catch (err) {
+        await client.query('ROLLBACK').catch(() => {});
+        throw err;
+      } finally {
+        client.release();
+      }
+    } catch (err) {
+      logger.error({ err }, 'PUT /api/me/organization/domains/:domain/primary failed');
+      return res.status(500).json({ error: 'Failed to set primary domain' });
+    }
+  });
+
+  return router;
+}

--- a/server/src/routes/me-organization-domains.ts
+++ b/server/src/routes/me-organization-domains.ts
@@ -135,19 +135,48 @@ export function createMeOrganizationDomainsRouter(
         });
       }
 
-      const normalizedDomain = req.params.domain.toLowerCase().trim();
+      // Canonicalize the input domain — strips protocol/path/`www.`/etc. and
+      // rejects shapes that aren't valid brand-domain inputs. Reuses the same
+      // function the GET path uses to compute `claimable`.
+      let normalizedDomain: string;
+      try {
+        normalizedDomain = canonicalizeBrandDomain(req.params.domain);
+      } catch (err) {
+        return res.status(400).json({
+          error: 'invalid_domain',
+          message: err instanceof Error ? err.message : 'Invalid domain',
+        });
+      }
+      if (normalizedDomain.length > 253) {
+        return res.status(400).json({ error: 'invalid_domain', message: 'Domain too long' });
+      }
+
       const pool = getPool();
       const client = await pool.connect();
 
       try {
         await client.query('BEGIN');
 
+        // Lock the org row to serialize against the WorkOS webhook
+        // (`upsertOrganizationDomain`), which takes the same row lock when it
+        // promotes a newly-verified domain to is_primary. Without this, our
+        // three writes can interleave with the webhook's two writes and end
+        // up with `organizations.email_domain` reflecting whichever
+        // transaction committed last.
+        await client.query(
+          'SELECT 1 FROM organizations WHERE workos_organization_id = $1 FOR UPDATE',
+          [orgId],
+        );
+
         // Verify the domain belongs to this org and is verified. We refuse to
         // promote a pending/unverified row — letting an attacker set
         // `pending` rows as primary would let them claim a domain via SSO
-        // before WorkOS confirms control.
-        const domainRow = await client.query<{ verified: boolean }>(
-          `SELECT verified FROM organization_domains
+        // before WorkOS confirms control. Also restrict to `source = 'workos'`
+        // for the brand-identity dual-write below; admin-imported / manual
+        // "verified" rows aren't actually DNS-proof-of-control claims (same
+        // trust boundary the backfill script enforces).
+        const domainRow = await client.query<{ verified: boolean; source: string }>(
+          `SELECT verified, source FROM organization_domains
             WHERE workos_organization_id = $1 AND domain = $2`,
           [orgId, normalizedDomain],
         );
@@ -162,6 +191,7 @@ export function createMeOrganizationDomainsRouter(
             message: 'The domain must be verified before it can be set as primary',
           });
         }
+        const sourceIsWorkos = domainRow.rows[0].source === 'workos';
 
         // Clear existing primary, set new primary, and update the
         // denormalized organizations.email_domain in one transaction.
@@ -182,18 +212,24 @@ export function createMeOrganizationDomainsRouter(
         );
 
         // Coherent dual-write: also update member_profiles.primary_brand_domain
-        // when the domain is claimable. This is the bit the admin set-primary
-        // path doesn't do — and the cause of the Media.net escalation #321.
-        // Members shouldn't have to think about the two-primary distinction.
+        // when the domain is claimable AND came from a WorkOS proof-of-control.
+        // This is the bit the admin set-primary path doesn't do — and the cause
+        // of the Media.net escalation #321. Members shouldn't have to think
+        // about the two-primary distinction.
+        //
+        // Source restriction: `source='manual'` / `'import'` rows can be
+        // flagged verified by admin tooling without actual DNS proof, so we
+        // refuse to let them seed brand identity. Same trust boundary the
+        // backfill-primary-brand-domain script applies.
         let brandPrimaryUpdated = false;
         let claimable = false;
         try {
-          assertClaimableBrandDomain(canonicalizeBrandDomain(normalizedDomain));
+          assertClaimableBrandDomain(normalizedDomain);
           claimable = true;
         } catch {
           claimable = false;
         }
-        if (claimable) {
+        if (claimable && sourceIsWorkos) {
           const updated = await client.query(
             `UPDATE member_profiles
                 SET primary_brand_domain = $1, updated_at = NOW()
@@ -224,7 +260,9 @@ export function createMeOrganizationDomainsRouter(
           brand_primary_updated: brandPrimaryUpdated,
         });
       } catch (err) {
-        await client.query('ROLLBACK').catch(() => {});
+        await client.query('ROLLBACK').catch((rbErr) => {
+          logger.error({ rbErr, orgId }, 'ROLLBACK failed in PUT primary');
+        });
         throw err;
       } finally {
         client.release();

--- a/server/tests/integration/me-organization-domains.test.ts
+++ b/server/tests/integration/me-organization-domains.test.ts
@@ -21,8 +21,9 @@ vi.hoisted(() => {
 });
 
 // Replace `requireAuth` with a test stub that reads the user id from
-// x-test-user. We don't want to forge a signed WorkOS session cookie just to
-// exercise our route logic; the auth surface is tested elsewhere.
+// x-test-user. The real requireAuth reads a signed WorkOS session cookie
+// (or static admin key); forging either just to exercise route logic is
+// noise. The auth surface itself is covered elsewhere.
 vi.mock('../../src/middleware/auth.js', async (importOriginal) => {
   const orig = (await importOriginal()) as Record<string, unknown>;
   return {
@@ -54,7 +55,7 @@ async function cleanup(pool: Pool) {
   await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [TEST_ORG]);
 }
 
-async function seedOrgWithDomains(pool: Pool, domains: Array<{ domain: string; verified: boolean; is_primary: boolean }>) {
+async function seedOrgWithDomains(pool: Pool, domains: Array<{ domain: string; verified: boolean; is_primary: boolean; source?: string }>) {
   await pool.query(
     `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
      VALUES ($1, $2, false, NOW(), NOW())
@@ -64,9 +65,9 @@ async function seedOrgWithDomains(pool: Pool, domains: Array<{ domain: string; v
   for (const d of domains) {
     await pool.query(
       `INSERT INTO organization_domains (workos_organization_id, domain, verified, is_primary, source, created_at, updated_at)
-       VALUES ($1, $2, $3, $4, 'workos', NOW(), NOW())
-       ON CONFLICT (domain) DO UPDATE SET verified = EXCLUDED.verified, is_primary = EXCLUDED.is_primary`,
-      [TEST_ORG, d.domain, d.verified, d.is_primary],
+       VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
+       ON CONFLICT (domain) DO UPDATE SET verified = EXCLUDED.verified, is_primary = EXCLUDED.is_primary, source = EXCLUDED.source`,
+      [TEST_ORG, d.domain, d.verified, d.is_primary, d.source ?? 'workos'],
     );
   }
 }
@@ -96,12 +97,8 @@ async function seedMembership(pool: Pool, userId: string, role: 'owner' | 'admin
 function buildApp(invalidateMemberContextCache: () => void) {
   const app = express();
   app.use(express.json());
-  // Mock requireAuth: read user id from x-test-user header.
-  app.use((req: any, _res, next) => {
-    const userId = req.headers['x-test-user'];
-    if (typeof userId === 'string') req.user = { id: userId };
-    next();
-  });
+  // requireAuth is replaced via vi.mock above; it reads x-test-user from
+  // the request headers and populates req.user.
   const router = createMeOrganizationDomainsRouter({
     workos: null,
     invalidateMemberContextCache,
@@ -232,6 +229,41 @@ describe('GET /api/me/organization/domains + PUT /:domain/primary', () => {
 
     expect(res.status).toBe(400);
     expect(res.body.error).toBe('domain_not_verified');
+  });
+
+  it('refuses brand-primary dual-write for source != workos (admin-imported / manual rows)', async () => {
+    // An admin-imported "verified" row shouldn't be promotable to brand
+    // identity — only WorkOS DNS-proven domains can seed primary_brand_domain.
+    // The org-membership-inference primary still flips (that's a different
+    // concern, controlled by admin tools), but member_profiles stays put.
+    await seedOrgWithDomains(pool, [
+      { domain: 'me-domains-1.test', verified: true, is_primary: true, source: 'workos' },
+      { domain: 'me-domains-imported.test', verified: true, is_primary: false, source: 'import' },
+    ]);
+    await seedProfile(pool, 'me-domains-1.test');
+    await seedMembership(pool, OWNER_USER, 'owner');
+
+    const res = await request(app)
+      .put('/api/me/organization/domains/me-domains-imported.test/primary?org=' + TEST_ORG)
+      .set('x-test-user', OWNER_USER);
+
+    expect(res.status).toBe(200);
+    expect(res.body.brand_primary_updated).toBe(false);
+
+    const profile = await pool.query<{ primary_brand_domain: string | null }>(
+      `SELECT primary_brand_domain FROM member_profiles WHERE workos_organization_id = $1`,
+      [TEST_ORG],
+    );
+    // Brand identity preserved on the original WorkOS-verified domain.
+    expect(profile.rows[0].primary_brand_domain).toBe('me-domains-1.test');
+
+    // org-membership primary still moved (admin-imported domains may legitimately
+    // be the membership-inference primary, e.g. for a prospect we're tracking).
+    const od = await pool.query<{ domain: string; is_primary: boolean }>(
+      `SELECT domain, is_primary FROM organization_domains WHERE workos_organization_id = $1 AND is_primary = true`,
+      [TEST_ORG],
+    );
+    expect(od.rows[0].domain).toBe('me-domains-imported.test');
   });
 
   it('returns 404 for a domain not on this org', async () => {

--- a/server/tests/integration/me-organization-domains.test.ts
+++ b/server/tests/integration/me-organization-domains.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Integration tests for the member-facing /api/me/organization/domains
+ * surface. Covers list + set-primary, with the dual-write semantic that
+ * sets `member_profiles.primary_brand_domain` alongside
+ * `organization_domains.is_primary` so members don't have to know about
+ * the two-primary distinction (Media.net escalation #321 root cause).
+ *
+ * Auth in dev mode reads from the local organization_memberships seed
+ * (resolveUserOrgMembership dev bypass), so we seed memberships rather
+ * than mocking WorkOS.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+
+// Set DEV_USER_* env vars BEFORE auth.ts module-evaluates them — auth.ts
+// caches DEV_MODE_ENABLED at module load. vi.hoisted runs before all imports
+// in the file, so this beats ESM hoisting.
+vi.hoisted(() => {
+  process.env.DEV_USER_EMAIL = process.env.DEV_USER_EMAIL || 'admin@test.local';
+  process.env.DEV_USER_ID = process.env.DEV_USER_ID || 'user_dev_admin_001';
+});
+
+// Replace `requireAuth` with a test stub that reads the user id from
+// x-test-user. We don't want to forge a signed WorkOS session cookie just to
+// exercise our route logic; the auth surface is tested elsewhere.
+vi.mock('../../src/middleware/auth.js', async (importOriginal) => {
+  const orig = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...orig,
+    requireAuth: (req: any, _res: any, next: any) => {
+      const userId = req.headers['x-test-user'];
+      if (typeof userId === 'string') req.user = { id: userId };
+      return next();
+    },
+  };
+});
+
+import express from 'express';
+import request from 'supertest';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { createMeOrganizationDomainsRouter } from '../../src/routes/me-organization-domains.js';
+import type { Pool } from 'pg';
+
+const TEST_ORG = 'org_me_domains_test';
+const OWNER_USER = 'user_dev_admin_001';
+const MEMBER_USER = 'user_dev_member_001';
+
+async function cleanup(pool: Pool) {
+  await pool.query('DELETE FROM organization_domains WHERE workos_organization_id = $1', [TEST_ORG]);
+  await pool.query('DELETE FROM organization_memberships WHERE workos_organization_id = $1', [TEST_ORG]);
+  await pool.query('DELETE FROM member_profiles WHERE workos_organization_id = $1', [TEST_ORG]);
+  await pool.query('DELETE FROM brands WHERE domain LIKE $1', ['me-domains-%.test']);
+  await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [TEST_ORG]);
+}
+
+async function seedOrgWithDomains(pool: Pool, domains: Array<{ domain: string; verified: boolean; is_primary: boolean }>) {
+  await pool.query(
+    `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+     VALUES ($1, $2, false, NOW(), NOW())
+     ON CONFLICT (workos_organization_id) DO NOTHING`,
+    [TEST_ORG, 'Me Domains Test Co'],
+  );
+  for (const d of domains) {
+    await pool.query(
+      `INSERT INTO organization_domains (workos_organization_id, domain, verified, is_primary, source, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, 'workos', NOW(), NOW())
+       ON CONFLICT (domain) DO UPDATE SET verified = EXCLUDED.verified, is_primary = EXCLUDED.is_primary`,
+      [TEST_ORG, d.domain, d.verified, d.is_primary],
+    );
+  }
+}
+
+async function seedProfile(pool: Pool, primary: string | null) {
+  await pool.query(
+    `INSERT INTO member_profiles (workos_organization_id, slug, display_name, primary_brand_domain, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, NOW(), NOW())
+     ON CONFLICT (workos_organization_id) DO UPDATE
+       SET primary_brand_domain = EXCLUDED.primary_brand_domain, updated_at = NOW()`,
+    [TEST_ORG, 'me-domains-test', 'Me Domains Test Co', primary],
+  );
+}
+
+async function seedMembership(pool: Pool, userId: string, role: 'owner' | 'admin' | 'member') {
+  await pool.query(
+    `INSERT INTO organization_memberships (
+       workos_user_id, workos_organization_id, workos_membership_id,
+       email, first_name, last_name, role, seat_type, provisioning_source,
+       synced_at, created_at, updated_at
+     ) VALUES ($1, $2, $3, $4, 'Test', 'User', $5, 'contributor', 'manual', NOW(), NOW(), NOW())
+     ON CONFLICT (workos_user_id, workos_organization_id) DO UPDATE SET role = EXCLUDED.role`,
+    [userId, TEST_ORG, `om_${userId}_${TEST_ORG}`, `${userId}@test.local`, role],
+  );
+}
+
+function buildApp(invalidateMemberContextCache: () => void) {
+  const app = express();
+  app.use(express.json());
+  // Mock requireAuth: read user id from x-test-user header.
+  app.use((req: any, _res, next) => {
+    const userId = req.headers['x-test-user'];
+    if (typeof userId === 'string') req.user = { id: userId };
+    next();
+  });
+  const router = createMeOrganizationDomainsRouter({
+    workos: null,
+    invalidateMemberContextCache,
+  });
+  app.use('/api/me/organization/domains', router);
+  return app;
+}
+
+describe('GET /api/me/organization/domains + PUT /:domain/primary', () => {
+  let pool: Pool;
+  let cacheInvalidations: number;
+  let app: ReturnType<typeof buildApp>;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  }, 60000);
+
+  afterAll(async () => {
+    await cleanup(pool);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanup(pool);
+    cacheInvalidations = 0;
+    app = buildApp(() => { cacheInvalidations += 1; });
+  });
+
+  it('lists verified domains with is_primary and is_brand_primary flags', async () => {
+    await seedOrgWithDomains(pool, [
+      { domain: 'me-domains-1.test', verified: true, is_primary: true },
+      { domain: 'me-domains-2.test', verified: true, is_primary: false },
+      { domain: 'me-domains-pending.test', verified: false, is_primary: false },
+    ]);
+    await seedProfile(pool, 'me-domains-1.test');
+    await seedMembership(pool, OWNER_USER, 'owner');
+
+    const res = await request(app)
+      .get('/api/me/organization/domains?org=' + TEST_ORG)
+      .set('x-test-user', OWNER_USER);
+
+    expect(res.status).toBe(200);
+    expect(res.body.primary_brand_domain).toBe('me-domains-1.test');
+    expect(res.body.domains).toHaveLength(3);
+    const byDomain = Object.fromEntries(res.body.domains.map((d: any) => [d.domain, d]));
+    expect(byDomain['me-domains-1.test']).toMatchObject({ is_primary: true, verified: true, is_brand_primary: true, claimable: true });
+    expect(byDomain['me-domains-2.test']).toMatchObject({ is_primary: false, verified: true, is_brand_primary: false, claimable: true });
+    expect(byDomain['me-domains-pending.test']).toMatchObject({ verified: false });
+  });
+
+  it('PUT primary updates BOTH organization_domains AND member_profiles.primary_brand_domain', async () => {
+    await seedOrgWithDomains(pool, [
+      { domain: 'me-domains-1.test', verified: true, is_primary: true },
+      { domain: 'me-domains-2.test', verified: true, is_primary: false },
+    ]);
+    await seedProfile(pool, 'me-domains-1.test');
+    await seedMembership(pool, OWNER_USER, 'owner');
+
+    const res = await request(app)
+      .put('/api/me/organization/domains/me-domains-2.test/primary?org=' + TEST_ORG)
+      .set('x-test-user', OWNER_USER);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ success: true, primary_domain: 'me-domains-2.test', brand_primary_updated: true });
+    expect(cacheInvalidations).toBe(1);
+
+    // organization_domains.is_primary moved
+    const od = await pool.query<{ domain: string; is_primary: boolean }>(
+      `SELECT domain, is_primary FROM organization_domains WHERE workos_organization_id = $1`,
+      [TEST_ORG],
+    );
+    const od_by = Object.fromEntries(od.rows.map((r) => [r.domain, r.is_primary]));
+    expect(od_by['me-domains-2.test']).toBe(true);
+    expect(od_by['me-domains-1.test']).toBe(false);
+
+    // organizations.email_domain follows
+    const org = await pool.query<{ email_domain: string }>(
+      `SELECT email_domain FROM organizations WHERE workos_organization_id = $1`,
+      [TEST_ORG],
+    );
+    expect(org.rows[0].email_domain).toBe('me-domains-2.test');
+
+    // member_profiles.primary_brand_domain follows (the dual-write that fixes #321)
+    const profile = await pool.query<{ primary_brand_domain: string | null }>(
+      `SELECT primary_brand_domain FROM member_profiles WHERE workos_organization_id = $1`,
+      [TEST_ORG],
+    );
+    expect(profile.rows[0].primary_brand_domain).toBe('me-domains-2.test');
+  });
+
+  it('rejects PUT primary from a non-owner/admin member', async () => {
+    await seedOrgWithDomains(pool, [
+      { domain: 'me-domains-1.test', verified: true, is_primary: true },
+      { domain: 'me-domains-2.test', verified: true, is_primary: false },
+    ]);
+    await seedProfile(pool, 'me-domains-1.test');
+    await seedMembership(pool, MEMBER_USER, 'member');
+
+    const res = await request(app)
+      .put('/api/me/organization/domains/me-domains-2.test/primary?org=' + TEST_ORG)
+      .set('x-test-user', MEMBER_USER);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('Not authorized');
+
+    // No write happened.
+    const od = await pool.query<{ domain: string; is_primary: boolean }>(
+      `SELECT domain, is_primary FROM organization_domains WHERE workos_organization_id = $1 AND is_primary = true`,
+      [TEST_ORG],
+    );
+    expect(od.rows[0].domain).toBe('me-domains-1.test');
+  });
+
+  it('rejects PUT primary on an unverified domain', async () => {
+    await seedOrgWithDomains(pool, [
+      { domain: 'me-domains-1.test', verified: true, is_primary: true },
+      { domain: 'me-domains-pending.test', verified: false, is_primary: false },
+    ]);
+    await seedProfile(pool, 'me-domains-1.test');
+    await seedMembership(pool, OWNER_USER, 'owner');
+
+    const res = await request(app)
+      .put('/api/me/organization/domains/me-domains-pending.test/primary?org=' + TEST_ORG)
+      .set('x-test-user', OWNER_USER);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('domain_not_verified');
+  });
+
+  it('returns 404 for a domain not on this org', async () => {
+    await seedOrgWithDomains(pool, [
+      { domain: 'me-domains-1.test', verified: true, is_primary: true },
+    ]);
+    await seedProfile(pool, 'me-domains-1.test');
+    await seedMembership(pool, OWNER_USER, 'owner');
+
+    const res = await request(app)
+      .put('/api/me/organization/domains/some-other.test/primary?org=' + TEST_ORG)
+      .set('x-test-user', OWNER_USER);
+
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

- New endpoints under `/api/me/organization/domains`: GET (list) and PUT `/:domain/primary` (set primary). Member self-service mirror of the admin "Linked Domains" card.
- The PUT writes BOTH `organization_domains.is_primary` AND `member_profiles.primary_brand_domain` in one transaction. **This is the bit the admin set-primary path doesn't do** — and the cause of the Media.net escalation #321.
- Linked Domains card added to `member-profile.html` for company orgs.

Closes #4158 (Stage 2 of the domain-cleanup series).

## Why this PR's PUT is dual-write

In the admin Set-Primary path (`admin-account-detail.html` → `PUT /api/admin/organizations/:orgId/domains/:domain/primary`), only `organization_domains.is_primary` and `organizations.email_domain` get written. `member_profiles.primary_brand_domain` is a separate column with a separate write path (the brand-claim verification flow). That's the two-primary surprise documented in #4159.

For a member self-service surface, we don't want to inflict that distinction on the user. So PUT writes both — when the domain is claimable (`assertClaimableBrandDomain`), `primary_brand_domain` follows. Existing brand-claim values are still preserved by the auto-populate path's `IS NULL` guard at the webhook (PR #4157); this PR only writes through an explicit member action.

## Out of scope

- POST (add a new domain, kicks off a WorkOS verification challenge): WorkOS-side wiring is materially more work; deferring to a follow-up.
- DELETE (remove a domain): same — needs WorkOS coordination.
- The four-column rationalization (#4159): Stage 3, design question pending Brian's steer.

## Test plan

- [x] 5 new integration tests:
  - lists verified domains with is_primary + is_brand_primary flags
  - PUT primary updates both `organization_domains` AND `member_profiles.primary_brand_domain` (asserts the dual-write)
  - rejects PUT primary from a non-owner/admin member (403)
  - rejects PUT primary on an unverified domain (400)
  - 404 on a domain not on the org
- [x] Typecheck clean
- [ ] Manual smoke after merge: load member-profile.html as a multi-domain user; verify the Linked Domains card renders + Set Primary works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)