### PR TITLE
docs(accounts): propagate account discovery MUST to overview

### DIFF
--- a/.changeset/account-discovery-must-normative.md
+++ b/.changeset/account-discovery-must-normative.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Propagate account discovery MUST from `required-tasks.mdx` into `accounts/overview.mdx`. Every seller agent must expose at least one of `list_accounts` or `sync_accounts` — this restates the existing `required-tasks.mdx` MUST in the surface-level overview where implementors look first. No wire shape change.

--- a/docs/accounts/overview.mdx
+++ b/docs/accounts/overview.mdx
@@ -137,8 +137,10 @@ The Accounts Protocol operates with four party types. See [Accounts and agents](
 
 ## Tasks
 
+**Account discovery (normative).** Every seller agent MUST expose at least one of `list_accounts` (`require_operator_auth: true`, explicit) or `sync_accounts` (`require_operator_auth: false`, implicit). An agent MAY implement both. Implementing neither is a compliance gap regardless of declared specialisms. See [Required tasks by protocol](/docs/protocol/required-tasks#accounts-protocol).
+
 | Task | Purpose |
-|------|---------|
+|------|--------|
 | [`sync_accounts`](/docs/accounts/tasks/sync_accounts) | Declare brand/operator pairs and billing; provision accounts (implicit accounts, `require_operator_auth: false`) |
 | [`list_accounts`](/docs/accounts/tasks/list_accounts) | Discover existing accounts (explicit accounts, `require_operator_auth: true`); poll status on pending accounts |
 | [`get_account_financials`](/docs/accounts/tasks/get_account_financials) | Query spend, credit, and invoice status for operator-billed accounts |
@@ -174,7 +176,7 @@ The [AgenticAdvertising.org brand registry](https://agenticadvertising.org) prov
 The recommended pattern for buyer agents uses three building blocks (see [#1166](https://github.com/adcontextprotocol/adcp/issues/1166)):
 
 | Tool | Purpose |
-|------|---------|
+|------|--------|
 | `resolve_brand` | Check registry and fetch brand.json — returns canonical identity if available |
 | `research_brand` | Enrich via Brandfetch and auto-save to registry as `enriched` |
 | `save_brand` | Manually contribute a brand to the registry as `community` |

--- a/docs/accounts/overview.mdx
+++ b/docs/accounts/overview.mdx
@@ -137,7 +137,7 @@ The Accounts Protocol operates with four party types. See [Accounts and agents](
 
 ## Tasks
 
-**Account discovery (normative).** Every vendor agent MUST expose at least one of `list_accounts` (`require_operator_auth: true`, explicit) or `sync_accounts` (`require_operator_auth: false`, implicit). An agent MAY implement both. See [Required tasks by protocol](/docs/protocol/required-tasks#any-agent-accepting-accounts).
+**Account discovery (normative).** Every agent accepting accounts MUST expose at least one of `list_accounts` (`require_operator_auth: true`, explicit) or `sync_accounts` (`require_operator_auth: false`, implicit). An agent MAY implement both. See [Required tasks by protocol](/docs/protocol/required-tasks#any-agent-accepting-accounts).
 
 | Task | Purpose |
 |------|--------|

--- a/docs/accounts/overview.mdx
+++ b/docs/accounts/overview.mdx
@@ -137,7 +137,7 @@ The Accounts Protocol operates with four party types. See [Accounts and agents](
 
 ## Tasks
 
-**Account discovery (normative).** Every seller agent MUST expose at least one of `list_accounts` (`require_operator_auth: true`, explicit) or `sync_accounts` (`require_operator_auth: false`, implicit). An agent MAY implement both. Implementing neither is a compliance gap regardless of declared specialisms. See [Required tasks by protocol](/docs/protocol/required-tasks#accounts-protocol).
+**Account discovery (normative).** Every vendor agent MUST expose at least one of `list_accounts` (`require_operator_auth: true`, explicit) or `sync_accounts` (`require_operator_auth: false`, implicit). An agent MAY implement both. See [Required tasks by protocol](/docs/protocol/required-tasks#any-agent-accepting-accounts).
 
 | Task | Purpose |
 |------|--------|

--- a/docs/accounts/overview.mdx
+++ b/docs/accounts/overview.mdx
@@ -137,7 +137,7 @@ The Accounts Protocol operates with four party types. See [Accounts and agents](
 
 ## Tasks
 
-**Account discovery (normative).** Every agent accepting accounts MUST expose at least one of `list_accounts` (`require_operator_auth: true`, explicit) or `sync_accounts` (`require_operator_auth: false`, implicit). An agent MAY implement both. See [Required tasks by protocol](/docs/protocol/required-tasks#any-agent-accepting-accounts).
+**Account discovery (normative).** Every agent accepting accounts MUST expose at least one of `list_accounts` (explicit accounts, `require_operator_auth: true`) or `sync_accounts` (implicit accounts, `require_operator_auth: false`). An agent MAY implement both. See [Required tasks by protocol](/docs/protocol/required-tasks#any-agent-accepting-accounts).
 
 | Task | Purpose |
 |------|--------|


### PR DESCRIPTION
Closes #4302

Adds a normative sentence to `docs/accounts/overview.mdx` restating the account discovery MUST that already exists in `docs/protocol/required-tasks.mdx` (section: "Any agent accepting accounts"). `accounts/overview.mdx` was previously silent on this requirement; implementors reading only the overview had no signal that exposing neither `list_accounts` nor `sync_accounts` is a conformance gap. No wire shape change; no new normative requirements introduced.

**Non-breaking justification:** pure restatement of an existing MUST from `required-tasks.mdx`; no field added, no enum changed, no wire format touched. Any conformant 3.0.0 implementation already satisfies this clause — it was already required by `required-tasks.mdx`.

**Scope per @bokelley's decision (issue #4302):**
- ✅ Option A: propagate existing MUST into overview, `3.0.x` patch
- ❌ `derived` mode: dropped (retired in 3.0-rc.2; `require_operator_auth` binary covers explicit/implicit)
- ❌ Specialism MUST-NOT gating (Option B): deferred to 3.1.x

**Pre-PR review (2 iterations):**
- code-reviewer: approved — resolved subject-scope narrowing ("seller agent" → "agent accepting accounts"), specialism clause removed, link anchor corrected to `#any-agent-accepting-accounts`
- ad-tech-protocol-expert: approved — `require_operator_auth` mapping accurate per 3.0.x GA schema; pure restatement confirmed non-breaking

**Nit (not fixed):** parenthetical order `(require_operator_auth: true, explicit)` vs. surrounding page convention `(explicit accounts, require_operator_auth: true)` — minor style inconsistency, not a blocker.

**Milestone note:** could not fetch open milestone via available tools — @bokelley confirmed 3.0.x patch target. Assign milestone manually if needed. Storyboard enforcement (`skip→fail`) rides on adcp-client#1624.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_014GZGAbKyfMpy1j4gSCVW7L

---
_Generated by [Claude Code](https://claude.ai/code/session_014GZGAbKyfMpy1j4gSCVW7L)_