### PR TITLE
feat(aao-directory): wire ?include=properties server implementation

### DIFF
--- a/.changeset/wire-include-properties-server.md
+++ b/.changeset/wire-include-properties-server.md
@@ -1,0 +1,11 @@
+---
+---
+
+server: wire `?include=properties` through the registry endpoint so `property_ids[]` is returned in each `PublisherEntry` when the flag is set (#4890).
+
+The spec-only changeset (`4890-aao-include-properties.md`) already documented the schema delta and docs. This changeset covers the server implementation:
+
+- `federated-index-db.ts`: `AgentPublisherDetailRow` gains `property_ids?: string[] | null`; `getPublishersForAgentDetail` accepts `includePropertyIds` opt; SQL adds `CASE WHEN $6 THEN ARRAY_AGG(dp.property_id)` subquery that short-circuits when false.
+- `federated-index.ts`: passes `includePropertyIds` through to the DB layer.
+- `registry-api.ts`: parses `?include` (repeated-key, same encoding as `?status`; comma-separated form rejected 400; unknown values rejected 400); passes flag to service; serializes `property_ids` when set; updates ETag to cover the include flag and resolved IDs; updates `AgentPublishersEntrySchema` and OpenAPI query schema.
+- Integration tests: DB-level (`registry-agent-publishers-detail.test.ts`) and HTTP-level (`registry-api-agent-publishers.test.ts`) coverage.

--- a/server/src/db/federated-index-db.ts
+++ b/server/src/db/federated-index-db.ts
@@ -359,14 +359,13 @@ export class FederatedIndexDatabase {
              FROM discovered_properties dp
             WHERE dp.publisher_domain = e.publisher_domain
          ), 0) AS properties_total,
