### PR TITLE
feat(compliance): capture per-step diagnostics on failing storyboard runs

### DIFF
--- a/.changeset/4738-compliance-step-diagnostics-capture.md
+++ b/.changeset/4738-compliance-step-diagnostics-capture.md
@@ -1,0 +1,4 @@
+---
+---
+
+Capture per-step compliance diagnostics (request + response payloads) on failing storyboard steps and expose them at `GET /api/registry/agents/:encodedUrl/compliance/diagnostics`. Owners can diff the runner's actual wire call against their own probes without re-running the storyboard themselves. Closes the diagnostic gap that drove adcp#4738 — sellers had no way to see why the scoring engine kept returning the same failed verdict when their direct probes succeeded, and ended up triangulating against a hypothetical result cache that does not exist. The SDK already records the exact request/response on every step (`StoryboardStepResult.request` / `.response_record`); we now persist failing-step rows into `agent_compliance_step_diagnostics` (migration 489) keyed by `run_id` with payloads capped at 64KB.

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -24,6 +24,7 @@ import type {
   OverallRunStatus,
   RecordComplianceRunInput,
   StoryboardStatusEntry,
+  StepDiagnosticEntry,
   LifecycleStage,
   TriggeredBy,
 } from '../../db/compliance-db.js';
@@ -575,5 +576,122 @@ export function complianceResultToDbInput(
     observations_json: result.observations,
     triggered_by: triggeredBy,
     storyboard_statuses: deriveStoryboardStatuses(result, storyboardIds),
+    step_diagnostics: extractFailingStepDiagnostics(result),
   };
+}
+
+// ── Step diagnostics extraction (adcp#4738) ─────────────────────────
+
+/**
+ * Per-step JSON payload cap. AdCP wire requests/responses are typically a
+ * few KB; the cap exists to bound the long tail (paginated lists with
+ * hundreds of entries, embedded base64 assets in error echos). 64KB lets a
+ * realistic page-of-160-creatives response through while preventing a
+ * pathological body from bloating the run insert. Truncated payloads are
+ * replaced with a marker object so downstream JSONB readers don't choke.
+ */
+const STEP_DIAGNOSTIC_PAYLOAD_BYTE_CAP = 64 * 1024;
+
+/**
+ * Headers we keep on response captures. AdCP MCP responses don't normally
+ * carry `Set-Cookie` or `Authorization` echoes, but defense-in-depth — the
+ * runner doesn't promise it'll never populate them, and once a JSONB blob
+ * lands in the DB we lose the ability to retroactively redact it.
+ */
+const ALLOWED_RESPONSE_HEADERS = new Set([
+  'content-type',
+  'content-length',
+  'cache-control',
+  'date',
+  'server',
+  'x-request-id',
+  'x-trace-id',
+]);
+
+function sanitizeHeaders(headers: Record<string, string> | undefined): Record<string, string> | undefined {
+  if (!headers) return undefined;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    if (ALLOWED_RESPONSE_HEADERS.has(k.toLowerCase())) out[k] = v;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function capPayload(value: unknown): unknown {
+  if (value === undefined || value === null) return value;
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(value);
+  } catch {
+    return { __truncated: true, reason: 'serialize_failed' };
+  }
+  if (serialized.length <= STEP_DIAGNOSTIC_PAYLOAD_BYTE_CAP) return value;
+  return {
+    __truncated: true,
+    reason: 'size_cap',
+    original_bytes: serialized.length,
+    cap_bytes: STEP_DIAGNOSTIC_PAYLOAD_BYTE_CAP,
+    preview: serialized.slice(0, 2048),
+  };
+}
+
+/**
+ * Walk a ComplianceResult and return one StepDiagnosticEntry per failing
+ * (non-skipped) step. The SDK populates `request` and `response_record` on
+ * every step where the call reached the wire; skipped steps and steps that
+ * never made it past local validation will have neither, and we still emit
+ * a row so the caller knows why the step failed even without payloads.
+ *
+ * `failed_validations_jsonb` only includes validations the runner marked
+ * not-passed — passing validations would be noise on a step that already
+ * failed for a different reason.
+ */
+export function extractFailingStepDiagnostics(result: ComplianceResult): StepDiagnosticEntry[] {
+  const out: StepDiagnosticEntry[] = [];
+  const tracks = result.tracks ?? [];
+  for (const track of tracks) {
+    for (const phase of track.scenarios) {
+      const sepIdx = typeof phase.scenario === 'string' ? phase.scenario.indexOf('/') : -1;
+      if (sepIdx <= 0) continue;
+      const storyboardId = phase.scenario.slice(0, sepIdx);
+      const phaseId = phase.scenario.slice(sepIdx + 1);
+      const steps = (phase as { steps?: any[] }).steps ?? [];
+      for (const step of steps) {
+        if (step.passed) continue;
+        if (step.skipped === true) continue;
+
+        const req = step.request as { url?: string; payload?: unknown } | undefined;
+        const resp = step.response_record as
+          | { status?: number; headers?: Record<string, string>; payload?: unknown }
+          | undefined;
+        const extraction = step.extraction as { path?: string; note?: string } | undefined;
+        const failedValidations = Array.isArray(step.validations)
+          ? step.validations.filter((v: { passed?: boolean }) => v?.passed === false)
+          : undefined;
+
+        out.push({
+          storyboard_id: step.storyboard_id ?? storyboardId,
+          phase_id: step.phase_id ?? phaseId,
+          step_id: step.step_id,
+          task: step.task,
+          step_passed: false,
+          duration_ms: typeof step.duration_ms === 'number' ? step.duration_ms : undefined,
+          request_url: req?.url,
+          request_jsonb: capPayload(req?.payload),
+          response_status: typeof resp?.status === 'number' ? resp.status : undefined,
+          response_headers_jsonb: sanitizeHeaders(resp?.headers),
+          response_jsonb: capPayload(resp?.payload),
+          extraction_path: extraction?.path,
+          extraction_note: extraction?.note,
+          error_text: typeof step.error === 'string' ? step.error : undefined,
+          adcp_error_jsonb: step.adcp_error,
+          failed_validations_jsonb: failedValidations && failedValidations.length > 0
+            ? capPayload(failedValidations)
+            : undefined,
+          served_by_agent_url: typeof step.agent_url === 'string' ? step.agent_url : undefined,
+        });
+      }
+    }
+  }
+  return out;
 }

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -612,7 +612,8 @@ function sanitizeHeaders(headers: Record<string, string> | undefined): Record<st
   if (!headers) return undefined;
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(headers)) {
-    if (ALLOWED_RESPONSE_HEADERS.has(k.toLowerCase())) out[k] = v;
+    const lower = k.toLowerCase();
+    if (ALLOWED_RESPONSE_HEADERS.has(lower)) out[lower] = v;
   }
   return Object.keys(out).length > 0 ? out : undefined;
 }

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -170,6 +170,44 @@ export interface StoryboardStatusEntry {
   steps_total: number;
 }
 
