### PR TITLE
spec(aao): pin status= query encoding to repeated-key (#4855)

### DIFF
--- a/.changeset/4855-aao-status-query-encoding.md
+++ b/.changeset/4855-aao-status-query-encoding.md
@@ -1,0 +1,16 @@
+---
+---
+
+fix(aao): pin `status=` query encoding for the directory inverse-lookup endpoint to repeated-key (`?status=authorized&status=revoked`), not comma-separated.
+
+**Why.** PR #4828 defined `GET /v1/agents/{agent_url}/publishers` with a `status` query parameter but never pinned how multiple values are encoded on the wire. Both comma-separated single-value (`?status=authorized,revoked`) and repeated-key (`?status=authorized&status=revoked`) are common HTTP conventions, and OpenAPI's `style: form` produces one or the other depending on `explode`. Two interpretations in the wild means silent mis-filtering: a repeated-key request against a comma-only directory keeps the last value the parser sees; a comma-separated request against a repeated-key-only directory matches the literal string `"authorized,revoked"` and returns nothing.
+
+**Decision.** Repeated-key. It is what `URLSearchParams.append()` produces, what OpenAPI's default `explode: true` produces, and what the TS SDK wrapper in adcp-client#1892 (merged) already ships. It composes cleanly with future values that might contain a comma. Comma-separated input is rejected at the directory with `400` rather than silently coerced — a same-origin parser bug that returns zero rows for a year is worse than an upfront error.
+
+**Changes.**
+
+- `docs/aao/directory-api.mdx` — `status` row in the query-parameter table now reads `string, repeated` and points to the repeated-key convention. Adds a worked example URL, TS/Python client snippets, and the OpenAPI fragment (`style: form, explode: true`). `400 Bad Request` row updated to mention comma-separated input as one of the rejection causes.
+
+No schema change — the response envelope is unaffected. No SDK change — adcp-client#1892 already shipped the repeated-key form.
+
+Resolves #4855.

--- a/docs/aao/directory-api.mdx
+++ b/docs/aao/directory-api.mdx
@@ -28,8 +28,49 @@ GET https://{aao_directory}/v1/agents/{agent_url}/publishers
 |---|---|---|---|
 | `since` | ISO 8601 | unset | Return only publishers whose `last_verified_at` ≥ `since`. Enables incremental sync. |
 | `cursor` | opaque string | unset | Pagination cursor returned by a prior response. Stable across the directory's refresh cycle for the lifetime of the cursor. |
-| `status` | comma-separated | `authorized` | Filter by lifecycle status. v1: `authorized`, `revoked`. |
+| `status` | string, repeated | `authorized` | Filter by lifecycle status. v1: `authorized`, `revoked`. Repeat the key once per value (OpenAPI `style: form, explode: true`). Comma-separated single-value form (`status=authorized,revoked`) is **not** accepted; directories MUST return `400` with an explanation pointing to the repeated-key form. |
 | `limit` | int (1–1000) | 200 | Max publishers per page. |
+
+#### Worked example: filtering by multiple status values
+
+```
+GET /v1/agents/https%3A%2F%2Fsales-agent.example.com%2F/publishers?status=authorized&status=revoked&limit=500
+```
+
+Equivalent in TypeScript:
+
+```ts
+const url = new URL(`${directory}/v1/agents/${encodeURIComponent(agentUrl)}/publishers`);
+url.searchParams.append("status", "authorized");
+url.searchParams.append("status", "revoked");
+url.searchParams.set("limit", "500");
+```
+
+Equivalent in Python (`requests`):
+
+```python
+requests.get(
+    f"{directory}/v1/agents/{quote(agent_url, safe='')}/publishers",
+    params=[("status", "authorized"), ("status", "revoked"), ("limit", "500")],
+)
+```
+
+The OpenAPI fragment for the `status` parameter:
+
+```yaml
+- in: query
+  name: status
+  schema:
+    type: array
+    items:
+      type: string
+      enum: [authorized, revoked]
+  style: form
+  explode: true
+  required: false
+```
+
+Repeated-key was chosen because (a) it is what `URLSearchParams.append()` and OpenAPI's default `explode: true` produce, (b) it composes cleanly with future values that might contain a comma, and (c) it leaves no parser ambiguity at the directory.
 
 ### Response
 
@@ -122,7 +163,7 @@ The directory verifies the `managerdomain` safety rule before returning a row wi
 | Status | Meaning |
 |---|---|
 | `200 OK` | Lookup succeeded. Body MAY have empty `publishers[]`. |
-| `400 Bad Request` | Malformed `agent_url`, invalid cursor, or unknown `status` value. |
+| `400 Bad Request` | Malformed `agent_url`, invalid cursor, unknown `status` value, or `status` supplied as a comma-separated list rather than repeated keys. |
 | `404 Not Found` | Directory has never indexed any publisher referencing this `agent_url`. **Distinct from `200` + empty** (which means the directory has indexed this agent, but no current authorizations resolve). |
 | `429 Too Many Requests` | Rate limit. `Retry-After` header set. Bucket key: `agent_url` (anonymous) plus IP (defense-in-depth). |
 | `5xx` | Directory error. Consumer SHOULD retry with backoff. |


### PR DESCRIPTION
## Summary

Resolves #4855. PR #4828 defined a `status` query parameter on `GET /v1/agents/{agent_url}/publishers` but never pinned the multi-value encoding. Two live interpretations:

1. Comma-separated: `?status=authorized,revoked`
2. Repeated-key: `?status=authorized&status=revoked`

Either alone is fine — the danger is **both at once**: a repeated-key request against a comma-only directory keeps the last value the parser sees; a comma-separated request against a repeated-key-only directory matches the literal string `"authorized,revoked"` and returns zero rows. Silent mis-filtering for a year is the failure mode.

## Decision

**Repeated-key.** Reasons, in order of weight:

- `URLSearchParams.append()` produces it (the default Web Platform path).
- OpenAPI's default `style: form, explode: true` produces it.
- The TS SDK wrapper in [adcp-client#1892](https://github.com/adcontextprotocol/adcp-client/pull/1892) (merged) already ships it.
- Composes cleanly with future values that might contain a comma.

Comma-separated input is **rejected** with `400` rather than tolerantly coerced. An upfront error is better than silent zero-row results.

## Changes

- `docs/aao/directory-api.mdx`
  - `status` row in the query-parameter table: `comma-separated` → `string, repeated`, with normative wording on the wire form and the rejection rule.
  - New worked-example subsection: a full URL, TS (`URLSearchParams.append`), Python (`requests` with `params=[...]`), and the OpenAPI fragment (`style: form, explode: true`).
  - `400 Bad Request` row in the HTTP-semantics table now mentions comma-separated `status` as one of the rejection causes.
- `.changeset/4855-aao-status-query-encoding.md`.

No schema change — the response envelope is unaffected. No SDK change — adcp-client#1892 already shipped the repeated-key form.

## Test plan

- [x] `npm run build:schemas` clean (no schema change but verified the build still passes).
- [x] precommit (vitest, dynamic-imports, typecheck) passes.
- [ ] Reviewer: confirm comma-separated `400` (rather than tolerant coercion) is the right strictness. A counter-argument exists — Postel — but tolerant coercion at the directory plus strict at the SDK is exactly the asymmetry that produces the silent mis-filter.
- [ ] Reviewer: confirm `style: form, explode: true` matches whatever generator the directory implementation will use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)