### PR TITLE
fix(addie): deliver cost-cap message in Slack streaming path (#4555)

### DIFF
--- a/.changeset/4555-addie-cap-message-delivery.md
+++ b/.changeset/4555-addie-cap-message-delivery.md
@@ -1,0 +1,10 @@
+---
+---
+
+fix(addie): deliver cost-cap message in Slack streaming path (#4555)
+
+When a user's daily Claude API usage cap fires, the cap message was generated but never reached Slack. The streaming path in `handleUserMessage` (bolt-app.ts) collected a `done` event with `flag_reason: 'cost_cap_exceeded'` but never called `say()` or passed `markdown_text` to `streamer.stop()` — the streamer closed with an empty buffer, leaving the user with no response.
+
+Fix: check for `flag_reason === 'cost_cap_exceeded'` before the normal `streamer.stop()` call; when the flag is present, stop the stream with `markdown_text: response.text` so the cap message is delivered inline. The catch-block fallback is updated to use the cap message text instead of the generic apology for the same case.
+
+Also: rename "AAO team" → "AgenticAdvertising.org team" in the cap-exceeded copy, and "The cap resets in" → "You can try again in" for clarity.

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -32,7 +32,7 @@ import { createLogger } from '../logger.js';
 const logger = createLogger('addie-bolt-app');
 import { sanitizeSpeakerName } from './prompts.js';
 import { captureEvent } from '../utils/posthog.js';
-import { AddieClaudeClient, ADMIN_MAX_ITERATIONS, CERTIFICATION_MAX_ITERATIONS, type UserScopedToolsResult } from './claude-client.js';
+import { AddieClaudeClient, ADMIN_MAX_ITERATIONS, CERTIFICATION_MAX_ITERATIONS, type AddieResponse, type UserScopedToolsResult } from './claude-client.js';
 import { buildSlackCostScope } from './claude-cost-tracker.js';
 import { AddieDatabase } from '../db/addie-db.js';
 import { SlackDatabase } from '../db/slack-db.js';
@@ -1680,7 +1680,7 @@ async function handleUserMessage({
   };
 
   // Process with Claude using streaming
-  let response;
+  let response: AddieResponse | undefined;
   let fullText = '';
   const toolsUsed: string[] = [];
   const toolExecutions: { tool_name: string; parameters: Record<string, unknown>; result: string }[] = [];
@@ -1933,22 +1933,31 @@ async function handleUserMessage({
       } else {
         // Stop the stream with feedback buttons and any inline images.
         try {
-          // Extract image URLs from streamed text for Slack Block Kit image blocks
-          const { images: streamImages } = extractMarkdownImages(fullText);
-          const MAX_SLACK_IMAGES = 3;
-          const imageBlocks = streamImages.slice(0, MAX_SLACK_IMAGES).map(img => ({
-            type: 'image' as const,
-            image_url: img.url,
-            alt_text: img.alt,
-          }));
-          // Don't pass markdown_text — the SDK buffer already has all text from
-          // append() calls. Passing it again would duplicate the message.
-          await streamer.stop({
-            blocks: [
-              ...imageBlocks,
-              buildFeedbackBlock(),
-            ],
-          });
+          // Cap-exceeded responses have no streamed text — deliver the cap
+          // message as the terminal text so the user isn't left with silence.
+          if (response?.flag_reason === 'cost_cap_exceeded') {
+            const capGuarded = guardBareJsonEnvelope(response.text, { pathTag: 'dm-streaming-cap-exceeded' });
+            const capValidation = validateOutput(capGuarded.text);
+            const capText = wrapUrlsForSlack(capValidation.sanitized);
+            await streamer.stop({ markdown_text: capText, blocks: [buildFeedbackBlock()] });
+          } else {
+            // Extract image URLs from streamed text for Slack Block Kit image blocks
+            const { images: streamImages } = extractMarkdownImages(fullText);
+            const MAX_SLACK_IMAGES = 3;
+            const imageBlocks = streamImages.slice(0, MAX_SLACK_IMAGES).map(img => ({
+              type: 'image' as const,
+              image_url: img.url,
+              alt_text: img.alt,
+            }));
+            // Don't pass markdown_text — the SDK buffer already has all text from
+            // append() calls. Passing it again would duplicate the message.
+            await streamer.stop({
+              blocks: [
+                ...imageBlocks,
+                buildFeedbackBlock(),
+              ],
+            });
+          }
         } catch (stopError) {
           logger.warn({ stopError }, 'Addie Bolt: Stream stop failed, falling back to say()');
           // Fallback: send via say() so the user isn't left without a response
@@ -1959,11 +1968,14 @@ async function handleUserMessage({
             const slackText = wrapUrlsForSlack(fallbackText);
             // Slack rejects section blocks with empty mrkdwn text. If streaming
             // produced nothing (e.g. upstream overload before any deltas), fall
-            // back to a plain apology so the user isn't left silent.
+            // back to a plain apology so the user isn't left silent. For
+            // cost_cap_exceeded, deliver the cap message directly.
             if (!slackText.trim()) {
-              const apology = isRetriesExhaustedError(stopError)
-                ? `${stopError.reason}. Please try again in a moment.`
-                : "I'm sorry, I encountered an error. Please try again.";
+              const apology = response?.flag_reason === 'cost_cap_exceeded'
+                ? response.text
+                : isRetriesExhaustedError(stopError)
+                  ? `${stopError.reason}. Please try again in a moment.`
+                  : "I'm sorry, I encountered an error. Please try again.";
               await say(apology);
             } else {
               await say({

--- a/server/src/addie/claude-cost-tracker.ts
+++ b/server/src/addie/claude-cost-tracker.ts
@@ -247,9 +247,9 @@ export function formatCapExceededMessage(result: CostCheckResult): string {
   return (
     `You've hit today's Claude API usage cap (${capUsd} USD) — ` +
     `spent ≈ $${spentUsd} in the last 24 hours. ` +
-    `The cap resets in ${humanReset}. ` +
+    `You can try again in ${humanReset}. ` +
     (tier === 'member_paid'
-      ? 'Ping the AAO team if you need a higher ceiling for legitimate work.'
+      ? 'Ping the AgenticAdvertising.org team if you need a higher ceiling for legitimate work.'
       : 'Upgrade your membership at /membership for a higher daily ceiling.')
   );
 }

--- a/server/tests/unit/claude-cost-tracker.test.ts
+++ b/server/tests/unit/claude-cost-tracker.test.ts
@@ -126,7 +126,7 @@ describe('formatCapExceededMessage', () => {
       retryAfterMs: 60 * 60 * 1000,
       tier: 'member_paid',
     });
-    expect(msg).toContain('AAO team');
+    expect(msg).toContain('AgenticAdvertising.org team');
     expect(msg).not.toContain('Upgrade');
   });
 });


### PR DESCRIPTION
## Summary

- When a user's daily Claude API usage cap fired, the cap message was generated in `processMessageStream` but never reached Slack. The `done` event handler in `handleUserMessage` stored `response` but the subsequent `streamer.stop()` call had no `markdown_text`, leaving the user with silence.
- Fix: check `flag_reason === 'cost_cap_exceeded'` before `streamer.stop()` and route the cap message through the standard `guardBareJsonEnvelope` → `validateOutput` → `wrapUrlsForSlack` pipeline, then pass it with `blocks: [buildFeedbackBlock()]`.
- Also updates catch-block fallback to use cap message text (not generic apology) for the same case, and fixes copy: `"You can try again in"` (was `"The cap resets in"`) and `"AgenticAdvertising.org team"` (was `"AAO team"`).

## Files changed

| File | Change |
|---|---|
| `server/src/addie/bolt-app.ts` | Cap-exceeded branch in streaming stop path; typed `response` as `AddieResponse \| undefined`; catch-block fallback |
| `server/src/addie/claude-cost-tracker.ts` | Copy fixes in `formatCapExceededMessage` |
| `.changeset/4555-addie-cap-message-delivery.md` | Empty changeset (Addie-only, non-protocol) |

## Test plan

- [ ] Trigger cap in staging (or manually set a very low cap) and send a DM — user should receive the cap message inline with the feedback block, not silence
- [ ] Verify non-cap streaming responses are unaffected (feedback block still appears, no duplicate text)
- [ ] Verify catch-block path: if `streamer.stop()` throws while cap is set, `say()` fallback should deliver cap text not generic apology
- [ ] Check copy: reset message reads "You can try again in X" and team name reads "AgenticAdvertising.org team"

Closes #4555

https://claude.ai/code/session_014QkPXWZgXi6XefzSBArC1W

---
_Generated by [Claude Code](https://claude.ai/code/session_014QkPXWZgXi6XefzSBArC1W)_