### PR TITLE
fix: stop two #admin-errors loggers (consistency reporter + slack invalid_blocks)

### DIFF
--- a/.changeset/admin-errors-quiet-consistency-and-invalid-blocks.md
+++ b/.changeset/admin-errors-quiet-consistency-and-invalid-blocks.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": patch
+---
+
+Stop two recurring `#admin-errors` log streams:
+
+- `network-consistency-reporter`: null-guard `extractDeclaredProperties` so brand rows with `brand_manifest IS NULL` no longer crash the worker with `Cannot read properties of null (reading 'brands')`. The outer org-selection query now filters `brand_manifest IS NOT NULL`, and the per-org loop drops manifest-less brands before picking `brands[0]`.
+
+- `announcement-trigger`: surface Slack's `response_metadata.messages` (the only place validation errors name the offending block/field) in the thrown `Error.message`, and add a redacted block-shape summary (per-block type + text/url/alt lengths) to the failure log. Bare `Slack API error: invalid_blocks` lines now carry actionable detail. Capped at 1KB to bound log size for pathological Slack responses, and `imageUrlLength` is only logged when the scheme is `https`. Header text is also clamped to Slack's 150-char `plain_text` cap so over-long `organizations.name` values can't push the header past the limit.

--- a/server/src/addie/jobs/announcement-trigger.ts
+++ b/server/src/addie/jobs/announcement-trigger.ts
@@ -205,6 +205,23 @@ export function sanitizeDraftForSlack(
   return out;
 }
 
