### PR TITLE
fix(dashboard): remove unfiltered storyboard fallback on probe failure

### DIFF
--- a/.changeset/fix-storyboard-probe-fallback.md
+++ b/.changeset/fix-storyboard-probe-fallback.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix storyboard probe-failure fallback in dashboard agent Test view: remove unfiltered /api/storyboards fallback that was showing all storyboards when capability discovery failed; replace with actionable per-reason guidance and handle specialism_parent_protocol_missing and 504 cases explicitly.

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -2965,35 +2965,35 @@
             return;
           }
 
-          const reasonText = errBody.reason ? ' (' + errBody.reason + ')' : '';
-          const msg = errBody.error || ('HTTP ' + res.status);
-          let html = '<div style="padding:var(--space-3);background:var(--color-error-50);border:1px solid var(--color-error-200);border-radius:var(--radius-md);color:var(--color-error-700);font-size:var(--text-sm);margin-bottom:var(--space-3);">';
-          html += '<strong>Could not probe agent capabilities.</strong> ' + escapeHtml(String(msg) + reasonText);
-          html += '</div>';
-
-          try {
-            const fallback = await fetch('/api/storyboards', { credentials: 'include' });
-            if (fallback.ok) {
-              const fdata = await fallback.json();
-              if (fdata.storyboards && fdata.storyboards.length > 0) {
-                html += '<div style="font-size:var(--text-xs);color:var(--color-text-secondary);margin-bottom:var(--space-2);">Showing all available storyboards:</div>';
-                html += '<div class="storyboard-picker">';
-                for (const sb of fdata.storyboards) {
-                  html += '<div class="storyboard-picker-item" data-storyboard-id="' + escapeHtml(sb.id) + '" data-agent-url="' + escapeHtml(agentUrl) + '" data-card-id="' + escapeHtml(cardId) + '">';
-                  html += '<div>';
-                  html += '<div class="storyboard-picker-title">' + escapeHtml(sb.title) + '</div>';
-                  html += '<div class="storyboard-picker-summary">' + escapeHtml(sb.summary) + '</div>';
-                  html += '</div>';
-                  html += '<span style="font-size:var(--text-xs);color:var(--color-text-tertiary);">' + sb.step_count + ' steps</span>';
-                  html += '</div>';
-                }
-                html += '</div>';
-              }
+          if (errBody.specialism_parent_protocol_missing) {
+            let html = '<div style="padding:var(--space-3);background:var(--color-error-50);border:1px solid var(--color-error-200);border-radius:var(--radius-md);color:var(--color-error-700);font-size:var(--text-sm);">';
+            html += '<strong>Capabilities misconfigured.</strong>';
+            if (errBody.specialism && errBody.parent_protocol) {
+              html += ' Specialism <code>' + escapeHtml(String(errBody.specialism)) + '</code> requires <code>' + escapeHtml(String(errBody.parent_protocol)) + '</code> in <code>supported_protocols</code>.';
+              html += '<div style="margin-top:var(--space-2);">Add <code>' + escapeHtml(String(errBody.parent_protocol)) + '</code> to <code>supported_protocols</code> in your <code>get_adcp_capabilities</code> response.</div>';
+            } else {
+              html += ' ' + escapeHtml(String(errBody.error || 'A declared specialism is missing its required parent protocol.'));
             }
-          } catch (fallbackErr) {
-            console.error('Storyboard fallback failed:', fallbackErr);
+            html += '</div>';
+            panel.innerHTML = html;
+            return;
           }
 
+          const reasonHints = {
+            network: 'Check the agent URL — the host is unreachable or DNS lookup failed.',
+            tls: "The agent's TLS certificate is invalid or expired.",
+            timeout: 'The agent did not respond in time. It may be down or slow to start.',
+            protocol: 'The agent responded but did not speak MCP correctly.',
+          };
+          const msg = errBody.error || ('HTTP ' + res.status);
+          const hint = res.status === 504
+            ? reasonHints.timeout
+            : (reasonHints[errBody.reason] || 'Verify the agent URL is correct and the agent is running.');
+          let html = '<div style="padding:var(--space-3);background:var(--color-error-50);border:1px solid var(--color-error-200);border-radius:var(--radius-md);color:var(--color-error-700);font-size:var(--text-sm);">';
+          html += '<strong>Could not probe agent capabilities.</strong>';
+          html += '<div style="margin-top:var(--space-1);">' + escapeHtml(String(msg)) + '</div>';
+          html += '<div style="margin-top:var(--space-2);color:var(--color-error-600);">' + escapeHtml(hint) + '</div>';
+          html += '</div>';
           panel.innerHTML = html;
         } catch (err) {
           console.error('Failed to load storyboards:', err);


### PR DESCRIPTION
Closes #4254

When the capability probe fails for a registered agent, the Test view's `renderStoryboardPicker()` was falling back to `GET /api/storyboards` — the full unfiltered catalog — and rendering 20+ storyboards regardless of the agent's declared capabilities. A signals-only agent would see `get-media-buys-pagination-integrity`, `list_creatives` pagination storyboards, and other media-buy tests it would never be required to pass. The "Showing all available storyboards:" subheading was not sufficient to prevent confusion; members were clicking Run against a still-unreachable agent and getting a second error.

**Non-breaking justification:** this is a UI-only change inside `server/public/dashboard-agents.html`; it removes a misleading fallback fetch and replaces it with structured error messages. No API surface, schema, or protocol contract is changed.

**What changed:**

1. **Removed the `/api/storyboards` fallback** — when the probe fails with a non-classified 500/504, no storyboard list is shown. The member needs to fix their agent first.

2. **Added `specialism_parent_protocol_missing` branch** — was previously falling through to the generic error path (and then the fallback). Now shows "Capabilities misconfigured. Specialism `X` requires `Y` in `supported_protocols`. Add `Y` to your `get_adcp_capabilities` response."

3. **Added per-reason guidance** using the existing `reason` enum the server already returns (`network | tls | timeout | protocol | unknown`) — gives the member a one-sentence actionable hint matched to the failure mode instead of a raw `(network)` tag appended to the error string.

4. **Mapped HTTP 504** explicitly to the timeout hint — the server returns `{ error: "Connection timeout" }` with no `reason` field on 504, so `res.status === 504` check ensures the right guidance rather than falling to the generic fallback.

**Pre-PR review:**
- code-reviewer: approved — no blockers; XSS handling correct throughout; nit: add explicit `unknown` key to `reasonHints` map for self-documentation
- internal-tools-strategist: approved — right UX decision; nits: (1) move `specialism_parent_protocol_missing` check before `unknown_specialism` for logical priority order; (2) `tls` hint copy is descriptive rather than imperative ("Renew or replace..." fits the register better); (3) fallback string in `specialism_parent_protocol_missing` branch re-uses `errBody.error` which includes "misconfigured" twice — use specialism/parent_protocol fields directly

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_011RjJrMxXuaEQXgg6HJMWqA

---
_Generated by [Claude Code](https://claude.ai/code/session_011RjJrMxXuaEQXgg6HJMWqA)_