### PR TITLE
fix(adagents): server fan-out for publisher_domains[] + revocation precedence (#4506)

### DIFF
--- a/.changeset/adagents-server-fanout.md
+++ b/.changeset/adagents-server-fanout.md
@@ -1,0 +1,16 @@
+---
+---
+
+fix(adagents): server-side fan-out for `publisher_domains[]` + `revoked_publisher_domains[]` precedence
+
+Closes the in-tree server portion of #4506 — the catalog projection writer's two missing behaviors from the PR #4504 spec additions.
+
+**1. Compact-form fan-out in `publisher-db.projectAuthorizationToCatalog`.** The writer previously checked only `publisher_properties[].publisher_domain` (singular) and refused as "cross-publisher" if missing. With the compact form, a managed-network manifest authorizes the publisher via `publisher_domains[]` (plural) and the source publisher_domain appears inside that array. The writer now accepts a selector if **either** the singular `publisher_domain` matches the source **or** the source appears in the compact `publisher_domains[]` list. Same projection semantics as the singular form — no special-case downstream.
+
+**2. `revoked_publisher_domains[]` precedence in `upsertAdagentsCache`.** When a manifest's top-level `revoked_publisher_domains[]` lists the source publisher domain, the writer now skips **all** property and authorization projection for that source. The `publishers` row is still upserted (cache reflects the manifest verbatim) but no `catalog_properties` or `catalog_agent_authorizations` rows land. Revocation takes precedence over any other appearance of the publisher in `publisher_properties[]` or top-level `properties[]`, matching the spec MUST.
+
+**Type model**: added `publisher_domains?: string[]` to the internal `AdagentsAuthorizedAgent.publisher_properties[]` element type. Tolerant of malformed input — every consumer path uses runtime `typeof`/`Array.isArray` guards before string operations.
+
+**Tests** (integration, against a real postgres): two compact-form cases (acceptance when source listed, refusal when not) plus two `revoked_publisher_domains[]` cases (revocation wins; unrelated revocation entry doesn't block projection). Lives in `server/tests/integration/registry-catalog-agent-auth-writer.test.ts`.
+
+**Out of scope (tracked in #4506)**: in-memory `AuthorizationIndex` revocation propagation (currently event-driven — would need crawler-side emission of `authorization.revoked` events for each entry in `revoked_publisher_domains[]`), per-`authorized_agents[]` `last_updated` partial-walk indexing (advisory optimization), and `federated-index-db` SQL-layer changes (only invoked from product paths, which #4508 restricted to singular form).

--- a/server/src/db/publisher-db.ts
+++ b/server/src/db/publisher-db.ts
@@ -145,17 +145,23 @@ function truncateResolvedUrl(url: string | undefined): string | null {
 }
 
 // Read `revoked_publisher_domains[]` from a (loose-typed) manifest and return
-// the set of lowercased publisher_domain values. Tolerant of missing or
-// malformed entries — only well-formed string publisher_domain values count.
+// the set of lowercased publisher_domain values. Entries MUST carry both
+// a string `publisher_domain` and a parseable `revoked_at` per the spec —
+// the writer is a security boundary, and silently accepting incomplete
+// revocation entries is the same shape as the cross-publisher bypass this
+// PR closes. Malformed entries are dropped, not honored.
 function extractRevokedPublisherDomains(manifest: unknown): Set<string> {
   const out = new Set<string>();
   const m = manifest as { revoked_publisher_domains?: unknown };
   if (!Array.isArray(m?.revoked_publisher_domains)) return out;
   for (const entry of m.revoked_publisher_domains) {
     const pd = (entry as { publisher_domain?: unknown })?.publisher_domain;
-    if (typeof pd === 'string' && pd.length > 0) {
-      out.add(pd.toLowerCase());
-    }
+    const ra = (entry as { revoked_at?: unknown })?.revoked_at;
+    if (typeof pd !== 'string' || pd.length === 0) continue;
+    if (typeof ra !== 'string' || ra.length === 0) continue;
+    // Require parseable date-time. Date.parse returns NaN on invalid input.
+    if (Number.isNaN(Date.parse(ra))) continue;
+    out.add(pd.toLowerCase());
   }
   return out;
 }
@@ -285,15 +291,42 @@ export class PublisherDatabase {
 
       // `revoked_publisher_domains[]` precedence: if this manifest revokes
       // the source domain, skip property and authorization projection
-      // entirely. The publisher row above is still upserted so the cache
-      // reflects the manifest verbatim, but no catalog rows land — the
-      // revocation list takes precedence over any other appearance of
-      // the domain in the file. See managed-networks.mdx for spec.
+      // entirely AND retire any catalog rows that a prior projection of
+      // this same publisher had landed. The publishers row stays as the
+      // verbatim cache of the manifest, but every writer-owned catalog
+      // row (`evidence='adagents_json'`, `created_by='system'`) gets
+      // soft-deleted so the index stops authorizing the revoked
+      // publisher on the next refresh. Without this retirement the
+      // revocation is advisory only — stale rows from before the
+      // revocation would continue to serve, defeating the security gate
+      // the spec promises. See managed-networks.mdx (Publisher
+      // revocation) and the reconciliation block below this branch.
       const revokedDomains = extractRevokedPublisherDomains(safeManifest);
       if (revokedDomains.has(domain)) {
         log.info(
           { domain, revokedCount: revokedDomains.size },
-          'Skipping projection: source domain appears in revoked_publisher_domains[]'
+          'Revoking projection: source domain appears in revoked_publisher_domains[] — retiring all writer-owned catalog rows for this publisher'
+        );
+        // Soft-delete every writer-owned CAA row for this publisher.
+        // currentCanonical is empty: no authorized_agents[] entries
+        // survive revocation. The OR-chain matches all three writer
+        // shapes (publisher-wide, property_rid-keyed, slug-keyed).
+        await client.query(
+          `UPDATE catalog_agent_authorizations caa
+              SET deleted_at = NOW()
+            WHERE caa.evidence = 'adagents_json'
+              AND caa.created_by = 'system'
+              AND caa.deleted_at IS NULL
+              AND (
+                caa.publisher_domain = $1
+                OR caa.property_rid IN (
+                  SELECT property_rid FROM catalog_properties WHERE created_by = $2
+                )
+                OR (caa.property_id_slug IS NOT NULL AND caa.property_rid IN (
+                  SELECT property_rid FROM catalog_properties WHERE created_by = $2
+                ))
+              )`,
+          [domain, adagentsCreatedBy(domain)],
         );
         await client.query('COMMIT');
         return;
@@ -834,20 +867,38 @@ export class PublisherDatabase {
     } else if (variant === 'publisher_properties') {
       const sels = Array.isArray(entry.publisher_properties) ? entry.publisher_properties : [];
       for (const sel of sels) {
+        // The spec requires XOR — exactly one of `publisher_domain` (singular)
+        // or `publisher_domains[]` (compact) is present on each selector. A
+        // manifest with both populated is malformed and dangerous: a writer
+        // that accepts the union turns a singular-points-at-victim + plural-
+        // points-at-source shape into an unintended permissive projection.
+        // Refuse and log rather than picking a winner.
+        const hasSingular = typeof sel?.publisher_domain === 'string' && sel.publisher_domain.length > 0;
+        const hasPlural = Array.isArray(sel?.publisher_domains) && sel.publisher_domains.length > 0;
+        if (hasSingular && hasPlural) {
+          log.warn(
+            { publisherDomain, agentUrl: agentCanonical, selPub: sel.publisher_domain, selPubsCount: sel.publisher_domains?.length },
+            'Skipping auth projection: publisher_properties entry violates singular/plural XOR (both present)'
+          );
+          continue;
+        }
         // A selector claims the publisher if the source publisherDomain matches
         // either the singular publisher_domain or any entry in the compact
         // publisher_domains[] array. Both forms are equivalent for projection.
-        const selPubSingular = typeof sel?.publisher_domain === 'string' ? sel.publisher_domain.toLowerCase() : null;
-        const selPubInList = Array.isArray((sel as { publisher_domains?: unknown })?.publisher_domains)
-          && (sel as { publisher_domains: unknown[] }).publisher_domains.some(
-            (d: unknown) => typeof d === 'string' && d.toLowerCase() === publisherDomain
-          );
+        const selPubSingular = hasSingular ? sel.publisher_domain!.toLowerCase() : null;
+        const selPubInList = hasPlural
+          && sel.publisher_domains!.some((d) => typeof d === 'string' && d.toLowerCase() === publisherDomain);
         if (selPubSingular !== publisherDomain && !selPubInList) {
           // Cross-publisher third-party-sales claim. Refused per spec — the
           // writer cannot land an authoritative row for another publisher's
           // properties without out-of-band corroboration.
           log.warn(
-            { publisherDomain, agentUrl: agentCanonical, selPub: selPubSingular },
+            {
+              publisherDomain,
+              agentUrl: agentCanonical,
+              selPub: selPubSingular,
+              selPubsCount: hasPlural ? sel.publisher_domains!.length : 0,
+            },
             'Skipping auth projection: publisher_properties claims a different publisher (cross-publisher refused)'
           );
           continue;

--- a/server/src/db/publisher-db.ts
+++ b/server/src/db/publisher-db.ts
@@ -43,6 +43,7 @@ export interface AdagentsAuthorizedAgent {
   properties?: AdagentsProperty[];           // for inline_properties variant
   publisher_properties?: Array<{
     publisher_domain?: string;
+    publisher_domains?: string[];
     selection_type?: 'all' | 'by_id' | 'by_tag';
     property_ids?: string[];
     property_tags?: string[];
@@ -141,6 +142,22 @@ const RESOLVED_URL_MAX = 2048;
 function truncateResolvedUrl(url: string | undefined): string | null {
   if (typeof url !== 'string' || url.length === 0) return null;
   return url.length > RESOLVED_URL_MAX ? url.slice(0, RESOLVED_URL_MAX) : url;
+}
+
+// Read `revoked_publisher_domains[]` from a (loose-typed) manifest and return
+// the set of lowercased publisher_domain values. Tolerant of missing or
+// malformed entries — only well-formed string publisher_domain values count.
+function extractRevokedPublisherDomains(manifest: unknown): Set<string> {
+  const out = new Set<string>();
+  const m = manifest as { revoked_publisher_domains?: unknown };
+  if (!Array.isArray(m?.revoked_publisher_domains)) return out;
+  for (const entry of m.revoked_publisher_domains) {
+    const pd = (entry as { publisher_domain?: unknown })?.publisher_domain;
+    if (typeof pd === 'string' && pd.length > 0) {
+      out.add(pd.toLowerCase());
+    }
+  }
+  return out;
 }
 
 export function canonicalizeAgentUrl(raw: string): string | null {
@@ -265,6 +282,22 @@ export class PublisherDatabase {
           input.managerDomain ?? null,
         ]
       );
+
+      // `revoked_publisher_domains[]` precedence: if this manifest revokes
+      // the source domain, skip property and authorization projection
+      // entirely. The publisher row above is still upserted so the cache
+      // reflects the manifest verbatim, but no catalog rows land — the
+      // revocation list takes precedence over any other appearance of
+      // the domain in the file. See managed-networks.mdx for spec.
+      const revokedDomains = extractRevokedPublisherDomains(safeManifest);
+      if (revokedDomains.has(domain)) {
+        log.info(
+          { domain, revokedCount: revokedDomains.size },
+          'Skipping projection: source domain appears in revoked_publisher_domains[]'
+        );
+        await client.query('COMMIT');
+        return;
+      }
 
       const properties = Array.isArray(safeManifest.properties) ? safeManifest.properties : [];
       for (let i = 0; i < properties.length; i += 1) {
@@ -801,13 +834,20 @@ export class PublisherDatabase {
     } else if (variant === 'publisher_properties') {
       const sels = Array.isArray(entry.publisher_properties) ? entry.publisher_properties : [];
       for (const sel of sels) {
-        const selPub = typeof sel?.publisher_domain === 'string' ? sel.publisher_domain.toLowerCase() : null;
-        if (selPub !== publisherDomain) {
+        // A selector claims the publisher if the source publisherDomain matches
+        // either the singular publisher_domain or any entry in the compact
+        // publisher_domains[] array. Both forms are equivalent for projection.
+        const selPubSingular = typeof sel?.publisher_domain === 'string' ? sel.publisher_domain.toLowerCase() : null;
+        const selPubInList = Array.isArray((sel as { publisher_domains?: unknown })?.publisher_domains)
+          && (sel as { publisher_domains: unknown[] }).publisher_domains.some(
+            (d: unknown) => typeof d === 'string' && d.toLowerCase() === publisherDomain
+          );
+        if (selPubSingular !== publisherDomain && !selPubInList) {
           // Cross-publisher third-party-sales claim. Refused per spec — the
           // writer cannot land an authoritative row for another publisher's
           // properties without out-of-band corroboration.
           log.warn(
-            { publisherDomain, agentUrl: agentCanonical, selPub },
+            { publisherDomain, agentUrl: agentCanonical, selPub: selPubSingular },
             'Skipping auth projection: publisher_properties claims a different publisher (cross-publisher refused)'
           );
           continue;

--- a/server/tests/integration/registry-catalog-agent-auth-writer.test.ts
+++ b/server/tests/integration/registry-catalog-agent-auth-writer.test.ts
@@ -559,6 +559,81 @@ describe('catalog_agent_authorizations writer projection', () => {
       expect(rows).toHaveLength(0);
     });
 
+    it('accepts publisher_properties[].publisher_domains[] compact form when source domain is listed', async () => {
+      // Managed-network shape: the entry uses publisher_domains[] (plural)
+      // instead of singular publisher_domain. The source publisher (TEST_PUB)
+      // appears in the list, so the projection MUST resolve as if the
+      // selector had named TEST_PUB directly. See #4506.
+      await publisherDb.upsertAdagentsCache({
+        domain: TEST_PUB,
+        manifest: manifest(
+          [
+            {
+              url: TEST_AGENT_RAW,
+              authorization_type: 'publisher_properties',
+              publisher_properties: [
+                {
+                  publisher_domains: [VICTIM_PUB, TEST_PUB, 'other.example'],
+                  selection_type: 'all',
+                },
+              ],
+            },
+          ],
+          [
+            {
+              property_id: 'site_a',
+              property_type: 'website',
+              name: 'Site A',
+              identifiers: [{ type: 'domain', value: TEST_PUB }],
+            },
+          ]
+        ),
+      });
+      const { rows } = await pool.query<{ property_id_slug: string }>(
+        `SELECT property_id_slug FROM catalog_agent_authorizations
+          WHERE agent_url_canonical = $1 AND property_rid IS NOT NULL`,
+        [TEST_AGENT_CANON]
+      );
+      expect(rows.map((r) => r.property_id_slug)).toEqual(['site_a']);
+    });
+
+    it('refuses publisher_domains[] compact form when source domain is NOT listed', async () => {
+      // Same compact form, but the source publisher (TEST_PUB) is absent
+      // from the list. Refused for the same cross-publisher reason as the
+      // singular form.
+      await publisherDb.upsertAdagentsCache({
+        domain: TEST_PUB,
+        manifest: manifest(
+          [
+            {
+              url: TEST_AGENT_RAW,
+              authorization_type: 'publisher_properties',
+              publisher_properties: [
+                {
+                  publisher_domains: [VICTIM_PUB, 'other.example'],
+                  selection_type: 'all',
+                },
+              ],
+            },
+          ],
+          [
+            {
+              property_id: 'site_a',
+              property_type: 'website',
+              name: 'Site A',
+              identifiers: [{ type: 'domain', value: TEST_PUB }],
+            },
+          ]
+        ),
+      });
+      const { rows } = await pool.query(
+        `SELECT 1 FROM catalog_agent_authorizations
+          WHERE agent_url_canonical = $1 AND property_rid IS NOT NULL`,
+        [TEST_AGENT_CANON]
+      );
+      expect(rows).toHaveLength(0);
+    });
+
     it('matches own publisher when selector publisher_domain has mixed case', async () => {
       // Legacy or hand-edited manifests may use mixed-case publisher_domain.
       // The selector is lowercased before comparison; own-publisher claims
@@ -624,6 +699,94 @@ describe('catalog_agent_authorizations writer projection', () => {
         [TEST_AGENT_CANON]
       );
       expect(rows).toHaveLength(0);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // revoked_publisher_domains[] precedence (#4506)
+  // ──────────────────────────────────────────────────────────────────
+
+  describe('revoked_publisher_domains[] precedence', () => {
+    it('skips both property and auth projection when the source domain is revoked', async () => {
+      // Manifest authorizes an agent for the publisher's own property AND
+      // lists the publisher in revoked_publisher_domains[]. The revocation
+      // MUST win — no CAA rows for the auth, no catalog_properties either.
+      await publisherDb.upsertAdagentsCache({
+        domain: TEST_PUB,
+        manifest: {
+          ...manifest(
+            [
+              {
+                url: TEST_AGENT_RAW,
+                authorization_type: 'publisher_properties',
+                publisher_properties: [
+                  { publisher_domain: TEST_PUB, selection_type: 'all' },
+                ],
+              },
+            ],
+            [
+              {
+                property_id: 'site_a',
+                property_type: 'website',
+                name: 'Site A',
+                identifiers: [{ type: 'domain', value: TEST_PUB }],
+              },
+            ]
+          ),
+          revoked_publisher_domains: [
+            { publisher_domain: TEST_PUB, revoked_at: '2026-05-13T00:00:00Z', reason: 'relationship_ended' },
+          ],
+        },
+      });
+      const { rows: authRows } = await pool.query(
+        `SELECT 1 FROM catalog_agent_authorizations
+          WHERE agent_url_canonical = $1`,
+        [TEST_AGENT_CANON]
+      );
+      const { rows: propRows } = await pool.query(
+        `SELECT 1 FROM catalog_properties
+          WHERE created_by = $1`,
+        [`adagents_json:${TEST_PUB}`]
+      );
+      expect(authRows).toHaveLength(0);
+      expect(propRows).toHaveLength(0);
+    });
+
+    it('projects normally when revoked_publisher_domains[] lists a different domain', async () => {
+      // Revocation list contains an unrelated domain; projection proceeds.
+      await publisherDb.upsertAdagentsCache({
+        domain: TEST_PUB,
+        manifest: {
+          ...manifest(
+            [
+              {
+                url: TEST_AGENT_RAW,
+                authorization_type: 'publisher_properties',
+                publisher_properties: [
+                  { publisher_domain: TEST_PUB, selection_type: 'all' },
+                ],
+              },
+            ],
+            [
+              {
+                property_id: 'site_a',
+                property_type: 'website',
+                name: 'Site A',
+                identifiers: [{ type: 'domain', value: TEST_PUB }],
+              },
+            ]
+          ),
+          revoked_publisher_domains: [
+            { publisher_domain: 'some-other.example', revoked_at: '2026-05-13T00:00:00Z' },
+          ],
+        },
+      });
+      const { rows } = await pool.query<{ property_id_slug: string }>(
+        `SELECT property_id_slug FROM catalog_agent_authorizations
+          WHERE agent_url_canonical = $1 AND property_rid IS NOT NULL`,
+        [TEST_AGENT_CANON]
+      );
+      expect(rows.map((r) => r.property_id_slug)).toEqual(['site_a']);
     });
   });
 

--- a/server/tests/integration/registry-catalog-agent-auth-writer.test.ts
+++ b/server/tests/integration/registry-catalog-agent-auth-writer.test.ts
@@ -752,6 +752,207 @@ describe('catalog_agent_authorizations writer projection', () => {
       expect(propRows).toHaveLength(0);
     });
 
+    it('retires prior CAA rows when a later manifest revokes the publisher (regression)', async () => {
+      // Step 1: project a manifest that authorizes the agent.
+      await publisherDb.upsertAdagentsCache({
+        domain: TEST_PUB,
+        manifest: manifest(
+          [
+            {
+              url: TEST_AGENT_RAW,
+              authorization_type: 'publisher_properties',
+              publisher_properties: [
+                { publisher_domain: TEST_PUB, selection_type: 'all' },
+              ],
+            },
+          ],
+          [
+            {
+              property_id: 'site_a',
+              property_type: 'website',
+              name: 'Site A',
+              identifiers: [{ type: 'domain', value: TEST_PUB }],
+            },
+          ]
+        ),
+      });
+      const { rows: rowsAfterGrant } = await pool.query(
+        `SELECT 1 FROM catalog_agent_authorizations
+          WHERE agent_url_canonical = $1
+            AND property_rid IS NOT NULL
+            AND deleted_at IS NULL`,
+        [TEST_AGENT_CANON]
+      );
+      expect(rowsAfterGrant).toHaveLength(1);
+
+      // Step 2: a later manifest revokes the publisher. The writer MUST
+      // soft-delete the prior CAA rows — not just skip new projection.
+      // Without this, revocation is advisory and the index keeps
+      // authorizing the agent against the revoked publisher.
+      await publisherDb.upsertAdagentsCache({
+        domain: TEST_PUB,
+        manifest: {
+          ...manifest(
+            [
+              {
+                url: TEST_AGENT_RAW,
+                authorization_type: 'publisher_properties',
+                publisher_properties: [
+                  { publisher_domain: TEST_PUB, selection_type: 'all' },
+                ],
+              },
+            ],
+            [
+              {
+                property_id: 'site_a',
+                property_type: 'website',
+                name: 'Site A',
+                identifiers: [{ type: 'domain', value: TEST_PUB }],
+              },
+            ]
+          ),
+          revoked_publisher_domains: [
+            { publisher_domain: TEST_PUB, revoked_at: '2026-05-13T00:00:00Z' },
+          ],
+        },
+      });
+      const { rows: liveRowsAfterRevoke } = await pool.query(
+        `SELECT 1 FROM catalog_agent_authorizations
+          WHERE agent_url_canonical = $1
+            AND deleted_at IS NULL`,
+        [TEST_AGENT_CANON]
+      );
+      expect(liveRowsAfterRevoke).toHaveLength(0);
+      // And confirm the soft-delete actually landed (rows still exist
+      // historically, just retired).
+      const { rows: retiredRowsAfterRevoke } = await pool.query(
+        `SELECT 1 FROM catalog_agent_authorizations
+          WHERE agent_url_canonical = $1
+            AND deleted_at IS NOT NULL`,
+        [TEST_AGENT_CANON]
+      );
+      expect(retiredRowsAfterRevoke.length).toBeGreaterThan(0);
+    });
+
+    it('matches publisher_domains[] case-insensitively', async () => {
+      // Pattern at line 17-18 of the JSON Schema already enforces
+      // lowercase, but the writer's comparison MUST also be case-
+      // insensitive so a hand-edited mixed-case manifest still resolves.
+      await publisherDb.upsertAdagentsCache({
+        domain: TEST_PUB,
+        manifest: manifest(
+          [
+            {
+              url: TEST_AGENT_RAW,
+              authorization_type: 'publisher_properties',
+              publisher_properties: [
+                {
+                  publisher_domains: [`OTHER.example`, `CAA-Writer.EXAMPLE`],
+                  selection_type: 'all',
+                },
+              ],
+            },
+          ],
+          [
+            {
+              property_id: 'site_a',
+              property_type: 'website',
+              name: 'Site A',
+              identifiers: [{ type: 'domain', value: TEST_PUB }],
+            },
+          ]
+        ),
+      });
+      const { rows } = await pool.query<{ property_id_slug: string }>(
+        `SELECT property_id_slug FROM catalog_agent_authorizations
+          WHERE agent_url_canonical = $1 AND property_rid IS NOT NULL`,
+        [TEST_AGENT_CANON]
+      );
+      expect(rows.map((r) => r.property_id_slug)).toEqual(['site_a']);
+    });
+
+    it('refuses selector when both publisher_domain and publisher_domains are present (XOR violation)', async () => {
+      // A malformed/malicious manifest could put the source publisher
+      // in the compact list while pointing the singular at a victim.
+      // The writer MUST refuse rather than accept the union — accepting
+      // either-match converts schema XOR into a permissive projection.
+      await publisherDb.upsertAdagentsCache({
+        domain: TEST_PUB,
+        manifest: manifest(
+          [
+            {
+              url: TEST_AGENT_RAW,
+              authorization_type: 'publisher_properties',
+              publisher_properties: [
+                {
+                  publisher_domain: VICTIM_PUB,
+                  publisher_domains: [TEST_PUB],
+                  selection_type: 'all',
+                },
+              ],
+            },
+          ],
+          [
+            {
+              property_id: 'site_a',
+              property_type: 'website',
+              name: 'Site A',
+              identifiers: [{ type: 'domain', value: TEST_PUB }],
+            },
+          ]
+        ),
+      });
+      const { rows } = await pool.query(
+        `SELECT 1 FROM catalog_agent_authorizations
+          WHERE agent_url_canonical = $1 AND property_rid IS NOT NULL`,
+        [TEST_AGENT_CANON]
+      );
+      expect(rows).toHaveLength(0);
+    });
+
+    it('ignores revoked_publisher_domains[] entries missing revoked_at or with invalid date', async () => {
+      // The writer is a security boundary. Silently accepting incomplete
+      // revocation entries (e.g., publisher_domain but no revoked_at)
+      // is the same shape as the cross-publisher bypass the rest of
+      // this PR closes. Malformed entries MUST be dropped, not honored.
+      await publisherDb.upsertAdagentsCache({
+        domain: TEST_PUB,
+        manifest: {
+          ...manifest(
+            [
+              {
+                url: TEST_AGENT_RAW,
+                authorization_type: 'publisher_properties',
+                publisher_properties: [
+                  { publisher_domain: TEST_PUB, selection_type: 'all' },
+                ],
+              },
+            ],
+            [
+              {
+                property_id: 'site_a',
+                property_type: 'website',
+                name: 'Site A',
+                identifiers: [{ type: 'domain', value: TEST_PUB }],
+              },
+            ]
+          ),
+          revoked_publisher_domains: [
+            { publisher_domain: TEST_PUB }, // missing revoked_at
+            { publisher_domain: TEST_PUB, revoked_at: 'not-a-date' }, // invalid
+          ],
+        },
+      });
+      // Projection should proceed normally — neither malformed entry
+      // is honored as a revocation.
+      const { rows } = await pool.query<{ property_id_slug: string }>(
+        `SELECT property_id_slug FROM catalog_agent_authorizations
+          WHERE agent_url_canonical = $1 AND property_rid IS NOT NULL`,
+        [TEST_AGENT_CANON]
+      );
+      expect(rows.map((r) => r.property_id_slug)).toEqual(['site_a']);
+    });
+
     it('projects normally when revoked_publisher_domains[] lists a different domain', async () => {
       // Revocation list contains an unrelated domain; projection proceeds.
       await publisherDb.upsertAdagentsCache({


### PR DESCRIPTION
## Summary

In-tree server portion of #4506. The catalog projection writer was missing two behaviors from PR #4504's spec additions:

1. **Compact-form fan-out** in \`publisher-db.projectAuthorizationToCatalog\`. The writer now accepts a \`publisher_properties[]\` selector if either the singular \`publisher_domain\` matches the source OR the source appears in the compact \`publisher_domains[]\` array. Same projection semantics as singular — no special-case downstream.

2. **\`revoked_publisher_domains[]\` precedence** in \`upsertAdagentsCache\`. When the manifest's top-level \`revoked_publisher_domains[]\` lists the source publisher domain, the writer skips ALL property and authorization projection. Revocation takes precedence over any other appearance of the publisher.

## Out of scope (still tracked in #4506)

- In-memory \`AuthorizationIndex\` revocation propagation (event-driven; needs crawler-side \`authorization.revoked\` emission for each entry in \`revoked_publisher_domains[]\`)
- Per-\`authorized_agents[]\` \`last_updated\` partial-walk indexing (advisory optimization)
- \`federated-index-db\` SQL changes (only invoked from product paths, which #4508 restricted to singular form — no fan-out needed there)

## Test plan

- [x] Typecheck clean
- [ ] Integration tests (real postgres) — CI runs:
  - Compact form accepted when source in \`publisher_domains[]\`
  - Compact form refused when source NOT in \`publisher_domains[]\`
  - \`revoked_publisher_domains[]\` precedence: revocation skips projection
  - Unrelated revocation entry doesn't block projection

🤖 Generated with [Claude Code](https://claude.com/claude-code)