### PR TITLE
refactor(adagents): extract shared authorized_agents[*] fields into core/authorized-agent-base.json (closes #4510)

### DIFF
--- a/.changeset/authorized-agent-base-schema.md
+++ b/.changeset/authorized-agent-base-schema.md
@@ -1,0 +1,23 @@
+---
+---
+
+refactor(adagents): extract shared `authorized_agents[*]` fields into `core/authorized-agent-base.json`
+
+Closes #4510. Previously deferred because adcp-client's TS codegen (json-schema-to-typescript) produced broken union types on `allOf + $ref` patterns. Unblocked by adcp-client#1756 (PRs #1777 / #1783 shipped a pre-merge pass that flattens `allOf+$ref` siblings before codegen).
+
+**What changes.** Five fields shared across all six `authorized_agents[*]` variants (`url`, `authorized_for`, `signing_keys`, `encryption_keys`, `last_updated`) move into a new `static/schemas/source/core/authorized-agent-base.json`. Each variant now `allOf`s the base alongside its variant-specific properties. Discriminator-specific fields (`authorization_type` const + `property_ids` / `property_tags` / `properties` / `publisher_properties` / `signal_ids` / `signal_tags`) and property-variant qualifiers (`collections`, `placement_ids`, `placement_tags`, `delegation_type`, `exclusive`, `countries`, `effective_from`, `effective_until`) stay at the variant root so the `discriminator: { propertyName: "authorization_type" }` pattern keeps working with audit-oneof.
+
+**No semantic change.** The bundled schema permits the same set of inputs as before. JSON Schema `allOf` merges the base's properties into each variant's instance shape, so validators see identical required-field semantics. Existing files validate unchanged.
+
+**Codegen verified.**
+
+- **Python** (`datamodel-codegen`, used by adcp-client-python): produces clean inheritance — `class AuthorizedAgents1(AuthorizedAgentBase)`, `class AuthorizedAgents2(AuthorizedAgentBase)`, ..., `class AuthorizedAgents6(AuthorizedAgentBase)`. Field duplication across the six variants is eliminated.
+- **TypeScript** (`json-schema-to-typescript`, used by adcp-client): the pre-merge pass adcp-client just shipped (adcp-client#1756) handles `allOf+$ref` correctly. Verifying end-to-end after they regenerate against this schema; if regression surfaces, file back against adcp-client.
+
+**Drift prevention.** Adding a new field shared across all six variants now requires touching one schema file instead of six. The `last_updated` field landed in PR #4504 had to be added six times — that's the recurrence this refactor prevents.
+
+**Test coverage.**
+- `audit-oneof.mjs --check` ok (no new undiscriminated oneOfs; discriminator still resolves correctly because `authorization_type` const stays at the variant root).
+- `composed-schema-validation.test.cjs` 43/43 pass.
+- `example-validation.test.cjs` 14/14 adagents-relevant pass (7 pre-existing unrelated failures unchanged).
+- Bundled schema build clean; dist outputs include the new `core/authorized-agent-base.json`.

--- a/static/schemas/source/adagents.json
+++ b/static/schemas/source/adagents.json
@@ -92,7 +92,7 @@
         },
         "revoked_publisher_domains": {
           "type": "array",
-          "description": "Publisher domains explicitly removed from this managed network. Validators MUST treat any publisher domain listed here as no-longer-authorized, taking precedence over any appearance of the same domain in `authorized_agents[].publisher_properties[].publisher_domain` / `.publisher_domains[]` or in top-level `properties[].publisher_domain`. Lets a network propagate per-publisher revocations on the next refresh instead of waiting for the file-level 7-day cache cap. Validators MUST hold previously-observed `(publisher_domain, revoked_at)` tuples for 7 days from the validator's first observation, even if the entry vanishes from a subsequent fetch — this closes the rollback gap where an attacker re-serves a stale file with the revocation removed. Networks SHOULD retain entries for at least 7 days after `revoked_at` so validators that didn't observe the original entry still pick it up on refresh.",
+          "description": "Publisher domains explicitly removed from this managed network. Validators MUST treat any publisher domain listed here as no-longer-authorized, taking precedence over any appearance of the same domain in `authorized_agents[].publisher_properties[].publisher_domain` / `.publisher_domains[]` or in top-level `properties[].publisher_domain`. Lets a network propagate per-publisher revocations on the next refresh instead of waiting for the file-level 7-day cache cap. Validators MUST hold previously-observed `(publisher_domain, revoked_at)` tuples for 7 days from the validator's first observation, even if the entry vanishes from a subsequent fetch \u2014 this closes the rollback gap where an attacker re-serves a stale file with the revocation removed. Networks SHOULD retain entries for at least 7 days after `revoked_at` so validators that didn't observe the original entry still pick it up on refresh.",
           "items": {
             "type": "object",
             "properties": {
@@ -108,11 +108,19 @@
               },
               "reason": {
                 "type": "string",
-                "enum": ["relationship_ended", "compliance_violation", "publisher_request", "other"],
-                "description": "Reason for revocation. **Operator-internal self-classification for review routing — not a public accusation.** `relationship_ended` is the routine commercial case. `compliance_violation` SHOULD be used only when the network has itself determined the publisher is out of policy; for un-adjudicated third-party allegations (regulator inquiries, advertiser complaints, ongoing investigations), use `other` to avoid making a discoverable adverse statement. `publisher_request` is for publisher-initiated exits. Compare to sellers.json, which deliberately carries no reason field for the same exposure concern."
+                "enum": [
+                  "relationship_ended",
+                  "compliance_violation",
+                  "publisher_request",
+                  "other"
+                ],
+                "description": "Reason for revocation. **Operator-internal self-classification for review routing \u2014 not a public accusation.** `relationship_ended` is the routine commercial case. `compliance_violation` SHOULD be used only when the network has itself determined the publisher is out of policy; for un-adjudicated third-party allegations (regulator inquiries, advertiser complaints, ongoing investigations), use `other` to avoid making a discoverable adverse statement. `publisher_request` is for publisher-initiated exits. Compare to sellers.json, which deliberately carries no reason field for the same exposure concern."
               }
             },
-            "required": ["publisher_domain", "revoked_at"],
+            "required": [
+              "publisher_domain",
+              "revoked_at"
+            ],
             "additionalProperties": true
           }
         },
@@ -186,17 +194,6 @@
               {
                 "type": "object",
                 "properties": {
-                  "url": {
-                    "type": "string",
-                    "format": "uri",
-                    "description": "The authorized agent's API endpoint URL. Callers looking up an agent against this list (e.g., TMP providers validating `seller_agent.agent_url`) MUST compare using the AdCP URL canonicalization rules, not byte-equality — two URLs that differ only in case, default port, or percent-encoding of unreserved characters are the same agent. See docs/reference/url-canonicalization."
-                  },
-                  "authorized_for": {
-                    "type": "string",
-                    "description": "Human-readable description of what this agent is authorized to sell",
-                    "minLength": 1,
-                    "maxLength": 500
-                  },
                   "authorization_type": {
                     "type": "string",
                     "const": "property_ids",
@@ -237,7 +234,11 @@
                   },
                   "delegation_type": {
                     "type": "string",
-                    "enum": ["direct", "delegated", "ad_network"],
+                    "enum": [
+                      "direct",
+                      "delegated",
+                      "ad_network"
+                    ],
                     "description": "Commercial relationship for this inventory path. 'direct' means the publisher treats this as a direct way to buy from them, even if a third party operates the software. 'delegated' means the agent is authorized to sell on the publisher's behalf. 'ad_network' means the inventory is sold as part of a network/package context rather than as the publisher's direct endpoint."
                   },
                   "exclusive": {
@@ -263,51 +264,22 @@
                     "type": "string",
                     "format": "date-time",
                     "description": "Optional end time for this authorization window."
-                  },
-                  "signing_keys": {
-                    "type": "array",
-                    "description": "Optional publisher-attested public signing keys for this agent. Use these as the trust anchor for verifying signed agent responses instead of relying on key discovery from the agent domain alone.",
-                    "items": {
-                      "$ref": "/schemas/core/agent-signing-key.json"
-                    },
-                    "minItems": 1
-                  },
-                  "encryption_keys": {
-                    "type": "array",
-                    "description": "X25519 public keys for TMPX exposure token encryption. Each key identifies a cluster master that can decrypt TMPX tokens. Used with HPKE mode_base — read replicas encrypt with this public key, only the master can decrypt.",
-                    "items": {
-                      "$ref": "/schemas/core/agent-encryption-key.json"
-                    },
-                    "minItems": 1
-                  },
-                  "last_updated": {
-                    "type": "string",
-                    "format": "date-time",
-                    "description": "Optional ISO 8601 timestamp indicating when this `authorized_agents[]` entry last changed. Independent of the file-level `last_updated`. Lets validators perform a partial walk by skipping entries whose `last_updated` is older than their indexed value. Advisory — consumers MAY ignore and re-index the full file."
                   }
                 },
                 "required": [
-                  "url",
-                  "authorized_for",
                   "authorization_type",
                   "property_ids"
                 ],
-                "additionalProperties": true
+                "additionalProperties": true,
+                "allOf": [
+                  {
+                    "$ref": "/schemas/core/authorized-agent-base.json"
+                  }
+                ]
               },
               {
                 "type": "object",
                 "properties": {
-                  "url": {
-                    "type": "string",
-                    "format": "uri",
-                    "description": "The authorized agent's API endpoint URL. Callers looking up an agent against this list (e.g., TMP providers validating `seller_agent.agent_url`) MUST compare using the AdCP URL canonicalization rules, not byte-equality — two URLs that differ only in case, default port, or percent-encoding of unreserved characters are the same agent. See docs/reference/url-canonicalization."
-                  },
-                  "authorized_for": {
-                    "type": "string",
-                    "description": "Human-readable description of what this agent is authorized to sell",
-                    "minLength": 1,
-                    "maxLength": 500
-                  },
                   "authorization_type": {
                     "type": "string",
                     "const": "property_tags",
@@ -348,7 +320,11 @@
                   },
                   "delegation_type": {
                     "type": "string",
-                    "enum": ["direct", "delegated", "ad_network"],
+                    "enum": [
+                      "direct",
+                      "delegated",
+                      "ad_network"
+                    ],
                     "description": "Commercial relationship for this inventory path. 'direct' means the publisher treats this as a direct way to buy from them, even if a third party operates the software. 'delegated' means the agent is authorized to sell on the publisher's behalf. 'ad_network' means the inventory is sold as part of a network/package context rather than as the publisher's direct endpoint."
                   },
                   "exclusive": {
@@ -374,51 +350,22 @@
                     "type": "string",
                     "format": "date-time",
                     "description": "Optional end time for this authorization window."
-                  },
-                  "signing_keys": {
-                    "type": "array",
-                    "description": "Optional publisher-attested public signing keys for this agent. Use these as the trust anchor for verifying signed agent responses instead of relying on key discovery from the agent domain alone.",
-                    "items": {
-                      "$ref": "/schemas/core/agent-signing-key.json"
-                    },
-                    "minItems": 1
-                  },
-                  "encryption_keys": {
-                    "type": "array",
-                    "description": "X25519 public keys for TMPX exposure token encryption. Each key identifies a cluster master that can decrypt TMPX tokens. Used with HPKE mode_base — read replicas encrypt with this public key, only the master can decrypt.",
-                    "items": {
-                      "$ref": "/schemas/core/agent-encryption-key.json"
-                    },
-                    "minItems": 1
-                  },
-                  "last_updated": {
-                    "type": "string",
-                    "format": "date-time",
-                    "description": "Optional ISO 8601 timestamp indicating when this `authorized_agents[]` entry last changed. Independent of the file-level `last_updated`. Lets validators perform a partial walk by skipping entries whose `last_updated` is older than their indexed value. Advisory — consumers MAY ignore and re-index the full file."
                   }
                 },
                 "required": [
-                  "url",
-                  "authorized_for",
                   "authorization_type",
                   "property_tags"
                 ],
-                "additionalProperties": true
+                "additionalProperties": true,
+                "allOf": [
+                  {
+                    "$ref": "/schemas/core/authorized-agent-base.json"
+                  }
+                ]
               },
               {
                 "type": "object",
                 "properties": {
-                  "url": {
-                    "type": "string",
-                    "format": "uri",
-                    "description": "The authorized agent's API endpoint URL. Callers looking up an agent against this list (e.g., TMP providers validating `seller_agent.agent_url`) MUST compare using the AdCP URL canonicalization rules, not byte-equality — two URLs that differ only in case, default port, or percent-encoding of unreserved characters are the same agent. See docs/reference/url-canonicalization."
-                  },
-                  "authorized_for": {
-                    "type": "string",
-                    "description": "Human-readable description of what this agent is authorized to sell",
-                    "minLength": 1,
-                    "maxLength": 500
-                  },
                   "authorization_type": {
                     "type": "string",
                     "const": "inline_properties",
@@ -459,7 +406,11 @@
                   },
                   "delegation_type": {
                     "type": "string",
-                    "enum": ["direct", "delegated", "ad_network"],
+                    "enum": [
+                      "direct",
+                      "delegated",
+                      "ad_network"
+                    ],
                     "description": "Commercial relationship for this inventory path. 'direct' means the publisher treats this as a direct way to buy from them, even if a third party operates the software. 'delegated' means the agent is authorized to sell on the publisher's behalf. 'ad_network' means the inventory is sold as part of a network/package context rather than as the publisher's direct endpoint."
                   },
                   "exclusive": {
@@ -485,51 +436,22 @@
                     "type": "string",
                     "format": "date-time",
                     "description": "Optional end time for this authorization window."
-                  },
-                  "signing_keys": {
-                    "type": "array",
-                    "description": "Optional publisher-attested public signing keys for this agent. Use these as the trust anchor for verifying signed agent responses instead of relying on key discovery from the agent domain alone.",
-                    "items": {
-                      "$ref": "/schemas/core/agent-signing-key.json"
-                    },
-                    "minItems": 1
-                  },
-                  "encryption_keys": {
-                    "type": "array",
-                    "description": "X25519 public keys for TMPX exposure token encryption. Each key identifies a cluster master that can decrypt TMPX tokens. Used with HPKE mode_base — read replicas encrypt with this public key, only the master can decrypt.",
-                    "items": {
-                      "$ref": "/schemas/core/agent-encryption-key.json"
-                    },
-                    "minItems": 1
-                  },
-                  "last_updated": {
-                    "type": "string",
-                    "format": "date-time",
-                    "description": "Optional ISO 8601 timestamp indicating when this `authorized_agents[]` entry last changed. Independent of the file-level `last_updated`. Lets validators perform a partial walk by skipping entries whose `last_updated` is older than their indexed value. Advisory — consumers MAY ignore and re-index the full file."
                   }
                 },
                 "required": [
-                  "url",
-                  "authorized_for",
                   "authorization_type",
                   "properties"
                 ],
-                "additionalProperties": true
+                "additionalProperties": true,
+                "allOf": [
+                  {
+                    "$ref": "/schemas/core/authorized-agent-base.json"
+                  }
+                ]
               },
               {
                 "type": "object",
                 "properties": {
-                  "url": {
-                    "type": "string",
-                    "format": "uri",
-                    "description": "The authorized agent's API endpoint URL. Callers looking up an agent against this list (e.g., TMP providers validating `seller_agent.agent_url`) MUST compare using the AdCP URL canonicalization rules, not byte-equality — two URLs that differ only in case, default port, or percent-encoding of unreserved characters are the same agent. See docs/reference/url-canonicalization."
-                  },
-                  "authorized_for": {
-                    "type": "string",
-                    "description": "Human-readable description of what this agent is authorized to sell",
-                    "minLength": 1,
-                    "maxLength": 500
-                  },
                   "authorization_type": {
                     "type": "string",
                     "const": "publisher_properties",
@@ -570,7 +492,11 @@
                   },
                   "delegation_type": {
                     "type": "string",
-                    "enum": ["direct", "delegated", "ad_network"],
+                    "enum": [
+                      "direct",
+                      "delegated",
+                      "ad_network"
+                    ],
                     "description": "Commercial relationship for this inventory path. 'direct' means the publisher treats this as a direct way to buy from them, even if a third party operates the software. 'delegated' means the agent is authorized to sell on the publisher's behalf. 'ad_network' means the inventory is sold as part of a network/package context rather than as the publisher's direct endpoint."
                   },
                   "exclusive": {
@@ -596,52 +522,23 @@
                     "type": "string",
                     "format": "date-time",
                     "description": "Optional end time for this authorization window."
-                  },
-                  "signing_keys": {
-                    "type": "array",
-                    "description": "Optional publisher-attested public signing keys for this agent. Use these as the trust anchor for verifying signed agent responses instead of relying on key discovery from the agent domain alone.",
-                    "items": {
-                      "$ref": "/schemas/core/agent-signing-key.json"
-                    },
-                    "minItems": 1
-                  },
-                  "encryption_keys": {
-                    "type": "array",
-                    "description": "X25519 public keys for TMPX exposure token encryption. Each key identifies a cluster master that can decrypt TMPX tokens. Used with HPKE mode_base — read replicas encrypt with this public key, only the master can decrypt.",
-                    "items": {
-                      "$ref": "/schemas/core/agent-encryption-key.json"
-                    },
-                    "minItems": 1
-                  },
-                  "last_updated": {
-                    "type": "string",
-                    "format": "date-time",
-                    "description": "Optional ISO 8601 timestamp indicating when this `authorized_agents[]` entry last changed. Independent of the file-level `last_updated`. Lets validators perform a partial walk by skipping entries whose `last_updated` is older than their indexed value. Advisory — consumers MAY ignore and re-index the full file."
                   }
                 },
                 "required": [
-                  "url",
-                  "authorized_for",
                   "authorization_type",
                   "publisher_properties"
                 ],
-                "additionalProperties": true
+                "additionalProperties": true,
+                "allOf": [
+                  {
+                    "$ref": "/schemas/core/authorized-agent-base.json"
+                  }
+                ]
               },
               {
                 "type": "object",
                 "description": "Authorization for signals by specific signal IDs",
                 "properties": {
-                  "url": {
-                    "type": "string",
-                    "format": "uri",
-                    "description": "The authorized signals agent's API endpoint URL. Callers comparing this URL against a signal-provider registry MUST canonicalize both sides per the AdCP URL canonicalization rules, not byte-equality. See docs/reference/url-canonicalization."
-                  },
-                  "authorized_for": {
-                    "type": "string",
-                    "description": "Human-readable description of what signals this agent is authorized to resell",
-                    "minLength": 1,
-                    "maxLength": 500
-                  },
                   "authorization_type": {
                     "type": "string",
                     "const": "signal_ids",
@@ -655,52 +552,23 @@
                       "pattern": "^[a-zA-Z0-9_-]+$"
                     },
                     "minItems": 1
-                  },
-                  "signing_keys": {
-                    "type": "array",
-                    "description": "Optional publisher-attested public signing keys for this agent. Use these as the trust anchor for verifying signed agent responses instead of relying on key discovery from the agent domain alone.",
-                    "items": {
-                      "$ref": "/schemas/core/agent-signing-key.json"
-                    },
-                    "minItems": 1
-                  },
-                  "encryption_keys": {
-                    "type": "array",
-                    "description": "X25519 public keys for TMPX exposure token encryption. Each key identifies a cluster master that can decrypt TMPX tokens. Used with HPKE mode_base — read replicas encrypt with this public key, only the master can decrypt.",
-                    "items": {
-                      "$ref": "/schemas/core/agent-encryption-key.json"
-                    },
-                    "minItems": 1
-                  },
-                  "last_updated": {
-                    "type": "string",
-                    "format": "date-time",
-                    "description": "Optional ISO 8601 timestamp indicating when this `authorized_agents[]` entry last changed. Independent of the file-level `last_updated`. Lets validators perform a partial walk by skipping entries whose `last_updated` is older than their indexed value. Advisory — consumers MAY ignore and re-index the full file."
                   }
                 },
                 "required": [
-                  "url",
-                  "authorized_for",
                   "authorization_type",
                   "signal_ids"
                 ],
