### PR TITLE
ops(registry): one-shot cleanup for agent_url canonicalization drift

### DIFF
--- a/.changeset/3573-agent-url-canonicalization-cleanup.md
+++ b/.changeset/3573-agent-url-canonicalization-cleanup.md
@@ -1,0 +1,6 @@
+---
+---
+
+ops(registry): one-shot cleanup scripts for `agent_url` canonicalization drift (follow-up to #4551 / #3573).
+
+`audit-agent-url-canonicalization-collisions.ts` reports collisions in `agent_registry_metadata` and `member_profiles.agents`. `reconcile-agent-url-canonicalization.ts` merges canonical-collision pairs in the metadata table and dedupes intra-profile JSONB collisions; defaults to dry-run, `--apply` to write. Tested locally against the exact prod duplicate shapes; idempotent on re-run.

--- a/server/src/scripts/audit-agent-url-canonicalization-collisions.ts
+++ b/server/src/scripts/audit-agent-url-canonicalization-collisions.ts
@@ -1,0 +1,225 @@
+/**
+ * Audit `agent_url` collisions that would collapse under the canonicalizer
+ * added in PR #4551 / issue #3573. Read-only — emits a report only.
+ *
+ * Two stores are surveyed:
+ *
+ *   1. `agent_registry_metadata` (PK = `agent_url`) — direct readers
+ *      (compliance heartbeat, lifecycle dashboards) won't get the
+ *      `FederatedIndexService` read-side fallback, so duplicates here
+ *      are the ones that need a one-shot cleanup the most.
+ *
+ *   2. `member_profiles.agents` (JSONB array of {url, ...}) — duplicates
+ *      here drive the badge-drop bug #3573 describes. PR #4551's
+ *      canonical-key + `?? raw` fallback papers over reads, but the
+ *      stored bytes stay non-canonical until the member next saves.
+ *
+ * Canonical form mirrors `canonicalizeAgentUrl` (publisher-db.ts):
+ *   trim → lower → strip trailing slashes. Wildcards / whitespace-only
+ *   rows are surfaced separately so an operator can decide what to do
+ *   with them; they would canonicalize to null in JS.
+ *
+ * Usage (dev):
+ *   DATABASE_URL=… npx tsx server/src/scripts/audit-agent-url-canonicalization-collisions.ts
+ *
+ * Usage (prod, via fly ssh):
+ *   fly ssh console -a adcp-docs -C 'node /app/dist/scripts/audit-agent-url-canonicalization-collisions.js'
+ */
+
+import { initializeDatabase, getPool, closeDatabase } from '../db/client.js';
+import { getDatabaseConfig } from '../config.js';
+
+interface MetadataCollisionRow {
+  canonical: string;
+  raw_urls: string[];
+  row_count: number;
+}
+
+interface ProfileCollisionRow {
+  profile_id: string;
+  profile_slug: string;
+  canonical: string;
+  raw_urls: string[];
+  row_count: number;
+}
+
+interface CrossStoreMismatch {
+  canonical: string;
+  metadata_raw: string | null;
+  profile_raws: string[];
+}
+
+async function main(): Promise<void> {
+  const dbConfig = getDatabaseConfig();
+  if (!dbConfig) {
+    console.error('DATABASE_URL is required');
+    process.exit(1);
+  }
+  initializeDatabase(dbConfig);
+  const pool = getPool();
+
+  // SQL canonicalization mirrors canonicalizeAgentUrl:
+  //   trim → lower → strip 1+ trailing slashes.
+  // `regexp_replace(..., '/+$', '')` strips all trailing slashes in one pass.
+  // Wildcard '*' is kept literal (no trailing slashes to strip anyway).
+  const sqlCanonical = `regexp_replace(lower(trim(agent_url)), '/+$', '')`;
+
+  // 1. agent_registry_metadata collisions
+  const metadataCollisions = await pool.query<MetadataCollisionRow>(`
+    SELECT
+      ${sqlCanonical} AS canonical,
+      array_agg(DISTINCT agent_url ORDER BY agent_url) AS raw_urls,
+      COUNT(*)::int AS row_count
+    FROM agent_registry_metadata
+    WHERE agent_url IS NOT NULL
+    GROUP BY ${sqlCanonical}
+    HAVING COUNT(DISTINCT agent_url) > 1
+    ORDER BY COUNT(*) DESC, canonical
+  `);
+
+  // 2. member_profiles.agents JSONB collisions (within a single profile)
+  const profileCollisions = await pool.query<ProfileCollisionRow>(`
+    WITH unnested AS (
+      SELECT
+        mp.id AS profile_id,
+        mp.slug AS profile_slug,
+        (elem ->> 'url') AS raw_url,
+        regexp_replace(lower(trim(elem ->> 'url')), '/+$', '') AS canonical
+      FROM member_profiles mp,
+           jsonb_array_elements(mp.agents) elem
+      WHERE elem ->> 'url' IS NOT NULL
+    )
+    SELECT
+      profile_id,
+      profile_slug,
+      canonical,
+      array_agg(DISTINCT raw_url ORDER BY raw_url) AS raw_urls,
+      COUNT(*)::int AS row_count
+    FROM unnested
+    GROUP BY profile_id, profile_slug, canonical
+    HAVING COUNT(DISTINCT raw_url) > 1
+    ORDER BY COUNT(*) DESC, profile_slug, canonical
+  `);
+
+  // 3. Cross-store mismatch — one canonical key shared between the two
+  //    stores but with different raw spellings. This is the case that
+  //    silently drops the member badge: registered side wrote one shape,
+  //    discovered/metadata side has another.
+  const crossStore = await pool.query<CrossStoreMismatch>(`
+    WITH meta AS (
+      SELECT
+        agent_url AS raw,
+        regexp_replace(lower(trim(agent_url)), '/+$', '') AS canonical
+      FROM agent_registry_metadata
+      WHERE agent_url IS NOT NULL
+    ),
+    profile_urls AS (
+      SELECT DISTINCT
+        (elem ->> 'url') AS raw,
+        regexp_replace(lower(trim(elem ->> 'url')), '/+$', '') AS canonical
+      FROM member_profiles mp,
+           jsonb_array_elements(mp.agents) elem
+      WHERE elem ->> 'url' IS NOT NULL
+    ),
+    joined AS (
+      SELECT
+        COALESCE(m.canonical, p.canonical) AS canonical,
+        m.raw AS metadata_raw,
+        p.raw AS profile_raw
+      FROM meta m
+      FULL OUTER JOIN profile_urls p ON m.canonical = p.canonical
+    )
+    SELECT
+      canonical,
+      MAX(metadata_raw) AS metadata_raw,
+      array_agg(DISTINCT profile_raw) FILTER (WHERE profile_raw IS NOT NULL) AS profile_raws
+    FROM joined
+    GROUP BY canonical
+    HAVING
+      -- Drop the common case where both stores agree byte-for-byte.
+      NOT (
+        COUNT(DISTINCT metadata_raw) <= 1
+        AND COUNT(DISTINCT profile_raw) <= 1
+        AND (
+          MAX(metadata_raw) IS NULL
+          OR MAX(profile_raw) IS NULL
+          OR MAX(metadata_raw) = MAX(profile_raw)
+        )
+      )
+    ORDER BY canonical
+  `);
+
+  // 4. Whitespace / wildcard / null-canonical rows in metadata — these
+  //    would canonicalize to null in JS and need operator attention
+  //    regardless of #4551.
+  const malformed = await pool.query<{ agent_url: string }>(`
+    SELECT agent_url
+    FROM agent_registry_metadata
+    WHERE agent_url ~ '[[:space:]]'
+       OR agent_url = ''
+       OR agent_url LIKE '%*%'
+  `);
+
+  console.log('=== agent_url canonicalization sweep (PR #4551 / issue #3573) ===\n');
+
+  console.log(`1. agent_registry_metadata collisions: ${metadataCollisions.rowCount}`);
+  if (metadataCollisions.rowCount && metadataCollisions.rowCount > 0) {
+    for (const row of metadataCollisions.rows) {
+      console.log(`   canonical=${row.canonical}  rows=${row.row_count}`);
+      for (const raw of row.raw_urls) console.log(`     - ${raw}`);
+    }
+  }
+  console.log('');
+
+  console.log(`2. member_profiles.agents intra-profile collisions: ${profileCollisions.rowCount}`);
+  if (profileCollisions.rowCount && profileCollisions.rowCount > 0) {
+    for (const row of profileCollisions.rows) {
+      console.log(`   profile=${row.profile_slug} [${row.profile_id}]`);
+      console.log(`     canonical=${row.canonical}  rows=${row.row_count}`);
+      for (const raw of row.raw_urls) console.log(`     - ${raw}`);
+    }
+  }
+  console.log('');
+
+  console.log(`3. Cross-store mismatches (registered vs metadata raw spelling differs but canonical matches): ${crossStore.rowCount}`);
+  if (crossStore.rowCount && crossStore.rowCount > 0) {
+    for (const row of crossStore.rows) {
+      console.log(`   canonical=${row.canonical}`);
+      console.log(`     metadata_raw=${row.metadata_raw ?? '(missing)'}`);
+      const profiles = row.profile_raws ?? [];
+      if (profiles.length === 0) {
+        console.log(`     profile_raws=(none)`);
+      } else {
+        for (const raw of profiles) console.log(`     profile_raw=${raw}`);
+      }
+    }
+  }
+  console.log('');
+
+  console.log(`4. Malformed metadata rows (whitespace / wildcard / empty): ${malformed.rowCount}`);
+  if (malformed.rowCount && malformed.rowCount > 0) {
+    for (const row of malformed.rows) {
+      console.log(`   - ${JSON.stringify(row.agent_url)}`);
+    }
+  }
+  console.log('');
+
+  const totalIssues =
+    (metadataCollisions.rowCount ?? 0)
+    + (profileCollisions.rowCount ?? 0)
+    + (crossStore.rowCount ?? 0)
+    + (malformed.rowCount ?? 0);
+
+  if (totalIssues === 0) {
+    console.log('Clean. No backfill needed; PR #4551 prevents new drift going forward.');
+  } else {
+    console.log(`Total findings: ${totalIssues}. A one-shot cleanup is warranted; see issue #3573 "out of scope" guidance.`);
+  }
+
+  await closeDatabase();
+}
+
+main().catch((err) => {
+  console.error('audit failed:', err);
+  process.exit(1);
+});

--- a/server/src/scripts/reconcile-agent-url-canonicalization.ts
+++ b/server/src/scripts/reconcile-agent-url-canonicalization.ts
@@ -1,0 +1,362 @@
+/**
+ * One-shot cleanup of pre-PR-#4551 non-canonical `agent_url` rows in
+ * `agent_registry_metadata` and `member_profiles.agents`. Pairs the
+ * audit script `audit-agent-url-canonicalization-collisions.ts`.
+ *
+ * Dry-run by default. Pass `--apply` to write.
+ *
+ * Scope:
+ *   1. `agent_registry_metadata` — merge canonical-collision pairs into
+ *      a single canonical-form row, applying the per-column merge rules
+ *      below. Drop the non-canonical PK.
+ *   2. `member_profiles.agents` (JSONB array) — rewrite each element's
+ *      `url` to canonical form, deduping intra-profile collisions.
+ *
+ * Out of scope: the ~20 other tables that hold `agent_url` as a soft
+ * pointer. PR #4551's read-side canonical-key + `?? raw` fallback in
+ * `FederatedIndexService` is the documented strategy for those; this
+ * script targets only the two stores with duplicate-row pathology
+ * (compliance heartbeat double-counting, member-profile badge drop).
+ *
+ * Merge rules (`agent_registry_metadata`, per canonical key):
+ *   - agent_url           → canonical form
+ *   - lifecycle_stage     → from most-recently-updated row
+ *   - compliance_opt_out  → TRUE if any row is TRUE  (conservative)
+ *   - monitoring_paused   → TRUE if any row is TRUE  (conservative)
+ *   - check_interval_hours→ MIN (more-frequent monitoring wins)
+ *   - monitoring_paused_at→ MAX, non-null preferred
+ *   - created_at          → MIN
+ *   - updated_at          → MAX
+ *
+ * JSONB merge rules (`member_profiles.agents`, per profile, per canonical):
+ *   - url        → canonical form
+ *   - any other field — if siblings agree, take the shared value; if
+ *                       siblings disagree, take the value from whichever
+ *                       sibling's raw `url` was already canonical (matches
+ *                       what the post-#4551 write path would produce). If
+ *                       no sibling is canonical, take the first entry's
+ *                       value. The drop is logged.
+ *     (Empty/missing fields are dropped silently.)
+ *
+ * Usage (dev):
+ *   DATABASE_URL=… npx tsx server/src/scripts/reconcile-agent-url-canonicalization.ts            # dry-run
+ *   DATABASE_URL=… npx tsx server/src/scripts/reconcile-agent-url-canonicalization.ts --apply    # write
+ *
+ * Usage (prod):
+ *   fly ssh console -a adcp-docs -C 'node /app/dist/scripts/reconcile-agent-url-canonicalization.js'           # dry-run
+ *   fly ssh console -a adcp-docs -C 'node /app/dist/scripts/reconcile-agent-url-canonicalization.js --apply'   # write
+ */
+
+import { initializeDatabase, getPool, closeDatabase } from '../db/client.js';
+import { getDatabaseConfig } from '../config.js';
+import { canonicalizeAgentUrl } from '../db/publisher-db.js';
+
+interface MetadataRow {
+  agent_url: string;
+  lifecycle_stage: string;
+  compliance_opt_out: boolean;
+  monitoring_paused: boolean;
+  check_interval_hours: number;
+  monitoring_paused_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+interface ProfileRow {
+  id: string;
+  slug: string;
+  agents: Record<string, unknown>[];
+}
+
+function pickMostRecent<T extends { updated_at: Date }>(rows: T[]): T {
+  return rows.reduce((a, b) => (a.updated_at >= b.updated_at ? a : b));
+}
+
+function minDate(dates: Date[]): Date {
+  return dates.reduce((a, b) => (a <= b ? a : b));
+}
+
+function maxDate(dates: Date[]): Date {
+  return dates.reduce((a, b) => (a >= b ? a : b));
+}
+
+function maxNullableDate(dates: (Date | null)[]): Date | null {
+  const nonNull = dates.filter((d): d is Date => d !== null);
+  return nonNull.length === 0 ? null : maxDate(nonNull);
+}
+
+interface JsonbResolution {
+  profile_slug: string;
+  canonical: string;
+  field: string;
+  kept: unknown;
+  dropped: unknown[];
+}
+
+function mergeJsonbAgents(
+  profileSlug: string,
+  agents: Record<string, unknown>[],
+): { next: Record<string, unknown>[]; resolutions: JsonbResolution[]; changed: boolean } {
+  // Group by canonical url. Preserve first-seen order.
+  const groups = new Map<string, Record<string, unknown>[]>();
+  const order: string[] = [];
+  for (const elem of agents) {
+    const rawUrl = typeof elem.url === 'string' ? elem.url : null;
+    if (!rawUrl) {
+      // Pass through elements without a url — defensive; never observed.
+      const key = `__no_url_${order.length}`;
+      groups.set(key, [elem]);
+      order.push(key);
+      continue;
+    }
+    const canonical = canonicalizeAgentUrl(rawUrl) ?? rawUrl;
+    if (!groups.has(canonical)) {
+      groups.set(canonical, []);
+      order.push(canonical);
+    }
+    groups.get(canonical)!.push(elem);
+  }
+
+  const resolutions: JsonbResolution[] = [];
+  const merged: Record<string, unknown>[] = [];
+  let changed = false;
+
+  for (const key of order) {
+    const group = groups.get(key)!;
+    if (group.length === 1) {
+      const elem = group[0];
+      const rawUrl = typeof elem.url === 'string' ? elem.url : null;
+      if (rawUrl) {
+        const canonical = canonicalizeAgentUrl(rawUrl);
+        if (canonical && canonical !== rawUrl) {
+          merged.push({ ...elem, url: canonical });
+          changed = true;
+          continue;
+        }
+      }
+      merged.push(elem);
+      continue;
+    }
+
+    // Two or more elements share a canonical key. Pick the "winner": the
+    // sibling whose raw url already equals the canonical form. If none
+    // is already canonical (all are slashed/cased variants), fall back
+    // to the first sibling in array order.
+    changed = true;
+    const winner = group.find(e => e.url === key) ?? group[0];
+    const out: Record<string, unknown> = { ...winner, url: key };
+
+    // Log any field where the winner kept its value over a non-empty
+    // value from a sibling — these are decisions an operator should see.
+    const fieldKeys = new Set<string>();
+    for (const elem of group) for (const k of Object.keys(elem)) if (k !== 'url') fieldKeys.add(k);
+    for (const f of fieldKeys) {
+      const kept = winner[f];
+      const dropped: unknown[] = [];
+      for (const elem of group) {
+        if (elem === winner) continue;
+        const v = elem[f];
+        if (v === null || v === undefined || v === '') continue;
+        if (JSON.stringify(v) === JSON.stringify(kept)) continue;
+        dropped.push(v);
+      }
+      if (dropped.length > 0) {
+        resolutions.push({ profile_slug: profileSlug, canonical: key, field: f, kept, dropped });
+      }
+    }
+    merged.push(out);
+  }
+
+  return { next: merged, resolutions, changed };
+}
+
+async function main(): Promise<void> {
+  const apply = process.argv.includes('--apply');
+
+  const dbConfig = getDatabaseConfig();
+  if (!dbConfig) {
+    console.error('DATABASE_URL is required');
+    process.exit(1);
+  }
+  initializeDatabase(dbConfig);
+  const pool = getPool();
+
+  console.log(`=== agent_url reconciliation (${apply ? 'APPLY' : 'DRY-RUN'}) ===\n`);
+
+  // ─── 1. agent_registry_metadata ──────────────────────────────────
+  const metadataPairsQ = await pool.query<{ canonical: string }>(`
+    SELECT regexp_replace(lower(trim(agent_url)), '/+$', '') AS canonical
+    FROM agent_registry_metadata
+    WHERE agent_url IS NOT NULL
+    GROUP BY regexp_replace(lower(trim(agent_url)), '/+$', '')
+    HAVING COUNT(DISTINCT agent_url) > 1
+    ORDER BY canonical
+  `);
+
+  console.log(`1. agent_registry_metadata canonical pair-sets: ${metadataPairsQ.rowCount}\n`);
+
+  let metadataMerged = 0;
+  let metadataDeleted = 0;
+
+  for (const { canonical } of metadataPairsQ.rows) {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const rowsQ = await client.query<MetadataRow>(
+        `SELECT * FROM agent_registry_metadata
+         WHERE regexp_replace(lower(trim(agent_url)), '/+$', '') = $1
+         ORDER BY agent_url
+         FOR UPDATE`,
+        [canonical],
+      );
+      const rows = rowsQ.rows;
+      if (rows.length < 2) {
+        await client.query('ROLLBACK');
+        continue;
+      }
+
+      const mostRecent = pickMostRecent(rows);
+      const merged = {
+        agent_url: canonical,
+        lifecycle_stage: mostRecent.lifecycle_stage,
+        compliance_opt_out: rows.some(r => r.compliance_opt_out),
+        monitoring_paused: rows.some(r => r.monitoring_paused),
+        check_interval_hours: Math.min(...rows.map(r => r.check_interval_hours)),
+        monitoring_paused_at: maxNullableDate(rows.map(r => r.monitoring_paused_at)),
+        created_at: minDate(rows.map(r => r.created_at)),
+        updated_at: maxDate(rows.map(r => r.updated_at)),
+      };
+
+      console.log(`  canonical=${canonical}`);
+      for (const r of rows) {
+        console.log(
+          `    in:  url=${r.agent_url}  lifecycle=${r.lifecycle_stage}  opt_out=${r.compliance_opt_out}  paused=${r.monitoring_paused}  interval=${r.check_interval_hours}h  updated=${r.updated_at.toISOString()}`,
+        );
+      }
+      console.log(
+        `    out: url=${merged.agent_url}  lifecycle=${merged.lifecycle_stage}  opt_out=${merged.compliance_opt_out}  paused=${merged.monitoring_paused}  interval=${merged.check_interval_hours}h  updated=${merged.updated_at.toISOString()}`,
+      );
+
+      if (apply) {
+        // Strategy: delete every row in the pair-set, then insert the
+        // merged row. This avoids the UPDATE-PK-to-existing-value
+        // conflict when the canonical row already exists; ON CONFLICT
+        // on the insert would also work but is harder to reason about.
+        await client.query(
+          `DELETE FROM agent_registry_metadata
+           WHERE regexp_replace(lower(trim(agent_url)), '/+$', '') = $1`,
+          [canonical],
+        );
+        await client.query(
+          `INSERT INTO agent_registry_metadata
+            (agent_url, lifecycle_stage, compliance_opt_out, monitoring_paused,
+             check_interval_hours, monitoring_paused_at, created_at, updated_at)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+          [
+            merged.agent_url,
+            merged.lifecycle_stage,
+            merged.compliance_opt_out,
+            merged.monitoring_paused,
+            merged.check_interval_hours,
+            merged.monitoring_paused_at,
+            merged.created_at,
+            merged.updated_at,
+          ],
+        );
+        await client.query('COMMIT');
+      } else {
+        await client.query('ROLLBACK');
+      }
+
+      metadataMerged += 1;
+      metadataDeleted += rows.length - 1;
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  // Also: singleton non-canonical rows (no sibling). These won't double-
+  // count anything but they keep the table on a different shape from the
+  // new write path. Normalize them so the table is uniformly canonical
+  // after this run. Skip any that would collide with an existing row.
+  const singletonsQ = await pool.query<{ agent_url: string }>(`
+    SELECT agent_url FROM agent_registry_metadata
+    WHERE agent_url <> regexp_replace(lower(trim(agent_url)), '/+$', '')
+      AND NOT EXISTS (
+        SELECT 1 FROM agent_registry_metadata m2
+        WHERE m2.agent_url = regexp_replace(lower(trim(agent_registry_metadata.agent_url)), '/+$', '')
+      )
+    ORDER BY agent_url
+  `);
+
+  console.log(`\n   Singleton non-canonical rows to normalize: ${singletonsQ.rowCount}`);
+  for (const { agent_url } of singletonsQ.rows) {
+    const canonical = canonicalizeAgentUrl(agent_url);
+    if (!canonical || canonical === agent_url) continue;
+    console.log(`     ${agent_url}  →  ${canonical}`);
+    if (apply) {
+      await pool.query(
+        `UPDATE agent_registry_metadata SET agent_url = $1 WHERE agent_url = $2`,
+        [canonical, agent_url],
+      );
+    }
+  }
+
+  console.log(
+    `\n   metadata pairs merged: ${metadataMerged}, rows dropped: ${metadataDeleted}, singletons normalized: ${singletonsQ.rowCount}\n`,
+  );
+
+  // ─── 2. member_profiles.agents ───────────────────────────────────
+  const profilesQ = await pool.query<ProfileRow>(`
+    SELECT id, slug, agents
+    FROM member_profiles
+    WHERE agents IS NOT NULL AND jsonb_array_length(agents) > 0
+  `);
+
+  let profilesTouched = 0;
+  const allResolutions: JsonbResolution[] = [];
+
+  for (const profile of profilesQ.rows) {
+    const result = mergeJsonbAgents(profile.slug, profile.agents);
+    if (!result.changed) continue;
+
+    allResolutions.push(...result.resolutions);
+
+    console.log(`  profile=${profile.slug} [${profile.id}]`);
+    console.log(`    in:  ${JSON.stringify(profile.agents)}`);
+    console.log(`    out: ${JSON.stringify(result.next)}`);
+    for (const r of result.resolutions) {
+      console.log(
+        `    field=${r.field}  kept=${JSON.stringify(r.kept)}  dropped=${JSON.stringify(r.dropped)}`,
+      );
+    }
+
+    profilesTouched += 1;
+    if (apply) {
+      await pool.query(
+        `UPDATE member_profiles SET agents = $1::jsonb, updated_at = NOW() WHERE id = $2`,
+        [JSON.stringify(result.next), profile.id],
+      );
+    }
+  }
+
+  console.log(
+    `\n2. member_profiles touched: ${profilesTouched}, field resolutions (dropped non-empty sibling values): ${allResolutions.length}\n`,
+  );
+
+  if (!apply) {
+    console.log('Dry-run complete. Pass --apply to write.');
+  } else {
+    console.log('Apply complete.');
+  }
+
+  await closeDatabase();
+}
+
+main().catch((err) => {
+  console.error('reconciliation failed:', err);
+  process.exit(1);
+});

--- a/server/src/scripts/reconcile-agent-url-canonicalization.ts
+++ b/server/src/scripts/reconcile-agent-url-canonicalization.ts
@@ -68,8 +68,16 @@ interface ProfileRow {
   agents: Record<string, unknown>[];
 }
 
-function pickMostRecent<T extends { updated_at: Date }>(rows: T[]): T {
-  return rows.reduce((a, b) => (a.updated_at >= b.updated_at ? a : b));
+function pickMostRecent<T extends { updated_at: Date; agent_url: string }>(rows: T[], canonical: string): T {
+  // Ties on updated_at break toward the canonical-form row so the merged
+  // lifecycle_stage matches what a fresh canonical write would produce.
+  return rows.reduce((a, b) => {
+    if (a.updated_at > b.updated_at) return a;
+    if (b.updated_at > a.updated_at) return b;
+    if (a.agent_url === canonical) return a;
+    if (b.agent_url === canonical) return b;
+    return a;
+  });
 }
 
 function minDate(dates: Date[]): Date {
@@ -140,10 +148,18 @@ function mergeJsonbAgents(
 
     // Two or more elements share a canonical key. Pick the "winner": the
     // sibling whose raw url already equals the canonical form. If none
-    // is already canonical (all are slashed/cased variants), fall back
-    // to the first sibling in array order.
+    // is already canonical (all are slashed/cased variants — possible
+    // only on pre-#4551 data where neither sibling was ever written
+    // canonically), fall back to the first sibling in array order and
+    // warn — operator should inspect.
     changed = true;
-    const winner = group.find(e => e.url === key) ?? group[0];
+    let winner = group.find(e => e.url === key);
+    if (!winner) {
+      console.warn(
+        `  WARN profile=${profileSlug} canonical=${key}: no canonical-form sibling; defaulting to first array element. Inspect manually.`,
+      );
+      winner = group[0];
+    }
     const out: Record<string, unknown> = { ...winner, url: key };
 
     // Log any field where the winner kept its value over a non-empty
@@ -215,7 +231,7 @@ async function main(): Promise<void> {
         continue;
       }
 
-      const mostRecent = pickMostRecent(rows);
+      const mostRecent = pickMostRecent(rows, canonical);
       const merged = {
         agent_url: canonical,
         lifecycle_stage: mostRecent.lifecycle_stage,
@@ -293,20 +309,50 @@ async function main(): Promise<void> {
   `);
 
   console.log(`\n   Singleton non-canonical rows to normalize: ${singletonsQ.rowCount}`);
+  let singletonsNormalized = 0;
   for (const { agent_url } of singletonsQ.rows) {
     const canonical = canonicalizeAgentUrl(agent_url);
     if (!canonical || canonical === agent_url) continue;
     console.log(`     ${agent_url}  →  ${canonical}`);
-    if (apply) {
-      await pool.query(
+    if (!apply) continue;
+    // Race with concurrent member-side writes: a writer could insert the
+    // canonical PK between our SELECT above and the UPDATE below. Lock
+    // both rows FOR UPDATE inside one transaction so the writer either
+    // blocks on us (we win, our UPDATE conflicts → ON CONFLICT skip) or
+    // we block on the writer (their canonical row already exists → skip).
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        `SELECT agent_url FROM agent_registry_metadata
+         WHERE agent_url IN ($1, $2) FOR UPDATE`,
+        [agent_url, canonical],
+      );
+      const exists = await client.query(
+        `SELECT 1 FROM agent_registry_metadata WHERE agent_url = $1`,
+        [canonical],
+      );
+      if (exists.rowCount && exists.rowCount > 0) {
+        console.log(`     (skip — canonical row appeared during run)`);
+        await client.query('ROLLBACK');
+        continue;
+      }
+      await client.query(
         `UPDATE agent_registry_metadata SET agent_url = $1 WHERE agent_url = $2`,
         [canonical, agent_url],
       );
+      await client.query('COMMIT');
+      singletonsNormalized += 1;
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
     }
   }
 
   console.log(
-    `\n   metadata pairs merged: ${metadataMerged}, rows dropped: ${metadataDeleted}, singletons normalized: ${singletonsQ.rowCount}\n`,
+    `\n   metadata pairs merged: ${metadataMerged}, rows dropped: ${metadataDeleted}, singletons normalized: ${apply ? singletonsNormalized : singletonsQ.rowCount}\n`,
   );
 
   // ─── 2. member_profiles.agents ───────────────────────────────────


### PR DESCRIPTION
## Summary

Follow-up to PR #4551 / issue #3573. #4551 stops the bleeding by canonicalizing every member-side write boundary, but pre-existing non-canonical rows persist. The read-side canonical-key + `?? raw` fallback in `FederatedIndexService` papers over the registry surface, but **direct readers of `agent_registry_metadata` (compliance heartbeat, lifecycle dashboards) still see un-collapsed duplicate rows.** #4551's own trade-off list flagged this gap.

### Sweep against prod (2026-05-16)

- **6 metadata pair-sets** — all trailing-slash drift only, no case differences
- **1 intra-profile JSONB collision** — `adzymic` staging-sales-agent stored with both slashed and unslashed forms, different `name` values
- **0 malformed rows** (whitespace / wildcard / empty)

### Two scripts, both dry-run by default

**`audit-agent-url-canonicalization-collisions.ts`** — reports metadata pair-sets, intra-profile JSONB collisions, cross-store raw-spelling mismatches, and malformed rows. Reusable diagnostic for future drift detection.

**`reconcile-agent-url-canonicalization.ts`** — merges metadata pairs per the documented column rules:
- `lifecycle_stage` → most-recently-updated row
- `compliance_opt_out`, `monitoring_paused` → TRUE if any row is TRUE (conservative)
- `check_interval_hours` → MIN (more-frequent monitoring wins)
- `created_at` → MIN, `updated_at` → MAX

Normalizes singleton non-canonical rows (post-#4551 cleanliness). Dedupes intra-profile JSONB by canonical key with **canonical-form-sibling-wins on field conflicts** — matches what the post-#4551 write path would produce.

For the `adzymic` collision, the canonical-form sibling has `name="Adzymic Staging Sales Agent"`; that value is kept, `"Adzymic Staging Agent (default tenant)"` is dropped. Logged in the resolution output.

### Test plan

- [x] `npm run typecheck` — passes
- [x] Local seed of exact prod duplicate shapes — dry-run output matches expected merge
- [x] `--apply` produces correct post-state in `agent_registry_metadata` and `member_profiles.agents`
- [x] Re-run is a no-op (idempotent)
- [ ] **MERGE ORDER:** wait for #4551 to merge first. Running this before the new write path lands would let non-canonical writes recreate the same drift.
- [ ] After #4551 merges + this deploys: `fly ssh console -a adcp-docs -C 'node /app/dist/scripts/audit-agent-url-canonicalization-collisions.js'` to re-confirm prod state
- [ ] Then `fly ssh console -a adcp-docs -C 'node /app/dist/scripts/reconcile-agent-url-canonicalization.js'` (dry-run) → `--apply` to clean up

🤖 Generated with [Claude Code](https://claude.com/claude-code)