### PR TITLE
spec(3.1.0-beta.2): unblock webhook token round-trip and required_any_of_tools

### DIFF
--- a/.changeset/4339-4325-webhook-token-required-any-of-tools.md
+++ b/.changeset/4339-4325-webhook-token-required-any-of-tools.md
@@ -1,0 +1,29 @@
+---
+"adcontextprotocol": minor
+---
+
+spec: webhook token round-trip + storyboard `required_any_of_tools` (closes #4339, #4325)
+
+Two additive 3.1.0-beta.2 blockers bundled. Both are non-breaking — existing senders and receivers continue to interoperate.
+
+**#4339 — webhook authentication `token` round-trip (`static/schemas/source/core/`)**
+
+- `mcp-webhook-payload.json` — promote the echoed authentication `token` to a typed optional property (`minLength: 16`, `maxLength: 4096`). The field previously traveled on the wire under `additionalProperties: true`; this is purely a typed surface on an existing implicit contract. Schema-driven SDK clients can now access `payload.token` without falling through an extras path. Receivers that configured a token MUST compare it to this value to validate request authenticity, and SHOULD use a constant-time equality check to mitigate timing attacks. The length-check fast-path is forbidden — receivers MAY range-check token length only after subscription lookup and never as a short-circuit on equal-length inputs.
+- `push-notification-config.json` — add `maxLength: 4096` to the existing `token` field (was previously only `minLength: 16`); this is a constraint addition on the upper bound, not a tightening of the lower bound that would reject existing-conformant configs. Cross-reference the payload-side validation obligation. Add downgrade-defense sentence: receivers that registered both an RFC 9421 signing key and a `token` MUST NOT treat a valid token echo as authorization to skip signature verification. Clarify that `token` is NOT on the 4.0 removal track (only the legacy `authentication` block is being removed in favor of RFC 9421).
+
+**#4325 — storyboard `required_any_of_tools` declarative one-of-N gate (`static/compliance/source/universal/`)**
+
+- `storyboard-schema.yaml` — add `required_any_of_tools` as a top-level optional storyboard field. Each entry is an OR-family `{ tools: string[] (minItems: 2), rationale?: string }`. Multiple entries AND-combine. Distinct from `required_tools` (lenient any-of coverage skip) and `provides_state_for` (step-scope state substitution).
+- `runner-output-contract.yaml` — extend `requirement_unmet` with the canonical `detail` sub-reason prefix `missing_required_tool_family:` plus the literal wire shape for separators (`" or "` between family members, `"; "` between multi-gate aggregations). No new top-level `skip_result.reason` enum value — the contract version stays at 2.2.0. Aggregator guidance is human-display only; automated consumers SHOULD parse only the first sub-reason from aggregated `detail` and surface multi-gate state separately.
+- `scripts/build-compliance.cjs` — validate the field on specialism `index.yaml` files (filter+trim `tools[]` before `minItems:2` enforcement; reject non-string `rationale`; drop empty `rationale` after trim) and hoist into `compliance/<version>/index.json` for downstream SDK consumption.
+
+**Downstream pickups (tracked separately):**
+
+- `adcontextprotocol/adcp-client-python#638` — drops the `extra='allow'` token round-trip path once types regenerate against this schema.
+- `adcontextprotocol/adcp-client#1481` — drops `examples/hello_si_adapter_brand.ts` top-level `offering_id` mirror once the 3.1.0-beta.2 dist publishes (the SI capture-path fix shipped in #3937 / dist 3.1.0-beta.1).
+- `adcontextprotocol/adcp-client#1642` — migrates the runner-level account-discovery conformance gate (#1624) to per-storyboard `required_any_of_tools` consumption.
+
+**Known follow-ups (filed as issues, non-blocking on this beta):**
+
+- `minLength: 16` on both `token` fields permits ~96-bit base64url credentials, below the 128-bit entropy SHOULD in the description. Raising the floor to 22 would tighten an existing field; the gap is intentional for backward compatibility and re-evaluated in 4.0.
+- `docs/building/by-layer/L3/webhooks.mdx` token-echo subsection and `whats-new-in-3-1.mdx` / `migration/prerelease-upgrades.mdx` entries are pending. Schema descriptions carry normative weight; the docs page catches up in a follow-up PR.

--- a/scripts/build-compliance.cjs
+++ b/scripts/build-compliance.cjs
@@ -95,20 +95,30 @@ function readYamlFrontmatter(filePath) {
           `required_any_of_tools[${i}] in ${filePath} must be an object with a 'tools' list`
         );
       }
-      const tools = entry.tools;
-      if (!Array.isArray(tools) || tools.length < 2) {
+      if (!Array.isArray(entry.tools)) {
         throw new Error(
-          `required_any_of_tools[${i}].tools in ${filePath} must be a list of at least 2 tool names ` +
-          `(single-tool families collapse to required_tools)`
+          `required_any_of_tools[${i}].tools in ${filePath} must be a YAML list`
         );
       }
-      const out_entry = {
-        tools: tools.map(t => String(t).trim()).filter(Boolean)
-      };
-      if (entry.rationale != null) {
-        out_entry.rationale = String(entry.rationale).trim();
+      const tools = entry.tools.map(t => String(t).trim()).filter(Boolean);
+      if (tools.length < 2) {
+        throw new Error(
+          `required_any_of_tools[${i}].tools in ${filePath} must contain at least 2 non-empty tool names ` +
+          `after trimming (single-tool families collapse to required_tools)`
+        );
       }
-      return out_entry;
+      const outEntry = { tools };
+      if (entry.rationale != null) {
+        if (typeof entry.rationale !== 'string') {
+          throw new Error(
+            `required_any_of_tools[${i}].rationale in ${filePath} must be a string, ` +
+            `got ${typeof entry.rationale}`
+          );
+        }
+        const rationale = entry.rationale.trim();
+        if (rationale) outEntry.rationale = rationale;
+      }
+      return outEntry;
     });
   }
   return out;

--- a/scripts/build-compliance.cjs
+++ b/scripts/build-compliance.cjs
@@ -83,6 +83,34 @@ function readYamlFrontmatter(filePath) {
     }
     out.required_tools = doc.required_tools.map(t => String(t).trim()).filter(Boolean);
   }
