### PR TITLE
docs(adagents): add authorization_type companion-field reference table

### DIFF
--- a/.changeset/4776-authorization-type-companion-table.md
+++ b/.changeset/4776-authorization-type-companion-table.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": patch
+---
+
+docs(adagents): add `authorization_type` → companion-field quick-reference table at the top of the Authorization Patterns section, plus a `<Warning>` callout on the `inline_properties` naming exception (companion field is `properties`, not `inline_properties`). Schema `description` strings on the `inline_properties` `oneOf` branch updated to surface the same exception where IDEs and linters display it. "Four patterns" count corrected to "six authorization types" (the two signal-side values were absent from the prose count). Non-normative — no fields, enums, or `required` arrays change.
+
+Closes #4776.

--- a/docs/governance/property/adagents.mdx
+++ b/docs/governance/property/adagents.mdx
@@ -324,7 +324,20 @@ Absolute cache caps and refresh floors for authoritative files live in [Managed 
 
 ## Authorization Patterns
 
-AdCP supports four authorization patterns, each optimized for different use cases:
+AdCP supports six `authorization_type` values, each optimized for different use cases. The table below maps each value to the companion field that carries the selector — useful as a quick reference when writing or validating `adagents.json`:
+
+| `authorization_type` | Companion field | Carries | Pattern |
+|---|---|---|---|
+| `property_ids` | `property_ids[]` | IDs into the top-level `properties[]` of the same file | [Pattern 1](#pattern-1-property-ids-direct-references) |
+| `property_tags` | `property_tags[]` | Tags into the top-level `properties[]` of the same file | [Pattern 2](#pattern-2-property-tags-efficient-grouping) |
+| `inline_properties` | `properties[]` *(see warning below)* | Property objects defined directly on the agent entry | [Pattern 3](#pattern-3-inline-properties) |
+| `publisher_properties` | `publisher_properties[]` | Per-publisher selectors that resolve against each listed publisher's `adagents.json` (or the parent file's inline `properties[]`) | [Pattern 4](#pattern-4-publisher-property-references) |
+| `signal_ids` | `signal_ids[]` | IDs into the top-level `signals[]` of the same file | Signal-provider entries (see `signals` schema) |
+| `signal_tags` | `signal_tags[]` | Tags into the top-level `signals[]` of the same file | Signal-provider entries (see `signals` schema) |
+
+<Warning>
+  **`inline_properties` companion field is `properties`, not `inline_properties`.** It is the only `authorization_type` whose companion field name does not mirror the discriminator value. Validators reject `inline_properties` entries that carry a top-level `inline_properties` array but no `properties`. See [Pattern 3](#pattern-3-inline-properties) for an example.
+</Warning>
 
 ### Pattern 1: Property IDs (Direct References)
 
@@ -523,7 +536,7 @@ Inline resolution is a **per-domain optimization**: a consumer MAY use inline re
 
 ## Authorization Qualifiers
 
-The four `authorization_type` patterns above answer **which inventory** an agent can sell. The optional qualifiers below answer **how** that inventory is being made available.
+The four property-side `authorization_type` patterns above answer **which inventory** an agent can sell; the two signal-side values (`signal_ids`, `signal_tags`) carry the same shape for `signals[]`. The optional qualifiers below answer **how** that inventory is being made available.
 
 ### `delegation_type`
 

--- a/static/schemas/source/adagents.json
+++ b/static/schemas/source/adagents.json
@@ -402,11 +402,11 @@
                   "authorization_type": {
                     "type": "string",
                     "const": "inline_properties",
-                    "description": "Discriminator indicating authorization by inline property definitions"
+                    "description": "Discriminator indicating authorization by inline property definitions. Companion field is `properties` (not `inline_properties`) — the only authorization_type whose companion field name does not mirror the discriminator value."
                   },
                   "properties": {
                     "type": "array",
-                    "description": "Specific properties this agent is authorized for (alternative to property_ids/property_tags)",
+                    "description": "Specific properties this agent is authorized for, defined inline on the agent entry (alternative to property_ids/property_tags). Note: this is the companion field for `authorization_type: \"inline_properties\"` — the field is named `properties`, not `inline_properties`.",
                     "items": {
                       "$ref": "/schemas/core/property.json"
                     },


### PR DESCRIPTION
Closes #4776. Replaces the broken-tree #4809 (12,730-file diff from stale base).

## Summary

Publishers hit trial-and-error wiring up `authorized_agents[]` entries because the docs described patterns in prose but provided no quick-reference mapping from `authorization_type` value to required companion field. The `inline_properties` variant is the main footgun: its companion field is `properties`, not `inline_properties` — the only type that doesn't mirror the discriminator. The signal-side values (`signal_ids`, `signal_tags`) were absent from the Authorization Patterns prose entirely.

## Changes

- **`docs/governance/property/adagents.mdx`** — adds a six-row quick-reference table at the top of the Authorization Patterns section, plus a `<Warning>` callout on Pattern 3 naming the `inline_properties` → `properties` exception. Corrects the stale "four patterns" count to acknowledge the two signal-side values.
- **`static/schemas/source/adagents.json`** — updates the `description` strings on the `inline_properties` `oneOf` branch (`authorization_type` discriminator + `properties` companion field) to surface the naming exception where IDEs and linters display it.
- **`.changeset/4776-authorization-type-companion-table.md`** — patch.

## Non-breaking justification

All changes are additive prose and non-normative schema `description` string updates. No fields, enum values, or `required` arrays are added or removed. Existing consumers are unaffected.

## Validation

- `npm run test:schemas` — passes
- `npm run lint:schema-links` — passes
- Diff: 3 files, +24/-4.