### PR TITLE
ci(changeset-check): backport forward-merge/* skip rule to 3.0.x

### DIFF
--- a/.changeset/4310-changeset-check-skip-forward-merge-3.0.x.md
+++ b/.changeset/4310-changeset-check-skip-forward-merge-3.0.x.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci(changeset-check): backport `forward-merge/*` skip rule to 3.0.x. Mirrors #4315 + #4316 on main. Forward-merge PRs targeting 3.0.x (rare but possible — e.g., a 2.6.x → 3.0.x line in the future) will now skip the changeset check the same way main does.

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -8,9 +8,17 @@ jobs:
   check:
     name: Check for changeset
     runs-on: ubuntu-latest
-    # Skip changeset check on Version Packages PR (created by changesets/action)
-    # for any release line: changeset-release/main, changeset-release/3.0.x, etc.
-    if: ${{ !startsWith(github.head_ref, 'changeset-release/') }}
+    # Skip changeset check on:
+    # - Version Packages PRs (`changeset-release/<branch>`) — changesets/action consumes
+    #   .changeset files into a CHANGELOG bump, so by the time CI runs there are no
+    #   pending changesets to find.
+    # - Forward-merge PRs (`forward-merge/*`) — they merge a release branch (3.0.x)
+    #   whose changesets were already consumed by its own Version Packages cut.
+    #   From main's perspective, the merge brings package-changing commits with no
+    #   .changeset/*.md files to explain them; the changes are explained by the
+    #   3.0.x branch's CHANGELOG, not by a new changeset on main. Without this skip
+    #   every forward-merge PR fails this check (see #4306, #4310).
+    if: ${{ !startsWith(github.head_ref, 'changeset-release/') && !startsWith(github.head_ref, 'forward-merge/') }}
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Backport of #4315 + #4316 to `3.0.x`.

The changeset-check workflow runs on PRs to either `main`, `3.0.x`, or `2.6.x`. PRs to 3.0.x use 3.0.x's copy of the workflow. Without this backport, future forward-merge PRs targeting 3.0.x (e.g., from a 2.6.x line) would still hit the same structural failure that main's #4310 surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)