### PR TITLE
feat(watchdog): active recovery for stopped workers (#4723)

### DIFF
--- a/.changeset/4723-fly-worker-comment-correction.md
+++ b/.changeset/4723-fly-worker-comment-correction.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Correct misleading comment in `fly.toml` for the worker `[[services]]` block. The block was introduced in PR #3374 with `auto_start_machines = true` + `min_machines_running = 1`, and the comment claimed this opted the worker into Fly's autostart lifecycle. Per Fly docs, those flags are only enforced via fly-proxy, and a `[[services]]` block without `[[services.ports]]` doesn't get fly-proxy routing — so both settings are inert. The block still serves a purpose (it attaches the http_check), but the autostart claim was wrong. The actual recovery gap is tracked in #4723. Comment-only change; no behavior delta.

--- a/.changeset/4723-fly-worker-comment-correction.md
+++ b/.changeset/4723-fly-worker-comment-correction.md
@@ -2,4 +2,8 @@
 "adcontextprotocol": patch
 ---
 
-Correct misleading comment in `fly.toml` for the worker `[[services]]` block. The block was introduced in PR #3374 with `auto_start_machines = true` + `min_machines_running = 1`, and the comment claimed this opted the worker into Fly's autostart lifecycle. Per Fly docs, those flags are only enforced via fly-proxy, and a `[[services]]` block without `[[services.ports]]` doesn't get fly-proxy routing — so both settings are inert. The block still serves a purpose (it attaches the http_check), but the autostart claim was wrong. The actual recovery gap is tracked in #4723. Comment-only change; no behavior delta.
+Fix worker recovery gap on rolling deploys (#4723). PR #3374 added `auto_start_machines = true` + `min_machines_running = 1` to the worker `[[services]]` block, but per Fly docs those flags are only enforced via fly-proxy — and a `[[services]]` block without `[[services.ports]]` doesn't get fly-proxy routing. The settings were inert. If a rolling deploy left the worker `stopped` (flyctl does not always issue `MachineStart` after `MachineUpdate`), nothing brought it back automatically; the watchdog from PR #4358 observed the failure but couldn't recover. Today's incident at 04:31 UTC required a manual `fly machine start`.
+
+The watchdog now actively recovers: on probe failure it queries the Fly Machines API, finds any worker machines in `stopped` state, and starts them. Started machines surface as a successful probe on the next tick; if start didn't help (real crashloop), failures keep climbing and the alert still fires. Requires `FLY_API_TOKEN` secret on the app — without it, recovery is a no-op and behavior matches PR #4358.
+
+Also corrects the misleading comment block in `fly.toml` that asserted autostart was wired up.

--- a/fly.toml
+++ b/fly.toml
@@ -58,9 +58,10 @@ primary_region = 'iad'
 # directly over 6PN, so its traffic also bypasses fly-proxy and cannot
 # trigger autostart.
 #
-# Consequence: if a rolling deploy leaves the worker `stopped` (flyctl
-# does not always issue MachineStart after MachineUpdate), nothing
-# automatic brings it back. See issue #4723 for the recovery-gap fix.
+# Rolling deploys can leave the worker `stopped` (flyctl does not always
+# issue MachineStart after MachineUpdate). Active recovery now lives in
+# the watchdog: when a probe fails, it calls the Fly Machines API to
+# start any stopped worker machines. Requires `FLY_API_TOKEN` secret.
 [[services]]
   internal_port = 8080
   protocol = "tcp"

--- a/fly.toml
+++ b/fly.toml
@@ -50,22 +50,23 @@ primary_region = 'iad'
 
 # Worker process group config.
 #
-# `[[services]]` (rather than a bare `[[checks]]`) opts the worker process
-# group into Fly's auto_start_machines + min_machines_running lifecycle —
-# the same mechanism `[http_service]` uses for web. Without this, workers
-# created by a rolling deploy stay in `stopped` state forever (no
-# auto_start path) and the periodic crawler / scheduled jobs don't run.
+# The `[[services]]` block here exists only to attach an http_check to the
+# worker process group. `auto_start_machines` and `min_machines_running`
+# are SET but INERT — Fly only enforces them via fly-proxy, and without a
+# `[[services.ports]]` block fly-proxy doesn't route to this service. The
+# watchdog at server/src/services/worker-watchdog.ts polls the worker
+# directly over 6PN, so its traffic also bypasses fly-proxy and cannot
+# trigger autostart.
 #
-# No `[[services.ports]]` block: no external traffic. The internal_port
-# is only used by the health check below.
+# Consequence: if a rolling deploy leaves the worker `stopped` (flyctl
+# does not always issue MachineStart after MachineUpdate), nothing
+# automatic brings it back. See issue #4723 for the recovery-gap fix.
 [[services]]
   internal_port = 8080
   protocol = "tcp"
   processes = ["worker"]
   auto_start_machines = true
   auto_stop_machines = "off"
-  # Workers run scheduled jobs only — no external traffic, no HA story.
-  # One worker is plenty; brief gaps during deploys are invisible.
   min_machines_running = 1
 
   [[services.http_checks]]

--- a/server/src/services/worker-watchdog.ts
+++ b/server/src/services/worker-watchdog.ts
@@ -6,6 +6,14 @@
  * threshold — `logger.error` auto-routes to #admin-errors via posthog (see
  * `posthog.ts`), so the alert reaches Slack without any extra wiring.
  *
+ * Recovery: on each failure, attempts to start any worker machines in `stopped`
+ * state via the Fly Machines API. Rolling deploys can leave the worker stopped
+ * because `auto_start_machines` is a fly-proxy feature and the worker has no
+ * `[[services.ports]]` (see fly.toml). Without active recovery, nothing brings
+ * a stopped worker back. Started machines surface as a successful probe on the
+ * next tick; if start didn't help (real crashloop), failures keep climbing and
+ * the alert still fires at the threshold.
+ *
  * Fire-once semantics: alert when the failure streak crosses the threshold, and
  * again on recovery (info level). Without these guards a flapping worker would
  * spam the channel every tick.
@@ -17,10 +25,17 @@ const logger = createLogger('worker-watchdog');
 const TICK_MS = 60_000;
 const FAILURE_THRESHOLD = 3;
 const FETCH_TIMEOUT_MS = 5_000;
+const FLY_API_BASE = 'https://api.machines.dev/v1';
 
 let intervalId: NodeJS.Timeout | null = null;
 let consecutiveFailures = 0;
 let alerted = false;
+
+interface FlyMachine {
+  id: string;
+  state: string;
+  config?: { metadata?: { fly_process_group?: string } };
+}
 
 async function probeWorker(): Promise<{ ok: true } | { ok: false; reason: string }> {
   const appName = process.env.FLY_APP_NAME;
@@ -43,6 +58,60 @@ async function probeWorker(): Promise<{ ok: true } | { ok: false; reason: string
   }
 }
 
+async function recoverStoppedWorkers(): Promise<number> {
+  const appName = process.env.FLY_APP_NAME;
+  const token = process.env.FLY_API_TOKEN;
+  if (!appName || !token) return 0;
+
+  const headers = { Authorization: `Bearer ${token}` };
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  let machines: FlyMachine[];
+  try {
+    const listRes = await fetch(`${FLY_API_BASE}/apps/${appName}/machines`, {
+      headers,
+      signal: controller.signal,
+    });
+    if (!listRes.ok) {
+      logger.warn({ status: listRes.status }, 'Fly Machines API list failed');
+      return 0;
+    }
+    machines = (await listRes.json()) as FlyMachine[];
+  } catch (err) {
+    logger.warn({ err: err instanceof Error ? err.message : String(err) }, 'Fly Machines API list errored');
+    return 0;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const stoppedWorkers = machines.filter(
+    (m) => m.config?.metadata?.fly_process_group === 'worker' && m.state === 'stopped',
+  );
+  if (stoppedWorkers.length === 0) return 0;
+
+  let started = 0;
+  for (const machine of stoppedWorkers) {
+    try {
+      const res = await fetch(`${FLY_API_BASE}/apps/${appName}/machines/${machine.id}/start`, {
+        method: 'POST',
+        headers,
+      });
+      if (res.ok) {
+        started++;
+        logger.info({ machineId: machine.id }, 'Started stopped worker machine');
+      } else {
+        logger.warn({ machineId: machine.id, status: res.status }, 'Fly Machines API start failed');
+      }
+    } catch (err) {
+      logger.warn(
+        { machineId: machine.id, err: err instanceof Error ? err.message : String(err) },
+        'Fly Machines API start errored',
+      );
+    }
+  }
+  return started;
+}
+
 async function tick(): Promise<void> {
   const result = await probeWorker();
   if (result.ok) {
@@ -55,6 +124,8 @@ async function tick(): Promise<void> {
   }
 
   consecutiveFailures++;
+  await recoverStoppedWorkers();
+
   if (consecutiveFailures === FAILURE_THRESHOLD && !alerted) {
     alerted = true;
     logger.error(

--- a/server/tests/unit/worker-watchdog.test.ts
+++ b/server/tests/unit/worker-watchdog.test.ts
@@ -17,6 +17,7 @@ describe('worker-watchdog', () => {
 
   afterEach(() => {
     delete process.env.FLY_APP_NAME;
+    delete process.env.FLY_API_TOKEN;
     vi.restoreAllMocks();
   });
 
@@ -78,5 +79,81 @@ describe('worker-watchdog', () => {
     await _internals.tick(); // failure after success → streak = 1
     expect(errorSpy).not.toHaveBeenCalled();
     expect(_internals.getState()).toEqual({ consecutiveFailures: 1, alerted: false });
+  });
+
+  describe('recovery via Fly Machines API', () => {
+    beforeEach(() => {
+      process.env.FLY_API_TOKEN = 'test-token';
+    });
+
+    it('starts a stopped worker machine on probe failure', async () => {
+      // Probe fails, then API list returns one stopped worker, then start succeeds.
+      fetchSpy.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+      fetchSpy.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            { id: 'wk1', state: 'stopped', config: { metadata: { fly_process_group: 'worker' } } },
+            { id: 'web1', state: 'started', config: { metadata: { fly_process_group: 'web' } } },
+          ]),
+          { status: 200 },
+        ),
+      );
+      fetchSpy.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+      await _internals.tick();
+
+      const startCall = fetchSpy.mock.calls.find(([url]) =>
+        String(url).endsWith('/machines/wk1/start'),
+      );
+      expect(startCall).toBeDefined();
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ machineId: 'wk1' }),
+        'Started stopped worker machine',
+      );
+    });
+
+    it('does not call start when no worker machines are stopped', async () => {
+      fetchSpy.mockRejectedValueOnce(new Error('boom'));
+      fetchSpy.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            { id: 'wk1', state: 'started', config: { metadata: { fly_process_group: 'worker' } } },
+          ]),
+          { status: 200 },
+        ),
+      );
+
+      await _internals.tick();
+
+      const startCall = fetchSpy.mock.calls.find(([url]) =>
+        String(url).includes('/start'),
+      );
+      expect(startCall).toBeUndefined();
+    });
+
+    it('still alerts at threshold when recovery does not help', async () => {
+      // Recovery on every failure tick: list returns empty (nothing to start).
+      // Three probe failures, three list calls → alert fires once.
+      for (let i = 0; i < 3; i++) {
+        fetchSpy.mockRejectedValueOnce(new Error('unreachable'));
+        fetchSpy.mockResolvedValueOnce(new Response('[]', { status: 200 }));
+      }
+
+      await _internals.tick();
+      await _internals.tick();
+      await _internals.tick();
+
+      expect(errorSpy).toHaveBeenCalledOnce();
+    });
+
+    it('skips recovery without FLY_API_TOKEN', async () => {
+      delete process.env.FLY_API_TOKEN;
+      fetchSpy.mockRejectedValueOnce(new Error('boom'));
+
+      await _internals.tick();
+
+      // Only the probe; no API calls.
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Watchdog now actively recovers a stopped worker via the Fly Machines API, closing the gap behind today's 04:31 UTC alert (issue #4723).

## Root cause

PR #3374 added `[[services]]` with `auto_start_machines = true` + `min_machines_running = 1` for the worker process group, claiming this would prevent rolling deploys from leaving workers `stopped`. Per Fly docs, those flags are only enforced via fly-proxy, and a `[[services]]` block without `[[services.ports]]` isn't routed through fly-proxy — so both settings are inert. The watchdog from PR #4358 observed the failure but couldn't recover it.

Today's incident: v2738 rolling deploy. Worker `6832693c334dd8` event log: `pending(launch) → created(launch) → stopped(update)` — no `start` event. Watchdog tripped at 3 misses (~180s); manual `fly machine start` was required.

## Fix

On probe failure the watchdog calls `GET /v1/apps/{app}/machines`, filters to `fly_process_group == worker && state == stopped`, and issues `POST /v1/apps/{app}/machines/{id}/start` for each. Recovered machines surface as successful probes on the next tick. If start didn't help (real crashloop), the failure streak still climbs and the alert fires at threshold as before.

Recovery requires `FLY_API_TOKEN` secret on the app. Without it the watchdog gracefully degrades — behavior matches PR #4358 exactly. Failures during the recovery call are logged at `warn` (not `error`, so they don't re-route to #admin-errors and stack on top of the real alert).

## Setup

After merge, mint and set the token (one time):

```bash
fly tokens create deploy -a adcp-docs --expiry 8760h | xargs -I{} fly secrets set FLY_API_TOKEN={} -a adcp-docs
```

Until that secret is set, the watchdog behaves identically to today.

## Test plan
- [x] 9 vitest cases — original 5 plus 4 new for the recovery path (starts stopped worker, skips when none stopped, still alerts when recovery doesn't help, skips without token)
- [x] Typecheck clean
- [ ] Verify in prod: next deploy where the worker happens to be left `stopped` should self-heal within one watchdog tick; alert should NOT fire

## Refs
- Closes #4723
- Supersedes PR #3374's inert flags
- Builds on PR #4358's watchdog

🤖 Generated with [Claude Code](https://claude.com/claude-code)