### PR TITLE
feat(schema): extend three-shape submitted envelope to sync_audiences (refs #2435)

### DIFF
--- a/.changeset/2435-sync-audiences-submitted-envelope.md
+++ b/.changeset/2435-sync-audiences-submitted-envelope.md
@@ -1,0 +1,23 @@
+---
+"adcontextprotocol": minor
+---
+
+spec(media-buy): extend three-shape submitted envelope to `sync_audiences`.
+
+PR #2434 established the three-shape (`success | error | submitted`) response pattern on `sync_creatives` for operations whose ingestion may be queued before per-item results can be returned. `sync_audiences` is the next natural fit — audience matching is classically asynchronous (`capabilities.audience_targeting.matching_latency_hours` already declares it), and sellers whose pipeline batches ingestion, gates the upload behind governance review, or routes through an upstream clean-room cannot return the per-audience `audiences` array before the response is emitted.
+
+`SyncAudiencesSubmitted` mirrors `SyncCreativesSubmitted` exactly: top-level `status: "submitted"` + `task_id`, optional `message`, optional advisory `errors[]`, no `audiences` array on the envelope. The synchronous success branch is tightened with the same triple-`not` guard (`errors`, `task_id`, `status: submitted`) so the three shapes are unambiguously mutually exclusive — preserving the structural parser invariant from adcp-client#649 across all three-shape `sync_*` responses.
+
+This is purely additive on the success/error arms — per-audience asynchronous matching (an audience reported with `status: "processing"` while the rest of the sync resolves synchronously) continues to belong on the synchronous success branch via the existing `audience-status` enum; the submitted envelope is the less-common operation-level async case.
+
+Files:
+- `static/schemas/source/media-buy/sync-audiences-response.json` — third `SyncAudiencesSubmitted` arm; success/error arms tightened to forbid `task_id` / `status: submitted` so the discriminated union is mutually exclusive.
+- `docs/media-buy/task-reference/sync_audiences.mdx` — `## Response shapes` documents the three branches; quick-start examples updated to discriminate `submitted` before reading `audiences`; new `## Async patterns` section names the per-audience-async vs operation-level-async distinction.
+- `scripts/oneof-discriminators.baseline.json` — variant count bumped to 3.
+
+`sync_accounts` and `sync_event_sources` were considered for the same treatment and deliberately left synchronous:
+
+- `sync_accounts` — per-item `action` + `status` already cover the realistic async-of-records cases; no operation-level async pattern needed.
+- `sync_event_sources` — deferred pending implementer input on whether seller-side validation of stream endpoints is a real latency source (filed as a follow-up RFC).
+
+Closes #2435.

--- a/docs/media-buy/task-reference/sync_audiences.mdx
+++ b/docs/media-buy/task-reference/sync_audiences.mdx
@@ -10,7 +10,7 @@ Manage first-party CRM audiences on a seller account. Upload hashed customer lis
 
 Audiences are distinct from [signals](/docs/signals/): signals are third-party data products you discover and activate; audiences are data you own and upload. Use `audience_include` to target only members of an uploaded list. `audience_include` is a hard constraint — only users on the list are eligible. To find new users *similar to* an audience (lookalike expansion), describe that intent in your campaign brief — the seller handles expansion strategy. Note: lookalike intent expressed in the brief cannot be verified through the protocol; confirm via seller-side reporting.
 
-**Response Time**: Upload accepted in ~1–2s. The task remains active until matching completes (1–48 hours depending on the seller). Configure `push_notification_config` to receive a webhook when the audience is ready.
+**Response Time**: Upload accepted in ~1–2s. Per-audience matching is asynchronous — the task remains active until matching completes (1–48 hours depending on the seller). Configure `push_notification_config` to receive a webhook when the audience is ready. Sellers whose ingestion pipeline cannot return per-audience results in the synchronous response (batch ingestion, governance-gated upload, clean-room flows) MAY respond with an operation-level submitted task envelope — see [Response shapes](#response-shapes).
 
 **Request Schema**: [`/schemas/v3/media-buy/sync-audiences-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/sync-audiences-request.json)
 **Response Schema**: [`/schemas/v3/media-buy/sync-audiences-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/sync-audiences-response.json)
@@ -52,11 +52,13 @@ if (!result.success) {
 
 const validated = SyncAudiencesResponseSchema.parse(result.data);
 
-if ("errors" in validated && validated.errors) {
+// Three-shape discriminated union: errors | submitted | audiences
+if ("status" in validated && validated.status === "submitted") {
+  // Whole sync queued asynchronously — poll tasks/get with task_id or await webhook
+  console.log(`Sync queued as task ${validated.task_id}: ${validated.message ?? ""}`);
+} else if ("errors" in validated && validated.errors && !("audiences" in validated)) {
   throw new Error(`Operation failed: ${JSON.stringify(validated.errors)}`);
-}
-
-if ("audiences" in validated) {
+} else if ("audiences" in validated) {
   for (const audience of validated.audiences) {
     console.log(`${audience.audience_id}: ${audience.action} (${audience.status ?? "n/a"})`);
     if (audience.status === "ready") {
@@ -90,7 +92,13 @@ async def main():
         }]
     )
 
-    if hasattr(result, 'errors') and result.errors:
+    # Three-shape discriminated union: errors | submitted | audiences
+    if getattr(result, 'status', None) == 'submitted':
+        # Whole sync queued asynchronously — poll tasks/get with task_id or await webhook
+        print(f"Sync queued as task {result.task_id}: {getattr(result, 'message', '') or ''}")
+        return
+
+    if getattr(result, 'errors', None) and not getattr(result, 'audiences', None):
         raise Exception(f"Operation failed: {result.errors}")
 
     for audience in result.audiences:
@@ -142,17 +150,26 @@ Providing multiple identifiers for the same person improves match rates. Composi
 
 **Concurrency**: Ensure that calls made to `sync_audience` are independent of eachother. They may be processed out-of-order. If you need sequential execution, wait for the callback to your configured webhook before making another call. 
 
-## Response
+## Response shapes
 
-**Success Response:**
+Responses use discriminated unions — a response has exactly one of three shapes, never mixed:
+
+**1. Synchronous success** — per-audience results:
 
 - `audiences` — Results for each audience on the account, including audiences not in this request
+- `sandbox` — Boolean indicating if this response is from sandbox mode (optional)
 
-**Error Response:**
+**2. Terminal failure** — no audiences processed:
 
-- `errors` — Array of operation-level errors (auth failure, account not found)
+- `errors` — Array of operation-level errors (auth failure, account not found, invalid request format)
 
-**Note:** Responses use discriminated unions — you get either success fields OR errors, never both.
+**3. Submitted task envelope** — whole operation queued asynchronously (batch ingestion, governance-gated upload, clean-room flows where the seller cannot return per-audience results before the response is emitted):
+
+- `status` — Always `"submitted"`
+- `task_id` — Handle for polling via `tasks/get` or receiving a webhook on completion
+- `message` — Optional human-readable explanation of the queue state
+
+The final per-audience `audiences` array lands on the task completion artifact, not on the submitted envelope. Per-audience asynchronous matching (one audience in `processing` while the rest of the sync resolves synchronously) belongs on the synchronous success branch with `status: "processing"` on that item, not on the submitted envelope. Matching latency on the per-audience [audience-status](#audience-status) enum is the common case; the submitted envelope is for the less-common operation-level async case.
 
 **Each audience in success response includes:**
 
@@ -502,6 +519,22 @@ Sellers MUST emit `too_small` whenever `matched_count < minimum_size`. Returning
 **Polling fallback**: If not using webhooks, poll with discovery-only calls (omit `audiences`) no more frequently than every 15 minutes. Use `tasks/get` with the `task_id` to check task status — the task will be `submitted` while matching is in progress and `completed` when the audience is ready or too small.
 
 **Agent workflow**: Upload with `push_notification_config` set. Externalize the `audience_id` and `account_id` before the session ends. When the webhook fires with `status: "ready"`, resume and proceed to `create_media_buy`.
+
+## Async patterns
+
+Two distinct async patterns — match the right one to the seller's behavior:
+
+**Per-audience async matching** (common): the sync operation itself resolves synchronously and returns per-audience results immediately. Audiences whose matching is still running come back on the synchronous success response with `status: "processing"`. The buyer reconciles terminal state (`ready` / `too_small`) via subsequent discovery-only calls or a webhook. This is the case covered by the [Audience Status](#audience-status) enum above.
+
+**Operation-level async** (less common): the whole sync is queued — the seller cannot return any per-audience results before responding, because ingestion is batched, governance review gates the upload, or an upstream clean-room flow must settle before matching can start. The response is a submitted envelope:
+
+- Top-level `status: "submitted"` with `task_id`
+- `message` — optional human-readable explanation
+- No `audiences` array on this envelope
+
+Poll `tasks/get` or wait for the webhook. The completion artifact carries the `audiences` array with per-item `action`/`status` results; operation-level failures surface as `status: "failed"` on the task.
+
+**See:** [Webhooks](/docs/building/implementation/webhooks) for webhook configuration.
 
 ## Hashing Requirements
 

--- a/scripts/oneof-discriminators.baseline.json
+++ b/scripts/oneof-discriminators.baseline.json
@@ -238,8 +238,8 @@
     },
     "media-buy/sync-audiences-response.json##/oneOf": {
       "kind": "narrowable",
-      "variants": 2,
-      "note": "0:[audiences] | 1:[errors]"
+      "variants": 3,
+      "note": "0:[audiences] | 1:[errors] | 2:[status,task_id]"
     },
     "media-buy/sync-catalogs-response.json##/oneOf": {
       "kind": "narrowable",

--- a/static/schemas/source/media-buy/sync-audiences-response.json
+++ b/static/schemas/source/media-buy/sync-audiences-response.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/media-buy/sync-audiences-response.json",
   "title": "Sync Audiences Response",
-  "description": "Response from audience sync operation. Returns either per-audience results OR operation-level errors.",
+  "description": "Response from audience sync operation. Exactly one of three shapes: (1) synchronous success — per-audience results in the audiences array (best-effort processing with per-item status/failures); (2) terminal failure — errors array with no audiences processed; (3) submitted task envelope — status 'submitted' with task_id when the whole operation is queued (batch ingestion, governance-gated upload, or any flow where the seller cannot return per-audience results before the response is emitted). The submitted branch MAY carry advisory errors for non-blocking warnings; terminal failures belong in the error branch. Final per-audience results land on the task completion artifact, not this envelope. Per-audience asynchronous matching (an audience reported with status 'processing' while the rest of the sync resolves synchronously) belongs on the synchronous success branch via audience-status, NOT here — operation-level async is for when the seller has no per-item results to return yet. These three shapes are mutually exclusive — a response has exactly one.",
   "type": "object",
   "allOf": [
     {
@@ -12,7 +12,7 @@
   "oneOf": [
     {
       "title": "SyncAudiencesSuccess",
-      "description": "Success response - sync operation processed audiences",
+      "description": "Success response - sync operation processed audiences (may include per-item failures)",
       "type": "object",
       "properties": {
         "audiences": {
@@ -148,19 +148,38 @@
       ],
       "additionalProperties": true,
       "not": {
-        "required": [
-          "errors"
+        "anyOf": [
+          {
+            "required": [
+              "errors"
+            ]
+          },
+          {
+            "required": [
+              "task_id"
+            ]
+          },
+          {
+            "properties": {
+              "status": {
+                "const": "submitted"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          }
         ]
       }
     },
     {
       "title": "SyncAudiencesError",
-      "description": "Error response - operation failed completely",
+      "description": "Error response - operation failed completely, no audiences were processed",
       "type": "object",
       "properties": {
         "errors": {
           "type": "array",
-          "description": "Operation-level errors that prevented processing",
+          "description": "Operation-level errors that prevented processing any audiences (e.g., authentication failure, account not found, invalid request format)",
           "items": {
             "$ref": "/schemas/core/error.json"
           },
@@ -188,7 +207,67 @@
             "required": [
               "sandbox"
             ]
+          },
+          {
+            "required": [
+              "task_id"
+            ]
+          },
+          {
+            "properties": {
+              "status": {
+                "const": "submitted"
+              }
+            },
+            "required": [
+              "status"
+            ]
           }
+        ]
+      }
+    },
+    {
+      "title": "SyncAudiencesSubmitted",
+      "description": "Async task envelope returned when the whole sync operation cannot be confirmed before the response is emitted — for example, when the seller batches ingestion, when governance review gates the upload before matching can start, or when an upstream clean-room flow needs to settle before any per-audience result can be issued. The buyer polls tasks/get with task_id or receives a webhook when the task completes; the audiences array with per-item action/status lands on the completion artifact, not this envelope. Per-audience asynchronous matching (one audience in 'processing' while the rest of the sync resolves synchronously) belongs on the SyncAudiencesSuccess branch with status: processing on that item, not here. Matching latency on the per-audience status enum (processing → ready / too_small) is the common case; this envelope is the less-common operation-level case.",
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "const": "submitted",
+          "description": "Task-level status literal. Discriminates this async envelope from the synchronous success shape, whose audiences array carries per-item matching state via audience-status. See task-status.json for the full task-status enum."
+        },
+        "task_id": {
+          "type": "string",
+          "description": "Task handle the buyer uses with tasks/get, and that the seller references on push-notification callbacks. The audiences array is issued on the completion artifact, not here. Per AdCP wire conventions this is snake_case; A2A adapters MAY surface it as taskId, but the payload field emitted by the agent is task_id.",
+          "x-entity": "task"
+        },
+        "message": {
+          "type": "string",
+          "maxLength": 2000,
+          "description": "Optional human-readable explanation of why the task is submitted — e.g., 'Batch ingestion queued; typical turnaround 15-30 minutes.' Plain text only. Buyers MUST treat this as untrusted seller input: escape before rendering to HTML UIs, and sanitize or isolate before passing to an LLM prompt context — a hostile seller may inject prompt-injection payloads aimed at the buyer's agent."
+        },
+        "errors": {
+          "type": "array",
+          "description": "Optional advisory errors accompanying the submitted envelope. Use only for non-blocking warnings (e.g., throttled_severity advisories, governance observations). Terminal failures belong in the error branch, not here.",
+          "items": {
+            "$ref": "/schemas/core/error.json"
+          }
+        },
+        "context": {
+          "$ref": "/schemas/core/context.json"
+        },
+        "ext": {
+          "$ref": "/schemas/core/ext.json"
+        }
+      },
+      "required": [
+        "status",
+        "task_id"
+      ],
+      "additionalProperties": true,
+      "not": {
+        "required": [
+          "audiences"
         ]
       }
     }


### PR DESCRIPTION
## Summary

Extends the three-shape (`success | error | submitted`) response pattern established on `sync_creatives` by PR #2434 (closes #2428) to `sync_audiences`. Audience matching is classically asynchronous — `capabilities.audience_targeting.matching_latency_hours` already declares it — and sellers whose pipeline batches ingestion, gates the upload behind governance review, or routes through an upstream clean-room cannot return per-audience results before the response is emitted. The submitted envelope gives them a wire shape for that case without forcing per-item fabrication.

`SyncAudiencesSubmitted` mirrors `SyncCreativesSubmitted` exactly:

- Top-level `status: "submitted"` + `task_id`
- Optional `message`, optional advisory `errors[]`
- No `audiences` array on the envelope (per-item results land on the task completion artifact)
- Triple-`not` guard (`errors`, `task_id`, `status: submitted`) on the success arm and a parallel `not` block on the error arm, so the three shapes are unambiguously mutually exclusive — preserving the structural parser invariant from adcp-client#649 across all three-shape `sync_*` responses.

Per-audience asynchronous matching (an audience reported with `status: "processing"` while the rest of the sync resolves synchronously) stays on the synchronous success branch via the existing `audience-status` enum. The submitted envelope is for the less-common operation-level async case where no per-item results can be returned yet.

## Sibling-operation decisions (refs #2435)

| Operation | Decision | Rationale |
|---|---|---|
| `sync_audiences` | **EXTENDED** in this PR | Matching is async; capabilities already declares it. Operation-level async is a real scenario. |
| `sync_accounts` | **NOT EXTENDED** | Per-item `action` + `status` already cover the realistic cases. No operation-level async pattern needed. |
| `sync_event_sources` | **DEFERRED** — implementer input needed | Filed as a follow-up RFC. Open question: is seller-side validation of stream endpoints a real latency source? |
| `activate_signal` | **OUT OF SCOPE** | Explicitly 4.0 per the issue body. |

## Files

- `static/schemas/source/media-buy/sync-audiences-response.json` — third `SyncAudiencesSubmitted` arm; success/error arms tightened so the discriminated union is mutually exclusive.
- `docs/media-buy/task-reference/sync_audiences.mdx` — `## Response shapes` documents the three branches; quick-start examples updated to discriminate `submitted` before reading `audiences`; new `## Async patterns` section names the per-audience-async vs operation-level-async distinction.
- `scripts/oneof-discriminators.baseline.json` — variant count bumped to 3.
- `.changeset/2435-sync-audiences-submitted-envelope.md` — minor bump.

## Test plan

- [x] `npm run build:schemas` — clean (525 schemas, 81 bundled)
- [x] `npm run test:schemas` — all 7 schema-validation tests pass
- [x] `npm run test:composed` — 43/43 (discriminated-union shape compiles)
- [x] `npm run test:oneof-discriminators` — clean (no new undiscriminated oneOfs)
- [x] `npm run test:json-schema` — 260/260 in-doc JSON blocks with `$schema` pass
- [x] `npm run test:examples` — 36/36
- [x] `npm run test:rejection-arm-mutex` — 4/4
- [x] `npm run test:storyboard-response-schema` — 6/6
- [x] `npm run test:storyboard-doc-parity` — 10/10
- [x] `npm run test:unit` — 887/887
- [x] `npm run typecheck` — clean

Closes #2435. Builds on #2428 / PR #2434.

🤖 Generated with [Claude Code](https://claude.com/claude-code)