### PR TITLE
fix(brand-resolve): return brand_manifest from flat brand fields

### DIFF
--- a/.changeset/fix-brand-resolve-manifest.md
+++ b/.changeset/fix-brand-resolve-manifest.md
@@ -1,0 +1,8 @@
+---
+---
+
+Fix `/api/brands/resolve` returning empty `brand_manifest` for house-portfolio brand.json files.
+
+`BrandManager.resolveBrand` and `resolveBrandRef` were reading a nested `brand.brand_manifest` field that no longer exists in the brand.json schema — brand fields (logos, colors, fonts, tone, description, properties, etc.) have been flat on the brand object since the unified brand identity refactor. The master-brand fallback (when the queried domain matches the house domain) also omitted the manifest entirely.
+
+All three return sites now build `brand_manifest` from the brand object minus identity fields (`id`, `names`, `keller_type`, `parent_brand`). Legacy nested `brand_manifest` sub-keys are merged in for backwards compatibility.

--- a/.changeset/fix-brand-resolve-manifest.md
+++ b/.changeset/fix-brand-resolve-manifest.md
@@ -5,4 +5,8 @@ Fix `/api/brands/resolve` returning empty `brand_manifest` for house-portfolio b
 
 `BrandManager.resolveBrand` and `resolveBrandRef` were reading a nested `brand.brand_manifest` field that no longer exists in the brand.json schema — brand fields (logos, colors, fonts, tone, description, properties, etc.) have been flat on the brand object since the unified brand identity refactor. The master-brand fallback (when the queried domain matches the house domain) also omitted the manifest entirely.
 
-All three return sites now build `brand_manifest` from the brand object minus identity fields (`id`, `names`, `keller_type`, `parent_brand`). Legacy nested `brand_manifest` sub-keys are merged in for backwards compatibility.
+All three return sites now build `brand_manifest` from the brand object via a new `buildBrandManifest` helper. Identity fields (`id`, `names`, `keller_type`, `parent_brand`) and ownership data (`properties`) are stripped; remaining flat fields become the manifest payload. Legacy nested `brand_manifest` sub-keys are merged in for backwards compatibility, with flat fields taking precedence.
+
+**Behavior note for `brand_manifest` consumers:** `properties` (digital touchpoints the brand owns) is intentionally excluded from `brand_manifest` even though it lives on the brand object. The manifest is the brand's creative-asset payload (logos, colors, fonts, tone) — consistent with how downstream code (`services/brand-enrichment.ts`) already treats it. Callers needing ownership data should read `brand.properties` directly.
+
+**Type model:** `BrandDefinition` and `BrandProperty` in `server/src/types.ts` are now derived from the canonical `BrandJson` zod schema in `@adcp/sdk` (>= 7.3.0) rather than hand-maintained. Future brand.json schema changes regenerate the SDK type and flow through automatically — preventing the staleness class that caused this bug. Required SDK bump from `^7.1.0` to `^7.3.0`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.0.3",
       "dependencies": {
-        "@adcp/sdk": "^7.1.0",
+        "@adcp/sdk": "^7.3.0",
         "@anthropic-ai/sdk": "^0.91.1",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-7.1.0.tgz",
-      "integrity": "sha512-RSm07ImvdKX1XqiiEmIBzYdgdaQZWIu0PAhRmNEPyn/A8odOE4RmkUOYouV+Fhra75DINBso8k/UbVgkAjibbQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-7.3.0.tgz",
+      "integrity": "sha512-rtECZdvaVf4t3Co0uMsDq9kvKCC+x0MrUleVP2aLMMSAo+/c7yL+x4ENM8FZlmv63tOW+c2d26ktoDSpojoyYw==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "dev:docs": "node scripts/dev-docs.mjs"
   },
   "dependencies": {
-    "@adcp/sdk": "^7.1.0",
+    "@adcp/sdk": "^7.3.0",
     "@anthropic-ai/sdk": "^0.91.1",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",

--- a/server/src/brand-manager.ts
+++ b/server/src/brand-manager.ts
@@ -679,7 +679,7 @@ export class BrandManager {
               parent_brand: brand.parent_brand,
               house_domain: portfolioData.house.domain,
               house_name: portfolioData.house.name,
-              brand_manifest: brand.brand_manifest as Record<string, unknown> | undefined,
+              brand_manifest: this.buildBrandManifest(brand),
               source: 'brand_json',
             };
             this.resolutionCache.set(cacheKey, result);
@@ -700,6 +700,7 @@ export class BrandManager {
                 keller_type: masterBrand.keller_type,
                 house_domain: portfolioData.house.domain,
                 house_name: portfolioData.house.name,
+                brand_manifest: this.buildBrandManifest(masterBrand),
                 source: 'brand_json',
               };
               this.resolutionCache.set(cacheKey, result);
@@ -757,13 +758,39 @@ export class BrandManager {
           parent_brand: brand.parent_brand,
           house_domain: portfolio.house.domain,
           house_name: portfolio.house.name,
-          brand_manifest: brand.brand_manifest as Record<string, unknown> | undefined,
+          brand_manifest: this.buildBrandManifest(brand),
           source: 'brand_json',
         };
       }
     }
 
     return null;