-                "additionalProperties": true
+                "additionalProperties": true,
+                "allOf": [
+                  {
+                    "$ref": "/schemas/core/authorized-agent-base.json"
+                  }
+                ]
               },
               {
                 "type": "object",
                 "description": "Authorization for signals by tag membership",
                 "properties": {
-                  "url": {
-                    "type": "string",
-                    "format": "uri",
-                    "description": "The authorized signals agent's API endpoint URL. Callers comparing this URL against a signal-provider registry MUST canonicalize both sides per the AdCP URL canonicalization rules, not byte-equality. See docs/reference/url-canonicalization."
-                  },
-                  "authorized_for": {
-                    "type": "string",
-                    "description": "Human-readable description of what signals this agent is authorized to resell",
-                    "minLength": 1,
-                    "maxLength": 500
-                  },
                   "authorization_type": {
                     "type": "string",
                     "const": "signal_tags",
@@ -714,36 +582,18 @@
                       "pattern": "^[a-z0-9_-]+$"
                     },
                     "minItems": 1
-                  },
-                  "signing_keys": {
-                    "type": "array",
-                    "description": "Optional publisher-attested public signing keys for this agent. Use these as the trust anchor for verifying signed agent responses instead of relying on key discovery from the agent domain alone.",
-                    "items": {
-                      "$ref": "/schemas/core/agent-signing-key.json"
-                    },
-                    "minItems": 1
-                  },
-                  "encryption_keys": {
-                    "type": "array",
-                    "description": "X25519 public keys for TMPX exposure token encryption. Each key identifies a cluster master that can decrypt TMPX tokens. Used with HPKE mode_base — read replicas encrypt with this public key, only the master can decrypt.",
-                    "items": {
-                      "$ref": "/schemas/core/agent-encryption-key.json"
-                    },
-                    "minItems": 1
-                  },
-                  "last_updated": {
-                    "type": "string",
-                    "format": "date-time",
-                    "description": "Optional ISO 8601 timestamp indicating when this `authorized_agents[]` entry last changed. Independent of the file-level `last_updated`. Lets validators perform a partial walk by skipping entries whose `last_updated` is older than their indexed value. Advisory — consumers MAY ignore and re-index the full file."
                   }
                 },
                 "required": [
-                  "url",
-                  "authorized_for",
                   "authorization_type",
                   "signal_tags"
                 ],
