### PR TITLE
compliance(idempotency): runtime rate-limit replay invariant

### DIFF
--- a/.changeset/4547-rate-limit-replay-invariant.md
+++ b/.changeset/4547-rate-limit-replay-invariant.md
@@ -1,0 +1,20 @@
+---
+---
+
+compliance(idempotency): runtime rate-limit replay invariant
+
+Per L1/security.mdx#idempotency rule 3 ("Only successful responses are cached") and bullet 8 (insert-rate ceiling), a `RATE_LIMITED` response on idempotency-cache insert MUST NOT be cached as the canonical replay for that key. Otherwise `retry_after` is meaningless — a buyer retrying past the hint receives the cached error forever, regardless of when the limiter actually cleared.
+
+Adds runtime grading for that invariant. Burst-volume attestation of the 60/300 req/sec threshold remains seller self-attestation (structurally non-deterministic in CI; see #2615 close).
+
+Changes:
+
+- New test-kit contract `rate_limit_trip_runner` at `static/compliance/source/test-kits/rate-limit-trip-runner.yaml`. Defines sequential fresh-key burst (50 ≤ max_attempts ≤ 500), trip-detection (first `RATE_LIMITED` response), wait + replay mechanics (sleep `retry_after`, replay captured key), and the not_applicable fallback when no `RATE_LIMITED` appears within the burst window.
+- New task `expect_rate_limit_not_replayed` documented in `storyboard-schema.yaml` with full field spec and error modes.
+- New cross-response check kind `replay_not_cached_rate_limit` registered in `runner-output-contract.yaml`. Compares `trip_response.error.code` vs `replay_response.error.code`; fails iff both are `RATE_LIMITED`.
+- New phase `rate_limit_replay_invariant` at the end of `universal/idempotency.yaml`. Single step exercising the contract against `create_media_buy` with `max_attempts: 200` and `replay_max_wait_seconds: 30`.
+- Updates the cache-growth-defense narrative in the storyboard preamble — bullet 8's MUST is now partially runtime-graded (the invariant), threshold remains self-attestation.
+
+Coverage extends to #3305's new mutating ops (`build_creative`, `validate_input`) when they land: the phase's `trip_target_task` can be wired to any mutating op the agent declares, but `create_media_buy` is the canonical target in 3.0 and the only one this phase exercises today.
+
+Closes #4547.

--- a/static/compliance/source/test-kits/rate-limit-trip-runner.yaml
+++ b/static/compliance/source/test-kits/rate-limit-trip-runner.yaml
@@ -1,0 +1,172 @@
+# Rate Limit Trip Runner — Harness Contract Test Kit
+#
+# Applies to:
+#   - universal/idempotency.yaml (rate_limit_replay_invariant phase — verifies
+#     that a RATE_LIMITED response on idempotency-cache insert MUST NOT be
+#     cached as the canonical replay for that key, per
+#     L1/security.mdx#idempotency bullet 8 + rule 3 ("Only successful
+#     responses are cached")).
+#   - Any future storyboard that needs to drive a fresh-key burst until a
+#     RATE_LIMITED response appears, then verify a downstream invariant.
+#
+# Storyboards are sequential by default and the storyboard YAML has no
+# loop primitive. This test-kit defines the coordination contract between
+# a runner that can drive a sequential burst of fresh-idempotency-key
+# requests and a storyboard step that needs that capability.
+#
+# The runner's burst happens at the @adcp/client layer (or its Python/Go
+# equivalents) using the SDK's request primitive in a tight sequential
+# loop with a configurable max-attempts ceiling. The storyboard author
+# MUST NOT try to express the burst via separate YAML steps.
+
+id: rate_limit_trip_runner
+applies_to:
+  universals:
+    - idempotency
+
+description: |
+  Coordination contract between a runner that can drive a fresh-key burst
+  until a `RATE_LIMITED` response is observed and a storyboard step that
+  needs to verify the replay invariant on the rate-limited key. The runner
+  fires up to `max_attempts` sequential requests with fresh
+  `idempotency_key` values and otherwise-identical canonical payloads. On
+  the first `RATE_LIMITED` response it captures the request's idempotency
+  key, sleeps `error.details.retry_after` seconds, and then re-submits the
+  same key with the same payload. The cross-step assertion compares the
+  replay response against the rate-limit response and fails if the replay
+  returned the cached `RATE_LIMITED`.
+
+endpoint_scope: sandbox
+# Driving a burst against production would consume rate-limit budget that
+# legitimate traffic relies on and may produce real downstream commitments
+# if any of the sequential requests succeed before the limiter trips.
+# Graders MUST target a sandbox/staging endpoint. Agents claiming the
+# universal SHOULD expose a dedicated grading endpoint whose limiter is
+# configured at the same ceiling as production but whose downstream side
+# effects are sandboxed.
+
+harness_mode: black_box
+
+# --- Trip mechanism ---
+#
+# The runner fires requests sequentially against a single mutating-op
+# target named by the storyboard step. Each request carries a fresh
+# UUID v4 idempotency_key and an otherwise-identical canonical payload.
+# The runner observes each response and stops when one of:
+#
+#   1. A response with envelope error_code = RATE_LIMITED is observed.
+#      The runner captures the request's idempotency_key into the
+#      step's context as `rate_limited_key`, captures the response's
+#      `error.details.retry_after` as `retry_after_seconds`, captures
+#      the rate-limit response body for the replay assertion, and
+#      proceeds to the wait + replay phase.
+#
+#   2. `max_attempts` requests complete without producing RATE_LIMITED.
+#      The runner grades the step as `not_applicable` with reason
+#      `rate_limit_not_triggered` — sellers may legitimately configure
+#      a sandbox limiter at a higher ceiling than this contract's
+#      max_attempts. The remainder of the storyboard is unaffected.
+#
+# Pacing. The runner fires requests as fast as the transport will accept
+# without artificial throttling — the goal is to exceed the seller's
+# configured insert-rate ceiling within max_attempts. Runners MAY use the
+# SDK's connection pooling but MUST NOT batch via parallel_dispatch (that
+# changes the cross-key timing and risks IDEMPOTENCY_IN_FLIGHT noise on
+# parallel paths). Sequential is the simpler shape and matches what
+# attacker-burst traffic would look like.
+
+burst_step_contract:
+  required_step_fields:
+    - rate_limit_trip.trip_target_task
+    - rate_limit_trip.trip_target_sample_request
+    - rate_limit_trip.max_attempts
+  optional_step_fields:
+    - rate_limit_trip.replay_max_wait_seconds
+  max_attempts_min: 50
+  max_attempts_max: 500
+  # 50 ≤ max_attempts ≤ 500. Below 50 won't reliably trip a 60/sec-sustained
+  # limiter even with HTTP/2 multiplexing; above 500 inflates runtime
+  # materially without improving signal. Storyboards SHOULD start at 200
+  # and adjust per observed trip rates in CI.
+
+# --- Wait + replay mechanism ---
+#
+# When a RATE_LIMITED is observed the runner reads
+# `error.details.retry_after` (seconds), waits that long (capped by
+# `rate_limit_trip.replay_max_wait_seconds`, default 30), then re-submits
+# the rate-limited request:
+#
+#   - Same idempotency_key (the one captured at trip time).
+#   - Same canonical payload (the trip_target_sample_request, with the
+#     same `$generate:uuid_v4#alias` resolutions as the trip request).
+#   - A distinct correlation_id so the replay's response is traceable in
+#     runner output.
+#
+# Sellers returning `retry_after` greater than `replay_max_wait_seconds`
+# fail the step on `replay_wait_exceeded` rather than the replay invariant
+# itself — `retry_after` values larger than the runner's wait budget are
+# either a seller-side bug or a production-tuning mismatch with the
+# conformance budget, and either way prevent the invariant from being
+# verified.
+#
+# Sellers returning a `RATE_LIMITED` response without
+# `error.details.retry_after` (or with retry_after = 0) fail with
+# `missing_retry_after` — the retry hint is required to make rate-limit
+# responses actionable, per L1/security.mdx error semantics.
+
+# --- Cross-step assertion ---
+#
+# The runner emits a single structured result with three response objects
+# the storyboard validations[] can target:
+#
+#   trip_response.<path>       The first RATE_LIMITED response observed
+#                              during the burst.
+#   replay_response.<path>     The response to the replay request issued
+#                              after the retry_after wait.
+#   rate_limited_request.idempotency_key
+#                              The key captured at trip time, for traceability.
+#
+# The step's validations declare the invariant against `replay_response`.
+# The minimum required assertion is the not-cached check below; storyboards
+# MAY add further assertions on `replay_response.media_buy_id` (success
+# path) or other handler outputs.
+
+replay_invariant_check_kinds:
+  - replay_not_cached_rate_limit
+
+# `replay_not_cached_rate_limit` semantics: the runner compares
+# `trip_response.error.code` against `replay_response.error.code` (when
+# the replay carries an error envelope) or against the absence of error
+# (when the replay carries a success envelope). If both responses carry
+# error_code = RATE_LIMITED, the replay was served from the idempotency
+# cache and the invariant fails. Any other replay response shape passes
+# the invariant — either the handler succeeded (RATE_LIMITED was not
+# cached, the seller correctly re-executed), or the handler returned a
+# different error (the seller correctly re-executed and a state-dependent
+# error fired).
+
+# --- What the contract does NOT cover ---
+#
+# Burst-volume attestation of the 60/300 req/sec ceiling itself. The
+# contract observes whether the limiter exists and behaves correctly under
+# the replay invariant; it does NOT measure the threshold at which the
+# limiter activates. Threshold attestation is structurally non-deterministic
+# in CI environments (runner CPU, network jitter, agent cold-start) and is
+# better evaluated via operator-side load testing or self-attestation.
+#
+# Cross-scope rate-limit leakage. The contract dispatches all requests
+# within a single (authenticated_agent, account) scope. Storyboards needing
+# to verify that one agent's rate-limit budget does not affect another
+# agent's traffic require a separate contract.
+#
+# RATE_LIMITED on read paths. The contract drives mutating-op traffic
+# (where idempotency caching applies). Sellers MAY also rate-limit read
+# operations, but the replay invariant doesn't apply there — reads are
+# inherently safe to retry.
+
+# --- Reviewer checks ---
+
+reviewer_checks:
+  - "Confirm the seller's idempotency-cache implementation explicitly excludes RATE_LIMITED (and other transient-error) responses from the cached-replay path. Review the storage layer or runbook describing which response classes are persisted under idempotency_key."
+  - "Confirm the seller's rate-limit response carries a usable retry_after value (seconds, integer, > 0, ≤ a documented ceiling). A seller that returns retry_after values larger than buyers' realistic retry windows produces unusable rate-limit signaling."
+  - "Confirm the seller's rate-limit budget is scoped per (authenticated_agent, account) tuple — not shared across all agents or accounts globally — so one agent's burst cannot exhaust another's budget."

--- a/static/compliance/source/universal/idempotency.yaml
+++ b/static/compliance/source/universal/idempotency.yaml
@@ -69,16 +69,22 @@ narrative: |
   validates the supported: true behavior; sellers declaring supported: false
   MUST skip this storyboard (they have no replay window to test).
 
-  **Cache-growth defense (MUST, not yet runtime-graded).** Per
+  **Cache-growth defense (partial runtime grading).** Per
   security.mdx bullet 8 on the idempotency section, sellers MUST apply per-agent
   rate limits on idempotency-cache inserts and MUST return RATE_LIMITED when the
   per-agent insert rate exceeds the configured ceiling. The recommended
   first-deployment ceiling is 60 inserts/sec sustained per agent (3,600/min)
   with burst allowance to 300/sec over rolling 10-second windows. This storyboard
-  does not yet drive the high-volume burst that would exercise the ceiling —
-  runtime grading is tracked as a follow-up once a burst-runner test-kit
-  contract is defined. Sellers SHOULD self-attest to this requirement until the
-  runtime phase lands.
+  does NOT attest the threshold itself — burst-volume measurement is
+  structurally non-deterministic in CI (runner CPU, network jitter, agent
+  cold-start) and better evaluated via operator-side load testing. What it
+  DOES attest, via the `rate_limit_replay_invariant` phase below, is the
+  invariant that matters most for client safety: a `RATE_LIMITED` response on
+  insert MUST NOT be cached as the canonical idempotency replay for that
+  key. Otherwise a client retrying past `retry_after` receives the cached
+  rate-limit error forever, defeating the point of `retry_after`. The
+  threshold (60/300 req/sec) remains seller self-attestation pending
+  operator-side tooling.
 
 agent:
   interaction_model: media_buy_seller
@@ -738,3 +744,118 @@ phases:
             path: "context.correlation_id"
             value: "idempotency--get_media_buys_dedup_check"
             description: "Context correlation_id returned unchanged"
+
+  - id: rate_limit_replay_invariant
+    title: "RATE_LIMITED responses are not cached as idempotency replays"
+    narrative: |
+      Per L1/security.mdx#idempotency rule 3 ("Only successful responses
+      are cached") and bullet 8 (insert-rate ceiling): when the seller's
+      idempotency-cache insert-rate limiter trips and a request receives
+      `RATE_LIMITED`, the response MUST NOT be cached as the canonical
+      replay for that idempotency_key. A buyer retrying with the same key
+      after `error.details.retry_after` elapses MUST observe the real
+      handler result (success or a state-dependent error) — not a cached
+      rate-limit response that would persist for the entire replay TTL.
+
+      Without this invariant, `retry_after` is a meaningless signal: a
+      buyer who hits the limiter once would receive the cached
+      `RATE_LIMITED` on every subsequent retry until the replay window
+      expires, regardless of when the limiter actually cleared. The
+      invariant collapses a real client-safety regression into a
+      cross-response check.
+
+      This phase runs the `expect_rate_limit_not_replayed` task via the
+      `rate_limit_trip_runner` contract. The runner drives a sequential
+      fresh-key burst against `create_media_buy` until one request receives
+      `RATE_LIMITED`, captures that request's `idempotency_key`, waits the
+      response's `retry_after` seconds, then re-submits the captured key
+      with the same payload. The cross-response check
+      `replay_not_cached_rate_limit` fails if the replay response carries
+      `error.code = RATE_LIMITED` (i.e., the cached rate-limit was served
+      as the replay).
+
+      Runners without `rate_limit_trip_runner` skip this phase with a
+      stable `not_applicable` marker. Runners with the contract that
+      exhaust `max_attempts` without observing `RATE_LIMITED` also grade
+      `not_applicable` (reason: `rate_limit_not_triggered`) — a sandbox
+      limiter sitting above the contract's burst ceiling is not a seller
+      conformance fault, only a configuration choice that prevents the
+      invariant from being verified end-to-end.
+
+      The 60/300 req/sec ceiling itself is NOT attested here. Burst-volume
+      measurement is structurally non-deterministic in CI environments and
+      remains seller self-attestation per the cache-growth-defense note
+      above.
+
+    steps:
+      - id: expect_rate_limit_not_replayed
+        title: "Trip the limiter, replay the key after retry_after, assert the cached response is not RATE_LIMITED"
+        narrative: |
+          The runner fires up to `max_attempts` sequential `create_media_buy`
+          requests with fresh UUID v4 idempotency_keys and otherwise-identical
+          canonical payloads. On the first response with envelope error_code
+          = `RATE_LIMITED`, the runner captures the request's
+          `idempotency_key` and the response's `error.details.retry_after`,
+          waits that long (capped by `replay_max_wait_seconds`), and
+          re-submits the captured key with the same payload but a distinct
+          `context.correlation_id` for traceability.
+
+          The cross-response `replay_not_cached_rate_limit` check compares
+          `trip_response.error.code` against `replay_response.error.code`
+          (when the replay carries an error envelope) or against the absence
+          of error (when the replay carries a success envelope). The check
+          fails iff both responses carry `error.code = RATE_LIMITED` — that
+          is the cached-replay regression. Any other replay response shape
+          passes the invariant: either the handler succeeded (the seller
+          correctly re-executed against the cleared budget), or the handler
+          returned a different error (the seller correctly re-executed and
+          a state-dependent error fired).
+
+          The `trip_target_sample_request` below intentionally uses a
+          minimal `create_media_buy` payload — the goal of the burst is to
+          generate insert-rate pressure on the idempotency cache, not to
+          exercise the create flow itself. The replay payload is byte-
+          identical to the trip request to keep the canonical hash stable.
+        task: expect_rate_limit_not_replayed
+        requires_contract: rate_limit_trip_runner
+        rate_limit_trip:
+          trip_target_task: create_media_buy
+          max_attempts: 200
+          replay_max_wait_seconds: 30
+          trip_target_sample_request:
+            account:
+              brand:
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
+            brand:
+              domain: "acmeoutdoor.example"
+            start_time: "2026-07-01T00:00:00Z"
+            end_time: "2026-07-31T23:59:59Z"
+            packages:
+              - product_id: "test-product"
+                budget: 5000
+                pricing_option_id: "test-pricing"
+            context:
+              correlation_id: "idempotency--rate_limit_trip_request"
+        expected: |
+          One of two outcomes:
+
+          - At least one burst request returns `RATE_LIMITED`. The runner
+            captures the request's idempotency_key, waits the response's
+            retry_after, replays the captured key, and the replay response
+            does NOT carry `error.code = RATE_LIMITED`. The
+            `replay_not_cached_rate_limit` check passes.
+
+          - All `max_attempts` requests complete without producing
+            `RATE_LIMITED`. The step grades `not_applicable` with reason
+            `rate_limit_not_triggered`. The rest of the storyboard is
+            unaffected.
+
+        validations:
+          - check: replay_not_cached_rate_limit
+            description: "RATE_LIMITED response on rate-limit trip was not cached as the idempotency replay for the same key"
+
+        reviewer_checks:
+          - "Confirm the seller's idempotency-cache implementation explicitly excludes RATE_LIMITED (and other transient-error) responses from the cached-replay path. Review the storage layer or runbook describing which response classes are persisted under idempotency_key."
+          - "Confirm the seller's RATE_LIMITED response carries a usable retry_after value (seconds, integer, > 0, ≤ a documented ceiling). A seller that returns retry_after values larger than buyers' realistic retry windows produces unusable rate-limit signaling."
+          - "Confirm the seller's rate-limit budget is scoped per (authenticated_agent, account) tuple — not shared across all agents or accounts globally — so one agent's burst cannot exhaust another's budget."

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -61,14 +61,17 @@ authored_check_kinds:
   - upstream_traffic
 
 # Cross-response check kinds — applied across the response set of a
-# step that dispatches multiple parallel requests under the
-# `parallel_dispatch_runner` contract. These kinds are NOT applicable
-# to single-dispatch steps: a runner that applies them per-response
-# produces nonsense (a single response trivially has cardinality 1
-# on any field). Runners MUST gate dispatch of these checks on the
-# step declaring `requires_contract: parallel_dispatch_runner` and a
-# `parallel_dispatch` block; otherwise grade the validation
-# `not_applicable` per the forward-compat clause.
+# step that dispatches multiple requests under a runner contract that
+# produces a structured multi-response observation, today either
+# `parallel_dispatch_runner` (N parallel dispatches with the same
+# idempotency_key) or `rate_limit_trip_runner` (sequential burst +
+# replay). These kinds are NOT applicable to single-dispatch steps: a
+# runner that applies them per-response produces nonsense (a single
+# response trivially has cardinality 1 on any field). Runners MUST gate
+# dispatch of these checks on the step declaring the appropriate
+# `requires_contract:` and its accompanying parameter block
+# (`parallel_dispatch:` or `rate_limit_trip:`); otherwise grade the
+# validation `not_applicable` per the forward-compat clause.
 #
 # The `lint-storyboard-check-enum.cjs` lint reads BOTH this list and
 # `authored_check_kinds` as the canonical published-time enum, so
@@ -76,6 +79,7 @@ authored_check_kinds:
 cross_response_check_kinds:
   - cross_response_field_equal
   - cross_response_count_distinct
+  - replay_not_cached_rate_limit
 
 # Conforming implementation: adcp-client PR #611
 # (src/lib/testing/storyboard/types.ts — RunnerRequestRecord,

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -1767,6 +1767,42 @@
 #   http_status | content_type | size_exceeded | redirect_returned |
 #   ssrf_blocked | fetch_timeout).
 #
+# task: expect_rate_limit_not_replayed
+#   Assert that a `RATE_LIMITED` response on idempotency-cache insert MUST NOT
+#   be cached as the canonical replay for that idempotency_key, per
+#   L1/security.mdx#idempotency rule 3 ("Only successful responses are cached")
+#   and bullet 8 (insert-rate ceiling). The runner drives a sequential fresh-
+#   key burst against the named mutating-op target until a RATE_LIMITED
+#   response appears, then re-submits the same idempotency_key after waiting
+#   `error.details.retry_after` seconds. The cross-step assertion fails if the
+#   replay returned the cached RATE_LIMITED response shape.
+#
+#   When `max_attempts` requests complete without producing a RATE_LIMITED
+#   response, the step grades as `not_applicable` with reason
+#   `rate_limit_not_triggered` — a seller's sandbox limiter may legitimately
+#   sit above the contract's burst ceiling. Runner delegates the burst,
+#   wait, and replay mechanics to the `@adcp/client` RateLimitTripObserver
+#   primitive (see test-kit rate-limit-trip-runner.yaml).
+#
+#   Fields:
+#     rate_limit_trip:
+#       trip_target_task: "<task name, e.g. create_media_buy>"
+#                                       # the mutating-op the burst targets
+#       trip_target_sample_request: { ... }
+#                                       # full canonical request body; the runner
+#                                       # rewrites `idempotency_key` per attempt
+#                                       # and on the replay reuses the captured key
+#       max_attempts: 200               # 50–500; see test-kit max_attempts bounds
+#       replay_max_wait_seconds: 30     # optional; caps the post-trip wait. Sellers
+#                                       # returning retry_after > this fail with
+#                                       # `replay_wait_exceeded` rather than the
+#                                       # invariant itself.
+#     requires_contract: rate_limit_trip_runner
+#
+#   Error modes: rate_limit_response_cached_as_replay,
+#   missing_retry_after, replay_wait_exceeded, rate_limit_not_triggered
+#   (the not_applicable case, surfaced for runner output transparency).
+#
 # --- shared_receiver (deferred / out of scope v1) ---
 #
 # Storyboards with multiple webhook-triggering steps MUST use per-step receiver


### PR DESCRIPTION
## Summary

Per L1/security.mdx#idempotency rule 3 ("Only successful responses are cached") and bullet 8 (insert-rate ceiling): a `RATE_LIMITED` response on idempotency-cache insert MUST NOT be cached as the canonical replay for that key. Without this invariant, `retry_after` is meaningless — a buyer retrying past the hint receives the cached error forever, regardless of when the limiter actually cleared.

This PR adds runtime grading for that invariant. Burst-volume attestation of the 60/300 req/sec threshold remains seller self-attestation — structurally non-deterministic in CI environments (runner CPU, network jitter, agent cold-start) per the #2615 close.

## Changes

- **`static/compliance/source/test-kits/rate-limit-trip-runner.yaml`** (new) — coordination contract for runners that can drive a sequential fresh-key burst until `RATE_LIMITED` appears, capture the request's `idempotency_key`, sleep `error.details.retry_after`, and replay the captured key with the same payload. `max_attempts` bounded 50–500.
- **`static/compliance/source/universal/storyboard-schema.yaml`** — documents new `task: expect_rate_limit_not_replayed` with field shape, contract dependency, and error modes (`rate_limit_response_cached_as_replay`, `missing_retry_after`, `replay_wait_exceeded`, `rate_limit_not_triggered`).
- **`static/compliance/source/universal/runner-output-contract.yaml`** — registers new cross-response check kind `replay_not_cached_rate_limit`. Comment block updated to mention the rate-limit-trip use case alongside parallel_dispatch.
- **`static/compliance/source/universal/idempotency.yaml`** — new phase `rate_limit_replay_invariant` at the end of the storyboard, single step exercising the contract against `create_media_buy` with `max_attempts: 200` / `replay_max_wait_seconds: 30`. Cache-growth-defense narrative updated — bullet 8's MUST is now partially runtime-graded.

## Behavior

| Outcome | Grade |
|---|---|
| At least one burst request returns `RATE_LIMITED`; replay does NOT carry `error.code = RATE_LIMITED` | **PASS** (invariant verified) |
| Both trip and replay carry `error.code = RATE_LIMITED` | **FAIL** (`rate_limit_response_cached_as_replay`) |
| All `max_attempts` requests complete without `RATE_LIMITED` | **not_applicable** (`rate_limit_not_triggered`) — sandbox limiter sits above the contract's burst ceiling, not a conformance fault |
| Runner doesn't advertise `rate_limit_trip_runner` | **not_applicable** (contract not in scope) |

## Forward compatibility

When #3305's new mutating ops (`build_creative`, `validate_input`) land, the phase's `trip_target_task` can be wired to any mutating op the agent declares. `create_media_buy` is the canonical target in 3.0 and the only one this phase exercises today.

## Test plan

- [x] `npm run build:compliance` passes all lints (check-enum lint accepts the new `replay_not_cached_rate_limit`)
- [x] Typecheck passes
- [ ] Reference runner implementation in `@adcp/client` (separate PR, tracked when the runner team picks this up)

Closes #4547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)