+  if (doc.required_any_of_tools != null) {
+    if (!Array.isArray(doc.required_any_of_tools) || doc.required_any_of_tools.length === 0) {
+      throw new Error(
+        `required_any_of_tools in ${filePath} must be a non-empty YAML list of OR-family objects`
+      );
+    }
+    out.required_any_of_tools = doc.required_any_of_tools.map((entry, i) => {
+      if (entry == null || typeof entry !== 'object' || Array.isArray(entry)) {
+        throw new Error(
+          `required_any_of_tools[${i}] in ${filePath} must be an object with a 'tools' list`
+        );
+      }
+      const tools = entry.tools;
+      if (!Array.isArray(tools) || tools.length < 2) {
+        throw new Error(
+          `required_any_of_tools[${i}].tools in ${filePath} must be a list of at least 2 tool names ` +
+          `(single-tool families collapse to required_tools)`
+        );
+      }
+      const out_entry = {
+        tools: tools.map(t => String(t).trim()).filter(Boolean)
+      };
+      if (entry.rationale != null) {
+        out_entry.rationale = String(entry.rationale).trim();
+      }
+      return out_entry;
+    });
+  }
   return out;
 }
 
@@ -126,6 +154,7 @@ function discoverSpecialisms(sourceDir) {
       title: fm.title || null,
       status,
       required_tools,
+      ...(fm.required_any_of_tools ? { required_any_of_tools: fm.required_any_of_tools } : {}),
       path: `specialisms/${entry.name}/`
     });
   }
@@ -397,6 +426,7 @@ function generateIndex(version, sourceDir) {
       title: s.title,
       status: s.status,
       required_tools: s.required_tools,
+      ...(s.required_any_of_tools ? { required_any_of_tools: s.required_any_of_tools } : {}),
       path: s.path
     }))
   };

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -773,24 +773,50 @@ skip_result:
                                      detail names the unmet requirement value
                                      directly, e.g. "controller",
                                      "seeded_state", or an unrecognized
