### PR TITLE
feat(schema): add pending_provision to Account.status enum

### DIFF
--- a/.changeset/pending-provision-account-status.md
+++ b/.changeset/pending-provision-account-status.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add `pending_provision` to `Account.status` enum for sellers that auto-approve accounts but require downstream technical provisioning (advertiser ID assignment, ad-server adapter wiring, third-party billing setup). Extends the `setup` field description and operations matrix to cover the new state. Inline enum copies in `list-accounts-request.json` and `sync-accounts-response.json` updated in lockstep with the canonical `enums/account-status.json`.

--- a/docs/accounts/overview.mdx
+++ b/docs/accounts/overview.mdx
@@ -45,16 +45,15 @@ Accounts progress through a defined set of states. Terminal states (`rejected`, 
 
 ```
 sync_accounts ──▶ pending_approval ──▶ active
-                       │                  │
-                       │ (seller declines) ├── (credit limit / funds depleted)
-                       ▼                  │    ▼
-                   rejected (terminal)    │  payment_required
-                                          │    │ (buyer resolves billing)
-                                          │    ▼
-                                          │  active
-                                          │
-                                          ├── (seller suspends) ──▶ suspended
-                                          │                           │
+               │       │ (declines)       │
+               │       ▼                 ├── (credit limit / funds depleted)
+               │   rejected (terminal)   │    ▼
+               │                         │  payment_required
+               └──▶ pending_provision    │    │ (buyer resolves billing)
+                         │ ──────────────▶  active
+                         │ (declines)       │
+                         ▼                 ├── (seller suspends) ──▶ suspended
+                     rejected (terminal)   │                           │
                                           │    (seller reactivates) ◀─┤
                                           │                           │
                                           │                           └──▶ closed (terminal)
@@ -66,6 +65,8 @@ sync_accounts ──▶ pending_approval ──▶ active
 
 - `pending_approval` → `active`: seller approves after credit/contract/identity review
 - `pending_approval` → `rejected`: seller declines. Terminal — buyer must submit a new account request.
+- `pending_provision` → `active`: downstream provisioning completes (advertiser ID assigned, ad-server adapter wired). Sellers SHOULD notify via webhook if `push_notification_config` was provided.
+- `pending_provision` → `rejected`: provisioning fails terminally (e.g., advertiser category blocked by platform policy). Terminal — buyer must submit a new account request.
 - `active` → `payment_required`: automatic when credit limit is reached or funds are depleted
 - `payment_required` → `active`: when the buyer resolves the outstanding balance. Sellers MAY auto-transition or MAY require manual re-activation.
 - `active` → `suspended`: seller-initiated (policy violation, billing dispute, fraud review). Sellers MUST notify orchestrators via webhook.
@@ -78,19 +79,20 @@ sync_accounts ──▶ pending_approval ──▶ active
 
 Account status acts as a gate on which tasks are permitted. Read-only operations are always available; mutation operations are restricted based on status.
 
-| Task | `active` | `pending_approval` | `payment_required` | `suspended` | `rejected` / `closed` |
-|------|----------|-------------------|-------------------|------------|----------------------|
-| `list_accounts` | Yes | Yes | Yes | Yes | Yes |
-| `get_account_financials` | Yes | Yes | Yes | Yes | No |
-| `get_products` | Yes | No | Yes | No | No |
-| `create_media_buy` | Yes | No | No | No | No |
-| `update_media_buy` | Yes | No | Yes | No | No |
-| `get_media_buys` | Yes | No | Yes | Yes | No |
-| `sync_creatives` | Yes | No | Yes | No | No |
-| `sync_catalogs` | Yes | No | Yes | No | No |
-| `sync_event_sources` | Yes | No | Yes | No | No |
-| `report_usage` | Yes | No | Yes | Yes | No |
+| Task | `active` | `pending_approval` | `pending_provision` | `payment_required` | `suspended` | `rejected` / `closed` |
+|------|----------|-------------------|---------------------|-------------------|------------|----------------------|
+| `list_accounts` | Yes | Yes | Yes | Yes | Yes | Yes |
+| `get_account_financials` | Yes | Yes | Yes | Yes | Yes | No |
+| `get_products` | Yes | No | No | Yes | No | No |
+| `create_media_buy` | Yes | No | No | No | No | No |
+| `update_media_buy` | Yes | No | No | Yes | No | No |
+| `get_media_buys` | Yes | No | No | Yes | Yes | No |
+| `sync_creatives` | Yes | No | No | Yes | No | No |
+| `sync_catalogs` | Yes | No | No | Yes | No | No |
+| `sync_event_sources` | Yes | No | No | Yes | No | No |
+| `report_usage` | Yes | No | No | Yes | Yes | No |
 
+- `pending_approval` and `pending_provision` both block all mutations — the account is not yet ready for spend. Use `list_accounts` or webhook to monitor the transition to `active`.
 - `payment_required` blocks new spend (`create_media_buy`) but allows managing existing buys and resolving setup. Sellers SHOULD also reject `new_packages` within `update_media_buy` when the account is in `payment_required`, since adding packages is functionally equivalent to new spend.
 - `suspended` allows read-only access to existing data but blocks all mutations
 - Sellers MUST return `ACCOUNT_SUSPENDED` for blocked operations on suspended accounts and `ACCOUNT_PAYMENT_REQUIRED` for blocked operations on payment-required accounts
@@ -294,7 +296,7 @@ When an orchestrator references an account, the `brand.domain` identifies the ad
 
 This verification is grounded in publicly accessible DNS-hosted identity — not in what the buyer agent asserts, but in what the brand itself has declared.
 
-The `pending_approval` account state is where human review occurs: credit checks, legal agreements, and identity verification. Vendor agents that require these steps return a `setup.url` for the human to complete the process before the account becomes active.
+The `pending_approval` account state is where human review occurs: credit checks, legal agreements, and identity verification. Vendor agents that require these steps return a `setup.url` for the human to complete the process before the account becomes active. For machine-gate provisioning (`pending_provision`), no human action is needed — `setup.url` is omitted and the buyer awaits a webhook or polls `list_accounts`.
 
 ### Brand registry and the contribute-back pattern
 

--- a/docs/accounts/tasks/list_accounts.mdx
+++ b/docs/accounts/tasks/list_accounts.mdx
@@ -65,7 +65,7 @@ All parameters are optional. An empty request returns all accounts.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `status` | string | No | Filter by account status: `active`, `pending_approval`, `rejected`, `payment_required`, `suspended`, or `closed`. |
+| `status` | string | No | Filter by account status: `active`, `pending_approval`, `pending_provision`, `rejected`, `payment_required`, `suspended`, or `closed`. |
 | `sandbox` | boolean | No | When true, return only sandbox accounts. When false or omitted, return only production accounts. Primarily used with explicit accounts (`require_operator_auth: true`) where sandbox accounts are pre-existing test accounts on the platform. |
 | `pagination` | object | No | Pagination cursor for large account sets. |
 
@@ -85,19 +85,19 @@ All parameters are optional. An empty request returns all accounts.
 | `name` | Vendor agent's display name for the account |
 | `brand` | Brand reference object: `domain` (the [brand registry](/docs/brand-protocol/brand-json) house domain) and optional `brand_id` (sub-brand within the house) |
 | `operator` | Operator domain. Always present — when the brand operates directly, `operator` equals the brand's domain. |
-| `status` | Current account state: `active`, `pending_approval`, `rejected`, `payment_required`, `suspended`, or `closed` |
+| `status` | Current account state: `active`, `pending_approval`, `pending_provision`, `rejected`, `payment_required`, `suspended`, or `closed` |
 | `billing` | Billing model in effect: `operator` or `agent` |
 | `account_scope` | How the seller scoped this account: `operator`, `brand`, `operator_brand`, or `agent`. See [account scope](/docs/building/integration/accounts-and-agents#account-scope). |
 | `payment_terms` | Payment terms agreed for this account: `net_15`, `net_30`, `net_45`, `net_60`, `net_90`, or `prepay`. Binding for all invoices when the account is active. |
 | `governance_agents` | Governance agent endpoints registered on this account. Present when governance agents have been configured via [`sync_governance`](/docs/accounts/tasks/sync_governance). |
-| `setup` | Present when `status: "pending_approval"`. Contains `url` for completing setup and `message` explaining what's needed. |
+| `setup` | Present when `status: "pending_approval"` or `"pending_provision"`. For `pending_approval`: contains `url` (optional) for completing setup and `message` explaining what's needed. For `pending_provision`: contains `message` describing the provisioning step; `url` is omitted. |
 | `authorization` | Optional. The calling agent's scope grant for this account — `allowed_tasks`, `field_scopes`, `scope_name`, `read_only`. Applies to every vendor agent type (media-buy, signals, governance, creative, brand) — the Accounts Protocol surface is shared. Vendor agents that support scope introspection SHOULD populate this; media-buy sales agents claiming the `attestation_verifier` standard scope MUST populate it. Absence means the vendor agent does not advertise introspectable scope for this account; callers MUST NOT infer access from absence and fall back to error-driven discovery via the RBAC error codes. See [Caller authorization](/docs/accounts/overview#caller-authorization) for the full shape and semantics. |
 
 ## Common Scenarios
 
 ### Poll until account becomes active
 
-After `sync_accounts` returns `pending_approval`, poll until the account is ready:
+After `sync_accounts` returns `pending_approval` or `pending_provision`, poll until the account is ready:
 
 <CodeGroup>
 

--- a/docs/accounts/tasks/sync_accounts.mdx
+++ b/docs/accounts/tasks/sync_accounts.mdx
@@ -9,7 +9,7 @@ Sync advertiser accounts with a seller for one or more brand/operator pairs. The
 
 `sync_accounts` is used across all seller protocols: media buy agents, signals agents, governance agents, and creative agents. It declares the buyer's intent — the seller provisions or links accounts internally. For implicit accounts (`require_operator_auth: false`), use natural keys (`brand` + `operator`) on subsequent requests. For explicit accounts (`require_operator_auth: true`), discover seller-assigned account IDs via [`list_accounts`](/docs/accounts/tasks/list_accounts). For sandbox on implicit accounts, include `sandbox: true` in the account entry — the seller provisions a test account with no real spend. For explicit accounts, sandbox accounts are pre-existing test accounts discovered via [`list_accounts`](/docs/accounts/tasks/list_accounts).
 
-**Response Time**: ~1s. Account provisioning is synchronous; credit and legal review may require human action (indicated by `status: "pending_approval"` with a `setup.url`).
+**Response Time**: ~1s. Account provisioning is synchronous; credit and legal review may require human action (`status: "pending_approval"` with a `setup.url`); downstream technical provisioning returns `status: "pending_provision"` with no action needed — poll or await webhook.
 
 **Request Schema**: [`/schemas/v3/account/sync-accounts-request.json`](https://adcontextprotocol.org/schemas/v3/account/sync-accounts-request.json)
 **Response Schema**: [`/schemas/v3/account/sync-accounts-response.json`](https://adcontextprotocol.org/schemas/v3/account/sync-accounts-response.json)
@@ -48,6 +48,8 @@ for (const account of validated.accounts) {
   console.log(`${account.brand.domain}: ${account.status}`);
   if (account.status === "pending_approval" && account.setup?.url) {
     console.log(`  Complete setup at: ${account.setup.url}`);
+  } else if (account.status === "pending_provision") {
+    console.log(`  Provisioning in progress: ${account.setup?.message ?? "awaiting completion"}`);
   }
 }
 ```
@@ -72,8 +74,11 @@ async def main():
 
     for account in result.accounts:
         print(f"{account.brand['domain']}: {account.status}")
-        if account.status == 'pending_approval' and hasattr(account, 'setup') and account.setup:
-            print(f"  Complete setup at: {account.setup.url}")
+        if account.status == 'pending_approval' and hasattr(account, 'setup') and account.setup and account.setup.get('url'):
+            print(f"  Complete setup at: {account.setup['url']}")
+        elif account.status == 'pending_provision':
+            msg = account.setup.get('message', 'awaiting completion') if hasattr(account, 'setup') and account.setup else 'awaiting completion'
+            print(f"  Provisioning in progress: {msg}")
 
 asyncio.run(main())
 ```
@@ -87,7 +92,7 @@ asyncio.run(main())
 | `accounts` | array | Yes | Array of account entries to sync (see below). |
 | `delete_missing` | boolean | No | When true, accounts previously synced by this agent but not in this request are deactivated. Scoped to the authenticated agent. Default: `false`. |
 | `dry_run` | boolean | No | When true, preview what would change without applying. Default: `false`. |
-| `push_notification_config` | object | No | Webhook for async notifications when account status changes (e.g., `pending_approval` transitions to `active`). |
+| `push_notification_config` | object | No | Webhook for async notifications when account status changes (e.g., `pending_approval` or `pending_provision` transitions to `active`). |
 
 **Account entry fields:**
 
@@ -126,7 +131,7 @@ Returns an `accounts` array with per-account results. Individual accounts may be
 | `billing` | Billing model applied. Matches the requested value. |
 | `billing_entity` | Business entity details for the invoiced party, echoed from the request. Sellers may add fields the agent omitted (e.g., `registration_number` from a credit check) but must not return data from a different entity. Bank details are omitted (write-only). |
 | `account_scope` | How the seller scoped this account: `operator` (shared across brands for this operator), `brand` (shared across operators for this brand), `operator_brand` (dedicated to this operator+brand pair), or `agent` (the agent's default account). See [account scope](/docs/building/integration/accounts-and-agents#account-scope). |
-| `setup` | Present when `status: "pending_approval"`. Contains `url` for completing credit or legal setup, `message` explaining what's needed, and optional `expires_at`. |
+| `setup` | Present when `status: "pending_approval"` or `"pending_provision"`. For `pending_approval`: contains `url` for completing credit or legal setup, `message` explaining what's needed, and optional `expires_at`. For `pending_provision`: contains `message` describing the provisioning step in progress; `url` is omitted (no human action needed). |
 | `rate_card` | Seller-assigned rate card identifier (when applicable). |
 | `payment_terms` | Payment terms agreed for this account: `net_15`, `net_30`, `net_45`, `net_60`, `net_90`, or `prepay`. When the account is active, these are the binding terms for all invoices. |
 | `credit_limit` | Maximum outstanding balance as `{amount, currency}`. |
@@ -140,7 +145,8 @@ Returns an `accounts` array with per-account results. Individual accounts may be
 | Status | Meaning | Next step |
 |--------|---------|-----------|
 | `active` | Ready to use | Use [account reference](/docs/building/integration/accounts-and-agents#account-references) in protocol operations |
-| `pending_approval` | Seller reviewing | Human may need to visit `setup.url` to complete credit or legal process. Poll `list_accounts` for updates. |
+| `pending_approval` | Seller reviewing (credit, legal) — human gate | Human may need to visit `setup.url` to complete credit or legal process. Poll `list_accounts` or await webhook for updates. |
+| `pending_provision` | Seller accepted; downstream technical provisioning in progress — machine gate | No human action needed. Poll `list_accounts` or register `push_notification_config` to be notified when provisioning completes. |
 | `rejected` | Seller declined the request | Review rejection reason in `warnings`, adjust and retry, or contact seller |
 | `payment_required` | Credit limit reached or funds depleted | Add funds or increase credit limit. Route spend to other accounts. |
 | `suspended` | Was active, now paused | Contact seller to resolve |
@@ -148,7 +154,7 @@ Returns an `accounts` array with per-account results. Individual accounts may be
 
 ### Async notifications
 
-When `push_notification_config` is provided and the seller returns `pending_approval`, the seller sends a webhook notification when the account status changes (e.g., approved → `active`, declined → `rejected`).
+When `push_notification_config` is provided and the seller returns `pending_approval` or `pending_provision`, the seller sends a webhook notification when the account status changes (e.g., approved or provisioned → `active`, declined → `rejected`).
 
 The notification payload includes the `(brand, operator)` natural key so the buyer can correlate it to the original sync request. For explicit accounts (`require_operator_auth: true`), the notification also includes the seller-assigned `account_id` once provisioned.
 

--- a/docs/building/by-layer/L2/accounts-and-agents.mdx
+++ b/docs/building/by-layer/L2/accounts-and-agents.mdx
@@ -106,7 +106,7 @@ The operator already has an account on the platform — an ad account, a busines
    a. Obtain operator's credential (OAuth via `authorization_endpoint`, or API key out-of-band)
    b. Open a new session with the operator's credential
    c. Call `sync_accounts` to set up each brand for this operator
-3. Wait for account status `active` (poll `list_accounts` if `pending_approval`)
+3. Wait for account status `active` (poll `list_accounts` if `pending_approval` or `pending_provision`)
 4. Call `get_products` / `create_media_buy` with the operator's session and `account` reference
 
 **sync_accounts request:**
@@ -411,6 +411,7 @@ On individual media buys, an `invoice_recipient` can override the account defaul
 2. Seller provisions or links accounts for each, responds with status:
    - `active` — ready to use
    - `pending_approval` — seller reviewing (human may need to visit `setup.url`)
+   - `pending_provision` — seller accepted; technical provisioning in progress (no human action needed — poll or await webhook)
    - `rejected` — seller declined the request
 3. For subsequent requests, pass the account reference:
    - **Implicit accounts** (`require_operator_auth: false`): pass the natural key `{ "brand": { "domain": "acme-corp.com" }, "operator": "pinnacle-media.com" }`
@@ -432,7 +433,8 @@ See [sync_accounts task reference](/docs/accounts/tasks/sync_accounts) for the f
 | Status | Meaning | Next step |
 |--------|---------|-----------|
 | `active` | Ready to use | Place buys on this account |
-| `pending_approval` | Seller reviewing | Human may need to visit `setup.url`. Poll `list_accounts` for updates. |
+| `pending_approval` | Seller reviewing — human gate | Human may need to visit `setup.url`. Poll `list_accounts` or await webhook. |
+| `pending_provision` | Technical provisioning in progress — machine gate | No human action needed. Poll `list_accounts` or await webhook. |
 | `rejected` | Seller declined the request | Review rejection reason, adjust and re-sync, or contact seller |
 | `payment_required` | Credit limit reached | Add funds or route spend to other accounts |
 | `suspended` | Was active, now paused | Contact seller |

--- a/docs/building/by-layer/L3/comply-test-controller.mdx
+++ b/docs/building/by-layer/L3/comply-test-controller.mdx
@@ -123,7 +123,7 @@ Transitions an account to the specified status. The seller MUST enforce the [acc
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `account_id` | string | Yes | Account to transition |
-| `status` | `active` \| `pending_approval` \| `rejected` \| `payment_required` \| `suspended` \| `closed` | Yes | Target status |
+| `status` | `active` \| `pending_approval` \| `pending_provision` \| `rejected` \| `payment_required` \| `suspended` \| `closed` | Yes | Target status |
 
 **Example:**
 

--- a/static/schemas/source/account/list-accounts-request.json
+++ b/static/schemas/source/account/list-accounts-request.json
@@ -15,6 +15,7 @@
       "enum": [
         "active",
         "pending_approval",
+        "pending_provision",
         "rejected",
         "payment_required",
         "suspended",

--- a/static/schemas/source/account/sync-accounts-response.json
+++ b/static/schemas/source/account/sync-accounts-response.json
@@ -57,12 +57,13 @@
                 "enum": [
                   "active",
                   "pending_approval",
+                  "pending_provision",
                   "rejected",
                   "payment_required",
                   "suspended",
                   "closed"
                 ],
-                "description": "Account status. active: ready for use. pending_approval: seller reviewing (credit, legal). rejected: seller declined the account request. payment_required: credit limit reached or funds depleted. suspended: was active, now paused. closed: was active, now terminated."
+                "description": "Account status. active: ready for use. pending_approval: seller reviewing (credit, legal) — human gate. pending_provision: seller accepted but downstream technical provisioning in progress — machine gate; buyer should poll or await webhook. rejected: seller declined the account request. payment_required: credit limit reached or funds depleted. suspended: was active, now paused. closed: was active, now terminated."
               },
               "billing": {
                 "$ref": "/schemas/enums/billing-party.json",
@@ -77,12 +78,12 @@
               },
               "setup": {
                 "type": "object",
-                "description": "Setup information for pending accounts. Provides the agent (or human) with next steps to complete account activation.",
+                "description": "Present when status is 'pending_approval' or 'pending_provision'. For pending_approval: url (if present) points to a human-action page. For pending_provision: url SHOULD be omitted — no human action is needed; message describes the provisioning step in progress.",
                 "properties": {
                   "url": {
                     "type": "string",
                     "format": "uri",
-                    "description": "URL where the human can complete the required action (credit application, legal agreement, add funds)"
+                    "description": "URL where the human can complete the required action (credit application, legal agreement, add funds). Applicable to pending_approval only; SHOULD be omitted for pending_provision."
                   },
                   "message": {
                     "type": "string",

--- a/static/schemas/source/core/account.json
+++ b/static/schemas/source/core/account.json
@@ -69,12 +69,12 @@
     },
     "setup": {
       "type": "object",
-      "description": "Present when status is 'pending_approval'. Contains next steps for completing account activation.",
+      "description": "Present when status is 'pending_approval' or 'pending_provision'. For pending_approval: url (if present) points to a human-action page (credit application, legal agreement). For pending_provision: url SHOULD be omitted — no human action is needed; message describes the provisioning step in progress (e.g., 'Wiring advertiser ID in ad server — typically completes within 5 minutes').",
       "properties": {
         "url": {
           "type": "string",
           "format": "uri",
-          "description": "URL where the human can complete the required action (credit application, legal agreement, add funds)."
+          "description": "URL where the human can complete the required action (credit application, legal agreement, add funds). Applicable to pending_approval only; SHOULD be omitted for pending_provision."
         },
         "message": {
           "type": "string",

--- a/static/schemas/source/enums/account-status.json
+++ b/static/schemas/source/enums/account-status.json
@@ -7,6 +7,7 @@
   "enum": [
     "active",
     "pending_approval",
+    "pending_provision",
     "rejected",
     "payment_required",
     "suspended",
@@ -14,7 +15,8 @@
   ],
   "enumDescriptions": {
     "active": "Account is operational and can create media buys",
-    "pending_approval": "Seller is reviewing the account (credit, contracts)",
+    "pending_approval": "Seller is reviewing the account (credit, contracts) — human gate",
+    "pending_provision": "Seller has accepted the account but downstream technical provisioning (advertiser ID assignment, ad-server adapter wiring, third-party billing setup) is in progress — machine gate. Buyer should poll list_accounts or await an account-update webhook.",
     "rejected": "Seller declined the account request — terminal state",
     "payment_required": "Credit limit reached or funds depleted",
     "suspended": "Was active, now paused — operations gated",


### PR DESCRIPTION
Closes #4370

## Summary

Sellers that auto-approve accounts but require downstream technical provisioning (GAM advertiser ID assignment, ad-server adapter wiring, third-party billing setup) currently have no spec-honest state to report. They are forced to use `pending_approval` even when no human review is involved, making the wire lossy — operator agents cannot distinguish a human gate from a machine gate.

This PR adds `pending_provision` as a new `Account.status` value with semantics: "seller has accepted the account commercially but downstream provisioning is in progress." The `setup` field is extended to cover this state (with `url` SHOULD-omitted — no human action needed; `message` carries diagnostic context such as "Wiring advertiser ID in ad server — typically completes within 5 minutes"). Operations matrix in the docs mirrors `pending_approval`: reads permitted, all mutations blocked.

## Files changed

| File | Change |
|------|--------|
| `static/schemas/source/enums/account-status.json` | Canonical enum: add `pending_provision` |
| `static/schemas/source/account/list-accounts-request.json` | Inline enum copy: add `pending_provision` |
| `static/schemas/source/account/sync-accounts-response.json` | Inline enum copy + `setup` field description |
| `static/schemas/source/core/account.json` | `setup` field description extended |
| `docs/accounts/overview.mdx` | State machine, transition rules, operations matrix, counterparty verification |
| `docs/accounts/tasks/sync_accounts.mdx` | Response time note, code examples, setup/status tables, async notifications |
| `docs/accounts/tasks/list_accounts.mdx` | Status filter, response field table, setup description, poll scenario |
| `docs/building/by-layer/L2/accounts-and-agents.mdx` | Status bullet list and status table |
| `docs/building/by-layer/L3/comply-test-controller.mdx` | `force_account_status` parameter table |
| `.changeset/pending-provision-account-status.md` | `minor` bump for `adcontextprotocol` |

## Non-breaking justification

Adds a new enum value to a string enum on a stable response surface. Existing consumers that receive `pending_provision` but don't explicitly handle it will fall back to the standard poll-and-wait pattern (unknown status → wait for active), which is exactly the correct behavior. No existing valid instance is invalidated. Per the repo versioning policy (playbook): new enum values = `minor`, not `major`.

## Milestone

**3.1.0** — `minor` bump (new enum value on stable surface); targets `main`. Not patch-eligible on `3.0.x` per the stable-schemas rule: "new enum values" are explicitly excluded from patch eligibility.

## Pre-PR review

- **code-reviewer**: approved — all three enum-bearing files updated in lockstep; task reference docs updated with correct buyer-side branching for `pending_provision`; changeset typed `minor`. Nits: inline enum in `sync-accounts-response.json` vs `$ref` (pre-existing debt); no `if/then` schema enforcement of `url` SHOULD-omit (intentional — matches existing pattern). All blockers resolved.
- **ad-tech-protocol-expert**: approved — semantic distinction is protocol-level (not impl detail); enum lockstep across all three files confirmed; `setup` descriptions consistent across both schema files; webhook MUST symmetrized to SHOULD; `force_account_status` table in comply-test-controller.mdx updated; all five task/building-guide pages carry new state. `minor` bump correct.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01BrvV7mLzKdKiQpm1dPXeU5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrvV7mLzKdKiQpm1dPXeU5)_