### PR TITLE
feat(schema): add allowed_values to text-asset-requirements

### DIFF
--- a/.changeset/4331-text-slot-allowed-values.md
+++ b/.changeset/4331-text-slot-allowed-values.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": minor
+---
+
+Add `allowed_values` to `text-asset-requirements.json`. Creative agents can now declare a closed set of permitted string values for a text input slot (e.g., localized CTA variants approved by legal or brand); conformant implementations MUST reject submissions not in the list. The field is optional and additive — existing producers and consumers are unaffected.
+
+Refs #4331.

--- a/.changeset/4331-text-slot-allowed-values.md
+++ b/.changeset/4331-text-slot-allowed-values.md
@@ -2,6 +2,6 @@
 "adcontextprotocol": minor
 ---
 
-Add `allowed_values` to `text-asset-requirements.json`. Creative agents can now declare a closed set of permitted string values for a text input slot (e.g., localized CTA variants approved by legal or brand); conformant implementations MUST reject submissions not in the list. The field is optional and additive — existing producers and consumers are unaffected.
+Add `allowed_values` to `text-asset-requirements.json` and the matching `CREATIVE_VALUE_NOT_ALLOWED` error code. Creative agents can now declare a closed set of permitted string values for a text input slot (e.g., legal- or brand-approved CTAs); conformant implementations MUST reject submissions outside the list with `CREATIVE_VALUE_NOT_ALLOWED`, echoing the offending field path in `error.field` and the allowed list in `error.details.allowed_values` so buyer agents can re-prompt deterministically. The field is optional and additive — existing producers and consumers are unaffected.
 
 Refs #4331.

--- a/docs/creative/formats.mdx
+++ b/docs/creative/formats.mdx
@@ -376,6 +376,25 @@ Each asset type has its own requirements schema that defines what constraints ap
 - `min_lines`, `max_lines` - Line count limits
 - `character_pattern` - Regex for allowed characters
 - `prohibited_terms` - Words/phrases not allowed
+- `allowed_values` - Closed list of permitted strings; submissions outside the list are rejected with `CREATIVE_VALUE_NOT_ALLOWED`
+
+**Closed-set text example (legal/brand-approved CTA list):**
+
+```json
+{
+  "asset_id": "cta_label",
+  "asset_type": "text",
+  "required": true,
+  "requirements": {
+    "max_length": 14,
+    "allowed_values": ["Shop Now", "Learn More", "Get Quote", "Find a Provider"]
+  }
+}
+```
+
+Sellers in regulated verticals (pharma, financial services) and brand-controlled programs use `allowed_values` to expose the exact strings legal or brand has pre-approved. All declared constraints are conjunctive (every allowed value must also satisfy `max_length`, `character_pattern`, etc.) and matching is case-sensitive — buyers MUST submit one of the listed strings verbatim. Buyer agents using LLMs to fill text slots should pass `allowed_values` as a constrained-sampling option rather than generating freely and retrying after rejection.
+
+When a submitted value is not in the list, sellers MUST return `CREATIVE_VALUE_NOT_ALLOWED` with `error.field` pointing at the offending asset path and `error.details.allowed_values` echoing the format's list so the buyer can re-prompt deterministically.
 
 **URL assets** (`asset_type: "url"`):
 - `role` - Standard purpose (clickthrough, impression_tracker, click_tracker, etc.)

--- a/scripts/error-code-drift-dispositions.json
+++ b/scripts/error-code-drift-dispositions.json
@@ -31,6 +31,11 @@
       "target_version": "3.1",
       "note": "Added in #3995/#4003. Verified not a rename of 3.0.x's ACCOUNT_SETUP_REQUIRED \u2014 that signals account-level setup; CONFIGURATION_ERROR is operational misconfiguration. Held for 3.1."
     },
