### PR TITLE
feat(addie): emit stream_error + discard mid-stream partial turns (#4797 PR1)

### DIFF
--- a/.changeset/4797-mid-stream-discard.md
+++ b/.changeset/4797-mid-stream-discard.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Stop persisting partial assistant turns when an Anthropic stream errors mid-reply. `processMessageStream` now yields a `stream_error` event after deltas have already shipped but before the underlying error throws (`server/src/addie/claude-client.ts`); Slack (`bolt-app.ts`), web (`addie-chat.ts`), and voice (`tavus.ts`) consumers handle it by rendering a recovery banner / SSE event and skipping persistence of the partial turn. The user's last message stays the most recent turn, so a retry or rephrase replays cleanly without a truncated assistant message biasing the resample — fixing the "goldfish" / dropped-context symptom observed during the 2026-05-19 Anthropic incidents. First step of #4797; banner + retry-after + model fallback follow.

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -1652,6 +1652,11 @@ async function handleUserMessage({
   let fullText = '';
   const toolsUsed: string[] = [];
   const toolExecutions: { tool_name: string; parameters: Record<string, unknown>; result: string }[] = [];
+  // Mid-stream upstream failure tracking (#4797). When set, we render a recovery
+  // banner in Slack and skip persisting the partial turn so prompt assembly for
+  // the next turn doesn't feed the model a truncated assistant message.
+  let streamWasInterrupted = false;
+  let streamInterruptReason = '';
 
   try {
     // Get team ID from context for streaming
@@ -1734,6 +1739,30 @@ async function handleUserMessage({
             await setStatus(`${event.reason}, retrying (${event.attempt}/${event.maxRetries})...`);
           } catch {
             // Ignore status update errors
+          }
+        } else if (event.type === 'stream_error') {
+          // Mid-stream upstream failure after partial delivery (#4797). Render
+          // the recovery banner in place, finalize the Slack message with
+          // feedback buttons, and mark the turn so the outer catch skips
+          // persistence. The original error throws on the next iteration of
+          // the underlying stream — control will continue to the outer catch.
+          streamWasInterrupted = true;
+          streamInterruptReason = event.reason;
+          logger.warn(
+            { reason: event.reason, deltasBeforeError: event.deltasBeforeError, fullTextLength: fullText.length },
+            'Addie Bolt: Stream interrupted mid-reply — discarding partial turn'
+          );
+          try {
+            await streamer.append({
+              markdown_text: `\n\n_(${event.reason} — I didn't save this response. Ask again and I'll start over.)_`,
+            });
+          } catch (appendError) {
+            logger.warn({ appendError }, 'Addie Bolt: Recovery banner append failed');
+          }
+          try {
+            await streamer.stop({ blocks: [buildFeedbackBlock()] });
+          } catch (stopError) {
+            logger.warn({ stopError }, 'Addie Bolt: Streamer stop after interruption failed');
           }
         } else if (event.type === 'done') {
           response = event.response;
@@ -1838,6 +1867,39 @@ async function handleUserMessage({
       }
     }
   } catch (error) {
+    // Stream interrupted mid-reply (#4797): recovery banner already rendered
+    // inline when the stream_error event fired. Skip persistence of the
+    // partial turn — the user's message remains the most recent turn so a
+    // retry or rephrase replays cleanly without a truncated assistant
+    // message biasing the resample.
+    if (streamWasInterrupted) {
+      logger.info(
+        { reason: streamInterruptReason, partialLength: fullText.length },
+        'Addie Bolt: Skipping persistence for interrupted stream turn'
+      );
+      // Preserve security-audit symmetry: the user message already wrote a
+      // row upstream (line 1599). Emit a minimal interrupted-turn row so
+      // forensics for an Anthropic-degraded window doesn't show a wall of
+      // user inputs with no matching assistant rows.
+      logInteraction({
+        id: thread.thread_id,
+        timestamp: new Date(),
+        event_type: 'assistant_thread',
+        channel_id: channelId,
+        thread_ts: threadTs,
+        user_id: userId,
+        input_text: messageText || '',
+        input_sanitized: inputValidation.sanitized,
+        output_text: '',
+        tools_used: toolsUsed,
+        model: AddieModelConfig.chat,
+        latency_ms: Date.now() - startTime,
+        flagged: true,
+        flag_reason: `stream_interrupted: ${streamInterruptReason}`,
+      });
+      return;
+    }
+
     // Provide user-friendly error message based on error type
     let errorMessage: string;
     if (error instanceof Error && error.message.includes('prompt is too long')) {

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -349,6 +349,16 @@ export type StreamEvent =
   | { type: 'tool_start'; tool_name: string; parameters: Record<string, unknown> }
   | { type: 'tool_end'; tool_name: string; result: string; is_error: boolean }
   | { type: 'retry'; attempt: number; maxRetries: number; delayMs: number; reason: string }
+  | {
+      // Mid-stream upstream failure after deltas were already yielded. Anthropic
+      // streaming has no resumption token and prompt cache only dedupes input —
+      // retrying produces a fresh sample, so we cannot stitch attempts together.
+      // Consumers should render a recovery banner and drop the partial assistant
+      // turn from conversation history (see issue #4797).
+      type: 'stream_error';
+      reason: string;
+      deltasBeforeError: number;
+    }
   | { type: 'done'; response: AddieResponse }
   | { type: 'error'; error: string };
 
@@ -1355,6 +1365,23 @@ export class AddieClaudeClient {
                                   streamRetryCount > maxStreamRetries;
               if (isExhausted) {
                 throw new RetriesExhaustedError(streamError, streamRetryCount);
+              }
+              // Mid-stream failure: deltas already shipped to the user, retry
+              // is impossible (no resumption token, prompt cache only dedupes
+              // input). Yield a stream_error so consumers can render a recovery
+              // banner and drop the partial assistant turn from conversation
+              // history. Then rethrow for the outer error path (#4797).
+              if (hasYieldedContent && isRetryableError(streamError)) {
+                const errorMsg = streamError instanceof Error ? streamError.message : String(streamError);
+                const reason = errorMsg.includes('overloaded') ? 'API is busy' :
+                              errorMsg.includes('rate') ? 'Rate limited' :
+                              errorMsg.includes('timeout') ? 'Request timed out' :
+                              'Connection broke mid-reply';
+                yield {
+                  type: 'stream_error',
+                  reason,
+                  deltasBeforeError: textChunks.length,
+                };
               }
               // Not retryable or already yielded content - rethrow original error
               throw streamError;

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -1193,6 +1193,24 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
             maxRetries: event.maxRetries,
             reason: event.reason,
           });
+        } else if (event.type === 'stream_error') {
+          // Mid-stream upstream failure after partial delivery (#4797). Forward
+          // to the SSE client so it can render a Retry affordance, then end
+          // the response. The underlying throw on the next iteration is caught
+          // by the outer handler — persistence is already skipped because we
+          // never reach addMessage on this path. The partial fullText is
+          // discarded by virtue of returning here.
+          logger.warn(
+            { reason: event.reason, deltasBeforeError: event.deltasBeforeError, fullTextLength: fullText.length },
+            'Addie Chat Stream: Stream interrupted mid-reply — discarding partial turn'
+          );
+          sendEvent("stream_error", {
+            reason: event.reason,
+            deltasBeforeError: event.deltasBeforeError,
+            recoverable: true,
+          });
+          res.end();
+          return;
         } else if (event.type === 'done') {
           response = event.response;
         } else if (event.type === 'error') {

--- a/server/src/routes/tavus.ts
+++ b/server/src/routes/tavus.ts
@@ -763,6 +763,17 @@ export function createTavusRouter() {
         if (event.type === "text") {
           fullResponse += event.text;
           sendChunk({ content: event.text });
+        } else if (event.type === "stream_error") {
+          // Mid-stream upstream failure (#4797). Drop the partial so we
+          // don't persist a truncated assistant turn into thread history
+          // and confuse the next-turn prompt assembly.
+          logger.warn(
+            { reason: event.reason, deltasBeforeError: event.deltasBeforeError, partialLength: fullResponse.length },
+            "Tavus: Addie stream interrupted mid-reply — discarding partial turn"
+          );
+          fullResponse = '';
+          streamError = true;
+          break;
         } else if (event.type === "error") {
           logger.error({ error: event.error }, "Tavus: Addie stream error");
           streamError = true;

--- a/server/tests/unit/claude-client-stream-error.test.ts
+++ b/server/tests/unit/claude-client-stream-error.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/**
+ * Mid-stream upstream-failure event surface (#4797).
+ *
+ * When Anthropic's streaming API errors after deltas have already shipped
+ * to the user, `processMessageStream` must yield a `stream_error` event
+ * before the underlying error throws — so consumers (Slack via bolt-app,
+ * web via addie-chat, voice via tavus) can render a recovery banner and
+ * drop the partial assistant turn from conversation history.
+ *
+ * The "no retry after content yielded" guard in claude-client.ts is
+ * load-bearing: Anthropic streaming has no resumption token and the
+ * prompt cache only dedupes input, so a retried request would sample a
+ * fresh output and we'd be stitching two unrelated streams. The event
+ * gives the consumer the signal needed to do the discard cleanly.
+ */
+
+// Two stream stubs covering both realistic mid-stream failure shapes.
+//
+// Production sees either:
+// 1. A keyword-only Error (e.g. when the underlying SDK has already
+//    unwrapped to a generic error) — matches the line-103 fallback in
+//    `isRetryableError`.
+// 2. An SDK `APIError` carrying an SSE-body `{ error: { type:
+//    'overloaded_error' } }` and `status: undefined` (streaming errors
+//    arrive inside an HTTP 200) — matches the line-95-99 path in
+//    `isRetryableError`. This is the load-bearing branch in prod.
+function makeKeywordErrorStub() {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield {
+        type: 'content_block_delta',
+        delta: { type: 'text_delta', text: 'Sure, the answer is ' },
+      };
+      throw new Error("overloaded_error: Anthropic API is overloaded");
+    },
+    finalMessage: vi.fn().mockResolvedValue(null),
+  };
+}
+
+function makeApiErrorStub(MockedAPIError: { new (msg: string): Error & { status?: number; error?: unknown } }) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield {
+        type: 'content_block_delta',
+        delta: { type: 'text_delta', text: 'Sure, the answer is ' },
+      };
+      const apiErr = new MockedAPIError("Streaming error");
+      apiErr.status = undefined;
+      apiErr.error = { type: 'overloaded_error', message: 'overloaded' };
+      throw apiErr;
+    },
+    finalMessage: vi.fn().mockResolvedValue(null),
+  };
+}
+
+// Selects which stub the mocked SDK returns. Mutated per-test below.
+let streamStubFactory: () => ReturnType<typeof makeKeywordErrorStub> = makeKeywordErrorStub;
+
+vi.mock('@anthropic-ai/sdk', () => {
+  class MockAPIError extends Error {
+    status?: number;
+    error?: unknown;
+    constructor(msg: string) { super(msg); this.name = 'APIError'; }
+  }
+  class MockAPIConnectionError extends Error {
+    constructor(msg: string) { super(msg); this.name = 'APIConnectionError'; }
+  }
+  return {
+    default: class {
+      beta = {
+        messages: {
+          stream: vi.fn(() => streamStubFactory()),
+          create: vi.fn(),
+        },
+      };
+      messages = {
+        create: vi.fn(),
+        stream: vi.fn(() => streamStubFactory()),
+      };
+    },
+    APIError: MockAPIError,
+    APIConnectionError: MockAPIConnectionError,
+  };
+});
+
+import { AddieClaudeClient, type StreamEvent } from '../../src/addie/claude-client.js';
+import {
+  __setCostTrackerStore,
+  __createInMemoryCostStore,
+} from '../../src/addie/claude-cost-tracker.js';
+
+beforeEach(() => {
+  __setCostTrackerStore(__createInMemoryCostStore());
+  // Default stub: keyword-only Error. Per-test overrides flip to APIError.
+  streamStubFactory = makeKeywordErrorStub;
+});
+
+describe('processMessageStream — mid-stream upstream failure (#4797)', () => {
+  it('yields a stream_error event with deltasBeforeError before the underlying error throws', async () => {
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
+
+    const events: StreamEvent[] = [];
+    for await (const event of client.processMessageStream(
+      'tell me about X',
+      undefined,
+      undefined,
+      { costScope: { userId: 'test-user', tier: 'member_paid' }, maxIterations: 1 },
+    )) {
+      events.push(event);
+    }
+
+    // Should have seen the text delta then the stream_error event.
+    const textEvents = events.filter(e => e.type === 'text');
+    expect(textEvents.length).toBeGreaterThan(0);
+    expect((textEvents[0] as { type: 'text'; text: string }).text).toBe('Sure, the answer is ');
+
+    const streamErrorEvents = events.filter(e => e.type === 'stream_error');
+    expect(streamErrorEvents).toHaveLength(1);
+
+    const evt = streamErrorEvents[0] as Extract<StreamEvent, { type: 'stream_error' }>;
+    expect(evt.reason).toBe('API is busy');
+    expect(evt.deltasBeforeError).toBe(1);
+
+    // The underlying error is wrapped into a final `error` event by
+    // processMessageStream's outer catch (claude-client.ts:1730). The
+    // consumer-side throw happens in bolt-app's event-loop branch that
+    // re-raises on `error`; addie-chat/tavus return/break on the
+    // `stream_error` event instead. Either path lands persistence in
+    // the discard branch.
+    const errorEvents = events.filter(e => e.type === 'error');
+    expect(errorEvents).toHaveLength(1);
+    expect((errorEvents[0] as { type: 'error'; error: string }).error).toMatch(/overloaded/);
+  });
+
+  it('orders stream_error after text deltas (consumer can render in-place recovery)', async () => {
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
+
+    const eventTypes: string[] = [];
+    try {
+      for await (const event of client.processMessageStream(
+        'hi',
+        undefined,
+        undefined,
+        { costScope: { userId: 'test-user-2', tier: 'member_paid' }, maxIterations: 1 },
+      )) {
+        eventTypes.push(event.type);
+      }
+    } catch {
+      // expected
+    }
+
+    const textIdx = eventTypes.indexOf('text');
+    const streamErrorIdx = eventTypes.indexOf('stream_error');
+    expect(textIdx).toBeGreaterThanOrEqual(0);
+    expect(streamErrorIdx).toBeGreaterThan(textIdx);
+  });
+
+  it('also fires for the production-shape APIError (SSE-body overloaded_error, status undefined)', async () => {
+    // Switch the SDK mock to throw an APIError carrying the SSE-body
+    // shape. This is the actual production code path (`isRetryableError`
+    // line 95-99 in anthropic-retry.ts), not the line-103 keyword
+    // fallback the first test exercises.
+    const sdkModule = await import('@anthropic-ai/sdk');
+    const MockedAPIError = (sdkModule as unknown as { APIError: new (msg: string) => Error & { status?: number; error?: unknown } }).APIError;
+    streamStubFactory = () => makeApiErrorStub(MockedAPIError);
+
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
+
+    const events: StreamEvent[] = [];
+    for await (const event of client.processMessageStream(
+      'tell me about Y',
+      undefined,
+      undefined,
+      { costScope: { userId: 'test-user-3', tier: 'member_paid' }, maxIterations: 1 },
+    )) {
+      events.push(event);
+    }
+
+    const streamErrorEvents = events.filter(e => e.type === 'stream_error');
+    expect(streamErrorEvents).toHaveLength(1);
+    const evt = streamErrorEvents[0] as Extract<StreamEvent, { type: 'stream_error' }>;
+    expect(evt.deltasBeforeError).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

First PR for #4797. Stops persisting partial assistant turns when an Anthropic stream errors mid-reply — fixes the "goldfish" / dropped-context symptom multiple users reported during today's Anthropic-degraded windows (Haiku 4.5 + Opus 4.7 elevated errors, ~5h total).

`processMessageStream` now yields a `stream_error` event before the underlying error throws on the mid-stream path. Slack (`bolt-app`), web (`addie-chat`), and voice (`tavus`) consumers handle it by skipping persistence of the partial turn so the next-turn prompt assembly doesn't see a truncated assistant message biasing the resample. The user's last message remains the most recent turn — a retry or rephrase replays cleanly.

Retry mid-stream is impossible by construction (Anthropic streaming has no resumption token and the prompt cache dedupes input only, so a retried request would sample a fresh output and we'd be stitching two unrelated streams). The right shape is making mid-stream failure a clean, recoverable user state — which is what this PR delivers.

## Scope

- **In:** stream_error event + persistence discard across all three streaming consumers, recovery banner copy in Slack (using `event.reason`), SSE forwarding for web client, audit-log symmetry on the discard branch, two test stubs covering both production failure shapes (keyword-only Error and APIError with SSE-body `overloaded_error`).
- **Out (PR2):** provider-degradation banner with `retry-after` header + rolling-rate trigger, pre-content model fallback (Opus 4.7 → Sonnet 4.6, Haiku 4.5 → Sonnet 4.6), `withStreamRetry` helper consolidation, tool-use partial carveout.

## Review trail

- prompt-engineer-deep review of the issue body refined the persistence decision (discard, not commit) and the threshold strategy.
- code-reviewer-deep review of this PR caught three should-fix items (now addressed): test mock fidelity for the production APIError shape, audit-log gap on the early return, banner text dropping the reason.

## Test plan

- [x] `npx vitest run tests/unit/claude-client-stream-error.test.ts` — 3 tests pass (delta-then-stream-error, event ordering, APIError shape).
- [x] `npx tsc --noEmit` clean.
- [ ] Manual: tail an Addie Slack DM during an Anthropic-degraded window, confirm the recovery banner edits in place and the next user message starts cleanly without the model anchoring on a phantom prefix.

Closes nothing on its own; #4797 stays open until PR2 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)