### PR TITLE
fix(addie): reject NUL/CR/LF in save_agent auth tokens

### DIFF
--- a/.changeset/save-agent-utf8-null-byte.md
+++ b/.changeset/save-agent-utf8-null-byte.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix: `save_agent` and `PUT /registry/agents/:url/connect` now reject auth tokens containing NUL, CR, or LF bytes with a clear user-facing message, instead of bubbling a Postgres `invalid byte sequence for encoding "UTF8": 0x00` 500 from the `auth_token_hint` TEXT-column write. The hint generator also sanitizes those characters as defense-in-depth. NUL crashes Postgres TEXT-column writes; CR/LF are HTTP header-injection vectors — neither is legitimate in an Authorization header per RFC 7235.

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -54,7 +54,7 @@ import {
 } from '@adcp/sdk/testing';
 import { AuthenticationRequiredError } from '@adcp/sdk';
 import { renderAllHintFixPlans } from '../services/storyboard-fix-plan.js';
-import { AgentContextDatabase, type OAuthClientCredentials } from '../../db/agent-context-db.js';
+import { AgentContextDatabase, validateAuthTokenChars, type OAuthClientCredentials } from '../../db/agent-context-db.js';
 import { buildAgentOAuthAuthorizeUrl, isOAuthRequiredError } from '../../routes/helpers/agent-oauth-prompt.js';
 import { isOAuthRequiredErrorMessage } from '../../routes/helpers/oauth-error-detection.js';
 import {
@@ -5664,6 +5664,10 @@ export function createMemberToolHandlers(
     }
     const agentName = input.agent_name as string | undefined;
     const authToken = input.auth_token as string | undefined;
+    if (authToken !== undefined) {
+      const tokenErr = validateAuthTokenChars(authToken);
+      if (tokenErr) return tokenErr;
+    }
     const rawAuthType = input.auth_type as string | undefined;
     const authType: 'bearer' | 'basic' = rawAuthType === 'basic' ? 'basic' : 'bearer';
     const protocol = (input.protocol as 'mcp' | 'a2a') || 'mcp';

--- a/server/src/db/agent-context-db.ts
+++ b/server/src/db/agent-context-db.ts
@@ -135,14 +135,33 @@ export interface RecordTestInput {
   agent_profile_json?: any;
 }
 
+/**
+ * Validate an auth token for characters that cannot legitimately appear in
+ * an HTTP Authorization header value. NUL bytes crash Postgres TEXT-column
+ * writes; CR/LF are header-injection vectors. Returns a user-facing error
+ * message when the token is rejected, or null when the token is acceptable.
+ *
+ * TODO: apply the same character validation to OAuth client_id / client_secret
+ * / scope / resource / audience in parseOAuthClientCredentialsInput — those
+ * strings hit the same encrypted-storage path and are also body-encoded into
+ * outbound token-endpoint requests.
+ */
+export function validateAuthTokenChars(token: string): string | null {
+  if (/[\u0000\r\n]/.test(token)) {
+    return 'Auth token contains invalid characters (NUL, CR, or LF). This usually means the token picked up stray bytes from copy/paste — paste it again from the source.';
+  }
+  return null;
+}
+
 function getTokenHint(token: string, authType: AuthType = 'bearer'): string {
+  const sanitize = (s: string): string => s.replace(/[\u0000\r\n]/g, '');
   if (authType === 'basic') {
     // For Basic auth, try to show username only (token is base64-encoded user:password)
     try {
       const decoded = Buffer.from(token, 'base64').toString();
       const colonIndex = decoded.indexOf(':');
       if (colonIndex > 0) {
-        return decoded.substring(0, colonIndex) + ':****';
+        return sanitize(decoded.substring(0, colonIndex)) + ':****';
       }
     } catch {
       // Not valid base64, fall through
@@ -150,7 +169,7 @@ function getTokenHint(token: string, authType: AuthType = 'bearer'): string {
     return '****';
   }
   if (token.length <= 4) return '****';
-  return '****' + token.slice(-4);
+  return '****' + sanitize(token.slice(-4));
 }
 
 // =====================================================

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -95,7 +95,7 @@ import { resolveUserAgentAuth } from "./helpers/resolve-user-agent-auth.js";
 import { adaptAuthForSdk, type SdkAuth } from "../services/sdk-auth-adapter.js";
 import { parseOAuthClientCredentialsInput } from "./helpers/oauth-client-credentials-input.js";
 import { isOAuthRequiredErrorMessage } from "./helpers/oauth-error-detection.js";
-import { AgentContextDatabase } from "../db/agent-context-db.js";
+import { AgentContextDatabase, validateAuthTokenChars } from "../db/agent-context-db.js";
 import { getRequestLog, getRequestCount } from "../db/outbound-log-db.js";
 import { enrichUserWithMembership } from "../utils/html-config.js";
 import { classifyProbeError } from "../utils/probe-error.js";
@@ -5259,6 +5259,12 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       }
       if (auth_token && auth_token.length > 4096) {
         return res.status(400).json({ error: "auth_token exceeds maximum length" });
+      }
+      if (auth_token) {
+        const tokenErr = validateAuthTokenChars(auth_token);
+        if (tokenErr) {
+          return res.status(400).json({ error: tokenErr });
+        }
       }
 
       const validAuthTypes = ["bearer", "basic"];

--- a/server/tests/unit/auth-token-validation.test.ts
+++ b/server/tests/unit/auth-token-validation.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { validateAuthTokenChars } from '../../src/db/agent-context-db.js';
+
+describe('validateAuthTokenChars', () => {
+  it('accepts a normal bearer token', () => {
+    expect(validateAuthTokenChars('token-1')).toBeNull();
+    expect(validateAuthTokenChars('a.b.c')).toBeNull();
+  });
+
+  it('accepts an empty string (caller decides whether empty means clear)', () => {
+    expect(validateAuthTokenChars('')).toBeNull();
+  });
+
+  it('accepts visible-ASCII punctuation common in tokens', () => {
+    expect(validateAuthTokenChars('punct.~+/=')).toBeNull();
+  });
+
+  it('rejects tokens containing a NUL byte (Postgres TEXT-column crash vector)', () => {
+    expect(validateAuthTokenChars('abc\u0000def')).toMatch(/invalid characters/i);
+  });
+
+  it('rejects a NUL byte at the tail (the failure mode from the InMobi report)', () => {
+    expect(validateAuthTokenChars('mytoken\u0000')).toMatch(/invalid characters/i);
+    expect(validateAuthTokenChars('\u0000mytoken')).toMatch(/invalid characters/i);
+  });
+
+  it('rejects CR or LF (HTTP header-injection vectors)', () => {
+    expect(validateAuthTokenChars('abc\rdef')).toMatch(/invalid characters/i);
+    expect(validateAuthTokenChars('abc\ndef')).toMatch(/invalid characters/i);
+    expect(validateAuthTokenChars('abc\r\ndef')).toMatch(/invalid characters/i);
+  });
+
+  // Pin the "narrow" decision: we reject only the three characters that are
+  // definitively dangerous (Postgres TEXT crash + HTTP header injection).
+  // Bearer tokens in the wild can be opaque — a future PR that quietly
+  // broadens this regex to all C0 control bytes would break legitimate
+  // provider tokens. This test catches that drift.
+  it('does NOT reject other control bytes (kept narrow on purpose)', () => {
+    expect(validateAuthTokenChars('abc\u0001def')).toBeNull();
+    expect(validateAuthTokenChars('abc\u001Fdef')).toBeNull();
+    expect(validateAuthTokenChars('abc\u007Fdef')).toBeNull();
+    expect(validateAuthTokenChars('abc\tdef')).toBeNull();
+  });
+
+  // Defense-in-depth: a Basic-auth token is base64 (visible-ASCII), so the
+  // outer validator can't see a NUL hidden in the decoded user:pass. The
+  // hint sanitizer in getTokenHint strips it before the hint is written to
+  // the auth_token_hint TEXT column. We exercise the outer validator here
+  // and assert the base64 envelope passes — the hint sanitizer is covered
+  // implicitly by the saveAuthToken path used by save_agent.
+  it('accepts Basic-auth base64 envelopes even when the decoded payload contains a NUL', () => {
+    const evilBasic = Buffer.from('u\u0000:p').toString('base64');
+    expect(validateAuthTokenChars(evilBasic)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Production Slack alert (`#admin-errors`) surfaced a Postgres crash from `save_agent` on the InMobi nonprod MCP URL:

```
save_agent failed: invalid byte sequence for encoding "UTF8": 0x00
  at AgentContextDatabase.saveAuthToken
```

Root cause: the supplied `auth_token` contained a NUL byte. Encryption stores the token in `bytea` (fine), but `getTokenHint` derives a hint that's written to the `auth_token_hint` TEXT column — Postgres rejects NULs in TEXT, and the UPDATE crashed before any user-friendly response could be returned. The two user-facing entry points (`save_agent` MCP tool and `PUT /registry/agents/:url/connect`) accepted the token with no character validation.

## Fix

- New exported `validateAuthTokenChars()` rejects NUL/CR/LF with a clear message ("contains invalid characters... paste it again from the source").
- Wired into both call sites — `save_agent` returns the string, `/connect` returns 400.
- `getTokenHint` strips NUL/CR/LF from the hint output as defense-in-depth (also covers the Basic-auth case where a NUL hides inside the base64-decoded `user:pass` and bypasses the outer validator).
- 8 unit tests, including a "narrow-decision" pin so a future PR can't quietly broaden the regex and break opaque provider tokens.

## Scope decision

Narrow rejection (NUL/CR/LF only), not all C0 control bytes. Rationale: NUL crashes Postgres, CR/LF is HTTP-header-injection — those three are definitively dangerous. Bearer tokens in the wild are opaque; aggressive rejection risks breaking a legitimate provider. The pinning test on ``/``/``/`\t` catches drift.

## Follow-up (filed as TODO in code)

OAuth `client_id` / `client_secret` / `scope` / `resource` / `audience` in `parseOAuthClientCredentialsInput` hit the same storage path and are body-encoded into outbound token-endpoint requests. Same validation should apply — left as a follow-up to keep this hotfix small.

## Reviewed by

`security-reviewer` (GO with tweaks) and `code-reviewer` (GO with tweaks) — all tweaks addressed before commit.

## Test plan

- [x] `vitest run server/tests/unit/auth-token-validation.test.ts` — 8/8 pass
- [x] `tsc -p server/tsconfig.json --noEmit` — clean
- [x] Pre-commit hooks (`npm run test:unit && test:test-dynamic-imports && test:callapi-state-change && typecheck`) — all pass
- [ ] Manual: paste a token with a trailing NUL into Addie `save_agent` — expect the user-facing rejection, no 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)