### PR TITLE
fix(scripts): No Fluff Advisory expected_brand_primary is www.linkedin.com

### DIFF
--- a/.changeset/extend-deny-list-and-2-per-case-fixes.md
+++ b/.changeset/extend-deny-list-and-2-per-case-fixes.md
@@ -1,4 +1,0 @@
----
----
-
-Tighten `assertClaimableBrandDomain`: add social/profile platforms (linkedin.com, twitter.com, x.com, facebook.com, instagram.com, youtube.com, tiktok.com, reddit.com, etc.) to `SHARED_PLATFORM_DOMAINS`, and add a new `SHARED_PLATFORM_SUFFIXES` matcher for shared SaaS subdomain hosts (hubspotusercontent.com, amazonaws.com, atlassian.net, force.com, myshopify.com, etc.). Catches the `linkedin.com` and HubSpot CDN URL classes that were stored as brand-primary in the wild. Adds two more per-case fixes to `stage0-domain-cleanup` for the orgs that already had those values stored: Mogl (reset to mogl.com) and No Fluff Advisory (reset to signal-stack.io + canonicalize the org_domains www. row).

--- a/.changeset/no-fluff-advisory-www-prefix-fix.md
+++ b/.changeset/no-fluff-advisory-www-prefix-fix.md
@@ -1,0 +1,4 @@
+---
+---
+
+Update the No Fluff Advisory per-case-fix in `stage0-domain-cleanup` to expect `www.linkedin.com` (their actual stored value) instead of bare `linkedin.com`. The earlier expectation aborted on dry-run because the value was www-prefixed.

--- a/server/src/scripts/stage0-domain-cleanup.ts
+++ b/server/src/scripts/stage0-domain-cleanup.ts
@@ -174,8 +174,8 @@ const PER_CASE_FIXES: PerCaseFix[] = [
   {
     org_id: 'org_01KJED4HHAKZS5AMQA8N64X3S0',
     org_name: 'No Fluff Advisory',
-    description: 'Bug: linkedin.com was set as brand. Reset to apex of their actual domain (signal-stack.io). Also canonicalize the org_domains row (www.signal-stack.io → signal-stack.io). Order: delete www row first, then insert apex, so we never hold two is_primary=true rows simultaneously.',
-    expected_brand_primary_before: 'linkedin.com',
+    description: 'Bug: www.linkedin.com was set as brand. Reset to apex of their actual domain (signal-stack.io). Also canonicalize the org_domains row (www.signal-stack.io → signal-stack.io). Order: delete www row first, then insert apex, so we never hold two is_primary=true rows simultaneously.',
+    expected_brand_primary_before: 'www.linkedin.com',
     expected_organization_domains_before: [
       { domain: 'www.signal-stack.io', is_primary: true, verified: true },
     ],


### PR DESCRIPTION
## Summary

One-line fix to the No Fluff Advisory per-case-fix in `stage0-domain-cleanup`. The PR #4290 dry-run aborted this case because the actual stored value is `www.linkedin.com` (www-prefixed), not bare `linkedin.com`. Update the expected before-state to match.

## Why this slipped through

Earlier survey output abbreviated the displayed primary_brand_domain values for some rows; the No Fluff value showed as `linkedin.com` in summary. The actual database value is `www.linkedin.com`. The script's guard correctly aborted instead of stomping; this fix re-aligns the guard with reality.

## After this lands

Re-run per-case-fixes against No Fluff Advisory; should apply cleanly. Mogl was already applied on the previous PR's run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)