### PR TITLE
fix(registry): heartbeat picks up member-registered agents — write-side seed + read-side CTE

### DIFF
--- a/.changeset/heartbeat-picks-up-member-profile-agents.md
+++ b/.changeset/heartbeat-picks-up-member-profile-agents.md
@@ -1,0 +1,62 @@
+---
+---
+
+Compliance heartbeat now picks up agents registered through the member-profile
+surface, fixing a "registered but compliance status stays `unknown` forever"
+bug that's the same shape as the operator-endpoint visibility miss.
+
+**Why this changed.** A member registered an agent at
+`https://www.harvingupta.xyz/api/mcp` and saw it correctly in
+`/dashboard/agents`, but `GET /api/registry/agents/<url>/compliance` returned
+`{ status: "unknown", last_checked_at: null }` indefinitely. The heartbeat's
+"agents due for check" query (`compliance-db.ts:getAgentsDueForCheck`) keys off
+a `known_agents` CTE that unioned `discovered_agents` (crawler-discovered) and
+`agent_registry_metadata` (explicit registration). Member-registered agents
+land in `member_profiles.agents` JSONB, not in either of those tables —
+the heartbeat never picked them up, so `agent_compliance_status` stayed empty
+and the API served `status: "unknown"` forever.
+
+**Fix shape — both write-side and read-side.**
+
+- **Write-side seed.** `applyMemberAgentMutation` (the helper backing
+  `POST /api/me/agents` and `PATCH /api/me/agents/:url`) now bulk-upserts
+  an `agent_registry_metadata` row for every URL in the resulting agents
+  array, atomically with the JSONB write. `ON CONFLICT DO NOTHING`
+  preserves any owner-customized `lifecycle_stage` /
+  `check_interval_hours` / `compliance_opt_out` value the dashboard or
+  heartbeat wrote earlier — the seed only fires when the row is absent.
+  The Addie `save_agent` MCP handler does the same upsert after its
+  profile write; failures are logged at `warn` and don't fail the
+  registration.
+- **Read-side defense in depth.** The `known_agents` CTE in
+  `getAgentsDueForCheck` now has a third leg:
+  `SELECT (a->>'url') FROM member_profiles, jsonb_array_elements(agents) a`.
+  Any agent that slipped past the seed (write-side fallback fired,
+  pre-fix row, direct SQL) is still picked up by the heartbeat.
+  `ORDER BY` gains `ka.agent_url ASC` as a deterministic tiebreaker so
+  two never-checked agents land in a stable order across runs.
+
+**Behavior change.** None on existing API contracts. The heartbeat will
+start picking up previously-orphaned member-profile agents on its next
+cycle, which means a brief surge of compliance runs after deploy as the
+backlog drains. Per-agent rate limits and the heartbeat's per-run
+`limit` cap (default 10) bound the surge.
+
+**Existing rows.** A backfill script seeds `agent_registry_metadata`
+rows for every URL currently in `member_profiles.agents` that has no
+metadata row. Manual run on the pod, intentionally out of
+`release_command` so it doesn't auto-fire on deploy. The read-side CTE
+widening means the heartbeat would pick those agents up regardless, but
+seeding the metadata row keeps every other downstream consumer
+(dashboard lifecycle / opt-out / monitoring settings) consistent.
+
+**Tests.** Three new integration tests in `member-agents-api.test.ts`
+pin the contract:
+
+- POST seeds an `agent_registry_metadata` row when none exists
+  (default `lifecycle_stage = 'production'`, `compliance_opt_out = false`)
+- POST does NOT overwrite an existing metadata row on re-register
+  (custom `lifecycle_stage = 'testing'`, `check_interval_hours = 24` survive)
+- `getAgentsDueForCheck` picks up an agent that lives only in
+  `member_profiles.agents` (read-side CTE widening verified in isolation
+  by deliberately deleting the metadata row before the call)

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -5690,6 +5690,29 @@ export function createMemberToolHandlers(
           }
           if (dirty) await memberDb.updateProfile(profile.id, { agents });
         }
