### PR TITLE
feat(member): self-service domain add+verify via WorkOS DNS challenge

### DIFF
--- a/.changeset/member-self-service-domain-verify.md
+++ b/.changeset/member-self-service-domain-verify.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add `POST /api/me/organization/domains` (issue WorkOS DNS-TXT challenge) and `POST /:domain/verify` (confirm + flip `verified=true source='workos'`) so owners and admins can attach and verify a new brand domain from `/member-profile` without admin intervention. The existing `PUT /:domain/primary` already accepts `source='workos'` rows, so once the member verifies they can set primary themselves and the dashboard's Public visibility toggle unblocks. The issue path is cross-tenant safe: it pre-checks for a local row owned by another org and returns 409 cleanly instead of transferring ownership without DNS proof. Verify has a 60s per-(org, domain) cooldown to stop agentic loops from polling on `still_pending`.

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -1251,7 +1251,7 @@
         ? `<span class="agent-visibility-upsell"><a href="/membership">Upgrade to Professional</a> to list publicly.</span>`
         : '';
       const brandNudge = canSetPublic && publicRequiresDomain
-        ? `<span class="agent-visibility-upsell">Set a <a href="/member-profile#brand-domain-input">primary brand domain</a> to publish publicly.</span>`
+        ? `<span class="agent-visibility-upsell">Verify a <a href="/member-profile#linked-domains-section">primary brand domain</a> to publish publicly.</span>`
         : '';
 
       return `<div class="agent-card-visibility">

--- a/server/public/member-profile.html
+++ b/server/public/member-profile.html
@@ -1742,6 +1742,8 @@
 
     async function loadLinkedDomains() {
       const section = document.getElementById('linked-domains-section');
+      const addCard = document.getElementById('linked-domains-add');
+      const isAdmin = currentOrgRole === 'owner' || currentOrgRole === 'admin';
       try {
         const resp = await fetch('/api/me/organization/domains', { credentials: 'include' });
         if (!resp.ok) {
@@ -1749,15 +1751,20 @@
           return;
         }
         const data = await resp.json();
-        if (!data.domains || data.domains.length === 0) {
-          // Personal orgs typically have 0 verified domains. Keep the section
-          // hidden rather than showing an empty-state — there's nothing
-          // actionable for them here.
+        const domains = Array.isArray(data.domains) ? data.domains : [];
+        // Show the section when there's something to read OR the caller can
+        // act (owner/admin). Zero-domain orgs with an admin viewer still need
+        // an entry point so they can add the first domain — the original
+        // gate hid the only path to make an agent Public.
+        if (domains.length === 0 && !isAdmin) {
           if (section) section.style.display = 'none';
           return;
         }
         if (section) section.style.display = 'block';
-        renderLinkedDomains(data.domains);
+        // Backend rejects non-admin POST/verify with 403; hide the Add card
+        // client-side too so non-admin viewers don't see a button that 403s.
+        if (addCard) addCard.style.display = isAdmin ? 'block' : 'none';
+        renderLinkedDomains(domains);
       } catch (err) {
         if (section) section.style.display = 'none';
       }
@@ -2480,10 +2487,9 @@
       // Populate brand identity section
       populateBrandSection(profile);
 
-      // Populate Linked Domains section. The section starts hidden and
-      // loadLinkedDomains() reveals it only when the API returns ≥1 row,
-      // so personal orgs (which usually have 0 verified domains) silently
-      // stay hidden — no extra gating needed here.
+      // Populate Linked Domains section. The section starts hidden;
+      // loadLinkedDomains() reveals it for owner/admin viewers (so they
+      // can add the first domain) and for any viewer when ≥1 row exists.
       loadLinkedDomains();
       document.getElementById('contact_email').value = profile.contact_email || '';
       // Set phone and trigger formatting

--- a/server/public/member-profile.html
+++ b/server/public/member-profile.html
@@ -906,6 +906,35 @@
               Domains your organization has verified via SSO. The primary domain drives auto-membership inference (employees signing up with this domain auto-link to your org) and seeds your brand identity.
             </p>
             <div id="linked-domains-list" style="margin-bottom: var(--space-4);"></div>
+
+            <!-- Add domain (DNS TXT challenge via WorkOS) -->
+            <div id="linked-domains-add" style="background: var(--color-bg-subtle); border: 1px solid var(--color-border); border-radius: var(--radius-md); padding: var(--space-4);">
+              <div style="font-weight: var(--font-semibold); color: var(--color-text-heading); margin-bottom: var(--space-2);">Add a domain</div>
+              <p style="font-size: var(--text-sm); color: var(--color-text-secondary); margin: 0 0 var(--space-3) 0;">
+                Prove your organization controls a new domain via a DNS TXT record. After verification you can set it as primary.
+              </p>
+              <div style="display: flex; gap: var(--space-2); align-items: stretch; flex-wrap: wrap;">
+                <input type="text" id="add-domain-input" placeholder="example.com" autocomplete="off" style="flex: 1 1 240px; min-width: 200px; padding: var(--space-2) var(--space-3); border: 1px solid var(--color-gray-300); border-radius: var(--radius-md); font-size: var(--text-sm); background: var(--color-bg-card); color: var(--color-text);">
+                <button type="button" id="add-domain-btn" onclick="addLinkedDomain()" style="padding: var(--space-2) var(--space-5); background: var(--color-brand); color: white; border: none; border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer; font-weight: var(--font-medium); white-space: nowrap;">Issue challenge</button>
+              </div>
+              <div id="add-domain-error" style="display: none; color: var(--color-error-600); font-size: var(--text-sm); margin-top: var(--space-2);"></div>
+
+              <!-- TXT record callout, shown after a challenge is issued -->
+              <div id="add-domain-challenge" style="display: none; margin-top: var(--space-4); background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: var(--radius-md); padding: var(--space-3);">
+                <div style="font-weight: var(--font-semibold); color: var(--color-text-heading); margin-bottom: var(--space-2);">Publish this DNS TXT record</div>
+                <p style="font-size: var(--text-sm); color: var(--color-text-secondary); margin: 0 0 var(--space-2) 0;">
+                  Add a TXT record at <code id="add-domain-host" style="background: var(--color-bg-subtle); padding: 1px 4px; border-radius: 3px;"></code> with the value below. DNS propagation can take 5–15 minutes.
+                </p>
+                <div style="position: relative;">
+                  <pre id="add-domain-token" style="background: var(--color-gray-900); color: var(--color-gray-100); padding: var(--space-3); border-radius: var(--radius-md); font-size: var(--text-sm); overflow-x: auto; margin: 0;"></pre>
+                  <button onclick="copyAddDomainToken()" style="position: absolute; top: var(--space-2); right: var(--space-2); padding: 4px 10px; background: var(--color-gray-700); color: white; border: none; border-radius: var(--radius-sm); font-size: 11px; cursor: pointer;">Copy</button>
+                </div>
+                <div style="margin-top: var(--space-3);">
+                  <button type="button" onclick="verifyAddedDomain()" id="add-domain-verify-btn" style="padding: var(--space-2) var(--space-5); background: var(--color-brand); color: white; border: none; border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer; font-weight: var(--font-medium);">Verify DNS</button>
+                  <span id="add-domain-verify-status" style="margin-left: var(--space-3); font-size: var(--text-sm);"></span>
+                </div>
+              </div>
+            </div>
           </div>
 
           <!-- Brand identity (companies only) -->
@@ -1744,9 +1773,12 @@
           ? '<span style="display: inline-block; padding: 2px 8px; background: var(--color-brand-bg); color: var(--color-primary-700); border-radius: var(--radius-sm); font-size: 11px; font-weight: var(--font-semibold);">Primary</span>'
           : '';
         const sourceLabel = d.source ? '<span style="color: var(--color-text-muted); font-size: var(--text-xs);">' + escapeHtml(d.source) + '</span>' : '';
-        const action = (!d.is_primary && d.verified)
-          ? '<button type="button" onclick="setLinkedDomainPrimary(\'' + escapeHtml(d.domain) + '\', this)" style="padding: var(--space-2) var(--space-4); background: var(--color-bg-subtle); color: var(--color-text-secondary); border: 1px solid var(--color-border); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer;">Set Primary</button>'
-          : '';
+        let action = '';
+        if (!d.verified) {
+          action = '<button type="button" onclick="verifyLinkedDomain(\'' + escapeHtml(d.domain) + '\', this)" style="padding: var(--space-2) var(--space-4); background: var(--color-bg-subtle); color: var(--color-text-secondary); border: 1px solid var(--color-border); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer;">Verify DNS</button>';
+        } else if (!d.is_primary) {
+          action = '<button type="button" onclick="setLinkedDomainPrimary(\'' + escapeHtml(d.domain) + '\', this)" style="padding: var(--space-2) var(--space-4); background: var(--color-bg-subtle); color: var(--color-text-secondary); border: 1px solid var(--color-border); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer;">Set Primary</button>';
+        }
         return (
           '<div style="display: flex; align-items: center; gap: var(--space-3); padding: var(--space-3) var(--space-4); background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: var(--radius-md); margin-bottom: var(--space-2);">' +
             '<div style="font-weight: var(--font-medium); color: var(--color-text-heading); flex-grow: 1;">' + escapeHtml(d.domain) + '</div>' +
@@ -1757,6 +1789,124 @@
           '</div>'
         );
       }).join('');
+    }
+
+    // Tracks the domain whose challenge is currently displayed in the
+    // "Publish this DNS TXT record" callout so the Verify button knows
+    // which domain to confirm.
+    let pendingChallengeDomain = null;
+
+    async function addLinkedDomain() {
+      const input = document.getElementById('add-domain-input');
+      const btn = document.getElementById('add-domain-btn');
+      const errEl = document.getElementById('add-domain-error');
+      const challengeEl = document.getElementById('add-domain-challenge');
+      const raw = (input.value || '').trim();
+      if (!raw) {
+        errEl.style.display = 'block';
+        errEl.textContent = 'Enter a domain';
+        return;
+      }
+      errEl.style.display = 'none';
+      btn.disabled = true;
+      const original = btn.textContent;
+      btn.textContent = 'Issuing...';
+      try {
+        const resp = await fetch('/api/me/organization/domains', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ domain: raw }),
+        });
+        const data = await resp.json().catch(function() { return {}; });
+        if (!resp.ok) {
+          errEl.style.display = 'block';
+          errEl.textContent = data.message || data.error || 'Failed to add domain';
+          return;
+        }
+        if (data.already_verified) {
+          challengeEl.style.display = 'none';
+          pendingChallengeDomain = null;
+          await loadLinkedDomains();
+          if (typeof loadProfile === 'function') loadProfile();
+          return;
+        }
+        pendingChallengeDomain = data.domain;
+        document.getElementById('add-domain-host').textContent = (data.verification_prefix || '_workos') + '.' + data.domain;
+        document.getElementById('add-domain-token').textContent = data.verification_token || '';
+        document.getElementById('add-domain-verify-status').textContent = '';
+        challengeEl.style.display = 'block';
+        await loadLinkedDomains();
+      } catch (err) {
+        errEl.style.display = 'block';
+        errEl.textContent = 'Failed to add domain: ' + err.message;
+      } finally {
+        btn.disabled = false;
+        btn.textContent = original;
+      }
+    }
+
+    function copyAddDomainToken() {
+      const text = document.getElementById('add-domain-token').textContent;
+      navigator.clipboard.writeText(text).then(function() {
+        const btn = event.target;
+        btn.textContent = 'Copied!';
+        setTimeout(function() { btn.textContent = 'Copy'; }, 2000);
+      });
+    }
+
+    async function verifyAddedDomain() {
+      if (!pendingChallengeDomain) return;
+      await runVerify(pendingChallengeDomain, document.getElementById('add-domain-verify-btn'), document.getElementById('add-domain-verify-status'));
+    }
+
+    async function verifyLinkedDomain(domain, btn) {
+      await runVerify(domain, btn, null);
+    }
+
+    async function runVerify(domain, btn, statusEl) {
+      const originalText = btn ? btn.textContent : '';
+      if (btn) { btn.disabled = true; btn.textContent = 'Checking...'; }
+      if (statusEl) { statusEl.textContent = ''; statusEl.style.color = ''; }
+      try {
+        const resp = await fetch('/api/me/organization/domains/' + encodeURIComponent(domain) + '/verify', {
+          method: 'POST',
+          credentials: 'include',
+        });
+        const data = await resp.json().catch(function() { return {}; });
+        if (!resp.ok) {
+          const msg = data.message || data.error || 'Verification failed';
+          if (statusEl) {
+            statusEl.style.color = 'var(--color-error-600)';
+            statusEl.textContent = msg;
+          } else {
+            alert(msg);
+          }
+          if (btn) { btn.disabled = false; btn.textContent = originalText; }
+          return;
+        }
+        if (statusEl) {
+          statusEl.style.color = 'var(--color-success-700)';
+          statusEl.textContent = 'Verified.';
+        }
+        // Clear the challenge UI if this was the pending one.
+        if (pendingChallengeDomain === domain) {
+          document.getElementById('add-domain-challenge').style.display = 'none';
+          document.getElementById('add-domain-input').value = '';
+          pendingChallengeDomain = null;
+        }
+        await loadLinkedDomains();
+        if (typeof loadProfile === 'function') loadProfile();
+      } catch (err) {
+        const msg = 'Failed to verify domain: ' + err.message;
+        if (statusEl) {
+          statusEl.style.color = 'var(--color-error-600)';
+          statusEl.textContent = msg;
+        } else {
+          alert(msg);
+        }
+        if (btn) { btn.disabled = false; btn.textContent = originalText; }
+      }
     }
 
     async function setLinkedDomainPrimary(domain, btn) {

--- a/server/src/routes/me-organization-domains.ts
+++ b/server/src/routes/me-organization-domains.ts
@@ -20,6 +20,7 @@ import { getPool } from '../db/client.js';
 import {
   setPrimaryDomain,
   upsertWorkosDomain,
+  linkDomain,
 } from '../db/organization-domains-db.js';
 import {
   assertClaimableBrandDomain,
@@ -27,6 +28,53 @@ import {
 } from '../services/identifier-normalization.js';
 
 const logger = createLogger('me-organization-domains');
+
+// In-process verify cooldown — mirrors the brand-claim service. DNS
+// propagation is minutes-scale; agentic loops that see `still_pending`
+// will retry immediately. A 60s floor between verify attempts on the
+// same (org, domain) costs a real user nothing and kills the loop.
+// Per-process — multi-instance deployments get a softer guarantee but
+// the route's auth gate is the trust boundary.
+const VERIFY_COOLDOWN_MS = 60_000;
+const VERIFY_COOLDOWN_MAX_ENTRIES = 10_000;
+const verifyAttemptTimes = new Map<string, number>();
+
+function cooldownKey(orgId: string, domain: string) {
+  return `${orgId}:${domain}`;
+}
+
+function trimVerifyAttempts(now: number) {
+  if (verifyAttemptTimes.size < VERIFY_COOLDOWN_MAX_ENTRIES) return;
+  for (const [k, t] of verifyAttemptTimes) {
+    if (now - t >= VERIFY_COOLDOWN_MS) verifyAttemptTimes.delete(k);
+  }
+  if (verifyAttemptTimes.size < VERIFY_COOLDOWN_MAX_ENTRIES) return;
+  const overflow = verifyAttemptTimes.size - VERIFY_COOLDOWN_MAX_ENTRIES + 1;
+  let dropped = 0;
+  for (const k of verifyAttemptTimes.keys()) {
+    if (dropped >= overflow) break;
+    verifyAttemptTimes.delete(k);
+    dropped++;
+  }
+}
+
+export function _resetVerifyCooldown() {
+  verifyAttemptTimes.clear();
+}
+
+// Returns true when `domain` is already linked to an organization other
+// than `orgId`. Used by the POST issue path to refuse cross-tenant
+// ownership transfer at issue time (before DNS proof). `linkDomain` would
+// also refuse, but a pre-check keeps us from leaking a WorkOS resource
+// for a domain we can't accept locally.
+async function crossOrgConflict(domain: string, orgId: string): Promise<boolean> {
+  const row = await getPool().query<{ workos_organization_id: string }>(
+    `SELECT workos_organization_id FROM organization_domains WHERE domain = $1 LIMIT 1`,
+    [domain],
+  );
+  if (row.rowCount === 0) return false;
+  return row.rows[0].workos_organization_id !== orgId;
+}
 
 export interface MeOrganizationDomainsRouterConfig {
   workos: WorkOS | null;
@@ -254,11 +302,14 @@ export function createMeOrganizationDomainsRouter(
         logger.warn({ err, orgId }, 'POST add domain: getOrganization failed, will attempt create');
       }
       const existingEntry = existingOrg?.domains.find(d => d.domain.toLowerCase() === normalizedDomain);
+
       if (existingEntry) {
         const stateStr = String(existingEntry.state);
         const verified = stateStr === 'verified' || stateStr === 'legacy_verified';
-        const tokenMissing = !existingEntry.verificationToken || !existingEntry.verificationPrefix;
         if (verified) {
+          // WorkOS confirms DNS proof for THIS org. That's the documented
+          // contract for transfer-on-conflict, so upsertWorkosDomain is safe
+          // even if a cross-org local row exists.
           await upsertWorkosDomain({ orgId, domain: normalizedDomain, verified: true });
           invalidateMemberContextCache();
           return res.json({
@@ -270,9 +321,23 @@ export function createMeOrganizationDomainsRouter(
             verification_strategy: existingEntry.verificationStrategy ?? null,
           });
         }
+        // Non-verified branches below MUST cross-check the local DB before
+        // writing — see comment near the create path.
+        const tokenMissing = !existingEntry.verificationToken || !existingEntry.verificationPrefix;
         if (!tokenMissing) {
-          // Mirror the local row so the GET list reflects the pending state.
-          await upsertWorkosDomain({ orgId, domain: normalizedDomain, verified: false });
+          const conflict = await crossOrgConflict(normalizedDomain, orgId);
+          if (conflict) {
+            return res.status(409).json({
+              error: 'domain_already_claimed',
+              message: 'This domain is already linked to another organization.',
+            });
+          }
+          await linkDomain({
+            orgId,
+            domain: normalizedDomain,
+            source: 'workos',
+            verified: false,
+          });
           return res.json({
             domain: normalizedDomain,
             state: stateStr,
@@ -295,14 +360,35 @@ export function createMeOrganizationDomainsRouter(
         }
       }
 
+      // Cross-org local conflict check BEFORE creating the WorkOS resource.
+      // `organization_domains` is the single-source-of-truth row for both
+      // brand identity and org-membership inference (#4159 Stage 2). At
+      // issue time we have no DNS proof, so we must not overwrite a row
+      // owned by another org — even one with `source='manual'` from an
+      // admin attach or the brands FK backfill. `upsertWorkosDomain` would
+      // silently transfer; `linkDomain` refuses transfer; an explicit
+      // pre-check returns 409 cleanly and avoids leaking a WorkOS resource.
+      const preConflict = await crossOrgConflict(normalizedDomain, orgId);
+      if (preConflict) {
+        return res.status(409).json({
+          error: 'domain_already_claimed',
+          message: 'This domain is already linked to another organization.',
+        });
+      }
+
       try {
         const created = await workos.organizationDomains.createOrganizationDomain({
           organizationId: orgId,
           domain: normalizedDomain,
         });
-        await upsertWorkosDomain({
+        // linkDomain (not upsertWorkosDomain) — leaves any same-org row
+        // alone (e.g. an existing source='manual' row stays as-is until
+        // the verify path provides DNS proof). Inserts source='workos'
+        // verified=false when no local row exists.
+        await linkDomain({
           orgId,
           domain: normalizedDomain,
+          source: 'workos',
           verified: false,
         });
         logger.info(
@@ -378,6 +464,23 @@ export function createMeOrganizationDomainsRouter(
         return res.status(400).json({ error: 'invalid_domain' });
       }
 
+      // 60s cooldown per (org, domain). DNS propagation is minutes-scale,
+      // so a tight retry loop only burns WorkOS quota and gives no new
+      // information. Same guard as brand-claim.ts.
+      const cdKey = cooldownKey(orgId, normalizedDomain);
+      const now = Date.now();
+      const last = verifyAttemptTimes.get(cdKey);
+      if (last !== undefined && now - last < VERIFY_COOLDOWN_MS) {
+        const retryAfterSeconds = Math.ceil((VERIFY_COOLDOWN_MS - (now - last)) / 1000);
+        return res.status(429).json({
+          error: 'still_pending',
+          message: `Hold off — wait ${retryAfterSeconds}s before re-checking. DNS propagation takes minutes; rapid retries don't help.`,
+          retry_after_seconds: retryAfterSeconds,
+        });
+      }
+      trimVerifyAttempts(now);
+      verifyAttemptTimes.set(cdKey, now);
+
       let org;
       try {
         org = await workos.organizations.getOrganization(orgId);
@@ -428,6 +531,9 @@ export function createMeOrganizationDomainsRouter(
         verified: true,
       });
       invalidateMemberContextCache();
