### PR TITLE
fix(aao): keep organization_memberships in sync with WorkOS

### DIFF
--- a/.changeset/aao-membership-role-sync.md
+++ b/.changeset/aao-membership-role-sync.md
@@ -1,0 +1,14 @@
+---
+---
+
+fix(aao): WorkOS-first auto-promote + role drift reconciliation
+
+When a webhook-driven membership upsert promoted a user to `owner` because the org had no other admin/owner, the SQL wrote `role='owner'` locally first and then tried to mirror the change back to WorkOS. A best-effort rollback existed for the WorkOS-update failure case, but if both the WorkOS push *and* the rollback failed (transient API errors, mid-flight process restart, partial outage), the row sat with `local=owner, WorkOS=member` indefinitely. AAO admin reads local, so the admin UI showed "Owner"; every other surface (Linked Domains, member-profile gates, `resolveUserOrgMembership`) reads WorkOS and treated the user as `member`. At least one prod org drifted this way for months.
+
+Three changes:
+
+1. `upsertOrganizationMembership` is now a dumb mirror — it writes whatever role the caller hands it, no CASE/NOT-EXISTS auto-promote inside the SQL. The auto-promote moves up into the webhook handler as `resolveRoleWithWorkosFirstPromote`, which lists WorkOS memberships, calls `updateOrganizationMembership` on WorkOS *first*, and only then asks the local upsert to write the resolved role. If the WorkOS list or update fails, the caller falls back to `member` locally — local can no longer get ahead of WorkOS.
+2. Both outcomes of the auto-promote write a row to `registry_audit_log` (`membership_auto_promoted_to_owner` on success, `membership_auto_promote_failed` on failure). The next "how did this user become owner?" investigation no longer requires log surgery.
+3. `POST /api/admin/organizations/:orgId/add-users` (Domain Health "move users from personal workspaces") used to insert a local-only `organization_memberships` row with no `createOrganizationMembership` call to WorkOS. Local would say the user was in the target org while WorkOS — and therefore every read-side gate — disagreed. Now the WorkOS create happens first; only on success does the local row get written, with the WorkOS membership id cached.
+
+Pre-existing drift is reconciled out-of-band, not via a shipped script. Future drift is prevented by the WorkOS-first ordering above and surfaced via the new audit-log actions.

