### PR TITLE
feat(server): Stage 1 brand-domain resolver (#4159)

### DIFF
--- a/.changeset/stage1-brand-domain-resolver.md
+++ b/.changeset/stage1-brand-domain-resolver.md
@@ -1,0 +1,4 @@
+---
+---
+
+Stage 1 of #4159: introduce `getBrandPrimaryDomain(orgId)` and `getBrandPrimaryDomainsForOrgs(orgIds)` in `server/src/services/brand-domain-resolver.ts`. Reads `organization_domains.is_primary=true` first, falls back to `member_profiles.primary_brand_domain` (logs a warn). Single read surface for the brand-identity facet ahead of Stage 2 dropping the column. No call site changes — those land in subsequent PRs.

--- a/server/src/services/brand-domain-resolver.ts
+++ b/server/src/services/brand-domain-resolver.ts
@@ -1,0 +1,110 @@
+/**
+ * Single resolver for an org's brand-primary domain.
+ *
+ * Stage 1 of the domain-column rationalization (#4159, spec at
+ * specs/domain-column-rationalization.md). After Stage 0's backfill, the
+ * canonical truth is `organization_domains.is_primary=true` for both
+ * org-membership-inference and brand-identity. This function is the single
+ * read surface for the brand-identity facet.
+ *
+ * During Stage 1, callers migrate from direct reads of
+ * `member_profiles.primary_brand_domain` to this resolver. Writers continue
+ * to dual-write both fields. Once every read site has migrated, Stage 2
+ * drops the column and the fallback path here becomes a no-op (and gets
+ * removed). Stage 3 introduces the matching `setPrimaryDomain` writer.
+ *
+ * The resolver returns `null` when an org has neither a primary on
+ * organization_domains nor a profile-level brand_primary — caller must
+ * decide whether that's a hard error or a soft "not yet set" path.
+ */
+
+import { getPool } from '../db/client.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('brand-domain-resolver');
+
+/**
+ * Resolve the brand-primary domain for an org.
+ *
+ * Read order:
+ *   1. `organization_domains.is_primary=true` (Stage 1 canonical)
+ *   2. `member_profiles.primary_brand_domain` (transition fallback)
+ *
+ * The fallback exists for orgs Stage 0 missed (e.g., HYPD orphan, or new
+ * orgs joining after the backfill ran). It logs a warn so we can spot any
+ * remaining drift before Stage 2 drops the column.
+ */
+export async function getBrandPrimaryDomain(orgId: string): Promise<string | null> {
+  const pool = getPool();
+
+  const od = await pool.query<{ domain: string }>(
+    `SELECT domain FROM organization_domains
+      WHERE workos_organization_id = $1 AND is_primary = true
+      LIMIT 1`,
+    [orgId],
+  );
+  if (od.rows[0]) return od.rows[0].domain;
+
+  // Fallback during transition. Post-Stage-0 should be near-empty; any hit
+  // here is a drift signal worth surfacing for Stage-1.5 cleanup.
+  const mp = await pool.query<{ primary_brand_domain: string | null }>(
+    `SELECT primary_brand_domain FROM member_profiles WHERE workos_organization_id = $1`,
+    [orgId],
+  );
+  if (mp.rows[0]?.primary_brand_domain) {
+    logger.warn(
+      { orgId, fallback_value: mp.rows[0].primary_brand_domain },
+      'getBrandPrimaryDomain fell back to member_profiles.primary_brand_domain — Stage 0 missed this org or it joined post-backfill',
+    );
+    return mp.rows[0].primary_brand_domain;
+  }
+
+  return null;
+}
+
+/**
+ * Batch variant. Returns a Map keyed by org_id with values of brand-primary
+ * domain (or undefined when an org has neither). Use this from call sites
+ * that walk a list of orgs (e.g., dashboard list views, announcement-trigger
+ * batches) to avoid N+1 queries.
+ *
+ * Same fallback semantics as `getBrandPrimaryDomain`: org_domains.is_primary
+ * wins; profile field fills any gaps with a per-orgId warn.
+ */
+export async function getBrandPrimaryDomainsForOrgs(
+  orgIds: ReadonlyArray<string>,
+): Promise<Map<string, string>> {
+  const result = new Map<string, string>();
+  if (orgIds.length === 0) return result;
+
+  const pool = getPool();
+
+  // Step 1: org_domains.is_primary=true rows for the requested orgs.
+  const od = await pool.query<{ workos_organization_id: string; domain: string }>(
+    `SELECT workos_organization_id, domain FROM organization_domains
+      WHERE workos_organization_id = ANY($1::varchar[]) AND is_primary = true`,
+    [orgIds],
+  );
+  for (const row of od.rows) result.set(row.workos_organization_id, row.domain);
+
+  // Step 2: fall back to member_profiles for orgs not yet in the result.
+  const missing = orgIds.filter((id) => !result.has(id));
+  if (missing.length > 0) {
+    const mp = await pool.query<{ workos_organization_id: string; primary_brand_domain: string }>(
+      `SELECT workos_organization_id, primary_brand_domain
+         FROM member_profiles
+        WHERE workos_organization_id = ANY($1::varchar[])
+          AND primary_brand_domain IS NOT NULL`,
+      [missing],
+    );
+    for (const row of mp.rows) {
+      logger.warn(
+        { orgId: row.workos_organization_id, fallback_value: row.primary_brand_domain },
+        'getBrandPrimaryDomainsForOrgs fell back to member_profiles.primary_brand_domain',
+      );
+      result.set(row.workos_organization_id, row.primary_brand_domain);
+    }
+  }
+
+  return result;
+}

--- a/server/src/services/brand-domain-resolver.ts
+++ b/server/src/services/brand-domain-resolver.ts
@@ -16,6 +16,12 @@
  * The resolver returns `null` when an org has neither a primary on
  * organization_domains nor a profile-level brand_primary — caller must
  * decide whether that's a hard error or a soft "not yet set" path.
+ *
+ * AUTHORIZATION: This is a low-level service with no authz inside. Callers
+ * must have already verified the requesting principal has read access to
+ * the supplied `orgId` (typically via `requireAuth` + membership check).
+ * Same trust posture as the existing `member_profiles.primary_brand_domain`
+ * reads it replaces.
  */
 
 import { getPool } from '../db/client.js';
@@ -37,12 +43,22 @@ const logger = createLogger('brand-domain-resolver');
 export async function getBrandPrimaryDomain(orgId: string): Promise<string | null> {
   const pool = getPool();
 
+  // Read all is_primary=true rows (no LIMIT) so we can detect the rare case
+  // of multiple primaries — Stage 0 enforced the "exactly 1" invariant on
+  // every write path, but a future bug could regress it. logger.error so
+  // it's loud; return the first row regardless (caller still gets a valid
+  // primary, we don't want to bring the page down on a data anomaly).
   const od = await pool.query<{ domain: string }>(
     `SELECT domain FROM organization_domains
-      WHERE workos_organization_id = $1 AND is_primary = true
-      LIMIT 1`,
+      WHERE workos_organization_id = $1 AND is_primary = true`,
     [orgId],
   );
+  if (od.rows.length > 1) {
+    logger.error(
+      { orgId, count: od.rows.length, domains: od.rows.map((r) => r.domain) },
+      'Multiple is_primary=true rows on organization_domains for one org — Stage 0 invariant broken',
+    );
+  }
   if (od.rows[0]) return od.rows[0].domain;
 
   // Fallback during transition. Post-Stage-0 should be near-empty; any hit
@@ -64,7 +80,8 @@ export async function getBrandPrimaryDomain(orgId: string): Promise<string | nul
 
 /**
  * Batch variant. Returns a Map keyed by org_id with values of brand-primary
- * domain (or undefined when an org has neither). Use this from call sites
+ * domain. Orgs with neither a primary nor a fallback are absent from the
+ * map (not present with a null/undefined value). Use this from call sites
  * that walk a list of orgs (e.g., dashboard list views, announcement-trigger
  * batches) to avoid N+1 queries.
  *
@@ -80,14 +97,35 @@ export async function getBrandPrimaryDomainsForOrgs(
   const pool = getPool();
 
   // Step 1: org_domains.is_primary=true rows for the requested orgs.
+  // Detect multi-primary anomalies in the aggregate (one logger.error per
+  // affected org rather than per row).
   const od = await pool.query<{ workos_organization_id: string; domain: string }>(
     `SELECT workos_organization_id, domain FROM organization_domains
       WHERE workos_organization_id = ANY($1::varchar[]) AND is_primary = true`,
     [orgIds],
   );
-  for (const row of od.rows) result.set(row.workos_organization_id, row.domain);
+  const primaryCounts = new Map<string, string[]>();
+  for (const row of od.rows) {
+    const list = primaryCounts.get(row.workos_organization_id) ?? [];
+    list.push(row.domain);
+    primaryCounts.set(row.workos_organization_id, list);
+    if (!result.has(row.workos_organization_id)) {
+      result.set(row.workos_organization_id, row.domain);
+    }
+  }
+  for (const [orgId, domains] of primaryCounts) {
+    if (domains.length > 1) {
+      logger.error(
+        { orgId, count: domains.length, domains },
+        'Multiple is_primary=true rows on organization_domains for one org — Stage 0 invariant broken',
+      );
+    }
+  }
 
   // Step 2: fall back to member_profiles for orgs not yet in the result.
+  // Aggregate the fallback warn into a single log line per batch instead of
+  // one-per-row — keeps the signal usable even if a large batch hits many
+  // fallbacks.
   const missing = orgIds.filter((id) => !result.has(id));
   if (missing.length > 0) {
     const mp = await pool.query<{ workos_organization_id: string; primary_brand_domain: string }>(
@@ -97,11 +135,16 @@ export async function getBrandPrimaryDomainsForOrgs(
           AND primary_brand_domain IS NOT NULL`,
       [missing],
     );
-    for (const row of mp.rows) {
+    if (mp.rows.length > 0) {
       logger.warn(
-        { orgId: row.workos_organization_id, fallback_value: row.primary_brand_domain },
-        'getBrandPrimaryDomainsForOrgs fell back to member_profiles.primary_brand_domain',
+        {
+          count: mp.rows.length,
+          orgIds: mp.rows.map((r) => r.workos_organization_id),
+        },
+        'getBrandPrimaryDomainsForOrgs fell back to member_profiles.primary_brand_domain for some orgs',
       );
+    }
+    for (const row of mp.rows) {
       result.set(row.workos_organization_id, row.primary_brand_domain);
     }
   }

--- a/server/tests/integration/brand-domain-resolver.test.ts
+++ b/server/tests/integration/brand-domain-resolver.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Integration tests for the brand-domain resolver (Stage 1 of #4159).
+ *
+ * Asserts the read order: organization_domains.is_primary first, then
+ * member_profiles.primary_brand_domain as a transition fallback. Single +
+ * batch variants both covered.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { initializeDatabase, getPool, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import {
+  getBrandPrimaryDomain,
+  getBrandPrimaryDomainsForOrgs,
+} from '../../src/services/brand-domain-resolver.js';
+import type { Pool } from 'pg';
+
+const ORG_A = 'org_brand_resolver_a';
+const ORG_B = 'org_brand_resolver_b';
+const ORG_C = 'org_brand_resolver_c';
+
+async function cleanup(pool: Pool) {
+  const ids = [ORG_A, ORG_B, ORG_C];
+  await pool.query('DELETE FROM organization_domains WHERE workos_organization_id = ANY($1)', [ids]);
+  await pool.query('DELETE FROM member_profiles WHERE workos_organization_id = ANY($1)', [ids]);
+  await pool.query('DELETE FROM organizations WHERE workos_organization_id = ANY($1)', [ids]);
+}
+
+async function seedOrg(pool: Pool, orgId: string, name: string) {
+  await pool.query(
+    `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+     VALUES ($1, $2, false, NOW(), NOW())
+     ON CONFLICT (workos_organization_id) DO NOTHING`,
+    [orgId, name],
+  );
+}
+
+async function seedDomain(pool: Pool, orgId: string, domain: string, isPrimary: boolean) {
+  await pool.query(
+    `INSERT INTO organization_domains (workos_organization_id, domain, verified, is_primary, source, created_at, updated_at)
+     VALUES ($1, $2, true, $3, 'workos', NOW(), NOW())
+     ON CONFLICT (domain) DO UPDATE SET is_primary = EXCLUDED.is_primary`,
+    [orgId, domain, isPrimary],
+  );
+}
+
+async function seedProfile(pool: Pool, orgId: string, slug: string, brandPrimary: string | null) {
+  await pool.query(
+    `INSERT INTO member_profiles (workos_organization_id, slug, display_name, primary_brand_domain, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, NOW(), NOW())
+     ON CONFLICT (workos_organization_id) DO UPDATE
+       SET primary_brand_domain = EXCLUDED.primary_brand_domain, updated_at = NOW()`,
+    [orgId, slug, slug, brandPrimary],
+  );
+}
+
+describe('getBrandPrimaryDomain', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  }, 60000);
+
+  afterAll(async () => {
+    await cleanup(pool);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanup(pool);
+  });
+
+  it('returns the organization_domains.is_primary domain when one exists', async () => {
+    await seedOrg(pool, ORG_A, 'A Co');
+    await seedDomain(pool, ORG_A, 'a.example', true);
+    await seedDomain(pool, ORG_A, 'a-secondary.example', false);
+    await seedProfile(pool, ORG_A, 'a-co', 'a.example');
+
+    expect(await getBrandPrimaryDomain(ORG_A)).toBe('a.example');
+  });
+
+  it('prefers org_domains over a divergent member_profiles value', async () => {
+    // Post-Stage-0 these should never diverge, but the resolver's contract
+    // is: org_domains wins.
+    await seedOrg(pool, ORG_A, 'A Co');
+    await seedDomain(pool, ORG_A, 'a.example', true);
+    await seedProfile(pool, ORG_A, 'a-co', 'a-old.example');
+
+    expect(await getBrandPrimaryDomain(ORG_A)).toBe('a.example');
+  });
+
+  it('falls back to member_profiles.primary_brand_domain when no org_domains primary exists', async () => {
+    await seedOrg(pool, ORG_A, 'A Co');
+    await seedProfile(pool, ORG_A, 'a-co', 'a-fallback.example');
+
+    expect(await getBrandPrimaryDomain(ORG_A)).toBe('a-fallback.example');
+  });
+
+  it('returns null when neither source has a value', async () => {
+    await seedOrg(pool, ORG_A, 'A Co');
+    await seedProfile(pool, ORG_A, 'a-co', null);
+
+    expect(await getBrandPrimaryDomain(ORG_A)).toBeNull();
+  });
+
+  it('returns null when the org has no profile and no domains', async () => {
+    await seedOrg(pool, ORG_A, 'A Co');
+    expect(await getBrandPrimaryDomain(ORG_A)).toBeNull();
+  });
+
+  it('does not match a non-primary verified row', async () => {
+    await seedOrg(pool, ORG_A, 'A Co');
+    await seedDomain(pool, ORG_A, 'a.example', false); // verified but not primary
+    await seedProfile(pool, ORG_A, 'a-co', null);
+
+    expect(await getBrandPrimaryDomain(ORG_A)).toBeNull();
+  });
+});
+
+describe('getBrandPrimaryDomainsForOrgs', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  }, 60000);
+
+  afterAll(async () => {
+    await cleanup(pool);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanup(pool);
+  });
+
+  it('returns an empty map for an empty input', async () => {
+    expect(await getBrandPrimaryDomainsForOrgs([])).toEqual(new Map());
+  });
+
+  it('resolves a mix of org_domains and member_profiles fallbacks', async () => {
+    await seedOrg(pool, ORG_A, 'A Co');
+    await seedOrg(pool, ORG_B, 'B Co');
+    await seedOrg(pool, ORG_C, 'C Co');
+
+    // ORG_A: primary on org_domains
+    await seedDomain(pool, ORG_A, 'a.example', true);
+    await seedProfile(pool, ORG_A, 'a-co', 'a.example');
+
+    // ORG_B: only on member_profiles
+    await seedProfile(pool, ORG_B, 'b-co', 'b-fallback.example');
+
+    // ORG_C: no brand identity at all
+    await seedProfile(pool, ORG_C, 'c-co', null);
+
+    const result = await getBrandPrimaryDomainsForOrgs([ORG_A, ORG_B, ORG_C]);
+    expect(result.get(ORG_A)).toBe('a.example');
+    expect(result.get(ORG_B)).toBe('b-fallback.example');
+    expect(result.has(ORG_C)).toBe(false);
+  });
+
+  it('does not include orgs with no brand identity in the result map', async () => {
+    await seedOrg(pool, ORG_A, 'A Co');
+    await seedProfile(pool, ORG_A, 'a-co', null);
+
+    const result = await getBrandPrimaryDomainsForOrgs([ORG_A]);
+    expect(result.size).toBe(0);
+  });
+});

