### PR TITLE
fix(compliance): add bid prices to media-buy storyboards

### DIFF
--- a/static/compliance/source/protocols/media-buy/scenarios/creative_fate_after_cancellation.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/creative_fate_after_cancellation.yaml
@@ -121,6 +121,7 @@ phases:
             - product_id: "$context.product_id"
               budget: 5000
               pricing_option_id: "$context.pricing_option_id"
+              bid_price: 10.0
           context:
             correlation_id: "creative_fate--create_buy"
         context_outputs:
@@ -347,6 +348,7 @@ phases:
             - product_id: "$context.product_id"
               budget: 5000
               pricing_option_id: "$context.pricing_option_id"
+              bid_price: 10.0
           context:
             correlation_id: "creative_fate--create_second_buy"
         context_outputs:

--- a/static/compliance/source/protocols/media-buy/scenarios/dependency_impairment.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/dependency_impairment.yaml
@@ -171,6 +171,7 @@ phases:
             - product_id: "$context.product_id"
               budget: 5000
               pricing_option_id: "$context.pricing_option_id"
+              bid_price: 10.0
           context:
             correlation_id: "dependency_impairment--create_buy"
         context_outputs:

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_denied_recovery.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_denied_recovery.yaml
@@ -191,6 +191,7 @@ phases:
             - product_id: "$context.product_id"
               budget: 50000
               pricing_option_id: "$context.pricing_option_id"
+              bid_price: 10.0
           context:
             correlation_id: "governance_denied_recovery--create_media_buy_denied"
         validations:
@@ -236,6 +237,7 @@ phases:
             - product_id: "$context.product_id"
               budget: 8000
               pricing_option_id: "$context.pricing_option_id"
+              bid_price: 10.0
         context_outputs:
           - name: media_buy_id
             path: "media_buy_id"

--- a/static/compliance/source/protocols/media-buy/scenarios/invalid_transitions.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/invalid_transitions.yaml
@@ -147,6 +147,7 @@ phases:
             - product_id: "$context.product_id"
               budget: 5000
               pricing_option_id: "$context.pricing_option_id"
+              bid_price: 10.0
           context:
             correlation_id: "invalid_transitions--create_buy"
         context_outputs:

--- a/static/compliance/source/protocols/media-buy/scenarios/inventory_list_no_match.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/inventory_list_no_match.yaml
@@ -123,6 +123,7 @@ phases:
             - product_id: "$context.product_id"
               budget: 10000
               pricing_option_id: "$context.pricing_option_id"
+              bid_price: 10.0
               targeting_overlay:
                 property_list:
                   agent_url: "https://governance.pinnacle-agency.example"

--- a/static/compliance/source/protocols/media-buy/scenarios/inventory_list_targeting.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/inventory_list_targeting.yaml
@@ -121,6 +121,7 @@ phases:
             - product_id: "$context.product_id"
               budget: 20000
               pricing_option_id: "$context.pricing_option_id"
+              bid_price: 10.0
               targeting_overlay:
                 property_list:
                   agent_url: "https://governance.pinnacle-agency.example"

--- a/static/compliance/source/protocols/media-buy/scenarios/measurement_accountability.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/measurement_accountability.yaml
@@ -166,6 +166,7 @@ phases:
           packages:
             - product_id: "$context.product_id"
               pricing_option_id: "$context.pricing_option_id"
+              bid_price: 10.0
               budget: 25000
           idempotency_key: "$generate:uuid_v4#media_buy_seller_measurement_accountability_create"
         validations:

--- a/static/compliance/source/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
@@ -113,6 +113,7 @@ phases:
             - product_id: "$context.product_id"
               budget: 25000
               pricing_option_id: "$context.pricing_option_id"
+              bid_price: 10.0
               measurement_terms:
                 billing_measurement:
                   vendor:
@@ -170,6 +171,7 @@ phases:
             - product_id: "$context.product_id"
               budget: 25000
               pricing_option_id: "$context.pricing_option_id"
+              bid_price: 10.0
               measurement_terms:
                 billing_measurement:
                   vendor:

--- a/static/compliance/source/protocols/media-buy/scenarios/pending_creatives_to_start.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/pending_creatives_to_start.yaml
@@ -110,6 +110,7 @@ phases:
             - product_id: "$context.product_id"
               budget: 10000
               pricing_option_id: "$context.pricing_option_id"
+              bid_price: 10.0
 
           context:
             correlation_id: "pending_creatives_to_start--create_buy_no_creatives"

--- a/static/compliance/source/protocols/media-buy/scenarios/vendor_metric_accountability.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/vendor_metric_accountability.yaml
@@ -192,6 +192,7 @@ phases:
           packages:
             - product_id: "$context.product_id"
               pricing_option_id: "$context.pricing_option_id"
+              bid_price: 10.0
               budget: 12000
           idempotency_key: "$generate:uuid_v4#media_buy_seller_vendor_metric_accountability_create"
         context_outputs:


### PR DESCRIPTION
## Summary

Fixes #4732.

This adds explicit `bid_price: 10.0` values to media-buy storyboard `create_media_buy` sample requests that reuse `$context.pricing_option_id` captured from `get_products`.

The issue is that `products[0].pricing_options[0].pricing_option_id` can point at an auction pricing option. Without a `bid_price`, those storyboards can fail at media-buy creation before they reach the scenario-specific behavior they are meant to exercise. Adding a defensive bid price is compatible with fixed-price options and prevents auction-first product ordering from preempting the intended validations.

I kept this narrow to the media-buy `create_media_buy` steps that consume `$context.pricing_option_id`; broader pricing-option selection semantics are out of scope for this PR.

## Testing

- `npm run build:compliance`
- `npm run test:storyboard-check-enum`
- changed-storyboard `sample_request` schema lint via `scripts/lint-storyboard-sample-request-schema.cjs` exports
- audit script: no media-buy `create_media_buy` step using `$context.pricing_option_id` is missing `bid_price`
- `git diff --check`
- precommit hook:
  - `npm run test:unit`
  - `npm run test:test-dynamic-imports`
  - `npm run test:callapi-state-change`
  - `npm run typecheck`
- push hook:
  - `npm run verify-version-sync`
  - storyboard matrix passed all tenant floors (`/signals`, `/sales`, `/governance`, `/creative`, `/creative-builder`, `/brand`)

Known unrelated full-tree lint drift observed locally:

- `npm run test:storyboard-context-output-paths` currently reports `specialisms/sales-guaranteed/index.yaml:create_media_buy — task_completion.media_buy_id`.
- `npm run test:storyboard-validations-paths` currently reports `specialisms/brand-rights/scenarios/governance_denied.yaml:acquire_rights_denied — errors`.
- `node scripts/lint-storyboard-sample-request-schema.cjs` currently reports existing creative `native_in_feed.yaml` tracker discriminator/type drift. The changed media-buy storyboards pass the same schema lint when scoped to the edited files.
