### PR TITLE
feat(schema): add SHOULD for capability_id on every format_options[] entry

### DIFF
--- a/.changeset/product-format-declaration-capability-id-should.md
+++ b/.changeset/product-format-declaration-capability-id-should.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+`product-format-declaration.json` `capability_id`: sellers SHOULD publish a stable `capability_id` on every `format_options[]` entry (not just when structurally required to disambiguate). Pairs with the buyer-side `PackageRequest.capability_ids[]` added in 3.1 so sellers reading the 3.1 release notes see the obligation alongside the capability. Products without `capability_id` remain conformant; V2 buyers get `UNSUPPORTED_FEATURE / capability_ids_not_published` and fall back to `format_ids[]`.

--- a/static/schemas/source/core/product-format-declaration.json
+++ b/static/schemas/source/core/product-format-declaration.json
@@ -9,7 +9,7 @@
   "properties": {
     "capability_id": {
       "type": "string",
-      "description": "Optional stable identifier for this format declaration. REQUIRED when the parent product's `format_options` contains multiple declarations sharing the same `format_kind` (so buyers can disambiguate which option a manifest targets via `manifest.capability_id`). Recommended for any declaration that may be referenced by capability_id over time. Format-internal (not a URI). Examples: 'flashtalking_image_300x250', 'pmax_responsive_search'."
+      "description": "Optional stable identifier for this format declaration. REQUIRED when the parent product's `format_options` contains multiple declarations sharing the same `format_kind` (so buyers can disambiguate which option a manifest targets via `manifest.capability_id`). Sellers SHOULD publish a stable `capability_id` on every `format_options[]` entry — not just when structurally required to disambiguate — so that buyers using the v2 authoring path (`PackageRequest.capability_ids[]`) can target this product's format declarations directly. This is not a conformance gate: products without `capability_id` values remain valid, and v2 buyers that encounter a product with no published `capability_id` values may receive `UNSUPPORTED_FEATURE` with `reason: capability_ids_not_published` and SHOULD fall back to `format_ids[]`. Sellers SHOULD NOT change a published `capability_id`. Format-internal (not a URI). Examples: 'flashtalking_image_300x250', 'pmax_responsive_search'."
     },
     "display_name": {
       "type": "string",


### PR DESCRIPTION
Closes #4856

## Summary

`product-format-declaration.json` `capability_id` description update: sellers SHOULD publish a stable `capability_id` on every `format_options[]` entry — not just when structurally required to disambiguate. Pairs the seller-side obligation with the v2 buyer capability (`PackageRequest.capability_ids[]`) added in #4845, so sellers reading 3.1 release notes see the obligation alongside the capability in the same minor.

The change also:
- Fixes "should be stable once published" (informal) → `Sellers SHOULD NOT change a published capability_id` (normative, consistent with `display_name`'s pattern)
- Fixes "V2" → "v2" to match file convention
- Softens "will receive UNSUPPORTED_FEATURE" → "may receive" to accurately reflect the SHOULD on the `reason` field in `package-request.json`

**Non-breaking justification:** Description-only change. The `capability_id` field remains `type: string` and optional in JSON Schema (`required` array unchanged). Existing conformant implementations remain conformant — sellers who omit `capability_id` on single-`format_kind` entries stay valid; the SHOULD creates a normative recommendation, not a mandatory requirement.

**Not patch-eligible for 3.0.x.** The prior description was "Recommended for any declaration that may be referenced by capability_id over time" (informal). Adding explicit RFC 2119 SHOULD language fails the patch-eligibility test (a conformant 3.0.0 implementation that omits `capability_id` entirely is valid but does not satisfy the new SHOULD). Ships on `main` as `3.1.0-beta.N` under pre-mode — correct and intentional.

**Pre-PR review:**
- code-reviewer: approved — no blockers; two wording nits addressed (lowercase "should" → normative, "will receive" → "may receive")
- ad-tech-protocol-expert: approved — non-breaking per spec; `minor` changeset correct; REQUIRED + SHOULD combination is coherent and consistent with existing patterns in this schema

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_017v9EZzS9ZFzexe58cmFc4k

---
_Generated by [Claude Code](https://claude.ai/code/session_017v9EZzS9ZFzexe58cmFc4k)_