### PR TITLE
feat(compliance): add 3.1 delivery-metrics storyboards for reach_window and viewability.viewed_seconds

### DIFF
--- a/.changeset/4931-delivery-metrics-storyboards.md
+++ b/.changeset/4931-delivery-metrics-storyboards.md
@@ -1,0 +1,27 @@
+---
+"adcontextprotocol": patch
+---
+
+Add 3.1 compliance storyboards for `reach_window` (cumulative/period/rolling) and `viewability.viewed_seconds` in delivery reporting (closes #4931).
+
+**Storyboard additions:**
+
+`reach_buy_flow.yaml` gains four new phases after the existing `reach_delivery` phase:
+- `reach_window_cumulative` — injects a delivery row with `reach_window.kind: cumulative` (no `period` field) and verifies the seller surfaces the window semantics.
+- `reach_window_period` — injects with `kind: period` + `period: {interval:1, unit:"days"}` and asserts both `kind` and `period` present on the delivery row.
+- `reach_window_rolling` — injects with `kind: rolling` + `period: {interval:7, unit:"days"}` and asserts both fields present.
+- `reach_window_absent_advisory` — injects a reach row without `reach_window`; issues a `severity: advisory` + `permanent_advisory` check (schema-valid SHOULD, not MUST — buyers warned but sellers not failed; promotion to required is a 4.0 concern).
+
+`delivery_reporting.yaml` gains a new `viewability_delivery` phase that:
+- Creates a media buy for a viewability-capable vCPM video product.
+- Injects a full viewability block (`measurable_impressions`, `viewable_impressions`, `viewable_rate`, `viewed_seconds: 4.3`, `standard: "mrc"`).
+- Asserts `viewability.viewed_seconds`, `viewability.measurable_impressions`, and `viewability.standard` present on the delivery row.
+
+**Schema addition (`comply-test-controller-request.json`):**
+
+`params` block gains four new named properties for `simulate_delivery`:
+- `reach` (number) and `frequency` (number) — formally declared (previously used in `reach_buy_flow.yaml` but undeclared).
+- `reach_window` (object: `{kind, period?}`) — typed declaration so controller implementers have a schema-grounded contract for injecting window semantics.
+- `viewability` (object: `{measurable_impressions?, viewable_impressions?, viewable_rate?, viewed_seconds?, standard?}`) — typed declaration for the viewability block.
+
+All additions are additive (`additionalProperties: true` was already set on `params`); existing controller implementations that ignore unknown params are unaffected. Conformant 3.1 implementations that populate `reach_window` and `viewability` on delivery responses will pass the new assertions.

--- a/static/compliance/source/protocols/media-buy/scenarios/delivery_reporting.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/delivery_reporting.yaml
@@ -51,6 +51,11 @@ fixtures:
       channels: ["video"]
       format_ids:
         - id: "video_15s"
+    - product_id: "video_viewability_q2"
+      delivery_type: "guaranteed"
+      channels: ["video"]
+      format_ids:
+        - id: "video_15s"
   pricing_options:
     - product_id: "outdoor_display_q2"
       pricing_option_id: "cpm_standard"
@@ -62,6 +67,11 @@ fixtures:
       pricing_model: "cpm"
       currency: "USD"
       fixed_price: 12.0
+    - product_id: "video_viewability_q2"
+      pricing_option_id: "vcpm_standard"
+      pricing_model: "vcpm"
+      currency: "USD"
+      fixed_price: 14.0
 
 phases:
   - id: setup
@@ -205,3 +215,128 @@ phases:
           - check: field_present
             path: "media_buy_deliveries"
             description: "Response contains delivery data"
+
+  - id: viewability_delivery
+    title: "Delivery reporting surfaces viewability.viewed_seconds for viewability-capable products"
+    narrative: |
+      3.1 adds `viewability.viewed_seconds` to delivery-metrics — the
+      average in-view duration per measurable impression in seconds. It
+      shares the same denominator (`measurable_impressions`) as
+      `viewable_rate` and is governed by the same measurement `standard`
+      (e.g., MRC 50%/1s for display, 50%/2s for video). Sellers reporting
+      against a `viewed_seconds` optimization goal MUST populate this field.
+
+      This phase creates a separate media buy for a viewability-capable
+      vCPM video product, injects simulated delivery with a full viewability
+      block (measurable_impressions, viewable_impressions, viewable_rate,
+      viewed_seconds, standard), and verifies that get_media_buy_delivery
+      returns the viewed_seconds field inside the viewability block. The
+      denominator check (viewable_rate is viewable_impressions /
+      measurable_impressions, not total impressions) is enforced by the
+      response_schema validation against delivery-metrics.json.
+
+    steps:
+      - id: create_media_buy_viewability
+        title: "Create media buy for viewability-capable video product"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        expected: |
+          Create the media buy. Returns a media_buy_id used for the
+          viewability delivery simulation.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-06-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "video_viewability_q2"
+              budget: 20000
+              pricing_option_id: "vcpm_standard"
+          idempotency_key: "$generate:uuid_v4#delivery_reporting_viewability_delivery_create_media_buy"
+        context_outputs:
+          - name: viewability_media_buy_id
+            path: "media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Media buy has a platform-assigned ID"
+
+      - id: simulate_viewability_delivery
+        title: "Inject simulated delivery with full viewability block including viewed_seconds"
+        task: comply_test_controller
+        requires_tool: comply_test_controller
+        stateful: true
+        expected: |
+          The test controller acknowledges the simulated delivery with a
+          full viewability block: measurable_impressions as the shared
+          denominator, viewable_impressions, viewable_rate, viewed_seconds,
+          and the MRC standard.
+        sample_request:
+          account:
+            sandbox: true
+          scenario: "simulate_delivery"
+          params:
+            media_buy_id: "$context.viewability_media_buy_id"
+            impressions: 80000
+            viewability:
+              measurable_impressions: 74000
+              viewable_impressions: 59200
+              viewable_rate: 0.80
+              viewed_seconds: 4.3
+              standard: "mrc"
+            reported_spend:
+              amount: 1030.00
+              currency: "USD"
+        validations:
+          - check: field_value
+            path: "success"
+            allowed_values: [true]
+            description: "Delivery simulation with viewability block succeeds"
+
+      - id: get_viewability_delivery
+        title: "Verify viewability.viewed_seconds appears in delivery report"
+        task: get_media_buy_delivery
+        schema_ref: "media-buy/get-media-buy-delivery-request.json"
+        response_schema_ref: "media-buy/get-media-buy-delivery-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buy_delivery"
+        stateful: true
+        expected: |
+          Delivery response carries a viewability block with viewed_seconds,
+          measurable_impressions (shared denominator), viewable_rate, and
+          standard. The viewed_seconds value represents the average in-view
+          duration per measurable impression — the reporting counterpart to
+          the viewed_seconds optimization metric. The denominator for both
+          viewable_rate and viewed_seconds is measurable_impressions (not
+          total impressions) since some environments cannot measure viewability.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "$context.viewability_media_buy_id"
+          include_package_daily_breakdown: true
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buy-delivery-response.json schema"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.viewability"
+            description: "Viewability block present on delivery row"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.viewability.viewed_seconds"
+            description: "viewed_seconds — average in-view duration per measurable impression — present in viewability block"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.viewability.measurable_impressions"
+            description: "measurable_impressions denominator present (shared basis for viewable_rate and viewed_seconds)"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.viewability.standard"
+            description: "viewability standard present — governs threshold for both viewable_rate and viewed_seconds"

--- a/static/compliance/source/protocols/media-buy/scenarios/reach_buy_flow.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/reach_buy_flow.yaml
@@ -347,3 +347,317 @@ phases:
           - check: field_present
             path: "media_buy_deliveries[0].totals.frequency"
             description: "Frequency surfaced at the buy level — average exposures per reach unit"
+
+  - id: reach_window_cumulative
+    title: "Delivery row carries reach_window.kind cumulative"
+    narrative: |
+      A cumulative reach_window declares that the reach value represents
+      unique audiences since campaign start. Each successive delivery row
+      supersedes the prior one — buyers MUST NOT sum cumulative rows to
+      compute campaign reach, since each later row already includes all
+      prior audiences. No period field is required for cumulative.
+
+      This phase injects a delivery row with reach_window.kind cumulative
+      and verifies that the seller surfaces the window semantics on the
+      delivery response. Sellers that omit reach_window on a reach-optimized
+      buy force buyers to guess the window — creating silent double-counting
+      when buyers aggregate across reporting periods.
+
+    steps:
+      - id: simulate_cumulative_reach
+        title: "Inject delivery with cumulative reach_window"
+        task: comply_test_controller
+        requires_tool: comply_test_controller
+        stateful: true
+        expected: |
+          The test controller acknowledges the simulated delivery with a
+          cumulative reach_window.
+        sample_request:
+          account:
+            sandbox: true
+          scenario: "simulate_delivery"
+          params:
+            media_buy_id: "$context.media_buy_id"
+            impressions: 1200000
+            reach: 400000
+            frequency: 3.0
+            reach_window:
+              kind: "cumulative"
+            reported_spend:
+              amount: 22000.00
+              currency: "USD"
+        validations:
+          - check: field_value
+            path: "success"
+            allowed_values: [true]
+            description: "Delivery simulation with cumulative reach_window succeeds"
+
+      - id: get_cumulative_reach_delivery
+        title: "Verify reach_window.kind cumulative on delivery row"
+        task: get_media_buy_delivery
+        schema_ref: "media-buy/get-media-buy-delivery-request.json"
+        response_schema_ref: "media-buy/get-media-buy-delivery-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buy_delivery"
+        stateful: true
+        expected: |
+          Delivery row carries reach_window with kind: cumulative. No period
+          field is expected — cumulative reach is campaign-to-date and the
+          window is implicit. The row's reach value is the total unique count
+          since campaign start; each subsequent cumulative row supersedes
+          this one.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "$context.media_buy_id"
+          include_package_daily_breakdown: true
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buy-delivery-response.json schema"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.reach_window"
+            description: "Seller populates reach_window on the delivery row"
+          - check: field_value
+            path: "media_buy_deliveries[0].totals.reach_window.kind"
+            allowed_values: ["cumulative"]
+            description: "reach_window.kind is cumulative as injected"
+
+  - id: reach_window_period
+    title: "Delivery row carries reach_window.kind period with period field"
+    narrative: |
+      A period reach_window declares that the reach value covers a single
+      non-overlapping reporting period (e.g., one calendar day). Adjacent
+      period rows do not share audiences by construction — the same person
+      MAY appear across multiple periods — so buyers MUST NOT sum period
+      rows to compute campaign reach. The period field is REQUIRED for
+      kind: period and declares the snapshot length (e.g., 1 day).
+
+      This phase injects a delivery row with reach_window.kind period and
+      period: {interval:1, unit:"days"} and verifies the seller surfaces
+      both the kind and the period duration on the delivery response.
+
+    steps:
+      - id: simulate_period_reach
+        title: "Inject delivery with period reach_window"
+        task: comply_test_controller
+        requires_tool: comply_test_controller
+        stateful: true
+        expected: |
+          The test controller acknowledges the simulated delivery with a
+          period reach_window carrying a 1-day period.
+        sample_request:
+          account:
+            sandbox: true
+          scenario: "simulate_delivery"
+          params:
+            media_buy_id: "$context.media_buy_id"
+            impressions: 175000
+            reach: 140000
+            frequency: 1.25
+            reach_window:
+              kind: "period"
+              period:
+                interval: 1
+                unit: "days"
+            reported_spend:
+              amount: 3200.00
+              currency: "USD"
+        validations:
+          - check: field_value
+            path: "success"
+            allowed_values: [true]
+            description: "Delivery simulation with period reach_window succeeds"
+
+      - id: get_period_reach_delivery
+        title: "Verify reach_window.kind period and period duration on delivery row"
+        task: get_media_buy_delivery
+        schema_ref: "media-buy/get-media-buy-delivery-request.json"
+        response_schema_ref: "media-buy/get-media-buy-delivery-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buy_delivery"
+        stateful: true
+        expected: |
+          Delivery row carries reach_window with kind: period and a period
+          duration of 1 day. The period field is required for kind: period —
+          its absence would leave buyers unable to determine the snapshot
+          length, making cross-period reach comparisons unreliable.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "$context.media_buy_id"
+          include_package_daily_breakdown: true
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buy-delivery-response.json schema"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.reach_window"
+            description: "Seller populates reach_window on the delivery row"
+          - check: field_value
+            path: "media_buy_deliveries[0].totals.reach_window.kind"
+            allowed_values: ["period"]
+            description: "reach_window.kind is period as injected"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.reach_window.period"
+            description: "period field is present — required for kind: period"
+
+  - id: reach_window_rolling
+    title: "Delivery row carries reach_window.kind rolling with period field"
+    narrative: |
+      A rolling reach_window declares that the reach value covers a trailing
+      window ending at the row's reporting timestamp (e.g., trailing-7-day
+      unique reach). Adjacent rolling rows overlap — each row stands alone
+      and MUST NOT be summed; summing rolling rows double-counts audiences
+      seen in multiple windows. The period field is REQUIRED for kind: rolling
+      and declares the trailing-window length (e.g., 7 days).
+
+      This phase injects a delivery row with reach_window.kind rolling and
+      period: {interval:7, unit:"days"} and verifies the seller surfaces
+      both the kind and the window duration. A trailing-7-day reach window
+      is the canonical frequency-cap companion — buyers reading this value
+      know exactly which audiences are within the 7-day dedup window.
+
+    steps:
+      - id: simulate_rolling_reach
+        title: "Inject delivery with rolling reach_window"
+        task: comply_test_controller
+        requires_tool: comply_test_controller
+        stateful: true
+        expected: |
+          The test controller acknowledges the simulated delivery with a
+          rolling reach_window carrying a 7-day trailing window.
+        sample_request:
+          account:
+            sandbox: true
+          scenario: "simulate_delivery"
+          params:
+            media_buy_id: "$context.media_buy_id"
+            impressions: 450000
+            reach: 210000
+            frequency: 2.1
+            reach_window:
+              kind: "rolling"
+              period:
+                interval: 7
+                unit: "days"
+            reported_spend:
+              amount: 8500.00
+              currency: "USD"
+        validations:
+          - check: field_value
+            path: "success"
+            allowed_values: [true]
+            description: "Delivery simulation with rolling reach_window succeeds"
+
+      - id: get_rolling_reach_delivery
+        title: "Verify reach_window.kind rolling and period duration on delivery row"
+        task: get_media_buy_delivery
+        schema_ref: "media-buy/get-media-buy-delivery-request.json"
+        response_schema_ref: "media-buy/get-media-buy-delivery-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buy_delivery"
+        stateful: true
+        expected: |
+          Delivery row carries reach_window with kind: rolling and a period
+          of 7 days. The period field is required for kind: rolling — without
+          it, buyers cannot determine the trailing window length and cannot
+          safely use the reach value for frequency optimization.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "$context.media_buy_id"
+          include_package_daily_breakdown: true
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buy-delivery-response.json schema"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.reach_window"
+            description: "Seller populates reach_window on the delivery row"
+          - check: field_value
+            path: "media_buy_deliveries[0].totals.reach_window.kind"
+            allowed_values: ["rolling"]
+            description: "reach_window.kind is rolling as injected"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.reach_window.period"
+            description: "period field is present — required for kind: rolling"
+
+  - id: reach_window_absent_advisory
+    title: "Advisory: delivery row with reach but no reach_window is schema-valid but sum-unsafe"
+    narrative: |
+      Reach/frequency rows with `reach_window` omitted are schema-valid —
+      the schema marks the field SHOULD (not MUST) populate it. However,
+      buyers MUST NOT treat omitted-window rows as sum-safe: the value may
+      be a daily snapshot, a cumulative total, or something else. Summing
+      reach values across rows without a declared window silently
+      double-counts audiences.
+
+      This phase simulates a delivery row without reach_window and issues
+      an advisory (not a conformance fail) when the seller returns reach
+      without the window declaration. Advisory grading: sellers that do
+      not populate reach_window on reach-optimized buys are warned but
+      not failed — the omission is spec-valid. Sellers should treat this
+      advisory as a signal to add reach_window to their delivery responses
+      for 3.1+ buyers.
+
+    steps:
+      - id: simulate_reach_no_window
+        title: "Inject delivery with reach but no reach_window"
+        task: comply_test_controller
+        requires_tool: comply_test_controller
+        stateful: true
+        expected: |
+          The test controller injects a delivery row with reach and frequency
+          but no reach_window. This is a valid operation — the scenario
+          tests the advisory behavior, not a rejection.
+        sample_request:
+          account:
+            sandbox: true
+          scenario: "simulate_delivery"
+          params:
+            media_buy_id: "$context.media_buy_id"
+            impressions: 300000
+            reach: 180000
+            frequency: 1.67
+            reported_spend:
+              amount: 5800.00
+              currency: "USD"
+        validations:
+          - check: field_value
+            path: "success"
+            allowed_values: [true]
+            description: "Delivery simulation without reach_window succeeds"
+
+      - id: get_delivery_reach_no_window
+        title: "Verify advisory when reach is present but reach_window is absent"
+        task: get_media_buy_delivery
+        schema_ref: "media-buy/get-media-buy-delivery-request.json"
+        response_schema_ref: "media-buy/get-media-buy-delivery-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buy_delivery"
+        stateful: true
+        expected: |
+          Delivery row contains reach without reach_window. Schema-valid —
+          this is a SHOULD, not a MUST. The advisory validation below fires
+          when reach_window is absent, surfacing the omission for the seller
+          to address in future delivery responses.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "$context.media_buy_id"
+          include_package_daily_breakdown: true
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buy-delivery-response.json schema"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.reach_window"
+            severity: advisory
+            permanent_advisory:
+              reason: "delivery-metrics.json declares reach_window as SHOULD (not MUST) for 3.1. Omitting it is schema-valid but prevents buyers from determining the measurement window, making the reach value sum-unsafe across reporting periods. Sellers on the 3.1 track should populate reach_window on all reach-bearing delivery rows. This advisory is permanent: promotion to required is a 4.0 breaking change and will be tracked separately."
+            description: "reach_window populated on reach-bearing delivery row (advisory — SHOULD per 3.1 spec)"

