### PR TITLE
ci(changeset-check): fix multi-condition if: syntax

### DIFF
--- a/.changeset/4315-changeset-check-if-syntax-fix.md
+++ b/.changeset/4315-changeset-check-if-syntax-fix.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci(changeset-check): inline the multi-condition `if:` expression on one line. The previous block-scalar form (`if: |` with a multi-line `${{ ... }}` body) didn't evaluate as expected — GitHub Actions ran the job for `forward-merge/*` PRs anyway. One-line expression mirrors the working pattern elsewhere in the repo. Closes the regression introduced by #4315.

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -18,9 +18,7 @@ jobs:
     #   .changeset/*.md files to explain them; the changes are explained by the
     #   3.0.x branch's CHANGELOG, not by a new changeset on main. Without this skip
     #   every forward-merge PR fails this check (see #4306, #4310).
-    if: |
-      ${{ !startsWith(github.head_ref, 'changeset-release/') &&
-          !startsWith(github.head_ref, 'forward-merge/') }}
+    if: ${{ !startsWith(github.head_ref, 'changeset-release/') && !startsWith(github.head_ref, 'forward-merge/') }}
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Follow-up to #4315. The block-scalar `if: |` form with a multi-line `${{ ... }}` body did not evaluate — GitHub Actions ran the changeset-check job on `forward-merge/*` PRs anyway (verified empirically on PR #4310's re-run after #4315 merged).

One-line expression mirrors the working pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)