### PR TITLE
fix(dashboard): drop unfiltered /api/storyboards fallback (closes #4254)

### DIFF
--- a/.changeset/fix-dashboard-applicable-storyboards-fallback.md
+++ b/.changeset/fix-dashboard-applicable-storyboards-fallback.md
@@ -1,0 +1,4 @@
+---
+---
+
+Drops the unfiltered `/api/storyboards` fallback on the dashboard's storyboard picker. When `/api/registry/agents/:url/applicable-storyboards` returned a generic error (capabilities probe failed for a reason other than the recognized OAuth / needs-auth / unknown-specialism shapes), the dashboard fell back to the unfiltered full storyboard catalog — so a signals-only agent showed pagination-creative-formats, get-media-buys-pagination-integrity, and the rest. Closes #4254. Now: error message stays, but no storyboards render until the agent's `get_adcp_capabilities` returns `supported_protocols` and `specialisms`. OAuth / needs-auth / unknown-specialism error paths are unchanged.

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -3022,35 +3022,20 @@
             return;
           }
 
+          // Capability probe failed for an unclassified reason. We deliberately
+          // do NOT fall back to the unfiltered storyboard catalog here: without
+          // the agent's declared protocols + specialisms, every storyboard we
+          // could show is misleading (the agent may not even implement most of
+          // them). Issue #4254 — signals-only agent was seeing pagination-
+          // creative-formats etc. because of that fallback.
           const reasonText = errBody.reason ? ' (' + errBody.reason + ')' : '';
           const msg = errBody.error || ('HTTP ' + res.status);
-          let html = '<div style="padding:var(--space-3);background:var(--color-error-50);border:1px solid var(--color-error-200);border-radius:var(--radius-md);color:var(--color-error-700);font-size:var(--text-sm);margin-bottom:var(--space-3);">';
+          let html = '<div style="padding:var(--space-3);background:var(--color-error-50);border:1px solid var(--color-error-200);border-radius:var(--radius-md);color:var(--color-error-700);font-size:var(--text-sm);">';
           html += '<strong>Could not probe agent capabilities.</strong> ' + escapeHtml(String(msg) + reasonText);
+          html += '<div style="margin-top:var(--space-2);font-size:var(--text-xs);color:var(--color-error-600);">';
+          html += 'Once <code>get_adcp_capabilities</code> responds with <code>supported_protocols</code> and <code>specialisms</code>, applicable storyboards will appear here.';
           html += '</div>';
-
-          try {
-            const fallback = await fetch('/api/storyboards', { credentials: 'include' });
-            if (fallback.ok) {
-              const fdata = await fallback.json();
-              if (fdata.storyboards && fdata.storyboards.length > 0) {
-                html += '<div style="font-size:var(--text-xs);color:var(--color-text-secondary);margin-bottom:var(--space-2);">Showing all available storyboards:</div>';
-                html += '<div class="storyboard-picker">';
-                for (const sb of fdata.storyboards) {
-                  html += '<div class="storyboard-picker-item" data-storyboard-id="' + escapeHtml(sb.id) + '" data-agent-url="' + escapeHtml(agentUrl) + '" data-card-id="' + escapeHtml(cardId) + '">';
-                  html += '<div>';
-                  html += '<div class="storyboard-picker-title">' + escapeHtml(sb.title) + '</div>';
-                  html += '<div class="storyboard-picker-summary">' + escapeHtml(sb.summary) + '</div>';
-                  html += '</div>';
-                  html += '<span style="font-size:var(--text-xs);color:var(--color-text-tertiary);">' + sb.step_count + ' steps</span>';
-                  html += '</div>';
-                }
-                html += '</div>';
-              }
-            }
-          } catch (fallbackErr) {
-            console.error('Storyboard fallback failed:', fallbackErr);
-          }
-
+          html += '</div>';
           panel.innerHTML = html;
         } catch (err) {
           console.error('Failed to load storyboards:', err);


### PR DESCRIPTION
## Summary
Closes #4254. The dashboard's storyboard picker was falling back to the unfiltered full catalog when `applicable-storyboards` returned a generic error, defeating the per-agent filter.

## The bug
The dashboard renders the storyboard picker by calling `/api/registry/agents/:url/applicable-storyboards`, which uses `resolveStoryboardsForCapabilities` to filter to (universal baseline + protocol baseline + declared specialisms). That endpoint works correctly.

But when it returned anything other than 2xx / OAuth-challenge / needs-auth / unknown-specialism (e.g. capabilities probe failed for a different reason), the dashboard fell back to `/api/storyboards` — the unfiltered, registry-wide catalog. So a signals-only agent rendered pagination-creative-formats, get-media-buys-pagination-integrity, collection-lists-pagination-integrity, and the rest. The issue report's "20+ storyboards including pagination-integrity (list_creatives)" is exactly this code path firing.

## Fix
Drop the fallback. Keep the error message; suffix it with the underlying contract pointer (`get_adcp_capabilities` must return `supported_protocols` and `specialisms` before applicable storyboards can be computed). OAuth, needs-auth, and unknown-specialism error paths unchanged — those still surface their respective actionable UIs (authorize button / connect form / specialism list).

## Test plan
- [ ] Owner dashboard on an agent whose capabilities probe succeeds → renders filtered applicable list (current behavior, unchanged)
- [ ] Owner dashboard on an agent that requires OAuth → renders Authorize button (unchanged)
- [ ] Owner dashboard on an agent that requires saved auth → renders connect form (unchanged)
- [ ] Owner dashboard on an agent that declared an unknown specialism → renders specialism error + known-specialisms list (unchanged)
- [ ] Owner dashboard on an agent whose capabilities probe failed for a generic reason → renders the error message **without** falling back to the full catalog

## Stack note
Part of Push A in the compliance reporting fidelity initiative (PR #4364 → this PR → docs-disambiguation PR → canonical-surface UI). Orthogonal to Emma's #4247 unification stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)