### PR TITLE
fix(compliance): add normative additionalProperties validator clause to runner-output-contract

### DIFF
--- a/.changeset/runner-output-contract-additionalproperties-must.md
+++ b/.changeset/runner-output-contract-additionalproperties-must.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": minor
+---
+
+Add normative `response_schema_validator_semantics` clause to `runner-output-contract.yaml`.
+
+Runners MUST apply the referenced JSON schema with a draft-07 compliant validator that honours the schema's own `additionalProperties` declaration without process-level override. Configuring AJV `removeAdditional: 'all'` or Zod `.strict()` on derived schema objects in a way that contradicts the schema's `additionalProperties: true` declaration is a conformance violation. Addresses issue #4419, where the comply runner produced false-negative verdicts for spec-valid seller responses that included optional or newly-added fields (`authorization`, `sandbox`).

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -410,8 +410,8 @@ validation_result:
       omission — draft-07 default is `true`), the runner MUST NOT fail a
       response that includes fields beyond those enumerated in `properties`.
       In draft-07, `oneOf` branch-selection does not grant a validator
-      licence to reject fields that are permitted by all branches'
-      `additionalProperties` declarations.
+      licence to apply stricter `additionalProperties` constraints than
+      those declared on the selected branch.
 
       Configuring the validator in a way that contradicts the schema's own
       `additionalProperties` declaration is a conformance violation of this

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -401,6 +401,34 @@ validation_result:
       not_applicable for the entire check (not just per-assertion). Use
       sparingly — see storyboard-schema.yaml > "upstream_traffic" >
       `attestation_mode_required` for the rationale.
+    response_schema_validator_semantics: |
+      Runners MUST apply the referenced JSON schema using a JSON Schema
+      draft-07 compliant validator configured to honour the schema's own
+      `additionalProperties` declaration without global override. When a
+      schema or any sub-schema reached via `$ref`, `allOf`, `oneOf`, or
+      `anyOf` declares `"additionalProperties": true` (explicitly or by
+      omission — draft-07 default is `true`), the runner MUST NOT fail a
+      response that includes fields beyond those enumerated in `properties`.
+      In draft-07, `oneOf` branch-selection does not grant a validator
+      licence to reject fields that are permitted by all branches'
+      `additionalProperties` declarations.
+
+      Configuring the validator in a way that contradicts the schema's own
+      `additionalProperties` declaration is a conformance violation of this
+      contract (e.g., AJV `removeAdditional: 'all'` or a schema-level
+      `additionalProperties: false` override; Zod `.strict()` on a derived
+      schema object). A seller returning a spec-valid response with optional
+      or newly-added fields (such as `authorization` or `sandbox` on
+      sync-accounts items) is conformant. A runner that fails such a
+      response because its internal schema representation is stricter than
+      the canonical JSON Schema produces a false negative that blocks
+      legitimate conformance progress.
+
+      The AdCP spec-side lint (`scripts/lint-storyboard-response-schema.cjs`,
+      AJV `strict: false`, no `removeAdditional`) sets the precedent. This
+      clause makes the same requirement normative for all conforming runners.
+      Any runner correctly implementing draft-07 JSON Schema validation
+      already satisfies it.
   optional_fields:
     - remediation             # runner-suggested fix when the failure maps to
                               # a well-known cause (e.g., "agent did not echo


### PR DESCRIPTION
Refs #4419

Adds a `response_schema_validator_semantics` normative note to `validation_result.notes` in `runner-output-contract.yaml`. The new MUST clause states that runners MUST apply the referenced JSON schema with a draft-07 compliant validator that honours the schema's own `additionalProperties` declaration without global process-level override. Configuring `AJV removeAdditional: 'all'` or Zod `.strict()` on derived schema objects in a way that contradicts `additionalProperties: true` is a conformance violation. This addresses the root cause of issue #4419, where the comply runner produced false-negative verdicts for spec-valid seller responses that included optional fields (`authorization`, `sandbox`). Also adds a sentence clarifying that `oneOf` branch-selection in draft-07 does not permit a validator to apply stricter constraints than those declared on the selected branch.

**Non-breaking justification:** Additive note to `validation_result.notes`. Any runner correctly implementing draft-07 JSON Schema validation already satisfies the new MUST; no conformant 3.0.x implementation needs to change behaviour to pass. Strict-mode runners (using `removeAdditional` or Zod `.strict()`) were already producing false-negative verdicts and were therefore non-conformant in behavior, not merely newly obligated.

**Changeset:** `minor` bump (`runner-output-contract-additionalproperties-must.md`). Note: bump level is debatable — `patch` if the IETF errata test fully applies (any conformant runner already satisfies it); `minor` if strict-mode runners that were previously passing on limited test suites now have a new explicit obligation. Reviewer to adjust.

**Known forward-merge impact:** `runner-output-contract.yaml` is in the known-divergent file list (playbook line 281). A push to `3.0.x` touching this file will require a manual forward-merge. Cherry-pick to `3.0.x` is recommended (the false-negative issue affects current 3.0.x adopters) but not included in this PR — that's a follow-up decision.

**Sibling-repo fix still needed:** `adcontextprotocol/adcp-client` — switch to `.passthrough()` Zod (or AJV `strict: false`, no `removeAdditional`) for schemas derived from JSON schemas with `additionalProperties: true`; regenerate to pick up `authorization` and other recently-added fields. adcp-client#831 (strict/lenient response-schema reporting) is the in-flight work. This PR alone closes the spec gap; the runtime fix ships via adcp-client.

**Pre-PR review:**
- code-reviewer: approved — YAML placement correct, draft-07 default claim accurate, lint reference accurate; `oneOf` sentence precision fixed per reviewer feedback; changeset present (`.changeset/runner-output-contract-additionalproperties-must.md`)
- ad-tech-protocol-expert: approved — patch-eligible clarification per draft-07 spec; `unevaluatedProperties` not needed (all AdCP schemas are draft-07, no occurrences of that keyword in the corpus); AJV `strict: true` vs. `removeAdditional` distinction clarified in final diff

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/cse_01QEyzziVGioJVzZoKe69BSD

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEyzziVGioJVzZoKe69BSD)_