### PR TITLE
fix(registry): dashboard probe sends owner-saved auth token

### DIFF
--- a/.changeset/dashboard-probe-uses-saved-bearer.md
+++ b/.changeset/dashboard-probe-uses-saved-bearer.md
@@ -1,0 +1,10 @@
+---
+---
+
+Dashboard "Recheck" probe now sends the agent's saved auth token. Previously the probe path (`POST /api/registry/agents/:encodedUrl/refresh` → `crawler.refreshSingleAgent` → `capabilityDiscovery.discoverCapabilities` → `discoverMCPTools`) constructed the `AdCPClient` with no auth fields, so any agent gated behind a static bearer (or saved OAuth) returned 401 → wrapped as `AuthenticationRequiredError` → reported as "Offline · 0 tools · type unknown · OAuth required" — even when `evaluate_agent_quality` worked fine using the same saved token (escalation: Warren Fernandes / Media.net, agent at `seller-platform.aitools.access.mn/mcp`, hint `****8Txk`).
+
+The route now resolves owner-org auth via the existing `resolveUserAgentAuth` + `adaptAuthForSdk` helpers and threads it through `refreshSingleAgent` → `discoverCapabilities`, `checkHealth`, `getStats` → SDK `AgentConfig.auth_token` / `headers` / `oauth_tokens` fields. A2A health probes (raw fetch to `/.well-known/agent.json`) gain the same `Authorization` header. The periodic crawl path stays unauthenticated by design (it scans the public federated index across all orgs).
+
+When auth is provided, the discovery / health / formats caches are both read-bypassed (so a manual refresh sees fresh state) and write-bypassed (so an authed-discovered profile — which may include tools the agent only exposes behind credentials — never leaks into the shared cache that feeds unauthed periodic crawls and the public registry render).
+
+OAuth client_credentials variants pre-exchange via the existing `adaptAuthForSdk` adapter and probe with the resulting bearer. Authorization-code OAuth (saved `oauth_tokens` + `oauth_client`) probes with the current access token; refresh-on-401 inside the probe is not wired because `oauth_client` doesn't carry a `token_endpoint`. If the saved token has expired, the owner re-authorizes via the existing OAuth flow and re-probes. Static bearer (the original report) works fully.

--- a/server/src/capabilities.ts
+++ b/server/src/capabilities.ts
@@ -4,6 +4,7 @@ import { createLogger } from "./logger.js";
 import { is401Error, AuthenticationRequiredError } from "@adcp/sdk";
 import { AAO_UA_DISCOVERY } from "./config/user-agents.js";
 import { logOutboundRequest } from "./db/outbound-log-db.js";
+import { agentConfigAuthFields, type SdkAuth } from "./services/sdk-auth-adapter.js";
 
 const logger = createLogger('capabilities');
 
@@ -265,16 +266,21 @@ export class CapabilityDiscovery {
     this.formatsService = new FormatsService();
   }
 
