### PR TITLE
docs(creative): clarify preview_creative renders manifests, not generates

### DIFF
--- a/.changeset/docs-preview-creative-render-clarification.md
+++ b/.changeset/docs-preview-creative-render-clarification.md
@@ -1,0 +1,4 @@
+---
+---
+
+Clarify on `preview_creative` and `build_creative` task reference pages that `preview_creative` renders an existing manifest (it does not generate or modify it), while `build_creative` is the generation step. Fixes misleading "generates" wording in the `preview_creative` frontmatter description and opening sentence. Closes #4452.

--- a/docs/creative/task-reference/build_creative.mdx
+++ b/docs/creative/task-reference/build_creative.mdx
@@ -5,7 +5,7 @@ description: "build_creative generates, transforms, or retrieves ad creative man
 ---
 
 
-Transform, generate, or retrieve a creative manifest for a specific format. Supports three modes:
+Transform, generate, or retrieve a creative manifest for a specific format. To render a visual preview of the resulting manifest, pass it to [`preview_creative`](/docs/creative/task-reference/preview_creative). Supports three modes:
 
 1. **Generation**: Create a manifest from a brief or seed assets (`message` + `creative_manifest`)
 2. **Transformation**: Adapt an existing manifest to a different format (`creative_manifest` + `target_format_id`)

--- a/docs/creative/task-reference/preview_creative.mdx
+++ b/docs/creative/task-reference/preview_creative.mdx
@@ -1,11 +1,11 @@
 ---
 title: preview_creative
-description: "preview_creative generates visual previews of ad creative manifests in AdCP in single or batch mode returning URL, image, or HTML output."
+description: "preview_creative renders an existing creative manifest into viewable output in AdCP, in single or batch mode, returning URL, image, or HTML output."
 "og:title": "AdCP — preview_creative"
 ---
 
 
-Generate preview renderings of creative manifests. Supports both single creative preview and batch preview (5-10x faster for multiple creatives).
+`preview_creative` renders an existing creative manifest into viewable output. It does not generate or modify the input manifest — use [`build_creative`](/docs/creative/task-reference/build_creative) for that. Supports both single creative preview and batch preview (5-10x faster for multiple creatives).
 
 **Request Schema**: [`/schemas/v3/creative/preview-creative-request.json`](https://adcontextprotocol.org/schemas/v3/creative/preview-creative-request.json)
 **Response Schema**: [`/schemas/v3/creative/preview-creative-response.json`](https://adcontextprotocol.org/schemas/v3/creative/preview-creative-response.json)


### PR DESCRIPTION
Closes #4452

The `preview_creative` task reference page opened with "Generate preview renderings" and its frontmatter description said "generates visual previews" — both misleading, since the task renders an existing manifest into viewable output and never generates or modifies it. Implementers choosing between `preview_creative` and `build_creative` had no explicit statement of the render/generate distinction on either page.

**Changes:**
- `preview_creative.mdx`: frontmatter description changes "generates" → "renders an existing creative manifest into viewable output"; opening sentence replaced with an explicit render/generate distinction and cross-link to `build_creative`
- `build_creative.mdx`: cross-link to `preview_creative` folded into the existing opening sentence so readers see the downstream render step immediately

**Non-breaking justification:** docs-only wording fix — no schema fields, enum values, or task definitions touched; existing consumers unaffected.

**Pre-PR review:**
- code-reviewer: approved — no blockers; nit on `build_creative.mdx` opening sentence redundancy addressed in final diff
- docs-expert: approved — accurate, agent-parseable, cross-links resolve to real files; nit on `preview_creative.mdx` "input manifest" wording incorporated

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01Ak6rrT9p3ZzeU6YY2y9o5p

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ak6rrT9p3ZzeU6YY2y9o5p)_