### PR TITLE
feat(compliance): add proposal_finalize_asap_timing storyboard scenario

### DIFF
--- a/.changeset/proposal-finalize-asap-timing-coverage.md
+++ b/.changeset/proposal-finalize-asap-timing-coverage.md
@@ -1,0 +1,10 @@
+---
+"adcontextprotocol": patch
+---
+
+Add `proposal_finalize_asap_timing` storyboard scenario covering `start_time: "asap"` on `create_media_buy`.
+
+The existing `proposal_finalize` scenario only tested the ISO 8601 date string form. This new scenario
+exercises the spec-defined `"asap"` string literal (from `start-timing.json`), catching wrapper-layer
+rejections that accept ISO dates but reject the asap form before the handler runs. Registered under
+both `sales-guaranteed` and `sales-proposal-mode` specialism indexes.

--- a/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize_asap_timing.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize_asap_timing.yaml
@@ -21,7 +21,7 @@ narrative: |
   The AdCP spec defines start_time as a oneOf over two string variants: the literal "asap"
   and an ISO 8601 date-time string. Both must be accepted by conformant sellers.
 
-  Background: a Wave 23.20 seller identified that their Pydantic wrapper was rejecting
+  Background: an adopter identified that their Pydantic wrapper was rejecting
   "asap" at the input-validation layer. The current proposal_finalize scenario only tests
   the ISO date form; this variant provides coverage for the "asap" form.
 
@@ -208,6 +208,12 @@ phases:
       proposal's insertion_order carries requires_signature: true, and gating
       this scenario on IO signing would conflate two independent conformance
       checks. The io_acceptance path is covered by the proposal_finalize scenario.
+
+      Response field checks (media_buy_id, status, etc.) are intentionally limited
+      to response_schema here. Behavioral verification of the create_media_buy
+      response is the parent proposal_finalize scenario's job. This variant's sole
+      purpose is to confirm the seller's input layer does not reject start_time:
+      "asap" before the handler runs — a non-error response satisfies that.
 
     steps:
       - id: create_media_buy