-  async discoverCapabilities(agent: Agent): Promise<AgentCapabilityProfile> {
-    const cached = this.cache.get(agent.url);
-    if (cached && Date.now() - new Date(cached.last_discovered).getTime() < this.CACHE_TTL_MS) {
-      return cached;
+  async discoverCapabilities(agent: Agent, auth?: SdkAuth): Promise<AgentCapabilityProfile> {
+    // Skip cache when auth is provided — manual owner-triggered refresh
+    // wants fresh data and may previously have cached an unauthed
+    // discovery_error result. Periodic crawls (no auth) keep the cache.
+    if (!auth) {
+      const cached = this.cache.get(agent.url);
+      if (cached && Date.now() - new Date(cached.last_discovered).getTime() < this.CACHE_TTL_MS) {
+        return cached;
+      }
     }
 
     const startTime = Date.now();
     try {
       const protocol = agent.protocol || "mcp";
-      const tools = await this.discoverTools(agent.url, protocol);
+      const tools = await this.discoverTools(agent.url, protocol, auth);
 
       logOutboundRequest({
         agent_url: agent.url,
@@ -298,7 +304,7 @@ export class CapabilityDiscovery {
         profile.standard_operations = this.analyzeSalesCapabilities(tools);
       }
       if (CapabilityDiscovery.CREATIVE_TOOLS.some(t => toolNames.has(t))) {
-        profile.creative_capabilities = await this.analyzeCreativeCapabilities(agent, tools);
+        profile.creative_capabilities = await this.analyzeCreativeCapabilities(agent, tools, auth);
       }
       if (CapabilityDiscovery.SIGNALS_TOOLS.some(t => toolNames.has(t))) {
         profile.signals_capabilities = this.analyzeSignalsCapabilities(tools);
@@ -307,11 +313,15 @@ export class CapabilityDiscovery {
       // tool names — only fetch when the agent actually exposes the tool, so
       // sales/creative/signals agents don't incur an extra round-trip.
       if (toolNames.has('get_adcp_capabilities')) {
-        const measurement = await this.fetchMeasurementCapabilities(agent);
+        const measurement = await this.fetchMeasurementCapabilities(agent, auth);
         if (measurement) profile.measurement_capabilities = measurement;
       }
 
-      this.cache.set(agent.url, profile);
+      // Don't cache authed-discovery results in the shared cache — the
+      // tool list an agent advertises behind auth may differ from the
+      // public-facing one, and the cache is read by unauthed periodic
+      // crawls + the public registry render.
+      if (!auth) this.cache.set(agent.url, profile);
       return profile;
     } catch (error: any) {
       logOutboundRequest({
@@ -332,23 +342,24 @@ export class CapabilityDiscovery {
         discovery_error: error.message,
         oauth_required: isOAuthError,
       };
-      // Don't cache OAuth errors - user may authorize and retry
-      if (!isOAuthError) {
+      // Don't cache OAuth errors - user may authorize and retry.
+      // Don't cache authed probes (see successful-path comment above).
+      if (!isOAuthError && !auth) {
         this.cache.set(agent.url, errorProfile);
       }
       return errorProfile;
     }
   }
 
-  private async discoverTools(url: string, protocol: "mcp" | "a2a"): Promise<ToolCapability[]> {
+  private async discoverTools(url: string, protocol: "mcp" | "a2a", auth?: SdkAuth): Promise<ToolCapability[]> {
     if (protocol === "a2a") {
-      return this.discoverA2ATools(url);
+      return this.discoverA2ATools(url, auth);
     } else {
-      return this.discoverMCPTools(url);
+      return this.discoverMCPTools(url, auth);
     }
   }
 
-  private async discoverMCPTools(url: string): Promise<ToolCapability[]> {
+  private async discoverMCPTools(url: string, auth?: SdkAuth): Promise<ToolCapability[]> {
     try {
       // Use AdCPClient to connect to agent
       const { AdCPClient } = await import("@adcp/sdk");
@@ -357,6 +368,7 @@ export class CapabilityDiscovery {
         name: "Discovery Client",
         agent_uri: url,
         protocol: "mcp",
+        ...agentConfigAuthFields(auth),
       }], { userAgent: AAO_UA_DISCOVERY });
       const client = multiClient.agent("discovery");
 
@@ -385,7 +397,7 @@ export class CapabilityDiscovery {
     }
   }
 
-  private async discoverA2ATools(url: string): Promise<ToolCapability[]> {
+  private async discoverA2ATools(url: string, auth?: SdkAuth): Promise<ToolCapability[]> {
     try {
       // Use AdCPClient to connect to agent
       const { AdCPClient } = await import("@adcp/sdk");
@@ -394,6 +406,7 @@ export class CapabilityDiscovery {
         name: "Discovery Client",
         agent_uri: url,
         protocol: "a2a",
+        ...agentConfigAuthFields(auth),
       }], { userAgent: AAO_UA_DISCOVERY });
       const client = multiClient.agent("discovery");
 
@@ -466,14 +479,14 @@ export class CapabilityDiscovery {
     };
   }
 
-  private async analyzeCreativeCapabilities(agent: Agent, tools: ToolCapability[]): Promise<CreativeCapabilities> {
+  private async analyzeCreativeCapabilities(agent: Agent, tools: ToolCapability[], auth?: SdkAuth): Promise<CreativeCapabilities> {
     const toolNames = new Set(tools.map((t) => t.name.toLowerCase()));
     const hasFormatTool = toolNames.has("list_creative_formats");
 
     let formats: string[] = [];
     if (hasFormatTool) {
       try {
-        const formatsProfile = await this.formatsService.getFormatsForAgent(agent);
+        const formatsProfile = await this.formatsService.getFormatsForAgent(agent, auth);
         formats = formatsProfile.formats.map(f => f.name);
       } catch (error: any) {
         logger.debug({ url: agent.url, error: error.message }, 'Format discovery failed');
@@ -510,7 +523,7 @@ export class CapabilityDiscovery {
    * caller (the catch block in discoverCapabilities) records the error in
    * `discovery_error` so the registry panel surfaces it.
    */
-  private async fetchMeasurementCapabilities(agent: Agent): Promise<MeasurementCapabilities | undefined> {
+  private async fetchMeasurementCapabilities(agent: Agent, auth?: SdkAuth): Promise<MeasurementCapabilities | undefined> {
     try {
       const { AdCPClient } = await import("@adcp/sdk");
       const multiClient = new AdCPClient([{
@@ -518,6 +531,7 @@ export class CapabilityDiscovery {
         name: "Discovery Client",
         agent_uri: agent.url,
         protocol: agent.protocol || "mcp",
+        ...agentConfigAuthFields(auth),
       }], { userAgent: AAO_UA_DISCOVERY });
       const client = multiClient.agent("discovery");
 

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -17,6 +17,7 @@ import type { CatalogEventsDatabase, WriteEventInput } from "./db/catalog-events
 import type { AgentInventoryProfilesDatabase, ProfileUpsertInput } from "./db/agent-inventory-profiles-db.js";
 import { query } from "./db/client.js";
 import { insertTypeReclassification } from "./db/type-reclassification-log-db.js";
+import type { SdkAuth } from "./services/sdk-auth-adapter.js";
 
 const log = createLogger('crawler');
 
@@ -721,7 +722,7 @@ export class CrawlerService {
    * route handler maps that to a 502 so the user sees why the refresh
    * couldn't happen (timeout, DNS, OAuth wall, etc).
    */
-  async refreshSingleAgent(agentUrl: string): Promise<{
+  async refreshSingleAgent(agentUrl: string, options: { auth?: SdkAuth } = {}): Promise<{
     online: boolean;
     tools_count: number | null;
     response_time_ms: number | null;
@@ -732,6 +733,7 @@ export class CrawlerService {
     error?: string;
   }> {
     const PROBE_TIMEOUT_MS = 10000;
+    const { auth } = options;
 
     const pausedUrls = await this.getPausedAgentUrls();
     if (pausedUrls.has(agentUrl)) {
@@ -758,7 +760,7 @@ export class CrawlerService {
     };
 
     const profile = await Promise.race([
-      this.capabilityDiscovery.discoverCapabilities(agent),
+      this.capabilityDiscovery.discoverCapabilities(agent, auth),
       new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error('Probe timeout')), PROBE_TIMEOUT_MS)
       ),
@@ -770,7 +772,7 @@ export class CrawlerService {
 
     const [health, stats] = await Promise.all([
       Promise.race([
-        this.healthChecker.checkHealth(agentForHealth),
+        this.healthChecker.checkHealth(agentForHealth, auth),
         new Promise<never>((_, reject) =>
           setTimeout(() => reject(new Error('Health timeout')), PROBE_TIMEOUT_MS)
         ),
@@ -780,7 +782,7 @@ export class CrawlerService {
         error: err instanceof Error ? err.message : 'health check failed',
       })),
       Promise.race([
-        this.healthChecker.getStats(agentForHealth),
+        this.healthChecker.getStats(agentForHealth, auth),
         new Promise<never>((_, reject) =>
           setTimeout(() => reject(new Error('Stats timeout')), PROBE_TIMEOUT_MS)
         ),

--- a/server/src/formats.ts
+++ b/server/src/formats.ts
@@ -1,6 +1,7 @@
 import { AdCPClient } from "@adcp/sdk";
 import type { Agent, FormatInfo } from "./types.js";
 import { AAO_UA_DISCOVERY } from "./config/user-agents.js";
+import { agentConfigAuthFields, type SdkAuth } from "./services/sdk-auth-adapter.js";
 
 export interface AgentFormatsProfile {
   agent_url: string;
@@ -14,10 +15,12 @@ export class FormatsService {
   private cache: Map<string, AgentFormatsProfile> = new Map();
   private readonly CACHE_TTL_MS = 15 * 60 * 1000; // 15 minutes
 
-  async getFormatsForAgent(agent: Agent): Promise<AgentFormatsProfile> {
-    const cached = this.cache.get(agent.url);
-    if (cached && Date.now() - new Date(cached.last_fetched).getTime() < this.CACHE_TTL_MS) {
-      return cached;
+  async getFormatsForAgent(agent: Agent, auth?: SdkAuth): Promise<AgentFormatsProfile> {
+    if (!auth) {
+      const cached = this.cache.get(agent.url);
+      if (cached && Date.now() - new Date(cached.last_fetched).getTime() < this.CACHE_TTL_MS) {
+        return cached;
+      }
     }
 
     let formats: FormatInfo[] = [];
@@ -29,6 +32,7 @@ export class FormatsService {
         name: agent.name,
         agent_uri: agent.url,
         protocol: (agent.protocol || "mcp") as "mcp" | "a2a",
+        ...agentConfigAuthFields(auth),
       };
       const multiClient = new AdCPClient([agentConfig], { userAgent: AAO_UA_DISCOVERY });
       const client = multiClient.agent(agent.name);
@@ -65,7 +69,10 @@ export class FormatsService {
       error,
     };
 
-    this.cache.set(agent.url, profile);
+    // Don't cache authed-discovery results — the format list returned
+    // with credentials may differ from the public-facing one, and this
+    // cache feeds unauthed callers.
+    if (!auth) this.cache.set(agent.url, profile);
     return profile;
   }
 

--- a/server/src/health.ts
+++ b/server/src/health.ts
@@ -7,6 +7,7 @@ import { logOutboundRequest } from "./db/outbound-log-db.js";
 import { safeFetch } from "./utils/url-security.js";
 import { logger } from "./logger.js";
 import { promises as dnsPromises } from "node:dns";
+import { agentConfigAuthFields, type SdkAuth } from "./services/sdk-auth-adapter.js";
 
 export interface ClassifiedProbeError {
   kind: ProbeErrorKind;
@@ -156,23 +157,30 @@ export class HealthChecker {
     this.formatsService = new FormatsService();
   }
 
-  async checkHealth(agent: Agent): Promise<AgentHealth> {
-    const cached = this.healthCache.get(agent.url);
-    if (cached) return cached;
+  async checkHealth(agent: Agent, auth?: SdkAuth): Promise<AgentHealth> {
+    // Skip cache when auth is provided — manual owner-triggered refresh
+    // wants fresh data. Periodic crawls (no auth) keep the cache.
+    if (!auth) {
+      const cached = this.healthCache.get(agent.url);
+      if (cached) return cached;
+    }
 
-    const health = await this.performHealthCheck(agent);
-    this.healthCache.set(agent.url, health);
+    const health = await this.performHealthCheck(agent, auth);
+    // Don't write authed probe results back to the shared cache —
+    // tools_count discovered with credentials may differ from what
+    // the agent exposes publicly, and the cache feeds unauthed reads.
+    if (!auth) this.healthCache.set(agent.url, health);
     return health;
   }
 
-  private async performHealthCheck(agent: Agent): Promise<AgentHealth> {
+  private async performHealthCheck(agent: Agent, auth?: SdkAuth): Promise<AgentHealth> {
     const startTime = Date.now();
     const protocol = agent.protocol || "mcp";
 
     // Only try the protocol the agent declares
     const health = protocol === "a2a"
-      ? await this.tryA2A(agent, startTime)
-      : await this.tryMCP(agent, startTime);
+      ? await this.tryA2A(agent, startTime, auth)
+      : await this.tryMCP(agent, startTime, auth);
 
     logOutboundRequest({
       agent_url: agent.url,
@@ -186,7 +194,7 @@ export class HealthChecker {
     return health;
   }
 
-  private async tryMCP(agent: Agent, startTime: number): Promise<AgentHealth> {
+  private async tryMCP(agent: Agent, startTime: number, auth?: SdkAuth): Promise<AgentHealth> {
     try {
       // Use AdCPClient to handle MCP protocol complexity (sessions, SSE, etc.)
       const { AdCPClient } = await import("@adcp/sdk");
@@ -195,6 +203,7 @@ export class HealthChecker {
         name: "Health Checker",
         agent_uri: agent.url,
         protocol: "mcp",
+        ...agentConfigAuthFields(auth),
       }], { userAgent: AAO_UA_HEALTH_CHECK });
       const client = multiClient.agent("health-check");
 
@@ -276,13 +285,26 @@ export class HealthChecker {
     }
   }
 
-  private async tryA2A(agent: Agent, startTime: number): Promise<AgentHealth> {
+  private async tryA2A(agent: Agent, startTime: number, auth?: SdkAuth): Promise<AgentHealth> {
     try {
       // Check for A2A agent card at /.well-known/agent.json
       const agentCardUrl = `${agent.url.replace(/\/$/, "")}/.well-known/agent.json`;
+      const headers: Record<string, string> = { 'User-Agent': AAO_UA_HEALTH_CHECK };
+      const authFields = agentConfigAuthFields(auth);
+      if (authFields.auth_token) {
+        headers['Authorization'] = `Bearer ${authFields.auth_token}`;
+      } else if (authFields.headers?.Authorization) {
+        headers['Authorization'] = authFields.headers.Authorization;
+      } else if (authFields.oauth_tokens?.access_token) {
+        headers['Authorization'] = `Bearer ${authFields.oauth_tokens.access_token}`;
+      }
       const response = await fetch(agentCardUrl, {
-        headers: { 'User-Agent': AAO_UA_HEALTH_CHECK },
+        headers,
         signal: AbortSignal.timeout(5000),
+        // Don't let the saved Authorization header travel to a different
+        // origin via a 302 — if the agent host gets compromised that's a
+        // credential exfil vector.
+        redirect: 'error',
       });
 
       if (!response.ok) {
@@ -314,33 +336,35 @@ export class HealthChecker {
     }
   }
 
-  async getStats(agent: Agent): Promise<AgentStats> {
-    const cached = this.statsCache.get(agent.url);
-    if (cached) return cached;
+  async getStats(agent: Agent, auth?: SdkAuth): Promise<AgentStats> {
+    if (!auth) {
+      const cached = this.statsCache.get(agent.url);
+      if (cached) return cached;
+    }
 
-    const stats = await this.fetchStats(agent);
-    this.statsCache.set(agent.url, stats);
+    const stats = await this.fetchStats(agent, auth);
+    if (!auth) this.statsCache.set(agent.url, stats);
     return stats;
   }
 
-  private async fetchStats(agent: Agent): Promise<AgentStats> {
+  private async fetchStats(agent: Agent, auth?: SdkAuth): Promise<AgentStats> {
     const stats: AgentStats = {};
 
     try {
       if (agent.type === "sales") {
         // Use PropertyIndex if available (populated by crawler)
         const index = getPropertyIndex();
-        const auth = index.getAgentAuthorizations(agent.url);
+        const authorizations = index.getAgentAuthorizations(agent.url);
 
-        if (auth && auth.properties.length > 0) {
-          stats.property_count = auth.properties.length;
-          stats.publishers = auth.publisher_domains;
-          stats.publisher_count = auth.publisher_domains.length;
+        if (authorizations && authorizations.properties.length > 0) {
+          stats.property_count = authorizations.properties.length;
+          stats.publishers = authorizations.publisher_domains;
+          stats.publisher_count = authorizations.publisher_domains.length;
         }
       } else if (agent.type === "creative") {
         // For creative agents, get format count from FormatsService
         try {
-          const formatsProfile = await this.formatsService.getFormatsForAgent(agent);
+          const formatsProfile = await this.formatsService.getFormatsForAgent(agent, auth);
           if (formatsProfile.formats && formatsProfile.formats.length > 0) {
             stats.creative_formats = formatsProfile.formats.length;
           }

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -91,7 +91,7 @@ import { BulkPropertyCheckService } from "../services/bulk-property-check.js";
 import { ComplianceDatabase, type LifecycleStage } from "../db/compliance-db.js";
 import { AgentSnapshotDatabase } from "../db/agent-snapshot-db.js";
 import { resolveUserAgentAuth } from "./helpers/resolve-user-agent-auth.js";
-import { adaptAuthForSdk } from "../services/sdk-auth-adapter.js";
+import { adaptAuthForSdk, type SdkAuth } from "../services/sdk-auth-adapter.js";
 import { parseOAuthClientCredentialsInput } from "./helpers/oauth-client-credentials-input.js";
 import { isOAuthRequiredErrorMessage } from "./helpers/oauth-error-detection.js";
 import { AgentContextDatabase } from "../db/agent-context-db.js";
@@ -5122,8 +5122,21 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       // Owner sees 502/409 error → has 60s to fix and try again.
       refreshAgentRateLimits.set(agentUrl, now);
 
+      // Resolve saved owner auth (static bearer / basic / OAuth) so the
+      // probe sees the same credentials evaluate_agent_quality uses. The
+      // periodic crawl path stays unauthenticated by design. Auth is
+      // only resolved when the caller belongs to the owning org —
+      // resolveAgentOwnerOrg returns null for an AAO admin probing an
+      // agent they don't own, so the admin path probes unauthed.
+      const ownerOrgId = await resolveAgentOwnerOrg(req.user.id, agentUrl);
+      let resolvedAuth: SdkAuth | undefined;
+      if (ownerOrgId) {
+        const auth = await resolveUserAgentAuth(agentContextDb, ownerOrgId, agentUrl, logger);
+        resolvedAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `refresh:${agentUrl}` });
+      }
+
       try {
-        const result = await crawler.refreshSingleAgent(agentUrl);
+        const result = await crawler.refreshSingleAgent(agentUrl, { auth: resolvedAuth });
         return res.json(result);
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Probe failed';

--- a/server/src/services/sdk-auth-adapter.ts
+++ b/server/src/services/sdk-auth-adapter.ts
@@ -67,3 +67,39 @@ export async function adaptAuthForSdk(
     }
   }
 }
+
+/**
+ * Subset of `AgentConfig` (from `@adcp/sdk`) populated from saved auth.
+ * Spread into the config literal passed to `new AdCPClient(...)` to make
+ * authenticated probe / discovery / health calls. Bearer maps to
+ * `auth_token`; basic maps to a pre-encoded `Authorization: Basic …`
+ * header; oauth maps to the `oauth_tokens` + `oauth_client` shape the
+ * SDK refreshes on 401.
+ */
+export type AgentConfigAuthFields = {
+  auth_token?: string;
+  headers?: Record<string, string>;
+  oauth_tokens?: {
+    access_token: string;
+    refresh_token: string;
+    expires_at?: string;
+  };
+  oauth_client?: { client_id: string; client_secret?: string };
+};
+
+export function agentConfigAuthFields(auth: SdkAuth | undefined): AgentConfigAuthFields {
+  if (!auth) return {};
+  switch (auth.type) {
+    case 'bearer':
+      return { auth_token: auth.token };
+    case 'basic': {
+      const encoded = Buffer.from(`${auth.username}:${auth.password}`).toString('base64');
+      return { headers: { Authorization: `Basic ${encoded}` } };
+    }
+    case 'oauth': {
+      const fields: AgentConfigAuthFields = { oauth_tokens: auth.tokens };
+      if (auth.client) fields.oauth_client = auth.client;
+      return fields;
+    }
+  }
+}

--- a/server/tests/integration/registry-api-agent-refresh.test.ts
+++ b/server/tests/integration/registry-api-agent-refresh.test.ts
@@ -35,6 +35,7 @@ const ALL_OWNED_URLS = [
   ownedAgentUrl('probe-fail'),
   ownedAgentUrl('paused'),
   ownedAgentUrl('rate-limit'),
+  ownedAgentUrl('saved-bearer'),
 ];
 
 // Toggle which user the auth middleware stamps onto the request. Tests
@@ -95,8 +96,8 @@ vi.mock('../../src/addie/admin-status-lookup.js', () => ({
 const refreshSingleAgentMock = vi.fn();
 vi.mock('../../src/crawler.js', async () => {
   const actual = await vi.importActual<typeof import('../../src/crawler.js')>('../../src/crawler.js');
-  actual.CrawlerService.prototype.refreshSingleAgent = function (agentUrl: string) {
-    return refreshSingleAgentMock(agentUrl);
+  actual.CrawlerService.prototype.refreshSingleAgent = function (agentUrl: string, options?: unknown) {
+    return refreshSingleAgentMock(agentUrl, options);
   };
   return actual;
 });
@@ -178,7 +179,7 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
       inferred_type: 'governance',
       type_promoted: true,
     });
-    expect(refreshSingleAgentMock).toHaveBeenCalledWith(agentUrl);
+    expect(refreshSingleAgentMock).toHaveBeenCalledWith(agentUrl, expect.any(Object));
   });
 
   it('admin can refresh an agent they do not own', async () => {
@@ -186,7 +187,7 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
     const agentUrl = ownedAgentUrl('admin');
     const res = await request(app).post(url(agentUrl)).send();
     expect(res.status).toBe(200);
-    expect(refreshSingleAgentMock).toHaveBeenCalledWith(agentUrl);
+    expect(refreshSingleAgentMock).toHaveBeenCalledWith(agentUrl, expect.any(Object));
   });
 
   it('non-owner non-admin gets 403', async () => {
@@ -237,5 +238,34 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
     const second = await request(app).post(url(agentUrl)).send();
     expect(second.status).toBe(429);
     expect(second.body.retry_after).toBeGreaterThan(0);
+  });
+
+  // Regression: dashboard probe was constructing AdCPClient with no auth,
+  // so any agent gated behind a static bearer reported "OAuth required"
+  // even though evaluate_agent_quality (which resolves saved auth) worked
+  // fine. The route now resolves owner-org auth and threads it to the
+  // crawler so the probe sees the same credentials.
+  it('threads the org-saved bearer token to the crawler', async () => {
+    const agentUrl = ownedAgentUrl('saved-bearer');
+    const { AgentContextDatabase } = await import('../../src/db/agent-context-db.js');
+    const db = new AgentContextDatabase();
+    const context = await db.create({
+      organization_id: TEST_ORG_ID,
+      agent_url: agentUrl,
+      created_by: OWNER_USER_ID,
+    });
+    const FAKE_BEARER = 'fake-test-bearer-do-not-use-in-prod';
+    await db.saveAuthToken(context.id, FAKE_BEARER, 'bearer');
+
+    const res = await request(app).post(url(agentUrl)).send();
+    expect(res.status).toBe(200);
+    expect(refreshSingleAgentMock).toHaveBeenCalledWith(
+      agentUrl,
+      expect.objectContaining({
+        auth: { type: 'bearer', token: FAKE_BEARER },
+      }),
+    );
+
+    await pool.query('DELETE FROM agent_contexts WHERE id = $1', [context.id]);
   });
 });


### PR DESCRIPTION
## Summary

- Dashboard "Recheck" was constructing `AdCPClient` with no auth, so any agent gated behind a static bearer reported "Offline · 0 tools · type unknown · OAuth required" even when `evaluate_agent_quality` worked fine with the same saved token. Reported by Warren Fernandes (Media.net) for `seller-platform.aitools.access.mn/mcp` (token hint `****8Txk`).
- The route now resolves owner-org auth via the existing `resolveUserAgentAuth` + `adaptAuthForSdk` helpers and threads it through `refreshSingleAgent` → `discoverCapabilities`, `checkHealth`, `getStats`, and the A2A agent-card fetch. Periodic crawl path stays unauthenticated by design (federated index across all orgs).
- Caches in capabilities/health/formats both read-bypass and write-bypass when auth is provided, so an authed-discovered profile (potentially including auth-only tools) never lands in the shared cache that feeds unauthed periodic crawls and the public registry render.

## Why this scope

Considered delegating to `comply()` (the path `evaluate_agent_quality` uses) but rejected — comply runs the full storyboard suite (~30s, 5-30 live tool calls) for what should be a lightweight tools/list probe. The SDK's `AgentConfig` already exposes `auth_token` / `oauth_tokens` / `headers` directly; threading auth is ~30 lines and preserves dashboard probe semantics.

OAuth `client_credentials` works fully (pre-exchanges via existing adapter). Authorization-code OAuth probes with the current access token but won't refresh-on-401 inside the probe (saved `oauth_client` doesn't carry `token_endpoint`); owner re-authorizes and re-probes. Static bearer (the actual report) works fully.

## Test plan

- [x] `npx tsc -p server/tsconfig.json --noEmit` clean
- [x] Targeted unit tests pass (`tests/unit/` filtered to formats/health/capabilities/crawler)
- [x] Pre-commit hooks (full unit suite + dynamic-imports + callapi-state-change + typecheck) green
- [x] Updated `tests/integration/registry-api-agent-refresh.test.ts` mock to forward the new `(agentUrl, options)` signature; added a regression test that saves a bearer in `agent_contexts` and asserts the route threads `{ auth: { type: 'bearer', token } }` to `refreshSingleAgent`
- [ ] Smoke after deploy: Warren's agent (`seller-platform.aitools.access.mn/mcp`) Recheck now reports online + tools count

## Reviewer findings (all addressed)

- code-reviewer flagged A2A branch un-threaded → fixed (`tryA2A` now applies bearer/basic/oauth header)
- security-reviewer flagged cache-poisoning visibility leak → fixed (cache.set gated on `!auth` everywhere)
- security-reviewer follow-up flagged credential exfil via redirect → fixed (`redirect: 'error'` on A2A fetch)
- protocol-expert verified bearer/basic mapping correct; documented OAuth-refresh limitation in changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)