### PR TITLE
fix(security): handle WorkOS user.deleted for primary-bound users (#3718)

### DIFF
--- a/.changeset/3718-workos-user-deleted-primary.md
+++ b/.changeset/3718-workos-user-deleted-primary.md
@@ -1,0 +1,24 @@
+---
+"adcontextprotocol": patch
+---
+
+Security: handle WorkOS `user.deleted` for primary-bound users (#3718).
+
+When a WorkOS user that is the primary credential on a multi-credential
+identity was deleted (operator action, account closure, or GDPR/CCPA erasure
+webhook), the CASCADE on `identity_workos_users.workos_user_id` dropped the
+binding and left the identity with zero primaries. `attachIdentityId` then
+resolved `primary_workos_user_id` to NULL, skipped the id-swap, and the
+surviving secondary signed in to an empty workspace — a denial-of-service
+against any non-primary user, reachable end-user-initiated via GDPR/CCPA.
+
+The `user.deleted` handler now promotes the longest-bound surviving secondary
+to primary in a single transaction before the CASCADE fires, mirroring the
+`findSuccessorForPromotion` pattern already used by `deleteMembership`. The
+handler also invalidates the session/JWT cache for both the deleted user and
+the promoted successor to close the 60-second window where a cached id-swap
+could still route reads to the dead binding. Promotion failures emit
+`logger.warn` (auto-routed to `#admin-errors`) plus an explicit
+`notifySystemError` ops alert, then return 200 so WorkOS doesn't retry-storm
+the webhook; the identity is left in a recoverable state for an admin to
+repair.

--- a/server/src/db/identity-db.ts
+++ b/server/src/db/identity-db.ts
@@ -1,0 +1,129 @@
+/**
+ * Identity-binding operations for `identity_workos_users`.
+ *
+ * An "identity" is the person; a WorkOS user is one credential bundle for
+ * one email. `identity_workos_users` rows bind credentials to identities,
+ * with a partial unique index enforcing exactly one primary per identity.
+ *
+ * Extracted from the webhook handler so the SQL can be exercised by
+ * integration tests against a real PostgreSQL instance without dragging in
+ * the full webhook transitive dependency chain.
+ */
+
+import { getPool } from './client.js';
+import { createLogger } from '../logger.js';
+import { notifySystemError } from '../addie/error-notifier.js';
+
+const logger = createLogger('identity-db');
+
+/**
+ * When a WorkOS user that is the primary binding on a multi-credential
+ * identity is deleted (operator action, account closure, GDPR/CCPA erasure
+ * webhook), the CASCADE on `identity_workos_users.workos_user_id` drops the
+ * binding. The identity is left with zero primaries until an admin
+ * intervenes — `attachIdentityId` resolves `primary_workos_user_id` to NULL
+ * and skips the id-swap, so the surviving secondary signs in to an empty
+ * workspace (all their app-state was keyed on the now-deleted primary's
+ * workos_user_id). That's a denial-of-service against any non-primary user.
+ *
+ * Promote the longest-bound surviving secondary to primary in the same
+ * transaction, before the CASCADE fires. The id-swap in the auth middleware
+ * then routes both the dead binding and the surviving secondary to the new
+ * primary, keeping app-state reads intact.
+ *
+ * Returns the promoted credential's workos_user_id when a promotion ran, or
+ * null when there was no successor (single-credential identity — normal
+ * deletion, nothing to do) or the deleted user was not primary.
+ *
+ * On unexpected DB errors: log + ops alert, return null. The caller still
+ * returns 200 to WorkOS so the webhook doesn't retry-storm on a transient
+ * promotion failure; the binding is still deleted by the subsequent CASCADE,
+ * and admins can repair the identity manually.
+ */
+export async function promoteSecondaryIfPrimaryDeleted(
+  workosUserId: string,
+): Promise<{ promotedUserId: string } | null> {
+  const pool = getPool();
+  const client = await pool.connect();
+
+  try {
+    await client.query('BEGIN');
+
+    // Lock the binding row to serialize concurrent promotions (e.g. two
+    // user.deleted webhooks against bindings on the same identity).
+    const primaryCheck = await client.query<{ identity_id: string }>(
+      `SELECT identity_id FROM identity_workos_users
+        WHERE workos_user_id = $1 AND is_primary = TRUE
+        FOR UPDATE`,
+      [workosUserId],
+    );
+
+    if (primaryCheck.rows.length === 0) {
+      // Not primary (or no binding at all) — nothing to promote.
+      await client.query('ROLLBACK');
+      return null;
+    }
+
+    const identityId = primaryCheck.rows[0].identity_id;
+
+    // Pick the longest-bound surviving secondary — matches the
+    // findSuccessorForPromotion convention used by membership owner
+    // succession (created_at ASC).
+    const successor = await client.query<{ workos_user_id: string }>(
+      `SELECT workos_user_id FROM identity_workos_users
+        WHERE identity_id = $1
+          AND workos_user_id <> $2
+          AND is_primary = FALSE
+        ORDER BY bound_at ASC
+        LIMIT 1
+        FOR UPDATE`,
+      [identityId, workosUserId],
+    );
+
+    if (successor.rows.length === 0) {
+      // Single-credential identity. Nothing to promote — the CASCADE will
+      // drop the only binding and the (orphan) identity row alongside it.
+      await client.query('ROLLBACK');
+      return null;
+    }
+
+    const successorId = successor.rows[0].workos_user_id;
+
+    // Demote the deleted user's binding first so the partial unique index
+    // `idx_identity_workos_users_one_primary` doesn't reject the promotion.
+    await client.query(
+      `UPDATE identity_workos_users SET is_primary = FALSE
+        WHERE workos_user_id = $1`,
+      [workosUserId],
+    );
+    await client.query(
+      `UPDATE identity_workos_users SET is_primary = TRUE
+        WHERE workos_user_id = $1 AND identity_id = $2`,
+      [successorId, identityId],
+    );
+
+    await client.query('COMMIT');
+
+    logger.info(
+      { deletedUserId: workosUserId, promotedUserId: successorId, identityId },
+      'Promoted secondary to primary before WorkOS user.deleted CASCADE',
+    );
+
+    return { promotedUserId: successorId };
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => undefined);
+    // logger.warn auto-routes to #admin-errors via posthog.ts:201-205.
+    logger.warn(
+      { err, userId: workosUserId },
+      'Failed to promote secondary on user.deleted — identity may be left with zero primaries',
+    );
+    // Explicit ops alert so this doesn't drown in the warn stream.
+    notifySystemError({
+      source: 'workos-webhook',
+      errorMessage: `user.deleted: failed to promote secondary for ${workosUserId}; identity may be left with zero primaries and the surviving binding will sign in to an empty workspace until repaired`,
+    });
+    return null;
+  } finally {
+    client.release();
+  }
+}

--- a/server/src/routes/workos-webhooks.ts
+++ b/server/src/routes/workos-webhooks.ts
@@ -21,6 +21,8 @@
 import { Router, Request, Response } from 'express';
 import { createLogger } from '../logger.js';
 import { getPool } from '../db/client.js';
+import { invalidateSessionsForUsers } from '../middleware/auth.js';
+import { promoteSecondaryIfPrimaryDeleted } from '../db/identity-db.js';
 import {
   upsertWorkosDomain,
   autoPromotePrimaryIfNone,
@@ -1044,8 +1046,21 @@ export function createWorkOSWebhooksRouter(): Router {
 
           case 'user.deleted': {
             const user = event.data as unknown as UserData;
+            // Promote a surviving secondary BEFORE the CASCADE on
+            // identity_workos_users.workos_user_id fires (via deleteUser).
+            // Without this, the identity is left with zero primaries and the
+            // surviving secondary signs in to an empty workspace — a DoS
+            // vector reachable via GDPR/CCPA-driven WorkOS deletions.
+            const promoted = await promoteSecondaryIfPrimaryDeleted(user.id);
             await deleteUser(user.id);
             await deleteUserMemberships(user.id);
+            // Close the 60-second session/JWT cache window where a cached
+            // pre-deletion swap would still route reads to the dead binding.
+            // Invalidate both the deleted user and the promoted successor so
+            // the next request re-resolves identity from the DB.
+            const sessionsToInvalidate = [user.id];
+            if (promoted) sessionsToInvalidate.push(promoted.promotedUserId);
+            invalidateSessionsForUsers(sessionsToInvalidate);
             invalidateUnifiedUsersCache();
             break;
           }

--- a/server/tests/integration/workos-user-deleted-primary.test.ts
+++ b/server/tests/integration/workos-user-deleted-primary.test.ts
@@ -1,0 +1,177 @@
+/**
+ * WorkOS user.deleted webhook — primary-bound user safety.
+ *
+ * Issue adcontextprotocol/adcp#3718: deleting the primary binding on a
+ * multi-credential identity (e.g. GDPR/CCPA erasure via WorkOS dashboard)
+ * leaves the identity with zero primaries after the CASCADE on
+ * identity_workos_users.workos_user_id fires. `attachIdentityId` then
+ * resolves the surviving secondary to a NULL primary and skips the id-swap,
+ * so they sign in to an empty workspace.
+ *
+ * Mitigation: promote the longest-bound surviving secondary to primary in
+ * the same transaction, BEFORE the CASCADE runs. This test exercises the
+ * `promoteSecondaryIfPrimaryDeleted` helper end-to-end against a real DB
+ * and asserts the wiring in the user.deleted handler.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { promoteSecondaryIfPrimaryDeleted } from '../../src/db/identity-db.js';
+import type { Pool } from 'pg';
+
+const TEST_USER_PREFIX = 'user_wh_deleted_test_';
+
+describe('user.deleted: promote secondary before CASCADE (#3718)', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString:
+        process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  }, 60000);
+
+  afterAll(async () => {
+    await pool.query(`DELETE FROM users WHERE workos_user_id LIKE $1`, [`${TEST_USER_PREFIX}%`]);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await pool.query(`DELETE FROM users WHERE workos_user_id LIKE $1`, [`${TEST_USER_PREFIX}%`]);
+  });
+
+  async function insertUser(suffix: string, email: string): Promise<string> {
+    const userId = `${TEST_USER_PREFIX}${suffix}`;
+    await pool.query(
+      `INSERT INTO users (workos_user_id, email, first_name, last_name, email_verified,
+                          workos_created_at, workos_updated_at, created_at, updated_at)
+       VALUES ($1, $2, 'Test', 'User', true, NOW(), NOW(), NOW(), NOW())`,
+      [userId, email]
+    );
+    return userId;
+  }
+
+  /**
+   * Bind `secondaryUserId` as a non-primary credential on the same identity
+   * as `primaryUserId`, mirroring what `mergeUsers` does when a secondary
+   * sign-in email is linked. We do this directly rather than calling
+   * mergeUsers so the test stays focused on the deletion path.
+   */
+  async function bindAsSecondary(
+    primaryUserId: string,
+    secondaryUserId: string,
+    boundAtOffsetSeconds: number,
+  ): Promise<string> {
+    const identityResult = await pool.query<{ identity_id: string }>(
+      `SELECT identity_id FROM identity_workos_users WHERE workos_user_id = $1`,
+      [primaryUserId]
+    );
+    const identityId = identityResult.rows[0].identity_id;
+
+    // Drop the secondary's singleton identity and re-point its binding
+    // (mirrors the mergeUsers fixup in user-merge-db.ts).
+    const oldIdentity = await pool.query<{ identity_id: string }>(
+      `SELECT identity_id FROM identity_workos_users WHERE workos_user_id = $1`,
+      [secondaryUserId]
+    );
+    await pool.query(
+      `UPDATE identity_workos_users
+          SET identity_id = $1,
+              is_primary = FALSE,
+              bound_at = NOW() + ($3 || ' seconds')::interval
+        WHERE workos_user_id = $2`,
+      [identityId, secondaryUserId, String(boundAtOffsetSeconds)]
+    );
+    if (oldIdentity.rows[0]?.identity_id && oldIdentity.rows[0].identity_id !== identityId) {
+      await pool.query(`DELETE FROM identities WHERE id = $1`, [oldIdentity.rows[0].identity_id]);
+    }
+    return identityId;
+  }
+
+  it('promotes the longest-bound secondary to primary when the primary is deleted', async () => {
+    const primary = await insertUser('promote_p', 'primary@test.example');
+    const olderSecondary = await insertUser('promote_s1', 'older-secondary@test.example');
+    const newerSecondary = await insertUser('promote_s2', 'newer-secondary@test.example');
+
+    // older binds first (smaller bound_at offset), newer binds later
+    const identityId = await bindAsSecondary(primary, olderSecondary, 1);
+    await bindAsSecondary(primary, newerSecondary, 2);
+
+    const result = await promoteSecondaryIfPrimaryDeleted(primary);
+
+    expect(result).not.toBeNull();
+    expect(result!.promotedUserId).toBe(olderSecondary);
+
+    // The deleted user is no longer primary; the older secondary is.
+    const primaries = await pool.query<{ workos_user_id: string; is_primary: boolean }>(
+      `SELECT workos_user_id, is_primary FROM identity_workos_users
+        WHERE identity_id = $1
+        ORDER BY workos_user_id`,
+      [identityId]
+    );
+    const byUser = Object.fromEntries(primaries.rows.map(r => [r.workos_user_id, r.is_primary]));
+    expect(byUser[primary]).toBe(false);
+    expect(byUser[olderSecondary]).toBe(true);
+    expect(byUser[newerSecondary]).toBe(false);
+
+    // Exactly one primary on the identity — the partial unique index holds.
+    const primaryCount = primaries.rows.filter(r => r.is_primary).length;
+    expect(primaryCount).toBe(1);
+  });
+
+  it('returns null and leaves state untouched when the identity has no secondaries', async () => {
+    const onlyUser = await insertUser('solo', 'solo@test.example');
+
+    const result = await promoteSecondaryIfPrimaryDeleted(onlyUser);
+
+    expect(result).toBeNull();
+
+    // The original primary binding is unchanged.
+    const row = await pool.query<{ is_primary: boolean }>(
+      `SELECT is_primary FROM identity_workos_users WHERE workos_user_id = $1`,
+      [onlyUser]
+    );
+    expect(row.rows[0].is_primary).toBe(true);
+  });
+
+  it('returns null when the deleted user is not a primary binding', async () => {
+    const primary = await insertUser('np_p', 'primary2@test.example');
+    const secondary = await insertUser('np_s', 'secondary2@test.example');
+    await bindAsSecondary(primary, secondary, 1);
+
+    // Delete the secondary (not the primary). No promotion is needed.
+    const result = await promoteSecondaryIfPrimaryDeleted(secondary);
+
+    expect(result).toBeNull();
+
+    const primaryRow = await pool.query<{ is_primary: boolean }>(
+      `SELECT is_primary FROM identity_workos_users WHERE workos_user_id = $1`,
+      [primary]
+    );
+    expect(primaryRow.rows[0].is_primary).toBe(true);
+  });
+
+  it('CASCADE on the deleted user removes the binding after promotion', async () => {
+    const primary = await insertUser('cascade_p', 'cascadeprimary@test.example');
+    const secondary = await insertUser('cascade_s', 'cascadesecondary@test.example');
+    const identityId = await bindAsSecondary(primary, secondary, 1);
+
+    const result = await promoteSecondaryIfPrimaryDeleted(primary);
+    expect(result?.promotedUserId).toBe(secondary);
+
+    // The webhook handler runs deleteUser() next, which CASCADE-drops the
+    // (now non-primary) binding. Surviving primary remains.
+    await pool.query(`DELETE FROM users WHERE workos_user_id = $1`, [primary]);
+
+    const survivors = await pool.query<{ workos_user_id: string; is_primary: boolean }>(
+      `SELECT workos_user_id, is_primary FROM identity_workos_users WHERE identity_id = $1`,
+      [identityId]
+    );
+    expect(survivors.rows).toHaveLength(1);
+    expect(survivors.rows[0].workos_user_id).toBe(secondary);
+    expect(survivors.rows[0].is_primary).toBe(true);
+  });
+});
+

--- a/server/tests/unit/workos-webhook-user-deleted-wiring.test.ts
+++ b/server/tests/unit/workos-webhook-user-deleted-wiring.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Static-analysis wiring assertions on the user.deleted webhook handler.
+ *
+ * Issue adcontextprotocol/adcp#3718: WorkOS-side deletion of a primary
+ * credential leaves multi-credential identities with zero primaries. The
+ * handler must promote a surviving secondary before the CASCADE fires,
+ * invalidate the 60-second session cache, and never return a 5xx on
+ * promotion failure (which would trigger WorkOS retry storms).
+ *
+ * These checks are static so a refactor that re-orders the calls or drops
+ * the invalidation fails fast without spinning up the full HTTP stack.
+ */
+
+const WEBHOOK_FILE = path.resolve(__dirname, '../../src/routes/workos-webhooks.ts');
+const IDENTITY_DB_FILE = path.resolve(__dirname, '../../src/db/identity-db.ts');
+const webhookSource = fs.readFileSync(WEBHOOK_FILE, 'utf-8');
+const identitySource = fs.readFileSync(IDENTITY_DB_FILE, 'utf-8');
+
+describe('user.deleted handler wiring (#3718)', () => {
+  const userDeletedBlockMatch = webhookSource.match(
+    /case 'user\.deleted':\s*\{([\s\S]*?)\n\s{10}\}/,
+  );
+  const block = userDeletedBlockMatch?.[1] ?? '';
+
+  it('matched the user.deleted case body', () => {
+    expect(block).not.toEqual('');
+  });
+
+  it('calls promoteSecondaryIfPrimaryDeleted before deleteUser', () => {
+    const promoteIdx = block.indexOf('promoteSecondaryIfPrimaryDeleted');
+    const deleteUserIdx = block.indexOf('deleteUser(');
+    expect(promoteIdx).toBeGreaterThanOrEqual(0);
+    expect(deleteUserIdx).toBeGreaterThan(promoteIdx);
+  });
+
+  it('invalidates session caches for the deleted user', () => {
+    expect(block).toMatch(/invalidateSessionsForUsers\s*\(/);
+  });
+});
+
+describe('promoteSecondaryIfPrimaryDeleted error containment (#3718)', () => {
+  // The handler awaits the helper directly without a try/catch — a thrown
+  // error would land in the outer catch and produce a 500, triggering WorkOS
+  // retry storms. The helper must catch its own errors and return null so
+  // the handler falls through to the 200 path.
+  const helperSource = identitySource.match(
+    /export async function promoteSecondaryIfPrimaryDeleted[\s\S]*?\n\}\n/,
+  )?.[0];
+
+  it('matched the helper source', () => {
+    expect(helperSource).toBeDefined();
+  });
+
+  it('swallows DB errors (catch + return null) so the webhook returns 200', () => {
+    expect(helperSource).toMatch(/catch\s*\(/);
+    expect(helperSource).toMatch(/return null/);
+  });
+
+  it('emits an explicit ops alert on promotion failure', () => {
+    // logger.warn auto-posts to #admin-errors (posthog.ts:201-205); plus an
+    // explicit notifySystemError so the alert doesn't get lost in the warn
+    // stream during noisy hours.
+    expect(helperSource).toMatch(/logger\.warn/);
+    expect(helperSource).toMatch(/notifySystemError/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3718.

When a WorkOS user that is the primary credential on a multi-credential identity is deleted (operator action, account closure, **GDPR/CCPA erasure webhook**), the CASCADE on `identity_workos_users.workos_user_id` drops the binding. The identity is then left with zero primaries:

- `attachIdentityId` resolves `primary_workos_user_id` to NULL and skips the id-swap.
- The surviving non-primary user signs in successfully but to an **empty workspace** — all their app-state was keyed on the now-deleted primary's `workos_user_id`.

That's a denial-of-service against any non-primary user, reachable end-user-initiated via GDPR/CCPA flows in WorkOS — not just operator action.

## Fix (Option A — auto-promote successor)

In the `user.deleted` switch case in `server/src/routes/workos-webhooks.ts`:

1. **Promote before CASCADE.** Call `promoteSecondaryIfPrimaryDeleted` (new helper in `server/src/db/identity-db.ts`) which, in a single transaction, picks the longest-bound surviving secondary on the identity and flips `is_primary` from the deleted user's binding onto it. Mirrors the `findSuccessorForPromotion` pattern already used by `deleteMembership`. `attachIdentityId` then routes both the dead binding and the surviving secondary to the new primary, keeping app-state reads intact.
2. **Invalidate sessions.** Call `invalidateSessionsForUsers([deletedUserId, promotedUserId])` to close the 60-second session/JWT cache window where a cached pre-deletion id-swap could still route reads to the dead binding.
3. **Return 200 on promotion failure.** The helper swallows DB errors, emits `logger.warn` (auto-routes to `#admin-errors` via `posthog.ts:201-205`) plus an explicit `notifySystemError` ops alert, and returns null. The handler awaits the helper directly without a try/catch, so the outer 500 path is never reached; WorkOS doesn't retry-storm.

The CASCADE still drops the (now non-primary) binding when `deleteUser()` runs. App-state FKs aren't rewritten — the `attachIdentityId` indirection already handles routing, per scope guard.

## Surface area

| File | Change |
|---|---|
| `server/src/db/identity-db.ts` | New: `promoteSecondaryIfPrimaryDeleted` helper |
| `server/src/routes/workos-webhooks.ts` | Wire helper + `invalidateSessionsForUsers` into `user.deleted` |
| `server/tests/integration/workos-user-deleted-primary.test.ts` | Integration: real-DB exercise of helper |
| `server/tests/unit/workos-webhook-user-deleted-wiring.test.ts` | Static-analysis: handler wiring + error-containment assertions |
| `.changeset/3718-workos-user-deleted-primary.md` | Patch, security |

~415 lines total (within scope guard).

## Test plan

- [x] Integration: `vitest run server/tests/integration/workos-user-deleted-primary.test.ts` — 4/4 pass
  - Asserts longest-bound secondary becomes primary, partial unique index holds (exactly one primary)
  - Asserts null + no-op when identity has no secondaries (single-credential normal-deletion path)
  - Asserts null + no-op when deleted user is not primary
  - Asserts CASCADE removes the (now non-primary) binding after promotion
- [x] Unit (static analysis): `vitest run server/tests/unit/workos-webhook-user-deleted-wiring.test.ts` — 6/6 pass
  - `promoteSecondaryIfPrimaryDeleted` is called BEFORE `deleteUser` in the switch case
  - `invalidateSessionsForUsers` is called in the case body
  - Helper catches DB errors + returns null (no thrown error escapes to outer 500)
  - Helper emits `logger.warn` and `notifySystemError` on failure
- [x] `npx tsc --noEmit -p server/tsconfig.json` — no new errors in touched files
- [x] No regression on `identity-layer.test.ts` (7/7 pass) or `workos-webhook-email-refresh.test.ts` (2/2 pass)

## Out of scope

- Re-keying app-state FKs from the deleted user to the new primary — the `attachIdentityId` indirection already handles this routing.
- Changing `deleteMembership` — just reused its `findSuccessorForPromotion` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)