### PR TITLE
feat(training-agent): metric-mode forcing function for clicks/reach/completed_views scenarios

### DIFF
--- a/.changeset/training-agent-metric-mode-forcing.md
+++ b/.changeset/training-agent-metric-mode-forcing.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": patch
+---
+
+feat(training-agent): metric-mode forcing function for clicks / reach / completed_views storyboard scenarios
+
+The training agent now declares seller-level `media_buy.supported_optimization_metrics` (the honest union across catalog products), validates `reach_unit` against the product's `metric_optimization.supported_reach_units` and `view_duration_seconds` against `metric_optimization.supported_view_durations` on `create_media_buy` (INVALID_REQUEST with literal JSONPath-lite `error.field`), and emits `cost_per_click` plus goal-gated `reach + frequency` / `completed_views + completion_rate` on `get_media_buy_delivery`. Flips three capability-gated storyboards (`clicks_buy_flow`, `reach_buy_flow`, `completed_views_buy_flow`) from `not_applicable` to applicable on the training agent. Same forcing-function shape as #4654 (event_source_id) and #4664 (audience_buy_flow / event_dedup_flow). Manual rollup declaration — adcp-client#1818's auto-derive remains blocked on the SDK exposing the seller-level field.

--- a/server/src/training-agent/product-factory.ts
+++ b/server/src/training-agent/product-factory.ts
@@ -412,8 +412,21 @@ function buildProduct(
       metrics.push('engagements', 'reach');
     }
     if (metrics.length > 0) {
+      // Sibling unit declarations to supported_metrics: completed_views
+      // requires durations and reach requires units. Industry-default values
+      // (TikTok/Meta/Snap durations; CTV/social reach units) so buyers can
+      // bind reach_unit / view_duration_seconds without re-discovery.
+      // create_media_buy's metric-kind validation reads these to reject
+      // unsupported values (reach_buy_flow / completed_views_buy_flow).
+      type MetricOpt = NonNullable<Product['metric_optimization']>;
+      const supportedViewDurations: MetricOpt['supported_view_durations'] = metrics.includes('completed_views') ? [2, 6, 15, 30] : undefined;
+      const supportedReachUnits: MetricOpt['supported_reach_units'] = metrics.includes('reach')
+        ? ['individuals', 'households', 'devices', 'accounts']
+        : undefined;
       metricOptimization = {
         supported_metrics: metrics,
+        ...(supportedReachUnits && { supported_reach_units: supportedReachUnits }),
+        ...(supportedViewDurations && { supported_view_durations: supportedViewDurations }),
         supported_targets: ['cost_per'],
       };
     }

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -1902,6 +1902,64 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
   const productMap = new Map(catalog.map(cp => [cp.product.product_id, cp.product]));
   overlaySeededProducts(session, productMap);
 
