### PR TITLE
fix(brands): FK + orphan trigger on brands.workos_organization_id

### DIFF
--- a/.changeset/4374-brands-org-fk.md
+++ b/.changeset/4374-brands-org-fk.md
@@ -1,0 +1,6 @@
+---
+---
+
+Reinstate the foreign key on `brands.workos_organization_id` (dropped during the migration-389 hosted_brands→brands merge) and close the three drift paths that produced it: (1) `network-consistency-reporter` joins `organizations` so it no longer tries to insert a report for a brand whose owner org has been deleted (was firing a noisy FK violation into `#admin-errors` every cycle); (2) migration 474 adds the FK with `ON DELETE SET NULL`, nulls existing dangles, and installs a BEFORE UPDATE trigger that mirrors `deleteHostedBrand`'s relinquish state whenever the owner pointer is cleared (`manifest_orphaned=TRUE`, `is_public=FALSE`, `domain_verified=FALSE`, `prior_owner_org_id`-stash) so an org-delete never leaves a publicly-visible verified-but-unowned brand row in the registry; (3) `mergeOrganizations` reparents the secondary org's brands to the primary inside the merge transaction so the FK's `SET NULL` doesn't strip ownership when the secondary row is deleted.
+
+Server-internal — no protocol surface changes. Follows the FK-less denormalized pointer drift playbook (PRs #4182/#4342/#4343 for the equivalent fix on `users.primary_organization_id`).

--- a/server/src/db/migrations/474_brands_workos_organization_id_fk.sql
+++ b/server/src/db/migrations/474_brands_workos_organization_id_fk.sql
@@ -1,0 +1,100 @@
+-- Add a foreign key on brands.workos_organization_id with ON DELETE SET NULL.
+--
+-- Why: this column is a denormalized owner pointer that several read sites
+-- and child tables trust (network_consistency_reports has a hard FK on
+-- organizations(workos_organization_id) and inserts org_id sourced from
+-- brands; member-db, federated-index, brand-property workflows all gate on
+-- the same pointer). Migration 200 declared the FK when the table was
+-- hosted_brands. Migration 389 merged hosted_brands into the wider brands
+-- (formerly discovered_brands) table and re-added workos_organization_id as
+-- a bare VARCHAR(255) — without the FK. From that point onward every
+-- DELETE FROM organizations left brand rows pointing at a row that no
+-- longer existed, and the network-consistency-reporter worker hit a noisy
+-- FK violation on every cycle for those orgs (May 2026: org_01KC7R3...).
+--
+-- The deliberate "relinquish" path (deleteHostedBrand in brand-db.ts) moves
+-- workos_organization_id → prior_owner_org_id explicitly before clearing,
+-- so we don't want ON DELETE CASCADE here — losing the brand row on org
+-- delete would be wrong. ON DELETE SET NULL matches the original migration
+-- 200 declaration and the existing hosted_brands_delete trigger semantics
+-- (which already clear the column to NULL when the legacy view path is
+-- used to "delete" a hosted brand).
+--
+-- Strategy: declare the constraint NOT VALID first so existing rows that
+-- already dangle don't block the migration; null those out with a single
+-- UPDATE; then VALIDATE so the constraint becomes enforceable for future
+-- inserts/updates as well.
+
+-- Step 1: declare the FK with ON DELETE SET NULL, but skip validation of
+-- existing rows. Cheap (no table scan, no exclusive lock) and lets us do
+-- the data fix in step 3 with the constraint already present so any
+-- concurrent INSERT during the migration is also constrained.
+ALTER TABLE brands
+  ADD CONSTRAINT brands_workos_organization_id_fkey
+  FOREIGN KEY (workos_organization_id)
+  REFERENCES organizations(workos_organization_id)
+  ON DELETE SET NULL
+  NOT VALID;
+
+-- Step 2: mirror the deliberate-relinquish orphan state on every path that
+-- nulls workos_organization_id, including the FK SET NULL cascade from
+-- step 1 and the dangle-cleanup UPDATE in step 3.
+--
+-- Why: deleteHostedBrand in brand-db.ts ("relinquish") sets
+-- workos_organization_id=NULL together with manifest_orphaned=TRUE,
+-- is_public=FALSE, domain_verified=FALSE, and stashes prior_owner_org_id —
+-- the brand goes off the public registry until a new owner claims it.
+-- The bare FK SET NULL cascade nulls only the pointer, which would leave
+-- the brand row in a "visible, verified, owner-less" state no other code
+-- path produces: still publicly listed in the registry as a verified
+-- brand with no current owner. Containment-wise we're still safe (the
+-- next claim requires a fresh WorkOS DNS challenge — see
+-- applyVerifiedBrandClaim), but the UX surface is wrong.
+--
+-- A BEFORE UPDATE trigger gated on "pointer cleared" mirrors the
+-- relinquish state on every path: the FK cascade, the legacy
+-- hosted_brands view delete trigger, the step-3 dangle UPDATE in this
+-- migration, and any direct UPDATE. The org-merge layer-3 reparent in
+-- mergeOrganizations updates the pointer to a new owner (non-NULL), so
+-- this trigger does not fire on that path.
+CREATE OR REPLACE FUNCTION brands_orphan_on_owner_cleared() RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.workos_organization_id IS NULL AND OLD.workos_organization_id IS NOT NULL THEN
+    NEW.prior_owner_org_id := OLD.workos_organization_id;
+    NEW.manifest_orphaned := TRUE;
+    NEW.is_public := FALSE;
+    NEW.domain_verified := FALSE;
+    NEW.verification_token := NULL;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS brands_orphan_on_owner_cleared_trigger ON brands;
+CREATE TRIGGER brands_orphan_on_owner_cleared_trigger
+  BEFORE UPDATE OF workos_organization_id ON brands
+  FOR EACH ROW
+  EXECUTE FUNCTION brands_orphan_on_owner_cleared();
+
+-- Step 3: clear any pointer that doesn't resolve to a current
+-- organizations row. The trigger from step 2 fires on each row, applying
+-- the orphan state alongside the NULL. These rows were already
+-- operationally unowned — every read path that gates on org existence
+-- either 404s or short-circuits them. Orphaning here matches what the FK
+-- cascade + trigger would have produced had they been in place when each
+-- parent was deleted.
+UPDATE brands
+   SET workos_organization_id = NULL,
+       updated_at = NOW()
+ WHERE workos_organization_id IS NOT NULL
+   AND NOT EXISTS (
+     SELECT 1 FROM organizations o
+     WHERE o.workos_organization_id = brands.workos_organization_id
+   );
+
+-- Step 4: VALIDATE the constraint now that no row violates it. From here
+-- on, any DELETE FROM organizations automatically nulls the brand pointer
+-- (no more dangling no_parent_row drift), and any INSERT/UPDATE into
+-- brands with a bogus workos_organization_id is rejected at the DB level.
+ALTER TABLE brands
+  VALIDATE CONSTRAINT brands_workos_organization_id_fkey;

