### PR TITLE
fix(server): emit agent_visibility_gate on profile response (#4159 follow-up)

### DIFF
--- a/.changeset/4159-fix-public-toggle-greyed.md
+++ b/.changeset/4159-fix-public-toggle-greyed.md
@@ -1,0 +1,4 @@
+---
+---
+
+Server: `GET /api/me/member-profile` re-derives `primary_brand_domain` via the brand-domain resolver and emits `agent_visibility_gate: { can_publish_publicly, reasons[] }` so the dashboard's "Public" visibility toggle reads from the same gate the publish endpoint enforces. Stage 2 of #4159 dropped the column the dashboard had been inferring the gate from, silently greying out the toggle for every Builder/Member/Leader since #4313 shipped.

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -901,7 +901,13 @@
       complianceMap: new Map(),
       orgId: null,
       hasApiAccess: false,
-      brandHostingType: null,
+      // Server-computed { can_publish_publicly, reasons[] }. Populated from
+      // GET /api/me/member-profile so the UI affordance reads from the
+      // same gate the publish endpoint enforces. Defaults to
+      // `brand_domain_required` (the >95% case among logged-in dashboard
+      // users) so the brand-nudge text renders during the sub-second load
+      // gap instead of an unexplained-disabled toggle.
+      visibilityGate: { can_publish_publicly: false, reasons: ['brand_domain_required'] },
       // Tracks agents that have already auto-retried once after a 429
       // (#2804). A second 429 on the same agent freezes the card with
       // "you've refreshed too quickly" guidance instead of looping.
@@ -1098,7 +1104,8 @@
         pageState.complianceMap = agentCompliance;
         pageState.orgId = currentOrgId;
         pageState.hasApiAccess = !!profileData?.has_api_access;
-        pageState.brandHostingType = null;
+        pageState.visibilityGate = profileData?.agent_visibility_gate
+          || { can_publish_publicly: false, reasons: ['brand_domain_required'] };
         renderPage(agents, agentCompliance, currentOrgId);
 
         if (agents.length > 0) {
@@ -1130,21 +1137,6 @@
           }
         }
 
-        // Brand hosting type gates the "Public" visibility option. Fetched
-        // asynchronously — the cards re-render once the answer lands.
-        const primaryBrandDomain = profileData?.profile?.primary_brand_domain;
-        if (primaryBrandDomain) {
-          fetch(`/api/brands/discovered/${encodeURIComponent(primaryBrandDomain)}/edit-status`, { credentials: 'include' })
-            .then(r => (r.ok ? r.json() : null))
-            .then(editStatus => {
-              pageState.brandHostingType = editStatus?.source_type === 'brand_json' ? 'self-hosted' : 'community';
-              renderPage(pageState.agents, pageState.complianceMap, pageState.orgId);
-            })
-            .catch(() => {
-              pageState.brandHostingType = 'community';
-              renderPage(pageState.agents, pageState.complianceMap, pageState.orgId);
-            });
-        }
       } catch (err) {
         console.error('Agents page load error:', err);
         document.getElementById('hub-loading').innerHTML =
@@ -1224,17 +1216,19 @@
 
     // Renders a compact visibility dropdown for each agent card.
     // Shows a single inline hint describing what the currently-selected
-    // visibility means. Public may be disabled for users without API access
-    // or without a primary brand domain.
+    // visibility means. The "Public" option is gated on the server-
+    // computed `agent_visibility_gate` — same two preconditions the
+    // /agents/:index/publish endpoint enforces (tier + primary brand domain).
     function renderVisibilitySelector(index, visibility) {
       const vis = visibility || 'private';
-      const canSetPublic = !!pageState.hasApiAccess;
-      const brandHostingType = pageState.brandHostingType;
-      const publicRequiresDomain = !brandHostingType;
-      const publicDisabled = !canSetPublic || publicRequiresDomain;
-      const publicDisabledReason = !canSetPublic
+      const gate = pageState.visibilityGate || { can_publish_publicly: false, reasons: [] };
+      const reasons = Array.isArray(gate.reasons) ? gate.reasons : [];
+      const publicDisabled = !gate.can_publish_publicly;
+      const tierRequired = reasons.includes('tier_required');
+      const brandRequired = reasons.includes('brand_domain_required');
+      const publicDisabledReason = tierRequired
         ? 'Publicly listing an agent requires a paid AAO tier (Professional, Builder, Member, or Leader).'
-        : publicRequiresDomain
+        : brandRequired
           ? 'Set a primary brand domain to publish publicly.'
           : '';
 
@@ -1247,10 +1241,10 @@
       const selectId = `agent-${index}-visibility`;
       const publicLabel = publicDisabled ? 'Public (unavailable)' : 'Public';
 
-      const upsell = !canSetPublic
-        ? `<span class="agent-visibility-upsell"><a href="/membership">Upgrade to Professional</a> to list publicly.</span>`
+      const upsell = tierRequired
+        ? `<span class="agent-visibility-upsell"><a href="/membership">Upgrade to a paid AAO tier</a> to list publicly.</span>`
         : '';
-      const brandNudge = canSetPublic && publicRequiresDomain
+      const brandNudge = !tierRequired && brandRequired
         ? `<span class="agent-visibility-upsell">Verify a <a href="/member-profile#linked-domains-section">primary brand domain</a> to publish publicly.</span>`
         : '';
 

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -52,7 +52,7 @@ import { updateBrandIdentity, BrandIdentityError } from "../services/brand-ident
 import { createEscalation } from "../db/escalation-db.js";
 import { insertTypeReclassification } from "../db/type-reclassification-log-db.js";
 import { recordProfilePublishedIfNeeded } from "../services/profile-publish-event.js";
-import { gateAgentVisibilityForCaller, type VisibilityWarning } from "../services/agent-visibility-gate.js";
+import { gateAgentVisibilityForCaller, computeAgentVisibilityGate, type VisibilityWarning, type AgentVisibilityGate } from "../services/agent-visibility-gate.js";
 import { getBrandPrimaryDomain } from "../services/brand-domain-resolver.js";
 import { normalizeFoundingMemberGrant } from "../services/founding-member-grant.js";
 
@@ -673,18 +673,24 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
           });
         }
         const profile = await memberDb.getProfileByOrgId(devOrgId);
