### PR TITLE
feat(registry): support ?scope=public on /api/registry/operator

### DIFF
--- a/.changeset/registry-operator-scope-buckets.md
+++ b/.changeset/registry-operator-scope-buckets.md
@@ -1,0 +1,4 @@
+---
+---
+
+`/api/registry/operator` accepts an optional `?scope=public|member|private|all` query parameter to opt INTO a specific visibility bucket. `scope` is a narrowing filter — it can never escalate beyond what the caller's auth admits (e.g. `scope=member` from an explorer/anonymous caller silently returns public only; `scope=private` from a non-owner returns empty). Default behavior (no param, or `scope=all`) is unchanged — tier-aware union of public + members_only (API-tier members) + private (profile owner).

--- a/.changeset/registry-operator-scope-buckets.md
+++ b/.changeset/registry-operator-scope-buckets.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-`/api/registry/operator` accepts an optional `?scope=public|member|private|all` query parameter to opt INTO a specific visibility bucket. `scope` is a narrowing filter — it can never escalate beyond what the caller's auth admits (e.g. `scope=member` from an explorer/anonymous caller silently returns public only; `scope=private` from a non-owner returns empty). Default behavior (no param, or `scope=all`) is unchanged — tier-aware union of public + members_only (API-tier members) + private (profile owner).
+`/api/registry/operator` accepts an optional `?scope=public|member|private|all` query parameter to opt INTO a specific visibility bucket. `scope` is a narrowing filter — it can never escalate beyond what the caller's auth admits (e.g. `scope=member` from an explorer/anonymous caller silently returns public only; `scope=private` from a non-owner returns empty). Unknown scope values return 400 rather than silently coercing to `all`. Default behavior (no param, or `scope=all`) is unchanged — tier-aware union of public + members_only (API-tier members) + private (profile owner).

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -756,6 +756,11 @@ registry.registerPath({
     "Authenticated callers on an AAO membership tier with API access also see `members_only` agents. " +
     "Profile owners (callers whose org owns the queried domain) additionally see `private` agents. " +
     "This is the primary mechanism by which AAO membership unlocks deeper registry visibility.\n\n" +
+    "**`scope` bucket filter.** Callers can opt INTO a single visibility bucket (or the full " +
+    "union) regardless of what their auth would otherwise unlock — useful for picker UIs that " +
+    "want exactly one slice (e.g. anonymous-equivalent, members-only catalog, owner's private " +
+    "drafts). `scope` only narrows; it never escalates (e.g. `scope=member` on an explorer or " +
+    "anonymous caller silently returns public only).\n\n" +
     "**Member level visibility.** When the profile owner has set their member card to public " +
     "(`is_public=true`), the `member` object additionally carries `is_founding_member` (boolean) " +
     "plus `membership_tier` (raw enum) and `membership_tier_label` (e.g. `Professional`, `Partner`, " +
@@ -765,6 +770,20 @@ registry.registerPath({
   request: {
     query: z.object({
       domain: z.string().openapi({ example: "pubmatic.com" }),
+      scope: z.enum(["public", "member", "private", "all"]).optional().openapi({
+        description:
+          "Visibility bucket filter for returned agents. One value per agent-visibility enum " +
+          "value plus a catch-all. Each bucket is still gated by auth — `scope` can only narrow, " +
+          "never escalate.\n\n" +
+          "- `public` → only `visibility=public` agents.\n" +
+          "- `member` → public + members_only (members_only is gated on caller's tier; anonymous " +
+          "or explorer-tier callers silently fall through to public-only rather than 403).\n" +
+          "- `private` → only `visibility=private`. Private agents are visible only to the profile " +
+          "owner; non-owners get an empty list.\n" +
+          "- Omitted or `all` → tier-aware full unlock: public + members_only for API-tier " +
+          "members + private for the profile owner.",
+        example: "member",
+      }),
     }),
   },
   responses: {
@@ -6080,11 +6099,36 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
 
       const callerOrgId = await resolveCallerOrgId(req);
 
-      let includeMembersOnly = false;
-      if (callerOrgId) {
+      // `scope` is a narrowing filter — it picks WHICH visibility buckets the
+      // caller wants, but each bucket is still gated by auth (it can never
+      // escalate). Four values, one per agent-visibility enum value plus a
+      // catch-all:
+      //   - `public`  → only visibility=public
+      //   - `member`  → public + members_only (members_only still tier-gated,
+      //                 so anonymous/explorer callers silently fall through to
+      //                 public only rather than 403'ing)
+      //   - `private` → only visibility=private (only the profile owner can
+      //                 see private agents; non-owners get an empty list)
+      //   - omitted / `all` → tier-aware full unlock (public + members_only
+      //                 for API-tier members + private for the profile owner)
+      const rawScope = (req.query.scope as string | undefined)?.toLowerCase();
+      const scope: 'public' | 'member' | 'private' | 'all' =
+        rawScope === 'public' || rawScope === 'member' || rawScope === 'private' || rawScope === 'all'
+          ? rawScope
+          : 'all';
+
+      // Which buckets the scope param asks for, before auth gating.
+      const scopeAllowsPublic = scope === 'public' || scope === 'member' || scope === 'all';
+      const scopeAllowsMembersOnly = scope === 'member' || scope === 'all';
+      const scopeAllowsPrivate = scope === 'private' || scope === 'all';
+
+      // Tier check is only worth running if the scope could plausibly admit
+      // members_only — otherwise the org lookup is wasted work.
+      let callerHasApiAccess = false;
+      if (scopeAllowsMembersOnly && callerOrgId) {
         const org = await orgDb.getOrganization(callerOrgId);
         if (org && hasApiAccess(resolveMembershipTier(org))) {
-          includeMembersOnly = true;
+          callerHasApiAccess = true;
         }
       }
 
@@ -6092,11 +6136,15 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         callerOrgId && profile?.workos_organization_id && profile.workos_organization_id === callerOrgId
       );
 
+      const allowPublic = scopeAllowsPublic;
+      const allowMembersOnly = scopeAllowsMembersOnly && callerHasApiAccess;
+      const allowPrivate = scopeAllowsPrivate && isProfileOwner;
+
       const displayName = profile?.display_name || domain;
       const agentConfigs = (profile?.agents || []).filter(a => {
-        if (a.visibility === 'public') return true;
-        if (includeMembersOnly && a.visibility === 'members_only') return true;
-        if (isProfileOwner && a.visibility === 'private') return true;
+        if (allowPublic && a.visibility === 'public') return true;
+        if (allowMembersOnly && a.visibility === 'members_only') return true;
+        if (allowPrivate && a.visibility === 'private') return true;
         return false;
       }).slice(0, 20);
 

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -781,14 +781,16 @@ registry.registerPath({
           "- `private` → only `visibility=private`. Private agents are visible only to the profile " +
           "owner; non-owners get an empty list.\n" +
           "- Omitted or `all` → tier-aware full unlock: public + members_only for API-tier " +
-          "members + private for the profile owner.",
+          "members + private for the profile owner.\n\n" +
+          "Unknown values return 400 — a silent coerce to `all` could leak data the caller " +
+          "explicitly tried to scope away from.",
         example: "member",
       }),
     }),
   },
   responses: {
     200: { description: "Operator lookup result", content: { "application/json": { schema: OperatorLookupResultSchema } } },
-    400: { description: "Missing domain", content: { "application/json": { schema: ErrorSchema } } },
+    400: { description: "Missing or invalid domain, or unknown scope value", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
 
@@ -6062,6 +6064,20 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       if (!isValidDomain(domain)) {
         return res.status(400).json({ error: "Invalid domain" });
       }
+      // Validate `scope` before doing any DB work. Unknown values are
+      // rejected rather than silently coerced — a typo like `?scope=membr`
+      // would otherwise return the full union (the opposite of what the
+      // caller asked for) and there's no header to surface the swap.
+      const rawScopeQuery = req.query.scope;
+      if (rawScopeQuery !== undefined && typeof rawScopeQuery !== 'string') {
+        return res.status(400).json({ error: "Invalid scope: must be a string" });
+      }
+      const rawScopeLower = rawScopeQuery?.toLowerCase();
+      if (rawScopeLower !== undefined && !['public', 'member', 'private', 'all'].includes(rawScopeLower)) {
+        return res.status(400).json({
+          error: "Invalid scope: must be one of public, member, private, all",
+        });
+      }
       const memberDb = new MemberDatabase();
       const federatedIndex = crawler.getFederatedIndex();
 
@@ -6111,11 +6127,10 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       //                 see private agents; non-owners get an empty list)
       //   - omitted / `all` → tier-aware full unlock (public + members_only
       //                 for API-tier members + private for the profile owner)
-      const rawScope = (req.query.scope as string | undefined)?.toLowerCase();
+      // Unknown values were rejected above; only the four literals (or
+      // undefined) reach this point.
       const scope: 'public' | 'member' | 'private' | 'all' =
-        rawScope === 'public' || rawScope === 'member' || rawScope === 'private' || rawScope === 'all'
-          ? rawScope
-          : 'all';
+        (rawScopeLower as 'public' | 'member' | 'private' | 'all' | undefined) ?? 'all';
 
       // Which buckets the scope param asks for, before auth gating.
       const scopeAllowsPublic = scope === 'public' || scope === 'member' || scope === 'all';

--- a/server/tests/integration/registry-reader-baseline-public-endpoints.test.ts
+++ b/server/tests/integration/registry-reader-baseline-public-endpoints.test.ts
@@ -35,24 +35,43 @@ vi.hoisted(() => {
 });
 
 // Bypass WorkOS auth — the registry feed requires `requireAuth`. Stamp
-// every request with a fixed test user. Other public registry endpoints
-// use `optAuth` (no-op without a session), so the pass-through here is
-// only load-bearing for /registry/feed.
-const TEST_USER_ID = 'user_test_registry_baseline_endpoints';
+// every requireAuth request with a fixed default test user. Other public
+// registry endpoints use `optAuth` (no-op without a session), which the
+// real implementation leaves alone; we follow suit by default so the
+// existing baseline assertions keep their anonymous-caller behavior.
+//
+// The scope-matrix tests below swap callers per request via
+// `setOptAuthUser(...)` — that lets us exercise the auth × scope filter
+// matrix without rebuilding the route's dependency graph.
+const DEFAULT_TEST_USER_ID = 'user_test_registry_baseline_endpoints';
+const authState = vi.hoisted(() => ({
+  optAuthUser: null as { id: string; email: string } | null,
+}));
 vi.mock('../../src/middleware/auth.js', async () => {
   const actual = await vi.importActual<Record<string, unknown>>(
     '../../src/middleware/auth.js'
   );
-  const pass = (req: { user: unknown }, _res: unknown, next: () => void) => {
-    req.user = { id: TEST_USER_ID, email: 'registry-baseline@test.com' };
+  const requireAuthPass = (req: { user: unknown }, _res: unknown, next: () => void) => {
+    req.user = { id: DEFAULT_TEST_USER_ID, email: 'registry-baseline@test.com' };
+    next();
+  };
+  const optAuthPass = (req: { user: unknown }, _res: unknown, next: () => void) => {
+    if (authState.optAuthUser) {
+      req.user = authState.optAuthUser;
+    }
     next();
   };
   return {
     ...actual,
-    requireAuth: pass,
+    requireAuth: requireAuthPass,
+    optionalAuth: optAuthPass,
     requireAdmin: (_req: unknown, _res: unknown, next: () => void) => next(),
   };
 });
+
+function setOptAuthUser(user: { id: string; email: string } | null) {
+  authState.optAuthUser = user;
+}
 
 vi.mock('../../src/middleware/csrf.js', async () => {
   const actual = await vi.importActual<Record<string, unknown>>(
@@ -768,6 +787,223 @@ describe('Registry reader baseline — public endpoints', () => {
     it('rejects an invalid cursor format with 400', async () => {
       const res = await request(app).get('/api/registry/feed?cursor=not-a-uuid');
       expect(res.status).toBe(400);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // /registry/operator ?scope= filter × auth-tier matrix.
+  //
+  // `scope` only narrows what auth would otherwise unlock — never
+  // escalates. The 12-cell matrix below pins one assertion per cell so
+  // a future refactor that quietly inverts a row (e.g. lets `scope=member`
+  // expose members_only to anonymous callers) flips red.
+  // ──────────────────────────────────────────────────────────────────
+
+  describe('/registry/operator ?scope= × auth tier matrix', () => {
+    const SCOPE_DOMAIN = 'endpoint-scope-matrix.registry-baseline.example';
+    const SCOPE_OWNER_ORG = 'org_endpoint_scope_owner';
+    const SCOPE_OTHER_API_ORG = 'org_endpoint_scope_other_api';
+    const SCOPE_EXPLORER_ORG = 'org_endpoint_scope_explorer';
+    const SCOPE_OWNER_USER = 'user_endpoint_scope_owner';
+    const SCOPE_OTHER_API_USER = 'user_endpoint_scope_other_api';
+    const SCOPE_EXPLORER_USER = 'user_endpoint_scope_explorer';
+    const SCOPE_SLUG = 'endpoint-scope-matrix';
+
+    const PUBLIC_URL = 'https://public.scope-matrix.example';
+    const MEMBERS_URL = 'https://members.scope-matrix.example';
+    const PRIVATE_URL = 'https://private.scope-matrix.example';
+
+    async function seedOrg(orgId: string, tier: string | null) {
+      await pool.query(
+        `INSERT INTO organizations (
+           workos_organization_id, name, is_personal, membership_tier,
+           subscription_status, created_at, updated_at
+         ) VALUES ($1, $2, true, $3, $4, NOW(), NOW())
+         ON CONFLICT (workos_organization_id) DO UPDATE SET
+           membership_tier = EXCLUDED.membership_tier,
+           subscription_status = EXCLUDED.subscription_status`,
+        [orgId, `Scope Matrix ${orgId}`, tier, tier ? 'active' : null],
+      );
+    }
+
+    async function provisionUser(userId: string, orgId: string) {
+      await pool.query(
+        `INSERT INTO users (workos_user_id, email, primary_organization_id, created_at, updated_at)
+         VALUES ($1, $2, $3, NOW(), NOW())
+         ON CONFLICT (workos_user_id) DO UPDATE SET primary_organization_id = EXCLUDED.primary_organization_id`,
+        [userId, `${userId}@example.com`, orgId],
+      );
+      // resolvePrimaryOrganization trusts the cached column only when a
+      // current organization_memberships row backs it.
+      await pool.query(
+        `INSERT INTO organization_memberships
+           (workos_user_id, workos_organization_id, role, email, created_at, updated_at)
+         VALUES ($1, $2, 'admin', $3, NOW(), NOW())
+         ON CONFLICT (workos_user_id, workos_organization_id) DO NOTHING`,
+        [userId, orgId, `${userId}@example.com`],
+      );
+    }
+
+    async function clearScopeFixtures() {
+      const orgs = [SCOPE_OWNER_ORG, SCOPE_OTHER_API_ORG, SCOPE_EXPLORER_ORG];
+      const users = [SCOPE_OWNER_USER, SCOPE_OTHER_API_USER, SCOPE_EXPLORER_USER];
+      await pool.query(
+        `DELETE FROM organization_domains WHERE workos_organization_id = ANY($1::text[]) OR domain = $2`,
+        [orgs, SCOPE_DOMAIN],
+      );
+      await pool.query(
+        `DELETE FROM member_profiles WHERE workos_organization_id = ANY($1::text[])`,
+        [orgs],
+      );
+      await pool.query(
+        `DELETE FROM organization_memberships WHERE workos_user_id = ANY($1::text[])`,
+        [users],
+      );
+      await pool.query(
+        `DELETE FROM users WHERE workos_user_id = ANY($1::text[])`,
+        [users],
+      );
+      await pool.query(
+        `DELETE FROM organizations WHERE workos_organization_id = ANY($1::text[])`,
+        [orgs],
+      );
+    }
+
+    beforeEach(async () => {
+      await clearScopeFixtures();
+      // Owner: API-tier org that owns the queried domain + a profile with
+      // one agent per visibility bucket. Other-API: API-tier org with no
+      // ownership claim. Explorer: no-API-tier org.
+      await seedOrg(SCOPE_OWNER_ORG, 'company_standard');
+      await seedOrg(SCOPE_OTHER_API_ORG, 'company_standard');
+      await seedOrg(SCOPE_EXPLORER_ORG, 'individual_academic');
+      await provisionUser(SCOPE_OWNER_USER, SCOPE_OWNER_ORG);
+      await provisionUser(SCOPE_OTHER_API_USER, SCOPE_OTHER_API_ORG);
+      await provisionUser(SCOPE_EXPLORER_USER, SCOPE_EXPLORER_ORG);
+      await pool.query(
+        `INSERT INTO member_profiles (
+           workos_organization_id, display_name, slug,
+           agents, is_public, created_at, updated_at
+         ) VALUES ($1, 'Scope Matrix Owner', $2, $3::jsonb, true, NOW(), NOW())`,
+        [
+          SCOPE_OWNER_ORG,
+          SCOPE_SLUG,
+          JSON.stringify([
+            { url: PUBLIC_URL, name: 'Public', type: 'sales', visibility: 'public' },
+            { url: MEMBERS_URL, name: 'Members', type: 'sales', visibility: 'members_only' },
+            { url: PRIVATE_URL, name: 'Private', type: 'sales', visibility: 'private' },
+          ]),
+        ],
+      );
+      await pool.query(
+        `INSERT INTO organization_domains
+           (workos_organization_id, domain, verified, is_primary, source, created_at, updated_at)
+         VALUES ($1, $2, true, true, 'workos', NOW(), NOW())
+         ON CONFLICT (domain) DO UPDATE SET
+           workos_organization_id = EXCLUDED.workos_organization_id,
+           verified = true, is_primary = true, source = 'workos'`,
+        [SCOPE_OWNER_ORG, SCOPE_DOMAIN],
+      );
+    });
+
+    afterAll(async () => {
+      await clearScopeFixtures();
+      setOptAuthUser(null);
+    });
+
+    type CallerKind = 'anonymous' | 'owner' | 'other_api' | 'explorer';
+    function setCaller(kind: CallerKind) {
+      if (kind === 'anonymous') return setOptAuthUser(null);
+      const id = kind === 'owner' ? SCOPE_OWNER_USER
+        : kind === 'other_api' ? SCOPE_OTHER_API_USER
+        : SCOPE_EXPLORER_USER;
+      setOptAuthUser({ id, email: `${id}@example.com` });
+    }
+
+    async function fetchAgents(scope: string | null, kind: CallerKind): Promise<string[]> {
+      setCaller(kind);
+      const qs = scope === null ? '' : `&scope=${encodeURIComponent(scope)}`;
+      const res = await request(app).get(
+        `/api/registry/operator?domain=${encodeURIComponent(SCOPE_DOMAIN)}${qs}`,
+      );
+      expect(res.status).toBe(200);
+      return (res.body.agents as Array<{ url: string }>).map(a => a.url).sort();
+    }
+
+    // ── scope omitted (existing tier-aware behavior) ──────────────────
+    it('scope omitted, anonymous → public only', async () => {
+      expect(await fetchAgents(null, 'anonymous')).toEqual([PUBLIC_URL]);
+    });
+    it('scope omitted, explorer (no API tier) → public only', async () => {
+      expect(await fetchAgents(null, 'explorer')).toEqual([PUBLIC_URL]);
+    });
+    it('scope omitted, API-tier non-owner → public + members_only', async () => {
+      expect(await fetchAgents(null, 'other_api')).toEqual(
+        [MEMBERS_URL, PUBLIC_URL].sort(),
+      );
+    });
+    it('scope omitted, profile owner → all three buckets', async () => {
+      expect(await fetchAgents(null, 'owner')).toEqual(
+        [MEMBERS_URL, PRIVATE_URL, PUBLIC_URL].sort(),
+      );
+    });
+
+    // ── scope=public ──────────────────────────────────────────────────
+    it('scope=public collapses every caller to public only', async () => {
+      for (const kind of ['anonymous', 'explorer', 'other_api', 'owner'] as const) {
+        expect(await fetchAgents('public', kind)).toEqual([PUBLIC_URL]);
+      }
+    });
+
+    // ── scope=member ──────────────────────────────────────────────────
+    it('scope=member from anonymous silently degrades to public only', async () => {
+      expect(await fetchAgents('member', 'anonymous')).toEqual([PUBLIC_URL]);
+    });
+    it('scope=member from explorer (no API tier) silently degrades to public only', async () => {
+      expect(await fetchAgents('member', 'explorer')).toEqual([PUBLIC_URL]);
+    });
+    it('scope=member from API-tier non-owner → public + members_only', async () => {
+      expect(await fetchAgents('member', 'other_api')).toEqual(
+        [MEMBERS_URL, PUBLIC_URL].sort(),
+      );
+    });
+    it('scope=member from owner → public + members_only (private excluded by scope)', async () => {
+      expect(await fetchAgents('member', 'owner')).toEqual(
+        [MEMBERS_URL, PUBLIC_URL].sort(),
+      );
+    });
+
+    // ── scope=private ─────────────────────────────────────────────────
+    it('scope=private from non-owner callers returns empty (no 403)', async () => {
+      for (const kind of ['anonymous', 'explorer', 'other_api'] as const) {
+        expect(await fetchAgents('private', kind)).toEqual([]);
+      }
+    });
+    it('scope=private from owner → only private agents', async () => {
+      expect(await fetchAgents('private', 'owner')).toEqual([PRIVATE_URL]);
+    });
+
+    // ── scope=all (explicit) matches omitted ─────────────────────────
+    it('scope=all is equivalent to omitting scope', async () => {
+      expect(await fetchAgents('all', 'owner')).toEqual(
+        await fetchAgents(null, 'owner'),
+      );
+      expect(await fetchAgents('all', 'other_api')).toEqual(
+        await fetchAgents(null, 'other_api'),
+      );
+      expect(await fetchAgents('all', 'anonymous')).toEqual(
+        await fetchAgents(null, 'anonymous'),
+      );
+    });
+
+    // ── validation ────────────────────────────────────────────────────
+    it('rejects unknown scope with 400', async () => {
+      setCaller('owner');
+      const res = await request(app).get(
+        `/api/registry/operator?domain=${encodeURIComponent(SCOPE_DOMAIN)}&scope=membr`,
+      );
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/scope/i);
     });
   });
 });

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -3471,6 +3471,8 @@ paths:
               - `member` → public + members_only (members_only is gated on caller's tier; anonymous or explorer-tier callers silently fall through to public-only rather than 403).
               - `private` → only `visibility=private`. Private agents are visible only to the profile owner; non-owners get an empty list.
               - Omitted or `all` → tier-aware full unlock: public + members_only for API-tier members + private for the profile owner.
+
+              Unknown values return 400 — a silent coerce to `all` could leak data the caller explicitly tried to scope away from.
             example: member
           required: false
           description: |-
@@ -3480,6 +3482,8 @@ paths:
             - `member` → public + members_only (members_only is gated on caller's tier; anonymous or explorer-tier callers silently fall through to public-only rather than 403).
             - `private` → only `visibility=private`. Private agents are visible only to the profile owner; non-owners get an empty list.
             - Omitted or `all` → tier-aware full unlock: public + members_only for API-tier members + private for the profile owner.
+
+            Unknown values return 400 — a silent coerce to `all` could leak data the caller explicitly tried to scope away from.
           name: scope
           in: query
       responses:
@@ -3490,7 +3494,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/OperatorLookupResult"
         "400":
-          description: Missing domain
+          description: Missing or invalid domain, or unknown scope value
           content:
             application/json:
               schema:

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -3445,6 +3445,8 @@ paths:
 
         **Response shape is auth-aware.** Anonymous callers see only `public` agents. Authenticated callers on an AAO membership tier with API access also see `members_only` agents. Profile owners (callers whose org owns the queried domain) additionally see `private` agents. This is the primary mechanism by which AAO membership unlocks deeper registry visibility.
 
+        **`scope` bucket filter.** Callers can opt INTO a single visibility bucket (or the full union) regardless of what their auth would otherwise unlock — useful for picker UIs that want exactly one slice (e.g. anonymous-equivalent, members-only catalog, owner's private drafts). `scope` only narrows; it never escalates (e.g. `scope=member` on an explorer or anonymous caller silently returns public only).
+
         **Member level visibility.** When the profile owner has set their member card to public (`is_public=true`), the `member` object additionally carries `is_founding_member` (boolean) plus `membership_tier` (raw enum) and `membership_tier_label` (e.g. `Professional`, `Partner`, `Leader`) when the org has a resolvable tier. Founding Member is orthogonal to tier — founding orgs typically display both. For private profiles these fields are absent.
       tags:
         - Authorization Lookups
@@ -3454,6 +3456,31 @@ paths:
             example: pubmatic.com
           required: true
           name: domain
+          in: query
+        - schema:
+            type: string
+            enum:
+              - public
+              - member
+              - private
+              - all
+            description: |-
+              Visibility bucket filter for returned agents. One value per agent-visibility enum value plus a catch-all. Each bucket is still gated by auth — `scope` can only narrow, never escalate.
+
+              - `public` → only `visibility=public` agents.
+              - `member` → public + members_only (members_only is gated on caller's tier; anonymous or explorer-tier callers silently fall through to public-only rather than 403).
+              - `private` → only `visibility=private`. Private agents are visible only to the profile owner; non-owners get an empty list.
+              - Omitted or `all` → tier-aware full unlock: public + members_only for API-tier members + private for the profile owner.
+            example: member
+          required: false
+          description: |-
+            Visibility bucket filter for returned agents. One value per agent-visibility enum value plus a catch-all. Each bucket is still gated by auth — `scope` can only narrow, never escalate.
+
+            - `public` → only `visibility=public` agents.
+            - `member` → public + members_only (members_only is gated on caller's tier; anonymous or explorer-tier callers silently fall through to public-only rather than 403).
+            - `private` → only `visibility=private`. Private agents are visible only to the profile owner; non-owners get an empty list.
+            - Omitted or `all` → tier-aware full unlock: public + members_only for API-tier members + private for the profile owner.
+          name: scope
           in: query
       responses:
         "200":


### PR DESCRIPTION
## Summary

Adds an optional `?scope=public|member|private|all` query param to `GET /api/registry/operator`. Each value names exactly one agent-visibility bucket (plus a catch-all). `scope` is a **narrowing filter** — it can only ever show the caller a smaller slice than their auth would otherwise unlock, never larger.

## Why

The current operator-lookup filter is auth-driven only:

```ts
let includeMembersOnly = false;
if (callerOrgId && hasApiAccess(...)) includeMembersOnly = true;
const isProfileOwner = !!(callerOrgId && profile?.workos_organization_id === callerOrgId);

const agentConfigs = (profile?.agents || []).filter(a => {
  if (a.visibility === 'public') return true;
  if (includeMembersOnly && a.visibility === 'members_only') return true;
  if (isProfileOwner && a.visibility === 'private') return true;
  return false;
});
```

Callers have no way to opt INTO a smaller view than their auth gives them. That breaks several picker UIs:

- A platform integration whose admin-tier API key is required for rate-limit + audit attribution wants the **anonymous-equivalent** view for a pre-sign-in picker — without a knob, it leaks every other org's `members_only` agents into a picker scoped to one operator domain.
- A profile owner who wants a "**signed-in member catalog**" view (public + members_only) can't get it without also pulling in their own `private` drafts.
- A profile owner who wants a "**my drafts**" view (private only) can't filter client-side because `visibility` is not on the wire — the response only returns `url / name / type / authorized_by`.

This PR gives the missing knob and gives it cleanly.

## Behavior

| `scope=` | returns | auth gating |
|---|---|---|
| `public` | only `visibility=public` | none — anyone can see this |
| `member` | public + members_only | members_only gated on API-tier; anonymous / explorer-tier callers silently fall through to public only (no 403) |
| `private` | only `visibility=private` | profile-owner only; non-owners get an empty list |
| omitted / `all` | all three buckets | tier-aware (members_only requires API-tier; private requires owner) |

`scope` only **narrows**; it never escalates. A non-owner asking `?scope=private` gets an empty list rather than 403, matching how `?scope=member` from a non-member silently degrades to public-only.

## What changed

In `server/src/routes/registry-api.ts /registry/operator`:

- Parse `req.query.scope` into a typed enum (`'public' | 'member' | 'private' | 'all'`, defaulting to `'all'` for omitted / unknown values).
- Compute three "scope admits this bucket" booleans from the enum value (`scopeAllowsPublic`, `scopeAllowsMembersOnly`, `scopeAllowsPrivate`).
- Intersect each with auth: `allowMembersOnly = scopeAllowsMembersOnly && callerHasApiAccess`, `allowPrivate = scopeAllowsPrivate && isProfileOwner`. `allowPublic = scopeAllowsPublic`.
- Visibility filter becomes a clean three-line check, one per bucket.
- The tier DB lookup is skipped when the scope wouldn't admit members_only anyway — saves a query on `scope=public` / `scope=private` calls.

OpenAPI spec for `/registry/operator` is updated to document the new param (the previous commit added the runtime check but missed the spec).

## Backwards compatibility

**Non-breaking.** Existing callers (no `scope` param) get the same response shape and same data — `omitted` falls into the `all` branch, which preserves the historical tier-aware union. The new param is opt-in.

## Companion PR

`@adcp/sdk` PR exposes this as `lookupOperator(domain, { scope: 'public' | 'member' | 'private' | 'all' })`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build:openapi` — regenerates `static/openapi/registry.yaml` cleanly; drift matches the route change
- [ ] Manual: `GET /api/registry/operator?domain=<operator>&scope=public` from an API-tier key → only public agents
- [ ] Manual: same from owner with `?scope=member` → public + members_only, no private
- [ ] Manual: same from owner with `?scope=private` → only private
- [ ] Manual: `?scope=private` from a non-owner → empty `agents` array
- [ ] Manual: no `scope` param → existing tier-aware behavior unchanged