### PR TITLE
fix(crawler): skip fan-out when crawl source delegates via ads.txt MANAGERDOMAIN

### DIFF
--- a/.changeset/fanout-skip-managerdomain.md
+++ b/.changeset/fanout-skip-managerdomain.md
@@ -1,0 +1,12 @@
+---
+---
+
+fix(crawler): skip publisher_properties fan-out when crawl source is a delegating child
+
+#4851 wired fan-out into all four crawl call sites, but missed that the crawl SOURCE isn't always the manifest's host. When a crawl hits a publisher that delegates via `ads.txt MANAGERDOMAIN=`, the crawler fetches the file from the manager domain — but the source publisher being processed is the delegating child, not the manager. Firing fan-out from those calls used the **child** as the `manager_domain` attribution for all 6,800 siblings, overwriting whichever sibling got crawled most recently.
+
+**Observed in production:** after the cafemedia crawl, `07.gg.manager_domain = '2foodtrippers.com'` instead of `'cafemedia.com'` — because a 2foodtrippers.com crawl had fired fan-out after the cafemedia crawl and stamped itself as the manager.
+
+**Prospective fix** (crawler.ts): at all four fan-out call sites, gate on `validation.discovery_method !== 'ads_txt_managerdomain'`. Delegating-child crawls skip fan-out; the manager's own crawl handles it.
+
+**Retrospective fix** (migration 487): walk the chain `child.manager_domain → grandparent → root` and reset every `adagents_authoritative` row whose `manager_domain` points to another `adagents_authoritative` row, pointing it at the first non-`adagents_authoritative` ancestor (the actual manager — typically `cafemedia.com` for the Raptive set, `discovery_method='direct'`). Bounded recursion (depth 10) defends against unexpected cycles.

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -479,10 +479,18 @@ export class CrawlerService {
               // (adcp#4823) returns one row per represented publisher
               // instead of one row for the manager. See adcp#4825 for the
               // inline-resolution rule this implements.
-              await this.fanOutPublisherPropertiesAuthorizations(
-                authorizedAgent,
-                pubConfig.domain,
-              );
+              //
+              // Skip when the crawl source is a delegating child (the
+              // file lives at the manager via ads.txt MANAGERDOMAIN). In
+              // that case the manager's own crawl handles fan-out with
+              // correct attribution; firing fan-out here would overwrite
+              // siblings' manager_domain with the delegating child's name.
+              if (validation.discovery_method !== 'ads_txt_managerdomain') {
+                await this.fanOutPublisherPropertiesAuthorizations(
+                  authorizedAgent,
+                  pubConfig.domain,
+                );
+              }
             }
             await this.reconcileLegacyAdagentsAgents(pubConfig.domain, validation.raw_data as AdagentsManifest);
           } else {
@@ -559,7 +567,11 @@ export class CrawlerService {
                 authorizedAgent.property_ids
               );
 
-              await this.fanOutPublisherPropertiesAuthorizations(authorizedAgent, domain);
+              // Skip fan-out when the source publisher delegates via
+              // ads.txt MANAGERDOMAIN — see L482 for rationale.
+              if (validation.discovery_method !== 'ads_txt_managerdomain') {
+                await this.fanOutPublisherPropertiesAuthorizations(authorizedAgent, domain);
+              }
             }
             await this.reconcileLegacyAdagentsAgents(domain, validation.raw_data as AdagentsManifest);
           }
@@ -1344,7 +1356,11 @@ export class CrawlerService {
           authorizedAgent.property_ids
         );
 
-        await this.fanOutPublisherPropertiesAuthorizations(authorizedAgent, domain);
+        // Skip fan-out when the source publisher delegates via ads.txt
+        // MANAGERDOMAIN — the manager's own crawl handles the fan-out.
+        if (validation.discovery_method !== 'ads_txt_managerdomain') {
+          await this.fanOutPublisherPropertiesAuthorizations(authorizedAgent, domain);
+        }
       }
       await this.reconcileLegacyAdagentsAgents(domain, validation.raw_data as AdagentsManifest);
 
@@ -1621,7 +1637,11 @@ export class CrawlerService {
         authorizedAgent.property_ids
       );
 
-      await this.fanOutPublisherPropertiesAuthorizations(authorizedAgent, domain);
+      // Skip fan-out when the source publisher delegates via ads.txt
+      // MANAGERDOMAIN — the manager's own crawl handles the fan-out.
+      if (validation.discovery_method !== 'ads_txt_managerdomain') {
+        await this.fanOutPublisherPropertiesAuthorizations(authorizedAgent, domain);
+      }
     }
     await this.reconcileLegacyAdagentsAgents(domain, validation.raw_data as AdagentsManifest);
 

