### PR TITLE
feat(crawler): schedule periodic re-validation for fan-out child publishers (#4850)

### DIFF
--- a/.changeset/4850-fanout-child-revalidation.md
+++ b/.changeset/4850-fanout-child-revalidation.md
@@ -1,0 +1,19 @@
+---
+---
+
+feat(crawler): schedule periodic re-validation for fan-out child publishers (#4850)
+
+`recordChildPublisherFromManager` (PR #4840) creates `publishers` rows for each child synthesized from a manager file's `publisher_properties[].publisher_domains[]` fan-out, but those rows had **no refresh schedule**. A manager-asserted child stamped `last_validated = NOW()` at fan-out time stayed at that timestamp indefinitely — manager-side revocation only propagated on the next full manager crawl, and the child's own `adagents.json` (if it exists) was never independently fetched.
+
+**Fix.** `recordChildPublisherFromManager` now also enqueues the child into `manager_revalidation_queue` (the existing queue infrastructure from migration 471) with `next_attempt_after = NOW() + INTERVAL '24 hours'`. The existing worker (`processManagerRevalidationQueue`, drain rate 50/5min) picks them up.
+
+**Why reuse `manager_revalidation_queue`** rather than a new table: same shape, same worker, same `crawlSingleDomain` action. The queue row says "re-validate publisher P that delegates to manager M"; that's exactly what fan-out is requesting. Migration 471's `(publisher_domain PRIMARY KEY)` is naturally idempotent.
+
+**24h initial delay** prevents 6,800 fan-out children from immediately storming the crawler on top of the cafemedia fan-out itself. The drain rate spreads them across the following day. `ON CONFLICT DO NOTHING` preserves any existing backoff state (so a child that 404'd recently isn't reset to NOW+24h on the next fan-out — its longer backoff window stays in effect).
+
+**What the worker does per row**: `crawlSingleDomain(child)` runs the full discovery cascade — first tries the child's own `/.well-known/adagents.json`, falls back to `ads.txt MANAGERDOMAIN`. If the child has its own file, it gets promoted to `discovery_method='direct'` with the cached blob (the divergence-detector use case from adcp-client-python#749 part 3 now has data to compare). If the child 404s, `recordFailedAdagentsFetch` records `last_http_status` and the queue row is deleted (re-enqueue happens on the next cafemedia rotation — no infinite loop).
+
+**Tests** (extending `crawler-publisher-properties-fanout.test.ts`):
+- Fan-out enqueues child with `next_attempt_after ≈ NOW + 24h`, `attempts = 0`
+- Re-enqueue preserves existing backoff (idempotent)
+- Self-attribute case (child == manager) skips both publishers write and queue write

--- a/server/src/db/publisher-db.ts
+++ b/server/src/db/publisher-db.ts
@@ -268,6 +268,21 @@ export class PublisherDatabase {
            updated_at = NOW()`,
         [childDomain, managerDomain],
       );
+
+      // Enqueue the child for delayed periodic re-validation (#4850) so a
+      // manager-asserted child eventually gets bilateral confirmation
+      // (or a 404 backoff). Initial delay of 24h prevents 6,800 fan-out
+      // children from immediately storming the crawler — they spread
+      // across the next day's drain ticks. ON CONFLICT DO NOTHING
+      // preserves any existing backoff window (avoid resetting if the
+      // child already 404'd recently).
+      await client.query(
+        `INSERT INTO manager_revalidation_queue
+           (publisher_domain, manager_domain, enqueued_at, next_attempt_after, attempts, last_attempted_at, last_error)
+         VALUES ($1, $2, NOW(), NOW() + INTERVAL '24 hours', 0, NULL, NULL)
+         ON CONFLICT (publisher_domain) DO NOTHING`,
+        [childDomain, managerDomain],
+      );
     } finally {
       client.release();
     }

--- a/server/tests/integration/crawler-publisher-properties-fanout.test.ts
+++ b/server/tests/integration/crawler-publisher-properties-fanout.test.ts
@@ -94,6 +94,80 @@ describe('crawler publisher_properties fan-out (integration)', () => {
       expect(result.rows[0]?.count).toBe('0');
     });
 
+    it('enqueues child for periodic re-validation with 24h initial delay (#4850)', async () => {
+      await publisherDb.recordChildPublisherFromManager({
+        childDomain: CHILD_A,
+        managerDomain: MANAGER,
+      });
+      const queueRow = await query<{
+        publisher_domain: string;
+        manager_domain: string;
+        next_attempt_after: Date;
+        attempts: number;
+      }>(
+        `SELECT publisher_domain, manager_domain, next_attempt_after, attempts
+           FROM manager_revalidation_queue WHERE publisher_domain = $1`,
+        [CHILD_A],
+      );
+      expect(queueRow.rows[0]).toMatchObject({
+        publisher_domain: CHILD_A,
+        manager_domain: MANAGER,
+        attempts: 0,
+      });
+      // First attempt should be ~24 hours from now (allow 1-min slack for clock drift)
+      const expectedAttemptAt = Date.now() + 24 * 60 * 60 * 1000;
+      const actualAttemptAt = new Date(queueRow.rows[0]!.next_attempt_after).getTime();
+      expect(Math.abs(actualAttemptAt - expectedAttemptAt)).toBeLessThan(60 * 1000);
+
+      // Cleanup
+      await pool.query('DELETE FROM manager_revalidation_queue WHERE publisher_domain = $1', [CHILD_A]);
+    });
+
+    it('preserves existing queue backoff on re-enqueue (idempotent)', async () => {
+      // Initial enqueue from fan-out
+      await publisherDb.recordChildPublisherFromManager({
+        childDomain: CHILD_A,
+        managerDomain: MANAGER,
+      });
+      // Manually advance backoff (simulate a recent failed attempt)
+      await pool.query(
+        `UPDATE manager_revalidation_queue
+            SET next_attempt_after = NOW() + INTERVAL '3 days',
+                attempts = 2
+          WHERE publisher_domain = $1`,
+        [CHILD_A],
+      );
+      // Re-enqueue from a subsequent fan-out (same row exists)
+      await publisherDb.recordChildPublisherFromManager({
+        childDomain: CHILD_A,
+        managerDomain: MANAGER,
+      });
+      // Backoff state should be preserved (NOT reset to NOW + 24h)
+      const queueRow = await query<{ next_attempt_after: Date; attempts: number }>(
+        `SELECT next_attempt_after, attempts FROM manager_revalidation_queue WHERE publisher_domain = $1`,
+        [CHILD_A],
+      );
+      expect(queueRow.rows[0]?.attempts).toBe(2); // unchanged
+      const attemptAt = new Date(queueRow.rows[0]!.next_attempt_after).getTime();
+      const threeDaysFromNow = Date.now() + 3 * 24 * 60 * 60 * 1000;
+      expect(Math.abs(attemptAt - threeDaysFromNow)).toBeLessThan(60 * 1000);
+
+      // Cleanup
+      await pool.query('DELETE FROM manager_revalidation_queue WHERE publisher_domain = $1', [CHILD_A]);
+    });
+
+    it('does not enqueue when manager == child (self-attribute no-op skips queue too)', async () => {
+      await publisherDb.recordChildPublisherFromManager({
+        childDomain: MANAGER,
+        managerDomain: MANAGER,
+      });
+      const queueCount = await query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count FROM manager_revalidation_queue WHERE publisher_domain = $1`,
+        [MANAGER],
+      );
+      expect(queueCount.rows[0]?.count).toBe('0');
+    });
+
     it('does not overwrite a child that already has its own adagents_json cached', async () => {
       // Seed a stronger row: child was independently crawled, has its own
       // adagents_json blob and discovery_method=direct.


### PR DESCRIPTION
## Summary

Resolves #4850. `recordChildPublisherFromManager` (PR #4840) created `publishers` rows for fan-out children but never scheduled them for refresh — a manager-asserted child stamped `last_validated = NOW()` at fan-out time stayed at that timestamp indefinitely. This wires children into the existing `manager_revalidation_queue` worker.

## Fix

Two-line addition to `recordChildPublisherFromManager`:

```sql
INSERT INTO manager_revalidation_queue
  (publisher_domain, manager_domain, enqueued_at, next_attempt_after, attempts, ...)
VALUES ($1, $2, NOW(), NOW() + INTERVAL '24 hours', 0, ...)
ON CONFLICT (publisher_domain) DO NOTHING
```

- **24h initial delay** — prevents 6,800 cafemedia children from storming the crawler on top of the cafemedia fan-out itself
- **`ON CONFLICT DO NOTHING`** — preserves existing backoff (idempotent re-enqueue from subsequent fan-outs doesn't reset)
- **Reuses existing queue** (`manager_revalidation_queue` from migration 471) — same shape, same worker, same `crawlSingleDomain` action

## What the worker does per child

`crawlSingleDomain(child)` runs the full discovery cascade:

1. **Try child's own `/.well-known/adagents.json` (direct)**. If present, the child gets promoted to `discovery_method='direct'` with the cached blob. The divergence detector (filed in SDK companion tickets adcp-client-python#749 part 3, etc.) now has real data to compare manager's inline claim against child's own declaration.
2. **Fall back to `ads.txt MANAGERDOMAIN`**. Child's row stays as-is, queue row deletes.
3. **404 on both**. `recordFailedAdagentsFetch` updates `last_http_status`. Queue row deletes — re-enqueue happens on next cafemedia rotation, no infinite loop.

## Out of scope

- **Long-interval periodic re-check** for children that 404'd (the spec text's "30-day re-check"). Today the queue deletes on success; re-enqueue depends on the manager rotating. Worth a follow-up if it bites.
- **Backoff for non-404 failures** — already in place via existing `markRevalidationFailed` schedule (1h / 6h / 24h / 72h).

## Test plan

- [x] Typecheck passes
- [x] Integration tests added: 24h initial delay, idempotent re-enqueue, self-attribute skip
- [ ] Reviewer (post-deploy): probe `manager_revalidation_queue` after a cafemedia crawl, confirm ~6,800 rows with `next_attempt_after` clustered ~24h out

🤖 Generated with [Claude Code](https://claude.com/claude-code)