### PR TITLE
perf(registry): hoist verified-domain query out of bulk hostname check (closes #4673)

### DIFF
--- a/.changeset/hostname-verify-bulk-perf.md
+++ b/.changeset/hostname-verify-bulk-perf.md
@@ -1,0 +1,4 @@
+---
+---
+
+Refactor `verifyAgentHostname` into a two-call shape so bulk callers (bulk PUT `/api/me/member-profile`, POST create) issue one query for the verified-domain list and then run a pure in-memory check per agent — N agents now cost one round-trip instead of N. `getVerifiedOrgDomains(orgId)` fetches; `checkAgentHostnameAgainstDomains(url, domains, orgId?)` is pure. `verifyAgentHostname` remains as a single-agent convenience wrapper for unchanged call sites (REST POST, `save_agent` MCP, visibility flip). Closes #4673.

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -33,6 +33,8 @@ import { slugify } from "../services/collection-feed-sync.js";
 import {
   verifyAgentHostname,
   buildUnverifiedHostnameMessage,
+  checkAgentHostnameAgainstDomains,
+  getVerifiedOrgDomains,
   isHostnameOwnershipRejection,
 } from "../services/agent-hostname-verification.js";
 import {
@@ -972,15 +974,20 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       // the bulk PUT). No grandfathering is needed here — this branch
       // creates a fresh profile, so there are no existing entries to
       // honor. All agents in the body are NEW writes.
-      if (Array.isArray(agents)) {
+      //
+      // Bulk shape (#4673): one query for the verified-domain list
+      // before the loop, pure check inside. Avoids N+1 queries when
+      // the caller submits many agents at once.
+      if (Array.isArray(agents) && agents.length > 0) {
+        const verifiedDomains = await getVerifiedOrgDomains(targetOrgId);
         for (let i = 0; i < agents.length; i++) {
           // Canonicalization loop above 400s on any entry without a
           // string `url`, so by here every `agents[i].url` is a
-          // canonical string. Use a non-null assertion to satisfy TS
+          // canonical string. Cast at the call site to satisfy TS
           // without a conditional that CodeQL classifies as a
           // user-controlled bypass.
           const agentUrl = (agents[i] as AgentConfig).url as string;
-          const verification = await verifyAgentHostname(targetOrgId, agentUrl);
+          const verification = checkAgentHostnameAgainstDomains(agentUrl, verifiedDomains, targetOrgId);
           if (isHostnameOwnershipRejection(verification)) {
             return res.status(400).json({
               error: 'unverified_hostname',
@@ -1281,6 +1288,10 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
             })
             .filter((u): u is string => u !== null),
         );
+        // Bulk shape (#4673): one query for the verified-domain list
+        // before the loop, pure check inside. Avoids N+1 queries when
+        // the bulk caller submits many agents at once.
+        const bulkVerifiedDomains = await getVerifiedOrgDomains(targetOrgId);
         for (let i = 0; i < updates.agents.length; i++) {
           // Canonicalization loop above 400s on any entry without a
           // string `url`, so by here every `updates.agents[i].url` is a
@@ -1289,7 +1300,7 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
           // user-controlled bypass.
           const agentUrl = (updates.agents[i] as AgentConfig).url as string;
           if (existingUrls.has(agentUrl)) continue;
-          const verification = await verifyAgentHostname(targetOrgId, agentUrl);
+          const verification = checkAgentHostnameAgainstDomains(agentUrl, bulkVerifiedDomains, targetOrgId);
           if (isHostnameOwnershipRejection(verification)) {
             return res.status(400).json({
               error: 'unverified_hostname',

--- a/server/src/services/agent-hostname-verification.ts
+++ b/server/src/services/agent-hostname-verification.ts
@@ -52,10 +52,34 @@ export type AgentHostnameVerification =
       verified_domains: string[];
     };
 
-export async function verifyAgentHostname(
-  orgId: string,
+/**
+ * Fetch the verified-domain list for an org, lowercased. Used as the
+ * input to `checkAgentHostnameAgainstDomains` so bulk callers (bulk
+ * PUT, POST create) can issue ONE query for N agents instead of N
+ * queries. Single-agent paths should call `verifyAgentHostname`
+ * directly.
+ */
+export async function getVerifiedOrgDomains(orgId: string): Promise<string[]> {
+  const pool = getPool();
+  const r = await pool.query<{ domain: string }>(
+    `SELECT domain FROM organization_domains
+     WHERE workos_organization_id = $1 AND verified = true`,
+    [orgId],
+  );
+  return r.rows.map((row) => row.domain.toLowerCase());
+}
+
+/**
+ * Pure hostname-check against a pre-fetched verified-domain list.
+ * No I/O. `verifiedDomains` is expected lowercased (matches what
+ * `getVerifiedOrgDomains` returns). `orgId` is informational, only
+ * used in the rejection log.
+ */
+export function checkAgentHostnameAgainstDomains(
   agentUrl: string,
-): Promise<AgentHostnameVerification> {
+  verifiedDomains: string[],
+  orgId?: string,
+): AgentHostnameVerification {
   let hostname: string;
   try {
     hostname = new URL(agentUrl).hostname.toLowerCase();
@@ -75,14 +99,6 @@ export async function verifyAgentHostname(
       verified_domains: [],
     };
   }
-
-  const pool = getPool();
-  const r = await pool.query<{ domain: string }>(
-    `SELECT domain FROM organization_domains
-     WHERE workos_organization_id = $1 AND verified = true`,
-    [orgId],
-  );
-  const verifiedDomains = r.rows.map((row) => row.domain.toLowerCase());
 
   if (verifiedDomains.length === 0) {
     logger.warn(
@@ -113,6 +129,19 @@ export async function verifyAgentHostname(
     agent_hostname: hostname,
     verified_domains: verifiedDomains,
   };
+}
+
+/**
+ * Single-agent convenience wrapper. Bulk callers should prefer
+ * `getVerifiedOrgDomains` + `checkAgentHostnameAgainstDomains` to
+ * avoid N+1 queries.
+ */
+export async function verifyAgentHostname(
+  orgId: string,
+  agentUrl: string,
+): Promise<AgentHostnameVerification> {
+  const verifiedDomains = await getVerifiedOrgDomains(orgId);
+  return checkAgentHostnameAgainstDomains(agentUrl, verifiedDomains, orgId);
 }
 
 /**


### PR DESCRIPTION
## Summary

The hostname-verification gate added in #4648 ran one query against `organization_domains` per agent in the bulk PUT and POST-create payloads. Round-3 security review flagged the N+1 shape.

Split `verifyAgentHostname` into:
- **`getVerifiedOrgDomains(orgId)`** — one query, returns lowercased domain list
- **`checkAgentHostnameAgainstDomains(url, domains, orgId?)`** — pure, in-memory hostname match

`verifyAgentHostname(orgId, url)` becomes a thin wrapper that calls both in sequence — keeps the single-agent paths (REST POST, save_agent MCP, visibility flip) unchanged.

Bulk PUT and POST create now hoist `getVerifiedOrgDomains` out of the per-agent loop; N agents = 1 query instead of N.

## Test plan

- [x] All 72 existing hostname-verification + agent-route tests pass
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)