### PR TITLE
fix(registry): agent-level visibility is the only listing gate

### DIFF
--- a/.changeset/agent-visibility-authoritative.md
+++ b/.changeset/agent-visibility-authoritative.md
@@ -1,0 +1,15 @@
+---
+"adcontextprotocol": patch
+---
+
+fix(registry): per-agent `visibility` is the only listing gate (legacy `member_profiles.is_public` no longer hides public agents)
+
+`member_profiles.is_public` is the **member-directory** flag (per migration 011: `-- Show in member directory`) and predates per-agent `visibility`. Continuing to gate the agent registry on it silently hid agents whose owners explicitly marked them `public` whenever the parent profile wasn't listed in the member directory — breaking the AAO member-profile UI's "Visibility: Public — Listed publicly and added to brand.json" promise.
+
+Drops the profile-level `is_public` filter in:
+
+- `FederatedIndexService.listAllAgents` / `listAllPublishers` / `lookupDomain` / `getStats` (back the public registry surface)
+- `AgentService.listAgents` / `getAgentByUrl` (and the redundant "public agent on private profile → hide" early-continue)
+- `CrawlerService.populateFederatedIndex` (publisher crawl)
+
+Per-agent `visibility` (`public` / `members_only` / `private`) and per-publisher `is_public` are now authoritative. Profile-level `is_public` continues to gate the `/Members` directory listing only — its documented purpose.

