### PR TITLE
fix(crawler): also fan publisher_properties[] from crawlSingleDomain + catalog variant

### DIFF
--- a/.changeset/fanout-singledomain-hotfix.md
+++ b/.changeset/fanout-singledomain-hotfix.md
@@ -1,0 +1,10 @@
+---
+---
+
+fix(crawler): also fan publisher_properties[].publisher_domains[] from crawlSingleDomain + crawlSingleDomainForCatalog
+
+#4840 wired the fan-out helper into the two periodic-crawl loops (L457 registered publishers, L542 sales-agent claimed publishers) but missed the on-demand `crawlSingleDomain` path (called by `POST /api/registry/crawl-request`) and `crawlSingleDomainForCatalog` (called by the manager revalidation queue worker). Both iterate `authorized_agents[]` independently and need the same fan-out call.
+
+Symptom: admin-triggered crawl of cafemedia.com refreshed the manifest cache (`last_verified_at` updated) but didn't synthesize the 6,800 child rows — the directory inverse-lookup kept returning a single `cafemedia.com` row with `properties_total: 0`.
+
+Fix: add `await this.fanOutPublisherPropertiesAuthorizations(authorizedAgent, domain)` inside both per-agent loops (`crawlSingleDomain` at line ~1346 and `crawlSingleDomainForCatalog` at line ~1620), mirroring the periodic-crawl paths.

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -1343,6 +1343,8 @@ export class CrawlerService {
           authorizedAgent.authorized_for,
           authorizedAgent.property_ids
         );
+
+        await this.fanOutPublisherPropertiesAuthorizations(authorizedAgent, domain);
       }
       await this.reconcileLegacyAdagentsAgents(domain, validation.raw_data as AdagentsManifest);
 
@@ -1618,6 +1620,8 @@ export class CrawlerService {
         authorizedAgent.authorized_for,
         authorizedAgent.property_ids
       );
+
+      await this.fanOutPublisherPropertiesAuthorizations(authorizedAgent, domain);
     }
     await this.reconcileLegacyAdagentsAgents(domain, validation.raw_data as AdagentsManifest);
 


### PR DESCRIPTION
## Summary

Hotfix to #4840. The fan-out was wired into the two periodic-crawl loops but missed the on-demand `crawlSingleDomain` path (called by `POST /api/registry/crawl-request`) and `crawlSingleDomainForCatalog` (called by the manager revalidation queue worker).

## Symptom

Admin-triggered crawl of cafemedia.com on agenticadvertising.org refreshed the manifest cache (`last_verified_at` updated to 14:53 UTC) but didn't synthesize the 6,800 child rows. Production endpoint kept returning:

```json
{
  "publishers": [{
    "publisher_domain": "cafemedia.com",
    "discovery_method": "direct",
    "properties_authorized": 0,
    "properties_total": 0,
    "last_verified_at": "2026-05-20T14:53:31.264Z"
  }]
}
```

## Fix

Two lines: `await this.fanOutPublisherPropertiesAuthorizations(authorizedAgent, domain)` inside the `crawlSingleDomain` per-agent loop (`crawler.ts:~1346`) and the `crawlSingleDomainForCatalog` loop (`~1620`).

## Verification after deploy

```
curl -X POST 'https://agenticadvertising.org/api/registry/crawl-request' \
  -H "Authorization: Bearer \$ADMIN_API_KEY" \
  -H 'Content-Type: application/json' \
  -d '{"domain":"cafemedia.com"}'

# wait ~30s for the 2.6MB fetch + 6,800 fan-out writes

curl 'https://agenticadvertising.org/api/v1/agents/https%3A%2F%2Finterchange.io/publishers?limit=1000' | jq '.publishers | length'
# expect 1000 (page 1 of 7)
```

## Test plan

- [x] Typecheck passes
- [ ] Existing fan-out integration tests still cover the helper behavior; the new call sites use the same helper, no new test logic required
- [ ] Reviewer (post-merge): re-run the cafemedia probe and report row counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)