### PR TITLE
fix(training-agent): close webhook-fetch SSRF gaps on connect-pin + redirect (#4700)

### DIFF
--- a/.changeset/4700-webhook-fetch-ssrf-connect-pin-and-redirect-manual.md
+++ b/.changeset/4700-webhook-fetch-ssrf-connect-pin-and-redirect-manual.md
@@ -1,0 +1,21 @@
+---
+---
+
+training-agent webhook-fetch: close SSRF gaps on steps 3 (connect-pin) + 4 (refuse redirects). Fixes #4700.
+
+`server/src/training-agent/webhook-fetch.ts` previously implemented steps 1, 2, 5, 6 of `docs/building/by-layer/L1/security.mdx#webhook-url-validation-ssrf` but skipped two:
+
+- **Step 3** — no DNS-rebinding-resistant connect pin. The pre-flight `assertPublicTarget` resolved the hostname and rejected private IPs, but the actual `globalThis.fetch` call re-resolved at TCP-connect time. A hostile authoritative server serving a public IP at validation and a private IP at connect bypassed the check.
+- **Step 4** — no `redirect: 'manual'`. Default Node fetch follows up to 20 redirects, and the redirect target was never re-validated. A 302 from any buyer-controlled host to `http://169.254.169.254/...` slipped past the IP-range guard on the original URL.
+
+Fix reuses the SSRF-safe dispatcher pattern already proven in `server/src/utils/url-security.ts` (`safeFetch`):
+
+- Attach an `undici.Agent` whose `connect.lookup` hook delegates to the existing `ssrfSafeLookup` from `utils/url-security.ts`. The lookup re-validates the resolved IP at dial time and rejects private/loopback/link-local/IPv4-mapped-private addresses, closing the validation→connect TOCTOU window. SNI/cert verification continues to use the original hostname.
+- Set `redirect: 'manual'` on every fetch call, in **every** environment (including `allowPrivateIp: true` sandbox mode). Redirect-follow is a security guard, not a routing affordance. 3xx responses are returned to the SDK emitter as-is, which then treats them as a delivery failure under its existing non-2xx handling.
+- Lift the scheme refusal (`file://`, `ftp://`, etc.) out of `assertPublicTarget` so it applies unconditionally — a sandbox loopback receiver always uses http/https; rejecting non-http(s) URLs in dev is strictly tightening, never a footgun.
+
+Two new unit tests pin the construction shape so a future refactor that drops the dispatcher or flips redirect-follow back on fails before the SSRF gap silently reopens.
+
+Out of scope: a broader audit of other outbound-fetch call sites that share the same emitter (non-training-agent paths) — separate follow-up. No protocol changes; no schema changes.
+
+Closes #4700.

--- a/server/src/training-agent/webhook-fetch.ts
+++ b/server/src/training-agent/webhook-fetch.ts
@@ -6,22 +6,34 @@
  * including loopback (`127.0.0.1`), link-local (`169.254.169.254` fly/AWS
  * metadata), or RFC1918 private IPs reachable from the container.
  *
- * Two-step guard:
+ * Implements steps 1–4 of `docs/building/by-layer/L1/security.mdx#webhook-url-validation-ssrf`:
+ *
  * 1. Refuse non-`http:`/`https:` URLs outright.
  * 2. Resolve the hostname via DNS. If any resolved address is private,
  *    link-local, loopback, or broadcast, refuse.
- *
- * The DNS lookup happens immediately before `fetch`; a rebinding attack that
- * flips the answer between the check and the connect is theoretically
- * possible but narrower than the primary "caller submits metadata URL"
- * threat. Matches the SSRF pattern already used in `server/src/validator.ts`.
+ * 3. Pin the TCP connect to the validated IP via an undici dispatcher whose
+ *    `connect.lookup` hook re-checks the resolved IP at dial time. Closes
+ *    the DNS-rebinding window between hostname validation and the actual
+ *    connect: a hostile authoritative server cannot return a public IP at
+ *    validation and a private IP at fetch time.
+ * 4. Set `redirect: 'manual'` so a 30x to `169.254.169.254` or any other
+ *    reserved address cannot bypass the IP-range check on the original URL.
+ *    3xx responses are returned to the caller as-is — the emitter treats
+ *    them as a delivery failure (per its existing non-2xx handling), and
+ *    receivers wanting to relocate their endpoint must re-register, not
+ *    redirect.
  *
  * `allowPrivateIp: true` is required for conformance storyboards that use
- * `http://127.0.0.1:<port>` loopback receivers. Default in non-production.
+ * `http://127.0.0.1:<port>` loopback receivers; it bypasses steps 2 and 3
+ * but **not** step 4 — the no-follow redirect contract holds in every
+ * environment, since redirect-follow is a security guard, not a routing
+ * affordance.
  */
 
 import { lookup } from 'node:dns/promises';
 import { isIP } from 'node:net';
+import { type Dispatcher } from 'undici';
+import { buildSsrfSafeDispatcher } from '../utils/url-security.js';
 
 export class SsrfRefusedError extends Error {
   readonly url: string;
@@ -78,9 +90,9 @@ function isNumericHostname(hostname: string): boolean {
 }
 
 async function assertPublicTarget(url: URL): Promise<void> {
-  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
-    throw new SsrfRefusedError(url.toString(), `scheme ${url.protocol} not allowed`);
-  }
+  // Scheme refusal is handled by the wrapper before this is called (so it
+  // applies unconditionally, including under `allowPrivateIp: true`). By the
+  // time we get here the URL is already known to be http(s).
   // `url.hostname` strips brackets from `[::1]` → `::1`. Userinfo (user:pass@)
   // never leaks into hostname per WHATWG, so we don't need to scrub that.
   const hostname = url.hostname;
@@ -113,19 +125,46 @@ async function assertPublicTarget(url: URL): Promise<void> {
 
 /** Build a `fetch`-shaped function gated by the SSRF guard.
  *
- * When `allowPrivateIp` is true the guard is bypassed. That's the right
- * default for dev/CI where conformance storyboards use `http://127.0.0.1:<port>`
- * receivers; it's explicitly the wrong default for production. The returned
- * function always dereferences `globalThis.fetch` lazily so tests that replace
- * the global see their replacement. */
+ * When `allowPrivateIp` is true the hostname/connect guard is bypassed
+ * (steps 2–3). That's the right default for dev/CI where conformance
+ * storyboards use `http://127.0.0.1:<port>` receivers; it's explicitly
+ * the wrong default for production. Step 1 (scheme refusal) and step 4
+ * (`redirect: 'manual'`) hold in every environment — redirect-follow is
+ * a security guard, not a routing affordance.
+ *
+ * The returned function always dereferences `globalThis.fetch` lazily
+ * so tests that replace the global see their replacement. */
 export function createWebhookFetch(options: { allowPrivateIp: boolean }): typeof fetch {
   return async (input, init) => {
-    if (!options.allowPrivateIp) {
-      const href = typeof input === 'string' || input instanceof URL
-        ? input.toString()
-        : input.url;
-      await assertPublicTarget(new URL(href));
+    const href = typeof input === 'string' || input instanceof URL
+      ? input.toString()
+      : input.url;
+    const url = new URL(href);
+    // Step 1 (scheme refusal) is unconditional even under allowPrivateIp —
+    // a sandbox loopback receiver always uses http/https.
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+      throw new SsrfRefusedError(url.toString(), `scheme ${url.protocol} not allowed`);
     }
-    return globalThis.fetch(input, init);
+    if (!options.allowPrivateIp) {
+      // Step 2: pre-flight hostname + DNS check. Catches literal private
+      // IPs and numeric-encoded bypasses (`http://2852039166/`) before
+      // we even open a socket.
+      await assertPublicTarget(url);
+    }
+    // Step 4 (no redirect-follow) and step 3 (connect-time IP recheck via
+    // the dispatcher) both apply on the fetch call itself. Manual redirect
+    // mode returns the 3xx response to the caller as-is rather than chasing
+    // the Location header — the emitter's existing non-2xx handling then
+    // treats the 3xx as a delivery failure.
+    const dispatcher = options.allowPrivateIp ? undefined : buildSsrfSafeDispatcher();
+    // `dispatcher` is the standard escape hatch for undici-on-Node.fetch but is
+    // not typed on Node's `RequestInit` (the userland `undici` and Node's bundled
+    // `undici-types` are type-incompatible copies). Cast at the call site —
+    // same pattern as `safeFetch` in `utils/url-security.ts`.
+    return globalThis.fetch(input, {
+      ...(init ?? {}),
+      redirect: 'manual',
+      dispatcher,
+    } as RequestInit & { dispatcher?: Dispatcher });
   };
 }

--- a/server/tests/unit/training-agent-webhook-fetch.test.ts
+++ b/server/tests/unit/training-agent-webhook-fetch.test.ts
@@ -3,13 +3,14 @@ import { createWebhookFetch, SsrfRefusedError } from '../../src/training-agent/w
 
 describe('createWebhookFetch — SSRF guard', () => {
   let originalFetch: typeof globalThis.fetch;
-  let calls: string[];
+  let calls: Array<{ url: string; init: RequestInit | undefined }>;
 
   beforeEach(() => {
     originalFetch = globalThis.fetch;
     calls = [];
-    globalThis.fetch = vi.fn(async (input: Parameters<typeof fetch>[0]) => {
-      calls.push(typeof input === 'string' || input instanceof URL ? input.toString() : input.url);
+    globalThis.fetch = vi.fn(async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      const url = typeof input === 'string' || input instanceof URL ? input.toString() : input.url;
+      calls.push({ url, init });
       return new Response('', { status: 200 });
     }) as typeof fetch;
   });
@@ -18,12 +19,17 @@ describe('createWebhookFetch — SSRF guard', () => {
     globalThis.fetch = originalFetch;
   });
 
+  /** Convenience: pull the recorded URLs without dragging out the init plumbing. */
+  function urls(): string[] {
+    return calls.map((c) => c.url);
+  }
+
   describe('with allowPrivateIp=true (dev/CI)', () => {
     const fetch = createWebhookFetch({ allowPrivateIp: true });
 
     it('passes loopback URLs through', async () => {
       await expect(fetch('http://127.0.0.1:9999/hook')).resolves.toBeInstanceOf(Response);
-      expect(calls).toEqual(['http://127.0.0.1:9999/hook']);
+      expect(urls()).toEqual(['http://127.0.0.1:9999/hook']);
     });
 
     it('passes public URLs through', async () => {
@@ -36,7 +42,7 @@ describe('createWebhookFetch — SSRF guard', () => {
 
     it('refuses literal IPv4 loopback', async () => {
       await expect(fetch('http://127.0.0.1/metadata')).rejects.toBeInstanceOf(SsrfRefusedError);
-      expect(calls).toEqual([]);
+      expect(urls()).toEqual([]);
     });
 
     it('refuses AWS/fly metadata (169.254.169.254)', async () => {
@@ -99,7 +105,46 @@ describe('createWebhookFetch — SSRF guard', () => {
     it('allows public hostnames', async () => {
       // example.com is guaranteed public by IANA.
       await expect(fetch('https://example.com/hook')).resolves.toBeInstanceOf(Response);
-      expect(calls).toEqual(['https://example.com/hook']);
+      expect(urls()).toEqual(['https://example.com/hook']);
+    });
+
+    it('forces redirect:manual on the underlying fetch (security.mdx SSRF step 4)', async () => {
+      // A 302 to `http://169.254.169.254/...` from a public buyer-controlled
+      // host would otherwise let the buyer punch through the IP-range check.
+      // Pinning the redirect mode at the wrapper layer prevents the SDK
+      // emitter or any future caller from accidentally re-enabling follow.
+      await fetch('https://example.com/hook');
+      expect(calls[0].init?.redirect).toBe('manual');
+    });
+
+    it('attaches the SSRF-safe dispatcher so connect-time DNS rebinding is rejected (security.mdx SSRF step 3)', async () => {
+      // The dispatcher's `connect.lookup` hook re-checks the resolved IP at
+      // TCP-connect time, closing the validation→connect TOCTOU window. We
+      // can't exercise the rebind from a unit test, but we can pin the
+      // construction shape: if a future refactor drops the dispatcher, this
+      // assertion fails before the SSRF gap silently reopens.
+      await fetch('https://example.com/hook');
+      expect((calls[0].init as RequestInit & { dispatcher?: unknown }).dispatcher).toBeDefined();
+    });
+  });
+
+  describe('redirect-mode pinning (applies in every environment)', () => {
+    it('pins redirect:manual even when allowPrivateIp is true', async () => {
+      // The no-follow contract is a security guard, not a routing
+      // affordance — dev/CI receivers shouldn't be able to bounce
+      // signed bodies to a metadata endpoint either.
+      const fetch = createWebhookFetch({ allowPrivateIp: true });
+      await fetch('http://127.0.0.1:9999/hook');
+      expect(calls[0].init?.redirect).toBe('manual');
+    });
+
+    it('does NOT attach the SSRF dispatcher when allowPrivateIp is true', async () => {
+      // The dispatcher's lookup rejects private IPs; attaching it under
+      // allowPrivateIp:true would defeat the loopback-receiver use case
+      // the flag exists to support.
+      const fetch = createWebhookFetch({ allowPrivateIp: true });
+      await fetch('http://127.0.0.1:9999/hook');
+      expect((calls[0].init as RequestInit & { dispatcher?: unknown }).dispatcher).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
Closes #4700. Surfaced by the security review of #4693.

## Gap

`server/src/training-agent/webhook-fetch.ts` previously implemented steps 1, 2, 5, 6 of `docs/building/by-layer/L1/security.mdx#webhook-url-validation-ssrf` but skipped two:

- **Step 3 (DNS-rebinding-resistant connect pin):** the pre-flight `assertPublicTarget` resolved the hostname and rejected private IPs, but the actual `globalThis.fetch` call re-resolved at TCP-connect time. A hostile authoritative server serving a public IP at validation and a private IP at connect bypassed the check.
- **Step 4 (Refuse redirects):** default Node fetch follows up to 20 redirects, and the redirect target was never re-validated. A 302 from any buyer-controlled host to `http://169.254.169.254/...` slipped past the IP-range guard on the original URL.

Both vectors are reachable in production (Fly machine with `NODE_ENV=production` → `allowPrivateIp: false`).

## Fix

Reuses the SSRF-safe dispatcher already proven in `server/src/utils/url-security.ts` (`safeFetch`):

- Attach an undici Agent whose `connect.lookup` hook delegates to the existing `ssrfSafeLookup`. Re-validates the resolved IP at TCP-connect time, closing the validation→connect TOCTOU window. SNI/cert verification continues to use the original hostname.
- Set `redirect: 'manual'` on every fetch call, in every environment (including `allowPrivateIp: true` sandbox mode). Redirect-follow is a security guard, not a routing affordance — a buyer-controlled 302 to a metadata endpoint should never be chased even in dev.
- Lift the scheme refusal (`file://`, `ftp://`, etc.) out of `assertPublicTarget` so it applies unconditionally.
- Imports `buildSsrfSafeDispatcher` rather than reimplementing it locally (initial draft duplicated the helper; code-reviewer caught the drift risk).

Two new unit tests pin the construction shape — if a future refactor drops the dispatcher or flips redirect-follow back on, the tests fail before the SSRF gap silently reopens.

## Out of scope

- A broader audit of other outbound-fetch call sites that share the same emitter (non-training-agent paths) — separate follow-up.
- Hardening the `NODE_ENV !== 'production'` gate that selects `allowPrivateIp` (a misconfigured machine with `NODE_ENV` unset opens the gate). Pre-existing; not introduced by #4693 or this PR.
- The `SsrfRefusedError` message contains the specific reason (`scheme not allowed`, `literal private/loopback address`, etc.). If a future `WebhookEmitter` change surfaces these messages to the buyer in a delivery-failure receipt, that's a small internal-network probe channel. Worth checking before any public-buyer enablement.

## Expert sign-off

- **security-reviewer:** ship-ready. Rebinding gap closed; dispatcher lifecycle correct; no new attack surface.
- **code-reviewer:** clean after the `buildSsrfSafeDispatcher` reuse and duplicate-scheme-check cleanup.

## Test plan

- [x] `npx vitest run server/tests/unit/training-agent-webhook-fetch.test.ts` — 20/20 pass (4 new)
- [x] `npx vitest run server/tests/unit/training-agent-webhook-operation-id.test.ts` — 6/6 pass (unaffected, sanity check)
- [x] `npx tsc --noEmit -p server/tsconfig.json` — clean
- [ ] CI green
- [ ] No protocol-spec or schema changes; changeset is `--empty`

🤖 Generated with [Claude Code](https://claude.com/claude-code)