### PR TITLE
feat(stage1-4): migrate remaining brand-domain reads to resolver (#4159)

### DIFF
--- a/.changeset/stage1-4-brand-services.md
+++ b/.changeset/stage1-4-brand-services.md
@@ -1,0 +1,4 @@
+---
+---
+
+Stage 1.4 of #4159: migrate the remaining read sites that referenced `member_profiles.primary_brand_domain` directly to use `getBrandPrimaryDomain[sForOrgs]` from the Stage 1 resolver. Touches `services/brand-identity.ts`, `services/brand-property-parse.ts`, `addie/jobs/announcement-trigger.ts` and `profile-completion-nudge.ts` (SQL queries now JOIN `organization_domains.is_primary` instead of selecting from `member_profiles`), `addie/mcp/member-tools.ts`, `routes/si-chat.ts`, `routes/referrals.ts`, and the remaining `routes/member-profiles.ts` GET-resolution + cosmetic-logo paths. After this lands, every legacy READ of `primary_brand_domain` is gone — only writes (dual-writing during transition) and the response-shape field remain. Stage 2 drops both.

--- a/server/src/addie/jobs/announcement-trigger.ts
+++ b/server/src/addie/jobs/announcement-trigger.ts
@@ -60,7 +60,7 @@ export interface AnnounceCandidate {
   tagline: string | null;
   description: string | null;
   offerings: string[] | null;
-  primary_brand_domain: string | null;
+  brand_primary_domain: string | null;
   brand_manifest: Record<string, unknown> | null;
   last_published_at: Date | null;
 }
@@ -108,7 +108,7 @@ export async function findAnnounceCandidates(
         mp.tagline,
         mp.description,
         mp.offerings,
-        mp.primary_brand_domain,
+        primary_od.domain AS brand_primary_domain,
         b.brand_manifest,
         (
           SELECT MAX(activity_date)
@@ -119,8 +119,11 @@ export async function findAnnounceCandidates(
       FROM organizations o
       JOIN member_profiles mp
         ON mp.workos_organization_id = o.workos_organization_id
+      JOIN organization_domains primary_od
+        ON primary_od.workos_organization_id = o.workos_organization_id
+       AND primary_od.is_primary = true
       JOIN brands b
-        ON b.domain = LOWER(mp.primary_brand_domain)
+        ON b.domain = LOWER(primary_od.domain)
        AND b.brand_manifest IS NOT NULL
       WHERE mp.is_public = true
         AND COALESCE(mp.metadata->>'no_announcement', 'false') <> 'true'
@@ -318,7 +321,7 @@ async function processAnnounceCandidate(
       tagline: candidate.tagline,
       description: candidate.description,
       offerings: candidate.offerings ?? [],
-      primaryBrandDomain: candidate.primary_brand_domain,
+      primaryBrandDomain: candidate.brand_primary_domain,
       agents: summarizeAgents(candidate.brand_manifest),
       profileSlug: candidate.slug,
     });
@@ -326,7 +329,7 @@ async function processAnnounceCandidate(
     const visual = await resolveAnnouncementVisual({
       workosOrganizationId: candidate.workos_organization_id,
       membershipTier: candidate.membership_tier,
-      primaryBrandDomain: candidate.primary_brand_domain,
+      primaryBrandDomain: candidate.brand_primary_domain,
       displayName: candidate.display_name,
     });
 
@@ -497,7 +500,7 @@ export type BackfillPreviewRow = {
   workos_organization_id: string;
   org_name: string;
   membership_tier: string | null;
-  primary_brand_domain: string | null;
+  brand_primary_domain: string | null;
   last_published_at: Date | null;
 };
 
@@ -543,7 +546,7 @@ function previewRow(c: AnnounceCandidate): BackfillPreviewRow {
     workos_organization_id: c.workos_organization_id,
     org_name: c.org_name,
     membership_tier: c.membership_tier,
-    primary_brand_domain: c.primary_brand_domain,
+    brand_primary_domain: c.brand_primary_domain,
     last_published_at: c.last_published_at,
   };
 }

--- a/server/src/addie/jobs/profile-completion-nudge.ts
+++ b/server/src/addie/jobs/profile-completion-nudge.ts
@@ -39,7 +39,7 @@ interface NudgeCandidate {
   membership_tier: string | null;
   agreement_signed_at: Date;
   is_public: boolean | null;
-  primary_brand_domain: string | null;
+  brand_primary_domain: string | null;
   has_brand_manifest: boolean;
   subscription_created_by: string | null;
 }
@@ -59,15 +59,18 @@ export async function findCandidatesForDay(day: NudgeDay): Promise<NudgeCandidat
         o.membership_tier,
         o.agreement_signed_at,
         mp.is_public,
-        mp.primary_brand_domain,
+        primary_od.domain AS brand_primary_domain,
         (b.brand_manifest IS NOT NULL) AS has_brand_manifest,
         sub_act.logged_by_user_id AS subscription_created_by
       FROM organizations o
       LEFT JOIN member_profiles mp
         ON mp.workos_organization_id = o.workos_organization_id
+      LEFT JOIN organization_domains primary_od
+        ON primary_od.workos_organization_id = o.workos_organization_id
+       AND primary_od.is_primary = true
       LEFT JOIN brands b
-        ON mp.primary_brand_domain IS NOT NULL
-       AND b.domain = LOWER(mp.primary_brand_domain)
+        ON primary_od.domain IS NOT NULL
+       AND b.domain = LOWER(primary_od.domain)
        AND b.brand_manifest IS NOT NULL
       LEFT JOIN LATERAL (
         SELECT logged_by_user_id
@@ -225,7 +228,7 @@ export async function runProfileCompletionNudgeJob(): Promise<NudgeResult> {
         day,
         hasPublicProfile: candidate.is_public === true,
         hasBrandManifest: candidate.has_brand_manifest === true,
-        primaryBrandDomain: candidate.primary_brand_domain,
+        primaryBrandDomain: candidate.brand_primary_domain,
         orgName: candidate.org_name,
       });
 

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -66,6 +66,7 @@ import { MemberDatabase } from '../../db/member-db.js';
 import { ensureMemberProfileExists } from '../../services/member-profile-autopublish.js';
 import { updateBrandIdentity, BrandIdentityError } from '../../services/brand-identity.js';
 import { canonicalizeBrandDomain } from '../../services/identifier-normalization.js';
+import { getBrandPrimaryDomain } from '../../services/brand-domain-resolver.js';
 import { ComplianceDatabase } from '../../db/compliance-db.js';
 import { AgentSnapshotDatabase } from '../../db/agent-snapshot-db.js';
 import { AgentValidator } from '../../validator.js';
@@ -2191,7 +2192,8 @@ export function createMemberToolHandlers(
     }
 
     let fallbackDomainHint: string | undefined;
-    if (!profile.primary_brand_domain && !profile.contact_website && logoUrl) {
+    const existingBrandPrimary = await getBrandPrimaryDomain(orgId);
+    if (!existingBrandPrimary && !profile.contact_website && logoUrl) {
       try {
         fallbackDomainHint = canonicalizeBrandDomain(new URL(logoUrl).hostname);
       } catch { /* validated below */ }

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -693,8 +693,11 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
           });
         }
         const profile = await memberDb.getProfileByOrgId(devOrgId);
-        if (profile?.primary_brand_domain) {
-          profile.resolved_brand = await resolveBrand(brandDb, profile.primary_brand_domain);
+        if (profile) {
+          const brandPrimary = await getBrandPrimaryDomain(devOrgId);
+          if (brandPrimary) {
+            profile.resolved_brand = await resolveBrand(brandDb, brandPrimary);
+          }
         }
         logger.info({ userId: user.id, orgId: devOrgId, hasProfile: !!profile, durationMs: Date.now() - startTime }, 'GET /api/me/member-profile completed (dev mode)');
         return res.json({
@@ -746,8 +749,11 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       }
 
       const profile = await memberDb.getProfileByOrgId(targetOrgId);
-      if (profile?.primary_brand_domain) {
-        profile.resolved_brand = await resolveBrand(brandDb, profile.primary_brand_domain);
+      if (profile) {
+        const brandPrimary = await getBrandPrimaryDomain(targetOrgId);
+        if (brandPrimary) {
+          profile.resolved_brand = await resolveBrand(brandDb, brandPrimary);
+        }
       }
 
       // Get org name from WorkOS
@@ -2012,7 +2018,8 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       // If no brand domain on file, fall back to the logo URL hostname (only if
       // the candidate domain isn't already owned by another org)
       let fallbackDomainHint: string | undefined;
-      if (!profile?.primary_brand_domain && !profile?.contact_website && logo_url) {
+      const existingBrandPrimary = await getBrandPrimaryDomain(targetOrgId);
+      if (!existingBrandPrimary && !profile?.contact_website && logo_url) {
         try {
           const candidate = canonicalizeBrandDomain(new URL(logo_url).hostname);
           const existingBrand = await brandDb.getHostedBrandByDomain(candidate);

--- a/server/src/routes/referrals.ts
+++ b/server/src/routes/referrals.ts
@@ -5,6 +5,7 @@ import { MemberDatabase } from '../db/member-db.js';
 import { BrandDatabase, resolveBrandFromJson } from '../db/brand-db.js';
 import { requireAuth } from '../middleware/auth.js';
 import { resolvePrimaryOrganization } from '../db/users-db.js';
+import { getBrandPrimaryDomain } from '../services/brand-domain-resolver.js';
 import { emailPrefsDb } from '../db/email-preferences-db.js';
 
 const logger = createLogger('referral-routes');
@@ -43,11 +44,12 @@ export function createReferralsRouter(): Router {
 
       // Fetch member profile for richer landing page experience
       const profile = await memberDb.getProfileByOrgId(referralCode.referrer_org_id);
+      const brandPrimary = await getBrandPrimaryDomain(referralCode.referrer_org_id);
 
       let logo_url: string | null = null;
       let brand_color: string | null = null;
-      if (profile?.primary_brand_domain) {
-        const domain = profile.primary_brand_domain;
+      if (profile && brandPrimary) {
+        const domain = brandPrimary;
         // Skip orphaned brands — manifest is preserved server-side for adoption
         // but must not surface on public read paths until claim is applied.
         const hosted = await brandDb.getHostedBrandByDomain(domain);

--- a/server/src/routes/si-chat.ts
+++ b/server/src/routes/si-chat.ts
@@ -47,7 +47,10 @@ async function getBrandProfile(memberProfileId: string): Promise<{
     `SELECT mp.id, mp.display_name, mp.slug, mp.tagline, mp.description,
             hb.brand_manifest AS brand_json
      FROM member_profiles mp
-     LEFT JOIN brands hb ON hb.domain = mp.primary_brand_domain
+     LEFT JOIN organization_domains primary_od
+       ON primary_od.workos_organization_id = mp.workos_organization_id
+      AND primary_od.is_primary = true
+     LEFT JOIN brands hb ON hb.domain = primary_od.domain
      WHERE mp.id = $1`,
     [memberProfileId]
   );

--- a/server/src/scripts/backfill-member-announcements.ts
+++ b/server/src/scripts/backfill-member-announcements.ts
@@ -117,7 +117,7 @@ system setting. Configure it at /admin/settings.
 
 function formatPreviewRow(r: BackfillPreviewRow): string {
   const tier = r.membership_tier ?? 'no-tier';
-  const domain = r.primary_brand_domain ?? 'no-domain';
+  const domain = r.brand_primary_domain ?? 'no-domain';
   const when = r.last_published_at
     ? new Date(r.last_published_at).toISOString().slice(0, 10)
     : 'no-event';

--- a/server/src/services/brand-identity.ts
+++ b/server/src/services/brand-identity.ts
@@ -14,6 +14,7 @@
 import { getPool } from '../db/client.js';
 import { canonicalizeBrandDomain, assertValidBrandDomain } from './identifier-normalization.js';
 import { checkLogoUrlIsImage } from './brand-logo-service.js';
+import { getBrandPrimaryDomain } from './brand-domain-resolver.js';
 import { createLogger } from '../logger.js';
 
 const logger = createLogger('brand-identity');
@@ -23,17 +24,22 @@ export interface UpdateBrandIdentityInput {
   workosOrganizationId: string;
   /** Display name used when minting a new brand record. */
   displayName: string;
-  /** Member profile, if one exists. Required for primary_brand_domain link-back. */
+  /**
+   * Member profile, if one exists. The function dual-writes
+   * `member_profiles.primary_brand_domain` during the Stage 1 transition
+   * (Stage 2 drops the column); the profile id is needed to target the
+   * write. `contact_website` is a fallback brand-domain hint when the
+   * resolver returns null.
+   */
   profile?: {
     id: string;
-    primary_brand_domain?: string;
     contact_website?: string;
   } | null;
   /** New logo URL. HTTPS, must HEAD-resolve to image/*. Pass undefined to leave unchanged. */
   logoUrl?: string | null;
   /** New primary brand color. #RRGGBB. Pass undefined to leave unchanged. */
   brandColor?: string | null;
-  /** Domain hint used when the profile has no primary_brand_domain yet (e.g., logo URL hostname). */
+  /** Domain hint used when the resolver has nothing yet (e.g., logo URL hostname). */
   fallbackDomainHint?: string;
   /**
    * When the brand row is orphaned (prior owner relinquished, manifest
@@ -120,9 +126,11 @@ export async function updateBrandIdentity(
     throw new BrandIdentityError(400, 'Brand color must be a hex color (e.g., #FF5733).');
   }
 
-  // Pick a brand domain. Prefer the profile's, fall back to website hostname,
-  // then to a hint from the caller (typically the logo URL hostname).
-  let brandDomain = profile?.primary_brand_domain ?? undefined;
+  // Pick a brand domain. Prefer the resolver's value (org_domains.is_primary
+  // first, member_profiles fallback), then the profile's website hostname,
+  // then a hint from the caller (typically the logo URL hostname).
+  const existingPrimary = (await getBrandPrimaryDomain(workosOrganizationId)) ?? undefined;
+  let brandDomain: string | undefined = existingPrimary;
   if (!brandDomain && profile?.contact_website) {
     try { brandDomain = new URL(profile.contact_website).hostname; } catch { /* ignore */ }
   }
@@ -227,7 +235,11 @@ export async function updateBrandIdentity(
       );
     }
 
-    if (profile && profile.primary_brand_domain !== brandDomain) {
+    // Dual-write the legacy member_profiles.primary_brand_domain column
+    // during the Stage 1 transition. Stage 2 drops the column; this write
+    // goes away with it. The compare-against-existingPrimary check skips
+    // a no-op write when the brand-primary hasn't actually changed.
+    if (profile && existingPrimary !== brandDomain) {
       await client.query(
         'UPDATE member_profiles SET primary_brand_domain = $1, updated_at = NOW() WHERE id = $2',
         [brandDomain, profile.id]

--- a/server/src/services/brand-property-parse.ts
+++ b/server/src/services/brand-property-parse.ts
@@ -17,6 +17,7 @@ import { createLogger } from '../logger.js';
 import { query } from '../db/client.js';
 import { BrandDatabase } from '../db/brand-db.js';
 import { resolvePrimaryOrganization } from '../db/users-db.js';
+import { getBrandPrimaryDomain } from './brand-domain-resolver.js';
 import { validateFetchUrl, safeFetch, sanitizeUrl } from '../utils/url-security.js';
 import { ModelConfig } from '../config/models.js';
 
@@ -101,19 +102,18 @@ export async function getBrandForEdit(
     return { ok: false, status: 403, error: 'No organization associated with your account' };
   }
 
+  // Same TODO(#4159) trust gap as brand-feeds.ts: orgDomains walk doesn't
+  // filter on verified=true, and the resolver fallback path uses
+  // member_profiles for orgs Stage 0 missed. Stage 2 should add the
+  // verified gate when the column drops.
   const orgDomains = await query<{ domain: string }>(
     'SELECT domain FROM organization_domains WHERE workos_organization_id = $1',
     [orgId],
   );
-  const memberProfile = await query<{ primary_brand_domain: string | null }>(
-    'SELECT primary_brand_domain FROM member_profiles WHERE workos_organization_id = $1',
-    [orgId],
-  );
+  const brandPrimary = await getBrandPrimaryDomain(orgId);
   const ownedDomains = new Set([
     ...orgDomains.rows.map((r) => r.domain.toLowerCase()),
-    ...(memberProfile.rows[0]?.primary_brand_domain
-      ? [memberProfile.rows[0].primary_brand_domain.toLowerCase()]
-      : []),
+    ...(brandPrimary ? [brandPrimary.toLowerCase()] : []),
   ]);
   if (!ownedDomains.has(domain.toLowerCase())) {
     return { ok: false, status: 403, error: 'You do not own this brand domain' };

--- a/server/tests/integration/brand-orphan-adoption.test.ts
+++ b/server/tests/integration/brand-orphan-adoption.test.ts
@@ -57,6 +57,11 @@ describe('Brand orphan-adoption integration', () => {
   // this as a real parallelism risk in the #3186 review.
   async function clearTestFixtures() {
     await pool.query('DELETE FROM brands WHERE domain = $1', [TEST_DOMAIN]);
+    // Defensive: also delete any organization_domains row pinned to TEST_DOMAIN
+    // by domain, not just by org_id. The ON CONFLICT (domain) DO UPDATE in the
+    // seed below would otherwise trample a third-party org's row if one slipped
+    // in via a parallel test. See nodejs-testing-expert flag on #3186.
+    await pool.query('DELETE FROM organization_domains WHERE domain = $1', [TEST_DOMAIN]);
     await pool.query(
       'DELETE FROM organization_domains WHERE workos_organization_id IN ($1, $2)',
       [PRIOR_ORG, NEW_ORG]

--- a/server/tests/integration/brand-orphan-adoption.test.ts
+++ b/server/tests/integration/brand-orphan-adoption.test.ts
@@ -58,6 +58,14 @@ describe('Brand orphan-adoption integration', () => {
   async function clearTestFixtures() {
     await pool.query('DELETE FROM brands WHERE domain = $1', [TEST_DOMAIN]);
     await pool.query(
+      'DELETE FROM organization_domains WHERE workos_organization_id IN ($1, $2)',
+      [PRIOR_ORG, NEW_ORG]
+    );
+    await pool.query(
+      'DELETE FROM member_profiles WHERE workos_organization_id IN ($1, $2)',
+      [PRIOR_ORG, NEW_ORG]
+    );
+    await pool.query(
       'DELETE FROM organizations WHERE workos_organization_id IN ($1, $2)',
       [PRIOR_ORG, NEW_ORG]
     );
@@ -78,6 +86,17 @@ describe('Brand orphan-adoption integration', () => {
        VALUES ($1, 'Prior Owner Inc', false), ($2, 'New Owner Inc', false)
        ON CONFLICT (workos_organization_id) DO NOTHING`,
       [PRIOR_ORG, NEW_ORG]
+    );
+
+    // Seed the brand-primary on organization_domains for NEW_ORG so the Stage 1
+    // resolver returns TEST_DOMAIN. Pre-Stage-1 the test relied on
+    // profile.primary_brand_domain passed to updateBrandIdentity; the function
+    // now reads via getBrandPrimaryDomain(workosOrganizationId).
+    await pool.query(
+      `INSERT INTO organization_domains (workos_organization_id, domain, verified, is_primary, source)
+       VALUES ($1, $2, true, true, 'manual')
+       ON CONFLICT (domain) DO UPDATE SET workos_organization_id = $1, is_primary = true, verified = true`,
+      [NEW_ORG, TEST_DOMAIN]
     );
 
     // Seed a hosted brand owned by the prior org with a recognizable manifest.

--- a/tests/announcement/announcement-backfill.test.ts
+++ b/tests/announcement/announcement-backfill.test.ts
@@ -91,7 +91,7 @@ const ORG_A = {
   tagline: null,
   description: null,
   offerings: null,
-  primary_brand_domain: 'alpha.example',
+  brand_primary_domain: 'alpha.example',
   brand_manifest: { agents: [] },
   last_published_at: null,
 };
@@ -101,7 +101,7 @@ const ORG_B = {
   workos_organization_id: 'org_BBB',
   org_name: 'Beta Co',
   slug: 'beta',
-  primary_brand_domain: 'beta.example',
+  brand_primary_domain: 'beta.example',
 };
 
 beforeEach(() => {
@@ -304,7 +304,7 @@ describe('runBackfillAnnouncements', () => {
         workos_organization_id: 'org_AAA',
         org_name: 'Alpha Co',
         membership_tier: 'builder',
-        primary_brand_domain: 'alpha.example',
+        brand_primary_domain: 'alpha.example',
         last_published_at: published,
       },
     ]);
@@ -384,7 +384,7 @@ describe('runBackfillAnnouncements', () => {
         workos_organization_id: 'org_AAA',
         org_name: 'Alpha Co',
         membership_tier: 'company_standard',
-        primary_brand_domain: 'alpha.example',
+        brand_primary_domain: 'alpha.example',
         last_published_at: null,
       },
     ]);


### PR DESCRIPTION
## Summary

Stage 1.4 of [#4159](https://github.com/adcontextprotocol/adcp/issues/4159) — the **final** read-site migration. After this lands, every legacy read of `member_profiles.primary_brand_domain` is gone. Only writes (dual-writing during transition), schema/type definitions, and the API response field remain — Stage 2 drops them all together with the column.

## Sites migrated

| File | Pattern |
|---|---|
| `services/brand-identity.ts` | resolver replaces `profile.primary_brand_domain` for brand-domain pick. Field dropped from `UpdateBrandIdentityInput.profile` type. Dual-write to member_profiles still fires. |
| `services/brand-property-parse.ts` | ownership-gate uses resolver |
| `addie/jobs/announcement-trigger.ts` | SQL JOIN reads `org_domains.is_primary` instead of `member_profiles`. Field rename: `AnnounceCandidate.primary_brand_domain` → `brand_primary_domain`. Same for `BackfillPreviewRow`. |
| `addie/jobs/profile-completion-nudge.ts` | same SQL migration + field rename on `NudgeCandidate` |
| `addie/mcp/member-tools.ts` | cosmetic logo fallback path uses resolver |
| `routes/si-chat.ts` | brand-profile JOIN reads `org_domains.is_primary` |
| `routes/referrals.ts` | landing-page brand resolution uses resolver |
| `routes/member-profiles.ts` (GET dev + prod resolution paths, cosmetic logo fallback) | resolver |
| `scripts/backfill-member-announcements.ts` + `tests/announcement/announcement-backfill.test.ts` | track BackfillPreviewRow field rename |
| `tests/integration/brand-orphan-adoption.test.ts` | seed `organization_domains` for the test orgs so the resolver returns the expected domain |

## What's left referencing `primary_brand_domain` after this

| Reference | Reason | Stage 2 |
|---|---|---|
| `services/brand-domain-resolver.ts` | the fallback path that this entire effort is unwinding | drop the fallback |
| `routes/{member-profiles,me-organization-domains,workos-webhooks}.ts` write sites | dual-write during transition | drop the writes |
| `routes/member-profiles.ts` API request/response shape (lines 249, 287, 341-352, 545, 801, 972) | wire-format contract | drop the field from the API |
| `db/member-db.ts` SQL insert/update | persistence layer | drop the column from queries |
| `services/brand-identity.ts` write at line 234 | dual-write target | drop |
| `types.ts`, `schemas/member-agents-openapi.ts` | TypeScript / OpenAPI types | drop |
| `db/migrations/230_member_primary_brand.sql` | historical migration | always stays |
| `scripts/backfill-primary-brand-domain.ts`, `scripts/stage0-domain-cleanup.ts` | one-shot backfills already run on prod | delete in Stage 2 cleanup |
| `services/announcement-drafter.ts:13`, `addie/mcp/brand-property-tools.ts:18` | comments | clean up incidentally |

## Test plan

- [x] 97 tests pass across 6 closely-related integration test files (brand-orphan-adoption, agent-visibility-e2e, member-agents-api, brand-domain-resolver, brand-properties-parse, agent-visibility-enforcement)
- [x] 871 protocol-level unit tests pass (precommit hook)
- [x] Typecheck clean

## What this unblocks

Stage 2: a single PR that drops `member_profiles.primary_brand_domain` (column + write paths + API field + types + resolver fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)