### PR TITLE
feat(brand-logos): Slack notify pending uploads + SLA hint (closes part of #4748)

### DIFF
--- a/.changeset/4748-pending-logo-slack-notify.md
+++ b/.changeset/4748-pending-logo-slack-notify.md
@@ -1,0 +1,21 @@
+---
+---
+
+feat(brand-logos): Slack notification on pending uploads + SLA hint in response (closes part of #4748)
+
+Follow-up to #4743's walk-back of community logo auto-approval. With uploads now queueing as `pending` instead of going live instantly, moderators need a signal to drain the queue, and uploaders need to know roughly when their change will appear.
+
+**Slack notification.** `notifyPendingBrandLogo()` fires from both the HTTP route (`POST /api/brands/:domain/logos`) and Addie's `upload_brand_logo` MCP tool whenever a logo lands with `review_status='pending'`. Posts to `REGISTRY_EDITS_CHANNEL_ID` (same channel as other registry edit notifications). Includes uploader, tags, format, optional note, and a link to the brand viewer where moderators can review. Owner-attested uploads (auto-approved) do not fire — they're already trust-bound. Fire-and-forget: notification failure is logged but doesn't block the upload response.
+
+**SLA hint.** `201` response for pending uploads now includes:
+- `review_sla_hours: 48`
+- `message: "Logo queued for moderator review (typically within 48h). It will appear on the brand viewer once approved."`
+
+Same hint in Addie's tool response so chat users know what to expect.
+
+**Tests.** Updated `brand-logos-upload-auth.test.ts` and `addie-upload-brand-logo-auth.test.ts` to assert:
+- Pending uploads fire the notification with the expected payload.
+- Owner-attested (auto-approved) uploads do not fire.
+- Refused uploads (verified_owner_required) do not fire.
+
+**Not in this PR** (still on #4748): moderator queue UI (list of pending across all brands), per-user pending-queue depth alerts, per-brand reserved-slot logic for verified-owner uploads. Smallest unblocker first.

--- a/server/src/addie/mcp/brand-tools.ts
+++ b/server/src/addie/mcp/brand-tools.ts
@@ -15,6 +15,7 @@ import { downloadAndCacheLogos, isBrandfetchUrl } from '../../services/logo-cdn.
 import { BrandLogoDatabase } from '../../db/brand-logo-db.js';
 import { safeFetch } from '../../utils/url-security.js';
 import { detectContentType, sanitizeSvg, validateLogoTags, computeSha256, extractDimensions, rebuildManifestLogos } from '../../services/brand-logo-service.js';
+import { notifyPendingBrandLogo } from '../../notifications/registry.js';
 import { query } from '../../db/client.js';
 import { createLogger } from '../../logger.js';
 
@@ -651,13 +652,26 @@ export function createBrandToolHandlers(): Map<string, (args: Record<string, unk
       await rebuildManifestLogos(domain, brandLogoDb, brandDb);
     }
 
+    // Fire-and-forget Slack notification so moderators see the pending upload.
+    notifyPendingBrandLogo({
+      domain,
+      logo_id: logo.id,
+      content_type: contentType,
+      tags,
+      upload_note: note,
+      source: 'addie',
+    }).catch((err) => {
+      logger.warn({ err, domain }, 'Pending-logo Slack notification failed');
+    });
+
     // Exclude upload_note and original_filename from response (prompt injection vector)
     return JSON.stringify({
       success: true,
       domain,
       logo_id: logo.id,
       review_status: 'pending',
-      message: 'Logo queued for moderator review. It will not appear on the brand viewer until approved.',
+      message: 'Logo queued for moderator review (typically within 48h). It will not appear on the brand viewer until approved.',
+      review_sla_hours: 48,
       url: `/logos/brands/${domain}/${logo.id}`,
       content_type: contentType,
       tags,

--- a/server/src/notifications/registry.ts
+++ b/server/src/notifications/registry.ts
@@ -193,6 +193,22 @@ export async function notifyRegistryRollback(rollback: {
 }
 
 /**
+ * Strip Slack mrkdwn meta-characters from user-controlled strings before
+ * interpolating them into a channel message. Without this, an uploader
+ * could plant `<!channel>` / `<!here>` / `<@U…>` mentions to ping the
+ * whole moderator channel, or `<https://evil/|legit-text>` to plant a
+ * phishing link in a moderator-trusted surface. Replaces angle brackets
+ * and ampersand with HTML-escaped equivalents and inserts a zero-width
+ * space inside `!channel|here|everyone` so the broadcast token loses
+ * its meaning while staying human-readable.
+ */
+function sanitizeMrkdwn(s: string): string {
+  return s
+    .replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c]!))
+    .replace(/!(channel|here|everyone)/gi, '!​$1');
+}
+
+/**
  * Notify moderators when a community logo upload queues for review.
  *
  * Fires from both the HTTP route and the Addie MCP tool whenever a logo
@@ -214,9 +230,10 @@ export async function notifyPendingBrandLogo(upload: {
   const channelId = getChannelId();
   if (!channelId || !isSlackConfigured()) return null;
 
-  const uploaderDisplay = upload.source === 'addie'
+  const rawUploader = upload.source === 'addie'
     ? 'Addie (chat)'
     : (upload.uploader_name || upload.uploader_email || 'Unknown');
+  const uploaderDisplay = sanitizeMrkdwn(rawUploader);
   const reviewUrl = `${APP_URL}/brand/view/${upload.domain}`;
   const tagsLine = upload.tags.length ? upload.tags.join(', ') : '(none)';
 
@@ -239,9 +256,9 @@ export async function notifyPendingBrandLogo(upload: {
 
   if (upload.upload_note) {
     // Truncate to keep the Slack block under the 3000-char text limit and
-    // to keep moderator-facing copy scannable — full note is on the brand
-    // viewer page.
-    const note = upload.upload_note.slice(0, 500);
+    // sanitize before interpolating — the note is uploader-controlled and
+    // posted into a moderator-trusted channel.
+    const note = sanitizeMrkdwn(upload.upload_note.slice(0, 500));
     blocks.push({
       type: 'section',
       text: { type: 'mrkdwn', text: `*Note:*\n${note}` },

--- a/server/src/notifications/registry.ts
+++ b/server/src/notifications/registry.ts
@@ -193,6 +193,76 @@ export async function notifyRegistryRollback(rollback: {
 }
 
 /**
+ * Notify moderators when a community logo upload queues for review.
+ *
+ * Fires from both the HTTP route and the Addie MCP tool whenever a logo
+ * lands with `review_status='pending'`. Verified-owner uploads (auto-
+ * approved) do NOT fire this — they're owner-attested and don't need a
+ * second pair of eyes. Returns the message ts so future approval/rejection
+ * notifications can thread off it.
+ */
+export async function notifyPendingBrandLogo(upload: {
+  domain: string;
+  logo_id: string;
+  content_type: string;
+  tags: string[];
+  uploader_email?: string;
+  uploader_name?: string;
+  upload_note?: string;
+  source: 'community' | 'addie';
+}): Promise<string | null> {
+  const channelId = getChannelId();
+  if (!channelId || !isSlackConfigured()) return null;
+
+  const uploaderDisplay = upload.source === 'addie'
+    ? 'Addie (chat)'
+    : (upload.uploader_name || upload.uploader_email || 'Unknown');
+  const reviewUrl = `${APP_URL}/brand/view/${upload.domain}`;
+  const tagsLine = upload.tags.length ? upload.tags.join(', ') : '(none)';
+
+  const fields = [
+    { type: 'mrkdwn', text: `*Uploader:*\n${uploaderDisplay}` },
+    { type: 'mrkdwn', text: `*Tags:*\n${tagsLine}` },
+    { type: 'mrkdwn', text: `*Format:*\n${upload.content_type}` },
+  ] as const;
+
+  const blocks: SlackBlockMessage['blocks'] = [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `🖼️ *Logo pending review:* <${reviewUrl}|${upload.domain}>`,
+      },
+    },
+    { type: 'section', fields: [...fields] },
+  ];
+
+  if (upload.upload_note) {
+    // Truncate to keep the Slack block under the 3000-char text limit and
+    // to keep moderator-facing copy scannable — full note is on the brand
+    // viewer page.
+    const note = upload.upload_note.slice(0, 500);
+    blocks.push({
+      type: 'section',
+      text: { type: 'mrkdwn', text: `*Note:*\n${note}` },
+    });
+  }
+
+  const message: SlackBlockMessage = {
+    text: `🖼️ Logo pending review: ${upload.domain} by ${uploaderDisplay}`,
+    blocks,
+  };
+
+  try {
+    const result = await sendChannelMessage(channelId, message);
+    return result.ts || null;
+  } catch (error) {
+    logger.error({ error, domain: upload.domain, logoId: upload.logo_id }, 'Failed to send pending-logo notification');
+    return null;
+  }
+}
+
+/**
  * Notify when a user is banned from editing.
  */
 export async function notifyRegistryBan(ban: {

--- a/server/src/routes/brand-logos.ts
+++ b/server/src/routes/brand-logos.ts
@@ -21,6 +21,9 @@ import {
 } from '../services/brand-logo-service.js';
 import { createLogger } from '../logger.js';
 import { isUuid } from '../utils/uuid.js';
+import { notifyPendingBrandLogo } from '../notifications/registry.js';
+
+const PENDING_REVIEW_SLA_HOURS = 48;
 
 const logger = createLogger('brand-logo-routes');
 
@@ -209,13 +212,33 @@ export function createBrandLogoRouter(config: BrandLogoRoutesConfig): Router {
           logger.debug({ err, domain, userId: user.id }, 'Logo upload audit revision skipped');
         }
 
+        // Fire-and-forget Slack notification for pending uploads. Owners
+        // who self-approve don't need a moderator nudge.
+        if (reviewStatus === 'pending') {
+          notifyPendingBrandLogo({
+            domain,
+            logo_id: logo.id,
+            content_type: contentType,
+            tags,
+            uploader_email: user.email,
+            uploader_name: (user as { firstName?: string; lastName?: string }).firstName
+              ? `${(user as { firstName?: string }).firstName} ${(user as { lastName?: string }).lastName ?? ''}`.trim()
+              : undefined,
+            upload_note: note,
+            source: 'community',
+          }).catch((err) => {
+            logger.warn({ err, domain }, 'Pending-logo Slack notification failed');
+          });
+        }
+
         return res.status(201).json({
           success: true,
           domain,
           logo_id: logo.id,
           review_status: reviewStatus,
           ...(reviewStatus === 'pending' && {
-            message: 'Logo queued for moderator review. It will appear on the brand viewer once approved.',
+            message: `Logo queued for moderator review (typically within ${PENDING_REVIEW_SLA_HOURS}h). It will appear on the brand viewer once approved.`,
+            review_sla_hours: PENDING_REVIEW_SLA_HOURS,
           }),
           url: `/logos/brands/${domain}/${logo.id}`,
         });

--- a/server/src/routes/brand-logos.ts
+++ b/server/src/routes/brand-logos.ts
@@ -221,8 +221,8 @@ export function createBrandLogoRouter(config: BrandLogoRoutesConfig): Router {
             content_type: contentType,
             tags,
             uploader_email: user.email,
-            uploader_name: (user as { firstName?: string; lastName?: string }).firstName
-              ? `${(user as { firstName?: string }).firstName} ${(user as { lastName?: string }).lastName ?? ''}`.trim()
+            uploader_name: user.firstName
+              ? `${user.firstName} ${user.lastName ?? ''}`.trim()
               : undefined,
             upload_note: note,
             source: 'community',

--- a/server/tests/unit/addie-upload-brand-logo-auth.test.ts
+++ b/server/tests/unit/addie-upload-brand-logo-auth.test.ts
@@ -28,6 +28,11 @@ const mocks = vi.hoisted(() => ({
   extractDimensions: vi.fn().mockResolvedValue({ width: 64, height: 64 }),
   rebuildManifestLogos: vi.fn().mockResolvedValue(undefined),
   validateLogoTags: vi.fn().mockReturnValue({ valid: true }),
+  notifyPendingBrandLogo: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../../src/notifications/registry.js', () => ({
+  notifyPendingBrandLogo: (...args: unknown[]) => mocks.notifyPendingBrandLogo(...args),
 }));
 
 vi.mock('../../src/db/brand-db.js', () => ({
@@ -110,6 +115,7 @@ describe('Addie upload_brand_logo write-authority gate', () => {
     mocks.countBrandLogos.mockResolvedValue(0);
     mocks.detectContentType.mockResolvedValue('image/png');
     mocks.validateLogoTags.mockReturnValue({ valid: true });
+    mocks.notifyPendingBrandLogo.mockResolvedValue(null);
     mocks.insertBrandLogo.mockImplementation(async (input) => ({
       id: 'logo_addie_test',
       ...input,
@@ -143,6 +149,7 @@ describe('Addie upload_brand_logo write-authority gate', () => {
     const parsed = JSON.parse(result);
     expect(parsed.success).toBe(true);
     expect(parsed.review_status).toBe('pending');
+    expect(parsed.review_sla_hours).toBe(48);
     expect(mocks.insertBrandLogo).toHaveBeenCalledWith(
       expect.objectContaining({
         source: 'community',
@@ -150,6 +157,29 @@ describe('Addie upload_brand_logo write-authority gate', () => {
         uploaded_by_user_id: 'system:addie',
       }),
     );
+    // Settle microtasks — notification is fire-and-forget.
+    await new Promise((r) => setImmediate(r));
+    expect(mocks.notifyPendingBrandLogo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        domain: 'unowned.example',
+        logo_id: 'logo_addie_test',
+        source: 'addie',
+        tags: ['primary'],
+      }),
+    );
+  });
+
+  it('does NOT fire a Slack notification when the upload is refused (verified owner exists)', async () => {
+    mocks.getHostedBrandByDomain.mockResolvedValue({
+      workos_organization_id: 'org_owner',
+      domain_verified: true,
+    });
+    await upload({
+      domain: 'fandom.com',
+      logo_url: 'https://example.com/logo.png',
+      tags: ['primary'],
+    });
+    expect(mocks.notifyPendingBrandLogo).not.toHaveBeenCalled();
   });
 
   it('queues uploads as pending when the brand exists but is not domain-verified', async () => {

--- a/server/tests/unit/brand-logos-upload-auth.test.ts
+++ b/server/tests/unit/brand-logos-upload-auth.test.ts
@@ -24,6 +24,11 @@ const mocks = vi.hoisted(() => ({
   countLogos: vi.fn().mockResolvedValue(0),
   listLogos: vi.fn().mockResolvedValue([]),
   rebuildManifestLogos: vi.fn().mockResolvedValue(undefined),
+  notifyPendingBrandLogo: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../../src/notifications/registry.js', () => ({
+  notifyPendingBrandLogo: (...args: unknown[]) => mocks.notifyPendingBrandLogo(...args),
 }));
 
 vi.mock('../../src/services/brand-logo-auth.js', () => ({
@@ -107,6 +112,8 @@ function makeApp(opts: {
 describe('POST /api/brands/:domain/logos write authority', () => {
   beforeEach(() => {
     mocks.insertLogo.mockReset();
+    mocks.notifyPendingBrandLogo.mockReset();
+    mocks.notifyPendingBrandLogo.mockResolvedValue(null);
     mocks.insertLogo.mockImplementation(async (input) => ({
       id: 'logo_test_id',
       ...input,
@@ -143,6 +150,8 @@ describe('POST /api/brands/:domain/logos write authority', () => {
     expect(mocks.insertLogo).toHaveBeenCalledWith(
       expect.objectContaining({ source: 'brand_owner', review_status: 'approved' }),
     );
+    // Owner-attested uploads don't need a moderator nudge.
+    expect(mocks.notifyPendingBrandLogo).not.toHaveBeenCalled();
   });
 
   it('queues community uploads as pending when no verified owner exists', async () => {
@@ -154,8 +163,20 @@ describe('POST /api/brands/:domain/logos write authority', () => {
     expect(res.status).toBe(201);
     expect(res.body.review_status).toBe('pending');
     expect(res.body.message).toMatch(/queued for moderator review/i);
+    expect(res.body.review_sla_hours).toBe(48);
     expect(mocks.insertLogo).toHaveBeenCalledWith(
       expect.objectContaining({ source: 'community', review_status: 'pending' }),
+    );
+    // Settle any microtasks (notification is fire-and-forget).
+    await new Promise((r) => setImmediate(r));
+    expect(mocks.notifyPendingBrandLogo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        domain: 'example.com',
+        logo_id: 'logo_test_id',
+        source: 'community',
+        uploader_email: 'test@example.com',
+        tags: ['primary'],
+      }),
     );
   });
 

--- a/server/tests/unit/notify-pending-brand-logo-sanitize.test.ts
+++ b/server/tests/unit/notify-pending-brand-logo-sanitize.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Pin: notifyPendingBrandLogo neutralizes Slack mrkdwn meta-characters in
+ * user-controlled fields (upload note, uploader name) before posting to a
+ * moderator-trusted channel. Without this, an uploader could plant
+ * `<!channel>` / `<!here>` / `<@U…>` mentions to ping moderators, or
+ * `<https://evil/|legit-text>` links to phish them.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// hoisted runs before module imports, so REGISTRY_EDITS_CHANNEL_ID is set
+// before `registry.js` captures it at module load.
+vi.hoisted(() => {
+  process.env.REGISTRY_EDITS_CHANNEL_ID = 'C_TEST_LOGO_REVIEW';
+});
+
+const mocks = vi.hoisted(() => ({
+  sendChannelMessage: vi.fn(),
+  isSlackConfigured: vi.fn(() => true),
+}));
+
+vi.mock('../../src/slack/client.js', () => ({
+  sendChannelMessage: (...args: unknown[]) => mocks.sendChannelMessage(...args),
+  isSlackConfigured: () => mocks.isSlackConfigured(),
+}));
+
+import { notifyPendingBrandLogo } from '../../src/notifications/registry.js';
+
+function lastSentBlocks() {
+  const call = mocks.sendChannelMessage.mock.calls.at(-1);
+  expect(call).toBeDefined();
+  const [, message] = call!;
+  return (message as { blocks: { text?: { text?: string }; fields?: { text: string }[] }[] }).blocks;
+}
+
+function lastSentJSON(): string {
+  const blocks = lastSentBlocks();
+  return JSON.stringify(blocks);
+}
+
+describe('notifyPendingBrandLogo mrkdwn sanitization', () => {
+  beforeEach(() => {
+    mocks.sendChannelMessage.mockReset();
+    mocks.sendChannelMessage.mockResolvedValue({ ts: '1779110411.874' });
+    mocks.isSlackConfigured.mockReturnValue(true);
+  });
+
+  it('neutralizes <!channel> / <!here> / <!everyone> mention tokens in upload note', async () => {
+    await notifyPendingBrandLogo({
+      domain: 'example.com',
+      logo_id: 'logo_1',
+      content_type: 'image/png',
+      tags: ['primary'],
+      uploader_email: 'alice@example.com',
+      upload_note: 'Ping <!channel> and <!here> and <!everyone> please',
+      source: 'community',
+    });
+    const json = lastSentJSON();
+    // Angle brackets are escaped, broadcasts are zero-width-spaced.
+    expect(json).not.toContain('<!channel>');
+    expect(json).not.toContain('<!here>');
+    expect(json).not.toContain('<!everyone>');
+    expect(json).toContain('&lt;!​channel&gt;');
+    expect(json).toContain('&lt;!​here&gt;');
+  });
+
+  it('neutralizes <@U…> user-mentions in upload note', async () => {
+    await notifyPendingBrandLogo({
+      domain: 'example.com',
+      logo_id: 'logo_2',
+      content_type: 'image/png',
+      tags: ['primary'],
+      upload_note: 'cc <@U12345> for review',
+      source: 'community',
+    });
+    const json = lastSentJSON();
+    expect(json).not.toContain('<@U12345>');
+    expect(json).toContain('&lt;@U12345&gt;');
+  });
+
+  it('neutralizes <url|text> link syntax in upload note', async () => {
+    await notifyPendingBrandLogo({
+      domain: 'example.com',
+      logo_id: 'logo_3',
+      content_type: 'image/png',
+      tags: ['primary'],
+      upload_note: 'See <https://evil.example/phish|the brand site>',
+      source: 'community',
+    });
+    const json = lastSentJSON();
+    expect(json).not.toContain('<https://evil.example/phish|');
+    expect(json).toContain('&lt;https://evil.example/phish|');
+  });
+
+  it('neutralizes mention tokens in uploader_name', async () => {
+    await notifyPendingBrandLogo({
+      domain: 'example.com',
+      logo_id: 'logo_4',
+      content_type: 'image/png',
+      tags: ['primary'],
+      uploader_name: 'Mallory <!channel>',
+      source: 'community',
+    });
+    const json = lastSentJSON();
+    expect(json).not.toContain('<!channel>');
+  });
+
+  it('leaves benign notes untouched', async () => {
+    await notifyPendingBrandLogo({
+      domain: 'example.com',
+      logo_id: 'logo_5',
+      content_type: 'image/png',
+      tags: ['primary'],
+      uploader_email: 'alice@example.com',
+      upload_note: 'New press kit logo, vector master',
+      source: 'community',
+    });
+    const json = lastSentJSON();
+    expect(json).toContain('New press kit logo, vector master');
+  });
+});


### PR DESCRIPTION
First wedge from #4748. PR #4743 walked back instant auto-approval for community logo uploads — they now queue as \`pending\`. Without a moderator signal and an uploader-visible SLA, the walk-back regresses UX (\"my change disappeared\"). This patches both.

## Changes

**Slack notification** (\`server/src/notifications/registry.ts\`)
- New \`notifyPendingBrandLogo()\` posts to \`REGISTRY_EDITS_CHANNEL_ID\` (same channel as existing registry-edit notifications) when a logo lands with \`review_status='pending'\`. Includes uploader, tags, format, optional note, link to the brand viewer.
- Fire-and-forget at both call sites; notification failure is logged but doesn't block the upload response.
- Verified-owner (auto-approved) uploads do not fire — they're trust-bound. Refused uploads (\`verified_owner_required\`) do not fire.

**Wired up at two call sites:**
- \`server/src/routes/brand-logos.ts\` — HTTP route, attributed to the authenticated user.
- \`server/src/addie/mcp/brand-tools.ts\` — Addie's \`upload_brand_logo\` tool, attributed as \`source: 'addie'\`.

**SLA hint** in the upload response (HTTP + Addie):
- \`review_sla_hours: 48\`
- \`message: \"Logo queued for moderator review (typically within 48h). It will appear on the brand viewer once approved.\"\`

## Tests

8 unit tests across \`brand-logos-upload-auth.test.ts\` (HTTP) and \`addie-upload-brand-logo-auth.test.ts\` (Addie). Pin:
- Pending upload fires \`notifyPendingBrandLogo\` with the right payload.
- Approved (verified-owner) upload does not fire.
- Refused (verified_owner_required) upload does not fire.
- Response includes SLA hint on pending, not on approved.

TypeScript clean. Pre-commit hooks pass.

## Not in this PR (still on #4748)

- Moderator queue UI / pending-logo list page.
- Per-user pending-queue-depth alerts (abuse signal).
- Per-brand reserved-slot logic so a verified owner can always upload their N logos even if community uploaders saturated the cap with pending entries.

Smallest unblocker first — Slack notification gets moderators a signal today.

## Test plan
- [ ] CI tests pass.
- [ ] After deploy, upload a logo to an unverified brand from a non-owner account; confirm Slack notification fires in \`REGISTRY_EDITS_CHANNEL_ID\` with link to brand viewer.
- [ ] Confirm response includes \`review_sla_hours: 48\` and the friendly \`message\`.
- [ ] Upload from a verified owner; confirm no notification fires and \`review_status\` is \`approved\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)