### PR TITLE
feat(visibility): demote-on-downgrade + /verify-brand use resolver (#4159 Stage 1.2)

### DIFF
--- a/.changeset/stage1-2-visibility-enforcement-resolver.md
+++ b/.changeset/stage1-2-visibility-enforcement-resolver.md
@@ -1,0 +1,4 @@
+---
+---
+
+Stage 1.2 of #4159: migrate `demotePublicAgentsOnTierDowngrade` (the visibility-demote path that strips public agents from brand.json on tier downgrade) and `/verify-brand` (the brand-claim verifier endpoint) from direct `member_profiles.primary_brand_domain` reads to `getBrandPrimaryDomain(orgId)`. Same lock-release reasoning as Stage 1.1: brand-primary read happens on the pool, outside the FOR UPDATE that protects the agents JSONB write.

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -1741,11 +1741,15 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       }
 
       const profile = await memberDb.getProfileByOrgId(orgId);
-      if (!profile?.primary_brand_domain) {
+      if (!profile) {
+        return res.status(404).json({ error: 'Profile not found' });
+      }
+
+      const domain = await getBrandPrimaryDomain(orgId);
+      if (!domain) {
         return res.status(400).json({ error: 'No brand domain configured' });
       }
 
-      const domain = profile.primary_brand_domain;
       const brandManager = new BrandManager();
       const result = await brandManager.validateDomain(domain, { skipCache: true });
 

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -1740,6 +1740,9 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
         return res.status(400).json({ error: 'No organization associated with this account' });
       }
 
