### PR TITLE
fix(server): code-hygiene trio in admin org-membership path after #4909

### DIFF
--- a/.changeset/4911-add-users-drift-hardening.md
+++ b/.changeset/4911-add-users-drift-hardening.md
@@ -1,0 +1,10 @@
+---
+---
+
+Server: three code-hygiene fixes in the admin org-membership path after #4909.
+
+- Update stale comment in `autoLinkByVerifiedDomain` (membership-db.ts) to reflect #4909's ownerless-org-promotion flow (`resolveRoleWithWorkosFirstPromote` via WorkOS list, replacing the deleted NOT EXISTS subquery).
+- Remove inner shadowed `orgDb` in workos-webhooks.ts (uses module-level instance instead).
+- Add explicit type annotation for `let newMembership` in the admin add-users loop.
+
+Refs #4911. Security items and the `organization_membership_already_exists` handler tracked separately in that issue.

--- a/server/src/db/membership-db.ts
+++ b/server/src/db/membership-db.ts
@@ -452,10 +452,10 @@ export async function autoLinkByVerifiedDomain(
   );
 
   // Always create as member. Auto-promotion to owner for ownerless orgs is
-  // handled atomically by upsertOrganizationMembership when the
-  // organization_membership.created webhook fires — that path uses a NOT EXISTS
-  // subquery against the live membership table, which is race-safe and not
-  // vulnerable to the local-cache skew that a `has_admin` lookup here would be.
+  // handled by resolveRoleWithWorkosFirstPromote when the
+  // organization_membership.created webhook fires — that path pages WorkOS for
+  // existing admin/owner memberships before promoting, so it reflects live state
+  // rather than the local cache.
   try {
     await workos.userManagement.createOrganizationMembership({
       userId,

--- a/server/src/routes/admin/organizations.ts
+++ b/server/src/routes/admin/organizations.ts
@@ -1167,7 +1167,7 @@ export function setupOrganizationRoutes(
               continue;
             }
 
-            let newMembership;
+            let newMembership: Awaited<ReturnType<WorkOS['userManagement']['createOrganizationMembership']>>;
             try {
               newMembership = await workos.userManagement.createOrganizationMembership({
                 userId,

--- a/server/src/routes/workos-webhooks.ts
+++ b/server/src/routes/workos-webhooks.ts
@@ -1074,7 +1074,6 @@ export function createWorkOSWebhooksRouter(): Router {
                           let ownerName: string | null = null;
                           if (brand.domain_verified && brand.workos_organization_id) {
                             try {
-                              const orgDb = new OrganizationDatabase();
                               const ownerOrg = await orgDb.getOrganization(brand.workos_organization_id);
                               ownerName = ownerOrg?.name ?? null;
                             } catch (orgErr) {


### PR DESCRIPTION
Refs #4911

Three non-breaking server-side fixes surfaced by Argus review after #4909 merged. All are purely hygiene changes in the admin org-membership path; they do not touch the auth boundary, schema, or protocol surfaces.

**Non-breaking justification:** comment-only edit, a one-line deletion of a redundant object instantiation, and a type annotation addition. No API contract changes; no runtime behavior changes for any valid call path.

**Pre-PR review:**
- code-reviewer: approved (items 2, 9, 10 — nits only; item 4 deferred, see below)
- internal-tools-strategist: approved — all three changes correct and bounded

**What's in this PR (items 2, 9, 10 from #4911):**
- `membership-db.ts:454-458` — update stale comment in `autoLinkByVerifiedDomain`; #4909 replaced the NOT EXISTS subquery with `resolveRoleWithWorkosFirstPromote`; the old comment pointed at machinery that no longer exists.
- `workos-webhooks.ts:1077` — remove inner shadowed `orgDb`; the module-level instance at line 57 is in scope and pool-equivalent; the inner `new OrganizationDatabase()` was a throwaway allocation.
- `admin/organizations.ts:1170` — add explicit type annotation for `let newMembership` (was implicitly `any`).

**What's NOT in this PR (deferred from #4911):**
- **Item 1** (cross-tenant scope / `requireGlobalAdmin` decision) — security-sensitive, flagged for human review; see triage comment on #4911.
- **Item 3** (use `upsertOrganizationMembership`) — deferred until item 1 lands; internal-tools-strategist noted it should follow the auth fix.
- **Item 4** (`organization_membership_already_exists` handler) — code-reviewer and internal-tools-strategist disagreed on whether the local DB repair is needed in the error path; deferred for human review alongside item 3.
- **Items 5, 6, 7, 8** — security-sensitive or require design decisions; see triage comment on #4911.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_015z2eRYT2ZcmYemiAN3cLiC

---
_Generated by [Claude Code](https://claude.ai/code/session_015z2eRYT2ZcmYemiAN3cLiC)_