### PR TITLE
fix: stop paging on three expected error classes + plug pg-pool retry gap

### DIFF
--- a/.changeset/quiet-three-expected-errors.md
+++ b/.changeset/quiet-three-expected-errors.md
@@ -1,0 +1,8 @@
+---
+---
+
+Fix three error classes that were incorrectly paging `#aao-errors` via the pino → posthog hook, plus a pg-pool retry gap that turned them into 500s for `/api/notifications/count`.
+
+- **`server/src/db/client.ts`** — `isTransientConnectionError` now matches the `Connection terminated unexpectedly` and `Connection terminated due to connection timeout` messages that pg-pool throws (no error `code`) when the other side closes a pooled connection between checkout and use. The existing one-shot retry now covers the case. Surfaced first by the 30s polling on `/api/notifications/count`. Helper is exported so the classifier has direct unit-test coverage (`server/tests/unit/db-transient-error.test.ts`).
+- **`server/src/routes/agent-oauth.ts`** — the `/start` catch block now logs `OAuthError` (and subclasses) at `warn` instead of `error`. These are agent-side conditions — no metadata at the well-known URL, malformed PRM, AS rejection — not server failures. The user-facing redirect to `/oauth-complete.html` is unchanged. Same convention as the `AuthenticationRequiredError` branch in `server/src/http.ts` and the slack-client expected-error sites.
+- **`server/src/billing/stripe-client.ts`** — `getPriceByLookupKey` now logs the "no price found" miss at `warn` instead of `error`. The lookup key comes from the Addie LLM (`create_payment_link`, `send_invoice`, `confirm_send_invoice`) — a missing key is a tool-shape issue, and the calling handler already returns a structured error to the user. The deeper fix (validate against the cached list before calling Stripe and return `did_you_mean`) is tracked in `TODO(#2550)`.

