### PR TITLE
feat(server): migrate admin DELETE + bulk sync to canonical writers (#4159)

### DIFF
--- a/.changeset/4159-medium-inline-holdouts.md
+++ b/.changeset/4159-medium-inline-holdouts.md
@@ -1,0 +1,4 @@
+---
+---
+
+Server: migrate two of the three remaining inline `organization_domains` writers in `routes/admin/domains.ts`. Adds `unlinkDomainAndReselectPrimary` (admin-flavor: any source, reselect prefers verified) and uses it in the admin DELETE handler. Bulk domain-health sync rewritten as a SELECT-then-`linkDomain` loop. Reassign-from-personal cleanup stays inline by design — its `email_domain = $2` defensive filter has reason. #4159 cleanup.

--- a/server/src/db/organization-domains-db.ts
+++ b/server/src/db/organization-domains-db.ts
@@ -256,7 +256,9 @@ export async function autoPromotePrimaryIfNone(
  * back to NULL `email_domain` if nothing's verified.
  *
  * Only deletes rows where `source='workos'` — admin/import rows are immune
- * to WorkOS-driven removal.
+ * to WorkOS-driven removal. For an admin-driven unlink (any source, prefers
+ * verified rows but falls back to unverified), use
+ * `unlinkDomainAndReselectPrimary`.
  */
 export async function removeWorkosDomainAndReselectPrimary(
   args: { orgId: string; domain: string },
@@ -283,6 +285,64 @@ export async function removeWorkosDomainAndReselectPrimary(
     `SELECT domain FROM organization_domains
       WHERE workos_organization_id = $1 AND verified = true
       ORDER BY created_at ASC
+      LIMIT 1`,
+    [orgId],
+  );
+  const newPrimary = remaining.rows[0]?.domain ?? null;
+
+  if (newPrimary) {
+    await q.query(
+      `UPDATE organization_domains SET is_primary = true, updated_at = NOW()
+        WHERE workos_organization_id = $1 AND domain = $2`,
+      [orgId, newPrimary],
+    );
+  }
+  await q.query(
+    `UPDATE organizations SET email_domain = $1, updated_at = NOW()
+      WHERE workos_organization_id = $2`,
+    [newPrimary, orgId],
+  );
+
+  return { deleted: true, wasPrimary: true, newPrimary };
+}
+
+/**
+ * Admin-flavor unlink: delete a domain row regardless of source and reselect
+ * a new primary if the deleted row was primary. Reselect order prefers
+ * verified rows but falls back to unverified — admin tools may have linked
+ * unverified rows and shouldn't lose `email_domain` denormalization just
+ * because nothing's verified yet.
+ *
+ * Compare with `removeWorkosDomainAndReselectPrimary` (workos-source filter,
+ * verified-only reselect): that function refuses to delete admin/import
+ * rows because they're not WorkOS's to remove. This function is the
+ * admin-controlled escape hatch.
+ */
+export async function unlinkDomainAndReselectPrimary(
+  args: { orgId: string; domain: string },
+  q: Queryable = getPool(),
+): Promise<{ deleted: boolean; wasPrimary: boolean; newPrimary: string | null }> {
+  const { orgId, domain } = args;
+  const result = await q.query<{ is_primary: boolean }>(
+    `DELETE FROM organization_domains
+      WHERE workos_organization_id = $1 AND domain = $2
+      RETURNING is_primary`,
+    [orgId, domain],
+  );
+
+  if ((result.rowCount ?? 0) === 0) {
+    return { deleted: false, wasPrimary: false, newPrimary: null };
+  }
+
+  const wasPrimary = result.rows[0].is_primary === true;
+  if (!wasPrimary) {
+    return { deleted: true, wasPrimary: false, newPrimary: null };
+  }
+
+  const remaining = await q.query<{ domain: string }>(
+    `SELECT domain FROM organization_domains
+      WHERE workos_organization_id = $1
+      ORDER BY verified DESC, created_at ASC
       LIMIT 1`,
     [orgId],
   );

--- a/server/src/routes/admin/domains.ts
+++ b/server/src/routes/admin/domains.ts
@@ -10,6 +10,7 @@ import {
   linkDomain,
   setPrimaryDomain,
   upsertWorkosDomain,
+  unlinkDomainAndReselectPrimary,
 } from "../../db/organization-domains-db.js";
 import { createLogger } from "../../logger.js";
 import { requireAuth, requireAdmin } from "../../middleware/auth.js";
@@ -1498,18 +1499,16 @@ export function setupDomainRoutes(
           return res.status(500).json({ error: "WorkOS not configured" });
         }
 
-        // Get domain info before deletion
+        // Pre-check: ensure the domain belongs to this org so we can return a
+        // clean 404 before touching WorkOS.
         const domainResult = await pool.query(
-          `SELECT is_primary, source FROM organization_domains
+          `SELECT 1 FROM organization_domains
            WHERE workos_organization_id = $1 AND domain = $2`,
           [orgId, normalizedDomain]
         );
-
         if (domainResult.rows.length === 0) {
           return res.status(404).json({ error: "Domain not found for this organization" });
         }
-
-        const wasPrimary = domainResult.rows[0].is_primary;
 
         // Remove from WorkOS first - this is the source of truth
         try {
@@ -1532,47 +1531,24 @@ export function setupDomainRoutes(
           });
         }
 
-        // Delete from local DB
-        await pool.query(
-          `DELETE FROM organization_domains WHERE workos_organization_id = $1 AND domain = $2`,
-          [orgId, normalizedDomain]
+        // Local-DB unlink + primary reselect (any source, prefers verified
+        // for the next primary). Webhook would do the same eventually; this
+        // is for immediate consistency.
+        const result = await unlinkDomainAndReselectPrimary({
+          orgId,
+          domain: normalizedDomain,
+        });
+
+        logger.info(
+          { orgId, domain: normalizedDomain, wasPrimary: result.wasPrimary, newPrimary: result.newPrimary },
+          "Removed domain from organization via WorkOS",
         );
-
-        // If we deleted the primary domain, pick a new one
-        let newPrimary: string | null = null;
-        if (wasPrimary) {
-          const remaining = await pool.query(
-            `SELECT domain FROM organization_domains
-             WHERE workos_organization_id = $1
-             ORDER BY verified DESC, created_at ASC
-             LIMIT 1`,
-            [orgId]
-          );
-
-          newPrimary = remaining.rows.length > 0 ? remaining.rows[0].domain : null;
-
-          if (newPrimary) {
-            await pool.query(
-              `UPDATE organization_domains SET is_primary = true, updated_at = NOW()
-               WHERE workos_organization_id = $1 AND domain = $2`,
-              [orgId, newPrimary]
-            );
-          }
-
-          await pool.query(
-            `UPDATE organizations SET email_domain = $1, updated_at = NOW()
-             WHERE workos_organization_id = $2`,
-            [newPrimary, orgId]
-          );
-        }
-
-        logger.info({ orgId, domain: normalizedDomain, wasPrimary, newPrimary }, "Removed domain from organization via WorkOS");
 
         res.json({
           success: true,
           domain: normalizedDomain,
-          was_primary: wasPrimary,
-          new_primary: newPrimary,
+          was_primary: result.wasPrimary,
+          new_primary: result.newPrimary,
         });
       } catch (error) {
         logger.error({ err: error }, "Error removing organization domain");
@@ -2403,52 +2379,49 @@ Respond with ONLY a JSON array, one entry per cluster:
           }
         }
 
-        // If org_id provided, sync just that org; otherwise sync all with issues
-        let query: string;
-        let params: string[];
+        // Find orgs whose email_domain is set but has no matching
+        // organization_domains row. Then call linkDomain per row so the
+        // canonical writer handles conflicts consistently (cross-org log
+        // included).
+        const candidatesSql = `
+          SELECT o.workos_organization_id, LOWER(o.email_domain) AS domain
+          FROM organizations o
+          LEFT JOIN organization_domains od ON od.workos_organization_id = o.workos_organization_id
+            AND LOWER(od.domain) = LOWER(o.email_domain)
+          WHERE ${org_id ? 'o.workos_organization_id = $1 AND ' : ''}
+            o.email_domain IS NOT NULL
+            AND o.is_personal = false
+            AND od.domain IS NULL
+        `;
+        const candidatesParams: string[] = org_id ? [org_id] : [];
+        const candidates = await pool.query<{ workos_organization_id: string; domain: string }>(
+          candidatesSql,
+          candidatesParams,
+        );
 
-        if (org_id) {
-          query = `
-            INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source)
-            SELECT o.workos_organization_id, LOWER(o.email_domain), true, false, 'import'
-            FROM organizations o
-            LEFT JOIN organization_domains od ON od.workos_organization_id = o.workos_organization_id
-              AND LOWER(od.domain) = LOWER(o.email_domain)
-            WHERE o.workos_organization_id = $1
-              AND o.email_domain IS NOT NULL
-              AND o.is_personal = false
-              AND od.domain IS NULL
-            ON CONFLICT (domain) DO NOTHING
-            RETURNING workos_organization_id, domain
-          `;
-          params = [org_id];
-        } else {
-          query = `
-            INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source)
-            SELECT o.workos_organization_id, LOWER(o.email_domain), true, false, 'import'
-            FROM organizations o
-            LEFT JOIN organization_domains od ON od.workos_organization_id = o.workos_organization_id
-              AND LOWER(od.domain) = LOWER(o.email_domain)
-            WHERE o.email_domain IS NOT NULL
-              AND o.is_personal = false
-              AND od.domain IS NULL
-            ON CONFLICT (domain) DO NOTHING
-            RETURNING workos_organization_id, domain
-          `;
-          params = [];
+        const synced: { workos_organization_id: string; domain: string }[] = [];
+        for (const row of candidates.rows) {
+          const result = await linkDomain({
+            orgId: row.workos_organization_id,
+            domain: row.domain,
+            source: 'import',
+            verified: false,
+            isPrimary: true,
+          });
+          if (result.inserted) {
+            synced.push(row);
+          }
         }
 
-        const result = await pool.query(query, params);
-
         logger.info(
-          { count: result.rowCount, org_id },
+          { count: synced.length, org_id },
           "Synced email_domain to organization_domains"
         );
 
         res.json({
           success: true,
-          synced_count: result.rowCount,
-          synced: result.rows,
+          synced_count: synced.length,
+          synced,
         });
       } catch (error) {
         logger.error({ err: error }, "Error syncing domain data");

--- a/server/tests/integration/organization-domains-db.test.ts
+++ b/server/tests/integration/organization-domains-db.test.ts
@@ -455,6 +455,20 @@ describe('organization-domains-db (#4159 Stage 3a)', () => {
       expect(row.rowCount).toBe(0);
     });
 
+    it('non-primary row delete leaves email_domain untouched', async () => {
+      await linkDomain({ orgId: ORG_A, domain: D1, source: 'workos', verified: true, isPrimary: true });
+      await linkDomain({ orgId: ORG_A, domain: D2, source: 'manual', verified: false, isPrimary: false });
+
+      const result = await unlinkDomainAndReselectPrimary({ orgId: ORG_A, domain: D2 });
+      expect(result).toEqual({ deleted: true, wasPrimary: false, newPrimary: null });
+
+      const org = await getPool().query(
+        `SELECT email_domain FROM organizations WHERE workos_organization_id = $1`,
+        [ORG_A],
+      );
+      expect(org.rows[0].email_domain).toBe(D1);
+    });
+
     it('reselect prefers verified, falls back to unverified', async () => {
       await linkDomain({ orgId: ORG_A, domain: D1, source: 'workos', verified: true, isPrimary: true });
       await linkDomain({ orgId: ORG_A, domain: D2, source: 'manual', verified: false, isPrimary: false });

--- a/server/tests/integration/organization-domains-db.test.ts
+++ b/server/tests/integration/organization-domains-db.test.ts
@@ -11,6 +11,7 @@ import {
   upsertWorkosDomain,
   autoPromotePrimaryIfNone,
   removeWorkosDomainAndReselectPrimary,
+  unlinkDomainAndReselectPrimary,
 } from '../../src/db/organization-domains-db.js';
 import type { Pool } from 'pg';
 
@@ -435,6 +436,66 @@ describe('organization-domains-db (#4159 Stage 3a)', () => {
         [ORG_A],
       );
       expect(org.rows[0].email_domain).toBeNull();
+    });
+  });
+
+  describe('unlinkDomainAndReselectPrimary', () => {
+    it('returns deleted=false when no row exists', async () => {
+      const result = await unlinkDomainAndReselectPrimary({ orgId: ORG_A, domain: 'never.test' });
+      expect(result).toEqual({ deleted: false, wasPrimary: false, newPrimary: null });
+    });
+
+    it('DELETES non-workos rows (admin-flavor unlink, no source filter)', async () => {
+      await linkDomain({ orgId: ORG_A, domain: D1, source: 'admin_discovery', verified: true, isPrimary: true });
+
+      const result = await unlinkDomainAndReselectPrimary({ orgId: ORG_A, domain: D1 });
+      expect(result.deleted).toBe(true);
+
+      const row = await getPool().query(`SELECT 1 FROM organization_domains WHERE domain = $1`, [D1]);
+      expect(row.rowCount).toBe(0);
+    });
+
+    it('reselect prefers verified, falls back to unverified', async () => {
+      await linkDomain({ orgId: ORG_A, domain: D1, source: 'workos', verified: true, isPrimary: true });
+      await linkDomain({ orgId: ORG_A, domain: D2, source: 'manual', verified: false, isPrimary: false });
+      await linkDomain({ orgId: ORG_A, domain: D3, source: 'manual', verified: false, isPrimary: false });
+      await getPool().query(
+        `UPDATE organization_domains SET created_at = $1 WHERE domain = $2`,
+        [new Date('2024-01-01'), D2],
+      );
+      await getPool().query(
+        `UPDATE organization_domains SET created_at = $1 WHERE domain = $2`,
+        [new Date('2024-06-01'), D3],
+      );
+
+      // Delete the only verified row; reselect should pick D2 (oldest unverified).
+      const result = await unlinkDomainAndReselectPrimary({ orgId: ORG_A, domain: D1 });
+      expect(result).toEqual({ deleted: true, wasPrimary: true, newPrimary: D2 });
+
+      const org = await getPool().query(
+        `SELECT email_domain FROM organizations WHERE workos_organization_id = $1`,
+        [ORG_A],
+      );
+      expect(org.rows[0].email_domain).toBe(D2);
+    });
+
+    it('reselect picks verified over older unverified', async () => {
+      await linkDomain({ orgId: ORG_A, domain: D1, source: 'workos', verified: true, isPrimary: true });
+      await linkDomain({ orgId: ORG_A, domain: D2, source: 'manual', verified: false, isPrimary: false });
+      await linkDomain({ orgId: ORG_A, domain: D3, source: 'workos', verified: true, isPrimary: false });
+      await getPool().query(
+        `UPDATE organization_domains SET created_at = $1 WHERE domain = $2`,
+        [new Date('2024-01-01'), D2],
+      );
+      await getPool().query(
+        `UPDATE organization_domains SET created_at = $1 WHERE domain = $2`,
+        [new Date('2024-06-01'), D3],
+      );
+
+      // Delete D1 (primary). D2 is older but unverified; D3 is verified.
+      // verified DESC, created_at ASC → D3 wins.
+      const result = await unlinkDomainAndReselectPrimary({ orgId: ORG_A, domain: D1 });
+      expect(result).toEqual({ deleted: true, wasPrimary: true, newPrimary: D3 });
     });
   });
 });


### PR DESCRIPTION
## Summary

#4159 cleanup — Medium tier. Migrate two of three remaining inline \`organization_domains\` writers in \`routes/admin/domains.ts\`.

### New primitive

\`unlinkDomainAndReselectPrimary\` — admin-flavor of \`removeWorkosDomainAndReselectPrimary\`. Differences:

| | \`removeWorkosDomainAndReselectPrimary\` | \`unlinkDomainAndReselectPrimary\` |
|---|---|---|
| DELETE source filter | \`source='workos'\` only | any source |
| Reselect WHERE | \`verified=true\` | (no filter) |
| Reselect ORDER BY | \`created_at ASC\` | \`verified DESC, created_at ASC\` |

The webhook variant refuses to delete admin/import rows (WorkOS shouldn't unilaterally remove rows it didn't create). The admin variant is the escape hatch — it removes any row regardless of source, and reselect prefers verified rows but falls back to unverified.

### Migrated

- **\`DELETE /admin/organizations/:orgId/domains/:domain\`** — ~40 lines of inline DELETE/SELECT/UPDATE collapsed. WorkOS-side removal still runs first; only the local DB cleanup uses the primitive.
- **\`POST /admin/domain-health/sync\`** — bulk \`INSERT...SELECT\` rewritten as a SELECT-candidates-then-loop using \`linkDomain\` per row. Cross-org conflicts now log via the canonical primitive (the original silently \`DO NOTHING\`'d).

### Stays inline

**Reassign-from-personal cleanup** in admin add-domain (lines ~1411-1421). 4 SQL lines. Its \`UPDATE organizations SET email_domain = NULL WHERE workos_organization_id = $1 AND email_domain = $2\` filter is a defensive idempotency guard — if the personal org's \`email_domain\` doesn't match the reassigned domain, leave it. Migrating to a primitive that unconditionally aligns email_domain with the reselected primary would change that semantic. Kept inline.

## Test plan

- [x] 4 new test cases on \`unlinkDomainAndReselectPrimary\` (25 cases total now, was 21).
- [x] Wider regression: 7 suites, 64 cases.
- [x] Typecheck clean.

## #4159 status after this PR

All five canonical primitives now used at every cleanly-mappable site. One inline holdout remains by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)