--- a/static/schemas/source/compliance/comply-test-controller-request.json
+++ b/static/schemas/source/compliance/comply-test-controller-request.json
@@ -520,6 +520,76 @@
             "currency"
           ]
         },
+        "reach": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Unique reach count to inject into the simulated delivery row. Used by simulate_delivery. The unit of measurement matches the reach_unit declared on the media buy's optimization goal. When supplied, sellers MUST surface this value at `totals.reach` in the next get_media_buy_delivery response."
+        },
+        "frequency": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Average frequency per reach unit to inject. Used by simulate_delivery. When supplied alongside reach, sellers MUST surface this value at `totals.frequency`. The measurement window for this frequency value is declared in `reach_window` when also present."
+        },
+        "reach_window": {
+          "type": "object",
+          "description": "Measurement window semantics to attach to the simulated reach and frequency values. Used by simulate_delivery. When present, sellers MUST populate `reach_window` on the delivery row so buyers can determine the window semantics (cumulative vs. period vs. rolling). Omitting this param produces a row with no `reach_window` — valid per schema but sum-unsafe. Mirrors the `reach_window` shape in delivery-metrics.json.",
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": ["cumulative", "period", "rolling"],
+              "description": "Window kind. `cumulative` — no period field required. `period` and `rolling` — period field REQUIRED."
+            },
+            "period": {
+              "allOf": [{ "$ref": "/schemas/core/duration.json" }],
+              "description": "Duration of the measurement window. REQUIRED when kind is `period` or `rolling`. Matches the `period` field in delivery-metrics.json's reach_window block."
+            }
+          },
+          "required": ["kind"],
+          "allOf": [
+            {
+              "if": {
+                "properties": { "kind": { "enum": ["period", "rolling"] } },
+                "required": ["kind"]
+              },
+              "then": {
+                "required": ["period"]
+              }
+            }
+          ],
+          "additionalProperties": true
+        },
+        "viewability": {
+          "type": "object",
+          "description": "Viewability metrics to inject into the simulated delivery row. Used by simulate_delivery. When present, sellers MUST surface these values inside `viewability` on the next get_media_buy_delivery response. Mirrors the `viewability` block in delivery-metrics.json: measurable_impressions is the shared denominator for viewable_rate and viewed_seconds.",
+          "properties": {
+            "measurable_impressions": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Impressions where viewability could be measured. Coverage denominator for viewable_rate and viewed_seconds."
+            },
+            "viewable_impressions": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Impressions that met the viewability threshold."
+            },
+            "viewable_rate": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1,
+              "description": "Viewable impression rate (viewable_impressions / measurable_impressions)."
+            },
+            "viewed_seconds": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Average in-view duration per measurable impression in seconds. Reporting counterpart to the viewed_seconds optimization metric."
+            },
+            "standard": {
+              "$ref": "/schemas/enums/viewability-standard.json",
+              "description": "Viewability measurement standard governing the threshold for viewable_rate and viewed_seconds."
+            }
+          },
+          "additionalProperties": true
+        },
         "spend_percentage": {
           "type": "number",
           "minimum": 0,


### PR DESCRIPTION
Closes #4931

Adds compliance storyboard coverage for the two 3.1 delivery-metrics additions that shipped without conformance tests: `reach_window` (three `kind` semantics) and `viewability.viewed_seconds`.

## Changes

**`reach_buy_flow.yaml` — 4 new phases after the existing `reach_delivery` phase:**

- `reach_window_cumulative` — injects `reach_window: {kind: "cumulative"}` (no `period` field) and verifies the seller surfaces window semantics on the delivery row.
- `reach_window_period` — injects `kind: "period"` + `period: {interval: 1, unit: "days"}`, asserts both `kind` and `period` present.
- `reach_window_rolling` — injects `kind: "rolling"` + `period: {interval: 7, unit: "days"}`, asserts both fields present.
- `reach_window_absent_advisory` — injects reach without `reach_window`, issues `severity: advisory` + `permanent_advisory` (schema-valid SHOULD; buyers warned, sellers not failed; promotion to required is a 4.0 concern).

**`delivery_reporting.yaml` — 1 new phase + new fixtures:**

- `viewability_delivery` phase: creates a vCPM video buy, injects a full viewability block (`measurable_impressions`, `viewable_impressions`, `viewable_rate`, `viewed_seconds: 4.3`, `standard: "mrc"`), asserts `viewability.viewed_seconds`, `measurable_impressions`, and `standard` present on the delivery row.
- New fixture: `video_viewability_q2` product + `vcpm_standard` pricing option.

**`comply-test-controller-request.json` — 4 new named `params` properties:**

- `reach` (number) and `frequency` (number) — formally declared (were already used in `reach_buy_flow.yaml` but undeclared; no behavioral change for existing implementers).
- `reach_window` (object: `{kind, period?}`) — mirrors `delivery-metrics.json`'s `reach_window` shape, including the `allOf/if/then` conditional that requires `period` when `kind` is `period` or `rolling`. Uses `$ref: /schemas/core/duration.json` for the `period` field.
- `viewability` (object: `{measurable_impressions?, viewable_impressions?, viewable_rate?, viewed_seconds?, standard?}`) — `standard` references `$ref: /schemas/enums/viewability-standard.json`.

## Non-breaking justification

All additions are to the conformance harness: new phases in existing storyboards and new named properties on an already-`additionalProperties: true` params block. Per playbook: "additive scenarios, additive `comply_test_controller` enum values, new universal storyboards, and additive `runner-output.json` step kinds are patch-eligible." No existing step kind renamed, no required field added to existing payloads, no enum value removed.

## Milestone / routing

- Bump: `patch` (additive conformance harness)
- Milestone: 3.1.0 (these cover 3.1-only schema fields; `3.1.x` branch doesn't exist until 3.1.0 stable ships — targeting `main` as the 3.1.0 beta development branch)

## Pre-PR review

- code-reviewer: approved — context threading, idempotency keys, advisory instrument all correct; fixed blocker (inline `period` object replaced with `$ref: duration.json` + `allOf/if/then` conditional)
- ad-tech-protocol-expert: approved — non-breaking per conformance harness patch-eligibility; `field_present + severity: advisory` is correct instrument for omitted-reach_window advisory; `vcpm` and `mrc` enum values confirmed valid

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01JJDWgvUWk89CGsx53VnSoJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJDWgvUWk89CGsx53VnSoJ)_