### PR TITLE
fix(compliance): measurement_terms_rejected — shared idempotency alias + Q3 2026 dates

### DIFF
--- a/.changeset/fix-measurement-terms-rejected-idempotency-key.md
+++ b/.changeset/fix-measurement-terms-rejected-idempotency-key.md
@@ -1,0 +1,10 @@
+---
+---
+
+fix(compliance): measurement_terms_rejected storyboard — shared idempotency alias + Q3 2026 dates
+
+Hardcoded idempotency_key literals combined with runner-substituted dates (stale May 2026
+window) caused IDEMPOTENCY_CONFLICT on every re-run against a long-running seller. Both
+create_media_buy steps now share a single $generate:uuid_v4# alias so the scenario
+correctly tests that TERMS_REJECTED responses do not cache the idempotency key (per AdCP
+idempotency spec). Flight dates advanced to Q3 2026.

--- a/static/compliance/source/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
@@ -106,7 +106,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "$generate:uuid_v4#media_buy_seller_measurement_terms_rejected_probe"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_measurement_terms_rejected_reject_terms_create_media_buy_aggressive_terms"
           start_time: "2026-07-01T00:00:00Z"
           end_time: "2026-09-30T23:59:59Z"
           packages:
@@ -117,7 +117,7 @@ phases:
                 billing_measurement:
                   vendor:
                     domain: "videoamp.example"
-                  measurement_window: "c30"
+                  measurement_window: "c28"
                   max_variance_percent: 0
                 makegood_policy:
                   available_remedies: ["credit"]
@@ -163,7 +163,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "$generate:uuid_v4#media_buy_seller_measurement_terms_rejected_probe"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_measurement_terms_rejected_reject_terms_create_media_buy_aggressive_terms"
           start_time: "2026-07-01T00:00:00Z"
           end_time: "2026-09-30T23:59:59Z"
           packages:
@@ -194,3 +194,5 @@ phases:
             path: "context.correlation_id"
             value: "measurement_terms_rejected--relaxed"
             description: "Context correlation_id returned unchanged"
+        reviewer_checks:
+          - "Reviewer MUST confirm the seller releases the idempotency claim after a TERMS_REJECTED response. Probe: send the aggressive-terms request (same key, step 1), then retry with the same key and corrected terms (this step) — the seller MUST return a fresh media_buy_id, not IDEMPOTENCY_CONFLICT. A seller that caches rejected requests would make this two-step retry pattern impossible. See security.mdx#idempotency rule 3 ('Only successful responses are cached')."

--- a/static/compliance/source/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
@@ -58,7 +58,7 @@ phases:
           measurement support in the response.
         sample_request:
           buying_mode: "brief"
-          brief: "Premium video inventory with measurement guarantees. Q2 flight, $50K."
+          brief: "Premium video inventory with measurement guarantees. Q3 flight, $50K."
           account:
             brand:
               domain: "acmeoutdoor.example"
@@ -106,9 +106,9 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "$generate:uuid_v4#measurement_terms_rejected_aggressive_terms"
-          start_time: "2026-05-01T00:00:00Z"
-          end_time: "2026-05-31T23:59:59Z"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_measurement_terms_rejected_probe"
+          start_time: "2026-07-01T00:00:00Z"
+          end_time: "2026-09-30T23:59:59Z"
           packages:
             - product_id: "$context.product_id"
               budget: 25000
@@ -163,9 +163,9 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "$generate:uuid_v4#measurement_terms_rejected_relaxed_terms"
-          start_time: "2026-05-01T00:00:00Z"
-          end_time: "2026-05-31T23:59:59Z"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_measurement_terms_rejected_probe"
+          start_time: "2026-07-01T00:00:00Z"
+          end_time: "2026-09-30T23:59:59Z"
           packages:
             - product_id: "$context.product_id"
               budget: 25000


### PR DESCRIPTION
Refs #4219

## Summary

`measurement_terms_rejected.yaml` had hardcoded `idempotency_key` literals (`measurement-terms-probe-aggressive-v1` / `measurement-terms-probe-relaxed-v1`) combined with a now-stale May 2026 flight window. A spec-compliant runner substitutes fresh dates when `start_time` is past — so each re-run sent the same key with a different body, tripping the seller's mandatory `IDEMPOTENCY_CONFLICT` check.

**Changes:**
- Both `create_media_buy` steps now use `$generate:uuid_v4#media_buy_seller_measurement_terms_rejected_reject_terms_create_media_buy_aggressive_terms` (the established alias pattern). Both steps **intentionally share the same alias** so the runner resolves them to the same UUID within a run — correctly testing that `TERMS_REJECTED` does not cache the idempotency key (spec rule 3: only successful responses cache).
- Flight dates advanced to Q3 2026 (`2026-07-01` → `2026-09-30`).
- `measurement_window: "c30"` → `"c28"` (clearly non-standard probe value; `c30` is not a Nielsen/IAB standard window and could be confused with `downloads_30d`).
- `reviewer_checks` entry added to `create_media_buy_relaxed_terms` surfacing the TERMS_REJECTED non-caching dependency (mirrors pattern from `idempotency.yaml` `key_reuse_conflict` step).
- Brief text updated from "Q2" to "Q3" for internal consistency.

## Non-breaking justification

Storyboard fixture change only — no JSON schema, task definition, or API reference is modified. Conformance harness changes are always non-breaking per playbook (existing consumers unaffected).

## Pre-PR review

- **code-reviewer:** approved — all blockers cleared after fixup commit; alias naming and reviewer_check correct.
- **ad-tech-protocol-expert:** two unresolved style-level questions (see below).

## ⚠️ Needs reviewer decision on two style points

Two expert instances disagreed on style; I've hit the review-iteration cap and am flagging rather than resolving:

**Q1 — Shared-alias naming when two steps share the same UUID:**
- *Code-reviewer says:* encoding the first step's phase/step coordinates (`reject_terms_create_media_buy_aggressive_terms`) for the shared alias is correct and consistent with the codebase grep pattern.
- *Protocol expert says:* the `accept_terms` step carrying an alias that names the `reject_terms` step could cause log misattribution; use a neutral name (e.g. `media_buy_seller_measurement_terms_rejected_probe`) instead, or the relaxed step's own coordinates (`accept_terms_create_media_buy_relaxed_terms`).
- **Decision needed:** keep the first-step-coordinate encoding, switch to a neutral probe name, or use each step's own coordinates (distinct aliases, which changes the test semantics).

**Q2 — `measurement_window: "c28"` probe value:**
- First expert consultation recommended `c28` or `vendor_custom_window` as a clearly non-standard replacement for `c30`.
- Pre-PR protocol expert says `c28` is not grounded in the narrative context and the change "breaks the rejection rationale."
- **Decision needed:** keep `c28`, revert to `c30`, or use a clearly annotated non-standard label like `vendor_custom_window`.

> **Triage-managed PR.** This bot does not currently iterate on review comments or PR conversation threads (only on the source issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` → fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121) for context.

Session: https://claude.ai/code/session_018doLSLKHN2Aer5yHSCpeW3

---
_Generated by [Claude Code](https://claude.ai/code/session_018doLSLKHN2Aer5yHSCpeW3)_