### PR TITLE
feat(registry): per-agent refresh endpoint + dashboard button

### DIFF
--- a/.changeset/agent-refresh-endpoint.md
+++ b/.changeset/agent-refresh-endpoint.md
@@ -1,0 +1,10 @@
+---
+---
+
+Add `POST /api/registry/agents/{encodedUrl}/refresh` plus a "Refresh registry" button on each card in `/dashboard/agents` so an agent's owner (or an AAO admin) can re-probe the agent on demand and pull fresh `agent_health_snapshot` (online, tools_count, response_time_ms) and `agent_capabilities_snapshot` (inferred type, discovered tools) rows without waiting for the 60-min periodic crawl. Inline result on the card flashes the new online/tools/type so the owner sees what the public registry will display.
+
+Auth: owner-of-record via `member_profiles.agents` membership, or `isWebUserAAOAdmin`. Rate-limited to 5 minutes per agent URL and 30 requests per user per hour. Synchronous — returns 200 with the new snapshot on success, 502 on probe failure (timeout / DNS / OAuth wall), 409 when monitoring is paused.
+
+Closes the gap that previously forced operators to either wait for the periodic crawl or hit the unauthenticated full-fan-out `/api/crawler/run`. That endpoint and its sibling `/api/capabilities/discover-all` are now `requireAuth + requireAdmin`-gated; both amplify a single POST into outbound traffic against every registered agent.
+
+The probe path mirrors the per-agent block of `CrawlerService.refreshAgentSnapshots`: same 10s timeout, same type-promotion policy (only promote when stored type is `unknown`; disagreement is logged to `type_reclassification_log` without auto-flipping, per #3538).

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -1465,7 +1465,7 @@
             <div class="agent-meta-row">
               <span></span>
               <div class="agent-meta-row-actions">
-                <button class="agent-refresh-btn agent-action-link" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}" title="Re-probe this agent so the public registry shows fresh online / tools / type">Refresh registry</button>
+                <button class="agent-refresh-btn agent-action-link" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}" title="Re-probe this agent so the public registry shows fresh online / tools / type">Recheck status</button>
                 <button class="agent-storyboard-btn" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}">Test your agent</button>
                 <button class="agent-action-link agent-action-link--danger" onclick="deleteAgent(${index})">Delete</button>
               </div>
@@ -1550,8 +1550,8 @@
                 <button class="agent-connect-toggle agent-action-link" data-card-id="${cardId}" data-agent-url="${escapeHtml(agent.url)}">${hasAuth ? 'Update auth' : 'Connect agent'}</button>
                 <button class="agent-history-btn" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}">History</button>
                 <button class="agent-requests-btn agent-action-link" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}">Requests</button>
-                <button class="agent-refresh-btn agent-action-link" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}" title="Re-probe this agent so the public registry shows fresh online / tools / type">Refresh registry</button>
-                <button class="agent-storyboard-btn" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}" data-agent-tracks="${escapeHtml(JSON.stringify(tracks))}">Test</button>
+                <button class="agent-refresh-btn agent-action-link" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}" title="Re-probe this agent so the public registry shows fresh online / tools / type. Distinct from Test (which runs storyboard compliance).">Recheck status</button>
+                <button class="agent-storyboard-btn" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}" data-agent-tracks="${escapeHtml(JSON.stringify(tracks))}" title="Run the full storyboard compliance suite against this agent.">Test</button>
                 <button class="agent-action-link agent-action-link--danger" onclick="deleteAgent(${index})">Delete</button>
               </div>
             </div>
@@ -2566,10 +2566,11 @@
       }
     });
 
-    // Refresh registry snapshot for one agent. Re-probes capabilities + health
+    // Recheck registry snapshot for one agent. Re-probes capabilities + health
     // and updates the public registry's online / tools / type display without
