### PR TITLE
feat(compliance): audience_buy_flow + event_dedup_flow capability-gated scenarios (#4637)

### DIFF
--- a/.changeset/4637-audience-and-event-dedup-scenarios.md
+++ b/.changeset/4637-audience-and-event-dedup-scenarios.md
@@ -1,0 +1,15 @@
+---
+"adcontextprotocol": minor
+---
+
+feat(compliance): audience_buy_flow + event_dedup_flow capability-gated scenarios; training-agent audience_id validation
+
+Two new scenarios in the capability-claim contract pattern (#4637), both added to `sales-non-guaranteed.requires_scenarios`:
+
+- `media_buy_seller/audience_buy_flow` — gated on `media_buy.audience_targeting` presence. Certifies `sync_audiences` → bound `audience_id` in targeting → unbound id rejected → delivery against an audience-targeted buy. Sibling to `performance_buy_flow` on the audience side; the unbound-id rejection is the discriminating assertion.
+
+- `media_buy_seller/event_dedup_flow` — gated on `media_buy.conversion_tracking.multi_source_event_dedup` equals true. Certifies that the same `event_id` from two registered event sources attributes to one conversion, not two. Sellers without `multi_source_event_dedup` grade `not_applicable` — the bit gates the scenario; the cumulative-count check is the assertion.
+
+Training-agent fix: `create_media_buy` now rejects `targeting_overlay.audience_include` / `audience_exclude` entries whose `audience_id` was never registered via `sync_audiences`, with `INVALID_REQUEST` and `error.field` set to the literal JSONPath-lite path of the offending entry. Mirrors the `event_source_id` validation pattern from #4654. `sync_audiences` itself is now wired through the training agent (legacy `/mcp` and v6 `/sales/mcp` via `AudiencePlatform`) so adopters can run the audience scenario against the reference implementation.
+
+Three sibling product-level scenarios (reach, clicks, completed_views) remain blocked on #4651 product-level capability gating RFC.

--- a/server/src/training-agent/audience-handlers.ts
+++ b/server/src/training-agent/audience-handlers.ts
@@ -1,0 +1,255 @@
+/**
+ * Audience handlers for the training agent.
+ *
+ * Implements sync_audiences per AdCP schemas. Backed by an in-process
+ * per-session store so create_media_buy can verify audience_include /
+ * audience_exclude entries reference audiences the buyer registered.
+ *
+ * Mirrors the catalog-event-handlers.ts pattern (sync_event_sources +
+ * findEventSourceInSession) — the rejection contract for unregistered
+ * audience_ids is the audience-side sibling of the event-source contract
+ * asserted in performance_buy_flow (#4642 / #4654).
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { TrainingContext, ToolArgs } from './types.js';
+import { sessionKeyFromArgs } from './state.js';
+
+// ── Types ────────────────────────────────────────────────────────
+
+interface SyncAudiencesInput extends ToolArgs {
+  audiences?: AudienceInput[];
+  delete_missing?: boolean;
+  idempotency_key?: string;
+}
+
+interface AudienceMemberInput {
+  external_id?: string;
+  hashed_email?: string;
+  hashed_phone?: string;
+  uids?: { type: string; value: string }[];
+  [key: string]: unknown;
+}
+
+interface AudienceInput {
+  audience_id: string;
+  name?: string;
+  description?: string;
+  audience_type?: 'crm' | 'suppression' | 'lookalike_seed';
+  tags?: string[];
+  add?: AudienceMemberInput[];
+  remove?: AudienceMemberInput[];
+  delete?: boolean;
+  consent_basis?: string;
+}
+
+interface AudienceState {
+  audienceId: string;
+  name: string;
+  sellerId: string;
+  uploadedCount: number;
+  matchedCount: number;
+  status: 'processing' | 'ready' | 'too_small';
+  audienceType: string;
+  createdAt: string;
+  lastSyncedAt: string;
+}
+
+const audienceStore = new Map<string, Map<string, AudienceState>>();
+
+function getAudienceMap(sessionKey: string): Map<string, AudienceState> {
+  let map = audienceStore.get(sessionKey);
+  if (!map) {
+    map = new Map();
+    audienceStore.set(sessionKey, map);
+  }
+  return map;
+}
+
+/** Look up an audience across every session. Some routes (legacy /mcp vs
+ *  v6 /sales/mcp) carry slightly different session keys for the same buyer
+ *  brand; a global scan ensures a synced audience is still reachable from
+ *  create_media_buy regardless of which surface received the sync. */
+export function findAudienceAnywhere(audienceId: string): AudienceState | undefined {
+  for (const map of audienceStore.values()) {
+    const hit = map.get(audienceId);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
+/** Look up an audience in a specific session, falling back to global scan.
+ *  Used by create_media_buy to validate that targeting_overlay.audience_include
+ *  and audience_exclude entries reference audiences registered via sync_audiences,
+ *  rather than silently accepting phantom ids. */
+export function findAudienceInSession(sessionKey: string, audienceId: string): AudienceState | undefined {
+  return audienceStore.get(sessionKey)?.get(audienceId) ?? findAudienceAnywhere(audienceId);
+}
+
+/** Exported for testing */
+export function clearAudienceStore(): void {
+  audienceStore.clear();
+}
+
+// ── Shared schema fragment ───────────────────────────────────────
+
+const ACCOUNT_REF_SCHEMA = {
+  type: 'object',
+  oneOf: [
+    { properties: { account_id: { type: 'string' } }, required: ['account_id'] },
+    {
+      properties: {
+        brand: { type: 'object', properties: { domain: { type: 'string' } }, required: ['domain'] },
+        operator: { type: 'string' },
+        sandbox: { type: 'boolean' },
+      },
+      required: ['brand'],
+    },
+  ],
+};
+
+// ── Tool definition ─────────────────────────────────────────────
+
+export const AUDIENCE_TOOLS = [
+  {
+    name: 'sync_audiences',
+    description: 'Manage CRM-based audiences on an account with upsert semantics. Existing audiences matched by audience_id are updated, new ones are created. Members are specified as delta operations: add appends, remove drops. Omit audiences for discovery-only.',
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+    execution: { taskSupport: 'forbidden' as const },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        account: ACCOUNT_REF_SCHEMA,
+        audiences: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              audience_id: { type: 'string' },
+              name: { type: 'string' },
+              description: { type: 'string' },
+              audience_type: { type: 'string', enum: ['crm', 'suppression', 'lookalike_seed'] },
+              tags: { type: 'array', items: { type: 'string' } },
+              add: { type: 'array' },
+              remove: { type: 'array' },
+              delete: { type: 'boolean' },
+              consent_basis: { type: 'string' },
+            },
+            required: ['audience_id'],
+          },
+          minItems: 1,
+        },
+        delete_missing: { type: 'boolean' },
+        idempotency_key: { type: 'string' },
+      },
+      required: ['account', 'idempotency_key'],
+    },
+  },
+];
+
+// ── Handler implementation ──────────────────────────────────────
+
+export async function handleSyncAudiences(args: ToolArgs, ctx: TrainingContext) {
+  const req = args as unknown as SyncAudiencesInput;
+
+  if (!req.account) {
+    return {
+      errors: [{ code: 'INVALID_REQUEST', message: 'account is required' }],
+    };
+  }
+
+  const sessionKey = sessionKeyFromArgs(req, ctx.mode, ctx.userId, ctx.moduleId);
+  const audiences = getAudienceMap(sessionKey);
+  const now = new Date().toISOString();
+
+  // Discovery mode — return existing audiences without mutation.
+  if (!req.audiences) {
+    const existing = Array.from(audiences.values()).map(a => ({
+      audience_id: a.audienceId,
+      name: a.name,
+      seller_id: a.sellerId,
+      action: 'unchanged',
+      status: a.status,
+      uploaded_count: 0,
+      total_uploaded_count: a.uploadedCount,
+      matched_count: a.matchedCount,
+      ...(a.uploadedCount > 0 && {
+        effective_match_rate: a.matchedCount / a.uploadedCount,
+      }),
+      last_synced_at: a.lastSyncedAt,
+    }));
+    return { audiences: existing };
+  }
+
+  const results: Record<string, unknown>[] = [];
+
+  for (const input of req.audiences) {
+    if (!input.audience_id) {
+      results.push({
+        audience_id: 'unknown',
+        action: 'failed',
+        errors: [{ code: 'INVALID_REQUEST', message: 'audience_id is required' }],
+      });
+      continue;
+    }
+
+    const existing = audiences.get(input.audience_id);
+
+    if (input.delete === true) {
+      if (existing) audiences.delete(input.audience_id);
+      results.push({
+        audience_id: input.audience_id,
+        action: 'deleted',
+      });
+      continue;
+    }
+
+    const uploadedThisCall = input.add?.length ?? 0;
+    // Simulate ~70% match rate for testing.
+    const matchedThisCall = Math.floor(uploadedThisCall * 0.7);
+    const totalUploaded = (existing?.uploadedCount ?? 0) + uploadedThisCall;
+    const totalMatched = (existing?.matchedCount ?? 0) + matchedThisCall;
+    // Mirror sales-platform capabilities.audience_targeting.minimum_audience_size.
+    const minimumSize = 100;
+    const status: AudienceState['status'] = totalMatched === 0
+      ? 'processing'
+      : totalMatched < minimumSize ? 'too_small' : 'ready';
+
+    const state: AudienceState = {
+      audienceId: input.audience_id,
+      name: input.name ?? existing?.name ?? input.audience_id,
+      sellerId: existing?.sellerId ?? `aud_${randomUUID().slice(0, 8)}`,
+      uploadedCount: totalUploaded,
+      matchedCount: totalMatched,
+      status,
+      audienceType: input.audience_type ?? existing?.audienceType ?? 'crm',
+      createdAt: existing?.createdAt ?? now,
+      lastSyncedAt: now,
+    };
+
+    audiences.set(input.audience_id, state);
+
+    const result: Record<string, unknown> = {
+      audience_id: state.audienceId,
+      name: state.name,
+      seller_id: state.sellerId,
+      action: existing ? 'updated' : 'created',
+      status: state.status,
+      uploaded_count: uploadedThisCall,
+      total_uploaded_count: state.uploadedCount,
+      matched_count: state.matchedCount,
+      last_synced_at: state.lastSyncedAt,
+    };
+
+    if (state.uploadedCount > 0) {
+      result.effective_match_rate = state.matchedCount / state.uploadedCount;
+    }
+    if (state.status === 'too_small') {
+      result.minimum_size = minimumSize;
+    }
+
+    results.push(result);
+  }
+
+  return { audiences: results };
+}

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -232,6 +232,11 @@ import {
   findEventSourceInSession,
 } from './catalog-event-handlers.js';
 import {
+  AUDIENCE_TOOLS,
+  handleSyncAudiences,
+  findAudienceInSession,
+} from './audience-handlers.js';
+import {
   COMPLY_TEST_CONTROLLER_TOOL,
   handleComplyTestController,
   getDeliverySimulation,
@@ -1327,6 +1332,7 @@ const TOOLS = [
   },
   ...ACCOUNT_TOOLS,
   ...CATALOG_EVENT_TOOLS,
+  ...AUDIENCE_TOOLS,
   ...GOVERNANCE_TOOLS,
   ...PROPERTY_TOOLS,
   ...COLLECTION_LIST_TOOLS,
@@ -1850,6 +1856,40 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
                 code: 'INVALID_REQUEST',
                 message: `event_source_id "${id}" was not registered via sync_event_sources`,
                 field: `packages[${i}].optimization_goals[${j}].event_sources[${k}].event_source_id`,
+              }] as TaskError[],
+            };
+          }
+        }
+      }
+    }
+  }
+
+  // Validate targeting_overlay.audience_include / audience_exclude entries
+  // reference an audience_id previously registered via sync_audiences. Silent
+  // acceptance of phantom ids is a façade — the seller cannot target an
+  // audience it doesn't know about. Sibling contract to the event_source_id
+  // check above. error.field is a literal JSONPath-lite per core/error.json
+  // so audience_buy_flow can assert equality, not regex.
+  const sessionKeyForAudiences = sessionKeyFromArgs(req, ctx.mode, ctx.userId, ctx.moduleId);
+  if (Array.isArray(req.packages)) {
+    for (let i = 0; i < req.packages.length; i++) {
+      const pkg = req.packages[i] as { targeting_overlay?: unknown; targeting?: unknown };
+      const overlay = (pkg?.targeting_overlay ?? pkg?.targeting) as
+        | { audience_include?: unknown; audience_exclude?: unknown }
+        | undefined;
+      if (!overlay || typeof overlay !== 'object') continue;
+      for (const field of ['audience_include', 'audience_exclude'] as const) {
+        const list = overlay[field];
+        if (!Array.isArray(list)) continue;
+        for (let k = 0; k < list.length; k++) {
+          const id = list[k];
+          if (typeof id !== 'string' || id.length === 0) continue;
+          if (!findAudienceInSession(sessionKeyForAudiences, id)) {
+            return {
+              errors: [{
+                code: 'INVALID_REQUEST',
+                message: `audience_id "${id}" was not registered via sync_audiences`,
+                field: `packages[${i}].targeting_overlay.${field}[${k}]`,
               }] as TaskError[],
             };
           }
@@ -4110,6 +4150,7 @@ const HANDLER_MAP: Record<string, ToolHandler> = {
   sync_governance: handleSyncGovernance,
   sync_catalogs: handleSyncCatalogs,
   sync_event_sources: handleSyncEventSources,
+  sync_audiences: handleSyncAudiences,
   log_event: handleLogEvent,
   provide_performance_feedback: handleProvidePerformanceFeedback,
   sync_plans: handleSyncPlans,

--- a/server/src/training-agent/tenants/tool-catalog.ts
+++ b/server/src/training-agent/tenants/tool-catalog.ts
@@ -35,6 +35,7 @@ export const TOOL_CATALOG: Readonly<Record<string, readonly string[]>> = {
   get_media_buys: ['sales'],
   get_media_buy_delivery: ['sales'],
   provide_performance_feedback: ['sales'],
+  sync_audiences: ['sales'],
   // list_creative_formats is framework-registered for any tenant claiming
   // creative (sales, creative, creative-builder) — the SDK auto-advertises
   // it. Catalog mirrors that advertisement so the drift test stays green.

--- a/server/src/training-agent/v6-sales-platform.ts
+++ b/server/src/training-agent/v6-sales-platform.ts
@@ -16,6 +16,9 @@ import {
   type DecisioningPlatform,
   type SalesPlatform,
   type AccountStore,
+  type AudiencePlatform,
+  type SyncAudiencesRow,
+  type AudienceStatus,
 } from '@adcp/sdk/server';
 import {
   handleGetProducts,
@@ -28,6 +31,7 @@ import {
   handleListCreativeFormats,
 } from './task-handlers.js';
 import { handleProvidePerformanceFeedback } from './catalog-event-handlers.js';
+import { handleSyncAudiences } from './audience-handlers.js';
 import { syncAccountsUpsert } from './v6-account-helpers.js';
 import { trainingBuyerAgentRegistry } from './buyer-agent-registry.js';
 import type { ToolArgs, TrainingContext } from './types.js';
@@ -278,6 +282,35 @@ export class TrainingSalesPlatform
     providePerformanceFeedback: async (req, ctx) => {
       const result = await handleProvidePerformanceFeedback(req as ToolArgs, buildTrainingCtx(ctx.account));
       return translateV5Result(result);
+    },
+  };
+
+  // Audience-targeting capability is declared above; expose sync_audiences
+  // so audience_buy_flow can register audiences before referencing them in
+  // targeting_overlay. The training agent does not claim the audience-sync
+  // specialism — this is the buy-side sibling, gated on audience_targeting
+  // capability rather than on the audience-sync storyboard.
+  audiences: AudiencePlatform<TrainingSalesMeta> = {
+    syncAudiences: async (audienceList, ctx) => {
+      const brandDomain = brandDomainFromCtx(ctx.account);
+      // sync_audiences requires idempotency_key per schema. The framework
+      // strips it from per-row params; synthesise one so the v5 handler's
+      // shape validation passes. The v5 handler doesn't enforce uniqueness
+      // here — the framework already handled idempotency upstream.
+      const args = {
+        audiences: audienceList,
+        idempotency_key: `framework-projected-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+        ...(brandDomain && { account: { brand: { domain: brandDomain } }, brand: { domain: brandDomain } }),
+      };
+      const result = await handleSyncAudiences(args as unknown as ToolArgs, buildTrainingCtx(ctx.account));
+      const wrapped = translateV5Result<{ audiences?: SyncAudiencesRow[] }>(result);
+      return (wrapped.audiences ?? []) as SyncAudiencesRow[];
+    },
+    pollAudienceStatuses: async (_audienceIds, _ctx) => {
+      // The training agent doesn't model long-running matching — every
+      // audience resolves synchronously in syncAudiences. Return empty so
+      // callers treat ids as not-yet-resolved; never throw here.
+      return new Map<string, AudienceStatus>();
     },
   };
 }

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -1081,6 +1081,7 @@ describe('createTrainingAgentServer', () => {
     expect(toolNames).toContain('sync_governance');
     expect(toolNames).toContain('sync_catalogs');
     expect(toolNames).toContain('sync_event_sources');
+    expect(toolNames).toContain('sync_audiences');
     expect(toolNames).toContain('log_event');
     expect(toolNames).toContain('provide_performance_feedback');
     expect(toolNames).toContain('create_collection_list');
@@ -1088,7 +1089,7 @@ describe('createTrainingAgentServer', () => {
     expect(toolNames).toContain('update_collection_list');
     expect(toolNames).toContain('list_collection_lists');
     expect(toolNames).toContain('delete_collection_list');
-    expect(toolNames).toHaveLength(49);
+    expect(toolNames).toHaveLength(50);
   });
 
   it('get_adcp_capabilities response uses 3.0 capability model', async () => {
@@ -1741,6 +1742,128 @@ describe('create_media_buy handler', () => {
           }],
           target: { kind: 'cost_per', value: 35 },
         }],
+      }],
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(typeof result.media_buy_id).toBe('string');
+  });
+
+  it('rejects targeting_overlay.audience_include referencing an unregistered audience_id', async () => {
+    const { productId, pricingOptionId } = getFirstProductAndPricing();
+    const account = { brand: { domain: 'phantom-audience.example' }, operator: 'phantom-audience.example' };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    const { result } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'phantom-audience.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 5000,
+        targeting_overlay: {
+          audience_include: ['does_not_exist_phantom_audience'],
+        },
+      }],
+    });
+
+    expect(result.code).toBe('INVALID_REQUEST');
+    expect(result.field).toBe('packages[0].targeting_overlay.audience_include[0]');
+    expect((result.message as string).includes('does_not_exist_phantom_audience')).toBe(true);
+  });
+
+  it('accepts targeting_overlay.audience_include after the audience was registered via sync_audiences', async () => {
+    const { productId, pricingOptionId } = getFirstProductAndPricing();
+    const account = { brand: { domain: 'bound-audience.example' }, operator: 'bound-audience.example' };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    await simulateCallTool(server, 'sync_audiences', {
+      account,
+      audiences: [{
+        audience_id: 'bound_loyalty',
+        name: 'Bound Loyalty',
+        audience_type: 'crm',
+        add: [
+          { external_id: 'u1', hashed_email: 'a000000000000000000000000000000000000000000000000000000000000010' },
+        ],
+      }],
+    });
+
+    const { result } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'bound-audience.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 5000,
+        targeting_overlay: {
+          audience_include: ['bound_loyalty'],
+        },
+      }],
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(typeof result.media_buy_id).toBe('string');
+  });
+
+  it('rejects targeting_overlay.audience_exclude referencing an unregistered audience_id', async () => {
+    const { productId, pricingOptionId } = getFirstProductAndPricing();
+    const account = { brand: { domain: 'phantom-exclude.example' }, operator: 'phantom-exclude.example' };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    const { result } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'phantom-exclude.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 5000,
+        targeting_overlay: {
+          audience_exclude: ['phantom_suppression_list'],
+        },
+      }],
+    });
+
+    expect(result.code).toBe('INVALID_REQUEST');
+    expect(result.field).toBe('packages[0].targeting_overlay.audience_exclude[0]');
+    expect((result.message as string).includes('phantom_suppression_list')).toBe(true);
+  });
+
+  it('accepts targeting_overlay.audience_exclude after the audience was registered via sync_audiences', async () => {
+    const { productId, pricingOptionId } = getFirstProductAndPricing();
+    const account = { brand: { domain: 'bound-exclude.example' }, operator: 'bound-exclude.example' };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    await simulateCallTool(server, 'sync_audiences', {
+      account,
+      audiences: [{
+        audience_id: 'bound_suppression',
+        name: 'Bound Suppression',
+        audience_type: 'suppression',
+        add: [
+          { external_id: 's1', hashed_email: 'a000000000000000000000000000000000000000000000000000000000000020' },
+        ],
+      }],
+    });
+
+    const { result } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'bound-exclude.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 5000,
+        targeting_overlay: {
+          audience_exclude: ['bound_suppression'],
+        },
       }],
     });
 

--- a/static/compliance/source/protocols/media-buy/scenarios/audience_buy_flow.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/audience_buy_flow.yaml
@@ -1,0 +1,378 @@
+id: media_buy_seller/audience_buy_flow
+version: "1.0.0"
+title: "Seller fulfills a media buy with audience targeting from a synced CRM audience"
+category: media_buy_seller
+summary: "Verifies that a seller advertising audience_targeting can ingest a CRM audience via sync_audiences, accept a media buy whose targeting_overlay references the bound audience_id, reject malformed audience references, and report delivery for the audience-targeted buy. Sibling to media_buy_seller/performance_buy_flow on the audience side: the unbound-id rejection is the discriminating assertion."
+track: media_buy
+
+# Gate: scenario runs only when the seller declares audience_targeting.
+# Sellers without it (broadcast TV, signal-only, pure brand-suitability) grade
+# `not_applicable`, not failing. Audience targeting and the audience-sync
+# specialism are separate concerns — a seller can support audience_include /
+# audience_exclude on a buy without claiming the full audience-sync lifecycle
+# (e.g., a DSP that accepts buyer-uploaded CRM lists but doesn't expose
+# discovery/deletion semantics). Requires runner support for the `present:`
+# matcher (adcp-client >= 7.6.0).
+requires_capability:
+  path: media_buy.audience_targeting
+  present: true
+
+required_tools:
+  - get_products
+  - sync_audiences
+  - create_media_buy
+  - get_media_buy_delivery
+  - comply_test_controller
+
+invariants:
+  - status.monotonic
+
+narrative: |
+  An "audience buy" is a media buy whose packages restrict delivery to
+  members of a first-party CRM audience. The buyer pushes hashed
+  identifiers to the seller via sync_audiences, the seller matches them
+  against its user graph, and the buyer references the resulting
+  audience_id in targeting_overlay.audience_include[] or audience_exclude[]
+  on a create_media_buy.
+
+  This scenario is a buy-mode contract test, not a parent specialism. A DSP
+  may run audience buys AND performance buys against the same agent; this
+  scenario certifies that the audience path connects end-to-end when the
+  seller advertises audience_targeting. The full audience lifecycle
+  (discovery, deletion, status polling) lives on the audience-sync
+  specialism — what this scenario asserts is the buy-side wiring.
+
+  Discriminating behaviors this scenario verifies:
+  1. sync_audiences returns an audience_id that is then valid as the
+     binding target on targeting_overlay.audience_include[].
+  2. create_media_buy with a package whose targeting_overlay references the
+     registered audience is accepted.
+  3. create_media_buy with targeting_overlay.audience_include referencing
+     an unregistered audience_id is rejected (INVALID_REQUEST with
+     error.field set to the offending audience_include[k] path) — silent
+     acceptance would mean the seller cannot actually restrict delivery to
+     the buyer's intended audience.
+  4. get_media_buy_delivery returns standard delivery totals for the
+     audience-targeted buy. Per-audience delivery breakdown
+     (impressions / spend split per audience_id) is deliberately NOT
+     asserted here — it isn't a first-class field in
+     get-media-buy-delivery-response.json today. A follow-up scenario gated
+     on a sub-capability bit will land per-audience attribution.
+
+  Audience suppression via audience_exclude follows the same binding
+  contract (rejected if the audience_id wasn't registered) but is not
+  exercised twice here — one positive + one negative on audience_include is
+  the discriminating signal.
+
+agent:
+  interaction_model: media_buy_seller
+  capabilities:
+    - sells_media
+    - supports_non_guaranteed
+    - audience_targeting
+  examples:
+    - "DSPs accepting buyer-uploaded CRM audiences"
+    - "Retail-media networks matching first-party identifiers"
+    - "Social platforms (Meta / TikTok / Snap audience-targeted buying)"
+    - "CTV platforms with audience overlay support"
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: |
+    The seller must implement comply_test_controller with simulate_delivery
+    (already required for delivery_reporting). simulate_delivery injects
+    impressions and spend so get_media_buy_delivery has something to return
+    for the audience-targeted buy.
+
+    The buyer fixture supplies a brand, an operator, and a small CRM
+    audience definition with hashed_email identifiers sufficient to
+    exercise the audience binding contract.
+  test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  products:
+    - product_id: "audience_display_q2"
+      delivery_type: "non_guaranteed"
+      channels: ["display"]
+      format_ids:
+        - id: "display_300x250"
+  pricing_options:
+    - product_id: "audience_display_q2"
+      pricing_option_id: "auction_cpm"
+      pricing_model: "cpm"
+      currency: "USD"
+      floor_price: 2.00
+
+phases:
+
+  - id: setup
+    title: "Establish account and discover products"
+    steps:
+      - id: sync_accounts
+        title: "Establish account"
+        task: sync_accounts
+        schema_ref: "account/sync-accounts-request.json"
+        response_schema_ref: "account/sync-accounts-response.json"
+        doc_ref: "/accounts/tasks/sync_accounts"
+        stateful: true
+        expected: |
+          Return the account with account_id and status active.
+        sample_request:
+          accounts:
+            - brand:
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
+              billing: "operator"
+          idempotency_key: "$generate:uuid_v4#audience_buy_flow_setup_sync_accounts"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-accounts-response.json schema"
+          - check: field_present
+            path: "accounts[0].account_id"
+            description: "Account has a platform-assigned ID"
+
+      - id: get_products_for_audience
+        title: "Discover products that support audience targeting"
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        stateful: false
+        expected: |
+          Return at least one product whose audience_targeting capabilities
+          indicate audience_include / audience_exclude overlays are accepted.
+        sample_request:
+          buying_mode: "brief"
+          brief: "Display inventory, US adults 25-54, restricted to a first-party CRM audience. Q2 flight, ~$15K budget."
+          required_capabilities:
+            - "audience_targeting"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+        validations:
+          - check: response_schema
+            description: "Response matches get-products-response.json schema"
+          - check: field_present
+            path: "products"
+            description: "Response contains products"
+
+  - id: audience_binding
+    title: "Register the CRM audience"
+    narrative: |
+      The audience-targeted buy cannot be created without a registered
+      audience_id. This phase exercises the binding — sync_audiences returns
+      an audience_id (echoing the buyer's submitted id) that subsequent
+      create_media_buy calls reference in targeting_overlay.
+
+    steps:
+      - id: sync_audience
+        title: "Push a CRM audience with hashed email identifiers"
+        task: sync_audiences
+        schema_ref: "media-buy/sync-audiences-request.json"
+        response_schema_ref: "media-buy/sync-audiences-response.json"
+        doc_ref: "/media-buy/task-reference/sync_audiences"
+        stateful: true
+        expected: |
+          Accept the audience and return:
+          - audience_id: matches the submitted ID
+          - action: created (first sync) or updated (re-sync)
+          - status: processing, ready, or too_small per match outcome
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          audiences:
+            - audience_id: "acmeoutdoor-loyal-customers"
+              name: "Acme Outdoor loyal customers"
+              audience_type: "crm"
+              add:
+                - external_id: "acme-cust-0001"
+                  hashed_email: "a000000000000000000000000000000000000000000000000000000000000001"
+                - external_id: "acme-cust-0002"
+                  hashed_email: "a000000000000000000000000000000000000000000000000000000000000002"
+                - external_id: "acme-cust-0003"
+                  hashed_email: "a000000000000000000000000000000000000000000000000000000000000003"
+          idempotency_key: "$generate:uuid_v4#audience_buy_flow_audience_binding_sync_audiences"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-audiences-response.json schema"
+          - check: field_present
+            path: "audiences[0].audience_id"
+            description: "Audience has an audience_id (echo of the buyer's submitted id)"
+          - check: field_present
+            path: "audiences[0].action"
+            description: "Audience has an action (created or updated)"
+          # Anti-façade: an adapter that returns a shape-valid sync_audiences
+          # response without forwarding the hashed identifiers to its upstream
+          # user-graph fails this check. Adopters who don't advertise
+          # query_upstream_traffic in list_scenarios grade not_applicable.
+          - check: upstream_traffic
+            description: "sync_audiences caused upstream traffic carrying the supplied hashed identifiers"
+            min_count: 1
+            endpoint_pattern: "POST *"
+            identifier_paths:
+              - "audiences[*].add[*].hashed_email"
+              - "audiences[*].add[*].external_id"
+
+  - id: create_buy_with_audience
+    title: "Create a buy whose targeting binds to the registered audience"
+    narrative: |
+      The buyer creates a media buy whose package targeting_overlay carries
+      audience_include referencing the registered audience_id. The seller
+      should accept and return a media_buy_id used for subsequent delivery
+      checks.
+
+    steps:
+      - id: create_media_buy_with_audience
+        title: "Create media buy with audience_include in targeting_overlay"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        expected: |
+          Create the media buy. Response carries a media_buy_id used for
+          subsequent get_media_buy_delivery calls.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-06-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "audience_display_q2"
+              budget: 15000
+              pricing_option_id: "auction_cpm"
+              targeting_overlay:
+                audience_include:
+                  - "acmeoutdoor-loyal-customers"
+          idempotency_key: "$generate:uuid_v4#audience_buy_flow_create_buy_with_audience_create_media_buy"
+        context_outputs:
+          - name: media_buy_id
+            path: "media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Media buy has a platform-assigned ID"
+
+  - id: rejection_unbound_audience
+    title: "Reject a buy referencing an unregistered audience"
+    narrative: |
+      Silent acceptance of an unregistered audience_id is a façade — the
+      seller cannot restrict delivery to an audience it doesn't know about.
+      The seller MUST reject with INVALID_REQUEST and set error.field to the
+      offending audience_include path. Sibling contract to the
+      event_source_id binding asserted in performance_buy_flow.
+
+    steps:
+      - id: create_media_buy_with_phantom_audience
+        title: "Submit a buy whose targeting_overlay references a non-existent audience_id"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: false
+        expected: |
+          Reject with INVALID_REQUEST. error.field points at the offending
+          audience_include[k] path. media_buy_id is not allocated.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-06-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "audience_display_q2"
+              budget: 5000
+              pricing_option_id: "auction_cpm"
+              targeting_overlay:
+                audience_include:
+                  - "does_not_exist_phantom_audience"
+          idempotency_key: "$generate:uuid_v4#audience_buy_flow_rejection_unbound_audience"
+        validations:
+          - check: error_code
+            allowed_values: ["INVALID_REQUEST"]
+            description: "Seller rejects the unbound audience_id with INVALID_REQUEST"
+          - check: field_value
+            path: "errors[0].field"
+            value: "packages[0].targeting_overlay.audience_include[0]"
+            description: "Error.field points at the offending audience_include[0] path (core/error.json defines field as deterministic JSONPath-lite — literal equality)"
+
+  - id: delivery_check
+    title: "Delivery reporting for the audience-targeted buy"
+    narrative: |
+      The discriminating assertion of the audience buy mode is the binding
+      contract proven above. Delivery reporting here verifies the
+      audience-targeted buy is a real, observable buy in the seller's
+      system — totals.impressions surfaces under standard delivery shape.
+
+      Per-audience delivery breakdown (impressions / spend split per
+      audience_id within media_buy_deliveries[].totals) is deliberately
+      NOT asserted: that field isn't first-class in delivery-metrics.json
+      today. A follow-up scenario gated on a sub-capability bit will land
+      per-audience attribution once the breakdown shape is in spec.
+
+    steps:
+      - id: simulate_audience_delivery
+        title: "Inject impressions + spend for the audience-targeted buy"
+        task: comply_test_controller
+        requires_tool: comply_test_controller
+        stateful: true
+        expected: |
+          The test controller acknowledges the simulated delivery.
+        sample_request:
+          account:
+            sandbox: true
+          scenario: "simulate_delivery"
+          params:
+            media_buy_id: "$context.media_buy_id"
+            impressions: 80000
+            clicks: 1200
+            reported_spend:
+              amount: 1800.00
+              currency: "USD"
+        validations:
+          - check: field_value
+            path: "success"
+            allowed_values: [true]
+            description: "Delivery simulation succeeds"
+
+      - id: get_audience_delivery
+        title: "Get delivery and verify totals for the audience-targeted buy"
+        task: get_media_buy_delivery
+        schema_ref: "media-buy/get-media-buy-delivery-request.json"
+        response_schema_ref: "media-buy/get-media-buy-delivery-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buy_delivery"
+        stateful: true
+        expected: |
+          Delivery response includes totals.impressions for the audience-
+          targeted buy. Per-audience attribution is not asserted (see
+          phase narrative).
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "$context.media_buy_id"
+          include_package_daily_breakdown: true
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buy-delivery-response.json schema"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.impressions"
+            description: "Impression count surfaced at the buy level"

--- a/static/compliance/source/protocols/media-buy/scenarios/event_dedup_flow.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/event_dedup_flow.yaml
@@ -1,0 +1,399 @@
+id: media_buy_seller/event_dedup_flow
+version: "1.0.0"
+title: "Seller deduplicates the same event across multiple registered event sources"
+category: media_buy_seller
+summary: "Verifies that a seller advertising conversion_tracking.multi_source_event_dedup can register multiple event sources for the same buy and deduplicate inbound events by event_id so the same conversion from a pixel and a CAPI source counts once, not twice. Sibling to media_buy_seller/performance_buy_flow gated on the dedup sub-capability bit: sellers that don't advertise multi-source dedup grade not_applicable."
+track: media_buy
+
+# Gate: scenario runs only when the seller declares
+# conversion_tracking.multi_source_event_dedup equals true. Sellers that
+# don't (most social platforms with independently-managed pixel + CAPI
+# pipelines, retail-media networks attributing per-source) grade
+# `not_applicable`, not failing. multi_source_event_dedup is a sub-capability
+# of conversion_tracking — gating on this bit rather than on
+# conversion_tracking presence avoids over-claiming against the broad
+# performance-tracking community.
+requires_capability:
+  path: media_buy.conversion_tracking.multi_source_event_dedup
+  equals: true
+
+required_tools:
+  - sync_event_sources
+  - create_media_buy
+  - log_event
+  - get_media_buy_delivery
+  - comply_test_controller
+
+invariants:
+  - status.monotonic
+
+narrative: |
+  "Multi-source event dedup" is the discriminating capability of sellers
+  whose attribution pipelines can deduplicate the same conversion observed
+  via two independent ingestion paths — typically a website pixel and a
+  server-side Conversions API (CAPI) feed, sharing event_id. When the
+  seller advertises multi_source_event_dedup: true, buyers can register
+  both sources on the same optimization_goal and rely on the seller
+  attributing each unique event_id once.
+
+  Most adopters cannot do this. Independently-managed pixel and CAPI
+  pipelines in social platforms attribute per source; retail-media networks
+  attribute at the line / placement level without cross-source dedup;
+  broadcast / CTV performance products dedup only within a single MMP feed.
+  Gating this scenario on the explicit sub-capability bit is what keeps
+  honest implementations from failing.
+
+  Discriminating behaviors this scenario verifies:
+  1. sync_event_sources can register multiple event sources for the same
+     buyer account, each with its own event_source_id but overlapping
+     event_types and allowed_domains.
+  2. create_media_buy accepts an event-kind optimization_goal whose
+     event_sources array contains both source ids — the seller commits to
+     deduplicating across them.
+  3. log_event accepts the SAME event_id from BOTH sources without
+     rejecting either as a duplicate (both API-level acks succeed —
+     the dedup happens in attribution, not ingestion).
+  4. get_media_buy_delivery reports the cumulative conversion count as 1,
+     not 2. The point of multi_source_event_dedup: true is that the same
+     event_id from two registered sources counts once.
+
+  Sellers without this capability would either reject the second log_event
+  call (overly conservative) or count both (the silent-double-count failure
+  mode this scenario guards against). The bit gates the scenario; the
+  assertion is the cumulative count.
+
+  Per-event-source conversion breakdown (conversions split per
+  event_source_id within media_buy_deliveries[].totals) is deliberately NOT
+  asserted: that field isn't first-class in delivery-metrics.json today.
+  A follow-up scenario gated on a sub-capability bit will land per-source
+  attribution once the breakdown shape is in spec.
+
+agent:
+  interaction_model: media_buy_seller
+  capabilities:
+    - sells_media
+    - conversion_tracking
+  examples:
+    - "Social platforms with unified pixel+CAPI dedup (rare — most don't)"
+    - "DSPs operating their own attribution graph"
+    - "Walled-garden platforms with deterministic cross-source dedup"
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: |
+    The seller must implement comply_test_controller with simulate_delivery
+    accepting a `conversions` param so the dedup outcome is observable via
+    get_media_buy_delivery without a real attribution run.
+
+    The buyer fixture supplies a brand, an operator, and two event-source
+    definitions (a website pixel and a CAPI feed) sufficient to exercise
+    multi-source registration and dedup.
+  test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  products:
+    - product_id: "dedup_performance_q2"
+      delivery_type: "non_guaranteed"
+      channels: ["display"]
+      format_ids:
+        - id: "display_300x250"
+  pricing_options:
+    - product_id: "dedup_performance_q2"
+      pricing_option_id: "auction_cpm"
+      pricing_model: "cpm"
+      currency: "USD"
+      floor_price: 1.50
+
+phases:
+
+  - id: setup
+    title: "Establish account and discover products"
+    steps:
+      - id: sync_accounts
+        title: "Establish account"
+        task: sync_accounts
+        schema_ref: "account/sync-accounts-request.json"
+        response_schema_ref: "account/sync-accounts-response.json"
+        doc_ref: "/accounts/tasks/sync_accounts"
+        stateful: true
+        expected: |
+          Return the account with account_id and status active.
+        sample_request:
+          accounts:
+            - brand:
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
+              billing: "operator"
+          idempotency_key: "$generate:uuid_v4#event_dedup_flow_setup_sync_accounts"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-accounts-response.json schema"
+          - check: field_present
+            path: "accounts[0].account_id"
+            description: "Account has a platform-assigned ID"
+
+      - id: get_products_for_dedup
+        title: "Discover products supporting multi-source event dedup"
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        stateful: false
+        expected: |
+          Return at least one product whose conversion_tracking capabilities
+          include multi_source_event_dedup.
+        sample_request:
+          buying_mode: "brief"
+          brief: "Performance display, US, adults 25-54. Target CPA $40 with pixel + CAPI conversion sources; same event_id from both must dedup."
+          required_capabilities:
+            - "conversion_tracking"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+        validations:
+          - check: response_schema
+            description: "Response matches get-products-response.json schema"
+          - check: field_present
+            path: "products"
+            description: "Response contains products"
+
+  - id: register_two_event_sources
+    title: "Register a pixel and a CAPI source sharing event types"
+    narrative: |
+      Two event_sources in a single sync_event_sources call — a website
+      pixel and a server-side CAPI feed. Both observe the same purchase
+      events; the buyer expects the seller to dedup by event_id when both
+      sources are attached to the same optimization_goal.
+
+    steps:
+      - id: sync_event_sources
+        title: "Register pixel + CAPI as two sources on one account"
+        task: sync_event_sources
+        schema_ref: "media-buy/sync-event-sources-request.json"
+        response_schema_ref: "media-buy/sync-event-sources-response.json"
+        doc_ref: "/media-buy/task-reference/sync_event_sources"
+        stateful: true
+        expected: |
+          Return both event_sources with event_source_id, setup.snippet,
+          and action: created. Both ids are referenced in the next phase's
+          create_media_buy call.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          event_sources:
+            - event_source_id: "acmeoutdoor_website_pixel"
+              name: "Acme Outdoor website pixel"
+              event_types: ["purchase", "add_to_cart"]
+              allowed_domains: ["acmeoutdoor.example"]
+            - event_source_id: "acmeoutdoor_website_capi"
+              name: "Acme Outdoor server-side CAPI"
+              event_types: ["purchase", "add_to_cart"]
+              allowed_domains: ["acmeoutdoor.example"]
+          idempotency_key: "$generate:uuid_v4#event_dedup_flow_register_two_event_sources_sync_event_sources"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-event-sources-response.json schema"
+          - check: field_present
+            path: "event_sources[0].event_source_id"
+            description: "First event source has a platform-assigned ID"
+          - check: field_present
+            path: "event_sources[1].event_source_id"
+            description: "Second event source has a platform-assigned ID"
+
+  - id: create_buy_with_dedup_goal
+    title: "Create a performance buy whose goal attaches BOTH event sources"
+    narrative: |
+      The buyer creates a media buy whose package carries an event-kind
+      optimization_goal binding to BOTH the pixel and the CAPI source.
+      Target is target_cpa $40 on purchase events; the seller commits to
+      deduplicating event_ids across the two sources.
+
+    steps:
+      - id: create_media_buy_dedup
+        title: "Create media buy with two event_sources on one goal"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        expected: |
+          Create the media buy. Response carries a media_buy_id used for
+          subsequent log_event and get_media_buy_delivery calls.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-06-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "dedup_performance_q2"
+              budget: 20000
+              pricing_option_id: "auction_cpm"
+              optimization_goals:
+                - kind: "event"
+                  event_sources:
+                    - event_source_id: "acmeoutdoor_website_pixel"
+                      event_type: "purchase"
+                    - event_source_id: "acmeoutdoor_website_capi"
+                      event_type: "purchase"
+                  target:
+                    kind: "cost_per"
+                    value: 40.00
+                  priority: 1
+          idempotency_key: "$generate:uuid_v4#event_dedup_flow_create_buy_with_dedup_goal_create_media_buy"
+        context_outputs:
+          - name: media_buy_id
+            path: "media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Media buy has a platform-assigned ID"
+
+  - id: log_same_event_id_from_both_sources
+    title: "Log the same event_id from BOTH registered sources"
+    narrative: |
+      The buyer logs the SAME purchase event_id from the pixel AND from
+      the CAPI source. Both calls succeed at the API level — the dedup
+      happens in attribution, not ingestion. A seller that rejects the
+      second call as a duplicate at the API level is over-claiming
+      ingestion-level dedup, which is not what multi_source_event_dedup
+      asserts.
+
+    steps:
+      - id: log_event_from_pixel
+        title: "Log purchase event from the pixel"
+        task: log_event
+        schema_ref: "media-buy/log-event-request.json"
+        response_schema_ref: "media-buy/log-event-response.json"
+        doc_ref: "/media-buy/task-reference/log_event"
+        stateful: true
+        expected: |
+          Acknowledge the event with accepted status.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          event_source_id: "acmeoutdoor_website_pixel"
+          events:
+            - event_type: "purchase"
+              event_id: "evt_dedup_001"
+              event_time: "2026-06-05T14:30:00Z"
+              user_match:
+                hashed_email: "a000000000000000000000000000000000000000000000000000000000000010"
+              custom_data:
+                order_total: 199.99
+                currency: "USD"
+          idempotency_key: "$generate:uuid_v4#event_dedup_flow_log_same_event_id_from_both_sources_log_event_pixel"
+        validations:
+          - check: response_schema
+            description: "Response matches log-event-response.json schema"
+
+      - id: log_event_from_capi
+        title: "Log the SAME event_id from the CAPI source"
+        task: log_event
+        schema_ref: "media-buy/log-event-request.json"
+        response_schema_ref: "media-buy/log-event-response.json"
+        doc_ref: "/media-buy/task-reference/log_event"
+        stateful: true
+        expected: |
+          Acknowledge the event with accepted status. The seller MUST NOT
+          reject this as a duplicate at the API level — dedup is an
+          attribution-time concern, asserted via the totals.conversions
+          check in the next phase.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          event_source_id: "acmeoutdoor_website_capi"
+          events:
+            - event_type: "purchase"
+              event_id: "evt_dedup_001"
+              event_time: "2026-06-05T14:30:00Z"
+              user_match:
+                hashed_email: "a000000000000000000000000000000000000000000000000000000000000010"
+              custom_data:
+                order_total: 199.99
+                currency: "USD"
+          idempotency_key: "$generate:uuid_v4#event_dedup_flow_log_same_event_id_from_both_sources_log_event_capi"
+        validations:
+          - check: response_schema
+            description: "Response matches log-event-response.json schema"
+
+  - id: assert_single_attribution
+    title: "Delivery reports the deduplicated event ONCE, not twice"
+    narrative: |
+      The discriminating assertion: get_media_buy_delivery surfaces
+      totals.conversions equal to the count of unique event_ids attributed
+      to the buy. simulate_delivery injects conversions: 1 reflecting the
+      single unique event_id; the seller's response totals.conversions must
+      equal 1, not 2. If the seller failed to dedup, the cumulative count
+      would double-count and the assertion fails.
+
+    steps:
+      - id: simulate_deduplicated_delivery
+        title: "Inject impressions + ONE attributed conversion"
+        task: comply_test_controller
+        requires_tool: comply_test_controller
+        stateful: true
+        expected: |
+          The test controller acknowledges the simulated delivery with the
+          deduplicated conversion count (1, not 2 — the same event_id from
+          two sources is one conversion).
+        sample_request:
+          account:
+            sandbox: true
+          scenario: "simulate_delivery"
+          params:
+            media_buy_id: "$context.media_buy_id"
+            impressions: 150000
+            clicks: 3200
+            conversions: 1
+            reported_spend:
+              amount: 2400.00
+              currency: "USD"
+        validations:
+          - check: field_value
+            path: "success"
+            allowed_values: [true]
+            description: "Delivery simulation succeeds"
+
+      - id: get_dedup_delivery
+        title: "Get delivery and verify single conversion attribution"
+        task: get_media_buy_delivery
+        schema_ref: "media-buy/get-media-buy-delivery-request.json"
+        response_schema_ref: "media-buy/get-media-buy-delivery-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buy_delivery"
+        stateful: true
+        expected: |
+          Delivery response includes totals.conversions equal to 1 — the
+          same event_id from two registered sources counts once. A seller
+          double-counting would report 2 and fail this assertion.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "$context.media_buy_id"
+          include_package_daily_breakdown: true
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buy-delivery-response.json schema"
+          - check: field_value
+            path: "media_buy_deliveries[0].totals.conversions"
+            value: 1
+            description: "Cumulative conversions equals 1 — the same event_id from two sources dedups to one (the discriminating assertion of multi_source_event_dedup)"

--- a/static/compliance/source/specialisms/sales-non-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-non-guaranteed/index.yaml
@@ -9,11 +9,13 @@ required_tools:
   - get_products
   - create_media_buy
 requires_scenarios:
+  - media_buy_seller/audience_buy_flow
   - media_buy_seller/delivery_reporting
-  - media_buy_seller/pending_creatives_to_start
-  - media_buy_seller/inventory_list_targeting
+  - media_buy_seller/event_dedup_flow
   - media_buy_seller/inventory_list_no_match
+  - media_buy_seller/inventory_list_targeting
   - media_buy_seller/invalid_transitions
+  - media_buy_seller/pending_creatives_to_start
   - media_buy_seller/performance_buy_flow
 
 # Cross-step assertion (adcp#2664). status.monotonic rejects resource


### PR DESCRIPTION
## Summary

Two new capability-gated scenarios in the contract pattern (#4637), both added to `sales-non-guaranteed.requires_scenarios`, plus a training-agent fix that unblocks one of them.

### `media_buy_seller/audience_buy_flow`

Gated on `media_buy.audience_targeting` **presence** (not on the audience-sync specialism — option B from the RFC chat: a DSP can accept buyer-uploaded CRM lists in `targeting_overlay` without claiming the full audience-sync discovery/deletion lifecycle). Certifies:

1. `sync_audiences` returns an `audience_id` valid as a binding target in `targeting_overlay.audience_include[]`.
2. `create_media_buy` with `targeting_overlay.audience_include` referencing the registered audience is accepted.
3. `create_media_buy` with `audience_include` referencing an **unregistered** id is rejected (`INVALID_REQUEST` with `error.field` set to the literal JSONPath-lite path `packages[0].targeting_overlay.audience_include[0]`) — silent acceptance would mean the seller cannot actually restrict delivery to the buyer's audience.
4. Delivery reporting surfaces `totals.impressions` for the audience-targeted buy. Per-audience attribution breakdown is intentionally deferred (not first-class in `delivery-metrics.json` today).

Sibling to `media_buy_seller/performance_buy_flow` on the audience side — the unbound-id rejection is the discriminating assertion, modeled on the event_source_id contract from #4642.

### `media_buy_seller/event_dedup_flow`

Gated on `media_buy.conversion_tracking.multi_source_event_dedup` **equals true**. Certifies that the same `event_id` from two registered event sources attributes to **one** conversion, not two:

1. `sync_event_sources` accepts two sources (pixel + CAPI) sharing event_types.
2. `create_media_buy` accepts an event-kind goal whose `event_sources` array contains BOTH ids.
3. Two `log_event` calls with the SAME `event_id` from each source both succeed at the API level (dedup is attribution-time, not ingestion-time).
4. `get_media_buy_delivery` reports `totals.conversions` equal to 1, not 2.

The training agent does **not** declare `multi_source_event_dedup: true` (verified in `v6-sales-platform.ts`), so this scenario grades `not_applicable` against the training agent in CI — no training-agent fix is needed. The scenario only runs against sellers that explicitly opt in.

### Training-agent fix (audience_buy_flow only)

`create_media_buy` now rejects `targeting_overlay.audience_include` / `audience_exclude` entries whose `audience_id` was never registered via `sync_audiences`, with `INVALID_REQUEST` and `error.field` set to the literal JSONPath-lite path. Mirrors the event_source_id validation pattern from #4654. Implementation:

- New `server/src/training-agent/audience-handlers.ts` with the in-memory store + `handleSyncAudiences`.
- `sync_audiences` wired into the legacy `/mcp` HANDLER_MAP and the v6 `/sales/mcp` `AudiencePlatform`.
- Validation block in `handleCreateMediaBuy` walking each package's `targeting_overlay.audience_include[]` and `audience_exclude[]` against the audience store.

Four unit tests in `server/tests/unit/training-agent.test.ts` cover the four contract paths: rejects/accepts × include/exclude.

### Refs

- #4569 — original capability-gating contract pattern
- #4637 — this PR's tracking issue
- #4642 — `performance_buy_flow` precedent
- #4654 — training-agent `event_source_id` validation precedent
- #4651 — blocks the three product-level sibling scenarios (reach, clicks, completed_views)

## Test plan

- [x] `npm run build:schemas` clean
- [x] `npm run build:compliance` — all 12 lints pass; new scenarios in `dist/compliance/latest/protocols/media-buy/scenarios/`
- [x] `npx tsc --project server/tsconfig.json --noEmit` clean
- [x] `npx vitest run server/tests/unit/training-agent.test.ts` — 376/376 pass (includes 4 new audience contract tests + updated tool-count assertion)
- [ ] Storyboard grader run against the training agent — `audience_buy_flow` should grade `passed`, `event_dedup_flow` should grade `not_applicable`

## Scenario design notes

- `error.field` uses literal `value:` only, not `matches:` regex — `field_value` doesn't support regex and the field is JSONPath-lite per `core/error.json`.
- No per-audience or per-event-source delivery breakdown asserted — neither is first-class in `delivery-metrics.json` today. Both will land as follow-up scenarios gated on sub-capability bits.
- `audience_exclude` follows the same binding contract but is exercised only via unit tests, not a separate scenario phase — one positive + one negative on `audience_include` is the discriminating signal in YAML.
- No modification of `audience-sync` specialism storyboard or its `index.yaml`.
- No modification of `performance_buy_flow.yaml` — reference only.
- The training agent intentionally does **not** declare `multi_source_event_dedup` — keeping it honest as a "doesn't claim what it can't do" reference is the right state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)