### PR TITLE
feat(brand-claim): signup-domain → claim suggestion (closes #4744)

### DIFF
--- a/.changeset/4744-signup-claim-suggestion.md
+++ b/.changeset/4744-signup-claim-suggestion.md
@@ -1,0 +1,34 @@
+---
+---
+
+feat(brand-claim): signup-domain → claim suggestion (closes #4744)
+
+Implements Brian's KYC framing from the 2026-05-18 Slack thread: when a user signs up with a verified email domain that matches a brand in the registry, nudge them to claim it. Three surfaces:
+
+**1. Dashboard banner.** Soft, dismissible banner on `/dashboard` for any user whose signup domain matches a registry brand. Links to `/brand/builder?domain=…` (the existing claim flow, #4742). Dismissal records a **30-day cooldown** in a new `user_dismissed_nudges` table; the banner reappears after that or on any of the re-surface triggers from #4765.
+
+**2. Just-in-time prompt on `/brand/view/{domain}`.** Same banner, scoped: only fires when the brand being viewed equals the user's verified email domain. Highest-intent moment — the user is literally looking at "their" brand.
+
+**3. Slack notify to ops** on every signup whose verified email domain matches a registry brand. Fires via `notifyBrandClaimOpportunity()`. No threshold today — volume is low and we want maximum visibility into who's signing up at known brands. Throttle later if needed.
+
+**Suppression rules** (per #4765 design discussion):
+- Free email domains (gmail, etc.) — never suggest.
+- Brand verified by caller's own org — already done, skip.
+- Brand verified by another org — claim would collision-fail at the DNS step, skip.
+- User dismissed within 30 days — suggestion still returns but `active: false`.
+
+**Delegation is orthogonal.** Per the design discussion, we deliberately don't try to handle holding-co / agency / consultant scenarios here. Those go through #4747's delegated-grant flow (planned) or the brand-owning org adding the user to their WorkOS org. The signup-domain-claim flow stays narrow: "you control this domain, want to claim it?"
+
+**Endpoints**
+- `GET /api/me/brand-claim-suggestion` — returns `{ suggestion: { domain, brand_name, active, dismissed_at?, claim_url, view_url } | null }`. Pass `?domain=…` to scope to a specific brand (drives the JIT prompt).
+- `POST /api/me/brand-claim-suggestion/dismiss` — records a 30-day cooldown for the `(user, domain)` pair.
+
+**Storage**
+- New `user_dismissed_nudges` table (migration 485) — generic, reusable for future in-app nudges. PK `(workos_user_id, nudge_key)`.
+
+**Tests**
+15 unit tests pin the suppression matrix (free email, no brand, own-org owned, other-org owned, unclaimed), the cooldown semantics (within 30d → inactive; older than 30d → active again), endpoint canonicalization, scoped JIT lookup, and the dismiss roundtrip.
+
+**Out of scope**
+- The re-surface triggers from #4765 Q8 (someone else's claim attempt, brand-viewer first visit, new auth session) — needs additional event plumbing; cooldown-based re-fire covers the baseline.
+- Cross-org delegation (#4747).

--- a/server/public/brand-viewer.html
+++ b/server/public/brand-viewer.html
@@ -1231,6 +1231,49 @@
       </div>
     </section>
 
+    <!-- Just-in-time claim suggestion (#4744). Fires only when the
+         viewer's verified email domain matches this brand. -->
+    <div class="container" style="padding-top: var(--space-6); padding-bottom: 0;">
+      <div id="claim-suggestion-banner" class="hidden" style="
+          background: linear-gradient(135deg, var(--color-info-50, #eff6ff), var(--color-bg-card));
+          border: var(--border-1) solid var(--color-info-200, #bfdbfe);
+          border-left: var(--border-4) solid var(--color-info-500, #3b82f6);
+          border-radius: var(--radius-md);
+          padding: var(--space-4) var(--space-5);
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: var(--space-4);
+          flex-wrap: wrap;
+        ">
+        <div style="flex: 1; min-width: 240px;">
+          <strong style="display: block; color: var(--color-text-heading); margin-bottom: 4px;">This looks like your brand</strong>
+          <span style="color: var(--color-text-secondary); font-size: var(--text-sm);">You signed up from this domain — verify ownership to manage the brand entry.</span>
+        </div>
+        <div style="display: flex; gap: var(--space-2); align-items: center;">
+          <a id="claim-suggestion-cta" class="btn btn-primary" href="#" style="
+              padding: 6px 14px;
+              font-size: var(--text-sm);
+              font-weight: var(--font-semibold);
+              background: var(--color-brand);
+              color: white;
+              border: none;
+              border-radius: var(--radius-md);
+              text-decoration: none;
+              white-space: nowrap;
+            ">Claim this brand</a>
+          <button id="claim-suggestion-dismiss" type="button" style="
+              padding: 6px 12px;
+              font-size: var(--text-sm);
+              background: transparent;
+              color: var(--color-text-muted);
+              border: none;
+              cursor: pointer;
+            " title="Dismiss for 30 days">Dismiss</button>
+        </div>
+      </div>
+    </div>
+
     <!-- Main content -->
     <div class="container" style="padding-top: var(--space-8); padding-bottom: var(--space-16);">
       <!-- Loading state -->
@@ -2400,6 +2443,43 @@
         }
       }
 
+      // Just-in-time claim prompt (#4744). Fires on /brand/view/{domain}
+      // when the viewer's verified email domain equals {domain} AND the
+      // brand isn't already verified-owned. Highest-intent moment — the
+      // user is literally looking at "their" brand page.
+      async function loadClaimSuggestion(domain) {
+        const banner = document.getElementById('claim-suggestion-banner');
+        if (!banner) return;
+        try {
+          const resp = await fetch(
+            `/api/me/brand-claim-suggestion?domain=${encodeURIComponent(domain)}`,
+            { credentials: 'include' },
+          );
+          if (!resp.ok) return;
+          const { suggestion } = await resp.json();
+          if (!suggestion || !suggestion.active) return;
+          const cta = document.getElementById('claim-suggestion-cta');
+          if (cta && suggestion.claim_url) cta.setAttribute('href', suggestion.claim_url);
+          const dismiss = document.getElementById('claim-suggestion-dismiss');
+          if (dismiss) {
+            dismiss.onclick = async () => {
+              banner.classList.add('hidden');
+              try {
+                await fetch('/api/me/brand-claim-suggestion/dismiss', {
+                  method: 'POST',
+                  credentials: 'include',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ domain }),
+                });
+              } catch (err) { /* non-critical */ }
+            };
+          }
+          banner.classList.remove('hidden');
+        } catch (err) {
+          // Non-fatal.
+        }
+      }
+
       async function loadOwnership(domain) {
         const row = document.getElementById('ownership-row');
         const badge = document.getElementById('ownership-badge');
@@ -2458,6 +2538,13 @@
         // Render the ownership badge + Claim/Manage CTA. Fire-and-forget so a
         // slow lookup never blocks the rest of the page.
         loadOwnership(domain);
+        // Just-in-time claim suggestion (#4744). Fires only when the
+        // viewer's verified email domain matches the brand they're
+        // looking at. Endpoint short-circuits to null otherwise so the
+        // call is safe to make unconditionally.
+        if (window.__APP_CONFIG__?.user) {
+          loadClaimSuggestion(domain);
+        }
 
         // Show refresh button for logged-in users
         if (window.__APP_CONFIG__?.user) {

--- a/server/public/dashboard.html
+++ b/server/public/dashboard.html
@@ -496,6 +496,49 @@
 
     <div id="content" style="display:none;">
 
+      <!-- Brand-claim suggestion banner (#4744) — fired when the user's
+           verified email domain matches a brand in the registry that they
+           haven't claimed yet. Soft, dismissible (30-day cooldown). -->
+      <div id="brand-claim-banner" class="hidden" style="
+          background: linear-gradient(135deg, var(--color-info-50, #eff6ff), var(--color-bg-card));
+          border: var(--border-1) solid var(--color-info-200, #bfdbfe);
+          border-left: var(--border-4) solid var(--color-info-500, #3b82f6);
+          border-radius: var(--radius-md);
+          padding: var(--space-4) var(--space-5);
+          margin-bottom: var(--space-6);
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: var(--space-4);
+          flex-wrap: wrap;
+        ">
+        <div style="flex: 1; min-width: 280px;">
+          <strong id="brand-claim-banner-title" style="display: block; color: var(--color-text-heading); margin-bottom: 4px;"></strong>
+          <span id="brand-claim-banner-body" style="color: var(--color-text-secondary); font-size: var(--text-sm);"></span>
+        </div>
+        <div style="display: flex; gap: var(--space-2); align-items: center;">
+          <a id="brand-claim-banner-cta" class="btn btn-primary" href="#" style="
+              padding: 6px 14px;
+              font-size: var(--text-sm);
+              font-weight: var(--font-semibold);
+              background: var(--color-brand);
+              color: white;
+              border: none;
+              border-radius: var(--radius-md);
+              text-decoration: none;
+              white-space: nowrap;
+            ">Claim this brand</a>
+          <button id="brand-claim-banner-dismiss" type="button" style="
+              padding: 6px 12px;
+              font-size: var(--text-sm);
+              background: transparent;
+              color: var(--color-text-muted);
+              border: none;
+              cursor: pointer;
+            " title="Dismiss for 30 days">Dismiss</button>
+        </div>
+      </div>
+
       <!-- Dashboard section styles -->
       <style>
         .dashboard-section {
@@ -4185,11 +4228,51 @@
         document.getElementById('loading').style.display = 'none';
         document.getElementById('content').style.display = 'block';
 
+        // Fire-and-forget: brand-claim suggestion banner (#4744).
+        loadBrandClaimSuggestion();
+
       } catch (error) {
         console.error('Error loading user data:', error);
         document.getElementById('loading').innerHTML = `
           <p style="color: var(--color-error-600);">Failed to load dashboard. <a href="/auth/login">Try logging in again</a></p>
         `;
+      }
+    }
+
+    // ─── Brand-claim suggestion banner (#4744) ────────────────────────
+    async function loadBrandClaimSuggestion() {
+      const banner = document.getElementById('brand-claim-banner');
+      if (!banner) return;
+      try {
+        const resp = await fetch('/api/me/brand-claim-suggestion', { credentials: 'include' });
+        if (!resp.ok) return;
+        const { suggestion } = await resp.json();
+        if (!suggestion || !suggestion.active) return;
+
+        const brand = suggestion.brand_name || suggestion.domain;
+        document.getElementById('brand-claim-banner-title').textContent =
+          `Claim ${brand}?`;
+        document.getElementById('brand-claim-banner-body').textContent =
+          `You signed up from this domain. Verify ownership to manage the brand on AAO.`;
+        const cta = document.getElementById('brand-claim-banner-cta');
+        cta.setAttribute('href', suggestion.claim_url);
+        const dismiss = document.getElementById('brand-claim-banner-dismiss');
+        dismiss.onclick = async () => {
+          banner.classList.add('hidden');
+          try {
+            await fetch('/api/me/brand-claim-suggestion/dismiss', {
+              method: 'POST',
+              credentials: 'include',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ domain: suggestion.domain }),
+            });
+          } catch (err) {
+            // Non-critical — the banner is already hidden client-side.
+          }
+        };
+        banner.classList.remove('hidden');
+      } catch (err) {
+        // Non-fatal — leave the banner hidden.
       }
     }
 

--- a/server/src/db/migrations/485_user_dismissed_nudges.sql
+++ b/server/src/db/migrations/485_user_dismissed_nudges.sql
@@ -1,0 +1,22 @@
+-- Generic per-user dismissed-nudges state for in-app banners and prompts.
+-- First consumer: brand-claim suggestion (#4744). Designed to be reusable
+-- for future dashboard / viewer nudges without further schema churn.
+--
+-- nudge_key namespacing convention: `<feature>:<scope>`, e.g.
+--   brand_claim_suggestion:scope3.com
+--   onboarding:welcome
+--
+-- Re-dismissal updates dismissed_at — the 30-day re-surface cooldown is a
+-- read-side concern (caller computes `NOW() - dismissed_at < interval`).
+-- Storing only the latest dismissal keeps the table small and the read
+-- query trivial.
+
+CREATE TABLE IF NOT EXISTS user_dismissed_nudges (
+  workos_user_id VARCHAR(255) NOT NULL,
+  nudge_key      TEXT         NOT NULL,
+  dismissed_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (workos_user_id, nudge_key)
+);
+
+-- Lookup by user is the only access pattern (dashboard load reads "what
+-- did this user dismiss"). PK already covers it.

--- a/server/src/db/user-nudges-db.ts
+++ b/server/src/db/user-nudges-db.ts
@@ -1,0 +1,53 @@
+/**
+ * Per-user dismissed-nudges state.
+ *
+ * Tracks when a user dismissed a soft banner / in-app prompt so the
+ * caller can implement a re-surface cooldown without each feature
+ * building its own dismissal table. First consumer: brand-claim
+ * suggestion (#4744).
+ *
+ * nudge_key namespacing convention: `<feature>:<scope>`. The scope is
+ * optional — `onboarding:welcome` and `brand_claim_suggestion:scope3.com`
+ * both work. Re-dismissal updates `dismissed_at` so the cooldown clock
+ * resets, which is the legible behaviour for a user clicking "dismiss"
+ * a second time.
+ */
+
+import { query } from './client.js';
+
+export interface DismissedNudge {
+  workos_user_id: string;
+  nudge_key: string;
+  dismissed_at: Date;
+}
+
+export async function recordNudgeDismissal(
+  workosUserId: string,
+  nudgeKey: string,
+): Promise<void> {
+  await query(
+    `INSERT INTO user_dismissed_nudges (workos_user_id, nudge_key, dismissed_at)
+     VALUES ($1, $2, NOW())
+     ON CONFLICT (workos_user_id, nudge_key)
+     DO UPDATE SET dismissed_at = NOW()`,
+    [workosUserId, nudgeKey],
+  );
+}
+
+/**
+ * Return the most recent dismissal for the given user/key, or null if
+ * the user has never dismissed it. Caller decides whether the cooldown
+ * is still active — `NOW() - dismissed_at < interval`.
+ */
+export async function getNudgeDismissal(
+  workosUserId: string,
+  nudgeKey: string,
+): Promise<DismissedNudge | null> {
+  const result = await query<DismissedNudge>(
+    `SELECT workos_user_id, nudge_key, dismissed_at
+       FROM user_dismissed_nudges
+      WHERE workos_user_id = $1 AND nudge_key = $2`,
+    [workosUserId, nudgeKey],
+  );
+  return result.rows[0] ?? null;
+}

--- a/server/src/db/user-nudges-db.ts
+++ b/server/src/db/user-nudges-db.ts
@@ -1,10 +1,13 @@
 /**
- * Per-user dismissed-nudges state.
+ * Per-user dismissed-nudges state — and, by extension, per-user fire-once
+ * markers for system events keyed off the same primitive.
  *
  * Tracks when a user dismissed a soft banner / in-app prompt so the
  * caller can implement a re-surface cooldown without each feature
- * building its own dismissal table. First consumer: brand-claim
- * suggestion (#4744).
+ * building its own dismissal table. Also used as a dedupe table for
+ * fire-once-per-(user,event) Slack notifications — same shape, different
+ * semantics. Use a distinct `nudge_key` prefix to keep the two uses
+ * unambiguous when reading the table by hand.
  *
  * nudge_key namespacing convention: `<feature>:<scope>`. The scope is
  * optional — `onboarding:welcome` and `brand_claim_suggestion:scope3.com`

--- a/server/src/db/users-db.ts
+++ b/server/src/db/users-db.ts
@@ -214,6 +214,19 @@ export class UsersDatabase {
  * Cross-org auth code that relies on a deterministic "primary" should
  * tolerate the user changing primary across membership additions.
  */
+/**
+ * Lookup a user's email from the canonical `users` table by WorkOS id.
+ * Returns null when the user row doesn't exist (e.g. during the brief
+ * window between WorkOS user.created webhook and our upsert).
+ */
+export async function getUserEmailById(workosUserId: string): Promise<string | null> {
+  const result = await query<{ email: string }>(
+    `SELECT email FROM users WHERE workos_user_id = $1`,
+    [workosUserId],
+  );
+  return result.rows[0]?.email ?? null;
+}
+
 export async function resolvePreferredOrganization(workosUserId: string): Promise<string | null> {
   const result = await query<{ workos_organization_id: string }>(
     `SELECT om.workos_organization_id

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -101,6 +101,7 @@ import { createCommitteeRouters } from "./routes/committees.js";
 import { createContentRouter, createMyContentRouter } from "./routes/content.js";
 import { createMeetingRouters } from "./routes/meetings.js";
 import { createMemberProfileRouter, createAdminMemberProfileRouter } from "./routes/member-profiles.js";
+import { createBrandClaimSuggestionRouter } from "./routes/me-brand-claim-suggestion.js";
 import { createMemberAgentsRouter } from "./routes/member-agents.js";
 import { createMeOrganizationDomainsRouter } from "./routes/me-organization-domains.js";
 import { createPublicPortraitRouter, createPortraitRouter, createAdminPortraitRouter } from "./routes/portraits.js";
@@ -1238,6 +1239,10 @@ export class HTTPServer {
     };
     const memberProfileRouter = createMemberProfileRouter(memberProfileConfig);
     this.app.use('/api/me/member-profile', memberProfileRouter); // User profile routes: /api/me/member-profile/*
+
+    // Brand-claim suggestion endpoints — drives the signup-domain → claim
+    // nudge on the dashboard banner and brand-viewer JIT prompt (#4744).
+    this.app.use('/api/me', createBrandClaimSuggestionRouter({ brandDb: this.brandDb }));
     const adminMemberProfileRouter = createAdminMemberProfileRouter(memberProfileConfig);
     this.app.use('/api/admin/member-profiles', adminMemberProfileRouter); // Admin profile routes: /api/admin/member-profiles/*
 

--- a/server/src/notifications/registry.ts
+++ b/server/src/notifications/registry.ts
@@ -72,6 +72,70 @@ export async function notifyRegistryEdit(edit: {
 }
 
 /**
+ * Notify ops when a new user signs up whose verified email domain
+ * matches a brand in our registry — the KYC signal Brian flagged in
+ * the brand-claim follow-up (#4744). At today's signup volume we
+ * notify on every match regardless of brand verification state so ops
+ * can watch the funnel; later we can threshold by signal value.
+ *
+ * Fire-and-forget at the call site — never block the webhook response.
+ */
+export async function notifyBrandClaimOpportunity(opportunity: {
+  user_email: string;
+  user_first_name?: string;
+  user_last_name?: string;
+  domain: string;
+  brand_name?: string | null;
+  brand_view_url: string;
+  brand_already_verified: boolean;
+  verified_owner_org_name?: string | null;
+}): Promise<void> {
+  const channelId = getChannelId();
+  if (!channelId || !isSlackConfigured()) return;
+
+  const display = [opportunity.user_first_name, opportunity.user_last_name]
+    .filter(Boolean)
+    .join(' ')
+    || opportunity.user_email;
+  const brandLabel = opportunity.brand_name
+    ? `${opportunity.brand_name} (${opportunity.domain})`
+    : opportunity.domain;
+  const statusLine = opportunity.brand_already_verified
+    ? `_Brand is already verified-owned${opportunity.verified_owner_org_name ? ` by *${opportunity.verified_owner_org_name}*` : ''} — claim won't fire._`
+    : `_Brand is unclaimed — signup will see a claim suggestion._`;
+
+  const message: SlackBlockMessage = {
+    text: `🪪 New signup matches brand: ${opportunity.user_email} → ${opportunity.domain}`,
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `🪪 *New signup matches a registry brand* — <${APP_URL}${opportunity.brand_view_url}|${brandLabel}>`,
+        },
+      },
+      {
+        type: 'section',
+        fields: [
+          { type: 'mrkdwn', text: `*User:*\n${display}` },
+          { type: 'mrkdwn', text: `*Email:*\n${opportunity.user_email}` },
+        ],
+      },
+      {
+        type: 'section',
+        text: { type: 'mrkdwn', text: statusLine },
+      },
+    ],
+  };
+
+  try {
+    await sendChannelMessage(channelId, message);
+  } catch (error) {
+    logger.error({ error, domain: opportunity.domain }, 'Failed to send brand-claim opportunity notification');
+  }
+}
+
+/**
  * Notify when a new record is created and pending Addie review.
  */
 export async function notifyRegistryCreate(record: {

--- a/server/src/notifications/registry.ts
+++ b/server/src/notifications/registry.ts
@@ -10,6 +10,11 @@ import { sendChannelMessage, isSlackConfigured } from '../slack/client.js';
 import type { SlackBlockMessage } from '../slack/types.js';
 
 const CHANNEL_ID = process.env.REGISTRY_EDITS_CHANNEL_ID;
+// KYC / signup-ops channel — falls back to the registry-edits channel
+// when unset so the notification still fires in dev / staging without
+// extra env wiring, but distinct in prod so the two audiences don't mix
+// (wiki edits vs. signup KYC are different reviewer flows).
+const SIGNUP_OPS_CHANNEL_ID = process.env.SIGNUP_OPS_CHANNEL_ID || CHANNEL_ID;
 const APP_URL = process.env.APP_URL || 'https://agenticadvertising.org';
 
 function getChannelId(): string | null {
@@ -18,6 +23,14 @@ function getChannelId(): string | null {
     return null;
   }
   return CHANNEL_ID;
+}
+
+function getSignupOpsChannelId(): string | null {
+  if (!SIGNUP_OPS_CHANNEL_ID) {
+    logger.debug('SIGNUP_OPS_CHANNEL_ID / REGISTRY_EDITS_CHANNEL_ID not configured, skipping signup ops notification');
+    return null;
+  }
+  return SIGNUP_OPS_CHANNEL_ID;
 }
 
 /**
@@ -90,22 +103,40 @@ export async function notifyBrandClaimOpportunity(opportunity: {
   brand_already_verified: boolean;
   verified_owner_org_name?: string | null;
 }): Promise<void> {
-  const channelId = getChannelId();
+  const channelId = getSignupOpsChannelId();
   if (!channelId || !isSlackConfigured()) return;
 
-  const display = [opportunity.user_first_name, opportunity.user_last_name]
-    .filter(Boolean)
-    .join(' ')
-    || opportunity.user_email;
-  const brandLabel = opportunity.brand_name
-    ? `${opportunity.brand_name} (${opportunity.domain})`
-    : opportunity.domain;
+  // All user-controlled fields go through sanitizeMrkdwn before
+  // interpolation — first_name / last_name / email arrive from WorkOS
+  // signup (user-supplied), brand_name and verified_owner_org_name flow
+  // from the discovered-brands / organizations tables which can be
+  // populated by external research. Without sanitization an attacker
+  // could plant <!channel> mentions or <https://evil|legit-text> links
+  // into the moderator-trusted channel (same threat as #4754).
+  // Link labels additionally strip `|`, `<`, `>` since those break out
+  // of mrkdwn link syntax even after standard escaping.
+  const display = sanitizeMrkdwn(
+    [opportunity.user_first_name, opportunity.user_last_name]
+      .filter(Boolean)
+      .join(' ')
+      || opportunity.user_email,
+  );
+  const emailSafe = sanitizeMrkdwn(opportunity.user_email);
+  const domainSafe = sanitizeMrkdwn(opportunity.domain);
+  const brandLabel = sanitizeMrkdwnLinkLabel(
+    opportunity.brand_name
+      ? `${opportunity.brand_name} (${opportunity.domain})`
+      : opportunity.domain,
+  );
+  const ownerLabel = opportunity.verified_owner_org_name
+    ? sanitizeMrkdwn(opportunity.verified_owner_org_name)
+    : null;
   const statusLine = opportunity.brand_already_verified
-    ? `_Brand is already verified-owned${opportunity.verified_owner_org_name ? ` by *${opportunity.verified_owner_org_name}*` : ''} — claim won't fire._`
+    ? `_Brand is already verified-owned${ownerLabel ? ` by *${ownerLabel}*` : ''} — claim won't fire._`
     : `_Brand is unclaimed — signup will see a claim suggestion._`;
 
   const message: SlackBlockMessage = {
-    text: `🪪 New signup matches brand: ${opportunity.user_email} → ${opportunity.domain}`,
+    text: `🪪 New signup matches brand: ${emailSafe} → ${domainSafe}`,
     blocks: [
       {
         type: 'section',
@@ -118,7 +149,7 @@ export async function notifyBrandClaimOpportunity(opportunity: {
         type: 'section',
         fields: [
           { type: 'mrkdwn', text: `*User:*\n${display}` },
-          { type: 'mrkdwn', text: `*Email:*\n${opportunity.user_email}` },
+          { type: 'mrkdwn', text: `*Email:*\n${emailSafe}` },
         ],
       },
       {
@@ -133,6 +164,15 @@ export async function notifyBrandClaimOpportunity(opportunity: {
   } catch (error) {
     logger.error({ error, domain: opportunity.domain }, 'Failed to send brand-claim opportunity notification');
   }
+}
+
+/**
+ * Stricter sanitizer for link-label interpolation (`<url|LABEL>`). On
+ * top of the standard mrkdwn escaping, strip `|`, `<`, `>` because those
+ * break out of the label segment of Slack link syntax.
+ */
+function sanitizeMrkdwnLinkLabel(s: string): string {
+  return sanitizeMrkdwn(s).replace(/[<>|]/g, '');
 }
 
 /**

--- a/server/src/routes/me-brand-claim-suggestion.ts
+++ b/server/src/routes/me-brand-claim-suggestion.ts
@@ -16,14 +16,37 @@ import { BrandDatabase } from '../db/brand-db.js';
 import {
   getBrandClaimSuggestionForUser,
   getSuggestionForDomain,
-  getUserEmailById,
   nudgeKey,
 } from '../services/brand-claim-suggestion.js';
+import { getUserEmailById } from '../db/users-db.js';
 import { recordNudgeDismissal } from '../db/user-nudges-db.js';
-import { canonicalizeBrandDomain } from '../services/identifier-normalization.js';
+import { canonicalizeBrandDomain, assertValidBrandDomain } from '../services/identifier-normalization.js';
 import { createLogger } from '../logger.js';
 
 const logger = createLogger('me-brand-claim-suggestion');
+
+// Defense in depth — cap the raw domain string before canonicalization so
+// a hostile client can't push megabytes of garbage through `normalizeDomain`
+// only to be rejected at validation. Real domains are ≤ 253 chars.
+const MAX_DOMAIN_LEN = 253;
+
+function parseDomainParam(raw: unknown): { ok: true; domain: string } | { ok: false; error: string } {
+  if (typeof raw !== 'string' || raw.length === 0 || raw.length > MAX_DOMAIN_LEN) {
+    return { ok: false, error: 'Invalid domain' };
+  }
+  let canonical: string;
+  try {
+    canonical = canonicalizeBrandDomain(raw);
+  } catch {
+    return { ok: false, error: 'Invalid domain' };
+  }
+  try {
+    assertValidBrandDomain(canonical);
+  } catch {
+    return { ok: false, error: 'Invalid domain' };
+  }
+  return { ok: true, domain: canonical };
+}
 
 export function createBrandClaimSuggestionRouter(config: { brandDb: BrandDatabase }): Router {
   const router = Router();
@@ -40,16 +63,14 @@ export function createBrandClaimSuggestionRouter(config: { brandDb: BrandDatabas
         return res.json({ suggestion: null });
       }
 
-      const scope = typeof req.query.domain === 'string' ? req.query.domain : null;
+      const scope = req.query.domain;
       let suggestion;
-      if (scope) {
-        let domain: string;
-        try {
-          domain = canonicalizeBrandDomain(scope);
-        } catch {
-          return res.status(400).json({ error: 'Invalid domain' });
+      if (typeof scope === 'string' && scope.length > 0) {
+        const parsed = parseDomainParam(scope);
+        if (!parsed.ok) {
+          return res.status(400).json({ error: parsed.error });
         }
-        suggestion = await getSuggestionForDomain(user.id, email, domain, { brandDb });
+        suggestion = await getSuggestionForDomain(user.id, email, parsed.domain, { brandDb });
       } else {
         suggestion = await getBrandClaimSuggestionForUser(user.id, email, { brandDb });
       }
@@ -65,18 +86,12 @@ export function createBrandClaimSuggestionRouter(config: { brandDb: BrandDatabas
   router.post('/brand-claim-suggestion/dismiss', requireAuth, async (req: Request, res: Response) => {
     try {
       const user = req.user as { id: string };
-      const rawDomain = typeof req.body?.domain === 'string' ? req.body.domain : null;
-      if (!rawDomain) {
-        return res.status(400).json({ error: 'domain is required' });
+      const parsed = parseDomainParam(req.body?.domain);
+      if (!parsed.ok) {
+        return res.status(400).json({ error: parsed.error });
       }
-      let domain: string;
-      try {
-        domain = canonicalizeBrandDomain(rawDomain);
-      } catch {
-        return res.status(400).json({ error: 'Invalid domain' });
-      }
-      await recordNudgeDismissal(user.id, nudgeKey(domain));
-      return res.json({ success: true, domain });
+      await recordNudgeDismissal(user.id, nudgeKey(parsed.domain));
+      return res.json({ success: true, domain: parsed.domain });
     } catch (error) {
       logger.error({ err: error }, 'Failed to record brand-claim suggestion dismissal');
       return res.status(500).json({ error: 'Failed to dismiss suggestion' });

--- a/server/src/routes/me-brand-claim-suggestion.ts
+++ b/server/src/routes/me-brand-claim-suggestion.ts
@@ -1,0 +1,87 @@
+/**
+ * GET  /api/me/brand-claim-suggestion
+ * POST /api/me/brand-claim-suggestion/dismiss
+ *
+ * Drives the dashboard banner + brand-viewer just-in-time prompt for
+ * #4744 — "you signed up as alice@scope3.com, want to claim scope3.com?"
+ *
+ * The endpoints are read-only / state-only. The actual claim runs
+ * through /api/me/member-profile/brand-claim/* where DNS proves
+ * ownership.
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { requireAuth } from '../middleware/auth.js';
+import { BrandDatabase } from '../db/brand-db.js';
+import {
+  getBrandClaimSuggestionForUser,
+  getSuggestionForDomain,
+  getUserEmailById,
+  nudgeKey,
+} from '../services/brand-claim-suggestion.js';
+import { recordNudgeDismissal } from '../db/user-nudges-db.js';
+import { canonicalizeBrandDomain } from '../services/identifier-normalization.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('me-brand-claim-suggestion');
+
+export function createBrandClaimSuggestionRouter(config: { brandDb: BrandDatabase }): Router {
+  const router = Router();
+  const { brandDb } = config;
+
+  // GET /api/me/brand-claim-suggestion — dashboard banner + (optionally)
+  // domain-scoped check for the just-in-time prompt. Pass ?domain=… to
+  // restrict the suggestion to a specific brand.
+  router.get('/brand-claim-suggestion', requireAuth, async (req: Request, res: Response) => {
+    try {
+      const user = req.user as { id: string; email?: string };
+      const email = user.email ?? (await getUserEmailById(user.id));
+      if (!email) {
+        return res.json({ suggestion: null });
+      }
+
+      const scope = typeof req.query.domain === 'string' ? req.query.domain : null;
+      let suggestion;
+      if (scope) {
+        let domain: string;
+        try {
+          domain = canonicalizeBrandDomain(scope);
+        } catch {
+          return res.status(400).json({ error: 'Invalid domain' });
+        }
+        suggestion = await getSuggestionForDomain(user.id, email, domain, { brandDb });
+      } else {
+        suggestion = await getBrandClaimSuggestionForUser(user.id, email, { brandDb });
+      }
+      return res.json({ suggestion });
+    } catch (error) {
+      logger.error({ err: error }, 'Failed to compute brand-claim suggestion');
+      return res.status(500).json({ error: 'Failed to compute suggestion' });
+    }
+  });
+
+  // POST /api/me/brand-claim-suggestion/dismiss — record a 30-day
+  // cooldown on the suggestion for this user/domain pair.
+  router.post('/brand-claim-suggestion/dismiss', requireAuth, async (req: Request, res: Response) => {
+    try {
+      const user = req.user as { id: string };
+      const rawDomain = typeof req.body?.domain === 'string' ? req.body.domain : null;
+      if (!rawDomain) {
+        return res.status(400).json({ error: 'domain is required' });
+      }
+      let domain: string;
+      try {
+        domain = canonicalizeBrandDomain(rawDomain);
+      } catch {
+        return res.status(400).json({ error: 'Invalid domain' });
+      }
+      await recordNudgeDismissal(user.id, nudgeKey(domain));
+      return res.json({ success: true, domain });
+    } catch (error) {
+      logger.error({ err: error }, 'Failed to record brand-claim suggestion dismissal');
+      return res.status(500).json({ error: 'Failed to dismiss suggestion' });
+    }
+  });
+
+  return router;
+}

--- a/server/src/routes/workos-webhooks.ts
+++ b/server/src/routes/workos-webhooks.ts
@@ -37,6 +37,8 @@ import { triageAndNotify } from '../services/prospect-triage.js';
 import { researchDomain, trackBackground } from '../services/brand-enrichment.js';
 import { isFreeEmailDomain } from '../utils/email-domain.js';
 import { notifyBrandClaimOpportunity } from '../notifications/registry.js';
+import { getNudgeDismissal, recordNudgeDismissal } from '../db/user-nudges-db.js';
+import { getCompanyDomain } from '../utils/email-domain.js';
 import { canonicalizeBrandDomain, assertClaimableBrandDomain } from '../services/identifier-normalization.js';
 import { resolvePreferredOrganization, backfillPrimaryOrganization } from '../db/users-db.js';
 import { notifySystemError } from '../addie/error-notifier.js';
@@ -988,10 +990,16 @@ export function createWorkOSWebhooksRouter(): Router {
                     })
                   );
                 }
-                // Classify brand hierarchy before the user finishes onboarding
-                const isValidDomain = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i.test(domain)
+                // Classify brand hierarchy before the user finishes onboarding.
+                // Use getCompanyDomain rather than the local isFreeEmailDomain
+                // check so the predicate matches what the in-app suggestion
+                // service uses (#4744) — drift between the two would produce
+                // "ops got pinged but no banner shows" or vice versa.
+                const business = getCompanyDomain(user.email);
+                const isValidDomain = business
+                  && /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i.test(domain)
                   && !(/^\d+\.\d+\.\d+\.\d+$/.test(domain));
-                if (isValidDomain && !isFreeEmailDomain(domain)) {
+                if (isValidDomain) {
                   trackBackground(
                     researchDomain(domain).catch(err => {
                       logger.warn({ err, domain }, 'Background domain research failed for new user');
@@ -1003,14 +1011,22 @@ export function createWorkOSWebhooksRouter(): Router {
                   // viewer JIT prompt drive the user-side flow; this is the
                   // ops-side visibility signal. At today's volume we notify
                   // on every match regardless of brand verification state.
+                  //
+                  // Idempotent on WorkOS retries: user.created is at-least-
+                  // once, so we record a per-(user, domain) marker in
+                  // user_dismissed_nudges after sending and skip if present.
+                  // Reusing the dismissals table keeps the schema lean — see
+                  // user-nudges-db.ts for the dual-use convention.
                   if (user.email_verified) {
                     trackBackground(
                       (async () => {
                         try {
+                          const canonicalDomain = canonicalizeBrandDomain(domain);
+                          const notifyKey = `signup_notified:${canonicalDomain}`;
+                          const prior = await getNudgeDismissal(user.id, notifyKey);
+                          if (prior) return;
                           const brandDb = new BrandDatabase();
-                          const brand = await brandDb.getDiscoveredBrandByDomain(
-                            canonicalizeBrandDomain(domain),
-                          );
+                          const brand = await brandDb.getDiscoveredBrandByDomain(canonicalDomain);
                           if (!brand) return;
                           let ownerName: string | null = null;
                           if (brand.domain_verified && brand.workos_organization_id) {
@@ -1026,12 +1042,17 @@ export function createWorkOSWebhooksRouter(): Router {
                             user_email: user.email,
                             user_first_name: user.first_name ?? undefined,
                             user_last_name: user.last_name ?? undefined,
-                            domain,
+                            domain: canonicalDomain,
                             brand_name: brand.brand_name ?? null,
-                            brand_view_url: `/brand/view/${encodeURIComponent(domain)}`,
+                            brand_view_url: `/brand/view/${encodeURIComponent(canonicalDomain)}`,
                             brand_already_verified: !!brand.domain_verified && !!brand.workos_organization_id,
                             verified_owner_org_name: ownerName,
                           });
+                          // Record the marker AFTER successful send so a
+                          // retry following a Slack 5xx will still get
+                          // through (the WorkOS retry is exactly the cover
+                          // we want for transient failures).
+                          await recordNudgeDismissal(user.id, notifyKey);
                         } catch (notifyErr) {
                           logger.warn({ err: notifyErr, domain }, 'brand-claim opportunity notify failed');
                         }

--- a/server/src/routes/workos-webhooks.ts
+++ b/server/src/routes/workos-webhooks.ts
@@ -36,10 +36,11 @@ import { resolveUserNameWithFallbacks } from '../utils/resolve-user-name.js';
 import { triageAndNotify } from '../services/prospect-triage.js';
 import { researchDomain, trackBackground } from '../services/brand-enrichment.js';
 import { isFreeEmailDomain } from '../utils/email-domain.js';
+import { notifyBrandClaimOpportunity } from '../notifications/registry.js';
 import { canonicalizeBrandDomain, assertClaimableBrandDomain } from '../services/identifier-normalization.js';
 import { resolvePreferredOrganization, backfillPrimaryOrganization } from '../db/users-db.js';
 import { notifySystemError } from '../addie/error-notifier.js';
-import { canAddSeat, type SeatType } from '../db/organization-db.js';
+import { canAddSeat, type SeatType, OrganizationDatabase } from '../db/organization-db.js';
 import { sendToOrgAdmins, escapeSlackMrkdwn } from '../slack/org-group-dm.js';
 import {
   upsertOrganizationMembership,
@@ -996,6 +997,47 @@ export function createWorkOSWebhooksRouter(): Router {
                       logger.warn({ err, domain }, 'Background domain research failed for new user');
                     })
                   );
+                  // KYC nudge (#4744): if the signup domain maps to a brand
+                  // in the registry, notify ops in Slack so we can watch
+                  // who's signing up at known brands. The in-app banner +
+                  // viewer JIT prompt drive the user-side flow; this is the
+                  // ops-side visibility signal. At today's volume we notify
+                  // on every match regardless of brand verification state.
+                  if (user.email_verified) {
+                    trackBackground(
+                      (async () => {
+                        try {
+                          const brandDb = new BrandDatabase();
+                          const brand = await brandDb.getDiscoveredBrandByDomain(
+                            canonicalizeBrandDomain(domain),
+                          );
+                          if (!brand) return;
+                          let ownerName: string | null = null;
+                          if (brand.domain_verified && brand.workos_organization_id) {
+                            try {
+                              const orgDb = new OrganizationDatabase();
+                              const ownerOrg = await orgDb.getOrganization(brand.workos_organization_id);
+                              ownerName = ownerOrg?.name ?? null;
+                            } catch (orgErr) {
+                              logger.debug({ orgErr, domain }, 'failed to resolve verified-owner org name for signup notify');
+                            }
+                          }
+                          await notifyBrandClaimOpportunity({
+                            user_email: user.email,
+                            user_first_name: user.first_name ?? undefined,
+                            user_last_name: user.last_name ?? undefined,
+                            domain,
+                            brand_name: brand.brand_name ?? null,
+                            brand_view_url: `/brand/view/${encodeURIComponent(domain)}`,
+                            brand_already_verified: !!brand.domain_verified && !!brand.workos_organization_id,
+                            verified_owner_org_name: ownerName,
+                          });
+                        } catch (notifyErr) {
+                          logger.warn({ err: notifyErr, domain }, 'brand-claim opportunity notify failed');
+                        }
+                      })()
+                    );
+                  }
                 }
               }
             }

--- a/server/src/services/brand-claim-suggestion.ts
+++ b/server/src/services/brand-claim-suggestion.ts
@@ -22,7 +22,6 @@
  *   - User dismissed in the last 30 days: respect the cooldown.
  */
 
-import { query } from '../db/client.js';
 import { BrandDatabase } from '../db/brand-db.js';
 import { getCompanyDomain } from '../utils/email-domain.js';
 import { canonicalizeBrandDomain } from './identifier-normalization.js';
@@ -114,6 +113,10 @@ export async function getBrandClaimSuggestionForUser(
  * just-in-time prompt. Returns the suggestion only when the requested
  * domain matches the user's verified email domain AND the standard
  * suggestion-applicability rules hold.
+ *
+ * Canonicalizes `requestedDomain` defensively even though every internal
+ * caller already passes a canonical value — keeps this function safe
+ * to call from new surfaces without auditing every callsite.
  */
 export async function getSuggestionForDomain(
   workosUserId: string,
@@ -124,29 +127,25 @@ export async function getSuggestionForDomain(
   const rawDomain = getCompanyDomain(email);
   if (!rawDomain) return null;
   let userDomain: string;
+  let canonicalRequested: string;
   try {
     userDomain = canonicalizeBrandDomain(rawDomain);
+    canonicalRequested = canonicalizeBrandDomain(requestedDomain);
   } catch {
     return null;
   }
-  if (userDomain !== requestedDomain) return null;
+  if (userDomain !== canonicalRequested) return null;
 
   return getBrandClaimSuggestionForUser(workosUserId, email, ctx);
 }
 
-export function nudgeKey(domain: string): string {
-  return `brand_claim_suggestion:${domain}`;
-}
-
 /**
- * Lookup the user's email from the canonical users table. Used by the
- * dashboard endpoint where the auth middleware exposes user.id but the
- * full WorkOS user object isn't necessarily attached.
+ * Build the storage key for a brand-claim dismissal. Defensively
+ * lowercases — every callsite today passes a canonicalized domain, but
+ * a typo or new caller passing `Scope3.com` would otherwise produce a
+ * different key from the canonical one and silently break the
+ * cooldown lookup.
  */
-export async function getUserEmailById(workosUserId: string): Promise<string | null> {
-  const result = await query<{ email: string }>(
-    `SELECT email FROM users WHERE workos_user_id = $1`,
-    [workosUserId],
-  );
-  return result.rows[0]?.email ?? null;
+export function nudgeKey(domain: string): string {
+  return `brand_claim_suggestion:${domain.toLowerCase()}`;
 }

--- a/server/src/services/brand-claim-suggestion.ts
+++ b/server/src/services/brand-claim-suggestion.ts
@@ -1,0 +1,152 @@
+/**
+ * Brand-claim suggestion (#4744).
+ *
+ * "You signed up as alice@scope3.com — want to claim scope3.com?"
+ *
+ * Locates a brand in the registry that matches the user's verified email
+ * domain and tells the caller whether the suggestion should fire on the
+ * dashboard banner or as the just-in-time prompt on /brand/view.
+ *
+ * Trust model: this is a *nudge*, not a claim. The DNS challenge at
+ * /api/me/member-profile/brand-claim/* is the actual trust boundary. We
+ * just point users at it when their signup hints they might control the
+ * domain.
+ *
+ * Suppression rules:
+ *   - Free email domains (gmail, etc.) never suggest — `getCompanyDomain`
+ *     filters those out at the source.
+ *   - Verified ownership by the user's *own* org: nothing to claim,
+ *     already done.
+ *   - Verified ownership by *another* org: claim would collision-fail at
+ *     the DNS step. Don't waste a nudge on a guaranteed dead end.
+ *   - User dismissed in the last 30 days: respect the cooldown.
+ */
+
+import { query } from '../db/client.js';
+import { BrandDatabase } from '../db/brand-db.js';
+import { getCompanyDomain } from '../utils/email-domain.js';
+import { canonicalizeBrandDomain } from './identifier-normalization.js';
+import { resolvePrimaryOrganization } from '../db/users-db.js';
+import { getNudgeDismissal } from '../db/user-nudges-db.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('brand-claim-suggestion');
+
+export const DISMISSAL_COOLDOWN_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+export interface BrandClaimSuggestion {
+  domain: string;
+  brand_name: string | null;
+  /** True when the suggestion is fresh (no recent dismissal). */
+  active: boolean;
+  /** Set when the user dismissed within the cooldown window. */
+  dismissed_at?: Date;
+  /** Deep-link to the brand-builder claim flow (#4742). */
+  claim_url: string;
+  /** Deep-link to view the brand. */
+  view_url: string;
+}
+
+export interface BrandClaimSuggestionContext {
+  brandDb: BrandDatabase;
+}
+
+/**
+ * Return a brand-claim suggestion for the given user, or null when no
+ * suggestion applies. The shape is the same for "suggestion exists but
+ * was recently dismissed" and "suggestion exists and is active" — the
+ * `active` boolean tells the caller which UI state to render. Null
+ * means "no suggestion at all" (free email, already verified by user's
+ * org, claimed by someone else, no matching brand).
+ */
+export async function getBrandClaimSuggestionForUser(
+  workosUserId: string,
+  email: string,
+  ctx: BrandClaimSuggestionContext,
+): Promise<BrandClaimSuggestion | null> {
+  const rawDomain = getCompanyDomain(email);
+  if (!rawDomain) return null;
+
+  let domain: string;
+  try {
+    domain = canonicalizeBrandDomain(rawDomain);
+  } catch (err) {
+    logger.debug({ err, rawDomain }, 'brand-claim suggestion: domain canonicalization failed');
+    return null;
+  }
+  if (!domain) return null;
+
+  const brand = await ctx.brandDb.getDiscoveredBrandByDomain(domain);
+  if (!brand) return null;
+
+  // Already verified by some org — caller's org or another.
+  if (brand.domain_verified && brand.workos_organization_id) {
+    let callerOrgId: string | null = null;
+    try {
+      callerOrgId = await resolvePrimaryOrganization(workosUserId);
+    } catch (err) {
+      logger.warn({ err, workosUserId }, 'brand-claim suggestion: failed to resolve caller org');
+    }
+    if (callerOrgId && callerOrgId === brand.workos_organization_id) {
+      // Caller's own org already owns it — nothing to suggest.
+      return null;
+    }
+    // Owned by another org. DNS challenge would collision-fail. Skip.
+    return null;
+  }
+
+  const dismissal = await getNudgeDismissal(workosUserId, nudgeKey(domain));
+  const active = !dismissal
+    || (Date.now() - new Date(dismissal.dismissed_at).getTime()) >= DISMISSAL_COOLDOWN_MS;
+
+  return {
+    domain,
+    brand_name: brand.brand_name ?? null,
+    active,
+    dismissed_at: dismissal?.dismissed_at,
+    claim_url: `/brand/builder?domain=${encodeURIComponent(domain)}`,
+    view_url: `/brand/view/${encodeURIComponent(domain)}`,
+  };
+}
+
+/**
+ * Same lookup, scoped to a specific domain — used by the brand-viewer
+ * just-in-time prompt. Returns the suggestion only when the requested
+ * domain matches the user's verified email domain AND the standard
+ * suggestion-applicability rules hold.
+ */
+export async function getSuggestionForDomain(
+  workosUserId: string,
+  email: string,
+  requestedDomain: string,
+  ctx: BrandClaimSuggestionContext,
+): Promise<BrandClaimSuggestion | null> {
+  const rawDomain = getCompanyDomain(email);
+  if (!rawDomain) return null;
+  let userDomain: string;
+  try {
+    userDomain = canonicalizeBrandDomain(rawDomain);
+  } catch {
+    return null;
+  }
+  if (userDomain !== requestedDomain) return null;
+
+  return getBrandClaimSuggestionForUser(workosUserId, email, ctx);
+}
+
+export function nudgeKey(domain: string): string {
+  return `brand_claim_suggestion:${domain}`;
+}
+
+/**
+ * Lookup the user's email from the canonical users table. Used by the
+ * dashboard endpoint where the auth middleware exposes user.id but the
+ * full WorkOS user object isn't necessarily attached.
+ */
+export async function getUserEmailById(workosUserId: string): Promise<string | null> {
+  const result = await query<{ email: string }>(
+    `SELECT email FROM users WHERE workos_user_id = $1`,
+    [workosUserId],
+  );
+  return result.rows[0]?.email ?? null;
+}

--- a/server/tests/unit/brand-claim-suggestion.test.ts
+++ b/server/tests/unit/brand-claim-suggestion.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Pin the brand-claim suggestion service + endpoint (#4744).
+ *
+ * Covers the suppression matrix:
+ *   - Free email domains → no suggestion.
+ *   - No matching brand → no suggestion.
+ *   - Brand verified by caller's own org → no suggestion (already done).
+ *   - Brand verified by another org → no suggestion (would collision-fail).
+ *   - Brand unowned → suggestion fires.
+ *   - Dismissal within 30d → suggestion still returned but `active: false`.
+ *   - Dismissal older than 30d → suggestion `active: true` again.
+ *
+ * Plus endpoint-level: domain canonicalization, dismiss roundtrip,
+ * domain-scoped query (for the brand-viewer JIT prompt).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+const mocks = vi.hoisted(() => ({
+  getDiscoveredBrandByDomain: vi.fn(),
+  resolvePrimaryOrganization: vi.fn().mockResolvedValue(null),
+  getNudgeDismissal: vi.fn().mockResolvedValue(null),
+  recordNudgeDismissal: vi.fn().mockResolvedValue(undefined),
+  getUserEmailById: vi.fn().mockResolvedValue('alice@scope3.com'),
+}));
+
+vi.mock('../../src/db/users-db.js', () => ({
+  resolvePrimaryOrganization: (...args: unknown[]) => mocks.resolvePrimaryOrganization(...args),
+}));
+
+vi.mock('../../src/db/user-nudges-db.js', () => ({
+  getNudgeDismissal: (...args: unknown[]) => mocks.getNudgeDismissal(...args),
+  recordNudgeDismissal: (...args: unknown[]) => mocks.recordNudgeDismissal(...args),
+}));
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  requireAuth: (req: any, _res: unknown, next: () => void) => {
+    req.user = currentUser;
+    next();
+  },
+  optionalAuth: (req: any, _res: unknown, next: () => void) => {
+    req.user = currentUser;
+    next();
+  },
+}));
+
+import {
+  getBrandClaimSuggestionForUser,
+  getSuggestionForDomain,
+  nudgeKey,
+  DISMISSAL_COOLDOWN_MS,
+} from '../../src/services/brand-claim-suggestion.js';
+import { createBrandClaimSuggestionRouter } from '../../src/routes/me-brand-claim-suggestion.js';
+import type { BrandDatabase } from '../../src/db/brand-db.js';
+
+let currentUser: { id: string; email?: string } = { id: 'user_test', email: 'alice@scope3.com' };
+
+function makeCtx(): { brandDb: BrandDatabase } {
+  return {
+    brandDb: {
+      getDiscoveredBrandByDomain: mocks.getDiscoveredBrandByDomain,
+    } as unknown as BrandDatabase,
+  };
+}
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/me', createBrandClaimSuggestionRouter({
+    brandDb: { getDiscoveredBrandByDomain: mocks.getDiscoveredBrandByDomain } as unknown as BrandDatabase,
+  }));
+  return app;
+}
+
+describe('getBrandClaimSuggestionForUser', () => {
+  beforeEach(() => {
+    mocks.getDiscoveredBrandByDomain.mockReset();
+    mocks.resolvePrimaryOrganization.mockReset();
+    mocks.resolvePrimaryOrganization.mockResolvedValue(null);
+    mocks.getNudgeDismissal.mockReset();
+    mocks.getNudgeDismissal.mockResolvedValue(null);
+  });
+
+  it('returns null for free email domains', async () => {
+    const result = await getBrandClaimSuggestionForUser('user_test', 'alice@gmail.com', makeCtx());
+    expect(result).toBeNull();
+    expect(mocks.getDiscoveredBrandByDomain).not.toHaveBeenCalled();
+  });
+
+  it('returns null when no brand matches the user domain', async () => {
+    mocks.getDiscoveredBrandByDomain.mockResolvedValue(null);
+    const result = await getBrandClaimSuggestionForUser('user_test', 'alice@unknown.example', makeCtx());
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the brand is already verified by the caller\'s own org', async () => {
+    mocks.getDiscoveredBrandByDomain.mockResolvedValue({
+      domain: 'scope3.com',
+      brand_name: 'Scope3',
+      domain_verified: true,
+      workos_organization_id: 'org_scope3',
+    });
+    mocks.resolvePrimaryOrganization.mockResolvedValue('org_scope3');
+    const result = await getBrandClaimSuggestionForUser('user_test', 'alice@scope3.com', makeCtx());
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the brand is verified by ANOTHER org (claim would collision-fail)', async () => {
+    mocks.getDiscoveredBrandByDomain.mockResolvedValue({
+      domain: 'scope3.com',
+      brand_name: 'Scope3',
+      domain_verified: true,
+      workos_organization_id: 'org_someone_else',
+    });
+    mocks.resolvePrimaryOrganization.mockResolvedValue('org_intruder');
+    const result = await getBrandClaimSuggestionForUser('user_test', 'alice@scope3.com', makeCtx());
+    expect(result).toBeNull();
+  });
+
+  it('returns an active suggestion when the brand exists and is unclaimed', async () => {
+    mocks.getDiscoveredBrandByDomain.mockResolvedValue({
+      domain: 'scope3.com',
+      brand_name: 'Scope3',
+      domain_verified: false,
+    });
+    const result = await getBrandClaimSuggestionForUser('user_test', 'alice@scope3.com', makeCtx());
+    expect(result).not.toBeNull();
+    expect(result!).toMatchObject({
+      domain: 'scope3.com',
+      brand_name: 'Scope3',
+      active: true,
+      claim_url: '/brand/builder?domain=scope3.com',
+      view_url: '/brand/view/scope3.com',
+    });
+  });
+
+  it('returns an inactive suggestion when the user dismissed within the cooldown', async () => {
+    mocks.getDiscoveredBrandByDomain.mockResolvedValue({
+      domain: 'scope3.com',
+      brand_name: 'Scope3',
+      domain_verified: false,
+    });
+    mocks.getNudgeDismissal.mockResolvedValue({
+      workos_user_id: 'user_test',
+      nudge_key: nudgeKey('scope3.com'),
+      dismissed_at: new Date(),
+    });
+    const result = await getBrandClaimSuggestionForUser('user_test', 'alice@scope3.com', makeCtx());
+    expect(result?.active).toBe(false);
+  });
+
+  it('re-activates the suggestion once the 30-day cooldown elapses', async () => {
+    mocks.getDiscoveredBrandByDomain.mockResolvedValue({
+      domain: 'scope3.com',
+      brand_name: 'Scope3',
+      domain_verified: false,
+    });
+    mocks.getNudgeDismissal.mockResolvedValue({
+      workos_user_id: 'user_test',
+      nudge_key: nudgeKey('scope3.com'),
+      dismissed_at: new Date(Date.now() - DISMISSAL_COOLDOWN_MS - 1000),
+    });
+    const result = await getBrandClaimSuggestionForUser('user_test', 'alice@scope3.com', makeCtx());
+    expect(result?.active).toBe(true);
+  });
+});
+
+describe('getSuggestionForDomain (brand-viewer JIT)', () => {
+  beforeEach(() => {
+    mocks.getDiscoveredBrandByDomain.mockReset();
+    mocks.resolvePrimaryOrganization.mockReset();
+    mocks.resolvePrimaryOrganization.mockResolvedValue(null);
+    mocks.getNudgeDismissal.mockReset();
+    mocks.getNudgeDismissal.mockResolvedValue(null);
+  });
+
+  it('returns the suggestion when the requested domain matches the user\'s email domain', async () => {
+    mocks.getDiscoveredBrandByDomain.mockResolvedValue({
+      domain: 'scope3.com',
+      brand_name: 'Scope3',
+      domain_verified: false,
+    });
+    const result = await getSuggestionForDomain('user_test', 'alice@scope3.com', 'scope3.com', makeCtx());
+    expect(result).not.toBeNull();
+    expect(result!.domain).toBe('scope3.com');
+  });
+
+  it('returns null when the requested domain does NOT match the user\'s email domain', async () => {
+    const result = await getSuggestionForDomain('user_test', 'alice@scope3.com', 'nike.com', makeCtx());
+    expect(result).toBeNull();
+    expect(mocks.getDiscoveredBrandByDomain).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/me/brand-claim-suggestion', () => {
+  beforeEach(() => {
+    currentUser = { id: 'user_test', email: 'alice@scope3.com' };
+    mocks.getDiscoveredBrandByDomain.mockReset();
+    mocks.resolvePrimaryOrganization.mockReset();
+    mocks.resolvePrimaryOrganization.mockResolvedValue(null);
+    mocks.getNudgeDismissal.mockReset();
+    mocks.getNudgeDismissal.mockResolvedValue(null);
+  });
+
+  it('returns the suggestion when applicable', async () => {
+    mocks.getDiscoveredBrandByDomain.mockResolvedValue({
+      domain: 'scope3.com',
+      brand_name: 'Scope3',
+      domain_verified: false,
+    });
+    const res = await request(makeApp()).get('/api/me/brand-claim-suggestion');
+    expect(res.status).toBe(200);
+    expect(res.body.suggestion).toMatchObject({
+      domain: 'scope3.com',
+      brand_name: 'Scope3',
+      active: true,
+    });
+  });
+
+  it('returns null suggestion when none applies', async () => {
+    mocks.getDiscoveredBrandByDomain.mockResolvedValue(null);
+    const res = await request(makeApp()).get('/api/me/brand-claim-suggestion');
+    expect(res.status).toBe(200);
+    expect(res.body.suggestion).toBeNull();
+  });
+
+  it('scopes to a specific domain via ?domain= for the JIT prompt', async () => {
+    const res = await request(makeApp()).get('/api/me/brand-claim-suggestion?domain=nike.com');
+    expect(res.status).toBe(200);
+    // alice@scope3.com asking about nike.com → no match
+    expect(res.body.suggestion).toBeNull();
+    expect(mocks.getDiscoveredBrandByDomain).not.toHaveBeenCalled();
+  });
+
+  it('400s a scoped query with a malformed domain', async () => {
+    const res = await request(makeApp()).get('/api/me/brand-claim-suggestion?domain=://bogus');
+    expect(res.status).toBe(200); // canonicalizeBrandDomain coerces; bogus → empty → null
+    expect(res.body.suggestion).toBeNull();
+  });
+});
+
+describe('POST /api/me/brand-claim-suggestion/dismiss', () => {
+  beforeEach(() => {
+    currentUser = { id: 'user_test', email: 'alice@scope3.com' };
+    mocks.recordNudgeDismissal.mockReset();
+    mocks.recordNudgeDismissal.mockResolvedValue(undefined);
+  });
+
+  it('records a dismissal for the canonicalized domain', async () => {
+    const res = await request(makeApp())
+      .post('/api/me/brand-claim-suggestion/dismiss')
+      .send({ domain: 'Scope3.com' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true, domain: 'scope3.com' });
+    expect(mocks.recordNudgeDismissal).toHaveBeenCalledWith(
+      'user_test',
+      'brand_claim_suggestion:scope3.com',
+    );
+  });
+
+  it('400s without a domain', async () => {
+    const res = await request(makeApp()).post('/api/me/brand-claim-suggestion/dismiss').send({});
+    expect(res.status).toBe(400);
+    expect(mocks.recordNudgeDismissal).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/brand-claim-suggestion.test.ts
+++ b/server/tests/unit/brand-claim-suggestion.test.ts
@@ -28,6 +28,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('../../src/db/users-db.js', () => ({
   resolvePrimaryOrganization: (...args: unknown[]) => mocks.resolvePrimaryOrganization(...args),
+  getUserEmailById: (...args: unknown[]) => mocks.getUserEmailById(...args),
 }));
 
 vi.mock('../../src/db/user-nudges-db.js', () => ({
@@ -236,8 +237,16 @@ describe('GET /api/me/brand-claim-suggestion', () => {
 
   it('400s a scoped query with a malformed domain', async () => {
     const res = await request(makeApp()).get('/api/me/brand-claim-suggestion?domain=://bogus');
-    expect(res.status).toBe(200); // canonicalizeBrandDomain coerces; bogus → empty → null
-    expect(res.body.suggestion).toBeNull();
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Invalid domain/i);
+  });
+
+  it('400s a scoped query with an over-long domain', async () => {
+    const long = 'a'.repeat(300) + '.example';
+    const res = await request(makeApp()).get(
+      `/api/me/brand-claim-suggestion?domain=${encodeURIComponent(long)}`,
+    );
+    expect(res.status).toBe(400);
   });
 });
 
@@ -264,5 +273,29 @@ describe('POST /api/me/brand-claim-suggestion/dismiss', () => {
     const res = await request(makeApp()).post('/api/me/brand-claim-suggestion/dismiss').send({});
     expect(res.status).toBe(400);
     expect(mocks.recordNudgeDismissal).not.toHaveBeenCalled();
+  });
+
+  it('400s a dismissal for an invalid domain shape', async () => {
+    const res = await request(makeApp())
+      .post('/api/me/brand-claim-suggestion/dismiss')
+      .send({ domain: 'not_a_real_domain' });
+    expect(res.status).toBe(400);
+    expect(mocks.recordNudgeDismissal).not.toHaveBeenCalled();
+  });
+
+  it('400s a dismissal whose raw domain exceeds 253 chars', async () => {
+    const long = 'a'.repeat(300) + '.example';
+    const res = await request(makeApp())
+      .post('/api/me/brand-claim-suggestion/dismiss')
+      .send({ domain: long });
+    expect(res.status).toBe(400);
+    expect(mocks.recordNudgeDismissal).not.toHaveBeenCalled();
+  });
+});
+
+describe('nudgeKey canonicalization guard', () => {
+  it('lowercases the domain so callers passing mixed-case hit the same key', () => {
+    expect(nudgeKey('Scope3.com')).toBe('brand_claim_suggestion:scope3.com');
+    expect(nudgeKey('scope3.com')).toBe('brand_claim_suggestion:scope3.com');
   });
 });

--- a/server/tests/unit/notify-brand-claim-opportunity-sanitize.test.ts
+++ b/server/tests/unit/notify-brand-claim-opportunity-sanitize.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Pin: notifyBrandClaimOpportunity neutralizes Slack mrkdwn meta-
+ * characters in user-controlled fields (user name, email, brand name,
+ * verified-owner-org name) before posting to a moderator-trusted
+ * channel. Same threat model as #4754's pending-logo sanitizer — the
+ * data here flows from signup form fields and the discovered-brand
+ * table, which are externally influenced.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.hoisted(() => {
+  process.env.REGISTRY_EDITS_CHANNEL_ID = 'C_TEST_SIGNUP_OPS';
+});
+
+const mocks = vi.hoisted(() => ({
+  sendChannelMessage: vi.fn(),
+  isSlackConfigured: vi.fn(() => true),
+}));
+
+vi.mock('../../src/slack/client.js', () => ({
+  sendChannelMessage: (...args: unknown[]) => mocks.sendChannelMessage(...args),
+  isSlackConfigured: () => mocks.isSlackConfigured(),
+}));
+
+import { notifyBrandClaimOpportunity } from '../../src/notifications/registry.js';
+
+function lastSentJSON(): string {
+  const call = mocks.sendChannelMessage.mock.calls.at(-1);
+  expect(call).toBeDefined();
+  const [, message] = call!;
+  return JSON.stringify(message);
+}
+
+describe('notifyBrandClaimOpportunity mrkdwn sanitization', () => {
+  beforeEach(() => {
+    mocks.sendChannelMessage.mockReset();
+    mocks.sendChannelMessage.mockResolvedValue({ ts: '1779200000.000' });
+    mocks.isSlackConfigured.mockReturnValue(true);
+  });
+
+  it('neutralizes broadcast tokens in first_name / last_name', async () => {
+    await notifyBrandClaimOpportunity({
+      user_email: 'alice@scope3.com',
+      user_first_name: 'Alice <!channel>',
+      user_last_name: '<!here>',
+      domain: 'scope3.com',
+      brand_name: 'Scope3',
+      brand_view_url: '/brand/view/scope3.com',
+      brand_already_verified: false,
+    });
+    const json = lastSentJSON();
+    expect(json).not.toContain('<!channel>');
+    expect(json).not.toContain('<!here>');
+  });
+
+  it('strips link-label-breakout characters from brand_name', async () => {
+    await notifyBrandClaimOpportunity({
+      user_email: 'alice@scope3.com',
+      domain: 'scope3.com',
+      brand_name: 'Scope3|<https://evil/|legit>',
+      brand_view_url: '/brand/view/scope3.com',
+      brand_already_verified: false,
+    });
+    const json = lastSentJSON();
+    // Link-label sanitizer drops `|`, `<`, `>` so the brand_name cannot
+    // break out of the <url|label> link.
+    expect(json).not.toContain('|<');
+    expect(json).not.toContain('|legit>');
+  });
+
+  it('sanitizes verified_owner_org_name when present', async () => {
+    await notifyBrandClaimOpportunity({
+      user_email: 'alice@scope3.com',
+      domain: 'scope3.com',
+      brand_name: 'Scope3',
+      brand_view_url: '/brand/view/scope3.com',
+      brand_already_verified: true,
+      verified_owner_org_name: 'Acme <!channel>',
+    });
+    const json = lastSentJSON();
+    expect(json).not.toContain('<!channel>');
+  });
+
+  it('preserves benign content', async () => {
+    await notifyBrandClaimOpportunity({
+      user_email: 'alice@scope3.com',
+      user_first_name: 'Alice',
+      user_last_name: 'Park',
+      domain: 'scope3.com',
+      brand_name: 'Scope3',
+      brand_view_url: '/brand/view/scope3.com',
+      brand_already_verified: false,
+    });
+    const json = lastSentJSON();
+    expect(json).toContain('Alice Park');
+    expect(json).toContain('alice@scope3.com');
+  });
+});


### PR DESCRIPTION
Implements the resolution from the #4765 design discussion. When a user signs up with a verified email domain that matches a brand in the registry, nudge them to claim it.

## Three surfaces

**1. Dashboard banner** — soft, dismissible, on \`/dashboard\`. Links to \`/brand/builder?domain=…\` (the claim flow from #4742). Dismissal records a 30-day cooldown in a new generic \`user_dismissed_nudges\` table.

**2. Just-in-time prompt on \`/brand/view/{domain}\`** — same banner, scoped to the brand being viewed. Fires only when the brand's domain equals the viewer's verified email domain. Highest-intent moment.

**3. Slack notify to ops** on every signup whose verified email domain matches a registry brand. No threshold (low volume; throttle later when it gets noisy). Fires from the existing \`user.created\` WorkOS webhook handler.

## Suppression rules (per #4765 design)

- Free email domains (gmail, etc.) — never suggest.
- Brand verified by caller's own org — already done.
- Brand verified by another org — would collision-fail at DNS, skip.
- Dismissed within 30 days — suggestion still returns but \`active: false\`.

## Delegation is orthogonal

Per Brian's reframe in #4765, we deliberately don't handle holding-co / agency / consultant scenarios here. Those go through #4747's delegated-grant flow (planned) or the brand-owning org adding the user to their WorkOS org. This flow stays narrow: \"you control this domain, want to claim it?\"

## New surfaces

| | What |
|---|---|
| \`GET /api/me/brand-claim-suggestion\` | Returns \`{ suggestion: { domain, brand_name, active, dismissed_at?, claim_url, view_url } \| null }\`. Pass \`?domain=…\` to scope (drives the JIT prompt). |
| \`POST /api/me/brand-claim-suggestion/dismiss\` | Records 30-day cooldown for the \`(user, domain)\` pair. |
| \`user_dismissed_nudges\` table (migration 485) | Generic in-app nudge state, reusable for future banners. PK \`(workos_user_id, nudge_key)\`. |
| \`notifyBrandClaimOpportunity()\` | New Slack notifier, posts to \`REGISTRY_EDITS_CHANNEL_ID\`. |

## Tests

15 unit tests pin:
- Suppression matrix (free email, no brand, own-org owned, other-org owned, unclaimed).
- 30-day cooldown (within → inactive; older → active again).
- Endpoint canonicalization + scoped JIT lookup.
- Dismiss roundtrip.

TypeScript clean.

## Test plan
- [ ] CI green.
- [ ] Sign up a fresh test user with an email at a known-registry domain (e.g. \`tester@scope3.com\` in dev). Confirm a Slack notification fires to \`REGISTRY_EDITS_CHANNEL_ID\`.
- [ ] Log in as that user → \`/dashboard\` shows the banner; click \"Claim this brand\" → \`/brand/builder?domain=scope3.com\` opens with the domain pre-filled.
- [ ] Visit \`/brand/view/scope3.com\` as that user → JIT banner appears above the brand content.
- [ ] Click Dismiss → banner disappears; refresh confirms it stays hidden.
- [ ] After 30 days (or a manual DB poke) the banner reappears.

## Out of scope (followups)

- Re-surface triggers from #4765 Q8 (someone else's claim attempt, new auth session) — covered by the cooldown re-fire today; richer event plumbing later.
- Delegation (#4747).

🤖 Generated with [Claude Code](https://claude.com/claude-code)