### PR TITLE
fix(addie): get_schema truncates large schemas at 6K chars

### DIFF
--- a/.changeset/fix-get-schema-truncation.md
+++ b/.changeset/fix-get-schema-truncation.md
@@ -1,0 +1,13 @@
+---
+---
+
+fix(addie): raise get_schema display limit from 6K to 20K chars and fix misleading truncation note
+
+The previous 6,000-char hard cut silently hid entire oneOf branches in
+schemas like creative/preview-render.json (~7.7K) and
+creative/preview-creative-response.json (~11K), causing Addie to report
+incomplete or structurally incorrect schema information. The truncation
+note incorrectly suggested using the `property` parameter, which only
+works for schema.properties — not for oneOf/allOf/anyOf union schemas.
+
+Fixes #4397.

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.05.1';
+export const CODE_VERSION = '2026.05.2';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/mcp/schema-tools.ts
+++ b/server/src/addie/mcp/schema-tools.ts
@@ -439,6 +439,40 @@ export const SCHEMA_TOOLS: AddieTool[] = [
   },
 ];
 
+// Max chars for the JSON block returned by get_schema. Matched to the
+// PRESERVE_TOOL_RESULTS ceiling in token-limiter.ts so the two layers stay
+// coherent — keep them in sync if either value changes.
+export const SCHEMA_MAX_DISPLAY_CHARS = 20_000;
+
+/**
+ * Format the JSON block for get_schema output, applying a size ceiling.
+ * Exported for unit testing without requiring HTTP mocks.
+ *
+ * @param schemaJson - Already-serialized schema JSON string
+ * @param propNames  - Top-level property names from schema.properties (used to
+ *                     craft a helpful truncation hint; pass [] for union schemas)
+ */
+export function formatSchemaJson(
+  schemaJson: string,
+  propNames: string[] = [],
+): { displayJson: string; truncationNote: string | null } {
+  if (schemaJson.length <= SCHEMA_MAX_DISPLAY_CHARS) {
+    return { displayJson: schemaJson, truncationNote: null };
+  }
+
+  const shown = SCHEMA_MAX_DISPLAY_CHARS.toLocaleString('en-US');
+  const total = schemaJson.length.toLocaleString('en-US');
+  const hint =
+    propNames.length > 0
+      ? `Use the \`property\` parameter with one of the **All properties** names above (e.g., \`property: "${propNames[0]}"\`) to retrieve a specific section.`
+      : `This schema uses union types (\`oneOf\`/\`allOf\`/\`anyOf\`) rather than top-level properties. Use \`list_schemas\` to find related sub-schemas or call \`get_schema\` with a different schema path.`;
+
+  return {
+    displayJson: schemaJson.substring(0, SCHEMA_MAX_DISPLAY_CHARS),
+    truncationNote: `Schema truncated (showing ${shown} of ${total} chars). ${hint}`,
+  };
+}
+
 /**
  * Create handlers for schema tools
  */
@@ -549,16 +583,13 @@ ${formatCandidates(schemaPath, registry)}`);
         summary += `**All properties:** ${propNames.join(', ')}\n`;
       }
 
-      // Truncate very long schemas
-      const maxLength = 6000;
-      const truncated = schemaJson.length > maxLength;
-      const displayJson = truncated ? schemaJson.substring(0, maxLength) + '\n... [truncated]' : schemaJson;
+      const { displayJson, truncationNote } = formatSchemaJson(schemaJson, propNames);
 
       return `${summary}
 \`\`\`json
 ${displayJson}
 \`\`\`
-${truncated ? '\n**Note:** Schema truncated. Use the `property` parameter to focus on specific sections.' : ''}`;
+${truncationNote ? `\n**Note:** ${truncationNote}` : ''}`;
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
       throw new ToolError(`Failed to fetch schema: ${message}