+  // Validate metric-kind optimization_goals against the package's product
+  // metric_optimization declarations. reach goals must declare a reach_unit
+  // present in supported_reach_units; completed_views goals must declare a
+  // view_duration_seconds present in supported_view_durations. Silent
+  // acceptance is a façade (the seller would either coerce the unit or run
+  // without one) — the reach_buy_flow / completed_views_buy_flow storyboards
+  // assert this rejection with error.field set to the offending JSONPath-lite
+  // path. Mirrors the event_source / audience_id checks above.
+  if (Array.isArray(req.packages)) {
+    for (let i = 0; i < req.packages.length; i++) {
+      const pkg = req.packages[i] as { product_id?: string; optimization_goals?: unknown };
+      const goals = pkg?.optimization_goals;
+      if (!Array.isArray(goals)) continue;
+      const product = pkg.product_id ? productMap.get(pkg.product_id) : undefined;
+      for (let j = 0; j < goals.length; j++) {
+        const goal = goals[j] as {
+          kind?: string;
+          metric?: string;
+          reach_unit?: string;
+          view_duration_seconds?: number;
+        };
+        if (goal?.kind !== 'metric') continue;
+        if (goal.metric === 'reach' && typeof goal.reach_unit === 'string' && goal.reach_unit.length > 0) {
+          const supported = product?.metric_optimization?.supported_reach_units;
+          // Reach is honest-bounded by reach-unit.json enum; reject when the
+          // product declares a narrower set OR when no declaration exists and
+          // the value isn't a spec-defined reach unit.
+          const allowed: readonly string[] = supported ?? ['individuals', 'households', 'devices', 'accounts', 'cookies', 'custom'];
+          if (!allowed.includes(goal.reach_unit)) {
+            return {
+              errors: [{
+                code: 'INVALID_REQUEST',
+                message: `reach_unit "${goal.reach_unit}" not in product's supported_reach_units`,
+                field: `packages[${i}].optimization_goals[${j}].reach_unit`,
+              }] as TaskError[],
+            };
+          }
+        }
+        if (goal.metric === 'completed_views' && typeof goal.view_duration_seconds === 'number') {
+          const supported = product?.metric_optimization?.supported_view_durations;
+          // No spec-bound enum on view_duration; fall back to industry-default
+          // durations when the product omits the declaration (matches the
+          // product-factory default 2/6/15/30).
+          const allowed: readonly number[] = supported ?? [2, 6, 15, 30];
+          if (!allowed.includes(goal.view_duration_seconds)) {
+            return {
+              errors: [{
+                code: 'INVALID_REQUEST',
+                message: `view_duration_seconds ${goal.view_duration_seconds} not in product's supported_view_durations`,
+                field: `packages[${i}].optimization_goals[${j}].view_duration_seconds`,
+              }] as TaskError[],
+            };
+          }
+        }
+      }
+    }
+  }
+
   // Proposal-based creation: expand proposal allocations into packages
   if (req.proposal_id && !req.packages?.length) {
     // Check session proposals first (may have finalized versions), then global catalog
@@ -2132,6 +2190,11 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
 
     const resolvedStart = startTime === 'asap' ? new Date().toISOString() : startTime;
 
+    const rawGoals = (pkg as unknown as { optimization_goals?: unknown }).optimization_goals;
+    const optimizationGoals = Array.isArray(rawGoals)
+      ? (rawGoals as unknown[]).filter((g): g is Record<string, unknown> => typeof g === 'object' && g !== null)
+      : undefined;
+
     createdPackages.push({
       packageId: `pkg-${i}`,
       productId: pkg.product_id,
@@ -2145,6 +2208,7 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
       formatIds: pkg.format_ids,
       creativeAssignments: [],
       targeting: targetingResult.targeting,
+      ...(optimizationGoals && optimizationGoals.length > 0 && { optimizationGoals }),
     });
   }
 