--- a/server/tests/integration/brand-domain-resolver.test.ts
+++ b/server/tests/integration/brand-domain-resolver.test.ts
@@ -54,21 +54,23 @@ async function seedProfile(pool: Pool, orgId: string, slug: string, brandPrimary
   );
 }
 
-describe('getBrandPrimaryDomain', () => {
-  let pool: Pool;
-
-  beforeAll(async () => {
-    pool = initializeDatabase({
-      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
-    });
-    await runMigrations();
-  }, 60000);
-
-  afterAll(async () => {
-    await cleanup(pool);
-    await closeDatabase();
+// Single beforeAll/afterAll pair shared across both describe blocks via
+// vitest's file-scoped lifecycle. Avoids running migrations twice and
+// initializing the pool twice (which races in the same process).
+let pool: Pool;
+beforeAll(async () => {
+  pool = initializeDatabase({
+    connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
   });
+  await runMigrations();
+}, 60000);
 
+afterAll(async () => {
+  await cleanup(pool);
+  await closeDatabase();
+});
+
+describe('getBrandPrimaryDomain', () => {
   beforeEach(async () => {
     await cleanup(pool);
   });
@@ -118,23 +120,39 @@ describe('getBrandPrimaryDomain', () => {
 
     expect(await getBrandPrimaryDomain(ORG_A)).toBeNull();
   });
+
+  it('returns an unverified is_primary=true row (verified is enforced at write time, not read)', async () => {
+    // The resolver does not filter on verified — Stage 0's writers ensure
+    // is_primary=true rows are also verified, and the publish-agent gate
+    // re-checks verified independently. Document the contract here so a
+    // future refactor that adds a verified filter is an intentional change.
+    await seedOrg(pool, ORG_A, 'A Co');
+    await pool.query(
+      `INSERT INTO organization_domains (workos_organization_id, domain, verified, is_primary, source, created_at, updated_at)
+       VALUES ($1, $2, false, true, 'workos', NOW(), NOW())
+       ON CONFLICT (domain) DO UPDATE SET verified = false, is_primary = true`,
+      [ORG_A, 'a-unverified.example'],
+    );
+    await seedProfile(pool, ORG_A, 'a-co', null);
+    expect(await getBrandPrimaryDomain(ORG_A)).toBe('a-unverified.example');
+  });
+
+  it('returns the first row but does not throw when multiple is_primary=true rows exist (data anomaly)', async () => {
+    // The Stage 0 invariant says exactly one is_primary=true row per org.
+    // If a future bug regresses it, the resolver should still produce a
+    // valid primary (some primary is better than none) and surface the
+    // anomaly via logger.error. This test documents the don't-crash
+    // contract; the log assertion isn't checked here.
+    await seedOrg(pool, ORG_A, 'A Co');
+    await seedDomain(pool, ORG_A, 'a-1.example', true);
+    await seedDomain(pool, ORG_A, 'a-2.example', true);
+
+    const result = await getBrandPrimaryDomain(ORG_A);
+    expect(result === 'a-1.example' || result === 'a-2.example').toBe(true);
+  });
 });
 
 describe('getBrandPrimaryDomainsForOrgs', () => {
-  let pool: Pool;
-
-  beforeAll(async () => {
-    pool = initializeDatabase({
-      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
-    });
-    await runMigrations();
-  }, 60000);
-
-  afterAll(async () => {
-    await cleanup(pool);
-    await closeDatabase();
-  });
-
   beforeEach(async () => {
     await cleanup(pool);
   });


### PR DESCRIPTION
## Summary

Stage 1 of [#4159](https://github.com/adcontextprotocol/adcp/issues/4159) (spec at [specs/domain-column-rationalization.md](../tree/main/specs/domain-column-rationalization.md)). Introduces the single read surface for an org's brand-identity primary domain.

```ts
import { getBrandPrimaryDomain, getBrandPrimaryDomainsForOrgs } from '../services/brand-domain-resolver.js';

const domain = await getBrandPrimaryDomain(orgId); // string | null
const map = await getBrandPrimaryDomainsForOrgs(orgIds); // Map<orgId, domain>
```

Read order:
1. `organization_domains.is_primary=true` (Stage 1 canonical, post-Stage-0 backfill)
2. `member_profiles.primary_brand_domain` (transition fallback; logs a warn on every hit so we can spot drift)

Once every read site has migrated to the resolver, Stage 2 drops the column and the fallback becomes a no-op (and gets removed). Stage 3 introduces the matching `setPrimaryDomain` writer.

## What's here

- `server/src/services/brand-domain-resolver.ts` — the resolver. Two surfaces (single + batched).
- `server/tests/integration/brand-domain-resolver.test.ts` — 9 cases covering primary-wins, fallback path, null/empty, mixed batches.
- Changeset.

## What's NOT here

The ~14 call sites that read `member_profiles.primary_brand_domain` directly. Those migrate in subsequent PRs — splitting them keeps each rewrite small and reviewable. Nothing breaks during the gap because writers continue to dual-write.

## Survey shows fallback should be ~empty in prod

Post-Stage-0 (this thread): 91 of 158 profiles have `brand_primary == organization_domains.is_primary`, 66 are NULL, 1 (HYPD orphan) is divergent. So the fallback path will fire only on:
- The HYPD orphan personal workspace (known cross-org collision)
- Any orgs that join after the backfill ran without going through the auto-populate webhook

Both are watchable signals via the warn log.

## Test plan

- [x] 9 integration tests pass
- [x] Typecheck clean
- [ ] After merge: monitor `getBrandPrimaryDomain fell back` warns to spot any drift; should be near-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)