### PR TITLE
fix(signup): capture first/last name reliably (escalation #382 root cause)

### DIFF
--- a/.changeset/capture-name-at-signup.md
+++ b/.changeset/capture-name-at-signup.md
@@ -1,0 +1,14 @@
+---
+---
+
+fix(signup): capture first/last name reliably so credentials never read "undefined undefined"
+
+Three coordinated changes that close the gap behind escalation #382 (Tom Hespos's credential, plus 12 other learners with email-fallback names):
+
+1. **Auth callback now applies the Slack-name fallback that the WorkOS webhook already had.** When `users.first_name` would be inserted as NULL, we now look at the user's `slack_user_mappings.slack_real_name` (or `slack_display_name`) and split it into first/last. 8 of the 11 nameless users on prod already have a Slack mapping with the right name — next time they sign in, they're silently backfilled.
+
+2. **Onboarding gates on a name.** When the callback fallbacks still produce no name (no Slack mapping, no WorkOS profile), `/onboarding.html` now shows a "What should we call you?" step before the rest of the flow. Submits to the existing `PUT /api/me/name`.
+
+3. **`PUT /api/me/name` pushes back to WorkOS.** Previously we only wrote to our `users` table and `organization_memberships`; WorkOS itself kept NULL, which meant the next webhook could overwrite us. Now WorkOS becomes the source of truth.
+
+The Slack-fallback cascade is extracted into `server/src/utils/resolve-user-name.ts` and used by both the auth callback (`server/src/http.ts`) and the WorkOS user-update webhook (`server/src/routes/workos-webhooks.ts`), so the two paths can't drift.

--- a/server/public/onboarding.html
+++ b/server/public/onboarding.html
@@ -438,6 +438,24 @@
   <div class="container">
     <div id="loading" class="loading">Loading...</div>
 
+    <!-- Name capture: shown when WorkOS + Slack fallbacks both came back empty -->
+    <div id="nameCaptureSection" style="display: none;">
+      <h1>What should we call you?</h1>
+      <p class="subtitle">We use this on certificates, member announcements, and conversations with Addie. You can change it anytime in your profile.</p>
+      <div id="nameCaptureError" class="error" style="display: none; margin-bottom: var(--space-3);"></div>
+      <form id="nameCaptureForm" style="display: flex; flex-direction: column; gap: var(--space-3);">
+        <div class="form-group">
+          <label for="nameCaptureFirst" style="display: block; margin-bottom: var(--space-1); font-weight: var(--font-medium);">First name</label>
+          <input type="text" id="nameCaptureFirst" required autocomplete="given-name" maxlength="255" autofocus>
+        </div>
+        <div class="form-group">
+          <label for="nameCaptureLast" style="display: block; margin-bottom: var(--space-1); font-weight: var(--font-medium);">Last name <span style="color: var(--color-text-muted); font-weight: normal;">(optional)</span></label>
+          <input type="text" id="nameCaptureLast" autocomplete="family-name" maxlength="255">
+        </div>
+        <button type="submit" class="btn" id="nameCaptureSubmit" style="margin-top: var(--space-2);">Continue</button>
+      </form>
+    </div>
+
     <div id="mainContent" style="display: none;">
       <h1>Welcome to AgenticAdvertising.org<span id="welcomeName"></span></h1>
       <p class="subtitle">How would you like to get started?</p>
@@ -888,6 +906,17 @@
 
         const data = await response.json();
         currentUser = data.user;
+
+        // Gate: when WorkOS + Slack fallbacks both produced no name, ask the
+        // user before letting them proceed. Credentials, member announcements,
+        // and Addie all read users.first_name; "undefined undefined" on a
+        // certificate (escalation #382) was the symptom of skipping this.
+        const hasName = (currentUser.first_name || '').trim().length > 0;
+        if (!hasName) {
+          document.getElementById('loading').style.display = 'none';
+          document.getElementById('nameCaptureSection').style.display = 'block';
+          return;
+        }
 
         const urlParams = new URLSearchParams(window.location.search);
         const personalMode = urlParams.get('mode') === 'personal';
@@ -1402,6 +1431,43 @@
     // Add listeners to revenue tier radio buttons
     document.querySelectorAll('input[name="revenueTier"]').forEach(function(radio) {
       radio.addEventListener('change', updateCompanyPricing);
+    });
+
+    // Name capture form — submits to PUT /api/me/name, then re-runs init
+    // so the regular onboarding flow proceeds with the captured name.
+    document.getElementById('nameCaptureForm').addEventListener('submit', async function(e) {
+      e.preventDefault();
+      var first = document.getElementById('nameCaptureFirst').value.trim();
+      var last = document.getElementById('nameCaptureLast').value.trim();
+      var errorEl = document.getElementById('nameCaptureError');
+      var submitBtn = document.getElementById('nameCaptureSubmit');
+      errorEl.style.display = 'none';
+      if (!first) {
+        errorEl.textContent = 'First name is required.';
+        errorEl.style.display = 'block';
+        return;
+      }
+      submitBtn.disabled = true;
+      submitBtn.textContent = 'Saving…';
+      try {
+        var resp = await fetch('/api/me/name', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ first_name: first, last_name: last || null }),
+        });
+        if (!resp.ok) {
+          var err = await resp.json().catch(function() { return null; });
+          throw new Error((err && err.error) || 'Could not save your name. Please try again.');
+        }
+        document.getElementById('nameCaptureSection').style.display = 'none';
+        document.getElementById('loading').style.display = 'block';
+        await init();
+      } catch (e) {
+        errorEl.textContent = e.message || 'Could not save your name. Please try again.';
+        errorEl.style.display = 'block';
+        submitBtn.disabled = false;
+        submitBtn.textContent = 'Continue';
+      }
     });
 
     // Create organization form

