### PR TITLE
fix: agent credentials stale warning + operator domain lookup

### DIFF
--- a/.changeset/fix-agent-credentials-stale-warning.md
+++ b/.changeset/fix-agent-credentials-stale-warning.md
@@ -1,0 +1,18 @@
+---
+---
+
+Fix: "Agent requires authentication" warning no longer persists after an owner saves credentials.
+
+The warning is driven by the crawler's `oauth_required` flag, which was set by an unauthenticated probe and never invalidated when an owner saved an auth token / OAuth credentials. The periodic heartbeat — also unauthenticated — kept re-asserting the flag, so the warning could survive indefinitely even when the saved credentials were perfectly valid.
+
+Three coordinated changes:
+
+1. **`PUT /api/registry/agents/{encodedUrl}/connect`** now auto-runs an authenticated `crawler.refreshSingleAgent` immediately after `saveAuthToken`. The success path returns the fresh probe result so the dashboard reload reflects current compliance state — no waiting for the next heartbeat cycle. Refresh failures log a warning but do not fail the save (credentials persist either way).
+
+2. **`PUT /api/registry/agents/{encodedUrl}/oauth-client-credentials`** mirrors the same auto-refresh after `saveOAuthClientCredentials`.
+
+3. **`CrawlerService.refreshAgentSnapshots`** (the periodic crawl) now resolves any org's saved credentials per agent via the new `AgentContextDatabase.findOrgWithSavedAuth(agentUrl)` and threads them into `discoverCapabilities`, `checkHealth`, and `getStats`. Agents with no registered credentials still probe anonymously. When multiple orgs have registered the same agent, the most recently updated credential set wins (matches "freshly-rotated creds take precedence"; the snapshot is one shared row).
+
+Existing stuck users do not need to re-authenticate. After deploy, either (a) clicking Refresh on the agent card, or (b) waiting for the next periodic heartbeat will clear the flag using the credentials already on file. Saves performed after deploy clear the warning synchronously.
+
+The dashboard's connect-form success message updates from "Compliance check will run on the next heartbeat cycle" to "Connected and re-checked" to match the new synchronous behavior.

--- a/.changeset/fix-operator-lookup-non-primary-domain.md
+++ b/.changeset/fix-operator-lookup-non-primary-domain.md
@@ -1,0 +1,10 @@
+---
+---
+
+Fix: `GET /api/registry/operator?domain=X` now resolves member profiles by any linked domain on the owning org, not just the primary one.
+
+`MemberDatabase.getProfileByDomain` was the only domain→org lookup in the codebase that filtered on `organization_domains.is_primary = true`. Every other lookup (`organization-domains-db.ts`, `me-organization-domains.ts`, `domain-resolution-db.ts`, brand-feed and registry verified-domain lookups) resolves by any linked domain, relying on `UNIQUE(domain)` in the `organization_domains` table to keep the join unambiguous.
+
+The `is_primary` flag exists to pick a canonical email/enrichment domain (per migration 066), not to gate ownership lookups. With the old filter, an org that had `gumgum.com` linked as a secondary domain — primary on a different parent domain — would silently return `{ "member": null, "agents": [] }` on the operator endpoint, indistinguishable from "no org owns this domain." This blocked legitimate multi-domain orgs (holdcos, multi-brand operators) from being discoverable through the operator API.
+
+The fix drops the `is_primary = true` clause from the join. No schema change; no API contract change beyond the bug.

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -2176,8 +2176,11 @@
           throw new Error(data.error || 'Failed to connect');
         }
 
