### PR TITLE
spec(comply_test_controller): add account.sandbox gate (closes #3755)

### DIFF
--- a/.changeset/comply-test-controller-account-sandbox.md
+++ b/.changeset/comply-test-controller-account-sandbox.md
@@ -1,0 +1,4 @@
+---
+---
+
+Adds optional `account` object to `comply_test_controller` request schema with `sandbox: true` const constraint when present. Defense-in-depth on top of the per-request seller-side gate: a runner asserting `sandbox: false` schema-rejects before reaching the seller. Foundation of the (Sandbox) verification tier framing decided in #4379 — closes #3755 (soft-land path); the runner contract MUST set the field, and the follow-up sweep tightens to required once all storyboard sample_requests are updated.

--- a/static/schemas/source/compliance/comply-test-controller-request.json
+++ b/static/schemas/source/compliance/comply-test-controller-request.json
@@ -561,6 +561,21 @@
     },
     "ext": {
       "$ref": "/schemas/core/ext.json"
+    },
+    "account": {
+      "type": "object",
+      "description": "Sandbox account assertion. The runner SHOULD set sandbox: true on every comply_test_controller request; required in a future version. The seller MUST refuse the request (returning a structured error) if the targeted account is not a sandbox account in the seller's persisted records. This field is a caller-side declaration of intent — it does not grant sandbox status; sellers verify against their own account state. The (Sandbox) verification tier is defined by this gate: real production endpoints accept sandbox-flagged traffic and process it without real-world side effects, no separate test-mode endpoint required. See spec issue #3755 and the (Sandbox) framing in #4379. NOTE: optional in this version while existing storyboards add the field; the const: true constraint applies when present, so a request asserting sandbox: false schema-rejects regardless. A subsequent version bump will move this field into the required array; follow-up issue tracks the storyboard sweep that unblocks that.",
+      "required": [
+        "sandbox"
+      ],
+      "properties": {
+        "sandbox": {
+          "type": "boolean",
+          "const": true,
+          "description": "MUST be true. The seller MUST verify the targeted account is sandbox by looking up the persisted account record, not by trusting this field. A request asserting sandbox: false schema-rejects before reaching the seller — defense-in-depth on top of the per-request gate."
+        }
+      },
+      "additionalProperties": true
     }
   },
   "required": [


### PR DESCRIPTION
## Summary
Closes #3755. Adds optional \`account\` object to the \`comply_test_controller\` request schema with a required \`sandbox: true\` const constraint when present.

Foundation of the (Sandbox) verification tier decided in #4379.

## What this gate does
- **Schema layer**: a runner asserting \`account.sandbox: false\` schema-rejects before reaching the seller. The \`const: true\` is defense-in-depth on top of the seller-side gate that already exists in normative docs.
- **Runner contract**: SHOULD set \`account.sandbox: true\` on every request. Will be MUST in a follow-up version bump.
- **Seller contract**: unchanged — MUST verify the targeted account is sandbox by looking up the persisted account record, not by trusting this field.

## Soft-land path (option 2 from the issue body)
The schema makes \`account\` optional in this PR so existing storyboard sample_requests stay valid. The const constraint applies when present, so the wrong-value case (sandbox: false) is caught regardless. A follow-up sweep updates ~25 sample_request blocks across 8 storyboard YAMLs to add \`account: { sandbox: true }\` and then tightens to required.

This trades full normative enforcement now for shipping the gate today without breaking existing storyboards. Per the (Sandbox) verdict in #4379, this is the foundation of the higher verification tier — the soft-land path gets it in place; the sweep tightens the contract.

## Test plan
- [ ] Existing storyboard sample_requests (without \`account\`) still validate
- [ ] Sample_requests with \`account: { sandbox: true }\` validate
- [ ] Sample_requests with \`account: { sandbox: false }\` schema-reject (const constraint)
- [ ] Sample_requests with \`account: {}\` (missing sandbox) schema-reject (required: ["sandbox"])

## Cross-links
- #4379 — (Sandbox) framing verdict
- #4028 — keystone storyboard for live-mode account denial (next)
- #4226 → #4228 — UNKNOWN_SCENARIO grading (merged)
- Follow-up: sample_request sweep + tighten to required

🤖 Generated with [Claude Code](https://claude.com/claude-code)