### PR TITLE
ops(certification): add --skip-personal-email-fallback flag to credential repair script

### DIFF
--- a/.changeset/4753-repair-script-skip-personal-email-fallback.md
+++ b/.changeset/4753-repair-script-skip-personal-email-fallback.md
@@ -1,0 +1,10 @@
+---
+---
+
+ops(certification): add `--skip-personal-email-fallback` flag to credential repair script
+
+`server/src/scripts/repair-credential-recipient-names.ts` now accepts a flag that skips credentials whose backfill value would be the user's email AND the email domain is a personal-email provider (gmail, hotmail, yahoo, icloud, etc.). Corporate-email users still get repaired — their email is already public on their business card / LinkedIn. Personal-email users wait for the new `NAME_REQUIRED` gate + `set_my_name` recovery flow (#4799) to populate their name, then a re-run picks them up.
+
+Closes the cleanup loop for #4753 and #4760 — Tom Hespos's two credentials in #4760 still get fixed cleanly to "Tom Hespos" because we have his real name in the users table.
+
+Ops-only; no protocol/wire change.

--- a/server/src/scripts/repair-credential-recipient-names.ts
+++ b/server/src/scripts/repair-credential-recipient-names.ts
@@ -19,6 +19,13 @@
  * Optional filters:
  *   --credential-id=<certifier_credential_id>   only this credential
  *   --workos-user-id=<id>                        only this learner's credentials
+ *   --skip-personal-email-fallback              skip credentials where the
+ *                                                proposed value is the user's
+ *                                                email AND the domain is a
+ *                                                personal-email provider
+ *                                                (gmail, hotmail, etc.) —
+ *                                                avoids surfacing PII on a
+ *                                                publicly-shareable artifact
  *
  * Usage (prod, via fly ssh):
  *   fly ssh console -a adcp-docs -C 'node /app/dist/scripts/repair-credential-recipient-names.js'
@@ -38,6 +45,7 @@ import {
 
 const apply = process.argv.includes('--apply');
 const dryRun = !apply;
+const skipPersonalEmailFallback = process.argv.includes('--skip-personal-email-fallback');
 
 function readFlag(name: string): string | null {
   const prefix = `--${name}=`;
@@ -47,6 +55,48 @@ function readFlag(name: string): string | null {
 
 const credentialIdFilter = readFlag('credential-id');
 const userIdFilter = readFlag('workos-user-id');
+
+// Personal-email domains where writing the email as the recipient name on a
+// public-shareable certificate would expose PII. Corporate domains are fine
+// — the email is already on the user's business card / LinkedIn — but
+// personal addresses surface on a publicly-linkable artifact in a way the
+// user didn't opt into. The `--skip-personal-email-fallback` flag skips
+// credentials where the proposed value would write one of these domains.
+// The recovery path for those users is the new NAME_REQUIRED gate +
+// set_my_name tool added in #4799 — they enter their name via Addie and
+// the backfill becomes a no-op when we re-run.
+const PERSONAL_EMAIL_DOMAINS = new Set([
+  'gmail.com',
+  'googlemail.com',
+  'hotmail.com',
+  'hotmail.co.uk',
+  'outlook.com',
+  'live.com',
+  'yahoo.com',
+  'yahoo.co.uk',
+  'icloud.com',
+  'me.com',
+  'mac.com',
+  'aol.com',
+  'protonmail.com',
+  'proton.me',
+  'mail.com',
+  'gmx.com',
+  'gmx.de',
+  'zoho.com',
+  'fastmail.com',
+  'pm.me',
+  'tutanota.com',
+  'msn.com',
+  'hey.com',
+]);
+
+function isPersonalEmailFallback(desired: string, email: string): boolean {
+  if (desired !== email) return false;
+  const at = email.lastIndexOf('@');
+  if (at < 0) return false;
+  return PERSONAL_EMAIL_DOMAINS.has(email.slice(at + 1).toLowerCase());
+}
 
 interface Row {
   workos_user_id: string;
@@ -124,13 +174,22 @@ async function main(): Promise<void> {
       const remote = await getCredential(row.certifier_credential_id);
       const current = remote.recipient?.name ?? '';
       if (needsRepair(current, desired, row)) {
-        plan.push({
-          workos_user_id: row.workos_user_id,
-          email: row.email,
-          certifier_credential_id: row.certifier_credential_id,
-          current_name: current,
-          desired_name: desired,
-        });
+        if (skipPersonalEmailFallback && isPersonalEmailFallback(desired, row.email)) {
+          skipped.push({
+            row,
+            current,
+            desired,
+            reason: 'personal-email-fallback (--skip-personal-email-fallback)',
+          });
+        } else {
+          plan.push({
+            workos_user_id: row.workos_user_id,
+            email: row.email,
+            certifier_credential_id: row.certifier_credential_id,
+            current_name: current,
+            desired_name: desired,
+          });
+        }
       } else {
         skipped.push({
           row,


### PR DESCRIPTION
Adds a flag to \`server/src/scripts/repair-credential-recipient-names.ts\` that skips credentials whose backfill value would be the user's email AND the email domain is a personal-email provider (gmail, hotmail, yahoo, icloud, etc.).

## Why

Dry-run against prod surfaced 20 credentials with broken recipient names ("undefined undefined" or "Davide undefined"). 11 of them have real names available in \`users.first_name\` / \`users.last_name\` and will write a proper name. The other 9 fall back to the email — fine for corporate addresses (publicly listed on the user's LinkedIn anyway), problematic for personal addresses (\`gmail.com\`, \`hotmail.co.uk\`) on a publicly-linkable certificate artifact.

This flag lets us repair the 18-of-20 cases (real names + corporate emails) and leave 2 personal-email-fallback cases until the user provides their name via Addie's \`set_my_name\` recovery flow (#4799), at which point a re-run picks them up cleanly.

## Validation

- \`tsc --project server/tsconfig.json --noEmit\` — clean
- Dry-run against prod confirmed 20 candidates before the change; with this flag the 2 personal-email-fallback users (ruizrojasangel@gmail.com, jonnyaustin@hotmail.co.uk) are surfaced as skipped.

## Cleanup operation

After merge, runbook:
\`\`\`bash
# 1. Dry-run with the new flag to verify scope
fly ssh console -a adcp-docs -C 'node /app/dist/scripts/repair-credential-recipient-names.js --skip-personal-email-fallback'

# 2. Apply
fly ssh console -a adcp-docs -C 'node /app/dist/scripts/repair-credential-recipient-names.js --skip-personal-email-fallback --apply'
\`\`\`

Closes the cleanup loop for #4753 (geneticallymodifiedfoodforthought) and #4760 (THespos). Tom Hespos's two credentials in #4760 are unaffected by the new flag — we have his real name in the users table, so the script writes "Tom Hespos".

## Follow-up

- Personal Workspace users whose AAO profile setup doesn't capture first/last name (separate issue to file).