### PR TITLE
feat(addie): byline override for propose_content and admin-content editor

### DIFF
--- a/.changeset/4888-byline-override-propose-content.md
+++ b/.changeset/4888-byline-override-propose-content.md
@@ -1,0 +1,8 @@
+---
+---
+
+feat(addie): byline override for propose_content and admin-content editor (#4888)
+
+Adds an optional `byline` parameter to the `propose_content` Addie tool so users can post as "AgenticAdvertising.org Team" (or any org-level name) instead of their personal profile name. The `byline` surfaces as a free-text "Author byline" field in the admin-content.html edit drawer as well, populated from the saved `author_name` when opening an existing piece.
+
+Server-side changes: `byline` added to `ProposeContentRequest`, validated at 255-char limit (matching sibling fields), used to override the hardcoded `userInfo.name` derivation in `proposeContentForUser`. The PATCH `author_name` branch is now gated to proposer/primary-author/admin (previously ungated — any co-author could rebrand someone else's post); syncs `content_authors.display_name` for the primary author row on save for consistency.

--- a/server/public/admin-content.html
+++ b/server/public/admin-content.html
@@ -483,6 +483,13 @@
           <input type="text" id="tagsInput" placeholder="e.g., buy-side, protocol, agentic (comma-separated)">
         </div>
 
+        <!-- Author byline override (shown when editing) -->
+        <div class="form-group hidden" id="bylineGroup">
+          <label>Author byline</label>
+          <input type="text" id="authorNameInput" placeholder="Leave blank to use your profile name" maxlength="255">
+          <small>Override the displayed byline, e.g., "AgenticAdvertising.org Team" for org-wide posts.</small>
+        </div>
+
         <!-- Co-authors (shown when editing) -->
         <div class="coauthor-section hidden" id="coauthorSection">
           <label style="font-weight: var(--font-semibold); font-size: var(--text-sm); margin-bottom: var(--space-2); display: block;">Co-Authors</label>
@@ -1286,6 +1293,8 @@
       updateExcerptCount();
       updateStatusHint();
       document.getElementById('coauthorSection').classList.add('hidden');
+      document.getElementById('bylineGroup').classList.add('hidden');
+      document.getElementById('authorNameInput').value = '';
       document.getElementById('sectionGroup').classList.toggle('hidden', !isAdmin);
       document.getElementById('sectionSelect').value = 'member';
       document.getElementById('autoCoverToggle').checked = true;
@@ -1332,8 +1341,10 @@
       updatePreview();
       updateExcerptCount();
       updateStatusHint();
-      // Show co-authors when editing
+      // Show co-authors and byline override when editing
       document.getElementById('coauthorSection').classList.remove('hidden');
+      document.getElementById('bylineGroup').classList.remove('hidden');
+      document.getElementById('authorNameInput').value = item.author_name || '';
       loadCoauthors(item.id);
       document.getElementById('contentModal').style.display = 'flex';
     }
@@ -1613,6 +1624,11 @@
       };
       if (isAdmin) {
         data.content_origin = document.getElementById('sectionSelect').value;
+      }
+      // Include byline override only on edits (field is not shown on create)
+      if (id) {
+        const bylineVal = document.getElementById('authorNameInput').value.trim();
+        data.author_name = bylineVal || null;
       }
       const btn = document.getElementById('saveBtn');
       btn.disabled = true; const origText = btn.textContent; btn.textContent = 'Saving...';

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -862,7 +862,7 @@ export const MEMBER_TOOLS: AddieTool[] = [
     name: 'propose_content',
     description:
       'Submit a draft (article or link) for editorial review. Content lands in pending_review; a committee lead or admin approves it to publish. Default committee is "editorial" (site-wide Perspectives). Only `title` is required.',
-    usage_hints: 'use for "publish this post", "write a perspective", "post to the sustainability group", "share my thoughts on X"',
+    usage_hints: 'use for "publish this post", "write a perspective", "post to the sustainability group", "share my thoughts on X", "post as AgenticAdvertising.org Team", "publish under the team name", "post as [org name]"',
     input_schema: {
       type: 'object',
       properties: {
@@ -873,9 +873,10 @@ export const MEMBER_TOOLS: AddieTool[] = [
         external_url: { type: 'string', description: 'URL for link type' },
         excerpt: { type: 'string', description: 'Short excerpt/summary' },
         category: { type: 'string', description: 'Category (e.g., Op-Ed, Interview, Ecosystem, White Paper, Press Release)' },
-        author_title: { type: 'string', description: 'Author title/role (e.g., CEO, JourneySpark Consulting)' },
+        author_title: { type: 'string', description: 'Author credential line shown under the byline (e.g., "VP Media Operations, Pinnacle Agency"). Distinct from the byline name — do not use for org names.' },
+        byline: { type: 'string', description: 'Display name for the author byline. Set when the user explicitly asks to post as a team or org name (e.g., "AgenticAdvertising.org Team"). Omit to show the user\'s profile name.' },
         featured_image_url: { type: 'string', description: 'Optional URL for cover image. Omit if the author did not provide one. Do not fabricate or search for a URL.' },
-        content_origin: { type: 'string', enum: ['official', 'member'], description: 'Content origin: official (AAO reports, press releases) or member (member perspectives). Default: member' },
+        content_origin: { type: 'string', enum: ['official', 'member'], description: 'Content origin: official (AgenticAdvertising.org reports, press releases) or member (member perspectives). Default: member' },
         committee_slug: { type: 'string', description: 'Target committee slug (default: editorial for Perspectives). Use list_working_groups to see options.' },
         co_author_emails: { type: 'array', items: { type: 'string' }, description: 'Co-author emails' },
       },
@@ -2629,6 +2630,7 @@ export function createMemberToolHandlers(
     const excerpt = input.excerpt as string | undefined;
     const category = input.category as string | undefined;
     const authorTitle = input.author_title as string | undefined;
+    const byline = input.byline as string | undefined;
     const featuredImageUrl = input.featured_image_url as string | undefined;
     const contentOrigin = (input.content_origin as string | undefined) || 'member';
     const coAuthorEmails = input.co_author_emails as string[] | undefined;
@@ -2671,6 +2673,7 @@ export function createMemberToolHandlers(
         excerpt,
         category,
         author_title: authorTitle,
+        byline,
         featured_image_url: featuredImageUrl,
         content_origin: contentOrigin as 'official' | 'member',
         collection: { committee_slug: committeeSlug },

--- a/server/src/routes/content.ts
+++ b/server/src/routes/content.ts
@@ -92,6 +92,7 @@ interface ProposeContentRequest {
   category?: string;
   tags?: string[];
   author_title?: string;
+  byline?: string;
   featured_image_url?: string;
   content_origin?: 'official' | 'member' | 'external';
   collection: {
@@ -378,6 +379,7 @@ export async function proposeContentForUser(
     category,
     tags = [],
     author_title: requestAuthorTitle,
+    byline: requestByline,
     featured_image_url,
     content_origin = 'member',
     collection,
@@ -414,6 +416,9 @@ export async function proposeContentForUser(
   }
   if (requestAuthorTitle && requestAuthorTitle.length > 255) {
     return { success: false, error: `author_title is too long (max 255 characters; got ${requestAuthorTitle.length})` };
+  }
+  if (requestByline && requestByline.length > 255) {
+    return { success: false, error: `byline is too long (max 255 characters; got ${requestByline.length})` };
   }
   if (external_site_name && external_site_name.length > 255) {
     return { success: false, error: `external_site_name is too long (max 255 characters; got ${external_site_name.length})` };
@@ -505,9 +510,10 @@ export async function proposeContentForUser(
   const publishedAt = status === 'published' ? new Date().toISOString() : null;
   const proposedAt = new Date().toISOString();
 
-  // Get author info for display
+  // Get author info for display; byline overrides the profile name when provided
   const userInfo = await getUserInfo(user.id);
-  const authorName = userInfo?.name || user.email?.split('@')[0] || 'Unknown';
+  const profileName = userInfo?.name || user.email?.split('@')[0] || 'Unknown';
+  const authorName = requestByline?.trim() || profileName;
 
   // Insert the content
   const result = await pool.query(
@@ -1504,7 +1510,8 @@ export function createMyContentRouter(): Router {
         updates.push(`tags = $${paramIndex++}`);
         values.push(tags);
       }
-      if (author_name !== undefined) {
+      const authorNameUpdated = author_name !== undefined && (isProposer || contentItem.author_user_id === user.id || userIsAdmin);
+      if (authorNameUpdated) {
         updates.push(`author_name = $${paramIndex++}`);
         values.push(author_name);
       }
@@ -1568,6 +1575,15 @@ export function createMyContentRouter(): Router {
          RETURNING *`,
         values
       );
+
+      // Keep the primary author's content_authors display_name in sync when the byline changes
+      if (authorNameUpdated && author_name && contentItem.author_user_id) {
+        await pool.query(
+          `UPDATE content_authors SET display_name = $1
+           WHERE perspective_id = $2 AND user_id = $3 AND display_order = 0`,
+          [author_name, id, contentItem.author_user_id]
+        );
+      }
 
       logger.info({ contentId: id, userId: user.id }, 'Content updated');
 


### PR DESCRIPTION
Closes #4888

## Summary

Blog posts on AgenticAdvertising.Org were ignoring requests to publish under "AgenticAdvertising.org Team" — `proposeContentForUser` hardcoded `author_name` to the submitter's WorkOS profile name with no override path, and the Addie `propose_content` tool had no `byline` parameter to communicate the intent. This fixes that, adds the admin-content.html edit field, and closes a pre-existing ungated PATCH vulnerability.

**`propose_content` tool (`member-tools.ts`):** Adds a `byline?: string` parameter with a clear description (`"Display name for the author byline. Set when the user explicitly asks to post as a team or org name…"`) and extends `usage_hints` so Addie correctly maps "post as AgenticAdvertising.org Team" / "publish under the team name" to this parameter rather than to `author_title` (the prior silent failure mode). Also tightens `author_title` description to prevent re-confusion between credential line and byline identity.

**`proposeContentForUser` (`content.ts`):** Adds `byline?: string` to `ProposeContentRequest`, validates it at 255-char max (matching sibling fields), and uses `requestByline?.trim() || profileName` as `authorName` so the byline flows through to both `perspectives.author_name` and the primary `content_authors.display_name`.

**PATCH route (`/api/me/content/:id`):** Gates `author_name` updates to proposer/primary-author/admin only (previously any co-author could silently rebrand someone else's post). Also syncs `content_authors.display_name` for the primary author row (`display_order = 0`) when `author_name` changes.

**Admin-content.html:** Adds a "Author byline" text input in the edit drawer, hidden on create and populated from `item.author_name` on edit. Sends `author_name` in the PUT body only when `id` is set (explicit guard, not CSS-class inspection).

**Non-breaking justification:** `byline` is a new optional field on `ProposeContentRequest`; `ProposeContentRequest` is an internal server interface, not a published protocol schema. Existing callers that omit `byline` see identical behaviour (`authorName` falls through to `profileName`). The PATCH gate is a security tightening that restricts a previously-unrestricted path — no legitimate co-author flow is broken since co-authors cannot currently submit a byline change via any UI.

**Pre-PR review:**
- code-reviewer: approved — length validation matches sibling fields, PATCH gate correct, CSS guard → `if (id)` fix applied, content_authors sync added
- internal-tools-strategist: approved — free-text field correct (no dropdown needed), `if (id)` guard replaces CSS-class check, co-author system orthogonal

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01H9NJy2NrkuqeyEjK51gHWC

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9NJy2NrkuqeyEjK51gHWC)_