### PR TITLE
ci(deploy): /health fallback + forensics capture for transient Fly API timeouts (closes #4780)

### DIFF
--- a/.changeset/deploy-yml-resilience.md
+++ b/.changeset/deploy-yml-resilience.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+deploy.yml resilience: when `flyctl deploy` exits non-zero, probe `https://adcontextprotocol.org/health` before failing. If the app responds 200, treat the deploy as fallback-success (Fly machines API issue, not an app issue), skip Fly-API-dependent gates, and continue. Real app failures still hard-fail. Always capture `flyctl status` / `machines list` / `releases` / `logs` as a workflow artifact on failure for next-turn forensics. Closes #4780.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,19 +78,23 @@ jobs:
           echo "::warning::flyctl deploy exited ${deploy_exit} — probing /health to distinguish API timeout from real failure"
           # Give Fly's edge a moment to settle in case rolling-restart is still in flight.
           sleep 10
-          health_code=$(curl -sS -o /tmp/health.json -w '%{http_code}' --max-time 15 https://adcontextprotocol.org/health || echo "000")
-          echo "adcontextprotocol.org/health → ${health_code}"
+          # Probe the Fly hostname directly, not the Cloudflare-fronted
+          # public hostname. Cloudflare can cache /health responses and
+          # a stale 200 would mask a real outage. The Fly hostname bypasses
+          # CDN and reflects the actual app state on the machine.
+          health_code=$(curl -sS -o /tmp/health.json -w '%{http_code}' --max-time 15 https://adcp-docs.fly.dev/health || echo "000")
+          echo "adcp-docs.fly.dev/health -> ${health_code}"
           if [ -s /tmp/health.json ]; then
             echo "Body (first 500 chars):"
             head -c 500 /tmp/health.json
             echo
           fi
-          if [ "$health_code" = "200" ]; then
-            echo "::warning::App is reachable (/health=200). Treating as fallback-success — the verification gate ran into a Fly API issue, not an app issue."
+          if [ "${health_code}" = "200" ]; then
+            echo "::warning::App is reachable on the Fly hostname (/health=200). Treating as fallback-success — the verification gate ran into a Fly API issue, not an app issue."
             echo "deploy_outcome=fallback-success" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "::error::flyctl deploy failed AND /health=${health_code} — real failure."
+          echo "::error::flyctl deploy failed AND adcp-docs.fly.dev/health=${health_code} — real failure."
           echo "deploy_outcome=hard-fail" >> "$GITHUB_OUTPUT"
           exit 1
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,12 +49,56 @@ jobs:
       - name: Setup Fly CLI
         uses: superfly/flyctl-actions/setup-flyctl@1.6
 
+      # flyctl deploy can fail for two very different reasons:
+      #   1. The new image is broken (real failure — must block).
+      #   2. Fly's machines API was unreachable during health-check polling
+      #      (transient — the app may already be healthy on the new image).
+      # v2760 on 2026-05-19 was case 2: app served 200 throughout while
+      # flyctl timed out polling the third machine because the machines API
+      # was rate-limited from the earlier crashloop storm. The post-deploy
+      # gates never ran. To distinguish, on failure we hit /health directly
+      # — the same signal end users see — and only hard-fail if the app
+      # itself is unreachable. The "verify all machines on same image" gate
+      # below depends on the machines API, so it gates itself on
+      # `deploy_outcome != fallback-success`. The tenant smoke runs over
+      # plain HTTP and stays unconditional.
       - name: Deploy
-        run: flyctl deploy --remote-only --wait-timeout 300
+        id: deploy
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          set +e
+          flyctl deploy --remote-only --wait-timeout 300
+          deploy_exit=$?
+          set -e
+          if [ $deploy_exit -eq 0 ]; then
+            echo "deploy_outcome=success" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "::warning::flyctl deploy exited ${deploy_exit} — probing /health to distinguish API timeout from real failure"
+          # Give Fly's edge a moment to settle in case rolling-restart is still in flight.
+          sleep 10
+          health_code=$(curl -sS -o /tmp/health.json -w '%{http_code}' --max-time 15 https://adcontextprotocol.org/health || echo "000")
+          echo "adcontextprotocol.org/health → ${health_code}"
+          if [ -s /tmp/health.json ]; then
+            echo "Body (first 500 chars):"
+            head -c 500 /tmp/health.json
+            echo
+          fi
+          if [ "$health_code" = "200" ]; then
+            echo "::warning::App is reachable (/health=200). Treating as fallback-success — the verification gate ran into a Fly API issue, not an app issue."
+            echo "deploy_outcome=fallback-success" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "::error::flyctl deploy failed AND /health=${health_code} — real failure."
+          echo "deploy_outcome=hard-fail" >> "$GITHUB_OUTPUT"
+          exit 1
 
       - name: Verify all app machines are on same image
+        # Skipped on the fallback path because this gate also goes through
+        # the Fly machines API — if that's what timed out above, it'll time
+        # out again here.
+        if: steps.deploy.outputs.deploy_outcome != 'fallback-success'
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |
@@ -176,3 +220,33 @@ jobs:
           else
             echo "No stale console machines found"
           fi
+
+      # On any failure (hard or fallback-with-degraded-gates), snapshot Fly
+      # state so the next-turn investigator doesn't have to fetch it
+      # manually. v2760 on 2026-05-19 cost an extra debugging cycle because
+      # the log was already past the retention horizon by the time we
+      # opened it. Cheap to run, free if not needed.
+      - name: Capture Fly forensics on failure
+        if: failure()
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          mkdir -p /tmp/forensics
+          flyctl status -a adcp-docs > /tmp/forensics/fly-status.txt 2>&1 || true
+          flyctl machines list -a adcp-docs --json > /tmp/forensics/fly-machines.json 2>&1 || true
+          flyctl releases -a adcp-docs > /tmp/forensics/fly-releases.txt 2>&1 || true
+          flyctl logs -a adcp-docs --no-tail 2>&1 | tail -500 > /tmp/forensics/fly-logs-tail.txt || true
+          # Capture the deploy-outcome we computed so the artifact is
+          # self-describing in 30 days.
+          echo "deploy_outcome=${{ steps.deploy.outputs.deploy_outcome }}" > /tmp/forensics/summary.txt
+          echo "github_sha=${{ github.sha }}" >> /tmp/forensics/summary.txt
+          echo "github_run_id=${{ github.run_id }}" >> /tmp/forensics/summary.txt
+          ls -la /tmp/forensics/
+
+      - name: Upload Fly forensics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fly-forensics-${{ github.run_id }}
+          path: /tmp/forensics/
+          retention-days: 30

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,14 +76,20 @@ jobs:
             exit 0
           fi
           echo "::warning::flyctl deploy exited ${deploy_exit} — probing /health to distinguish API timeout from real failure"
-          # Give Fly's edge a moment to settle in case rolling-restart is still in flight.
-          sleep 10
           # Probe the Fly hostname directly, not the Cloudflare-fronted
           # public hostname. Cloudflare can cache /health responses and
           # a stale 200 would mask a real outage. The Fly hostname bypasses
           # CDN and reflects the actual app state on the machine.
-          health_code=$(curl -sS -o /tmp/health.json -w '%{http_code}' --max-time 15 https://adcp-docs.fly.dev/health || echo "000")
-          echo "adcp-docs.fly.dev/health -> ${health_code}"
+          # Retry a few times in case the rolling restart hasn't settled —
+          # a healthy app reaches /health=200 within a couple of seconds
+          # once at least one machine is reachable.
+          health_code="000"
+          for attempt in 1 2 3 4; do
+            sleep 5
+            health_code=$(curl -sS -o /tmp/health.json -w '%{http_code}' --max-time 15 https://adcp-docs.fly.dev/health || echo "000")
+            echo "attempt ${attempt}: adcp-docs.fly.dev/health -> ${health_code}"
+            if [ "${health_code}" = "200" ]; then break; fi
+          done
           if [ -s /tmp/health.json ]; then
             echo "Body (first 500 chars):"
             head -c 500 /tmp/health.json
@@ -106,6 +112,10 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |
+          # pipefail so a silent flyctl failure (empty $images, count=0)
+          # surfaces as a real failure instead of being misread as
+          # "no running web/worker machines."
+          set -eo pipefail
           echo "Checking that all app machines are running the same image..."
 
           # Get image digests for started machines (web + worker process groups)
@@ -239,12 +249,22 @@ jobs:
           flyctl status -a adcp-docs > /tmp/forensics/fly-status.txt 2>&1 || true
           flyctl machines list -a adcp-docs --json > /tmp/forensics/fly-machines.json 2>&1 || true
           flyctl releases -a adcp-docs > /tmp/forensics/fly-releases.txt 2>&1 || true
-          flyctl logs -a adcp-docs --no-tail 2>&1 | tail -500 > /tmp/forensics/fly-logs-tail.txt || true
+          # Boot logs have historically contained JWT fragments, idempotency
+          # keys, and SDK init lines that echo env-derived config. The
+          # artifact is repo-readable for 30 days, so redact obvious secret
+          # shapes before persisting. This is best-effort — anything truly
+          # secret-shaped that doesn't match these patterns will still slip
+          # through, but most known leakage shapes are covered.
+          flyctl logs -a adcp-docs --no-tail 2>&1 \
+            | tail -500 \
+            | grep -v -iE 'authorization|bearer |authn=|secret|password|api[-_]?key|sk-[a-z0-9]|wos_[a-z0-9]|fly_[a-z0-9]{20,}|eyJ[A-Za-z0-9_-]{10,}\.eyJ' \
+            > /tmp/forensics/fly-logs-tail.txt || true
           # Capture the deploy-outcome we computed so the artifact is
           # self-describing in 30 days.
           echo "deploy_outcome=${{ steps.deploy.outputs.deploy_outcome }}" > /tmp/forensics/summary.txt
           echo "github_sha=${{ github.sha }}" >> /tmp/forensics/summary.txt
           echo "github_run_id=${{ github.run_id }}" >> /tmp/forensics/summary.txt
+          echo "note=fly-logs-tail.txt filtered for common secret shapes (Bearer/sk-/wos_/JWT/etc). Not exhaustive — treat as read-only." >> /tmp/forensics/summary.txt
           ls -la /tmp/forensics/
 
       - name: Upload Fly forensics


### PR DESCRIPTION
## Summary

Closes #4780. Surfaced by today's outage post-mortem (PRs #4769 hotfix, #4773 structural fix).

v2760 (the hotfix release) was marked \`failed\` in Fly's release ledger because \`flyctl deploy\` timed out at 5 minutes polling the third web machine's health (\`net/http: request canceled\` against \`api.machines.dev\`). The Fly machines API was rate-limited from the earlier crashloop storm. The **app itself was healthy** — \`adcontextprotocol.org\` served 200 throughout — but the deploy job exited 1 and the post-deploy verification gates (machine-image-consistency, training-agent tenant smoke, stale-console cleanup) never ran.

## Changes

1. **\`Deploy\` step** captures \`flyctl deploy\` exit code instead of letting it short-circuit the job. On non-zero, probes \`https://adcontextprotocol.org/health\` and stores outcome in step output \`deploy_outcome\`:
   - \`success\` — flyctl exited 0
   - \`fallback-success\` — flyctl failed but \`/health=200\`. Warning, continue.
   - \`hard-fail\` — flyctl failed and \`/health!=200\`. Exit 1.
2. **\`Verify all app machines are on same image\`** now skips on \`fallback-success\` — that gate also goes through the Fly machines API (the thing that timed out in the first place).
3. **\`Smoke training-agent tenants\`** unchanged. Uses external HTTP, independent of Fly API.
4. **Forensics capture** on any failure: \`flyctl status\`, \`machines list --json\`, \`releases\`, last 500 lines of \`flyctl logs\`, plus a summary file with \`deploy_outcome\`, SHA, run ID. Uploaded as artifact \`fly-forensics-{run_id}\` with 30-day retention. Today's incident cost a debug cycle because Fly log retention is short.

## Test plan

- [ ] CI green
- [ ] On merge: next \`flyctl deploy\` happy path completes as \`success\` (deploy_outcome=success), all gates run, no artifact uploaded (failure() didn't trigger)
- [ ] Eventually: when next transient Fly API issue happens, the workflow logs \`fallback-success\` and the tenant smoke still runs

## Risk

Bounded to the deploy workflow. Doesn't affect prod runtime. The conservative direction: if /health is genuinely down AND flyctl timed out, we still hard-fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)