### PR TITLE
feat(server): canonical organization_domains writers (#4159 Stage 3a)

### DIFF
--- a/.changeset/4159-stage3a-writer-primitives.md
+++ b/.changeset/4159-stage3a-writer-primitives.md
@@ -1,0 +1,4 @@
+---
+---
+
+Server: introduce `db/organization-domains-db.ts` with two canonical writers — `linkDomain` and `setPrimaryDomain` — and migrate the simpler call sites (prospect, organization-bootstrap, member-profiles bootstrap, bolt-app, me-organization-domains). Stage 3a of #4159. WorkOS webhook and admin/domains.ts still use inline SQL; covered by 3b/3c.

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -38,6 +38,7 @@ import { AddieDatabase } from '../db/addie-db.js';
 import { SlackDatabase } from '../db/slack-db.js';
 import { EmailPreferencesDatabase } from '../db/email-preferences-db.js';
 import { getPool } from '../db/client.js';
+import { linkDomain } from '../db/organization-domains-db.js';
 import {
   isKnowledgeReady,
   createKnowledgeToolHandlers,
@@ -2708,13 +2709,13 @@ async function handleAliasConfirm({ ack, body, client }: any): Promise<void> {
       return;
     }
 
-    // Add domain to organization_domains
-    await pool.query(
-      `INSERT INTO organization_domains (workos_organization_id, domain)
-       VALUES ($1, $2)
-       ON CONFLICT DO NOTHING`,
-      [orgId, domain]
-    );
+    await linkDomain({
+      orgId,
+      domain,
+      source: 'manual',
+      verified: false,
+      isPrimary: false,
+    });
     const orgRow = orgResult.rows[0];
 
     if (orgRow?.email_domain) {

--- a/server/src/db/organization-domains-db.ts
+++ b/server/src/db/organization-domains-db.ts
@@ -1,0 +1,162 @@
+/**
+ * Canonical writer module for `organization_domains` (#4159 Stage 3).
+ *
+ * Stage 2 collapsed brand identity and org-membership inference onto a single
+ * `organization_domains.is_primary=true` row. Stage 3 consolidates the write
+ * paths so every caller goes through the same two primitives instead of
+ * each reinventing the SQL with subtly different invariants:
+ *
+ *   - `linkDomain` — INSERT a row, DO NOTHING on conflict, log when the
+ *     existing row is owned by a different org. When `isPrimary=true` and
+ *     the row was actually inserted, also denormalize
+ *     `organizations.email_domain` so the two stay in sync (#4159 invariant).
+ *
+ *   - `setPrimaryDomain` — atomic clear-existing-primary + set-new-primary +
+ *     update `organizations.email_domain`. Locks the org row to serialize
+ *     against concurrent writers (member self-service, WorkOS webhook,
+ *     admin Set Primary). Optionally requires the target row's `source`
+ *     match an allowlist (the `'workos'`-only gate the member self-service
+ *     route enforces today).
+ */
+import { getPool } from './client.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('organization-domains-db');
+
+export type DomainSource =
+  | 'workos'
+  | 'email_verification'
+  | 'import'
+  | 'admin_discovery'
+  | 'manual';
+
+export interface LinkDomainArgs {
+  orgId: string;
+  domain: string;
+  source: DomainSource;
+  verified: boolean;
+  isPrimary?: boolean;
+}
+
+export interface LinkDomainResult {
+  inserted: boolean;
+  conflictOrgId: string | null;
+}
+
+export async function linkDomain(args: LinkDomainArgs): Promise<LinkDomainResult> {
+  const { orgId, domain, source, verified, isPrimary = false } = args;
+  const pool = getPool();
+
+  const insertResult = await pool.query<{ workos_organization_id: string }>(
+    `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source)
+     VALUES ($1, $2, $3, $4, $5)
+     ON CONFLICT (domain) DO NOTHING
+     RETURNING workos_organization_id`,
+    [orgId, domain, isPrimary, verified, source],
+  );
+
+  if (insertResult.rowCount === 0) {
+    const existing = await pool.query<{ workos_organization_id: string }>(
+      `SELECT workos_organization_id FROM organization_domains WHERE domain = $1`,
+      [domain],
+    );
+    const existingOrgId = existing.rows[0]?.workos_organization_id ?? null;
+    const conflictOrgId = existingOrgId !== orgId ? existingOrgId : null;
+    if (conflictOrgId) {
+      logger.warn(
+        { domain, orgId, existingOrgId },
+        'linkDomain: domain conflict — left existing organization_domains row in place',
+      );
+    }
+    return { inserted: false, conflictOrgId };
+  }
+
+  if (isPrimary) {
+    await pool.query(
+      `UPDATE organizations SET email_domain = $1, updated_at = NOW()
+        WHERE workos_organization_id = $2`,
+      [domain, orgId],
+    );
+  }
+
+  return { inserted: true, conflictOrgId: null };
+}
+
+export interface SetPrimaryDomainArgs {
+  orgId: string;
+  domain: string;
+  requireSource?: ReadonlyArray<DomainSource>;
+}
+
+export type SetPrimaryDomainResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason: 'not_found' | 'not_verified' | 'source_not_allowed';
+      foundSource?: string;
+    };
+
+export async function setPrimaryDomain(
+  args: SetPrimaryDomainArgs,
+): Promise<SetPrimaryDomainResult> {
+  const { orgId, domain, requireSource } = args;
+  const pool = getPool();
+  const client = await pool.connect();
+
+  try {
+    await client.query('BEGIN');
+
+    await client.query(
+      'SELECT 1 FROM organizations WHERE workos_organization_id = $1 FOR UPDATE',
+      [orgId],
+    );
+
+    const domainRow = await client.query<{ verified: boolean; source: string }>(
+      `SELECT verified, source FROM organization_domains
+        WHERE workos_organization_id = $1 AND domain = $2`,
+      [orgId, domain],
+    );
+    if (domainRow.rowCount === 0) {
+      await client.query('ROLLBACK');
+      return { ok: false, reason: 'not_found' };
+    }
+    if (!domainRow.rows[0].verified) {
+      await client.query('ROLLBACK');
+      return { ok: false, reason: 'not_verified' };
+    }
+    if (requireSource && !requireSource.includes(domainRow.rows[0].source as DomainSource)) {
+      await client.query('ROLLBACK');
+      return {
+        ok: false,
+        reason: 'source_not_allowed',
+        foundSource: domainRow.rows[0].source,
+      };
+    }
+
+    await client.query(
+      `UPDATE organization_domains SET is_primary = false, updated_at = NOW()
+        WHERE workos_organization_id = $1 AND is_primary = true`,
+      [orgId],
+    );
+    await client.query(
+      `UPDATE organization_domains SET is_primary = true, updated_at = NOW()
+        WHERE workos_organization_id = $1 AND domain = $2`,
+      [orgId, domain],
+    );
+    await client.query(
+      `UPDATE organizations SET email_domain = $1, updated_at = NOW()
+        WHERE workos_organization_id = $2`,
+      [domain, orgId],
+    );
+
+    await client.query('COMMIT');
+    return { ok: true };
+  } catch (err) {
+    await client.query('ROLLBACK').catch((rbErr) => {
+      logger.error({ rbErr, orgId, domain }, 'ROLLBACK failed in setPrimaryDomain');
+    });
+    throw err;
+  } finally {
+    client.release();
+  }
+}

--- a/server/src/routes/me-organization-domains.ts
+++ b/server/src/routes/me-organization-domains.ts
@@ -22,6 +22,7 @@ import { requireAuth } from '../middleware/auth.js';
 import { resolvePrimaryOrganization } from '../db/users-db.js';
 import { resolveUserOrgMembership } from '../utils/resolve-user-org-membership.js';
 import { getPool } from '../db/client.js';
+import { setPrimaryDomain } from '../db/organization-domains-db.js';
 import {
   assertClaimableBrandDomain,
   canonicalizeBrandDomain,
@@ -147,101 +148,53 @@ export function createMeOrganizationDomainsRouter(
         return res.status(400).json({ error: 'invalid_domain' });
       }
 
-      const pool = getPool();
-      const client = await pool.connect();
+      // Member self-service: only WorkOS-verified rows are eligible. After
+      // Stage 2 of #4159, is_primary drives BOTH org-membership inference
+      // AND brand identity, so we hold the bar at WorkOS DNS proof.
+      // Admin-imported / manual rows aren't DNS-proof-of-control claims and
+      // pending rows are pre-verification — the source allowlist below is
+      // the security gate.
+      const result = await setPrimaryDomain({
+        orgId,
+        domain: normalizedDomain,
+        requireSource: ['workos'],
+      });
 
-      try {
-        await client.query('BEGIN');
-
-        // Lock the org row to serialize against the WorkOS webhook
-        // (`upsertOrganizationDomain`), which takes the same row lock when it
-        // promotes a newly-verified domain to is_primary. Without this, our
-        // three writes can interleave with the webhook's two writes and end
-        // up with `organizations.email_domain` reflecting whichever
-        // transaction committed last.
-        await client.query(
-          'SELECT 1 FROM organizations WHERE workos_organization_id = $1 FOR UPDATE',
-          [orgId],
-        );
-
-        // Verify the domain belongs to this org and is a WorkOS-verified row.
-        // After Stage 2 of #4159, is_primary drives BOTH org-membership
-        // inference AND brand identity, so we hold the bar at WorkOS DNS
-        // proof: pending rows are pre-verification (would grant SSO claim
-        // before WorkOS confirms control) and admin-imported / manual rows
-        // aren't DNS-proof-of-control claims (would let an admin-imported
-        // verified=true row escalate to brand identity via member self-service).
-        const domainRow = await client.query<{ verified: boolean; source: string }>(
-          `SELECT verified, source FROM organization_domains
-            WHERE workos_organization_id = $1 AND domain = $2`,
-          [orgId, normalizedDomain],
-        );
-        if (domainRow.rowCount === 0) {
-          await client.query('ROLLBACK');
+      if (!result.ok) {
+        if (result.reason === 'not_found') {
           return res.status(404).json({ error: 'Domain not found for this organization' });
         }
-        if (!domainRow.rows[0].verified) {
-          await client.query('ROLLBACK');
+        if (result.reason === 'not_verified') {
           return res.status(400).json({
             error: 'domain_not_verified',
             message: 'The domain must be verified before it can be set as primary',
           });
         }
-        if (domainRow.rows[0].source !== 'workos') {
-          await client.query('ROLLBACK');
-          return res.status(400).json({
-            error: 'domain_not_workos_verified',
-            message: 'Only domains verified through WorkOS DNS challenge can be set as primary',
-          });
-        }
-
-        // Clear existing primary, set new primary, and update the
-        // denormalized organizations.email_domain in one transaction.
-        await client.query(
-          `UPDATE organization_domains SET is_primary = false, updated_at = NOW()
-            WHERE workos_organization_id = $1 AND is_primary = true`,
-          [orgId],
-        );
-        await client.query(
-          `UPDATE organization_domains SET is_primary = true, updated_at = NOW()
-            WHERE workos_organization_id = $1 AND domain = $2`,
-          [orgId, normalizedDomain],
-        );
-        await client.query(
-          `UPDATE organizations SET email_domain = $1, updated_at = NOW()
-            WHERE workos_organization_id = $2`,
-          [normalizedDomain, orgId],
-        );
-
-        await client.query('COMMIT');
-
-        // Brand-identity primary now mirrors org-membership-inference primary
-        // via the same row, so any member-context cache that depended on
-        // brand-primary still needs invalidation when the row flips.
-        invalidateMemberContextCache();
-
-        logger.info(
-          {
-            orgId,
-            domain: normalizedDomain,
-            actor: req.user!.id,
-            via_dev_bypass: membership.via_dev_bypass,
-          },
-          'Set primary domain via member self-service',
-        );
-
-        return res.json({
-          success: true,
-          primary_domain: normalizedDomain,
+        return res.status(400).json({
+          error: 'domain_not_workos_verified',
+          message: 'Only domains verified through WorkOS DNS challenge can be set as primary',
         });
-      } catch (err) {
-        await client.query('ROLLBACK').catch((rbErr) => {
-          logger.error({ rbErr, orgId }, 'ROLLBACK failed in PUT primary');
-        });
-        throw err;
-      } finally {
-        client.release();
       }
+
+      // Brand-identity primary now mirrors org-membership-inference primary
+      // via the same row, so any member-context cache that depended on
+      // brand-primary still needs invalidation when the row flips.
+      invalidateMemberContextCache();
+
+      logger.info(
+        {
+          orgId,
+          domain: normalizedDomain,
+          actor: req.user!.id,
+          via_dev_bypass: membership.via_dev_bypass,
+        },
+        'Set primary domain via member self-service',
+      );
+
+      return res.json({
+        success: true,
+        primary_domain: normalizedDomain,
+      });
     } catch (err) {
       logger.error({ err }, 'PUT /api/me/organization/domains/:domain/primary failed');
       return res.status(500).json({ error: 'Failed to set primary domain' });

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -20,6 +20,7 @@ import { BrandDatabase, resolveBrandFromJson } from "../db/brand-db.js";
 import { BrandManager } from "../brand-manager.js";
 import { OrganizationDatabase, hasApiAccess, readMembershipTierFromClient, resolveMembershipTier, VALID_REVENUE_TIERS, VALID_MEMBERSHIP_TIERS } from "../db/organization-db.js";
 import { OrgKnowledgeDatabase } from "../db/org-knowledge-db.js";
+import { linkDomain } from "../db/organization-domains-db.js";
 import { autoLinkByVerifiedDomain } from "../db/membership-db.js";
 import { resolvePrimaryOrganization } from "../db/users-db.js";
 import { AAO_HOST } from "../config/aao.js";
@@ -501,27 +502,16 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       // on this org and no domain link — half-broken state, no signal.
       // We still create the profile so programmatic callers aren't blocked
       // on an admin-resolvable issue.
-      const pool = getPool();
       let domainConflictOrgId: string | null = null;
       try {
-        const existingDomain = await pool.query<{ workos_organization_id: string }>(
-          `SELECT workos_organization_id FROM organization_domains WHERE LOWER(domain) = LOWER($1)`,
-          [corporateDomain],
-        );
-        if (existingDomain.rows.length === 0) {
-          await pool.query(
-            `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source)
-             VALUES ($1, $2, true, true, 'email_verification')
-             ON CONFLICT (domain) DO NOTHING`,
-            [targetOrgId, corporateDomain],
-          );
-        } else if (existingDomain.rows[0].workos_organization_id !== targetOrgId) {
-          domainConflictOrgId = existingDomain.rows[0].workos_organization_id;
-          logger.warn(
-            { orgId: targetOrgId, conflictOrgId: domainConflictOrgId, domain: corporateDomain },
-            'Bootstrap: corporate_domain already linked to a different org; profile created without domain link',
-          );
-        }
+        const result = await linkDomain({
+          orgId: targetOrgId,
+          domain: corporateDomain,
+          source: 'email_verification',
+          verified: true,
+          isPrimary: true,
+        });
+        domainConflictOrgId = result.conflictOrgId;
       } catch (err) {
         logger.warn({ err, orgId: targetOrgId, domain: corporateDomain }, 'Failed to write organization_domains during bootstrap');
       }

--- a/server/src/services/organization-bootstrap.ts
+++ b/server/src/services/organization-bootstrap.ts
@@ -24,6 +24,7 @@ import { WorkOS } from '@workos-inc/node';
 import { getPool } from '../db/client.js';
 import { createLogger } from '../logger.js';
 import { OrganizationDatabase, CompanyType, RevenueTier, VALID_REVENUE_TIERS } from '../db/organization-db.js';
+import { linkDomain } from '../db/organization-domains-db.js';
 import { COMPANY_TYPE_VALUES } from '../config/company-types.js';
 import { validateOrganizationName } from '../middleware/validation.js';
 import { getCompanyDomain } from '../utils/email-domain.js';
@@ -296,29 +297,14 @@ export async function performCreateOrganization(
   }, 'Organization record created');
 
   if (verifiedDomain) {
-    const existingDomainResult = await pool.query(
-      `SELECT workos_organization_id FROM organization_domains WHERE domain = $1`,
-      [verifiedDomain],
-    );
-
-    if (existingDomainResult.rows.length > 0 && existingDomainResult.rows[0].workos_organization_id !== workosOrgId) {
-      logger.warn({
-        orgId: workosOrgId,
-        domain: verifiedDomain,
-        existingOrgId: existingDomainResult.rows[0].workos_organization_id,
-      }, 'Domain already claimed; skipping domain assignment');
-    } else {
-      await pool.query(
-        `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source)
-         VALUES ($1, $2, true, true, 'email_verification')
-         ON CONFLICT (domain) DO NOTHING`,
-        [workosOrgId, verifiedDomain],
-      );
-      await pool.query(
-        `UPDATE organizations SET email_domain = $1, updated_at = NOW()
-         WHERE workos_organization_id = $2`,
-        [verifiedDomain, workosOrgId],
-      );
+    const result = await linkDomain({
+      orgId: workosOrgId,
+      domain: verifiedDomain,
+      source: 'email_verification',
+      verified: true,
+      isPrimary: true,
+    });
+    if (result.inserted) {
       logger.info({ orgId: workosOrgId, domain: verifiedDomain }, 'Corporate domain auto-verified via email');
     }
   }

--- a/server/src/services/prospect.ts
+++ b/server/src/services/prospect.ts
@@ -10,6 +10,7 @@ import { createLogger } from '../logger.js';
 import { WorkOS, DomainDataState } from '@workos-inc/node';
 import { resolveOrgByDomain } from '../db/domain-resolution-db.js';
 import { researchDomain, trackBackground } from './brand-enrichment.js';
+import { linkDomain } from '../db/organization-domains-db.js';
 import { enrichOrganization } from './enrichment.js';
 import { isLushaConfigured } from './lusha.js';
 import { COMPANY_TYPE_VALUES } from '../config/company-types.js';
@@ -186,39 +187,14 @@ export async function createProspect(
 
     const org = result.rows[0];
 
-    // Also insert into organization_domains if domain provided.
-    // DO NOTHING on conflict — `organization_domains.is_primary` is the
-    // single source of truth for brand identity (#4159 Stage 2), so a stray
-    // ON CONFLICT DO UPDATE here would silently transfer brand ownership
-    // from the original org to this prospect (#4321). The pre-check at
-    // resolveOrgByDomain above rejects known conflicts, so reaching the
-    // INSERT means we expect a clean insert; a conflict at this point is a
-    // race or alias-resolution miss — log and leave the existing row alone.
     if (normalizedDomain) {
-      const insertResult = await pool.query<{ workos_organization_id: string }>(
-        `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source)
-         VALUES ($1, $2, true, true, 'import')
-         ON CONFLICT (domain) DO NOTHING
-         RETURNING workos_organization_id`,
-        [workosOrg.id, normalizedDomain]
-      );
-
-      if (insertResult.rowCount === 0) {
-        const existing = await pool.query<{ workos_organization_id: string }>(
-          `SELECT workos_organization_id FROM organization_domains WHERE domain = $1`,
-          [normalizedDomain]
-        );
-        const existingOrgId = existing.rows[0]?.workos_organization_id;
-        logger.warn(
-          {
-            domain: normalizedDomain,
-            prospectOrgId: workosOrg.id,
-            existingOrgId,
-            sameOrg: existingOrgId === workosOrg.id,
-          },
-          'Prospect domain conflict — left existing organization_domains row in place',
-        );
-      }
+      await linkDomain({
+        orgId: workosOrg.id,
+        domain: normalizedDomain,
+        source: 'import',
+        verified: true,
+        isPrimary: true,
+      });
 
       const bgPromise = researchDomain(normalizedDomain, { org_id: workosOrg.id }).catch((err) => {
         logger.warn(

--- a/server/tests/integration/organization-domains-db.test.ts
+++ b/server/tests/integration/organization-domains-db.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Pins the invariants of the canonical writer module
+ * `db/organization-domains-db.ts` (#4159 Stage 3a).
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { initializeDatabase, closeDatabase, getPool } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { linkDomain, setPrimaryDomain } from '../../src/db/organization-domains-db.js';
+import type { Pool } from 'pg';
+
+const ORG_A = 'org_orgdom_db_a';
+const ORG_B = 'org_orgdom_db_b';
+const D1 = 'orgdom-db-1.test';
+const D2 = 'orgdom-db-2.test';
+const D3 = 'orgdom-db-3.test';
+const D_TAKEN = 'orgdom-db-taken.test';
+
+const TEST_ORGS = [ORG_A, ORG_B];
+const TEST_DOMAINS = [D1, D2, D3, D_TAKEN];
+
+async function clearFixtures(pool: Pool) {
+  await pool.query('DELETE FROM organization_domains WHERE workos_organization_id = ANY($1)', [TEST_ORGS]);
+  await pool.query('DELETE FROM organization_domains WHERE domain = ANY($1)', [TEST_DOMAINS]);
+  await pool.query('DELETE FROM organizations WHERE workos_organization_id = ANY($1)', [TEST_ORGS]);
+}
+
+async function seedOrg(pool: Pool, orgId: string) {
+  await pool.query(
+    `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+     VALUES ($1, $2, false, NOW(), NOW())
+     ON CONFLICT (workos_organization_id) DO NOTHING`,
+    [orgId, `Org ${orgId}`],
+  );
+}
+
+describe('organization-domains-db (#4159 Stage 3a)', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString:
+        process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  });
+
+  afterAll(async () => {
+    await clearFixtures(pool);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await clearFixtures(pool);
+    await seedOrg(pool, ORG_A);
+    await seedOrg(pool, ORG_B);
+  });
+
+  describe('linkDomain', () => {
+    it('inserts a row and returns inserted=true', async () => {
+      const result = await linkDomain({
+        orgId: ORG_A,
+        domain: D1,
+        source: 'workos',
+        verified: true,
+        isPrimary: false,
+      });
+
+      expect(result).toEqual({ inserted: true, conflictOrgId: null });
+
+      const row = await getPool().query(
+        `SELECT workos_organization_id, source, verified, is_primary FROM organization_domains WHERE domain = $1`,
+        [D1],
+      );
+      expect(row.rows[0]).toMatchObject({
+        workos_organization_id: ORG_A,
+        source: 'workos',
+        verified: true,
+        is_primary: false,
+      });
+    });
+
+    it('with isPrimary=true also denormalizes organizations.email_domain', async () => {
+      await linkDomain({
+        orgId: ORG_A,
+        domain: D1,
+        source: 'email_verification',
+        verified: true,
+        isPrimary: true,
+      });
+
+      const org = await getPool().query(
+        `SELECT email_domain FROM organizations WHERE workos_organization_id = $1`,
+        [ORG_A],
+      );
+      expect(org.rows[0].email_domain).toBe(D1);
+    });
+
+    it('does NOT touch email_domain when isPrimary=false', async () => {
+      await getPool().query(
+        `UPDATE organizations SET email_domain = 'pre-existing.test' WHERE workos_organization_id = $1`,
+        [ORG_A],
+      );
+
+      await linkDomain({
+        orgId: ORG_A,
+        domain: D2,
+        source: 'manual',
+        verified: false,
+        isPrimary: false,
+      });
+
+      const org = await getPool().query(
+        `SELECT email_domain FROM organizations WHERE workos_organization_id = $1`,
+        [ORG_A],
+      );
+      expect(org.rows[0].email_domain).toBe('pre-existing.test');
+    });
+
+    it('returns inserted=false and conflictOrgId=null for same-org conflict (idempotent re-link)', async () => {
+      await linkDomain({ orgId: ORG_A, domain: D1, source: 'workos', verified: true, isPrimary: true });
+
+      const second = await linkDomain({
+        orgId: ORG_A,
+        domain: D1,
+        source: 'workos',
+        verified: true,
+        isPrimary: true,
+      });
+
+      expect(second).toEqual({ inserted: false, conflictOrgId: null });
+    });
+
+    it('returns inserted=false and conflictOrgId=ORG_B for cross-org conflict; existing row untouched', async () => {
+      await linkDomain({ orgId: ORG_B, domain: D_TAKEN, source: 'workos', verified: true, isPrimary: true });
+
+      const result = await linkDomain({
+        orgId: ORG_A,
+        domain: D_TAKEN,
+        source: 'import',
+        verified: true,
+        isPrimary: true,
+      });
+
+      expect(result).toEqual({ inserted: false, conflictOrgId: ORG_B });
+
+      const row = await getPool().query(
+        `SELECT workos_organization_id, source, is_primary FROM organization_domains WHERE domain = $1`,
+        [D_TAKEN],
+      );
+      expect(row.rows[0]).toMatchObject({
+        workos_organization_id: ORG_B,
+        source: 'workos',
+        is_primary: true,
+      });
+    });
+  });
+
+  describe('setPrimaryDomain', () => {
+    beforeEach(async () => {
+      // Seed two verified workos rows on ORG_A; one is primary.
+      await linkDomain({ orgId: ORG_A, domain: D1, source: 'workos', verified: true, isPrimary: true });
+      await linkDomain({ orgId: ORG_A, domain: D2, source: 'workos', verified: true, isPrimary: false });
+    });
+
+    it('flips primary atomically and updates organizations.email_domain', async () => {
+      const result = await setPrimaryDomain({ orgId: ORG_A, domain: D2 });
+      expect(result).toEqual({ ok: true });
+
+      const rows = await getPool().query(
+        `SELECT domain, is_primary FROM organization_domains
+          WHERE workos_organization_id = $1 ORDER BY domain`,
+        [ORG_A],
+      );
+      expect(rows.rows).toEqual([
+        { domain: D1, is_primary: false },
+        { domain: D2, is_primary: true },
+      ]);
+
+      const org = await getPool().query(
+        `SELECT email_domain FROM organizations WHERE workos_organization_id = $1`,
+        [ORG_A],
+      );
+      expect(org.rows[0].email_domain).toBe(D2);
+    });
+
+    it('returns not_found when the domain is not linked to the org', async () => {
+      const result = await setPrimaryDomain({ orgId: ORG_A, domain: 'never-linked.test' });
+      expect(result).toEqual({ ok: false, reason: 'not_found' });
+    });
+
+    it('returns not_verified when the row is unverified', async () => {
+      await linkDomain({ orgId: ORG_A, domain: D3, source: 'workos', verified: false, isPrimary: false });
+
+      const result = await setPrimaryDomain({ orgId: ORG_A, domain: D3 });
+      expect(result).toEqual({ ok: false, reason: 'not_verified' });
+    });
+
+    it('returns source_not_allowed when requireSource excludes the row source', async () => {
+      await linkDomain({ orgId: ORG_A, domain: D3, source: 'import', verified: true, isPrimary: false });
+
+      const result = await setPrimaryDomain({
+        orgId: ORG_A,
+        domain: D3,
+        requireSource: ['workos'],
+      });
+      expect(result).toMatchObject({ ok: false, reason: 'source_not_allowed', foundSource: 'import' });
+
+      // Existing primary is unchanged.
+      const rows = await getPool().query(
+        `SELECT domain FROM organization_domains
+          WHERE workos_organization_id = $1 AND is_primary = true`,
+        [ORG_A],
+      );
+      expect(rows.rows[0].domain).toBe(D1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Stage 3a of #4159. Stage 2 collapsed four overlapping domain columns onto \`organization_domains.is_primary=true\`. This PR consolidates the **write paths** behind two canonical primitives so every caller goes through the same SQL with the same invariants.

### New module: \`db/organization-domains-db.ts\`

- **\`linkDomain({orgId, domain, source, verified, isPrimary?})\`** — INSERT a row. \`ON CONFLICT (domain) DO NOTHING\`. Logs when the existing row is owned by a different org (#4321 pattern, generalized). When \`isPrimary=true\` and the row was actually inserted, also denormalizes \`organizations.email_domain\` — closes a latent drift in the prior member-profiles / prospect call sites that updated only one side.

- **\`setPrimaryDomain({orgId, domain, requireSource?})\`** — atomic clear-existing-primary + set-new-primary + update \`organizations.email_domain\`. Locks the org row via FOR UPDATE. Optional \`requireSource\` allowlist (e.g. \`['workos']\` for member self-service).

### Migrated call sites

| File | Now uses | Notes |
|------|----------|-------|
| \`services/prospect.ts\` | \`linkDomain\` | Replaces #4323's hand-rolled INSERT + log |
| \`services/organization-bootstrap.ts\` | \`linkDomain\` | Drops manual \`email_domain\` UPDATE — primitive does it |
| \`routes/member-profiles.ts\` | \`linkDomain\` | Drops \`LOWER()\` pre-check (upstream domain is already lowercased via \`getEmailDomain\`) |
| \`routes/me-organization-domains.ts\` | \`setPrimaryDomain\` | Eliminates ~80 lines of inline transaction code |
| \`addie/bolt-app.ts\` | \`linkDomain\` | Alias-confirm tool, \`isPrimary=false\` |

### Out of scope

Deferred to **Stage 3b/3c**:
- \`routes/workos-webhooks.ts\` — FOR UPDATE locking + idempotency invariants. The webhook composes link + auto-promote in a way the primitives don't yet model; needs careful migration.
- \`routes/admin/domains.ts\` — ~10 call sites with diverging flows (set primary, unlink, admin import, recover-from-conflict). Worth a focused PR.
- \`routes/admin/organizations.ts:1001\` — admin tool with custom branching.

## Test plan

- [x] New \`tests/integration/organization-domains-db.test.ts\` — 9 cases covering both primitives + invariants (idempotent re-link, cross-org conflict, isPrimary email_domain sync, source allowlist, atomic flip).
- [x] Pre-existing call-site tests still pass: \`prospect-domain-conflict\`, \`me-organization-domains\`, \`member-profile-bootstrap\`, \`workos-domain-auto-primary\`, \`find-claimable-prospect-org\`, \`claim-prospect-org\`, \`prospect-triage-function\` (51/51).
- [x] Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)