+/**
+ * Per-step wire capture for a failing compliance step. Persisted into
+ * `agent_compliance_step_diagnostics` so sellers can diff the runner's
+ * actual request/response against their own probe without re-running the
+ * storyboard themselves. adcp#4738.
+ *
+ * All fields except the identifying tuple are optional because the SDK
+ * does not guarantee every field on every transport (e.g. stdio MCP omits
+ * `request_url`, error-path responses have no body). Persist what's there;
+ * leave the rest null.
+ */
+export interface StepDiagnosticEntry {
+  storyboard_id: string;
+  phase_id: string;
+  step_id: string;
+  task: string;
+  step_passed: boolean;
+  duration_ms?: number;
+  request_url?: string;
+  request_jsonb?: unknown;
+  response_status?: number;
+  response_headers_jsonb?: Record<string, string>;
+  response_jsonb?: unknown;
+  extraction_path?: string;
+  extraction_note?: string;
+  error_text?: string;
+  adcp_error_jsonb?: unknown;
+  failed_validations_jsonb?: unknown;
+  served_by_agent_url?: string;
+}
+
+export interface ComplianceStepDiagnosticRow extends StepDiagnosticEntry {
+  id: number;
+  run_id: string;
+  agent_url: string;
+  captured_at: Date;
+}
+
 export interface RecordComplianceRunInput {
   agent_url: string;
   lifecycle_stage: LifecycleStage;
@@ -186,6 +224,7 @@ export interface RecordComplianceRunInput {
   triggered_by?: TriggeredBy;
   dry_run?: boolean;
   storyboard_statuses?: StoryboardStatusEntry[];
+  step_diagnostics?: StepDiagnosticEntry[];
 }
 
 // =====================================================
@@ -409,6 +448,81 @@ export class ComplianceDatabase {
         }
       }
 
