### PR TITLE
fix(training-agent): event_source validation + cost_per_acquisition for performance_buy_flow

### DIFF
--- a/.changeset/4642-training-agent-performance-buy-flow.md
+++ b/.changeset/4642-training-agent-performance-buy-flow.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": patch
+---
+
+fix(training-agent): validate event_source_id refs in create_media_buy + emit cost_per_acquisition in delivery
+
+The training agent's `handleCreateMediaBuy` now rejects event-kind optimization goals whose `event_source_id` references were never registered via `sync_event_sources` (INVALID_REQUEST with `error.field` pointing at the offending JSONPath). Without this, the new `media_buy_seller/performance_buy_flow` storyboard scenario (#4642) silently passes phantom ids, defeating the anti-façade check.
+
+`get_media_buy_delivery` totals now compute `cost_per_acquisition = spend / conversions` when both are positive, matching the delivery contract expected by the same scenario.

--- a/server/src/training-agent/catalog-event-handlers.ts
+++ b/server/src/training-agent/catalog-event-handlers.ts
@@ -126,12 +126,20 @@ function getEventSourceMap(sessionKey: string): Map<string, EventSourceState> {
  *  drop the `account` context the SDK's request-builder strips against the
  *  published tool schema. Fall back to a global search so a synced source
  *  is still reachable from any session within the sandbox. */
-function findEventSourceAnywhere(eventSourceId: string): EventSourceState | undefined {
+export function findEventSourceAnywhere(eventSourceId: string): EventSourceState | undefined {
   for (const map of eventSourceStore.values()) {
     const hit = map.get(eventSourceId);
     if (hit) return hit;
   }
   return undefined;
+}
+
+/** Look up an event source in a specific session, falling back to global scan.
+ *  Used by create_media_buy to validate that event-kind optimization_goals
+ *  reference a previously-registered event_source_id rather than silently
+ *  accepting phantom ids. */
+export function findEventSourceInSession(sessionKey: string, eventSourceId: string): EventSourceState | undefined {
+  return eventSourceStore.get(sessionKey)?.get(eventSourceId) ?? findEventSourceAnywhere(eventSourceId);
 }
 
 /** Exported for testing */

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -229,6 +229,7 @@ import {
   handleSyncEventSources,
   handleLogEvent,
   handleProvidePerformanceFeedback,
+  findEventSourceInSession,
 } from './catalog-event-handlers.js';
 import {
   COMPLY_TEST_CONTROLLER_TOOL,
@@ -1823,6 +1824,40 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
     }
   }
 
+  // Validate event-kind optimization_goals reference a previously-registered
+  // event_source_id. Silent acceptance of phantom ids is a façade — the
+  // seller cannot optimize against a source it doesn't know about. The
+  // performance_buy_flow storyboard asserts this rejection with an error
+  // .field set to the offending JSONPath-lite path.
+  const sessionKeyForEventSources = sessionKeyFromArgs(req, ctx.mode, ctx.userId, ctx.moduleId);
+  if (Array.isArray(req.packages)) {
+    for (let i = 0; i < req.packages.length; i++) {
+      const pkg = req.packages[i] as { optimization_goals?: unknown };
+      const goals = pkg?.optimization_goals;
+      if (!Array.isArray(goals)) continue;
+      for (let j = 0; j < goals.length; j++) {
+        const goal = goals[j] as { kind?: string; event_sources?: unknown };
+        if (goal?.kind !== 'event') continue;
+        const eventSources = goal.event_sources;
+        if (!Array.isArray(eventSources)) continue;
+        for (let k = 0; k < eventSources.length; k++) {
+          const entry = eventSources[k] as { event_source_id?: string };
+          const id = entry?.event_source_id;
+          if (typeof id !== 'string' || id.length === 0) continue;
+          if (!findEventSourceInSession(sessionKeyForEventSources, id)) {
+            return {
+              errors: [{
+                code: 'INVALID_REQUEST',
+                message: `event_source_id "${id}" was not registered via sync_event_sources`,
+                field: `packages[${i}].optimization_goals[${j}].event_sources[${k}].event_source_id`,
+              }] as TaskError[],
+            };
+          }
+        }
+      }
+    }
+  }
+
   const catalog = getCatalog();
   const productMap = new Map(catalog.map(cp => [cp.product.product_id, cp.product]));
   overlaySeededProducts(session, productMap);
@@ -2402,6 +2437,20 @@ export async function handleGetMediaBuyDelivery(args: ToolArgs, ctx: TrainingCon
     totalSpend += simDelivery.reportedSpend.amount;
   }
 
+  // Conversion-attributed totals. Only surface when simulate_delivery
+  // injected conversion data — sellers that don't optimize toward events
+  // (pure brand/audience sellers) omit these fields entirely.
+  const totalConversions = simDelivery?.conversions ?? 0;
+  const roundedSpend = Math.round(totalSpend * 100) / 100;
+  const conversionTotals = totalConversions > 0 && roundedSpend > 0
+    ? {
+      conversions: totalConversions,
+      cost_per_acquisition: Math.round((roundedSpend / totalConversions) * 100) / 100,
+    }
+    : totalConversions > 0
+      ? { conversions: totalConversions }
+      : {};
+
   return {
     reporting_period: {
       start: mb.startTime,
@@ -2413,7 +2462,7 @@ export async function handleGetMediaBuyDelivery(args: ToolArgs, ctx: TrainingCon
       status: deriveStatus(mb),
       totals: {
         impressions: totalImpressions,
-        spend: Math.round(totalSpend * 100) / 100,
+        spend: roundedSpend,
         clicks: totalClicks,
         ...(totalCompletedViews > 0 ? {
           views: totalViews,
@@ -2425,6 +2474,7 @@ export async function handleGetMediaBuyDelivery(args: ToolArgs, ctx: TrainingCon
           reach_unit: totalReachUnit,
           frequency: +(totalImpressions / totalReach).toFixed(1),
         } : {}),
+        ...conversionTotals,
       },
       by_package: byPackage,
     }],

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -1677,6 +1677,76 @@ describe('create_media_buy handler', () => {
     // No creatives synced → pending_creatives regardless of dates
     expect(result.status).toBe('pending_creatives');
   });
+
+  it('rejects event-kind optimization_goal with unregistered event_source_id', async () => {
+    const { productId, pricingOptionId } = getFirstProductAndPricing();
+    const account = { brand: { domain: 'phantom-source.example' }, operator: 'phantom-source.example' };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    const { result } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'phantom-source.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 5000,
+        optimization_goals: [{
+          kind: 'event',
+          event_sources: [{
+            event_source_id: 'does_not_exist_phantom_source',
+            event_type: 'purchase',
+          }],
+          target: { kind: 'cost_per', value: 35 },
+        }],
+      }],
+    });
+
+    // simulateCallTool unwraps the first errors[] entry to the top level.
+    expect(result.code).toBe('INVALID_REQUEST');
+    expect(result.field).toBe('packages[0].optimization_goals[0].event_sources[0].event_source_id');
+    expect((result.message as string).includes('does_not_exist_phantom_source')).toBe(true);
+  });
+
+  it('accepts event-kind optimization_goal whose event_source_id was registered via sync_event_sources', async () => {
+    const { productId, pricingOptionId } = getFirstProductAndPricing();
+    const account = { brand: { domain: 'bound-source.example' }, operator: 'bound-source.example' };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    // Register the event source first
+    await simulateCallTool(server, 'sync_event_sources', {
+      account,
+      event_sources: [{
+        event_source_id: 'bound_website',
+        name: 'Bound Source',
+        event_types: ['purchase'],
+      }],
+    });
+
+    const { result } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'bound-source.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 5000,
+        optimization_goals: [{
+          kind: 'event',
+          event_sources: [{
+            event_source_id: 'bound_website',
+            event_type: 'purchase',
+          }],
+          target: { kind: 'cost_per', value: 35 },
+        }],
+      }],
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(typeof result.media_buy_id).toBe('string');
+  });
 });
 
 // ── sync_creatives handler ─────────────────────────────────────────