--- a/server/src/billing/stripe-client.ts
+++ b/server/src/billing/stripe-client.ts
@@ -994,7 +994,9 @@ export async function createAndSendInvoice(
   const priceId = await getPriceByLookupKey(data.lookupKey);
 
   if (!priceId) {
-    logger.error({
+    // Caller-supplied (Addie LLM tool) — getPriceByLookupKey already
+    // logged the available keys at warn. Don't double-page #aao-errors.
+    logger.warn({
       lookupKey: data.lookupKey,
     }, 'No price found for lookup key');
     return null;
@@ -1317,7 +1319,9 @@ export async function validateInvoiceDetails(data: {
 
   const priceId = await getPriceByLookupKey(data.lookupKey);
   if (!priceId) {
-    logger.error({ lookupKey: data.lookupKey }, 'validateInvoiceDetails: No price found');
+    // Caller-supplied (Addie LLM tool) — getPriceByLookupKey already
+    // logged the available keys at warn. Don't double-page #aao-errors.
+    logger.warn({ lookupKey: data.lookupKey }, 'validateInvoiceDetails: No price found');
     return null;
   }
 

--- a/server/src/billing/stripe-client.ts
+++ b/server/src/billing/stripe-client.ts
@@ -349,7 +349,12 @@ export async function getPriceByLookupKey(lookupKey: string): Promise<string | n
   }
 
   const availableLookupKeys = cachedProducts.map(p => p.lookup_key).filter(Boolean);
-  logger.error({ lookupKey, availableLookupKeys },
+  // Caller-supplied (Addie LLM, admin tool) — a missing key is a tool-shape
+  // issue, not a server failure. The caller already returns a structured
+  // error to the user; logging at `warn` keeps the pino → posthog hook
+  // from paging #aao-errors. See TODO(#2550) for the upstream fix
+  // (validate against this list before calling).
+  logger.warn({ lookupKey, availableLookupKeys },
     'getPriceByLookupKey: No price found for lookup key. Available: see structured fields');
   return null;
 }

--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -72,12 +72,22 @@ const TRANSIENT_CONNECTION_ERRORS = new Set([
   "08003", // connection_does_not_exist
 ]);
 
-function isTransientConnectionError(err: unknown): boolean {
+// pg-pool throws plain Errors with these messages and no `code` when the
+// other side closes a pooled connection between checkout and use. Matched
+// as substrings rather than exact set hits.
+const TRANSIENT_CONNECTION_MESSAGES = [
+  "Connection terminated unexpectedly",
+  "Connection terminated due to connection timeout",
+];
+
+export function isTransientConnectionError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   const code = (err as any).code || "";
   const message = err.message || "";
-  return TRANSIENT_CONNECTION_ERRORS.has(code)
-    || TRANSIENT_CONNECTION_ERRORS.has(message);
+  if (TRANSIENT_CONNECTION_ERRORS.has(code) || TRANSIENT_CONNECTION_ERRORS.has(message)) {
+    return true;
+  }
+  return TRANSIENT_CONNECTION_MESSAGES.some((m) => message.includes(m));
 }
 
 /**

--- a/server/src/routes/agent-oauth.ts
+++ b/server/src/routes/agent-oauth.ts
@@ -25,6 +25,7 @@ import {
   AgentVanishedDuringFlowError,
   ConfidentialClientNotAllowedError,
   InvalidOrExpiredFlowError,
+  OAuthError,
   ProtectedResourceMetadataError,
   StateMismatchError,
   TokenExchangeError,
@@ -190,7 +191,18 @@ export function createAgentOAuthRouter(): Router {
       logger.info({ agentUrl: agentContext.agent_url }, 'Starting OAuth flow');
       res.redirect(authorizationUrl);
     } catch (error) {
-      logger.error({ error }, 'Failed to start OAuth flow');
+      // OAuthError (and subclasses) is the SDK's signal that the *agent*
+      // returned bad/missing OAuth data — no metadata at the well-known
+      // URL, malformed PRM, AS rejected the request, etc. That's an
+      // expected third-party state, not a server failure, so log at
+      // `warn` to keep the pino → posthog hook from paging #aao-errors.
+      // Same convention as the `AuthenticationRequiredError` branch in
+      // server/src/http.ts and the slack-client expected-error sites.
+      if (error instanceof OAuthError) {
+        logger.warn({ error, code: error.code }, 'OAuth flow start failed (agent-side)');
+      } else {
+        logger.error({ error }, 'Failed to start OAuth flow');
+      }
       const message = sanitizeErrorMessage(error instanceof Error ? error.message : 'Unknown error');
       res.redirect(`/oauth-complete.html?success=false&error=${encodeURIComponent(message)}`);
     }

--- a/server/tests/unit/db-transient-error.test.ts
+++ b/server/tests/unit/db-transient-error.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { isTransientConnectionError } from '../../src/db/client.js';
+
+function errWithCode(code: string, message = ''): Error {
+  const e = new Error(message);
+  (e as any).code = code;
+  return e;
+}
+
+describe('isTransientConnectionError', () => {
+  it('matches pg error codes that should be retried', () => {
+    expect(isTransientConnectionError(errWithCode('ECONNRESET'))).toBe(true);
+    expect(isTransientConnectionError(errWithCode('EPIPE'))).toBe(true);
+    expect(isTransientConnectionError(errWithCode('57P01'))).toBe(true);
+    expect(isTransientConnectionError(errWithCode('57P03'))).toBe(true);
+    expect(isTransientConnectionError(errWithCode('08006'))).toBe(true);
+    expect(isTransientConnectionError(errWithCode('08003'))).toBe(true);
+  });
+
+  it('matches pg-pool messages that have no error code', () => {
+    expect(isTransientConnectionError(new Error('Connection terminated unexpectedly'))).toBe(true);
+    expect(
+      isTransientConnectionError(new Error('Connection terminated due to connection timeout')),
+    ).toBe(true);
+  });
+
+  it('matches even when the message is wrapped with extra prefix or suffix', () => {
+    expect(
+      isTransientConnectionError(new Error('error: Connection terminated unexpectedly')),
+    ).toBe(true);
+  });
+
+  it('does not match unrelated errors', () => {
+    expect(isTransientConnectionError(new Error('relation "foo" does not exist'))).toBe(false);
+    expect(isTransientConnectionError(errWithCode('23505', 'duplicate key'))).toBe(false);
+    expect(isTransientConnectionError(null)).toBe(false);
+    expect(isTransientConnectionError('string error')).toBe(false);
+    expect(isTransientConnectionError(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Three production errors that fired `:rotating_light: System error` alerts to Addie this morning all turned out to be the same pattern: third-party / user-input-driven conditions logged at `error` and then upgraded to red-light alerts by the pino → posthog hook. One of them (notifications) was also surfacing a real pg-pool retry gap.

- **`server/src/db/client.ts`** — `isTransientConnectionError` now matches pg-pool's codeless `Connection terminated unexpectedly` / `Connection terminated due to connection timeout` strings, so the existing one-shot retry covers them. The `/api/notifications/count` 30s poll surfaced this first; it's not notification-specific.
- **`server/src/routes/agent-oauth.ts`** — `/start` catch block logs `OAuthError` (and subclasses) at `warn` instead of `error`. Triggered today by a user trying to OAuth into `harvingupta.xyz`, which doesn't publish well-known endpoints. User redirect to `/oauth-complete.html` unchanged. Same convention as the `AuthenticationRequiredError` branch in `http.ts:8773` and the slack-client expected-error sites.
- **`server/src/billing/stripe-client.ts`** — `getPriceByLookupKey` logs the "no price found" miss at `warn`. Today's trigger was Addie's LLM hallucinating `company_1b_plus_member` (mashing the `1b_plus` revenue-tier enum + the new "Member" tier name). The calling handler in `billing-tools.ts` already returns a structured error to the user; the deeper fix (validate against the cached list before calling Stripe, return `did_you_mean`) lives in `TODO(#2550)`.

New unit test `server/tests/unit/db-transient-error.test.ts` exercises the transient classifier directly — both the existing pg error codes and the codeless pg-pool messages.

## Test plan
- [x] `npm run test:unit` (ran via precommit)
- [x] `npm run typecheck`
- [ ] Watch `#aao-errors` after deploy: `agent-oauth` and `stripe-client` system-error pages should drop; legitimate failures still page
- [ ] Watch the `notifications.getUnreadCount` 500 rate after deploy — should fall to ~0

🤖 Generated with [Claude Code](https://claude.com/claude-code)