+      // 6. Batch insert per-step diagnostics (failing steps only).
+      // SAVEPOINT-wrapped so a missing table (pre-migration 489) or a
+      // payload that fails column-level constraints doesn't roll back the
+      // compliance run itself. Diagnostics are an aid, not the verdict.
+      if (input.step_diagnostics?.length) {
+        await client.query('SAVEPOINT step_diag_insert');
+        try {
+          const diag = input.step_diagnostics;
+          await client.query(
+            `INSERT INTO agent_compliance_step_diagnostics (
+              run_id, agent_url, storyboard_id, phase_id, step_id, task,
+              step_passed, duration_ms,
+              request_url, request_jsonb,
+              response_status, response_headers_jsonb, response_jsonb,
+              extraction_path, extraction_note,
+              error_text, adcp_error_jsonb, failed_validations_jsonb,
+              served_by_agent_url
+            )
+            SELECT
+              $1, $2, sb_id, ph_id, st_id, tk,
+              passed, dur,
+              req_url, req_body::jsonb,
+              resp_status, resp_headers::jsonb, resp_body::jsonb,
+              ext_path, ext_note,
+              err_text, adcp_err::jsonb, failed_v::jsonb,
+              served_by
+            FROM unnest(
+              $3::text[], $4::text[], $5::text[], $6::text[],
+              $7::bool[], $8::int[],
+              $9::text[], $10::text[],
+              $11::int[], $12::text[], $13::text[],
+              $14::text[], $15::text[],
+              $16::text[], $17::text[], $18::text[],
+              $19::text[]
+            ) AS t(
+              sb_id, ph_id, st_id, tk,
+              passed, dur,
+              req_url, req_body,
+              resp_status, resp_headers, resp_body,
+              ext_path, ext_note,
+              err_text, adcp_err, failed_v,
+              served_by
+            )`,
+            [
+              run.id,
+              input.agent_url,
+              diag.map(d => d.storyboard_id),
+              diag.map(d => d.phase_id),
+              diag.map(d => d.step_id),
+              diag.map(d => d.task),
+              diag.map(d => d.step_passed),
+              diag.map(d => d.duration_ms ?? null),
+              diag.map(d => d.request_url ?? null),
+              diag.map(d => d.request_jsonb !== undefined ? JSON.stringify(d.request_jsonb) : null),
+              diag.map(d => d.response_status ?? null),
+              diag.map(d => d.response_headers_jsonb ? JSON.stringify(d.response_headers_jsonb) : null),
+              diag.map(d => d.response_jsonb !== undefined ? JSON.stringify(d.response_jsonb) : null),
+              diag.map(d => d.extraction_path ?? null),
+              diag.map(d => d.extraction_note ?? null),
+              diag.map(d => d.error_text ?? null),
+              diag.map(d => d.adcp_error_jsonb !== undefined ? JSON.stringify(d.adcp_error_jsonb) : null),
+              diag.map(d => d.failed_validations_jsonb !== undefined ? JSON.stringify(d.failed_validations_jsonb) : null),
+              diag.map(d => d.served_by_agent_url ?? null),
+            ],
+          );
+          await client.query('RELEASE SAVEPOINT step_diag_insert');
+        } catch (diagErr) {
+          await client.query('ROLLBACK TO SAVEPOINT step_diag_insert');
+          logger.warn(
+            { err: diagErr, agentUrl: input.agent_url, count: input.step_diagnostics.length },
+            'Step diagnostics insert failed (table may not exist yet)',
+          );
+        }
+      }
+
       await client.query('COMMIT');
 
       const row = statusResult.rows[0];
