### PR TITLE
feat(brand-viewer): claim CTA + ownership badge on /brand/view (closes #4741)

### DIFF
--- a/.changeset/4741-brand-view-claim-flow.md
+++ b/.changeset/4741-brand-view-claim-flow.md
@@ -1,0 +1,19 @@
+---
+---
+
+feat(brand-viewer): first-class "Claim this brand" flow on `/brand/view/{domain}` (closes #4741)
+
+Surfaces ownership state on the brand viewer page so visitors can tell at a glance whether a brand entry is community-hosted, verified-owned, or awaiting adoption — and gives every authenticated visitor a one-click path into the existing DNS-challenge claim flow.
+
+**New endpoint**
+
+- `GET /api/brands/:domain/ownership` (optional auth) — returns `{ status: community | verified | orphaned, owner: { name } | null, can_claim, can_manage, claim_url, manage_url, authenticated }`. Anonymous callers get status + display name; authenticated callers also get the management hint when their primary org owns the brand. The endpoint never grants edit authority — the actual claim still runs through `/api/me/member-profile/brand-claim/*` where DNS proves ownership.
+
+**Viewer UX**
+
+- Ownership badge in the hero ("Verified — owned by Acme Corp" / "Community" / "Awaiting adoption").
+- "Claim this brand" CTA → `/brand/builder?domain={domain}` for authenticated visitors when the brand isn't verified-owned.
+- "Manage brand" CTA → `/brand/builder?domain={domain}` for visitors whose primary org owns the brand.
+- "Sign in to claim" for unauthenticated visitors on community/orphaned brands, with `return_to` back to the viewer.
+
+The brand-builder page already accepts `?domain=` and pre-populates the claim flow, so no changes there.

--- a/server/public/brand-viewer.html
+++ b/server/public/brand-viewer.html
@@ -66,6 +66,34 @@
         letter-spacing: var(--tracking-wide);
       }
 
+      .ownership-badge {
+        font-size: var(--text-xs);
+        padding: var(--space-1) var(--space-3);
+        border-radius: var(--radius-full);
+        font-weight: var(--font-semibold);
+        text-transform: uppercase;
+        letter-spacing: var(--tracking-wide);
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-1_5);
+        line-height: 1;
+      }
+      .ownership-badge[data-status="verified"] {
+        background: var(--color-success-100, #d1fae5);
+        color: var(--color-success-700, #047857);
+      }
+      .ownership-badge[data-status="community"] {
+        background: var(--color-purple-100);
+        color: var(--color-purple-700);
+      }
+      .ownership-badge[data-status="orphaned"] {
+        background: var(--color-warning-100, #fef3c7);
+        color: var(--color-warning-700, #b45309);
+      }
+      .ownership-badge[data-status=""] {
+        display: none;
+      }
+
       /* Section headings */
       .section-heading {
         font-size: var(--text-xl);
@@ -1193,6 +1221,12 @@
         </div>
         <h1 id="hero-title">Brand Viewer</h1>
         <p class="hero-subtitle" id="hero-subtitle">Loading brand data...</p>
+        <div id="ownership-row" class="hidden" style="margin-top: var(--space-3); display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-2);">
+          <span id="ownership-badge" class="ownership-badge" data-status=""></span>
+          <a id="claim-brand-btn" class="hidden btn btn-primary" href="#" style="padding: 4px 12px; font-size: var(--text-xs); font-weight: var(--font-semibold); border-radius: var(--radius-md);">Claim this brand</a>
+          <a id="manage-brand-btn" class="hidden btn btn-primary" href="#" style="padding: 4px 12px; font-size: var(--text-xs); font-weight: var(--font-semibold); border-radius: var(--radius-md);">Manage brand</a>
+          <a id="claim-signin-btn" class="hidden" href="#" style="padding: 4px 12px; font-size: var(--text-xs); font-weight: var(--font-semibold); background: var(--color-bg-subtle); color: var(--color-text-secondary); border: 1px solid var(--color-border); border-radius: var(--radius-md); text-decoration: none;">Sign in to claim</a>
+        </div>
         <button id="refresh-brand-btn" class="hidden" onclick="refreshBrand()" style="margin-top: var(--space-3); padding: 4px 12px; font-size: var(--text-xs); font-weight: var(--font-semibold); background: var(--color-bg-subtle); color: var(--color-text-secondary); border: 1px solid var(--color-border); border-radius: var(--radius-md); cursor: pointer; transition: var(--transition-all);">Refresh from brand.json</button>
       </div>
     </section>
@@ -2366,6 +2400,47 @@
         }
       }
 
+      async function loadOwnership(domain) {
+        const row = document.getElementById('ownership-row');
+        const badge = document.getElementById('ownership-badge');
+        const claimBtn = document.getElementById('claim-brand-btn');
+        const manageBtn = document.getElementById('manage-brand-btn');
+        const signinBtn = document.getElementById('claim-signin-btn');
+        if (!row || !badge) return;
+        try {
+          const resp = await fetch(`/api/brands/${encodeURIComponent(domain)}/ownership`);
+          if (!resp.ok) return;
+          const data = await resp.json();
+
+          const labels = {
+            verified: data.owner?.name ? `Verified — owned by ${data.owner.name}` : 'Verified',
+            orphaned: 'Awaiting adoption',
+            community: 'Community',
+          };
+          badge.textContent = labels[data.status] || '';
+          badge.setAttribute('data-status', data.status || '');
+
+          if (data.can_manage && data.manage_url) {
+            manageBtn.setAttribute('href', data.manage_url);
+            manageBtn.classList.remove('hidden');
+          }
+          if (data.can_claim && data.claim_url) {
+            claimBtn.setAttribute('href', data.claim_url);
+            claimBtn.classList.remove('hidden');
+          }
+          // Anonymous viewers who could claim if signed in: prompt them.
+          // Skip when the brand is already verified — they can't claim it anyway.
+          if (!data.authenticated && data.status !== 'verified') {
+            const returnTo = encodeURIComponent(window.location.pathname);
+            signinBtn.setAttribute('href', `/auth/login?return_to=${returnTo}`);
+            signinBtn.classList.remove('hidden');
+          }
+          row.classList.remove('hidden');
+        } catch (err) {
+          // Non-fatal — leave the row hidden.
+        }
+      }
+
       async function init() {
         const pathParts = window.location.pathname.split('/');
         // /brand/view/domain.com → domain is everything after /brand/view/
@@ -2379,6 +2454,10 @@
         document.getElementById('hero-subtitle').textContent = domain;
         currentDomain = domain;
         initUploadUI();
+
+        // Render the ownership badge + Claim/Manage CTA. Fire-and-forget so a
+        // slow lookup never blocks the rest of the page.
+        loadOwnership(domain);
 
         // Show refresh button for logged-in users
         if (window.__APP_CONFIG__?.user) {

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -128,6 +128,7 @@ import { createAccountLinkingRouter, handleEmailLinkVerification } from "./route
 import { createNetworkHealthApiRouter } from "./routes/network-health.js";
 import { createBrandLogoRouter } from "./routes/brand-logos.js";
 import { createBrandFeedsRouter } from "./routes/brand-feeds.js";
+import { createBrandOwnershipRouter } from "./routes/brand-ownership.js";
 import { createTrainingAgentRouter } from "./training-agent/index.js";
 import { TRAINING_AGENT_HOSTNAMES, TRAINING_AGENT_HOSTNAME_DEPRECATED, TRAINING_AGENT_URL } from "./training-agent/config.js";
 import { createCreativeAgentRouter } from "./creative-agent/index.js";
@@ -1226,6 +1227,9 @@ export class HTTPServer {
 
     // Mount brand feed import routes (RSS, YouTube, Spotify + bulk property/collection merge)
     this.app.use('/api', createBrandFeedsRouter({ brandDb: this.brandDb }));
+
+    // Mount brand ownership status route (drives Claim/Manage CTAs on /brand/view)
+    this.app.use('/api', createBrandOwnershipRouter({ brandDb: this.brandDb }));
 
     // Mount member profile routes
     const memberDb = new MemberDatabase();

--- a/server/src/routes/brand-ownership.ts
+++ b/server/src/routes/brand-ownership.ts
@@ -1,0 +1,114 @@
+/**
+ * Brand ownership status route (#4741).
+ *
+ * Public read endpoint that surfaces whether a brand is community-hosted,
+ * verified-owned, or awaiting adoption. Drives the badge + claim/manage CTAs
+ * on /brand/view/{domain}.
+ *
+ * Trust model:
+ *  - Anonymous callers get status + owner display name only.
+ *  - Authenticated callers additionally get can_claim / can_manage hints.
+ *  - The actual claim flow still runs through /api/me/member-profile/brand-claim/*
+ *    where DNS proves ownership; this endpoint never grants edit authority.
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { optionalAuth } from '../middleware/auth.js';
+import { BrandDatabase } from '../db/brand-db.js';
+import { OrganizationDatabase } from '../db/organization-db.js';
+import { resolvePrimaryOrganization } from '../db/users-db.js';
+import { canonicalizeBrandDomain } from '../services/identifier-normalization.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('brand-ownership');
+
+const domainPattern = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/;
+
+export type BrandOwnershipStatus = 'verified' | 'orphaned' | 'community';
+
+export interface BrandOwnershipResponse {
+  domain: string;
+  status: BrandOwnershipStatus;
+  owner: { name: string } | null;
+  can_manage: boolean;
+  can_claim: boolean;
+  claim_url: string | null;
+  manage_url: string | null;
+  authenticated: boolean;
+}
+
+export function createBrandOwnershipRouter(config: { brandDb: BrandDatabase; orgDb?: OrganizationDatabase }): Router {
+  const router = Router();
+  const { brandDb } = config;
+  const orgDb = config.orgDb ?? new OrganizationDatabase();
+
+  // GET /api/brands/:domain/ownership
+  router.get('/brands/:domain/ownership', optionalAuth, async (req: Request, res: Response) => {
+    let domain: string;
+    try {
+      domain = canonicalizeBrandDomain(decodeURIComponent(req.params.domain));
+    } catch {
+      return res.status(400).json({ error: 'Invalid domain' });
+    }
+    if (!domainPattern.test(domain)) {
+      return res.status(400).json({ error: 'Invalid domain' });
+    }
+
+    try {
+      const brand = await brandDb.getDiscoveredBrandByDomain(domain);
+      const user = (req as any).user as { id: string } | undefined;
+
+      const verified = !!brand && brand.domain_verified === true && !!brand.workos_organization_id;
+      const orphaned = !!brand && brand.manifest_orphaned === true;
+      const status: BrandOwnershipStatus = verified ? 'verified' : orphaned ? 'orphaned' : 'community';
+
+      let ownerName: string | null = null;
+      let ownerOrgId: string | null = null;
+      if (verified && brand?.workos_organization_id) {
+        ownerOrgId = brand.workos_organization_id;
+        try {
+          const org = await orgDb.getOrganization(ownerOrgId);
+          ownerName = org?.name ?? null;
+        } catch (err) {
+          logger.warn({ err, domain, ownerOrgId }, 'Failed to resolve owner org name');
+        }
+      }
+
+      let canManage = false;
+      let canClaim = false;
+      if (user?.id) {
+        let userOrgId: string | null = null;
+        try {
+          userOrgId = await resolvePrimaryOrganization(user.id);
+        } catch (err) {
+          logger.warn({ err, userId: user.id }, 'Failed to resolve user primary org');
+        }
+        if (verified) {
+          canManage = !!userOrgId && userOrgId === ownerOrgId;
+          canClaim = false;
+        } else {
+          canManage = false;
+          canClaim = true;
+        }
+      }
+
+      const builderUrl = `/brand/builder?domain=${encodeURIComponent(domain)}`;
+      const body: BrandOwnershipResponse = {
+        domain,
+        status,
+        owner: ownerName ? { name: ownerName } : null,
+        can_manage: canManage,
+        can_claim: canClaim,
+        manage_url: canManage ? builderUrl : null,
+        claim_url: canClaim ? builderUrl : null,
+        authenticated: !!user?.id,
+      };
+      return res.json(body);
+    } catch (error) {
+      logger.error({ err: error, domain }, 'Failed to resolve brand ownership');
+      return res.status(500).json({ error: 'Failed to resolve brand ownership' });
+    }
+  });
+
+  return router;
+}

--- a/server/tests/integration/brand-ownership-route.test.ts
+++ b/server/tests/integration/brand-ownership-route.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Integration tests for GET /api/brands/:domain/ownership (#4741).
+ *
+ * Exercises the four observable states (community, verified, orphaned, plus
+ * the not-found-but-treated-as-community case) and the auth-conditional
+ * can_claim / can_manage hints.
+ *
+ * Run locally:
+ *   DATABASE_URL=postgresql://adcp:localdev@localhost:53198/adcp_test \
+ *     npx vitest run server/tests/integration/brand-ownership-route.test.ts
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import type { Pool } from 'pg';
+
+let currentUserId: string | null = null;
+
+vi.mock('../../src/middleware/auth.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/middleware/auth.js')>();
+  return {
+    ...actual,
+    optionalAuth: (req: { user?: unknown }, _res: unknown, next: () => void) => {
+      if (currentUserId !== null) {
+        req.user = { id: currentUserId, email: `${currentUserId}@test.com` };
+      }
+      next();
+    },
+    requireAuth: (req: { user?: unknown }, res: { status: (n: number) => { json: (b: unknown) => void } }, next: () => void) => {
+      if (currentUserId === null) return res.status(401).json({ error: 'auth required' });
+      req.user = { id: currentUserId, email: `${currentUserId}@test.com` };
+      next();
+    },
+  };
+});
+
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { BrandDatabase } from '../../src/db/brand-db.js';
+import { createBrandOwnershipRouter } from '../../src/routes/brand-ownership.js';
+
+const RUN_SUFFIX = `${process.pid}-${Date.now()}`;
+const OWNER_USER_ID = `user_test_brand_ownership_owner_${RUN_SUFFIX}`;
+const OTHER_USER_ID = `user_test_brand_ownership_other_${RUN_SUFFIX}`;
+const OWNER_ORG_ID = `org_test_brand_ownership_owner_${RUN_SUFFIX}`;
+const OTHER_ORG_ID = `org_test_brand_ownership_other_${RUN_SUFFIX}`;
+
+const VERIFIED_DOMAIN = `verified-${RUN_SUFFIX}.example.com`;
+const COMMUNITY_DOMAIN = `community-${RUN_SUFFIX}.example.com`;
+const ORPHANED_DOMAIN = `orphaned-${RUN_SUFFIX}.example.com`;
+const MISSING_DOMAIN = `missing-${RUN_SUFFIX}.example.com`;
+
+describe('GET /api/brands/:domain/ownership', () => {
+  let pool: Pool;
+  let app: express.Express;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:53198/adcp_test',
+    });
+    await runMigrations();
+
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, created_at, updated_at)
+       VALUES ($1, 'Acme Corp', NOW(), NOW()), ($2, 'Other Corp', NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      [OWNER_ORG_ID, OTHER_ORG_ID],
+    );
+
+    // Cache primary org pointer for both users — resolvePrimaryOrganization
+    // reads from users.primary_organization_id (denormalized, FK-enforced),
+    // not from organization_memberships, so the membership rows below are
+    // belt-and-suspenders for any consumer that prefers WorkOS-shaped joins.
+    await pool.query(
+      `INSERT INTO users (workos_user_id, email, primary_organization_id, created_at, updated_at)
+       VALUES ($1, $3, $5, NOW(), NOW()), ($2, $4, $6, NOW(), NOW())
+       ON CONFLICT (workos_user_id) DO UPDATE SET primary_organization_id = EXCLUDED.primary_organization_id`,
+      [OWNER_USER_ID, OTHER_USER_ID, `${OWNER_USER_ID}@test.com`, `${OTHER_USER_ID}@test.com`, OWNER_ORG_ID, OTHER_ORG_ID],
+    );
+
+    await pool.query(
+      `INSERT INTO organization_memberships (workos_user_id, workos_organization_id, email, role, created_at, updated_at)
+       VALUES ($1, $3, $5, 'admin', NOW(), NOW()), ($2, $4, $6, 'admin', NOW(), NOW())
+       ON CONFLICT (workos_user_id, workos_organization_id) DO NOTHING`,
+      [OWNER_USER_ID, OTHER_USER_ID, OWNER_ORG_ID, OTHER_ORG_ID, `${OWNER_USER_ID}@test.com`, `${OTHER_USER_ID}@test.com`],
+    );
+
+    const brandDb = new BrandDatabase();
+    app = express();
+    app.use(express.json());
+    app.use('/api', createBrandOwnershipRouter({ brandDb }));
+  });
+
+  afterAll(async () => {
+    await pool.query(
+      `DELETE FROM brands WHERE domain IN ($1, $2, $3, $4)`,
+      [VERIFIED_DOMAIN, COMMUNITY_DOMAIN, ORPHANED_DOMAIN, MISSING_DOMAIN],
+    );
+    await pool.query(
+      `DELETE FROM organization_memberships WHERE workos_organization_id IN ($1, $2)`,
+      [OWNER_ORG_ID, OTHER_ORG_ID],
+    );
+    await pool.query(
+      `DELETE FROM users WHERE workos_user_id IN ($1, $2)`,
+      [OWNER_USER_ID, OTHER_USER_ID],
+    );
+    await pool.query(
+      `DELETE FROM organizations WHERE workos_organization_id IN ($1, $2)`,
+      [OWNER_ORG_ID, OTHER_ORG_ID],
+    );
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    currentUserId = null;
+    await pool.query(`DELETE FROM brands WHERE domain IN ($1, $2, $3, $4)`,
+      [VERIFIED_DOMAIN, COMMUNITY_DOMAIN, ORPHANED_DOMAIN, MISSING_DOMAIN]);
+  });
+
+  async function seedBrand(domain: string, fields: Record<string, unknown>) {
+    const cols = ['domain', 'brand_name', 'source_type', 'is_public', 'has_brand_manifest', 'review_status', ...Object.keys(fields)];
+    const vals = [domain, 'Test Brand', 'community', true, false, 'approved', ...Object.values(fields)];
+    const placeholders = vals.map((_, i) => `$${i + 1}`).join(', ');
+    await pool.query(`INSERT INTO brands (${cols.join(', ')}) VALUES (${placeholders})`, vals);
+  }
+
+  it('returns community for a brand with no owner', async () => {
+    await seedBrand(COMMUNITY_DOMAIN, {});
+    const res = await request(app).get(`/api/brands/${COMMUNITY_DOMAIN}/ownership`);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      domain: COMMUNITY_DOMAIN,
+      status: 'community',
+      owner: null,
+      can_claim: false,
+      can_manage: false,
+      authenticated: false,
+    });
+  });
+
+  it('returns community (not 404) for a domain with no brand row at all', async () => {
+    const res = await request(app).get(`/api/brands/${MISSING_DOMAIN}/ownership`);
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('community');
+    expect(res.body.owner).toBeNull();
+  });
+
+  it('returns verified with owner name when a brand is claimed and DNS-verified', async () => {
+    await seedBrand(VERIFIED_DOMAIN, {
+      workos_organization_id: OWNER_ORG_ID,
+      domain_verified: true,
+    });
+    const res = await request(app).get(`/api/brands/${VERIFIED_DOMAIN}/ownership`);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      status: 'verified',
+      owner: { name: 'Acme Corp' },
+      authenticated: false,
+      can_claim: false,
+      can_manage: false,
+    });
+  });
+
+  it('flags can_manage when the authenticated user belongs to the owning org', async () => {
+    await seedBrand(VERIFIED_DOMAIN, {
+      workos_organization_id: OWNER_ORG_ID,
+      domain_verified: true,
+    });
+    currentUserId = OWNER_USER_ID;
+    const res = await request(app).get(`/api/brands/${VERIFIED_DOMAIN}/ownership`);
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('verified');
+    expect(res.body.can_manage).toBe(true);
+    expect(res.body.can_claim).toBe(false);
+    expect(res.body.manage_url).toBe(`/brand/builder?domain=${encodeURIComponent(VERIFIED_DOMAIN)}`);
+    expect(res.body.claim_url).toBeNull();
+  });
+
+  it('does not let a user from another org manage a verified brand', async () => {
+    await seedBrand(VERIFIED_DOMAIN, {
+      workos_organization_id: OWNER_ORG_ID,
+      domain_verified: true,
+    });
+    currentUserId = OTHER_USER_ID;
+    const res = await request(app).get(`/api/brands/${VERIFIED_DOMAIN}/ownership`);
+    expect(res.status).toBe(200);
+    expect(res.body.can_manage).toBe(false);
+    // A verified brand is not claimable by another org through this UX path.
+    expect(res.body.can_claim).toBe(false);
+  });
+
+  it('lets any authenticated user claim a community brand', async () => {
+    await seedBrand(COMMUNITY_DOMAIN, {});
+    currentUserId = OTHER_USER_ID;
+    const res = await request(app).get(`/api/brands/${COMMUNITY_DOMAIN}/ownership`);
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('community');
+    expect(res.body.can_claim).toBe(true);
+    expect(res.body.claim_url).toBe(`/brand/builder?domain=${encodeURIComponent(COMMUNITY_DOMAIN)}`);
+  });
+
+  it('reports orphaned status when prior owner relinquished', async () => {
+    await seedBrand(ORPHANED_DOMAIN, {
+      manifest_orphaned: true,
+      prior_owner_org_id: OWNER_ORG_ID,
+    });
+    currentUserId = OTHER_USER_ID;
+    const res = await request(app).get(`/api/brands/${ORPHANED_DOMAIN}/ownership`);
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('orphaned');
+    // Owner is null for orphaned brands — prior_owner_org_id is internal state.
+    expect(res.body.owner).toBeNull();
+    expect(res.body.can_claim).toBe(true);
+  });
+
+  it('rejects malformed domains', async () => {
+    const res = await request(app).get('/api/brands/not_a_domain/ownership');
+    expect(res.status).toBe(400);
+  });
+});

--- a/server/tests/unit/brand-ownership-route.test.ts
+++ b/server/tests/unit/brand-ownership-route.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for GET /api/brands/:domain/ownership (#4741).
+ *
+ * Pinned scenarios: community (no row + row-with-no-owner), verified (with and
+ * without same-org caller), orphaned, and malformed domain. DB and org lookups
+ * are mocked — the integration test (when DB is available) covers wire shape;
+ * this file pins the response logic.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+vi.mock('../../src/middleware/auth.js', async () => ({
+  optionalAuth: (req: { user?: unknown }, _res: unknown, next: () => void) => {
+    if (currentUserId !== null) {
+      req.user = { id: currentUserId, email: `${currentUserId}@test.com` };
+    }
+    next();
+  },
+}));
+
+const resolvePrimaryOrganizationMock = vi.fn();
+vi.mock('../../src/db/users-db.js', () => ({
+  resolvePrimaryOrganization: (userId: string) => resolvePrimaryOrganizationMock(userId),
+}));
+
+import { createBrandOwnershipRouter } from '../../src/routes/brand-ownership.js';
+import type { BrandDatabase } from '../../src/db/brand-db.js';
+import type { OrganizationDatabase } from '../../src/db/organization-db.js';
+
+let currentUserId: string | null = null;
+
+const OWNER_ORG = 'org_owner';
+const OWNER_USER = 'user_owner';
+const OTHER_USER = 'user_other';
+
+function makeApp(brandRow: Record<string, unknown> | null, orgName: string | null) {
+  const brandDb = {
+    getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(brandRow),
+  } as unknown as BrandDatabase;
+  const orgDb = {
+    getOrganization: vi.fn().mockResolvedValue(orgName ? { name: orgName } : null),
+  } as unknown as OrganizationDatabase;
+  const app = express();
+  app.use('/api', createBrandOwnershipRouter({ brandDb, orgDb }));
+  return app;
+}
+
+describe('GET /api/brands/:domain/ownership', () => {
+  beforeEach(() => {
+    currentUserId = null;
+    resolvePrimaryOrganizationMock.mockReset();
+  });
+
+  it('treats a missing brand row as community (not 404)', async () => {
+    const app = makeApp(null, null);
+    const res = await request(app).get('/api/brands/example.com/ownership');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      domain: 'example.com',
+      status: 'community',
+      owner: null,
+      can_claim: false,
+      can_manage: false,
+      authenticated: false,
+    });
+  });
+
+  it('returns community when the brand row exists but is unclaimed', async () => {
+    const app = makeApp({ domain: 'example.com' }, null);
+    const res = await request(app).get('/api/brands/example.com/ownership');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('community');
+    expect(res.body.owner).toBeNull();
+  });
+
+  it('returns verified + owner name for a claimed brand', async () => {
+    const app = makeApp(
+      { domain: 'example.com', workos_organization_id: OWNER_ORG, domain_verified: true },
+      'Acme Corp',
+    );
+    const res = await request(app).get('/api/brands/example.com/ownership');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('verified');
+    expect(res.body.owner).toEqual({ name: 'Acme Corp' });
+    expect(res.body.can_manage).toBe(false);
+    expect(res.body.can_claim).toBe(false);
+  });
+
+  it('sets can_manage when the authenticated user belongs to the owning org', async () => {
+    const app = makeApp(
+      { domain: 'example.com', workos_organization_id: OWNER_ORG, domain_verified: true },
+      'Acme Corp',
+    );
+    currentUserId = OWNER_USER;
+    resolvePrimaryOrganizationMock.mockResolvedValueOnce(OWNER_ORG);
+    const res = await request(app).get('/api/brands/example.com/ownership');
+    expect(res.status).toBe(200);
+    expect(res.body.can_manage).toBe(true);
+    expect(res.body.can_claim).toBe(false);
+    expect(res.body.manage_url).toBe('/brand/builder?domain=example.com');
+    expect(res.body.claim_url).toBeNull();
+  });
+
+  it('does not let an unrelated authenticated user claim a verified brand', async () => {
+    const app = makeApp(
+      { domain: 'example.com', workos_organization_id: OWNER_ORG, domain_verified: true },
+      'Acme Corp',
+    );
+    currentUserId = OTHER_USER;
+    resolvePrimaryOrganizationMock.mockResolvedValueOnce('org_other');
+    const res = await request(app).get('/api/brands/example.com/ownership');
+    expect(res.status).toBe(200);
+    expect(res.body.can_manage).toBe(false);
+    expect(res.body.can_claim).toBe(false);
+  });
+
+  it('lets any authenticated user claim a community brand', async () => {
+    const app = makeApp({ domain: 'example.com' }, null);
+    currentUserId = OTHER_USER;
+    resolvePrimaryOrganizationMock.mockResolvedValueOnce('org_other');
+    const res = await request(app).get('/api/brands/example.com/ownership');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('community');
+    expect(res.body.can_claim).toBe(true);
+    expect(res.body.claim_url).toBe('/brand/builder?domain=example.com');
+  });
+
+  it('reports orphaned status without leaking prior owner', async () => {
+    const app = makeApp(
+      { domain: 'example.com', manifest_orphaned: true, prior_owner_org_id: OWNER_ORG },
+      null,
+    );
+    currentUserId = OTHER_USER;
+    resolvePrimaryOrganizationMock.mockResolvedValueOnce('org_other');
+    const res = await request(app).get('/api/brands/example.com/ownership');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('orphaned');
+    expect(res.body.owner).toBeNull();
+    expect(res.body.can_claim).toBe(true);
+  });
+
+  it('rejects malformed domains', async () => {
+    const app = makeApp(null, null);
+    const res = await request(app).get('/api/brands/not_a_domain/ownership');
+    expect(res.status).toBe(400);
+  });
+
+  it('canonicalizes the domain (strips www, lowercases) before lookup', async () => {
+    const getBrand = vi.fn().mockResolvedValue(null);
+    const brandDb = { getDiscoveredBrandByDomain: getBrand } as unknown as BrandDatabase;
+    const orgDb = { getOrganization: vi.fn() } as unknown as OrganizationDatabase;
+    const app = express();
+    app.use('/api', createBrandOwnershipRouter({ brandDb, orgDb }));
+    const res = await request(app).get('/api/brands/WWW.Example.COM/ownership');
+    expect(res.status).toBe(200);
+    expect(getBrand).toHaveBeenCalledWith('example.com');
+    expect(res.body.domain).toBe('example.com');
+  });
+});

--- a/server/tests/unit/brand-ownership-route.test.ts
+++ b/server/tests/unit/brand-ownership-route.test.ts
@@ -7,7 +7,7 @@
  * this file pins the response logic.
  */
 
-import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 


### PR DESCRIPTION
## Summary
- New `GET /api/brands/:domain/ownership` endpoint (optional auth) returns `{ status: community | verified | orphaned, owner: { name } | null, can_claim, can_manage, claim_url, manage_url, authenticated }`. Anonymous viewers get status + owner display name; authenticated viewers also get `can_manage` when their primary org owns the brand. Trust boundary unchanged — actual claims still run through `/api/me/member-profile/brand-claim/*` where DNS proves ownership.
- Brand viewer hero now shows a status-coloured badge plus a context-appropriate CTA: **Manage brand** for owners, **Claim this brand** → `/brand/builder?domain={domain}` for any other authenticated visitor, **Sign in to claim** for anonymous visitors on community/orphaned brands. Brand-builder already accepts `?domain=` and auto-starts the DNS challenge.
- 9 unit tests (mocked DB) cover community / verified / orphaned, same-org vs other-org callers, anonymous viewers, canonicalization, and malformed input. Companion integration test for CI.

## Test plan
- [ ] `cd server && npx vitest run tests/unit/brand-ownership-route.test.ts` passes (9/9 locally).
- [ ] CI runs the DB-backed integration test in `tests/integration/brand-ownership-route.test.ts`.
- [ ] Manual: visit `/brand/view/{some-community-brand}` while signed in → see Community badge + Claim CTA → click → lands on `/brand/builder?domain=…` with the domain pre-filled.
- [ ] Manual: visit `/brand/view/{a-brand-your-org-verified}` → see Verified badge + Manage CTA.
- [ ] Manual: visit `/brand/view/{a-brand-someone-else-verified}` as a different org → Verified badge with their org name, no CTA.

Closes #4741.

🤖 Generated with [Claude Code](https://claude.com/claude-code)