### PR TITLE
docs+compliance: 3.1 release notes + version-negotiation storyboard (#3570)

### DIFF
--- a/.changeset/3570-version-negotiation-docs-and-storyboard.md
+++ b/.changeset/3570-version-negotiation-docs-and-storyboard.md
@@ -1,0 +1,8 @@
+---
+---
+
+Docs + compliance only — no schema or runtime impact, no SDK release required.
+
+3.1 release-notes entry for release-precision version negotiation (#3493) and new universal storyboard (`version_negotiation`) reporting `adcp.supported_versions` advertisement and `adcp_version` envelope echo. Both new validations ship advisory per the migration table in `docs/reference/versioning.mdx`; promotion to required is a separate PR at the 3.2 storyboard cut.
+
+Refs #3570.

--- a/docs/reference/release-notes.mdx
+++ b/docs/reference/release-notes.mdx
@@ -99,36 +99,37 @@ See [Metric lifecycle](/docs/media-buy/media-buys/optimization-reporting#metric-
 
 `adcp_major_version` (the 3.0 integer field) and `adcp.major_versions` remain functional through all of 3.x — additive ship, no required changes for 3.0-conformant agents. The full migration table lives in [Versioning & Governance § Migration timeline](/docs/reference/versioning#migration-timeline).
 
-**Pin your release.** Every SDK exposes a constructor option for the version pin. Through 3.x, the SDK SHOULD also emit `adcp_major_version` automatically so legacy 3.x sellers that only read the integer keep negotiating correctly.
+**Pin your release.** Every SDK exposes a constructor option for the version pin. Through 3.x, the SDK SHOULD also emit `adcp_major_version` automatically so legacy 3.x sellers that only read the integer keep negotiating correctly. The wire shape is **release-precision only** (`"3.1"`, `"3.1-beta.1"`) — full semver like `"3.1.2"` or `"3.1.0-beta.1"` is invalid on the wire.
 
 ```typescript
-// @adcp/client (TypeScript)
-import { AdcpClient } from "@adcp/client";
+// @adcp/sdk (TypeScript)
+import { SingleAgentClient } from "@adcp/sdk";
 
-const client = new AdcpClient({
-  endpoint: "https://sales.example/.well-known/agent.json",
-  adcpVersion: "3.1",      // emitted on every request as adcp_version
-                           // adcp_major_version: 3 mirror auto-emitted
-});
+const client = new SingleAgentClient(
+  { agent_uri: "https://sales.example/mcp/", protocol: "mcp" },
+  { adcpVersion: "3.1" },   // emitted on every request as adcp_version
+                            // adcp_major_version: 3 mirror auto-emitted
+);
 ```
 
 ```python
 # adcp (Python)
-from adcp import AdcpClient
+from adcp import ADCPClient
+from adcp.types import AgentConfig, Protocol
 
-client = AdcpClient(
-    endpoint="https://sales.example/.well-known/agent.json",
-    adcp_version="3.1",    # emitted on every request as adcp_version
-                           # adcp_major_version: 3 mirror auto-emitted
+client = ADCPClient(
+    AgentConfig(agent_uri="https://sales.example/mcp/", protocol=Protocol.MCP),
+    adcp_version="3.1",     # emitted on every request as adcp_version
+                            # adcp_major_version: 3 mirror auto-emitted
 )
 ```
 
 ```go
-// adcp-go (Go)
+// adcp-go (Go) — planned, tracked in adcontextprotocol/adcp-go#107
 import "github.com/adcontextprotocol/adcp-go/adcp"
 
 client, err := adcp.NewClient(
-    "https://sales.example/.well-known/agent.json",
+    "https://sales.example/mcp/",
     adcp.WithAdcpVersion("3.1"), // emitted on every request as adcp_version
                                   // AdcpMajorVersion: 3 mirror auto-emitted
 )
@@ -140,7 +141,7 @@ client, err := adcp.NewClient(
 
 **Wire shape is release-precision only.** `"3.1.2"`, `"3.1.0-beta.1"`, `"v3.1"`, and `"3"` are all invalid on the wire. SDKs that key bundles by full semver MUST normalize to release-precision (`"3.1.0-beta.1"` → `"3.1-beta.1"`) before emitting — the `published_version` field on meta-objects (schema registry, tarball `manifest.json`, compliance index, `/protocol/` discovery) is documentation, not a wire value. See [Versioning § Patches are not negotiated](/docs/reference/versioning#patches-are-not-negotiated) for the full wire-shape rule.
 
-**Compliance grader at 3.1 is advisory.** The grader runs the new `version_negotiation` universal storyboard and reports presence on requests and responses. Sellers SHOULD echo `adcp_version` and SHOULD declare `adcp.supported_versions` on `get_adcp_capabilities`; the storyboard reports missing entries without failing certification. At 3.2 the grader flips to blocking failure — sellers aiming for 3.2 certification ship the echo and the capability declaration during the 3.1 window. At 4.0 the spec promotes both to MUST and the legacy integer fields are removed.
+**Compliance grader at 3.1 is advisory.** The grader runs the new `version_negotiation` universal storyboard and reports presence on requests and responses — see the [migration timeline](/docs/reference/versioning#migration-timeline) for the 3.1 → 3.2 → 4.0 cadence.
 
 Spec PR [#3493](https://github.com/adcontextprotocol/adcp/pull/3493). RFC: [`specs/version-negotiation.md`](https://github.com/adcontextprotocol/adcp/blob/main/specs/version-negotiation.md). Full normative reference: [Versioning & Governance § Version negotiation](/docs/reference/versioning#version-negotiation).
 

--- a/docs/reference/release-notes.mdx
+++ b/docs/reference/release-notes.mdx
@@ -31,6 +31,7 @@ Additive over 3.0 — every existing brand.json publisher continues to validate 
 | A house running the AAO crawler today (or any consumer that walks brand hierarchy) | Read [`brand.json` § Mutual-assertion trust model](/docs/brand-protocol/brand-json#mutual-assertion-trust-model). The 3-tier read — identity-trusted vs relationship-trusted vs unverified — replaces the binary "is this in my portfolio" check for `brand_refs[]` pointer children. The 180-day TTL is already AAO's reference behavior. |
 | A publisher using free-text `status` or `countries` on `trademarks[]` entries | Move `status` values to the enum (`active`, `pending`, `abandoned`, `cancelled`, `expired`) and `countries` values to ISO 3166-1 alpha-2 codes. The fields were untyped via `additionalProperties: true`; they're now typed. Non-conforming values surface validation errors. |
 | An agency named in a house's `managed_by` claim | Nothing required at the protocol level. Aggregation by `managed_by` ("show me everything BBH manages") is the intended use; trust is not extended through it. Manager-side reciprocation is tracked as a follow-up. |
+| Building an SDK or in-house client against AdCP 3.x | Pin to a release via the constructor (`adcpVersion: "3.1"` / `adcp_version="3.1"` / `WithAdcpVersion("3.1")`) and emit `adcp_version` on every request alongside the `adcp_major_version` mirror. Read `supported_versions` from the seller's `get_adcp_capabilities` response; expect a `VERSION_UNSUPPORTED` typed error when your pin isn't in the list. See [Release-precision version negotiation](#release-precision-version-negotiation--pin-your-release-3493) below. |
 
 ### Distributed `brand.json` — new 5th variant and `brand_refs[]` (#4505, closes #3409 / #3533 / #3764 / #3910 / #3909)
 
@@ -91,6 +92,57 @@ End-to-end vendor binding for optimization goals against vendor-attested measure
 **Deprecation.** `attention_seconds` and `attention_score` remain in the `metric` enum on `optimization-goal.json` and on `product.json` `metric_optimization.supported_metrics` for backwards compatibility this minor, marked **deprecated** in their descriptions. Slated for removal at next major. Sellers MAY reject the deprecated values with `TERMS_REJECTED` and a pointer to the `vendor_metric` kind. Same deprecation pattern used for `delivery_measurement.provider` → `vendors[]`.
 
 See [Metric lifecycle](/docs/media-buy/media-buys/optimization-reporting#metric-lifecycle) for the full capability → commitment → optimization → delivery picture and [`kind: vendor_metric`](/docs/media-buy/conversion-tracking/#kind-vendor_metric) for the goal-shape reference.
+
+### Release-precision version negotiation — pin your release (#3493)
+
+3.1 lands release-precision (`VERSION.RELEASE`, e.g. `"3.1"`) version negotiation on every request and response, with multi-release advertisement on capabilities. Buyers pin the release their payloads conform to; sellers advertise everything they speak and echo the release they actually served. The negotiation field moves from `core/protocol-envelope.json` into a shared `core/version-envelope.json` composed via `allOf $ref` across every request and response schema, so the contract is one place and SDKs regenerate types from it.
+
+`adcp_major_version` (the 3.0 integer field) and `adcp.major_versions` remain functional through all of 3.x — additive ship, no required changes for 3.0-conformant agents. The full migration table lives in [Versioning & Governance § Migration timeline](/docs/reference/versioning#migration-timeline).
+
+**Pin your release.** Every SDK exposes a constructor option for the version pin. Through 3.x, the SDK SHOULD also emit `adcp_major_version` automatically so legacy 3.x sellers that only read the integer keep negotiating correctly.
+
+```typescript
+// @adcp/client (TypeScript)
+import { AdcpClient } from "@adcp/client";
+
+const client = new AdcpClient({
+  endpoint: "https://sales.example/.well-known/agent.json",
+  adcpVersion: "3.1",      // emitted on every request as adcp_version
+                           // adcp_major_version: 3 mirror auto-emitted
+});
+```
+
+```python
+# adcp (Python)
+from adcp import AdcpClient
+
+client = AdcpClient(
+    endpoint="https://sales.example/.well-known/agent.json",
+    adcp_version="3.1",    # emitted on every request as adcp_version
+                           # adcp_major_version: 3 mirror auto-emitted
+)
+```
+
+```go
+// adcp-go (Go)
+import "github.com/adcontextprotocol/adcp-go/adcp"
+
+client, err := adcp.NewClient(
+    "https://sales.example/.well-known/agent.json",
+    adcp.WithAdcpVersion("3.1"), // emitted on every request as adcp_version
+                                  // AdcpMajorVersion: 3 mirror auto-emitted
+)
+```
+
+**Read what the seller served.** Every response carries `adcp_version` echoed back at the release the seller actually served — not the seller's own latest. A 3.1 seller serving a 3.0 buyer at 3.0 echoes `"3.0"`. Buyers SHOULD validate the response against the echoed release's schema, not against their pin. Legacy 3.0 sellers omit the echo entirely; SDKs fall back to validating against the constructor pin in that case.
+
+**`VERSION_UNSUPPORTED` is typed.** When a buyer's pin isn't in the seller's `supported_versions`, the seller returns `VERSION_UNSUPPORTED` with `error.data` matching [`error-details/version-unsupported.json`](https://github.com/adcontextprotocol/adcp/blob/main/static/schemas/source/error-details/version-unsupported.json) — `supported_versions` is authoritative for retry. SDKs raise a typed error rather than silently retrying; auto-downshift changes wire shape under the caller and is left to application code.
+
+**Wire shape is release-precision only.** `"3.1.2"`, `"3.1.0-beta.1"`, `"v3.1"`, and `"3"` are all invalid on the wire. SDKs that key bundles by full semver MUST normalize to release-precision (`"3.1.0-beta.1"` → `"3.1-beta.1"`) before emitting — the `published_version` field on meta-objects (schema registry, tarball `manifest.json`, compliance index, `/protocol/` discovery) is documentation, not a wire value. See [Versioning § Patches are not negotiated](/docs/reference/versioning#patches-are-not-negotiated) for the full wire-shape rule.
+
+**Compliance grader at 3.1 is advisory.** The grader runs the new `version_negotiation` universal storyboard and reports presence on requests and responses. Sellers SHOULD echo `adcp_version` and SHOULD declare `adcp.supported_versions` on `get_adcp_capabilities`; the storyboard reports missing entries without failing certification. At 3.2 the grader flips to blocking failure — sellers aiming for 3.2 certification ship the echo and the capability declaration during the 3.1 window. At 4.0 the spec promotes both to MUST and the legacy integer fields are removed.
+
+Spec PR [#3493](https://github.com/adcontextprotocol/adcp/pull/3493). RFC: [`specs/version-negotiation.md`](https://github.com/adcontextprotocol/adcp/blob/main/specs/version-negotiation.md). Full normative reference: [Versioning & Governance § Version negotiation](/docs/reference/versioning#version-negotiation).
 
 ---
 

--- a/static/compliance/source/universal/version-negotiation.yaml
+++ b/static/compliance/source/universal/version-negotiation.yaml
@@ -1,0 +1,130 @@
+id: version_negotiation
+version: "1.0.0"
+title: "Release-precision version negotiation"
+category: version_negotiation
+summary: "Sellers advertise supported releases on capabilities and echo the served release on every response."
+track: core
+required_tools: []  # protocol-level: get_adcp_capabilities is mandatory for all agents
+
+narrative: |
+  AdCP 3.1 introduces release-precision (VERSION.RELEASE, e.g. "3.1") version
+  negotiation alongside the legacy major-precision (`adcp_major_version` integer)
+  carried since 3.0. Both directions of the negotiation are SHOULD-level through
+  3.x and graduate to MUST at 4.0 — this storyboard exercises both halves so
+  sellers can discover gaps before the 3.2 grader cutover flips advisory results
+  to blocking failures.
+
+  Two checks ride on a single get_adcp_capabilities call:
+
+  1. **Seller advertises** `adcp.supported_versions` — an array of release-precision
+     strings the seller speaks. Authoritative for buyer-side pinning; the legacy
+     `adcp.major_versions` integer array remains required through 3.x for
+     backwards compatibility.
+
+  2. **Seller echoes** `adcp_version` at the envelope root — the release the seller
+     actually served. Buyers SHOULD validate the response against the echoed
+     release's schema, not against their own pin. Legacy 3.0 sellers that don't
+     read the field omit the echo (`additionalProperties: true` makes the field
+     invisible to them) — buyers fall back to their constructor pin.
+
+  Per the [migration table](/docs/reference/versioning#migration-timeline), both
+  surfaces are advisory at 3.1 and become blocking failure at 3.2. The advisory
+  marker on each validation makes that promotion a single-PR change at 3.2 cut
+  rather than a per-adopter compliance break at the boundary.
+
+  Scope: protocol envelope and capabilities advertisement only. The
+  `VERSION_UNSUPPORTED` error path (buyer pins a release outside the seller's
+  `supported_versions`) is exercised separately by error_compliance — running it
+  here requires the runner to send a deliberately-mismatched pin and is left to
+  follow-up.
+
+agent:
+  interaction_model: "*"  # applies to every agent regardless of protocol or specialism
+  examples:
+    - "Any AdCP agent (seller, signals, creative, retail media, SI, governance)"
+
+caller:
+  role: buyer_agent
+  example: "Compliance test harness"
+
+prerequisites:
+  description: |
+    No test-kit credentials required. get_adcp_capabilities is a public operation
+    that every AdCP agent must expose without authentication.
+
+phases:
+  - id: capabilities_advertise_and_echo
+    title: "Capabilities advertise supported_versions; response echoes adcp_version"
+    narrative: |
+      Call get_adcp_capabilities. The single response carries both halves of the
+      negotiation contract — `adcp.supported_versions` in the body (seller's
+      advertisement) and `adcp_version` on the envelope (seller's echo of what
+      it served). Sellers SHOULD populate both at 3.1; the grader reports
+      missing entries as advisory findings without failing certification.
+
+    steps:
+      - id: get_capabilities_with_version
+        title: "Verify seller advertises supported_versions and echoes adcp_version"
+        narrative: |
+          The runner emits `adcp_version` on the request envelope based on its
+          configured pin (the SDK's release-precision constructor option). The
+          seller honors the pin within the resolution algorithm in
+          docs/reference/versioning.mdx, echoes the served release on the response
+          envelope, and lists every release it speaks under
+          `adcp.supported_versions` in the response body.
+
+          A seller serving only 3.0 (no awareness of the new fields) passes the
+          request schema unchanged — `adcp_version` rides on the envelope and is
+          invisible to readers that don't look for it. The advisory checks below
+          will report missing `supported_versions` advertisement and missing
+          envelope echo without failing the step.
+        task: get_adcp_capabilities
+        schema_ref: "protocol/get-adcp-capabilities-request.json"
+        response_schema_ref: "protocol/get-adcp-capabilities-response.json"
+        doc_ref: "/protocol/get_adcp_capabilities"
+        comply_scenario: version_negotiation
+        stateful: false
+        expected: |
+          Response carries both halves of the negotiation contract:
+          - Body: adcp.supported_versions (array of release-precision strings, e.g.
+            ["3.0", "3.1"]) declaring every release the seller speaks. Authoritative
+            for buyer-side pinning. SHOULD at 3.1, MUST at 4.0.
+          - Envelope: adcp_version (release-precision string) echoing the release
+            the seller actually served. SHOULD at 3.1, MUST at 4.0. Buyers SHOULD
+            validate the response against the echoed release's schema.
+
+          Legacy `adcp.major_versions` (integer array) remains required through 3.x.
+
+        sample_request:
+          context:
+            correlation_id: "version_negotiation--get_capabilities_with_version"
+
+        validations:
+          - check: response_schema
+            description: "Response matches get-adcp-capabilities-response.json schema"
+
+          - check: field_present
+            path: "adcp.major_versions"
+            description: "Legacy major-precision advertisement present (required through 3.x)"
+
+          - check: field_present
+            path: "adcp.supported_versions"
+            severity: advisory
+            permanent_advisory:
+              reason: "Per docs/reference/versioning.mdx > Migration timeline, sellers SHOULD declare supported_versions at 3.1 and the compliance grader reports presence as advisory. At 3.2 the storyboard cut promotes this validation to required (manual flip — not gated on runner_capability_version because the 3.2 boundary is a protocol-spec cutover, not a runner-capability cutover). 4.0 promotes to MUST per the spec. Marking permanent_advisory here is a deliberate use of the field to defer promotion to the 3.2 storyboard PR rather than relying on the expires_after_version semver gate."
+            description: "Seller advertises release-precision supported_versions (advisory at 3.1, required at 3.2)"
+
+          - check: envelope_field_present
+            path: "adcp_version"
+            severity: advisory
+            permanent_advisory:
+              reason: "Per docs/reference/versioning.mdx > Migration timeline, sellers SHOULD echo adcp_version at 3.1 and the compliance grader reports presence as advisory. At 3.2 the storyboard cut promotes this validation to required (manual flip — see the supported_versions check above for the same rationale). 4.0 promotes to MUST per the spec."
+            description: "Seller echoes adcp_version on the response envelope (advisory at 3.1, required at 3.2)"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "version_negotiation--get_capabilities_with_version"
+            description: "Context correlation_id returned unchanged"


### PR DESCRIPTION
## Summary

Lands two Tier-1 items from the version-negotiation epic (#3570) that live in this repo. Both surfaces ship advisory at 3.1 per the [migration table](https://github.com/adcontextprotocol/adcp/blob/main/docs/reference/versioning.mdx#migration-timeline) and promote to blocking at the 3.2 cut.

- **`docs/reference/release-notes.mdx`** — new *"Release-precision version negotiation — pin your release"* section under 3.1.0 with constructor examples for `@adcp/sdk` (TS — `SingleAgentClient`), `adcp` (Python — `ADCPClient`), and `adcp-go` (qualified as planned, tracked in `adcp-go#107`). Covers the four adopter touchpoints: pin, read the seller echo, handle typed `VERSION_UNSUPPORTED`, normalize wire shape away from full semver. New row added to the 3.1 adopter-action table pointing SDK builders at the pin contract.

- **`static/compliance/source/universal/version-negotiation.yaml`** — new universal storyboard (`id: version_negotiation`, `track: core`, 25th universal). One phase, one `get_adcp_capabilities` call, three new validations on top of the standard envelope/context checks:
  - `field_present` on `adcp.major_versions` (required through 3.x)
  - `field_present` on `adcp.supported_versions` (advisory at 3.1)
  - `envelope_field_present` on `adcp_version` (advisory at 3.1)

Both advisory checks use `severity: advisory` + `permanent_advisory` with a reason documenting the manual 3.2-cut promotion (the `expires_after_version` mechanism gates on `runner_capability_version` — a runner-capability anchor, not a protocol-spec anchor, so it's the wrong tool for this transition).

## Refs

- Tier 1 epic: #3570
- Spec PR (merged): #3493
- RFC: [`specs/version-negotiation.md`](https://github.com/adcontextprotocol/adcp/blob/main/specs/version-negotiation.md)
- Normative reference: [docs/reference/versioning.mdx § Version negotiation](https://github.com/adcontextprotocol/adcp/blob/main/docs/reference/versioning.mdx#version-negotiation)

## Follow-ups filed (out of scope for this PR)

Surfaced during expert review of this PR; tracked separately so this PR stays a focused docs+compliance landing.

- **#4711** — training-agent: emit `adcp.supported_versions` and `adcp_version` envelope echo (3.1.0 milestone). Reference implementation currently passes the storyboard only because the new validations are advisory.
- **#4712** — `error-compliance.yaml`: add release-precision `VERSION_UNSUPPORTED` probe (3.1.0). Existing probe sends integer `adcp_major_version: 99`; needs a parallel `adcp_version: "99.0"` step.
- **#4713** — docs: surface 3.1 version negotiation in `whats-new-in-v3.mdx` + L0 guides (3.1.0). Existing surfaces still describe the legacy integer-only contract.
- **#4714** — compliance: add `field_pattern` check kind so the echoed `adcp_version` shape is enforced, not just presence (3.2.0).
- **adcp-client#1838** — register `version_negotiation` `comply_scenario` in `@adcp/sdk` runner.

## Tier 1 items still open after this PR (per #3570)

- adcp-go PR #107 follow-up — constructor + typed `VersionUnsupportedError` + echo helpers (separate repo)
- `@adcp/client.ComplianceIndex.published_version` TS type bump (separate repo)
- Training agent emits the new fields (#4711)
- Scope3 production deployment exercising emit + echo end-to-end (external)

## Test plan

- [x] `node scripts/build-compliance.cjs` — 25 universal storyboards (was 24), bundle build clean
- [x] All 13 storyboard lints pass: advisory-expiry, check-enum, response-schema, scoping, branch-set, provides_state_for, contradictions, context-entity, auth-shape, test-kits, pagination-invariant, raw-mode-required, schema-links
- [x] Pre-push storyboard matrix green (signals + sales + governance + creative + creative-builder + brand)
- [x] CI green on first push (changeset check fixed in second commit)
- [x] SDK constructor signatures verified against `@adcp/sdk` `src/lib/index.ts:118` (TS), `adcp/client.py:359` (Python), `adcp-go#107` body (Go, qualified as planned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)