### PR TITLE
test(registry-feed): filter assertions by actor to fix OR-filter flake (closes #4413)

### DIFF
--- a/.changeset/4413-registry-feed-flake-fix.md
+++ b/.changeset/4413-registry-feed-flake-fix.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only: fix flake in `registry-feed.test.ts > combines multiple type filters with OR`. The four assertions in the `type glob filtering` describe block now filter results to this file's actor (`actor.startsWith('test')`) before counting, matching the pattern the file's other tests already use (lines 57, 78). `queryFeed` doesn't expose an actor filter — by design, since actor isn't part of the public feed contract — so the assertion filter is the right surface to add it. Closes #4413.

--- a/server/tests/integration/registry-feed.test.ts
+++ b/server/tests/integration/registry-feed.test.ts
@@ -164,30 +164,40 @@ describe('Registry Feed Integration Tests', () => {
       ]);
     });
 
+    // queryFeed has no actor filter (by design — the public feed contract
+    // doesn't expose actor). The catalog_events table is shared with the
+    // background crawler and other test files that write non-`test%` events,
+    // so each assertion below filters to this file's actor before counting.
+    // Matches the pattern at lines 57 and 78 above.
+    const ours = (events: { actor: string }[]) =>
+      events.filter(e => e.actor.startsWith('test'));
+
     it('filters by exact event type', async () => {
       const feed = await eventsDb.queryFeed(null, ['property.created']);
       if ('error' in feed) throw new Error(feed.message);
-      expect(feed.events).toHaveLength(1);
-      expect(feed.events[0].event_type).toBe('property.created');
+      const seeded = ours(feed.events);
+      expect(seeded).toHaveLength(1);
+      expect(seeded[0].event_type).toBe('property.created');
     });
 
     it('filters by glob pattern', async () => {
       const feed = await eventsDb.queryFeed(null, ['property.*']);
       if ('error' in feed) throw new Error(feed.message);
-      expect(feed.events).toHaveLength(3);
-      expect(feed.events.every(e => e.event_type.startsWith('property.'))).toBe(true);
+      const seeded = ours(feed.events);
+      expect(seeded).toHaveLength(3);
+      expect(seeded.every(e => e.event_type.startsWith('property.'))).toBe(true);
     });
 
     it('combines multiple type filters with OR', async () => {
       const feed = await eventsDb.queryFeed(null, ['property.*', 'agent.*']);
       if ('error' in feed) throw new Error(feed.message);
-      expect(feed.events).toHaveLength(4);
+      expect(ours(feed.events)).toHaveLength(4);
     });
 
     it('returns empty for non-matching type', async () => {
       const feed = await eventsDb.queryFeed(null, ['nonexistent.*']);
       if ('error' in feed) throw new Error(feed.message);
-      expect(feed.events).toHaveLength(0);
+      expect(ours(feed.events)).toHaveLength(0);
       expect(feed.has_more).toBe(false);
     });
   });


### PR DESCRIPTION
## Summary

Fixes the flake in \`server/tests/integration/registry-feed.test.ts > Registry Feed Integration Tests > type glob filtering > combines multiple type filters with OR\` that's been failing on \`main\` and every PR ([example failing run on main](https://github.com/adcontextprotocol/adcp/actions/runs/25687949037), [example on PR #4412](https://github.com/adcontextprotocol/adcp/actions/runs/25692443410)).

## Root cause

The four assertions in the \`type glob filtering\` describe block were checking \`feed.events\` length directly. \`queryFeed\` has no actor filter — by design, since actor isn't part of the public feed contract — so when other test files (the background crawler in particular, which the server boots at integration test start) write \`property.*\` or \`agent.*\` events with non-\`test%\` actors, those events end up in the result and skew the count.

The file already filters by actor in two earlier tests (line 57: \`feed.events.filter(e => e.actor.startsWith('test'))\`; line 78: \`feed.events.filter(e => e.actor === 'test')\`) precisely because the cleanup hook (\`DELETE FROM catalog_events WHERE actor LIKE 'test%'\`) is intentionally scoped — see the comments at lines 19-23 explaining sibling test files writing trigger-generated events with \`actor LIKE 'trigger:%'\`.

The OR-filter assertion has the lowest noise tolerance because its expected count (4) is closest to what crawler-written events can push the unfiltered total to (consistently observed as 9 = 4 seeded + 5 crawler-leaked). The narrower filter assertions in the same block (expected 1 and 3) happen to pass because their type filters don't catch the crawler's event types as aggressively.

## Fix

Add an \`ours\` helper that filters by actor before counting, applied to all four assertions in the describe block:

\`\`\`ts
const ours = (events: { actor: string }[]) =>
  events.filter(e => e.actor.startsWith('test'));
\`\`\`

This makes all four assertions robust to whatever the leak source is, without changing what they test — they were always testing \"my seeded events + this filter\", which is what the new assertions check explicitly.

## Test plan

- [x] Local run against a fresh Postgres: \`10/10 tests pass in registry-feed.test.ts\` (was 9/10 with the OR test failing).
- [x] Typecheck clean, no other test files touched.
- [x] Pattern matches what the file's other tests already use, so future readers won't be surprised.

Closes #4413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)