### PR TITLE
fix(addie): open external links in new tab from SI modal chat

### DIFF
--- a/.changeset/4395-si-modal-links-new-tab.md
+++ b/.changeset/4395-si-modal-links-new-tab.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix(addie): open external links in new tab from SI modal chat (closes #4395)

--- a/server/public/chat.html
+++ b/server/public/chat.html
@@ -3621,20 +3621,50 @@
         return `<div class="member-cards-container">${cards}</div>`;
       }
 
-      // Render markdown using marked library
-      function renderMessage(text) {
-        // Configure marked for security and compatibility
-        marked.setOptions({
-          breaks: true, // Convert \n to <br>
-          gfm: true, // GitHub flavored markdown
-        });
-
-        // Helper to escape HTML attribute values
+      // Shared renderer factory — opens external links in a new tab (chat is an SPA;
+      // navigating away loses context). Used by both the main chat and SI modal paths.
+      function createAdcpMarkdownRenderer() {
         const escapeAttr = (str) => str
           .replace(/&/g, '&amp;')
           .replace(/"/g, '&quot;')
           .replace(/</g, '&lt;')
           .replace(/>/g, '&gt;');
+
+        const renderer = new marked.Renderer();
+        renderer.link = function(href, title, text) {
+          // Handle marked v17+ which passes an object
+          if (href !== null && typeof href === 'object') {
+            const link = href;
+            href = link.href;
+            title = link.title;
+            text = link.text;
+          }
+          const safeHref = /^(https?:\/\/|mailto:|#|\/)/i.test(href) ? href : '#';
+          const titleAttr = title ? ` title="${escapeAttr(title)}"` : '';
+          const isAnchor = /^#/.test(href);
+          const targetAttr = !isAnchor ? ' target="_blank" rel="noopener noreferrer"' : '';
+          return `<a href="${escapeAttr(safeHref)}"${titleAttr}${targetAttr}>${text}</a>`;
+        };
+        renderer.image = function(href, title, text) {
+          // Handle marked v17+ which passes an object
+          if (href !== null && typeof href === 'object') {
+            const img = href;
+            href = img.href;
+            title = img.title;
+            text = img.text;
+          }
+          const safeHref = /^(https?:\/\/|data:image\/)/i.test(href) ? escapeAttr(href) : '';
+          if (!safeHref) return '';
+          const titleAttr = title ? ` title="${escapeAttr(title)}"` : '';
+          const altAttr = text ? ` alt="${escapeAttr(text)}"` : ' alt="Image"';
+          return `<a href="${safeHref}" target="_blank" rel="noopener noreferrer" class="chat-image-wrap"><img src="${safeHref}"${altAttr}${titleAttr} loading="lazy"></a>`;
+        };
+        return renderer;
+      }
+
+      // Render markdown using marked library
+      function renderMessage(text) {
+        marked.setOptions({ breaks: true, gfm: true });
 
         // Check for embedded ADDIE_DATA blocks and extract them
         const dataBlockRegex = /<!--ADDIE_DATA:([\s\S]*?):ADDIE_DATA-->/g;
@@ -3651,44 +3681,7 @@
           }
         });
 
-        // Use marked's built-in renderer with custom link and image handling
-        const renderer = new marked.Renderer();
-        renderer.link = function(href, title, text) {
-          // Handle marked v17+ which passes an object
-          if (typeof href === 'object') {
-            const link = href;
-            href = link.href;
-            title = link.title;
-            text = link.text;
-          }
-          // Validate URL scheme - only allow safe protocols
-          const safeHref = /^(https?:\/\/|mailto:|#|\/)/i.test(href) ? href : '#';
-          const titleAttr = title ? ` title="${escapeAttr(title)}"` : '';
-          // Open all navigable links in new tab — chat is an SPA, navigating away loses context
-          const isAnchor = /^#/.test(href);
-          const targetAttr = !isAnchor ? ' target="_blank" rel="noopener noreferrer"' : '';
-          return `<a href="${escapeAttr(safeHref)}"${titleAttr}${targetAttr}>${text}</a>`;
-        };
-
-        // Custom image renderer
-        renderer.image = function(href, title, text) {
-          // Handle marked v17+ which passes an object
-          if (typeof href === 'object') {
-            const img = href;
-            href = img.href;
-            title = img.title;
-            text = img.text;
-          }
-          // Validate URL scheme - only allow safe protocols
-          const safeHref = /^(https?:\/\/|data:image\/)/i.test(href) ? escapeAttr(href) : '';
-          if (!safeHref) return '';
-          const titleAttr = title ? ` title="${escapeAttr(title)}"` : '';
-          const altAttr = text ? ` alt="${escapeAttr(text)}"` : ' alt="Image"';
-          // Wrap in container to reserve space and prevent layout shift while loading
-          return `<a href="${safeHref}" target="_blank" rel="noopener noreferrer" class="chat-image-wrap"><img src="${safeHref}"${altAttr}${titleAttr} loading="lazy"></a>`;
-        };
-
-        let html = DOMPurify.sanitize(marked.parse(processedText, { renderer }));
+        let html = DOMPurify.sanitize(marked.parse(processedText, { renderer: createAdcpMarkdownRenderer() }));
 
         // Replace placeholders with rendered components
         dataBlocks.forEach((data, index) => {
@@ -4806,7 +4799,7 @@
 
         // Parse markdown for assistant messages
         if (role === 'assistant' && window.marked) {
-          contentDiv.innerHTML = DOMPurify.sanitize(marked.parse(content || ''));
+          contentDiv.innerHTML = DOMPurify.sanitize(marked.parse(content || '', { breaks: true, gfm: true, renderer: createAdcpMarkdownRenderer() }));
         } else {
           contentDiv.textContent = content || '';
         }
@@ -5514,6 +5507,7 @@
           const reader = response.body.getReader();
           const decoder = new TextDecoder();
           let buffer = '';
+          const siStreamRenderer = window.marked ? createAdcpMarkdownRenderer() : null;
 
           while (true) {
             const { done, value } = await reader.read();
@@ -5533,8 +5527,8 @@
                   if (event.type === 'text') {
                     streamedText += event.text;
                     // Update content with markdown parsing
-                    if (window.marked) {
-                      contentDiv.innerHTML = DOMPurify.sanitize(marked.parse(streamedText));
+                    if (siStreamRenderer) {
+                      contentDiv.innerHTML = DOMPurify.sanitize(marked.parse(streamedText, { breaks: true, gfm: true, renderer: siStreamRenderer }));
                     } else {
                       contentDiv.textContent = streamedText;
                     }


### PR DESCRIPTION
Closes #4395

The main Addie chat `renderMessage()` already rendered links with `target="_blank" rel="noopener noreferrer"` via a custom `marked.Renderer`. The Sponsored Intelligence (Brand Agent) modal had two call sites that used bare `marked.parse()` with no custom renderer — links from SI modal responses navigated the current tab, simultaneously wiping the brand agent conversation and the parent Addie chat.

This PR extracts the renderer setup into a shared `createAdcpMarkdownRenderer()` factory and wires it into all three `marked.parse()` call sites.

**Non-breaking justification:** adds `target="_blank"` behavior to SI modal links; existing consumers unaffected. No schema or protocol changes.

**Pre-PR review:**
- code-reviewer: approved — one nit fixed (added `href !== null &&` guard on the marked v17+ object-shim; renderer allocation hoisted before streaming loop)
- internal-tools-strategist: approved — shared factory is the right approach; `renderMessage` ADDIE_DATA logic untouched; no behavioral regression risk

**Nits noted but out of scope:**
- `mailto:` and root-relative `/` paths get `target="_blank"` (pre-existing, lower priority; file follow-up if needed)
- `renderMessage` still uses `marked.setOptions` rather than passing options inline (functional, minor inconsistency)

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01AQYeAjhF7D8eExajxUcFcD

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQYeAjhF7D8eExajxUcFcD)_