### PR TITLE
docs(creative): add inline delivery metrics field table to get_creative_delivery

### DIFF
--- a/.changeset/docs-get-creative-delivery-metrics-table.md
+++ b/.changeset/docs-get-creative-delivery-metrics-table.md
@@ -1,0 +1,12 @@
+---
+---
+
+docs(creative): add inline Delivery Metrics field table to get_creative_delivery
+
+Adds a curated "Delivery Metrics fields" sub-section to the `get_creative_delivery`
+task reference, covering the commonly-used fields available on both `creative.totals`
+and each `variant` entry. Includes explicit callouts that spend-derived metrics
+(`roas`, `cost_per_acquisition`) appear at `totals` only (not inside `by_event_type`)
+and that engagement fields are platform-conditional. Links to the full
+`delivery-metrics` schema for the complete field list. Updates the Variant Object
+"Standard metrics" row to cross-reference the new section. Closes #4362.

--- a/docs/creative/task-reference/get_creative_delivery.mdx
+++ b/docs/creative/task-reference/get_creative_delivery.mdx
@@ -46,9 +46,50 @@ At least one scoping filter (`media_buy_ids` or `creative_ids`) is required.
 | `creative_id` | Creative identifier |
 | `media_buy_id` | Seller's media buy identifier (present when the request spanned multiple media buys) |
 | `format_id` | Format of this creative |
