### PR TITLE
feat(training-agent): seed compliance media buys for demo.example.com

### DIFF
--- a/.changeset/seed-compliance-media-buys.md
+++ b/.changeset/seed-compliance-media-buys.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add pre-seeded media buy fixtures for demo.example.com to the sandbox training agent, so Module B3 can demonstrate get_media_buy_delivery without the learner first creating a buy.

--- a/server/src/training-agent/state.ts
+++ b/server/src/training-agent/state.ts
@@ -234,6 +234,12 @@ export function getComplianceCreative(id: string): CreativeState | undefined {
  * which is intentional — the teaching goal is delivery-metric interpretation,
  * not catalog browsing.
  *
+ * AUTHORING NOTE: storyboard and lesson-plan authors MUST NOT reference the
+ * fixture IDs (seed_mb_display_q2, seed_mb_video_q1) in criterion text or
+ * criterion IDs — only in exercise scaffolds. Embedding a fixture ID in a
+ * criterion string means that renaming a fixture would silently break
+ * recertification triggers without surfacing as a criterion-ID drift.
+ *
  * Two buys cover the two primary B3 lesson states:
  *  - seed_mb_display_q2: active, partial delivery (default status filter)
  *  - seed_mb_video_q1: completed, 100% delivery (requires status_filter: ['completed'])

--- a/server/src/training-agent/state.ts
+++ b/server/src/training-agent/state.ts
@@ -15,7 +15,7 @@
  */
 
 import { AsyncLocalStorage } from 'node:async_hooks';
-import type { SessionState, AccountRef, BrandRef, CreativeState } from './types.js';
+import type { SessionState, AccountRef, BrandRef, CreativeState, MediaBuyState, PackageState } from './types.js';
 import { cleanupExpiredTasks } from '@adcp/sdk';
 import {
   InMemoryStateStore,
@@ -220,6 +220,105 @@ export function getComplianceCreatives(): CreativeState[] {
 
 export function getComplianceCreative(id: string): CreativeState | undefined {
   return getComplianceCreatives().find(c => c.creativeId === id);
+}
+
+/**
+ * Canonical compliance media-buy fixtures for the open sandbox mode.
+ *
+ * Read-through fallback returned by handleGetMediaBuys and
+ * handleGetMediaBuyDelivery when the session has no caller-created buys.
+ * Sessions that already have buys return only those — no mixing.
+ *
+ * Product IDs are training-agent-internal labels that don't resolve against
+ * the live catalog; derivePricing falls back to the default $10 CPM rate,
+ * which is intentional — the teaching goal is delivery-metric interpretation,
+ * not catalog browsing.
+ *
+ * Two buys cover the two primary B3 lesson states:
+ *  - seed_mb_display_q2: active, partial delivery (default status filter)
+ *  - seed_mb_video_q1: completed, 100% delivery (requires status_filter: ['completed'])
+ *
+ * Dates are recomputed on each call so elapsed fractions remain realistic
+ * across server restarts.
+ */
+export function getComplianceMediaBuys(): MediaBuyState[] {
+  const now = Date.now();
+  const iso = (ms: number) => new Date(ms).toISOString();
+  const daysAgo = (n: number) => iso(now - n * 864e5);
+  const daysOut = (n: number) => iso(now + n * 864e5);
+
+  const displayPackage: PackageState = {
+    packageId: 'seed_pkg_display_q2_a',
+    productId: 'seed_product_display',
+    pricingOptionId: 'seed_po_display_cpm',
+    budget: 50000,
+    paused: false,
+    startTime: daysAgo(14),
+    endTime: daysOut(44),
+    creativeAssignments: ['campaign_hero_video'],
+  };
+
+  const socialPackage: PackageState = {
+    packageId: 'seed_pkg_display_q2_b',
+    productId: 'seed_product_social',
+    pricingOptionId: 'seed_po_social_cpm',
+    budget: 25000,
+    paused: false,
+    startTime: daysAgo(14),
+    endTime: daysOut(44),
+    creativeAssignments: ['campaign_hero_video'],
+  };
+
+  const videoPackage: PackageState = {
+    packageId: 'seed_pkg_video_q1_a',
+    productId: 'seed_product_video',
+    pricingOptionId: 'seed_po_video_cpm',
+    budget: 75000,
+    paused: false,
+    startTime: daysAgo(90),
+    endTime: daysAgo(30),
+    creativeAssignments: ['campaign_hero_video'],
+    optimizationGoals: [{ kind: 'metric', metric: 'reach', reach_unit: 'devices' }],
+  };
+
+  const activeBrand: AccountRef = { account_id: 'demo', brand: { domain: 'demo.example.com' } };
+
+  return [
+    {
+      mediaBuyId: 'seed_mb_display_q2',
+      accountRef: activeBrand,
+      brandRef: { domain: 'demo.example.com' },
+      status: 'active',
+      currency: 'USD',
+      packages: [displayPackage, socialPackage],
+      startTime: daysAgo(14),
+      endTime: daysOut(44),
+      revision: 1,
+      confirmedAt: daysAgo(15),
+      createdAt: daysAgo(15),
+      updatedAt: daysAgo(14),
+      history: [],
+    },
+    {
+      mediaBuyId: 'seed_mb_video_q1',
+      accountRef: activeBrand,
+      brandRef: { domain: 'demo.example.com' },
+      status: 'completed',
+      currency: 'USD',
+      packages: [videoPackage],
+      startTime: daysAgo(90),
+      endTime: daysAgo(30),
+      revision: 2,
+      confirmedAt: daysAgo(91),
+      createdAt: daysAgo(91),
+      updatedAt: daysAgo(30),
+      history: [],
+    },
+  ];
+}
+
+export function getComplianceMediaBuy(id: string): MediaBuyState | undefined {
+  return getComplianceMediaBuys().find(mb => mb.mediaBuyId === id);
 }
 
 /**

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -2308,10 +2308,12 @@ export async function handleGetMediaBuys(args: ToolArgs, ctx: TrainingContext) {
   const filterIds = req.media_buy_ids;
 
   let buys = Array.from(session.mediaBuys.values());
-  if (buys.length === 0) {
-    // Empty session: provide compliance fixtures so demo.example.com sessions
-    // show realistic media buy data without the learner first creating a buy.
-    // Sessions that have created their own buys return only those — no mixing.
+  if (!filterIds?.length && buys.length === 0) {
+    // Broad list on an empty session: provide compliance fixtures so demo.example.com
+    // sessions show realistic media buy data without the learner first creating a buy.
+    // ID-lookup paths skip this — loading all fixtures to filter down is wasteful when
+    // the caller already knows the IDs it wants (and unknown IDs should return empty,
+    // not a fixture). Sessions that have created their own buys return only those.
     buys = getComplianceMediaBuys();
   }
   if (filterIds?.length) {

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -183,6 +183,7 @@ import {
   getSession, sessionKeyFromArgs,
   runWithSessionContext, flushDirtySessions,
   getComplianceCreatives, getComplianceCreative,
+  getComplianceMediaBuys, getComplianceMediaBuy,
   MAX_MEDIA_BUYS_PER_SESSION, MAX_CREATIVES_PER_SESSION, MAX_USAGE_RECORDS_PER_SESSION,
 } from './state.js';
 import { getAgentUrl } from './config.js';
@@ -2307,6 +2308,12 @@ export async function handleGetMediaBuys(args: ToolArgs, ctx: TrainingContext) {
   const filterIds = req.media_buy_ids;
 
   let buys = Array.from(session.mediaBuys.values());
+  if (buys.length === 0) {
+    // Empty session: provide compliance fixtures so demo.example.com sessions
+    // show realistic media buy data without the learner first creating a buy.
+    // Sessions that have created their own buys return only those — no mixing.
+    buys = getComplianceMediaBuys();
+  }
   if (filterIds?.length) {
     buys = buys.filter(b => filterIds.includes(b.mediaBuyId));
     // Media buy lookup is scoped to the caller's session (brand/account-derived).
@@ -2445,7 +2452,7 @@ export async function handleGetMediaBuyDelivery(args: ToolArgs, ctx: TrainingCon
   const catalog = getCatalog();
   const productMap = new Map(catalog.map(cp => [cp.product.product_id, cp.product]));
   const mediaBuyId = req.media_buy_id || req.media_buy_ids?.[0] || '';
-  const mb = session.mediaBuys.get(mediaBuyId);
+  const mb = session.mediaBuys.get(mediaBuyId) ?? getComplianceMediaBuy(mediaBuyId);
 
   if (!mb) {
     return {

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -2214,12 +2214,29 @@ describe('get_media_buys handler', () => {
     clearSessions();
   });
 
-  it('returns empty array when no media buys exist', async () => {
+  it('falls back to active compliance media-buy fixtures when no media buys exist', async () => {
+    const account = { brand: { domain: 'demo.example.com' }, operator: 'demo.example.com' };
     const server = createTrainingAgentServer(DEFAULT_CTX);
-    const { result } = await simulateCallTool(server, 'get_media_buys', {});
+    const { result } = await simulateCallTool(server, 'get_media_buys', { account });
 
     expect(Array.isArray(result.media_buys)).toBe(true);
-    expect((result.media_buys as unknown[]).length).toBe(0);
+    const buys = result.media_buys as Array<Record<string, unknown>>;
+    expect(buys.map(b => b.media_buy_id)).toEqual(['seed_mb_display_q2']);
+    expect(buys[0].status).toBe('active');
+  });
+
+  it('skips compliance fixture fallback when media_buy_ids filter is explicit', async () => {
+    const account = { brand: { domain: 'demo.example.com' }, operator: 'demo.example.com' };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { result } = await simulateCallTool(server, 'get_media_buys', {
+      account,
+      media_buy_ids: ['mb_nonexistent'],
+    });
+
+    expect(result.media_buys).toEqual([]);
+    const pg = result.pagination as Record<string, unknown>;
+    expect(pg.has_more).toBe(false);
+    expect(pg.total_count).toBe(0);
   });
 
   it('returns created media buys', async () => {
@@ -3921,6 +3938,25 @@ describe('get_media_buy_delivery handler', () => {
     });
 
     expect(result.code).toBe('MEDIA_BUY_NOT_FOUND');
+  });
+
+  it('falls back to compliance media-buy fixtures for delivery lookups', async () => {
+    const account = { brand: { domain: 'demo.example.com' }, operator: 'demo.example.com' };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { result } = await simulateCallTool(server, 'get_media_buy_delivery', {
+      account,
+      media_buy_id: 'seed_mb_display_q2',
+    });
+
+    expect(result.errors).toBeUndefined();
+    const deliveries = result.media_buy_deliveries as Array<Record<string, unknown>>;
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].media_buy_id).toBe('seed_mb_display_q2');
+    const packages = deliveries[0].by_package as Array<Record<string, unknown>>;
+    expect(packages.map(pkg => pkg.package_id)).toEqual([
+      'seed_pkg_display_q2_a',
+      'seed_pkg_display_q2_b',
+    ]);
   });
 
   it('looks up by media_buy_id', async () => {


### PR DESCRIPTION
Refs #4969

Adds `getComplianceMediaBuys()` and `getComplianceMediaBuy()` to `state.ts`, mirroring the existing `getComplianceCreatives()` read-through fallback pattern, so Module B3 "Measurement, signals, and optimization" can demonstrate `get_media_buy_delivery` without requiring a learner to first create a buy.

Two fixtures are seeded for `demo.example.com`:
- `seed_mb_display_q2`: active, 2 packages (display $50k + social $25k), started 14 days ago — shows realistic partial delivery with per-package CTR variation (social 1.2% vs. display 0.1%)
- `seed_mb_video_q1`: completed, 1 video package ($75k, reach goal), ran 90–30 days ago — shows 100% delivery with reach/frequency metrics; surfaced with `status_filter: ['completed']`

`handleGetMediaBuys` merges fixtures only when the session has zero caller-created buys **and** no explicit `media_buy_ids` filter (broad list path only — mirrors the `handleListCreatives` guard). `handleGetMediaBuyDelivery` falls through to `getComplianceMediaBuy()` when the buy ID isn't in the session, consistent with how `build_creative` / `report_usage` handle compliance creatives. Delivery metrics are computed dynamically from elapsed time × budget so numbers remain realistic across server restarts.

**Non-breaking justification:** read-through fallback fires only when `session.mediaBuys.size === 0` and no ID filter is present; any session with existing buys is unaffected. No protocol schema changes. Changeset is `--empty` (server-side change, not a protocol change per playbook).

**Remaining in #4969:** `by_geo` and `by_device_type` dimension breakdowns are schema-supported but not yet implemented in `handleGetMediaBuyDelivery`. File a follow-up to track that gap. B3 criterion IDs (`b3_delivery_sc0`-style) are also not yet formally registered in the codebase — pre-existing gap, not introduced here.

**Pre-PR review:**
- code-reviewer: approved — one blocker fixed (ID-lookup guard now `!filterIds?.length && buys.length === 0` mirroring `handleListCreatives`); changeset `--empty` confirmed correct; missing delivery-fallback unit test noted as nit consistent with `getComplianceCreatives` precedent
- education-expert: approved — active + completed lifecycle covers B3 assessment exercises; multi-package display/social split makes per-package CTR variation demonstrable; reach goal on video buy correctly surfaces reach/frequency in delivery response; authoring warning comment added to prevent fixture IDs from being embedded in criterion strings

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_014sQHDETuttqxJThnTzsLxp