### PR TITLE
fix(admin): XSS in adagents builder + retire legacy creator (#4468)

### DIFF
--- a/.changeset/4468-adagents-builder-xss-and-legacy-creator.md
+++ b/.changeset/4468-adagents-builder-xss-and-legacy-creator.md
@@ -1,0 +1,11 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix: XSS in the adagents.json builder when rendering a hostile remote `adagents.json` or agent card. Any admin who validated a domain whose `adagents.json` or A2A agent-card contained script tags / event handlers in `card_data.name`, `validation.errors[*]`, `validation.warnings[*]`, `agent_cards[*].errors`, `agent_url`, or `domain` would have executed attacker-controlled JS in the admin's session.
+
+Reflections in `displayValidationResults()` and `displayAgentCardsResults()` now route every interpolated field through `escapeHtml()`, including the raw-data `<pre>` block (which previously emitted unescaped JSON, letting an attacker break out with `</pre><script>`).
+
+Also retires the legacy quick-add creator path (`startCreating()` and `updateUIForCreateOrUpdate()`): the entry-point DOM IDs were already removed when the v3 builder landed, leaving the v2-shape-emitting handlers orphaned. The supported `startManaging()` flow is the only entry point. `resetCreator()` was updated to stop referencing the removed IDs.
+
+Adds a jsdom-driven regression test that loads the static page, calls the two reflection helpers with hostile payloads (script tags, `<img onerror>`, `</pre>` break-out), and asserts no executable nodes land in the DOM and no global side-effect fires. Closes adcp#4468.

--- a/server/public/adagents-builder.html
+++ b/server/public/adagents-builder.html
@@ -1881,28 +1881,28 @@
         const resultsDiv = document.getElementById('validation-results');
         const { domain, found, validation, agent_cards } = data;
 
-        let html = `<h4>Validation Results for ${domain}</h4>`;
+        let html = `<h4>Validation Results for ${escapeHtml(domain)}</h4>`;
 
         // Overall status
         if (found && validation.valid) {
           html += `
                     <div class="validation-result result-success">
                         <strong>✅ Valid AdAgents.json Found</strong><br>
-                        Found at: <code>${validation.url}</code>
+                        Found at: <code>${escapeHtml(validation.url)}</code>
                     </div>
                 `;
         } else if (found && !validation.valid) {
           html += `
                     <div class="validation-result result-warning">
                         <strong>⚠️ AdAgents.json Found but Invalid</strong><br>
-                        Found at: <code>${validation.url}</code>
+                        Found at: <code>${escapeHtml(validation.url)}</code>
                     </div>
                 `;
         } else {
           html += `
                     <div class="validation-result result-error">
                         <strong>❌ No AdAgents.json Found</strong><br>
-                        Expected at: <code>https://${domain}/.well-known/adagents.json</code>
+                        Expected at: <code>https://${escapeHtml(domain)}/.well-known/adagents.json</code>
                     </div>
                 `;
         }
@@ -1914,7 +1914,7 @@
           if (validation.errors.length > 0) {
             html += '<h5>❌ Errors:</h5><ul style="margin-bottom: 10px;">';
             validation.errors.forEach(error => {
-              html += `<li style="color: var(--color-error-600);"><strong>${error.field}:</strong> ${error.message}</li>`;
+              html += `<li style="color: var(--color-error-600);"><strong>${escapeHtml(error.field)}:</strong> ${escapeHtml(error.message)}</li>`;
             });
             html += '</ul>';
           }
@@ -1922,9 +1922,9 @@
           if (validation.warnings.length > 0) {
             html += '<h5>⚠️ Warnings:</h5><ul>';
             validation.warnings.forEach(warning => {
-              html += `<li style="color: #92400e;"><strong>${warning.field}:</strong> ${warning.message}`;
+              html += `<li style="color: #92400e;"><strong>${escapeHtml(warning.field)}:</strong> ${escapeHtml(warning.message)}`;
               if (warning.suggestion) {
-                html += `<br><em>Suggestion: ${warning.suggestion}</em>`;
+                html += `<br><em>Suggestion: ${escapeHtml(warning.suggestion)}</em>`;
               }
               html += '</li>';
             });
@@ -1945,7 +1945,7 @@
             // Extract agent name from card data if available
             let agentName = '';
             if (card.valid && card.card_data && card.card_data.name) {
-              agentName = ` - ${card.card_data.name}`;
+              agentName = ` - ${escapeHtml(card.card_data.name)}`;
             }
 
             // Show which endpoint was used for successful validations
@@ -1957,22 +1957,28 @@
               } else if (endpointPath === '') {
                 endpointInfo = ' <span style="color: #7c3aed; font-size: 11px;">[Root]</span>';
               } else {
-                endpointInfo = ` <span style="color: #7c3aed; font-size: 11px;">[${endpointPath}]</span>`;
+                endpointInfo = ` <span style="color: #7c3aed; font-size: 11px;">[${escapeHtml(endpointPath)}]</span>`;
               }
             }
 