-        // Replace the form with a success message and reload after a moment
-        form.innerHTML = '<div class="agent-connect-msg" style="color:var(--color-success-600);">Connected. Compliance check will run on the next heartbeat cycle.</div>';
+        // Replace the form with a success message and reload after a moment.
+        // The server re-probes with the new credentials before responding, so
+        // the reload shows fresh compliance state — no waiting for the next
+        // heartbeat.
+        form.innerHTML = '<div class="agent-connect-msg" style="color:var(--color-success-600);">Connected and re-checked.</div>';
         setTimeout(() => location.reload(), 1500);
       } catch (err) {
         saveBtn.disabled = false;

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -10,6 +10,7 @@ import { MemberDatabase } from "./db/member-db.js";
 import { CapabilityDiscovery } from "./capabilities.js";
 import { HealthChecker } from "./health.js";
 import { AgentSnapshotDatabase } from "./db/agent-snapshot-db.js";
+import { AgentContextDatabase } from "./db/agent-context-db.js";
 import { AAO_HOST } from "./config/aao.js";
 import { AAO_UA_DISCOVERY } from "./config/user-agents.js";
 import { createLogger } from "./logger.js";
@@ -17,7 +18,8 @@ import type { CatalogEventsDatabase, WriteEventInput } from "./db/catalog-events
 import type { AgentInventoryProfilesDatabase, ProfileUpsertInput } from "./db/agent-inventory-profiles-db.js";
 import { query } from "./db/client.js";
 import { insertTypeReclassification } from "./db/type-reclassification-log-db.js";
-import type { SdkAuth } from "./services/sdk-auth-adapter.js";
+import { resolveUserAgentAuth } from "./routes/helpers/resolve-user-agent-auth.js";
+import { adaptAuthForSdk, type SdkAuth } from "./services/sdk-auth-adapter.js";
 
 const log = createLogger('crawler');
 
@@ -66,6 +68,7 @@ export class CrawlerService {
   private capabilityDiscovery: CapabilityDiscovery;
   private healthChecker: HealthChecker;
   private snapshotDb: AgentSnapshotDatabase;
+  private agentContextDb: AgentContextDatabase;
   private eventsDb?: CatalogEventsDatabase;
   private profilesDb?: AgentInventoryProfilesDatabase;
 
@@ -80,8 +83,29 @@ export class CrawlerService {
     this.capabilityDiscovery = new CapabilityDiscovery();
     this.healthChecker = new HealthChecker();
     this.snapshotDb = new AgentSnapshotDatabase();
+    this.agentContextDb = new AgentContextDatabase();
     this.eventsDb = options?.eventsDb;
     this.profilesDb = options?.profilesDb;
+  }
+
+  /**
+   * Resolve any saved owner auth for an agent URL so probes don't get 401'd
+   * by agents that gate discovery/health behind authentication. Returns
+   * `undefined` when no org has registered credentials for the URL, which
+   * preserves the historical anonymous-probe behavior for purely external
+   * agents. Errors are swallowed and logged: a credential lookup failure
+   * must never block a heartbeat.
+   */
+  private async resolveProbeAuth(agentUrl: string): Promise<SdkAuth | undefined> {
+    try {
+      const ownerOrgId = await this.agentContextDb.findOrgWithSavedAuth(agentUrl);
+      if (!ownerOrgId) return undefined;
+      const auth = await resolveUserAgentAuth(this.agentContextDb, ownerOrgId, agentUrl, log);
+      return await adaptAuthForSdk(auth, { tokenEndpointLabel: `crawler:${agentUrl}` });
+    } catch (err) {
+      log.warn({ err, agentUrl }, 'Failed to resolve owner auth for periodic probe; falling back to anonymous');
+      return undefined;
+    }
   }
 
   async crawlAllAgents(agents: Agent[]): Promise<CrawlResult> {
@@ -610,8 +634,15 @@ export class CrawlerService {
       const batch = toProbe.slice(i, i + CONCURRENCY);
       const results = await Promise.allSettled(
         batch.map(async (agent) => {
+          // Use saved owner credentials when the agent has any — keeps the
+          // snapshot's `oauth_required` consistent with what the owner sees
+          // after /connect, instead of clobbering it back to `true` on every
+          // anonymous heartbeat. Falls back to anonymous for purely external
+          // agents with no registered credentials.
+          const auth = await this.resolveProbeAuth(agent.url);
+
           const profile = await Promise.race([
-            this.capabilityDiscovery.discoverCapabilities(agent),
+            this.capabilityDiscovery.discoverCapabilities(agent, auth),
             new Promise<never>((_, reject) =>
               setTimeout(() => reject(new Error('Probe timeout')), PROBE_TIMEOUT_MS)
             ),
@@ -623,7 +654,7 @@ export class CrawlerService {
 
           const [health, stats] = await Promise.all([
             Promise.race([
-              this.healthChecker.checkHealth(agentForHealth),
+              this.healthChecker.checkHealth(agentForHealth, auth),
               new Promise<never>((_, reject) =>
                 setTimeout(() => reject(new Error('Health timeout')), PROBE_TIMEOUT_MS)
               ),
@@ -633,7 +664,7 @@ export class CrawlerService {
               error: err instanceof Error ? err.message : 'health check failed',
             })),
             Promise.race([
-              this.healthChecker.getStats(agentForHealth),
+              this.healthChecker.getStats(agentForHealth, auth),
               new Promise<never>((_, reject) =>
                 setTimeout(() => reject(new Error('Stats timeout')), PROBE_TIMEOUT_MS)
               ),

--- a/server/src/db/agent-context-db.ts
+++ b/server/src/db/agent-context-db.ts
@@ -296,6 +296,36 @@ export class AgentContextDatabase {
   }
 
   /**
+   * Find an organization that has saved any kind of auth (bearer, OAuth tokens,
+   * or OAuth client-credentials) for the given agent URL. Returns the most
+   * recently updated row's org id, or null if no credentials are saved by any
+   * org. Used by the periodic crawler so its probe runs with owner credentials
+   * when available — keeping a per-org-aware view of `oauth_required` instead
+   * of clobbering it back to `true` on every anonymous heartbeat. When multiple
+   * orgs have independently registered the same agent, the most recently
+   * updated set wins; that matches "freshly-rotated creds take precedence" and
+   * the periodic snapshot is a single shared row anyway.
+   */
+  async findOrgWithSavedAuth(agentUrl: string): Promise<string | null> {
+    const result = await query<{ organization_id: string }>(
+      `SELECT organization_id
+       FROM agent_contexts
+       WHERE agent_url = $1
+         AND (
+           auth_token_encrypted IS NOT NULL
+           OR oauth_access_token_encrypted IS NOT NULL
+           OR (oauth_cc_token_endpoint IS NOT NULL
+               AND oauth_cc_client_id IS NOT NULL
+               AND oauth_cc_client_secret_encrypted IS NOT NULL)
+         )
+       ORDER BY updated_at DESC
+       LIMIT 1`,
+      [agentUrl],
+    );
+    return result.rows[0]?.organization_id ?? null;
+  }
+
+  /**
    * Create a new agent context
    */
   async create(input: CreateAgentContextInput): Promise<AgentContext> {

--- a/server/src/db/member-db.ts
+++ b/server/src/db/member-db.ts
@@ -120,10 +120,14 @@ export class MemberDatabase {
   }
 
   /**
-   * Get profile by primary brand domain. Brand-primary lives on
-   * `organization_domains.is_primary=true` post-Stage-2 (#4159), so this
-   * joins through the org_id rather than reading a column directly off
-   * member_profiles.
+   * Resolve a member profile by any linked domain on the owning org.
+   * Matches the other domain→org lookups in the codebase
+   * (`organization-domains-db.ts`, `me-organization-domains.ts`,
+   * `domain-resolution-db.ts`) — `organization_domains.UNIQUE(domain)`
+   * guarantees the join is unambiguous. We previously filtered on
+   * `is_primary = true`, which silently dropped orgs whose linked domain
+   * was registered as secondary and made `/api/registry/operator?domain=…`
+   * return `member: null` for legitimate members.
    */
   async getProfileByDomain(domain: string): Promise<MemberProfile | null> {
     const result = await query<MemberProfile>(
@@ -131,7 +135,6 @@ export class MemberDatabase {
          FROM member_profiles mp
          JOIN organization_domains od
            ON od.workos_organization_id = mp.workos_organization_id
-          AND od.is_primary = true
         WHERE LOWER(od.domain) = LOWER($1)
         LIMIT 1`,
       [domain]

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -5217,10 +5217,11 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
 
       // Resolve saved owner auth (static bearer / basic / OAuth) so the
       // probe sees the same credentials evaluate_agent_quality uses. The
-      // periodic crawl path stays unauthenticated by design. Auth is
-      // only resolved when the caller belongs to the owning org —
-      // resolveAgentOwnerOrg returns null for an AAO admin probing an
-      // agent they don't own, so the admin path probes unauthed.
+      // periodic crawl path also now resolves owner credentials when any
+      // org has registered them (see CrawlerService.resolveProbeAuth); this
+      // route still scopes auth to the caller's own org so an AAO admin
+      // refreshing someone else's agent probes anonymously rather than
+      // accidentally running with the owner's tokens.
       const ownerOrgId = await resolveAgentOwnerOrg(req.user.id, agentUrl);
       let resolvedAuth: SdkAuth | undefined;
       if (ownerOrgId) {
@@ -5407,10 +5408,32 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         await agentContextDb.saveAuthToken(context.id, auth_token, resolvedAuthType);
       }
 
+      // Re-probe with the freshly-saved credentials so the stored `oauth_required`
+      // flag reflects the new auth state immediately. Without this, the warning
+      // surfaced from the last (unauthenticated) crawl persists until the next
+      // periodic heartbeat — which itself probes unauthenticated and therefore
+      // can never clear the flag. Mirrors the auth resolution in /refresh.
+      // Refresh failure does NOT fail /connect: the credentials are saved
+      // correctly either way, and a follow-up manual refresh can recover.
+      let refreshed: Awaited<ReturnType<typeof crawler.refreshSingleAgent>> | null = null;
+      if (auth_token) {
+        try {
+          const auth = await resolveUserAgentAuth(agentContextDb, orgId, agentUrl, logger);
+          const resolvedAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `connect:${agentUrl}` });
+          refreshed = await crawler.refreshSingleAgent(agentUrl, { auth: resolvedAuth });
+        } catch (refreshErr) {
+          logger.warn(
+            { err: refreshErr, agentUrl },
+            'Post-connect refresh failed; credentials saved but compliance flag may remain stale until next manual refresh',
+          );
+        }
+      }
+
       res.json({
         connected: true,
         has_auth: !!auth_token || context.has_auth_token,
         agent_context_id: context.id,
+        ...(refreshed ? { refresh: refreshed } : {}),
       });
     } catch (error) {
       logger.error({ err: error, path: req.path }, "Failed to connect agent");
@@ -5473,11 +5496,28 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
 
         await agentContextDb.saveOAuthClientCredentials(context.id, parsed.creds);
 
+        // Re-probe with the freshly-saved credentials so the stored
+        // `oauth_required` flag reflects the new auth state immediately.
+        // Same rationale and best-effort semantics as /connect — see
+        // the comment there.
+        let refreshed: Awaited<ReturnType<typeof crawler.refreshSingleAgent>> | null = null;
+        try {
+          const auth = await resolveUserAgentAuth(agentContextDb, orgId, agentUrl, logger);
+          const resolvedAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `connect-cc:${agentUrl}` });
+          refreshed = await crawler.refreshSingleAgent(agentUrl, { auth: resolvedAuth });
+        } catch (refreshErr) {
+          logger.warn(
+            { err: refreshErr, agentUrl },
+            'Post-connect-cc refresh failed; credentials saved but compliance flag may remain stale until next manual refresh',
+          );
+        }
+
         res.json({
           connected: true,
           has_auth: true,
           agent_context_id: context.id,
           auth_type: "oauth_client_credentials",
+          ...(refreshed ? { refresh: refreshed } : {}),
         });
       } catch (error) {
         logger.error({ err: error, path: req.path }, "Failed to save oauth client credentials");


### PR DESCRIPTION
## Summary

Two distinct bug fixes bundled in one PR.

### 1. Agent credentials "requires authentication" warning persists after save

**Symptom:** Owner saves an auth token (or re-registers an agent with a fresh key); the AAO dashboard keeps showing *"agent requires authentication"* indefinitely. Re-saves don't help; waiting a week doesn't help.

**Root cause:** Three independent issues compounded:
- `PUT /api/registry/agents/{encodedUrl}/connect` saved the token but did not invalidate or recompute the agent's `oauth_required` flag.
- `PUT /api/registry/agents/{encodedUrl}/oauth-client-credentials` had the same shape — credentials saved, flag untouched.
- The periodic crawler (`CrawlerService.refreshAgentSnapshots`) probed every agent **unauthenticated** by design. So even if something cleared the flag, the next heartbeat would re-assert it. The flag was effectively impossible to clear without manual intervention.

**Fix:**
- `/connect` now resolves owner auth and calls `crawler.refreshSingleAgent` immediately after `saveAuthToken`. Refresh failures log a warning but never fail the save (credentials persist either way).
- `/oauth-client-credentials` mirrors the same auto-refresh after `saveOAuthClientCredentials`.
- `refreshAgentSnapshots` resolves saved credentials per-agent via the new `AgentContextDatabase.findOrgWithSavedAuth(agentUrl)` and threads them through `discoverCapabilities`, `checkHealth`, and `getStats`. Agents with no registered credentials still probe anonymously. Multi-owner agents use the most recently updated credential set (snapshot is one shared row).
- Dashboard success message updated from *"Compliance check will run on the next heartbeat cycle"* to *"Connected and re-checked"* to match the new synchronous behavior.

**Migration note:** Existing stuck users do not need to re-authenticate. After deploy, either clicking Refresh on the agent card or waiting for the next periodic heartbeat will clear the flag using credentials already on file.

### 2. Operator endpoint silently dropped non-primary-domain orgs

**Symptom:** `GET /api/registry/operator?domain=X` returned `{ member: null, agents: [] }` for legitimate orgs that had `X` linked as a secondary domain.

**Root cause:** `MemberDatabase.getProfileByDomain` was the only domain→org lookup in the codebase that filtered on `organization_domains.is_primary = true`. The `is_primary` flag exists to pick a canonical email/enrichment domain (per migration 066), not to gate ownership lookups. Multi-domain orgs (holdcos, multi-brand operators) were invisible to the operator API.

**Fix:** Drop the `is_primary = true` clause from the join. All other domain→org lookups (`organization-domains-db.ts`, `me-organization-domains.ts`, `domain-resolution-db.ts`, brand-feed, registry verified-domain) already resolve by any linked domain, relying on `UNIQUE(domain)` to keep the join unambiguous. No schema change; no API contract change beyond the bug.

## Test plan

- [ ] Save a fresh bearer token via `/connect` → verify dashboard immediately shows "Connected and re-checked" and the "requires authentication" warning is gone on reload.
- [ ] Save OAuth client-credentials via `/oauth-client-credentials` → same verification.
- [ ] Existing stuck user: click Refresh on agent card → flag clears.
- [ ] Existing stuck user: wait for next periodic heartbeat → flag clears.
- [ ] Agent with no saved credentials still probes anonymously (no regression on external/public agents).
- [ ] `GET /api/registry/operator?domain=<secondary-domain>` returns the owning org (where it previously returned null).