### PR TITLE
fix(addie): disambiguate auth failure from empty capabilities in recommend_storyboards

### DIFF
--- a/.changeset/fix-addie-auth-failure-diagnostic.md
+++ b/.changeset/fix-addie-auth-failure-diagnostic.md
@@ -1,0 +1,17 @@
+---
+---
+
+fix(addie): disambiguate auth failure from empty capabilities in recommend_storyboards
+
+When `recommend_storyboards` received an empty capabilities response while using saved
+or OAuth credentials, it incorrectly told the user their agent hadn't declared
+`supported_protocols` or `specialisms`. The actual cause was an auth failure — the agent
+served its anonymous response because the credentials didn't reach it.
+
+The fix adds a pre-check: if `resolved.source` is `saved`, `oauth`, or `explicit`, an
+empty capabilities response emits an auth-failure diagnosis (verify credentials, re-save,
+check SDK version) instead of the developer-coaching path. The coaching path is now
+reached only when no credentials were expected (`source === 'none'` or `'public'`).
+
+Also adds `_Using saved OAuth credentials._` header parity for the OAuth source (previously
+only the `saved` source printed a credential indicator).

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.05.2';
+export const CODE_VERSION = '2026.05.3';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -3916,7 +3916,7 @@ export function createMemberToolHandlers(
 
     let output = '';
     if (resolved.source === 'saved') output += '_Using saved credentials._\n\n';
-    if (resolved.source === 'oauth') output += '_Using saved OAuth credentials._\n\n';
+    else if (resolved.source === 'oauth') output += '_Using saved OAuth credentials._\n\n';
     output += `## Agent: ${safeAgentName || resolved.resolvedUrl}\n\n`;
 
     // No capabilities declared — disambiguate: auth failure vs. genuinely
@@ -3929,17 +3929,19 @@ export function createMemberToolHandlers(
     if (supportedProtocols.length === 0 && specialisms.length === 0) {
       if (resolved.source === 'saved' || resolved.source === 'oauth' || resolved.source === 'explicit') {
         const safeUrl = sanitizeAgentField(resolved.resolvedUrl, 300);
-        const authLabel = resolved.source === 'oauth' ? 'OAuth token' : 'saved credentials';
+        // 'explicit' is a test/internal codepath (caller passed a raw token directly);
+        // label it the same as saved credentials since the diagnosis steps are identical.
+        const authLabel = resolved.source === 'oauth' ? 'OAuth token' : resolved.source === 'explicit' ? 'the provided token' : 'saved credentials';
         output += `I tested your agent using your ${authLabel}, but got back an empty capabilities response — no \`supported_protocols\` and no \`specialisms\`.\n\n`;
         if (probeError) {
           const safeProbeErr = fenceAgentValue(probeError, 300);
           output += `The agent reported: ${safeProbeErr || '(no detail)'}\n\n`;
         }
         output += `This usually means the credentials didn't reach the agent:\n\n`;
-        output += `1. **Verify the credentials work:** curl \`${safeUrl}\` directly with your credentials and confirm \`supported_protocols\` appears in the response.\n`;
+        output += `1. **Verify the credentials work:** curl "${safeUrl}" directly with your credentials and confirm \`supported_protocols\` appears in the response.\n`;
         output += `2. **Re-save if needed:** run \`save_agent\` again with the correct credentials.\n`;
         output += `3. **Check the SDK version:** if you're using \`@adcp/sdk\`, make sure it's up to date — older versions have a known issue that drops the auth header on the capabilities precheck path.\n\n`;
-        output += `If credentials look correct and the SDK is current, the agent may be returning an anonymous-shaped response for unrecognized auth rather than a 401. Confirm the agent accepts the auth scheme and credential format you saved.`;
+        output += `If credentials look correct and the SDK is current, the agent may be returning an anonymous-shaped response for unrecognized auth rather than a 401. Confirm the agent accepts the auth scheme and credential format you saved.\n`;
         return output;
       }
       output += `Your agent didn't tell us what it does yet.\n\n`;

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -3928,18 +3928,28 @@ export function createMemberToolHandlers(
     // credentials were expected.
     if (supportedProtocols.length === 0 && specialisms.length === 0) {
       if (resolved.source === 'saved' || resolved.source === 'oauth' || resolved.source === 'explicit') {
-        const safeUrl = sanitizeAgentField(resolved.resolvedUrl, 300);
         // 'explicit' is a test/internal codepath (caller passed a raw token directly);
-        // label it the same as saved credentials since the diagnosis steps are identical.
+        // label and remediation match `saved` since the diagnosis steps are identical.
+        // The four ResolvedAgentAuth.source variants ('explicit'|'saved'|'oauth'|'public'|'none')
+        // are an exhaustive enum from line 223; if a new variant is added, extend this branch.
         const authLabel = resolved.source === 'oauth' ? 'OAuth token' : resolved.source === 'explicit' ? 'the provided token' : 'saved credentials';
+        const reSaveStep = resolved.source === 'oauth'
+          ? 'reconnect the OAuth provider — the access token may have expired or had its scope revoked'
+          : 'run `save_agent` again with the correct credentials';
+        // Render the agent URL inside inline-code backticks rather than
+        // interpolating into a copy-pasteable `curl "..."` example.
+        // sanitizeAgentField strips control chars and backticks but does not
+        // escape shell metacharacters (`"`, `$`, `\``), so an in-prose URL
+        // with crafted content would be a copy-paste foot-gun.
+        const safeUrl = sanitizeAgentField(resolved.resolvedUrl, 300);
         output += `I tested your agent using your ${authLabel}, but got back an empty capabilities response — no \`supported_protocols\` and no \`specialisms\`.\n\n`;
         if (probeError) {
           const safeProbeErr = fenceAgentValue(probeError, 300);
           output += `The agent reported: ${safeProbeErr || '(no detail)'}\n\n`;
         }
         output += `This usually means the credentials didn't reach the agent:\n\n`;
-        output += `1. **Verify the credentials work:** curl "${safeUrl}" directly with your credentials and confirm \`supported_protocols\` appears in the response.\n`;
-        output += `2. **Re-save if needed:** run \`save_agent\` again with the correct credentials.\n`;
+        output += `1. **Verify the credentials work:** call \`${safeUrl}\` directly with your credentials (e.g. via curl or Postman) and confirm \`supported_protocols\` appears in the response.\n`;
+        output += `2. **Re-save if needed:** ${reSaveStep}.\n`;
         output += `3. **Check the SDK version:** if you're using \`@adcp/sdk\`, make sure it's up to date — older versions have a known issue that drops the auth header on the capabilities precheck path.\n\n`;
         output += `If credentials look correct and the SDK is current, the agent may be returning an anonymous-shaped response for unrecognized auth rather than a 401. Confirm the agent accepts the auth scheme and credential format you saved.\n`;
         return output;

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -3916,10 +3916,32 @@ export function createMemberToolHandlers(
 
     let output = '';
     if (resolved.source === 'saved') output += '_Using saved credentials._\n\n';
+    if (resolved.source === 'oauth') output += '_Using saved OAuth credentials._\n\n';
     output += `## Agent: ${safeAgentName || resolved.resolvedUrl}\n\n`;
 
-    // No capabilities declared → coach the developer on how to fix it.
+    // No capabilities declared — disambiguate: auth failure vs. genuinely
+    // undeployed agent. When Addie used saved or OAuth credentials, an empty
+    // response most likely means auth didn't reach the agent (malformed
+    // credential, header silently dropped by the SDK, agent degraded to anon).
+    // Blaming the agent owner is wrong in this case; emit an auth diagnosis
+    // instead. Fall through to the developer-coaching path only when no
+    // credentials were expected.
     if (supportedProtocols.length === 0 && specialisms.length === 0) {
+      if (resolved.source === 'saved' || resolved.source === 'oauth' || resolved.source === 'explicit') {
+        const safeUrl = sanitizeAgentField(resolved.resolvedUrl, 300);
+        const authLabel = resolved.source === 'oauth' ? 'OAuth token' : 'saved credentials';
+        output += `I tested your agent using your ${authLabel}, but got back an empty capabilities response — no \`supported_protocols\` and no \`specialisms\`.\n\n`;
+        if (probeError) {
+          const safeProbeErr = fenceAgentValue(probeError, 300);
+          output += `The agent reported: ${safeProbeErr || '(no detail)'}\n\n`;
+        }
+        output += `This usually means the credentials didn't reach the agent:\n\n`;
+        output += `1. **Verify the credentials work:** curl \`${safeUrl}\` directly with your credentials and confirm \`supported_protocols\` appears in the response.\n`;
+        output += `2. **Re-save if needed:** run \`save_agent\` again with the correct credentials.\n`;
+        output += `3. **Check the SDK version:** if you're using \`@adcp/sdk\`, make sure it's up to date — older versions have a known issue that drops the auth header on the capabilities precheck path.\n\n`;
+        output += `If credentials look correct and the SDK is current, the agent may be returning an anonymous-shaped response for unrecognized auth rather than a 401. Confirm the agent accepts the auth scheme and credential format you saved.`;
+        return output;
+      }
       output += `Your agent didn't tell us what it does yet.\n\n`;
       if (probeError) {
         const safeProbeErr = fenceAgentValue(probeError, 300);


### PR DESCRIPTION
Closes #4807

When `recommend_storyboards` used saved or OAuth credentials and got back an empty capabilities response (`supported_protocols: []`, `specialisms: []`), it incorrectly told the user their agent hadn't declared capabilities and coached them to add fields and redeploy. The actual cause was auth failure — the agent served its anonymous response because the credentials didn't reach it (malformed credential, SDK header drop, or agent silently degrading to anon for unrecognized auth).

This PR adds a pre-check before the developer-coaching path: if `resolved.source` is `saved`, `oauth`, or `explicit`, an empty capabilities response now emits an auth-failure diagnosis instead. The coaching path is now only reached for `source === 'none'` or `'public'`, where no credentials were expected.

**Non-breaking justification:** adds a new early-return branch inside an existing `if` block; all existing behavior for the coaching path is preserved and only reached when `resolved.source` indicates no auth was expected.

**Changes:**
- `member-tools.ts`: add auth-failure diagnostic branch in `recommend_storyboards` before the "agent didn't declare" coaching path
- `member-tools.ts`: add `_Using saved OAuth credentials._` banner for `source === 'oauth'` (parity with existing `saved` banner); use `else if` to match file convention
- `config-version.ts`: bump `CODE_VERSION` to `2026.05.3` (tool implementation change)

**Pre-PR review:**
- code-reviewer: approved — no new type errors; URL sanitized via `sanitizeAgentField`; `probeError` still surfaced; `authLabel` correct per source; trailing `\n` added; `CODE_VERSION` bumped
- prompt-engineer: approved — `if`/`else if` pattern consistent with file; step labels non-duplicate; auth-failure path correctly short-circuits before coaching; `explicit` fallthrough labeled `'the provided token'` with inline comment

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_012H4aWFfphy2Rk1ksRiFFdt

---
_Generated by [Claude Code](https://claude.ai/code/session_012H4aWFfphy2Rk1ksRiFFdt)_