### PR TITLE
fix(membership): upgrade flow follows portal URL on 409

### DIFF
--- a/.changeset/membership-upgrade-portal-redirect.md
+++ b/.changeset/membership-upgrade-portal-redirect.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": patch
+---
+
+Membership upgrade flow now follows the Stripe Customer Portal URL when `/api/checkout-session` returns 409. Previously the dashboard surfaced "Upgrade" buttons for tiers above the org's current sub, but clicking them routed through the checkout intake — which `blockIfActiveSubscription` refuses by design — and the client discarded the `customer_portal_url` from the 409 body, dead-ending the user on a toast like "already on Explorer ($50.00)". `proceedToCheckout` in `dashboard-membership.html` and both checkout entry points in `dashboard.html` now redirect to the returned portal URL so tier changes complete end-to-end.
+
+Adds `POST /api/admin/accounts/:orgId/portal-link` (admin/`ADMIN_API_KEY` only) to mint a Stripe Customer Portal session URL out-of-band, so support can hand a working tier-change link to any member blocked by an in-flight client.

--- a/.changeset/membership-upgrade-portal-redirect.md
+++ b/.changeset/membership-upgrade-portal-redirect.md
@@ -3,5 +3,3 @@
 ---
 
 Membership upgrade flow now follows the Stripe Customer Portal URL when `/api/checkout-session` returns 409. Previously the dashboard surfaced "Upgrade" buttons for tiers above the org's current sub, but clicking them routed through the checkout intake — which `blockIfActiveSubscription` refuses by design — and the client discarded the `customer_portal_url` from the 409 body, dead-ending the user on a toast like "already on Explorer ($50.00)". `proceedToCheckout` in `dashboard-membership.html` and both checkout entry points in `dashboard.html` now redirect to the returned portal URL so tier changes complete end-to-end.
-
-Adds `POST /api/admin/accounts/:orgId/portal-link` (admin/`ADMIN_API_KEY` only) to mint a Stripe Customer Portal session URL out-of-band, so support can hand a working tier-change link to any member blocked by an in-flight client.

--- a/server/public/dashboard-membership.html
+++ b/server/public/dashboard-membership.html
@@ -1852,6 +1852,7 @@
           // URL in the 409 body — follow it instead of dead-ending on a toast.
           if (response.status === 409 && error.customer_portal_url) {
             btn.textContent = 'Opening billing portal...';
+            closeAgreementModal();
             window.location.href = error.customer_portal_url;
             return;
           }

--- a/server/public/dashboard-membership.html
+++ b/server/public/dashboard-membership.html
@@ -1847,6 +1847,14 @@
 
         if (!response.ok) {
           const error = await response.json();
+          // Active subscriptions can't be re-billed via checkout; tier changes
+          // happen in the Stripe Customer Portal. The guard returns the portal
+          // URL in the 409 body — follow it instead of dead-ending on a toast.
+          if (response.status === 409 && error.customer_portal_url) {
+            btn.textContent = 'Opening billing portal...';
+            window.location.href = error.customer_portal_url;
+            return;
+          }
           throw new Error(error.message || 'Failed to create checkout session');
         }
 

--- a/server/public/dashboard.html
+++ b/server/public/dashboard.html
@@ -1944,6 +1944,11 @@
 
         if (!response.ok) {
           const error = await response.json();
+          if (response.status === 409 && error.customer_portal_url) {
+            btn.textContent = 'Opening billing portal...';
+            window.location.href = error.customer_portal_url;
+            return;
+          }
           throw new Error(error.message || 'Failed to create checkout session');
         }
 
@@ -2414,6 +2419,10 @@
 
         if (!response.ok) {
           const error = await response.json();
+          if (response.status === 409 && error.customer_portal_url) {
+            window.location.href = error.customer_portal_url;
+            return;
+          }
           throw new Error(error.message || 'Failed to create checkout session');
         }
 

--- a/server/src/routes/admin/accounts-billing.ts
+++ b/server/src/routes/admin/accounts-billing.ts
@@ -18,7 +18,7 @@ import {
   TIER_PRESERVING_STATUSES,
   buildSubscriptionUpdate,
 } from "../../db/organization-db.js";
-import { stripe, createCustomerPortalSession } from "../../billing/stripe-client.js";
+import { stripe } from "../../billing/stripe-client.js";
 import { pickMembershipSubWithProductFetch } from "../../billing/membership-prices.js";
 
 const logger = createLogger("admin-accounts-billing");
@@ -1290,51 +1290,6 @@ export function setupAccountsBillingRoutes(
           error: "Internal server error",
           message: "Unable to look up organization",
         });
