### PR TITLE
feat(crawler): include adagents_json-sourced discovered_agents in periodic probe (#4849)

### DIFF
--- a/.changeset/4849-register-publisher-properties-agents.md
+++ b/.changeset/4849-register-publisher-properties-agents.md
@@ -1,0 +1,22 @@
+---
+---
+
+feat(crawler): include adagents_json-sourced discovered_agents in the periodic probe set (#4849)
+
+The periodic probe loop (`refreshAgentSnapshots`) walks `listAllAgents()`, which only returns agents from `member_profiles.agents` (the configured / seed set). Agents that exist only in `discovered_agents` — like `interchange.io`, which is named only in cafemedia's `publisher_properties[]` selector and never appears in any sales-agent's `list_authorized_properties` — never enter the probe set.
+
+Result: capability + health snapshots, `agent_type` promotion, and signing-key-pin freshness all stop at the seed boundary. A manager-file-only agent's index entry sits frozen at first-seen.
+
+**Fix.** New `FederatedIndexService.listAllProbeableAgents()` unions:
+
+1. `listAllAgents()` — registered seed set (unchanged surface for everything else)
+2. `discovered_agents` where `source_type = 'adagents_json'` — agents we learned about by parsing some publisher's `adagents.json`
+
+`source_type = 'list_authorized_properties'` (`agent_claim`) is **intentionally excluded** — those are unverified peer claims; probing them creates churn without bilateral confirmation. Member-profile metadata wins on URL collision (richer name / type / visibility data).
+
+`refreshAgentSnapshots` switches to the new method. No other caller of `listAllAgents` is touched.
+
+**Test coverage** (`server/tests/integration/federated-index-probeable-agents.test.ts`):
+- `adagents_json` discovery → included
+- `list_authorized_properties` discovery → excluded
+- URL collision → member profile wins

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -616,7 +616,13 @@ export class CrawlerService {
   private async refreshAgentSnapshots(agents: Agent[]): Promise<void> {
     log.debug('Refreshing agent health + capability snapshots');
 
-    const allAgents = await this.federatedIndex.listAllAgents();
+    // listAllProbeableAgents unions member-profile registrations with
+    // adagents_json-sourced discovered_agents so manager-file-only agents
+    // (e.g., interchange.io, named only in cafemedia.com's selector with
+    // no seed-set registration of its own) still get periodic probes.
+    // Excludes agent_claim (list_authorized_properties) discoveries
+    // intentionally — those are unverified peer claims. (adcp#4849)
+    const allAgents = await this.federatedIndex.listAllProbeableAgents();
     const knownTypes = new Map<string, string>();
     for (const a of allAgents) {
       if (a.type && a.type !== 'unknown') {

--- a/server/src/federated-index.ts
+++ b/server/src/federated-index.ts
@@ -27,6 +27,45 @@ export class FederatedIndexService {
   // ============================================
 
   /**
+   * List all agents the crawler should periodically probe.
+   *
+   * Two sources, deduplicated by canonical URL:
+   *  - `listAllAgents()` — agents registered in member profiles (the
+   *    configured / seed set)
+   *  - `discovered_agents` where `source_type='adagents_json'` — agents
+   *    we learned about by parsing some publisher's `adagents.json`,
+   *    including manager-file-only agents like `interchange.io` that
+   *    are only ever named in cafemedia.com's selector and never appear
+   *    in any sales-agent's `list_authorized_properties` (adcp#4849).
+   *
+   * `source_type='list_authorized_properties'` (agent_claim) is
+   * intentionally excluded — those are unverified claims from other
+   * agents; probing them creates churn without confirmation.
+   */
+  async listAllProbeableAgents(): Promise<FederatedAgent[]> {
+    const registered = await this.listAllAgents();
+    const discovered = await this.db.getAllDiscoveredAgents();
+
+    const byKey = new Map<string, FederatedAgent>();
+    for (const agent of registered) {
+      const key = canonicalizeAgentUrl(agent.url) ?? agent.url;
+      byKey.set(key, agent);
+    }
+    for (const d of discovered) {
+      if (d.source_type !== 'adagents_json') continue;
+      const key = canonicalizeAgentUrl(d.agent_url) ?? d.agent_url;
+      if (byKey.has(key)) continue; // registered metadata wins
+      byKey.set(key, {
+        url: key,
+        name: d.name || key,
+        type: (d.agent_type as FederatedAgent['type']) || 'unknown',
+        protocol: (d.protocol as 'mcp' | 'a2a') || 'mcp',
+      });
+    }
+    return Array.from(byKey.values());
+  }
+
+  /**
    * List all registered agents, optionally filtered by type.
    *
    * `includeMembersOnly` expands the visibility filter to also include

--- a/server/tests/integration/federated-index-probeable-agents.test.ts
+++ b/server/tests/integration/federated-index-probeable-agents.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Integration test for FederatedIndexService.listAllProbeableAgents
+ * (adcp#4849). The crawler's periodic probe loop iterates this set,
+ * so agents missing from it never get health/capability refresh.
+ *
+ * Pre-#4849, the periodic probe only walked member-profile-registered
+ * agents. Manager-file-only agents (like interchange.io, named only in
+ * cafemedia.com's selector with no seed-set registration) were never
+ * touched. This test pins the union behavior so a future regression
+ * to listAllAgents-only is caught.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import type { Pool } from 'pg';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { FederatedIndexService } from '../../src/federated-index.js';
+
+const RUN_SUFFIX = Math.random().toString(36).slice(2, 8);
+const AGENT_ADAGENTS = `https://adagents-${RUN_SUFFIX}.probeable.example`;
+const AGENT_CLAIM = `https://claim-${RUN_SUFFIX}.probeable.example`;
+const AGENT_REGISTERED = `https://registered-${RUN_SUFFIX}.probeable.example`;
+const ORG_ID = `org_test_probe_${RUN_SUFFIX}`;
+const PROFILE_SLUG = `probe-${RUN_SUFFIX}`;
+
+describe('FederatedIndexService.listAllProbeableAgents (adcp#4849)', () => {
+  let pool: Pool;
+  let svc: FederatedIndexService;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:53198/adcp_test',
+    });
+    await runMigrations();
+    svc = new FederatedIndexService();
+  });
+
+  async function clearFixtures() {
+    await pool.query(
+      `DELETE FROM discovered_agents WHERE agent_url = ANY($1::text[])`,
+      [[AGENT_ADAGENTS, AGENT_CLAIM, AGENT_REGISTERED]],
+    );
+    await pool.query(`DELETE FROM member_profiles WHERE workos_organization_id = $1`, [ORG_ID]);
+    await pool.query(`DELETE FROM organizations WHERE workos_organization_id = $1`, [ORG_ID]);
+  }
+
+  afterAll(async () => {
+    await clearFixtures();
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await clearFixtures();
+  });
+
+  it('includes agents discovered via adagents_json (manager-file-only path)', async () => {
+    await pool.query(
+      `INSERT INTO discovered_agents (agent_url, source_type, source_domain, agent_type, protocol)
+       VALUES ($1, 'adagents_json', $2, 'sales', 'mcp')`,
+      [AGENT_ADAGENTS, 'manager.probeable.example'],
+    );
+    const probeable = await svc.listAllProbeableAgents();
+    expect(probeable.map(a => a.url)).toContain(AGENT_ADAGENTS);
+  });
+
+  it('excludes agents discovered only via list_authorized_properties (agent_claim)', async () => {
+    await pool.query(
+      `INSERT INTO discovered_agents (agent_url, source_type, source_domain, agent_type, protocol)
+       VALUES ($1, 'list_authorized_properties', $2, 'sales', 'mcp')`,
+      [AGENT_CLAIM, 'claimer.probeable.example'],
+    );
+    const probeable = await svc.listAllProbeableAgents();
+    expect(probeable.map(a => a.url)).not.toContain(AGENT_CLAIM);
+  });
+
+  it('member-profile registrations win on URL collision (richer metadata)', async () => {
+    // Seed: same URL, in discovered_agents AND in a member profile.
+    await pool.query(
+      `INSERT INTO discovered_agents (agent_url, source_type, source_domain, agent_type, protocol, name)
+       VALUES ($1, 'adagents_json', 'somepub.example', 'sales', 'mcp', 'old name from discovered')`,
+      [AGENT_REGISTERED],
+    );
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, created_at, updated_at)
+       VALUES ($1, 'Probe Test Org', NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      [ORG_ID],
+    );
+    await pool.query(
+      `INSERT INTO member_profiles (workos_organization_id, display_name, slug, agents, created_at, updated_at)
+       VALUES ($1, 'Probe Test Org', $2, $3::jsonb, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO UPDATE SET agents = EXCLUDED.agents`,
+      [
+        ORG_ID,
+        PROFILE_SLUG,
+        JSON.stringify([{ url: AGENT_REGISTERED, name: 'registered name', type: 'sales', visibility: 'public' }]),
+      ],
+    );
+
+    const probeable = await svc.listAllProbeableAgents();
+    const found = probeable.find(a => a.url === AGENT_REGISTERED);
+    expect(found).toBeDefined();
+    expect(found!.name).toBe('registered name'); // member-profile metadata wins
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #4849 (deeper-issue follow-up flagged during the cafemedia rollout). The periodic probe loop never touched `interchange.io` because it walks `listAllAgents()` — the member-profile registration set — not `discovered_agents`. Manager-file-only agents stayed frozen at first-seen.

## Fix

New `FederatedIndexService.listAllProbeableAgents()` returns the union of:

1. **Member-profile registrations** (`listAllAgents()`, unchanged surface for every other caller)
2. **`discovered_agents` where `source_type='adagents_json'`** — agents learned by parsing some publisher's `adagents.json`

`source_type='list_authorized_properties'` (`agent_claim`) is **intentionally excluded** — those are unverified peer claims and probing them creates churn without bilateral confirmation.

Member-profile metadata wins on URL collision so richer name/type/visibility data isn't shadowed by `discovered_agents` defaults.

`refreshAgentSnapshots` (crawler.ts:616) switches to the new method. **No other caller of `listAllAgents` is touched** — the registered/seed semantics are preserved everywhere they matter (the public registry listing at `/api/registry/agents`, the catalog crawl, etc.).

## Verification after deploy

```bash
# Before #4849: interchange.io's agent_capabilities_snapshot is stale.
# After deploy + one ~60-min crawl cycle: interchange.io should have a
# fresh capabilities_snapshot row.
curl 'https://agenticadvertising.org/api/registry/agents/https%3A%2F%2Finterchange.io/compliance' | jq .last_probed_at
```

## Out of scope

- Per-child re-validation for fan-out publishers (#4850) — separate PR.
- Backoff on probe failure so an unresponsive agent doesn't get re-probed every 60 min — file as follow-up if it bites.

## Test plan

- [x] Typecheck passes
- [x] Integration test covers all three paths (adagents_json included / agent_claim excluded / collision-resolution)
- [ ] Reviewer (post-deploy): re-check production probe loop touches interchange.io within one cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)