### PR TITLE
fix(compliance): extend $generate:uuid_v4 to all hardcoded idempotency_keys across compliance storyboards

### DIFF
--- a/.changeset/4344-storyboard-uuid-idempotency-keys-sweep.md
+++ b/.changeset/4344-storyboard-uuid-idempotency-keys-sweep.md
@@ -1,0 +1,8 @@
+---
+---
+
+Convert the 16 remaining static `idempotency_key` literals across error, governance,
+measurement, signal, and schema-validation storyboard scenarios to
+`$generate:uuid_v4#<alias>` form. Closes the static-key sweep started in #4218 / #4232
+so storyboard re-runs against any spec-compliant seller no longer collide with the
+seller's idempotency cache after deploys. Closes #4344.

--- a/static/compliance/source/protocols/governance/index.yaml
+++ b/static/compliance/source/protocols/governance/index.yaml
@@ -246,7 +246,7 @@ phases:
           - human_review_required: set when the plan mandates escalation
 
         sample_request:
-          idempotency_key: "media-buy-governance-escalation-sync-plans-v1"
+          idempotency_key: "$generate:uuid_v4#gov-escalation-sync"
           plans:
             - plan_id: "gov_acme_q2_2027"
               brand:

--- a/static/compliance/source/specialisms/creative-ad-server/index.yaml
+++ b/static/compliance/source/specialisms/creative-ad-server/index.yaml
@@ -367,7 +367,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+          idempotency_key: "$generate:uuid_v4#creative-ad-server-report-usage"
           reporting_period:
             start: "2026-03-01T00:00:00Z"
             end: "2026-03-31T23:59:59Z"

--- a/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
+++ b/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
@@ -164,7 +164,7 @@ phases:
           - budget.reallocation_threshold: amount above which reallocation requires re-evaluation
 
         sample_request:
-          idempotency_key: "governance-delivery-monitor-sync-plans-v1"
+          idempotency_key: "$generate:uuid_v4#gov-delivery-monitor-sync"
           plans:
             - plan_id: "gov_acme_delivery_monitor"
               brand:

--- a/static/compliance/source/specialisms/governance-spend-authority/denied.yaml
+++ b/static/compliance/source/specialisms/governance-spend-authority/denied.yaml
@@ -110,7 +110,7 @@ phases:
           - budget.total: $10K cap that any single buy above will exceed
 
         sample_request:
-          idempotency_key: "governance-spend-authority-denied-sync-plans-v1"
+          idempotency_key: "$generate:uuid_v4#gov-spend-authority-denied-sync"
           plans:
             - plan_id: "gov_acme_strict"
               brand:

--- a/static/compliance/source/specialisms/governance-spend-authority/index.yaml
+++ b/static/compliance/source/specialisms/governance-spend-authority/index.yaml
@@ -159,7 +159,7 @@ phases:
           - custom_policies: policy conditions registered
 
         sample_request:
-          idempotency_key: "governance-spend-authority-sync-plans-v1"
+          idempotency_key: "$generate:uuid_v4#gov-spend-authority-sync"
           plans:
             - plan_id: "gov_acme_spend_authority_q2_2027"
               brand:

--- a/static/compliance/source/specialisms/signal-marketplace/scenarios/governance_denied.yaml
+++ b/static/compliance/source/specialisms/signal-marketplace/scenarios/governance_denied.yaml
@@ -187,7 +187,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "signal-gov-denied-v1"
+          idempotency_key: "$generate:uuid_v4#signal-gov-denied"
 
           context:
             correlation_id: "signal_marketplace--governance_denied--activate"

--- a/static/compliance/source/universal/error-compliance-signals.yaml
+++ b/static/compliance/source/universal/error-compliance-signals.yaml
@@ -127,7 +127,7 @@ phases:
           destinations:
             - type: "agent"
               agent_url: "https://test-dsp.example"
-          idempotency_key: "error-test-signals-nonexistent"
+          idempotency_key: "$generate:uuid_v4#error-signals-nonexistent"
           context:
             correlation_id: "error_compliance_signals--nonexistent_signal"
         validations:
@@ -173,7 +173,7 @@ phases:
           destinations:
             - type: "agent"
               agent_url: "https://test-dsp.example"
-          idempotency_key: "error-test-signals-missing-field"
+          idempotency_key: "$generate:uuid_v4#error-signals-missing-field"
           context:
             correlation_id: "error_compliance_signals--missing_required_field"
         validations:
@@ -225,7 +225,7 @@ phases:
           destinations:
             - type: "agent"
               agent_url: "https://test-dsp.example"
-          idempotency_key: "error-structure-signals-test"
+          idempotency_key: "$generate:uuid_v4#error-signals-structure"
           context:
             correlation_id: "error_compliance_signals--validate_error_shape"
         validations:
@@ -362,7 +362,7 @@ phases:
           destinations:
             - type: "agent"
               agent_url: "https://test-dsp.example"
-          idempotency_key: "error-transport-signals-test"
+          idempotency_key: "$generate:uuid_v4#error-signals-transport"
           context:
             correlation_id: "error_compliance_signals--validate_transport_binding"
         validations:

--- a/static/compliance/source/universal/error-compliance.yaml
+++ b/static/compliance/source/universal/error-compliance.yaml
@@ -117,7 +117,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "error-test-negative-budget"
+          idempotency_key: "$generate:uuid_v4#error-negative-budget"
           start_time: "2026-05-01T00:00:00Z"
           end_time: "2026-05-31T23:59:59Z"
           packages:
