### PR TITLE
fix(docs): use serve_window_sec in TMP Identity Match overview example

### DIFF
--- a/docs/trusted-match/index.mdx
+++ b/docs/trusted-match/index.mdx
@@ -161,11 +161,11 @@ Response from Sam's buyer agent:
   "type": "identity_match_response",
   "request_id": "id-7c9e1d",
   "eligible_package_ids": ["pkg-outdoor-audio"],
-  "ttl_sec": 60
+  "serve_window_sec": 60
 }
 ```
 
-Only eligible packages are listed — `pkg-outdoor-audio` passes the buyer's checks. The `ttl_sec: 60` tells the router to cache this eligibility for 60 seconds.
+Only eligible packages are listed — `pkg-outdoor-audio` passes the buyer's checks. The `serve_window_sec: 60` is a per-package single-shot fcap: after StreamHaus serves the user one impression on `pkg-outdoor-audio`, it MUST re-query Identity Match before serving from that package again.
 
 The example sends `package_ids` explicitly, but the publisher MAY omit it — Sam's identity-match service resolves the active package set from `seller_agent_url`. When `package_ids` IS sent, its composition MUST be independent of the current page — either all-active (every Sam package at StreamHaus) or fuzzed (a random sample padded with synthetic IDs that Sam will silently drop). A page-specific subset is forbidden; it would let the buyer correlate package sets across Context Match and Identity Match, breaking the structural separation.
 

--- a/tests/example-validation-simple.test.cjs
+++ b/tests/example-validation-simple.test.cjs
@@ -581,7 +581,7 @@ async function runTests() {
       "type": "identity_match_response",
       "request_id": "id-7c9e1d",
       "eligible_package_ids": ["pkg-outdoor-audio"],
-      "ttl_sec": 60
+      "serve_window_sec": 60
     },
     '/schemas/tmp/identity-match-response.json',
     'TMP Identity Match response — web (overview walkthrough)'


### PR DESCRIPTION
## Summary

- The overview walkthrough's `identity_match_response` example used the legacy `ttl_sec` field, which fails schema validation — the schema requires `serve_window_sec`.
- The two fields are not synonyms: `serve_window_sec` is a per-package single-shot fcap (the publisher must re-query Identity Match after serving once per eligible package), not a router response cache TTL. Updated the example's accompanying explanation to reflect this.
- Updated the matching fixture in `tests/example-validation-simple.test.cjs` so the `TMP Identity Match response — web (overview walkthrough)` case validates against the schema.

Note: the same `ttl_sec` vs. `serve_window_sec` drift exists in the surface walkthroughs (`surfaces/web.mdx`, `surfaces/mobile.mdx`, `surfaces/ctv.mdx`, `surfaces/retail-media.mdx`, `surfaces/ai-assistants.mdx`) and in `context-and-identity.mdx`. Those aren't covered by the current validation test and are left for a follow-up to keep this PR scoped to the failing test.

## Test plan

- [x] `node tests/example-validation-simple.test.cjs` — 36/36 passing; the previously failing `TMP Identity Match response — web (overview walkthrough)` case now passes.
- [ ] Mintlify renders `docs/trusted-match/index.mdx` Step 4 cleanly with the new explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)