### PR TITLE
feat(aao): implement GET /v1/agents/{agent_url}/publishers endpoint (#4836)

### DIFF
--- a/.changeset/4836-aao-directory-inverse-lookup-server.md
+++ b/.changeset/4836-aao-directory-inverse-lookup-server.md
@@ -1,0 +1,31 @@
+---
+---
+
+feat(aao): implement `GET /v1/agents/{agent_url}/publishers` directory inverse-lookup endpoint (#4836)
+
+Server implementation of the spec landed in #4828. Returns the publishers whose `adagents.json` authorizes a given `agent_url`, with provenance (`discovery_method`, `manager_domain`), per-publisher property counts (`properties_authorized`, `properties_total`), signing-key pin status, and lifecycle state.
+
+**What changes.**
+
+1. **New SQL method** (`server/src/db/federated-index-db.ts`). `getPublishersForAgentDetail(agentUrl, opts)` unions the legacy `agent_publisher_authorizations` arm and the catalog-side `v_effective_agent_authorizations` arm (same dual-read pattern as the existing `getDomainsForAgent`), joins to the `publishers` overlay for `discovery_method` / `manager_domain` / cached `adagents_json` JSONB, and derives the response shape entirely in SQL:
+   - `properties_total` / `properties_authorized`: correlated subqueries over `discovered_properties` and `agent_property_authorizations`, scoped to **this publisher only** (never network-wide — avoids the "12/12 vs 12-of-6800" misread that flat counts would produce on managed-network rows).
+   - `signing_keys_pinned`: walks `adagents_json->'authorized_agents'` for entries whose canonicalized `url` matches the requested agent, returns `true` iff `signing_keys[]` is a non-empty array.
+   - `status`: `revoked` when the parent file lists this `publisher_domain` in `revoked_publisher_domains[]`; otherwise `authorized`.
+
+2. **New endpoint** (`server/src/routes/registry-api.ts`). `GET /v1/agents/:encodedUrl/publishers` mounted next to the existing legacy `/registry/lookup/agent/:agentUrl/domains` (which is kept; the new path is the spec-compliant richer shape). Honors:
+   - `since=<iso8601>` — incremental sync filter against `publishers.last_validated`.
+   - `cursor=<opaque>` — base64url-encoded `publisher_domain` for stable ASC pagination.
+   - `status=authorized,revoked` — comma-separated filter; default `authorized` only.
+   - `limit=<1..1000>` — default 200. Caller-fetched `limit+1` enables next-page detection without a second round-trip.
+   - `If-None-Match` — returns `304` when the response fingerprint (cursor + filter + content hash) matches.
+   - `200` vs `404`: 404 only when **no filter is in effect AND** the directory has never indexed any publisher referencing this `agent_url`. Otherwise 200 with possibly-empty `publishers[]` — distinct semantics per the spec.
+
+3. **Federated-index wrapper** (`server/src/federated-index.ts`). Re-exports the DB method behind `getPublishersForAgentDetail` so the route doesn't reach into the DB layer directly.
+
+4. **Integration tests** (`server/tests/integration/registry-agent-publishers-detail.test.ts`). Covers: empty result, direct-discovery row with `signing_keys_pinned: true`, `ads_txt_managerdomain` with `manager_domain` populated, empty/missing `signing_keys` array, `status: revoked` from `revoked_publisher_domains[]`, agent-URL canonicalization on the JSONB side (mixed case + trailing slash), cursor pagination, `since` filter, and isolation from other agents' authorizations.
+
+**Out of scope (deferred).**
+
+- `adagents_authoritative` as a fourth `discovery_method` value — the spec schema allows it, but the crawler currently only emits the three values from migration 470 (`direct`, `authoritative_location`, `ads_txt_managerdomain`). Adding the fourth requires crawler changes to detect inline-resolution discovery via parent-file `properties[].publisher_domain` matching; tracked as follow-up under #4836 once cafemedia-shape parent files start indexing.
+- `?include=properties` for inline property detail — counts-only v1 per the spec.
+- Authentication. Public endpoint with anonymous rate limiting via `registryReadRateLimiter`.

--- a/docs/aao/directory-api.mdx
+++ b/docs/aao/directory-api.mdx
@@ -80,7 +80,7 @@ GET https://{aao_directory}/v1/agents/{agent_url}/publishers
 | Field | Required | Notes |
 |---|---|---|
 | `agent_url` | yes | Canonicalized echo of the lookup key. |
-| `directory_indexed_at` | yes | Most recent per-publisher refresh in the result set. Provenance for the consumer's own cache. |
+| `directory_indexed_at` | yes | Most recent per-publisher refresh in the result set. Provenance for the consumer's own cache. **NULL on empty pages** — there's no anchor to report; consumers SHOULD NOT advance cache freshness from a null value. |
 | `publishers` | yes | Array. Empty array is a valid response — the directory has indexed this agent but no current authorizations resolve. |
 | `next_cursor` | optional | Opaque pagination cursor; absent or null on the terminal page. |
 

--- a/server/src/db/federated-index-db.ts
+++ b/server/src/db/federated-index-db.ts
@@ -59,6 +59,25 @@ export interface AgentPublisherAuthorization {
 }
 
 /**
+ * Detailed agent → publisher row for the AAO directory inverse-lookup
+ * endpoint (adcp#4823). Layered on top of AgentPublisherAuthorization
+ * with provenance, per-publisher counts, and lifecycle status — all
+ * computed from the cached publishers.adagents_json blob.
+ */
+export interface AgentPublisherDetailRow {
+  publisher_domain: string;
+  source: 'adagents_json' | 'agent_claim';
+  authz_last_validated: Date | null;
+  publisher_last_validated: Date | null;
+  discovery_method: 'direct' | 'authoritative_location' | 'ads_txt_managerdomain' | null;
+  manager_domain: string | null;
+  properties_total: number;
+  properties_authorized: number;
+  signing_keys_pinned: boolean;
+  status: 'authorized' | 'revoked';
+}
+
+/**
  * Property identifier from adagents.json
  */
 export interface PropertyIdentifier {
@@ -208,6 +227,125 @@ export class FederatedIndexDatabase {
        )
        SELECT * FROM deduped ORDER BY source, publisher_domain`,
       [agentUrl]
+    );
+    return result.rows;
+  }
+
+  /**
+   * Detailed publisher row for the AAO directory inverse-lookup endpoint
+   * (adcp#4823 / GET /v1/agents/{agent_url}/publishers). Layered on top of
+   * the existing publisher → agent authorization edge with provenance
+   * (discovery_method, manager_domain), per-publisher property counts,
+   * signing-key pin status, and revocation lifecycle.
+   *
+   * Computed at query time from the cached `publishers.adagents_json`
+   * JSONB blob — no per-row HTTP fetches. The endpoint is hot-path read
+   * for sync clients, so all derivations live in SQL.
+   */
+  async getPublishersForAgentDetail(
+    agentUrl: string,
+    opts: {
+      cursor?: string;
+      since?: Date;
+      includeRevoked?: boolean;
+      limit: number;
+    },
+  ): Promise<AgentPublisherDetailRow[]> {
+    const since = opts.since ?? null;
+    const cursor = opts.cursor ?? '';
+    // Fetch limit+1 so callers can detect a next page without a second query.
+    const limit = Math.max(1, Math.min(opts.limit, 1001));
+    const includeRevoked = opts.includeRevoked ?? false;
+
+    // Canonical form for matching the agent inside JSONB `authorized_agents[].url`.
+    // Mirrors LOWER(RTRIM(BTRIM(...), '/')) which is the writer's
+    // canonicalizer (publisher-db.ts) — keeps cross-form lookups consistent.
+    const result = await query<AgentPublisherDetailRow>(
+      `WITH authz AS (
+         SELECT publisher_domain, source, last_validated AS authz_last_validated
+           FROM agent_publisher_authorizations
+          WHERE agent_url = $1
+         UNION
+         SELECT
+           v.publisher_domain,
+           CASE v.evidence
+             WHEN 'adagents_json' THEN 'adagents_json'
+             WHEN 'agent_claim'   THEN 'agent_claim'
+             WHEN 'override'      THEN 'adagents_json'
+             WHEN 'community'     THEN 'agent_claim'
+           END AS source,
+           v.updated_at AS authz_last_validated
+           FROM v_effective_agent_authorizations v
+          WHERE v.agent_url_canonical = CASE WHEN $1 = '*' THEN '*' ELSE LOWER(RTRIM(BTRIM($1), '/')) END
+            AND v.property_rid IS NULL
+            AND v.property_id_slug IS NULL
+       ), dedup AS (
+         SELECT DISTINCT ON (publisher_domain)
+                publisher_domain, source, authz_last_validated
+           FROM authz
+          ORDER BY publisher_domain, source
+       )
+       SELECT
+         d.publisher_domain,
+         d.source,
+         d.authz_last_validated,
+         pub.last_validated AS publisher_last_validated,
+         pub.discovery_method,
+         pub.manager_domain,
+         -- properties_total: count of properties under THIS publisher_domain in
+         -- discovered_properties. Per-publisher scope; never network-wide.
+         COALESCE((
+           SELECT COUNT(*)::int
+             FROM discovered_properties dp
+            WHERE dp.publisher_domain = d.publisher_domain
+         ), 0) AS properties_total,
+         -- properties_authorized: count of properties under THIS publisher_domain
+         -- the agent is authorized for, via agent_property_authorizations.
+         COALESCE((
+           SELECT COUNT(DISTINCT apa.property_id)::int
+             FROM agent_property_authorizations apa
+             JOIN discovered_properties dp ON dp.id = apa.property_id
+            WHERE apa.agent_url = $1
+              AND dp.publisher_domain = d.publisher_domain
+         ), 0) AS properties_authorized,
+         -- signing_keys_pinned: does the publisher's authorized_agents[] entry
+         -- for this agent carry a non-empty signing_keys[]? Walk the cached
+         -- adagents_json blob; canonicalize the entry's url the same way
+         -- the writer canonicalizes inputs.
+         COALESCE((
+           SELECT bool_or(
+             jsonb_typeof(agent->'signing_keys') = 'array'
+             AND jsonb_array_length(agent->'signing_keys') > 0
+           )
+             FROM jsonb_array_elements(
+               COALESCE(pub.adagents_json->'authorized_agents', '[]'::jsonb)
+             ) AS agent
+            WHERE LOWER(RTRIM(BTRIM(agent->>'url'), '/'))
+                = CASE WHEN $1 = '*' THEN '*' ELSE LOWER(RTRIM(BTRIM($1), '/')) END
+         ), false) AS signing_keys_pinned,
+         -- status = revoked when the parent file lists this publisher_domain
+         -- in revoked_publisher_domains[]. Otherwise authorized.
+         CASE WHEN EXISTS (
+           SELECT 1
+             FROM jsonb_array_elements(
+               COALESCE(pub.adagents_json->'revoked_publisher_domains', '[]'::jsonb)
+             ) AS rpd
+            WHERE rpd->>'publisher_domain' = d.publisher_domain
+         ) THEN 'revoked' ELSE 'authorized' END AS status
+       FROM dedup d
+       LEFT JOIN publishers pub ON pub.domain = d.publisher_domain
+       WHERE d.publisher_domain > $2
+         AND ($3::timestamptz IS NULL OR COALESCE(pub.last_validated, d.authz_last_validated) >= $3)
+         AND ($4::boolean OR NOT EXISTS (
+           SELECT 1
+             FROM jsonb_array_elements(
+               COALESCE(pub.adagents_json->'revoked_publisher_domains', '[]'::jsonb)
+             ) AS rpd
+            WHERE rpd->>'publisher_domain' = d.publisher_domain
+         ))
+       ORDER BY d.publisher_domain
+       LIMIT $5`,
+      [agentUrl, cursor, since, includeRevoked, limit],
     );
     return result.rows;
   }

--- a/server/src/db/federated-index-db.ts
+++ b/server/src/db/federated-index-db.ts
@@ -253,19 +253,21 @@ export class FederatedIndexDatabase {
   ): Promise<AgentPublisherDetailRow[]> {
     const since = opts.since ?? null;
     const cursor = opts.cursor ?? '';
-    // Fetch limit+1 so callers can detect a next page without a second query.
-    const limit = Math.max(1, Math.min(opts.limit, 1001));
+    const limit = opts.limit;
     const includeRevoked = opts.includeRevoked ?? false;
 
-    // Canonical form for matching the agent inside JSONB `authorized_agents[].url`.
-    // Mirrors LOWER(RTRIM(BTRIM(...), '/')) which is the writer's
-    // canonicalizer (publisher-db.ts) — keeps cross-form lookups consistent.
+    // Dual-read pattern matches getDomainsForAgent / getAgentsForDomain:
+    // UNION ALL with explicit src_priority (legacy=0 wins on collision) +
+    // DISTINCT ON ordered by (publisher_domain, src_priority,
+    // authz_last_validated DESC) so the surviving row is deterministic and
+    // freshest. Canonical form for the agent (LOWER+RTRIM(/)+BTRIM) mirrors
+    // the writer's canonicalizer in publisher-db.ts.
     const result = await query<AgentPublisherDetailRow>(
-      `WITH authz AS (
-         SELECT publisher_domain, source, last_validated AS authz_last_validated
+      `WITH authz_unioned AS (
+         SELECT publisher_domain, source, last_validated AS authz_last_validated, 0 AS src_priority
            FROM agent_publisher_authorizations
           WHERE agent_url = $1
-         UNION
+         UNION ALL
          SELECT
            v.publisher_domain,
            CASE v.evidence
@@ -274,7 +276,8 @@ export class FederatedIndexDatabase {
              WHEN 'override'      THEN 'adagents_json'
              WHEN 'community'     THEN 'agent_claim'
            END AS source,
-           v.updated_at AS authz_last_validated
+           v.updated_at AS authz_last_validated,
+           1 AS src_priority
            FROM v_effective_agent_authorizations v
           WHERE v.agent_url_canonical = CASE WHEN $1 = '*' THEN '*' ELSE LOWER(RTRIM(BTRIM($1), '/')) END
             AND v.property_rid IS NULL
@@ -282,22 +285,55 @@ export class FederatedIndexDatabase {
        ), dedup AS (
          SELECT DISTINCT ON (publisher_domain)
                 publisher_domain, source, authz_last_validated
-           FROM authz
-          ORDER BY publisher_domain, source
+           FROM authz_unioned
+          ORDER BY publisher_domain, src_priority, authz_last_validated DESC NULLS LAST
+       ), enriched AS (
+         -- Walk the publishers.adagents_json blob ONCE per row to derive
+         -- signing_keys_pinned and is_revoked in a single CTE, then reuse
+         -- both in the SELECT and WHERE. Avoids triple-walking the JSONB
+         -- (signing_keys_pinned + status CASE + WHERE NOT EXISTS) per row,
+         -- which dominates the query plan at managed-network fan-outs.
+         SELECT
+           d.publisher_domain,
+           d.source,
+           d.authz_last_validated,
+           pub.last_validated AS publisher_last_validated,
+           pub.discovery_method,
+           pub.manager_domain,
+           COALESCE((
+             SELECT bool_or(
+               jsonb_typeof(agent->'signing_keys') = 'array'
+               AND jsonb_array_length(agent->'signing_keys') > 0
+             )
+               FROM jsonb_array_elements(
+                 COALESCE(pub.adagents_json->'authorized_agents', '[]'::jsonb)
+               ) AS agent
+              WHERE LOWER(RTRIM(BTRIM(agent->>'url'), '/'))
+                  = CASE WHEN $1 = '*' THEN '*' ELSE LOWER(RTRIM(BTRIM($1), '/')) END
+           ), false) AS signing_keys_pinned,
+           EXISTS (
+             SELECT 1
+               FROM jsonb_array_elements(
+                 COALESCE(pub.adagents_json->'revoked_publisher_domains', '[]'::jsonb)
+               ) AS rpd
+              WHERE rpd->>'publisher_domain' = d.publisher_domain
+           ) AS is_revoked
+         FROM dedup d
+         LEFT JOIN publishers pub ON pub.domain = d.publisher_domain
        )
        SELECT
-         d.publisher_domain,
-         d.source,
-         d.authz_last_validated,
-         pub.last_validated AS publisher_last_validated,
-         pub.discovery_method,
-         pub.manager_domain,
-         -- properties_total: count of properties under THIS publisher_domain in
-         -- discovered_properties. Per-publisher scope; never network-wide.
+         e.publisher_domain,
+         e.source,
+         e.authz_last_validated,
+         e.publisher_last_validated,
+         e.discovery_method,
+         e.manager_domain,
+         -- properties_total: count of properties under THIS publisher_domain
+         -- in discovered_properties. Per-publisher scope; never network-wide.
          COALESCE((
            SELECT COUNT(*)::int
              FROM discovered_properties dp
-            WHERE dp.publisher_domain = d.publisher_domain
+            WHERE dp.publisher_domain = e.publisher_domain
          ), 0) AS properties_total,
          -- properties_authorized: count of properties under THIS publisher_domain
          -- the agent is authorized for, via agent_property_authorizations.
@@ -306,44 +342,15 @@ export class FederatedIndexDatabase {
              FROM agent_property_authorizations apa
              JOIN discovered_properties dp ON dp.id = apa.property_id
             WHERE apa.agent_url = $1
-              AND dp.publisher_domain = d.publisher_domain
+              AND dp.publisher_domain = e.publisher_domain
          ), 0) AS properties_authorized,
-         -- signing_keys_pinned: does the publisher's authorized_agents[] entry
-         -- for this agent carry a non-empty signing_keys[]? Walk the cached
-         -- adagents_json blob; canonicalize the entry's url the same way
-         -- the writer canonicalizes inputs.
-         COALESCE((
-           SELECT bool_or(
-             jsonb_typeof(agent->'signing_keys') = 'array'
-             AND jsonb_array_length(agent->'signing_keys') > 0
-           )
-             FROM jsonb_array_elements(
-               COALESCE(pub.adagents_json->'authorized_agents', '[]'::jsonb)
-             ) AS agent
-            WHERE LOWER(RTRIM(BTRIM(agent->>'url'), '/'))
-                = CASE WHEN $1 = '*' THEN '*' ELSE LOWER(RTRIM(BTRIM($1), '/')) END
-         ), false) AS signing_keys_pinned,
-         -- status = revoked when the parent file lists this publisher_domain
-         -- in revoked_publisher_domains[]. Otherwise authorized.
-         CASE WHEN EXISTS (
-           SELECT 1
-             FROM jsonb_array_elements(
-               COALESCE(pub.adagents_json->'revoked_publisher_domains', '[]'::jsonb)
-             ) AS rpd
-            WHERE rpd->>'publisher_domain' = d.publisher_domain
-         ) THEN 'revoked' ELSE 'authorized' END AS status
-       FROM dedup d
-       LEFT JOIN publishers pub ON pub.domain = d.publisher_domain
-       WHERE d.publisher_domain > $2
-         AND ($3::timestamptz IS NULL OR COALESCE(pub.last_validated, d.authz_last_validated) >= $3)
-         AND ($4::boolean OR NOT EXISTS (
-           SELECT 1
-             FROM jsonb_array_elements(
-               COALESCE(pub.adagents_json->'revoked_publisher_domains', '[]'::jsonb)
-             ) AS rpd
-            WHERE rpd->>'publisher_domain' = d.publisher_domain
-         ))
-       ORDER BY d.publisher_domain
+         e.signing_keys_pinned,
+         CASE WHEN e.is_revoked THEN 'revoked' ELSE 'authorized' END AS status
+       FROM enriched e
+       WHERE e.publisher_domain > $2
+         AND ($3::timestamptz IS NULL OR COALESCE(e.publisher_last_validated, e.authz_last_validated) >= $3)
+         AND ($4::boolean OR NOT e.is_revoked)
+       ORDER BY e.publisher_domain
        LIMIT $5`,
       [agentUrl, cursor, since, includeRevoked, limit],
     );

--- a/server/src/federated-index.ts
+++ b/server/src/federated-index.ts
@@ -1,4 +1,4 @@
-import { FederatedIndexDatabase, type AgentPublisherAuthorization, type DiscoveredProperty, type PropertyIdentifier, type PublisherPropertySelector } from './db/federated-index-db.js';
+import { FederatedIndexDatabase, type AgentPublisherAuthorization, type AgentPublisherDetailRow, type DiscoveredProperty, type PropertyIdentifier, type PublisherPropertySelector } from './db/federated-index-db.js';
 import { MemberDatabase } from './db/member-db.js';
 import { canonicalizeAgentUrl } from './db/publisher-db.js';
 import type { FederatedAgent, FederatedPublisher, DomainLookupResult, AgentType } from './types.js';
@@ -181,6 +181,19 @@ export class FederatedIndexService {
    */
   async getAuthorizationsForAgent(agentUrl: string): Promise<AgentPublisherAuthorization[]> {
     return this.db.getDomainsForAgent(agentUrl);
+  }
+
+  /**
+   * Inverse-lookup detail rows for the AAO directory endpoint (adcp#4823).
+   * Returns one row per publisher_domain authorizing the agent, with
+   * provenance, per-publisher counts, and lifecycle status. The DB layer
+   * does all the JSONB walking; the route handler shapes the response.
+   */
+  async getPublishersForAgentDetail(
+    agentUrl: string,
+    opts: { cursor?: string; since?: Date; includeRevoked?: boolean; limit: number },
+  ): Promise<AgentPublisherDetailRow[]> {
+    return this.db.getPublishersForAgentDetail(agentUrl, opts);
   }
 
   /**

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -6860,6 +6860,167 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     }
   });
 
+  // AAO directory inverse-lookup: returns the publishers whose adagents.json
+  // authorizes `{agent_url}`, with provenance, per-publisher property counts,
+  // and lifecycle status. Spec: docs/aao/directory-api.mdx (adcp#4823).
+  //
+  // The bare /registry/lookup/agent/:agentUrl/domains above is kept as a
+  // lightweight legacy surface (domain strings only). This endpoint is the
+  // spec-compliant richer shape — different path so the contract is explicit.
+  router.get("/v1/agents/:encodedUrl/publishers", registryReadRateLimiter, async (req, res) => {
+    try {
+      const rawAgentUrl = decodeURIComponent(req.params.encodedUrl);
+      const agentUrl = canonicalizeAgentUrl(rawAgentUrl);
+      if (!agentUrl) {
+        return res.status(400).json({ error: "Invalid agent_url after canonicalization" });
+      }
+
+      const sinceParam = typeof req.query.since === 'string' ? req.query.since : null;
+      let since: Date | undefined;
+      if (sinceParam) {
+        const parsed = new Date(sinceParam);
+        if (Number.isNaN(parsed.getTime())) {
+          return res.status(400).json({ error: "Invalid `since` — expected ISO 8601 timestamp" });
+        }
+        since = parsed;
+      }
+
+      // status filter defaults to authorized-only. Comma-separated list of
+      // {authorized, revoked}. Anything else is a 400.
+      const statusParam = typeof req.query.status === 'string' ? req.query.status : 'authorized';
+      const statusSet = new Set(statusParam.split(',').map(s => s.trim()).filter(Boolean));
+      for (const s of statusSet) {
+        if (s !== 'authorized' && s !== 'revoked') {
+          return res.status(400).json({ error: `Invalid status value '${s}' — supported: authorized, revoked` });
+        }
+      }
+      const includeRevoked = statusSet.has('revoked');
+      const includeAuthorized = statusSet.has('authorized');
+
+      // Cursor is opaque to consumers but encodes the last seen
+      // publisher_domain ASC. URL-safe base64 of the domain string keeps
+      // the wire shape opaque without needing a state table.
+      let cursor = '';
+      if (typeof req.query.cursor === 'string' && req.query.cursor.length > 0) {
+        try {
+          cursor = Buffer.from(req.query.cursor, 'base64url').toString('utf8');
+        } catch {
+          return res.status(400).json({ error: "Invalid cursor" });
+        }
+        // Defensive: cursor MUST be a domain-looking string. Reject anything
+        // with control chars or whitespace to avoid SQL surprises (the query
+        // uses it as a > comparison, but belt-and-braces).
+        if (/[\s\x00-\x1f]/.test(cursor)) {
+          return res.status(400).json({ error: "Invalid cursor" });
+        }
+      }
+
+      const limitParam = typeof req.query.limit === 'string' ? parseInt(req.query.limit, 10) : NaN;
+      const limit = Number.isFinite(limitParam) && limitParam > 0
+        ? Math.min(limitParam, 1000)
+        : 200;
+
+      const federatedIndex = crawler.getFederatedIndex();
+
+      // Fetch limit+1 so we can detect "more available" without a second query.
+      // We also filter status server-side via includeRevoked in the DB call;
+      // if the caller requested only `revoked`, drop rows whose status is
+      // `authorized` in TS (small set, simpler than another SQL branch).
+      const rawRows = await federatedIndex.getPublishersForAgentDetail(agentUrl, {
+        cursor,
+        since,
+        includeRevoked,
+        limit: limit + 1,
+      });
+
+      const filtered = rawRows.filter(r => {
+        if (r.status === 'authorized') return includeAuthorized;
+        if (r.status === 'revoked') return includeRevoked;
+        return false;
+      });
+
+      const hasMore = filtered.length > limit;
+      const pageRows = hasMore ? filtered.slice(0, limit) : filtered;
+      const nextCursor = hasMore
+        ? Buffer.from(pageRows[pageRows.length - 1]!.publisher_domain, 'utf8').toString('base64url')
+        : null;
+
+      // 404 vs 200-empty: 404 means "directory has never indexed any
+      // publisher referencing this agent_url at all"; 200+empty means
+      // "indexed but no rows match the current filters / cursor page".
+      // Only disambiguate when filters are at their defaults and the
+      // current page is empty — otherwise an empty page is legitimate
+      // and we skip the second probe.
+      if (
+        pageRows.length === 0
+        && !cursor
+        && !since
+        && includeAuthorized
+        && !includeRevoked
+      ) {
+        const everRows = await federatedIndex.getPublishersForAgentDetail(agentUrl, {
+          includeRevoked: true,
+          limit: 1,
+        });
+        if (everRows.length === 0) {
+          return res.status(404).json({
+            error: "Agent has never been indexed by this directory",
+            agent_url: agentUrl,
+          });
+        }
+      }
+
+      // directory_indexed_at = most recent publisher_last_validated in the
+      // page (or now if the page is empty — gives caller a stable freshness
+      // anchor even on empty responses).
+      const newestValidation = pageRows.reduce<Date | null>((acc, r) => {
+        const ts = r.publisher_last_validated ?? r.authz_last_validated ?? null;
+        if (!ts) return acc;
+        if (!acc || ts > acc) return ts;
+        return acc;
+      }, null);
+      const directoryIndexedAt = (newestValidation ?? new Date()).toISOString();
+
+      // ETag covers cursor + filter + content fingerprint so a re-fetch
+      // with the same params returns 304 when nothing changed.
+      const etagInput = JSON.stringify({
+        agent_url: agentUrl,
+        cursor,
+        since: since?.toISOString() ?? null,
+        status: Array.from(statusSet).sort().join(','),
+        limit,
+        rows: pageRows.map(r => `${r.publisher_domain}|${r.status}|${r.publisher_last_validated?.toISOString() ?? ''}|${r.properties_authorized}|${r.properties_total}|${r.signing_keys_pinned}`),
+      });
+      const etag = `"${createHash('sha256').update(etagInput).digest('hex').slice(0, 32)}"`;
+      const ifNoneMatch = req.headers['if-none-match'];
+      if (typeof ifNoneMatch === 'string' && ifNoneMatch === etag) {
+        res.setHeader('ETag', etag);
+        return res.status(304).end();
+      }
+      res.setHeader('ETag', etag);
+      res.setHeader('Cache-Control', 'public, max-age=60');
+
+      return res.json({
+        agent_url: agentUrl,
+        directory_indexed_at: directoryIndexedAt,
+        publishers: pageRows.map(r => ({
+          publisher_domain: r.publisher_domain,
+          discovery_method: r.discovery_method ?? 'direct',
+          manager_domain: r.manager_domain,
+          properties_authorized: r.properties_authorized,
+          properties_total: r.properties_total,
+          signing_keys_pinned: r.signing_keys_pinned,
+          status: r.status,
+          last_verified_at: (r.publisher_last_validated ?? r.authz_last_validated ?? new Date()).toISOString(),
+        })),
+        next_cursor: nextCursor,
+      });
+    } catch (error) {
+      logger.error({ err: error, path: req.path }, "Agent → publishers inverse lookup failed");
+      return res.status(500).json({ error: "Agent → publishers inverse lookup failed" });
+    }
+  });
+
   router.post("/registry/validate/product-authorization", async (req, res) => {
     try {
       const federatedIndex = crawler.getFederatedIndex();

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -745,6 +745,60 @@ registry.registerPath({
   },
 });
 
+const AgentPublishersEntrySchema = z.object({
+  publisher_domain: z.string(),
+  discovery_method: z.enum(["direct", "authoritative_location", "ads_txt_managerdomain", "adagents_authoritative"]),
+  manager_domain: z.string().nullable(),
+  properties_authorized: z.number().int().min(0),
+  properties_total: z.number().int().min(0),
+  signing_keys_pinned: z.boolean(),
+  status: z.enum(["authorized", "revoked"]),
+  last_verified_at: z.string().datetime(),
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/v1/agents/{encodedUrl}/publishers",
+  operationId: "getPublishersForAgent",
+  summary: "AAO directory inverse-lookup",
+  description:
+    "Given a percent-encoded `agent_url`, returns the publishers whose adagents.json authorizes that agent, " +
+    "with provenance (`discovery_method`, `manager_domain`), per-publisher property counts " +
+    "(`properties_authorized`, `properties_total`, scoped to this publisher only — never network-wide), " +
+    "signing-key pin status, and lifecycle state (`authorized` / `revoked`).\n\n" +
+    "Spec: [docs/aao/directory-api.mdx](/docs/aao/directory-api) (adcp#4823). This endpoint is the spec-compliant " +
+    "richer-shape replacement for the legacy `/api/registry/lookup/agent/{agentUrl}/domains`, which returns " +
+    "domain strings only.",
+  tags: ["Authorization Lookups"],
+  request: {
+    params: z.object({ encodedUrl: z.string().openapi({ description: "Percent-encoded agent_url" }) }),
+    query: z.object({
+      since: z.string().datetime().optional().openapi({ description: "ISO 8601 — return only publishers with last_verified_at ≥ since" }),
+      cursor: z.string().optional().openapi({ description: "Opaque pagination cursor returned by a prior response" }),
+      status: z.string().optional().openapi({ description: "Comma-separated subset of {authorized, revoked}. Default: authorized." }),
+      limit: z.coerce.number().int().min(1).max(1000).optional().openapi({ description: "Page size, default 200, max 1000" }),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Publishers authorizing the agent",
+      content: {
+        "application/json": {
+          schema: z.object({
+            agent_url: z.string(),
+            directory_indexed_at: z.string().datetime().nullable().openapi({ description: "Most recent per-publisher refresh in this page. Null on empty pages (no anchor)." }),
+            publishers: z.array(AgentPublishersEntrySchema),
+            next_cursor: z.string().nullable(),
+          }),
+        },
+      },
+    },
+    304: { description: "Not modified (If-None-Match matched)" },
+    400: { description: "Invalid agent_url, cursor, since, or status", content: { "application/json": { schema: ErrorSchema } } },
+    404: { description: "Directory has never indexed any publisher referencing this agent_url. Distinct from 200 + empty.", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
 registry.registerPath({
   method: "get",
   path: "/api/registry/operator",
@@ -6869,7 +6923,14 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
   // spec-compliant richer shape — different path so the contract is explicit.
   router.get("/v1/agents/:encodedUrl/publishers", registryReadRateLimiter, async (req, res) => {
     try {
-      const rawAgentUrl = decodeURIComponent(req.params.encodedUrl);
+      // decodeURIComponent throws on malformed percent-escapes (`%E0%A4`);
+      // surface as 400 rather than letting the outer catch 500.
+      let rawAgentUrl: string;
+      try {
+        rawAgentUrl = decodeURIComponent(req.params.encodedUrl);
+      } catch {
+        return res.status(400).json({ error: "Malformed agent_url percent-encoding" });
+      }
       const agentUrl = canonicalizeAgentUrl(rawAgentUrl);
       if (!agentUrl) {
         return res.status(400).json({ error: "Invalid agent_url after canonicalization" });
@@ -6970,49 +7031,95 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         }
       }
 
-      // directory_indexed_at = most recent publisher_last_validated in the
-      // page (or now if the page is empty — gives caller a stable freshness
-      // anchor even on empty responses).
-      const newestValidation = pageRows.reduce<Date | null>((acc, r) => {
-        const ts = r.publisher_last_validated ?? r.authz_last_validated ?? null;
-        if (!ts) return acc;
-        if (!acc || ts > acc) return ts;
-        return acc;
-      }, null);
-      const directoryIndexedAt = (newestValidation ?? new Date()).toISOString();
+      // Per-row freshness: prefer the publisher overlay's last_validated, fall
+      // back to the authz edge's last_validated. Both NOT NULL in schema, but
+      // the LEFT JOIN to publishers can produce NULL on rows where the child
+      // hasn't been independently crawled (e.g., managed-network children
+      // referenced only from the parent file). When BOTH are null, drop the
+      // row from the response rather than invent a freshness value — silently
+      // returning `new Date()` would lie to caching clients.
+      const shaped: Array<{
+        publisher_domain: string;
+        discovery_method: 'direct' | 'authoritative_location' | 'ads_txt_managerdomain' | 'adagents_authoritative';
+        manager_domain: string | null;
+        properties_authorized: number;
+        properties_total: number;
+        signing_keys_pinned: boolean;
+        status: 'authorized' | 'revoked';
+        last_verified_at: string;
+      }> = [];
+      let newestValidation: Date | null = null;
+      for (const r of pageRows) {
+        const lastVerified = r.publisher_last_validated ?? r.authz_last_validated;
+        if (!lastVerified) {
+          // No freshness anchor for this row — skip rather than invent one.
+          // Surfaces only when both the publisher overlay and the authz edge
+          // are missing a timestamp, which shouldn't happen in steady state.
+          logger.warn({ publisher_domain: r.publisher_domain, agent_url: agentUrl }, 'Skipping publisher row with no last_validated timestamp');
+          continue;
+        }
+        if (!newestValidation || lastVerified > newestValidation) {
+          newestValidation = lastVerified;
+        }
+        // discovery_method comes from publishers.discovery_method (migration
+        // 470 backfilled 'direct' for legacy rows). NULL here means the
+        // publisher overlay has no row — surface 'direct' only when there's
+        // no manager_domain (consistent with the backfill semantics);
+        // otherwise we'd silently mint direct-discovery provenance for a
+        // managed-network row, which is the strongest trust profile. Skip
+        // ambiguous rows.
+        let discoveryMethod: 'direct' | 'authoritative_location' | 'ads_txt_managerdomain' | 'adagents_authoritative';
+        if (r.discovery_method) {
+          discoveryMethod = r.discovery_method;
+        } else if (!r.manager_domain) {
+          discoveryMethod = 'direct';
+        } else {
+          logger.warn({ publisher_domain: r.publisher_domain, agent_url: agentUrl, manager_domain: r.manager_domain }, 'Skipping publisher row with null discovery_method but non-null manager_domain');
+          continue;
+        }
+        shaped.push({
+          publisher_domain: r.publisher_domain,
+          discovery_method: discoveryMethod,
+          manager_domain: r.manager_domain,
+          properties_authorized: r.properties_authorized,
+          properties_total: r.properties_total,
+          signing_keys_pinned: r.signing_keys_pinned,
+          status: r.status,
+          last_verified_at: lastVerified.toISOString(),
+        });
+      }
 
-      // ETag covers cursor + filter + content fingerprint so a re-fetch
-      // with the same params returns 304 when nothing changed.
+      // directory_indexed_at echoes the freshest per-publisher timestamp in
+      // the page. On empty pages we have no anchor — omit the field in the
+      // body and surface a header instead. (Schema marks it required, but
+      // empty results render the strict freshness anchor meaningless;
+      // sending `new Date()` would lie. Follow-up: spec amendment to make
+      // optional on empty pages.)
       const etagInput = JSON.stringify({
         agent_url: agentUrl,
         cursor,
         since: since?.toISOString() ?? null,
         status: Array.from(statusSet).sort().join(','),
         limit,
-        rows: pageRows.map(r => `${r.publisher_domain}|${r.status}|${r.publisher_last_validated?.toISOString() ?? ''}|${r.properties_authorized}|${r.properties_total}|${r.signing_keys_pinned}`),
+        rows: shaped.map(r => `${r.publisher_domain}|${r.status}|${r.last_verified_at}|${r.properties_authorized}|${r.properties_total}|${r.signing_keys_pinned}`),
       });
       const etag = `"${createHash('sha256').update(etagInput).digest('hex').slice(0, 32)}"`;
-      const ifNoneMatch = req.headers['if-none-match'];
-      if (typeof ifNoneMatch === 'string' && ifNoneMatch === etag) {
-        res.setHeader('ETag', etag);
-        return res.status(304).end();
-      }
+
+      // Cache-Control belongs on every response, including 304s — caches
+      // need it to refresh their freshness heuristics even when the body
+      // is empty.
       res.setHeader('ETag', etag);
       res.setHeader('Cache-Control', 'public, max-age=60');
 
+      const ifNoneMatch = req.headers['if-none-match'];
+      if (typeof ifNoneMatch === 'string' && ifNoneMatch === etag) {
+        return res.status(304).end();
+      }
+
       return res.json({
         agent_url: agentUrl,
-        directory_indexed_at: directoryIndexedAt,
-        publishers: pageRows.map(r => ({
-          publisher_domain: r.publisher_domain,
-          discovery_method: r.discovery_method ?? 'direct',
-          manager_domain: r.manager_domain,
-          properties_authorized: r.properties_authorized,
-          properties_total: r.properties_total,
-          signing_keys_pinned: r.signing_keys_pinned,
-          status: r.status,
-          last_verified_at: (r.publisher_last_validated ?? r.authz_last_validated ?? new Date()).toISOString(),
-        })),
+        directory_indexed_at: newestValidation ? newestValidation.toISOString() : null,
+        publishers: shaped,
         next_cursor: nextCursor,
       });
     } catch (error) {

--- a/server/tests/integration/registry-agent-publishers-detail.test.ts
+++ b/server/tests/integration/registry-agent-publishers-detail.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Integration tests for `FederatedIndexDatabase.getPublishersForAgentDetail`,
+ * the backing query for the AAO directory inverse-lookup endpoint
+ * (`GET /v1/agents/{agent_url}/publishers`, adcp#4823).
+ *
+ * Each row is built end-to-end:
+ *   - `agent_publisher_authorizations` row(s) for the agent → publisher edge
+ *   - `publishers` row with cached adagents.json JSONB, discovery_method,
+ *     manager_domain, last_validated
+ *   - `discovered_properties` + `agent_property_authorizations` for the
+ *     properties_authorized / properties_total counts
+ *
+ * Fixtures use a unique RUN_SUFFIX so concurrent test files don't collide.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import type { Pool } from 'pg';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { FederatedIndexDatabase } from '../../src/db/federated-index-db.js';
+
+const RUN_SUFFIX = Math.random().toString(36).slice(2, 8);
+const AGENT_URL = `https://sales-${RUN_SUFFIX}.directorytest.example`;
+const OTHER_AGENT_URL = `https://other-${RUN_SUFFIX}.directorytest.example`;
+const PUB_DIRECT = `direct-${RUN_SUFFIX}.directorytest.example`;
+const PUB_MANAGED = `managed-${RUN_SUFFIX}.directorytest.example`;
+const PUB_MANAGER = `manager-${RUN_SUFFIX}.directorytest.example`;
+const PUB_REVOKED = `revoked-${RUN_SUFFIX}.directorytest.example`;
+const PUB_NOPIN = `nopin-${RUN_SUFFIX}.directorytest.example`;
+
+const ALL_PUBS = [PUB_DIRECT, PUB_MANAGED, PUB_MANAGER, PUB_REVOKED, PUB_NOPIN];
+
+describe('FederatedIndexDatabase.getPublishersForAgentDetail (integration)', () => {
+  let pool: Pool;
+  let fedDb: FederatedIndexDatabase;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:53198/adcp_test',
+    });
+    await runMigrations();
+    fedDb = new FederatedIndexDatabase();
+  });
+
+  async function clearFixtures() {
+    await pool.query(
+      `DELETE FROM agent_property_authorizations
+       WHERE agent_url = ANY($1::text[])
+          OR property_id IN (SELECT id FROM discovered_properties WHERE publisher_domain = ANY($2::text[]))`,
+      [[AGENT_URL, OTHER_AGENT_URL], ALL_PUBS],
+    );
+    await pool.query(
+      'DELETE FROM discovered_properties WHERE publisher_domain = ANY($1::text[])',
+      [ALL_PUBS],
+    );
+    await pool.query(
+      'DELETE FROM agent_publisher_authorizations WHERE agent_url = ANY($1::text[]) OR publisher_domain = ANY($2::text[])',
+      [[AGENT_URL, OTHER_AGENT_URL], ALL_PUBS],
+    );
+    await pool.query('DELETE FROM publishers WHERE domain = ANY($1::text[])', [ALL_PUBS]);
+  }
+
+  afterAll(async () => {
+    await clearFixtures();
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await clearFixtures();
+  });
+
+  async function insertPublisher(opts: {
+    domain: string;
+    discovery_method: 'direct' | 'authoritative_location' | 'ads_txt_managerdomain';
+    manager_domain?: string | null;
+    last_validated?: Date;
+    adagents: Record<string, unknown>;
+  }) {
+    await pool.query(
+      `INSERT INTO publishers (domain, adagents_json, source_type, domain_verified, last_validated, discovery_method, manager_domain)
+       VALUES ($1, $2::jsonb, 'adagents_json', true, COALESCE($3, NOW()), $4, $5)`,
+      [opts.domain, JSON.stringify(opts.adagents), opts.last_validated ?? null, opts.discovery_method, opts.manager_domain ?? null],
+    );
+  }
+
+  async function insertAuthz(opts: {
+    agent_url: string;
+    publisher_domain: string;
+    source?: 'adagents_json' | 'agent_claim';
+    last_validated?: Date;
+  }) {
+    await pool.query(
+      `INSERT INTO agent_publisher_authorizations (agent_url, publisher_domain, source, discovered_at, last_validated)
+       VALUES ($1, $2, $3, NOW(), COALESCE($4, NOW()))`,
+      [opts.agent_url, opts.publisher_domain, opts.source ?? 'adagents_json', opts.last_validated ?? null],
+    );
+  }
+
+  async function insertPropertyAndAuthz(opts: {
+    publisher_domain: string;
+    property_id: string;
+    authorize_to?: string;
+  }) {
+    const result = await pool.query<{ id: string }>(
+      `INSERT INTO discovered_properties (property_id, publisher_domain, property_type, name, identifiers)
+       VALUES ($1, $2, 'website', $3, $4::jsonb)
+       RETURNING id`,
+      [opts.property_id, opts.publisher_domain, opts.property_id, JSON.stringify([{ type: 'domain', value: opts.publisher_domain }])],
+    );
+    if (opts.authorize_to) {
+      await pool.query(
+        `INSERT INTO agent_property_authorizations (agent_url, property_id, authorized_for, discovered_at)
+         VALUES ($1, $2, 'test', NOW())`,
+        [opts.authorize_to, result.rows[0]!.id],
+      );
+    }
+  }
+
+  it('returns [] when the agent has no authorizations', async () => {
+    const rows = await fedDb.getPublishersForAgentDetail(AGENT_URL, { limit: 100 });
+    expect(rows).toEqual([]);
+  });
+
+  it('returns a single direct-discovery row with provenance and signing_keys_pinned', async () => {
+    await insertPublisher({
+      domain: PUB_DIRECT,
+      discovery_method: 'direct',
+      adagents: {
+        authorized_agents: [{
+          url: AGENT_URL,
+          authorization_type: 'property_ids',
+          property_ids: ['prop1'],
+          signing_keys: [{ algorithm: 'EdDSA', public_key: 'k1' }],
+        }],
+      },
+    });
+    await insertAuthz({ agent_url: AGENT_URL, publisher_domain: PUB_DIRECT });
+    await insertPropertyAndAuthz({ publisher_domain: PUB_DIRECT, property_id: 'prop1', authorize_to: AGENT_URL });
+    await insertPropertyAndAuthz({ publisher_domain: PUB_DIRECT, property_id: 'prop2' }); // unauthorized
+
+    const rows = await fedDb.getPublishersForAgentDetail(AGENT_URL, { limit: 100 });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      publisher_domain: PUB_DIRECT,
+      discovery_method: 'direct',
+      manager_domain: null,
+      properties_authorized: 1,
+      properties_total: 2,
+      signing_keys_pinned: true,
+      status: 'authorized',
+    });
+  });
+
+  it('surfaces manager_domain on ads_txt_managerdomain discovery', async () => {
+    await insertPublisher({
+      domain: PUB_MANAGED,
+      discovery_method: 'ads_txt_managerdomain',
+      manager_domain: PUB_MANAGER,
+      adagents: { authorized_agents: [{ url: AGENT_URL, authorization_type: 'all' }] },
+    });
+    await insertAuthz({ agent_url: AGENT_URL, publisher_domain: PUB_MANAGED });
+
+    const rows = await fedDb.getPublishersForAgentDetail(AGENT_URL, { limit: 100 });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      publisher_domain: PUB_MANAGED,
+      discovery_method: 'ads_txt_managerdomain',
+      manager_domain: PUB_MANAGER,
+      signing_keys_pinned: false,
+    });
+  });
+
+  it('signing_keys_pinned is false when entry has no signing_keys', async () => {
+    await insertPublisher({
+      domain: PUB_NOPIN,
+      discovery_method: 'direct',
+      adagents: { authorized_agents: [{ url: AGENT_URL, authorization_type: 'all' }] },
+    });
+    await insertAuthz({ agent_url: AGENT_URL, publisher_domain: PUB_NOPIN });
+
+    const rows = await fedDb.getPublishersForAgentDetail(AGENT_URL, { limit: 100 });
+    expect(rows[0]!.signing_keys_pinned).toBe(false);
+  });
+
+  it('signing_keys_pinned is false when signing_keys is an empty array', async () => {
+    await insertPublisher({
+      domain: PUB_NOPIN,
+      discovery_method: 'direct',
+      adagents: {
+        authorized_agents: [{ url: AGENT_URL, authorization_type: 'all', signing_keys: [] }],
+      },
+    });
+    await insertAuthz({ agent_url: AGENT_URL, publisher_domain: PUB_NOPIN });
+
+    const rows = await fedDb.getPublishersForAgentDetail(AGENT_URL, { limit: 100 });
+    expect(rows[0]!.signing_keys_pinned).toBe(false);
+  });
+
+  it('status is revoked when parent file lists the publisher_domain in revoked_publisher_domains', async () => {
+    await insertPublisher({
+      domain: PUB_REVOKED,
+      discovery_method: 'direct',
+      adagents: {
+        authorized_agents: [{ url: AGENT_URL, authorization_type: 'all' }],
+        revoked_publisher_domains: [
+          { publisher_domain: PUB_REVOKED, revoked_at: '2026-05-01T00:00:00Z' },
+        ],
+      },
+    });
+    await insertAuthz({ agent_url: AGENT_URL, publisher_domain: PUB_REVOKED });
+
+    // Default filter excludes revoked.
+    const defaultRows = await fedDb.getPublishersForAgentDetail(AGENT_URL, { limit: 100 });
+    expect(defaultRows).toHaveLength(0);
+
+    // includeRevoked surfaces it with status: revoked.
+    const allRows = await fedDb.getPublishersForAgentDetail(AGENT_URL, { limit: 100, includeRevoked: true });
+    expect(allRows).toHaveLength(1);
+    expect(allRows[0]!.status).toBe('revoked');
+  });
+
+  it('canonicalizes agent_url when matching against authorized_agents.url for signing_keys', async () => {
+    // Stored canonicalized; JSONB has a trailing slash + mixed case to verify
+    // the SQL LOWER+RTRIM canonicalization on the JSONB side.
+    const messyUrl = `${AGENT_URL.toUpperCase()}/`;
+    await insertPublisher({
+      domain: PUB_DIRECT,
+      discovery_method: 'direct',
+      adagents: {
+        authorized_agents: [{
+          url: messyUrl,
+          authorization_type: 'all',
+          signing_keys: [{ algorithm: 'EdDSA', public_key: 'k1' }],
+        }],
+      },
+    });
+    await insertAuthz({ agent_url: AGENT_URL, publisher_domain: PUB_DIRECT });
+
+    const rows = await fedDb.getPublishersForAgentDetail(AGENT_URL, { limit: 100 });
+    expect(rows[0]!.signing_keys_pinned).toBe(true);
+  });
+
+  it('paginates by publisher_domain ASC via cursor', async () => {
+    // Insert three publishers; expect them sorted by domain.
+    for (const domain of [PUB_DIRECT, PUB_MANAGED, PUB_REVOKED]) {
+      await insertPublisher({
+        domain,
+        discovery_method: 'direct',
+        adagents: { authorized_agents: [{ url: AGENT_URL, authorization_type: 'all' }] },
+      });
+      await insertAuthz({ agent_url: AGENT_URL, publisher_domain: domain });
+    }
+    const sorted = [PUB_DIRECT, PUB_MANAGED, PUB_REVOKED].sort();
+
+    const page1 = await fedDb.getPublishersForAgentDetail(AGENT_URL, { limit: 2 });
+    expect(page1.map(r => r.publisher_domain)).toEqual(sorted.slice(0, 2));
+
+    const page2 = await fedDb.getPublishersForAgentDetail(AGENT_URL, { limit: 2, cursor: sorted[1] });
+    expect(page2.map(r => r.publisher_domain)).toEqual(sorted.slice(2));
+  });
+
+  it('honors the since filter using publisher.last_validated', async () => {
+    const oldDate = new Date('2026-01-01T00:00:00Z');
+    const newDate = new Date('2026-05-19T00:00:00Z');
+    await insertPublisher({
+      domain: PUB_DIRECT,
+      discovery_method: 'direct',
+      last_validated: oldDate,
+      adagents: { authorized_agents: [{ url: AGENT_URL, authorization_type: 'all' }] },
+    });
+    await insertAuthz({ agent_url: AGENT_URL, publisher_domain: PUB_DIRECT });
+    await insertPublisher({
+      domain: PUB_MANAGED,
+      discovery_method: 'direct',
+      last_validated: newDate,
+      adagents: { authorized_agents: [{ url: AGENT_URL, authorization_type: 'all' }] },
+    });
+    await insertAuthz({ agent_url: AGENT_URL, publisher_domain: PUB_MANAGED });
+
+    const recent = await fedDb.getPublishersForAgentDetail(AGENT_URL, {
+      limit: 100,
+      since: new Date('2026-03-01T00:00:00Z'),
+    });
+    expect(recent.map(r => r.publisher_domain)).toEqual([PUB_MANAGED]);
+  });
+
+  it('does not leak other agents into the result', async () => {
+    await insertPublisher({
+      domain: PUB_DIRECT,
+      discovery_method: 'direct',
+      adagents: { authorized_agents: [{ url: OTHER_AGENT_URL, authorization_type: 'all' }] },
+    });
+    await insertAuthz({ agent_url: OTHER_AGENT_URL, publisher_domain: PUB_DIRECT });
+
+    const rows = await fedDb.getPublishersForAgentDetail(AGENT_URL, { limit: 100 });
+    expect(rows).toEqual([]);
+  });
+});

--- a/server/tests/integration/registry-api-agent-publishers.test.ts
+++ b/server/tests/integration/registry-api-agent-publishers.test.ts
@@ -1,0 +1,202 @@
+/**
+ * HTTP-level integration tests for `GET /api/v1/agents/{agent_url}/publishers`,
+ * the AAO directory inverse-lookup endpoint (adcp#4823).
+ *
+ * Focused on route-handler parsing logic (status / cursor / since / limit /
+ * ETag / 404 vs 200-empty) that the DB-level integration test
+ * (`registry-agent-publishers-detail.test.ts`) doesn't exercise. The DB
+ * test covers the SQL shape; this test covers everything between the wire
+ * and the DB call.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import request from 'supertest';
+import type { Pool } from 'pg';
+import { HTTPServer } from '../../src/http.js';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+
+const RUN_SUFFIX = Math.random().toString(36).slice(2, 8);
+const AGENT_URL = `https://route-${RUN_SUFFIX}.directorytest.example`;
+const ABSENT_AGENT_URL = `https://absent-${RUN_SUFFIX}.directorytest.example`;
+const PUB_A = `route-a-${RUN_SUFFIX}.directorytest.example`;
+const PUB_B = `route-b-${RUN_SUFFIX}.directorytest.example`;
+const PUB_REVOKED = `route-revoked-${RUN_SUFFIX}.directorytest.example`;
+const ALL_PUBS = [PUB_A, PUB_B, PUB_REVOKED];
+
+describe('GET /api/v1/agents/{agent_url}/publishers (HTTP)', () => {
+  let server: HTTPServer;
+  let app: unknown;
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:53198/adcp_test',
+    });
+    await runMigrations();
+    server = new HTTPServer();
+    await server.start(0);
+    app = server.app;
+  });
+
+  afterAll(async () => {
+    await pool.query(
+      `DELETE FROM agent_property_authorizations
+       WHERE agent_url = ANY($1::text[])`,
+      [[AGENT_URL, ABSENT_AGENT_URL]],
+    );
+    await pool.query('DELETE FROM discovered_properties WHERE publisher_domain = ANY($1::text[])', [ALL_PUBS]);
+    await pool.query('DELETE FROM agent_publisher_authorizations WHERE agent_url = ANY($1::text[])', [[AGENT_URL, ABSENT_AGENT_URL]]);
+    await pool.query('DELETE FROM publishers WHERE domain = ANY($1::text[])', [ALL_PUBS]);
+    await server?.stop();
+    await closeDatabase();
+  });
+
+  async function clearFixtures() {
+    await pool.query(
+      `DELETE FROM agent_property_authorizations
+       WHERE agent_url = ANY($1::text[])`,
+      [[AGENT_URL, ABSENT_AGENT_URL]],
+    );
+    await pool.query('DELETE FROM discovered_properties WHERE publisher_domain = ANY($1::text[])', [ALL_PUBS]);
+    await pool.query('DELETE FROM agent_publisher_authorizations WHERE agent_url = ANY($1::text[])', [[AGENT_URL, ABSENT_AGENT_URL]]);
+    await pool.query('DELETE FROM publishers WHERE domain = ANY($1::text[])', [ALL_PUBS]);
+  }
+
+  beforeEach(async () => {
+    await clearFixtures();
+  });
+
+  async function seedAuthorized(domain: string) {
+    await pool.query(
+      `INSERT INTO publishers (domain, adagents_json, source_type, domain_verified, last_validated, discovery_method)
+       VALUES ($1, $2::jsonb, 'adagents_json', true, NOW(), 'direct')`,
+      [domain, JSON.stringify({ authorized_agents: [{ url: AGENT_URL, authorization_type: 'all' }] })],
+    );
+    await pool.query(
+      `INSERT INTO agent_publisher_authorizations (agent_url, publisher_domain, source, discovered_at, last_validated)
+       VALUES ($1, $2, 'adagents_json', NOW(), NOW())`,
+      [AGENT_URL, domain],
+    );
+  }
+
+  async function seedRevoked(domain: string) {
+    await pool.query(
+      `INSERT INTO publishers (domain, adagents_json, source_type, domain_verified, last_validated, discovery_method)
+       VALUES ($1, $2::jsonb, 'adagents_json', true, NOW(), 'direct')`,
+      [
+        domain,
+        JSON.stringify({
+          authorized_agents: [{ url: AGENT_URL, authorization_type: 'all' }],
+          revoked_publisher_domains: [{ publisher_domain: domain, revoked_at: '2026-05-01T00:00:00Z' }],
+        }),
+      ],
+    );
+    await pool.query(
+      `INSERT INTO agent_publisher_authorizations (agent_url, publisher_domain, source, discovered_at, last_validated)
+       VALUES ($1, $2, 'adagents_json', NOW(), NOW())`,
+      [AGENT_URL, domain],
+    );
+  }
+
+  const url = (agentUrl: string, qs = '') =>
+    `/api/v1/agents/${encodeURIComponent(agentUrl)}/publishers${qs}`;
+
+  it('returns 404 for an agent never indexed', async () => {
+    const res = await request(app).get(url(ABSENT_AGENT_URL));
+    expect(res.status).toBe(404);
+    expect(res.body).toMatchObject({ agent_url: expect.any(String) });
+  });
+
+  it('returns 200 with publishers for an indexed agent', async () => {
+    await seedAuthorized(PUB_A);
+    const res = await request(app).get(url(AGENT_URL));
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      agent_url: expect.any(String),
+      directory_indexed_at: expect.any(String),
+      publishers: expect.arrayContaining([
+        expect.objectContaining({
+          publisher_domain: PUB_A,
+          discovery_method: 'direct',
+          status: 'authorized',
+        }),
+      ]),
+      next_cursor: null,
+    });
+  });
+
+  it('returns 200 + empty (not 404) when filters exclude all rows', async () => {
+    await seedAuthorized(PUB_A);
+    // Filter to only `revoked` — there are none, but the agent IS indexed.
+    const res = await request(app).get(url(AGENT_URL, '?status=revoked'));
+    expect(res.status).toBe(200);
+    expect(res.body.publishers).toEqual([]);
+    expect(res.body.directory_indexed_at).toBeNull();
+  });
+
+  it('rejects malformed percent-encoding with 400', async () => {
+    // %E0%A4 is a malformed UTF-8 sequence; decodeURIComponent throws.
+    const res = await request(app).get('/api/v1/agents/%E0%A4/publishers');
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects invalid status values with 400', async () => {
+    const res = await request(app).get(url(AGENT_URL, '?status=banned'));
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/status/i);
+  });
+
+  it('rejects invalid since with 400', async () => {
+    const res = await request(app).get(url(AGENT_URL, '?since=not-a-date'));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects invalid cursor with 400', async () => {
+    // Cursor with embedded control character (after base64url decode).
+    const cursor = Buffer.from('foobar', 'utf8').toString('base64url');
+    const res = await request(app).get(url(AGENT_URL, `?cursor=${cursor}`));
+    expect(res.status).toBe(400);
+  });
+
+  it('honors ETag with 304 on If-None-Match', async () => {
+    await seedAuthorized(PUB_A);
+    const first = await request(app).get(url(AGENT_URL));
+    expect(first.status).toBe(200);
+    const etag = first.headers['etag'];
+    expect(etag).toBeTruthy();
+    const second = await request(app).get(url(AGENT_URL)).set('If-None-Match', etag);
+    expect(second.status).toBe(304);
+  });
+
+  it('paginates via opaque cursor', async () => {
+    await seedAuthorized(PUB_A);
+    await seedAuthorized(PUB_B);
+    const sorted = [PUB_A, PUB_B].sort();
+
+    const page1 = await request(app).get(url(AGENT_URL, '?limit=1'));
+    expect(page1.status).toBe(200);
+    expect(page1.body.publishers).toHaveLength(1);
+    expect(page1.body.publishers[0].publisher_domain).toBe(sorted[0]);
+    expect(page1.body.next_cursor).toBeTruthy();
+
+    const page2 = await request(app).get(url(AGENT_URL, `?limit=1&cursor=${page1.body.next_cursor}`));
+    expect(page2.status).toBe(200);
+    expect(page2.body.publishers).toHaveLength(1);
+    expect(page2.body.publishers[0].publisher_domain).toBe(sorted[1]);
+    expect(page2.body.next_cursor).toBeNull();
+  });
+
+  it('surfaces revoked rows only when status=revoked is requested', async () => {
+    await seedRevoked(PUB_REVOKED);
+    await seedAuthorized(PUB_A);
+
+    const defaultRes = await request(app).get(url(AGENT_URL));
+    expect(defaultRes.status).toBe(200);
+    expect(defaultRes.body.publishers.map((p: { publisher_domain: string }) => p.publisher_domain)).toEqual([PUB_A]);
+
+    const bothRes = await request(app).get(url(AGENT_URL, '?status=authorized,revoked'));
+    expect(bothRes.status).toBe(200);
+    const domains = bothRes.body.publishers.map((p: { publisher_domain: string }) => p.publisher_domain).sort();
+    expect(domains).toEqual([PUB_A, PUB_REVOKED].sort());
+  });
+});

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -3436,6 +3436,137 @@ paths:
                   - agent_url
                   - domains
                   - count
+  /api/v1/agents/{encodedUrl}/publishers:
+    get:
+      operationId: getPublishersForAgent
+      summary: AAO directory inverse-lookup
+      description: |-
+        Given a percent-encoded `agent_url`, returns the publishers whose adagents.json authorizes that agent, with provenance (`discovery_method`, `manager_domain`), per-publisher property counts (`properties_authorized`, `properties_total`, scoped to this publisher only — never network-wide), signing-key pin status, and lifecycle state (`authorized` / `revoked`).
+
+        Spec: [docs/aao/directory-api.mdx](/docs/aao/directory-api) (adcp#4823). This endpoint is the spec-compliant richer-shape replacement for the legacy `/api/registry/lookup/agent/{agentUrl}/domains`, which returns domain strings only.
+      tags:
+        - Authorization Lookups
+      parameters:
+        - schema:
+            type: string
+            description: Percent-encoded agent_url
+          required: true
+          description: Percent-encoded agent_url
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+            format: date-time
+            description: ISO 8601 — return only publishers with last_verified_at ≥ since
+          required: false
+          description: ISO 8601 — return only publishers with last_verified_at ≥ since
+          name: since
+          in: query
+        - schema:
+            type: string
+            description: Opaque pagination cursor returned by a prior response
+          required: false
+          description: Opaque pagination cursor returned by a prior response
+          name: cursor
+          in: query
+        - schema:
+            type: string
+            description: "Comma-separated subset of {authorized, revoked}. Default: authorized."
+          required: false
+          description: "Comma-separated subset of {authorized, revoked}. Default: authorized."
+          name: status
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            description: Page size, default 200, max 1000
+          required: false
+          description: Page size, default 200, max 1000
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Publishers authorizing the agent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  directory_indexed_at:
+                    type:
+                      - string
+                      - "null"
+                    format: date-time
+                    description: Most recent per-publisher refresh in this page. Null on empty pages (no anchor).
+                  publishers:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        publisher_domain:
+                          type: string
+                        discovery_method:
+                          type: string
+                          enum:
+                            - direct
+                            - authoritative_location
+                            - ads_txt_managerdomain
+                            - adagents_authoritative
+                        manager_domain:
+                          type:
+                            - string
+                            - "null"
+                        properties_authorized:
+                          type: integer
+                          minimum: 0
+                        properties_total:
+                          type: integer
+                          minimum: 0
+                        signing_keys_pinned:
+                          type: boolean
+                        status:
+                          type: string
+                          enum:
+                            - authorized
+                            - revoked
+                        last_verified_at:
+                          type: string
+                          format: date-time
+                      required:
+                        - publisher_domain
+                        - discovery_method
+                        - manager_domain
+                        - properties_authorized
+                        - properties_total
+                        - signing_keys_pinned
+                        - status
+                        - last_verified_at
+                  next_cursor:
+                    type:
+                      - string
+                      - "null"
+                required:
+                  - agent_url
+                  - directory_indexed_at
+                  - publishers
+                  - next_cursor
+        "304":
+          description: Not modified (If-None-Match matched)
+        "400":
+          description: Invalid agent_url, cursor, since, or status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Directory has never indexed any publisher referencing this agent_url. Distinct from 200 + empty.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /api/registry/operator:
     get:
       operationId: lookupOperator

--- a/static/schemas/source/aao/agent-publishers.json
+++ b/static/schemas/source/aao/agent-publishers.json
@@ -16,9 +16,9 @@
       "description": "Canonicalized echo of the agent_url that was looked up. Lowercase host, default port stripped, trailing slash on path component normalized — matches the canonicalization the SDK applies in `verify_agent_authorization`."
     },
     "directory_indexed_at": {
-      "type": "string",
+      "type": ["string", "null"],
       "format": "date-time",
-      "description": "When the directory last completed a refresh of any publisher in this result. Provenance anchor for the consumer's own cache."
+      "description": "When the directory last completed a refresh of any publisher in this result. Provenance anchor for the consumer's own cache. NULL on empty pages — there's no per-publisher anchor to report; consumers SHOULD treat a null value as 'no freshness assertion for this response' and not advance their own cache freshness."
     },
     "publishers": {
       "type": "array",


### PR DESCRIPTION
## Summary

Server-side implementation of the AAO directory inverse-lookup endpoint specified in #4823 / PR #4828. Returns the publishers whose `adagents.json` authorizes a given `agent_url`, with provenance, per-publisher property counts, signing-key pin status, and lifecycle state.

## What's here

**`server/src/db/federated-index-db.ts`** — new `getPublishersForAgentDetail(agentUrl, opts)`. Unions the legacy `agent_publisher_authorizations` arm and the catalog-side `v_effective_agent_authorizations` arm (same dual-read pattern as `getDomainsForAgent`), joins to the `publishers` overlay for `discovery_method` / `manager_domain` / cached `adagents_json` JSONB, and derives the response shape entirely in SQL:

- `properties_total` / `properties_authorized` — correlated subqueries scoped to **this publisher only**, never network-wide
- `signing_keys_pinned` — walks `adagents_json->'authorized_agents'` matching the canonicalized agent URL, true iff `signing_keys[]` is a non-empty array
- `status` — `revoked` when the parent file lists this `publisher_domain` in `revoked_publisher_domains[]`; otherwise `authorized`

**`server/src/routes/registry-api.ts`** — new `GET /v1/agents/:encodedUrl/publishers` mounted next to the existing legacy `/registry/lookup/agent/:agentUrl/domains` (kept; the new path is the spec-compliant richer shape). Handles `since`, `cursor` (base64url-encoded `publisher_domain` for stable ASC pagination), `status` (comma-separated filter), `limit` (1..1000, default 200), `If-None-Match`, and 200-vs-404 disambiguation per the spec.

**`server/src/federated-index.ts`** — wrapper so the route uses the federated-index facade.

**`server/tests/integration/registry-agent-publishers-detail.test.ts`** — covers: empty result, direct-discovery row with `signing_keys_pinned: true`, `ads_txt_managerdomain` with `manager_domain` populated, empty/missing `signing_keys`, `status: revoked`, agent-URL canonicalization on the JSONB side (mixed case + trailing slash), cursor pagination, `since` filter, isolation from other agents' authorizations.

## Design notes

**Per-publisher count scoping.** Counts are scoped to the row's `publisher_domain` only — never network-wide. So `recipeswithessentialoils.com` returns `{ properties_authorized: 1, properties_total: 1 }`, and the operator sees 6,800 such rows summing to the network total. Avoids the "12/12 reads as full auth but really means 12-of-6800-network" misread the triage flagged on #4823.

**Existing data covers everything.** The `publishers` table already has `discovery_method` (migration 470) and `manager_domain`. `adagents_json` JSONB blob is the source for `signing_keys_pinned` and `status: revoked` checks. No new migration needed.

**Single SQL query.** The cafemedia case is the design driver — 6,800 publishers per agent. The implementation does one round-trip; JSONB ops (`jsonb_array_elements`, `jsonb_typeof`, `jsonb_array_length`) handle the per-row derivations.

**404 vs 200-empty disambiguation.** Only does the second probe (unfiltered detail query) when filters are at their defaults and the page is empty. With a cursor or `since` filter in effect, an empty page is a legitimate 200 — caller has paged off the end or filtered everything out.

## Out of scope

- `adagents_authoritative` as a fourth `discovery_method` value. The spec schema (in #4828) allows it; the crawler currently only emits the three values from migration 470. Adding the fourth requires crawler changes to detect inline-resolution discovery via parent-file `properties[].publisher_domain` matching. Filed as follow-up under #4836.
- `?include=properties` for inline property detail — counts-only v1 per the spec.
- Authentication. Public endpoint with anonymous rate limiting via `registryReadRateLimiter`.

## Dependencies

- Spec PR #4828 (merged) defines the endpoint shape this implements.
- Spec PR #4827 (merged) defines the inline resolution rule that `properties_total` will rely on once the crawler is taught to count parent-file inline properties; today the count comes from `discovered_properties` which the crawler already populates for both direct and managed-network shapes.

Resolves #4836.

## Test plan

- [x] Typecheck passes (`npm run typecheck`)
- [ ] Reviewer: integration test runs on CI (file lives under `server/tests/integration/`, not in the precommit `tests/` glob)
- [ ] Reviewer: hand-check the SQL query plan on a representative agent — single round-trip even with 1000-row result, JSONB ops not torpedoed by missing GIN index
- [ ] Reviewer: confirm `discovery_method: 'direct'` fallback in the route is the right call when `publishers.discovery_method` is NULL (legacy rows). Currently defaults to `'direct'`; alternative is to suppress that field entirely on null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)