### PR TITLE
fix(compliance): collapse key_reuse_conflict into replay_same_payload phase (3.0.x)

### DIFF
--- a/.changeset/idempotency-yaml-collapse-conflict-into-replay-phase.md
+++ b/.changeset/idempotency-yaml-collapse-conflict-into-replay-phase.md
@@ -1,0 +1,14 @@
+---
+"adcontextprotocol": patch
+---
+
+Collapse the `key_reuse_conflict` phase of `universal/idempotency.yaml` into
+`replay_same_payload` as a fourth step. The conflict step deliberately shares
+the `$generate:uuid_v4#replay_key` alias with the replay steps so the seller
+receives one cached entry that the conflict request probes with a different
+body. With adcp-client#1658's phase-boundary alias reset, the conflict step
+must live in the same phase as the replay steps — a separate phase mints a
+fresh UUID and the seller treats the request as new, defeating the
+IDEMPOTENCY_CONFLICT assertion. Companion to adcp-client#1657 / #1658; no
+behavior change for sellers, only restructures the storyboard so the runner
+fix is safe to land.

--- a/static/compliance/source/universal/idempotency.yaml
+++ b/static/compliance/source/universal/idempotency.yaml
@@ -211,12 +211,28 @@ phases:
             description: "Context correlation_id returned unchanged"
 
   - id: replay_same_payload
-    title: "Replay returns cached response"
+    title: "Replay returns cached response; key reuse with different payload conflicts"
     narrative: |
-      The canonical retry-safety case: a buyer's first request times out but actually
-      succeeded on the server. The buyer retries with the same idempotency_key and
-      the same payload. The seller MUST return the same response — same media_buy_id,
-      no new side effects.
+      Two halves of the same key-reuse contract, exercised against a single cached
+      entry on the seller:
+
+      1. Same key + same payload (the canonical retry-safety case): a buyer's first
+         request times out but actually succeeded on the server. The buyer retries
+         with the same idempotency_key and the same payload. The seller MUST return
+         the same response — same media_buy_id, no new side effects.
+
+      2. Same key + materially different payload (key reuse): the buyer reuses the
+         same idempotency_key with a different payload within the replay window. The
+         seller MUST reject with IDEMPOTENCY_CONFLICT. Silently applying the new
+         payload would break the at-most-once guarantee; silently returning the old
+         response would hide a real bug in the buyer's retry logic.
+
+      Both branches share a single `$generate:uuid_v4#replay_key` placeholder. They
+      live in the same phase so the alias resolves to one UUID across all four steps
+      — the seller sees one cached idempotency entry that the conflict step probes
+      with a different body. Splitting these into separate phases would reset the
+      alias cache at the phase boundary (adcp-client#1657) and mint a fresh UUID for
+      the conflict step, defeating the test.
 
     steps:
       - id: create_media_buy_initial
@@ -409,24 +425,21 @@ phases:
           duplicate_webhook_on_replay. Not_applicable when the runner does not
           host a webhook receiver.
 
-  - id: key_reuse_conflict
-    title: "Key reuse with different payload returns IDEMPOTENCY_CONFLICT"
-    narrative: |
-      When a buyer reuses an idempotency_key with a different payload within the
-      replay window, the seller MUST reject the second request with
-      IDEMPOTENCY_CONFLICT. Silently applying the new payload would break the
-      at-most-once guarantee; silently returning the old response would hide a
-      real bug in the buyer's retry logic.
-
-    steps:
       - id: create_media_buy_conflict
         title: "Same key, different payload returns IDEMPOTENCY_CONFLICT"
         narrative: |
-          Re-send create_media_buy with the same idempotency_key as the replay
-          phase but a materially different payload — a different end_time and
-          a different budget. The seller MUST reject this with IDEMPOTENCY_CONFLICT.
-          CONFLICT is accepted as a fallback for sellers that haven't adopted the
-          new error code yet.
+          Re-send create_media_buy with the same idempotency_key as the prior
+          replay steps but a materially different payload — a different end_time
+          and a different budget. The seller MUST reject this with
+          IDEMPOTENCY_CONFLICT. CONFLICT is accepted as a fallback for sellers
+          that haven't adopted the new error code yet.
+
+          This step shares the `$generate:uuid_v4#replay_key` alias with the
+          initial and replay steps above, so the runner injects the same UUID
+          on the wire. Lives in the same phase as those steps because the
+          runner's alias cache resets at phase boundaries (adcp-client#1657);
+          a separate phase would mint a fresh UUID and the seller would treat
+          the call as a new request rather than a conflicting key reuse.
         task: create_media_buy
         schema_ref: "media-buy/create-media-buy-request.json"
         response_schema_ref: "media-buy/create-media-buy-response.json"


### PR DESCRIPTION
## Summary

Companion to **adcp-client#1657** / **adcp-client#1658**.

#1658 fixes a runner bug where `\$generate:uuid_v4#alias` placeholders leaked across phase boundaries within a single pass. The fix resets the alias cache at every non-skipped phase entry.

`universal/idempotency.yaml` is the one storyboard in the corpus that **depends** on cross-phase alias sharing: `\#replay_key` is reused in the `key_reuse_conflict` phase to assert IDEMPOTENCY_CONFLICT against the cache entry the `replay_same_payload` phase populated. With #1658's reset, that phase boundary mints a fresh UUID — the seller sees a new request and returns 201 instead of IDEMPOTENCY_CONFLICT, masking the assertion.

This PR restructures the storyboard so the alias stays in a single phase:

| Phase | Before | After |
|---|---|---|
| `replay_same_payload` | 3 steps (initial, replay, no-dup-webhooks) | **4 steps** — adds `create_media_buy_conflict` |
| `key_reuse_conflict` | 1 step (`create_media_buy_conflict`) | **removed** |

The conflict step's task, schema refs, request body, validations, and reviewer_checks are unchanged — only its parent phase changes. Phase narrative is updated to cover both replay and conflict semantics, including a one-paragraph note on why both branches must share the same phase (so future authors don't try to re-split for organizational cleanliness).