+/**
+ * Slack `plain_text` cap on a `header` block. Exceeding it returns
+ * `invalid_blocks` with `must be no longer than 150 characters` —
+ * see https://api.slack.com/reference/block-kit/blocks#header.
+ */
+const SLACK_HEADER_MAX_LENGTH = 150;
+
+/**
+ * Truncate `s` to `max` chars, replacing the trailing char with `…`
+ * when truncated so the cutoff is visible. Returns `s` unchanged if
+ * already under the cap.
+ */
+function clampForHeader(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1).trimEnd() + '…';
+}
+
 export function buildReviewBlocks(args: {
   orgName: string;
   workosOrganizationId: string;
@@ -219,9 +236,15 @@ export function buildReviewBlocks(args: {
   const profileUrl = `${APP_URL}/members/${args.profileSlug}`;
   const safeSlack = sanitizeDraftForSlack(args.slackText);
   const safeLinkedIn = sanitizeDraftForSlack(args.linkedinText, { forFencedBlock: true });
-  const headerText = args.backfill
+  // `args.orgName` is `organizations.name` and is not length-clamped at
+  // source. The header `plain_text` block caps at 150 chars; an org name
+  // long enough to push past that returns `invalid_blocks` and the entire
+  // announcement post fails. Truncate the orgName portion (not the prefix)
+  // so the framing stays intact and only the name is shortened.
+  const rawHeader = args.backfill
     ? `[BACKFILL] New member announcement ready: ${args.orgName}`
     : `New member announcement ready: ${args.orgName}`;
+  const headerText = clampForHeader(rawHeader, SLACK_HEADER_MAX_LENGTH);
   const blocks: SlackBlock[] = [
     {
       type: 'header',

--- a/server/src/services/network-consistency-reporter.ts
+++ b/server/src/services/network-consistency-reporter.ts
@@ -52,10 +52,17 @@ interface ReportResult {
 /**
  * Extract declared properties from a brand.json structure.
  * Walks brands[].properties[] and collects identifier, type, and relationship.
+ *
+ * `brandJson` may be null/undefined or a non-object — brand rows can exist
+ * without a manifest (registry sync, manifest_orphaned trigger, partial
+ * onboarding). Treat those as "no declared properties" rather than throwing.
  */
-function extractDeclaredProperties(brandJson: Record<string, unknown>): DeclaredProperty[] {
+export function extractDeclaredProperties(
+  brandJson: Record<string, unknown> | null | undefined,
+): DeclaredProperty[] {
   const properties: DeclaredProperty[] = [];
 
+  if (!brandJson || typeof brandJson !== 'object') return properties;
   const brands = Array.isArray(brandJson.brands) ? brandJson.brands : [];
   for (const brand of brands) {
     if (!brand || typeof brand !== 'object') continue;
@@ -89,7 +96,7 @@ async function generateReportForOrg(
   brand: HostedBrand,
   orgAgentUrls: string[]
 ): Promise<{ report: networkHealthDb.NetworkConsistencyReport; alertsFired: number }> {
-  const brandJson = brand.brand_json as Record<string, unknown>;
+  const brandJson = brand.brand_json as Record<string, unknown> | null | undefined;
   const declared = extractDeclaredProperties(brandJson);
 
   // Build a set of domains the org's agents are authorized for (from crawl)
@@ -268,6 +275,7 @@ export async function generateNetworkConsistencyReports(
      FROM brands b
      JOIN organizations o ON o.workos_organization_id = b.workos_organization_id
      WHERE b.workos_organization_id IS NOT NULL
+       AND b.brand_manifest IS NOT NULL
      ORDER BY b.workos_organization_id
      LIMIT $1`,
     [limit]
@@ -277,8 +285,13 @@ export async function generateNetworkConsistencyReports(
     const orgId = row.workos_organization_id;
 
     try {
-      // Get org's brands and agent URLs
-      const brands = await brandDb.listHostedBrandsByOrg(orgId);
+      // Get org's brands and agent URLs. Skip brands without a manifest —
+      // they have no declared properties to report against, and passing
+      // a null `brand_json` to `generateReportForOrg` would log a noisy
+      // empty report. The outer SQL only guarantees the org has *some*
+      // brand with a manifest, not that brands[0] does.
+      const allBrands = await brandDb.listHostedBrandsByOrg(orgId);
+      const brands = allBrands.filter((b) => b.brand_json != null);
       if (brands.length === 0) {
         result.skipped++;
         continue;
@@ -289,7 +302,6 @@ export async function generateNetworkConsistencyReports(
         .filter(a => a.visibility === 'public' && a.url)
         .map(a => a.url);
 
-      // Generate report for the primary brand (first one)
       const primaryBrand = brands[0];
       const { alertsFired } = await generateReportForOrg(orgId, primaryBrand, agentUrls);
 

--- a/server/src/slack/client.ts
+++ b/server/src/slack/client.ts
@@ -138,14 +138,25 @@ async function slackRequest<T>(
  * this they're discarded into the void and the caller logs a bare
  * "Slack API error: invalid_blocks" with no diagnosis.
  */
+/** Cap on the joined metadata string so a pathological Slack response
+ *  (very many failing blocks, very long validator strings) can't push
+ *  multi-KB text into `Error.message` and on through `logger.error` to
+ *  `#admin-errors`. 1024 bytes is enough for ~5 typical validator
+ *  messages with JSON pointers. */
+const SLACK_METADATA_SUMMARY_MAX_LENGTH = 1024;
+
 export function formatSlackResponseMetadata(data: unknown): string {
   const md = (data as { response_metadata?: { messages?: unknown } })?.response_metadata;
   const messages = md?.messages;
   if (!Array.isArray(messages) || messages.length === 0) return '';
-  const summary = messages
+  let summary = messages
     .filter((m): m is string => typeof m === 'string')
     .join('; ');
-  return summary ? ` (${summary})` : '';
+  if (!summary) return '';
+  if (summary.length > SLACK_METADATA_SUMMARY_MAX_LENGTH) {
+    summary = summary.slice(0, SLACK_METADATA_SUMMARY_MAX_LENGTH - 1) + '…';
+  }
+  return ` (${summary})`;
 }
 
 /**
@@ -626,8 +637,12 @@ function summarizeBlocksForLog(
       summary.textLength = b.text.text.length;
     }
     if (b.image_url != null) {
-      summary.imageUrlLength = b.image_url.length;
-      summary.imageUrlScheme = b.image_url.split(':', 1)[0];
+      const scheme = b.image_url.split(':', 1)[0];
+      summary.imageUrlScheme = scheme;
+      // Only log length for https URLs. If `isSafeVisualUrl` ever
+      // regresses and a `data:` URL slips through, the base64 payload
+      // length is itself a fingerprint we don't want in #admin-errors.
+      if (scheme === 'https') summary.imageUrlLength = b.image_url.length;
     }
     if (b.alt_text != null) {
       summary.altTextLength = b.alt_text.length;

--- a/server/src/slack/client.ts
+++ b/server/src/slack/client.ts
@@ -103,7 +103,7 @@ async function slackRequest<T>(
           continue;
         }
 
-        throw new Error(`Slack API error: ${data.error}`);
+        throw new Error(`Slack API error: ${data.error}${formatSlackResponseMetadata(data)}`);
       }
 
       return data;
@@ -127,6 +127,25 @@ async function slackRequest<T>(
   }
 
   throw new Error(`Slack API request failed after ${retries} retries`);
+}
+
+/**
+ * Format Slack's `response_metadata.messages` (an array of validation
+ * detail strings) into a single trailing fragment for the thrown
+ * `Error.message`. Slack returns these for `invalid_blocks`,
+ * `invalid_arguments`, and a few other validation errors — they are
+ * the only place that names *which* block or field failed. Without
+ * this they're discarded into the void and the caller logs a bare
+ * "Slack API error: invalid_blocks" with no diagnosis.
+ */
+export function formatSlackResponseMetadata(data: unknown): string {
+  const md = (data as { response_metadata?: { messages?: unknown } })?.response_metadata;
+  const messages = md?.messages;
+  if (!Array.isArray(messages) || messages.length === 0) return '';
+  const summary = messages
+    .filter((m): m is string => typeof m === 'string')
+    .join('; ');
+  return summary ? ` (${summary})` : '';
 }
 
 /**
@@ -165,7 +184,7 @@ async function slackPostRequest<T>(
           continue;
         }
 
-        throw new Error(`Slack API error: ${data.error}`);
+        throw new Error(`Slack API error: ${data.error}${formatSlackResponseMetadata(data)}`);
       }
 
       return data;
@@ -576,9 +595,48 @@ export async function sendChannelMessage(
     return { ok: true, ts: response.ts };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    logger.error({ error, channelId }, 'Failed to send Slack channel message');
+    logger.error(
+      {
+        error,
+        channelId,
+        blockSummary: summarizeBlocksForLog(message.blocks),
+        textLength: message.text?.length ?? 0,
+      },
+      'Failed to send Slack channel message',
+    );
     return { ok: false, error: errorMessage };
   }
+}
+
+/**
+ * Build a redacted block-shape summary for error logs. Captures the
+ * fields Slack's block validator most often rejects (text length,
+ * image_url length, alt_text length, element counts) without leaking
+ * draft content into application logs. Use only inside an error path
+ * where the original send already failed.
+ */
+function summarizeBlocksForLog(
+  blocks: SlackBlockMessage['blocks'],
+): Array<Record<string, unknown>> {
+  if (!Array.isArray(blocks)) return [];
+  return blocks.map((b, index) => {
+    const summary: Record<string, unknown> = { index, type: b.type };
+    if (b.text?.text != null) {
+      summary.textType = b.text.type;
+      summary.textLength = b.text.text.length;
+    }
+    if (b.image_url != null) {
+      summary.imageUrlLength = b.image_url.length;
+      summary.imageUrlScheme = b.image_url.split(':', 1)[0];
+    }
+    if (b.alt_text != null) {
+      summary.altTextLength = b.alt_text.length;
+    }
+    if (Array.isArray(b.elements)) {
+      summary.elementCount = b.elements.length;
+    }
+    return summary;
+  });
 }
 
 /**

--- a/tests/announcement/announcement-trigger.test.ts
+++ b/tests/announcement/announcement-trigger.test.ts
@@ -112,6 +112,33 @@ describe('buildReviewBlocks', () => {
     expect(byId.get('announcement_mark_linkedin')?.style).toBeUndefined();
   });
 
+  it('clamps the header to Slack\'s 150-char plain_text cap', () => {
+    // Org names come from organizations.name and are not length-clamped
+    // at source. An overly long name used to push the header text past
+    // Slack's 150-char limit and the whole post failed with
+    // `invalid_blocks`.
+    const longName = 'A'.repeat(200);
+    const { blocks } = buildReviewBlocks({ ...base, orgName: longName });
+    const header = blocks.find((b) => b.type === 'header');
+    expect(header?.text?.type).toBe('plain_text');
+    expect(header?.text?.text.length).toBeLessThanOrEqual(150);
+    expect(header?.text?.text.endsWith('…')).toBe(true);
+  });
+
+  it('leaves short headers untouched (no trailing ellipsis)', () => {
+    const { blocks } = buildReviewBlocks(base);
+    const header = blocks.find((b) => b.type === 'header');
+    expect(header?.text?.text).toBe('New member announcement ready: Acme Ad Tech');
+  });
+
+  it('clamps backfill headers too — prefix counts against the 150 cap', () => {
+    const longName = 'A'.repeat(200);
+    const { blocks } = buildReviewBlocks({ ...base, orgName: longName, backfill: true });
+    const header = blocks.find((b) => b.type === 'header');
+    expect(header?.text?.text.length).toBeLessThanOrEqual(150);
+    expect(header?.text?.text.startsWith('[BACKFILL]')).toBe(true);
+  });
+
   it('neutralizes @channel, user tags, and backticks injected into drafts', () => {
     const hostile = {
       ...base,

--- a/tests/services/network-consistency-reporter.test.ts
+++ b/tests/services/network-consistency-reporter.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { extractDeclaredProperties } from '../../server/src/services/network-consistency-reporter.js';
+
+describe('extractDeclaredProperties', () => {
+  it('returns [] when brand_json is null (brand row without a manifest)', () => {
+    // Brand rows can exist without a manifest (registry sync,
+    // manifest_orphaned trigger, partial onboarding). The worker
+    // previously crashed with "Cannot read properties of null
+    // (reading 'brands')" when this happened.
+    expect(extractDeclaredProperties(null)).toEqual([]);
+    expect(extractDeclaredProperties(undefined)).toEqual([]);
+  });
+
+  it('returns [] when brand_json is not an object', () => {
+    // Defensive: the column is JSONB so this is unreachable in
+    // practice, but the type signature allows `unknown` callers.
+    expect(extractDeclaredProperties('not-an-object' as unknown as Record<string, unknown>)).toEqual([]);
+  });
+
+  it('returns [] when brands key is missing or not an array', () => {
+    expect(extractDeclaredProperties({})).toEqual([]);
+    expect(extractDeclaredProperties({ brands: 'oops' })).toEqual([]);
+  });
+
+  it('extracts identifier, type, and relationship from each property', () => {
+    const out = extractDeclaredProperties({
+      brands: [
+        {
+          properties: [
+            { identifier: 'acme.com', type: 'website', relationship: 'owned' },
+            { identifier: 'partner.com', type: 'website', relationship: 'delegated' },
+          ],
+        },
+      ],
+    });
+    expect(out).toEqual([
+      { identifier: 'acme.com', type: 'website', relationship: 'owned' },
+      { identifier: 'partner.com', type: 'website', relationship: 'delegated' },
+    ]);
+  });
+
+  it('defaults type to "website" and relationship to "owned"', () => {
+    const out = extractDeclaredProperties({
+      brands: [{ properties: [{ identifier: 'acme.com' }] }],
+    });
+    expect(out).toEqual([
+      { identifier: 'acme.com', type: 'website', relationship: 'owned' },
+    ]);
+  });
+
+  it('skips properties without an identifier', () => {
+    const out = extractDeclaredProperties({
+      brands: [
+        {
+          properties: [
+            { type: 'website' },
+            { identifier: '', type: 'website' },
+            { identifier: 'ok.com' },
+          ],
+        },
+      ],
+    });
+    expect(out.map((p) => p.identifier)).toEqual(['ok.com']);
+  });
+});

--- a/tests/slack/format-response-metadata.test.ts
+++ b/tests/slack/format-response-metadata.test.ts
@@ -43,4 +43,17 @@ describe('formatSlackResponseMetadata', () => {
     });
     expect(out).toBe(' (ok; fine)');
   });
+
+  it('caps the summary so pathological responses can\'t flood Error.message', () => {
+    // Many blocks failing at once can return very long messages; we
+    // don't want multi-KB text traveling through `logger.error` into
+    // #admin-errors.
+    const longMsg = 'x'.repeat(2000);
+    const out = formatSlackResponseMetadata({
+      response_metadata: { messages: [longMsg] },
+    });
+    // 2 chars for the wrapping " ()" + capped summary
+    expect(out.length).toBeLessThanOrEqual(1024 + 3);
+    expect(out.endsWith('…)')).toBe(true);
+  });
 });

--- a/tests/slack/format-response-metadata.test.ts
+++ b/tests/slack/format-response-metadata.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { formatSlackResponseMetadata } from '../../server/src/slack/client.js';
+
+describe('formatSlackResponseMetadata', () => {
+  it('joins messages into a parenthesised suffix', () => {
+    // Slack returns the only diagnosis of *which* field/block failed
+    // inside `response_metadata.messages`. Without surfacing this the
+    // worker logs a bare "Slack API error: invalid_blocks" and we
+    // have no way to tell whether the header was over the 150-char
+    // cap, an image_url was unreachable, or a section text overran.
+    const out = formatSlackResponseMetadata({
+      ok: false,
+      error: 'invalid_blocks',
+      response_metadata: {
+        messages: [
+          '[ERROR] must be no longer than 150 characters [json-pointer:/blocks/0/text/text]',
+        ],
+      },
+    });
+    expect(out).toBe(
+      ' ([ERROR] must be no longer than 150 characters [json-pointer:/blocks/0/text/text])',
+    );
+  });
+
+  it('joins multiple messages with semicolons', () => {
+    const out = formatSlackResponseMetadata({
+      response_metadata: { messages: ['first', 'second', 'third'] },
+    });
+    expect(out).toBe(' (first; second; third)');
+  });
+
+  it('returns an empty string when there is no metadata', () => {
+    expect(formatSlackResponseMetadata({})).toBe('');
+    expect(formatSlackResponseMetadata({ response_metadata: {} })).toBe('');
+    expect(formatSlackResponseMetadata({ response_metadata: { messages: [] } })).toBe('');
+    expect(formatSlackResponseMetadata(null)).toBe('');
+    expect(formatSlackResponseMetadata(undefined)).toBe('');
+  });
+
+  it('ignores non-string entries in messages', () => {
+    const out = formatSlackResponseMetadata({
+      response_metadata: { messages: ['ok', 42, null, 'fine'] },
+    });
+    expect(out).toBe(' (ok; fine)');
+  });
+});


### PR DESCRIPTION
## Summary

Two unrelated production errors hammering `#admin-errors`:

### 1. `network-consistency-reporter` — null deref on missing `brand_manifest`

The worker crashed every cycle with `Cannot read properties of null (reading 'brands')`:

```
TypeError: Cannot read properties of null (reading 'brands')
    at extractDeclaredProperties (network-consistency-reporter.js:31:44)
    at generateReportForOrg (network-consistency-reporter.js:58:22)
```

Root cause: `extractDeclaredProperties` dereferenced `brandJson.brands` without a null guard, and `brand.brand_json` (the row's `brand_manifest` column, aliased) can be `NULL`. PR #4386 added the `JOIN organizations` filter for deleted orgs but didn't filter on `brand_manifest IS NOT NULL`. Org `org_01KC9AYD5P38KXNH23BKRS1T0N` had such a row.

Three-layer fix, matching the playbook:
- Read-side null-guard in `extractDeclaredProperties` (tolerates `null` / `undefined` / non-object).
- Outer query filters `b.brand_manifest IS NOT NULL` so we don't queue an org whose only brand has no manifest.
- Per-org loop drops manifest-less brands before picking `brands[0]` — the outer query only guarantees the *org* has *some* manifest brand, not that `brands[0]` does.

### 2. `announcement-trigger` — `Slack API error: invalid_blocks` with no diagnosis

Slack's response carries `response_metadata.messages` listing exactly which block/field failed validation, but `slackPostRequest` was throwing only `data.error` and dropping the detail. Two months of `invalid_blocks` alerts with zero way to tell which block was wrong.

- `formatSlackResponseMetadata` threads `response_metadata.messages` into the thrown `Error.message` so existing `logger.error` calls capture it.
- `sendChannelMessage` error path now logs a **redacted block-shape summary** (per-block type + text/url/alt lengths) so future failures tell us which block needs fixing even when Slack omits metadata.
- Header text clamped to Slack's 150-char `plain_text` cap. `organizations.name` is unbounded at source, and `[BACKFILL] New member announcement ready: ${orgName}` exceeds 150 chars when `orgName > ~108`. Strongest hypothesis for the current failures, and a cheap pre-emptive fix while the diagnostic plumbing confirms.

## Test plan

- [x] `vitest run tests/announcement/announcement-trigger.test.ts tests/services/network-consistency-reporter.test.ts tests/slack/format-response-metadata.test.ts` — 29 passed
- [x] `tsc --project server/tsconfig.json --noEmit` — clean
- [x] Pre-commit hook (unit + dynamic-imports + callapi-lint + typecheck) — passed
- [ ] After deploy: confirm `#admin-errors` rate drops for both `network-consistency-reporter` and `announcement-trigger`. If the announcement Slack post still fails, the next `invalid_blocks` log line will name the specific block + field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)