### PR TITLE
ci(release): narrow forward-merge auto-resolve to metadata-only files

### DIFF
--- a/.changeset/4306-forward-merge-narrow-allowlist.md
+++ b/.changeset/4306-forward-merge-narrow-allowlist.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci(release): narrow forward-merge auto-resolve allowlist to metadata-only files. Content-file divergences (schemas, docs, workflow scripts) now fail the workflow loud and require human review, rather than silently dropping 3.0.x patches via whole-file `--ours` checkout. Closes #4306.

--- a/.github/workflows/forward-merge-3.0.yml
+++ b/.github/workflows/forward-merge-3.0.yml
@@ -166,70 +166,6 @@ jobs:
                   git checkout --theirs -- "$f"
                   git add -- "$f"
                   ;;
-                # Known cherry-pick divergence: 3.0.x has #3789's prose-only
-                # backport of #3739 (AUTH_REQUIRED tightening); main has the
-                # full enum split (adds AUTH_MISSING / AUTH_INVALID codes
-                # that can't ship to 3.0.x without breaking the patch
-                # contract). Main's version is the more advanced state and
-                # main's content should win on every forward-merge until
-                # 3.1.0 cuts and replaces both.
-                #
-                # Without this rule, every forward-merge from 3.0.x → main
-                # rediscovers the divergence — squash-merges of prior
-                # forward-merges don't advance the merge-base, so git keeps
-                # seeing 3.0.x's version vs main's version and conflicting.
-                # This rule short-circuits the conflict permanently.
-                #
-                # When 3.1.0 ships and main no longer has the in-flight
-                # enum split (the work has been released), remove this
-                # block. It's a temporary bridge across a known content
-                # divergence, not a permanent allowlist entry.
-                # See adcontextprotocol/adcp#3784 / #3789 for context.
-                docs/building/implementation/error-handling.mdx|static/schemas/source/enums/error-code.json)
-                  git checkout --ours -- "$f"
-                  git add -- "$f"
-                  ;;
-                # Known 3.1-track divergences: main has additions that 3.0.x
-                # cannot adopt within the patch contract. Same rationale as
-                # the AUTH_REQUIRED bridge above — main is the more advanced
-                # state, 3.0.x's content here is the older shape, and
-                # squash-merges of prior forward-merges don't advance the
-                # merge-base so the conflict resurfaces every push without
-                # this short-circuit.
-                #
-                # - .github/workflows/training-agent-storyboards.yml: main
-                #   extracted overlay logic to scripts/overlay-compliance-
-                #   cache.sh (#3793-era refactor); 3.0.x still inlines it.
-                # - static/compliance/source/universal/runner-output-contract.yaml:
-                #   main has forward-compat narrative for unrecognized
-                #   `check` kinds and additional grading-code coverage.
-                # - static/schemas/source/core/error.json: main has #3875's
-                #   schema_id + discriminator additions on issues[] entries.
-                # - static/schemas/source/protocol/get-adcp-capabilities-response.json:
-                #   main has the 3.1+ measurement capability block plus the
-                #   identity.additionalProperties:true relaxation that 3.0.x
-                #   adopted in 3.0.5 (#3896). Both shapes converged on the
-                #   identity flip; main's superset wins.
-                # - static/compliance/source/universal/storyboard-schema.yaml:
-                #   doc-comment authoring schema. 3.0.x's clean-merged
-                #   additions (default_agent in #3897, provides_state_for in
-                #   #3734) are above the conflict region and merge
-                #   automatically; the only conflict is main's CANONICAL
-                #   CHECK ENUM block at the bottom of the file, which 3.0.x
-                #   doesn't have. `--ours` keeps main's enum block AND
-                #   preserves 3.0.x's upper additions (those weren't part
-                #   of the conflict). Verified manually on PRs #3902 (3.0.5),
-                #   the unmerged 3.0.6 forward-merge attempts, and #4225
-                #   (3.0.7). Promoted to allowlist after the third repeat.
-                #
-                # Remove these entries when 3.1.0 ships and main absorbs the
-                # 3.0.x line — these are temporary bridges, not permanent
-                # allowlist entries. First observed on the 3.0.5 forward-
-                # merge (manual resolution: PR #3902).
-                .github/workflows/training-agent-storyboards.yml|static/compliance/source/universal/runner-output-contract.yaml|static/compliance/source/universal/storyboard-schema.yaml|static/schemas/source/core/error.json|static/schemas/source/protocol/get-adcp-capabilities-response.json)
-                  git checkout --ours -- "$f"
-                  git add -- "$f"
-                  ;;
                 *)
                   UNEXPECTED="$UNEXPECTED $f"
                   ;;
