### PR TITLE
fix(docs): replace phantom FORMAT_INCOMPATIBLE with UNSUPPORTED_FEATURE

### DIFF
--- a/.changeset/fix-format-incompatible-phantom-code.md
+++ b/.changeset/fix-format-incompatible-phantom-code.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix phantom `FORMAT_INCOMPATIBLE` error code on `create_media_buy` docs. The code was referenced in the error table and two response examples on `docs/media-buy/task-reference/create_media_buy.mdx` but was never defined in `static/schemas/source/enums/error-code.json`. SDKs that validate `errors[].code` against the published enum would reject responses built from the docs literally.
+
+Migrated all three references to `UNSUPPORTED_FEATURE` — the enum value whose semantics ("a requested feature or field is not supported by this seller") match the "format not in the product's accepted set" case exactly. The error-table row was also merged with the sibling `UNSUPPORTED_FEATURE` row added in #4845 (which covered the v2 `capability_ids[]` failure modes), so a single row now spans both v1 (`format_ids[]`) and v2 (`capability_ids[]`) format-mismatch cases.
+
+Closes #4852.

--- a/docs/media-buy/task-reference/create_media_buy.mdx
+++ b/docs/media-buy/task-reference/create_media_buy.mdx
@@ -918,8 +918,7 @@ Common errors and resolutions:
 | Error Code | Description | Resolution |
 |------------|-------------|------------|
 | `PRODUCT_NOT_FOUND` | Invalid product_id | Verify product exists via `get_products` |
-| `FORMAT_INCOMPATIBLE` | Format not supported by product | Check product's `format_ids` field |
-| `UNSUPPORTED_FEATURE` | `capability_ids[]` entry doesn't resolve against the target product's `format_options[]` — or the product is v1-only (no `format_options[]` at all) — or the product's `format_options[]` entries don't publish `capability_id` values | Re-author against `format_ids[]`, or pick a `capability_id` from the product's published `format_options[]` |
+| `UNSUPPORTED_FEATURE` | Format not supported by the product — covers both v1 (`format_ids[]` not in the product's accepted formats) and v2 (`capability_ids[]` entry doesn't resolve against the product's `format_options[]`, the product is v1-only with no `format_options[]` at all, or the product's `format_options[]` entries don't publish `capability_id` values) | Check the product's `format_ids` and/or `format_options[]` from `get_products` — re-author against a supported format, or pick a `capability_id` from the product's published `format_options[]` |
 | `BUDGET_TOO_LOW` | Budget below product minimum | Increase budget or choose different product |
 | `TARGETING_TOO_NARROW` | Targeting yields zero inventory | Broaden geographic or audience criteria |
 | `POLICY_VIOLATION` | Brand/product violates policy | Review publisher's content policies |
@@ -931,7 +930,7 @@ Example error response:
 ```json
 {
   "errors": [{
-    "code": "FORMAT_INCOMPATIBLE",
+    "code": "UNSUPPORTED_FEATURE",
     "message": "Product 'prod_d979b543' does not support format 'display_728x90'",
     "field": "packages[0].format_ids",
     "suggestion": "Use display_300x250_image, display_300x250_html, or display_300x250_generative formats"
@@ -1042,7 +1041,7 @@ Invalid format example (v1 path):
 ```json
 {
   "errors": [{
-    "code": "FORMAT_INCOMPATIBLE",
+    "code": "UNSUPPORTED_FEATURE",
     "message": "Product 'ctv_sports_premium' does not support format 'audio_standard_30s'",
     "field": "packages[0].format_ids",
     "supported_formats": [


### PR DESCRIPTION
## Summary

Closes #4852.

`create_media_buy` docs referenced `FORMAT_INCOMPATIBLE` in the error table and two JSON response examples, but the code is not defined in `static/schemas/source/enums/error-code.json`. SDKs that validate `errors[].code` against the published enum would reject responses built from the docs literally — sellers reading the spec either ship a non-conformant code or invent their own.

Surfaced during review of #4845 (added `capability_ids[]` to `PackageRequest`), where the new failure modes were deliberately routed to `UNSUPPORTED_FEATURE` to avoid inheriting the bug.

## Change

Migrated all three references to `UNSUPPORTED_FEATURE` — the enum value whose semantics ("a requested feature or field is not supported by this seller") match the "format not in the product's accepted set" case exactly. The error-table row was also merged with the sibling `UNSUPPORTED_FEATURE` row added in #4845 (which covered the v2 `capability_ids[]` failure modes), so a single row now spans both v1 (`format_ids[]`) and v2 (`capability_ids[]`) format-mismatch cases.

## Files

- `docs/media-buy/task-reference/create_media_buy.mdx` — 1 table row merged, 2 JSON example bodies
- `.changeset/fix-format-incompatible-phantom-code.md` — `patch`

## Test plan

- [ ] CI green
- [ ] Mintlify renders the merged error-table row cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)