### PR TITLE
feat(tmp): backport seller_agent_url to 3.0.x (3.0.12)

### DIFF
--- a/.changeset/tmp-identity-match-seller-agent-url.md
+++ b/.changeset/tmp-identity-match-seller-agent-url.md
@@ -1,0 +1,42 @@
+---
+"adcontextprotocol": patch
+---
+
+TMP Identity Match: add required `seller_agent_url` to the request and make
+`package_ids` optional.
+
+**Why.** The buyer's identity-match service already keeps the authoritative
+set of active packages it has registered per seller. Carrying that set on
+every request was redundant and forced publishers to enumerate ALL active
+packages on every call to avoid the set-correlation attack on Context
+Match. Identifying the seller by URL lets the buyer resolve the package
+set itself.
+
+**Changes to `static/schemas/source/tmp/identity-match-request.json`.**
+
+- New required field `seller_agent_url` (`string`, `format: uri`). The
+  seller agent's API endpoint URL. Compared using the AdCP URL
+  canonicalization rules, consistent with `seller_agent.agent_url` on
+  `AvailablePackage` and `agent_url` in `adagents.json`.
+- `package_ids` is now optional. When omitted, the buyer evaluates against
+  the full active set registered for `seller_agent_url`. When provided,
+  the ALL-active-packages rule still applies — partial sets remain a
+  correlation risk.
+- Top-level description updated to reflect both modes.
+
+**Spec changes alongside the schema.**
+
+- Reversed prior stance forbidding seller identity on `identity_match_request`. The "What This Is Not" / SellerAgentRef guidance has been narrowed to apply only to `context_match_request`.
+- Added a fail-closed rule: when `seller_agent_url` matches no seller for which the buyer has registered active packages, the buyer MUST return an empty `eligible_package_ids`, not fall back to another seller's set.
+- Defined precedence when both `seller_agent_url` and `package_ids` are present: buyer evaluates against the intersection of its registered active set and `package_ids`; unknown IDs are silently dropped (not error-surfaced) so the response cannot leak registry membership.
+- Reframed the package-set-decorrelation invariant as **statistical independence of `package_ids` from the current placement**, with two acceptable modes: all-active and fuzzed (random sample padded with synthetic non-existent IDs that the buyer silently drops). The page-specific subset remains forbidden.
+- Strengthened temporal decorrelation: random delay alone leaks the pairing through ordering. Publishers SHOULD also randomize whether Context Match or Identity Match is sent first — each opportunity SHOULD have a roughly equal probability either way.
+
+**Privacy boundary.** `seller_agent_url` identifies the seller agent, not
+the user; no leakage across the identity boundary. Routers do NOT strip
+it (unlike `country`) — buyers need it to resolve the package set.
+
+**Backwards compatibility.** Breaking for the experimental TMP schema
+(`x-status: experimental`): callers MUST now send `seller_agent_url`. The
+relaxation of `package_ids` is non-breaking on its own — previously valid
+requests remain valid as long as they also include `seller_agent_url`.