+
+        // Seed an `agent_registry_metadata` row so the compliance heartbeat
+        // picks this agent up. Without this, an agent registered via
+        // save_agent lives only in `member_profiles.agents` JSONB and never
+        // enters the heartbeat's `known_agents` CTE — the dashboard's
+        // compliance tile stays `unknown` indefinitely. ON CONFLICT DO
+        // NOTHING preserves any owner-customized lifecycle / opt-out /
+        // check-interval the heartbeat or dashboard wrote earlier.
+        try {
+          await query(
+            `INSERT INTO agent_registry_metadata (agent_url)
+             VALUES ($1)
+             ON CONFLICT (agent_url) DO NOTHING`,
+            [agentUrl],
+          );
+        } catch (err) {
+          // Non-fatal: the read-side CTE widening (member_profiles.agents
+          // unioned into known_agents) catches this case as a fallback.
+          // We log so a real metadata-table outage is visible without
+          // failing the user's registration.
+          logger.warn({ err, agentUrl }, 'Addie: failed to seed agent_registry_metadata row');
+        }
+
         return { ok: true, createdProfile };
       } catch (err) {
         logger.warn({ err, agentUrl, orgId: saveOrgId }, 'Addie: failed to add agent to member profile');

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -511,11 +511,31 @@ export class ComplianceDatabase {
     lifecycle_stage: LifecycleStage;
     last_checked_at: Date | null;
   }>> {
+    // `known_agents` unions every source the heartbeat is allowed to test:
+    //
+    // - `discovered_agents` — crawler-discovered via adagents.json on a
+    //   publisher domain.
+    // - `agent_registry_metadata` — explicit registration / lifecycle-stage
+    //   write. Most member-registered agents land a row here via the
+    //   write-side seed in member-agents.ts and the save_agent MCP handler.
+    // - `member_profiles.agents` (JSONB) — defense-in-depth: any agent the
+    //   owner registered through Addie or the REST surface, even if the
+    //   metadata-row seed failed (the seed is best-effort with a warn-log
+    //   on failure). Without this third leg of the union, an agent that
+    //   slipped past the seed would stay `unknown` forever — the same
+    //   class of bug as the operator-endpoint visibility miss.
+    //
+    // ORDER BY adds `agent_url` as a deterministic tiebreaker so two
+    // never-checked agents land in a stable order across heartbeat runs.
     const result = await query(
       `WITH known_agents AS (
         SELECT agent_url FROM discovered_agents
         UNION
         SELECT agent_url FROM agent_registry_metadata
+        UNION
+        SELECT (a->>'url') AS agent_url
+        FROM member_profiles, jsonb_array_elements(agents) a
+        WHERE a->>'url' IS NOT NULL
       )
       SELECT
         ka.agent_url,
@@ -534,7 +554,7 @@ export class ComplianceDatabase {
             CASE WHEN COALESCE(m.lifecycle_stage, 'production') = 'testing' THEN 24 ELSE 12 END
           ))
         )
-      ORDER BY s.last_checked_at ASC NULLS FIRST
+      ORDER BY s.last_checked_at ASC NULLS FIRST, ka.agent_url ASC
       LIMIT $1`,
       [limit],
     );

--- a/server/src/routes/member-agents.ts
+++ b/server/src/routes/member-agents.ts
@@ -357,6 +357,35 @@ export function createMemberAgentsRouter(config: MemberAgentsRouterConfig): Rout
           [JSON.stringify(typed), profileId],
         );
       }
