### PR TITLE
fix(adagents): validator requires authorization_type per v3 schema

### DIFF
--- a/.changeset/4476-validator-requires-authorization-type.md
+++ b/.changeset/4476-validator-requires-authorization-type.md
@@ -1,0 +1,4 @@
+---
+---
+
+Validator: `AdAgentsManager.validateAgent` now requires every `authorized_agents[]` entry to declare `authorization_type` plus the matching non-empty selector (`property_ids`, `property_tags`, `properties` for `inline_properties`, `publisher_properties`, `signal_ids`, or `signal_tags`) — that's the v3 schema's oneOf invariant. Before this change, files that omitted `authorization_type` (e.g. wonderstruck.org's bare `{url, authorized_for}` entries) returned `valid: true` while downstream resolvers correctly read them as unauthorized — the publisher saw "valid" while the buyer saw "agent not authorized." Per-entry error messages name the missing field and list the valid selector enums. Quick Start example on `/adagents` and the `authorized_agents` reference in `docs/governance/property/adagents.mdx` updated to reflect the requirement. Closes #4476.

--- a/docs/governance/property/adagents.mdx
+++ b/docs/governance/property/adagents.mdx
@@ -163,7 +163,7 @@ The file must be valid JSON with UTF-8 encoding and return HTTP 200 status.
 **`authorized_agents`** *(required)*: Array of authorized sales agents
   - **`url`** *(required)*: Agent's API endpoint URL
   - **`authorized_for`** *(required)*: Human-readable authorization description
-  - **`authorization_type`** *(optional)*: One of `property_ids`, `property_tags`, `inline_properties`, `publisher_properties`
+  - **`authorization_type`** *(required)*: Discriminator naming which selector field carries the scope. One of `property_ids`, `property_tags`, `inline_properties`, `publisher_properties` (for properties) or `signal_ids`, `signal_tags` (for signal providers). The corresponding selector field must be present and non-empty — see [Authorization Patterns](#authorization-patterns) below.
   - **`delegation_type`** *(optional)*: Commercial relationship for this path: `direct`, `delegated`, or `ad_network`
   - **`collections`** *(optional)*: Additional collection selectors that narrow authorization to specific content programs
   - **`placement_ids`** *(optional)*: Placement IDs from the top-level `placements` array that narrow authorization to specific placements

--- a/server/public/adagents-landing.html
+++ b/server/public/adagents-landing.html
@@ -388,26 +388,28 @@
           <span class="filename">/.well-known/adagents.json</span>
         </div>
         <div class="code-block"><code><span class="code-bracket">{</span>
-  <span class="code-key">"$schema"</span>: <span class="code-string">"https://adcontextprotocol.org/schemas/latest/adagents.json"</span>,
-  <span class="code-key">"publisher_domain"</span>: <span class="code-string">"publisher.com"</span>,
+  <span class="code-key">"$schema"</span>: <span class="code-string">"https://adcontextprotocol.org/schemas/v3/adagents.json"</span>,
   <span class="code-key">"properties"</span>: <span class="code-bracket">[</span>
     <span class="code-bracket">{</span>
+      <span class="code-key">"property_id"</span>: <span class="code-string">"main_site"</span>,
+      <span class="code-key">"property_type"</span>: <span class="code-string">"website"</span>,
       <span class="code-key">"name"</span>: <span class="code-string">"Publisher News"</span>,
-      <span class="code-key">"domain"</span>: <span class="code-string">"news.publisher.com"</span>,
-      <span class="code-key">"categories"</span>: <span class="code-bracket">[</span><span class="code-string">"news"</span>, <span class="code-string">"technology"</span><span class="code-bracket">]</span>
+      <span class="code-key">"identifiers"</span>: <span class="code-bracket">[</span><span class="code-bracket">{</span><span class="code-key">"type"</span>: <span class="code-string">"domain"</span>, <span class="code-key">"value"</span>: <span class="code-string">"news.publisher.com"</span><span class="code-bracket">}</span><span class="code-bracket">]</span>
     <span class="code-bracket">}</span>
   <span class="code-bracket">]</span>,
   <span class="code-key">"authorized_agents"</span>: <span class="code-bracket">[</span>
     <span class="code-bracket">{</span>
       <span class="code-key">"url"</span>: <span class="code-string">"https://agent.example.com"</span>,
-      <span class="code-key">"authorized_for"</span>: <span class="code-bracket">[</span><span class="code-string">"display"</span>, <span class="code-string">"video"</span><span class="code-bracket">]</span>
+      <span class="code-key">"authorized_for"</span>: <span class="code-string">"Display and video inventory across the main site"</span>,
+      <span class="code-key">"authorization_type"</span>: <span class="code-string">"property_ids"</span>,
+      <span class="code-key">"property_ids"</span>: <span class="code-bracket">[</span><span class="code-string">"main_site"</span><span class="code-bracket">]</span>
     <span class="code-bracket">}</span>
   <span class="code-bracket">]</span>
 <span class="code-bracket">}</span></code></div>
       </div>
 
       <p class="quickstart-note">
-        Place this file at <code>https://yourdomain.com/.well-known/adagents.json</code> and AI sales agents will discover your properties and authorization rules.
+        Place this file at <code>https://yourdomain.com/.well-known/adagents.json</code> and AI sales agents will discover your properties and authorization rules. Every <code>authorized_agents</code> entry must declare an <code>authorization_type</code> plus the matching selector (e.g. <code>property_ids</code>) — otherwise resolvers won't be able to decide what the agent is authorized for.
       </p>
     </div>
   </section>

--- a/server/src/adagents-manager.ts
+++ b/server/src/adagents-manager.ts
@@ -957,30 +957,43 @@ export class AdAgentsManager {
       }
     }
 
-    // Validate authorization_type consistency
-    if (agent.authorization_type) {
-      const validTypes = ['property_ids', 'property_tags', 'inline_properties', 'publisher_properties', 'signal_ids', 'signal_tags'];
-      if (!validTypes.includes(agent.authorization_type)) {
-        result.errors.push({
-          field: `${prefix}.authorization_type`,
-          message: `authorization_type must be one of: ${validTypes.join(', ')}`,
-          severity: 'error'
-        });
-      }
+    // Validate authorization_type per v3 schema. Every authorized_agents[]
+    // entry must declare an authorization_type and ship the matching
+    // non-empty selector — that's the schema's oneOf invariant, and it's
+    // what downstream resolvers (Python/TS SDKs) rely on to decide whether
+    // an agent is actually authorized for a given property/signal. Without
+    // it, publishers see valid:true while consumers see "agent not
+    // authorized" — issue #4476.
+    const validAuthTypes = ['property_ids', 'property_tags', 'inline_properties', 'publisher_properties', 'signal_ids', 'signal_tags'] as const;
+    const selectorByType: Record<typeof validAuthTypes[number], string> = {
+      property_ids: 'property_ids',
+      property_tags: 'property_tags',
+      inline_properties: 'properties',
+      publisher_properties: 'publisher_properties',
+      signal_ids: 'signal_ids',
+      signal_tags: 'signal_tags',
+    };
 
-      // Check that the corresponding array exists for the authorization_type
-      if (agent.authorization_type === 'signal_ids' && (!agent.signal_ids || agent.signal_ids.length === 0)) {
-        result.warnings.push({
-          field: `${prefix}.signal_ids`,
-          message: 'authorization_type is "signal_ids" but no signal_ids provided',
-          suggestion: 'Add signal_ids array with the authorized signal IDs'
-        });
-      }
-      if (agent.authorization_type === 'signal_tags' && (!agent.signal_tags || agent.signal_tags.length === 0)) {
-        result.warnings.push({
-          field: `${prefix}.signal_tags`,
-          message: 'authorization_type is "signal_tags" but no signal_tags provided',
-          suggestion: 'Add signal_tags array with the authorized signal tags'
+    if (!agent.authorization_type) {
+      result.errors.push({
+        field: `${prefix}.authorization_type`,
+        message: `missing required field \`authorization_type\` (one of ${validAuthTypes.map((t) => `\`${t}\``).join(', ')})`,
+        severity: 'error',
+      });
+    } else if (!validAuthTypes.includes(agent.authorization_type)) {
+      result.errors.push({
+        field: `${prefix}.authorization_type`,
+        message: `authorization_type must be one of: ${validAuthTypes.join(', ')}`,
+        severity: 'error',
+      });
+    } else {
+      const selectorField = selectorByType[agent.authorization_type as typeof validAuthTypes[number]];
+      const selectorValue = (agent as Record<string, unknown>)[selectorField];
+      if (!Array.isArray(selectorValue) || selectorValue.length === 0) {
+        result.errors.push({
+          field: `${prefix}.${selectorField}`,
+          message: `authorization_type is "${agent.authorization_type}" but \`${selectorField}\` is missing or empty`,
+          severity: 'error',
         });
       }
     }

--- a/server/tests/unit/adagents-manager.test.ts
+++ b/server/tests/unit/adagents-manager.test.ts
@@ -48,11 +48,13 @@ describe('AdAgentsManager', () => {
   describe('validateDomain', () => {
     it('validates a valid adagents.json file', async () => {
       const validAdAgents: AdAgentsJson = {
-        $schema: 'https://adcontextprotocol.org/schemas/v2/adagents.json',
+        $schema: 'https://adcontextprotocol.org/schemas/v3/adagents.json',
         authorized_agents: [
           {
             url: 'https://agent.example.com',
             authorized_for: 'Test authorization scope',
+            authorization_type: 'property_ids',
+            property_ids: ['p1'],
           },
         ],
         last_updated: new Date().toISOString(),
@@ -83,7 +85,7 @@ describe('AdAgentsManager', () => {
     // the route-layer tests still pass (they upsert metadata directly).
     it('captures response_bytes and resolved_url on a 200 fetch', async () => {
       const valid: AdAgentsJson = {
-        authorized_agents: [{ url: 'https://agent.example.com', authorized_for: 'Test' }],
+        authorized_agents: [{ url: 'https://agent.example.com', authorized_for: 'Test', authorization_type: 'property_ids', property_ids: ['p1'] }],
         last_updated: new Date().toISOString(),
       };
       const body = buf(valid);
@@ -130,7 +132,7 @@ describe('AdAgentsManager', () => {
       // (the authoritative_location target), not where the stub lived.
       const stubBody = buf({ authoritative_location: 'https://cdn.example.net/adagents.json' });
       const canonicalBody = buf({
-        authorized_agents: [{ url: 'https://agent.example.com', authorized_for: 'Test' }],
+        authorized_agents: [{ url: 'https://agent.example.com', authorized_for: 'Test', authorization_type: 'property_ids', property_ids: ['p1'] }],
         last_updated: new Date().toISOString(),
       });
       mockedSafeFetch
@@ -157,7 +159,7 @@ describe('AdAgentsManager', () => {
     it('normalizes domain by removing protocol', async () => {
       mockedSafeFetch.mockResolvedValue({
         status: 200,
-        data: buf({ authorized_agents: [{ url: 'https://agent.example.com', authorized_for: 'Test' }] }),
+        data: buf({ authorized_agents: [{ url: 'https://agent.example.com', authorized_for: 'Test', authorization_type: 'property_ids', property_ids: ['p1'] }] }),
         headers: { 'content-type': 'application/json' },
       });
 
@@ -170,7 +172,7 @@ describe('AdAgentsManager', () => {
     it('normalizes domain by removing trailing slash', async () => {
       mockedSafeFetch.mockResolvedValue({
         status: 200,
-        data: buf({ authorized_agents: [{ url: 'https://agent.example.com', authorized_for: 'Test' }] }),
+        data: buf({ authorized_agents: [{ url: 'https://agent.example.com', authorized_for: 'Test', authorization_type: 'property_ids', property_ids: ['p1'] }] }),
         headers: { 'content-type': 'application/json' },
       });
 
@@ -205,7 +207,7 @@ describe('AdAgentsManager', () => {
         if (url === 'https://manager.example/.well-known/adagents.json') {
           return {
             status: 200,
-            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'All inventory', publisher_properties: [{ publisher_domain: 'publisher.example', selection_type: 'all' }] }] }),
+            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'All inventory', authorization_type: 'publisher_properties', publisher_properties: [{ publisher_domain: 'publisher.example', selection_type: 'all' }] }] }),
             headers: { 'content-type': 'application/json' },
           };
         }
@@ -292,7 +294,7 @@ describe('AdAgentsManager', () => {
         if (url === 'https://manager.example/.well-known/adagents.json') {
           return {
             status: 200,
-            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'All inventory', publisher_properties: [{ publisher_domain: 'publisher.example', selection_type: 'all' }] }] }),
+            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'All inventory', authorization_type: 'publisher_properties', publisher_properties: [{ publisher_domain: 'publisher.example', selection_type: 'all' }] }] }),
             headers: { 'content-type': 'application/json' },
           };
         }
@@ -335,7 +337,7 @@ describe('AdAgentsManager', () => {
         if (url === 'https://good-manager.example/.well-known/adagents.json') {
           return {
             status: 200,
-            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'Good', publisher_properties: [{ publisher_domain: 'publisher.example' }] }] }),
+            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'Good', authorization_type: 'publisher_properties', publisher_properties: [{ publisher_domain: 'publisher.example' }] }] }),
             headers: { 'content-type': 'application/json' },
           };
         }
@@ -367,7 +369,7 @@ describe('AdAgentsManager', () => {
         if (url === 'https://allowed.example/.well-known/adagents.json') {
           return {
             status: 200,
-            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'Allowed', publisher_properties: [{ publisher_domain: 'publisher.example' }] }] }),
+            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'Allowed', authorization_type: 'publisher_properties', publisher_properties: [{ publisher_domain: 'publisher.example' }] }] }),
             headers: { 'content-type': 'application/json' },
           };
         }