@@ -237,8 +173,13 @@ jobs:
             done <<< "$CONFLICTS"
 
             if [ -n "$UNEXPECTED" ]; then
-              echo "::error::Forward-merge has unexpected conflicts that need manual resolution:$UNEXPECTED"
-              echo "::error::Resolve manually: git checkout main && git merge origin/3.0.x"
+              echo "::error::Forward-merge has content conflicts that require human review:$UNEXPECTED"
+              echo "::error::Each conflict is a real decision about whether 3.0.x's change should land on main."
+              echo "::error::Resolve manually:"
+              echo "::error::  git fetch origin && git checkout -b forward-merge/3.0.x origin/main"
+              echo "::error::  git merge origin/3.0.x  # resolve conflicts in editor"
+              echo "::error::  git push origin forward-merge/3.0.x"
+              echo "::error::  gh pr create --base main --head forward-merge/3.0.x"
               git merge --abort
               exit 1
             fi
@@ -320,15 +261,12 @@ jobs:
             - `CHANGELOG.md` → take 3.0.x's (main's next Version Packages
               cut prepends its own beta entries above)
             - `dist/*` → take 3.0.x's (versioned release artifacts)
-            - `docs/building/implementation/error-handling.mdx`,
-              `static/schemas/source/enums/error-code.json` → preserve
-              main's. Temporary bridge across a known cherry-pick
-              divergence (#3789's prose-only backport of #3739); remove
-              when 3.1.0 cuts.
 
             Any conflict outside this list fails the workflow loud — needs
-            manual resolution and indicates a playbook violation (a change
-            on 3.0.x that wasn't first cherry-picked from main).
+            manual resolution. Content-file divergences between 3.0.x and
+            main (schemas, docs, workflow scripts) are real backport
+            decisions and require human review — auto-resolving them
+            silently dropped 3.0.x patches in the past (see #4306).
 
             ## Review checklist
 


### PR DESCRIPTION
Closes #4306.

Auto-resolve allowlist used `git checkout --ours -- "$f"` which takes the *entire* file from main when any conflict region is detected. That was safe when only one EOF block diverged (`storyboard-schema.yaml`'s CANONICAL CHECK ENUM), but as 3.0.x patches accumulated *anywhere* in the allowlisted content files, whole-file `--ours` started silently dropping legitimate 3.0.x changes.

**Symptom:** `main` fell **465 commits behind** `3.0.x` while every push reported "success" with no PR opened. v3.0.5 through v3.0.9 patches never reached main.

## Fix

Drop content files from the allowlist. Keep only true metadata where whole-file resolution is correct by-design.

**Kept (metadata):**
- `package.json` / `package-lock.json` (preserve main's; main may have structural changes 3.0.x doesn't)
- `CHANGELOG.md` (take 3.0.x's; main's next Version Packages prepends above)
- `.changeset/*.md` / `.changeset/pre.json` (preserve main's; independent pre-mode pool)
- `static/schemas/source/index.json`, `static/schemas/source/registry/index.yaml` (regenerated on next release build)
- `dist/{schemas,compliance,protocol,docs}/*` (immutable per release)

**Removed (content files that need human review):**
- `docs/building/implementation/error-handling.mdx`
- `static/schemas/source/enums/error-code.json`
- `.github/workflows/training-agent-storyboards.yml`
- `static/compliance/source/universal/runner-output-contract.yaml`
- `static/compliance/source/universal/storyboard-schema.yaml`
- `static/schemas/source/core/error.json`
- `static/schemas/source/protocol/get-adcp-capabilities-response.json`

## Trade-off

Every patch release pushed to 3.0.x will now trigger a forward-merge run that **fails loud** on these files (they have permanent divergent regions until 3.1.0 cuts and replaces both lines). The failure is the right signal — it surfaces a real decision rather than silently picking main's version.

The error message now includes the manual resolution recipe inline:

```
git fetch origin && git checkout -b forward-merge/3.0.x origin/main
git merge origin/3.0.x  # resolve conflicts in editor
git push origin forward-merge/3.0.x
gh pr create --base main --head forward-merge/3.0.x
```

## Follow-ups

1. **Backport to `3.0.x`** — workflow runs from the pushed ref, so the fix needs to ride to `3.0.x` too. Otherwise the next 3.0.x push still uses the buggy version.
2. **Backfill PR** — once both branches have the fix, manually trigger forward-merge from 3.0.x. The resulting failure surfaces the real conflicts. One big PR resolves the 5/3 → 5/9 backlog (v3.0.5 through v3.0.9 patches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)