### PR TITLE
chore(server): rename upsertDomainFromWorkos and pin cross-org edge case (#4159)

### DIFF
--- a/.changeset/4159-rename-and-edge-test.md
+++ b/.changeset/4159-rename-and-edge-test.md
@@ -1,0 +1,4 @@
+---
+---
+
+Server: rename `upsertDomainFromWorkos` → `upsertWorkosDomain` to match the existing `removeWorkosDomainAndReselectPrimary` pattern, and document the caller-contract trust assumption (callers must have actual WorkOS provenance — not arbitrary admin scripts). Pin the cross-org `is_primary` upsert edge case in tests. #4159 cleanup.

--- a/server/src/db/organization-domains-db.ts
+++ b/server/src/db/organization-domains-db.ts
@@ -7,7 +7,7 @@
  * reinventing the SQL with subtly different invariants.
  *
  * **Trust model:** `linkDomain` rejects ownership transfer on conflict — the
- * existing row stays put. The WorkOS-sourced primitives (`upsertDomainFromWorkos`
+ * existing row stays put. The WorkOS-sourced primitives (`upsertWorkosDomain`
  * and friends) **do** transfer ownership on conflict because WorkOS is the
  * authoritative source of truth for DNS-proof-of-control. Use the
  * member/admin-facing primitives for everything else.
@@ -169,29 +169,38 @@ export async function setPrimaryDomain(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// WorkOS-sourced writers (Stage 3b)
+// WorkOS-provenance writers (Stage 3b)
 //
-// These trust WorkOS's domain ownership as authoritative, so they DO transfer
-// ownership on conflict — opposite of `linkDomain`. They accept an optional
-// `Queryable` so the WorkOS webhook can compose them inside a single
-// transaction with the `FOR UPDATE` lock on `organizations`.
+// **Caller contract:** these primitives stamp `source='workos'` and trust
+// WorkOS as authoritative for DNS-proof-of-control, so they DO transfer
+// ownership on conflict — opposite of `linkDomain`. Only call them when you
+// have actual WorkOS provenance: the `routes/workos-webhooks.ts` handler
+// (events from WorkOS) and the admin add-domain handler (which pushes to
+// WorkOS via the API before writing locally) both qualify. Don't call them
+// from arbitrary admin scripts to plant `source='workos'` on a row that
+// WorkOS doesn't actually own — that's data forgery.
+//
+// They accept an optional `Queryable` so callers can compose them inside a
+// single transaction with the `FOR UPDATE` lock on `organizations`.
 // ─────────────────────────────────────────────────────────────────────────────
 
-export interface UpsertDomainFromWorkosArgs {
+export interface UpsertWorkosDomainArgs {
   orgId: string;
   domain: string;
   verified: boolean;
   /**
    * Set this to true when the caller is sure no other primary exists for the
-   * org (e.g. first verified domain on a fresh org). For the conditional
-   * "promote-to-primary if no other primary" flow, call
-   * `autoPromotePrimaryIfNone` after this.
+   * org (e.g. first verified domain on a fresh org). NOTE: on conflict, the
+   * existing row's `is_primary` is preserved — the EXCLUDED set deliberately
+   * excludes `is_primary` so the auto-promote flow in `autoPromotePrimaryIfNone`
+   * can run independently. If you need atomic "set primary on this row,
+   * regardless of conflict", call `setPrimaryDomain` after.
    */
   isPrimary?: boolean;
 }
 
-export async function upsertDomainFromWorkos(
-  args: UpsertDomainFromWorkosArgs,
+export async function upsertWorkosDomain(
+  args: UpsertWorkosDomainArgs,
   q: Queryable = getPool(),
 ): Promise<void> {
   const { orgId, domain, verified, isPrimary = false } = args;

--- a/server/src/routes/admin/domains.ts
+++ b/server/src/routes/admin/domains.ts
@@ -9,7 +9,7 @@ import { getPool } from "../../db/client.js";
 import {
   linkDomain,
   setPrimaryDomain,
-  upsertDomainFromWorkos,
+  upsertWorkosDomain,
 } from "../../db/organization-domains-db.js";
 import { createLogger } from "../../logger.js";
 import { requireAuth, requireAdmin } from "../../middleware/auth.js";
@@ -1427,7 +1427,7 @@ export function setupDomainRoutes(
         // Insert/update local DB immediately (webhook will also do this, but
         // for immediate consistency). Admin tool already pushed this domain
         // to WorkOS above, so source='workos' reflects upstream truth.
-        await upsertDomainFromWorkos({
+        await upsertWorkosDomain({
           orgId,
           domain: normalizedDomain,
           verified: true,
@@ -1440,7 +1440,7 @@ export function setupDomainRoutes(
           await setPrimaryDomain({ orgId, domain: normalizedDomain });
         } else {
           // Preserve prior behavior: re-add with is_primary=false demotes.
-          // upsertDomainFromWorkos doesn't change is_primary on conflict
+          // upsertWorkosDomain doesn't change is_primary on conflict
           // (correct for the webhook's auto-promote path), so demote here.
           await pool.query(
             `UPDATE organization_domains SET is_primary = false, updated_at = NOW()

--- a/server/src/routes/workos-webhooks.ts
+++ b/server/src/routes/workos-webhooks.ts
@@ -22,7 +22,7 @@ import { Router, Request, Response } from 'express';
 import { createLogger } from '../logger.js';
 import { getPool } from '../db/client.js';
 import {
-  upsertDomainFromWorkos,
+  upsertWorkosDomain,
   autoPromotePrimaryIfNone,
   removeWorkosDomainAndReselectPrimary,
 } from '../db/organization-domains-db.js';
@@ -559,7 +559,7 @@ async function syncOrganizationDomains(org: OrganizationData): Promise<void> {
       // inference and only apply to non-personal orgs.
       const isPrimaryEligible = !isPersonal && i === 0;
 
-      await upsertDomainFromWorkos(
+      await upsertWorkosDomain(
         {
           orgId: org.id,
           domain: domainData.domain,
@@ -691,7 +691,7 @@ export async function upsertOrganizationDomain(domainData: OrganizationDomainEve
     // (multi-user companies sneaking onto a 1-seat individual sub) is
     // enforced at the seat-cap layer (checkSeatAvailability), not by hiding
     // the ownership claim in the data layer.
-    await upsertDomainFromWorkos(
+    await upsertWorkosDomain(
       {
         orgId: domainData.organization_id,
         domain: normalizedDomain,

--- a/server/tests/integration/organization-domains-db.test.ts
+++ b/server/tests/integration/organization-domains-db.test.ts
@@ -8,7 +8,7 @@ import { runMigrations } from '../../src/db/migrate.js';
 import {
   linkDomain,
   setPrimaryDomain,
-  upsertDomainFromWorkos,
+  upsertWorkosDomain,
   autoPromotePrimaryIfNone,
   removeWorkosDomainAndReselectPrimary,
 } from '../../src/db/organization-domains-db.js';
@@ -243,9 +243,9 @@ describe('organization-domains-db (#4159 Stage 3a)', () => {
   // Stage 3b: WorkOS-sourced writers
   // ───────────────────────────────────────────────────────────────────────
 
-  describe('upsertDomainFromWorkos', () => {
+  describe('upsertWorkosDomain', () => {
     it('inserts a fresh row with source=workos', async () => {
-      await upsertDomainFromWorkos({ orgId: ORG_A, domain: D1, verified: true });
+      await upsertWorkosDomain({ orgId: ORG_A, domain: D1, verified: true });
 
       const row = await getPool().query(
         `SELECT workos_organization_id, source, verified, is_primary FROM organization_domains WHERE domain = $1`,
@@ -260,10 +260,10 @@ describe('organization-domains-db (#4159 Stage 3a)', () => {
     });
 
     it('TRANSFERS ownership on conflict — WorkOS is authoritative', async () => {
-      await upsertDomainFromWorkos({ orgId: ORG_B, domain: D_TAKEN, verified: true });
+      await upsertWorkosDomain({ orgId: ORG_B, domain: D_TAKEN, verified: true });
 
       // WorkOS now reassigns the domain to ORG_A; we must follow.
-      await upsertDomainFromWorkos({ orgId: ORG_A, domain: D_TAKEN, verified: true });
+      await upsertWorkosDomain({ orgId: ORG_A, domain: D_TAKEN, verified: true });
 
       const row = await getPool().query(
         `SELECT workos_organization_id, source FROM organization_domains WHERE domain = $1`,
@@ -278,7 +278,7 @@ describe('organization-domains-db (#4159 Stage 3a)', () => {
     it('flips a non-workos row to source=workos on conflict', async () => {
       await linkDomain({ orgId: ORG_A, domain: D1, source: 'manual', verified: false });
 
-      await upsertDomainFromWorkos({ orgId: ORG_A, domain: D1, verified: true });
+      await upsertWorkosDomain({ orgId: ORG_A, domain: D1, verified: true });
 
       const row = await getPool().query(
         `SELECT source, verified FROM organization_domains WHERE domain = $1`,
@@ -286,11 +286,31 @@ describe('organization-domains-db (#4159 Stage 3a)', () => {
       );
       expect(row.rows[0]).toMatchObject({ source: 'workos', verified: true });
     });
+
+    it('on cross-org conflict, transfers ownership but preserves the existing row\'s is_primary (caller intent dropped)', async () => {
+      // Pin the documented edge case: caller passes isPrimary=true but the
+      // existing row from a different org was is_primary=false. Ownership
+      // transfers (good), but the EXCLUDED set excludes is_primary so the
+      // existing false stays. Callers that need "set primary on this row,
+      // regardless of conflict" must call setPrimaryDomain after.
+      await upsertWorkosDomain({ orgId: ORG_B, domain: D_TAKEN, verified: true, isPrimary: false });
+
+      await upsertWorkosDomain({ orgId: ORG_A, domain: D_TAKEN, verified: true, isPrimary: true });
+
+      const row = await getPool().query(
+        `SELECT workos_organization_id, is_primary FROM organization_domains WHERE domain = $1`,
+        [D_TAKEN],
+      );
+      expect(row.rows[0]).toMatchObject({
+        workos_organization_id: ORG_A,
+        is_primary: false,
+      });
+    });
   });
 
   describe('autoPromotePrimaryIfNone', () => {
     it('promotes when no primary exists; updates email_domain', async () => {
-      await upsertDomainFromWorkos({ orgId: ORG_A, domain: D1, verified: true });
+      await upsertWorkosDomain({ orgId: ORG_A, domain: D1, verified: true });
 
       const result = await autoPromotePrimaryIfNone({ orgId: ORG_A, domain: D1 });
       expect(result).toEqual({ promoted: true });
@@ -309,8 +329,8 @@ describe('organization-domains-db (#4159 Stage 3a)', () => {
     });
 
     it('does NOT promote when another primary already exists', async () => {
-      await upsertDomainFromWorkos({ orgId: ORG_A, domain: D1, verified: true, isPrimary: true });
-      await upsertDomainFromWorkos({ orgId: ORG_A, domain: D2, verified: true });
+      await upsertWorkosDomain({ orgId: ORG_A, domain: D1, verified: true, isPrimary: true });
+      await upsertWorkosDomain({ orgId: ORG_A, domain: D2, verified: true });
 
       // Set email_domain to a sentinel; promotion should not touch it.
       await getPool().query(
@@ -353,8 +373,8 @@ describe('organization-domains-db (#4159 Stage 3a)', () => {
     });
 
     it('deletes a non-primary workos row; no reselection', async () => {
-      await upsertDomainFromWorkos({ orgId: ORG_A, domain: D1, verified: true, isPrimary: true });
-      await upsertDomainFromWorkos({ orgId: ORG_A, domain: D2, verified: true });
+      await upsertWorkosDomain({ orgId: ORG_A, domain: D1, verified: true, isPrimary: true });
+      await upsertWorkosDomain({ orgId: ORG_A, domain: D2, verified: true });
 
       const result = await removeWorkosDomainAndReselectPrimary({ orgId: ORG_A, domain: D2 });
       expect(result).toEqual({ deleted: true, wasPrimary: false, newPrimary: null });
@@ -367,10 +387,10 @@ describe('organization-domains-db (#4159 Stage 3a)', () => {
     });
 
     it('deletes the primary row, picks the oldest verified remaining as new primary, syncs email_domain', async () => {
-      await upsertDomainFromWorkos({ orgId: ORG_A, domain: D1, verified: true, isPrimary: true });
+      await upsertWorkosDomain({ orgId: ORG_A, domain: D1, verified: true, isPrimary: true });
       // Force a known created_at ordering: D2 older than D3.
-      await upsertDomainFromWorkos({ orgId: ORG_A, domain: D2, verified: true });
-      await upsertDomainFromWorkos({ orgId: ORG_A, domain: D3, verified: true });
+      await upsertWorkosDomain({ orgId: ORG_A, domain: D2, verified: true });
+      await upsertWorkosDomain({ orgId: ORG_A, domain: D3, verified: true });
       await getPool().query(
         `UPDATE organization_domains SET created_at = $1 WHERE domain = $2`,
         [new Date('2024-01-01'), D2],
@@ -401,7 +421,7 @@ describe('organization-domains-db (#4159 Stage 3a)', () => {
     });
 
     it('deletes the only primary row, no remaining; nulls email_domain', async () => {
-      await upsertDomainFromWorkos({ orgId: ORG_A, domain: D1, verified: true, isPrimary: true });
+      await upsertWorkosDomain({ orgId: ORG_A, domain: D1, verified: true, isPrimary: true });
       await getPool().query(
         `UPDATE organizations SET email_domain = $1 WHERE workos_organization_id = $2`,
         [D1, ORG_A],


### PR DESCRIPTION
## Summary

#4159 cleanup — easy tier of follow-ups from Stage 3 reviews.

### Rename

\`upsertDomainFromWorkos\` → \`upsertWorkosDomain\`. Matches the existing \`removeWorkosDomainAndReselectPrimary\` naming pattern.

The original name read directionally ("from WorkOS"), which made the trust contract unclear — could be misread as "this writes a row that came from WorkOS for any caller's convenience." The new name + expanded doc-comment makes the caller contract explicit: stamps \`source='workos'\` and trusts WorkOS as authoritative for DNS-proof-of-control, so only callers with **actual WorkOS provenance** should use it (the webhook handler, or admin tools that pushed to WorkOS upstream first). Don't call from arbitrary scripts to plant \`source='workos'\` on a row WorkOS doesn't actually own — that's data forgery.

### Edge-case test

Pins the documented behavior on cross-org conflict: ownership transfers (good), but \`is_primary\` is preserved from the existing row (caller's \`isPrimary: true\` intent is silently dropped because the EXCLUDED set excludes \`is_primary\` — that's load-bearing for the webhook's \`autoPromotePrimaryIfNone\` flow).

Callers needing atomic "set primary on this row regardless of conflict" must call \`setPrimaryDomain\` after.

## Test plan

- [x] 21 cases (was 20) on \`organization-domains-db.test.ts\`.
- [x] Wider regression: 7 suites, 60 cases.
- [x] Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)