### PR TITLE
fix(migration): 476 skips rows that would collide on the email unique index

### DIFF
--- a/.changeset/4481-migration-476-conflict-guard.md
+++ b/.changeset/4481-migration-476-conflict-guard.md
@@ -1,0 +1,15 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix migration 476 (`refresh_denormalized_user_email`) which was failing on prod
+deploy with a `idx_person_relationships_email_unique` collision. The naive
+`UPDATE person_relationships SET email = users.email` collided when two
+relationship rows would land on the same email — the symptom of two
+`person_relationships` rows pointing to the same person, or a stale row that
+should have been merged when `users.email` was reassigned. The migration now
+skips rows whose target email is already held by a different
+`person_relationships` row; the in-app read self-heal continues to surface the
+right email at display time, and the residual duplicates are left for separate
+dedup. Unblocks the `Deploy` workflow on `main`, which had been failing on
+release_command since #4481 merged.

--- a/server/src/db/migrations/476_refresh_denormalized_user_email.sql
+++ b/server/src/db/migrations/476_refresh_denormalized_user_email.sql
@@ -14,13 +14,28 @@
 -- write-path fix, one-shot backfill. There's no FK to add for email — it's
 -- a string, not a pointer — but the refresh-on-write keeps it from drifting
 -- again.
+--
+-- Conflict handling: person_relationships.email has a partial UNIQUE index
+-- (idx_person_relationships_email_unique, migration 291), so a naive UPDATE
+-- collides when two rows would land on the same email. That indicates a
+-- separate problem — two relationship rows pointing to the same person, or
+-- a stale row that should have been merged when users.email was reassigned.
+-- We skip those rows here so the backfill is fail-safe; the in-app read
+-- self-heal continues to surface the right email at display time, and the
+-- residual duplicates are tracked for dedup separately (see PR description).
 
 UPDATE person_relationships pr
    SET email = u.email,
        updated_at = NOW()
   FROM users u
  WHERE pr.workos_user_id = u.workos_user_id
-   AND pr.email IS DISTINCT FROM u.email;
+   AND pr.email IS DISTINCT FROM u.email
+   AND NOT EXISTS (
+     SELECT 1
+       FROM person_relationships other
+      WHERE other.email = u.email
+        AND other.id <> pr.id
+   );
 
 UPDATE organization_memberships om
    SET email = u.email,


### PR DESCRIPTION
## Summary

Migration 476 (`refresh_denormalized_user_email`, from #4481) has been failing on prod since merge with:

\`\`\`
duplicate key value violates unique constraint "idx_person_relationships_email_unique"
Key (email)=(chrisgaglia@gmail.com) already exists.
\`\`\`

This blocks the Deploy workflow on main → the Fly app doesn't redeploy → the schema CDN at \`adcontextprotocol.org/schemas/v3/*\` doesn't pick up the just-cut v3.0.12 (the dist artifacts are in the repo, but the live alias still resolves to 3.0.11 because the running container holds the older \`dist/schemas/\` tree).

## What's going on

\`person_relationships.email\` has a partial UNIQUE index (\`idx_person_relationships_email_unique\`, migration 291: \`UNIQUE (email) WHERE email IS NOT NULL\`). The naive \`UPDATE pr SET email = u.email\` collides whenever two relationship rows would land on the same email. Concretely, for \`chrisgaglia@gmail.com\`:

- Some \`person_relationships\` row already holds that email.
- Another row binds (via \`workos_user_id\`) to a \`users\` record whose \`.email\` is also \`chrisgaglia@gmail.com\`.
- The backfill tries to set the second row's email to match — collision.

That's the symptom of a different problem (two relationships for the same person, or a stale row that should have been merged when \`users.email\` was reassigned). The email refresh shouldn't be the thing that surfaces it as a hard crash.

## Fix

Add a \`NOT EXISTS\` guard so the refresh skips any row whose target email is already held by a different \`person_relationships\` row. The stale-email rows that can't be safely refreshed are left in place — the in-app read self-heal continues to surface the right email at display time, and the residual duplicate-row problem is tracked separately for dedup (will file an issue once main can deploy).

\`organization_memberships\` has no UNIQUE constraint on email (migration 055: plain index), so that UPDATE is unchanged.

## Why edit in place vs. add 477

476 has not been applied on prod (it failed before \`INSERT INTO schema_migrations\`, in the BEGIN/COMMIT block at \`migrate.ts:125-148\`), so editing the file just makes the next attempt succeed. Dev DBs that already applied the old version won't re-run it — the runner keys on the version integer; the filename-mismatch check at \`migrate.ts:241-244\` is a warning, not a blocker. Same SQL intent, safer WHERE clause.

## Test plan

- [ ] Deploy workflow runs and the release_command machine exits 0
- [ ] \`/schemas/v3/tmp/identity-match-request.json\` returns \`$id: /schemas/3.0.12/...\` and the new \`seller_agent_url\` field is required

## Follow-up

- File a dedup issue for the conflicting person_relationships rows once the deploy passes — those are real data drift, not noise.