+      // Existence check stays separate from the brand-primary lookup so the
+      // two failure modes can keep their distinct status codes — 404 for no
+      // profile, 400 for "profile but no brand domain."
       const profile = await memberDb.getProfileByOrgId(orgId);
       if (!profile) {
         return res.status(404).json({ error: 'Profile not found' });

--- a/server/src/services/agent-visibility-enforcement.ts
+++ b/server/src/services/agent-visibility-enforcement.ts
@@ -125,6 +125,10 @@ export async function demotePublicAgentsOnTierDowngrade(
   // setPrimaryDomain landing between commit and this read just changes
   // which manifest we strip — both old and new domains belong to this
   // org, so the cleanup still targets the org's brand identity.
+  //
+  // TODO(#4159 Stage 3): when setPrimaryDomain lands, it should own
+  // old-primary-manifest cleanup itself rather than depending on a
+  // tier-downgrade race to do it. Janitorial gap, not a security hole.
   const brandPrimaryDomain = await getBrandPrimaryDomain(orgId);
 
   let brandJsonCleared = false;

--- a/server/src/services/agent-visibility-enforcement.ts
+++ b/server/src/services/agent-visibility-enforcement.ts
@@ -14,6 +14,7 @@ import {
 } from '../db/organization-db.js';
 import type { AgentConfig } from '../types.js';
 import { createLogger } from '../logger.js';
+import { getBrandPrimaryDomain } from './brand-domain-resolver.js';
 
 const logger = createLogger('agent-visibility-enforcement');
 
@@ -50,7 +51,7 @@ export async function demotePublicAgentsOnTierDowngrade(
 
   const pool = getPool();
   const client = await pool.connect();
-  let profile: { id: string; agents: AgentConfig[]; primary_brand_domain: string | null } | null = null;
+  let profile: { id: string; agents: AgentConfig[] } | null = null;
   let demotedUrls = new Set<string>();
   try {
     await client.query('BEGIN');
@@ -58,9 +59,8 @@ export async function demotePublicAgentsOnTierDowngrade(
     const row = await client.query<{
       id: string;
       agents: unknown;
-      primary_brand_domain: string | null;
     }>(
-      `SELECT id, agents, primary_brand_domain
+      `SELECT id, agents
        FROM member_profiles
        WHERE workos_organization_id = $1
        FOR UPDATE`,
@@ -101,7 +101,7 @@ export async function demotePublicAgentsOnTierDowngrade(
     const updatedAgents: AgentConfig[] = agents.map((a) =>
       demotedUrls.has(a.url) ? { ...a, visibility: 'members_only' as const } : a
     );
-    profile = { id: r.id, agents: updatedAgents, primary_brand_domain: r.primary_brand_domain };
+    profile = { id: r.id, agents: updatedAgents };
 
     await client.query(
       `UPDATE member_profiles
@@ -119,9 +119,17 @@ export async function demotePublicAgentsOnTierDowngrade(
 
   if (!profile) return null;
 
+  // Brand-primary lookup runs on the pool (outside the demote tx). The
+  // FOR UPDATE was load-bearing for the agents JSONB read; brand-primary
+  // ownership is enforced at write time elsewhere. A concurrent
+  // setPrimaryDomain landing between commit and this read just changes
+  // which manifest we strip — both old and new domains belong to this
+  // org, so the cleanup still targets the org's brand identity.
+  const brandPrimaryDomain = await getBrandPrimaryDomain(orgId);
+
   let brandJsonCleared = false;
-  if (profile.primary_brand_domain) {
-    const discovered = await brandDb.getDiscoveredBrandByDomain(profile.primary_brand_domain);
+  if (brandPrimaryDomain) {
+    const discovered = await brandDb.getDiscoveredBrandByDomain(brandPrimaryDomain);
     if (discovered && discovered.source_type !== 'brand_json') {
       const manifest = (discovered.brand_manifest as Record<string, unknown>) || {};
       const currentAgents = Array.isArray(manifest.agents)
@@ -129,7 +137,7 @@ export async function demotePublicAgentsOnTierDowngrade(
         : [];
       const remaining = currentAgents.filter((a) => !demotedUrls.has(a.url));
       if (remaining.length !== currentAgents.length) {
-        await brandDb.updateManifestAgents(profile.primary_brand_domain, remaining, {
+        await brandDb.updateManifestAgents(brandPrimaryDomain, remaining, {
           user_id: 'system:tier-downgrade',
           email: 'system@agenticadvertising.org',
           name: 'AAO System',

--- a/server/tests/unit/agent-visibility-enforcement.test.ts
+++ b/server/tests/unit/agent-visibility-enforcement.test.ts
@@ -23,7 +23,16 @@ vi.mock('../../src/db/client.js', () => {
   };
 });
 
+// Stub the brand-domain resolver. After Stage 1.1 the demote path reads
+// brand-primary via getBrandPrimaryDomain (on the pool, not the locked
+// client). Each test sets the mock return value to whatever brand-primary
+// the test scenario expects.
+vi.mock('../../src/services/brand-domain-resolver.js', () => ({
+  getBrandPrimaryDomain: vi.fn(),
+}));
+
 import { demotePublicAgentsOnTierDowngrade } from '../../src/services/agent-visibility-enforcement.js';
+import { getBrandPrimaryDomain } from '../../src/services/brand-domain-resolver.js';
 import * as dbClient from '../../src/db/client.js';
 
 /**
@@ -61,7 +70,6 @@ const mockedConnect: ReturnType<typeof vi.fn> = (() => {
 type SelectRow = {
   id: string;
   agents: unknown;
-  primary_brand_domain: string | null;
 };
 
 type RecordedQuery = { sql: string; params: unknown[] };
@@ -81,7 +89,7 @@ function mockProfileTx(rows: SelectRow[]): { recorded: RecordedQuery[]; updateAr
     if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
       return { rowCount: 0, rows: [] };
     }
-    if (sql.includes('SELECT id, agents, primary_brand_domain')) {
+    if (sql.includes('SELECT id, agents')) {
       return { rowCount: rows.length, rows };
     }
     if (sql.trim().startsWith('UPDATE member_profiles')) {
@@ -102,6 +110,10 @@ describe('demotePublicAgentsOnTierDowngrade', () => {
       updateManifestAgents: vi.fn().mockResolvedValue(undefined),
     };
     mockedConnect.mockClear();
+    // Default: no brand-primary on file. Tests that need a specific value
+    // override per-case below.
+    vi.mocked(getBrandPrimaryDomain).mockReset();
+    vi.mocked(getBrandPrimaryDomain).mockResolvedValue(null);
   });
 
   function agent(url: string, visibility: AgentConfig['visibility']): AgentConfig {
@@ -129,10 +141,10 @@ describe('demotePublicAgentsOnTierDowngrade', () => {
     // wrong org param are the exact thing this PR's transactional
     // rewrite is meant to prevent.
     const { recorded } = mockProfileTx([
-      { id: 'p1', agents: [agent('https://a', 'public')], primary_brand_domain: null },
+      { id: 'p1', agents: [agent('https://a', 'public')] },
     ]);
     await demotePublicAgentsOnTierDowngrade('org-target', 'individual_professional', null, brandDb);
-    const selectProfile = recorded.find(r => r.sql.includes('SELECT id, agents, primary_brand_domain'));
+    const selectProfile = recorded.find(r => r.sql.includes('SELECT id, agents'));
     expect(selectProfile, 'should issue a SELECT for the profile row').toBeTruthy();
     expect(selectProfile!.sql).toMatch(/FOR UPDATE/);
     expect(selectProfile!.params[0]).toBe('org-target');
@@ -152,7 +164,7 @@ describe('demotePublicAgentsOnTierDowngrade', () => {
 
   it('no-op when profile has no public agents', async () => {
     const agents = [agent('https://a.example', 'private'), agent('https://b.example', 'members_only')];
-    const { recorded } = mockProfileTx([{ id: 'p1', agents, primary_brand_domain: null }]);
+    const { recorded } = mockProfileTx([{ id: 'p1', agents }]);
     const result = await demotePublicAgentsOnTierDowngrade(
       'org1', 'individual_professional', 'individual_academic', brandDb,
     );
@@ -169,7 +181,7 @@ describe('demotePublicAgentsOnTierDowngrade', () => {
       agent('https://priv.example', 'private'),
     ];
     const { updateArgs } = mockProfileTx([
-      { id: 'p1', agents, primary_brand_domain: null },
+      { id: 'p1', agents },
     ]);
     const result = await demotePublicAgentsOnTierDowngrade(
       'org1', 'individual_professional', 'individual_academic', brandDb,
@@ -186,7 +198,7 @@ describe('demotePublicAgentsOnTierDowngrade', () => {
 
   it('demotes on full cancellation (newTier = null)', async () => {
     mockProfileTx([
-      { id: 'p1', agents: [agent('https://p.example', 'public')], primary_brand_domain: null },
+      { id: 'p1', agents: [agent('https://p.example', 'public')] },
     ]);
     const result = await demotePublicAgentsOnTierDowngrade(
       'org1', 'company_leader', null, brandDb,
@@ -196,8 +208,9 @@ describe('demotePublicAgentsOnTierDowngrade', () => {
 
   it('clears demoted agents from a community brand.json', async () => {
     mockProfileTx([
-      { id: 'p1', agents: [agent('https://p.example', 'public')], primary_brand_domain: 'acme.example' },
+      { id: 'p1', agents: [agent('https://p.example', 'public')] },
     ]);
+    vi.mocked(getBrandPrimaryDomain).mockResolvedValue('acme.example');
     brandDb.getDiscoveredBrandByDomain.mockResolvedValue({
       source_type: 'community',
       brand_manifest: {
@@ -220,8 +233,9 @@ describe('demotePublicAgentsOnTierDowngrade', () => {
 
   it('does not touch brand.json for self-hosted brands', async () => {
     mockProfileTx([
-      { id: 'p1', agents: [agent('https://p.example', 'public')], primary_brand_domain: 'acme.example' },
+      { id: 'p1', agents: [agent('https://p.example', 'public')] },
     ]);
+    vi.mocked(getBrandPrimaryDomain).mockResolvedValue('acme.example');
     brandDb.getDiscoveredBrandByDomain.mockResolvedValue({
       source_type: 'brand_json',
       brand_manifest: {
@@ -237,8 +251,9 @@ describe('demotePublicAgentsOnTierDowngrade', () => {
 
   it('commits the profile tx before touching brand.json (so a failed manifest write does not orphan the JSONB update)', async () => {
     const { recorded } = mockProfileTx([
-      { id: 'p1', agents: [agent('https://p.example', 'public')], primary_brand_domain: 'acme.example' },
+      { id: 'p1', agents: [agent('https://p.example', 'public')] },
     ]);
+    vi.mocked(getBrandPrimaryDomain).mockResolvedValue('acme.example');
     brandDb.getDiscoveredBrandByDomain.mockResolvedValue({
       source_type: 'community',
       brand_manifest: { agents: [{ url: 'https://p.example', type: 'brand', id: 'p' }] },


### PR DESCRIPTION
## Summary

Stage 1.2 of [#4159](https://github.com/adcontextprotocol/adcp/issues/4159). Two more read sites migrated to `getBrandPrimaryDomain(orgId)`:

1. **`demotePublicAgentsOnTierDowngrade`** (`server/src/services/agent-visibility-enforcement.ts`) — the visibility-demote path that fires when an org's tier loses API access. Drops `primary_brand_domain` from the FOR-UPDATE SELECT; brand.json manifest cleanup now reads the brand-primary via the resolver after commit.

2. **`/verify-brand`** (`server/src/routes/member-profiles.ts`) — the brand-claim verifier endpoint. Same swap.

## Lock-release reasoning (same as Stage 1.1)

The FOR UPDATE on `member_profiles` is load-bearing for the agents JSONB read/write. Brand-primary ownership is enforced at write time elsewhere (member self-service PUT verifies membership; brand-claim verify proves DNS control). A concurrent `setPrimaryDomain` (Stage 3) racing this read lands old-or-new — both states the org legitimately controls.

## Tests

- Unit test `agent-visibility-enforcement.test.ts` updated to mock the resolver. Tests that depend on a brand domain set the mock per-case.
- 60 tests pass across the 4 affected files: visibility-enforcement (10), visibility-e2e (14), member-agents-api (25), brand-domain-resolver (11).

## What's left

| Site | Reads | Notes |
|---|---|---|
| `member-profiles.ts` GET-resolution paths (lines ~695, ~748, ~1995) | 5 | Response-shape sites; deferred to Stage 2 with the column drop |
| `http.ts` | 11 | Dashboard/list views — natural fit for batched resolver |
| `services/brand-property-parse.ts` | 4 | Brand-property crawler |
| `services/brand-identity.ts` | 6 | Mostly write-side; minimal reads to migrate |
| `services/announcement-drafter.ts` | 1 | Addie announcements |
| `routes/brand-feeds.ts` | 4 | Public brand registry feeds |
| Other addie/MCP/jobs | ~6 | Profile-completion-nudge, announcement-trigger, member-tools, brand-property-tools, registry-api, si-chat, referrals |

Next PR will likely target dashboard reads in `http.ts` (good fit for the batched resolver shipped in PR #4299).

🤖 Generated with [Claude Code](https://claude.com/claude-code)