### PR TITLE
fix(server): short-circuit GitHub Pipes authorize for already-connected users

### DIFF
--- a/.changeset/pipes-already-installed-short-circuit.md
+++ b/.changeset/pipes-already-installed-short-circuit.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix(server): `/connect/github` and the Member Hub Connect button now precheck the user's existing Pipes token state before calling WorkOS authorize. Already-connected users get sent straight to `returnTo` instead of receiving a 502/error page driven by WorkOS' `400 "User has already installed this integration"` response. Recovers from the same 400 if it slips through (TOCTOU between the token check and the authorize POST).

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -38,7 +38,7 @@ import { OrganizationDatabase, getUserSeatType, buildSubscriptionUpdate, TIER_PR
 import { MemberDatabase } from "./db/member-db.js";
 import { ensureMemberProfilePublished } from "./services/member-profile-autopublish.js";
 import { getBrandPrimaryDomain, getBrandPrimaryDomainsForOrgs } from "./services/brand-domain-resolver.js";
-import { getGitHubConnectedAccount, getGitHubAuthorizeUrl, disconnectGitHub, buildPipesReturnTo } from "./services/pipes.js";
+import { getGitHubConnectedAccount, resolveGitHubConnectUrl, disconnectGitHub, buildPipesReturnTo } from "./services/pipes.js";
 import { BrandDatabase, resolveBrandFromJson } from "./db/brand-db.js";
 import { CatalogEventsDatabase } from "./db/catalog-events-db.js";
 import { AgentInventoryProfilesDatabase } from "./db/agent-inventory-profiles-db.js";
@@ -7447,8 +7447,8 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
     this.app.post('/api/me/connected-accounts/github/authorize', requireAuth, async (req, res) => {
       try {
         const returnTo = buildPipesReturnTo(req.get('host') || '', req.protocol, req.body?.return_to);
-        const url = await getGitHubAuthorizeUrl(req.user!.id, returnTo);
-        res.json({ url });
+        const result = await resolveGitHubConnectUrl(req.user!.id, returnTo);
+        res.json({ url: result.url, already_connected: result.status === 'already_connected' });
       } catch (error) {
         logger.error({ err: error }, 'Failed to mint GitHub authorize URL');
         res.status(502).json({ error: 'Failed to start GitHub connection' });
@@ -7478,8 +7478,8 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
       const requestedReturnTo = typeof req.query.return_to === 'string' ? req.query.return_to : null;
       try {
         const returnTo = buildPipesReturnTo(reqHost, reqProto, req.query.return_to);
-        const url = await getGitHubAuthorizeUrl(req.user!.id, returnTo);
-        return res.redirect(302, url);
+        const result = await resolveGitHubConnectUrl(req.user!.id, returnTo);
+        return res.redirect(302, result.url);
       } catch (error) {
         logger.error(
           {

--- a/server/src/services/pipes.ts
+++ b/server/src/services/pipes.ts
@@ -56,6 +56,39 @@ export function buildPipesReturnTo(
   return `${safeProtocol}://${host}${safe}`;
 }
 
+export type ResolveGitHubConnectResult =
+  | { status: 'authorize'; url: string }
+  | { status: 'already_connected'; url: string };
+
+/**
+ * Picks the right URL to send a user to when they click "connect GitHub":
+ * if they already hold an active Pipes token with all required scopes, skip
+ * the WorkOS authorize POST (which 400s with `User has already installed this
+ * integration`) and send them straight to `returnTo`. Also recovers from the
+ * same 400 if it slips through — covers the TOCTOU window where another
+ * tab/click finishes the connect between our token check and the POST.
+ */
+export async function resolveGitHubConnectUrl(
+  workosUserId: string,
+  returnTo: string,
+): Promise<ResolveGitHubConnectResult> {
+  const token = await getGitHubAccessToken(workosUserId);
+  if (token.status === 'ok' && token.missingScopes.length === 0) {
+    return { status: 'already_connected', url: returnTo };
+  }
+  try {
+    const url = await getGitHubAuthorizeUrl(workosUserId, returnTo);
+    return { status: 'authorize', url };
+  } catch (error) {
+    const e = error as { status?: number; rawData?: { message?: string } };
+    const message = typeof e?.rawData?.message === 'string' ? e.rawData.message : '';
+    if (e?.status === 400 && /already installed/i.test(message)) {
+      return { status: 'already_connected', url: returnTo };
+    }
+    throw error;
+  }
+}
+
 export async function getGitHubAuthorizeUrl(workosUserId: string, returnTo: string): Promise<string> {
   const workos = getWorkos();
   let returnToHost = '';

--- a/server/tests/unit/connect-github-bouncer.test.ts
+++ b/server/tests/unit/connect-github-bouncer.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 
-const { mockGetAuthorizeUrl } = vi.hoisted(() => ({ mockGetAuthorizeUrl: vi.fn() }));
+const { mockResolveConnectUrl } = vi.hoisted(() => ({ mockResolveConnectUrl: vi.fn() }));
 
 vi.mock('../../src/services/pipes.js', async () => {
   const actual = await vi.importActual<typeof import('../../src/services/pipes.js')>(
@@ -10,22 +10,21 @@ vi.mock('../../src/services/pipes.js', async () => {
   );
   return {
     ...actual,
-    getGitHubAuthorizeUrl: mockGetAuthorizeUrl,
+    resolveGitHubConnectUrl: mockResolveConnectUrl,
   };
 });
 
-const { getGitHubAuthorizeUrl, buildPipesReturnTo } = await import('../../src/services/pipes.js');
+const { resolveGitHubConnectUrl, buildPipesReturnTo } = await import('../../src/services/pipes.js');
 
 /**
  * Mounts the same bouncer logic that lives in http.ts on a tiny app so we can
  * exercise the redirect/502 wiring without booting the full server. The
- * production route uses the same `buildPipesReturnTo` + `getGitHubAuthorizeUrl`
+ * production route uses the same `buildPipesReturnTo` + `resolveGitHubConnectUrl`
  * pair, so this stays in lock-step as long as those two stay the integration
  * surface for the bouncer.
  */
 function buildBouncerApp() {
   const app = express();
-  // Stub requireAuth so we don't drag in the WorkOS session machinery.
   app.use((req, _res, next) => {
     (req as unknown as { user: { id: string } }).user = { id: 'user_test' };
     next();
@@ -33,11 +32,11 @@ function buildBouncerApp() {
   app.get('/connect/github', async (req, res) => {
     try {
       const returnTo = buildPipesReturnTo(req.get('host') || '', req.protocol, req.query.return_to);
-      const url = await getGitHubAuthorizeUrl(
+      const result = await resolveGitHubConnectUrl(
         (req as unknown as { user: { id: string } }).user.id,
         returnTo,
       );
-      return res.redirect(302, url);
+      return res.redirect(302, result.url);
     } catch {
       return res
         .status(502)
@@ -49,11 +48,14 @@ function buildBouncerApp() {
 
 describe('GET /connect/github bouncer', () => {
   beforeEach(() => {
-    mockGetAuthorizeUrl.mockReset();
+    mockResolveConnectUrl.mockReset();
   });
 
   it('302-redirects to a freshly minted Pipes URL on the click', async () => {
-    mockGetAuthorizeUrl.mockResolvedValueOnce('https://auth.example/data-integrations/abc/authorize-redirect');
+    mockResolveConnectUrl.mockResolvedValueOnce({
+      status: 'authorize',
+      url: 'https://auth.example/data-integrations/abc/authorize-redirect',
+    });
 
     const res = await request(buildBouncerApp())
       .get('/connect/github')
@@ -61,29 +63,41 @@ describe('GET /connect/github bouncer', () => {
 
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('https://auth.example/data-integrations/abc/authorize-redirect');
-    // Pipes URL is minted on click using the verified session user, not at message-write time.
-    expect(mockGetAuthorizeUrl).toHaveBeenCalledWith('user_test', expect.stringContaining('/member-hub?connected=github'));
+    expect(mockResolveConnectUrl).toHaveBeenCalledWith('user_test', expect.stringContaining('/member-hub?connected=github'));
+  });
+
+  it('302-redirects to returnTo when the user is already connected', async () => {
+    mockResolveConnectUrl.mockResolvedValueOnce({
+      status: 'already_connected',
+      url: 'https://example.com/member-hub?connected=github',
+    });
+
+    const res = await request(buildBouncerApp())
+      .get('/connect/github')
+      .query({ return_to: '/member-hub?connected=github' });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('https://example.com/member-hub?connected=github');
   });
 
   it('returns 502 with a user-friendly body when WorkOS Pipes is unavailable', async () => {
-    mockGetAuthorizeUrl.mockRejectedValueOnce(new Error('workos pipes 503'));
+    mockResolveConnectUrl.mockRejectedValueOnce(new Error('workos pipes 503'));
 
     const res = await request(buildBouncerApp()).get('/connect/github');
 
     expect(res.status).toBe(502);
     expect(res.text).toContain('Could not start GitHub connection');
-    // The fallback should still point users at the Hub so they aren't dead-ended.
     expect(res.text).toContain('/member-hub');
   });
 
   it('falls back to the default return_to path when the caller supplies an unsafe one', async () => {
-    mockGetAuthorizeUrl.mockResolvedValueOnce('https://auth.example/x');
+    mockResolveConnectUrl.mockResolvedValueOnce({ status: 'authorize', url: 'https://auth.example/x' });
 
     await request(buildBouncerApp())
       .get('/connect/github')
       .query({ return_to: '//evil.example/owned' });
 
-    const [, returnTo] = mockGetAuthorizeUrl.mock.calls[0];
+    const [, returnTo] = mockResolveConnectUrl.mock.calls[0];
     expect(returnTo).toContain('/member-hub?connected=github');
     expect(returnTo).not.toContain('evil.example');
   });

--- a/server/tests/unit/pipes-resolve-connect-url.test.ts
+++ b/server/tests/unit/pipes-resolve-connect-url.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockGetAccessToken, mockPost } = vi.hoisted(() => ({
+  mockGetAccessToken: vi.fn(),
+  mockPost: vi.fn(),
+}));
+
+vi.mock('../../src/auth/workos-client.js', () => ({
+  getWorkos: () => ({
+    pipes: { getAccessToken: mockGetAccessToken },
+    post: mockPost,
+  }),
+}));
+
+const { resolveGitHubConnectUrl } = await import('../../src/services/pipes.js');
+
+describe('resolveGitHubConnectUrl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns already_connected without calling authorize when user has an active token with all scopes', async () => {
+    mockGetAccessToken.mockResolvedValueOnce({
+      active: true,
+      accessToken: { accessToken: 'ghs_xxx', scopes: ['repo'], missingScopes: [] },
+    });
+
+    const result = await resolveGitHubConnectUrl('user_123', 'https://example.com/member-hub?connected=github');
+
+    expect(result).toEqual({
+      status: 'already_connected',
+      url: 'https://example.com/member-hub?connected=github',
+    });
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('calls authorize when the active token is missing required scopes', async () => {
+    mockGetAccessToken.mockResolvedValueOnce({
+      active: true,
+      accessToken: { accessToken: 'ghs_xxx', scopes: ['repo'], missingScopes: ['workflow'] },
+    });
+    mockPost.mockResolvedValueOnce({ data: { url: 'https://auth.example/authorize-x' } });
+
+    const result = await resolveGitHubConnectUrl('user_123', 'https://example.com/member-hub?connected=github');
+
+    expect(result).toEqual({ status: 'authorize', url: 'https://auth.example/authorize-x' });
+    expect(mockPost).toHaveBeenCalledOnce();
+  });
+
+  it('calls authorize when the user is not yet connected', async () => {
+    mockGetAccessToken.mockResolvedValueOnce({ active: false, error: 'not_installed' });
+    mockPost.mockResolvedValueOnce({ data: { url: 'https://auth.example/authorize-y' } });
+
+    const result = await resolveGitHubConnectUrl('user_123', 'https://example.com/member-hub?connected=github');
+
+    expect(result).toEqual({ status: 'authorize', url: 'https://auth.example/authorize-y' });
+  });
+
+  it('treats WorkOS 400 "User has already installed this integration" as already_connected (TOCTOU)', async () => {
+    mockGetAccessToken.mockResolvedValueOnce({ active: false, error: 'not_installed' });
+    const err = Object.assign(new Error('Bad Request'), {
+      status: 400,
+      rawData: { message: 'User has already installed this integration', error: 'Bad Request' },
+    });
+    mockPost.mockRejectedValueOnce(err);
+
+    const result = await resolveGitHubConnectUrl('user_123', 'https://example.com/member-hub?connected=github');
+
+    expect(result).toEqual({
+      status: 'already_connected',
+      url: 'https://example.com/member-hub?connected=github',
+    });
+  });
+
+  it('rethrows non-recoverable WorkOS errors', async () => {
+    mockGetAccessToken.mockResolvedValueOnce({ active: false, error: 'not_installed' });
+    mockPost.mockRejectedValueOnce(Object.assign(new Error('Service Unavailable'), { status: 503 }));
+
+    await expect(
+      resolveGitHubConnectUrl('user_123', 'https://example.com/member-hub?connected=github'),
+    ).rejects.toThrow('Service Unavailable');
+  });
+
+  it('rethrows 400s with a different message rather than swallowing them', async () => {
+    mockGetAccessToken.mockResolvedValueOnce({ active: false, error: 'not_installed' });
+    const err = Object.assign(new Error('Bad Request'), {
+      status: 400,
+      rawData: { message: 'Invalid return_to', error: 'Bad Request' },
+    });
+    mockPost.mockRejectedValueOnce(err);
+
+    await expect(
+      resolveGitHubConnectUrl('user_123', 'https://example.com/member-hub?connected=github'),
+    ).rejects.toThrow('Bad Request');
+  });
+});


### PR DESCRIPTION
## Summary

- `GET /connect/github` and `POST /api/me/connected-accounts/github/authorize` now precheck the user's WorkOS Pipes token state before calling authorize. Already-connected users get sent straight to `returnTo` instead of bouncing through a 502 driven by WorkOS' `400 "User has already installed this integration"` response.
- New `resolveGitHubConnectUrl` helper in `pipes.ts` also catches the same 400 if it slips through, covering the TOCTOU window between the token check and the authorize POST.
- Unblocks the alert that's been hitting `#admin-errors` from the diagnostic-only logging on this branch — root cause confirmed as already-connected users clicking the Slack-shared bouncer link.

## Notes

- POST endpoint response gains `already_connected: boolean` alongside `url`. `hub.html` only reads `url` and navigates, so the page reloads on `?connected=github` and the existing query handler refreshes the Connections card. No client change needed; the new field is available if we want to differentiate UI in the future.
- `getGitHubAuthorizeUrl` is unchanged — other callers aren't surprised.

## Test plan

- [x] `vitest run tests/unit/connect-github-bouncer.test.ts tests/unit/pipes-resolve-connect-url.test.ts tests/unit/pipes-connected-account.test.ts` (29 passed)
- [x] `vitest run tests/unit/slack-integration.test.ts tests/unit/member-context.test.ts` (83 passed — no GitHub-link surface regressions)
- [x] `npx tsc --noEmit` clean
- [x] Precommit suite (unit + dynamic imports + callapi-state-change + typecheck) green
- [ ] Post-deploy: alert volume in `#admin-errors` for `Pipes authorize request failed` drops to zero from already-connected user flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)