+    "CREATIVE_VALUE_NOT_ALLOWED": {
+      "disposition": "held-for-next-minor",
+      "target_version": "3.1",
+      "note": "Pairs with text-asset-requirements.allowed_values (#4331). Closed-set creative validation rejection. Wire change — held for 3.1."
+    },
     "CREDENTIAL_IN_ARGS": {
       "disposition": "held-for-next-major",
       "target_version": "4.0",

--- a/static/schemas/source/core/requirements/text-asset-requirements.json
+++ b/static/schemas/source/core/requirements/text-asset-requirements.json
@@ -43,7 +43,7 @@
       },
       "minItems": 1,
       "uniqueItems": true,
-      "description": "Closed set of permitted string values for this text slot. When present, a conformant implementation MUST reject any submitted content not in this list. Matching is case-sensitive; producers MUST supply exact casing. If the submitted value contains unresolved template tokens (e.g., {{product_name}}), validation against allowed_values MUST be deferred until interpolation is complete. All declared constraints (allowed_values, character_pattern, max_length, etc.) are conjunctive — submitted content must satisfy every applicable constraint simultaneously."
+      "description": "Closed set of permitted string values for this text slot. When present, a conformant implementation MUST reject any submitted content not in this list with `CREATIVE_VALUE_NOT_ALLOWED` (echoing the offending field path in `error.field` and the allowed list in `error.details.allowed_values`). Matching is case-sensitive; producers MUST supply exact casing. If the submitted value contains unresolved template tokens (e.g., {{product_name}}), validation against allowed_values MUST be deferred until interpolation is complete. All declared constraints (allowed_values, character_pattern, max_length, etc.) are conjunctive — submitted content must satisfy every applicable constraint simultaneously."
     }
   },
   "additionalProperties": true

--- a/static/schemas/source/core/requirements/text-asset-requirements.json
+++ b/static/schemas/source/core/requirements/text-asset-requirements.json
@@ -35,6 +35,15 @@
         "type": "string"
       },
       "description": "List of prohibited words or phrases"
+    },
+    "allowed_values": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "uniqueItems": true,
+      "description": "Closed set of permitted string values for this text slot. When present, a conformant implementation MUST reject any submitted content not in this list. Matching is case-sensitive; producers MUST supply exact casing. If the submitted value contains unresolved template tokens (e.g., {{product_name}}), validation against allowed_values MUST be deferred until interpolation is complete. All declared constraints (allowed_values, character_pattern, max_length, etc.) are conjunctive — submitted content must satisfy every applicable constraint simultaneously."
     }
   },
   "additionalProperties": true

--- a/static/schemas/source/enums/error-code.json
+++ b/static/schemas/source/enums/error-code.json
@@ -16,6 +16,7 @@
     "PROPOSAL_EXPIRED",
     "BUDGET_TOO_LOW",
     "CREATIVE_REJECTED",
+    "CREATIVE_VALUE_NOT_ALLOWED",
     "UNSUPPORTED_FEATURE",
     "AUDIENCE_TOO_SMALL",
     "ACCOUNT_NOT_FOUND",
@@ -80,6 +81,7 @@
     "PROPOSAL_EXPIRED": "A referenced proposal ID has passed its expires_at timestamp. Recovery: correctable (re-discover with get_products to get a fresh proposal).",
     "BUDGET_TOO_LOW": "Budget is below the seller's minimum. Recovery: correctable (increase budget or check capabilities.media_buy.limits).",
     "CREATIVE_REJECTED": "Creative failed content policy review. For deadline violations, see CREATIVE_DEADLINE_EXCEEDED. Recovery: correctable (revise the creative per the seller's advertising_policies).",
