### PR TITLE
fix(compliance): rotate 5 static idempotency_keys in success-path storyboard steps

### DIFF
--- a/.changeset/fix-storyboard-static-idempotency-keys-success-path.md
+++ b/.changeset/fix-storyboard-static-idempotency-keys-success-path.md
@@ -1,0 +1,27 @@
+---
+# No package bump — compliance YAML harness files are not a versioned protocol schema change.
+# The storyboard source ships in dist/compliance/<version>/ on the next patch cut, not via semver.
+---
+
+fix(compliance): rotate 5 static idempotency keys in success-path storyboard steps (issue #4344)
+
+Converts 5 hardcoded `idempotency_key` string literals to `$generate:uuid_v4#alias` form in
+`sample_request` blocks that are success-path, stateful steps. Static keys in these steps cause
+seller idempotency caches to return stale responses on re-runs, surfacing phantom regressions
+whenever a seller deploys a response-shape change between test runs.
+
+Files changed:
+- `static/compliance/source/protocols/governance/index.yaml` — `register_plan.sync_plans`
+- `static/compliance/source/specialisms/governance-delivery-monitor/index.yaml` — `plan_registration.sync_plans`
+- `static/compliance/source/specialisms/creative-ad-server/index.yaml` — `report_billing.report_usage`
+- `static/compliance/source/specialisms/governance-spend-authority/denied.yaml` — `plan_registration.sync_plans`
+- `static/compliance/source/specialisms/governance-spend-authority/index.yaml` — `plan_registration.sync_plans`
+
+**Not converted (intentional):** 11 remaining static keys are in steps with `expect_error: true`.
+Per AdCP spec (`idempotency.yaml` line 46): "Error responses do not cache. The next request
+carrying the same key re-executes the handler." A static key on an error step is correct behavior —
+it surfaces the compliance violation if a seller incorrectly caches error responses. This includes
+the 5 keys in `error-compliance.yaml`, 4 in `error-compliance-signals.yaml`, 1 in
+`schema-validation.yaml`, and 1 `signal-gov-denied-v1` (`activate_signal_denied`, stateful+error).
+
+Partial rollout of #4344. Issue stays open as the tracker for the error-step decision.

--- a/static/compliance/source/protocols/governance/index.yaml
+++ b/static/compliance/source/protocols/governance/index.yaml
@@ -246,7 +246,7 @@ phases:
           - human_review_required: set when the plan mandates escalation
 
         sample_request:
-          idempotency_key: "media-buy-governance-escalation-sync-plans-v1"
+          idempotency_key: "$generate:uuid_v4#media_buy_governance_escalation_register_plan_sync_plans"
           plans:
             - plan_id: "gov_acme_q2_2027"
               brand:

--- a/static/compliance/source/specialisms/creative-ad-server/index.yaml
+++ b/static/compliance/source/specialisms/creative-ad-server/index.yaml
@@ -367,7 +367,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+          idempotency_key: "$generate:uuid_v4#creative_ad_server_report_billing_report_usage"
           reporting_period:
             start: "2026-03-01T00:00:00Z"
             end: "2026-03-31T23:59:59Z"

--- a/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
+++ b/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
@@ -164,7 +164,7 @@ phases:
           - budget.reallocation_threshold: amount above which reallocation requires re-evaluation
 
         sample_request:
-          idempotency_key: "governance-delivery-monitor-sync-plans-v1"
+          idempotency_key: "$generate:uuid_v4#governance_delivery_monitor_plan_registration_sync_plans"
           plans:
             - plan_id: "gov_acme_delivery_monitor"
               brand:

--- a/static/compliance/source/specialisms/governance-spend-authority/denied.yaml
+++ b/static/compliance/source/specialisms/governance-spend-authority/denied.yaml
@@ -110,7 +110,7 @@ phases:
           - budget.total: $10K cap that any single buy above will exceed
 
         sample_request:
-          idempotency_key: "governance-spend-authority-denied-sync-plans-v1"
+          idempotency_key: "$generate:uuid_v4#governance_spend_authority_denied_plan_registration_sync_plans"
           plans:
             - plan_id: "gov_acme_strict"
               brand:

--- a/static/compliance/source/specialisms/governance-spend-authority/index.yaml
+++ b/static/compliance/source/specialisms/governance-spend-authority/index.yaml
@@ -159,7 +159,7 @@ phases:
           - custom_policies: policy conditions registered
 
         sample_request:
-          idempotency_key: "governance-spend-authority-sync-plans-v1"
+          idempotency_key: "$generate:uuid_v4#governance_spend_authority_plan_registration_sync_plans"
           plans:
             - plan_id: "gov_acme_spend_authority_q2_2027"
               brand:


### PR DESCRIPTION
Refs #4344

Converts 5 hardcoded `idempotency_key:` string literals in storyboard `sample_request:` blocks to `$generate:uuid_v4#alias` form. Static keys in these steps cause seller idempotency caches to return stale responses across test runs, surfacing phantom regressions whenever a seller deploys a response-shape change between runs.

**Non-breaking justification:** Changes only `sample_request:` block values in conformance storyboard YAML files. The runner already expands `$generate:uuid_v4#alias` tokens (100+ existing uses across the storyboard corpus). No protocol schema, task definition, or normative requirement is changed. All aliases are globally unique and follow the `<storyboard_id>_<phase_id>_<step_id>` convention.

**Files changed:**
- `protocols/governance/index.yaml` — `register_plan.sync_plans` (was `"media-buy-governance-escalation-sync-plans-v1"`)
- `specialisms/governance-delivery-monitor/index.yaml` — `plan_registration.sync_plans` (was `"governance-delivery-monitor-sync-plans-v1"`)
- `specialisms/creative-ad-server/index.yaml` — `report_billing.report_usage` (was `"a1b2c3d4-e5f6-7890-abcd-ef1234567890"`)
- `specialisms/governance-spend-authority/denied.yaml` — `plan_registration.sync_plans` (was `"governance-spend-authority-denied-sync-plans-v1"`)
- `specialisms/governance-spend-authority/index.yaml` — `plan_registration.sync_plans` (was `"governance-spend-authority-sync-plans-v1"`)

**Intentionally not converted (11 remaining static keys):** All have `expect_error: true`. Per `idempotency.yaml` line 46: "Error responses do not cache. The next request carrying the same key re-executes the handler." A static key on an error step is correct — it surfaces the compliance violation if a seller incorrectly caches error responses. This includes `signal-gov-denied-v1` (`activate_signal_denied`, `stateful: true + expect_error: true`) — experts split on this one; left static per protocol semantics until #4344 is revisited for the error-step policy.

**dist/compliance/** not updated — versioned directories are immutable release artifacts regenerated by `build-compliance.cjs` on next patch cut.

**Pre-PR review:**
- code-reviewer: approved — 5 aliases globally unique, convention followed, no dist touched (nit: changeset front-matter clarified with inline comment)
- ad-tech-protocol-expert: approved — non-breaking per spec; `$generate:uuid_v4` produces a conformant UUID satisfying the `[A-Za-z0-9_.:-]{16,255}` pattern; error-step keys correctly excluded per idempotency spec line 46

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01UVhU8JP7FiN4ZJYtYWSWC9

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVhU8JP7FiN4ZJYtYWSWC9)_