### PR TITLE
fix(server): prospect domain conflict no longer transfers ownership (#4321)

### DIFF
--- a/.changeset/4321-prospect-on-conflict-do-nothing.md
+++ b/.changeset/4321-prospect-on-conflict-do-nothing.md
@@ -1,0 +1,4 @@
+---
+---
+
+Server: `createProspect` no longer transfers `organization_domains` ownership on a domain conflict. After #4159 Stage 2, that row drives brand identity, so a stray `ON CONFLICT DO UPDATE` could silently move the brand-primary across orgs. Closes the medium finding from #4321.

--- a/server/src/services/prospect.ts
+++ b/server/src/services/prospect.ts
@@ -186,17 +186,39 @@ export async function createProspect(
 
     const org = result.rows[0];
 
-    // Also insert into organization_domains if domain provided
+    // Also insert into organization_domains if domain provided.
+    // DO NOTHING on conflict — `organization_domains.is_primary` is the
+    // single source of truth for brand identity (#4159 Stage 2), so a stray
+    // ON CONFLICT DO UPDATE here would silently transfer brand ownership
+    // from the original org to this prospect (#4321). The pre-check at
+    // resolveOrgByDomain above rejects known conflicts, so reaching the
+    // INSERT means we expect a clean insert; a conflict at this point is a
+    // race or alias-resolution miss — log and leave the existing row alone.
     if (normalizedDomain) {
-      await pool.query(
+      const insertResult = await pool.query<{ workos_organization_id: string }>(
         `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source)
          VALUES ($1, $2, true, true, 'import')
-         ON CONFLICT (domain) DO UPDATE SET
-           workos_organization_id = EXCLUDED.workos_organization_id,
-           is_primary = true,
-           updated_at = NOW()`,
+         ON CONFLICT (domain) DO NOTHING
+         RETURNING workos_organization_id`,
         [workosOrg.id, normalizedDomain]
       );
+
+      if (insertResult.rowCount === 0) {
+        const existing = await pool.query<{ workos_organization_id: string }>(
+          `SELECT workos_organization_id FROM organization_domains WHERE domain = $1`,
+          [normalizedDomain]
+        );
+        const existingOrgId = existing.rows[0]?.workos_organization_id;
+        logger.warn(
+          {
+            domain: normalizedDomain,
+            prospectOrgId: workosOrg.id,
+            existingOrgId,
+            sameOrg: existingOrgId === workosOrg.id,
+          },
+          'Prospect domain conflict — left existing organization_domains row in place',
+        );
+      }
 
       const bgPromise = researchDomain(normalizedDomain, { org_id: workosOrg.id }).catch((err) => {
         logger.warn(

--- a/server/tests/integration/prospect-domain-conflict.test.ts
+++ b/server/tests/integration/prospect-domain-conflict.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Pins the conflict-handling behavior in `createProspect` (#4321):
+ * when a domain row already exists for a different org, the prospect
+ * insert must NOT transfer ownership. After #4159 Stage 2,
+ * `organization_domains.is_primary` drives brand identity, so a stray
+ * `ON CONFLICT DO UPDATE SET workos_organization_id = EXCLUDED...` would
+ * silently move the brand-identity primary across orgs.
+ *
+ * Two layers of defense:
+ *   1. Pre-check at `resolveOrgByDomain` rejects callers whose domain is
+ *      already linked. This is the primary path users hit.
+ *   2. INSERT-level `ON CONFLICT (domain) DO NOTHING`. Catches races and
+ *      alias-resolution misses where the pre-check returns null but the
+ *      domain row already exists.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+
+const {
+  EXISTING_ORG_ID,
+  PROSPECT_ORG_ID,
+  TAKEN_DOMAIN,
+  FRESH_DOMAIN,
+  RACE_DOMAIN,
+  mockCreateOrganization,
+  mockResolveOrgByDomain,
+} = vi.hoisted(() => {
+  process.env.WORKOS_API_KEY ||= 'sk_test_dummy_for_unit_tests';
+  process.env.WORKOS_CLIENT_ID ||= 'client_test_dummy_for_unit_tests';
+  return {
+    EXISTING_ORG_ID: 'org_prospect_conflict_existing',
+    PROSPECT_ORG_ID: 'org_prospect_conflict_new',
+    TAKEN_DOMAIN: 'taken-by-original.test',
+    FRESH_DOMAIN: 'fresh-domain-for-prospect.test',
+    RACE_DOMAIN: 'race-conflict.test',
+    mockCreateOrganization: vi.fn(),
+    mockResolveOrgByDomain: vi.fn(),
+  };
+});
+
+vi.mock('@workos-inc/node', async () => {
+  const actual = await vi.importActual<typeof import('@workos-inc/node')>('@workos-inc/node');
+  return {
+    ...actual,
+    WorkOS: class {
+      organizations = {
+        createOrganization: mockCreateOrganization,
+      };
+    },
+  };
+});
+
+vi.mock('../../src/db/domain-resolution-db.js', () => ({
+  resolveOrgByDomain: mockResolveOrgByDomain,
+}));
+
+vi.mock('../../src/services/brand-enrichment.js', () => ({
+  researchDomain: vi.fn().mockResolvedValue(undefined),
+  trackBackground: vi.fn(),
+}));
+
+vi.mock('../../src/services/enrichment.js', () => ({
+  enrichOrganization: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/services/lusha.js', () => ({
+  isLushaConfigured: () => false,
+}));
+
+import { initializeDatabase, closeDatabase, getPool } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { createProspect } from '../../src/services/prospect.js';
+import type { Pool } from 'pg';
+
+const TEST_ORGS = [EXISTING_ORG_ID, PROSPECT_ORG_ID];
+const TEST_DOMAINS = [TAKEN_DOMAIN, FRESH_DOMAIN, RACE_DOMAIN];
+
+async function clearFixtures(pool: Pool) {
+  await pool.query('DELETE FROM organization_domains WHERE workos_organization_id = ANY($1)', [TEST_ORGS]);
+  await pool.query('DELETE FROM organization_domains WHERE domain = ANY($1)', [TEST_DOMAINS]);
+  await pool.query('DELETE FROM organizations WHERE workos_organization_id = ANY($1)', [TEST_ORGS]);
+}
+
+async function seedExistingOwner(pool: Pool, domain: string) {
+  await pool.query(
+    `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+     VALUES ($1, $2, false, NOW(), NOW())
+     ON CONFLICT (workos_organization_id) DO NOTHING`,
+    [EXISTING_ORG_ID, 'Original Owner'],
+  );
+  await pool.query(
+    `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source, created_at, updated_at)
+     VALUES ($1, $2, true, true, 'workos', NOW(), NOW())
+     ON CONFLICT (domain) DO NOTHING`,
+    [EXISTING_ORG_ID, domain],
+  );
+}
+
+describe('createProspect domain conflict handling (#4321)', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString:
+        process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  });
+
+  afterAll(async () => {
+    await clearFixtures(pool);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await clearFixtures(pool);
+    mockCreateOrganization.mockReset();
+    mockCreateOrganization.mockResolvedValue({
+      id: PROSPECT_ORG_ID,
+      name: 'New Prospect',
+    });
+    mockResolveOrgByDomain.mockReset();
+    mockResolveOrgByDomain.mockResolvedValue(null);
+  });
+
+  it('pre-check rejects when domain is already linked to another org', async () => {
+    await seedExistingOwner(pool, TAKEN_DOMAIN);
+
+    // The real resolver would catch this — restore real behavior for one call.
+    mockResolveOrgByDomain.mockResolvedValueOnce({
+      orgId: EXISTING_ORG_ID,
+      matchedDomain: TAKEN_DOMAIN,
+      method: 'exact',
+    });
+
+    const result = await createProspect({
+      name: 'Some Prospect',
+      domain: TAKEN_DOMAIN,
+      prospect_source: 'manual',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.alreadyExists).toBe(true);
+
+    const row = await pool.query(
+      `SELECT workos_organization_id FROM organization_domains WHERE domain = $1`,
+      [TAKEN_DOMAIN],
+    );
+    expect(row.rows[0].workos_organization_id).toBe(EXISTING_ORG_ID);
+  });
+
+  it('INSERT-level conflict (race / resolver-miss) does NOT transfer ownership', async () => {
+    // Bypass the pre-check (mockResolveOrgByDomain returns null by default)
+    // to simulate the race condition: two concurrent createProspect calls
+    // for the same domain both passing the pre-check, then one losing the
+    // INSERT race. The loser must not steal the winner's row.
+    await seedExistingOwner(pool, RACE_DOMAIN);
+
+    const result = await createProspect({
+      name: 'New Prospect',
+      domain: RACE_DOMAIN,
+      prospect_source: 'manual',
+    });
+
+    // Org-level creation succeeded — only the domain link was rejected.
+    expect(result.success).toBe(true);
+
+    const row = await pool.query(
+      `SELECT workos_organization_id, is_primary, source
+         FROM organization_domains WHERE domain = $1`,
+      [RACE_DOMAIN],
+    );
+    expect(row.rowCount).toBe(1);
+    expect(row.rows[0].workos_organization_id).toBe(EXISTING_ORG_ID);
+    expect(row.rows[0].is_primary).toBe(true);
+    expect(row.rows[0].source).toBe('workos');
+
+    // Prospect org exists in organizations but has no domain link.
+    const prospectDomains = await pool.query(
+      `SELECT domain FROM organization_domains WHERE workos_organization_id = $1`,
+      [PROSPECT_ORG_ID],
+    );
+    expect(prospectDomains.rowCount).toBe(0);
+  });
+
+  it('inserts a new organization_domains row for a fresh domain (no conflict)', async () => {
+    const result = await createProspect({
+      name: 'New Prospect',
+      domain: FRESH_DOMAIN,
+      prospect_source: 'manual',
+    });
+
+    expect(result.success).toBe(true);
+
+    const row = await pool.query(
+      `SELECT workos_organization_id, is_primary, verified, source
+         FROM organization_domains WHERE domain = $1`,
+      [FRESH_DOMAIN],
+    );
+    expect(row.rowCount).toBe(1);
+    expect(row.rows[0].workos_organization_id).toBe(PROSPECT_ORG_ID);
+    expect(row.rows[0].is_primary).toBe(true);
+    expect(row.rows[0].verified).toBe(true);
+    expect(row.rows[0].source).toBe('import');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the medium finding in #4321.

Before #4159 Stage 2, `organization_domains.is_primary` only drove org-membership inference; after Stage 2 it also drives brand identity. The `ON CONFLICT (domain) DO UPDATE` in `createProspect` was rewriting `workos_organization_id` and `is_primary=true` on conflict — silently transferring brand identity from the original owner to a fresh prospect org.

Switch to `ON CONFLICT (domain) DO NOTHING` and log when the existing row is owned by a different `workos_organization_id`.

## Two layers of defense

1. **Pre-check at `resolveOrgByDomain`** — already rejects callers whose domain is already linked. This is the path users hit in normal operation.
2. **INSERT-level `ON CONFLICT DO NOTHING`** (this PR) — catches races and alias-resolution misses where the pre-check returns null but the unique constraint still fires.

## Out of scope

The two **Low** findings from #4321 (admin-side `is_primary=true` inserts in `admin/domains.ts` / `organization-bootstrap.ts` from non-WorkOS sources, and the FOR UPDATE serialization comment correction in `me-organization-domains.ts`) are not addressed here. The first is admin-trust scope; the second is a comment fix. Will track separately if they need action.

## Test plan

- [x] New `tests/integration/prospect-domain-conflict.test.ts` — 3 cases:
  - Pre-check rejects when domain is already linked.
  - INSERT-level conflict (race / resolver-miss) does NOT transfer ownership.
  - Fresh-domain insert still works.
- [x] Sibling tests still pass: `prospect-triage-function`, `claim-prospect-org`, `find-claimable-prospect-org` (20/20).
- [x] Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)