@@ -488,6 +602,63 @@ export class ComplianceDatabase {
       `SELECT * FROM agent_compliance_runs
        WHERE agent_url = $1
        ORDER BY tested_at DESC
+       LIMIT $2`,
+      [agentUrl, limit],
+    );
+    return result.rows;
+  }
+
+  /**
+   * Fetch per-step diagnostics for a single compliance run.
+   *
+   * If `runId` is omitted, resolves to the latest run for the agent. Returns
+   * an empty array when no run exists or no failing steps were captured.
+   * Diagnostics are owner-only PII (request bodies can contain seller-side
+   * account identifiers, brand domains, etc.) — callers are responsible for
+   * gating with the appropriate ownership middleware.
+   */
+  async getStepDiagnostics(
+    agentUrl: string,
+    opts: { runId?: string; limit?: number } = {},
+  ): Promise<ComplianceStepDiagnosticRow[]> {
+    const limit = Math.min(opts.limit ?? 500, 1000);
+    if (opts.runId) {
+      const result = await query(
+        `SELECT id, run_id, agent_url, storyboard_id, phase_id, step_id, task,
+                step_passed, duration_ms,
+                request_url, request_jsonb,
+                response_status, response_headers_jsonb, response_jsonb,
+                extraction_path, extraction_note,
+                error_text, adcp_error_jsonb, failed_validations_jsonb,
+                served_by_agent_url, captured_at
+         FROM agent_compliance_step_diagnostics
+         WHERE run_id = $1 AND agent_url = $2
+         ORDER BY storyboard_id, phase_id, step_id
+         LIMIT $3`,
+        [opts.runId, agentUrl, limit],
+      );
+      return result.rows;
+    }
+
+    // Latest run by tested_at — diagnostics are joined via run_id.
+    const result = await query(
+      `WITH latest AS (
+         SELECT id FROM agent_compliance_runs
+         WHERE agent_url = $1
+         ORDER BY tested_at DESC
+         LIMIT 1
+       )
+       SELECT d.id, d.run_id, d.agent_url, d.storyboard_id, d.phase_id, d.step_id, d.task,
+              d.step_passed, d.duration_ms,
+              d.request_url, d.request_jsonb,
+              d.response_status, d.response_headers_jsonb, d.response_jsonb,
+              d.extraction_path, d.extraction_note,
+              d.error_text, d.adcp_error_jsonb, d.failed_validations_jsonb,
+              d.served_by_agent_url, d.captured_at
+       FROM agent_compliance_step_diagnostics d
+       JOIN latest l ON d.run_id = l.id
+       WHERE d.agent_url = $1
+       ORDER BY d.storyboard_id, d.phase_id, d.step_id
        LIMIT $2`,
       [agentUrl, limit],
     );

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -503,7 +503,7 @@ export class ComplianceDatabase {
               diag.map(d => d.request_url ?? null),
               diag.map(d => d.request_jsonb !== undefined ? JSON.stringify(d.request_jsonb) : null),
               diag.map(d => d.response_status ?? null),
-              diag.map(d => d.response_headers_jsonb ? JSON.stringify(d.response_headers_jsonb) : null),
+              diag.map(d => d.response_headers_jsonb !== undefined ? JSON.stringify(d.response_headers_jsonb) : null),
               diag.map(d => d.response_jsonb !== undefined ? JSON.stringify(d.response_jsonb) : null),
               diag.map(d => d.extraction_path ?? null),
               diag.map(d => d.extraction_note ?? null),

--- a/server/src/db/migrations/489_compliance_step_diagnostics.sql
+++ b/server/src/db/migrations/489_compliance_step_diagnostics.sql
@@ -1,0 +1,74 @@
+-- Per-step diagnostic capture for compliance runs (adcp#4738).
+--
+-- Sellers debugging failing compliance verdicts cannot today see the exact
+-- request the runner sent or the exact response their agent returned. They
+-- replay storyboards by hand against their own auth/account, the calls pass,
+-- and we end up triangulating against a hypothesised "scoring engine cache"
+-- that does not exist. The actual divergence is usually that the runner's
+-- request body (account, brand, correlation_id, idempotency_key) differs from
+-- whatever the seller probed with.
+--
+-- The SDK already records the exact wire request and response on every step
+-- (RunnerRequestRecord / RunnerResponseRecord on StoryboardStepResult). We
+-- just don't persist it. This table captures the failing steps so owners can
+-- diff their probe against the runner's call without filing a ticket.
+--
+-- Policy: only failing (non-skipped) steps are captured. Skipped steps carry
+-- no wire payload by construction; passing steps would balloon storage
+-- without diagnostic value. If we need to widen later, the `step_passed`
+-- column lets us include sampled passing rows without a schema change.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS agent_compliance_step_diagnostics (
+  id BIGSERIAL PRIMARY KEY,
+  run_id UUID NOT NULL REFERENCES agent_compliance_runs(id) ON DELETE CASCADE,
+  agent_url TEXT NOT NULL,
+
+  storyboard_id TEXT NOT NULL,
+  phase_id TEXT NOT NULL,
+  step_id TEXT NOT NULL,
+  task TEXT NOT NULL,
+
+  step_passed BOOLEAN NOT NULL,
+  duration_ms INTEGER,
+
+  -- Wire payloads (capped client-side; see compliance-testing.ts).
+  -- request_jsonb is what the runner sent; response_jsonb is the parsed body
+  -- the runner observed. Headers omitted from request (SDK refuses to surface
+  -- Authorization bearers); response headers retained for content-type and
+  -- cache-control surfaces.
+  request_url TEXT,
+  request_jsonb JSONB,
+  response_status INTEGER,
+  response_headers_jsonb JSONB,
+  response_jsonb JSONB,
+
+  -- Provenance of the parsed response (structured_content / text_fallback /
+  -- error / none). Lets implementors distinguish runner extraction bugs
+  -- from agent bugs without re-running.
+  extraction_path TEXT,
+  extraction_note TEXT,
+
+  -- Failure context.
+  error_text TEXT,
+  adcp_error_jsonb JSONB,
+  failed_validations_jsonb JSONB,
+
+  -- Multi-instance routing — which replica served this step.
+  served_by_agent_url TEXT,
+
+  captured_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Owner debug flow: "show me the failing steps from the latest run for this
+-- agent." Hits run_id directly; outer join from agent_compliance_runs by id.
+CREATE INDEX IF NOT EXISTS idx_compliance_step_diag_run
+  ON agent_compliance_step_diagnostics(run_id);
+
+-- Cross-run regression flow: "has this step been failing the same way for
+-- the last N runs?" Lets the owner spot deterministic failures vs flakes.
+CREATE INDEX IF NOT EXISTS idx_compliance_step_diag_agent_step_time
+  ON agent_compliance_step_diagnostics(agent_url, storyboard_id, step_id, captured_at DESC);
+
+COMMIT;

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -5302,6 +5302,50 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     }
   });
 
+  // ── Per-step compliance diagnostics (owner-only, adcp#4738) ──────
+  //
+  // Returns the exact request/response payloads the runner captured for
+  // failing storyboard steps on a single compliance run. Lets owners diff
+  // what the runner sent against their own probes without re-running.
+  // Owner-only because payloads echo seller-side account/brand identifiers
+  // and may contain sensitive descriptive fields.
+  router.get(
+    "/registry/agents/:encodedUrl/compliance/diagnostics",
+    ...complianceWriteMiddleware,
+    async (req, res) => {
+      try {
+        const agentUrl = decodeURIComponent(req.params.encodedUrl);
+        if (!validateAgentUrlParam(agentUrl)) {
+          return res.status(400).json({ error: "Invalid agent URL" });
+        }
+        if (!req.user) {
+          return res.status(401).json({ error: "Authentication required" });
+        }
+        const isOwner = await verifyAgentOwnership(req.user.id, agentUrl);
+        if (!isOwner) {
+          return res.status(403).json({ error: "You do not have permission to view this agent" });
+        }
+
+        const runId = typeof req.query.run_id === "string" ? req.query.run_id : undefined;
+        const limit = req.query.limit !== undefined
+          ? Math.min(parseInt(req.query.limit as string) || 500, 1000)
+          : undefined;
+
+        const rows = await complianceDb.getStepDiagnostics(agentUrl, { runId, limit });
+
+        res.json({
+          agent_url: agentUrl,
+          run_id: runId ?? (rows[0]?.run_id ?? null),
+          count: rows.length,
+          diagnostics: rows,
+        });
+      } catch (error) {
+        logger.error({ err: error, path: req.path }, "Failed to get compliance diagnostics");
+        res.status(500).json({ error: "Failed to get compliance diagnostics" });
+      }
+    },
+  );
+
   router.get("/registry/agents/:encodedUrl/monitoring/requests", ...complianceWriteMiddleware, async (req, res) => {
     try {
       const agentUrl = decodeURIComponent(req.params.encodedUrl);

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -66,6 +66,7 @@ import {
   RegistryMetadataSchema,
   MonitoringSettingsSchema,
   ComplianceRunSchema,
+  ComplianceStepDiagnosticSchema,
   OutboundRequestSchema,
   AgentAuthStatusSchema,
   CredentialSaveValidationErrorSchema,
@@ -2178,6 +2179,45 @@ registry.registerPath({
     401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
     403: { description: "Not authorized", content: { "application/json": { schema: ErrorSchema } } },
     429: { description: "Rate limited", content: { "application/json": { schema: ErrorSchema } } },
+    500: { description: "Server error", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/registry/agents/{encodedUrl}/compliance/diagnostics",
+  operationId: "getAgentComplianceStepDiagnostics",
+  summary: "Get per-step diagnostics for a compliance run",
+  description:
+    "Returns the exact request and response payloads the runner captured for failing storyboard steps on a single compliance run.\n\nLets agent owners diff what the runner sent against their own probes without re-running the storyboard. Owner-only — payloads echo seller-side account/brand identifiers and may carry sensitive descriptive fields. If `run_id` is omitted, resolves to the latest run for the agent.",
+  tags: ["Agent Compliance"],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
+  request: {
+    params: z.object({
+      encodedUrl: z.string().openapi({ description: "URL-encoded agent URL" }),
+    }),
+    query: z.object({
+      run_id: z.string().optional().openapi({ description: "Specific compliance run UUID. Defaults to latest." }),
+      limit: z.string().optional().openapi({ description: "Max rows (default 500, max 1000)" }),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Per-step diagnostics for the requested run",
+      content: {
+        "application/json": {
+          schema: z.object({
+            agent_url: z.string(),
+            run_id: z.string().nullable(),
+            count: z.number().int(),
+            diagnostics: z.array(ComplianceStepDiagnosticSchema),
+          }),
+        },
+      },
+    },
+    400: { description: "Invalid agent URL", content: { "application/json": { schema: ErrorSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
+    403: { description: "Not authorized", content: { "application/json": { schema: ErrorSchema } } },
     500: { description: "Server error", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
@@ -5326,16 +5366,25 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           return res.status(403).json({ error: "You do not have permission to view this agent" });
         }
 
-        const runId = typeof req.query.run_id === "string" ? req.query.run_id : undefined;
-        const limit = req.query.limit !== undefined
-          ? Math.min(parseInt(req.query.limit as string) || 500, 1000)
-          : undefined;
+        const runIdRaw = typeof req.query.run_id === "string" ? req.query.run_id : undefined;
+        if (runIdRaw !== undefined && !isUuid(runIdRaw)) {
+          return res.status(400).json({ error: "Invalid run_id (expected UUID)" });
+        }
 
-        const rows = await complianceDb.getStepDiagnostics(agentUrl, { runId, limit });
+        let limit: number | undefined;
+        if (typeof req.query.limit === "string") {
+          const parsed = Number(req.query.limit);
+          if (!Number.isFinite(parsed) || parsed <= 0) {
+            return res.status(400).json({ error: "Invalid limit (expected positive integer)" });
+          }
+          limit = Math.min(Math.floor(parsed), 1000);
+        }
+
+        const rows = await complianceDb.getStepDiagnostics(agentUrl, { runId: runIdRaw, limit });
 
         res.json({
           agent_url: agentUrl,
-          run_id: runId ?? (rows[0]?.run_id ?? null),
+          run_id: runIdRaw ?? (rows[0]?.run_id ?? null),
           count: rows.length,
           diagnostics: rows,
         });

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -731,6 +731,32 @@ export const ComplianceRunSchema = z
   })
   .openapi("ComplianceRun");
 
+export const ComplianceStepDiagnosticSchema = z
+  .object({
+    id: z.union([z.number(), z.string()]),
+    run_id: z.string(),
+    agent_url: z.string(),
+    storyboard_id: z.string(),
+    phase_id: z.string(),
+    step_id: z.string(),
+    task: z.string(),
+    step_passed: z.boolean(),
+    duration_ms: z.number().nullable().optional(),
+    request_url: z.string().nullable().optional(),
+    request_jsonb: z.any().optional(),
+    response_status: z.number().nullable().optional(),
+    response_headers_jsonb: z.record(z.string(), z.string()).nullable().optional(),
+    response_jsonb: z.any().optional(),
+    extraction_path: z.string().nullable().optional(),
+    extraction_note: z.string().nullable().optional(),
+    error_text: z.string().nullable().optional(),
+    adcp_error_jsonb: z.any().optional(),
+    failed_validations_jsonb: z.any().optional(),
+    served_by_agent_url: z.string().nullable().optional(),
+    captured_at: z.string(),
+  })
+  .openapi("ComplianceStepDiagnostic");
+
 export const OutboundRequestSchema = z
   .object({
     id: z.string(),

--- a/server/tests/unit/compliance-step-diagnostics.test.ts
+++ b/server/tests/unit/compliance-step-diagnostics.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@adcp/sdk/testing', () => ({
+  setAgentTesterLogger: vi.fn(),
+  comply: vi.fn(),
+  loadComplianceIndex: vi.fn(() => ({ specialisms: [] })),
+  SAMPLE_BRIEFS: [],
+  getBriefsByVertical: vi.fn(() => []),
+}));
+
+vi.mock('../../src/services/storyboards.js', () => ({
+  getStoryboard: vi.fn(() => null),
+  getAllStoryboards: vi.fn(() => []),
+}));
+
+vi.mock('../../src/services/adcp-taxonomy.js', () => ({
+  isStableSpecialism: vi.fn(() => true),
+}));
+
+import {
+  extractFailingStepDiagnostics,
+  complianceResultToDbInput,
+} from '../../src/addie/services/compliance-testing.js';
+
+function step(overrides: Record<string, unknown>) {
+  return {
+    storyboard_id: 'creative_lifecycle',
+    step_id: 'list_all',
+    phase_id: 'list_and_filter',
+    title: 'List all creatives',
+    task: 'list_creatives',
+    passed: false,
+    duration_ms: 123,
+    validations: [],
+    context: {},
+    extraction: { path: 'structured_content' },
+    ...overrides,
+  };
+}
+
+function phase(scenarioKey: string, steps: any[]) {
+  return {
+    scenario: scenarioKey,
+    overall_passed: steps.every(s => s.passed),
+    steps,
+  };
+}
+
+function resultWith(tracks: any[]) {
+  return {
+    overall_status: 'partial',
+    tracks,
+    summary: {
+      headline: 'fixture',
+      tracks_passed: 0,
+      tracks_failed: 1,
+      tracks_partial: 0,
+      tracks_skipped: 0,
+    },
+    total_duration_ms: 500,
+    agent_profile: { name: 'test', tools: [] },
+    observations: [],
+  };
+}
+
+describe('extractFailingStepDiagnostics', () => {
+  it('captures request + response payloads for a failing wire step', () => {
+    const failing = step({
+      passed: false,
+      request: {
+        transport: 'mcp_http',
+        url: 'https://adcp.bidmachine.io/adcp/mcp',
+        payload: {
+          account: { brand: { domain: 'acmeoutdoor.example' }, operator: 'pinnacle-agency.example' },
+          context: { correlation_id: 'creative_lifecycle--list_all' },
+        },
+      },
+      response_record: {
+        transport: 'mcp_http',
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+        payload: { creatives: [], total_matching: 0 },
+        duration_ms: 87,
+      },
+      validations: [
+        { check: 'field_present', path: 'creatives', passed: true },
+        { check: 'field_value', path: 'context.correlation_id', passed: false, expected: 'creative_lifecycle--list_all', actual: undefined },
+      ],
+    });
+
+    const out = extractFailingStepDiagnostics(
+      resultWith([
+        { track: 'creative', status: 'fail', duration_ms: 100, scenarios: [phase('creative_lifecycle/list_and_filter', [failing])] },
+      ]) as any,
+    );
+
+    expect(out).toHaveLength(1);
+    const d = out[0];
+    expect(d.storyboard_id).toBe('creative_lifecycle');
+    expect(d.phase_id).toBe('list_and_filter');
+    expect(d.step_id).toBe('list_all');
+    expect(d.task).toBe('list_creatives');
+    expect(d.step_passed).toBe(false);
+    expect(d.duration_ms).toBe(123);
+    expect(d.request_url).toBe('https://adcp.bidmachine.io/adcp/mcp');
+    expect(d.request_jsonb).toMatchObject({
+      account: { brand: { domain: 'acmeoutdoor.example' } },
+      context: { correlation_id: 'creative_lifecycle--list_all' },
+    });
+    expect(d.response_status).toBe(200);
+    expect(d.response_jsonb).toEqual({ creatives: [], total_matching: 0 });
+    expect(d.extraction_path).toBe('structured_content');
+    expect(d.failed_validations_jsonb).toEqual([
+      { check: 'field_value', path: 'context.correlation_id', passed: false, expected: 'creative_lifecycle--list_all', actual: undefined },
+    ]);
+  });
+
+  it('skips passing and skipped steps', () => {
+    const passing = step({ passed: true, step_id: 'passing_step' });
+    const skipped = step({ passed: false, skipped: true, step_id: 'skipped_step', skip_reason: 'missing_tool' });
+    const failed = step({ passed: false, step_id: 'failed_step' });
+
+    const out = extractFailingStepDiagnostics(
+      resultWith([
+        { track: 'creative', status: 'partial', duration_ms: 100, scenarios: [phase('sb/phase', [passing, skipped, failed])] },
+      ]) as any,
+    );
+
+    expect(out).toHaveLength(1);
+    expect(out[0].step_id).toBe('failed_step');
+  });
+
+  it('emits a row when a step failed without reaching the wire', () => {
+    // Step that failed during local request building — no request/response_record.
+    const localFail = step({
+      passed: false,
+      step_id: 'no_wire',
+      error: 'Schema validation failed before send',
+      request: undefined,
+      response_record: undefined,
+    });
+
+    const out = extractFailingStepDiagnostics(
+      resultWith([
+        { track: 'creative', status: 'fail', duration_ms: 5, scenarios: [phase('sb/phase', [localFail])] },
+      ]) as any,
+    );
+
+    expect(out).toHaveLength(1);
+    expect(out[0].step_id).toBe('no_wire');
+    expect(out[0].request_url).toBeUndefined();
+    expect(out[0].request_jsonb).toBeUndefined();
+    expect(out[0].response_status).toBeUndefined();
+    expect(out[0].response_jsonb).toBeUndefined();
+    expect(out[0].error_text).toBe('Schema validation failed before send');
+  });
+
+  it('truncates oversized payloads with a marker', () => {
+    const huge = { creatives: Array.from({ length: 5000 }, (_, i) => ({ creative_id: `id_${i}`, padding: 'x'.repeat(64) })) };
+    const failing = step({
+      passed: false,
+      request: { transport: 'mcp_http', url: 'https://x/mcp', payload: { ok: true } },
+      response_record: { transport: 'mcp_http', status: 200, payload: huge },
+    });
+
+    const out = extractFailingStepDiagnostics(
+      resultWith([
+        { track: 'creative', status: 'fail', duration_ms: 100, scenarios: [phase('sb/phase', [failing])] },
+      ]) as any,
+    );
+
+    expect(out).toHaveLength(1);
+    const body = out[0].response_jsonb as Record<string, unknown>;
+    expect(body.__truncated).toBe(true);
+    expect(body.reason).toBe('size_cap');
+    expect(typeof body.original_bytes).toBe('number');
+    expect(out[0].request_jsonb).toEqual({ ok: true });
+  });
+
+  it('drops disallowed response headers (Set-Cookie, Authorization) and keeps content-type', () => {
+    const failing = step({
+      passed: false,
+      request: { transport: 'mcp_http', payload: { ok: true } },
+      response_record: {
+        transport: 'mcp_http',
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          'set-cookie': 'session=abc123; HttpOnly',
+          authorization: 'Bearer leaked-token',
+          'cache-control': 'no-store',
+        },
+        payload: { ok: false },
+      },
+    });
+
+    const out = extractFailingStepDiagnostics(
+      resultWith([
+        { track: 'creative', status: 'fail', duration_ms: 10, scenarios: [phase('sb/phase', [failing])] },
+      ]) as any,
+    );
+
+    expect(out).toHaveLength(1);
+    const headers = out[0].response_headers_jsonb!;
+    expect(headers['content-type']).toBe('application/json');
+    expect(headers['cache-control']).toBe('no-store');
+    expect(headers).not.toHaveProperty('set-cookie');
+    expect(headers).not.toHaveProperty('authorization');
+  });
+
+  it('skips phases whose scenario key has no storyboard/phase separator', () => {
+    const orphan = step({ passed: false });
+    const out = extractFailingStepDiagnostics(
+      resultWith([
+        { track: 'creative', status: 'fail', duration_ms: 10, scenarios: [phase('bare_legacy_scenario', [orphan])] },
+      ]) as any,
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('is wired into complianceResultToDbInput', () => {
+    const failing = step({
+      passed: false,
+      request: { transport: 'mcp_http', payload: { x: 1 } },
+      response_record: { transport: 'mcp_http', status: 200, payload: { y: 2 } },
+    });
+    const result = resultWith([
+      { track: 'creative', status: 'fail', duration_ms: 10, scenarios: [phase('creative_lifecycle/list_and_filter', [failing])] },
+    ]);
+
+    const dbInput = complianceResultToDbInput(result as any, 'https://x/mcp', 'production');
+    expect(dbInput.step_diagnostics).toBeDefined();
+    expect(dbInput.step_diagnostics).toHaveLength(1);
+    expect(dbInput.step_diagnostics?.[0].storyboard_id).toBe('creative_lifecycle');
+  });
+});

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -1719,6 +1719,77 @@ components:
         - monitoring_paused
         - check_interval_hours
         - monitoring_paused_at
+    ComplianceStepDiagnostic:
+      type: object
+      properties:
+        id:
+          anyOf:
+            - type: number
+            - type: string
+        run_id:
+          type: string
+        agent_url:
+          type: string
+        storyboard_id:
+          type: string
+        phase_id:
+          type: string
+        step_id:
+          type: string
+        task:
+          type: string
+        step_passed:
+          type: boolean
+        duration_ms:
+          type:
+            - number
+            - "null"
+        request_url:
+          type:
+            - string
+            - "null"
+        request_jsonb: {}
+        response_status:
+          type:
+            - number
+            - "null"
+        response_headers_jsonb:
+          type:
+            - object
+            - "null"
+          additionalProperties:
+            type: string
+        response_jsonb: {}
+        extraction_path:
+          type:
+            - string
+            - "null"
+        extraction_note:
+          type:
+            - string
+            - "null"
+        error_text:
+          type:
+            - string
+            - "null"
+        adcp_error_jsonb: {}
+        failed_validations_jsonb: {}
+        served_by_agent_url:
+          type:
+            - string
+            - "null"
+        captured_at:
+          type: string
+      required:
+        - id
+        - run_id
+        - agent_url
+        - storyboard_id
+        - phase_id
+        - step_id
+        - task
+        - step_passed
+        - captured_at
     OutboundRequest:
       type: object
       properties:
@@ -6367,6 +6438,90 @@ paths:
                 $ref: "#/components/schemas/Error"
         "429":
           description: Rate limited
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/compliance/diagnostics:
+    get:
+      operationId: getAgentComplianceStepDiagnostics
+      summary: Get per-step diagnostics for a compliance run
+      description: |-
+        Returns the exact request and response payloads the runner captured for failing storyboard steps on a single compliance run.
+
+        Lets agent owners diff what the runner sent against their own probes without re-running the storyboard. Owner-only — payloads echo seller-side account/brand identifiers and may carry sensitive descriptive fields. If `run_id` is omitted, resolves to the latest run for the agent.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+            description: Specific compliance run UUID. Defaults to latest.
+          required: false
+          description: Specific compliance run UUID. Defaults to latest.
+          name: run_id
+          in: query
+        - schema:
+            type: string
+            description: Max rows (default 500, max 1000)
+          required: false
+          description: Max rows (default 500, max 1000)
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Per-step diagnostics for the requested run
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  run_id:
+                    type:
+                      - string
+                      - "null"
+                  count:
+                    type: integer
+                  diagnostics:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ComplianceStepDiagnostic"
+                required:
+                  - agent_url
+                  - run_id
+                  - count
+                  - diagnostics
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Summary

- Persist per-step request/response payloads for **failing** storyboard steps into a new `agent_compliance_step_diagnostics` table (migration 489), keyed by `run_id`.
- Expose them via `GET /api/registry/agents/:encodedUrl/compliance/diagnostics` (owner-only).
- Closes the diagnostic gap behind adcp#4738: sellers had no way to see why the scoring engine kept returning the same failed verdict when their direct probes succeeded, and ended up triangulating against a hypothetical result cache that does not exist. The actual gap is almost always that the runner sends fixture-authored `account` / `brand` / `correlation_id` values the seller never replays.

## Mechanics

The SDK already records the exact wire payloads on every step (`StoryboardStepResult.request` / `.response_record`). We were just dropping them. This PR:

- Adds `StepDiagnosticEntry` and threads it through `RecordComplianceRunInput`. Insert is `SAVEPOINT`-wrapped so a missing table (pre-migration) or bad payload doesn't roll back the run itself.
- Caps each JSON payload at 64KB with a structured truncation marker (a 160-creative page fits well under).
- Filters response headers to the content-type/cache-control surface — defensive against the SDK ever populating `Set-Cookie` / `Authorization` echoes.
- Captures **failing, non-skipped** steps only. `step_passed` column keeps room to widen to sampled passing rows later without a schema change.
- Read endpoint is gated by `complianceWriteMiddleware` + `verifyAgentOwnership` because payloads echo seller-side account/brand identifiers.

## Test plan

- [x] Unit tests for `extractFailingStepDiagnostics`: wire success, passing/skipped exclusion, no-wire fallback, payload cap, header sanitization, orphan scenario, wiring into `complianceResultToDbInput` (7 tests, all passing).
- [x] Server typecheck.
- [x] Pre-commit unit suite + dynamic-imports + callapi-state-change.
- [ ] Manual verification on staging: trigger a heartbeat run against a failing agent, then `GET /api/registry/agents/.../compliance/diagnostics` and confirm payloads land.

## Follow-ups (out of scope for this PR)

- Surface a "see diagnostics" pointer in the `check_agent_health` MCP tool output when a run failed.
- Dashboard rendering of the diff between runner request and the storyboard fixture.
- The wire-vs-internal latency anomaly the seller reported (60.5s in our report vs 0–2.4s on Railway audit) is independent of this PR and still needs its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)