--- a/server/src/db/migrations/487_fanout_manager_attribution_backfill.sql
+++ b/server/src/db/migrations/487_fanout_manager_attribution_backfill.sql
@@ -1,0 +1,82 @@
+-- Backfill bad fan-out attribution from the brief window between #4851
+-- (fan-out wired into crawlSingleDomain) and this migration. During that
+-- window, when the crawler hit any cafemedia-managed publisher via
+-- ads.txt MANAGERDOMAIN, it ran the fan-out using the SOURCE publisher
+-- (the delegating child) as the manager_domain — overwriting siblings'
+-- manager_domain attribution with whichever child got crawled most
+-- recently.
+--
+-- Result on production: ~6,800 publisher rows had discovery_method =
+-- 'adagents_authoritative' but manager_domain pointing at one of their
+-- siblings (e.g., 07.gg.manager_domain = '2foodtrippers.com') instead
+-- of the actual manager (e.g., cafemedia.com).
+--
+-- Fix: a row whose manager_domain points to another `adagents_authoritative`
+-- row is downstream of a delegation chain. Resolve to the chain's root
+-- (the row whose discovery_method is NOT 'adagents_authoritative'). For
+-- the cafemedia/Raptive set, that resolves to the actual cafemedia.com
+-- row (discovery_method = 'direct').
+--
+-- This is one-shot data cleanup; the prospective fix in crawler.ts
+-- (skip fan-out when validation.discovery_method = 'ads_txt_managerdomain')
+-- prevents re-introduction.
+
+BEGIN;
+
+-- Two-step backfill:
+--  1. For rows currently attributed to another adagents_authoritative
+--     row, find the root manager (the first non-adagents_authoritative
+--     ancestor in the chain).
+--  2. UPDATE those rows to point at the root.
+--
+-- Recursive CTE walks the chain (max depth 10 to defend against cycles
+-- that shouldn't exist but might if data is more broken than we think).
+
+WITH RECURSIVE
+chain AS (
+  -- Seed: every child whose manager points at another fan-out child.
+  SELECT
+    p1.domain AS child_domain,
+    p2.domain AS hop_domain,
+    p2.manager_domain AS next_manager,
+    p2.discovery_method AS hop_discovery_method,
+    1 AS depth
+  FROM publishers p1
+  JOIN publishers p2 ON p2.domain = p1.manager_domain
+  WHERE p1.discovery_method = 'adagents_authoritative'
+    AND p2.discovery_method = 'adagents_authoritative'
+
+  UNION ALL
+
+  -- Walk: follow the chain until we hit a non-adagents_authoritative row
+  -- (the actual manager) or a row with NULL manager_domain.
+  SELECT
+    c.child_domain,
+    p.domain,
+    p.manager_domain,
+    p.discovery_method,
+    c.depth + 1
+  FROM chain c
+  JOIN publishers p ON p.domain = c.next_manager
+  WHERE c.hop_discovery_method = 'adagents_authoritative'
+    AND c.depth < 10
+),
+resolved AS (
+  -- The root manager is the deepest hop whose discovery_method is NOT
+  -- adagents_authoritative. DISTINCT ON keeps one row per child_domain.
+  SELECT DISTINCT ON (child_domain)
+    child_domain,
+    hop_domain AS root_manager_domain
+  FROM chain
+  WHERE hop_discovery_method IS NOT NULL
+    AND hop_discovery_method != 'adagents_authoritative'
+  ORDER BY child_domain, depth DESC
+)
+UPDATE publishers p
+   SET manager_domain = r.root_manager_domain,
+       updated_at = NOW()
+  FROM resolved r
+ WHERE p.domain = r.child_domain
+   AND p.manager_domain != r.root_manager_domain;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Empirical bug found in production after #4851 deployed. The fan-out is wired at all four call sites, but the **source publisher being crawled isn't always the manifest's host**. When a crawl hits a publisher that delegates via `ads.txt MANAGERDOMAIN=`, the file comes from the manager — but the crawl source is the delegating child. Firing fan-out from those calls used the **child** as the `manager_domain` for all 6,800 siblings.

## Observed in production (the smoking gun)

After triggering a cafemedia.com crawl-request:

```bash
$ curl '.../api/registry/publisher?domain=07.gg' | jq '{discovery_method, manager_domain}'
{ "discovery_method": "adagents_authoritative", "manager_domain": "2foodtrippers.com" }
```

07.gg's manager should be `cafemedia.com`. It's `2foodtrippers.com` because a 2foodtrippers.com crawl (via `managerdomain=cafemedia.com` in 2foodtrippers' ads.txt) fired fan-out after the cafemedia crawl and overwrote sibling attribution. The `publishers` UPSERT preserves direct rows but happily overwrites `adagents_authoritative` rows.

## Prospective fix (crawler.ts)

Gate all four fan-out call sites on `validation.discovery_method !== 'ads_txt_managerdomain'`. When the crawl source is a delegating child, skip fan-out; the manager's own crawl handles it with correct attribution.

The four sites (per #4851):
- crawler.ts:482 — main loop, registered publishers
- crawler.ts:570 — main loop, agent-claimed publishers
- crawler.ts:1356 — `crawlSingleDomain` (admin crawl-request)
- crawler.ts:1642 — `crawlSingleDomainForCatalog` (manager revalidation worker)

## Retrospective fix (migration 487)

Recursive CTE walks `child.manager_domain → grandparent → root` and fixes every `adagents_authoritative` row whose `manager_domain` points to another `adagents_authoritative` row, pointing it at the first non-`adagents_authoritative` ancestor (the actual root manager — `cafemedia.com` for the Raptive set, `discovery_method='direct'`). Bounded recursion depth 10 to defend against cycles.

## Out of scope

- More invasive crawler refactor to pass the manifest host (vs source publisher) through the helper chain. The gate above is the minimum surgical fix.

## Test plan

- [x] Typecheck passes
- [ ] Reviewer: confirm migration 487 backfill query plan on production publishers table size
- [ ] After deploy: re-trigger cafemedia.com crawl; probe a sample child (e.g., `07.gg`) and confirm `manager_domain = 'cafemedia.com'` again
- [ ] After deploy: probe the directory endpoint and confirm `discovery_methods: ["adagents_authoritative"]` for the 6,800 Raptive children, all with `manager_domain: "cafemedia.com"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)