### PR TITLE
feat(brand-protocol): verify_brand_claims — bulk variant (#4542)

### DIFF
--- a/.changeset/verify-brand-claims-bulk.md
+++ b/.changeset/verify-brand-claims-bulk.md
@@ -1,0 +1,23 @@
+---
+"adcontextprotocol": minor
+---
+
+Brand protocol gains `verify_brand_claims` — the bulk variant of `verify_brand_claim`. Same four claim types (`subsidiary`, `parent`, `property`, `trademark`), same per-claim semantics, one MCP round-trip and one rate-limit slot for up to 100 claims. Use when a caller (crawler refreshing a brand portfolio, creative-clearance pipeline batch, inventory-onboarding scan) needs to verify many claims against one brand-agent and per-call overhead dominates.
+
+**Sibling tool, not a mode flag.** `verify_brand_claim` stays as-is for one-off verifications; `verify_brand_claims` is the dedicated bulk surface. Cleaner schemas (no single-vs-bulk discriminator inside one tool), cleaner capability advertisement (each tool is advertised independently in `supported_tasks`), cleaner error semantics (per-result errors don't mix with single-target failures).
+
+**Order is preserved.** Agents MUST return `results[]` in the same order as the request's `claims[]` (positional zip-by-index). Callers pass a position-indexed batch and consume results by index.
+
+**Partial-failure semantics.** Per-claim failures (`UNSUPPORTED_CLAIM_TYPE` for one item, `AMBIGUOUS_MATCH` on one trademark query) ride on a per-result `error` field and do NOT fail the batch. Top-level `errors[]` is reserved for batch-level failures (auth, rate-limit, malformed request, over-cap claim count) — when set, `results` is absent. The two are mutually exclusive at the wire.
+
+**Caching.** Top-level `Cache-Control: max-age` represents the lowest-common max-age across the batch. Per-result staleness varies by status; callers needing finer cache control should split batches by expected volatility or re-verify volatile claims individually.
+
+**Rate-limiting.** A bulk call consumes one rate-limit slot per call, not per result. A batch of 100 hits the per-`{caller, query-target}` limit once. Agents SHOULD size bulk limits in calls/window when bulk is advertised.
+
+**Trust model unchanged and unshortened.** Mutual assertion still requires calling both sides — a `subsidiary` result returning `owned` inside a bulk batch still requires a separate `parent` call against the leaf-side agent. Bulk is round-trip economy, not a trust-model shortcut.
+
+**Schema additions:**
+- `brand/verify-brand-claims-request.json` — `claims[]` array with the per-item discriminator on `claim_type`. Max batch size 100; agents MAY enforce lower.
+- `brand/verify-brand-claims-response.json` — success arm carries `results[]` aligned to the request; per-result success mirrors `verify-brand-claim-response.json` success arm, per-result error carries an `error` field. Error arm carries batch-level `errors[]`.
+
+**No changes to `verify_brand_claim`.** Single-target tool ships unchanged; the bulk variant is purely additive. Capability advertisement is per-tool — agents MAY ship one, the other, or both. A `supported_claim_types` declaration applies to both tools when both are advertised.

--- a/docs.json
+++ b/docs.json
@@ -501,6 +501,7 @@
                         "pages": [
                           "docs/brand-protocol/tasks/get_brand_identity",
                           "docs/brand-protocol/tasks/verify_brand_claim",
+                          "docs/brand-protocol/tasks/verify_brand_claims",
                           "docs/brand-protocol/tasks/get_rights",
                           "docs/brand-protocol/tasks/acquire_rights",
                           "docs/brand-protocol/tasks/update_rights"
@@ -1071,6 +1072,7 @@
                     "pages": [
                       "docs/brand-protocol/tasks/get_brand_identity",
                       "docs/brand-protocol/tasks/verify_brand_claim",
+                      "docs/brand-protocol/tasks/verify_brand_claims",
                       "docs/brand-protocol/tasks/get_rights",
                       "docs/brand-protocol/tasks/acquire_rights",
                       "docs/brand-protocol/tasks/update_rights"

--- a/docs/brand-protocol/tasks/verify_brand_claim.mdx
+++ b/docs/brand-protocol/tasks/verify_brand_claim.mdx
@@ -16,6 +16,8 @@ Ask a brand-agent a verification question about a facet of its identity. **This 
 
 The brand-agent answers using its own data — which is brand.json plus the richer states (`pending_review`, `transferring`, `licensed_in`, etc.) that the static file can't express. The tool is one specific-question affordance on top of the same identity surface `get_brand_identity` reads.
 
+For high-volume verification (portfolio refresh, creative-clearance batches, crawler scans), use the bulk variant [`verify_brand_claims`](/docs/brand-protocol/tasks/verify_brand_claims) — same per-claim semantics, one round-trip and one rate-limit slot for the whole batch.
+
 ## The trust rule — two calls, not one
 
 **A single signed `owned` response is NOT trust-extending. Mutual assertion remains the floor for positive trust.** This is the load-bearing rule of the asymmetric trust model — assertion direction requires both sides to agree. Consumers MUST call both sides when extending relationship trust:

--- a/docs/brand-protocol/tasks/verify_brand_claims.mdx
+++ b/docs/brand-protocol/tasks/verify_brand_claims.mdx
@@ -1,0 +1,159 @@
+---
+title: verify_brand_claims
+description: "verify_brand_claims is the bulk variant of verify_brand_claim — verify many claims against one brand-agent in a single round-trip. Same four claim types (subsidiary, parent, property, trademark); results are returned positionally aligned with the request."
+"og:title": "AdCP — verify_brand_claims"
+testable: true
+---
+
+Bulk variant of [`verify_brand_claim`](/docs/brand-protocol/tasks/verify_brand_claim). The agent answers many verification questions in a single round-trip, returning one result per claim in the same order the caller sent them. Use when MCP round-trip cost dominates the per-claim work — crawlers refreshing brand portfolios, creative-clearance pipelines clearing a creative batch against one rights-holder, inventory-onboarding scans verifying a supply-path against a house.
+
+**This is a bulk affordance, not a different operation.** Per-claim semantics — trust model, applicable statuses, authorization tiers, per-claim-type `details` shapes — are identical to the single-target tool. Everything documented on the single-target page applies per-result; this page covers only the bulk-specific concerns.
+
+## When to use the bulk variant
+
+| Workflow | Variant | Why |
+|---|---|---|
+| One-off verification (single page, single creative, single subsidiary check) | [`verify_brand_claim`](/docs/brand-protocol/tasks/verify_brand_claim) | No batching benefit; simpler error model. |
+| Portfolio refresh (re-verify all known subsidiaries / properties / marks for one brand) | `verify_brand_claims` | MCP overhead dominates. |
+| Crawler-driven full-portfolio verification (Nike portfolio: ~100 properties across regions) | `verify_brand_claims` | 100 → 1 round-trip. |
+| Creative-clearance batch (clear N creatives against one rights-holder pre-flight) | `verify_brand_claims` | Same rate-limit slot for the batch (see below). |
+| Cross-brand verification (different claims against different agents) | One bulk call per brand-agent | Each agent is a separate addressable endpoint; bulk is intra-agent. |
+
+## Schema
+
+- **Request**: [`verify-brand-claims-request.json`](https://adcontextprotocol.org/schemas/v3/brand/verify-brand-claims-request.json)
+- **Response**: [`verify-brand-claims-response.json`](https://adcontextprotocol.org/schemas/v3/brand/verify-brand-claims-response.json)
+
+## Capability discovery
+
+Bulk support is advertised separately from the single-target tool. Agents MAY ship the single-target tool only, the bulk tool only, or both. A `supported_claim_types` declaration applies to BOTH tools when both are advertised — the bulk variant cannot accept claim types the agent's single-target implementation cannot answer.
+
+```json
+{
+  "supported_protocols": ["brand"],
+  "supported_tasks": [
+    "get_brand_identity",
+    "verify_brand_claim",
+    "verify_brand_claims"
+  ],
+  "brand": {
+    "verify_brand_claim": {
+      "supported_claim_types": ["subsidiary", "parent", "property", "trademark"]
+    }
+  }
+}
+```
+
+Agents MAY advertise a lower per-call batch ceiling than the spec's 100 cap. When the ceiling differs, advertise it via an `extensions`-style entry on the capability descriptor or document it out-of-band; consumers SHOULD treat 100 as the maximum and SHOULD chunk accordingly when the agent's cap is lower.
+
+## Order is preserved
+
+The agent MUST return `results[]` in the same order as the request's `claims[]` (positional zip-by-index). Callers pass a position-indexed batch and consume results by index. This guarantee lets callers correlate inputs and outputs without re-keying:
+
+```
+request.claims[7]  ↔  response.results[7]
+```
+
+If the batch fails wholesale (auth, rate-limit, malformed request), the response carries top-level `errors[]` and omits `results`. There is no "partial response with results AND batch errors" mode — batch errors and per-result errors are mutually exclusive at the wire.
+
+## Partial failure — per-result errors
+
+Per-claim failures (an `UNSUPPORTED_CLAIM_TYPE` for one of many claims, an `AMBIGUOUS_MATCH` on one trademark query in a portfolio of properties) DO NOT fail the batch. The corresponding entry in `results[]` carries an `error` field instead of `claim_type`/`status`, and the rest of the batch is unaffected:
+
+```json
+{
+  "results": [
+    { "claim_type": "property", "status": "owned", "details": { "regions": ["US"] } },
+    { "error": { "code": "AMBIGUOUS_MATCH", "message": "Multiple registrations match 'CONVERSE'; narrow with registry+number." } },
+    { "claim_type": "subsidiary", "status": "not_ours" }
+  ]
+}
+```
+
+Batch-level errors are reserved for failures that prevent the agent from answering anything:
+
+| Tier | Where it goes | Example codes |
+|---|---|---|
+| Per-result | `results[i].error` | `UNSUPPORTED_CLAIM_TYPE`, `INVALID_INPUT` for one item, `AMBIGUOUS_MATCH` |
+| Batch-level | top-level `errors[]` | `AUTH_INVALID`, `RATE_LIMITED`, malformed request, `claims[]` over the cap |
+
+Full error-code semantics are documented on the [single-target task page § Error handling](/docs/brand-protocol/tasks/verify_brand_claim#error-handling).
+
+## Caching
+
+Each result MAY carry its own staleness — `pending_review` is short-lived (≤1h), `owned` is stable (24-72h). Per-status caching guidance is per the single-target page.
+
+Top-level `Cache-Control: max-age` on the bulk response represents the **lowest-common max-age across the batch**: a batch with one `pending_review` and 99 `owned` results SHOULD cache at the `pending_review` ceiling, because consumer-side cache invalidation typically operates at response granularity. Callers that need per-result staleness should either split batches by expected status volatility, or re-verify volatile claims individually.
+
+Agents that support per-result cache hints MAY surface them via `ext` (e.g., `results[i].ext.cache.max_age_seconds`); this remains an extension surface, not part of the normative response.
+
+## Rate-limiting
+
+A bulk call consumes a **single rate-limit slot** per-call, not per-result. A batch of 100 claims hits the per-`{caller, query-target}` limit once, not 100 times. This is the core economic argument for the bulk variant — the limit is on the round-trip, not on the verification work.
+
+Implications:
+
+- Agents SHOULD size rate limits in calls/window rather than claims/window when bulk is advertised. If claim-volume matters operationally, advertise a per-batch claim cap (see Capability discovery).
+- Callers SHOULD prefer one bulk call over N single calls when verifying against the same agent — both for cost and for staying inside the limit.
+- A `RATE_LIMITED` response on a bulk call is a batch-level error; the whole batch is rejected. Retry with `Retry-After` honoured.
+
+## Trust model
+
+Identical to the single-target tool. Per-result `status` follows the same direction-asymmetric rules: rejections (`disputed` / `not_ours`) are authoritative on a single signed response; assertions (`owned` / `pending_review` / `transferring` / `licensed_*`) require reciprocation before extending positive trust.
+
+**No "single-call mutual assertion" shortcut.** A bulk call against one agent does NOT establish mutual assertion for the assertion-direction claims in that batch, even if both halves of a relationship pair appear inside the same bulk request. Mutual assertion is a property of two parties agreeing — the leaf-side agent still has to be called separately for any `subsidiary` claim that returns `owned`, the licensor's agent still has to be called for any `licensed_in`, and so on. Batching is about MCP-round-trip economics, not about collapsing the trust model.
+
+See [`brand.json` § Agent-augmented verification](/docs/brand-protocol/brand-json#agent-augmented-verification) for the full trust table.
+
+## Example — portfolio refresh
+
+A crawler refreshes a known Nike portfolio (one subsidiary check + three property checks) in one round-trip:
+
+```json
+{
+  "claims": [
+    {
+      "claim_type": "subsidiary",
+      "claim": { "subsidiary_domain": "converse.com", "subsidiary_brand_id": "converse" }
+    },
+    {
+      "claim_type": "property",
+      "claim": { "property": { "type": "website", "identifier": "nike.com" } }
+    },
+    {
+      "claim_type": "property",
+      "claim": { "property": { "type": "website", "identifier": "nike.cn", "region": "CN" } }
+    },
+    {
+      "claim_type": "trademark",
+      "claim": { "mark": "AIR JORDAN", "registry": "USPTO", "number": "1234567" }
+    }
+  ]
+}
+```
+
+```json
+{
+  "results": [
+    { "claim_type": "subsidiary", "status": "owned", "details": { "brand_id": "converse" } },
+    { "claim_type": "property", "status": "owned", "details": { "relationship": "owned", "brand_id": "nike", "regions": ["US", "CA", "GB", "FR", "DE", "JP", "AU"] } },
+    { "claim_type": "property", "status": "owned", "details": { "relationship": "owned", "brand_id": "nike", "regions": ["CN"] }, "context_note": "Regional site for China market" },
+    { "claim_type": "trademark", "status": "owned", "details": { "matched_registration": { "registry": "USPTO", "number": "1234567", "mark": "AIR JORDAN", "registration_status": "active" }, "countries": ["US"], "nice_classes": [25, 41] } }
+  ]
+}
+```
+
+To extend governance trust through the `subsidiary` result, the caller still needs to call Converse's brand-agent with `claim_type: "parent"`. The bulk call is round-trip economy; it is not a trust-model shortcut.
+
+## Batch-level error example
+
+```json
+{
+  "errors": [
+    {
+      "code": "RATE_LIMITED",
+      "message": "Caller has exhausted per-window quota. Retry after the indicated interval."
+    }
+  ]
+}
+```

--- a/scripts/oneof-discriminators.baseline.json
+++ b/scripts/oneof-discriminators.baseline.json
@@ -81,6 +81,16 @@
       "variants": 2,
       "note": "0:[claim_type,status] | 1:[errors]"
     },
+    "brand/verify-brand-claims-response.json##/definitions/result_entry/oneOf": {
+      "kind": "narrowable",
+      "variants": 2,
+      "note": "0:[claim_type,status] | 1:[error]"
+    },
+    "brand/verify-brand-claims-response.json##/oneOf": {
+      "kind": "narrowable",
+      "variants": 2,
+      "note": "0:[results] | 1:[errors]"
+    },
     "compliance/comply-test-controller-response.json##/oneOf": {
       "kind": "dangerous",
       "variants": 7,

--- a/static/schemas/source/brand/verify-brand-claims-request.json
+++ b/static/schemas/source/brand/verify-brand-claims-request.json
@@ -1,0 +1,184 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/brand/verify-brand-claims-request.json",
+  "title": "Verify Brand Claims Request (Bulk)",
+  "description": "Bulk variant of `verify_brand_claim` — ask a brand-agent to verify many claims in a single round-trip. Use when a caller (e.g., a crawler refreshing a brand portfolio, a creative-clearance pipeline batch, an inventory-onboarding scan) needs to verify 10s-100s of claims against one brand-agent and the per-call MCP overhead dominates. Each entry in `claims[]` carries the same `{ claim_type, claim }` shape as the single-target tool; the agent returns one result per claim in the same order (zip-by-index). Sibling to `verify_brand_claim`; the single-target tool remains the right choice for one-off verifications. Read-only; naturally idempotent — same per-claim dedup as the single-target tool (the brand's internal bookkeeping deduplicates per {caller_identity, claim_type, claim-target}).",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/schemas/core/version-envelope.json"
+    }
+  ],
+  "properties": {
+    "claims": {
+      "type": "array",
+      "description": "Ordered list of verification claims. The agent MUST return `results[]` in the same order (positional zip-by-index). Maximum batch size is 100 per call; agents MAY enforce a lower limit and SHOULD advertise it via `get_adcp_capabilities` (see the task page).",
+      "minItems": 1,
+      "maxItems": 100,
+      "items": {
+        "$ref": "#/definitions/claim_entry"
+      }
+    }
+  },
+  "required": ["claims"],
+  "additionalProperties": true,
+  "definitions": {
+    "claim_entry": {
+      "type": "object",
+      "description": "One verification claim. Shape mirrors the single-target `verify_brand_claim` request body (minus the version envelope, which lives on the batch).",
+      "discriminator": {
+        "propertyName": "claim_type"
+      },
+      "oneOf": [
+        {
+          "title": "VerifySubsidiaryClaim",
+          "description": "House-side: is this brand a subsidiary of mine?",
+          "properties": {
+            "claim_type": {
+              "type": "string",
+              "const": "subsidiary"
+            },
+            "claim": {
+              "type": "object",
+              "properties": {
+                "subsidiary_domain": {
+                  "type": "string",
+                  "format": "hostname",
+                  "description": "Domain of the leaf brand whose `house_domain` claim is being verified."
+                },
+                "subsidiary_brand_id": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9_]+$",
+                  "description": "Stable brand identifier the leaf uses for itself. Optional but recommended."
+                },
+                "observed_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "When the caller observed the leaf's claim."
+                }
+              },
+              "required": ["subsidiary_domain"],
+              "additionalProperties": true
+            }
+          },
+          "required": ["claim_type", "claim"],
+          "additionalProperties": true
+        },
+        {
+          "title": "VerifyParentClaim",
+          "description": "Leaf-side mirror: is this brand my parent house?",
+          "properties": {
+            "claim_type": {
+              "type": "string",
+              "const": "parent"
+            },
+            "claim": {
+              "type": "object",
+              "properties": {
+                "parent_domain": {
+                  "type": "string",
+                  "format": "hostname",
+                  "description": "Domain of the house claimed as this brand's parent."
+                },
+                "claimant_says": {
+                  "type": "string",
+                  "description": "Optional context — what the claimant published or said."
+                },
+                "observed_at": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              },
+              "required": ["parent_domain"],
+              "additionalProperties": true
+            }
+          },
+          "required": ["claim_type", "claim"],
+          "additionalProperties": true
+        },
+        {
+          "title": "VerifyPropertyClaim",
+          "description": "Is this property (website, app, podcast, etc.) one of mine?",
+          "properties": {
+            "claim_type": {
+              "type": "string",
+              "const": "property"
+            },
+            "claim": {
+              "type": "object",
+              "properties": {
+                "property": {
+                  "type": "object",
+                  "description": "Shape matches brand.json properties[] entry.",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": ["website", "mobile_app", "ctv_app", "desktop_app", "dooh", "podcast", "radio", "streaming_audio"]
+                    },
+                    "identifier": { "type": "string" },
+                    "store": {
+                      "type": "string",
+                      "enum": ["apple", "google", "amazon", "roku", "fire_tv", "samsung", "lg", "vizio", "other"]
+                    },
+                    "region": { "type": "string" }
+                  },
+                  "required": ["type", "identifier"],
+                  "additionalProperties": true
+                },
+                "use_case": {
+                  "type": "string",
+                  "maxLength": 100,
+                  "description": "Optional caller-declared use case."
+                }
+              },
+              "required": ["property"],
+              "additionalProperties": true
+            }
+          },
+          "required": ["claim_type", "claim"],
+          "additionalProperties": true
+        },
+        {
+          "title": "VerifyTrademarkClaim",
+          "description": "Is this trademark mine?",
+          "properties": {
+            "claim_type": {
+              "type": "string",
+              "const": "trademark"
+            },
+            "claim": {
+              "type": "object",
+              "properties": {
+                "mark": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 200
+                },
+                "registry": {
+                  "type": "string",
+                  "maxLength": 50
+                },
+                "number": {
+                  "type": "string",
+                  "maxLength": 100
+                },
+                "countries": {
+                  "type": "array",
+                  "items": { "type": "string", "minLength": 2, "maxLength": 2 }
+                },
+                "use_case": {
+                  "type": "string",
+                  "maxLength": 100
+                }
+              },
+              "required": ["mark"],
+              "additionalProperties": true
+            }
+          },
+          "required": ["claim_type", "claim"],
+          "additionalProperties": true
+        }
+      ]
+    }
+  }
+}