## Why this lives in the same phase, not a sibling phase with explicit alias propagation

Three options on the table:

1. **Same-phase grouping** (this PR) — pure YAML restructure, no spec/runner change beyond #1658.
2. **Syntactic marker** — `\$generate:uuid_v4@scenario#replay_key` (or similar) for storyboard-scoped aliases. Requires runner + spec change; broadens the substitution grammar; one more thing for storyboard authors to learn.
3. **Capture-and-reinject via `\$context.<name>`** — would require the response to echo `idempotency_key` (it doesn't, per `protocol-envelope.json`), or a new \`from: request\` source on \`context_outputs\`. Bigger spec change.

Option 1 is the smallest landing surface for the 3.0.x patch line. Options 2/3 can be revisited in 3.1+ if a future storyboard legitimately needs cross-phase aliases.

## Compatibility

- **Compliance reports.** The \`key_reuse_conflict\` phase row goes away; the step result moves under \`replay_same_payload\`. Consumers that pin to \`(storyboard_id, step_id)\` are unaffected. Consumers that pin to \`(storyboard_id, phase_id)\` lose one row and gain a step under the renamed phase.
- **Step IDs.** \`create_media_buy_conflict\` keeps its step ID.
- **Validations.** Identical — same \`error_code\`, same \`field_present\`/\`field_value\` checks on \`context\`, same reviewer_checks.
- **Sellers.** No wire-level change. The seller receives the same four calls in the same order with the same key and the same bodies; the only difference is that they all arrive within one phase from the runner's perspective.
- **YAML schema validation.** Passes \`yaml.safe_load\`; phase count drops from 6 to 5; \`replay_same_payload.steps\` count increases from 3 to 4.

## Wire order

Steps fire sequentially:

1. \`create_media_buy_initial\` — fresh \`#replay_key\` UUID, body A → seller caches.
2. \`create_media_buy_replay\` — same key, body A → seller returns cached response, \`replayed: true\`.
3. \`no_duplicate_webhooks_on_replay\` — drains receiver for 30s, asserts ≤1 webhook fired.
4. \`create_media_buy_conflict\` — same key, body B (different end_time + budget) → seller MUST raise IDEMPOTENCY_CONFLICT.

Step 4's error response doesn't fire a webhook, so it doesn't interact with step 3's drain window.

## Forward-merge

Branch is 3.0.x. The forward-merge bot will replay to main once landed.

## Linked

- adcp-client#1657 — bug report (cross-phase alias leak).
- adcp-client#1658 — runner fix (phase-boundary alias reset). Blocked-on this storyboard restructure to avoid breaking \`universal/idempotency\`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)