### PR TITLE
skills(call-adcp-agent): document RFC 9421 as default webhook signing path

### DIFF
--- a/.changeset/4270-skill-webhook-signing-on-ramp.md
+++ b/.changeset/4270-skill-webhook-signing-on-ramp.md
@@ -1,0 +1,16 @@
+---
+---
+
+skills(call-adcp-agent): document RFC 9421 as the default webhook signing path
+
+The five protocol skills (`adcp-media-buy`, `adcp-creative`, `adcp-signals`, `adcp-governance`, `adcp-si`, `adcp-brand`) all delegate cross-cutting buyer-side basics to `call-adcp-agent/SKILL.md`. That skill teaches `idempotency_key`, the `account` `oneOf`, `status:'submitted'` polling, and error recovery — but was silent on webhook signing, leaving SDK consumers with no signal that omitting `push_notification_config.authentication` selects the modern RFC 9421 path. A new buyer reading the schema sees a visible `authentication` field and reaches for it; the modern default is invisible from the schema alone.
+
+Adds a "Webhook signing — default to RFC 9421, don't reach for `authentication`" section to the cross-cutting skill, mirroring the framing locked in by #2506 on `push-notification-config.json`. The section covers:
+
+- The default 9421 path (seller publishes JWKS at `brand.json` `agents[].jwks_uri`, buyer verifies — no shared secret on the wire).
+- The switch-not-fallback rule: presence of `authentication` selects legacy; absence selects 9421.
+- Inbound verifier checklist: required covered components, `tag="adcp/webhook-signing/v1"`, `adcp_use="webhook-signing"`, error taxonomy.
+- Pointer at the `compliance/{version}/test-vectors/webhook-signing/` conformance suite as the only deterministic path to cover every `webhook_signature_*` error code.
+- "Use the SDK's verifier; don't roll your own" — RFC 9421 canonicalization is the dominant interop-bug surface.
+
+No normative change — the section surfaces existing rules from `security.mdx` § Webhook callbacks at the on-ramp surface where SDK consumers actually read them. Pairs with the schema-description fix in #4273 (deprecates HMAC-SHA256 recommendation in `reporting-webhook.json` + `auth-scheme.json`); both close pieces of #4270.

--- a/skills/call-adcp-agent/SKILL.md
+++ b/skills/call-adcp-agent/SKILL.md
@@ -79,6 +79,18 @@ A mutating tool can return one of three shapes:
 
 When you see `status: 'submitted'`, the work is NOT complete. Poll via `tasks/get` (A2A) or the MCP async task extension, using the `task_id`. Over A2A the AdCP `task_id` also rides on `artifact.metadata.adcp_task_id` — both work.
 
