### PR TITLE
docs(governance): policy attribution pattern (closes #2303)

### DIFF
--- a/.changeset/2303-policy-attribution-pattern.md
+++ b/.changeset/2303-policy-attribution-pattern.md
@@ -13,6 +13,15 @@ Adds [`docs/governance/policy-attribution.mdx`](https://docs.adcontextprotocol.o
 - Worked examples for UK HFSS (buyer-encoded threshold), US COPPA (delegated to seller's `registry:` feature), and creative measurement attribution.
 - Explicit non-scope: audience-selector and targeting overlays do NOT carry `policy_id` — those should be derived from plan-level declarations, not hand-authored with policy authority.
 
-Tightens the `policy_id` descriptions on both schemas to point at the new doc page and replace the placeholder "see issue #2303" references. No structural schema changes; the field was already reserved with `additionalProperties: false` permitting populated values in 3.1+.
+Tightens the `policy_id` descriptions across the four surfaces that carry the field to point at the new doc and replace placeholder cross-references:
+
+- `core/feature-requirement.json` — buyer-authored threshold attribution
+- `creative/creative-feature-result.json` — measurement attribution
+- `property/validation-result.json` `features[].policy_id` — validation-result attribution (normalized to drop the registry-only `x-entity` since the same PolicyEntry-resolution logic applies as on the other two)
+- `governance/check-governance-response.json` `findings[].policy_id` — adds the SHOULD-echo / MUST-NOT-invent contract so finding emitters see the rule from the schema side, not only from the doc
+
+Back-links added from `docs/governance/policy-registry.mdx` (after the `registry:` prefix section) and `docs/governance/campaign/specification.mdx` (after the finding `policy_id` paragraph) so readers landing on existing pages find the attribution pattern.
+
+No structural schema changes. All four `policy_id` fields existed before this PR; this is description-only normalization.
 
 Closes #2303. Related: #4629 (3.2 RFC on top-down `applicable_policies` from buyer to seller — complementary direction).

--- a/.changeset/2303-policy-attribution-pattern.md
+++ b/.changeset/2303-policy-attribution-pattern.md
@@ -1,0 +1,18 @@
+---
+---
+
+docs(governance): policy attribution pattern + tighten reserved-field descriptions
+
+The `policy_id` field on `core/feature-requirement.json` and `creative/creative-feature-result.json` was reserved in 3.0 with placeholder descriptions ("populated by producers in 3.1, see issue #2303"). 3.1 formalizes the contract.
+
+Adds [`docs/governance/policy-attribution.mdx`](https://docs.adcontextprotocol.org/docs/governance/policy-attribution) documenting:
+
+- The split between **plan-level `policy_ids[]`** (declares applicability to the buyer's governance agent) and **filter-level `policy_id`** (declares authorship of a specific mechanism-level threshold or measurement).
+- When producers SHOULD vs SHOULD NOT populate `policy_id` — only when the mechanism exists because of a specific authorizing policy, not when a policy merely applies.
+- The round-trip via governance findings: buyer authors `feature_requirements[i].policy_id` → sales agent calls `check_governance` → buyer's governance agent emits a finding echoing the same `policy_id` → audit trail closes the loop.
+- Worked examples for UK HFSS (buyer-encoded threshold), US COPPA (delegated to seller's `registry:` feature), and creative measurement attribution.
+- Explicit non-scope: audience-selector and targeting overlays do NOT carry `policy_id` — those should be derived from plan-level declarations, not hand-authored with policy authority.
+
+Tightens the `policy_id` descriptions on both schemas to point at the new doc page and replace the placeholder "see issue #2303" references. No structural schema changes; the field was already reserved with `additionalProperties: false` permitting populated values in 3.1+.
+
+Closes #2303. Related: #4629 (3.2 RFC on top-down `applicable_policies` from buyer to seller — complementary direction).

--- a/docs.json
+++ b/docs.json
@@ -372,6 +372,7 @@
                       "docs/governance/embedded-human-judgment",
                       "docs/governance/policy-registry",
                       "docs/governance/policy-registry-sync",
+                      "docs/governance/policy-attribution",
                       "docs/governance/annex-iii-obligations",
                       "docs/governance/working-group-charter",
                       {
@@ -952,6 +953,7 @@
                   "docs/governance/embedded-human-judgment",
                   "docs/governance/policy-registry",
                   "docs/governance/policy-registry-sync",
+                  "docs/governance/policy-attribution",
                   "docs/governance/working-group-charter",
                   {
                     "group": "Property Governance",

--- a/docs/governance/campaign/specification.mdx
+++ b/docs/governance/campaign/specification.mdx
@@ -997,6 +997,8 @@ Buyers that need internal specialist review (legal, brand safety, category) comp
 
 Internal decomposition is auditable through `check-governance-response.findings[]`. Each finding carries `category_id` (the agent-internal taxonomy — pharma MLR, brand safety, legal compliance, whichever specialism flagged it) and `policy_id` (the specific policy that triggered the finding). Buyers and sellers see one consolidated decision; per-finding attribution lets readers trace which specialist within the governance agent contributed to a denial or condition without surfacing the split as separate protocol-level agents.
 
+When the violation traces to a producer-tagged surface — a `feature_requirements[i].policy_id` the buyer authored, a `creative-feature-result.policy_id` the creative agent recorded, or a `validation-result.features[i].policy_id` a property-list agent emitted — the governance agent echoes that `policy_id` on the finding for end-to-end traceability. See [Policy Attribution](/docs/governance/policy-attribution) for the producer contract.
+
 Related specialist reviews that sit adjacent to (not inside) campaign governance — brand-safety pre-screen of creatives, property-list policy, content-standards evaluation — are separate governance surfaces with their own agents and their own lifecycle (see [`build_creative`](/docs/creative/task-reference/build_creative), property governance, content-standards governance). Campaign governance speaks only for the plan.
 
 ### Governance checks and the governance loop

--- a/docs/governance/policy-attribution.mdx
+++ b/docs/governance/policy-attribution.mdx
@@ -9,14 +9,15 @@ When a buyer caps audience children-composition at 15%, the threshold itself doe
 
 Policy attribution closes that gap. Producers tag mechanism-level filters and measurements with `policy_id` to record the authorizing policy. Governance findings echo the same `policy_id` when emitting denials, so the trace runs end-to-end.
 
-## Two surfaces, one pattern
+## Three surfaces, one pattern
 
 | Surface | Producer | Use |
 |---|---|---|
 | [`core/feature-requirement.json`](https://adcontextprotocol.org/schemas/v3/core/feature-requirement.json) | Buyer (or buyer's compliance tooling) | Tag a buyer-authored threshold predicate with the policy that authorized it |
 | [`creative/creative-feature-result.json`](https://adcontextprotocol.org/schemas/v3/creative/creative-feature-result.json) | Creative agent / seller | Tag a measurement record with the policy that motivated the evaluation |
+| [`property/validation-result.json`](https://adcontextprotocol.org/schemas/v3/property/validation-result.json) `features[].policy_id` | Property-list agent | Tag a per-feature validation result with the policy that triggered the check |
 
-Both fields are optional. Both have been reserved in the 3.0 schemas since GA — populating them in 3.1 is non-breaking for strict 3.0 validators.
+All three fields are optional. The first two were reserved in 3.0 GA; populating them in 3.1 is non-breaking for strict 3.0 validators. The third has been present on validation-result since 3.0.
 
 ## When to populate `policy_id`
 
@@ -38,7 +39,7 @@ Only the third row carries filter-level `policy_id`. The first two rows already 
 
 ## Round-trip via governance findings
 
-The attribution loop runs filter → governance agent → finding → audit:
+The attribution loop runs filter → governance agent → finding → audit. The agent acting on the buyer's plan calls `check_governance`; depending on `phase`, this is either an **intent check** (orchestrator-side, before commitment) or an **execution check** (seller-side, before binding planned delivery). Both paths produce findings with the same shape.
 
 ```
 Buyer's property list (stored at the property-list agent)
@@ -47,11 +48,13 @@ Buyer's property list (stored at the property-list agent)
       max_value: 15
       policy_id: uk_hfss        ← authored here
                 │
-                │ Sales agent resolves the property list, sees policy_id as pass-through metadata
+                │ Acting agent resolves the property list, sees policy_id as pass-through metadata
                 ▼
-Sales agent's planned delivery violates the requirement
+Planned action would violate the requirement
                 │
-                │ check_governance(plan_id, planned_delivery, governance_context)
+                │ check_governance(plan_id, payload | planned_delivery, governance_context)
+                │   - orchestrator on intent check (tool + payload)
+                │   - seller on execution check (planned_delivery)
                 ▼
 Buyer's Governance agent emits a finding:
   findings:
@@ -64,7 +67,7 @@ Buyer's Governance agent emits a finding:
 Audit: "why was this denied?" → uk_hfss → grep buyer's filters → find the originating requirement.
 ```
 
-The sales agent is a transit point — it does not produce findings. The buyer's governance agent is the producer, and it has direct access to the buyer's filters (same trust boundary), so it can populate `policy_id` on findings by reading the underlying requirement.
+The acting agent (orchestrator or seller, depending on phase) is a transit point — it does not produce findings. The buyer's governance agent is the producer, and it has direct access to the buyer's filters (same trust boundary), so it can populate `policy_id` on findings by reading the underlying requirement.
 
 ## Contract for producers
 
@@ -103,7 +106,7 @@ If a different team later asks "why 15? why not 20?", the policy_id points at th
 
 ### COPPA — delegated to the seller's registry feature
 
-The buyer doesn't pick a threshold for COPPA — they delegate the evaluation entirely. The `registry:` feature convention does this without needing `policy_id`:
+The buyer doesn't pick a threshold for COPPA — they delegate the evaluation entirely. The `registry:` prefix is a feature-naming convention (see [`property-feature-definition`](https://adcontextprotocol.org/schemas/v3/property/property-feature-definition.json) and [Policy Registry](/docs/governance/policy-registry#feature-prefix-convention)) where the feature ID `registry:<policy_id>` references a standardized policy directly:
 
 ```json
 {
@@ -133,6 +136,19 @@ A creative agent evaluates a creative for HFSS compliance and records:
 ```
 
 The `policy_id` answers "why did this evaluation run?" Anyone reviewing the creative's measurement history can correlate this result with the originating policy.
+
+When this result fails the creative-level governance check, the governance agent's finding echoes the same `policy_id`:
+
+```json
+{
+  "category_id": "regulatory_compliance",
+  "policy_id": "uk_hfss",
+  "severity": "block",
+  "explanation": "Creative failed UK HFSS compliance evaluation."
+}
+```
+
+The buyer can correlate the finding back to the originating measurement by matching `policy_id` across both records.
 
 ## What attribution does not cover
 

--- a/docs/governance/policy-attribution.mdx
+++ b/docs/governance/policy-attribution.mdx
@@ -1,0 +1,147 @@
+---
+title: Policy Attribution
+description: "How producers tag mechanism-level filters and measurements with the authorizing policy, so audit trails and governance findings can trace back to why a specific threshold or evaluation exists."
+"og:title": "AdCP — Policy Attribution"
+sidebarTitle: Policy Attribution
+---
+
+When a buyer caps audience children-composition at 15%, the threshold itself doesn't explain why. The number is mechanical; the *reason* (UK HFSS) lives elsewhere. Without attribution, an auditor reading a property list six months later can't answer "why does this list exclude high-children-composition properties?" without human interpretation.
+
+Policy attribution closes that gap. Producers tag mechanism-level filters and measurements with `policy_id` to record the authorizing policy. Governance findings echo the same `policy_id` when emitting denials, so the trace runs end-to-end.
+
+## Two surfaces, one pattern
+
+| Surface | Producer | Use |
+|---|---|---|
+| [`core/feature-requirement.json`](https://adcontextprotocol.org/schemas/v3/core/feature-requirement.json) | Buyer (or buyer's compliance tooling) | Tag a buyer-authored threshold predicate with the policy that authorized it |
+| [`creative/creative-feature-result.json`](https://adcontextprotocol.org/schemas/v3/creative/creative-feature-result.json) | Creative agent / seller | Tag a measurement record with the policy that motivated the evaluation |
+
+Both fields are optional. Both have been reserved in the 3.0 schemas since GA — populating them in 3.1 is non-breaking for strict 3.0 validators.
+
+## When to populate `policy_id`
+
+Populate `policy_id` when **the filter or measurement exists because of a specific authorizing policy** — and the producer chose the specific mechanism as their encoding of that policy.
+
+Do **not** populate `policy_id` when the policy merely applies in general. Plan-level policy applicability is declared on the plan itself via `policy_ids[]` (sent to the buyer's governance agent through `sync_plans`). The filter-level field is for mechanism authorship, not blanket applicability.
+
+### Plan-level vs filter-level
+
+These are different jobs:
+
+| Buyer says | Where it lives | Who picks the mechanism |
+|---|---|---|
+| "Apply COPPA — governance figures out who qualifies" | `plan.policy_ids: ["us_coppa"]` | Buyer's governance agent |
+| "Compliance with COPPA means: require properties to attest to it" | `feature_requirements: [{feature_id: "registry:us_coppa", value: true}]` | Buyer, delegating measurement to the seller's `registry:` feature |
+| "I'm encoding HFSS as ≤15% children composition" | `feature_requirements: [{feature_id: "audience_children_composition", max_value: 15, policy_id: "uk_hfss"}]` | Buyer, picking the threshold themselves |
+
+Only the third row carries filter-level `policy_id`. The first two rows already capture intent at higher abstraction levels — the registry feature ID is itself the policy reference in the second case.
+
+## Round-trip via governance findings
+
+The attribution loop runs filter → governance agent → finding → audit:
+
+```
+Buyer's property list (stored at the property-list agent)
+  feature_requirements:
+    - feature_id: audience_children_composition
+      max_value: 15
+      policy_id: uk_hfss        ← authored here
+                │
+                │ Sales agent resolves the property list, sees policy_id as pass-through metadata
+                ▼
+Sales agent's planned delivery violates the requirement
+                │
+                │ check_governance(plan_id, planned_delivery, governance_context)
+                ▼
+Buyer's Governance agent emits a finding:
+  findings:
+    - category_id: regulatory_compliance
+      policy_id: uk_hfss        ← echoed from the originating requirement
+      severity: block
+      explanation: "Planned targeting exceeds the 15% children-composition cap."
+                │
+                ▼
+Audit: "why was this denied?" → uk_hfss → grep buyer's filters → find the originating requirement.
+```
+
+The sales agent is a transit point — it does not produce findings. The buyer's governance agent is the producer, and it has direct access to the buyer's filters (same trust boundary), so it can populate `policy_id` on findings by reading the underlying requirement.
+
+## Contract for producers
+
+**Buyer (or buyer's compliance tooling) authoring `feature-requirement`:**
+- SHOULD populate `policy_id` when the requirement encodes a specific policy threshold the buyer chose.
+- SHOULD NOT populate `policy_id` when the requirement is a general feature filter unrelated to any policy.
+- MUST reference a `policy_id` that resolves either in the policy registry or in the plan's `custom_policies[]`.
+
+**Creative agent or seller authoring `creative-feature-result`:**
+- SHOULD populate `policy_id` when the feature was measured for the purpose of a specific policy evaluation.
+- SHOULD NOT populate `policy_id` when the feature is a generic measurement (carbon score, brand consistency) unrelated to any policy.
+
+**Governance agent emitting findings:**
+- SHOULD echo `policy_id` on findings when the underlying violation traces to a filter or measurement carrying `policy_id`.
+- MUST NOT invent a `policy_id` that wasn't present on the originating filter — finding `policy_id` is for traceability, not for declaring new policy applicability (that belongs in `policies_evaluated[]`).
+
+## Worked examples
+
+### UK HFSS — buyer-encoded threshold
+
+The buyer's compliance team interprets UK HFSS as "audience must be less than 15% children." They encode that interpretation as a feature requirement:
+
+```json
+{
+  "feature_requirements": [
+    {
+      "feature_id": "audience_children_composition",
+      "max_value": 15,
+      "policy_id": "uk_hfss"
+    }
+  ]
+}
+```
+
+If a different team later asks "why 15? why not 20?", the policy_id points at the registry entry for UK HFSS, where the rationale and exemplars live.
+
+### COPPA — delegated to the seller's registry feature
+
+The buyer doesn't pick a threshold for COPPA — they delegate the evaluation entirely. The `registry:` feature convention does this without needing `policy_id`:
+
+```json
+{
+  "feature_requirements": [
+    {
+      "feature_id": "registry:us_coppa",
+      "value": true
+    }
+  ]
+}
+```
+
+The feature ID *is* the policy reference. Adding `policy_id: "us_coppa"` here would be redundant — and would imply the buyer authored the mechanism, when in fact they delegated it.
+
+### Creative measurement — agent records the why
+
+A creative agent evaluates a creative for HFSS compliance and records:
+
+```json
+{
+  "feature_id": "uk_hfss_compliance",
+  "value": false,
+  "policy_id": "uk_hfss",
+  "methodology_version": "v2.1",
+  "measured_at": "2026-05-17T14:00:00Z"
+}
+```
+
+The `policy_id` answers "why did this evaluation run?" Anyone reviewing the creative's measurement history can correlate this result with the originating policy.
+
+## What attribution does not cover
+
+- **Top-down policy declaration from buyer to seller.** When the buyer wants the seller to apply specialized handling for a policy (HIPAA vendor, COPPA dataset) without the buyer encoding the mechanism, that's a separate surface tracked in [#4629](https://github.com/adcontextprotocol/adcp/issues/4629).
+- **Per-criterion attribution on audience selectors.** Audience exclusions in a plan should be derived from plan-level `policy_ids[]` by the buyer's governance agent — not hand-authored by buyers and tagged with policy authority. Audience-selector schemas do not carry `policy_id`.
+- **Per-criterion attribution on the targeting overlay.** Targeting fields (`geo_countries_exclude`, age restrictions, device platforms) use flat arrays without a per-entry shape; per-criterion attribution would require schema restructuring. Use plan-level declaration for these constraints.
+
+## See also
+
+- [Policy Registry](/docs/governance/policy-registry) — the shared library of `policy_id`s
+- [Policy Registry Sync](/docs/governance/policy-registry-sync) — how plans reference policies via `policy_ids[]` and `custom_policies[]`
+- [`check_governance`](/docs/governance/campaign/tasks/check_governance) — where findings are emitted with `policy_id` traceability

--- a/docs/governance/policy-registry.mdx
+++ b/docs/governance/policy-registry.mdx
@@ -162,9 +162,15 @@ Filter by domain via the API: `GET /api/policies/registry?domain=creative`
 
 ## The `registry:` prefix
 
+<a id="feature-prefix-convention"></a>
+
 Governance agents declare standardized capabilities using `registry:` prefixed feature IDs. This creates a shared vocabulary so buyers searching for "EU AI Act compliance" find agents using the same terminology.
 
 **Convention:** `registry:{policy_id}` maps a feature ID to a registry policy. Unprefixed feature IDs are agent-defined.
+
+<Note>
+The `registry:` convention is the **delegated** form of policy reference — buyer asks the seller's governance agent to evaluate the policy as a binary feature. The complementary **attribution** pattern, where producers tag mechanism-level filters and measurements with `policy_id` to record buyer-chosen thresholds and motivated evaluations, lives at [Policy Attribution](/docs/governance/policy-attribution).
+</Note>
 
 **Property governance agent declares:**
 ```json

--- a/static/schemas/source/core/feature-requirement.json
+++ b/static/schemas/source/core/feature-requirement.json
@@ -31,7 +31,7 @@
     },
     "policy_id": {
       "type": "string",
-      "description": "Optional attribution — when this requirement exists to satisfy a specific policy, policy_id references the authorizing PolicyEntry. Reserved field; populated by producers in 3.1 and later (see issue #2303). Governance agents MAY ignore in 3.0.",
+      "description": "Optional attribution — when this requirement encodes a specific buyer-chosen threshold authorized by a policy, policy_id references the authorizing PolicyEntry. Producers populate when the mechanism exists because of a specific policy (e.g., max_value: 15 on audience_children_composition because of uk_hfss); do NOT populate when the requirement is a general filter unrelated to any policy. Governance findings echo this policy_id when emitting denials traced to the requirement. See /docs/governance/policy-attribution.",
       "$comment": "x-entity deliberately omitted — a PolicyEntry reference can resolve to either a governance_registry_policy or a governance_inline_policy depending on the authorizing entry's source. See issue #2685."
     }
   },

--- a/static/schemas/source/creative/creative-feature-result.json
+++ b/static/schemas/source/creative/creative-feature-result.json
@@ -48,7 +48,7 @@
     },
     "policy_id": {
       "type": "string",
-      "description": "Optional attribution — when this feature was evaluated to satisfy a specific policy, policy_id references the authorizing PolicyEntry. Reserved field; populated by producers in 3.1 and later (see issue #2303). Governance agents MAY ignore in 3.0.",
+      "description": "Optional attribution — when this feature was evaluated for the purpose of a specific policy, policy_id references the authorizing PolicyEntry. Creative agents and sellers populate when the measurement was motivated by a specific policy; do NOT populate when the feature is a generic measurement (carbon score, brand consistency) unrelated to any policy. See /docs/governance/policy-attribution.",
       "$comment": "x-entity deliberately omitted — a PolicyEntry reference can resolve to either a governance_registry_policy or a governance_inline_policy depending on the authorizing entry's source. See issue #2685."
     },
     "ext": {

--- a/static/schemas/source/governance/check-governance-response.json
+++ b/static/schemas/source/governance/check-governance-response.json
@@ -104,7 +104,7 @@
           },
           "policy_id": {
             "type": "string",
-            "description": "ID of the policy that triggered this finding. May reference a registry policy (with source: registry) or a bespoke inline policy (with source: inline). Bespoke policy_ids are unique within their authoring container; use source_plan_id when findings aggregate across multiple plans (e.g., portfolio evaluations).",
+            "description": "ID of the policy that triggered this finding. May reference a registry policy (with source: registry) or a bespoke inline policy (with source: inline). Bespoke policy_ids are unique within their authoring container; use source_plan_id when findings aggregate across multiple plans (e.g., portfolio evaluations). When the violation traces to a producer-tagged surface (feature-requirement, creative-feature-result, or validation-result feature) carrying policy_id, governance agents SHOULD echo that policy_id here for end-to-end traceability, and MUST NOT invent a policy_id that wasn't present on the originating surface. See /docs/governance/policy-attribution.",
             "$comment": "x-entity deliberately omitted — a finding's policy_id can reference EITHER a governance_registry_policy or a governance_inline_policy depending on which policy matched. Resolution requires a sibling source discriminator the lint can't see from this leaf. Storyboards that capture from findings must re-annotate at the consume site (see #2685 for the registry/inline split)."
           },
           "source_plan_id": {

--- a/static/schemas/source/property/validation-result.json
+++ b/static/schemas/source/property/validation-result.json
@@ -38,8 +38,8 @@
           },
           "policy_id": {
             "type": "string",
-            "description": "Registry policy ID that triggered this result. Enables programmatic routing by looking up the policy in the registry.",
-            "x-entity": "governance_registry_policy"
+            "description": "Optional attribution — when this feature was evaluated for the purpose of a specific policy, policy_id references the authorizing PolicyEntry. Property-list agents populate when the validation was motivated by a specific policy. See /docs/governance/policy-attribution.",
+            "$comment": "x-entity deliberately omitted — a PolicyEntry reference can resolve to either a governance_registry_policy or a governance_inline_policy depending on the authorizing entry's source. See issue #2685."
           },
           "explanation": {
             "type": "string",


### PR DESCRIPTION
## Summary

- Formalizes the bottom-up `policy_id` contract on `core/feature-requirement.json` and `creative/creative-feature-result.json` (both reserved in 3.0; 3.1 now defines the producer semantics).
- Adds `docs/governance/policy-attribution.mdx` documenting plan-level vs filter-level attribution, the round-trip via governance findings, and worked HFSS/COPPA examples.
- Tightens reserved-field descriptions to point at the new doc and drop the "see issue #2303" placeholders. No structural schema changes.

## Background

#2303 originally proposed adding `policy_id` to several mechanism-level schemas. The reservation work shipped in 3.0 (feature-requirement, creative-feature-result). After scoping discussion (see issue thread), the 3.1 work narrows to:

- A doc page explaining the pattern producers should follow
- Cleanup of placeholder field descriptions
- Explicit non-scope: `audience-selector` and `targeting` overlay do NOT get `policy_id` — those constraints derive from plan-level `policy_ids[]`, not hand-authored filter authorship

The complementary top-down direction (buyer declares applicable policies to seller for specialized handling) is filed as #4629 in the 3.2 milestone.

## Test plan

- [x] `npm run build:schemas` — clean
- [x] `npm run test:schemas` — 7/7
- [x] `npm run test:docs-nav` — 15/15
- [ ] Reviewer: read the new doc page; confirm the SHOULD/SHOULD NOT producer contract reads correctly
- [ ] Reviewer: confirm the round-trip diagram (filter → check_governance → finding) matches actual governance flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)