### PR TITLE
refactor(server): share constant-time secret compare

### DIFF
--- a/server/src/creative-agent/index.ts
+++ b/server/src/creative-agent/index.ts
@@ -7,10 +7,10 @@
 
 import { Router } from 'express';
 import type { Request, Response, NextFunction } from 'express';
-import { createHash, timingSafeEqual } from 'node:crypto';
 import rateLimit from 'express-rate-limit';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { createLogger } from '../logger.js';
+import { constantTimeEqual } from '../utils/constant-time-equal.js';
 import { createCreativeAgentServer } from './task-handlers.js';
 import { getPreview, cleanExpiredPreviews } from './preview-store.js';
 
@@ -24,12 +24,6 @@ function setCORSHeaders(res: Response): void {
   res.setHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, mcp-session-id');
   res.setHeader('Access-Control-Expose-Headers', 'Content-Type');
-}
-
-function constantTimeEqual(a: string, b: string): boolean {
-  const ha = createHash('sha256').update(a).digest();
-  const hb = createHash('sha256').update(b).digest();
-  return timingSafeEqual(ha, hb);
 }
 
 function requireToken(req: Request, res: Response, next: NextFunction): void {

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -10,6 +10,7 @@ import { isWorkOSApiKeyFormat } from './api-key-format.js';
 import { verifyWorkOSJWT, looksLikeJWT } from '../auth/workos-jwt.js';
 import { storeRefreshedSession, getRefreshedSession, cleanExpiredRefreshes } from '../db/session-refresh-db.js';
 import { getPool } from '../db/client.js';
+import { constantTimeEqual } from '../utils/constant-time-equal.js';
 
 const logger = createLogger('auth-middleware');
 
@@ -649,27 +650,6 @@ function hasValidAdminApiKey(req: Request): boolean {
   // Don't match WorkOS API keys - those are handled separately
   if (isWorkOSApiKeyFormat(token)) return false;
   return constantTimeEqual(token, ADMIN_API_KEY);
-}
-
-/**
- * Constant-time string compare for ASCII secrets. Intended for comparing
- * attacker-supplied input against a fixed server-side secret (e.g. ADMIN_API_KEY).
- * On length mismatch, runs a same-length dummy compare so total work is
- * O(len(input)), not O(len(secret)) — this leaks the attacker's chosen
- * input length (already public) but never the secret's length.
- *
- * Do NOT reuse this to compare two attacker-controlled inputs against each
- * other — the timing model assumes one side is a known-to-server fixed value.
- * `latin1` encoding makes the ASCII-only assumption on the secret explicit.
- */
-export function constantTimeEqual(a: string, b: string): boolean {
-  const aBuf = Buffer.from(a, 'latin1');
-  const bBuf = Buffer.from(b, 'latin1');
-  if (aBuf.length !== bBuf.length) {
-    timingSafeEqual(aBuf, Buffer.alloc(aBuf.length));
-    return false;
-  }
-  return timingSafeEqual(aBuf, bBuf);
 }
 
 /**

--- a/server/src/utils/constant-time-equal.ts
+++ b/server/src/utils/constant-time-equal.ts
@@ -1,0 +1,22 @@
+import { timingSafeEqual } from 'node:crypto';
+
+/**
+ * Constant-time string compare for ASCII secrets. Intended for comparing
+ * attacker-supplied input against a fixed server-side secret.
+ *
+ * On length mismatch, runs a same-length dummy compare so total work is
+ * O(len(input)), not O(len(secret)). This leaks the attacker's chosen input
+ * length, which is already public, but never the server-side secret's length.
+ *
+ * Do not use this to compare two attacker-controlled values. The timing model
+ * assumes one side is a fixed server-side ASCII secret.
+ */
+export function constantTimeEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, 'latin1');
+  const bBuf = Buffer.from(b, 'latin1');
+  if (aBuf.length !== bBuf.length) {
+    timingSafeEqual(aBuf, Buffer.alloc(aBuf.length));
+    return false;
+  }
+  return timingSafeEqual(aBuf, bBuf);
+}

--- a/server/tests/unit/auth-constant-time-equal.test.ts
+++ b/server/tests/unit/auth-constant-time-equal.test.ts
@@ -1,14 +1,6 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 
-// auth.ts constructs `new WorkOS(process.env.WORKOS_API_KEY!)` at module
-// load. Stub the module so CI runs against the repo-root vitest config
-// (which has no setup file) don't trip on the missing env var. The
-// pattern matches dev-session-signing.test.ts.
-vi.mock('@workos-inc/node', () => ({
-  WorkOS: class { userManagement = {}; organizations = {}; },
-}));
-
-import { constantTimeEqual } from '../../src/middleware/auth.js';
+import { constantTimeEqual } from '../../src/utils/constant-time-equal.js';
 
 describe('constantTimeEqual', () => {
   it('returns true for identical strings', () => {


### PR DESCRIPTION
## Summary

Fixes #4632.

This consolidates the duplicate `constantTimeEqual(a, b)` implementations into a shared server utility. The admin API key path and the reference creative-agent bearer-token gate now use the same helper, based on the existing `auth.ts` latin1 + length-mismatch dummy-compare implementation.

## What changed

- Added `server/src/utils/constant-time-equal.ts`.
- Updated `server/src/middleware/auth.ts` to import the shared helper.
- Updated `server/src/creative-agent/index.ts` to remove its local sha256-based helper and import the shared helper.
- Pointed the existing constant-time compare unit test at the shared utility, removing the old WorkOS mock needed only because the helper lived in `auth.ts`.

## Testing

- `npx vitest run server/tests/unit/auth-constant-time-equal.test.ts server/tests/unit/creative-agent.test.ts`
- `npm run typecheck`
- `git diff --check`
- precommit hook: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run typecheck`
- push hook: `verify-version-sync`, storyboard matrix skipped because no training-agent/compliance changes, Mintlify skipped because no docs changes