### PR TITLE
docs(brand-protocol): Tier-2 implementer guide for verify_brand_claim + consumer UI guidance (#4543, #4544)

### DIFF
--- a/.changeset/brand-agent-tier-2-guide.md
+++ b/.changeset/brand-agent-tier-2-guide.md
@@ -1,0 +1,11 @@
+---
+"adcontextprotocol": patch
+---
+
+Docs: implementer guidance for `verify_brand_claim` and consumer-side UI conventions for rejected claims.
+
+`building-a-brand-agent.mdx` gains a new section, "Adding verify_brand_claim", covering the layered capability on top of the identity tier: capability declaration with `supported_claim_types`, the internal state model (subsidiary portfolio, parent declaration, property registry, trademark registry, pending-claim queue, archive), per-claim-type request validation and response shaping, the public-vs-authorized field split, the `pending_review` aging contract, per-purpose JWK setup (`adcp_use: "response-signing"` separate from `request-signing`), the `{caller_identity, claim_type, claim-target}` rate-limiting pattern with `Retry-After` and prefer-cached-prior-answer behavior, per-status `Cache-Control` recommendations, and a reference pattern for surfacing `pending_review` to the brand's portfolio team. The role table and deployment checklist are extended accordingly.
+
+A new page, `docs/brand-protocol/ui-guidance.mdx`, collects consumer-side conventions for rendering `disputed` / `not_ours` rejections — DSP inventory shopping, portfolio explorer, creative-clearance, brand-safety pipelines. Covers attribution language (render rejections as the rejecting brand's first-person statement), recovery paths for the rejected leaf publisher (there is no protocol-level appeal — update or remove the claim), audit-trail recommendations (keep the signed envelope), and legal-exposure considerations (the consumer surface owns editorial framing; AdCP delivers the signed answer).
+
+No schema changes. Both additions are non-normative consumer-side guidance — the canonical normative spec remains the `verify_brand_claim` task page.

--- a/docs.json
+++ b/docs.json
@@ -496,6 +496,7 @@
                       "docs/brand-protocol/for-rights-holders",
                       "docs/brand-protocol/brand-json",
                       "docs/brand-protocol/building-a-brand-agent",
+                      "docs/brand-protocol/ui-guidance",
                       {
                         "group": "Tasks",
                         "pages": [
@@ -1066,6 +1067,7 @@
                   "docs/brand-protocol/for-rights-holders",
                   "docs/brand-protocol/brand-json",
                   "docs/brand-protocol/building-a-brand-agent",
+                  "docs/brand-protocol/ui-guidance",
                   {
                     "group": "Tasks",
                     "pages": [

--- a/docs/brand-protocol/building-a-brand-agent.mdx
+++ b/docs/brand-protocol/building-a-brand-agent.mdx
@@ -11,8 +11,9 @@ The agent declares `supported_protocols: ["brand"]` in [`get_adcp_capabilities`]
 | Role | Tasks | Example |
 |------|-------|---------|
 | Identity provider | `get_brand_identity` | Acme DAM serving brand assets and guidelines |
+| Identity + verification | `get_brand_identity` + `verify_brand_claim` | Nike, Inc. answering authoritative subsidiary, property, and trademark questions |
 | Rights manager | `get_rights` + `acquire_rights` | Pinnacle Agency licensing talent |
-| Both | All three | Nova Talent managing identity and rights |
+| Full coverage | All five | Nova Talent managing identity, verification, and rights |
 
 ## Server setup
 
@@ -151,6 +152,391 @@ function buildIdentityResponse(brand, { fields, use_case, isAuthorized }) {
 ```
 
 When a public caller requests `fields: ["logos", "tone"]`, they get logos but not tone. The response includes `available_fields: ["tone"]` so the caller knows what linking their account would unlock.
+
+## Adding verify_brand_claim
+
+[`verify_brand_claim`](/docs/brand-protocol/tasks/verify_brand_claim) lets partners ask the brand-agent an authoritative yes/no question about its identity — "is this subsidiary yours", "is this property yours", "is this trademark yours". It's a layered capability on top of the identity tier: same brand data, plus the richer states (`pending_review`, `transferring`, `disputed`, `licensed_in`) the static `brand.json` can't express.
+
+The trust model is asymmetric by direction. Signed rejections (`disputed` / `not_ours`) are authoritative unilaterally — a brand has standing to refuse association without reciprocation. Signed assertions (`owned` / `pending_review` / `transferring` / `licensed_*`) are informative but NOT trust-extending alone; the reciprocating side must still confirm. This is the load-bearing concept — see [`brand.json` § Agent-augmented verification](/docs/brand-protocol/brand-json#agent-augmented-verification) for the full normative table.
+
+### Capability declaration
+
+Advertise `verify_brand_claim` in `get_adcp_capabilities`, and declare which claim types you implement via the per-tool extension. A brand-agent MAY ship a slice (e.g., property only for creative-clearance, or subsidiary+parent for governance-trust extension) instead of all four.
+
+```typescript
+server.tool("get_adcp_capabilities", {}, async () => ({
+  content: [{
+    type: "text",
+    text: JSON.stringify({
+      supported_protocols: ["brand"],
+      supported_tasks: ["get_brand_identity", "verify_brand_claim"],
+      brand: {
+        verify_brand_claim: {
+          supported_claim_types: ["subsidiary", "parent", "property", "trademark"],
+        },
+      },
+    }),
+  }],
+}));
+```
+
+When `supported_claim_types` is omitted, the agent advertises support for all four. Consumers MUST check before relying on a specific claim type; unsupported types MUST return `UNSUPPORTED_CLAIM_TYPE`.
+
+### State model
+
+The agent needs internal data corresponding to each claim type. Treat `brand.json` as the public projection of these stores — the agent serves the same facts plus the richer lifecycle states.
+
+| Store | Backs | Mirrors in `brand.json` |
+|---|---|---|
+| Subsidiary portfolio | `claim_type: "subsidiary"` | `brand_refs[]` and inline `brands[]` |
+| Parent declaration | `claim_type: "parent"` | `house_domain` on the leaf's canonical document |
+| Property registry | `claim_type: "property"` | `properties[]` |
+| Trademark registry | `claim_type: "trademark"` | `trademarks[]` plus internal licensee-side records (which don't appear in `brand.json` today) |
+| Pending-claim queue | `pending_review` lifecycle | Not represented |
+| Archive | `archived` status | Not represented |
+
+```typescript
+type SubsidiaryRecord = {
+  subsidiary_brand_id: string;
+  subsidiary_domain: string;
+  status: "owned" | "pending_review" | "transferring" | "disputed" | "not_ours" | "archived";
+  first_observed_by_house_at: string;
+  expected_resolution_window_days?: number; // REQUIRED when status is "pending_review"
+};
+
+type PropertyRecord = {
+  type: "website" | "mobile_app" | "ctv_app" | "desktop_app" | "dooh" | "podcast" | "radio" | "streaming_audio";
+  identifier: string;
+  brand_id: string;
+  relationship: "owned" | "direct" | "delegated" | "ad_network";
+  regions: string[]; // ISO 3166-1 alpha-2 or ["global"]
+  status: "owned" | "transferring" | "disputed" | "not_ours" | "archived";
+  use_case_authorization?: Record<string, boolean>;
+};
+
+type TrademarkRecord = {
+  registry: string;
+  number: string;
+  mark: string;
+  registration_status: "active" | "pending" | "expired" | "cancelled";
+  countries: string[];
+  nice_classes: number[];
+  status: "owned" | "licensed_in" | "licensed_out" | "transferring" | "disputed" | "not_ours" | "archived";
+  licensor_domain?: string; // when status is "licensed_in"
+  use_case_authorization?: Record<string, boolean>;
+};
+```
+
+### Tool registration and request validation
+
+`verify_brand_claim` discriminates on `claim_type`. Validate the `claim` payload per type — required fields differ, and `INVALID_INPUT` is the right response when they're missing or malformed.
+
+```typescript
+import { z } from "zod";
+
+const SubsidiaryClaim = z.object({
+  subsidiary_domain: z.string().min(1),
+  subsidiary_brand_id: z.string().optional(),
+  observed_at: z.string().datetime().optional(),
+});
+
+const ParentClaim = z.object({
+  parent_domain: z.string().min(1),
+  claimant_says: z.string().optional(),
+  observed_at: z.string().datetime().optional(),
+});
+
+const PropertyClaim = z.object({
+  property: z.object({
+    type: z.enum(["website", "mobile_app", "ctv_app", "desktop_app", "dooh", "podcast", "radio", "streaming_audio"]),
+    identifier: z.string().min(1),
+    store: z.enum(["apple", "google", "amazon", "roku", "fire_tv", "samsung", "lg", "vizio", "other"]).optional(),
+    region: z.string().optional(),
+  }),
+  use_case: z.string().optional(),
+});
+
+const TrademarkClaim = z.object({
+  mark: z.string().min(1),
+  registry: z.string().optional(),
+  number: z.string().optional(),
+  countries: z.array(z.string().length(2)).optional(),
+});
+
+server.tool(
+  "verify_brand_claim",
+  "Answer an authoritative yes/no about a facet of brand identity",
+  {
+    claim_type: z.enum(["subsidiary", "parent", "property", "trademark"]),
+    claim: z.unknown(),
+  },
+  async ({ claim_type, claim }, extra) => {
+    const isAuthorized = await checkLinkedAccount(extra);
+    const callerId = await resolveCaller(extra);
+
+    if (await rateLimited(callerId, claim_type, claim)) {
+      return rateLimitedResponse(claim_type, callerId, claim);
+    }
+
+    switch (claim_type) {
+      case "subsidiary": {
+        const parsed = SubsidiaryClaim.safeParse(claim);
+        if (!parsed.success) return invalidInput(parsed.error);
+        return await answerSubsidiary(parsed.data, { isAuthorized });
+      }
+      case "parent": {
+        const parsed = ParentClaim.safeParse(claim);
+        if (!parsed.success) return invalidInput(parsed.error);
+        return await answerParent(parsed.data, { isAuthorized });
+      }
+      case "property": {
+        const parsed = PropertyClaim.safeParse(claim);
+        if (!parsed.success) return invalidInput(parsed.error);
+        return await answerProperty(parsed.data, { isAuthorized });
+      }
+      case "trademark": {
+        const parsed = TrademarkClaim.safeParse(claim);
+        if (!parsed.success) return invalidInput(parsed.error);
+        return await answerTrademark(parsed.data, { isAuthorized });
+      }
+    }
+  }
+);
+```
+
+### Per-claim-type response shaping
+
+The `details` field varies by `claim_type`. Build the typed response from your internal record, then strip authorized-only fields when the caller isn't linked.
+
+```typescript
+async function answerSubsidiary(claim, { isAuthorized }) {
+  const record = await subsidiaries.findByDomain(claim.subsidiary_domain);
+
+  if (!record) {
+    return signedResponse({
+      claim_type: "subsidiary",
+      status: "not_ours",
+      context_note: "We have no record of this brand.",
+    });
+  }
+
+  const details: Record<string, unknown> = {};
+
+  // Public fields
+  if (["owned", "pending_review", "transferring"].includes(record.status)) {
+    details.brand_id = record.subsidiary_brand_id;
+  }
+
+  // Authorized-only fields
+  if (isAuthorized) {
+    details.first_observed_by_house_at = record.first_observed_by_house_at;
+    if (record.expected_resolution_window_days != null) {
+      details.expected_resolution_window_days = record.expected_resolution_window_days;
+    }
+  }
+
+  // expected_resolution_window_days is REQUIRED when status is pending_review,
+  // even for unauthorized callers — surface the bound so they can age the answer.
+  if (record.status === "pending_review" && !isAuthorized) {
+    details.expected_resolution_window_days = record.expected_resolution_window_days;
+  }
+
+  return signedResponse({
+    claim_type: "subsidiary",
+    status: record.status,
+    details,
+  });
+}
+```
+
+The same shaping pattern applies to `property` (omit `details.use_case_authorization` for public callers) and `trademark` (keep `matched_registration`, `licensor_domain`, `countries`, `nice_classes` public; gate `use_case_authorization` behind authorization).
+
+### Public vs authorized field gating
+
+Mirror the public/authorized split from `get_brand_identity`. The split per claim type:
+
+| Public | Authorized-only |
+|---|---|
+| `claim_type`, `status`, `context_note` (always) | `details.first_observed_by_house_at` |
+| `details.brand_id`, `details.relationship`, `details.matched_registration`, `details.countries`, `details.nice_classes`, `details.regions` | `details.expected_resolution_window_days` (except when REQUIRED on `pending_review`) |
+| `details.licensor_domain` (when status is `licensed_in`) | `details.use_case_authorization` |
+
+Queue position, ticket state, and team routing are never exposed at any tier.
+
+### Aging contract for pending_review
+
+The agent MUST transition a `pending_review` record to a terminal status (`owned`, `disputed`, `not_ours`, `transferring`, `archived`) or to `unknown` once its `expected_resolution_window_days` elapses. Consumers SHOULD treat a stale `pending_review` response as `unknown` and fall back to crawl-based verification — but the agent owes the transition either way.
+
+A cron-driven sweep is the simplest implementation:
+
+```typescript
+// Run hourly. Promotes timed-out pending_review records to unknown
+// unless a human reviewer has acted in the meantime.
+async function ageOutPendingClaims(): Promise<void> {
+  const now = Date.now();
+  const stale = await pendingClaims.findStale(now);
+
+  for (const record of stale) {
+    const elapsedDays = (now - Date.parse(record.first_observed_by_house_at)) / 86_400_000;
+    if (elapsedDays >= record.expected_resolution_window_days) {
+      await pendingClaims.update(record.id, {
+        status: "unknown",
+        aged_out_at: new Date(now).toISOString(),
+      });
+      logger.info("aged_out_pending_claim", { record_id: record.id, claim_type: record.claim_type });
+    }
+  }
+}
+
+setInterval(ageOutPendingClaims, 60 * 60 * 1000);
+```
+
+Event-driven implementations work too — schedule a deferred job at `first_observed_by_house_at + expected_resolution_window_days` when the record is created, and have the job check that no human action intervened before flipping to `unknown`.
+
+### Signing setup
+
+Responses are signed under the brand's `adcp_use: "response-signing"` JWK. **This is a distinct key from the `request-signing` key the agent uses for its own outbound calls** — per the keys-per-purpose convention, receivers enforce purpose at the JWK `adcp_use` level. Reusing a key across purposes is forbidden by the spec.
+
+Publish the JWK in the agent's JWKS, referenced from the relevant `agents[]` entry in `brand.json`:
+
+```json
+// /.well-known/jwks.json on the brand-agent origin
+{
+  "keys": [
+    {
+      "kty": "EC", "crv": "P-256",
+      "kid": "brand-agent-response-2026-01",
+      "x": "...", "y": "...",
+      "use": "sig",
+      "key_ops": ["verify"],
+      "adcp_use": "response-signing"
+    },
+    {
+      "kty": "EC", "crv": "P-256",
+      "kid": "brand-agent-request-2026-01",
+      "x": "...", "y": "...",
+      "use": "sig",
+      "key_ops": ["verify"],
+      "adcp_use": "request-signing"
+    }
+  ]
+}
+```
+
+```json
+// /.well-known/brand.json — agents[] entry
+{
+  "agents": [
+    {
+      "type": "brand",
+      "url": "https://brand-agent.nikeinc.com/mcp",
+      "id": "nikeinc_brand_agent",
+      "jwks_uri": "https://brand-agent.nikeinc.com/.well-known/jwks.json"
+    }
+  ]
+}
+```
+
+In code, sign the response payload before returning it:
+
+```typescript
+import { signResponseEnvelope } from "./signing"; // your library of choice
+
+function signedResponse(body: Record<string, unknown>) {
+  const signed = signResponseEnvelope(body, {
+    kid: "brand-agent-response-2026-01",
+    adcp_use: "response-signing",
+  });
+  return { content: [{ type: "text", text: JSON.stringify(signed) }] };
+}
+```
+
+See [request-signing](/docs/building/by-layer/L1/request-signing) for the keypair-generation and JWKS-publication pattern; the response-signing key follows the same shape with a different `adcp_use` tag.
+
+### Rate limiting
+
+Rate-limit per `{caller_identity, claim_type, claim-target}` — a buyer hammering one trademark differs from a buyer surveying many properties, and conflating them invites either over- or under-blocking. On the limit, return `Retry-After` AND prefer returning a cached prior answer over a hard `RATE_LIMITED` error. The caller can act on a stale `owned`; they can't act on `429`.
+
+```typescript
+const RATE_LIMIT_WINDOW_SEC = 60;
+const RATE_LIMIT_MAX = 30;
+
+function rateLimitKey(callerId: string, claimType: string, claim: unknown): string {
+  const target = extractTarget(claimType, claim); // subsidiary_domain | property.identifier | mark+registry
+  return `${callerId}::${claimType}::${target}`;
+}
+
+async function rateLimited(callerId: string, claimType: string, claim: unknown): Promise<boolean> {
+  const key = rateLimitKey(callerId, claimType, claim);
+  const count = await counter.increment(key, RATE_LIMIT_WINDOW_SEC);
+  return count > RATE_LIMIT_MAX;
+}
+
+async function rateLimitedResponse(claimType: string, callerId: string, claim: unknown) {
+  const cached = await responseCache.get(rateLimitKey(callerId, claimType, claim));
+  if (cached) {
+    return { content: [{ type: "text", text: JSON.stringify({ ...cached, _from_cache: true }) }] };
+  }
+  return {
+    content: [{
+      type: "text",
+      text: JSON.stringify({
+        errors: [{ code: "RATE_LIMITED", message: "Rate limit exceeded for this claim." }],
+      }),
+    }],
+    _meta: { "retry-after": String(RATE_LIMIT_WINDOW_SEC) },
+    isError: true,
+  };
+}
+```
+
+### Cache headers per status
+
+Set `Cache-Control: max-age=N` on the response. Recommended values from the task page:
+
+| Status | max-age |
+|---|---|
+| `owned`, `not_ours`, `disputed` | 24–72h |
+| `pending_review` | ≤1h |
+| `transferring` | ≤4h |
+| `licensed_in`, `licensed_out` | 24h |
+| `unknown` | ≤1h |
+| `use_case_authorization` present | Re-check per session |
+
+Consumers MAY override downward but SHOULD NOT exceed agent-supplied `max-age`.
+
+### Notification loop for pending_review
+
+When a `verify_brand_claim` call lands on an unknown subsidiary/property/trademark and the agent's policy is "ask the portfolio team", the agent enqueues a `pending_review` record AND surfaces a notification to the team. Implementation is agent-side; common patterns:
+
+- **Email the portfolio team** at the address on `brand.json` `contact.email`.
+- **Open a ticket** in the brand's existing tracker (Jira, Linear, Zendesk).
+- **Slack notify** the portfolio channel.
+
+The notification carries the claim payload, the caller identity, and the `expected_resolution_window_days`. A reviewer's action — accept, reject, transfer, archive — flips the record's status and the next `verify_brand_claim` call on the same claim returns the terminal answer.
+
+```typescript
+async function enqueuePendingReview(claim: SubsidiaryClaim, callerId: string): Promise<SubsidiaryRecord> {
+  const record: SubsidiaryRecord = {
+    subsidiary_brand_id: claim.subsidiary_brand_id ?? "",
+    subsidiary_domain: claim.subsidiary_domain,
+    status: "pending_review",
+    first_observed_by_house_at: new Date().toISOString(),
+    expected_resolution_window_days: 14,
+  };
+  await subsidiaries.create(record);
+  await notifications.send({
+    channel: "portfolio_team",
+    subject: `New subsidiary claim: ${claim.subsidiary_domain}`,
+    body: { claim, caller: callerId, window_days: 14 },
+  });
+  return record;
+}
+```
+
+### UI considerations
+
+When your agent returns `disputed` or `not_ours`, consumers render the rejection in their own UIs (DSP inventory shopping, portfolio explorer, creative clearance). The agent owes a clear `context_note` — that string ends up in front of humans. See [UI guidance for rejected claims](/docs/brand-protocol/ui-guidance) for the consumer-side conventions to keep in mind when writing your `context_note` text.
 
 ## Tier 2: rights only
 
@@ -379,12 +765,15 @@ Key things to verify: core fields returned for public callers, deeper data for a
 - [ ] `available_fields` correctly lists withheld sections
 - [ ] Error responses use the `errors` array format
 - [ ] If implementing rights: `get_rights` returns pricing options and `acquire_rights` returns terms
+- [ ] If implementing verification: `get_adcp_capabilities` advertises `verify_brand_claim` and `supported_claim_types`, responses are signed under a distinct `adcp_use: "response-signing"` JWK, `pending_review` records age out per the declared window, rate-limited calls return `Retry-After` and prefer cached prior answers
 
 ## Related
 
 - [Brand protocol overview](/docs/brand-protocol/index) — How brand discovery works
 - [brand.json spec](/docs/brand-protocol/brand-json) — File format for brand declaration
 - [get_brand_identity](/docs/brand-protocol/tasks/get_brand_identity) — Identity task reference
+- [verify_brand_claim](/docs/brand-protocol/tasks/verify_brand_claim) — Verification task reference
+- [UI guidance for rejected claims](/docs/brand-protocol/ui-guidance) — Consumer-side rendering of `disputed` / `not_ours`
 - [get_rights](/docs/brand-protocol/tasks/get_rights) — Rights discovery task reference
 - [acquire_rights](/docs/brand-protocol/tasks/acquire_rights) — Rights acquisition task reference
 - [Accounts overview](/docs/accounts/overview) — How account linking works

--- a/docs/brand-protocol/ui-guidance.mdx
+++ b/docs/brand-protocol/ui-guidance.mdx
@@ -1,0 +1,163 @@
+---
+title: UI guidance for rejected claims
+description: "Non-normative consumer-side guidance for rendering verify_brand_claim disputed / not_ours rejections in DSPs, portfolio explorers, creative-clearance UIs, and brand-safety pipelines. Covers attribution language, recovery paths for the rejected publisher, audit trail recommendations, and legal-exposure considerations."
+"og:title": "AdCP — UI guidance for rejected claims"
+---
+
+When [`verify_brand_claim`](/docs/brand-protocol/tasks/verify_brand_claim) returns `disputed` or `not_ours`, the rejection is authoritative — a brand has standing to refuse association unilaterally. But the *signed answer* travels alone; the consumer surface that renders it owes the humans on both sides a sane presentation.
+
+This page is non-normative. It collects conventions for the consumer side — DSPs, portfolio explorers, creative-clearance UIs, brand-safety pipelines — and for the leaf publisher whose claim was rejected.
+
+## Rendering rejected claims
+
+The rejected response carries a `status` (`disputed` or `not_ours`) and usually a `context_note` written by the brand-agent. The note is intended for human eyes; surface it.
+
+### Attribution language
+
+**Always attribute the rejection to the rejecting brand.** A signed `not_ours` from Nike's brand-agent says *Nike says this is not theirs* — it does NOT say *this publisher is fake*. The distinction matters legally; see [Legal exposure](#legal-exposure) below.
+
+| Don't render | Render instead |
+|---|---|
+| "fake-nike-store.com is fraudulent" | "Nike, Inc. does not recognize fake-nike-store.com as one of its properties" |
+| "This subsidiary claim is invalid" | "Nike, Inc. has rejected this brand's subsidiary claim" |
+| "Trademark not owned" | "Brand X disputes the claim that this mark is theirs in this jurisdiction" |
+
+### DSP inventory shopping
+
+When a DSP buyer agent checks a property claim before bidding and gets `not_ours` or `disputed`:
+
+- **Exclude the property from the buy by default.** A rejected property claim means the publisher's house attribution is in question — bid risk is elevated regardless of the underlying inventory quality.
+- **Surface the rejection inline in the inventory row**, not in a separate audit log. The buyer needs the signal at decision time.
+- **Show the `context_note` verbatim** as the brand's explanation. Don't paraphrase — the brand wrote it deliberately.
+- **Offer the buyer a manual-override path** for cases where the property is legitimately operated under a different relationship the buyer has separately verified.
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│ ◯ premium-sports-network.com                CPM $4.20  ━━━ │
+│                                                              │
+│  ⚠ Nike, Inc. has rejected this site's house-affiliation    │
+│    claim ("Unaffiliated third-party site; we do not         │
+│    authorize use of our marks on it.")                      │
+│                                                              │
+│  [View details]  [Override and bid anyway]                  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Portfolio explorer
+
+A portfolio explorer (the AAO registry, a brand-safety vendor's lookup tool) renders brand relationships. When a relationship edge has been rejected at the agent layer:
+
+- **Don't show the edge as if it exists with a warning icon.** Show it as *contested* — a distinct visual state from *verified*, *unverified-pending-reciprocation*, and *missing*.
+- **Render both sides of the rejected edge.** "Brand X claims subsidiary-of Brand Y. Brand Y has rejected this claim."
+- **Timestamp the rejection.** Brands change positions; a 2-year-old rejection of what is now a real acquisition shouldn't dominate the UI.
+- **Link the leaf to its update path** (see [Recovery paths](#recovery-paths-for-the-rejected-leaf) below).
+
+### Creative-clearance UI
+
+Creative-clearance pipelines call `verify_brand_claim` with `claim_type: "trademark"` to confirm a generated creative isn't trespassing on a mark. When the response is `disputed` or `not_ours`:
+
+- **Block the creative from publish by default.** The mark is contested or denied; promoting the creative invites takedown.
+- **Render the disputing brand's `context_note`** so the creative reviewer can decide whether to escalate to legal.
+- **Don't auto-retry** with a different mark variant — the rejection is jurisdictional and a near-miss may produce the same result.
+
+### Brand-safety pipeline
+
+Brand-safety vendors aggregate `verify_brand_claim` signals across the supply chain. When a property is rejected by its claimed house:
+
+- **Demote the property in safety scoring** but don't silently zero it out — the publisher may have legitimate independent inventory.
+- **Surface the rejection in the safety report** with full attribution: "Brand X rejected this site's affiliation claim on $DATE." Buyers reading the report need to know who made the call.
+- **Recompute on a schedule** matching the agent's `Cache-Control: max-age`. Don't pin the rejection state forever — the underlying status can transition.
+
+## Recovery paths for the rejected leaf
+
+The leaf publisher whose `house_domain` (or `properties[]`, or `trademarks[]`) claim was rejected has **no protocol-level recourse beyond updating or removing the claim**. There is no "appeal" task in the brand protocol. This is by design — a brand has standing to refuse association without a counter-process.
+
+But a consumer surface that lands on a rejected leaf SHOULD give that leaf operator a clear next-step UI. Otherwise the publisher sees their site demoted with no explanation.
+
+### Surface the rejection to the leaf
+
+If the consumer surface knows it's looking at the leaf (e.g., the leaf logged into a portfolio explorer or DSP self-service portal):
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│ Your brand.json claims house_domain: nikeinc.com            │
+│                                                              │
+│ Nike, Inc.'s brand-agent has rejected this claim:           │
+│   "We have no record of this brand; the leaf's claim is in  │
+│    error."                                                   │
+│                                                              │
+│ What this means: AdCP consumers will treat your site as     │
+│ standalone (not a Nike subsidiary). Your own brand identity │
+│ is unaffected.                                              │
+│                                                              │
+│ Next steps:                                                 │
+│   • If you should be in Nike's portfolio, contact           │
+│     <portfolio@nikeinc.com> (from Nike's brand.json).       │
+│   • If the claim was mistaken, edit your brand.json to      │
+│     remove `house_domain`, or point it at the correct       │
+│     parent.                                                 │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### What the leaf cannot do
+
+- **There is no protocol-defined challenge mechanism.** The leaf cannot "force" reconsideration through AdCP; that is an out-of-band business conversation.
+- **A leaf claiming `house_domain: A` against A's published rejection does NOT establish the relationship.** Consumers will continue to treat the leaf as standalone.
+- **Re-asserting via different surfaces (a new brand-agent on a new subdomain) doesn't help** — the consumer trust gate is domain control + house-side reciprocation, not number of assertions.
+
+## Audit trail and appeal-process notes
+
+Out-of-spec but worth documenting: keep a record of rejections so a brand or publisher can see the history.
+
+### What to record per rejected response
+
+- **Timestamp** of the response.
+- **Caller identity** that initiated the verify call (your own user, or the upstream service).
+- **Full signed envelope** of the brand-agent's response — signature included, for downstream attestation.
+- **`status`**, **`context_note`**, and the `claim` payload that triggered it.
+- **Cache validity window** (`Cache-Control: max-age`) so you know when the record could be stale.
+
+A signed envelope is durable evidence. If a buyer is challenged for excluding a property based on a Nike rejection, the signed envelope from Nike's brand-agent at that moment in time is the artifact the buyer hands back.
+
+### Appeal-process surface
+
+If your platform supports an appeal flow (a vendor-mediated dispute between leaf and house), keep it OUT of the protocol layer and IN your platform's relationship-management surface. The protocol's job is to convey the brand's authoritative answer; your platform's job is to broker the business conversation if there is one.
+
+## Legal exposure
+
+Broadcasting one brand's rejection of another party carries defamation risk. Two considerations:
+
+### Attribute, don't editorialize
+
+Render rejections as the brand's first-person statement, attributed to the brand:
+
+- **Good**: "Nike, Inc. has stated that fake-nike-store.com is not one of its properties."
+- **Bad**: "fake-nike-store.com is a fraudulent Nike imitator."
+
+The first is a reportable fact (Nike's signed statement); the second is an accusation made by your platform.
+
+### The consumer surface is responsible, not AdCP
+
+AdCP delivers a signed answer from one party to another. The consumer surface — the UI that renders that answer to a third party — owns the editorial decisions about how to present it. AdCP does not pre-litigate defamation; render with care.
+
+Specifically:
+
+- **The rejecting brand owns the `context_note` text.** If a brand writes "fake-nike-store.com is a scam," that's the brand's statement and the brand's exposure. Your surface can render it verbatim or summarize it more neutrally; both are reasonable depending on your audience.
+- **Your platform owns any text outside the `context_note`.** Headlines, severity labels, badges ("VERIFIED FRAUD") are your editorial choices and your exposure.
+- **Status-icon design carries weight.** A red X next to a publisher's name reads differently than a yellow "house affiliation contested" badge. Choose the visual register that matches the underlying signal.
+
+### When in doubt, attribute and link
+
+The lowest-risk pattern is to attribute the statement to the brand and link to the signed source:
+
+```text
+"Nike, Inc. says this is not theirs." [View signed response]
+```
+
+The buyer or reviewer can click through to the signed envelope and form their own view. Your platform delivered the signal without amplifying it.
+
+## Related
+
+- [verify_brand_claim](/docs/brand-protocol/tasks/verify_brand_claim) — The task this guidance applies to
+- [Building a brand agent](/docs/brand-protocol/building-a-brand-agent) — Agent-side implementation, including the public/authorized split and signing setup
+- [brand.json § Agent-augmented verification](/docs/brand-protocol/brand-json#agent-augmented-verification) — The asymmetric trust model that makes rejections authoritative


### PR DESCRIPTION
## Summary

Bundled documentation work for issues #4543 and #4544, both built on the `verify_brand_claim` task shipped in #4540.

**#4543 — building-a-brand-agent Tier-2 implementer guide.** New section `Adding verify_brand_claim` in `docs/brand-protocol/building-a-brand-agent.mdx`, positioned between the existing Tier 1 (identity) and the existing Tier 2 (rights) sections so the doc flow stays intact. Covers:

- Capability declaration with `supported_claim_types` per-tool extension
- Internal state model (subsidiary portfolio, parent declaration, property registry, trademark registry, pending-claim queue, archive) and how it mirrors `brand.json`
- Tool registration with per-`claim_type` request validation (`INVALID_INPUT` discipline)
- Per-claim-type response shaping with the public/authorized field split
- `pending_review` aging contract — cron sweep and event-driven patterns
- Per-purpose JWK setup: `adcp_use: "response-signing"` distinct from `request-signing` per the keys-per-purpose convention, with brand.json `agents[].jwks_uri` pointer
- Rate-limiting per `{caller_identity, claim_type, claim-target}`, returning `Retry-After` and preferring cached prior answer over `RATE_LIMITED`
- Per-status `Cache-Control: max-age` recommendations
- Notification-loop reference pattern for surfacing `pending_review` to the portfolio team
- Role table and deployment checklist extended

**#4544 — UI guidance for disputed/not_ours rendering.** New file `docs/brand-protocol/ui-guidance.mdx` (option A — separate page; keeps the agent-implementer guide focused and gives consumer UX its own audience). Covers attribution language ("Brand X says this is not theirs", not "Brand Y is fake"), surface-specific guidance (DSP inventory shopping, portfolio explorer, creative-clearance, brand-safety pipelines), recovery paths for the rejected leaf publisher (no protocol-level appeal — update or remove the claim), audit-trail recommendations (keep the signed envelope), and legal-exposure considerations (the consumer surface owns editorial framing; AdCP delivers the signed answer). Added to both Brand nav groups in `docs.json`.

Pure docs; no schema changes. Patch-level changeset.

## Test plan

- [x] `npm run test:json-schema` — 260 schema-bearing JSON blocks valid
- [x] `npm run check:owned-links` — all browser-facing links reachable
- [x] `npm run lint:schema-links` — no bare /schemas/ link rewrites needed
- [x] `docs.json` is valid JSON; new `ui-guidance` page registered in both Brand nav groups
- [ ] Mintlify renders the new page and the new section without anchor collisions

Closes #4543
Closes #4544

🤖 Generated with [Claude Code](https://claude.com/claude-code)