--- a/server/src/addie/mcp/schema-tools.ts
+++ b/server/src/addie/mcp/schema-tools.ts
@@ -442,7 +442,9 @@ export const SCHEMA_TOOLS: AddieTool[] = [
 // Max chars for the JSON block returned by get_schema. Matched to the
 // PRESERVE_TOOL_RESULTS ceiling in token-limiter.ts so the two layers stay
 // coherent — keep them in sync if either value changes.
-export const SCHEMA_MAX_DISPLAY_CHARS = 20_000;
+// 50K covers all schemas in the v3 registry except the largest union enumerations
+// (get-adcp-capabilities-response at ~75K, brand.json/adagents.json at ~74K/50K).
+export const SCHEMA_MAX_DISPLAY_CHARS = 50_000;
 
 /**
  * Format the JSON block for get_schema output, applying a size ceiling.
@@ -465,7 +467,7 @@ export function formatSchemaJson(
   const hint =
     propNames.length > 0
       ? `Use the \`property\` parameter with one of the **All properties** names above (e.g., \`property: "${propNames[0]}"\`) to retrieve a specific section.`
-      : `This schema uses union types (\`oneOf\`/\`allOf\`/\`anyOf\`) rather than top-level properties. Use \`list_schemas\` to find related sub-schemas or call \`get_schema\` with a different schema path.`;
+      : `This schema uses inline union branches (\`oneOf\`/\`allOf\`/\`anyOf\`) that exceed the display limit. Use \`validate_json\` with a candidate payload to check validity and identify the matching branch.`;
 
   return {
     displayJson: schemaJson.substring(0, SCHEMA_MAX_DISPLAY_CHARS),
@@ -565,7 +567,7 @@ ${formatCandidates(schemaPath, registry)}`);
       // Format schema for readability
       const schemaJson = JSON.stringify(displaySchema, null, 2);
 
-      // Extract key info for summary
+      // Extract key info for summary (always from root schema for navigation context)
       const required = schema.required as string[] | undefined;
       const properties = schema.properties as Record<string, unknown> | undefined;
       const propNames = properties ? Object.keys(properties) : [];
@@ -583,7 +585,14 @@ ${formatCandidates(schemaPath, registry)}`);
         summary += `**All properties:** ${propNames.join(', ')}\n`;
       }
 
-      const { displayJson, truncationNote } = formatSchemaJson(schemaJson, propNames);
+      // When drilling into a sub-property, use its own children for the truncation
+      // hint so the note points to paths the agent can actually drill into next.
+      const displayProperties = displaySchema.properties as Record<string, unknown> | undefined;
+      const truncationPropNames = property
+        ? (displayProperties ? Object.keys(displayProperties) : [])
+        : propNames;
+
+      const { displayJson, truncationNote } = formatSchemaJson(schemaJson, truncationPropNames);
 
       return `${summary}
 \`\`\`json

--- a/server/src/utils/token-limiter.ts
+++ b/server/src/utils/token-limiter.ts
@@ -276,8 +276,9 @@ const PRESERVE_TOOL_RESULTS = new Set([
  * Replaces tool call results older than `keepRecentTurns` assistant turns
  * with a short placeholder. Checkpoints capture teaching state, so old
  * tool results (get_products responses, module content, etc.) are redundant.
- * Knowledge search results are preserved up to 20K chars since they contain
- * authoritative protocol verification.
+ * Knowledge search and schema results are preserved up to 25K chars since they
+ * contain authoritative protocol verification. (25K = 20K JSON ceiling for
+ * get_schema + ~300 char header overhead; see SCHEMA_MAX_DISPLAY_CHARS.)
  *
  * @param messages - Conversation history (newest last)
  * @param keepRecentTurns - Number of most-recent assistant turns to preserve fully
@@ -306,8 +307,11 @@ export function compactOldToolResults(
 
     const compactedCalls = msg.toolCalls.map(tc => {
       if (tc.result.length <= 200) return tc;
-      // Preserve knowledge search results under 20K chars — they're authoritative verification
-      if (PRESERVE_TOOL_RESULTS.has(tc.name) && tc.result.length <= 20000) return tc;
+      // Preserve knowledge search / schema results up to 25K chars.
+      // 25K accounts for get_schema's 20K JSON ceiling plus summary header
+      // overhead (~300 chars). Keep in sync with SCHEMA_MAX_DISPLAY_CHARS in
+      // schema-tools.ts if either value changes.
+      if (PRESERVE_TOOL_RESULTS.has(tc.name) && tc.result.length <= 25000) return tc;
       return {
         ...tc,
         result: '[Result compacted — see checkpoint for current teaching state]',

--- a/server/src/utils/token-limiter.ts
+++ b/server/src/utils/token-limiter.ts
@@ -276,8 +276,8 @@ const PRESERVE_TOOL_RESULTS = new Set([
  * Replaces tool call results older than `keepRecentTurns` assistant turns
  * with a short placeholder. Checkpoints capture teaching state, so old
  * tool results (get_products responses, module content, etc.) are redundant.
- * Knowledge search and schema results are preserved up to 25K chars since they
- * contain authoritative protocol verification. (25K = 20K JSON ceiling for
+ * Knowledge search and schema results are preserved up to 55K chars since they
+ * contain authoritative protocol verification. (55K = 50K JSON ceiling for
  * get_schema + ~300 char header overhead; see SCHEMA_MAX_DISPLAY_CHARS.)
  *
  * @param messages - Conversation history (newest last)
@@ -307,11 +307,11 @@ export function compactOldToolResults(
 
     const compactedCalls = msg.toolCalls.map(tc => {
       if (tc.result.length <= 200) return tc;
-      // Preserve knowledge search / schema results up to 25K chars.
-      // 25K accounts for get_schema's 20K JSON ceiling plus summary header
+      // Preserve knowledge search / schema results up to 55K chars.
+      // 55K accounts for get_schema's 50K JSON ceiling plus summary header
       // overhead (~300 chars). Keep in sync with SCHEMA_MAX_DISPLAY_CHARS in
       // schema-tools.ts if either value changes.
-      if (PRESERVE_TOOL_RESULTS.has(tc.name) && tc.result.length <= 25000) return tc;
+      if (PRESERVE_TOOL_RESULTS.has(tc.name) && tc.result.length <= 55000) return tc;
       return {
         ...tc,
         result: '[Result compacted — see checkpoint for current teaching state]',

--- a/server/tests/unit/addie/schema-tools.test.ts
+++ b/server/tests/unit/addie/schema-tools.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   extractRegistryPaths,
   findClosestSchema,
+  formatSchemaJson,
+  SCHEMA_MAX_DISPLAY_CHARS,
   type SchemaRegistry,
 } from '../../../src/addie/mcp/schema-tools.js';
 
@@ -72,6 +74,53 @@ describe('extractRegistryPaths', () => {
     const cyclic: Cyclic = { $ref: '/schemas/v3/core/product.json' };
     cyclic.self = cyclic;
     expect(extractRegistryPaths(cyclic)).toEqual(['core/product.json']);
+  });
+});
+
+describe('formatSchemaJson', () => {
+  const smallSchema = JSON.stringify({ title: 'Test', properties: { foo: { type: 'string' } } }, null, 2);
+
+  it('returns schema verbatim when under the character limit', () => {
+    const { displayJson, truncationNote } = formatSchemaJson(smallSchema, ['foo']);
+    expect(displayJson).toBe(smallSchema);
+    expect(truncationNote).toBeNull();
+  });
+
+  it('truncates schemas that exceed SCHEMA_MAX_DISPLAY_CHARS', () => {
+    const largeJson = 'x'.repeat(SCHEMA_MAX_DISPLAY_CHARS + 500);
+    const { displayJson, truncationNote } = formatSchemaJson(largeJson, []);
+    expect(displayJson).toHaveLength(SCHEMA_MAX_DISPLAY_CHARS);
+    expect(truncationNote).not.toBeNull();
+  });
+
+  it('truncation note mentions property parameter when propNames are present', () => {
+    const largeJson = 'x'.repeat(SCHEMA_MAX_DISPLAY_CHARS + 1);
+    const { truncationNote } = formatSchemaJson(largeJson, ['assets', 'renders']);
+    expect(truncationNote).toContain('property');
+    expect(truncationNote).toContain('assets');
+  });
+
+  it('truncation note mentions union types when no propNames are present', () => {
+    const largeJson = 'x'.repeat(SCHEMA_MAX_DISPLAY_CHARS + 1);
+    const { truncationNote } = formatSchemaJson(largeJson, []);
+    expect(truncationNote).toContain('oneOf');
+    expect(truncationNote).not.toContain('All properties');
+  });
+
+  it('truncation note does not suggest property param for union-only schemas (regression guard for #4397)', () => {
+    // Schemas like creative/preview-render.json use oneOf at root with no
+    // top-level properties. The old note incorrectly suggested `property`
+    // would help; it doesn't for union schemas.
+    const largeJson = 'x'.repeat(SCHEMA_MAX_DISPLAY_CHARS + 1);
+    const { truncationNote } = formatSchemaJson(largeJson, []);
+    // Should NOT tell the agent to drill into schema.properties
+    expect(truncationNote).not.toMatch(/Use the `property` parameter with one of the \*\*All properties\*\*/);
+  });
+
+  it('SCHEMA_MAX_DISPLAY_CHARS is at least 20_000', () => {
+    // Regression guard: the old 6K limit silently hid oneOf branches.
+    // creative/preview-creative-response.json is ~11K — must not be truncated.
+    expect(SCHEMA_MAX_DISPLAY_CHARS).toBeGreaterThanOrEqual(20_000);
   });
 });
 