-         -- properties_authorized: count of properties under THIS publisher_domain
-         -- the agent is authorized for, via agent_property_authorizations.
-         -- Filtered to dp.property_id IS NOT NULL so this count is symmetric
-         -- with the property_ids ARRAY_AGG below (MUST len(property_ids) ==
-         -- properties_authorized per spec). Properties without a canonical
-         -- property_id string can't appear in either count or array.
+         -- properties_authorized: count of canonical property_id strings under
+         -- THIS publisher_domain the agent is authorized for. Filtered to
+         -- dp.property_id IS NOT NULL so this count is symmetric with the
+         -- property_ids ARRAY_AGG below (MUST len(property_ids) ==
+         -- properties_authorized per spec).
          COALESCE((
-           SELECT COUNT(DISTINCT apa.property_id)::int
+           SELECT COUNT(DISTINCT dp.property_id)::int
              FROM agent_property_authorizations apa
              JOIN discovered_properties dp ON dp.id = apa.property_id
             WHERE apa.agent_url = $1
@@ -376,10 +375,9 @@ export class FederatedIndexDatabase {
          -- property_ids: resolved property_id strings, present only when
          -- ?include=properties was requested ($6=true). CASE WHEN short-circuits
          -- the subquery when false, so there is no cost on default calls.
-         -- Only properties with a non-null property_id are included; properties
-         -- without one are counted in properties_authorized but cannot be named.
+         -- Only properties with a non-null property_id are included.
          CASE WHEN $6::boolean THEN (
-           SELECT ARRAY_AGG(dp.property_id ORDER BY dp.property_id)
+           SELECT ARRAY_AGG(DISTINCT dp.property_id ORDER BY dp.property_id)
              FROM agent_property_authorizations apa
              JOIN discovered_properties dp ON dp.id = apa.property_id
             WHERE apa.agent_url = $1

--- a/server/src/db/federated-index-db.ts
+++ b/server/src/db/federated-index-db.ts
@@ -73,6 +73,7 @@ export interface AgentPublisherDetailRow {
   manager_domain: string | null;
   properties_total: number;
   properties_authorized: number;
+  property_ids: string[] | null;
   signing_keys_pinned: boolean;
   status: 'authorized' | 'revoked';
 }
@@ -250,6 +251,7 @@ export class FederatedIndexDatabase {
       cursor?: string;
       since?: Date;
       includeRevoked?: boolean;
+      includePropertyIds?: boolean;
       limit: number;
     },
   ): Promise<AgentPublisherDetailRow[]> {
@@ -257,6 +259,7 @@ export class FederatedIndexDatabase {
     const cursor = opts.cursor ?? '';
     const limit = opts.limit;
     const includeRevoked = opts.includeRevoked ?? false;
+    const includePropertyIds = opts.includePropertyIds ?? false;
 
     // Dual-read pattern matches getDomainsForAgent / getAgentsForDomain:
     // UNION ALL with explicit src_priority (legacy=0 wins on collision) +
@@ -358,13 +361,31 @@ export class FederatedIndexDatabase {
          ), 0) AS properties_total,
          -- properties_authorized: count of properties under THIS publisher_domain
          -- the agent is authorized for, via agent_property_authorizations.
+         -- Filtered to dp.property_id IS NOT NULL so this count is symmetric
+         -- with the property_ids ARRAY_AGG below (MUST len(property_ids) ==
+         -- properties_authorized per spec). Properties without a canonical
+         -- property_id string can't appear in either count or array.
          COALESCE((
            SELECT COUNT(DISTINCT apa.property_id)::int
              FROM agent_property_authorizations apa
              JOIN discovered_properties dp ON dp.id = apa.property_id
             WHERE apa.agent_url = $1
               AND dp.publisher_domain = e.publisher_domain
+              AND dp.property_id IS NOT NULL
          ), 0) AS properties_authorized,
+         -- property_ids: resolved property_id strings, present only when
+         -- ?include=properties was requested ($6=true). CASE WHEN short-circuits
+         -- the subquery when false, so there is no cost on default calls.
+         -- Only properties with a non-null property_id are included; properties
+         -- without one are counted in properties_authorized but cannot be named.
+         CASE WHEN $6::boolean THEN (
+           SELECT ARRAY_AGG(dp.property_id ORDER BY dp.property_id)
+             FROM agent_property_authorizations apa
+             JOIN discovered_properties dp ON dp.id = apa.property_id
+            WHERE apa.agent_url = $1
+              AND dp.publisher_domain = e.publisher_domain
+              AND dp.property_id IS NOT NULL
+         ) ELSE NULL END AS property_ids,
          e.signing_keys_pinned,
          CASE WHEN e.is_revoked THEN 'revoked' ELSE 'authorized' END AS status
        FROM enriched e
@@ -373,7 +394,7 @@ export class FederatedIndexDatabase {
          AND ($4::boolean OR NOT e.is_revoked)
        ORDER BY e.publisher_domain
        LIMIT $5`,
-      [agentUrl, cursor, since, includeRevoked, limit],
+      [agentUrl, cursor, since, includeRevoked, limit, includePropertyIds],
     );
     return result.rows;
   }

--- a/server/src/federated-index.ts
+++ b/server/src/federated-index.ts
@@ -239,7 +239,7 @@ export class FederatedIndexService {
    */
   async getPublishersForAgentDetail(
     agentUrl: string,
-    opts: { cursor?: string; since?: Date; includeRevoked?: boolean; limit: number },
+    opts: { cursor?: string; since?: Date; includeRevoked?: boolean; includePropertyIds?: boolean; limit: number },
   ): Promise<AgentPublisherDetailRow[]> {
     return this.db.getPublishersForAgentDetail(agentUrl, opts);
   }

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -752,6 +752,9 @@ const AgentPublishersEntrySchema = z.object({
   manager_domain: z.string().nullable(),
   properties_authorized: z.number().int().min(0),
   properties_total: z.number().int().min(0),
+  property_ids: z.array(z.string()).optional().openapi({
+    description: "Canonical list of property_id strings the agent is authorized for under this publisher. Present iff the request included `?include=properties`. Same population as `properties_authorized` but surfaced as IDs for set-diff comparison.",
+  }),
   signing_keys_pinned: z.boolean(),
   status: z.enum(["authorized", "revoked"]),
   last_verified_at: z.string().datetime(),
@@ -778,6 +781,9 @@ registry.registerPath({
       cursor: z.string().optional().openapi({ description: "Opaque pagination cursor returned by a prior response" }),
       status: z.array(z.enum(["authorized", "revoked"])).optional().openapi({
         description: "Lifecycle status filter — repeat the key once per value (?status=authorized&status=revoked). Default: authorized. The comma-separated single-value form is rejected with 400.",
+      }),
+      include: z.array(z.enum(["properties"])).optional().openapi({
+        description: "Opt into expanded per-row fields — repeat the key once per value. v1: `properties` adds `property_ids[]` to each PublisherEntry so consumers can run full set-diff against a federated fetch (count-equality is not set-equality). Unknown values return 400. The comma-separated form is rejected with 400.",
       }),
       limit: z.coerce.number().int().min(1).max(1000).optional().openapi({ description: "Page size, default 200, max 1000" }),
     }),
@@ -7169,6 +7175,32 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         ? Math.min(limitParam, 1000)
         : 200;
 
+      // include: repeated-key form (?include=properties), same encoding rule as status.
+      // Comma-separated single-value form is rejected with 400.
+      const rawInclude = req.query.include;
+      let includePropertyIds = false;
+      if (rawInclude !== undefined) {
+        let includeValues: string[];
+        if (Array.isArray(rawInclude)) {
+          includeValues = rawInclude.filter((v): v is string => typeof v === 'string');
+        } else if (typeof rawInclude === 'string') {
+          if (rawInclude.includes(',')) {
+            return res.status(400).json({
+              error: "Invalid `include` encoding — repeat the key once per value (?include=properties). The comma-separated form is not accepted.",
+            });
+          }
+          includeValues = [rawInclude];
+        } else {
+          return res.status(400).json({ error: "Invalid `include` query parameter" });
+        }
+        for (const v of includeValues) {
+          if (v !== 'properties') {
+            return res.status(400).json({ error: `Invalid include value '${v}' — supported: properties` });
+          }
+        }
+        includePropertyIds = includeValues.includes('properties');
+      }
+
       const federatedIndex = crawler.getFederatedIndex();
 
       // Fetch limit+1 so we can detect "more available" without a second query.
@@ -7179,6 +7211,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         cursor,
         since,
         includeRevoked,
+        includePropertyIds,
         limit: limit + 1,
       });
 
@@ -7232,6 +7265,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         manager_domain: string | null;
         properties_authorized: number;
         properties_total: number;
+        property_ids?: string[];
         signing_keys_pinned: boolean;
         status: 'authorized' | 'revoked';
         last_verified_at: string;
@@ -7271,6 +7305,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           manager_domain: r.manager_domain,
           properties_authorized: r.properties_authorized,
           properties_total: r.properties_total,
+          ...(includePropertyIds ? { property_ids: r.property_ids ?? [] } : {}),
           signing_keys_pinned: r.signing_keys_pinned,
           status: r.status,
           last_verified_at: lastVerified.toISOString(),
@@ -7288,8 +7323,9 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         cursor,
         since: since?.toISOString() ?? null,
         status: Array.from(statusSet).sort().join(','),
+        include: includePropertyIds ? 'properties' : '',
         limit,
-        rows: shaped.map(r => `${r.publisher_domain}|${r.status}|${r.last_verified_at}|${r.properties_authorized}|${r.properties_total}|${r.signing_keys_pinned}`),
+        rows: shaped.map(r => `${r.publisher_domain}|${r.status}|${r.last_verified_at}|${r.properties_authorized}|${r.properties_total}|${r.signing_keys_pinned}|${(r.property_ids ?? []).join(',')}`),
       });
       const etag = `"${createHash('sha256').update(etagInput).digest('hex').slice(0, 32)}"`;
 

--- a/server/tests/integration/registry-agent-publishers-detail.test.ts
+++ b/server/tests/integration/registry-agent-publishers-detail.test.ts
@@ -333,4 +333,50 @@ describe('FederatedIndexDatabase.getPublishersForAgentDetail (integration)', () 
     const rows = await fedDb.getPublishersForAgentDetail(AGENT_URL, { limit: 100 });
     expect(rows).toEqual([]);
   });
+
+  it('includePropertyIds=true surfaces property_ids[] for authorized properties', async () => {
+    await insertPublisher({
+      domain: PUB_DIRECT,
+      discovery_method: 'direct',
+      adagents: { authorized_agents: [{ url: AGENT_URL, authorization_type: 'all' }] },
+    });
+    await insertAuthz({ agent_url: AGENT_URL, publisher_domain: PUB_DIRECT });
+    await insertPropertyAndAuthz({ publisher_domain: PUB_DIRECT, property_id: 'prop-b', authorize_to: AGENT_URL });
+    await insertPropertyAndAuthz({ publisher_domain: PUB_DIRECT, property_id: 'prop-a', authorize_to: AGENT_URL });
+    await insertPropertyAndAuthz({ publisher_domain: PUB_DIRECT, property_id: 'prop-c' }); // not authorized
+
+    const rows = await fedDb.getPublishersForAgentDetail(AGENT_URL, { limit: 100, includePropertyIds: true });
+    expect(rows).toHaveLength(1);
+    // Sorted ascending by property_id, unauthorized excluded.
+    expect(rows[0]!.property_ids).toEqual(['prop-a', 'prop-b']);
+    expect(rows[0]!.properties_authorized).toBe(2);
+  });
+
+  it('includePropertyIds=true returns empty array when no properties are authorized', async () => {
+    await insertPublisher({
+      domain: PUB_NOPIN,
+      discovery_method: 'direct',
+      adagents: { authorized_agents: [{ url: AGENT_URL, authorization_type: 'all' }] },
+    });
+    await insertAuthz({ agent_url: AGENT_URL, publisher_domain: PUB_NOPIN });
+    // No properties seeded at all.
+
+    const rows = await fedDb.getPublishersForAgentDetail(AGENT_URL, { limit: 100, includePropertyIds: true });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.property_ids).toBeNull(); // ARRAY_AGG returns NULL for empty set
+  });
+
+  it('includePropertyIds omitted (default) leaves property_ids null', async () => {
+    await insertPublisher({
+      domain: PUB_DIRECT,
+      discovery_method: 'direct',
+      adagents: { authorized_agents: [{ url: AGENT_URL, authorization_type: 'all' }] },
+    });
+    await insertAuthz({ agent_url: AGENT_URL, publisher_domain: PUB_DIRECT });
+    await insertPropertyAndAuthz({ publisher_domain: PUB_DIRECT, property_id: 'prop-x', authorize_to: AGENT_URL });
+
+    const rows = await fedDb.getPublishersForAgentDetail(AGENT_URL, { limit: 100 });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.property_ids).toBeNull();
+  });
 });

--- a/server/tests/integration/registry-api-agent-publishers.test.ts
+++ b/server/tests/integration/registry-api-agent-publishers.test.ts
@@ -205,4 +205,68 @@ describe('GET /api/v1/agents/{agent_url}/publishers (HTTP)', () => {
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/repeat the key/i);
   });
+
+  it('?include=properties surfaces property_ids[] on each PublisherEntry', async () => {
+    await seedAuthorized(PUB_A);
+    // Seed a property and authorize it.
+    const result = await pool.query<{ id: string }>(
+      `INSERT INTO discovered_properties (property_id, publisher_domain, property_type, name, identifiers)
+       VALUES ($1, $2, 'website', $1, $3::jsonb)
+       RETURNING id`,
+      ['p-001', PUB_A, JSON.stringify([{ type: 'domain', value: PUB_A }])],
+    );
+    await pool.query(
+      `INSERT INTO agent_property_authorizations (agent_url, property_id, authorized_for, discovered_at)
+       VALUES ($1, $2, 'test', NOW())`,
+      [AGENT_URL, result.rows[0]!.id],
+    );
+
+    const res = await request(app).get(url(AGENT_URL, '?include=properties'));
+    expect(res.status).toBe(200);
+    const pub = res.body.publishers.find((p: { publisher_domain: string }) => p.publisher_domain === PUB_A);
+    expect(pub).toBeDefined();
+    expect(pub.property_ids).toEqual(['p-001']);
+  });
+
+  it('default (no include) omits property_ids from PublisherEntry', async () => {
+    await seedAuthorized(PUB_A);
+    const res = await request(app).get(url(AGENT_URL));
+    expect(res.status).toBe(200);
+    const pub = res.body.publishers[0];
+    expect(pub).toBeDefined();
+    expect(pub.property_ids).toBeUndefined();
+  });
+
+  it('rejects unknown include value with 400', async () => {
+    await seedAuthorized(PUB_A);
+    const res = await request(app).get(url(AGENT_URL, '?include=full_objects'));
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/include/i);
+  });
+
+  it('rejects comma-separated include with 400', async () => {
+    await seedAuthorized(PUB_A);
+    const res = await request(app).get(url(AGENT_URL, '?include=properties,other'));
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/repeat the key/i);
+  });
+
+  it('?include=properties returns property_ids: [] (not null or absent) when no properties authorized', async () => {
+    await seedAuthorized(PUB_A);
+    // No properties seeded — agent has authorization but no named properties.
+    const res = await request(app).get(url(AGENT_URL, '?include=properties'));
+    expect(res.status).toBe(200);
+    const pub = res.body.publishers.find((p: { publisher_domain: string }) => p.publisher_domain === PUB_A);
+    expect(pub).toBeDefined();
+    expect(pub.property_ids).toEqual([]); // null coerced to [] at the route layer
+  });
+
+  it('?include=properties produces a different ETag than default', async () => {
+    await seedAuthorized(PUB_A);
+    const base = await request(app).get(url(AGENT_URL));
+    const withProps = await request(app).get(url(AGENT_URL, '?include=properties'));
+    expect(base.status).toBe(200);
+    expect(withProps.status).toBe(200);
+    expect(base.headers['etag']).not.toBe(withProps.headers['etag']);
+  });
 });

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -3553,6 +3553,17 @@ paths:
           name: status
           in: query
         - schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - properties
+            description: "Opt into expanded per-row fields — repeat the key once per value. v1: `properties` adds `property_ids[]` to each PublisherEntry so consumers can run full set-diff against a federated fetch (count-equality is not set-equality). Unknown values return 400. The comma-separated form is rejected with 400."
+          required: false
+          description: "Opt into expanded per-row fields — repeat the key once per value. v1: `properties` adds `property_ids[]` to each PublisherEntry so consumers can run full set-diff against a federated fetch (count-equality is not set-equality). Unknown values return 400. The comma-separated form is rejected with 400."
+          name: include
+          in: query
+        - schema:
             type: integer
             minimum: 1
             maximum: 1000
@@ -3601,6 +3612,11 @@ paths:
                         properties_total:
                           type: integer
                           minimum: 0
+                        property_ids:
+                          type: array
+                          items:
+                            type: string
+                          description: Canonical list of property_id strings the agent is authorized for under this publisher. Present iff the request included `?include=properties`. Same population as `properties_authorized` but surfaced as IDs for set-diff comparison.
                         signing_keys_pinned:
                           type: boolean
                         status:
@@ -3689,6 +3705,17 @@ paths:
           name: status
           in: query
         - schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - properties
+            description: "Opt into expanded per-row fields — repeat the key once per value. v1: `properties` adds `property_ids[]` to each PublisherEntry so consumers can run full set-diff against a federated fetch (count-equality is not set-equality). Unknown values return 400. The comma-separated form is rejected with 400."
+          required: false
+          description: "Opt into expanded per-row fields — repeat the key once per value. v1: `properties` adds `property_ids[]` to each PublisherEntry so consumers can run full set-diff against a federated fetch (count-equality is not set-equality). Unknown values return 400. The comma-separated form is rejected with 400."
+          name: include
+          in: query
+        - schema:
             type: integer
             minimum: 1
             maximum: 1000
@@ -3737,6 +3764,11 @@ paths:
                         properties_total:
                           type: integer
                           minimum: 0
+                        property_ids:
+                          type: array
+                          items:
+                            type: string
+                          description: Canonical list of property_id strings the agent is authorized for under this publisher. Present iff the request included `?include=properties`. Same population as `properties_authorized` but surfaced as IDs for set-diff comparison.
                         signing_keys_pinned:
                           type: boolean
                         status:


### PR DESCRIPTION
Closes #4890

Schema and docs for `?include=properties` are already on `main` (merged via #4894, spec-only changeset `4890-aao-include-properties.md`). This PR wires the server side so the endpoint actually parses the flag and serializes `property_ids[]`.

### What changed

- **`federated-index-db.ts`** — `AgentPublisherDetailRow` gains `property_ids: string[] | null`; `getPublishersForAgentDetail` accepts `includePropertyIds?: boolean`; SQL adds a `CASE WHEN $6 THEN ARRAY_AGG(dp.property_id ORDER BY dp.property_id) ELSE NULL END` subquery that PostgreSQL short-circuits when false (zero cost on default calls). Also fixes `properties_authorized` to filter `dp.property_id IS NOT NULL`, making it symmetric with the `ARRAY_AGG` subquery so `len(property_ids) == properties_authorized` holds (the spec's MUST invariant — without the fix, properties without a canonical string ID would be counted but not named).
- **`federated-index.ts`** — passes `includePropertyIds` through to the DB layer.
- **`registry-api.ts`** — parses `?include` (repeated-key form, same encoding as `?status`; comma-separated form rejected 400; unknown values rejected 400); passes flag to service; spreads `property_ids: r.property_ids ?? []` onto each shaped row when set (SQL `NULL` from empty ARRAY_AGG coerces to `[]` — correct: empty array signals "flag was honored, zero results" vs absent field which signals "flag not set"); updates ETag to cover the include flag and resolved IDs; updates `AgentPublishersEntrySchema` and OpenAPI query schema.
- **Tests** — DB-level (`registry-agent-publishers-detail.test.ts`): sorted IDs, empty-set returns `null` at DB layer, default leaves `property_ids` null. HTTP-level (`registry-api-agent-publishers.test.ts`): `?include=properties` surfaces IDs, default omits field, empty-authorized returns `[]`, unknown value 400, comma-separated 400, ETag differs with/without flag.

**Non-breaking justification:** `?include` is a new optional query parameter; default behavior (no `property_ids` in response) is unchanged. `property_ids` is optional in the Zod schema. Existing clients receive an identical envelope. The `properties_authorized` fix is a data-accuracy correction; any property missing a canonical `property_id` slug was never reliably surfaceable anyway.

**Changeset:** `--empty` (server-side implementation; the protocol changeset `4890-aao-include-properties.md` already covers the schema/docs bump).

**Pre-PR review:**
- code-reviewer: approved — no blockers. Nit: add HTTP-level test asserting `property_ids: []` for zero-authorized case (done). Nit: `?include[foo]=bar` silently drops nested ParsedQs (noted, consistent with how Express handles analogous edge cases across the codebase). Nit: 404-probe omits `includePropertyIds` correctly (no change needed).
- ad-tech-protocol-expert: approved — non-breaking per spec. `?include` repeated-key form mirrors `?status` exactly. Sorted `ARRAY_AGG` is correct (deterministic ETag). Blocker fixed: `properties_authorized` now filters `dp.property_id IS NOT NULL`, making it symmetric with `ARRAY_AGG` so the `MUST len(property_ids) == properties_authorized` invariant holds. `r.property_ids ?? []` is correct wire form per OpenRTB pattern (empty array distinct from absent field).

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_012j248bSRq5CcDQEwuberu1

---
_Generated by [Claude Code](https://claude.ai/code/session_012j248bSRq5CcDQEwuberu1)_