### PR TITLE
test(server): resolve migration 419 path relative to test file

### DIFF
--- a/.changeset/fix-agent-visibility-e2e-path.md
+++ b/.changeset/fix-agent-visibility-e2e-path.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only: fix `agent-visibility-e2e` path resolution so the legacy-`is_public` migration test works whether vitest runs from repo root or `server/`.

--- a/server/tests/integration/agent-visibility-e2e.test.ts
+++ b/server/tests/integration/agent-visibility-e2e.test.ts
@@ -477,10 +477,14 @@ describe('Agent visibility E2E', () => {
       ],
     );
 
-    // Re-run migration 419 explicitly to simulate the transform on legacy rows
+    // Re-run migration 419 explicitly to simulate the transform on legacy rows.
+    // Resolve relative to this file so the path works regardless of vitest cwd
+    // (root invocation vs. server/ invocation both stable).
     const fs = await import('fs/promises');
     const path = await import('path');
-    const sqlPath = path.resolve(process.cwd(), 'server/src/db/migrations/419_agent_visibility.sql');
+    const url = await import('url');
+    const here = path.dirname(url.fileURLToPath(import.meta.url));
+    const sqlPath = path.resolve(here, '../../src/db/migrations/419_agent_visibility.sql');
     const sql = await fs.readFile(sqlPath, 'utf-8');
     await pool.query(sql);
 


### PR DESCRIPTION
## Summary
- The legacy-`is_public` test in `agent-visibility-e2e.test.ts` was using `process.cwd()` to locate `419_agent_visibility.sql`. When vitest runs with `cwd=server/` (e.g. running a single file from inside `server/`), the path doubled up to `server/server/...` and the test failed with ENOENT.
- Resolve relative to `import.meta.url` instead, so the path is stable regardless of cwd.

Surfaced while running the Stage 2 (#4159) integration sweep — the test passes in CI because vitest is invoked from repo root, but fails locally when run from `server/`.

## Test plan
- [x] `cd server && npx vitest run tests/integration/agent-visibility-e2e.test.ts` — 14/14 passing
- [x] Confirmed pre-existing on `main`: same 1 failure / 13 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)