### PR TITLE
feat(schemas): add media_buy.frequency_capping capability declaration (closes #4640)

### DIFF
--- a/.changeset/4640-frequency-capping-capability.md
+++ b/.changeset/4640-frequency-capping-capability.md
@@ -1,0 +1,15 @@
+---
+"adcontextprotocol": minor
+---
+
+feat(schemas): add media_buy.frequency_capping capability declaration (closes #4640)
+
+Sellers can now declare frequency-capping support in get_adcp_capabilities. Presence of the object means the seller honors `targeting.frequency_cap` and MUST reject caps they cannot enforce rather than silently dropping them.
+
+Two optional sub-fields let buyers pre-flight validate before submitting:
+- `supported_per_units` — entity granularities (devices, individuals, etc.) from reach-unit.json
+- `supported_window_units` — duration units (hours, days, campaign) from duration.json
+
+`enforces_within` from the original RFC was dropped — no SSP can back that attestation cleanly. Per-product overrides for mixed addressable/non-addressable inventory are a likely follow-up.
+
+A capability-gated `frequency_cap_enforcement` storyboard scenario lands separately under the capability-claim contract pattern (#4637).

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -589,6 +589,29 @@
           },
           "additionalProperties": true
         },
+        "frequency_capping": {
+          "type": "object",
+          "description": "Frequency capping capabilities. Presence of this object indicates the seller honors targeting.frequency_cap on packages and MUST reject caps it cannot enforce rather than silently dropping them. Buyers SHOULD inspect supported_per_units and supported_window_units before submitting caps; sellers without these sub-fields populated MAY accept any reach-unit / duration-unit combination they can enforce. Per-product overrides (for sellers with mixed addressable/non-addressable inventory) are a likely follow-up — file a separate RFC if needed.",
+          "properties": {
+            "supported_per_units": {
+              "type": "array",
+              "description": "Entity granularities the seller can enforce caps against. Values from the reach-unit enum. Omit to indicate all reach-unit values are supported.",
+              "items": { "$ref": "/schemas/enums/reach-unit.json" },
+              "minItems": 1,
+              "uniqueItems": true
+            },
+            "supported_window_units": {
+              "type": "array",
+              "description": "Duration units the seller supports for frequency cap windows. Values must match the duration.json unit enum (e.g., 'hours', 'days', 'campaign'). Omit to indicate all duration units are supported.",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            }
+          },
+          "additionalProperties": true
+        },
         "content_standards": {
           "type": "object",
           "description": "Content standards implementation details. Presence of this object indicates the seller supports content_standards configuration including sampling rates and category filtering. Gives buyers pre-buy visibility into local evaluation and artifact delivery capabilities.",


### PR DESCRIPTION
## Summary

Adds an additive `media_buy.frequency_capping` capability block to `get_adcp_capabilities` so sellers can declare frequency-cap support up front and buyers can pre-flight validate before submitting.

**Shape** (B-lite per WG triage on #4640):
- Presence of the object = seller honors `targeting.frequency_cap` on packages and MUST reject caps it cannot enforce (no silent drops).
- `supported_per_units` (optional) — entity granularities, `$ref` to `/schemas/enums/reach-unit.json`.
- `supported_window_units` (optional) — duration units (`hours`, `days`, `campaign`, etc.) aligned with `duration.json`'s `unit` enum.

Both sub-fields are optional; omission means "all values supported." Neither sub-field is `required` on the parent object.

## Why

- Today there's no capability declaration for frequency capping. Sellers either honor `targeting.frequency_cap` silently or drop unenforceable caps without telling the buyer — a façade-prevention gap.
- Two aligned arrays let buyer agents short-circuit submission for unsupported reach-unit / window combinations rather than discovering at activation.
- Façade prevention: a seller advertising the block but rejecting all caps gets caught by the capability-claim contract (#4637) once the corresponding `frequency_cap_enforcement` storyboard lands.

## What was dropped

The original RFC included `enforces_within` (a duration attestation of "we enforce caps within X minutes of impression"). Dropped per WG triage on #4640 — no SSP can back that attestation cleanly across DSP/SSP/exchange layers, so the field would have invited unfalsifiable claims.

## Per-product overrides

Sellers with mixed addressable / non-addressable inventory may need per-product overrides on `targeting_capabilities`. Out of scope here — file a follow-up RFC if needed. The seller-level declaration is the floor.

## Notes

- `supported_window_units` items shape: `{type: string}` (free string with documented enum values). `duration.json` defines the `unit` enum inline on the object schema rather than as a standalone enum file, so there's no $ref target. The description names the canonical values (`hours`, `days`, `campaign`).
- The corresponding `frequency_cap_enforcement` storyboard scenario lands in a separate PR under the capability-claim contract pattern (#4637).
- Build: `npm run build:schemas` and `npm run build:compliance` both pass.

## Refs

- Closes #4640 (RFC)
- Pattern: #4637 (capability-claim contract / capability-gated scenarios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)