### PR TITLE
feat(training-agent): RFC 9421 sign outbound MCP responses

### DIFF
--- a/.changeset/training-agent-response-signing.md
+++ b/.changeset/training-agent-response-signing.md
@@ -1,0 +1,18 @@
+---
+---
+
+feat(training-agent): RFC 9421 sign outbound MCP responses
+
+Every successful JSON response from a tenant MCP route (`/api/training-agent/<tenant>/mcp` and the strict variants) now carries RFC 9421 `Signature`, `Signature-Input`, and `Content-Digest` headers. Signed with a new per-tenant Ed25519 keypair marked `adcp_use: "response-signing"` — distinct from the existing webhook-signing material per the `adcp_use` distinct-keys-per-purpose invariant the SDK enforces.
+
+The response-signing JWK appears in the shared `/.well-known/jwks.json` discovery document; buyer verifiers filter by `adcp_use` and `kid` to find the right one. The JWKS endpoint now aggregates every signing purpose the training agent publishes (shared webhook + per-tenant webhook + per-tenant response + governance).
+
+Unblocks step 1 of the seller-verification walkthrough (`docs/verification/overview`) being demoable against the training agent: a buyer client fetching `https://test-agent.adcontextprotocol.org/api/training-agent/sales/mcp` now receives a signed response whose `keyid` resolves via `agents[].jwks_uri` in `brand.json`.
+
+Implementation notes:
+
+- The `wrapResponseForSigning` middleware buffers writes from the MCP transport (`StreamableHTTPServerTransport` with `enableJsonResponse: true`) and intercepts `res.writeHead` so signing headers can be set before the response commits. Non-2xx and non-JSON responses (SSE, errors) pass through unsigned.
+- Per-tenant response-signing material is pre-warmed at router-create time so the JWKS includes every tenant's key from the first request, not only after each tenant has been touched.
+- Built on `@adcp/sdk@^7.7.0` which ships `signResponse` / `signResponseAsync` from [adcp-client#1823](https://github.com/adcontextprotocol/adcp-client/pull/1823).
+
+Bumps `@adcp/sdk` from `^7.6.0` to `^7.7.0`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.0.3",
       "dependencies": {
-        "@adcp/sdk": "^7.6.0",
+        "@adcp/sdk": "^7.7.0",
         "@anthropic-ai/sdk": "^0.96.0",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -123,9 +123,9 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-7.6.0.tgz",
-      "integrity": "sha512-B14uD0l+hwpeGcxsteu7bhaSvk2dJCMVC2atZW23eGcMUZ52EodmmDTbgSjomUfLcQa0FVDyquzEkKL1dVR5FQ==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-7.7.0.tgz",
+      "integrity": "sha512-OPlt8I2ZSV87LmYjapKMsvRzTyhzGAmfOE1xzNKVpRp6mkiuqTByHeNojHzFHNXprXH8Dw9svzmkaMpU3IPPkg==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "dev:docs": "node scripts/dev-docs.mjs"
   },
   "dependencies": {
-    "@adcp/sdk": "^7.6.0",
+    "@adcp/sdk": "^7.7.0",
     "@anthropic-ai/sdk": "^0.96.0",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",

--- a/server/src/training-agent/index.ts
+++ b/server/src/training-agent/index.ts
@@ -38,6 +38,7 @@ import type { TrainingContext } from './types.js';
 import { PUBLISHERS } from './publishers.js';
 import { SIGNAL_PROVIDERS } from './signal-providers.js';
 import { getPublicJwks } from './webhooks.js';
+import { getAggregatedPublicJwks, getTenantResponseSigningMaterial } from './tenants/signing.js';
 import { WALKTHROUGH_FIXTURES } from './fixtures/verification-walkthrough/index.js';
 import {
   buildRequestSigningAuthenticator,
@@ -352,6 +353,14 @@ export function createTrainingAgentRouter(): Router {
     },
   });
 
+  // Pre-warm per-tenant response-signing material so each tenant's
+  // response-signing JWK appears in /.well-known/jwks.json from the first
+  // request — buyer verifiers fetching the JWKS before any tenant has been
+  // touched would otherwise see only the shared webhook key.
+  for (const tenantId of TENANT_IDS) {
+    getTenantResponseSigningMaterial(tenantId);
+  }
+
   // Per-tenant MCP routes — each tenant gets POST /<tenant>/mcp with bearer
   // auth + rate limiting. The tenant registry handles dispatch via
   // resolveByRequest(host, pathname).
@@ -561,9 +570,21 @@ export function createTrainingAgentRouter(): Router {
 
   // JWKS for webhook-signature verification by buyers (RFC 7517).
   // Public keys only — the emitter holds the private half.
+  // JWKS aggregates every signing purpose the training agent publishes:
+  //   - shared webhook-delivery key (adcp_use: 'webhook-signing')
+  //   - per-tenant response-signing keys (adcp_use: 'response-signing')
+  //   - per-tenant webhook-signing keys (adcp_use: 'webhook-signing')
+  //   - governance signing key (adcp_use: 'governance-signing')
+  // Buyer verifiers filter by adcp_use + kid to find the right one.
   router.get('/.well-known/jwks.json', (_req: Request, res: Response) => {
     res.setHeader('Cache-Control', 'public, max-age=300');
-    res.json(getPublicJwks());
+    const aggregated = getAggregatedPublicJwks();
+    res.json({
+      keys: [
+        ...getPublicJwks().keys,
+        ...aggregated.keys,
+      ],
+    });
   });
 
   // brand.json discovery — house portfolio variant per

--- a/server/src/training-agent/index.ts
+++ b/server/src/training-agent/index.ts
@@ -579,12 +579,22 @@ export function createTrainingAgentRouter(): Router {
   router.get('/.well-known/jwks.json', (_req: Request, res: Response) => {
     res.setHeader('Cache-Control', 'public, max-age=300');
     const aggregated = getAggregatedPublicJwks();
-    res.json({
-      keys: [
-        ...getPublicJwks().keys,
-        ...aggregated.keys,
-      ],
+    // Dedupe by kid — the shared webhook key and per-tenant keys are
+    // minted with disjoint kid namespaces, but a future config that
+    // collides them would otherwise publish two entries with the same
+    // kid and different keys (verifiers pick at random).
+    const seen = new Set<string>();
+    const keys = [...getPublicJwks().keys, ...aggregated.keys].filter(k => {
+      const kid = typeof k.kid === 'string' ? k.kid : undefined;
+      if (!kid) return true; // un-kid'd keys can't dedupe; pass through
+      if (seen.has(kid)) {
+        logger.warn({ kid }, 'duplicate kid in aggregated JWKS; dropping later occurrence');
+        return false;
+      }
+      seen.add(kid);
+      return true;
     });
+    res.json({ keys });
   });
 
   // brand.json discovery — house portfolio variant per

--- a/server/src/training-agent/response-signing.ts
+++ b/server/src/training-agent/response-signing.ts
@@ -6,25 +6,42 @@
  * body is committed. The signing key is the tenant's response-signing
  * material (`getTenantResponseSigningMaterial`), distinct from the
  * webhook-signing key per the `adcp_use` distinct-keys-per-purpose
- * invariant.
+ * invariant the SDK enforces.
  *
  * The MCP transport (`StreamableHTTPServerTransport` with
  * `enableJsonResponse: true`) writes the JSON-RPC body directly to
  * `res.write` / `res.end`. To compute `Content-Digest` and set headers
- * before the body flushes, this wrapper buffers all writes, signs the
- * concatenated body at `end()` time, sets headers via `res.setHeader`,
- * then issues a single underlying `end()` with the buffered body.
+ * before the body flushes, this wrapper:
  *
- * Streaming responses (text/event-stream) and non-2xx responses pass
- * through unsigned — the MCP transport falls back to SSE for some
- * tool calls, and signing an error body is not what the buyer is
- * verifying against.
+ *   1. Intercepts `res.writeHead` so the MCP transport's
+ *      "headers-then-body" flush pattern can't commit headers until
+ *      signing happens at `end()`.
+ *   2. Buffers writes into `chunks: Buffer[]` until end().
+ *   3. At end() time, signs the buffered body, sets signing headers,
+ *      replays the deferred writeHead, then flushes via the original end().
+ *
+ * SSE / streaming bypass: if `writeHead` or `setHeader` observes
+ * `Content-Type: text/event-stream`, the wrapper disengages — flushes
+ * any buffered chunks via the original `write`, then routes subsequent
+ * writes directly. Signing per-SSE-event isn't in the AdCP response-
+ * signing profile and buffering SSE chunks until end() would break the
+ * protocol entirely.
+ *
+ * Non-2xx and non-JSON responses pass through unsigned — buyer verifiers
+ * treat unsigned errors as a hard miss, but a 500 is worse than a
+ * missed signature.
  */
 import type { Request, Response } from 'express';
 import { signResponse, type ResponseLike, type SignerKey } from '@adcp/sdk/signing';
 import { createLogger } from '../logger.js';
 
 const logger = createLogger('training-agent-response-signing');
+
+/** Cap on buffered body bytes before we abandon signing and pass through.
+ *  Defense in depth — the training agent's fixture data doesn't get this
+ *  big in practice, but a misbehaving handler shouldn't be able to OOM the
+ *  worker by buffering an unbounded response. */
+const MAX_SIGNED_BODY_BYTES = 8 * 1024 * 1024;
 
 /** Reconstruct the absolute request URL the SDK's response signer expects.
  *  Express's `req.originalUrl` is path+query only; the signer needs scheme
@@ -33,6 +50,27 @@ function absoluteRequestUrl(req: Request): string {
   const proto = (req.headers['x-forwarded-proto'] as string) || req.protocol || 'http';
   const host = (req.headers['x-forwarded-host'] as string) || req.headers.host || 'localhost';
   return `${proto}://${host}${req.originalUrl}`;
+}
+
+/** Case-insensitive lookup against either Express-normalized headers
+ *  (already lowercase) or raw `writeHead(status, headers)` headers
+ *  (mixed case). */
+function findHeader(headers: Record<string, string | string[] | number | undefined> | undefined, name: string): string | undefined {
+  if (!headers) return undefined;
+  const want = name.toLowerCase();
+  for (const [k, v] of Object.entries(headers)) {
+    if (k.toLowerCase() === want) return Array.isArray(v) ? v[0] : (v === undefined ? undefined : String(v));
+  }
+  return undefined;
+}
+
+/** RFC 6839 — JSON content types include `application/json` plus any
+ *  `+json` suffix (`application/vnd.api+json`, `application/problem+json`,
+ *  `application/jose+json`). */
+function isJsonContentType(ct: string | undefined): boolean {
+  if (!ct) return false;
+  const lower = ct.toLowerCase();
+  return lower.includes('application/json') || /\+json(\b|;)/.test(lower);
 }
 
 /**
@@ -44,24 +82,49 @@ function absoluteRequestUrl(req: Request): string {
  */
 export function wrapResponseForSigning(req: Request, res: Response, signerKey: SignerKey, tenantId: string): void {
   const chunks: Buffer[] = [];
-  // Capture the originals — we must NOT call the wrapped versions when
-  // flushing or we infinite-loop.
+  let bufferedBytes = 0;
+  /** Once true, the wrapper acts as a pass-through — buffered chunks have
+   *  been flushed and subsequent writes go straight to the underlying
+   *  stream. Set when SSE or oversize body is detected. */
+  let passthrough = false;
   const origWrite = res.write.bind(res);
   const origEnd = res.end.bind(res);
   const origWriteHead = res.writeHead.bind(res) as Response['writeHead'];
+  const origSetHeader = res.setHeader.bind(res);
 
   // Pending writeHead args — buffered when the MCP transport tries to flush
   // headers, replayed at end() time after signing headers have been added.
   let pendingStatus: number | undefined;
   let pendingStatusMessage: string | undefined;
-  let pendingHeaders: Record<string, string | string[] | number> | undefined;
+  let pendingHeaders: Record<string, string | string[] | number | undefined> | undefined;
+
+  function currentContentType(): string {
+    return String(res.getHeader('content-type') || findHeader(pendingHeaders, 'content-type') || '');
+  }
 
   function shouldSign(): boolean {
-    const contentType = String(res.getHeader('content-type') || (pendingHeaders ? pendingHeaders['content-type'] || pendingHeaders['Content-Type'] || '' : ''));
-    if (!String(contentType).includes('application/json')) return false;
+    if (passthrough) return false;
+    const ct = currentContentType();
+    if (!isJsonContentType(ct)) return false;
     const status = pendingStatus ?? res.statusCode;
     if (status < 200 || status >= 300) return false;
     return true;
+  }
+
+  function disengageAsPassthrough(reason: string): void {
+    if (passthrough) return;
+    passthrough = true;
+    logger.debug({ tenantId, reason }, 'response signing disengaged; passing through unsigned');
+    // Flush any deferred writeHead so the transport's own header bytes go
+    // out before we start writing body chunks directly.
+    if (!res.headersSent && pendingStatus !== undefined) {
+      if (pendingStatusMessage !== undefined) origWriteHead(pendingStatus, pendingStatusMessage);
+      else origWriteHead(pendingStatus);
+    }
+    // Flush any chunks we've already buffered.
+    for (const c of chunks) origWrite(c);
+    chunks.length = 0;
+    bufferedBytes = 0;
   }
 
   // Buffer writeHead — the MCP transport calls this to commit status +
@@ -76,19 +139,45 @@ export function wrapResponseForSigning(req: Request, res: Response, signerKey: S
     } else if (args[1] && typeof args[1] === 'object') {
       pendingHeaders = args[1] as typeof pendingHeaders;
     }
+    // Mirror pending headers into Express so getHeader() reflects them
+    // even before we replay writeHead.
     if (pendingHeaders) {
       for (const [k, v] of Object.entries(pendingHeaders)) {
-        if (Array.isArray(v)) res.setHeader(k, v as string[]);
-        else if (v !== undefined) res.setHeader(k, v as string | number);
+        if (Array.isArray(v)) origSetHeader(k, v as string[]);
+        else if (v !== undefined) origSetHeader(k, v as string | number);
       }
     }
     if (pendingStatus !== undefined) res.statusCode = pendingStatus;
+    // SSE detected via Content-Type — disengage immediately so chunked
+    // event frames flow without buffering.
+    if (isStreamingContentType(currentContentType())) {
+      disengageAsPassthrough('sse-content-type-on-writeHead');
+    }
+    return res;
+  };
+
+  // Mirror setHeader so the wrapper sees Content-Type updates made via
+  // setHeader instead of writeHead.
+  (res as unknown as { setHeader: (...args: unknown[]) => Response }).setHeader = (name: unknown, value: unknown) => {
+    origSetHeader(name as string, value as string);
+    if (typeof name === 'string' && name.toLowerCase() === 'content-type' && isStreamingContentType(String(value))) {
+      disengageAsPassthrough('sse-content-type-on-setHeader');
+    }
     return res;
   };
 
   (res as unknown as { write: (...args: unknown[]) => boolean }).write = (chunk: unknown, ...rest: unknown[]) => {
+    if (passthrough) return origWrite(chunk as Buffer | string, ...rest as []);
     if (chunk !== null && chunk !== undefined) {
-      chunks.push(typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : (chunk as Buffer));
+      const buf = typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : (chunk as Buffer);
+      bufferedBytes += buf.length;
+      if (bufferedBytes > MAX_SIGNED_BODY_BYTES) {
+        logger.warn({ tenantId, bufferedBytes }, 'response body exceeds signing cap; disengaging unsigned');
+        chunks.push(buf);
+        disengageAsPassthrough('body-size-cap');
+        return true;
+      }
+      chunks.push(buf);
     }
     const cb = rest.find(a => typeof a === 'function') as (() => void) | undefined;
     if (cb) queueMicrotask(cb);
@@ -96,6 +185,7 @@ export function wrapResponseForSigning(req: Request, res: Response, signerKey: S
   };
 
   (res as unknown as { end: (...args: unknown[]) => Response }).end = (chunk?: unknown, ...rest: unknown[]) => {
+    if (passthrough) return origEnd(chunk as Buffer | string | undefined, ...rest as []);
     if (chunk !== null && chunk !== undefined) {
       chunks.push(typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : (chunk as Buffer));
     }
@@ -105,7 +195,7 @@ export function wrapResponseForSigning(req: Request, res: Response, signerKey: S
       try {
         const responseLike: ResponseLike = {
           status: pendingStatus ?? res.statusCode,
-          headers: { 'content-type': String(res.getHeader('content-type') || 'application/json') },
+          headers: { 'content-type': currentContentType() || 'application/json' },
           body,
           request: {
             method: req.method,
@@ -114,19 +204,29 @@ export function wrapResponseForSigning(req: Request, res: Response, signerKey: S
         };
         const signed = signResponse(responseLike, signerKey);
         for (const [k, v] of Object.entries(signed.headers)) {
-          if (typeof v === 'string') res.setHeader(k, v);
+          if (typeof v === 'string') origSetHeader(k, v);
         }
+        // Vary on the forwarding headers absoluteRequestUrl() reads so a
+        // shared cache keyed only on path doesn't serve a signed body
+        // back to a mismatched authority.
+        origSetHeader('Vary', 'X-Forwarded-Host, X-Forwarded-Proto, Host');
       } catch (err) {
+        // Don't break the request if signing fails — log and ship the
+        // body unsigned. A 500 is worse than a missed signature; verifier
+        // integration tests should assert headers present, not status==200.
         logger.error({ err: err instanceof Error ? err.message : String(err), tenantId }, 'response signing failed; shipping unsigned');
       }
     }
 
-    // Now commit the headers (writeHead was deferred) + flush the body.
     if (!res.headersSent) {
       const status = pendingStatus ?? res.statusCode;
-      if (pendingStatusMessage) origWriteHead(status, pendingStatusMessage);
+      if (pendingStatusMessage !== undefined) origWriteHead(status, pendingStatusMessage);
       else origWriteHead(status);
     }
     return origEnd(body, ...rest as []);
   };
+}
+
+function isStreamingContentType(ct: string): boolean {
+  return ct.toLowerCase().includes('text/event-stream');
 }

--- a/server/src/training-agent/response-signing.ts
+++ b/server/src/training-agent/response-signing.ts
@@ -1,0 +1,132 @@
+/**
+ * Outbound response signing for the training agent.
+ *
+ * Wraps an Express `res` so that successful JSON responses get RFC 9421
+ * `Signature`, `Signature-Input`, and `Content-Digest` headers before the
+ * body is committed. The signing key is the tenant's response-signing
+ * material (`getTenantResponseSigningMaterial`), distinct from the
+ * webhook-signing key per the `adcp_use` distinct-keys-per-purpose
+ * invariant.
+ *
+ * The MCP transport (`StreamableHTTPServerTransport` with
+ * `enableJsonResponse: true`) writes the JSON-RPC body directly to
+ * `res.write` / `res.end`. To compute `Content-Digest` and set headers
+ * before the body flushes, this wrapper buffers all writes, signs the
+ * concatenated body at `end()` time, sets headers via `res.setHeader`,
+ * then issues a single underlying `end()` with the buffered body.
+ *
+ * Streaming responses (text/event-stream) and non-2xx responses pass
+ * through unsigned — the MCP transport falls back to SSE for some
+ * tool calls, and signing an error body is not what the buyer is
+ * verifying against.
+ */
+import type { Request, Response } from 'express';
+import { signResponse, type ResponseLike, type SignerKey } from '@adcp/sdk/signing';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('training-agent-response-signing');
+
+/** Reconstruct the absolute request URL the SDK's response signer expects.
+ *  Express's `req.originalUrl` is path+query only; the signer needs scheme
+ *  and authority for `@authority` / `@target-uri` derivation. */
+function absoluteRequestUrl(req: Request): string {
+  const proto = (req.headers['x-forwarded-proto'] as string) || req.protocol || 'http';
+  const host = (req.headers['x-forwarded-host'] as string) || req.headers.host || 'localhost';
+  return `${proto}://${host}${req.originalUrl}`;
+}
+
+/**
+ * Mutate `res` so a successful JSON response gets signed before it flushes.
+ *
+ * @param signerKey  Tenant's response-signing key (must carry
+ *                   `adcp_use: 'response-signing'`; the SDK enforces this).
+ * @param tenantId   Used in log lines for failure correlation.
+ */
+export function wrapResponseForSigning(req: Request, res: Response, signerKey: SignerKey, tenantId: string): void {
+  const chunks: Buffer[] = [];
+  // Capture the originals — we must NOT call the wrapped versions when
+  // flushing or we infinite-loop.
+  const origWrite = res.write.bind(res);
+  const origEnd = res.end.bind(res);
+  const origWriteHead = res.writeHead.bind(res) as Response['writeHead'];
+
+  // Pending writeHead args — buffered when the MCP transport tries to flush
+  // headers, replayed at end() time after signing headers have been added.
+  let pendingStatus: number | undefined;
+  let pendingStatusMessage: string | undefined;
+  let pendingHeaders: Record<string, string | string[] | number> | undefined;
+
+  function shouldSign(): boolean {
+    const contentType = String(res.getHeader('content-type') || (pendingHeaders ? pendingHeaders['content-type'] || pendingHeaders['Content-Type'] || '' : ''));
+    if (!String(contentType).includes('application/json')) return false;
+    const status = pendingStatus ?? res.statusCode;
+    if (status < 200 || status >= 300) return false;
+    return true;
+  }
+
+  // Buffer writeHead — the MCP transport calls this to commit status +
+  // headers before writing the body, which would flush headers and lock
+  // us out of adding Signature / Signature-Input. Capture the args and
+  // replay them at end() time after signing.
+  (res as unknown as { writeHead: (...args: unknown[]) => Response }).writeHead = (...args: unknown[]) => {
+    pendingStatus = typeof args[0] === 'number' ? (args[0] as number) : pendingStatus;
+    if (typeof args[1] === 'string') {
+      pendingStatusMessage = args[1] as string;
+      if (args[2] && typeof args[2] === 'object') pendingHeaders = args[2] as typeof pendingHeaders;
+    } else if (args[1] && typeof args[1] === 'object') {
+      pendingHeaders = args[1] as typeof pendingHeaders;
+    }
+    if (pendingHeaders) {
+      for (const [k, v] of Object.entries(pendingHeaders)) {
+        if (Array.isArray(v)) res.setHeader(k, v as string[]);
+        else if (v !== undefined) res.setHeader(k, v as string | number);
+      }
+    }
+    if (pendingStatus !== undefined) res.statusCode = pendingStatus;
+    return res;
+  };
+
+  (res as unknown as { write: (...args: unknown[]) => boolean }).write = (chunk: unknown, ...rest: unknown[]) => {
+    if (chunk !== null && chunk !== undefined) {
+      chunks.push(typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : (chunk as Buffer));
+    }
+    const cb = rest.find(a => typeof a === 'function') as (() => void) | undefined;
+    if (cb) queueMicrotask(cb);
+    return true;
+  };
+
+  (res as unknown as { end: (...args: unknown[]) => Response }).end = (chunk?: unknown, ...rest: unknown[]) => {
+    if (chunk !== null && chunk !== undefined) {
+      chunks.push(typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : (chunk as Buffer));
+    }
+    const body = Buffer.concat(chunks).toString('utf8');
+
+    if (shouldSign() && body.length > 0) {
+      try {
+        const responseLike: ResponseLike = {
+          status: pendingStatus ?? res.statusCode,
+          headers: { 'content-type': String(res.getHeader('content-type') || 'application/json') },
+          body,
+          request: {
+            method: req.method,
+            url: absoluteRequestUrl(req),
+          },
+        };
+        const signed = signResponse(responseLike, signerKey);
+        for (const [k, v] of Object.entries(signed.headers)) {
+          if (typeof v === 'string') res.setHeader(k, v);
+        }
+      } catch (err) {
+        logger.error({ err: err instanceof Error ? err.message : String(err), tenantId }, 'response signing failed; shipping unsigned');
+      }
+    }
+
+    // Now commit the headers (writeHead was deferred) + flush the body.
+    if (!res.headersSent) {
+      const status = pendingStatus ?? res.statusCode;
+      if (pendingStatusMessage) origWriteHead(status, pendingStatusMessage);
+      else origWriteHead(status);
+    }
+    return origEnd(body, ...rest as []);
+  };
+}

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -15,6 +15,8 @@ import { createLogger } from '../../logger.js';
 import { runWithSessionContext, flushDirtySessions } from '../state.js';
 import { createRegistryHolder, getCanonicalBase, resolveTenantHost, type RegistryHolder } from './registry.js';
 import { buildSignedRevocationList } from '../governance-revocations.js';
+import { getTenantResponseSigningMaterial } from './signing.js';
+import { wrapResponseForSigning } from '../response-signing.js';
 
 const logger = createLogger('training-agent-tenant-router');
 
@@ -87,6 +89,14 @@ function setCORSHeaders(res: Response): void {
 function tenantMcpHandler(holder: RegistryHolder, tenantId: string) {
   return async (req: Request, res: Response): Promise<void> => {
     setCORSHeaders(res);
+
+    // Wrap res with the response-signing middleware. Buffers writes from
+    // the MCP transport, signs the buffered body with the tenant's
+    // response-signing key, and writes back with RFC 9421 Signature /
+    // Signature-Input / Content-Digest headers. Non-2xx and non-JSON
+    // responses pass through unsigned.
+    const responseSigner = getTenantResponseSigningMaterial(tenantId);
+    wrapResponseForSigning(req, res, responseSigner.signerKey, tenantId);
 
     // Bridge `res.locals.trainingPrincipal` (set by the upstream
     // `requireAuth` middleware) onto `req.auth` so the framework's MCP

--- a/server/src/training-agent/tenants/signing.ts
+++ b/server/src/training-agent/tenants/signing.ts
@@ -17,7 +17,7 @@
 
 import { generateKeyPairSync, randomBytes } from 'node:crypto';
 import type { TenantSigningKey } from '@adcp/sdk/server';
-import type { AdcpJsonWebKey } from '@adcp/sdk/signing';
+import type { AdcpJsonWebKey, SignerKey } from '@adcp/sdk/signing';
 import { createLogger } from '../../logger.js';
 import { getGovernanceSigningPublicJwk } from '../governance-signing.js';
 
@@ -28,7 +28,17 @@ interface TenantMaterial {
   publicJwk: AdcpJsonWebKey;
 }
 
+/** Response-signing material is distinct from webhook-signing material per
+ *  the `adcp_use` distinct-keys-per-purpose invariant — the SDK's
+ *  `signResponse` verifies that the supplied key carries
+ *  `adcp_use: "response-signing"` before signing. */
+interface TenantResponseSigningMaterial {
+  signerKey: SignerKey;
+  publicJwk: AdcpJsonWebKey;
+}
+
 const materials: Map<string, TenantMaterial> = new Map();
+const responseSigningMaterials: Map<string, TenantResponseSigningMaterial> = new Map();
 
 /**
  * Generate an ephemeral Ed25519 keypair for a tenant. KID = `training-${tenantId}-${random}`.
@@ -80,6 +90,63 @@ export function getTenantSigningMaterial(tenantId: string): TenantMaterial {
   return m;
 }
 
+/** Generate an ephemeral Ed25519 response-signing keypair. Distinct kid +
+ *  adcp_use from the webhook-signing key on the same tenant so the SDK's
+ *  signResponse purpose-binding check passes against this key and only this
+ *  key. */
+function generateResponseSigningKey(tenantId: string): TenantResponseSigningMaterial {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  const privateJwk = privateKey.export({ format: 'jwk' }) as Record<string, unknown>;
+  const publicJwk = publicKey.export({ format: 'jwk' }) as Record<string, unknown>;
+  const kid = `training-${tenantId}-resp-${randomBytes(4).toString('hex')}`;
+
+  const privateAdcpJwk: AdcpJsonWebKey = {
+    ...privateJwk,
+    kid,
+    alg: 'EdDSA',
+    adcp_use: 'response-signing',
+    key_ops: ['sign'],
+    use: 'sig',
+  } as AdcpJsonWebKey;
+
+  const signerKey: SignerKey = {
+    keyid: kid,
+    alg: 'ed25519',
+    privateKey: privateAdcpJwk,
+  };
+
+  const brandJwk: AdcpJsonWebKey = {
+    ...publicJwk,
+    kid,
+    alg: 'EdDSA',
+    adcp_use: 'response-signing',
+    key_ops: ['verify'],
+    use: 'sig',
+  } as AdcpJsonWebKey;
+
+  logger.warn(
+    { tenantId, kid },
+    'Tenant response-signing key generated ephemerally. Provision KMS-backed keys for stable kids.',
+  );
+
+  return { signerKey, publicJwk: brandJwk };
+}
+
+/**
+ * Get-or-create response-signing material for a tenant. Memoizes per process.
+ * The SDK's signResponse will reject this key if its adcp_use isn't
+ * "response-signing", which is why this is generated separately from
+ * `getTenantSigningMaterial`'s webhook-scoped keys.
+ */
+export function getTenantResponseSigningMaterial(tenantId: string): TenantResponseSigningMaterial {
+  let m = responseSigningMaterials.get(tenantId);
+  if (!m) {
+    m = generateResponseSigningKey(tenantId);
+    responseSigningMaterials.set(tenantId, m);
+  }
+  return m;
+}
+
 /**
  * Aggregate public JWKs across all registered tenants. Served at the host's
  * `/.well-known/brand.json` so the SDK validator finds each tenant's kid in
@@ -94,6 +161,7 @@ export function getAggregatedPublicJwks(): { keys: AdcpJsonWebKey[] } {
   return {
     keys: [
       ...Array.from(materials.values()).map(m => m.publicJwk),
+      ...Array.from(responseSigningMaterials.values()).map(m => m.publicJwk),
       getGovernanceSigningPublicJwk(),
     ],
   };
@@ -102,4 +170,5 @@ export function getAggregatedPublicJwks(): { keys: AdcpJsonWebKey[] } {
 /** Reset state — tests only. */
 export function resetTenantSigning(): void {
   materials.clear();
+  responseSigningMaterials.clear();
 }

--- a/server/src/training-agent/tenants/signing.ts
+++ b/server/src/training-agent/tenants/signing.ts
@@ -40,42 +40,49 @@ interface TenantResponseSigningMaterial {
 const materials: Map<string, TenantMaterial> = new Map();
 const responseSigningMaterials: Map<string, TenantResponseSigningMaterial> = new Map();
 
-/**
- * Generate an ephemeral Ed25519 keypair for a tenant. KID = `training-${tenantId}-${random}`.
- * Stable for the process lifetime; regenerates on restart.
- */
-function generateEphemeralKey(tenantId: string): TenantMaterial {
+type AdcpKeyPurpose = 'webhook-signing' | 'response-signing';
+
+interface EphemeralEd25519 {
+  kid: string;
+  privateJwk: Record<string, unknown>;
+  publicJwk: Record<string, unknown>;
+  brandJwk: AdcpJsonWebKey;
+}
+
+/** Generate an ephemeral Ed25519 keypair for a tenant + purpose. Distinct
+ *  `adcp_use` per purpose enforces the SDK's distinct-keys-per-purpose
+ *  invariant: signResponse / signWebhook each reject a key minted for the
+ *  wrong purpose at sign-time. */
+function generateEphemeralEd25519(tenantId: string, purpose: AdcpKeyPurpose, kidSuffix: string): EphemeralEd25519 {
   const { publicKey, privateKey } = generateKeyPairSync('ed25519');
-  // node:crypto JWK export is plain Record<string, unknown>; use a permissive
-  // shape that satisfies both AdcpJsonWebKey and TenantSigningKey's
-  // JsonWebKey expectation.
   const privateJwk = privateKey.export({ format: 'jwk' }) as Record<string, unknown>;
   const publicJwk = publicKey.export({ format: 'jwk' }) as Record<string, unknown>;
-  const kid = `training-${tenantId}-${randomBytes(4).toString('hex')}`;
-
-  const signingKey: TenantSigningKey = {
-    keyId: kid,
-    publicJwk: { ...publicJwk, kid },
-    privateJwk: { ...privateJwk, kid },
-  };
-
-  // brand.json's jwks.keys[] entries are AdcpJsonWebKey shape — adcp_use,
-  // key_ops, alg, use are all required by the SDK validator.
+  const kid = `training-${tenantId}-${kidSuffix}${randomBytes(4).toString('hex')}`;
   const brandJwk: AdcpJsonWebKey = {
     ...publicJwk,
     kid,
     alg: 'EdDSA',
-    adcp_use: 'webhook-signing',
+    adcp_use: purpose,
     key_ops: ['verify'],
     use: 'sig',
   } as AdcpJsonWebKey;
-
   logger.warn(
-    { tenantId, kid },
-    'Tenant signing key generated ephemerally. Provision GCP KMS keys for stable kids.',
+    { tenantId, kid, purpose },
+    'Tenant signing key generated ephemerally. Provision KMS-backed keys for stable kids.',
   );
+  return { kid, privateJwk, publicJwk, brandJwk };
+}
 
-  return { signingKey, publicJwk: brandJwk };
+function generateEphemeralKey(tenantId: string): TenantMaterial {
+  const e = generateEphemeralEd25519(tenantId, 'webhook-signing', '');
+  return {
+    signingKey: {
+      keyId: e.kid,
+      publicJwk: { ...e.publicJwk, kid: e.kid },
+      privateJwk: { ...e.privateJwk, kid: e.kid },
+    },
+    publicJwk: e.brandJwk,
+  };
 }
 
 /**
@@ -90,46 +97,20 @@ export function getTenantSigningMaterial(tenantId: string): TenantMaterial {
   return m;
 }
 
-/** Generate an ephemeral Ed25519 response-signing keypair. Distinct kid +
- *  adcp_use from the webhook-signing key on the same tenant so the SDK's
- *  signResponse purpose-binding check passes against this key and only this
- *  key. */
 function generateResponseSigningKey(tenantId: string): TenantResponseSigningMaterial {
-  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
-  const privateJwk = privateKey.export({ format: 'jwk' }) as Record<string, unknown>;
-  const publicJwk = publicKey.export({ format: 'jwk' }) as Record<string, unknown>;
-  const kid = `training-${tenantId}-resp-${randomBytes(4).toString('hex')}`;
-
+  const e = generateEphemeralEd25519(tenantId, 'response-signing', 'resp-');
   const privateAdcpJwk: AdcpJsonWebKey = {
-    ...privateJwk,
-    kid,
+    ...e.privateJwk,
+    kid: e.kid,
     alg: 'EdDSA',
     adcp_use: 'response-signing',
     key_ops: ['sign'],
     use: 'sig',
   } as AdcpJsonWebKey;
-
-  const signerKey: SignerKey = {
-    keyid: kid,
-    alg: 'ed25519',
-    privateKey: privateAdcpJwk,
+  return {
+    signerKey: { keyid: e.kid, alg: 'ed25519', privateKey: privateAdcpJwk },
+    publicJwk: e.brandJwk,
   };
-
-  const brandJwk: AdcpJsonWebKey = {
-    ...publicJwk,
-    kid,
-    alg: 'EdDSA',
-    adcp_use: 'response-signing',
-    key_ops: ['verify'],
-    use: 'sig',
-  } as AdcpJsonWebKey;
-
-  logger.warn(
-    { tenantId, kid },
-    'Tenant response-signing key generated ephemerally. Provision KMS-backed keys for stable kids.',
-  );
-
-  return { signerKey, publicJwk: brandJwk };
 }
 
 /**

--- a/server/tests/integration/training-agent-response-signing.test.ts
+++ b/server/tests/integration/training-agent-response-signing.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Integration test for outbound RFC 9421 response signing on tenant MCP
+ * routes. Asserts:
+ *   - successful JSON-RPC responses get `Signature`, `Signature-Input`, and
+ *     `Content-Digest` headers
+ *   - the signature verifies against the tenant's `response-signing` JWK
+ *     published at `/.well-known/jwks.json`
+ *   - the JWK carries `adcp_use: "response-signing"` (purpose-binding)
+ *   - non-JSON / SSE responses pass through unsigned
+ *
+ * Verifier-side helpers (`buildResponseSignatureBase`, Ed25519 verify via
+ * node:crypto) follow the same pattern as the SDK's own response-signing
+ * test — round-trips the bytes without depending on a verifier helper that
+ * hasn't shipped yet.
+ */
+import { createPublicKey, createVerify, verify as cryptoVerify, type KeyObject } from 'node:crypto';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { buildResponseSignatureBase, type ResponseLike } from '@adcp/sdk/signing';
+
+vi.hoisted(() => {
+  process.env.PUBLIC_TEST_AGENT_TOKEN = 'test-token-for-response-signing';
+  delete process.env.BASE_URL;
+});
+
+vi.mock('../../src/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+const { createTrainingAgentRouter } = await import('../../src/training-agent/index.js');
+const { stopSessionCleanup } = await import('../../src/training-agent/state.js');
+
+/** Parse the Signature-Input header value into components + params.
+ *  Format per RFC 9421 §4.1: `sig1=("@status" "@authority" "content-digest");created=…;keyid=…;alg=…` */
+function parseSignatureInput(headerValue: string): { label: string; components: string[]; params: Record<string, string | number> } {
+  const eq = headerValue.indexOf('=');
+  const label = headerValue.slice(0, eq);
+  const rest = headerValue.slice(eq + 1);
+  const closeParen = rest.indexOf(')');
+  const componentList = rest.slice(1, closeParen);
+  const components = componentList.split(' ').map(c => c.replace(/^"|"$/g, ''));
+  const paramPart = rest.slice(closeParen + 1).replace(/^;/, '');
+  const params: Record<string, string | number> = {};
+  for (const p of paramPart.split(';')) {
+    if (!p) continue;
+    const [k, v] = p.split('=');
+    if (!k) continue;
+    const stripped = (v ?? '').replace(/^"|"$/g, '');
+    params[k] = /^\d+$/.test(stripped) ? Number(stripped) : stripped;
+  }
+  return { label, components, params };
+}
+
+/** Decode the bare signature bytes from a Signature header value.
+ *  Format: `sig1=:<base64>:` per RFC 9421 §4.2. */
+function decodeSignatureBytes(headerValue: string): Buffer {
+  const colon = headerValue.indexOf(':');
+  const closing = headerValue.lastIndexOf(':');
+  const b64 = headerValue.slice(colon + 1, closing);
+  return Buffer.from(b64, 'base64');
+}
+
+describe('Training Agent response signing', () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json({
+      limit: '5mb',
+      verify: (req, _res, buf) => {
+        (req as unknown as { rawBody: string }).rawBody = buf.toString('utf8');
+      },
+    }));
+    app.use('/api/training-agent', createTrainingAgentRouter());
+  });
+
+  afterAll(() => {
+    stopSessionCleanup();
+  });
+
+  it("publishes the response-signing JWK on /.well-known/jwks.json", async () => {
+    const res = await request(app)
+      .get('/api/training-agent/.well-known/jwks.json')
+      .set('Host', 'test-agent.example.org')
+      .set('X-Forwarded-Proto', 'https');
+
+    expect(res.status).toBe(200);
+    const keys = res.body.keys as Array<Record<string, unknown>>;
+    const salesKey = keys.find(k => typeof k.kid === 'string' && (k.kid as string).startsWith('training-sales-resp-'));
+    expect(salesKey, 'sales tenant must publish a response-signing JWK').toBeDefined();
+    expect(salesKey?.adcp_use).toBe('response-signing');
+    expect(salesKey?.kty).toBe('OKP');
+    expect(salesKey?.crv).toBe('Ed25519');
+    expect(salesKey?.alg).toBe('EdDSA');
+  });
+
+  it('signs initialize responses on /sales/mcp and the signature verifies', async () => {
+    // The MCP `initialize` handshake produces a plain JSON-RPC 2.0 result
+    // that the response-signing wrapper covers. We use it instead of
+    // `tools/list` because supertest doesn't negotiate the streamable HTTP
+    // SSE upgrade, and initialize returns plain JSON in both modes.
+    const res = await request(app)
+      .post('/api/training-agent/sales/mcp')
+      .set('Host', 'test-agent.example.org')
+      .set('X-Forwarded-Proto', 'https')
+      .set('Authorization', 'Bearer test-token-for-response-signing')
+      .set('Accept', 'application/json, text/event-stream')
+      .set('Content-Type', 'application/json')
+      .send({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          clientInfo: { name: 'response-signing-test', version: '1.0' },
+          capabilities: {},
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+    expect(res.headers['signature']).toBeDefined();
+    expect(res.headers['signature-input']).toBeDefined();
+    expect(res.headers['content-digest']).toBeDefined();
+
+    // Pull the kid out of Signature-Input + look up the matching public key.
+    const parsed = parseSignatureInput(res.headers['signature-input']);
+    expect(parsed.components).toContain('@status');
+    expect(parsed.components).toContain('@authority');
+    expect(parsed.components).toContain('content-digest');
+    expect(typeof parsed.params.keyid).toBe('string');
+    const kid = parsed.params.keyid as string;
+    expect(kid).toMatch(/^training-sales-resp-/);
+
+    const jwksRes = await request(app)
+      .get('/api/training-agent/.well-known/jwks.json')
+      .set('Host', 'test-agent.example.org')
+      .set('X-Forwarded-Proto', 'https');
+    const jwk = (jwksRes.body.keys as Array<Record<string, unknown>>).find(k => k.kid === kid);
+    expect(jwk).toBeDefined();
+
+    // Reconstruct the signature base the signer produced, then verify the
+    // Ed25519 signature against the JWK. This is a round-trip of the wire
+    // bytes — same pattern as the SDK's own response-signing test.
+    const responseLike: ResponseLike = {
+      status: res.status,
+      headers: {
+        'content-type': res.headers['content-type'],
+        'content-digest': res.headers['content-digest'],
+      },
+      body: res.text,
+      request: {
+        method: 'POST',
+        url: 'https://test-agent.example.org/api/training-agent/sales/mcp',
+      },
+    };
+    const sigInputHeader = res.headers['signature-input'] as string;
+    const sigParamsValue = sigInputHeader.slice(sigInputHeader.indexOf('=') + 1);
+    const base = buildResponseSignatureBase(parsed.components, responseLike, parsed.params as Parameters<typeof buildResponseSignatureBase>[2], sigParamsValue);
+    const signatureBytes = decodeSignatureBytes(res.headers['signature'] as string);
+
+    const publicKey: KeyObject = createPublicKey({ format: 'jwk', key: jwk as Parameters<typeof createPublicKey>[0]['key'] });
+    const ok = cryptoVerify(null, Buffer.from(base, 'utf8'), publicKey, signatureBytes);
+    expect(ok, 'Signature must verify against the published response-signing JWK').toBe(true);
+  });
+
+  it('passes through non-JSON responses unsigned (health endpoint)', async () => {
+    const res = await request(app).get('/api/training-agent/health');
+    expect(res.headers['signature']).toBeUndefined();
+    expect(res.headers['signature-input']).toBeUndefined();
+  });
+});

--- a/server/tests/integration/training-agent-response-signing.test.ts
+++ b/server/tests/integration/training-agent-response-signing.test.ts
@@ -13,11 +13,11 @@
  * test — round-trips the bytes without depending on a verifier helper that
  * hasn't shipped yet.
  */
-import { createPublicKey, createVerify, verify as cryptoVerify, type KeyObject } from 'node:crypto';
+import { createPublicKey, verify as cryptoVerify, type KeyObject } from 'node:crypto';
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
-import { buildResponseSignatureBase, type ResponseLike } from '@adcp/sdk/signing';
+import { buildResponseSignatureBase, signResponse, type ResponseLike, type SignerKey } from '@adcp/sdk/signing';
 
 vi.hoisted(() => {
   process.env.PUBLIC_TEST_AGENT_TOKEN = 'test-token-for-response-signing';
@@ -174,5 +174,103 @@ describe('Training Agent response signing', () => {
     const res = await request(app).get('/api/training-agent/health');
     expect(res.headers['signature']).toBeUndefined();
     expect(res.headers['signature-input']).toBeUndefined();
+  });
+
+  it('signature is freshness-bound (created within 5s of now)', async () => {
+    const res = await request(app)
+      .post('/api/training-agent/sales/mcp')
+      .set('Host', 'test-agent.example.org')
+      .set('X-Forwarded-Proto', 'https')
+      .set('Authorization', 'Bearer test-token-for-response-signing')
+      .set('Accept', 'application/json, text/event-stream')
+      .set('Content-Type', 'application/json')
+      .send({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'initialize',
+        params: { protocolVersion: '2025-03-26', clientInfo: { name: 'x', version: '1' }, capabilities: {} },
+      });
+    expect(res.status).toBe(200);
+    const parsed = parseSignatureInput(res.headers['signature-input']);
+    const created = parsed.params.created as number;
+    const now = Math.floor(Date.now() / 1000);
+    expect(Math.abs(now - created)).toBeLessThan(5);
+  });
+
+  it('signature fails to verify when signature bytes are tampered', async () => {
+    const res = await request(app)
+      .post('/api/training-agent/sales/mcp')
+      .set('Host', 'test-agent.example.org')
+      .set('X-Forwarded-Proto', 'https')
+      .set('Authorization', 'Bearer test-token-for-response-signing')
+      .set('Accept', 'application/json, text/event-stream')
+      .set('Content-Type', 'application/json')
+      .send({
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'initialize',
+        params: { protocolVersion: '2025-03-26', clientInfo: { name: 'x', version: '1' }, capabilities: {} },
+      });
+    expect(res.status).toBe(200);
+    const parsed = parseSignatureInput(res.headers['signature-input']);
+    const kid = parsed.params.keyid as string;
+
+    const jwksRes = await request(app)
+      .get('/api/training-agent/.well-known/jwks.json')
+      .set('Host', 'test-agent.example.org')
+      .set('X-Forwarded-Proto', 'https');
+    const jwk = (jwksRes.body.keys as Array<Record<string, unknown>>).find(k => k.kid === kid);
+
+    const responseLike: ResponseLike = {
+      status: res.status,
+      headers: {
+        'content-type': res.headers['content-type'],
+        'content-digest': res.headers['content-digest'],
+      },
+      body: res.text,
+      request: {
+        method: 'POST',
+        url: 'https://test-agent.example.org/api/training-agent/sales/mcp',
+      },
+    };
+    const sigInputHeader = res.headers['signature-input'] as string;
+    const sigParamsValue = sigInputHeader.slice(sigInputHeader.indexOf('=') + 1);
+    const base = buildResponseSignatureBase(parsed.components, responseLike, parsed.params as Parameters<typeof buildResponseSignatureBase>[2], sigParamsValue);
+
+    // Flip the first byte of the signature — verification must reject.
+    const signatureBytes = decodeSignatureBytes(res.headers['signature'] as string);
+    const tampered = Buffer.from(signatureBytes);
+    tampered[0] ^= 0xff;
+
+    const publicKey: KeyObject = createPublicKey({ format: 'jwk', key: jwk as Parameters<typeof createPublicKey>[0]['key'] });
+    const ok = cryptoVerify(null, Buffer.from(base, 'utf8'), publicKey, tampered);
+    expect(ok).toBe(false);
+  });
+
+  it('signResponse throws when handed a key with the wrong adcp_use', () => {
+    // Mint a key with adcp_use: 'webhook-signing' and try to use it for
+    // signResponse — SDK MUST reject (closing the gap flagged on adcp-client#1823).
+    const wrongPurposeKey: SignerKey = {
+      keyid: 'wrong-purpose-test',
+      alg: 'ed25519',
+      privateKey: {
+        kty: 'OKP',
+        crv: 'Ed25519',
+        x: 'Xe2lAKRJR_zr3FQRdSNwp3zsrv_IXnVCWJXDcWXwkLI',
+        d: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaQ',
+        alg: 'EdDSA',
+        adcp_use: 'webhook-signing', // wrong purpose
+        key_ops: ['sign'],
+        use: 'sig',
+        kid: 'wrong-purpose-test',
+      } as Parameters<typeof signResponse>[1]['privateKey'],
+    };
+    const responseLike: ResponseLike = {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+      body: '{"ok":true}',
+      request: { method: 'POST', url: 'https://test-agent.example.org/sales/mcp' },
+    };
+    expect(() => signResponse(responseLike, wrongPurposeKey)).toThrow(/purpose|adcp_use/i);
   });
 });


### PR DESCRIPTION
## Summary
- Every successful JSON response from a tenant MCP route now carries RFC 9421 `Signature`, `Signature-Input`, and `Content-Digest` headers.
- New per-tenant Ed25519 response-signing keypair (`adcp_use: "response-signing"`), distinct from existing webhook-signing material per the SDK's purpose-binding invariant.
- `/.well-known/jwks.json` now aggregates every signing purpose the training agent publishes; buyer verifiers filter by `adcp_use` + `kid`.
- Built on `@adcp/sdk@^7.7.0` which ships `signResponse` from [adcp-client#1823](https://github.com/adcontextprotocol/adcp-client/pull/1823). Bumped from `^7.6.0`.

## Stack progress

| PR | Status |
|---|---|
| #4671 (training-agent brand.json) | ✅ MERGED |
| #4675 (walkthrough fixtures) | ✅ MERGED |
| **PR #2 (this) — sign MCP responses** | **up for review** |
| PR #4 (`verify_brand_claim`) | optional / parked |

All four walkthrough steps in `docs/verification/overview` are now demoable against the training agent:
- Step 1: signature → this PR (the buyer's verifier finds `keyid` in jwks.json via `adcp_use: "response-signing"`)
- Steps 2–4: brand.json / adagents.json / parent-house → #4675 fixtures

## Implementation notes

`wrapResponseForSigning` buffers writes from the MCP transport (`StreamableHTTPServerTransport` with `enableJsonResponse: true`) and intercepts `res.writeHead` so signing headers can be set before the response commits. The MCP transport calls `res.writeHead()` to flush headers before the body — the wrapper defers that flush until `res.end()` time so signing headers can be added.

Non-2xx and non-JSON responses (SSE, errors) pass through unsigned. Response-signing material is pre-warmed at router-create time so the JWKS includes every tenant's key from the first request.

## Test plan
- [x] Integration test verifies headers present AND Ed25519 signature cryptographically round-trips via `buildResponseSignatureBase`
- [x] Full sweep of 21 related tests passes (brand.json, fixtures, governance-signing, tenant-smoke, response-signing)
- [x] Typecheck green
- [ ] Curl `/sales/mcp` against a running training agent; verify response carries the three headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)