### PR TITLE
fix(reach_buy_flow): replace phantom_unit with valid enum value + narrow product fixture

### DIFF
--- a/.changeset/fix-reach-buy-flow-phantom-unit.md
+++ b/.changeset/fix-reach-buy-flow-phantom-unit.md
@@ -1,0 +1,21 @@
+---
+"adcontextprotocol": patch
+---
+
+fix(compliance): replace phantom_unit with devices in reach_buy_flow rejection step
+
+The rejection_unsupported_reach_unit phase was using reach_unit: "phantom_unit", which
+is not a valid reach-unit.json enum value. Because the step carries negative_path:
+payload_well_formed, the payload must be schema-valid — but phantom_unit caused schema
+rejection before the seller's capability-checking logic ran, so the test was passing for
+the wrong reason.
+
+Fix: add metric_optimization.supported_metrics: ["reach"] and
+supported_reach_units: ["households", "individuals"] to the reach_ctv_q2 product fixture,
+replace phantom_unit with "devices" (a valid enum value deliberately absent from the
+fixture's declared units), and rename the step id from
+create_media_buy_with_phantom_reach_unit to create_media_buy_with_unsupported_reach_unit.
+The rejection now comes from the seller's business-logic capability check, which is the
+contract the scenario is designed to exercise.
+
+Closes #4819.

--- a/static/compliance/source/protocols/media-buy/scenarios/reach_buy_flow.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/reach_buy_flow.yaml
@@ -95,6 +95,7 @@ fixtures:
       format_ids:
         - id: "video_30s"
       metric_optimization:
+        supported_metrics: ["reach"]
         supported_reach_units: ["households", "individuals"]
   pricing_options:
     - product_id: "reach_ctv_q2"
@@ -161,8 +162,8 @@ phases:
     title: "Create a reach-optimized buy with a supported reach_unit"
     narrative: |
       The buyer creates a media buy whose package carries a metric-kind
-      optimization_goal with metric: reach, reach_unit: households (assumed
-      to be in the product's supported_reach_units for CTV inventory), and
+      optimization_goal with metric: reach, reach_unit: households (explicitly
+      declared in the product fixture's supported_reach_units), and
       a target_frequency band of 1–3 over a 7-day rolling window. The seller
       should accept and return a media_buy_id used for subsequent delivery
       checks.
@@ -225,15 +226,18 @@ phases:
       rejection in performance_buy_flow and the unbound audience_id
       rejection in audience_buy_flow.
 
-      "devices" is chosen as the unsupported value: it is a valid spec enum
-      value, keeping the request schema-valid (payload_well_formed), but the
-      product fixture narrows supported_reach_units to ["households",
-      "individuals"] so the seller must reject it. Sellers that accept "devices"
-      are demonstrating they don't validate against their product capability
-      declarations.
+      "devices" is chosen because it is a valid spec-defined reach_unit enum
+      value that the reach_ctv_q2 product fixture deliberately omits from
+      supported_reach_units (which declares only "households" and
+      "individuals"). Using a valid enum value satisfies
+      negative_path: payload_well_formed (the request is schema-valid),
+      while the fixture exclusion ensures the rejection must come from the
+      seller's capability-checking logic rather than schema validation.
+      Sellers that silently accept "devices" are demonstrating they don't
+      validate reach_unit against their product capability declarations.
 
     steps:
-      - id: create_media_buy_with_phantom_reach_unit
+      - id: create_media_buy_with_unsupported_reach_unit
         title: "Submit a reach goal whose reach_unit is not in supported_reach_units"
         task: create_media_buy
         schema_ref: "media-buy/create-media-buy-request.json"

--- a/static/compliance/source/protocols/media-buy/scenarios/reach_buy_flow.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/reach_buy_flow.yaml
@@ -94,6 +94,8 @@ fixtures:
       channels: ["video"]
       format_ids:
         - id: "video_30s"
+      metric_optimization:
+        supported_reach_units: ["households", "individuals"]
   pricing_options:
     - product_id: "reach_ctv_q2"
       pricing_option_id: "auction_cpm"
@@ -223,11 +225,12 @@ phases:
       rejection in performance_buy_flow and the unbound audience_id
       rejection in audience_buy_flow.
 
-      The literal string "phantom_unit" is chosen because no spec-defined
-      reach_unit value matches it and no honest product will declare it in
-      supported_reach_units. Sellers that round-trip "phantom_unit" as
-      accepted are demonstrating they don't validate against their product
-      capability declarations.
+      "devices" is chosen as the unsupported value: it is a valid spec enum
+      value, keeping the request schema-valid (payload_well_formed), but the
+      product fixture narrows supported_reach_units to ["households",
+      "individuals"] so the seller must reject it. Sellers that accept "devices"
+      are demonstrating they don't validate against their product capability
+      declarations.
 
     steps:
       - id: create_media_buy_with_phantom_reach_unit
@@ -258,7 +261,7 @@ phases:
               optimization_goals:
                 - kind: "metric"
                   metric: "reach"
-                  reach_unit: "phantom_unit"
+                  reach_unit: "devices"
           idempotency_key: "$generate:uuid_v4#reach_buy_flow_rejection_unsupported_reach_unit"
         validations:
           - check: error_code


### PR DESCRIPTION
## Summary

The `rejection_unsupported_reach_unit` phase was testing at the wrong layer. `"phantom_unit"` is not a valid `reach_unit` enum value, so the compliance runner was rejecting the request at schema validation before it ever reached seller logic. The scenario is designed to test that sellers enforce their own `supported_reach_units` declarations — not that schema validation catches unknown values.

## Changes

- **Product fixture**: added `metric_optimization.supported_reach_units: ["households", "individuals"]` to the `reach_ctv_q2` fixture, giving the seller an explicit constraint to enforce.
- **Test value**: replaced `reach_unit: "phantom_unit"` with `reach_unit: "devices"`. `"devices"` is a valid spec enum value so the payload is schema-valid, but since the product does not declare it in `supported_reach_units` the seller must reject it via capability checking.

A seller that silently accepts `"devices"` will now correctly fail the storyboard.

Addresses #4819
🤖 Generated with [Claude Code](https://claude.com/claude-code)