### PR TITLE
fix(scripts): rehost-external-brand-logos dry-run is actually dry

### DIFF
--- a/.changeset/fix-rehost-backfill-dry-run.md
+++ b/.changeset/fix-rehost-backfill-dry-run.md
@@ -1,0 +1,8 @@
+---
+---
+
+fix(scripts): make `rehost-external-brand-logos` dry-run actually side-effect-free
+
+Discovered while running the prod backfill that introduced this script: `rehostExternalLogo` was called unconditionally, which downloaded the bytes and inserted a `brand_logos` row even when `--apply` was absent. The script only gated the final manifest `UPDATE` on `--apply`, so dry-run produced orphan blob rows (harmless thanks to `(domain, sha256)` dedup on re-runs, but misleading — a dry-run is supposed to read state and write nothing).
+
+Dry-run now lists the URLs it would attempt and exits without touching the database. The per-URL outcome (rewrite vs left-alone) is reported only in `--apply` mode, since it depends on live fetches. Output labels updated to make the distinction explicit ("Brands eligible / URLs to attempt" in dry-run vs "Brands touched / URLs rewritten / URLs left" in apply).

--- a/server/src/scripts/rehost-external-brand-logos.ts
+++ b/server/src/scripts/rehost-external-brand-logos.ts
@@ -157,6 +157,20 @@ async function main(): Promise<void> {
     const externals = Array.from(externalLogosOf(manifest, ourHost));
     if (externals.length === 0) continue;
 
+    // Dry-run is truly side-effect-free: don't call rehostExternalLogo (which
+    // would download bytes and insert a brand_logos row even if we discard the
+    // result). Just list the URLs that would be attempted. Apply mode actually
+    // does the work — the per-URL outcome (rewrite vs left-alone) is reported
+    // there.
+    if (dryRun) {
+      touched++;
+      for (const { logo, location } of externals) {
+        console.log(`  ${row.domain}  ${location}  ${logo.url as string}  (would attempt rehost)`);
+        urlsRewritten++;
+      }
+      continue;
+    }
+
     let changed = false;
     for (const { logo, location } of externals) {
       const before = logo.url as string;
@@ -176,12 +190,10 @@ async function main(): Promise<void> {
 
     if (changed) {
       touched++;
-      if (!dryRun) {
-        await pool.query(
-          `UPDATE brands SET brand_manifest = $1::jsonb, updated_at = NOW() WHERE domain = $2`,
-          [JSON.stringify(manifest), row.domain],
-        );
-      }
+      await pool.query(
+        `UPDATE brands SET brand_manifest = $1::jsonb, updated_at = NOW() WHERE domain = $2`,
+        [JSON.stringify(manifest), row.domain],
+      );
     }
   }
 
@@ -190,9 +202,14 @@ async function main(): Promise<void> {
   console.log(`Our host:       ${ourHost}`);
   console.log(`Scope:          ${onlyDomain ? `single brand (${onlyDomain})` : 'all brands with manifests'}`);
   console.log(`Scanned:        ${scanned} brands`);
-  console.log(`Brands touched: ${touched}${dryRun ? ' (would touch)' : ''}`);
-  console.log(`URLs rewritten: ${urlsRewritten}${dryRun ? ' (would rewrite)' : ''}`);
-  console.log(`URLs left:      ${urlsLeftAlone}  (rehost failed — URL stays in manifest)`);
+  if (dryRun) {
+    console.log(`Brands eligible:    ${touched}`);
+    console.log(`URLs to attempt:    ${urlsRewritten}  (per-URL success depends on the live fetch — see --apply output)`);
+  } else {
+    console.log(`Brands touched:     ${touched}`);
+    console.log(`URLs rewritten:     ${urlsRewritten}`);
+    console.log(`URLs left:          ${urlsLeftAlone}  (rehost failed — URL stays in manifest)`);
+  }
 
   if (failures.length > 0) {
     console.log('\nLeft-alone URLs (rehost failed; runtime <img onerror> fallback hides these):');


### PR DESCRIPTION
## Summary

- Dry-run was calling `rehostExternalLogo` unconditionally, which downloaded bytes and inserted a `brand_logos` row even without `--apply`. Only the manifest `UPDATE` was gated, so dry-run produced orphan blob rows (harmless thanks to `(domain, sha256)` dedup on re-runs, but misleading — a dry-run shouldn't write).
- Dry-run now lists URLs it would attempt and exits without DB writes. Per-URL outcomes are only reported in `--apply` mode since they depend on live fetches. Output labels updated.

Caught while running the prod backfill from #4456 — fix forward.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Dry-run scoped to `signal-stack.io` against prod, confirm no DB write (no new `brand_logos` row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)