### PR TITLE
fix(certification): block credential issuance when learner has no name (closes #4782)

### DIFF
--- a/.changeset/credential-issuance-name-gate.md
+++ b/.changeset/credential-issuance-name-gate.md
@@ -1,0 +1,12 @@
+---
+---
+
+fix(certification): block credential issuance when learner has no name, recover conversationally (#4782)
+
+Closes #4782 — the safety net behind escalation #382. Even after the auth-callback Slack fallback (PR #4781) and the onboarding name-capture gate, an exotic auth path could still drop a learner at credential-issuance time without a name. Today that produced an email-on-certificate ("tom@example.com"); now it produces a one-turn conversational recovery instead.
+
+- **Gate**: `issueCertifierBadge` returns a `NAME_REQUIRED` sentinel (without calling Certifier) when `users.first_name` is empty.
+- **Recovery loop**: `checkAndFormatCredentials` now also retries previously-deferred Certifier issuances on every call, so the post-`set_my_name` retry finalizes the certificate that was held back.
+- **`set_my_name` tool**: new learner-self tool (member-tools) wrapping the same write-through-to-WorkOS path the onboarding form uses. Sage's prompt rule (`Credential name recovery`) instructs her to ask for first + last on seeing the marker, call `set_my_name`, then call `check_credentials` to finalize.
+- **`check_credentials` tool**: new tool that runs the award + issue pass on demand (previously the only triggers were `complete_certification_module` / exam). Used by the recovery flow.
+- The `NAME_REQUIRED_MARKER` constant is exported and referenced from all three sites (sentinel, warning line, Sage rule) so they can't drift — guarded by a unit test.

--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -422,8 +422,29 @@ function validateDemonstrationIds(
 }
 
 /**
+ * Sentinel returned by `issueCertifierBadge` when issuance was blocked because
+ * the learner has no real name on file. The caller surfaces this as a
+ * `NAME_REQUIRED` line that Sage's prompt rules (see `buildCertificationContext`)
+ * know how to recover from: ask for first/last, call `set_my_name`, re-check.
+ *
+ * Exported so the prompt rule and the warning line and the tests all reference
+ * the same string — if the marker changes, every match site changes with it.
+ *
+ * The credential row is already awarded in `user_credentials`; only the
+ * Certifier-side issuance is deferred. `checkAndFormatCredentials` retries
+ * deferred issuances on its next call.
+ */
+export const NAME_REQUIRED_MARKER = 'NAME_REQUIRED';
+type IssueResult = string | null | typeof NAME_REQUIRED_MARKER;
+
+/**
  * Issue a Certifier badge for an awarded credential.
  * Handles expiry logic (tier 1 = no expiry, others = 2 years) and records the credential ID.
+ * Returns:
+ *   - the credential's publicId when issuance succeeded
+ *   - `NAME_REQUIRED` when the learner has no real name on file (gate fires
+ *     before any Certifier call — see escalation #382 and issue #4782)
+ *   - `null` on transient / configuration failures (logged for ops)
  */
 async function issueCertifierBadge(
   userId: string,
@@ -431,8 +452,17 @@ async function issueCertifierBadge(
   cred: { name: string; tier: number; certifier_group_id: string | null },
   memberContext: MemberContext | null,
   extraAttributes?: Record<string, string>,
-): Promise<string | null> {
+): Promise<IssueResult> {
   if (!cred.certifier_group_id || !memberContext?.workos_user) return null;
+
+  // Gate: refuse to issue with email-as-name. Issuing a "tom@example.com"
+  // certificate is worse than the one-turn friction of asking for the name.
+  const wu = memberContext.workos_user;
+  const hasFirst = (wu.first_name ?? '').trim().length > 0;
+  if (!hasFirst) {
+    logger.info({ userId, credId, email: wu.email }, 'Credential issuance gated: no first_name on file');
+    return NAME_REQUIRED_MARKER;
+  }
 
   try {
     const { issueCredential, isCertifierConfigured, getCredentialBadgeUrl, buildRecipientName } = await import('../../services/certifier-client.js');
@@ -503,22 +533,44 @@ function buildShareLinks(
 
 /**
  * Check for newly earned credentials, issue badges, and return formatted lines.
+ * Also retries any previously-awarded credentials whose Certifier issuance
+ * was deferred (typically gated by `NAME_REQUIRED` on a prior turn) — that's
+ * the recovery path after Sage calls `set_my_name`.
  */
 async function checkAndFormatCredentials(
   userId: string,
   memberContext: MemberContext | null,
 ): Promise<string[]> {
   const awarded = await certDb.checkAndAwardCredentials(userId);
-  if (awarded.length === 0) return [];
+
+  // Pick up the "awarded earlier, never issued to Certifier" backlog so a
+  // post-set_my_name retry actually finalizes the certificate. The repair
+  // script handles ops-side backfills; this is the user-facing retry.
+  const existing = await certDb.getUserCredentials(userId);
+  const deferred = existing
+    .filter(c => !c.certifier_credential_id && !awarded.includes(c.credential_id))
+    .map(c => c.credential_id);
+
+  const toProcess = [...awarded, ...deferred];
+  if (toProcess.length === 0) return [];
+
   const creds = await certDb.getCredentials();
   const credMap = new Map(creds.map(c => [c.id, c]));
   const lines: string[] = [''];
-  for (const credId of awarded) {
+  let nameRequired = false;
+  for (const credId of toProcess) {
     const cred = credMap.get(credId);
     if (cred) {
       lines.push(`**Credential earned: ${cred.name}!**`);
-      const publicId = await issueCertifierBadge(userId, credId, cred, memberContext);
-      lines.push(...buildShareLinks(cred.name, publicId));
+      const result = await issueCertifierBadge(userId, credId, cred, memberContext);
+      if (result === NAME_REQUIRED_MARKER) {
+        nameRequired = true;
+        // Don't post share links or specialist notifications until the
+        // credential is actually issued — those re-fire on the retry pass
+        // once `set_my_name` has been called.
+        continue;
+      }
+      lines.push(...buildShareLinks(cred.name, result));
 
       // Post immediate Slack notification for Specialist (tier 3) credentials
       if (cred.tier === 3) {
@@ -529,6 +581,13 @@ async function checkAndFormatCredentials(
         });
       }
     }
+  }
+
+  if (nameRequired) {
+    // Sage rule (see buildCertificationContext) tells her to ask the learner
+    // for first + last, call set_my_name, then re-check credentials.
+    lines.push('');
+    lines.push(`⚠️ **${NAME_REQUIRED_MARKER}** — credential earned but not yet issued: we have no name on file for this learner. Ask them for the name they'd like on the certificate (first + last), then call \`set_my_name\` with both, then call \`check_credentials\` to finalize issuance.`);
   }
   return lines;
 }
@@ -573,6 +632,8 @@ export async function buildCertificationContext(
   lines.push('**Mastery fast-track (CHECK EVERY TURN after turn 3)**: Teaching and assessment serve different purposes. Teaching is for the learner; assessment is for the credential. After each learner response, ask: "Has this learner given correct, detailed answers to 3+ concepts without needing correction?" If YES: (1) STOP running demos — no more sandbox tool calls, (2) SAY SO: "You clearly know this material — I\'m going to skip the tutorial and have you demonstrate the remaining concepts directly," (3) for each remaining concept, ask ONE targeted demonstration question (scenario-based, teach-back, or "walk me through") that produces auditable evidence of competency. The conversation transcript is the audit trail — the learner\'s own words showing they understand each dimension. Same scoring rubric, same dimension requirements, same minimum engagement — just no unnecessary instruction. Continuing to teach or demo after someone has demonstrated mastery is the #1 learner complaint.');
 
   lines.push('**Protocol accuracy (non-negotiable)**: When a learner asks about protocol details (field definitions, message flows, terminology, agent roles), use search_docs or search_repos to verify before answering. Never construct protocol answers from general knowledge. If you cannot verify, say "I need to check that" and search. Teaching mode does not override accuracy — a wrong answer during certification is worse than saying "let me look that up."');
+  lines.push('');
+  lines.push(`**Credential name recovery**: If a tool result contains the marker \`${NAME_REQUIRED_MARKER}\`, the learner just earned a credential but has no name on file for the certificate. Ask them in one short turn for the name they'd like on it (first + last, last optional). Once they answer, call \`set_my_name\` with \`first_name\` and \`last_name\` from what they said. Do not announce the tool call. After it succeeds, call \`check_credentials\` once to finalize and post the share links. Never paste the literal \`${NAME_REQUIRED_MARKER}\` string into the learner-facing reply.`);
   lines.push('');
 
   // Inject training-agent URLs for demos. Pull the union of tenant_ids
@@ -802,6 +863,16 @@ export const CERTIFICATION_TOOLS: AddieTool[] = [
     name: 'get_learner_progress',
     description: 'Get the current learner\'s progress across all certification modules and tracks. Shows which modules are completed, in progress, or not started, plus any earned certificates.',
     usage_hints: 'use for "my progress", "certification status", "what have I completed"',
+    input_schema: {
+      type: 'object',
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: 'check_credentials',
+    description: 'Award any newly-eligible credentials and finalize any previously-deferred Certifier issuances for the current learner. Returns share links for newly-issued credentials, or a NAME_REQUIRED marker when the learner has no name on file. Use this after `set_my_name` to finalize a credential that was gated on the missing name.',
+    usage_hints: 'call after `set_my_name` to finalize a deferred credential; safe to call any time the learner asks "did I earn anything new?"',
     input_schema: {
       type: 'object',
       properties: {},
@@ -1818,6 +1889,21 @@ export function createCertificationToolHandlers(
       logger.error({ error }, 'Failed to complete certification module');
       throw new ToolError('Failed to record module completion. Please try again.');
     }
+  });
+
+  // ----- check_credentials -----
+  // Trigger an award/issue pass without completing a module. The primary use
+  // is the post-`set_my_name` retry: when a previous turn returned
+  // NAME_REQUIRED, Sage calls set_my_name to capture the learner's name and
+  // then calls this to finalize the deferred Certifier issuance.
+  handlers.set('check_credentials', async () => {
+    const userId = getUserId();
+    if (!userId) return 'You need to be logged in to check your credentials.';
+    const lines = await checkAndFormatCredentials(userId, memberContext);
+    if (lines.length === 0) {
+      return 'No new credentials to issue. Your existing credentials are unchanged.';
+    }
+    return lines.join('\n');
   });
 
   // ----- get_learner_progress -----

--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -26,6 +26,7 @@ import { createLogger } from '../../logger.js';
 import { notifySpecialistCredential } from '../jobs/credential-digest.js';
 import { TRAINING_AGENT_URL, tenantUrlsForModule, type ModuleTenantUrls } from '../../training-agent/config.js';
 import { ToolError } from '../tool-error.js';
+import { checkToolRateLimit } from './tool-rate-limiter.js';
 import { stripe } from '../../billing/stripe-client.js';
 import { attemptStripeReconciliation } from '../../billing/lazy-reconcile.js';
 
@@ -435,7 +436,7 @@ function validateDemonstrationIds(
  * deferred issuances on its next call.
  */
 export const NAME_REQUIRED_MARKER = 'NAME_REQUIRED';
-type IssueResult = string | null | typeof NAME_REQUIRED_MARKER;
+type IssueResult = string | null | 'NAME_REQUIRED';
 
 /**
  * Issue a Certifier badge for an awarded credential.
@@ -455,11 +456,16 @@ async function issueCertifierBadge(
 ): Promise<IssueResult> {
   if (!cred.certifier_group_id || !memberContext?.workos_user) return null;
 
-  // Gate: refuse to issue with email-as-name. Issuing a "tom@example.com"
-  // certificate is worse than the one-turn friction of asking for the name.
+  // Resolve the name from the freshest source available: the helper falls
+  // back to the DB when memberContext is stale (the closure-bound context
+  // doesn't see the row `set_my_name` just wrote), and to the Slack mapping
+  // when neither has a value.
+  const { resolveUserNameWithFallbacks } = await import('../../utils/resolve-user-name.js');
   const wu = memberContext.workos_user;
-  const hasFirst = (wu.first_name ?? '').trim().length > 0;
-  if (!hasFirst) {
+  const resolved = await resolveUserNameWithFallbacks(
+    getPool(), userId, wu.first_name, wu.last_name,
+  );
+  if (!(resolved.firstName ?? '').trim()) {
     logger.info({ userId, credId, email: wu.email }, 'Credential issuance gated: no first_name on file');
     return NAME_REQUIRED_MARKER;
   }
@@ -477,8 +483,12 @@ async function issueCertifierBadge(
     const credential = await issueCredential({
       groupId: cred.certifier_group_id,
       recipient: {
-        name: buildRecipientName(memberContext.workos_user),
-        email: memberContext.workos_user.email,
+        name: buildRecipientName({
+          first_name: resolved.firstName,
+          last_name: resolved.lastName,
+          email: wu.email,
+        }),
+        email: wu.email,
       },
       ...(expiryDate ? { expiryDate } : {}),
       ...(extraAttributes ? { customAttributes: extraAttributes } : {}),
@@ -544,14 +554,23 @@ async function checkAndFormatCredentials(
   const awarded = await certDb.checkAndAwardCredentials(userId);
 
   // Pick up the "awarded earlier, never issued to Certifier" backlog so a
-  // post-set_my_name retry actually finalizes the certificate. The repair
-  // script handles ops-side backfills; this is the user-facing retry.
+  // post-set_my_name retry actually finalizes the certificate. Bounded to a
+  // 24-hour window so we never accidentally re-issue a legitimately-issued
+  // older credential whose `certifier_credential_id` got nulled by an
+  // out-of-band operation (corrupt-row defense). The admin backfill route +
+  // repair script handle anything outside this window.
+  const RETRY_WINDOW_MS = 24 * 60 * 60 * 1000;
+  const now = Date.now();
   const existing = await certDb.getUserCredentials(userId);
   const deferred = existing
-    .filter(c => !c.certifier_credential_id && !awarded.includes(c.credential_id))
+    .filter(c =>
+      !c.certifier_credential_id &&
+      !awarded.includes(c.credential_id) &&
+      (now - new Date(c.awarded_at).getTime()) < RETRY_WINDOW_MS,
+    )
     .map(c => c.credential_id);
 
-  const toProcess = [...awarded, ...deferred];
+  const toProcess = [...new Set([...awarded, ...deferred])];
   if (toProcess.length === 0) return [];
 
   const creds = await certDb.getCredentials();
@@ -561,15 +580,15 @@ async function checkAndFormatCredentials(
   for (const credId of toProcess) {
     const cred = credMap.get(credId);
     if (cred) {
-      lines.push(`**Credential earned: ${cred.name}!**`);
       const result = await issueCertifierBadge(userId, credId, cred, memberContext);
       if (result === NAME_REQUIRED_MARKER) {
         nameRequired = true;
-        // Don't post share links or specialist notifications until the
-        // credential is actually issued — those re-fire on the retry pass
-        // once `set_my_name` has been called.
+        // Don't post "Credential earned!" or share links or specialist
+        // notifications until the credential is actually issued — those
+        // fire on the retry pass once `set_my_name` has been called.
         continue;
       }
+      lines.push(`**Credential earned: ${cred.name}!**`);
       lines.push(...buildShareLinks(cred.name, result));
 
       // Post immediate Slack notification for Specialist (tier 3) credentials
@@ -1899,6 +1918,13 @@ export function createCertificationToolHandlers(
   handlers.set('check_credentials', async () => {
     const userId = getUserId();
     if (!userId) return 'You need to be logged in to check your credentials.';
+    // Each call can fan out to N outbound Certifier calls (one per deferred
+    // credential); default cap (60/10min/user) bounds the blast radius.
+    const rate = await checkToolRateLimit('check_credentials', userId);
+    if (!rate.ok) {
+      const retrySeconds = Math.max(1, Math.ceil((rate.retryAfterMs ?? 60000) / 1000));
+      return `Rate limit exceeded on check_credentials. Try again in ~${retrySeconds} seconds.`;
+    }
     const lines = await checkAndFormatCredentials(userId, memberContext);
     if (lines.length === 0) {
       return 'No new credentials to issue. Your existing credentials are unchanged.';

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -1884,6 +1884,13 @@ export function createMemberToolHandlers(
     if (!memberContext?.workos_user?.workos_user_id) {
       return 'You need to be logged in to set your name. Please log in at https://agenticadvertising.org/dashboard first.';
     }
+    // Bounded — writes to users + organization_memberships + WorkOS on every
+    // call. Default cap (60/10min/user) is plenty for legitimate use.
+    const rate = await checkToolRateLimit('set_my_name', memberContext.workos_user.workos_user_id);
+    if (!rate.ok) {
+      const retrySeconds = Math.max(1, Math.ceil((rate.retryAfterMs ?? 60000) / 1000));
+      return `Rate limit exceeded on set_my_name. Try again in ~${retrySeconds} seconds.`;
+    }
     if (typeof input.first_name !== 'string') {
       throw new ToolError('first_name is required.');
     }

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -655,9 +655,23 @@ export const MEMBER_TOOLS: AddieTool[] = [
     },
   },
   {
+    name: 'set_my_name',
+    description:
+      "Set the current user's first name and (optionally) last name. Writes through to the local DB, organization memberships, and back to WorkOS. Use this when a credential check tells you the user has no name on file, or whenever the user explicitly asks to set or correct their name.",
+    usage_hints: 'use when check_credentials returns NAME_REQUIRED, or the user says "my name is X" / "set my name to X". For full names like "Tom Hespos" split into first_name="Tom" + last_name="Hespos". Do NOT call this for an admin renaming someone else — that\'s update_user_name (admin only).',
+    input_schema: {
+      type: 'object',
+      properties: {
+        first_name: { type: 'string', description: 'First name (required, 1-255 chars)' },
+        last_name: { type: 'string', description: 'Last name (optional, up to 255 chars). Pass empty string or omit to leave blank.' },
+      },
+      required: ['first_name'],
+    },
+  },
+  {
     name: 'update_my_profile',
     description:
-      "Update the current user's personal profile — who they are as a person. Can update headline, bio, expertise, interests, location, and social links. Only updates fields that are provided.",
+      "Update the current user's personal profile — who they are as a person. Can update headline, bio, expertise, interests, location, and social links. Only updates fields that are provided. Does NOT update first/last name — use set_my_name for that.",
     usage_hints: 'use when user wants to update their personal info, headline, bio, or expertise',
     input_schema: {
       type: 'object',
@@ -1866,6 +1880,53 @@ export function createMemberToolHandlers(
   // ============================================
   // PERSONAL PROFILE (the person)
   // ============================================
+  handlers.set('set_my_name', async (input) => {
+    if (!memberContext?.workos_user?.workos_user_id) {
+      return 'You need to be logged in to set your name. Please log in at https://agenticadvertising.org/dashboard first.';
+    }
+    if (typeof input.first_name !== 'string') {
+      throw new ToolError('first_name is required.');
+    }
+
+    const { sanitizeName } = await import('../../utils/resolve-user-name.js');
+    const rawFirst = input.first_name;
+    const rawLast = typeof input.last_name === 'string' ? input.last_name : '';
+    if (rawFirst.length > 255) throw new ToolError('first_name must be 255 characters or fewer.');
+    if (rawLast.length > 255) throw new ToolError('last_name must be 255 characters or fewer.');
+
+    const firstName = sanitizeName(rawFirst);
+    const lastName = sanitizeName(rawLast) || null;
+    if (!firstName) throw new ToolError('first_name cannot be empty after trimming.');
+
+    const userId = memberContext.workos_user.workos_user_id;
+    const pool = getPool();
+    await pool.query(
+      `UPDATE users SET first_name = $1, last_name = $2, updated_at = NOW() WHERE workos_user_id = $3`,
+      [firstName, lastName, userId]
+    );
+    await pool.query(
+      `UPDATE organization_memberships SET first_name = $1, last_name = $2, updated_at = NOW() WHERE workos_user_id = $3`,
+      [firstName, lastName, userId]
+    );
+
+    try {
+      await getWorkos().userManagement.updateUser({
+        userId,
+        firstName,
+        lastName: lastName ?? undefined,
+      });
+    } catch (workosError) {
+      logger.warn({ err: workosError, userId }, 'set_my_name: WorkOS push failed (local update applied)');
+    }
+
+    const { invalidateMemberContextCache } = await import('../member-context.js');
+    invalidateMemberContextCache();
+    logger.info({ userId }, 'set_my_name: user name updated');
+
+    const display = lastName ? `${firstName} ${lastName}` : firstName;
+    return `Your name is set to **${display}**. Anything that uses your name (credentials, member announcements, Addie's greetings) will now use this.`;
+  });
+
   handlers.set('get_my_profile', async () => {
     if (!memberContext?.workos_user?.workos_user_id) {
       return 'You need to be logged in to see your profile. Please log in at https://agenticadvertising.org/dashboard first.';

--- a/server/tests/unit/credential-name-required-marker.test.ts
+++ b/server/tests/unit/credential-name-required-marker.test.ts
@@ -25,4 +25,22 @@ describe('NAME_REQUIRED marker', () => {
     expect(NAME_REQUIRED_MARKER.trim()).toBe(NAME_REQUIRED_MARKER);
     expect(NAME_REQUIRED_MARKER).not.toMatch(/[\s*`]/);
   });
+
+  it('appears in the certification-tools source verbatim in three load-bearing sites', () => {
+    // The Sage rule, the warning line, and the sentinel return all reference
+    // NAME_REQUIRED_MARKER via template literal. This pins the count so a
+    // refactor that drops one accidentally fails the test instead of silently
+    // breaking the recovery loop.
+    const { readFileSync } = require('node:fs') as typeof import('node:fs');
+    const { resolve } = require('node:path') as typeof import('node:path');
+    const src = readFileSync(
+      resolve(__dirname, '../../src/addie/mcp/certification-tools.ts'),
+      'utf8',
+    );
+    const refs = src.match(/NAME_REQUIRED_MARKER/g) ?? [];
+    // 1 export + 1 type alias + 1 sentinel return + 1 caller comparison
+    // + 1 warning-line template + 2 Sage-rule template references = 7.
+    // Set a floor so dropping one fails loud while still allowing safe refactors.
+    expect(refs.length).toBeGreaterThanOrEqual(6);
+  });
 });

--- a/server/tests/unit/credential-name-required-marker.test.ts
+++ b/server/tests/unit/credential-name-required-marker.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Tests for the NAME_REQUIRED marker used by issueCertifierBadge and consumed
+ * by Sage's prompt rule (`Credential name recovery` in buildCertificationContext).
+ *
+ * Three load-bearing sites have to agree on this string:
+ *   1. The sentinel `issueCertifierBadge` returns
+ *   2. The warning line `checkAndFormatCredentials` emits when the gate fires
+ *   3. The Sage prompt rule that tells her how to recover
+ *
+ * If any drifts, Sage either loops back into the gate without recovering or
+ * pastes the literal marker into the learner-facing reply. Both have user-
+ * visible regressions (escalation #382 if the gate silently no-ops; ugly UX
+ * if Sage echoes the marker). This file keeps them in sync.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { NAME_REQUIRED_MARKER } from '../../src/addie/mcp/certification-tools.js';
+
+describe('NAME_REQUIRED marker', () => {
+  it('is the literal string Sage pattern-matches', () => {
+    expect(NAME_REQUIRED_MARKER).toBe('NAME_REQUIRED');
+  });
+
+  it('contains no whitespace or markdown so substring match never fails on rendering', () => {
+    expect(NAME_REQUIRED_MARKER.trim()).toBe(NAME_REQUIRED_MARKER);
+    expect(NAME_REQUIRED_MARKER).not.toMatch(/[\s*`]/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #4782 — the credential-issuance safety net behind escalation #382. Even after the auth-callback Slack fallback and onboarding gate in #4781, an exotic auth path could still drop a learner at credential-issuance time without a name. Today that produces an email-on-certificate (`tom@example.com`); now it produces a one-turn conversational recovery.

## Pattern

Hard block + Sage conversational prompt — option (1) from the issue. Fits the "Sage tools just work" pattern from feedback memory (Sage handles errors conversationally, doesn't announce tool names).

## What's new

| Change | Where |
|---|---|
| `NAME_REQUIRED_MARKER` constant — exported, referenced from all three sites (sentinel, warning line, Sage rule) | `server/src/addie/mcp/certification-tools.ts` |
| `issueCertifierBadge` returns the marker (no Certifier call) when `users.first_name` is empty | `certification-tools.ts:428` |
| `checkAndFormatCredentials` retries previously-deferred issuances on every call — that's the post-`set_my_name` finalize path | `certification-tools.ts:535` |
| `set_my_name` learner-self tool — wraps the same write-through-to-WorkOS path as the onboarding form | `server/src/addie/mcp/member-tools.ts` |
| `check_credentials` tool — runs an award/issue pass on demand (previously the only triggers were `complete_certification_module` / exam) | `certification-tools.ts` |
| Sage prompt rule "Credential name recovery" | `buildCertificationContext` |

## Flow

1. Learner finishes a module → `complete_certification_module` → `checkAndFormatCredentials` → `issueCertifierBadge` detects no name → returns `NAME_REQUIRED_MARKER`
2. `checkAndFormatCredentials` emits a warning line containing the marker. Share links + specialist Slack notification are deferred.
3. Sage sees the marker, asks the learner one short turn for their name
4. Sage calls `set_my_name` with what they said
5. Sage calls `check_credentials` — `checkAndFormatCredentials` picks up the deferred issuance via the new "already-awarded-but-unissued" path, calls Certifier with the real name, returns share links + fires specialist notification

## Test plan
- [x] `tests/unit/credential-name-required-marker.test.ts` — keeps the marker string stable across the sentinel + warning + Sage rule (drift would silently break recovery)
- [x] `npm run typecheck` clean
- [x] Precommit (test:unit + dynamic-imports + callapi-state-change + typecheck) green
- [ ] Manual: clear a test user's name, complete a module, observe `NAME_REQUIRED` in Sage's reply, set name, re-trigger, certificate finalizes
- [ ] Manual: confirm `set_my_name` write-through hits `users` + `organization_memberships` + WorkOS

## Related
- PR #4781 — auth-callback fallback + onboarding gate + WorkOS push-back (merged)
- PR #4768 — repair script + buildRecipientName helper (merged)
- Escalation #382 — Tom Hespos's "undefined undefined" credential

🤖 Generated with [Claude Code](https://claude.com/claude-code)