### PR TITLE
docs(nav): group transparency pages under Trust & Security

### DIFF
--- a/.changeset/docs-trust-security-nav-group.md
+++ b/.changeset/docs-trust-security-nav-group.md
@@ -1,0 +1,4 @@
+---
+---
+
+Docs nav: group transparency pages under Trust & Security. AI Disclosure was sitting at the top level of the sidebar as a peer of Reference and Certification — structurally heavier than its content warranted, and odd next to Privacy Considerations which lived buried inside Reference. Created a Trust & Security group fronted by the existing `docs/trust.mdx` overview, and pulled AI Disclosure, Privacy Considerations, and Known Limitations into it. Applied to both 3.0 and latest navs.

--- a/docs.json
+++ b/docs.json
@@ -558,8 +558,16 @@
                 ]
               },
               "docs/faq",
-              "docs/ai-disclosure",
-              "docs/trust",
+              {
+                "group": "Trust & Security",
+                "expanded": false,
+                "pages": [
+                  "docs/trust",
+                  "docs/ai-disclosure",
+                  "docs/reference/privacy-considerations",
+                  "docs/reference/known-limitations"
+                ]
+              },
               {
                 "group": "Reference",
                 "expanded": false,
@@ -588,8 +596,6 @@
                   "docs/reference/experimental-status",
                   "docs/reference/schema-extensions",
                   "docs/reference/v2-sunset",
-                  "docs/reference/known-limitations",
-                  "docs/reference/privacy-considerations",
                   "docs/reference/release-notes",
                   "docs/reference/changelog",
                   "docs/reference/implementor-faq",
@@ -1115,9 +1121,17 @@
           {
             "group": "FAQ",
             "pages": [
-              "docs/faq",
+              "docs/faq"
+            ]
+          },
+          {
+            "group": "Trust & Security",
+            "expanded": false,
+            "pages": [
+              "docs/trust",
               "docs/ai-disclosure",
-              "docs/trust"
+              "docs/reference/privacy-considerations",
+              "docs/reference/known-limitations"
             ]
           },
           {
@@ -1143,8 +1157,6 @@
               "docs/reference/versioning",
               "docs/reference/url-canonicalization",
               "docs/reference/verifying-protocol-tarballs",
-              "docs/reference/known-limitations",
-              "docs/reference/privacy-considerations",
               "docs/reference/experimental-status",
               "docs/reference/schema-extensions",
               "docs/reference/release-notes",


### PR DESCRIPTION
## Summary

- AI Disclosure was sitting at the top level of the sidebar as a peer of Reference and Certification — structurally heavier than its content warranted, and odd next to Privacy Considerations which lived buried inside Reference.
- Create a **Trust & Security** group fronted by the existing `docs/trust.mdx` overview (which already reads as a hub page across governance / regulatory / privacy / identity surfaces). Pull AI Disclosure, Privacy Considerations, and Known Limitations into it.
- Applied to both 3.0 and latest navs. `docs/faq` stays as a loose top-level page — it's intentionally prominent as a routing entry point.

## What's NOT changing

- `docs/trust.mdx` title stays "Trust & Security" — that's the term CISOs and procurement actually search for.
- `Community` (working-group, joining-slack) stays inside Reference — these are builder-oriented and referenced from many places.
- "AdCP 3.0" migration sub-group stays prominently inside *Building with AdCP* — most v2.5 implementors are mid-migration. Revisit when 3.1 ships.

## Test plan

- [ ] Mintlify preview renders the new Trust & Security group on the 3.0 nav
- [ ] Privacy Considerations and Known Limitations no longer appear in Reference
- [ ] Footer's "AI Disclosure" link (`/docs/ai-disclosure`) still resolves
- [ ] Latest nav: FAQ group only contains `docs/faq`; new Trust & Security group sits below it

🤖 Generated with [Claude Code](https://claude.com/claude-code)