### PR TITLE
feat(compliance): metric-mode (reach/clicks/completed_views) + ROAS capability-gated scenarios (#4637)

### DIFF
--- a/.changeset/4637-metric-mode-and-roas-scenarios.md
+++ b/.changeset/4637-metric-mode-and-roas-scenarios.md
@@ -1,0 +1,19 @@
+---
+"adcontextprotocol": minor
+---
+
+feat(compliance): metric-mode (reach/clicks/completed_views) + ROAS capability-gated scenarios using contains: matcher
+
+Four new scenarios in the capability-claim contract pattern (#4637), all gated via the `contains:` matcher (shipped in @adcp/client 7.70 — adcp-client#1817), all added to `sales-non-guaranteed.requires_scenarios`:
+
+- `media_buy_seller/performance_buy_flow_roas` — gated on `media_buy.conversion_tracking.supported_targets` containing `per_ad_spend` (#4639). Certifies that sellers advertising ROAS optimization accept event-kind goals with `target.kind: per_ad_spend` and `value_field` populated, reject ROAS goals that omit `value_field` on every event source entry, and report `conversion_value` and `roas` on delivery alongside `conversions` and `cost_per_acquisition`. Sibling to `performance_buy_flow` on the value side.
+
+- `media_buy_seller/reach_buy_flow` — gated on `media_buy.supported_optimization_metrics` containing `reach` (#4669). Certifies that sellers advertising reach optimization accept metric-kind goals with `metric: reach`, a `reach_unit` from the product's `metric_optimization.supported_reach_units`, and an optional `target_frequency` band; reject unsupported `reach_unit` values; and report `reach` and `frequency` on delivery.
+
+- `media_buy_seller/clicks_buy_flow` — gated on `media_buy.supported_optimization_metrics` containing `clicks` (#4669). Certifies that sellers advertising click optimization accept metric-kind goals with `metric: clicks` and a `cost_per` target, and report `clicks` and `cost_per_click` on delivery. No rejection arm — clicks is universal in semantics with no obvious unbound-id surface.
+
+- `media_buy_seller/completed_views_buy_flow` — gated on `media_buy.supported_optimization_metrics` containing `completed_views` (#4669). Certifies that sellers advertising completion optimization accept metric-kind goals with `metric: completed_views` and a `view_duration_seconds` in the product's `metric_optimization.supported_view_durations`; reject unsupported `view_duration_seconds` values (per `optimization-goal.json:50-53`, silent rounding creates measurement discrepancies); and report `completed_views` and `completion_rate` on delivery.
+
+All four scenarios grade `not_applicable` against the embedded training agent today — the training agent doesn't declare `supported_targets` or `supported_optimization_metrics` and therefore cannot claim these optimization kinds. This is the correct anti-façade hygiene per the `event_dedup_flow` precedent (#4664): an agent that doesn't claim a capability is not held to its scenario. The training agent stays honest by NOT claiming what it can't do; production adopters opt in by declaring the capability bits.
+
+Refs: #4637 (meta), #4639 (`supported_targets`), #4669 (`supported_optimization_metrics`), #4642 (CPA scenario precedent), #4664 (`event_dedup_flow` precedent), #4651 (product-level capability gating), adcp-client#1817 (`contains:` matcher).

--- a/static/compliance/source/protocols/media-buy/scenarios/clicks_buy_flow.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/clicks_buy_flow.yaml
@@ -1,0 +1,264 @@
+id: media_buy_seller/clicks_buy_flow
+version: "1.0.0"
+title: "Seller fulfills a media buy with a clicks optimization goal (target CPC)"
+category: media_buy_seller
+summary: "Verifies that a seller advertising clicks in supported_optimization_metrics can accept a media buy whose metric-kind optimization_goal targets cost-per-click and reports clicks + cost_per_click on delivery. Lightweight sibling to the performance scenarios on the click-optimization side: sellers that don't advertise clicks as an optimization metric (rare — most do; pure brand sellers like broadcast TV upper-funnel video are the not_applicable population) grade not_applicable."
+track: media_buy
+
+# Gate: scenario runs only when the seller declares clicks in
+# media_buy.supported_optimization_metrics (proposed in #4669). Most
+# adopters declare clicks (it is the most universal metric in advertising),
+# but broadcast TV upper-funnel video and signal-only sellers honestly
+# don't optimize for clicks and grade `not_applicable`. The gate is what
+# keeps them from being marked failing. Requires runner support for the
+# `contains:` matcher (adcp-client >= 7.70).
+requires_capability:
+  path: media_buy.supported_optimization_metrics
+  contains: "clicks"
+
+required_tools:
+  - get_products
+  - create_media_buy
+  - get_media_buy_delivery
+  - comply_test_controller
+
+invariants:
+  - status.monotonic
+
+narrative: |
+  A "clicks buy" is a media buy whose optimization_goal is metric-kind with
+  metric: clicks and a target_cpc (target.kind: cost_per, value:
+  target-cost-per-click in the buy currency). This is the most common
+  performance-shaped buy in advertising — link clicks, swipe-throughs, CTA
+  taps that navigate away — and the optimization shape is well-understood
+  across the industry. The scenario certifies that the click-optimization
+  path connects end-to-end when the seller advertises clicks as an
+  optimization metric.
+
+  This scenario is intentionally lightweight (no rejection arm) because
+  clicks is universal in semantics — there isn't an obvious unbound-id or
+  unsupported-value to reject. The seller either supports clicks as an
+  optimization metric or it doesn't (handled by the capability gate). The
+  three-phase shape — setup, create, delivery — is sufficient to certify
+  the click-optimization path without manufacturing artificial rejection
+  surfaces.
+
+  Discriminating behaviors this scenario verifies:
+  1. create_media_buy with metric-kind goal (metric: clicks, target.kind:
+     cost_per, target.value: target CPC) is accepted.
+  2. get_media_buy_delivery surfaces totals.clicks and totals.cost_per_click
+     — the discriminating output fields of click optimization. cost_per_click
+     is defined in delivery-metrics.json as spend / clicks; sellers
+     optimizing for clicks MUST populate both fields on delivery.
+
+agent:
+  interaction_model: media_buy_seller
+  capabilities:
+    - sells_media
+    - supports_non_guaranteed
+  examples:
+    - "DSPs running click-optimized campaigns"
+    - "Social platforms (Meta link clicks, TikTok swipe-throughs)"
+    - "Search-adjacent / native sellers optimizing for CTA taps"
+    - "Retail-media performance products optimizing for product page visits"
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: |
+    The seller must implement comply_test_controller with simulate_delivery
+    (already required for delivery_reporting). simulate_delivery injects
+    impressions, clicks, and spend so get_media_buy_delivery has something
+    to surface for the click-optimized buy.
+
+    The buyer fixture supplies a brand, an operator, and click optimization
+    parameters sufficient to exercise the cost_per target binding.
+  test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  products:
+    - product_id: "clicks_display_q2"
+      delivery_type: "non_guaranteed"
+      channels: ["display"]
+      format_ids:
+        - id: "display_300x250"
+  pricing_options:
+    - product_id: "clicks_display_q2"
+      pricing_option_id: "auction_cpm"
+      pricing_model: "cpm"
+      currency: "USD"
+      floor_price: 1.50
+
+phases:
+
+  - id: setup
+    title: "Establish account and discover products"
+    steps:
+      - id: sync_accounts
+        title: "Establish account"
+        task: sync_accounts
+        schema_ref: "account/sync-accounts-request.json"
+        response_schema_ref: "account/sync-accounts-response.json"
+        doc_ref: "/accounts/tasks/sync_accounts"
+        stateful: true
+        expected: |
+          Return the account with account_id and status active.
+        sample_request:
+          accounts:
+            - brand:
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
+              billing: "operator"
+          idempotency_key: "$generate:uuid_v4#clicks_buy_flow_setup_sync_accounts"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-accounts-response.json schema"
+          - check: field_present
+            path: "accounts[0].account_id"
+            description: "Account has a platform-assigned ID"
+
+      - id: get_products_for_clicks
+        title: "Discover products that support click optimization"
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        stateful: false
+        expected: |
+          Return at least one product whose metric_optimization capabilities
+          include clicks as an optimization metric.
+        sample_request:
+          buying_mode: "brief"
+          brief: "Display performance, US adults 25-54. Q2 flight ~$15K, optimizing for clicks with a target CPC."
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+        validations:
+          - check: response_schema
+            description: "Response matches get-products-response.json schema"
+          - check: field_present
+            path: "products"
+            description: "Response contains products"
+
+  - id: create_clicks_buy
+    title: "Create a click-optimized buy with a target CPC"
+    narrative: |
+      The buyer creates a media buy whose package carries a metric-kind
+      optimization_goal with metric: clicks and target.kind: cost_per at
+      $2.50 per click. The seller should accept and return a media_buy_id
+      used for subsequent delivery checks.
+
+    steps:
+      - id: create_media_buy_clicks
+        title: "Create media buy with metric-kind clicks goal"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        expected: |
+          Create the media buy. Response carries a media_buy_id used for
+          subsequent get_media_buy_delivery calls.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-06-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "clicks_display_q2"
+              budget: 15000
+              pricing_option_id: "auction_cpm"
+              optimization_goals:
+                - kind: "metric"
+                  metric: "clicks"
+                  target:
+                    kind: "cost_per"
+                    value: 2.50
+                  priority: 1
+          idempotency_key: "$generate:uuid_v4#clicks_buy_flow_create_clicks_buy_create_media_buy"
+        context_outputs:
+          - name: media_buy_id
+            path: "media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Media buy has a platform-assigned ID"
+
+  - id: clicks_delivery
+    title: "Delivery reporting carries clicks and cost_per_click"
+    narrative: |
+      The discriminating assertion of the click-optimization mode: delivery
+      reporting MUST surface clicks and cost_per_click — not just
+      impressions and spend. The runner injects simulated impressions,
+      clicks, and spend via the test controller, then verifies
+      get_media_buy_delivery returns clicks + cost_per_click on totals.
+
+      cost_per_click is defined in delivery-metrics.json as spend / clicks;
+      sellers optimizing for clicks at a cost_per target are committing to
+      populate both fields on delivery responses so the buyer can reconcile
+      effective CPC against the target.
+
+    steps:
+      - id: simulate_clicks_delivery
+        title: "Inject impressions + clicks + spend"
+        task: comply_test_controller
+        requires_tool: comply_test_controller
+        stateful: true
+        expected: |
+          The test controller acknowledges the simulated delivery.
+        sample_request:
+          account:
+            sandbox: true
+          scenario: "simulate_delivery"
+          params:
+            media_buy_id: "$context.media_buy_id"
+            impressions: 300000
+            clicks: 4800
+            reported_spend:
+              amount: 11000.00
+              currency: "USD"
+        validations:
+          - check: field_value
+            path: "success"
+            allowed_values: [true]
+            description: "Delivery simulation succeeds"
+
+      - id: get_clicks_delivery
+        title: "Get delivery and verify clicks + cost_per_click metrics"
+        task: get_media_buy_delivery
+        schema_ref: "media-buy/get-media-buy-delivery-request.json"
+        response_schema_ref: "media-buy/get-media-buy-delivery-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buy_delivery"
+        stateful: true
+        expected: |
+          Delivery response includes totals.clicks (the click count) and
+          totals.cost_per_click (effective CPC, spend / clicks). These are
+          the discriminating output fields of click optimization and are
+          required on click-optimized buys.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "$context.media_buy_id"
+          include_package_daily_breakdown: true
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buy-delivery-response.json schema"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.clicks"
+            description: "Click count surfaced at the buy level"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.cost_per_click"
+            description: "Effective CPC surfaced at the buy level (spend / clicks — the discriminating field of click-optimization with a cost_per target)"

--- a/static/compliance/source/protocols/media-buy/scenarios/completed_views_buy_flow.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/completed_views_buy_flow.yaml
@@ -1,0 +1,344 @@
+id: media_buy_seller/completed_views_buy_flow
+version: "1.0.0"
+title: "Seller fulfills a video media buy with a completed_views optimization goal (target CPCV)"
+category: media_buy_seller
+summary: "Verifies that a seller advertising completed_views in supported_optimization_metrics can accept a media buy whose metric-kind optimization_goal targets completed views at a buyer-supplied view_duration_seconds, reject view_duration_seconds values not in the product's metric_optimization.supported_view_durations, and report completed_views + completion_rate on delivery. Sibling to reach_buy_flow on the video-completion side: sellers without video inventory (display-only DSPs, retail-media networks, audio-only sellers without video products) grade not_applicable."
+track: media_buy
+
+# Gate: scenario runs only when the seller declares completed_views in
+# media_buy.supported_optimization_metrics (proposed in #4669). Sellers
+# without video inventory or whose video products don't optimize for
+# completion (display-only DSPs, retail-media networks, audio-only
+# sellers without video) grade `not_applicable`, not failing. Gating
+# on the explicit metric in supported_optimization_metrics avoids
+# over-claiming against the broad delivery-tracking community.
+# Requires runner support for the `contains:` matcher (adcp-client >= 7.70).
+requires_capability:
+  path: media_buy.supported_optimization_metrics
+  contains: "completed_views"
+
+required_tools:
+  - get_products
+  - create_media_buy
+  - get_media_buy_delivery
+  - comply_test_controller
+
+invariants:
+  - status.monotonic
+
+narrative: |
+  A "completed-views buy" (CPCV — cost per completed view) is a video or
+  audio media buy whose optimization_goal is metric-kind with metric:
+  completed_views, a buyer-supplied view_duration_seconds (e.g., 2 for
+  Snap/LinkedIn defaults, 6 for TikTok, 15 for Meta ThruPlay), and a
+  target.kind: cost_per target. The view_duration_seconds value MUST be
+  in the product's metric_optimization.supported_view_durations — silent
+  rounding to the seller's nearest supported duration would create
+  measurement discrepancies (a buyer targeting 6-second completion would
+  unknowingly be billed against 2-second or 15-second completion).
+
+  Discriminating behaviors this scenario verifies:
+  1. create_media_buy with metric: completed_views, a view_duration_seconds
+     value declared in the product's supported_view_durations, and a
+     target.kind: cost_per target is accepted.
+  2. create_media_buy with a view_duration_seconds value NOT in the
+     product's supported_view_durations is rejected with INVALID_REQUEST.
+     error.field points at the offending view_duration_seconds path.
+     optimization-goal.json:50-53 makes this requirement explicit:
+     "Sellers must reject goals with unsupported values — silent rounding
+     would create measurement discrepancies."
+  3. get_media_buy_delivery surfaces totals.completed_views and
+     totals.completion_rate on delivery. completion_rate is defined in
+     delivery-metrics.json as completed_views / impressions; sellers
+     optimizing for completed_views MUST populate both fields.
+
+  The 999-second view_duration is chosen for the rejection arm because
+  no honest video product will declare a 999-second duration in
+  supported_view_durations — common values are 2, 6, 15, and 30. A
+  seller that round-trips 999 as accepted is demonstrating they don't
+  validate against their product capability declarations.
+
+agent:
+  interaction_model: media_buy_seller
+  capabilities:
+    - sells_media
+    - supports_non_guaranteed
+  examples:
+    - "CTV sellers optimizing for video completion"
+    - "Social platforms with video completion goals (Meta ThruPlay, TikTok 6-second views)"
+    - "Audio sellers optimizing for podcast/stream completion"
+    - "Online video DSPs with CPCV pricing"
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: |
+    The seller must implement comply_test_controller with simulate_delivery
+    (already required for delivery_reporting). simulate_delivery injects
+    impressions and completed_views so get_media_buy_delivery has something
+    to surface for the completion-optimized buy.
+
+    The buyer fixture supplies a brand, an operator, and video-channel
+    targeting parameters sufficient to exercise the view_duration_seconds
+    binding contract and the unsupported-value rejection.
+  test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  products:
+    - product_id: "cpcv_video_q2"
+      delivery_type: "non_guaranteed"
+      channels: ["video"]
+      format_ids:
+        - id: "video_30s"
+  pricing_options:
+    - product_id: "cpcv_video_q2"
+      pricing_option_id: "auction_cpm"
+      pricing_model: "cpm"
+      currency: "USD"
+      floor_price: 12.00
+
+phases:
+
+  - id: setup
+    title: "Establish account and discover products"
+    steps:
+      - id: sync_accounts
+        title: "Establish account"
+        task: sync_accounts
+        schema_ref: "account/sync-accounts-request.json"
+        response_schema_ref: "account/sync-accounts-response.json"
+        doc_ref: "/accounts/tasks/sync_accounts"
+        stateful: true
+        expected: |
+          Return the account with account_id and status active.
+        sample_request:
+          accounts:
+            - brand:
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
+              billing: "operator"
+          idempotency_key: "$generate:uuid_v4#completed_views_buy_flow_setup_sync_accounts"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-accounts-response.json schema"
+          - check: field_present
+            path: "accounts[0].account_id"
+            description: "Account has a platform-assigned ID"
+
+      - id: get_products_for_cpcv
+        title: "Discover video products that support completed_views optimization"
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        stateful: false
+        expected: |
+          Return at least one video product whose metric_optimization
+          capabilities include completed_views as an optimization metric and
+          declare supported_view_durations. The buyer selects a duration
+          from that list for the create_media_buy call below.
+        sample_request:
+          buying_mode: "brief"
+          brief: "Online video / CTV, US adults 25-54. Q2 flight ~$30K, optimizing for completed views at a 6-second threshold with target CPCV."
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+        validations:
+          - check: response_schema
+            description: "Response matches get-products-response.json schema"
+          - check: field_present
+            path: "products"
+            description: "Response contains products"
+
+  - id: create_cpcv_buy
+    title: "Create a completed-views buy at a supported view_duration"
+    narrative: |
+      The buyer creates a media buy whose package carries a metric-kind
+      optimization_goal with metric: completed_views, view_duration_seconds:
+      6 (a common supported value for online video — TikTok native, Meta
+      6-second qualifier), and target.kind: cost_per at $0.05 per completed
+      view. The seller should accept and return a media_buy_id used for
+      subsequent delivery checks.
+
+    steps:
+      - id: create_media_buy_cpcv
+        title: "Create media buy with metric-kind completed_views goal"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        expected: |
+          Create the media buy. Response carries a media_buy_id used for
+          subsequent get_media_buy_delivery calls.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-06-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "cpcv_video_q2"
+              budget: 30000
+              pricing_option_id: "auction_cpm"
+              optimization_goals:
+                - kind: "metric"
+                  metric: "completed_views"
+                  view_duration_seconds: 6
+                  target:
+                    kind: "cost_per"
+                    value: 0.05
+                  priority: 1
+          idempotency_key: "$generate:uuid_v4#completed_views_buy_flow_create_cpcv_buy_create_media_buy"
+        context_outputs:
+          - name: media_buy_id
+            path: "media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Media buy has a platform-assigned ID"
+
+  - id: rejection_unsupported_view_duration
+    title: "Reject a completed_views goal whose view_duration_seconds is not in supported_view_durations"
+    narrative: |
+      Silent acceptance of a view_duration_seconds value not declared in
+      the product's metric_optimization.supported_view_durations is a
+      façade — the seller either rounds to the nearest supported duration
+      (creating measurement discrepancies where the buyer thinks they're
+      paying for 999-second completion but is billed against the rounded
+      duration) or runs without a duration (delivery becomes uncomparable).
+      The seller MUST reject with INVALID_REQUEST and set error.field to
+      the offending view_duration_seconds path. Same shape as the
+      unsupported reach_unit rejection in reach_buy_flow.
+
+      optimization-goal.json:50-53 makes this requirement explicit:
+      "Sellers declare which durations they support in
+      metric_optimization.supported_view_durations. Sellers must reject
+      goals with unsupported values — silent rounding would create
+      measurement discrepancies."
+
+      The literal 999 is chosen because no honest video product will
+      declare a 999-second duration — common values are 2, 6, 15, and 30.
+
+    steps:
+      - id: create_media_buy_with_phantom_view_duration
+        title: "Submit a completed_views goal whose view_duration_seconds is not in supported_view_durations"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: false
+        expected: |
+          Reject with INVALID_REQUEST. error.field points at the offending
+          view_duration_seconds path. media_buy_id is not allocated.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-06-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "cpcv_video_q2"
+              budget: 5000
+              pricing_option_id: "auction_cpm"
+              optimization_goals:
+                - kind: "metric"
+                  metric: "completed_views"
+                  view_duration_seconds: 999
+                  target:
+                    kind: "cost_per"
+                    value: 0.05
+          idempotency_key: "$generate:uuid_v4#completed_views_buy_flow_rejection_unsupported_view_duration"
+        validations:
+          - check: error_code
+            allowed_values: ["INVALID_REQUEST"]
+            description: "Seller rejects the unsupported view_duration_seconds with INVALID_REQUEST"
+          - check: field_value
+            path: "errors[0].field"
+            value: "packages[0].optimization_goals[0].view_duration_seconds"
+            description: "Error.field points at the offending view_duration_seconds path (core/error.json defines field as deterministic JSONPath-lite — literal equality)"
+
+  - id: cpcv_delivery
+    title: "Delivery reporting carries completed_views and completion_rate"
+    narrative: |
+      The discriminating assertion of the completed-views buy mode:
+      delivery reporting MUST surface completed_views and completion_rate
+      — not just impressions and spend. The runner injects simulated
+      impressions and completed_views via the test controller, then
+      verifies get_media_buy_delivery returns completed_views +
+      completion_rate on totals.
+
+      completion_rate is defined in delivery-metrics.json as
+      completed_views / impressions; sellers optimizing for completed_views
+      at a target view_duration_seconds are committing to populate both
+      fields on delivery responses.
+
+    steps:
+      - id: simulate_cpcv_delivery
+        title: "Inject impressions + completed_views + spend"
+        task: comply_test_controller
+        requires_tool: comply_test_controller
+        stateful: true
+        expected: |
+          The test controller acknowledges the simulated delivery.
+        sample_request:
+          account:
+            sandbox: true
+          scenario: "simulate_delivery"
+          params:
+            media_buy_id: "$context.media_buy_id"
+            impressions: 500000
+            completed_views: 350000
+            reported_spend:
+              amount: 18000.00
+              currency: "USD"
+        validations:
+          - check: field_value
+            path: "success"
+            allowed_values: [true]
+            description: "Delivery simulation succeeds"
+
+      - id: get_cpcv_delivery
+        title: "Get delivery and verify completed_views + completion_rate metrics"
+        task: get_media_buy_delivery
+        schema_ref: "media-buy/get-media-buy-delivery-request.json"
+        response_schema_ref: "media-buy/get-media-buy-delivery-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buy_delivery"
+        stateful: true
+        expected: |
+          Delivery response includes totals.completed_views (the completion
+          count at the declared view_duration_seconds threshold) and
+          totals.completion_rate (completed_views / impressions). These two
+          fields are the discriminating output of completed-views
+          optimization and are required on completion-optimized buys.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "$context.media_buy_id"
+          include_package_daily_breakdown: true
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buy-delivery-response.json schema"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.completed_views"
+            description: "Completed-views count surfaced at the buy level (at the declared view_duration_seconds threshold)"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.completion_rate"
+            description: "Completion rate surfaced at the buy level (completed_views / impressions)"

--- a/static/compliance/source/protocols/media-buy/scenarios/performance_buy_flow_roas.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/performance_buy_flow_roas.yaml
@@ -1,0 +1,470 @@
+id: media_buy_seller/performance_buy_flow_roas
+version: "1.0.0"
+title: "Seller fulfills a performance (event-kind goal) media buy with a ROAS target"
+category: media_buy_seller
+summary: "Verifies that a seller advertising conversion_tracking with per_ad_spend in supported_targets can accept a media buy whose event-kind optimization_goal carries a ROAS (per_ad_spend) target bound to an event source with value_field, reject ROAS goals that omit value_field on every event-source entry, ingest valued purchase events, and report conversion_value + roas alongside conversions and cost_per_acquisition. Sibling to media_buy_seller/performance_buy_flow gated on the supported_targets sub-capability: sellers that don't advertise per_ad_spend (most broadcast TV, upper-funnel video, signal-only) grade not_applicable."
+track: media_buy
+
+# Gate: scenario runs only when the seller declares per_ad_spend in
+# conversion_tracking.supported_targets. Sellers that compute conversions
+# but not return-on-ad-spend (broadcast TV, upper-funnel video, signal-only,
+# many MMP-mediated mobile pipelines) grade `not_applicable`, not failing.
+# supported_targets is a per-target-kind enumeration of the target kinds the
+# seller can actually optimize toward (proposed in #4639). Gating on the
+# explicit kind rather than on conversion_tracking presence is what keeps
+# honest CPA-only implementations from failing. Requires runner support for
+# the `contains:` matcher (adcp-client >= 7.70).
+requires_capability:
+  path: media_buy.conversion_tracking.supported_targets
+  contains: "per_ad_spend"
+
+required_tools:
+  - get_products
+  - sync_event_sources
+  - create_media_buy
+  - log_event
+  - get_media_buy_delivery
+  - comply_test_controller
+
+invariants:
+  - status.monotonic
+
+narrative: |
+  A "ROAS buy" is a performance media buy whose optimization_goal targets
+  return-on-ad-spend rather than cost-per-acquisition. The buyer commits to
+  a target_roas (per_ad_spend) and binds the buy to one or more conversion
+  event sources whose events carry monetary value. value_field on the
+  event-source entry tells the seller which custom_data field carries the
+  per-event value to aggregate; without value_field there is nothing to
+  divide by spend, so the seller MUST reject the goal.
+
+  This scenario is a sibling to media_buy_seller/performance_buy_flow, gated
+  on a separate sub-capability bit (conversion_tracking.supported_targets
+  contains per_ad_spend). The CPA scenario is gated on conversion_tracking
+  presence — every seller that tracks conversions can compute CPA. ROAS is
+  narrower: many performance sellers honestly track conversions but don't
+  compute return-on-ad-spend because their attribution doesn't carry value.
+  Gating ROAS on the explicit per_ad_spend kind in supported_targets is what
+  prevents that population from being marked failing instead of
+  not_applicable.
+
+  Discriminating behaviors this scenario verifies:
+  1. sync_event_sources returns an event_source_id that is valid as the
+     binding target on a per_ad_spend optimization_goal.
+  2. create_media_buy with an event-kind goal whose target.kind is
+     per_ad_spend AND whose event_sources[k].value_field is populated is
+     accepted.
+  3. create_media_buy with target.kind = per_ad_spend AND NO value_field on
+     any event_sources[] entry is rejected with INVALID_REQUEST. The seller
+     cannot compute ROAS without a value field; silent acceptance would mean
+     reporting roas: 0 for the life of the buy. error.field points at the
+     offending value_field absence at packages[0].optimization_goals[0].event_sources[0].value_field.
+  4. log_event flows valued conversions back, scoped to the registered
+     event_source_id with order_total in custom_data.
+  5. get_media_buy_delivery returns first-class ROAS metrics — conversion_value
+     and roas — alongside conversions and cost_per_acquisition. CPA is still
+     computed (spend / conversions is well-defined for any conversion source);
+     roas is the field this scenario exists to assert.
+
+  Per-creative ROAS breakdown is deliberately NOT asserted here for the
+  same reason per-creative attribution is deferred in performance_buy_flow:
+  honest adopters report at differing granularities (social per-ad, retail-
+  media per-line, MMP-mediated per-campaign, broadcast/CTV per-placement).
+  A follow-up scenario gated on a sub-capability bit will land per-creative
+  value attribution once the breakdown shape is settled.
+
+agent:
+  interaction_model: media_buy_seller
+  capabilities:
+    - sells_media
+    - supports_non_guaranteed
+    - conversion_tracking
+  examples:
+    - "Performance-mode DSPs with value-aware bidding"
+    - "Retail-media networks (Amazon Ads, Criteo, Walmart Connect)"
+    - "Social platforms with value optimization (Meta VBO, TikTok VBO)"
+    - "Agentic optimizers that pass value into upstream attribution"
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: |
+    The seller must implement comply_test_controller with simulate_delivery
+    (already required for delivery_reporting). simulate_delivery's
+    `conversions` param injects attributed conversion counts and the seller
+    is expected to compute conversion_value from logged events with
+    order_total. Sellers whose attribution pipeline cannot ingest a value
+    field do not advertise per_ad_spend in supported_targets and grade
+    not_applicable.
+
+    The buyer fixture supplies a brand, an operator, a conversion event
+    source definition, and a valued purchase event sufficient to exercise
+    the ROAS reporting contract.
+  test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  products:
+    - product_id: "performance_roas_native_q2"
+      delivery_type: "non_guaranteed"
+      channels: ["display", "native"]
+      format_ids:
+        - id: "native_feed_1x1"
+        - id: "display_300x250"
+  pricing_options:
+    - product_id: "performance_roas_native_q2"
+      pricing_option_id: "auction_cpm"
+      pricing_model: "cpm"
+      currency: "USD"
+      floor_price: 1.50
+
+phases:
+
+  - id: setup
+    title: "Establish account and discover products"
+    steps:
+      - id: sync_accounts
+        title: "Establish account"
+        task: sync_accounts
+        schema_ref: "account/sync-accounts-request.json"
+        response_schema_ref: "account/sync-accounts-response.json"
+        doc_ref: "/accounts/tasks/sync_accounts"
+        stateful: true
+        expected: |
+          Return the account with account_id and status active.
+        sample_request:
+          accounts:
+            - brand:
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
+              billing: "operator"
+          idempotency_key: "$generate:uuid_v4#performance_buy_flow_roas_setup_sync_accounts"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-accounts-response.json schema"
+          - check: field_present
+            path: "accounts[0].account_id"
+            description: "Account has a platform-assigned ID"
+
+      - id: get_products_for_roas
+        title: "Discover products that support ROAS optimization"
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        stateful: false
+        expected: |
+          Return at least one product whose conversion_tracking capabilities
+          accept per_ad_spend event-kind targets.
+        sample_request:
+          buying_mode: "brief"
+          brief: "Performance native + display, US, adults 25-54. Target ROAS 4.0 on purchase events with order_total from acmeoutdoor.example."
+          required_capabilities:
+            - "conversion_tracking"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+        validations:
+          - check: response_schema
+            description: "Response matches get-products-response.json schema"
+          - check: field_present
+            path: "products"
+            description: "Response contains products"
+
+  - id: event_source_binding
+    title: "Register the conversion event source"
+    narrative: |
+      The ROAS buy cannot be created without a registered event source whose
+      entry carries value_field. This phase exercises the binding —
+      sync_event_sources returns an event_source_id that the next phase
+      references on a per_ad_spend optimization_goal.
+
+    steps:
+      - id: sync_event_sources
+        title: "Register a website conversion source"
+        task: sync_event_sources
+        schema_ref: "media-buy/sync-event-sources-request.json"
+        response_schema_ref: "media-buy/sync-event-sources-response.json"
+        doc_ref: "/media-buy/task-reference/sync_event_sources"
+        stateful: true
+        expected: |
+          Return event_sources with event_source_id, setup.snippet, and
+          action: created. The id is captured for the ROAS create_media_buy
+          phase.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          event_sources:
+            - event_source_id: "acmeoutdoor_website"
+              name: "Acme Outdoor Website"
+              event_types: ["purchase"]
+              allowed_domains: ["acmeoutdoor.example"]
+          idempotency_key: "$generate:uuid_v4#performance_buy_flow_roas_event_source_binding_sync_event_sources"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-event-sources-response.json schema"
+          - check: field_present
+            path: "event_sources[0].event_source_id"
+            description: "Event source has a platform-assigned ID"
+          - check: field_present
+            path: "event_sources[0].setup.snippet"
+            description: "Event source returns integration code"
+          # Anti-façade: an adapter that returns a shape-valid
+          # sync_event_sources response without forwarding the source
+          # definition upstream fails this check. Adopters who don't
+          # advertise query_upstream_traffic grade not_applicable.
+          - check: upstream_traffic
+            description: "sync_event_sources caused upstream traffic registering the event source"
+            min_count: 1
+            endpoint_pattern: "POST *"
+
+  - id: create_performance_buy_roas
+    title: "Create a performance buy with a ROAS goal"
+    narrative: |
+      The buyer creates a media buy whose package carries an event-kind
+      optimization_goal binding to the registered event source. The target
+      is per_ad_spend (ROAS) 4.0 on purchase events, with value_field
+      "order_total" telling the seller which custom_data field to aggregate.
+
+    steps:
+      - id: create_media_buy_roas
+        title: "Create media buy with event-kind goal (per_ad_spend target)"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        expected: |
+          Create the media buy. Response carries a media_buy_id used for
+          subsequent log_event and get_media_buy_delivery calls.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-06-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "performance_roas_native_q2"
+              budget: 25000
+              pricing_option_id: "auction_cpm"
+              optimization_goals:
+                - kind: "event"
+                  event_sources:
+                    - event_source_id: "acmeoutdoor_website"
+                      event_type: "purchase"
+                      value_field: "order_total"
+                  target:
+                    kind: "per_ad_spend"
+                    value: 4.0
+                  priority: 1
+          idempotency_key: "$generate:uuid_v4#performance_buy_flow_roas_create_performance_buy_roas_create_media_buy"
+        context_outputs:
+          - name: media_buy_id
+            path: "media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Media buy has a platform-assigned ID"
+
+  - id: rejection_per_ad_spend_no_value_field
+    title: "Reject a per_ad_spend goal that omits value_field"
+    narrative: |
+      Silent acceptance of a per_ad_spend target with no value_field on any
+      event_sources[] entry is a façade — the seller cannot compute ROAS
+      without a value to divide by spend, so the buy would silently report
+      roas: 0 (or absent) for the life of the flight. The seller MUST reject
+      with INVALID_REQUEST and set error.field to the offending value_field
+      absence on the first event_sources entry. This mirrors the unbound
+      event_source_id rejection in performance_buy_flow on the value side.
+
+      optimization-goal.json:148-156 makes the requirement explicit: target
+      kinds per_ad_spend and maximize_value require value_field on at least
+      one entry. Sellers MUST reject when the requirement is unmet.
+
+    steps:
+      - id: create_media_buy_per_ad_spend_no_value_field
+        title: "Submit a per_ad_spend goal with no value_field on any source"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: false
+        expected: |
+          Reject with INVALID_REQUEST. error.field points at the missing
+          value_field on the event_sources entry. media_buy_id is not
+          allocated.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-06-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "performance_roas_native_q2"
+              budget: 5000
+              pricing_option_id: "auction_cpm"
+              optimization_goals:
+                - kind: "event"
+                  event_sources:
+                    - event_source_id: "acmeoutdoor_website"
+                      event_type: "purchase"
+                  target:
+                    kind: "per_ad_spend"
+                    value: 4.0
+          idempotency_key: "$generate:uuid_v4#performance_buy_flow_roas_rejection_per_ad_spend_no_value_field"
+        validations:
+          - check: error_code
+            allowed_values: ["INVALID_REQUEST"]
+            description: "Seller rejects the per_ad_spend goal with no value_field with INVALID_REQUEST"
+          - check: field_value
+            path: "errors[0].field"
+            value: "packages[0].optimization_goals[0].event_sources[0].value_field"
+            description: "Error.field points at the missing value_field on the first event_sources entry (core/error.json defines field as deterministic JSONPath-lite — literal equality; the value_field path is more buyer-actionable than pointing at target.kind because it tells the buyer what to add, not what to remove)"
+
+  - id: log_purchase_event
+    title: "Log a valued purchase event against the bound source"
+    narrative: |
+      The buyer logs a purchase event with order_total in custom_data tied
+      to the registered event_source_id. The seller's attribution pipeline
+      ingests order_total via the value_field declared on the goal and
+      aggregates it into conversion_value, surfaced in delivery in the next
+      phase.
+
+    steps:
+      - id: log_purchase_event
+        title: "Log a purchase event with order_total"
+        task: log_event
+        schema_ref: "media-buy/log-event-request.json"
+        response_schema_ref: "media-buy/log-event-response.json"
+        doc_ref: "/media-buy/task-reference/log_event"
+        stateful: true
+        expected: |
+          Acknowledge the event with accepted status.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          event_source_id: "acmeoutdoor_website"
+          events:
+            - event_type: "purchase"
+              event_id: "evt_perf_buy_flow_roas_001"
+              event_time: "2026-06-05T14:30:00Z"
+              user_match:
+                hashed_email: "a000000000000000000000000000000000000000000000000000000000000020"
+              custom_data:
+                order_total: 149.99
+                currency: "USD"
+          idempotency_key: "$generate:uuid_v4#performance_buy_flow_roas_log_purchase_event_log_event"
+        validations:
+          - check: response_schema
+            description: "Response matches log-event-response.json schema"
+          - check: upstream_traffic
+            description: "log_event forwards the event to the seller's upstream conversion endpoint with the order_total value"
+            min_count: 1
+            endpoint_pattern: "POST *"
+            identifier_paths:
+              - "events[*].user_match.hashed_email"
+
+  - id: attributed_roas_delivery
+    title: "Delivery reporting carries ROAS, conversion_value, conversions, and CPA"
+    narrative: |
+      The discriminating assertion of the ROAS buy mode: delivery reporting
+      MUST surface conversion_value and roas — not just conversions and CPA.
+      The runner injects simulated impressions, conversions, and spend via
+      the test controller, then verifies get_media_buy_delivery returns all
+      four first-class metrics at the buy level.
+
+      CPA is still computed (spend / conversions is well-defined whenever
+      the seller tracks conversions); ROAS is the addition this scenario
+      exists to certify. Sellers that advertise per_ad_spend in
+      supported_targets are committing to populate conversion_value and roas
+      on delivery responses.
+
+      Per-creative ROAS breakdown is deliberately NOT asserted here for the
+      same reason performance_buy_flow defers per-creative attribution:
+      honest adopters report at differing granularities and gating
+      per-creative value attribution on a sub-capability bit lands as a
+      follow-up scenario.
+
+    steps:
+      - id: simulate_roas_delivery
+        title: "Inject impressions + conversions + spend"
+        task: comply_test_controller
+        requires_tool: comply_test_controller
+        stateful: true
+        expected: |
+          The test controller acknowledges the simulated delivery.
+        sample_request:
+          account:
+            sandbox: true
+          scenario: "simulate_delivery"
+          params:
+            media_buy_id: "$context.media_buy_id"
+            impressions: 200000
+            clicks: 4500
+            conversions: 90
+            reported_spend:
+              amount: 3000.00
+              currency: "USD"
+        validations:
+          - check: field_value
+            path: "success"
+            allowed_values: [true]
+            description: "Delivery simulation succeeds"
+
+      - id: get_attributed_roas_delivery
+        title: "Get delivery and verify ROAS-attributed metrics"
+        task: get_media_buy_delivery
+        schema_ref: "media-buy/get-media-buy-delivery-request.json"
+        response_schema_ref: "media-buy/get-media-buy-delivery-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buy_delivery"
+        stateful: true
+        expected: |
+          Delivery response includes:
+          - conversions (the count of attributed conversions)
+          - conversion_value (the sum of order_total across attributed conversions)
+          - roas (conversion_value / spend — the discriminating assertion for this scenario)
+          - cost_per_acquisition (still computed; ROAS is in addition, not instead)
+
+          Per-creative value attribution is intentionally NOT asserted here
+          (see phase narrative). A follow-up scenario gated on a sub-capability
+          bit will land per-creative ROAS once the breakdown shape is settled.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "$context.media_buy_id"
+          include_package_daily_breakdown: true
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buy-delivery-response.json schema"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.conversions"
+            description: "Conversion count surfaced at the buy level"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.conversion_value"
+            description: "Aggregated conversion_value surfaced at the buy level (sum of order_total across attributed conversions)"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.roas"
+            description: "ROAS surfaced at the buy level — the discriminating assertion of per_ad_spend optimization (conversion_value / spend)"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.cost_per_acquisition"
+            description: "CPA still computed alongside ROAS (spend / conversions)"

--- a/static/compliance/source/protocols/media-buy/scenarios/reach_buy_flow.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/reach_buy_flow.yaml
@@ -1,0 +1,342 @@
+id: media_buy_seller/reach_buy_flow
+version: "1.0.0"
+title: "Seller fulfills a media buy with a reach optimization goal"
+category: media_buy_seller
+summary: "Verifies that a seller advertising reach in supported_optimization_metrics can accept a media buy whose metric-kind optimization_goal targets unique reach with a buyer-supplied reach_unit, reject reach_unit values not in the product's metric_optimization.supported_reach_units, and report reach + frequency on delivery. Sibling to the performance buy scenarios on the brand-reach side: sellers that don't advertise reach as an optimization metric (most pure performance DSPs, retail-media networks) grade not_applicable."
+track: media_buy
+
+# Gate: scenario runs only when the seller declares reach in
+# media_buy.supported_optimization_metrics (proposed in #4669). Sellers
+# whose products optimize for clicks / conversions / views but not unique
+# reach grade `not_applicable`, not failing. Reach as an optimization
+# metric is upper-funnel-shaped — broadcast TV, CTV, social brand
+# campaigns, audio — and gating on the explicit metric in
+# supported_optimization_metrics avoids over-claiming against the
+# performance-tracking community. Requires runner support for the
+# `contains:` matcher (adcp-client >= 7.70).
+requires_capability:
+  path: media_buy.supported_optimization_metrics
+  contains: "reach"
+
+required_tools:
+  - get_products
+  - create_media_buy
+  - get_media_buy_delivery
+  - comply_test_controller
+
+invariants:
+  - status.monotonic
+
+narrative: |
+  A "reach buy" is a media buy whose optimization_goal is metric-kind with
+  metric: reach and a buyer-supplied reach_unit naming the units of the
+  count (individuals / households / devices / accounts / cookies / custom).
+  Optionally the buyer specifies a target_frequency band — the seller treats
+  impressions toward entities already within [min, max] as lower-value and
+  prioritizes fresh reach. This is the upper-funnel optimization shape
+  (broadcast TV, CTV, social brand campaigns, audio) that's distinct from
+  the performance / conversion-tracking shapes.
+
+  Discriminating behaviors this scenario verifies:
+  1. create_media_buy with metric: reach, a reach_unit value declared in
+     the product's metric_optimization.supported_reach_units, and an optional
+     target_frequency band is accepted.
+  2. create_media_buy with a reach_unit value NOT in the product's
+     supported_reach_units is rejected with INVALID_REQUEST. error.field
+     points at the offending reach_unit path. Silent acceptance with
+     unit-coercion would create cross-platform comparison errors because
+     reach in cookies is not reach in households.
+  3. get_media_buy_delivery surfaces totals.reach (the unique-count value)
+     and totals.frequency (average exposures per reach unit over the
+     declared reach_window). reach_unit on delivery aligns with the
+     reach_unit declared on the optimization goal — the unit declaration is
+     load-bearing for cross-platform comparison.
+
+  Per-window reach-window breakdown (cumulative vs period vs rolling
+  semantics declared in delivery-metrics.json's reach_window block) is
+  deliberately NOT asserted at the per-row level here. The scenario asserts
+  that totals.reach and totals.frequency are present at the buy level;
+  follow-up scenarios will exercise the per-window semantics once the
+  reach_window field is widely populated by adopters.
+
+agent:
+  interaction_model: media_buy_seller
+  capabilities:
+    - sells_media
+    - supports_non_guaranteed
+  examples:
+    - "Broadcast TV / CTV sellers optimizing for unique households"
+    - "Social platforms with reach optimization (Meta Reach & Frequency, TikTok Reach)"
+    - "Audio sellers optimizing for unique listeners"
+    - "OOH / DOOH sellers optimizing for unique passers-by"
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: |
+    The seller must implement comply_test_controller with simulate_delivery
+    (already required for delivery_reporting). simulate_delivery injects
+    impressions, reach, and frequency values so get_media_buy_delivery has
+    something to surface for the reach-optimized buy.
+
+    The buyer fixture supplies a brand, an operator, and reach targeting
+    parameters sufficient to exercise the reach_unit binding contract and
+    the unsupported-unit rejection.
+  test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  products:
+    - product_id: "reach_ctv_q2"
+      delivery_type: "non_guaranteed"
+      channels: ["video"]
+      format_ids:
+        - id: "video_30s"
+  pricing_options:
+    - product_id: "reach_ctv_q2"
+      pricing_option_id: "auction_cpm"
+      pricing_model: "cpm"
+      currency: "USD"
+      floor_price: 18.00
+
+phases:
+
+  - id: setup
+    title: "Establish account and discover products"
+    steps:
+      - id: sync_accounts
+        title: "Establish account"
+        task: sync_accounts
+        schema_ref: "account/sync-accounts-request.json"
+        response_schema_ref: "account/sync-accounts-response.json"
+        doc_ref: "/accounts/tasks/sync_accounts"
+        stateful: true
+        expected: |
+          Return the account with account_id and status active.
+        sample_request:
+          accounts:
+            - brand:
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
+              billing: "operator"
+          idempotency_key: "$generate:uuid_v4#reach_buy_flow_setup_sync_accounts"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-accounts-response.json schema"
+          - check: field_present
+            path: "accounts[0].account_id"
+            description: "Account has a platform-assigned ID"
+
+      - id: get_products_for_reach
+        title: "Discover products that support reach optimization"
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        stateful: false
+        expected: |
+          Return at least one product whose metric_optimization capabilities
+          include reach as an optimization metric and declare
+          supported_reach_units. The buyer selects a unit from that list for
+          the create_media_buy call below.
+        sample_request:
+          buying_mode: "brief"
+          brief: "CTV video, US adults 25-54. Q2 brand flight ~$50K, optimizing for unique household reach with a target frequency cap."
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+        validations:
+          - check: response_schema
+            description: "Response matches get-products-response.json schema"
+          - check: field_present
+            path: "products"
+            description: "Response contains products"
+
+  - id: create_reach_buy
+    title: "Create a reach-optimized buy with a supported reach_unit"
+    narrative: |
+      The buyer creates a media buy whose package carries a metric-kind
+      optimization_goal with metric: reach, reach_unit: households (assumed
+      to be in the product's supported_reach_units for CTV inventory), and
+      a target_frequency band of 1–3 over a 7-day rolling window. The seller
+      should accept and return a media_buy_id used for subsequent delivery
+      checks.
+
+    steps:
+      - id: create_media_buy_reach
+        title: "Create media buy with metric-kind reach goal"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        expected: |
+          Create the media buy. Response carries a media_buy_id used for
+          subsequent get_media_buy_delivery calls.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-06-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "reach_ctv_q2"
+              budget: 50000
+              pricing_option_id: "auction_cpm"
+              optimization_goals:
+                - kind: "metric"
+                  metric: "reach"
+                  reach_unit: "households"
+                  target_frequency:
+                    window:
+                      interval: 7
+                      unit: "days"
+                    min: 1
+                    max: 3
+                  priority: 1
+          idempotency_key: "$generate:uuid_v4#reach_buy_flow_create_reach_buy_create_media_buy"
+        context_outputs:
+          - name: media_buy_id
+            path: "media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Media buy has a platform-assigned ID"
+
+  - id: rejection_unsupported_reach_unit
+    title: "Reject a reach goal whose reach_unit is not in supported_reach_units"
+    narrative: |
+      Silent acceptance of a reach_unit value not declared in the product's
+      metric_optimization.supported_reach_units is a façade — the seller
+      either coerces the unit (creating cross-platform comparison errors)
+      or runs without a unit (delivery reach values become uncomparable).
+      The seller MUST reject with INVALID_REQUEST and set error.field to the
+      offending reach_unit path. Same shape as the unbound event_source_id
+      rejection in performance_buy_flow and the unbound audience_id
+      rejection in audience_buy_flow.
+
+      The literal string "phantom_unit" is chosen because no spec-defined
+      reach_unit value matches it and no honest product will declare it in
+      supported_reach_units. Sellers that round-trip "phantom_unit" as
+      accepted are demonstrating they don't validate against their product
+      capability declarations.
+
+    steps:
+      - id: create_media_buy_with_phantom_reach_unit
+        title: "Submit a reach goal whose reach_unit is not in supported_reach_units"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: false
+        expected: |
+          Reject with INVALID_REQUEST. error.field points at the offending
+          reach_unit path. media_buy_id is not allocated.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-06-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "reach_ctv_q2"
+              budget: 10000
+              pricing_option_id: "auction_cpm"
+              optimization_goals:
+                - kind: "metric"
+                  metric: "reach"
+                  reach_unit: "phantom_unit"
+          idempotency_key: "$generate:uuid_v4#reach_buy_flow_rejection_unsupported_reach_unit"
+        validations:
+          - check: error_code
+            allowed_values: ["INVALID_REQUEST"]
+            description: "Seller rejects the unsupported reach_unit with INVALID_REQUEST"
+          - check: field_value
+            path: "errors[0].field"
+            value: "packages[0].optimization_goals[0].reach_unit"
+            description: "Error.field points at the offending reach_unit path (core/error.json defines field as deterministic JSONPath-lite — literal equality)"
+
+  - id: reach_delivery
+    title: "Delivery reporting carries reach and frequency"
+    narrative: |
+      The discriminating assertion of the reach buy mode: delivery reporting
+      MUST surface reach and frequency at the buy level — not just
+      impressions and spend. The runner injects simulated impressions,
+      reach, and frequency via the test controller, then verifies
+      get_media_buy_delivery returns reach + frequency on totals.
+
+      Per-row reach_window semantics (cumulative vs period vs rolling — see
+      delivery-metrics.json) are deliberately not asserted at this layer.
+      The scenario asserts the discriminating fields are present at the
+      buy level; reach_window correctness is asserted by the schema
+      validation alongside the totals payload.
+
+    steps:
+      - id: simulate_reach_delivery
+        title: "Inject impressions + reach + frequency"
+        task: comply_test_controller
+        requires_tool: comply_test_controller
+        stateful: true
+        expected: |
+          The test controller acknowledges the simulated delivery.
+        sample_request:
+          account:
+            sandbox: true
+          scenario: "simulate_delivery"
+          params:
+            media_buy_id: "$context.media_buy_id"
+            impressions: 750000
+            reach: 250000
+            frequency: 3.0
+            reported_spend:
+              amount: 14000.00
+              currency: "USD"
+        validations:
+          - check: field_value
+            path: "success"
+            allowed_values: [true]
+            description: "Delivery simulation succeeds"
+
+      - id: get_reach_delivery
+        title: "Get delivery and verify reach + frequency metrics"
+        task: get_media_buy_delivery
+        schema_ref: "media-buy/get-media-buy-delivery-request.json"
+        response_schema_ref: "media-buy/get-media-buy-delivery-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buy_delivery"
+        stateful: true
+        expected: |
+          Delivery response includes totals.reach (the unique-count value
+          in the declared reach_unit) and totals.frequency (average
+          exposures per reach unit over the declared reach_window). These
+          two fields are the discriminating output of reach optimization
+          and are required on reach-optimized buys.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "$context.media_buy_id"
+          include_package_daily_breakdown: true
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buy-delivery-response.json schema"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.reach"
+            description: "Reach count surfaced at the buy level (in the declared reach_unit)"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.frequency"
+            description: "Frequency surfaced at the buy level — average exposures per reach unit"

--- a/static/compliance/source/specialisms/sales-non-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-non-guaranteed/index.yaml
@@ -10,6 +10,8 @@ required_tools:
   - create_media_buy
 requires_scenarios:
   - media_buy_seller/audience_buy_flow
+  - media_buy_seller/clicks_buy_flow
+  - media_buy_seller/completed_views_buy_flow
   - media_buy_seller/delivery_reporting
   - media_buy_seller/event_dedup_flow
   - media_buy_seller/inventory_list_no_match
@@ -17,6 +19,8 @@ requires_scenarios:
   - media_buy_seller/invalid_transitions
   - media_buy_seller/pending_creatives_to_start
   - media_buy_seller/performance_buy_flow
+  - media_buy_seller/performance_buy_flow_roas
+  - media_buy_seller/reach_buy_flow
 
 # Cross-step assertion (adcp#2664). status.monotonic rejects resource
 # status transitions observed across steps that aren't on the spec


### PR DESCRIPTION
## Summary

Four new storyboard scenarios in the capability-claim contract pattern, all gated via the `contains:` matcher shipped in @adcp/client 7.70 (adcp-client#1817), all added to `sales-non-guaranteed.requires_scenarios`. Each certifies a discriminating optimization shape end-to-end (acceptance + rejection where the spec defines one + delivery surfaces the discriminating fields).

### Scenarios

- **`media_buy_seller/performance_buy_flow_roas`** — gated on `media_buy.conversion_tracking.supported_targets` containing `per_ad_spend` (#4639). Sibling to `performance_buy_flow` (#4642) on the value side. Certifies ROAS goal acceptance, rejection of `per_ad_spend` goals with no `value_field` on any event_sources entry (per `optimization-goal.json:148-156`), and delivery surfaces `conversion_value` + `roas` alongside `conversions` + `cost_per_acquisition`.

- **`media_buy_seller/reach_buy_flow`** — gated on `media_buy.supported_optimization_metrics` containing `reach` (#4669). Certifies reach goal acceptance with a buyer-supplied `reach_unit` and optional `target_frequency` band, rejection of `reach_unit` values not in the product's `metric_optimization.supported_reach_units`, and delivery surfaces `reach` + `frequency`.

- **`media_buy_seller/clicks_buy_flow`** — gated on `media_buy.supported_optimization_metrics` containing `clicks` (#4669). Certifies click goal acceptance with a `cost_per` target and delivery surfaces `clicks` + `cost_per_click`. Lightweight three-phase shape — no rejection arm, since clicks is universal in semantics with no obvious unbound-id surface.

- **`media_buy_seller/completed_views_buy_flow`** — gated on `media_buy.supported_optimization_metrics` containing `completed_views` (#4669). Certifies completion goal acceptance at a buyer-supplied `view_duration_seconds`, rejection of `view_duration_seconds` values not in the product's `metric_optimization.supported_view_durations` (per `optimization-goal.json:50-53` — silent rounding creates measurement discrepancies), and delivery surfaces `completed_views` + `completion_rate`.

### Why `contains:` (vs `present:`)

The CPA scenario (#4642) gates on `conversion_tracking` presence — every seller that tracks conversions can compute CPA. The four scenarios in this PR are narrower: each certifies a specific optimization target-kind or metric. Gating on presence of the parent capability would over-claim (a CPA-only DSP would fail the ROAS scenario; a click-optimized DSP without video would fail the completed_views scenario). `contains:` filters on specific membership in an array-valued capability so honest implementations grade `not_applicable`, not failing.

### Training agent — `not_applicable` by design

All four scenarios grade `not_applicable` against the embedded training agent today. The training agent doesn't declare `supported_targets` or `supported_optimization_metrics` and therefore cannot claim these optimization kinds. This is the correct anti-façade hygiene per the `event_dedup_flow` precedent (#4664): an agent that doesn't claim a capability is not held to its scenario. The training agent stays honest by NOT claiming what it can't do; production adopters opt in by declaring the capability bits.

No training-agent code changes in this PR.

## Test plan

- [x] `npm run build:schemas` — clean
- [x] `npm run build:compliance` — all 12 lints pass (storyboard scoping, branch-sets, provides_state_for, contradictions, context-entity, auth-shape, test-kits, pagination-invariant, vendor-metric-uniqueness, check-enum, raw-mode-required, advisory-expiry)
- [x] `npm run typecheck` — pre-existing unrelated training-agent errors only (verified against `origin/main`)
- [ ] Storyboard runner picks up four new scenarios under `sales-non-guaranteed` and grades them `not_applicable` against training-agent
- [ ] When an adopter declares `conversion_tracking.supported_targets: [per_ad_spend]`, the ROAS scenario runs against them and asserts `conversion_value` / `roas` on delivery
- [ ] When an adopter declares `supported_optimization_metrics: [reach]`, the reach scenario runs and asserts reach_unit rejection + reach/frequency on delivery

Refs: #4637 (meta), #4639 (`supported_targets`), #4669 (`supported_optimization_metrics`), #4642 (CPA precedent), #4664 (`event_dedup_flow` precedent), #4651 (product-level capability gating), adcp-client#1817 (`contains:` matcher).

🤖 Generated with [Claude Code](https://claude.com/claude-code)