--- a/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize_asap_timing.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize_asap_timing.yaml
@@ -1,0 +1,250 @@
+id: media_buy_seller/proposal_finalize_asap_timing
+version: "1.0.0"
+title: "Seller handles proposal finalize — asap start_time form"
+category: media_buy_seller
+summary: "Variant of proposal_finalize that exercises start_time: 'asap' on create_media_buy, catching wrapper-layer rejections of the spec-defined string literal form."
+track: media_buy
+required_tools:
+  - get_products
+  - create_media_buy
+
+requires_capability:
+  path: media_buy.supports_proposals
+  equals: true
+
+narrative: |
+  Mirrors the proposal_finalize scenario but passes start_time: "asap" (the spec-defined
+  string literal from start-timing.json) when accepting the committed proposal. This arm
+  catches implementations that accept ISO 8601 dates but reject the "asap" string form
+  at the wrapper/validation layer before the handler's date-carry-forward logic runs.
+
+  The AdCP spec defines start_time as a oneOf over two string variants: the literal "asap"
+  and an ISO 8601 date-time string. Both must be accepted by conformant sellers.
+
+  Background: a Wave 23.20 seller identified that their Pydantic wrapper was rejecting
+  "asap" at the input-validation layer. The current proposal_finalize scenario only tests
+  the ISO date form; this variant provides coverage for the "asap" form.
+
+agent:
+  interaction_model: media_buy_seller
+  capabilities:
+    - sells_media
+    - accepts_briefs
+    - generates_proposals
+  examples:
+    - "Full-service publisher with proposal engine"
+    - "Retail media network with curated packages"
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: |
+    The caller needs a brand identity and operator credentials. The seller must support
+    proposal generation (return proposals alongside products in get_products responses).
+  test_kit: "test-kits/acme-outdoor.yaml"
+
+phases:
+  - id: setup
+    title: "Account setup"
+    steps:
+      - id: sync_accounts
+        title: "Establish account"
+        task: sync_accounts
+        schema_ref: "account/sync-accounts-request.json"
+        response_schema_ref: "account/sync-accounts-response.json"
+        doc_ref: "/accounts/tasks/sync_accounts"
+        stateful: true
+        expected: |
+          Return the account with account_id and status active.
+
+        sample_request:
+          accounts:
+            - brand:
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
+              billing: "operator"
+              payment_terms: "net_30"
+
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_proposal_finalize_asap_timing_setup_sync_accounts"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-accounts-response.json schema"
+          - check: field_present
+            path: "accounts[0].account_id"
+            description: "Account has a platform-assigned ID"
+
+  - id: brief_with_proposals
+    title: "Brief with proposals"
+    narrative: |
+      Send a brief and receive proposals alongside products.
+
+    steps:
+      - id: get_products_brief
+        title: "Send a brief and receive proposals"
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        comply_scenario: full_sales_flow
+        stateful: false
+        expected: |
+          Return products and proposals matching the brief:
+          - products: individual products with pricing and forecasts
+          - proposals: curated media plans with proposal_id, budget_allocations, rationale
+
+        sample_request:
+          buying_mode: "brief"
+          brief: "Premium video and display across outdoor lifestyle and sports. Q2 flight, $50K budget. Adults 25-54, US and Canada."
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+
+        context_outputs:
+          - path: "proposals[0].proposal_id"
+            key: "proposal_id"
+
+        validations:
+          - check: response_schema
+            description: "Response matches get-products-response.json schema"
+          - check: field_present
+            path: "products"
+            description: "Response contains products"
+          - check: field_present
+            path: "proposals"
+            description: "Response contains proposals"
+          - check: field_present
+            path: "proposals[0].proposal_id"
+            description: "Proposals have IDs"
+
+  - id: refine_proposal
+    title: "Refine the proposal"
+    narrative: |
+      The buyer reviews and refines the proposal before finalization.
+
+    steps:
+      - id: get_products_refine
+        title: "Refine a specific proposal"
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        comply_scenario: full_sales_flow
+        stateful: true
+        expected: |
+          Return the refined proposal reflecting the requested changes.
+
+        sample_request:
+          buying_mode: "refine"
+          refine:
+            - scope: "proposal"
+              proposal_id: "$context.proposal_id"
+              ask: "Shift 60% of budget to CTV. Drop the display product and redistribute that budget to video."
+            - scope: "request"
+              ask: "All products must support frequency capping at 3 per day."
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+
+        validations:
+          - check: response_schema
+            description: "Response matches get-products-response.json schema"
+          - check: field_present
+            path: "proposals"
+            description: "Response contains updated proposals"
+
+  - id: finalize_proposal
+    title: "Finalize the proposal"
+    narrative: |
+      The buyer requests finalization to transition the proposal from draft to committed
+      with firm pricing and an inventory hold.
+
+    steps:
+      - id: get_products_finalize
+        title: "Finalize the proposal"
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        comply_scenario: full_sales_flow
+        stateful: true
+        expected: |
+          Return the finalized proposal with committed status:
+          - proposals[0].proposal_status: committed
+          - proposals[0].expires_at: timestamp for the inventory hold window
+          - Firm pricing (not indicative)
+          - The proposal is ready to accept via create_media_buy
+
+        sample_request:
+          buying_mode: "refine"
+          refine:
+            - scope: "proposal"
+              proposal_id: "$context.proposal_id"
+              action: "finalize"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+
+        validations:
+          - check: response_schema
+            description: "Response matches get-products-response.json schema"
+          - check: field_present
+            path: "proposals"
+            description: "Response contains the finalized proposal"
+
+  - id: accept_proposal
+    title: "Accept the committed proposal with start_time: asap"
+    narrative: |
+      The buyer accepts the committed proposal via create_media_buy, supplying
+      start_time as the string literal "asap" (the spec-defined form from
+      start-timing.json). This verifies the seller's input-validation layer
+      accepts this form without rejecting it before the handler runs.
+
+      io_acceptance is intentionally omitted: it is only required when the
+      proposal's insertion_order carries requires_signature: true, and gating
+      this scenario on IO signing would conflate two independent conformance
+      checks. The io_acceptance path is covered by the proposal_finalize scenario.
+
+    steps:
+      - id: create_media_buy
+        title: "Create media buy from proposal — start_time: asap"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        comply_scenario: create_media_buy
+        stateful: true
+        expected: |
+          Convert the committed proposal into an active media buy:
+          - media_buy_id: the seller's identifier
+          - status: active
+          - confirmed_at: timestamp
+          - packages: line items derived from the proposal's budget allocations
+          - proposal_id: echoed back to confirm which proposal was accepted
+
+          The seller MUST accept start_time: "asap" (string literal) without
+          rejecting it at the wrapper/input-validation layer.
+
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          proposal_id: "$context.proposal_id"
+          total_budget:
+            amount: 50000
+            currency: "USD"
+          start_time: "asap"
+          end_time: "2026-06-30T23:59:59Z"
+
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_proposal_finalize_asap_timing_accept_proposal_create_media_buy"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema"