@@ -2504,6 +2568,67 @@ export async function handleGetMediaBuyDelivery(args: ToolArgs, ctx: TrainingCon
       ? { conversions: totalConversions }
       : {};
 
+  // Click-attributed total. cost_per_click is defined as spend / clicks in
+  // delivery-metrics.json. Always surface when both are positive — this
+  // doesn't need a goal-kind gate because every buy emits clicks (the
+  // default totals.clicks already does) and the derived metric is the
+  // discriminating field for click-optimized buys (clicks_buy_flow).
+  const clickTotals = totalClicks > 0 && roundedSpend > 0
+    ? { cost_per_click: Math.round((roundedSpend / totalClicks) * 100) / 100 }
+    : {};
+
+  // Metric-goal-gated emission. Reach + frequency are surfaced when at
+  // least one package was created with a reach goal; completed_views +
+  // completion_rate when at least one package was created with a
+  // completed_views goal. Without the gate the seller would blanket-emit
+  // these fields on every buy (a brand-only seller would emit completion
+  // metrics on a click-only buy — confuses buyers and runs against the
+  // discriminating-field contract in the storyboards).
+  //
+  // Placeholder ratios: reach = floor(impressions / 3) with frequency = 3
+  // (industry-typical for mixed-channel campaigns); completed_views =
+  // floor(impressions * 0.7) (70% completion rate is a common video
+  // platform default). Documented as placeholders because the
+  // get_media_buy_delivery contract requires field_present, not specific
+  // numeric values, on the gating scenarios.
+  const hasReachGoal = mb.packages.some(pkg =>
+    pkg.optimizationGoals?.some(g => g?.kind === 'metric' && g?.metric === 'reach'),
+  );
+  const hasCompletedViewsGoal = mb.packages.some(pkg =>
+    pkg.optimizationGoals?.some(g => g?.kind === 'metric' && g?.metric === 'completed_views'),
+  );
+  // Resolve reach_unit from the first reach goal that declared one — buyers
+  // bind reach measurement to the unit (households vs cookies are not
+  // comparable). When goals omitted the unit, fall back to the existing
+  // channel-derived unit (totalReachUnit) computed above.
+  let derivedReachUnit: string | undefined = totalReachUnit !== 'mixed' ? totalReachUnit : undefined;
+  if (!derivedReachUnit && hasReachGoal) {
+    for (const pkg of mb.packages) {
+      const goal = pkg.optimizationGoals?.find(g => g?.kind === 'metric' && g?.metric === 'reach' && typeof g?.reach_unit === 'string');
+      if (goal && typeof goal.reach_unit === 'string') {
+        derivedReachUnit = goal.reach_unit;
+        break;
+      }
+    }
+  }
+
+  const goalDerivedReach = hasReachGoal && totalImpressions > 0 && totalReach === 0
+    ? {
+      reach: Math.max(1, Math.floor(totalImpressions / 3)),
+      ...(derivedReachUnit && { reach_unit: derivedReachUnit }),
+      frequency: +(totalImpressions / Math.max(1, Math.floor(totalImpressions / 3))).toFixed(1),
+    }
+    : {};
+  const goalDerivedCompletedViews = hasCompletedViewsGoal && totalImpressions > 0 && totalCompletedViews === 0
+    ? (() => {
+      const completed = Math.floor(totalImpressions * 0.7);
+      return {
+        completed_views: completed,
+        completion_rate: +(completed / totalImpressions).toFixed(3),
+      };
+    })()
+    : {};
+
   return {
     reporting_period: {
       start: mb.startTime,
@@ -2517,16 +2642,19 @@ export async function handleGetMediaBuyDelivery(args: ToolArgs, ctx: TrainingCon
         impressions: totalImpressions,
         spend: roundedSpend,
         clicks: totalClicks,
+        ...clickTotals,
         ...(totalCompletedViews > 0 ? {
           views: totalViews,
           completed_views: totalCompletedViews,
           completion_rate: +(totalCompletedViews / totalImpressions).toFixed(3),
         } : {}),
+        ...goalDerivedCompletedViews,
         ...(totalReach > 0 && totalReachUnit && totalReachUnit !== 'mixed' ? {
           reach: totalReach,
           reach_unit: totalReachUnit,
           frequency: +(totalImpressions / totalReach).toFixed(1),
         } : {}),
+        ...goalDerivedReach,
         ...conversionTotals,
       },
       by_package: byPackage,
@@ -3123,6 +3251,15 @@ export async function handleGetAdcpCapabilities(_args: ToolArgs, ctx: TrainingCo
         supported_hashed_identifiers: ['hashed_email'],
         supported_action_sources: ['website', 'app'],
       },
+      // Seller-level rollup of metric-optimization capabilities. Honest
+      // union across catalog products (product-factory.ts assigns these
+      // by channel mix). Gate scenarios — clicks_buy_flow / reach_buy_flow
+      // / completed_views_buy_flow — read this field and grade
+      // not_applicable when missing. adcp-client#1818 will auto-derive
+      // from product-level metric_optimization.supported_metrics once
+      // the SDK ships the seller-level field; until then this is a
+      // manual declaration.
+      supported_optimization_metrics: ['clicks', 'views', 'completed_views', 'engagements', 'reach'],
       execution: {
         targeting: {
           geo_countries: true,

--- a/server/src/training-agent/types.ts
+++ b/server/src/training-agent/types.ts
@@ -363,6 +363,11 @@ export interface PackageState {
   formatIds?: FormatID[];
   creativeAssignments: string[];
   targeting?: PackageTargeting;
+  /** Buyer-declared optimization goals carried through from create_media_buy.
+   *  Persisted opaquely so delivery handlers can gate metric emission on
+   *  what the buyer actually requested (e.g., only surface reach + frequency
+   *  when a reach goal was requested). */
+  optimizationGoals?: Array<Record<string, unknown>>;
 }
 
 export interface ListReference {

--- a/server/src/training-agent/v6-sales-platform.ts
+++ b/server/src/training-agent/v6-sales-platform.ts
@@ -173,6 +173,14 @@ export class TrainingSalesPlatform
       supported_hashed_identifiers: ['hashed_email' as const],
       supported_action_sources: ['website' as const, 'app' as const],
     },
+    // Seller-level rollup of metric-optimization capabilities. Honest
+    // union across catalog products (product-factory.ts assigns these
+    // by channel mix). Mirrors the same declaration on the legacy /mcp
+    // route (task-handlers.ts handleGetAdcpCapabilities). adcp-client#1818
+    // will auto-derive this from product-level supported_metrics once
+    // the SDK ships the seller-level field; until then both surfaces
+    // declare it manually for parity.
+    supported_optimization_metrics: ['clicks' as const, 'views' as const, 'completed_views' as const, 'engagements' as const, 'reach' as const],
     supportedBillings: ['agent', 'operator'] as const,
     // Auto-derives `compliance_testing.scenarios[]` from the adapters
     // wired in `serverOptions.complyTest`. Empty block opts in; the

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -1870,6 +1870,135 @@ describe('create_media_buy handler', () => {
     expect(result.errors).toBeUndefined();
     expect(typeof result.media_buy_id).toBe('string');
   });
+
+  // ── metric-kind optimization_goal validation (reach / completed_views) ───
+  // Look up a catalog product that declares the metric in metric_optimization.
+  // Tests bind to the discovered IDs rather than hard-coded fixtures so
+  // they stay aligned with product-factory if channel→metric mapping shifts.
+  function findProductWithMetric(metric: 'reach' | 'completed_views'): { productId: string; pricingOptionId: string } {
+    const catalog = buildCatalog();
+    for (const cp of catalog) {
+      const supported = (cp.product as { metric_optimization?: { supported_metrics?: string[] } }).metric_optimization?.supported_metrics;
+      if (supported?.includes(metric)) {
+        const pricingOptions = cp.product.pricing_options as Array<Record<string, unknown>>;
+        return {
+          productId: cp.product.product_id as string,
+          pricingOptionId: pricingOptions[0].pricing_option_id as string,
+        };
+      }
+    }
+    throw new Error(`No catalog product supports ${metric}`);
+  }
+
+  it('rejects reach optimization_goal with reach_unit not in product supported_reach_units', async () => {
+    const { productId, pricingOptionId } = findProductWithMetric('reach');
+    const account = { brand: { domain: 'phantom-reach.example' }, operator: 'phantom-reach.example' };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    const { result } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'phantom-reach.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 10000,
+        optimization_goals: [{
+          kind: 'metric',
+          metric: 'reach',
+          reach_unit: 'phantom_unit',
+        }],
+      }],
+    });
+
+    expect(result.code).toBe('INVALID_REQUEST');
+    expect(result.field).toBe('packages[0].optimization_goals[0].reach_unit');
+    expect((result.message as string).includes('phantom_unit')).toBe(true);
+  });
+
+  it('accepts reach optimization_goal with reach_unit declared in supported_reach_units', async () => {
+    const { productId, pricingOptionId } = findProductWithMetric('reach');
+    const account = { brand: { domain: 'bound-reach.example' }, operator: 'bound-reach.example' };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    const { result } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'bound-reach.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 10000,
+        bid_price: 5.0,
+        optimization_goals: [{
+          kind: 'metric',
+          metric: 'reach',
+          reach_unit: 'households',
+        }],
+      }],
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(typeof result.media_buy_id).toBe('string');
+  });
+
+  it('rejects completed_views optimization_goal with view_duration_seconds not in supported_view_durations', async () => {
+    const { productId, pricingOptionId } = findProductWithMetric('completed_views');
+    const account = { brand: { domain: 'phantom-cpcv.example' }, operator: 'phantom-cpcv.example' };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    const { result } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'phantom-cpcv.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 5000,
+        optimization_goals: [{
+          kind: 'metric',
+          metric: 'completed_views',
+          view_duration_seconds: 999,
+          target: { kind: 'cost_per', value: 0.05 },
+        }],
+      }],
+    });
+
+    expect(result.code).toBe('INVALID_REQUEST');
+    expect(result.field).toBe('packages[0].optimization_goals[0].view_duration_seconds');
+    expect((result.message as string).includes('999')).toBe(true);
+  });
+
+  it('accepts completed_views optimization_goal with view_duration_seconds declared in supported_view_durations', async () => {
+    const { productId, pricingOptionId } = findProductWithMetric('completed_views');
+    const account = { brand: { domain: 'bound-cpcv.example' }, operator: 'bound-cpcv.example' };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    const { result } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'bound-cpcv.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 5000,
+        bid_price: 5.0,
+        optimization_goals: [{
+          kind: 'metric',
+          metric: 'completed_views',
+          view_duration_seconds: 6,
+          target: { kind: 'cost_per', value: 0.05 },
+        }],
+      }],
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(typeof result.media_buy_id).toBe('string');
+  });
 });
 
 // ── sync_creatives handler ─────────────────────────────────────────
