### PR TITLE
feat(catalog): project publisher_properties fan-out into catalog_agent_authorizations (#4841)

### DIFF
--- a/.changeset/4841-catalog-fanout-projection.md
+++ b/.changeset/4841-catalog-fanout-projection.md
@@ -1,0 +1,31 @@
+---
+---
+
+feat(catalog): project publisher_properties fan-out into catalog_agent_authorizations so partner-sync endpoints see manager-asserted children (#4841)
+
+Closes the gap surfaced after PR #4840 landed fan-out writes in the legacy `agent_publisher_authorizations` arm: the catalog projection in `publisher-db.ts:upsertAdagentsCache` deliberately refuses cross-publisher claims (line 968: "publisher_properties claims a different publisher — cross-publisher refused"). Result: ~6,800 cafemedia child authorization edges existed in the legacy arm but never landed in `catalog_agent_authorizations`. The auth-gated partner-sync endpoints (`/registry/authorizations`, `/registry/authorizations/snapshot`) read the catalog only and missed all of them.
+
+## Design
+
+The existing guard is load-bearing for catalog trust — a hostile manager file can't project authoritative rows for publishers that didn't authorize anything. The guard stays. Instead, the fan-out gets its **own evidence value** so the projection is explicit and consumers can filter:
+
+- **New evidence value `adagents_authoritative`** (migration 488) — distinct from `adagents_json`. Trust profile is lower (manager-asserted, no bilateral confirmation from the publisher's own origin). Per the inline-resolution rule (#4825), the manager file naming the publisher in `publisher_properties[].publisher_domains[]` is the out-of-band corroboration that makes the projection safe.
+- **New writer** `PublisherDatabase.recordCatalogFanoutAuthorization({ agentUrl, childDomain, authorizedFor? })` — INSERT-or-UPDATE into `catalog_agent_authorizations` with `evidence='adagents_authoritative'`, `created_by='system'`, no `property_rid` (publisher-wide row).
+- **Crawler hook** — fan-out helper in `crawler.ts:fanOutPublisherPropertiesAuthorizations` calls the new writer per (agent, child) pair, alongside the existing `recordChildPublisherFromManager` (publishers row) and `recordAgentFromAdagentsJson` (legacy authz row).
+- **Backfill** — migration 488 inserts catalog rows for every existing fan-out edge (`SELECT ... FROM publishers JOIN agent_publisher_authorizations WHERE discovery_method='adagents_authoritative'`). Idempotent — `ON CONFLICT DO NOTHING`.
+- **Evidence-to-source mapping** — the 6 sites in `federated-index-db.ts` that map `v.evidence → source` add `WHEN 'adagents_authoritative' THEN 'adagents_json'` so the legacy `source` field round-trips through the catalog dual-read path correctly.
+
+## What partner-sync consumers see after this lands
+
+`/registry/authorizations?agent_url=https://interchange.io` now returns ~6,800 rows (the cafemedia children), each with `evidence: 'adagents_authoritative'`. Consumers that want bilateral-confirmed-only can filter `evidence=adagents_json`; consumers that want the full picture take both.
+
+The directory inverse-lookup endpoint (#4838) is unchanged — it was already returning these via the legacy-arm union. This PR brings the catalog-only consumers up to parity.
+
+## Tests
+
+- Catalog row shape (evidence, created_by, publisher_domain, property_rid=null)
+- Idempotent re-write
+- Coexists with an `adagents_json` row for the same (agent, publisher) without conflict
+- Silent-skip on invalid agent_url
+- Canonicalization
+- Appears in `v_effective_agent_authorizations` with evidence preserved

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -1085,6 +1085,14 @@ export class CrawlerService {
           authorizedAgent.authorized_for,
           undefined, // property_ids: managed-network children authorize via tags, not IDs
         );
+        // Catalog projection (#4841) — partner sync endpoints read
+        // catalog_agent_authorizations, not the legacy edge table.
+        // Without this row they miss the manager-asserted child.
+        await this.publisherDb.recordCatalogFanoutAuthorization({
+          agentUrl,
+          childDomain: childCanonical,
+          authorizedFor: authorizedAgent.authorized_for,
+        });
       } catch (err) {
         // Per-child failures must not abort the rest of the fan-out —
         // partial progress beats silent total failure on a 6,800-domain

--- a/server/src/db/federated-index-db.ts
+++ b/server/src/db/federated-index-db.ts
@@ -157,10 +157,11 @@ export class FederatedIndexDatabase {
            v.authorized_for,
            NULL::text[] AS property_ids,
            CASE v.evidence
-             WHEN 'adagents_json' THEN 'adagents_json'
-             WHEN 'agent_claim'   THEN 'agent_claim'
-             WHEN 'override'      THEN 'adagents_json'
-             WHEN 'community'     THEN 'agent_claim'
+             WHEN 'adagents_json'          THEN 'adagents_json'
+             WHEN 'agent_claim'            THEN 'agent_claim'
+             WHEN 'override'               THEN 'adagents_json'
+             WHEN 'community'              THEN 'agent_claim'
+             WHEN 'adagents_authoritative' THEN 'adagents_json'
            END AS source,
            v.created_at AS discovered_at,
            v.updated_at AS last_validated,
@@ -206,10 +207,11 @@ export class FederatedIndexDatabase {
            v.authorized_for,
            NULL::text[] AS property_ids,
            CASE v.evidence
-             WHEN 'adagents_json' THEN 'adagents_json'
-             WHEN 'agent_claim'   THEN 'agent_claim'
-             WHEN 'override'      THEN 'adagents_json'
-             WHEN 'community'     THEN 'agent_claim'
+             WHEN 'adagents_json'          THEN 'adagents_json'
+             WHEN 'agent_claim'            THEN 'agent_claim'
+             WHEN 'override'               THEN 'adagents_json'
+             WHEN 'community'              THEN 'agent_claim'
+             WHEN 'adagents_authoritative' THEN 'adagents_json'
            END AS source,
            v.created_at AS discovered_at,
            v.updated_at AS last_validated,
@@ -271,10 +273,11 @@ export class FederatedIndexDatabase {
          SELECT
            v.publisher_domain,
            CASE v.evidence
-             WHEN 'adagents_json' THEN 'adagents_json'
-             WHEN 'agent_claim'   THEN 'agent_claim'
-             WHEN 'override'      THEN 'adagents_json'
-             WHEN 'community'     THEN 'agent_claim'
+             WHEN 'adagents_json'          THEN 'adagents_json'
+             WHEN 'agent_claim'            THEN 'agent_claim'
+             WHEN 'override'               THEN 'adagents_json'
+             WHEN 'community'              THEN 'agent_claim'
+             WHEN 'adagents_authoritative' THEN 'adagents_json'
            END AS source,
            v.updated_at AS authz_last_validated,
            1 AS src_priority
@@ -437,10 +440,11 @@ export class FederatedIndexDatabase {
              v.authorized_for,
              NULL::text[] AS property_ids,
              CASE v.evidence
-               WHEN 'adagents_json' THEN 'adagents_json'
-               WHEN 'agent_claim'   THEN 'agent_claim'
-               WHEN 'override'      THEN 'adagents_json'
-               WHEN 'community'     THEN 'agent_claim'
+               WHEN 'adagents_json'          THEN 'adagents_json'
+               WHEN 'agent_claim'            THEN 'agent_claim'
+               WHEN 'override'               THEN 'adagents_json'
+               WHEN 'community'              THEN 'agent_claim'
+               WHEN 'adagents_authoritative' THEN 'adagents_json'
              END AS source,
              v.created_at AS discovered_at,
              v.updated_at AS last_validated,
@@ -1283,10 +1287,11 @@ export class FederatedIndexDatabase {
          UNION ALL
          SELECT
            CASE v.evidence
-             WHEN 'adagents_json' THEN 'adagents_json'
-             WHEN 'agent_claim'   THEN 'agent_claim'
-             WHEN 'override'      THEN 'adagents_json'
-             WHEN 'community'     THEN 'agent_claim'
+             WHEN 'adagents_json'          THEN 'adagents_json'
+             WHEN 'agent_claim'            THEN 'agent_claim'
+             WHEN 'override'               THEN 'adagents_json'
+             WHEN 'community'              THEN 'agent_claim'
+             WHEN 'adagents_authoritative' THEN 'adagents_json'
            END AS source,
            1 AS src_priority
            FROM v_effective_agent_authorizations v

--- a/server/src/db/migrations/488_catalog_fanout_authoritative_evidence.sql
+++ b/server/src/db/migrations/488_catalog_fanout_authoritative_evidence.sql
@@ -1,0 +1,76 @@
+-- Catalog projection for publisher_properties fan-out rows (adcp#4841).
+--
+-- The fan-out write path (PR #4840) lands rows in the legacy
+-- `agent_publisher_authorizations` table but the catalog projection in
+-- `publisher-db.ts:upsertAdagentsCache` deliberately refuses cross-
+-- publisher claims (line 968: "publisher_properties claims a different
+-- publisher — cross-publisher refused"). Result: 6,800 cafemedia child
+-- authorizations exist in the legacy arm but not in
+-- `catalog_agent_authorizations`. The `/registry/authorizations` and
+-- `/registry/authorizations/snapshot` partner-sync endpoints read the
+-- catalog only and miss them.
+--
+-- This migration:
+--   1. Widens the `evidence` CHECK to add `'adagents_authoritative'` —
+--      a distinct evidence value for manager-asserted authorizations
+--      (lower trust than `'adagents_json'`; the publisher itself was
+--      not consulted, only the manager file is the source).
+--   2. Backfills catalog rows from existing fan-out state — every
+--      (agent_url, child_domain) pair where the child has
+--      `discovery_method = 'adagents_authoritative'` gets a catalog row
+--      with the new evidence value.
+--
+-- The writer change (publisher-db.ts:recordCatalogFanoutAuthorization,
+-- called from crawler.ts fan-out helper) lands in the same PR and
+-- writes new fan-out rows directly so the backfill is only needed once.
+--
+-- Trust profile of `'adagents_authoritative'` (documented in code +
+-- spec PR #4827): manager-asserted, no bilateral confirmation. Lower
+-- than `'adagents_json'`. Consumers SHOULD filter by evidence when
+-- bilateral verification matters.
+
+BEGIN;
+
+-- 1. Widen the CHECK to include the new evidence value.
+ALTER TABLE catalog_agent_authorizations
+  DROP CONSTRAINT catalog_agent_authorizations_evidence_check;
+ALTER TABLE catalog_agent_authorizations
+  ADD CONSTRAINT catalog_agent_authorizations_evidence_check
+  CHECK (evidence IN ('adagents_json', 'agent_claim', 'community', 'adagents_authoritative'));
+
+COMMENT ON COLUMN catalog_agent_authorizations.evidence IS
+  'Trust signal for the authorization edge. '
+  '''adagents_json'': verified — publisher''s own adagents.json declares this. '
+  '''agent_claim'': lower-trust — asserting agent claims authorization, publisher has not confirmed. '
+  '''community'': curated by AAO moderators. '
+  '''adagents_authoritative'': manager-asserted — a manager file (e.g., cafemedia.com) names this '
+  'publisher in its publisher_properties[] selector, but the publisher itself was not directly '
+  'fetched. Lower trust than ''adagents_json'' (no bilateral confirmation). Per #4825 inline '
+  'resolution rule.';
+
+-- 2. Backfill: insert catalog rows for every existing fan-out edge.
+-- ON CONFLICT DO NOTHING preserves any existing rows (shouldn't be any
+-- with this evidence value yet, but defensive).
+INSERT INTO catalog_agent_authorizations
+  (agent_url, agent_url_canonical, property_rid, property_id_slug,
+   publisher_domain, authorized_for, evidence, created_by)
+SELECT
+  apa.agent_url,
+  LOWER(RTRIM(BTRIM(apa.agent_url), '/')),
+  NULL,
+  NULL,
+  pub.domain,
+  apa.authorized_for,
+  'adagents_authoritative',
+  'system'
+FROM publishers pub
+JOIN agent_publisher_authorizations apa ON apa.publisher_domain = pub.domain
+WHERE pub.discovery_method = 'adagents_authoritative'
+  AND apa.source = 'adagents_json'
+ON CONFLICT (agent_url_canonical,
+             (COALESCE(property_rid::text, '')),
+             (COALESCE(publisher_domain, '')),
+             evidence) WHERE deleted_at IS NULL
+DO NOTHING;
+
+COMMIT;

--- a/server/src/db/publisher-db.ts
+++ b/server/src/db/publisher-db.ts
@@ -273,6 +273,59 @@ export class PublisherDatabase {
     }
   }
 
+  /**
+   * Project a fan-out authorization edge into the catalog
+   * (`catalog_agent_authorizations`) so the partner-sync endpoints
+   * (`/registry/authorizations`, `/registry/authorizations/snapshot`)
+   * — which read the catalog only — see the same edge the legacy
+   * `agent_publisher_authorizations` arm carries. Adcp#4841.
+   *
+   * The catalog's `cacheAdagentsManifest` projection deliberately
+   * refuses cross-publisher claims (publisher-db.ts ~L968: a manager
+   * file cannot land authoritative rows for another publisher's
+   * properties without out-of-band corroboration). For the fan-out
+   * shape — where the manager file names the child publisher in its
+   * `publisher_properties[].publisher_domains[]` selector — the
+   * out-of-band corroboration is the inline-resolution rule itself
+   * (#4825). Evidence value `'adagents_authoritative'` (migration 488)
+   * carries the lower trust profile so consumers can filter when
+   * bilateral verification matters.
+   *
+   * Called from the crawler's fan-out helper per (agent, child) pair.
+   * The companion `recordChildPublisherFromManager` writes the
+   * publishers row (per-child, agent-independent); this writes the
+   * catalog row (per agent × child).
+   */
+  async recordCatalogFanoutAuthorization(input: {
+    agentUrl: string;
+    childDomain: string;
+    authorizedFor?: string;
+  }): Promise<void> {
+    const childDomain = canonicalizePublisherDomain(input.childDomain);
+    const agentCanonical = canonicalizeAgentUrl(input.agentUrl);
+    if (!agentCanonical) return; // canonicalizer rejected — invalid URL, skip
+    const client = await getClient();
+    try {
+      await client.query(
+        `INSERT INTO catalog_agent_authorizations
+           (agent_url, agent_url_canonical, property_rid, property_id_slug,
+            publisher_domain, authorized_for, evidence, created_by)
+         VALUES ($1, $2, NULL, NULL, $3, $4, 'adagents_authoritative', 'system')
+         ON CONFLICT (agent_url_canonical,
+                      (COALESCE(property_rid::text, '')),
+                      (COALESCE(publisher_domain, '')),
+                      evidence)
+                WHERE deleted_at IS NULL
+         DO UPDATE SET
+           authorized_for = EXCLUDED.authorized_for,
+           updated_at = NOW()`,
+        [input.agentUrl, agentCanonical, childDomain, input.authorizedFor ?? null],
+      );
+    } finally {
+      client.release();
+    }
+  }
+
   async recordFailedAdagentsFetch(input: {
     domain: string;
     statusCode?: number;

--- a/server/tests/integration/catalog-fanout-projection.test.ts
+++ b/server/tests/integration/catalog-fanout-projection.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Integration test for catalog projection of publisher_properties
+ * fan-out rows (adcp#4841).
+ *
+ * `recordCatalogFanoutAuthorization` writes the edge into
+ * `catalog_agent_authorizations` with the new `adagents_authoritative`
+ * evidence value (migration 488). This is the projection that lets
+ * partner-sync endpoints (`/registry/authorizations`,
+ * `/registry/authorizations/snapshot`) see manager-asserted children.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import type { Pool } from 'pg';
+import { initializeDatabase, closeDatabase, query } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { PublisherDatabase } from '../../src/db/publisher-db.js';
+
+const RUN_SUFFIX = Math.random().toString(36).slice(2, 8);
+const AGENT_URL = `https://catalog-agent-${RUN_SUFFIX}.example`;
+const CHILD = `child-${RUN_SUFFIX}.catalog-fanout.example`;
+
+describe('catalog fan-out projection — recordCatalogFanoutAuthorization (#4841)', () => {
+  let pool: Pool;
+  let publisherDb: PublisherDatabase;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:53198/adcp_test',
+    });
+    await runMigrations();
+    publisherDb = new PublisherDatabase();
+  });
+
+  async function clearFixtures() {
+    await pool.query(
+      `DELETE FROM catalog_agent_authorizations
+        WHERE agent_url_canonical = LOWER(RTRIM(BTRIM($1), '/'))`,
+      [AGENT_URL],
+    );
+  }
+
+  afterAll(async () => {
+    await clearFixtures();
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await clearFixtures();
+  });
+
+  it('writes a catalog row with evidence=adagents_authoritative + created_by=system', async () => {
+    await publisherDb.recordCatalogFanoutAuthorization({
+      agentUrl: AGENT_URL,
+      childDomain: CHILD,
+      authorizedFor: 'Test scope description',
+    });
+
+    const result = await query<{
+      agent_url: string;
+      agent_url_canonical: string;
+      publisher_domain: string;
+      authorized_for: string;
+      evidence: string;
+      created_by: string;
+      property_rid: string | null;
+      deleted_at: Date | null;
+    }>(
+      `SELECT agent_url, agent_url_canonical, publisher_domain, authorized_for,
+              evidence, created_by, property_rid, deleted_at
+         FROM catalog_agent_authorizations
+        WHERE agent_url_canonical = LOWER(RTRIM(BTRIM($1), '/'))
+          AND publisher_domain = $2`,
+      [AGENT_URL, CHILD],
+    );
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]).toMatchObject({
+      agent_url: AGENT_URL,
+      agent_url_canonical: AGENT_URL.toLowerCase(),
+      publisher_domain: CHILD,
+      authorized_for: 'Test scope description',
+      evidence: 'adagents_authoritative',
+      created_by: 'system',
+      property_rid: null, // publisher-wide
+      deleted_at: null,
+    });
+  });
+
+  it('is idempotent — second call updates authorized_for instead of duplicating', async () => {
+    await publisherDb.recordCatalogFanoutAuthorization({
+      agentUrl: AGENT_URL,
+      childDomain: CHILD,
+      authorizedFor: 'first',
+    });
+    await publisherDb.recordCatalogFanoutAuthorization({
+      agentUrl: AGENT_URL,
+      childDomain: CHILD,
+      authorizedFor: 'second',
+    });
+    const result = await query<{ count: string; authorized_for: string }>(
+      `SELECT COUNT(*)::text AS count, MAX(authorized_for) AS authorized_for
+         FROM catalog_agent_authorizations
+        WHERE agent_url_canonical = LOWER(RTRIM(BTRIM($1), '/'))
+          AND publisher_domain = $2
+          AND evidence = 'adagents_authoritative'`,
+      [AGENT_URL, CHILD],
+    );
+    expect(result.rows[0]?.count).toBe('1');
+    expect(result.rows[0]?.authorized_for).toBe('second');
+  });
+
+  it('coexists with adagents_json evidence for the same (agent, publisher) pair', async () => {
+    // A child that ALSO has its own adagents.json directly authorizing
+    // this agent would carry evidence='adagents_json'. The fan-out row
+    // with evidence='adagents_authoritative' should be a separate row
+    // (different evidence) — consumers can filter by trust level.
+    await pool.query(
+      `INSERT INTO catalog_agent_authorizations
+         (agent_url, agent_url_canonical, publisher_domain, authorized_for, evidence, created_by)
+       VALUES ($1, LOWER(RTRIM(BTRIM($1), '/')), $2, 'direct', 'adagents_json', 'system')`,
+      [AGENT_URL, CHILD],
+    );
+    await publisherDb.recordCatalogFanoutAuthorization({
+      agentUrl: AGENT_URL,
+      childDomain: CHILD,
+      authorizedFor: 'manager-asserted',
+    });
+    const result = await query<{ evidence: string; authorized_for: string }>(
+      `SELECT evidence, authorized_for FROM catalog_agent_authorizations
+        WHERE agent_url_canonical = LOWER(RTRIM(BTRIM($1), '/'))
+          AND publisher_domain = $2
+          AND deleted_at IS NULL
+        ORDER BY evidence`,
+      [AGENT_URL, CHILD],
+    );
+    expect(result.rows).toHaveLength(2);
+    expect(result.rows.map(r => r.evidence)).toEqual(['adagents_authoritative', 'adagents_json']);
+  });
+
+  it('rejects an invalid agent_url silently (skips write, does not throw)', async () => {
+    await publisherDb.recordCatalogFanoutAuthorization({
+      agentUrl: '  ',
+      childDomain: CHILD,
+    });
+    const result = await query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM catalog_agent_authorizations
+        WHERE publisher_domain = $1`,
+      [CHILD],
+    );
+    expect(result.rows[0]?.count).toBe('0');
+  });
+
+  it('canonicalizes the child domain (lowercases + strips trailing dot)', async () => {
+    await publisherDb.recordCatalogFanoutAuthorization({
+      agentUrl: AGENT_URL,
+      childDomain: `  ${CHILD.toUpperCase()}.  `,
+    });
+    const result = await query<{ publisher_domain: string }>(
+      `SELECT publisher_domain FROM catalog_agent_authorizations
+        WHERE agent_url_canonical = LOWER(RTRIM(BTRIM($1), '/'))
+          AND evidence = 'adagents_authoritative'`,
+      [AGENT_URL],
+    );
+    expect(result.rows[0]?.publisher_domain).toBe(CHILD);
+  });
+
+  it('appears in v_effective_agent_authorizations with evidence preserved', async () => {
+    await publisherDb.recordCatalogFanoutAuthorization({
+      agentUrl: AGENT_URL,
+      childDomain: CHILD,
+    });
+    const result = await query<{ evidence: string; publisher_domain: string }>(
+      `SELECT evidence, publisher_domain
+         FROM v_effective_agent_authorizations
+        WHERE agent_url_canonical = LOWER(RTRIM(BTRIM($1), '/'))
+          AND publisher_domain = $2`,
+      [AGENT_URL, CHILD],
+    );
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]?.evidence).toBe('adagents_authoritative');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the catalog snapshot gap from #4840's rollout. Adds a new `adagents_authoritative` evidence value to `catalog_agent_authorizations`, lifts the cross-publisher refusal *specifically* for the fan-out shape, and backfills the ~6,800 existing cafemedia rows. `/registry/authorizations` and `/registry/authorizations/snapshot` (partner-sync endpoints, catalog-only readers) now see the manager-asserted children.

## Why the cross-publisher guard stays

`publisher-db.ts:968` refuses to project `catalog_agent_authorizations` rows where the selector's `publisher_domain` ≠ the publisher being projected. This is **load-bearing for catalog trust** — without it, a hostile manager file could project authoritative rows for publishers that didn't authorize anything. Don't lift the guard.

Instead, give the fan-out its own evidence value:

| Evidence | Source | Trust |
|---|---|---|
| `adagents_json` | publisher's own `/.well-known/adagents.json` | strongest — bilateral |
| `agent_claim` | sales-agent `list_authorized_properties` | lower — unverified peer |
| `community` | AAO moderator curation | curated |
| **`adagents_authoritative`** (new) | manager file (e.g. cafemedia) names this publisher in `publisher_properties[].publisher_domains[]` | medium — manager-asserted, no bilateral |

Consumers that want bilateral-only filter `evidence=adagents_json`; consumers that want the full picture take both.

## Files

- **Migration 488** — CHECK widening + backfill from `publishers WHERE discovery_method='adagents_authoritative'` ⋈ `agent_publisher_authorizations WHERE source='adagents_json'`. `ON CONFLICT DO NOTHING`.
- **`publisher-db.ts`** — new `recordCatalogFanoutAuthorization({ agentUrl, childDomain, authorizedFor? })`. INSERT-or-UPDATE with the new evidence value, `created_by='system'`, no `property_rid`.
- **`crawler.ts`** — fan-out helper calls the new writer per (agent, child) pair alongside `recordChildPublisherFromManager` (publishers row) and `recordAgentFromAdagentsJson` (legacy authz row).
- **`federated-index-db.ts`** — 6 evidence-CASE statements add `WHEN 'adagents_authoritative' THEN 'adagents_json'` so the dual-read `source` field round-trips correctly.
- **Integration test** (`catalog-fanout-projection.test.ts`) — 6 cases: row shape, idempotent re-write, coexistence with `adagents_json` for same (agent, publisher), invalid agent_url silent-skip, canonicalization, view round-trip.

## Production verification after deploy

```bash
# Re-trigger cafemedia crawl (deploy runs the backfill as release_command).
ADMIN_KEY=$(grep "^ADMIN_API_KEY=" .env.local | cut -d= -f2)
curl -X POST 'https://agenticadvertising.org/api/registry/crawl-request' \
  -H "Authorization: Bearer $ADMIN_KEY" -H 'Content-Type: application/json' \
  -d '{"domain":"cafemedia.com"}'

# Wait ~60s, then probe the catalog-only auth snapshot endpoint:
curl -sS 'https://agenticadvertising.org/api/registry/authorizations?agent_url=https://interchange.io&evidence=adagents_authoritative' \
  -H "Authorization: Bearer $ADMIN_KEY" | jq '{count: (.rows | length), evidences: ([.rows[].evidence] | unique)}'
# Expected: ~6,800 rows, evidence=["adagents_authoritative"]
```

## Test plan

- [x] Typecheck passes
- [x] 6 integration tests for the new writer
- [ ] Reviewer: backfill query plan on production catalog (~thousands of rows expected)
- [ ] Reviewer (post-deploy): partner snapshot endpoint returns ~6,800 cafemedia children

🤖 Generated with [Claude Code](https://claude.com/claude-code)