### PR TITLE
feat(observability): worker-unreachable watchdog (escalation #329)

### DIFF
--- a/.changeset/worker-watchdog.md
+++ b/.changeset/worker-watchdog.md
@@ -1,0 +1,4 @@
+---
+---
+
+Web-side watchdog that polls `/internal/jobs` on the worker every 60s and emits `logger.error` after 3 consecutive failures (so #admin-errors gets paged via the existing posthog auto-route). Closes the silent-death gap behind escalation #329 — the worker crashlooped for 6 days while every scheduled job (compliance heartbeat, escalation triage, weekly digest, announcement handlers, …) silently stopped firing and nothing alerted. Recovery transitions log at info so flapping doesn't spam.

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -9065,6 +9065,11 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
       logger.info('Worker process: scheduled jobs and crawlers started');
     } else {
       logger.info('Web process: skipping scheduled jobs and crawlers');
+      // Watchdog so silent worker death (firecracker-stage crashloop, OOM,
+      // failed deploy) reaches #admin-errors instead of being noticed days
+      // later via a user escalation. See escalation #329, May 2026.
+      const { startWorkerWatchdog } = await import('./services/worker-watchdog.js');
+      startWorkerWatchdog();
     }
 
     this.server = this.app.listen(port, () => {

--- a/server/src/services/worker-watchdog.ts
+++ b/server/src/services/worker-watchdog.ts
@@ -1,0 +1,97 @@
+/**
+ * Worker reachability watchdog.
+ *
+ * Runs on web machines. Polls `http://worker.process.<app>.internal:8080/internal/jobs`
+ * on a fixed cadence and emits `logger.error` once consecutive failures cross a
+ * threshold — `logger.error` auto-routes to #admin-errors via posthog (see
+ * `posthog.ts`), so the alert reaches Slack without any extra wiring.
+ *
+ * Fire-once semantics: alert when the failure streak crosses the threshold, and
+ * again on recovery (info level). Without these guards a flapping worker would
+ * spam the channel every tick.
+ */
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('worker-watchdog');
+
+const TICK_MS = 60_000;
+const FAILURE_THRESHOLD = 3;
+const FETCH_TIMEOUT_MS = 5_000;
+
+let intervalId: NodeJS.Timeout | null = null;
+let consecutiveFailures = 0;
+let alerted = false;
+
+async function probeWorker(): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const appName = process.env.FLY_APP_NAME;
+  if (!appName) {
+    return { ok: false, reason: 'FLY_APP_NAME not set' };
+  }
+  const url = `http://worker.process.${appName}.internal:8080/internal/jobs`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    if (!res.ok) {
+      return { ok: false, reason: `HTTP ${res.status}` };
+    }
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function tick(): Promise<void> {
+  const result = await probeWorker();
+  if (result.ok) {
+    if (alerted) {
+      logger.info({ priorFailures: consecutiveFailures }, 'Worker reachable again');
+    }
+    consecutiveFailures = 0;
+    alerted = false;
+    return;
+  }
+
+  consecutiveFailures++;
+  if (consecutiveFailures === FAILURE_THRESHOLD && !alerted) {
+    alerted = true;
+    logger.error(
+      { consecutiveFailures, reason: result.reason },
+      `Worker unreachable for ${FAILURE_THRESHOLD} consecutive checks (${FAILURE_THRESHOLD * TICK_MS / 1000}s) — scheduled jobs are not running`,
+    );
+  }
+}
+
+export function startWorkerWatchdog(): void {
+  if (intervalId !== null) return;
+  if (!process.env.FLY_APP_NAME) {
+    logger.info('FLY_APP_NAME not set — watchdog disabled (local dev)');
+    return;
+  }
+  intervalId = setInterval(() => {
+    void tick();
+  }, TICK_MS);
+  intervalId.unref();
+  logger.info({ tickMs: TICK_MS, failureThreshold: FAILURE_THRESHOLD }, 'Worker watchdog started');
+}
+
+export function stopWorkerWatchdog(): void {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+  consecutiveFailures = 0;
+  alerted = false;
+}
+
+export const _internals = {
+  tick,
+  probeWorker,
+  getState: () => ({ consecutiveFailures, alerted }),
+  reset: () => {
+    consecutiveFailures = 0;
+    alerted = false;
+  },
+};

--- a/server/tests/unit/worker-watchdog.test.ts
+++ b/server/tests/unit/worker-watchdog.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { _internals } from '../../src/services/worker-watchdog.js';
+import { logger } from '../../src/logger.js';
+
+describe('worker-watchdog', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let infoSpy: ReturnType<typeof vi.spyOn>;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    _internals.reset();
+    process.env.FLY_APP_NAME = 'adcp-docs';
+    errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => logger);
+    infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    delete process.env.FLY_APP_NAME;
+    vi.restoreAllMocks();
+  });
+
+  it('does not alert on a single failure', async () => {
+    fetchSpy.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    await _internals.tick();
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(_internals.getState()).toEqual({ consecutiveFailures: 1, alerted: false });
+  });
+
+  it('alerts exactly once after the third consecutive failure', async () => {
+    fetchSpy.mockRejectedValue(new Error('timeout'));
+    await _internals.tick();
+    await _internals.tick();
+    await _internals.tick();
+    expect(errorSpy).toHaveBeenCalledOnce();
+    // Subsequent failures don't re-alert
+    await _internals.tick();
+    await _internals.tick();
+    expect(errorSpy).toHaveBeenCalledOnce();
+    expect(_internals.getState().alerted).toBe(true);
+  });
+
+  it('logs recovery after a prior alert', async () => {
+    fetchSpy.mockRejectedValue(new Error('boom'));
+    await _internals.tick();
+    await _internals.tick();
+    await _internals.tick(); // alerts
+    expect(errorSpy).toHaveBeenCalledOnce();
+
+    fetchSpy.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+    await _internals.tick();
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ priorFailures: 3 }),
+      'Worker reachable again',
+    );
+    expect(_internals.getState()).toEqual({ consecutiveFailures: 0, alerted: false });
+  });
+
+  it('treats non-2xx as a failure', async () => {
+    fetchSpy.mockResolvedValue(new Response('upstream error', { status: 502 }));
+    await _internals.tick();
+    await _internals.tick();
+    await _internals.tick();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'HTTP 502' }),
+      expect.any(String),
+    );
+  });
+
+  it('resets streak on transient success', async () => {
+    fetchSpy.mockRejectedValueOnce(new Error('first'));
+    fetchSpy.mockRejectedValueOnce(new Error('second'));
+    fetchSpy.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+    fetchSpy.mockRejectedValueOnce(new Error('third'));
+    await _internals.tick();
+    await _internals.tick();
+    await _internals.tick(); // success
+    await _internals.tick(); // failure after success → streak = 1
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(_internals.getState()).toEqual({ consecutiveFailures: 1, alerted: false });
+  });
+});


