### PR TITLE
fix(admin): full IANA timezone list in events + meetings forms

### DIFF
--- a/.changeset/4530-admin-timezone-dropdown.md
+++ b/.changeset/4530-admin-timezone-dropdown.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix #4530 — admin events + meetings forms now offer every IANA timezone, labelled by current UTC offset and sorted by offset, instead of a hardcoded list of 8. Mary hit this scheduling the Singapore meetup: `Asia/Singapore` wasn't selectable, so the form kept the `America/New_York` default and rendered the event in EST. Server-side HTML only, no schema or SDK change.

--- a/server/public/admin-events.html
+++ b/server/public/admin-events.html
@@ -510,16 +510,7 @@
           </div>
           <div class="form-group">
             <label>Timezone</label>
-            <select id="timezone">
-              <option value="America/New_York">Eastern Time</option>
-              <option value="America/Chicago">Central Time</option>
-              <option value="America/Denver">Mountain Time</option>
-              <option value="America/Los_Angeles">Pacific Time</option>
-              <option value="Europe/London">London</option>
-              <option value="Europe/Paris">Paris</option>
-              <option value="Asia/Tokyo">Tokyo</option>
-              <option value="UTC">UTC</option>
-            </select>
+            <select id="timezone"></select>
           </div>
         </div>
 
@@ -892,9 +883,43 @@
 
     // Initialize
     async function init() {
+      populateTimezoneSelect(document.getElementById('timezone'), 'America/New_York');
       await Promise.all([loadEvents(), loadAvailableCommittees()]);
       document.getElementById('loading').style.display = 'none';
       document.getElementById('content').style.display = 'block';
+    }
+
+    // Populate a <select> with all IANA timezones, labelled with current UTC offset, sorted by offset.
+    function populateTimezoneSelect(selectEl, defaultValue) {
+      if (!selectEl) return;
+      const zones = (typeof Intl.supportedValuesOf === 'function')
+        ? Intl.supportedValuesOf('timeZone')
+        : ['UTC','America/New_York','America/Chicago','America/Denver','America/Los_Angeles','Europe/London','Europe/Paris','Asia/Tokyo','Asia/Singapore','Asia/Hong_Kong','Asia/Shanghai','Asia/Kolkata','Asia/Dubai','Australia/Sydney'];
+
+      const now = new Date();
+      const entries = zones.map(tz => {
+        let offsetMin = 0;
+        try {
+          const parts = new Intl.DateTimeFormat('en-US', { timeZone: tz, timeZoneName: 'shortOffset' }).formatToParts(now);
+          const tzName = parts.find(p => p.type === 'timeZoneName')?.value || 'GMT';
+          const m = tzName.match(/GMT([+-])(\d{1,2})(?::?(\d{2}))?/);
+          if (m) {
+            const sign = m[1] === '-' ? -1 : 1;
+            offsetMin = sign * (parseInt(m[2], 10) * 60 + parseInt(m[3] || '0', 10));
+          }
+        } catch (_) { /* skip unsupported zone */ }
+        const sign = offsetMin < 0 ? '-' : '+';
+        const abs = Math.abs(offsetMin);
+        const hh = String(Math.floor(abs / 60)).padStart(2, '0');
+        const mm = String(abs % 60).padStart(2, '0');
+        const label = `(UTC${sign}${hh}:${mm}) ${tz.replace(/_/g, ' ')}`;
+        return { tz, offsetMin, label };
+      }).sort((a, b) => a.offsetMin - b.offsetMin || a.tz.localeCompare(b.tz));
+
+      selectEl.innerHTML = entries.map(e =>
+        `<option value="${e.tz}">${e.label}</option>`
+      ).join('');
+      if (defaultValue) selectEl.value = defaultValue;
     }
 
     // Load events from API

--- a/server/public/admin-meetings.html
+++ b/server/public/admin-meetings.html
@@ -345,16 +345,7 @@
           </div>
           <div class="form-group">
             <label>Timezone</label>