+      // Clear the cooldown so a follow-up call (e.g. "verify, now set primary")
+      // doesn't have to wait out the loop-prevention window.
+      verifyAttemptTimes.delete(cdKey);
 
       logger.info(
         { orgId, domain: normalizedDomain, actor: req.user!.id, already_verified: alreadyVerified },

--- a/server/src/routes/me-organization-domains.ts
+++ b/server/src/routes/me-organization-domains.ts
@@ -1,18 +1,13 @@
 /**
  * Member-facing self-service for the org's linked domains.
  *
- * Mirrors the admin Set-Primary affordance from `admin-account-detail.html`
- * but scoped to the caller's own organization. The PUT path flips
- * `organization_domains.is_primary` — after the Stage 2 column drop, that
- * row drives both org-membership-inference and brand-identity, so a single
- * write sets the primary unambiguously.
- *
- * MVP scope: list + set-primary. Add (POST → WorkOS verification challenge)
- * and remove (DELETE) deferred to a follow-up — the WorkOS-side wiring is
- * materially more work than the read+set paths.
+ * Add (POST) issues a WorkOS DNS-TXT challenge and writes a pending row;
+ * verify (POST /:domain/verify) confirms the TXT record with WorkOS and
+ * flips `verified=true`. The existing PUT /:domain/primary then accepts
+ * the row because `source='workos'` matches the member self-service gate.
  *
  * Auth: WorkOS session OR Bearer API key (`requireAuth` handles both).
- * Role: GET allows any member; PUT requires owner/admin.
+ * Role: GET allows any member; POST/PUT require owner/admin.
  */
 
 import { Router } from 'express';
@@ -22,7 +17,10 @@ import { requireAuth } from '../middleware/auth.js';
 import { resolvePrimaryOrganization } from '../db/users-db.js';
 import { resolveUserOrgMembership } from '../utils/resolve-user-org-membership.js';
 import { getPool } from '../db/client.js';
-import { setPrimaryDomain } from '../db/organization-domains-db.js';
+import {
+  setPrimaryDomain,
+  upsertWorkosDomain,
+} from '../db/organization-domains-db.js';
 import {
   assertClaimableBrandDomain,
   canonicalizeBrandDomain,
@@ -198,6 +196,253 @@ export function createMeOrganizationDomainsRouter(
     } catch (err) {
       logger.error({ err }, 'PUT /api/me/organization/domains/:domain/primary failed');
       return res.status(500).json({ error: 'Failed to set primary domain' });
+    }
+  });
+
+  // POST /api/me/organization/domains — issue a WorkOS DNS-TXT challenge.
+  // Owner/admin only. On success, returns the prefix/token the caller must
+  // publish at `<prefix>.<domain>` IN TXT. Re-posting the same domain is
+  // idempotent: if a pending challenge already exists on WorkOS for this org
+  // we surface the existing token; if it's already verified we still write
+  // through to the local row (source='workos', verified=true).
+  router.post('/', requireAuth, async (req, res) => {
+    try {
+      const orgId = await resolveTargetOrgId(req, res);
+      if (!orgId) return;
+
+      const membership = await resolveUserOrgMembership(workos, req.user!.id, orgId);
+      if (!membership || (membership.role !== 'owner' && membership.role !== 'admin')) {
+        return res.status(403).json({
+          error: 'Not authorized',
+          message: 'Only owners and admins can add a domain',
+        });
+      }
+
+      if (!workos) {
+        return res.status(503).json({
+          error: 'workos_unavailable',
+          message: 'Domain verification is not configured on this deployment.',
+        });
+      }
+
+      const rawDomain = (req.body as Record<string, unknown>)?.domain;
+      if (typeof rawDomain !== 'string' || rawDomain.length === 0) {
+        return res.status(400).json({ error: 'invalid_domain', message: 'domain is required' });
+      }
+      let normalizedDomain: string;
+      try {
+        normalizedDomain = canonicalizeBrandDomain(rawDomain);
+        assertClaimableBrandDomain(normalizedDomain);
+      } catch (err) {
+        logger.debug({ err, rawDomain }, 'POST add domain: rejected non-claimable domain');
+        return res.status(400).json({
+          error: 'invalid_domain',
+          message: 'The domain is malformed or a shared platform / public-suffix domain that cannot be claimed.',
+        });
+      }
+      if (normalizedDomain.length > 253) {
+        return res.status(400).json({ error: 'invalid_domain' });
+      }
+
+      // Idempotent re-issue: WorkOS rejects duplicate creates, so check first.
+      // If a usable challenge already exists (or it's verified), return that
+      // state instead of failing on the create call below.
+      let existingOrg;
+      try {
+        existingOrg = await workos.organizations.getOrganization(orgId);
+      } catch (err) {
+        logger.warn({ err, orgId }, 'POST add domain: getOrganization failed, will attempt create');
+      }
+      const existingEntry = existingOrg?.domains.find(d => d.domain.toLowerCase() === normalizedDomain);
+      if (existingEntry) {
+        const stateStr = String(existingEntry.state);
+        const verified = stateStr === 'verified' || stateStr === 'legacy_verified';
+        const tokenMissing = !existingEntry.verificationToken || !existingEntry.verificationPrefix;
+        if (verified) {
+          await upsertWorkosDomain({ orgId, domain: normalizedDomain, verified: true });
+          invalidateMemberContextCache();
+          return res.json({
+            domain: normalizedDomain,
+            state: stateStr,
+            already_verified: true,
+            verification_token: null,
+            verification_prefix: null,
+            verification_strategy: existingEntry.verificationStrategy ?? null,
+          });
+        }
+        if (!tokenMissing) {
+          // Mirror the local row so the GET list reflects the pending state.
+          await upsertWorkosDomain({ orgId, domain: normalizedDomain, verified: false });
+          return res.json({
+            domain: normalizedDomain,
+            state: stateStr,
+            already_verified: false,
+            verification_token: existingEntry.verificationToken,
+            verification_prefix: existingEntry.verificationPrefix,
+            verification_strategy: existingEntry.verificationStrategy ?? 'dns',
+          });
+        }
+        // Broken state: pending but no token. Delete + recreate so the user
+        // gets a usable record. Same pattern as brand-claim.ts.
+        try {
+          await workos.organizationDomains.deleteOrganizationDomain(existingEntry.id);
+        } catch (err) {
+          logger.error({ err, orgId, domain: normalizedDomain }, 'Failed to delete broken pending domain');
+          return res.status(502).json({
+            error: 'workos_error',
+            message: 'Failed to clear a broken pending challenge for this domain. Try again or contact support.',
+          });
+        }
+      }
+
+      try {
+        const created = await workos.organizationDomains.createOrganizationDomain({
+          organizationId: orgId,
+          domain: normalizedDomain,
+        });
+        await upsertWorkosDomain({
+          orgId,
+          domain: normalizedDomain,
+          verified: false,
+        });
+        logger.info(
+          { orgId, domain: normalizedDomain, actor: req.user!.id, workos_domain_id: created.id },
+          'Issued domain verification challenge via member self-service',
+        );
+        return res.json({
+          domain: normalizedDomain,
+          state: String(created.state),
+          already_verified: false,
+          verification_token: created.verificationToken ?? null,
+          verification_prefix: created.verificationPrefix ?? null,
+          verification_strategy: created.verificationStrategy ?? 'dns',
+        });
+      } catch (err: any) {
+        const status = err?.status ?? err?.response?.status;
+        const body = err?.response?.data ?? err?.rawResponse ?? null;
+        const code = body?.code ?? '';
+        const message = String(body?.message ?? err?.message ?? '');
+        const looksLikeCollision =
+          code === 'organization_domain_already_used'
+          || /already\s+(?:exists|used|associated|attached|registered)/i.test(message)
+          || /belongs\s+to\s+another/i.test(message);
+        if ((status === 422 || status === 409) && looksLikeCollision) {
+          return res.status(409).json({
+            error: 'domain_already_claimed',
+            message: 'This domain is already registered to another organization.',
+          });
+        }
+        if (status === 422 || status === 400) {
+          return res.status(400).json({
+            error: 'invalid_domain',
+            message: 'WorkOS rejected the domain as malformed.',
+          });
+        }
+        logger.error({ err, orgId, domain: normalizedDomain }, 'createOrganizationDomain failed');
+        return res.status(502).json({ error: 'workos_error', message: 'Failed to issue domain verification challenge.' });
+      }
+    } catch (err) {
+      logger.error({ err }, 'POST /api/me/organization/domains failed');
+      return res.status(500).json({ error: 'Failed to add domain' });
+    }
+  });
+
+  // POST /api/me/organization/domains/:domain/verify — confirm the DNS-TXT
+  // record with WorkOS. On success the local row flips to verified=true,
+  // which makes it eligible for PUT /:domain/primary above.
+  router.post('/:domain/verify', requireAuth, async (req, res) => {
+    try {
+      const orgId = await resolveTargetOrgId(req, res);
+      if (!orgId) return;
+
+      const membership = await resolveUserOrgMembership(workos, req.user!.id, orgId);
+      if (!membership || (membership.role !== 'owner' && membership.role !== 'admin')) {
+        return res.status(403).json({
+          error: 'Not authorized',
+          message: 'Only owners and admins can verify a domain',
+        });
+      }
+
+      if (!workos) {
+        return res.status(503).json({
+          error: 'workos_unavailable',
+          message: 'Domain verification is not configured on this deployment.',
+        });
+      }
+
+      let normalizedDomain: string;
+      try {
+        normalizedDomain = canonicalizeBrandDomain(req.params.domain);
+      } catch (err) {
+        logger.warn({ err, raw: req.params.domain }, 'Rejected invalid domain in verify');
+        return res.status(400).json({ error: 'invalid_domain' });
+      }
+
+      let org;
+      try {
+        org = await workos.organizations.getOrganization(orgId);
+      } catch (err) {
+        logger.error({ err, orgId, domain: normalizedDomain }, 'verify: getOrganization failed');
+        return res.status(502).json({ error: 'workos_error', message: 'Failed to look up organization.' });
+      }
+      const entry = org.domains.find(d => d.domain.toLowerCase() === normalizedDomain);
+      if (!entry) {
+        return res.status(404).json({
+          error: 'no_challenge',
+          message: 'No outstanding domain challenge for this organization. Issue one first.',
+        });
+      }
+
+      const stateStr = String(entry.state);
+      const alreadyVerified = stateStr === 'verified' || stateStr === 'legacy_verified';
+      let verifiedState = stateStr;
+      if (!alreadyVerified) {
+        try {
+          const verified = await workos.organizationDomains.verifyOrganizationDomain(entry.id);
+          verifiedState = String(verified.state);
+        } catch (err: any) {
+          const status = err?.status ?? err?.response?.status;
+          if (status === 422 || status === 400) {
+            return res.status(400).json({
+              error: 'still_pending',
+              message: 'WorkOS could not find a matching DNS TXT record. Make sure the prefix.domain TXT record is published, then retry.',
+              state: stateStr,
+            });
+          }
+          logger.error({ err, orgId, domain: normalizedDomain }, 'verifyOrganizationDomain failed');
+          return res.status(502).json({ error: 'workos_error', message: 'Failed to verify domain.' });
+        }
+      }
+
+      if (verifiedState !== 'verified' && verifiedState !== 'legacy_verified') {
+        return res.status(400).json({
+          error: 'still_pending',
+          message: 'WorkOS has not confirmed the DNS record yet. DNS propagation can take 5-15 minutes.',
+          state: verifiedState,
+        });
+      }
+
+      await upsertWorkosDomain({
+        orgId,
+        domain: normalizedDomain,
+        verified: true,
+      });
+      invalidateMemberContextCache();
+
+      logger.info(
+        { orgId, domain: normalizedDomain, actor: req.user!.id, already_verified: alreadyVerified },
+        'Verified domain via member self-service',
+      );
+
+      return res.json({
+        success: true,
+        domain: normalizedDomain,
+        newly_verified: !alreadyVerified,
+        state: verifiedState,
+      });
+    } catch (err) {
+      logger.error({ err }, 'POST /api/me/organization/domains/:domain/verify failed');
+      return res.status(500).json({ error: 'Failed to verify domain' });
     }
   });
 