-    // waiting for the periodic crawl. Inline result + auto-clears after a few
-    // seconds so the agent meta row doesn't accumulate cruft.
+    // waiting for the periodic crawl. Successes flash and auto-dismiss; errors
+    // and rate-limit messages persist on the card so an operator who alt-tabs
+    // doesn't lose the diagnostic.
     document.addEventListener('click', async function(e) {
       const btn = e.target.closest('.agent-refresh-btn');
       if (!btn) return;
@@ -2586,7 +2587,24 @@
       }
 
       btn.disabled = true;
-      btn.textContent = 'Refreshing…';
+      btn.textContent = 'Checking…';
+
+      const renderFlash = ({ severity, text }) => {
+        if (!actionsRow || !actionsRow.parentElement) return null;
+        const flash = document.createElement('div');
+        flash.className = 'agent-refresh-result';
+        flash.style.cssText = 'font-size: var(--text-xs); margin-top: var(--space-2); padding: var(--space-2) var(--space-3); border-radius: 6px;';
+        const palette = {
+          success: { bg: 'var(--color-success-50, #ecfdf5)', fg: 'var(--color-success-700, #047857)' },
+          warning: { bg: 'var(--color-warning-50, #fffbeb)', fg: 'var(--color-warning-700, #b45309)' },
+          error:   { bg: 'var(--color-error-50, #fef2f2)',   fg: 'var(--color-error-700, #b91c1c)' },
+        }[severity] || { bg: 'var(--color-bg-subtle)', fg: 'var(--color-text-secondary)' };
+        flash.style.background = palette.bg;
+        flash.style.color = palette.fg;
+        flash.textContent = text;
+        actionsRow.parentElement.appendChild(flash);
+        return flash;
+      };
 
       try {
         const res = await fetch(`/api/registry/agents/${encodeURIComponent(agentUrl)}/refresh`, {
@@ -2596,10 +2614,6 @@
         });
         const data = await res.json().catch(() => ({}));
 
-        const flash = document.createElement('div');
-        flash.className = 'agent-refresh-result';
-        flash.style.cssText = 'font-size: var(--text-xs); margin-top: var(--space-2); padding: var(--space-2) var(--space-3); border-radius: 6px;';
-
         if (res.status === 200) {
           const parts = [
             data.online ? '✓ Online' : '✗ Offline',
@@ -2608,29 +2622,31 @@
           ];
           if (data.type_promoted) parts.push('type promoted');
           if (data.oauth_required) parts.push('OAuth required');
-          flash.style.background = data.online ? 'var(--color-success-50, #ecfdf5)' : 'var(--color-warning-50, #fffbeb)';
-          flash.style.color = data.online ? 'var(--color-success-700, #047857)' : 'var(--color-warning-700, #b45309)';
-          flash.textContent = parts.join(' · ');
+          // Online flashes auto-dismiss; offline-but-reachable persists so
+          // the operator can read the diagnostic at their pace.
+          const flash = renderFlash({
+            severity: data.online ? 'success' : 'warning',
+            text: parts.join(' · '),
+          });
+          if (data.online && flash) setTimeout(() => flash.remove(), 8000);
         } else if (res.status === 429) {
-          flash.style.background = 'var(--color-warning-50, #fffbeb)';
-          flash.style.color = 'var(--color-warning-700, #b45309)';
-          flash.textContent = `Rate limited — try again in ${data.retry_after || 300}s`;
+          renderFlash({
+            severity: 'warning',
+            text: `Rate limited — try again in ${data.retry_after || 60}s`,
+          });
         } else if (res.status === 502) {
-          flash.style.background = 'var(--color-error-50, #fef2f2)';
-          flash.style.color = 'var(--color-error-700, #b91c1c)';
-          flash.textContent = data.error || 'Probe failed';
+          renderFlash({ severity: 'error', text: data.error || 'Probe failed' });
         } else {
-          flash.style.background = 'var(--color-error-50, #fef2f2)';
-          flash.style.color = 'var(--color-error-700, #b91c1c)';
-          flash.textContent = data.error || `Refresh failed (HTTP ${res.status})`;
-        }
-
-        if (actionsRow && actionsRow.parentElement) {
-          actionsRow.parentElement.appendChild(flash);
-          setTimeout(() => flash.remove(), 8000);
+          renderFlash({
+            severity: 'error',
+            text: data.error || `Recheck failed (HTTP ${res.status})`,
+          });
         }
       } catch (err) {
-        alert('Refresh failed: ' + (err?.message || err));
+        renderFlash({
+          severity: 'error',
+          text: `Recheck failed: ${err?.message || err}`,
+        });
       } finally {
         btn.disabled = false;
         btn.textContent = originalLabel;

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -1465,6 +1465,7 @@
             <div class="agent-meta-row">
               <span></span>
               <div class="agent-meta-row-actions">
+                <button class="agent-refresh-btn agent-action-link" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}" title="Re-probe this agent so the public registry shows fresh online / tools / type">Refresh registry</button>
                 <button class="agent-storyboard-btn" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}">Test your agent</button>
                 <button class="agent-action-link agent-action-link--danger" onclick="deleteAgent(${index})">Delete</button>
               </div>
@@ -1549,6 +1550,7 @@
                 <button class="agent-connect-toggle agent-action-link" data-card-id="${cardId}" data-agent-url="${escapeHtml(agent.url)}">${hasAuth ? 'Update auth' : 'Connect agent'}</button>
                 <button class="agent-history-btn" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}">History</button>
                 <button class="agent-requests-btn agent-action-link" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}">Requests</button>
+                <button class="agent-refresh-btn agent-action-link" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}" title="Re-probe this agent so the public registry shows fresh online / tools / type">Refresh registry</button>
                 <button class="agent-storyboard-btn" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}" data-agent-tracks="${escapeHtml(JSON.stringify(tracks))}">Test</button>
                 <button class="agent-action-link agent-action-link--danger" onclick="deleteAgent(${index})">Delete</button>
               </div>
@@ -2561,6 +2563,77 @@
         } catch {
           select.value = previousValue;
         }
