### PR TITLE
feat(scripts): Stage 0.3 — insert-missing-rows phase (#4159)

### DIFF
--- a/.changeset/stage0-3-insert-missing-rows.md
+++ b/.changeset/stage0-3-insert-missing-rows.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add `insert-missing-rows` phase to `stage0-domain-cleanup` (#4159 Stage 0.3): inserts `organization_domains` rows for member profiles where `primary_brand_domain` is set but no matching row exists. Source `manual`, verified true, is_primary true. Trust model: brand-claim DNS verification. Cross-org collisions surface (exit code 2), not stomped.

--- a/server/src/scripts/stage0-domain-cleanup.ts
+++ b/server/src/scripts/stage0-domain-cleanup.ts
@@ -35,7 +35,10 @@
 
 import { initializeDatabase, getPool, closeDatabase } from '../db/client.js';
 import { getDatabaseConfig } from '../config.js';
-import { canonicalizeBrandDomain } from '../services/identifier-normalization.js';
+import {
+  assertClaimableBrandDomain,
+  canonicalizeBrandDomain,
+} from '../services/identifier-normalization.js';
 import type { Pool } from 'pg';
 
 const apply = process.argv.includes('--apply');
@@ -391,12 +394,14 @@ async function phasePerCaseFixes(pool: Pool): Promise<void> {
  * exists for that domain on the same org.
  *
  * Trust model: these domains were claimed via the brand-claim verify flow
- * (DNS publication of brand.json), not WorkOS DNS. Insert as
+ * (web-root publication of brand.json), not WorkOS DNS. Insert as
  * `source='manual', verified=true, is_primary=true` — auto-link will route
- * future @<domain> signups to this org, which is the same end-state Stage 1
- * needs anyway. No-op when the domain is already on a different org
- * (ON CONFLICT DO NOTHING) — those collisions surface as a warning so an
- * operator can resolve them manually.
+ * future @<domain> signups to this org. Refuses non-claimable domains
+ * (free-email providers, shared platforms, public-suffix etlds) — the
+ * candidate set is filtered through `assertClaimableBrandDomain` before
+ * any write, since stale `primary_brand_domain` values can include junk
+ * (Mangrove had `linkedin.com`). Cross-org collisions also skipped and
+ * surfaced for manual resolution.
  */
 async function phaseInsertMissingRows(pool: Pool): Promise<void> {
   console.log('=== PHASE: insert-missing-rows ===');
@@ -407,7 +412,6 @@ async function phaseInsertMissingRows(pool: Pool): Promise<void> {
   const candidates = await pool.query<{
     org_id: string;
     org_name: string;
-    is_personal: boolean;
     primary_brand_domain: string;
     other_org_owns: string | null;
     other_org_name: string | null;
@@ -415,7 +419,6 @@ async function phaseInsertMissingRows(pool: Pool): Promise<void> {
     SELECT
       mp.workos_organization_id AS org_id,
       o.name AS org_name,
-      o.is_personal,
       mp.primary_brand_domain,
       other_od.workos_organization_id AS other_org_owns,
       other_o.name AS other_org_name
@@ -437,16 +440,37 @@ async function phaseInsertMissingRows(pool: Pool): Promise<void> {
   console.log(`Candidates (profile has primary_brand_domain but no matching org_domains row): ${candidates.rowCount}`);
   let inserted = 0;
   let skippedCollision = 0;
+  let skippedNonClaimable = 0;
+  let raceLost = 0;
   const collisions: Array<{ name: string; domain: string; owner: string }> = [];
+  const nonClaimable: Array<{ name: string; domain: string; reason: string }> = [];
 
   for (const r of candidates.rows) {
+    // Filter out junk values that managed to land in primary_brand_domain
+    // (linkedin.com, hubspot CDN URLs, free-email providers, etc.). Same
+    // gate every live writer applies. Skipping here is safer than asserting
+    // them as verified — auto-link reads `od.verified=true` regardless of
+    // source, so an elevated junk row would route signups onto the wrong
+    // tenant.
+    let normalized: string;
+    try {
+      normalized = canonicalizeBrandDomain(r.primary_brand_domain);
+      assertClaimableBrandDomain(normalized);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      console.log(`  NON-CLAIMABLE  ${r.org_name} (${r.org_id})  ${r.primary_brand_domain}  ${reason}`);
+      nonClaimable.push({ name: r.org_name, domain: r.primary_brand_domain, reason });
+      skippedNonClaimable += 1;
+      continue;
+    }
+
     if (r.other_org_owns) {
-      console.log(`  COLLISION  ${r.org_name} (${r.org_id}) wants ${r.primary_brand_domain} but org ${r.other_org_owns} (${r.other_org_name}) already owns it`);
-      collisions.push({ name: r.org_name, domain: r.primary_brand_domain, owner: r.other_org_name ?? r.other_org_owns });
+      console.log(`  COLLISION  ${r.org_name} (${r.org_id}) wants ${normalized} but org ${r.other_org_owns} (${r.other_org_name}) already owns it`);
+      collisions.push({ name: r.org_name, domain: normalized, owner: r.other_org_name ?? r.other_org_owns });
       skippedCollision += 1;
       continue;
     }
-    console.log(`  ${apply ? 'INSERT' : 'WOULD INSERT'}  ${r.org_name} (${r.org_id})  ${r.primary_brand_domain}  source=manual is_primary=true`);
+    console.log(`  ${apply ? 'INSERT' : 'WOULD INSERT'}  ${r.org_name} (${r.org_id})  ${normalized}  source=manual is_primary=true`);
     if (apply) {
       const client = await pool.connect();
       try {
@@ -466,31 +490,34 @@ async function phaseInsertMissingRows(pool: Pool): Promise<void> {
           [r.org_id],
         );
 
-        // Insert. ON CONFLICT (domain) DO NOTHING — handles the rare race where
-        // another org claimed this domain between the SELECT above and this
-        // INSERT. Result: silent no-op for that row; surface via post-loop tally.
+        // Insert. Lowercase the domain on insert for symmetry with the
+        // LOWER-based candidate lookup. ON CONFLICT (domain) DO NOTHING —
+        // handles the rare race where another org claimed this domain between
+        // the SELECT above and this INSERT.
         const ins = await client.query(
           `INSERT INTO organization_domains
              (workos_organization_id, domain, verified, is_primary, source, created_at, updated_at)
-           VALUES ($1, $2, true, true, 'manual', NOW(), NOW())
+           VALUES ($1, LOWER($2), true, true, 'manual', NOW(), NOW())
            ON CONFLICT (domain) DO NOTHING
            RETURNING domain`,
-          [r.org_id, r.primary_brand_domain],
+          [r.org_id, normalized],
         );
         if (ins.rowCount === 0) {
           // Race-loser. Roll back the demotion so we don't leave the org with
           // zero is_primary=true rows.
           await client.query('ROLLBACK');
           console.log(`    RACE: another writer inserted this domain first; demote rolled back`);
+          raceLost += 1;
           continue;
         }
 
-        // Mirror the new primary onto organizations.email_domain.
+        // Mirror the new primary onto organizations.email_domain. Match the
+        // lowercase form the row was inserted with.
         await client.query(
           `UPDATE organizations
-              SET email_domain = $1, updated_at = NOW()
+              SET email_domain = LOWER($1), updated_at = NOW()
             WHERE workos_organization_id = $2`,
-          [r.primary_brand_domain, r.org_id],
+          [normalized, r.org_id],
         );
 
         // Same invariant assertion as per-case-fixes.
@@ -515,10 +542,16 @@ async function phaseInsertMissingRows(pool: Pool): Promise<void> {
     inserted += 1;
   }
 
-  console.log(`\nResult: ${inserted} inserted${dryRun ? ' (would insert)' : ''}, ${skippedCollision} skipped (collision with another org)`);
+  console.log(`\nResult: ${inserted} inserted${dryRun ? ' (would insert)' : ''}, ${skippedCollision} skipped (collision with another org), ${skippedNonClaimable} skipped (non-claimable domain), ${raceLost} race-lost (rolled back)`);
   if (collisions.length > 0) {
     console.log('\nCollisions need manual resolution:');
     for (const c of collisions) console.log(`  ${c.name}: ${c.domain} owned by ${c.owner}`);
+  }
+  if (nonClaimable.length > 0) {
+    console.log('\nNon-claimable primary_brand_domain values (likely stale; need manual reset):');
+    for (const c of nonClaimable) console.log(`  ${c.name}: ${c.domain} — ${c.reason}`);
+  }
+  if (collisions.length > 0 || nonClaimable.length > 0 || raceLost > 0) {
     process.exitCode = 2;
   }
 }

--- a/server/src/scripts/stage0-domain-cleanup.ts
+++ b/server/src/scripts/stage0-domain-cleanup.ts
@@ -6,19 +6,19 @@
  * member_profiles.primary_brand_domain into organization_domains.is_primary).
  *
  * Phases:
- *  - canonicalize-www  Strip `www.` from member_profiles.primary_brand_domain
- *                      values where the apex equivalent already exists in
- *                      organization_domains for the same org. ~10 cases per
- *                      the 2026-05-08 survey.
- *  - per-case-fixes    Hand-tuned fixes for the 6 non-trivial divergence
- *                      cases (DanAds, iPROM, Transfon, Mission Media, Triton,
- *                      Mangrove). Each case has explicit before-state guards
- *                      so re-runs after a manual change abort instead of
- *                      stomping. Each writes both organization_domains AND
- *                      member_profiles.primary_brand_domain so the row state
- *                      is coherent post-Stage-0.
+ *  - canonicalize-www       Strip `www.` from member_profiles.primary_brand_domain
+ *                           values where the apex equivalent already exists in
+ *                           organization_domains for the same org.
+ *  - per-case-fixes         Hand-tuned fixes for the 6 non-trivial divergence
+ *                           cases. Each guards on expected before-state.
+ *  - insert-missing-rows    For profiles where primary_brand_domain is set but
+ *                           no matching organization_domains row exists,
+ *                           insert as `source='manual', verified=true,
+ *                           is_primary=true`. Trust model: brand-claim DNS
+ *                           verification, not WorkOS DNS. Cross-org collisions
+ *                           are surfaced (exit code 2), not stomped.
  *
- * Both phases are independently runnable. Both default to dry-run; pass
+ * All phases are independently runnable. All default to dry-run; pass
  * `--apply` to write.
  *
  * Usage:
@@ -26,9 +26,11 @@
  *   node /app/dist/scripts/stage0-domain-cleanup.js --phase=canonicalize-www --apply
  *   node /app/dist/scripts/stage0-domain-cleanup.js --phase=per-case-fixes
  *   node /app/dist/scripts/stage0-domain-cleanup.js --phase=per-case-fixes --apply
+ *   node /app/dist/scripts/stage0-domain-cleanup.js --phase=insert-missing-rows
+ *   node /app/dist/scripts/stage0-domain-cleanup.js --phase=insert-missing-rows --apply
  *
- * Exit codes: 0 success; 1 unrecoverable error; 2 a per-case guard rejected
- * because the row state diverges from the expected before-state.
+ * Exit codes: 0 success; 1 unrecoverable error; 2 a guard rejected (per-case
+ * before-state drift, or insert-missing-rows cross-org collision).
  */
 
 import { initializeDatabase, getPool, closeDatabase } from '../db/client.js';
@@ -383,6 +385,144 @@ async function phasePerCaseFixes(pool: Pool): Promise<void> {
   if (aborted > 0) process.exitCode = 2;
 }
 
+/**
+ * Stage 0.3: insert organization_domains rows for member_profiles where
+ * `primary_brand_domain` is set but no matching organization_domains row
+ * exists for that domain on the same org.
+ *
+ * Trust model: these domains were claimed via the brand-claim verify flow
+ * (DNS publication of brand.json), not WorkOS DNS. Insert as
+ * `source='manual', verified=true, is_primary=true` — auto-link will route
+ * future @<domain> signups to this org, which is the same end-state Stage 1
+ * needs anyway. No-op when the domain is already on a different org
+ * (ON CONFLICT DO NOTHING) — those collisions surface as a warning so an
+ * operator can resolve them manually.
+ */
+async function phaseInsertMissingRows(pool: Pool): Promise<void> {
+  console.log('=== PHASE: insert-missing-rows ===');
+
+  // Candidates: profiles with a brand-primary that's not on any organization_domains
+  // row anywhere (regardless of org). Splitting "any-org collision" out from
+  // "this-org missing" gives a cleaner picture of the data.
+  const candidates = await pool.query<{
+    org_id: string;
+    org_name: string;
+    is_personal: boolean;
+    primary_brand_domain: string;
+    other_org_owns: string | null;
+    other_org_name: string | null;
+  }>(`
+    SELECT
+      mp.workos_organization_id AS org_id,
+      o.name AS org_name,
+      o.is_personal,
+      mp.primary_brand_domain,
+      other_od.workos_organization_id AS other_org_owns,
+      other_o.name AS other_org_name
+    FROM member_profiles mp
+    JOIN organizations o ON o.workos_organization_id = mp.workos_organization_id
+    LEFT JOIN organization_domains same_od
+      ON same_od.workos_organization_id = mp.workos_organization_id
+     AND LOWER(same_od.domain) = LOWER(mp.primary_brand_domain)
+    LEFT JOIN organization_domains other_od
+      ON LOWER(other_od.domain) = LOWER(mp.primary_brand_domain)
+     AND other_od.workos_organization_id != mp.workos_organization_id
+    LEFT JOIN organizations other_o
+      ON other_o.workos_organization_id = other_od.workos_organization_id
+    WHERE mp.primary_brand_domain IS NOT NULL
+      AND same_od.domain IS NULL
+    ORDER BY o.name
+  `);
+
+  console.log(`Candidates (profile has primary_brand_domain but no matching org_domains row): ${candidates.rowCount}`);
+  let inserted = 0;
+  let skippedCollision = 0;
+  const collisions: Array<{ name: string; domain: string; owner: string }> = [];
+
+  for (const r of candidates.rows) {
+    if (r.other_org_owns) {
+      console.log(`  COLLISION  ${r.org_name} (${r.org_id}) wants ${r.primary_brand_domain} but org ${r.other_org_owns} (${r.other_org_name}) already owns it`);
+      collisions.push({ name: r.org_name, domain: r.primary_brand_domain, owner: r.other_org_name ?? r.other_org_owns });
+      skippedCollision += 1;
+      continue;
+    }
+    console.log(`  ${apply ? 'INSERT' : 'WOULD INSERT'}  ${r.org_name} (${r.org_id})  ${r.primary_brand_domain}  source=manual is_primary=true`);
+    if (apply) {
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        await client.query(
+          'SELECT 1 FROM organizations WHERE workos_organization_id = $1 FOR UPDATE',
+          [r.org_id],
+        );
+
+        // Demote any existing is_primary=true row on this org first — there
+        // should be at most one. The personal-tier candidates almost never
+        // have one, but the assertion keeps the post-write invariant ("exactly
+        // one is_primary=true") clean.
+        await client.query(
+          `UPDATE organization_domains SET is_primary = false, updated_at = NOW()
+            WHERE workos_organization_id = $1 AND is_primary = true`,
+          [r.org_id],
+        );
+
+        // Insert. ON CONFLICT (domain) DO NOTHING — handles the rare race where
+        // another org claimed this domain between the SELECT above and this
+        // INSERT. Result: silent no-op for that row; surface via post-loop tally.
+        const ins = await client.query(
+          `INSERT INTO organization_domains
+             (workos_organization_id, domain, verified, is_primary, source, created_at, updated_at)
+           VALUES ($1, $2, true, true, 'manual', NOW(), NOW())
+           ON CONFLICT (domain) DO NOTHING
+           RETURNING domain`,
+          [r.org_id, r.primary_brand_domain],
+        );
+        if (ins.rowCount === 0) {
+          // Race-loser. Roll back the demotion so we don't leave the org with
+          // zero is_primary=true rows.
+          await client.query('ROLLBACK');
+          console.log(`    RACE: another writer inserted this domain first; demote rolled back`);
+          continue;
+        }
+
+        // Mirror the new primary onto organizations.email_domain.
+        await client.query(
+          `UPDATE organizations
+              SET email_domain = $1, updated_at = NOW()
+            WHERE workos_organization_id = $2`,
+          [r.primary_brand_domain, r.org_id],
+        );
+
+        // Same invariant assertion as per-case-fixes.
+        const primaryCount = await client.query<{ n: string }>(
+          `SELECT COUNT(*)::text AS n FROM organization_domains
+            WHERE workos_organization_id = $1 AND is_primary = true`,
+          [r.org_id],
+        );
+        const n = parseInt(primaryCount.rows[0].n, 10);
+        if (n !== 1) {
+          throw new Error(`Invariant violation for ${r.org_name} (${r.org_id}): expected 1 is_primary=true row, got ${n}`);
+        }
+
+        await client.query('COMMIT');
+      } catch (err) {
+        await client.query('ROLLBACK').catch(() => {});
+        throw err;
+      } finally {
+        client.release();
+      }
+    }
+    inserted += 1;
+  }
+
+  console.log(`\nResult: ${inserted} inserted${dryRun ? ' (would insert)' : ''}, ${skippedCollision} skipped (collision with another org)`);
+  if (collisions.length > 0) {
+    console.log('\nCollisions need manual resolution:');
+    for (const c of collisions) console.log(`  ${c.name}: ${c.domain} owned by ${c.owner}`);
+    process.exitCode = 2;
+  }
+}
+
 async function main(): Promise<void> {
   const dbConfig = getDatabaseConfig();
   if (!dbConfig) {
@@ -401,8 +541,10 @@ async function main(): Promise<void> {
     await phaseCanonicalizeWww(pool);
   } else if (phaseArg === 'per-case-fixes') {
     await phasePerCaseFixes(pool);
+  } else if (phaseArg === 'insert-missing-rows') {
+    await phaseInsertMissingRows(pool);
   } else {
-    console.error('Pass --phase=canonicalize-www or --phase=per-case-fixes');
+    console.error('Pass --phase=canonicalize-www, --phase=per-case-fixes, or --phase=insert-missing-rows');
     process.exit(1);
   }
 }

--- a/server/tests/integration/stage0-domain-cleanup.test.ts
+++ b/server/tests/integration/stage0-domain-cleanup.test.ts
@@ -256,6 +256,61 @@ describe('Stage 0 domain-cleanup: insert-missing-rows phase (SQL behavior)', () 
     expect(candidates.rowCount).toBe(0);
   });
 
+  it('demote-then-insert-then-rollback leaves the existing primary intact on a race loss', async () => {
+    // Pre-existing is_primary=true row on TEST_ORG. We're going to simulate
+    // the script wanting to insert a new primary, then losing the ON CONFLICT
+    // race. The existing primary must survive.
+    await seedDomains(pool, [
+      { domain: 'existing-primary.example', verified: true, is_primary: true },
+    ]);
+    await seedProfile(pool, 'wanted-primary.example');
+
+    // Seed the conflict on OTHER_ORG so our INSERT race-loses.
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+       VALUES ($1, $2, false, NOW(), NOW()) ON CONFLICT DO NOTHING`,
+      [OTHER_ORG, 'Other Org'],
+    );
+    await pool.query(
+      `INSERT INTO organization_domains (workos_organization_id, domain, verified, is_primary, source, created_at, updated_at)
+       VALUES ($1, $2, true, true, 'workos', NOW(), NOW())
+       ON CONFLICT (domain) DO UPDATE SET workos_organization_id = $1`,
+      [OTHER_ORG, 'wanted-primary.example'],
+    );
+
+    // Replicate the phase's transaction. Demote → INSERT race-loses → ROLLBACK.
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        'SELECT 1 FROM organizations WHERE workos_organization_id = $1 FOR UPDATE',
+        [TEST_ORG],
+      );
+      await client.query(
+        `UPDATE organization_domains SET is_primary = false WHERE workos_organization_id = $1 AND is_primary = true`,
+        [TEST_ORG],
+      );
+      const ins = await client.query(
+        `INSERT INTO organization_domains (workos_organization_id, domain, verified, is_primary, source, created_at, updated_at)
+         VALUES ($1, LOWER($2), true, true, 'manual', NOW(), NOW())
+         ON CONFLICT (domain) DO NOTHING
+         RETURNING domain`,
+        [TEST_ORG, 'wanted-primary.example'],
+      );
+      expect(ins.rowCount).toBe(0); // race-lost
+      await client.query('ROLLBACK');
+    } finally {
+      client.release();
+    }
+
+    // The pre-existing primary must still be marked is_primary=true.
+    const after = await pool.query<{ is_primary: boolean }>(
+      `SELECT is_primary FROM organization_domains WHERE workos_organization_id = $1 AND domain = $2`,
+      [TEST_ORG, 'existing-primary.example'],
+    );
+    expect(after.rows[0].is_primary).toBe(true);
+  });
+
   it('insert with ON CONFLICT (domain) DO NOTHING is a no-op when another org owns the row', async () => {
     // Seed the conflict.
     await pool.query(

--- a/server/tests/integration/stage0-domain-cleanup.test.ts
+++ b/server/tests/integration/stage0-domain-cleanup.test.ts
@@ -163,3 +163,128 @@ describe('Stage 0 domain-cleanup: canonicalize-www phase (SQL behavior)', () => 
     expect(candidates.rowCount).toBe(0);
   });
 });
+
+describe('Stage 0 domain-cleanup: insert-missing-rows phase (SQL behavior)', () => {
+  let pool: Pool;
+  const OTHER_ORG = 'org_stage0_other_test';
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  }, 60000);
+
+  afterAll(async () => {
+    await cleanup(pool);
+    await pool.query('DELETE FROM organization_domains WHERE workos_organization_id = $1', [OTHER_ORG]);
+    await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [OTHER_ORG]);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanup(pool);
+    await pool.query('DELETE FROM organization_domains WHERE workos_organization_id = $1', [OTHER_ORG]);
+    await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [OTHER_ORG]);
+    await seedOrg(pool);
+  });
+
+  // The candidate-discovery query is what determines what gets inserted vs
+  // surfaced as a collision. Assert both paths.
+  const CANDIDATE_QUERY = `
+    SELECT
+      mp.workos_organization_id AS org_id,
+      mp.primary_brand_domain,
+      other_od.workos_organization_id AS other_org_owns
+    FROM member_profiles mp
+    LEFT JOIN organization_domains same_od
+      ON same_od.workos_organization_id = mp.workos_organization_id
+     AND LOWER(same_od.domain) = LOWER(mp.primary_brand_domain)
+    LEFT JOIN organization_domains other_od
+      ON LOWER(other_od.domain) = LOWER(mp.primary_brand_domain)
+     AND other_od.workos_organization_id != mp.workos_organization_id
+    WHERE mp.primary_brand_domain IS NOT NULL
+      AND same_od.domain IS NULL
+      AND mp.workos_organization_id = $1
+  `;
+
+  it('lists a profile as a candidate when primary_brand_domain has no matching org_domains row', async () => {
+    await seedProfile(pool, 'qux-stage0test.example');
+    // No organization_domains rows for this org.
+
+    const candidates = await pool.query(CANDIDATE_QUERY, [TEST_ORG]);
+    expect(candidates.rowCount).toBe(1);
+    expect(candidates.rows[0].primary_brand_domain).toBe('qux-stage0test.example');
+    expect(candidates.rows[0].other_org_owns).toBeNull();
+  });
+
+  it('flags a candidate as a collision when another org already owns the domain', async () => {
+    // Seed the OTHER org with the domain claimed.
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+       VALUES ($1, $2, false, NOW(), NOW()) ON CONFLICT DO NOTHING`,
+      [OTHER_ORG, 'Other Org'],
+    );
+    await pool.query(
+      `INSERT INTO organization_domains (workos_organization_id, domain, verified, is_primary, source, created_at, updated_at)
+       VALUES ($1, $2, true, true, 'workos', NOW(), NOW())
+       ON CONFLICT (domain) DO UPDATE SET workos_organization_id = $1`,
+      [OTHER_ORG, 'collision-stage0test.example'],
+    );
+
+    // TEST_ORG's profile claims the same domain.
+    await seedProfile(pool, 'collision-stage0test.example');
+
+    const candidates = await pool.query(CANDIDATE_QUERY, [TEST_ORG]);
+    expect(candidates.rowCount).toBe(1);
+    expect(candidates.rows[0].other_org_owns).toBe(OTHER_ORG);
+  });
+
+  it('does NOT list as candidate when this org already owns the domain (idempotent re-run)', async () => {
+    await seedProfile(pool, 'already-stage0test.example');
+    await seedDomains(pool, [
+      { domain: 'already-stage0test.example', verified: true, is_primary: true, source: 'manual' },
+    ]);
+
+    const candidates = await pool.query(CANDIDATE_QUERY, [TEST_ORG]);
+    expect(candidates.rowCount).toBe(0);
+  });
+
+  it('does NOT list as candidate when primary_brand_domain is NULL', async () => {
+    await seedProfile(pool, null);
+    const candidates = await pool.query(CANDIDATE_QUERY, [TEST_ORG]);
+    expect(candidates.rowCount).toBe(0);
+  });
+
+  it('insert with ON CONFLICT (domain) DO NOTHING is a no-op when another org owns the row', async () => {
+    // Seed the conflict.
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+       VALUES ($1, $2, false, NOW(), NOW()) ON CONFLICT DO NOTHING`,
+      [OTHER_ORG, 'Other Org'],
+    );
+    await pool.query(
+      `INSERT INTO organization_domains (workos_organization_id, domain, verified, is_primary, source, created_at, updated_at)
+       VALUES ($1, $2, true, true, 'workos', NOW(), NOW())
+       ON CONFLICT (domain) DO UPDATE SET workos_organization_id = $1`,
+      [OTHER_ORG, 'racewinner-stage0test.example'],
+    );
+
+    // Try the insert that would fire from phase code.
+    const result = await pool.query(
+      `INSERT INTO organization_domains (workos_organization_id, domain, verified, is_primary, source, created_at, updated_at)
+       VALUES ($1, $2, true, true, 'manual', NOW(), NOW())
+       ON CONFLICT (domain) DO NOTHING
+       RETURNING domain`,
+      [TEST_ORG, 'racewinner-stage0test.example'],
+    );
+    expect(result.rowCount).toBe(0);
+
+    // OTHER org still owns it.
+    const owner = await pool.query<{ workos_organization_id: string }>(
+      `SELECT workos_organization_id FROM organization_domains WHERE LOWER(domain) = $1`,
+      ['racewinner-stage0test.example'],
+    );
+    expect(owner.rows[0].workos_organization_id).toBe(OTHER_ORG);
+  });
+});


### PR DESCRIPTION
## Summary

Stage 0.3 of the domain-column rationalization. Final precondition phase before Stage 1's resolver. Adds an `insert-missing-rows` phase to the existing `stage0-domain-cleanup` script.

For each `member_profiles` row where `primary_brand_domain` is set but no matching `organization_domains` row exists, insert as `source='manual', verified=true, is_primary=true`. ~23 candidates per the post-Stage-0.2 survey.

## Trust model

These domains were claimed via the brand-claim verify flow (DNS publication of `brand.json` on the domain) — different proof from WorkOS DNS, but pre-Stage-0 they were already implicitly trusted: the publish-agent gate read `primary_brand_domain` directly, and auto-link routed via `member_profiles` referencing them. This phase makes that trust explicit on the org_domains row so Stage 1 can read from one place.

Cross-org collisions (someone claims a domain another org already owns) are surfaced as warnings and exit code 2, not silently stomped. The auditor has to resolve them manually.

## Test plan

- [x] 5 new integration tests covering candidate discovery (claim with no row, claim that collides with another org, idempotent re-run, NULL primary, ON CONFLICT race)
- [x] 8 tests total in the file pass; typecheck clean
- [ ] Run dry-run on prod via `fly ssh`, eyeball collisions, then `--apply`

## After this PR lands

The fleet will be in coherent state:
- `member_profiles.primary_brand_domain` always equals an `organization_domains.is_primary=true` row
- No orgs with brand identity floating without a backing org_domains row
- Stage 1 (resolver + read-site migration) can safely treat `organization_domains.is_primary` as the single source of truth

🤖 Generated with [Claude Code](https://claude.com/claude-code)