### PR TITLE
fix: stop paging #admin-errors on expected discovery/Luma failures

### DIFF
--- a/.changeset/mcp-discovery-luma-error-log-levels.md
+++ b/.changeset/mcp-discovery-luma-error-log-levels.md
@@ -1,0 +1,8 @@
+---
+"adcontextprotocol": patch
+---
+
+Stop paging `#admin-errors` on expected per-agent / per-API failures.
+
+- `/api/discover-agent` now classifies the discovery error via `classifyMCPError` and logs `unreachable` / `wrong_path` (e.g. stale `*.trycloudflare.com` tunnel URLs, agent advertising MCP at a non-standard path) at `warn` with a structured `kind` + actionable `message` in the 502 response. Only `unknown` kinds still escalate via `logger.error`. `TimeoutError` was already a separate branch and is now `warn` too, since it's a per-agent issue rather than a system fault.
+- `lumaFetch` no longer logs `logger.error` on every non-2xx; it just throws. Every call site already logs on catch — `getEventHosts` deliberately at `debug` because hosts API access is best-effort — so 404s from `/event/get-hosts` (events the API key can't see) stop paging. The endpoint, status, and body are now included in the thrown message so callers' single error log still has them.

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -12,7 +12,7 @@ import { WorkOS, DomainDataState } from "@workos-inc/node";
 import { AgentService } from "./agent-service.js";
 import { AgentValidator } from "./validator.js";
 import { configureMCPRoutes, isMCPServerReady, resolveMCPServerURL } from "./mcp/index.js";
-import { HealthChecker } from "./health.js";
+import { HealthChecker, classifyMCPError } from "./health.js";
 import { notifySystemError } from "./addie/error-notifier.js";
 import { CrawlerService } from "./crawler.js";
 import { createLogger, processRole } from "./logger.js";
@@ -8842,15 +8842,28 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
           });
         }
 
-        logger.error({ err: error, url }, 'Agent discovery error');
-
         if (error instanceof Error && error.name === 'TimeoutError') {
+          logger.warn({ url }, 'Agent discovery timed out');
           return res.status(504).json({
             error: 'Connection timeout',
             message: 'Agent did not respond within 10 seconds',
           });
         }
 
+        // Classify so user-data failures (stale tunnel URLs, wrong path,
+        // unreachable hosts) don't page #admin-errors via logger.error.
+        // Only unknown kinds escalate.
+        const classified = classifyMCPError(error);
+        if (classified.kind === 'unreachable' || classified.kind === 'wrong_path') {
+          logger.warn({ url, kind: classified.kind, raw: classified.raw }, 'Agent discovery failed');
+          return res.status(502).json({
+            error: 'Agent discovery failed',
+            kind: classified.kind,
+            message: classified.message,
+          });
+        }
+
+        logger.error({ err: error, url }, 'Agent discovery error');
         return res.status(500).json({
           error: 'Agent discovery failed',
         });

--- a/server/src/luma/client.ts
+++ b/server/src/luma/client.ts
@@ -122,13 +122,7 @@ async function lumaFetch<T>(
 
   if (!response.ok) {
     const errorText = await response.text();
-    logger.error({
-      endpoint,
-      status: response.status,
-      statusText: response.statusText,
-      error: errorText,
-    }, 'Luma API request failed');
-    throw new Error(`Luma API error: ${response.status} ${response.statusText} - ${errorText}`);
+    throw new Error(`Luma API error ${response.status} ${response.statusText} at ${endpoint} - ${errorText}`);
   }
 
   return response.json() as Promise<T>;


### PR DESCRIPTION
## Summary

Two `logger.error` call sites were paging `#admin-errors` (via `posthog.ts:201-205` auto-poster) for things that aren't system errors:

- **`/api/discover-agent`** — every probe failure on a user-registered URL was logged at `error`. Common failure modes are user-data issues: stale `*.trycloudflare.com` tunnel URLs, agents at non-standard MCP paths.
- **`lumaFetch`** — logged `error` on every non-2xx, overriding the caller-side intent. `getEventHosts` deliberately catches and logs at `debug` because hosts-API access is best-effort, but the inner `error` paged anyway on every 404.

## Changes

- `server/src/http.ts` — In the discovery catch block, call `classifyMCPError` (already used by `HealthChecker`) and downgrade `unreachable` / `wrong_path` to `warn` with a structured 502 response (`{ error, kind, message }`). `TimeoutError` moved above the classifier and also downgraded — per-call timeout is a per-agent issue, not systemic. Only `unknown` kinds still escalate via `logger.error`.
- `server/src/luma/client.ts` — Remove the duplicate `logger.error` inside `lumaFetch`; the thrown error now embeds endpoint/status/body so every existing caller-side log still has the context. Verified every caller has its own try/catch with logger call.
- `.changeset/mcp-discovery-luma-error-log-levels.md` — patch.

## Reviews

- **code-reviewer-deep**: clean — "ship it"
- **security-reviewer-deep**: clean — verified no audit-log loss (warn still writes to structured logs, just skips Slack), no SSRF info leak in response body (`raw` is logged but not returned), no auth-required bypass (typed-error branch still runs first), Luma response body in thrown message is bounded risk

## Test plan

- [x] `npm run test:unit` (precommit hook) passed
- [x] `npm run typecheck` (precommit hook) passed
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)