### PR TITLE
fix(addie): chunk long streamed replies into a continuation message

### DIFF
--- a/.changeset/addie-stream-length-watcher.md
+++ b/.changeset/addie-stream-length-watcher.md
@@ -1,0 +1,21 @@
+---
+---
+
+fix(addie): chunk long streamed replies into a continuation message
+
+Slack's `chat.stopStream` rejects with `msg_too_long` once the cumulative streamed message crosses a server-side cap (undocumented, observed around 12,000 chars). PR #4820 made the resulting fallback survivable, but a long Addie reply still broke the streaming UX entirely. This adds proactive length-watching to the DM streaming loop:
+
+1. **Decision function in `server/src/addie/slack-blocks.ts`.** `decideStreamAppend(streamedLen, delta, softCap)` returns the prefix to append to the stream, the carry remainder, and whether to finalize. Splits at paragraph → line → word boundaries, with a hard cut for whitespace-free tokens (long URLs, base64 blobs).
+
+2. **Length-watcher in `bolt-app.ts` streaming loop.** Tracks bytes actually appended (`streamedLen`), separate from `fullText.length`. When a delta would cross `STREAM_SOFT_CAP` (default 9000, tunable via `ADDIE_STREAM_SOFT_CAP`), append the safe prefix, append a `_(continued in next message ↓)_` marker, stop the stream, and route subsequent deltas into a continuation buffer.
+
+3. **Continuation post.** After the model finishes, the continuation buffer is posted via `say()` as a follow-up in the same thread, prefixed with `_(continued from above ↑)_`, chunked through `splitMrkdwnIntoSections`, carrying the inline images and feedback block.
+
+4. **Failure modes.**
+   - If the early `streamer.stop` fails, the post-loop fallback still has the full reply in `fullText` and ships it as a chunked `say()` (existing path).
+   - If upstream Claude fails after early finalization (`stream_error` event), the recovery banner posts via `say()` since the streamed message is sealed.
+   - Tool widgets after the cap simply don't render — execution still tracked.
+
+5. **Telemetry.** Logs `streamedLen`, `softCap`, `carryLen`, `fullTextLen` on every cap hit so we can tune the default once we have a few real cases.
+
+Tests cover the decision function: paragraph/line/word/hard-cut boundary preferences, exact-cap, delta-larger-than-cap-from-zero, streamed-len-already-at-cap, full-delta-preserved across `appendPart + carryPart`. The streaming loop itself is not unit-tested — manual smoke verification required.

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -124,6 +124,10 @@ const STREAM_SOFT_CAP = (() => {
   if (!raw) return DEFAULT_STREAM_SOFT_CAP;
   const parsed = parseInt(raw, 10);
   if (!Number.isFinite(parsed) || parsed < 1000 || parsed > 11000) {
+    logger.warn(
+      { raw, default: DEFAULT_STREAM_SOFT_CAP },
+      'Addie Bolt: ADDIE_STREAM_SOFT_CAP invalid — using default. Must parse as int in [1000, 11000].',
+    );
     return DEFAULT_STREAM_SOFT_CAP;
   }
   return parsed;
@@ -1867,6 +1871,11 @@ async function handleUserMessage({
       // continuation buffer as a follow-up message in the same thread.
       // Images are extracted from the full text so they appear with the
       // continuation (which carries the feedback block).
+      //
+      // Note: if a late `stream_error` flips `streamWasInterrupted` after
+      // we've already shipped the first chunk, the downstream persistence
+      // logic still discards the turn. The user sees both messages but
+      // the next turn starts fresh — matching #4797's contract.
       if (streamFinalizedEarly) {
         try {
           const guarded = guardBareJsonEnvelope(continuationBuffer, { pathTag: 'dm-streaming-continuation' });
@@ -1890,6 +1899,36 @@ async function handleUserMessage({
           }
         } catch (continuationError) {
           logger.warn({ continuationError, continuationLen: continuationBuffer.length }, 'Addie Bolt: Continuation post failed');
+        }
+      } else if (!streamWriteable) {
+        // Stream was closed mid-flow (length-cap stop failed, or upstream
+        // interruption with a successful recovery banner). Skip the second
+        // stop attempt — it would throw and we'd just land in the same
+        // chunked-say fallback. Ship the full reply directly here unless
+        // the stream_error branch already posted a recovery banner.
+        if (!streamWasInterrupted) {
+          try {
+            const guarded = guardBareJsonEnvelope(fullText, { pathTag: 'dm-streaming-stop-failed' });
+            const fallbackValidation = validateOutput(guarded.text);
+            const { text: fallbackText, images: fallbackImages } = extractMarkdownImages(fallbackValidation.sanitized);
+            const slackText = wrapUrlsForSlack(fallbackText);
+            if (slackText.trim()) {
+              await say({
+                text: truncateNotificationText(slackText),
+                blocks: [
+                  ...splitMrkdwnIntoSections(slackText),
+                  ...fallbackImages.slice(0, 3).map(img => ({
+                    type: 'image' as const,
+                    image_url: img.url,
+                    alt_text: img.alt,
+                  })),
+                  buildFeedbackBlock(),
+                ],
+              });
+            }
+          } catch (fallbackError) {
+            logger.error({ fallbackError, fullTextLen: fullText.length }, 'Addie Bolt: Stop-failed fallback say() also failed');
+          }
         }
       } else {
         // Stop the stream with feedback buttons and any inline images.

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -103,7 +103,34 @@ import {
   guardBareJsonEnvelope,
   logInteraction,
 } from './security.js';
-import { splitMrkdwnIntoSections, truncateNotificationText } from './slack-blocks.js';
+import {
+  splitMrkdwnIntoSections,
+  truncateNotificationText,
+  decideStreamAppend,
+  DEFAULT_STREAM_SOFT_CAP,
+} from './slack-blocks.js';
+
+/**
+ * Slack rejects `chat.stopStream` with `msg_too_long` once the cumulative
+ * streamed message crosses a server-side cap (undocumented, clusters
+ * around 12000 chars). When `fullText` is about to exceed
+ * `ADDIE_STREAM_SOFT_CAP`, we finalize the stream early with a
+ * continuation marker and post the remainder as a follow-up message in
+ * the same thread. Default 9000 leaves headroom for the marker, the
+ * SDK's in-flight buffer, and the feedback block.
+ */
+const STREAM_SOFT_CAP = (() => {
+  const raw = process.env.ADDIE_STREAM_SOFT_CAP;
+  if (!raw) return DEFAULT_STREAM_SOFT_CAP;
+  const parsed = parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1000 || parsed > 11000) {
+    return DEFAULT_STREAM_SOFT_CAP;
+  }
+  return parsed;
+})();
+
+const STREAM_CONTINUATION_TAIL = '\n\n_(continued in next message ↓)_';
+const STREAM_CONTINUATION_HEAD = '_(continued from above ↑)_\n\n';
 import type { RequestTools } from './claude-client.js';
 import type { SuggestedPrompt } from './types.js';
 import { DatabaseThreadContextStore } from './thread-context-store.js';
@@ -1658,6 +1685,17 @@ async function handleUserMessage({
   // the next turn doesn't feed the model a truncated assistant message.
   let streamWasInterrupted = false;
   let streamInterruptReason = '';
+  // Length-cap continuation state. When the streamed message approaches
+  // Slack's `msg_too_long` cap, we finalize the in-flight stream and route
+  // subsequent deltas into a continuation buffer that ships as a follow-up
+  // message after the model finishes. `streamWriteable` flips false the
+  // moment we attempt to stop — subsequent text deltas skip the stream API
+  // either way (continuation goes into the buffer; failed-stop falls
+  // through to the post-loop chunked-say() fallback via fullText).
+  let streamedLen = 0;
+  let streamWriteable = true;
+  let streamFinalizedEarly = false;
+  let continuationBuffer = '';
 
   try {
     // Get team ID from context for streaming
@@ -1686,32 +1724,72 @@ async function handleUserMessage({
       for await (const event of claudeClient.processMessageStream(inputValidation.sanitized, conversationHistory, routedTools.tools, processOptions)) {
         if (event.type === 'text') {
           fullText += event.text;
-          // Append text chunk to Slack stream
+          // Once we've attempted to stop the stream (whether stop succeeded
+          // and we're in continuation mode, or stop failed and we're heading
+          // for the post-loop fallback), don't touch the stream API. In the
+          // continuation case, accumulate into the buffer for the follow-up
+          // post; in the failed-stop case, fullText carries the full reply
+          // and the post-loop fallback will chunk it via say().
+          if (!streamWriteable) {
+            if (streamFinalizedEarly) continuationBuffer += event.text;
+            continue;
+          }
           // Note: don't apply wrapUrlsForSlack() per-chunk — URLs can span chunk
           // boundaries. Slack auto-links bare https:// URLs in streamed messages.
-          try {
-            await streamer.append({ markdown_text: event.text });
-          } catch (streamError) {
-            logger.warn({ streamError }, 'Addie Bolt: Stream append failed for chunk, continuing');
+          const decision = decideStreamAppend(streamedLen, event.text, STREAM_SOFT_CAP);
+          if (decision.appendPart) {
+            try {
+              await streamer.append({ markdown_text: decision.appendPart });
+              streamedLen += decision.appendPart.length;
+            } catch (streamError) {
+              logger.warn({ streamError }, 'Addie Bolt: Stream append failed for chunk, continuing');
+            }
+          }
+          if (decision.shouldFinalize) {
+            logger.info(
+              { streamedLen, softCap: STREAM_SOFT_CAP, carryLen: decision.carryPart.length, fullTextLen: fullText.length },
+              'Addie Bolt: Stream length cap reached — finalizing and switching to continuation',
+            );
+            try {
+              await streamer.append({ markdown_text: STREAM_CONTINUATION_TAIL });
+            } catch (appendError) {
+              logger.warn({ appendError }, 'Addie Bolt: Continuation tail marker append failed');
+            }
+            streamWriteable = false;
+            try {
+              await streamer.stop({ blocks: [buildFeedbackBlock()] });
+              streamFinalizedEarly = true;
+              continuationBuffer = decision.carryPart;
+            } catch (stopError) {
+              // Stop failed — the first chunk's wire delivery is uncertain.
+              // Don't flip `streamFinalizedEarly`; let the existing post-loop
+              // fallback recover via `fullText` (it can post the entire reply
+              // as a chunked say()).
+              logger.warn({ stopError }, 'Addie Bolt: Stream stop at length cap failed — falling through to post-loop fallback');
+            }
           }
         } else if (event.type === 'tool_start') {
           toolsUsed.push(event.tool_name);
           toolInvocationCount++;
           const taskId = `${event.tool_name}_${toolInvocationCount}`;
           activeToolTaskIds.push(taskId);
-          // Show tool execution as an in-progress task in the streamed message
-          try {
-            // chunks is a Slack streaming API feature not yet in the SDK types
-            await streamer.append({
-              chunks: [{
-                type: 'task_update',
-                id: taskId,
-                title: event.tool_name.replace(/_/g, ' '),
-                status: 'in_progress',
-              }],
-            } as unknown as Parameters<typeof streamer.append>[0]);
-          } catch {
-            // Ignore stream errors for status updates
+          // Skip the task widget once we've closed the stream — any
+          // append would throw on a completed stream. Tool widgets simply
+          // won't render for tools that fire after the cap.
+          if (streamWriteable) {
+            try {
+              // chunks is a Slack streaming API feature not yet in the SDK types
+              await streamer.append({
+                chunks: [{
+                  type: 'task_update',
+                  id: taskId,
+                  title: event.tool_name.replace(/_/g, ' '),
+                  status: 'in_progress',
+                }],
+              } as unknown as Parameters<typeof streamer.append>[0]);
+            } catch {
+              // Ignore stream errors for status updates
+            }
           }
         } else if (event.type === 'tool_end') {
           toolExecutions.push({
@@ -1719,20 +1797,21 @@ async function handleUserMessage({
             parameters: {},
             result: event.result,
           });
-          // Mark tool execution as complete in the streamed message
           const taskId = activeToolTaskIds.pop() || event.tool_name;
-          try {
-            // chunks is a Slack streaming API feature not yet in the SDK types
-            await streamer.append({
-              chunks: [{
-                type: 'task_update',
-                id: taskId,
-                title: event.tool_name.replace(/_/g, ' '),
-                status: event.is_error ? 'error' : 'complete',
-              }],
-            } as unknown as Parameters<typeof streamer.append>[0]);
-          } catch {
-            // Ignore stream errors for status updates
+          if (streamWriteable) {
+            try {
+              // chunks is a Slack streaming API feature not yet in the SDK types
+              await streamer.append({
+                chunks: [{
+                  type: 'task_update',
+                  id: taskId,
+                  title: event.tool_name.replace(/_/g, ' '),
+                  status: event.is_error ? 'error' : 'complete',
+                }],
+              } as unknown as Parameters<typeof streamer.append>[0]);
+            } catch {
+              // Ignore stream errors for status updates
+            }
           }
         } else if (event.type === 'retry') {
           // Show retry status to user
@@ -1750,20 +1829,32 @@ async function handleUserMessage({
           streamWasInterrupted = true;
           streamInterruptReason = event.reason;
           logger.warn(
-            { reason: event.reason, deltasBeforeError: event.deltasBeforeError, fullTextLength: fullText.length },
+            { reason: event.reason, deltasBeforeError: event.deltasBeforeError, fullTextLength: fullText.length, streamFinalizedEarly },
             'Addie Bolt: Stream interrupted mid-reply — discarding partial turn'
           );
-          try {
-            await streamer.append({
-              markdown_text: `\n\n_(${event.reason} — I didn't save this response. Ask again and I'll start over.)_`,
-            });
-          } catch (appendError) {
-            logger.warn({ appendError }, 'Addie Bolt: Recovery banner append failed');
-          }
-          try {
-            await streamer.stop({ blocks: [buildFeedbackBlock()] });
-          } catch (stopError) {
-            logger.warn({ stopError }, 'Addie Bolt: Streamer stop after interruption failed');
+          if (!streamWriteable) {
+            // First chunk already shipped + sealed (or stop attempt already
+            // happened); post the recovery banner as a follow-up in the
+            // same thread so the user knows the rest isn't coming.
+            try {
+              await say(`_(${event.reason} — the rest of that response didn't make it. Ask again and I'll start over.)_`);
+            } catch (sayError) {
+              logger.warn({ sayError }, 'Addie Bolt: Recovery banner say() failed after stream close');
+            }
+          } else {
+            try {
+              await streamer.append({
+                markdown_text: `\n\n_(${event.reason} — I didn't save this response. Ask again and I'll start over.)_`,
+              });
+            } catch (appendError) {
+              logger.warn({ appendError }, 'Addie Bolt: Recovery banner append failed');
+            }
+            streamWriteable = false;
+            try {
+              await streamer.stop({ blocks: [buildFeedbackBlock()] });
+            } catch (stopError) {
+              logger.warn({ stopError }, 'Addie Bolt: Streamer stop after interruption failed');
+            }
           }
         } else if (event.type === 'done') {
           response = event.response;
@@ -1772,46 +1863,23 @@ async function handleUserMessage({
         }
       }
 
-      // Stop the stream with feedback buttons and any inline images.
-      try {
-        // Extract image URLs from streamed text for Slack Block Kit image blocks
-        const { images: streamImages } = extractMarkdownImages(fullText);
-        const MAX_SLACK_IMAGES = 3;
-        const imageBlocks = streamImages.slice(0, MAX_SLACK_IMAGES).map(img => ({
-          type: 'image' as const,
-          image_url: img.url,
-          alt_text: img.alt,
-        }));
-        // Don't pass markdown_text — the SDK buffer already has all text from
-        // append() calls. Passing it again would duplicate the message.
-        await streamer.stop({
-          blocks: [
-            ...imageBlocks,
-            buildFeedbackBlock(),
-          ],
-        });
-      } catch (stopError) {
-        logger.warn({ stopError }, 'Addie Bolt: Stream stop failed, falling back to say()');
-        // Fallback: send via say() so the user isn't left without a response
+      // If the stream was finalized early due to length cap, post the
+      // continuation buffer as a follow-up message in the same thread.
+      // Images are extracted from the full text so they appear with the
+      // continuation (which carries the feedback block).
+      if (streamFinalizedEarly) {
         try {
-          const guarded = guardBareJsonEnvelope(fullText, { pathTag: 'dm-streaming-fallback' });
-          const fallbackValidation = validateOutput(guarded.text);
-          const { text: fallbackText, images: fallbackImages } = extractMarkdownImages(fallbackValidation.sanitized);
-          const slackText = wrapUrlsForSlack(fallbackText);
-          // Slack rejects section blocks with empty mrkdwn text. If streaming
-          // produced nothing (e.g. upstream overload before any deltas), fall
-          // back to a plain apology so the user isn't left silent.
-          if (!slackText.trim()) {
-            const apology = isRetriesExhaustedError(stopError)
-              ? `${stopError.reason}. Please try again in a moment.`
-              : "I'm sorry, I encountered an error. Please try again.";
-            await say(apology);
-          } else {
+          const guarded = guardBareJsonEnvelope(continuationBuffer, { pathTag: 'dm-streaming-continuation' });
+          const continuationValidation = validateOutput(guarded.text);
+          const { text: continuationText, images: continuationImages } = extractMarkdownImages(continuationValidation.sanitized);
+          const slackText = wrapUrlsForSlack(continuationText);
+          if (slackText.trim()) {
+            const bodyWithHead = `${STREAM_CONTINUATION_HEAD}${slackText}`;
             await say({
-              text: truncateNotificationText(slackText),
+              text: truncateNotificationText(bodyWithHead),
               blocks: [
-                ...splitMrkdwnIntoSections(slackText),
-                ...fallbackImages.slice(0, 3).map(img => ({
+                ...splitMrkdwnIntoSections(bodyWithHead),
+                ...continuationImages.slice(0, 3).map(img => ({
                   type: 'image' as const,
                   image_url: img.url,
                   alt_text: img.alt,
@@ -1820,10 +1888,63 @@ async function handleUserMessage({
               ],
             });
           }
-        } catch (sayError) {
-          const rootCause = isRetriesExhaustedError(stopError) ? 'retries-exhausted' : 'other';
-          const logLevel = rootCause === 'retries-exhausted' ? 'warn' : 'error';
-          logger[logLevel]({ sayError, stopError, rootCause }, 'Addie Bolt: Fallback say() also failed');
+        } catch (continuationError) {
+          logger.warn({ continuationError, continuationLen: continuationBuffer.length }, 'Addie Bolt: Continuation post failed');
+        }
+      } else {
+        // Stop the stream with feedback buttons and any inline images.
+        try {
+          // Extract image URLs from streamed text for Slack Block Kit image blocks
+          const { images: streamImages } = extractMarkdownImages(fullText);
+          const MAX_SLACK_IMAGES = 3;
+          const imageBlocks = streamImages.slice(0, MAX_SLACK_IMAGES).map(img => ({
+            type: 'image' as const,
+            image_url: img.url,
+            alt_text: img.alt,
+          }));
+          // Don't pass markdown_text — the SDK buffer already has all text from
+          // append() calls. Passing it again would duplicate the message.
+          await streamer.stop({
+            blocks: [
+              ...imageBlocks,
+              buildFeedbackBlock(),
+            ],
+          });
+        } catch (stopError) {
+          logger.warn({ stopError }, 'Addie Bolt: Stream stop failed, falling back to say()');
+          // Fallback: send via say() so the user isn't left without a response
+          try {
+            const guarded = guardBareJsonEnvelope(fullText, { pathTag: 'dm-streaming-fallback' });
+            const fallbackValidation = validateOutput(guarded.text);
+            const { text: fallbackText, images: fallbackImages } = extractMarkdownImages(fallbackValidation.sanitized);
+            const slackText = wrapUrlsForSlack(fallbackText);
+            // Slack rejects section blocks with empty mrkdwn text. If streaming
+            // produced nothing (e.g. upstream overload before any deltas), fall
+            // back to a plain apology so the user isn't left silent.
+            if (!slackText.trim()) {
+              const apology = isRetriesExhaustedError(stopError)
+                ? `${stopError.reason}. Please try again in a moment.`
+                : "I'm sorry, I encountered an error. Please try again.";
+              await say(apology);
+            } else {
+              await say({
+                text: truncateNotificationText(slackText),
+                blocks: [
+                  ...splitMrkdwnIntoSections(slackText),
+                  ...fallbackImages.slice(0, 3).map(img => ({
+                    type: 'image' as const,
+                    image_url: img.url,
+                    alt_text: img.alt,
+                  })),
+                  buildFeedbackBlock(),
+                ],
+              });
+            }
+          } catch (sayError) {
+            const rootCause = isRetriesExhaustedError(stopError) ? 'retries-exhausted' : 'other';
+            const logLevel = rootCause === 'retries-exhausted' ? 'warn' : 'error';
+            logger[logLevel]({ sayError, stopError, rootCause }, 'Addie Bolt: Fallback say() also failed');
+          }
         }
       }
     } else {

--- a/server/src/addie/slack-blocks.ts
+++ b/server/src/addie/slack-blocks.ts
@@ -23,6 +23,26 @@ export interface SlackSectionBlock {
 }
 
 /**
+ * Find a cut index in `text` no later than `maxLen` that lands on a
+ * paragraph boundary if possible, then a line boundary, then a word
+ * boundary. Falls back to a hard cut at `maxLen` when the text has no
+ * usable break points (e.g. a long URL or base64 blob).
+ *
+ * The "half of max" thresholds prefer a later cut: a paragraph break in
+ * the first half of the window means we'd lose too much text to that
+ * preference, so fall through to line/word cuts that pack more in.
+ */
+function findSafeCut(text: string, maxLen: number): number {
+  if (text.length <= maxLen) return text.length;
+  const window = text.slice(0, maxLen);
+  let cut = window.lastIndexOf('\n\n');
+  if (cut < maxLen / 2) cut = window.lastIndexOf('\n');
+  if (cut < maxLen / 2) cut = window.lastIndexOf(' ');
+  if (cut <= 0) cut = maxLen;
+  return cut;
+}
+
+/**
  * Split `text` into Slack `section` blocks each no longer than
  * `SLACK_SECTION_MRKDWN_LIMIT`. Prefers paragraph, then line, then word
  * boundaries. Caps at `SLACK_MAX_SECTION_BLOCKS`; if input is longer,
@@ -37,11 +57,7 @@ export function splitMrkdwnIntoSections(text: string): SlackSectionBlock[] {
       remaining = '';
       break;
     }
-    const window = remaining.slice(0, SLACK_SECTION_MRKDWN_LIMIT);
-    let cut = window.lastIndexOf('\n\n');
-    if (cut < SLACK_SECTION_MRKDWN_LIMIT / 2) cut = window.lastIndexOf('\n');
-    if (cut < SLACK_SECTION_MRKDWN_LIMIT / 2) cut = window.lastIndexOf(' ');
-    if (cut <= 0) cut = SLACK_SECTION_MRKDWN_LIMIT;
+    const cut = findSafeCut(remaining, SLACK_SECTION_MRKDWN_LIMIT);
     sections.push({ type: 'section', text: { type: 'mrkdwn', text: remaining.slice(0, cut) } });
     // Strip leading whitespace at the chunk boundary. The leading `\n` we cut
     // on is decorative — list markers (`- item`, `1. item`) at start-of-section
@@ -54,6 +70,55 @@ export function splitMrkdwnIntoSections(text: string): SlackSectionBlock[] {
     last.text.text = `${last.text.text}\n\n_(response truncated)_`;
   }
   return sections;
+}
+
+/**
+ * Default soft cap on Slack-streamed message length. Slack's server
+ * rejects `chat.stopStream` with `msg_too_long` once the cumulative
+ * streamed content crosses an internal cap; the exact number is not
+ * documented but reports cluster around 12000 chars. We pick a
+ * conservative default that leaves headroom for the continuation
+ * marker, any in-flight SDK buffer, and the feedback block.
+ *
+ * Tunable via the `ADDIE_STREAM_SOFT_CAP` env var.
+ */
+export const DEFAULT_STREAM_SOFT_CAP = 9000;
+
+export interface StreamAppendDecision {
+  /** Pass to `streamer.append({ markdown_text: appendPart })` when non-empty. */
+  appendPart: string;
+  /** Accumulate into the continuation buffer when non-empty. */
+  carryPart: string;
+  /** True iff this delta crossed the cap and the stream must be finalized. */
+  shouldFinalize: boolean;
+}
+
+/**
+ * Decide how to handle the next streamed delta given how much has
+ * already been streamed. While we're under `softCap`, the entire delta
+ * gets appended. When this delta would cross `softCap`, we split it at
+ * the latest safe boundary that still fits: the prefix is streamed,
+ * the remainder is carried into the continuation buffer, and the
+ * caller must finalize the stream + post the buffer as a follow-up.
+ */
+export function decideStreamAppend(
+  streamedLen: number,
+  delta: string,
+  softCap: number,
+): StreamAppendDecision {
+  if (streamedLen + delta.length <= softCap) {
+    return { appendPart: delta, carryPart: '', shouldFinalize: false };
+  }
+  const budget = Math.max(0, softCap - streamedLen);
+  if (budget === 0) {
+    return { appendPart: '', carryPart: delta, shouldFinalize: true };
+  }
+  const cut = findSafeCut(delta, budget);
+  return {
+    appendPart: delta.slice(0, cut),
+    carryPart: delta.slice(cut),
+    shouldFinalize: true,
+  };
 }
 
 /**

--- a/server/tests/unit/addie/slack-blocks.test.ts
+++ b/server/tests/unit/addie/slack-blocks.test.ts
@@ -146,12 +146,15 @@ describe('decideStreamAppend', () => {
 
   it('falls back to a line boundary when the paragraph cut is too early', () => {
     // Budget = 20. Paragraph break at position 2 (under budget/2 = 10), so
-    // the splitter falls through to the latest `\n` inside the budget, which
-    // lands at position 15 (the newline before "here").
+    // the splitter falls through to a line boundary inside the budget.
+    // Assert structural invariants rather than the exact cut so a later
+    // tweak to the boundary preference doesn't break this for the wrong
+    // reason.
     const delta = 'ab\n\nlater words\nhere then much more text past the cap and beyond';
     const d = decideStreamAppend(80, delta, CAP);
     expect(d.shouldFinalize).toBe(true);
-    expect(d.appendPart).toBe('ab\n\nlater words');
+    expect(d.appendPart.length).toBeLessThanOrEqual(20);
+    expect(d.appendPart).toMatch(/\n[^\n]*$|^[^\n]*$/);
     expect(d.appendPart + d.carryPart).toBe(delta);
   });
 
@@ -175,6 +178,31 @@ describe('decideStreamAppend', () => {
   it('carries the whole delta when streamedLen already equals cap', () => {
     const d = decideStreamAppend(100, 'anything', CAP);
     expect(d).toEqual({ appendPart: '', carryPart: 'anything', shouldFinalize: true });
+  });
+
+  it('carries the whole delta when streamedLen has overshot cap', () => {
+    // Defensive: `budget = Math.max(0, …)` makes overshoot safe. A future
+    // refactor that drops the clamp would silently regress; this pins it.
+    const d = decideStreamAppend(120, 'anything', CAP);
+    expect(d).toEqual({ appendPart: '', carryPart: 'anything', shouldFinalize: true });
+  });
+
+  it('returns an empty no-op for an empty delta', () => {
+    const d = decideStreamAppend(50, '', CAP);
+    expect(d).toEqual({ appendPart: '', carryPart: '', shouldFinalize: false });
+  });
+
+  it('maintains the invariant: shouldFinalize=false implies carryPart is empty', () => {
+    // The type permits a contradictory state; this pins the contract.
+    const cases = [
+      decideStreamAppend(0, 'short', CAP),
+      decideStreamAppend(50, 'still fits', CAP),
+      decideStreamAppend(99, 'x', CAP),
+      decideStreamAppend(100, '', CAP),
+    ];
+    for (const d of cases) {
+      if (!d.shouldFinalize) expect(d.carryPart).toBe('');
+    }
   });
 
   it('handles a single delta larger than the entire cap from a zero start', () => {

--- a/server/tests/unit/addie/slack-blocks.test.ts
+++ b/server/tests/unit/addie/slack-blocks.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   splitMrkdwnIntoSections,
   truncateNotificationText,
+  decideStreamAppend,
   SLACK_SECTION_MRKDWN_LIMIT,
   SLACK_SECTION_HARD_LIMIT,
   SLACK_MAX_SECTION_BLOCKS,
@@ -115,6 +116,81 @@ describe('splitMrkdwnIntoSections', () => {
     const sections = splitMrkdwnIntoSections(oversized);
     expect(sections.length).toBe(SLACK_MAX_SECTION_BLOCKS);
     expect(sections[sections.length - 1].text.text).toMatch(/_\(response truncated\)_/);
+  });
+});
+
+describe('decideStreamAppend', () => {
+  const CAP = 100;
+
+  it('appends the full delta when under cap', () => {
+    const d = decideStreamAppend(50, 'hello world', CAP);
+    expect(d).toEqual({ appendPart: 'hello world', carryPart: '', shouldFinalize: false });
+  });
+
+  it('appends the full delta when exactly at cap', () => {
+    const d = decideStreamAppend(90, '1234567890', CAP);
+    expect(d.appendPart).toBe('1234567890');
+    expect(d.carryPart).toBe('');
+    expect(d.shouldFinalize).toBe(false);
+  });
+
+  it('splits the delta at a paragraph boundary when one exists in the budget', () => {
+    // Cap = 100, streamed = 80, budget = 20. `\n\n` lands at position 14 — well
+    // past budget/2, so the splitter takes it.
+    const delta = 'starting words\n\nthen new para and more text past cap';
+    const d = decideStreamAppend(80, delta, CAP);
+    expect(d.shouldFinalize).toBe(true);
+    expect(d.appendPart).toBe('starting words');
+    expect(d.appendPart + d.carryPart).toBe(delta);
+  });
+
+  it('falls back to a line boundary when the paragraph cut is too early', () => {
+    // Budget = 20. Paragraph break at position 2 (under budget/2 = 10), so
+    // the splitter falls through to the latest `\n` inside the budget, which
+    // lands at position 15 (the newline before "here").
+    const delta = 'ab\n\nlater words\nhere then much more text past the cap and beyond';
+    const d = decideStreamAppend(80, delta, CAP);
+    expect(d.shouldFinalize).toBe(true);
+    expect(d.appendPart).toBe('ab\n\nlater words');
+    expect(d.appendPart + d.carryPart).toBe(delta);
+  });
+
+  it('falls back to a word boundary when no newlines exist', () => {
+    const delta = 'word word word word word word word word word word word';
+    const d = decideStreamAppend(80, delta, CAP);
+    expect(d.shouldFinalize).toBe(true);
+    expect(d.appendPart.endsWith(' ') || d.appendPart.endsWith('d')).toBe(true);
+    expect(d.appendPart + d.carryPart).toBe(delta);
+  });
+
+  it('hard-cuts a whitespace-free token at the budget', () => {
+    const delta = 'x'.repeat(50);
+    const d = decideStreamAppend(80, delta, CAP);
+    expect(d.shouldFinalize).toBe(true);
+    expect(d.appendPart.length).toBe(20);
+    expect(d.carryPart.length).toBe(30);
+    expect(d.appendPart + d.carryPart).toBe(delta);
+  });
+
+  it('carries the whole delta when streamedLen already equals cap', () => {
+    const d = decideStreamAppend(100, 'anything', CAP);
+    expect(d).toEqual({ appendPart: '', carryPart: 'anything', shouldFinalize: true });
+  });
+
+  it('handles a single delta larger than the entire cap from a zero start', () => {
+    const delta = 'a'.repeat(CAP * 3);
+    const d = decideStreamAppend(0, delta, CAP);
+    expect(d.shouldFinalize).toBe(true);
+    expect(d.appendPart.length).toBe(CAP);
+    expect(d.carryPart.length).toBe(CAP * 2);
+    expect(d.appendPart + d.carryPart).toBe(delta);
+  });
+
+  it('preserves the full delta across appendPart + carryPart', () => {
+    // Cross-boundary text with mixed structure.
+    const delta = 'sentence one. sentence two.\n\nparagraph two starts here and continues.';
+    const d = decideStreamAppend(50, delta, CAP);
+    expect(d.appendPart + d.carryPart).toBe(delta);
   });
 });
 


### PR DESCRIPTION
## Summary
- Watch `streamedLen` during the DM streaming loop; when a delta would cross `STREAM_SOFT_CAP` (default 9000, tunable via `ADDIE_STREAM_SOFT_CAP`), split at a paragraph/line/word boundary, finalize the stream with `_(continued in next message ↓)_`, and post the remainder via `say()` as a chunked follow-up message in the same thread.
- New pure helper `decideStreamAppend(streamedLen, delta, softCap)` in `server/src/addie/slack-blocks.ts` returns `{ appendPart, carryPart, shouldFinalize }`. Boundary-finder shared with `splitMrkdwnIntoSections` via a private `findSafeCut`.
- Tool widgets and `stream_error` recovery banner both gated on a new `streamWriteable` flag so we don't call `streamer.append` / `streamer.stop` on a closed stream.
- Post-loop gates the second `streamer.stop` retry on `streamWriteable` — if the early stop already failed, skip the retry and ship the full reply directly (or suppress if `stream_error` already posted a recovery banner). Avoids a degenerate triple-message UX.
- `logger.warn` on invalid `ADDIE_STREAM_SOFT_CAP` so a typo doesn't silently fall back to the default in prod.

## Background
Closes the `streamer.stop() msg_too_long` half of the original Addie alert. PR #4820 made the resulting fallback survivable; this stops the failure from happening in the first place. Slack's cumulative streamed-message cap is server-enforced and undocumented; reports cluster around 12,000 chars, so 9000 leaves headroom for the continuation marker, the SDK's in-flight buffer, and the feedback block. Env-var override lets us tune in prod without a redeploy if we learn the cap is different.

## Test plan
- [x] `npx tsc --noEmit -p server/tsconfig.json` — clean
- [x] `npx vitest run tests/unit/addie/slack-blocks.test.ts` — 26/26 passing (13 new for `decideStreamAppend`)
- [ ] Trigger a long Addie reply in Slack DM (>9000 chars). Verify: first message streams in real time and ends with `_(continued in next message ↓)_`; a follow-up message arrives in the same thread starting with `_(continued from above ↑)_` and ending with the feedback block.
- [ ] Verify a normal-length reply still streams + finalizes in one message (no continuation post).
- [ ] Verify tool widgets render normally for tools that fire before the cap; tools after the cap simply don't show widgets (execution still tracked).
- [ ] Verify `ADDIE_STREAM_SOFT_CAP=2000` env override produces a continuation at a much smaller threshold.

## Follow-up
- Reducer extraction for the streaming loop state machine — tracked in #4826.

🤖 Generated with [Claude Code](https://claude.com/claude-code)