### PR TITLE
fix(error-code): add enumMetadata for AUTH_MISSING and AUTH_INVALID

### DIFF
--- a/.changeset/fix-auth-missing-invalid-enum-metadata.md
+++ b/.changeset/fix-auth-missing-invalid-enum-metadata.md
@@ -1,0 +1,6 @@
+---
+---
+
+Fix `enums/error-code.json`: add missing `enumMetadata` entries for `AUTH_MISSING` and `AUTH_INVALID`, introduced by #3739 in `enum` + `enumDescriptions` but never added to `enumMetadata`. The schema lint (`Build` step → `npm run build:schemas` → `scripts/build-schemas.cjs`) catches this and fails CI on every PR until the metadata is consistent. SDKs read `enumMetadata` for recovery classification — drift here ships as recovery bugs in every downstream consumer.
+
+Metadata mirrors the descriptions on the same codes: `AUTH_MISSING` is correctable (provide credentials and retry), `AUTH_INVALID` is terminal (credentials presented and rejected; rotate or escalate — OAuth refresh-once is documented in the description but the default disposition is terminal).

--- a/scripts/error-code-drift-dispositions.json
+++ b/scripts/error-code-drift-dispositions.json
@@ -1,6 +1,16 @@
 {
   "$comment": "Disposition registry for error codes that are present in the current source enum but absent from the 3.0.x maintenance branch. Read by scripts/lint-error-code-drift.cjs. Every code in the AHEAD set (main \\ 3.0.x) MUST have an entry here; codes missing from this file fail the lint. Policy: 3.0.x is wire-stable. Adding a new enum value is a wire change (a 3.0.x receiver decoding a 3.1 sender's error.code cannot match against an enum it doesn't carry, and JSON Schema enum is closed by default), so the default disposition for any new code is 'held-for-next-minor' with target_version='3.1'. 'held-for-next-major' (target_version='4.0') is for codes that should defer past 3.x \u2014 typically because the surrounding subsystem is being reworked. 'backport-pending' is reserved for prose-only or doc-comment-only changes to a code that already exists on 3.0.x; the lint rejects backport-pending entries whose code is not on 3.0.x. Valid `disposition` values: 'backport-pending', 'held-for-next-minor', 'held-for-next-major', 'unclassified'. `target_version` (required for held-*) is a 'MAJOR.MINOR' string. When a code lands on 3.0.x its entry SHOULD be removed; the lint flags stale entries.",
   "dispositions": {
+    "AUTH_INVALID": {
+      "disposition": "held-for-next-minor",
+      "target_version": "3.1",
+      "note": "AUTH_REQUIRED split (#3739) — terminal-recovery half (credentials presented but rejected). Wire change — held for 3.1. Pairs with AUTH_MISSING."
+    },
+    "AUTH_MISSING": {
+      "disposition": "held-for-next-minor",
+      "target_version": "3.1",
+      "note": "AUTH_REQUIRED split (#3739) — correctable-recovery half (no credentials presented). Wire change — held for 3.1. Pairs with AUTH_INVALID."
+    },
     "AGENT_BLOCKED": {
       "disposition": "held-for-next-minor",
       "target_version": "3.1",

--- a/static/schemas/source/enums/error-code.json
+++ b/static/schemas/source/enums/error-code.json
@@ -150,6 +150,14 @@
       "recovery": "correctable",
       "suggestion": "provide credentials when missing; do NOT auto-retry rejected credentials — escalate for rotation"
     },
+    "AUTH_MISSING": {
+      "recovery": "correctable",
+      "suggestion": "provide credentials via the auth header and retry"
+    },
+    "AUTH_INVALID": {
+      "recovery": "terminal",
+      "suggestion": "do NOT auto-retry — credentials were rejected; rotate keys, refresh OAuth tokens once if applicable, otherwise escalate to a human"
+    },
     "RATE_LIMITED": {
       "recovery": "transient",
       "suggestion": "retry after the retry_after interval"


### PR DESCRIPTION
## Summary

#3739 (merged ~08:35 UTC) split \`AUTH_REQUIRED\` into \`AUTH_MISSING\` (correctable, no credentials presented) and \`AUTH_INVALID\` (terminal, credentials presented and rejected) — adding both new codes to \`enum\` and \`enumDescriptions\` in \`enums/error-code.json\` but not to \`enumMetadata\`.

\`scripts/build-schemas.cjs\` lints for that consistency and fails:

\`\`\`
❌ Build failed: Schema enumMetadata lint: 2 issue(s) in enums/error-code.json.

  AUTH_MISSING: missing enumMetadata entry
  AUTH_INVALID: missing enumMetadata entry
\`\`\`

This blocks the \`Build\` step (`npm run build:schemas`) on every PR's CI until metadata is consistent with the enum, including #4513 (Emma's tier exposure), #4518 (CI freshness gate), and anything else in flight.

## Metadata classification

| Code | recovery | suggestion |
|---|---|---|
| \`AUTH_MISSING\` | \`correctable\` | provide credentials via the auth header and retry |
| \`AUTH_INVALID\` | \`terminal\` | do NOT auto-retry — credentials were rejected; rotate keys, refresh OAuth tokens once if applicable, otherwise escalate to a human |

Mirrors the same codes' \`enumDescriptions\` text. The OAuth refresh-once exception remains documented in the description; the default \`recovery\` stays \`terminal\` so SDK classifiers do not auto-retry by default.

## Test plan

- [x] \`npm run build:schemas\` is clean locally
- [ ] Build Check CI passes the \`Build\` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)