### PR TITLE
fix(schema,skill): align HMAC framing to RFC 9421 default in reporting-webhook, auth-scheme, call-adcp-agent SKILL.md

### DIFF
--- a/.changeset/fix-hmac-framing-skill-9421-default.md
+++ b/.changeset/fix-hmac-framing-skill-9421-default.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix stale HMAC-as-recommended framing in reporting-webhook.json and auth-scheme.json; add RFC 9421 default guidance to call-adcp-agent SKILL.md. Description-only fixes aligning these surfaces with the existing push-notification-config.json framing (HMAC is the deprecated fallback, RFC 9421 is the default). No wire format changes.

--- a/.changeset/fix-hmac-framing-skill-9421-default.md
+++ b/.changeset/fix-hmac-framing-skill-9421-default.md
@@ -2,4 +2,4 @@
 "adcontextprotocol": patch
 ---
 
-Fix stale HMAC-as-recommended framing in reporting-webhook.json and auth-scheme.json; add RFC 9421 default guidance to call-adcp-agent SKILL.md. Description-only fixes aligning these surfaces with the existing push-notification-config.json framing (HMAC is the deprecated fallback, RFC 9421 is the default). No wire format changes.
+Fix stale HMAC-as-recommended framing in reporting-webhook.json, auth-scheme.json, and create-media-buy-request.json's artifact_webhook; add RFC 9421 default guidance to call-adcp-agent SKILL.md. Description-only fixes aligning these surfaces with the existing push-notification-config.json framing (HMAC is the deprecated fallback, RFC 9421 is the default). No wire format changes.