@@ -3629,6 +3699,82 @@ describe('get_media_buy_delivery handler', () => {
 
     expect(result.errors).toBeUndefined();
     expect(result.media_buy_deliveries).toBeDefined();
+  });
+
+  it('computes cost_per_acquisition when simulate_delivery injects conversions and spend', async () => {
+    const catalog = buildCatalog();
+    const product = catalog[0].product;
+    const pricingOptions = product.pricing_options as Array<Record<string, unknown>>;
+    const account = { brand: { domain: 'cpa-delivery.example' }, operator: 'cpa-delivery.example', sandbox: true };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    const { result: createResult } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'cpa-delivery.example' },
+      start_time: '2025-01-01T00:00:00Z',
+      end_time: '2025-12-31T00:00:00Z',
+      packages: [{
+        product_id: product.product_id,
+        pricing_option_id: pricingOptions[0].pricing_option_id,
+        budget: 50000,
+      }],
+    });
+    const mediaBuyId = createResult.media_buy_id as string;
+
+    // Inject impressions + conversions + reported_spend via the test controller.
+    await simulateCallTool(server, 'comply_test_controller', {
+      scenario: 'simulate_delivery',
+      params: {
+        media_buy_id: mediaBuyId,
+        impressions: 200000,
+        clicks: 4500,
+        conversions: 90,
+        reported_spend: { amount: 3000, currency: 'USD' },
+      },
+      account,
+      brand: { domain: 'cpa-delivery.example' },
+    });
+
+    const { result } = await simulateCallTool(server, 'get_media_buy_delivery', {
+      account,
+      media_buy_id: mediaBuyId,
+    });
+    const deliveries = result.media_buy_deliveries as Array<Record<string, unknown>>;
+    const totals = deliveries[0].totals as Record<string, number>;
+    expect(totals.conversions).toBe(90);
+    // spend includes scheduled spend (impressions × CPM rate ÷ 1000) plus the
+    // injected $3000; we assert CPA equals spend / conversions to that exact
+    // ratio rather than a fixed number.
+    expect(totals.cost_per_acquisition).toBeGreaterThan(0);
+    expect(totals.cost_per_acquisition).toBeCloseTo(totals.spend / totals.conversions, 2);
+  });
+
+  it('omits cost_per_acquisition when no conversions were injected', async () => {
+    const catalog = buildCatalog();
+    const product = catalog[0].product;
+    const pricingOptions = product.pricing_options as Array<Record<string, unknown>>;
+    const account = { brand: { domain: 'no-conversions.example' }, operator: 'no-conversions.example' };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    const { result: createResult } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'no-conversions.example' },
+      start_time: '2025-01-01T00:00:00Z',
+      end_time: '2025-12-31T00:00:00Z',
+      packages: [{
+        product_id: product.product_id,
+        pricing_option_id: pricingOptions[0].pricing_option_id,
+        budget: 50000,
+      }],
+    });
+
+    const { result } = await simulateCallTool(server, 'get_media_buy_delivery', {
+      account,
+      media_buy_id: createResult.media_buy_id,
+    });
+    const totals = ((result.media_buy_deliveries as Array<Record<string, unknown>>)[0].totals) as Record<string, unknown>;
+    expect(totals.cost_per_acquisition).toBeUndefined();
+    expect(totals.conversions).toBeUndefined();
   });
 
   it('returns delivery metrics for multi-package buy', async () => {


### PR DESCRIPTION
## Summary

Close the two gaps that prevent the `media_buy_seller/performance_buy_flow` storyboard scenario (#4642) from passing against the training agent. The training agent already advertises `media_buy.conversion_tracking`, so the scenario runs against it (not `not_applicable`) — without these fixes the new `rejection_unbound_event_source` and `attributed_delivery_reporting` phases fail.

- `handleCreateMediaBuy` validates `optimization_goals[].event_sources[].event_source_id` against the session's registered sources. Phantom ids reject with `INVALID_REQUEST` and `error.field` set to the literal JSONPath-lite shape `packages[i].optimization_goals[j].event_sources[k].event_source_id` the scenario asserts on. Silent acceptance would let a seller advertise `conversion_tracking` without being able to actually optimize against the event source the buyer thinks is bound — a façade.
- `get_media_buy_delivery` totals now emit `conversions` and `cost_per_acquisition = spend / conversions` when `simulate_delivery` injected both. Sellers that don't compute conversion metrics simply omit the fields (no conversions injected → no fields emitted).

Lookup uses a new exported helper `findEventSourceInSession(sessionKey, id)` (session-local lookup with global fallback) in `catalog-event-handlers.ts` — same fallback semantics that `log_event` already relies on so the test-controller seeding path stays consistent.

## Test plan

- [x] `npx vitest run server/tests/unit/training-agent.test.ts` — 372 tests pass, including three new assertions covering the rejection path, the success path against a registered source, and CPA emission/omission in delivery reporting.
- [x] `npx vitest run server/tests/unit/comply-test-controller.test.ts` — 42 tests pass; delivery simulation totals stay backwards-compatible for non-conversion buys.
- [x] `npx vitest run server/tests/unit/training-agent` (all 12 training-agent unit suites) — 503 tests pass.
- [x] `npm run build` — full schema build, compliance build, tarball build all clean.
- [x] Pre-commit hook (test:unit + typecheck + dynamic-imports) passed on commit.

## Refs

- Unblocks #4642 (the storyboard scenario PR; this lands first so #4642 can rebase onto a passing fixture).
- Implements seller-side behavior for the capability declared in #4569.
- Related: #4637.

## What is NOT in this PR

- No changes to `static/compliance/source/**` — the storyboard ships in #4642.
- No `by_creative[].conversions` per-creative attribution — that scenario assertion is being dropped from #4642.
- No new schema fields. Server-side behavior only on existing optimization-goal + delivery shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)