@@ -393,7 +395,7 @@ describe('AdAgentsManager', () => {
         if (url === 'https://manager.example/.well-known/adagents.json') {
           return {
             status: 200,
-            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'All inventory' }] }),
+            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'All inventory', authorization_type: 'property_ids', property_ids: ['p1'] }] }),
             headers: { 'content-type': 'application/json' },
           };
         }
@@ -420,7 +422,7 @@ describe('AdAgentsManager', () => {
         if (url === 'https://good.example/.well-known/adagents.json') {
           return {
             status: 200,
-            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'Good', publisher_properties: [{ publisher_domain: 'publisher.example' }] }] }),
+            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'Good', authorization_type: 'publisher_properties', publisher_properties: [{ publisher_domain: 'publisher.example' }] }] }),
             headers: { 'content-type': 'application/json' },
           };
         }
@@ -447,7 +449,7 @@ describe('AdAgentsManager', () => {
         if (url === 'https://good.example/.well-known/adagents.json') {
           return {
             status: 200,
-            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'Good', publisher_properties: [{ publisher_domain: 'publisher.example' }] }] }),
+            data: buf({ authorized_agents: [{ url: 'https://agent.example', authorized_for: 'Good', authorization_type: 'publisher_properties', publisher_properties: [{ publisher_domain: 'publisher.example' }] }] }),
             headers: { 'content-type': 'application/json' },
           };
         }
