### PR TITLE
feat(training-agent): seller-verification walkthrough fixtures

### DIFF
--- a/.changeset/training-agent-verification-walkthrough-fixtures.md
+++ b/.changeset/training-agent-verification-walkthrough-fixtures.md
@@ -1,0 +1,18 @@
+---
+---
+
+feat(training-agent): seller-verification walkthrough fixtures
+
+Adds schema-conformant brand.json / adagents.json fixtures simulating the
+multi-tier chain documented at `docs/verification/overview`:
+
+- **Northwind Media** — independent agency (standalone canonical brand doc, names a signing JWKS)
+- **StreamHaus** — sub-brand publisher (canonical brand doc with `house_domain` pointing at Sportshaus Holdings, `keller_type: "endorsed"`)
+- **StreamHaus's adagents.json** — authorizes Northwind under `delegation_type: "delegated"`, names the signing-key `kid` inline
+- **Sportshaus Holdings** — parent house (house portfolio variant, `brand_refs[]` reciprocates StreamHaus → bilateral mutual assertion closes)
+
+Fixtures live in `server/src/training-agent/fixtures/verification-walkthrough/` as schema-conformant JSON. The TypeScript module exports a typed `WALKTHROUGH_FIXTURES` map for in-process consumers (storyboards, conformance tests). Each document is also served over HTTP at `/fixtures/walkthrough/<role>/.well-known/<doc>` so a buyer agent pointed at the training agent's host can fetch the chain end-to-end against simulated publisher / sub-brand / parent-house surfaces.
+
+Test (`training-agent-verification-walkthrough-fixtures.test.ts`) validates each document against the canonical schema with Ajv and asserts the bilateral parent/sub-brand assertion closes end-to-end (`streamhaus.house_domain ↔ sportshaus.brand_refs[].domain`).
+
+Step 1 of the walkthrough (RFC 9421 signature verification) is blocked on the `signResponse` SDK helper tracked under [adcp-client#1822](https://github.com/adcontextprotocol/adcp-client/issues/1822); steps 2/3/4 (brand.json, adagents.json, parent-house) are now fully demoable.

--- a/server/src/training-agent/fixtures/verification-walkthrough/index.ts
+++ b/server/src/training-agent/fixtures/verification-walkthrough/index.ts
@@ -10,26 +10,20 @@
  *   - Sportshaus Holdings (parent house, brand_refs[] points back at
  *     StreamHaus — completes the bilateral parent/sub-brand assertion)
  *
- * Schema-conformant per `static/schemas/source/{brand,adagents}.json`. The
- * fixture lives in code (TypeScript module) and on disk (sibling `.json`
- * files) — `.json` shape is what gets served at the HTTP endpoints; the
- * module export gives in-process consumers (storyboards, conformance tests)
- * a typed surface.
+ * Schema-conformant per `static/schemas/source/{brand,adagents}.json`. JSON
+ * documents are statically imported so the build emits the data inline and
+ * no filesystem reads happen at runtime — Fly's dist/ layout doesn't copy
+ * sibling JSON, so a `readFileSync` here would crash the route handler.
  */
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import northwindBrand from './northwind-brand.json';
+import streamhausBrand from './streamhaus-brand.json';
+import streamhausAdagents from './streamhaus-adagents.json';
+import sportshausHoldingsBrand from './sportshaus-holdings-brand.json';
 
-const FIXTURE_DIR = dirname(fileURLToPath(import.meta.url));
-
-function load(filename: string): Record<string, unknown> {
-  return JSON.parse(readFileSync(join(FIXTURE_DIR, filename), 'utf8'));
-}
-
-export const NORTHWIND_BRAND_JSON = load('northwind-brand.json');
-export const STREAMHAUS_BRAND_JSON = load('streamhaus-brand.json');
-export const STREAMHAUS_ADAGENTS_JSON = load('streamhaus-adagents.json');
-export const SPORTSHAUS_HOLDINGS_BRAND_JSON = load('sportshaus-holdings-brand.json');
+export const NORTHWIND_BRAND_JSON = northwindBrand;
+export const STREAMHAUS_BRAND_JSON = streamhausBrand;
+export const STREAMHAUS_ADAGENTS_JSON = streamhausAdagents;
+export const SPORTSHAUS_HOLDINGS_BRAND_JSON = sportshausHoldingsBrand;
 
 /** Map of fixture-walkthrough role → served documents. Used by the HTTP
  *  mount in `index.ts` to expose each role's documents under

--- a/server/src/training-agent/fixtures/verification-walkthrough/index.ts
+++ b/server/src/training-agent/fixtures/verification-walkthrough/index.ts
@@ -1,0 +1,50 @@
+/**
+ * Fixture documents for the seller-verification walkthrough at
+ * `docs/verification/overview`. Three brand.json variants + one adagents.json
+ * forming a mutual-assertion chain:
+ *
+ *   - Northwind Media (independent agency, standalone canonical brand doc)
+ *   - StreamHaus (publisher, sub-brand of Sportshaus Holdings via house_domain)
+ *   - StreamHaus's adagents.json (authorizes Northwind to sell with
+ *     delegation_type: "delegated", names Northwind's signing key by kid)
+ *   - Sportshaus Holdings (parent house, brand_refs[] points back at
+ *     StreamHaus — completes the bilateral parent/sub-brand assertion)
+ *
+ * Schema-conformant per `static/schemas/source/{brand,adagents}.json`. The
+ * fixture lives in code (TypeScript module) and on disk (sibling `.json`
+ * files) — `.json` shape is what gets served at the HTTP endpoints; the
+ * module export gives in-process consumers (storyboards, conformance tests)
+ * a typed surface.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const FIXTURE_DIR = dirname(fileURLToPath(import.meta.url));
+
+function load(filename: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(FIXTURE_DIR, filename), 'utf8'));
+}
+
+export const NORTHWIND_BRAND_JSON = load('northwind-brand.json');
+export const STREAMHAUS_BRAND_JSON = load('streamhaus-brand.json');
+export const STREAMHAUS_ADAGENTS_JSON = load('streamhaus-adagents.json');
+export const SPORTSHAUS_HOLDINGS_BRAND_JSON = load('sportshaus-holdings-brand.json');
+
+/** Map of fixture-walkthrough role → served documents. Used by the HTTP
+ *  mount in `index.ts` to expose each role's documents under
+ *  `/fixtures/walkthrough/<role>/.well-known/<doc>`. */
+export const WALKTHROUGH_FIXTURES = {
+  northwind: {
+    'brand.json': NORTHWIND_BRAND_JSON,
+  },
+  streamhaus: {
+    'brand.json': STREAMHAUS_BRAND_JSON,
+    'adagents.json': STREAMHAUS_ADAGENTS_JSON,
+  },
+  'sportshaus-holdings': {
+    'brand.json': SPORTSHAUS_HOLDINGS_BRAND_JSON,
+  },
+} as const satisfies Record<string, Record<string, Record<string, unknown>>>;
+
+export type WalkthroughRole = keyof typeof WALKTHROUGH_FIXTURES;

--- a/server/src/training-agent/fixtures/verification-walkthrough/northwind-brand.json
+++ b/server/src/training-agent/fixtures/verification-walkthrough/northwind-brand.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "/schemas/brand.json",
+  "version": "1.0",
+  "id": "northwind_media",
+  "names": [{ "en_US": "Northwind Media" }],
+  "url": "https://northwind.example",
+  "keller_type": "master",
+  "industries": ["advertising"],
+  "description": "Independent agency representing publisher inventory under delegated authority. Fixture for the seller-verification walkthrough (docs/verification/overview).",
+  "agents": [
+    {
+      "type": "sales",
+      "id": "northwind_sales",
+      "url": "https://northwind.example/mcp",
+      "jwks_uri": "https://northwind.example/.well-known/jwks.json",
+      "description": "Northwind Media sales agent — sells StreamHaus CTV inventory under delegated authority."
+    }
+  ],
+  "last_updated": "2026-04-12T10:00:00Z"
+}

