### PR TITLE
fix(agent-visibility): gate public visibility on verified brand domain (#4511)

### DIFF
--- a/.changeset/agent-visibility-brand-domain-gate.md
+++ b/.changeset/agent-visibility-brand-domain-gate.md
@@ -1,0 +1,5 @@
+---
+---
+
+Report an unverified primary brand domain before per-agent hostname ownership
+errors when publishing an agent publicly.

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -62,7 +62,7 @@ import { createEscalation } from "../db/escalation-db.js";
 import { insertTypeReclassification } from "../db/type-reclassification-log-db.js";
 import { recordProfilePublishedIfNeeded } from "../services/profile-publish-event.js";
 import { gateAgentVisibilityForCaller, computeAgentVisibilityGate, type VisibilityWarning, type AgentVisibilityGate } from "../services/agent-visibility-gate.js";
-import { getBrandPrimaryDomain } from "../services/brand-domain-resolver.js";
+import { getBrandPrimaryDomain, getBrandPrimaryDomainRecord } from "../services/brand-domain-resolver.js";
 import { normalizeFoundingMemberGrant } from "../services/founding-member-grant.js";
 
 const orgKnowledgeDb = new OrgKnowledgeDatabase();
@@ -682,11 +682,11 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
           });
         }
         const profile = await memberDb.getProfileByOrgId(devOrgId);
-        const devBrandPrimary = await getBrandPrimaryDomain(devOrgId);
+        const devBrandRecord = await getBrandPrimaryDomainRecord(devOrgId);
         if (profile) {
-          if (devBrandPrimary) {
-            profile.resolved_brand = await resolveBrand(brandDb, devBrandPrimary);
-            (profile as unknown as Record<string, unknown>).primary_brand_domain = devBrandPrimary;
+          if (devBrandRecord) {
+            profile.resolved_brand = await resolveBrand(brandDb, devBrandRecord.domain);
+            (profile as unknown as Record<string, unknown>).primary_brand_domain = devBrandRecord.domain;
           }
         }
         const devHasApiAccess = hasApiAccess(resolveMembershipTier(localOrg));
@@ -698,7 +698,8 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
           has_api_access: devHasApiAccess,
           agent_visibility_gate: computeAgentVisibilityGate({
             hasApiAccess: devHasApiAccess,
-            brandPrimaryDomain: devBrandPrimary,
+            brandPrimaryDomain: devBrandRecord?.domain ?? null,
+            brandDomainVerified: devBrandRecord?.verified ?? false,
           }),
         });
       }
@@ -744,14 +745,14 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       }
 
       const profile = await memberDb.getProfileByOrgId(targetOrgId);
