### PR TITLE
feat(registry): publisher page Phase B — fetch metadata + Case-B redirect

### DIFF
--- a/.changeset/publisher-page-phase-b-fetch-metadata.md
+++ b/.changeset/publisher-page-phase-b-fetch-metadata.md
@@ -1,0 +1,8 @@
+---
+---
+
+Phase B of the publisher-page redesign: AAO now records per-fetch metadata (HTTP status code, response body byte length, post-redirect resolved URL) on the `publishers` overlay row and surfaces it through `/api/registry/publisher`. The verifier hero on `/publisher/<domain>` now reads `Last verified · HTTP 200 · 1,438 · Expected URL · Resolved URL` — copy-paste-friendly, scrape-friendly chrome that lets buy-side operators sanity-check they're seeing the same response AAO is.
+
+The route also closes the Case-B `self_redirected` gap from Phase A: when the publisher's `/.well-known/adagents.json` returns a 301/302 to a third-party HTTPS origin (no `authoritative_location` field in the body), the new `resolved_url` column drives `mode = "self_redirected"` so the TLS-chain shift is visible to verifiers. Failed fetches (404, 5xx) record metadata via a new `recordFailedAdagentsFetch` path so the UI can show "Last attempted" even when no manifest is cached.
+
+Migration `469_publisher_fetch_metadata.sql` adds three nullable columns to `publishers`. Backfill is implicit via the 60-min crawl cadence; UI degrades gracefully when the columns are NULL. Schema additions are backward compatible — `last_http_status`, `last_bytes`, and `resolved_url` are all nullable optionals.

--- a/server/public/publisher-home.html
+++ b/server/public/publisher-home.html
@@ -540,14 +540,23 @@
         hero.setAttribute('data-state', state);
 
         // Verification chrome. Always shows expected_url; adds
-        // resolved_url when self_redirected; adds last_validated when
-        // populated (some legacy rows may be NULL).
+        // resolved_url when self_redirected; adds last_validated /
+        // HTTP status / bytes when populated (NULL until next crawl
+        // for rows that pre-date Phase B).
         const verification = document.getElementById('verification-chrome');
         const hosting = data.hosting || {};
         const ts = fmtTimestamp(hosting.last_validated);
         const verRows = [];
         if (ts) {
           verRows.push(`<div><dt>Last verified</dt><dd><time datetime="${escapeHtml(ts.iso)}"><code>${escapeHtml(ts.display)}</code></time></dd></div>`);
+        }
+        if (typeof hosting.last_http_status === 'number') {
+          verRows.push(`<div><dt>HTTP</dt><dd><code>${escapeHtml(String(hosting.last_http_status))}</code></dd></div>`);
+        }
+        if (typeof hosting.last_bytes === 'number') {
+          // Use locale-formatted thousands separators for human read,
+          // wrapped in <code> with user-select:all for copy-paste.
+          verRows.push(`<div><dt>Bytes</dt><dd><code>${escapeHtml(hosting.last_bytes.toLocaleString('en-US'))}</code></dd></div>`);
         }
         verRows.push(`<div><dt>Expected URL</dt><dd><code>${escapeHtml(hosting.expected_url || '')}</code></dd></div>`);
         if (state === 'self_redirected' && hosting.resolved_url) {

--- a/server/src/adagents-manager.ts
+++ b/server/src/adagents-manager.ts
@@ -21,6 +21,20 @@ export interface AdAgentsValidationResult {
   domain: string;
   url: string;
   status_code?: number;
+  /**
+   * Response body byte length from the most recent fetch
+   * (post-decompression). When `authoritative_location` is followed,
+   * measures the canonical document body, not the stub. Set even on
+   * non-200 responses for `self_invalid` triage.
+   */
+  response_bytes?: number;
+  /**
+   * Final URL after following both HTTP-layer redirects and
+   * `authoritative_location`. Differs from the input URL when the
+   * publisher's stub redirects elsewhere; lets verifiers audit the
+   * TLS chain at the actual canonical origin.
+   */
+  resolved_url?: string;
   raw_data?: any;
 }
 
@@ -185,6 +199,12 @@ export class AdAgentsManager {
       });
 
       result.status_code = response.status;
+      result.response_bytes = response.data.byteLength;
+      // Final URL after HTTP-layer redirects (Response.url). May
+      // equal `url` when no redirects fired, or a third-party origin
+      // when the publisher returned a 301/302. Captured even on
+      // non-200 responses for downstream `self_invalid` triage.
+      result.resolved_url = response.url;
 
       // Check HTTP status
       if (response.status !== 200) {
@@ -298,6 +318,14 @@ export class AdAgentsManager {
           'User-Agent': AAO_UA_VALIDATOR,
         },
       });