--- a/server/src/training-agent/fixtures/verification-walkthrough/sportshaus-holdings-brand.json
+++ b/server/src/training-agent/fixtures/verification-walkthrough/sportshaus-holdings-brand.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "/schemas/brand.json",
+  "version": "1.0",
+  "house": {
+    "domain": "sportshaus-holdings.example",
+    "name": "Sportshaus Holdings",
+    "architecture": "branded_house"
+  },
+  "brand_refs": [
+    { "domain": "streamhaus.example", "brand_id": "streamhaus", "effective_at": "2025-01-01T00:00:00Z" },
+    { "domain": "courtsidehq.example", "brand_id": "courtsidehq" }
+  ],
+  "contact": {
+    "name": "Sportshaus Brand Operations",
+    "email": "brands@sportshaus-holdings.example"
+  },
+  "last_updated": "2026-04-12T10:00:00Z"
+}

--- a/server/src/training-agent/fixtures/verification-walkthrough/sportshaus-holdings-brand.json
+++ b/server/src/training-agent/fixtures/verification-walkthrough/sportshaus-holdings-brand.json
@@ -4,7 +4,7 @@
   "house": {
     "domain": "sportshaus-holdings.example",
     "name": "Sportshaus Holdings",
-    "architecture": "branded_house"
+    "architecture": "house_of_brands"
   },
   "brand_refs": [
     { "domain": "streamhaus.example", "brand_id": "streamhaus", "effective_at": "2025-01-01T00:00:00Z" },

--- a/server/src/training-agent/fixtures/verification-walkthrough/streamhaus-adagents.json
+++ b/server/src/training-agent/fixtures/verification-walkthrough/streamhaus-adagents.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "/schemas/adagents.json",
+  "contact": {
+    "name": "StreamHaus Publishing",
+    "email": "adops@streamhaus.example",
+    "domain": "streamhaus.example"
+  },
+  "properties": [
+    {
+      "property_id": "streamhaus_ctv",
+      "property_type": "ctv_app",
+      "name": "StreamHaus CTV App",
+      "publisher_domain": "streamhaus.example",
+      "identifiers": [
+        { "type": "roku_store_id", "value": "12345" },
+        { "type": "domain", "value": "streamhaus.example" }
+      ]
+    }
+  ],
+  "authorized_agents": [
+    {
+      "url": "https://northwind.example/mcp",
+      "authorized_for": "StreamHaus CTV inventory via delegated authority",
+      "authorization_type": "property_ids",
+      "property_ids": ["streamhaus_ctv"],
+      "delegation_type": "delegated",
+      "signing_keys": [
+        {
+          "kid": "northwind-sell-prod-2026",
+          "kty": "OKP",
+          "alg": "EdDSA",
+          "crv": "Ed25519",
+          "x": "Xe2lAKRJR_zr3FQRdSNwp3zsrv_IXnVCWJXDcWXwkLI",
+          "use": "sig"
+        }
+      ]
+    }
+  ],
+  "last_updated": "2026-04-12T10:00:00Z"
+}

