### PR TITLE
docs(3.1-beta): switch docs banner to beta + WG-review clarifications

### DIFF
--- a/.changeset/3-1-beta-banner-and-wg-review.md
+++ b/.changeset/3-1-beta-banner-and-wg-review.md
@@ -1,0 +1,13 @@
+---
+"adcontextprotocol": patch
+---
+
+Two coordinated updates ahead of 3.1 beta:
+
+- **Docs banner switch**: `docs.json` banner content updated from "🎉 AdCP 3.0 is now GA — see what's new" → "🚀 AdCP 3.1 beta is now available — see what's new". Links to `/docs/reference/whats-new-in-3-1`. The 3.0 GA banner had been displayed on docs.adcontextprotocol.org for months and was out of date. AAO main site (`server/public/index.html`) banner intentionally stays on "3.0 GA" — that audience is operators/agencies/members, beta messaging adds confusion without value.
+
+- **`whats-new-in-3-1.mdx` updates**:
+  - **Beta status callout** at top: status is 3.1 beta; spec feature-complete; SDK + grader advisory-only during beta; GA target 2026-05-29; adopters can pin `adcp_version: "3.1-beta"` today.
+  - **New "Final-spec clarifications (WG-review batch)" section** covering the 10 normative tightenings from PR #4796 (`4c124545f1`): `PROPOSAL_NOT_FOUND`, forward-compatible `error.code` decoding, `idempotency_key` required on every task request, MCP tool wrapper envelope tolerance, MCP serialization normalization (drops `payload.required`, adds `context` envelope field), idempotency replay returns historical snapshot, `refine[]` finalize-exclusivity, `pending_creatives` status disambiguation, `notices` advisory channel on runner-output-contract.
+
+The clarifications batch shipped after the original whats-new page was written; this catches the page up to current main.

--- a/docs.json
+++ b/docs.json
@@ -2,7 +2,7 @@
   "$schema": "https://mintlify.com/schema.json",
   "name": "AdCP - Ad Context Protocol",
   "banner": {
-    "content": "🎉 AdCP 3.0 is now GA — [see what's new](/docs/reference/whats-new-in-v3)",
+    "content": "🚀 AdCP 3.1 beta is now available — [see what's new](/docs/reference/whats-new-in-3-1)",
     "dismissible": true
   },
   "description": "AdCP (Ad Context Protocol) is the open standard for agentic advertising. It defines how AI agents buy media, generate creatives, activate audiences, and enforce governance across platforms.",

--- a/docs/reference/whats-new-in-3-1.mdx
+++ b/docs/reference/whats-new-in-3-1.mdx
@@ -4,6 +4,10 @@ description: "Adopter overview of AdCP 3.1 — distributed brand.json, dependenc
 "og:title": "AdCP — What's New in 3.1"
 ---
 