### PR DESCRIPTION
## Summary
Web-side watchdog that polls `/internal/jobs` on the worker every 60s and emits `logger.error` after 3 consecutive failures. `logger.error` auto-routes to #admin-errors via the existing posthog notifier, so the alert reaches Slack without any extra wiring.

## Why
Escalation #329 surfaced that the worker had crashlooped for **6 days** (machine created 2026-05-04, recovered 2026-05-10). Every scheduled job — compliance heartbeat, escalation triage, weekly digest, announcement handlers, conversation insights, knowledge staleness, ~40 others — silently stopped firing. The only user-visible signal was Evgeny's stale "comply re-runner" status; the response from `/api/admin/jobs` already carried `workerUnreachable: true` but **nothing was polling it**.

## Design
- 60s tick, 3-failure threshold → minimum 3-minute outage before paging. Avoids transient blip spam.
- Fire-once: re-alerts only after recovery. Without this a flapping worker pages every tick.
- Recovery transition logs at info level with the prior failure count.
- Same `worker.process.<app>.internal:8080` lookup the existing `/api/admin/jobs` proxy uses (`http.ts:2256`), so the alert reflects the exact reachability that the admin UI does.

## Tests
5 vitest cases:
- single failure does not alert
- threshold-crossing alerts exactly once and stays silent after
- recovery from alerted state logs at info
- non-2xx HTTP counts as failure
- transient success in the middle of a streak resets

```
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

## Follow-up (separate PR)
The actual root cause of the 6-day crashloop — `app.listen()` racing the training-agent tenant warmup, killing the worker via health-check timeout during the 30-60s warmup window — is being addressed by re-landing PR #4062 (the boot gate that was reverted on May 4). Tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)