+  }
+
+  /**
+   * Build the brand_manifest payload from a BrandDefinition by stripping
+   * identity/locator fields that are already surfaced as top-level
+   * ResolvedBrand fields. Returns undefined when no manifest data remains.
+   *
+   * Brand fields are flat on the brand object per the unified brand.json
+   * schema (post-commit 892da1df2). A legacy nested `brand_manifest`
+   * sub-key, if present, is merged in for backwards compatibility.
+   */
+  private buildBrandManifest(brand: BrandDefinition): Record<string, unknown> | undefined {
+    const { id, names, keller_type, parent_brand, brand_manifest, ...rest } =
+      brand as BrandDefinition & Record<string, unknown>;
+    void id;
+    void names;
+    void keller_type;
+    void parent_brand;
+
+    const legacy =
+      brand_manifest && typeof brand_manifest === 'object'
+        ? (brand_manifest as Record<string, unknown>)
+        : undefined;
+
+    const merged: Record<string, unknown> = { ...(legacy ?? {}), ...rest };
+    return Object.keys(merged).length > 0 ? merged : undefined;
   }
 
   /**

--- a/server/src/brand-manager.ts
+++ b/server/src/brand-manager.ts
@@ -768,25 +768,29 @@ export class BrandManager {
   }
 
   /**
-   * Build the brand_manifest payload from a BrandDefinition by stripping
-   * identity/locator fields that are already surfaced as top-level
-   * ResolvedBrand fields. Returns undefined when no manifest data remains.
+   * Build the brand_manifest payload (creative asset data) from a brand by
+   * stripping identity (`id`, `names`, `keller_type`, `parent_brand`) and
+   * ownership (`properties`) fields that have separate semantic meaning.
+   * Returns undefined when no manifest data remains.
    *
    * Brand fields are flat on the brand object per the unified brand.json
-   * schema (post-commit 892da1df2). A legacy nested `brand_manifest`
-   * sub-key, if present, is merged in for backwards compatibility.
+   * schema. A legacy nested `brand_manifest` sub-key, if present, is merged
+   * in for backwards compatibility; flat fields take precedence.
    */
   private buildBrandManifest(brand: BrandDefinition): Record<string, unknown> | undefined {
-    const { id, names, keller_type, parent_brand, brand_manifest, ...rest } =
-      brand as BrandDefinition & Record<string, unknown>;
-    void id;
-    void names;
-    void keller_type;
-    void parent_brand;
+    const {
+      id: _id,
+      names: _names,
+      keller_type: _kellerType,
+      parent_brand: _parentBrand,
+      properties: _properties,
+      brand_manifest: brandManifest,
+      ...rest
+    } = brand;
 
     const legacy =
-      brand_manifest && typeof brand_manifest === 'object'
-        ? (brand_manifest as Record<string, unknown>)
+      brandManifest && typeof brandManifest === 'object'
+        ? (brandManifest as Record<string, unknown>)
         : undefined;
 
     const merged: Record<string, unknown> = { ...(legacy ?? {}), ...rest };

--- a/server/src/brand-manager.ts
+++ b/server/src/brand-manager.ts
@@ -544,7 +544,7 @@ export class BrandManager {
 
     // Validate properties if present
     if (brand.properties) {
-      brand.properties.forEach((prop, propIndex) => {
+      brand.properties.forEach((prop: BrandProperty, propIndex: number) => {
         this.validateProperty(prop, `${prefix}.properties[${propIndex}]`, result);
       });
     }

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -490,7 +490,8 @@ export interface LocalizedName {
 }
 
 /**
- * Brand property (digital touchpoint owned by a brand)
+ * Brand property (digital touchpoint owned by a brand).
+ * Mirrors the `properties[]` shape in static/schemas/source/brand.json.
  */
 export interface BrandProperty {
   type: 'website' | 'mobile_app' | 'ctv_app' | 'desktop_app' | 'dooh' | 'podcast' | 'radio' | 'streaming_audio';
@@ -498,19 +499,42 @@ export interface BrandProperty {
   store?: 'apple' | 'google' | 'amazon' | 'roku' | 'samsung' | 'lg' | 'other';
   region?: string;
   primary?: boolean;
+  relationship?: 'owned' | 'direct' | 'delegated' | 'ad_network';
 }
 
 /**
- * Brand definition within a house portfolio
+ * Brand definition within a house portfolio.
+ *
+ * Mirrors the `brand` object in static/schemas/source/brand.json. The schema
+ * is the source of truth; this interface is hand-maintained until `BrandJson`
+ * is exported from `@adcp/sdk`'s public surface (the inferred type exists at
+ * `dist/lib/types/wellknown-schemas.generated` but is not re-exported).
  */
 export interface BrandDefinition {
   id: string;
+  url?: string;
   names: LocalizedName[];
   keller_type?: KellerType;
   parent_brand?: string;
+  description?: string;
+  industries?: string[];
+  target_audience?: string;
+  logos?: Array<Record<string, unknown>>;
+  colors?: Record<string, unknown>;
+  fonts?: Record<string, unknown>;
+  tone?: string | Record<string, unknown>;
+  tagline?: string | Array<Record<string, string>>;
+  assets?: Array<Record<string, unknown>>;
   properties?: BrandProperty[];
+  product_catalog?: Record<string, unknown>;
+  privacy_policy_url?: string;
+  data_subject_contestation?: Record<string, unknown>;
+  disclaimers?: Array<Record<string, unknown>>;
   brand_standards?: string;
+  /** Legacy nested manifest — flat fields above are preferred. */
   brand_manifest?: Record<string, unknown> | string;
+  /** Schema allows additional creative/identity properties via `additionalProperties: true`. */
+  [key: string]: unknown;
 }
 
 /**

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,3 +1,5 @@
+import type { BrandJson } from '@adcp/sdk';
+
 export type AgentType = "brand" | "rights" | "measurement" | "governance" | "creative" | "sales" | "buying" | "signals" | "unknown";
 
 /**
@@ -490,52 +492,21 @@ export interface LocalizedName {
 }
 
 /**
- * Brand property (digital touchpoint owned by a brand).
- * Mirrors the `properties[]` shape in static/schemas/source/brand.json.
- */
-export interface BrandProperty {
-  type: 'website' | 'mobile_app' | 'ctv_app' | 'desktop_app' | 'dooh' | 'podcast' | 'radio' | 'streaming_audio';
-  identifier: string;
-  store?: 'apple' | 'google' | 'amazon' | 'roku' | 'samsung' | 'lg' | 'other';
-  region?: string;
-  primary?: boolean;
-  relationship?: 'owned' | 'direct' | 'delegated' | 'ad_network';
-}
-
-/**
  * Brand definition within a house portfolio.
  *
- * Mirrors the `brand` object in static/schemas/source/brand.json. The schema
- * is the source of truth; this interface is hand-maintained until `BrandJson`
- * is exported from `@adcp/sdk`'s public surface (the inferred type exists at
- * `dist/lib/types/wellknown-schemas.generated` but is not re-exported).
+ * Derived from the canonical `BrandJson` zod schema in `@adcp/sdk` so flat
+ * brand fields (logos, colors, fonts, tone, description, properties, etc.)
+ * stay in sync with the brand.json spec. Adding fields to the schema
+ * regenerates the SDK type; consumers here pick them up automatically.
  */
-export interface BrandDefinition {
-  id: string;
-  url?: string;
-  names: LocalizedName[];
-  keller_type?: KellerType;
-  parent_brand?: string;
-  description?: string;
-  industries?: string[];
-  target_audience?: string;
-  logos?: Array<Record<string, unknown>>;
-  colors?: Record<string, unknown>;
-  fonts?: Record<string, unknown>;
-  tone?: string | Record<string, unknown>;
-  tagline?: string | Array<Record<string, string>>;
-  assets?: Array<Record<string, unknown>>;
-  properties?: BrandProperty[];
-  product_catalog?: Record<string, unknown>;
-  privacy_policy_url?: string;
-  data_subject_contestation?: Record<string, unknown>;
-  disclaimers?: Array<Record<string, unknown>>;
-  brand_standards?: string;
-  /** Legacy nested manifest — flat fields above are preferred. */
-  brand_manifest?: Record<string, unknown> | string;
-  /** Schema allows additional creative/identity properties via `additionalProperties: true`. */
-  [key: string]: unknown;
-}
+type BrandJsonHousePortfolio = Extract<BrandJson, { brands: unknown[] }>;
+export type BrandDefinition = BrandJsonHousePortfolio['brands'][number];
+
+/**
+ * Brand property (digital touchpoint owned by a brand). Derived from
+ * `BrandDefinition` so it tracks the schema.
+ */
+export type BrandProperty = NonNullable<BrandDefinition['properties']>[number];
 
 /**
  * House definition (corporate entity that owns brands)

--- a/server/tests/unit/brand-manager-cache.test.ts
+++ b/server/tests/unit/brand-manager-cache.test.ts
@@ -340,6 +340,10 @@ describe('BrandManager caching', () => {
       expect(result).not.toBeNull();
       expect(result?.brand_manifest).toBeDefined();
       expect(result?.brand_manifest?.description).toBe('A sub-brand');
+      // properties is ownership/identity data, not creative payload — must
+      // not leak into brand_manifest, which downstream consumers treat as
+      // logos/colors/fonts/tone (see services/brand-enrichment.ts).
+      expect(result?.brand_manifest).not.toHaveProperty('properties');
     });
 
     it('merges legacy nested brand_manifest with flat fields', async () => {

--- a/server/tests/unit/brand-manager-cache.test.ts
+++ b/server/tests/unit/brand-manager-cache.test.ts
@@ -235,6 +235,212 @@ describe('BrandManager caching', () => {
     });
   });
 
+  describe('brand_manifest construction', () => {
+    it('populates brand_manifest from flat brand fields (master-brand fallback)', async () => {
+      const mockBrandJson = {
+        $schema: 'https://adcontextprotocol.org/schemas/latest/brand.json',
+        version: '1.0',
+        house: {
+          domain: 'wonderstruck.org',
+          name: 'Wonderstruck',
+        },
+        brands: [
+          {
+            id: 'wonderstruck',
+            names: [{ en: 'Wonderstruck' }],
+            keller_type: 'master',
+            description: 'A creative studio',
+            target_audience: 'designers',
+            tagline: 'Make wonder',
+            logos: [{ url: 'https://wonderstruck.org/logo.svg' }],
+            colors: { primary: '#ff00ff' },
+            fonts: { primary: 'Inter' },
+            tone: 'playful',
+          },
+        ],
+      };
+
+      mockedSafeFetch.mockResolvedValue({
+        status: 200,
+        data: Buffer.from(JSON.stringify(mockBrandJson)),
+      });
+
+      const result = await manager.resolveBrand('wonderstruck.org');
+      expect(result).not.toBeNull();
+      expect(result?.brand_manifest).toBeDefined();
+      expect(result?.brand_manifest?.description).toBe('A creative studio');
+      expect(result?.brand_manifest?.target_audience).toBe('designers');
+      expect(result?.brand_manifest?.tagline).toBe('Make wonder');
+      expect(result?.brand_manifest?.logos).toEqual([
+        { url: 'https://wonderstruck.org/logo.svg' },
+      ]);
+      expect(result?.brand_manifest?.colors).toEqual({ primary: '#ff00ff' });
+      expect(result?.brand_manifest?.fonts).toEqual({ primary: 'Inter' });
+      expect(result?.brand_manifest?.tone).toBe('playful');
+    });
+
+    it('strips identity fields from brand_manifest', async () => {
+      const mockBrandJson = {
+        $schema: 'https://adcontextprotocol.org/schemas/latest/brand.json',
+        version: '1.0',
+        house: {
+          domain: 'acme.com',
+          name: 'Acme',
+        },
+        brands: [
+          {
+            id: 'acme',
+            names: [{ en: 'Acme' }],
+            keller_type: 'master',
+            parent_brand: 'parent',
+            description: 'A brand',
+          },
+        ],
+      };
+
+      mockedSafeFetch.mockResolvedValue({
+        status: 200,
+        data: Buffer.from(JSON.stringify(mockBrandJson)),
+      });
+
+      const result = await manager.resolveBrand('acme.com');
+      expect(result?.brand_manifest).toBeDefined();
+      expect(result?.brand_manifest).not.toHaveProperty('id');
+      expect(result?.brand_manifest).not.toHaveProperty('names');
+      expect(result?.brand_manifest).not.toHaveProperty('keller_type');
+      expect(result?.brand_manifest).not.toHaveProperty('parent_brand');
+      expect(result?.brand_manifest?.description).toBe('A brand');
+    });
+
+    it('returns brand_manifest from property-match resolution', async () => {
+      const mockBrandJson = {
+        $schema: 'https://adcontextprotocol.org/schemas/latest/brand.json',
+        version: '1.0',
+        house: {
+          domain: 'house.com',
+          name: 'House',
+        },
+        brands: [
+          {
+            id: 'subbrand',
+            names: [{ en: 'Sub Brand' }],
+            keller_type: 'sub_brand',
+            description: 'A sub-brand',
+            properties: [{ type: 'website', identifier: 'subbrand.com' }],
+          },
+        ],
+      };
+
+      mockedSafeFetch.mockResolvedValue({
+        status: 200,
+        data: Buffer.from(JSON.stringify(mockBrandJson)),
+      });
+
+      const result = await manager.resolveBrand('subbrand.com');
+      expect(result).not.toBeNull();
+      expect(result?.brand_manifest).toBeDefined();
+      expect(result?.brand_manifest?.description).toBe('A sub-brand');
+    });
+
+    it('merges legacy nested brand_manifest with flat fields', async () => {
+      const mockBrandJson = {
+        $schema: 'https://adcontextprotocol.org/schemas/latest/brand.json',
+        version: '1.0',
+        house: {
+          domain: 'legacy.com',
+          name: 'Legacy',
+        },
+        brands: [
+          {
+            id: 'legacy',
+            names: [{ en: 'Legacy' }],
+            keller_type: 'master',
+            description: 'Flat description',
+            brand_manifest: {
+              legacy_field: 'from-nested',
+              description: 'Nested description (should be overridden)',
+            },
+          },
+        ],
+      };
+
+      mockedSafeFetch.mockResolvedValue({
+        status: 200,
+        data: Buffer.from(JSON.stringify(mockBrandJson)),
+      });
+
+      const result = await manager.resolveBrand('legacy.com');
+      expect(result?.brand_manifest).toBeDefined();
+      expect(result?.brand_manifest?.legacy_field).toBe('from-nested');
+      // Flat fields take precedence over legacy nested values
+      expect(result?.brand_manifest?.description).toBe('Flat description');
+    });
+
+    it('omits brand_manifest when no manifest data is present', async () => {
+      const mockBrandJson = {
+        $schema: 'https://adcontextprotocol.org/schemas/latest/brand.json',
+        version: '1.0',
+        house: {
+          domain: 'minimal.com',
+          name: 'Minimal',
+        },
+        brands: [
+          {
+            id: 'minimal',
+            names: [{ en: 'Minimal' }],
+            keller_type: 'master',
+          },
+        ],
+      };
+
+      mockedSafeFetch.mockResolvedValue({
+        status: 200,
+        data: Buffer.from(JSON.stringify(mockBrandJson)),
+      });
+
+      const result = await manager.resolveBrand('minimal.com');
+      expect(result).not.toBeNull();
+      expect(result?.brand_manifest).toBeUndefined();
+    });
+
+    it('populates brand_manifest from resolveBrandRef with brand_id', async () => {
+      const mockBrandJson = {
+        $schema: 'https://adcontextprotocol.org/schemas/latest/brand.json',
+        version: '1.0',
+        house: {
+          domain: 'multi.com',
+          name: 'Multi',
+        },
+        brands: [
+          {
+            id: 'brand-a',
+            names: [{ en: 'Brand A' }],
+            keller_type: 'master',
+            description: 'Brand A description',
+          },
+          {
+            id: 'brand-b',
+            names: [{ en: 'Brand B' }],
+            keller_type: 'sub_brand',
+            description: 'Brand B description',
+          },
+        ],
+      };
+
+      mockedSafeFetch.mockResolvedValue({
+        status: 200,
+        data: Buffer.from(JSON.stringify(mockBrandJson)),
+      });
+
+      const result = await manager.resolveBrandRef({
+        domain: 'multi.com',
+        brand_id: 'brand-b',
+      });
+      expect(result).not.toBeNull();
+      expect(result?.brand_manifest?.description).toBe('Brand B description');
+    });
+  });
+
   describe('cache management', () => {
     it('getCacheStats returns correct counts', async () => {
       const mockBrandJson = {


### PR DESCRIPTION
## Summary

`/api/brands/resolve?domain=<house>` was returning identity fields only — `brand_manifest` was always empty. Reported on `wonderstruck.org`: the member updated their brand.json (logos, colors, fonts, tone, properties, etc. all present at the source), but resolve dropped all of it.

Two bugs in `BrandManager`:

1. **Master-brand fallback** (`resolveBrand`, when the queried domain matches `house.domain`) returned the master brand but never populated `brand_manifest` at all.
2. **Property-match and brand-id-match branches** read `brand.brand_manifest as Record<string, unknown> | undefined` — but `brand_manifest` is no longer a nested field on the brand object. Since commit 892da1df2 ("Unify brand identity — delete brand-manifest.json, use brand refs"), brand fields (logos, colors, fonts, tone, description, target_audience, tagline, properties, privacy_policy_url, etc.) are **flat** on the brand object. So this read was always `undefined`.

## Fix

Added `buildBrandManifest(brand)` helper that strips identity fields (`id`, `names`, `keller_type`, `parent_brand`) from the brand object and returns the rest as the manifest. A legacy nested `brand_manifest` sub-key, if present, is merged in for backwards compatibility. Returns `undefined` when no manifest data remains.

Applied at all three return sites in `server/src/brand-manager.ts`:
- `resolveBrand` — property-match branch
- `resolveBrand` — master-brand fallback (queried domain == house domain)
- `resolveBrandRef` — explicit `brand_id` match

## Note on caching

The in-memory `resolutionCache` and `validationCache` have a 24-hour TTL with no invalidation hook. After this deploys, the stale `wonderstruck.org` entry will persist until the cache expires OR someone hits `?fresh=true`. Cache invalidation on hosted-brand save and a shorter TTL for external brands are follow-ups worth doing — flagged but not in this PR.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `tests/unit/brand-manager-cache.test.ts` — 9/9 passing
- [x] Broader unit run — no new failures (5 pre-existing failures are unrelated: taxonomy/schema/storyboard tests on `main`)
- [ ] After deploy, verify `curl /api/brands/resolve?domain=wonderstruck.org&fresh=true` returns a populated `brand_manifest` with logos/colors/fonts/tone/properties