-                                     forward-compat value.
+                                     forward-compat value. This legacy form
+                                     is BARE — no `requires:` prefix is
+                                     synthesized — and remains the canonical
+                                     wire shape for single-gate `requires:`
+                                     failures.
 
         required_any_of_tools:     — tool-family advertisement gates
                                      (see storyboard-schema.yaml >
                                      `required_any_of_tools`). detail
                                      carries the canonical sub-reason prefix
                                      "missing_required_tool_family:" followed
-                                     by the unsatisfied family and optional
-                                     rationale, e.g.
-                                     "missing_required_tool_family: needs
-                                     list_accounts or sync_accounts (AdCP
-                                     3.0.9 §accounts/overview)".
+                                     by " needs <tool_a> or <tool_b>[ or
+                                     <tool_c>...]" and, when a rationale was
+                                     declared, a trailing " (<rationale>)"
+                                     parenthetical. Canonical single-line
+                                     example:
+                                     `missing_required_tool_family: needs list_accounts or sync_accounts (AdCP 3.0.9 §accounts/overview)`
 
-      The sub-reason prefix is the canonical attribution string — dashboards
-      and skip-cause aggregators MUST switch on the prefix to separate
-      tool-family gates from `requires:` gates when summarizing. Runners
-      that aggregate multiple unmet gates in a single detail string SHOULD
-      preserve each sub-reason's prefix so the aggregator survives.
+      Family-list separator. When a family contains more than two tools,
+      runners MUST join names with the literal three-character " or "
+      separator (no Oxford comma; no list-style punctuation). Dashboards
+      that parse the family list MAY split on " or " safely. Tool names
+      are constrained by the spec's tool-name charset and do not contain
+      the literal " or " substring.
+
+      Wire-shape posture for aggregation. Runners SHOULD emit a single
+      sub-reason in `detail` even when multiple gates are unmet —
+      surfacing the first-evaluated gate is the canonical wire shape and
+      keeps `detail` programmatically parseable. When a runner aggregates
+      multiple unmet gates into one `detail` string for human display,
+      it MUST use "; " (semicolon + space) as the sub-reason separator
+      and MUST preserve each sub-reason's standalone form (the bare
+      `requires:` legacy value, or the prefixed `missing_required_tool_family:
+      …` shape). Example multi-gate aggregation:
+      `controller; missing_required_tool_family: needs list_accounts or sync_accounts (AdCP 3.0.9 §accounts/overview)`.
+      Automated consumers SHOULD parse only the first sub-reason from
+      aggregated `detail` (everything up to the first "; ") and surface
+      multi-gate state through a separate UI affordance rather than
+      treating `detail` as a structured list.
+
+      The sub-reason prefix is the canonical attribution string —
+      dashboards and skip-cause aggregators MUST switch on the prefix to
+      separate tool-family gates from `requires:` gates when summarizing
+      the first sub-reason.
 
       Distinct from missing_test_controller (which fires mid-run at a
       specific step when comply_test_controller is absent) — this reason

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -764,11 +764,33 @@ skip_result:
       offers an interchangeable tool that the storyboard accepts as an
       equivalent state contract.
     requirement_unmet: |
-      A storyboard-level runtime requirement declared in the storyboard's
-      `requires:` field (see storyboard-schema.yaml > `requires`) was not
-      satisfied at load time. detail MUST name the unmet requirement value
-      (e.g., "controller", "seeded_state") so dashboards can aggregate
-      skips by requirement type.
+      A storyboard-level load-time precondition was not satisfied. Two
+      storyboard-schema fields produce this reason, distinguished by the
+      `detail` sub-reason prefix so dashboards can aggregate independently:
+
+        requires:                  — runtime context gates
+                                     (see storyboard-schema.yaml > `requires`).
+                                     detail names the unmet requirement value
+                                     directly, e.g. "controller",
+                                     "seeded_state", or an unrecognized
+                                     forward-compat value.
+
+        required_any_of_tools:     — tool-family advertisement gates
+                                     (see storyboard-schema.yaml >
+                                     `required_any_of_tools`). detail
+                                     carries the canonical sub-reason prefix
+                                     "missing_required_tool_family:" followed
+                                     by the unsatisfied family and optional
+                                     rationale, e.g.
+                                     "missing_required_tool_family: needs
+                                     list_accounts or sync_accounts (AdCP
+                                     3.0.9 §accounts/overview)".
+
+      The sub-reason prefix is the canonical attribution string — dashboards
+      and skip-cause aggregators MUST switch on the prefix to separate
+      tool-family gates from `requires:` gates when summarizing. Runners
+      that aggregate multiple unmet gates in a single detail string SHOULD
+      preserve each sub-reason's prefix so the aggregator survives.
 
       Distinct from missing_test_controller (which fires mid-run at a
       specific step when comply_test_controller is absent) — this reason
@@ -776,6 +798,11 @@ skip_result:
       executes. When `requires: [controller]` is set, the runner MUST
       emit this reason at storyboard scope, not missing_test_controller
       at step scope.
+
+      Distinct from missing_tool (which fires at step scope when a tool
+      declared in the storyboard's `required_tools` is absent — a coverage
+      skip). `required_any_of_tools` is a load-time gate on tool
+      advertisement, not a per-step coverage signal.
 
       Forward compatibility: runners that encounter a `requires` value
       they do not recognize MUST emit this reason with the unrecognized

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -49,6 +49,13 @@
 #   core | products | media_buy | creative | reporting | governance |
 #   campaign_governance | signals | si | audiences | error_handling | brand | security)
 # required_tools: string[] (optional — tool names the storyboard uses; empty for protocol-level tests)
+# required_any_of_tools: array of OR-family objects (optional — declarative one-of-N
+#   tool-advertisement gate. Each entry is { tools: string[], rationale?: string };
+#   at least one tool in each family MUST be advertised by the agent under test.
+#   Multiple entries are AND-combined: every family must be satisfied independently.
+#   Distinct from `required_tools` (which is the lenient any-of for storyboard
+#   applicability — missing all listed tools triggers a coverage-gap skip).
+#   See the dedicated `required_any_of_tools` block below for full semantics.
 # narrative: string (paragraph explaining the overall flow)
 #
 # requires_scenarios: string[] (optional — scenario IDs from storyboards/scenarios/ that must pass alongside this storyboard.
@@ -219,6 +226,71 @@
 #   requires gates the whole storyboard at load time; requires_tool gates
 #   individual steps at execution time. Both may be declared on the same
 #   storyboard.)
