### PR TITLE
fix(webhooks): source email_domain from is_primary, not org.domains[0]

### DIFF
--- a/.changeset/4448-email-domain-from-is-primary.md
+++ b/.changeset/4448-email-domain-from-is-primary.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix `syncOrganizationDomains` (WorkOS `organization.updated` webhook) so `organizations.email_domain` is sourced from `organization_domains.is_primary=true` rather than `org.domains[0]`. WorkOS's domain-array order is not stable — orgs with a verified root + a `failed` www variant could have WorkOS list www first, overwriting `email_domain` to the wrong value on every webhook fire even though our table's `is_primary` row was correct. Scope3 hit this in prod: `email_domain` had drifted to `www.scope3.com` while `is_primary=true` was on `scope3.com`, causing downstream lookups like `brand-enrichment.ts`'s `WHERE email_domain = $1` to miss the org row entirely. Adds `server/src/scripts/sync-email-domain-from-is-primary.ts` (dry-run + `--apply`) to clear the pre-fix backlog and an integration test pinning the new behavior.

--- a/server/src/routes/workos-webhooks.ts
+++ b/server/src/routes/workos-webhooks.ts
@@ -520,7 +520,7 @@ async function deleteUserMemberships(userId: string): Promise<void> {
  * Sync organization domains from WorkOS
  * This upserts domains and removes any that are no longer in WorkOS
  */
-async function syncOrganizationDomains(org: OrganizationData): Promise<void> {
+export async function syncOrganizationDomains(org: OrganizationData): Promise<void> {
   const pool = getPool();
 
   // First check if the organization exists in our database
@@ -586,13 +586,39 @@ async function syncOrganizationDomains(org: OrganizationData): Promise<void> {
     // column is the auto-membership inference key and applying it to
     // personal-tier orgs would let `@vastlint.org` users auto-resolve to a
     // 1-seat individual sub.
-    const primaryDomain = org.domains.length > 0 ? org.domains[0].domain : null;
+    //
+    // Source the value from `organization_domains.is_primary=true` (the
+    // canonical brand-primary the rest of the system honors) rather than
+    // `org.domains[0]`. WorkOS's domain-array order is not stable: orgs
+    // with multiple domains (e.g. a verified root + a `failed` www variant)
+    // can have WorkOS list the failed one first, which would otherwise
+    // overwrite the correct email_domain on every webhook fire. The
+    // `upsertWorkosDomain` loop above doesn't change `is_primary` on
+    // conflict, so our table preserves the canonical choice; reading from
+    // there keeps `email_domain` in lockstep with what auto-membership
+    // inference and brand-registry lookups already use.
+    //
+    // Fallback to `org.domains[0]` covers the initial-sync case (this is
+    // the first webhook for this org, no `organization_domains` rows are
+    // is_primary=true yet — the upsert above set `i===0` as primary, so
+    // the query usually picks it up, but the fallback is a safety net).
+    let primaryDomain: string | null = null;
     if (!isPersonal) {
+      const primaryRow = await client.query<{ domain: string }>(
+        `SELECT domain FROM organization_domains
+         WHERE workos_organization_id = $1 AND is_primary = true
+         LIMIT 1`,
+        [org.id],
+      );
+      primaryDomain = primaryRow.rows[0]?.domain
+        ?? (org.domains.length > 0 ? org.domains[0].domain : null);
       await client.query(
         `UPDATE organizations SET email_domain = $1, updated_at = NOW()
          WHERE workos_organization_id = $2`,
         [primaryDomain, org.id]
       );
+    } else if (org.domains.length > 0) {
+      primaryDomain = org.domains[0].domain;
     }
 
     await client.query('COMMIT');

--- a/server/src/scripts/sync-email-domain-from-is-primary.ts
+++ b/server/src/scripts/sync-email-domain-from-is-primary.ts
@@ -1,0 +1,108 @@
+/**
+ * Reconcile `organizations.email_domain` for orgs where the value drifted
+ * away from `organization_domains.is_primary=true`.
+ *
+ * Root cause (pre-#4448 follow-up): the WorkOS `organization.updated`
+ * webhook handler sourced `email_domain` from `org.domains[0]`. WorkOS
+ * array order is not stable, so orgs with a verified root + a `failed`
+ * www variant could have WorkOS list www first, overwriting `email_domain`
+ * to the wrong value on every webhook fire even when our table's
+ * `is_primary` row was correct.
+ *
+ * Scope3 was the known case: `organizations.email_domain='www.scope3.com'`
+ * while `organization_domains.is_primary=true` was on `scope3.com`. Caused
+ * downstream lookups (e.g. `services/brand-enrichment.ts`'s
+ * `WHERE email_domain = $1`) to miss the org row entirely.
+ *
+ * The webhook itself is now fixed (see `routes/workos-webhooks.ts`
+ * `syncOrganizationDomains`) — it reads `email_domain` from
+ * `organization_domains.is_primary=true` directly. This script clears the
+ * pre-fix backlog.
+ *
+ * Usage:
+ *   npx tsx server/src/scripts/sync-email-domain-from-is-primary.ts            # dry-run
+ *   npx tsx server/src/scripts/sync-email-domain-from-is-primary.ts --apply    # write
+ *
+ *   fly ssh console -a adcp-docs -C \
+ *     'node /app/dist/scripts/sync-email-domain-from-is-primary.js --apply'
+ *
+ * Prerequisites: DATABASE_URL set.
+ */
+
+import { initializeDatabase, getPool, closeDatabase } from '../db/client.js';
+import { getDatabaseConfig } from '../config.js';
+
+const apply = process.argv.includes('--apply');
+const dryRun = !apply;
+
+interface DriftRow {
+  workos_organization_id: string;
+  org_name: string;
+  current_email_domain: string | null;
+  canonical_domain: string;
+}
+
+async function main(): Promise<void> {
+  const dbConfig = getDatabaseConfig();
+  if (!dbConfig) {
+    console.error('DATABASE_URL is required');
+    process.exit(1);
+  }
+  initializeDatabase(dbConfig);
+  const pool = getPool();
+
+  // Only non-personal orgs — personal orgs intentionally have NULL
+  // email_domain (see workos-webhooks.ts:587). The canonical source is the
+  // is_primary=true row in organization_domains.
+  const result = await pool.query<DriftRow>(`
+    SELECT
+      o.workos_organization_id,
+      o.name AS org_name,
+      o.email_domain AS current_email_domain,
+      od.domain AS canonical_domain
+    FROM organizations o
+    JOIN organization_domains od
+      ON od.workos_organization_id = o.workos_organization_id
+     AND od.is_primary = true
+    WHERE o.is_personal = false
+      AND LOWER(COALESCE(o.email_domain, '')) != LOWER(od.domain)
+    ORDER BY o.name
+  `);
+
+  console.log(`=== email_domain drift reconciliation (#4448 follow-up) ===`);
+  console.log(`Mode: ${dryRun ? 'DRY-RUN (no writes; pass --apply to persist)' : 'APPLY'}`);
+  console.log(`Drifted orgs: ${result.rowCount}\n`);
+
+  if (result.rowCount === 0) {
+    console.log('No drift detected — done.');
+    await closeDatabase();
+    return;
+  }
+
+  for (const row of result.rows) {
+    console.log(
+      `  ${row.org_name} [${row.workos_organization_id}]`
+      + ` email_domain=${row.current_email_domain ?? '-'} → canonical=${row.canonical_domain}`,
+    );
+    if (!dryRun) {
+      await pool.query(
+        `UPDATE organizations SET email_domain = $1, updated_at = NOW()
+         WHERE workos_organization_id = $2`,
+        [row.canonical_domain, row.workos_organization_id],
+      );
+    }
+  }
+
+  if (dryRun) {
+    console.log('\nDRY-RUN — nothing written. Re-run with --apply to fix.');
+  } else {
+    console.log('\nApplied. Future webhook fires preserve via the fix to syncOrganizationDomains.');
+  }
+
+  await closeDatabase();
+}
+
+main().catch((err) => {
+  console.error('sync-email-domain failed:', err);
+  process.exit(1);
+});

--- a/server/tests/integration/workos-sync-email-domain.test.ts
+++ b/server/tests/integration/workos-sync-email-domain.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Regression test for #4448 follow-up: the WorkOS `organization.updated`
+ * webhook handler (`syncOrganizationDomains`) used to set
+ * `organizations.email_domain` from `org.domains[0]`. WorkOS's domain-array
+ * order is not stable — an org with a verified root and a `failed` www
+ * variant can have WorkOS list www first, which would overwrite the
+ * correct email_domain on every webhook fire even though our
+ * `organization_domains.is_primary=true` row was already pointing at the
+ * root. Scope3 caught this in prod (escalation #334 follow-up): WorkOS
+ * had `[www.scope3.com (failed), scope3.com (verified)]` but our DB had
+ * `scope3.com is_primary=true` — `email_domain` was drifting to www on
+ * every webhook.
+ *
+ * Fix: source `email_domain` from `organization_domains.is_primary=true`
+ * (the canonical brand-primary), falling back to `org.domains[0]` only on
+ * initial sync.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { initializeDatabase, closeDatabase, getPool } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { syncOrganizationDomains } from '../../src/routes/workos-webhooks.js';
+import type { Pool } from 'pg';
+
+const TEST_ORG = 'org_wkos_sync_email_test';
+
+async function cleanup(pool: Pool) {
+  await pool.query('DELETE FROM organization_domains WHERE workos_organization_id = $1', [TEST_ORG]);
+  await pool.query('DELETE FROM brands WHERE domain LIKE $1', ['wkos-sync-email-%.test']);
+  await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [TEST_ORG]);
+}
+
+async function seedOrg(pool: Pool, isPersonal = false) {
+  await pool.query(
+    `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+     VALUES ($1, $2, $3, NOW(), NOW())
+     ON CONFLICT (workos_organization_id) DO UPDATE SET is_personal = EXCLUDED.is_personal`,
+    [TEST_ORG, 'Sync Email Domain Test Co', isPersonal],
+  );
+}
+
+describe('syncOrganizationDomains email_domain sourcing', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  }, 60000);
+
+  afterAll(async () => {
+    await cleanup(pool);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanup(pool);
+    await seedOrg(pool);
+  });
+
+  it('does NOT overwrite email_domain when WorkOS lists a non-primary domain first', async () => {
+    // Mimic Scope3: our DB has the root is_primary=true; WorkOS has the
+    // www variant first in the array (often because it was added earlier
+    // and never reordered after the root was verified).
+    await pool.query(
+      `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source, created_at, updated_at)
+       VALUES
+         ($1, 'wkos-sync-email-root.test', true,  true,  'workos', NOW(), NOW()),
+         ($1, 'wkos-sync-email-www.test',  false, false, 'workos', NOW(), NOW())`,
+      [TEST_ORG],
+    );
+
+    await syncOrganizationDomains({
+      id: TEST_ORG,
+      name: 'Sync Email Domain Test Co',
+      domains: [
+        { domain: 'wkos-sync-email-www.test', state: 'pending' }, // WorkOS-order-first, but NOT primary in our table
+        { domain: 'wkos-sync-email-root.test', state: 'verified' },
+      ],
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-05-12T00:00:00Z',
+    });
+
+    const org = await pool.query<{ email_domain: string | null }>(
+      `SELECT email_domain FROM organizations WHERE workos_organization_id = $1`,
+      [TEST_ORG],
+    );
+    expect(org.rows[0].email_domain).toBe('wkos-sync-email-root.test');
+  });
+
+  it('initial sync (no is_primary row yet) falls back to org.domains[0]', async () => {
+    // Cold start: no organization_domains rows exist. The upsert loop
+    // inside the function inserts both, and the first one (i===0) is
+    // upserted with isPrimary=true — so by the time the email_domain
+    // UPDATE runs, the SELECT finds a primary row. Either way, the
+    // initial-sync expectation is that email_domain matches org.domains[0].
+    await syncOrganizationDomains({
+      id: TEST_ORG,
+      name: 'Sync Email Domain Test Co',
+      domains: [
+        { domain: 'wkos-sync-email-cold.test', state: 'verified' },
+      ],
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-05-12T00:00:00Z',
+    });
+
+    const org = await pool.query<{ email_domain: string | null }>(
+      `SELECT email_domain FROM organizations WHERE workos_organization_id = $1`,
+      [TEST_ORG],
+    );
+    expect(org.rows[0].email_domain).toBe('wkos-sync-email-cold.test');
+  });
+
+  it('personal orgs do not touch email_domain', async () => {
+    await cleanup(pool);
+    await seedOrg(pool, /* isPersonal */ true);
+
+    await syncOrganizationDomains({
+      id: TEST_ORG,
+      name: 'Sync Email Domain Test Co',
+      domains: [
+        { domain: 'wkos-sync-email-personal.test', state: 'verified' },
+      ],
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-05-12T00:00:00Z',
+    });
+
+    const org = await pool.query<{ email_domain: string | null }>(
+      `SELECT email_domain FROM organizations WHERE workos_organization_id = $1`,
+      [TEST_ORG],
+    );
+    expect(org.rows[0].email_domain).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Closes a Scope3-specific drift identified during the #4448 reconciliation: their `organizations.email_domain` had been set to `www.scope3.com` while `organization_domains.is_primary=true` was on `scope3.com`. Cause: the WorkOS `organization.updated` webhook handler (`syncOrganizationDomains`) sourced `email_domain` from `org.domains[0]`, and WorkOS's array order is not stable. Scope3 had `[www.scope3.com (failed), scope3.com (verified)]` in WorkOS, so every webhook fire overwrote `email_domain` to the failed www variant.

`upsertWorkosDomain` already preserves `is_primary` across conflicts (so our table's choice survives webhook re-fires) — this change reads `email_domain` from that same canonical source. Falls back to `org.domains[0]` only for the initial-sync case (cold start, no is_primary row exists yet).

## Downstream impact of the bug

Lookups like `services/brand-enrichment.ts:772` (`SELECT … FROM organizations WHERE email_domain = $1`) were missing Scope3's org row entirely — brand enrichment ran as though `scope3.com` had no associated org.

## Included

- **`server/src/routes/workos-webhooks.ts`** — `syncOrganizationDomains` reads `email_domain` from `organization_domains.is_primary=true`. Export added so the integration test can call it directly (mirrors the existing `upsertOrganizationDomain` export pattern).
- **`server/src/scripts/sync-email-domain-from-is-primary.ts`** — backfill script for any other org that drifted pre-fix. Dry-run by default; `--apply` to write.
- **`server/tests/integration/workos-sync-email-domain.test.ts`** — pins the new behavior. Three cases: (1) non-primary first in WorkOS array stays at the canonical primary, (2) initial cold-sync falls back to `org.domains[0]`, (3) personal orgs are not touched.

## Applied on prod

Scope3 backfill applied via fly ssh 2026-05-12 11:55 UTC:

```
before: {"workos_organization_id":"org_01KC84E45378RJDDARFGR4E2WD","name":"Scope3","email_domain":"www.scope3.com"}
canonical (is_primary=true): scope3.com
would set email_domain: www.scope3.com → scope3.com
after: scope3.com
```

The webhook fix in this PR prevents re-drift on the next WorkOS `organization.updated` for Scope3.

## Test plan

- [x] Typecheck clean
- [ ] CI integration test passes
- [ ] Re-run audit: no remaining `email_domain` drift across non-personal orgs

🤖 Generated with [Claude Code](https://claude.com/claude-code)