### PR TITLE
fix(admin): adagents.json builder v3 validation + UX polish

### DIFF
--- a/.changeset/4421-adagents-builder-v3-validation-polish.md
+++ b/.changeset/4421-adagents-builder-v3-validation-polish.md
@@ -1,0 +1,14 @@
+---
+---
+
+adagents.json builder: fix 6 validation + UX issues from expert review of #4415.
+
+1. `importFile` now runs a validation pass on import: normalizes country codes (uppercase, dedup), warns about malformed encryption key x values, normalizes contact.domain to lowercase, shows a summary alert for any coerced entries. Reference-only stubs (authoritative_location with no authorized_agents) now refuse to import with a helpful message.
+2. Countries in `saveAgent`: `.filter(Boolean)` prevents empty tokens from trailing/double commas aborting save; `[...new Set(...)]` deduplicates before schema uniqueItems validation.
+3. Half-filled encryption key rows (kid without x or vice versa) now alert with the row index at save time rather than silently dropping the row.
+4. Signing key JSON parse failures now alert with the row index at save time instead of silently omitting the key.
+5. `contact.domain` normalized to lowercase on save (schema requires lowercase host syntax).
+6. `adagents-manager.test.ts`: 5 new tests for v3 fields round-tripping through `createAdAgentsJson` and `validateProposed` (exclusive, countries, effective dates, signing_keys).
+7. `renderAgents` template literal: escaped agent.url, authorized_for, delegation_type, tagNames, propNames with `escapeHtml()` to close a self-XSS vector on imported malicious files.
+
+Refs #4421.

--- a/server/public/adagents-builder.html
+++ b/server/public/adagents-builder.html
@@ -2275,14 +2275,14 @@
                     <div class="dashboard-card">
                         <div class="dashboard-card-content">
                             <div class="dashboard-card-title">
-                                ${icon} ${prop.property_id}
+                                ${icon} ${escapeHtml(prop.property_id)}
                             </div>
                             <div class="dashboard-card-meta">
-                                ${formatPropertyType(prop.property_type)} • ${prop.name}
+                                ${escapeHtml(formatPropertyType(prop.property_type))} • ${escapeHtml(prop.name)}
                             </div>
                             <div class="dashboard-card-meta" style="font-size: 13px; color: var(--color-text-muted);">
                                 ${identifierCount} identifier${identifierCount > 1 ? 's' : ''}
-                                ${prop.tags && prop.tags.length > 0 ? ` • Tags: ${prop.tags.join(', ')}` : ''}
+                                ${prop.tags && prop.tags.length > 0 ? ` • Tags: ${escapeHtml(prop.tags.join(', '))}` : ''}
                             </div>
                             <div class="dashboard-card-tags">
                                 ${assignmentTag}
@@ -2382,7 +2382,7 @@
                     <div class="dashboard-card" style="display: inline-block; min-width: 200px; margin-right: 12px; margin-bottom: 12px;">
                         <div class="dashboard-card-content">
                             <div class="dashboard-card-title">
-                                🏷️ ${tag}
+                                🏷️ ${escapeHtml(tag)}
                             </div>
                             <div class="dashboard-card-meta" style="font-size: 13px; color: var(--color-text-muted);">
                                 Used by ${propertyCount} ${propertyCount === 1 ? 'property' : 'properties'}
@@ -2399,9 +2399,13 @@
         // Update bulk tag select dropdown
         const bulkSelect = document.getElementById('bulk-tag-select');
         if (bulkSelect) {
-          bulkSelect.innerHTML =
-            '<option value="">Select a tag...</option>' +
-            state.tags.map(tag => `<option value="${tag}">${tag}</option>`).join('');
+          bulkSelect.innerHTML = '<option value="">Select a tag...</option>';
+          state.tags.forEach(tag => {
+            const opt = document.createElement('option');
+            opt.value = tag;
+            opt.textContent = tag;
+            bulkSelect.appendChild(opt);
+          });
         }
       }
 
@@ -2436,19 +2440,19 @@
             }
 
             const tagDisplay = signal.tags && signal.tags.length > 0
