### PR TITLE
feat(adagents): endorse parent-file inline resolution of publisher_properties (#4825)

### DIFF
--- a/.changeset/4825-publisher-properties-inline-resolution.md
+++ b/.changeset/4825-publisher-properties-inline-resolution.md
@@ -1,0 +1,24 @@
+---
+---
+
+feat(adagents): endorse parent-file inline resolution of `publisher_properties` selectors when matched top-level `properties[]` carry a `publisher_domain` matching the selector's `publisher_domain` / `publisher_domains[]`.
+
+**Why.** The production reference for the managed-network pattern (cafemedia.com, ~6,800 represented domains, 2.6 MB authoritative file with 6,843 inline `properties[]`) inlines properties — strict federation requires N HTTP fetches per authorization check, infeasible at managed-network scale. The previous "manager file MUST NOT inline copies of each represented publisher's properties" sentence at `docs/governance/property/adagents.mdx:498` mandated a resolution path no production consumer can take. Either the spec endorses the shape, or every conformant consumer reports cafemedia as broken — and the spec was the wrong answer.
+
+**What changes** (`docs/governance/property/adagents.mdx`).
+
+1. Replaced the "Fan-out resolution semantics" section under `publisher_properties` with a "Resolution paths" section that defines two paths:
+   - **Federated (default)** — fetch each listed publisher's `adagents.json` and apply the selector. Unchanged from the prior wording; remains the trust root.
+   - **Parent-file inline (managed-network optimization)** — MAY satisfy the selector from the parent file's top-level `properties[]` when every matched property carries a `publisher_domain` matching one of the selector's domains AND the selector's predicate (by_tag / by_id / all) is satisfied by the inline entry. `by_id` retains its singular-`publisher_domain`-only restriction; the compact `publisher_domains[]` form remains rejected for `by_id`.
+2. Added a **safety rationale**: the trust anchor is `publisher_domain` on each property. The inline path preserves the "publisher whose inventory is being authorized must be explicitly named" invariant the [`managerdomain` fallback safety rule](#safety-rules-for-this-fallback) protects. A manager file cannot use inline resolution to authorize inventory for a publisher it doesn't list.
+3. Added a **divergence rule**: if inline and federated resolutions disagree on the same `(publisher_domain, property_id)`, the federated result is authoritative. Consumers SHOULD log the divergence as a publisher-side data-integrity warning. Consumers that prefer strict federation MAY ignore the inline path entirely.
+4. Added a **revocation rule under inline resolution**: inline path MUST honor `revoked_publisher_domains[]` on the parent file. Consumers that also resolve federated SHOULD cross-check the child's own `revoked_publisher_domains[]`; first match (parent or child) revokes.
+5. Tightened the reachability invariant clause at `:244` to acknowledge `publisher_properties` selectors satisfied via parent-file inline (the property-level resolution path the managed-network-scale changeset established now extends to `publisher_properties` selectors, not just `property_ids` / `property_tags` on the agent entry).
+
+**Schema** (`static/schemas/source/core/publisher-property-selector.json`).
+
+Updated descriptions on the `selection_type: "all"` and `selection_type: "by_tag"` selectors to acknowledge the inline resolution path. No structural schema change — this is resolution-semantics clarification, not a new field shape. Existing files validate unchanged.
+
+**SDK companions.** Consumers walking `publisher_properties` selectors should learn to consult parent-file `properties[]` matching the selector's `publisher_domain` / `publisher_domains[]` set before initiating per-child fetches. `_resolve_agent_properties` in `adcp-client-python` (gap at `adcp/adagents.py:909-959`) is the canonical site; tracking issue: adcontextprotocol/adcp-client-python (companion). The SDK fan-out bug (`publisher_domains[]` not being expanded into N per-domain resolutions) is orthogonal and lands separately.
+
+**Companion ticket.** adcontextprotocol/adcp#4823 (AAO directory inverse-lookup) is a hard consumer of this rule — the directory's `properties_total` per publisher cannot be computed on managed-network-shape files without this resolution path settled.

--- a/docs/governance/property/adagents.mdx
+++ b/docs/governance/property/adagents.mdx
@@ -242,7 +242,7 @@ When `https://{publisher}/.well-known/adagents.json` returns `404`, validators M
 - **Explicit publisher scoping required**: a manager-hosted `adagents.json` MUST positively name the source publisher domain in a `publisher_domain` field that is reachable from at least one `authorized_agents[]` entry. "Reachable" means one of the following paths resolves to the source domain:
 
   1. **Per-agent paths.** The agent entry directly carries the publisher domain under `publisher_properties[].publisher_domain`, inside `publisher_properties[].publisher_domains[]` (the compact managed-network form), or under `collections[].publisher_domain`.
-  2. **Property-level paths.** The agent entry references one or more top-level `properties[]` entries by ID (`property_ids`) or by tag (`property_tags`), and at least one resolved property carries a `publisher_domain` matching the source. This is the shape used in production by Mediavine and other managed networks where a property declares its `publisher_domain` once and many agents reference it indirectly.
+  2. **Property-level paths.** The agent entry references one or more top-level `properties[]` entries — either directly by ID/tag on the agent entry (`property_ids` / `property_tags` authorization_type), or indirectly via a `publisher_properties` selector whose predicate is satisfied by parent-file `properties[]` carrying matching `publisher_domain` (see [Resolution paths](#resolution-paths) below) — and at least one resolved property carries a `publisher_domain` matching the source. This is the shape used in production by Mediavine and other managed networks where a property declares its `publisher_domain` once and many agents reference it indirectly.
 
   What does **not** satisfy this rule: an `inline_properties` selector whose inline properties omit `publisher_domain`, or a top-level `property_tags` selector whose resolved top-level properties carry no matching `publisher_domain`. If no reachable `publisher_domain` field matches the source, fallback MUST fail closed.
 
@@ -493,12 +493,33 @@ Validators MUST reject any `publisher_properties[]` entry that includes both `pu
 
 The above is semantically identical to repeating the singular-form entry once per domain. Use it when every represented publisher tags inventory the same way (typical of WordPress/managed-network deployments); fall back to one entry per publisher only when the selector predicate genuinely differs.
 
-**Fan-out resolution semantics.** Each listed domain in `publisher_domains[]` is resolved **independently and in parallel** against that publisher's `adagents.json`:
+### Resolution paths
 
-- Resolution is **consumer-side**, not publish-side. The manager file MUST NOT inline copies of each represented publisher's properties; consumers (validators, buyer agents indexing the file) fetch each listed publisher's own `adagents.json` to resolve the selector predicate. The manager file is the authorization declaration; the per-publisher files are the property catalog.
+A `publisher_properties` selector resolves against properties in one of two ways. Federated is the default and the trust root; parent-file inline is a per-domain optimization a consumer MAY take when the parent file carries enough information to resolve the selector locally.
+
+**1. Federated resolution (default).** For each domain in `publisher_domain` or `publisher_domains[]`, fetch that publisher's `adagents.json` and apply the selector predicate against the publisher's own top-level `properties[]`. Each listed domain is resolved **independently and in parallel**:
+
 - If a listed publisher's `adagents.json` is unreachable (404, 5xx, timeout, fails its own validation), the selector resolves to the empty set **for that publisher only** — the entry remains valid for all other listed publishers. Consumers MUST NOT treat a single unreachable publisher as poisoning the rest of the compact entry.
 - If a listed publisher's `adagents.json` carries no properties matching the predicate (no entries with the named tag), the selector resolves to the empty set for that publisher. Same partial-resolution rule applies.
 - Resolution caching follows each publisher's own cache policy on their `adagents.json`, independently. A consumer SHOULD NOT extend or shorten one publisher's cache TTL based on observations of another publisher in the same compact entry.
+
+**2. Parent-file inline resolution (managed-network optimization).** A consumer MAY satisfy the selector from the parent file's own top-level `properties[]` when **all** of the following hold:
+
+- The parent file has top-level `properties[]` entries.
+- Every matched property carries an explicit `publisher_domain` field whose value equals one of the domains in the selector's `publisher_domain` / `publisher_domains[]` set.
+- For `selection_type: by_tag`: the property's `tags[]` contains at least one of the selector's `property_tags[]`.
+- For `selection_type: by_id`: the property's `property_id` is in the selector's `property_ids[]` AND the selector uses its singular `publisher_domain` form (the compact `publisher_domains[]` form remains rejected for `by_id` — property IDs are publisher-scoped and fanning a fixed ID set across publishers would silently authorize wrong inventory).
+- For `selection_type: all`: every parent-file `properties[]` entry with a matching `publisher_domain` is selected.
+
+Inline resolution is a **per-domain optimization**: a consumer MAY use inline resolution for the listed domains that have matching inline properties in the parent file, AND federated resolution for the remainder. Both paths SHOULD produce the same `(publisher_domain, property_id)` set when both are available.
+
+**Why this is safe.** The trust anchor for property authorization is the publisher whose domain is named on the property. By requiring `publisher_domain` on each inline property and matching against the selector's `publisher_domains[]`, the inline path preserves the invariant that the publisher whose inventory is being authorized is explicitly named — the same invariant the [`managerdomain` fallback safety rule](#safety-rules-for-this-fallback) protects. A manager file cannot use inline resolution to authorize inventory for a publisher it doesn't list.
+
+**Divergence rule.** If a consumer resolves the same `(publisher_domain, property_id)` via both inline and federated paths and the results disagree, the federated result is authoritative. Consumers SHOULD log the divergence as a publisher-side data-integrity warning and MAY surface it to operators. Consumers that prefer strict federation MAY ignore the inline path entirely.
+
+**Revocation under inline resolution.** Inline resolution MUST honor `revoked_publisher_domains[]` on the parent file. A `publisher_domain` listed as revoked at the parent level resolves to the empty set for that domain, regardless of whether matching properties exist in the parent's `properties[]`. Consumers that also resolve federated SHOULD cross-check the child's own `revoked_publisher_domains[]`; first match (parent or child) revokes.
+
+**When to use which.** Inline resolution exists because strict federation at managed-network scale (thousands of represented publishers under one operator) requires N HTTP fetches per authorization check, which no production consumer can sustain. Files that inline `properties[]` with `publisher_domain` anchors are signalling "you can resolve this here." Consumers handling small federated entries (a handful of publishers, each with their own properly-populated `adagents.json`) should prefer the federated path; it carries less consumer-side trust assumption. Consumers indexing managed-network parent files at scale should prefer the inline path; the parent file is structurally the property catalog whether the spec endorses it or not, and inline resolution makes that explicit.
 
 ## Authorization Qualifiers
 

--- a/static/schemas/source/core/publisher-property-selector.json
+++ b/static/schemas/source/core/publisher-property-selector.json
@@ -9,7 +9,7 @@
   "oneOf": [
     {
       "type": "object",
-      "description": "Select all properties from one publisher domain, or from each publisher domain when `publisher_domains` is used.",
+      "description": "Select all properties from one publisher domain, or from each publisher domain when `publisher_domains` is used. Consumers MAY satisfy the selector from the parent file's top-level `properties[]` when those properties carry a `publisher_domain` matching one of the listed domains (see Resolution paths in the spec).",
       "properties": {
         "publisher_domain": {
           "type": "string",
@@ -76,7 +76,7 @@
     },
     {
       "type": "object",
-      "description": "Select properties by tag membership. With `publisher_domains`, the same `property_tags` predicate is resolved against each listed publisher's adagents.json — the common managed-network case where every represented site tags inventory with a shared label.",
+      "description": "Select properties by tag membership. With `publisher_domains`, the same `property_tags` predicate is resolved against each listed publisher's adagents.json — the common managed-network case where every represented site tags inventory with a shared label. Consumers MAY also satisfy the predicate from the parent file's top-level `properties[]` when those properties carry a `publisher_domain` matching one of the selector's `publisher_domains[]` (see Resolution paths in the spec).",
       "properties": {
         "publisher_domain": {
           "type": "string",
@@ -100,7 +100,7 @@
         },
         "property_tags": {
           "type": "array",
-          "description": "Property tags resolved against each addressed publisher's adagents.json. Selector covers all properties carrying any of these tags.",
+          "description": "Property tags resolved against each addressed publisher's adagents.json, OR against the parent file's top-level `properties[]` when those properties carry a `publisher_domain` matching the selector. Selector covers all properties carrying any of these tags.",
           "items": {
             "$ref": "/schemas/core/property-tag.json"
           },


### PR DESCRIPTION
## Summary

- Replaces the "manager file MUST NOT inline copies of each represented publisher's properties" rule at `adagents.mdx:498` with a **two-path resolution rule** for `publisher_properties` selectors. Federated remains the default and trust root; parent-file inline becomes a recognized per-domain optimization.
- Adds the divergence rule (federated wins) and revocation rule (parent + child `revoked_publisher_domains[]`, first match revokes).
- Tightens the reachability invariant at `:244` to cover `publisher_properties` selectors satisfied via parent-file inline.
- Selector schema descriptions updated; no structural schema change — existing files validate unchanged.

## Why

The production reference for the managed-network pattern ([cafemedia.com](https://cafemedia.com/.well-known/adagents.json), ~6,800 represented domains, 2.6 MB authoritative file with 6,843 inline `properties[]`) inlines properties. Strict federation requires N HTTP fetches per authorization check, infeasible at managed-network scale. The prior wording mandated a resolution path no production consumer can take — either the spec endorses the shape, or every conformant consumer reports cafemedia as broken.

The trust anchor moves from "per-publisher `adagents.json` fetch named this property" to "per-property `publisher_domain` field named this publisher." Both are publisher-naming; both refuse silent cross-publisher authorization. The inline path preserves the invariant the [`managerdomain` fallback safety rule](https://adcontextprotocol.org/docs/governance/property/adagents#safety-rules-for-this-fallback) protects.

## WG questions answered (from issue triage)

1. **Is the MUST NOT's rationale (bilateral verifiability) still load-bearing?** The safety invariant is preserved by Option A's gating: each inline property MUST carry an explicit `publisher_domain` matching one in the selector's `publisher_domains[]`. This is the same anchor the [managed-network-scale changeset](https://github.com/adcontextprotocol/adcp/blob/main/.changeset/adagents-managed-network-scale.md) already accepted for `property_ids` / `property_tags` selectors on the agent entry — this change extends it to `publisher_properties` selectors.
2. **Which file wins on divergence?** Federated. Spec text: "If a consumer resolves the same `(publisher_domain, property_id)` via both inline and federated paths and the results disagree, the federated result is authoritative."
3. **Does revocation work under inline?** Yes — inline path MUST honor parent file's `revoked_publisher_domains[]`. Consumers that also resolve federated SHOULD cross-check the child's own; first match revokes.

## Companion / dependent work

- **#4823** (AAO directory inverse-lookup endpoint) is a hard consumer of this rule — the directory's `properties_total` per publisher cannot be computed on managed-network-shape files without this resolution path settled.
- `adcp-client-python` `_resolve_agent_properties` (gap at `adcp/adagents.py:909-959`) needs to learn the inline path and the `publisher_domains[]` fan-out fix (orthogonal SDK bug — lands separately).

Resolves #4825.

## Test plan

- [x] `npm run build:schemas` clean
- [x] precommit (`vitest run`, typecheck, dynamic-imports) passes
- [ ] Reviewer cross-check: re-read `adagents.mdx:244` (tightened reachability invariant) against `adagents.mdx` Resolution paths section — they MUST align on which paths satisfy explicit-publisher-scoping
- [ ] Reviewer cross-check: re-read divergence rule against `adagents-manager.ts`'s actual resolution behavior — ensure normative text doesn't contradict shipping code

🤖 Generated with [Claude Code](https://claude.com/claude-code)