--- a/server/tests/unit/addie/schema-tools.test.ts
+++ b/server/tests/unit/addie/schema-tools.test.ts
@@ -120,7 +120,26 @@ describe('formatSchemaJson', () => {
   it('SCHEMA_MAX_DISPLAY_CHARS is at least 20_000', () => {
     // Regression guard: the old 6K limit silently hid oneOf branches.
     // creative/preview-creative-response.json is ~11K — must not be truncated.
+    // core/format.json (~29K) and core/product.json (~25K) also require ≥25K.
     expect(SCHEMA_MAX_DISPLAY_CHARS).toBeGreaterThanOrEqual(20_000);
+  });
+
+  it('truncation note for union schemas does not suggest list_schemas (regression guard for #4397)', () => {
+    // Schemas like brand.json use inline oneOf branches — list_schemas only returns
+    // registry paths and cannot surface inline branches, so suggesting it is a dead end.
+    const largeJson = 'x'.repeat(SCHEMA_MAX_DISPLAY_CHARS + 1);
+    const { truncationNote } = formatSchemaJson(largeJson, []);
+    expect(truncationNote).not.toContain('list_schemas');
+    expect(truncationNote).toContain('validate_json');
+  });
+
+  it('truncation note for empty-properties schema (properties: {}) fires union hint', () => {
+    // comply-test-controller-response.json has "properties": {} at root.
+    // Object.keys({}) === [] so propNames is empty and the union hint fires.
+    const largeJson = 'x'.repeat(SCHEMA_MAX_DISPLAY_CHARS + 1);
+    const { truncationNote } = formatSchemaJson(largeJson, Object.keys({}));
+    expect(truncationNote).toContain('oneOf');
+    expect(truncationNote).not.toContain('All properties');
   });
 });
 


