### PR TITLE
fix(addie): correct start_time shape in create_media_buy guidance

### DIFF
--- a/.changeset/fix-addie-start-time-shape-4736.md
+++ b/.changeset/fix-addie-start-time-shape-4736.md
@@ -1,0 +1,11 @@
+---
+---
+
+fix(addie): correct start_time shape in Addie's create_media_buy guidance
+
+The call_adcp_task tool description and adcp-media-buy SKILL.md both
+documented start_time as an object ({ type: "asap"|"scheduled" }) that
+does not exist in the schema. start_time is a oneOf string: the literal
+"asap" or an ISO 8601 datetime. Updates the quick-reference, SKILL.md
+example, and the create_media_buy validator to reject object payloads early
+with a clear error message. Fixes #4736.

--- a/server/src/addie/mcp/adcp-tools.ts
+++ b/server/src/addie/mcp/adcp-tools.ts
@@ -59,8 +59,8 @@ export const ADCP_TASK_REGISTRY: Record<string, AdcpTaskMeta> = {
     validate: (params) => {
       if (!params.brand) return 'brand is required (with domain).';
       if (!params.packages || !Array.isArray(params.packages)) return 'packages array is required.';
-      if (!params.start_time) return 'start_time is required.';
-      if (!params.end_time) return 'end_time is required.';
+      if (typeof params.start_time !== 'string' || !params.start_time) return 'start_time must be "asap" or an ISO 8601 datetime string.';
+      if (typeof params.end_time !== 'string' || !params.end_time) return 'end_time must be an ISO 8601 datetime string.';
       return null;
     },
   },
@@ -497,7 +497,7 @@ const callAdcpTaskTool: AddieTool = {
         description: [
           'Task-specific parameters. Quick reference for common tasks:',
           '• get_products: { brief, brand: { domain }, buying_mode?: "brief"|"wholesale"|"refine", filters?: { channels, budget_range } }',
-          '• create_media_buy: { idempotency_key, brand: { domain }, packages: [{ product_id, pricing_option_id, budget }], start_time: { type: "asap"|"scheduled" }, end_time }',
+          '• create_media_buy: { idempotency_key, brand: { domain }, packages: [{ product_id, pricing_option_id, budget }], start_time: "asap" | "2024-06-01T00:00:00Z", end_time: "2024-06-30T23:59:59Z" }',
           '• update_media_buy: { idempotency_key, account: { account_id } OR { brand:{domain}, operator }, media_buy_id, paused?, canceled?, packages?: [{ package_id, budget? }] }',
           '• sync_creatives: { idempotency_key, creatives: [{ creative_id, format_id: { agent_url, id }, assets }], assignments? }',
           '• build_creative: { message, target_format_id: { agent_url, id }, brand?: { domain } }',

--- a/skills/adcp-media-buy/SKILL.md
+++ b/skills/adcp-media-buy/SKILL.md
@@ -131,9 +131,7 @@ Create an advertising campaign from selected products.
       "budget": 10000
     }
   ],
-  "start_time": {
-    "type": "asap"
-  },
+  "start_time": "asap",
   "end_time": "2024-03-31T23:59:59Z"
 }
 ```
@@ -147,7 +145,7 @@ Create an advertising campaign from selected products.
   - `bid_price`: Required for auction pricing
   - `targeting_overlay`: Additional targeting constraints
   - `creative_ids` or `creatives`: Creative assignments
-- `start_time` (object, required): `{ "type": "asap" }` or `{ "type": "scheduled", "datetime": "..." }`
+- `start_time` (string, required): `"asap"` or an ISO 8601 datetime (e.g., `"2024-06-01T00:00:00Z"`)
 - `end_time` (string, required): ISO 8601 datetime
 
 **Response contains:**


### PR DESCRIPTION
Closes #4736

`start_time` in `create_media_buy` is a `oneOf` string — either the literal `"asap"` or an ISO 8601 datetime. Addie's tool description and `adcp-media-buy/SKILL.md` both documented a nonexistent object variant `{ type: "asap"|"scheduled" }`, causing Addie to recommend payloads that fail schema validation.

**Changes:**
- `skills/adcp-media-buy/SKILL.md`: fix the JSON example and field description to match the actual schema
- `server/src/addie/mcp/adcp-tools.ts` (quick-reference): replace object-shaped hint with concrete string examples
- `server/src/addie/mcp/adcp-tools.ts` (validator): tighten the `create_media_buy` validator to reject non-string `start_time`/`end_time` values with clear error messages (previously, `{ type: "asap" }` was truthy and passed the required-field check silently)

**Non-breaking justification:** documentation and validator message changes; no protocol schema or wire format touched. The validator is stricter than before — existing correct callers are unaffected; previously-passing invalid payloads now get an early, clear error rather than a downstream schema-validation failure.

**Pre-PR review:**
- prompt-engineer: approved — diff matches `static/schemas/source/core/start-timing.json` exactly; nit on format placeholder addressed (changed to concrete example)
- code-reviewer: approved — validator logic covers all invalid input classes; no valid `start_time` value is rejected; no existing tests broken

> **Triage-managed PR.** This bot does not currently iterate on review comments or PR conversation threads (only on the source issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` → fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121) for context.

Session: https://claude.ai/code/session_01RsjFaAWtGczz2m2frRD7H8

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsjFaAWtGczz2m2frRD7H8)_