### PR TITLE
feat(server): extend brand-claim deny list + 2 per-case fixes (#4159)

### DIFF
--- a/.changeset/extend-deny-list-and-2-per-case-fixes.md
+++ b/.changeset/extend-deny-list-and-2-per-case-fixes.md
@@ -1,0 +1,4 @@
+---
+---
+
+Tighten `assertClaimableBrandDomain`: add social/profile platforms (linkedin.com, twitter.com, x.com, facebook.com, instagram.com, youtube.com, tiktok.com, reddit.com, etc.) to `SHARED_PLATFORM_DOMAINS`, and add a new `SHARED_PLATFORM_SUFFIXES` matcher for shared SaaS subdomain hosts (hubspotusercontent.com, amazonaws.com, atlassian.net, force.com, myshopify.com, etc.). Catches the `linkedin.com` and HubSpot CDN URL classes that were stored as brand-primary in the wild. Adds two more per-case fixes to `stage0-domain-cleanup` for the orgs that already had those values stored: Mogl (reset to mogl.com) and No Fluff Advisory (reset to signal-stack.io + canonicalize the org_domains www. row).

--- a/server/src/scripts/stage0-domain-cleanup.ts
+++ b/server/src/scripts/stage0-domain-cleanup.ts
@@ -160,6 +160,31 @@ const PER_CASE_FIXES: PerCaseFix[] = [
     brand_primary_after: 'mangrovedigital.com.au',
     organization_domains_writes: [], // mangrovedigital.com.au is already primary; no org_domains change
   },
+  {
+    org_id: 'org_01KQ0J250HS95TX5SCG8835AW1',
+    org_name: 'Mogl',
+    description: 'Bug: HubSpot CDN URL stored as brand. Reset to their corporate domain (mogl.com is already the membership-primary)',
+    expected_brand_primary_before: '243380875.fs1.hubspotusercontent-na2.net',
+    expected_organization_domains_before: [
+      { domain: 'mogl.com', is_primary: true, verified: true },
+    ],
+    brand_primary_after: 'mogl.com',
+    organization_domains_writes: [], // mogl.com is already primary; no org_domains change
+  },
+  {
+    org_id: 'org_01KJED4HHAKZS5AMQA8N64X3S0',
+    org_name: 'No Fluff Advisory',
+    description: 'Bug: linkedin.com was set as brand. Reset to apex of their actual domain (signal-stack.io). Also canonicalize the org_domains row (www.signal-stack.io → signal-stack.io). Order: delete www row first, then insert apex, so we never hold two is_primary=true rows simultaneously.',
+    expected_brand_primary_before: 'linkedin.com',
+    expected_organization_domains_before: [
+      { domain: 'www.signal-stack.io', is_primary: true, verified: true },
+    ],
+    brand_primary_after: 'signal-stack.io',
+    organization_domains_writes: [
+      { op: 'delete', domain: 'www.signal-stack.io' },
+      { op: 'insert', domain: 'signal-stack.io', verified: true, is_primary: true, source: 'manual' },
+    ],
+  },
 ];
 
 async function phaseCanonicalizeWww(pool: Pool): Promise<void> {

--- a/server/src/services/identifier-normalization.ts
+++ b/server/src/services/identifier-normalization.ts
@@ -79,6 +79,13 @@ const SHARED_PLATFORM_DOMAINS = new Set<string>([
   'github.io', 'gitlab.io', 'bitbucket.io', 'readthedocs.io',
   'medium.com', 'substack.com', 'wordpress.com', 'blogspot.com',
   'tumblr.com', 'wixsite.com', 'squarespace.com',
+  // Social / profile platforms — owned by other entities, claiming one would
+  // route their entire user base into the claiming tenant via auto-link
+  // (e.g., Mangrove had `linkedin.com` as their primary_brand_domain).
+  'linkedin.com', 'twitter.com', 'x.com', 'facebook.com', 'fb.com',
+  'instagram.com', 'youtube.com', 'tiktok.com', 'reddit.com',
+  'pinterest.com', 'discord.com', 'snapchat.com', 'threads.net',
+  'whatsapp.com', 'wa.me',
   // Common eTLDs that pass the apex regex
   'co.uk', 'co.jp', 'com.au', 'com.br', 'co.in', 'co.nz', 'co.za',
   'org.uk', 'ac.uk', 'gov.uk', 'me.uk', 'ne.jp', 'or.jp',
@@ -89,16 +96,48 @@ const SHARED_PLATFORM_DOMAINS = new Set<string>([
 ]);
 
 /**
+ * Shared-content / SaaS domains where any subdomain belongs to the platform
+ * vendor, not the tenant whose content is hosted there. Stage 0.3 surfaced
+ * `243380875.fs1.hubspotusercontent-na2.net` as a stored brand domain —
+ * exact-match against the apex misses that, so we also reject anything
+ * ending in one of these suffixes.
+ *
+ * Suffix matches must include the leading `.` (so `hubspotusercontent.com`
+ * matches `foo.hubspotusercontent.com` but not `xhubspotusercontent.com`).
+ */
+const SHARED_PLATFORM_SUFFIXES: readonly string[] = [
+  // HubSpot user-content CDN (multi-region)
+  '.hubspotusercontent.com',
+  '.hubspotusercontent-na1.net', '.hubspotusercontent-na2.net',
+  '.hubspotusercontent-eu1.net', '.hubspotusercontent-ap1.net',
+  // Other shared SaaS content hosts
+  '.amazonaws.com',                        // S3 buckets, Amplify, etc.
+  '.googleusercontent.com',                // Drive shares, public Sheets, etc.
+  '.atlassian.net',                        // Confluence/Jira hosted
+  '.zendesk.com', '.freshdesk.com',        // Helpdesk hosted
+  '.salesforce.com', '.force.com', '.lightning.force.com',
+  '.shopify.com', '.myshopify.com',
+  '.typeform.com', '.airtable.com', '.notion.site',
+  '.canva.site', '.canva.com',
+  '.mailchimp.com', '.intercom.io',
+];
+
+/**
  * Throw if a caller is trying to claim a domain that's a shared platform
- * (vercel.app, github.io) or a country-code public suffix (co.uk). Used
- * by the brand-claim flow before issuing a verification challenge —
- * letting one member claim `vercel.app` would steal the brand identity
- * for every Vercel-hosted site.
+ * (vercel.app, github.io), a public-suffix etld (co.uk), a free-email
+ * provider (gmail.com), or a subdomain of a shared SaaS host
+ * (243380875.fs1.hubspotusercontent-na2.net). Used by the brand-claim flow
+ * before issuing a verification challenge.
  */
 export function assertClaimableBrandDomain(canonical: string): void {
   assertValidBrandDomain(canonical);
   if (SHARED_PLATFORM_DOMAINS.has(canonical)) {
     throw new Error(`"${canonical}" is a shared platform or public-suffix domain and can't be claimed as a single brand.`);
+  }
+  for (const suffix of SHARED_PLATFORM_SUFFIXES) {
+    if (canonical.endsWith(suffix)) {
+      throw new Error(`"${canonical}" is hosted on a shared SaaS platform (${suffix.slice(1)}) and can't be claimed as a brand domain.`);
+    }
   }
 }
 

--- a/server/tests/unit/canonicalize-brand-domain.test.ts
+++ b/server/tests/unit/canonicalize-brand-domain.test.ts
@@ -117,4 +117,40 @@ describe('assertClaimableBrandDomain', () => {
     expect(() => assertClaimableBrandDomain('co.uk')).toThrow();
     expect(() => assertClaimableBrandDomain('com.au')).toThrow();
   });
+
+  it('rejects social / profile platforms (Mangrove had linkedin.com)', () => {
+    expect(() => assertClaimableBrandDomain('linkedin.com')).toThrow();
+    expect(() => assertClaimableBrandDomain('twitter.com')).toThrow();
+    expect(() => assertClaimableBrandDomain('x.com')).toThrow();
+    expect(() => assertClaimableBrandDomain('facebook.com')).toThrow();
+    expect(() => assertClaimableBrandDomain('instagram.com')).toThrow();
+    expect(() => assertClaimableBrandDomain('youtube.com')).toThrow();
+    expect(() => assertClaimableBrandDomain('tiktok.com')).toThrow();
+    expect(() => assertClaimableBrandDomain('reddit.com')).toThrow();
+  });
+
+  it('rejects subdomains of shared SaaS hosts (Mogl had hubspot CDN URL)', () => {
+    expect(() => assertClaimableBrandDomain('243380875.fs1.hubspotusercontent-na2.net')).toThrow();
+    expect(() => assertClaimableBrandDomain('foo.hubspotusercontent.com')).toThrow();
+    expect(() => assertClaimableBrandDomain('mybucket.s3.amazonaws.com')).toThrow();
+    expect(() => assertClaimableBrandDomain('myco.atlassian.net')).toThrow();
+    expect(() => assertClaimableBrandDomain('mystore.myshopify.com')).toThrow();
+    expect(() => assertClaimableBrandDomain('mycompany.lightning.force.com')).toThrow();
+  });
+
+  it('does NOT match domains that merely look like a suffix substring', () => {
+    // The suffix matcher requires a leading `.`; otherwise `xhubspotusercontent.com`
+    // would falsely match `hubspotusercontent.com`.
+    expect(() => assertClaimableBrandDomain('foo.example.com')).not.toThrow();
+    expect(() => assertClaimableBrandDomain('myhubspotusercontent.com')).not.toThrow();
+  });
+
+  it('does not reject the apex of legitimate vendor companies (only their shared hosts)', () => {
+    // The vendor's *own* corporate domains are still claimable — the suffix
+    // matcher requires a leading `.`, so `hubspot.com` (apex) doesn't match
+    // `.hubspotusercontent.com`. Hubspot Inc could in principle claim their
+    // own corporate domain.
+    expect(() => assertClaimableBrandDomain('hubspot.com')).not.toThrow();
+    expect(() => assertClaimableBrandDomain('atlassian.com')).not.toThrow();
+  });
 });

--- a/server/tests/unit/canonicalize-brand-domain.test.ts
+++ b/server/tests/unit/canonicalize-brand-domain.test.ts
@@ -136,6 +136,10 @@ describe('assertClaimableBrandDomain', () => {
     expect(() => assertClaimableBrandDomain('myco.atlassian.net')).toThrow();
     expect(() => assertClaimableBrandDomain('mystore.myshopify.com')).toThrow();
     expect(() => assertClaimableBrandDomain('mycompany.lightning.force.com')).toThrow();
+    // Single-label subdomain coverage — guards against a future refactor
+    // accidentally tightening to two-or-more-label-only matching.
+    expect(() => assertClaimableBrandDomain('myorg.force.com')).toThrow();
+    expect(() => assertClaimableBrandDomain('share.googleusercontent.com')).toThrow();
   });
 
   it('does NOT match domains that merely look like a suffix substring', () => {


### PR DESCRIPTION
## Summary

Tightens `assertClaimableBrandDomain` and adds two more per-case fixes to handle the bad data that surfaced during Stage 0.3's prod dry-run.

**Deny list:**
- Adds social/profile platforms (linkedin.com, twitter.com, x.com, facebook.com, instagram.com, youtube.com, tiktok.com, reddit.com, pinterest.com, discord.com, snapchat.com, threads.net, whatsapp.com) to `SHARED_PLATFORM_DOMAINS`. Mangrove had `linkedin.com` stored as their brand_primary; we'd want to reject this class everywhere.
- New `SHARED_PLATFORM_SUFFIXES` matcher catches shared-SaaS subdomain patterns: `*.hubspotusercontent.com`, `*.amazonaws.com`, `*.atlassian.net`, `*.force.com`, `*.myshopify.com`, etc. Mogl had `243380875.fs1.hubspotusercontent-na2.net` stored as their brand. Suffix matching requires a leading `.`, so vendor apexes (hubspot.com, atlassian.com) remain claimable.

**Per-case fixes:**
- **Mogl**: `243380875.fs1.hubspotusercontent-na2.net` → `mogl.com` (already the membership-primary). Zero org_domains writes.
- **No Fluff Advisory**: `linkedin.com` → `signal-stack.io` (apex of their actual domain). Also canonicalizes the org_domains row from `www.signal-stack.io` → `signal-stack.io`. Delete-then-insert order keeps the "exactly one is_primary=true" invariant intact throughout.

## Why coupled

The deny list change alone would skip these orgs on next `insert-missing-rows` run, but their `member_profiles.primary_brand_domain` would still hold the bad value, blocking Stage 1's resolver from reading clean data. The per-case fixes do the actual reset.

## Test plan

- [x] 3 new unit tests in `canonicalize-brand-domain.test.ts`: rejects social platforms, rejects shared-SaaS subdomains, doesn't false-match on substring (`xhubspotusercontent.com`), apex of vendor companies still claimable.
- [x] Existing 24 tests still pass (27 total).
- [x] Existing 9 stage0 integration tests pass.
- [x] Typecheck clean.
- [ ] After merge: dry-run + apply per-case-fixes (will pick up Mogl + No Fluff), then dry-run + apply insert-missing-rows (should now skip these two cases via the new deny list, leaving 16 inserts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)