+<Warning>
+**Status: 3.1 beta.** The spec is feature-complete for 3.1; the published `@adcp/sdk` and the runtime grader are advisory-only against the new surfaces during beta. 3.1 GA target: **2026-05-29**. Adopters can pin `adcp_version: "3.1-beta"` today and migrate the pin to `"3.1"` on GA without code changes.
+</Warning>
+
 AdCP 3.1 is a minor release. Every 3.1 change is **additive** over 3.0: new fields are optional, no required field was removed, no shape changed in a way that breaks a 3.0-conformant client. **No breaking changes.** But schemas moved — 3.1 introduces meaningful new surfaces that solve production problems 3.0 left open. **You should bump your pin to 3.1 as soon as your SDK is ready** to pick up the new fields.
 
 For per-PR detail and migration tables, see [Release Notes § Version 3.1.0](/docs/reference/release-notes#version-3-1-0-unreleased). For long-form normative reference, follow the link on each headline below.
@@ -159,6 +163,22 @@ Three production-scale improvements. **Managed-network scale:** authoritative `a
 Capability-gated storyboard scenarios let sellers run *only* what they claim. New scenarios for `frequency_cap_enforcement`, `per_creative_attribution`, `metric_mode` + ROAS (using a `contains:` matcher), `audience_buy_flow`, `event_dedup_flow`, and `performance_buy_flow` (capability-gated CPA buys). Plus a new `requires` runtime gate on Storyboards that conditions execution on declared capabilities — no more all-or-nothing scenarios. The full set is enumerated on the [Compliance catalog](/docs/building/verification/compliance-catalog).
 
 → Spec: [Compliance catalog](/docs/building/verification/compliance-catalog) · PRs [#4312](https://github.com/adcontextprotocol/adcp/pull/4312), [#4642](https://github.com/adcontextprotocol/adcp/pull/4642), [#4664](https://github.com/adcontextprotocol/adcp/pull/4664), [#4722](https://github.com/adcontextprotocol/adcp/pull/4722), [#4727](https://github.com/adcontextprotocol/adcp/pull/4727), [#4731](https://github.com/adcontextprotocol/adcp/pull/4731)
+
+### Final-spec clarifications (WG-review batch)
+
+Ten normative tightenings landed as the spec settled into beta. Mostly low-risk — adopters who'd already inferred reasonable defaults will continue working — but worth knowing about because the grader will check them at GA.
+
+- **`PROPOSAL_NOT_FOUND` error code** (#4043). Completes the proposal-lifecycle error catalog (alongside `PROPOSAL_EXPIRED` and `PROPOSAL_NOT_COMMITTED`). Sellers MUST return it when a referenced `proposal_id` isn't recognized — wrong tenant, evicted from cache, or never finalized. Recovery: correctable.
+- **Forward-compatible `error.code` decoding** (#4227). Receivers MUST treat `error.code` as an **open enum** — decode unknown codes without rejecting, classify recovery from `error.recovery`, default to `transient` when recovery is absent. Senders from 3.1 onward MUST populate `error.recovery` on every error. Unblocks additive-in-patch for error codes on future maintenance lines without breaking pinned-version receivers.
+- **`idempotency_key` required on every AdCP task request** (#4399). Closes a longstanding gap where the spec said dedupe via idempotency_key but didn't require buyers to send one. Sellers MAY reject requests missing the key after 3.1 GA.
+- **MCP tool wrappers MUST tolerate envelope fields** (#4399). The protocol envelope (`status`, `context_id`, `context`, `task_id`, `timestamp`, `replayed`, `adcp_error`, `governance_context`, `idempotency_key`) on MCP requests now goes through the wrapper layer instead of being rejected as "unexpected fields." Closes a wrapper-layer bug where adopters had to omit envelope fields to call MCP successfully.
+- **MCP serialization normalization** (#2911). Drops `payload.required` from the protocol-envelope schema; adds the `context` field at envelope level; clarifies the flat-sibling MCP wire shape (envelope and body fields at the root, no nested `payload:` key). Adopters who'd implemented the de-facto flat shape are unaffected.
+- **Idempotency replay returns historical snapshot** (#4371). When a buyer retries a stateful create call (e.g., `create_media_buy`) within the replay window, the seller MUST return the **historical snapshot** of state-tracking fields (`status`, `confirmed_at`, etc.) — not the current state. Otherwise an at-most-once retry mutates the response from underneath the buyer.
+- **`refine[]` finalize-exclusivity + multi-finalize atomicity** (#4107). `get_products` `refine[]` semantics tightened: when one entry uses `action: "finalize"`, that entry MUST be the only one in the array — multi-finalize is rejected. Multi-finalize across multiple proposals goes through separate `get_products` calls. Atomicity guarantee: finalize either succeeds completely or leaves the proposal unchanged.
+- **`pending_creatives` status disambiguation** (#4196). The description now explicitly states buyer action is required — sellers awaiting creative sync MUST surface what's missing (creative count, deadline) in the response message rather than just emitting the status enum value. Clarifies adopter-facing UX without changing the wire shape.
+- **`notices` advisory channel on runner-output-contract** (#4418). Storyboard runners surface non-failure advisories (e.g., "agent still advertises a deprecated specialism, but the storyboard passed") through a structured `notices[]` field on the run output. Replaces ad-hoc `skip.detail` prose carrying advisory text — unparseable for graders and dashboards.
+
+→ Full batch shipped as one commit: PR [#4796](https://github.com/adcontextprotocol/adcp/pull/4796) (`4c124545f1`). See per-issue links for the full prose.
 
 ### Misc schema additions
 


### PR DESCRIPTION
Two coordinated updates ahead of the 3.1 beta drop:

## 1. Docs banner switch

\`docs.json\` banner: **🎉 AdCP 3.0 is now GA** → **🚀 AdCP 3.1 beta is now available**, links to \`/docs/reference/whats-new-in-3-1\`. The 3.0 GA banner had been displayed on docs.adcontextprotocol.org for months and was out of date.

**Intentionally not touched:** \`server/public/index.html\` (AAO main site banner stays on "3.0 GA"). Different audience — operators, agencies, members. Beta messaging adds confusion there without value.

Other "3.0 GA" mentions in body docs (faq.mdx, design-principles.mdx, v2-sunset.mdx, etc.) are factual historical context and stay.

## 2. \`whats-new-in-3-1.mdx\` catch-up

- **Beta status callout** at top: spec feature-complete; SDK + grader advisory-only during beta; GA target 2026-05-29; adopters can pin \`adcp_version: "3.1-beta"\` today and migrate to \`"3.1"\` on GA without code changes.
- **New "Final-spec clarifications (WG-review batch)" section** covering the 10 normative tightenings from PR [#4796](https://github.com/adcontextprotocol/adcp/pull/4796) (\`4c124545f1\`) that landed after the original whats-new page was written:
  - \`PROPOSAL_NOT_FOUND\` error code (#4043)
  - Forward-compatible \`error.code\` decoding (#4227) — open-enum receiver contract, recovery-classification rule
  - \`idempotency_key\` required on every AdCP task request (#4399)
  - MCP tool wrappers MUST tolerate envelope fields (#4399)
  - MCP serialization normalization, drop \`payload.required\`, add \`context\` envelope field (#2911)
  - Idempotency replay returns historical snapshot (#4371)
  - \`refine[]\` finalize-exclusivity + multi-finalize atomicity (#4107)
  - \`pending_creatives\` status disambiguation (#4196)
  - \`notices\` advisory channel on runner-output-contract (#4418)

## Test plan

- [x] \`test:docs-nav\` ✓
- [x] \`git diff --stat origin/main..HEAD\` shows only 2 files modified + 1 changeset (no stale-tree surprises)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)