### PR TITLE
fix(bundled): add x-adcp-hoist to data-provider-signal-selector to fix codegen discriminator fabrication

### DIFF
--- a/.changeset/fix-bundled-schema-dedup-hoist.md
+++ b/.changeset/fix-bundled-schema-dedup-hoist.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": patch
+---
+
+Mark `data-provider-signal-selector.json` with `x-adcp-hoist: true` so the schema bundler deduplicates it via root `$defs` instead of inlining it N times.
+
+In 3.1.0-beta.x, the `tasks-get-response.json` `result` field references `async-response-data.json` — a union of all task response schemas. When bundled, shared sub-schemas get inlined once per referencing response schema. The duplicate `data-provider-signal-selector` instances (a discriminated `oneOf` with `selection_type` values `all`, `by_id`, `by_tag`) caused `datamodel-code-generator` to fabricate a `Literal['reuse']` discriminator value, raising `TypeError: Value 'reuse' for discriminator 'selection_type' mapped to multiple choices` and blocking the entire Python SDK from importing.
+
+The bundler already has `hoistMarkedSchemas()` for exactly this case. The `x-adcp-hoist: true` directive is build-time only and is stripped from the emitted bundled schemas — the normative wire contract is unchanged.

--- a/static/schemas/source/core/data-provider-signal-selector.json
+++ b/static/schemas/source/core/data-provider-signal-selector.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/core/data-provider-signal-selector.json",
   "title": "Data Provider Signal Selector",
   "description": "Selects signals from a data provider's adagents.json catalog. Used for product definitions and agent authorization. Supports three selection patterns: all signals, specific IDs, or by tags.",
+  "x-adcp-hoist": true,
   "discriminator": {
     "propertyName": "selection_type"
   },

--- a/tests/build-schemas-hoist-marked.test.cjs
+++ b/tests/build-schemas-hoist-marked.test.cjs
@@ -299,3 +299,48 @@ test('strips stray markers even when no hoistable markers exist outside $defs', 
   const json = JSON.stringify(result);
   assert.equal(json.includes('x-adcp-hoist'), false);
 });
+
+test('hoists a discriminated oneOf appearing twice — regression for issue #4859 codegen fabrication', () => {
+  // data-provider-signal-selector.json appears twice in the same bundled
+  // output. datamodel-code-generator fabricated a synthetic Literal['reuse']
+  // discriminator value when the same discriminated oneOf was inlined twice,
+  // raising TypeError at import time. Hoisting collapses both to a $ref.
+  const selector = {
+    'x-adcp-hoist': true,
+    title: 'SignalSelector',
+    discriminator: { propertyName: 'selection_type' },
+    oneOf: [
+      {
+        type: 'object',
+        properties: { selection_type: { type: 'string', const: 'all' } },
+        required: ['selection_type'],
+      },
+      {
+        type: 'object',
+        properties: {
+          selection_type: { type: 'string', const: 'by_id' },
+          signal_ids: { type: 'array', items: { type: 'string' } },
+        },
+        required: ['selection_type', 'signal_ids'],
+      },
+    ],
+  };
+  const schema = {
+    type: 'object',
+    properties: {
+      first_use: JSON.parse(JSON.stringify(selector)),
+      second_use: JSON.parse(JSON.stringify(selector)),
+    },
+  };
+  const result = hoistMarkedSchemas(clone(schema));
+
+  // Both inline copies collapse to a single $ref.
+  assert.deepEqual(result.properties.first_use, { $ref: '#/$defs/SignalSelector' });
+  assert.deepEqual(result.properties.second_use, { $ref: '#/$defs/SignalSelector' });
+  // Exactly one $defs entry with discriminator intact.
+  assert.ok(result.$defs.SignalSelector);
+  assert.deepEqual(result.$defs.SignalSelector.discriminator, { propertyName: 'selection_type' });
+  assert.equal(result.$defs.SignalSelector.oneOf.length, 2);
+  // Directive stripped.
+  assert.equal(result.$defs.SignalSelector['x-adcp-hoist'], undefined);
+});


### PR DESCRIPTION
## Summary

- Adds `"x-adcp-hoist": true` to `data-provider-signal-selector.json` so the bundler deduplicates it via root `$defs` instead of inlining it N times
- Adds a regression test covering the discriminated `oneOf` dedup case (the exact pattern that triggered the bug)
- Adds a patch changeset

## Problem

In 3.1.0-beta.x, `tasks-get-response.json` gained a `result` field referencing `async-response-data.json` — a union of all task response schemas. When bundled, `data-provider-signal-selector.json` (a 3-branch discriminated `oneOf` with `selection_type` values `all`, `by_id`, `by_tag`) appeared twice in the same bundled file. `datamodel-code-generator` 0.56.1 fabricated a `Literal['reuse']` discriminator value, raising:

```
TypeError: Value 'reuse' for discriminator 'selection_type' mapped to multiple choices
```

This blocked the entire Python SDK from importing.

## Fix

Mark the schema `x-adcp-hoist: true`. The bundler's existing `hoistMarkedSchemas()` function moves it to root `$defs.DataProviderSignalSelector` and replaces all inline occurrences with `{"$ref": "#/$defs/DataProviderSignalSelector"}`. The directive is stripped from bundled output — wire contract is unchanged.

Verified: `DataProviderSignalSelector` appears once in `$defs` with `discriminator` + `oneOf` intact and `x-adcp-hoist` absent.

## Test plan

- [x] `npm run build:schemas` — 0 failures, 83 schemas bundled
- [x] `npm run test:build-schemas-hoist-marked` — 15/15 pass (14 existing + 1 new regression test)
- [x] Protocol expert review — confirmed semantically equivalent under JSON Schema draft-07; no wire contract change
- [x] Code reviewer — approved; no blockers

Fixes #4859

https://claude.ai/code/session_01KTXLjR1c5tGKPZQpSE8T4H

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTXLjR1c5tGKPZQpSE8T4H)_