### PR TITLE
fix: 3.1.0 docs + scenario sweep (#4574 #4713 #4712)

### DIFF
--- a/.changeset/3-1-0-doc-scenario-sweep.md
+++ b/.changeset/3-1-0-doc-scenario-sweep.md
@@ -1,0 +1,25 @@
+---
+"adcontextprotocol": patch
+---
+
+3.1.0 docs + scenario sweep — three remaining small fixes batched ahead of GA (2026-05-29):
+
+- **#4574** Cleanup of stale `list_authorized_properties` references (replaced by `get_adcp_capabilities` portfolio in v3):
+  - `static/compliance/source/specialisms/signal-owned/index.yaml` — narrative rewritten to reflect the v3 retirement.
+  - `skills/adcp-media-buy/SKILL.md` — table row + dedicated section removed; `get_adcp_capabilities` row updated to mention portfolio surface.
+  - `server/src/addie/mcp/adcp-tools.ts` — removed from the ADCP_TASK_REGISTRY map so Addie's MCP routing no longer advertises the retired task.
+  - `tests/addie/__snapshots__/adcp-tool-schema-drift.test.ts.snap` — snapshot updated to match.
+
+- **#4713** Surface 3.1 version negotiation in three docs surfaces previously describing the legacy integer-only contract:
+  - `docs/reference/whats-new-in-v3.mdx § Per-request version declaration` — leads with release-precision `adcp_version` + `adcp.supported_versions`; legacy `adcp_major_version` retained as backwards-compatible.
+  - `docs/building/by-layer/L0/a2a-guide.mdx` and `mcp-guide.mdx` — agent/server card notes updated with release-precision framing and a cross-link to `versioning.mdx § Version negotiation`.
+
+- **#4712** `static/compliance/source/universal/error-compliance.yaml` (phase `version_negotiation`) — added a release-precision `VERSION_UNSUPPORTED` probe (`adcp_version: "99.0"`) as the sibling to the existing integer-only probe. Advisory at 3.1; promotes to required at the 3.2 storyboard cut. Closes the gap where an integer-only validator could pass all storyboards while shipping a broken 3.1 buyer experience.
+
+Three sibling issues closed without code change (already done on main or upstream):
+- #4466 — adagents.mdx `authorization_type` is now `(required)` on main.
+- #3981 — sponsored-intelligence si_get_offering `context_outputs` path is now `offering.offering_id` on main.
+- #3555 — push-notification-config.json `url` description now documents port permissiveness on main.
+- #4519 — refine_products scenario `brief` already removed on main.
+- #4462 — schema's `ttl_sec` is the required field; the commit cited in the issue body was reverted/never landed.
+- #3349 — references `scenarios/signals.js` in adcp-client; spec storyboards already use correct field names.

--- a/docs/building/by-layer/L0/a2a-guide.mdx
+++ b/docs/building/by-layer/L0/a2a-guide.mdx
@@ -909,7 +909,7 @@ if (adcpExt) {
 **Extension Params**: The `adcp-extension.json` schema was used in v2 to describe these params, but was removed in v3. For v3+ agents, use the `get_adcp_capabilities` task for runtime capability discovery instead. The extension `params` object above shows the typical structure.
 
 :::note
-The `adcp_version` field in agent card metadata is a v2 convention and is not part of the v3 spec. For version negotiation, use [`get_adcp_capabilities`](/docs/protocol/get_adcp_capabilities#version-negotiation) with the `adcp_major_version` field.
+The `adcp_version` field in agent card metadata is a v2 convention and is not part of the v3 spec. For v3 version negotiation, the buyer sends release-precision `adcp_version` (e.g., `"3.1"`) on every request, and the seller advertises supported releases via `adcp.supported_versions` on [`get_adcp_capabilities`](/docs/protocol/get_adcp_capabilities) and echoes `adcp_version` at the envelope root on every response. The legacy integer-only `adcp_major_version` field is still accepted for backwards compatibility. See [versioning.mdx § Version negotiation](/docs/reference/versioning#version-negotiation) for the full contract.
 :::
 
 **Benefits**:

--- a/docs/building/by-layer/L0/mcp-guide.mdx
+++ b/docs/building/by-layer/L0/mcp-guide.mdx
@@ -808,7 +808,7 @@ if (adcpMeta) {
 - Enable compatibility checks based on version
 
 :::note
-The `adcp_version` field in server card metadata is a v2 convention and is not part of the v3 spec. For version negotiation, use [`get_adcp_capabilities`](/docs/protocol/get_adcp_capabilities#version-negotiation) with the `adcp_major_version` field.
+The `adcp_version` field in server card metadata is a v2 convention and is not part of the v3 spec. For v3 version negotiation, the buyer sends release-precision `adcp_version` (e.g., `"3.1"`) on every request, and the seller advertises supported releases via `adcp.supported_versions` on [`get_adcp_capabilities`](/docs/protocol/get_adcp_capabilities) and echoes `adcp_version` at the envelope root on every response. The legacy integer-only `adcp_major_version` field is still accepted for backwards compatibility. See [versioning.mdx § Version negotiation](/docs/reference/versioning#version-negotiation) for the full contract.
 :::
 
 **Note:** The `_meta` field uses reverse DNS namespacing per the [MCP server.json spec](https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/generic-server-json.md). AdCP servers should support both `/.well-known/mcp.json` and `/.well-known/server.json` locations.

--- a/docs/reference/whats-new-in-v3.mdx
+++ b/docs/reference/whats-new-in-v3.mdx
@@ -343,9 +343,11 @@ Campaign governance extends beyond media buys to cover brand rights licensing, s
 
 ### Per-request version declaration
 
-All request schemas now include `adcp_major_version`, allowing v3 buyers to declare which major version their payloads conform to. Sellers validate against their `major_versions` and return `VERSION_UNSUPPORTED` if unsupported. When omitted, sellers default to their highest supported version.
+All request schemas now include `adcp_version` (release-precision, e.g., `"3.1"`), allowing v3 buyers to declare which release their payloads conform to. Sellers validate against their advertised `adcp.supported_versions` array on `get_adcp_capabilities` and echo `adcp_version` at the envelope root on every response. Unsupported releases return `VERSION_UNSUPPORTED`. When omitted, sellers default to their highest supported version.
 
-Note: `adcp_major_version` is a v3 field — v2 clients cannot set it (the field does not exist in v2 schemas). Multi-version sellers detect v2 payloads by structural cues (missing `buying_mode`, `fixed_rate` vs `fixed_price`, `geo_postal_codes` vs `geo_postal_areas`, etc.) rather than by this field.
+3.1 also retains `adcp_major_version` (integer) as a backwards-compatible legacy field, but release-precision `adcp_version` is the primary wire field going forward. See [Version negotiation](/docs/reference/versioning#version-negotiation) for the negotiation contract, migration timeline, and SDK pinning examples.
+
+Note: both fields are v3-only — v2 clients cannot set either (the fields do not exist in v2 schemas). Multi-version sellers detect v2 payloads by structural cues (missing `buying_mode`, `fixed_rate` vs `fixed_price`, `geo_postal_codes` vs `geo_postal_areas`, etc.) rather than by these fields.
 
 ### Collection lists
 

--- a/server/src/addie/mcp/adcp-tools.ts
+++ b/server/src/addie/mcp/adcp-tools.ts
@@ -74,7 +74,6 @@ export const ADCP_TASK_REGISTRY: Record<string, AdcpTaskMeta> = {
   },
   sync_catalogs: { area: 'media-buy', description: 'Sync product catalogs, store locations, job postings, and other structured feeds to a seller account' },
   list_creative_formats: { area: 'media-buy', description: 'View supported creative specifications from a sales or creative agent' },
-  list_authorized_properties: { area: 'media-buy', description: 'Get the list of publisher properties this sales agent can sell' },
   get_media_buys: { area: 'media-buy', description: 'Retrieve media buy state: status, valid_actions, creative approvals, pending formats' },
   get_media_buy_delivery: { area: 'media-buy', description: 'Retrieve performance metrics for a campaign' },
   update_media_buy: {

--- a/skills/adcp-media-buy/SKILL.md
+++ b/skills/adcp-media-buy/SKILL.md
@@ -16,7 +16,7 @@ The Media Buy Protocol provides 11 standardized tasks for managing advertising c
 | Task | Purpose | Response Time |
 |------|---------|---------------|
 | `get_products` | Discover inventory using natural language | ~60s |
-| `list_authorized_properties` | See publisher properties | ~1s |
+| `get_adcp_capabilities` | See agent capabilities, supported protocols, and publisher properties | ~1s |
 | `list_creative_formats` | View creative specifications | ~1s |
 | `create_media_buy` | Create campaigns | Minutes-Days |
 | `update_media_buy` | Modify campaigns | Minutes-Days |
@@ -91,22 +91,6 @@ Discover advertising products using natural language briefs.
 **Response contains:**
 - `products`: Array of matching products with `product_id`, `name`, `description`, `pricing_options`
 - Each product includes `format_ids` (supported creative formats) and `targeting` (available targeting)
-
----
-
-### list_authorized_properties
-
-Get the list of publisher properties this agent can sell.
-
-**Request:**
-```json
-{}
-```
-
-No parameters required.
-
-**Response contains:**
-- `publisher_domains`: Array of domain strings the agent is authorized to sell
 
 ---
 

--- a/static/compliance/source/specialisms/signal-owned/index.yaml
+++ b/static/compliance/source/specialisms/signal-owned/index.yaml
@@ -27,7 +27,8 @@ narrative: |
   Pricing is hard-required here for the same reason as signal marketplaces: signals
   are rate-carded goods. Buyers cannot activate without a pricing_option_id to anchor
   billing. Agents distributing first-party signals without commercial terms belong on
-  list_authorized_properties or a different specialism, not this one.
+  a different specialism, not this one — the v2 `list_authorized_properties`
+  task is retired; portfolio advertising now lives on `get_adcp_capabilities`.
 
 agent:
   interaction_model: owned_signals

--- a/static/compliance/source/universal/error-compliance.yaml
+++ b/static/compliance/source/universal/error-compliance.yaml
@@ -382,6 +382,60 @@ phases:
             value: "error_compliance--unsupported_major_version"
             description: "Context correlation_id returned unchanged"
 
+      - id: unsupported_release_version
+        title: "Reject unsupported adcp_version (release-precision)"
+        narrative: |
+          Send a get_products request asserting an unsupported release-precision
+          version. The seller must reject with VERSION_UNSUPPORTED and surface
+          `error.data.supported_versions[]` so the buyer can retry against a known
+          release.
+
+          This step is the release-precision sibling of `unsupported_major_version`
+          above. With 3.1 promoting `adcp_version` (release-precision, e.g. "3.1")
+          to the primary wire field, the error-path probe must also exercise the
+          release-precision shape — otherwise a seller could implement
+          integer-only VERSION_UNSUPPORTED validation and pass all storyboards
+          while shipping a broken 3.1 buyer experience. Advisory at 3.1; promotes
+          to required with the rest of the version-negotiation suite at the 3.2
+          storyboard cut.
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        comply_scenario: error_handling
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: false
+        severity: advisory
+        expected: |
+          Reject with:
+          - code: VERSION_UNSUPPORTED
+          - error.data.supported_versions[] present and non-empty (release-precision strings)
+          - message referencing the buyer's requested release and the seller's supported set
+
+        sample_request:
+          adcp_version: "99.0"
+          buying_mode: "brief"
+          brief: "Release-precision version negotiation probe"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+
+          context:
+            correlation_id: "error_compliance--unsupported_release_version"
+        validations:
+          - check: error_code
+            value: "VERSION_UNSUPPORTED"
+            description: "Error code is VERSION_UNSUPPORTED on release-precision unsupported pin"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object even on errors"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "error_compliance--unsupported_release_version"
+            description: "Context correlation_id returned unchanged"
+
       - id: supported_major_version
         title: "Accept supported adcp_major_version"
         narrative: |

--- a/tests/addie/__snapshots__/adcp-tool-schema-drift.test.ts.snap
+++ b/tests/addie/__snapshots__/adcp-tool-schema-drift.test.ts.snap
@@ -23,7 +23,6 @@ exports[`AdCP task registry completeness > registry task names match expected se
   "get_property_list",
   "get_rights",
   "get_signals",
-  "list_authorized_properties",
   "list_collection_lists",
   "list_content_standards",
   "list_creative_formats",


### PR DESCRIPTION
Three small fixes ahead of 3.1.0 GA (2026-05-29). Plus six sibling issues closed without code (already done on main, stale, or upstream).

## Commits

1. **`fix: 3.1.0 docs + scenario sweep`** — combined sweep covering:
   - **#4574** stale `list_authorized_properties` references cleaned: `skills/adcp-media-buy/SKILL.md` (table row + dedicated section), `static/compliance/source/specialisms/signal-owned/index.yaml` (narrative), `server/src/addie/mcp/adcp-tools.ts` (removed from `ADCP_TASK_REGISTRY`), plus the corresponding snapshot update. The v2 task is retired; portfolio advertising now lives on `get_adcp_capabilities`.
   - **#4713** release-precision version negotiation surfaced in three docs surfaces that still described the legacy integer-only contract: `docs/reference/whats-new-in-v3.mdx § Per-request version declaration`, `docs/building/by-layer/L0/a2a-guide.mdx`, `docs/building/by-layer/L0/mcp-guide.mdx`. Each now leads with `adcp_version` (release-precision) + `adcp.supported_versions` + envelope echo, with the legacy integer field retained as backwards-compatible.
   - **#4712** release-precision `VERSION_UNSUPPORTED` probe added to `static/compliance/source/universal/error-compliance.yaml` (phase `version_negotiation`). Advisory at 3.1; promotes to required at the 3.2 storyboard cut. Closes the gap where a seller could implement integer-only validation, pass all storyboards, and still ship a broken 3.1 buyer experience.

## Sibling issues closed without code change

Already addressed on main: **#4466** (adagents `authorization_type` required), **#3981** (`offering.offering_id` context path), **#3555** (push-notification-config port permissiveness).

Stale or upstream: **#4519** (refine_products `brief` already removed), **#4462** (schema's `ttl_sec` is current; cited commit reverted), **#3349** (references `scenarios/signals.js` in adcp-client; spec storyboards already correct).

## Test plan

- [x] `build:schemas` ✓ / `build:compliance` ✓
- [x] `test:schemas` ✓ / `test:examples` ✓ (34/34) / `test:storyboard-{branch-sets,contradictions,context-entity,auth-shape,test-kits,sample-request-schema,response-schema,doc-parity}` ✓
- [x] `test:docs-nav` ✓ / `test:composed` ✓ / `test:error-codes` ✓
- [x] `test:unit` ✓ (900/900) — `adcp-tool-schema-drift` snapshot updated to reflect the registry change
- [x] `typecheck` ✓ (after `@adcp/sdk` 7.7.0 pickup)
- [x] Pre-push storyboard matrix ✓
- ⚠️ Pre-existing `test:storyboard-scoping` failure on `list_accounts` HANDLER_MAP classification — unrelated to this PR, confirmed on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)