### PR TITLE
chore(brand-protocol): register verify_brand_claim + verify_brand_claims in schema index (#4604)

### DIFF
--- a/.changeset/register-verify-brand-claim-in-index.md
+++ b/.changeset/register-verify-brand-claim-in-index.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Register `verify_brand_claim`, `verify_brand_claims` (bulk), and the shared `verification-status.json` enum in `static/schemas/source/index.json`. The tools and schemas shipped in PRs #4540 and #4603 but the central schema registry was missed — this restores parity with `get_brand_identity`, `get_rights`, etc., for any consumer that reads the registry for discovery (closes #4604).

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -1579,6 +1579,10 @@
         "revocation-notification": {
           "$ref": "/schemas/brand/revocation-notification.json",
           "description": "Notification sent to the buyer's revocation_webhook when an acquired rights grant is revoked"
+        },
+        "verification-status": {
+          "$ref": "/schemas/brand/verification-status.json",
+          "description": "Shared status enum returned by verify_brand_claim — owned, pending_review, transferring, disputed, not_ours, archived, licensed_in, licensed_out, unknown"
         }
       },
       "tasks": {
@@ -1590,6 +1594,26 @@
           "response": {
             "$ref": "/schemas/brand/get-brand-identity-response.json",
             "description": "Response payload for get_brand_identity task"
+          }
+        },
+        "verify-brand-claim": {
+          "request": {
+            "$ref": "/schemas/brand/verify-brand-claim-request.json",
+            "description": "Request parameters for verifying a single brand claim (subsidiary / parent / property / trademark, discriminated by claim_type)"
+          },
+          "response": {
+            "$ref": "/schemas/brand/verify-brand-claim-response.json",
+            "description": "Response payload for verify_brand_claim task — claim_type echoed, status from the shared VerificationStatus enum, per-claim-type details"
+          }
+        },
+        "verify-brand-claims": {
+          "request": {
+            "$ref": "/schemas/brand/verify-brand-claims-request.json",
+            "description": "Request parameters for bulk verification — claims[] array (max 100), each entry shaped like a single verify_brand_claim request"
+          },
+          "response": {
+            "$ref": "/schemas/brand/verify-brand-claims-response.json",
+            "description": "Response payload for verify_brand_claims task — results[] positionally aligned with the request's claims[], per-result success or error inline"
           }
         },
         "get-rights": {


### PR DESCRIPTION
Closes #4604.

## What

Adds three entries to \`static/schemas/source/index.json\` under \`brand-protocol\`:

- \`verification-status\` (supporting-schemas) — the shared status enum used by both verify tools
- \`verify-brand-claim\` (tasks) — single-target verification, four claim types discriminated by \`claim_type\`
- \`verify-brand-claims\` (tasks) — bulk variant, claims[] array (max 100)

## Why

Both tools shipped — verify_brand_claim in PR #4540, verify_brand_claims in PR #4603 — but the central schema registry was missed. Missing entries mean the schemas are reachable by direct URL but invisible to registry-driven tooling and schema-validation tests.

This restores parity with \`get_brand_identity\`, \`get_rights\`, \`acquire_rights\`, \`update_rights\`.

## Validation

- \`npm run build:schemas\` clean
- \`npm run test:schemas\` 7/7 (was 5/7 + 2 failures before this PR — the two failures were registry-vs-actual-schemas drift exactly because index.json was missing these entries)
- \`npm run test:json-schema\` 260/260
- \`npm run typecheck\` clean