--- a/docs/trusted-match/buyer-guide.mdx
+++ b/docs/trusted-match/buyer-guide.mdx
@@ -16,7 +16,7 @@ A buyer agent exposes two HTTP/2 endpoints under a single base URL — `POST /co
 | Message type | Receives | Returns |
 |---|---|---|
 | `context_match_request` | Page/content signals, placement, geo | Offers with creative manifests |
-| `identity_match_request` | Opaque user token, all active package IDs | Eligible package IDs + TTL |
+| `identity_match_request` | Seller agent URL, identity tokens, optional package ID list | Eligible package IDs + TTL |
 
 Each endpoint handles one message type. Both must respond in under 50ms. The router enforces this budget and will skip slow providers.
 
@@ -90,13 +90,14 @@ The router sends you page context. You evaluate your active packages against tha
 
 ## Responding to Identity Match
 
-The router sends you one or more opaque identity tokens and a list of ALL your active package IDs for this publisher. You resolve on whichever tokens you support, then check each package's eligibility rules against the resolved user.
+The router sends you the seller's `seller_agent_url` and one or more identity tokens. Use `seller_agent_url` to look up the active package set you have registered for that seller, resolve identities on whichever tokens you support, then check each package's eligibility rules against the resolved user. The publisher MAY also send `package_ids` to scope evaluation explicitly; when present, evaluate against the **intersection** of your registered active set and `package_ids`, and **silently drop** any IDs you don't recognize — both publisher modes (all-active and fuzzed/padded) rely on this behavior. Surfacing unknown IDs as errors would leak your registry membership back to the publisher.
 
 ```json
 // Request you receive
 {
   "type": "identity_match_request",
   "request_id": "id-9c4e",
+  "seller_agent_url": "https://publisher.example",
   "identities": [
     { "user_token": "opaque-token-abc123", "uid_type": "publisher_first_party" },
     { "user_token": "ID5*7xYp...", "uid_type": "id5" }

--- a/docs/trusted-match/context-and-identity.mdx
+++ b/docs/trusted-match/context-and-identity.mdx
@@ -116,7 +116,7 @@ This is not a policy restriction. It is enforced by the router's context code pa
 
 ## Identity Match
 
-Separately — and with a random time delay — the publisher sends an Identity Match request to the TMP Router, which fans out to each buyer's agent. The request contains an opaque user token and the list of packages to evaluate. It contains no page context.
+Separately — and with a random delay and random ordering, so the two requests can't be paired by timing or by which arrives first — the publisher sends an Identity Match request to the TMP Router, which fans out to each buyer's agent. The request contains the publisher's `seller_agent_url` and an identity token; the buyer resolves the active package set from `seller_agent_url`, or evaluates against the explicit `package_ids` list when the publisher sends one. The request contains no page context.
 
 ### What the publisher sends
 
@@ -124,6 +124,7 @@ Separately — and with a random time delay — the publisher sends an Identity 
 {
   "type": "identity_match_request",
   "request_id": "id-9b2c",
+  "seller_agent_url": "https://publisher.example",
   "identities": [
     { "user_token": "tok_hk82mfp1", "uid_type": "uid2" },
     { "user_token": "ID5*aB3xY...", "uid_type": "id5" },
@@ -225,6 +226,6 @@ Identity Match sends ALL active package IDs for a given buyer — not just those
 
 Package lists update when new media buys are created via `create_media_buy`. The router maintains the active package list per buyer, derived from the buyer's media buy history with the publisher.
 
-In Context Match, the optional `package_ids` field can narrow evaluation when the publisher has a specific reason — for example, CTV pod composition where only video packages apply. This does not affect Identity Match, which always sends ALL active packages.
+In Context Match, the optional `package_ids` field can narrow evaluation when the publisher has a specific reason — for example, CTV pod composition where only video packages apply. This does not affect Identity Match: when Identity Match sends `package_ids`, the composition must be independent of the current placement (all-active or fuzzed), not the placement-specific subset.
 
 Stale packages from expired or cancelled media buys should be removed from the active list within 1 hour. The router is responsible for this cleanup.

--- a/docs/trusted-match/index.mdx
+++ b/docs/trusted-match/index.mdx
@@ -141,6 +141,7 @@ Request from StreamHaus to Sam's buyer agent:
 {
   "type": "identity_match_request",
   "request_id": "id-7c9e1d",
+  "seller_agent_url": "https://streamhaus.example",
   "identities": [
     { "user_token": "opaque-streamhaus-token-abc123", "uid_type": "uid2" },
     { "user_token": "ID5*zP3wK...", "uid_type": "id5" }
@@ -166,7 +167,7 @@ Response from Sam's buyer agent:
 
 Only eligible packages are listed — `pkg-outdoor-audio` passes the buyer's checks. The `ttl_sec: 60` tells the router to cache this eligibility for 60 seconds.
 
-The `package_ids` in the request includes ALL of Sam's active packages — not just those relevant to the current page. Sending only the page-specific subset would let the buyer match package sets across Context Match and Identity Match, breaking the structural separation.
+The example sends `package_ids` explicitly, but the publisher MAY omit it — Sam's identity-match service resolves the active package set from `seller_agent_url`. When `package_ids` IS sent, its composition MUST be independent of the current page — either all-active (every Sam package at StreamHaus) or fuzzed (a random sample padded with synthetic IDs that Sam will silently drop). A page-specific subset is forbidden; it would let the buyer correlate package sets across Context Match and Identity Match, breaking the structural separation.
 
 </Accordion>
 

--- a/docs/trusted-match/privacy-architecture.mdx
+++ b/docs/trusted-match/privacy-architecture.mdx
@@ -107,7 +107,7 @@ The TMPX token does not violate structural separation because:
 If the context path sent only the packages relevant to this page, and the identity path sent only those same packages, a buyer could compare the two sets and infer which page the identity request came from. TMP prevents this by requiring structurally different sets:
 
 - **Context Match** sends no package list. The provider evaluates its synced package set for the placement — stable per placement, the same for every user. Because no packages are sent per request, the publisher cannot accidentally leak identity through package filtering.
-- **Identity Match** sends `package_ids`: ALL active packages for the buyer across all placements and properties. The buyer evaluates the user against their full package portfolio.
+- **Identity Match** sends `package_ids` (or omits it entirely, in which case the buyer evaluates against its full registered active set for `seller_agent_url`). When sent, composition MUST be statistically independent of the current placement — either all-active (every active package for this buyer at this publisher) or fuzzed (a random sample optionally padded with synthetic non-existent IDs that the buyer silently drops). The buyer evaluates the user against this set, not against just the page-specific subset.
 
 The context set is scoped to one placement. The identity set is scoped to one buyer's entire active inventory. The two sets are structurally different, and neither reveals information about the other.
 
@@ -115,9 +115,10 @@ The publisher performs the intersection locally: which packages were both activa
 
 ## Temporal Decorrelation
 
-Even with separate code paths and different package sets, if Context Match and Identity Match requests arrive at a buyer at the same instant from the same publisher, timing correlation is possible. TMP addresses this:
+Even with separate code paths and different package sets, if Context Match and Identity Match requests arrive at a buyer at the same instant — or always in the same order — from the same publisher, timing or ordering correlation is possible. TMP addresses both:
 
 - Publishers SHOULD introduce a random delay between context and identity requests. The recommended range is 100-2000ms, uniformly distributed.
+- Publishers SHOULD also randomize the order: each opportunity SHOULD have a roughly equal probability of context match going first or identity match going first. A fixed order leaks the pairing through ordering even when the delay is randomized.
 - Publishers MAY batch Identity Match requests across multiple page views, further obscuring which context request each identity request corresponds to.
 - Publishers MAY route context and identity requests through different network paths.
 

--- a/docs/trusted-match/specification.mdx
+++ b/docs/trusted-match/specification.mdx
@@ -26,7 +26,7 @@ Specific areas expected to evolve include TMPX exposure tokens, country-partitio
 | **Seller agent** | The buyer-side agent that sold the package into a publisher. Identified by the agent URL declared in the publisher's `adagents.json` `authorized_agents[].url`. Every `AvailablePackage` is bound to exactly one seller agent at sync time. |
 | **Eligibility** | List of eligible package IDs returned by Identity Match, plus a TTL caching contract. The buyer computes eligibility from frequency caps, audience membership, and other signals; the reasons are opaque to the publisher. |
 | **Artifact** | A typed content reference associated with a publisher property (article URL, episode EIDR, show Gracenote ID, music ISRC, product GTIN, conversation turn). Each artifact has a `type` and `value`. Referenced in context match requests. |
-| **Temporal decorrelation** | Random delay introduced between Context Match and Identity Match requests to prevent timing-based correlation. |
+| **Temporal decorrelation** | Random delay and random ordering between Context Match and Identity Match requests, preventing timing- and order-based correlation. |
 
 ## Message Types
 
@@ -174,16 +174,17 @@ Response-level targeting signals for ad server pass-through.
 
 ### IdentityMatchRequest
 
-Sent by the publisher (via router) to buyer agents. Contains one or more opaque identity tokens and package IDs. MUST NOT contain page context.
+Sent by the publisher (via router) to buyer agents. Contains the seller agent URL, one or more opaque identity tokens, and an optional package ID list. MUST NOT contain page context.
 
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `type` | string | Yes | `"identity_match_request"`. Message type discriminator for deserialization. |
 | `protocol_version` | string | No | TMP protocol version. Default: `1.0`. |
 | `request_id` | string | Yes | Unique request identifier. MUST NOT correlate with any Context Match request_id. |
+| `seller_agent_url` | string (URI) | Yes | API endpoint URL of the seller agent issuing this request. The buyer's identity-match service uses this to resolve the active package set it has registered for this seller; when `package_ids` is omitted, evaluation occurs against that full set. Compared using the [AdCP URL canonicalization rules](/docs/reference/url-canonicalization), not byte-equality. Consistent with `seller_agent.agent_url` on `AvailablePackage` and `agent_url` in `adagents.json`. |
 | `identities` | List\<Identity\> | Yes | One or more identity tokens for the user. Publishers SHOULD include every token they have available — the buyer resolves on whichever graph matches, maximizing match rate. Each entry is an independent identifier for the same user; buyers MUST NOT treat the combination as a new correlated identity. |
 | `consent` | Consent | No | Privacy consent signals. Buyers in regulated jurisdictions MUST NOT process identity tokens without consent information. |
-| `package_ids` | List\<string\> | Yes | ALL active packages for this buyer at this publisher. MUST include every active package, not just those on the current page, to prevent set-correlation with Context Match. |
+| `package_ids` | List\<string\> | No | When omitted, the buyer evaluates eligibility against the full set of active packages it has registered for `seller_agent_url`. When provided, composition MUST be statistically independent of the current placement. Two acceptable modes: **all-active** (every active package for this buyer at this publisher) or **fuzzed** (a random sample of active packages, optionally padded with synthetic non-existent IDs, drawn from a distribution that does not depend on the current placement). The page-specific subset is forbidden — it would let the buyer correlate with Context Match by comparing package sets. |
 | `country` | string | No | ISO 3166-1 alpha-2 country code. Routing directive — the router uses this to select the correct regional provider. The router MUST strip this field before forwarding to the buyer agent. Not an identity signal. |
 
 Each entry in `identities` is an `{user_token, uid_type}` pair:
@@ -329,11 +330,13 @@ TMP providers cache packages from many seller agents against many publishers. Th
 
 The canonical seller identity in AdCP is the agent URL declared in the property publisher's [adagents.json](https://adcontextprotocol.org/schemas/v3/adagents.json) `authorized_agents[].url` entry. TMP reuses that URL directly rather than introducing a parallel identifier space. The `id` slot on `SellerAgentRef` is reserved for a future registry-assigned opaque identifier and is not used today.
 
-**Placement rationale.** `seller_agent` lives on the cached `AvailablePackage` (sync time), not on `context_match_request` or `identity_match_request`:
+**Placement rationale.** Context Match and Identity Match are processed by different actors with different package visibility, so seller identity is on the wire for one but not the other: Context Match goes to the provider (which already has the sync-time binding), Identity Match goes to the buyer agent (which needs the seller URL to index its own registered active set). `seller_agent` lives on the cached `AvailablePackage` (sync time) and does not appear on `context_match_request`:
 
 - Sync time is when a provider first learns about a package; the binding is established once and reused for every subsequent evaluation.
-- Putting `seller_agent` on the request would either duplicate the sync-time binding (redundant) or open a path for request-time seller filtering, which re-introduces the identity- and allocation-leakage failure modes [Package set decorrelation](#package-set-decorrelation) exists to prevent.
+- Putting `seller_agent` on `context_match_request` would either duplicate the sync-time binding (redundant) or open a path for request-time seller filtering on the context path, which re-introduces the identity- and allocation-leakage failure modes [Package set decorrelation](#package-set-decorrelation) exists to prevent.
 - Publishers and routers can derive seller identity from `media_buy_id` via their own stores; providers cannot. Keeping attribution on the package serves the actor that actually needs it on the wire.
+
+`identity_match_request` carries `seller_agent_url` directly because the buyer's identity-match service needs it to resolve the active package set it has registered for that seller — that resolution happens at the buyer agent, not at the provider, and is keyed on seller URL rather than on a per-package binding. This is buyer-side scoping, not provider-side filtering, and so does not interact with the package-set decorrelation guarantee.
 
 **Offer echo.** `seller_agent` MAY appear on `offer.json` as an echo from the cached package, for publisher-side log pipelines that want one-hop attribution without rejoining to the media-buy store. The echo is non-authoritative — the cached `AvailablePackage` binding is source of truth. Providers and routers MUST overwrite a disagreeing echo with the cached binding before logging, forwarding, or emitting the offer downstream, and MUST NOT use the echo value in any field consumed for billing, reporting, or dispute resolution. A disagreement SHOULD be counted to a `seller_agent_echo_mismatch` metric for anomaly detection. Routers MAY stamp `seller_agent` on merge when providers omit it.
 
@@ -357,12 +360,12 @@ Providers SHOULD validate `seller_agent.agent_url` against the property publishe
 |---|---|---|
 | **Seller agent** | Include its own adagents-registered `agent_url` as `seller_agent.agent_url` on every `AvailablePackage` it syncs. MUST be the URL the publisher has attested in `authorized_agents[].url`. | No new behavior. The offer MAY echo `seller_agent`; omitting it is fine — the router can stamp from cache. |
 | **Publisher** | Keep `authorized_agents` in adagents.json accurate, including scope constraints (`property_ids`, `placement_ids`, `countries`, effective windows). | No new behavior. |
-| **Router** | No new behavior. | MAY stamp `seller_agent` on offers that arrive without it, using its cached package→seller binding. MUST NOT forward `seller_agent` into `context_match_request` or `identity_match_request`. |
+| **Router** | No new behavior. | MAY stamp `seller_agent` on offers that arrive without it, using its cached package→seller binding. MUST NOT forward `seller_agent` into `context_match_request`. (`identity_match_request` carries `seller_agent_url` directly per its schema; the router MUST forward it unchanged.) |
 | **Provider** | Validate `seller_agent.agent_url` against the property's adagents.json per [Sync-Time Validation](#sync-time-validation). Reject unauthorized packages with `seller_not_authorized`. Store the binding with the cached package. | Echo `seller_agent` on offers it produces. The cached binding is immutable for an in-flight decision, but providers MUST treat packages whose authorization has expired (removal from `authorized_agents` or `effective_until` passed) as `unknown_package` on subsequent requests until the package is re-synced. |
 
 ### What This Is Not
 
-- **Not a request-time filter.** Publishers, routers, and providers MUST NOT use `seller_agent` to scope, filter, or route `context_match_request` or `identity_match_request`. `package_ids` remains the only scoping mechanism.
+- **Not a request-time filter on Context Match.** Publishers, routers, and providers MUST NOT use `seller_agent` to scope, filter, or route `context_match_request`. `package_ids` is not present on Context Match either; package selection is provider-side based on the cached sync. `identity_match_request` does carry `seller_agent_url`, but only as the key the buyer agent uses to resolve its registered package set — not as a provider/router filter.
 - **Not a sellers.json bridge.** IAB sellers.json `seller_id` and TAG-IDs serve a distinct financial-audit identity space. They remain on `adagents.json` `contact` — TMP does not duplicate them.
 - **Not a cryptographic attestation.** The binding is publisher-attested via adagents.json over HTTPS. Signed TMP seller claims are a future enhancement and can layer onto `SellerAgentRef` through the reserved `id` slot or an `ext` field without breaking changes. When a future release populates both `agent_url` and `id`, `agent_url` remains authoritative and `id` is advisory — a disagreement between the two MUST NOT be used to upgrade trust above what the URL's adagents.json binding provides.
 
@@ -380,13 +383,17 @@ The following requirements use RFC 2119 keywords (MUST, SHOULD, MAY).
 ### Package set decorrelation
 
 - Context Match MUST NOT be filtered by user identity or audience. The provider evaluates its synced package set for the placement — the same packages for every user. No per-request package list is sent, so the publisher cannot accidentally leak identity through package filtering.
-- Identity Match `package_ids` MUST include ALL active packages for the buyer at this publisher, not just those available on the current page. Sending only the page-specific subset would allow a buyer to correlate Identity Match with Context Match by comparing package sets.
-- The publisher SHOULD maintain a cached list of all active package IDs per buyer and send the full set on every Identity Match request.
+- The publisher SHOULD omit `package_ids` from Identity Match and let the buyer evaluate against the full active set it has registered for `seller_agent_url`. When `package_ids` IS provided, its composition MUST be statistically independent of the current placement — sending only the page-specific subset would allow a buyer to correlate Identity Match with Context Match by comparing package sets. Two acceptable modes:
+  - **All-active.** Include every active package this buyer has at this publisher.
+  - **Fuzzed.** Include a random sample of active packages, optionally padded with synthetic non-existent IDs, drawn from a distribution that does not depend on the current placement. The silent-drop rule below makes synthetic-ID padding safe — unknown IDs do not affect response shape and cannot leak registry membership.
+- When both `seller_agent_url` and `package_ids` are present, the buyer evaluates against the intersection of its registered active set and `package_ids`; unknown IDs in `package_ids` MUST be silently ignored (not error-surfaced) so the response does not leak registry membership back to the publisher.
+- A publisher that maintains a cached list of all active package IDs per buyer MAY send the full set on every Identity Match request as a defense in depth, but the buyer-side resolution from `seller_agent_url` is the primary mechanism.
 - The publisher performs the intersection of context match offers and identity match eligibility locally, after both responses arrive.
 
 ### Temporal decorrelation
 
 - Publishers SHOULD introduce a random delay between Context Match and Identity Match requests. Recommended: 100-2000ms, uniformly distributed.
+- Publishers SHOULD also randomize the order of Context Match and Identity Match: each opportunity SHOULD have a roughly equal probability of Context Match being sent first or Identity Match being sent first. A fixed order — e.g., Identity Match always after Context Match — leaks the pairing through ordering even when the delay is randomized.
 - Publishers MAY batch Identity Match requests across multiple page views.
 - Publishers MAY route Context Match and Identity Match through different network paths.
 

--- a/docs/trusted-match/surfaces/ai-assistants.mdx
+++ b/docs/trusted-match/surfaces/ai-assistants.mdx
@@ -87,12 +87,13 @@ The buyer's offer includes `package_id` (required) along with optional fields: `
 
 ## Identity Match
 
-The platform sends an Identity Match request with a session token. The `package_ids` include ALL active packages for this buyer — not just the ones on the current page — to prevent the buyer from correlating this request with the context match by comparing package sets:
+The platform sends an Identity Match request with a session token and the platform's `seller_agent_url`. The buyer resolves its active package set from `seller_agent_url`; when the platform sends `package_ids` explicitly (as below), composition MUST be independent of the current page — either all-active (every active package for this buyer on the platform) or fuzzed (a random sample padded with synthetic non-existent IDs the buyer silently drops). The page-specific subset is forbidden — it would let the buyer correlate this request with the context match by comparing package sets:
 
 ```json
 {
   "type": "identity_match_request",
   "request_id": "id-e5f6g7h8",
+  "seller_agent_url": "https://ai-assistant.example",
   "identities": [
     { "user_token": "tok_session_k2f8", "uid_type": "publisher_first_party" }
   ],

--- a/docs/trusted-match/surfaces/ctv.mdx
+++ b/docs/trusted-match/surfaces/ctv.mdx
@@ -87,12 +87,13 @@ For CTV creatives, the `creative_manifest` typically references a VAST URL rathe
 
 ### Identity Match Request
 
-Separately, the broadcaster sends an identity match request with a household token. The `package_ids` list includes ALL active packages for each buyer — not just the ones in this pod break. This prevents a buyer from correlating the identity request with a specific context request by comparing package sets.
+Separately, the broadcaster sends an identity match request with a household token and the broadcaster's `seller_agent_url`. The buyer resolves its active package set from `seller_agent_url`. When the broadcaster sends `package_ids` explicitly (as below), composition MUST be independent of the current pod break — either all-active (every active package for that buyer at this broadcaster) or fuzzed (a random sample padded with synthetic non-existent IDs the buyer silently drops). The pod-break-specific subset is forbidden — it would let the buyer correlate the identity request with a specific context request by comparing package sets.
 
 ```json
 {
   "type": "identity_match_request",
   "request_id": "id-7k2m-p4w1",
+  "seller_agent_url": "https://broadcaster.example",
   "identities": [
     { "user_token": "tok_household_q7w2", "uid_type": "publisher_first_party" },
     { "user_token": "ID5*mN4pQ...", "uid_type": "id5" }
@@ -114,7 +115,7 @@ Separately, the broadcaster sends an identity match request with a household tok
 }
 ```
 
-The list includes packages from other surfaces (web display, mobile native, audio). The broadcaster maintains a cached list of all active packages per buyer and sends the full set every time.
+The list includes packages from other surfaces (web display, mobile native, audio). The example uses all-active mode — the broadcaster maintains a cached list of all active packages per buyer and sends the full set every time. Fuzzed mode (random sample padded with synthetic IDs) is the equivalent privacy guarantee for broadcasters that prefer not to maintain that cache.
 
 ### Identity Match Response
 
@@ -194,7 +195,7 @@ Mid-roll break in "The Night Kitchen" S02E07
   --> Vaultline agent: no activation (financial services, no context fit)
   --> Driftmoto agent: no activation (motorcycle brand, no context fit)
 
-  Identity Match (after temporal decorrelation delay)
+  Identity Match (after temporal decorrelation — random delay + random order)
   --> Broadcaster sends request: all 9 active packages across all buyers
   --> Response: eligible_package_ids includes Sparklean, Greenleaf, Vaultline, Driftmoto-30s
   --> ttl_sec: 90 (covers the ad break)

--- a/docs/trusted-match/surfaces/mobile.mdx
+++ b/docs/trusted-match/surfaces/mobile.mdx
@@ -149,9 +149,9 @@ When the product's `trusted_match` config declares creative as the response type
 
 ## Identity Match
 
-The TMP SDK sends an Identity Match request with a publisher-scoped device token. This request is structurally separate from Context Match — it carries no content signals and is sent with temporal decorrelation (a random delay of 100-2000ms).
+The TMP SDK sends an Identity Match request with a publisher-scoped device token and the publisher's `seller_agent_url`. This request is structurally separate from Context Match — it carries no content signals and is sent with temporal decorrelation: a random delay of 100-2000ms, plus randomized order (each opportunity has roughly equal probability of Context Match or Identity Match being sent first).
 
-The `package_ids` list includes all active packages for the buyer, not just the packages from the current placement. Sending only the placement-specific subset would let the buyer correlate Identity Match with Context Match by comparing package sets.
+The buyer resolves its active package set from `seller_agent_url`. When the SDK sends `package_ids` explicitly (as below), composition MUST be independent of the current placement — either all-active (every active package for the buyer at this publisher) or fuzzed (a random sample padded with synthetic non-existent IDs the buyer silently drops). The placement-specific subset is forbidden — it would let the buyer correlate Identity Match with Context Match by comparing package sets.
 
 #### Request
 
@@ -159,6 +159,7 @@ The `package_ids` list includes all active packages for the buyer, not just the 
 {
   "type": "identity_match_request",
   "request_id": "id-mob-e4d782",
+  "seller_agent_url": "https://mobile-publisher.example",
   "identities": [
     { "user_token": "tok_idfv_a9c3e7", "uid_type": "publisher_first_party" },
     { "user_token": "A1B2C3D4-E5F6-7890-1234-567890ABCDEF", "uid_type": "maid" }
@@ -178,7 +179,7 @@ The `package_ids` list includes all active packages for the buyer, not just the 
 }
 ```
 
-Seven package IDs — all active packages for this buyer across every placement and format, not just the two that were activated by Context Match.
+Seven package IDs — the example uses all-active mode (every active package for this buyer across every placement and format, not just the two that were activated by Context Match). A fuzzed list of similar size, padded with synthetic non-existent IDs the buyer silently drops, would satisfy the same privacy invariant.
 
 #### Response
 
@@ -261,7 +262,7 @@ Mobile TMP follows the same structural separation as all surfaces:
 
 - **Context Match** carries content signals and placement data. No device identifiers, no user tokens, no IDFA/IDFV in the request.
 - **Identity Match** carries only a publisher-scoped device token and the full list of buyer package IDs. No content signals, no screen names, no topic IDs.
-- **Temporal decorrelation** between the two requests prevents timing-based correlation. The TMP SDK introduces a random delay (100-2000ms) before sending the Identity Match request.
+- **Temporal decorrelation** between the two requests prevents timing- and order-based correlation. The TMP SDK introduces a random delay (100-2000ms) AND randomizes which request is sent first — each opportunity has roughly equal probability of Context Match or Identity Match going first.
 - **Package set decorrelation**: Context Match sends no package list — the provider evaluates the same synced package set for every user on a placement. Identity Match sends all packages for the buyer. Neither path reveals which packages are relevant to the current opportunity.
 
 The publisher performs the intersection locally after both responses arrive. The buyer never sees the joined result.

--- a/docs/trusted-match/surfaces/retail-media.mdx
+++ b/docs/trusted-match/surfaces/retail-media.mdx
@@ -72,12 +72,13 @@ The buyer's offer summary helps the retailer judge relevance. The creative manif
 
 ## Identity Match
 
-The retailer sends an Identity Match request with the shopper's loyalty token. The `package_ids` include ALL active packages for this buyer — not just those on the current page — to prevent the buyer from correlating this request with the context match by comparing package sets:
+The retailer sends an Identity Match request with the shopper's loyalty token and the retailer's `seller_agent_url`. The buyer resolves its active package set from `seller_agent_url`; when the retailer sends `package_ids` explicitly (as below), composition MUST be independent of the current page — either all-active (every active package for this buyer at the retailer) or fuzzed (a random sample padded with synthetic non-existent IDs the buyer silently drops). The page-specific subset is forbidden — it would let the buyer correlate this request with the context match by comparing package sets:
 
 ```json
 {
   "type": "identity_match_request",
   "request_id": "id-retail-c7b2",
+  "seller_agent_url": "https://retailer.example",
   "identities": [
     { "user_token": "tok_loyalty_m3p7", "uid_type": "publisher_first_party" },
     { "user_token": "a1b2c3d4e5f67890abcdef...", "uid_type": "hashed_email" }

--- a/docs/trusted-match/surfaces/web.mdx
+++ b/docs/trusted-match/surfaces/web.mdx
@@ -71,7 +71,7 @@ Key points:
 
 ## Identity Match
 
-Separately, the TMP Prebid module sends an Identity Match request with the user's opaque token. This request carries no page context. The `package_ids` list includes ALL active packages for the buyer — not just the packages on this page.
+Separately, the TMP Prebid module sends an Identity Match request with the user's identity tokens and the publisher's `seller_agent_url`. This request carries no page context. The buyer resolves its active package set from `seller_agent_url`; when the module sends `package_ids` explicitly (as below), composition MUST be independent of the current page — either all-active (every active package for that buyer at this publisher) or fuzzed (a random sample padded with synthetic non-existent IDs the buyer will silently drop). The page-specific subset is forbidden.
 
 ### Identity Match Request
 
@@ -79,6 +79,7 @@ Separately, the TMP Prebid module sends an Identity Match request with the user'
 {
   "type": "identity_match_request",
   "request_id": "id-3k9p-oakwood-d4f1",
+  "seller_agent_url": "https://oakwood.example",
   "identities": [
     { "user_token": "tok_uid2_8f2a3b7c", "uid_type": "uid2" },
     { "user_token": "XY1a2b3c4d5e6f7g8h9i0jKlMnOpQrSt", "uid_type": "rampid" },
@@ -100,7 +101,7 @@ Separately, the TMP Prebid module sends an Identity Match request with the user'
 Key points:
 
 - `request_id` is unrelated to the context match `request_id`. The two must not be derivable from each other.
-- `package_ids` includes ALL active packages for the buyer across the entire site, not just the three that were on this placement's context match. Sending only the page-specific subset would let the buyer correlate identity with context by comparing package sets.
+- `package_ids` example shows all-active mode: every active package for the buyer across the entire site, not just the three that were on this placement's context match. The page-specific subset is forbidden — it would let the buyer correlate identity with context by comparing package sets. Fuzzed mode (a random sample padded with synthetic IDs the buyer silently drops) is also acceptable.
 - `identities` carries every token the publisher has available (UID2, ID5, LiveRamp, hashed email, publisher first-party). Each token is opaque — the buyer cannot reverse it to PII. Sending the full set maximizes match rate because different buyers resolve on different graphs.
 
 ### Identity Match Response
@@ -175,11 +176,11 @@ The TMP Prebid module is a Real-Time Data (RTD) module that replaces vendor-spec
 
 1. **On auction init**: Send Context Match request to the TMP router for each placement on the page.
 2. **On context match response**: Store offers and targeting signals.
-3. **After temporal delay** (100-2000ms, randomized): Send Identity Match request with the user's opaque token and ALL active package IDs for each buyer.
+3. **After temporal decorrelation**: Send Identity Match request with the user's identity tokens and ALL active package IDs for each buyer. Decorrelation has two parts — a random 100-2000ms delay AND randomized order: each auction has roughly equal probability of the Identity Match request being sent first or the Context Match request being sent first.
 4. **On identity match response**: Join with context match results. Set targeting key-values on the ad unit.
 5. **On bid request**: GAM receives the enriched ad request with TMP targeting keys and selects line items as normal.
 
-The temporal delay between context and identity requests is a privacy measure. It prevents timing-based correlation of the two request types.
+The temporal decorrelation between context and identity requests is a privacy measure. Random delay alone is insufficient — fixed ordering (Identity always after Context) leaks the pairing through ordering. The module randomizes both the delay and which request is sent first.
 
 ## Sequence Diagram
 
@@ -192,7 +193,9 @@ Page Load
   |                              |<- merge <--- offers + signals
   |<--- Context Match Response --
   |
-  |   (100-2000ms random delay)
+  |   (100-2000ms random delay; Context/Identity order randomized
+  |    per auction — diagram shows Context-first; Identity-first
+  |    runs the two phases in reverse)
   |
   |-- Prebid TMP Module ---> TMP Router (Identity)
   |                              |-- fan out --> Buyer Agent A
@@ -219,6 +222,6 @@ Most publishers run TMP alongside Prebid header bidding, which sources demand vi
 These constraints apply to all surfaces but are worth restating for the web case:
 
 - **Context match carries no user data.** No cookies, no user tokens, no IP addresses. The provider evaluates the same synced package set for every user on a placement.
-- **Identity match carries no page data.** No URLs, no content signals, no placement IDs. The package_ids list includes all active packages for the buyer, not just the ones on this page.
+- **Identity match carries no page data.** No URLs, no content signals, no placement IDs. The `package_ids` list, when sent, has composition independent of the current page (all-active or fuzzed) — never the page-specific subset.
 - **The publisher joins locally.** The router never sees both context and identity for the same impression. Only the publisher, who already has both the page context and the user identity, performs the intersection.
-- **Temporal decorrelation.** A random delay between the two requests prevents timing-based correlation at the network level.
+- **Temporal decorrelation.** A random delay between the two requests AND a randomized order (Context Match or Identity Match equally likely to be sent first) prevent timing- and order-based correlation at the network level. Random delay alone is insufficient because a fixed order leaks the pairing through ordering.

--- a/static/schemas/source/tmp/identity-match-request.json
+++ b/static/schemas/source/tmp/identity-match-request.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/tmp/identity-match-request.json",
   "title": "Identity Match Request",
-  "description": "Sent by publisher to evaluate user eligibility for packages using an opaque identity token. MUST NOT contain page context. The request_id MUST NOT correlate with any context match request_id. The package_ids MUST include ALL active packages for the buyer, not just those on the current page, to prevent set-correlation attacks. Extension fields (ext, context) are intentionally omitted to prevent data leakage across the identity privacy boundary.",
+  "description": "Sent by publisher to evaluate user eligibility for packages using an opaque identity token. MUST NOT contain page context. The request_id MUST NOT correlate with any context match request_id. The buyer resolves the active package set for this seller from `seller_agent_url`; if `package_ids` is provided, its composition MUST be independent of the current placement (e.g., all-active or fuzzed; see field description) to prevent set-correlation attacks. Extension fields (ext, context) are intentionally omitted to prevent data leakage across the identity privacy boundary.",
   "x-status": "experimental",
   "type": "object",
   "properties": {
@@ -30,6 +30,11 @@
     "request_id": {
       "type": "string",
       "description": "Unique request identifier. MUST NOT correlate with any context match request_id."
+    },
+    "seller_agent_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "API endpoint URL of the seller agent issuing this request. The buyer's identity-match service uses this to resolve the active package set it has registered for this seller; when `package_ids` is omitted, evaluation occurs against that full set. If `seller_agent_url` does not match any seller for which the buyer has registered active packages, the buyer MUST return an empty `eligible_package_ids` set — it MUST NOT fall back to evaluating against another seller's active set. Compared using the AdCP URL canonicalization rules, not byte-equality — see docs/reference/url-canonicalization. Consistent with `seller_agent.agent_url` on `AvailablePackage` and `agent_url` in `adagents.json`."
     },
     "identities": {
       "type": "array",
@@ -77,7 +82,7 @@
     },
     "package_ids": {
       "type": "array",
-      "description": "ALL active package identifiers for this buyer at this publisher. MUST include every active package, not just those on the current page, to prevent correlation with Context Match requests.",
+      "description": "Optional. When omitted, the buyer evaluates eligibility against the full set of active packages it has registered for `seller_agent_url`. When provided, the composition of `package_ids` MUST be statistically independent of the current placement — sending only the page-specific subset would let the buyer correlate Identity Match with Context Match by comparing package sets. Two acceptable modes: (a) **all-active** — include every active package this buyer has at this publisher; (b) **fuzzed** — include a random sample of active packages, optionally padded with synthetic non-existent IDs, drawn from a distribution that does not depend on the current placement. The buyer's silent-drop behavior on unknown IDs (specified below) is what makes synthetic-ID padding safe — they do not affect the response shape and cannot leak registry membership. When both `seller_agent_url` and `package_ids` are present, the buyer evaluates against the intersection of its registered active set and `package_ids`; IDs in `package_ids` that the buyer has not registered for this seller MUST be silently ignored (not surfaced as errors) to avoid leaking registry membership back to the publisher.",
       "items": {
         "type": "string"
       },
@@ -92,8 +97,8 @@
   "required": [
     "type",
     "request_id",
-    "identities",
-    "package_ids"
+    "seller_agent_url",
+    "identities"
   ],
   "additionalProperties": false
 }

--- a/tests/example-validation-simple.test.cjs
+++ b/tests/example-validation-simple.test.cjs
@@ -560,6 +560,7 @@ async function runTests() {
     {
       "type": "identity_match_request",
       "request_id": "id-7c9e1d",
+      "seller_agent_url": "https://streamhaus.example",
       "identities": [
         { "user_token": "opaque-streamhaus-token-abc123", "uid_type": "uid2" },
         { "user_token": "ID5*zP3wK...", "uid_type": "id5" }
@@ -637,6 +638,7 @@ async function runTests() {
     {
       "type": "identity_match_request",
       "request_id": "id-9b2c",
+      "seller_agent_url": "https://publisher.example",
       "identities": [
         { "user_token": "tok_hk82mfp1", "uid_type": "uid2" },
         { "user_token": "ID5*aB3xY...", "uid_type": "id5" },
@@ -657,6 +659,7 @@ async function runTests() {
     {
       "type": "identity_match_request",
       "request_id": "id-e5f6g7h8",
+      "seller_agent_url": "https://ai-assistant.example",
       "identities": [
         { "user_token": "tok_session_k2f8", "uid_type": "publisher_first_party" }
       ],
@@ -671,6 +674,7 @@ async function runTests() {
     {
       "type": "identity_match_request",
       "request_id": "id-boundary-4",
+      "seller_agent_url": "https://seller.example",
       "identities": [
         { "user_token": "a", "uid_type": "uid2" },
         { "user_token": "b", "uid_type": "id5" },


### PR DESCRIPTION
## Summary

Cherry-pick of #3687 (`seller_agent_url` on IdentityMatch) into the `3.0.x` release line, downgraded to a `patch` changeset so the next release-please run cuts **3.0.12**. The original change shipped a `minor` changeset on `main` (intended for 3.1.0), but consumers of the stable line need the field today.

This is the schema change adcp-go's [adcp-go#117](https://github.com/adcontextprotocol/adcp-go/pull/117) is gating on — that PR pinned to `latest` only because no tagged release contained `seller_agent_url`. Once this lands and 3.0.12 ships, adcp-go can re-pin to a tagged version.

## What's in the patch

Cherry-picked from `1e44c041a` (#3687) on `main`:

- `static/schemas/source/tmp/identity-match-request.json` — adds required `seller_agent_url`, makes `package_ids` optional, updates description. **One trivial conflict resolved** (3.0.x lacked the updated description; resolution kept the new description and avoided duplicating an adjacent `"type": "object"` line).
- `tests/example-validation-simple.test.cjs` — auto-merged.
- `docs/trusted-match/**` — surface docs auto-merged.
- `.changeset/tmp-identity-match-seller-agent-url.md` — content kept as-is; **only the version bump downgraded from `minor` → `patch`** to match the 3.0.x release line convention.

## Why patch, not minor

The 3.0.x line ships patches only. Existing in-flight changesets on this branch (e.g. `comply-controller-mode-gate.md`, `fix-3.0.x-storyboard-product-catalog-seeding.md`) all use `patch`. A `minor` changeset here would either be rejected by tooling or jump the line to 3.1.0, which conflicts with what's queued for the next 3.0.x release. The original `minor` changeset on `main` is unchanged and will still drive the 3.1.0 cut from `main`.

## Why a backport at all

The schema is annotated `x-status: experimental`. Experimental schemas evolve on `main` and reach implementors via `latest`. But pinning a Go SDK to `latest` is brittle — there's no integrity guarantee against silent upstream shifts. Tagging the change into a stable release lets adopters depend on it auditably.

## Test plan

- [ ] CI runs the full schema validation suite (`npm test`).
- [ ] Schema diff is byte-equivalent to `main`'s version of the same file (verified locally).
- [ ] After merge: release-please cuts 3.0.12; adcp-go#117 re-pins from `latest` to `3.0.12` and stops depending on the dev snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)