### PR TITLE
docs(accounts): clarify single-publisher cardinality on `list_accounts` (refs #4914)

### DIFF
--- a/.changeset/list-accounts-single-publisher-cardinality.md
+++ b/.changeset/list-accounts-single-publisher-cardinality.md
@@ -1,0 +1,10 @@
+---
+---
+
+docs(accounts): clarify that single-publisher sellers may return a single
+`list_accounts` account without a pagination envelope.
+
+The canonical `list-accounts-response.json` example already shows this shape.
+This documentation update makes the conformance expectation explicit: pagination
+walk checks are not applicable when pagination is absent, or when
+`pagination.total_count` is present and no more than one.

--- a/docs/accounts/tasks/list_accounts.mdx
+++ b/docs/accounts/tasks/list_accounts.mdx
@@ -94,6 +94,17 @@ All parameters are optional. An empty request returns all accounts.
 | `authorization` | Optional. The calling agent's scope grant for this account — `allowed_tasks`, `field_scopes`, `scope_name`, `read_only`. Applies to every vendor agent type (media-buy, signals, governance, creative, brand) — the Accounts Protocol surface is shared. Vendor agents that support scope introspection SHOULD populate this; media-buy sales agents claiming the `attestation_verifier` standard scope MUST populate it. Absence means the vendor agent does not advertise introspectable scope for this account; callers MUST NOT infer access from absence and fall back to error-driven discovery via the RBAC error codes. See [Caller authorization](/docs/accounts/overview#caller-authorization) for the full shape and semantics. |
 | `notification_configs` | Account-level webhook subscribers registered via [`sync_accounts`](/docs/accounts/tasks/sync_accounts#account-level-webhook-subscriptions). Each entry carries `subscriber_id`, `url`, `event_types[]`, and `active`. Present when the account has any persisted subscribers. `authentication.credentials` is omitted on every entry (write-only). Use this surface to verify what's active after a sync, audit fan-out across multiple subscribers, and detect drift between buyer-side expectations and seller-side persisted state. |
 
+### Single-publisher cardinality
+
+A seller serving exactly one publisher entity MAY return that entity as the sole account on `list_accounts` responses, regardless of calling principal. The *"Direct advertiser with single account"* example in [`list-accounts-response.json`](https://github.com/adcontextprotocol/adcp/blob/main/static/schemas/source/account/list-accounts-response.json) is canonical for this case — a single-element `accounts[]` with no `pagination` envelope at all.
+
+Pagination conformance requiring `pagination.has_more: true` does not apply when:
+
+- `pagination` is absent entirely (canonical single-account shape), or
+- `pagination.total_count` is present and ≤ 1
+
+Runners SHOULD grade pagination-walk phases as `not_applicable` in either case. This pattern is conformant; the spec carries no `minItems` constraint on `accounts[]` and the single-account example is normative.
+
 ## Common Scenarios
 
 ### Poll until account becomes active


### PR DESCRIPTION
## Summary

Clarifies that single-publisher first-party sellers are spec-conformant when `list_accounts` returns a single-element `accounts[]` with no pagination envelope. The canonical *"Direct advertiser with single account"* example in `list-accounts-response.json` already shows this shape — this PR makes the pattern explicit in the docs and gives conformance runners normative guidance for the pagination-walk phase.

This is **Option C** from #4914 (community-reported issue). The B vs D runner-fix decision is independent and tracked in that thread.

## What changes

`docs/accounts/tasks/list_accounts.mdx` — adds a `### Single-publisher cardinality` subsection after the Response field tables. The new content:

- States the single-account return is conformant regardless of calling principal
- References the canonical schema example as normative evidence
- Defines when pagination-walk conformance does not apply:
  - `pagination` field is absent entirely (canonical single-account shape), or
  - `pagination.total_count` is present and ≤ 1
- Recommends `not_applicable` grading for storyboard runners in either case

## Why

The spec carries no `minItems` constraint on `accounts[]` and ships a normative single-account example, but the conformance suite's `pagination_integrity_list_accounts` storyboard unconditionally asserts `pagination.has_more: true` — structurally unsatisfiable for single-publisher sellers. Without an explicit docs callout, future adopters in this category (direct publishers, vertical-specific marketplaces, first-party signal sellers) hit the same gap.

The runner-side fix is independent — see #4914 for the B (response-value skip) vs D (capability declaration) discussion. This PR is the docs-only companion that can land regardless.

## Closes / refs

- Refs: #4914
- Verified against canonical example in `static/schemas/source/account/list-accounts-response.json` (3.1.0-beta.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