+#
+# required_any_of_tools: array (optional — declarative one-of-N tool-advertisement
+#   gate at storyboard load time. Each array entry is an OR-family object:
+#
+#     required_any_of_tools:
+#       - tools: [list_accounts, sync_accounts]
+#         rationale: "AdCP 3.0.9 §accounts/overview"
+#
+#   Per-entry object shape:
+#     tools: string[] — tool names; at least one MUST be advertised by the agent
+#                       under test. minItems: 2 (a single-tool family collapses
+#                       to `required_tools`; encode it there instead).
+#     rationale: string (optional) — human-readable spec citation surfaced in
+#                       skip messages so dashboards can attribute the gate to
+#                       the underlying normative requirement.
+#
+#   Multiple entries are AND-combined: every family in the array MUST be
+#   satisfied independently. Empty array is fail-load — omit the field entirely
+#   for "no requirement" (same posture as `requires`).
+#
+#   Distinct from `required_tools`. `required_tools` is the lenient any-of for
+#   storyboard applicability — missing all listed tools triggers a coverage-gap
+#   skip. `required_any_of_tools` is the strict variant: missing the family is
+#   still a skip (not a fail-load — see "Runner behavior" below), but with
+#   distinct `detail` attribution so the skip aggregates against the spec rule
+#   rather than the storyboard scope. The two compose cleanly on the same
+#   storyboard.
+#
+#   Runner behavior. When an agent advertises NONE of the tools in any family,
+#   the runner MUST emit at storyboard scope:
+#
+#     skip_result.reason  = requirement_unmet
+#     skip_result.detail  = "missing_required_tool_family: needs <tool_a> or
+#                            <tool_b>[ or <tool_c>...] (<rationale>)"
+#
+#   The `missing_required_tool_family:` sub-reason prefix in `detail` is the
+#   canonical attribution string (see runner-output-contract.yaml >
+#   `requirement_unmet` for the full enumeration of recognized detail
+#   sub-reasons). This matches the same `requirement_unmet`-with-detail pattern
+#   already used for `requires:` gates — no new top-level reason enum is added
+#   to `runner-output-contract.yaml`, so this field ships without bumping the
+#   contract version.
+#
+#   Per-family OR semantics. A family is satisfied as soon as the agent
+#   advertises ANY tool in `tools[]`. The runner MUST NOT additionally require
+#   that the named tools are exercised by storyboard steps — this field gates
+#   on tool *advertisement*, not on step execution. Per-step gating remains
+#   the job of `requires_tool` on individual steps.
+#
+#   Forward compatibility. Runners encountering this field on a storyboard
+#   they otherwise support MUST honor it. Runners that pre-date this field
+#   will load and execute the storyboard as if the field were absent; this
+#   is acceptable because the universal account-discovery rule (the first
+#   use case) is also enforced by the SDK's runner-level conformance gate,
+#   which fires independently of per-storyboard tagging. Future runners that
+#   migrate to per-storyboard attribution (see adcp-client#1642) consume this
+#   field for richer skip-cause aggregation.
+#
+#   Composition with other gates. `required_any_of_tools` is evaluated at
+#   load time alongside `requires`. Either gate failing produces
+#   skip_result.reason: requirement_unmet at storyboard scope; the runner
+#   MAY emit a single skip carrying detail for the first failing gate it
+#   evaluates, or aggregate multiple unmet reasons in detail — implementations
+#   SHOULD prefer aggregation when more than one gate fails, so operators see
+#   the full set of unmet preconditions on one screen.)
 #
 # agent:
 #   interaction_model: enum (stateless_transform | stateful_preloaded | stateful_push | stateless_generate | media_buy_seller | marketplace_catalog | owned_signals | si_platform | brand_rights_holder | governance_agent)

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -48,7 +48,10 @@
 # track: enum (optional — compliance track this storyboard contributes to:
 #   core | products | media_buy | creative | reporting | governance |
 #   campaign_governance | signals | si | audiences | error_handling | brand | security)
-# required_tools: string[] (optional — tool names the storyboard uses; empty for protocol-level tests)
+# required_tools: string[] (optional — tool names the storyboard uses; empty for protocol-level tests.
+#   Lenient any-of: missing all listed tools triggers a coverage-gap skip
+#   (skip_result.reason: missing_tool at step scope). See `required_any_of_tools`
+#   below for the strict per-family load-time gate that grades requirement_unmet.)
 # required_any_of_tools: array of OR-family objects (optional — declarative one-of-N
 #   tool-advertisement gate. Each entry is { tools: string[], rationale?: string };
 #   at least one tool in each family MUST be advertised by the agent under test.
@@ -240,7 +243,13 @@
 #                       to `required_tools`; encode it there instead).
 #     rationale: string (optional) — human-readable spec citation surfaced in
 #                       skip messages so dashboards can attribute the gate to
-#                       the underlying normative requirement.
+#                       the underlying normative requirement. Storyboard-author-
+#                       controlled string; runners that render this value into
+#                       LLM-facing surfaces MUST fence per
+#                       runner-output-contract.yaml > rendered_output_fencing
+#                       (the value flows into skip_result.detail, which is
+#                       already on the fenced list — this is defense-in-depth
+#                       for renderers that consume rationale directly).
 #
 #   Multiple entries are AND-combined: every family in the array MUST be
 #   satisfied independently. Empty array is fail-load — omit the field entirely
