### PR TITLE
docs(skill): backport #3932 SKILL.md issues[] field-name correction to 3.0.x

### DIFF
--- a/.changeset/skill-issues-fields-fix.md
+++ b/.changeset/skill-issues-fields-fix.md
@@ -1,0 +1,16 @@
+---
+---
+
+docs(skill): correct `issues[]` field names + split spec-optional from SDK-synthesized
+
+Follow-up to #3927. Three corrections to `skills/call-adcp-agent/SKILL.md`:
+
+1. **Casing.** `error.json` defines the wire field as `schema_id` (snake_case, line 54). #3927 documented it as `schemaId` — that shape is `@adcp/sdk`-normalized and breaks Python/Go/raw-HTTP callers reading the literal JSON. Renamed to `schema_id` in prose and the symptom-fix table; called out the SDK casing variance separately.
+
+2. **Category split.** `schema_id` and `discriminator` are spec-optional wire fields per `error.json`. `hint` and `allowedValues` are NOT in `error.json` — they're synthesized client-side by `@adcp/sdk` after parsing. Grouping all four under "implementation-dependent fields a validator may opt into" told non-TS callers to look for fields no AdCP seller emits. Split into two clearly-labeled tiers: spec-optional (sellers MAY emit) vs SDK-side enrichment (your SDK adds these locally, irrespective of seller).
+
+3. **Recovery order.** Restored `pointer` + `keyword` + `variants` as the unconditional one-step path; treats `discriminator` / `hint` / `schema_id` as shortcuts when present rather than required first reads. The previous front-loading made callers branch on optional fields that are absent on the long tail.
+
+Also fixed `discriminator` field shape in prose and table: items are `{property_name, value}` per `error.json:65-71`, not `{field, value}`.
+
+Doc-only. No wire-format change. Not for cherry-pick to `3.0.x` — `schema_id` and `discriminator` were added to `error.json` in #3875 (main only) and are not in 3.0.x's wire schema.

--- a/skills/call-adcp-agent/SKILL.md
+++ b/skills/call-adcp-agent/SKILL.md
@@ -115,17 +115,22 @@ Every validation failure produces:
 }
 ```
 
+**Required fields — every conformant validator surfaces these:**
+
 - `issues[].pointer` — RFC 6901 JSON Pointer to the field.
 - `issues[].keyword` — AJV keyword (`required`, `type`, `oneOf`, `anyOf`, `additionalProperties`, `format`, `enum`).
 - `issues[].variants` — when the keyword is `oneOf` or `anyOf`, each entry lists one variant's `required` + declared `properties`. **Pick ONE variant**, send only its `required` fields. This is the fastest recovery path when you didn't know the field was a union.
-- `issues[].discriminator` — _implementation-dependent._ When the validator picks a "best surviving variant" of a const-discriminated union, this is the `[{field, value}, …]` pairs that variant requires. Reads as the validator's verdict on which branch you were inferred to be targeting. Example: `discriminator: [{field: 'type', value: 'key_value'}]` plus `pointer: '/deployments/0/activation_key/key'` and `keyword: 'required'` means "you picked the `key_value` activation_key variant and it requires top-level `key` and `value`." Compound discriminators like `audience-selector`'s `(type, value_type)` produce two-entry arrays.
-- `issues[].schemaId` — _implementation-dependent._ `$id` of the rejecting schema. For tools served from the bundled tree this is usually the response root; for flat-tree tools it can land on the deeper sub-schema. Diagnostic only; the actionable lever is `discriminator` + `variants` + `pointer`.
-- `issues[].allowedValues` — _implementation-dependent._ Closed enum lists for `keyword: 'enum'` issues. Picking from this list closes the case in one round.
-- `issues[].hint` — _implementation-dependent._ One-sentence curated recipe for known shape gotchas: discriminator nesting (`activation_key`, VAST `delivery_type`), shape mismatches (`format_id` object, `budget` number, `signal_ids` provenance objects), and discriminator merging (`account`). When present, the hint is the most-direct fix path; read it before walking variants. Absent on the long tail — no hint just means there's no curated rule for the pattern.
 
-The four `_implementation-dependent_` fields are emitted by validators that opt into them; sellers running schema-strict validation libraries surface them, others may not. Treat them as additive: their presence shortens recovery; their absence just means falling back to `pointer` + `keyword` + `variants`.
+**Spec-optional wire fields — sellers MAY emit per `error.json`:**
 
-**Recovery order**: read `hint` first (when present, it's the validated fix path); then `discriminator` (names which branch to fix); then `variants` (lists every option if you're not in a branch); then `pointer` + `keyword` + `message` for the leaf fix. Patch and resend. Three attempts should cover every field.
+- `issues[].schema_id` — `$id` of the rejecting (sub-)schema (e.g. `/schemas/3.1.0/core/activation-key.json`). Diagnostic; the actionable lever is `discriminator` + `variants` + `pointer`. Sellers MUST omit when the rejection is against a private extension or pre-release element. See [error-handling.mdx](../docs/protocol/error-handling.mdx).
+- `issues[].discriminator` — `[{property_name, value}, …]` pairs identifying the const-discriminated `oneOf`/`anyOf` variant the validator selected from values present in the payload. Reads as "you targeted this branch; the missing/wrong fields are at the same level." Compound discriminators like `audience-selector`'s `(type, value_type)` produce two-entry arrays. Example: `discriminator: [{property_name: 'type', value: 'key_value'}]` plus `pointer: '/deployments/0/activation_key/key'` and `keyword: 'required'` means "you picked the `key_value` activation_key variant and it requires top-level `key` and `value`."
+
+Both fields are optional in the spec — their presence shortens recovery; their absence just means falling back to `pointer` + `keyword` + `variants`. They are wire-level: a Python or Go caller reading the raw JSON sees them as `schema_id` and `discriminator`. SDKs that normalize keys (e.g. `@adcp/sdk` camelCases to `schemaId`) surface the SDK-shaped name.
+
+**Recovery order:** patch the `pointer`s using `keyword` + `variants`, resend. If `discriminator` is present, prefer it — it names the branch directly so you don't have to walk `variants`. If `schema_id` is present, use it for diagnostic logging only. Three attempts should cover every field.
+
+> **SDK-side enrichment.** Some SDKs synthesize additional fields client-side after parsing — e.g. `@adcp/sdk` adds `hint` (one-sentence curated recipes for known shape gotchas) and `allowedValues` (closed enum lists for `keyword: 'enum'`). These are **not** wire fields and are not emitted by sellers; if you're not using that SDK, you won't see them regardless of the seller. When present, prefer them over walking `variants`. See your SDK's docs for the full list.
 
 ## Minimal working examples
 
@@ -231,9 +236,9 @@ Quick lookup before reading the full envelope. Match what you see in `adcp_error
 | Symptom | What it means | Fix |
 |---|---|---|
 | `keyword: 'oneOf'` with `variants[]` | Discriminated union — you sent fields from multiple variants, or none | Pick ONE variant from `variants[]`. Send only its `required` fields. |
