### PR TITLE
feat(dashboard): storyboard count as canonical compliance headline

### DIFF
--- a/.changeset/dashboard-storyboard-summary-headline.md
+++ b/.changeset/dashboard-storyboard-summary-headline.md
@@ -1,0 +1,4 @@
+---
+---
+
+Adds a "X / Y storyboards passing" headline element on the dashboard agent card, with a tooltip explaining that storyboard counts are the canonical compliance unit (each applicable specialism, protocol baseline, and universal check is one storyboard) and that the track pills below are the SDK's coarse roll-up. Resolves the Evgeny-shape disconnect surfaced by escalation #329: track summary showed "30/30 passing" (correctly, per the SDK's silent-track semantics) while the underlying storyboards were partial — the dashboard had no surface to communicate which number to trust. The track pills also gain a tooltip pointing readers at the Verification panel for the per-storyboard view. Follows from the adtech-product review feedback on PR #4364.

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -121,6 +121,29 @@
       margin-top: var(--space-2);
     }
 
+    .agent-storyboard-summary {
+      margin-top: var(--space-2);
+      display: inline-flex;
+      align-items: baseline;
+      gap: var(--space-1);
+      padding: var(--space-1) var(--space-2);
+      background: var(--color-bg-subtle);
+      border-radius: var(--radius-sm);
+      cursor: help;
+    }
+
+    .agent-storyboard-summary-count {
+      font-size: var(--text-sm);
+      font-weight: var(--font-semibold);
+      color: var(--color-text);
+      font-variant-numeric: tabular-nums;
+    }
+
+    .agent-storyboard-summary-label {
+      font-size: var(--text-xs);
+      color: var(--color-text-secondary);
+    }
+
     .agent-tracks {
       display: flex;
       gap: 3px;
@@ -1488,6 +1511,25 @@
           return '<button class="agent-track ' + cls + '" data-track="' + escapeHtml(track) + '" data-agent-url="' + escapeHtml(agent.url) + '">' + escapeHtml(track) + '</button>';
         }).join('');
 
+        // Storyboards passing is the canonical compliance metric: each
+        // applicable storyboard (universal + protocol + declared specialism)
+        // either passes or doesn't. The track pills above are the SDK's
+        // coarse roll-up (a track "passes" when its storyboards execute
+        // without warnings) — useful as a quick-glance summary but
+        // misleading in isolation: agents that pass 0/N storyboards
+        // can still show "silent" track status if the SDK had nothing
+        // to flag (the literal absence of negative observations is
+        // counted as a clean track). When both views exist, the
+        // storyboard count is the one to trust.
+        const sbPassing = Number.isFinite(cs.storyboards_passing) ? cs.storyboards_passing : null;
+        const sbTotal = Number.isFinite(cs.storyboards_total) ? cs.storyboards_total : null;
+        const storyboardSummary = (sbPassing !== null && sbTotal !== null && sbTotal > 0)
+          ? `<div class="agent-storyboard-summary" title="${escapeHtml(`${sbPassing} of ${sbTotal} applicable storyboards passing. Storyboards are the canonical conformance unit — every applicable specialism, protocol baseline, and universal check is one storyboard. Track pills below are the SDK's coarse summary; storyboard counts are the source of truth for AAO Verified (Spec).`)}">`
+            + `<span class="agent-storyboard-summary-count">${sbPassing} / ${sbTotal}</span>`
+            + `<span class="agent-storyboard-summary-label"> storyboards passing</span>`
+            + `</div>`
+          : '';
+
         const runs = history?.runs || [];
         const sparkline = runs.length > 0 ? '<div class="agent-sparkline">' +
           runs.slice().reverse().map(r => {
@@ -1533,7 +1575,8 @@
               </div>
             </div>
             ${cs.headline ? '<div class="agent-headline">' + escapeHtml(cs.headline) + '</div>' : ''}
-            ${clickableTrackPills ? '<div class="agent-tracks">' + clickableTrackPills + '</div>' : ''}
+            ${storyboardSummary}
+            ${clickableTrackPills ? '<div class="agent-tracks" title="SDK track summary — coarse roll-up of storyboard results into core / signals / media_buy / etc. For per-storyboard pass/fail (the canonical view), see the Verification panel below.">' + clickableTrackPills + '</div>' : ''}
             <div class="agent-track-detail" id="${cardId}-track-detail" style="display:none;"></div>
             ${sparkline}
             ${renderVerificationPanel(cs, agent.url, hasAuth)}


### PR DESCRIPTION
## Summary
Adds an "X / Y storyboards passing" headline element on the dashboard agent card, with a tooltip that names the canonical / debug relationship between storyboard counts and SDK track pills.

Push A item 4 of 4 in the compliance reporting fidelity initiative.

## Why
Escalation #329 surfaced a real product gap: track summary showed "2 silent" (correct per SDK silent-track semantics — no negative observations) while the agent's `signal_owned` specialism storyboard was 1/5 steps. The dashboard had no surface to communicate which number to trust. With #4364 making storyboard data flow correctly, this change closes the loop visually:

- **Storyboards passing (canonical)** — each applicable specialism, protocol baseline, and universal check is one storyboard, pass or fail. This is what AAO Verified (Spec) is gated on.
- **Track pills (SDK roll-up, debug context)** — coarse aggregation that can read as "passing" even when underlying storyboards are partial.

## What changed
- New `<div class="agent-storyboard-summary">` between the headline and track pills. Renders `X / Y storyboards passing` with a tooltip explaining the canonical-ness when `storyboards_total > 0`.
- Track pills container (`<div class="agent-tracks">`) gains a `title` attribute pointing readers at the Verification panel for the per-storyboard view.
- CSS for the new summary element.

## Test plan
- [ ] Agent with passing storyboards renders the count prominently
- [ ] Agent with 0 storyboards (no compliance run yet) renders nothing
- [ ] Tooltip on hover names the canonical vs debug relationship
- [ ] Track pills tooltip works
- [ ] No visual regression on the rest of the agent card

## Out of scope (potential follow-ups)
- Collapsing track pills into an "advanced" expandable for owners
- Public registry agent-detail page (different surface, different audience)
- Tooltip text variants for different audiences

🤖 Generated with [Claude Code](https://claude.com/claude-code)