### PR TITLE
fix(addie): coerce LLM-provided string-array tool inputs at runtime

### DIFF
--- a/.changeset/fix-github-issue-labels-string-coercion.md
+++ b/.changeset/fix-github-issue-labels-string-coercion.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix `draft_github_issue` and `list_github_issues` crashing with `labels.join is not a function` when the LLM passes `labels` as a comma-separated string instead of an array. Extracts a shared `coerceStringArray` helper (`server/src/addie/mcp/input-coercion.ts`) that normalizes unknown values into a clean string array — splitting strings on commas, trimming, deduping, and capping at 20 items to prevent pathological inputs from ballooning downstream URLs. Also applied to `suggest_prospects` (`lusha_keywords`), which had the same antipattern.

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -33,6 +33,7 @@ import { MemberSearchAnalyticsDatabase } from '../../db/member-search-analytics-
 import { MemberDatabase } from '../../db/member-db.js';
 import { normalizeFoundingMemberGrant, foundingMemberFieldsTouched } from '../../services/founding-member-grant.js';
 import { BrandDatabase } from '../../db/brand-db.js';
+import { coerceStringArray } from './input-coercion.js';
 import {
   getPendingInvoices,
   getAllOpenInvoices,
@@ -6114,7 +6115,8 @@ Use add_committee_leader to assign a leader.`;
     const pool = getPool();
     const limit = Math.min((input.limit as number) || 10, 20);
     const includeLusha = input.include_lusha !== false;
-    const lushaKeywords = (input.lusha_keywords as string[]) || ['programmatic', 'DSP', 'ad tech'];
+    const coercedKeywords = coerceStringArray(input.lusha_keywords);
+    const lushaKeywords = coercedKeywords.length > 0 ? coercedKeywords : ['programmatic', 'DSP', 'ad tech'];
 
     let response = `## Suggested Prospects\n\n`;
 

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -6115,8 +6115,9 @@ Use add_committee_leader to assign a leader.`;
     const pool = getPool();
     const limit = Math.min((input.limit as number) || 10, 20);
     const includeLusha = input.include_lusha !== false;
-    const coercedKeywords = coerceStringArray(input.lusha_keywords);
-    const lushaKeywords = coercedKeywords.length > 0 ? coercedKeywords : ['programmatic', 'DSP', 'ad tech'];
+    const lushaKeywords = input.lusha_keywords === undefined
+      ? ['programmatic', 'DSP', 'ad tech']
+      : coerceStringArray(input.lusha_keywords);
 
     let response = `## Suggested Prospects\n\n`;
 

--- a/server/src/addie/mcp/input-coercion.ts
+++ b/server/src/addie/mcp/input-coercion.ts
@@ -1,0 +1,37 @@
+/**
+ * Runtime coercion helpers for LLM-provided tool inputs.
+ *
+ * Tool input_schemas declare types, but the model occasionally drifts —
+ * passing a string where the schema says `array of strings`, or omitting
+ * a field. TypeScript casts (`input.x as string[]`) silently survive
+ * these runtime shape mismatches and crash later (e.g. `.join is not a
+ * function`). Coerce at the handler boundary instead.
+ */
+
+const DEFAULT_MAX_ITEMS = 20;
+
+/**
+ * Normalize an unknown value into a clean string array.
+ *
+ * - Arrays: keep non-empty string entries.
+ * - Strings: split on commas, trim, drop empties.
+ * - Anything else: empty array.
+ *
+ * Trims, drops empties, dedupes, and caps length to prevent pathological
+ * inputs (e.g. `"bug,bug,bug,..."` 1000×) from ballooning downstream URLs
+ * or queries.
+ */
+export function coerceStringArray(value: unknown, maxItems: number = DEFAULT_MAX_ITEMS): string[] {
+  let items: string[];
+  if (Array.isArray(value)) {
+    items = value
+      .filter((v): v is string => typeof v === 'string')
+      .map(s => s.trim())
+      .filter(s => s.length > 0);
+  } else if (typeof value === 'string') {
+    items = value.split(',').map(s => s.trim()).filter(s => s.length > 0);
+  } else {
+    return [];
+  }
+  return Array.from(new Set(items)).slice(0, maxItems);
+}

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -24,6 +24,7 @@ import { ToolError } from '../tool-error.js';
 import { checkToolRateLimit } from './tool-rate-limiter.js';
 import { isUuid } from '../../utils/uuid.js';
 import { neutralizeAndTruncate } from './untrusted-input.js';
+import { coerceStringArray } from './input-coercion.js';
 import { createEscalation } from '../../db/escalation-db.js';
 import { SlackDatabase } from '../../db/slack-db.js';
 import {
@@ -5227,7 +5228,7 @@ export function createMemberToolHandlers(
   handlers.set('draft_github_issue', async (input) => {
     const title = input.title as string;
     let body = input.body as string;
-    const labels = (input.labels as string[]) || [];
+    const labels = coerceStringArray(input.labels);
 
     // GitHub organization
     const org = 'adcontextprotocol';
@@ -5481,7 +5482,7 @@ export function createMemberToolHandlers(
     if (!parsed.ok) return parsed.error;
     const { org, repo } = parsed;
     const state = (input.state as string) || 'open';
-    const labels = (input.labels as string[]) || [];
+    const labels = coerceStringArray(input.labels);
     const query = input.query as string | undefined;
     const limit = Math.min((input.limit as number) || 20, 50);
 

--- a/server/tests/unit/addie/input-coercion.test.ts
+++ b/server/tests/unit/addie/input-coercion.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { coerceStringArray } from '../../../src/addie/mcp/input-coercion.js';
+
+describe('coerceStringArray', () => {
+  it('keeps a clean string array as-is', () => {
+    expect(coerceStringArray(['bug', 'needs-triage'])).toEqual(['bug', 'needs-triage']);
+  });
+
+  it('splits a comma-separated string', () => {
+    expect(coerceStringArray('bug,needs-triage')).toEqual(['bug', 'needs-triage']);
+  });
+
+  it('trims whitespace and drops empty entries', () => {
+    expect(coerceStringArray(' bug , , needs-triage ')).toEqual(['bug', 'needs-triage']);
+  });
+
+  it('dedupes repeated entries', () => {
+    expect(coerceStringArray('bug,bug,bug,feature')).toEqual(['bug', 'feature']);
+  });
+
+  it('caps at the default 20-item limit', () => {
+    const input = Array.from({ length: 50 }, (_, i) => `tag${i}`).join(',');
+    const result = coerceStringArray(input);
+    expect(result).toHaveLength(20);
+    expect(result[0]).toBe('tag0');
+    expect(result[19]).toBe('tag19');
+  });
+
+  it('respects a custom max', () => {
+    expect(coerceStringArray('a,b,c,d,e', 3)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns an empty array for non-string, non-array input', () => {
+    expect(coerceStringArray(42)).toEqual([]);
+    expect(coerceStringArray(null)).toEqual([]);
+    expect(coerceStringArray(undefined)).toEqual([]);
+    expect(coerceStringArray({ foo: 'bar' })).toEqual([]);
+  });
+
+  it('drops non-string entries from arrays', () => {
+    expect(coerceStringArray(['bug', 42, null, 'feature'] as unknown[])).toEqual(['bug', 'feature']);
+  });
+});

--- a/tests/addie/member-tools.test.ts
+++ b/tests/addie/member-tools.test.ts
@@ -313,6 +313,36 @@ describe('createMemberToolHandlers', () => {
       expect(result).toContain('creative-agent');
       expect(result).toContain('Original body');
     });
+
+    it('coerces a string labels value into an array (LLM schema drift)', async () => {
+      const handlers = createMemberToolHandlers(null);
+      const handler = handlers.get('draft_github_issue')!;
+
+      const result = await handler({
+        title: 'T',
+        body: 'B',
+        labels: 'bug,needs-triage',
+      });
+
+      expect(result).toContain('Labels:');
+      expect(result).toContain('bug');
+      expect(result).toContain('needs-triage');
+      expect(result).toContain('labels=bug%2Cneeds-triage');
+    });
+
+    it('treats a non-string, non-array labels value as empty', async () => {
+      const handlers = createMemberToolHandlers(null);
+      const handler = handlers.get('draft_github_issue')!;
+
+      const result = await handler({
+        title: 'T',
+        body: 'B',
+        labels: 42 as unknown as string[],
+      });
+
+      expect(result).toContain('GitHub Issue Draft');
+      expect(result).not.toContain('Labels:');
+    });
   });
 
   describe('create_github_issue handler', () => {


### PR DESCRIPTION
## Summary

- `draft_github_issue` crashed in production with `labels.join is not a function` when the LLM emitted `labels: \"pending_creatives\"` (a string) instead of an array. The handler used a TypeScript cast (`input.labels as string[]`) that silently survived the runtime shape mismatch.
- Adds a shared `coerceStringArray` helper at `server/src/addie/mcp/input-coercion.ts` that splits comma-strings, trims, dedupes, and caps at 20 items.
- Applied at the three call sites that had this antipattern: `draft_github_issue`, `list_github_issues`, and `suggest_prospects` (`lusha_keywords`).

## Why coerce instead of reject

The codebase convention for LLM-provided tool inputs is to coerce rather than reject (see `brand-tools.ts:365`). Rejecting would surface a confusing error back to the user for what's a model schema-drift issue.

## Test plan

- [x] New unit tests for `coerceStringArray` (8 cases: clean array, comma-string, whitespace, dedupe, cap, custom max, non-string/null/undefined/object, mixed-type array)
- [x] New regression tests on `draft_github_issue` handler: string `labels` coerces; non-string-non-array `labels` becomes empty
- [x] Existing 55 `member-tools.test.ts` cases still pass
- [x] `tsc --noEmit` clean
- [x] Pre-commit hooks (test:unit, test:test-dynamic-imports, test:callapi-state-change, typecheck) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)