### PR TITLE
chore(deps): bump @adcp/sdk to ^7.1.0; re-baseline storyboard floors

### DIFF
--- a/.changeset/bump-adcp-sdk-7-1-0.md
+++ b/.changeset/bump-adcp-sdk-7-1-0.md
@@ -1,0 +1,17 @@
+---
+---
+
+chore(deps): bump `@adcp/sdk` to ^7.1.0; re-baseline storyboard floors
+
+7.1.0 ships [adcp-client#1714](https://github.com/adcontextprotocol/adcp-client/pull/1714) — the `findSecretEcho` fix that restored `account_setup` grading for sellers whose endpoints had been failing the secret-echo probe under the 7.0.0 strict-vs-passthrough path. External integrator (bidmachine) confirmed empirically: re-running the storyboard CLI against `https://adcp.bidmachine.io/adcp/mcp` with `@adcp/sdk@7.1.0` cleared `account_setup` from the failure list across both `media_buy_seller` and `sales_non_guaranteed` runs.
+
+Re-baselined the per-tenant floors in `scripts/run-storyboards-matrix.sh` and `.github/workflows/training-agent-storyboards.yml` against the current matrix run. The published floors had drifted well below actuals across the 6.x → 7.0 → 7.1 bumps; new floors capture the post-7.1 ceiling so CI actually defends regressions instead of rubber-stamping a 50-step margin.
+
+| Tenant            | clean (old → new) | passed (old → new) |
+|-------------------|-------------------|--------------------|
+| /signals          | 67 → 67           | 58 → 111           |
+| /sales            | 67 → 67           | 258 → 314          |
+| /governance       | 65 → 65           | 102 → 153          |
+| /creative         | 66 → 66           | 118 → 169          |
+| /creative-builder | 60 → 63           | 96 → 146           |
+| /brand            | 66 → 66           | 45 → 96            |

--- a/.github/workflows/training-agent-storyboards.yml
+++ b/.github/workflows/training-agent-storyboards.yml
@@ -50,26 +50,22 @@ jobs:
           # from the storyboard's positive + negative conformance vectors.
           - tenant: signals
             min_clean_storyboards: 67
-            min_passing_steps: 58
+            min_passing_steps: 111
           - tenant: sales
             min_clean_storyboards: 67
-            min_passing_steps: 258
+            min_passing_steps: 314
           - tenant: governance
             min_clean_storyboards: 65
-            min_passing_steps: 102
+            min_passing_steps: 153
           - tenant: creative
             min_clean_storyboards: 66
-            min_passing_steps: 118
+            min_passing_steps: 169
           - tenant: creative-builder
-            min_clean_storyboards: 60
-            # Dropped from 100 → 96 with @adcp/sdk 7.0: list_creatives and
-            # get_creative_delivery moved off CreativeBuilderPlatform onto
-            # CreativeAdServerPlatform, so /creative-builder no longer
-            # advertises them. Step count drop is exact (2 tools × 2 steps).
-            min_passing_steps: 96
+            min_clean_storyboards: 63
+            min_passing_steps: 146
           - tenant: brand
             min_clean_storyboards: 66
-            min_passing_steps: 45
+            min_passing_steps: 96
     steps:
       - uses: actions/checkout@v6
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.0.3",
       "dependencies": {
-        "@adcp/sdk": "^7.0.0",
+        "@adcp/sdk": "^7.1.0",
         "@anthropic-ai/sdk": "^0.91.1",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-7.0.0.tgz",
-      "integrity": "sha512-JPtXCjJhf1kpRk3JVJR1sKT1CXLzeai+z82ziC2Cq2jPfZQvcfdOoxaMBxm0hsDIudCns36YTi3llqSBXgp7sg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-7.1.0.tgz",
+      "integrity": "sha512-RSm07ImvdKX1XqiiEmIBzYdgdaQZWIu0PAhRmNEPyn/A8odOE4RmkUOYouV+Fhra75DINBso8k/UbVgkAjibbQ==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "dev:docs": "node scripts/dev-docs.mjs"
   },
   "dependencies": {
-    "@adcp/sdk": "^7.0.0",
+    "@adcp/sdk": "^7.1.0",
     "@anthropic-ai/sdk": "^0.91.1",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",

--- a/scripts/run-storyboards-matrix.sh
+++ b/scripts/run-storyboards-matrix.sh
@@ -20,12 +20,12 @@ bash "${SCRIPT_DIR}/overlay-compliance-cache.sh" || true
 # tenant:min_clean:min_passed — kept in sync with the matrix.include block in
 # .github/workflows/training-agent-storyboards.yml.
 TENANTS=(
-  "signals:67:58"
-  "sales:67:258"
-  "governance:65:102"
-  "creative:66:118"
-  "creative-builder:60:96"
-  "brand:66:45"
+  "signals:67:111"
+  "sales:67:314"
+  "governance:65:153"
+  "creative:66:169"
+  "creative-builder:63:146"
+  "brand:66:96"
 )
 
 REGRESSED=0


### PR DESCRIPTION
## Summary

- Bumps `@adcp/sdk` from `^7.0.0` → `^7.1.0`. 7.1.0 ships [adcp-client#1714](https://github.com/adcontextprotocol/adcp-client/pull/1714), the `findSecretEcho` fix. External integrator (bidmachine) empirically confirmed `account_setup` clears from the failure list against `https://adcp.bidmachine.io/adcp/mcp` once on 7.1.0.
- Re-baselines per-tenant storyboard floors in both `scripts/run-storyboards-matrix.sh` and `.github/workflows/training-agent-storyboards.yml`. Floors had drifted 50+ steps below actuals across 6.x → 7.0 → 7.1; new floors match observed step counts so CI defends regressions instead of rubber-stamping a wide margin.

| Tenant            | clean (old → new) | passed (old → new) |
|-------------------|-------------------|--------------------|
| /signals          | 67 → 67           | 58 → 111           |
| /sales            | 67 → 67           | 258 → 314          |
| /governance       | 65 → 65           | 102 → 153          |
| /creative         | 66 → 66           | 118 → 169          |
| /creative-builder | 60 → 63           | 96 → 146           |
| /brand            | 66 → 66           | 45 → 96            |

## Test plan

- [x] `npm install` resolves `@adcp/sdk@7.1.0`
- [x] `bash scripts/run-storyboards-matrix.sh` — all six tenants land exactly on the new floors (deterministic green)
- [x] Re-run with bumped floors — all tenants still green
- [ ] CI `Training Agent Storyboards` matrix green on the workflow's six tenants

🤖 Generated with [Claude Code](https://claude.com/claude-code)