@@ -254,17 +263,25 @@
 #   rather than the storyboard scope. The two compose cleanly on the same
 #   storyboard.
 #
+#   Distinct from `provides_state_for`. `provides_state_for` is a per-step
+#   substitution mechanism that waives a downstream cascade when a peer step
+#   establishes equivalent state at runtime. `required_any_of_tools` is a
+#   storyboard-load-time gate on tool *advertisement* — it fires before any
+#   step executes and does not interact with step-level substitution. The two
+#   operate on different axes (storyboard scope vs step scope; advertisement-
+#   time vs run-time) and may coexist on the same storyboard.
+#
 #   Runner behavior. When an agent advertises NONE of the tools in any family,
 #   the runner MUST emit at storyboard scope:
 #
 #     skip_result.reason  = requirement_unmet
-#     skip_result.detail  = "missing_required_tool_family: needs <tool_a> or
-#                            <tool_b>[ or <tool_c>...] (<rationale>)"
+#     skip_result.detail  = "missing_required_tool_family: needs <tool_a> or <tool_b>[ or <tool_c>...] (<rationale>)"
 #
 #   The `missing_required_tool_family:` sub-reason prefix in `detail` is the
 #   canonical attribution string (see runner-output-contract.yaml >
 #   `requirement_unmet` for the full enumeration of recognized detail
-#   sub-reasons). This matches the same `requirement_unmet`-with-detail pattern
+#   sub-reasons and the canonical wire shape for separators when more than one
+#   gate fails). This matches the same `requirement_unmet`-with-detail pattern
 #   already used for `requires:` gates — no new top-level reason enum is added
 #   to `runner-output-contract.yaml`, so this field ships without bumping the
 #   contract version.
@@ -286,11 +303,14 @@
 #
 #   Composition with other gates. `required_any_of_tools` is evaluated at
 #   load time alongside `requires`. Either gate failing produces
-#   skip_result.reason: requirement_unmet at storyboard scope; the runner
-#   MAY emit a single skip carrying detail for the first failing gate it
-#   evaluates, or aggregate multiple unmet reasons in detail — implementations
-#   SHOULD prefer aggregation when more than one gate fails, so operators see
-#   the full set of unmet preconditions on one screen.)
+#   skip_result.reason: requirement_unmet at storyboard scope. Runners SHOULD
+#   emit a single sub-reason in `detail` when only one gate is unmet. When
+#   multiple gates fail, runners MAY aggregate sub-reasons per the wire shape
+#   pinned in runner-output-contract.yaml > `requirement_unmet`; aggregated
+#   `detail` strings are intended for human display and SHOULD NOT be
+#   parsed beyond the first sub-reason by automated consumers. Dashboards
+#   that need exhaustive multi-gate attribution SHOULD surface a multi-gate
+#   indicator separately rather than splitting `detail` themselves.)
 #
 # agent:
 #   interaction_model: enum (stateless_transform | stateful_preloaded | stateful_push | stateless_generate | media_buy_seller | marketplace_catalog | owned_signals | si_platform | brand_rights_holder | governance_agent)

--- a/static/schemas/source/core/mcp-webhook-payload.json
+++ b/static/schemas/source/core/mcp-webhook-payload.json
@@ -53,6 +53,12 @@
       "type": "string",
       "description": "Session/conversation identifier. Use this to continue the conversation if input-required status needs clarification or additional parameters."
     },
