### PR TITLE
fix(aao): implement repeated-key status= encoding per #4858

### DIFF
--- a/.changeset/aao-directory-status-repeated-key.md
+++ b/.changeset/aao-directory-status-repeated-key.md
@@ -1,0 +1,6 @@
+---
+---
+
+fix(aao): implement repeated-key status= encoding per #4858 spec
+
+The directory endpoint at `/v1/agents/{agent_url}/publishers` shipped accepting `?status=authorized,revoked` (comma-separated). Spec PR #4858 pinned the encoding to repeated-key form (`?status=authorized&status=revoked`) with the comma form explicitly rejected. Updating the impl + OpenAPI registration + HTTP integration test to match.

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -775,7 +775,9 @@ registry.registerPath({
     query: z.object({
       since: z.string().datetime().optional().openapi({ description: "ISO 8601 — return only publishers with last_verified_at ≥ since" }),
       cursor: z.string().optional().openapi({ description: "Opaque pagination cursor returned by a prior response" }),
-      status: z.string().optional().openapi({ description: "Comma-separated subset of {authorized, revoked}. Default: authorized." }),
+      status: z.array(z.enum(["authorized", "revoked"])).optional().openapi({
+        description: "Lifecycle status filter — repeat the key once per value (?status=authorized&status=revoked). Default: authorized. The comma-separated single-value form is rejected with 400.",
+      }),
       limit: z.coerce.number().int().min(1).max(1000).optional().openapi({ description: "Page size, default 200, max 1000" }),
     }),
   },
@@ -6946,10 +6948,28 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         since = parsed;
       }
 
-      // status filter defaults to authorized-only. Comma-separated list of
-      // {authorized, revoked}. Anything else is a 400.
-      const statusParam = typeof req.query.status === 'string' ? req.query.status : 'authorized';
-      const statusSet = new Set(statusParam.split(',').map(s => s.trim()).filter(Boolean));
+      // status filter: repeated-key form per spec
+      // (docs/aao/directory-api.mdx — `?status=authorized&status=revoked`).
+      // The comma-separated single-value form is explicitly rejected with
+      // 400 so callers don't silently get unexpected filter behavior when
+      // a future enum value contains a comma. v1 enum: {authorized, revoked}.
+      const rawStatus = req.query.status;
+      let statusValues: string[];
+      if (rawStatus === undefined) {
+        statusValues = ['authorized'];
+      } else if (Array.isArray(rawStatus)) {
+        statusValues = rawStatus.filter((v): v is string => typeof v === 'string');
+      } else if (typeof rawStatus === 'string') {
+        if (rawStatus.includes(',')) {
+          return res.status(400).json({
+            error: "Invalid `status` encoding — repeat the key once per value (?status=authorized&status=revoked). The comma-separated form is not accepted.",
+          });
+        }
+        statusValues = [rawStatus];
+      } else {
+        return res.status(400).json({ error: "Invalid `status` query parameter" });
+      }
+      const statusSet = new Set(statusValues.map(s => s.trim()).filter(Boolean));
       for (const s of statusSet) {
         if (s !== 'authorized' && s !== 'revoked') {
           return res.status(400).json({ error: `Invalid status value '${s}' — supported: authorized, revoked` });

--- a/server/tests/integration/registry-api-agent-publishers.test.ts
+++ b/server/tests/integration/registry-api-agent-publishers.test.ts
@@ -186,7 +186,7 @@ describe('GET /api/v1/agents/{agent_url}/publishers (HTTP)', () => {
     expect(page2.body.next_cursor).toBeNull();
   });
 
-  it('surfaces revoked rows only when status=revoked is requested', async () => {
+  it('surfaces revoked rows when status=revoked is repeated alongside authorized', async () => {
     await seedRevoked(PUB_REVOKED);
     await seedAuthorized(PUB_A);
 
@@ -194,9 +194,15 @@ describe('GET /api/v1/agents/{agent_url}/publishers (HTTP)', () => {
     expect(defaultRes.status).toBe(200);
     expect(defaultRes.body.publishers.map((p: { publisher_domain: string }) => p.publisher_domain)).toEqual([PUB_A]);
 
-    const bothRes = await request(app).get(url(AGENT_URL, '?status=authorized,revoked'));
+    const bothRes = await request(app).get(url(AGENT_URL, '?status=authorized&status=revoked'));
     expect(bothRes.status).toBe(200);
     const domains = bothRes.body.publishers.map((p: { publisher_domain: string }) => p.publisher_domain).sort();
     expect(domains).toEqual([PUB_A, PUB_REVOKED].sort());
+  });
+
+  it('rejects the comma-separated status form with 400 (per #4858 spec)', async () => {
+    const res = await request(app).get(url(AGENT_URL, '?status=authorized,revoked'));
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/repeat the key/i);
   });
 });

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -3470,10 +3470,15 @@ paths:
           name: cursor
           in: query
         - schema:
-            type: string
-            description: "Comma-separated subset of {authorized, revoked}. Default: authorized."
+            type: array
+            items:
+              type: string
+              enum:
+                - authorized
+                - revoked
+            description: "Lifecycle status filter — repeat the key once per value (?status=authorized&status=revoked). Default: authorized. The comma-separated single-value form is rejected with 400."
           required: false
-          description: "Comma-separated subset of {authorized, revoked}. Default: authorized."
+          description: "Lifecycle status filter — repeat the key once per value (?status=authorized&status=revoked). Default: authorized. The comma-separated single-value form is rejected with 400."
           name: status
           in: query
         - schema:


### PR DESCRIPTION
## Summary

Catches the impl up to spec #4858. The directory endpoint at \`/v1/agents/{agent_url}/publishers\` initially accepted \`?status=authorized,revoked\` (comma-separated single-value). #4858 pinned the wire encoding to repeated-key form (\`?status=authorized&status=revoked\`) and required directories to **return 400 on the comma form** so future enum values containing commas don't silently change filter semantics.

## Changes

- **Route handler** (\`registry-api.ts\`) parses \`string[]\` (Express's repeated-key parsing), with explicit 400 on any single string value containing \`,\`.
- **OpenAPI registration** switches \`z.string()\` → \`z.array(z.enum([...]))\` so generated client SDKs serialize the query param in repeated form (matches OpenAPI's default \`style: form, explode: true\`).
- **HTTP integration test** replaces the comma probe with the new repeated form and adds an explicit 400 case for the rejected comma form.

## Test plan

- [x] Typecheck passes
- [x] OpenAPI yaml regenerated
- [ ] Reviewer: confirm Express's default query parser produces \`string[]\` for repeated keys (it does — confirmed in adjacent endpoints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)