--- a/server/src/db/org-merge-db.ts
+++ b/server/src/db/org-merge-db.ts
@@ -831,6 +831,29 @@ export async function mergeOrganizations(
     });
 
     // =====================================================
+    // 20f. Merge brands (ownership pointer)
+    // brands.workos_organization_id is FK→organizations ON DELETE SET NULL
+    // (migration 474). Without an explicit reparent, the secondary's brand
+    // rows would survive the DELETE FROM organizations at step 24 but get
+    // their owner pointer nulled, losing the brand entirely. UNIQUE is on
+    // `domain` alone, not (org, domain) — a domain can only ever belong
+    // to one org at a time — so a straight reparent UPDATE never conflicts.
+    // =====================================================
+    const brandsResult = await client.query(
+      `UPDATE brands
+       SET workos_organization_id = $1, updated_at = NOW()
+       WHERE workos_organization_id = $2
+       RETURNING id`,
+      [primaryOrgId, secondaryOrgId]
+    );
+
+    summary.tables_merged.push({
+      table_name: 'brands',
+      rows_moved: brandsResult.rows.length,
+      rows_skipped_duplicate: 0,
+    });
+
+    // =====================================================
     // 21. Merge prospect notes
     // =====================================================
     if (secondaryOrg.prospect_notes && secondaryOrg.prospect_notes.trim()) {

--- a/server/src/services/network-consistency-reporter.ts
+++ b/server/src/services/network-consistency-reporter.ts
@@ -251,12 +251,24 @@ export async function generateNetworkConsistencyReports(
   const limit = options?.limit ?? 50;
   const result: ReportResult = { generated: 0, skipped: 0, failed: 0, alerts_fired: 0 };
 
-  // Find orgs with hosted brands
+  // Find orgs with hosted brands. Join organizations so we don't try to
+  // generate a report for a brand whose org has been deleted (the
+  // network_consistency_reports.org_id FK would reject the insert and the
+  // worker would noisily log to #admin-errors every cycle). The structural
+  // fix is the FK added in migration 474 (ON DELETE SET NULL + orphan
+  // trigger), so once that migration is universally applied the JOIN
+  // becomes a no-op. Kept as defense-in-depth.
+  //
+  // The LIMIT applies post-join, so during the deploy window between this
+  // code shipping and migration 474 running, pre-existing dangles can crowd
+  // out valid orgs at the tail of the sort order. Acceptable: the missed
+  // orgs surface again on the next cycle once the migration nulls dangles.
   const orgsWithBrands = await query<{ workos_organization_id: string }>(
-    `SELECT DISTINCT workos_organization_id
-     FROM brands
-     WHERE workos_organization_id IS NOT NULL
-     ORDER BY workos_organization_id
+    `SELECT DISTINCT b.workos_organization_id
+     FROM brands b
+     JOIN organizations o ON o.workos_organization_id = b.workos_organization_id
+     WHERE b.workos_organization_id IS NOT NULL
+     ORDER BY b.workos_organization_id
      LIMIT $1`,
     [limit]
   );

--- a/server/tests/integration/org-merge-brands-repoint.test.ts
+++ b/server/tests/integration/org-merge-brands-repoint.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Integration test for the brands.workos_organization_id repoint added in
+ * mergeOrganizations.
+ *
+ * Without the repoint, the FK ON DELETE SET NULL on brands (migration 474)
+ * fires when the secondary org row is deleted at the end of the merge,
+ * leaving the secondary's brand rows owner-less. With the repoint inside
+ * the merge transaction, the brand rows land at the primary org first and
+ * the FK never fires for them.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { initializeDatabase, closeDatabase, getPool } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { mergeOrganizations } from '../../src/db/org-merge-db.js';
+import type { Pool } from 'pg';
+import type { WorkOS } from '@workos-inc/node';
+
+const PRIMARY_ORG = 'org_merge_brands_primary';
+const SECONDARY_ORG = 'org_merge_brands_secondary';
+const THIRD_ORG = 'org_merge_brands_third';
+const PRIMARY_DOMAIN = 'merge-brands-primary.test';
+const SECONDARY_DOMAIN_A = 'merge-brands-secondary-a.test';
+const SECONDARY_DOMAIN_B = 'merge-brands-secondary-b.test';
+const THIRD_DOMAIN = 'merge-brands-third.test';
+const ORPHAN_DOMAIN = 'merge-brands-orphan.test';
+const MERGED_BY = 'user_merge_brands_admin';
+
+const workosStub = {
+  organizations: {
+    deleteOrganization: async (_id: string) => {},
+  },
+} as unknown as WorkOS;
+
+describe('mergeOrganizations — brands.workos_organization_id repoint', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  }, 60000);
+
+  afterAll(async () => {
+    await cleanup();
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanup();
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, created_at, updated_at)
+       VALUES ($1, 'Primary', NOW(), NOW()),
+              ($2, 'Secondary', NOW(), NOW()),
+              ($3, 'Third', NOW(), NOW())`,
+      [PRIMARY_ORG, SECONDARY_ORG, THIRD_ORG],
+    );
+  });
+
+  async function cleanup() {
+    await pool.query(
+      `DELETE FROM brands WHERE domain IN ($1, $2, $3, $4, $5)`,
+      [PRIMARY_DOMAIN, SECONDARY_DOMAIN_A, SECONDARY_DOMAIN_B, THIRD_DOMAIN, ORPHAN_DOMAIN],
+    );
+    await pool.query(
+      `DELETE FROM organizations WHERE workos_organization_id IN ($1, $2, $3)`,
+      [PRIMARY_ORG, SECONDARY_ORG, THIRD_ORG],
+    );
+  }
+
+  async function seedBrand(domain: string, orgId: string | null) {
+    await pool.query(
+      `INSERT INTO brands (domain, workos_organization_id, source_type, is_public, created_at, updated_at)
+       VALUES ($1, $2, 'community', TRUE, NOW(), NOW())`,
+      [domain, orgId],
+    );
+  }
+
+  it('repoints brands owned by the secondary org to the primary org', async () => {
+    await seedBrand(SECONDARY_DOMAIN_A, SECONDARY_ORG);
+    await seedBrand(SECONDARY_DOMAIN_B, SECONDARY_ORG);
+
+    const summary = await mergeOrganizations(PRIMARY_ORG, SECONDARY_ORG, MERGED_BY, workosStub);
+
+    const after = await pool.query<{ workos_organization_id: string | null }>(
+      'SELECT workos_organization_id FROM brands WHERE domain = ANY($1) ORDER BY domain',
+      [[SECONDARY_DOMAIN_A, SECONDARY_DOMAIN_B]],
+    );
+    expect(after.rows).toHaveLength(2);
+    expect(after.rows[0]?.workos_organization_id).toBe(PRIMARY_ORG);
+    expect(after.rows[1]?.workos_organization_id).toBe(PRIMARY_ORG);
+
+    // Summary reports the repoint so admins running merges can audit it.
+    const brandsEntry = summary.tables_merged.find((t) => t.table_name === 'brands');
+    expect(brandsEntry).toBeDefined();
+    expect(brandsEntry!.rows_moved).toBe(2);
+  });
+
+  it('does not touch brands owned by the primary or a third org', async () => {
+    await seedBrand(PRIMARY_DOMAIN, PRIMARY_ORG);
+    await seedBrand(THIRD_DOMAIN, THIRD_ORG);
+
+    await mergeOrganizations(PRIMARY_ORG, SECONDARY_ORG, MERGED_BY, workosStub);
+
+    const after = await pool.query<{ domain: string; workos_organization_id: string | null }>(
+      'SELECT domain, workos_organization_id FROM brands WHERE domain = ANY($1) ORDER BY domain',
+      [[PRIMARY_DOMAIN, THIRD_DOMAIN]],
+    );
+    expect(after.rows.find((r) => r.domain === PRIMARY_DOMAIN)?.workos_organization_id).toBe(PRIMARY_ORG);
+    expect(after.rows.find((r) => r.domain === THIRD_DOMAIN)?.workos_organization_id).toBe(THIRD_ORG);
+  });
+
+  it('does not touch brands with null workos_organization_id', async () => {
+    await seedBrand(ORPHAN_DOMAIN, null);
+
+    await mergeOrganizations(PRIMARY_ORG, SECONDARY_ORG, MERGED_BY, workosStub);
+
+    const after = await pool.query<{ workos_organization_id: string | null }>(
+      'SELECT workos_organization_id FROM brands WHERE domain = $1',
+      [ORPHAN_DOMAIN],
+    );
+    expect(after.rows[0]?.workos_organization_id).toBeNull();
+  });
+
+  it('direct org delete (no merge) triggers FK SET NULL + orphan trigger', async () => {
+    // When an org is deleted without a merge to absorb its brands, the FK
+    // cascade nulls workos_organization_id and the BEFORE UPDATE trigger
+    // (migration 474) mirrors the relinquish state — manifest_orphaned,
+    // is_public=FALSE, domain_verified=FALSE, prior_owner_org_id stashed.
+    // Without the trigger, the brand row would remain publicly listed in
+    // the registry as a verified-but-unowned brand.
+    await pool.query(
+      `INSERT INTO brands (
+         domain, workos_organization_id, source_type, is_public,
+         domain_verified, manifest_orphaned, created_at, updated_at
+       ) VALUES ($1, $2, 'community', TRUE, TRUE, FALSE, NOW(), NOW())`,
+      [SECONDARY_DOMAIN_A, SECONDARY_ORG],
+    );
+
+    await pool.query(
+      'DELETE FROM organizations WHERE workos_organization_id = $1',
+      [SECONDARY_ORG],
+    );
+
+    const after = await pool.query<{
+      workos_organization_id: string | null;
+      prior_owner_org_id: string | null;
+      manifest_orphaned: boolean;
+      is_public: boolean;
+      domain_verified: boolean;
+    }>(
+      `SELECT workos_organization_id, prior_owner_org_id, manifest_orphaned,
+              is_public, domain_verified
+       FROM brands WHERE domain = $1`,
+      [SECONDARY_DOMAIN_A],
+    );
+    expect(after.rows[0]?.workos_organization_id).toBeNull();
+    expect(after.rows[0]?.prior_owner_org_id).toBe(SECONDARY_ORG);
+    expect(after.rows[0]?.manifest_orphaned).toBe(true);
+    expect(after.rows[0]?.is_public).toBe(false);
+    expect(after.rows[0]?.domain_verified).toBe(false);
+  });
+
+  it('repoint runs before the secondary org is deleted, so the FK SET NULL never fires for these rows', async () => {
+    // Without the repoint, the FK ON DELETE SET NULL would fire when the
+    // secondary org row is deleted at the end of the merge, leaving these
+    // brands owner-less. The repoint inside the merge transaction takes
+    // precedence — assert the column lands at primary, not NULL.
+    await seedBrand(SECONDARY_DOMAIN_A, SECONDARY_ORG);
+
+    await mergeOrganizations(PRIMARY_ORG, SECONDARY_ORG, MERGED_BY, workosStub);
+
+    const after = await pool.query<{ workos_organization_id: string | null }>(
+      'SELECT workos_organization_id FROM brands WHERE domain = $1',
+      [SECONDARY_DOMAIN_A],
+    );
+    // Specifically NOT null — the FK fired for any column that DIDN'T get
+    // repointed, but we explicitly UPDATE'd this one before the DELETE.
+    expect(after.rows[0]?.workos_organization_id).not.toBeNull();
+    expect(after.rows[0]?.workos_organization_id).toBe(PRIMARY_ORG);
+
+    // Confirm secondary org row was actually deleted (proves the FK
+    // would have fired had the repoint not run first).
+    const secondaryCheck = await pool.query<{ count: string }>(
+      'SELECT COUNT(*)::text AS count FROM organizations WHERE workos_organization_id = $1',
+      [SECONDARY_ORG],
+    );
+    expect(secondaryCheck.rows[0]?.count).toBe('0');
+  });
+});