+    "token": {
+      "type": "string",
+      "description": "Authentication token echoed verbatim from `PushNotificationConfig.token`. Receivers that configured a token MUST compare it to this value to validate request authenticity, and SHOULD use a constant-time equality check to mitigate timing attacks. Absent when no token was configured at registration. Length bounds mirror the config-side field — receivers MAY reject payloads whose token length falls outside the configured range as a defensive check, but MUST NOT treat absence as an authenticity failure when no token was configured.",
+      "minLength": 16,
+      "maxLength": 4096
+    },
     "result": {
       "$ref": "/schemas/core/async-response-data.json",
       "description": "Task-specific payload matching the status. For completed/failed, contains the full task response. For working/input-required/submitted, contains status-specific data. This is the data layer that AdCP specs - same structure used in A2A status.message.parts[].data."

--- a/static/schemas/source/core/mcp-webhook-payload.json
+++ b/static/schemas/source/core/mcp-webhook-payload.json
@@ -55,7 +55,7 @@
     },
     "token": {
       "type": "string",
-      "description": "Authentication token echoed verbatim from `PushNotificationConfig.token`. Receivers that configured a token MUST compare it to this value to validate request authenticity, and SHOULD use a constant-time equality check to mitigate timing attacks. Absent when no token was configured at registration. Length bounds mirror the config-side field — receivers MAY reject payloads whose token length falls outside the configured range as a defensive check, but MUST NOT treat absence as an authenticity failure when no token was configured.",
+      "description": "Authentication token echoed verbatim from [`PushNotificationConfig.token`](/schemas/core/push-notification-config.json). Receivers that configured a token MUST compare it to this value to validate request authenticity, and SHOULD use a constant-time equality check to mitigate timing attacks. Absent when no token was configured at registration. Length bounds mirror the config-side field — receivers MAY reject payloads whose token length falls outside the configured range as a defensive check, provided the length check is performed only after the configured token is known to exist for this subscription, and the length comparison is not used as a fast-path to short-circuit the constant-time compare on equal-length inputs. Receivers MUST NOT treat absence as an authenticity failure when no token was configured.",
       "minLength": 16,
       "maxLength": 4096
     },

--- a/static/schemas/source/core/push-notification-config.json
+++ b/static/schemas/source/core/push-notification-config.json
@@ -19,7 +19,7 @@
     },
     "token": {
       "type": "string",
-      "description": "Optional client-provided token for webhook validation. The seller MUST echo this value verbatim in every webhook payload's `token` field (see [`mcp-webhook-payload.json`](/schemas/core/mcp-webhook-payload.json) for the receiver-side validation obligation). Length bounds give receivers a defensive range check on the echoed value; senders SHOULD generate tokens with at least 128 bits of entropy. This is a complementary authenticity mechanism that can layer on top of the RFC 9421 webhook signature — unlike the `authentication` block below, it is not on the 4.0 removal track.",
+      "description": "Optional client-provided token for webhook validation. The seller MUST echo this value verbatim in every webhook payload's `token` field (see [`mcp-webhook-payload.json`](/schemas/core/mcp-webhook-payload.json) for the receiver-side validation obligation). Length bounds give receivers a defensive range check on the echoed value; senders SHOULD generate tokens with at least 128 bits of entropy (≥22 base64url characters). This is a complementary authenticity mechanism that can layer on top of the RFC 9421 webhook signature — unlike the `authentication` block below, it is not on the 4.0 removal track. Receivers that registered both a signing key (RFC 9421) and a `token` MUST NOT treat a valid token echo as authorization to skip signature verification; both checks remain independent obligations.",
       "minLength": 16,
       "maxLength": 4096
     },