+    "CREATIVE_VALUE_NOT_ALLOWED": "A submitted text-asset value is not in the format's declared `allowed_values` list. Distinct from `CREATIVE_REJECTED` (generic content-policy failure) by being a closed-set constraint violation that the buyer can resolve mechanically without policy interpretation — the seller has published the complete list of acceptable values on the format, and any value outside that list is rejected by definition. The seller MUST set `error.field` to the offending asset's path within the manifest (e.g., `creatives[0].creative_manifest.assets[0].value` or the field name declared by the format) and SHOULD include the format's `allowed_values` array in `error.details.allowed_values` so the buyer agent can re-prompt its LLM with constrained sampling. Recovery: correctable (select a value from `allowed_values` and resubmit).",
     "UNSUPPORTED_FEATURE": "A requested feature or field is not supported by this seller. Recovery: correctable (check get_adcp_capabilities and remove unsupported fields).",
     "AUDIENCE_TOO_SMALL": "Audience segment is below the minimum required size for targeting. Recovery: correctable (broaden targeting or upload more audience members).",
     "ACCOUNT_NOT_FOUND": "The account reference could not be resolved. Recovery: terminal (verify account via list_accounts or contact seller).",
@@ -177,6 +179,10 @@
     "CREATIVE_REJECTED": {
       "recovery": "correctable",
       "suggestion": "revise the creative per the seller's advertising_policies"
+    },
+    "CREATIVE_VALUE_NOT_ALLOWED": {
+      "recovery": "correctable",
+      "suggestion": "pick a value from error.details.allowed_values (or re-fetch the format) and resubmit"
     },
     "UNSUPPORTED_FEATURE": {
       "recovery": "correctable",


### PR DESCRIPTION
Refs #4331 — item 1 of 5. Items 2, 4, 5 deferred pending RFC #3305; item 3 (`language`) flagged for human review on grain question — see triage comment on #4331.

## Summary

Adds `allowed_values` to `text-asset-requirements.json`: an optional closed set of permitted string values for a text input slot. Creative agents can now advertise which exact strings are valid for a slot (e.g., localized CTA variants approved by legal or brand), enabling orchestrators to discover constraints at format-discovery time and validate submissions before calling `build_creative` or `sync_creatives`.

**Non-breaking justification:** Adds an optional field to a stable schema with `additionalProperties: true`. Existing producers that don't populate the field continue to validate without change; existing consumers that don't read the field are unaffected.

## Schema change

```json
"allowed_values": {
  "type": "array",
  "items": { "type": "string" },
  "minItems": 1,
  "uniqueItems": true,
  "description": "Closed set of permitted string values for this text slot. When present, a conformant implementation MUST reject any submitted content not in this list. Matching is case-sensitive; producers MUST supply exact casing. If the submitted value contains unresolved template tokens (e.g., {{product_name}}), validation against allowed_values MUST be deferred until interpolation is complete. All declared constraints (allowed_values, character_pattern, max_length, etc.) are conjunctive — submitted content must satisfy every applicable constraint simultaneously."
}
```

## Pre-PR review

- **code-reviewer:** approved — three issues fixed: case-sensitivity MUST clause added, `uniqueItems: true` added, example token changed from `{{brand}}` to `{{product_name}}`.
- **ad-tech-protocol-expert:** approved — two blockers fixed: replaced `validate_input` task-name reference with implementation-agnostic phrasing; SHOULD→MUST on template-token deferral semantics.

**Nits surfaced (not fixed):** Normative MUST/SHOULD behavior lives in the description string only — same tradeoff as the rest of the schema family (`prohibited_terms`, `feature-requirement.json`). Follow-up recommended: surface normative constraints in task reference docs for `build_creative`/`sync_creatives` so SDK authors see them beyond the generated type.

## Build note

`npm run build` has pre-existing failures in this sandboxed environment (missing `js-yaml` in node_modules; pre-existing TypeScript errors in `server/src/utils/url-security.ts` and `server/src/validator.ts`). Neither is caused by this diff. The schema JSON is well-formed (validated via `node -e "JSON.parse(...)"`).

## Milestone

Targets **3.1.0** (next open minor; `main` is in `3.1.0-beta.N` pre-mode). Changeset: `minor` — new optional field on a stable schema.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01Uhhmzg64VNaTwiQL9SfqyH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uhhmzg64VNaTwiQL9SfqyH)_