### PR TITLE
docs(creative): backport #4153 list_creatives filter-types fix to 3.0.x

### DIFF
--- a/.changeset/list-creatives-filter-types-doc.md
+++ b/.changeset/list-creatives-filter-types-doc.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs(creative): tighten type column in the `list_creatives` filtering options table to match `core/creative-filters.json`. `accounts` now shows `AccountRef[]` (was `array`), `format_ids` shows `FormatID[]` (was `format_id[]`, matching the casing used in `list_creative_formats`, `get_products`, and `create_media_buy`), and `statuses` links to `CreativeStatus` rather than the under-specified `string[]`. Docs only — no schema or wire-format change.

--- a/.changeset/list-creatives-filter-types-doc.md
+++ b/.changeset/list-creatives-filter-types-doc.md
@@ -1,4 +1,5 @@
 ---
+"adcontextprotocol": patch
 ---
 
-docs(creative): tighten type column in the `list_creatives` filtering options table to match `core/creative-filters.json`. `accounts` now shows `AccountRef[]` (was `array`), `format_ids` shows `FormatID[]` (was `format_id[]`, matching the casing used in `list_creative_formats`, `get_products`, and `create_media_buy`), and `statuses` links to `CreativeStatus` rather than the under-specified `string[]`. Docs only — no schema or wire-format change.
+docs(creative): tighten type column in the `list_creatives` filtering options table to match `core/creative-filters.json`. `accounts` now shows `AccountRef[]` (was `array`), `format_ids` shows `FormatID[]` (was `format_id[]`, matching the casing used in `list_creative_formats`, `get_products`, and `create_media_buy`), and `statuses` links to `CreativeStatus` rather than the under-specified `string[]`. Docs only — no schema or wire-format change. Patch-eligible per the non-normative-docs rule in `.agents/playbook.md`.

--- a/docs/creative/task-reference/list_creatives.mdx
+++ b/docs/creative/task-reference/list_creatives.mdx
@@ -54,9 +54,9 @@ The `filters` object supports these optional, composable filters:
 
 | Filter | Type | Description |
 |--------|------|-------------|
-| `accounts` | array | Filter by owning accounts |
-| `format_ids` | format_id[] | Filter by structured format IDs |
-| `statuses` | string[] | Filter by approval status |
+| `accounts` | [AccountRef](/docs/building/integration/accounts-and-agents#account-references)[] | Filter by owning accounts |
+| `format_ids` | FormatID[] | Filter by structured format IDs |
+| `statuses` | [CreativeStatus](/docs/creative/specification#creative-status-lifecycle)[] | Filter by approval status |
 | `tags` | string[] | Filter by tags (all must match) |
 | `tags_any` | string[] | Filter by tags (any must match) |
 | `name_contains` | string | Case-insensitive name search |


### PR DESCRIPTION
Cherry-pick of #4153 (merged to `main` as `93146bbc07`) onto the `3.0.x` patch line.

## Summary
- Fixes the filter type column in `docs/creative/task-reference/list_creatives.mdx` to match `static/schemas/source/core/creative-filters.json`:
  - `accounts`: `array` → `AccountRef[]` (linked)
  - `format_ids`: `format_id[]` → `FormatID[]` (matching casing in `list_creative_formats`, `get_products`, `create_media_buy`)
  - `statuses`: `string[]` → `CreativeStatus[]` (linked to lifecycle section)

Schema source of truth was always authoritative; this aligns the docs rendering. No wire-format change.

## Why backport
So the fix ships in the next `3.0.X` patch and reaches readers on the stable docs channel, not just `3.1`-beta.

## Changeset
Promoted from `--empty` (main) to `"adcontextprotocol": patch` on this branch. Patch-eligible per the "Non-normative docs and release tooling — always patch-eligible" rule in `.agents/playbook.md`. The forward-merge workflow will auto-preserve main's `--empty` changeset on flow-back, so this stays scoped to the `3.0.x` line.

## Test plan
- [x] CI green on the `main` PR (#4153)
- [ ] CI green on this backport
- [ ] After merge: forward-merge workflow opens a PR back to `main` (near-no-op)

Cherry-pick of: 93146bbc074f41e5621f952279684cf94a2313b0