### PR TITLE
fix(certification): repair script verifies Certifier attribute override (closes #4885)

### DIFF
--- a/.changeset/4885-certifier-attribute-override-verification.md
+++ b/.changeset/4885-certifier-attribute-override-verification.md
@@ -1,0 +1,14 @@
+---
+---
+
+fix(certification): repair script reads Certifier `attributes['recipient.name']` (the actual render layer), not the stale `recipient.name` snapshot
+
+Closes #4885. Earlier diagnosis was wrong — the repair script's PATCH `/credentials/{id}` does succeed; Certifier writes the new name into the credential's `attributes` override map, and the certificate design template renders from that override (verified on Credsverse: Tom Hespos, Tom Charles, Tsvetelina Georgieva, Davide Astuto all show the correct name today). The `recipient.name` field on the credential GET is a denormalized snapshot that stays stale — it does NOT drive rendering.
+
+The actual bug: the script's `needsRepair()` compared against `recipient.name`, so the dry-run kept reporting already-fixed credentials as still-broken. This produced the false "silent-success" signal that originally went into #4885.
+
+Fix:
+- `server/src/services/certifier-client.ts` — declare `attributes?: Record<string, string>` on `CertifierCredential`; document the snapshot-vs-override semantics on both the `recipient` and `attributes` fields and on `updateCredential`.
+- `server/src/scripts/repair-credential-recipient-names.ts` — introduce `effectiveRenderedName(remote)` that reads `attributes['recipient.name']` first and falls back to `recipient.name`. Use it in both the dry-run scan and the post-apply verification step. The apply loop now re-GETs after every PATCH and fails loudly if the rendered name didn't actually change — so the "PATCH 200 but field didn't mutate" class of bug can't reach silent-success again.
+
+Server-only; no spec change.

--- a/server/src/scripts/repair-credential-recipient-names.ts
+++ b/server/src/scripts/repair-credential-recipient-names.ts
@@ -115,6 +115,24 @@ interface PlanEntry {
   desired_name: string;
 }
 
+// Certifier's recipient.name field on the credential GET is a denormalized
+// snapshot of the recipient resource — it is NOT what drives certificate
+// rendering. The design template resolves `{recipient.name}` placeholders
+// against the `attributes` map first (the override layer written by PATCH
+// /credentials/{id}); only when that key is absent does it fall back to the
+// recipient resource. So:
+//   - When attributes['recipient.name'] is set, that's the rendered name.
+//   - When attributes['recipient.name'] is absent, recipient.name renders.
+// effectiveRenderedName picks the right one. Prior versions of this script
+// compared against recipient.name alone, which made the dry-run report
+// already-repaired credentials as still-broken (the attribute override was
+// landing correctly, but the comparison missed it).
+function effectiveRenderedName(remote: { recipient?: { name?: string }; attributes?: Record<string, string> }): string {
+  const override = remote.attributes?.['recipient.name']?.trim();
+  if (override) return override;
+  return remote.recipient?.name ?? '';
+}
+
 function needsRepair(current: string, desired: string, user: Row): boolean {
   if (current === desired) return false;
   if (current.toLowerCase().includes('undefined')) return true;
@@ -172,7 +190,7 @@ async function main(): Promise<void> {
     try {
       const desired = buildRecipientName(row);
       const remote = await getCredential(row.certifier_credential_id);
-      const current = remote.recipient?.name ?? '';
+      const current = effectiveRenderedName(remote);
       if (needsRepair(current, desired, row)) {
         if (skipPersonalEmailFallback && isPersonalEmailFallback(desired, row.email)) {
           skipped.push({
@@ -233,6 +251,17 @@ async function main(): Promise<void> {
         await updateCredential(p.certifier_credential_id, {
           recipient: { name: p.desired_name, email: p.email },
         });
+        // Verify the attribute override actually landed. Certifier returns
+        // 200 on PATCH regardless, so post-update GET is the only honest
+        // signal that the rendered cert will pick up the new name. Catches
+        // the "PATCH accepted but field-shape was wrong" class of bug.
+        const verify = await getCredential(p.certifier_credential_id);
+        const verifyName = effectiveRenderedName(verify);
+        if (verifyName !== p.desired_name) {
+          console.log(`  FAIL  ${p.certifier_credential_id}  PATCH 200 but rendered name still "${verifyName}" (expected "${p.desired_name}")`);
+          failed++;
+          continue;
+        }
         console.log(`  ok    ${p.certifier_credential_id}  -> "${p.desired_name}"`);
         ok++;
       } catch (err) {

--- a/server/src/services/certifier-client.ts
+++ b/server/src/services/certifier-client.ts
@@ -40,9 +40,29 @@ export interface CertifierCredential {
   publicId: string;
   groupId: string;
   status: string;
+  /**
+   * Denormalized snapshot of the recipient resource at issuance time. The
+   * recipient is a separate resource with its own ID (`recipient.id`).
+   * **This snapshot is NOT what drives certificate rendering** — Certifier's
+   * design template resolves `{recipient.name}` placeholders against the
+   * `attributes` map below (an override layer), falling back to the
+   * snapshot only when the attribute is absent. To update the rendered
+   * name post-issuance, PATCH `/credentials/{id}` with
+   * `{ recipient: { name, email } }` — Certifier writes the new value into
+   * `attributes['recipient.name']`. The snapshot field stays stale; the
+   * cert re-renders from the attribute override.
+   */
   recipient: CertifierRecipient;
   issueDate: string;
   expiryDate: string | null;
+  /**
+   * Render-time override map. Keys are dotted paths matching design-template
+   * placeholders (e.g., `recipient.name`); values override the corresponding
+   * resource snapshot at render time. Populated by PATCH /credentials/{id}
+   * post-issuance — that's how the recipient-name repair workflow lands a
+   * corrected name on already-issued certs.
+   */
+  attributes?: Record<string, string>;
   customAttributes: Record<string, string>;
   createdAt: string;
   updatedAt: string;
@@ -107,8 +127,14 @@ export interface UpdateCredentialOptions {
 /**
  * Update a previously-issued credential — typically used to correct the
  * recipient name on a credential that was issued before the user's profile
- * populated (see escalation #382). Certifier re-renders the certificate
- * artifacts after a successful PATCH.
+ * populated (see escalation #382). PATCHing `recipient: { name, email }`
+ * does NOT mutate the recipient resource snapshot on the credential;
+ * Certifier instead writes the new value into the credential's `attributes`
+ * map (e.g., `attributes['recipient.name']`). That override is what the
+ * design template reads at render time, so the corrected name appears on
+ * the cert even though the snapshot field stays stale. Verification of a
+ * successful repair MUST read `attributes['recipient.name']`, not
+ * `recipient.name`.
  */
 export async function updateCredential(
   credentialId: string,


### PR DESCRIPTION
Closes #4885. **The original \"silent-success\" diagnosis was wrong** — the repair script's PATCH actually does work; certificates are rendering with the corrected name on Credsverse today.

## What turned out to be happening

Certifier's PATCH \`/credentials/{id}\` with \`{ recipient: { name, email } }\` does NOT mutate the recipient resource snapshot on the credential. Instead, it writes the new value into the credential's \`attributes\` override map (e.g. \`attributes['recipient.name']\`). The certificate design template resolves \`{recipient.name}\` placeholders against that override first, falling back to the snapshot only when the attribute is absent.

So after the May 20 apply run:
- \`recipient.name\` on the credential GET still reads \`\"undefined undefined\"\` (stale denormalized snapshot, never mutated by PATCH)
- \`attributes['recipient.name']\` reads the correct value (override layer, set by PATCH)
- Credsverse renders from the override → **the public certificate shows the correct name**

Verified via live HTTP fetch of four credentials on Credsverse: **Tom Hespos** (#4760), **Tom Charles**, **Tsvetelina Georgieva**, and **Davide Astuto** all display correctly today.

## Actual bug

The script's \`needsRepair()\` compared the desired name against \`remote.recipient?.name\` — the stale snapshot. Every dry-run after the first apply kept reporting the same credentials as still needing repair, even though they were already fixed at the render layer. That false signal is what originally went into #4885 as \"silent-success\".

## Fix

- **\`server/src/services/certifier-client.ts\`** — declare optional \`attributes\` on \`CertifierCredential\` (was missing from the type entirely); document the snapshot-vs-override semantics on \`recipient\`, \`attributes\`, and \`updateCredential\` so the next reader understands why the snapshot stays stale by design.
- **\`server/src/scripts/repair-credential-recipient-names.ts\`** — introduce \`effectiveRenderedName(remote)\` that reads \`attributes['recipient.name']\` first and falls back to \`recipient.name\`. Used in both the dry-run scan and a new post-apply verification step that re-GETs after every PATCH and fails loudly if the rendered name didn't actually change. Closes the \"PATCH 200 but field didn't mutate\" silent-success class for real, even though it turned out we weren't hitting it here.

## Validation

- \`tsc --project server/tsconfig.json --noEmit\` — clean
- Live verification of Tom Hespos's two credentials on Credsverse (publicId \`ad5e1781-4f45-4162-b457-6ce3627383aa\` + sibling) — both render \"Tom Hespos\" correctly today

## Adopter impact

None — the certificates have been rendering correctly since May 20. This PR just fixes the script's dry-run telemetry so we don't waste another cycle thinking the cleanup is still pending. Re-running the script after merge should report 0 credentials needing repair for everyone we already touched.

## Related

- #4760 (THespos) — both his certificates render correctly today, can close
- #4753 (geneticallymodifiedfoodforthought) — going-forward fix already shipped via #4799; existing credentials with \`first_name\` populated also render correctly
- #4882 — \`--skip-personal-email-fallback\` flag (still useful for future runs that pick up new broken creds)