### PR TITLE
feat(server): migrate WorkOS webhook to canonical writers (#4159 Stage 3b)

### DIFF
--- a/.changeset/4159-stage3b-webhook-writers.md
+++ b/.changeset/4159-stage3b-webhook-writers.md
@@ -1,0 +1,4 @@
+---
+---
+
+Server: migrate WorkOS webhook (`syncOrganizationDomains`, `upsertOrganizationDomain`, `deleteSingleOrganizationDomain`) to use new canonical writers in `db/organization-domains-db.ts` — `upsertDomainFromWorkos`, `autoPromotePrimaryIfNone`, `removeWorkosDomainAndReselectPrimary`. The new primitives accept an optional `Queryable` so the webhook can compose them under its existing `FOR UPDATE` lock. Stage 3b of #4159.

--- a/server/src/db/organization-domains-db.ts
+++ b/server/src/db/organization-domains-db.ts
@@ -3,25 +3,26 @@
  *
  * Stage 2 collapsed brand identity and org-membership inference onto a single
  * `organization_domains.is_primary=true` row. Stage 3 consolidates the write
- * paths so every caller goes through the same two primitives instead of
- * each reinventing the SQL with subtly different invariants:
+ * paths so every caller goes through the same primitives instead of each
+ * reinventing the SQL with subtly different invariants.
  *
- *   - `linkDomain` — INSERT a row, DO NOTHING on conflict, log when the
- *     existing row is owned by a different org. When `isPrimary=true` and
- *     the row was actually inserted, also denormalize
- *     `organizations.email_domain` so the two stay in sync (#4159 invariant).
- *
- *   - `setPrimaryDomain` — atomic clear-existing-primary + set-new-primary +
- *     update `organizations.email_domain`. Locks the org row to serialize
- *     against concurrent writers (member self-service, WorkOS webhook,
- *     admin Set Primary). Optionally requires the target row's `source`
- *     match an allowlist (the `'workos'`-only gate the member self-service
- *     route enforces today).
+ * **Trust model:** `linkDomain` rejects ownership transfer on conflict — the
+ * existing row stays put. The WorkOS-sourced primitives (`upsertDomainFromWorkos`
+ * and friends) **do** transfer ownership on conflict because WorkOS is the
+ * authoritative source of truth for DNS-proof-of-control. Use the
+ * member/admin-facing primitives for everything else.
  */
+import type { Pool, PoolClient } from 'pg';
 import { getPool } from './client.js';
 import { createLogger } from '../logger.js';
 
 const logger = createLogger('organization-domains-db');
+
+/**
+ * Either a full pool (each query runs on a fresh connection) or a single
+ * client checked out by the caller (queries share the caller's transaction).
+ */
+type Queryable = Pick<Pool, 'query'> | Pick<PoolClient, 'query'>;
 
 export type DomainSource =
   | 'workos'
@@ -159,4 +160,131 @@ export async function setPrimaryDomain(
   } finally {
     client.release();
   }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WorkOS-sourced writers (Stage 3b)
+//
+// These trust WorkOS's domain ownership as authoritative, so they DO transfer
+// ownership on conflict — opposite of `linkDomain`. They accept an optional
+// `Queryable` so the WorkOS webhook can compose them inside a single
+// transaction with the `FOR UPDATE` lock on `organizations`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface UpsertDomainFromWorkosArgs {
+  orgId: string;
+  domain: string;
+  verified: boolean;
+  /**
+   * Set this to true when the caller is sure no other primary exists for the
+   * org (e.g. first verified domain on a fresh org). For the conditional
+   * "promote-to-primary if no other primary" flow, call
+   * `autoPromotePrimaryIfNone` after this.
+   */
+  isPrimary?: boolean;
+}
+
+export async function upsertDomainFromWorkos(
+  args: UpsertDomainFromWorkosArgs,
+  q: Queryable = getPool(),
+): Promise<void> {
+  const { orgId, domain, verified, isPrimary = false } = args;
+  await q.query(
+    `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source)
+     VALUES ($1, $2, $3, $4, 'workos')
+     ON CONFLICT (domain) DO UPDATE SET
+       workos_organization_id = EXCLUDED.workos_organization_id,
+       verified = EXCLUDED.verified,
+       source = 'workos',
+       updated_at = NOW()`,
+    [orgId, domain, isPrimary, verified],
+  );
+}
+
+/**
+ * Promote `domain` to `is_primary=true` for `orgId` only if no other primary
+ * exists. Idempotent and race-safe under the caller's transaction lock.
+ *
+ * When promotion happens, also denormalizes `organizations.email_domain`
+ * to match. Returns whether the promotion fired so the caller can branch
+ * on side-effects (logging, brand-registry sync).
+ */
+export async function autoPromotePrimaryIfNone(
+  args: { orgId: string; domain: string },
+  q: Queryable = getPool(),
+): Promise<{ promoted: boolean }> {
+  const { orgId, domain } = args;
+  const result = await q.query(
+    `UPDATE organization_domains SET is_primary = true, updated_at = NOW()
+      WHERE workos_organization_id = $1 AND domain = $2
+        AND NOT EXISTS (
+          SELECT 1 FROM organization_domains
+          WHERE workos_organization_id = $1 AND is_primary = true AND domain != $2
+        )
+      RETURNING domain`,
+    [orgId, domain],
+  );
+  if ((result.rowCount ?? 0) === 0) {
+    return { promoted: false };
+  }
+  await q.query(
+    `UPDATE organizations SET email_domain = $1, updated_at = NOW()
+      WHERE workos_organization_id = $2`,
+    [domain, orgId],
+  );
+  return { promoted: true };
+}
+
+/**
+ * Delete a WorkOS-sourced domain row and reselect a new primary if the
+ * deleted row was primary. Picks the oldest verified row remaining; falls
+ * back to NULL `email_domain` if nothing's verified.
+ *
+ * Only deletes rows where `source='workos'` — admin/import rows are immune
+ * to WorkOS-driven removal.
+ */
+export async function removeWorkosDomainAndReselectPrimary(
+  args: { orgId: string; domain: string },
+  q: Queryable = getPool(),
+): Promise<{ deleted: boolean; wasPrimary: boolean; newPrimary: string | null }> {
+  const { orgId, domain } = args;
+  const result = await q.query<{ is_primary: boolean }>(
+    `DELETE FROM organization_domains
+      WHERE workos_organization_id = $1 AND domain = $2 AND source = 'workos'
+      RETURNING is_primary`,
+    [orgId, domain],
+  );
+
+  if ((result.rowCount ?? 0) === 0) {
+    return { deleted: false, wasPrimary: false, newPrimary: null };
+  }
+
+  const wasPrimary = result.rows[0].is_primary === true;
+  if (!wasPrimary) {
+    return { deleted: true, wasPrimary: false, newPrimary: null };
+  }
+
+  const remaining = await q.query<{ domain: string }>(
+    `SELECT domain FROM organization_domains
+      WHERE workos_organization_id = $1 AND verified = true
+      ORDER BY created_at ASC
+      LIMIT 1`,
+    [orgId],
+  );
+  const newPrimary = remaining.rows[0]?.domain ?? null;
+
+  if (newPrimary) {
+    await q.query(
+      `UPDATE organization_domains SET is_primary = true, updated_at = NOW()
+        WHERE workos_organization_id = $1 AND domain = $2`,
+      [orgId, newPrimary],
+    );
+  }
+  await q.query(
+    `UPDATE organizations SET email_domain = $1, updated_at = NOW()
+      WHERE workos_organization_id = $2`,
+    [newPrimary, orgId],
+  );
+
+  return { deleted: true, wasPrimary: true, newPrimary };
 }

--- a/server/src/routes/workos-webhooks.ts
+++ b/server/src/routes/workos-webhooks.ts
@@ -21,6 +21,11 @@
 import { Router, Request, Response } from 'express';
 import { createLogger } from '../logger.js';
 import { getPool } from '../db/client.js';
+import {
+  upsertDomainFromWorkos,
+  autoPromotePrimaryIfNone,
+  removeWorkosDomainAndReselectPrimary,
+} from '../db/organization-domains-db.js';
 import { BrandDatabase } from '../db/brand-db.js';
 import { getWorkos } from '../auth/workos-client.js';
 import { invalidateUnifiedUsersCache } from '../cache/unified-users.js';
@@ -551,24 +556,17 @@ async function syncOrganizationDomains(org: OrganizationData): Promise<void> {
       workOSDomains.add(domainData.domain);
 
       // is_primary + the email_domain update below drive auto-membership
-      // inference and only apply to non-personal orgs (see upsertOrganizationDomain).
+      // inference and only apply to non-personal orgs.
       const isPrimaryEligible = !isPersonal && i === 0;
 
-      await client.query(
-        `INSERT INTO organization_domains (
-          workos_organization_id, domain, is_primary, verified, source
-        ) VALUES ($1, $2, $3, $4, 'workos')
-        ON CONFLICT (domain) DO UPDATE SET
-          workos_organization_id = EXCLUDED.workos_organization_id,
-          verified = EXCLUDED.verified,
-          source = 'workos',
-          updated_at = NOW()`,
-        [
-          org.id,
-          domainData.domain,
-          isPrimaryEligible,
-          domainData.state === 'verified',
-        ]
+      await upsertDomainFromWorkos(
+        {
+          orgId: org.id,
+          domain: domainData.domain,
+          verified: domainData.state === 'verified',
+          isPrimary: isPrimaryEligible,
+        },
+        client,
       );
     }
 
@@ -693,20 +691,13 @@ export async function upsertOrganizationDomain(domainData: OrganizationDomainEve
     // (multi-user companies sneaking onto a 1-seat individual sub) is
     // enforced at the seat-cap layer (checkSeatAvailability), not by hiding
     // the ownership claim in the data layer.
-    await client.query(
-      `INSERT INTO organization_domains (
-        workos_organization_id, domain, verified, source
-      ) VALUES ($1, $2, $3, 'workos')
-      ON CONFLICT (domain) DO UPDATE SET
-        workos_organization_id = EXCLUDED.workos_organization_id,
-        verified = EXCLUDED.verified,
-        source = 'workos',
-        updated_at = NOW()`,
-      [
-        domainData.organization_id,
-        normalizedDomain,
-        domainData.state === 'verified',
-      ]
+    await upsertDomainFromWorkos(
+      {
+        orgId: domainData.organization_id,
+        domain: normalizedDomain,
+        verified: domainData.state === 'verified',
+      },
+      client,
     );
 
     // is_primary + organizations.email_domain drive auto-membership inference
@@ -716,24 +707,10 @@ export async function upsertOrganizationDomain(domainData: OrganizationDomainEve
     // Skip the inference wiring for personal orgs; the verified row above
     // still records the ownership fact.
     if (!isPersonal && domainData.state === 'verified') {
-      const updated = await client.query(
-        `UPDATE organization_domains SET is_primary = true, updated_at = NOW()
-         WHERE workos_organization_id = $1 AND domain = $2
-         AND NOT EXISTS (
-           SELECT 1 FROM organization_domains
-           WHERE workos_organization_id = $1 AND is_primary = true AND domain != $2
-         )
-         RETURNING domain`,
-        [domainData.organization_id, normalizedDomain]
+      await autoPromotePrimaryIfNone(
+        { orgId: domainData.organization_id, domain: normalizedDomain },
+        client,
       );
-
-      if (updated.rows.length > 0) {
-        await client.query(
-          `UPDATE organizations SET email_domain = $1, updated_at = NOW()
-           WHERE workos_organization_id = $2`,
-          [normalizedDomain, domainData.organization_id]
-        );
-      }
     }
 
     await client.query('COMMIT');
@@ -817,54 +794,20 @@ async function deleteSingleOrganizationDomain(domainData: OrganizationDomainEven
     // Normalize domain to lowercase
     const normalizedDomain = domainData.domain.toLowerCase();
 
-    const result = await client.query(
-      `DELETE FROM organization_domains
-       WHERE workos_organization_id = $1 AND domain = $2 AND source = 'workos'
-       RETURNING is_primary`,
-      [domainData.organization_id, normalizedDomain]
+    const result = await removeWorkosDomainAndReselectPrimary(
+      { orgId: domainData.organization_id, domain: normalizedDomain },
+      client,
     );
 
-    if (result.rowCount && result.rowCount > 0) {
-      const wasPrimary = result.rows[0]?.is_primary;
+    await client.query('COMMIT');
 
-      // If we deleted the primary domain, pick a new one
-      let newPrimary: string | null = null;
-      if (wasPrimary) {
-        const remaining = await client.query(
-          `SELECT domain FROM organization_domains
-           WHERE workos_organization_id = $1 AND verified = true
-           ORDER BY created_at ASC
-           LIMIT 1`,
-          [domainData.organization_id]
-        );
-
-        newPrimary = remaining.rows.length > 0 ? remaining.rows[0].domain : null;
-
-        if (newPrimary) {
-          await client.query(
-            `UPDATE organization_domains SET is_primary = true, updated_at = NOW()
-             WHERE workos_organization_id = $1 AND domain = $2`,
-            [domainData.organization_id, newPrimary]
-          );
-        }
-
-        await client.query(
-          `UPDATE organizations SET email_domain = $1, updated_at = NOW()
-           WHERE workos_organization_id = $2`,
-          [newPrimary, domainData.organization_id]
-        );
-      }
-
-      await client.query('COMMIT');
-
+    if (result.deleted) {
       logger.info({
         orgId: domainData.organization_id,
         domain: normalizedDomain,
-        wasPrimary,
-        newPrimary,
+        wasPrimary: result.wasPrimary,
+        newPrimary: result.newPrimary,
       }, 'Deleted organization domain');
-    } else {
-      await client.query('COMMIT');
     }
   } catch (error) {
     await client.query('ROLLBACK');

--- a/server/tests/integration/organization-domains-db.test.ts
+++ b/server/tests/integration/organization-domains-db.test.ts
@@ -1,11 +1,17 @@
 /**
  * Pins the invariants of the canonical writer module
- * `db/organization-domains-db.ts` (#4159 Stage 3a).
+ * `db/organization-domains-db.ts` (#4159 Stage 3a + 3b).
  */
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { initializeDatabase, closeDatabase, getPool } from '../../src/db/client.js';
 import { runMigrations } from '../../src/db/migrate.js';
-import { linkDomain, setPrimaryDomain } from '../../src/db/organization-domains-db.js';
+import {
+  linkDomain,
+  setPrimaryDomain,
+  upsertDomainFromWorkos,
+  autoPromotePrimaryIfNone,
+  removeWorkosDomainAndReselectPrimary,
+} from '../../src/db/organization-domains-db.js';
 import type { Pool } from 'pg';
 
 const ORG_A = 'org_orgdom_db_a';
@@ -212,6 +218,185 @@ describe('organization-domains-db (#4159 Stage 3a)', () => {
         [ORG_A],
       );
       expect(rows.rows[0].domain).toBe(D1);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Stage 3b: WorkOS-sourced writers
+  // ───────────────────────────────────────────────────────────────────────
+
+  describe('upsertDomainFromWorkos', () => {
+    it('inserts a fresh row with source=workos', async () => {
+      await upsertDomainFromWorkos({ orgId: ORG_A, domain: D1, verified: true });
+
+      const row = await getPool().query(
+        `SELECT workos_organization_id, source, verified, is_primary FROM organization_domains WHERE domain = $1`,
+        [D1],
+      );
+      expect(row.rows[0]).toMatchObject({
+        workos_organization_id: ORG_A,
+        source: 'workos',
+        verified: true,
+        is_primary: false,
+      });
+    });
+
+    it('TRANSFERS ownership on conflict — WorkOS is authoritative', async () => {
+      await upsertDomainFromWorkos({ orgId: ORG_B, domain: D_TAKEN, verified: true });
+
+      // WorkOS now reassigns the domain to ORG_A; we must follow.
+      await upsertDomainFromWorkos({ orgId: ORG_A, domain: D_TAKEN, verified: true });
+
+      const row = await getPool().query(
+        `SELECT workos_organization_id, source FROM organization_domains WHERE domain = $1`,
+        [D_TAKEN],
+      );
+      expect(row.rows[0]).toMatchObject({
+        workos_organization_id: ORG_A,
+        source: 'workos',
+      });
+    });
+
+    it('flips a non-workos row to source=workos on conflict', async () => {
+      await linkDomain({ orgId: ORG_A, domain: D1, source: 'manual', verified: false });
+
+      await upsertDomainFromWorkos({ orgId: ORG_A, domain: D1, verified: true });
+
+      const row = await getPool().query(
+        `SELECT source, verified FROM organization_domains WHERE domain = $1`,
+        [D1],
+      );
+      expect(row.rows[0]).toMatchObject({ source: 'workos', verified: true });
+    });
+  });
+
+  describe('autoPromotePrimaryIfNone', () => {
+    it('promotes when no primary exists; updates email_domain', async () => {
+      await upsertDomainFromWorkos({ orgId: ORG_A, domain: D1, verified: true });
+
+      const result = await autoPromotePrimaryIfNone({ orgId: ORG_A, domain: D1 });
+      expect(result).toEqual({ promoted: true });
+
+      const row = await getPool().query(
+        `SELECT is_primary FROM organization_domains WHERE domain = $1`,
+        [D1],
+      );
+      expect(row.rows[0].is_primary).toBe(true);
+
+      const org = await getPool().query(
+        `SELECT email_domain FROM organizations WHERE workos_organization_id = $1`,
+        [ORG_A],
+      );
+      expect(org.rows[0].email_domain).toBe(D1);
+    });
+
+    it('does NOT promote when another primary already exists', async () => {
+      await upsertDomainFromWorkos({ orgId: ORG_A, domain: D1, verified: true, isPrimary: true });
+      await upsertDomainFromWorkos({ orgId: ORG_A, domain: D2, verified: true });
+
+      // Set email_domain to a sentinel; promotion should not touch it.
+      await getPool().query(
+        `UPDATE organizations SET email_domain = 'sentinel.test' WHERE workos_organization_id = $1`,
+        [ORG_A],
+      );
+
+      const result = await autoPromotePrimaryIfNone({ orgId: ORG_A, domain: D2 });
+      expect(result).toEqual({ promoted: false });
+
+      const rows = await getPool().query(
+        `SELECT domain FROM organization_domains
+          WHERE workos_organization_id = $1 AND is_primary = true`,
+        [ORG_A],
+      );
+      expect(rows.rows[0].domain).toBe(D1);
+
+      const org = await getPool().query(
+        `SELECT email_domain FROM organizations WHERE workos_organization_id = $1`,
+        [ORG_A],
+      );
+      expect(org.rows[0].email_domain).toBe('sentinel.test');
+    });
+  });
+
+  describe('removeWorkosDomainAndReselectPrimary', () => {
+    it('returns deleted=false when no row exists', async () => {
+      const result = await removeWorkosDomainAndReselectPrimary({ orgId: ORG_A, domain: 'never.test' });
+      expect(result).toEqual({ deleted: false, wasPrimary: false, newPrimary: null });
+    });
+
+    it('does NOT delete non-workos rows (admin-imported is immune)', async () => {
+      await linkDomain({ orgId: ORG_A, domain: D1, source: 'admin_discovery', verified: true, isPrimary: true });
+
+      const result = await removeWorkosDomainAndReselectPrimary({ orgId: ORG_A, domain: D1 });
+      expect(result.deleted).toBe(false);
+
+      const row = await getPool().query(`SELECT 1 FROM organization_domains WHERE domain = $1`, [D1]);
+      expect(row.rowCount).toBe(1);
+    });
+
+    it('deletes a non-primary workos row; no reselection', async () => {
+      await upsertDomainFromWorkos({ orgId: ORG_A, domain: D1, verified: true, isPrimary: true });
+      await upsertDomainFromWorkos({ orgId: ORG_A, domain: D2, verified: true });
+
+      const result = await removeWorkosDomainAndReselectPrimary({ orgId: ORG_A, domain: D2 });
+      expect(result).toEqual({ deleted: true, wasPrimary: false, newPrimary: null });
+
+      const remaining = await getPool().query(
+        `SELECT domain FROM organization_domains WHERE workos_organization_id = $1 AND is_primary = true`,
+        [ORG_A],
+      );
+      expect(remaining.rows[0].domain).toBe(D1);
+    });
+
+    it('deletes the primary row, picks the oldest verified remaining as new primary, syncs email_domain', async () => {
+      await upsertDomainFromWorkos({ orgId: ORG_A, domain: D1, verified: true, isPrimary: true });
+      // Force a known created_at ordering: D2 older than D3.
+      await upsertDomainFromWorkos({ orgId: ORG_A, domain: D2, verified: true });
+      await upsertDomainFromWorkos({ orgId: ORG_A, domain: D3, verified: true });
+      await getPool().query(
+        `UPDATE organization_domains SET created_at = $1 WHERE domain = $2`,
+        [new Date('2024-01-01'), D2],
+      );
+      await getPool().query(
+        `UPDATE organization_domains SET created_at = $1 WHERE domain = $2`,
+        [new Date('2024-06-01'), D3],
+      );
+      await getPool().query(
+        `UPDATE organizations SET email_domain = $1 WHERE workos_organization_id = $2`,
+        [D1, ORG_A],
+      );
+
+      const result = await removeWorkosDomainAndReselectPrimary({ orgId: ORG_A, domain: D1 });
+      expect(result).toEqual({ deleted: true, wasPrimary: true, newPrimary: D2 });
+
+      const newPrimary = await getPool().query(
+        `SELECT domain FROM organization_domains WHERE workos_organization_id = $1 AND is_primary = true`,
+        [ORG_A],
+      );
+      expect(newPrimary.rows[0].domain).toBe(D2);
+
+      const org = await getPool().query(
+        `SELECT email_domain FROM organizations WHERE workos_organization_id = $1`,
+        [ORG_A],
+      );
+      expect(org.rows[0].email_domain).toBe(D2);
+    });
+
+    it('deletes the only primary row, no remaining; nulls email_domain', async () => {
+      await upsertDomainFromWorkos({ orgId: ORG_A, domain: D1, verified: true, isPrimary: true });
+      await getPool().query(
+        `UPDATE organizations SET email_domain = $1 WHERE workos_organization_id = $2`,
+        [D1, ORG_A],
+      );
+
+      const result = await removeWorkosDomainAndReselectPrimary({ orgId: ORG_A, domain: D1 });
+      expect(result).toEqual({ deleted: true, wasPrimary: true, newPrimary: null });
+
+      const org = await getPool().query(
+        `SELECT email_domain FROM organizations WHERE workos_organization_id = $1`,
+        [ORG_A],
+      );
+      expect(org.rows[0].email_domain).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary

Stage 3b of #4159. Stage 3a introduced canonical writers for the **member/admin-facing** call sites (\`linkDomain\`, \`setPrimaryDomain\`). The WorkOS webhook needed different semantics — it must **transfer ownership** on conflict because WorkOS is the authoritative source of truth for DNS-proof-of-control — and it composes link + auto-promote + email_domain sync under a single \`FOR UPDATE\` lock.

This PR adds three new primitives that accept an optional \`Queryable\` (Pool | PoolClient) so they compose under the webhook's existing transaction:

- **\`upsertDomainFromWorkos({orgId, domain, verified, isPrimary?}, q?)\`** — \`INSERT…ON CONFLICT DO UPDATE\`, sets \`source='workos'\`. Trusted: transfers ownership when WorkOS asserts.
- **\`autoPromotePrimaryIfNone({orgId, domain}, q?)\`** — promotes only if no other primary exists for the org. Syncs \`organizations.email_domain\` when the promotion fires. Returns \`{promoted: boolean}\`.
- **\`removeWorkosDomainAndReselectPrimary({orgId, domain}, q?)\`** — deletes a \`source='workos'\` row, picks oldest verified remaining as new primary, syncs \`email_domain\`. Admin/import rows are immune to WorkOS-driven removal.

### Migrated call sites

| Function | Now uses |
|---|---|
| \`syncOrganizationDomains\` (full org-level sync from \`organization.updated\`) | \`upsertDomainFromWorkos\` per domain |
| \`upsertOrganizationDomain\` (single \`organization_domain.*\` events) | \`upsertDomainFromWorkos\` + \`autoPromotePrimaryIfNone\` |
| \`deleteSingleOrganizationDomain\` (\`organization_domain.deleted\`) | \`removeWorkosDomainAndReselectPrimary\` |

~120 lines of inline SQL replaced.

## Test plan

- [x] 10 new unit tests pin the primitives directly (\`tests/integration/organization-domains-db.test.ts\` — 19 cases total now, was 9).
- [x] Existing webhook tests pass: \`workos-domain-auto-primary\`, \`login-name-persistence\`, \`identity-layer\` (17/17).
- [x] Wider integration regression: 7 suites, 58 cases all green.
- [x] Typecheck clean.

## Out of scope

Deferred to **Stage 3c**:
- \`routes/admin/domains.ts\` — ~10 call sites with diverging flows (admin set-primary, unlink, admin import, recover-from-conflict).
- \`routes/admin/organizations.ts:1001\` — admin tool with custom branching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)