### PR TITLE
feat(schema): add optional currency and total_budget to create/update media buy success responses

### DIFF
--- a/.changeset/fix-create-update-media-buy-currency-total-budget.md
+++ b/.changeset/fix-create-update-media-buy-currency-total-budget.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add optional `currency` and `total_budget` fields to `CreateMediaBuySuccess` and `UpdateMediaBuySuccess` response schemas to match the entity shape already required by `get_media_buys`. Sellers using a shared mapper across create/list will now have these fields declared in the create and update schemas, eliminating silent Zod validation failures on `get_media_buys` poll steps.

--- a/static/schemas/source/media-buy/create-media-buy-response.json
+++ b/static/schemas/source/media-buy/create-media-buy-response.json
@@ -47,6 +47,16 @@
           "description": "Initial revision number for this media buy. Use in subsequent update_media_buy requests for optimistic concurrency.",
           "minimum": 1
         },
+        "currency": {
+          "type": "string",
+          "description": "ISO 4217 currency code (e.g., USD, EUR, GBP) for monetary values at this media buy level. total_budget is denominated in this currency. Package-level fields may override with package.currency. In proposal mode the seller derives this from the request's total_budget object (total_budget.currency); in manual mode it is present when all packages share a currency. Matches the currency field in subsequent get_media_buys responses.",
+          "pattern": "^[A-Z]{3}$"
+        },
+        "total_budget": {
+          "type": "number",
+          "description": "Total budget amount across all packages, denominated in currency. Note: the create_media_buy request encodes total_budget as an object {amount, currency} (proposal mode only); this response field is the flattened scalar amount, with currency promoted to the sibling currency field. Present when the seller can compute a deterministic aggregate — always in proposal mode, conditionally in manual mode when all packages share a currency. Matches the total_budget field in subsequent get_media_buys responses.",
+          "minimum": 0
+        },
         "valid_actions": {
           "type": "array",
           "description": "Actions the buyer can perform on this media buy after creation. Saves a round-trip to get_media_buys.",

--- a/static/schemas/source/media-buy/update-media-buy-response.json
+++ b/static/schemas/source/media-buy/update-media-buy-response.json
@@ -29,6 +29,16 @@
           "description": "Revision number after this update. Use this value in subsequent update_media_buy requests for optimistic concurrency.",
           "minimum": 1
         },
+        "currency": {
+          "type": "string",
+          "description": "ISO 4217 currency code for monetary values at this media buy level. Echoed when the update affects budget or currency. Matches the currency field in subsequent get_media_buys responses.",
+          "pattern": "^[A-Z]{3}$"
+        },
+        "total_budget": {
+          "type": "number",
+          "description": "Updated total budget amount across all packages, denominated in currency. Echoed when the update affects package budgets so buyers can verify the new aggregate without a round-trip to get_media_buys. Matches the total_budget field in subsequent get_media_buys responses.",
+          "minimum": 0
+        },
         "implementation_date": {
           "type": [
             "string",


### PR DESCRIPTION
Refs #4416

`CreateMediaBuySuccess` and `UpdateMediaBuySuccess` both lacked `currency` and `total_budget` in their properties declarations while `get-media-buys-response.json` required them. A seller using a shared mapper across create and list would either strip these fields (per the create schema) — causing silent Zod validation failures on every `get_media_buys` poll step — or include them as undocumented extensions. The Wave 23.20.7 compliance run reported 63/128 storyboard score with no server-side errors; all failures were Zod rejections at the runner layer.

**Non-breaking justification:** Adds two optional properties (`currency: string`, `total_budget: number`) to `CreateMediaBuySuccess` and `UpdateMediaBuySuccess`. Neither field is added to `required`. Both schemas already have `"additionalProperties": true`, so existing sellers returning these fields were not previously breaking; this change makes the declared shape match reality. No existing implementation needs to change to stay conformant.

**Open question for @bokelley (not in this PR):** The product expert argues `currency` and `total_budget` should be **required** in `CreateMediaBuySuccess`, particularly for proposal mode where both values are deterministic at creation time. Making them required is a breaking change (MAJOR bump — forces all `create_media_buy` sellers to emit these fields). This PR takes the non-breaking path; the required-upgrade question is left for WG decision. See issue #4416 for full context.

**Note on request/response shape difference:** The create request encodes `total_budget` as an object `{amount, currency}` (proposal mode only). The response flattens this into two sibling scalar fields — `total_budget: number` and `currency: string`. The field descriptions document this explicitly to prevent mis-implementation.

**Milestone:** Targets 3.1.0 (MINOR bump — additive optional fields on stable surface, not patch-eligible per the stable-schemas rule). Milestone not assigned; needs @bokelley to confirm milestone number.

**Build note:** Local build environment is missing `node_modules` (pre-existing — unrelated to this PR). Schema JSON validated syntactically via Python. CI will run the full schema build.

**Pre-PR review:**
- code-reviewer: approved — no blockers; fixed blocker re: `total_budget.currency` description ambiguity (request object vs. response scalar); 2 nits noted in PR body above
- ad-tech-protocol-expert: approved — non-breaking per spec; field naming, types, and pattern match `get-media-buys-response.json`; optional-on-write vs. required-on-read is consistent with OpenRTB `cur` echo pattern

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01QH73KwxYwPBV4uF551zAE1

---
_Generated by [Claude Code](https://claude.ai/code/session_01QH73KwxYwPBV4uF551zAE1)_