+
+      // Ensure every registered agent has an `agent_registry_metadata` row
+      // so the compliance heartbeat picks it up. Pre-fix, the heartbeat's
+      // `known_agents` CTE unioned only `discovered_agents` and
+      // `agent_registry_metadata` — agents living solely in
+      // `member_profiles.agents` JSONB stayed `unknown` forever, regardless
+      // of the 12h cycle. The read-side CTE was widened in the same change
+      // so existing rows recover, but writing the row here keeps every
+      // downstream consumer of `agent_registry_metadata` (lifecycle,
+      // monitoring, rate-limit policy) consistent without needing each one
+      // to learn about the JSONB shape.
+      //
+      // Atomic with the JSONB write — same transaction, same FOR UPDATE
+      // lock. ON CONFLICT DO NOTHING preserves any owner-customized
+      // lifecycle_stage / check_interval_hours / opt-out the heartbeat or
+      // dashboard wrote earlier; we only seed the row when it doesn't
+      // exist. Defaults inherit from the column DDL.
+      const urls = typed
+        .map(a => (a && typeof a.url === 'string' ? a.url : null))
+        .filter((u): u is string => u !== null);
+      if (urls.length > 0) {
+        await client.query(
+          `INSERT INTO agent_registry_metadata (agent_url)
+           SELECT unnest($1::text[])
+           ON CONFLICT (agent_url) DO NOTHING`,
+          [urls],
+        );
+      }
+
       await client.query('COMMIT');
       invalidateMemberContextCache();
 

--- a/server/tests/integration/member-agents-api.test.ts
+++ b/server/tests/integration/member-agents-api.test.ts
@@ -23,6 +23,7 @@ import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
 import { runMigrations } from '../../src/db/migrate.js';
 import { MemberDatabase } from '../../src/db/member-db.js';
 import { OrganizationDatabase, type MembershipTier } from '../../src/db/organization-db.js';
+import { ComplianceDatabase } from '../../src/db/compliance-db.js';
 import { createMemberAgentsRouter } from '../../src/routes/member-agents.js';
 
 const TEST_PREFIX = 'org_member_agents_api';