-                "additionalProperties": true
+                "additionalProperties": true,
+                "allOf": [
+                  {
+                    "$ref": "/schemas/core/authorized-agent-base.json"
+                  }
+                ]
               }
             ]
           },
@@ -782,7 +632,11 @@
                 "description": "Optional publisher identifier at this agent (for lookup)"
               }
             },
-            "required": ["url", "name", "features"],
+            "required": [
+              "url",
+              "name",
+              "features"
+            ],
             "additionalProperties": true
           }
         },
@@ -829,12 +683,12 @@
       "authoritative_location": "https://cdn.example.com/adagents/v2/adagents.json",
       "last_updated": "2025-01-15T10:00:00Z"
     },
+    {
+      "$schema": "/schemas/adagents.json",
+      "properties": [
         {
-          "$schema": "/schemas/adagents.json",
-          "properties": [
-            {
-              "property_id": "example_site",
-              "property_type": "website",
+          "property_id": "example_site",
+          "property_type": "website",
           "name": "Example Site",
           "identifiers": [
             {
@@ -842,52 +696,65 @@
               "value": "example.com"
             }
           ],
-              "publisher_domain": "example.com"
-            }
+          "publisher_domain": "example.com"
+        }
+      ],
+      "placements": [
+        {
+          "placement_id": "homepage_banner",
+          "name": "Homepage Banner",
+          "tags": [
+            "homepage",
+            "display",
+            "premium"
           ],
-          "placements": [
+          "property_ids": [
+            "example_site"
+          ],
+          "format_ids": [
             {
-              "placement_id": "homepage_banner",
-              "name": "Homepage Banner",
-              "tags": ["homepage", "display", "premium"],
-              "property_ids": ["example_site"],
-              "format_ids": [
-                {
-                  "agent_url": "https://creative.example.com",
-                  "id": "display_728x90"
-                }
-              ]
+              "agent_url": "https://creative.example.com",
+              "id": "display_728x90"
             }
+          ]
+        }
+      ],
+      "placement_tags": {
+        "homepage": {
+          "name": "Homepage",
+          "description": "Placements that render on the homepage"
+        },
+        "display": {
+          "name": "Display",
+          "description": "Standard display placements"
+        },
+        "premium": {
+          "name": "Premium",
+          "description": "Premium monetization placements"
+        }
+      },
+      "authorized_agents": [
+        {
+          "url": "https://agent.example.com",
+          "authorized_for": "Official sales agent",
+          "authorization_type": "property_tags",
+          "property_tags": [
+            "all"
           ],
-          "placement_tags": {
-            "homepage": {
-              "name": "Homepage",
-              "description": "Placements that render on the homepage"
-            },
-            "display": {
-              "name": "Display",
-              "description": "Standard display placements"
-            },
-            "premium": {
-              "name": "Premium",
-              "description": "Premium monetization placements"
-            }
-          },
-          "authorized_agents": [
-            {
-              "url": "https://agent.example.com",
-              "authorized_for": "Official sales agent",
-              "authorization_type": "property_tags",
-              "property_tags": ["all"],
-              "placement_ids": ["homepage_banner"],
-              "delegation_type": "direct",
-              "exclusive": true,
-              "countries": ["US", "CA"],
-              "effective_from": "2025-01-01T00:00:00Z"
-            }
+          "placement_ids": [
+            "homepage_banner"
           ],
-          "tags": {
-            "all": {
+          "delegation_type": "direct",
+          "exclusive": true,
+          "countries": [
+            "US",
+            "CA"
+          ],
+          "effective_from": "2025-01-01T00:00:00Z"
+        }
+      ],
+      "tags": {
+        "all": {
           "name": "All Properties",
           "description": "All properties in this file"
         }
@@ -922,7 +789,11 @@
             "meta_network",
             "social_media"
           ],
-          "supported_channels": ["social", "display", "olv"],
+          "supported_channels": [
+            "social",
+            "display",
+            "olv"
+          ],
           "publisher_domain": "instagram.com"
         },
         {
@@ -942,7 +813,11 @@
             "meta_network",
             "social_media"
           ],
-          "supported_channels": ["social", "display", "olv"],
+          "supported_channels": [
+            "social",
+            "display",
+            "olv"
+          ],
           "publisher_domain": "facebook.com"
         },
         {
@@ -962,7 +837,10 @@
             "meta_network",
             "messaging"
           ],
-          "supported_channels": ["social", "display"],
+          "supported_channels": [
+            "social",
+            "display"
+          ],
           "publisher_domain": "whatsapp.com"
         }
       ],
@@ -1113,7 +991,10 @@
               "value": "news.example.com"
             }
           ],
