### PR TITLE
fix(member-profile): hoist parsed URL variable outside try block

### DIFF
--- a/.changeset/fix-member-profile-photo-preview-scope.md
+++ b/.changeset/fix-member-profile-photo-preview-scope.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix `parsed is not defined` ReferenceError in member profile photo preview. The `parsed` variable was declared with `const` inside a `try` block but referenced outside it; hoisting to `let` before the block resolves the scope error.

--- a/server/public/member-profile.html
+++ b/server/public/member-profile.html
@@ -2642,8 +2642,9 @@
       }
 
       if (photoUrl) {
+        let parsed;
         try {
-          const parsed = new URL(photoUrl);
+          parsed = new URL(photoUrl);
           if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
             setPreviewMessage('Only http/https URLs allowed', 'var(--color-error-500)', '11px');
             return;


### PR DESCRIPTION
Closes #4257

The member profile edit page threw `ReferenceError: parsed is not defined` on every page load for org members who already have a photo URL saved. The `parsed` variable was declared with `const` inside the `try {}` block (block-scoped, not visible outside), then referenced after the block at `img.src = parsed.href`. Hoisting to `let parsed;` before the `try` resolves the scope error.

**Non-breaking justification:** This is a single-variable scope declaration change in client-side UI JavaScript. No API, schema, or protocol surface is touched. Existing orgs without a photo URL are unaffected; orgs with a photo URL now load the page correctly instead of crashing.

**Pre-PR review:**
- code-reviewer: approved — fix is mechanically correct, no uninitialized-access risk (both early-return paths in catch/protocol-check fire before `parsed.href` is reached), no security concerns
- internal-tools-strategist: approved — fully addresses the reported issue, low regression risk, no other code paths affected

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01NtURTgGU62uABeHEP9hgQ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtURTgGU62uABeHEP9hgQ7)_