### PR TITLE
fix(server): resolver self-heals dangling primary_organization_id

### DIFF
--- a/.changeset/resolver-self-heals-dangling-primary-org.md
+++ b/.changeset/resolver-self-heals-dangling-primary-org.md
@@ -1,0 +1,10 @@
+---
+---
+
+Stop returning a phantom orgId when `users.primary_organization_id` points at an org with no row in `organizations` (or no current `organization_memberships` row for that user). Every tier-gated read site that runs `getOrganization()` after `resolvePrimaryOrganization()` would 404 with "Organization not found" — Warren at media.net hit this when flipping an agent to public; 14 other users had the same dangling cache state.
+
+Fix:
+- `resolvePrimaryOrganization()` cache read now uses an `EXISTS`-checked SELECT that returns the cached pointer plus a `joins_valid` boolean. Only trusts the cache when both `organizations` and `organization_memberships` joins still hold.
+- When the cache dangles and a real membership exists, repoints the column unconditionally (the existing `backfillPrimaryOrganization` is IS-NULL-guarded by design — used by webhooks where overwriting would be wrong).
+- When the cache dangles and no replacement exists, NULLs the column so a future membership webhook can re-trigger the IS-NULL backfill.
+- Adds `server/src/scripts/repair-dangling-primary-orgs.ts` (default dry-run) to clear the existing backlog in one shot rather than waiting for each user to round-trip an authenticated page.

