### PR TITLE
fix(compliance): replace phantom_unit with devices in reach_buy_flow rejection step

### DIFF
--- a/.changeset/fix-reach-buy-flow-phantom-unit.md
+++ b/.changeset/fix-reach-buy-flow-phantom-unit.md
@@ -1,0 +1,17 @@
+---
+"adcontextprotocol": patch
+---
+
+fix(compliance): replace phantom_unit with devices in reach_buy_flow rejection step
+
+The rejection_unsupported_reach_unit phase was using reach_unit: "phantom_unit", which
+is not a valid reach-unit.json enum value. Because the step carries negative_path:
+payload_well_formed, the payload must be schema-valid — but phantom_unit caused schema
+rejection before the seller's capability-checking logic ran, so the test was passing for
+the wrong reason.
+
+Fix: add metric_optimization.supported_reach_units: ["households", "individuals"] to the
+reach_ctv_q2 product fixture and replace phantom_unit with "devices" (a valid enum value
+deliberately absent from the fixture's declared units). The rejection now comes from the
+seller's business-logic capability check, which is the contract the scenario is designed
+to exercise.

--- a/static/compliance/source/protocols/media-buy/scenarios/reach_buy_flow.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/reach_buy_flow.yaml
@@ -94,6 +94,12 @@ fixtures:
       channels: ["video"]
       format_ids:
         - id: "video_30s"
+      metric_optimization:
+        supported_metrics:
+          - "reach"
+        supported_reach_units:
+          - "households"
+          - "individuals"
   pricing_options:
     - product_id: "reach_ctv_q2"
       pricing_option_id: "auction_cpm"
@@ -159,8 +165,8 @@ phases:
     title: "Create a reach-optimized buy with a supported reach_unit"
     narrative: |
       The buyer creates a media buy whose package carries a metric-kind
-      optimization_goal with metric: reach, reach_unit: households (assumed
-      to be in the product's supported_reach_units for CTV inventory), and
+      optimization_goal with metric: reach, reach_unit: households (explicitly
+      declared in the product fixture's supported_reach_units), and
       a target_frequency band of 1–3 over a 7-day rolling window. The seller
       should accept and return a media_buy_id used for subsequent delivery
       checks.
@@ -223,14 +229,18 @@ phases:
       rejection in performance_buy_flow and the unbound audience_id
       rejection in audience_buy_flow.
 
-      The literal string "phantom_unit" is chosen because no spec-defined
-      reach_unit value matches it and no honest product will declare it in
-      supported_reach_units. Sellers that round-trip "phantom_unit" as
-      accepted are demonstrating they don't validate against their product
-      capability declarations.
+      "devices" is chosen because it is a valid spec-defined reach_unit enum
+      value that the reach_ctv_q2 product fixture deliberately omits from
+      supported_reach_units (which declares only "households" and
+      "individuals"). Using a valid enum value satisfies
+      negative_path: payload_well_formed (the request is schema-valid),
+      while the fixture exclusion ensures the rejection must come from the
+      seller's capability-checking logic rather than schema validation.
+      Sellers that silently accept "devices" are demonstrating they don't
+      validate reach_unit against their product capability declarations.
 
     steps:
-      - id: create_media_buy_with_phantom_reach_unit
+      - id: create_media_buy_with_unsupported_reach_unit
         title: "Submit a reach goal whose reach_unit is not in supported_reach_units"
         task: create_media_buy
         schema_ref: "media-buy/create-media-buy-request.json"
@@ -258,7 +268,7 @@ phases:
               optimization_goals:
                 - kind: "metric"
                   metric: "reach"
-                  reach_unit: "phantom_unit"
+                  reach_unit: "devices"
           idempotency_key: "$generate:uuid_v4#reach_buy_flow_rejection_unsupported_reach_unit"
         validations:
           - check: error_code


### PR DESCRIPTION
Closes #4819

The `rejection_unsupported_reach_unit` phase in `reach_buy_flow.yaml` used `reach_unit: "phantom_unit"`, which is not a valid value in `reach-unit.json`. Because the step carries `negative_path: payload_well_formed`, the payload must be schema-valid — but `phantom_unit` caused schema rejection before the seller's capability-checking logic ran. The test was passing for the wrong reason: any seller with a working schema validator would pass, regardless of whether it implemented `supported_reach_units` enforcement.

**Changes:**
- Add `metric_optimization.supported_metrics: ["reach"]` and `supported_reach_units: ["households", "individuals"]` to the `reach_ctv_q2` product fixture, giving the runner a deterministic seed contract
- Replace `reach_unit: "phantom_unit"` with `reach_unit: "devices"` — a valid enum value deliberately absent from the fixture's declared units, so rejection must come from the seller's business-logic capability check
- Rename step id from `create_media_buy_with_phantom_reach_unit` to `create_media_buy_with_unsupported_reach_unit`
- Update phase narrative to explain the `payload_well_formed` / fixture-exclusion contract

**Non-breaking justification:** The spec requirement on sellers (reject `reach_unit` values not in `supported_reach_units` with `INVALID_REQUEST`) is unchanged. This corrects a test that was exercising schema validation instead of seller capability logic; no protocol wire behavior changes.

**Patch eligibility:** This fix is patch-eligible for `3.0.x` (conformance harness bug fix, per playbook). Cherry-pick to `3.0.x` after merge.

**Pre-PR review:**
- code-reviewer: approved — all three hunks correct; `supported_metrics` required field added; step id renamed; `patch` bump appropriate
- ad-tech-protocol-expert: approved — `devices` is the correct sentinel for a CTV-household product; `payload_well_formed` contract is now coherent; non-breaking confirmed

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01UcTjmS2fXjBBUgu7vHZXvg

---
_Generated by [Claude Code](https://claude.ai/code/session_01UcTjmS2fXjBBUgu7vHZXvg)_