### PR TITLE
feat(server): migrate admin/domains.ts to canonical writers (#4159 Stage 3c)

### DIFF
--- a/.changeset/4159-stage3c-admin-domains.md
+++ b/.changeset/4159-stage3c-admin-domains.md
@@ -1,0 +1,4 @@
+---
+---
+
+Server: migrate the cleanly-mappable write sites in `routes/admin/domains.ts` to canonical writers. Three "admin create prospect" mirrors → `linkDomain`; admin add-domain-to-org → `upsertDomainFromWorkos` + conditional `setPrimaryDomain`; admin Set Primary endpoint → `setPrimaryDomain`. Adds `requireVerified` opt-out to `setPrimaryDomain` so admin tools can promote a hand-imported unverified row. Stage 3c of #4159. Admin DELETE (different reselection policy) and bulk domain-health sync stay inline.

--- a/server/src/db/organization-domains-db.ts
+++ b/server/src/db/organization-domains-db.ts
@@ -87,6 +87,12 @@ export interface SetPrimaryDomainArgs {
   orgId: string;
   domain: string;
   requireSource?: ReadonlyArray<DomainSource>;
+  /**
+   * Whether to require the target row's `verified=true`. Default true (the
+   * member self-service guard). Admin tools that resolve messes — e.g.
+   * promoting a hand-imported row before WorkOS confirms — can opt out.
+   */
+  requireVerified?: boolean;
 }
 
 export type SetPrimaryDomainResult =
@@ -100,7 +106,7 @@ export type SetPrimaryDomainResult =
 export async function setPrimaryDomain(
   args: SetPrimaryDomainArgs,
 ): Promise<SetPrimaryDomainResult> {
-  const { orgId, domain, requireSource } = args;
+  const { orgId, domain, requireSource, requireVerified = true } = args;
   const pool = getPool();
   const client = await pool.connect();
 
@@ -121,7 +127,7 @@ export async function setPrimaryDomain(
       await client.query('ROLLBACK');
       return { ok: false, reason: 'not_found' };
     }
-    if (!domainRow.rows[0].verified) {
+    if (requireVerified && !domainRow.rows[0].verified) {
       await client.query('ROLLBACK');
       return { ok: false, reason: 'not_verified' };
     }

--- a/server/src/routes/admin/domains.ts
+++ b/server/src/routes/admin/domains.ts
@@ -6,6 +6,11 @@
 import { Router } from "express";
 import { WorkOS, DomainDataState } from "@workos-inc/node";
 import { getPool } from "../../db/client.js";
+import {
+  linkDomain,
+  setPrimaryDomain,
+  upsertDomainFromWorkos,
+} from "../../db/organization-domains-db.js";
 import { createLogger } from "../../logger.js";
 import { requireAuth, requireAdmin } from "../../middleware/auth.js";
 import { SlackDatabase } from "../../db/slack-db.js";
@@ -289,21 +294,17 @@ export function setupDomainRoutes(
 
         // Mirror the domain into organization_domains so findPayingOrgForDomain
         // and the upcoming claim-existing-org flow can locate this prospect by
-        // domain even before the webhook fires. If the domain is already
-        // claimed by another org we don't steal it (DO NOTHING) — log a
-        // warning so admins can resolve the conflict. The new org's
-        // email_domain column is still populated either way, so
+        // domain even before the webhook fires. linkDomain logs the conflict;
+        // the new org's email_domain column is still populated either way, so
         // findClaimableProspectOrgForDomain can still locate it via the
         // email_domain branch of its OR predicate.
-        const domainMirror = await pool.query(
-          `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source)
-           VALUES ($1, $2, true, true, 'admin_discovery')
-           ON CONFLICT (domain) DO NOTHING`,
-          [workosOrg.id, normalizedDomain]
-        );
-        if ((domainMirror.rowCount ?? 0) === 0) {
-          logger.warn({ orgId: workosOrg.id, domain: normalizedDomain }, "organization_domains row already claimed by a different org — new prospect's domain hookup will rely on organizations.email_domain");
-        }
+        await linkDomain({
+          orgId: workosOrg.id,
+          domain: normalizedDomain,
+          source: "admin_discovery",
+          verified: true,
+          isPrimary: true,
+        });
 
         // Auto-enrich the new organization in the background
         trackBackground(
@@ -488,17 +489,15 @@ export function setupDomainRoutes(
             );
 
             // Mirror into organization_domains for auto-link / claim flows.
-            // ON CONFLICT does not steal the domain from another org —
-            // log a warning when the upsert no-ops.
-            const domainMirror = await pool.query(
-              `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source)
-               VALUES ($1, $2, true, true, 'admin_discovery')
-               ON CONFLICT (domain) DO NOTHING`,
-              [workosOrg.id, normalizedDomain]
-            );
-            if ((domainMirror.rowCount ?? 0) === 0) {
-              logger.warn({ orgId: workosOrg.id, domain: normalizedDomain }, "organization_domains row already claimed by a different org — new prospect's domain hookup will rely on organizations.email_domain");
-            }
+            // linkDomain refuses to steal the domain from another org and
+            // logs the conflict.
+            await linkDomain({
+              orgId: workosOrg.id,
+              domain: normalizedDomain,
+              source: "admin_discovery",
+              verified: true,
+              isPrimary: true,
+            });
 
             // Auto-enrich in background
             trackBackground(
@@ -787,17 +786,15 @@ export function setupDomainRoutes(
         );
 
         // Mirror into organization_domains for auto-link / claim flows.
-        // ON CONFLICT does not steal the domain from another org —
-        // log a warning when the upsert no-ops.
-        const domainMirror = await pool.query(
-          `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source)
-           VALUES ($1, $2, true, true, 'admin_discovery')
-           ON CONFLICT (domain) DO NOTHING`,
-          [workosOrg.id, normalizedDomain]
-        );
-        if ((domainMirror.rowCount ?? 0) === 0) {
-          logger.warn({ orgId: workosOrg.id, domain: normalizedDomain }, "organization_domains row already claimed by a different org — new prospect's domain hookup will rely on organizations.email_domain");
-        }
+        // linkDomain refuses to steal the domain from another org and
+        // logs the conflict.
+        await linkDomain({
+          orgId: workosOrg.id,
+          domain: normalizedDomain,
+          source: "admin_discovery",
+          verified: true,
+          isPrimary: true,
+        });
 
         // Auto-enrich the new organization in the background
         trackBackground(
@@ -1423,35 +1420,20 @@ export function setupDomainRoutes(
           );
         }
 
-        // If setting as primary, clear existing primary first
-        if (is_primary) {
-          await pool.query(
-            `UPDATE organization_domains SET is_primary = false, updated_at = NOW()
-             WHERE workos_organization_id = $1 AND is_primary = true`,
-            [orgId]
-          );
-        }
+        // Insert/update local DB immediately (webhook will also do this, but
+        // for immediate consistency). Admin tool already pushed this domain
+        // to WorkOS above, so source='workos' reflects upstream truth.
+        await upsertDomainFromWorkos({
+          orgId,
+          domain: normalizedDomain,
+          verified: true,
+          isPrimary: is_primary === true,
+        });
 
-        // Insert/update local DB immediately (webhook will also do this, but for immediate consistency)
-        await pool.query(
-          `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source)
-           VALUES ($1, $2, $3, true, 'workos')
-           ON CONFLICT (domain) DO UPDATE SET
-             workos_organization_id = EXCLUDED.workos_organization_id,
-             is_primary = EXCLUDED.is_primary,
-             verified = true,
-             source = 'workos',
-             updated_at = NOW()`,
-          [orgId, normalizedDomain, is_primary || false]
-        );
-
-        // If primary, also update the email_domain column
+        // If admin requested primary, atomic-flip across the org's rows and
+        // sync email_domain. No requireSource — this is an admin override.
         if (is_primary) {
-          await pool.query(
-            `UPDATE organizations SET email_domain = $1, updated_at = NOW()
-             WHERE workos_organization_id = $2`,
-            [normalizedDomain, orgId]
-          );
+          await setPrimaryDomain({ orgId, domain: normalizedDomain });
         }
 
         logger.info({ orgId, domain: normalizedDomain, isPrimary: is_primary }, "Added domain to organization via WorkOS");
@@ -1598,39 +1580,23 @@ export function setupDomainRoutes(
       try {
         const { orgId, domain } = req.params;
         const normalizedDomain = domain.toLowerCase().trim();
-        const pool = getPool();
 
-        // Verify domain belongs to this org
-        const domainResult = await pool.query(
-          `SELECT domain FROM organization_domains
-           WHERE workos_organization_id = $1 AND domain = $2`,
-          [orgId, normalizedDomain]
-        );
+        // Admin override — no requireSource gate, no requireVerified gate.
+        // This endpoint is used to resolve messes (e.g. promote a
+        // hand-imported row before WorkOS confirms). Member self-service has
+        // both gates set in routes/me-organization-domains.ts.
+        const result = await setPrimaryDomain({
+          orgId,
+          domain: normalizedDomain,
+          requireVerified: false,
+        });
 
-        if (domainResult.rows.length === 0) {
-          return res.status(404).json({ error: "Domain not found for this organization" });
+        if (!result.ok) {
+          if (result.reason === "not_found") {
+            return res.status(404).json({ error: "Domain not found for this organization" });
+          }
+          return res.status(400).json({ error: "Cannot set primary domain" });
         }
-
-        // Clear existing primary
-        await pool.query(
-          `UPDATE organization_domains SET is_primary = false, updated_at = NOW()
-           WHERE workos_organization_id = $1 AND is_primary = true`,
-          [orgId]
-        );
-
-        // Set new primary
-        await pool.query(
-          `UPDATE organization_domains SET is_primary = true, updated_at = NOW()
-           WHERE workos_organization_id = $1 AND domain = $2`,
-          [orgId, normalizedDomain]
-        );
-
-        // Update organizations.email_domain
-        await pool.query(
-          `UPDATE organizations SET email_domain = $1, updated_at = NOW()
-           WHERE workos_organization_id = $2`,
-          [normalizedDomain, orgId]
-        );
 
         logger.info({ orgId, domain: normalizedDomain }, "Set primary domain for organization");
 

--- a/server/src/routes/admin/domains.ts
+++ b/server/src/routes/admin/domains.ts
@@ -1420,6 +1420,10 @@ export function setupDomainRoutes(
           );
         }
 
+        // Match prior `is_primary || false` coercion — undefined / missing
+        // body field is treated as a non-primary add.
+        const wantsPrimary = is_primary === true;
+
         // Insert/update local DB immediately (webhook will also do this, but
         // for immediate consistency). Admin tool already pushed this domain
         // to WorkOS above, so source='workos' reflects upstream truth.
@@ -1427,13 +1431,22 @@ export function setupDomainRoutes(
           orgId,
           domain: normalizedDomain,
           verified: true,
-          isPrimary: is_primary === true,
+          isPrimary: wantsPrimary,
         });
 
-        // If admin requested primary, atomic-flip across the org's rows and
-        // sync email_domain. No requireSource — this is an admin override.
-        if (is_primary) {
+        if (wantsPrimary) {
+          // Atomic-flip across the org's rows and sync email_domain. No
+          // requireSource — admin override.
           await setPrimaryDomain({ orgId, domain: normalizedDomain });
+        } else {
+          // Preserve prior behavior: re-add with is_primary=false demotes.
+          // upsertDomainFromWorkos doesn't change is_primary on conflict
+          // (correct for the webhook's auto-promote path), so demote here.
+          await pool.query(
+            `UPDATE organization_domains SET is_primary = false, updated_at = NOW()
+             WHERE workos_organization_id = $1 AND domain = $2 AND is_primary = true`,
+            [orgId, normalizedDomain],
+          );
         }
 
         logger.info({ orgId, domain: normalizedDomain, isPrimary: is_primary }, "Added domain to organization via WorkOS");

--- a/server/tests/integration/organization-domains-db.test.ts
+++ b/server/tests/integration/organization-domains-db.test.ts
@@ -201,6 +201,24 @@ describe('organization-domains-db (#4159 Stage 3a)', () => {
       expect(result).toEqual({ ok: false, reason: 'not_verified' });
     });
 
+    it('with requireVerified=false, promotes an unverified row (admin override)', async () => {
+      await linkDomain({ orgId: ORG_A, domain: D3, source: 'admin_discovery', verified: false, isPrimary: false });
+
+      const result = await setPrimaryDomain({
+        orgId: ORG_A,
+        domain: D3,
+        requireVerified: false,
+      });
+      expect(result).toEqual({ ok: true });
+
+      const rows = await getPool().query(
+        `SELECT domain FROM organization_domains
+          WHERE workos_organization_id = $1 AND is_primary = true`,
+        [ORG_A],
+      );
+      expect(rows.rows[0].domain).toBe(D3);
+    });
+
     it('returns source_not_allowed when requireSource excludes the row source', async () => {
       await linkDomain({ orgId: ORG_A, domain: D3, source: 'import', verified: true, isPrimary: false });
 


### PR DESCRIPTION
## Summary

Stage 3c of #4159 — the last write surface. Migrate the cleanly-mappable sites in \`routes/admin/domains.ts\` to the canonical writers introduced in 3a/3b.

### Migrated

| Site | Now uses |
|------|----------|
| 3× "admin create prospect" mirrors (lines ~299, 494, 793) | \`linkDomain({source: 'admin_discovery', isPrimary: true, verified: true})\` |
| Admin add-domain-to-org (\`PUT /organizations/:orgId/domains\`) | \`upsertDomainFromWorkos\` + conditional \`setPrimaryDomain\` |
| Admin Set Primary (\`PUT /organizations/:orgId/domains/:domain/primary\`) | \`setPrimaryDomain\` with \`requireVerified: false\` |

### New flag on `setPrimaryDomain`

Adds optional \`requireVerified?: boolean\` (default \`true\`). Member self-service keeps the gate; admin tools that resolve messes — e.g. promoting a hand-imported row before WorkOS confirms — can opt out. Pinned by a new test case.

### Left inline (different policy / one-shot)

- **Admin DELETE** (\`DELETE /organizations/:orgId/domains/:domain\`) — uses \`ORDER BY verified DESC, created_at ASC\` for next-primary picking; \`removeWorkosDomainAndReselectPrimary\` filters \`WHERE verified = true\` first. Different policy intentional.
- **Bulk domain-health sync** (one-shot maintenance \`INSERT...SELECT\`).
- **Reassign-from-personal cleanup** in admin add-domain — admin-takeover specific, low-traffic, kept for clarity.

## Test plan

- [x] New test pins \`requireVerified: false\` admin override (20 cases total now, was 19).
- [x] Wider regression: 9 suites, 76 cases (organization-domains-db, workos-domain-auto-primary, me-organization-domains, prospect-domain-conflict, member-profile-bootstrap, login-name-persistence, identity-layer, find-claimable-prospect-org, claim-prospect-org).
- [x] Typecheck clean.

## Stage 3 status after this PR

3a (member/admin-facing simple writers): merged #4329.
3b (WorkOS webhook): merged #4332.
3c (admin/domains.ts): this PR.

Three sites remain inline by design (above). Two minor follow-ups from earlier reviews still tracked on #4159: rename \`upsertDomainFromWorkos\` to make misuse harder, and pin the cross-org \`is_primary\` upsert edge case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)