--- a/static/schemas/source/core/push-notification-config.json
+++ b/static/schemas/source/core/push-notification-config.json
@@ -19,8 +19,9 @@
     },
     "token": {
       "type": "string",
-      "description": "Optional client-provided token for webhook validation. Echoed back in webhook payload to validate request authenticity.",
-      "minLength": 16
+      "description": "Optional client-provided token for webhook validation. The seller MUST echo this value verbatim in every webhook payload's `token` field (see [`mcp-webhook-payload.json`](/schemas/core/mcp-webhook-payload.json) for the receiver-side validation obligation). Length bounds give receivers a defensive range check on the echoed value; senders SHOULD generate tokens with at least 128 bits of entropy. This is a complementary authenticity mechanism that can layer on top of the RFC 9421 webhook signature — unlike the `authentication` block below, it is not on the 4.0 removal track.",
+      "minLength": 16,
+      "maxLength": 4096
     },
     "authentication": {
       "type": "object",


### PR DESCRIPTION
## Summary

Two upstream spec changes that unblock the next 3.1.0-beta release:

- **Closes #4339** — promote echoed authentication `token` to a typed property on `mcp-webhook-payload.json`.
- **Closes #4325** — add `required_any_of_tools` declarative one-of-N tool-advertisement gate to the storyboard schema.

The third blocker called out in the same release scrub (#3981) was already fixed upstream in #3937 and is included in `dist/compliance/3.1.0-beta.1/`. Closed separately with a pointer comment.

## #4339 — webhook token, design decisions made

- **Q1 (receiver obligation):** `MUST` validate, `SHOULD` use constant-time. The MUST is scoped to "receivers that configured a token" — pass-through forwarders that didn't configure one aren't bound. Constant-time is `SHOULD` because HSM-backed and secure-enclave comparisons are equivalent without literally being string-compare; mandating the algorithm overspecifies.
- **Q2 (4.0 deprecation):** `token` is **not** on the same removal track as the `authentication` block. The block is a deprecated signing-scheme selector (Bearer / HMAC-SHA256) being replaced by RFC 9421. `token` is a complementary echo-back authenticity check that layers on top of 9421 and survives past 4.0. No deprecation marker added.
- Corrections applied: `minLength: 1 → 16` (mirrors config-side), description path `authentication.token → token`, payload-side `maxLength: 4096`, matching `maxLength: 4096` added to the config-side `token` for symmetry.

## #4325 — `required_any_of_tools`, Option A

Per the May 10 triage, both protocol experts leaned Option A (re-use `requirement_unmet` with a `detail` sub-reason) over Option B (new top-level reason enum requiring a runner-output-contract bump). This PR ships Option A:

- `storyboard-schema.yaml` — new top-level field, with per-entry shape `{ tools: string[] (minItems: 2), rationale?: string }`. Empty array is fail-load.
- `runner-output-contract.yaml` — `requirement_unmet` now documents two detail sub-reasons (`requires:`-derived gate values and `missing_required_tool_family:`-prefixed tool-family gates) with explicit aggregator guidance for multi-gate failures.
- `build-compliance.cjs` — parse + validation branch so the field is accepted on specialism index.yaml files and hoisted into `compliance/<version>/index.json` for downstream SDKs that want attribution at specialism scope.

No storyboards are tagged in this PR. Tagging is opt-in — downstream SDK migration in adcontextprotocol/adcp-client#1642 will audit and tag.

## What this does NOT change

- No new top-level `skip_result.reason` enum value (preserves the existing runner-output-contract version).
- No deprecation marker on `push-notification-config.token` (see Q2 above).
- No storyboard YAML files re-tagged — schema lands first, SDK migration consumes it.

## Test plan

- [x] `npm run build:schemas` — clean
- [x] `npm run build:compliance` — all storyboard lints green, 25 universal + 6 protocols + 20 specialisms built
- [x] `npm run test:schemas` — 577 schemas validated
- [x] `npm run test:json-schema` — 270 typed JSON blocks validated
- [x] `npm run test:examples` — 36 example tests passed
- [x] `npm run test:composed` — 43 composed schema tests passed
- [x] `npm run test:storyboard-doc-parity` — 10 / 10
- [x] Precommit hook (test:unit + test:test-dynamic-imports + test:callapi-state-change + typecheck) passed at commit time

## Downstream pickups

- adcontextprotocol/adcp-client-python#638 — drops `extra='allow'` token round-trip once this lands and types regenerate
- adcontextprotocol/adcp-client#1481 (partial) — drops `examples/hello_si_adapter_brand.ts` top-level `offering_id` mirror once the 3.1.0-beta.2 dist publishes (#3981 leg)
- adcontextprotocol/adcp-client#1642 — migrates runner-level account-discovery gate from #1624 to per-storyboard `required_any_of_tools` consumption

🤖 Generated with [Claude Code](https://claude.com/claude-code)