### PR TITLE
fix(aao): normalize ?status= encoding to repeated-key; accept both forms

### DIFF
--- a/.changeset/4855-status-query-encoding-normative.md
+++ b/.changeset/4855-status-query-encoding-normative.md
@@ -1,0 +1,14 @@
+---
+---
+
+fix(aao): normalize `?status=` query encoding to repeated-key; accept both forms (#4855)
+
+The `GET /v1/agents/{agent_url}/publishers` endpoint accepted only comma-separated
+`?status=authorized,revoked` but the TS SDK (adcp-client#1892) correctly uses the
+OpenAPI default of repeated-key (`?status=authorized&status=revoked`). Express delivers
+repeated keys as `string[]`; the prior `typeof === 'string'` guard silently treated
+them as a missing param and defaulted to `authorized`-only — a silent wrong-result bug.
+
+The server now coerces `string[]` (repeated-key) to a joined string before splitting,
+making both forms functionally equivalent. Docs updated to declare repeated-key as
+normative; comma-separated noted as backward-compatible.

--- a/docs/aao/directory-api.mdx
+++ b/docs/aao/directory-api.mdx
@@ -28,7 +28,7 @@ GET https://{aao_directory}/v1/agents/{agent_url}/publishers
 |---|---|---|---|
 | `since` | ISO 8601 | unset | Return only publishers whose `last_verified_at` ≥ `since`. Enables incremental sync. |
 | `cursor` | opaque string | unset | Pagination cursor returned by a prior response. Stable across the directory's refresh cycle for the lifetime of the cursor. |
-| `status` | comma-separated | `authorized` | Filter by lifecycle status. v1: `authorized`, `revoked`. |
+| `status` | repeated key | `authorized` | Filter by lifecycle status. v1: `authorized`, `revoked`. Repeat the key to request multiple values: `?status=authorized&status=revoked`. The comma-separated form (`?status=authorized,revoked`) is also accepted. |
 | `limit` | int (1–1000) | 200 | Max publishers per page. |
 
 ### Response

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -775,7 +775,7 @@ registry.registerPath({
     query: z.object({
       since: z.string().datetime().optional().openapi({ description: "ISO 8601 — return only publishers with last_verified_at ≥ since" }),
       cursor: z.string().optional().openapi({ description: "Opaque pagination cursor returned by a prior response" }),
-      status: z.string().optional().openapi({ description: "Comma-separated subset of {authorized, revoked}. Default: authorized." }),
+      status: z.array(z.enum(["authorized", "revoked"])).optional().openapi({ description: "Lifecycle status filter. Normative form: repeated key (?status=authorized&status=revoked). Comma-separated form also accepted. Default: authorized." }),
       limit: z.coerce.number().int().min(1).max(1000).optional().openapi({ description: "Page size, default 200, max 1000" }),
     }),
   },
@@ -6946,9 +6946,19 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         since = parsed;
       }
 
-      // status filter defaults to authorized-only. Comma-separated list of
-      // {authorized, revoked}. Anything else is a 400.
-      const statusParam = typeof req.query.status === 'string' ? req.query.status : 'authorized';
+      // status filter defaults to authorized-only. Normative form is repeated-key
+      // (?status=authorized&status=revoked, produces string[] in Express); comma-separated
+      // form is also accepted for backward compat. Arrays arrive when a client sends repeated
+      // keys; the string guard would silently default to authorized-only without this coercion.
+      const rawStatus = req.query.status;
+      if (Array.isArray(rawStatus) && rawStatus.some(s => typeof s !== 'string')) {
+        return res.status(400).json({ error: "Invalid status parameter — nested objects not allowed" });
+      }
+      const statusParam = Array.isArray(rawStatus)
+        ? (rawStatus as string[]).join(',')
+        : typeof rawStatus === 'string'
+        ? rawStatus
+        : 'authorized';
       const statusSet = new Set(statusParam.split(',').map(s => s.trim()).filter(Boolean));
       for (const s of statusSet) {
         if (s !== 'authorized' && s !== 'revoked') {

--- a/server/tests/integration/registry-api-agent-publishers.test.ts
+++ b/server/tests/integration/registry-api-agent-publishers.test.ts
@@ -198,5 +198,13 @@ describe('GET /api/v1/agents/{agent_url}/publishers (HTTP)', () => {
     expect(bothRes.status).toBe(200);
     const domains = bothRes.body.publishers.map((p: { publisher_domain: string }) => p.publisher_domain).sort();
     expect(domains).toEqual([PUB_A, PUB_REVOKED].sort());
+
+    // Repeated-key form (?status=authorized&status=revoked) is the normative encoding
+    // and MUST produce the same result. Express delivers repeated keys as string[]; the
+    // route must coerce the array rather than silently defaulting to authorized-only.
+    const repeatedKeyRes = await request(app).get(url(AGENT_URL, '?status=authorized&status=revoked'));
+    expect(repeatedKeyRes.status).toBe(200);
+    const repeatedDomains = repeatedKeyRes.body.publishers.map((p: { publisher_domain: string }) => p.publisher_domain).sort();
+    expect(repeatedDomains).toEqual([PUB_A, PUB_REVOKED].sort());
   });
 });

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -3470,10 +3470,15 @@ paths:
           name: cursor
           in: query
         - schema:
-            type: string
-            description: "Comma-separated subset of {authorized, revoked}. Default: authorized."
+            type: array
+            items:
+              type: string
+              enum:
+                - authorized
+                - revoked
+            description: "Lifecycle status filter. Normative form: repeated key (?status=authorized&status=revoked). Comma-separated form also accepted for backward compatibility. Default: authorized."
           required: false
-          description: "Comma-separated subset of {authorized, revoked}. Default: authorized."
+          description: "Lifecycle status filter. Normative form: repeated key (?status=authorized&status=revoked). Comma-separated form also accepted for backward compatibility. Default: authorized."
           name: status
           in: query
         - schema:


### PR DESCRIPTION
Closes #4855

## Summary

`GET /v1/agents/{agent_url}/publishers` had a **silent wrong-result bug**: the server parsed `?status=` as a comma-separated string, but the TS SDK (adcp-client#1892) correctly uses the OpenAPI default of repeated-key (`?status=authorized&status=revoked`). Express delivers repeated keys as `string[]`; the prior `typeof === 'string'` guard silently treated them as a missing param and defaulted to `authorized`-only — callers asking for both statuses got only authorized publishers.

This PR fixes the coercion, declares repeated-key as normative in the docs and OpenAPI spec, and adds a regression test.

## Files changed

- **`docs/aao/directory-api.mdx`** — `status` table row: "comma-separated" → "repeated key"; adds worked example URL; notes comma-sep is also accepted.
- **`server/src/routes/registry-api.ts`** (line ~778) — Zod schema updated from `z.string()` to `z.array(z.enum(["authorized","revoked"]))`, matching the `verification_mode` pattern already used on this endpoint file.
- **`server/src/routes/registry-api.ts`** (line ~6950) — Route handler: coerces `string[]` (repeated-key) to join'd string before splitting; adds 400 guard for nested-object inputs; removes the silent-default hole.
- **`static/openapi/registry.yaml`** — `status` parameter updated from `type: string` to `type: array` with enum items; description updated. (Static artifact updated in-place; `js-yaml` not available in this environment to regenerate.)
- **`.changeset/4855-status-query-encoding-normative.md`** — `--empty` changeset (docs + server, no protocol schema change).

## Non-breaking justification

Additive: the server now accepts **both** repeated-key (`string[]`) and comma-separated (`string`) forms. Existing callers sending comma-sep continue to work unchanged. New callers using the TS SDK's repeated-key form no longer get silently filtered results.

## Pre-PR review

- **code-reviewer**: approved — no blockers. Nit: new assertion could be its own `it()` block (noted; not fixed, kept co-located with the existing comma-sep test for symmetry).
- **ad-tech-protocol-expert**: approved — repeated-key is OpenAPI 3.1 default for `in: query` array params; consistent with `verification_mode` pattern already in this file. One nit: comma-sep should be noted as backward-compat only, not co-normative (addressed: docs say "also accepted for backward compatibility").

## Build note

`npm run build:schemas` and `npm run build:compliance` fail in this environment due to missing `js-yaml` module (pre-existing, not introduced by this PR — confirmed 4860 errors on baseline vs 4859 with this PR). TypeScript errors in `url-security.ts` and `validator.ts` are also pre-existing. No new TypeScript errors were introduced.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01XuYKjk7akCpYWnzcCon1Ys

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuYKjk7akCpYWnzcCon1Ys)_