### PR TITLE
ci(release): backport forward-merge bridges (#3905) to 3.0.x — fixes underlying issue in #4189

### DIFF
--- a/.changeset/extend-forward-merge-allowlist.md
+++ b/.changeset/extend-forward-merge-allowlist.md
@@ -1,0 +1,10 @@
+---
+---
+
+ci(release): extend forward-merge auto-resolution for known 3.1-track divergences
+
+Adds four files to the auto-resolved set in `forward-merge-3.0.yml`, all routed to `--ours` (main): `training-agent-storyboards.yml`, `runner-output-contract.yaml`, `core/error.json`, `get-adcp-capabilities-response.json`. Same bridge pattern as the existing AUTH_REQUIRED rule (#3811) — main has 3.1-track additions in these files that 3.0.x can't adopt within the patch contract; without the short-circuit, every forward-merge re-discovers the divergence.
+
+Discovered on the 3.0.5 forward-merge, which required manual resolution (#3902). Future 3.0.x patch forward-merges will now auto-open without these five recurring conflicts.
+
+`storyboard-schema.yaml` is intentionally LEFT in the manual-resolution path — both lines legitimately add new doc blocks (3.0.x added `default_agent` in 3.0.5; main has CANONICAL CHECK ENUM additions), and `git checkout --ours` silently drops clean-merged 3.0.x additions. Hybrid resolution needs a human.

--- a/.github/workflows/forward-merge-3.0.yml
+++ b/.github/workflows/forward-merge-3.0.yml
@@ -189,6 +189,46 @@ jobs:
                   git checkout --ours -- "$f"
                   git add -- "$f"
                   ;;
+                # Known 3.1-track divergences: main has additions that 3.0.x
+                # cannot adopt within the patch contract. Same rationale as
+                # the AUTH_REQUIRED bridge above — main is the more advanced
+                # state, 3.0.x's content here is the older shape, and
+                # squash-merges of prior forward-merges don't advance the
+                # merge-base so the conflict resurfaces every push without
+                # this short-circuit.
+                #
+                # - .github/workflows/training-agent-storyboards.yml: main
+                #   extracted overlay logic to scripts/overlay-compliance-
+                #   cache.sh (#3793-era refactor); 3.0.x still inlines it.
+                # - static/compliance/source/universal/runner-output-contract.yaml:
+                #   main has forward-compat narrative for unrecognized
+                #   `check` kinds and additional grading-code coverage.
+                # - static/schemas/source/core/error.json: main has #3875's
+                #   schema_id + discriminator additions on issues[] entries.
+                # - static/schemas/source/protocol/get-adcp-capabilities-response.json:
+                #   main has the 3.1+ measurement capability block plus the
+                #   identity.additionalProperties:true relaxation that 3.0.x
+                #   adopted in 3.0.5 (#3896). Both shapes converged on the
+                #   identity flip; main's superset wins.
+                #
+                # Remove these entries when 3.1.0 ships and main absorbs the
+                # 3.0.x line — these are temporary bridges, not permanent
+                # allowlist entries. First observed on the 3.0.5 forward-
+                # merge (manual resolution: PR #3902).
+                .github/workflows/training-agent-storyboards.yml|static/compliance/source/universal/runner-output-contract.yaml|static/schemas/source/core/error.json|static/schemas/source/protocol/get-adcp-capabilities-response.json)
+                  git checkout --ours -- "$f"
+                  git add -- "$f"
+                  ;;
+                # static/compliance/source/universal/storyboard-schema.yaml
+                # is intentionally NOT auto-resolved. The file is the doc-
+                # comment authoring schema; both lines legitimately add new
+                # field documentation (3.0.x added `default_agent` in 3.0.5
+                # via #3897; main has its own additions like the CANONICAL
+                # CHECK ENUM block). `git checkout --ours -- <file>` would
+                # silently drop 3.0.x's clean-merged additions, so any
+                # conflict here needs human attention to merge both sides'
+                # new doc blocks. Falls through to the UNEXPECTED handler
+                # below by design.
                 *)
                   UNEXPECTED="$UNEXPECTED $f"
                   ;;


### PR DESCRIPTION
Cherry-pick of [#3905](https://github.com/adcontextprotocol/adcp/pull/3905) (\`26e03c2c71\` on \`main\`) to \`3.0.x\`. Fixes the root cause of the recurring forward-merge failures tracked in #4189.

## Why this is the underlying fix

The \`forward-merge-3.0.yml\` workflow keeps failing on every push to \`3.0.x\` because:

1. GitHub runs the workflow definition from the **branch that triggered it** (\`3.0.x\`)
2. \`3.0.x\`'s copy of the workflow lacks the bridges added in #3905 on \`main\` (2026-05-02)
3. So the workflow's auto-resolution case-statement doesn't include \`training-agent-storyboards.yml\`, \`runner-output-contract.yaml\`, \`core/error.json\`, \`get-adcp-capabilities-response.json\`
4. These four files conflict on every forward-merge attempt and the workflow falls into the UNEXPECTED handler → fails

After this PR lands on \`3.0.x\`, the next push will run the workflow with bridges enabled and the four perennial conflicts will auto-resolve to \`--ours\` (main) per the documented design.

## Validation

- Pure cherry-pick of an already-merged main commit
- Touches only \`.github/workflows/forward-merge-3.0.yml\` and a \`--empty\` changeset
- No protocol/schema/wire-format change

## Sequencing

Land **after** #4191 (the manual reconciliation that catches \`3.0.x\` up to \`main\`). Order matters: if this lands first, the workflow on the next \`3.0.x\` push runs with bridges and auto-opens a forward-merge PR — but the manual resolution of \`storyboard-schema.yaml\`, \`SKILL.md\`, and \`error-code.json\` (the non-bridged files) still needs to happen, so the workflow will still fail. #4191 puts \`main\` in a state where the next forward-merge has *only* the bridge-eligible conflicts, which this PR's bridges then resolve cleanly.

## Followup

Issue #4189 also flags backporting #3932 (SKILL.md field-name correction) to \`3.0.x\` so \`SKILL.md\` doesn't reappear as a conflict on the next forward-merge. Separate small PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)