### PR TITLE
fix(slack): prospect-claim lookup and portrait image URL for Slack blocks

### DIFF
--- a/.changeset/fix-prospect-claim-and-portrait-slack-blocks.md
+++ b/.changeset/fix-prospect-claim-and-portrait-slack-blocks.md
@@ -1,0 +1,7 @@
+---
+---
+
+Fix two production errors surfaced in `#admin-errors`:
+
+- Prospect-claim Slack action looked up `users.slack_user_id`, but that column doesn't exist — Slack↔WorkOS linkage lives in `slack_user_mappings`. The lookup now joins through that table on `mapping_status = 'mapped'`.
+- Member-announcement Slack cards passed `member_portraits.image_url` (a same-origin relative path like `/api/portraits/{id}.png`) into a Slack `image` block, which Slack can't fetch. Portrait URLs are now resolved to absolute `APP_URL`-prefixed URLs and re-validated through `isSafeVisualUrl` before reaching Slack; on reject the visual falls back to the AAO mark.

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -2468,7 +2468,9 @@ async function handleProspectClaim({ ack, body, client }: any): Promise<void> {
   try {
     const pool = getPool();
 
-    // Look up the Slack user's WorkOS identity and verify they're an admin
+    // Look up the Slack user's WorkOS identity (via slack_user_mappings) and
+    // verify they're an admin. `users` has no slack_user_id column — Slack ↔
+    // WorkOS linkage lives in slack_user_mappings.
     const userResult = await pool.query<{ workos_user_id: string; first_name: string; email: string; is_admin: boolean }>(
       `SELECT u.workos_user_id, u.first_name, u.email,
               EXISTS(
@@ -2479,7 +2481,11 @@ async function handleProspectClaim({ ack, body, client }: any): Promise<void> {
                   )
                   AND om.role IN ('admin')
               ) as is_admin
-       FROM users u WHERE u.slack_user_id = $1`,
+       FROM slack_user_mappings sm
+       JOIN users u ON u.workos_user_id = sm.workos_user_id
+       WHERE sm.slack_user_id = $1
+         AND sm.mapping_status = 'mapped'
+         AND sm.workos_user_id IS NOT NULL`,
       [userId]
     );
 

--- a/server/src/services/announcement-visual.ts
+++ b/server/src/services/announcement-visual.ts
@@ -152,7 +152,16 @@ async function fetchApprovedPortraitUrlByOrg(orgId: string): Promise<string | nu
      LIMIT 1`,
     [orgId],
   );
-  return result.rows[0]?.image_url ?? null;
+  const raw = result.rows[0]?.image_url ?? null;
+  if (!raw) return null;
+  // Portraits are stored as same-origin relative paths (`/api/portraits/{id}.png`).
+  // Slack needs an absolute https URL to fetch the image, so prefix APP_URL.
+  const absolute = raw.startsWith('/') ? `${APP_URL}${raw}` : raw;
+  if (!isSafeVisualUrl(absolute)) {
+    logger.warn({ orgId, reason: 'unsafe_visual_url' }, 'Rejected portrait URL');
+    return null;
+  }
+  return absolute;
 }
 
 export interface VisualResolveInputs {


### PR DESCRIPTION
## Summary

Fixes two distinct production errors reported in `#admin-errors`:

- **`column u.slack_user_id does not exist`** in `handleProspectClaim` (`server/src/addie/bolt-app.ts`) — the `users` table has no `slack_user_id` column; Slack ↔ WorkOS linkage lives in `slack_user_mappings`. Rewritten to join through that table on `mapping_status = 'mapped' AND workos_user_id IS NOT NULL`. Unmapped Slack users still hit the existing "link your Slack account first" branch.
- **`invalid_blocks (downloading image failed)`** on member-announcement Slack cards (`server/src/services/announcement-visual.ts`) — `member_portraits.image_url` is stored as a same-origin relative path (`/api/portraits/{id}.png`), but Slack needs an absolute https URL to fetch the image. `fetchApprovedPortraitUrlByOrg` now prefixes `APP_URL` when relative, then runs through the existing `isSafeVisualUrl` SSRF guard (matching the brand-logo path). On reject, returns null so the visual falls back to the AAO mark instead of posting a broken URL.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/announcement/announcement-visual.test.ts tests/announcement/announcement-handlers.test.ts` — 58/58 pass
- [ ] Verify in prod: prospect-claim button in #admin-prospects resolves to the Slack admin's WorkOS identity
- [ ] Verify in prod: new-member announcement review card renders the portrait image (no `invalid_blocks` in #admin-errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)