### PR TITLE
fix(adagents): unify publisher_domain canonicalization across writer/validator/adagents-manager (closes #4541)

### DIFF
--- a/.changeset/publisher-domain-normalization.md
+++ b/.changeset/publisher-domain-normalization.md
@@ -1,0 +1,33 @@
+---
+---
+
+fix(adagents): unify `publisher_domain` canonicalization across writer/validator/adagents-manager
+
+Closes #4541. Code-reviewer-deep follow-up from PR #4538.
+
+**The drift.** Three consumers compared `publisher_domain` strings against each other with different normalization rules:
+
+- `server/src/db/publisher-db.ts` (catalog projection writer): plain `.toLowerCase()` on the source domain, selector matches, and `revoked_publisher_domains[]` entries.
+- `server/src/adagents-manager.ts` (`hasExplicitPublisherScope`, the `managerdomain` fallback safety gate): plain `.toLowerCase()`.
+- `server/src/validator.ts` (`selectorTargetsDomain`, `propertyMatchesDomain`, placement/collection filters): `normalizeDomain` which additionally stripped `http(s)://` scheme and trailing slashes.
+
+A loose-typed manifest with `selector.publisher_domain: "https://cnn.com"` matched in the validator but failed cross-publisher refusal in the writer. Trailing-dot DNS-canonical forms (`"site.example."`) varied similarly. Catalog projection and live validation could disagree on whether two strings refer to the same publisher — the security boundary the writer enforces.
+
+**The fix.** New `server/src/services/publisher-domain.ts` exports `canonicalizePublisherDomain(raw)` which:
+
+- lowercases
+- trims surrounding whitespace
+- strips an `http(s)://` scheme prefix (defensive — schema pattern already rejects but writer/validator both accept loose-typed input)
+- strips trailing slashes and trailing dots (DNS-canonical form)
+
+Does NOT do SSRF rejection (that concern stays in the validator's `normalizeDomain` for URL-bearing input) or IDN/punycode conversion (schema pattern rejects non-ASCII today).
+
+Applied at every `publisher_domain` comparison site in the three consumers. Validator's `normalizeDomain` keeps its SSRF guards for source-side input but gains trailing-dot stripping so it produces the same canonical form as the shared helper for clean inputs.
+
+**Tests.**
+
+- `server/tests/unit/publisher-domain.test.ts`: 8 unit tests covering lowercase / trim / trailing-dot / trailing-slash / scheme strip / canonical-form equivalence across representations.
+- `server/tests/integration/registry-catalog-agent-auth-writer.test.ts`: two new integration tests locking trailing-dot and scheme-prefix selector forms as accepted by the writer (regression coverage for the drift the unification closes).
+- Existing 95 adagents-manager unit tests still pass.
+
+**Reference**: #4541 (issue), PR #4538 code-reviewer-deep should-fix #3 (origin).

--- a/server/src/adagents-manager.ts
+++ b/server/src/adagents-manager.ts
@@ -1,6 +1,7 @@
 import { PropertyDefinition, PlacementDefinition } from './types.js';
 import { AAO_UA_VALIDATOR } from './config/user-agents.js';
 import { safeFetchAxiosLike, classifySafeFetchError } from './utils/url-security.js';
+import { canonicalizePublisherDomain } from './services/publisher-domain.js';
 
 export interface ValidationError {
   field: string;
@@ -410,7 +411,7 @@ export class AdAgentsManager {
     const data = rawData as AdAgentsJsonInline;
     const agents = Array.isArray(data.authorized_agents) ? data.authorized_agents : [];
     const properties = Array.isArray(data.properties) ? data.properties : [];
-    const normalizedPublisher = publisherDomain.toLowerCase();
+    const normalizedPublisher = canonicalizePublisherDomain(publisherDomain);
 
     // Index properties by id and by tag for the per-agent reference lookup.
     // Both indexes filter to properties whose publisher_domain matches the
@@ -420,7 +421,7 @@ export class AdAgentsManager {
     const matchingPropertyTags = new Set<string>();
     for (const prop of properties) {
       if (typeof prop?.publisher_domain !== 'string') continue;
-      if (prop.publisher_domain.toLowerCase() !== normalizedPublisher) continue;
+      if (canonicalizePublisherDomain(prop.publisher_domain) !== normalizedPublisher) continue;
       if (typeof prop.property_id === 'string' && prop.property_id.length > 0) {
         matchingPropertyIds.add(prop.property_id);
       }
@@ -434,16 +435,16 @@ export class AdAgentsManager {
     return agents.some((agent) => {
       const hasPublisherProperties = Array.isArray(agent.publisher_properties)
         && agent.publisher_properties.some((p) => {
-          if (typeof p.publisher_domain === 'string' && p.publisher_domain.toLowerCase() === normalizedPublisher) {
+          if (typeof p.publisher_domain === 'string' && canonicalizePublisherDomain(p.publisher_domain) === normalizedPublisher) {
             return true;
           }
           if (Array.isArray(p.publisher_domains)) {
-            return p.publisher_domains.some((d) => typeof d === 'string' && d.toLowerCase() === normalizedPublisher);
+            return p.publisher_domains.some((d) => typeof d === 'string' && canonicalizePublisherDomain(d) === normalizedPublisher);
           }
           return false;
         });
       const hasCollections = Array.isArray(agent.collections)
-        && agent.collections.some((c) => c.publisher_domain.toLowerCase() === normalizedPublisher);
+        && agent.collections.some((c) => canonicalizePublisherDomain(c.publisher_domain) === normalizedPublisher);
 
       // Property-level scoping: the agent reaches a property whose
       // publisher_domain matches the source. by_id walks property_ids;

--- a/server/src/db/federated-index-db.ts
+++ b/server/src/db/federated-index-db.ts
@@ -1,4 +1,5 @@
 import { query } from './client.js';
+import { canonicalizePublisherDomain } from '../services/publisher-domain.js';
 
 /**
  * Discovered agent from adagents.json or list_authorized_properties
@@ -727,6 +728,7 @@ export class FederatedIndexDatabase {
    * removed and the query collapses to catalog-only.
    */
   async getPropertiesForDomain(domain: string): Promise<DiscoveredProperty[]> {
+    const canonicalDomain = canonicalizePublisherDomain(domain);
     const result = await query<DiscoveredProperty>(
       `WITH unioned AS (
          SELECT id, property_id, publisher_domain, property_type, name,
@@ -783,7 +785,7 @@ export class FederatedIndexDatabase {
           ORDER BY publisher_domain, name, property_type, src_priority
        )
        SELECT * FROM deduped ORDER BY property_type, name`,
-      [domain]
+      [canonicalDomain]
     );
     return result.rows.map(row => this.deserializeProperty(row));
   }
@@ -1109,6 +1111,7 @@ export class FederatedIndexDatabase {
     agentUrl: string,
     publisherDomain: string
   ): Promise<'adagents_json' | 'agent_claim' | 'none'> {
+    const canonicalDomain = canonicalizePublisherDomain(publisherDomain);
     const authResult = await query<{ source: string }>(
       `WITH unioned AS (
          SELECT source, 0 AS src_priority
@@ -1133,7 +1136,7 @@ export class FederatedIndexDatabase {
         ORDER BY src_priority,
                  CASE source WHEN 'adagents_json' THEN 0 ELSE 1 END
         LIMIT 1`,
-      [agentUrl, publisherDomain]
+      [agentUrl, canonicalDomain]
     );
 
     if (authResult.rows.length === 0) return 'none';
@@ -1210,8 +1213,13 @@ export class FederatedIndexDatabase {
     publisherDomain: string
   ): Promise<DiscoveredProperty[]> {
     const all = await this.getPropertiesForAgent(agentUrl);
+    // Canonicalize both sides so a runtime query for `"https://cnn.com"` or
+    // `"cnn.com."` resolves a stored property whose `publisher_domain` was
+    // written as `"cnn.com"`. Read-side of the writer's canonicalization
+    // boundary; legacy rows may also carry non-canonical forms.
+    const target = canonicalizePublisherDomain(publisherDomain);
     return all
-      .filter((p) => p.publisher_domain === publisherDomain)
+      .filter((p) => canonicalizePublisherDomain(p.publisher_domain) === target)
       .sort((a, b) => a.property_type.localeCompare(b.property_type) || a.name.localeCompare(b.name));
   }
 

--- a/server/src/db/publisher-db.ts
+++ b/server/src/db/publisher-db.ts
@@ -1,6 +1,7 @@
 import { getClient } from './client.js';
 import { uuidv7 } from './uuid.js';
 import { normalizeIdentifier } from '../services/identifier-normalization.js';
+import { canonicalizePublisherDomain } from '../services/publisher-domain.js';
 import { createLogger } from '../logger.js';
 import type { PoolClient } from 'pg';
 
@@ -161,7 +162,7 @@ function extractRevokedPublisherDomains(manifest: unknown): Set<string> {
     if (typeof ra !== 'string' || ra.length === 0) continue;
     // Require parseable date-time. Date.parse returns NaN on invalid input.
     if (Number.isNaN(Date.parse(ra))) continue;
-    out.add(pd.toLowerCase());
+    out.add(canonicalizePublisherDomain(pd));
   }
   return out;
 }
@@ -217,7 +218,7 @@ export class PublisherDatabase {
     responseBytes?: number;
     resolvedUrl?: string;
   }): Promise<void> {
-    const domain = input.domain.toLowerCase();
+    const domain = canonicalizePublisherDomain(input.domain);
     const client = await getClient();
     try {
       await client.query(
@@ -242,7 +243,7 @@ export class PublisherDatabase {
   }
 
   async upsertAdagentsCache(input: UpsertAdagentsCacheInput): Promise<void> {
-    const domain = input.domain.toLowerCase();
+    const domain = canonicalizePublisherDomain(input.domain);
     const client = await getClient();
     try {
       await client.query('BEGIN');
@@ -885,9 +886,9 @@ export class PublisherDatabase {
         // A selector claims the publisher if the source publisherDomain matches
         // either the singular publisher_domain or any entry in the compact
         // publisher_domains[] array. Both forms are equivalent for projection.
-        const selPubSingular = hasSingular ? sel.publisher_domain!.toLowerCase() : null;
+        const selPubSingular = hasSingular ? canonicalizePublisherDomain(sel.publisher_domain!) : null;
         const selPubInList = hasPlural
-          && sel.publisher_domains!.some((d) => typeof d === 'string' && d.toLowerCase() === publisherDomain);
+          && sel.publisher_domains!.some((d) => typeof d === 'string' && canonicalizePublisherDomain(d) === publisherDomain);
         if (selPubSingular !== publisherDomain && !selPubInList) {
           // Cross-publisher third-party-sales claim. Refused per spec — the
           // writer cannot land an authoritative row for another publisher's

--- a/server/src/db/publisher-db.ts
+++ b/server/src/db/publisher-db.ts
@@ -145,12 +145,21 @@ function truncateResolvedUrl(url: string | undefined): string | null {
   return url.length > RESOLVED_URL_MAX ? url.slice(0, RESOLVED_URL_MAX) : url;
 }
 
+// Pattern from the JSON Schema for `publisher_domain`. Used after
+// canonicalization to drop entries whose canonical form doesn't look like
+// a publishable domain — embedded control chars, scheme remnants, paths,
+// etc. would otherwise land in the revocation set with a key that no
+// real lookup hits (silently-ignored revocation), which is the wrong
+// failure mode for a security control.
+const PUBLISHER_DOMAIN_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/;
+
 // Read `revoked_publisher_domains[]` from a (loose-typed) manifest and return
-// the set of lowercased publisher_domain values. Entries MUST carry both
-// a string `publisher_domain` and a parseable `revoked_at` per the spec —
-// the writer is a security boundary, and silently accepting incomplete
-// revocation entries is the same shape as the cross-publisher bypass this
-// PR closes. Malformed entries are dropped, not honored.
+// the set of canonicalized publisher_domain values. Entries MUST carry both
+// a string `publisher_domain` (which canonicalizes to a schema-valid domain)
+// and a parseable `revoked_at` per the spec — the writer is a security
+// boundary, and silently accepting malformed revocation entries is the
+// same shape as the cross-publisher bypass this PR closes. Malformed
+// entries are dropped, not honored.
 function extractRevokedPublisherDomains(manifest: unknown): Set<string> {
   const out = new Set<string>();
   const m = manifest as { revoked_publisher_domains?: unknown };
@@ -162,7 +171,13 @@ function extractRevokedPublisherDomains(manifest: unknown): Set<string> {
     if (typeof ra !== 'string' || ra.length === 0) continue;
     // Require parseable date-time. Date.parse returns NaN on invalid input.
     if (Number.isNaN(Date.parse(ra))) continue;
-    out.add(canonicalizePublisherDomain(pd));
+    const canonical = canonicalizePublisherDomain(pd);
+    // Reject canonical forms that wouldn't pass the schema pattern — they
+    // can't match any legitimately-stored publisher_domain anyway, and
+    // accepting them lets a misbehaving manifest hide revocations as
+    // garbage entries.
+    if (!PUBLISHER_DOMAIN_PATTERN.test(canonical)) continue;
+    out.add(canonical);
   }
   return out;
 }
@@ -437,7 +452,7 @@ export class PublisherDatabase {
     try {
       const r = await client.query<{ adagents_json: AdagentsManifest | null }>(
         `SELECT adagents_json FROM publishers WHERE domain = $1 LIMIT 1`,
-        [domain.toLowerCase()],
+        [canonicalizePublisherDomain(domain)],
       );
       return r.rows[0]?.adagents_json ?? null;
     } finally {
@@ -474,7 +489,7 @@ export class PublisherDatabase {
            attempts = 0,
            last_attempted_at = NULL,
            last_error = NULL`,
-        [managerDomain.toLowerCase()],
+        [canonicalizePublisherDomain(managerDomain)],
       );
       return r.rowCount ?? 0;
     } finally {
@@ -515,7 +530,7 @@ export class PublisherDatabase {
     try {
       await client.query(
         `DELETE FROM manager_revalidation_queue WHERE publisher_domain = $1`,
-        [publisherDomain.toLowerCase()],
+        [canonicalizePublisherDomain(publisherDomain)],
       );
     } finally {
       client.release();
@@ -542,7 +557,7 @@ export class PublisherDatabase {
                   ELSE INTERVAL '3 days'
                 END
           WHERE publisher_domain = $1`,
-        [publisherDomain.toLowerCase(), err],
+        [canonicalizePublisherDomain(publisherDomain), err],
       );
     } finally {
       client.release();

--- a/server/src/services/publisher-domain.ts
+++ b/server/src/services/publisher-domain.ts
@@ -22,6 +22,12 @@ export function canonicalizePublisherDomain(raw: string): string {
   let v = raw.trim().toLowerCase();
   if (v.startsWith('https://')) v = v.slice(8);
   else if (v.startsWith('http://')) v = v.slice(7);
+  // Trailing-slash and trailing-dot strip is interleaved on purpose — both
+  // `"cnn.com./"` and `"cnn.com/."` collapse to `"cnn.com"` because each
+  // iteration peels whichever terminator is currently at the end. This is
+  // a security boundary (writer-vs-validator parity); two strings that
+  // refer to the same publisher MUST canonicalize identically regardless
+  // of the order of their non-significant trailing characters.
   while (v.endsWith('/') || v.endsWith('.')) v = v.slice(0, -1);
   return v;
 }

--- a/server/src/services/publisher-domain.ts
+++ b/server/src/services/publisher-domain.ts
@@ -1,0 +1,27 @@
+// Canonicalize a `publisher_domain` value for comparison.
+//
+// Used wherever code compares `publisher_domain` strings from adagents.json
+// against each other — writer (publisher-db), runtime authorization gate
+// (adagents-manager.hasExplicitPublisherScope), selector resolution
+// (validator.selectorTargetsDomain). Before this helper existed, the writer
+// used plain `.toLowerCase()` while the validator's `normalizeDomain` also
+// stripped scheme prefixes and trailing slashes. A manifest with
+// `selector.publisher_domain: "https://cnn.com"` matched in the validator
+// but failed cross-publisher refusal in the writer; manifests with trailing
+// dots or whitespace varied similarly. Catalog projection and live
+// validation could then disagree on whether two strings refer to the same
+// publisher.
+//
+// Scope: lowercases, trims whitespace, strips an `http(s)://` scheme prefix,
+// strips trailing slashes, strips trailing dots (DNS-canonical form). Does
+// NOT do SSRF rejection (localhost/IP refusal) — that concern belongs with
+// URL-bearing input the validator separately defends against in
+// `normalizeDomain`. Does NOT do IDN/punycode conversion — the schema
+// pattern rejects non-ASCII today; revisit if that changes.
+export function canonicalizePublisherDomain(raw: string): string {
+  let v = raw.trim().toLowerCase();
+  if (v.startsWith('https://')) v = v.slice(8);
+  else if (v.startsWith('http://')) v = v.slice(7);
+  while (v.endsWith('/') || v.endsWith('.')) v = v.slice(0, -1);
+  return v;
+}

--- a/server/src/validator.ts
+++ b/server/src/validator.ts
@@ -46,6 +46,18 @@ export class AgentValidator {
     const normalizedDomain = this.normalizeDomain(domain);
     const normalizedAgentUrl = this.normalizeUrl(agentUrl);
     const normalizedScope = this.normalizeScope(scope);
+    // SSRF reject (localhost / IP / empty) collapsed normalizedDomain to "".
+    // Fail closed here so downstream comparisons can't match a selector
+    // whose canonical form is also "" (e.g., "/", ".", "https://").
+    if (normalizedDomain === "") {
+      return {
+        authorized: false,
+        domain,
+        agent_url: agentUrl,
+        checked_at: new Date().toISOString(),
+        error: "Invalid publisher domain (resolves to local/private address or empty)",
+      };
+    }
     const cacheKey = JSON.stringify({
       domain: normalizedDomain,
       agent_url: normalizedAgentUrl,
@@ -358,6 +370,11 @@ export class AgentValidator {
   // publisher_domains[] array (managed-network fan-out — exactly equivalent to
   // repeating the selector once per listed domain).
   private selectorTargetsDomain(selector: PublisherPropertySelector, normalizedDomain: string): boolean {
+    // Empty normalized source means SSRF reject fired upstream (localhost,
+    // IP literal, empty input). Never let any selector match — comparing
+    // against an empty canonical form would otherwise authorize a manifest
+    // whose own selector canonicalizes to "" (e.g., "/", ".", "https://").
+    if (normalizedDomain === "") return false;
     if (typeof selector.publisher_domain === "string"
       && canonicalizePublisherDomain(selector.publisher_domain) === normalizedDomain) {
       return true;
@@ -490,6 +507,7 @@ export class AgentValidator {
   }
 
   private propertyMatchesDomain(property: PropertyDefinition, normalizedDomain: string): boolean {
+    if (normalizedDomain === "") return false;
     if (property.publisher_domain && canonicalizePublisherDomain(property.publisher_domain) === normalizedDomain) {
       return true;
     }

--- a/server/src/validator.ts
+++ b/server/src/validator.ts
@@ -1,5 +1,6 @@
 import dns from "node:dns/promises";
 import net from "node:net";
+import { canonicalizePublisherDomain } from "./services/publisher-domain.js";
 import type {
   AdAgentsJson,
   AuthorizationResult,
@@ -276,7 +277,7 @@ export class AgentValidator {
     }
 
     return selectors.some((selector) =>
-      this.normalizeDomain(selector.publisher_domain) === normalizedDomain &&
+      canonicalizePublisherDomain(selector.publisher_domain) === normalizedDomain &&
       this.hasIntersection(selector.collection_ids, collectionIds)
     );
   }
@@ -358,12 +359,12 @@ export class AgentValidator {
   // repeating the selector once per listed domain).
   private selectorTargetsDomain(selector: PublisherPropertySelector, normalizedDomain: string): boolean {
     if (typeof selector.publisher_domain === "string"
-      && this.normalizeDomain(selector.publisher_domain) === normalizedDomain) {
+      && canonicalizePublisherDomain(selector.publisher_domain) === normalizedDomain) {
       return true;
     }
     if (Array.isArray(selector.publisher_domains)) {
       return selector.publisher_domains.some((d) =>
-        typeof d === "string" && this.normalizeDomain(d) === normalizedDomain
+        typeof d === "string" && canonicalizePublisherDomain(d) === normalizedDomain
       );
     }
     return false;
@@ -489,7 +490,7 @@ export class AgentValidator {
   }
 
   private propertyMatchesDomain(property: PropertyDefinition, normalizedDomain: string): boolean {
-    if (property.publisher_domain && this.normalizeDomain(property.publisher_domain) === normalizedDomain) {
+    if (property.publisher_domain && canonicalizePublisherDomain(property.publisher_domain) === normalizedDomain) {
       return true;
     }
 
@@ -535,8 +536,13 @@ export class AgentValidator {
       normalized = normalized.slice("http://".length);
     }
 
-    // Remove trailing slashes.
-    while (normalized.endsWith("/")) {
+    // Remove trailing slashes and trailing dots. Trailing dot is the
+    // DNS-canonical form for FQDNs and is round-trip equivalent to the
+    // dotless form for `publisher_domain` comparison. Stripping here
+    // keeps the validator in agreement with the shared
+    // canonicalizePublisherDomain helper used by the writer and the
+    // adagents-manager safety gate.
+    while (normalized.endsWith("/") || normalized.endsWith(".")) {
       normalized = normalized.slice(0, -1);
     }
 
@@ -713,7 +719,7 @@ export class AgentValidator {
     return [
       ...new Set(
         selectors
-          .filter((selector) => this.normalizeDomain(selector.publisher_domain) === normalizedDomain)
+          .filter((selector) => canonicalizePublisherDomain(selector.publisher_domain) === normalizedDomain)
           .flatMap((selector) => selector.collection_ids)
       ),
     ];
@@ -741,7 +747,7 @@ export class AgentValidator {
     }
 
     return placements.filter((placement) => {
-      if (placement.publisher_domain && this.normalizeDomain(placement.publisher_domain) !== normalizedDomain) {
+      if (placement.publisher_domain && canonicalizePublisherDomain(placement.publisher_domain) !== normalizedDomain) {
         return false;
       }
       if (placementIds && !placementIds.has(placement.placement_id)) {

--- a/server/tests/integration/registry-catalog-agent-auth-writer.test.ts
+++ b/server/tests/integration/registry-catalog-agent-auth-writer.test.ts
@@ -1024,6 +1024,116 @@ describe('catalog_agent_authorizations writer projection', () => {
       expect(rows.map((r) => r.property_id_slug)).toEqual(['site_a']);
     });
 
+    it('revokes when revoked_publisher_domains[] entry uses non-canonical form (trailing dot, mixed case, scheme prefix)', async () => {
+      // Code-reviewer SF3 / #4541: a revocation entry of `"CAA-Writer.example."`
+      // or `"https://caa-writer.example"` must canonicalize to the same key
+      // as the publisher row under `"caa-writer.example"` and fire the
+      // retirement branch. Locks the canonicalization parity end-to-end.
+      // Step 1: grant projection under the canonical key.
+      await publisherDb.upsertAdagentsCache({
+        domain: TEST_PUB,
+        manifest: manifest(
+          [
+            {
+              url: TEST_AGENT_RAW,
+              authorization_type: 'publisher_properties',
+              publisher_properties: [
+                { publisher_domain: TEST_PUB, selection_type: 'all' },
+              ],
+            },
+          ],
+          [
+            {
+              property_id: 'site_a',
+              property_type: 'website',
+              name: 'Site A',
+              identifiers: [{ type: 'domain', value: TEST_PUB }],
+            },
+          ]
+        ),
+      });
+      // Step 2: revoke using a non-canonical form (trailing dot + mixed case).
+      await publisherDb.upsertAdagentsCache({
+        domain: TEST_PUB,
+        manifest: {
+          ...manifest(
+            [
+              {
+                url: TEST_AGENT_RAW,
+                authorization_type: 'publisher_properties',
+                publisher_properties: [
+                  { publisher_domain: TEST_PUB, selection_type: 'all' },
+                ],
+              },
+            ],
+            [
+              {
+                property_id: 'site_a',
+                property_type: 'website',
+                name: 'Site A',
+                identifiers: [{ type: 'domain', value: TEST_PUB }],
+              },
+            ]
+          ),
+          revoked_publisher_domains: [
+            // Mixed case + trailing dot — must canonicalize to TEST_PUB.
+            { publisher_domain: `CAA-Writer.example.`, revoked_at: '2026-05-13T00:00:00Z' },
+          ],
+        },
+      });
+      const { rows: liveRowsAfterRevoke } = await pool.query(
+        `SELECT 1 FROM catalog_agent_authorizations
+          WHERE agent_url_canonical = $1
+            AND deleted_at IS NULL`,
+        [TEST_AGENT_CANON]
+      );
+      expect(liveRowsAfterRevoke).toHaveLength(0);
+    });
+
+    it('drops revoked_publisher_domains[] entries whose canonical form fails the schema pattern', async () => {
+      // Security SF2 / #4541: garbage-looking entries (control chars,
+      // scheme remnants that don't strip cleanly, paths) MUST be dropped,
+      // not honored as silently-unmatching revocations.
+      await publisherDb.upsertAdagentsCache({
+        domain: TEST_PUB,
+        manifest: {
+          ...manifest(
+            [
+              {
+                url: TEST_AGENT_RAW,
+                authorization_type: 'publisher_properties',
+                publisher_properties: [
+                  { publisher_domain: TEST_PUB, selection_type: 'all' },
+                ],
+              },
+            ],
+            [
+              {
+                property_id: 'site_a',
+                property_type: 'website',
+                name: 'Site A',
+                identifiers: [{ type: 'domain', value: TEST_PUB }],
+              },
+            ]
+          ),
+          revoked_publisher_domains: [
+            // Embedded NUL — canonical form still has the NUL, fails the pattern.
+            { publisher_domain: ' caa-writer.example', revoked_at: '2026-05-13T00:00:00Z' },
+            // Path segment — canonical form has `/`, fails the pattern.
+            { publisher_domain: 'https://caa-writer.example/path', revoked_at: '2026-05-13T00:00:00Z' },
+          ],
+        },
+      });
+      // Projection should proceed normally — neither malformed entry
+      // revokes the publisher.
+      const { rows } = await pool.query<{ property_id_slug: string }>(
+        `SELECT property_id_slug FROM catalog_agent_authorizations
+          WHERE agent_url_canonical = $1 AND property_rid IS NOT NULL`,
+        [TEST_AGENT_CANON]
+      );
+      expect(rows.map((r) => r.property_id_slug)).toEqual(['site_a']);
+    });
+
     it('projects normally when revoked_publisher_domains[] lists a different domain', async () => {
       // Revocation list contains an unrelated domain; projection proceeds.
       await publisherDb.upsertAdagentsCache({

--- a/server/tests/integration/registry-catalog-agent-auth-writer.test.ts
+++ b/server/tests/integration/registry-catalog-agent-auth-writer.test.ts
@@ -1117,8 +1117,9 @@ describe('catalog_agent_authorizations writer projection', () => {
             ]
           ),
           revoked_publisher_domains: [
-            // Embedded NUL — canonical form still has the NUL, fails the pattern.
-            { publisher_domain: ' caa-writer.example', revoked_at: '2026-05-13T00:00:00Z' },
+            // Embedded space inside the domain — survives trim(); canonical
+            // form retains the interior space; fails the schema pattern.
+            { publisher_domain: 'caa writer.example', revoked_at: '2026-05-13T00:00:00Z' }, caa-writer.example', revoked_at: '2026-05-13T00:00:00Z' },
             // Path segment — canonical form has `/`, fails the pattern.
             { publisher_domain: 'https://caa-writer.example/path', revoked_at: '2026-05-13T00:00:00Z' },
           ],

--- a/server/tests/integration/registry-catalog-agent-auth-writer.test.ts
+++ b/server/tests/integration/registry-catalog-agent-auth-writer.test.ts
@@ -1119,7 +1119,7 @@ describe('catalog_agent_authorizations writer projection', () => {
           revoked_publisher_domains: [
             // Embedded space inside the domain — survives trim(); canonical
             // form retains the interior space; fails the schema pattern.
-            { publisher_domain: 'caa writer.example', revoked_at: '2026-05-13T00:00:00Z' }, caa-writer.example', revoked_at: '2026-05-13T00:00:00Z' },
+            { publisher_domain: 'caa writer.example', revoked_at: '2026-05-13T00:00:00Z' },
             // Path segment — canonical form has `/`, fails the pattern.
             { publisher_domain: 'https://caa-writer.example/path', revoked_at: '2026-05-13T00:00:00Z' },
           ],

--- a/server/tests/integration/registry-catalog-agent-auth-writer.test.ts
+++ b/server/tests/integration/registry-catalog-agent-auth-writer.test.ts
@@ -634,6 +634,77 @@ describe('catalog_agent_authorizations writer projection', () => {
       expect(rows).toHaveLength(0);
     });
 
+    it('matches own publisher when selector publisher_domain has a trailing dot (DNS-canonical form)', async () => {
+      // A hand-edited or DNS-tool-emitted manifest may use the trailing-dot
+      // FQDN form (`"caa-writer.example."`). The writer MUST treat this as
+      // equivalent to the dotless form to stay in agreement with the
+      // validator. See canonicalizePublisherDomain in
+      // services/publisher-domain.ts.
+      await publisherDb.upsertAdagentsCache({
+        domain: TEST_PUB,
+        manifest: manifest(
+          [
+            {
+              url: TEST_AGENT_RAW,
+              authorization_type: 'publisher_properties',
+              publisher_properties: [
+                { publisher_domain: `${TEST_PUB}.`, selection_type: 'all' },
+              ],
+            },
+          ],
+          [
+            {
+              property_id: 'site_a',
+              property_type: 'website',
+              name: 'Site A',
+              identifiers: [{ type: 'domain', value: TEST_PUB }],
+            },
+          ]
+        ),
+      });
+      const { rows } = await pool.query<{ property_id_slug: string }>(
+        `SELECT property_id_slug FROM catalog_agent_authorizations
+          WHERE agent_url_canonical = $1 AND property_rid IS NOT NULL`,
+        [TEST_AGENT_CANON]
+      );
+      expect(rows.map((r) => r.property_id_slug)).toEqual(['site_a']);
+    });
+
+    it('matches own publisher when selector publisher_domain has an http(s) scheme prefix', async () => {
+      // Scheme-prefixed publisher_domain is technically invalid per the JSON
+      // Schema pattern, but the writer accepts loose-typed input and was
+      // previously diverging from the validator (which strips scheme via
+      // normalizeDomain). Unified through canonicalizePublisherDomain now.
+      await publisherDb.upsertAdagentsCache({
+        domain: TEST_PUB,
+        manifest: manifest(
+          [
+            {
+              url: TEST_AGENT_RAW,
+              authorization_type: 'publisher_properties',
+              publisher_properties: [
+                { publisher_domain: `https://${TEST_PUB}`, selection_type: 'all' },
+              ],
+            },
+          ],
+          [
+            {
+              property_id: 'site_a',
+              property_type: 'website',
+              name: 'Site A',
+              identifiers: [{ type: 'domain', value: TEST_PUB }],
+            },
+          ]
+        ),
+      });
+      const { rows } = await pool.query<{ property_id_slug: string }>(
+        `SELECT property_id_slug FROM catalog_agent_authorizations
+          WHERE agent_url_canonical = $1 AND property_rid IS NOT NULL`,
+        [TEST_AGENT_CANON]
+      );
+      expect(rows.map((r) => r.property_id_slug)).toEqual(['site_a']);
+    });
+
     it('matches own publisher when selector publisher_domain has mixed case', async () => {
       // Legacy or hand-edited manifests may use mixed-case publisher_domain.
       // The selector is lowercased before comparison; own-publisher claims

--- a/server/tests/unit/adagents-manager.test.ts
+++ b/server/tests/unit/adagents-manager.test.ts
@@ -677,6 +677,86 @@ describe('AdAgentsManager', () => {
       expect(result.errors.some(e => e.field === 'managerdomain_scope')).toBe(true);
     });
 
+    it('accepts managerdomain fallback when manager publisher_domain has non-canonical form (trailing dot, scheme prefix, mixed case)', async () => {
+      // Code-reviewer SF2 / #4541: hasExplicitPublisherScope must produce
+      // identical canonicalization across publisher_domain (singular),
+      // publisher_domains[] (compact), collections[].publisher_domain, and
+      // the property-level publisher_domain filter. A manifest with any of
+      // these in DNS-canonical form (trailing dot) or with a stray scheme
+      // prefix should still satisfy the gate.
+      mockedSafeFetch.mockImplementation(async (url) => {
+        if (url === 'https://publisher.example/.well-known/adagents.json') {
+          return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://publisher.example/ads.txt') {
+          return { status: 200, data: Buffer.from('MANAGERDOMAIN=manager.example\n'), headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://manager.example/.well-known/adagents.json') {
+          return {
+            status: 200,
+            data: buf({
+              authorized_agents: [{
+                url: 'https://agent.example',
+                authorized_for: 'Mixed non-canonical forms',
+                authorization_type: 'publisher_properties',
+                publisher_properties: [{
+                  // Trailing dot, mixed case, scheme prefix — should all
+                  // canonicalize to "publisher.example".
+                  publisher_domains: ['Publisher.Example.', 'https://other.example'],
+                  selection_type: 'by_tag',
+                  property_tags: ['managed_network'],
+                }],
+              }],
+            }),
+            headers: { 'content-type': 'application/json' },
+          };
+        }
+        throw new Error(`Unexpected URL: ${url}`);
+      });
+
+      const result = await manager.validateDomain('publisher.example');
+      expect(result.valid).toBe(true);
+      expect(result.discovery_method).toBe('ads_txt_managerdomain');
+    });
+
+    it('accepts managerdomain fallback via property-level path when properties[].publisher_domain has trailing dot', async () => {
+      // The property-level fallback path also flows through
+      // canonicalizePublisherDomain — locks that for trailing-dot forms.
+      mockedSafeFetch.mockImplementation(async (url) => {
+        if (url === 'https://publisher.example/.well-known/adagents.json') {
+          return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://publisher.example/ads.txt') {
+          return { status: 200, data: Buffer.from('MANAGERDOMAIN=manager.example\n'), headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://manager.example/.well-known/adagents.json') {
+          return {
+            status: 200,
+            data: buf({
+              properties: [{
+                property_id: 'pub_main_site',
+                property_type: 'website',
+                // Trailing-dot DNS-canonical form.
+                publisher_domain: 'publisher.example.',
+                tags: ['scope3-aee'],
+              }],
+              authorized_agents: [{
+                url: 'https://agent.example',
+                authorized_for: 'Property-level path with canonical mismatch',
+                authorization_type: 'property_tags',
+                property_tags: ['scope3-aee'],
+              }],
+            }),
+            headers: { 'content-type': 'application/json' },
+          };
+        }
+        throw new Error(`Unexpected URL: ${url}`);
+      });
+
+      const result = await manager.validateDomain('publisher.example');
+      expect(result.valid).toBe(true);
+    });
+
     it('accepts managerdomain fallback when manager scopes via publisher_properties[].publisher_domains[] compact form', async () => {
       // Managed networks (Raptive/Cafemedia shape) declare scope across
       // many represented publishers in a single publisher_properties[]

--- a/server/tests/unit/publisher-domain.test.ts
+++ b/server/tests/unit/publisher-domain.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { canonicalizePublisherDomain } from '../../src/services/publisher-domain.js';
+
+describe('canonicalizePublisherDomain', () => {
+  it('lowercases mixed-case input', () => {
+    expect(canonicalizePublisherDomain('CNN.com')).toBe('cnn.com');
+    expect(canonicalizePublisherDomain('Site.Example')).toBe('site.example');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(canonicalizePublisherDomain('  cnn.com  ')).toBe('cnn.com');
+    expect(canonicalizePublisherDomain('\tcnn.com\n')).toBe('cnn.com');
+  });
+
+  it('strips trailing dot (DNS-canonical form)', () => {
+    expect(canonicalizePublisherDomain('cnn.com.')).toBe('cnn.com');
+    expect(canonicalizePublisherDomain('Site.Example.')).toBe('site.example');
+    // Multiple trailing dots collapsed.
+    expect(canonicalizePublisherDomain('cnn.com..')).toBe('cnn.com');
+  });
+
+  it('strips trailing slashes', () => {
+    expect(canonicalizePublisherDomain('cnn.com/')).toBe('cnn.com');
+    expect(canonicalizePublisherDomain('cnn.com//')).toBe('cnn.com');
+  });
+
+  it('strips http(s):// scheme prefix', () => {
+    expect(canonicalizePublisherDomain('https://cnn.com')).toBe('cnn.com');
+    expect(canonicalizePublisherDomain('HTTP://CNN.com')).toBe('cnn.com');
+    expect(canonicalizePublisherDomain('https://cnn.com/')).toBe('cnn.com');
+  });
+
+  it('produces the same canonical form for equivalent representations', () => {
+    // The whole point of this helper — writer, validator, and adagents-manager
+    // MUST agree on whether two strings refer to the same publisher.
+    const canonical = canonicalizePublisherDomain('cnn.com');
+    expect(canonicalizePublisherDomain('CNN.com')).toBe(canonical);
+    expect(canonicalizePublisherDomain('cnn.com.')).toBe(canonical);
+    expect(canonicalizePublisherDomain('  cnn.com  ')).toBe(canonical);
+    expect(canonicalizePublisherDomain('https://cnn.com/')).toBe(canonical);
+    expect(canonicalizePublisherDomain('HTTPS://CNN.com.')).toBe(canonical);
+  });
+
+  it('passes through ASCII-only domains unchanged when already canonical', () => {
+    expect(canonicalizePublisherDomain('cnn.com')).toBe('cnn.com');
+    expect(canonicalizePublisherDomain('news.example.com')).toBe('news.example.com');
+    expect(canonicalizePublisherDomain('a.b.c.d')).toBe('a.b.c.d');
+  });
+
+  it('does NOT do IDN/punycode conversion (schema pattern rejects non-ASCII today)', () => {
+    // Documented non-behavior. If the schema later admits IDN, this
+    // helper needs an IDN-to-ASCII pass to keep writer/runtime in
+    // agreement on münchen.example vs xn--mnchen-3ya.example.
+    const idn = 'münchen.example';
+    // Just confirms the helper doesn't crash; whether it returns the
+    // input or the lowercased input is implementation detail until IDN
+    // is supported.
+    expect(canonicalizePublisherDomain(idn)).toBe(idn);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #4541. Code-reviewer-deep follow-up from PR #4538.

Three consumers compared \`publisher_domain\` strings with different normalization:

- \`publisher-db.ts\`: plain \`.toLowerCase()\`
- \`adagents-manager.ts\` (\`hasExplicitPublisherScope\`): plain \`.toLowerCase()\`
- \`validator.ts\` (\`normalizeDomain\`): lowercase + scheme strip + slash strip

A manifest with \`selector.publisher_domain: "https://cnn.com"\` matched in the validator but failed cross-publisher refusal in the writer. Trailing-dot DNS-canonical forms varied similarly. Catalog projection and live validation could disagree on whether two strings refer to the same publisher — the security boundary the writer enforces.

## What changes

- New \`server/src/services/publisher-domain.ts\` exports \`canonicalizePublisherDomain(raw)\`: lowercase + trim + scheme strip + trailing-slash strip + trailing-dot strip.
- Applied at every \`publisher_domain\` comparison site in the three consumers.
- Validator's \`normalizeDomain\` keeps its SSRF guards (URL-bearing input) but gains trailing-dot stripping for parity with the shared helper.

## Test plan

- [x] 8 unit tests in \`publisher-domain.test.ts\` (lowercase, trim, trailing-dot, trailing-slash, scheme strip, canonical-form equivalence)
- [x] 2 new integration tests for trailing-dot and scheme-prefix selector acceptance
- [x] Existing 95 adagents-manager tests pass
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)