### PR TITLE
feat(schemas): add supported_optimization_metrics seller-level capability (closes #4651)

### DIFF
--- a/.changeset/4651-supported-optimization-metrics-capability.md
+++ b/.changeset/4651-supported-optimization-metrics-capability.md
@@ -1,0 +1,11 @@
+---
+"adcontextprotocol": minor
+---
+
+feat(schemas): add media_buy.supported_optimization_metrics seller-level summary (closes #4651)
+
+Sellers can now declare which optimization metrics they support at the seller level, mirroring the product-level `metric_optimization.supported_metrics` enum. Buyer agents get a single discoverable rollup for pre-flight metric filtering; storyboard scenarios get a gate path they can use with `requires_capability` to skip sellers that don't support a metric (e.g., reach_buy_flow, clicks_buy_flow, completed_views_buy_flow).
+
+Sellers MUST keep this in sync with their product catalog — values appear here only if at least one product supports them. Per-product inspection via `metric_optimization.supported_metrics` remains the source of truth for buy-time targeting; this is a seller-level discoverability convenience.
+
+Unblocks the metric-buy-mode storyboards under the capability-claim contract pattern (#4637). Those scenarios additionally require a `contains:` matcher on `requires_capability` (filed against adcp-client).

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -499,6 +499,16 @@
           ],
           "additionalProperties": true
         },
+        "supported_optimization_metrics": {
+          "type": "array",
+          "description": "Optimization metrics this seller can support on at least one of their products. Seller-level rollup of product-level metric_optimization.supported_metrics declarations (core/product.json). Buyers SHOULD filter their requested optimization goals against this list before submitting briefs. Sellers MUST keep this in sync with their product catalog — if no products support a metric, it must not appear here. Omitting this field means the seller declares no specific guarantees about which metrics they support; buyers should fall back to per-product inspection of metric_optimization.supported_metrics.",
+          "items": {
+            "type": "string",
+            "enum": ["clicks", "views", "completed_views", "viewed_seconds", "attention_seconds", "attention_score", "engagements", "follows", "saves", "profile_visits", "reach"]
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
         "conversion_tracking": {
           "type": "object",
           "description": "Seller-level conversion tracking capabilities. Presence of this object indicates the seller supports sync_event_sources and log_event for conversion event tracking.",


### PR DESCRIPTION
## Summary

Adds `media_buy.supported_optimization_metrics` to `get_adcp_capabilities` response — a seller-level rollup of which optimization metrics any of the seller's products support. Mirrors the product-level `metric_optimization.supported_metrics` enum in `core/product.json` exactly.

This is the **option Y** decision from #4651 — a lightweight capability summary that storyboards can gate on via `requires_capability` plus a `contains:` matcher, instead of option X (deeper runner support for inspecting per-product capability arrays).

## Why option Y

- **Single discoverable surface.** Buyer agents already fetch `get_adcp_capabilities` for pre-flight filtering; one more rollup array is cheaper than crawling every product's `metric_optimization` block.
- **Lighter runner change.** Storyboard gating only needs a `contains:` matcher on `requires_capability` (filed against adcp-client) — no semantic understanding of nested per-product capability claims.
- **Doesn't replace product-level inspection.** Per-product `metric_optimization.supported_metrics` remains the source of truth for buy-time targeting and product selection. This rollup is a seller-level discoverability convenience.

## Sync invariant

Sellers MUST keep this in sync with their product catalog: values appear here only if **at least one product** declares support. If no products support a metric, it MUST NOT appear here. This is a seller responsibility, not a schema-enforced one — enforcement would require cross-document validation which we don't run on capability responses.

## Schema details

- **Location:** `media_buy.supported_optimization_metrics`, placed adjacent to other rollup capabilities (`audience_targeting`, `conversion_tracking`)
- **Type:** array of string enum, `uniqueItems: true`, `minItems: 1`
- **Enum:** byte-identical to `core/product.json` `metric_optimization.supported_metrics.items.enum` — `["clicks", "views", "completed_views", "viewed_seconds", "attention_seconds", "attention_score", "engagements", "follows", "saves", "profile_visits", "reach"]`
- **Optional.** Omission = "seller declares no specific guarantees; buyers fall back to per-product inspection." Not added to `media_buy.required`.

## What this unblocks

The metric-buy-mode storyboard scenarios under #4637 (capability-claim contract pattern) — `reach_buy_flow`, `clicks_buy_flow`, `completed_views_buy_flow`. Those scenarios additionally require a `contains:` matcher for `requires_capability` (filed against adcp-client); this PR is the schema half.

## What this does NOT do

- Does NOT touch `core/product.json` `metric_optimization` block.
- Does NOT add the corresponding metric-buy-mode storyboards — those land once the `contains:` matcher ships in adcp-client.
- Does NOT include vendor-gated metrics or attention-vendor declarations — that's a separate dimension (measurement_terms / measurement vendor catalog).

## Refs

- Closes #4651 (RFC + option Y decision)
- #4637 (metric-buy-mode capability-claim meta)

## Test plan

- [x] `npm run build:schemas` succeeds
- [x] `npm run build:compliance` succeeds
- [x] Enum byte-matches `core/product.json` `metric_optimization.supported_metrics.items.enum`
- [x] Precommit (`test:unit`, `test:test-dynamic-imports`, `test:callapi-state-change`, `typecheck`) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)