### PR TITLE
fix(compliance): /refresh now also re-runs the full compliance suite (closes #4886)

### DIFF
--- a/.changeset/4886-refresh-runs-comply.md
+++ b/.changeset/4886-refresh-runs-comply.md
@@ -1,0 +1,14 @@
+---
+---
+
+fix(compliance): `POST /api/registry/agents/{url}/refresh` now also re-runs the full compliance suite
+
+Closes #4886. Prior to this change, `/refresh` probed capabilities + health via `crawler.refreshSingleAgent` but did NOT call `comply()` or update `agent_storyboard_status`. The dashboard verdict view kept showing whatever the periodic heartbeat last wrote (up to 12h stale), so adopters who fixed their agent and clicked "Refresh" saw no movement and concluded the cache was broken (e.g. fgranata's report: identical 72/128 verdict across 5+ runs over 7+ hours post-deploy).
+
+What changed:
+- After the existing capability/health probe in `/refresh`, when the caller owns the agent and the probe succeeded, the full storyboard suite runs via `comply()` (90s timeout) and results are persisted to `agent_storyboard_status` via `recordComplianceRun()` under `triggered_by: 'manual'`. The CHECK constraint on `valid_storyboard_triggered_by` already accepts `'manual'`.
+- Badge fan-out (`runBadgeFanOut`) fires after a successful compliance run so verification badges reflect the new verdict immediately. Matches the per-storyboard owner-test path's pattern.
+- Compliance failure is soft-fail: if `comply()` times out, returns `auth_required`, or throws, the capability/health snapshot still returns successfully and the response carries `compliance: { ran: false, error: "..." }`. The pre-existing 60s per-agent rate limit on `/refresh` is unchanged and bounds repeat-clicks.
+- Response shape gains a `compliance` block with `ran` / `overall_status` / `storyboards_passing` / `storyboards_total` / `error`. Dashboard's existing "Recheck" button now appends `compliance: N/M` to the flash message so the operator sees the verdict update without leaving the page.
+
+Server-only change; no spec/wire change for AdCP. OpenAPI doc updated to describe the new behavior and the response shape.

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -2676,6 +2676,13 @@
           ];
           if (data.type_promoted) parts.push('type promoted');
           if (data.oauth_required) parts.push('OAuth required');
+          if (data.compliance?.ran) {
+            const passing = data.compliance.storyboards_passing ?? 0;
+            const total = data.compliance.storyboards_total ?? 0;
+            parts.push(`compliance: ${passing}/${total}`);
+          } else if (data.compliance?.error) {
+            parts.push(`compliance not run (${data.compliance.error})`);
+          }
           // Online flashes auto-dismiss; offline-but-reachable persists so
           // the operator can read the diagnostic at their pace.
           const flash = renderFlash({

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -2227,7 +2227,7 @@ registry.registerPath({
   operationId: "refreshAgent",
   summary: "Refresh agent snapshot",
   description:
-    "Re-probe the agent and update its registry health (online, tools_count, response_time_ms) and capability snapshot (inferred type, discovered tools). Use after fixing your agent so the registry shows fresh data without waiting for the periodic crawl.\n\n**Auth:** owner of the agent or AAO admin.\n\n**Rate limits:** 60 seconds per agent URL, 30 requests per user per hour.",
+    "Re-probe the agent and update its registry health (online, tools_count, response_time_ms), capability snapshot (inferred type, discovered tools), and compliance verdict (storyboard pass/fail counts). Use after fixing your agent so the registry shows fresh data without waiting for the periodic heartbeat (~12h).\n\n**Compliance re-run:** when the caller owns the agent and the capability probe succeeds, the full storyboard suite runs (~30–90s) and `agent_storyboard_status` is updated under `triggered_by: 'manual'`. Badge fan-out reissues verification badges off the new run. If the compliance call fails (timeout, OAuth wall, internal error), the capability/health portion still returns successfully — `compliance.ran` is `false` with an `error` string.\n\n**Auth:** owner of the agent or AAO admin.\n\n**Rate limits:** 60 seconds per agent URL, 30 requests per user per hour.",
   tags: ["Agent Compliance"],
   security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
@@ -2249,6 +2249,13 @@ registry.registerPath({
             oauth_required: z.boolean(),
             checked_at: z.string(),
             error: z.string().optional(),
+            compliance: z.object({
+              ran: z.boolean().openapi({ description: "True if the full storyboard suite ran and agent_storyboard_status was updated. False when ownership couldn't be resolved, the agent reported auth_required, or the compliance call itself failed." }),
+              overall_status: z.string().optional().openapi({ description: "Aggregate verdict from the run (passing / failing / partial / unknown). Only present when `ran` is true." }),
+              storyboards_passing: z.number().int().optional().openapi({ description: "Number of storyboards passing on this run." }),
+              storyboards_total: z.number().int().optional().openapi({ description: "Number of storyboards evaluated on this run." }),
+              error: z.string().optional().openapi({ description: "Reason compliance didn't run when `ran` is false." }),
+            }).openapi({ description: "Compliance re-run summary. The capability/health portion of the response is independent of this block — a failed compliance run still returns the rest of the snapshot." }),
           }),
         },
       },
@@ -5285,9 +5292,9 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         resolvedAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `refresh:${agentUrl}` });
       }
 