-            <select id="timezone">
-              <option value="America/New_York">Eastern Time (ET)</option>
-              <option value="America/Chicago">Central Time (CT)</option>
-              <option value="America/Denver">Mountain Time (MT)</option>
-              <option value="America/Los_Angeles">Pacific Time (PT)</option>
-              <option value="UTC">UTC</option>
-              <option value="Europe/London">London (GMT/BST)</option>
-              <option value="Europe/Paris">Paris (CET)</option>
-              <option value="Asia/Tokyo">Tokyo (JST)</option>
-            </select>
+            <select id="timezone"></select>
           </div>
         </div>
 
@@ -951,8 +942,42 @@
       return text.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/"/g, '\\"');
     }
 
+    // Populate a <select> with all IANA timezones, labelled with current UTC offset, sorted by offset.
+    function populateTimezoneSelect(selectEl, defaultValue) {
+      if (!selectEl) return;
+      const zones = (typeof Intl.supportedValuesOf === 'function')
+        ? Intl.supportedValuesOf('timeZone')
+        : ['UTC','America/New_York','America/Chicago','America/Denver','America/Los_Angeles','Europe/London','Europe/Paris','Asia/Tokyo','Asia/Singapore','Asia/Hong_Kong','Asia/Shanghai','Asia/Kolkata','Asia/Dubai','Australia/Sydney'];
+
+      const now = new Date();
+      const entries = zones.map(tz => {
+        let offsetMin = 0;
+        try {
+          const parts = new Intl.DateTimeFormat('en-US', { timeZone: tz, timeZoneName: 'shortOffset' }).formatToParts(now);
+          const tzName = parts.find(p => p.type === 'timeZoneName')?.value || 'GMT';
+          const m = tzName.match(/GMT([+-])(\d{1,2})(?::?(\d{2}))?/);
+          if (m) {
+            const sign = m[1] === '-' ? -1 : 1;
+            offsetMin = sign * (parseInt(m[2], 10) * 60 + parseInt(m[3] || '0', 10));
+          }
+        } catch (_) { /* skip unsupported zone */ }
+        const sign = offsetMin < 0 ? '-' : '+';
+        const abs = Math.abs(offsetMin);
+        const hh = String(Math.floor(abs / 60)).padStart(2, '0');
+        const mm = String(abs % 60).padStart(2, '0');
+        const label = `(UTC${sign}${hh}:${mm}) ${tz.replace(/_/g, ' ')}`;
+        return { tz, offsetMin, label };
+      }).sort((a, b) => a.offsetMin - b.offsetMin || a.tz.localeCompare(b.tz));
+
+      selectEl.innerHTML = entries.map(e =>
+        `<option value="${e.tz}">${e.label}</option>`
+      ).join('');
+      if (defaultValue) selectEl.value = defaultValue;
+    }
+
     // Initialize
     async function init() {
+      populateTimezoneSelect(document.getElementById('timezone'), 'America/New_York');
       await loadWorkingGroups();
       await loadMeetings();
 


### PR DESCRIPTION
## Summary
- Replaces the 8-entry hardcoded timezone dropdown in `admin-events.html` and `admin-meetings.html` with a JS-populated list of every IANA timezone (`Intl.supportedValuesOf('timeZone')`), labelled by current UTC offset and sorted by offset.
- Mary hit this trying to schedule the Singapore meetup — `Asia/Singapore` wasn't in the list, so the event silently kept the `America/New_York` default and rendered as Eastern.
- Closes #4530.

## Test plan
- [ ] Open `/admin-events.html`, create event → dropdown shows full global list, `Asia/Singapore` selectable
- [ ] Edit existing Singapore event → dropdown opens already set to `Asia/Singapore`
- [ ] Same for `/admin-meetings.html`
- [ ] Event display in admin list still renders times in the chosen timezone

🤖 Generated with [Claude Code](https://claude.com/claude-code)