### PR TITLE
fix(ci): compare changesets against PR base

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -32,4 +32,4 @@ jobs:
           node-version: '22'
 
       - name: Check for changeset
-        run: npx --yes @changesets/cli@^2.31.0 status --since=origin/main
+        run: npx --yes @changesets/cli@^2.31.0 status --since=origin/${{ github.base_ref }}


### PR DESCRIPTION
## Summary

Fixes #4633.

The changeset check currently compares every PR against `origin/main`, even when the PR targets a maintenance branch. This updates the workflow to derive the comparison branch from `github.base_ref`, so PRs against `3.0.x`, `2.6.x`, and `2.5-maintenance` are checked against their actual base branch.

## Testing

- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/changeset-check.yml'); puts 'yaml ok'"`