--- a/server/src/db/users-db.ts
+++ b/server/src/db/users-db.ts
@@ -242,39 +242,99 @@ export async function backfillPrimaryOrganization(workosUserId: string, orgId: s
 }
 
 /**
+ * Unconditionally point users.primary_organization_id at orgId. Used by the
+ * resolver self-heal path when the cached column is set but dangles (org row
+ * missing, or membership row missing). The webhook backfill keeps its
+ * IS-NULL guard so a stray membership webhook can't repoint a user away
+ * from the org they actually use.
+ */
+async function repointPrimaryOrganization(workosUserId: string, orgId: string): Promise<void> {
+  await query(
+    `UPDATE users SET primary_organization_id = $1, updated_at = NOW()
+     WHERE workos_user_id = $2 AND primary_organization_id IS DISTINCT FROM $1`,
+    [orgId, workosUserId]
+  );
+}
+
+/**
+ * Clear a stale primary_organization_id when no replacement membership
+ * exists. Lets a future organization_membership.created webhook re-trigger
+ * the IS-NULL backfill rather than leaving a phantom pointer in place.
+ */
+async function clearStalePrimaryOrganization(workosUserId: string, staleOrgId: string): Promise<void> {
+  await query(
+    `UPDATE users SET primary_organization_id = NULL, updated_at = NOW()
+     WHERE workos_user_id = $1 AND primary_organization_id = $2`,
+    [workosUserId, staleOrgId]
+  );
+}
+
+/**
  * Resolve the user's primary organization id.
  *
- *   1. Read users.primary_organization_id (the cached pointer).
- *   2. If NULL, derive from organization_memberships (preferring paying orgs).
- *   3. Best-effort backfill so the next read hits the fast path.
+ *   1. Read users.primary_organization_id, but only trust it when both the
+ *      organization row and a current membership row still exist. A bare
+ *      column read masquerades a deleted/never-synced org as a valid cache
+ *      hit and 404s every tier-gated read site (#…).
+ *   2. On miss/dangle, derive from organization_memberships (preferring
+ *      paying orgs) and repoint the cache.
+ *   3. If no derived org exists either, clear the stale pointer so a later
+ *      membership webhook can re-trigger the IS-NULL backfill.
  *
- * Returns null when the user has no organization at all.
+ * Returns null when the user has no valid organization affiliation.
  *
- * Use this instead of selecting primary_organization_id directly. Direct reads
- * silently return null for users whose backfill never completed (race between
- * organization_membership.created and user.created webhooks, fire-and-forget
- * backfill failures), which silently breaks every surface that gates on the
- * column. The integrity invariant `users-have-primary-organization` catches
- * any rows that stay NULL despite the fallback.
+ * Use this instead of selecting primary_organization_id directly. Direct
+ * reads silently return null (or worse, a phantom orgId) for users whose
+ * cache state drifted from organizations / organization_memberships, which
+ * silently breaks every surface that gates on the column. The integrity
+ * invariant `users-have-primary-organization` catches both drift modes.
  */
 export async function resolvePrimaryOrganization(workosUserId: string): Promise<string | null> {
-  const cached = await query<{ primary_organization_id: string | null }>(
-    `SELECT primary_organization_id FROM users
-       WHERE workos_user_id = $1 AND primary_organization_id IS NOT NULL`,
+  // Single read returns both the cached pointer AND whether the joins to
+  // organizations + organization_memberships still hold. Lets us trust the
+  // cache only when both are present, while still knowing what value was
+  // stored so the no-recourse branch can clear a dangling id without an
+  // extra round trip.
+  const cached = await query<{ primary_organization_id: string | null; joins_valid: boolean }>(
+    `SELECT u.primary_organization_id,
+            (
+              EXISTS (
+                SELECT 1 FROM organizations o
+                 WHERE o.workos_organization_id = u.primary_organization_id
+              )
+              AND EXISTS (
+                SELECT 1 FROM organization_memberships om
+                 WHERE om.workos_user_id = u.workos_user_id
+                   AND om.workos_organization_id = u.primary_organization_id
+              )
+            ) AS joins_valid
+       FROM users u
+      WHERE u.workos_user_id = $1`,
     [workosUserId]
   );
-  if (cached.rows[0]?.primary_organization_id) {
-    return cached.rows[0].primary_organization_id;
+  const row = cached.rows[0];
+  if (row?.primary_organization_id && row.joins_valid) {
+    return row.primary_organization_id;
   }
 
   const derived = await resolvePreferredOrganization(workosUserId);
-  if (!derived) return null;
+  if (!derived) {
+    // Cache was set to a dangling id and no replacement exists — null it
+    // out so a later membership webhook can re-trigger the IS-NULL backfill.
+    if (row?.primary_organization_id) {
+      const staleOrgId = row.primary_organization_id;
+      clearStalePrimaryOrganization(workosUserId, staleOrgId).catch((err) => {
+        logger.warn({ err, userId: workosUserId, staleOrgId }, 'failed to clear stale primary_organization_id');
+      });
+    }
+    return null;
+  }
 
-  // Opportunistic backfill — failures don't block the lookup. The integrity
-  // invariant catches any row that stays NULL (e.g. because the users row
-  // doesn't exist yet, or a transient DB error swallows the UPDATE).
-  backfillPrimaryOrganization(workosUserId, derived).catch((err) => {
-    logger.warn({ err, userId: workosUserId, orgId: derived }, 'opportunistic primary_organization_id backfill failed');
+  // Cache didn't pass the JOIN check but a derived org exists — repoint
+  // unconditionally. The IS-NULL-guarded backfill helper would let a
+  // dangling pointer persist forever.
+  repointPrimaryOrganization(workosUserId, derived).catch((err) => {
+    logger.warn({ err, userId: workosUserId, orgId: derived }, 'opportunistic primary_organization_id repoint failed');
   });
 
   return derived;

--- a/server/src/db/users-db.ts
+++ b/server/src/db/users-db.ts
@@ -275,7 +275,7 @@ async function clearStalePrimaryOrganization(workosUserId: string, staleOrgId: s
  *   1. Read users.primary_organization_id, but only trust it when both the
  *      organization row and a current membership row still exist. A bare
  *      column read masquerades a deleted/never-synced org as a valid cache
- *      hit and 404s every tier-gated read site (#…).
+ *      hit and 404s every tier-gated read site.
  *   2. On miss/dangle, derive from organization_memberships (preferring
  *      paying orgs) and repoint the cache.
  *   3. If no derived org exists either, clear the stale pointer so a later

--- a/server/src/scripts/repair-dangling-primary-orgs.ts
+++ b/server/src/scripts/repair-dangling-primary-orgs.ts
@@ -1,0 +1,131 @@
+/**
+ * Repair users whose `primary_organization_id` points at an org that doesn't
+ * exist in the local `organizations` table (or that the user has no
+ * membership for). The resolver self-heals on the next read after this PR
+ * lands; this script clears the backlog in one shot so existing users don't
+ * have to round-trip an authenticated page first.
+ *
+ * For each dangling user, derives a replacement via
+ * `resolvePreferredOrganization` (joins `organizations` and `organization_memberships`):
+ *   - If a valid replacement exists, repoints the cache.
+ *   - If none exists, NULLs out the column so a later membership webhook
+ *     can re-trigger the IS-NULL backfill.
+ *
+ * Usage (dev):
+ *   npx tsx server/src/scripts/repair-dangling-primary-orgs.ts            # dry-run
+ *   npx tsx server/src/scripts/repair-dangling-primary-orgs.ts --apply    # write
+ *
+ * Usage (prod, via fly ssh):
+ *   fly ssh console -a adcp-docs -C 'node /app/dist/scripts/repair-dangling-primary-orgs.js'
+ *   fly ssh console -a adcp-docs -C 'node /app/dist/scripts/repair-dangling-primary-orgs.js --apply'
+ *
+ * Prerequisites: DATABASE_URL set.
+ */
+
+import { initializeDatabase, getPool, closeDatabase } from '../db/client.js';
+import { getDatabaseConfig } from '../config.js';
+import { resolvePreferredOrganization } from '../db/users-db.js';
+
+const apply = process.argv.includes('--apply');
+const dryRun = !apply;
+
+interface DanglingRow {
+  workos_user_id: string;
+  email: string;
+  primary_organization_id: string;
+  reason: 'no_org_row' | 'no_membership_row';
+}
+
+async function main(): Promise<void> {
+  const dbConfig = getDatabaseConfig();
+  if (!dbConfig) {
+    console.error('DATABASE_URL is required');
+    process.exit(1);
+  }
+  initializeDatabase(dbConfig);
+  const pool = getPool();
+
+  // Mirror the JOIN logic the resolver now uses: dangling = either the org
+  // row is missing, or the membership row is missing for the cached org.
+  const result = await pool.query<DanglingRow>(`
+    SELECT u.workos_user_id,
+           u.email,
+           u.primary_organization_id,
+           CASE
+             WHEN o.workos_organization_id IS NULL THEN 'no_org_row'
+             ELSE 'no_membership_row'
+           END AS reason
+      FROM users u
+      LEFT JOIN organizations o
+        ON o.workos_organization_id = u.primary_organization_id
+      LEFT JOIN organization_memberships om
+        ON om.workos_user_id = u.workos_user_id
+       AND om.workos_organization_id = u.primary_organization_id
+     WHERE u.primary_organization_id IS NOT NULL
+       AND (o.workos_organization_id IS NULL OR om.workos_user_id IS NULL)
+  `);
+
+  const repointed: Array<{ user: string; from: string; to: string; reason: string }> = [];
+  const cleared: Array<{ user: string; from: string; reason: string }> = [];
+
+  for (const row of result.rows) {
+    const replacement = await resolvePreferredOrganization(row.workos_user_id);
+    if (replacement) {
+      repointed.push({
+        user: row.workos_user_id,
+        from: row.primary_organization_id,
+        to: replacement,
+        reason: row.reason,
+      });
+      if (!dryRun) {
+        await pool.query(
+          `UPDATE users
+              SET primary_organization_id = $1, updated_at = NOW()
+            WHERE workos_user_id = $2 AND primary_organization_id = $3`,
+          [replacement, row.workos_user_id, row.primary_organization_id]
+        );
+      }
+    } else {
+      cleared.push({
+        user: row.workos_user_id,
+        from: row.primary_organization_id,
+        reason: row.reason,
+      });
+      if (!dryRun) {
+        await pool.query(
+          `UPDATE users
+              SET primary_organization_id = NULL, updated_at = NOW()
+            WHERE workos_user_id = $1 AND primary_organization_id = $2`,
+          [row.workos_user_id, row.primary_organization_id]
+        );
+      }
+    }
+  }
+
+  console.log(`Mode:      ${dryRun ? 'DRY-RUN (use --apply to write)' : 'APPLY (writing changes)'}`);
+  console.log(`Scanned:   ${result.rows.length} users with dangling primary_organization_id`);
+  console.log(`Repointed: ${repointed.length}${dryRun ? ' (would repoint)' : ''}`);
+  console.log(`Cleared:   ${cleared.length}${dryRun ? ' (would clear)' : ''} (no valid membership — needs WorkOS sync)`);
+
+  if (repointed.length > 0) {
+    console.log('\nRepoint plan:');
+    for (const r of repointed) {
+      console.log(`  ${r.user}  ${r.from} -> ${r.to}  (${r.reason})`);
+    }
+  }
+  if (cleared.length > 0) {
+    console.log('\nCleared (no replacement; WorkOS-sync these orgs by hand if the user should still belong):');
+    for (const c of cleared) {
+      console.log(`  ${c.user}  was: ${c.from}  (${c.reason})`);
+    }
+  }
+}
+
+main()
+  .then(() => closeDatabase())
+  .then(() => process.exit(0))
+  .catch(async (err) => {
+    console.error(err);
+    await closeDatabase().catch(() => {});
+    process.exit(1);
+  });

--- a/server/tests/integration/addie-brand-property-tools.test.ts
+++ b/server/tests/integration/addie-brand-property-tools.test.ts
@@ -89,6 +89,10 @@ describe('Addie brand-property tools — integration', () => {
       [OWNER_ORG, OUTSIDER_ORG],
     );
     await pool.query(
+      'DELETE FROM organization_memberships WHERE workos_organization_id IN ($1, $2)',
+      [OWNER_ORG, OUTSIDER_ORG],
+    );
+    await pool.query(
       'DELETE FROM users WHERE workos_user_id IN ($1, $2)',
       [OWNER_USER, OUTSIDER_USER],
     );
@@ -115,6 +119,15 @@ describe('Addie brand-property tools — integration', () => {
       `INSERT INTO users (workos_user_id, email, primary_organization_id)
        VALUES ($1, $2, $3), ($4, $5, $6)`,
       [OWNER_USER, 'owner@addie.test', OWNER_ORG, OUTSIDER_USER, 'outsider@addie.test', OUTSIDER_ORG],
+    );
+    // resolvePrimaryOrganization requires both an organizations row and a
+    // current organization_memberships row to trust the cached pointer.
+    await pool.query(
+      `INSERT INTO organization_memberships
+         (workos_user_id, workos_organization_id, role, email, created_at, updated_at)
+       VALUES ($1, $2, 'admin', $3, NOW(), NOW()),
+              ($4, $5, 'admin', $6, NOW(), NOW())`,
+      [OWNER_USER, OWNER_ORG, 'owner@addie.test', OUTSIDER_USER, OUTSIDER_ORG, 'outsider@addie.test'],
     );
     await pool.query(
       `INSERT INTO organization_domains (workos_organization_id, domain, verified)

--- a/server/tests/integration/agent-visibility-e2e.test.ts
+++ b/server/tests/integration/agent-visibility-e2e.test.ts
@@ -132,6 +132,10 @@ describe('Agent visibility E2E', () => {
       [`${TEST_PREFIX}%`],
     );
     await pool.query(
+      `DELETE FROM organization_memberships WHERE workos_organization_id LIKE $1`,
+      [`${TEST_PREFIX}%`],
+    );
+    await pool.query(
       `DELETE FROM users WHERE primary_organization_id LIKE $1`,
       [`${TEST_PREFIX}%`],
     );
@@ -148,6 +152,15 @@ describe('Agent visibility E2E', () => {
        VALUES ($1, $2, $3, NOW(), NOW())
        ON CONFLICT (workos_user_id) DO UPDATE SET primary_organization_id = EXCLUDED.primary_organization_id`,
       [userId, `${userId}@example.com`, orgId],
+    );
+    // resolvePrimaryOrganization requires both an organizations row and a
+    // current organization_memberships row to trust the cached pointer.
+    await pool.query(
+      `INSERT INTO organization_memberships
+         (workos_user_id, workos_organization_id, role, email, created_at, updated_at)
+       VALUES ($1, $2, 'admin', $3, NOW(), NOW())
+       ON CONFLICT (workos_user_id, workos_organization_id) DO NOTHING`,
+      [userId, orgId, `${userId}@example.com`],
     );
   }
 
@@ -168,6 +181,10 @@ describe('Agent visibility E2E', () => {
   beforeEach(async () => {
     await pool.query(
       `DELETE FROM member_profiles WHERE workos_organization_id LIKE $1`,
+      [`${TEST_PREFIX}%`],
+    );
+    await pool.query(
+      `DELETE FROM organization_memberships WHERE workos_organization_id LIKE $1`,
       [`${TEST_PREFIX}%`],
     );
     await pool.query(

--- a/server/tests/integration/brand-properties-parse.test.ts
+++ b/server/tests/integration/brand-properties-parse.test.ts
@@ -104,6 +104,7 @@ describe('POST /api/brands/:domain/properties/parse', () => {
   async function clearFixtures() {
     await pool.query('DELETE FROM brands WHERE domain = $1', [TEST_DOMAIN]);
     await pool.query('DELETE FROM organization_domains WHERE workos_organization_id IN ($1, $2)', [OWNER_ORG, OUTSIDER_ORG]);
+    await pool.query('DELETE FROM organization_memberships WHERE workos_organization_id IN ($1, $2)', [OWNER_ORG, OUTSIDER_ORG]);
     await pool.query('DELETE FROM users WHERE workos_user_id IN ($1, $2)', [OWNER_USER, OUTSIDER_USER]);
     await pool.query('DELETE FROM organizations WHERE workos_organization_id IN ($1, $2)', [OWNER_ORG, OUTSIDER_ORG]);
   }
@@ -126,6 +127,15 @@ describe('POST /api/brands/:domain/properties/parse', () => {
       `INSERT INTO users (workos_user_id, email, primary_organization_id)
        VALUES ($1, $2, $3), ($4, $5, $6)`,
       [OWNER_USER, 'owner@test.example', OWNER_ORG, OUTSIDER_USER, 'outsider@test.example', OUTSIDER_ORG]
+    );
+    // resolvePrimaryOrganization requires both an organizations row and a
+    // current organization_memberships row to trust the cached pointer.
+    await pool.query(
+      `INSERT INTO organization_memberships
+         (workos_user_id, workos_organization_id, role, email, created_at, updated_at)
+       VALUES ($1, $2, 'admin', $3, NOW(), NOW()),
+              ($4, $5, 'admin', $6, NOW(), NOW())`,
+      [OWNER_USER, OWNER_ORG, 'owner@test.example', OUTSIDER_USER, OUTSIDER_ORG, 'outsider@test.example']
     );
     await pool.query(
       `INSERT INTO organization_domains (workos_organization_id, domain, verified)

--- a/server/tests/integration/member-agents-api.test.ts
+++ b/server/tests/integration/member-agents-api.test.ts
@@ -157,6 +157,11 @@ describe('Per-agent REST API (/api/me/agents)', () => {
        ON CONFLICT (workos_user_id) DO UPDATE SET primary_organization_id = EXCLUDED.primary_organization_id`,
       [userId, `${userId}@example.com`, orgId],
     );
+    // resolvePrimaryOrganization requires both the organizations row AND a
+    // current organization_memberships row to trust the cached pointer; seed
+    // the membership too so tests don't accidentally exercise the dangling-
+    // pointer self-heal path.
+    await provisionMembership(userId, orgId);
   }
 
   async function provisionMembership(userId: string, orgId: string, role = 'member') {

--- a/server/tests/integration/primary-organization-resolution.test.ts
+++ b/server/tests/integration/primary-organization-resolution.test.ts
@@ -83,9 +83,10 @@ describe('primary_organization_id resolution', () => {
   });
 
   describe('resolvePrimaryOrganization', () => {
-    it('returns the cached column when set', async () => {
+    it('returns the cached column when both org and membership exist', async () => {
       await seedOrg(pool, TEST_ORG_ACTIVE, { subscription_status: 'active' });
       await seedUser(pool, TEST_USER, TEST_ORG_ACTIVE);
+      await seedMembership(pool, TEST_USER, TEST_ORG_ACTIVE);
 
       const result = await resolvePrimaryOrganization(TEST_USER);
       expect(result).toBe(TEST_ORG_ACTIVE);
@@ -137,6 +138,83 @@ describe('primary_organization_id resolution', () => {
     it('returns null when the user does not exist at all', async () => {
       const result = await resolvePrimaryOrganization('user_does_not_exist_xyz');
       expect(result).toBeNull();
+    });
+
+    // Self-heal cases — Warren's situation (#…). The cached column was set
+    // but the join targets had drifted; the bare-column read returned a
+    // phantom orgId that 404'd every tier-gated route until repaired by hand.
+    it('falls through and repoints when cached pointer has no organizations row', async () => {
+      // Real org + membership exists; cached column points at a different
+      // org that's missing from the organizations table.
+      await seedOrg(pool, TEST_ORG_ACTIVE, { subscription_status: 'active' });
+      await seedUser(pool, TEST_USER, 'org_dangling_no_org_row');
+      await seedMembership(pool, TEST_USER, TEST_ORG_ACTIVE);
+
+      const result = await resolvePrimaryOrganization(TEST_USER);
+      expect(result).toBe(TEST_ORG_ACTIVE);
+
+      // Repoint is fire-and-forget — poll for it to land.
+      const deadline = Date.now() + 2000;
+      let cached: string | null = null;
+      while (Date.now() < deadline) {
+        const after = await pool.query<{ primary_organization_id: string | null }>(
+          'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
+          [TEST_USER],
+        );
+        cached = after.rows[0]?.primary_organization_id ?? null;
+        if (cached === TEST_ORG_ACTIVE) break;
+        await new Promise((r) => setTimeout(r, 25));
+      }
+      expect(cached).toBe(TEST_ORG_ACTIVE);
+    });
+
+    it('falls through and repoints when cached pointer has no membership row', async () => {
+      // Org row exists but the user has no membership for it (e.g. removal
+      // happened via a path that bypassed deleteOrganizationMembership).
+      // A different real membership exists and should win.
+      await seedOrg(pool, TEST_ORG_ACTIVE, { subscription_status: 'active' });
+      await seedOrg(pool, TEST_ORG_INACTIVE, { subscription_status: null });
+      await seedUser(pool, TEST_USER, TEST_ORG_INACTIVE); // cache points at INACTIVE
+      await seedMembership(pool, TEST_USER, TEST_ORG_ACTIVE); // but only member of ACTIVE
+
+      const result = await resolvePrimaryOrganization(TEST_USER);
+      expect(result).toBe(TEST_ORG_ACTIVE);
+
+      const deadline = Date.now() + 2000;
+      let cached: string | null = null;
+      while (Date.now() < deadline) {
+        const after = await pool.query<{ primary_organization_id: string | null }>(
+          'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
+          [TEST_USER],
+        );
+        cached = after.rows[0]?.primary_organization_id ?? null;
+        if (cached === TEST_ORG_ACTIVE) break;
+        await new Promise((r) => setTimeout(r, 25));
+      }
+      expect(cached).toBe(TEST_ORG_ACTIVE);
+    });
+
+    it('clears the stale pointer and returns null when cache dangles and no other membership exists', async () => {
+      // Cache is set, but no org row, no membership row, nowhere to fall
+      // back to. Resolver should return null AND null out the column so a
+      // later membership webhook re-triggers the IS-NULL backfill.
+      await seedUser(pool, TEST_USER, 'org_dangling_no_recourse');
+
+      const result = await resolvePrimaryOrganization(TEST_USER);
+      expect(result).toBeNull();
+
+      const deadline = Date.now() + 2000;
+      let cached: string | null = 'org_dangling_no_recourse';
+      while (Date.now() < deadline) {
+        const after = await pool.query<{ primary_organization_id: string | null }>(
+          'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
+          [TEST_USER],
+        );
+        cached = after.rows[0]?.primary_organization_id ?? null;
+        if (cached === null) break;
+        await new Promise((r) => setTimeout(r, 25));
+      }
+      expect(cached).toBeNull();
     });
   });
 

--- a/server/tests/integration/primary-organization-resolution.test.ts
+++ b/server/tests/integration/primary-organization-resolution.test.ts
@@ -140,7 +140,7 @@ describe('primary_organization_id resolution', () => {
       expect(result).toBeNull();
     });
 
-    // Self-heal cases — Warren's situation (#…). The cached column was set
+    // Self-heal cases. The cached column was set
     // but the join targets had drifted; the bare-column read returned a
     // phantom orgId that 404'd every tier-gated route until repaired by hand.
     it('falls through and repoints when cached pointer has no organizations row', async () => {

--- a/server/tests/unit/resolve-caller-org.test.ts
+++ b/server/tests/unit/resolve-caller-org.test.ts
@@ -145,14 +145,16 @@ describe('resolveCallerOrgId', () => {
 
   it('falls back to users.primary_organization_id when only req.user is set', async () => {
     validateWorkOSApiKeyMock.mockResolvedValueOnce(null);
-    // resolvePrimaryOrganization: fast-path read returns the cached column.
-    dbQueryMock.mockResolvedValueOnce({ rows: [{ primary_organization_id: 'org_from_session' }] });
+    // resolvePrimaryOrganization: fast-path read returns the cached column
+    // alongside joins_valid, so a dangling pointer can fall through.
+    dbQueryMock.mockResolvedValueOnce({ rows: [{ primary_organization_id: 'org_from_session', joins_valid: true }] });
 
     const orgId = await resolveCallerOrgId(reqWith(undefined, { id: 'user_session' }));
 
     expect(orgId).toBe('org_from_session');
-    // Assert the fast-path SQL — the WHERE filter is what makes it the fast path.
-    expect(dbQueryMock.mock.calls[0][0]).toMatch(/SELECT primary_organization_id FROM users[\s\S]*workos_user_id\s*=\s*\$1[\s\S]*primary_organization_id IS NOT NULL/);
+    // Assert the fast-path SQL — joins_valid checks both organizations and
+    // organization_memberships so a dangling pointer falls through.
+    expect(dbQueryMock.mock.calls[0][0]).toMatch(/SELECT[\s\S]*primary_organization_id[\s\S]*EXISTS[\s\S]*organizations[\s\S]*EXISTS[\s\S]*organization_memberships[\s\S]*joins_valid[\s\S]*FROM users[\s\S]*workos_user_id\s*=\s*\$1/);
     expect(dbQueryMock.mock.calls[0][1]).toEqual(['user_session']);
   });
 


### PR DESCRIPTION
## Summary

- `resolvePrimaryOrganization()` no longer returns a phantom orgId when `users.primary_organization_id` points at an org missing from `organizations` or with no current `organization_memberships` row. Every tier-gated read site that runs `getOrganization()` after the resolver was 404-ing with "Organization not found" — Warren at media.net hit this when flipping an agent to public; **15 users total** are stuck in this state.
- Cache read uses an `EXISTS`-checked SELECT that returns the cached pointer plus a `joins_valid` boolean. Only trusts the cache when both `organizations` and `organization_memberships` joins still hold. On dangle, repoints unconditionally; on no-recourse, NULLs the column so a future membership webhook can re-trigger the IS-NULL backfill. `backfillPrimaryOrganization` stays IS-NULL-guarded — webhooks must not overwrite.
- `server/src/scripts/repair-dangling-primary-orgs.ts` (default dry-run) clears the existing backlog in one shot rather than waiting for each user to round-trip an authenticated page.

## Why now

Manual SQL on prod confirmed Warren's `primary_organization_id` was `org_01KDV7Z…` while neither `organizations` nor `organization_memberships` had a row for it; his real org `org_01KCQ3KY…` (owner, has the agent he's trying to publish) only lives in `organization_memberships`. Existing `backfillPrimaryOrganization` is `WHERE primary_organization_id IS NULL`, so once the column was set to a stale id it stayed there forever. The resolver's bare-column read trusted it and the rest of the system 404'd on every tier check.

`users-have-primary-organization` integrity invariant already detects this drift (`drift: 'stale_pointer'`) — this PR makes the read path self-heal instead of just warning.

## Test plan

- [x] Unit + integration tests pass (`tests/unit/resolve-caller-org.test.ts`, `tests/integration/primary-organization-resolution.test.ts` — 29/29)
- [x] Three new integration cases: cache dangles with no `organizations` row → repoints; cache dangles with no membership row → repoints; cache dangles with no recourse → returns null and clears column
- [x] Existing `'returns the cached column when set'` updated to seed a membership (the prior version passed only because the bare-column read didn't validate membership — semantics now match the existing integrity invariant)
- [x] Pre-commit hooks (typecheck, unit, dynamic-imports, callApi state-change) green
- [ ] Run `repair-dangling-primary-orgs.ts` in dry-run on prod, review repoint plan, then `--apply`
- [ ] Spot-check Warren can flip the agent to public after merge (already manually unblocked, but the next user shouldn't need a hand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)