--- a/server/tests/integration/me-organization-domains.test.ts
+++ b/server/tests/integration/me-organization-domains.test.ts
@@ -40,19 +40,35 @@ import express from 'express';
 import request from 'supertest';
 import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
 import { runMigrations } from '../../src/db/migrate.js';
-import { createMeOrganizationDomainsRouter } from '../../src/routes/me-organization-domains.js';
+import {
+  createMeOrganizationDomainsRouter,
+  _resetVerifyCooldown,
+} from '../../src/routes/me-organization-domains.js';
 import type { Pool } from 'pg';
 
 const TEST_ORG = 'org_me_domains_test';
+const OTHER_ORG = 'org_me_domains_other';
 const OWNER_USER = 'user_dev_admin_001';
 const MEMBER_USER = 'user_dev_member_001';
 
 async function cleanup(pool: Pool) {
-  await pool.query('DELETE FROM organization_domains WHERE workos_organization_id = $1', [TEST_ORG]);
-  await pool.query('DELETE FROM organization_memberships WHERE workos_organization_id = $1', [TEST_ORG]);
-  await pool.query('DELETE FROM member_profiles WHERE workos_organization_id = $1', [TEST_ORG]);
+  await pool.query(
+    'DELETE FROM organization_domains WHERE workos_organization_id = ANY($1)',
+    [[TEST_ORG, OTHER_ORG]],
+  );
+  await pool.query(
+    'DELETE FROM organization_memberships WHERE workos_organization_id = ANY($1)',
+    [[TEST_ORG, OTHER_ORG]],
+  );
+  await pool.query(
+    'DELETE FROM member_profiles WHERE workos_organization_id = ANY($1)',
+    [[TEST_ORG, OTHER_ORG]],
+  );
   await pool.query('DELETE FROM brands WHERE domain LIKE $1', ['me-domains-%.test']);
-  await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [TEST_ORG]);
+  await pool.query(
+    'DELETE FROM organizations WHERE workos_organization_id = ANY($1)',
+    [[TEST_ORG, OTHER_ORG]],
+  );
 }
 
 async function seedOrgWithDomains(pool: Pool, domains: Array<{ domain: string; verified: boolean; is_primary: boolean; source?: string }>) {
@@ -337,6 +353,7 @@ describe('POST /api/me/organization/domains (issue + verify challenge)', () => {
   beforeEach(async () => {
     await cleanup(pool);
     cacheInvalidations = 0;
+    _resetVerifyCooldown();
   });
 
   it('issues a WorkOS DNS challenge and writes a pending source=workos row', async () => {
@@ -623,5 +640,165 @@ describe('POST /api/me/organization/domains (issue + verify challenge)', () => {
       .set('x-test-user', OWNER_USER);
     expect(primaryRes.status).toBe(200);
     expect(primaryRes.body.primary_domain).toBe('me-domains-new.test');
+  });
+
+  it('refuses to overwrite a local row owned by another org (cross-tenant safety)', async () => {
+    // Threat model: Org B has a local-only row for `me-domains-shared.test`
+    // (e.g. admin-imported, source='import'). WorkOS doesn't know about it.
+    // Org A's owner POSTs the same domain. Without the pre-check, the
+    // ownership-transfer-on-conflict semantic of upsertWorkosDomain would
+    // silently move the row to Org A. We expect 409, with Org B's row
+    // untouched. The transfer-on-conflict primitive is reserved for the
+    // verify path, where WorkOS confirms DNS proof.
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+       VALUES ($1, $2, false, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      [TEST_ORG, 'Me Domains Test Co'],
+    );
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+       VALUES ($1, $2, false, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      [OTHER_ORG, 'Other Org'],
+    );
+    await pool.query(
+      `INSERT INTO organization_domains (workos_organization_id, domain, verified, is_primary, source, created_at, updated_at)
+       VALUES ($1, $2, true, true, 'import', NOW(), NOW())
+       ON CONFLICT (domain) DO UPDATE SET verified = EXCLUDED.verified, is_primary = EXCLUDED.is_primary, source = EXCLUDED.source`,
+      [OTHER_ORG, 'me-domains-shared.test'],
+    );
+    await seedProfile(pool);
+    await seedMembership(pool, OWNER_USER, 'owner');
+
+    const app = buildApp(() => { cacheInvalidations += 1; }, makeFakeWorkos());
+
+    const res = await request(app)
+      .post('/api/me/organization/domains?org=' + TEST_ORG)
+      .set('x-test-user', OWNER_USER)
+      .send({ domain: 'me-domains-shared.test' });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('domain_already_claimed');
+
+    // Other org's row is untouched.
+    const row = await pool.query<{ workos_organization_id: string; source: string; is_primary: boolean }>(
+      `SELECT workos_organization_id, source, is_primary FROM organization_domains WHERE domain = $1`,
+      ['me-domains-shared.test'],
+    );
+    expect(row.rowCount).toBe(1);
+    expect(row.rows[0].workos_organization_id).toBe(OTHER_ORG);
+    expect(row.rows[0].source).toBe('import');
+    expect(row.rows[0].is_primary).toBe(true);
+  });
+
+  it('detects WorkOS collision via the message-regex fallback (no code field)', async () => {
+    // WorkOS sometimes returns 422 with a plain-English message and no
+    // structured `code`. The route falls back to a regex match on the
+    // message body. Without this test the regex can silently rot.
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+       VALUES ($1, $2, false, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      [TEST_ORG, 'Me Domains Test Co'],
+    );
+    await seedProfile(pool);
+    await seedMembership(pool, OWNER_USER, 'owner');
+
+    const fakeWorkos = makeFakeWorkos();
+    const collisionErr: any = new Error('Domain already used');
+    collisionErr.status = 422;
+    collisionErr.response = { data: { message: 'Domain belongs to another organization' } };
+    fakeWorkos.setCreateError(collisionErr);
+    const app = buildApp(() => { cacheInvalidations += 1; }, fakeWorkos);
+
+    const res = await request(app)
+      .post('/api/me/organization/domains?org=' + TEST_ORG)
+      .set('x-test-user', OWNER_USER)
+      .send({ domain: 'me-domains-collide.test' });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('domain_already_claimed');
+  });
+
+  it('deletes and recreates a broken pending WorkOS entry (no verification token)', async () => {
+    // Broken state on WorkOS: a domain is attached but verificationToken /
+    // verificationPrefix are null. Returning the broken state would echo
+    // nulls back to the user forever. The route deletes the broken entry
+    // and falls through to a fresh create.
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+       VALUES ($1, $2, false, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      [TEST_ORG, 'Me Domains Test Co'],
+    );
+    await seedProfile(pool);
+    await seedMembership(pool, OWNER_USER, 'owner');
+
+    const fakeWorkos = makeFakeWorkos([
+      {
+        id: 'org_domain_broken',
+        domain: 'me-domains-broken.test',
+        state: 'pending',
+        verificationToken: null,
+        verificationPrefix: null,
+        verificationStrategy: null,
+      },
+    ]);
+    const app = buildApp(() => { cacheInvalidations += 1; }, fakeWorkos);
+
+    const res = await request(app)
+      .post('/api/me/organization/domains?org=' + TEST_ORG)
+      .set('x-test-user', OWNER_USER)
+      .send({ domain: 'me-domains-broken.test' });
+
+    expect(res.status).toBe(200);
+    expect(typeof res.body.verification_token).toBe('string');
+    expect(res.body.verification_token.length).toBeGreaterThan(0);
+    expect(res.body.verification_prefix).toBe('_workos');
+    // Broken entry was deleted and a fresh one replaced it.
+    expect(fakeWorkos.state.domains).toHaveLength(1);
+    expect(fakeWorkos.state.domains[0].id).not.toBe('org_domain_broken');
+  });
+
+  it('rate-limits verify retries with a 60s cooldown', async () => {
+    // Agentic loops poll on still_pending. The cooldown stops them from
+    // burning WorkOS quota. A successful verify clears the cooldown so a
+    // follow-up "verify, then set primary" sequence doesn't have to wait.
+    await seedOrgWithDomains(pool, [
+      { domain: 'me-domains-new.test', verified: false, is_primary: false, source: 'workos' },
+    ]);
+    await seedProfile(pool);
+    await seedMembership(pool, OWNER_USER, 'owner');
+
+    const fakeWorkos = makeFakeWorkos([
+      {
+        id: 'org_domain_new',
+        domain: 'me-domains-new.test',
+        state: 'pending',
+        verificationToken: 'token123',
+        verificationPrefix: '_workos',
+        verificationStrategy: 'dns',
+      },
+    ]);
+    const pendingErr: any = new Error('not yet propagated');
+    pendingErr.status = 422;
+    fakeWorkos.setVerifyError(pendingErr);
+    const app = buildApp(() => { cacheInvalidations += 1; }, fakeWorkos);
+
+    const first = await request(app)
+      .post('/api/me/organization/domains/me-domains-new.test/verify?org=' + TEST_ORG)
+      .set('x-test-user', OWNER_USER);
+    expect(first.status).toBe(400);
+    expect(first.body.error).toBe('still_pending');
+
+    // Immediate retry — within the cooldown window. Should 429 without
+    // calling WorkOS again.
+    const second = await request(app)
+      .post('/api/me/organization/domains/me-domains-new.test/verify?org=' + TEST_ORG)
+      .set('x-test-user', OWNER_USER);
+    expect(second.status).toBe(429);
+    expect(second.body.error).toBe('still_pending');
+    expect(typeof second.body.retry_after_seconds).toBe('number');
   });
 });

--- a/server/tests/integration/me-organization-domains.test.ts
+++ b/server/tests/integration/me-organization-domains.test.ts
@@ -93,17 +93,71 @@ async function seedMembership(pool: Pool, userId: string, role: 'owner' | 'admin
   );
 }
 
-function buildApp(invalidateMemberContextCache: () => void) {
+function buildApp(invalidateMemberContextCache: () => void, workos: any = null) {
   const app = express();
   app.use(express.json());
   // requireAuth is replaced via vi.mock above; it reads x-test-user from
   // the request headers and populates req.user.
   const router = createMeOrganizationDomainsRouter({
-    workos: null,
+    workos,
     invalidateMemberContextCache,
   });
   app.use('/api/me/organization/domains', router);
   return app;
+}
+
+// Minimal WorkOS SDK stand-in for the add/verify routes. Each test seeds
+// the in-memory state and points the methods at it. Mirrors the real SDK
+// shapes used in the route (organizations.getOrganization,
+// organizationDomains.{create,verify,delete}OrganizationDomain).
+type FakeDomain = {
+  id: string;
+  domain: string;
+  state: string;
+  verificationToken: string | null;
+  verificationPrefix: string | null;
+  verificationStrategy: string | null;
+};
+
+function makeFakeWorkos(initial: FakeDomain[] = []) {
+  const state = { domains: initial.slice() };
+  const errors: { create?: any; verify?: any } = {};
+  return {
+    state,
+    setCreateError(err: any) { errors.create = err; },
+    setVerifyError(err: any) { errors.verify = err; },
+    organizations: {
+      async getOrganization(_orgId: string) {
+        return { domains: state.domains };
+      },
+    },
+    organizationDomains: {
+      async createOrganizationDomain({ domain }: { organizationId: string; domain: string }) {
+        if (errors.create) throw errors.create;
+        const created: FakeDomain = {
+          id: 'org_domain_' + Math.random().toString(36).slice(2, 10),
+          domain,
+          state: 'pending',
+          verificationToken: 'token_' + Math.random().toString(36).slice(2, 10),
+          verificationPrefix: '_workos',
+          verificationStrategy: 'dns',
+        };
+        state.domains.push(created);
+        return created;
+      },
+      async verifyOrganizationDomain(id: string) {
+        if (errors.verify) throw errors.verify;
+        const found = state.domains.find(d => d.id === id);
+        if (!found) throw Object.assign(new Error('not found'), { status: 404 });
+        found.state = 'verified';
+        return found;
+      },
+      async deleteOrganizationDomain(id: string) {
+        const idx = state.domains.findIndex(d => d.id === id);
+        if (idx >= 0) state.domains.splice(idx, 1);
+      },
+    },
+  };
 }
 
 describe('GET /api/me/organization/domains + PUT /:domain/primary', () => {
@@ -261,5 +315,313 @@ describe('GET /api/me/organization/domains + PUT /:domain/primary', () => {
       .set('x-test-user', OWNER_USER);
 
     expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/me/organization/domains (issue + verify challenge)', () => {
+  let pool: Pool;
+  let cacheInvalidations: number;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  }, 60000);
+
+  afterAll(async () => {
+    await cleanup(pool);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanup(pool);
+    cacheInvalidations = 0;
+  });
+
+  it('issues a WorkOS DNS challenge and writes a pending source=workos row', async () => {
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+       VALUES ($1, $2, false, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      [TEST_ORG, 'Me Domains Test Co'],
+    );
+    await seedProfile(pool);
+    await seedMembership(pool, OWNER_USER, 'owner');
+
+    const fakeWorkos = makeFakeWorkos();
+    const app = buildApp(() => { cacheInvalidations += 1; }, fakeWorkos);
+
+    const res = await request(app)
+      .post('/api/me/organization/domains?org=' + TEST_ORG)
+      .set('x-test-user', OWNER_USER)
+      .send({ domain: 'me-domains-new.test' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      domain: 'me-domains-new.test',
+      already_verified: false,
+      verification_prefix: '_workos',
+      verification_strategy: 'dns',
+    });
+    expect(typeof res.body.verification_token).toBe('string');
+    expect(res.body.verification_token.length).toBeGreaterThan(0);
+
+    const row = await pool.query<{ source: string; verified: boolean }>(
+      `SELECT source, verified FROM organization_domains WHERE workos_organization_id = $1 AND domain = $2`,
+      [TEST_ORG, 'me-domains-new.test'],
+    );
+    expect(row.rowCount).toBe(1);
+    expect(row.rows[0].source).toBe('workos');
+    expect(row.rows[0].verified).toBe(false);
+  });
+
+  it('rejects POST add from a non-owner/admin member', async () => {
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+       VALUES ($1, $2, false, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      [TEST_ORG, 'Me Domains Test Co'],
+    );
+    await seedProfile(pool);
+    await seedMembership(pool, MEMBER_USER, 'member');
+
+    const app = buildApp(() => { cacheInvalidations += 1; }, makeFakeWorkos());
+
+    const res = await request(app)
+      .post('/api/me/organization/domains?org=' + TEST_ORG)
+      .set('x-test-user', MEMBER_USER)
+      .send({ domain: 'me-domains-new.test' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects malformed / public-suffix domains', async () => {
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+       VALUES ($1, $2, false, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      [TEST_ORG, 'Me Domains Test Co'],
+    );
+    await seedProfile(pool);
+    await seedMembership(pool, OWNER_USER, 'owner');
+
+    const app = buildApp(() => { cacheInvalidations += 1; }, makeFakeWorkos());
+
+    const res = await request(app)
+      .post('/api/me/organization/domains?org=' + TEST_ORG)
+      .set('x-test-user', OWNER_USER)
+      .send({ domain: 'gmail.com' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_domain');
+  });
+
+  it('surfaces the existing token when a pending challenge already exists (idempotent)', async () => {
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+       VALUES ($1, $2, false, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      [TEST_ORG, 'Me Domains Test Co'],
+    );
+    await seedProfile(pool);
+    await seedMembership(pool, OWNER_USER, 'owner');
+
+    const fakeWorkos = makeFakeWorkos([
+      {
+        id: 'org_domain_existing',
+        domain: 'me-domains-new.test',
+        state: 'pending',
+        verificationToken: 'preexisting-token',
+        verificationPrefix: '_workos',
+        verificationStrategy: 'dns',
+      },
+    ]);
+    const app = buildApp(() => { cacheInvalidations += 1; }, fakeWorkos);
+
+    const res = await request(app)
+      .post('/api/me/organization/domains?org=' + TEST_ORG)
+      .set('x-test-user', OWNER_USER)
+      .send({ domain: 'me-domains-new.test' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.verification_token).toBe('preexisting-token');
+    expect(res.body.already_verified).toBe(false);
+
+    // Local row mirrors pending state at source=workos.
+    const row = await pool.query<{ source: string; verified: boolean }>(
+      `SELECT source, verified FROM organization_domains WHERE workos_organization_id = $1 AND domain = $2`,
+      [TEST_ORG, 'me-domains-new.test'],
+    );
+    expect(row.rows[0].source).toBe('workos');
+    expect(row.rows[0].verified).toBe(false);
+  });
+
+  it('returns 409 when WorkOS reports the domain belongs to another org', async () => {
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+       VALUES ($1, $2, false, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      [TEST_ORG, 'Me Domains Test Co'],
+    );
+    await seedProfile(pool);
+    await seedMembership(pool, OWNER_USER, 'owner');
+
+    const fakeWorkos = makeFakeWorkos();
+    const collisionErr: any = new Error('Domain already used');
+    collisionErr.status = 422;
+    collisionErr.response = { data: { code: 'organization_domain_already_used', message: 'already used' } };
+    fakeWorkos.setCreateError(collisionErr);
+    const app = buildApp(() => { cacheInvalidations += 1; }, fakeWorkos);
+
+    const res = await request(app)
+      .post('/api/me/organization/domains?org=' + TEST_ORG)
+      .set('x-test-user', OWNER_USER)
+      .send({ domain: 'me-domains-collide.test' });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('domain_already_claimed');
+  });
+
+  it('verify flips local row to verified=true and invalidates cache', async () => {
+    await seedOrgWithDomains(pool, [
+      { domain: 'me-domains-new.test', verified: false, is_primary: false, source: 'workos' },
+    ]);
+    await seedProfile(pool);
+    await seedMembership(pool, OWNER_USER, 'owner');
+
+    const fakeWorkos = makeFakeWorkos([
+      {
+        id: 'org_domain_new',
+        domain: 'me-domains-new.test',
+        state: 'pending',
+        verificationToken: 'token123',
+        verificationPrefix: '_workos',
+        verificationStrategy: 'dns',
+      },
+    ]);
+    const app = buildApp(() => { cacheInvalidations += 1; }, fakeWorkos);
+
+    const res = await request(app)
+      .post('/api/me/organization/domains/me-domains-new.test/verify?org=' + TEST_ORG)
+      .set('x-test-user', OWNER_USER);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ success: true, newly_verified: true, state: 'verified' });
+    expect(cacheInvalidations).toBe(1);
+
+    const row = await pool.query<{ verified: boolean; source: string }>(
+      `SELECT verified, source FROM organization_domains WHERE workos_organization_id = $1 AND domain = $2`,
+      [TEST_ORG, 'me-domains-new.test'],
+    );
+    expect(row.rows[0].verified).toBe(true);
+    expect(row.rows[0].source).toBe('workos');
+  });
+
+  it('verify returns still_pending when WorkOS finds no TXT record', async () => {
+    await seedOrgWithDomains(pool, [
+      { domain: 'me-domains-new.test', verified: false, is_primary: false, source: 'workos' },
+    ]);
+    await seedProfile(pool);
+    await seedMembership(pool, OWNER_USER, 'owner');
+
+    const fakeWorkos = makeFakeWorkos([
+      {
+        id: 'org_domain_new',
+        domain: 'me-domains-new.test',
+        state: 'pending',
+        verificationToken: 'token123',
+        verificationPrefix: '_workos',
+        verificationStrategy: 'dns',
+      },
+    ]);
+    const pendingErr: any = new Error('not yet propagated');
+    pendingErr.status = 422;
+    fakeWorkos.setVerifyError(pendingErr);
+    const app = buildApp(() => { cacheInvalidations += 1; }, fakeWorkos);
+
+    const res = await request(app)
+      .post('/api/me/organization/domains/me-domains-new.test/verify?org=' + TEST_ORG)
+      .set('x-test-user', OWNER_USER);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('still_pending');
+
+    const row = await pool.query<{ verified: boolean }>(
+      `SELECT verified FROM organization_domains WHERE workos_organization_id = $1 AND domain = $2`,
+      [TEST_ORG, 'me-domains-new.test'],
+    );
+    expect(row.rows[0].verified).toBe(false);
+  });
+
+  it('verify returns 404 when no WorkOS challenge exists', async () => {
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+       VALUES ($1, $2, false, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      [TEST_ORG, 'Me Domains Test Co'],
+    );
+    await seedProfile(pool);
+    await seedMembership(pool, OWNER_USER, 'owner');
+
+    const app = buildApp(() => { cacheInvalidations += 1; }, makeFakeWorkos());
+
+    const res = await request(app)
+      .post('/api/me/organization/domains/me-domains-never-issued.test/verify?org=' + TEST_ORG)
+      .set('x-test-user', OWNER_USER);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('no_challenge');
+  });
+
+  it('rejects verify from a non-owner/admin member', async () => {
+    await seedOrgWithDomains(pool, [
+      { domain: 'me-domains-new.test', verified: false, is_primary: false, source: 'workos' },
+    ]);
+    await seedProfile(pool);
+    await seedMembership(pool, MEMBER_USER, 'member');
+
+    const app = buildApp(() => { cacheInvalidations += 1; }, makeFakeWorkos());
+
+    const res = await request(app)
+      .post('/api/me/organization/domains/me-domains-new.test/verify?org=' + TEST_ORG)
+      .set('x-test-user', MEMBER_USER);
+
+    expect(res.status).toBe(403);
+  });
+
+  it('after verify, PUT /:domain/primary accepts the WorkOS-verified row', async () => {
+    // End-to-end seam: this is the original "why does this need admin?" path —
+    // a member-issued and member-verified domain should be promotable to
+    // primary without admin intervention.
+    await seedOrgWithDomains(pool, [
+      { domain: 'me-domains-existing.test', verified: true, is_primary: true, source: 'workos' },
+      { domain: 'me-domains-new.test', verified: false, is_primary: false, source: 'workos' },
+    ]);
+    await seedProfile(pool);
+    await seedMembership(pool, OWNER_USER, 'owner');
+
+    const fakeWorkos = makeFakeWorkos([
+      {
+        id: 'org_domain_new',
+        domain: 'me-domains-new.test',
+        state: 'pending',
+        verificationToken: 'token123',
+        verificationPrefix: '_workos',
+        verificationStrategy: 'dns',
+      },
+    ]);
+    const app = buildApp(() => { cacheInvalidations += 1; }, fakeWorkos);
+
+    const verifyRes = await request(app)
+      .post('/api/me/organization/domains/me-domains-new.test/verify?org=' + TEST_ORG)
+      .set('x-test-user', OWNER_USER);
+    expect(verifyRes.status).toBe(200);
+
+    const primaryRes = await request(app)
+      .put('/api/me/organization/domains/me-domains-new.test/primary?org=' + TEST_ORG)
+      .set('x-test-user', OWNER_USER);
+    expect(primaryRes.status).toBe(200);
+    expect(primaryRes.body.primary_domain).toBe('me-domains-new.test');
   });
 });


### PR DESCRIPTION
## Summary

- Adds `POST /api/me/organization/domains` (issue WorkOS DNS-TXT challenge) and `POST /:domain/verify` so owners/admins can attach and verify a new domain without admin intervention.
- Verified rows land at `source='workos'`, which the existing `PUT /:domain/primary` already accepts — once primary, the Public visibility toggle on the agent dashboard unblocks automatically.
- Linked Domains card on `/member-profile` gets an "Add a domain" form + per-row Verify button.

## Why

Today, admins are paged whenever a member wants to publicly list an MCP agent on a domain not auto-promoted from WorkOS SSO. The dashboard's Public toggle is gated on `organization_domains.is_primary=true` with `source='workos'` — the member self-service set-primary endpoint hard-codes `requireSource: ['workos']`. Without a member-issued WorkOS challenge, the only path was admin override.

Active escalation: Santhosh @ Affinity Answers wants to make his MCP agent Public; `affinityanswers.com` is admin-attached so he can't promote it himself. With this change he runs the DNS challenge in the UI and unblocks himself.

## Security model

The verify path keeps the documented `upsertWorkosDomain` ownership-transfer-on-conflict semantic — DNS proof is in hand, so a same-domain row on another org is correctly overridden. The **issue** path explicitly does NOT have DNS proof yet, so it:
1. Pre-checks for a cross-org local row and returns 409 cleanly (avoids leaking a WorkOS resource).
2. Uses `linkDomain` (refuses transfer on conflict) instead of `upsertWorkosDomain` for the local write.

Verify is rate-limited with the same 60s per-(org,domain) cooldown as `brand-claim.ts` to stop agentic loops from burning WorkOS quota on `still_pending`.

## What changed

- `server/src/routes/me-organization-domains.ts` — two new owner/admin-gated routes; in-process verify cooldown; cross-org pre-check; `linkDomain` at issue time.
- `server/public/member-profile.html` — Add-domain form with TXT record callout (host + token + copy button) and Verify DNS button; pending rows in the list get a per-row Verify button. Section shows for owner/admin even when 0 domains. Add card hidden client-side for non-admin viewers.
- `server/public/dashboard-agents.html` — "primary brand domain" hint deep-links to `#linked-domains-section`.
- `server/tests/integration/me-organization-domains.test.ts` — 14 new tests including cross-tenant safety, message-regex collision fallback, broken-pending recreate, verify cooldown, and an end-to-end seam (issue → verify → set-primary by an owner with no admin in the loop).

## Test plan

- [x] `npx vitest run tests/integration/me-organization-domains.test.ts` — 20/20
- [x] `npx vitest run tests/integration/{organization-domains-db,brand-domain-resolver,me-organization-domains}.test.ts` — 53/53
- [x] TypeScript clean (precommit gate)
- [x] code-reviewer, security-reviewer, adtech-product-expert reviews — all blockers / mediums addressed
- [ ] CI green
- [ ] manual e2e on staging (no existing Playwright coverage of Linked Domains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)