+            const safeStatusCode = card.status_code != null ? escapeHtml(String(card.status_code)) : '';
+            const safeResponseTime = card.response_time_ms != null ? escapeHtml(String(card.response_time_ms)) : '';
+            const safeErrors = Array.isArray(card.errors)
+              ? card.errors.map(e => escapeHtml(String(e))).join(', ')
+              : '';
+
             html += `
                         <div style="margin-bottom: 10px; padding: 12px; border-left: 4px solid ${statusColor}; background: var(--color-bg-card); border-radius: 4px;">
-                            <strong>${status} ${card.agent_url}${agentName}</strong>${endpointInfo}
+                            <strong>${status} ${escapeHtml(card.agent_url)}${agentName}</strong>${endpointInfo}
                             ${
-                              card.response_time_ms
-                                ? `<span style="color: #666; font-size: 12px;"> (${card.response_time_ms}ms)</span>`
+                              safeResponseTime
+                                ? `<span style="color: #666; font-size: 12px;"> (${safeResponseTime}ms)</span>`
                                 : ''
                             }
-                            ${card.status_code ? `<br><em>HTTP ${card.status_code}</em>` : ''}
+                            ${safeStatusCode ? `<br><em>HTTP ${safeStatusCode}</em>` : ''}
                             ${
-                              card.errors.length > 0
-                                ? `<br><span style="color: var(--color-error-600);">Errors: ${card.errors.join(', ')}</span>`
+                              safeErrors
+                                ? `<br><span style="color: var(--color-error-600);">Errors: ${safeErrors}</span>`
                                 : ''
                             }
                         </div>
@@ -1986,10 +1992,8 @@
           html += `
                     <details style="margin-top: 20px;">
                         <summary style="cursor: pointer; font-weight: bold; color: var(--text-secondary);">📄 Raw AdAgents.json Data</summary>
