### PR TITLE
chore(deps): bump @adcp/sdk to ^7.0.0

### DIFF
--- a/.changeset/adcp-sdk-7.0.0-bump.md
+++ b/.changeset/adcp-sdk-7.0.0-bump.md
@@ -1,0 +1,17 @@
+---
+"adcontextprotocol": patch
+---
+
+Bump `@adcp/sdk` from `^6.19.1` to `^7.0.0`.
+
+7.0.0 ships the SDK-side fixes for five compliance-harness issues we filed against `adcp-client` ([#1676](https://github.com/adcontextprotocol/adcp-client/issues/1676) – [#1680](https://github.com/adcontextprotocol/adcp-client/issues/1680)) after probing Wonderstruck against the AAO conformance suite:
+
+- `request-normalizer` no longer fabricates `account` from `brand.domain` on `create_media_buy` — missing `account` now throws `ValidationError` at the client boundary, per the AdCP 3.0 spec and the v2 sunset policy (#1676).
+- `PackageRequest` normalizer throws on the pre-3.0 `product_ids: string[]` and `budget: {total, currency}` shapes — there's no safe translation for these (which id wins? which currency?) so it fails closed (#1677).
+- Webhook storyboards skip cleanly when no `webhook_receiver` is configured instead of sending a relative `push_notification_config.url` and false-failing (#1678).
+- `ComplianceResult.failures[]` now carries the structured `adcp_error` payload + `validation` detail, so heartbeat output reveals real wire-level failures instead of dropping to `error: {}` (#1679).
+- Storyboards whose `required_tools` aren't all present in the agent's discovered toolset are graded `not_applicable` at the storyboard level, surfaced via `storyboards_missing_tools` / `storyboards_not_applicable` on the result root — they no longer cascade `partial` to the track (#1680).
+
+Net effect for AAO heartbeat output: false-positive passes go away (no more badges issued against fabricated-account requests), false-negative track drops go away (controller-dependent storyboards on agents that don't expose controller stop dragging unrelated tracks to `partial`), and failures become diagnosable from the heartbeat alone instead of needing a separate SDK-level probe.
+
+Typecheck clean, 873/873 unit tests pass on 7.0.0.

--- a/.github/workflows/training-agent-storyboards.yml
+++ b/.github/workflows/training-agent-storyboards.yml
@@ -62,7 +62,11 @@ jobs:
             min_passing_steps: 118
           - tenant: creative-builder
             min_clean_storyboards: 60
-            min_passing_steps: 100
+            # Dropped from 100 → 96 with @adcp/sdk 7.0: list_creatives and
+            # get_creative_delivery moved off CreativeBuilderPlatform onto
+            # CreativeAdServerPlatform, so /creative-builder no longer
+            # advertises them. Step count drop is exact (2 tools × 2 steps).
+            min_passing_steps: 96
           - tenant: brand
             min_clean_storyboards: 66
             min_passing_steps: 45

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.0.3",
       "dependencies": {
-        "@adcp/sdk": "^6.19.0",
+        "@adcp/sdk": "^7.0.0",
         "@anthropic-ai/sdk": "^0.91.1",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-6.19.0.tgz",
-      "integrity": "sha512-ASp1xEEiuSeCILCJHmVr8EUjNBEyqT76m2Qyc2e4Zus5DxJrruELkEO2FeGWwi0K/1UKSXUr5IJ7fYsrBY9Gmg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-7.0.0.tgz",
+      "integrity": "sha512-JPtXCjJhf1kpRk3JVJR1sKT1CXLzeai+z82ziC2Cq2jPfZQvcfdOoxaMBxm0hsDIudCns36YTi3llqSBXgp7sg==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "dev:docs": "node scripts/dev-docs.mjs"
   },
   "dependencies": {
-    "@adcp/sdk": "^6.19.0",
+    "@adcp/sdk": "^7.0.0",
     "@anthropic-ai/sdk": "^0.91.1",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",

--- a/scripts/run-storyboards-matrix.sh
+++ b/scripts/run-storyboards-matrix.sh
@@ -24,7 +24,7 @@ TENANTS=(
   "sales:67:258"
   "governance:65:102"
   "creative:66:118"
-  "creative-builder:60:100"
+  "creative-builder:60:96"
   "brand:66:45"
 )
 

--- a/server/src/training-agent/tenants/tool-catalog.ts
+++ b/server/src/training-agent/tenants/tool-catalog.ts
@@ -41,11 +41,15 @@ export const TOOL_CATALOG: Readonly<Record<string, readonly string[]>> = {
   list_creative_formats: ['sales', 'creative', 'creative-builder'],
 
   // creative — exposed on multiple tenants
-  list_creatives: ['sales', 'creative', 'creative-builder'],
+  // list_creatives / get_creative_delivery are sales-side / ad-server-side
+  // operations. SDK 7.0's `CreativeBuilderPlatform` interface dropped them
+  // (they live on `CreativeAdServerPlatform`); the /creative-builder tenant
+  // no longer advertises them in tools/list.
+  list_creatives: ['sales', 'creative'],
   sync_creatives: ['sales', 'creative', 'creative-builder'],
   build_creative: ['creative', 'creative-builder'],
   preview_creative: ['creative', 'creative-builder'],
-  get_creative_delivery: ['creative', 'creative-builder'],
+  get_creative_delivery: ['creative'],
 
   // signals — sync_governance rides customTools (governance-aware-seller pattern)
   sync_governance: ['signals'],


### PR DESCRIPTION
## Summary

Bumps \`@adcp/sdk\` from \`^6.19.1\` to \`^7.0.0\`, which ships the SDK-side fixes for the five compliance-harness issues filed against \`adcp-client\` after the Wonderstruck probe:

- adcp-client#1676 — \`request-normalizer\` no longer fabricates \`account\` from \`brand.domain\` on \`create_media_buy\`. Missing account now throws \`ValidationError\` at the client boundary, per the AdCP 3.0 spec + v2 sunset policy.
- adcp-client#1677 — \`PackageRequest\` normalizer fails closed on pre-3.0 \`product_ids: string[]\` and \`budget: {total, currency}\` shapes (no safe translation; which id wins, which currency?).
- adcp-client#1678 — Webhook storyboards skip cleanly when no \`webhook_receiver\` is configured instead of sending a relative URL and false-failing.
- adcp-client#1679 — \`ComplianceResult.failures[]\` carries structured \`adcp_error\` + \`validation\` detail, so heartbeat output reveals real wire-level failures.
- adcp-client#1680 — Storyboards whose \`required_tools\` aren't all in the discovered toolset are graded \`not_applicable\` and surfaced in \`storyboards_missing_tools\` / \`storyboards_not_applicable\` on the result root. No more cascading \`partial\`.

## What this changes for AAO grading

- **No more false-positive badges.** Previously, comply() against any 3.0-strict seller went through the account-fabrication shim and badges were issued against requests with invented \`account.operator\` data. Now those calls throw before they hit the wire.
- **No more cascading-partial false negatives.** Tracks like \`media_buy: 59/66 partial\` (where 7 of the 7 non-passing were controller-dependent storyboards on a non-governance agent) cleanly become \`media_buy: 59/59 + N missing-tool\`.
- **Diagnosable failures.** \`step.error = {}\` is replaced by structured \`failures[].adcp_error\` + \`failures[].validation\`, so an owner staring at a failing storyboard from the dashboard can see exactly what the seller rejected and why.

## Wonderstruck before/after

| | 6.19.0 | 7.0.0 |
|---|---|---|
| Scenarios run | 117 | 92 |
| Passing | 97 | ~83 |
| Empty \`{}\` errors | 9 | 0 (all carry \`adcp_error\` or \`validation\` detail) |
| Storyboards cleanly skipped (\`missing_tools\`) | 0 (chained mid-flight) | 11 (storyboard-level) |
| Real conformance gaps surfaced | 0 (hidden) | 52 (each diagnosable) |

The 52 surfaced failures are real Wonderstruck-side gaps (lowercase error codes, missing RFC 6750 auth metadata, no RFC 9421 signing, etc.) — 6.19.x was hiding them.

## Test plan

- [x] \`npx tsc --noEmit -p server/tsconfig.json\` — clean
- [x] \`npm run test:unit\` — 873/873 pass
- [x] Wonderstruck probe re-run end-to-end — confirms new behavior matches the filed issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)