### PR TITLE
feat(registry): publisher page follow-ups — freshness pill, agent links, buy-side cross-link

### DIFF
--- a/.changeset/publisher-page-followups-freshness-links.md
+++ b/.changeset/publisher-page-followups-freshness-links.md
@@ -1,0 +1,10 @@
+---
+---
+
+Three deferred follow-ups from the publisher-page redesign roadmap, shipped as a single small UI patch on `/publisher/<domain>`:
+
+- **Freshness pill** alongside the verified timestamp — color-coded green (<24h), amber (<7d), red (older). Lets a verifier scan staleness without subtracting dates. Reads off `last_validated` (already plumbed through Phase B); pure CSS + a small JS helper.
+- **Buy-side agents** added as a fourth cross-link card in the page footer (alongside spec / publishers / builder). Closes the "no exit to the agent directory" gap from the product review.
+- **Authorized agent URLs are now clickable** — open in a new tab so a buyer can inspect the agent endpoint directly. Validated to http(s) only at the renderer so a malicious manifest can't smuggle a `javascript:` href. Replaces the prior plain-text rendering.
+
+No backend changes. Single-file edit, +88 net LoC.

--- a/server/public/publisher-home.html
+++ b/server/public/publisher-home.html
@@ -112,6 +112,30 @@
         background: none; padding: 0; user-select: all;
       }
 