+      let probeResult: Awaited<ReturnType<typeof crawler.refreshSingleAgent>>;
       try {
-        const result = await crawler.refreshSingleAgent(agentUrl, { auth: resolvedAuth });
-        return res.json(result);
+        probeResult = await crawler.refreshSingleAgent(agentUrl, { auth: resolvedAuth });
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Probe failed';
         if (/Monitoring paused/i.test(message)) {
@@ -5296,6 +5303,72 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         logger.warn({ agentUrl, err }, 'Manual agent refresh probe failed');
         return res.status(502).json({ error: `Probe failed: ${message}` });
       }
+
+      // Also re-run compliance so the dashboard verdict updates alongside the
+      // capability/health probe. Prior to #4886, /refresh probed capabilities
+      // and health but left agent_storyboard_status untouched, leaving owners
+      // to stare at a stale verdict for up to a full heartbeat cycle after
+      // deploying a fix. The full storyboard suite can run 30–90s; the
+      // per-agent 60s rate limit above bounds repeat-clicks. comply() failure
+      // is a soft-fail — we still return the capability/health refresh so a
+      // partially-working agent still moves the snapshot forward.
+      let complianceSummary: {
+        ran: boolean;
+        overall_status?: string;
+        storyboards_passing?: number;
+        storyboards_total?: number;
+        error?: string;
+      } = { ran: false };
+
+      if (ownerOrgId && !probeResult.error && !probeResult.oauth_required) {
+        try {
+          const complyResult = await comply(agentUrl, {
+            timeout_ms: 90_000,
+            ...(resolvedAuth && { auth: resolvedAuth }),
+          });
+          if (complyResult.overall_status === 'auth_required') {
+            complianceSummary = { ran: false, error: 'Agent requires OAuth authorization' };
+          } else {
+            const metadata = await complianceDb.getRegistryMetadata(agentUrl);
+            const dbInput = complianceResultToDbInput(
+              complyResult,
+              agentUrl,
+              metadata?.lifecycle_stage || 'production',
+              'manual',
+            );
+            dbInput.dry_run = false;
+            const { storyboardStatuses } = await complianceDb.recordComplianceRun(dbInput);
+            const passing = storyboardStatuses.filter(s => s.status === 'passing').length;
+            complianceSummary = {
+              ran: true,
+              overall_status: dbInput.overall_status,
+              storyboards_passing: passing,
+              storyboards_total: storyboardStatuses.length,
+            };
+
+            // Fan out badge issuance so verification badges reflect the new
+            // verdict immediately. Matches the per-storyboard owner-test path.
+            const declaredSpecialisms = complyResult.agent_profile?.specialisms ?? [];
+            if (declaredSpecialisms.length > 0) {
+              try {
+                await runBadgeFanOut({
+                  complianceDb,
+                  agentUrl,
+                  declaredSpecialisms,
+                });
+              } catch (badgeError) {
+                logger.warn({ err: badgeError, agentUrl }, 'Badge fan-out failed after manual refresh');
+              }
+            }
+          }
+        } catch (complyErr) {
+          const msg = complyErr instanceof Error ? complyErr.message : 'compliance run failed';
+          logger.warn({ agentUrl, err: complyErr }, 'Compliance re-run failed during manual refresh');
+          complianceSummary = { ran: false, error: msg };
+        }
+      }
+
+      return res.json({ ...probeResult, compliance: complianceSummary });
     } catch (error) {
       logger.error({ err: error, path: req.path }, "Failed to refresh agent");
       res.status(500).json({ error: "Failed to refresh agent" });

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -6461,7 +6461,9 @@ paths:
       operationId: refreshAgent
       summary: Refresh agent snapshot
       description: |-
-        Re-probe the agent and update its registry health (online, tools_count, response_time_ms) and capability snapshot (inferred type, discovered tools). Use after fixing your agent so the registry shows fresh data without waiting for the periodic crawl.
+        Re-probe the agent and update its registry health (online, tools_count, response_time_ms), capability snapshot (inferred type, discovered tools), and compliance verdict (storyboard pass/fail counts). Use after fixing your agent so the registry shows fresh data without waiting for the periodic heartbeat (~12h).
+
+        **Compliance re-run:** when the caller owns the agent and the capability probe succeeds, the full storyboard suite runs (~30–90s) and `agent_storyboard_status` is updated under `triggered_by: 'manual'`. Badge fan-out reissues verification badges off the new run. If the compliance call fails (timeout, OAuth wall, internal error), the capability/health portion still returns successfully — `compliance.ran` is `false` with an `error` string.
 
         **Auth:** owner of the agent or AAO admin.
 
@@ -6510,6 +6512,27 @@ paths:
                     type: string
                   error:
                     type: string
+                  compliance:
+                    type: object
+                    properties:
+                      ran:
+                        type: boolean
+                        description: True if the full storyboard suite ran and agent_storyboard_status was updated. False when ownership couldn't be resolved, the agent reported auth_required, or the compliance call itself failed.
+                      overall_status:
+                        type: string
+                        description: Aggregate verdict from the run (passing / failing / partial / unknown). Only present when `ran` is true.
+                      storyboards_passing:
+                        type: integer
+                        description: Number of storyboards passing on this run.
+                      storyboards_total:
+                        type: integer
+                        description: Number of storyboards evaluated on this run.
+                      error:
+                        type: string
+                        description: Reason compliance didn't run when `ran` is false.
+                    required:
+                      - ran
+                    description: Compliance re-run summary. The capability/health portion of the response is independent of this block — a failed compliance run still returns the rest of the snapshot.
                 required:
                   - online
                   - tools_count
@@ -6518,6 +6541,7 @@ paths:
                   - type_promoted
                   - oauth_required
                   - checked_at
+                  - compliance
         "400":
           description: Invalid agent URL
           content:


### PR DESCRIPTION
Closes #4886. Ships **Fix A** from the diagnosis comment.

## Root cause (recap)

\`POST /api/registry/agents/{url}/refresh\` previously called \`crawler.refreshSingleAgent\`, which probes capabilities + health but **never calls \`comply()\`** and never writes to \`agent_storyboard_status\`. The dashboard verdict view kept showing whatever the periodic heartbeat last wrote (~12h stale). Adopters who deployed a fix and clicked "Refresh" saw no movement and concluded the cache was broken — fgranata's symptom of identical 72/128 across 5+ runs over 7+ hours is exactly this behavior.

## What this PR changes

\`server/src/routes/registry-api.ts\` — after the existing capability/health probe in the \`/refresh\` handler, when the caller owns the agent and the probe succeeded, the full storyboard suite runs via \`comply()\` (90s timeout) and results are persisted via \`recordComplianceRun()\` with \`triggered_by: 'manual'\`. Badge fan-out (\`runBadgeFanOut\`) fires after a successful run so verification badges reflect the new verdict immediately.

**Soft-fail semantics.** If \`comply()\` times out, returns \`auth_required\`, or throws, the capability/health portion of the response is still returned successfully — the new \`compliance\` block in the response carries \`{ ran: false, error: \"...\" }\`. The pre-existing 60s per-agent rate limit on \`/refresh\` is unchanged and continues to bound repeat-clicks during a long compliance call.

**Response shape gains a \`compliance\` block:**

\`\`\`json
{
  \"online\": true,
  \"tools_count\": 23,
  \"response_time_ms\": 412,
  \"inferred_type\": \"sales\",
  \"type_promoted\": false,
  \"oauth_required\": false,
  \"checked_at\": \"2026-05-21T...\",
  \"compliance\": {
    \"ran\": true,
    \"overall_status\": \"passing\",
    \"storyboards_passing\": 89,
    \"storyboards_total\": 121
  }
}
\`\`\`

**Dashboard surface** (\`server/public/dashboard-agents.html\`): the existing \"Recheck\" button's flash message now appends \`compliance: N/M\` when \`compliance.ran\` is true, or \`compliance not run (<reason>)\` when it isn't. Operators see the verdict update without leaving the page.

**OpenAPI** (\`/api/registry/agents/{encodedUrl}/refresh\`): description rewritten to spell out the new dual-purpose semantics; response schema updated with the \`compliance\` block; soft-fail behavior documented.

## What this PR doesn't change

- The 60s per-agent rate limit stays. It's still the right bound — owners can re-click after a fix lands, not faster than 1/min.
- The heartbeat job is unchanged. \`triggered_by\` still distinguishes \`heartbeat\` vs \`manual\` vs \`owner_test\` so observability can tell where a verdict came from.
- The per-storyboard \`/storyboard/:id/run\` owner-test endpoint is unchanged — it's the narrower escape hatch for owners who just want to re-test one storyboard.
- Wire-vs-pipeline latency split (the third ask in #4886's diagnostic) is a feature request against \`@adcp/client\`'s runner output format, filed separately.

## Validation

- \`tsc --project server/tsconfig.json --noEmit\` — clean
- Local \`npm run build:openapi\` requires WorkOS env vars; CI will rebuild
- No new tests added — the existing compliance-run tests cover \`recordComplianceRun\` directly; the integration test surface for \`/refresh\` is hard to mock cleanly without a fixture agent. Adopter-side smoke is the deploy.

## Adopter impact

This is the behavior change adopters have been silently expecting from the \"Refresh\" button. fgranata-class symptoms (deploy fix → click refresh → verdict still stale) disappear on the next click. No spec change, no SDK regen — pure server-side.

## Related

- #4886 — root-cause diagnosis comment above this fix
- #4799 — \`NAME_REQUIRED\` gate (different surface, related class of "going-forward fix is in place but cleanup mechanics are uneven")
- #4877 — \`@adcp/client\` SDK companion for envelope \`status\` (related to wire-vs-pipeline latency ask)