@@ -634,6 +635,117 @@ describe('Per-agent REST API (/api/me/agents)', () => {
     // The existing brand-domain wins; auto-backfill never fires when the
     // column is already populated, even if the agent URL hostname differs.
     expect(profile!.primary_brand_domain).toBe('preset.example');
+  });
+
+  // ── agent_registry_metadata seed on register (PR follow-up) ────
+  // Without this seed, an agent registered via /api/me/agents lives only
+  // in member_profiles.agents JSONB and never enters the heartbeat's
+  // known_agents CTE — compliance status stays `unknown` forever. The
+  // seed is best-effort; the read-side CTE was widened in the same change
+  // as defense-in-depth.
+
+  it('POST seeds an agent_registry_metadata row so the heartbeat can pick it up', async () => {
+    const orgId = `${TEST_PREFIX}_meta_seed`;
+    const userId = `${TEST_PREFIX}_meta_seed_user`;
+    await seedOrg(pool, orgId, 'individual_professional');
+    await provisionUser(userId, orgId);
+    await createProfile(orgId, 'metaseed');
+
+    const targetUrl = 'https://meta-seed.example/mcp';
+    // Sanity: no metadata row before the POST.
+    const before = await pool.query(
+      'SELECT agent_url FROM agent_registry_metadata WHERE agent_url = $1',
+      [targetUrl],
+    );
+    expect(before.rowCount).toBe(0);
+
+    (app as any).setCurrentUser(userId);
+    const res = await request(app)
+      .post('/api/me/agents')
+      .send({ url: targetUrl, type: 'sales', visibility: 'private' });
+    expect(res.status).toBe(201);
+
+    // Metadata row exists post-write, with default lifecycle_stage so the
+    // heartbeat will include it.
+    const after = await pool.query<{ agent_url: string; lifecycle_stage: string; compliance_opt_out: boolean }>(
+      `SELECT agent_url, lifecycle_stage, compliance_opt_out
+       FROM agent_registry_metadata WHERE agent_url = $1`,
+      [targetUrl],
+    );
+    expect(after.rowCount).toBe(1);
+    expect(after.rows[0].lifecycle_stage).toBe('production');
+    expect(after.rows[0].compliance_opt_out).toBe(false);
+
+    // Cleanup the metadata row to avoid leaking state across tests.
+    await pool.query('DELETE FROM agent_registry_metadata WHERE agent_url = $1', [targetUrl]);
+  });
+
+  it('heartbeat picks up an agent that lives only in member_profiles.agents (read-side CTE widening)', async () => {
+    // Defense-in-depth case: a row whose write-side seed never landed
+    // (best-effort fallback fired) must still be visible to the
+    // compliance heartbeat. We bypass the route deliberately to simulate
+    // pre-fix data and to isolate the read-side CTE behavior from the
+    // write-side seed.
+    const orgId = `${TEST_PREFIX}_cte_only`;
+    const userId = `${TEST_PREFIX}_cte_only_user`;
+    const targetUrl = 'https://cte-only.example/mcp';
+    await seedOrg(pool, orgId, 'individual_professional');
+    await provisionUser(userId, orgId);
+    await memberDb.createProfile({
+      workos_organization_id: orgId,
+      display_name: 'Test cteonly',
+      slug: 'cteonly',
+      primary_brand_domain: 'cte-only.example',
+      is_public: false,
+      agents: [{ url: targetUrl, type: 'sales', visibility: 'private' }],
+    });
+    // Sanity: no metadata row, no discovered_agents row.
+    await pool.query('DELETE FROM agent_registry_metadata WHERE agent_url = $1', [targetUrl]);
+    await pool.query('DELETE FROM discovered_agents WHERE agent_url = $1', [targetUrl]);
+
+    const complianceDb = new ComplianceDatabase();
+    const due = await complianceDb.getAgentsDueForCheck(100);
+    const matched = due.find((d) => d.agent_url === targetUrl);
+    // The read-side CTE's third leg (member_profiles.agents) is what
+    // makes this match. With the pre-fix two-leg CTE this assertion
+    // would fail.
+    expect(matched).toBeDefined();
+    expect(matched!.lifecycle_stage).toBe('production');
+    expect(matched!.last_checked_at).toBeNull();
+  });
+
+  it('POST does NOT overwrite an existing agent_registry_metadata row on re-register', async () => {
+    const orgId = `${TEST_PREFIX}_meta_existing`;
+    const userId = `${TEST_PREFIX}_meta_existing_user`;
+    await seedOrg(pool, orgId, 'individual_professional');
+    await provisionUser(userId, orgId);
+    await createProfile(orgId, 'metaexisting');
+
+    const targetUrl = 'https://meta-existing.example/mcp';
+    // Seed metadata with non-default lifecycle and a custom interval — the
+    // re-register MUST preserve these so an owner who tuned cadence /
+    // lifecycle from the dashboard doesn't see it reset by the next save.
+    await pool.query(
+      `INSERT INTO agent_registry_metadata (agent_url, lifecycle_stage, check_interval_hours)
+       VALUES ($1, 'testing', 24)`,
+      [targetUrl],
+    );
+
+    (app as any).setCurrentUser(userId);
+    const res = await request(app)
+      .post('/api/me/agents')
+      .send({ url: targetUrl, type: 'sales', visibility: 'private' });
+    expect(res.status).toBe(201);
+
+    const after = await pool.query<{ lifecycle_stage: string; check_interval_hours: number }>(
+      `SELECT lifecycle_stage, check_interval_hours
+       FROM agent_registry_metadata WHERE agent_url = $1`,
+      [targetUrl],
+    );
+    expect(after.rows[0].lifecycle_stage).toBe('testing');
+    expect(after.rows[0].check_interval_hours).toBe(24);
+
+    await pool.query('DELETE FROM agent_registry_metadata WHERE agent_url = $1', [targetUrl]);
   });
 
   it('DELETE returns 409 unpublish_first when the agent is currently public', async () => {


### PR DESCRIPTION
Closes part of the visibility-miss bug class fixed in #4235 (different table, same shape).

## Summary

Agents registered via `POST /api/me/agents` or `save_agent` lived in `member_profiles.agents` JSONB but never landed an `agent_registry_metadata` row. The compliance heartbeat's `known_agents` CTE unioned only `discovered_agents` and `agent_registry_metadata`, so member-registered agents were invisible to the heartbeat. `agent_compliance_status` stayed empty, `/api/registry/agents/<url>/compliance` returned `status: "unknown"` forever regardless of the 12h cycle.

## Why

Caught on the same agent that motivated #4235 (`harvingupta.xyz/api/mcp`). Pod audit confirmed: `agent_registry_metadata` 0 rows, `agent_compliance_status` 0 rows, `discovered_agents` 0 rows — but `agent_capabilities_snapshot` and `agent_health_snapshot` had 1 row each (other probes ran). The heartbeat's enqueue query keys off the wrong source for member-registered agents.

## Fix shape — write-side seed + read-side CTE

- **Write-side seed.** `applyMemberAgentMutation` (the helper backing `POST /api/me/agents` and `PATCH /api/me/agents/:url`) bulk-upserts `agent_registry_metadata` rows for every URL in the resulting agents array, atomically with the JSONB write. `ON CONFLICT DO NOTHING` preserves owner-customized `lifecycle_stage` / `check_interval_hours` / `compliance_opt_out`. The `save_agent` MCP handler does the same upsert after its profile write; failures are logged at `warn` and don't fail the registration.
- **Read-side defense in depth.** The `known_agents` CTE in `getAgentsDueForCheck` gains a third leg unioning `member_profiles.agents` URLs. Any agent that slipped past the seed is still picked up by the heartbeat. `ORDER BY` adds `ka.agent_url ASC` as a deterministic tiebreaker so two never-checked agents land in stable order across runs.

## Behavior change

Heartbeat will start picking up previously-orphaned member-profile agents on its next cycle — brief surge of compliance runs after deploy as the backlog drains. Per-agent rate limits and the heartbeat's per-run `limit` cap (default 10) bound the surge.

## Migration

Manual backfill script for existing rows (out of `release_command` so it doesn't auto-fire on deploy):

```bash
fly ssh console -a adcp-docs
cd /app && cat > /app/migrate-metadata.mjs <<'SCRIPT'
import pg from 'pg';
const DRY_RUN = process.argv.includes('--dry-run');
const c = new pg.Client({ connectionString: process.env.DATABASE_URL });
await c.connect();
const candidates = await c.query(`
  SELECT DISTINCT (a->>'url') AS agent_url
  FROM member_profiles, jsonb_array_elements(agents) a
  WHERE a->>'url' IS NOT NULL
    AND (a->>'url') NOT IN (SELECT agent_url FROM agent_registry_metadata)
  ORDER BY agent_url
`);
console.log(`${candidates.rowCount} URL(s) need a metadata row`);
for (const row of candidates.rows) {
  if (!DRY_RUN) {
    await c.query(`INSERT INTO agent_registry_metadata (agent_url) VALUES ($1) ON CONFLICT DO NOTHING`, [row.agent_url]);
  }
}
await c.end();
SCRIPT
node /app/migrate-metadata.mjs --dry-run  # review
node /app/migrate-metadata.mjs            # commit
```

## Refs

- #4235 — type-required + brand-domain backfill (the prior visibility-miss fix; same shape of bug)
- #4247 — full unification plan that supersedes the dual-write architecture entirely (this PR is the immediate-fix; #4247 is the structural one)

## Test plan

- [x] `tsc --noEmit -p server/tsconfig.json` clean
- [x] Build passes
- [x] 3 new integration tests in `member-agents-api.test.ts`:
  - POST seeds an `agent_registry_metadata` row when none exists
  - POST does NOT overwrite an existing metadata row on re-register (`lifecycle_stage = 'testing'` and `check_interval_hours = 24` survive)
  - `getAgentsDueForCheck` picks up an agent that lives only in `member_profiles.agents` (read-side CTE in isolation, with metadata row deliberately absent)
- [ ] Integration tests in CI (require live Postgres)
- [ ] Smoke after deploy: register a fresh agent, wait one heartbeat cycle, confirm `/api/registry/agents/:url/compliance` returns a real verdict (not `"unknown"`)