--- a/static/schemas/source/brand/verify-brand-claims-response.json
+++ b/static/schemas/source/brand/verify-brand-claims-response.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/brand/verify-brand-claims-response.json",
+  "title": "Verify Brand Claims Response (Bulk)",
+  "description": "Bulk response for `verify_brand_claims`. `results[]` is positionally aligned with the request's `claims[]` (zip-by-index). Per-result success carries `claim_type` + `status` + per-claim-type `details`; per-result failure carries an `error` field on that single result without failing the batch. Top-level `errors[]` is reserved for batch-level failures (auth, rate-limit, malformed request) — in that case `results` is absent. Top-level `Cache-Control` represents the lowest-common max-age across the batch; individual results MAY carry their own staleness signals out-of-band.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/schemas/core/version-envelope.json"
+    }
+  ],
+  "oneOf": [
+    {
+      "title": "VerifyBrandClaimsSuccess",
+      "type": "object",
+      "properties": {
+        "results": {
+          "type": "array",
+          "description": "Per-claim results, positionally aligned with the request's `claims[]`. Each entry is either a per-claim success (claim_type + status + optional details/context_note) or a per-claim error (error field only).",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/result_entry"
+          }
+        },
+        "context": {
+          "$ref": "/schemas/core/context.json"
+        },
+        "ext": {
+          "$ref": "/schemas/core/ext.json"
+        }
+      },
+      "required": ["results"],
+      "additionalProperties": true,
+      "not": {
+        "anyOf": [
+          { "required": ["errors"] }
+        ]
+      }
+    },
+    {
+      "title": "VerifyBrandClaimsError",
+      "type": "object",
+      "description": "Batch-level failure — the entire request was rejected. Use per-result `error` on the success arm for per-claim failures that should not fail the batch.",
+      "properties": {
+        "errors": {
+          "type": "array",
+          "items": {
+            "$ref": "/schemas/core/error.json"
+          },
+          "minItems": 1
+        },
+        "context": {
+          "$ref": "/schemas/core/context.json"
+        },
+        "ext": {
+          "$ref": "/schemas/core/ext.json"
+        }
+      },
+      "required": ["errors"],
+      "additionalProperties": true,
+      "not": {
+        "anyOf": [
+          { "required": ["results"] }
+        ]
+      }
+    }
+  ],
+  "properties": {},
+  "definitions": {
+    "result_entry": {
+      "type": "object",
+      "description": "One entry in `results[]`. Either a per-claim success (claim_type + status + optional details/context_note) or a per-claim error (error field only). Mirrors the single-target `verify_brand_claim` response success arm shape.",
+      "oneOf": [
+        {
+          "title": "VerifyBrandClaimsResultSuccess",
+          "type": "object",
+          "properties": {
+            "claim_type": {
+              "type": "string",
+              "enum": ["subsidiary", "parent", "property", "trademark"],
+              "description": "Echoes the request item's claim_type for caller-side routing."
+            },
+            "status": {
+              "$ref": "/schemas/brand/verification-status.json",
+              "description": "Verification status for this claim. Not every status applies to every claim_type — see the single-target task page for the applicable subset."
+            },
+            "details": {
+              "type": "object",
+              "description": "Per-claim-type response fields. Shape varies — see the single-target task page for each claim_type's expected fields.",
+              "additionalProperties": true
+            },
+            "context_note": {
+              "type": "string",
+              "maxLength": 500,
+              "description": "Public — free-text context the brand chooses to surface."
+            }
+          },
+          "required": ["claim_type", "status"],
+          "additionalProperties": true,
+          "not": {
+            "anyOf": [
+              { "required": ["error"] }
+            ]
+          }
+        },
+        {
+          "title": "VerifyBrandClaimsResultError",
+          "type": "object",
+          "description": "Per-claim failure carried inline so a batch can return partial results. Distinct from the batch-level errors arm.",
+          "properties": {
+            "error": {
+              "$ref": "/schemas/core/error.json"
+            }
+          },
+          "required": ["error"],
+          "additionalProperties": true,
+          "not": {
+            "anyOf": [
+              { "required": ["status"] },
+              { "required": ["claim_type"] }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/check-platform-agnostic.cjs
+++ b/tests/check-platform-agnostic.cjs
@@ -86,6 +86,13 @@ const ENUM_VALUE_ALLOWLIST = [
   { value: 'amazon', pathContains: 'brand/verify-brand-claim-request.json' },
   { value: 'roku',   pathContains: 'brand/verify-brand-claim-request.json' },
 
+  // brand/verify-brand-claims-request.json — bulk variant mirrors the same
+  // store enum; same canonical-identifier justification applies.
+  { value: 'apple',  pathContains: 'brand/verify-brand-claims-request.json' },
+  { value: 'google', pathContains: 'brand/verify-brand-claims-request.json' },
+  { value: 'amazon', pathContains: 'brand/verify-brand-claims-request.json' },
+  { value: 'roku',   pathContains: 'brand/verify-brand-claims-request.json' },
+
   // brand.json — feed_format: google_merchant_center and facebook_catalog are
   // widely-adopted open interchange formats implemented by many third parties.
   { value: 'google_merchant_center', pathContains: 'brand.json' },


### PR DESCRIPTION
Closes #4542.

Adds the bulk sibling to `verify_brand_claim` (shipped in #4540). Same four claim types (`subsidiary` / `parent` / `property` / `trademark`), same per-claim semantics; one MCP round-trip and one rate-limit slot for up to 100 claims. Targets crawlers refreshing brand portfolios, creative-clearance batches, and inventory-onboarding scans where MCP per-call overhead dominates per-claim work.

## Design — Path B (sibling tool)

`verify_brand_claims` ships as a dedicated bulk tool rather than as an array mode bolted onto the single-target tool:

- Cleaner schemas — no single-vs-bulk discriminator inside one tool.
- Cleaner capability advertisement — `supported_tasks: ["verify_brand_claim", "verify_brand_claims"]` is unambiguous; agents MAY ship one, the other, or both.
- Cleaner error semantics — per-result errors don't mix with single-target failures.

`supported_claim_types` declarations apply to both tools when both are advertised — the bulk variant cannot answer claim types the agent's single-target implementation can't.

## Wire contract

- Request: `claims[]` array (1..100), each entry matches the single-target request's per-claim-type shape with `discriminator: { propertyName: "claim_type" }`.
- Response success arm: `results[]` positionally aligned with `claims[]`; each entry is `{ claim_type, status, details?, context_note? }` or `{ error }` for per-claim failures.
- Response error arm: top-level `errors[]` for batch-level failures (auth, rate-limit, malformed, over-cap). Mutually exclusive with `results[]`.
- **Order is normative**: agents MUST zip-by-index. Callers correlate inputs and outputs by position.

## Partial failure

Per-claim failures (`UNSUPPORTED_CLAIM_TYPE` for one item, `AMBIGUOUS_MATCH` on one trademark query) ride on a per-result `error` field and do NOT fail the batch. Top-level `errors[]` is reserved for failures that prevent the agent from answering anything.

## Caching and rate-limiting

- Top-level `Cache-Control: max-age` = lowest-common across the batch. Callers needing finer cache control split batches by expected volatility or re-verify volatile claims individually.
- One rate-limit slot per call, not per result. Agents SHOULD size limits in calls/window when bulk is advertised.

## Trust model — unchanged and unshortened

Mutual assertion still requires calling both sides. A `subsidiary` result returning `owned` inside a bulk batch still requires a separate `parent` call against the leaf-side agent — even if both halves of a relationship pair are in the same batch. Direction-asymmetric trust applies per-result: rejections (`disputed` / `not_ours`) authoritative single-side, assertions (`owned` / `pending_review` / `transferring` / `licensed_*`) require reciprocation. Bulk is round-trip economy, not a trust-model shortcut.

## Files

- `static/schemas/source/brand/verify-brand-claims-request.json` — discriminated `claims[]`; naturally-idempotent exemption marker (parallel to single-target).
- `static/schemas/source/brand/verify-brand-claims-response.json` — narrowable oneOf at the top (results vs errors) and inside `result_entry` (claim_type/status vs error). Ratcheted into `oneof-discriminators.baseline.json` alongside the single-target response's same pattern.
- `docs/brand-protocol/tasks/verify_brand_claims.mdx` — new task page.
- `docs/brand-protocol/tasks/verify_brand_claim.mdx` — one-line pointer to the bulk variant.
- `docs.json` — nav (both top-level and platform-builder reading-path copies).
- `tests/check-platform-agnostic.cjs` — store enum allowlist for the bulk request (mirrors single-target).
- `.changeset/verify-brand-claims-bulk.md` — `adcontextprotocol: minor`.

## Test plan

- [x] `npm run build:schemas` — clean build, idempotency-lint exemption recognised.
- [x] `npm run test:schemas` — all 540 schemas valid, $refs resolve.
- [x] `npm run test:json-schema` — 260 typed JSON blocks validate.
- [x] `npm run test:composed` — 43 tests pass.
- [x] `npm run test:oneof-discriminators` — new entries ratcheted into baseline (same narrowable-by-required-field pattern as single-target response).
- [x] `npm run test:docs-nav` — 15 nav tests pass.
- [x] `npm run test:rejection-arm-mutex` — pass.
- [x] `npm run test:error-handling` — pass.
- [x] `node tests/check-platform-agnostic.cjs` — store enum allowlist accepted.
- [x] `npm run typecheck` — only pre-existing errors (`@adcp/sdk` module missing, `undici` types) that exist on `main`; no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)