### PR TITLE
chore: symlink AGENTS.md to CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,1 @@
-# Agent Guide
-
-This file is a thin wrapper. The canonical shared behavior for this repository
-lives in `.agents/playbook.md`.
-
-## Start Here
-
-1. Read `.agents/playbook.md`.
-2. Subagent role definitions: `.agents/roles/*.md`.
-3. Prompt shortcuts: `.agents/shortcuts/`.
-4. Codex multi-agent wiring is generated from `.agents/roles/` —
-   run `node scripts/import-claude-agents.mjs` to regenerate `.codex/`.
-5. Treat this file as a pointer only. Shared behavior changes belong in
-   `.agents/playbook.md`.
+CLAUDE.md


### PR DESCRIPTION
These files have drifted out of sync

Either this should merge or the change set instructions from claude should be moved to playbook or my preference both the files should just symlink to playbook with agent specific nuances simply in playbook

I don't think the go look at this other file instructions within work very will y

See https://vercel.com/blog/agents-md-outperforms-skills-in-our-agent-evals