### PR TITLE
feat(aao-directory): add ?include=properties for set-diff divergence detection

### DIFF
--- a/.changeset/4890-include-properties-set-diff.md
+++ b/.changeset/4890-include-properties-set-diff.md
@@ -1,0 +1,18 @@
+---
+"adcontextprotocol": minor
+---
+
+feat(aao-directory): add `?include=properties` to agent-publishers endpoint
+
+Adds an opt-in `?include=properties` query parameter to
+`GET /v1/agents/{agent_url}/publishers`. When set, each `PublisherEntry`
+carries a `property_ids: array[string]` field — the canonical list of
+property IDs the agent's selectors resolve to under that publisher.
+
+This unblocks full set-diff divergence detection in SDK clients.
+Count-equality is not set-equality: a publisher rotating three properties
+leaves `properties_authorized` unchanged while the entire authorized set
+changes. `property_ids` gives SDK divergence detectors the data they need
+to catch this class of silent drift.
+
+Non-breaking: default off, existing response envelope unchanged.

--- a/docs/aao/directory-api.mdx
+++ b/docs/aao/directory-api.mdx
@@ -30,6 +30,7 @@ GET https://{aao_directory}/v1/agents/{agent_url}/publishers
 | `cursor` | opaque string | unset | Pagination cursor returned by a prior response. Stable across the directory's refresh cycle for the lifetime of the cursor. |
 | `status` | string, repeated | `authorized` | Filter by lifecycle status. v1: `authorized`, `revoked`. Repeat the key once per value (OpenAPI `style: form, explode: true`). Comma-separated single-value form (`status=authorized,revoked`) is **not** accepted; directories MUST return `400` with an explanation pointing to the repeated-key form. |
 | `limit` | int (1–1000) | 200 | Max publishers per page. |
+| `include` | string, repeated | unset | Opt-in field expansion. v1 value: `properties`. When set, each `PublisherEntry` carries a `property_ids` array (see below). Operators using divergence detection SHOULD pass `include=properties` to enable full set-diff instead of count-only comparison. |
 
 #### Worked example: filtering by multiple status values
 
@@ -137,6 +138,54 @@ Repeated-key was chosen because (a) it is what `URLSearchParams.append()` and Op
 | `signing_keys_pinned` | optional | Whether the publisher pins `signing_keys[]` on this agent. When `true`, agent's signed responses MUST verify against the pinned set regardless of the agent's own JWKS. |
 | `status` | yes | `authorized` or `revoked`. See below. |
 | `last_verified_at` | yes | When the directory last fetched and validated this publisher's `adagents.json`. |
+| `property_ids` | conditional | Present only when `?include=properties` was set. Array of `property_id` strings the agent's selectors resolve to under this publisher. Length MUST equal `properties_authorized`. See [Property ID expansion](#property-id-expansion). |
+
+### Property ID expansion
+
+Adding `?include=properties` to the request expands each `PublisherEntry` with a `property_ids` array — the canonical list of `property_id` strings the agent's selectors resolve to under that publisher:
+
+```
+GET /v1/agents/https%3A%2F%2Fsales-agent.example.com%2F/publishers?include=properties
+```
+
+```json
+{
+  "publishers": [
+    {
+      "publisher_domain": "recipeswithessentialoils.com",
+      "discovery_method": "ads_txt_managerdomain",
+      "manager_domain": "cafemedia.com",
+      "properties_authorized": 3,
+      "properties_total": 3,
+      "property_ids": ["homepage", "mobile_ios", "amp"],
+      "signing_keys_pinned": false,
+      "status": "authorized",
+      "last_verified_at": "2026-05-19T08:00:00Z"
+    }
+  ]
+}
+```
+
+`property_ids` is **absent by default** — the `?include=properties` flag opts in. This preserves the existing response envelope for callers that do not need the expanded form.
+
+**Why `?include=properties` matters for divergence detection.** Count-equality does not imply set-equality. A publisher that rotates three properties (`{p-001, p-002, p-003}` → `{p-004, p-005, p-006}`) leaves `properties_authorized` unchanged at 3, so a count-only comparison returns "no divergence" even though the entire authorized set changed. Set-diff on `property_ids` catches this. The SDK divergence detector (`detect_publisher_properties_divergence`) uses `property_ids` for a full set-diff when available; operators using the detector SHOULD pass `include=properties`.
+
+When `property_ids` is present, its length MUST equal `properties_authorized` — both are derived from the same selector-predicate resolution at index time.
+
+The OpenAPI fragment for `include`:
+
+```yaml
+- in: query
+  name: include
+  schema:
+    type: array
+    items:
+      type: string
+      enum: [properties]
+  style: form
+  explode: true
+  required: false
+```
 
 ### `discovery_method` values
 