--- a/server/public/onboarding.html
+++ b/server/public/onboarding.html
@@ -892,6 +892,10 @@
     let pendingInvitations = [];
     let joinableOrgs = [];
     let userDomain = null;
+    // Set to true right before re-entering init() after the name-capture form
+    // succeeds. Prevents the gate from re-firing if /api/me momentarily still
+    // returns a null first_name (cache, read-after-write race).
+    let nameJustCaptured = false;
 
     // Initialize page
     async function init() {
@@ -912,7 +916,7 @@
         // and Addie all read users.first_name; "undefined undefined" on a
         // certificate (escalation #382) was the symptom of skipping this.
         const hasName = (currentUser.first_name || '').trim().length > 0;
-        if (!hasName) {
+        if (!hasName && !nameJustCaptured) {
           document.getElementById('loading').style.display = 'none';
           document.getElementById('nameCaptureSection').style.display = 'block';
           return;
@@ -1459,6 +1463,12 @@
           var err = await resp.json().catch(function() { return null; });
           throw new Error((err && err.error) || 'Could not save your name. Please try again.');
         }
+        // Optimistic: don't re-call /api/me — the gate would loop if that
+        // response still returned an empty name (caching, race). The PUT
+        // already wrote through to users + memberships + WorkOS.
+        currentUser.first_name = first;
+        currentUser.last_name = last || null;
+        nameJustCaptured = true;
         document.getElementById('nameCaptureSection').style.display = 'none';
         document.getElementById('loading').style.display = 'block';
         await init();

--- a/server/src/db/slack-db.ts
+++ b/server/src/db/slack-db.ts
@@ -133,7 +133,34 @@ export class SlackDatabase {
         input.slack_user_id,
       ]
     );
-    return result.rows[0] || null;
+    const mapping = result.rows[0] || null;
+
+    // Backfill users.first_name/last_name from the Slack mapping when they're
+    // currently empty. The OAuth callback's resolveUserNameWithFallbacks runs
+    // the same cascade on next sign-in, but admin links and email-based
+    // auto-links happen out-of-band — without this, a learner can be Slack-
+    // linked, earn a credential via Sage, and never have signed in via OAuth
+    // in between. SQL-side split: first word → first_name, rest → last_name.
+    if (mapping) {
+      const slackName = mapping.slack_real_name || mapping.slack_display_name;
+      if (slackName?.trim()) {
+        const trimmed = slackName.trim();
+        const spaceIdx = trimmed.indexOf(' ');
+        const firstName = spaceIdx === -1 ? trimmed : trimmed.slice(0, spaceIdx);
+        const lastName = spaceIdx === -1 ? null : trimmed.slice(spaceIdx + 1).trim() || null;
+        await query(
+          `UPDATE users
+              SET first_name = COALESCE(NULLIF(TRIM(first_name), ''), $1),
+                  last_name = COALESCE(NULLIF(TRIM(last_name), ''), $2),
+                  updated_at = NOW()
+            WHERE workos_user_id = $3
+              AND (NULLIF(TRIM(first_name), '') IS NULL OR NULLIF(TRIM(last_name), '') IS NULL)`,
+          [firstName, lastName, input.workos_user_id]
+        );
+      }
+    }
+
+    return mapping;
   }
 
   /**

--- a/server/src/db/slack-db.ts
+++ b/server/src/db/slack-db.ts
@@ -6,6 +6,7 @@ import type {
   SlackMappingStats,
 } from '../slack/types.js';
 import { FREE_EMAIL_PROVIDER_DOMAINS } from '../services/identifier-normalization.js';
+import { splitFullName } from '../utils/resolve-user-name.js';
 
 /**
  * Escape LIKE pattern wildcards to prevent SQL injection
@@ -144,10 +145,7 @@ export class SlackDatabase {
     if (mapping) {
       const slackName = mapping.slack_real_name || mapping.slack_display_name;
       if (slackName?.trim()) {
-        const trimmed = slackName.trim();
-        const spaceIdx = trimmed.indexOf(' ');
-        const firstName = spaceIdx === -1 ? trimmed : trimmed.slice(0, spaceIdx);
-        const lastName = spaceIdx === -1 ? null : trimmed.slice(spaceIdx + 1).trim() || null;
+        const { firstName, lastName } = splitFullName(slackName);
         await query(
           `UPDATE users
               SET first_name = COALESCE(NULLIF(TRIM(first_name), ''), $1),

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -53,7 +53,7 @@ import { isSlackConfigured, testSlackConnection } from "./slack/client.js";
 import { handleSlashCommand } from "./slack/commands.js";
 import { getCompanyDomain, getGoogleEmailAliases } from "./utils/email-domain.js";
 import { isUuid } from "./utils/uuid.js";
-import { resolveUserNameWithFallbacks } from "./utils/resolve-user-name.js";
+import { resolveUserNameWithFallbacks, sanitizeName } from "./utils/resolve-user-name.js";
 import { requireAuth, requireAdmin, optionalAuth, invalidateSessionCache, isDevModeEnabled, getDevUser, getAvailableDevUsers, getDevSessionCookieName, encodeDevSessionCookie, DEV_USERS, type DevUserConfig } from "./middleware/auth.js";
 import { invitationRateLimiter, brandCreationRateLimiter, notificationRateLimiter, emailPrefsRateLimiter, adminContentWriteRateLimiter, newsletterSubscribeRateLimiter, newsletterConfirmRateLimiter } from "./middleware/rate-limit.js";
 import { findOrCreateUserByEmail } from "./auth/workos-client.js";
@@ -7354,18 +7354,26 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
           return res.status(400).json({ error: 'first_name must be a string' });
         }
 
-        const sanitize = (s: string) => s.trim().replace(/[\r\n\t]/g, ' ').replace(/\s+/g, ' ');
-        const firstName = sanitize(req.body.first_name);
-        const lastName = typeof req.body.last_name === 'string' ? sanitize(req.body.last_name) || null : null;
+        // Reject overlong raw input *before* sanitizing so the user gets a
+        // clear 422 instead of silent truncation.
+        if (req.body.first_name.length > 255) {
+          return res.status(400).json({ error: 'first_name must be 255 characters or fewer' });
+        }
+        if (typeof req.body.last_name === 'string' && req.body.last_name.length > 255) {
+          return res.status(400).json({ error: 'last_name must be 255 characters or fewer' });
+        }
+
+        // sanitizeName strips C0/C1 controls + Unicode direction/format
+        // characters (RTL-override spoofing, ZWSP), collapses whitespace,
+        // trims, and caps at 255 chars — same guarantees as the Slack-source
+        // paths. It preserves multi-word names ("Mary Jane") intact.
+        const firstName = sanitizeName(req.body.first_name);
+        const lastName = typeof req.body.last_name === 'string'
+          ? (sanitizeName(req.body.last_name) || null)
+          : null;
 
         if (!firstName) {
           return res.status(400).json({ error: 'first_name is required' });
-        }
-        if (firstName.length > 255) {
-          return res.status(400).json({ error: 'first_name must be 255 characters or fewer' });
-        }
-        if (lastName && lastName.length > 255) {
-          return res.status(400).json({ error: 'last_name must be 255 characters or fewer' });
         }
 
         const pool = getPool();
@@ -7398,7 +7406,7 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
         }
 
         invalidateMemberContextCache();
-        logger.info({ userId: user.id, firstName, lastName }, 'User updated their display name');
+        logger.info({ userId: user.id }, 'User updated their display name');
         res.json({ first_name: firstName, last_name: lastName });
       } catch (error) {
         logger.error({ err: error }, 'Update user name error');

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -53,6 +53,7 @@ import { isSlackConfigured, testSlackConnection } from "./slack/client.js";
 import { handleSlashCommand } from "./slack/commands.js";
 import { getCompanyDomain, getGoogleEmailAliases } from "./utils/email-domain.js";
 import { isUuid } from "./utils/uuid.js";
+import { resolveUserNameWithFallbacks } from "./utils/resolve-user-name.js";
 import { requireAuth, requireAdmin, optionalAuth, invalidateSessionCache, isDevModeEnabled, getDevUser, getAvailableDevUsers, getDevSessionCookieName, encodeDevSessionCookie, DEV_USERS, type DevUserConfig } from "./middleware/auth.js";
 import { invitationRateLimiter, brandCreationRateLimiter, notificationRateLimiter, emailPrefsRateLimiter, adminContentWriteRateLimiter, newsletterSubscribeRateLimiter, newsletterConfirmRateLimiter } from "./middleware/rate-limit.js";
 import { findOrCreateUserByEmail } from "./auth/workos-client.js";
@@ -6502,10 +6503,14 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
         logger.info({ userId: user.id }, 'User authenticated via OAuth callback');
 
         // Ensure user exists in local users table (webhooks may have been missed).
-        // On INSERT, use WorkOS values. On UPDATE, preserve user-set names:
-        // only fill in names that are currently empty in the DB.
+        // On INSERT, use WorkOS values — falling back to existing DB / Slack
+        // mapping when WorkOS itself has empty names. On UPDATE, preserve
+        // user-set names: only fill in names that are currently empty.
         try {
           const pool = getPool();
+          const { firstName, lastName } = await resolveUserNameWithFallbacks(
+            pool, user.id, user.firstName, user.lastName,
+          );
           await pool.query(
             `INSERT INTO users (workos_user_id, email, first_name, last_name, email_verified, workos_created_at, workos_updated_at, created_at, updated_at)
              VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())
@@ -6516,7 +6521,7 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
                email_verified = EXCLUDED.email_verified,
                workos_updated_at = EXCLUDED.workos_updated_at,
                updated_at = NOW()`,
-            [user.id, user.email, user.firstName, user.lastName, user.emailVerified, user.createdAt, user.updatedAt]
+            [user.id, user.email, firstName, lastName, user.emailVerified, user.createdAt, user.updatedAt]
           );
         } catch (upsertError) {
           logger.error({ error: upsertError, userId: user.id }, 'Failed to upsert user on login');
@@ -7376,6 +7381,21 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
           `UPDATE organization_memberships SET first_name = $1, last_name = $2, updated_at = NOW() WHERE workos_user_id = $3`,
           [firstName, lastName, user.id]
         );
+
+        // Push back to WorkOS so subsequent webhooks / SDK reads don't show
+        // empty names. Best-effort: a transient WorkOS failure shouldn't fail
+        // the user's local name update.
+        try {
+          if (workos) {
+            await workos.userManagement.updateUser({
+              userId: user.id,
+              firstName,
+              lastName: lastName ?? undefined,
+            });
+          }
+        } catch (workosError) {
+          logger.warn({ err: workosError, userId: user.id }, 'Failed to push name to WorkOS (local update applied)');
+        }
 
         invalidateMemberContextCache();
         logger.info({ userId: user.id, firstName, lastName }, 'User updated their display name');

--- a/server/src/routes/workos-webhooks.ts
+++ b/server/src/routes/workos-webhooks.ts
@@ -32,6 +32,7 @@ import { BrandDatabase } from '../db/brand-db.js';
 import { getWorkos } from '../auth/workos-client.js';
 import { invalidateUnifiedUsersCache } from '../cache/unified-users.js';
 import { tryAutoLinkWebsiteUserToSlack } from '../slack/sync.js';
+import { resolveUserNameWithFallbacks } from '../utils/resolve-user-name.js';
 import { triageAndNotify } from '../services/prospect-triage.js';
 import { researchDomain, trackBackground } from '../services/brand-enrichment.js';
 import { isFreeEmailDomain } from '../utils/email-domain.js';
@@ -370,43 +371,9 @@ async function deleteMembership(membership: OrganizationMembershipData): Promise
 async function upsertUser(user: UserData): Promise<void> {
   const pool = getPool();
 
-  // Resolve names: prefer WorkOS values, but when WorkOS sends empty names,
-  // preserve existing DB values or backfill from Slack mapping
-  let firstName = user.first_name;
-  let lastName = user.last_name;
-
-  if (!firstName?.trim() || !lastName?.trim()) {
-    const existing = await pool.query<{
-      first_name: string | null;
-      last_name: string | null;
-      slack_real_name: string | null;
-      slack_display_name: string | null;
-    }>(
-      `SELECT u.first_name, u.last_name, sm.slack_real_name, sm.slack_display_name
-       FROM users u
-       LEFT JOIN slack_user_mappings sm ON sm.slack_user_id = u.primary_slack_user_id
-       WHERE u.workos_user_id = $1`,
-      [user.id]
-    );
-
-    if (existing.rows.length > 0) {
-      const row = existing.rows[0];
-
-      // Keep existing DB names if WorkOS sends empty
-      if (!firstName?.trim()) firstName = row.first_name;
-      if (!lastName?.trim()) lastName = row.last_name;
-
-      // Backfill from Slack if still empty
-      if (!firstName?.trim() && !lastName?.trim()) {
-        const slackName = row.slack_real_name || row.slack_display_name;
-        if (slackName) {
-          const parts = slackName.trim().split(/\s+/);
-          firstName = parts[0];
-          lastName = parts.length > 1 ? parts.slice(1).join(' ') : null;
-        }
-      }
-    }
-  }
+  const { firstName, lastName } = await resolveUserNameWithFallbacks(
+    pool, user.id, user.first_name, user.last_name,
+  );
 
   await pool.query(
     `INSERT INTO users (

--- a/server/src/utils/resolve-user-name.ts
+++ b/server/src/utils/resolve-user-name.ts
@@ -1,5 +1,62 @@
 import type { PoolClient, Pool } from 'pg';
 
+const MAX_NAME_LEN = 255;
+
+// Defense-in-depth: drop C0/C1 controls, DEL, and Unicode direction/format
+// characters (U+200B..F, U+202A..E, U+2060..4, U+FEFF). A user setting their
+// Slack display name to an RTL-override that renders one way in Slack and
+// another on a Certifier PDF or in an Addie speaker prefix is a real (if
+// minor) spoofing surface; strip these before the value leaves the helper.
+function isInvisibleOrControl(cp: number): boolean {
+  // Keep \t (0x09), \n (0x0a), \r (0x0d) — they're treated as whitespace by
+  // the trim+collapse step below, so "Tom\tHespos" collapses to "Tom Hespos".
+  return (
+    (cp >= 0x00 && cp <= 0x08) ||
+    cp === 0x0b ||
+    cp === 0x0c ||
+    (cp >= 0x0e && cp <= 0x1f) ||
+    cp === 0x7f ||
+    (cp >= 0x200b && cp <= 0x200f) ||
+    (cp >= 0x202a && cp <= 0x202e) ||
+    (cp >= 0x2060 && cp <= 0x2064) ||
+    cp === 0xfeff
+  );
+}
+
+function stripInvisibles(value: string): string {
+  let out = '';
+  for (const ch of value) {
+    const cp = ch.codePointAt(0);
+    if (cp !== undefined && !isInvisibleOrControl(cp)) out += ch;
+  }
+  return out;
+}
+
+/**
+ * Strip invisible / control characters, collapse internal whitespace runs,
+ * trim, and cap at 255 chars. Multi-word first names like "Mary Jane" stay
+ * intact — this is *not* a name-splitter; use `splitFullName` for that.
+ */
+export function sanitizeName(value: string): string {
+  return stripInvisibles(value).trim().replace(/\s+/g, ' ').slice(0, MAX_NAME_LEN);
+}
+
+/**
+ * Split a single "full name" string into first / last. Collapses any run of
+ * whitespace, so "Tom  Hespos", "Tom\tHespos", and "Tom Hespos" all produce
+ * the same result. Returns `null` for the last half when the input is a
+ * single name like "Cher". Also strips invisible / control characters and
+ * caps each half at 255 chars (matches the `users` table column).
+ */
+export function splitFullName(fullName: string): { firstName: string; lastName: string | null } {
+  const cleaned = sanitizeName(fullName);
+  if (!cleaned) return { firstName: '', lastName: null };
+  const parts = cleaned.split(' ');
+  const firstName = (parts[0] ?? '').slice(0, MAX_NAME_LEN);
+  const lastName = parts.length > 1 ? parts.slice(1).join(' ').slice(0, MAX_NAME_LEN) : null;
+  return { firstName, lastName };
+}
+
 /**
  * Resolve a user's name with a fallback cascade so we don't end up persisting
  * NULL first/last when richer data already exists in our system. The cascade:
@@ -54,9 +111,9 @@ export async function resolveUserNameWithFallbacks(
   if (!firstName?.trim() && !lastName?.trim()) {
     const slackName = row.slack_real_name || row.slack_display_name;
     if (slackName) {
-      const parts = slackName.trim().split(/\s+/);
-      firstName = parts[0] ?? null;
-      lastName = parts.length > 1 ? parts.slice(1).join(' ') : null;
+      const split = splitFullName(slackName);
+      firstName = split.firstName || null;
+      lastName = split.lastName;
     }
   }
 

--- a/server/src/utils/resolve-user-name.ts
+++ b/server/src/utils/resolve-user-name.ts
@@ -1,0 +1,64 @@
+import type { PoolClient, Pool } from 'pg';
+
+/**
+ * Resolve a user's name with a fallback cascade so we don't end up persisting
+ * NULL first/last when richer data already exists in our system. The cascade:
+ *
+ *   1. WorkOS values (if set) — these are the user-provided source of truth
+ *   2. Existing `users.first_name` / `users.last_name` — preserve anything the
+ *      user supplied via /api/me/name even if WorkOS later sends nulls
+ *   3. `slack_user_mappings.slack_real_name` / `slack_display_name` — many
+ *      learners auth via Slack-linked WorkOS accounts; Slack has the human
+ *      name even when WorkOS profile fields are empty
+ *
+ * Returns the resolved pair. Falls through to the input WorkOS values if no
+ * fallback applies, so callers can use the result unconditionally.
+ *
+ * Mirrors the inline cascade in `workos-webhooks.ts:upsertUser` so the OAuth
+ * callback and the user.updated webhook agree on the resolved name.
+ */
+export async function resolveUserNameWithFallbacks(
+  db: Pick<Pool | PoolClient, 'query'>,
+  workosUserId: string,
+  workosFirstName: string | null | undefined,
+  workosLastName: string | null | undefined,
+): Promise<{ firstName: string | null; lastName: string | null }> {
+  let firstName = workosFirstName ?? null;
+  let lastName = workosLastName ?? null;
+
+  if (firstName?.trim() && lastName?.trim()) {
+    return { firstName, lastName };
+  }
+
+  const existing = await db.query<{
+    first_name: string | null;
+    last_name: string | null;
+    slack_real_name: string | null;
+    slack_display_name: string | null;
+  }>(
+    `SELECT u.first_name, u.last_name, sm.slack_real_name, sm.slack_display_name
+       FROM users u
+       LEFT JOIN slack_user_mappings sm ON sm.slack_user_id = u.primary_slack_user_id
+      WHERE u.workos_user_id = $1`,
+    [workosUserId],
+  );
+
+  if (existing.rows.length === 0) {
+    return { firstName, lastName };
+  }
+
+  const row = existing.rows[0];
+  if (!firstName?.trim()) firstName = row.first_name;
+  if (!lastName?.trim()) lastName = row.last_name;
+
+  if (!firstName?.trim() && !lastName?.trim()) {
+    const slackName = row.slack_real_name || row.slack_display_name;
+    if (slackName) {
+      const parts = slackName.trim().split(/\s+/);
+      firstName = parts[0] ?? null;
+      lastName = parts.length > 1 ? parts.slice(1).join(' ') : null;
+    }
+  }
+
+  return { firstName, lastName };
+}