-| `discriminator: [{field, value}]` on a `required` issue | Validator inferred which branch you targeted; you missed required fields IN that branch | Read the `discriminator` pair, fill the missing required fields at the same level (don't nest under the discriminator field name). |
-| `hint:` field present on the issue | Validator matched a curated shape-gotcha rule | Apply the hint directly — it's the validated fix path. |
-| 2-3 `additionalProperties` errors at the same pointer | You merged `oneOf` variants ({account_id, brand, operator, …}) | Drop to one variant. Don't keep "extra" fields "for completeness". |
+| `discriminator: [{property_name, value}]` on a `required` issue | Seller's validator inferred which branch you targeted; you missed required fields IN that branch | Read the `discriminator` pair, fill the missing required fields at the same level (don't nest under the discriminator property name). |
+| `hint:` field present (SDK-side enrichment, not on the wire) | Your SDK matched a curated shape-gotcha rule | Apply the hint directly — it's the validated fix path. |
+| 2-3 `additionalProperties` errors at the same pointer | You merged `oneOf` variants (`` `{account_id, brand, operator, …}` ``) | Drop to one variant. Don't keep "extra" fields "for completeness". |
 | `keyword: 'required'`, `pointer: '/idempotency_key'` | Mutating tool, no UUID | Generate fresh UUID per logical operation. Reuse it on retries. |
 | `keyword: 'type'` or `additionalProperties` at `/budget` | Sent `{amount, currency}` | `budget` is a number. Currency is implied by `pricing_option_id`. |
 | `additionalProperties` at `/format_id` (string passed) | Sent `"format_id": "video_..."` | `format_id` is `{agent_url, id}` — always an object. |


### PR DESCRIPTION
Cherry-pick of [#3932](https://github.com/adcontextprotocol/adcp/pull/3932) (\`d9ac5f44ad\` on \`main\`) to \`3.0.x\`. Part of the cleanup tracked in #4189.

## Why

\`SKILL.md\` was the third file recurring as a forward-merge conflict (\`#4191\` had to manually resolve it on the merge into \`main\`). Without this backport, every future forward-merge attempt re-discovers the same divergence.

The change is also user-facing: buyer agents reading \`SKILL.md\` on the \`3.0.x\` skills bundle currently see \`field\` (incorrect) instead of \`property_name\` (the corrected wire field name) in the \`discriminator\` documentation, and don't get the wire-vs-SDK split that explains why \`hint\` and \`allowedValues\` aren't always present.

## Sequencing

After \`#4191\` (the manual reconciliation) and \`#4192\` (the workflow-bridge backport). Together those three PRs close out the entire forward-merge backlog tracked in #4189.

## Validation

- Cherry-pick of an already-merged main commit (#3932)
- Pre-commit hook passed: 866/866 unit tests, typecheck clean
- Touches \`skills/call-adcp-agent/SKILL.md\` and a \`--empty\` changeset
- No protocol/schema/wire-format change

🤖 Generated with [Claude Code](https://claude.com/claude-code)