### PR TITLE
[codex] Fix WorkOS membership integrity invariant

### DIFF
--- a/.changeset/fix-workos-membership-invariant.md
+++ b/.changeset/fix-workos-membership-invariant.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": patch
+---
+
+fix(server): align the WorkOS membership integrity invariant with the local membership cache schema.
+
+The invariant no longer reads a nonexistent `organization_memberships.status` column when checking cached WorkOS memberships. This keeps the audit from failing before it can report stale local membership rows that should be reconciled by the WorkOS sync.

--- a/server/src/audit/integrity/invariants/workos-membership-row-exists-in-workos.ts
+++ b/server/src/audit/integrity/invariants/workos-membership-row-exists-in-workos.ts
@@ -16,7 +16,6 @@ interface MembershipRow {
   workos_user_id: string;
   workos_organization_id: string;
   workos_membership_id: string | null;
-  status: string;
 }
 
 export const workosMembershipRowExistsInWorkosInvariant: Invariant = {
@@ -35,9 +34,8 @@ export const workosMembershipRowExistsInWorkosInvariant: Invariant = {
     // ORDER BY RANDOM() is fine at our scale (tens of thousands of rows).
     // If membership counts grow significantly, switch to TABLESAMPLE.
     const result = await pool.query<MembershipRow>(
-      `SELECT workos_user_id, workos_organization_id, workos_membership_id, status
+      `SELECT workos_user_id, workos_organization_id, workos_membership_id
          FROM organization_memberships
-        WHERE status = 'active'
         ORDER BY RANDOM()
         LIMIT $1`,
       [sampleSize],
@@ -56,7 +54,7 @@ export const workosMembershipRowExistsInWorkosInvariant: Invariant = {
             subject_type: 'membership',
             subject_id: `${row.workos_user_id}:${row.workos_organization_id}`,
             message:
-              `organization_memberships row marked active for user ${row.workos_user_id} in ` +
+              `organization_memberships row cached for user ${row.workos_user_id} in ` +
               `org ${row.workos_organization_id}, but WorkOS reports no such membership`,
             details: {
               workos_user_id: row.workos_user_id,

--- a/server/tests/unit/integrity/invariants.test.ts
+++ b/server/tests/unit/integrity/invariants.test.ts
@@ -659,18 +659,19 @@ describe('stripe-sub-reflected-in-org-row', () => {
 describe('workos-membership-row-exists-in-workos', () => {
   it('passes when every sampled membership row resolves in WorkOS', async () => {
     mockPoolQuery.mockResolvedValueOnce({
-      rows: [{ workos_user_id: 'u_1', workos_organization_id: 'org_1', workos_membership_id: 'mem_1', status: 'active' }],
+      rows: [{ workos_user_id: 'u_1', workos_organization_id: 'org_1', workos_membership_id: 'mem_1' }],
     });
     mockWorkosListMemberships.mockResolvedValueOnce({ data: [{ id: 'mem_1' }] });
 
     const result = await workosMembershipRowExistsInWorkosInvariant.check(makeCtx());
     expect(result.checked).toBe(1);
     expect(result.violations).toEqual([]);
+    expect(mockPoolQuery.mock.calls[0][0]).not.toContain('status');
   });
 
   it('flags rows that no longer exist in WorkOS', async () => {
     mockPoolQuery.mockResolvedValueOnce({
-      rows: [{ workos_user_id: 'u_stale', workos_organization_id: 'org_1', workos_membership_id: 'mem_stale', status: 'active' }],
+      rows: [{ workos_user_id: 'u_stale', workos_organization_id: 'org_1', workos_membership_id: 'mem_stale' }],
     });
     mockWorkosListMemberships.mockResolvedValueOnce({ data: [] });
 
@@ -683,7 +684,7 @@ describe('workos-membership-row-exists-in-workos', () => {
 
   it('records a warning when WorkOS lookup fails', async () => {
     mockPoolQuery.mockResolvedValueOnce({
-      rows: [{ workos_user_id: 'u_1', workos_organization_id: 'org_1', workos_membership_id: 'mem_1', status: 'active' }],
+      rows: [{ workos_user_id: 'u_1', workos_organization_id: 'org_1', workos_membership_id: 'mem_1' }],
     });
     mockWorkosListMemberships.mockRejectedValueOnce(new Error('WorkOS down'));
 


### PR DESCRIPTION
## Summary

Fixes the `workos-membership-row-exists-in-workos` integrity invariant so it matches the current `organization_memberships` table schema.

The invariant was still selecting and filtering on a `status` column that does not exist locally. Production therefore returned an invariant runner warning instead of checking for stale local WorkOS membership rows.

## Changes

- Remove the nonexistent `status` column from the invariant query.
- Treat rows in `organization_memberships` as cached active memberships, matching the table contract and `/api/admin/users/sync-workos` behavior.
- Update the unit tests and add an assertion that the invariant query does not reference `status`.

## Validation

- `npx vitest run server/tests/unit/integrity/invariants.test.ts --config server/vitest.config.ts`
- `npm run typecheck`
- Commit hook also ran:
  - `npm run test:unit`
  - `npm run test:test-dynamic-imports`
  - `npm run test:callapi-state-change`
  - `npm run typecheck`