+### Webhook signing — default to RFC 9421, don't reach for `authentication`
+
+For async flows the seller signs outbound webhook deliveries. The default is the AdCP RFC 9421 webhook-signing profile: the seller publishes a webhook-signing key at the `jwks_uri` on its `brand.json` `agents[]` entry, and the buyer verifies using that JWKS. No shared secret crosses the wire.
+
+**Don't populate `push_notification_config.authentication`** unless you specifically need the legacy Bearer / HMAC-SHA256 fallback. It's deprecated (removed in AdCP 4.0), and per [#2506](https://github.com/adcontextprotocol/adcp/pull/2506) **presence of the block selects the legacy scheme; absence selects 9421** — it's a switch, not a fallback. A buyer MUST NOT attempt "try 9421 first, fall back to HMAC" verification; signature mode is determined solely by whether the block was present at registration time. New integrations: omit the block.
+
+Verifier path on inbound webhooks: load the seller's JWKS from its `brand.json` `agents[].jwks_uri`, then verify per the [verifier checklist for webhooks](https://adcontextprotocol.org/docs/building/implementation/security#verifier-checklist-for-webhooks). Required covered components are `@method`, `@authority`, `@target-uri`, `content-type`, and `content-digest` (no policy branch on webhooks — `content-digest` MUST be covered); `tag="adcp/webhook-signing/v1"`; the verifying JWK MUST carry `adcp_use="webhook-signing"`. Reject with the matching `webhook_signature_*` code from the [error taxonomy](https://adcontextprotocol.org/docs/building/implementation/security#webhook-error-taxonomy).
+
+Conformance vectors at `https://adcontextprotocol.org/compliance/{version}/test-vectors/webhook-signing/` cover every `webhook_signature_*` error code deterministically. Run them in CI before trusting your verifier — RFC 9421 canonicalization disagreements are the [#1 silent interop bug](https://adcontextprotocol.org/compliance/latest/test-vectors/request-signing/) and the only reliable way to surface them is the static negative-vector suite.
+
+SDKs that ship a 9421 webhook verifier (e.g. `@adcp/sdk` 5.25.0+ on TypeScript) wire all of the above for you. Use it; don't roll your own.
+
 ### `packages[*]` on media buys
 
 ```json


### PR DESCRIPTION
Second leg of the two-PR shape proposed in #4270 (storyboard / SDK-skill on-ramp inventory). Pairs with #4273 (schema-description fix for `reporting-webhook.json` + `auth-scheme.json`) — independent landing order, both close pieces of #4270.

## Why

The five protocol skills (`adcp-media-buy`, `adcp-creative`, `adcp-signals`, `adcp-governance`, `adcp-si`, `adcp-brand`) all defer cross-cutting buyer-side basics with:

> Buyer-side basics — idempotency replay, `oneOf` variants, async `status:'submitted'` polling, error recovery from `adcp_error.issues[]` — live in `skills/call-adcp-agent/SKILL.md`.

That skill teaches `idempotency_key`, the `account` `oneOf`, `status:'submitted'` polling, and error recovery — but **was silent on webhook signing**. New buyers reading `push-notification-config.json` see a visible `authentication` field and reach for it; the modern 9421 default (omit the block, verify against the seller's JWKS) is invisible from the schema alone. That's the silent-default trap I called out in #4270 inventory.

This PR adds a section to the cross-cutting skill so all five protocol skills inherit the framing.

## What this PR does

Single new H3 in `skills/call-adcp-agent/SKILL.md` titled _\"Webhook signing — default to RFC 9421, don't reach for `authentication`\"_, placed inside _\"Non-obvious rules every buyer must follow\"_ right after the async-polling section. Covers:

- **Default 9421 path** — seller publishes a webhook-signing key at `brand.json` `agents[].jwks_uri`; buyer verifies via that JWKS; no shared secret on the wire.
- **Switch-not-fallback rule** (per #2506) — presence of `push_notification_config.authentication` selects legacy; absence selects 9421. Buyer MUST NOT attempt try-9421-then-HMAC verification.
- **Inbound verifier checklist** — required covered components (`@method`, `@authority`, `@target-uri`, `content-type`, `content-digest` — all required on webhooks; no policy branch); `tag=\"adcp/webhook-signing/v1\"`; `adcp_use=\"webhook-signing\"`; error taxonomy `webhook_signature_*`.
- **Conformance vectors** — pointer at `compliance/{version}/test-vectors/webhook-signing/` as the only deterministic path to cover every `webhook_signature_*` error code.
- **\"Use the SDK's verifier\"** — explicit nudge against rolling your own; RFC 9421 canonicalization is the dominant interop-bug surface (cross-references the canonicalization-bug language already in `request-signing/README.md`).

Plus a changeset entry mirroring the convention from #2506.

## What this PR does NOT do

- No schema changes (those live in #4273).
- No normative change — the section surfaces existing rules from `security.mdx` § Webhook callbacks at the on-ramp surface where SDK consumers actually read them.
- No edits to the per-protocol skills (`adcp-media-buy`, `adcp-signals`, etc.) — they delegate to `call-adcp-agent` already, so this single addition flows through.
- No `dist/` regen; `skills/` is the source.

## Test plan

- [x] Markdown renders cleanly (no broken anchor refs in the existing skill)
- [x] Anchor URLs in the new section resolve (`docs/building/implementation/security#verifier-checklist-for-webhooks`, `#webhook-error-taxonomy`)
- [x] Cross-link to #2506 + the test-vector path is correct
- [ ] CI lint:schema-links (will run on PR — note: this PR doesn't touch schema files but the linter scope check is good)

## Cross-references

- #4270 (parent — storyboard / SDK-skill on-ramp inventory)
- #4273 (sibling PR — schema-description fixes; same close-piece)
- #2506 (precedent — push-notification-config.json switch-not-fallback framing)
- #4205 (RFC 9421 webhook signing migration coordination — on-ramp framing)
- #2423 (original 9421 unification PR)

I have read the IPR Policy