--- a/server/src/training-agent/fixtures/verification-walkthrough/streamhaus-brand.json
+++ b/server/src/training-agent/fixtures/verification-walkthrough/streamhaus-brand.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "/schemas/brand.json",
+  "version": "1.0",
+  "id": "streamhaus",
+  "names": [{ "en_US": "StreamHaus" }],
+  "url": "https://streamhaus.example",
+  "house_domain": "sportshaus-holdings.example",
+  "keller_type": "endorsed",
+  "industries": ["media", "broadcasting"],
+  "description": "Sports CTV publisher; sub-brand of Sportshaus Holdings under an endorsed Keller-architecture relationship. Fixture for the seller-verification walkthrough.",
+  "agents": [
+    {
+      "type": "sales",
+      "id": "streamhaus_sales",
+      "url": "https://streamhaus.example/mcp",
+      "jwks_uri": "https://streamhaus.example/.well-known/jwks.json",
+      "description": "StreamHaus internal sales agent — publisher-direct path. Most inventory routes through Northwind Media under delegated authority (see adagents.json)."
+    }
+  ],
+  "last_updated": "2026-04-12T10:00:00Z"
+}

--- a/server/src/training-agent/index.ts
+++ b/server/src/training-agent/index.ts
@@ -38,6 +38,7 @@ import type { TrainingContext } from './types.js';
 import { PUBLISHERS } from './publishers.js';
 import { SIGNAL_PROVIDERS } from './signal-providers.js';
 import { getPublicJwks } from './webhooks.js';
+import { WALKTHROUGH_FIXTURES } from './fixtures/verification-walkthrough/index.js';
 import {
   buildRequestSigningAuthenticator,
   buildStrictRequestSigningAuthenticator,
@@ -619,6 +620,23 @@ export function createTrainingAgentRouter(): Router {
       last_updated: STARTUP_TIME,
     });
   });
