### PR TITLE
feat(admin): cross-org agent inspection + removal (closes #4498)

### DIFF
--- a/.changeset/admin-cross-org-agent-removal.md
+++ b/.changeset/admin-cross-org-agent-removal.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add `GET /api/admin/accounts/:orgId/agents` and `DELETE /api/admin/accounts/:orgId/agents/:url` for admin inspection and removal of rogue or disputed agent registrations the owning org cannot or will not self-serve clean up. DELETE bypasses the member-side "unpublish public first" guard, requires a `reason` query param, writes an `admin_remove_agent` row to `registry_audit_log` (actor, reason, optional `escalation_id`, removed-agent snapshot), invalidates the member-context cache so Addie reflects the change immediately, and emits a structured `brand_json_drift` event when a public agent is removed so `/check` can surface manifest divergence. Both routes refuse cross-tenant WorkOS API keys (an `admin:*` key issued by org A cannot operate on org B's profile) as defense-in-depth on top of `requireAdmin`. Resolves the gap surfaced by escalation #340 (Celtra).

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -39,6 +39,7 @@ import { setupIllustrationRoutes } from "./admin/illustrations.js";
 import { setupAddieCostRoutes } from "./admin/addie-costs.js";
 import { setupPromptMetricsRoutes } from "./admin/prompt-metrics.js";
 import { setupIntegrityRoutes } from "./admin/integrity.js";
+import { setupAdminAgentsRoutes } from "./admin/agents.js";
 import { getAllNewsletters } from "../newsletters/registry.js";
 import { createNewsletterAdminRoutes } from "../newsletters/admin-routes.js";
 // Ensure newsletters register themselves before routes mount
@@ -184,6 +185,9 @@ export function createAdminRouter(): { pageRouter: Router; apiRouter: Router } {
 
   // Cross-system integrity invariants (WorkOS ↔ Stripe ↔ AAO Postgres)
   setupIntegrityRoutes(apiRouter, { workos });
+
+  // Cross-org agent removal (rogue / disputed registrations)
+  setupAdminAgentsRoutes(apiRouter);
 
   // Unified newsletter admin routes
   for (const nlConfig of getAllNewsletters()) {

--- a/server/src/routes/admin/agents.ts
+++ b/server/src/routes/admin/agents.ts
@@ -1,0 +1,306 @@
+/**
+ * Admin agent management routes.
+ *
+ * Cross-org agent removal for rogue / disputed registrations. The member
+ * surface at `DELETE /api/me/agents/:url` resolves the target org from the
+ * caller's WorkOS membership, so admins (including the static
+ * `admin_api_key` synthetic user) cannot use it to remove an entry that
+ * lives in a different org's `member_profiles.agents` JSONB.
+ *
+ * This route deliberately bypasses the member-side "unpublish public
+ * first" guard — the entries this endpoint exists to remove are typically
+ * fraudulent and never had a real brand.json manifest behind them. The
+ * caller must supply a `reason`, which lands in `registry_audit_log` so
+ * every admin removal carries a written justification.
+ */
+
+import { Router, type Request } from 'express';
+import { getPool } from '../../db/client.js';
+import { createLogger } from '../../logger.js';
+import { requireAuth, requireAdmin, type ValidatedApiKey } from '../../middleware/auth.js';
+import { invalidateMemberContextCache } from '../../addie/index.js';
+import type { AgentConfig } from '../../types.js';
+
+const logger = createLogger('admin-agents');
+
+const MIN_REASON_LENGTH = 5;
+const MAX_REASON_LENGTH = 500;
+
+/**
+ * Defense-in-depth gate against tenant-scoped WorkOS API keys with `admin:*`
+ * being used cross-org. `requireAdmin` accepts any key holding the
+ * permission regardless of which org issued it; this route would otherwise
+ * let one org's owner mutate a different org's `member_profiles.agents`.
+ * Static `admin_api_key` and SSO admin users are not tenant-scoped and
+ * pass through.
+ */
+function refuseCrossTenantApiKey(req: Request, orgId: string): string | null {
+  const apiKey = (req as Request & { apiKey?: ValidatedApiKey }).apiKey;
+  if (!apiKey?.organizationId) return null;
+  if (apiKey.organizationId === orgId) return null;
+  return apiKey.organizationId;
+}
+
+/**
+ * Decode `member_profiles.agents`. The column is typed `jsonb` but the pg
+ * driver hands it back as either an array or a JSON string depending on
+ * driver settings. Any other shape (including a string that parses to a
+ * non-array) means the column is corrupt — surface that to the caller
+ * rather than silently coercing to `[]`, which would make a corrupted
+ * profile look agent-less to the admin tool.
+ */
+class CorruptAgentsColumnError extends Error {
+  constructor() {
+    super('member_profiles.agents is not a JSON array');
+    this.name = 'CorruptAgentsColumnError';
+  }
+}
+
+function parseAgents(raw: unknown): AgentConfig[] {
+  if (raw === null || raw === undefined) return [];
+  if (Array.isArray(raw)) return raw as AgentConfig[];
+  if (typeof raw === 'string') {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw new CorruptAgentsColumnError();
+    }
+    if (parsed === null) return [];
+    if (Array.isArray(parsed)) return parsed as AgentConfig[];
+    throw new CorruptAgentsColumnError();
+  }
+  throw new CorruptAgentsColumnError();
+}
+
+export function setupAdminAgentsRoutes(apiRouter: Router): void {
+  // GET /api/admin/accounts/:orgId/agents
+  //
+  // Lists the agents on an org's member profile. Companion to the DELETE
+  // below — admins must be able to see what they're about to remove.
+  apiRouter.get(
+    '/accounts/:orgId/agents',
+    requireAuth,
+    requireAdmin,
+    async (req, res) => {
+      const { orgId } = req.params;
+
+      const crossTenantOrg = refuseCrossTenantApiKey(req, orgId);
+      if (crossTenantOrg) {
+        return res.status(403).json({
+          error: 'cross_tenant_api_key',
+          message: `API key issued by ${crossTenantOrg} cannot read agents on ${orgId}`,
+        });
+      }
+
+      try {
+        const pool = getPool();
+        const row = await pool.query<{ agents: unknown }>(
+          `SELECT agents FROM member_profiles WHERE workos_organization_id = $1`,
+          [orgId],
+        );
+        if (row.rowCount === 0) {
+          return res.status(404).json({
+            error: 'profile_not_found',
+            message: `No member profile exists for org ${orgId}`,
+          });
+        }
+        return res.json({ org_id: orgId, agents: parseAgents(row.rows[0].agents) });
+      } catch (err) {
+        if (err instanceof CorruptAgentsColumnError) {
+          logger.error({ orgId }, 'member_profiles.agents column is corrupt');
+          return res.status(500).json({
+            error: 'corrupt_agents_column',
+            message: `member_profiles.agents for org ${orgId} is not a JSON array`,
+          });
+        }
+        logger.error({ err, orgId }, 'Admin agent list failed');
+        return res.status(500).json({
+          error: 'internal_error',
+          message: 'Failed to list agents',
+        });
+      }
+    },
+  );
+
+  // DELETE /api/admin/accounts/:orgId/agents/:url
+  //
+  // `:url` is URL-encoded by the caller (Express decodes path params once).
+  // `reason` is required and lands in the audit trail; `escalation_id` is
+  // optional context. Both arrive as query params — DELETE bodies are
+  // poorly supported across HTTP clients.
+  apiRouter.delete(
+    '/accounts/:orgId/agents/:url',
+    requireAuth,
+    requireAdmin,
+    async (req, res) => {
+      const { orgId } = req.params;
+      const targetUrl = req.params.url;
+
+      const crossTenantOrg = refuseCrossTenantApiKey(req, orgId);
+      if (crossTenantOrg) {
+        return res.status(403).json({
+          error: 'cross_tenant_api_key',
+          message: `API key issued by ${crossTenantOrg} cannot remove agents from ${orgId}`,
+        });
+      }
+
+      const reasonParam = req.query.reason;
+      const reason =
+        typeof reasonParam === 'string' ? reasonParam.trim() : '';
+      if (reason.length < MIN_REASON_LENGTH) {
+        return res.status(400).json({
+          error: 'reason_required',
+          message: `reason query param is required (min ${MIN_REASON_LENGTH} chars)`,
+        });
+      }
+      if (reason.length > MAX_REASON_LENGTH) {
+        return res.status(400).json({
+          error: 'reason_too_long',
+          message: `reason exceeds ${MAX_REASON_LENGTH} chars`,
+        });
+      }
+
+      const escalationIdParam = req.query.escalation_id;
+      const escalationId =
+        typeof escalationIdParam === 'string' && escalationIdParam.length > 0
+          ? escalationIdParam
+          : null;
+
+      const pool = getPool();
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+
+        const row = await client.query<{ id: string; agents: unknown }>(
+          `SELECT id, agents
+           FROM member_profiles
+           WHERE workos_organization_id = $1
+           FOR UPDATE`,
+          [orgId],
+        );
+        if (row.rowCount === 0) {
+          await client.query('ROLLBACK');
+          return res.status(404).json({
+            error: 'profile_not_found',
+            message: `No member profile exists for org ${orgId}`,
+          });
+        }
+
+        const profileId = row.rows[0].id;
+        const existing = parseAgents(row.rows[0].agents);
+        const idx = existing.findIndex((a) => a.url === targetUrl);
+        if (idx === -1) {
+          await client.query('ROLLBACK');
+          return res.status(404).json({
+            error: 'agent_not_found',
+            message: `No agent with url=${targetUrl} on org ${orgId}`,
+          });
+        }
+
+        const removed = existing[idx];
+        const next = existing.filter((_, i) => i !== idx);
+
+        await client.query(
+          `UPDATE member_profiles
+           SET agents = $1::jsonb, updated_at = NOW()
+           WHERE id = $2`,
+          [JSON.stringify(next), profileId],
+        );
+
+        await client.query(
+          `INSERT INTO registry_audit_log
+             (workos_organization_id, workos_user_id, action, resource_type, resource_id, details)
+           VALUES ($1, $2, 'admin_remove_agent', 'agent', $3, $4)`,
+          [
+            orgId,
+            req.user!.id,
+            targetUrl,
+            JSON.stringify({
+              reason,
+              escalation_id: escalationId,
+              admin_email: req.user!.email,
+              removed_agent: removed,
+              bypassed_public_unpublish_guard: removed.visibility === 'public',
+            }),
+          ],
+        );
+
+        await client.query('COMMIT');
+
+        // Addie's per-org member-context snapshot includes the agents
+        // array; without this, her view stays stale until TTL.
+        invalidateMemberContextCache();
+
+        logger.warn(
+          {
+            orgId,
+            agentUrl: targetUrl,
+            adminUserId: req.user!.id,
+            adminEmail: req.user!.email,
+            escalationId,
+            wasPublic: removed.visibility === 'public',
+          },
+          'Admin removed agent from org member profile',
+        );
+
+        // Public-visibility removals bypass the member-side
+        // "unpublish first" guard, so any real brand.json manifest
+        // for this org now points at a URL the registry no longer
+        // recognizes. Unlike member-side unpublish
+        // (member-profiles.ts:1485-1517, which calls
+        // `brandDb.updateManifestAgents` first and only falls back
+        // to a drift event on failure), the admin path deliberately
+        // does NOT attempt reconciliation: the entries this endpoint
+        // exists to remove are rogue registrations where the
+        // owning-org-of-record is not a cooperating manifest owner,
+        // so silently rewriting their brand-mirror is the wrong
+        // default. Emit the structured drift event so `/check` picks
+        // it up; ops can follow up with the rightful brand owner.
+        if (removed.visibility === 'public') {
+          logger.warn(
+            {
+              orgId,
+              agentUrl: targetUrl,
+              event: 'brand_json_drift',
+              cause: 'admin_remove_agent',
+              escalationId,
+            },
+            'Admin removed a public agent — brand.json manifest may now reference a stale URL; /check will surface drift',
+          );
+        }
+
+        return res.json({
+          removed_agent: removed,
+          org_id: orgId,
+          reason,
+          escalation_id: escalationId,
+          remaining_agent_count: next.length,
+        });
+      } catch (err) {
+        await client.query('ROLLBACK').catch(() => {});
+        if (err instanceof CorruptAgentsColumnError) {
+          logger.error({ orgId }, 'member_profiles.agents column is corrupt');
+          return res.status(500).json({
+            error: 'corrupt_agents_column',
+            message: `member_profiles.agents for org ${orgId} is not a JSON array`,
+          });
+        }
+        logger.error(
+          { err, orgId, agentUrl: targetUrl },
+          'Admin agent removal failed',
+        );
+        return res.status(500).json({
+          error: 'internal_error',
+          message: 'Failed to remove agent',
+        });
+      } finally {
+        try {
+          client.release();
+        } catch (releaseErr) {
+          logger.warn({ err: releaseErr, orgId }, 'pg client release failed');
+        }
+      }
+    },
+  );
+}

--- a/server/src/routes/admin/index.ts
+++ b/server/src/routes/admin/index.ts
@@ -25,3 +25,4 @@ export { setupBrandEnrichmentRoutes } from './brand-enrichment.js';
 export { setupGeoRoutes } from './geo.js';
 export { setupAnnouncementsRoutes } from './announcements.js';
 export { setupIntegrityRoutes } from './integrity.js';
+export { setupAdminAgentsRoutes } from './agents.js';

--- a/server/tests/integration/admin-agent-removal.test.ts
+++ b/server/tests/integration/admin-agent-removal.test.ts
@@ -1,0 +1,468 @@
+/**
+ * Integration tests for admin cross-org agent removal.
+ *
+ * Covers the DELETE /api/admin/accounts/:orgId/agents/:url endpoint —
+ * the path that resolves rogue / disputed agent entries the owning org
+ * cannot or will not self-serve clean up (see escalation #340).
+ */
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  vi,
+} from 'vitest';
+
+vi.mock('../../src/middleware/auth.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/middleware/auth.js')>(
+    '../../src/middleware/auth.js',
+  );
+  let isAdmin = true;
+  let apiKeyOrgId: string | null = null;
+  return {
+    ...actual,
+    requireAuth: (req: any, _res: any, next: any) => {
+      req.user = {
+        id: 'admin_api_key',
+        email: 'admin-api-key@internal',
+        firstName: 'Admin',
+        lastName: 'API Key',
+      };
+      if (apiKeyOrgId) {
+        req.apiKey = { organizationId: apiKeyOrgId, permissions: ['admin:*'] };
+      }
+      next();
+    },
+    requireAdmin: (_req: any, res: any, next: any) => {
+      if (!isAdmin) {
+        return res.status(403).json({ error: 'forbidden' });
+      }
+      next();
+    },
+    __setAdmin: (v: boolean) => {
+      isAdmin = v;
+    },
+    __setApiKeyOrg: (orgId: string | null) => {
+      apiKeyOrgId = orgId;
+    },
+  };
+});
+
+import express from 'express';
+import request from 'supertest';
+import type { Pool } from 'pg';
+import { initializeDatabase, closeDatabase, getPool } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { MemberDatabase } from '../../src/db/member-db.js';
+import { setupAdminAgentsRoutes } from '../../src/routes/admin/agents.js';
+
+const TEST_PREFIX = 'org_admin_agent_remove';
+
+describe('Admin cross-org agent removal (DELETE /api/admin/accounts/:orgId/agents/:url)', () => {
+  let pool: Pool;
+  let app: express.Application;
+  let memberDb: MemberDatabase;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString:
+        process.env.DATABASE_URL ||
+        'postgresql://adcp:localdev@localhost:5432/adcp_registry',
+      max: 5,
+    });
+    await runMigrations();
+
+    memberDb = new MemberDatabase();
+
+    app = express();
+    app.use(express.json());
+    const apiRouter = express.Router();
+    setupAdminAgentsRoutes(apiRouter);
+    app.use('/api/admin', apiRouter);
+  });
+
+  afterAll(async () => {
+    await pool.query(
+      `DELETE FROM registry_audit_log WHERE workos_organization_id LIKE $1`,
+      [`${TEST_PREFIX}%`],
+    );
+    await pool.query(
+      `DELETE FROM member_profiles WHERE workos_organization_id LIKE $1`,
+      [`${TEST_PREFIX}%`],
+    );
+    await pool.query(
+      `DELETE FROM organizations WHERE workos_organization_id LIKE $1`,
+      [`${TEST_PREFIX}%`],
+    );
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    const mod = (await import('../../src/middleware/auth.js')) as unknown as {
+      __setAdmin: (v: boolean) => void;
+      __setApiKeyOrg: (orgId: string | null) => void;
+    };
+    mod.__setAdmin(true);
+    mod.__setApiKeyOrg(null);
+
+    await pool.query(
+      `DELETE FROM registry_audit_log WHERE workos_organization_id LIKE $1`,
+      [`${TEST_PREFIX}%`],
+    );
+    await pool.query(
+      `DELETE FROM member_profiles WHERE workos_organization_id LIKE $1`,
+      [`${TEST_PREFIX}%`],
+    );
+    await pool.query(
+      `DELETE FROM organizations WHERE workos_organization_id LIKE $1`,
+      [`${TEST_PREFIX}%`],
+    );
+  });
+
+  async function seedOrgWithAgents(
+    orgId: string,
+    slug: string,
+    agents: Array<{ url: string; type?: string; visibility?: string; name?: string }>,
+  ) {
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+       VALUES ($1, $2, true, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      [orgId, `Test ${slug}`],
+    );
+    await memberDb.createProfile({
+      workos_organization_id: orgId,
+      display_name: `Test ${slug}`,
+      slug,
+      is_public: false,
+      agents: agents as any,
+    });
+  }
+
+  it('removes the targeted agent from the org JSONB and writes an audit row', async () => {
+    const orgId = `${TEST_PREFIX}_basic`;
+    const rogueUrl = 'https://adcp-mcp.celtra.com/mcp/';
+    await seedOrgWithAgents(orgId, 'adzymic-basic', [
+      { url: 'https://apx.sales-agent.adzymic.ai/mcp', type: 'sales', visibility: 'public' },
+      { url: rogueUrl, type: 'sales', visibility: 'public', name: 'Celtra Creative Agent' },
+    ]);
+
+    const encoded = encodeURIComponent(rogueUrl);
+    const res = await request(app)
+      .delete(`/api/admin/accounts/${orgId}/agents/${encoded}`)
+      .query({ reason: 'escalation 340: rogue Celtra entry under Adzymic', escalation_id: '340' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.removed_agent).toMatchObject({
+      url: rogueUrl,
+      name: 'Celtra Creative Agent',
+    });
+    expect(res.body.remaining_agent_count).toBe(1);
+    expect(res.body.escalation_id).toBe('340');
+
+    const profile = await memberDb.getProfileByOrgId(orgId);
+    expect(profile?.agents).toHaveLength(1);
+    expect(profile?.agents?.[0]?.url).toBe('https://apx.sales-agent.adzymic.ai/mcp');
+
+    const audit = await pool.query(
+      `SELECT action, resource_type, resource_id, details, workos_user_id
+       FROM registry_audit_log
+       WHERE workos_organization_id = $1`,
+      [orgId],
+    );
+    expect(audit.rowCount).toBe(1);
+    expect(audit.rows[0].action).toBe('admin_remove_agent');
+    expect(audit.rows[0].resource_type).toBe('agent');
+    expect(audit.rows[0].resource_id).toBe(rogueUrl);
+    expect(audit.rows[0].workos_user_id).toBe('admin_api_key');
+    expect(audit.rows[0].details).toMatchObject({
+      reason: 'escalation 340: rogue Celtra entry under Adzymic',
+      escalation_id: '340',
+      bypassed_public_unpublish_guard: true,
+    });
+  });
+
+  it('rejects when reason is missing or too short', async () => {
+    const orgId = `${TEST_PREFIX}_no_reason`;
+    await seedOrgWithAgents(orgId, 'adzymic-noreason', [
+      { url: 'https://x.example/mcp', type: 'sales', visibility: 'private' },
+    ]);
+
+    const encoded = encodeURIComponent('https://x.example/mcp');
+
+    const noReason = await request(app).delete(`/api/admin/accounts/${orgId}/agents/${encoded}`);
+    expect(noReason.status).toBe(400);
+    expect(noReason.body.error).toBe('reason_required');
+
+    const tooShort = await request(app)
+      .delete(`/api/admin/accounts/${orgId}/agents/${encoded}`)
+      .query({ reason: 'x' });
+    expect(tooShort.status).toBe(400);
+    expect(tooShort.body.error).toBe('reason_required');
+
+    const profile = await memberDb.getProfileByOrgId(orgId);
+    expect(profile?.agents).toHaveLength(1);
+  });
+
+  it('returns 404 when the agent url is not on the org profile', async () => {
+    const orgId = `${TEST_PREFIX}_missing_agent`;
+    await seedOrgWithAgents(orgId, 'adzymic-missing', [
+      { url: 'https://only-this.example/mcp', type: 'sales' },
+    ]);
+
+    const encoded = encodeURIComponent('https://nope.example/mcp');
+    const res = await request(app)
+      .delete(`/api/admin/accounts/${orgId}/agents/${encoded}`)
+      .query({ reason: 'looking for an entry that does not exist here' });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('agent_not_found');
+  });
+
+  it('returns 404 when the org has no member profile', async () => {
+    const orgId = `${TEST_PREFIX}_no_profile`;
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+       VALUES ($1, $2, true, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      [orgId, 'Profile-less org'],
+    );
+
+    const encoded = encodeURIComponent('https://anything.example/mcp');
+    const res = await request(app)
+      .delete(`/api/admin/accounts/${orgId}/agents/${encoded}`)
+      .query({ reason: 'profile does not exist' });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('profile_not_found');
+  });
+
+  it('rejects non-admin callers via requireAdmin', async () => {
+    const orgId = `${TEST_PREFIX}_nonadmin`;
+    const url = 'https://nonadmin.example/mcp';
+    await seedOrgWithAgents(orgId, 'adzymic-nonadmin', [
+      { url, type: 'sales', visibility: 'private' },
+    ]);
+
+    const mod = (await import('../../src/middleware/auth.js')) as unknown as {
+      __setAdmin: (v: boolean) => void;
+    };
+    mod.__setAdmin(false);
+
+    const encoded = encodeURIComponent(url);
+    const res = await request(app)
+      .delete(`/api/admin/accounts/${orgId}/agents/${encoded}`)
+      .query({ reason: 'should not be permitted to remove' });
+
+    expect(res.status).toBe(403);
+
+    const profile = await memberDb.getProfileByOrgId(orgId);
+    expect(profile?.agents).toHaveLength(1);
+  });
+
+  it('pins bypassed_public_unpublish_guard=false when the removed agent was private', async () => {
+    const orgId = `${TEST_PREFIX}_private_flag`;
+    const url = 'https://private-rogue.example/mcp';
+    await seedOrgWithAgents(orgId, 'adzymic-private-flag', [
+      { url, type: 'sales', visibility: 'private' },
+    ]);
+
+    const res = await request(app)
+      .delete(`/api/admin/accounts/${orgId}/agents/${encodeURIComponent(url)}`)
+      .query({ reason: 'private rogue cleanup' });
+
+    expect(res.status).toBe(200);
+
+    const audit = await pool.query(
+      `SELECT details FROM registry_audit_log
+       WHERE workos_organization_id = $1 AND resource_id = $2`,
+      [orgId, url],
+    );
+    expect(audit.rows[0].details.bypassed_public_unpublish_guard).toBe(false);
+  });
+
+  it('refuses cross-tenant WorkOS API keys (admin:* from one org cannot mutate another)', async () => {
+    const orgId = `${TEST_PREFIX}_xtenant_target`;
+    const otherOrgId = `${TEST_PREFIX}_xtenant_caller`;
+    const url = 'https://xtenant.example/mcp';
+    await seedOrgWithAgents(orgId, 'adzymic-xtenant', [
+      { url, type: 'sales', visibility: 'private' },
+    ]);
+
+    const mod = (await import('../../src/middleware/auth.js')) as unknown as {
+      __setApiKeyOrg: (orgId: string | null) => void;
+    };
+    mod.__setApiKeyOrg(otherOrgId);
+
+    const res = await request(app)
+      .delete(`/api/admin/accounts/${orgId}/agents/${encodeURIComponent(url)}`)
+      .query({ reason: 'attempted cross-tenant removal' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('cross_tenant_api_key');
+
+    const profile = await memberDb.getProfileByOrgId(orgId);
+    expect(profile?.agents).toHaveLength(1);
+
+    const audit = await pool.query(
+      `SELECT count(*) FROM registry_audit_log WHERE workos_organization_id = $1`,
+      [orgId],
+    );
+    expect(Number(audit.rows[0].count)).toBe(0);
+  });
+
+  it('allows same-tenant WorkOS API keys and actually mutates + audits', async () => {
+    // The current mock unconditionally treats the caller as admin; this test
+    // exercises the negative branch of `refuseCrossTenantApiKey` (apiKey set,
+    // organizationId matches), and additionally asserts the request actually
+    // performed the mutation rather than short-circuiting to a no-op 200.
+    const orgId = `${TEST_PREFIX}_xtenant_same`;
+    const url = 'https://same-tenant.example/mcp';
+    await seedOrgWithAgents(orgId, 'adzymic-same-tenant', [
+      { url, type: 'sales', visibility: 'private' },
+    ]);
+
+    const mod = (await import('../../src/middleware/auth.js')) as unknown as {
+      __setApiKeyOrg: (orgId: string | null) => void;
+    };
+    mod.__setApiKeyOrg(orgId);
+
+    const res = await request(app)
+      .delete(`/api/admin/accounts/${orgId}/agents/${encodeURIComponent(url)}`)
+      .query({ reason: 'same-tenant cleanup via org-issued admin key' });
+
+    expect(res.status).toBe(200);
+
+    const profile = await memberDb.getProfileByOrgId(orgId);
+    expect(profile?.agents).toHaveLength(0);
+
+    const audit = await pool.query(
+      `SELECT count(*) FROM registry_audit_log
+       WHERE workos_organization_id = $1 AND action = 'admin_remove_agent'`,
+      [orgId],
+    );
+    expect(Number(audit.rows[0].count)).toBe(1);
+  });
+
+  it('GET /api/admin/accounts/:orgId/agents lists agents (companion to DELETE)', async () => {
+    const orgId = `${TEST_PREFIX}_list`;
+    await seedOrgWithAgents(orgId, 'adzymic-list', [
+      { url: 'https://a.example/mcp', type: 'sales' },
+      { url: 'https://b.example/mcp', type: 'creative' },
+    ]);
+
+    const res = await request(app).get(`/api/admin/accounts/${orgId}/agents`);
+    expect(res.status).toBe(200);
+    expect(res.body.org_id).toBe(orgId);
+    expect(res.body.agents).toHaveLength(2);
+    expect(res.body.agents.map((a: any) => a.url)).toContain('https://a.example/mcp');
+  });
+
+  it('GET returns 404 when the org has no member profile', async () => {
+    const orgId = `${TEST_PREFIX}_list_missing`;
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+       VALUES ($1, $2, true, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      [orgId, 'no profile'],
+    );
+
+    const res = await request(app).get(`/api/admin/accounts/${orgId}/agents`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('profile_not_found');
+  });
+
+  it('GET returns an empty agents array when the profile has no agents', async () => {
+    const orgId = `${TEST_PREFIX}_list_empty`;
+    await seedOrgWithAgents(orgId, 'adzymic-list-empty', []);
+
+    const res = await request(app).get(`/api/admin/accounts/${orgId}/agents`);
+    expect(res.status).toBe(200);
+    expect(res.body.org_id).toBe(orgId);
+    expect(res.body.agents).toEqual([]);
+  });
+
+  it('GET rejects non-admin callers via requireAdmin', async () => {
+    const orgId = `${TEST_PREFIX}_list_nonadmin`;
+    await seedOrgWithAgents(orgId, 'adzymic-list-nonadmin', [
+      { url: 'https://x.example/mcp', type: 'sales' },
+    ]);
+
+    const mod = (await import('../../src/middleware/auth.js')) as unknown as {
+      __setAdmin: (v: boolean) => void;
+    };
+    mod.__setAdmin(false);
+
+    const res = await request(app).get(`/api/admin/accounts/${orgId}/agents`);
+    expect(res.status).toBe(403);
+  });
+
+  it('GET surfaces a 500 when member_profiles.agents is corrupt', async () => {
+    const orgId = `${TEST_PREFIX}_list_corrupt`;
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+       VALUES ($1, $2, true, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      [orgId, 'corrupt agents profile'],
+    );
+    // Insert directly with a JSONB string that is not an array. The
+    // member_profiles.agents column accepts any jsonb value; the row
+    // shape is broken by definition, the test pins the route's
+    // 500-with-distinct-code response rather than the silent-empty-list
+    // failure mode an earlier version produced.
+    await pool.query(
+      `INSERT INTO member_profiles
+         (workos_organization_id, display_name, slug, is_public, agents, created_at, updated_at)
+       VALUES ($1, $2, $3, false, $4::jsonb, NOW(), NOW())`,
+      [orgId, 'Corrupt', `corrupt-${orgId}`, '"not an array"'],
+    );
+
+    const res = await request(app).get(`/api/admin/accounts/${orgId}/agents`);
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('corrupt_agents_column');
+  });
+
+  it('GET refuses cross-tenant API keys', async () => {
+    const orgId = `${TEST_PREFIX}_get_xtenant`;
+    await seedOrgWithAgents(orgId, 'adzymic-get-xtenant', [
+      { url: 'https://x.example/mcp', type: 'sales' },
+    ]);
+
+    const mod = (await import('../../src/middleware/auth.js')) as unknown as {
+      __setApiKeyOrg: (orgId: string | null) => void;
+    };
+    mod.__setApiKeyOrg(`${TEST_PREFIX}_other`);
+
+    const res = await request(app).get(`/api/admin/accounts/${orgId}/agents`);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('cross_tenant_api_key');
+  });
+
+  it('removes a public-visibility agent (bypasses the unpublish-first guard)', async () => {
+    const orgId = `${TEST_PREFIX}_public_bypass`;
+    const rogueUrl = 'https://rogue-public.example/mcp';
+    await seedOrgWithAgents(orgId, 'adzymic-public', [
+      { url: rogueUrl, type: 'sales', visibility: 'public', name: 'Rogue Public Agent' },
+    ]);
+
+    const encoded = encodeURIComponent(rogueUrl);
+    const res = await request(app)
+      .delete(`/api/admin/accounts/${orgId}/agents/${encoded}`)
+      .query({ reason: 'rogue public entry, owner unreachable' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.removed_agent.visibility).toBe('public');
+
+    const profile = await memberDb.getProfileByOrgId(orgId);
+    expect(profile?.agents).toHaveLength(0);
+
+    const audit = await pool.query(
+      `SELECT details FROM registry_audit_log
+       WHERE workos_organization_id = $1 AND resource_id = $2`,
+      [orgId, rogueUrl],
+    );
+    expect(audit.rows[0].details.bypassed_public_unpublish_guard).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `GET` and `DELETE /api/admin/accounts/:orgId/agents[/:url]` so AAO admins can inspect and remove rogue or disputed agent registrations the owning org cannot or will not self-serve clean up.

- **`GET`** lists agents on an org's member profile — admins shouldn't destroy what they can't list
- **`DELETE`** removes an entry from `member_profiles.agents` JSONB and writes an `admin_remove_agent` row to `registry_audit_log`
  - Required `reason` query param (5–500 chars) — lands in audit details
  - Optional `escalation_id` query param
  - Bypasses the member-side "unpublish public first" guard (rogue entries by definition lack a cooperating manifest owner; admin override is the point)
  - Emits a structured `brand_json_drift` event when a public agent is removed so `/check` can surface manifest divergence

### Defense-in-depth: cross-tenant API-key refusal

`requireAdmin` accepts any WorkOS API key holding `admin:*` regardless of which org issued it. Both new routes additionally compare `req.apiKey?.organizationId` to the path `:orgId` and 403 on mismatch — an org-issued admin key cannot operate on a different org's profile. Static `admin_api_key` and SSO admin users bypass (they're not tenant-scoped).

### Corrupt-column handling

`parseAgents` now throws `CorruptAgentsColumnError` on non-array JSONB instead of silently coercing to `[]`. GET/DELETE catch it and return 500 `corrupt_agents_column` rather than lying with "agent not found."

## Why

Resolves the gap surfaced by [escalation #340](https://github.com/adcontextprotocol/adcp/issues/4498) (Celtra), where an Adzymic-owned entry pointing at `adcp-mcp.celtra.com/mcp/` (trailing slash, `type: sales`) could not be removed via any HTTP surface short of direct DB writes. The member-side `DELETE /api/me/agents/:url` resolves the target org from the caller's WorkOS membership, so admins (including the static `admin_api_key`) couldn't reach a different org's JSONB.

## Follow-ups filed

- #4501 — audit cousin admin routes for the same cross-tenant API-key bypass (likely also affects `admin/brand-enrichment.ts`, `admin/accounts-billing.ts`, `admin/users.ts`)
- #4502 — widen `registry_audit_log.resource_id` from `VARCHAR(255)` to `TEXT` (signed-CDN agent URLs can overflow)
- #4499 — prevention story: verify hostname ownership / delegation at registration time

## Test plan

- [x] 15 integration tests in `server/tests/integration/admin-agent-removal.test.ts` — all pass
- [x] `tsc --noEmit` clean
- [x] Reviewed in two rounds by code-reviewer, security-reviewer, internal-tools-strategist, and nodejs-testing-expert subagents
- [ ] Reviewer should verify: the `brand_json_drift` divergence from member-side reconciliation is the right call for rogue removal (see comment at the COMMIT site in `agents.ts`)
- [ ] After merge: use the new endpoint to clean up the Adzymic→Celtra entry from escalation #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)