-                        <pre style="background: #1a202c; color: #f7fafc; padding: 16px; border-radius: 8px; margin-top: 12px; font-size: 12px; overflow-x: auto;">${JSON.stringify(
-                          validation.raw_data,
-                          null,
-                          2
+                        <pre style="background: #1a202c; color: #f7fafc; padding: 16px; border-radius: 8px; margin-top: 12px; font-size: 12px; overflow-x: auto;">${escapeHtml(
+                          JSON.stringify(validation.raw_data, null, 2)
                         )}</pre>
                     </details>
                 `;
@@ -4718,10 +4722,6 @@
       }
 
       // ============================================================================
-      // Initialize Dashboard (Update startCreating function)
-      // ============================================================================
-
-      // ============================================================================
       // Unified Entry Point
       // ============================================================================
 
@@ -5262,19 +5262,24 @@
         agentCards.forEach(card => {
           const status = card.valid ? '✅' : '❌';
           const statusColor = card.valid ? '#166534' : '#dc2626';
+          const safeStatusCode = card.status_code != null ? escapeHtml(String(card.status_code)) : '';
+          const safeResponseTime = card.response_time_ms != null ? escapeHtml(String(card.response_time_ms)) : '';
+          const safeErrors = Array.isArray(card.errors)
+            ? card.errors.map(e => escapeHtml(String(e))).join(', ')
+            : '';
 
           html += `
                     <div style="margin-bottom: 10px; padding: 12px; border-left: 4px solid ${statusColor}; background: var(--color-bg-card); border-radius: 4px;">
-                        <strong>${status} ${card.agent_url}</strong>
+                        <strong>${status} ${escapeHtml(card.agent_url)}</strong>
                         ${
-                          card.response_time_ms
-                            ? `<span style="color: #666; font-size: 12px;"> (${card.response_time_ms}ms)</span>`
+                          safeResponseTime
+                            ? `<span style="color: #666; font-size: 12px;"> (${safeResponseTime}ms)</span>`
                             : ''
                         }
-                        ${card.status_code ? `<br><em>HTTP ${card.status_code}</em>` : ''}
+                        ${safeStatusCode ? `<br><em>HTTP ${safeStatusCode}</em>` : ''}
                         ${
-                          card.errors.length > 0
-                            ? `<br><span style="color: var(--color-error-600);">Issues: ${card.errors.join(', ')}</span>`
+                          safeErrors
+                            ? `<br><span style="color: var(--color-error-600);">Issues: ${safeErrors}</span>`
                             : ''
                         }
                         ${
@@ -5342,137 +5347,6 @@
         document.getElementById('json-output').value = '';
       }
 
-      async function startCreating() {
-        const domain = document.getElementById('creator-domain-input').value.trim();
-        const startBtn = document.getElementById('start-creating-btn');
-
-        if (!domain) {
-          alert('Please enter a domain name');
-          return;
-        }
-
-        // Normalize domain (remove protocol, www, trailing slash)
-        const normalizedDomain = domain
-          .replace(/^https?:\/\//, '')
-          .replace(/^www\./, '')
-          .replace(/\/$/, '');
-
-        startBtn.disabled = true;
-        startBtn.textContent = '🔄 Checking domain...';
-
-        try {
-          // First validate domain to see if adagents.json exists
-          console.log(`Checking existing adagents.json for domain: ${normalizedDomain}`);
-
-          const response = await fetch('/api/adagents/validate', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({ domain: normalizedDomain }),
-          });
-
-          const result = await response.json();
-          let isUpdate = false;
-          let existingAgents = [];
-
-          if (result.success && result.data.found && result.data.validation.valid) {
-            // Valid adagents.json exists - this is an update
-            isUpdate = true;
-            if (result.data.validation.raw_data && result.data.validation.raw_data.authorized_agents) {
-              existingAgents = result.data.validation.raw_data.authorized_agents;
-            }
-            console.log(`Found existing valid adagents.json with ${existingAgents.length} agents`);
-          } else {
-            console.log(`No valid adagents.json found - will create new file`);
-          }
-
-          // Update UI based on create vs update mode
-          updateUIForCreateOrUpdate(normalizedDomain, isUpdate, existingAgents);
-
-          // Hide domain step, show creation form
-          document.getElementById('creator-domain-step').style.display = 'none';
-          document.getElementById('creator-form').style.display = 'block';
-
-          startBtn.disabled = false;
-          startBtn.textContent = '▶️ Start Creating';
-        } catch (error) {
-          console.error(`Error checking domain: ${error.message}`);
-          // On error, default to create mode
-          updateUIForCreateOrUpdate(normalizedDomain, false, []);
-
-          // Hide domain step, show creation form
-          document.getElementById('creator-domain-step').style.display = 'none';
-          document.getElementById('creator-form').style.display = 'block';
-
-          startBtn.disabled = false;
-          startBtn.textContent = '▶️ Start Creating';
-        }
-      }
-
-      function updateUIForCreateOrUpdate(normalizedDomain, isUpdate, existingAgents) {
-        // Update section title and description
-        const sectionTitle = document.getElementById('creator-section-title');
-        const sectionDescription = document.getElementById('creator-section-description');
-
-        if (isUpdate) {
-          sectionTitle.innerHTML = '📝 Update AdAgents.json';
-          sectionDescription.textContent =
-            'Update the existing adagents.json file for your domain. Modify authorized sales agents and generate an updated compliant file ready for deployment.';
-        } else {
-          sectionTitle.innerHTML = '📝 Create AdAgents.json';
-          sectionDescription.textContent =
-            'Create a properly formatted adagents.json file for your domain. Add authorized sales agents and generate a compliant file ready for deployment.';
-        }
-
-        // Update personalized instructions
-        document.getElementById('user-domain-display').textContent = normalizedDomain;
-        document.getElementById('user-file-path').textContent = `https://${normalizedDomain}/.well-known/adagents.json`;
-        document.getElementById('generated-domain-display').textContent = normalizedDomain;
-        document.getElementById('reminder-file-path').textContent =
-          `https://${normalizedDomain}/.well-known/adagents.json`;
-
-        // Pre-populate agents if updating
-        if (isUpdate && existingAgents.length > 0) {
-          const agentsList = document.getElementById('agents-list');
-          agentsList.innerHTML = '';
-
-          existingAgents.forEach(agent => {
-            const newEntry = document.createElement('div');
-            newEntry.className = 'agent-entry';
-            const propertyIds = agent.property_ids ? agent.property_ids.join(', ') : '';
-
-            const delegationType = agent.delegation_type || 'direct';
-            newEntry.innerHTML = `
-                        <input type="url" placeholder="https://agent.example.com" style="flex: 2;" class="agent-url" value="${agent.url}">
-                        <input type="text" placeholder="Authorized for all products and services" style="flex: 3;" class="agent-auth" value="${agent.authorized_for}">
-                        <select class="agent-delegation-type" style="flex: 1; padding: 8px; border-radius: 8px; border: 2px solid var(--color-border);" title="Commercial relationship: direct (your sales path), delegated (agent manages your monetization), ad_network (sold through network/package)">
-                          <option value="direct" ${delegationType === 'direct' ? 'selected' : ''}>direct</option>
-                          <option value="delegated" ${delegationType === 'delegated' ? 'selected' : ''}>delegated</option>
-                          <option value="ad_network" ${delegationType === 'ad_network' ? 'selected' : ''}>ad_network</option>
-                        </select>
-                        <input type="text" placeholder="property_id1, property_id2 (optional)" style="flex: 2;" class="agent-property-ids" value="${propertyIds}" title="Comma-separated list of property IDs this agent can sell">
-                        <button class="btn" onclick="removeAgentEntry(this)" style="background: var(--color-error-500);">✖️</button>
-                    `;
-
-            agentsList.appendChild(newEntry);
-          });
-
-          console.log(`Pre-populated ${existingAgents.length} existing agents for update`);
-        }
-
-        // Update personalized instructions based on create/update mode
-        const instructionsHeading = document.querySelector('#personalized-instructions h4');
-        const step2Title = document.getElementById('step-2-title');
-        if (isUpdate) {
-          instructionsHeading.innerHTML = `📍 File Update Instructions for <span id="user-domain-display">${escapeHtml(normalizedDomain)}</span>`;
-          step2Title.textContent = 'Step 2: Update Authorized Agents';
-        } else {
-          instructionsHeading.innerHTML = `📍 File Placement Instructions for <span id="user-domain-display">${escapeHtml(normalizedDomain)}</span>`;
-          step2Title.textContent = 'Step 2: Add Authorized Agents';
-        }
-      }
-
       function resetCreator() {
         // Clear state
         state.domain = '';
@@ -5481,16 +5355,26 @@
         state.fileFound = false;
 
         // Clear form data
-        document.getElementById('creator-domain-input').value = '';
-        document.getElementById('json-output').value = '';
+        const domainInput = document.getElementById('domain-input');
+        if (domainInput) domainInput.value = '';
+        const jsonOutput = document.getElementById('json-output');
+        if (jsonOutput) jsonOutput.value = '';
 
-        // Hide dashboard, show domain entry
+        // Hide dashboard
         document.getElementById('creator-form').style.display = 'none';
-        document.getElementById('creator-domain-step').style.display = 'block';
+
+        // Hide validation results from prior run
+        const validationResults = document.getElementById('validation-results');
+        if (validationResults) {
+          validationResults.style.display = 'none';
+          validationResults.innerHTML = '';
+        }
 
         // Reset JSON preview
-        document.getElementById('json-preview-panel').style.display = 'none';
-        document.getElementById('json-preview-toggle').textContent = '📄 View JSON ▼';
+        const previewPanel = document.getElementById('json-preview-panel');
+        if (previewPanel) previewPanel.style.display = 'none';
+        const previewToggle = document.getElementById('json-preview-toggle');
+        if (previewToggle) previewToggle.textContent = '📄 View JSON ▼';
 
         console.log('Reset adagents.json creator to domain entry step');
       }

--- a/server/public/adagents-builder.html
+++ b/server/public/adagents-builder.html
@@ -4896,8 +4896,10 @@
         }
 
         const { valid, errors = [], warnings = [] } = validationData;
+        const errorsArr = Array.isArray(errors) ? errors : [];
+        const warningsArr = Array.isArray(warnings) ? warnings : [];
 
-        if (errors.length === 0 && warnings.length === 0) {
+        if (errorsArr.length === 0 && warningsArr.length === 0) {
           resultsDiv.style.display = 'none';
           return;
         }
@@ -4910,19 +4912,28 @@
           html += '<h4 style="color: var(--color-error-600); margin: 0 0 12px 0;">❌ Invalid File</h4>';
         }
 
-        if (errors.length > 0) {
+        // Defensively gate: messages come from validator output that echoes
+        // attacker-controlled strings from a fetched adagents.json. Always
+        // escape, and skip entries that aren't `{ message: string }`.
+        const isMessageEntry = entry =>
+          entry && typeof entry === 'object' && typeof entry.message === 'string';
+
+        const safeErrors = errorsArr.filter(isMessageEntry);
+        const safeWarnings = warningsArr.filter(isMessageEntry);
+
+        if (safeErrors.length > 0) {
           html +=
             '<div style="margin-bottom: 12px;"><strong>Errors:</strong><ul style="margin: 4px 0; padding-left: 20px;">';
-          errors.forEach(err => {
-            html += `<li style="color: var(--color-error-600);">${err.message}</li>`;
+          safeErrors.forEach(err => {
+            html += `<li style="color: var(--color-error-600);">${escapeHtml(err.message)}</li>`;
           });
           html += '</ul></div>';
         }
 
-        if (warnings.length > 0) {
+        if (safeWarnings.length > 0) {
           html += '<div><strong>Warnings:</strong><ul style="margin: 4px 0; padding-left: 20px;">';
-          warnings.forEach(warn => {
-            html += `<li style="color: #f59e0b;">${warn.message}</li>`;
+          safeWarnings.forEach(warn => {
+            html += `<li style="color: #f59e0b;">${escapeHtml(warn.message)}</li>`;
           });
           html += '</ul></div>';
         }

--- a/tests/community/adagents-builder-xss.test.ts
+++ b/tests/community/adagents-builder-xss.test.ts
@@ -9,6 +9,7 @@ const htmlContent = readFileSync(htmlPath, 'utf-8');
 interface BuilderWindow extends Window {
   displayValidationResults: (data: unknown) => void;
   displayAgentCardsResults: (cards: unknown[]) => void;
+  showValidationSummary: (data: unknown) => void;
   escapeHtml: (s: string) => string;
   state: Record<string, unknown>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -173,6 +174,93 @@ describe('adagents-builder: XSS hardening on imported markup', () => {
     // The <pre> block should not allow injected </pre><script>
     expect(results.querySelectorAll('script').length).toBe(0);
     expect((win as unknown as { __rawPwned?: boolean }).__rawPwned).toBeUndefined();
+  });
+});
+
+describe('adagents-builder: showValidationSummary live path (#4468)', () => {
+  let win: BuilderWindow;
+  let dom: JSDOM;
+
+  beforeEach(() => {
+    dom = createDOM();
+    win = (dom as JSDOM & { window: BuilderWindow }).window;
+  });
+
+  it('escapes hostile error message in showValidationSummary', () => {
+    win.showValidationSummary({
+      valid: false,
+      errors: [{ message: '<img src=x onerror="window.__pwned = true">' }],
+      warnings: [],
+    });
+
+    const results = win.document.getElementById('validation-results') as HTMLElement;
+    expect(results.querySelectorAll('img').length).toBe(0);
+    expect(results.querySelectorAll('script').length).toBe(0);
+    expect((win as unknown as { __pwned?: boolean }).__pwned).toBeUndefined();
+    // The hostile payload survives as text, not as DOM
+    expect(results.textContent).toContain('<img src=x onerror=');
+  });
+
+  it('escapes hostile warning message in showValidationSummary', () => {
+    win.showValidationSummary({
+      valid: true,
+      errors: [],
+      warnings: [{ message: '<img src=x onerror="window.__warnPwned = true">' }],
+    });
+
+    const results = win.document.getElementById('validation-results') as HTMLElement;
+    expect(results.querySelectorAll('img').length).toBe(0);
+    expect(results.querySelectorAll('script').length).toBe(0);
+    expect((win as unknown as { __warnPwned?: boolean }).__warnPwned).toBeUndefined();
+  });
+
+  it('escapes hostile script payload from real adagents-manager echoed fields', () => {
+    // Mirrors server/src/adagents-manager.ts:1007/1079/1157/1235/1275/1288/1319
+    // where signal IDs, agent fields, tag names, and property IDs from the
+    // attacker-hosted adagents.json get echoed into validator messages.
+    win.showValidationSummary({
+      valid: false,
+      errors: [
+        { message: 'Signal id "<script>window.__sigPwned = true;</script>" is invalid' },
+        { message: 'Property id "<script>window.__propPwned = true;</script>" not found' },
+      ],
+      warnings: [
+        { message: 'Tag "<script>window.__tagPwned = true;</script>" is unknown' },
+      ],
+    });
+
+    const results = win.document.getElementById('validation-results') as HTMLElement;
+    expect(results.querySelectorAll('script').length).toBe(0);
+    const w = win as unknown as {
+      __sigPwned?: boolean;
+      __propPwned?: boolean;
+      __tagPwned?: boolean;
+    };
+    expect(w.__sigPwned).toBeUndefined();
+    expect(w.__propPwned).toBeUndefined();
+    expect(w.__tagPwned).toBeUndefined();
+  });
+
+  it('skips error/warning entries that are not { message: string }', () => {
+    // Defensive shape gate: never call escapeHtml on something we haven't
+    // confirmed is a string-message entry.
+    win.showValidationSummary({
+      valid: false,
+      errors: [
+        null,
+        'just a bare string',
+        { message: 123 },
+        { notMessage: '<img src=x onerror="window.__shapePwned = true">' },
+        { message: 'real error' },
+      ],
+      warnings: 'not even an array',
+    });
+
+    const results = win.document.getElementById('validation-results') as HTMLElement;
+    expect(results.querySelectorAll('img').length).toBe(0);
+    expect((win as unknown as { __shapePwned?: boolean }).__shapePwned).toBeUndefined();
+    // The one well-formed entry still renders
+    expect(results.textContent).toContain('real error');
   });
 });
 

--- a/tests/community/adagents-builder-xss.test.ts
+++ b/tests/community/adagents-builder-xss.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const htmlPath = resolve(__dirname, '../../server/public/adagents-builder.html');
+const htmlContent = readFileSync(htmlPath, 'utf-8');
+
+interface BuilderWindow extends Window {
+  displayValidationResults: (data: unknown) => void;
+  displayAgentCardsResults: (cards: unknown[]) => void;
+  escapeHtml: (s: string) => string;
+  state: Record<string, unknown>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [k: string]: any;
+}
+
+function createDOM(): JSDOM & { window: BuilderWindow } {
+  const dom = new JSDOM(htmlContent, {
+    url: 'https://example.test/adagents-builder.html',
+    runScripts: 'dangerously',
+    pretendToBeVisual: true,
+  });
+  // Stub fetch (the page may call /api endpoints on load).
+  (dom.window as unknown as BuilderWindow).fetch = () =>
+    Promise.resolve({ ok: false, status: 404, json: async () => ({}) }) as unknown as Promise<Response>;
+  return dom as JSDOM & { window: BuilderWindow };
+}
+
+describe('adagents-builder: XSS hardening on imported markup', () => {
+  let win: BuilderWindow;
+  let dom: JSDOM;
+
+  beforeEach(() => {
+    dom = createDOM();
+    win = (dom as JSDOM & { window: BuilderWindow }).window;
+  });
+
+  it('escapes script tags in agent card name field (displayValidationResults)', () => {
+    const hostile = {
+      domain: 'attacker.test',
+      found: true,
+      validation: {
+        valid: true,
+        url: 'https://attacker.test/.well-known/adagents.json',
+        errors: [],
+        warnings: [],
+      },
+      agent_cards: [
+        {
+          valid: true,
+          agent_url: 'https://attacker.test/agent',
+          card_data: {
+            name: '<script>window.__pwned = true;</script>',
+          },
+          card_endpoint: 'https://attacker.test/agent/.well-known/agent-card.json',
+          response_time_ms: 50,
+          status_code: 200,
+          errors: [],
+        },
+      ],
+    };
+
+    win.displayValidationResults(hostile);
+
+    const results = win.document.getElementById('validation-results') as HTMLElement;
+    // No <script> element should have been parsed into the DOM
+    expect(results.querySelectorAll('script').length).toBe(0);
+    // And the hostile global side-effect must not have fired
+    expect((win as unknown as { __pwned?: boolean }).__pwned).toBeUndefined();
+    // The text content should still contain the escaped representation
+    expect(results.textContent).toContain('<script>window.__pwned = true;</script>');
+  });
+
+  it('escapes event handlers in validation errors and warnings (displayValidationResults)', () => {
+    const hostile = {
+      domain: 'attacker.test',
+      found: true,
+      validation: {
+        valid: false,
+        url: 'https://attacker.test/.well-known/adagents.json',
+        errors: [
+          {
+            field: '<img src=x onerror="window.__errPwned = true">',
+            message: 'plain message',
+          },
+        ],
+        warnings: [
+          {
+            field: 'warnField',
+            message: '<img src=x onerror="window.__warnPwned = true">',
+            suggestion: '<img src=x onerror="window.__sugPwned = true">',
+          },
+        ],
+      },
+      agent_cards: [],
+    };
+
+    win.displayValidationResults(hostile);
+
+    const results = win.document.getElementById('validation-results') as HTMLElement;
+    expect(results.querySelectorAll('img').length).toBe(0);
+    const w = win as unknown as { __errPwned?: boolean; __warnPwned?: boolean; __sugPwned?: boolean };
+    expect(w.__errPwned).toBeUndefined();
+    expect(w.__warnPwned).toBeUndefined();
+    expect(w.__sugPwned).toBeUndefined();
+  });
+
+  it('escapes hostile errors array in displayAgentCardsResults', () => {
+    // The host div for this helper is no longer in the live HTML; inject one
+    // so the function can render and we can assert on its output.
+    const host = win.document.createElement('div');
+    host.id = 'agent-cards-results';
+    win.document.body.appendChild(host);
+
+    const hostile = [
+      {
+        valid: false,
+        agent_url: '<script>window.__cardsPwned = true;</script>',
+        response_time_ms: 10,
+        status_code: 500,
+        errors: ['<img src=x onerror="window.__cardsErrPwned = true">'],
+      },
+    ];
+
+    win.displayAgentCardsResults(hostile);
+
+    expect(host.querySelectorAll('script').length).toBe(0);
+    expect(host.querySelectorAll('img').length).toBe(0);
+    const w = win as unknown as { __cardsPwned?: boolean; __cardsErrPwned?: boolean };
+    expect(w.__cardsPwned).toBeUndefined();
+    expect(w.__cardsErrPwned).toBeUndefined();
+  });
+
+  it('escapes hostile domain in the results heading', () => {
+    const hostile = {
+      domain: '<script>window.__domainPwned = true;</script>',
+      found: false,
+      validation: { valid: false, url: '', errors: [], warnings: [] },
+      agent_cards: [],
+    };
+
+    win.displayValidationResults(hostile);
+
+    const results = win.document.getElementById('validation-results') as HTMLElement;
+    expect(results.querySelectorAll('script').length).toBe(0);
+    expect((win as unknown as { __domainPwned?: boolean }).__domainPwned).toBeUndefined();
+  });
+
+  it('escapes hostile JSON in the raw data <pre> block', () => {
+    const hostile = {
+      domain: 'attacker.test',
+      found: true,
+      validation: {
+        valid: true,
+        url: 'https://attacker.test/.well-known/adagents.json',
+        errors: [],
+        warnings: [],
+        raw_data: {
+          authorized_agents: [
+            {
+              url: 'https://attacker.test/</pre><script>window.__rawPwned = true;</script><pre>',
+            },
+          ],
+        },
+      },
+      agent_cards: [],
+    };
+
+    win.displayValidationResults(hostile);
+
+    const results = win.document.getElementById('validation-results') as HTMLElement;
+    // The <pre> block should not allow injected </pre><script>
+    expect(results.querySelectorAll('script').length).toBe(0);
+    expect((win as unknown as { __rawPwned?: boolean }).__rawPwned).toBeUndefined();
+  });
+});
+
+describe('adagents-builder: legacy creator retired', () => {
+  it('does not expose startCreating or updateUIForCreateOrUpdate on the window', () => {
+    const { window } = createDOM();
+    expect(typeof (window as unknown as Record<string, unknown>).startCreating).toBe('undefined');
+    expect(typeof (window as unknown as Record<string, unknown>).updateUIForCreateOrUpdate).toBe('undefined');
+  });
+});


### PR DESCRIPTION
## Summary

- **XSS fix.** `displayValidationResults()` and `displayAgentCardsResults()` in `server/public/adagents-builder.html` interpolated attacker-controlled fields from a fetched `adagents.json` and its A2A agent cards straight into `innerHTML`. Any admin who validated a hostile domain executed attacker-controlled JS. All reflections now route through `escapeHtml()`, including the raw-data `<pre>` block (which previously let an attacker break out with `</pre><script>`).
- **Legacy creator retired.** `startCreating()` and `updateUIForCreateOrUpdate()` were orphaned when the v3 builder landed — their entry-point DOM IDs (`creator-domain-input`, `creator-domain-step`, `start-creating-btn`, etc.) are gone from the HTML — but the v2-shape-emitting handlers stayed in the source and interpolated attacker-controlled `agent.url` / `authorized_for` / `property_ids` into `value=` attributes without escaping. Removed. `resetCreator()` updated to drop references to the removed IDs.
- **Regression test.** New `tests/community/adagents-builder-xss.test.ts` loads the static page in jsdom, drives the two reflection helpers with hostile payloads (`<script>`, `<img onerror>`, `</pre>` break-out, hostile `domain`), and asserts no executable nodes are parsed into the DOM and no global side-effect fires.

## Scope guards

Per the audit, only the two cited reflection clusters (~1884-1975, ~5256-5292) and the legacy form path are touched in this PR. The file has 61 `innerHTML` usages total; a systematic migration to `textContent` / DOM-API construction is out of scope here and should be a follow-up issue. The live `showValidationSummary()` helper at ~4890 also reflects attacker-controlled `errors[*].message` / `warnings[*].message` into `innerHTML` without escaping — same defect class, also worth folding into the follow-up.

Closes adcp#4468.

## Test plan

- [x] `npx vitest run tests/community/` — 34 passed (2 files), including the 6 new XSS regression cases
- [x] Precommit (`test:unit` + lint passes + `typecheck`) green
- [ ] Manual smoke: open `/adagents-builder.html`, enter a domain that returns a hostile `adagents.json`, confirm script payloads render as literal text

🤖 Generated with [Claude Code](https://claude.com/claude-code)