### PR TITLE
Enforce v3 envelope integrity storyboard

### DIFF
--- a/.changeset/envelope-integrity-storyboard.md
+++ b/.changeset/envelope-integrity-storyboard.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Enforce the v3 envelope integrity storyboard by adding envelope-scoped absent-field checks for legacy `task_status` and `response_status`, and document the check kind in the runner output contract.

--- a/scripts/lint-storyboard-validations-paths.cjs
+++ b/scripts/lint-storyboard-validations-paths.cjs
@@ -17,6 +17,8 @@
  *   - field_value
  *   - field_value_or_absent
  *   - field_absent
+ *   - envelope_field_present
+ *   - envelope_field_absent
  *
  * Non-path-bearing checks (error_code, response_schema, http_status_in,
  * http_status, any_of, on_401_require_header) are skipped — they don't
@@ -43,6 +45,8 @@ const PATH_BEARING_CHECKS = new Set([
   'field_value',
   'field_value_or_absent',
   'field_absent',
+  'envelope_field_present',
+  'envelope_field_absent',
 ]);
 
 function loadAllowlist() {
@@ -303,6 +307,48 @@ function pathResolvesAgainstResponseOrEnvelope(schema, segments) {
   return false;
 }
 
+function pathIsForbiddenByRequiredNot(node, segments, seen = new Set()) {
+  if (!node || typeof node !== 'object') return false;
+  if (segments.length !== 1) return false;
+
+  if (node.$ref) {
+    if (seen.has(node.$ref)) return false;
+    const next = new Set(seen);
+    next.add(node.$ref);
+    return pathIsForbiddenByRequiredNot(loadSchema(node.$ref), segments, next);
+  }
+
+  const [seg] = segments;
+  const notNode = node.not;
+  const notVariants = notNode && typeof notNode === 'object'
+    ? [notNode, ...(Array.isArray(notNode.anyOf) ? notNode.anyOf : []), ...(Array.isArray(notNode.oneOf) ? notNode.oneOf : [])]
+    : [];
+  for (const variant of notVariants) {
+    const required = variant && typeof variant === 'object' && Array.isArray(variant.required)
+      ? variant.required
+      : [];
+    if (required.includes(seg)) return true;
+  }
+
+  const variants = node.oneOf || node.anyOf || node.allOf;
+  if (Array.isArray(variants)) {
+    for (const variant of variants) {
+      if (pathIsForbiddenByRequiredNot(variant, segments, seen)) return true;
+    }
+  }
+
+  return false;
+}
+
+function absentPathForbiddenState(schema, segments) {
+  const envelope = loadSchema(ENVELOPE_REF);
+  const forbiddenByEnvelope = Boolean(envelope && pathIsForbiddenByRequiredNot(envelope, segments));
+  return {
+    forbiddenBySchema: pathIsForbiddenByRequiredNot(schema, segments),
+    forbiddenByEnvelope,
+  };
+}
+
 function lintDoc(doc, filePath, allowlist = []) {
   const violations = [];
   if (!doc) return violations;
@@ -336,7 +382,29 @@ function lintDoc(doc, filePath, allowlist = []) {
       const rawPath = v.path;
       if (typeof rawPath !== 'string' || rawPath.length === 0) continue;
       const segments = parsePath(rawPath);
+      if (v.check === 'envelope_field_present' || v.check === 'envelope_field_absent') {
+        const envelope = loadSchema(ENVELOPE_REF);
+        const resolvesOnEnvelope = Boolean(envelope && pathResolves(envelope, segments));
+        const forbiddenOnEnvelope = Boolean(envelope && pathIsForbiddenByRequiredNot(envelope, segments));
+        if (v.check === 'envelope_field_present' && resolvesOnEnvelope) continue;
+        if (v.check === 'envelope_field_absent' && (resolvesOnEnvelope || forbiddenOnEnvelope)) continue;
+        if (isAllowlisted(allowlist, filePath, step.stepId, rawPath)) continue;
+        violations.push({
+          rule: 'path_not_in_schema',
+          filePath,
+          stepId: step.stepId,
+          responseRef: step.responseRef,
+          validationPath: rawPath,
+          check: v.check,
+          index: i,
+        });
+        continue;
+      }
       if (pathResolvesAgainstResponseOrEnvelope(schema, segments)) continue;
+      if (v.check === 'field_absent' || v.check === 'envelope_field_absent') {
+        const { forbiddenBySchema, forbiddenByEnvelope } = absentPathForbiddenState(schema, segments);
+        if (v.check === 'field_absent' && forbiddenBySchema && !forbiddenByEnvelope) continue;
+      }
       if (isAllowlisted(allowlist, filePath, step.stepId, rawPath)) continue;
       violations.push({
         rule: 'path_not_in_schema',

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -26,7 +26,7 @@
 # --- Schema definition ---
 
 id: runner_output_contract
-version: "2.2.0"
+version: "2.3.0"
 title: "Runner output contract"
 summary: "Required failure-detail shape that AdCP storyboard runners MUST emit so implementors can self-diagnose validation failures."
 
@@ -44,6 +44,7 @@ authored_check_kinds:
   - field_present
   - field_absent
   - envelope_field_present
+  - envelope_field_absent
   - field_value
   - field_value_or_absent
   - status_code
@@ -141,7 +142,8 @@ validation_result:
     - check                   # Validation kind. For storyboard-authored checks,
                               # mirrors the storyboard's step.validations[].check:
                               # response_schema | field_present |
-                              # envelope_field_present | field_value |
+                              # field_absent | envelope_field_present |
+                              # envelope_field_absent | field_value |
                               # field_value_or_absent | status_code | http_status |
                               # http_status_in | error_code | on_401_require_header |
                               # resource_equals_agent_url | any_of | refs_resolve |
@@ -198,8 +200,11 @@ validation_result:
                               #   field_value_or_absent → value or allowed_values array
                               #                          from the storyboard validation
                               #   field_present        → the path that should resolve
+                              #   field_absent         → null (the field must not be present)
                               #   envelope_field_present → the path that should resolve
                               #                          in the protocol envelope
+                              #   envelope_field_absent → null (the envelope field must
+                              #                          not be present)
                               #   status_code          → expected status
                               #   error_code           → expected error code
                               #   any_of               → array of acceptable forms
@@ -251,9 +256,14 @@ validation_result:
                               #   field_present        → null (the field was missing)
                               #                          or the observed non-object
                               #                          value
+                              #   field_absent         → observed value at path (any JSON
+                              #                          type); emitted only on failure
                               #   envelope_field_present → null (the field was missing)
                               #                          or the observed non-object
                               #                          value (scoped to envelope)
+                              #   envelope_field_absent → observed value at path (any JSON
+                              #                          type); emitted only on failure
+	                              #                          and scoped to envelope
                               #   field_less_than      → the observed value at `path`
                               #                          (number when resolvable, null
                               #                          when the field was missing).

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -1043,8 +1043,10 @@
 # enum AND document semantics here in the same PR.
 #
 # check: string (what to validate: "response_schema", "field_present",
-#                "envelope_field_present" (walks protocol-envelope.json instead of
-#                response_schema_ref — use for top-level envelope fields like `status`),
+#                "envelope_field_present" / "envelope_field_absent" (walks
+#                protocol-envelope.json instead of response_schema_ref — use for
+#                top-level envelope fields like `status`, `task_status`, and
+#                `response_status`),
 #                "field_value",
 #                "field_value_or_absent", "status_code", "http_status", "http_status_in",
 #                "error_code", "on_401_require_header", "resource_equals_agent_url",

--- a/static/compliance/source/universal/v3-envelope-integrity.yaml
+++ b/static/compliance/source/universal/v3-envelope-integrity.yaml
@@ -15,15 +15,12 @@ narrative: |
   docs/building/implementation/task-lifecycle.mdx.
 
   This storyboard documents the machine-check assertion and asserts the canonical v3
-  `status` field is present using the `envelope_field_present` check type (added in
-  adcp-client#1045), which walks the protocol envelope rather than the inner response
-  schema. The explicit envelope-root field-absence checks
-  (asserting task_status and response_status are absent) require `field_absent`
-  runner support in @adcp/client — those checks are marked TODO below and are not
-  executed until the runner ships that check type. The schema-level constraint
-  (protocol-envelope.json's top-level `not: { anyOf: [{ required: [task_status] },
-  { required: [response_status] }] }`) is the immediately effective enforcement
-  path for any schema-aware validator operating on the full protocol envelope.
+  `status` field is present using the `envelope_field_present` check type, which
+  walks the protocol envelope rather than the inner response schema. The explicit
+  envelope-root field-absence checks assert that task_status and response_status are
+  absent using `envelope_field_absent`; protocol-envelope.json carries the matching
+  top-level `not: { anyOf: [{ required: [task_status] }, { required:
+  [response_status] }] }` schema constraint.
 
   Scope: envelope top-level only. Domain data inside `payload` (e.g., a reporting
   row carrying a field named task_status) is outside this prohibition and is not
@@ -48,9 +45,8 @@ phases:
     title: "v3 envelope must not carry legacy v2 status field names"
     narrative: |
       Call get_adcp_capabilities and verify the response envelope carries the
-      canonical v3 status field. The complementary absence assertions for
-      task_status and response_status require field_absent runner support
-      (see TODO comments on the validation steps below).
+      canonical v3 status field and omits the legacy v2 field names
+      task_status and response_status.
 
     steps:
       - id: no_legacy_status_fields
@@ -106,16 +102,12 @@ phases:
           - check: envelope_field_present
             path: "status"
             description: "Envelope carries the canonical v3 status field"
-          # TODO: restore these as field_absent checks once @adcp/client runner ships
-          # the field_absent check type. Until then, the schema-level not: {} constraint
-          # in protocol-envelope.json is the enforcement path for schema-aware validators.
-          #
-          # - check: field_absent
-          #   path: "task_status"
-          #   description: "Envelope root MUST NOT carry task_status (v2 legacy; no v3 semantics)"
-          # - check: field_absent
-          #   path: "response_status"
-          #   description: "Envelope root MUST NOT carry response_status (v2 legacy; no v3 semantics)"
+          - check: envelope_field_absent
+            path: "task_status"
+            description: "Envelope root MUST NOT carry task_status (v2 legacy; no v3 semantics)"
+          - check: envelope_field_absent
+            path: "response_status"
+            description: "Envelope root MUST NOT carry response_status (v2 legacy; no v3 semantics)"
           - check: field_present
             path: "context"
             description: "Response echoes back the context object"

--- a/static/compliance/source/universal/version-negotiation.yaml
+++ b/static/compliance/source/universal/version-negotiation.yaml
@@ -114,7 +114,7 @@ phases:
               reason: "Per docs/reference/versioning.mdx > Migration timeline, sellers SHOULD declare supported_versions at 3.1 and the compliance grader reports presence as advisory. At 3.2 the storyboard cut promotes this validation to required (manual flip — not gated on runner_capability_version because the 3.2 boundary is a protocol-spec cutover, not a runner-capability cutover). 4.0 promotes to MUST per the spec. Marking permanent_advisory here is a deliberate use of the field to defer promotion to the 3.2 storyboard PR rather than relying on the expires_after_version semver gate."
             description: "Seller advertises release-precision supported_versions (advisory at 3.1, required at 3.2)"
 
-          - check: envelope_field_present
+          - check: field_present
             path: "adcp_version"
             severity: advisory
             permanent_advisory:

--- a/tests/lint-storyboard-contradictions.test.cjs
+++ b/tests/lint-storyboard-contradictions.test.cjs
@@ -174,6 +174,16 @@ test('classifyOutcome treats envelope_field_present as success assertion', () =>
   assert.equal(outcome.kind, 'success');
 });
 
+test('classifyOutcome treats envelope_field_absent alone as unspecified', () => {
+  const step = {
+    validations: [
+      { check: 'envelope_field_absent', path: 'task_status' },
+    ],
+  };
+  const outcome = classifyOutcome(step);
+  assert.equal(outcome.kind, 'unspecified');
+});
+
 test('outcomesAgree: error sets with overlap agree, disjoint disagree', () => {
   const a = { kind: 'error', codes: new Set(['X', 'Y']) };
   const b = { kind: 'error', codes: new Set(['Y', 'Z']) };

--- a/tests/lint-storyboard-validations-paths.test.cjs
+++ b/tests/lint-storyboard-validations-paths.test.cjs
@@ -201,6 +201,90 @@ test('envelope-aware resolution: replayed and adcp_error resolve via protocol-en
   );
 });
 
+test('source tree allows envelope_field_absent for protocol-envelope forbidden fields', () => {
+  const violations = lintDoc({
+    phases: [
+      {
+        id: 'p',
+        steps: [
+          {
+            id: 's',
+            task: 'get_adcp_capabilities',
+            response_schema_ref: 'protocol/get-adcp-capabilities-response.json',
+            validations: [
+              {
+                check: 'envelope_field_absent',
+                path: 'task_status',
+                description: 'legacy v2 field must be absent',
+              },
+              {
+                check: 'envelope_field_absent',
+                path: 'response_status',
+                description: 'legacy v2 field must be absent',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  }, '/synth/envelope-absent.yaml');
+  assert.deepEqual(violations, []);
+});
+
+test('field_absent does not use the envelope-forbidden exemption', () => {
+  const violations = lintDoc({
+    phases: [
+      {
+        id: 'p',
+        steps: [
+          {
+            id: 's',
+            task: 'get_adcp_capabilities',
+            response_schema_ref: 'protocol/get-adcp-capabilities-response.json',
+            validations: [
+              {
+                check: 'field_absent',
+                path: 'task_status',
+                description: 'wrong check kind for an envelope field',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  }, '/synth/envelope-absent-wrong-kind.yaml');
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].rule, 'path_not_in_schema');
+  assert.equal(violations[0].check, 'field_absent');
+});
+
+test('envelope_field_absent does not accept payload-only paths', () => {
+  const violations = lintDoc({
+    phases: [
+      {
+        id: 'p',
+        steps: [
+          {
+            id: 's',
+            task: 'get_adcp_capabilities',
+            response_schema_ref: 'protocol/get-adcp-capabilities-response.json',
+            validations: [
+              {
+                check: 'envelope_field_absent',
+                path: 'adcp',
+                description: 'payload field is not an envelope field',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  }, '/synth/envelope-absent-payload-path.yaml');
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].rule, 'path_not_in_schema');
+  assert.equal(violations[0].check, 'envelope_field_absent');
+});
+
 test('isEnvelopeProperty identifies envelope fields', () => {
   assert.equal(isEnvelopeProperty('replayed'), true);
   assert.equal(isEnvelopeProperty('adcp_error'), true);
@@ -226,6 +310,8 @@ test('PATH_BEARING_CHECKS is the documented set', () => {
   assert.ok(PATH_BEARING_CHECKS.has('field_value'));
   assert.ok(PATH_BEARING_CHECKS.has('field_value_or_absent'));
   assert.ok(PATH_BEARING_CHECKS.has('field_absent'));
+  assert.ok(PATH_BEARING_CHECKS.has('envelope_field_present'));
+  assert.ok(PATH_BEARING_CHECKS.has('envelope_field_absent'));
   assert.ok(!PATH_BEARING_CHECKS.has('error_code'));
   assert.ok(!PATH_BEARING_CHECKS.has('response_schema'));
 });


### PR DESCRIPTION
## Summary

- Enables live `envelope_field_absent` assertions in `v3_envelope_integrity` for legacy `task_status` / `response_status` fields.
- Adds `envelope_field_absent` to the authored check contract and documents failure `expected` / `actual` semantics.
- Tightens storyboard path linting so envelope-prefixed checks resolve only against `core/protocol-envelope.json`, while preserving response-schema forbidden-field support for plain `field_absent`.
- Corrects `version_negotiation` to use `field_present` for `adcp_version`, which comes from `core/version-envelope.json`, not `core/protocol-envelope.json`.

Fixes #4930.

## Tests

- `npm run test:storyboard-validations-paths`
- `npm run test:storyboard-check-enum`
- `npm run test:storyboard-contradictions`
- `TENANT_PATH=sales npx tsx server/tests/manual/run-storyboards.ts --filter v3_envelope_integrity`
- `npm run test:storyboards`
- `npm run test:storyboards:3.0-compat`
- pre-commit: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run typecheck`
- pre-push: current storyboard matrix and 3.0.12 compatibility matrix
