### PR TITLE
fix(member-profile): hoist parsed + wire real photo upload (escalations #330, #331)

### DIFF
--- a/.changeset/fix-member-profile-photo.md
+++ b/.changeset/fix-member-profile-photo.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix `/member-profile` regressions reported by Evgeny Popov (escalations #330, #331). #330: `updatePhotoPreview()` declared `parsed` as block-scoped `const` inside a try, then used it after — hoisted to `let` above the try. #331: `handleLogoUpload` produced data URLs that the brand-identity endpoint rejected (>2000 char cap + image-fetch validation), and `saveProfile` never sent `photo_url` to any endpoint. Upload now multipart-POSTs to `/api/brands/:domain/logos` for a real hosted URL, and `saveProfile` syncs the result to brand-identity on save. HTML-only; no behavior change to published packages.

--- a/server/public/member-profile.html
+++ b/server/public/member-profile.html
@@ -2642,14 +2642,15 @@
       }
 
       if (photoUrl) {
+        let parsed;
         try {
-          const parsed = new URL(photoUrl);
-          if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
-            setPreviewMessage('Only http/https URLs allowed', 'var(--color-error-500)', '11px');
-            return;
-          }
+          parsed = new URL(photoUrl);
         } catch {
           setPreviewMessage('Invalid URL', 'var(--color-error-500)', '11px');
+          return;
+        }
+        if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+          setPreviewMessage('Only http/https URLs allowed', 'var(--color-error-500)', '11px');
           return;
         }
         const img = document.createElement('img');
@@ -2688,40 +2689,76 @@
       const file = input.files[0];
       if (!file) return;
 
-      // Check file size (max 2MB)
+      const previewEl = document.getElementById('photo-preview');
+      const setPreviewMsg = (msg, color) => {
+        if (!previewEl) return;
+        previewEl.textContent = msg;
+        previewEl.style.color = color || '';
+        previewEl.style.fontSize = '11px';
+      };
+
       if (file.size > 2 * 1024 * 1024) {
-        alert('File too large. Maximum size is 2MB.');
+        setPreviewMsg('File too large (max 2MB)', 'var(--color-error-500)');
         input.value = '';
         return;
       }
 
-      // Check file type
       if (!file.type.startsWith('image/')) {
-        alert('Please select an image file.');
+        setPreviewMsg('Please select an image file', 'var(--color-error-500)');
         input.value = '';
         return;
       }
 
-      // Update filename display
-      const filenameEl = document.getElementById(filenameId);
-      filenameEl.textContent = file.name;
-      filenameEl.classList.add('has-file');
+      const brandDomain = currentProfile?.primary_brand_domain;
+      if (!brandDomain) {
+        setPreviewMsg('Set your brand domain first, then upload', 'var(--color-error-500)');
+        input.value = '';
+        return;
+      }
 
-      // Show clear button
-      const clearBtn = document.getElementById(targetFieldId.replace('_url', '_clear'));
-      if (clearBtn) clearBtn.style.display = 'block';
+      setPreviewMsg('Uploading…', 'var(--color-text-muted)');
 
-      // Convert to data URL
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        document.getElementById(targetFieldId).value = e.target.result;
+      try {
+        const fd = new FormData();
+        fd.append('file', file);
+        fd.append('tags', 'primary');
+        const resp = await fetch(`/api/brands/${encodeURIComponent(brandDomain)}/logos`, {
+          method: 'POST',
+          body: fd,
+          credentials: 'include',
+        });
+
+        if (!resp.ok) {
+          let msg = `Upload failed (${resp.status})`;
+          try {
+            const errData = await resp.json();
+            if (errData?.error) msg = errData.error;
+          } catch { /* non-JSON response */ }
+          setPreviewMsg(msg, 'var(--color-error-500)');
+          input.value = '';
+          return;
+        }
+
+        const data = await resp.json();
+        const hostedUrl = new URL(data.url, window.location.origin).href;
+
+        document.getElementById(targetFieldId).value = hostedUrl;
+
+        const filenameEl = document.getElementById(filenameId);
+        filenameEl.textContent = file.name;
+        filenameEl.classList.add('has-file');
+
+        const clearBtn = document.getElementById(targetFieldId.replace('_url', '_clear'));
+        if (clearBtn) clearBtn.style.display = 'block';
+
         updatePhotoPreview();
         updateMemberCardPreview();
-      };
-      reader.readAsDataURL(file);
-
-      // Clear file input for potential re-upload
-      input.value = '';
+      } catch (err) {
+        console.error('Photo upload failed', err);
+        setPreviewMsg('Upload failed — check connection', 'var(--color-error-500)');
+      } finally {
+        input.value = '';
+      }
     }
 
     function clearLogo(fieldId, filenameId) {
@@ -2818,6 +2855,13 @@
         formData.slug = document.getElementById('slug').value;
       }
 
