### PR TITLE
docs: convert broken anchor links in RELEASING.md to plain text

### DIFF
--- a/.changeset/fix-releasing-broken-anchors.md
+++ b/.changeset/fix-releasing-broken-anchors.md
@@ -1,0 +1,4 @@
+---
+---
+
+Docs: convert two markdown links in `RELEASING.md` that pointed at `.agents/playbook.md` anchors into plain-text references. Mintlify's broken-link checker can't resolve anchors in files outside the docs root, so it flagged them on every PR that touches a docs path. The playbook anchors do exist as headings; the references now match the existing plain-text style elsewhere in the file.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Release Process
 
-This document describes how to manage releases of the AdCP specification using Changesets. **For deeper operational guidance** — release lines, cherry-pick conventions, the forward-merge workflow, manual resolution recipes, and the 3.1.0 transition plan — see [`.agents/playbook.md` § Release lines](.agents/playbook.md#release-lines). The playbook is canonical; this file is the introductory walkthrough.
+This document describes how to manage releases of the AdCP specification using Changesets. **For deeper operational guidance** — release lines, cherry-pick conventions, the forward-merge workflow, manual resolution recipes, and the 3.1.0 transition plan — see `.agents/playbook.md` (§ Release lines). The playbook is canonical; this file is the introductory walkthrough.
 
 ## Overview
 
@@ -203,7 +203,7 @@ See `.agents/playbook.md` for the full manual forward-merge runbook.
 
 ### Forward-merge workflow fails loud on content conflicts
 
-Expected behavior when 3.0.x has changes in the cross-line-divergent files (`error-code.json`, `storyboard-schema.yaml`, `runner-output-contract.yaml`, `error.json`, `get-adcp-capabilities-response.json`, `training-agent-storyboards.yml`, `error-handling.mdx`). The workflow's error message includes the manual resolution recipe. See [playbook § Cherry-pick convention](.agents/playbook.md#cherry-pick-convention) for the full procedure and rationale.
+Expected behavior when 3.0.x has changes in the cross-line-divergent files (`error-code.json`, `storyboard-schema.yaml`, `runner-output-contract.yaml`, `error.json`, `get-adcp-capabilities-response.json`, `training-agent-storyboards.yml`, `error-handling.mdx`). The workflow's error message includes the manual resolution recipe. See `.agents/playbook.md` (§ Cherry-pick convention) for the full procedure and rationale.
 
 ### Changesets not found
 


### PR DESCRIPTION
## Summary

Mintlify's broken-link checker can't resolve anchors in files outside the docs root (\`.agents/\`), so two links in \`RELEASING.md\` were being flagged on every PR that touches a docs path:

- \`.agents/playbook.md#release-lines\`
- \`.agents/playbook.md#cherry-pick-convention\`

Both anchors **do** exist as headings in \`.agents/playbook.md\` (lines 252 and 261), but mintlify won't follow into a file it doesn't index. Convert the markdown links to plain-text references that match the existing \`.agents/playbook.md\` style elsewhere in the same file (line 202).

## Test plan

- [x] Pre-push hook runs on PRs touching \`server/src/addie/*.ts\` and other DOC_PATHS — would previously fail with these two broken-link errors.
- [x] After this PR, the link check on subsequent PRs that touch DOC_PATHS will pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)