### PR TITLE
fix(migration): 477 broadcast delivery criteria — redefine _append_criterion helper

### DIFF
--- a/.changeset/fix-migration-477-append-criterion.md
+++ b/.changeset/fix-migration-477-append-criterion.md
@@ -1,0 +1,6 @@
+---
+---
+
+Fix migration `477_broadcast_delivery_criteria.sql` which called `_append_criterion()` without redefining it. The helper was created and dropped inside migration 407, so any later migration that wants to use it must redefine it inline (same pattern 407 uses).
+
+Migration 477 has been broken since it merged — failing every PR's integration-test job at `Apply migrations to test database` with `function _append_criterion(unknown, unknown, unknown, unknown) does not exist`, and blocking deploys. This patches it so the function is created at the top, the criteria are appended, and the function is dropped at the end — identical structure to 407. No criterion text or IDs are changed; only the function-availability wrapper is added.

--- a/server/src/db/migrations/477_broadcast_delivery_criteria.sql
+++ b/server/src/db/migrations/477_broadcast_delivery_criteria.sql
@@ -3,8 +3,66 @@
 -- S1 ex8: interpret get_media_buy_delivery measurement windows (live/c3/c7).
 -- B3 ex2: represent partial delivery correctly to the buyer.
 
+-- Re-define the helper that 407_curriculum_3_0_criterion_ids.sql created and
+-- then dropped at the end of its run. New criterion-appending migrations need
+-- to redefine the function locally; it is not a persistent fixture.
+CREATE OR REPLACE FUNCTION _append_criterion(
+  p_module_id text,
+  p_exercise_id text,
+  p_criterion_id text,
+  p_text text
+) RETURNS void AS $$
+DECLARE
+  defs jsonb;
+  updated jsonb := '[]'::jsonb;
+  ex jsonb;
+  criteria jsonb;
+  already_present boolean;
+  exercise_matched boolean := false;
+BEGIN
+  SELECT exercise_definitions INTO defs
+  FROM certification_modules
+  WHERE id = p_module_id;
+
+  IF defs IS NULL OR jsonb_typeof(defs) <> 'array' THEN
+    RAISE EXCEPTION 'Module % not found or has no exercise_definitions array', p_module_id;
+  END IF;
+
+  FOR ex IN SELECT * FROM jsonb_array_elements(defs)
+  LOOP
+    IF ex->>'id' = p_exercise_id THEN
+      exercise_matched := true;
+      criteria := COALESCE(ex->'success_criteria', '[]'::jsonb);
+
+      SELECT EXISTS (
+        SELECT 1 FROM jsonb_array_elements(criteria) c
+        WHERE c->>'id' = p_criterion_id
+      ) INTO already_present;
+
+      IF NOT already_present THEN
+        criteria := criteria || jsonb_build_array(
+          jsonb_build_object('id', p_criterion_id, 'text', p_text)
+        );
+        ex := jsonb_set(ex, '{success_criteria}', criteria);
+      END IF;
+    END IF;
+    updated := updated || jsonb_build_array(ex);
+  END LOOP;
+
+  IF NOT exercise_matched THEN
+    RAISE EXCEPTION 'Exercise % not found in module %', p_exercise_id, p_module_id;
+  END IF;
+
+  UPDATE certification_modules
+  SET exercise_definitions = updated
+  WHERE id = p_module_id;
+END;
+$$ LANGUAGE plpgsql;
+
 SELECT _append_criterion('S1', 's1_ex1', 's1_ex1_sc_broadcast_delivery_windows',
   'Calls get_media_buy_delivery on a broadcast buy and correctly interprets live/c3/c7 measurement window fields; explains that c7 DVR accumulation closes seven days post-air with additional vendor processing delay, and identifies incomplete data as by-design maturation rather than underdelivery.');
 
 SELECT _append_criterion('B3', 'b3_ex1', 'b3_ex1_sc_broadcast_delivery_seller_communication',
   'Given a broadcast product with c3/c7 measurement windows, describes what data is available two days after the flight date, explains why c7 is incomplete, and specifies how the seller should represent partial delivery to prevent buyer misreading it as underdelivery.');
+
+DROP FUNCTION _append_criterion(text, text, text, text);


### PR DESCRIPTION
## Summary

Migration `477_broadcast_delivery_criteria.sql` called `_append_criterion()` without redefining it. The helper was created and dropped inside migration `407_curriculum_3_0_criterion_ids.sql`, so any later migration that wants to use it must redefine it inline (same pattern 407 uses).

## Why now

477 has been broken since it merged — failing every PR's integration-test job at the "Apply migrations to test database" step:

\`\`\`
✗ Failed to apply migration: 477_broadcast_delivery_criteria.sql
Migration failed: error: function _append_criterion(unknown, unknown, unknown, unknown) does not exist
\`\`\`

This blocks every other PR from going green, including #4515 (OpenAPI regen) and #4513 (member tier exposure) which both surfaced the failure but were also independent work.

## What changed

- Added the `CREATE OR REPLACE FUNCTION _append_criterion(...)` definition at the top of 477, copied verbatim from 407.
- Added the matching `DROP FUNCTION _append_criterion(text, text, text, text);` at the bottom.
- No criterion text or IDs change; only the function-availability wrapper is added.

## Test plan

- [x] Same structure as migration 407, which has been running cleanly in prod
- [ ] Migration smoke test CI green
- [ ] Server integration tests CI green (the one currently failing on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)