### PR TITLE
docs(webhooks): registration channel determines envelope shape (closes #4246)

### DIFF
--- a/.changeset/push-notification-config-protocol.md
+++ b/.changeset/push-notification-config-protocol.md
@@ -1,0 +1,11 @@
+---
+"adcontextprotocol": patch
+---
+
+docs(webhooks): clarify that the **registration channel** determines webhook envelope shape — there is no per-call discriminator. AdCP `push_notification_config` (task arg) always delivers the AdCP `mcp-webhook-payload` envelope; A2A `TaskPushNotificationConfig` (native A2A push registration) always delivers A2A `StreamResponse`-wrapped `Task` / `TaskStatusUpdateEvent` per A2A 1.0 §4.3.3. The two channels are independent and a buyer MAY register both.
+
+This closes [adcontextprotocol/adcp#4246](https://github.com/adcontextprotocol/adcp/issues/4246) without a schema change. The issue's premise — "sellers default to match inbound transport, buyers need an override field to escape it" — was wrong: each registration channel is already purpose-built for its envelope shape, so the buyer picks the channel that matches the receiver. An A2A sync buyer that wants AdCP-shape webhooks puts `push_notification_config` in the AdCP task args inside the `SendMessage` body — no new field needed; an A2A buyer that wants A2A-shape webhooks registers through A2A's native push mechanism.
+
+Verified against [a2a.proto §TaskPushNotificationConfig](https://github.com/a2aproject/A2A/blob/main/specification/a2a.proto): A2A 1.0's push config has no encoding-negotiation field, confirming that wire shape is fixed per-channel rather than per-registration.
+
+**`docs/building/by-layer/L3/webhooks.mdx`** — replaces an earlier draft of a "Protocol override" subsection with §"Registration channel determines envelope shape": a two-row table mapping registration channel to delivered envelope, the rationale for channel-as-discriminator over transport-matched, and the typical "A2A sync, AdCP-shape webhooks" case worked example.

--- a/docs/building/by-layer/L3/webhooks.mdx
+++ b/docs/building/by-layer/L3/webhooks.mdx
@@ -214,6 +214,23 @@ A2A sends a `Task` object (for final states) or `TaskStatusUpdateEvent` (for pro
 | **Result location** | `result` field | `.artifacts[0].parts[].data` (final) / `status.message.parts[].data` (interim) |
 | **Data schemas** | Identical AdCP schemas | Identical AdCP schemas |
 
+### Registration channel determines envelope shape
+
+Webhook envelope shape is determined by **which registration mechanism the buyer used**, not by which transport the sync request was sent over:
+
+| Registered via | Delivered envelope |
+|---|---|
+| AdCP `push_notification_config` (task argument, MCP/A2A/REST) | [`mcp-webhook-payload.json`](#mcp) |
+| A2A `TaskPushNotificationConfig` ([`CreateTaskPushNotificationConfig`](https://a2a-protocol.org/latest/specification/) RPC, or inline `task_push_notification_config` on `SendMessage`) | A2A native `Task` / `TaskStatusUpdateEvent` per A2A 1.0 §4.3.3 |
+
+The two channels are independent. A buyer MAY register both for the same task and receive both webhooks per status change.
+
+**Why this is the model, not "match inbound transport".** Each channel is purpose-built for its envelope: AdCP `push_notification_config` is the AdCP-layer registration for the AdCP `mcp-webhook-payload` shape; A2A `TaskPushNotificationConfig` is the A2A-layer registration for A2A's own `StreamResponse`-wrapped delivery. The buyer picks the channel that matches the receiver — there's no need for a discriminator field, and no ambiguity to override.
+
+**Typical case: A2A sync, AdCP-shape webhooks.** A buyer orchestrating from an MCP-native runtime that uses A2A for one specific high-throughput sync operation puts `push_notification_config` in the AdCP task arguments inside its `SendMessage` body. The seller honors it as an AdCP-shape registration, regardless of A2A being the sync transport. The buyer's receiver gets the same `mcp-webhook-payload` shape it gets from every other AdCP webhook in its pipeline.
+
+**A2A buyers wanting A2A-shape webhooks** register through A2A's native push notification mechanism; AdCP doesn't need to add anything for that case.
+
 ### Status-specific result data
 
 | Status | `result` / `data` contains |


### PR DESCRIPTION
## Summary

- Closes #4246 **without a schema change**. The issue's premise was wrong: webhook envelope shape is determined by **which registration channel the buyer used**, not by sync transport — so no per-call discriminator is needed.
- Adds §"Registration channel determines envelope shape" to `docs/building/by-layer/L3/webhooks.mdx`: a two-row table (AdCP `push_notification_config` → AdCP `mcp-webhook-payload`; A2A `TaskPushNotificationConfig` → A2A `StreamResponse`), the rationale for channel-as-discriminator, and the worked "A2A sync, AdCP-shape webhooks" case.

## Why no schema change

The issue proposed an optional `protocol` enum field on `push_notification_config` so an A2A sync buyer could opt into MCP-shape webhooks. Working through it surfaced a cleaner model:

| Registered via | Delivered envelope |
|---|---|
| AdCP `push_notification_config` (task arg) | `mcp-webhook-payload.json` |
| A2A `TaskPushNotificationConfig` (native A2A push registration) | A2A native `Task` / `TaskStatusUpdateEvent` |

The two channels are independent. An A2A sync buyer that wants MCP-shape webhooks just puts `push_notification_config` in the AdCP task args inside their `SendMessage` body — the seller honors it as an AdCP-shape registration regardless of A2A being the sync transport. An A2A buyer that wants A2A-shape webhooks uses A2A's native push registration. No discriminator, no override, no field.

Verified against [a2a.proto §TaskPushNotificationConfig](https://github.com/a2aproject/A2A/blob/main/specification/a2a.proto): A2A 1.0's push config has six fields (`tenant`, `id`, `task_id`, `url`, `token`, `authentication`) — **no encoding-negotiation field**. This confirms wire shape is fixed per-channel rather than per-registration in A2A's own design, which is the same model AdCP should adopt.

## Test plan

- [x] `node tests/composed-schema-validation.test.cjs` — 32 passed
- [x] precommit (unit suite, dynamic imports, callapi state change, typecheck) — passed during commit
- [ ] Docs build verifies the new anchor renders cleanly

## Out of scope

- Wire encoding (JSON vs ProtoJSON vs binary protobuf vs TMP-binary). A2A 1.0 doesn't standardize binary push, no buyer is asking, deferred until a real case shows up.
- Reverse case (MCP sync buyer wanting A2A-shape webhooks). No real demand — A2A-native receivers have A2A clients and use A2A's native registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)