### PR TITLE
fix(server): add /v1/agents path alias for spec-conformant AAO directory lookup

### DIFF
--- a/.changeset/4924-aao-directory-v1-path-alias.md
+++ b/.changeset/4924-aao-directory-v1-path-alias.md
@@ -3,4 +3,4 @@
 
 fix(server): mount AAO directory inverse-lookup at spec-conformant /v1/agents path
 
-Adds a /v1/agents/:encodedUrl/publishers route alongside the existing /api/v1/agents/... path so spec-conformant SDK clients (adcp-client-python fetch_agent_authorizations_from_directory) work without the /api-prefix workaround. Keeps /api/v1/... for backward compat. Also corrects the OpenAPI path registration from /api/v1/agents/... to /v1/agents/... to match docs/aao/directory-api.mdx.
+Adds a /v1/agents/:encodedUrl/publishers route alongside the existing /api/v1/agents/... path so spec-conformant SDK clients (adcp-client-python fetch_agent_authorizations_from_directory) work without the /api-prefix workaround. Keeps /api/v1/... for backward compat and documents both OpenAPI paths, with /v1/agents/... as the spec-conformant operation.

--- a/.changeset/4924-aao-directory-v1-path-alias.md
+++ b/.changeset/4924-aao-directory-v1-path-alias.md
@@ -1,0 +1,6 @@
+---
+---
+
+fix(server): mount AAO directory inverse-lookup at spec-conformant /v1/agents path
+
+Adds a /v1/agents/:encodedUrl/publishers route alongside the existing /api/v1/agents/... path so spec-conformant SDK clients (adcp-client-python fetch_agent_authorizations_from_directory) work without the /api-prefix workaround. Keeps /api/v1/... for backward compat. Also corrects the OpenAPI path registration from /api/v1/agents/... to /v1/agents/... to match docs/aao/directory-api.mdx.

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -120,7 +120,7 @@ import {
   buildConformanceTokenRouter,
   conformanceSessions,
 } from "./conformance/index.js";
-import { createRegistryApiRouter } from "./routes/registry-api.js";
+import { createRegistryApiRouters } from "./routes/registry-api.js";
 import { getPublicJwks } from "./services/verification-token.js";
 import { createCatalogApiRouter } from "./routes/catalog-api.js";
 import { getLogo, isAllowedLogoContentType } from "./services/logo-cdn.js";