@@ -165,7 +165,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "error-test-nonexistent-product"
+          idempotency_key: "$generate:uuid_v4#error-nonexistent-product"
           start_time: "2026-05-01T00:00:00Z"
           end_time: "2026-05-31T23:59:59Z"
           packages:
@@ -252,7 +252,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "error-test-reversed-dates"
+          idempotency_key: "$generate:uuid_v4#error-reversed-dates"
           start_time: "2026-12-31T00:00:00Z"
           end_time: "2026-01-01T00:00:00Z"
           packages:
@@ -308,7 +308,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "error-structure-test"
+          idempotency_key: "$generate:uuid_v4#error-structure"
           start_time: "2026-12-31T00:00:00Z"
           end_time: "2026-01-01T00:00:00Z"
           packages:
@@ -452,7 +452,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "error-transport-test"
+          idempotency_key: "$generate:uuid_v4#error-transport"
           start_time: "2026-12-31T00:00:00Z"
           end_time: "2026-01-01T00:00:00Z"
           packages:

--- a/static/compliance/source/universal/schema-validation.yaml
+++ b/static/compliance/source/universal/schema-validation.yaml
@@ -333,7 +333,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "schema-validation-reversed-dates-v1"
+          idempotency_key: "$generate:uuid_v4#schema-validation-reversed-dates"
           start_time: "2026-12-31T00:00:00Z"
           end_time: "2026-01-01T00:00:00Z"
           packages:


### PR DESCRIPTION
Closes #4230
Closes #4344

## Summary

Extends the `$generate:uuid_v4#<alias>` pattern to all remaining hardcoded `idempotency_key` literals across the compliance storyboard suite. Scope expanded on rebase after #4232 merged the original media-buy sweep; this PR covers the universal, specialism, and protocol files that were out of scope for that sweep.

**What this PR converts (16 keys, 9 files):**

| File | Keys |
|------|------|
| `universal/error-compliance.yaml` | 5 (negative-budget, nonexistent-product, reversed-dates, structure, transport) |
| `universal/error-compliance-signals.yaml` | 4 (signals-nonexistent, signals-missing-field, signals-structure, signals-transport) |
| `universal/schema-validation.yaml` | 1 (reversed-dates) |
| `specialisms/governance-spend-authority/{index,denied}.yaml` | 2 (sync, denied-sync) |
| `specialisms/governance-delivery-monitor/index.yaml` | 1 |
| `specialisms/signal-marketplace/scenarios/governance_denied.yaml` | 1 |
| `specialisms/creative-ad-server/index.yaml` | 1 (was the literal `a1b2c3d4-…` UUID) |
| `protocols/governance/index.yaml` | 1 (escalation-sync) |

**Root cause:** Hardcoded keys collide cross-run when a seller's `IdempotencyStore` is long-lived. The runner shifts `start_time` forward to keep buys future-dated, so each run produces `same key + different canonical body` → seller correctly replays a stale cached response. This blocks conformance scenarios whenever the seller ships a spec-version upgrade that changes its response shape.

**Literal UUID handling:** The `a1b2c3d4-e5f6-7890-abcd-ef1234567890` literal in `creative-ad-server/index.yaml` was inside an executed `sample_request` block under a `steps:` chain (not a docs-only example). Converted to `$generate:uuid_v4#creative-ad-server-report-usage`. No format-probe semantics in the surrounding validations.

**Not in scope:** `measurement_terms_rejected.yaml` and `provenance_enforcement.yaml` still have non-prefixed aliases (pre-existing, pre-date the naming convention). Left as follow-up to avoid scope creep.

**Verification:** `grep -rn 'idempotency_key: "[^$]' static/compliance/source --include='*.yaml'` returns zero results. Storyboard sweep complete.

## Non-breaking justification

Storyboard YAML files are conformance test harness configuration, not published protocol schema. No wire format, task definition, schema field, or normative requirement is changed. The `$generate:uuid_v4#alias` token is runner-internal and never transmitted to a seller. Per playbook "Conformance harness" — additive or fix changes are `--empty` (no protocol bump).

## Build

`npm run build:compliance` passes with all 12 storyboard lints green:
```
✓ scoping lint ✓ branch-set lint ✓ provides_state_for lint
✓ contradiction lint ✓ context-entity lint ✓ auth-shape lint
✓ test-kits lint ✓ pagination-invariant lint ✓ vendor metric uniqueness lint
✓ check-enum lint ✓ raw-mode-required lint ✓ advisory-expiry lint
✅ 23 universal, 6 protocols, 20 specialisms
```

## Pre-PR review

_Note: pre-PR review was conducted on the original 15-key media-buy scope (before @bokelley's scope expansion on 2026-05-10 to 16 keys across universal/specialism/protocol files). The additional keys follow the same `$generate:uuid_v4#alias` pattern; re-review can be requested if needed._

- **code-reviewer:** approved — all 15 keys covered (original scope), aliases unique (53/53), convention consistent, `--empty` correct. Noted `measurement_terms_rejected` / `provenance_enforcement` pre-existing non-prefixed aliases are out of scope for this PR.
- **ad-tech-protocol-expert:** approved — non-breaking per spec, `sync_plans` dynamic key is sound (governance agent upserts on `plan_id` deterministically regardless of key), `--empty` changeset classification is correct per playbook.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_016efYC8QLXVZZSPiisZ83oM

---
_Generated by [Claude Code](https://claude.ai/code/session_016efYC8QLXVZZSPiisZ83oM)_