### PR TITLE
fix(compliance): finish $generate:uuid_v4 sweep across error/gov/signal/schema storyboards (cherry-pick #4231)

### DIFF
--- a/.changeset/4344-storyboard-uuid-idempotency-keys-sweep-3-0-x.md
+++ b/.changeset/4344-storyboard-uuid-idempotency-keys-sweep-3-0-x.md
@@ -1,0 +1,10 @@
+---
+"adcontextprotocol": patch
+---
+
+Convert the 12 remaining static `idempotency_key` literals across error, governance,
+signal, schema-validation, and creative-ad-server storyboard scenarios to
+`$generate:uuid_v4#<alias>` form. Closes the static-key sweep for the 3.0.x line so
+storyboard re-runs against any spec-compliant seller no longer collide with the
+seller's idempotency cache after deploys. 3.0.x port of #4231; closes #4344 on the
+patch line.

--- a/static/compliance/source/protocols/governance/index.yaml
+++ b/static/compliance/source/protocols/governance/index.yaml
@@ -247,7 +247,7 @@ phases:
           - human_review_required: set when the plan mandates escalation
 
         sample_request:
-          idempotency_key: "media-buy-governance-escalation-sync-plans-v1"
+          idempotency_key: "$generate:uuid_v4#gov-escalation-sync"
           plans:
             - plan_id: "gov_acme_q2_2027"
               brand:

--- a/static/compliance/source/specialisms/creative-ad-server/index.yaml
+++ b/static/compliance/source/specialisms/creative-ad-server/index.yaml
@@ -355,7 +355,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+          idempotency_key: "$generate:uuid_v4#creative-ad-server-report-usage"
           reporting_period:
             start: "2026-03-01T00:00:00Z"
             end: "2026-03-31T23:59:59Z"

--- a/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
+++ b/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
@@ -164,7 +164,7 @@ phases:
           - budget.reallocation_threshold: amount above which reallocation requires re-evaluation
 
         sample_request:
-          idempotency_key: "governance-delivery-monitor-sync-plans-v1"
+          idempotency_key: "$generate:uuid_v4#gov-delivery-monitor-sync"
           plans:
             - plan_id: "gov_acme_delivery_monitor"
               brand:

--- a/static/compliance/source/specialisms/governance-spend-authority/denied.yaml
+++ b/static/compliance/source/specialisms/governance-spend-authority/denied.yaml
@@ -110,7 +110,7 @@ phases:
           - budget.total: $10K cap that any single buy above will exceed
 
         sample_request:
-          idempotency_key: "governance-spend-authority-denied-sync-plans-v1"
+          idempotency_key: "$generate:uuid_v4#gov-spend-authority-denied-sync"
           plans:
             - plan_id: "gov_acme_strict"
               brand:

--- a/static/compliance/source/specialisms/governance-spend-authority/index.yaml
+++ b/static/compliance/source/specialisms/governance-spend-authority/index.yaml
@@ -159,7 +159,7 @@ phases:
           - custom_policies: policy conditions registered
 
         sample_request:
-          idempotency_key: "governance-spend-authority-sync-plans-v1"
+          idempotency_key: "$generate:uuid_v4#gov-spend-authority-sync"
           plans:
             - plan_id: "gov_acme_spend_authority_q2_2027"
               brand:

--- a/static/compliance/source/specialisms/signal-marketplace/scenarios/governance_denied.yaml
+++ b/static/compliance/source/specialisms/signal-marketplace/scenarios/governance_denied.yaml
@@ -184,7 +184,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "signal-gov-denied-v1"
+          idempotency_key: "$generate:uuid_v4#signal-gov-denied"
 
           context:
             correlation_id: "signal_marketplace--governance_denied--activate"

--- a/static/compliance/source/universal/error-compliance.yaml
+++ b/static/compliance/source/universal/error-compliance.yaml
@@ -117,7 +117,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "error-test-negative-budget"
+          idempotency_key: "$generate:uuid_v4#error-negative-budget"
           start_time: "2026-05-01T00:00:00Z"
           end_time: "2026-05-31T23:59:59Z"
           packages:
@@ -165,7 +165,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "error-test-nonexistent-product"
+          idempotency_key: "$generate:uuid_v4#error-nonexistent-product"
           start_time: "2026-05-01T00:00:00Z"
           end_time: "2026-05-31T23:59:59Z"
           packages:
@@ -252,7 +252,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "error-test-reversed-dates"
+          idempotency_key: "$generate:uuid_v4#error-reversed-dates"
           start_time: "2026-12-31T00:00:00Z"
           end_time: "2026-01-01T00:00:00Z"
           packages:
@@ -308,7 +308,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "error-structure-test"
+          idempotency_key: "$generate:uuid_v4#error-structure"
           start_time: "2026-12-31T00:00:00Z"
           end_time: "2026-01-01T00:00:00Z"
           packages:
@@ -452,7 +452,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "error-transport-test"
+          idempotency_key: "$generate:uuid_v4#error-transport"
           start_time: "2026-12-31T00:00:00Z"
           end_time: "2026-01-01T00:00:00Z"
           packages:

--- a/static/compliance/source/universal/schema-validation.yaml
+++ b/static/compliance/source/universal/schema-validation.yaml
@@ -333,7 +333,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "schema-validation-reversed-dates-v1"
+          idempotency_key: "$generate:uuid_v4#schema-validation-reversed-dates"
           start_time: "2026-12-31T00:00:00Z"
           end_time: "2026-01-01T00:00:00Z"
           packages:


### PR DESCRIPTION
## Summary

Cherry-pick of #4231 onto 3.0.x. Converts the 12 remaining static \`idempotency_key\` literals that exist on this branch to \`\$generate:uuid_v4#<alias>\` form. Closes #4344 on the patch line.

## Scope vs. main

\`error-compliance-signals.yaml\` is a 3.1-era addition and does not exist on 3.0.x — the 4 keys converted there on main are not applicable here. Remaining 12 keys span:

- \`universal/error-compliance.yaml\` (5)
- \`universal/schema-validation.yaml\` (1)
- \`specialisms/governance-spend-authority/{index,denied}.yaml\` (2)
- \`specialisms/governance-delivery-monitor/index.yaml\` (1)
- \`specialisms/signal-marketplace/scenarios/governance_denied.yaml\` (1)
- \`specialisms/creative-ad-server/index.yaml\` (1, includes the literal \`a1b2c3d4\` UUID)
- \`protocols/governance/index.yaml\` (1)

After this commit, zero static idempotency_keys remain under \`static/compliance/source/\` on 3.0.x.

Forward-merge workflow will sync back to main.

## Test plan

- [x] \`grep -rn 'idempotency_key: \"[^\$]' static/compliance/source\` returns zero results
- [x] Pre-commit unit suite passes locally
- [ ] CI green on 3.0.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)