-              ? `Tags: ${signal.tags.join(', ')}`
+              ? `Tags: ${escapeHtml(signal.tags.join(', '))}`
               : 'No tags';
 
             return `
               <div class="dashboard-card">
                 <div class="dashboard-card-content">
                   <div class="dashboard-card-title">
-                    ${icon} ${signal.id}
+                    ${icon} ${escapeHtml(signal.id)}
                   </div>
                   <div class="dashboard-card-meta">
-                    ${typeInfo} - ${signal.name}
+                    ${escapeHtml(typeInfo)} - ${escapeHtml(signal.name)}
                   </div>
-                  ${signal.description ? `<div class="dashboard-card-meta" style="font-size: 13px; color: var(--color-text-muted);">${signal.description.substring(0, 100)}${signal.description.length > 100 ? '...' : ''}</div>` : ''}
+                  ${signal.description ? `<div class="dashboard-card-meta" style="font-size: 13px; color: var(--color-text-muted);">${escapeHtml(signal.description.substring(0, 100))}${signal.description.length > 100 ? '...' : ''}</div>` : ''}
                   <div class="dashboard-card-meta" style="font-size: 13px; color: var(--color-text-muted);">
                     ${tagDisplay}
                   </div>
@@ -2485,7 +2489,7 @@
               <div class="dashboard-card" style="display: inline-block; min-width: 200px; margin-right: 12px; margin-bottom: 12px;">
                 <div class="dashboard-card-content">
                   <div class="dashboard-card-title">
-                    🏷️ ${tag}
+                    🏷️ ${escapeHtml(tag)}
                   </div>
                   <div class="dashboard-card-meta" style="font-size: 13px; color: var(--color-text-muted);">
                     Used by ${signalCount} ${signalCount === 1 ? 'signal' : 'signals'}
@@ -3459,6 +3463,7 @@
           textarea.dataset.sigIndex = String(i);
           textarea.style.cssText = 'flex:1;padding:6px;border:1px solid var(--color-border);border-radius:6px;font-size:12px;font-family:monospace;resize:vertical;';
           textarea.rows = 4;
+          textarea.maxLength = 16384;
           textarea.placeholder = '{"kid":"key-1","kty":"OKP","crv":"Ed25519","x":"base64url..."}';
           textarea.value = JSON.stringify(key, null, 2);
 

--- a/server/public/adagents-builder.html
+++ b/server/public/adagents-builder.html
@@ -2095,7 +2095,7 @@
         const tagId = document.getElementById('contact-tag-id').value.trim();
         if (name) contact.name = name;
         if (email) contact.email = email;
-        if (domain) contact.domain = domain;
+        if (domain) contact.domain = domain.toLowerCase();
         if (privacyPolicyUrl) contact.privacy_policy_url = privacyPolicyUrl;
         if (sellerId) contact.seller_id = sellerId;
         if (tagId) contact.tag_id = tagId;
@@ -2321,16 +2321,16 @@
               // Check if using tags (prefixed with 'tag:')
               const tagIds = agent.property_ids.filter(id => id.startsWith('tag:'));
               if (tagIds.length > 0) {
-                const tagNames = tagIds.map(id => id.replace('tag:', '')).join(', ');
+                const tagNames = escapeHtml(tagIds.map(id => id.replace('tag:', '')).join(', '));
                 propertyInfo = `<span class="dashboard-card-tag assigned">Can sell tags: ${tagNames}</span>`;
               } else {
                 // Regular property IDs
-                const propNames = agent.property_ids
+                const propNames = escapeHtml(agent.property_ids
                   .map(id => {
                     const prop = state.properties.find(p => p.property_id === id);
                     return prop ? prop.property_id : `${id} (missing)`;
                   })
-                  .join(', ');
+                  .join(', '));
                 propertyInfo = `<span class="dashboard-card-tag assigned">Can sell: ${propNames}</span>`;
               }
             }
@@ -2339,13 +2339,13 @@
                     <div class="dashboard-card">
                         <div class="dashboard-card-content">
                             <div class="dashboard-card-title">
-                                🤝 ${agent.url}
+                                🤝 ${escapeHtml(agent.url)}
                             </div>
                             <div class="dashboard-card-meta">
-                                ${agent.authorized_for}
+                                ${escapeHtml(agent.authorized_for)}
                             </div>
                             <div class="dashboard-card-tags">
-                                <span class="dashboard-card-tag">${agent.delegation_type || 'direct'}</span>
+                                <span class="dashboard-card-tag">${escapeHtml(agent.delegation_type || 'direct')}</span>
                                 ${propertyInfo}
                             </div>
                         </div>
@@ -3669,8 +3669,8 @@
 
         const countriesRaw = document.getElementById('agent-countries').value.trim();
         if (countriesRaw) {
-          const tokens = countriesRaw.split(',').map(c => c.trim().toUpperCase());
-          const countries = tokens.filter(c => /^[A-Z]{2}$/.test(c));
+          const tokens = countriesRaw.split(',').map(c => c.trim().toUpperCase()).filter(Boolean);
+          const countries = [...new Set(tokens.filter(c => /^[A-Z]{2}$/.test(c)))];
           const rejected = tokens.filter(c => !/^[A-Z]{2}$/.test(c));
           if (rejected.length > 0) {
             alert(`These country codes are not valid ISO 3166-1 alpha-2 and were ignored: ${rejected.join(', ')}\n\nOnly two-letter codes (e.g. US, CA, GB) are accepted.`);
@@ -3685,7 +3685,14 @@
         const effectiveUntil = document.getElementById('agent-effective-until').value;
         if (effectiveUntil) agent.effective_until = new Date(effectiveUntil).toISOString();
 
-        const encKeys = getEncryptionKeysFromForm().filter(k => k.kid && k.x);
+        const allEncKeys = getEncryptionKeysFromForm();
+        const halfFilledEncKey = allEncKeys.find(k => (k.kid && !k.x) || (!k.kid && k.x));
+        if (halfFilledEncKey) {
+          const rowIndex = allEncKeys.indexOf(halfFilledEncKey) + 1;
+          alert(`Encryption key row ${rowIndex}: both "kid" and "x" are required. Fill in the missing field or remove the row.`);
+          return;
+        }
+        const encKeys = allEncKeys.filter(k => k.kid && k.x);
         if (encKeys.length > 0) {
           const invalidKey = encKeys.find(k => !/^[A-Za-z0-9_-]+$/.test(k.x) || k.x.length < 43 || k.x.length > 44);
           if (invalidKey) {
@@ -3695,6 +3702,16 @@
           agent.encryption_keys = encKeys;
         }
 
+        const rawSigTextareas = document.querySelectorAll('#agent-signing-keys-list [data-sig-index]');
+        const sigParseErrors = [];
+        rawSigTextareas.forEach((ta, i) => {
+          if (!ta.value.trim()) return;
+          try { JSON.parse(ta.value); } catch (_) { sigParseErrors.push(i + 1); }
+        });
+        if (sigParseErrors.length > 0) {
+          alert(`Signing key row${sigParseErrors.length > 1 ? 's' : ''} ${sigParseErrors.join(', ')}: invalid JSON. Fix the typo or remove the row.`);
+          return;
+        }
         const sigKeys = getSigningKeysFromForm().filter(k => k.kid && k.kty);
         if (sigKeys.length > 0) agent.signing_keys = sigKeys;
 
@@ -3719,6 +3736,49 @@
       // JSON Import/Export
       // ============================================================================
 
+      // Normalize and validate data loaded at import time. Returns a list of
+      // warning strings for fields that were coerced or flagged. Invalid data
+      // is normalized where possible (e.g. uppercase countries) rather than
+      // dropped — the agent edit flow's save-time guards will catch anything
+      // that still needs attention.
+      function normalizeImportedData(data) {
+        const warnings = [];
+        (data.authorized_agents || []).forEach((agent, i) => {
+          const label = agent.url ? `Agent "${agent.url}"` : `Agent[${i}]`;
+
+          // Normalize and deduplicate country codes; warn about unrecognized tokens
+          if (Array.isArray(agent.countries)) {
+            const tokens = agent.countries.map(c => String(c).trim().toUpperCase()).filter(Boolean);
+            const valid = [...new Set(tokens.filter(c => /^[A-Z]{2}$/.test(c)))];
+            const bad = tokens.filter(c => !/^[A-Z]{2}$/.test(c));
+            if (bad.length > 0) {
+              warnings.push(`${label}: invalid country codes removed (${bad.join(', ')})`);
+            }
+            if (tokens.length !== valid.length && bad.length === 0) {
+              warnings.push(`${label}: duplicate country codes removed`);
+            }
+            agent.countries = valid.length > 0 ? valid : undefined;
+          }
+
+          // Warn about malformed encryption key x values (but keep them — the
+          // save-time guard surfaces the error when the publisher edits the agent)
+          if (Array.isArray(agent.encryption_keys)) {
+            agent.encryption_keys.forEach((k, ki) => {
+              if (k.x && (!/^[A-Za-z0-9_-]+$/.test(k.x) || k.x.length < 43 || k.x.length > 44)) {
+                warnings.push(`${label}: encryption key[${ki}] x is not a valid base64url X25519 value — review before saving`);
+              }
+            });
+          }
+        });
+
+        // Normalize contact.domain to lowercase
+        if (data.contact && data.contact.domain) {
+          data.contact.domain = data.contact.domain.toLowerCase();
+        }
+
+        return warnings;
+      }
+
       function importFile() {
         const input = document.createElement('input');
         input.type = 'file';
@@ -3729,6 +3789,19 @@
           reader.onload = event => {
             try {
               const data = JSON.parse(event.target.result);
+
+              if (!data || typeof data !== 'object' || (!data.authorized_agents && !data.authoritative_location)) {
+                alert('Import failed: file does not look like a valid adagents.json.');
+                return;
+              }
+
+              if (data.authoritative_location && !data.authorized_agents) {
+                alert(`This file is a URL reference stub pointing to:\n${data.authoritative_location}\n\nThe builder cannot edit reference-only files. Import the full file from that URL instead.`);
+                return;
+              }
+
+              const warnings = normalizeImportedData(data);
+
               state.agents = data.authorized_agents || [];
               state.properties = data.properties || [];
               state.signals = data.signals || [];
@@ -3761,7 +3834,11 @@
               state.signalTags = Array.from(signalTags).sort();
 
               render();
-              alert('File imported successfully!');
+              if (warnings.length > 0) {
+                alert(`File imported with ${warnings.length} issue${warnings.length > 1 ? 's' : ''} — review before exporting:\n\n${warnings.join('\n')}`);
+              } else {
+                alert('File imported successfully!');
+              }
             } catch (error) {
               alert(`Import failed: ${error.message}`);
             }

--- a/server/tests/unit/adagents-manager.test.ts
+++ b/server/tests/unit/adagents-manager.test.ts
@@ -1142,6 +1142,32 @@ describe('AdAgentsManager', () => {
       expect(json).toContain('  '); // Contains 2-space indentation
       expect(json.split('\n').length).toBeGreaterThan(1); // Multiple lines
     });
+
+    it('round-trips v3 agent fields (exclusive, countries, effective_from/until, signing_keys)', () => {
+      const agents: AuthorizedAgent[] = [
+        {
+          url: 'https://agent.example.com',
+          authorized_for: 'Premium inventory',
+          exclusive: true,
+          countries: ['US', 'CA', 'GB'],
+          effective_from: '2025-01-01T00:00:00.000Z',
+          effective_until: '2025-12-31T23:59:59.000Z',
+          signing_keys: [{ kid: 'key-1', kty: 'OKP', crv: 'Ed25519', x: 'base64urlvalue' }],
+        },
+      ];
+
+      const json = manager.createAdAgentsJson(agents, true, true);
+      const parsed = JSON.parse(json);
+      const agent = parsed.authorized_agents[0];
+
+      expect(agent.exclusive).toBe(true);
+      expect(agent.countries).toEqual(['US', 'CA', 'GB']);
+      expect(agent.effective_from).toBe('2025-01-01T00:00:00.000Z');
+      expect(agent.effective_until).toBe('2025-12-31T23:59:59.000Z');
+      expect(agent.signing_keys).toHaveLength(1);
+      expect(agent.signing_keys[0].kid).toBe('key-1');
+      expect(agent.signing_keys[0].kty).toBe('OKP');
+    });
   });
 
   describe('URL Reference Support', () => {
@@ -1404,6 +1430,71 @@ describe('AdAgentsManager', () => {
       // Empty string is treated as missing/required in JavaScript (falsy check)
       expect(result.valid).toBe(false);
       expect(result.errors.some(e => e.field.includes('.authorized_for') && e.message.includes('required'))).toBe(true);
+    });
+
+    it('accepts valid v3 agent fields', () => {
+      const agents: AuthorizedAgent[] = [
+        {
+          url: 'https://agent.example.com',
+          authorized_for: 'Premium inventory',
+          exclusive: true,
+          countries: ['US', 'CA'],
+          effective_from: '2025-01-01T00:00:00.000Z',
+          effective_until: '2025-12-31T23:59:59.000Z',
+          signing_keys: [{ kid: 'key-1', kty: 'OKP', crv: 'Ed25519', x: 'base64urlvalue' }],
+        },
+      ];
+
+      const result = manager.validateProposed(agents);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('rejects invalid country codes in proposal', () => {
+      const agents: AuthorizedAgent[] = [
+        {
+          url: 'https://agent.example.com',
+          authorized_for: 'Test',
+          countries: ['us', 'USA'] as any,
+        },
+      ];
+
+      const result = manager.validateProposed(agents);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.field.includes('.countries') && e.message.includes('ISO 3166-1 alpha-2'))).toBe(true);
+    });
+
+    it('rejects effective_until before effective_from', () => {
+      const agents: AuthorizedAgent[] = [
+        {
+          url: 'https://agent.example.com',
+          authorized_for: 'Test',
+          effective_from: '2025-06-01T00:00:00.000Z',
+          effective_until: '2025-01-01T00:00:00.000Z',
+        },
+      ];
+
+      const result = manager.validateProposed(agents);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.field.includes('.effective_until'))).toBe(true);
+    });
+
+    it('rejects malformed signing_keys entries', () => {
+      const agents: AuthorizedAgent[] = [
+        {
+          url: 'https://agent.example.com',
+          authorized_for: 'Test',
+          signing_keys: [{ kty: 'OKP' } as any],
+        },
+      ];
+
+      const result = manager.validateProposed(agents);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.field.includes('.signing_keys') && e.message.includes('kid'))).toBe(true);
     });
   });
 


### PR DESCRIPTION
Refs #4421

Six validation and UX fixes from expert review of PR #4415 (v2→v3 builder upgrade). All items were non-blocking at merge time; this PR cleans them up.

## Changes

**Item 1 — `importFile` validation bypass + `renderAgents` self-XSS**
- `importFile()` now calls `normalizeImportedData()` before loading state: uppercases and deduplicates country codes, warns about malformed `encryption_keys.x` values, lowercases `contact.domain`. Returns a summary alert listing any coerced entries (warn-and-import, not hard-reject).
- Reference-only stubs (`authoritative_location` with no `authorized_agents`) now refuse to load with a helpful message pointing to the actual file URL.
- Structural sanity check before loading (`authorized_agents` or `authoritative_location` must be present).
- `renderAgents()` template literal: wrapped `agent.url`, `agent.authorized_for`, `agent.delegation_type`, `tagNames`, `propNames` in the existing `escapeHtml()` helper to close a self-XSS vector in imported file rendering.

**Item 2 — Countries: dedupe + empty-token tolerance** (`saveAgent()`)
- Added `.filter(Boolean)` to remove empty tokens from trailing/double commas — previously aborted save with confusing "invalid code" error.
- Added `[...new Set(...)]` deduplication — schema `uniqueItems: true` would reject duplicates on strict validators.

**Item 3 — Half-filled encryption key rows silently dropped** (`saveAgent()`)
- Before `filter(k => k.kid && k.x)`, now checks for rows with one field filled but not the other and alerts with 1-based row index.

**Item 4 — Signing keys: silent JSON parse failure** (`saveAgent()`)
- Iterates `[data-sig-index]` textareas directly; alerts with 1-based row indices for any rows containing invalid JSON before `getSigningKeysFromForm()` silently drops them.

**Item 5 — `contact.domain` lowercase normalization** (`getContactFromForm()`)
- `.toLowerCase()` applied on save. Schema pattern requires lowercase host syntax.

**Item 6 — Test coverage for v3 fields** (`adagents-manager.test.ts`)
- `createAdAgentsJson`: new round-trip test for `exclusive`, `countries`, `effective_from/until`, `signing_keys`.
- `validateProposed`: 4 new tests — valid v3 fields accepted, invalid country codes rejected, `effective_until < effective_from` rejected, malformed `signing_keys` (missing `kid`) rejected.

## Non-breaking justification

All changes are in a client-side admin HTML tool (`server/public/`) and a server unit test file. No protocol schemas, no API contracts, no published spec surfaces touched. The worst failure mode is an additional alert box.

## Pre-PR review

- **code-reviewer**: approved — one blocker found and fixed (reference-only file import data loss); `renderAgents` escaping correct; countries dedup logic correct; signing-key parse-check logic correct; test `as any` casts appropriate.
- **internal-tools-strategist**: approved — all 6 items correctly implemented; item-by-item UX assessment confirms alert-on-save pattern is right for quarterly-use admin tool; `normalizeImportedData` mutation on fresh parse result is safe.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01RunY4jCVuW6pABsJZsBiXk

---
_Generated by [Claude Code](https://claude.ai/code/session_01RunY4jCVuW6pABsJZsBiXk)_