### PR TITLE
feat(compliance): fire badge issuance on owner_test runs (closes #4376)

### DIFF
--- a/.changeset/4376-fire-badge-issuance-owner-test.md
+++ b/.changeset/4376-fire-badge-issuance-owner-test.md
@@ -1,0 +1,16 @@
+---
+"adcontextprotocol": patch
+---
+
+Server: fire badge issuance on owner-driven compliance runs.
+
+The per-version badge fan-out (membership-org resolution + `processAgentBadges` loop across `SUPPORTED_BADGE_VERSIONS`) is extracted into a shared `runBadgeFanOut()` helper in `services/badge-issuance.ts`, and the two owner-driven paths now call it immediately after `recordComplianceRun`:
+
+- `evaluate_agent_quality` (member-tools) — full comply runs from an agent owner.
+- `POST /api/registry/agents/:url/storyboard/:storyboardId/run` — single-storyboard re-runs from the dashboard.
+
+The helper reads the latest per-storyboard state from `agent_storyboard_status` (rather than trusting the run's own inputs), so a single-storyboard owner re-run doesn't degrade badges for storyboards it didn't touch.
+
+Owner-facing impact: an owner who fixes a compliance issue and re-runs sees the badge update on the next page load instead of waiting up to a heartbeat cycle. Heartbeat behavior is unchanged — it still emits the verification-change Slack notification; owner paths skip the notify because the result is already delivered in chat / HTTP response.
+
+Closes #4376.

--- a/server/src/addie/jobs/compliance-heartbeat.ts
+++ b/server/src/addie/jobs/compliance-heartbeat.ts
@@ -19,11 +19,8 @@ import { notifySystemError } from '../error-notifier.js';
 import { logger as baseLogger } from '../../logger.js';
 import { logOutboundRequest } from '../../db/outbound-log-db.js';
 import { AAO_UA_COMPLIANCE } from '../../config/user-agents.js';
-import { processAgentBadges } from '../../services/badge-issuance.js';
+import { runBadgeFanOut } from '../../services/badge-issuance.js';
 import { adaptAuthForSdk } from '../../services/sdk-auth-adapter.js';
-import { API_ACCESS_TIERS, ACTIVE_SUBSCRIPTION_STATUSES } from '../../services/membership-tiers.js';
-import { SUPPORTED_BADGE_VERSIONS } from '../../services/adcp-taxonomy.js';
-import { getStoryboardIdsForVersion } from '../../services/storyboards.js';
 
 const logger = baseLogger.child({ module: 'compliance-heartbeat' });
 const complianceDb = new ComplianceDatabase();
@@ -124,87 +121,25 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
       }
 
       // Process AAO Verified badges — fan out per supported AdCP version.
-      // One comply() run produced a flat storyboard_statuses list; for each
-      // version we filter to that version's applicable storyboards and run
-      // processAgentBadges with that version. Each version's badge issues
-      // and revokes independently — see #3524 stage 2.
+      // Issuance is shared with owner_test and single-storyboard run paths;
+      // heartbeat is the only caller that follows it up with a Slack
+      // notification, since owner-driven runs already have a chat response.
       const declaredSpecialisms = complianceResult.agent_profile?.specialisms ?? [];
 
       if (declaredSpecialisms.length > 0 && storyboardStatuses.length > 0) {
         try {
-          // Resolve membership org for this agent — only orgs with an active
-          // API-access tier qualify for badge issuance. If the org downgrades
-          // or cancels, processAgentBadges will see undefined here and revoke
-          // any existing badges (across every version).
-          const orgResult = await query(
-            `SELECT mp.workos_organization_id
-             FROM member_profiles mp
-             JOIN organizations o ON o.workos_organization_id = mp.workos_organization_id
-             WHERE mp.agents @> $1::jsonb
-               AND o.membership_tier = ANY($2::text[])
-               AND o.subscription_status = ANY($3::text[])
-             ORDER BY mp.created_at ASC
-             LIMIT 1`,
-            [
-              JSON.stringify([{ url: agent.agent_url }]),
-              [...API_ACCESS_TIERS],
-              [...ACTIVE_SUBSCRIPTION_STATUSES],
-            ],
-          );
-          const membershipOrgId = orgResult.rows[0]?.workos_organization_id;
+          const badgeResult = await runBadgeFanOut({
+            complianceDb,
+            agentUrl: agent.agent_url,
+            declaredSpecialisms,
+          });
 
-          const aggregatedIssued: Array<{ role: string; specialisms: string[]; adcp_version: string }> = [];
-          const aggregatedRevoked: Array<{ role: string; reason: string; adcp_version: string }> = [];
-
-          for (const adcpVersion of SUPPORTED_BADGE_VERSIONS) {
-            // Per-version try/catch: a failure on 3.1 must not poison the
-            // notification for an already-completed 3.0 issuance, and a
-            // persistent per-version failure must surface via system-error
-            // alerts rather than disappear into a non-fatal warn.
-            try {
-              // Restrict storyboard statuses to the IDs that exist at this
-              // version. With a single supported version (3.0) this filter is
-              // a no-op since every storyboard's `introduced_in` is unset
-              // ("always applied"). When 3.1 ships with new storyboards, this
-              // is what isolates 3.0 badge issuance from 3.1-only fixtures.
-              const versionStoryboardIds = new Set(getStoryboardIdsForVersion(adcpVersion));
-              const versionScopedStatuses = storyboardStatuses.filter(s => versionStoryboardIds.has(s.storyboard_id));
-
-              const badgeResult = await processAgentBadges(
-                complianceDb,
-                agent.agent_url,
-                declaredSpecialisms,
-                versionScopedStatuses,
-                dbInput.overall_status === 'passing',
-                membershipOrgId,
-                adcpVersion,
-              );
-
-              for (const issued of badgeResult.issued) aggregatedIssued.push(issued);
-              for (const revoked of badgeResult.revoked) aggregatedRevoked.push(revoked);
-            } catch (versionError) {
-              const errorMessage = versionError instanceof Error ? versionError.message : String(versionError);
-              logger.error(
-                { versionError, agentUrl: agent.agent_url, adcpVersion },
-                'Badge processing failed for one AdCP version — continuing with remaining versions',
-              );
-              notifySystemError({
-                source: 'compliance-badge-issuance',
-                errorMessage: `Per-version badge processing failed for ${agent.agent_url} at AdCP ${adcpVersion}: ${errorMessage}`,
-              });
-            }
-          }
-
-          // Notify on badge changes from the versions that completed —
-          // skipping versions that threw above. A partial result that
-          // ships only completed-version notifications is correct: the
-          // system-error alert above carries the failure signal.
-          if (aggregatedIssued.length > 0 || aggregatedRevoked.length > 0) {
+          if (badgeResult.issued.length > 0 || badgeResult.revoked.length > 0) {
             try {
               await notifyVerificationChange({
                 agentUrl: agent.agent_url,
-                issued: aggregatedIssued,
-                revoked: aggregatedRevoked,
+                issued: badgeResult.issued,
+                revoked: badgeResult.revoked,
               });
             } catch (notifyError) {
               logger.error({ notifyError, agentUrl: agent.agent_url }, 'Failed to send verification notification');

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -69,6 +69,7 @@ import { canonicalizeBrandDomain } from '../../services/identifier-normalization
 import { isOrgOwnerOfAgent } from '../../services/agent-ownership.js';
 import { getBrandPrimaryDomain } from '../../services/brand-domain-resolver.js';
 import { ComplianceDatabase } from '../../db/compliance-db.js';
+import { runBadgeFanOut } from '../../services/badge-issuance.js';
 import { AgentSnapshotDatabase } from '../../db/agent-snapshot-db.js';
 import { AgentValidator } from '../../validator.js';
 import {
@@ -3618,6 +3619,24 @@ export function createMemberToolHandlers(
               // notifyComplianceChange intentionally omitted: owner test runs are
               // exploratory; compliance-change notifications fire on heartbeat
               // transitions only to prevent iteration-loop spam.
+
+              // Fire badge issuance off the canonical write so an owner who
+              // just fixed a compliance issue sees their badge update on the
+              // next page load instead of waiting up to a heartbeat cycle.
+              // Verification-change notifications are intentionally skipped —
+              // the owner already received the result in their chat response.
+              const declaredSpecialisms = result.agent_profile?.specialisms ?? [];
+              if (declaredSpecialisms.length > 0) {
+                try {
+                  await runBadgeFanOut({
+                    complianceDb,
+                    agentUrl: resolved.resolvedUrl,
+                    declaredSpecialisms,
+                  });
+                } catch (badgeError) {
+                  logger.warn({ badgeError, agentUrl: resolved.resolvedUrl }, 'Badge fan-out failed after owner_test run');
+                }
+              }
             }
           } catch (error) {
             logger.warn({ error, agentUrl: resolved.resolvedUrl }, 'Could not write owner test result to canonical compliance state');

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -30,6 +30,7 @@ import {
 } from "../addie/services/compliance-testing.js";
 import { getPublicJwks } from "../services/verification-token.js";
 import { renderBadgeSvg, VALID_BADGE_ROLES } from "../services/badge-svg.js";
+import { runBadgeFanOut } from "../services/badge-issuance.js";
 import { resolveOwnerMembership } from "../services/membership-tiers.js";
 import { inferDiagnosticAgentType } from "../lib/diagnostic-agent-type-inference.js";
 import { isValidAdcpVersionShape } from "../services/adcp-taxonomy.js";
@@ -5743,6 +5744,25 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         await complianceDb.recordComplianceRun(
           complianceResultToDbInput(complyResult, agentUrl, metadata?.lifecycle_stage || "development", "owner_test", [req.params.storyboardId]),
         );
+
+        // Fan out badge issuance on the canonical write so an owner who
+        // just fixed a single storyboard sees the badge update on their
+        // next page load. The helper loads ALL latest storyboard statuses
+        // from agent_storyboard_status so this partial run doesn't degrade
+        // badges for storyboards it didn't touch. No notification — the
+        // owner already sees the result in the HTTP response.
+        const declaredSpecialisms = complyResult.agent_profile?.specialisms ?? [];
+        if (declaredSpecialisms.length > 0) {
+          try {
+            await runBadgeFanOut({
+              complianceDb,
+              agentUrl,
+              declaredSpecialisms,
+            });
+          } catch (badgeError) {
+            logger.warn({ err: badgeError, agentUrl }, 'Badge fan-out failed after storyboard-run');
+          }
+        }
 
         // Annotate storyboard phases with comply results
         const annotatedPhases = storyboard.phases.map((phase) => ({

--- a/server/src/services/badge-issuance.ts
+++ b/server/src/services/badge-issuance.ts
@@ -3,10 +3,14 @@
  * AAO Verified badges based on specialism results.
  */
 
-import { ComplianceDatabase, DEFAULT_BADGE_ADCP_VERSION, type BadgeRole, type StoryboardStatusEntry } from '../db/compliance-db.js';
+import { ComplianceDatabase, DEFAULT_BADGE_ADCP_VERSION, type BadgeRole, type StoryboardStatus, type StoryboardStatusEntry } from '../db/compliance-db.js';
 import { deriveVerificationStatus } from '../addie/services/compliance-testing.js';
 import { signVerificationToken, isTokenSigningEnabled } from './verification-token.js';
-import { isVerificationMode, type VerificationMode } from './adcp-taxonomy.js';
+import { isVerificationMode, SUPPORTED_BADGE_VERSIONS, type VerificationMode } from './adcp-taxonomy.js';
+import { getStoryboardIdsForVersion } from './storyboards.js';
+import { API_ACCESS_TIERS, ACTIVE_SUBSCRIPTION_STATUSES } from './membership-tiers.js';
+import { query } from '../db/client.js';
+import { notifySystemError } from '../addie/error-notifier.js';
 import { logger as baseLogger } from '../logger.js';
 
 const logger = baseLogger.child({ module: 'badge-issuance' });
@@ -148,4 +152,106 @@ export async function processAgentBadges(
   }
 
   return result;
+}
+
+/**
+ * Fan badge issuance out across every supported AdCP version after a
+ * compliance run completes.
+ *
+ * Resolves the membership org, reads the latest per-storyboard statuses
+ * from `agent_storyboard_status` (so single-storyboard owner_test runs
+ * don't revoke badges for storyboards they didn't touch), and calls
+ * `processAgentBadges` per version with that version's storyboard set.
+ *
+ * Callers (heartbeat, owner_test paths, single-storyboard run) decide
+ * separately whether to send a verification-change notification.
+ */
+export async function runBadgeFanOut(params: {
+  complianceDb: ComplianceDatabase;
+  agentUrl: string;
+  declaredSpecialisms: string[];
+}): Promise<BadgeIssuanceResult> {
+  const { complianceDb, agentUrl, declaredSpecialisms } = params;
+  const aggregate: BadgeIssuanceResult = { issued: [], revoked: [], degraded: [], unchanged: [] };
+
+  if (declaredSpecialisms.length === 0) {
+    return aggregate;
+  }
+
+  // Resolve membership org for this agent — only orgs with an active
+  // API-access tier qualify for badge issuance. processAgentBadges
+  // revokes all badges if this returns undefined.
+  const orgResult = await query(
+    `SELECT mp.workos_organization_id
+     FROM member_profiles mp
+     JOIN organizations o ON o.workos_organization_id = mp.workos_organization_id
+     WHERE mp.agents @> $1::jsonb
+       AND o.membership_tier = ANY($2::text[])
+       AND o.subscription_status = ANY($3::text[])
+     ORDER BY mp.created_at ASC
+     LIMIT 1`,
+    [
+      JSON.stringify([{ url: agentUrl }]),
+      [...API_ACCESS_TIERS],
+      [...ACTIVE_SUBSCRIPTION_STATUSES],
+    ],
+  );
+  const membershipOrgId = orgResult.rows[0]?.workos_organization_id as string | undefined;
+
+  // Load the latest per-storyboard state from the canonical table. This
+  // captures the row that recordComplianceRun() just upserted plus every
+  // earlier storyboard's last result — essential for partial runs
+  // (single-storyboard owner_test) so unrelated storyboards' badges
+  // aren't degraded just because they weren't touched this run.
+  const latestStatuses = await complianceDb.getStoryboardStatuses(agentUrl);
+  const storyboardStatuses: StoryboardStatusEntry[] = latestStatuses.map(s => ({
+    storyboard_id: s.storyboard_id,
+    status: s.status as StoryboardStatus,
+    steps_passed: s.steps_passed,
+    steps_total: s.steps_total,
+  }));
+
+  // overallPassing reflects whether *every* storyboard the agent has
+  // ever run is currently passing. processAgentBadges does not branch
+  // on this today but accepts it for symmetry; keep it accurate.
+  const overallPassing = storyboardStatuses.length > 0 &&
+    storyboardStatuses.every(s => s.status === 'passing');
+
+  for (const adcpVersion of SUPPORTED_BADGE_VERSIONS) {
+    // Per-version try/catch matches the heartbeat behavior: a failure
+    // at one version must not poison another version's issuance, and a
+    // persistent failure must surface via the system-error channel
+    // instead of disappearing into a non-fatal warn.
+    try {
+      const versionStoryboardIds = new Set(getStoryboardIdsForVersion(adcpVersion));
+      const versionScoped = storyboardStatuses.filter(s => versionStoryboardIds.has(s.storyboard_id));
+
+      const versionResult = await processAgentBadges(
+        complianceDb,
+        agentUrl,
+        declaredSpecialisms,
+        versionScoped,
+        overallPassing,
+        membershipOrgId,
+        adcpVersion,
+      );
+
+      for (const issued of versionResult.issued) aggregate.issued.push(issued);
+      for (const revoked of versionResult.revoked) aggregate.revoked.push(revoked);
+      for (const degraded of versionResult.degraded) aggregate.degraded.push(degraded);
+      for (const unchanged of versionResult.unchanged) aggregate.unchanged.push(unchanged);
+    } catch (versionError) {
+      const errorMessage = versionError instanceof Error ? versionError.message : String(versionError);
+      logger.error(
+        { versionError, agentUrl, adcpVersion },
+        'Badge processing failed for one AdCP version — continuing with remaining versions',
+      );
+      notifySystemError({
+        source: 'compliance-badge-issuance',
+        errorMessage: `Per-version badge processing failed for ${agentUrl} at AdCP ${adcpVersion}: ${errorMessage}`,
+      });
+    }
+  }
+
+  return aggregate;
 }

--- a/server/tests/unit/badge-fan-out.test.ts
+++ b/server/tests/unit/badge-fan-out.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// query() is used to resolve the membership org; mock it before importing
+// the unit under test so the import-time singleton doesn't open a real pool.
+vi.mock('../../src/db/client.js', () => ({
+  query: vi.fn(),
+}));
+
+import { query } from '../../src/db/client.js';
+import { runBadgeFanOut } from '../../src/services/badge-issuance.js';
+import type {
+  AgentVerificationBadge,
+  BadgeRole,
+  ComplianceDatabase,
+  StoryboardStatus,
+} from '../../src/db/compliance-db.js';
+
+const queryMock = vi.mocked(query);
+
+function badge(role: BadgeRole, status: AgentVerificationBadge['status'] = 'active', adcpVersion = '3.0'): AgentVerificationBadge {
+  return {
+    agent_url: 'https://example.com/mcp',
+    role,
+    adcp_version: adcpVersion,
+    verified_at: new Date(Date.now() - 86_400_000),
+    verified_protocol_version: null,
+    verified_specialisms: ['sales-broadcast-tv'],
+    verification_modes: ['spec'],
+    verification_token: null,
+    token_expires_at: null,
+    membership_org_id: 'org_test',
+    status,
+    revoked_at: null,
+    revocation_reason: null,
+    created_at: new Date(),
+    updated_at: new Date(),
+  };
+}
+
+function status(id: string, s: StoryboardStatus) {
+  return { storyboard_id: id, status: s, last_tested_at: new Date(), last_passed_at: s === 'passing' ? new Date() : null, last_failed_at: s === 'passing' ? null : new Date(), steps_passed: s === 'passing' ? 5 : 0, steps_total: 5, triggered_by: 'owner_test' };
+}
+
+function makeDb(opts: {
+  existingBadges?: AgentVerificationBadge[];
+  latestStatuses?: ReturnType<typeof status>[];
+}): ComplianceDatabase {
+  const upserts: any[] = [];
+  const degrades: any[] = [];
+  const revokes: any[] = [];
+  return {
+    getBadgesForAgent: vi.fn().mockResolvedValue(opts.existingBadges ?? []),
+    getStoryboardStatuses: vi.fn().mockResolvedValue(opts.latestStatuses ?? []),
+    upsertBadge: vi.fn().mockImplementation((b: any) => { upserts.push(b); return Promise.resolve({ ...badge(b.role), ...b }); }),
+    degradeBadge: vi.fn().mockImplementation((...args: any[]) => { degrades.push(args); return Promise.resolve(undefined); }),
+    revokeBadge: vi.fn().mockImplementation((...args: any[]) => { revokes.push(args); return Promise.resolve(undefined); }),
+    _upserts: upserts,
+    _degrades: degrades,
+    _revokes: revokes,
+  } as unknown as ComplianceDatabase;
+}
+
+describe('runBadgeFanOut', () => {
+  beforeEach(() => queryMock.mockReset());
+
+  it('no-ops when the agent declared no specialisms', async () => {
+    const db = makeDb({});
+    const result = await runBadgeFanOut({
+      complianceDb: db,
+      agentUrl: 'https://example.com/mcp',
+      declaredSpecialisms: [],
+    });
+    expect(result.issued).toHaveLength(0);
+    expect(result.revoked).toHaveLength(0);
+    expect(db.getStoryboardStatuses).not.toHaveBeenCalled();
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('reads ALL latest storyboard statuses from the canonical table — not just what one partial run touched', async () => {
+    // Agent declared two specialisms across two roles. The OTHER storyboard
+    // is still passing on disk; this run only retested the broadcast-tv
+    // storyboard. We must read the full set so we don't degrade the
+    // creative-ad-server badge as a side effect.
+    queryMock.mockResolvedValueOnce({ rows: [{ workos_organization_id: 'org_member' }], rowCount: 1, command: 'SELECT', oid: 0, fields: [] } as never);
+
+    const db = makeDb({
+      latestStatuses: [
+        status('sales_broadcast_tv', 'passing'),
+        status('creative_ad_server', 'passing'),
+      ],
+    });
+
+    await runBadgeFanOut({
+      complianceDb: db,
+      agentUrl: 'https://example.com/mcp',
+      declaredSpecialisms: ['sales-broadcast-tv', 'creative-ad-server'],
+    });
+
+    expect(db.getStoryboardStatuses).toHaveBeenCalledWith('https://example.com/mcp');
+    // Both roles should be issued — no revoke of the role we didn't retest
+    expect(db.upsertBadge).toHaveBeenCalledTimes(2);
+    expect(db.revokeBadge).not.toHaveBeenCalled();
+  });
+
+  it('passes undefined membershipOrgId when the org lookup returns no row, causing all badges to revoke', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [], rowCount: 0, command: 'SELECT', oid: 0, fields: [] } as never);
+
+    const db = makeDb({
+      existingBadges: [badge('media-buy')],
+      latestStatuses: [status('sales_broadcast_tv', 'passing')],
+    });
+
+    const result = await runBadgeFanOut({
+      complianceDb: db,
+      agentUrl: 'https://example.com/mcp',
+      declaredSpecialisms: ['sales-broadcast-tv'],
+    });
+
+    expect(result.revoked).toHaveLength(1);
+    expect(result.revoked[0].reason).toBe('Membership lapsed');
+  });
+
+  it('aggregates results across supported AdCP versions', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ workos_organization_id: 'org_member' }], rowCount: 1, command: 'SELECT', oid: 0, fields: [] } as never);
+
+    const db = makeDb({
+      latestStatuses: [status('sales_broadcast_tv', 'passing')],
+    });
+
+    const result = await runBadgeFanOut({
+      complianceDb: db,
+      agentUrl: 'https://example.com/mcp',
+      declaredSpecialisms: ['sales-broadcast-tv'],
+    });
+
+    // With one supported version (3.0) we get one issuance; the test
+    // documents the aggregation contract (one entry per (role, version)
+    // pair) so adding 3.1 to SUPPORTED_BADGE_VERSIONS will surface here.
+    expect(result.issued.length).toBeGreaterThanOrEqual(1);
+    expect(result.issued.every(i => typeof i.adcp_version === 'string')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Extract the per-version badge fan-out (membership-org resolution + `processAgentBadges` loop across `SUPPORTED_BADGE_VERSIONS`) from `compliance-heartbeat.ts` into a shared `runBadgeFanOut()` helper in `services/badge-issuance.ts`.
- Call the helper from the two owner-driven test paths immediately after `recordComplianceRun()`:
  - `member-tools.ts` `evaluate_agent_quality` (full comply) for an agent owner — fires badges off the canonical write so an owner who just fixed compliance sees the badge update on the next page load.
  - `registry-api.ts` `POST /registry/agents/:encodedUrl/storyboard/:storyboardId/run` (single storyboard) — same effect for in-place storyboard re-runs from the dashboard.
- Verification-change Slack notifications stay scoped to heartbeat — owner runs already deliver the result via chat / HTTP response.

## Why the helper reads `getStoryboardStatuses()` instead of trusting the run's own inputs

The single-storyboard endpoint (`storyboard/:storyboardId/run`) supplies only one storyboard status in `dbInput`. If the helper used those inputs verbatim, `deriveVerificationStatus()` would treat every other declared specialism as "failing" (its storyboard would be absent from the status map) and degrade unrelated badges as a side effect. Loading the merged latest state from `agent_storyboard_status` after `recordComplianceRun()` returns the correct picture for both partial owner runs and full heartbeat runs.

## Test plan

- [x] `npx vitest run tests/unit/badge-fan-out.test.ts tests/unit/badge-issuance.test.ts` — 17 tests pass.
  - New tests: no-op on empty specialisms, full-status load for partial runs, membership-lapse revoke path, per-version aggregation contract.
- [x] `npx tsc --noEmit -p server/tsconfig.json` clean.
- [ ] After merge: spot-check a heartbeat run still emits the verification-change Slack DM (no behavior change there — same code path, just goes through the helper).

Closes #4376.

🤖 Generated with [Claude Code](https://claude.com/claude-code)