### PR TITLE
fix(server): atomic admin transfer-member + cache invalidation

### DIFF
--- a/.changeset/admin-transfer-atomicity-nits.md
+++ b/.changeset/admin-transfer-atomicity-nits.md
@@ -1,0 +1,11 @@
+---
+---
+
+Tighten the admin transfer-member flow that PR #4342 left as a known nit:
+
+- `deleteOrganizationMembership` now accepts an optional `PoolClient` so a multi-step caller can wrap the helper's DELETE+UPDATE with a sibling write in a single transaction.
+- The admin transfer-member loop in `routes/admin/accounts.ts` now wraps the source-membership delete and the target-membership insert in one transaction, closing the brief window where a parallel reader could see "user has no membership at all" between the two writes.
+- Adds `invalidateMembershipCache(sourceOrgId)` + `invalidateMembershipCache(targetOrgId)` after the transaction so the in-process cache reflects the post-transfer state immediately.
+- Same defensive `invalidateMembershipCache(orgId)` added to `routes/organizations.ts` admin remove-member after `deleteOrganizationMembership`.
+
+Tests cover the external-client transaction (mid-transaction parallel reader sees pre-state, post-COMMIT sees post-state) and the rollback case (caller-side ROLLBACK rolls back the helper's writes).

--- a/server/src/db/membership-db.ts
+++ b/server/src/db/membership-db.ts
@@ -6,6 +6,7 @@
  */
 
 import type { WorkOS } from '@workos-inc/node';
+import type { PoolClient } from 'pg';
 import { getPool, getClient } from './client.js';
 import { findPayingOrgForDomain } from './org-filters.js';
 import { createLogger } from '../logger.js';
@@ -142,17 +143,24 @@ export async function upsertOrganizationMembership(
  * a stale pointer would let resolvePrimaryOrganization keep returning a
  * removed-org id, which read sites use as an authorization scope. Next
  * read backfills via resolvePreferredOrganization.
+ *
+ * @param externalClient — when provided, the caller owns the transaction;
+ *   we run only the DELETE+UPDATE on that client without BEGIN/COMMIT.
+ *   Lets a multi-step caller (admin transfer-member) wrap this with a
+ *   sibling write in one atomic unit.
  */
 export async function deleteOrganizationMembership(
   userId: string,
   organizationId: string,
+  externalClient?: PoolClient,
 ): Promise<string | null> {
   // Atomic: DELETE membership and clear the cached pointer in one transaction.
   // If the DELETE succeeded but the pointer-clear UPDATE failed, we'd recreate
   // the exact stale-pointer state the integrity invariant exists to catch.
-  const client = await getClient();
+  const client = externalClient ?? await getClient();
+  const ownsTransaction = externalClient === undefined;
   try {
-    await client.query('BEGIN');
+    if (ownsTransaction) await client.query('BEGIN');
     const result = await client.query<{ role: string }>(
       `DELETE FROM organization_memberships
        WHERE workos_user_id = $1 AND workos_organization_id = $2
@@ -164,13 +172,15 @@ export async function deleteOrganizationMembership(
        WHERE workos_user_id = $1 AND primary_organization_id = $2`,
       [userId, organizationId],
     );
-    await client.query('COMMIT');
+    if (ownsTransaction) await client.query('COMMIT');
     return result.rows[0]?.role ?? null;
   } catch (err) {
-    try { await client.query('ROLLBACK'); } catch { /* swallow */ }
+    if (ownsTransaction) {
+      try { await client.query('ROLLBACK'); } catch { /* swallow */ }
+    }
     throw err;
   } finally {
-    client.release();
+    if (ownsTransaction) client.release();
   }
 }
 

--- a/server/src/db/membership-db.ts
+++ b/server/src/db/membership-db.ts
@@ -146,6 +146,9 @@ export async function upsertOrganizationMembership(
  *
  * @param externalClient — when provided, the caller owns the transaction;
  *   we run only the DELETE+UPDATE on that client without BEGIN/COMMIT.
+ *   The caller MUST have already issued BEGIN on this client — otherwise
+ *   the DELETE and UPDATE run as separate auto-commit statements and the
+ *   atomic guarantee this helper exists to provide silently regresses.
  *   Lets a multi-step caller (admin transfer-member) wrap this with a
  *   sibling write in one atomic unit.
  */

--- a/server/src/routes/admin/accounts.ts
+++ b/server/src/routes/admin/accounts.ts
@@ -17,6 +17,7 @@ import { requireAuth, requireAdmin } from "../../middleware/auth.js";
 import { serveHtmlWithConfig } from "../../utils/html-config.js";
 import { OrganizationDatabase, VALID_REVENUE_TIERS } from "../../db/organization-db.js";
 import { deleteOrganizationMembership } from "../../db/membership-db.js";
+import { invalidateMembershipCache } from "../../db/org-filters.js";
 import {
   getPendingInvoices,
   getProductsForCustomer,
@@ -2194,34 +2195,50 @@ export function setupAccountRoutes(
               );
             }
 
-            // Update local cache - remove from source and add to target.
-            // Use the membership-db helper so users.primary_organization_id
-            // gets cleared in the same transaction when it pointed at the
-            // source org — otherwise the user is left pointing at an org
-            // they're no longer a member of, which read sites trust as the
-            // caller's authorization scope. The next read self-heals to the
-            // target org via resolvePrimaryOrganization.
-            await deleteOrganizationMembership(member.workos_user_id, sourceOrgId);
-
-            // Insert into target org cache
-            await pool.query(
-              `INSERT INTO organization_memberships
-               (workos_user_id, workos_organization_id, workos_membership_id, email, first_name, last_name, role, synced_at)
-               VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
-               ON CONFLICT (workos_user_id, workos_organization_id) DO UPDATE SET
-               workos_membership_id = EXCLUDED.workos_membership_id,
-               role = EXCLUDED.role,
-               synced_at = NOW()`,
-              [
+            // Update local cache atomically — the source DELETE (with its
+            // primary_organization_id pointer-clear) and the target INSERT
+            // commit together so an HTTP request landing mid-transfer can
+            // never see "neither membership exists for this user." Without
+            // the wrap, the deleteOrganizationMembership self-commit briefly
+            // exposes a no-membership window before the target INSERT lands.
+            const txClient = await pool.connect();
+            try {
+              await txClient.query('BEGIN');
+              await deleteOrganizationMembership(
                 member.workos_user_id,
-                targetOrgId,
-                newMembership.id,
-                member.email,
-                member.first_name,
-                member.last_name,
-                member.role || 'member',
-              ]
-            );
+                sourceOrgId,
+                txClient,
+              );
+              await txClient.query(
+                `INSERT INTO organization_memberships
+                 (workos_user_id, workos_organization_id, workos_membership_id, email, first_name, last_name, role, synced_at)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
+                 ON CONFLICT (workos_user_id, workos_organization_id) DO UPDATE SET
+                 workos_membership_id = EXCLUDED.workos_membership_id,
+                 role = EXCLUDED.role,
+                 synced_at = NOW()`,
+                [
+                  member.workos_user_id,
+                  targetOrgId,
+                  newMembership.id,
+                  member.email,
+                  member.first_name,
+                  member.last_name,
+                  member.role || 'member',
+                ]
+              );
+              await txClient.query('COMMIT');
+            } catch (txErr) {
+              await txClient.query('ROLLBACK').catch(() => {});
+              throw txErr;
+            } finally {
+              txClient.release();
+            }
+
+            // Drop both orgs' membership caches so the next read sees the
+            // post-transfer state instead of the pre-transfer snapshot.
+            invalidateMembershipCache(sourceOrgId);
+            invalidateMembershipCache(targetOrgId);
 
             results.push({
               user_id: member.workos_user_id,

--- a/server/src/routes/organizations.ts
+++ b/server/src/routes/organizations.ts
@@ -3384,6 +3384,9 @@ export function createOrganizationsRouter(): Router {
       // longer belong to.
       try {
         await deleteOrganizationMembership(membership.userId, orgId);
+        // Drop the membership cache for this org so the next read sees the
+        // post-removal state instead of the pre-removal snapshot.
+        invalidateMembershipCache(orgId);
         logger.debug({ userId: membership.userId, orgId }, 'Cleaned up local organization_memberships');
       } catch (cleanupError) {
         // Log but don't fail - the webhook will eventually clean this up

--- a/server/tests/integration/primary-organization-resolution.test.ts
+++ b/server/tests/integration/primary-organization-resolution.test.ts
@@ -341,5 +341,89 @@ describe('primary_organization_id resolution', () => {
       );
       expect(after.rows[0].primary_organization_id).toBe(TEST_ORG_ACTIVE);
     });
+
+    it('participates in the caller-owned transaction when an external client is provided', async () => {
+      // The admin transfer-member route wraps deleteOrganizationMembership +
+      // a sibling INSERT in one transaction so a mid-transfer reader can
+      // never see "no membership at all." This test proves the helper
+      // honors an externally-managed client by asserting that a parallel
+      // SELECT from a different connection sees the pre-transfer state
+      // until COMMIT, then the post-transfer state immediately after.
+      const { deleteOrganizationMembership } = await import('../../src/db/membership-db.js');
+      await seedOrg(pool, TEST_ORG_ACTIVE, { subscription_status: 'active' });
+      await seedOrg(pool, TEST_ORG_INACTIVE, { subscription_status: 'active' });
+      await seedUser(pool, TEST_USER, TEST_ORG_ACTIVE);
+      await seedMembership(pool, TEST_USER, TEST_ORG_ACTIVE);
+
+      const txClient = await pool.connect();
+      try {
+        await txClient.query('BEGIN');
+        await deleteOrganizationMembership(TEST_USER, TEST_ORG_ACTIVE, txClient);
+
+        // Mid-transaction: a parallel reader on a different pool connection
+        // still sees the pre-delete membership row because we haven't COMMIT'd.
+        const midRead = await pool.query<{ count: string }>(
+          `SELECT COUNT(*)::text AS count FROM organization_memberships
+            WHERE workos_user_id = $1 AND workos_organization_id = $2`,
+          [TEST_USER, TEST_ORG_ACTIVE],
+        );
+        expect(midRead.rows[0]?.count).toBe('1');
+
+        await txClient.query('COMMIT');
+      } finally {
+        txClient.release();
+      }
+
+      // Post-COMMIT: parallel readers see both the membership delete and the
+      // primary-pointer clear.
+      const postRead = await pool.query<{
+        membership_count: string;
+        primary_organization_id: string | null;
+      }>(
+        `SELECT
+           (SELECT COUNT(*)::text FROM organization_memberships
+              WHERE workos_user_id = $1 AND workos_organization_id = $2) AS membership_count,
+           (SELECT primary_organization_id FROM users
+              WHERE workos_user_id = $1) AS primary_organization_id`,
+        [TEST_USER, TEST_ORG_ACTIVE],
+      );
+      expect(postRead.rows[0]?.membership_count).toBe('0');
+      expect(postRead.rows[0]?.primary_organization_id).toBeNull();
+    });
+
+    it('rolls back the membership delete and pointer clear together when the external transaction aborts', async () => {
+      // The whole point of accepting an external client is "atomic with my
+      // sibling write." If the caller's outer transaction rolls back, the
+      // helper's DELETE + UPDATE must roll back with it.
+      const { deleteOrganizationMembership } = await import('../../src/db/membership-db.js');
+      await seedOrg(pool, TEST_ORG_ACTIVE, { subscription_status: 'active' });
+      await seedUser(pool, TEST_USER, TEST_ORG_ACTIVE);
+      await seedMembership(pool, TEST_USER, TEST_ORG_ACTIVE);
+
+      const txClient = await pool.connect();
+      try {
+        await txClient.query('BEGIN');
+        await deleteOrganizationMembership(TEST_USER, TEST_ORG_ACTIVE, txClient);
+        await txClient.query('ROLLBACK');
+      } finally {
+        txClient.release();
+      }
+
+      // Both writes must have rolled back — membership row still present,
+      // primary pointer still pointing at TEST_ORG_ACTIVE.
+      const after = await pool.query<{
+        membership_count: string;
+        primary_organization_id: string | null;
+      }>(
+        `SELECT
+           (SELECT COUNT(*)::text FROM organization_memberships
+              WHERE workos_user_id = $1 AND workos_organization_id = $2) AS membership_count,
+           (SELECT primary_organization_id FROM users
+              WHERE workos_user_id = $1) AS primary_organization_id`,
+        [TEST_USER, TEST_ORG_ACTIVE],
+      );
+      expect(after.rows[0]?.membership_count).toBe('1');
+      expect(after.rows[0]?.primary_organization_id).toBe(TEST_ORG_ACTIVE);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Tightens the admin transfer-member flow PR #4342 left as a known nit (review feedback from both code- and security-reviewer).

- **`deleteOrganizationMembership` accepts an optional `PoolClient`** so a multi-step caller can wrap the helper's DELETE+UPDATE with a sibling write in one transaction. Existing single-step callers (workos webhooks, etc.) are unchanged — the helper still owns its own BEGIN/COMMIT when no client is passed.
- **Admin transfer-member loop** in `routes/admin/accounts.ts` now wraps the source-membership delete and the target-membership insert in one transaction, closing the brief window where a parallel reader could see "user has no membership at all" between the two writes.
- **Cache invalidation** added after both transfer-member and remove-member so the in-process membership cache reflects the post-write state immediately instead of waiting for TTL. The remove-member path is the one security-reviewer flagged on #4342; transfer-member never had it.

## Why now

Brian asked for the two follow-up nits from #4342 to be tightened in a focused follow-up rather than left rotting in a TODO. The atomic-transfer fix is the more substantive one — it eliminates a race where mid-transfer the user appears as "no organization at all" to other requests. The cache invalidations are defense-in-depth.

## Test plan

- [x] 18 tests pass in `primary-organization-resolution.test.ts` (16 existing + 2 new)
- [x] New: external-client visibility test — proves parallel readers on a different pool connection see pre-transfer state until COMMIT, then post-state immediately after
- [x] New: external-client rollback test — caller's ROLLBACK rolls back the helper's DELETE + UPDATE together
- [x] Pre-commit hooks green (typecheck + unit + dynamic-imports + callApi state-change)
- [ ] After deploy: run admin transfer-member end-to-end via UI to confirm no behavior regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)