### PR TITLE
docs(compliance): backport MCP transport note to v3_envelope_integrity storyboard

### DIFF
--- a/.changeset/4832-v3-envelope-integrity-mcp-transport-note.md
+++ b/.changeset/4832-v3-envelope-integrity-mcp-transport-note.md
@@ -1,0 +1,19 @@
+---
+"adcontextprotocol": patch
+---
+
+Backport MCP transport clarification to `v3_envelope_integrity` storyboard (3.0.x).
+
+Adds the MCP-specific note (already present on main) explaining that `status` must
+appear at the top level of `structuredContent` and is distinct from the
+task-body schema (`get-adcp-capabilities-response.json`). Addresses the
+confusion reported in #4832: `response_schema` passes because the task schema
+intentionally omits protocol envelope fields; `envelope_field_present` for
+`status` is the separate, correct enforcement layer. Also updates the `expected`
+block header from "Response envelope:" to "Response envelope (all transports):"
+to match main-branch wording.
+
+The `field_absent` TODO comments for `task_status`/`response_status` are unchanged —
+those await `field_absent` runner support in adcp-client (tracked separately).
+The SDK gap (SDK 7.7.0 not emitting `status` on `get_adcp_capabilities`) is a
+sibling-repo concern also tracked separately.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adcontextprotocol",
-  "version": "3.0.0",
+  "version": "3.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adcontextprotocol",
-      "version": "3.0.0",
+      "version": "3.0.12",
       "dependencies": {
         "@adcp/client": "5.21.1",
         "@anthropic-ai/sdk": "^0.91.1",

--- a/static/compliance/source/universal/v3-envelope-integrity.yaml
+++ b/static/compliance/source/universal/v3-envelope-integrity.yaml
@@ -62,6 +62,18 @@ phases:
           The protocol-envelope.json schema's top-level `not: { anyOf: [...] }`
           constraint forbids either field, making this constraint detectable by
           any schema-aware validator without runner-specific primitives.
+
+          MCP transport note: the `status` field must appear at the top level of
+          `structuredContent` (or the first parseable `content[].text` JSON object
+          for older MCP servers) — it is NOT a JSON-RPC result-level field. The extracted AdCP
+          response IS the protocol envelope: `status` lives alongside task-specific
+          payload fields in the same flat object. The `get-adcp-capabilities-response.json`
+          schema validates only the task-specific fields (capabilities, context echo,
+          etc.) and does not cover protocol envelope fields like `status` — an agent
+          whose MCP response passes response_schema validation but omits `status` is
+          still non-conformant. See docs/building/implementation/mcp-response-extraction
+          for the normative MCP extraction algorithm and the expected structuredContent
+          shape, including the required `status` field at the top level.
         task: get_adcp_capabilities
         schema_ref: "protocol/get-adcp-capabilities-request.json"
         response_schema_ref: "protocol/get-adcp-capabilities-response.json"
@@ -69,13 +81,20 @@ phases:
         comply_scenario: envelope_integrity
         stateful: false
         expected: |
-          Response envelope:
+          Response envelope (all transports):
           - MUST contain status (the v3 canonical field)
           - MUST NOT contain task_status (v2 legacy, no v3 semantics)
           - MUST NOT contain response_status (v2 legacy, no v3 semantics)
           Both forbidden fields are blocked by the top-level `not: { anyOf: [...] }`
           constraint in protocol-envelope.json, so any schema-aware validator that
           validates the full protocol envelope will detect violations.
+
+          For MCP agents specifically: `status` MUST be present at the top level of
+          structuredContent (or the first parseable content[].text JSON object). It is not a JSON-RPC sibling
+          field — it lives inside the content payload, at the same level as the
+          task-specific response fields. An agent returning only the task payload
+          without `status` fails this check regardless of whether the payload itself
+          validates against the task response schema.
 
         sample_request:
           context:


### PR DESCRIPTION
Closes #4832

Backports the MCP transport clarification note (already present on `main`) to the 3.0.x storyboard for `v3_envelope_integrity/no_legacy_status_fields`.

## What changed

**Step `narrative` (additive):** Added the MCP-specific paragraph explaining that `status` must appear at the root of `structuredContent` — it is not a JSON-RPC result-level field, and it is not declared in `get-adcp-capabilities-response.json` because that schema covers only task-body fields. An MCP agent whose response passes `response_schema` but omits `status` is still non-conformant.

**`expected` block (additive + minor header):** Extended with the MCP-specific note, and updated the header from "Response envelope:" to "Response envelope (all transports):" to match main-branch wording.

**No changes** to `validations`, check semantics, step ID, or the `field_absent` TODO block (which correctly notes those checks await runner support in adcp-client).

## Non-breaking justification

Pure documentary additions to `narrative` and `expected` fields. The `validations` array is unchanged; no new checks are active; step ID and storyboard ID are unchanged. The added text describes behavior that `protocol-envelope.json` already requires — no previously-conformant implementation is affected.

## What this does NOT fix (tracked separately)

- **SDK gap:** `@adcp/sdk@7.7.0` (`createAdcpServerFromPlatform` + `serve()`) does not emit `status` on `get_adcp_capabilities` responses. This is the root cause of the reporter's `envelope_field_present` failure and requires a fix in the adcp-client/adcp-go repos. **Sibling-repo-fix-needed: adcp-client — `serve()` must inject `status: "completed"` in the MCP `structuredContent` envelope for all synchronous tasks.**
- **`field_absent` checks:** The TODO block for `task_status`/`response_status` absence checks is unchanged. Those checks require `field_absent` runner support in adcp-client (not yet shipped on 3.0.x; available on the 3.1.x/main track via runner-output-contract.yaml v2.2.0).
- **Storyboard rename:** The step ID `no_legacy_status_fields` is intentionally dual-purpose (presence of canonical field + absence of legacy fields). A rename would break CLI users. No rename in this PR.

## Pre-PR review

- code-reviewer: approved — no blockers; minor nits (changeset filename, `expected` header) addressed
- ad-tech-protocol-expert: approved — non-breaking, consistent with `protocol-envelope.json` normative text; patch-eligible per compliance harness rules

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01R4RczMKmss3yAeUpwz5Fum

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4RczMKmss3yAeUpwz5Fum)_