--- a/server/tests/integration/slack-db-name-backfill.test.ts
+++ b/server/tests/integration/slack-db-name-backfill.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Guards the Slack-link-time name backfill in `SlackDatabase.mapUser`.
+ *
+ * Scenario behind the test: a learner signs up via OAuth without filling
+ * first/last in WorkOS (escalation #382 root cause), then later gets
+ * Slack-linked via admin tooling or email-based auto-link. Before this
+ * backfill, their `users.first_name/last_name` stayed NULL until their
+ * NEXT OAuth callback fired — long enough that they could earn a
+ * credential ("undefined undefined" certificate) in between.
+ *
+ * mapUser now does the cascade inline on every link.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { getPool, initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { SlackDatabase } from '../../src/db/slack-db.js';
+import type { Pool } from 'pg';
+
+const TEST_USER_PREFIX = 'user_namebackfill_';
+const TEST_SLACK_PREFIX = 'U_namebackfill_';
+
+describe.skipIf(!process.env.DATABASE_URL)('SlackDatabase.mapUser name backfill', () => {
+  let pool: Pool;
+  let slackDb: SlackDatabase;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:53198/adcp_test',
+    });
+    await runMigrations();
+    slackDb = new SlackDatabase();
+  });
+
+  afterAll(async () => {
+    await pool.query(`DELETE FROM slack_user_mappings WHERE slack_user_id LIKE $1`, [`${TEST_SLACK_PREFIX}%`]);
+    await pool.query(`DELETE FROM users WHERE workos_user_id LIKE $1`, [`${TEST_USER_PREFIX}%`]);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await pool.query(`DELETE FROM slack_user_mappings WHERE slack_user_id LIKE $1`, [`${TEST_SLACK_PREFIX}%`]);
+    await pool.query(`DELETE FROM users WHERE workos_user_id LIKE $1`, [`${TEST_USER_PREFIX}%`]);
+  });
+
+  async function seedUser(suffix: string, opts: { first?: string | null; last?: string | null } = {}) {
+    const workosUserId = `${TEST_USER_PREFIX}${suffix}`;
+    await pool.query(
+      `INSERT INTO users (workos_user_id, email, first_name, last_name, email_verified, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, true, NOW(), NOW())`,
+      [workosUserId, `${suffix}@example.com`, opts.first ?? null, opts.last ?? null]
+    );
+    return workosUserId;
+  }
+
+  async function seedSlackUser(suffix: string, opts: { real?: string | null; display?: string | null }) {
+    const slackUserId = `${TEST_SLACK_PREFIX}${suffix}`;
+    await pool.query(
+      `INSERT INTO slack_user_mappings (slack_user_id, slack_email, slack_display_name, slack_real_name, mapping_status, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, 'unmapped', NOW(), NOW())`,
+      [slackUserId, `${suffix}@example.com`, opts.display ?? null, opts.real ?? null]
+    );
+    return slackUserId;
+  }
+
+  async function getUserName(workosUserId: string) {
+    const r = await pool.query<{ first_name: string | null; last_name: string | null }>(
+      `SELECT first_name, last_name FROM users WHERE workos_user_id = $1`,
+      [workosUserId]
+    );
+    return r.rows[0];
+  }
+
+  it('fills first/last from slack_real_name when both are NULL', async () => {
+    const workosUserId = await seedUser('a');
+    const slackUserId = await seedSlackUser('a', { real: 'Lillie Ratliff', display: 'lillie' });
+    await slackDb.mapUser({ slack_user_id: slackUserId, workos_user_id: workosUserId, mapping_source: 'admin' });
+    expect(await getUserName(workosUserId)).toEqual({ first_name: 'Lillie', last_name: 'Ratliff' });
+  });
+
+  it('falls back to slack_display_name when real_name is missing', async () => {
+    const workosUserId = await seedUser('b');
+    const slackUserId = await seedSlackUser('b', { real: null, display: 'Daniel Di Tullio' });
+    await slackDb.mapUser({ slack_user_id: slackUserId, workos_user_id: workosUserId, mapping_source: 'admin' });
+    expect(await getUserName(workosUserId)).toEqual({ first_name: 'Daniel', last_name: 'Di Tullio' });
+  });
+
+  it('handles single-word Slack names without inventing a last name', async () => {
+    const workosUserId = await seedUser('c');
+    const slackUserId = await seedSlackUser('c', { real: 'Cher', display: null });
+    await slackDb.mapUser({ slack_user_id: slackUserId, workos_user_id: workosUserId, mapping_source: 'admin' });
+    expect(await getUserName(workosUserId)).toEqual({ first_name: 'Cher', last_name: null });
+  });
+
+  it('does NOT overwrite existing user-set names', async () => {
+    const workosUserId = await seedUser('d', { first: 'Kept', last: 'Original' });
+    const slackUserId = await seedSlackUser('d', { real: 'Different Person', display: null });
+    await slackDb.mapUser({ slack_user_id: slackUserId, workos_user_id: workosUserId, mapping_source: 'admin' });
+    expect(await getUserName(workosUserId)).toEqual({ first_name: 'Kept', last_name: 'Original' });
+  });
+
+  it('fills only the missing half when one of first/last is already set', async () => {
+    const workosUserId = await seedUser('e', { first: 'Davide', last: null });
+    const slackUserId = await seedSlackUser('e', { real: 'Davide Astuto', display: null });
+    await slackDb.mapUser({ slack_user_id: slackUserId, workos_user_id: workosUserId, mapping_source: 'admin' });
+    expect(await getUserName(workosUserId)).toEqual({ first_name: 'Davide', last_name: 'Astuto' });
+  });
+
+  it('does nothing when the Slack mapping has no names', async () => {
+    const workosUserId = await seedUser('f');
+    const slackUserId = await seedSlackUser('f', { real: null, display: null });
+    await slackDb.mapUser({ slack_user_id: slackUserId, workos_user_id: workosUserId, mapping_source: 'admin' });
+    expect(await getUserName(workosUserId)).toEqual({ first_name: null, last_name: null });
+  });
+});

