### PR TITLE
docs(charter): tense-correct §7 transparency, link live WG minutes archive

### DIFF
--- a/.changeset/charter-transparency-honest.md
+++ b/.changeset/charter-transparency-honest.md
@@ -1,0 +1,6 @@
+---
+---
+
+CHARTER §7 (Transparency): soften the "Board meetings publish agendas and minutes" claim to honest tense — the interim board holds office until the first AGM (May 6, 2026), and a Board minutes archive doesn't exist yet. Add a parallel WG-minutes bullet pointing at the live archive at agenticadvertising.org/working-groups, which IS where Working Group agendas and minutes are published today.
+
+Closes the truthfulness gap from #2385 without forking a separate static archive (see closed PR #3383).

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -106,7 +106,7 @@ Day-to-day technical work happens in **Working Groups**, which are the Foundatio
 
 ## 7. Transparency principles
 
-- **Open meetings** — Board meetings publish agendas and minutes.
+- **Open meetings** — Once the elected Board convenes after the first AGM (scheduled May 6, 2026), Board meeting agendas and minutes will be published on the Foundation website. Working Group meetings are open to all members and publish agendas and minutes per Working Group at [agenticadvertising.org/working-groups](https://agenticadvertising.org/working-groups).
 - **Public governing documents** — Bylaws, Membership Agreement, IPR Policy, and Antitrust Policy are publicly available.
 - **Financial reporting** — Annual financial reports are shared with the membership.
 - **Equal voice** — Each voting class has equal representation regardless of company size.


### PR DESCRIPTION
## Summary

CHARTER §7 (Transparency principles) claimed:

> Open meetings — Board meetings publish agendas and minutes.

The Foundation has an interim board until the first AGM (scheduled May 6, 2026), so this is aspirational. The truthfulness audit (#2385) flagged the gap.

## What changed

- Soften the Board-meetings line to honest tense: "Once the elected Board convenes after the first AGM (scheduled May 6, 2026), Board meeting agendas and minutes will be published on the Foundation website."
- Add a parallel WG-meetings bullet pointing to the **live archive** at [agenticadvertising.org/working-groups](https://agenticadvertising.org/working-groups), which is where WG agendas and minutes are published today (the WG detail page already has a minutes section that loads past meetings from the API).

## Why not the static docs archive

Closes the truthfulness gap without forking a separate static archive. PR #3383 proposed `docs/community/meeting-minutes/` with manual MDX entries — that duplicated the live AAO WG site's minutes feature and put minutes at the wrong layer (community/event artifact, not protocol docs). #3383 closed in favor of this approach.

## Test plan

- [x] Diff is two-line tense correction + new bullet
- [ ] Mintlify preview renders cleanly (CHARTER.md is in repo root, not docs/, so no Mintlify render)

Closes the §7 portion of #2385.

🤖 Generated with [Claude Code](https://claude.com/claude-code)