### PR TITLE
fix(compliance): UUID-aliased idempotency_keys across remaining storyboard scenarios

### DIFF
--- a/.changeset/storyboard-uuid-aliased-idempotency-keys.md
+++ b/.changeset/storyboard-uuid-aliased-idempotency-keys.md
@@ -1,0 +1,11 @@
+---
+"adcontextprotocol": patch
+---
+
+fix(compliance): UUID-aliased idempotency_keys across remaining storyboard scenarios
+
+Extends the [#4218](https://github.com/adcontextprotocol/adcp/pull/4218) precedent (`measurement_terms_rejected`) to the rest of the suite. 15 storyboard steps across 9 scenarios still shipped hardcoded `idempotency_key` literals on state-mutating tasks (`create_media_buy`, `sync_creatives`, `sync_plans`, `update_media_buy`). The runner shifts dynamic `start_time` substitutions forward to keep buys future-dated, so against a long-running seller deployment those static keys collide cross-run with the same key + a different canonical body, arming the spec-mandated `IDEMPOTENCY_CONFLICT` (or, when the seller's emit shape changed between runs, replaying a now-spec-non-compliant cached payload — the production failure mode that surfaced this).
+
+Switch every remaining literal to `$generate:uuid_v4#<scenario>_<step>` so each storyboard run mints fresh keys and never collides with stale cached state. Affected scenarios: `creative_fate_after_cancellation` (5), `governance_approved`, `governance_conditions`, `governance_denied`, `governance_denied_recovery` (3), `invalid_transitions`, `inventory_list_no_match`, `inventory_list_targeting`, `pending_creatives_to_start`.
+
+Closes #4230.

--- a/static/compliance/source/protocols/media-buy/scenarios/creative_fate_after_cancellation.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/creative_fate_after_cancellation.yaml
@@ -114,7 +114,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "creative-fate-setup-create-buy-v1"
+          idempotency_key: "$generate:uuid_v4#creative_fate_after_cancellation_create_buy"
           start_time: "2026-09-01T00:00:00Z"
           end_time: "2026-09-30T23:59:59Z"
           packages:
@@ -175,7 +175,7 @@ phases:
           assignments:
             - creative_id: "acme_reuse_banner_001"
               package_id: "$context.package_id"
-          idempotency_key: "creative-fate-setup-sync-v1"
+          idempotency_key: "$generate:uuid_v4#creative_fate_after_cancellation_sync_creative_with_assignment"
           context:
             correlation_id: "creative_fate--sync_creative_with_assignment"
         context_outputs:
@@ -257,7 +257,7 @@ phases:
           media_buy_id: "$context.media_buy_id"
           canceled: true
           cancellation_reason: "Creative-fate scenario: releasing assignment to verify library persistence."
-          idempotency_key: "creative-fate-cancel-v1"
+          idempotency_key: "$generate:uuid_v4#creative_fate_after_cancellation_update_media_buy_canceled"
           context:
             correlation_id: "creative_fate--update_media_buy_canceled"
         validations:
@@ -340,7 +340,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "creative-fate-second-buy-v1"
+          idempotency_key: "$generate:uuid_v4#creative_fate_after_cancellation_create_second_buy"
           start_time: "2026-10-01T00:00:00Z"
           end_time: "2026-10-31T23:59:59Z"
           packages:
@@ -406,7 +406,7 @@ phases:
           assignments:
             - creative_id: "acme_reuse_banner_001"
               package_id: "$context.second_package_id"
-          idempotency_key: "creative-fate-reassign-v1"
+          idempotency_key: "$generate:uuid_v4#creative_fate_after_cancellation_reassign_creative"
           context:
             correlation_id: "creative_fate--reassign_creative"
         validations:

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_approved.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_approved.yaml
@@ -84,7 +84,7 @@ phases:
         expected: |
           The governance agent acknowledges the plan with a plan_id.
         sample_request:
-          idempotency_key: "comply-gov-approved-sync-plans-v1"
+          idempotency_key: "$generate:uuid_v4#governance_approved_sync_plans"
           plans:
             - plan_id: "comply-gov-approved-plan"
               brand:

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_conditions.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_conditions.yaml
@@ -61,7 +61,7 @@ phases:
         expected: |
           The governance agent acknowledges the plan with a plan_id.
         sample_request:
-          idempotency_key: "comply-gov-conditions-sync-plans-v1"
+          idempotency_key: "$generate:uuid_v4#governance_conditions_sync_plans"
           plans:
             - plan_id: "comply-gov-conditions-plan"
               brand:

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
@@ -61,7 +61,7 @@ phases:
         expected: |
           The governance agent acknowledges the plan with a plan_id.
         sample_request:
-          idempotency_key: "comply-gov-denied-sync-plans-v1"
+          idempotency_key: "$generate:uuid_v4#governance_denied_sync_plans"
           plans:
             - plan_id: "comply-gov-denied-plan"
               brand:

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_denied_recovery.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_denied_recovery.yaml
@@ -61,7 +61,7 @@ phases:
         expected: |
           The governance agent acknowledges the plan.
         sample_request:
-          idempotency_key: "comply-gov-recovery-sync-plans-v1"
+          idempotency_key: "$generate:uuid_v4#governance_denied_recovery_sync_plans"
           plans:
             - plan_id: "comply-gov-recovery-plan"
               brand:
@@ -184,7 +184,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "gov-recovery-initial-denied-v1"
+          idempotency_key: "$generate:uuid_v4#governance_denied_recovery_create_media_buy_denied"
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
           packages:
@@ -229,7 +229,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "gov-recovery-retry-approved-v1"
+          idempotency_key: "$generate:uuid_v4#governance_denied_recovery_create_media_buy_retry"
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
           packages:

--- a/static/compliance/source/protocols/media-buy/scenarios/invalid_transitions.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/invalid_transitions.yaml
@@ -140,7 +140,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "invalid-transitions-setup-v1"
+          idempotency_key: "$generate:uuid_v4#invalid_transitions_create_buy"
           start_time: "2026-08-01T00:00:00Z"
           end_time: "2026-08-31T23:59:59Z"
           packages:

--- a/static/compliance/source/protocols/media-buy/scenarios/inventory_list_no_match.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/inventory_list_no_match.yaml
@@ -116,7 +116,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "inventory-list-no-match-v1"
+          idempotency_key: "$generate:uuid_v4#inventory_list_no_match_create_buy"
           start_time: "2026-07-01T00:00:00Z"
           end_time: "2026-09-30T23:59:59Z"
           packages:

--- a/static/compliance/source/protocols/media-buy/scenarios/inventory_list_targeting.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/inventory_list_targeting.yaml
@@ -114,7 +114,7 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
             sandbox: true
-          idempotency_key: "inventory-list-targeting-create-v1"
+          idempotency_key: "$generate:uuid_v4#inventory_list_targeting_create_buy"
           start_time: "2026-07-01T00:00:00Z"
           end_time: "2026-09-30T23:59:59Z"
           packages:

--- a/static/compliance/source/protocols/media-buy/scenarios/pending_creatives_to_start.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/pending_creatives_to_start.yaml
@@ -103,7 +103,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "pending-creatives-transition-v1"
+          idempotency_key: "$generate:uuid_v4#pending_creatives_to_start_create_buy_no_creatives"
           start_time: "2026-08-01T00:00:00Z"
           end_time: "2026-08-31T23:59:59Z"
           packages:


### PR DESCRIPTION
## Summary

Extends [#4218](https://github.com/adcontextprotocol/adcp/pull/4218) (`measurement_terms_rejected`) to the rest of the storyboard suite. 15 steps across 9 scenarios still shipped hardcoded `idempotency_key` literals on state-mutating tasks (`create_media_buy`, `sync_creatives`, `sync_plans`, `update_media_buy`).

Same root cause as #4218: the runner shifts `start_time` substitutions forward each run to keep buys future-dated, so against a long-running seller deployment those static keys produce **same key + different canonical body** cross-run. That arms the spec-mandated `IDEMPOTENCY_CONFLICT`. Worse: when the seller's emit shape changed between runs (e.g. a `CreateMediaBuyResponse` variant fix), subsequent runs replay now-spec-non-compliant cached payloads — the production failure mode that surfaced this issue, knocking out 5 stateful chains on `media_buy_seller` and cascading into ~43 dependent skipped steps.

## Change

Every remaining literal `idempotency_key` is replaced with `\$generate:uuid_v4#<scenario>_<step>` so each run mints fresh keys. Affected:

| Scenario | Steps |
|---|---|
| `creative_fate_after_cancellation` | 5 |
| `governance_approved` | 1 |
| `governance_conditions` | 1 |
| `governance_denied` | 1 |
| `governance_denied_recovery` | 3 |
| `invalid_transitions` | 1 |
| `inventory_list_no_match` | 1 |
| `inventory_list_targeting` | 1 |
| `pending_creatives_to_start` | 1 |

15 keys total, matching the issue inventory. Source files at `static/compliance/source/protocols/media-buy/scenarios/*.yaml`; the `compliance/cache/3.0.7/...` paths in the issue body are generated.

After this, no hardcoded `idempotency_key` literals remain in the storyboard suite (verified by grep on the source dir).

## Why this matters beyond the symptom

The runner's stale-cache replay is **correct seller behavior** — the spec mandates that an `idempotency_key` replay returns the cached response. But any time the spec or seller's emit shape changes (which happens whenever AdCP versions roll forward), every storyboard scenario with a static key becomes a one-shot landmine: works on first run, breaks after the seller updates. The `\$generate:uuid_v4` pattern is the systemic prevention.

## Test plan

- [x] `npm run test:substitution-vector-names` — clean
- [x] `npm run build:compliance` — clean rebuild
- [x] precommit (test:unit + test:test-dynamic-imports + test:callapi-state-change + typecheck) — passing
- [ ] Storyboard runner against `media_buy_seller` post-merge: confirm the 5 previously-failing `create_buy*` scenarios + 43 dependent steps unblock

## Release

Patch-eligible (compliance fixture fix, no spec/wire changes). Same shape as #4218 — should land in 3.0.8 via cherry-pick to `3.0.x`.

Closes #4230. Refs #4218, adcontextprotocol/adcp-client#1586.

🤖 Generated with [Claude Code](https://claude.com/claude-code)