### PR TITLE
fix(addie): require verbatim tool-result rendering in Sage sandbox demos

### DIFF
--- a/.changeset/fix-sage-demo-verbatim-render.md
+++ b/.changeset/fix-sage-demo-verbatim-render.md
@@ -1,0 +1,9 @@
+---
+---
+
+fix(addie): require verbatim tool-result rendering in Sage sandbox demos
+
+Adds an explicit render-verbatim instruction to Sage's demo-scenario prompt in
+certification modules. Without it Claude could satisfy "run a demo" by writing
+explanatory prose rather than displaying the actual tool response, causing the
+learner to see no catalog data on the first get_products call in B1. Closes #4961.

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.05.4';
+export const CODE_VERSION = '2026.05.5';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -1604,6 +1604,7 @@ export function createCertificationToolHandlers(
           lines.push('', '## Demo scenarios');
           lines.push(formatTenantBlock(tenants));
           lines.push('YOU (Sage) run ONE demo early (turn 2-3) to ground concepts. Clearly label it as YOUR demonstration — say "Let me show you..." before calling the tool. Do NOT attribute tool results to the learner. After the demo, invite the learner to try the exercise themselves.');
+          lines.push('After the tool call returns, display the actual response data (formatted JSON block or structured list) BEFORE any explanatory commentary. Tool result blocks are exempt from the 150-word cap — show the full response if it is ≤20 items; for larger responses, show the first 10 items verbatim with a note that the catalog has N total. Never substitute a prose summary for the data block.');
           lp.demo_scenarios.forEach(ds => {
             lines.push(`### ${ds.description}`);
             lines.push(`Tools: ${ds.tools.join(', ')}`);


### PR DESCRIPTION
Closes #4961

During B1 certification, Sage calls `get_products` successfully on the first attempt but the learner sees only explanatory prose — no catalog data. On retry it renders correctly. Root cause: the demo-scenario instruction block (`certification-tools.ts:1606`) told Sage to "run a demo" but had no output-format contract, leaving Claude free to narrate the result instead of displaying it. The retry worked because the prior turn's (even non-displaying) response sat in context as an implicit few-shot example.

**Non-breaking justification:** server-side prompt string addition; no schema, protocol, or API surface change. Existing learners are unaffected mid-session.

## Changes

- `server/src/addie/mcp/certification-tools.ts` — adds one `lines.push()` after the existing demo-run instruction requiring Sage to display the actual tool response (formatted JSON block or structured list) before any explanatory commentary, with a size-aware cap (full response ≤20 items; first 10 + count note for larger catalogs) and an explicit exemption from the 150-word cap so the two instructions don't conflict.
- `server/src/addie/config-version.ts` — bumps `CODE_VERSION` `2026.05.4` → `2026.05.5` per playbook requirement for `mcp/*.ts` changes.
- `.changeset/fix-sage-demo-verbatim-render.md` — `--empty` changeset (server-only, no protocol bump).

**Nit (out of scope for this PR):** the same rendering gap could theoretically affect learner-initiated exercise blocks (line ~1630 path). This PR scopes to the Sage-initiated demo block (the reported failure site); exercise rendering is tracked as a follow-up.

**Pre-PR review:**
- code-reviewer: approved — instruction closes the failure mode; `CODE_VERSION` bump required (addressed); no prompt-injection vector (static literal, no interpolation); `--empty` changeset correct.
- education-expert: approved (conditional) — satisfies practical-knowledge grounding requirement; size-aware cap + 150-word exemption resolves instruction conflict; structural curriculum change not required for this bug.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_013LXwTgzBC943KVa54tU7U9

---
_Generated by [Claude Code](https://claude.ai/code/session_013LXwTgzBC943KVa54tU7U9)_