### PR TITLE
test(membership-tiers): pin is_owner semantics for verdict_source gate (#4378)

### DIFF
--- a/.changeset/verdict-source-is-owner-coverage.md
+++ b/.changeset/verdict-source-is-owner-coverage.md
@@ -1,0 +1,4 @@
+---
+---
+
+Partial completion of #4378: adds 6 explicit unit tests pinning the `is_owner` field semantics in `resolveOwnerMembership` — the load-bearing gate for `verdict_source` on the public compliance API. Covers anonymous, non-owner, orphan-profile (deleted org), and three distinct owner tiers (free Explorer, API-access, canceled-sub). Anchors the invariant that `is_owner` is broader than `is_api_access_tier` so free-tier owners still see the UX cue on their own dashboard. Full route-level integration test deferred to a follow-up — requires DB-fixture scaffolding not currently in place for this endpoint.

--- a/server/tests/unit/membership-tiers.test.ts
+++ b/server/tests/unit/membership-tiers.test.ts
@@ -188,5 +188,68 @@ describe('membership-tiers', () => {
       });
       expect(nonOwner).toEqual(orphanOwner);
     });
+
+    describe('is_owner field — load-bearing gate for verdict_source on the public API', () => {
+      // verdict_source on /api/registry/agents/:url/compliance is gated on
+      // ownerMembership.is_owner (not on is_api_access_tier — that would be
+      // too narrow and hide the UX cue from free-tier owners). These tests
+      // pin the is_owner semantics so a future refactor can't silently break
+      // the gate. Issue #4378.
+
+      it('is_owner is false for anonymous (no userId)', async () => {
+        const result = await resolveOwnerMembership(undefined, 'https://agent.example.com', {
+          resolveOwnerOrgId: async () => 'irrelevant',
+          fetchOrgMembership: async () => ({ membership_tier: 'company_standard', subscription_status: 'active' }),
+        });
+        expect(result.is_owner).toBe(false);
+      });
+
+      it('is_owner is false when the user is not a member of any owning org', async () => {
+        const result = await resolveOwnerMembership('user_123', 'https://agent.example.com', {
+          resolveOwnerOrgId: async () => null,
+          fetchOrgMembership: async () => ({ membership_tier: 'company_standard', subscription_status: 'active' }),
+        });
+        expect(result.is_owner).toBe(false);
+      });
+
+      it('is_owner is false when the resolved org has been deleted (orphan profile)', async () => {
+        const result = await resolveOwnerMembership('user_123', 'https://agent.example.com', {
+          resolveOwnerOrgId: async () => 'org_deleted',
+          fetchOrgMembership: async () => null,
+        });
+        expect(result.is_owner).toBe(false);
+      });
+
+      it('is_owner is true for an actual owner regardless of tier — Explorer (free)', async () => {
+        const result = await resolveOwnerMembership('user_123', 'https://agent.example.com', {
+          resolveOwnerOrgId: async () => 'org_abc',
+          fetchOrgMembership: async () => ({ membership_tier: 'explorer', subscription_status: 'active' }),
+        });
+        expect(result.is_owner).toBe(true);
+        // is_owner is broader than is_api_access_tier: free-tier owners
+        // still get verdict_source on their own dashboard view.
+        expect(result.is_api_access_tier).toBe(false);
+      });
+
+      it('is_owner is true for an actual owner — API-access tier with active sub', async () => {
+        const result = await resolveOwnerMembership('user_123', 'https://agent.example.com', {
+          resolveOwnerOrgId: async () => 'org_abc',
+          fetchOrgMembership: async () => ({ membership_tier: 'company_icl', subscription_status: 'active' }),
+        });
+        expect(result.is_owner).toBe(true);
+        expect(result.is_api_access_tier).toBe(true);
+      });
+
+      it('is_owner is true even when subscription is canceled (ownership ≠ entitlement)', async () => {
+        const result = await resolveOwnerMembership('user_123', 'https://agent.example.com', {
+          resolveOwnerOrgId: async () => 'org_abc',
+          fetchOrgMembership: async () => ({ membership_tier: 'company_standard', subscription_status: 'canceled' }),
+        });
+        expect(result.is_owner).toBe(true);
+        expect(result.is_api_access_tier).toBe(false);
+        // The canceled-sub owner still sees their own verdict_source on the
+        // dashboard — they just can't earn badges until they reactivate.
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
Partial completion of #4378. Adds 6 explicit unit tests pinning the \`is_owner\` field semantics in \`resolveOwnerMembership\` — the load-bearing gate for \`verdict_source\` exposure on the public compliance API.

## The matrix
| Caller | is_owner | Reasoning |
|---|---|---|
| Anonymous (no userId) | false | Never an owner |
| User not in any owning org | false | Membership query returns null |
| Orphan profile (org deleted) | false | Treated same as non-owner (no side-channel) |
| Owner on free Explorer tier | **true** | Broader than \`is_api_access_tier\` — free-tier owners still see the UX cue on their own dashboard |
| Owner on API-access tier, active sub | true | Standard owner case |
| Owner with canceled sub | true | Ownership ≠ entitlement (badges don't issue, but dashboard cue still works) |

## Why this anchors a real invariant
PR #4263's review caught that gating \`verdict_source\` on \`is_api_access_tier\` was too narrow — free-tier owners would see \`null\` on their own agent. These tests pin the correction so a future refactor can't silently regress to the narrower predicate.

## What's deferred
The original #4378 also called for a route-level integration test (\`request(app).get(...).expect(...)\` against the compliance endpoint). That needs DB-fixture scaffolding (agent_compliance_status row inserts, auth simulation) not currently in place for this endpoint. Filed as the follow-up — leaving #4378 open.

## Test plan
\`\`\`bash
npx vitest run tests/unit/membership-tiers.test.ts
# 27 passing (6 new)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)