### PR TITLE
fix(slack-noise): stop posting expected agent/user input errors to #admin-errors

### DIFF
--- a/.changeset/registry-pending-review-409.md
+++ b/.changeset/registry-pending-review-409.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Stop posting agent/user input errors to `#admin-errors`. The MCP server catch block now distinguishes `ToolError` (expected — logged at `warn`) from genuine exceptions (logged at `error`), matching the pattern already used in `claude-client.ts`. `POST /api/registry/properties/save` and `POST /api/registry/brands/save` now pre-check `review_status === 'pending'` and return 409, parallel to the existing authoritative-source check, instead of letting the DB throw and bubble up as a 500.

--- a/server/src/mcp/server.ts
+++ b/server/src/mcp/server.ts
@@ -26,6 +26,7 @@ import {
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { createLogger } from '../logger.js';
+import { ToolError } from '../addie/tool-error.js';
 import type { AddieTool } from '../addie/types.js';
 import type { MCPAuthContext } from './auth.js';
 
@@ -202,7 +203,11 @@ export function createUnifiedMCPServer(authContext?: MCPAuthContext): Server {
         isError?: boolean;
       };
     } catch (error) {
-      logger.error({ error, tool: name }, 'MCP: Tool execution error');
+      if (error instanceof ToolError) {
+        logger.warn({ error: error.message, tool: name }, 'MCP: Tool returned expected error');
+      } else {
+        logger.error({ error, tool: name }, 'MCP: Tool execution error');
+      }
       return {
         content: [{ type: 'text', text: JSON.stringify({ error: error instanceof Error ? error.message : 'Unknown error' }) }],
         isError: true,

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -3266,6 +3266,13 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           });
         }
 
+        if (existing.review_status === "pending") {
+          return res.status(409).json({
+            error: "Cannot edit brand pending review",
+            domain,
+          });
+        }
+
         const editInput: Parameters<typeof brandDb.editDiscoveredBrand>[1] = {
           brand_name,
           edit_summary: "API: updated brand data",
@@ -3593,6 +3600,13 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         if (discovered.length > 0) {
           return res.status(409).json({
             error: "Cannot edit authoritative property (managed via adagents.json)",
+            domain: publisher_domain,
+          });
+        }
+
+        if (existing.review_status === "pending") {
+          return res.status(409).json({
+            error: "Cannot edit property pending review",
             domain: publisher_domain,
           });
         }


### PR DESCRIPTION
## Summary

Two distinct system-error Slack posts that share a root cause: expected user/agent input errors were being logged at `logger.error`, which auto-routes to `#admin-errors` (see `posthog.ts:201-205`).

**1. `mcp-server`: Failed to fetch schema 404** — An agent called `get_schema` with `media_buy/create_media_buy.json` (underscores, no request/response suffix). The fuzzy resolver in `schema-tools.ts:168` correctly refused to auto-pick between `create-media-buy-request.json` and `create-media-buy-response.json` (token-overlap tie → return `null`). The fetch 404s and a `ToolError` is thrown — but `server/src/mcp/server.ts:205` was logging *every* exception at `error`, ignoring the `ToolError` convention (see `tool-error.ts:1-4` and `claude-client.ts:1061-1067`).

**2. `registry-api`: Cannot edit property pending review** — `POST /api/registry/properties/save` pre-checked the authoritative-property conflict (returns 409), but didn't pre-check `review_status === 'pending'`. The DB threw, the generic catch logged `logger.error` and returned 500. Brand save had the same latent bug.

## Changes

- `server/src/mcp/server.ts` — `ToolError` now logs at `warn`; other exceptions still log at `error`. Mirrors `claude-client.ts` behavior.
- `server/src/routes/registry-api.ts` — pre-check `review_status === 'pending'` on property save → 409, parallel to the existing authoritative check.
- Same pre-check added on brand save.

## Test plan

- [ ] Confirm an MCP `get_schema` call with a bad path returns the existing fuzzy-match error to the caller (unchanged) but no longer posts to `#admin-errors`.
- [ ] `POST /api/registry/properties/save` for a property in `review_status='pending'` returns HTTP 409 with body `{ error: "Cannot edit property pending review", domain }` and does not post to `#admin-errors`.
- [ ] `POST /api/registry/brands/save` for a brand in `review_status='pending'` returns HTTP 409 with body `{ error: "Cannot edit brand pending review", domain }`.
- [ ] Genuine `editCommunityProperty` / `editDiscoveredBrand` failures (DB error, not-found) still produce a 500 + `logger.error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)