### PR TITLE
fix(compliance): measurement_terms_rejected — UUID-aliased idempotency_keys + spec-aligned narrative

### DIFF
--- a/.changeset/measurement-terms-rejected-narrative.md
+++ b/.changeset/measurement-terms-rejected-narrative.md
@@ -1,0 +1,8 @@
+---
+---
+
+spec(compliance): correct `measurement_terms_rejected` idempotency narrative
+
+The narrative on the `media_buy_seller/measurement_terms_rejected` storyboard told implementers the buyer "retries the same `create_media_buy` `idempotency_key` with an adjusted payload." That contradicts the spec — reusing a key against a different body MUST yield `IDEMPOTENCY_CONFLICT`. The sample payloads in the fixture already use distinct keys (`measurement-terms-probe-aggressive-v1` / `measurement-terms-probe-relaxed-v1`); only the prose was wrong. Rewrite the narrative to match the spec and the actual sample payloads.
+
+Refs adcontextprotocol/adcp-client#1586.

--- a/.changeset/measurement-terms-rejected-narrative.md
+++ b/.changeset/measurement-terms-rejected-narrative.md
@@ -1,4 +1,5 @@
 ---
+"adcontextprotocol": patch
 ---
 
 fix(compliance): `measurement_terms_rejected` — UUID-aliased idempotency_keys + spec-aligned narrative

--- a/.changeset/measurement-terms-rejected-narrative.md
+++ b/.changeset/measurement-terms-rejected-narrative.md
@@ -1,8 +1,10 @@
 ---
 ---
 
-spec(compliance): correct `measurement_terms_rejected` idempotency narrative
+fix(compliance): `measurement_terms_rejected` — UUID-aliased idempotency_keys + spec-aligned narrative
 
-The narrative on the `media_buy_seller/measurement_terms_rejected` storyboard told implementers the buyer "retries the same `create_media_buy` `idempotency_key` with an adjusted payload." That contradicts the spec — reusing a key against a different body MUST yield `IDEMPOTENCY_CONFLICT`. The sample payloads in the fixture already use distinct keys (`measurement-terms-probe-aggressive-v1` / `measurement-terms-probe-relaxed-v1`); only the prose was wrong. Rewrite the narrative to match the spec and the actual sample payloads.
+The `media_buy_seller/measurement_terms_rejected` storyboard shipped hardcoded `idempotency_key` literals on both `create_media_buy` steps. Combined with runner-side dynamic `start_time` substitution (the runner shifts stale dates forward to keep the buy future-dated), this produced **same key + different body** on every run against a long-running seller deployment, arming the spec-mandated `IDEMPOTENCY_CONFLICT` on the seller side. Switch to `$generate:uuid_v4#…` aliases so each run mints fresh keys (matches the established pattern across the storyboard suite).
 
-Refs adcontextprotocol/adcp-client#1586.
+Also rewrites the narrative, which previously told implementers the buyer "retries the same `create_media_buy` `idempotency_key` with an adjusted payload" — a direct spec violation — to describe minting a fresh key for the retry.
+
+Closes #4219. Refs adcontextprotocol/adcp-client#1586.

--- a/static/compliance/source/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
@@ -106,7 +106,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "measurement-terms-probe-aggressive-v1"
+          idempotency_key: "$generate:uuid_v4#measurement_terms_rejected_aggressive_terms"
           start_time: "2026-05-01T00:00:00Z"
           end_time: "2026-05-31T23:59:59Z"
           packages:
@@ -163,7 +163,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "measurement-terms-probe-relaxed-v1"
+          idempotency_key: "$generate:uuid_v4#measurement_terms_rejected_relaxed_terms"
           start_time: "2026-05-01T00:00:00Z"
           end_time: "2026-05-31T23:59:59Z"
           packages:

--- a/static/compliance/source/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
@@ -12,8 +12,9 @@ narrative: |
   measurement_terms negotiation is a round-trip. The buyer proposes a measurement vendor,
   window, and variance tolerance on each package; the seller either accepts (returning
   measurement_terms echoed in the response) or rejects with TERMS_REJECTED and a message
-  explaining what is unacceptable. The buyer corrects the terms and retries the same
-  create_media_buy idempotency_key with an adjusted payload.
+  explaining what is unacceptable. The buyer mints a fresh idempotency_key and retries
+  create_media_buy with the adjusted payload — reusing the prior key against a different
+  body MUST be rejected with IDEMPOTENCY_CONFLICT per spec.
 
   This scenario sends an intentionally aggressive first proposal (max_variance_percent: 0
   with a window the seller does not guarantee), verifies the seller rejects with


### PR DESCRIPTION
Closes #4219. Refs adcontextprotocol/adcp-client#1586.

## Root cause

Two issues stacked on the same storyboard:

1. **Hardcoded `idempotency_key` literals** on both `create_media_buy` steps (`measurement-terms-probe-aggressive-v1` / `…-relaxed-v1`).
2. **Runner-side dynamic `start_time` substitution** — the `@adcp/sdk` storyboard runner shifts stale sample dates forward to keep the buy future-dated (`sampleStart && Date.parse(sampleStart) >= now ? sampleStart : defaultStart`).

Against a long-running seller deployment (Wonderstruck staging), each run produces **same key + different body**, which arms the spec-mandated `IDEMPOTENCY_CONFLICT` on the seller side. The seller is correct; the storyboard was the bug.

## Fix

- Switch both `create_media_buy` steps to `$generate:uuid_v4#…` aliases. This is the established pattern across the suite (see `creative/index.yaml`, `governance/index.yaml`, `signals/index.yaml`, etc.) — each test run mints fresh keys, intra-run replay still works.
- Rewrite the narrative, which previously told implementers the buyer "retries the same `create_media_buy` `idempotency_key` with an adjusted payload" (a direct spec violation), to describe minting a fresh key.

## Test plan

- [x] `npm run precommit` passes (storyboard matrix all-green across all six tenants: signals / sales / governance / creative / creative-builder / brand)
- [ ] Reviewer eyeballs the new narrative against the actual sample_request idempotency_key behavior
- [ ] Re-run against Wonderstruck staging confirms `measurement_terms_rejected` no longer hits IDEMPOTENCY_CONFLICT (validates root cause)

🤖 Generated with [Claude Code](https://claude.com/claude-code)