### PR TITLE
fix(catalog): allow adagents_authoritative as evidence= filter on /registry/authorizations

### DIFF
--- a/.changeset/4841-snapshot-evidence-allowlist.md
+++ b/.changeset/4841-snapshot-evidence-allowlist.md
@@ -1,0 +1,8 @@
+---
+---
+
+fix(catalog): allow `adagents_authoritative` as an `evidence=` filter value on `/registry/authorizations` (#4841 follow-up)
+
+#4879 added the `adagents_authoritative` evidence value to `catalog_agent_authorizations` and projected ~6,800 cafemedia children into catalog, but `authorization-snapshot-db.ts:parseEvidenceParam` rejected `?evidence=adagents_authoritative` with 400 because the validator's `VALID_EVIDENCE` set was hardcoded to the pre-#4841 enum.
+
+Adds the new value to `VALID_EVIDENCE`. **Not** added to `DEFAULT_EVIDENCE` — the partner-sync default stays strict-bilateral `adagents_json` only; consumers opt in to weaker evidence explicitly.

--- a/server/src/db/authorization-snapshot-db.ts
+++ b/server/src/db/authorization-snapshot-db.ts
@@ -39,7 +39,12 @@ const log = createLogger('authorization-snapshot-db');
 /** Empty-feed sentinel — UUIDv7 with all-zero fields. */
 const EMPTY_CURSOR = '00000000-0000-7000-8000-000000000000';
 
-const VALID_EVIDENCE = new Set(['adagents_json', 'agent_claim', 'community', 'override']);
+// `adagents_authoritative` (added in migration 488 / #4841) is a valid
+// filter value but NOT in the default set — it's lower-trust (manager-
+// asserted, no bilateral confirmation), so partner consumers default to
+// the strict-bilateral `adagents_json` set and opt in to the weaker
+// evidence explicitly.
+const VALID_EVIDENCE = new Set(['adagents_json', 'agent_claim', 'community', 'override', 'adagents_authoritative']);
 const DEFAULT_EVIDENCE: ReadonlyArray<string> = ['adagents_json'];
 
 const VALID_INCLUDE = new Set(['raw', 'effective']);


### PR DESCRIPTION
## Summary

Hotfix follow-up to #4879. The new \`adagents_authoritative\` evidence value landed in \`catalog_agent_authorizations\` and backfilled ~6,800 cafemedia children, but the partner-sync endpoints rejected \`?evidence=adagents_authoritative\` with 400 because the validator's \`VALID_EVIDENCE\` allowlist was hardcoded to the pre-#4841 enum.

\`\`\`
$ curl '.../api/registry/authorizations?agent_url=https://interchange.io&evidence=adagents_authoritative'
{"error":"Invalid evidence value: adagents_authoritative. Expected one of: adagents_json, agent_claim, community, override."}
\`\`\`

## Change

One-line addition to \`server/src/db/authorization-snapshot-db.ts:42\`:

\`\`\`diff
-const VALID_EVIDENCE = new Set(['adagents_json', 'agent_claim', 'community', 'override']);
+const VALID_EVIDENCE = new Set(['adagents_json', 'agent_claim', 'community', 'override', 'adagents_authoritative']);
\`\`\`

**Not** added to \`DEFAULT_EVIDENCE\` — the partner-sync default stays strict-bilateral \`adagents_json\` only. Consumers opt into the weaker evidence explicitly.

## Verification after deploy

\`\`\`bash
ADMIN_KEY=\$(grep "^ADMIN_API_KEY=" .env.local | cut -d= -f2)
curl -sS 'https://agenticadvertising.org/api/registry/authorizations?agent_url=https://interchange.io&evidence=adagents_authoritative' \
  -H "Authorization: Bearer \$ADMIN_KEY" | jq '{count, evidences: ([.rows[].evidence] | unique)}'
# Expected: count ~6,800, evidences=["adagents_authoritative"]
\`\`\`

## Test plan

- [x] Typecheck passes
- [ ] Reviewer: existing tests covering the allowlist should still pass (no test asserts the old hardcoded set; the new value is additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)