-          "tags": ["premium", "news"],
+          "tags": [
+            "premium",
+            "news"
+          ],
           "publisher_domain": "news.example.com"
         }
       ],
@@ -1132,25 +1013,37 @@
           "url": "https://sales.news.example.com",
           "authorized_for": "All news properties",
           "authorization_type": "property_tags",
-          "property_tags": ["news"]
+          "property_tags": [
+            "news"
+          ]
         }
       ],
       "property_features": [
         {
           "url": "https://api.scope3.com",
           "name": "Scope3",
-          "features": ["carbon_score", "sustainability_grade"],
+          "features": [
+            "carbon_score",
+            "sustainability_grade"
+          ],
           "publisher_id": "pub_news_12345"
         },
         {
           "url": "https://api.tagtoday.net",
           "name": "TAG",
-          "features": ["tag_certified_against_fraud", "tag_brand_safety_certified"]
+          "features": [
+            "tag_certified_against_fraud",
+            "tag_brand_safety_certified"
+          ]
         },
         {
           "url": "https://api.onetrust.com",
           "name": "OneTrust",
-          "features": ["gdpr_compliant", "tcf_registered", "ccpa_compliant"],
+          "features": [
+            "gdpr_compliant",
+            "tcf_registered",
+            "ccpa_compliant"
+          ],
           "publisher_id": "ot_news_67890"
         }
       ],
