### PR TITLE
fix(users): refresh denormalized email after primary-credential swap

### DIFF
--- a/.changeset/refresh-denormalized-user-email.md
+++ b/.changeset/refresh-denormalized-user-email.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix stale email in admin person-detail view and member list after a primary-email swap. `person_relationships.email` and `organization_memberships.email` denormalize `users.email`, but the three write paths that mutate `users.email` (`mergeUsers`, `PUT /api/me/linked-emails/primary`, and the WorkOS `user.updated` webhook) were not all refreshing both denorms — the most common gap was `person_relationships.email`, which is what the admin "person" header reads. Refreshes are now applied in all three paths inside the same transaction as the swap, and a backfill migration (476) repairs the rows that already drifted.

--- a/server/src/db/migrations/476_refresh_denormalized_user_email.sql
+++ b/server/src/db/migrations/476_refresh_denormalized_user_email.sql
@@ -1,0 +1,30 @@
+-- Backfill stale denormalized email on person_relationships and
+-- organization_memberships from users.email.
+--
+-- Why: both tables carry a copy of users.email that the admin UI and member
+-- list read directly. The mergeUsers and PUT /primary code paths swap
+-- users.email without refreshing these denorms, so promotes and primary-email
+-- swaps leave the row showing the old email. The companion code change in
+-- this PR adds the refresh to both paths going forward; this migration mops
+-- up the rows that already drifted (174 person_relationships, 2
+-- organization_memberships at the time of writing).
+--
+-- Same drift pattern as the FK-less denormalized pointer playbook on
+-- users.primary_organization_id (PR #4182 / migration 473): read self-heal,
+-- write-path fix, one-shot backfill. There's no FK to add for email — it's
+-- a string, not a pointer — but the refresh-on-write keeps it from drifting
+-- again.
+
+UPDATE person_relationships pr
+   SET email = u.email,
+       updated_at = NOW()
+  FROM users u
+ WHERE pr.workos_user_id = u.workos_user_id
+   AND pr.email IS DISTINCT FROM u.email;
+
+UPDATE organization_memberships om
+   SET email = u.email,
+       updated_at = NOW()
+  FROM users u
+ WHERE om.workos_user_id = u.workos_user_id
+   AND om.email IS DISTINCT FROM u.email;

--- a/server/src/db/user-merge-db.ts
+++ b/server/src/db/user-merge-db.ts
@@ -662,6 +662,28 @@ export async function mergeUsers(
       );
     }
 
+    // Refresh denormalized email on rows now keyed to the primary credential.
+    // person_relationships and organization_memberships each carry their own
+    // copy of users.email; without this re-derive, a promote (or any merge
+    // that swings workos_user_id onto a different credential) leaves the
+    // admin UI and member list showing the old email.
+    await client.query(
+      `UPDATE person_relationships pr SET email = u.email, updated_at = NOW()
+         FROM users u
+        WHERE pr.workos_user_id = $1
+          AND u.workos_user_id = $1
+          AND pr.email IS DISTINCT FROM u.email`,
+      [primaryUserId]
+    );
+    await client.query(
+      `UPDATE organization_memberships om SET email = u.email, updated_at = NOW()
+         FROM users u
+        WHERE om.workos_user_id = $1
+          AND u.workos_user_id = $1
+          AND om.email IS DISTINCT FROM u.email`,
+      [primaryUserId]
+    );
+
     // =====================================================
     // 5. Audit log
     // =====================================================