+
+      // Overwrite the resolved URL — when authoritative_location is
+      // followed, the canonical document body came from THIS fetch,
+      // not the original /.well-known. Verifiers should pin trust to
+      // the authoritative location's TLS chain, not the publisher's.
+      // Bytes likewise reflect the canonical body, not the stub.
+      result.response_bytes = response.data.byteLength;
+      result.resolved_url = response.url;
 
       if (response.status !== 200) {
         const statusMessage = response.status === 404

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -383,7 +383,15 @@ export class CrawlerService {
             const propCount = validation.raw_data.properties?.length || 0;
             log.debug({ domain: pubConfig.domain, agentCount, propCount }, 'Domain crawled');
 
-            await this.cacheAdagentsManifest(pubConfig.domain, validation.raw_data as AdagentsManifest);
+            await this.cacheAdagentsManifest(
+              pubConfig.domain,
+              validation.raw_data as AdagentsManifest,
+              {
+                statusCode: validation.status_code,
+                responseBytes: validation.response_bytes,
+                resolvedUrl: validation.resolved_url,
+              },
+            );
 
             // Record agents
             for (const authorizedAgent of validation.raw_data.authorized_agents) {
@@ -408,6 +416,17 @@ export class CrawlerService {
             await this.reconcileLegacyAdagentsAgents(pubConfig.domain, validation.raw_data as AdagentsManifest);
           } else {
             log.debug({ domain: pubConfig.domain }, 'No valid adagents.json');
+            // Record failed-fetch metadata so the verifier UI can show
+            // "Last attempted at <ts> · HTTP <code>" even when no
+            // manifest was cached. validation.status_code is set even
+            // for non-200 responses; missing only when a network error
+            // prevented any HTTP response (recordFailedAdagentsFetch
+            // accepts undefined and writes NULL).
+            await this.recordFailedAdagentsFetch(pubConfig.domain, {
+              statusCode: validation.status_code,
+              responseBytes: validation.response_bytes,
+              resolvedUrl: validation.resolved_url,
+            });
           }
         } catch (err) {
           log.warn({ domain: pubConfig.domain, err: err instanceof Error ? err.message : err }, 'Publisher crawl failed');
@@ -438,7 +457,15 @@ export class CrawlerService {
             await this.federatedIndex.markPublisherHasValidAdagents(domain);
             processedDomains.add(domain);
 
-            await this.cacheAdagentsManifest(domain, validation.raw_data as AdagentsManifest);
+            await this.cacheAdagentsManifest(
+              domain,
+              validation.raw_data as AdagentsManifest,
+              {
+                statusCode: validation.status_code,
+                responseBytes: validation.response_bytes,
+                resolvedUrl: validation.resolved_url,
+              },
+            );
 
             for (const authorizedAgent of validation.raw_data.authorized_agents) {
               if (!authorizedAgent.url) continue;
@@ -653,11 +680,38 @@ export class CrawlerService {
    * happen separately via recordPropertiesForAgent and remain authoritative
    * until catalog readers take over.
    */
-  private async cacheAdagentsManifest(domain: string, manifest: AdagentsManifest): Promise<void> {
+  private async cacheAdagentsManifest(
+    domain: string,
+    manifest: AdagentsManifest,
+    meta?: { statusCode?: number; responseBytes?: number; resolvedUrl?: string },
+  ): Promise<void> {
     try {
-      await this.publisherDb.upsertAdagentsCache({ domain, manifest });
+      await this.publisherDb.upsertAdagentsCache({
+        domain,
+        manifest,
+        statusCode: meta?.statusCode,
+        responseBytes: meta?.responseBytes,
+        resolvedUrl: meta?.resolvedUrl,
+      });
     } catch (err) {
       log.warn({ domain, err: err instanceof Error ? err.message : err }, 'Publisher cache write failed');
+    }
+  }
+
+  /**
+   * Record a failed fetch on the publishers row so the verifier UI can
+   * show "Last attempted: <ts> · HTTP <code>" even when no manifest
+   * was cached. Best-effort — a failure to record metadata must not
+   * abort the rest of the crawl.
+   */
+  private async recordFailedAdagentsFetch(
+    domain: string,
+    meta: { statusCode?: number; responseBytes?: number; resolvedUrl?: string },
+  ): Promise<void> {
+    try {
+      await this.publisherDb.recordFailedAdagentsFetch({ domain, ...meta });
+    } catch (err) {
+      log.warn({ domain, err: err instanceof Error ? err.message : err }, 'Publisher failed-fetch record failed');
     }
   }
 
@@ -905,10 +959,23 @@ export class CrawlerService {
 
       if (!validation.valid || !validation.raw_data?.authorized_agents) {
         log.warn({ domain }, 'No valid adagents.json for domain');
+        await this.recordFailedAdagentsFetch(domain, {
+          statusCode: validation.status_code,
+          responseBytes: validation.response_bytes,
+          resolvedUrl: validation.resolved_url,
+        });
         return;
       }
 
-      await this.cacheAdagentsManifest(domain, validation.raw_data as AdagentsManifest);
+      await this.cacheAdagentsManifest(
+        domain,
+        validation.raw_data as AdagentsManifest,
+        {
+          statusCode: validation.status_code,
+          responseBytes: validation.response_bytes,
+          resolvedUrl: validation.resolved_url,
+        },
+      );
 
       // Record agents and properties
       for (const authorizedAgent of validation.raw_data.authorized_agents) {
@@ -1076,9 +1143,24 @@ export class CrawlerService {
 
   private async crawlSingleDomainForCatalog(domain: string): Promise<void> {
     const validation = await this.adAgentsManager.validateDomain(domain);
-    if (!validation.valid || !validation.raw_data?.authorized_agents) return;
+    if (!validation.valid || !validation.raw_data?.authorized_agents) {
+      await this.recordFailedAdagentsFetch(domain, {
+        statusCode: validation.status_code,
+        responseBytes: validation.response_bytes,
+        resolvedUrl: validation.resolved_url,
+      });
+      return;
+    }
 
-    await this.cacheAdagentsManifest(domain, validation.raw_data as AdagentsManifest);
+    await this.cacheAdagentsManifest(
+      domain,
+      validation.raw_data as AdagentsManifest,
+      {
+        statusCode: validation.status_code,
+        responseBytes: validation.response_bytes,
+        resolvedUrl: validation.resolved_url,
+      },
+    );
 
     for (const authorizedAgent of validation.raw_data.authorized_agents) {
       if (!authorizedAgent.url) continue;

--- a/server/src/db/migrations/469_publisher_fetch_metadata.sql
+++ b/server/src/db/migrations/469_publisher_fetch_metadata.sql
@@ -1,0 +1,27 @@
+-- Phase B of the publisher-page redesign (.context/publisher-page-phase-b-roadmap.md):
+-- record per-fetch metadata on the publishers overlay row so the
+-- /api/registry/publisher hero chrome can surface verifier-grade
+-- "Last verified at <ts> · HTTP <code> · <bytes>" lines, and so the
+-- backend can detect HTTP-layer redirects that produce a third-party
+-- resolved URL (the Case-B `self_redirected` case from Phase A's
+-- backend addendum).
+--
+-- Backfill is implicit: every publisher gets re-crawled within the
+-- 60-minute crawl cadence, so the new columns populate naturally on
+-- next-fetch. UI degrades gracefully when fields are NULL (Phase A
+-- already renders the hero correctly without HTTP status / bytes).
+--
+-- No indexes — these columns are read on the per-domain detail
+-- endpoint only, never used as filter or sort keys.
+
+ALTER TABLE publishers
+  ADD COLUMN last_http_status SMALLINT,
+  ADD COLUMN last_response_bytes INTEGER,
+  ADD COLUMN resolved_url TEXT;
+
+COMMENT ON COLUMN publishers.last_http_status IS
+  'HTTP status code (100..599) returned by the most recent fetch attempt of the publisher origin /.well-known/adagents.json. NULL until first fetch records or transient errors that never produced an HTTP response.';
+COMMENT ON COLUMN publishers.last_response_bytes IS
+  'Response body byte length from the most recent fetch (post-decompression). When authoritative_location is followed, measures the canonical document body, not the stub. NULL when last_http_status is NULL.';
+COMMENT ON COLUMN publishers.resolved_url IS
+  'Final URL after following both HTTP-layer redirects and authoritative_location. Differs from the publisher''s expected /.well-known URL when self_redirected or aao_hosted. Lets verifiers audit the TLS chain at the actual canonical origin. NULL until first fetch.';

--- a/server/src/db/publisher-db.ts
+++ b/server/src/db/publisher-db.ts
@@ -111,6 +111,27 @@ function isPublisherDomainAnchor(publisherDomain: string, type: string, value: s
  * agent_url query parameter through the same function the writer uses
  * for stored rows. Drift between the two would silently miss matches.
  */
+// Phase B fetch-metadata hardening. The HTTP status writer column is a
+// SMALLINT (-32768..32767), broader than the RFC 100..599 range. Clamp
+// at write time so a malicious origin returning, e.g., status 999 can't
+// surface that to verifiers — text-only display is harmless, but the
+// schema docstring promises 100..599 and we should match it.
+function clampHttpStatus(status: number | undefined): number | null {
+  if (typeof status !== 'number' || !Number.isFinite(status)) return null;
+  return Math.max(100, Math.min(599, Math.trunc(status)));
+}
+
+// Phase B: cap resolved_url length at write. `Response.url` is built
+// from chained Location headers — undici defaults bound each hop but
+// not the resulting string. A pathological redirect chain could
+// otherwise stuff a multi-KB URL into the column. 2048 covers every
+// real publisher CDN URL with comfortable headroom.
+const RESOLVED_URL_MAX = 2048;
+function truncateResolvedUrl(url: string | undefined): string | null {
+  if (typeof url !== 'string' || url.length === 0) return null;
+  return url.length > RESOLVED_URL_MAX ? url.slice(0, RESOLVED_URL_MAX) : url;
+}
+
 export function canonicalizeAgentUrl(raw: string): string | null {
   const trimmed = raw.trim();
   if (trimmed.length === 0) return null;
@@ -176,9 +197,9 @@ export class PublisherDatabase {
            updated_at = NOW()`,
         [
           domain,
-          input.statusCode ?? null,
+          clampHttpStatus(input.statusCode),
           input.responseBytes ?? null,
-          input.resolvedUrl ?? null,
+          truncateResolvedUrl(input.resolvedUrl),
         ],
       );
     } finally {
@@ -223,9 +244,9 @@ export class PublisherDatabase {
           domain,
           JSON.stringify(safeManifest),
           input.expiresAt ?? null,
-          input.statusCode ?? null,
+          clampHttpStatus(input.statusCode),
           input.responseBytes ?? null,
-          input.resolvedUrl ?? null,
+          truncateResolvedUrl(input.resolvedUrl),
         ]
       );
 

--- a/server/src/db/publisher-db.ts
+++ b/server/src/db/publisher-db.ts
@@ -59,6 +59,24 @@ export interface UpsertAdagentsCacheInput {
   domain: string;
   manifest: AdagentsManifest;
   expiresAt?: Date;
+  /**
+   * HTTP status code from the fetch that produced this manifest. When
+   * supplied, written to publishers.last_http_status. Phase B of the
+   * publisher-page redesign — surfaces verifier-grade chrome.
+   */
+  statusCode?: number;
+  /**
+   * Response body byte length (post-decompression). When
+   * authoritative_location was followed, measures the canonical
+   * document body, not the stub.
+   */
+  responseBytes?: number;
+  /**
+   * Final URL after following redirects + authoritative_location.
+   * Differs from the publisher's expected /.well-known URL when
+   * `self_redirected` or `aao_hosted`.
+   */
+  resolvedUrl?: string;
 }
 
 const ADAGENTS_CREATED_BY_PREFIX = 'adagents_json:';
@@ -130,6 +148,44 @@ export class PublisherDatabase {
    * crawl-tracking columns; org/ownership and review state are preserved so a
    * later org claim isn't wiped by a routine re-crawl.
    */
+  /**
+   * Record a failed adagents.json fetch attempt. The crawl returned a
+   * non-200 response (404, 5xx, etc.) so there is no manifest to cache,
+   * but the fetch metadata still belongs on the publishers row so the
+   * verifier-facing UI can show "Last attempted: <ts> · HTTP <code>".
+   * Does not touch adagents_json (preserves the last successful body
+   * if one exists) and does not bump source_type.
+   */
+  async recordFailedAdagentsFetch(input: {
+    domain: string;
+    statusCode?: number;
+    responseBytes?: number;
+    resolvedUrl?: string;
+  }): Promise<void> {
+    const domain = input.domain.toLowerCase();
+    const client = await getClient();
+    try {
+      await client.query(
+        `INSERT INTO publishers
+           (domain, source_type, last_http_status, last_response_bytes, resolved_url)
+         VALUES ($1, 'community', $2, $3, $4)
+         ON CONFLICT (domain) DO UPDATE SET
+           last_http_status = EXCLUDED.last_http_status,
+           last_response_bytes = EXCLUDED.last_response_bytes,
+           resolved_url = EXCLUDED.resolved_url,
+           updated_at = NOW()`,
+        [
+          domain,
+          input.statusCode ?? null,
+          input.responseBytes ?? null,
+          input.resolvedUrl ?? null,
+        ],
+      );
+    } finally {
+      client.release();
+    }
+  }
+
   async upsertAdagentsCache(input: UpsertAdagentsCacheInput): Promise<void> {
     const domain = input.domain.toLowerCase();
     const client = await getClient();
@@ -150,15 +206,27 @@ export class PublisherDatabase {
       };
 
       await client.query(
-        `INSERT INTO publishers (domain, adagents_json, source_type, last_validated, expires_at)
-         VALUES ($1, $2::jsonb, 'adagents_json', NOW(), $3)
+        `INSERT INTO publishers
+           (domain, adagents_json, source_type, last_validated, expires_at,
+            last_http_status, last_response_bytes, resolved_url)
+         VALUES ($1, $2::jsonb, 'adagents_json', NOW(), $3, $4, $5, $6)
          ON CONFLICT (domain) DO UPDATE SET
            adagents_json = EXCLUDED.adagents_json,
            source_type = 'adagents_json',
            last_validated = NOW(),
            expires_at = EXCLUDED.expires_at,
+           last_http_status = EXCLUDED.last_http_status,
+           last_response_bytes = EXCLUDED.last_response_bytes,
+           resolved_url = EXCLUDED.resolved_url,
            updated_at = NOW()`,
-        [domain, JSON.stringify(safeManifest), input.expiresAt ?? null]
+        [
+          domain,
+          JSON.stringify(safeManifest),
+          input.expiresAt ?? null,
+          input.statusCode ?? null,
+          input.responseBytes ?? null,
+          input.resolvedUrl ?? null,
+        ]
       );
 
       const properties = Array.isArray(safeManifest.properties) ? safeManifest.properties : [];

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -5747,13 +5747,29 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         // index AND we haven't re-crawled in over an hour, trigger a
         // re-crawl on visit so an anonymous publisher visit picks up
         // their newly-added agents without needing to sign in.
-        query<{ adagents_json: Record<string, unknown> | null; last_validated: Date | null }>(
-          `SELECT adagents_json, last_validated FROM publishers WHERE domain = $1 AND source_type = 'adagents_json' LIMIT 1`,
+        query<{
+          adagents_json: Record<string, unknown> | null;
+          last_validated: Date | null;
+          last_http_status: number | null;
+          last_response_bytes: number | null;
+          resolved_url: string | null;
+        }>(
+          // Drop the source_type='adagents_json' filter. Phase B writes
+          // failed-fetch metadata onto rows with source_type='community',
+          // and we want the verifier UI to surface
+          // "Last attempted: <ts> · HTTP <code>" even for never-validated
+          // domains. Read whatever row exists; downstream code handles
+          // null adagents_json gracefully.
+          `SELECT adagents_json, last_validated, last_http_status, last_response_bytes, resolved_url
+             FROM publishers WHERE domain = $1 LIMIT 1`,
           [domain],
         ).then(r => r.rows[0] ?? null),
       ]);
       const cachedAdagentsManifest = cachedAdagentsRow?.adagents_json ?? null;
       const cachedAdagentsLastValidated = cachedAdagentsRow?.last_validated ?? null;
+      const cachedHttpStatus = cachedAdagentsRow?.last_http_status ?? null;
+      const cachedResponseBytes = cachedAdagentsRow?.last_response_bytes ?? null;
+      const cachedResolvedUrl = cachedAdagentsRow?.resolved_url ?? null;
 
       // Auto-crawl on view: if we've never crawled this domain (adagents
       // never seen, brand never seen), kick off background fetches so a
@@ -5928,19 +5944,29 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       //     host) → mode = "self_redirected" so verifiers can audit the
       //     TLS chain at the resolved origin instead of assuming it
       //     terminates at the publisher's own domain.
+      // Resolution source for the canonical adagents.json document.
+      // Case A: JSONB `authoritative_location` (publisher's stub
+      // explicitly names a target). Case B: HTTP-layer 301/302 redirect
+      // captured by the validator (Phase B `resolved_url` column).
+      // Both unify under one resolution string — the validator already
+      // overwrites the column with `authoritative_location`'s URL when
+      // followed, so for a fresh crawl the two should agree.
+      // `stubAuthLocRaw` (JSONB) wins for legacy rows where the column
+      // is still NULL pending re-crawl.
+      const resolutionSource = stubAuthLocRaw ?? cachedResolvedUrl ?? null;
       const stubResolution: "aao" | "self" | "third_party_https" | "third_party_insecure" | "none" = (() => {
-        if (!stubAuthLocRaw) return "none";
+        if (!resolutionSource) return "none";
         try {
-          const stubCanon = canonicalTargetUri(stubAuthLocRaw);
-          if (stubCanon === canonicalTargetUri(aaoHostedAdagentsJsonUrl(domain))) return "aao";
-          if (stubCanon === canonicalTargetUri(expectedAdagentsJsonUrl(domain))) return "self";
+          const resolvedCanon = canonicalTargetUri(resolutionSource);
+          if (resolvedCanon === canonicalTargetUri(aaoHostedAdagentsJsonUrl(domain))) return "aao";
+          if (resolvedCanon === canonicalTargetUri(expectedAdagentsJsonUrl(domain))) return "self";
           // Third-party canonical — but the schema description for
           // `self_redirected` promises an HTTPS origin. A publisher
           // pointing at `http://...` is mis-configured (cleartext is
           // not a usable trust anchor for buy-side verifiers); treat
           // that the same as a file that fails validation rather than
           // promote it as a third-party-trusted location.
-          if (new URL(stubAuthLocRaw).protocol !== 'https:') return "third_party_insecure";
+          if (new URL(resolutionSource).protocol !== 'https:') return "third_party_insecure";
           return "third_party_https";
         } catch {
           return "none";
@@ -5961,11 +5987,18 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         hosted_url: isAaoHosted ? aaoHostedAdagentsJsonUrl(domain) : undefined,
         expected_url: expectedAdagentsJsonUrl(domain),
         // Resolved URL — where the canonical adagents.json document
-        // actually lives after following authoritative_location. For
-        // self_redirected this is the third-party HTTPS origin the
-        // publisher's stub points at; verifiers audit the TLS chain
-        // there. NULL when no stub is in play.
-        resolved_url: hostingMode === "self_redirected" ? stubAuthLocRaw : null,
+        // actually lives after following authoritative_location AND
+        // HTTP-layer redirects. For self_redirected this is the
+        // third-party HTTPS origin verifiers should audit; for
+        // aao_hosted it's AAO's hosted URL; otherwise NULL.
+        resolved_url: hostingMode === "self_redirected" ? resolutionSource : null,
+        // Phase B: HTTP status + byte count from the most recent fetch.
+        // Verifier-grade chrome — lets a buy-side scraper sanity-check
+        // they're seeing the same response AAO is. NULL until the
+        // first crawl completes after Phase B deploys (existing rows
+        // backfill via the 60-min crawl cadence).
+        last_http_status: cachedHttpStatus,
+        last_bytes: cachedResponseBytes,
         // Last successful validation timestamp. Already plumbed
         // internally; surface for verifiers to sanity-check freshness.
         last_validated: cachedAdagentsLastValidated

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -5972,8 +5972,19 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           return "none";
         }
       })();
+      // Stale-cache safety: if the most recent fetch attempt returned
+      // 4xx/5xx, the publisher's origin is no longer serving the
+      // canonical document. The cached `adagents_json` body and the
+      // federated index's `source_type='adagents_json'` may both still
+      // exist (recordFailedAdagentsFetch preserves them so prior good
+      // data isn't wiped on a single transient error), but the live
+      // state is broken — the verifier-facing UI must reflect that.
+      // Treat as `self_invalid` so the hero state and the action row
+      // surface the recovery path instead of falsely declaring `self`.
+      const recentFetchFailed = typeof cachedHttpStatus === 'number' && cachedHttpStatus >= 400;
       const hostingMode: "self" | "self_invalid" | "aao_hosted" | "self_redirected" | "none" = (
-        adagentsValid === true && stubResolution === "aao"                  ? "aao_hosted"
+        recentFetchFailed && (adagentsValid === true || adagentsValid === false) ? "self_invalid"
+        : adagentsValid === true && stubResolution === "aao"                  ? "aao_hosted"
         : adagentsValid === true && stubResolution === "third_party_https"   ? "self_redirected"
         : adagentsValid === true && stubResolution === "third_party_insecure" ? "self_invalid"
         : adagentsValid === true                                              ? "self"
@@ -5989,9 +6000,18 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         // Resolved URL — where the canonical adagents.json document
         // actually lives after following authoritative_location AND
         // HTTP-layer redirects. For self_redirected this is the
-        // third-party HTTPS origin verifiers should audit; for
-        // aao_hosted it's AAO's hosted URL; otherwise NULL.
-        resolved_url: hostingMode === "self_redirected" ? resolutionSource : null,
+        // third-party HTTPS origin verifiers should audit. For
+        // aao_hosted, surface it ONLY when there's actual evidence the
+        // publisher set up the redirect (a JSONB authoritative_location
+        // field or a column-level resolved_url that lands at AAO) — a
+        // stale-only `aaoOptedIn` row without origin evidence has no
+        // resolution to report.
+        resolved_url:
+          hostingMode === "self_redirected"
+            ? resolutionSource
+            : hostingMode === "aao_hosted" && resolutionSource && stubResolution === "aao"
+              ? resolutionSource
+              : null,
         // Phase B: HTTP status + byte count from the most recent fetch.
         // Verifier-grade chrome — lets a buy-side scraper sanity-check
         // they're seeing the same response AAO is. NULL until the

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -610,10 +610,16 @@ const PublisherHostingSchema = z.object({
     description: "Where adagents.json *should* live for this domain — the publisher's own /.well-known path. Always populated, regardless of `mode`.",
   }),
   resolved_url: z.string().nullable().optional().openapi({
-    description: "Where the canonical adagents.json document actually lives after following the publisher's `authoritative_location` stub. Populated iff `mode === 'self_redirected'` — verifiers should pin trust to this URL's TLS chain, not to `expected_url`'s. NULL otherwise.",
+    description: "Where the canonical adagents.json document actually lives after following the publisher's `authoritative_location` stub or any HTTP-layer redirects. Populated iff `mode === 'self_redirected'` — verifiers should pin trust to this URL's TLS chain, not to `expected_url`'s. NULL otherwise.",
   }),
   last_validated: z.string().nullable().optional().openapi({
     description: "ISO timestamp of the last successful validation crawl. Lets verifiers sanity-check freshness. NULL when never crawled.",
+  }),
+  last_http_status: z.number().int().min(100).max(599).nullable().optional().openapi({
+    description: "HTTP status code returned by AAO's most recent fetch attempt of the publisher's `/.well-known/adagents.json`. Verifier-grade chrome — lets a buy-side scraper confirm they see the same response AAO does. NULL until the first crawl records or for transient errors that never produced an HTTP response.",
+  }),
+  last_bytes: z.number().int().nonnegative().nullable().optional().openapi({
+    description: "Response body byte length from the most recent fetch (post-decompression). When `authoritative_location` was followed, measures the canonical document body, not the stub. NULL until the first crawl records.",
   }),
   origin_verified_at: z.string().nullable().optional().openapi({
     description: "ISO timestamp of the last successful origin verification — AAO fetched the publisher's own /.well-known/adagents.json and confirmed `authoritative_location` points at our hosted URL. When set, the publisher's authorization rows have been promoted to `source='adagents_json'` (origin-attested). NULL when never verified or last attempt failed. Only populated when `mode === 'aao_hosted'`.",

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -610,7 +610,7 @@ const PublisherHostingSchema = z.object({
     description: "Where adagents.json *should* live for this domain — the publisher's own /.well-known path. Always populated, regardless of `mode`.",
   }),
   resolved_url: z.string().nullable().optional().openapi({
-    description: "Where the canonical adagents.json document actually lives after following the publisher's `authoritative_location` stub or any HTTP-layer redirects. Populated iff `mode === 'self_redirected'` — verifiers should pin trust to this URL's TLS chain, not to `expected_url`'s. NULL otherwise.",
+    description: "Where the canonical adagents.json document actually lives after following the publisher's `authoritative_location` stub or any HTTP-layer redirects. Populated when `mode === 'self_redirected'` (the third-party HTTPS origin verifiers should audit) and when `mode === 'aao_hosted'` AND the publisher has actively set up the redirect (`authoritative_location` in the manifest body or a network-layer redirect to AAO's hosted URL). NULL when there's no resolved-URL evidence to report.",
   }),
   last_validated: z.string().nullable().optional().openapi({
     description: "ISO timestamp of the last successful validation crawl. Lets verifiers sanity-check freshness. NULL when never crawled.",

--- a/server/src/utils/url-security.ts
+++ b/server/src/utils/url-security.ts
@@ -455,6 +455,14 @@ export interface SafeFetchAxiosLike {
   status: number;
   data: Buffer;
   headers: Record<string, string>;
+  /**
+   * Final URL after following redirects (per Fetch Response.url). Lets
+   * callers audit the post-redirect TLS chain — important for
+   * publisher-page verification chrome where a /.well-known fetch may
+   * 30x to a CDN or partner host. May equal the input URL when no
+   * redirects were followed.
+   */
+  url: string;
 }
 
 const DEFAULT_MAX_RESPONSE_BYTES = 10 * 1024 * 1024;
@@ -506,7 +514,7 @@ export async function safeFetchAxiosLike(
     const headers: Record<string, string> = {};
     res.headers.forEach((v, k) => { headers[k.toLowerCase()] = v; });
 
-    return { status: res.status, data, headers };
+    return { status: res.status, data, headers, url: res.url };
   } finally {
     clearTimeout(timer);
   }

--- a/server/tests/integration/registry-publisher-brand-json-hydration.test.ts
+++ b/server/tests/integration/registry-publisher-brand-json-hydration.test.ts
@@ -595,6 +595,35 @@ describe('Registry publisher endpoint — brand.json hydration', () => {
     expect(res.body.hosting.resolved_url).toBeNull();
   });
 
+  it('flips hosting.mode to self_invalid when the most recent fetch was 4xx, even with a stale-cached valid manifest', async () => {
+    // Stale-cache safety: a previously-valid publisher whose origin
+    // now 404s should NOT be reported as `self`. The cached manifest
+    // and source_type='adagents_json' both linger (so prior good data
+    // isn't wiped on a single transient blip), but the live state is
+    // broken — the verifier UI must reflect that.
+    const pub = `stale-cache-404-${Date.now()}.registry-baseline.example`;
+    await publisherDb.upsertAdagentsCache({
+      domain: pub,
+      manifest: {
+        authorized_agents: [{ url: 'https://agent.example', authorized_for: 'display' }],
+        properties: [],
+      },
+    });
+    // Then: the next fetch fails. recordFailedAdagentsFetch updates
+    // last_http_status without clearing the cached body.
+    await publisherDb.recordFailedAdagentsFetch({
+      domain: pub,
+      statusCode: 404,
+      responseBytes: 162,
+      resolvedUrl: `https://${pub}/.well-known/adagents.json`,
+    });
+
+    const res = await request(app).get(`/api/registry/publisher?domain=${encodeURIComponent(pub)}`);
+    expect(res.status).toBe(200);
+    expect(res.body.hosting.mode).toBe('self_invalid');
+    expect(res.body.hosting.last_http_status).toBe(404);
+  });
+
   it('records failed-fetch metadata via recordFailedAdagentsFetch even when no manifest is cached', async () => {
     // After Phase B the crawler calls recordFailedAdagentsFetch on
     // 4xx/5xx responses so the verifier UI can show

--- a/server/tests/integration/registry-publisher-brand-json-hydration.test.ts
+++ b/server/tests/integration/registry-publisher-brand-json-hydration.test.ts
@@ -513,6 +513,108 @@ describe('Registry publisher endpoint — brand.json hydration', () => {
     expect(res.body.hosting.last_validated).toMatch(/\d{4}-\d{2}-\d{2}T/);
   });
 
+  it('surfaces Phase B fetch metadata: last_http_status, last_bytes, resolved_url', async () => {
+    const pub = `phase-b-${Date.now()}.registry-baseline.example`;
+    await publisherDb.upsertAdagentsCache({
+      domain: pub,
+      manifest: { authorized_agents: [], properties: [] },
+      statusCode: 200,
+      responseBytes: 1438,
+      resolvedUrl: `https://${pub}/.well-known/adagents.json`,
+    });
+
+    const res = await request(app).get(`/api/registry/publisher?domain=${encodeURIComponent(pub)}`);
+    expect(res.status).toBe(200);
+    expect(res.body.hosting.last_http_status).toBe(200);
+    expect(res.body.hosting.last_bytes).toBe(1438);
+    // For mode === 'self', resolved_url is null in the response shape
+    // even though the column is populated — it's only surfaced when
+    // self_redirected. The column-vs-response distinction is intentional
+    // (verifier audit hook only kicks in when the chain has actually
+    // shifted).
+    expect(res.body.hosting.resolved_url).toBeNull();
+  });
+
+  it('detects Case-B self_redirected via HTTP-layer redirect (no authoritative_location in JSONB)', async () => {
+    // Phase B closes the gap where the publisher's /.well-known
+    // serves a 301/302 to a third-party host with NO
+    // `authoritative_location` field in the manifest body. Phase A
+    // could only see Case A (JSONB-based redirection); Case B requires
+    // the resolved_url column to be populated.
+    const pub = `case-b-redirect-${Date.now()}.registry-baseline.example`;
+    const cdnUrl = `https://cdn-${Date.now()}.example.test/adagents.json`;
+    await publisherDb.upsertAdagentsCache({
+      domain: pub,
+      // Note: no authoritative_location in the manifest. The redirect
+      // happened at the HTTP layer, not as an in-document pointer.
+      manifest: { authorized_agents: [], properties: [] },
+      statusCode: 200,
+      resolvedUrl: cdnUrl,
+    });
+
+    const res = await request(app).get(`/api/registry/publisher?domain=${encodeURIComponent(pub)}`);
+    expect(res.status).toBe(200);
+    expect(res.body.hosting.mode).toBe('self_redirected');
+    expect(res.body.hosting.resolved_url).toBe(cdnUrl);
+  });
+
+  it('detects aao_hosted via Case-B HTTP redirect to AAO (no authoritative_location)', async () => {
+    // Edge: publisher's /.well-known returns a 301 to AAO's hosted
+    // URL. There's no authoritative_location field but the network
+    // layer pointed at AAO. Should resolve to aao_hosted.
+    const pub = `case-b-aao-${Date.now()}.registry-baseline.example`;
+    await publisherDb.upsertAdagentsCache({
+      domain: pub,
+      manifest: { authorized_agents: [], properties: [] },
+      statusCode: 200,
+      resolvedUrl: aaoHostedAdagentsJsonUrl(pub),
+    });
+
+    const res = await request(app).get(`/api/registry/publisher?domain=${encodeURIComponent(pub)}`);
+    expect(res.status).toBe(200);
+    expect(res.body.hosting.mode).toBe('aao_hosted');
+    expect(res.body.hosting.hosted_url).toBe(aaoHostedAdagentsJsonUrl(pub));
+  });
+
+  it('gracefully handles NULL Phase B metadata (legacy rows pre-deploy)', async () => {
+    // Existing publishers rows from before Phase B have NULL for
+    // last_http_status / last_response_bytes / resolved_url. The API
+    // surfaces them as null; the UI degrades gracefully (verification
+    // chrome omits the row when typeof !== 'number').
+    const pub = `legacy-row-${Date.now()}.registry-baseline.example`;
+    await publisherDb.upsertAdagentsCache({
+      domain: pub,
+      manifest: { authorized_agents: [], properties: [] },
+      // No statusCode / responseBytes / resolvedUrl supplied.
+    });
+
+    const res = await request(app).get(`/api/registry/publisher?domain=${encodeURIComponent(pub)}`);
+    expect(res.status).toBe(200);
+    expect(res.body.hosting.last_http_status).toBeNull();
+    expect(res.body.hosting.last_bytes).toBeNull();
+    expect(res.body.hosting.resolved_url).toBeNull();
+  });
+
+  it('records failed-fetch metadata via recordFailedAdagentsFetch even when no manifest is cached', async () => {
+    // After Phase B the crawler calls recordFailedAdagentsFetch on
+    // 4xx/5xx responses so the verifier UI can show
+    // "Last attempted: <ts> · HTTP 404" even when no manifest was
+    // stored. The row is created with source_type='community' so
+    // adagents_valid still reports null/false.
+    const pub = `failed-fetch-${Date.now()}.registry-baseline.example`;
+    await publisherDb.recordFailedAdagentsFetch({
+      domain: pub,
+      statusCode: 404,
+      responseBytes: 162,
+      resolvedUrl: `https://${pub}/.well-known/adagents.json`,
+    });
+
+    const res = await request(app).get(`/api/registry/publisher?domain=${encodeURIComponent(pub)}`);
+    expect(res.status).toBe(200);
+    expect(res.body.hosting.last_http_status).toBe(404);
+    expect(res.body.hosting.last_bytes).toBe(162);
+  });
+
   it('tags federated-index properties with source=adagents_json when the publisher serves a valid adagents.json', async () => {
     // Wonderstruck-shaped regression: properties listed in the live
     // adagents.json were being labelled `discovered` (i.e. "found by

--- a/server/tests/unit/adagents-manager.test.ts
+++ b/server/tests/unit/adagents-manager.test.ts
@@ -62,6 +62,7 @@ describe('AdAgentsManager', () => {
         status: 200,
         data: buf(validAdAgents),
         headers: { 'content-type': 'application/json' },
+        url: 'https://example.com/.well-known/adagents.json',
       });
 
       const result = await manager.validateDomain('example.com');
@@ -71,6 +72,85 @@ describe('AdAgentsManager', () => {
       expect(result.domain).toBe('example.com');
       expect(result.url).toBe('https://example.com/.well-known/adagents.json');
       expect(result.status_code).toBe(200);
+    });
+
+    // Phase B regression: validator must capture response body byte
+    // length and post-redirect resolved URL on success. The crawler
+    // threads both into publishers.last_response_bytes / resolved_url
+    // for verifier-grade hero chrome. Without these tests, a
+    // refactor that loses the captures would silently regress while
+    // the route-layer tests still pass (they upsert metadata directly).
+    it('captures response_bytes and resolved_url on a 200 fetch', async () => {
+      const valid: AdAgentsJson = {
+        authorized_agents: [{ url: 'https://agent.example.com', authorized_for: 'Test' }],
+        last_updated: new Date().toISOString(),
+      };
+      const body = buf(valid);
+      mockedSafeFetch.mockResolvedValue({
+        status: 200,
+        data: body,
+        headers: { 'content-type': 'application/json' },
+        // Simulate a 301 redirect: input was example.com, final URL
+        // is the CDN host. Validator should record the post-redirect URL.
+        url: 'https://cdn.example.net/.well-known/adagents.json',
+      });
+
+      const result = await manager.validateDomain('example.com');
+
+      expect(result.valid).toBe(true);
+      expect(result.response_bytes).toBe(body.byteLength);
+      expect(result.resolved_url).toBe('https://cdn.example.net/.well-known/adagents.json');
+    });
+
+    it('captures response_bytes and resolved_url even on a non-200', async () => {
+      // Failed fetch still surfaces the metadata via
+      // recordFailedAdagentsFetch downstream — the validator must
+      // populate both before early-returning.
+      const errBody = Buffer.from('<html>Not Found</html>');
+      mockedSafeFetch.mockResolvedValue({
+        status: 404,
+        data: errBody,
+        headers: { 'content-type': 'text/html' },
+        url: 'https://example.com/.well-known/adagents.json',
+      });
+
+      const result = await manager.validateDomain('example.com');
+
+      expect(result.valid).toBe(false);
+      expect(result.status_code).toBe(404);
+      expect(result.response_bytes).toBe(errBody.byteLength);
+      expect(result.resolved_url).toBe('https://example.com/.well-known/adagents.json');
+    });
+
+    it('overwrites resolved_url when authoritative_location is followed', async () => {
+      // Phase A behavior reaffirmed: when the publisher's stub points
+      // at a different canonical URL, the validator follows it and the
+      // resolved_url should reflect WHERE the canonical body came from
+      // (the authoritative_location target), not where the stub lived.
+      const stubBody = buf({ authoritative_location: 'https://cdn.example.net/adagents.json' });
+      const canonicalBody = buf({
+        authorized_agents: [{ url: 'https://agent.example.com', authorized_for: 'Test' }],
+        last_updated: new Date().toISOString(),
+      });
+      mockedSafeFetch
+        .mockResolvedValueOnce({
+          status: 200,
+          data: stubBody,
+          headers: { 'content-type': 'application/json' },
+          url: 'https://example.com/.well-known/adagents.json',
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          data: canonicalBody,
+          headers: { 'content-type': 'application/json' },
+          url: 'https://cdn.example.net/adagents.json',
+        });
+
+      const result = await manager.validateDomain('example.com');
+
+      expect(result.valid).toBe(true);
+      expect(result.resolved_url).toBe('https://cdn.example.net/adagents.json');
+      expect(result.response_bytes).toBe(canonicalBody.byteLength);
     });
 
     it('normalizes domain by removing protocol', async () => {


### PR DESCRIPTION
## Summary

Closes the verifier-grade gap left by [Phase A](https://github.com/adcontextprotocol/adcp/pull/4154). AAO now records per-fetch metadata (HTTP status code, response body byte length, post-redirect resolved URL) on the publishers overlay row and surfaces it through \`/api/registry/publisher\`. The hero on \`/publisher/<domain>\` now reads \`Last verified · HTTP 200 · 1,438 · Expected URL · Resolved URL\` — copy-paste-friendly, scrape-friendly chrome that lets buy-side operators sanity-check they see the same response AAO does.

Also closes the Case-B \`self_redirected\` gap: when the publisher's \`/.well-known\` returns a 301/302 to a third-party HTTPS origin (with no \`authoritative_location\` field in the body), the new \`resolved_url\` column drives \`mode="self_redirected"\` so the TLS-chain shift is visible. Phase A could only see Case A (in-document authoritative_location); Phase B unifies both under one resolution path.

Plan source: \`.context/publisher-page-phase-b-roadmap.md\` (committed before code).

## Changes

- **Migration** (\`469_publisher_fetch_metadata.sql\`): three nullable columns on \`publishers\` (\`last_http_status\`, \`last_response_bytes\`, \`resolved_url\`). No backfill — 60-min crawl cadence rolls in naturally.
- **\`safeFetchAxiosLike\`** exposes \`Response.url\`. Backward-compatible additive return field.
- **\`AdAgentsValidationResult\`** carries \`response_bytes\` and \`resolved_url\`. \`validateDomain\` captures both on the \`/.well-known\` fetch; \`fetchAuthoritativeFile\` overwrites them with the canonical document's metrics when followed.
- **\`upsertAdagentsCache\`** persists statusCode/responseBytes/resolvedUrl. **New \`recordFailedAdagentsFetch\`** sibling for 4xx/5xx so failed fetches still record verifier metadata on the row.
- **Crawler** threads metadata through all four \`cacheAdagentsManifest\` call sites and calls the failure-path recorder on non-200 at each site.
- **\`/api/registry/publisher\`** reads the new columns; drops the \`source_type='adagents_json'\` SELECT filter so failed-only rows still surface "Last attempted" chrome. Case-B \`self_redirected\` detection unifies JSONB \`authoritative_location\` (Case A) and column \`resolved_url\` (Case B) under one resolution path.
- **\`PublisherHostingSchema\`** adds \`last_http_status\` and \`last_bytes\` as nullable optionals. Backward compatible.
- **\`publisher-home.html\`** hero \`<dl>\` renders HTTP and Bytes rows when populated. Graceful for legacy NULL rows pre-deploy.

## Test plan

- [x] \`vitest run tests/integration/registry-publisher-brand-json-hydration.test.ts\` — 25 passed (5 new Phase B cases)
- [x] Sweep across registry-publisher / catalog-writer / crawler-cache / hosted-property tests — 86 passed
- [x] \`tsc --noEmit\` — clean
- [ ] Smoke after deploy: visit \`/publisher/wonderstruck.org\` post-next-crawl and verify HTTP/Bytes rows render in hero
- [ ] Migration runs cleanly on prod (additive, nullable, no locks)

## Notes

Migration ordering: standard \`release_command\` + zero-downtime since columns are nullable. Pre-deploy code (without the new SELECT) continues to work; new SELECT pulls NULLs for any rows not yet re-crawled.

Out of scope (deferred per the roadmap §7): partner-embed endpoint, change-history view, dispute affordance, freshness pills, agent-row→publisher backlink. Those build on top of \`last_validated\` (now exposed) without further schema work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)