+      // Photo URL is persisted via the brand-identity endpoint (logo_url on the
+      // brand row), not the profile PUT. Capture the desired and current values
+      // here so we can fire a follow-up update after the main save succeeds.
+      const desiredPhotoUrl = (document.getElementById('photo_url')?.value || '').trim();
+      const originalPhotoUrl = currentProfile?.resolved_brand?.logo_url || '';
+      const photoChanged = desiredPhotoUrl !== originalPhotoUrl;
+
       try {
         const method = isNewProfile ? 'POST' : 'PUT';
         const response = await fetch(buildApiUrl('/api/me/member-profile'), {
@@ -2847,6 +2891,39 @@
         const wasNewProfile = isNewProfile;
         isNewProfile = false;
 
+        // If the photo changed, persist it as the primary brand logo. The main
+        // profile PUT doesn't accept logo_url; brand-identity does. Surface
+        // failure as a warning rather than blocking the success path.
+        let photoSyncWarning = null;
+        if (!wasNewProfile && photoChanged) {
+          try {
+            const photoResp = await fetch(buildApiUrl('/api/me/member-profile/brand-identity'), {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ logo_url: desiredPhotoUrl || null }),
+              credentials: 'include',
+            });
+            if (photoResp.ok) {
+              const photoData = await photoResp.json();
+              currentResolvedBrand = photoData.brand || null;
+              if (currentProfile) {
+                currentProfile.resolved_brand = photoData.brand;
+                currentProfile.primary_brand_domain = photoData.brand_domain;
+              }
+            } else {
+              let errMsg = `Photo could not be saved (${photoResp.status})`;
+              try {
+                const errData = await photoResp.json();
+                if (errData?.message) errMsg = `Photo not saved: ${errData.message}`;
+              } catch { /* non-JSON */ }
+              photoSyncWarning = errMsg;
+            }
+          } catch (err) {
+            console.error('Photo sync failed', err);
+            photoSyncWarning = 'Photo not saved — connection error.';
+          }
+        }
+
         // Server may have coerced visibility settings the caller isn't
         // eligible for (e.g. public → members_only on a non-API-access
         // tier). Surface those warnings so the user knows we didn't
@@ -2870,11 +2947,14 @@
           const detail = agents.length
             ? ` Affected agents: ${agents.join(', ')}.`
             : '';
+          const photoSuffix = photoSyncWarning ? ` ${photoSyncWarning}` : '';
           showError(
             `Saved, but ${downgrades.length} agent${downgrades.length > 1 ? 's' : ''} could not be listed publicly — ` +
             `public listing requires Professional tier or higher, so they were stored as members_only instead.${detail} ` +
-            `Upgrade at /membership to publish publicly.`
+            `Upgrade at /membership to publish publicly.${photoSuffix}`
           );
+        } else if (photoSyncWarning) {
+          showError(`Profile saved, but ${photoSyncWarning}`);
         } else {
           showSuccess('Profile saved successfully!');
         }


### PR DESCRIPTION
## Summary
Fixes two regressions on `/member-profile` reported by Evgeny Popov in escalations #330 and #331.

**#330 — \"parsed is not defined\" page break.** `updatePhotoPreview()` declared `const parsed = new URL(photoUrl)` inside a `try` block but used `parsed.href` outside it. `const` is block-scoped, so any successful URL parse threw `ReferenceError`. Since `populateForm()` calls `updatePhotoPreview()` on every page load, members with a populated `logo_url` saw the page break entirely. Fix: hoist `let parsed;` above the try.

**#331 — photo upload silently reverts on save.** Two compounding bugs:
1. `handleLogoUpload` converted the file to a base64 `data:` URL and wrote it into `#photo_url`. The brand-identity endpoint rejects logo URLs >2000 chars and HTTP-fetches them to verify image content, so data URLs were never persistable.
2. `saveProfile` builds its formData from ~15 fields but never includes `photo_url` — so even a real URL would not be saved through the profile PUT.

Fix: rewrite `handleLogoUpload` to multipart-POST the file to `POST /api/brands/:domain/logos` (the existing real upload endpoint, used elsewhere in the registry) and drop the returned hosted URL into `#photo_url`. Extend `saveProfile` to detect `photo_url !== currentProfile.resolved_brand.logo_url` and fire `PUT /api/me/member-profile/brand-identity` after the main save. Surface upload and persistence failures inline rather than reverting silently.

Pre-flights:
- Requires `currentProfile.primary_brand_domain` (the upload endpoint is brand-scoped). New profiles without a domain see \"Set your brand domain first, then upload.\"
- Existing 2MB client cap and image-MIME check kept; server enforces 5MB and magic-byte validation independently.

## Test plan
- [ ] On a profile with an existing `logo_url`, load `/member-profile` — page renders without console error.
- [ ] Upload a PNG via the profile photo control → preview updates with hosted URL → click Save Profile → reload → photo persists.
- [ ] Upload an oversized file (>2MB) → inline error, no silent revert.
- [ ] Upload from a profile with no `primary_brand_domain` → inline \"Set your brand domain first\" error.
- [ ] Server returns 4xx on upload (e.g., banned, dup) → error surfaced inline with backend message.

Closes escalation #330, escalation #331 (in-app escalations, not GitHub issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)