### PR TITLE
fix(addie): reliable routing for admin outreach logging phrases

### DIFF
--- a/.changeset/addie-admin-outreach-logging-router-fix.md
+++ b/.changeset/addie-admin-outreach-logging-router-fix.md
@@ -1,0 +1,12 @@
+---
+---
+
+fix(addie): add quick-match router pattern for admin outreach logging phrases
+
+Adds a deterministic quick-match pattern for "I emailed/called/met with/spoke
+with/contacted" phrasing so admin outreach reports reliably route to the admin
+tool set and trigger log_conversation — instead of falling through to the LLM
+router where the intent sometimes misfires.
+
+Also updates log_conversation's usage_hints to make it clear all fields except
+summary are optional and can be inferred from context.

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.05.2';
+export const CODE_VERSION = '2026.05.3';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -1136,7 +1136,7 @@ Roles: member (default), admin (can manage team), owner (full control)`,
   {
     name: 'log_conversation',
     description: 'Log a conversation or interaction with a prospect/member. Analyzes and extracts learnings.',
-    usage_hints: 'Use when admin reports an interaction.',
+    usage_hints: 'Use when admin reports an email, call, meeting, Slack DM, or any outreach — e.g. "I emailed X at Y about Z", "spoke with [person] today", "had a call with [org]". Only summary is required; infer channel, contact_name, and company_name from context.',
     input_schema: {
       type: 'object' as const,
       properties: {

--- a/server/src/addie/router.ts
+++ b/server/src/addie/router.ts
@@ -698,6 +698,22 @@ export class AddieRouter {
           latency_ms: Date.now() - startTime,
         };
       }
+
+      // Admin outreach logging - "I emailed X", "spoke with Y", "had a call with Z"
+      // log_conversation exists in the admin tool set but the LLM router sometimes
+      // misses informal past-tense outreach reports. Quick-match ensures reliable routing.
+      const outreachLogPattern =
+        /\b(?:emailed|contacted|dm['']?d|direct\s+message[d]?|spoke\s+(?:with|to)|reached\s+out(?:\s+to)?|had\s+a\s+(?:call|meeting|chat|conversation)\s+with|logged\s+a\s+(?:call|conversation|meeting))\b/i;
+      if (outreachLogPattern.test(text)) {
+        return {
+          action: 'respond',
+          tool_sets: ['admin'],
+          confidence: 'high',
+          reason: 'Admin outreach logging',
+          decision_method: 'quick_match',
+          latency_ms: Date.now() - startTime,
+        };
+      }
     }
 
     // Check for greeting/thanks patterns to react (standalone channel messages only —


### PR DESCRIPTION
Refs #4745

When an admin says "I emailed X at Acme about seat limits" in Slack, the message fell through to the LLM router where the intent ("logging conversations → admin") occasionally misfired and `log_conversation` was never called. This is the real friction in the issue — not a missing tool.

This PR adds a deterministic quick-match pattern (`outreachLogPattern`) inside the existing `if (ctx.isAAOAdmin)` guard so past-tense outreach reports reliably route to the `admin` tool set without LLM classification. It also updates `log_conversation`'s `usage_hints` so Sonnet infers optional fields from context rather than asking for them, and bumps `CODE_VERSION` to `2026.05.3` per playbook.

**Non-breaking justification:** adds a new routing branch for admin users only (guarded by `ctx.isAAOAdmin`). No existing routing path changes; non-admin behaviour is entirely unaffected.

**Pre-PR review:**
- code-reviewer: approved — regex is ReDoS-safe (no nested quantifiers), `called` and `met with` dropped after reviewer flagged false-positive risk; `isAAOAdmin` guard confirmed airtight
- adtech-product-expert: approved — routing fix directly addresses the stated friction; usage_hints update is sufficient; non-breaking confirmed

**Deferred from this issue (tracked on #4745):**
- Items 3 (auto-tag upgrade signals): `upgrade_interest` field doesn't exist; `interaction-analyzer.ts` already extracts `learnings.interests` via LLM pass — surface existing field in `get_account`/`query_prospects` instead of a new DB column + keyword regex. Flagged for @bokelley.
- Item 4 (contact creation): `lookup_person` already resolves contacts inline; creation half needs a `create_contact` tool wiring `upsertEmailContact` + `upsertRelationship`. Scoped, but separate PR.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01LKoBrZNkG2uie6GPkTFL9i

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKoBrZNkG2uie6GPkTFL9i)_