### PR TITLE
compliance(request-signing): add vector 028 — unsigned tasks/cancel

### DIFF
--- a/.changeset/request-signing-vector-028-tasks-cancel.md
+++ b/.changeset/request-signing-vector-028-tasks-cancel.md
@@ -1,0 +1,11 @@
+---
+"adcontextprotocol": patch
+---
+
+compliance(request-signing): add negative vector 028 — unsigned `tasks/cancel` JSON-RPC POST → `request_signature_required` (closes #4327)
+
+Vector 028 grades the `protocol_methods_required_for` namespace introduced in #4326. The runner POSTs an unsigned `{"method":"tasks/cancel",...}` JSON-RPC body to a verifier whose capability declares `required_for: []` and `protocol_methods_required_for: ["tasks/cancel"]`. A correct verifier resolves the JSON-RPC envelope's `method` field, matches it against `protocol_methods_required_for`, and rejects with `request_signature_required`. A verifier that only consults `required_for` (the AdCP-tool namespace) would silently accept — which is the regression this vector locks out.
+
+Gating: vector 028 is skipped when the agent doesn't declare `protocol_methods_required_for`. When the agent declares the bucket but doesn't enforce it, the vector FAILs (does not SKIP). Same shape as the existing capability-gated negative vectors.
+
+Conformance harness addition only — no schema changes, no normative spec changes. Patch-eligible per the playbook (additive scenarios are patch-eligible). Cross-namespace match prevention (signed `tools/call` with `params.name: "tasks/cancel"` MUST NOT satisfy `protocol_methods_required_for`) is enforced server-side via the test-agent's `mcpOperationResolver` and unit-tested there; a positive-vector cross-namespace test deferred to a future PR (requires a live signing harness for the positive case).

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -396,6 +396,11 @@ async function main() {
             '007-missing-content-digest',
             '018-digest-covered-when-forbidden',
             '025-jwk-alg-crv-mismatch',
+            // Vector 028 grades `protocol_methods_required_for` (introduced
+            // in adcp#4326). The SDK runner does not yet ship an adversarial
+            // builder for it — un-skip once `@adcp/sdk` adds the builder.
+            // Tracked under the runner-implementation umbrella adcp#2331.
+            '028-unsigned-protocol-method-required',
           ],
           skipRateAbuse: true,
         },

--- a/static/compliance/source/test-vectors/request-signing/README.md
+++ b/static/compliance/source/test-vectors/request-signing/README.md
@@ -44,7 +44,8 @@ test-vectors/request-signing/
 │   ├── 024-unquoted-string-param.json     → request_signature_header_malformed (step 1; RFC 8941 §3.3 string values must be quoted)
 │   ├── 025-jwk-alg-crv-mismatch.json      → request_signature_key_purpose_invalid (step 8; alg=EdDSA with crv=P-256 is impossible per RFC 8037)
 │   ├── 026-non-ascii-host.json            → request_signature_header_malformed (step 1; raw IDN U-label on wire; MUST be A-label)
-│   └── 027-webhook-registration-authentication-unsigned.json → request_signature_required (webhook-reg with push_notification_config.authentication over bearer on a seller supporting signing; operation NOT in required_for)
+│   ├── 027-webhook-registration-authentication-unsigned.json → request_signature_required (webhook-reg with push_notification_config.authentication over bearer on a seller supporting signing; operation NOT in required_for)
+│   └── 028-unsigned-protocol-method-required.json → request_signature_required (unsigned `tasks/cancel` JSON-RPC POST; method is in `protocol_methods_required_for`)
 └── positive/                             vectors that MUST verify successfully
     ├── 001-basic-post.json                   Ed25519, no content-digest
     ├── 002-post-with-content-digest.json     Ed25519, content-digest covered

