### PR TITLE
fix(audit-log): widen registry_audit_log.resource_id to TEXT (closes #4502)

### DIFF
--- a/.changeset/widen-audit-resource-id.md
+++ b/.changeset/widen-audit-resource-id.md
@@ -1,0 +1,4 @@
+---
+---
+
+Widen `registry_audit_log.resource_id` from `VARCHAR(255)` to `TEXT`. Several admin actions write resource identifiers (notably agent URLs) that can exceed 255 chars; overflow raised `22001` mid-transaction and rolled back the originating mutation. Closes #4502.

--- a/server/src/db/migrations/482_widen_registry_audit_log_resource_id.sql
+++ b/server/src/db/migrations/482_widen_registry_audit_log_resource_id.sql
@@ -1,0 +1,11 @@
+-- registry_audit_log.resource_id was declared VARCHAR(255) in 030_recreate_audit_log.sql.
+-- Several admin actions write resource identifiers that can exceed that cap —
+-- agent URLs with signed-CDN tokens or query strings routinely overflow.
+-- Overflow raises 22001 mid-transaction and rolls back the originating
+-- mutation (e.g. the admin agent removal added in #4498), with no signal to
+-- the caller that the cause was column width.
+--
+-- TEXT has identical storage characteristics for short values and no cap.
+-- No data conversion needed.
+
+ALTER TABLE registry_audit_log ALTER COLUMN resource_id TYPE TEXT;


### PR DESCRIPTION
## Summary

Widens `registry_audit_log.resource_id` from `VARCHAR(255)` to `TEXT`. Admin audit rows store resource identifiers including agent URLs, which with signed-CDN tokens or query strings can overflow the 255-char cap. Overflow raises `22001` mid-transaction and rolls back the originating mutation (e.g. the admin agent removal added in #4498) with no useful signal to the caller.

`TEXT` has identical storage characteristics to `VARCHAR` for short values, no cap, and no data conversion needed.

## Why

Surfaced by the testing review on #4498. The current rogue URL (Adzymic→Celtra, 35 chars) is safe today, but the structural cap will bite the next case.

## Test plan

- [x] Migration runs cleanly against `adcp_test` (verified via `runMigrations()` script)
- [x] `information_schema.columns` confirms post-migration shape: `data_type=text, character_maximum_length=null`
- [x] `tsc --project server/tsconfig.json --noEmit` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)