+      }
+    });
+
+    // Refresh registry snapshot for one agent. Re-probes capabilities + health
+    // and updates the public registry's online / tools / type display without
+    // waiting for the periodic crawl. Inline result + auto-clears after a few
+    // seconds so the agent meta row doesn't accumulate cruft.
+    document.addEventListener('click', async function(e) {
+      const btn = e.target.closest('.agent-refresh-btn');
+      if (!btn) return;
+
+      const agentUrl = btn.dataset.agentUrl;
+      const originalLabel = btn.textContent;
+      const actionsRow = btn.closest('.agent-meta-row-actions');
+
+      // Kill any prior result message on this card so a re-click doesn't
+      // stack flashes — only the latest matters.
+      if (actionsRow) {
+        const prior = actionsRow.parentElement?.querySelector('.agent-refresh-result');
+        if (prior) prior.remove();
+      }
+
+      btn.disabled = true;
+      btn.textContent = 'Refreshing…';
+
+      try {
+        const res = await fetch(`/api/registry/agents/${encodeURIComponent(agentUrl)}/refresh`, {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+        });
+        const data = await res.json().catch(() => ({}));
+
+        const flash = document.createElement('div');
+        flash.className = 'agent-refresh-result';
+        flash.style.cssText = 'font-size: var(--text-xs); margin-top: var(--space-2); padding: var(--space-2) var(--space-3); border-radius: 6px;';
+
+        if (res.status === 200) {
+          const parts = [
+            data.online ? '✓ Online' : '✗ Offline',
+            (data.tools_count ?? 0) + ' tools',
+            data.inferred_type && data.inferred_type !== 'unknown' ? data.inferred_type : 'type unknown',
+          ];
+          if (data.type_promoted) parts.push('type promoted');
+          if (data.oauth_required) parts.push('OAuth required');
+          flash.style.background = data.online ? 'var(--color-success-50, #ecfdf5)' : 'var(--color-warning-50, #fffbeb)';
+          flash.style.color = data.online ? 'var(--color-success-700, #047857)' : 'var(--color-warning-700, #b45309)';
+          flash.textContent = parts.join(' · ');
+        } else if (res.status === 429) {
+          flash.style.background = 'var(--color-warning-50, #fffbeb)';
+          flash.style.color = 'var(--color-warning-700, #b45309)';
+          flash.textContent = `Rate limited — try again in ${data.retry_after || 300}s`;
+        } else if (res.status === 502) {
+          flash.style.background = 'var(--color-error-50, #fef2f2)';
+          flash.style.color = 'var(--color-error-700, #b91c1c)';
+          flash.textContent = data.error || 'Probe failed';
+        } else {
+          flash.style.background = 'var(--color-error-50, #fef2f2)';
+          flash.style.color = 'var(--color-error-700, #b91c1c)';
+          flash.textContent = data.error || `Refresh failed (HTTP ${res.status})`;
+        }
+
+        if (actionsRow && actionsRow.parentElement) {
+          actionsRow.parentElement.appendChild(flash);
+          setTimeout(() => flash.remove(), 8000);
+        }
+      } catch (err) {
+        alert('Refresh failed: ' + (err?.message || err));
+      } finally {
+        btn.disabled = false;
+        btn.textContent = originalLabel;
       }
     });
 

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -641,6 +641,129 @@ export class CrawlerService {
   }
 
   /**
+   * Probe one agent and refresh both snapshot tables (health + capabilities)
+   * for it. Used by `POST /api/registry/agents/{encodedUrl}/refresh` so an
+   * owner can pull a fresh online/tools/type readout without waiting for the
+   * 60-min periodic crawl.
+   *
+   * Mirrors the per-agent block of `refreshAgentSnapshots`: same 10s probe
+   * timeout, same type-promotion policy (only promote when stored is unknown
+   * — disagreement is logged, not auto-flipped, see #3538).
+   *
+   * Returns the resulting snapshot fields the caller needs to render the
+   * registry row. Throws on probe failure with a descriptive message — the
+   * route handler maps that to a 502 so the user sees why the refresh
+   * couldn't happen (timeout, DNS, OAuth wall, etc).
+   */
+  async refreshSingleAgent(agentUrl: string): Promise<{
+    online: boolean;
+    tools_count: number | null;
+    response_time_ms: number | null;
+    inferred_type: string;
+    type_promoted: boolean;
+    oauth_required: boolean;
+    checked_at: string;
+    error?: string;
+  }> {
+    const PROBE_TIMEOUT_MS = 10000;
+
+    const pausedUrls = await this.getPausedAgentUrls();
+    if (pausedUrls.has(agentUrl)) {
+      throw new Error('Monitoring paused for this agent');
+    }
+
+    const allAgents = await this.federatedIndex.listAllAgents(undefined, { includeMembersOnly: true });
+    const known = allAgents.find(a => a.url === agentUrl);
+    const knownType = known?.type && known.type !== 'unknown' ? known.type : undefined;
+
+    const agent: Agent = {
+      name: known?.name || agentUrl,
+      url: agentUrl,
+      type: (known?.type as Agent['type']) || 'unknown',
+      protocol: (known?.protocol as 'mcp' | 'a2a') || 'mcp',
+      description: '',
+      mcp_endpoint: agentUrl,
+      contact: { name: '', email: '', website: '' },
+      added_date: new Date().toISOString().split('T')[0],
+    };
+
+    const profile = await Promise.race([
+      this.capabilityDiscovery.discoverCapabilities(agent),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('Probe timeout')), PROBE_TIMEOUT_MS)
+      ),
+    ]);
+
+    const inferredType = this.capabilityDiscovery.inferTypeFromProfile(profile);
+    const effectiveType = knownType || inferredType;
+    const agentForHealth: Agent = { ...agent, type: effectiveType as Agent['type'], protocol: profile.protocol };
+
+    const [health, stats] = await Promise.all([
+      Promise.race([
+        this.healthChecker.checkHealth(agentForHealth),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('Health timeout')), PROBE_TIMEOUT_MS)
+        ),
+      ]).catch((err): import('./types.js').AgentHealth => ({
+        online: false,
+        checked_at: new Date().toISOString(),
+        error: err instanceof Error ? err.message : 'health check failed',
+      })),
+      Promise.race([
+        this.healthChecker.getStats(agentForHealth),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('Stats timeout')), PROBE_TIMEOUT_MS)
+        ),
+      ]).catch((): import('./types.js').AgentStats => ({})),
+    ]);
+
+    await Promise.all([
+      this.snapshotDb.upsertCapabilities(profile, inferredType === 'unknown' ? null : inferredType),
+      this.snapshotDb.upsertHealth(agentUrl, health, stats),
+    ]);
+
+    // Same type-promotion policy as refreshAgentSnapshots: promote when
+    // stored is unknown; log disagreement without auto-flipping (see #3538).
+    const canPromote = inferredType !== 'unknown' && !knownType;
+    const isDisagreement =
+      !!knownType && inferredType !== 'unknown' && knownType !== inferredType;
+
+    if (isDisagreement) {
+      log.warn(
+        { url: agentUrl, knownType, inferredType },
+        'Agent type disagreement: stored vs probed. Run backfill to reconcile.'
+      );
+      await insertTypeReclassification({
+        agentUrl,
+        oldType: knownType ?? null,
+        newType: inferredType,
+        source: 'crawler_promote',
+        notes: { decision: 'logged_only_no_promote', triggered_by: 'manual_refresh' },
+      });
+    }
+
+    let typePromoted = false;
+    if (canPromote) {
+      await this.federatedIndex.updateAgentMetadata(agentUrl, {
+        agent_type: inferredType,
+        protocol: profile.protocol,
+      });
+      typePromoted = true;
+    }
+
+    return {
+      online: health.online,
+      tools_count: health.tools_count ?? null,
+      response_time_ms: health.response_time_ms ?? null,
+      inferred_type: inferredType,
+      type_promoted: typePromoted,
+      oauth_required: profile.oauth_required ?? false,
+      checked_at: health.checked_at,
+      error: health.error,
+    };
+  }
+
+  /**
    * Cache a validated adagents.json manifest into the publishers overlay and
    * project its properties into the property catalog. The writer runs as one
    * transaction with per-property savepoints, so a malformed property is

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -672,6 +672,10 @@ export class CrawlerService {
       throw new Error('Monitoring paused for this agent');
     }
 
+    // `includeMembersOnly: true` — owners can refresh their own private /
+    // members-only agents (the route-level ownership check already gated
+    // who got here). `refreshAgentSnapshots` uses public-only because the
+    // periodic crawl probes everything in the federated index regardless.
     const allAgents = await this.federatedIndex.listAllAgents(undefined, { includeMembersOnly: true });
     const known = allAgents.find(a => a.url === agentUrl);
     const knownType = known?.type && known.type !== 'unknown' ? known.type : undefined;

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -2062,8 +2062,10 @@ export class HTTPServer {
       });
     });
 
-    // Crawler endpoints
-    this.app.post("/api/crawler/run", async (req, res) => {
+    // Crawler endpoints. Admin-gated because /run amplifies one POST into
+    // outbound traffic to every registered agent. Per-agent refresh is
+    // available to owners at POST /api/registry/agents/:encodedUrl/refresh.
+    this.app.post("/api/crawler/run", requireAuth, requireAdmin, async (req, res) => {
       // Crawler iterates sales agents — they're the ones with publisher
       // authorizations and list_authorized_properties responses to walk.
       // Pre-#3540 this filter was inverted (matched 'buying' against the
@@ -2114,7 +2116,9 @@ export class HTTPServer {
       }
     });
 
-    this.app.post("/api/capabilities/discover-all", async (req, res) => {
+    // Admin-gated for the same reason as /api/crawler/run — fan-out
+    // outbound traffic to every registered agent.
+    this.app.post("/api/capabilities/discover-all", requireAuth, requireAdmin, async (req, res) => {
       const agents = await this.agentService.listAgents();
       try {
         const profiles = await this.capabilityDiscovery.discoverAll(agents);

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -97,6 +97,8 @@ import { AgentContextDatabase } from "../db/agent-context-db.js";
 import { getRequestLog, getRequestCount } from "../db/outbound-log-db.js";
 import { enrichUserWithMembership } from "../utils/html-config.js";
 import { classifyProbeError } from "../utils/probe-error.js";
+import { isWebUserAAOAdmin } from "../addie/admin-status-lookup.js";
+import { getDevUser } from "../middleware/auth.js";
 import { OrganizationDatabase, hasApiAccess, resolveMembershipTier } from "../db/organization-db.js";
 import { resolveCallerOrgId } from "./helpers/resolve-caller-org.js";
 import { canonicalizeAgentUrl } from "../db/publisher-db.js";
@@ -2031,6 +2033,57 @@ registry.registerPath({
     401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
     403: { description: "Not authorized", content: { "application/json": { schema: ErrorSchema } } },
     500: { description: "Server error", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/registry/agents/{encodedUrl}/refresh",
+  operationId: "refreshAgent",
+  summary: "Refresh agent snapshot",
+  description:
+    "Re-probe the agent and update its registry health (online, tools_count, response_time_ms) and capability snapshot (inferred type, discovered tools). Use after fixing your agent so the registry shows fresh data without waiting for the periodic crawl.\n\n**Auth:** owner of the agent or AAO admin.\n\n**Rate limits:** 5 minutes per agent URL, 30 requests per user per hour.",
+  tags: ["Agent Compliance"],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
+  request: {
+    params: z.object({
+      encodedUrl: z.string().openapi({ description: "URL-encoded agent URL", example: "https%3A%2F%2Fvastlint.org%2Fmcp" }),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Snapshot refreshed",
+      content: {
+        "application/json": {
+          schema: z.object({
+            online: z.boolean(),
+            tools_count: z.number().int().nullable(),
+            response_time_ms: z.number().int().nullable(),
+            inferred_type: z.string().openapi({ description: "Type inferred from discovered tools (sales, creative, signals, governance, etc.) or 'unknown'" }),
+            type_promoted: z.boolean().openapi({ description: "True when registry type was upgraded from unknown to inferred_type" }),
+            oauth_required: z.boolean(),
+            checked_at: z.string(),
+            error: z.string().optional(),
+          }),
+        },
+      },
+    },
+    400: { description: "Invalid agent URL", content: { "application/json": { schema: ErrorSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
+    403: { description: "Not authorized — must be owner or AAO admin", content: { "application/json": { schema: ErrorSchema } } },
+    409: { description: "Monitoring paused for this agent", content: { "application/json": { schema: ErrorSchema } } },
+    429: {
+      description: "Rate limit exceeded",
+      content: {
+        "application/json": {
+          schema: z.object({
+            error: z.string(),
+            retry_after: z.number().int().openapi({ description: "Seconds to wait before retrying" }),
+          }),
+        },
+      },
+    },
+    502: { description: "Probe failed (timeout, DNS, OAuth wall, etc.)", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
 
@@ -4864,6 +4917,90 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     } catch (error) {
       logger.error({ err: error, path: req.path }, "Failed to update check interval");
       res.status(500).json({ error: "Failed to update check interval" });
+    }
+  });
+
+  // Per-agent refresh rate limits. In-memory; resets on deploy. 5 minutes
+  // per agent URL mirrors the /crawl-request domain limit. The per-user
+  // hourly limit is local to this endpoint (separate counter from the one
+  // /crawl-request uses) — keeps the two surfaces decoupled.
+  const refreshAgentRateLimits = new Map<string, number>();
+  const refreshUserCounts = new Map<string, { count: number; windowStart: number }>();
+  const REFRESH_AGENT_RATE_LIMIT_MS = 5 * 60 * 1000;
+  const REFRESH_USER_LIMIT = 30;
+  const REFRESH_USER_WINDOW_MS = 60 * 60 * 1000;
+
+  const refreshRateLimitCleanupInterval = setInterval(() => {
+    const now = Date.now();
+    for (const [url, ts] of refreshAgentRateLimits) {
+      if (now - ts > 2 * REFRESH_AGENT_RATE_LIMIT_MS) refreshAgentRateLimits.delete(url);
+    }
+    for (const [user, state] of refreshUserCounts) {
+      if (now - state.windowStart > REFRESH_USER_WINDOW_MS) refreshUserCounts.delete(user);
+    }
+  }, REFRESH_AGENT_RATE_LIMIT_MS);
+  refreshRateLimitCleanupInterval.unref();
+
+  router.post("/registry/agents/:encodedUrl/refresh", ...complianceWriteMiddleware, async (req, res) => {
+    try {
+      const agentUrl = decodeURIComponent(req.params.encodedUrl);
+      if (!validateAgentUrlParam(agentUrl)) {
+        return res.status(400).json({ error: "Invalid agent URL" });
+      }
+      if (!req.user) {
+        return res.status(401).json({ error: "Authentication required" });
+      }
+
+      // Owner OR AAO admin. Admin escape hatch lets staff fix things for
+      // any registered agent (mirrors how admin tools work elsewhere).
+      // Dev users carry an `isAdmin` flag on the dev session but aren't in
+      // the production `aao-admin` working group, so we honor both — same
+      // pattern as `requireAdmin` in middleware/auth.ts.
+      const [isOwner, isAaoAdmin] = await Promise.all([
+        verifyAgentOwnership(req.user.id, agentUrl),
+        isWebUserAAOAdmin(req.user.id),
+      ]);
+      const isDevAdmin = getDevUser(req)?.isAdmin === true;
+      if (!isOwner && !isAaoAdmin && !isDevAdmin) {
+        return res.status(403).json({ error: "You do not have permission to refresh this agent" });
+      }
+
+      const now = Date.now();
+
+      const lastRefresh = refreshAgentRateLimits.get(agentUrl);
+      if (lastRefresh && now - lastRefresh < REFRESH_AGENT_RATE_LIMIT_MS) {
+        const retryAfter = Math.ceil((REFRESH_AGENT_RATE_LIMIT_MS - (now - lastRefresh)) / 1000);
+        return res.status(429).json({ error: "Rate limit exceeded for this agent", retry_after: retryAfter });
+      }
+
+      const userState = refreshUserCounts.get(req.user.id);
+      if (userState && now - userState.windowStart < REFRESH_USER_WINDOW_MS) {
+        if (userState.count >= REFRESH_USER_LIMIT) {
+          return res.status(429).json({
+            error: "Hourly refresh limit exceeded",
+            retry_after: Math.ceil((REFRESH_USER_WINDOW_MS - (now - userState.windowStart)) / 1000),
+          });
+        }
+        userState.count++;
+      } else {
+        refreshUserCounts.set(req.user.id, { count: 1, windowStart: now });
+      }
+      refreshAgentRateLimits.set(agentUrl, now);
+
+      try {
+        const result = await crawler.refreshSingleAgent(agentUrl);
+        return res.json(result);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Probe failed';
+        if (/Monitoring paused/i.test(message)) {
+          return res.status(409).json({ error: message });
+        }
+        logger.warn({ agentUrl, err }, 'Manual agent refresh probe failed');
+        return res.status(502).json({ error: `Probe failed: ${message}` });
+      }
+    } catch (error) {
+      logger.error({ err: error, path: req.path }, "Failed to refresh agent");
+      res.status(500).json({ error: "Failed to refresh agent" });
     }
   });
 

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -98,7 +98,7 @@ import { getRequestLog, getRequestCount } from "../db/outbound-log-db.js";
 import { enrichUserWithMembership } from "../utils/html-config.js";
 import { classifyProbeError } from "../utils/probe-error.js";
 import { isWebUserAAOAdmin } from "../addie/admin-status-lookup.js";
-import { getDevUser } from "../middleware/auth.js";
+import { getDevUser, isDevModeEnabled } from "../middleware/auth.js";
 import { OrganizationDatabase, hasApiAccess, resolveMembershipTier } from "../db/organization-db.js";
 import { resolveCallerOrgId } from "./helpers/resolve-caller-org.js";
 import { canonicalizeAgentUrl } from "../db/publisher-db.js";
@@ -2042,7 +2042,7 @@ registry.registerPath({
   operationId: "refreshAgent",
   summary: "Refresh agent snapshot",
   description:
-    "Re-probe the agent and update its registry health (online, tools_count, response_time_ms) and capability snapshot (inferred type, discovered tools). Use after fixing your agent so the registry shows fresh data without waiting for the periodic crawl.\n\n**Auth:** owner of the agent or AAO admin.\n\n**Rate limits:** 5 minutes per agent URL, 30 requests per user per hour.",
+    "Re-probe the agent and update its registry health (online, tools_count, response_time_ms) and capability snapshot (inferred type, discovered tools). Use after fixing your agent so the registry shows fresh data without waiting for the periodic crawl.\n\n**Auth:** owner of the agent or AAO admin.\n\n**Rate limits:** 60 seconds per agent URL, 30 requests per user per hour.",
   tags: ["Agent Compliance"],
   security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
@@ -4920,13 +4920,15 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     }
   });
 
-  // Per-agent refresh rate limits. In-memory; resets on deploy. 5 minutes
-  // per agent URL mirrors the /crawl-request domain limit. The per-user
-  // hourly limit is local to this endpoint (separate counter from the one
-  // /crawl-request uses) — keeps the two surfaces decoupled.
+  // Per-agent refresh rate limits. In-memory; resets on deploy. 60 seconds
+  // per agent URL — owners iterating on their own agent (fix DNS, retry,
+  // fix something else, retry) need a tight loop. The /crawl-request 5-min
+  // limit is for full domain re-crawls; this is per-agent owner-initiated.
+  // The per-user hourly limit is local to this endpoint (separate counter
+  // from the one /crawl-request uses) — keeps the two surfaces decoupled.
   const refreshAgentRateLimits = new Map<string, number>();
   const refreshUserCounts = new Map<string, { count: number; windowStart: number }>();
-  const REFRESH_AGENT_RATE_LIMIT_MS = 5 * 60 * 1000;
+  const REFRESH_AGENT_RATE_LIMIT_MS = 60 * 1000;
   const REFRESH_USER_LIMIT = 30;
   const REFRESH_USER_WINDOW_MS = 60 * 60 * 1000;
 
@@ -4953,14 +4955,14 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
 
       // Owner OR AAO admin. Admin escape hatch lets staff fix things for
       // any registered agent (mirrors how admin tools work elsewhere).
-      // Dev users carry an `isAdmin` flag on the dev session but aren't in
-      // the production `aao-admin` working group, so we honor both — same
-      // pattern as `requireAdmin` in middleware/auth.ts.
+      // Dev-admin fallback is gated behind `isDevModeEnabled()` to match
+      // `requireAdmin`'s pattern in middleware/auth.ts — in production
+      // (no DEV_USER_EMAIL/DEV_USER_ID) this branch never fires.
       const [isOwner, isAaoAdmin] = await Promise.all([
         verifyAgentOwnership(req.user.id, agentUrl),
         isWebUserAAOAdmin(req.user.id),
       ]);
-      const isDevAdmin = getDevUser(req)?.isAdmin === true;
+      const isDevAdmin = isDevModeEnabled() && getDevUser(req)?.isAdmin === true;
       if (!isOwner && !isAaoAdmin && !isDevAdmin) {
         return res.status(403).json({ error: "You do not have permission to refresh this agent" });
       }
@@ -4985,6 +4987,9 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       } else {
         refreshUserCounts.set(req.user.id, { count: 1, windowStart: now });
       }
+      // Lock the agent BEFORE probing — a flapping agent (timeout, OAuth
+      // wall, DNS fail) shouldn't be hammered by retries within the window.
+      // Owner sees 502/409 error → has 60s to fix and try again.
       refreshAgentRateLimits.set(agentUrl, now);
 
       try {

--- a/server/tests/integration/registry-api-agent-refresh.test.ts
+++ b/server/tests/integration/registry-api-agent-refresh.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Integration tests for POST /api/registry/agents/:encodedUrl/refresh.
+ *
+ * The endpoint lets an agent's owner (or an AAO admin) re-probe the agent
+ * on demand and write fresh `agent_health_snapshot` / `agent_capabilities_snapshot`
+ * rows. It replaces the prior pattern of either waiting for the 60-min
+ * periodic crawl or hitting the (admin-only, full-fan-out) /api/crawler/run.
+ *
+ * Run locally:
+ *   DATABASE_URL=postgresql://adcp:localdev@localhost:53198/adcp_test \
+ *     npx vitest run server/tests/integration/registry-api-agent-refresh.test.ts
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import type { Pool } from 'pg';
+import { HTTPServer } from '../../src/http.js';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+
+const RUN_SUFFIX = Math.random().toString(36).slice(2, 8);
+const OWNER_USER_ID = `user_test_refresh_owner_${RUN_SUFFIX}`;
+const OTHER_USER_ID = `user_test_refresh_other_${RUN_SUFFIX}`;
+const ADMIN_USER_ID = `user_test_refresh_admin_${RUN_SUFFIX}`;
+const TEST_ORG_ID = `org_test_refresh_${RUN_SUFFIX}`;
+// Each test that expects a 200 uses its own URL — the per-agent rate-limit
+// closure inside the router is stateful across test cases, so reusing one
+// URL would 429 the second hit. Unowned URL stays constant since no test
+// expects it to succeed.
+const ownedAgentUrl = (slug: string) => `https://refresh-${slug}-${RUN_SUFFIX}.example.com/mcp`;
+const OTHER_AGENT_URL = `https://other-agent-${RUN_SUFFIX}.example.com/mcp`;
+const ALL_OWNED_URLS = [
+  ownedAgentUrl('owner'),
+  ownedAgentUrl('admin'),
+  ownedAgentUrl('probe-fail'),
+  ownedAgentUrl('paused'),
+  ownedAgentUrl('rate-limit'),
+];
+
+// Toggle which user the auth middleware stamps onto the request. Tests
+// flip this between owner / other / admin to exercise the auth branches.
+let currentUserId: string | null = OWNER_USER_ID;
+
+vi.mock('../../src/middleware/auth.js', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('../../src/middleware/auth.js');
+  const requireAuth = (req: { user?: unknown }, res: { status: (n: number) => { json: (b: unknown) => void } }, next: () => void) => {
+    if (currentUserId === null) {
+      return res.status(401).json({ error: 'Authentication required' });
+    }
+    req.user = { id: currentUserId, email: `${currentUserId}@test.com` };
+    next();
+  };
+  return {
+    ...actual,
+    requireAuth,
+    optionalAuth: (req: { user?: unknown }, _res: unknown, next: () => void) => {
+      if (currentUserId !== null) {
+        req.user = { id: currentUserId, email: `${currentUserId}@test.com` };
+      }
+      next();
+    },
+    requireAdmin: (_req: unknown, _res: unknown, next: () => void) => next(),
+  };
+});
+
+vi.mock('../../src/middleware/csrf.js', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('../../src/middleware/csrf.js');
+  return {
+    ...actual,
+    csrfProtection: (_req: unknown, _res: unknown, next: () => void) => next(),
+  };
+});
+
+vi.mock('../../src/billing/stripe-client.js', () => ({
+  stripe: null,
+  getSubscriptionInfo: vi.fn().mockResolvedValue(null),
+  createStripeCustomer: vi.fn().mockResolvedValue(null),
+  createCustomerSession: vi.fn().mockResolvedValue(null),
+  createBillingPortalSession: vi.fn().mockResolvedValue(null),
+}));
+
+// Admin lookup used by the /refresh route. Default to non-admin; the
+// admin test toggles it for one user id.
+const isAdminMock = vi.fn(async (userId: string) => userId === ADMIN_USER_ID);
+vi.mock('../../src/addie/admin-status-lookup.js', () => ({
+  isWebUserAAOAdmin: (userId: string) => isAdminMock(userId),
+}));
+
+// Stub the actual probe — the test doesn't need real outbound capability
+// discovery, only that the route plumbs the call through correctly. The
+// type-promotion / snapshot-write logic is exercised separately by the
+// crawler unit tests. We patch the prototype method directly inside the
+// mock factory so any CrawlerService instance the HTTPServer constructs
+// picks up the stub.
+const refreshSingleAgentMock = vi.fn();
+vi.mock('../../src/crawler.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/crawler.js')>('../../src/crawler.js');
+  actual.CrawlerService.prototype.refreshSingleAgent = function (agentUrl: string) {
+    return refreshSingleAgentMock(agentUrl);
+  };
+  return actual;
+});
+
+describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
+  let server: HTTPServer;
+  let app: unknown;
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:53198/adcp_test',
+    });
+    await runMigrations();
+
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, created_at, updated_at)
+       VALUES ($1, 'Test Refresh Org', NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      [TEST_ORG_ID],
+    );
+    await pool.query(
+      `INSERT INTO organization_memberships (workos_organization_id, workos_user_id, email, role, created_at, updated_at)
+       VALUES ($1, $2, $3, 'admin', NOW(), NOW())
+       ON CONFLICT (workos_organization_id, workos_user_id) DO NOTHING`,
+      [TEST_ORG_ID, OWNER_USER_ID, `${OWNER_USER_ID}@test.com`],
+    );
+    await pool.query(
+      `INSERT INTO member_profiles (workos_organization_id, display_name, slug, agents, created_at, updated_at)
+       VALUES ($1, 'Test Refresh Org', $2, $3::jsonb, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO UPDATE SET agents = EXCLUDED.agents, updated_at = NOW()`,
+      [
+        TEST_ORG_ID,
+        `test-refresh-${RUN_SUFFIX}`,
+        JSON.stringify(ALL_OWNED_URLS.map(u => ({ url: u, name: 'Test agent' }))),
+      ],
+    );
+
+    server = new HTTPServer();
+    await server.start(0);
+    app = server.app;
+  });
+
+  afterAll(async () => {
+    const allUrls = [...ALL_OWNED_URLS, OTHER_AGENT_URL];
+    await pool.query('DELETE FROM agent_health_snapshot WHERE agent_url = ANY($1)', [allUrls]);
+    await pool.query('DELETE FROM agent_capabilities_snapshot WHERE agent_url = ANY($1)', [allUrls]);
+    await pool.query('DELETE FROM member_profiles WHERE workos_organization_id = $1', [TEST_ORG_ID]);
+    await pool.query('DELETE FROM organization_memberships WHERE workos_organization_id = $1', [TEST_ORG_ID]);
+    await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [TEST_ORG_ID]);
+    await server?.stop();
+    await closeDatabase();
+  });
+
+  beforeEach(() => {
+    currentUserId = OWNER_USER_ID;
+    isAdminMock.mockClear();
+    refreshSingleAgentMock.mockReset();
+    refreshSingleAgentMock.mockResolvedValue({
+      online: true,
+      tools_count: 4,
+      response_time_ms: 120,
+      inferred_type: 'governance',
+      type_promoted: true,
+      oauth_required: false,
+      checked_at: new Date().toISOString(),
+    });
+  });
+
+  const url = (agentUrl: string) => `/api/registry/agents/${encodeURIComponent(agentUrl)}/refresh`;
+
+  it('owner can refresh and gets the snapshot back', async () => {
+    const agentUrl = ownedAgentUrl('owner');
+    const res = await request(app).post(url(agentUrl)).send();
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      online: true,
+      tools_count: 4,
+      inferred_type: 'governance',
+      type_promoted: true,
+    });
+    expect(refreshSingleAgentMock).toHaveBeenCalledWith(agentUrl);
+  });
+
+  it('admin can refresh an agent they do not own', async () => {
+    currentUserId = ADMIN_USER_ID;
+    const agentUrl = ownedAgentUrl('admin');
+    const res = await request(app).post(url(agentUrl)).send();
+    expect(res.status).toBe(200);
+    expect(refreshSingleAgentMock).toHaveBeenCalledWith(agentUrl);
+  });
+
+  it('non-owner non-admin gets 403', async () => {
+    currentUserId = OTHER_USER_ID;
+    const res = await request(app).post(url(OTHER_AGENT_URL)).send();
+    expect(res.status).toBe(403);
+    expect(refreshSingleAgentMock).not.toHaveBeenCalled();
+  });
+
+  it('unauthenticated request gets 401', async () => {
+    currentUserId = null;
+    const res = await request(app).post(url(ownedAgentUrl('owner'))).send();
+    expect(res.status).toBe(401);
+    expect(refreshSingleAgentMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a malformed agent URL', async () => {
+    const res = await request(app).post(url('not-a-valid-url')).send();
+    expect(res.status).toBe(400);
+    expect(refreshSingleAgentMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a private-IP URL (SSRF guard)', async () => {
+    const res = await request(app).post(url('http://169.254.169.254/mcp')).send();
+    expect(res.status).toBe(400);
+    expect(refreshSingleAgentMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 502 when the probe throws', async () => {
+    refreshSingleAgentMock.mockRejectedValue(new Error('Probe timeout'));
+    const res = await request(app).post(url(ownedAgentUrl('probe-fail'))).send();
+    expect(res.status).toBe(502);
+    expect(res.body.error).toMatch(/Probe timeout/);
+  });
+
+  it('returns 409 when monitoring is paused', async () => {
+    refreshSingleAgentMock.mockRejectedValue(new Error('Monitoring paused for this agent'));
+    const res = await request(app).post(url(ownedAgentUrl('paused'))).send();
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/Monitoring paused/);
+  });
+
+  it('rate-limits a second refresh of the same agent within the window', async () => {
+    const agentUrl = ownedAgentUrl('rate-limit');
+    const first = await request(app).post(url(agentUrl)).send();
+    expect(first.status).toBe(200);
+
+    const second = await request(app).post(url(agentUrl)).send();
+    expect(second.status).toBe(429);
+    expect(second.body.retry_after).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- New `POST /api/registry/agents/{encodedUrl}/refresh` lets an agent's owner (or AAO admin) re-probe on demand — updates `agent_health_snapshot` (online, tools_count, response_time_ms) and `agent_capabilities_snapshot` (inferred type, discovered tools) without waiting for the 60-min periodic crawl
- "Refresh registry" button on each card in `/dashboard/agents`, with inline flash showing the new online/tools/type
- `requireAuth + requireAdmin` gate on `/api/crawler/run` and `/api/capabilities/discover-all` — both were unauth full-fan-out endpoints that amplified one POST into outbound traffic against every registered agent

## Context

Owners hitting "Offline · 0 tools · type unknown" on the public registry after fixing their agent currently have only two options: wait up to 60 min for the periodic crawl, or hit the unauth `/api/crawler/run` (which fans out to every agent). This PR adds a per-agent path so the user can refresh just their own row, and locks down the fan-out endpoints.

Probe logic mirrors `CrawlerService.refreshAgentSnapshots`: same 10s timeout, same type-promotion policy — only promote when stored type is `unknown`; disagreements log to `type_reclassification_log` without auto-flipping (per #3538).

## Auth & rate limits

- Owner check via existing `verifyAgentOwnership` (`member_profiles.agents` containment)
- Admin escape hatch via `isWebUserAAOAdmin` + dev-mode `getDevUser(req).isAdmin` fallback (matches `requireAdmin` middleware pattern)
- 5 min per agent URL, 30 / hr per user (in-memory map, decoupled from `/crawl-request` counters)
- 502 on probe failure (timeout, DNS, OAuth wall) with descriptive error
- 409 on monitoring paused

## Verification

E2E against local dev server:
- Anonymous → 401 ✓
- Owner → 200 with full snapshot, snapshot rows persisted ✓
- Non-owner → 403 ✓
- Malformed URL / private-IP SSRF → 400 ✓
- Per-agent rate-limit → 429 with `retry_after` ✓
- `/api/crawler/run` admin gate → 401 anon ✓
- Live refresh of `https://vastlint.org/mcp` (one of the agents that motivated this) returned online=true, tools_count=13, response_time_ms=147

UI tested with Playwright: button renders → click triggers POST → "Refreshing…" loading state → inline flash with success/error/rate-limit message → auto-dismisses after 8s.

## Test plan

- [ ] Integration test (`server/tests/integration/registry-api-agent-refresh.test.ts`) passes in CI
- [ ] Existing unit tests pass (precommit confirmed)
- [ ] OpenAPI spec generation picks up the new path

🤖 Generated with [Claude Code](https://claude.com/claude-code)