@@ -1055,7 +1055,7 @@ export class HTTPServer {
     this.app.use('/api', createInvitesRouter());
 
     // Mount public Registry API routes (brands, properties, agents, search, validation)
-    const { router: registryApiRouter, v1AgentsRouter } = createRegistryApiRouter({
+    const { router: registryApiRouter, v1AgentsRouter } = createRegistryApiRouters({
       brandManager: this.brandManager,
       brandDb: this.brandDb,
       propertyDb: this.propertyDb,

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -1055,7 +1055,7 @@ export class HTTPServer {
     this.app.use('/api', createInvitesRouter());
 
     // Mount public Registry API routes (brands, properties, agents, search, validation)
-    const registryApiRouter = createRegistryApiRouter({
+    const { router: registryApiRouter, v1AgentsRouter } = createRegistryApiRouter({
       brandManager: this.brandManager,
       brandDb: this.brandDb,
       propertyDb: this.propertyDb,
@@ -1070,6 +1070,11 @@ export class HTTPServer {
       optionalAuth,
     });
     this.app.use('/api', registryApiRouter);
+    // adcp#4924: spec defines the AAO directory inverse-lookup path as
+    // /v1/agents/{url}/publishers (docs/aao/directory-api.mdx). Mount the
+    // v1AgentsRouter at /v1 so spec-conformant clients work without the /api
+    // prefix workaround. The /api/v1/agents/... path remains for backward compat.
+    this.app.use('/v1', v1AgentsRouter);
 
     // RFC 8615: serve JWKS at root /.well-known/ path for standard OIDC/JWT discovery
     this.app.get('/.well-known/jwks.json', (_req, res) => {

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -759,7 +759,7 @@ const AgentPublishersEntrySchema = z.object({
 
 registry.registerPath({
   method: "get",
-  path: "/api/v1/agents/{encodedUrl}/publishers",
+  path: "/v1/agents/{encodedUrl}/publishers",
   operationId: "getPublishersForAgent",
   summary: "AAO directory inverse-lookup",
   description:
@@ -2951,7 +2951,7 @@ registry.registerPath({
 
 // ── Router factory ──────────────────────────────────────────────
 
-export function createRegistryApiRouter(config: RegistryApiConfig): Router {
+export function createRegistryApiRouter(config: RegistryApiConfig): { router: Router; v1AgentsRouter: Router } {
   const router = Router();
   const {
     brandManager,
@@ -7091,7 +7091,11 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
   // The bare /registry/lookup/agent/:agentUrl/domains above is kept as a
   // lightweight legacy surface (domain strings only). This endpoint is the
   // spec-compliant richer shape — different path so the contract is explicit.
-  router.get("/v1/agents/:encodedUrl/publishers", registryReadRateLimiter, async (req, res) => {
+  //
+  // adcp#4924: handler extracted so it can be registered at both the legacy
+  // /api/v1/agents/... path (via the /api mount in http.ts) and the
+  // spec-conformant /v1/agents/... path (via v1AgentsRouter mounted at /v1).
+  const agentPublishersHandler: RequestHandler = async (req, res) => {
     try {
       // decodeURIComponent throws on malformed percent-escapes (`%E0%A4`);
       // surface as 400 rather than letting the outer catch 500.
@@ -7314,7 +7318,15 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       logger.error({ err: error, path: req.path }, "Agent → publishers inverse lookup failed");
       return res.status(500).json({ error: "Agent → publishers inverse lookup failed" });
     }
-  });
+  };
+
+  // Legacy path (router mounted at /api in http.ts → /api/v1/agents/...).
+  router.get("/v1/agents/:encodedUrl/publishers", registryReadRateLimiter, agentPublishersHandler);
+
+  // Spec-conformant path: mounted at /v1 in http.ts → /v1/agents/...
+  // (adcp#4924). Keeps /api/v1/... working for backward compat.
+  const v1AgentsRouter = Router();
+  v1AgentsRouter.get("/agents/:encodedUrl/publishers", registryReadRateLimiter, agentPublishersHandler);
 
   router.post("/registry/validate/product-authorization", async (req, res) => {
     try {
@@ -8444,5 +8456,5 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
     }
   });
 
-  return router;
+  return { router, v1AgentsRouter };
 }

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -757,10 +757,7 @@ const AgentPublishersEntrySchema = z.object({
   last_verified_at: z.string().datetime(),
 });
 
-registry.registerPath({
-  method: "get",
-  path: "/v1/agents/{encodedUrl}/publishers",
-  operationId: "getPublishersForAgent",
+const AgentPublishersOpenApi = {
   summary: "AAO directory inverse-lookup",
   description:
     "Given a percent-encoded `agent_url`, returns the publishers whose adagents.json authorizes that agent, " +
@@ -800,6 +797,20 @@ registry.registerPath({
     400: { description: "Invalid agent_url, cursor, since, or status", content: { "application/json": { schema: ErrorSchema } } },
     404: { description: "Directory has never indexed any publisher referencing this agent_url. Distinct from 200 + empty.", content: { "application/json": { schema: ErrorSchema } } },
   },
+};
+
+registry.registerPath({
+  method: "get",
+  path: "/api/v1/agents/{encodedUrl}/publishers",
+  operationId: "getPublishersForAgentLegacyApiPrefix",
+  ...AgentPublishersOpenApi,
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/agents/{encodedUrl}/publishers",
+  operationId: "getPublishersForAgent",
+  ...AgentPublishersOpenApi,
 });
 
 registry.registerPath({
@@ -2951,7 +2962,11 @@ registry.registerPath({
 
 // ── Router factory ──────────────────────────────────────────────
 
-export function createRegistryApiRouter(config: RegistryApiConfig): { router: Router; v1AgentsRouter: Router } {
+export function createRegistryApiRouter(config: RegistryApiConfig): Router {
+  return createRegistryApiRouters(config).router;
+}
+
+export function createRegistryApiRouters(config: RegistryApiConfig): { router: Router; v1AgentsRouter: Router } {
   const router = Router();
   const {
     brandManager,

--- a/server/tests/integration/registry-api-agent-publishers.test.ts
+++ b/server/tests/integration/registry-api-agent-publishers.test.ts
@@ -1,6 +1,7 @@
 /**
- * HTTP-level integration tests for `GET /api/v1/agents/{agent_url}/publishers`,
- * the AAO directory inverse-lookup endpoint (adcp#4823).
+ * HTTP-level integration tests for the AAO directory inverse-lookup endpoint
+ * (adcp#4823), exposed at `/v1/agents/{agent_url}/publishers` with the
+ * legacy `/api/v1/agents/{agent_url}/publishers` path kept for compatibility.
  *
  * Focused on route-handler parsing logic (status / cursor / since / limit /
  * ETag / 404 vs 200-empty) that the DB-level integration test
@@ -23,7 +24,7 @@ const PUB_B = `route-b-${RUN_SUFFIX}.directorytest.example`;
 const PUB_REVOKED = `route-revoked-${RUN_SUFFIX}.directorytest.example`;
 const ALL_PUBS = [PUB_A, PUB_B, PUB_REVOKED];
 
-describe('GET /api/v1/agents/{agent_url}/publishers (HTTP)', () => {
+describe('GET /v1 and /api/v1 agents/{agent_url}/publishers (HTTP)', () => {
   let server: HTTPServer;
   let app: unknown;
   let pool: Pool;
@@ -100,6 +101,8 @@ describe('GET /api/v1/agents/{agent_url}/publishers (HTTP)', () => {
 
   const url = (agentUrl: string, qs = '') =>
     `/api/v1/agents/${encodeURIComponent(agentUrl)}/publishers${qs}`;
+  const specUrl = (agentUrl: string, qs = '') =>
+    `/v1/agents/${encodeURIComponent(agentUrl)}/publishers${qs}`;
 
   it('returns 404 for an agent never indexed', async () => {
     const res = await request(app).get(url(ABSENT_AGENT_URL));
@@ -123,6 +126,18 @@ describe('GET /api/v1/agents/{agent_url}/publishers (HTTP)', () => {
       ]),
       next_cursor: null,
     });
+  });
+
+  it('serves the spec-conformant /v1 path alias', async () => {
+    await seedAuthorized(PUB_A);
+    const res = await request(app).get(specUrl(AGENT_URL));
+    expect(res.status).toBe(200);
+    expect(res.body.publishers).toEqual([
+      expect.objectContaining({
+        publisher_domain: PUB_A,
+        status: 'authorized',
+      }),
+    ]);
   });
 
   it('returns 200 + empty (not 404) when filters exclude all rows', async () => {

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -3507,6 +3507,142 @@ paths:
                   - agent_url
                   - domains
                   - count
+  /api/v1/agents/{encodedUrl}/publishers:
+    get:
+      operationId: getPublishersForAgentLegacyApiPrefix
+      summary: AAO directory inverse-lookup
+      description: |-
+        Given a percent-encoded `agent_url`, returns the publishers whose adagents.json authorizes that agent, with provenance (`discovery_method`, `manager_domain`), per-publisher property counts (`properties_authorized`, `properties_total`, scoped to this publisher only — never network-wide), signing-key pin status, and lifecycle state (`authorized` / `revoked`).
+
+        Spec: [docs/aao/directory-api.mdx](/docs/aao/directory-api) (adcp#4823). This endpoint is the spec-compliant richer-shape replacement for the legacy `/api/registry/lookup/agent/{agentUrl}/domains`, which returns domain strings only.
+      tags:
+        - Authorization Lookups
+      parameters:
+        - schema:
+            type: string
+            description: Percent-encoded agent_url
+          required: true
+          description: Percent-encoded agent_url
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+            format: date-time
+            description: ISO 8601 — return only publishers with last_verified_at ≥ since
+          required: false
+          description: ISO 8601 — return only publishers with last_verified_at ≥ since
+          name: since
+          in: query
+        - schema:
+            type: string
+            description: Opaque pagination cursor returned by a prior response
+          required: false
+          description: Opaque pagination cursor returned by a prior response
+          name: cursor
+          in: query
+        - schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - authorized
+                - revoked
+            description: "Lifecycle status filter — repeat the key once per value (?status=authorized&status=revoked). Default: authorized. The comma-separated single-value form is rejected with 400."
+          required: false
+          description: "Lifecycle status filter — repeat the key once per value (?status=authorized&status=revoked). Default: authorized. The comma-separated single-value form is rejected with 400."
+          name: status
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            description: Page size, default 200, max 1000
+          required: false
+          description: Page size, default 200, max 1000
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Publishers authorizing the agent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  directory_indexed_at:
+                    type:
+                      - string
+                      - "null"
+                    format: date-time
+                    description: Most recent per-publisher refresh in this page. Null on empty pages (no anchor).
+                  publishers:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        publisher_domain:
+                          type: string
+                        discovery_method:
+                          type: string
+                          enum:
+                            - direct
+                            - authoritative_location
+                            - ads_txt_managerdomain
+                            - adagents_authoritative
+                        manager_domain:
+                          type:
+                            - string
+                            - "null"
+                        properties_authorized:
+                          type: integer
+                          minimum: 0
+                        properties_total:
+                          type: integer
+                          minimum: 0
+                        signing_keys_pinned:
+                          type: boolean
+                        status:
+                          type: string
+                          enum:
+                            - authorized
+                            - revoked
+                        last_verified_at:
+                          type: string
+                          format: date-time
+                      required:
+                        - publisher_domain
+                        - discovery_method
+                        - manager_domain
+                        - properties_authorized
+                        - properties_total
+                        - signing_keys_pinned
+                        - status
+                        - last_verified_at
+                  next_cursor:
+                    type:
+                      - string
+                      - "null"
+                required:
+                  - agent_url
+                  - directory_indexed_at
+                  - publishers
+                  - next_cursor
+        "304":
+          description: Not modified (If-None-Match matched)
+        "400":
+          description: Invalid agent_url, cursor, since, or status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Directory has never indexed any publisher referencing this agent_url. Distinct from 200 + empty.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /v1/agents/{encodedUrl}/publishers:
     get:
       operationId: getPublishersForAgent

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -3507,7 +3507,7 @@ paths:
                   - agent_url
                   - domains
                   - count
-  /api/v1/agents/{encodedUrl}/publishers:
+  /v1/agents/{encodedUrl}/publishers:
     get:
       operationId: getPublishersForAgent
       summary: AAO directory inverse-lookup


### PR DESCRIPTION
Closes #4924

## Summary

The spec (`docs/aao/directory-api.mdx`) defines the AAO directory inverse-lookup endpoint as:

```
GET https://{aao_directory}/v1/agents/{agent_url}/publishers
```

The production server mounted it at `/api/v1/agents/...` because the registry router is registered at `/api` in `http.ts`. Spec-conformant SDK clients (`adcp-client-python`'s `fetch_agent_authorizations_from_directory`) build the URL per spec and get HTTP 404. The only workaround was passing `directory_url = "https://agenticadvertising.org/api"` — a bespoke non-spec string.

This PR:
1. Extracts the handler into a named `const agentPublishersHandler` and registers it on both the existing router (keeping `/api/v1/agents/...` for backward compat) and a new `v1AgentsRouter` mounted at `/v1` in `http.ts` (giving `/v1/agents/...` per spec).
2. Corrects the OpenAPI `registry.registerPath` path from `/api/v1/agents/{encodedUrl}/publishers` to `/v1/agents/{encodedUrl}/publishers` to match the spec doc.

**Non-breaking justification:** Adds a new route at `/v1/agents/...`; the existing `/api/v1/agents/...` path is unchanged and continues to serve all current callers.

**Note on rate limiting:** Both paths apply the same `registryReadRateLimiter` middleware instance. A caller alternating between the two paths would consume two quota slots per round-trip. This is expected behavior (two requests = two counts) and acceptable given the backward-compat intent; the effective ceiling is unchanged for any single-path client.

**Pre-PR review:**
- code-reviewer: approved — path math correct, rate limiter applied to both paths, Router instance stateless, return-type refactor caught by TS, no blockers
- ad-tech-protocol-expert: approved — spec unambiguously defines /v1/ path, alias approach is correct, OpenAPI path correction is sufficient for doc/spec coherence

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01ReqvSDyC16Fum8QbQ9peUL

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReqvSDyC16Fum8QbQ9peUL)_