@@ -207,7 +256,7 @@ On managed-network-shape parent files (per [adcp#4825 inline resolution rule](/d
 - **Authentication.** Public endpoint, anonymous rate limiting. Identity-bound limits arrive in a separate RFC if needed.
 - **Cross-directory federation.** Single directory. The endpoint shape is defined such that multiple AAO-compatible directories could implement it; discovery of which directory to query is configuration today.
 - **Push notification of new authorizations.** Poll-based v1.
-- **Inline property detail.** `properties_authorized` / `properties_total` are counts only; full property lists arrive via a future `?include=properties` if operators ask.
+- **Full property objects.** `?include=properties` returns `property_id` strings only; full property detail (name, domain, format capabilities) is available via existing per-domain primitives and is out of scope for the directory response.
 
 ## See also
 

--- a/static/schemas/source/aao/agent-publishers.json
+++ b/static/schemas/source/aao/agent-publishers.json
@@ -88,6 +88,13 @@
           "type": "string",
           "format": "date-time",
           "description": "When the directory last fetched and validated this publisher's adagents.json. Distinct from the envelope's `directory_indexed_at` — `last_verified_at` is per-publisher freshness, the envelope value is the most recent refresh in the result set."
+        },
+        "property_ids": {
+          "type": "array",
+          "description": "Canonical list of property_ids the agent's selectors resolve to under this publisher. Present only when `?include=properties` was set on the request; absent otherwise. When present, length MUST equal `properties_authorized` — both are derived from the same selector-predicate resolution at index time. Operators using divergence detection SHOULD prefer set-diff on `property_ids` over count-only comparison: count-equality does not imply set-equality when a publisher rotates properties (same count, entirely different set).",
+          "items": {
+            "$ref": "/schemas/core/property-id.json"
+          }
         }
       },
       "allOf": [


### PR DESCRIPTION
Closes #4890

Adds an opt-in `?include=properties` query parameter to `GET /v1/agents/{agent_url}/publishers`. When set, each `PublisherEntry` in the response carries a `property_ids: array[string]` field — the canonical list of property IDs the agent's selectors resolve to under that publisher. Default off; existing response envelope unchanged for callers that omit the flag.

This unblocks the SDK divergence detector (`detect_publisher_properties_divergence` in adcp-client-python#752 and mirrors in adcp-client/adcp-go) from count-only comparison to full set-diff. Count-equality is not set-equality: a publisher rotating three properties (`{p-001, p-002, p-003}` → `{p-004, p-005, p-006}`) leaves `properties_authorized` unchanged at 3 while the entire authorized set changes silently. `property_ids` closes that gap. The companion SDK upgrades (tracked in #4890 acceptance criteria) should follow in a coordinated release cycle so operators relying on `detect_publisher_properties_divergence` migrate together.

**Non-breaking justification:** Adds an optional query parameter (`?include=properties`, default unset) and an optional response field (`property_ids`, absent when flag is not set). Existing consumers receive an identical envelope with no new field. No required field added, no field removed, no enum value changed. `minor` changeset per AdCP semver rules.

**Milestone:** `3.1.0` (minor bump → `main`; ships as `3.1.0-beta.N` while pre-mode is active)

**Pre-PR review:**
- code-reviewer: approved — no blockers. Nit: `recipeswithessentialoils.com` in worked example is a real domain (pre-existing in docs before this PR); nit: `property_ids` field placement in schema/table could move adjacent to `properties_total` for grouping clarity.
- ad-tech-protocol-expert: approved — non-breaking per spec. `include=properties` follows the `status` repeated-key encoding convention exactly. `minor` bump confirmed correct. Nit: normative MUST `len(property_ids) == properties_authorized` is prose-only; JSON Schema draft-07 cannot express cross-field cardinality. A conformance storyboard assertion should cover this invariant (tracked as a follow-up).

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_0198vqiJviQkgCoSn98WWdE6

---
_Generated by [Claude Code](https://claude.ai/code/session_0198vqiJviQkgCoSn98WWdE6)_