--- a/server/tests/integration/slack-db-name-backfill.test.ts
+++ b/server/tests/integration/slack-db-name-backfill.test.ts
@@ -73,42 +73,42 @@ describe.skipIf(!process.env.DATABASE_URL)('SlackDatabase.mapUser name backfill'
   it('fills first/last from slack_real_name when both are NULL', async () => {
     const workosUserId = await seedUser('a');
     const slackUserId = await seedSlackUser('a', { real: 'Lillie Ratliff', display: 'lillie' });
-    await slackDb.mapUser({ slack_user_id: slackUserId, workos_user_id: workosUserId, mapping_source: 'admin' });
+    await slackDb.mapUser({ slack_user_id: slackUserId, workos_user_id: workosUserId, mapping_source: 'manual_admin' });
     expect(await getUserName(workosUserId)).toEqual({ first_name: 'Lillie', last_name: 'Ratliff' });
   });
 
   it('falls back to slack_display_name when real_name is missing', async () => {
     const workosUserId = await seedUser('b');
     const slackUserId = await seedSlackUser('b', { real: null, display: 'Daniel Di Tullio' });
-    await slackDb.mapUser({ slack_user_id: slackUserId, workos_user_id: workosUserId, mapping_source: 'admin' });
+    await slackDb.mapUser({ slack_user_id: slackUserId, workos_user_id: workosUserId, mapping_source: 'manual_admin' });
     expect(await getUserName(workosUserId)).toEqual({ first_name: 'Daniel', last_name: 'Di Tullio' });
   });
 
   it('handles single-word Slack names without inventing a last name', async () => {
     const workosUserId = await seedUser('c');
     const slackUserId = await seedSlackUser('c', { real: 'Cher', display: null });
-    await slackDb.mapUser({ slack_user_id: slackUserId, workos_user_id: workosUserId, mapping_source: 'admin' });
+    await slackDb.mapUser({ slack_user_id: slackUserId, workos_user_id: workosUserId, mapping_source: 'manual_admin' });
     expect(await getUserName(workosUserId)).toEqual({ first_name: 'Cher', last_name: null });
   });
 
   it('does NOT overwrite existing user-set names', async () => {
     const workosUserId = await seedUser('d', { first: 'Kept', last: 'Original' });
     const slackUserId = await seedSlackUser('d', { real: 'Different Person', display: null });
-    await slackDb.mapUser({ slack_user_id: slackUserId, workos_user_id: workosUserId, mapping_source: 'admin' });
+    await slackDb.mapUser({ slack_user_id: slackUserId, workos_user_id: workosUserId, mapping_source: 'manual_admin' });
     expect(await getUserName(workosUserId)).toEqual({ first_name: 'Kept', last_name: 'Original' });
   });
 
   it('fills only the missing half when one of first/last is already set', async () => {
     const workosUserId = await seedUser('e', { first: 'Davide', last: null });
     const slackUserId = await seedSlackUser('e', { real: 'Davide Astuto', display: null });
-    await slackDb.mapUser({ slack_user_id: slackUserId, workos_user_id: workosUserId, mapping_source: 'admin' });
+    await slackDb.mapUser({ slack_user_id: slackUserId, workos_user_id: workosUserId, mapping_source: 'manual_admin' });
     expect(await getUserName(workosUserId)).toEqual({ first_name: 'Davide', last_name: 'Astuto' });
   });
 
   it('does nothing when the Slack mapping has no names', async () => {
     const workosUserId = await seedUser('f');
     const slackUserId = await seedSlackUser('f', { real: null, display: null });
-    await slackDb.mapUser({ slack_user_id: slackUserId, workos_user_id: workosUserId, mapping_source: 'admin' });
+    await slackDb.mapUser({ slack_user_id: slackUserId, workos_user_id: workosUserId, mapping_source: 'manual_admin' });
     expect(await getUserName(workosUserId)).toEqual({ first_name: null, last_name: null });
   });
 });