+        const devBrandPrimary = await getBrandPrimaryDomain(devOrgId);
         if (profile) {
-          const brandPrimary = await getBrandPrimaryDomain(devOrgId);
-          if (brandPrimary) {
-            profile.resolved_brand = await resolveBrand(brandDb, brandPrimary);
+          if (devBrandPrimary) {
+            profile.resolved_brand = await resolveBrand(brandDb, devBrandPrimary);
+            (profile as unknown as Record<string, unknown>).primary_brand_domain = devBrandPrimary;
           }
         }
+        const devHasApiAccess = hasApiAccess(resolveMembershipTier(localOrg));
         logger.info({ userId: user.id, orgId: devOrgId, hasProfile: !!profile, durationMs: Date.now() - startTime }, 'GET /api/me/member-profile completed (dev mode)');
         return res.json({
           profile: profile || null,
           organization_id: devOrgId,
           organization_name: localOrg.name,
-          has_api_access: hasApiAccess(resolveMembershipTier(localOrg)),
+          has_api_access: devHasApiAccess,
+          agent_visibility_gate: computeAgentVisibilityGate({
+            hasApiAccess: devHasApiAccess,
+            brandPrimaryDomain: devBrandPrimary,
+          }),
         });
       }
 
@@ -729,23 +735,32 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       }
 
       const profile = await memberDb.getProfileByOrgId(targetOrgId);
+      const brandPrimary = await getBrandPrimaryDomain(targetOrgId);
       if (profile) {
-        const brandPrimary = await getBrandPrimaryDomain(targetOrgId);
         if (brandPrimary) {
           profile.resolved_brand = await resolveBrand(brandDb, brandPrimary);
+          // After Stage 2 of #4159 dropped the column, the field is
+          // re-derived from organization_domains.is_primary so clients
+          // (member-profile.html, dashboard-agents.html) keep working.
+          (profile as unknown as Record<string, unknown>).primary_brand_domain = brandPrimary;
         }
       }
 
       // Get org name from WorkOS
       const org = await workos!.organizations.getOrganization(targetOrgId);
       const localOrg = await orgDb.getOrganization(targetOrgId);
