### PR TITLE
fix(server): users.primary_organization_id FK + merge repoint

### DIFF
--- a/.changeset/users-primary-org-fk-and-merge-fix.md
+++ b/.changeset/users-primary-org-fk-and-merge-fix.md
@@ -1,0 +1,12 @@
+---
+---
+
+Close the structural source of `users.primary_organization_id` drift that PR #4182 had to add a read-time self-heal for.
+
+Root cause was that `users.primary_organization_id` was a plain `VARCHAR(255)` with no FK to `organizations(workos_organization_id)`. Every other table that points at organizations declares an `ON DELETE CASCADE` or `ON DELETE SET NULL` FK (member_profiles, organization_domains, organization_memberships, brands, referral_codes, slack_activity_tracking, registry_audit_log, …) — `users` was the lone exception, so any code path that dropped an `organizations` row left the cached pointer dangling. Three offending paths in production: user self-deletes their workspace, admin force-deletes an account, and `mergeOrganizations` deletes the secondary org.
+
+Fix:
+- Migration 473 adds `users.primary_organization_id` FK with `ON DELETE SET NULL` (NOT VALID → null any rows that already dangle → VALIDATE so existing prod state doesn't block the migration). Closes the `no_org_row` drift class structurally — Postgres now enforces it on every INSERT/UPDATE/DELETE.
+- `mergeOrganizations` now `UPDATE`s users' `primary_organization_id` from secondary → primary inside the merge transaction, BEFORE the secondary org delete fires the FK SET NULL. Without this the repoint intent of the merge would be lost.
+- Two raw `DELETE FROM organization_memberships` callsites (admin remove-member, admin transfer-member) now go through `deleteOrganizationMembership`, which clears the cached pointer in the same transaction — closes the `no_membership_row` drift class for those paths.
+- Tests cover FK rejection, ON DELETE SET NULL self-heal, and the merge repoint.

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -5202,13 +5202,14 @@ Use add_committee_leader to assign a leader.`;
 
         response += `### Data Moved\n`;
         const totalMoved = result.tables_merged.reduce((sum, t) => sum + t.rows_moved, 0);
-        const totalSkipped = result.tables_merged.reduce((sum, t) => sum + t.rows_skipped_duplicate, 0);
+        const totalSkipped = result.tables_merged.reduce((sum, t) => sum + (t.rows_skipped_duplicate ?? 0), 0);
 
         for (const table of result.tables_merged) {
-          if (table.rows_moved > 0 || table.rows_skipped_duplicate > 0) {
+          const skipped = table.rows_skipped_duplicate ?? 0;
+          if (table.rows_moved > 0 || skipped > 0) {
             response += `- **${table.table_name}**: ${table.rows_moved} moved`;
-            if (table.rows_skipped_duplicate > 0) {
-              response += ` (${table.rows_skipped_duplicate} skipped as duplicates)`;
+            if (skipped > 0) {
+              response += ` (${skipped} skipped as duplicates)`;
             }
             response += `\n`;
           }

--- a/server/src/db/migrations/473_users_primary_organization_id_fk.sql
+++ b/server/src/db/migrations/473_users_primary_organization_id_fk.sql
@@ -1,0 +1,58 @@
+-- Add a foreign key on users.primary_organization_id with ON DELETE SET NULL.
+--
+-- Why: the column is a denormalized pointer that 11+ read sites trust as the
+-- caller's authorization scope (member tools, brand-feeds, registry-api,
+-- resolve-caller-org, agent-publish gate, etc.). Until now the column was a
+-- bare VARCHAR(255) — every other table that points at organizations declares
+-- a FK with ON DELETE CASCADE or SET NULL (member_profiles, organization_domains,
+-- organization_memberships, brands, referral_codes, slack_activity_tracking,
+-- registry_audit_log, …) but `users` was the lone exception, so every code path
+-- that drops an organizations row left this pointer dangling.
+--
+-- The dangling pointer surfaced as "Organization not found" 404s on tier-gated
+-- routes (PR #4182 added the resolver self-heal; this migration removes the
+-- structural source of the drift).
+--
+-- Three suspect write paths today:
+--   - routes/organizations.ts (user self-deletes their workspace)
+--   - routes/admin/accounts-billing.ts (admin force-deletes an account)
+--   - db/org-merge-db.ts (merge two orgs — secondary gets DELETE'd, primary
+--     pointers stay pointed at it). The companion code change in this PR
+--     adds an explicit repoint to the merge transaction so SET NULL doesn't
+--     fire there.
+--
+-- Strategy: declare the constraint NOT VALID first so existing rows that
+-- already dangle don't block the migration; null those out with a single
+-- UPDATE; then VALIDATE so the constraint becomes enforceable for future
+-- inserts/updates as well.
+
+-- Step 1: declare the FK with ON DELETE SET NULL, but skip validation of
+-- existing rows. This is cheap (no table scan, no exclusive lock) and lets
+-- us do the data fix in step 2 with the constraint already present so any
+-- concurrent INSERT during the migration is also constrained.
+ALTER TABLE users
+  ADD CONSTRAINT users_primary_organization_id_fkey
+  FOREIGN KEY (primary_organization_id)
+  REFERENCES organizations(workos_organization_id)
+  ON DELETE SET NULL
+  NOT VALID;
+
+-- Step 2: clear any pointer that doesn't resolve to a current organizations
+-- row. The resolver (resolvePrimaryOrganization) re-derives from
+-- organization_memberships on the next read, so this is exactly the same
+-- end state PR #4182's self-heal would land on once each user authenticates.
+UPDATE users
+   SET primary_organization_id = NULL,
+       updated_at = NOW()
+ WHERE primary_organization_id IS NOT NULL
+   AND NOT EXISTS (
+     SELECT 1 FROM organizations o
+     WHERE o.workos_organization_id = users.primary_organization_id
+   );
+
+-- Step 3: VALIDATE the constraint now that no row violates it. From here on,
+-- any future delete of an organizations row automatically nulls the pointer
+-- (no more dangling no_org_row drift), and any INSERT/UPDATE into users with
+-- a bogus primary_organization_id is rejected at the DB level.
+ALTER TABLE users
+  VALIDATE CONSTRAINT users_primary_organization_id_fkey;

--- a/server/src/db/org-merge-db.ts
+++ b/server/src/db/org-merge-db.ts
@@ -25,7 +25,8 @@ export interface MergeSummary {
   tables_merged: {
     table_name: string;
     rows_moved: number;
-    rows_skipped_duplicate: number;
+    /** Only set on tables with a uniqueness conflict. Omitted for plain UPDATEs (e.g. users.primary_organization_id repoint). */
+    rows_skipped_duplicate?: number;
   }[];
   prospect_notes_merged: boolean;
   enrichment_data_preserved: boolean;
@@ -236,6 +237,25 @@ export async function mergeOrganizations(
       `DELETE FROM organization_memberships WHERE workos_organization_id = $1`,
       [secondaryOrgId]
     );
+
+    // Repoint users.primary_organization_id from secondary to primary. Must
+    // happen BEFORE the secondary org row delete (step 24) — once the FK
+    // ON DELETE SET NULL fires, the pointer is gone and we lose the merge
+    // intent. Without this, every user whose primary was the secondary org
+    // ends up resolving back to a different membership (or no org at all)
+    // after the merge, even though we just moved their membership to the
+    // primary above.
+    const repointResult = await client.query(
+      `UPDATE users
+          SET primary_organization_id = $1, updated_at = NOW()
+        WHERE primary_organization_id = $2
+        RETURNING workos_user_id`,
+      [primaryOrgId, secondaryOrgId]
+    );
+    summary.tables_merged.push({
+      table_name: 'users.primary_organization_id',
+      rows_moved: repointResult.rows.length,
+    });
 
     // =====================================================
     // 2. Merge organization_domains

--- a/server/src/routes/admin/accounts.ts
+++ b/server/src/routes/admin/accounts.ts
@@ -16,6 +16,7 @@ import { createLogger } from "../../logger.js";
 import { requireAuth, requireAdmin } from "../../middleware/auth.js";
 import { serveHtmlWithConfig } from "../../utils/html-config.js";
 import { OrganizationDatabase, VALID_REVENUE_TIERS } from "../../db/organization-db.js";
+import { deleteOrganizationMembership } from "../../db/membership-db.js";
 import {
   getPendingInvoices,
   getProductsForCustomer,
@@ -2193,12 +2194,14 @@ export function setupAccountRoutes(
               );
             }
 
-            // Update local cache - remove from source and add to target
-            await pool.query(
-              `DELETE FROM organization_memberships
-               WHERE workos_user_id = $1 AND workos_organization_id = $2`,
-              [member.workos_user_id, sourceOrgId]
-            );
+            // Update local cache - remove from source and add to target.
+            // Use the membership-db helper so users.primary_organization_id
+            // gets cleared in the same transaction when it pointed at the
+            // source org — otherwise the user is left pointing at an org
+            // they're no longer a member of, which read sites trust as the
+            // caller's authorization scope. The next read self-heals to the
+            // target org via resolvePrimaryOrganization.
+            await deleteOrganizationMembership(member.workos_user_id, sourceOrgId);
 
             // Insert into target org cache
             await pool.query(

--- a/server/src/routes/organizations.ts
+++ b/server/src/routes/organizations.ts
@@ -22,6 +22,7 @@ import { OrganizationDatabase, CompanyType, RevenueTier, VALID_REVENUE_TIERS, ge
 import { COMPANY_TYPE_VALUES } from "../config/company-types.js";
 import { VALID_ORGANIZATION_ROLES, VALID_ASSIGNABLE_ROLES } from "../types.js";
 import { JoinRequestDatabase } from "../db/join-request-db.js";
+import { deleteOrganizationMembership } from "../db/membership-db.js";
 import * as referralDb from "../db/referral-codes-db.js";
 import { SlackDatabase } from "../db/slack-db.js";
 import { getCompanyDomain } from "../utils/email-domain.js";
@@ -3376,14 +3377,13 @@ export function createOrganizationsRouter(): Router {
       await workos!.userManagement.deleteOrganizationMembership(membershipId);
 
       // Clean up local organization_memberships table immediately (don't wait for webhook)
-      // This ensures the user isn't "stuck" with stale membership data
-      const pool = getPool();
+      // This ensures the user isn't "stuck" with stale membership data. Use the
+      // membership-db helper so users.primary_organization_id gets cleared in the
+      // same transaction when it pointed at this org — otherwise read sites
+      // continue resolving the just-removed user back into the org they no
+      // longer belong to.
       try {
-        await pool.query(
-          `DELETE FROM organization_memberships
-           WHERE workos_user_id = $1 AND workos_organization_id = $2`,
-          [membership.userId, orgId]
-        );
+        await deleteOrganizationMembership(membership.userId, orgId);
         logger.debug({ userId: membership.userId, orgId }, 'Cleaned up local organization_memberships');
       } catch (cleanupError) {
         // Log but don't fail - the webhook will eventually clean this up

--- a/server/tests/integration/org-merge-primary-org-repoint.test.ts
+++ b/server/tests/integration/org-merge-primary-org-repoint.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Integration test for the users.primary_organization_id repoint added in
+ * mergeOrganizations.
+ *
+ * Without the repoint, every user whose primary pointed at the secondary
+ * org gets a dangling pointer after the merge — the secondary org row gets
+ * deleted, the FK ON DELETE SET NULL nulls the column, and the resolver
+ * has to re-derive on next read. Worse, if the user wasn't in any other
+ * paying org, the resolver might pick a non-paying alternative even
+ * though the merge intent was "treat them as part of primary."
+ *
+ * The repoint runs inside the merge transaction BEFORE the secondary org
+ * row is deleted, so users land at the primary org directly.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { initializeDatabase, closeDatabase, getPool } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { mergeOrganizations } from '../../src/db/org-merge-db.js';
+import type { Pool } from 'pg';
+import type { WorkOS } from '@workos-inc/node';
+
+const PRIMARY_ORG = 'org_merge_repoint_primary';
+const SECONDARY_ORG = 'org_merge_repoint_secondary';
+const THIRD_ORG = 'org_merge_repoint_third';
+const USER_PRIMARY_AT_SECONDARY = 'user_merge_repoint_at_secondary';
+const USER_PRIMARY_ELSEWHERE = 'user_merge_repoint_elsewhere';
+const USER_NULL_PRIMARY = 'user_merge_repoint_null';
+const MERGED_BY = 'user_merge_repoint_admin';
+
+const workosStub = {
+  organizations: {
+    deleteOrganization: async (_id: string) => {},
+  },
+} as unknown as WorkOS;
+
+describe('mergeOrganizations — users.primary_organization_id repoint', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  }, 60000);
+
+  afterAll(async () => {
+    await cleanup();
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanup();
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, created_at, updated_at)
+       VALUES ($1, 'Primary', NOW(), NOW()),
+              ($2, 'Secondary', NOW(), NOW()),
+              ($3, 'Third', NOW(), NOW())`,
+      [PRIMARY_ORG, SECONDARY_ORG, THIRD_ORG],
+    );
+  });
+
+  async function cleanup() {
+    await pool.query(
+      `DELETE FROM organization_memberships WHERE workos_organization_id IN ($1, $2, $3)`,
+      [PRIMARY_ORG, SECONDARY_ORG, THIRD_ORG],
+    );
+    await pool.query(
+      `DELETE FROM users WHERE workos_user_id IN ($1, $2, $3, $4)`,
+      [USER_PRIMARY_AT_SECONDARY, USER_PRIMARY_ELSEWHERE, USER_NULL_PRIMARY, MERGED_BY],
+    );
+    await pool.query(
+      `DELETE FROM organizations WHERE workos_organization_id IN ($1, $2, $3)`,
+      [PRIMARY_ORG, SECONDARY_ORG, THIRD_ORG],
+    );
+  }
+
+  async function seedUser(userId: string, primaryOrgId: string | null) {
+    await pool.query(
+      `INSERT INTO users (workos_user_id, email, primary_organization_id, created_at, updated_at)
+       VALUES ($1, $2, $3, NOW(), NOW())`,
+      [userId, `${userId}@test.com`, primaryOrgId],
+    );
+  }
+
+  async function seedMembership(userId: string, orgId: string) {
+    await pool.query(
+      `INSERT INTO organization_memberships (
+         workos_user_id, workos_organization_id, workos_membership_id, email,
+         role, seat_type, synced_at, created_at, updated_at
+       ) VALUES ($1, $2, $3, $4, 'member', 'community_only', NOW(), NOW(), NOW())`,
+      [userId, orgId, `om_${userId}_${orgId}`, `${userId}@test.com`],
+    );
+  }
+
+  it('repoints users whose primary was the secondary org to the primary org', async () => {
+    await seedUser(USER_PRIMARY_AT_SECONDARY, SECONDARY_ORG);
+    await seedMembership(USER_PRIMARY_AT_SECONDARY, SECONDARY_ORG);
+
+    const summary = await mergeOrganizations(PRIMARY_ORG, SECONDARY_ORG, MERGED_BY, workosStub);
+
+    const after = await pool.query<{ primary_organization_id: string | null }>(
+      'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
+      [USER_PRIMARY_AT_SECONDARY],
+    );
+    expect(after.rows[0]?.primary_organization_id).toBe(PRIMARY_ORG);
+
+    // Summary reports the repoint so admins running merges can audit it.
+    const repointEntry = summary.tables_merged.find(
+      (t) => t.table_name === 'users.primary_organization_id',
+    );
+    expect(repointEntry).toBeDefined();
+    expect(repointEntry!.rows_moved).toBe(1);
+  });
+
+  it('does not touch users whose primary points at a different org', async () => {
+    await seedUser(USER_PRIMARY_ELSEWHERE, THIRD_ORG);
+    await seedMembership(USER_PRIMARY_ELSEWHERE, THIRD_ORG);
+    await seedMembership(USER_PRIMARY_ELSEWHERE, SECONDARY_ORG);
+
+    await mergeOrganizations(PRIMARY_ORG, SECONDARY_ORG, MERGED_BY, workosStub);
+
+    const after = await pool.query<{ primary_organization_id: string | null }>(
+      'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
+      [USER_PRIMARY_ELSEWHERE],
+    );
+    expect(after.rows[0]?.primary_organization_id).toBe(THIRD_ORG);
+  });
+
+  it('does not touch users with null primary_organization_id', async () => {
+    await seedUser(USER_NULL_PRIMARY, null);
+    await seedMembership(USER_NULL_PRIMARY, SECONDARY_ORG);
+
+    await mergeOrganizations(PRIMARY_ORG, SECONDARY_ORG, MERGED_BY, workosStub);
+
+    const after = await pool.query<{ primary_organization_id: string | null }>(
+      'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
+      [USER_NULL_PRIMARY],
+    );
+    expect(after.rows[0]?.primary_organization_id).toBeNull();
+  });
+
+  it('repoint runs before the secondary org is deleted, so the FK SET NULL never fires for these rows', async () => {
+    // Without the repoint, the FK ON DELETE SET NULL would fire when the
+    // secondary org row is deleted at the end of the merge, dropping the
+    // user's primary to NULL even though we just moved their membership
+    // to the primary above. The repoint inside the merge transaction
+    // takes precedence — assert the column lands at primary, not NULL.
+    await seedUser(USER_PRIMARY_AT_SECONDARY, SECONDARY_ORG);
+    await seedMembership(USER_PRIMARY_AT_SECONDARY, SECONDARY_ORG);
+
+    await mergeOrganizations(PRIMARY_ORG, SECONDARY_ORG, MERGED_BY, workosStub);
+
+    const after = await pool.query<{ primary_organization_id: string | null }>(
+      'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
+      [USER_PRIMARY_AT_SECONDARY],
+    );
+    // Specifically NOT null — the FK fired for any column that DIDN'T get
+    // repointed, but we explicitly UPDATE'd this one before the DELETE.
+    expect(after.rows[0]?.primary_organization_id).not.toBeNull();
+    expect(after.rows[0]?.primary_organization_id).toBe(PRIMARY_ORG);
+
+    // Confirm secondary org row was actually deleted (proves the FK
+    // would have fired had the repoint not run first).
+    const secondaryCheck = await pool.query<{ count: string }>(
+      'SELECT COUNT(*)::text AS count FROM organizations WHERE workos_organization_id = $1',
+      [SECONDARY_ORG],
+    );
+    expect(secondaryCheck.rows[0]?.count).toBe('0');
+  });
+});

--- a/server/tests/integration/primary-organization-resolution.test.ts
+++ b/server/tests/integration/primary-organization-resolution.test.ts
@@ -140,38 +140,41 @@ describe('primary_organization_id resolution', () => {
       expect(result).toBeNull();
     });
 
-    // Self-heal cases. The cached column was set
-    // but the join targets had drifted; the bare-column read returned a
-    // phantom orgId that 404'd every tier-gated route until repaired by hand.
-    it('falls through and repoints when cached pointer has no organizations row', async () => {
-      // Real org + membership exists; cached column points at a different
-      // org that's missing from the organizations table.
+    // Self-heal cases. The cached column was set but the join targets had
+    // drifted; the bare-column read returned a phantom orgId that 404'd
+    // every tier-gated route until repaired by hand. Migration 470 closes
+    // the no_org_row class structurally via FK ON DELETE SET NULL — the
+    // FK-driven cases below replace the previous "manually seed dangling
+    // pointer" tests, which the FK now rejects at INSERT time.
+
+    it('FK ON DELETE SET NULL fires when cached org is deleted; resolver re-derives', async () => {
+      // User's cache points at INACTIVE; INACTIVE gets deleted; the FK
+      // automatically nulls the pointer (CASCADE drops INACTIVE membership
+      // too). Resolver should fall back to ACTIVE on the next read.
+      await seedOrg(pool, TEST_ORG_INACTIVE, { subscription_status: null });
       await seedOrg(pool, TEST_ORG_ACTIVE, { subscription_status: 'active' });
-      await seedUser(pool, TEST_USER, 'org_dangling_no_org_row');
+      await seedUser(pool, TEST_USER, TEST_ORG_INACTIVE);
+      await seedMembership(pool, TEST_USER, TEST_ORG_INACTIVE);
       await seedMembership(pool, TEST_USER, TEST_ORG_ACTIVE);
+
+      await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [TEST_ORG_INACTIVE]);
+
+      // FK should have nulled the pointer atomically with the DELETE.
+      const after = await pool.query<{ primary_organization_id: string | null }>(
+        'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
+        [TEST_USER],
+      );
+      expect(after.rows[0]?.primary_organization_id).toBeNull();
 
       const result = await resolvePrimaryOrganization(TEST_USER);
       expect(result).toBe(TEST_ORG_ACTIVE);
-
-      // Repoint is fire-and-forget — poll for it to land.
-      const deadline = Date.now() + 2000;
-      let cached: string | null = null;
-      while (Date.now() < deadline) {
-        const after = await pool.query<{ primary_organization_id: string | null }>(
-          'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
-          [TEST_USER],
-        );
-        cached = after.rows[0]?.primary_organization_id ?? null;
-        if (cached === TEST_ORG_ACTIVE) break;
-        await new Promise((r) => setTimeout(r, 25));
-      }
-      expect(cached).toBe(TEST_ORG_ACTIVE);
     });
 
-    it('falls through and repoints when cached pointer has no membership row', async () => {
-      // Org row exists but the user has no membership for it (e.g. removal
-      // happened via a path that bypassed deleteOrganizationMembership).
-      // A different real membership exists and should win.
+    it('falls through and repoints when cached pointer has no membership row (FK does not catch this)', async () => {
+      // Org row still exists but the user has no membership for it — a
+      // membership-delete path that bypassed deleteOrganizationMembership
+      // (the FK protects no_org_row but not no_membership_row). The
+      // resolver self-heal handles this class.
       await seedOrg(pool, TEST_ORG_ACTIVE, { subscription_status: 'active' });
       await seedOrg(pool, TEST_ORG_INACTIVE, { subscription_status: null });
       await seedUser(pool, TEST_USER, TEST_ORG_INACTIVE); // cache points at INACTIVE
@@ -194,27 +197,48 @@ describe('primary_organization_id resolution', () => {
       expect(cached).toBe(TEST_ORG_ACTIVE);
     });
 
-    it('clears the stale pointer and returns null when cache dangles and no other membership exists', async () => {
-      // Cache is set, but no org row, no membership row, nowhere to fall
-      // back to. Resolver should return null AND null out the column so a
-      // later membership webhook re-triggers the IS-NULL backfill.
-      await seedUser(pool, TEST_USER, 'org_dangling_no_recourse');
+    it('returns null when FK ON DELETE SET NULL leaves no remaining org', async () => {
+      // Single org, single membership; org gets deleted. FK nulls the
+      // pointer (and CASCADE drops the membership). Resolver returns null.
+      await seedOrg(pool, TEST_ORG_ACTIVE, { subscription_status: 'active' });
+      await seedUser(pool, TEST_USER, TEST_ORG_ACTIVE);
+      await seedMembership(pool, TEST_USER, TEST_ORG_ACTIVE);
+
+      await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [TEST_ORG_ACTIVE]);
+
+      const after = await pool.query<{ primary_organization_id: string | null }>(
+        'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
+        [TEST_USER],
+      );
+      expect(after.rows[0]?.primary_organization_id).toBeNull();
 
       const result = await resolvePrimaryOrganization(TEST_USER);
       expect(result).toBeNull();
+    });
+  });
 
-      const deadline = Date.now() + 2000;
-      let cached: string | null = 'org_dangling_no_recourse';
-      while (Date.now() < deadline) {
-        const after = await pool.query<{ primary_organization_id: string | null }>(
-          'SELECT primary_organization_id FROM users WHERE workos_user_id = $1',
-          [TEST_USER],
-        );
-        cached = after.rows[0]?.primary_organization_id ?? null;
-        if (cached === null) break;
-        await new Promise((r) => setTimeout(r, 25));
-      }
-      expect(cached).toBeNull();
+  describe('users.primary_organization_id FK constraint', () => {
+    it('rejects INSERT into users with a non-existent primary_organization_id', async () => {
+      await expect(
+        pool.query(
+          `INSERT INTO users (workos_user_id, email, primary_organization_id, created_at, updated_at)
+           VALUES ($1, $2, $3, NOW(), NOW())`,
+          [TEST_USER, `${TEST_USER}@test.com`, 'org_does_not_exist_fkey_test'],
+        ),
+      ).rejects.toThrow(/foreign key|fkey|primary_organization_id/i);
+    });
+
+    it('rejects UPDATE setting primary_organization_id to a non-existent org', async () => {
+      await seedOrg(pool, TEST_ORG_ACTIVE, { subscription_status: 'active' });
+      await seedUser(pool, TEST_USER, TEST_ORG_ACTIVE);
+      await seedMembership(pool, TEST_USER, TEST_ORG_ACTIVE);
+
+      await expect(
+        pool.query(
+          `UPDATE users SET primary_organization_id = $1 WHERE workos_user_id = $2`,
+          ['org_does_not_exist_fkey_test', TEST_USER],
+        ),
+      ).rejects.toThrow(/foreign key|fkey|primary_organization_id/i);
     });
   });
 


### PR DESCRIPTION
## Summary

Close the structural source of dangling `users.primary_organization_id` pointers that PR #4182 had to add a read-time self-heal for.

**Root cause** was that `users.primary_organization_id` was a plain `VARCHAR(255)` with no FK to `organizations(workos_organization_id)`. Every other table that points at organizations declares an FK with cascade behavior — `users` was the lone exception, so every code path that dropped an `organizations` row left the cached pointer dangling. Three suspect write paths in production (visible in #4182's repair-script dry-run): user self-deletes their workspace, admin force-deletes an account, and `mergeOrganizations` deletes the secondary org without repointing users who pointed at it.

## Changes

- **Migration 473** adds `users.primary_organization_id` FK with `ON DELETE SET NULL` (NOT VALID → null any rows that already dangle → VALIDATE so prod state doesn't block the migration). Closes the `no_org_row` drift class structurally — Postgres now enforces it on every INSERT/UPDATE/DELETE.
- **`mergeOrganizations`** now `UPDATE`s users' `primary_organization_id` from secondary → primary inside the merge transaction, BEFORE the secondary org delete fires the FK SET NULL. Without this the repoint intent of the merge would be lost.
- **Admin remove-member** (`routes/organizations.ts`) and **admin transfer-member** (`routes/admin/accounts.ts`) now go through `deleteOrganizationMembership`, which clears the cached pointer in the same transaction — closes the `no_membership_row` drift class for those paths.
- **Tests** cover FK rejection, ON DELETE SET NULL self-heal, and the merge repoint behavior.

## Why now

PR #4182 made the resolver self-heal on read but the *writes* that create the dangling state were untouched. Today's repair-script dry-run on prod shows 17 users still dangling, clustered around specific deleted orgs (`org_01KDV7ZA…`, `org_01KDTES6B43…`) — strong signature of merge + delete paths that don't cascade. This PR removes the source.

## Test plan

- [x] 70 tests pass across `primary-organization-resolution.test.ts`, `org-merge-primary-org-repoint.test.ts`, `org-merge-agent-contexts.test.ts`, `membership-webhook.test.ts`
- [x] FK rejection cases: INSERT and UPDATE setting `primary_organization_id` to a non-existent org both reject
- [x] FK ON DELETE SET NULL: deleting an org auto-nulls the cached pointer; resolver re-derives from remaining memberships
- [x] Merge repoint: users' `primary_organization_id` lands at primary, not NULL, after merge; tested with three scenarios (primary at secondary, primary elsewhere, NULL primary)
- [x] Pre-commit (typecheck + unit + dynamic-imports + callApi state-change) green
- [ ] After deploy: re-run `repair-dangling-primary-orgs.js --apply` to clear remaining backlog. New dangles should stop accumulating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)