@@ -1170,7 +1063,10 @@
           "description": "Consumers modeled as likely to purchase a Tesla in the next 12 months based on vehicle registration, financial, and behavioral data",
           "value_type": "binary",
           "category": "purchase_intent",
-          "tags": ["automotive", "premium"]
+          "tags": [
+            "automotive",
+            "premium"
+          ]
         },
         {
           "id": "vehicle_ownership",
@@ -1178,8 +1074,18 @@
           "description": "Current vehicle make owned by the consumer",
           "value_type": "categorical",
           "category": "ownership",
-          "allowed_values": ["tesla", "bmw", "mercedes", "audi", "lexus", "other_luxury", "non_luxury"],
-          "tags": ["automotive"]
+          "allowed_values": [
+            "tesla",
+            "bmw",
+            "mercedes",
+            "audi",
+            "lexus",
+            "other_luxury",
+            "non_luxury"
+          ],
+          "tags": [
+            "automotive"
+          ]
         },
         {
           "id": "purchase_propensity",
@@ -1187,8 +1093,14 @@
           "description": "Likelihood score of purchasing any new vehicle in the next 6 months",
           "value_type": "numeric",
           "category": "purchase_intent",
-          "range": { "min": 0, "max": 1, "unit": "score" },
-          "tags": ["automotive"]
+          "range": {
+            "min": 0,
+            "max": 1,
+            "unit": "score"
+          },
+          "tags": [
+            "automotive"
+          ]
         }
       ],
       "signal_tags": {
@@ -1206,13 +1118,17 @@
           "url": "https://liveramp.com/.well-known/adcp/signals",
           "authorized_for": "All Polk automotive signals via LiveRamp",
           "authorization_type": "signal_tags",
-          "signal_tags": ["automotive"]
+          "signal_tags": [
+            "automotive"
+          ]
         },
         {
           "url": "https://the-trade-desk.com/.well-known/adcp/signals",
           "authorized_for": "Polk premium signals only",
           "authorization_type": "signal_ids",
-          "signal_ids": ["likely_tesla_buyers"]
+          "signal_ids": [
+            "likely_tesla_buyers"
+          ]
         }
       ],
       "last_updated": "2025-01-15T10:00:00Z"

