### PR TITLE
fix(server): org profile page always shows "Register an agent" CTA when agents exist

### DIFF
--- a/.changeset/fix-org-health-agent-count-stub.md
+++ b/.changeset/fix-org-health-agent-count-stub.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix org profile page always showing "Register an agent to start integrating" CTA by replacing the hardcoded `agentCount = 0` stub in `assembleOrgHealth` with a real query against `member_profiles.agents`. Orgs with registered agents will now correctly see their tech-integration health score reflect actual registrations and will no longer see the spurious onboarding CTA.

--- a/server/src/services/org-health.ts
+++ b/server/src/services/org-health.ts
@@ -309,8 +309,17 @@ export async function assembleOrgHealth(orgId: string): Promise<OrgHealth> {
       return [];
     }),
 
-    // Agent count — no org-scoped agents table yet; always 0 until one exists
-    Promise.resolve(0),
+    // Count all registered agents across org member profiles, regardless of visibility.
+    // "Any agent registered" is the threshold — visibility tier is not the gate here.
+    query<{ total: string }>(
+      `SELECT COALESCE(SUM(COALESCE(jsonb_array_length(agents), 0)), 0) AS total
+       FROM member_profiles
+       WHERE workos_organization_id = $1`,
+      [orgId]
+    ).then(r => parseInt(r.rows[0]?.total || '0', 10)).catch(err => {
+      logger.error({ err, orgId }, 'Failed to fetch agent count');
+      return 0;
+    }),
 
     // Leadership roles across all org members
     query<{ count: string }>(


### PR DESCRIPTION
Closes #4255

`assembleOrgHealth` in `server/src/services/org-health.ts` contained a stub that returned a hardcoded `0` for the agent count:

```typescript
// Agent count — no org-scoped agents table yet; always 0 until one exists
Promise.resolve(0),
```

The agents table _does_ exist — agents are stored as a JSONB array in `member_profiles.agents` (added in migration `014_agent_configs.sql`). Because `agentCount` was always `0`, `suggestActions()` always fired the "Register an agent to start integrating" CTA, regardless of how many agents the org had registered.

This PR replaces the stub with a query that counts all agents across the org's member profile:

```sql
SELECT COALESCE(SUM(COALESCE(jsonb_array_length(agents), 0)), 0) AS total
FROM member_profiles
WHERE workos_organization_id = $1
```

The double `COALESCE` handles: (inner) `agents` column being `NULL` on older rows; (outer) no matching profile row at all. Error path falls back to `0` (preserving the previous behavior on DB failure).

Visibility is intentionally not filtered — "has the org registered any agent" is the correct semantic for the CTA gate; a `private` agent is still a registered agent.

**Non-breaking justification:** server-side service change only; no schema, API, or protocol surface affected. Existing callers of `assembleOrgHealth` receive a more accurate `suggested_actions` array (the `register_agent` action is correctly absent when agents exist).

**Pre-PR review:**
- code-reviewer: approved — SQL is safe (parameterized), double COALESCE is correct, error fallback consistent with surrounding pattern; nit: outer SUM redundant given one-per-org constraint (harmless)
- internal-tools-strategist: approved — counting all visibility tiers is correct for this gate; display path for agents list is a separate read path, correctly out of scope

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01MGmeJKgbaF39WEmwEuDRQY

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGmeJKgbaF39WEmwEuDRQY)_