### PR TITLE
fix(migrations): retire 8.7MB Scope3 seed in migration 206 (closes #4778)

### DIFF
--- a/.changeset/drop-seed-properties-migration.md
+++ b/.changeset/drop-seed-properties-migration.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Retire the 8.7 MB Scope3 publisher seed in migration 206. The migration body becomes a no-op (`SELECT 1`) — the data was a one-shot 2026-02-12 Scope3 BigQuery export of 1,250 publishers / 53,422 properties / 62,440 identifiers that aged into a stale snapshot in every runtime image. Production environments retain the data (the migration already ran months ago; Postgres doesn't re-run applied versions). Fresh installs start with an empty `hosted_properties` table and populate via the normal user-claim and discovery-crawler paths. Drops ~9 MB from every shipped image. Closes #4778.

--- a/server/src/db/migrations/206_seed_properties.sql
+++ b/server/src/db/migrations/206_seed_properties.sql
@@ -18,6 +18,10 @@
 --
 -- See: issue #4778 for the retirement rationale, PR #4773 (Dockerfile asset
 -- hygiene that surfaced the 8.7 MB blob).
+--
+-- Salvage path: the original 1,250 publisher / 53,422 property / 62,440
+-- identifier dataset is preserved in git history. To recover it:
+--   git show 89619fb060:server/src/db/migrations/206_seed_properties.sql
 
 -- intentional no-op; keep the version slot so schema_migrations stays linear
 SELECT 1;


### PR DESCRIPTION
## Summary

Closes #4778. Surfaced during PR #4773 review (Dockerfile asset hygiene).

\`server/src/db/migrations/206_seed_properties.sql\` was a 8.7 MB one-shot Scope3 BigQuery export from 2026-02-12 (1,250 publishers / 53,422 properties / 62,440 identifiers) that shipped in every runtime image and aged into a stale snapshot.

## What changes

The migration body becomes a no-op (\`SELECT 1;\`). The version slot (206) is preserved so \`schema_migrations\` stays linear in already-applied environments.

- **Prod is unaffected.** The migration already ran months ago in every environment. Postgres doesn't re-run applied versions, so prod keeps the rows it has in \`hosted_properties\`.
- **Fresh installs start empty.** \`hosted_properties\` populates via two production paths that don't depend on this seed:
  - User claims keyed by \`workos_organization_id\` / \`created_by_user_id\` (the registry API)
  - Discovery crawler writing to \`discovered_properties\` (separate table), feeding \`catalog_properties\` via migration 336
- **Tests don't depend on the seeded rows.** All hosted_properties test fixtures use \`DELETE WHERE publisher_domain LIKE ...\` cleanup and \`INSERT\` their own rows. No test references \`1001fonts.com\`, \`111percent.net\`, or any other seeded domain.

## Why retire rather than fixture

The seed served as "starter content for the registry so it isn't empty." It's not load-bearing for the protocol or for any feature — the CRUD code does scoped lookups (by id, domain, org), not bulk reads. What degrades without it is the registry-discovery UX (autocomplete, "is this domain known?" lookups) — a feature, not a hard dependency. Refreshing fixtures from a curated handful is a separate, deferrable concern.

## Test plan

- [ ] CI green, including \`Built migrations against Postgres\` (applies the new no-op stub to a fresh postgres)
- [ ] CI \`Server integration tests\` still green (tests insert their own fixtures)
- [ ] Image size reduction visible on next deploy (~9 MB less)
- [ ] Prod \`hosted_properties\` row count unchanged after deploy

## Risk

The fresh-install path loses the 53k-row starter content. Mitigation: that data is reproducible via the discovery crawler (which is the architecturally correct source — it writes to \`discovered_properties\`, not \`hosted_properties\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)