### PR TITLE
spec(3.1): pre-GA clarifications batch #3 — build_creative per-format errors + sales-guaranteed contract

### DIFF
--- a/.changeset/3-1-clarifications-batch-3.md
+++ b/.changeset/3-1-clarifications-batch-3.md
@@ -1,0 +1,29 @@
+---
+"adcontextprotocol": minor
+---
+
+spec(3.1): pre-GA clarifications batch #3 — per-format error attribution on `build_creative` + sales-guaranteed submitted-vs-sync contract.
+
+Two real spec clarifications surfaced during the 3.1 cluster work.
+
+**#4556 — Per-format error attribution on `BuildCreativeError`.** The multi-format `build_creative` contract is **atomic** (already documented on `BuildCreativeMultiSuccess`: "all formats must succeed or the entire request fails") — so the issue's framing of "partial success with some manifests + some errors" is non-conformant. What the spec was missing is the per-format attribution convention on the error response, so buyers can identify *which* format(s) caused the batch to fail and retry only the failing subset. Added normative guidance on `BuildCreativeError.errors[]`:
+
+- `error.field` carries `target_format_ids[N]` (zero-based index) — required when the error is format-scoped, mirrors the JSONPath-lite convention used elsewhere
+- `error.details.format_id` carries the resolved `format_id` value — required when the error is format-scoped, lets buyers dispatch on format identity without re-parsing `field`
+- Whole-batch errors (auth, governance denial, transport-level) MAY omit both
+- Sellers SHOULD emit one error per failing format rather than collapsing — keeps per-format recovery routing unambiguous
+- Per-format `correctable` errors are scoped to the named format only; buyers may retry just that format with corrected input
+
+This is the spec-level diagnostic surface for the agentic self-correction loop the issue identifies — the atomicity rule stays, but buyers no longer have to retry the whole batch to figure out which format failed.
+
+**#3822 — Sales-guaranteed submitted-vs-sync contract.** The skill ↔ storyboard contradiction surfaced during matrix-blind fixture runs: an SDK skill in adcp-client (`build-seller-agent`) instructed sales-guaranteed agents to return a task envelope for every `create_media_buy`. The `sales_guaranteed` compliance storyboard runs **multiple** create_media_buy paths and only one expects `submitted` — four shared scenarios (measurement_terms_rejected, pending_creatives_to_start, inventory_list_targeting, invalid_transitions) expect synchronous `media_buy_id` returns against the non-guaranteed fixture products listed first in the storyboard. A blind agent following the skill fails 5 of 5 grader steps.
+
+Resolution at the spec layer: added a `### When to return Submitted vs synchronous Success (normative)` section to `docs/media-buy/task-reference/create_media_buy.mdx` documenting that the choice is **per-call**, driven by per-product `delivery_type` + the seller's `requires_io_approval` capability — not a uniform per-seller rule. Conformant SDK skills MUST NOT instruct agents to return `submitted` for every `create_media_buy` regardless of input. Cross-references the `sales-guaranteed` specialism storyboard fixture pattern (non-guaranteed products listed first so open-brief `get_products` calls resolve to synchronous-create paths). Names the issue explicitly so future readers / future SDK skill audits land on the correct contract.
+
+The SDK skill itself lives in adcp-client and will need a follow-up fix there; this PR closes the spec-side ambiguity that allowed the bad skill to ship.
+
+Files:
+- `static/schemas/source/media-buy/build-creative-response.json` — `BuildCreativeError` description + `errors` field gain per-format attribution convention
+- `docs/media-buy/task-reference/create_media_buy.mdx` — new "When to return Submitted vs synchronous Success" section after the Submitted Response shape
+
+Closes #4556. Refs #3822 (spec-side resolution; SDK-side skill fix tracked in adcp-client).

--- a/docs/media-buy/task-reference/create_media_buy.mdx
+++ b/docs/media-buy/task-reference/create_media_buy.mdx
@@ -266,6 +266,26 @@ Returned when the buy cannot be confirmed synchronously — e.g., guaranteed buy
 
 **Note**: Responses are mutually exclusive across these three shapes. Dispatch on `status` first: `"submitted"` → async envelope, otherwise check `errors` before accessing success fields.
 