@@ -3870,6 +3999,102 @@ describe('get_media_buy_delivery handler', () => {
     // ratio rather than a fixed number.
     expect(totals.cost_per_acquisition).toBeGreaterThan(0);
     expect(totals.cost_per_acquisition).toBeCloseTo(totals.spend / totals.conversions, 2);
+  });
+
+  it('emits cost_per_click when clicks and spend are positive', async () => {
+    const catalog = buildCatalog();
+    const product = catalog[0].product;
+    const pricingOptions = product.pricing_options as Array<Record<string, unknown>>;
+    const account = { brand: { domain: 'cpc-delivery.example' }, operator: 'cpc-delivery.example', sandbox: true };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    const { result: createResult } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'cpc-delivery.example' },
+      start_time: '2025-01-01T00:00:00Z',
+      end_time: '2025-12-31T00:00:00Z',
+      packages: [{
+        product_id: product.product_id,
+        pricing_option_id: pricingOptions[0].pricing_option_id,
+        budget: 15000,
+      }],
+    });
+    const mediaBuyId = createResult.media_buy_id as string;
+
+    // Inject clicks + spend via simulate_delivery
+    await simulateCallTool(server, 'comply_test_controller', {
+      scenario: 'simulate_delivery',
+      params: {
+        media_buy_id: mediaBuyId,
+        impressions: 300000,
+        clicks: 4800,
+        reported_spend: { amount: 11000, currency: 'USD' },
+      },
+      account,
+      brand: { domain: 'cpc-delivery.example' },
+    });
+
+    const { result } = await simulateCallTool(server, 'get_media_buy_delivery', {
+      account,
+      media_buy_id: mediaBuyId,
+    });
+    const totals = (result.media_buy_deliveries as Array<Record<string, unknown>>)[0].totals as Record<string, number>;
+    expect(totals.clicks).toBeGreaterThan(0);
+    expect(totals.cost_per_click).toBeGreaterThan(0);
+    expect(totals.cost_per_click).toBeCloseTo(totals.spend / totals.clicks, 2);
+  });
+
+  it('emits reach + frequency for a buy created with a reach optimization goal', async () => {
+    const catalog = buildCatalog();
+    const reachProduct = catalog.find(cp =>
+      (cp.product as { metric_optimization?: { supported_metrics?: string[] } }).metric_optimization?.supported_metrics?.includes('reach'),
+    );
+    if (!reachProduct) throw new Error('No catalog product supports reach');
+    const product = reachProduct.product;
+    const pricingOptions = product.pricing_options as Array<Record<string, unknown>>;
+    const account = { brand: { domain: 'reach-delivery.example' }, operator: 'reach-delivery.example', sandbox: true };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    const { result: createResult } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'reach-delivery.example' },
+      start_time: '2025-01-01T00:00:00Z',
+      end_time: '2025-12-31T00:00:00Z',
+      packages: [{
+        product_id: product.product_id,
+        pricing_option_id: pricingOptions[0].pricing_option_id,
+        budget: 50000,
+        bid_price: 5.0,
+        optimization_goals: [{
+          kind: 'metric',
+          metric: 'reach',
+          reach_unit: 'households',
+        }],
+      }],
+    });
+    const mediaBuyId = createResult.media_buy_id as string;
+
+    // Inject impressions so the reach derivation has something to scale from.
+    await simulateCallTool(server, 'comply_test_controller', {
+      scenario: 'simulate_delivery',
+      params: {
+        media_buy_id: mediaBuyId,
+        impressions: 750000,
+        reported_spend: { amount: 14000, currency: 'USD' },
+      },
+      account,
+      brand: { domain: 'reach-delivery.example' },
+    });
+
+    const { result } = await simulateCallTool(server, 'get_media_buy_delivery', {
+      account,
+      media_buy_id: mediaBuyId,
+    });
+    const totals = (result.media_buy_deliveries as Array<Record<string, unknown>>)[0].totals as Record<string, unknown>;
+    expect(totals.reach).toBeDefined();
+    expect(totals.frequency).toBeDefined();
+    expect(typeof totals.reach).toBe('number');
+    expect((totals.reach as number) > 0).toBe(true);
   });
 
   it('omits cost_per_acquisition when no conversions were injected', async () => {

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -4044,6 +4044,48 @@ describe('get_media_buy_delivery handler', () => {
     expect(totals.cost_per_click).toBeCloseTo(totals.spend / totals.clicks, 2);
   });
 
+  it('omits cost_per_click when clicks are zero', async () => {
+    const catalog = buildCatalog();
+    const product = catalog[0].product;
+    const pricingOptions = product.pricing_options as Array<Record<string, unknown>>;
+    const account = { brand: { domain: 'no-clicks.example' }, operator: 'no-clicks.example', sandbox: true };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    const { result: createResult } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'no-clicks.example' },
+      start_time: '2025-01-01T00:00:00Z',
+      end_time: '2025-12-31T00:00:00Z',
+      packages: [{
+        product_id: product.product_id,
+        pricing_option_id: pricingOptions[0].pricing_option_id,
+        budget: 15000,
+      }],
+    });
+    const mediaBuyId = createResult.media_buy_id as string;
+
+    // Inject impressions + spend but explicitly clicks: 0
+    await simulateCallTool(server, 'comply_test_controller', {
+      scenario: 'simulate_delivery',
+      params: {
+        media_buy_id: mediaBuyId,
+        impressions: 300000,
+        clicks: 0,
+        reported_spend: { amount: 11000, currency: 'USD' },
+      },
+      account,
+      brand: { domain: 'no-clicks.example' },
+    });
+
+    const { result } = await simulateCallTool(server, 'get_media_buy_delivery', {
+      account,
+      media_buy_id: mediaBuyId,
+    });
+    const totals = (result.media_buy_deliveries as Array<Record<string, unknown>>)[0].totals as Record<string, unknown>;
+    expect(totals.clicks).toBe(0);
+    expect(totals.cost_per_click).toBeUndefined();
+  });
+
   it('emits reach + frequency for a buy created with a reach optimization goal', async () => {
     const catalog = buildCatalog();
     const reachProduct = catalog.find(cp =>
@@ -4095,6 +4137,60 @@ describe('get_media_buy_delivery handler', () => {
     expect(totals.frequency).toBeDefined();
     expect(typeof totals.reach).toBe('number');
     expect((totals.reach as number) > 0).toBe(true);
+  });
+
+  it('emits completed_views + completion_rate for a buy created with a completed_views optimization goal', async () => {
+    const catalog = buildCatalog();
+    const cvProduct = catalog.find(cp =>
+      (cp.product as { metric_optimization?: { supported_metrics?: string[] } }).metric_optimization?.supported_metrics?.includes('completed_views'),
+    );
+    if (!cvProduct) throw new Error('No catalog product supports completed_views');
+    const product = cvProduct.product;
+    const pricingOptions = product.pricing_options as Array<Record<string, unknown>>;
+    const account = { brand: { domain: 'cv-delivery.example' }, operator: 'cv-delivery.example', sandbox: true };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    const { result: createResult } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'cv-delivery.example' },
+      start_time: '2025-01-01T00:00:00Z',
+      end_time: '2025-12-31T00:00:00Z',
+      packages: [{
+        product_id: product.product_id,
+        pricing_option_id: pricingOptions[0].pricing_option_id,
+        budget: 50000,
+        bid_price: 5.0,
+        optimization_goals: [{
+          kind: 'metric',
+          metric: 'completed_views',
+          view_duration_seconds: 6,
+          target: { kind: 'cost_per', value: 0.05 },
+        }],
+      }],
+    });
+    const mediaBuyId = createResult.media_buy_id as string;
+
+    // Inject impressions so the completed_views derivation has something to scale from.
+    await simulateCallTool(server, 'comply_test_controller', {
+      scenario: 'simulate_delivery',
+      params: {
+        media_buy_id: mediaBuyId,
+        impressions: 750000,
+        reported_spend: { amount: 14000, currency: 'USD' },
+      },
+      account,
+      brand: { domain: 'cv-delivery.example' },
+    });
+
+    const { result } = await simulateCallTool(server, 'get_media_buy_delivery', {
+      account,
+      media_buy_id: mediaBuyId,
+    });
+    const totals = (result.media_buy_deliveries as Array<Record<string, unknown>>)[0].totals as Record<string, unknown>;
+    expect(totals.completed_views).toBeDefined();
+    expect(totals.completion_rate).toBeDefined();
+    expect(typeof totals.completed_views).toBe('number');
+    expect((totals.completed_views as number) > 0).toBe(true);
   });
 
   it('omits cost_per_acquisition when no conversions were injected', async () => {


### PR DESCRIPTION
## Summary

- Declares seller-level `media_buy.supported_optimization_metrics` on both surfaces (v5 legacy `/mcp` handler and v6 `TrainingSalesPlatform.capabilities`) as the honest union across catalog products: `[clicks, views, completed_views, engagements, reach]`.
- Validates `reach_unit` against the product's `metric_optimization.supported_reach_units` and `view_duration_seconds` against `supported_view_durations` on `create_media_buy`, returning `INVALID_REQUEST` with literal JSONPath-lite `error.field`. Mirrors the event_source_id / audience_id checks already in place.
- Emits `cost_per_click` (always when clicks + spend > 0), plus goal-gated `reach + frequency` and `completed_views + completion_rate` on `get_media_buy_delivery`. Placeholder ratios documented inline (reach = floor(impressions / 3); completed_views = floor(impressions × 0.7)).
- Persists `optimization_goals` on `PackageState` so delivery handlers can gate metric emission on what the buyer actually requested.

Flips three capability-gated storyboards from `not_applicable` to applicable on the training agent: `clicks_buy_flow`, `reach_buy_flow`, `completed_views_buy_flow`.

Same forcing-function shape as #4654 (event_source validation + CPA) and #4664 (audience_buy_flow / event_dedup_flow). Manual declaration is required until adcp-client#1818 (SDK auto-rollup from product-level `supported_metrics`) ships — that PR is blocked on the SDK exposing the seller-level field.

Refs: #4637, #4642, #4654, #4664, #4722.

## Test plan

- [x] `npm run build:schemas`
- [x] `npm run build:compliance`
- [x] `npm run typecheck`
- [x] `npx vitest run server/tests/unit/training-agent.test.ts` — 382 tests pass (6 new)
- [ ] Confirm the three storyboard scenarios grade `applicable` (no longer `not_applicable`) against the training agent on the next compliance run

🤖 Generated with [Claude Code](https://claude.com/claude-code)