--- a/static/schemas/source/core/authorized-agent-base.json
+++ b/static/schemas/source/core/authorized-agent-base.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/authorized-agent-base.json",
+  "title": "Authorized Agent Base Fields",
+  "description": "Fields shared by every variant of `authorized_agents[*]` in adagents.json, regardless of authorization_type. Variants `allOf` this base and add their discriminator-specific fields. Centralized to prevent drift across the six authorization-type variants (4 property + 2 signal).",
+  "type": "object",
+  "properties": {
+    "url": {
+      "type": "string",
+      "format": "uri",
+      "description": "The authorized agent's API endpoint URL. Callers looking up an agent against this list (e.g., TMP providers validating `seller_agent.agent_url`) MUST compare using the AdCP URL canonicalization rules, not byte-equality — two URLs that differ only in case, default port, or percent-encoding of unreserved characters are the same agent. See docs/reference/url-canonicalization."
+    },
+    "authorized_for": {
+      "type": "string",
+      "description": "Human-readable description of what this agent is authorized to sell",
+      "minLength": 1,
+      "maxLength": 500
+    },
+    "signing_keys": {
+      "type": "array",
+      "description": "Optional publisher-attested public signing keys for this agent. Use these as the trust anchor for verifying signed agent responses instead of relying on key discovery from the agent domain alone.",
+      "items": {
+        "$ref": "/schemas/core/agent-signing-key.json"
+      },
+      "minItems": 1
+    },
+    "encryption_keys": {
+      "type": "array",
+      "description": "X25519 public keys for TMPX exposure token encryption. Each key identifies a cluster master that can decrypt TMPX tokens. Used with HPKE mode_base — read replicas encrypt with this public key, only the master can decrypt.",
+      "items": {
+        "$ref": "/schemas/core/agent-encryption-key.json"
+      },
+      "minItems": 1
+    },
+    "last_updated": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Optional ISO 8601 timestamp indicating when this `authorized_agents[]` entry last changed. Independent of the file-level `last_updated`. Lets validators perform a partial walk by skipping entries whose `last_updated` is older than their indexed value. Advisory — consumers MAY ignore and re-index the full file."
+    }
+  },
+  "required": ["url", "authorized_for"]
+}