-      const brandPrimary = await getBrandPrimaryDomain(targetOrgId);
+      const brandRecord = await getBrandPrimaryDomainRecord(targetOrgId);
       if (profile) {
-        if (brandPrimary) {
-          profile.resolved_brand = await resolveBrand(brandDb, brandPrimary);
+        if (brandRecord) {
+          profile.resolved_brand = await resolveBrand(brandDb, brandRecord.domain);
           // After Stage 2 of #4159 dropped the column, the field is
           // re-derived from organization_domains.is_primary so clients
           // (member-profile.html, dashboard-agents.html) keep working.
-          (profile as unknown as Record<string, unknown>).primary_brand_domain = brandPrimary;
+          (profile as unknown as Record<string, unknown>).primary_brand_domain = brandRecord.domain;
         }
       }
 
@@ -768,7 +769,8 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
         has_api_access: callerHasApiAccess,
         agent_visibility_gate: computeAgentVisibilityGate({
           hasApiAccess: callerHasApiAccess,
-          brandPrimaryDomain: brandPrimary,
+          brandPrimaryDomain: brandRecord?.domain ?? null,
+          brandDomainVerified: brandRecord?.verified ?? false,
         }),
       });
     } catch (error) {
@@ -1317,6 +1319,25 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
         const localOrgForTier = await orgDb.getOrganization(targetOrgId);
         const callerHasApi = hasApiAccess(resolveMembershipTier(localOrgForTier));
         const gated = gateAgentVisibilityForCaller(updates.agents, callerHasApi);
+
+        // If any agent will be publicly listed, require a DNS-verified brand domain.
+        // Tier downgrade (above) is a soft warning; domain verification is a hard gate.
+        if (gated.agents.some((a) => a.visibility === 'public')) {
+          const brandRec = await getBrandPrimaryDomainRecord(targetOrgId);
+          if (!brandRec) {
+            return res.status(400).json({
+              error: 'brand_domain_required',
+              message: 'To list an agent publicly, your profile needs a primary brand domain.',
+            });
+          }
+          if (!brandRec.verified) {
+            return res.status(400).json({
+              error: 'brand_domain_unverified',
+              message: 'To list an agent publicly, your primary brand domain must be DNS-verified. Complete the domain verification challenge in the Brand section of your profile.',
+            });
+          }
+        }
+
         // Resolve `type` server-side from the capability snapshot. The
         // client cannot pin a misclassification (e.g. sales agent typed
         // 'buying') — the inferred_type from the crawler probe wins. See
@@ -1533,7 +1554,8 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       // setPrimaryDomain (Stage 3) racing this read lands old-or-new — both
       // states the org legitimately controls, so worst case is wrong-brand
       // listing recoverable by re-publish.
-      const brandPrimaryDomain = await getBrandPrimaryDomain(orgId);
+      const brandPrimaryRecord = await getBrandPrimaryDomainRecord(orgId);
+      const brandPrimaryDomain = brandPrimaryRecord?.domain ?? null;
       const parsedAgents = typeof row.agents === 'string'
         ? JSON.parse(row.agents)
         : Array.isArray(row.agents) ? row.agents : [];
@@ -1589,6 +1611,16 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
             body: {
               error: 'brand_domain_required',
               message: 'To list an agent publicly, your profile needs a primary brand domain. If you have a verified email domain in your organization (e.g. via SSO), it should auto-populate — otherwise, claim your brand domain in the Brand section of your profile.',
+            },
+          };
+        }
+        if (!brandPrimaryRecord?.verified) {
+          await client.query('ROLLBACK');
+          return {
+            status: 400,
+            body: {
+              error: 'brand_domain_unverified',
+              message: 'To list an agent publicly, your primary brand domain must be DNS-verified. Complete the domain verification challenge in the Brand section of your profile.',
             },
           };
         }

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -1580,6 +1580,33 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       }
       const agent = agents[index];
 
+      // For public listing, the primary brand domain is the first
+      // prerequisite: an imported or legacy primary domain can exist before
+      // DNS verification is complete. Report that state before falling
+      // through to per-agent hostname ownership checks.
+      if (target === 'public') {
+        if (!brandPrimaryDomain) {
+          await client.query('ROLLBACK');
+          return {
+            status: 400,
+            body: {
+              error: 'brand_domain_required',
+              message: 'To list an agent publicly, your profile needs a primary brand domain. If you have a verified email domain in your organization (e.g. via SSO), it should auto-populate — otherwise, claim your brand domain in the Brand section of your profile.',
+            },
+          };
+        }
+        if (!brandPrimaryRecord?.verified) {
+          await client.query('ROLLBACK');
+          return {
+            status: 400,
+            body: {
+              error: 'brand_domain_unverified',
+              message: 'To list an agent publicly, your primary brand domain must be DNS-verified. Complete the domain verification challenge in the Brand section of your profile.',
+            },
+          };
+        }
+      }
+
       // Re-verify hostname ownership on any non-private flip (#4499 MVP).
       // A grandfathered row registered before the gate landed should not
       // be promotable to `members_only` or `public` without satisfying