-      }
-    }
-  );
-
-  // POST /api/admin/accounts/:orgId/portal-link - Mint a Stripe Customer Portal
-  // session URL for the org. Used to unblock members whose dashboard upgrade
-  // path is gated by `blockIfActiveSubscription` so an admin can hand them a
-  // working tier-change link out-of-band.
-  apiRouter.post(
-    "/accounts/:orgId/portal-link",
-    requireAuth,
-    requireAdmin,
-    async (req, res) => {
-      const { orgId } = req.params;
-      const returnUrl =
-        typeof req.body?.return_url === "string" && req.body.return_url.length > 0
-          ? req.body.return_url
-          : "https://agenticadvertising.org/dashboard/membership";
-
-      try {
-        const pool = getPool();
-        const result = await pool.query<{ stripe_customer_id: string | null }>(
-          "SELECT stripe_customer_id FROM organizations WHERE workos_organization_id = $1",
-          [orgId]
-        );
-        if (result.rows.length === 0) {
-          return res.status(404).json({ error: "Organization not found" });
-        }
-        const customerId = result.rows[0].stripe_customer_id;
-        if (!customerId) {
-          return res
-            .status(400)
-            .json({ error: "Organization has no Stripe customer" });
-        }
-        const portalUrl = await createCustomerPortalSession(customerId, returnUrl);
-        if (!portalUrl) {
-          return res.status(502).json({ error: "Failed to create portal session" });
-        }
-        return res.json({
-          portal_url: portalUrl,
-          stripe_customer_id: customerId,
-        });
-      } catch (err) {
-        logger.error({ err, orgId }, "Error minting portal link");
-        return res.status(500).json({ error: "Failed to mint portal link" });
       }
     }
   );

--- a/server/src/routes/admin/accounts-billing.ts
+++ b/server/src/routes/admin/accounts-billing.ts
@@ -18,7 +18,7 @@ import {
   TIER_PRESERVING_STATUSES,
   buildSubscriptionUpdate,
 } from "../../db/organization-db.js";
-import { stripe } from "../../billing/stripe-client.js";
+import { stripe, createCustomerPortalSession } from "../../billing/stripe-client.js";
 import { pickMembershipSubWithProductFetch } from "../../billing/membership-prices.js";
 
 const logger = createLogger("admin-accounts-billing");
@@ -1290,6 +1290,51 @@ export function setupAccountsBillingRoutes(
           error: "Internal server error",
           message: "Unable to look up organization",
         });
+      }
+    }
+  );
+
+  // POST /api/admin/accounts/:orgId/portal-link - Mint a Stripe Customer Portal
+  // session URL for the org. Used to unblock members whose dashboard upgrade
+  // path is gated by `blockIfActiveSubscription` so an admin can hand them a
+  // working tier-change link out-of-band.
+  apiRouter.post(
+    "/accounts/:orgId/portal-link",
+    requireAuth,
+    requireAdmin,
+    async (req, res) => {
+      const { orgId } = req.params;
+      const returnUrl =
+        typeof req.body?.return_url === "string" && req.body.return_url.length > 0
+          ? req.body.return_url
+          : "https://agenticadvertising.org/dashboard/membership";
+
+      try {
+        const pool = getPool();
+        const result = await pool.query<{ stripe_customer_id: string | null }>(
+          "SELECT stripe_customer_id FROM organizations WHERE workos_organization_id = $1",
+          [orgId]
+        );
+        if (result.rows.length === 0) {
+          return res.status(404).json({ error: "Organization not found" });
+        }
+        const customerId = result.rows[0].stripe_customer_id;
+        if (!customerId) {
+          return res
+            .status(400)
+            .json({ error: "Organization has no Stripe customer" });
+        }
+        const portalUrl = await createCustomerPortalSession(customerId, returnUrl);
+        if (!portalUrl) {
+          return res.status(502).json({ error: "Failed to create portal session" });
+        }
+        return res.json({
+          portal_url: portalUrl,
+          stripe_customer_id: customerId,
+        });
+      } catch (err) {
+        logger.error({ err, orgId }, "Error minting portal link");
+        return res.status(500).json({ error: "Failed to mint portal link" });
       }
     }
   );


### PR DESCRIPTION
## Summary

- Dashboard upgrade buttons routed clicks through `/api/checkout-session`, which `blockIfActiveSubscription` refuses for any org with an active sub (tier changes belong in the Customer Portal). The 409 body already carries `customer_portal_url`, but the three checkout clients discarded it and threw the raw message into a toast — members on an active sub saw "already on Explorer (\$50.00)" with no actionable next step.
- Clients now redirect to the returned `customer_portal_url` when present on a 409. Falls through to the existing toast for other error shapes.
- Closes the agreement modal before navigating, so the modal doesn't linger if the redirect ever stalls.

Refs the membership upgrade escalation from Kayla Moore.

(Earlier revision added an admin \`POST /api/admin/accounts/:orgId/portal-link\` endpoint; reverted in second commit after strategist review — Stripe Dashboard's "Send customer portal link" already covers the one-off use case without adding a new admin surface.)

## Test plan

- [ ] CI green
- [ ] Manual: as a member on an active Explorer sub, click "Upgrade" on `/dashboard/membership` — verify redirect to Stripe Customer Portal instead of toast
- [ ] Manual: a 409 with no `customer_portal_url` (e.g. portal session creation failed) still toasts the message and re-enables the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)