### PR TITLE
feat(training-agent): serve schema-conformant /.well-known/brand.json

### DIFF
--- a/.changeset/training-agent-brand-json-endpoint.md
+++ b/.changeset/training-agent-brand-json-endpoint.md
@@ -1,0 +1,24 @@
+---
+---
+
+feat(training-agent): serve schema-conformant `/.well-known/brand.json`
+
+The training agent now serves a brand.json discovery document conformant
+with `static/schemas/source/brand.json` oneOf[3] (house portfolio
+variant). Declares AAO as the house operating the training agent and
+lists each tenant's MCP endpoint as a typed `brand_agent_entry` with a
+`jwks_uri` pointing at the shared `/.well-known/jwks.json`.
+
+Single-tier (no `brand_refs[]`, no `house_domain`). Per-publisher /
+multi-tier fixtures (Sportshaus / StreamHaus / Northwind from the
+verification walkthrough) come in a follow-up PR. Unblocks step 2
+("Read the seller's brand.json") of the seller-verification walkthrough
+being demoable against the training agent.
+
+Replaces an earlier malformed handler in `tenants/router.ts` that
+returned `{ jwks: getAggregatedPublicJwks() }` under the brand.json path
+— that endpoint pre-dated the brand-protocol schema and was used only
+for SDK-validator debug introspection (`autoValidate: false`).
+`getAggregatedPublicJwks()` remains exported for direct callers
+(`training-agent-governance-signing.test.ts`); buyer-side fetchers walk
+the chain via `agents[].jwks_uri` pointers.

--- a/server/src/training-agent/index.ts
+++ b/server/src/training-agent/index.ts
@@ -543,6 +543,73 @@ export function createTrainingAgentRouter(): Router {
     res.json(getPublicJwks());
   });
 
+  // brand.json discovery — house portfolio variant per
+  // `static/schemas/source/brand.json` oneOf[3]. Declares AAO as the house
+  // operating the training agent and lists each tenant's MCP endpoint as a
+  // typed brand_agent_entry. Buyer-side verifiers fetching brand.json from
+  // a deployment of this agent get a schema-conformant single-tier document
+  // suitable for end-to-end verification storyboards.
+  //
+  // Single-tier (no `brand_refs[]`, no `house_domain`). Per-publisher /
+  // multi-tier fixtures (Sportshaus / StreamHaus / Northwind from the
+  // verification walkthrough) come in a follow-up PR.
+  router.get('/.well-known/brand.json', (req: Request, res: Response) => {
+    const baseUrl = getBaseUrl(req);
+    const agentBase = `${baseUrl}${req.baseUrl}`;
+    const jwksUri = `${agentBase}/.well-known/jwks.json`;
+
+    const tenantAgentType: Record<typeof TENANT_IDS[number], string> = {
+      sales: 'sales',
+      signals: 'signals',
+      governance: 'governance',
+      creative: 'creative',
+      'creative-builder': 'creative',
+      brand: 'brand',
+    };
+
+    const tenantAgentDescription: Record<typeof TENANT_IDS[number], string> = {
+      sales: 'Training-agent sales tenant — non-guaranteed + guaranteed inventory across simulated publishers',
+      signals: 'Training-agent signals tenant — signal marketplace + owned signals across simulated providers',
+      governance: 'Training-agent governance tenant — spend authority, delivery monitoring, property/collection lists, content standards',
+      creative: 'Training-agent creative tenant — creative ad server',
+      'creative-builder': 'Training-agent creative-builder tenant — creative template + generative',
+      brand: 'Training-agent brand tenant — brand rights and discovery',
+    };
+
+    res.setHeader('Cache-Control', 'public, max-age=300');
+    res.json({
+      $schema: '/schemas/brand.json',
+      version: '1.0',
+      house: {
+        domain: 'adcontextprotocol.org',
+        name: 'Ad Context Protocol',
+        architecture: 'branded_house',
+        agents: TENANT_IDS.map(tenantId => ({
+          type: tenantAgentType[tenantId],
+          id: `aao_training_agent_${tenantId.replace(/-/g, '_')}`,
+          url: `${agentBase}/${tenantId}/mcp`,
+          jwks_uri: jwksUri,
+          description: tenantAgentDescription[tenantId],
+        })),
+      },
+      brands: [
+        {
+          id: 'adcp_training_agent',
+          names: [{ en_US: 'AdCP Training Agent' }],
+          url: agentBase,
+          keller_type: 'master',
+          industries: ['advertising'],
+          description: 'Reference sandbox for AdCP — multi-tenant agent simulating sales, signals, governance, creative, and brand specialisms for conformance testing and education.',
+        },
+      ],
+      contact: {
+        name: 'AdCP Training Agent',
+        email: 'hello@agenticadvertising.org',
+      },
+      last_updated: STARTUP_TIME,
+    });
+  });
+
   // adagents.json discovery. Schema-conformant per
   // `static/schemas/source/adagents.json`:
   //   - `authorized_agents[]` is a discriminated union — sales agents use