+      const callerHasApiAccess = hasApiAccess(resolveMembershipTier(localOrg));
 
       logger.info({ userId: user.id, orgId: targetOrgId, hasProfile: !!profile, durationMs: Date.now() - startTime }, 'GET /api/me/member-profile completed');
       res.json({
         profile: profile || null,
         organization_id: targetOrgId,
         organization_name: org.name,
-        has_api_access: hasApiAccess(resolveMembershipTier(localOrg)),
+        has_api_access: callerHasApiAccess,
+        agent_visibility_gate: computeAgentVisibilityGate({
+          hasApiAccess: callerHasApiAccess,
+          brandPrimaryDomain: brandPrimary,
+        }),
       });
     } catch (error) {
       logger.error({ err: error, durationMs: Date.now() - startTime }, 'GET /api/me/member-profile error');

--- a/server/src/services/agent-visibility-gate.ts
+++ b/server/src/services/agent-visibility-gate.ts
@@ -11,6 +11,42 @@ import { isValidAgentVisibility, isValidAgentType } from '../types.js';
 import type { AgentConfig, AgentVisibility } from '../types.js';
 import { validateExternalUrl } from '../utils/url-security.js';
 
+/**
+ * Server-authoritative answer to "can this caller publish an agent publicly?"
+ * Two independent preconditions:
+ *  - `tier_required`: caller's org lacks an API-access membership tier
+ *  - `brand_domain_required`: caller's org has no `organization_domains.is_primary=true`
+ *
+ * The same two preconditions are enforced at write time by the
+ * `/agents/:index/publish` and `/agents/:index/visibility` route handlers
+ * (`tier_required` via `requireApiAccessTier`, `brand_domain_required` via
+ * the `brandPrimaryDomain` null-check inside `applyAgentVisibility`). This
+ * helper exists so the UI affordance and the write-time enforcement read
+ * from one place — the dashboard previously reverse-engineered the gate
+ * by checking whether a domain field was present on the profile response,
+ * which silently broke when the field shape changed.
+ *
+ * Shares the same `tier_required` reason code with the per-agent downgrade
+ * warnings emitted by {@link gateAgentVisibilityForCaller} below — keep the
+ * vocabulary aligned when adding new reasons.
+ */
+export type AgentVisibilityGateReason = 'tier_required' | 'brand_domain_required';
+
+export interface AgentVisibilityGate {
+  can_publish_publicly: boolean;
+  reasons: AgentVisibilityGateReason[];
+}
+
+export function computeAgentVisibilityGate(opts: {
+  hasApiAccess: boolean;
+  brandPrimaryDomain: string | null | undefined;
+}): AgentVisibilityGate {
+  const reasons: AgentVisibilityGateReason[] = [];
+  if (!opts.hasApiAccess) reasons.push('tier_required');
+  if (!opts.brandPrimaryDomain) reasons.push('brand_domain_required');
+  return { can_publish_publicly: reasons.length === 0, reasons };
+}
+
 export interface VisibilityWarning {
   code: 'visibility_downgraded';
   /**

--- a/server/tests/integration/agent-visibility-e2e.test.ts
+++ b/server/tests/integration/agent-visibility-e2e.test.ts
@@ -626,4 +626,95 @@ describe('Agent visibility E2E', () => {
       updateSpy.mockRestore();
     }
   });
+
+  // Pins the contract the dashboard reads to enable/disable the "Public"
+  // visibility toggle. Stage 2 of #4159 dropped the column the dashboard
+  // was inferring from; without this surface, the toggle silently greyed
+  // out for every Builder/Member with a verified primary domain.
+  describe('GET /api/me/member-profile: agent_visibility_gate', () => {
+    it('Builder with primary brand domain: can_publish_publicly=true', async () => {
+      const orgId = `${TEST_PREFIX}_gate_ok`;
+      const userId = `${TEST_PREFIX}_gate_ok_user`;
+      await seedOrg(pool, orgId, 'company_standard');
+      await provisionUser(userId, orgId);
+      await createProfile(orgId, 'gateok');
+
+      (app as any).setCurrentUser(userId, orgId);
+      const res = await request(app).get('/api/me/member-profile');
+
+      expect(res.status).toBe(200);
+      expect(res.body.has_api_access).toBe(true);
+      expect(res.body.agent_visibility_gate).toEqual({
+        can_publish_publicly: true,
+        reasons: [],
+      });
+      // Re-derived from organization_domains.is_primary so legacy callers
+      // (member-profile.html, dashboard-agents.html) keep working post-#4313.
+      expect(res.body.profile.primary_brand_domain).toBe('gateok.example');
+    });
+
+    it('Explorer with primary brand domain: tier_required', async () => {
+      const orgId = `${TEST_PREFIX}_gate_tier`;
+      const userId = `${TEST_PREFIX}_gate_tier_user`;
+      await seedOrg(pool, orgId, 'individual_academic');
+      await provisionUser(userId, orgId);
+      await createProfile(orgId, 'gatetier');
+
+      (app as any).setCurrentUser(userId, orgId);
+      const res = await request(app).get('/api/me/member-profile');
+
+      expect(res.status).toBe(200);
+      expect(res.body.agent_visibility_gate.can_publish_publicly).toBe(false);
+      expect(res.body.agent_visibility_gate.reasons).toEqual(['tier_required']);
+    });
+
+    it('Builder without primary brand domain: brand_domain_required', async () => {
+      const orgId = `${TEST_PREFIX}_gate_brand`;
+      const userId = `${TEST_PREFIX}_gate_brand_user`;
+      await seedOrg(pool, orgId, 'company_standard');
+      await provisionUser(userId, orgId);
+      await memberDb.createProfile({
+        workos_organization_id: orgId,
+        display_name: 'No Brand Org',
+        slug: 'gatebrand',
+        is_public: true,
+        agents: [{ url: 'https://a.gatebrand.example', visibility: 'private' }],
+      });
+      // Deliberately no seedBrandPrimary — the org has no is_primary row.
+
+      (app as any).setCurrentUser(userId, orgId);
+      const res = await request(app).get('/api/me/member-profile');
+
+      expect(res.status).toBe(200);
+      expect(res.body.agent_visibility_gate.can_publish_publicly).toBe(false);
+      expect(res.body.agent_visibility_gate.reasons).toEqual(['brand_domain_required']);
+      expect(res.body.profile.primary_brand_domain).toBeUndefined();
+    });
+
+    it('unpaid tier with no brand domain: both reasons surface', async () => {
+      const orgId = `${TEST_PREFIX}_gate_both`;
+      const userId = `${TEST_PREFIX}_gate_both_user`;
+      await seedOrg(pool, orgId, null);
+      await provisionUser(userId, orgId);
+      await memberDb.createProfile({
+        workos_organization_id: orgId,
+        display_name: 'Bare Org',
+        slug: 'gateboth',
+        is_public: true,
+        agents: [{ url: 'https://a.gateboth.example', visibility: 'private' }],
+      });
+
+      (app as any).setCurrentUser(userId, orgId);
+      const res = await request(app).get('/api/me/member-profile');
+
+      expect(res.status).toBe(200);
+      expect(res.body.agent_visibility_gate.can_publish_publicly).toBe(false);
+      // Order is deterministic: tier first, then brand. Pinned in the
+      // unit test for computeAgentVisibilityGate too.
+      expect(res.body.agent_visibility_gate.reasons).toEqual([
+        'tier_required',
+        'brand_domain_required',
+      ]);
+    });
+  });
 });

--- a/server/tests/unit/agent-visibility-gate.test.ts
+++ b/server/tests/unit/agent-visibility-gate.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { gateAgentVisibilityForCaller } from '../../src/services/agent-visibility-gate.js';
+import {
+  gateAgentVisibilityForCaller,
+  computeAgentVisibilityGate,
+} from '../../src/services/agent-visibility-gate.js';
 
 /**
  * Shared-helper tests for the tier-gate coercion used by both POST and
@@ -118,5 +121,41 @@ describe('gateAgentVisibilityForCaller', () => {
     expect(agents.map((a) => a.visibility)).toEqual(['members_only', 'private', 'members_only']);
     expect(warnings).toHaveLength(2);
     expect(warnings.map((w) => w.agent_url)).toEqual(['https://a', 'https://c']);
+  });
+});
+
+describe('computeAgentVisibilityGate', () => {
+  it('allows public when caller has both API access and a brand domain', () => {
+    expect(
+      computeAgentVisibilityGate({ hasApiAccess: true, brandPrimaryDomain: 'example.com' }),
+    ).toEqual({ can_publish_publicly: true, reasons: [] });
+  });
+
+  it('returns tier_required when caller lacks API access', () => {
+    const gate = computeAgentVisibilityGate({ hasApiAccess: false, brandPrimaryDomain: 'example.com' });
+    expect(gate.can_publish_publicly).toBe(false);
+    expect(gate.reasons).toEqual(['tier_required']);
+  });
+
+  it('returns brand_domain_required when caller has API access but no primary brand domain', () => {
+    const gate = computeAgentVisibilityGate({ hasApiAccess: true, brandPrimaryDomain: null });
+    expect(gate.can_publish_publicly).toBe(false);
+    expect(gate.reasons).toEqual(['brand_domain_required']);
+  });
+
+  it('returns both reasons when neither precondition is met', () => {
+    const gate = computeAgentVisibilityGate({ hasApiAccess: false, brandPrimaryDomain: null });
+    expect(gate.can_publish_publicly).toBe(false);
+    expect(gate.reasons).toEqual(['tier_required', 'brand_domain_required']);
+  });
+
+  it('treats an empty-string domain the same as null', () => {
+    const gate = computeAgentVisibilityGate({ hasApiAccess: true, brandPrimaryDomain: '' });
+    expect(gate.reasons).toEqual(['brand_domain_required']);
+  });
+
+  it('treats undefined the same as null', () => {
+    const gate = computeAgentVisibilityGate({ hasApiAccess: true, brandPrimaryDomain: undefined });
+    expect(gate.reasons).toEqual(['brand_domain_required']);
   });
 });


### PR DESCRIPTION
## Summary

Real escalation from Affinity Answers (Builder member) today: the "Public" visibility toggle on `/dashboard/agents` was greyed out despite their primary brand domain being verified.

**Root cause.** Stage 2 of #4159 (PR #4313) dropped `member_profiles.primary_brand_domain` and updated the bootstrap POST to re-derive the field via the resolver. The GET handler at `member-profiles.ts:744` was missed — it returned the raw `MemberProfile` row without the re-derived field. The dashboard at `dashboard-agents.html:1135` keyed its "is Public allowed?" gate on the presence of that field, so the toggle silently greyed out for **every Builder/Member/Leader with a verified primary domain** since #4313 shipped. Santhosh just happened to escalate.

## Fix (two layers)

**Layer 1 — restore the GET response.** `GET /api/me/member-profile` (dev-mode + prod paths) now re-derives `primary_brand_domain` via `getBrandPrimaryDomain(orgId)` and merges it onto the returned profile, the same way the bootstrap POST already does via `toSpecMemberProfile`. This alone unblocks Santhosh and every other affected member, plus restores `member-profile.html`'s brand-section display which had been silently broken too.

**Layer 2 — eliminate the bug class.** Adds `computeAgentVisibilityGate({ hasApiAccess, brandPrimaryDomain })` next to the existing `gateAgentVisibilityForCaller`. Returns `{ can_publish_publicly, reasons: ('tier_required' | 'brand_domain_required')[] }`. The GET response emits this as `agent_visibility_gate`. The dashboard's `renderVisibilitySelector` binds the toggle's `disabled` state and the upsell/nudge copy directly to that gate — same two preconditions the `/publish` endpoint already enforces server-side. The reverse-engineering from data-shape presence is gone, as is the redundant `/api/brands/discovered/.../edit-status` fetch the dashboard never actually used for its `self-hosted` vs `community` value.

**Layer 3 — regression guard.** Unit tests for the new helper (six cases) and integration tests in `agent-visibility-e2e.test.ts` that hit `GET /api/me/member-profile` for all four gate combinations. A failing GET-shape test would have caught the #4313 regression on day one.

## Expert review notes

- **code-reviewer**: gate predicate accurately mirrors both write-time enforcement paths; `company_standard` correctly maps to Builder. Asked for the changeset (added), the load-gap default question (addressed — defaults to `brand_domain_required` so the brand nudge renders during the sub-second load), and the deterministic-order assertion (addressed — `.sort()` dropped from the integration test).
- **adtech-product-expert**: asked to update the upsell copy from "Upgrade to Professional" to "Upgrade to a paid AAO tier" (matches the disabled-state list and survives pricing changes) — done. Also flagged that `is_primary` doesn't imply `verified` — out of scope for this PR (matches today's write-side enforcement); worth a follow-up issue once PR #4440's verification flow is universal.

## Test plan

- [x] `npm run test:server-unit` for `agent-visibility-gate.test.ts` — 16 pass (10 existing + 6 new)
- [x] `npm run typecheck` clean
- [ ] CI: `test:server-integration` runs the new GET-shape tests against a real Postgres
- [ ] Manual: Santhosh's affinityanswers.com toggle flips Public after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)