### PR TITLE
feat(aao-directory): implement ?include=properties on GET /v1/agents/{url}/publishers

### DIFF
--- a/server/src/db/federated-index-db.ts
+++ b/server/src/db/federated-index-db.ts
@@ -73,6 +73,7 @@ export interface AgentPublisherDetailRow {
   manager_domain: string | null;
   properties_total: number;
   properties_authorized: number;
+  property_ids: string[] | null;
   signing_keys_pinned: boolean;
   status: 'authorized' | 'revoked';
 }
@@ -250,6 +251,7 @@ export class FederatedIndexDatabase {
       cursor?: string;
       since?: Date;
       includeRevoked?: boolean;
+      includePropertyIds?: boolean;
       limit: number;
     },
   ): Promise<AgentPublisherDetailRow[]> {
@@ -257,6 +259,7 @@ export class FederatedIndexDatabase {
     const cursor = opts.cursor ?? '';
     const limit = opts.limit;
     const includeRevoked = opts.includeRevoked ?? false;
+    const includePropertyIds = opts.includePropertyIds ?? false;
 
     // Dual-read pattern matches getDomainsForAgent / getAgentsForDomain:
     // UNION ALL with explicit src_priority (legacy=0 wins on collision) +
@@ -365,6 +368,17 @@ export class FederatedIndexDatabase {
             WHERE apa.agent_url = $1
               AND dp.publisher_domain = e.publisher_domain
          ), 0) AS properties_authorized,
+         -- property_ids: the resolved property_id strings, present iff $6 is true.
+         -- Mirrors the properties_authorized population but surfaces IDs for set-diff.
+         -- Only properties with a non-null property_id (from adagents.json) are included.
+         CASE WHEN $6 THEN COALESCE((
+           SELECT array_agg(DISTINCT dp.property_id ORDER BY dp.property_id)
+             FROM agent_property_authorizations apa
+             JOIN discovered_properties dp ON dp.id = apa.property_id
+            WHERE apa.agent_url = $1
+              AND dp.publisher_domain = e.publisher_domain
+              AND dp.property_id IS NOT NULL
+         ), ARRAY[]::text[]) ELSE NULL END AS property_ids,
          e.signing_keys_pinned,
          CASE WHEN e.is_revoked THEN 'revoked' ELSE 'authorized' END AS status
        FROM enriched e
@@ -373,7 +387,7 @@ export class FederatedIndexDatabase {
          AND ($4::boolean OR NOT e.is_revoked)
        ORDER BY e.publisher_domain
        LIMIT $5`,
-      [agentUrl, cursor, since, includeRevoked, limit],
+      [agentUrl, cursor, since, includeRevoked, limit, includePropertyIds],
     );
     return result.rows;
   }

--- a/server/src/federated-index.ts
+++ b/server/src/federated-index.ts
@@ -239,7 +239,7 @@ export class FederatedIndexService {
    */
   async getPublishersForAgentDetail(
     agentUrl: string,
-    opts: { cursor?: string; since?: Date; includeRevoked?: boolean; limit: number },
+    opts: { cursor?: string; since?: Date; includeRevoked?: boolean; includePropertyIds?: boolean; limit: number },
   ): Promise<AgentPublisherDetailRow[]> {
     return this.db.getPublishersForAgentDetail(agentUrl, opts);
   }

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -752,6 +752,9 @@ const AgentPublishersEntrySchema = z.object({
   manager_domain: z.string().nullable(),
   properties_authorized: z.number().int().min(0),
   properties_total: z.number().int().min(0),
+  property_ids: z.array(z.string()).optional().openapi({
+    description: "Resolved property_id strings for set-diff divergence detection. Present iff request included ?include=properties; absent otherwise.",
+  }),
   signing_keys_pinned: z.boolean(),
   status: z.enum(["authorized", "revoked"]),
   last_verified_at: z.string().datetime(),
@@ -778,6 +781,9 @@ registry.registerPath({
       cursor: z.string().optional().openapi({ description: "Opaque pagination cursor returned by a prior response" }),
       status: z.array(z.enum(["authorized", "revoked"])).optional().openapi({
         description: "Lifecycle status filter — repeat the key once per value (?status=authorized&status=revoked). Default: authorized. The comma-separated single-value form is rejected with 400.",
+      }),
+      include: z.array(z.enum(["properties"])).optional().openapi({
+        description: "Optional inclusions — repeat the key once per value (?include=properties). `properties` adds property_ids: string[] per PublisherEntry for full set-diff divergence detection. Default: omit.",
       }),
       limit: z.coerce.number().int().min(1).max(1000).optional().openapi({ description: "Page size, default 200, max 1000" }),
     }),
@@ -7146,6 +7152,30 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
       const includeRevoked = statusSet.has('revoked');
       const includeAuthorized = statusSet.has('authorized');
 
+      // include: repeated-key form — ?include=properties. Unknown values → 400.
+      const rawInclude = req.query.include;
+      let includeSet: Set<string>;
+      if (rawInclude === undefined) {
+        includeSet = new Set();
+      } else if (Array.isArray(rawInclude)) {
+        includeSet = new Set(rawInclude.filter((v): v is string => typeof v === 'string'));
+      } else if (typeof rawInclude === 'string') {
+        if (rawInclude.includes(',')) {
+          return res.status(400).json({
+            error: "Invalid `include` encoding — repeat the key once per value (?include=properties). The comma-separated form is not accepted.",
+          });
+        }
+        includeSet = new Set([rawInclude]);
+      } else {
+        return res.status(400).json({ error: "Invalid `include` query parameter" });
+      }
+      for (const v of includeSet) {
+        if (v !== 'properties') {
+          return res.status(400).json({ error: `Invalid include value '${v}' — supported: properties` });
+        }
+      }
+      const includePropertyIds = includeSet.has('properties');
+
       // Cursor is opaque to consumers but encodes the last seen
       // publisher_domain ASC. URL-safe base64 of the domain string keeps
       // the wire shape opaque without needing a state table.
@@ -7179,6 +7209,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         cursor,
         since,
         includeRevoked,
+        includePropertyIds,
         limit: limit + 1,
       });
 
@@ -7232,6 +7263,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         manager_domain: string | null;
         properties_authorized: number;
         properties_total: number;
+        property_ids?: string[];
         signing_keys_pinned: boolean;
         status: 'authorized' | 'revoked';
         last_verified_at: string;
@@ -7271,6 +7303,7 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
           manager_domain: r.manager_domain,
           properties_authorized: r.properties_authorized,
           properties_total: r.properties_total,
+          ...(includePropertyIds ? { property_ids: r.property_ids ?? [] } : {}),
           signing_keys_pinned: r.signing_keys_pinned,
           status: r.status,
           last_verified_at: lastVerified.toISOString(),
@@ -7288,8 +7321,9 @@ export function createRegistryApiRouter(config: RegistryApiConfig): Router {
         cursor,
         since: since?.toISOString() ?? null,
         status: Array.from(statusSet).sort().join(','),
+        include: Array.from(includeSet).sort().join(','),
         limit,
-        rows: shaped.map(r => `${r.publisher_domain}|${r.status}|${r.last_verified_at}|${r.properties_authorized}|${r.properties_total}|${r.signing_keys_pinned}`),
+        rows: shaped.map(r => `${r.publisher_domain}|${r.status}|${r.last_verified_at}|${r.properties_authorized}|${r.properties_total}|${r.signing_keys_pinned}|${r.property_ids?.join(',') ?? ''}`),
       });
       const etag = `"${createHash('sha256').update(etagInput).digest('hex').slice(0, 32)}"`;
 

--- a/server/tests/integration/registry-agent-publishers-detail.test.ts
+++ b/server/tests/integration/registry-agent-publishers-detail.test.ts
@@ -333,4 +333,59 @@ describe('FederatedIndexDatabase.getPublishersForAgentDetail (integration)', () 
     const rows = await fedDb.getPublishersForAgentDetail(AGENT_URL, { limit: 100 });
     expect(rows).toEqual([]);
   });
+
+  it('includePropertyIds returns property_ids array with authorized property IDs', async () => {
+    await insertPublisher({
+      domain: PUB_DIRECT,
+      discovery_method: 'direct',
+      adagents: { authorized_agents: [{ url: AGENT_URL, authorization_type: 'all' }] },
+    });
+    await insertAuthz({ agent_url: AGENT_URL, publisher_domain: PUB_DIRECT });
+    await insertPropertyAndAuthz({ publisher_domain: PUB_DIRECT, property_id: 'p-001', authorize_to: AGENT_URL });
+    await insertPropertyAndAuthz({ publisher_domain: PUB_DIRECT, property_id: 'p-002', authorize_to: AGENT_URL });
+    await insertPropertyAndAuthz({ publisher_domain: PUB_DIRECT, property_id: 'p-003' }); // unauthorized — must not appear
+
+    const rows = await fedDb.getPublishersForAgentDetail(AGENT_URL, { limit: 100, includePropertyIds: true });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.property_ids).toEqual(['p-001', 'p-002']);
+    expect(rows[0]!.properties_authorized).toBe(2);
+  });
+
+  it('without includePropertyIds, property_ids is null', async () => {
+    await insertPublisher({
+      domain: PUB_DIRECT,
+      discovery_method: 'direct',
+      adagents: { authorized_agents: [{ url: AGENT_URL, authorization_type: 'all' }] },
+    });
+    await insertAuthz({ agent_url: AGENT_URL, publisher_domain: PUB_DIRECT });
+    await insertPropertyAndAuthz({ publisher_domain: PUB_DIRECT, property_id: 'p-001', authorize_to: AGENT_URL });
+
+    const rows = await fedDb.getPublishersForAgentDetail(AGENT_URL, { limit: 100 });
+    expect(rows[0]!.property_ids).toBeNull();
+  });
+
+  it('includePropertyIds returns empty array when no authorized properties have property_id', async () => {
+    await insertPublisher({
+      domain: PUB_DIRECT,
+      discovery_method: 'direct',
+      adagents: { authorized_agents: [{ url: AGENT_URL, authorization_type: 'all' }] },
+    });
+    await insertAuthz({ agent_url: AGENT_URL, publisher_domain: PUB_DIRECT });
+    // Insert a property with no property_id (null) — should yield empty array not null
+    await pool.query(
+      `INSERT INTO discovered_properties (publisher_domain, property_type, name, identifiers)
+       VALUES ($1, 'website', 'no-id-prop', $2::jsonb)
+       RETURNING id`,
+      [PUB_DIRECT, JSON.stringify([{ type: 'domain', value: PUB_DIRECT }])],
+    ).then(async (res) => {
+      await pool.query(
+        `INSERT INTO agent_property_authorizations (agent_url, property_id, authorized_for, discovered_at)
+         VALUES ($1, $2, 'test', NOW())`,
+        [AGENT_URL, res.rows[0]!.id],
+      );
+    });
+
+    const rows = await fedDb.getPublishersForAgentDetail(AGENT_URL, { limit: 100, includePropertyIds: true });
+    expect(rows[0]!.property_ids).toEqual([]);
+  });
 });

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -3553,6 +3553,17 @@ paths:
           name: status
           in: query
         - schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - properties
+            description: "Optional inclusions — repeat the key once per value (?include=properties). `properties` adds property_ids: string[] per PublisherEntry for full set-diff divergence detection. Default: omit."
+          required: false
+          description: "Optional inclusions — repeat the key once per value (?include=properties). `properties` adds property_ids: string[] per PublisherEntry for full set-diff divergence detection. Default: omit."
+          name: include
+          in: query
+        - schema:
             type: integer
             minimum: 1
             maximum: 1000
@@ -3601,6 +3612,11 @@ paths:
                         properties_total:
                           type: integer
                           minimum: 0
+                        property_ids:
+                          type: array
+                          items:
+                            type: string
+                          description: Resolved property_id strings for set-diff divergence detection. Present iff request included ?include=properties; absent otherwise.
                         signing_keys_pinned:
                           type: boolean
                         status:

--- a/static/schemas/source/aao/agent-publishers.json
+++ b/static/schemas/source/aao/agent-publishers.json
@@ -78,7 +78,7 @@
         "property_ids": {
           "type": "array",
           "items": { "type": "string" },
-          "description": "Canonical list of `property_id`s under THIS `publisher_domain` that the agent's selectors resolve to. Present iff the request included `?include=properties`; absent otherwise. The set is the same population `properties_authorized` counts, surfaced as IDs so consumers can run full set-diff against a federated fetch (count-equality is not set-equality — a publisher rotating N properties leaves the count unchanged but the set entirely different). Per-publisher scope; never network-wide. Order is unspecified; consumers should treat as a set."
+          "description": "Canonical list of `property_id`s under THIS `publisher_domain` that the agent's selectors resolve to. Present iff the request included `?include=properties`; absent otherwise. Drawn from the same authorized-property population that `properties_authorized` counts, but limited to properties whose adagents.json entry carries an explicit `property_id` string — `len(property_ids) ≤ properties_authorized` when any authorized properties lack a `property_id`. Use for full set-diff divergence detection: count-equality is not set-equality — a publisher rotating N properties leaves the count unchanged but the set entirely different. Per-publisher scope; never network-wide. Order is unspecified; consumers should treat as a set."
         },
         "signing_keys_pinned": {
           "type": "boolean",


### PR DESCRIPTION
Refs #4890

Schema, docs, and changeset for `?include=properties` already landed on `main` (prior triage session). This PR adds the server implementation only: parsing the query parameter, passing it through the service layer, and serializing `property_ids` in the response.

**Non-breaking justification:** Adds an optional query parameter (`?include=properties`, default unset) and an optional response field (`property_ids`, absent when flag is not set). Existing consumers receive an identical envelope. No required field added, no field removed, no enum value changed. Changeset `.changeset/4890-aao-include-properties.md` already on `main` (classified `--empty` — server-only change; schema bump was in the spec-first landing).

**What changed:**
- `federated-index-db.ts` — `AgentPublisherDetailRow` gains `property_ids: string[] | null`; `getPublishersForAgentDetail` gains `includePropertyIds?: boolean`; SQL adds `CASE WHEN $6 THEN array_agg(DISTINCT dp.property_id ...) ELSE NULL END AS property_ids`
- `federated-index.ts` — service wrapper opts type updated to pass through `includePropertyIds`
- `registry-api.ts` — Zod `AgentPublishersEntrySchema` adds `property_ids?: string[]`; OpenAPI spec adds `include` query param (repeated-key form, same as `?status`); handler parses `?include`, passes `includePropertyIds` to DB layer, spreads `property_ids` into shaped output when flag is set; ETag hash includes `include` and per-row `property_ids`
- `static/schemas/source/aao/agent-publishers.json` — clarified `property_ids` description: `len(property_ids) ≤ properties_authorized` when any authorized properties lack a `property_id` in adagents.json
- `static/openapi/registry.yaml` — regenerated from Zod schemas (includes `include` param and `property_ids` field)
- Integration tests — 3 new cases: `includePropertyIds` returns IDs, without flag `property_ids` is null, empty array when no authorized property has `property_id`

**Nit (surfaced by pre-PR review, not fixed):** The 404 existence-probe call at line 7241 omits `includePropertyIds` — intentional, the probe needs only a row-count. Worth a comment to future readers.

**Pre-PR review:**
- code-reviewer: approved — fixed error-message inconsistency (`Unknown` → `Invalid`), updated schema description to clarify `len(property_ids) ≤ properties_authorized` subset semantics; regenerated OpenAPI spec
- ad-tech-protocol-expert: approved — non-breaking per spec; `include=properties` repeated-key encoding consistent with `?status` convention; `dp.property_id` (adagents.json slug) vs `dp.id` (UUID) distinction is correct for set-diff use case; ETag correctly keyed on `include` and per-row `property_ids`

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_015MXVgGH1xk84m361nM7fj7

---
_Generated by [Claude Code](https://claude.ai/code/session_015MXVgGH1xk84m361nM7fj7)_