--- a/static/compliance/source/specialisms/sales-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-guaranteed/index.yaml
@@ -17,6 +17,7 @@ requires_scenarios:
   - media_buy_seller/inventory_list_no_match
   - media_buy_seller/invalid_transitions
   - media_buy_seller/proposal_finalize
+  - media_buy_seller/proposal_finalize_asap_timing
 
 # Cross-step assertion (adcp#2664). status.monotonic rejects resource
 # status transitions observed across steps that aren't on the spec

--- a/static/compliance/source/specialisms/sales-proposal-mode/index.yaml
+++ b/static/compliance/source/specialisms/sales-proposal-mode/index.yaml
@@ -10,6 +10,7 @@ required_tools:
   - create_media_buy
 requires_scenarios:
   - media_buy_seller/proposal_finalize
+  - media_buy_seller/proposal_finalize_asap_timing
   - media_buy_seller/delivery_reporting
   - media_buy_seller/measurement_terms_rejected
   - media_buy_seller/pending_creatives_to_start


### PR DESCRIPTION
Refs #4401

Extends `proposal_finalize` coverage to test `start_time: "asap"` (the spec-defined string literal from `start-timing.json`) on `create_media_buy`. The existing scenario only exercised ISO date strings; this variant catches wrapper-layer rejections of the `"asap"` form before the handler runs.

**Non-breaking justification:** Additive new storyboard scenario file and two `requires_scenarios` list entries. No existing scenario, schema field, or step kind is renamed or modified. Per playbook, additive conformance harness scenarios are patch-eligible.

**What changed:**
- New file: `static/compliance/source/protocols/media-buy/scenarios/proposal_finalize_asap_timing.yaml` — mirrors the `proposal_finalize` phases but the `accept_proposal` step sends `start_time: "asap"` instead of an ISO date. `io_acceptance` is intentionally omitted to isolate the timing check from the IO-signing path (which is already covered by `proposal_finalize`). Response field checks are intentionally limited to `response_schema` — behavioral verification of the create_media_buy response is the parent scenario's job; this variant only confirms the input layer does not reject `"asap"`.
- `sales-guaranteed/index.yaml` — added `media_buy_seller/proposal_finalize_asap_timing` to `requires_scenarios`
- `sales-proposal-mode/index.yaml` — same addition (specialism is deprecated in 3.1 per its narrative, but still active in 3.x)
- Changeset: `patch`

**Note on `{type: "asap"}` object form:** The issue body describes `{type: "asap"}` as an object form. That form is not in the spec: `start-timing.json` only allows the string `"asap"` or an ISO 8601 date-time string. The seller's Pydantic wrapper fix that widened signatures to accept the object form was defensive against out-of-spec buyer requests. This PR tests the spec-compliant string literal form only.

**Note on "no dates / carry-forward" arm:** The issue also mentions testing `create_media_buy` without explicit dates (carry-forward from proposal). This is not spec-valid: `start_time` and `end_time` are `required[]` unconditionally with no proposal-mode conditional. Whether to add one is a design decision for @bokelley — flagged as a follow-up.

**Milestone routing gap:** This is a `patch` changeset targeting the `3.0.x` line (conformance harness addition is patch-eligible per playbook). No open `3.0.X` patch milestone was found. Needs @bokelley to create one before merge, or redirect to `3.1.0` if preferred.

**Pre-PR review:**
- ad-tech-protocol-expert: approved — `start_time: "asap"` + ISO `end_time` is normatively valid; no cross-field constraint prohibits this combination; `patch` changeset is correct; `io_acceptance` removed per expert recommendation to avoid spurious failures on sellers without IO signing
- code-reviewer: approved (no blockers) — confirmed schema-valid wire shape, correct idempotency key seeds, correct `id`/`category` pattern, correct specialism index placement. Two issues fixed: removed "Wave 23.20" (possible real company name → rephrased to "an adopter"); added narrative note explaining intentionally sparse response validations.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01Ek4rwwuHRtRhDtNW6hxwac