--- a/server/src/agent-service.ts
+++ b/server/src/agent-service.ts
@@ -33,21 +33,16 @@ export class AgentService {
       : typeOrOptions;
     const { type, viewerHasApiAccess = false } = options;
 
-    // API-access viewers can see members_only agents even on profiles that
-    // have opted out of the public directory — that's the entire Scope3
-    // use case. Public-only viewers are still scoped to public profiles.
-    const profiles = viewerHasApiAccess
-      ? await this.memberDb.listProfiles()
-      : await this.memberDb.listProfiles({ is_public: true });
+    // Walk every member profile. `member_profiles.is_public` is the
+    // member-directory gate, not an agent-visibility gate (legacy from
+    // before per-agent `visibility` existed). Per-agent `visibility` is
+    // the only gate for whether an agent is exposed.
+    const profiles = await this.memberDb.listProfiles();
     const agentsByUrl = new Map<string, Agent>();
 
     for (const profile of profiles) {
       for (const agentConfig of profile.agents || []) {
         if (!this.isVisibleToViewer(agentConfig.visibility, viewerHasApiAccess)) continue;
-        // Public agents on a profile that opted out of the public directory
-        // remain only available to API-access viewers — there is no public
-        // surface to leak them to.
-        if (agentConfig.visibility === 'public' && !profile.is_public && !viewerHasApiAccess) continue;
 
         const agentType = agentConfig.type || "unknown";
         if (type && agentType !== type) continue;
@@ -75,17 +70,14 @@ export class AgentService {
    */
   async getAgentByUrl(url: string, options: { viewerHasApiAccess?: boolean } = {}): Promise<Agent | undefined> {
     const viewerHasApiAccess = options.viewerHasApiAccess ?? false;
-    // Mirror listAgents: API-access viewers can look up members_only agents
-    // on private profiles; unauth viewers stay scoped to public profiles.
-    const profiles = viewerHasApiAccess
-      ? await this.memberDb.listProfiles()
-      : await this.memberDb.listProfiles({ is_public: true });
+    // Mirror listAgents: per-agent `visibility` is the gate; the parent
+    // profile's `is_public` only controls the member-directory listing.
+    const profiles = await this.memberDb.listProfiles();
 
     for (const profile of profiles) {
       for (const agentConfig of profile.agents || []) {
         if (agentConfig.url !== url) continue;
         if (!this.isVisibleToViewer(agentConfig.visibility, viewerHasApiAccess)) continue;
-        if (agentConfig.visibility === 'public' && !profile.is_public && !viewerHasApiAccess) continue;
         return this.configToAgent(agentConfig, profile);
       }
     }

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -357,8 +357,11 @@ export class CrawlerService {
     // Track domains we've already processed to avoid duplicates
     const processedDomains = new Set<string>();
 
-    // 1. Crawl registered publishers' adagents.json files
-    const profiles = await this.memberDb.listProfiles({ is_public: true });
+    // 1. Crawl registered publishers' adagents.json files. Walk every
+    // profile — the publisher-level `pubConfig.is_public` flag below is
+    // the gate; `member_profiles.is_public` is the member-directory
+    // listing flag and shouldn't gate publisher discovery.
+    const profiles = await this.memberDb.listProfiles({});
     const registeredPublisherDomains: string[] = [];
     for (const profile of profiles) {
       for (const pubConfig of profile.publishers || []) {

--- a/server/src/federated-index.ts
+++ b/server/src/federated-index.ts
@@ -37,7 +37,13 @@ export class FederatedIndexService {
     options: { includeMembersOnly?: boolean } = {},
   ): Promise<FederatedAgent[]> {
     const { includeMembersOnly = false } = options;
-    const profiles = await this.memberDb.listProfiles({ is_public: true });
+    // Walk every member profile. `member_profiles.is_public` is the
+    // member-directory gate (per migration 011: "Show in member
+    // directory") and predates per-agent `visibility`; gating registry
+    // listings on it as well silently hides agents that the owner
+    // explicitly marked public. Agent-level `visibility` is the only
+    // gate for whether an agent is listed.
+    const profiles = await this.memberDb.listProfiles({});
     const registeredAgents = new Map<string, FederatedAgent>();
 
     for (const profile of profiles) {
@@ -69,7 +75,10 @@ export class FederatedIndexService {
    * List all registered publishers.
    */
   async listAllPublishers(): Promise<FederatedPublisher[]> {
-    const profiles = await this.memberDb.listProfiles({ is_public: true });
+    // Walk every member profile — see `listAllAgents` above for why
+    // `member_profiles.is_public` is the wrong gate. Each publisher's
+    // own `is_public` flag is what decides whether it's listed.
+    const profiles = await this.memberDb.listProfiles({});
     const registeredPublishers = new Map<string, FederatedPublisher>();
 
     for (const profile of profiles) {
@@ -99,8 +108,10 @@ export class FederatedIndexService {
    * Lookup a domain to find all authorized agents and sales agents claiming it.
    */
   async lookupDomain(domain: string): Promise<DomainLookupResult> {
-    // Build a map of registered agents for enrichment
-    const profiles = await this.memberDb.listProfiles({ is_public: true });
+    // Build a map of registered agents for enrichment. Agent-level
+    // `visibility = 'public'` is the gate; the parent profile's
+    // `is_public` only controls the member directory listing.
+    const profiles = await this.memberDb.listProfiles({});
     const registeredAgentUrls = new Map<string, { slug: string; display_name: string }>();
 
     for (const profile of profiles) {
@@ -457,8 +468,10 @@ export class FederatedIndexService {
     authorizations_by_source: { adagents_json: number; agent_claim: number };
     properties_by_type: Record<string, number>;
   }> {
-    // Count registered (the public registry surface).
-    const profiles = await this.memberDb.listProfiles({ is_public: true });
+    // Count registered (the public registry surface). Match
+    // `listAllAgents` / `listAllPublishers` and let agent-/publisher-
+    // level visibility decide what counts.
+    const profiles = await this.memberDb.listProfiles({});
     let registeredAgents = 0;
     let registeredPublishers = 0;
 

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -8809,7 +8809,11 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
     this.app.get('/api/public/publishers', async (req, res) => {
       try {
         const memberDb = new MemberDatabase();
-        const members = await memberDb.getPublicProfiles({});
+        // Walk every member profile. `member_profiles.is_public` is the
+        // member-directory gate; per-publisher `is_public` is what gates
+        // the public publisher surface. Matches `FederatedIndexService.
+        // listAllPublishers`.
+        const members = await memberDb.listProfiles({});
 
         // Collect all public publishers from members
         const publishers = members.flatMap((m) =>

--- a/server/tests/integration/agent-visibility-e2e.test.ts
+++ b/server/tests/integration/agent-visibility-e2e.test.ts
@@ -435,6 +435,30 @@ describe('Agent visibility E2E', () => {
     expect(withApi.map((a) => a.url)).toContain('https://members.privp.example');
   });
 
+  it('public agent on private-profile member appears in listAgents (regression guard for #4194)', async () => {
+    // Pins the fix in #4194: before this PR, the early-continue
+    //   `if (visibility==='public' && !profile.is_public && !viewerHasApiAccess) continue`
+    // silently hid public agents on profiles that opted out of the member
+    // directory. Per-agent visibility is the only gate; is_public gates only
+    // the /Members directory listing.
+    const orgId = `${TEST_PREFIX}_pub_private`;
+    await seedOrg(pool, orgId, 'individual_professional');
+    await memberDb.createProfile({
+      workos_organization_id: orgId,
+      display_name: 'Pub On Private Org',
+      slug: 'pub-on-private',
+      primary_brand_domain: 'pubprivate.example',
+      is_public: false,
+      agents: [
+        { url: 'https://agent.pubprivate.example', visibility: 'public' },
+      ],
+    });
+
+    const service = new AgentService();
+    const agents = await service.listAgents();
+    expect(agents.map((a) => a.url)).toContain('https://agent.pubprivate.example');
+  });
+
   it('legacy is_public agents are normalized on read', async () => {
     const orgId = `${TEST_PREFIX}_legacy`;
     await seedOrg(pool, orgId, null);

--- a/server/tests/integration/registry-reader-baseline-public-endpoints.test.ts
+++ b/server/tests/integration/registry-reader-baseline-public-endpoints.test.ts
@@ -269,7 +269,7 @@ describe('Registry reader baseline — public endpoints', () => {
       });
     });
 
-    // ── /registry/publisher ────────────────────────────────────────
+    // ── /registry/publisher ────────────────────────────────────────────
 
     it('GET /api/registry/publisher returns properties + authorized agents for a seeded domain', async () => {
       const res = await request(app).get(
@@ -347,7 +347,7 @@ describe('Registry reader baseline — public endpoints', () => {
       });
     });
 
-    // ── /registry/publisher/authorization ──────────────────────────
+    // ── /registry/publisher/authorization ──────────────────────
 
     it('GET /api/registry/publisher/authorization returns the per-property breakdown', async () => {
       const res = await request(app).get(
@@ -413,7 +413,7 @@ describe('Registry reader baseline — public endpoints', () => {
       expect(res.body).toMatchObject({ publisher_domain: PUB_A, authorized: 1, total: 2 });
     });
 
-    // ── /registry/publishers ───────────────────────────────────────
+    // ── /registry/publishers ─────────────────────────────────────────────
 
     it('GET /api/registry/publishers does not surface crawler-only publishers', async () => {
       // Registry contains only publishers that members have explicitly
@@ -430,7 +430,7 @@ describe('Registry reader baseline — public endpoints', () => {
       expect(ours).toBeUndefined();
     });
 
-    // ── /registry/operator ─────────────────────────────────────────
+    // ── /registry/operator ──────────────────────────────────────────────
 
     it('GET /api/registry/operator returns null member when no profile owns the domain', async () => {
       // No member_profile seeded for PUB_A, so the operator endpoint
@@ -510,7 +510,7 @@ describe('Registry reader baseline — public endpoints', () => {
       });
     });
 
-    // ── /registry/stats ────────────────────────────────────────────
+    // ── /registry/stats ──────────────────────────────────────────────
 
     it('GET /api/registry/stats reflects at least our seeded auth-graph counts', async () => {
       const res = await request(app).get('/api/registry/stats');
@@ -529,7 +529,7 @@ describe('Registry reader baseline — public endpoints', () => {
       expect(res.body.properties_by_type.mobile_app).toBeGreaterThanOrEqual(1);
     });
 
-    // ── /registry/agents ───────────────────────────────────────────
+    // ── /registry/agents ───────────────────────────────────────────────
 
     it('GET /api/registry/agents?source=registered returns 400 (param removed, not deprecated)', async () => {
       // The `?source=` filter is gone (#3772). Reject explicitly so a caller
@@ -609,6 +609,50 @@ describe('Registry reader baseline — public endpoints', () => {
       const y = res.body.agents.find((a: { url: string }) => a.url === AGENT_Y);
       expect(x).toBeUndefined();
       expect(y).toBeUndefined();
+    });
+
+    it('GET /api/registry/agents: public agent on private-profile member appears (regression guard for #4194)', async () => {
+      // Pins the fix from PR #4194: before the fix, `member_profiles.is_public`
+      // was also used as a gate on the registry surface, silently hiding
+      // `visibility='public'` agents on profiles with is_public=false. The
+      // per-agent `visibility` field is the only listing gate; is_public
+      // controls only the /Members directory.
+      const PRIV_ORG = `${ORG_ID}_priv`;
+      const PRIV_AGENT = `${AGENT_PREFIX}pub-on-private.registry-baseline.example`;
+      await pool.query(
+        `INSERT INTO organizations (workos_organization_id, name, created_at, updated_at)
+         VALUES ($1, 'Pub-on-Private Org', NOW(), NOW())
+         ON CONFLICT (workos_organization_id) DO NOTHING`,
+        [PRIV_ORG],
+      );
+      await pool.query(
+        `INSERT INTO member_profiles (
+           workos_organization_id, display_name, slug,
+           agents, primary_brand_domain, is_public,
+           created_at, updated_at
+         ) VALUES ($1, 'Pub-on-Private Org', $2, $3::jsonb, $4, false, NOW(), NOW())
+         ON CONFLICT (workos_organization_id) DO UPDATE SET
+           agents = EXCLUDED.agents, is_public = EXCLUDED.is_public, updated_at = NOW()`,
+        [
+          PRIV_ORG,
+          'endpoint-pub-on-private-baseline',
+          JSON.stringify([
+            { url: PRIV_AGENT, name: 'Pub On Private', type: 'buying', visibility: 'public' },
+          ]),
+          PUB_A,
+        ],
+      );
+      try {
+        const res = await request(app).get('/api/registry/agents');
+        expect(res.status).toBe(200);
+
+        const found = res.body.agents.find((a: { url: string }) => a.url === PRIV_AGENT);
+        expect(found).toBeTruthy();
+        expect(found.member).toMatchObject({ slug: 'endpoint-pub-on-private-baseline' });
+      } finally {
+        await pool.query(`DELETE FROM member_profiles WHERE workos_organization_id = $1`, [PRIV_ORG]);
+        await pool.query(`DELETE FROM organizations WHERE workos_organization_id = $1`, [PRIV_ORG]);
+      }
     });
 
     it('GET /api/registry/agents?properties=true does not surface crawler-only agents', async () => {

--- a/server/tests/unit/agent-service-visibility.test.ts
+++ b/server/tests/unit/agent-service-visibility.test.ts
@@ -17,6 +17,24 @@ const { mockProfiles, mockDiscovered } = vi.hoisted(() => ({
         { url: 'https://private.acme.example', visibility: 'private', name: 'Private Draft', type: 'buying' },
       ],
     },
+    {
+      // Regression guard for #4194: profile NOT in member directory
+      // (is_public=false) but has a visibility='public' agent. The old code
+      // had an early-continue that hid this agent from public viewers. The
+      // per-agent `visibility` is the only gate; is_public is the member-
+      // directory flag and must not suppress the registry listing.
+      id: 'profile-2',
+      slug: 'nova',
+      display_name: 'Nova Brands',
+      description: 'Nova ad tech',
+      contact_email: 'hi@nova.example',
+      contact_website: 'https://nova.example',
+      is_public: false,
+      created_at: new Date('2025-01-01'),
+      agents: [
+        { url: 'https://public.nova.example', visibility: 'public', name: 'Nova Public', type: 'buying' },
+      ],
+    },
   ],
   mockDiscovered: [] as Array<Record<string, unknown>>,
 }));
@@ -45,13 +63,14 @@ describe('AgentService.listAgents visibility filtering', () => {
   it('returns only public agents when viewer lacks API access', async () => {
     const agents = await service.listAgents();
     const urls = agents.map((a) => a.url).sort();
-    expect(urls).toEqual(['https://public.acme.example']);
+    // Both the public-profile agent and the private-profile public agent appear.
+    expect(urls).toEqual(['https://public.acme.example', 'https://public.nova.example']);
   });
 
   it('explicit viewerHasApiAccess=false matches default behavior', async () => {
     const agents = await service.listAgents({ viewerHasApiAccess: false });
     const urls = agents.map((a) => a.url).sort();
-    expect(urls).toEqual(['https://public.acme.example']);
+    expect(urls).toEqual(['https://public.acme.example', 'https://public.nova.example']);
   });
 
   it('includes members_only agents when viewer has API access', async () => {
@@ -60,6 +79,7 @@ describe('AgentService.listAgents visibility filtering', () => {
     expect(urls).toEqual([
       'https://members.acme.example',
       'https://public.acme.example',
+      'https://public.nova.example',
     ]);
   });
 
@@ -75,6 +95,14 @@ describe('AgentService.listAgents visibility filtering', () => {
 
   it('legacy signature (type string) still works and defaults to public only', async () => {
     const agents = await service.listAgents('buying');
-    expect(agents.map((a) => a.url)).toEqual(['https://public.acme.example']);
+    const urls = agents.map((a) => a.url).sort();
+    expect(urls).toEqual(['https://public.acme.example', 'https://public.nova.example']);
+  });
+
+  it('public agent on private-profile member (is_public=false) is visible to all viewers (regression guard #4194)', async () => {
+    // Before #4194 the old early-continue `if (visibility==='public' && !profile.is_public && !viewerHasApiAccess) continue`
+    // silently hid this agent from public viewers. Per-agent visibility is the only gate.
+    const agents = await service.listAgents();
+    expect(agents.map((a) => a.url)).toContain('https://public.nova.example');
   });
 });


### PR DESCRIPTION
## Why

A member with a `Visibility: Public` agent on their profile expects that agent to appear in the public agent registry — that's literally what the agent-detail UI promises (\"Listed publicly and added to brand.json\"). Today it doesn't, because `member_profiles.is_public` (the **member-directory** flag, per migration 011's comment: `-- Show in member directory`) is also being used to gate the agent registry. That gate predates per-agent `visibility` and is legacy.

Concrete symptom: org with `is_public = false` on the profile but a `visibility = 'public'` agent — the agent shows on:
- their own member profile page
- `GET /api/registry/operator?domain=…` (which never gated on profile-level `is_public`)

…but does NOT show on:
- `GET /api/registry/agents` (the public registry feed)
- the registry browse at `/registry/agents`

The two surfaces disagreed on the visibility contract, and the public registry was the stricter one.

## What Changed

Dropped the `member_profiles.is_public` filter in every site that gates the **public registry** surface. Per-agent `visibility` (`public` / `members_only` / `private`) and per-publisher `is_public` are now authoritative.

**`server/src/federated-index.ts`** (4 sites)
- `listAllAgents` — backs `GET /api/registry/agents`
- `listAllPublishers`
- `lookupDomain` — agent reverse-lookup enrichment
- `getStats`

**`server/src/agent-service.ts`** (2 sites + redundant gate removed)
- `listAgents` and `getAgentByUrl` no longer split the profile fetch on `viewerHasApiAccess` and the explicit \"public agent on private profile\" early-continue is removed. `isVisibleToViewer` (`public` → all viewers; `members_only` → API-access only; `private` → no one) is now the only gate.

**`server/src/crawler.ts`** (1 site)
- `populateFederatedIndex` walks every profile; per-publisher `pubConfig.is_public` decides which adagents.json files actually get crawled.

Profile-level `is_public` continues to gate the /Members directory listing only — that's its documented purpose.

## Before / After

| Scenario | Before | After |
|---|---|---|
| `member.is_public = true` + agent `visibility = public` | Agent shown | Agent shown |
| `member.is_public = false` + agent `visibility = public` | Agent **hidden** in registry, **shown** in operator endpoint (UX inconsistency) | Agent shown in both |
| `member.is_public = false` + agent `visibility = private` | Hidden | Hidden |
| `member.is_public = false` + agent `visibility = members_only` | Hidden from anon, shown to API-access | Hidden from anon, shown to API-access |
| /Members directory | Public profiles only | Public profiles only (unchanged) |

## Test Plan

- Existing `agent-service-visibility.test.ts` (unit) and `agent-visibility-e2e.test.ts` (integration) still pass — none of them assert \"public agent on private profile must not appear\". The members-only-on-private-profile test (`e2e:399`) continues to work via `isVisibleToViewer`.
- Did NOT add a positive test for the new public-on-private path — happy to add one if you want, though the existing tier-downgrade and visibility-gate tests already exercise the agent-level gate in isolation.

## Notes

- This unblocks the AAO member-profile UX: members can register a single public agent without flipping their entire org profile to public-directory listing.
- Caller side: agentic-api's storefront discover-agents flow cross-references this list, so once this lands the staging sales agents that members register will start to surface in our picker correctly. (See [scope3data/agentic-api#2309](https://github.com/scope3data/agentic-api/pull/2309).)