--- a/server/tests/unit/resolve-user-name.test.ts
+++ b/server/tests/unit/resolve-user-name.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Guards the WorkOS → DB → Slack fallback cascade. The cascade is what would
+ * have saved Tom Hespos and the 12 other learners from being silently issued
+ * credentials with empty recipient names (escalation #382): 8 of 11 of those
+ * users already had a Slack mapping with `slack_real_name`, but the OAuth
+ * callback never looked at it.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { resolveUserNameWithFallbacks } from '../../src/utils/resolve-user-name.js';
+
+type Row = {
+  first_name: string | null;
+  last_name: string | null;
+  slack_real_name: string | null;
+  slack_display_name: string | null;
+};
+
+function fakeDb(row: Row | null) {
+  return {
+    query: vi.fn().mockResolvedValue({ rows: row ? [row] : [] }),
+  };
+}
+
+describe('resolveUserNameWithFallbacks', () => {
+  it('uses WorkOS values when both are set', async () => {
+    const db = fakeDb(null);
+    const out = await resolveUserNameWithFallbacks(db, 'user_1', 'Tom', 'Hespos');
+    expect(out).toEqual({ firstName: 'Tom', lastName: 'Hespos' });
+    expect(db.query).not.toHaveBeenCalled();
+  });
+
+  it('preserves existing DB names when WorkOS sends null', async () => {
+    const db = fakeDb({
+      first_name: 'Existing',
+      last_name: 'Name',
+      slack_real_name: null,
+      slack_display_name: null,
+    });
+    const out = await resolveUserNameWithFallbacks(db, 'user_1', null, null);
+    expect(out).toEqual({ firstName: 'Existing', lastName: 'Name' });
+  });
+
+  it('falls back to slack_real_name when WorkOS + DB are both empty', async () => {
+    const db = fakeDb({
+      first_name: null,
+      last_name: null,
+      slack_real_name: 'Lillie Ratliff',
+      slack_display_name: 'lillie',
+    });
+    const out = await resolveUserNameWithFallbacks(db, 'user_1', null, null);
+    expect(out).toEqual({ firstName: 'Lillie', lastName: 'Ratliff' });
+  });
+
+  it('falls back to slack_display_name when real_name is missing', async () => {
+    const db = fakeDb({
+      first_name: null,
+      last_name: null,
+      slack_real_name: null,
+      slack_display_name: 'Daniel Di Tullio',
+    });
+    const out = await resolveUserNameWithFallbacks(db, 'user_1', null, null);
+    expect(out).toEqual({ firstName: 'Daniel', lastName: 'Di Tullio' });
+  });
+
+  it('handles single-word Slack names without inventing a last name', async () => {
+    const db = fakeDb({
+      first_name: null,
+      last_name: null,
+      slack_real_name: 'Cher',
+      slack_display_name: null,
+    });
+    const out = await resolveUserNameWithFallbacks(db, 'user_1', null, null);
+    expect(out).toEqual({ firstName: 'Cher', lastName: null });
+  });
+
+  it('keeps WorkOS first when only the last is empty', async () => {
+    const db = fakeDb({
+      first_name: 'DBfirst',
+      last_name: 'DBlast',
+      slack_real_name: 'Slack Name',
+      slack_display_name: null,
+    });
+    const out = await resolveUserNameWithFallbacks(db, 'user_1', 'Davide', null);
+    // Slack fallback only triggers when BOTH are empty after DB merge; here
+    // the DB had a last name, so we take WorkOS first + DB last.
+    expect(out).toEqual({ firstName: 'Davide', lastName: 'DBlast' });
+  });
+
+  it('returns null pair when nothing is available anywhere', async () => {
+    const db = fakeDb({
+      first_name: null,
+      last_name: null,
+      slack_real_name: null,
+      slack_display_name: null,
+    });
+    const out = await resolveUserNameWithFallbacks(db, 'user_1', null, null);
+    expect(out).toEqual({ firstName: null, lastName: null });
+  });
+
+  it('returns input WorkOS values when the user row does not exist yet', async () => {
+    const db = fakeDb(null);
+    const out = await resolveUserNameWithFallbacks(db, 'user_new', null, null);
+    expect(out).toEqual({ firstName: null, lastName: null });
+  });
+
+  it('treats whitespace-only WorkOS names as empty', async () => {
+    const db = fakeDb({
+      first_name: null,
+      last_name: null,
+      slack_real_name: 'Sydney Fuhrman',
+      slack_display_name: null,
+    });
+    const out = await resolveUserNameWithFallbacks(db, 'user_1', '   ', '   ');
+    expect(out).toEqual({ firstName: 'Sydney', lastName: 'Fuhrman' });
+  });
+});

--- a/server/tests/unit/resolve-user-name.test.ts
+++ b/server/tests/unit/resolve-user-name.test.ts
@@ -6,7 +6,7 @@
  * callback never looked at it.
  */
 import { describe, it, expect, vi } from 'vitest';
-import { resolveUserNameWithFallbacks } from '../../src/utils/resolve-user-name.js';
+import { resolveUserNameWithFallbacks, splitFullName, sanitizeName } from '../../src/utils/resolve-user-name.js';
 
 type Row = {
   first_name: string | null;
@@ -20,6 +20,66 @@ function fakeDb(row: Row | null) {
     query: vi.fn().mockResolvedValue({ rows: row ? [row] : [] }),
   };
 }
+
+describe('sanitizeName', () => {
+  it('strips Unicode direction-override characters', () => {
+    // U+202E (RIGHT-TO-LEFT OVERRIDE) — a spoofing surface on certificates
+    expect(sanitizeName('Tom‮Hespos')).toBe('TomHespos');
+  });
+
+  it('strips zero-width space', () => {
+    expect(sanitizeName('Tom​Hespos')).toBe('TomHespos');
+  });
+
+  it('strips C0 controls and DEL', () => {
+    expect(sanitizeName('Tom\x00\x07\x1f\x7fHespos')).toBe('TomHespos');
+  });
+
+  it('collapses internal whitespace but preserves multi-word names', () => {
+    expect(sanitizeName('Mary   Jane  Watson')).toBe('Mary Jane Watson');
+  });
+
+  it('caps at 255 characters', () => {
+    const result = sanitizeName('A'.repeat(300));
+    expect(result.length).toBe(255);
+  });
+
+  it('returns empty string for whitespace-only input', () => {
+    expect(sanitizeName('   \t\n   ')).toBe('');
+  });
+});
+
+describe('splitFullName', () => {
+  it('splits two-part names', () => {
+    expect(splitFullName('Tom Hespos')).toEqual({ firstName: 'Tom', lastName: 'Hespos' });
+  });
+
+  it('treats tab as whitespace, returning a clean last name', () => {
+    expect(splitFullName('Tom\tHespos')).toEqual({ firstName: 'Tom', lastName: 'Hespos' });
+  });
+
+  it('collapses double-space without leaving a leading space in last name', () => {
+    expect(splitFullName('Tom  Hespos')).toEqual({ firstName: 'Tom', lastName: 'Hespos' });
+  });
+
+  it('returns null last name for single-word input', () => {
+    expect(splitFullName('Cher')).toEqual({ firstName: 'Cher', lastName: null });
+  });
+
+  it('joins three+ word names into the last-name slot', () => {
+    expect(splitFullName('Daniel Di Tullio')).toEqual({ firstName: 'Daniel', lastName: 'Di Tullio' });
+  });
+
+  it('strips a Unicode direction-override from a Slack-controlled name', () => {
+    // Without stripping, "Tom‮Hespos" would render reversed on a PDF
+    expect(splitFullName('Tom‮ Hespos')).toEqual({ firstName: 'Tom', lastName: 'Hespos' });
+  });
+
+  it('returns empty pair for empty or whitespace-only input', () => {
+    expect(splitFullName('')).toEqual({ firstName: '', lastName: null });
+    expect(splitFullName('   ')).toEqual({ firstName: '', lastName: null });
+  });
+});
 
 describe('resolveUserNameWithFallbacks', () => {
   it('uses WorkOS values when both are set', async () => {


### PR DESCRIPTION
## Summary

Closes the root cause behind escalation #382 (Tom Hespos's "undefined undefined" credential) and the 12 other learners surfaced by the dry-run of the repair script that shipped in #4768.

Three coordinated changes — one to silently recover existing data, one to ask the user when we still can't, and one to keep the source of truth in sync:

1. **OAuth callback now applies the Slack-name fallback that the WorkOS webhook already had.** Of the 11 nameless users on prod, 8 already have a `slack_user_mappings.slack_real_name` we can split into first/last (Lillie Ratliff, Bryan Szekely, Ángel Ruiz, Ken Ripley, Sydney Fuhrman, Maithili Jalihal, Brian Gilbert, Daniel Di Tullio). Next sign-in silently backfills them. `server/src/http.ts:6504-6526`.
2. **Onboarding gates on a name.** For the residual case — no Slack mapping, no WorkOS profile — `/onboarding.html` shows a "What should we call you?" step before the rest of the flow. Submits to the existing `PUT /api/me/name`. `server/public/onboarding.html`.
3. **`PUT /api/me/name` pushes back to WorkOS** via `userManagement.updateUser`, so the next webhook can't overwrite our local update with empty values. `server/src/http.ts:7343-7398`.

The cascade (WorkOS → existing DB → Slack) is extracted into `server/src/utils/resolve-user-name.ts` so the auth callback and the user.updated webhook can't drift; the webhook now calls the same helper.

## Why this matters

Today: a learner can earn an AdCP credential without ever having a name in WorkOS or our `users` table — they sign in via Slack-linked WorkOS auth or magic-link, never fill in name fields, and the credential issues with "undefined undefined" on the certificate. The repair script in #4768 cleans up after the fact; this PR stops it happening at all.

## Test plan
- [x] `npx vitest run tests/unit/resolve-user-name.test.ts` — 9 cases (existing DB preserve, Slack real_name fallback, slack_display_name fallback, single-word names, partial WorkOS data, whitespace-only WorkOS values, no row in DB, etc.)
- [x] `npx vitest run tests/unit/workos-webhook-email-refresh.test.ts tests/unit/workos-webhook-user-deleted-wiring.test.ts` — webhook regression coverage, 8/8 still pass after extracting the cascade
- [x] `npm run typecheck` clean
- [x] Precommit (test:unit + dynamic-imports + callapi-state-change + typecheck) green
- [ ] Post-merge: dry-run the repair script from #4768 to see how many of the 11 email-fallback users we can now upgrade after one sign-in cycle
  - `fly ssh console -a adcp-docs -C 'node /app/dist/scripts/repair-credential-recipient-names.js'`
- [ ] Manually exercise the onboarding gate (sign in as a test user with null name, verify the form blocks, verify saved name shows up in WorkOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)