--- a/server/src/training-agent/index.ts
+++ b/server/src/training-agent/index.ts
@@ -306,6 +306,28 @@ const TENANT_SPECIALISMS: Record<typeof TENANT_IDS[number], readonly string[]> =
   brand: ['brand-rights'],
 };
 
+/** Maps each tenant to its brand-agent type for brand.json `agents[]`.
+ *  Values must be valid per `static/schemas/source/enums/brand-agent-type.json`.
+ *  `creative-builder` collapses to `creative` — the enum has no separate
+ *  template/generative type and the description distinguishes them. */
+const TENANT_BRAND_AGENT_TYPE: Record<typeof TENANT_IDS[number], 'sales' | 'signals' | 'governance' | 'creative' | 'brand'> = {
+  sales: 'sales',
+  signals: 'signals',
+  governance: 'governance',
+  creative: 'creative',
+  'creative-builder': 'creative',
+  brand: 'brand',
+};
+
+const TENANT_BRAND_AGENT_DESCRIPTION: Record<typeof TENANT_IDS[number], string> = {
+  sales: 'Training-agent sales tenant — non-guaranteed + guaranteed inventory across simulated publishers',
+  signals: 'Training-agent signals tenant — signal marketplace + owned signals across simulated providers',
+  governance: 'Training-agent governance tenant — spend authority, delivery monitoring, property/collection lists, content standards',
+  creative: 'Training-agent creative tenant — creative ad server',
+  'creative-builder': 'Training-agent creative-builder tenant — creative template + generative',
+  brand: 'Training-agent brand tenant — brand rights and discovery',
+};
+
 export function createTrainingAgentRouter(): Router {
   const router = Router();
 
@@ -558,24 +580,12 @@ export function createTrainingAgentRouter(): Router {
     const agentBase = `${baseUrl}${req.baseUrl}`;
     const jwksUri = `${agentBase}/.well-known/jwks.json`;
 
-    const tenantAgentType: Record<typeof TENANT_IDS[number], string> = {
-      sales: 'sales',
-      signals: 'signals',
-      governance: 'governance',
-      creative: 'creative',
-      'creative-builder': 'creative',
-      brand: 'brand',
-    };
-
-    const tenantAgentDescription: Record<typeof TENANT_IDS[number], string> = {
-      sales: 'Training-agent sales tenant — non-guaranteed + guaranteed inventory across simulated publishers',
-      signals: 'Training-agent signals tenant — signal marketplace + owned signals across simulated providers',
-      governance: 'Training-agent governance tenant — spend authority, delivery monitoring, property/collection lists, content standards',
-      creative: 'Training-agent creative tenant — creative ad server',
-      'creative-builder': 'Training-agent creative-builder tenant — creative template + generative',
-      brand: 'Training-agent brand tenant — brand rights and discovery',
-    };
-
+    // Vary on the forwarding headers `getBaseUrl(req)` reads — a shared cache
+    // that keyed only on path would otherwise serve a poisoned host back to
+    // every subsequent caller (every agents[].url, jwks_uri, brands[0].url is
+    // derived from these headers). Same defense applies to `adagents.json`
+    // below.
+    res.setHeader('Vary', 'X-Forwarded-Host, X-Forwarded-Proto, Host');
     res.setHeader('Cache-Control', 'public, max-age=300');
     res.json({
       $schema: '/schemas/brand.json',
@@ -585,11 +595,11 @@ export function createTrainingAgentRouter(): Router {
         name: 'Ad Context Protocol',
         architecture: 'branded_house',
         agents: TENANT_IDS.map(tenantId => ({
-          type: tenantAgentType[tenantId],
+          type: TENANT_BRAND_AGENT_TYPE[tenantId],
           id: `aao_training_agent_${tenantId.replace(/-/g, '_')}`,
           url: `${agentBase}/${tenantId}/mcp`,
           jwks_uri: jwksUri,
-          description: tenantAgentDescription[tenantId],
+          description: TENANT_BRAND_AGENT_DESCRIPTION[tenantId],
         })),
       },
       brands: [

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -14,7 +14,6 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { createLogger } from '../../logger.js';
 import { runWithSessionContext, flushDirtySessions } from '../state.js';
 import { createRegistryHolder, getCanonicalBase, resolveTenantHost, type RegistryHolder } from './registry.js';
-import { getAggregatedPublicJwks } from './signing.js';
 import { buildSignedRevocationList } from '../governance-revocations.js';
 
 const logger = createLogger('training-agent-tenant-router');
@@ -279,16 +278,12 @@ export function mountTenantRoutes(
     });
   }
 
-  // Aggregated brand.json — lists every tenant's public key with its kid.
-  // SDK validator calls `new URL('/.well-known/brand.json', agentUrl)` which
-  // resolves to host root. For our mount under `/api/training-agent`, the
-  // SDK's validator hits the host root path which is OUTSIDE our router —
-  // so the spike runs with `autoValidate: false` and we only serve this for
-  // discovery / debug introspection.
-  parent.get('/.well-known/brand.json', (_req, res) => {
-    res.setHeader('Cache-Control', 'public, max-age=300');
-    res.json({ jwks: getAggregatedPublicJwks() });
-  });
+  // brand.json discovery is mounted at the parent training-agent router in
+  // `../index.ts` (schema-conformant per `static/schemas/source/brand.json`
+  // oneOf[3]). `getAggregatedPublicJwks()` remains exported for direct
+  // callers (governance-signing tests) — buyer-side fetchers walk the
+  // chain via brand.json `agents[].jwks_uri` pointers instead of an
+  // aggregated top-level JWKS.
 
   // Signed governance revocation list. Spec requires governance agents to
   // publish this at `{origin of iss}/.well-known/governance-revocations.json`;

--- a/server/src/training-agent/tenants/tenant-smoke.test.ts
+++ b/server/src/training-agent/tenants/tenant-smoke.test.ts
@@ -54,13 +54,19 @@ describe('tenant routing smoke', () => {
       // Body content irrelevant — we just need the init handshake to settle
       // before discovery so the JWKS is populated.
       await initR.text();
+      // brand.json is the brand-protocol portfolio document. Each tenant has
+      // an `agents[]` entry under house.agents with type, id, url, jwks_uri.
+      // The signals tenant must appear by id.
       const r = await fetch(`${baseUrl}/.well-known/brand.json`);
       expect(r.status).toBe(200);
-      const body = await r.json() as { jwks: { keys: Array<{ kid: string; alg: string }> } };
-      expect(Array.isArray(body.jwks?.keys)).toBe(true);
-      expect(body.jwks.keys.length).toBeGreaterThan(0);
-      const signalsKid = body.jwks.keys.find(k => k.kid?.includes('signals'));
-      expect(signalsKid).toBeDefined();
+      const body = await r.json() as { house: { agents: Array<{ id: string; type: string; url: string; jwks_uri: string }> } };
+      expect(Array.isArray(body.house?.agents)).toBe(true);
+      expect(body.house.agents.length).toBeGreaterThan(0);
+      const signalsAgent = body.house.agents.find(a => a.id === 'aao_training_agent_signals');
+      expect(signalsAgent).toBeDefined();
+      expect(signalsAgent?.type).toBe('signals');
+      expect(signalsAgent?.url).toMatch(/\/signals\/mcp$/);
+      expect(signalsAgent?.jwks_uri).toMatch(/\/\.well-known\/jwks\.json$/);
     } finally {
       await close();
     }

--- a/server/tests/integration/training-agent-brand-json.test.ts
+++ b/server/tests/integration/training-agent-brand-json.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Integration test for the training agent's `/.well-known/brand.json` discovery
+ * endpoint. Asserts schema-conformant shape per
+ * `static/schemas/source/brand.json` oneOf[3] (house portfolio variant).
+ *
+ * What the verification walkthrough at docs/verification/overview depends on:
+ *   - schema-conformant brand.json served from a well-known path
+ *   - house.agents[] enumerates each tenant with a typed brand_agent_entry
+ *     pointing at the tenant's MCP endpoint and the shared JWKS
+ *   - brands[] declares at least one brand under the house (variant 4 requires
+ *     either brands[] or brand_refs[])
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+vi.hoisted(() => {
+  process.env.PUBLIC_TEST_AGENT_TOKEN = 'test-token-for-brand-json';
+  // `mcp-resolve-base-url.test.ts` sets BASE_URL='/' and other tests in the
+  // same vitest pool may inherit it. We want getBaseUrl(req) to derive
+  // proto/host from the request headers, not from a global override.
+  delete process.env.BASE_URL;
+});
+
+vi.mock('../../src/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+const { createTrainingAgentRouter } = await import('../../src/training-agent/index.js');
+const { stopSessionCleanup } = await import('../../src/training-agent/state.js');
+
+describe('Training Agent /.well-known/brand.json', () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    app = express();
+    app.use('/api/training-agent', createTrainingAgentRouter());
+  });
+
+  afterAll(() => {
+    stopSessionCleanup();
+  });
+
+  it('serves a schema-conformant house portfolio brand.json', async () => {
+    const res = await request(app)
+      .get('/api/training-agent/.well-known/brand.json')
+      .set('Host', 'test-agent.example.org');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+
+    const body = res.body;
+    expect(body.$schema).toBe('/schemas/brand.json');
+    expect(body.version).toBe('1.0');
+
+    expect(body.house).toBeDefined();
+    expect(body.house.domain).toBe('adcontextprotocol.org');
+    expect(body.house.name).toBe('Ad Context Protocol');
+
+    expect(Array.isArray(body.brands)).toBe(true);
+    expect(body.brands.length).toBeGreaterThanOrEqual(1);
+
+    const trainingBrand = body.brands.find((b: { id: string }) => b.id === 'adcp_training_agent');
+    expect(trainingBrand).toBeDefined();
+    expect(trainingBrand.names).toEqual([{ en_US: 'AdCP Training Agent' }]);
+    expect(trainingBrand.keller_type).toBe('master');
+  });
+
+  it('lists every tenant as a typed brand_agent_entry with shared JWKS', async () => {
+    const res = await request(app)
+      .get('/api/training-agent/.well-known/brand.json')
+      .set('Host', 'test-agent.example.org');
+
+    const agents = res.body.house.agents;
+    expect(Array.isArray(agents)).toBe(true);
+
+    const tenants = ['sales', 'signals', 'governance', 'creative', 'creative-builder', 'brand'];
+    for (const tenant of tenants) {
+      const entry = agents.find((a: { url: string }) => a.url.endsWith(`/${tenant}/mcp`));
+      expect(entry, `agents[] entry for tenant=${tenant}`).toBeDefined();
+      expect(entry.id).toBe(`aao_training_agent_${tenant.replace(/-/g, '_')}`);
+      expect(entry.jwks_uri).toMatch(/\/\.well-known\/jwks\.json$/);
+      expect(['sales', 'signals', 'governance', 'creative', 'brand']).toContain(entry.type);
+    }
+  });
+
+  it('caches with public max-age=300', async () => {
+    const res = await request(app)
+      .get('/api/training-agent/.well-known/brand.json')
+      .set('Host', 'test-agent.example.org');
+
+    expect(res.headers['cache-control']).toBe('public, max-age=300');
+  });
+
+  it('JWKS pointed to by brand.json agents[] actually resolves', async () => {
+    const brandRes = await request(app)
+      .get('/api/training-agent/.well-known/brand.json')
+      .set('Host', 'test-agent.example.org');
+
+    const jwksUri = brandRes.body.house.agents[0].jwks_uri;
+    const jwksPath = new URL(jwksUri).pathname;
+
+    const jwksRes = await request(app)
+      .get(jwksPath)
+      .set('Host', 'test-agent.example.org');
+
+    expect(jwksRes.status).toBe(200);
+    expect(Array.isArray(jwksRes.body.keys)).toBe(true);
+    expect(jwksRes.body.keys.length).toBeGreaterThan(0);
+  });
+});

--- a/server/tests/integration/training-agent-brand-json.test.ts
+++ b/server/tests/integration/training-agent-brand-json.test.ts
@@ -1,7 +1,8 @@
 /**
  * Integration test for the training agent's `/.well-known/brand.json` discovery
- * endpoint. Asserts schema-conformant shape per
- * `static/schemas/source/brand.json` oneOf[3] (house portfolio variant).
+ * endpoint. Validates against the canonical brand.json schema
+ * (`static/schemas/source/brand.json` oneOf[3], house portfolio variant) using
+ * Ajv so any future drift between handler and schema fails CI.
  *
  * What the verification walkthrough at docs/verification/overview depends on:
  *   - schema-conformant brand.json served from a well-known path
@@ -10,9 +11,13 @@
  *   - brands[] declares at least one brand under the house (variant 4 requires
  *     either brands[] or brand_refs[])
  */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
 
 vi.hoisted(() => {
   process.env.PUBLIC_TEST_AGENT_TOKEN = 'test-token-for-brand-json';
@@ -34,80 +39,112 @@ vi.mock('../../src/logger.js', () => ({
 const { createTrainingAgentRouter } = await import('../../src/training-agent/index.js');
 const { stopSessionCleanup } = await import('../../src/training-agent/state.js');
 
+const SCHEMA_BASE_DIR = join(process.cwd(), 'static/schemas/source');
+
+/** Compile the published brand.json schema with $ref resolution against the
+ *  local schema tree. Same pattern as `account-handlers.test.ts`. */
+async function compileBrandJsonValidator() {
+  const ajv = new Ajv({
+    allErrors: true,
+    strict: false,
+    loadSchema: async (uri: string) => {
+      if (!uri.startsWith('/schemas/')) throw new Error(`Cannot load: ${uri}`);
+      const p = join(SCHEMA_BASE_DIR, uri.replace('/schemas/', ''));
+      return JSON.parse(readFileSync(p, 'utf8'));
+    },
+  });
+  addFormats(ajv);
+  const schema = JSON.parse(readFileSync(join(SCHEMA_BASE_DIR, 'brand.json'), 'utf8'));
+  return ajv.compileAsync(schema);
+}
+
 describe('Training Agent /.well-known/brand.json', () => {
   let app: express.Application;
+  let body: Record<string, unknown>;
+  let validate: Awaited<ReturnType<typeof compileBrandJsonValidator>>;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     app = express();
     app.use('/api/training-agent', createTrainingAgentRouter());
+    validate = await compileBrandJsonValidator();
+
+    // `X-Forwarded-Proto: https` so URLs in the response match the
+    // `^https://` pattern the brand.json schema enforces on
+    // brand_agent_entry.url and jwks_uri. Production deployments behind
+    // a TLS proxy set this header automatically.
+    const res = await request(app)
+      .get('/api/training-agent/.well-known/brand.json')
+      .set('Host', 'test-agent.example.org')
+      .set('X-Forwarded-Proto', 'https');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+    body = res.body;
   });
 
   afterAll(() => {
     stopSessionCleanup();
   });
 
-  it('serves a schema-conformant house portfolio brand.json', async () => {
-    const res = await request(app)
-      .get('/api/training-agent/.well-known/brand.json')
-      .set('Host', 'test-agent.example.org');
+  it('validates against the published brand.json schema', () => {
+    const ok = validate(body);
+    if (!ok) {
+      const errs = (validate.errors ?? [])
+        .map(e => `${e.instancePath || '(root)'}: ${e.message}`)
+        .join('; ');
+      throw new Error(`brand.json failed schema validation: ${errs}`);
+    }
+    expect(ok).toBe(true);
+  });
 
-    expect(res.status).toBe(200);
-    expect(res.headers['content-type']).toMatch(/application\/json/);
-
-    const body = res.body;
+  it('serves a house portfolio document with the training-agent brand', () => {
     expect(body.$schema).toBe('/schemas/brand.json');
     expect(body.version).toBe('1.0');
 
-    expect(body.house).toBeDefined();
-    expect(body.house.domain).toBe('adcontextprotocol.org');
-    expect(body.house.name).toBe('Ad Context Protocol');
+    const house = body.house as Record<string, unknown>;
+    expect(house.domain).toBe('adcontextprotocol.org');
+    expect(house.name).toBe('Ad Context Protocol');
 
-    expect(Array.isArray(body.brands)).toBe(true);
-    expect(body.brands.length).toBeGreaterThanOrEqual(1);
-
-    const trainingBrand = body.brands.find((b: { id: string }) => b.id === 'adcp_training_agent');
+    const brands = body.brands as Array<Record<string, unknown>>;
+    expect(Array.isArray(brands)).toBe(true);
+    const trainingBrand = brands.find(b => b.id === 'adcp_training_agent');
     expect(trainingBrand).toBeDefined();
-    expect(trainingBrand.names).toEqual([{ en_US: 'AdCP Training Agent' }]);
-    expect(trainingBrand.keller_type).toBe('master');
+    expect(trainingBrand?.keller_type).toBe('master');
   });
 
-  it('lists every tenant as a typed brand_agent_entry with shared JWKS', async () => {
-    const res = await request(app)
-      .get('/api/training-agent/.well-known/brand.json')
-      .set('Host', 'test-agent.example.org');
-
-    const agents = res.body.house.agents;
-    expect(Array.isArray(agents)).toBe(true);
+  it('lists every tenant as a typed brand_agent_entry with shared JWKS', () => {
+    const house = body.house as { agents: Array<{ id: string; type: string; url: string; jwks_uri: string }> };
+    expect(Array.isArray(house.agents)).toBe(true);
 
     const tenants = ['sales', 'signals', 'governance', 'creative', 'creative-builder', 'brand'];
     for (const tenant of tenants) {
-      const entry = agents.find((a: { url: string }) => a.url.endsWith(`/${tenant}/mcp`));
+      const entry = house.agents.find(a => a.url.endsWith(`/${tenant}/mcp`));
       expect(entry, `agents[] entry for tenant=${tenant}`).toBeDefined();
-      expect(entry.id).toBe(`aao_training_agent_${tenant.replace(/-/g, '_')}`);
-      expect(entry.jwks_uri).toMatch(/\/\.well-known\/jwks\.json$/);
-      expect(['sales', 'signals', 'governance', 'creative', 'brand']).toContain(entry.type);
+      expect(entry?.id).toBe(`aao_training_agent_${tenant.replace(/-/g, '_')}`);
+      expect(entry?.jwks_uri).toMatch(/^https:\/\/.+\/\.well-known\/jwks\.json$/);
+      expect(['sales', 'signals', 'governance', 'creative', 'brand']).toContain(entry?.type);
     }
   });
 
-  it('caches with public max-age=300', async () => {
+  it('caches with public max-age=300 and Vary on forwarding headers', async () => {
     const res = await request(app)
       .get('/api/training-agent/.well-known/brand.json')
-      .set('Host', 'test-agent.example.org');
+      .set('Host', 'test-agent.example.org')
+      .set('X-Forwarded-Proto', 'https');
 
     expect(res.headers['cache-control']).toBe('public, max-age=300');
+    expect(res.headers['vary']).toMatch(/X-Forwarded-Host/i);
+    expect(res.headers['vary']).toMatch(/X-Forwarded-Proto/i);
   });
 
   it('JWKS pointed to by brand.json agents[] actually resolves', async () => {
-    const brandRes = await request(app)
-      .get('/api/training-agent/.well-known/brand.json')
-      .set('Host', 'test-agent.example.org');
-
-    const jwksUri = brandRes.body.house.agents[0].jwks_uri;
-    const jwksPath = new URL(jwksUri).pathname;
+    const house = body.house as { agents: Array<{ jwks_uri: string }> };
+    const jwksPath = new URL(house.agents[0].jwks_uri).pathname;
 
     const jwksRes = await request(app)
       .get(jwksPath)
-      .set('Host', 'test-agent.example.org');
+      .set('Host', 'test-agent.example.org')
+      .set('X-Forwarded-Proto', 'https');
 
     expect(jwksRes.status).toBe(200);
     expect(Array.isArray(jwksRes.body.keys)).toBe(true);


### PR DESCRIPTION
## Summary
- Adds a schema-conformant `/.well-known/brand.json` discovery endpoint to the training agent, validating against `static/schemas/source/brand.json` oneOf[3] (house portfolio variant).
- Declares AAO as the house operating the training agent; each tenant's MCP endpoint appears as a typed `brand_agent_entry` with `jwks_uri` pointing at the shared `/.well-known/jwks.json`.
- Replaces an earlier malformed handler in `tenants/router.ts` that served `{ jwks: getAggregatedPublicJwks() }` under the brand.json path — that endpoint pre-dated the brand-protocol schema and was used only for SDK-validator debug introspection (`autoValidate: false`).
- Unblocks step 2 of the seller-verification walkthrough (`docs/verification/overview`, PR #4653) being demoable against the training agent.

## Scope
Single-tier only — no `brand_refs[]`, no `house_domain`. The multi-tier fixture (Sportshaus Holdings → StreamHaus → Northwind from the walkthrough) plus per-publisher `brand.json` endpoints come in follow-up PRs.

## What this is NOT
- Not request-signing on `get_products` (PR #2 in the stack).
- Not the Sportshaus/StreamHaus/Northwind fixture (PR #3).
- Not `verify_brand_claim` (PR #4, optional).

## Test plan
- [x] `server/tests/integration/training-agent-brand-json.test.ts` — schema-conformance, per-tenant agent listing, JWKS resolution, cache headers
- [x] `server/tests/unit/training-agent-governance-signing.test.ts` still passes (kept `getAggregatedPublicJwks()` export)
- [x] `npm run typecheck` clean
- [ ] Hit the endpoint against a running training agent and verify response shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)