### PR DESCRIPTION
Closes #4397

## Summary

The `get_schema` Addie tool truncated JSON schemas at a hardcoded 6,000-char limit using a raw `substring()` cut, producing syntactically broken output and hiding entire `oneOf` branches. `creative/preview-render.json` (~7.7K) had its third `output_format: "both"` branch cut mid-sentence; `creative/preview-creative-response.json` (~11K) had the `variant` branch hidden entirely. The truncation note compounded the issue by directing the AI to the `property` parameter — which only works for `schema.properties`, not for union-type schemas.

**Changes:**
- Raise `SCHEMA_MAX_DISPLAY_CHARS` from 6K → **50K**, covering all current v3 schemas except the largest union enumerations (`get-adcp-capabilities-response` ~75K, `brand.json` ~74K — documented as known remaining limitation; both reported schemas and `core/format.json` ~29K, `core/product.json` ~25K now return in full)
- Extract `formatSchemaJson()` as an exported pure function, making truncation logic unit-testable without HTTP mocks
- Context-aware truncation note: property-hint for schemas with top-level `properties`; `validate_json` guidance for `oneOf`/`allOf`/`anyOf`-only schemas (replaces the previous dead-end `list_schemas` redirect)
- Fix `propNames` derivation when `property` is set: truncation hint now uses `displaySchema.properties` so the note points to paths the agent can actually drill into, not siblings it has already passed
- Raise `PRESERVE_TOOL_RESULTS` threshold in `token-limiter.ts` from 20K → 55K to stay coherent with new 50K JSON ceiling
- Bump `CODE_VERSION` to `2026.05.2` per playbook (mcp/*.ts tool implementation change)
- Add 8 unit tests for `formatSchemaJson` including regression guards for #4397

**Known remaining limitation:** Schemas exceeding 50K chars (`get-adcp-capabilities-response.json` ~75K, `brand.json` ~74K, `adagents.json` ~50K borderline) will still trigger the truncation path. For these, `validate_json` guidance in the truncation note is the correct fallback.

## Non-breaking justification

Server-side Addie tool output change only. Existing callers that worked before still work; callers that were receiving truncated data now receive complete data. No protocol schemas, task definitions, or public API surfaces changed.

## Pre-PR review

- **code-reviewer:** approved — fixed `toLocaleString('en-US')` locale safety, stale JSDoc. Noted truncated JSON-in-fence is pre-existing; no blockers.
- **prompt-engineer (iterative review):** two blockers addressed — 20K → 50K covers high-traffic schemas; union-only truncation note replaces dead-end `list_schemas` with actionable `validate_json` guidance. `propNames` derivation fix added for sub-property truncation.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01Qy5CniM5du4RLEDiTadFuJ