### PR TITLE
fix(website): correct YouTube channel URL in footer nav

### DIFF
--- a/.changeset/fix-youtube-link-4244.md
+++ b/.changeset/fix-youtube-link-4244.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix(website): correct YouTube channel URL in footer nav from @AgenticAdvertisingOrg to @AgenticAdvertising, closes #4244

--- a/server/public/nav.js
+++ b/server/public/nav.js
@@ -899,7 +899,7 @@
                 <a href="https://www.linkedin.com/company/agenticadvertisingorg" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">
                   <svg aria-hidden="true" focusable="false" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
                 </a>
-                <a href="https://www.youtube.com/@AgenticAdvertisingOrg" target="_blank" rel="noopener noreferrer" aria-label="YouTube">
+                <a href="https://www.youtube.com/@AgenticAdvertising" target="_blank" rel="noopener noreferrer" aria-label="YouTube">
                   <svg aria-hidden="true" focusable="false" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.498 6.186a3.016 3.016 0 00-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 00.502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 002.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 002.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg>
                 </a>
               </div>


### PR DESCRIPTION
Closes #4244

The YouTube icon in the website footer (`server/public/nav.js`) linked to `https://www.youtube.com/@AgenticAdvertisingOrg` instead of the correct `https://www.youtube.com/@AgenticAdvertising`. Single-line fix in the shared nav component.

**Non-breaking justification:** Corrects an external URL value in a static HTML template; no schema, protocol, or API surface is touched. Existing visitors are unaffected beyond having a working link.

**Pre-PR review:**
- code-reviewer: approved — no blockers; nit on pre-existing `aria-label` mislabel (confirmed not present in actual file)
- docs-expert: approved — no other occurrences of the wrong YouTube URL found in `server/public/`; `about.html` "AgenticAdvertisingOrg Inc" is the legal entity name and is intentionally unchanged

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01T4QXSy7CfCVDsRHw1VPB3Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4QXSy7CfCVDsRHw1VPB3Q)_