+
+  // Verification-walkthrough fixtures — schema-conformant brand.json /
+  // adagents.json documents simulating the multi-tier chain from
+  // docs/verification/overview (Northwind / StreamHaus / Sportshaus Holdings).
+  // Mounted at /fixtures/walkthrough/<role>/.well-known/<doc> so a buyer
+  // agent can be pointed at the training agent's host and walk the chain
+  // end-to-end against simulated publisher / sub-brand / parent-house
+  // surfaces.
+  for (const [role, docs] of Object.entries(WALKTHROUGH_FIXTURES)) {
+    for (const [filename, body] of Object.entries(docs)) {
+      router.get(`/fixtures/walkthrough/${role}/.well-known/${filename}`, (_req: Request, res: Response) => {
+        res.setHeader('Vary', 'X-Forwarded-Host, X-Forwarded-Proto, Host');
+        res.setHeader('Cache-Control', 'public, max-age=300');
+        res.json(body);
+      });
+    }
+  }
 
   // adagents.json discovery. Schema-conformant per
   // `static/schemas/source/adagents.json`:

--- a/server/src/training-agent/index.ts
+++ b/server/src/training-agent/index.ts
@@ -628,9 +628,22 @@ export function createTrainingAgentRouter(): Router {
   // agent can be pointed at the training agent's host and walk the chain
   // end-to-end against simulated publisher / sub-brand / parent-house
   // surfaces.
+  //
+  // `X-Robots-Tag: noindex` so search engines don't index these as if the
+  // fictional publishers were real. The fixtures' `description` fields and
+  // `*.example` domains carry the "test artifact" framing in-body — adding
+  // a top-level `x_test_fixture` flag would fail brand.json oneOf[3]'s
+  // `additionalProperties: false`.
   for (const [role, docs] of Object.entries(WALKTHROUGH_FIXTURES)) {
     for (const [filename, body] of Object.entries(docs)) {
-      router.get(`/fixtures/walkthrough/${role}/.well-known/${filename}`, (_req: Request, res: Response) => {
+      const path = `/fixtures/walkthrough/${role}/.well-known/${filename}`;
+      router.options(path, (_req: Request, res: Response) => {
+        setLegacyCORS(res);
+        res.status(204).end();
+      });
+      router.get(path, (_req: Request, res: Response) => {
+        setLegacyCORS(res);
+        res.setHeader('X-Robots-Tag', 'noindex');
         res.setHeader('Vary', 'X-Forwarded-Host, X-Forwarded-Proto, Host');
         res.setHeader('Cache-Control', 'public, max-age=300');
         res.json(body);

--- a/server/tests/integration/training-agent-verification-walkthrough-fixtures.test.ts
+++ b/server/tests/integration/training-agent-verification-walkthrough-fixtures.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Integration test for the verification-walkthrough fixture documents. Three
+ * brand.json variants + one adagents.json forming the bilateral mutual-
+ * assertion chain documented at `docs/verification/overview`. Each fixture
+ * is validated against the canonical schema with Ajv, and the cross-document
+ * bilateral invariants are spot-checked end-to-end.
+ *
+ * What the walkthrough's steps depend on:
+ *   - step 2: northwind brand.json is fetchable, names its signing JWKS
+ *   - step 3: streamhaus adagents.json authorizes northwind with
+ *     delegation_type "delegated" and names the signing key by kid
+ *   - step 4: streamhaus brand.json declares house_domain, sportshaus
+ *     brand.json reciprocates with a matching brand_refs[] entry (bilateral
+ *     parent/sub-brand assertion)
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+
+vi.hoisted(() => {
+  process.env.PUBLIC_TEST_AGENT_TOKEN = 'test-token-for-walkthrough-fixtures';
+  delete process.env.BASE_URL;
+});
+
+vi.mock('../../src/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+const { createTrainingAgentRouter } = await import('../../src/training-agent/index.js');
+const { stopSessionCleanup } = await import('../../src/training-agent/state.js');
+
+const SCHEMA_BASE_DIR = join(process.cwd(), 'static/schemas/source');
+
+async function compileSchema(schemaPath: string) {
+  const ajv = new Ajv({
+    allErrors: true,
+    strict: false,
+    loadSchema: async (uri: string) => {
+      if (!uri.startsWith('/schemas/')) throw new Error(`Cannot load: ${uri}`);
+      const p = join(SCHEMA_BASE_DIR, uri.replace('/schemas/', ''));
+      return JSON.parse(readFileSync(p, 'utf8'));
+    },
+  });
+  addFormats(ajv);
+  const schema = JSON.parse(readFileSync(join(SCHEMA_BASE_DIR, schemaPath), 'utf8'));
+  return ajv.compileAsync(schema);
+}
+
+function explainErrors(errors: Ajv['errors']) {
+  return (errors ?? [])
+    .map(e => `${e.instancePath || '(root)'}: ${e.message}`)
+    .join('; ');
+}
+
+describe('Verification-walkthrough fixtures', () => {
+  let app: express.Application;
+  let validateBrand: Awaited<ReturnType<typeof compileSchema>>;
+  let validateAdagents: Awaited<ReturnType<typeof compileSchema>>;
+
+  async function fetchFixture(path: string): Promise<Record<string, unknown>> {
+    const res = await request(app)
+      .get(`/api/training-agent${path}`)
+      .set('Host', 'test-agent.example.org')
+      .set('X-Forwarded-Proto', 'https');
+    expect(res.status, `GET ${path}`).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+    return res.body;
+  }
+
+  beforeAll(async () => {
+    app = express();
+    app.use('/api/training-agent', createTrainingAgentRouter());
+    validateBrand = await compileSchema('brand.json');
+    validateAdagents = await compileSchema('adagents.json');
+  });
+
+  afterAll(() => {
+    stopSessionCleanup();
+  });
+
+  it("northwind brand.json validates and names a signing JWKS", async () => {
+    const body = await fetchFixture('/fixtures/walkthrough/northwind/.well-known/brand.json');
+    const ok = validateBrand(body);
+    if (!ok) throw new Error(`northwind brand.json invalid: ${explainErrors(validateBrand.errors)}`);
+
+    expect(body.id).toBe('northwind_media');
+    expect(body.url).toBe('https://northwind.example');
+    expect(body.house_domain).toBeUndefined();   // standalone agency, no parent
+    const agents = body.agents as Array<Record<string, string>>;
+    expect(agents[0].type).toBe('sales');
+    expect(agents[0].jwks_uri).toBe('https://northwind.example/.well-known/jwks.json');
+  });
+
+  it('streamhaus brand.json validates and declares the parent house_domain', async () => {
+    const body = await fetchFixture('/fixtures/walkthrough/streamhaus/.well-known/brand.json');
+    const ok = validateBrand(body);
+    if (!ok) throw new Error(`streamhaus brand.json invalid: ${explainErrors(validateBrand.errors)}`);
+
+    expect(body.id).toBe('streamhaus');
+    expect(body.house_domain).toBe('sportshaus-holdings.example');
+    expect(body.keller_type).toBe('endorsed');
+  });
+
+  it('sportshaus-holdings brand.json validates and reciprocates streamhaus', async () => {
+    const body = await fetchFixture('/fixtures/walkthrough/sportshaus-holdings/.well-known/brand.json');
+    const ok = validateBrand(body);
+    if (!ok) throw new Error(`sportshaus brand.json invalid: ${explainErrors(validateBrand.errors)}`);
+
+    const house = body.house as Record<string, string>;
+    expect(house.domain).toBe('sportshaus-holdings.example');
+    const refs = body.brand_refs as Array<Record<string, string>>;
+    const streamhausRef = refs.find(r => r.domain === 'streamhaus.example');
+    expect(streamhausRef).toBeDefined();
+    expect(streamhausRef?.brand_id).toBe('streamhaus');
+  });
+
+  it("streamhaus adagents.json validates and authorizes northwind by delegation_type", async () => {
+    const body = await fetchFixture('/fixtures/walkthrough/streamhaus/.well-known/adagents.json');
+    const ok = validateAdagents(body);
+    if (!ok) throw new Error(`streamhaus adagents.json invalid: ${explainErrors(validateAdagents.errors)}`);
+
+    const agents = body.authorized_agents as Array<Record<string, unknown>>;
+    const northwindEntry = agents.find(a => (a.url as string).startsWith('https://northwind.example'));
+    expect(northwindEntry).toBeDefined();
+    expect(northwindEntry?.delegation_type).toBe('delegated');
+    expect(northwindEntry?.authorization_type).toBe('property_ids');
+    expect(northwindEntry?.property_ids).toEqual(['streamhaus_ctv']);
+  });
+
+  it('bilateral parent / sub-brand assertion closes (streamhaus ↔ sportshaus-holdings)', async () => {
+    const child = await fetchFixture('/fixtures/walkthrough/streamhaus/.well-known/brand.json');
+    const parent = await fetchFixture('/fixtures/walkthrough/sportshaus-holdings/.well-known/brand.json');
+
+    const childHouseDomain = child.house_domain as string;
+    const parentHouse = parent.house as { domain: string };
+    expect(childHouseDomain).toBe(parentHouse.domain);
+
+    const refs = parent.brand_refs as Array<{ domain: string; brand_id: string }>;
+    const matchingRef = refs.find(r => r.domain === (new URL(child.url as string).hostname));
+    expect(matchingRef, 'parent brand_refs[] must include the child by domain').toBeDefined();
+    expect(matchingRef?.brand_id).toBe(child.id);
+  });
+
+  it('caches with public max-age=300 and Vary on forwarding headers', async () => {
+    const res = await request(app)
+      .get('/api/training-agent/fixtures/walkthrough/northwind/.well-known/brand.json')
+      .set('Host', 'test-agent.example.org')
+      .set('X-Forwarded-Proto', 'https');
+
+    expect(res.headers['cache-control']).toBe('public, max-age=300');
+    expect(res.headers['vary']).toMatch(/X-Forwarded-Host/i);
+    expect(res.headers['vary']).toMatch(/X-Forwarded-Proto/i);
+  });
+});

--- a/server/tests/integration/training-agent-verification-walkthrough-fixtures.test.ts
+++ b/server/tests/integration/training-agent-verification-walkthrough-fixtures.test.ts
@@ -129,7 +129,7 @@ describe('Verification-walkthrough fixtures', () => {
     if (!ok) throw new Error(`streamhaus adagents.json invalid: ${explainErrors(validateAdagents.errors)}`);
 
     const agents = body.authorized_agents as Array<Record<string, unknown>>;
-    const northwindEntry = agents.find(a => (a.url as string).startsWith('https://northwind.example'));
+    const northwindEntry = agents.find(a => new URL(a.url as string).hostname === 'northwind.example');
     expect(northwindEntry).toBeDefined();
     expect(northwindEntry?.delegation_type).toBe('delegated');
     expect(northwindEntry?.authorization_type).toBe('property_ids');


### PR DESCRIPTION
## Summary
- Schema-conformant brand.json / adagents.json fixtures simulating the multi-tier chain documented at `docs/verification/overview` (Northwind / StreamHaus / Sportshaus Holdings).
- Exposed via HTTP at `/fixtures/walkthrough/<role>/.well-known/<doc>` so a buyer agent can fetch the chain end-to-end against the training agent's host.
- TypeScript module exports `WALKTHROUGH_FIXTURES` for in-process consumers (storyboards, conformance tests).
- All four documents validated against the canonical schema with Ajv; bilateral parent/sub-brand assertion is asserted end-to-end (`streamhaus.house_domain ↔ sportshaus.brand_refs[].domain`).

## Walkthrough mapping

| Walkthrough step | Document | Fixture |
|---|---|---|
| Step 2: read seller's brand.json | Northwind brand.json | `northwind-brand.json` |
| Step 3: confirm against adagents.json | StreamHaus adagents.json | `streamhaus-adagents.json` |
| Step 4: walk parent house | StreamHaus brand.json + Sportshaus brand.json | `streamhaus-brand.json` + `sportshaus-holdings-brand.json` |

Step 1 (RFC 9421 signature verification) is blocked on the `signResponse` SDK helper — tracked in [adcp-client#1822](https://github.com/adcontextprotocol/adcp-client/issues/1822). Steps 2/3/4 are demoable today against this PR.

## Stack
- PR #1 (#4671, merged): serve `/.well-known/brand.json` from the training agent
- **PR #3 (this)**: multi-tier walkthrough fixtures
- PR #2 (blocked on adcp-client#1822): RFC 9421 sign `get_products` responses
- PR #4 (optional): `verify_brand_claim` implementation against this fixture

## Test plan
- [x] `training-agent-verification-walkthrough-fixtures.test.ts` — schema validation, bilateral assertion, cache + Vary headers
- [x] `npm run typecheck` clean
- [ ] Curl each `/fixtures/walkthrough/<role>/.well-known/<doc>` against a running training agent; verify response bodies match committed JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)