### PR TITLE
fix(member-profiles): allow member-role users to bootstrap their org's profile (closes #4839)

### DIFF
--- a/.changeset/4839-allow-member-profile-creation.md
+++ b/.changeset/4839-allow-member-profile-creation.md
@@ -1,0 +1,10 @@
+---
+---
+
+fix(member-profiles): allow member-role users to bootstrap their org's profile
+
+Closes #4839. Member-role users who land on the member-profile setup form (often via the "register your agent" CTA on the dashboard) hit `403 — Only admins and owners can create member profiles`. Meanwhile `POST /api/me/agents` already allowed any-role member to register an agent and auto-bootstrapped the profile silently via `ensureMemberProfileExists`. Two paths, two gates, one frustrated reporter.
+
+Closing the inconsistency: any-role member may now bootstrap the profile. New profiles still default to `is_public: false`. The `is_public: true` flip in the same call is downgraded to `false` for non-admin/owner creators with a `visibility_downgraded` warning (matching the existing tier-downgrade pattern). Publishing publicly later still goes through the dedicated `/visibility` PUT route, which retains its admin/owner gate.
+
+Server-side fix only — no spec change.

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -410,13 +410,12 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
               message: 'User is not a member of the requested organization',
             });
           }
-          const role = membership.role?.slug || 'member';
-          if (role !== 'admin' && role !== 'owner') {
-            return res.status(403).json({
-              error: 'Not authorized',
-              message: 'Only admins and owners can create member profiles',
-            });
-          }
+          // The bootstrap path creates the profile as `is_public: false` (see
+          // the createProfile call below). Public visibility flips through the
+          // dedicated `/visibility` PUT, which has its own admin/owner gate.
+          // Allowing any-role member to bootstrap mirrors the `/api/me/agents`
+          // POST auto-bootstrap behavior — the gate inconsistency between
+          // those two paths is what surfaced #4839.
           targetOrgId = requestedOrgId;
         } else {
           targetOrgId = memberships.data[0].organizationId;
@@ -847,6 +846,10 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       // Dev mode: handle dev organizations without WorkOS
       const isDevUserProfile = isDevModeEnabled() && Object.values(DEV_USERS).some(du => du.id === user.id) && requestedOrgId?.startsWith('org_dev_');
       let targetOrgId: string;
+      // Captured during membership resolution below. Drives the
+      // `is_public` downgrade — non-admin/owner creators can bootstrap
+      // their org's profile but cannot publish it publicly in the same call.
+      let callerRole: string = 'owner';
 
       if (isDevUserProfile) {
         const localOrg = await orgDb.getOrganization(requestedOrgId!);
@@ -882,7 +885,6 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
 
         // Determine which org to use
         if (requestedOrgId) {
-          // Verify user is admin/owner of the requested org
           const membership = memberships.data.find(m => m.organizationId === requestedOrgId);
           if (!membership) {
             return res.status(403).json({
@@ -890,16 +892,18 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
               message: 'User is not a member of the requested organization',
             });
           }
-          const role = membership.role?.slug || 'member';
-          if (role !== 'admin' && role !== 'owner') {
-            return res.status(403).json({
-              error: 'Not authorized',
-              message: 'Only admins and owners can create member profiles',
-            });
-          }
+          // Any-role member may create the org's profile. The `is_public`
+          // gate happens downstream on the role check below — non-admin/owner
+          // creators have their requested `is_public: true` downgraded to
+          // false with a `visibility_downgraded` warning, matching the tier
+          // gate's pattern. The mutation-visibility separation mirrors the
+          // `/api/me/agents` POST auto-bootstrap behavior (#4839).
+          callerRole = membership.role?.slug || 'member';
           targetOrgId = requestedOrgId;
         } else {
-          targetOrgId = memberships.data[0].organizationId;
+          const firstMembership = memberships.data[0];
+          callerRole = firstMembership.role?.slug || 'member';
+          targetOrgId = firstMembership.organizationId;
         }
       }
 
@@ -1027,7 +1031,23 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       // the agent-visibility bug this PR fixes.
       let effectiveIsPublic = is_public === true;
       if (effectiveIsPublic && !isDevModeEnabled()) {
-        if (!(await orgDb.hasActiveSubscription(targetOrgId))) {
+        // Role gate: non-admin/owner creators may bootstrap the profile
+        // but cannot publish it publicly in the same call. They flip
+        // `is_public` later via the dedicated `/visibility` PUT (which
+        // has its own admin/owner gate). Mirrors the tier-downgrade
+        // pattern below — same warning shape so the UI can render either
+        // path the same way (#4839).
+        if (callerRole !== 'admin' && callerRole !== 'owner') {
+          effectiveIsPublic = false;
+          createWarnings.push({
+            code: 'visibility_downgraded',
+            agent_url: 'profile',
+            requested: 'public',
+            applied: 'members_only',
+            reason: 'role_required',
+            message: 'Making the profile publicly visible requires an admin or owner; stored as private instead. Ask an admin to publish via the visibility setting.',
+          });
+        } else if (!(await orgDb.hasActiveSubscription(targetOrgId))) {
           effectiveIsPublic = false;
           createWarnings.push({
             code: 'visibility_downgraded',

--- a/server/src/services/agent-visibility-gate.ts
+++ b/server/src/services/agent-visibility-gate.ts
@@ -58,7 +58,7 @@ export interface VisibilityWarning {
   agent_url: string;
   requested: 'public';
   applied: 'members_only';
-  reason: 'tier_required';
+  reason: 'tier_required' | 'role_required';
   message: string;
 }
 

--- a/server/tests/integration/member-profile-bootstrap.test.ts
+++ b/server/tests/integration/member-profile-bootstrap.test.ts
@@ -137,9 +137,10 @@ describe('POST /api/me/member-profile (REST bootstrap)', () => {
 
   async function seedOrg(
     orgId: string,
-    overrides: Partial<{ name: string; company_type: string | null; revenue_tier: string | null; membership_tier: string | null }> = {},
+    overrides: Partial<{ name: string; company_type: string | null; revenue_tier: string | null; membership_tier: string | null; role: string }> = {},
   ) {
     const name = overrides.name ?? 'Acme Media';
+    const role = overrides.role ?? 'owner';
     await pool.query(
       `INSERT INTO organizations (workos_organization_id, name, is_personal, company_type, revenue_tier, membership_tier, created_at, updated_at)
        VALUES ($1, $2, false, $3, $4, $5, NOW(), NOW())
@@ -152,9 +153,9 @@ describe('POST /api/me/member-profile (REST bootstrap)', () => {
     );
     await pool.query(
       `INSERT INTO organization_memberships (workos_user_id, workos_organization_id, role, email, created_at, updated_at)
-       VALUES ($1, $2, 'owner', $3, NOW(), NOW())
-       ON CONFLICT (workos_user_id, workos_organization_id) DO UPDATE SET role = 'owner'`,
-      [currentUserId, orgId, currentUserEmail],
+       VALUES ($1, $2, $3, $4, NOW(), NOW())
+       ON CONFLICT (workos_user_id, workos_organization_id) DO UPDATE SET role = EXCLUDED.role`,
+      [currentUserId, orgId, role, currentUserEmail],
     );
   }
 
@@ -542,6 +543,30 @@ describe('POST /api/me/member-profile (REST bootstrap)', () => {
 
     // Cleanup
     await pool.query(`DELETE FROM user_agreement_acceptances WHERE workos_user_id = $1`, [currentUserId]);
+  });
+
+  it('allows member-role users to bootstrap the org profile (#4839)', async () => {
+    currentUserEmail = 'member@acme.example';
+    currentUserId = 'user_boot_member_role';
+    const orgId = `${TEST_PREFIX}_member_role`;
+    await seedOrg(orgId, { role: 'member' });
+
+    const res = await request(app)
+      .post('/api/me/member-profile')
+      .send({
+        organization_name: 'Acme Media',
+        company_type: 'publisher',
+        corporate_domain: 'acme.example',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.profile.organization_id).toBe(orgId);
+
+    const profileRow = await pool.query<{ is_public: boolean }>(
+      `SELECT is_public FROM member_profiles WHERE workos_organization_id = $1`,
+      [orgId],
+    );
+    expect(profileRow.rows[0]?.is_public).toBe(false);
   });
 
   it('still routes legacy display_name + slug bodies to the original handler', async () => {


### PR DESCRIPTION
Closes #4839.

## Root cause (traced)

The reporter (new today, \`geneticallymodifiedfoodforthought\`) hit \`403 — Only admins and owners can create member profiles\` from \`server/src/routes/member-profiles.ts:414\` when submitting the profile setup form on \`server/public/member-profile.html\` (line 3022-3023 does \`POST /api/me/member-profile\` when \`isNewProfile\`).

Meanwhile \`POST /api/me/agents\` (\`server/src/routes/member-agents.ts:404-510\`) already allows any-role member to register an agent. It auto-bootstraps the profile silently via \`ensureMemberProfileExists\` (\`server/src/services/member-profile-autopublish.ts:140\`), which creates profiles as \`is_public: false\` with no role check.

**Two paths, two gates.** The reporter happened to land on the explicit profile-create form (often via the "register your agent" CTA) and hit the gate; if they'd gone through the agents dashboard instead, the implicit bootstrap would have worked. Frustrating UX, real friction for new users at orgs where the admin/owner is unavailable.

## Fix

Close the gate inconsistency at \`POST /api/me/member-profile\`:

1. **Bootstrap path (line 414)**: removed the role gate entirely. The bootstrap branch creates as \`is_public: false\` implicitly; no need to gate.
2. **Direct-create path (line 893)**: removed the role gate. Captured the caller's role and added an \`is_public\` downgrade — non-admin/owner creators that pass \`is_public: true\` get downgraded to \`false\` with a \`visibility_downgraded\` warning. Mirrors the existing tier-downgrade pattern (same warning shape, new \`reason: 'role_required'\`).
3. **\`/visibility\` PUT route (line 1335)**: unchanged. Publishing publicly still goes through that route, which retains its admin/owner gate.

## Files

- \`server/src/routes/member-profiles.ts\` — drop role gate at two sites, add \`callerRole\` capture, add downgrade logic in \`effectiveIsPublic\` computation
- \`server/src/services/agent-visibility-gate.ts\` — widen \`VisibilityWarning.reason\` to \`'tier_required' | 'role_required'\`
- \`server/tests/integration/member-profile-bootstrap.test.ts\` — extend \`seedOrg\` helper with optional role; add test that member-role user bootstraps to \`is_public: false\`

## Non-breaking justification

- New profiles still default to \`is_public: false\` for non-admin/owner creators (and stay that way).
- Existing admin/owner-only callers see no behavior change — the gate is removed only for the bootstrap-or-private-create case.
- Public-publish route (\`/visibility\` PUT) keeps the admin/owner gate. No path widens public-publish ability.
- Server-side fix only; no spec change.

## Validation

- \`tsc --project server/tsconfig.json --noEmit\` — clean
- Integration test added; needs CI to run (local lacks \`WORKOS_API_KEY\`)