--- a/server/src/routes/account-linking.ts
+++ b/server/src/routes/account-linking.ts
@@ -250,11 +250,12 @@ export function createAccountLinkingRouter(): Router {
       //
       // If WorkOS accepts but the local swap below fails, `users.email` and
       // `organization_memberships.email` will eventually re-sync via the
-      // user.updated webhook. The `user_email_aliases` table is NOT touched
-      // by the webhook, so a partial failure here can leave the alias list
-      // stale (the new email remains as a verified alias, the old primary
-      // is not recorded). UNIQUE(LOWER(email)) on aliases prevents anyone
-      // else from claiming the abandoned email; cleanup is manual.
+      // user.updated webhook. `user_email_aliases` and `person_relationships`
+      // are NOT touched by the webhook, so a partial failure here can leave
+      // the alias list stale (new email remains as a verified alias, old
+      // primary is not recorded) and the relationship row's email lagging.
+      // UNIQUE(LOWER(email)) on aliases prevents anyone else from claiming
+      // the abandoned email; cleanup is manual.
       try {
         // Mutate the actually-signed-in WorkOS user's email, not the
         // post-swap canonical. Email is per-credential.
@@ -312,7 +313,15 @@ export function createAccountLinkingRouter(): Router {
 
         await client.query(
           `UPDATE organization_memberships SET email = $1, updated_at = NOW()
-           WHERE workos_user_id = $2`,
+           WHERE workos_user_id = $2
+             AND email IS DISTINCT FROM $1`,
+          [aliasEmail, userId]
+        );
+
+        await client.query(
+          `UPDATE person_relationships SET email = $1, updated_at = NOW()
+           WHERE workos_user_id = $2
+             AND email IS DISTINCT FROM $1`,
           [aliasEmail, userId]
         );
 

--- a/server/src/routes/workos-webhooks.ts
+++ b/server/src/routes/workos-webhooks.ts
@@ -493,6 +493,16 @@ async function updateUserAcrossMemberships(user: UserData): Promise<void> {
     [user.email, user.id]
   );
 
+  // person_relationships denormalizes users.email too. Keep it in sync so
+  // the admin person-detail header doesn't lag the canonical email after a
+  // WorkOS-side update (dashboard edit, OIDC profile sync, primary swap).
+  await pool.query(
+    `UPDATE person_relationships SET email = $1, updated_at = NOW()
+      WHERE workos_user_id = $2
+        AND email IS DISTINCT FROM $1`,
+    [user.email, user.id]
+  );
+
   logger.info({
     userId: user.id,
     updatedCount: result.rowCount,

--- a/server/tests/integration/merge-bind-not-delete.test.ts
+++ b/server/tests/integration/merge-bind-not-delete.test.ts
@@ -72,6 +72,10 @@ describe('mergeUsers (bind, don\'t delete)', () => {
       `DELETE FROM addie_prompt_telemetry WHERE workos_user_id IN ($1, $2)`,
       [PRIMARY_ID, SECONDARY_ID]
     );
+    await pool.query(
+      `DELETE FROM organization_memberships WHERE workos_user_id IN ($1, $2)`,
+      [PRIMARY_ID, SECONDARY_ID]
+    );
     await pool.query(`DELETE FROM users WHERE workos_user_id IN ($1, $2)`, [PRIMARY_ID, SECONDARY_ID]);
     await pool.query(`DELETE FROM organizations WHERE workos_organization_id = $1`, [ORG_ID]);
   }
@@ -224,6 +228,103 @@ describe('mergeUsers (bind, don\'t delete)', () => {
       [secondaryRelId]
     );
     expect(secondaryRelAfter.rows).toHaveLength(0);
+  });
+
+  it('refreshes person_relationships.email from users.email for the surviving primary row (promote case)', async () => {
+    // Promote shape: primary is the freshly-added credential with no
+    // person_relationships row of its own; secondary owns the row with the
+    // old email. After mergeUsers, the row is re-pointed to primary and its
+    // email column should reflect the primary's current users.email.
+    await pool.query(
+      `INSERT INTO person_relationships (workos_user_id, email, stage)
+       VALUES ($1, 'secondary@test.example', 'exploring')`,
+      [SECONDARY_ID]
+    );
+
+    await mergeUsers(PRIMARY_ID, SECONDARY_ID, PRIMARY_ID);
+
+    const rel = await pool.query<{ workos_user_id: string; email: string }>(
+      `SELECT workos_user_id, email FROM person_relationships WHERE workos_user_id = $1`,
+      [PRIMARY_ID]
+    );
+    expect(rel.rows).toHaveLength(1);
+    expect(rel.rows[0].email).toBe('primary@test.example');
+  });
+
+  it('refreshes person_relationships.email for primary\'s pre-existing row when its email is stale (merge case)', async () => {
+    // Both users have a person_relationships row, and primary's row carries a
+    // stale email that pre-dates the credential swap. After mergeUsers, the
+    // secondary's row is deleted and the primary's row keeps its id but its
+    // email column gets re-derived from users.email.
+    const primaryRel = await pool.query<{ id: string }>(
+      `INSERT INTO person_relationships (workos_user_id, email, stage)
+       VALUES ($1, 'stale-primary@test.example', 'exploring') RETURNING id`,
+      [PRIMARY_ID]
+    );
+    await pool.query(
+      `INSERT INTO person_relationships (workos_user_id, email, stage)
+       VALUES ($1, 'secondary@test.example', 'exploring')`,
+      [SECONDARY_ID]
+    );
+
+    await mergeUsers(PRIMARY_ID, SECONDARY_ID, PRIMARY_ID);
+
+    const rel = await pool.query<{ id: string; email: string }>(
+      `SELECT id, email FROM person_relationships WHERE workos_user_id = $1`,
+      [PRIMARY_ID]
+    );
+    expect(rel.rows).toHaveLength(1);
+    expect(rel.rows[0].id).toBe(primaryRel.rows[0].id);
+    expect(rel.rows[0].email).toBe('primary@test.example');
+  });
+
+  it('refreshes organization_memberships.email from users.email when it has drifted', async () => {
+    await pool.query(
+      `INSERT INTO organization_memberships (workos_user_id, workos_organization_id, email, role, created_at, updated_at)
+       VALUES ($1, $2, 'stale-primary@test.example', 'member', NOW(), NOW())`,
+      [PRIMARY_ID, ORG_ID]
+    );
+
+    await mergeUsers(PRIMARY_ID, SECONDARY_ID, PRIMARY_ID);
+
+    const row = await pool.query<{ email: string }>(
+      `SELECT email FROM organization_memberships WHERE workos_user_id = $1 AND workos_organization_id = $2`,
+      [PRIMARY_ID, ORG_ID]
+    );
+    expect(row.rows).toHaveLength(1);
+    expect(row.rows[0].email).toBe('primary@test.example');
+  });
+
+  it('refreshes email even on the consolidate path when secondary has app-state to move', async () => {
+    // Consolidate shape: secondary owns app-state (telemetry rows + a stale
+    // relationship row) and primary is the newly-bound credential. The merge
+    // moves data forward AND refreshes the denormalized email on the
+    // surviving primary row. This proves the refresh isn't short-circuited
+    // by any of the other merge branches.
+    await pool.query(
+      `INSERT INTO addie_prompt_telemetry (workos_user_id, rule_id, shown_count, clicked_count)
+       VALUES ($1, 'secondary_rule', 3, 1)`,
+      [SECONDARY_ID]
+    );
+    await pool.query(
+      `INSERT INTO person_relationships (workos_user_id, email, stage)
+       VALUES ($1, 'secondary@test.example', 'exploring')`,
+      [SECONDARY_ID]
+    );
+
+    await mergeUsers(PRIMARY_ID, SECONDARY_ID, PRIMARY_ID);
+
+    const rel = await pool.query<{ email: string }>(
+      `SELECT email FROM person_relationships WHERE workos_user_id = $1`,
+      [PRIMARY_ID]
+    );
+    expect(rel.rows[0].email).toBe('primary@test.example');
+
+    const telemetry = await pool.query<{ rule_id: string }>(
+      `SELECT rule_id FROM addie_prompt_telemetry WHERE workos_user_id = $1`,
+      [PRIMARY_ID]
+    );
+    expect(telemetry.rows.map(r => r.rule_id)).toEqual(['secondary_rule']);
   });
 
   it('merges addie_prompt_telemetry on (workos_user_id, rule_id), keeping primary\'s row when both have one for the same rule', async () => {

--- a/server/tests/unit/set-primary-email.test.ts
+++ b/server/tests/unit/set-primary-email.test.ts
@@ -70,6 +70,11 @@ describe('Set primary email endpoint', () => {
   it('rolls back on error', () => {
     expect(source).toMatch(/ROLLBACK/);
   });
+
+  it('refreshes denormalized email on organization_memberships and person_relationships', () => {
+    expect(source).toMatch(/UPDATE organization_memberships SET email/);
+    expect(source).toMatch(/UPDATE person_relationships SET email/);
+  });
 });
 
 describe('isEmailUnavailable', () => {

--- a/server/tests/unit/workos-webhook-email-refresh.test.ts
+++ b/server/tests/unit/workos-webhook-email-refresh.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Static-analysis test for the user.updated webhook handler.
+ * Asserts that updateUserAcrossMemberships refreshes both denormalized email
+ * columns (organization_memberships and person_relationships) when WorkOS
+ * pushes a user-update event — a regression here re-introduces the drift
+ * that migration 476 had to backfill.
+ */
+
+const WEBHOOK_FILE = path.resolve(
+  __dirname,
+  '../../src/routes/workos-webhooks.ts'
+);
+
+describe('updateUserAcrossMemberships denormalized email refresh', () => {
+  const source = fs.readFileSync(WEBHOOK_FILE, 'utf-8');
+
+  it('refreshes organization_memberships.email from the webhook payload', () => {
+    expect(source).toMatch(/UPDATE organization_memberships[\s\S]*?SET[\s\S]*?email = \$1/);
+  });
+
+  it('refreshes person_relationships.email from the webhook payload', () => {
+    expect(source).toMatch(/UPDATE person_relationships SET email = \$1/);
+  });
+});


### PR DESCRIPTION
## Summary

- `person_relationships.email` and `organization_memberships.email` denormalize `users.email`, but the three write paths that mutate `users.email` — `mergeUsers`, `PUT /api/me/linked-emails/primary`, and the WorkOS `user.updated` webhook — were not all refreshing both denorms. The admin person-detail header reads `person_relationships.email` and was showing stale addresses after a primary-credential promote.
- Refresh added in all three paths inside the swap transaction, guarded by `email IS DISTINCT FROM` so no-ops don't tick `updated_at`.
- Migration 476 backfills the rows that had already drifted in prod (174 person_relationships, 2 organization_memberships at audit time, including escalation #339 / Luc Cormier).

## Why this isn't a one-off

This is the same FK-less denormalized-pointer drift pattern fixed for `users.primary_organization_id` in PR #4182 / migration 473 — see [`feedback_fkless_pointer_playbook`](https://github.com/adcontextprotocol/adcp/blob/main/.claude/memory/feedback_fkless_pointer_playbook.md). Read self-heal isn't applicable here (the value is a string, not a pointer), so the playbook collapses to: fix the write paths and one-shot backfill.

## Test plan

- [x] `tests/integration/merge-bind-not-delete.test.ts` — 4 new tests cover promote (no primary row), merge (stale primary row), org_memberships drift, and consolidate-with-app-state.
- [x] `tests/unit/set-primary-email.test.ts` — static-analysis assertion that both UPDATEs exist in `PUT /primary`.
- [x] `tests/unit/workos-webhook-email-refresh.test.ts` — static-analysis assertion that the webhook handler refreshes both denorms.
- [x] Migration applied locally; backfill query confirmed idempotent (re-running counts zero drift).
- [x] Precommit (test:unit + dynamic-imports + typecheck) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)