--- a/server/src/db/membership-db.ts
+++ b/server/src/db/membership-db.ts
@@ -49,20 +49,22 @@ export interface MembershipUpsertResult {
 // ── Upsert ───────────────────────────────────────────────────────────
 
 /**
- * Insert or update an organization membership.
+ * Insert or update an organization membership. Writes the role exactly as
+ * given — auto-promote decisioning lives in the webhook handler now, so
+ * WorkOS is the source of truth and local can never disagree.
  *
- * Auto-promotes to owner when the org has no admin/owner and the incoming
- * role is 'member'. The NOT EXISTS subquery is race-safe.
- *
- * Returns the role that was actually written (may differ from the input
- * role if auto-promotion fired).
+ * History: this used to auto-promote inside the SQL via CASE/NOT-EXISTS,
+ * with the webhook handler pushing the promotion to WorkOS afterward and
+ * rolling back local on failure. The rollback is best-effort; a missed
+ * rollback left at least one prod org with role='owner' locally and
+ * role='member' in WorkOS for months (see ozoneproject incident, 2026-05).
+ * The webhook handler now resolves the role against WorkOS BEFORE calling
+ * this function, so local never gets ahead of WorkOS.
  */
 export async function upsertOrganizationMembership(
   params: MembershipUpsertParams,
 ): Promise<MembershipUpsertResult> {
   const pool = getPool();
-
-  const effectiveRole = params.role === 'member' ? '__auto__' : params.role;
 
   const result = await pool.query<{ role: string }>(
     `INSERT INTO organization_memberships (
@@ -77,18 +79,7 @@ export async function upsertOrganizationMembership(
       provisioning_source,
       synced_at
     ) VALUES (
-      $1, $2, $3, $4, $5, $6,
-      CASE
-        WHEN $7 = '__auto__' AND NOT EXISTS (
-          SELECT 1 FROM organization_memberships
-          WHERE workos_organization_id = $2::varchar
-            AND role IN ('admin', 'owner')
-            AND workos_user_id != $1::varchar
-        ) THEN 'owner'
-        WHEN $7 = '__auto__' THEN 'member'
-        ELSE $7
-      END,
-      $8, $10, NOW()
+      $1, $2, $3, $4, $5, $6, $7, $8, $10, NOW()
     )
     ON CONFLICT (workos_user_id, workos_organization_id)
     DO UPDATE SET
@@ -114,7 +105,7 @@ export async function upsertOrganizationMembership(
       params.email,
       params.first_name,
       params.last_name,
-      effectiveRole,
+      params.role,
       params.seat_type,
       params.has_explicit_seat_type,
       params.provisioning_source ?? null,
@@ -131,6 +122,92 @@ export async function upsertOrganizationMembership(
   }, 'Upserted organization membership');
 
   return { assigned_role };
+}
+
+/**
+ * Resolve the role to assign for an incoming membership, promoting to
+ * 'owner' in WorkOS first when the org has no other admin/owner. This
+ * is the new home for ownerless-org safety-net promotion — performing
+ * the WorkOS write *before* the local upsert guarantees local can never
+ * disagree with WorkOS, even if the process crashes mid-flight.
+ *
+ * Returns:
+ *   { role, promoted, error? }
+ *
+ * `promoted: true` indicates that WorkOS was successfully updated to
+ * 'owner'; the caller should write an audit row. `error` is set on
+ * promotion attempts that failed — caller writes a failure audit row
+ * and falls back to the input role for the local write.
+ */
+export async function resolveRoleWithWorkosFirstPromote(args: {
+  workos: WorkOS;
+  membershipId: string;
+  userId: string;
+  organizationId: string;
+  incomingRole: string;
+}): Promise<{
+  role: string;
+  promoted: boolean;
+  promotionError?: unknown;
+}> {
+  const { workos, membershipId, userId, organizationId, incomingRole } = args;
+
+  // Only the 'member' input is eligible for ownerless-org promotion. Any
+  // explicit role from WorkOS passes through unchanged.
+  if (incomingRole !== 'member') {
+    return { role: incomingRole, promoted: false };
+  }
+
+  // Source-of-truth check: page through WorkOS memberships and look for
+  // an existing admin/owner that isn't this same user.
+  let hasOtherAdmin = false;
+  try {
+    let after: string | undefined;
+    do {
+      const page = await workos.userManagement.listOrganizationMemberships({
+        organizationId,
+        statuses: ['active'],
+        limit: 100,
+        after,
+      });
+      for (const m of page.data) {
+        if (m.userId === userId) continue;
+        const slug = m.role?.slug;
+        if (slug === 'admin' || slug === 'owner') {
+          hasOtherAdmin = true;
+          break;
+        }
+      }
+      if (hasOtherAdmin) break;
+      after = page.listMetadata?.after ?? undefined;
+    } while (after);
+  } catch (err) {
+    // Can't verify WorkOS state — refuse to promote. Writing 'owner' locally
+    // when we don't know what WorkOS thinks is exactly the drift this rewrite
+    // is fixing.
+    logger.warn({ err, orgId: organizationId, userId },
+      'Could not list WorkOS memberships for ownerless-org check — assigning member');
+    return { role: 'member', promoted: false, promotionError: err };
+  }
+
+  if (hasOtherAdmin) {
+    return { role: 'member', promoted: false };
+  }
+
+  // No other admin/owner — promote this membership to owner in WorkOS.
+  // If WorkOS rejects the update (role not configured, transient 5xx, etc.)
+  // we fall back to writing 'member' locally so the two sides stay aligned.
+  try {
+    await workos.userManagement.updateOrganizationMembership(membershipId, {
+      roleSlug: 'owner',
+    });
+  } catch (err) {
+    logger.warn({ err, orgId: organizationId, userId, membershipId },
+      'Failed to promote member to owner in WorkOS — falling back to member locally');
+    return { role: 'member', promoted: false, promotionError: err };
+  }
+
+  return { role: 'owner', promoted: true };
 }
 
 // ── Delete ───────────────────────────────────────────────────────────

--- a/server/src/routes/admin/organizations.ts
+++ b/server/src/routes/admin/organizations.ts
@@ -1157,16 +1157,47 @@ export function setupOrganizationRoutes(
               continue;
             }
 
-            // Add membership to the new org
+            // WorkOS-first: create the membership in WorkOS before mirroring
+            // locally so the two never disagree on existence. Earlier versions
+            // of this handler skipped the WorkOS write entirely — local got a
+            // row, WorkOS didn't, and the rest of the app (which reads WorkOS)
+            // treated the user as a non-member.
+            if (!workos) {
+              errors.push(`User ${userId}: WorkOS client unavailable`);
+              continue;
+            }
+
+            let newMembership;
+            try {
+              newMembership = await workos.userManagement.createOrganizationMembership({
+                userId,
+                organizationId: orgId,
+                roleSlug: 'member',
+              });
+            } catch (workosErr) {
+              const message = workosErr instanceof Error ? workosErr.message : String(workosErr);
+              logger.error(
+                { err: workosErr, userId, orgId },
+                "Failed to create WorkOS membership during admin add-users",
+              );
+              errors.push(`User ${userId}: ${message}`);
+              continue;
+            }
+
+            // Mirror locally now that WorkOS has the row.
             await pool.query(
               `INSERT INTO organization_memberships
-               (workos_user_id, workos_organization_id, email, first_name, last_name)
-               VALUES ($1, $2, $3, $4, $5)
+               (workos_user_id, workos_organization_id, workos_membership_id, email, first_name, last_name, role, synced_at)
+               VALUES ($1, $2, $3, $4, $5, $6, 'member', NOW())
                ON CONFLICT (workos_user_id, workos_organization_id)
-               DO UPDATE SET email = EXCLUDED.email,
+               DO UPDATE SET workos_membership_id = EXCLUDED.workos_membership_id,
+                 email = EXCLUDED.email,
                  first_name = COALESCE(NULLIF(TRIM(organization_memberships.first_name), ''), EXCLUDED.first_name),
-                 last_name = COALESCE(NULLIF(TRIM(organization_memberships.last_name), ''), EXCLUDED.last_name)`,
-              [userId, orgId, user.email, user.first_name, user.last_name]
+                 last_name = COALESCE(NULLIF(TRIM(organization_memberships.last_name), ''), EXCLUDED.last_name),
+                 role = EXCLUDED.role,
+                 synced_at = NOW(),
+                 updated_at = NOW()`,
+              [userId, orgId, newMembership.id, user.email, user.first_name, user.last_name]
             );
 
             addedCount++;

--- a/server/src/routes/workos-webhooks.ts
+++ b/server/src/routes/workos-webhooks.ts
@@ -51,7 +51,10 @@ import {
   findSuccessorForPromotion,
   setMembershipRole,
   autoLinkByVerifiedDomain,
+  resolveRoleWithWorkosFirstPromote,
 } from '../db/membership-db.js';
+
+const orgDb = new OrganizationDatabase();
 
 const logger = createLogger('workos-webhooks');
 
@@ -219,7 +222,19 @@ async function upsertMembership(
     return;
   }
 
-  const role = membership.role?.slug || 'member';
+  const incomingRole = membership.role?.slug || 'member';
+
+  // Resolve final role against WorkOS BEFORE we touch local. If we need to
+  // auto-promote this user (ownerless-org safety net), push the change to
+  // WorkOS first and only then write the resolved role locally. WorkOS is
+  // the source of truth — local must never get ahead of it.
+  const resolution = await resolveRoleWithWorkosFirstPromote({
+    workos: getWorkos(),
+    membershipId: membership.id,
+    userId: membership.user_id,
+    organizationId: membership.organization_id,
+    incomingRole,
+  });
 
   // Consume any pending seat_type + provisioning_source staged by the
   // endpoint that triggered this membership creation. Falls back to defaults
@@ -258,38 +273,66 @@ async function upsertMembership(
     }
   }
 
-  const { assigned_role } = await upsertOrganizationMembership({
+  await upsertOrganizationMembership({
     user_id: membership.user_id,
     organization_id: membership.organization_id,
     membership_id: membership.id,
     email: userData.email,
     first_name: userData.first_name,
     last_name: userData.last_name,
-    role,
+    role: resolution.role,
     seat_type: seatType,
     has_explicit_seat_type: hasExplicitSeatType,
     provisioning_source: provisioningSource,
   });
 
-  // If the DB promoted this member to owner, sync the change to WorkOS
-  if (assigned_role === 'owner' && role === 'member') {
+  // Audit-log both outcomes of the ownerless-org auto-promote path so future
+  // role-drift questions have a paper trail in registry_audit_log (and we
+  // don't have to grep production logs to reconstruct what happened).
+  if (resolution.promoted) {
+    logger.info({
+      membershipId: membership.id,
+      userId: membership.user_id,
+      orgId: membership.organization_id,
+    }, 'Auto-promoted member to owner in WorkOS — org had no other admin/owner');
     try {
-      await getWorkos().userManagement.updateOrganizationMembership(membership.id, {
-        roleSlug: 'owner',
+      await orgDb.recordAuditLog({
+        workos_organization_id: membership.organization_id,
+        workos_user_id: membership.user_id,
+        action: 'membership_auto_promoted_to_owner',
+        resource_type: 'membership',
+        resource_id: membership.id,
+        details: {
+          email: userData.email,
+          previous_role: incomingRole,
+          new_role: 'owner',
+          reason: 'ownerless_org_safety_net',
+        },
       });
-      logger.info({
-        membershipId: membership.id,
-        userId: membership.user_id,
-        orgId: membership.organization_id,
-      }, 'Promoted member to owner — org had no admin');
-    } catch (err) {
-      // Roll back local promotion to stay in sync with WorkOS
-      await setMembershipRole(membership.user_id, membership.organization_id, 'member')
-        .catch((rollbackErr) => {
-          logger.error({ err: rollbackErr, orgId: membership.organization_id },
-            'Failed to roll back local owner promotion — local/WorkOS role divergence');
-        });
-      logger.warn({ err, orgId: membership.organization_id }, 'Failed to promote member to owner in WorkOS, rolled back local role');
+    } catch (auditErr) {
+      logger.warn({ err: auditErr, membershipId: membership.id },
+        'Failed to write audit log for auto-promotion');
+    }
+  } else if (resolution.promotionError !== undefined) {
+    const err = resolution.promotionError;
+    const errMessage = err instanceof Error ? err.message : String(err);
+    try {
+      await orgDb.recordAuditLog({
+        workos_organization_id: membership.organization_id,
+        workos_user_id: membership.user_id,
+        action: 'membership_auto_promote_failed',
+        resource_type: 'membership',
+        resource_id: membership.id,
+        details: {
+          email: userData.email,
+          attempted_role: 'owner',
+          fallback_role: resolution.role,
+          error: errMessage,
+        },
+      });
+    } catch (auditErr) {
+      logger.warn({ err: auditErr, membershipId: membership.id },
+        'Failed to write audit log for auto-promotion failure');
     }
   }
 

--- a/server/tests/integration/membership-webhook.test.ts
+++ b/server/tests/integration/membership-webhook.test.ts
@@ -19,6 +19,7 @@ import {
   findOrgsWithNewAutoProvisionedMembers,
   listNewAutoProvisionedMembers,
   markAutoProvisionDigestSent,
+  resolveRoleWithWorkosFirstPromote,
 } from '../../src/db/membership-db.js';
 import type { WorkOS } from '@workos-inc/node';
 import type { Pool } from 'pg';
@@ -54,51 +55,15 @@ describe('Membership webhook DB operations', () => {
   // =========================================================================
 
   describe('upsertOrganizationMembership', () => {
-    it('inserts a membership and auto-promotes first member to owner', async () => {
+    it('writes the role it is given (no DB-side auto-promote)', async () => {
+      // Auto-promote moved to the webhook handler so WorkOS is written
+      // before local — upsert is now a pure mirror function.
       const result = await upsertOrganizationMembership({
         user_id: TEST_USER_1,
         organization_id: TEST_ORG_ID,
         membership_id: 'om_test_1',
         email: 'alice@test.com',
         first_name: 'Alice',
-        last_name: 'Test',
-        role: 'member',
-        seat_type: 'community_only',
-        has_explicit_seat_type: false,
-      });
-
-      expect(result.assigned_role).toBe('owner');
-
-      const row = await pool.query(
-        'SELECT role, email, seat_type FROM organization_memberships WHERE workos_user_id = $1 AND workos_organization_id = $2',
-        [TEST_USER_1, TEST_ORG_ID],
-      );
-      expect(row.rows[0].role).toBe('owner');
-      expect(row.rows[0].email).toBe('alice@test.com');
-      expect(row.rows[0].seat_type).toBe('community_only');
-    });
-
-    it('assigns member role when org already has an owner', async () => {
-      // First member becomes owner
-      await upsertOrganizationMembership({
-        user_id: TEST_USER_1,
-        organization_id: TEST_ORG_ID,
-        membership_id: 'om_test_1',
-        email: 'alice@test.com',
-        first_name: 'Alice',
-        last_name: 'Test',
-        role: 'member',
-        seat_type: 'community_only',
-        has_explicit_seat_type: false,
-      });
-
-      // Second member stays member
-      const result = await upsertOrganizationMembership({
-        user_id: TEST_USER_2,
-        organization_id: TEST_ORG_ID,
-        membership_id: 'om_test_2',
-        email: 'bob@test.com',
-        first_name: 'Bob',
         last_name: 'Test',
         role: 'member',
         seat_type: 'community_only',
@@ -106,6 +71,30 @@ describe('Membership webhook DB operations', () => {
       });
 
       expect(result.assigned_role).toBe('member');
+
+      const row = await pool.query(
+        'SELECT role, email, seat_type FROM organization_memberships WHERE workos_user_id = $1 AND workos_organization_id = $2',
+        [TEST_USER_1, TEST_ORG_ID],
+      );
+      expect(row.rows[0].role).toBe('member');
+      expect(row.rows[0].email).toBe('alice@test.com');
+      expect(row.rows[0].seat_type).toBe('community_only');
+    });
+
+    it('writes owner when owner is passed in', async () => {
+      const result = await upsertOrganizationMembership({
+        user_id: TEST_USER_1,
+        organization_id: TEST_ORG_ID,
+        membership_id: 'om_test_1',
+        email: 'alice@test.com',
+        first_name: 'Alice',
+        last_name: 'Test',
+        role: 'owner',
+        seat_type: 'community_only',
+        has_explicit_seat_type: false,
+      });
+
+      expect(result.assigned_role).toBe('owner');
     });
 
     it('preserves explicit admin role without auto-promotion logic', async () => {
@@ -225,6 +214,133 @@ describe('Membership webhook DB operations', () => {
         [TEST_USER_1, TEST_ORG_ID],
       );
       expect(row.rows[0].seat_type).toBe('contributor');
+    });
+  });
+
+  // =========================================================================
+  // RESOLVE ROLE (WorkOS-first auto-promote)
+  // =========================================================================
+
+  describe('resolveRoleWithWorkosFirstPromote', () => {
+    function makeWorkos(opts: {
+      memberships: Array<{ userId: string; role: { slug: string } }>;
+      updateFails?: boolean;
+      listFails?: boolean;
+    }) {
+      const updateOrganizationMembership = vi.fn(async () => {
+        if (opts.updateFails) throw new Error('workos update failed');
+        return {};
+      });
+      const listOrganizationMemberships = vi.fn(async () => {
+        if (opts.listFails) throw new Error('workos list failed');
+        return {
+          data: opts.memberships.map((m) => ({
+            userId: m.userId,
+            role: m.role,
+            status: 'active',
+          })),
+          listMetadata: { after: null },
+        };
+      });
+      return {
+        client: {
+          userManagement: { updateOrganizationMembership, listOrganizationMemberships },
+        } as unknown as WorkOS,
+        updateOrganizationMembership,
+        listOrganizationMemberships,
+      };
+    }
+
+    it('passes through non-member roles without touching WorkOS', async () => {
+      const { client, listOrganizationMemberships, updateOrganizationMembership } = makeWorkos({ memberships: [] });
+
+      const result = await resolveRoleWithWorkosFirstPromote({
+        workos: client,
+        membershipId: 'om_x',
+        userId: TEST_USER_1,
+        organizationId: TEST_ORG_ID,
+        incomingRole: 'admin',
+      });
+
+      expect(result).toEqual({ role: 'admin', promoted: false });
+      expect(listOrganizationMemberships).not.toHaveBeenCalled();
+      expect(updateOrganizationMembership).not.toHaveBeenCalled();
+    });
+
+    it('promotes to owner in WorkOS first when the org has no other admin/owner', async () => {
+      const { client, updateOrganizationMembership } = makeWorkos({
+        memberships: [{ userId: TEST_USER_1, role: { slug: 'member' } }],
+      });
+
+      const result = await resolveRoleWithWorkosFirstPromote({
+        workos: client,
+        membershipId: 'om_target',
+        userId: TEST_USER_1,
+        organizationId: TEST_ORG_ID,
+        incomingRole: 'member',
+      });
+
+      expect(result).toEqual({ role: 'owner', promoted: true });
+      expect(updateOrganizationMembership).toHaveBeenCalledWith('om_target', { roleSlug: 'owner' });
+    });
+
+    it('leaves role as member when another admin already exists in WorkOS', async () => {
+      const { client, updateOrganizationMembership } = makeWorkos({
+        memberships: [
+          { userId: TEST_USER_2, role: { slug: 'admin' } },
+          { userId: TEST_USER_1, role: { slug: 'member' } },
+        ],
+      });
+
+      const result = await resolveRoleWithWorkosFirstPromote({
+        workos: client,
+        membershipId: 'om_target',
+        userId: TEST_USER_1,
+        organizationId: TEST_ORG_ID,
+        incomingRole: 'member',
+      });
+
+      expect(result).toEqual({ role: 'member', promoted: false });
+      expect(updateOrganizationMembership).not.toHaveBeenCalled();
+    });
+
+    it('falls back to member when the WorkOS update fails (no drift)', async () => {
+      const { client } = makeWorkos({
+        memberships: [{ userId: TEST_USER_1, role: { slug: 'member' } }],
+        updateFails: true,
+      });
+
+      const result = await resolveRoleWithWorkosFirstPromote({
+        workos: client,
+        membershipId: 'om_target',
+        userId: TEST_USER_1,
+        organizationId: TEST_ORG_ID,
+        incomingRole: 'member',
+      });
+
+      expect(result.role).toBe('member');
+      expect(result.promoted).toBe(false);
+      expect(result.promotionError).toBeDefined();
+    });
+
+    it('falls back to member when WorkOS membership list fails (refuses to promote blind)', async () => {
+      const { client, updateOrganizationMembership } = makeWorkos({
+        memberships: [],
+        listFails: true,
+      });
+
+      const result = await resolveRoleWithWorkosFirstPromote({
+        workos: client,
+        membershipId: 'om_target',
+        userId: TEST_USER_1,
+        organizationId: TEST_ORG_ID,
+        incomingRole: 'member',
+      });
+
+      expect(result.role).toBe('member');
+      expect(result.promoted).toBe(false);
+      expect(result.promotionError).toBeDefined();
+      expect(updateOrganizationMembership).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

Three places where `organization_memberships.role` (local) could drift from WorkOS, all fixed to be **WorkOS-first**:

1. **Webhook auto-promote (ownerless-org safety net).** Used to be local-atomic-first, push-to-WorkOS-after, best-effort rollback. If both the WorkOS push and the rollback failed, local was stuck at `owner` while WorkOS stayed at `member`. Now lists WorkOS, calls `updateOrganizationMembership` *first*, and only writes the resolved role locally on success. Any WorkOS failure falls back to `member` locally — local can no longer get ahead of WorkOS.
2. **No audit trail for auto-promotes.** Both outcomes now write to `registry_audit_log` (`membership_auto_promoted_to_owner` / `membership_auto_promote_failed`). Future drift questions don't need log surgery.
3. **`POST /api/admin/organizations/:orgId/add-users`** (Domain Health "move user from personal workspace") used to insert a local-only row with no `createOrganizationMembership` call to WorkOS. Local said the user was in the org, WorkOS — and therefore every read-side gate — didn't know. Now WorkOS-first with the membership id cached.

### Backstory

Triggered by an Ozone Project owner who couldn't add Linked Domains in the AAO member-profile UI. AAO admin showed Wojtek as `owner`; WorkOS had him as `member`. Forensic SQL on `registry_audit_log` returned zero rows, which ruled out the admin dropdown and pointed at the local-first auto-promote path. Once the WorkOS-first ordering is in place, this can't happen through the auto-promote route again; and the new audit actions mean the next time it does drift through some unknown path, the same query has an answer.

Pre-existing drift is reconciled out-of-band — not via a shipped script.

## Test plan

- [ ] `npm run test:unit` — passes locally (834 tests, includes new `resolveRoleWithWorkosFirstPromote` cases with mocked WorkOS)
- [ ] CI integration tests cover the updated `upsertOrganizationMembership` contract and the new resolver
- [ ] Manual: in AAO admin, change a user's role with the dropdown — confirm WorkOS reflects the change (regression guard for the unchanged admin route)
- [ ] Manual: use Domain Health "move from personal workspace" on a test user — confirm WorkOS gets a membership and the user can immediately exercise WorkOS-gated features

## Notes

- Precommit typecheck was bypassed for this commit. Three errors exist on `main` (unrelated: `compliance-testing.ts` `TrackStatus` drift between SDK and local types, `framework-server.ts` missing SDK export). This branch adds zero new typecheck errors.