--- a/static/compliance/source/test-vectors/request-signing/negative/028-unsigned-protocol-method-required.json
+++ b/static/compliance/source/test-vectors/request-signing/negative/028-unsigned-protocol-method-required.json
@@ -1,0 +1,26 @@
+{
+  "name": "Unsigned tasks/cancel JSON-RPC POST; method is in protocol_methods_required_for",
+  "spec_reference": "#signed-requests-transport-layer (protocol_methods_* namespace; pre-check 0)",
+  "reference_now": 1776520800,
+  "request": {
+    "method": "POST",
+    "url": "https://seller.example.com/mcp",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": "{\"jsonrpc\":\"2.0\",\"method\":\"tasks/cancel\",\"params\":{\"taskId\":\"task_conformance_001\"},\"id\":1}"
+  },
+  "verifier_capability": {
+    "supported": true,
+    "covers_content_digest": "either",
+    "required_for": [],
+    "protocol_methods_required_for": ["tasks/cancel"]
+  },
+  "jwks_ref": ["test-ed25519-2026"],
+  "expected_outcome": {
+    "success": false,
+    "error_code": "request_signature_required",
+    "failed_step": 0
+  },
+  "$comment": "Exercises the protocol_methods_required_for namespace introduced in adcp#4326. The verifier resolves the JSON-RPC envelope's `method` field (`tasks/cancel`), matches it against `protocol_methods_required_for`, and rejects the unsigned request with `request_signature_required`. A verifier that only consults `required_for` (the AdCP-tool namespace) would silently accept the unsigned request — which is the regression this vector locks out."
+}

--- a/static/compliance/source/universal/signed-requests.yaml
+++ b/static/compliance/source/universal/signed-requests.yaml
@@ -181,6 +181,16 @@ phases:
         018 content-digest when forbidden     → request_signature_components_unexpected
         019 Signature without Signature-Input → request_signature_header_malformed
         020 per-keyid replay cache cap        → request_signature_rate_abuse
+        028 unsigned tasks/cancel + protocol_methods_required_for → request_signature_required
+
+      Vector 028 is gated on `request_signing.protocol_methods_required_for`
+      being non-empty: the runner skips when the agent does not declare the
+      bucket, and FAILs (not SKIPs) when it declares it but doesn't enforce.
+      It's the only vector that targets a JSON-RPC protocol method rather
+      than a `tools/call` AdCP envelope. Vectors 021-027 (enumerated in the
+      negative/ directory but not in the summary above) cover later
+      additions to the checklist that share the `tools/call` envelope shape
+      with vectors 001-020.
 
       Vectors live at `/compliance/{version}/test-vectors/request-signing/negative/`.
       Grading requires byte-for-byte match on the error code; the failed_step value is


### PR DESCRIPTION
## Summary

Closes #4327. Follow-up to #4326, which added the `request_signing.protocol_methods_*` namespace and wired test-agent enforcement on `/<tenant>/mcp-strict`. This PR adds the conformance vector that grades the new bucket.

- New negative vector `028-unsigned-protocol-method-required.json`: unsigned `tasks/cancel` JSON-RPC POST against a verifier with `protocol_methods_required_for: ["tasks/cancel"]` MUST 401 with `request_signature_required`.
- Capability-gated like vectors 016 / 017 / 020: runner skips when the agent doesn't declare `protocol_methods_required_for`, FAILs (not SKIPs) when it declares but doesn't enforce.
- Updates `README.md` enumeration and `signed-requests.yaml` storyboard summary.
- Adds `028-unsigned-protocol-method-required` to the local runner's `skipVectors` until the SDK ships an adversarial builder. Tracked under the runner-implementation umbrella #2331.

Cross-namespace match prevention (a signed `tools/call` with `params.name: "tasks/cancel"` MUST NOT satisfy `protocol_methods_required_for`) is enforced server-side via the test-agent's `mcpOperationResolver` and unit-tested there. A positive cross-namespace vector is deferred — the positive case requires a live signing harness, and the resolver-side defense is locked in.

`patch` changeset per the playbook (additive conformance scenarios are patch-eligible).

## Test plan

- [x] `npm run test:schemas` (525 schemas valid)
- [x] `npm run test:composed` (35/35)
- [x] `npm run test:storyboard-doc-parity`
- [x] `bash scripts/run-storyboards-matrix.sh` — all 6 tenants meet floors
- [x] Vector JSON validates as plain JSON (`python3 -m json.tool`)
- [ ] SDK-side adversarial builder for vector 028 — separate PR against `@adcp/sdk` under #2331

🤖 Generated with [Claude Code](https://claude.com/claude-code)