### PR TITLE
fix(cert): A2B success_criteria as {id,text} objects (unbreak main)

### DIFF
--- a/.changeset/4530-a2b-criteria-objects.md
+++ b/.changeset/4530-a2b-criteria-objects.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix red main from PR #3398. Migration 478 (A2B hands-on lab) shipped `exercise_definitions[].success_criteria` as plain strings, but `SuccessCriterion` is `{id, text}` and `demonstrations-fairness.test.ts` asserts every criterion has an id — so main was failing the integration suite. Migration 479 converts each string criterion to `{id: "<exercise_id>_c<n>", text: <string>}`. Idempotent (skips entries already in object form). Server data only, no schema/protocol change.

--- a/server/src/db/migrations/479_a2b_success_criteria_objects.sql
+++ b/server/src/db/migrations/479_a2b_success_criteria_objects.sql
@@ -1,0 +1,32 @@
+-- A2B (migration 478) shipped exercise_definitions[].success_criteria as plain strings,
+-- but the SuccessCriterion contract is { id, text } (see certification-db.ts).
+-- demonstrations-fairness.test.ts asserts every criterion has an id, so main is red.
+-- Convert each string criterion into { id: "<exercise_id>_c<n>", text: <string> }.
+-- Idempotent: criteria already in object form pass through unchanged.
+
+UPDATE certification_modules
+SET exercise_definitions = (
+  SELECT jsonb_agg(
+    jsonb_set(
+      ex.value,
+      '{success_criteria}',
+      (
+        SELECT jsonb_agg(
+          CASE
+            WHEN jsonb_typeof(c.value) = 'string'
+              THEN jsonb_build_object(
+                'id', (ex.value->>'id') || '_c' || c.ordinality::text,
+                'text', c.value
+              )
+            ELSE c.value
+          END
+          ORDER BY c.ordinality
+        )
+        FROM jsonb_array_elements(ex.value->'success_criteria') WITH ORDINALITY AS c(value, ordinality)
+      )
+    )
+    ORDER BY ex.ordinality
+  )
+  FROM jsonb_array_elements(exercise_definitions) WITH ORDINALITY AS ex(value, ordinality)
+)
+WHERE id = 'A2B';


### PR DESCRIPTION
## Summary
- Migration 478 (A2B hands-on lab, #3398) shipped `exercise_definitions[].success_criteria` as plain strings.
- `SuccessCriterion` is `{ id, text }` (`server/src/db/certification-db.ts:48-51`), and `server/tests/integration/demonstrations-fairness.test.ts:105` asserts every criterion has an id.
- As a result, **`Server integration tests` has been failing on `main` since #3398 merged** — confirmed on run 25856546952. All open PRs (mine included: #4532) are blocked behind this.
- Migration 479 converts each string criterion to `{id: "<exercise_id>_c<n>", text: <string>}`. Idempotent — `CASE WHEN jsonb_typeof = 'string'` skips entries already in object form, so re-running is safe and any future hand-edits to objects survive.

## Verification
- Applied 478 + 479 against a fresh local Postgres.
- Verified 12 criteria across `a2b_ex1..a2b_ex4` now render as `{id, text}` with ids `a2b_ex1_c1`, `a2b_ex1_c2`, …, `a2b_ex4_c3`.
- `vitest run server/tests/integration/demonstrations-fairness.test.ts` → **13/13 pass** locally (was 12/13 with the same DB pre-479).

## Test plan
- [ ] CI: Server integration tests green
- [ ] Spot-check A2B module in `/learning` still renders exercises correctly post-migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)