### PR TITLE
test(brand-protocol): conformance red test for single-side trust extension on verify_brand_claim (#4597)

### DIFF
--- a/.changeset/verify-brand-claim-red-test.md
+++ b/.changeset/verify-brand-claim-red-test.md
@@ -1,0 +1,25 @@
+---
+---
+
+test(brand-protocol): conformance red test for single-side trust extension on `verify_brand_claim` (#4597).
+
+Adds `protocols/brand/scenarios/single_side_trust_extension.yaml` and the
+`test-kits/single-side-trust-runner.yaml` harness contract. Three variants —
+subsidiary, property, trademark `licensed_in` — drive a partner under test
+through the malicious-house walkthrough from `/brand-protocol/brand-json#agent-augmented-verification`
+and assert via `upstream_traffic`:
+
+- `min_count: 1` against the reciprocation endpoint (leaf `brand.json` crawl
+  for subsidiary; property real-owner crawl for property; licensor `brand.json`
+  crawl for trademark `licensed_in`).
+- `min_count: 0` against trust-extension side-effect patterns (member
+  auto-provisioning, governance-context creation, billable seat inclusion,
+  creative-clearance auto-approval).
+
+No schema or wire-protocol changes; no surface bump. The scenario is a
+consumer-under-test conformance test — the storyboard framework currently
+grades agents serving tasks, so every graded step declares
+`requires_contract: single_side_trust_runner` and grades `not_applicable`
+until adcp-client lands the consumer-under-test dispatch and a partner
+adopter advertises the `evaluate_verify_brand_claim_trust_extension`
+comply_test_controller scenario documented in the runner contract.

--- a/static/compliance/source/protocols/brand/scenarios/single_side_trust_extension.yaml
+++ b/static/compliance/source/protocols/brand/scenarios/single_side_trust_extension.yaml
@@ -1,0 +1,454 @@
+id: brand/single_side_trust_extension
+version: "1.0.0"
+title: "Partners MUST NOT extend trust on a single signed verify_brand_claim response"
+category: brand_baseline
+summary: "Red conformance test for the asymmetric trust model on verify_brand_claim. A partner that auto-provisions, propagates governance, or otherwise extends relationship trust on the strength of one signed `owned` response fails — assertion direction requires reciprocation."
+track: brand
+required_tools:
+  - verify_brand_claim
+
+narrative: |
+  `verify_brand_claim` ships with a direction-asymmetric trust model. Per
+  [`/brand-protocol/tasks/verify_brand_claim`](/brand-protocol/tasks/verify_brand_claim)
+  §"The trust rule — two calls, not one":
+
+  - **Rejection direction** (`disputed` / `not_ours`) is authoritative on a
+    single signed response. A brand has standing to refuse association
+    unilaterally.
+  - **Assertion direction** (`owned` / `pending_review` / `transferring` /
+    `licensed_*`) is informative but NOT trust-extending alone. The
+    reciprocating side must still confirm before relationship trust extends.
+
+  The load-bearing risk is partner-side, not agent-side: a partner that
+  signature-verifies one `owned` response and treats it as trust-conferring
+  would let a malicious or mistaken house claim subsidiaries, properties, or
+  licensed marks it does not legitimately have, and have consumers extend
+  governance trust on the strength of the signature alone. See
+  [`brand.json` § Agent-augmented verification](/brand-protocol/brand-json#agent-augmented-verification)
+  for the full normative trust table and the malicious-house walkthrough.
+
+  ## What this scenario grades
+
+  The subject under test is a CONSUMER of `verify_brand_claim` — a partner
+  that may extend governance trust (auto-provision a member account,
+  propagate governance posture, include the brand in a billable seat
+  computation) based on what the verify response returns. The scenario drives
+  three variants of the malicious-house walkthrough — subsidiary, property,
+  and trademark `licensed_in` — and asserts the partner:
+
+  1. DID call leaf-side reciprocation (a static crawl of the leaf's
+     `brand.json`, or a leaf-side `verify_brand_claim` with the mirror claim
+     type when one is advertised).
+  2. Did NOT extend governance trust on the strength of the malicious house's
+     signed `owned` response alone.
+
+  ## Framework extension
+
+  This scenario is a partner-conformance red test. Every storyboard in the
+  corpus today grades an agent serving a task; this scenario grades a
+  consumer of a task. The dispatch surface required is a partner-side
+  comply_test_controller scenario (`evaluate_verify_brand_claim_trust_extension`)
+  documented in `test-kits/single-side-trust-runner.yaml`. Until adcp-client
+  ships consumer-under-test dispatch and a partner adopter advertises the
+  controller scenario, every graded step in this file declares
+  `requires_contract: single_side_trust_runner` and grades `not_applicable`.
+  Authoring the scenario now gives partners a stable target to register
+  against and gives the runner a stable contract to implement against.
+
+  ## Variants
+
+  - **`subsidiary`** — Malicious house signs `owned` for a subsidiary claim
+    on `independent-leaf.example`. The leaf's static `brand.json` does NOT
+    declare `house_domain: malicious-house.example`. Pass = the partner
+    crawls the leaf and concludes no relationship; trust is not extended.
+  - **`property`** — Malicious house signs `owned` for a property
+    (`real-property-owner.example`) it does not actually own. The property's
+    real owner publishes a `brand.json` listing the property in its own
+    `properties[]`. Pass = the partner cross-checks the property's
+    real owner; trust is not extended.
+  - **`trademark` `licensed_in`** — Malicious house signs `licensed_in` for a
+    mark, naming `non-reciprocating-licensor.example` as the licensor. The
+    licensor's static `brand.json` does NOT publish a matching `licensed_out`
+    entry for the mark. Pass = the partner crawls the licensor and concludes
+    the licensing relationship is unverified; trust is not extended.
+
+  Each variant fires independently and grades independently. A partner that
+  passes one variant and fails another is reported per-variant — partial
+  conformance is informative for implementors.
+
+agent:
+  interaction_model: brand_rights_holder
+  capabilities: []
+  examples:
+    - "Any partner that consumes verify_brand_claim and may extend governance trust on the result — AAO members provisioning brand accounts, agencies inheriting brand relationships, governance platforms propagating spending-authority scope."
+
+caller:
+  role: compliance_runner
+  example: "AdCP Verified runner with consumer-under-test dispatch capability"
+
+prerequisites:
+  description: |
+    The runner hosts the fixture brand-agents and static `brand.json` files
+    documented in `test-kits/single-side-trust-runner.yaml`. The partner
+    under test advertises a comply_test_controller scenario named
+    `evaluate_verify_brand_claim_trust_extension` (see the runner contract
+    for the request shape). Partners that do not advertise this scenario
+    grade every step `not_applicable` (the red test is opt-in by partner
+    capability, matching the upstream_traffic convention from
+    `storyboard-schema.yaml`). Partners that DO advertise it but produce
+    traffic patterns inconsistent with the conformance criteria below grade
+    `failed` — silent passing on an empty traffic record is the façade
+    signal this scenario exists to catch.
+  test_kit: "test-kits/single-side-trust-runner.yaml"
+
+phases:
+  - id: subsidiary_variant
+    title: "Subsidiary — malicious house claims a non-reciprocating leaf"
+    narrative: |
+      The runner dispatches the partner under test with a verify_brand_claim
+      target on `malicious-house.example`'s brand-agent, asking the
+      subsidiary question for `independent-leaf.example`. The malicious
+      house signs `owned`. The partner is then observed via
+      `query_upstream_traffic`. The partner MUST have fetched the leaf's
+      static `brand.json` (no leaf-side brand-agent advertised) and MUST
+      NOT have triggered any trust-extension side effect.
+
+    steps:
+      - id: dispatch_subsidiary_red_test
+        title: "Drive partner through verify_brand_claim subsidiary walkthrough"
+        narrative: |
+          The runner calls the partner's comply_test_controller with
+          scenario `evaluate_verify_brand_claim_trust_extension`,
+          variant `subsidiary`. The controller scenario instructs the
+          partner to invoke verify_brand_claim against
+          `malicious-house.example`'s brand-agent, evaluate the signed
+          response, and decide whether to extend trust to the leaf. The
+          runner returns from the controller call and proceeds to the
+          observability assertions below.
+        task: comply_test_controller
+        schema_ref: "extensions/test/comply-test-controller-request.json"
+        response_schema_ref: "extensions/test/comply-test-controller-response.json"
+        doc_ref: "/building/implementation/comply-test-controller"
+        requires_contract: single_side_trust_runner
+        stateful: true
+        expected: |
+          The controller scenario completes (any terminal status). The
+          partner's trust-extension decision is asserted by the
+          upstream_traffic checks on the following step, not by the
+          controller's return shape.
+        sample_request:
+          scenario: evaluate_verify_brand_claim_trust_extension
+          params:
+            variant: subsidiary
+            brand_agent_url: "https://malicious-house.example/agents/brand"
+            claim:
+              claim_type: subsidiary
+              claim:
+                subsidiary_domain: "independent-leaf.example"
+                subsidiary_brand_id: "independent_leaf"
+                observed_at: "2026-05-16T00:00:00Z"
+          context:
+            correlation_id: "brand--single_side_trust--subsidiary--dispatch"
+
+      - id: assert_subsidiary_reciprocation_observed
+        title: "Partner DID call leaf-side reciprocation"
+        narrative: |
+          The runner queries the partner's comply_test_controller
+          `query_upstream_traffic` (window scoped to this step's
+          dispatch). The partner MUST have fetched
+          `https://independent-leaf.example/.well-known/brand.json` to
+          check for a reciprocating `house_domain` claim. A partner that
+          extended trust without performing this fetch is the bug the red
+          test exists to surface.
+        task: verify_brand_claim
+        schema_ref: "brand/verify-brand-claim-request.json"
+        response_schema_ref: "brand/verify-brand-claim-response.json"
+        doc_ref: "/brand-protocol/tasks/verify_brand_claim"
+        requires_contract: single_side_trust_runner
+        stateful: false
+        expected: |
+          Recorded upstream traffic includes at least one GET against the
+          leaf's `.well-known/brand.json` endpoint, carrying the leaf
+          domain as a load-bearing identifier echo (anti-façade).
+        sample_request:
+          claim_type: subsidiary
+          claim:
+            subsidiary_domain: "independent-leaf.example"
+          context:
+            correlation_id: "brand--single_side_trust--subsidiary--reciprocation"
+        validations:
+          - check: upstream_traffic
+            description: "Partner fetched the leaf's brand.json for reciprocation"
+            endpoint_pattern: "GET *independent-leaf.example/.well-known/brand.json"
+            min_count: 1
+            identifier_paths:
+              - "claim.subsidiary_domain"
+
+      - id: assert_subsidiary_trust_not_extended
+        title: "Partner did NOT extend trust on the signed `owned` alone"
+        narrative: |
+          The runner asserts the partner produced ZERO trust-extension
+          side effects in response to the malicious house's signed
+          `owned`. Trust-extension side effects are the partner-side
+          actions a spec-conformant consumer MUST gate on reciprocation:
+          member auto-provisioning, governance-context creation, billable
+          seat inclusion. The runner's candidate endpoint patterns cover
+          the closed set documented in the runner contract. A partner
+          whose trust-extension surface is not represented in the closed
+          set declares its endpoint patterns out of band when registering
+          for this red test; runners merge them into the negative
+          assertion.
+        task: verify_brand_claim
+        schema_ref: "brand/verify-brand-claim-request.json"
+        response_schema_ref: "brand/verify-brand-claim-response.json"
+        doc_ref: "/brand-protocol/tasks/verify_brand_claim"
+        requires_contract: single_side_trust_runner
+        stateful: false
+        expected: |
+          Zero recorded calls match any of the trust-extension endpoint
+          patterns. The partner's evaluation of the signed `owned`
+          response did not propagate into governance trust.
+        sample_request:
+          claim_type: subsidiary
+          claim:
+            subsidiary_domain: "independent-leaf.example"
+          context:
+            correlation_id: "brand--single_side_trust--subsidiary--no_trust"
+        validations:
+          - check: upstream_traffic
+            description: "No trust-extension side effects fired on the malicious house's owned response"
+            endpoint_pattern: "POST */governance/auto-provision"
+            min_count: 0
+          - check: upstream_traffic
+            description: "No member-auto-creation side effects fired"
+            endpoint_pattern: "POST */accounts/auto-create-member"
+            min_count: 0
+          - check: upstream_traffic
+            description: "No governance-context creation fired"
+            endpoint_pattern: "POST */governance/contexts"
+            min_count: 0
+          - check: upstream_traffic
+            description: "No billable seat auto-inclusion fired"
+            endpoint_pattern: "POST */billing/seats/auto-add"
+            min_count: 0
+
+  - id: property_variant
+    title: "Property — malicious house claims a property it does not own"
+    narrative: |
+      The runner dispatches the partner under test with a property claim
+      against `real-property-owner.example`. The malicious house signs
+      `owned`. The property's real owner publishes a `brand.json` listing
+      the property in its own `properties[]`. The partner MUST cross-check
+      the property against the real owner's `brand.json` before extending
+      trust.
+
+    steps:
+      - id: dispatch_property_red_test
+        title: "Drive partner through verify_brand_claim property walkthrough"
+        narrative: |
+          The runner dispatches the partner with variant `property`. The
+          controller scenario asks the partner to verify the property
+          claim against the malicious house and decide whether to extend
+          trust to the property as owned by that house.
+        task: comply_test_controller
+        schema_ref: "extensions/test/comply-test-controller-request.json"
+        response_schema_ref: "extensions/test/comply-test-controller-response.json"
+        doc_ref: "/building/implementation/comply-test-controller"
+        requires_contract: single_side_trust_runner
+        stateful: true
+        expected: |
+          The controller scenario completes. The partner's trust-extension
+          decision is asserted by the upstream_traffic checks below.
+        sample_request:
+          scenario: evaluate_verify_brand_claim_trust_extension
+          params:
+            variant: property
+            brand_agent_url: "https://malicious-house.example/agents/brand"
+            claim:
+              claim_type: property
+              claim:
+                property:
+                  type: "website"
+                  identifier: "real-property-owner.example"
+                use_case: "advertising"
+          context:
+            correlation_id: "brand--single_side_trust--property--dispatch"
+
+      - id: assert_property_cross_check_observed
+        title: "Partner DID cross-check the property's real owner"
+        narrative: |
+          The partner MUST have fetched
+          `https://real-property-owner.example/.well-known/brand.json` to
+          verify whether the property is in fact owned by the real
+          owner. Without this cross-check, a partner could let any house
+          claim any property by signing a forged `owned`.
+        task: verify_brand_claim
+        schema_ref: "brand/verify-brand-claim-request.json"
+        response_schema_ref: "brand/verify-brand-claim-response.json"
+        doc_ref: "/brand-protocol/tasks/verify_brand_claim"
+        requires_contract: single_side_trust_runner
+        stateful: false
+        expected: |
+          Recorded upstream traffic includes at least one GET against
+          the property's real-owner brand.json.
+        sample_request:
+          claim_type: property
+          claim:
+            property:
+              type: "website"
+              identifier: "real-property-owner.example"
+          context:
+            correlation_id: "brand--single_side_trust--property--cross_check"
+        validations:
+          - check: upstream_traffic
+            description: "Partner fetched the property's real-owner brand.json"
+            endpoint_pattern: "GET *real-property-owner.example/.well-known/brand.json"
+            min_count: 1
+            identifier_paths:
+              - "claim.property.identifier"
+
+      - id: assert_property_trust_not_extended
+        title: "Partner did NOT accept the malicious property claim"
+        narrative: |
+          Zero trust-extension side effects fire when the malicious
+          house's signed `owned` for a property is the only positive
+          evidence the partner has seen.
+        task: verify_brand_claim
+        schema_ref: "brand/verify-brand-claim-request.json"
+        response_schema_ref: "brand/verify-brand-claim-response.json"
+        doc_ref: "/brand-protocol/tasks/verify_brand_claim"
+        requires_contract: single_side_trust_runner
+        stateful: false
+        expected: |
+          Zero recorded calls match the trust-extension endpoint
+          patterns.
+        sample_request:
+          claim_type: property
+          claim:
+            property:
+              type: "website"
+              identifier: "real-property-owner.example"
+          context:
+            correlation_id: "brand--single_side_trust--property--no_trust"
+        validations:
+          - check: upstream_traffic
+            description: "No property-trust auto-binding fired on the malicious house's owned response"
+            endpoint_pattern: "POST */governance/auto-provision"
+            min_count: 0
+          - check: upstream_traffic
+            description: "No inventory/property auto-acceptance fired"
+            endpoint_pattern: "POST */inventory/auto-accept"
+            min_count: 0
+          - check: upstream_traffic
+            description: "No creative-clearance auto-approval fired"
+            endpoint_pattern: "POST */creative/auto-clearance"
+            min_count: 0
+
+  - id: trademark_licensed_in_variant
+    title: "Trademark licensed_in — licensor does not reciprocate licensed_out"
+    narrative: |
+      The runner dispatches the partner under test with a trademark
+      `licensed_in` claim. The malicious house signs `licensed_in` and
+      names `non-reciprocating-licensor.example` as the licensor. The
+      licensor's static `brand.json` does NOT publish a matching
+      `licensed_out` for the mark. Per the task spec's `licensed_in`
+      reciprocation rule, partners SHOULD treat `licensed_in` as
+      unverified until the named `licensor_domain` reciprocates
+      `licensed_out` for the same mark.
+
+    steps:
+      - id: dispatch_trademark_red_test
+        title: "Drive partner through verify_brand_claim trademark walkthrough"
+        narrative: |
+          The runner dispatches the partner with variant
+          `trademark_licensed_in`. The controller scenario asks the
+          partner to evaluate the licensee posture and decide whether to
+          extend trust (e.g., creative-clearance auto-approval).
+        task: comply_test_controller
+        schema_ref: "extensions/test/comply-test-controller-request.json"
+        response_schema_ref: "extensions/test/comply-test-controller-response.json"
+        doc_ref: "/building/implementation/comply-test-controller"
+        requires_contract: single_side_trust_runner
+        stateful: true
+        expected: |
+          The controller scenario completes. The partner's licensee-trust
+          decision is asserted by the upstream_traffic checks below.
+        sample_request:
+          scenario: evaluate_verify_brand_claim_trust_extension
+          params:
+            variant: trademark_licensed_in
+            brand_agent_url: "https://malicious-house.example/agents/brand"
+            claim:
+              claim_type: trademark
+              claim:
+                mark: "FABRICATED MARK"
+                use_case: "advertising"
+          context:
+            correlation_id: "brand--single_side_trust--trademark--dispatch"
+
+      - id: assert_licensor_reciprocation_observed
+        title: "Partner DID check the licensor for reciprocating licensed_out"
+        narrative: |
+          The partner MUST have fetched
+          `https://non-reciprocating-licensor.example/.well-known/brand.json`
+          (or called the licensor's brand-agent if one were advertised —
+          this fixture intentionally publishes none) to verify the
+          licensor recognizes the licensing relationship.
+        task: verify_brand_claim
+        schema_ref: "brand/verify-brand-claim-request.json"
+        response_schema_ref: "brand/verify-brand-claim-response.json"
+        doc_ref: "/brand-protocol/tasks/verify_brand_claim"
+        requires_contract: single_side_trust_runner
+        stateful: false
+        expected: |
+          Recorded upstream traffic includes at least one GET against
+          the licensor's brand.json.
+        sample_request:
+          claim_type: trademark
+          claim:
+            mark: "FABRICATED MARK"
+          context:
+            correlation_id: "brand--single_side_trust--trademark--reciprocation"
+        validations:
+          - check: upstream_traffic
+            description: "Partner fetched the licensor's brand.json for licensed_out reciprocation"
+            endpoint_pattern: "GET *non-reciprocating-licensor.example/.well-known/brand.json"
+            min_count: 1
+            identifier_paths:
+              - "claim.mark"
+
+      - id: assert_trademark_trust_not_extended
+        title: "Partner did NOT accept the unverified licensee posture"
+        narrative: |
+          With no reciprocating `licensed_out` from the licensor, the
+          partner MUST NOT have propagated licensee posture into
+          downstream surfaces (creative-clearance auto-approval, mark
+          auto-binding, etc.).
+        task: verify_brand_claim
+        schema_ref: "brand/verify-brand-claim-request.json"
+        response_schema_ref: "brand/verify-brand-claim-response.json"
+        doc_ref: "/brand-protocol/tasks/verify_brand_claim"
+        requires_contract: single_side_trust_runner
+        stateful: false
+        expected: |
+          Zero recorded calls match the licensee-trust-extension
+          endpoint patterns.
+        sample_request:
+          claim_type: trademark
+          claim:
+            mark: "FABRICATED MARK"
+          context:
+            correlation_id: "brand--single_side_trust--trademark--no_trust"
+        validations:
+          - check: upstream_traffic
+            description: "No creative-clearance auto-approval fired on the unverified licensee posture"
+            endpoint_pattern: "POST */creative/auto-clearance"
+            min_count: 0
+          - check: upstream_traffic
+            description: "No trademark auto-binding fired"
+            endpoint_pattern: "POST */trademarks/auto-bind"
+            min_count: 0
+          - check: upstream_traffic
+            description: "No governance/licensing auto-extension fired"
+            endpoint_pattern: "POST */governance/licensing/auto-extend"
+            min_count: 0

--- a/static/compliance/source/test-kits/single-side-trust-runner.yaml
+++ b/static/compliance/source/test-kits/single-side-trust-runner.yaml
@@ -1,0 +1,294 @@
+# Single-Side Trust Runner — Harness Contract Test Kit
+#
+# Applies to:
+#   - protocols/brand/scenarios/single_side_trust_extension.yaml
+#
+# The single-side-trust scenario is a partner-conformance red test. Unlike
+# every other storyboard in the corpus today — which grades an agent serving
+# verify_brand_claim — this scenario grades a CONSUMER of verify_brand_claim.
+# The subject under test is a partner that may extend governance trust (auto-
+# provision a member account, propagate billable seat inclusion, inherit
+# governance posture) based on what verify_brand_claim returns. The red test
+# asserts the asymmetric trust rule from
+# /docs/brand-protocol/tasks/verify_brand_claim §"The trust rule — two calls,
+# not one": a single signed `owned` response is NOT trust-extending.
+#
+# This is a framework extension. The conformance corpus today drives an agent
+# under test and grades its response. Grading a consumer-side trust decision
+# requires:
+#
+#   1. The runner hosts fixture brand-agents (a malicious house signing
+#      `owned` for relationships it does not legitimately have) plus the
+#      static brand.json files that should — under the spec — fail to
+#      reciprocate.
+#
+#   2. The runner exercises the partner under test through whatever surface
+#      that partner exposes for "evaluate a verify_brand_claim response and
+#      decide whether to extend trust" — the partner advertises this surface
+#      via comply_test_controller (scenario name
+#      `evaluate_verify_brand_claim_trust_extension`, defined below). Partners
+#      that do not advertise it grade the scenario `not_applicable`.
+#
+#   3. The runner queries the partner's comply_test_controller
+#      `query_upstream_traffic` to confirm:
+#        - The partner DID call leaf-side reciprocation (positive assertion:
+#          `min_count: 1` against a `GET *.well-known/brand.json` pattern on
+#          the leaf, OR a verify_brand_claim call with `claim_type: "parent"`
+#          on a leaf-side brand-agent — when one exists).
+#        - The partner did NOT extend trust (negative assertion: `min_count: 0`
+#          against governance-trust-extension endpoint patterns the partner
+#          declares via this contract).
+#
+# Runner-side implementation is pending. Until adcp-client lands the consumer-
+# under-test dispatch primitive, scenario steps grade `not_applicable` via
+# their `requires_contract: single_side_trust_runner` declaration. This file
+# documents the contract so the dispatch can be implemented against a stable
+# fixture surface.
+
+id: single_side_trust_runner
+applies_to:
+  protocol_scenarios:
+    - single_side_trust_extension
+
+description: |
+  Coordination contract between a black-box runner and a partner under test
+  whose responsibility is to evaluate verify_brand_claim responses and decide
+  whether to extend governance trust. The runner hosts the malicious-house
+  fixture brand-agent and the non-reciprocating leaf brand.json. The partner
+  receives a `verify_brand_claim` invocation through its comply_test_controller
+  `evaluate_verify_brand_claim_trust_extension` scenario, performs whatever
+  verification the spec mandates, and exposes its outbound HTTP traffic via
+  `query_upstream_traffic` for the runner to assert against.
+
+endpoint_scope: sandbox
+# The partner under test executes a real verify-and-decide pipeline against
+# the runner-hosted fixtures. Partners MUST NOT run this against any
+# production trust-extension surface; the runner's `owned` responses describe
+# fabricated relationships and any partner that auto-provisions on them in
+# production is the bug this test exists to surface.
+
+harness_mode: black_box
+
+# --- Fixture brand-agents and static documents the runner hosts ---
+#
+# The runner stands up three fixture surfaces. All use the IANA-reserved
+# `.example` TLD. The runner is the authoritative origin for every URL below
+# during a test run; partners under test resolve these names against the
+# runner's DNS or hosts override per the operator's harness configuration.
+
+fixtures:
+  malicious_house:
+    # A brand-agent at a runner-controlled domain that signs `owned` for
+    # arbitrary subsidiary / property / trademark claims. The agent's JWKS is
+    # published at the same domain so signature verification succeeds — the
+    # point of the red test is that signature validity does NOT confer
+    # relationship trust without reciprocation.
+    domain: "malicious-house.example"
+    brand_agent_url: "https://malicious-house.example/agents/brand"
+    jwks_uri: "https://malicious-house.example/.well-known/jwks.json"
+    response_signing_keyid: "test-malicious-house-2026"
+    # When the runner asks the malicious house's brand-agent any of the
+    # supported claim types, it returns `owned` with a freshly signed
+    # response. Behavior matrix:
+    response_matrix:
+      - claim_type: subsidiary
+        # Any `claim.subsidiary_domain` returns owned, regardless of whether
+        # the leaf actually claims this house as its parent.
+        status: owned
+        details:
+          brand_id: "fabricated_subsidiary"
+      - claim_type: property
+        # Any `claim.property.identifier` returns owned, regardless of the
+        # real registrant of that property.
+        status: owned
+        details:
+          relationship: "owned"
+      - claim_type: trademark
+        # Returns `licensed_in` claiming a licensor the runner ALSO hosts as
+        # a non-reciprocating fixture (see `non_reciprocating_licensor`
+        # below).
+        status: licensed_in
+        details:
+          matched_registration: "fabricated-mark-001"
+          licensor_domain: "non-reciprocating-licensor.example"
+
+  non_reciprocating_leaf:
+    # A static brand.json hosted at a runner-controlled domain. The brand
+    # declares NO `house_domain` (or declares a different parent). No
+    # brand-agent is advertised at this domain — reciprocation requires a
+    # static crawl. This is the "leaf does not agree" half of the asymmetric
+    # trust model.
+    domain: "independent-leaf.example"
+    brand_json_url: "https://independent-leaf.example/.well-known/brand.json"
+    brand_json_shape:
+      # The leaf is standalone — no `house_domain` field at all. A spec-
+      # conformant consumer that crawls this MUST conclude no relationship
+      # exists with malicious-house.example.
+      brand_id: "independent_leaf"
+      names:
+        - { locale: "en", value: "Independent Leaf" }
+      house_domain: null
+
+  non_reciprocating_licensor:
+    # A static brand.json for the trademark licensed_in variant. The
+    # malicious house claims `licensed_in` from this licensor; the licensor
+    # does NOT publish a matching `licensed_out` for the mark. Per the
+    # trademark trust rule, partners SHOULD treat `licensed_in` as
+    # unverified until the licensor reciprocates.
+    domain: "non-reciprocating-licensor.example"
+    brand_json_url: "https://non-reciprocating-licensor.example/.well-known/brand.json"
+    brand_json_shape:
+      brand_id: "non_reciprocating_licensor"
+      names:
+        - { locale: "en", value: "Non-Reciprocating Licensor" }
+      # No trademarks[] entry naming malicious-house.example as a licensee.
+      trademarks: []
+
+  non_reciprocating_property_owner:
+    # A static brand.json for the property variant. The runner exposes a
+    # property identifier (a website) the malicious house claims `owned`,
+    # but the property's actual owning brand publishes a brand.json that
+    # does NOT include the property in its `properties[]`.
+    domain: "real-property-owner.example"
+    brand_json_url: "https://real-property-owner.example/.well-known/brand.json"
+    property_under_test:
+      type: "website"
+      identifier: "real-property-owner.example"
+    brand_json_shape:
+      brand_id: "real_property_owner"
+      names:
+        - { locale: "en", value: "Real Property Owner" }
+      # The property is listed here under the real owner, NOT under the
+      # malicious house's `owned` claim.
+      properties:
+        - { type: "website", identifier: "real-property-owner.example" }
+
+# --- Consumer-under-test dispatch contract ---
+#
+# The runner drives the partner under test via its comply_test_controller.
+# The partner MUST advertise this scenario in its `list_scenarios` response
+# to participate; partners that do not advertise it grade the scenario
+# `not_applicable` (not failed) — the scenario is opt-in by partner
+# capability, matching the upstream_traffic convention documented in
+# storyboard-schema.yaml > authored_check_kinds.
+#
+# The contract is forward-looking: today no partner implements this
+# controller scenario, and runner support is pending. Partners that want to
+# claim conformance against this red test register support here.
+
+consumer_test_controller_scenario:
+  name: evaluate_verify_brand_claim_trust_extension
+  request_shape:
+    # Variant the runner is exercising.
+    variant: subsidiary | property | trademark_licensed_in
+    # The malicious-house brand-agent URL the partner should call
+    # verify_brand_claim against.
+    brand_agent_url: "<runner-supplied URL from fixtures.malicious_house>"
+    # The claim payload the partner should pass.
+    claim:
+      # Shape varies by variant — matches verify-brand-claim-request.json
+      # discriminator arms.
+      claim_type: subsidiary | property | trademark
+      claim: { ... }
+    # Optional account context. Partners that only auto-provision under
+    # an authenticated account context use this to scope the test to that
+    # path.
+    requesting_account:
+      brand:
+        domain: "<runner-supplied partner-controlled account domain>"
+      operator: "<runner-supplied operator>"
+
+  expected_partner_behavior:
+    # The partner MUST call verify_brand_claim on brand_agent_url.
+    # The partner MUST then EITHER:
+    #   (a) crawl the leaf's static brand.json for reciprocation, OR
+    #   (b) call a leaf-side brand-agent's verify_brand_claim with
+    #       claim_type: "parent" — if the leaf advertises one (in this
+    #       contract's fixtures, none does, forcing path (a)).
+    # The partner MUST NOT extend governance trust on the strength of the
+    # malicious-house's signed `owned` alone.
+
+# --- Upstream-traffic assertions the runner applies ---
+#
+# After dispatching the scenario, the runner queries the partner's
+# comply_test_controller `query_upstream_traffic` and applies these
+# assertions. See storyboard-schema.yaml > `upstream_traffic` for the
+# check primitives.
+
+upstream_traffic_contract:
+  reciprocation_call_observed:
+    # POSITIVE assertion. The partner MUST have called either the leaf's
+    # static brand.json or a leaf-side brand-agent's verify_brand_claim
+    # (claim_type: "parent" / property crawl / licensor reciprocation,
+    # depending on variant).
+    min_count: 1
+    endpoint_pattern_by_variant:
+      subsidiary: "GET *://independent-leaf.example/.well-known/brand.json"
+      property: "GET *://real-property-owner.example/.well-known/brand.json"
+      trademark_licensed_in: "GET *://non-reciprocating-licensor.example/.well-known/brand.json"
+
+  trust_extension_not_taken:
+    # NEGATIVE assertion. The partner MUST NOT have extended governance
+    # trust on the malicious house's response alone. Partners declare the
+    # endpoint patterns that represent trust-extension side effects in
+    # their own conformance config; the runner exercises a closed set:
+    min_count: 0
+    candidate_endpoint_patterns:
+      # The partner is configured (out of band, when registering for this
+      # red test) to surface trust-extension side effects through one of
+      # these well-known patterns OR through a partner-declared list
+      # carried alongside its list_scenarios response. The runner asserts
+      # NONE of these fire during the test window.
+      - "POST */governance/auto-provision"
+      - "POST */accounts/auto-create-member"
+      - "POST */governance/contexts"
+      - "POST */billing/seats/auto-add"
+
+# --- Identifier echo for anti-façade ---
+#
+# To raise the bar against partners that satisfy the controller scenario
+# without actually performing the upstream calls, the runner injects a
+# load-bearing identifier (a per-run nonce) into the malicious-house's
+# response_signing keyid path or the claim payload's `subsidiary_brand_id`
+# field. The reciprocation call MUST carry that identifier verbatim — a
+# façade that fabricates an empty traffic record cannot satisfy the
+# `identifier_paths` echo check.
+
+identifier_echo:
+  nonce_injection_field:
+    subsidiary: "claim.subsidiary_brand_id"
+    property: "claim.property.identifier"
+    trademark_licensed_in: "claim.mark"
+  identifier_paths_in_reciprocation_request:
+    # The runner asserts the leaf-side fetch (whether brand.json crawl or
+    # verify_brand_claim with claim_type: "parent") carries the same
+    # identifier value at the appropriate path.
+    subsidiary: "<HTTP path component containing the leaf domain>"
+    property: "<HTTP path component containing the property identifier>"
+    trademark_licensed_in: "<HTTP path component containing the licensor domain>"
+
+scope:
+  in_scope: |
+    - Fixture brand-agent endpoints (URLs, JWKS, signing keyids).
+    - Fixture static brand.json shapes that fail reciprocation.
+    - The consumer-test-controller scenario name and request shape the
+      runner uses to dispatch the partner under test.
+    - The endpoint patterns the runner asserts on via query_upstream_traffic.
+    - Identifier echo paths for anti-façade verification.
+  out_of_scope: |
+    - The partner's specific trust-extension implementation (account-
+      auto-provisioning, governance-context creation, billable seat
+      inclusion, etc.). The contract names the side-effect patterns it
+      asserts on; how the partner internally wires trust extension is
+      partner-specific.
+    - Runner-side dispatch implementation. Tracked separately when
+      partner adoption reaches a quorum — until then, scenario steps
+      grade not_applicable via `requires_contract`.
+    - Real-world brand domains. Every fixture domain is on the
+      IANA-reserved `.example` TLD.
+
+references:
+  scenario: static/compliance/source/protocols/brand/scenarios/single_side_trust_extension.yaml
+  task_spec: /brand-protocol/tasks/verify_brand_claim
+  trust_model: /brand-protocol/brand-json#agent-augmented-verification
+  source_issue: https://github.com/adcontextprotocol/adcp/issues/4597


### PR DESCRIPTION
## Summary

Adds a partner-conformance red test for the asymmetric trust model on `verify_brand_claim` (#4540 follow-up flagged in product review). Three variants — subsidiary, property, trademark `licensed_in` — drive the malicious-house walkthrough from [`/brand-protocol/brand-json#agent-augmented-verification`](https://adcontextprotocol.org/docs/brand-protocol/brand-json#agent-augmented-verification) and assert via `upstream_traffic` that the partner under test:

- DID call leaf-side reciprocation (positive: `min_count: 1` against the leaf / property-owner / licensor `brand.json` crawl).
- Did NOT extend governance trust on the malicious house's signed `owned` response alone (negative: `min_count: 0` against trust-extension side-effect endpoint patterns: auto-provisioning, governance-context creation, billable seat inclusion, creative-clearance auto-approval).

## Files

- `static/compliance/source/protocols/brand/scenarios/single_side_trust_extension.yaml` — scenario with three variant phases.
- `static/compliance/source/test-kits/single-side-trust-runner.yaml` — harness contract: fixture malicious-house brand-agent, non-reciprocating leaf / licensor / property-owner `brand.json` shapes, consumer-under-test dispatch surface (`evaluate_verify_brand_claim_trust_extension` comply_test_controller scenario), identifier echo paths for anti-façade.
- `.changeset/verify-brand-claim-red-test.md` — empty package block (test/conformance-only; no wire-protocol surface change).

## Framework extension flagged

Every storyboard in the corpus today grades an agent serving a task; this scenario grades a **consumer** of a task. The dispatch surface is a partner-side `comply_test_controller` scenario documented in the runner contract. Until adcp-client lands consumer-under-test dispatch and a partner adopter advertises the controller scenario, every graded step carries `requires_contract: single_side_trust_runner` and grades `not_applicable`. Authoring the scenario now gives partners a stable target to register against and gives the runner a stable contract to implement against — same posture as the `signed-requests` universal pre-adcp-client#2331.

## Test plan

- [x] `npm run build:compliance` — clean; scenario and test-kit picked up in build output.
- [x] `npm run test:schemas` — clean.
- [x] `npm run test:json-schema` — clean.
- [x] `npm run test:storyboard-test-kits` — clean (test-kit declares `applies_to`, classifying as runner-contract).
- [x] `npm run test:storyboard-check-enum` — clean (only `upstream_traffic` authored checks, all in the enum).
- [x] `npm run test:storyboard-branch-sets`, `test:storyboard-scoping`, `test:storyboard-auth-shape`, `test:storyboard-context-entity`, `test:storyboard-contradictions`, `test:storyboard-doc-parity`, `test:storyboard-advisory-expiry` — all clean.
- [x] Pre-existing lint failures on `origin/main` (`sales-guaranteed/index.yaml` context-output drift, `comply-controller-mode-gate.yaml` sample_request drift, `brand-rights/scenarios/governance_denied.yaml` validations-paths drift, `typecheck` missing `@adcp/sdk` modules) are unchanged — not introduced by this PR.

Execution against a naive vs. correct partner consumer is gated on the runner-side dispatch landing; that's the framework extension this PR flags.

Closes #4597.

🤖 Generated with [Claude Code](https://claude.com/claude-code)