### PR TITLE
fix(addie): prevent Sage from routing get_adcp_capabilities through call_adcp_task

### DIFF
--- a/.changeset/fix-sage-get-adcp-capabilities-routing.md
+++ b/.changeset/fix-sage-get-adcp-capabilities-routing.md
@@ -1,0 +1,4 @@
+---
+---
+
+Prevent Sage from routing `get_adcp_capabilities` through `call_adcp_task` during certification demos. Adds explicit guidance notes in module context (demo and exercise blocks, including capstone labs), a targeted error redirect in the `call_adcp_task` handler, and updated tool descriptions to make the tool boundary unambiguous at selection time.

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.05.4';
+export const CODE_VERSION = '2026.05.5';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/mcp/adcp-tools.ts
+++ b/server/src/addie/mcp/adcp-tools.ts
@@ -470,7 +470,8 @@ const askAboutAdcpTaskTool: AddieTool = {
 const callAdcpTaskTool: AddieTool = {
   name: 'call_adcp_task',
   description: [
-    'Execute any AdCP protocol task against an agent. For uncommon tasks or when unsure about parameters, call ask_about_adcp_task first.',
+    'Execute any registered AdCP protocol task against an agent. For uncommon tasks or when unsure about parameters, call ask_about_adcp_task first.',
+    'Does NOT include capability discovery — use the `get_adcp_capabilities` tool directly for that (it is not a task).',
     '',
     'Two rules a search round-trip cannot rescue you from after a mutating call:',
     '• idempotency_key: REQUIRED on every mutating task (UUID). Same key on retry replays the same response. Generating a fresh UUID after a failed attempt is how you double-book.',
@@ -520,7 +521,7 @@ const getAdcpCapabilitiesTool: AddieTool = {
   description:
     'Discover an agent\'s AdCP protocol support and capabilities. Returns supported tasks, domains, features, and configuration.',
   usage_hints:
-    'use when the user wants to discover what an agent can do, check supported features, or understand agent capabilities before using other tasks',
+    'use to discover an agent\'s supported tasks and features — call this tool directly, NOT via call_adcp_task',
   input_schema: {
     type: 'object',
     properties: {
@@ -810,6 +811,13 @@ export function createAdcpToolHandlers(
 
     if (!agentUrl) return '**Error:** agent_url is required.';
     if (!task) return '**Error:** task is required.';
+
+    // Defense-in-depth: fires if the MCP layer skips enum validation.
+    // In well-formed requests this branch is unreachable because 'get_adcp_capabilities'
+    // is not in TASK_NAMES and will be rejected by the input schema first.
+    if (task === 'get_adcp_capabilities') {
+      return '**Error:** `get_adcp_capabilities` is a protocol-layer handshake, not an AdCP task — use the dedicated `get_adcp_capabilities` tool directly (it takes only `agent_url`, no `task` parameter).';
+    }
 
     const meta = ADCP_TASK_REGISTRY[task];
     if (!meta) {

--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -1617,12 +1617,19 @@ export function createCertificationToolHandlers(
           if (scenarioTools.includes('get_brand_identity')) {
             lines.push('For get_brand_identity: pass a brand_id from the tool\'s "Available brands" list — not a domain name.');
           }
+          if (scenarioTools.includes('get_adcp_capabilities')) {
+            lines.push('For get_adcp_capabilities: call the `get_adcp_capabilities` tool directly — NOT via `call_adcp_task`.');
+          }
         }
       }
 
       if (mod.exercise_definitions) {
         const exercises = mod.exercise_definitions as certDb.ExerciseDefinition[];
         lines.push('', '## Exercises');
+        const exerciseTools = exercises.flatMap(ex => ex.sandbox_actions.map(a => a.tool));
+        if (exerciseTools.includes('get_adcp_capabilities')) {
+          lines.push('For get_adcp_capabilities: call the `get_adcp_capabilities` tool directly — NOT via `call_adcp_task`.');
+        }
         for (const ex of exercises) {
           lines.push(`### ${ex.title}`);
           lines.push(ex.description);
@@ -1755,6 +1762,9 @@ export function createCertificationToolHandlers(
           }
           if (scenarioTools.includes('get_brand_identity')) {
             lines.push('For get_brand_identity: pass a brand_id from the tool\'s "Available brands" list — not a domain name.');
+          }
+          if (scenarioTools.includes('get_adcp_capabilities')) {
+            lines.push('For get_adcp_capabilities: call the `get_adcp_capabilities` tool directly — NOT via `call_adcp_task`.');
           }
           lines.push('');
         }
@@ -2205,6 +2215,10 @@ export function createCertificationToolHandlers(
       // Lab exercises
       if (exercises?.length) {
         lines.push('## Lab exercises');
+        const labExerciseTools = exercises.flatMap(ex => ex.sandbox_actions.map(a => a.tool));
+        if (labExerciseTools.includes('get_adcp_capabilities')) {
+          lines.push('For get_adcp_capabilities: call the `get_adcp_capabilities` tool directly — NOT via `call_adcp_task`.');
+        }
         for (const ex of exercises) {
           lines.push(`### ${ex.title}`);
           lines.push(ex.description);


### PR DESCRIPTION
Closes #4956

During the A3 certification module (and any other module with `get_adcp_capabilities` in demo or exercise tools), Sage was calling `call_adcp_task` with `task: "get_adcp_capabilities"` instead of using the dedicated `get_adcp_capabilities` MCP tool. This produced `Unknown task "get_adcp_capabilities"` errors because `get_adcp_capabilities` is a protocol-layer handshake, not a registered task.

The fix adds disambiguation at three intervention points — tool selection, context injection, and error recovery — so the mistake is blocked at the earliest possible layer:

1. **`call_adcp_task` description** — "any AdCP protocol task" → "any *registered* AdCP protocol task" + explicit carve-out: "Does NOT include capability discovery — use the `get_adcp_capabilities` tool directly."
2. **`get_adcp_capabilities` usage_hints** — clarifies "call this tool directly, NOT via call_adcp_task" at tool-selection time.
3. **`call_adcp_task` handler** — defense-in-depth early exit for `task === 'get_adcp_capabilities'` with a clear redirect message (fires if the MCP layer skips enum validation).
4. **`certification-tools.ts`** — guidance notes injected in all four rendering paths where `get_adcp_capabilities` may appear: `get_certification_module` demo block, `get_certification_module` exercise block, `start_certification_module` demo block, and the capstone `start_certification_exam` lab block. Mirrors the existing `acquire_rights`/`sync_accounts`/`get_brand_identity` guidance pattern.
5. **`CODE_VERSION`** bumped to `2026.05.5` (tool implementation change in `mcp/*.ts`).

**Non-breaking justification:** no schema changes, no DB migrations, no protocol changes. All changes are server-side prompt/tool-description text and a runtime error redirect in Addie's MCP tool handlers. Existing behavior for all other tasks is unaffected.

**Pre-PR review:**
- code-reviewer: approved — missing changeset and capstone block gap flagged and fixed; no other blockers
- education-expert: approved — pedagogically sound, no accreditation risk; wording normalized across all four blocks

**Nits noted (not fixed — reviewer judgment):**
- The `call_adcp_task` defensive guard is unreachable via schema-conformant calls; the in-file comment explains this.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_017YyyMMpcRp7xRnEQek79vK

---
_Generated by [Claude Code](https://claude.ai/code/session_017YyyMMpcRp7xRnEQek79vK)_