@@ -1604,26 +1631,6 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       // Only the public path needs to reach out to brand.json, so the
       // brand-domain requirement is scoped to `target === 'public'`.
       if (target === 'public') {
-        if (!brandPrimaryDomain) {
-          await client.query('ROLLBACK');
-          return {
-            status: 400,
-            body: {
-              error: 'brand_domain_required',
-              message: 'To list an agent publicly, your profile needs a primary brand domain. If you have a verified email domain in your organization (e.g. via SSO), it should auto-populate — otherwise, claim your brand domain in the Brand section of your profile.',
-            },
-          };
-        }
-        if (!brandPrimaryRecord?.verified) {
-          await client.query('ROLLBACK');
-          return {
-            status: 400,
-            body: {
-              error: 'brand_domain_unverified',
-              message: 'To list an agent publicly, your primary brand domain must be DNS-verified. Complete the domain verification challenge in the Brand section of your profile.',
-            },
-          };
-        }
         try {
           const parsed = new URL(agent.url);
           if (parsed.protocol !== 'https:') {

--- a/server/src/services/agent-visibility-gate.ts
+++ b/server/src/services/agent-visibility-gate.ts
@@ -30,7 +30,10 @@ import { validateExternalUrl } from '../utils/url-security.js';
  * warnings emitted by {@link gateAgentVisibilityForCaller} below — keep the
  * vocabulary aligned when adding new reasons.
  */
-export type AgentVisibilityGateReason = 'tier_required' | 'brand_domain_required';
+export type AgentVisibilityGateReason =
+  | 'tier_required'
+  | 'brand_domain_required'
+  | 'brand_domain_unverified';
 
 export interface AgentVisibilityGate {
   can_publish_publicly: boolean;
@@ -40,10 +43,12 @@ export interface AgentVisibilityGate {
 export function computeAgentVisibilityGate(opts: {
   hasApiAccess: boolean;
   brandPrimaryDomain: string | null | undefined;
+  brandDomainVerified: boolean;
 }): AgentVisibilityGate {
   const reasons: AgentVisibilityGateReason[] = [];
   if (!opts.hasApiAccess) reasons.push('tier_required');
   if (!opts.brandPrimaryDomain) reasons.push('brand_domain_required');
+  else if (!opts.brandDomainVerified) reasons.push('brand_domain_unverified');
   return { can_publish_publicly: reasons.length === 0, reasons };
 }
 

--- a/server/src/services/brand-domain-resolver.ts
+++ b/server/src/services/brand-domain-resolver.ts
@@ -16,19 +16,21 @@ import { createLogger } from '../logger.js';
 
 const logger = createLogger('brand-domain-resolver');
 
+export interface BrandPrimaryDomainRecord {
+  domain: string;
+  verified: boolean;
+}
+
 /**
- * Resolve the brand-primary domain for an org. Reads
- * `organization_domains.is_primary=true`. Returns null when no such row.
- *
- * Detects the rare case of multiple is_primary=true rows (the "exactly one"
- * invariant Stage 0 enforced); logs a loud error but still returns a valid
- * domain so callers don't crash on the anomaly.
+ * Resolve the brand-primary domain record for an org. Returns both `domain`
+ * and `verified` so callers can gate on DNS proof-of-control. Returns null
+ * when no is_primary=true row exists.
  */
-export async function getBrandPrimaryDomain(orgId: string): Promise<string | null> {
+export async function getBrandPrimaryDomainRecord(orgId: string): Promise<BrandPrimaryDomainRecord | null> {
   const pool = getPool();
 
-  const od = await pool.query<{ domain: string }>(
-    `SELECT domain FROM organization_domains
+  const od = await pool.query<{ domain: string; verified: boolean }>(
+    `SELECT domain, verified FROM organization_domains
       WHERE workos_organization_id = $1 AND is_primary = true`,
     [orgId],
   );
@@ -38,7 +40,15 @@ export async function getBrandPrimaryDomain(orgId: string): Promise<string | nul
       'Multiple is_primary=true rows on organization_domains for one org — invariant broken',
     );
   }
-  return od.rows[0]?.domain ?? null;
+  return od.rows[0] ? { domain: od.rows[0].domain, verified: od.rows[0].verified } : null;
+}
+
+/**
+ * Convenience wrapper returning only the domain string. Delegates to
+ * {@link getBrandPrimaryDomainRecord}. Use when verified status is not needed.
+ */
+export async function getBrandPrimaryDomain(orgId: string): Promise<string | null> {
+  return (await getBrandPrimaryDomainRecord(orgId))?.domain ?? null;
 }
 
 /**

--- a/server/tests/integration/agent-visibility-e2e.test.ts
+++ b/server/tests/integration/agent-visibility-e2e.test.ts
@@ -150,6 +150,18 @@ describe('Agent visibility E2E', () => {
     await closeDatabase();
   });
 
+  async function seedBrandPrimaryUnverified(orgId: string, domain: string) {
+    await pool.query(
+      `INSERT INTO organization_domains
+         (workos_organization_id, domain, verified, is_primary, source, created_at, updated_at)
+       VALUES ($1, $2, false, true, 'workos', NOW(), NOW())
+       ON CONFLICT (domain) DO UPDATE SET
+         workos_organization_id = EXCLUDED.workos_organization_id,
+         verified = false, is_primary = true, source = 'workos'`,
+      [orgId, domain],
+    );
+  }
+
   async function seedBrandPrimary(orgId: string, domain: string) {
     await pool.query(
       `INSERT INTO organization_domains
@@ -715,6 +727,79 @@ describe('Agent visibility E2E', () => {
         'tier_required',
         'brand_domain_required',
       ]);
+    });
+
+    it('Builder with unverified primary domain: brand_domain_unverified', async () => {
+      const orgId = `${TEST_PREFIX}_gate_unverified`;
+      const userId = `${TEST_PREFIX}_gate_unverified_user`;
+      await seedOrg(pool, orgId, 'company_standard');
+      await provisionUser(userId, orgId);
+      await memberDb.createProfile({
+        workos_organization_id: orgId,
+        display_name: 'Unverified Domain Org',
+        slug: 'gateunverified',
+        is_public: true,
+        agents: [],
+      });
+      await seedBrandPrimaryUnverified(orgId, 'gateunverified.example');
+
+      (app as any).setCurrentUser(userId, orgId);
+      const res = await request(app).get('/api/me/member-profile');
+
+      expect(res.status).toBe(200);
+      expect(res.body.agent_visibility_gate.can_publish_publicly).toBe(false);
+      expect(res.body.agent_visibility_gate.reasons).toContain('brand_domain_unverified');
+    });
+  });
+
+  // Unverified domain write-side enforcement (#4511).
+  // An org can have is_primary=true but verified=false (admin import, legacy
+  // seeding). All three write paths that can set visibility='public' must
+  // reject with brand_domain_unverified until the org completes DNS verification.
+  describe('Unverified domain write-side enforcement', () => {
+    async function setupUnverifiedOrg(suffix: string) {
+      const orgId = `${TEST_PREFIX}_unv_${suffix}`;
+      const userId = `${TEST_PREFIX}_unv_${suffix}_user`;
+      const domain = `unv${suffix}.example`;
+      await seedOrg(pool, orgId, 'individual_professional');
+      await provisionUser(userId, orgId);
+      await memberDb.createProfile({
+        workos_organization_id: orgId,
+        display_name: `Unverified ${suffix}`,
+        slug: `unv${suffix}`,
+        is_public: true,
+        agents: [{ url: `https://agent.${domain}`, visibility: 'private' }],
+      });
+      await seedBrandPrimaryUnverified(orgId, domain);
+      return { orgId, userId, domain };
+    }
+
+    it('POST /publish returns 400 brand_domain_unverified when primary domain is not DNS-verified', async () => {
+      const { userId, orgId } = await setupUnverifiedOrg('pub');
+      (app as any).setCurrentUser(userId, orgId);
+      const res = await request(app).post('/api/me/member-profile/agents/0/publish');
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('brand_domain_unverified');
+    });
+
+    it('PATCH /visibility=public returns 400 brand_domain_unverified when primary domain is not DNS-verified', async () => {
+      const { userId, orgId } = await setupUnverifiedOrg('patch');
+      (app as any).setCurrentUser(userId, orgId);
+      const res = await request(app)
+        .patch('/api/me/member-profile/agents/0/visibility')
+        .send({ visibility: 'public' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('brand_domain_unverified');
+    });
+
+    it('PUT /member-profile: rejects visibility=public when primary domain is not DNS-verified', async () => {
+      const { userId, orgId, domain } = await setupUnverifiedOrg('put');
+      (app as any).setCurrentUser(userId, orgId);
+      const res = await request(app)
+        .put('/api/me/member-profile')
+        .send({ agents: [{ url: `https://agent.${domain}`, visibility: 'public' }] });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('brand_domain_unverified');
     });
   });
 

--- a/server/tests/integration/brand-domain-resolver.test.ts
+++ b/server/tests/integration/brand-domain-resolver.test.ts
@@ -13,6 +13,7 @@ import { runMigrations } from '../../src/db/migrate.js';
 import {
   getBrandPrimaryDomain,
   getBrandPrimaryDomainsForOrgs,
+  getBrandPrimaryDomainRecord,
 } from '../../src/services/brand-domain-resolver.js';
 import type { Pool } from 'pg';
 
@@ -82,11 +83,7 @@ describe('getBrandPrimaryDomain', () => {
     expect(await getBrandPrimaryDomain(ORG_A)).toBeNull();
   });
 
-  it('returns an unverified is_primary=true row (verified is enforced at write time, not read)', async () => {
-    // The resolver does not filter on verified — writers ensure
-    // is_primary=true rows are also verified, and the publish-agent gate
-    // re-checks verified independently. Document the contract here so a
-    // future refactor that adds a verified filter is an intentional change.
+  it('getBrandPrimaryDomainRecord returns { domain, verified: false } for an unverified is_primary row', async () => {
     await seedOrg(pool, ORG_A, 'A Co');
     await pool.query(
       `INSERT INTO organization_domains (workos_organization_id, domain, verified, is_primary, source, created_at, updated_at)
@@ -94,7 +91,22 @@ describe('getBrandPrimaryDomain', () => {
        ON CONFLICT (domain) DO UPDATE SET verified = false, is_primary = true`,
       [ORG_A, 'a-unverified.example'],
     );
-    expect(await getBrandPrimaryDomain(ORG_A)).toBe('a-unverified.example');
+    const record = await getBrandPrimaryDomainRecord(ORG_A);
+    expect(record?.domain).toBe('a-unverified.example');
+    expect(record?.verified).toBe(false);
+  });
+
+  it('getBrandPrimaryDomainRecord returns { domain, verified: true } for a verified is_primary row', async () => {
+    await seedOrg(pool, ORG_A, 'A Co');
+    await seedDomain(pool, ORG_A, 'a.example', true);
+    const record = await getBrandPrimaryDomainRecord(ORG_A);
+    expect(record?.domain).toBe('a.example');
+    expect(record?.verified).toBe(true);
+  });
+
+  it('getBrandPrimaryDomainRecord returns null when no is_primary row exists', async () => {
+    await seedOrg(pool, ORG_A, 'A Co');
+    expect(await getBrandPrimaryDomainRecord(ORG_A)).toBeNull();
   });
 
   it('returns the first row but does not throw when multiple is_primary=true rows exist (data anomaly)', async () => {

--- a/server/tests/unit/agent-visibility-gate.test.ts
+++ b/server/tests/unit/agent-visibility-gate.test.ts
@@ -127,35 +127,65 @@ describe('gateAgentVisibilityForCaller', () => {
 describe('computeAgentVisibilityGate', () => {
   it('allows public when caller has both API access and a brand domain', () => {
     expect(
-      computeAgentVisibilityGate({ hasApiAccess: true, brandPrimaryDomain: 'example.com' }),
+      computeAgentVisibilityGate({ hasApiAccess: true, brandPrimaryDomain: 'example.com', brandDomainVerified: true }),
     ).toEqual({ can_publish_publicly: true, reasons: [] });
   });
 
   it('returns tier_required when caller lacks API access', () => {
-    const gate = computeAgentVisibilityGate({ hasApiAccess: false, brandPrimaryDomain: 'example.com' });
+    const gate = computeAgentVisibilityGate({ hasApiAccess: false, brandPrimaryDomain: 'example.com', brandDomainVerified: true });
     expect(gate.can_publish_publicly).toBe(false);
     expect(gate.reasons).toEqual(['tier_required']);
   });
 
   it('returns brand_domain_required when caller has API access but no primary brand domain', () => {
-    const gate = computeAgentVisibilityGate({ hasApiAccess: true, brandPrimaryDomain: null });
+    const gate = computeAgentVisibilityGate({ hasApiAccess: true, brandPrimaryDomain: null, brandDomainVerified: false });
     expect(gate.can_publish_publicly).toBe(false);
     expect(gate.reasons).toEqual(['brand_domain_required']);
   });
 
   it('returns both reasons when neither precondition is met', () => {
-    const gate = computeAgentVisibilityGate({ hasApiAccess: false, brandPrimaryDomain: null });
+    const gate = computeAgentVisibilityGate({ hasApiAccess: false, brandPrimaryDomain: null, brandDomainVerified: false });
     expect(gate.can_publish_publicly).toBe(false);
     expect(gate.reasons).toEqual(['tier_required', 'brand_domain_required']);
   });
 
   it('treats an empty-string domain the same as null', () => {
-    const gate = computeAgentVisibilityGate({ hasApiAccess: true, brandPrimaryDomain: '' });
+    const gate = computeAgentVisibilityGate({ hasApiAccess: true, brandPrimaryDomain: '', brandDomainVerified: false });
     expect(gate.reasons).toEqual(['brand_domain_required']);
   });
 
   it('treats undefined the same as null', () => {
-    const gate = computeAgentVisibilityGate({ hasApiAccess: true, brandPrimaryDomain: undefined });
+    const gate = computeAgentVisibilityGate({ hasApiAccess: true, brandPrimaryDomain: undefined, brandDomainVerified: false });
     expect(gate.reasons).toEqual(['brand_domain_required']);
+  });
+
+  it('returns brand_domain_unverified when primary domain exists but verified=false', () => {
+    const gate = computeAgentVisibilityGate({
+      hasApiAccess: true,
+      brandPrimaryDomain: 'example.com',
+      brandDomainVerified: false,
+    });
+    expect(gate.can_publish_publicly).toBe(false);
+    expect(gate.reasons).toContain('brand_domain_unverified');
+  });
+
+  it('returns tier_required AND brand_domain_unverified when both preconditions fail', () => {
+    const gate = computeAgentVisibilityGate({
+      hasApiAccess: false,
+      brandPrimaryDomain: 'example.com',
+      brandDomainVerified: false,
+    });
+    expect(gate.reasons).toContain('tier_required');
+    expect(gate.reasons).toContain('brand_domain_unverified');
+  });
+
+  it('allows public when tier, domain, and verified are all present', () => {
+    const gate = computeAgentVisibilityGate({
+      hasApiAccess: true,
+      brandPrimaryDomain: 'example.com',
+      brandDomainVerified: true,
+    });
+    expect(gate.can_publish_publicly).toBe(true);
+    expect(gate.reasons).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

  - `organization_domains.is_primary=true` was being treated as sufficient proof of brand ownership, but admin-seeded and legacy-imported rows can have `verified=false` (no DNS proof). Orgs in that state could
   publish agents publicly.
  - All three write paths now enforce `verified=true`: `POST /agents/:index/publish`, `PATCH /agents/:index/visibility`, and bulk `PUT /member-profile`
  - `computeAgentVisibilityGate` gains a `brandDomainVerified` param and a new `brand_domain_unverified` reason code, keeping the UI affordance in sync with write-time enforcement

  ## Changes

  | File | What |
  |---|---|
  | `server/src/services/brand-domain-resolver.ts` | New `getBrandPrimaryDomainRecord()` returning `{domain, verified}` |
  | `server/src/services/agent-visibility-gate.ts` | New `brand_domain_unverified` reason; `brandDomainVerified` param on `computeAgentVisibilityGate` |
  | `server/src/routes/member-profiles.ts` | All three write paths check `brandPrimaryRecord.verified`, return 400 `brand_domain_unverified` |
  | `server/tests/unit/agent-visibility-gate.test.ts` | Unit coverage for new reason codes and verified/unverified gate paths |
  | `server/tests/integration/brand-domain-resolver.test.ts` | Coverage for `getBrandPrimaryDomainRecord` verified/unverified/null cases |
  | `server/tests/integration/agent-visibility-e2e.test.ts` | E2E coverage: gate response, POST/PATCH/PUT rejection with unverified domain |

  ## Testing

  All three test layers pass. `brand_domain_required` (no primary domain) and `brand_domain_unverified` (unverified domain) are mutually exclusive — the gate uses `else if` so they can't both fire.
  
  
  ## Related Issue
  Closes #4511
  
  ## Rollout note

Before this is enabled in production, we should confirm how many existing orgs have an unverified primary brand domain with active/public agents. Those orgs would be blocked by the stricter gate, so this may need an audit/backfill step or feature flag before enforcement.