### PR TITLE
ci(changeset-check): skip on forward-merge/* PRs

### DIFF
--- a/.changeset/4310-changeset-check-skip-forward-merge.md
+++ b/.changeset/4310-changeset-check-skip-forward-merge.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci(changeset-check): skip on `forward-merge/*` PRs. Forward-merge PRs bring in commits whose changesets were already consumed by the source branch's Version Packages cut, so `changeset status` finds nothing and fails the check. Mirrors the existing `changeset-release/*` skip rule. Closes #4310's blocker on `Check for changeset`.

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -8,9 +8,19 @@ jobs:
   check:
     name: Check for changeset
     runs-on: ubuntu-latest
-    # Skip changeset check on Version Packages PR (created by changesets/action)
-    # for any release line: changeset-release/main, changeset-release/3.0.x, etc.
-    if: ${{ !startsWith(github.head_ref, 'changeset-release/') }}
+    # Skip changeset check on:
+    # - Version Packages PRs (`changeset-release/<branch>`) — changesets/action consumes
+    #   .changeset files into a CHANGELOG bump, so by the time CI runs there are no
+    #   pending changesets to find.
+    # - Forward-merge PRs (`forward-merge/*`) — they merge a release branch (3.0.x)
+    #   whose changesets were already consumed by its own Version Packages cut.
+    #   From main's perspective, the merge brings package-changing commits with no
+    #   .changeset/*.md files to explain them; the changes are explained by the
+    #   3.0.x branch's CHANGELOG, not by a new changeset on main. Without this skip
+    #   every forward-merge PR fails this check (see #4306, #4310).
+    if: |
+      ${{ !startsWith(github.head_ref, 'changeset-release/') &&
+          !startsWith(github.head_ref, 'forward-merge/') }}
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Forward-merge PRs bring in commits whose changesets were already consumed by the source branch's Version Packages cut, so `changeset status --since=origin/main` finds no pending changesets and exits non-zero. Mirrors the existing `changeset-release/*` skip rule.

Without this skip, every forward-merge PR (auto-generated by `forward-merge-3.0.yml` or manual resolution following the same prefix convention) fails the `Check for changeset` job on a structural condition that has nothing to do with PR correctness — currently the only way to land them is admin override or padding in a meaningless empty changeset. Both are friction; the skip is the right primitive.

## What's covered

| Head ref prefix | Skipped? | Why |
|---|---|---|
| `changeset-release/<branch>` | yes (existing) | changesets/action consumes `.changeset` files into a CHANGELOG bump as part of the Version Packages PR |
| `forward-merge/*` | **yes (new)** | source branch's changesets already consumed; merge brings package-changing commits with no `.changeset/*.md` files to explain them |
| anything else | no | regular feature/bug PRs still require a changeset |

The skip is keyed on `head_ref` prefix, not on labels or commit content — not bypassable by a regular contributor naming their branch something else, since branch names are visible in the PR record.

## Refs

- #4306 — root forward-merge bug
- #4310 — backfill PR currently blocked on this exact check
- #4308 / #4309 — the auto-resolve narrowing fix that made `forward-merge/*` PRs more common (each push now surfaces a real PR rather than silently no-op'ing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)