### PR TITLE
chore(deps): bump @adcp/sdk to ^6.19.0; drop vector-028 skipVectors workaround

### DIFF
--- a/.changeset/sdk-6.19-drop-vector-028-skip.md
+++ b/.changeset/sdk-6.19-drop-vector-028-skip.md
@@ -1,0 +1,20 @@
+---
+"adcontextprotocol": patch
+---
+
+chore(deps): bump `@adcp/sdk` to ^6.19.0; drop vector-028 skipVectors workaround
+
+`@adcp/sdk@6.18.0` added the adversarial builder for conformance vector `028-unsigned-protocol-method-required` ([adcp-client#1644](https://github.com/adcontextprotocol/adcp-client/pull/1644)), which the test-agent's storyboard matrix had been skipping via `skipVectors` since vector 028 landed in [adcp#4335](https://github.com/adcontextprotocol/adcp/pull/4335). `6.19.0` ships the proposal-mode enricher fix ([adcp-client#1649](https://github.com/adcontextprotocol/adcp-client/pull/1649)) that PR #1603's over-application surfaced — required for the storyboard matrix to stay green at SDK 6.18+.
+
+Vector 028 grades the `protocol_methods_required_for` namespace introduced in [adcp#4326](https://github.com/adcontextprotocol/adcp/pull/4326) — an unsigned `tasks/cancel` JSON-RPC POST against a verifier declaring `protocol_methods_required_for: ["tasks/cancel"]` MUST 401 with `request_signature_required`. The test-agent's strict route already enforces this; this PR closes the loop by removing the local skip so the runner actually exercises the vector.
+
+Matrix lift (+1 step per tenant from vector 028 grading):
+
+| Tenant            | Before | After |
+|-------------------|--------|-------|
+| /signals          | 58     | 59    |
+| /sales            | 258    | 260   |
+| /governance       | 102    | 103   |
+| /creative         | 118    | 119   |
+| /creative-builder | 100    | 101   |
+| /brand            | 45     | 46    |

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.0.3",
       "dependencies": {
-        "@adcp/sdk": "^6.13.0",
+        "@adcp/sdk": "^6.19.0",
         "@anthropic-ai/sdk": "^0.91.1",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-6.13.0.tgz",
-      "integrity": "sha512-tI20xINPCjRXnW5U6kVygfYRrn3OfxZcP3vpC2JOtIEdfXZvohjFt/woEtfbpbpG3OnnSytUsl0pp/I1R8JgTA==",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-6.19.0.tgz",
+      "integrity": "sha512-ASp1xEEiuSeCILCJHmVr8EUjNBEyqT76m2Qyc2e4Zus5DxJrruELkEO2FeGWwi0K/1UKSXUr5IJ7fYsrBY9Gmg==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "dev:docs": "node scripts/dev-docs.mjs"
   },
   "dependencies": {
-    "@adcp/sdk": "^6.13.0",
+    "@adcp/sdk": "^6.19.0",
     "@anthropic-ai/sdk": "^0.91.1",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -396,11 +396,6 @@ async function main() {
             '007-missing-content-digest',
             '018-digest-covered-when-forbidden',
             '025-jwk-alg-crv-mismatch',
-            // Vector 028 grades `protocol_methods_required_for` (introduced
-            // in adcp#4326). The SDK runner does not yet ship an adversarial
-            // builder for it — un-skip once `@adcp/sdk` adds the builder.
-            // Tracked under the runner-implementation umbrella adcp#2331.
-            '028-unsigned-protocol-method-required',
           ],
           skipRateAbuse: true,
         },


### PR DESCRIPTION
## Summary

Closes the loop on the vector-028 / proposal-mode chain. `@adcp/sdk@6.19.0` now ships both pieces the test-agent needs:

- **6.18.0** ([adcp-client#1644](https://github.com/adcontextprotocol/adcp-client/pull/1644)): adversarial builder for conformance vector `028-unsigned-protocol-method-required` (the unsigned `tasks/cancel` JSON-RPC POST that grades `protocol_methods_required_for`, introduced in [adcp#4326](https://github.com/adcontextprotocol/adcp/pull/4326)).
- **6.19.0** ([adcp-client#1649](https://github.com/adcontextprotocol/adcp-client/pull/1649)): proposal-mode enricher fix — fixture's explicit `packages` wins over auto-captured `context.proposal_id`, so storyboards that intentionally exercise package-mode don't get forced through proposal-lifecycle validation.

This PR:
1. Bumps `@adcp/sdk` to `^6.19.0`.
2. Drops the `028-unsigned-protocol-method-required` line from `server/tests/manual/run-storyboards.ts::skipVectors` so the runner actually exercises vector 028.

## Test plan

- [x] `bash scripts/run-storyboards-matrix.sh` — all 6 tenants meet floors. Per-tenant step counts lift by +1 (vector 028 grading):
  | Tenant            | Before | After |
  |-------------------|--------|-------|
  | /signals          | 58     | 59    |
  | /sales            | 258    | 260   |
  | /governance       | 102    | 103   |
  | /creative         | 118    | 119   |
  | /creative-builder | 100    | 101   |
  | /brand            | 45     | 46    |
- [x] `tsc --project server/tsconfig.json --noEmit` (clean, ran via pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)