--- a/skills/call-adcp-agent/SKILL.md
+++ b/skills/call-adcp-agent/SKILL.md
@@ -89,6 +89,25 @@ When you see `status: 'submitted'`, the work is NOT complete. Poll via `tasks/ge
 
 `budget` is a **number** (not `{amount, currency}` — currency is implied by the pricing option). Required per package: `product_id`, `budget`, `pricing_option_id`. `buyer_ref` is optional but strongly recommended as a buyer-side correlation id across retries and reporting.
 
+### Webhook signing — omit `authentication` for new integrations
+
+When you include `push_notification_config` in a request, do **not** set `authentication`
+unless you are integrating with a legacy receiver. Omitting `authentication` selects the
+default: the seller signs each inbound webhook POST with its RFC 9421
+`adcp_use: "webhook-signing"` key, published at the `jwks_uri` in its own `brand.json`
+`agents[]` entry. You verify against the seller's JWKS. No shared secret crosses the wire.
+
+Presence of `authentication` is a **switch, not a fallback** — it opts the seller into
+Bearer or HMAC-SHA256 and disables 9421 for that registration. A buyer MUST NOT attempt
+"try 9421 first, fall back to HMAC" verification — mode is fixed at registration time.
+
+The `authentication` block (Bearer / HMAC-SHA256) is deprecated and sellers MAY decline
+to support it. It is removed in AdCP 4.0. The `token` field (a correlation token echoed
+back in the webhook payload) is separate from `authentication` and is not deprecated.
+
+See [Webhook callbacks](https://adcontextprotocol.org/docs/building/implementation/security#webhook-callbacks) for the
+full verifier checklist and downgrade-resistance rules.
+
 ## Error envelope — read `issues[]` to recover
 
 Every validation failure produces:

--- a/static/schemas/source/core/reporting-webhook.json
+++ b/static/schemas/source/core/reporting-webhook.json
@@ -17,11 +17,11 @@
     },
     "authentication": {
       "type": "object",
-      "description": "Authentication configuration for webhook delivery (A2A-compatible)",
+      "description": "Legacy authentication configuration for webhook delivery (A2A-compatible). Opts the receiver into Bearer or HMAC-SHA256 signing. Both schemes are deprecated; the preferred signing profile for new integrations is RFC 9421, where the seller signs with a key published at its brand.json agents[] entry and the buyer verifies against the seller's JWKS — no shared secret crosses the wire (see docs/building/implementation/security.mdx#webhook-callbacks). This field is required in AdCP 3.x; the requirement is removed in AdCP 4.0 when the default RFC 9421 path becomes the only path.",
       "properties": {
         "schemes": {
           "type": "array",
-          "description": "Array of authentication schemes. Supported: ['Bearer'] for simple token auth, ['HMAC-SHA256'] for signature verification (recommended for production)",
+          "description": "Array of authentication schemes. ['Bearer'] for simple token auth, ['HMAC-SHA256'] for legacy shared-secret signing. Both are deprecated; new integrations SHOULD use the RFC 9421 webhook signing profile instead.",
           "items": {
             "$ref": "/schemas/enums/auth-scheme.json"
           },
@@ -30,7 +30,7 @@
         },
         "credentials": {
           "type": "string",
-          "description": "Credentials for authentication. For Bearer: token sent in Authorization header. For HMAC-SHA256: shared secret used to generate signature. Minimum 32 characters. Exchanged out-of-band during onboarding.",
+          "description": "Credentials for the legacy scheme. For Bearer: token sent in Authorization header. For HMAC-SHA256: shared secret used to generate signature. Minimum 32 characters. Exchanged out-of-band during onboarding.",
           "minLength": 32
         }
       },

--- a/static/schemas/source/enums/auth-scheme.json
+++ b/static/schemas/source/enums/auth-scheme.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/enums/auth-scheme.json",
   "title": "Authentication Scheme",
-  "description": "Authentication schemes for push notification endpoints",
+  "description": "Legacy authentication schemes for the webhook auth block. Bearer: token sent in Authorization header. HMAC-SHA256: legacy shared-secret signing. Both are deprecated; new integrations SHOULD omit the authentication block and use the RFC 9421 webhook signing profile (applicable on schemas where authentication is optional). Removed in AdCP 4.0.",
   "type": "string",
   "enum": [
     "Bearer",

--- a/static/schemas/source/media-buy/create-media-buy-request.json
+++ b/static/schemas/source/media-buy/create-media-buy-request.json
@@ -145,11 +145,11 @@
         },
         "authentication": {
           "type": "object",
-          "description": "Authentication configuration for webhook delivery (A2A-compatible)",
+          "description": "Legacy authentication configuration for webhook delivery (A2A-compatible). Opts the receiver into Bearer or HMAC-SHA256 signing. Both schemes are deprecated; the preferred signing profile for new integrations is RFC 9421, where the seller signs with a key published at its brand.json agents[] entry and the buyer verifies against the seller's JWKS — no shared secret crosses the wire (see docs/building/implementation/security.mdx#webhook-callbacks). This field is required in AdCP 3.x; the requirement is removed in AdCP 4.0 when the default RFC 9421 path becomes the only path.",
           "properties": {
             "schemes": {
               "type": "array",
-              "description": "Array of authentication schemes. Supported: ['Bearer'] for simple token auth, ['HMAC-SHA256'] for signature verification (recommended for production)",
+              "description": "Array of authentication schemes. ['Bearer'] for simple token auth, ['HMAC-SHA256'] for legacy shared-secret signing. Both are deprecated; new integrations SHOULD use the RFC 9421 webhook signing profile instead.",
               "items": {
                 "$ref": "/schemas/enums/auth-scheme.json"
               },
@@ -158,7 +158,7 @@
             },
             "credentials": {
               "type": "string",
-              "description": "Credentials for authentication. For Bearer: token sent in Authorization header. For HMAC-SHA256: shared secret used to generate signature. Minimum 32 characters. Exchanged out-of-band during onboarding.",
+              "description": "Credentials for the legacy scheme. For Bearer: token sent in Authorization header. For HMAC-SHA256: shared secret used to generate signature. Minimum 32 characters. Exchanged out-of-band during onboarding.",
               "minLength": 32
             }
           },


### PR DESCRIPTION
Refs #4270

## Summary

Closes the on-ramp framing gap identified in #4270 — surface 4 of the HMAC→RFC 9421 migration checklist (@bokelley's four-surface plan from #4205):

- **`reporting-webhook.json`**: `authentication.schemes` description called HMAC-SHA256 "recommended for production" and `authentication` description had no deprecation signal. Fixed to match `push-notification-config.json` framing: both schemes are deprecated, RFC 9421 is the preferred profile. Since `authentication` remains in `required[]` in 3.x, the description now says explicitly "This field is required in AdCP 3.x; the requirement is removed in AdCP 4.0."
- **`auth-scheme.json`**: Enum description was silent on deprecation. Updated to label both values as legacy, note that RFC 9421 is the default when authentication is optional, and that both are removed in 4.0.
- **`skills/call-adcp-agent/SKILL.md`**: Added "Webhook signing — omit `authentication` for new integrations" section under "Non-obvious rules every buyer must follow." Closes the silent-default trap: a buyer agent reading only the SKILL.md previously had no guidance that omitting `authentication` selects the RFC 9421 default; reaching for the visible field in the schema would opt the seller into the deprecated HMAC path.

## Non-breaking justification

Description-only changes. No field added or removed, no `required` arrays changed, no enum values added or removed, no wire behavior change. `authentication` remains required in `reporting-webhook.json` in 3.x — the schema structure is unchanged. Changeset: `patch`.

## What is NOT in this PR (flagged for human review)

Two items from #4270 require human/WG decisions before landing:

1. **Making `authentication` optional in `reporting-webhook.json`** — removing from `required[]` is a signing-profile change (playbook: "never patch-eligible: signing profile changes"). Needs `minor` bump and security doc update to explicitly cover `reporting_webhook` signing-mode selection. Routed to `3.1.x`. The open question (per protocol-expert review): does the `webhook_mode_mismatch` downgrade-resistance rule already apply to reporting webhook registrations, or does the security doc need to be extended?

2. **`artifact_webhook` in `create-media-buy-request.json`** — protocol-expert found the same stale "recommended for production" framing on the `authentication.schemes` description there. Not in scope of this PR to keep the change bounded; should be a follow-up.

## Pre-PR review

- **code-reviewer**: approved — all blockers resolved (dead link reverted, required-constraint contradiction fixed, `adagents.json` → `brand.json` corrected per security.mdx §webhook-callbacks); two nits noted (link wraps across two lines in SKILL.md, changeset description updated)
- **ad-tech-protocol-expert**: approved — non-breaking per spec; description-only; `brand.json` is correct for buyer JWKS discovery (security.mdx line 1176, 1201-1206); `authentication` required constraint intact; changeset `patch` correct

**Milestone note:** `gh` CLI unavailable in this run environment — could not confirm the open 3.0.x patch milestone. Please set milestone to the active patch target before merge.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01WczUEAGjbrADfTVX2MWEn6

---
_Generated by [Claude Code](https://claude.ai/code/session_01WczUEAGjbrADfTVX2MWEn6)_