### PR TITLE
schemas(reporting-webhook, auth-scheme): deprecate HMAC-SHA256 recommendation, point at RFC 9421

### DIFF
--- a/.changeset/4270-deprecate-hmac-recommendation-in-schemas.md
+++ b/.changeset/4270-deprecate-hmac-recommendation-in-schemas.md
@@ -1,0 +1,16 @@
+---
+---
+
+schemas(reporting-webhook, auth-scheme): deprecate HMAC-SHA256 recommendation, point at RFC 9421 webhook profile
+
+Two schema-description-only edits, both surgical, no normative change. Surfaces existing `push-notification-config.json` framing at adjacent schemas where SDK authors actually read them.
+
+`reporting-webhook.json` — the `authentication.schemes` description previously said HMAC-SHA256 was "recommended for production". This contradicts `push-notification-config.json` (which marks both Bearer and HMAC-SHA256 as the deprecated legacy fallback, removed in AdCP 4.0). New buyers reading the schema in isolation were being steered toward the legacy on-ramp. Description now mirrors push-notification-config's framing — both schemes deprecated, removed in 4.0, see push-notification-config for the precedence model.
+
+`auth-scheme.json` — the enum's top-level description was silent about deprecation. SDK authors loading the enum in isolation had no signal these were legacy options. Description now states the values are scoped to the legacy `authentication` block and points readers at the RFC 9421 default.
+
+Out of scope (surfaced for maintainer triage):
+
+- `reporting-webhook.json` still has `authentication` in `required: [...]`, which means reporting webhooks have no opt-in path to RFC 9421 today. Mirroring `push-notification-config.json`'s structural shape (auth block optional, omitted = 9421 default) is a separate normative question — filed at #4270 as the broader on-ramp inventory.
+
+Closes the schema-description sub-item of #4270.

--- a/static/schemas/source/core/reporting-webhook.json
+++ b/static/schemas/source/core/reporting-webhook.json
@@ -21,7 +21,7 @@
       "properties": {
         "schemes": {
           "type": "array",
-          "description": "Array of authentication schemes. Supported: ['Bearer'] for simple token auth, ['HMAC-SHA256'] for signature verification (recommended for production)",
+          "description": "Array of authentication schemes. Supported: ['Bearer'] for simple token auth, ['HMAC-SHA256'] for legacy shared-secret signing. Both are deprecated and will be removed in AdCP 4.0; new integrations SHOULD use the RFC 9421 webhook profile (see push-notification-config.json's `authentication` description for the precedence model).",
           "items": {
             "$ref": "/schemas/enums/auth-scheme.json"
           },

--- a/static/schemas/source/enums/auth-scheme.json
+++ b/static/schemas/source/enums/auth-scheme.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/enums/auth-scheme.json",
   "title": "Authentication Scheme",
-  "description": "Authentication schemes for push notification endpoints",
+  "description": "Authentication schemes for the legacy push-notification `authentication` block. Both values are deprecated and will be removed in AdCP 4.0; new integrations SHOULD omit the `authentication` block and use the RFC 9421 webhook profile (see push-notification-config.json).",
   "type": "string",
   "enum": [
     "Bearer",


### PR DESCRIPTION
First pass on the schema-description sub-item of #4270 (storyboard / SDK-skill on-ramp inventory). Surgical, source-only, no normative change — mirrors precedent #2506.

## Why

`push-notification-config.json`'s `authentication` field was already updated in #2506 to mark Bearer / HMAC-SHA256 as the deprecated legacy fallback removed in AdCP 4.0, with RFC 9421 as the default. Two adjacent schemas were left out of that pass and still steer new buyers toward the HMAC on-ramp:

- `static/schemas/source/core/reporting-webhook.json` — `authentication.schemes` description literally says HMAC-SHA256 is _\"recommended for production\"_. Contradicts push-notification-config.json. Active mis-direction for any new buyer reading the schema in isolation.
- `static/schemas/source/enums/auth-scheme.json` — enum-level description doesn't mention deprecation at all. SDK authors loading the enum without cross-referencing push-notification-config.json have no signal these are legacy options.

## What this PR does

1. **`reporting-webhook.json` (1 line)**: replace _\"['HMAC-SHA256'] for signature verification (recommended for production)\"_ with the same _\"both deprecated, removed in 4.0, see push-notification-config\"_ framing already used in push-notification-config.json.
2. **`auth-scheme.json` (1 line)**: extend the description to state these enum values are scoped to the legacy `authentication` block and point readers at the RFC 9421 default.
3. **`.changeset/4270-deprecate-hmac-recommendation-in-schemas.md`**: changeset entry.

No `dist/` regen; `static/schemas/source/` is the source of truth and `build:schemas` regenerates `dist/` at release.

## What's NOT in this PR (deliberately scoped out — maintainer call)

`reporting-webhook.json` has `authentication` in `required: [...]`. That's a structural asymmetry vs `push-notification-config.json` (where the block is optional and absence selects 9421). Today there is **no opt-in path to RFC 9421 for reporting webhooks** — every reporting buyer is forced through the legacy auth block.

That's a normative question, not a description fix, so it stays in #4270 for triage. If the spec intends symmetry with push-notification-config.json, follow-up PR drops `\"authentication\"` from the `required` array and mirrors push-notification-config's framing on the field. Happy to take that as a follow-up if maintainers triage favorably.

## Test plan

- [x] `static/schemas/source/core/reporting-webhook.json` parses (JSON syntactically valid, no schema shape change)
- [x] `static/schemas/source/enums/auth-scheme.json` parses
- [x] No `dist/` files modified — release build regenerates from source
- [ ] CI: schema-validation, json-schema-validation, lint-schema-links (will run on PR)

## Cross-references

- #4270 (parent — storyboard / SDK-skill on-ramp inventory)
- #2506 (precedent — same shape of edit on push-notification-config.json)
- #4205 (RFC 9421 webhook signing migration coordination — on-ramp framing)
- #2423 (original 9421 unification PR)

I have read the IPR Policy