-| `totals` | Aggregate delivery metrics across all variants |
+| `totals` | Aggregate delivery metrics across all variants — see [Delivery metrics fields](#delivery-metrics-fields) below |
 | `variant_count` | Total number of variants (may exceed `variants` array length when `max_variants` is used) |
 | `variants` | Array of variant-level delivery data (empty if creative has no variants yet) |
+
+### Delivery metrics fields
+
+Fields available on both `creative.totals` and each `variant` entry. Commonly-used subset — see the [delivery-metrics schema](https://adcontextprotocol.org/schemas/v3/core/delivery-metrics.json) for the full list including incrementality, brand lift, and broadcast metrics.
+
+| Field | Description |
+|-------|-------------|
+| `impressions` | Impressions delivered |
+| `spend` | Amount spent (in `currency`) |
+| `clicks` | Total clicks |
+| `ctr` | Click-through rate (clicks/impressions) |
+| `cpm` | Cost per thousand impressions ((spend/impressions) × 1000) |
+| `cost_per_click` | Cost per click (spend/clicks) |
+| `views` | Billable views — threshold varies by format and pricing model |
+| `completed_views` | Video/audio completions |
+| `completion_rate` | Completion rate (completed_views/impressions) |
+| `quartile_data` | Audio/video quartile completion data — object with `q1_views`, `q2_views`, `q3_views`, `q4_views` |
+| `reach` | Unique reach in units specified by `reach_unit` |
+| `reach_unit` | Unit of measurement for `reach`; required when `reach` is present |
+| `frequency` | Average frequency per `reach_unit` |
+| `grps` | Gross Rating Points delivered (for CPP) |
+| `conversions` | Total attributed conversions; equals the sum of `by_event_type[].count` when present |
+| `conversion_value` | Total monetary value of attributed conversions |
+| `roas` | Return on ad spend (conversion_value/spend) — see note below |
+| `cost_per_acquisition` | Cost per conversion (spend/conversions) — see note below |
+| `new_to_brand_rate` | Fraction of conversions from first-time brand buyers (0–1) |
+| `leads` | Leads generated (convenience alias for `by_event_type` where `event_type='lead'`) |
+| `by_event_type` | Conversions by event type — array of `{ event_type, count, value?, event_source_id? }` |
+| `by_action_source` | Conversions by action source (website, app, in_store) — array of `{ action_source, count, value?, event_source_id? }` |
+| `dooh_metrics` | DOOH-specific data — object with `loop_plays`, `screens_used`, `screen_time_seconds`, `sov_achieved`, `venue_breakdown` |
+| `viewability` | Viewability data — object with `measurable_impressions`, `viewable_impressions`, `viewable_rate`, `standard`, `vendor` |
+| `engagements` | Total ad engagements beyond viewing (platform-specific) |
+| `follows` | New followers or subscriptions attributed to delivery |
+| `saves` | Saves, bookmarks, or pins attributed to delivery |
+| `profile_visits` | In-platform page visits attributed to delivery |
+| `engagement_rate` | Platform-specific engagement rate (engagements/impressions) |
+| `vendor_metric_values` | Vendor-attested metrics (viewability, attention, etc.) — one entry per vendor and metric identifier |
+
+> **Spend-derived metrics.** Sellers should not populate `roas` and `cost_per_acquisition` on individual `variant` objects — spend cannot be attributed per-variant since it applies to the creative as a whole. These fields are meaningful only on `creative.totals`. `by_event_type` entries carry `count` and `value` per event type, but not spend-derived rates.
+
+> **Platform-conditional fields.** `dooh_metrics` is present only for DOOH campaigns. Engagement fields (`engagements`, `follows`, `saves`, `profile_visits`, `engagement_rate`) are platform-specific; not all sellers emit them on standardized fields — some use `variant.ext` for engagement data instead.
 
 ### Variant Object
 
@@ -60,7 +101,7 @@ Each variant represents a specific execution: a fixed creative (Tier 1), an asse
 | `manifest` | (Optional) The rendered creative manifest — the actual output that was served, not the input assets. Contains format_id and resolved assets. Not all platforms can provide manifests for every variant. |
 | `generation_context` | (Optional, Tier 3) Input signals that triggered generation — e.g., page topic, conversation theme, query category. Platforms provide summarized/anonymized signals, not raw user input. When content context is managed through AdCP content standards, includes an `artifact` reference linking to the specific content artifact. Supports `ext` for vendor-specific context structures. |
 | `ext` | (Optional) Platform-specific data. Social platforms use this for engagement metrics (upvotes, comments, shares) that vary by platform. |
-| Standard metrics | All delivery metrics (impressions, spend, clicks, ctr, etc.) |
+| Standard metrics | All [Delivery metrics fields](#delivery-metrics-fields) — same shape as `creative.totals` |
 
 Derived metrics like `ctr`, `completion_rate`, `roas`, and `cost_per_click` are platform-calculated and may not equal naive division of their component fields due to rounding, attribution windows, or filtered impressions.
 


### PR DESCRIPTION
Closes #4362

Adds a curated **Delivery metrics fields** sub-section between the Creative Object and Variant Object tables in the `get_creative_delivery` task reference. Readers no longer need to follow a `$ref` to the schema to discover what metrics are available on `creative.totals` and each `variant` entry.

**Changes:**
- Expands the `totals` row in the Creative Object table to link to the new sub-section
- New `### Delivery metrics fields` table covering the 26 most commonly-used fields (core, video/audio, conversions, reach/frequency, DOOH, viewability, engagement, vendor metrics) with a link to the full [delivery-metrics schema](https://adcontextprotocol.org/schemas/v3/core/delivery-metrics.json) for the complete list
- Explicit callout that `roas` and `cost_per_acquisition` should not be populated on individual `variant` objects (spend cannot be attributed per-variant), and that engagement fields are platform-conditional
- Updates the Variant Object `Standard metrics` row to cross-reference the new section

**Non-breaking justification:** MDX content only — no schema changes, no wire-format changes, no protocol changes. All documented fields verified against `static/schemas/source/core/delivery-metrics.json`. Changeset is `--empty` per playbook convention for docs-only changes.

**Pre-PR review:**
- code-reviewer: approved — no blockers; nits on `quartile_data` ("completion" wording), heading case, and `roas`/`cost_per_acquisition` note strength; all addressed
- docs-expert: approved — verified heading case (sentence case ✓), anchor slug matches Mintlify convention (`#delivery-metrics-fields` ✓), blockquote syntax ✓, all field names match schema ✓

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01JKme2jf9KYqAmMGhMpGosN

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKme2jf9KYqAmMGhMpGosN)_