### PR TITLE
feat(member-tools): nudge publisher/adtech org admins to populate brand.json properties

### DIFF
--- a/.changeset/member-dash-brand-properties-nudge.md
+++ b/.changeset/member-dash-brand-properties-nudge.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add a setup-alert nudge on the member dashboard for publisher/adtech org admins when brand.json has zero properties. Dismisses with a 7-day localStorage snooze so it resurfaces if properties stay empty.

--- a/server/public/dashboard.html
+++ b/server/public/dashboard.html
@@ -2071,6 +2071,11 @@
       // Get dismissed alerts from session storage
       const dismissedAlerts = JSON.parse(sessionStorage.getItem('dismissedSetupAlerts') || '[]');
 
+      // Brand-properties nudge uses a localStorage timestamp for 7-day snooze (keyed per org)
+      const brandPropsDismissedAt = localStorage.getItem(`propertyNudgeDismissedAt_${org.id}`);
+      const brandPropsSnoozed = brandPropsDismissedAt &&
+        (Date.now() - parseInt(brandPropsDismissedAt, 10)) < (7 * 24 * 60 * 60 * 1000);
+
       // Fetch member profile to check for missing items
       try {
         const response = await fetch(`/api/member-profiles/org/${org.id}`);
@@ -2127,6 +2132,25 @@
               : 'Help others learn about your organization by adding a tagline.',
             actionLabel: 'Add Description',
             actionUrl: '/member-profile#tagline'
+          });
+        }
+
+        // Nudge publisher/adtech org admins to populate brand.json properties when empty.
+        // Empty properties = downstream discovery gap (brand→property catalog, ad-agents.json delegation).
+        if (!isPersonalAccount
+            && ['admin', 'owner'].includes(org.role)
+            && ['publisher', 'adtech'].includes(org.billing?.company_type)
+            && profile.primary_brand_domain
+            && profile.resolved_brand
+            && (profile.resolved_brand.property_count ?? 0) === 0
+            && !brandPropsSnoozed) {
+          alerts.push({
+            id: 'missing-brand-properties',
+            icon: '🏗️',
+            title: 'List your owned properties',
+            message: `List the publishers and properties ${org.name ?? 'your organization'} owns or represents — this powers brand-aware discovery and ad-agents.json delegation.`,
+            actionLabel: 'Add properties',
+            actionUrl: `/brand-builder?domain=${encodeURIComponent(profile.primary_brand_domain)}#properties`
           });
         }
 
@@ -2189,14 +2213,20 @@
     }
 
     function dismissSetupAlert(alertId) {
-      const dismissedAlerts = JSON.parse(sessionStorage.getItem('dismissedSetupAlerts') || '[]');
-      if (!dismissedAlerts.includes(alertId)) {
-        dismissedAlerts.push(alertId);
-        sessionStorage.setItem('dismissedSetupAlerts', JSON.stringify(dismissedAlerts));
+      if (alertId === 'missing-brand-properties') {
+        // currentOrg is set to org right before renderSetupAlerts is called; org switches rebuild
+        // the alerts DOM entirely, so currentOrg.id always matches the rendered card's org here.
+        localStorage.setItem(`propertyNudgeDismissedAt_${currentOrg?.id}`, Date.now().toString());
+      } else {
+        const dismissedAlerts = JSON.parse(sessionStorage.getItem('dismissedSetupAlerts') || '[]');
+        if (!dismissedAlerts.includes(alertId)) {
+          dismissedAlerts.push(alertId);
+          sessionStorage.setItem('dismissedSetupAlerts', JSON.stringify(dismissedAlerts));
+        }
       }
 
       // Remove the alert from the DOM
-      const alertEl = document.querySelector(`.setup-alert[data-alert-id="${alertId}"]`);
+      const alertEl = document.querySelector(`.setup-alert[data-alert-id="${CSS.escape(alertId)}"]`);
       if (alertEl) {
         alertEl.remove();
       }


### PR DESCRIPTION
Closes #4280

## Summary

Adds a setup-alert nudge to the member dashboard for publisher and adtech org admins whose `brand.json` has zero properties. Empty properties create downstream discovery gaps: `brand.json` → property catalog → `ad-agents.json` delegation all depend on this data being populated.

The nudge appears when all of:
- Org is active member-tier and not a personal account
- Signed-in user has `org.role` of `admin` or `owner`
- `org.billing.company_type` is `publisher` or `adtech`
- `profile.primary_brand_domain` is set (brand-mapped)
- `profile.resolved_brand.property_count` is 0 or undefined
- User has not snoozed it in the last 7 days

Dismissing snoozes for 7 days via `localStorage` (keyed per org ID), after which it resurfaces if properties are still empty. This differs from the session-only `sessionStorage` dismissal used by the other setup alerts, which are either self-resolving (publish profile, add logo) or action-gated (pending join requests). The `CSS.escape()` fix on the existing `querySelector` in `dismissSetupAlert` is a pre-existing unsafe pattern corrected in this PR.

**Non-breaking justification:** adds a new client-side conditional branch in `dashboard.html`; no API changes, no schema changes, no existing behaviour altered.

**Pre-PR review:**
- code-reviewer: approved (2 iterations — `isAdmin` scope → `org.role`, snooze key mismatch → resolved with `currentOrg?.id` invariant, `CSS.escape` added)
- internal-tools-strategist: approved — no overbuild risk, localStorage snooze is the right pattern, `org.role` gate correct for per-org admin check

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01BYkdrK3XyCwvkc6XAmLz74

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYkdrK3XyCwvkc6XAmLz74)_