+### When to return Submitted vs synchronous Success (normative)
+
+The choice between `submitted` and synchronous success is **per-call**, driven by per-product attributes and the seller's policy on each specific create — not a uniform per-seller rule. A sales-guaranteed seller may legitimately return synchronous success on some `create_media_buy` calls and `submitted` on others within the same session; conformant SDK skills MUST NOT instruct agents to return `submitted` for every `create_media_buy` regardless of input. Sellers that uniformly return `submitted` fail the non-IO-approval paths in the `sales-guaranteed` compliance storyboard.
+
+Sellers MUST return `submitted` when:
+
+- The request references one or more products with `delivery_type: "guaranteed"` **and** the seller declares the `requires_io_approval` capability — the human-approval handshake cannot complete inside the response. The completion artifact is delivered via `tasks/get` or webhook once IO signing finishes.
+- The request triggers a seller-side governance review that cannot complete synchronously (e.g., manual brand-safety review for a regulated vertical).
+- The request enters a batched-processing queue the seller cannot drain inside the response timeout.
+
+Sellers MUST return synchronous success when:
+
+- All referenced products have `delivery_type: "non_guaranteed"`. The buy is created and acknowledged in-line; `media_buy_id` and `packages` are issued immediately. This applies regardless of the seller's specialism — a sales-guaranteed seller serving a non-guaranteed product returns synchronous success.
+- The request references guaranteed products and the seller does NOT declare `requires_io_approval` (rare; typically retail-SKU or quoted-rate guaranteed flows where the seller has pre-cleared approval).
+- The buy enters a known non-terminal state immediately observable to the buyer (`pending_creatives` / `pending_start` / `active`).
+
+The compliance grader observes both paths against the same seller via separate storyboard scenarios: the `create_buy_submitted` scenario seeds a guaranteed product with `requires_io_approval`; four shared scenarios (`measurement_terms_rejected`, `pending_creatives_to_start`, `inventory_list_targeting`, `invalid_transitions`) seed non-guaranteed products and expect synchronous `media_buy_id` returns. Sellers that return `submitted` on the synchronous-expected scenarios fail compliance — see [`sales-guaranteed` specialism](https://github.com/adcontextprotocol/adcp/tree/main/static/compliance/source/specialisms/sales-guaranteed) for the fixture pattern (non-guaranteed products listed first so open-brief `get_products` calls resolve to a synchronous-create path).
+
+This rule resolves the skill ↔ storyboard contradiction tracked at [#3822](https://github.com/adcontextprotocol/adcp/issues/3822): an SDK skill that instructs agents to "return a task envelope for every `create_media_buy`" is non-conformant; the correct skill instructs agents to dispatch on per-product `delivery_type` and the seller's `requires_io_approval` capability.
+
 ## Common Scenarios
 
 ### Campaign with Targeting

--- a/static/schemas/source/media-buy/build-creative-response.json
+++ b/static/schemas/source/media-buy/build-creative-response.json
@@ -271,12 +271,12 @@
     },
     {
       "title": "BuildCreativeError",
-      "description": "Error response - creative generation failed",
+      "description": "Error response — creative generation failed. Multi-format requests (`target_format_ids[]`) are atomic per `BuildCreativeMultiSuccess` semantics: a single format failing means the entire batch returns an error response, not a partial success. Buyers diagnose per-format failures by reading the `errors[]` array's per-format attribution (see the `errors` field description).",
       "type": "object",
       "properties": {
         "errors": {
           "type": "array",
-          "description": "Array of errors explaining why creative generation failed",
+          "description": "Array of errors explaining why creative generation failed.\n\n**Per-format attribution on multi-format requests.** When the request used `target_format_ids[]` (a batch request), sellers MUST attribute each failure to the specific format(s) that caused it so buyers can correct and retry the failing subset rather than re-running the entire batch. Two attribution surfaces, populated together:\n\n1. **`error.field`** — set to `target_format_ids[N]` where `N` is the zero-based index of the failing format in the request's `target_format_ids[]` array (e.g., `target_format_ids[1]` for the second requested format). Mirrors the JSONPath-lite convention `error.field` uses elsewhere. Required when the error is format-scoped.\n2. **`error.details.format_id`** — the resolved `format_id` value (e.g., `\"meta-reels-9x16\"`). Required when the error is format-scoped. Lets buyers dispatch on the format identity without re-parsing `error.field`.\n\nErrors not attributable to a specific format (whole-batch failures: authentication, governance denial, transport-level errors) MAY omit `field` and `details.format_id`. Buyers MUST treat per-format errors as scoped to the named format only — a `correctable` error on `target_format_ids[1]` does NOT mean the buyer must reshape the entire batch; they may retry just that format with corrected input. Sellers SHOULD emit one error per failing format (rather than collapsing multiple format failures into a single error entry) so per-format recovery routing is unambiguous.",
           "items": {
             "$ref": "/schemas/core/error.json"
           },


### PR DESCRIPTION
Third 3.1 clarifications batch. Two real spec clarifications surfaced during cluster work.

## #4556 — Per-format error attribution on `BuildCreativeError`

The multi-format `build_creative` contract is **already atomic** (`BuildCreativeMultiSuccess` says "all formats must succeed or the entire request fails"). What was missing was the *attribution* convention on the error response — buyers had no contract for identifying which format(s) caused the batch to fail.

Added normative guidance on `BuildCreativeError.errors[]`:
- `error.field` carries `target_format_ids[N]` (zero-based index)
- `error.details.format_id` carries the resolved format identifier
- Whole-batch errors (auth, governance, transport) MAY omit both
- One error per failing format, not collapsed entries

Buyers can now identify the failing subset and retry just those formats with corrected input, without giving up the atomicity invariant.

## #3822 — Sales-guaranteed submitted-vs-sync contract (spec resolution)

An SDK skill in `adcp-client` (`build-seller-agent`) instructed sales-guaranteed agents to return a task envelope for every `create_media_buy`. The `sales_guaranteed` compliance storyboard runs multiple create_media_buy paths — only one expects `submitted`; four shared scenarios (measurement_terms_rejected, pending_creatives_to_start, inventory_list_targeting, invalid_transitions) expect synchronous `media_buy_id` returns against the non-guaranteed fixture products listed first in the storyboard. Blind agents following the skill fail 5 of 5 grader steps.

Added a new normative section `### When to return Submitted vs synchronous Success` to `create_media_buy.mdx` clarifying that the choice is **per-call** (driven by per-product `delivery_type` + seller's `requires_io_approval` capability), not a uniform per-seller rule. Cross-references the storyboard fixture pattern so future SDK skill audits land on the correct contract.

The SDK skill itself lives in adcp-client and will need a follow-up fix there; this PR closes the spec-side ambiguity.

## Validation

- `npm run build:schemas` clean
- `composed-schema-validation.test.cjs` 43/43
- `npm run lint:schema-links` clean
- precommit hooks pass

## Test plan
- [ ] Sellers implementing `BuildCreativeError` populate `error.field` + `error.details.format_id` per the new convention
- [ ] adcp-client `build-seller-agent` skill updated to match the per-call dispatch rule (follow-up PR)
- [ ] No regression on the `sales_guaranteed` storyboard's non-guaranteed scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)