### PR TITLE
feat(member-profile): publish-agent gate uses resolver (#4159 Stage 1.1)

### DIFF
--- a/.changeset/stage1-1-publish-gate-resolver.md
+++ b/.changeset/stage1-1-publish-gate-resolver.md
@@ -1,0 +1,4 @@
+---
+---
+
+Stage 1.1 of #4159: migrate the publish-agent gate (`applyAgentVisibility` in `server/src/routes/member-profiles.ts`) from direct `member_profiles.primary_brand_domain` reads to `getBrandPrimaryDomain(orgId)`. Drops the column from the FOR-UPDATE SELECT; brand-primary lookup now goes through the resolver. Behavior unchanged — reads org_domains.is_primary first, falls back to member_profiles for orgs Stage 0 missed.

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -52,6 +52,7 @@ import { createEscalation } from "../db/escalation-db.js";
 import { insertTypeReclassification } from "../db/type-reclassification-log-db.js";
 import { recordProfilePublishedIfNeeded } from "../services/profile-publish-event.js";
 import { gateAgentVisibilityForCaller, type VisibilityWarning } from "../services/agent-visibility-gate.js";
+import { getBrandPrimaryDomain } from "../services/brand-domain-resolver.js";
 import { normalizeFoundingMemberGrant } from "../services/founding-member-grant.js";
 
 const orgKnowledgeDb = new OrgKnowledgeDatabase();
@@ -1326,7 +1327,7 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       await client.query('BEGIN');
 
       const profileRow = await client.query(
-        `SELECT id, agents, primary_brand_domain
+        `SELECT id, agents
          FROM member_profiles
          WHERE workos_organization_id = $1
          FOR UPDATE`,
@@ -1360,7 +1361,17 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
           };
         }
       }
-      const row = profileRow.rows[0] as { id: string; agents: unknown; primary_brand_domain: string | null };
+      const row = profileRow.rows[0] as { id: string; agents: unknown };
+
+      // Brand-primary domain is now resolved through the Stage 1 service
+      // (organization_domains.is_primary first, member_profiles fallback)
+      // rather than read from the profile row directly. Read happens after
+      // the FOR UPDATE so a concurrent writer could in theory change the
+      // primary mid-flight — that's benign here: the publish either lands
+      // on the old or new primary, both are valid states. The ordering
+      // concern that motivated FOR UPDATE was tier downgrade, which still
+      // serializes correctly via the same lock.
+      const brandPrimaryDomain = await getBrandPrimaryDomain(orgId);
       const parsedAgents = typeof row.agents === 'string'
         ? JSON.parse(row.agents)
         : Array.isArray(row.agents) ? row.agents : [];
@@ -1388,7 +1399,7 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       // Only the public path needs to reach out to brand.json, so the
       // brand-domain requirement is scoped to `target === 'public'`.
       if (target === 'public') {
-        if (!row.primary_brand_domain) {
+        if (!brandPrimaryDomain) {
           await client.query('ROLLBACK');
           return {
             status: 400,
@@ -1410,7 +1421,7 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
         }
       }
 
-      const domain = row.primary_brand_domain;
+      const domain = brandPrimaryDomain;
       const discovered = domain ? await brandDb.getDiscoveredBrandByDomain(domain) : null;
       const isSelfHosted = discovered?.source_type === 'brand_json';
 

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -1363,14 +1363,14 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       }
       const row = profileRow.rows[0] as { id: string; agents: unknown };
 
-      // Brand-primary domain is now resolved through the Stage 1 service
-      // (organization_domains.is_primary first, member_profiles fallback)
-      // rather than read from the profile row directly. Read happens after
-      // the FOR UPDATE so a concurrent writer could in theory change the
-      // primary mid-flight — that's benign here: the publish either lands
-      // on the old or new primary, both are valid states. The ordering
-      // concern that motivated FOR UPDATE was tier downgrade, which still
-      // serializes correctly via the same lock.
+      // Brand-primary read runs on a separate pool connection — outside the
+      // FOR UPDATE on member_profiles. The lock here is load-bearing for
+      // tier downgrade and the agents JSONB read; brand-primary ownership
+      // is enforced at write time (member self-service PUT verifies
+      // membership; brand-claim verify proves DNS control). A concurrent
+      // setPrimaryDomain (Stage 3) racing this read lands old-or-new — both
+      // states the org legitimately controls, so worst case is wrong-brand
+      // listing recoverable by re-publish.
       const brandPrimaryDomain = await getBrandPrimaryDomain(orgId);
       const parsedAgents = typeof row.agents === 'string'
         ? JSON.parse(row.agents)
@@ -1673,13 +1673,13 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
 
       const profile = await memberDb.getProfileByOrgId(orgId);
       if (!profile) return res.status(404).json({ error: 'Profile not found' });
-      if (!profile.primary_brand_domain) return res.status(400).json({ error: 'No primary brand domain' });
+
+      const domain = await getBrandPrimaryDomain(orgId);
+      if (!domain) return res.status(400).json({ error: 'No primary brand domain' });
 
       const agents = profile.agents || [];
       if (index >= agents.length) return res.status(404).json({ error: 'Agent not found at index' });
       const agent = agents[index];
-
-      const domain = profile.primary_brand_domain;
 
       // Validate domain is safe to fetch (SSRF protection)
       try {


### PR DESCRIPTION
## Summary

First read-site migration on the way to dropping `member_profiles.primary_brand_domain` (Stage 2 of [#4159](https://github.com/adcontextprotocol/adcp/issues/4159), spec at `specs/domain-column-rationalization.md`).

The publish-agent gate inside `applyAgentVisibility` (the function the Media.net escalation surfaced as the symptom site) now reads brand-primary through `getBrandPrimaryDomain(orgId)` from PR #4299 instead of selecting the column directly under FOR UPDATE.

## Concretely

```diff
-      const profileRow = await client.query(
-        `SELECT id, agents, primary_brand_domain
+      const profileRow = await client.query(
+        `SELECT id, agents
          FROM member_profiles
          WHERE workos_organization_id = $1
          FOR UPDATE`,
         [orgId]
       );
       ...
-      const row = profileRow.rows[0] as { id: string; agents: unknown; primary_brand_domain: string | null };
+      const row = profileRow.rows[0] as { id: string; agents: unknown };
+      const brandPrimaryDomain = await getBrandPrimaryDomain(orgId);
       ...
-        if (!row.primary_brand_domain) {
+        if (!brandPrimaryDomain) {
            return { error: 'brand_domain_required', ... };
         }
       ...
-      const domain = row.primary_brand_domain;
+      const domain = brandPrimaryDomain;
```

## Why the lock-release is OK

The resolver read happens AFTER the FOR UPDATE on member_profiles. A concurrent writer (e.g., the soon-to-exist `setPrimaryDomain`) could change the primary mid-flight, but the publish either lands on the old or new primary — both valid states. The original FOR UPDATE was motivated by tier downgrade serialization, which still works via the same lock (the demote path also takes FOR UPDATE on member_profiles).

## Test plan

- [x] 14 existing `agent-visibility-e2e` tests pass
- [x] 25 existing `member-agents-api` tests pass (covers POST/PATCH/DELETE on /api/me/agents)
- [x] 11 `brand-domain-resolver` tests still pass
- [x] Typecheck clean
- [x] Test fixtures use the legacy member_profiles pattern, so the fallback path gets exercised — and the warn fires as expected (visible in test output)

## Remaining read sites in member-profiles.ts (next PRs)

- `/check` endpoint at line ~1665 (verify brand.json contains the agent)
- Profile-resolution paths at lines 695, 748 (GET endpoints adding `resolved_brand`)
- A few cosmetic/logo paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)