### PR TITLE
fix(server/addie): verify object + tool before offering mutations

### DIFF
--- a/.changeset/addie-verify-before-mutate.md
+++ b/.changeset/addie-verify-before-mutate.md
@@ -1,0 +1,25 @@
+---
+---
+
+fix(server/addie): add phantom-object mutation guard and brand-ownership routing (closes #4281)
+
+Third documented instance of Addie offering to mutate a named object that doesn't exist
+("update the prospect record for X"), then escalating when she discovers she lacks the tool.
+
+Root-cause fix: two new rules and a URL registry entry.
+
+**`constraints.md` — "Verify Object + Tool Before Offering a Mutation"**
+Hard prohibition: run the object-type-appropriate lookup tool before offering any state change.
+If the object doesn't exist, ask a clarifying question. If the object exists but no write tool
+is available, route to the self-serve surface rather than escalating. Explicitly overrides the
+"escalate" step in "Never Claim Unexecuted Actions" for this pattern. Also governs neutral
+declarative facts ("X is part of Y") — those are not mutation requests; acknowledge before asking.
+
+**`behaviors.md` — "Brand-Ownership Intent: Route to Brand Builder"**
+When a user states that a domain or company is owned by another org, route through
+`parse_brand_properties`/`import_brand_properties` (if caller owns the brand domain) or
+to the brand builder URL (if not). Never invent a "prospect record" for this intent.
+
+**`urls.md` — add `agenticadvertising.org/brand-builder`**
+Adds the brand builder to the canonical URL registry so the brand-ownership routing rule
+can reference it. The page accepts `?domain=example.com` to pre-load a domain.

--- a/server/src/addie/rules/behaviors.md
+++ b/server/src/addie/rules/behaviors.md
@@ -377,6 +377,15 @@ When the user's intent is **register** (e.g. "register my agent", "add my agent 
 
 **If the user is not signed in or not in an AAO org**, `save_agent` won't work. Tell them: sign up or sign in at [agenticadvertising.org/auth/login](https://agenticadvertising.org/auth/login) (AuthKit handles both), then return to `/dashboard/agents` and click **+ Register agent**. For non-member discovery paths (publisher's `adagents.json`), point them to https://docs.adcontextprotocol.org/docs/registry/registering-an-agent.
 
+## Brand-Ownership Intent: Route to Brand Builder
+
+When a user states that a domain or company is owned by or part of another organization ("X is part of Y", "Apex Athletic is a Nova Brands property"), brand.json Properties is the canonical surface for recording this fact — not prospect records.
+
+1. **Do not invent a "prospect record" or any other mutation target for this intent.** Brand ownership is recorded in brand.json Properties, not in any prospect or account management system.
+2. **Look up the parent domain** via `lookup_domain` or `resolve_brand` to confirm it has a registered brand entity.
+3. **If the caller's org owns the parent brand domain**: offer `parse_brand_properties` to preview adding the child domain as a property. Show the parsed list, wait for explicit confirmation, then call `import_brand_properties`. If `parse_brand_properties` or `import_brand_properties` returns an authorization error, do not retry or escalate — route to the brand builder URL instead (see step 4).
+4. **If the caller's org does not own the parent brand domain**: route to `https://agenticadvertising.org/brand-builder` (listed in urls.md), appending `?domain=` and the owner's brand domain. One-line explanation: "Brand properties are managed in the brand builder — that link opens the owner's brand directly." Do not escalate for this intent.
+
 ## Uncertainty Acknowledgment
 When you don't have enough information to answer confidently:
 - Say "I'm not sure about that" or "I don't have specific information on that"

--- a/server/src/addie/rules/constraints.md
+++ b/server/src/addie/rules/constraints.md
@@ -61,6 +61,21 @@ If a tool is not available, say "I don't have a tool to do that right now" and e
 If a tool failed, say "That didn't work" and explain what happened.
 NEVER say "Done!" or "Success!" without a tool call backing it up.
 
+## Verify Object + Tool Before Offering a Mutation
+
+CRITICAL: Do not offer to mutate a named object until you have confirmed (1) the object exists via a lookup tool, and (2) you have a write tool to execute the mutation. This extends "Never Claim Unexecuted Actions" — that rule stops you from claiming a mutation completed; this rule stops you from offering one until you know you can deliver it.
+
+Decision procedure when a user's message contains "add," "update," "delete," "remove," "record," "note," "mark," "flag," or "create" applied to a named entity, or when any phrasing implies state change on a named object:
+
+1. **Identify the object type and its read tool**: prospect records → `query_prospects`; accounts → `get_account`; brand entities → `lookup_domain` or `resolve_brand`; meetings → `list_upcoming_meetings`. If no read tool is registered for the object type but a write tool exists, state that you cannot verify whether the object already exists, ask the user to confirm before proceeding, and call the write tool only after explicit confirmation.
+2. **Look it up first.** Do not offer to mutate an object you haven't searched for.
+3. **Object not found**: ask "I searched and didn't find a [type] record for [name] — did you mean something else?" Only offer to create it if a creation tool for this object type is available in your catalog; do not offer creation if no creation tool is registered.
+4. **Object found, no write tool**: route to the self-serve surface (see "Brand-Ownership Intent" in behaviors.md for brand cases; for other object types, describe the limitation and offer to escalate). **Do not escalate** when a self-serve surface exists. This "do not escalate" override applies only to this step — when the object is confirmed found but no write tool is available. Steps where the object is not found (step 3) or where a write tool fails at runtime still follow "Never Claim Unexecuted Actions" normally.
+
+**User-asserted existence is not confirmed existence.** "Update the prospect record for X" does not mean a record exists — run the lookup even when the user's phrasing implies the object is there.
+
+**Neutral declarative facts are not mutation requests.** When a user is asserting a fact about the world rather than requesting that Addie perform an action (even if politely or conditionally phrased), acknowledge the fact, ask whether they want to act on it, and only then run the lookup procedure in steps 1–4 above if they say yes. Do not paraphrase a stated fact as an action offer.
+
 ## Never Fabricate People or Names
 NEVER refer to a specific person by name unless:
 1. The user mentioned them in this conversation