@@ -476,6 +478,8 @@ describe('AdAgentsManager', () => {
               authorized_agents: [{
                 url: 'https://agent.example',
                 authorized_for: 'Scoped via collection',
+                authorization_type: 'property_tags',
+                property_tags: ['network'],
                 collections: [{ publisher_domain: 'publisher.example' }],
               }],
             }),
@@ -506,6 +510,7 @@ describe('AdAgentsManager', () => {
               authorized_agents: [{
                 url: 'https://agent.example',
                 authorized_for: 'Wrong publisher',
+                authorization_type: 'publisher_properties',
                 publisher_properties: [{ publisher_domain: 'other-publisher.example' }],
               }],
             }),
@@ -744,7 +749,7 @@ describe('AdAgentsManager', () => {
     it('warns about missing optional $schema field', async () => {
       mockedSafeFetch.mockResolvedValue({
         status: 200,
-        data: buf({ authorized_agents: [{ url: 'https://agent.example.com', authorized_for: 'Test' }] }),
+        data: buf({ authorized_agents: [{ url: 'https://agent.example.com', authorized_for: 'Test', authorization_type: 'property_ids', property_ids: ['p1'] }] }),
         headers: { 'content-type': 'application/json' },
       });
 
@@ -757,7 +762,7 @@ describe('AdAgentsManager', () => {
     it('warns about missing last_updated field', async () => {
       mockedSafeFetch.mockResolvedValue({
         status: 200,
-        data: buf({ authorized_agents: [{ url: 'https://agent.example.com', authorized_for: 'Test' }] }),
+        data: buf({ authorized_agents: [{ url: 'https://agent.example.com', authorized_for: 'Test', authorization_type: 'property_ids', property_ids: ['p1'] }] }),
         headers: { 'content-type': 'application/json' },
       });
 
@@ -911,10 +916,14 @@ describe('AdAgentsManager', () => {
             {
               url: 'https://agent.example.com',
               authorized_for: 'Scope 1',
+              authorization_type: 'property_ids',
+              property_ids: ['p1'],
             },
             {
               url: 'https://agent.example.com',
               authorized_for: 'Scope 2',
+              authorization_type: 'property_ids',
+              property_ids: ['p2'],
             },
           ],
         }),
@@ -925,6 +934,85 @@ describe('AdAgentsManager', () => {
 
       expect(result.valid).toBe(true); // Valid but with warning
       expect(result.warnings.some(w => w.message.includes('Duplicate agent URL'))).toBe(true);
+    });
+
+    // Issue #4476: validator was returning valid:true on wonderstruck.org-
+    // style files that omit authorization_type. Per the v3 schema, every
+    // authorized_agents[] entry must declare authorization_type plus a
+    // matching non-empty selector — without that pairing, downstream
+    // resolvers can't decide what the agent is authorized for, and
+    // publishers see "valid" while consumers see "agent not authorized".
+    it('rejects authorized_agents entries that omit authorization_type (issue #4476)', async () => {
+      mockedSafeFetch.mockResolvedValue({
+        status: 200,
+        data: buf({
+          $schema: 'https://adcontextprotocol.org/schemas/v3/adagents.json',
+          authorized_agents: [
+            { url: 'https://wonderstruck.sales-agent.scope3.com', authorized_for: 'Authorized for display banners' },
+            { url: 'https://interchange.io', authorized_for: 'Authorized for display banners' },
+          ],
+          properties: [
+            { property_id: 'main_site', property_type: 'website', name: 'Main site', identifiers: [{ type: 'domain', value: 'wonderstruck.org' }], tags: ['sites'] },
+          ],
+          last_updated: '2026-05-03T14:32:20.587Z',
+        }),
+        headers: { 'content-type': 'application/json' },
+      });
+
+      const result = await manager.validateDomain('wonderstruck.org');
+
+      expect(result.valid).toBe(false);
+      // Per-entry error with field path so publishers can locate the
+      // missing field, plus enum list so they know which selectors to
+      // choose from.
+      expect(result.errors.some(e =>
+        e.field === 'authorized_agents[0].authorization_type' &&
+        e.message.includes('missing required field') &&
+        e.message.includes('authorization_type') &&
+        e.message.includes('property_ids') &&
+        e.message.includes('signal_tags')
+      )).toBe(true);
+      expect(result.errors.some(e => e.field === 'authorized_agents[1].authorization_type')).toBe(true);
+    });
+
+    it('rejects authorized_agents entries whose authorization_type lacks a matching selector', async () => {
+      mockedSafeFetch.mockResolvedValue({
+        status: 200,
+        data: buf({
+          authorized_agents: [
+            { url: 'https://agent.example.com', authorized_for: 'Test', authorization_type: 'property_ids' },
+          ],
+        }),
+        headers: { 'content-type': 'application/json' },
+      });
+
+      const result = await manager.validateDomain('example.com');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e =>
+        e.field === 'authorized_agents[0].property_ids' &&
+        e.message.includes('missing or empty')
+      )).toBe(true);
+    });
+
+    it('rejects authorized_agents entries whose authorization_type selector is an empty array', async () => {
+      mockedSafeFetch.mockResolvedValue({
+        status: 200,
+        data: buf({
+          authorized_agents: [
+            { url: 'https://agent.example.com', authorized_for: 'Test', authorization_type: 'signal_tags', signal_tags: [] },
+          ],
+        }),
+        headers: { 'content-type': 'application/json' },
+      });
+
+      const result = await manager.validateDomain('example.com');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e =>
+        e.field === 'authorized_agents[0].signal_tags' &&
+        e.message.includes('missing or empty')
+      )).toBe(true);
     });
   });
 
@@ -1179,11 +1267,13 @@ describe('AdAgentsManager', () => {
       };
 
       const authoritativeData = {
-        $schema: 'https://adcontextprotocol.org/schemas/v2/adagents.json',
+        $schema: 'https://adcontextprotocol.org/schemas/v3/adagents.json',
         authorized_agents: [
           {
             url: 'https://agent.example.com',
             authorized_for: 'Test authorization',
+            authorization_type: 'property_ids',
+            property_ids: ['p1'],
           },
         ],
         last_updated: '2025-01-15T09:00:00Z'
@@ -1392,6 +1482,8 @@ describe('AdAgentsManager', () => {
         {
           url: 'https://agent.example.com',
           authorized_for: 'Test authorization scope',
+          authorization_type: 'property_ids',
+          property_ids: ['p1'],
         },
       ];
 
@@ -1437,6 +1529,8 @@ describe('AdAgentsManager', () => {
         {
           url: 'https://agent.example.com',
           authorized_for: 'Premium inventory',
+          authorization_type: 'property_ids',
+          property_ids: ['p1'],
           exclusive: true,
           countries: ['US', 'CA'],
           effective_from: '2025-01-01T00:00:00.000Z',
@@ -1505,7 +1599,7 @@ describe('AdAgentsManager', () => {
           status: 200,
           data: buf({
             authorized_agents: [
-              { url: 'https://agent.example.com', authorized_for: 'Test' },
+              { url: 'https://agent.example.com', authorized_for: 'Test', authorization_type: 'property_ids', property_ids: ['p1'] },
             ],
             signals: [
               {
@@ -1530,7 +1624,7 @@ describe('AdAgentsManager', () => {
           status: 200,
           data: buf({
             authorized_agents: [
-              { url: 'https://agent.example.com', authorized_for: 'Test' },
+              { url: 'https://agent.example.com', authorized_for: 'Test', authorization_type: 'property_ids', property_ids: ['p1'] },
             ],
             signals: [
               {
@@ -1555,7 +1649,7 @@ describe('AdAgentsManager', () => {
           status: 200,
           data: buf({
             authorized_agents: [
-              { url: 'https://agent.example.com', authorized_for: 'Test' },
+              { url: 'https://agent.example.com', authorized_for: 'Test', authorization_type: 'property_ids', property_ids: ['p1'] },
             ],
             signals: [
               {
@@ -1580,7 +1674,7 @@ describe('AdAgentsManager', () => {
           status: 200,
           data: buf({
             authorized_agents: [
-              { url: 'https://agent.example.com', authorized_for: 'Test' },
+              { url: 'https://agent.example.com', authorized_for: 'Test', authorization_type: 'property_ids', property_ids: ['p1'] },
             ],
             signals: [
               {
@@ -1603,7 +1697,7 @@ describe('AdAgentsManager', () => {
           status: 200,
           data: buf({
             authorized_agents: [
-              { url: 'https://agent.example.com', authorized_for: 'Test' },
+              { url: 'https://agent.example.com', authorized_for: 'Test', authorization_type: 'property_ids', property_ids: ['p1'] },
             ],
             signals: [
               {
@@ -1627,7 +1721,7 @@ describe('AdAgentsManager', () => {
           status: 200,
           data: buf({
             authorized_agents: [
-              { url: 'https://agent.example.com', authorized_for: 'Test' },
+              { url: 'https://agent.example.com', authorized_for: 'Test', authorization_type: 'property_ids', property_ids: ['p1'] },
             ],
             signals: [
               {
@@ -1650,7 +1744,7 @@ describe('AdAgentsManager', () => {
           status: 200,
           data: buf({
             authorized_agents: [
-              { url: 'https://agent.example.com', authorized_for: 'Test' },
+              { url: 'https://agent.example.com', authorized_for: 'Test', authorization_type: 'property_ids', property_ids: ['p1'] },
             ],
             signals: [
               {
@@ -1674,7 +1768,7 @@ describe('AdAgentsManager', () => {
           status: 200,
           data: buf({
             authorized_agents: [
-              { url: 'https://agent.example.com', authorized_for: 'Test' },
+              { url: 'https://agent.example.com', authorized_for: 'Test', authorization_type: 'property_ids', property_ids: ['p1'] },
             ],
             signals: [
               {
@@ -1698,7 +1792,7 @@ describe('AdAgentsManager', () => {
           status: 200,
           data: buf({
             authorized_agents: [
-              { url: 'https://agent.example.com', authorized_for: 'Test' },
+              { url: 'https://agent.example.com', authorized_for: 'Test', authorization_type: 'property_ids', property_ids: ['p1'] },
             ],
             signals: [
               {
@@ -1723,7 +1817,7 @@ describe('AdAgentsManager', () => {
           status: 200,
           data: buf({
             authorized_agents: [
-              { url: 'https://agent.example.com', authorized_for: 'Test' },
+              { url: 'https://agent.example.com', authorized_for: 'Test', authorization_type: 'property_ids', property_ids: ['p1'] },
             ],
             signals: [
               {
@@ -1748,7 +1842,7 @@ describe('AdAgentsManager', () => {
           status: 200,
           data: buf({
             authorized_agents: [
-              { url: 'https://agent.example.com', authorized_for: 'Test' },
+              { url: 'https://agent.example.com', authorized_for: 'Test', authorization_type: 'property_ids', property_ids: ['p1'] },
             ],
             signals: [
               {
@@ -1773,7 +1867,7 @@ describe('AdAgentsManager', () => {
           status: 200,
           data: buf({
             authorized_agents: [
-              { url: 'https://agent.example.com', authorized_for: 'Test' },
+              { url: 'https://agent.example.com', authorized_for: 'Test', authorization_type: 'property_ids', property_ids: ['p1'] },
             ],
             signals: [
               {
@@ -1800,7 +1894,7 @@ describe('AdAgentsManager', () => {
           status: 200,
           data: buf({
             authorized_agents: [
-              { url: 'https://agent.example.com', authorized_for: 'Test' },
+              { url: 'https://agent.example.com', authorized_for: 'Test', authorization_type: 'property_ids', property_ids: ['p1'] },
             ],
             signals: [
               { id: 'test', name: 'Test', value_type: 'binary', tags: ['automotive'] },
@@ -1822,7 +1916,7 @@ describe('AdAgentsManager', () => {
           status: 200,
           data: buf({
             authorized_agents: [
-              { url: 'https://agent.example.com', authorized_for: 'Test' },
+              { url: 'https://agent.example.com', authorized_for: 'Test', authorization_type: 'property_ids', property_ids: ['p1'] },
             ],
             signals: [
               { id: 'test', name: 'Test', value_type: 'binary', tags: ['undefined_tag'] },
@@ -1842,7 +1936,7 @@ describe('AdAgentsManager', () => {
           status: 200,
           data: buf({
             authorized_agents: [
-              { url: 'https://agent.example.com', authorized_for: 'Test' },
+              { url: 'https://agent.example.com', authorized_for: 'Test', authorization_type: 'property_ids', property_ids: ['p1'] },
             ],
             signals: [
               { id: 'duplicate_id', name: 'Signal 1', value_type: 'binary' },
@@ -1937,7 +2031,7 @@ describe('AdAgentsManager', () => {
         expect(result.warnings.some(w => w.message.includes('nonexistent_signal'))).toBe(true);
       });
 
-      it('warns when signal_ids authorization type but no signal_ids array', async () => {
+      it('errors when signal_ids authorization type but no signal_ids array (v3 schema)', async () => {
         mockedSafeFetch.mockResolvedValue({
           status: 200,
           data: buf({
@@ -1954,8 +2048,13 @@ describe('AdAgentsManager', () => {
 
         const result = await manager.validateDomain('polk.com');
 
-        expect(result.valid).toBe(true);
-        expect(result.warnings.some(w => w.message.includes('signal_ids') && w.message.includes('no signal_ids provided'))).toBe(true);
+        // v3 schema requires a non-empty signal_ids selector when
+        // authorization_type is 'signal_ids' — see issue #4476.
+        expect(result.valid).toBe(false);
+        expect(result.errors.some(e =>
+          e.field === 'authorized_agents[0].signal_ids' &&
+          e.message.includes('missing or empty')
+        )).toBe(true);
       });
 
       it('errors when signal_ids is not an array', async () => {


### PR DESCRIPTION
## Summary

- `AdAgentsManager.validateAgent` now enforces the v3 schema's oneOf invariant on every `authorized_agents[]` entry: `authorization_type` plus a non-empty matching selector (`property_ids`, `property_tags`, `properties` for `inline_properties`, `publisher_properties`, `signal_ids`, `signal_tags`).
- Per-entry error messages name the missing field path (`authorized_agents[0].authorization_type`) and list the valid selector enums, so publishers can locate and fix the gap.
- The `/adagents` Quick Start example was on a stale schema (`publisher_domain` at root, `authorized_for` as an array, no `authorization_type`) — replaced with a v3-correct example. `docs/governance/property/adagents.mdx` field reference flips `authorization_type` from \"optional\" to \"required\" with the selector-pairing rule called out.

Before this change, files like [wonderstruck.org's adagents.json](https://wonderstruck.org/.well-known/adagents.json) (and Raptive's, and others') returned `valid: true` from the online validator — while the Python and TS SDKs correctly read the entries as unauthorized. Publishers saw \"valid\" and assumed they were done; buyers saw \"agent not authorized.\" The validator was the source of the disagreement.

Closes #4476.

## Test plan

- [x] `vitest run tests/unit/adagents-manager.test.ts` — 92/92 pass, including three new tests covering: the exact wonderstruck.org repro, `authorization_type` present without selector, and selector present as empty array.
- [x] Updated one previously-passing test that asserted the old warning-only behavior (signal_ids type with no signal_ids array) to expect the new error.
- [x] Existing managerdomain-fallback fixtures updated to declare `authorization_type` on the manager-served manifest so those tests still exercise the scope-rejection path rather than failing at structural validation.
- [ ] Spot-check the `/adagents` landing page renders the new Quick Start example correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)