### PR TITLE
feat(compliance): add Storyboard.requires runtime requirement gate

### DIFF
--- a/.changeset/storyboard-requires-runtime-gate.md
+++ b/.changeset/storyboard-requires-runtime-gate.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": minor
+---
+
+Add optional `requires` field to the storyboard schema for whole-storyboard runtime requirement gating.
+
+Third-party runners can now declare per-storyboard requirements (`controller`, `seeded_state`, `real_wire`) that the runner evaluates at load time before executing any steps. Storyboards without the field run unchanged. The `requirement_unmet` skip reason is added to runner-output-contract.yaml to match the skip reason already emitted by `@adcp/sdk@^6.16.0` (adcp-client#1635).

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -620,7 +620,7 @@ skip_result:
                               # prerequisite_failed | missing_tool |
                               # missing_test_controller |
                               # unsatisfied_contract | peer_branch_taken |
-                              # peer_substituted
+                              # peer_substituted | requirement_unmet
     - detail                  # human-readable explanation citing the
                               # declared supported_protocols / specialisms
                               # and, if relevant, the missing tool,
@@ -680,6 +680,26 @@ skip_result:
       this signal indicates the agent did declare the specialism but
       offers an interchangeable tool that the storyboard accepts as an
       equivalent state contract.
+    requirement_unmet: |
+      A storyboard-level runtime requirement declared in the storyboard's
+      `requires:` field (see storyboard-schema.yaml > `requires`) was not
+      satisfied at load time. detail MUST name the unmet requirement value
+      (e.g., "controller", "seeded_state") so dashboards can aggregate
+      skips by requirement type.
+
+      Distinct from missing_test_controller (which fires mid-run at a
+      specific step when comply_test_controller is absent) — this reason
+      fires at load time for the whole storyboard, before any step
+      executes. When `requires: [controller]` is set, the runner MUST
+      emit this reason at storyboard scope, not missing_test_controller
+      at step scope.
+
+      Forward compatibility: runners that encounter a `requires` value
+      they do not recognize MUST emit this reason with the unrecognized
+      value in detail, rather than fail-loading the storyboard. Using
+      requirement_unmet (not not_applicable) correctly signals "an unmet
+      gate" vs. "agent did not claim the protocol" — the two are distinct
+      signals for dashboards and summaries.
     description: |
       Runners MAY internally track narrower skip reasons (e.g., a grader
       distinguishing `rate_abuse_opt_out` from `live_side_effect_opt_in_required`).

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -130,7 +130,9 @@
 #   different topologies.)
 #
 # requires: string[] (optional — storyboard-level runtime requirement gate.
-#   Closed enum of recognized values: controller | seeded_state | real_wire.
+#   Known values: controller | seeded_state | real_wire (forward-compat:
+#   unrecognized values are NOT schema violations — runners emit
+#   requirement_unmet at runtime; see Forward compatibility below).
 #   Default when absent: [real_wire] — untagged storyboards run unchanged.
 #   minItems: 1 — runners MUST fail-load on requires: [] (empty array) because
 #   no distinct semantic exists between the empty set and omitting the field;

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -129,6 +129,95 @@
 #   rule above), not a schema concern — the same storyboard runs against
 #   different topologies.)
 #
+# requires: string[] (optional — storyboard-level runtime requirement gate.
+#   Closed enum of recognized values: controller | seeded_state | real_wire.
+#   Default when absent: [real_wire] — untagged storyboards run unchanged.
+#   minItems: 1 — runners MUST fail-load on requires: [] (empty array) because
+#   no distinct semantic exists between the empty set and omitting the field;
+#   the error message SHOULD read "use requires: [real_wire] for the default
+#   behavior, or omit the field entirely."
+#
+#   Values and availability:
+#
+#     controller   — gate on agent advertising comply_test_controller.
+#                    Available when the agent's get_adcp_capabilities response
+#                    includes comply_test_controller in its tool list. When
+#                    unmet, the runner MUST emit skip_result.reason:
+#                    requirement_unmet with detail naming "controller".
+#                    Orthogonal to prerequisites.controller_seeding: the two
+#                    fields are independent. controller_seeding is an execution-
+#                    phase instruction ("inject a fixtures phase before the main
+#                    phases run"); requires: [controller] is a load-phase gate
+#                    ("skip the whole storyboard if the capability is absent").
+#                    Storyboards may declare both: the gate fires first, and
+#                    controller_seeding takes effect only if the gate passes.
+#                    Declaring controller_seeding: true without requires:
+#                    [controller] is also valid — mid-run, individual steps
+#                    grade missing_test_controller if the agent lacks the
+#                    tool; requires: [controller] coalesces that into a single
+#                    whole-storyboard skip at load time instead.
+#                    Mid-run transient loss: if the load-phase gate passes
+#                    (the agent advertised comply_test_controller at load
+#                    time) but the tool becomes unavailable mid-run, the
+#                    runner MUST grade the affected step missing_test_controller
+#                    per the existing per-step path, NOT a retroactive
+#                    requirement_unmet at storyboard scope.
+#
+#     seeded_state — gate on operator asserting out-of-band state provisioning.
+#                    Available when the operator declares (e.g., via a CLI flag
+#                    or runner option) that prerequisite state has been seeded
+#                    externally before the run. When unmet, the runner MUST emit
+#                    skip_result.reason: requirement_unmet with detail naming
+#                    "seeded_state". Scenarios fail naturally on the first
+#                    stateful step if state is not actually present.
+#                    ANTI-GAMING: trust signals (verified-live badges, Tier-2
+#                    production scores) MUST NOT consume requires: [seeded_state]
+#                    pass results without independent verification. The field
+#                    widens the graded set; it does not attest the state.
+#                    This is an operator-governance norm; the runner cannot
+#                    enforce it on behalf of downstream certification dashboards.
+#
+#     real_wire    — reserved for a future --mock-only execution mode. Current
+#                    behavior: no runtime effect (gate is always met). Authors
+#                    SHOULD omit this value rather than listing it explicitly,
+#                    since the default when the field is absent is semantically
+#                    equivalent to [real_wire] today (this equivalence holds
+#                    only while --mock-only is not active; the --mock-only
+#                    inversion may break it — see below).
+#                    IMPORTANT: the future --mock-only semantics INVERT the
+#                    skip direction compared to other values — this value will
+#                    cause a storyboard to skip when --mock-only is active (i.e.,
+#                    skip-when-mocked, pass-when-live), opposite to the
+#                    skip-when-absent logic of controller and seeded_state.
+#                    Whether the default-when-absent (omitting `requires`)
+#                    also triggers the skip under --mock-only is to be defined
+#                    when --mock-only ships; until then, authors MUST NOT rely
+#                    on any particular behavior for omitted vs. explicit
+#                    real_wire under a mock-only runner.
+#                    Composing real_wire with other values (e.g., requires:
+#                    [controller, real_wire]) is syntactically valid but the
+#                    combined behavior under --mock-only is unspecified; authors
+#                    SHOULD NOT mix real_wire with other values until --mock-only
+#                    semantics are defined.
+#                    Harnesses that consume this value MUST account for the
+#                    skip-direction inversion when --mock-only support lands.
+#
+#   Forward compatibility: runners encountering a requires value they do not
+#   recognize MUST emit skip_result.reason: requirement_unmet (not fail-load)
+#   and MUST name the unrecognized value in skip_result.detail so dashboards
+#   can surface it. This matches runner-output-contract.yaml > requirement_unmet
+#   and is consistent with the forward-compat posture throughout the harness —
+#   an unrecognized gate is not a coverage gap (not_applicable would signal
+#   "agent did not claim the protocol"), it is an unmet requirement. Only
+#   requires: [] (empty array) is a hard fail-load — that is a schema
+#   constraint, not a semantic gate, and schema violations are always loader
+#   errors.
+#
+#   Interaction with per-step requires_tool: the two fields are independent.
+#   requires gates the whole storyboard at load time; requires_tool gates
+#   individual steps at execution time. Both may be declared on the same
+#   storyboard.)
+#
 # agent:
 #   interaction_model: enum (stateless_transform | stateful_preloaded | stateful_push | stateless_generate | media_buy_seller | marketplace_catalog | owned_signals | si_platform | brand_rights_holder | governance_agent)
 #   capabilities: string[] (AdCP capability flags: supports_transformation, has_creative_library, supports_generation, sells_media, accepts_briefs, supports_guaranteed, supports_non_guaranteed, catalog_signals)


### PR DESCRIPTION
Closes #4311

## Summary

Adds the optional `requires` field to `storyboard-schema.yaml`, aligning the spec with the reference implementation already shipped in `@adcp/sdk@^6.16.0` (adcp-client#1635, merged). Third-party runners can now interoperate using the same storyboard-level requirement gate the SDK emits.

Adds `requirement_unmet` to `runner-output-contract.yaml`'s `skip_result.reasons` enum — the SDK already emits this skip reason; the spec was missing it.

**Files changed:**
- `static/compliance/source/universal/storyboard-schema.yaml` — adds `requires` field doc block with full normative semantics
- `static/compliance/source/universal/runner-output-contract.yaml` — adds `requirement_unmet` to `skip_result.reasons`
- `.changeset/storyboard-requires-runtime-gate.md` — `minor` bump

**Non-breaking justification:** adds an optional field with a well-defined default-when-absent behavior (`[real_wire]` = run unchanged); existing storyboards with no `requires` field are unaffected. `requirement_unmet` is additive to the skip reason enum.

**Milestone:** targets `3.1.0` (minor — new optional schema field). Note: `gh` CLI unavailable in this environment; milestone was not set programmatically. Please set via `gh pr edit <num> --milestone "3.1.0"`.

## Key normative decisions (from expert review)

- **Unknown `requires` values → `requirement_unmet` (not fail-load):** consistent with the forward-compat posture throughout the harness; unknown gates are not schema violations
- **`requires: []` → hard fail-load:** schema constraint (empty array has no distinct semantic from omitting the field)
- **`controller` is orthogonal to `prerequisites.controller_seeding`:** load-phase gate vs. execution-phase instruction; both may be declared; mid-run transient loss after gate passes routes to `missing_test_controller` at step scope
- **`real_wire` semantics deferred:** default-when-absent behavior under `--mock-only` and composition with other values are explicitly deferred to the `--mock-only` PR

## Pre-PR review

- **code-reviewer:** approved — all three round-1 blockers resolved (not_applicable→requirement_unmet contradiction fixed; real_wire default-when-absent ambiguity fenced; transient controller loss clause added); one nit fixed (Closed enum → Known values)
- **ad-tech-protocol-expert:** approved — non-breaking per spec; additive optional field; forward-compat posture consistent with runner-output-contract throughout the harness

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_013gwxgVXaYDz63X8RGmnEUU

---
_Generated by [Claude Code](https://claude.ai/code/session_013gwxgVXaYDz63X8RGmnEUU)_