--- a/server/src/addie/rules/urls.md
+++ b/server/src/addie/rules/urls.md
@@ -17,6 +17,7 @@ are excluded from CI checks).
 - https://agenticadvertising.org/dashboard/membership — Membership and renewal management
 - https://agenticadvertising.org/account — Personal account settings (form fields you type into: name, bio, expertise, social links, including the GitHub-username text field that surfaces on the user's community profile). NOT where the GitHub OAuth connection lives.
 - https://agenticadvertising.org/member-hub — "Your hub" — the personal dashboard (engagement, working group recs, profile completeness). Hosts the **Connections card** where users connect or disconnect GitHub OAuth (the one-click toggle backed by WorkOS Pipes). Use this URL when the user asks how to disconnect or manage their GitHub OAuth connection.
+- https://agenticadvertising.org/brand-builder — brand.json builder tool; accepts `?domain=example.com` to pre-load a specific brand domain into the editor
 - https://agenticadvertising.org/connect/github — Session-aware bouncer that starts the WorkOS Pipes GitHub OAuth flow on click. Use when the user wants to **start** an OAuth connection from a Slack-shared link; the Connections card on /member-hub is where they go to manage or disconnect afterward.
 - https://agenticadvertising.org/member-profile — Member profile, company description, and logo upload
 - https://agenticadvertising.org/community — Community hub


### PR DESCRIPTION
Closes #4281

Third documented instance of Addie offering to mutate a named object that doesn't exist ("update the prospect record for Spreaker"), then escalating when she discovers she can't act. The root pattern: Addie misclassifies a neutral declarative fact ("X is part of Y") as a mutation intent, invents a phantom object, offers to update it, the user agrees, and Addie escalates when no tool can execute. This PR operationalizes the feedback already in memory (`feedback_addie_no_phantom_tools`, `feedback_addie_tools_just_work`) as concrete rules.

**Non-breaking justification:** adds new sections to existing Markdown rule files (`behaviors.md`, `constraints.md`) and one entry to `urls.md`. No TypeScript changes, no protocol schema changes, no public API surface touched. Changeset is `--empty` (server-only).

---

### Changes

**`constraints.md` — "Verify Object + Tool Before Offering a Mutation"**
Hard prohibition triggered by any message containing mutation-signaling verbs applied to a named entity. Decision procedure:
1. Identify the object type's read tool; if none exists but a write tool does, get explicit confirmation before writing.
2. Look it up before offering anything.
3. Object not found → clarifying question; only offer creation if a creation tool is in the catalog (prevents offering `add_prospect` to non-admins).
4. Object found, no write tool → route to self-serve surface; only escalate when neither a tool nor a self-serve path exists. Override scoped explicitly to step 4 only.

Also adds: "neutral declarative facts are not mutation requests" — when a user asserts a world-state rather than requesting an action, acknowledge and ask, don't paraphrase as an offer.

**`behaviors.md` — "Brand-Ownership Intent: Route to Brand Builder"**
When a user states domain/company ownership ("X is part of Y"): never invent a prospect record. Look up the parent domain. If the caller's org owns it, offer `parse_brand_properties` → confirm → `import_brand_properties`; if a runtime auth error fires, fall through to step 4. If the org doesn't own it, route to `agenticadvertising.org/brand-builder?domain=<owner>`. Do not escalate.

**`urls.md` — add `agenticadvertising.org/brand-builder`**
Brand builder (`server/public/brand-builder.html`) is a real page that accepts `?domain=` to pre-load a domain. Added to the canonical URL registry so the brand-ownership routing rule can reference it without violating the "do not emit unregistered URLs" constraint. CI link checker will validate on merge.

---

**Pre-PR review:**
- code-reviewer: approved after two nit fixes — vague `"account search tool"` → `query_prospects`/`get_account`; `Apex Radio` not on approved fictional-names list → `Apex Athletic`
- prompt-engineer: approved after four blocker fixes — trigger condition now enumerates mutation-signaling verbs; no-read-tool-but-write-tool case added; creation offer in step 3 gated on catalog presence; `(or you lack the import tools)` dead-code clause replaced with runtime auth-error handling; "neutral declarative facts" detector changed from syntactic (no imperative verb) to semantic (user asserting world-state vs. requesting action)

> **Triage-managed PR.** This bot does not currently iterate on review comments or PR conversation threads (only on the source issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` → fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121) for context.

Session: https://claude.ai/code/session_01N7nwk7MBtiepzAtcV2s3M4

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7nwk7MBtiepzAtcV2s3M4)_