+      /* Freshness pill — relative-time chip alongside the verified
+         timestamp. Color-coded by age so a verifier can scan staleness
+         at a glance without subtracting dates. green <24h, amber <7d,
+         red older. Pulled from the same color tokens as the
+         provenance ladder for visual consistency. */
+      .freshness {
+        display: inline-block;
+        margin-left: var(--space-2);
+        font-family: var(--font-sans);
+        font-size: var(--text-xs);
+        font-weight: var(--font-medium);
+        padding: 1px 8px;
+        border-radius: var(--radius-pill);
+        border: var(--border-1) solid transparent;
+        white-space: nowrap;
+        user-select: none;
+      }
+      .freshness--fresh  { background: var(--color-success-50);
+        color: var(--color-success-800); border-color: var(--color-success-200); }
+      .freshness--aging  { background: var(--color-warning-50);
+        color: var(--color-warning-800); border-color: var(--color-warning-200); }
+      .freshness--stale  { background: var(--color-error-50);
+        color: var(--color-error-800); border-color: var(--color-error-200); }
+
       .publisher-hero__status {
         display: flex; align-items: center; gap: var(--space-2);
         font-size: var(--text-base); font-weight: var(--font-semibold);
@@ -223,6 +247,19 @@
       .on-file__row-name code {
         font-family: var(--font-mono); background: none; padding: 0;
         font-size: inherit; font-weight: inherit;
+      }
+      .on-file__agent-link {
+        color: inherit; text-decoration: none;
+        border-bottom: 1px dashed var(--color-border);
+      }
+      .on-file__agent-link:hover {
+        color: var(--color-brand);
+        border-bottom-color: var(--color-brand);
+      }
+      .on-file__agent-link:focus-visible {
+        outline: 2px solid var(--color-brand);
+        outline-offset: 2px;
+        border-radius: 2px;
       }
       .on-file__row-meta {
         font-size: var(--text-xs); color: var(--color-text-muted);
@@ -417,6 +454,10 @@
               <h3>All publishers</h3>
               <p>Browse the full registry of publishers indexed at AAO.</p>
             </a>
+            <a class="cross-link-card" href="/agents">
+              <h3>Buy-side agents</h3>
+              <p>Browse the AI sales and buying agents in the registry.</p>
+            </a>
             <a class="cross-link-card" href="/adagents/builder">
               <h3>Build adagents.json</h3>
               <p>Generate a spec-conformant file for a new domain.</p>
@@ -534,6 +575,35 @@
         return { iso, display: d.toISOString().replace('T', ' ').replace('Z', ' UTC') };
       }
 
+      // Freshness pill alongside the verified timestamp. Color-coded by
+      // age so a verifier can scan staleness without subtracting dates:
+      // green <24h, amber <7d, red older. Returns null when the
+      // timestamp can't be parsed (so the caller omits the pill).
+      function freshnessPill(iso) {
+        if (!iso) return null;
+        const d = new Date(iso);
+        if (isNaN(d.getTime())) return null;
+        const ageMs = Date.now() - d.getTime();
+        const ageH = ageMs / 3600_000;
+        const ageD = ageH / 24;
+        let tier, label;
+        if (ageH < 1) {
+          tier = 'fresh';
+          const minutes = Math.max(1, Math.floor(ageMs / 60_000));
+          label = `${minutes} min ago`;
+        } else if (ageH < 24) {
+          tier = 'fresh';
+          label = `${Math.floor(ageH)}h ago`;
+        } else if (ageD < 7) {
+          tier = 'aging';
+          label = `${Math.floor(ageD)}d ago`;
+        } else {
+          tier = 'stale';
+          label = `${Math.floor(ageD)}d ago`;
+        }
+        return { tier, label };
+      }
+
       function renderHero(data) {
         const state = deriveHeroState(data);
         const hero = document.getElementById('publisher-hero');
@@ -546,9 +616,13 @@
         const verification = document.getElementById('verification-chrome');
         const hosting = data.hosting || {};
         const ts = fmtTimestamp(hosting.last_validated);
+        const fresh = freshnessPill(hosting.last_validated);
         const verRows = [];
         if (ts) {
-          verRows.push(`<div><dt>Last verified</dt><dd><time datetime="${escapeHtml(ts.iso)}"><code>${escapeHtml(ts.display)}</code></time></dd></div>`);
+          const pill = fresh
+            ? ` <span class="freshness freshness--${fresh.tier}" aria-label="Verified ${escapeHtml(fresh.label)}">${escapeHtml(fresh.label)}</span>`
+            : '';
+          verRows.push(`<div><dt>Last verified</dt><dd><time datetime="${escapeHtml(ts.iso)}"><code>${escapeHtml(ts.display)}</code></time>${pill}</dd></div>`);
         }
         if (typeof hosting.last_http_status === 'number') {
           verRows.push(`<div><dt>HTTP</dt><dd><code>${escapeHtml(String(hosting.last_http_status))}</code></dd></div>`);
@@ -871,6 +945,20 @@
         }</ul>`;
       }
 
+      // Render the agent URL — clickable link if it's a valid http(s)
+      // URL, plain code otherwise. Agent URLs are publisher-controlled
+      // strings from adagents.json; reject javascript:/data:/file: so a
+      // malicious manifest can't smuggle a script-execution href.
+      function renderAgentUrl(rawUrl) {
+        let url;
+        try { url = new URL(rawUrl); }
+        catch { return `<code>${escapeHtml(rawUrl)}</code>`; }
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+          return `<code>${escapeHtml(rawUrl)}</code>`;
+        }
+        return `<a href="${escapeHtml(url.href)}" target="_blank" rel="noopener noreferrer" class="on-file__agent-link"><code>${escapeHtml(rawUrl)}</code></a>`;
+      }
+
       function renderAgents(domain, agents) {
         const body = document.getElementById('agents-body');
         const count = document.getElementById('agents-count');
@@ -890,7 +978,7 @@
             const wide = a.publisher_wide ? `<span aria-hidden>·</span><span>publisher-wide</span>` : '';
             return `<li><div class="on-file__row">
               <div class="on-file__row-main">
-                <div class="on-file__row-name"><code>${escapeHtml(a.url)}</code></div>
+                <div class="on-file__row-name">${renderAgentUrl(a.url)}</div>
                 <div class="on-file__row-meta">
                   ${scope}
                   ${wide}


### PR DESCRIPTION
## Summary

Three deferred items from \`.context/publisher-page-phase-b-roadmap.md\` §7, shipped as a single small UI patch on \`/publisher/<domain>\`:

1. **Freshness pill** alongside the verified timestamp — color-coded green (<24h), amber (<7d), red (older). Lets a verifier scan staleness without subtracting dates. Reads off \`hosting.last_validated\` already plumbed through Phase B.
2. **Buy-side agents** cross-link card added to the footer (alongside spec / publishers / builder). Closes the "no exit to the agent directory" gap from the product review.
3. **Authorized agent URLs are clickable** — open in a new tab with \`rel="noopener noreferrer"\` so a buyer can inspect the agent endpoint directly. Validated to http(s) at the renderer so a publisher-controlled manifest can't smuggle a \`javascript:\` href. Falls back to plain \`<code>\` rendering when the URL fails the protocol check.

No backend changes. No API contract changes. Single-file edit at \`server/public/publisher-home.html\`, +88 net LoC.

## What's still deferred

Larger follow-ups remain captured in the roadmap for separate design + implementation cycles:
- Partner-embed endpoint (\`/publisher/<domain>/embed\`)
- Change-history view
- Dispute affordance
- Property identifier vocabulary alignment (separate catalog task)

## Test plan

- [x] \`tsc --noEmit\` — clean
- [x] \`vitest run tests/integration/registry-publisher-brand-json-hydration.test.ts\` — 26 passed (no behavior change at API layer)
- [ ] Smoke after deploy: visit \`/publisher/wonderstruck.org\` and confirm freshness pill renders next to "Last verified", agent URL is clickable + opens in new tab, footer has 4 cross-link cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)