--- a/static/schemas/source/core/authorized-agent-base.json
+++ b/static/schemas/source/core/authorized-agent-base.json
@@ -2,17 +2,17 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/core/authorized-agent-base.json",
   "title": "Authorized Agent Base Fields",
-  "description": "Fields shared by every variant of `authorized_agents[*]` in adagents.json, regardless of authorization_type. Variants `allOf` this base and add their discriminator-specific fields. Centralized to prevent drift across the six authorization-type variants (4 property + 2 signal).",
+  "description": "Fields shared by every variant of `authorized_agents[*]` in adagents.json, regardless of authorization_type. Variants `allOf` this base and add their discriminator-specific fields. Centralized to prevent drift across all authorization-type variants.",
   "type": "object",
   "properties": {
     "url": {
       "type": "string",
       "format": "uri",
-      "description": "The authorized agent's API endpoint URL. Callers looking up an agent against this list (e.g., TMP providers validating `seller_agent.agent_url`) MUST compare using the AdCP URL canonicalization rules, not byte-equality — two URLs that differ only in case, default port, or percent-encoding of unreserved characters are the same agent. See docs/reference/url-canonicalization."
+      "description": "The authorized agent's API endpoint URL. Callers comparing this URL against a registry (sales-agent list, signal-provider registry, TMP provider lookup, etc.) MUST canonicalize both sides per the AdCP URL canonicalization rules, not byte-equality — two URLs that differ only in case, default port, or percent-encoding of unreserved characters are the same agent. See docs/reference/url-canonicalization."
     },
     "authorized_for": {
       "type": "string",
-      "description": "Human-readable description of what this agent is authorized to sell",
+      "description": "Human-readable description of what this agent is authorized to do — what it sells (for sales/property agents) or what data it provides (for signal agents). The variant the entry uses (`property_ids`, `signal_tags`, etc.) tells consumers which inflection applies; this field carries the operator-supplied label.",
       "minLength": 1,
       "maxLength": 500
     },


### PR DESCRIPTION
## Summary

Closes #4510. Deferred earlier because adcp-client TS codegen produced broken union types on \`allOf+\$ref\` patterns. **Unblocked by adcp-client#1756** — PRs #1777 / #1783 shipped a pre-merge pass that flattens \`allOf+\$ref\` siblings before json-schema-to-typescript codegen.

## What changes

Five fields shared across all six \`authorized_agents[*]\` variants (\`url\`, \`authorized_for\`, \`signing_keys\`, \`encryption_keys\`, \`last_updated\`) move into a new \`static/schemas/source/core/authorized-agent-base.json\`. Each variant \`allOf\`s the base alongside its variant-specific properties.

Discriminator-specific fields (\`authorization_type\` const + the variant's selector) and property-variant qualifiers (\`collections\`, \`placement_ids\`, \`placement_tags\`, \`delegation_type\`, \`exclusive\`, \`countries\`, \`effective_from\`, \`effective_until\`) stay at the variant root so audit-oneof's discriminator detection keeps working.

## No semantic change

JSON Schema \`allOf\` merges the base's properties into each variant's instance shape — validators see the same required-field semantics. Existing files validate unchanged.

## Drift prevention

Adding a new shared field now requires one schema edit instead of six. The \`last_updated\` field that landed in PR #4504 had to be added six times; that's the recurrence this refactor prevents.

## Codegen verified

- **Python** (\`datamodel-codegen\`, used by adcp-client-python): clean inheritance — \`class AuthorizedAgents{1..6}(AuthorizedAgentBase)\`. Field duplication across the six variants eliminated.
- **TypeScript** (\`json-schema-to-typescript\`, used by adcp-client): adcp-client#1756's pre-merge pass handles this shape. End-to-end verification after adcp-client regenerates against this schema; if regression surfaces, file back upstream.

## Test plan

- [x] \`audit-oneof.mjs --check\` ok (discriminator still resolves; 37 → 39 discriminated thanks to the new base classification)
- [x] \`composed-schema-validation.test.cjs\` 43/43 pass
- [x] \`example-validation.test.cjs\` 14/14 adagents-relevant pass (7 pre-existing unrelated failures unchanged)
- [x] Bundled schemas include the new base file (\`dist/schemas/latest/core/authorized-agent-base.json\`)
- [x] Python codegen spike: 6/6 variants inherit \`AuthorizedAgentBase\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)