### PR TITLE
docs(capabilities): add account.supported_billing to media_buy examples (unblocks 3.0.x CI)

### DIFF
--- a/.changeset/docs-capabilities-account-block.md
+++ b/.changeset/docs-capabilities-account-block.md
@@ -1,0 +1,21 @@
+---
+"adcontextprotocol": patch
+---
+
+Docs: add the now-required `account.supported_billing` block to the four
+`get_adcp_capabilities` example JSON blocks that declare `media_buy`
+support.
+
+Since #3750 (`fix(schema): make account.supported_billing conditional on
+media_buy protocol`), the response schema requires `account.supported_billing`
+whenever `supported_protocols` contains `media_buy`. Four illustrative
+examples in the docs (`creative/sales-agent-creative-capabilities.mdx`,
+`media-buy/specification.mdx`, `reference/migration/channels.mdx`,
+`reference/migration/geo-targeting.mdx`) were not updated alongside the
+schema and have been failing CI's schema validation step on `3.0.x` HEAD,
+blocking every other patch PR against the branch.
+
+Each example now includes `"account": { "supported_billing": ["operator",
+"agent"] }`, matching the pattern already used in
+`docs/building/integration/accounts-and-agents.mdx`. Documentation only —
+no protocol behavior change.

--- a/docs/creative/sales-agent-creative-capabilities.mdx
+++ b/docs/creative/sales-agent-creative-capabilities.mdx
@@ -21,6 +21,9 @@ A sales agent declares Creative Protocol support in `get_adcp_capabilities`:
     "idempotency": { "supported": true, "replay_ttl_seconds": 86400 }
   },
   "supported_protocols": ["media_buy", "creative"],
+  "account": {
+    "supported_billing": ["operator", "agent"]
+  },
   "media_buy": {
     "features": {
       "inline_creative_management": true

--- a/docs/media-buy/specification.mdx
+++ b/docs/media-buy/specification.mdx
@@ -48,7 +48,10 @@ Sales agents MUST declare Media Buy Protocol support via `get_adcp_capabilities`
     "major_versions": [2],
     "idempotency": { "supported": true, "replay_ttl_seconds": 86400 }
   },
-  "supported_protocols": ["media_buy"]
+  "supported_protocols": ["media_buy"],
+  "account": {
+    "supported_billing": ["operator", "agent"]
+  }
 }
 ```
 

--- a/docs/reference/migration/channels.mdx
+++ b/docs/reference/migration/channels.mdx
@@ -108,6 +108,9 @@ v3 products declare an array of channels, so a single product can span multiple 
     "idempotency": { "supported": true, "replay_ttl_seconds": 86400 }
   },
   "supported_protocols": ["media_buy"],
+  "account": {
+    "supported_billing": ["operator", "agent"]
+  },
   "media_buy": {
     "portfolio": {
       "primary_channels": ["display", "olv", "ctv"],

--- a/docs/reference/migration/geo-targeting.mdx
+++ b/docs/reference/migration/geo-targeting.mdx
@@ -130,6 +130,9 @@ Before sending geo targeting, buyers should verify the seller supports the reque
     "idempotency": { "supported": true, "replay_ttl_seconds": 86400 }
   },
   "supported_protocols": ["media_buy"],
+  "account": {
+    "supported_billing": ["operator", "agent"]
+  },
   "media_buy": {
     "execution": {
       "targeting": {

--- a/tests/composed-schema-validation.test.cjs
+++ b/tests/composed-schema-validation.test.cjs
@@ -316,7 +316,8 @@ async function runTests() {
 
   const capabilitiesBase = {
     adcp: { major_versions: [3] },
-    supported_protocols: ['media_buy']
+    supported_protocols: ['media_buy'],
+    account: { supported_billing: ['operator', 'agent'] }
   };
 
   await testSchemaValidation(


### PR DESCRIPTION
## Summary

The `3.0.x` branch's TypeScript Build CI step is currently red on **every** PR — including its own HEAD commit — because four `get_adcp_capabilities_response` example JSON blocks in the docs don't satisfy the conditional `account.supported_billing` requirement introduced by #3750.

This PR adds the missing `account` block to each of those four examples, matching the established pattern in `docs/building/integration/accounts-and-agents.mdx`. Docs-only — no schema or behavior changes.

## Why now

Currently blocking [adcp#4482](https://github.com/adcontextprotocol/adcp/pull/4482) (and every other 3.0.x patch) from merging. Splitting this off so the docs-debt fix has clear ownership and the backport stays focused on its actual subject.

## What changed

Added `"account": { "supported_billing": ["operator", "agent"] }` to the `get_adcp_capabilities_response` example in:

- `docs/creative/sales-agent-creative-capabilities.mdx` (line 16)
- `docs/media-buy/specification.mdx` (line 44)
- `docs/reference/migration/channels.mdx` (line 103)
- `docs/reference/migration/geo-targeting.mdx` (line 125)

The `["operator", "agent"]` value was picked because it's already the canonical illustrative pair used in `docs/building/integration/accounts-and-agents.mdx`. Authors of the original schema change may want a different value per example (e.g. `["advertiser"]` for retail-media contexts); easy to amend before merge if so.

## Note about `main`

`main` has the same docs drift on the same four files, but is out of scope here — `main`'s CI configuration may differ and a separate forward-port should land if needed. This PR is targeted strictly at `3.0.x` to unblock the release line.

## Test plan

- [ ] TypeScript Build / Validate schemas step turns green.
- [ ] No other CI step regresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)