### PR DESCRIPTION
## Summary

The `network-consistency-reporter` worker was hitting an FK violation on every cycle (visible as a recurring `#admin-errors` alert) because `brands.workos_organization_id` had no FK and could point at a row no longer in `organizations`. Migration 389 (hosted_brands → brands merge) dropped the FK that migration 200 originally declared, and nothing has been catching dangles since.

Three-layer fix per the established **FK-less denormalized pointer drift playbook** (mirrors PRs #4182 / #4342 / #4343 for `users.primary_organization_id`):

1. **Read self-heal** — `network-consistency-reporter` JOINs `organizations` so deleted-org brands skip the report instead of throwing. Stops the alert immediately, becomes a no-op once layer 2 is universally applied.
2. **DB constraint (migration 474)** — adds the FK with `ON DELETE SET NULL`, plus a `BEFORE UPDATE` trigger that mirrors `deleteHostedBrand`'s relinquish state (`manifest_orphaned=TRUE`, `is_public=FALSE`, `domain_verified=FALSE`, `prior_owner_org_id` stashed) whenever the owner pointer is cleared. Without the trigger, FK `SET NULL` would leave the brand row visible-and-verified-but-unowned in the public registry.
3. **Write-path audit (org-merge)** — `mergeOrganizations` reparents secondary's brands to primary inside the merge transaction so the FK's `SET NULL` doesn't strip ownership when the secondary org is deleted.

## Expert review applied
- `code-reviewer` — addressed: added changeset, clarified reporter LIMIT/migration-474 comment. Filed mentally as follow-up: `prior_owner_org_id` is the same FK-less drift class (TEXT column, no FK), but org-merge already leaves it consistent because we now reparent before delete. Audit-log capture of specific brand domains is a low-impact polish.
- `security-reviewer` — addressed the medium finding: the BEFORE UPDATE trigger ensures FK cascade doesn't leave brands publicly verified-but-unowned. No prompt-injection / TEE / credential surface.
- `nodejs-testing-expert` — coverage right as-is for the org-merge path; added one extra case for direct org-delete to exercise the FK cascade + trigger.

## Test plan

- [x] `npx tsc --noEmit` (clean)
- [x] `npx vitest run server/tests/integration/org-merge-brands-repoint.test.ts` — 5/5 pass (repoint, primary/third untouched, NULL untouched, direct-delete-triggers-orphan, FK-never-fires-on-merge-path)
- [x] Full org-merge suite (`org-merge-primary-org-repoint`, `org-merge-agent-contexts`, `merge-bind-not-delete`, `org-merge-brands-repoint`) — 20/20 pass
- [x] Brand suite spot-check (`brand-claim-apply-verified`, `brand-orphan-adoption`, `brand-domain-resolver`, `brand-claim-service`) — 40/40 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)