### PR TITLE
fix(membership): correct stale prices on static membership page

### DIFF
--- a/.changeset/membership-pricing-static-fix.md
+++ b/.changeset/membership-pricing-static-fix.md
@@ -1,0 +1,4 @@
+---
+---
+
+Site: `server/public/membership.html` — corrects stale prices in the static fallback HTML (sr-only summary, comparison table, FAQ paragraph, `<noscript>` block). Builder $2,500 → $3,000 and Partner $10,000 → $15,000, matching the dynamic CTA component (`join-cta.js`) and Stripe (`aao_membership_builder_3000`, `aao_membership_member_15000`). No tier renames; "Partner" remains the public label per `server/src/services/membership-tiers.ts` TIER_LABELS. Same page was rendering two different numbers depending on whether JS had loaded.

--- a/server/public/membership.html
+++ b/server/public/membership.html
@@ -465,8 +465,8 @@
     <h2>Membership pricing summary</h2>
     <p>Explorer: $50/year. 1 community-only seat (Addie, all three certification tiers, training). Basics is free for everyone; Practitioner and Specialist require any membership.</p>
     <p>Professional: $250/year. 1 contributor seat (includes community access), councils, voting rights, directory listing.</p>
-    <p>Builder: $2,500/year. 5 contributor seats, 5 community-only seats, API access, councils, board eligible.</p>
-    <p>Partner: $10,000/year. 10 contributor seats, 50 community-only seats, API access, councils, board eligible, featured directory.</p>
+    <p>Builder: $3,000/year. 5 contributor seats, 5 community-only seats, API access, councils, board eligible.</p>
+    <p>Partner: $15,000/year. 10 contributor seats, 50 community-only seats, API access, councils, board eligible, featured directory.</p>
     <p>Leader: $50,000/year. 20+ contributor seats, unlimited community-only seats, API access, convene councils, board eligible, first access to marketing opportunities.</p>
     <p>All membership tiers unlock full certification access (Basics, Practitioner, Specialist).</p>
   </div>
@@ -701,8 +701,8 @@
               <td><strong>Annual</strong></td>
               <td><strong>$50</strong></td>
               <td><strong>$250</strong></td>
-              <td><strong>$2,500</strong></td>
-              <td><strong>$10,000</strong></td>
+              <td><strong>$3,000</strong></td>
+              <td><strong>$15,000</strong></td>
               <td><strong>$50,000</strong></td>
             </tr>
             <tr class="eligibility-row">
@@ -732,7 +732,7 @@
       <div class="faq-item">
         <div class="faq-question" role="button" tabindex="0" aria-expanded="false" aria-controls="faq-a2">How do I choose the right membership tier?</div>
         <div class="faq-answer" aria-hidden="true" id="faq-a2" role="region">
-          <strong>Explorer</strong> ($50/yr) to get fully certified &mdash; all three tiers, including Practitioner and Specialist &mdash; and see what agentic advertising is about. <strong>Professional</strong> ($250/yr) if you're a working practitioner who wants full community access and council participation. <strong>Builder</strong> ($2,500/yr) if you're a growing team that needs API access and multiple seats. <strong>Partner</strong> ($10,000/yr) if you're an established organization that wants to train your team and participate in governance. <strong>Leader</strong> ($50,000/yr) for organizations that want to convene councils, shape industry direction, and get first access to marketing opportunities.
+          <strong>Explorer</strong> ($50/yr) to get fully certified &mdash; all three tiers, including Practitioner and Specialist &mdash; and see what agentic advertising is about. <strong>Professional</strong> ($250/yr) if you're a working practitioner who wants full community access and council participation. <strong>Builder</strong> ($3,000/yr) if you're a growing team that needs API access and multiple seats. <strong>Partner</strong> ($15,000/yr) if you're an established organization that wants to train your team and participate in governance. <strong>Leader</strong> ($50,000/yr) for organizations that want to convene councils, shape industry direction, and get first access to marketing opportunities.
         </div>
       </div>
 
@@ -816,10 +816,10 @@
             <h3>Professional &mdash; $250/year</h3>
             <p>1 contributor seat (includes community access). Councils, voting rights, directory listing.</p>
 
-            <h3>Builder &mdash; $2,500/year</h3>
+            <h3>Builder &mdash; $3,000/year</h3>
             <p>5 contributor seats, 5 community-only seats. API access, councils, board eligible.</p>
 
-            <h3>Partner &mdash; $10,000/year</h3>
+            <h3>Partner &mdash; $15,000/year</h3>
             <p>10 contributor seats, 50 community-only seats. API access, board eligible, featured directory.</p>
 
             <h3>Leader &mdash; $50,000/year</h3>


### PR DESCRIPTION
## Summary

The membership page renders pricing twice — once via a dynamic CTA component (`server/public/join-cta.js`) that fetches live prices from Stripe, and once via static fallback HTML for the SEO summary, comparison table, FAQ, and `<noscript>` block. The static side had drifted:

- Builder: `$2,500` → **`$3,000`** (Stripe: `aao_membership_builder_3000`)
- Partner: `$10,000` → **`$15,000`** (Stripe: `aao_membership_member_15000`)

Same page, two different numbers depending on whether JS rendered first.

Tier labels are unchanged. "Partner" remains the public name per `server/src/services/membership-tiers.ts` `TIER_LABELS` (`company_icl` → `"Partner"`); the `member` in the Stripe `lookup_key` is legacy and not user-facing.

Five locations updated in `server/public/membership.html`:
- sr-only pricing summary
- Comparison-table price row
- "How do I choose the right membership tier?" FAQ paragraph
- `<noscript>` static fallback (Builder + Partner cards)

## Test plan

- [x] `grep` confirmed no remaining `$2,500` or `$10,000` references in `server/public/membership.html`
- [x] All five updated values match `server/public/join-cta.js` fallbacks and Stripe lookup keys
- [x] Tier label "Partner" verified against `server/src/services/membership-tiers.ts:54-60`
- [x] Precommit suite (unit + dynamic-imports + callapi-state-change + typecheck) passed locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)