### PR TITLE
fix(addie): chunk long replies into multiple Slack section blocks

### DIFF
--- a/.changeset/addie-slack-section-block-chunking.md
+++ b/.changeset/addie-slack-section-block-chunking.md
@@ -1,0 +1,18 @@
+---
+---
+
+fix(addie): chunk long replies into multiple Slack section blocks
+
+Slack rejects `section.text.text` over 3000 chars with `invalid_blocks`. The streaming fallback `say()` in `addie/bolt-app.ts` and the announcement review card / public payload in `announcement-handlers.ts` were stuffing entire replies (and LLM-generated announcement drafts) into a single section block, so any long output failed at the wire and the user was left with nothing.
+
+**Three changes:**
+
+1. **New shared module `server/src/addie/slack-blocks.ts`** with `splitMrkdwnIntoSections` (paragraph/line/word-aware chunking, ~2900-char per section, caps at 40 blocks with a truncation marker), `truncateNotificationText` (clamps the top-level `text` notification fallback so it can't trip `msg_too_long`), and `SLACK_SECTION_HARD_LIMIT` for callers that need the constant.
+
+2. **`bolt-app.ts` DM fallback paths** (streaming + non-streaming) now chunk via the shared helpers instead of emitting one giant section.
+
+3. **`announcement-handlers.ts`** review card and public payload chunk via the shared helpers; the LinkedIn draft surface uses a new local `buildLinkedInDraftSection` that truncates with a clear warning when the draft exceeds LinkedIn's own 3000-char post cap — multi-fence splitting would defeat the copy-paste UX and any draft that long already needs editor edits.
+
+Tests in `server/tests/unit/addie/slack-blocks.test.ts` pin empty input, exact-boundary, single-token overflow, markdown list across a boundary, paragraph-style overflow with the truncation marker, and Block Kit shape (catches typo regressions that would only surface at Slack).
+
+Does not address the `streamer.stop()` `msg_too_long` failure mode — that is server-enforced by Slack on cumulative streamed message length and needs a mid-stream length-watcher; tracked separately.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adcontextprotocol",
-  "version": "3.0.3",
+  "version": "3.1.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adcontextprotocol",
-      "version": "3.0.3",
+      "version": "3.1.0-beta.1",
       "dependencies": {
         "@adcp/sdk": "^7.7.0",
         "@anthropic-ai/sdk": "^0.96.0",

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -103,6 +103,7 @@ import {
   guardBareJsonEnvelope,
   logInteraction,
 } from './security.js';
+import { splitMrkdwnIntoSections, truncateNotificationText } from './slack-blocks.js';
 import type { RequestTools } from './claude-client.js';
 import type { SuggestedPrompt } from './types.js';
 import { DatabaseThreadContextStore } from './thread-context-store.js';
@@ -1807,9 +1808,9 @@ async function handleUserMessage({
             await say(apology);
           } else {
             await say({
-              text: slackText,
+              text: truncateNotificationText(slackText),
               blocks: [
-                { type: 'section', text: { type: 'mrkdwn', text: slackText } },
+                ...splitMrkdwnIntoSections(slackText),
                 ...fallbackImages.slice(0, 3).map(img => ({
                   type: 'image' as const,
                   image_url: img.url,
@@ -1844,15 +1845,9 @@ async function handleUserMessage({
           await say("I'm sorry, I encountered an error. Please try again.");
         } else {
           await say({
-            text: slackText,
+            text: truncateNotificationText(slackText),
             blocks: [
-              {
-                type: 'section',
-                text: {
-                  type: 'mrkdwn',
-                  text: slackText,
-                },
-              },
+              ...splitMrkdwnIntoSections(slackText),
               ...images.slice(0, 3).map(img => ({
                 type: 'image' as const,
                 image_url: img.url,

--- a/server/src/addie/jobs/announcement-handlers.ts
+++ b/server/src/addie/jobs/announcement-handlers.ts
@@ -48,8 +48,48 @@ import { sanitizeDraftForSlack } from './announcement-trigger.js';
 import { isSafeVisualUrl } from '../../services/announcement-visual.js';
 import { isSlackUserAAOAdmin } from '../mcp/admin-tools.js';
 import type { SlackBlock, SlackElement } from '../../slack/types.js';
+import {
+  splitMrkdwnIntoSections,
+  truncateNotificationText,
+} from '../slack-blocks.js';
 
 const logger = createLogger('announcement-handlers');
+
+/**
+ * LinkedIn's own post body cap is ~3000 chars; any draft beyond that is
+ * already broken before Slack-rendering. Show the editor as much as we
+ * can fit in one fenced section with a clear warning so they can
+ * regenerate or edit the draft. The Slack section cap (2900 with
+ * headroom) bounds what we display; the rest of the fenced section
+ * goes to header text, the warning line, and the fence delimiters.
+ */
+const LINKEDIN_FENCED_CONTENT_BUDGET = 2700;
+
+function buildLinkedInDraftSection(safeLinkedIn: string): {
+  type: 'section';
+  text: { type: 'mrkdwn'; text: string };
+} {
+  const header = '*LinkedIn draft* (copy-paste)';
+  if (safeLinkedIn.length <= LINKEDIN_FENCED_CONTENT_BUDGET) {
+    return {
+      type: 'section',
+      text: { type: 'mrkdwn', text: `${header}\n\`\`\`${safeLinkedIn}\`\`\`` },
+    };
+  }
+  logger.warn(
+    { draftLength: safeLinkedIn.length, displayBudget: LINKEDIN_FENCED_CONTENT_BUDGET },
+    'LinkedIn draft exceeds display budget; truncating in review card',
+  );
+  const truncated = safeLinkedIn.slice(0, LINKEDIN_FENCED_CONTENT_BUDGET);
+  const warning = `:warning: Draft is ${safeLinkedIn.length} chars — exceeds LinkedIn's 3000-char limit. Truncated below; regenerate or edit the draft before posting.`;
+  return {
+    type: 'section',
+    text: {
+      type: 'mrkdwn',
+      text: `${header}\n${warning}\n\`\`\`${truncated}…\`\`\``,
+    },
+  };
+}
 
 const APP_URL = process.env.APP_URL || 'https://agenticadvertising.org';
 
@@ -444,12 +484,9 @@ export function renderReviewCard(args: {
       image_url: draft.visual_url,
       alt_text: draft.visual_alt_text ?? `${orgName} announcement visual`,
     },
-    { type: 'section', text: { type: 'mrkdwn', text: `*Slack draft*\n${safeSlack}` } },
+    ...splitMrkdwnIntoSections(`*Slack draft*\n${safeSlack}`),
     { type: 'divider' },
-    {
-      type: 'section',
-      text: { type: 'mrkdwn', text: `*LinkedIn draft* (copy-paste)\n\`\`\`${safeLinkedIn}\`\`\`` },
-    },
+    buildLinkedInDraftSection(safeLinkedIn),
   ];
 
   const skipped = Boolean(
@@ -575,10 +612,10 @@ export function buildPublicAnnouncementPayload(draft: DraftMetadata): {
   );
   const alt = draft.visual_alt_text ?? `${draft.org_name ?? 'New member'} announcement visual`;
   const blocks: SlackBlock[] = [
-    { type: 'section', text: { type: 'mrkdwn', text: safeSlack } },
+    ...splitMrkdwnIntoSections(safeSlack),
     { type: 'image', image_url: draft.visual_url, alt_text: alt },
   ];
-  return { text: safeSlack, blocks };
+  return { text: truncateNotificationText(safeSlack), blocks };
 }
 
 // Bolt's action body types are a discriminated union that doesn't compose

--- a/server/src/addie/slack-blocks.ts
+++ b/server/src/addie/slack-blocks.ts
@@ -1,0 +1,67 @@
+/**
+ * Slack Block Kit length-safe helpers.
+ *
+ * Slack rejects a `section.text.text` mrkdwn body over 3000 chars with
+ * `invalid_blocks`, and a top-level `text` (notification fallback) over
+ * 40000 chars with `msg_too_long`. Any code path that posts model-generated
+ * or otherwise-unbounded content should run it through these helpers
+ * before handing it to `chat.postMessage` / `say()`.
+ */
+
+/** Slack's hard cap on `section.text.text`. Exceeding this returns `invalid_blocks`. */
+export const SLACK_SECTION_HARD_LIMIT = 3000;
+
+/** Per-section mrkdwn cap with headroom for safety. */
+export const SLACK_SECTION_MRKDWN_LIMIT = 2900;
+
+/** Soft cap on how many section blocks one message will produce. */
+export const SLACK_MAX_SECTION_BLOCKS = 40;
+
+export interface SlackSectionBlock {
+  type: 'section';
+  text: { type: 'mrkdwn'; text: string };
+}
+
+/**
+ * Split `text` into Slack `section` blocks each no longer than
+ * `SLACK_SECTION_MRKDWN_LIMIT`. Prefers paragraph, then line, then word
+ * boundaries. Caps at `SLACK_MAX_SECTION_BLOCKS`; if input is longer,
+ * the last block is suffixed with `_(response truncated)_`.
+ */
+export function splitMrkdwnIntoSections(text: string): SlackSectionBlock[] {
+  const sections: SlackSectionBlock[] = [];
+  let remaining = text;
+  while (remaining.length > 0 && sections.length < SLACK_MAX_SECTION_BLOCKS) {
+    if (remaining.length <= SLACK_SECTION_MRKDWN_LIMIT) {
+      sections.push({ type: 'section', text: { type: 'mrkdwn', text: remaining } });
+      remaining = '';
+      break;
+    }
+    const window = remaining.slice(0, SLACK_SECTION_MRKDWN_LIMIT);
+    let cut = window.lastIndexOf('\n\n');
+    if (cut < SLACK_SECTION_MRKDWN_LIMIT / 2) cut = window.lastIndexOf('\n');
+    if (cut < SLACK_SECTION_MRKDWN_LIMIT / 2) cut = window.lastIndexOf(' ');
+    if (cut <= 0) cut = SLACK_SECTION_MRKDWN_LIMIT;
+    sections.push({ type: 'section', text: { type: 'mrkdwn', text: remaining.slice(0, cut) } });
+    // Strip leading whitespace at the chunk boundary. The leading `\n` we cut
+    // on is decorative — list markers (`- item`, `1. item`) at start-of-section
+    // still render. Indented continuations would be mangled, but that's the
+    // pragmatic trade for never trailing into a half-word.
+    remaining = remaining.slice(cut).replace(/^\s+/, '');
+  }
+  if (remaining.length > 0 && sections.length > 0) {
+    const last = sections[sections.length - 1];
+    last.text.text = `${last.text.text}\n\n_(response truncated)_`;
+  }
+  return sections;
+}
+
+/**
+ * Cap a top-level `text` notification fallback. Slack will accept up to
+ * 40k, but there's no reason to send the full reply twice — clamp to one
+ * section's worth so we can't trip `msg_too_long` here.
+ */
+export function truncateNotificationText(text: string): string {
+  if (text.length <= SLACK_SECTION_MRKDWN_LIMIT) return text;
+  return text.slice(0, SLACK_SECTION_MRKDWN_LIMIT - 1) + '…';
+}

--- a/server/tests/unit/addie/slack-blocks.test.ts
+++ b/server/tests/unit/addie/slack-blocks.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import {
+  splitMrkdwnIntoSections,
+  truncateNotificationText,
+  SLACK_SECTION_MRKDWN_LIMIT,
+  SLACK_SECTION_HARD_LIMIT,
+  SLACK_MAX_SECTION_BLOCKS,
+  type SlackSectionBlock,
+} from '../../../src/addie/slack-blocks.js';
+
+/**
+ * Assert a value matches Slack's section-block shape and stays under the
+ * hard cap. Catches typo regressions (`type: 'mrkdown'`, empty text) that
+ * would only surface at Slack with `invalid_blocks`.
+ */
+function expectValidSection(s: unknown): asserts s is SlackSectionBlock {
+  expect(s).toMatchObject({
+    type: 'section',
+    text: { type: 'mrkdwn' },
+  });
+  const block = s as SlackSectionBlock;
+  expect(typeof block.text.text).toBe('string');
+  expect(block.text.text.length).toBeGreaterThan(0);
+  expect(block.text.text.length).toBeLessThan(SLACK_SECTION_HARD_LIMIT);
+}
+
+describe('splitMrkdwnIntoSections', () => {
+  it('returns no sections for an empty string', () => {
+    expect(splitMrkdwnIntoSections('')).toEqual([]);
+  });
+
+  it('returns a single section when text fits under the cap', () => {
+    const sections = splitMrkdwnIntoSections('hello');
+    expect(sections).toHaveLength(1);
+    expectValidSection(sections[0]);
+    expect(sections[0].text.text).toBe('hello');
+  });
+
+  it('keeps input exactly at the soft limit in a single section', () => {
+    const exact = 'a'.repeat(SLACK_SECTION_MRKDWN_LIMIT);
+    const sections = splitMrkdwnIntoSections(exact);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].text.text.length).toBe(SLACK_SECTION_MRKDWN_LIMIT);
+  });
+
+  it('splits input one char over the soft limit into two sections', () => {
+    const overflow = 'a'.repeat(SLACK_SECTION_MRKDWN_LIMIT + 1);
+    const sections = splitMrkdwnIntoSections(overflow);
+    expect(sections).toHaveLength(2);
+    for (const s of sections) expectValidSection(s);
+  });
+
+  it('hard-cuts a single whitespace-free token at the section limit', () => {
+    // Realistic shape: a long URL / base64 blob with no break points.
+    const token = 'https://example.com/' + 'x'.repeat(5000);
+    const sections = splitMrkdwnIntoSections(token);
+    expect(sections.length).toBeGreaterThan(1);
+    for (const s of sections) {
+      expectValidSection(s);
+      expect(s.text.text.length).toBeLessThanOrEqual(SLACK_SECTION_MRKDWN_LIMIT);
+    }
+    // Cuts at the soft limit, so rejoining recovers the original.
+    expect(sections.map(s => s.text.text).join('')).toBe(token);
+  });
+
+  it('produces multiple sections each within the per-section limit', () => {
+    const long = 'word '.repeat(2000); // ~10000 chars
+    const sections = splitMrkdwnIntoSections(long);
+    expect(sections.length).toBeGreaterThan(1);
+    for (const s of sections) {
+      expectValidSection(s);
+      expect(s.text.text.length).toBeLessThan(SLACK_SECTION_HARD_LIMIT);
+    }
+  });
+
+  it('prefers paragraph boundaries when splitting', () => {
+    const paragraphs = Array.from({ length: 5 }, (_, i) => `para ${i} `.repeat(200)).join('\n\n');
+    const sections = splitMrkdwnIntoSections(paragraphs);
+    // Every break should land at a paragraph boundary — no section should start
+    // with a half-word from the previous paragraph.
+    for (let i = 1; i < sections.length; i++) {
+      expect(sections[i].text.text.startsWith('para ')).toBe(true);
+    }
+  });
+
+  it('preserves markdown list markers across a chunk boundary', () => {
+    // The whitespace-strip at chunk boundaries drops leading `\n`, but list
+    // markers (`- item`) at start-of-section still render. This pins that
+    // trade-off: if a regression made the splitter drop the `- ` itself,
+    // this test would catch it.
+    const items = Array.from({ length: 400 }, (_, i) => `- list item ${i} with some prose to fill space`).join('\n');
+    const sections = splitMrkdwnIntoSections(items);
+    expect(sections.length).toBeGreaterThan(1);
+    for (let i = 1; i < sections.length; i++) {
+      // Second and subsequent sections must start with a list marker, not
+      // a half-word from the previous section's last item.
+      expect(sections[i].text.text.startsWith('- list item ')).toBe(true);
+    }
+  });
+
+  it('tags the last block when input exceeds max block count (hard-cut path)', () => {
+    const oversized = 'x'.repeat(SLACK_SECTION_MRKDWN_LIMIT * (SLACK_MAX_SECTION_BLOCKS + 2));
+    const sections = splitMrkdwnIntoSections(oversized);
+    expect(sections.length).toBe(SLACK_MAX_SECTION_BLOCKS);
+    expect(sections[sections.length - 1].text.text).toMatch(/_\(response truncated\)_/);
+  });
+
+  it('tags the last block when paragraph-style input exceeds max block count', () => {
+    // Same overflow case but with natural break points, so the splitter
+    // goes through the `lastIndexOf('\n\n')` branch. A regression that
+    // only broke the truncation marker on the boundary path wouldn't be
+    // caught by the hard-cut test above.
+    const paragraph = ('sentence words words words words. '.repeat(80) + '\n\n');
+    const oversized = paragraph.repeat(SLACK_MAX_SECTION_BLOCKS + 2);
+    const sections = splitMrkdwnIntoSections(oversized);
+    expect(sections.length).toBe(SLACK_MAX_SECTION_BLOCKS);
+    expect(sections[sections.length - 1].text.text).toMatch(/_\(response truncated\)_/);
+  });
+});
+
+describe('truncateNotificationText', () => {
+  it('returns input unchanged when within the section limit', () => {
+    expect(truncateNotificationText('short')).toBe('short');
+  });
+
+  it('returns input unchanged at exactly the section limit', () => {
+    const exact = 'a'.repeat(SLACK_SECTION_MRKDWN_LIMIT);
+    expect(truncateNotificationText(exact)).toBe(exact);
+  });
+
+  it('caps text one char over the limit with an ellipsis', () => {
+    const oneOver = 'a'.repeat(SLACK_SECTION_MRKDWN_LIMIT + 1);
+    const out = truncateNotificationText(oneOver);
+    expect(out.length).toBe(SLACK_SECTION_MRKDWN_LIMIT);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  it('caps long text at the section limit with an ellipsis', () => {
+    const oversized = 'a'.repeat(SLACK_SECTION_MRKDWN_LIMIT * 2);
+    const out = truncateNotificationText(oversized);
+    expect(out.length).toBe(SLACK_SECTION_MRKDWN_LIMIT);
+    expect(out.endsWith('…')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Lift length-safe Slack Block Kit helpers into a shared `server/src/addie/slack-blocks.ts` (`splitMrkdwnIntoSections`, `truncateNotificationText`, `SLACK_SECTION_HARD_LIMIT`).
- Apply to the DM fallback `say()` paths in `bolt-app.ts` (streaming + non-streaming) so a long reply can't trip `invalid_blocks` when the streamer's `stop()` already failed.
- Apply to the announcement review card and public payload (`announcement-handlers.ts:renderReviewCard`, `buildPublicAnnouncementPayload`); switch the LinkedIn draft surface to a `buildLinkedInDraftSection` helper that truncates with a warning when the draft exceeds LinkedIn's own 3000-char post cap.
- Tests: 14 vitest cases pinning empty input, exact-boundary, single-token overflow, markdown list across a boundary, paragraph-style overflow with the truncation marker, plus shape assertions that catch typo regressions.

## Background
Production alert: `streamer.stop()` failed with `msg_too_long`, then the fallback `say()` failed with `invalid_blocks: must be less than 3001 characters`. The `msg_too_long` is server-enforced by Slack on cumulative streamed message length (confirmed by reading `@slack/web-api/dist/chat-stream.js`) and is addressed separately by a planned streaming length-watcher. This PR closes the `invalid_blocks` half — the same antipattern existed in `announcement-handlers.ts` for editorial review cards.

## Test plan
- [x] `npx tsc --noEmit -p server/tsconfig.json` — clean
- [x] `npx vitest run tests/unit/addie/slack-blocks.test.ts` — 14/14 passing
- [ ] Trigger a long Addie reply in Slack DM where the streamer would previously fail; verify the fallback posts a chunked, valid message
- [ ] Verify a normal-length Addie reply still renders identically
- [ ] Verify the announcement review card unchanged for normal-length drafts; verify the LinkedIn surface shows the truncate-and-warn message for an oversized draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)