### PR TITLE
fix(server): retry Gemini 500 INTERNAL errors

### DIFF
--- a/server/src/utils/gemini-retry.ts
+++ b/server/src/utils/gemini-retry.ts
@@ -27,6 +27,9 @@ function isRetryableGeminiError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   const msg = error.message;
   return (
+    msg.includes('[500 ') ||
+    msg.includes('Internal error encountered') ||
+    msg.includes('INTERNAL:') ||
     msg.includes('503') ||
     msg.includes('Service Unavailable') ||
     msg.includes('429') ||

--- a/server/tests/unit/gemini-retry.test.ts
+++ b/server/tests/unit/gemini-retry.test.ts
@@ -12,6 +12,8 @@ describe('withGeminiRetry', () => {
   });
 
   it.each([
+    '[500 Internal Server Error] Internal error encountered.',
+    'INTERNAL: something went wrong',
     '503 Bad Gateway',
     'Service Unavailable',
     '429 Too Many Requests',


### PR DESCRIPTION
## Summary
- A 500 from Gemini was bypassing the retry helper and surfacing as a system-error page from portrait/illustration generation (observed today against `gemini-3.1-flash-image-preview`).
- Google classes 500 INTERNAL as transient — same retry treatment as 503/UNAVAILABLE.
- Match the bracketed `[500 ` form (Google's error format) plus `INTERNAL:` and the body text `Internal error encountered`. Avoids false positives like "5000ms timeout".

## Test plan
- [x] Existing 17 cases in `gemini-retry.test.ts` pass
- [x] New cases: `[500 Internal Server Error] Internal error encountered.` and `INTERNAL: ...` retry as expected
- [x] Precommit (test:unit, test:test-dynamic-imports, test:callapi-state-change, typecheck) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)