### PR TITLE
feat(compliance): cover vendor_metric optimization goals

### DIFF
--- a/.changeset/vendor-metric-optimization-storyboard.md
+++ b/.changeset/vendor-metric-optimization-storyboard.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add vendor_metric optimization-goal storyboard coverage (issue #4933). New storyboard exercises the 3.1 vendor_metric goal contract: positive acceptance when all preconditions are met, and negative paths for capability mismatch and reporting-coherence mismatch. Training-agent fixtures now surface vendor_metric_optimization on products.

--- a/.changeset/vendor-metric-optimization-storyboard.md
+++ b/.changeset/vendor-metric-optimization-storyboard.md
@@ -1,4 +1,5 @@
 ---
+"adcontextprotocol": minor
 ---
 
 Add vendor_metric optimization-goal storyboard coverage (issue #4933). New storyboard exercises the 3.1 vendor_metric goal contract: positive acceptance when all preconditions are met, and negative paths for capability mismatch and reporting-coherence mismatch. Training-agent fixtures now surface vendor_metric_optimization on products.

--- a/server/src/training-agent/product-factory.ts
+++ b/server/src/training-agent/product-factory.ts
@@ -562,6 +562,9 @@ function buildProduct(
     } as NonNullable<Product['reporting_capabilities']>,
     ...(pub.catalogTypes?.length && { catalog_types: pub.catalogTypes as CatalogType[] }),
     ...(metricOptimization && { metric_optimization: metricOptimization }),
+    // Vendor-metric optimization is a publisher/inventory capability, not
+    // auction-only. Guaranteed products can still steer allocation/pacing
+    // toward the vendor signal, so do not gate this on delivery_type.
     ...(pub.vendorMetricOptimization && { vendor_metric_optimization: pub.vendorMetricOptimization }),
     ...(forecast && { forecast }),
     ...(conversionTracking && { conversion_tracking: conversionTracking }),

--- a/server/src/training-agent/product-factory.ts
+++ b/server/src/training-agent/product-factory.ts
@@ -562,6 +562,7 @@ function buildProduct(
     } as NonNullable<Product['reporting_capabilities']>,
     ...(pub.catalogTypes?.length && { catalog_types: pub.catalogTypes as CatalogType[] }),
     ...(metricOptimization && { metric_optimization: metricOptimization }),
+    ...(pub.vendorMetricOptimization && { vendor_metric_optimization: pub.vendorMetricOptimization }),
     ...(forecast && { forecast }),
     ...(conversionTracking && { conversion_tracking: conversionTracking }),
     ...(collectionSelectors && { collections: collectionSelectors }),

--- a/server/src/training-agent/publishers.ts
+++ b/server/src/training-agent/publishers.ts
@@ -31,7 +31,17 @@ export const PUBLISHERS: PublisherProfile[] = [
     reportingMetrics: ['impressions', 'spend', 'clicks', 'ctr', 'viewability', 'completed_views', 'completion_rate'],
     vendorMetrics: [
       { vendor: { domain: 'attentionvendor.example' }, metric_id: 'attention_units' },
+      { vendor: { domain: 'attentionvendor.example' }, metric_id: 'attention_score' },
     ],
+    vendorMetricOptimization: {
+      supported_metrics: [
+        {
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'attention_score',
+          supported_targets: ['threshold_rate'],
+        },
+      ],
+    },
     properties: [
       {
         propertyId: 'pinnacle_web',

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -156,6 +156,27 @@ function validateTargeting(t: unknown, pathLabel: string): { targeting?: Package
   };
 }
 
+interface VendorMetricRefView {
+  vendor?: { domain?: unknown; brand_id?: unknown };
+  metric_id?: unknown;
+  supported_targets?: unknown;
+  scope?: unknown;
+}
+
+interface VendorMetricOptimizationView {
+  supported_metrics?: VendorMetricRefView[];
+}
+
+function vendorMetricKey(entry: VendorMetricRefView | undefined): string | null {
+  const domain = entry?.vendor?.domain;
+  const metricId = entry?.metric_id;
+  if (typeof domain !== 'string' || domain.length === 0 || typeof metricId !== 'string' || metricId.length === 0) {
+    return null;
+  }
+  const brandId = typeof entry?.vendor?.brand_id === 'string' ? entry.vendor.brand_id : '';
+  return `${domain.toLowerCase()}|${brandId}|${metricId}`;
+}
+
 // Proposal lifecycle fields not yet in @adcp/sdk — remove after client update
 interface ProposalLifecycle {
   proposal_status?: 'draft' | 'committed';
@@ -1969,6 +1990,78 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
               }] as TaskError[],
             };
           }
+        }
+      }
+    }
+  }
+
+  // Validate vendor_metric optimization_goals against the product's
+  // vendor_metric_optimization declarations and the package's reporting
+  // contract. This goal kind is only meaningful when the seller can both
+  // optimize toward the vendor metric and commit to reporting the same
+  // (vendor, metric_id) key back to the buyer.
+  if (Array.isArray(req.packages)) {
+    for (let i = 0; i < req.packages.length; i++) {
+      const pkg = req.packages[i] as {
+        product_id?: string;
+        optimization_goals?: unknown;
+        committed_metrics?: unknown;
+      };
+      const goals = pkg?.optimization_goals;
+      if (!Array.isArray(goals)) continue;
+      const product = pkg.product_id
+        ? productMap.get(pkg.product_id) as (Product & { vendor_metric_optimization?: VendorMetricOptimizationView }) | undefined
+        : undefined;
+      const supportedMetrics = product?.vendor_metric_optimization?.supported_metrics;
+      const committedMetrics = Array.isArray(pkg.committed_metrics)
+        ? (pkg.committed_metrics as VendorMetricRefView[])
+        : [];
+      for (let j = 0; j < goals.length; j++) {
+        const goal = goals[j] as VendorMetricRefView & { kind?: unknown; target?: { kind?: unknown } };
+        if (goal?.kind !== 'vendor_metric') continue;
+        const key = vendorMetricKey(goal);
+        if (!key) continue;
+
+        const supported = Array.isArray(supportedMetrics)
+          ? supportedMetrics.find(entry => vendorMetricKey(entry) === key)
+          : undefined;
+        if (!supported) {
+          return {
+            errors: [{
+              code: 'INVALID_REQUEST',
+              message: `vendor_metric goal "${goal.metric_id}" is not in product's vendor_metric_optimization.supported_metrics`,
+              field: `packages[${i}].optimization_goals[${j}].metric_id`,
+            }] as TaskError[],
+          };
+        }
+
+        const targetKind = goal.target?.kind;
+        if (typeof targetKind === 'string') {
+          const supportedTargets = Array.isArray(supported.supported_targets)
+            ? supported.supported_targets
+            : [];
+          if (!supportedTargets.includes(targetKind)) {
+            return {
+              errors: [{
+                code: 'INVALID_REQUEST',
+                message: `vendor_metric target.kind "${targetKind}" is not in product's vendor_metric_optimization.supported_targets`,
+                field: `packages[${i}].optimization_goals[${j}].target.kind`,
+              }] as TaskError[],
+            };
+          }
+        }
+
+        const hasCommittedMetric = committedMetrics.some(entry =>
+          entry?.scope === 'vendor' && vendorMetricKey(entry) === key,
+        );
+        if (!hasCommittedMetric) {
+          return {
+            errors: [{
+              code: 'INVALID_REQUEST',
+              message: `vendor_metric goal "${goal.metric_id}" requires a matching vendor-scope committed_metrics entry`,
+              field: `packages[${i}].committed_metrics`,
+            }] as TaskError[],
+          };
         }
       }
     }

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -1026,6 +1026,10 @@ const BRIEF_CHANNEL_ALIASES: Record<string, string> = {
   'radio': 'radio',
 };
 
+// Vendor-metric briefs often ask for a measurement outcome (emissions,
+// brand lift, attention) rather than the literal field name. Give products
+// with vendor_metric_optimization a discovery boost even when the brief does
+// not otherwise share catalog keywords with the product card.
 const VENDOR_METRIC_OPTIMIZATION_BRIEF_TERMS = [
   'attention',
   'vendor',
@@ -1512,10 +1516,17 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext) {
 
     // Cap at top 5 most relevant products so learners see brief mode as curated discovery
     const MAX_BRIEF_RESULTS = 5;
-    products = scored.slice(0, MAX_BRIEF_RESULTS).map(s => ({
-      ...s.product,
-      brief_relevance: `Matches ${s.channelScore > 0 ? `${s.channelScore / 10} channel(s)` : 'keywords only'}${s.vendorMetricScore > 0 ? ' with vendor-metric optimization' : ''}. ${s.product.description}`,
-    }));
+    products = scored.slice(0, MAX_BRIEF_RESULTS).map(s => {
+      const matchParts = [
+        ...(s.channelScore > 0 ? [`${s.channelScore / 10} channel(s)`] : []),
+        ...(s.keywordScore > 0 ? ['keywords'] : []),
+        ...(s.vendorMetricScore > 0 ? ['vendor-metric optimization'] : []),
+      ];
+      return {
+        ...s.product,
+        brief_relevance: `Matches ${matchParts.join(' and ')}. ${s.product.description}`,
+      };
+    });
 
     // If no keyword matches, return top products as suggestions
     if (products.length === 0) {

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -167,6 +167,10 @@ interface VendorMetricOptimizationView {
   supported_metrics?: VendorMetricRefView[];
 }
 
+interface ReportingCapabilitiesView {
+  vendor_metrics?: VendorMetricRefView[];
+}
+
 function vendorMetricKey(entry: VendorMetricRefView | undefined): string | null {
   const domain = entry?.vendor?.domain;
   const metricId = entry?.metric_id;
@@ -1478,8 +1482,12 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext) {
         const channelScore = briefChannels.size > 0
           ? (p.channels?.filter(c => briefChannels.has(c)).length ?? 0) * 10
           : 0;
-        const totalScore = channelScore + keywordScore;
-        return totalScore > 0 ? { product: p, totalScore, channelScore, keywordScore } : null;
+        const wantsVendorMetricOptimization =
+          (briefLower.includes('attention') || briefLower.includes('vendor'))
+          && Boolean((p as Product & { vendor_metric_optimization?: VendorMetricOptimizationView }).vendor_metric_optimization);
+        const vendorMetricScore = wantsVendorMetricOptimization ? 20 : 0;
+        const totalScore = channelScore + keywordScore + vendorMetricScore;
+        return totalScore > 0 ? { product: p, totalScore, channelScore, keywordScore, vendorMetricScore } : null;
       })
       .filter((s): s is NonNullable<typeof s> => s !== null)
       .sort((a, b) => b.totalScore - a.totalScore);
@@ -1488,7 +1496,7 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext) {
     const MAX_BRIEF_RESULTS = 5;
     products = scored.slice(0, MAX_BRIEF_RESULTS).map(s => ({
       ...s.product,
-      brief_relevance: `Matches ${s.channelScore > 0 ? `${s.channelScore / 10} channel(s)` : 'keywords only'}. ${s.product.description}`,
+      brief_relevance: `Matches ${s.channelScore > 0 ? `${s.channelScore / 10} channel(s)` : 'keywords only'}${s.vendorMetricScore > 0 ? ' with vendor-metric optimization' : ''}. ${s.product.description}`,
     }));
 
     // If no keyword matches, return top products as suggestions
@@ -2013,6 +2021,7 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
         ? productMap.get(pkg.product_id) as (Product & { vendor_metric_optimization?: VendorMetricOptimizationView }) | undefined
         : undefined;
       const supportedMetrics = product?.vendor_metric_optimization?.supported_metrics;
+      const reportableMetrics = (product?.reporting_capabilities as ReportingCapabilitiesView | undefined)?.vendor_metrics;
       const committedMetrics = Array.isArray(pkg.committed_metrics)
         ? (pkg.committed_metrics as VendorMetricRefView[])
         : [];
@@ -2028,7 +2037,7 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
         if (!supported) {
           return {
             errors: [{
-              code: 'INVALID_REQUEST',
+              code: 'TERMS_REJECTED',
               message: `vendor_metric goal "${goal.metric_id}" is not in product's vendor_metric_optimization.supported_metrics`,
               field: `packages[${i}].optimization_goals[${j}].metric_id`,
             }] as TaskError[],
@@ -2043,7 +2052,7 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
           if (!supportedTargets.includes(targetKind)) {
             return {
               errors: [{
-                code: 'INVALID_REQUEST',
+                code: 'TERMS_REJECTED',
                 message: `vendor_metric target.kind "${targetKind}" is not in product's vendor_metric_optimization.supported_targets`,
                 field: `packages[${i}].optimization_goals[${j}].target.kind`,
               }] as TaskError[],
@@ -2057,8 +2066,21 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
         if (!hasCommittedMetric) {
           return {
             errors: [{
-              code: 'INVALID_REQUEST',
+              code: 'TERMS_REJECTED',
               message: `vendor_metric goal "${goal.metric_id}" requires a matching vendor-scope committed_metrics entry`,
+              field: `packages[${i}].committed_metrics`,
+            }] as TaskError[],
+          };
+        }
+
+        const hasReportableMetric = Array.isArray(reportableMetrics)
+          ? reportableMetrics.some(entry => vendorMetricKey(entry) === key)
+          : false;
+        if (!hasReportableMetric) {
+          return {
+            errors: [{
+              code: 'TERMS_REJECTED',
+              message: `committed_metrics entry for vendor_metric goal "${goal.metric_id}" is not in product's reporting_capabilities.vendor_metrics`,
               field: `packages[${i}].committed_metrics`,
             }] as TaskError[],
           };
@@ -3379,6 +3401,9 @@ export async function handleGetAdcpCapabilities(_args: ToolArgs, ctx: TrainingCo
         supported_event_types: ['purchase', 'add_to_cart', 'lead', 'page_view'],
         supported_hashed_identifiers: ['hashed_email'],
         supported_action_sources: ['website', 'app'],
+      },
+      vendor_metric_optimization: {
+        supported_targets: ['threshold_rate'],
       },
       // Seller-level rollup of metric-optimization capabilities. Honest
       // union across catalog products (product-factory.ts assigns these

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -1026,6 +1026,20 @@ const BRIEF_CHANNEL_ALIASES: Record<string, string> = {
   'radio': 'radio',
 };
 
+const VENDOR_METRIC_OPTIMIZATION_BRIEF_TERMS = [
+  'attention',
+  'vendor',
+  'emission',
+  'scope3',
+  'carbon',
+  'sustainability',
+  'brand lift',
+  'brand-lift',
+  'awareness',
+  'incremental',
+  'panel',
+];
+
 // ── Shared schema fragments ──────────────────────────────────────
 
 const ACCOUNT_REF_SCHEMA = {
@@ -1482,9 +1496,13 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext) {
         const channelScore = briefChannels.size > 0
           ? (p.channels?.filter(c => briefChannels.has(c)).length ?? 0) * 10
           : 0;
+        const hasVendorMetricOptimization = Boolean(
+          (p as Product & { vendor_metric_optimization?: VendorMetricOptimizationView })
+            .vendor_metric_optimization?.supported_metrics?.length,
+        );
         const wantsVendorMetricOptimization =
-          (briefLower.includes('attention') || briefLower.includes('vendor'))
-          && Boolean((p as Product & { vendor_metric_optimization?: VendorMetricOptimizationView }).vendor_metric_optimization);
+          hasVendorMetricOptimization
+          && VENDOR_METRIC_OPTIMIZATION_BRIEF_TERMS.some(term => briefLower.includes(term));
         const vendorMetricScore = wantsVendorMetricOptimization ? 20 : 0;
         const totalScore = channelScore + keywordScore + vendorMetricScore;
         return totalScore > 0 ? { product: p, totalScore, channelScore, keywordScore, vendorMetricScore } : null;
@@ -2017,6 +2035,9 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
       };
       const goals = pkg?.optimization_goals;
       if (!Array.isArray(goals)) continue;
+      // Product existence is validated later as PRODUCT_NOT_FOUND. This
+      // precondition block mirrors the sibling metric_optimization validator:
+      // a missing product map entry presents here as a capability miss first.
       const product = pkg.product_id
         ? productMap.get(pkg.product_id) as (Product & { vendor_metric_optimization?: VendorMetricOptimizationView }) | undefined
         : undefined;
@@ -2037,6 +2058,11 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
         if (!supported) {
           return {
             errors: [{
+              // Vendor-metric optimization is negotiated against vendor
+              // measurement/reporting terms. The normative docs route
+              // capability and reporting-coherence misses through
+              // TERMS_REJECTED, even though legacy seller-native metric
+              // shape checks above still use INVALID_REQUEST.
               code: 'TERMS_REJECTED',
               message: `vendor_metric goal "${goal.metric_id}" is not in product's vendor_metric_optimization.supported_metrics`,
               field: `packages[${i}].optimization_goals[${j}].metric_id`,
@@ -2044,8 +2070,19 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
           };
         }
 
-        const targetKind = goal.target?.kind;
-        if (typeof targetKind === 'string') {
+        const target = goal.target;
+        if (target !== undefined && (target === null || typeof target !== 'object' || typeof (target as { kind?: unknown }).kind !== 'string')) {
+          return {
+            errors: [{
+              code: 'INVALID_REQUEST',
+              message: 'vendor_metric target.kind is required when target is present',
+              field: `packages[${i}].optimization_goals[${j}].target.kind`,
+            }] as TaskError[],
+          };
+        }
+
+        const targetKind = (target as { kind?: string } | undefined)?.kind;
+        if (targetKind) {
           const supportedTargets = Array.isArray(supported.supported_targets)
             ? supported.supported_targets
             : [];
@@ -2053,7 +2090,7 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
             return {
               errors: [{
                 code: 'TERMS_REJECTED',
-                message: `vendor_metric target.kind "${targetKind}" is not in product's vendor_metric_optimization.supported_targets`,
+                message: `vendor_metric target.kind "${targetKind}" is not in product's vendor_metric_optimization.supported_metrics[].supported_targets`,
                 field: `packages[${i}].optimization_goals[${j}].target.kind`,
               }] as TaskError[],
             };

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -1027,22 +1027,56 @@ const BRIEF_CHANNEL_ALIASES: Record<string, string> = {
 };
 
 // Vendor-metric briefs often ask for a measurement outcome (emissions,
-// brand lift, attention) rather than the literal field name. Give products
-// with vendor_metric_optimization a discovery boost even when the brief does
-// not otherwise share catalog keywords with the product card.
-const VENDOR_METRIC_OPTIMIZATION_BRIEF_TERMS = [
-  'attention',
-  'vendor',
-  'emission',
-  'scope3',
-  'carbon',
-  'sustainability',
-  'brand lift',
-  'brand-lift',
-  'awareness',
-  'incremental',
-  'panel',
-];
+// brand lift, attention) rather than the literal field name. Score against
+// each product's declared vendor metrics so the named vendor/metric pair wins
+// even when the product card text has no ordinary keyword overlap.
+function inferVendorMetricBriefTerms(domain: string, metricId: string): string[] {
+  const identity = `${domain} ${metricId} ${metricId.replace(/[_-]+/g, ' ')}`;
+  const terms = new Set<string>();
+
+  if (/(attention|focus)/.test(identity)) terms.add('attention');
+  if (/(gco2e|co2|carbon|emission|scope3|sustainability)/.test(identity)) {
+    terms.add('emission');
+    terms.add('emissions');
+    terms.add('carbon');
+    terms.add('scope3');
+    terms.add('sustainability');
+  }
+  if (/(brand.?lift|awareness|incremental|panel)/.test(identity)) {
+    terms.add('brand lift');
+    terms.add('brand-lift');
+    terms.add('awareness');
+    terms.add('incremental');
+    terms.add('panel');
+  }
+
+  return [...terms];
+}
+
+function vendorMetricBriefScore(product: Product, briefLower: string): number {
+  const supportedMetrics = (product as Product & { vendor_metric_optimization?: VendorMetricOptimizationView })
+    .vendor_metric_optimization?.supported_metrics;
+  if (!supportedMetrics?.length) return 0;
+
+  let bestScore = 0;
+  for (const metric of supportedMetrics) {
+    const domain = typeof metric.vendor?.domain === 'string' ? metric.vendor.domain.toLowerCase() : '';
+    const metricId = typeof metric.metric_id === 'string' ? metric.metric_id.toLowerCase() : '';
+    const metricPhrase = metricId.replace(/[_-]+/g, ' ');
+    const categoryTerms = inferVendorMetricBriefTerms(domain, metricId);
+
+    let score = 0;
+    if (domain && briefLower.includes(domain)) score += 14;
+    if (metricId && (briefLower.includes(metricId) || briefLower.includes(metricPhrase))) score += 14;
+    if (categoryTerms.some(term => briefLower.includes(term))) {
+      score += 6;
+    }
+    if (briefLower.includes('vendor metric') || briefLower.includes('vendor-metric')) score += 2;
+    bestScore = Math.max(bestScore, score);
+  }
+
+  return bestScore;
+}
 
 // ── Shared schema fragments ──────────────────────────────────────
 
@@ -1500,14 +1534,7 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext) {
         const channelScore = briefChannels.size > 0
           ? (p.channels?.filter(c => briefChannels.has(c)).length ?? 0) * 10
           : 0;
-        const hasVendorMetricOptimization = Boolean(
-          (p as Product & { vendor_metric_optimization?: VendorMetricOptimizationView })
-            .vendor_metric_optimization?.supported_metrics?.length,
-        );
-        const wantsVendorMetricOptimization =
-          hasVendorMetricOptimization
-          && VENDOR_METRIC_OPTIMIZATION_BRIEF_TERMS.some(term => briefLower.includes(term));
-        const vendorMetricScore = wantsVendorMetricOptimization ? 20 : 0;
+        const vendorMetricScore = vendorMetricBriefScore(p, briefLower);
         const totalScore = channelScore + keywordScore + vendorMetricScore;
         return totalScore > 0 ? { product: p, totalScore, channelScore, keywordScore, vendorMetricScore } : null;
       })
@@ -2046,22 +2073,31 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
       };
       const goals = pkg?.optimization_goals;
       if (!Array.isArray(goals)) continue;
-      // Product existence is validated later as PRODUCT_NOT_FOUND. This
-      // precondition block mirrors the sibling metric_optimization validator:
-      // a missing product map entry presents here as a capability miss first.
       const product = pkg.product_id
         ? productMap.get(pkg.product_id) as (Product & { vendor_metric_optimization?: VendorMetricOptimizationView }) | undefined
         : undefined;
+      if (!product) continue;
       const supportedMetrics = product?.vendor_metric_optimization?.supported_metrics;
       const reportableMetrics = (product?.reporting_capabilities as ReportingCapabilitiesView | undefined)?.vendor_metrics;
       const committedMetrics = Array.isArray(pkg.committed_metrics)
         ? (pkg.committed_metrics as VendorMetricRefView[])
         : [];
       for (let j = 0; j < goals.length; j++) {
-        const goal = goals[j] as VendorMetricRefView & { kind?: unknown; target?: { kind?: unknown } };
+        const goal = goals[j] as VendorMetricRefView & { kind?: unknown; target?: { kind?: unknown; value?: unknown } };
         if (goal?.kind !== 'vendor_metric') continue;
         const key = vendorMetricKey(goal);
-        if (!key) continue;
+        if (!key) {
+          const field = typeof goal?.vendor?.domain !== 'string' || goal.vendor.domain.length === 0
+            ? `packages[${i}].optimization_goals[${j}].vendor.domain`
+            : `packages[${i}].optimization_goals[${j}].metric_id`;
+          return {
+            errors: [{
+              code: 'INVALID_REQUEST',
+              message: 'vendor_metric goal requires non-empty vendor.domain and metric_id',
+              field,
+            }] as TaskError[],
+          };
+        }
 
         const supported = Array.isArray(supportedMetrics)
           ? supportedMetrics.find(entry => vendorMetricKey(entry) === key)
@@ -2092,7 +2128,18 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
           };
         }
 
-        const targetKind = (target as { kind?: string } | undefined)?.kind;
+        const targetKind = (target as { kind?: string; value?: unknown } | undefined)?.kind;
+        const targetValue = (target as { value?: unknown } | undefined)?.value;
+        if (target !== undefined && (typeof targetValue !== 'number' || !Number.isFinite(targetValue) || targetValue <= 0)) {
+          return {
+            errors: [{
+              code: 'INVALID_REQUEST',
+              message: 'vendor_metric target.value must be a positive number when target is present',
+              field: `packages[${i}].optimization_goals[${j}].target.value`,
+            }] as TaskError[],
+          };
+        }
+
         if (targetKind) {
           const supportedTargets = Array.isArray(supported.supported_targets)
             ? supported.supported_targets

--- a/server/src/training-agent/types.ts
+++ b/server/src/training-agent/types.ts
@@ -97,6 +97,14 @@ export interface PublisherProfile {
     vendor: { domain: string; brand_id?: string };
     metric_id: string;
   }>;
+  /** Optional: vendor-defined metrics this publisher can optimize against */
+  vendorMetricOptimization?: {
+    supported_metrics: Array<{
+      vendor: { domain: string; brand_id?: string };
+      metric_id: string;
+      supported_targets?: Array<'cost_per' | 'threshold_rate'>;
+    }>;
+  };
   /** Optional: shows this publisher carries */
   shows?: ShowDefinition[];
   /** Hero image URL for product and proposal cards */

--- a/server/src/training-agent/v6-sales-platform.ts
+++ b/server/src/training-agent/v6-sales-platform.ts
@@ -188,6 +188,9 @@ export class TrainingSalesPlatform
     // the SDK ships the seller-level field; until then both surfaces
     // declare it manually for parity.
     supported_optimization_metrics: ['clicks' as const, 'views' as const, 'completed_views' as const, 'engagements' as const, 'reach' as const],
+    vendor_metric_optimization: {
+      supported_targets: ['threshold_rate' as const],
+    },
     supportedBillings: ['agent', 'operator'] as const,
     // Auto-derives `compliance_testing.scenarios[]` from the adapters
     // wired in `serverOptions.complyTest`. Empty block opts in; the

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -1898,9 +1898,14 @@ describe('create_media_buy handler', () => {
       }).vendor_metric_optimization?.supported_metrics;
       if (supported?.some(entry => entry.metric_id === 'attention_score')) {
         const pricingOptions = cp.product.pricing_options as Array<Record<string, unknown>>;
+        const pricingOption = pricingOptions.find(option => {
+          const floor = typeof option.floor_price === 'number' ? option.floor_price : 0;
+          const minSpend = typeof option.min_spend_per_package === 'number' ? option.min_spend_per_package : 0;
+          return floor <= 5 && minSpend <= 10000;
+        }) ?? pricingOptions[0];
         return {
           productId: cp.product.product_id as string,
-          pricingOptionId: pricingOptions[0].pricing_option_id as string,
+          pricingOptionId: pricingOption.pricing_option_id as string,
         };
       }
     }
@@ -2067,6 +2072,38 @@ describe('create_media_buy handler', () => {
           vendor: { domain: 'attentionvendor.example' },
           metric_id: 'attention_score',
           target: { kind: 'threshold_rate', value: 70 },
+        }],
+        committed_metrics: [{
+          scope: 'vendor',
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'attention_score',
+        }],
+      }],
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(typeof result.media_buy_id).toBe('string');
+  });
+
+  it('accepts vendor_metric optimization_goal without a target as maximize-within-budget', async () => {
+    const { productId, pricingOptionId } = findProductWithVendorMetric();
+    const account = { brand: { domain: 'targetless-vendor-goal.example' }, operator: 'targetless-vendor-goal.example' };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    const { result } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'targetless-vendor-goal.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 10000,
+        bid_price: 5.0,
+        optimization_goals: [{
+          kind: 'vendor_metric',
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'attention_score',
         }],
         committed_metrics: [{
           scope: 'vendor',
@@ -2260,6 +2297,39 @@ describe('create_media_buy handler', () => {
     expect(result.code).toBe('TERMS_REJECTED');
     expect(result.field).toBe('packages[0].optimization_goals[0].target.kind');
     expect((result.message as string).includes('cost_per')).toBe(true);
+  });
+
+  it('rejects vendor_metric optimization_goal when target is present without kind', async () => {
+    const { productId, pricingOptionId } = findProductWithVendorMetric();
+    const account = { brand: { domain: 'malformed-vendor-target.example' }, operator: 'malformed-vendor-target.example' };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    const { result } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'malformed-vendor-target.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 10000,
+        bid_price: 5.0,
+        optimization_goals: [{
+          kind: 'vendor_metric',
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'attention_score',
+          target: {},
+        }],
+        committed_metrics: [{
+          scope: 'vendor',
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'attention_score',
+        }],
+      }],
+    });
+
+    expect(result.code).toBe('INVALID_REQUEST');
+    expect(result.field).toBe('packages[0].optimization_goals[0].target.kind');
   });
 });
 

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -1907,6 +1907,36 @@ describe('create_media_buy handler', () => {
     throw new Error('No catalog product supports vendor_metric attention_score');
   }
 
+  async function seedVendorMetricProduct(
+    server: ReturnType<typeof createTrainingAgentServer>,
+    account: Record<string, unknown>,
+    productId: string,
+    fixture: Record<string, unknown>,
+  ): Promise<void> {
+    const seedProduct = await simulateCallTool(server, 'comply_test_controller', {
+      account,
+      brand: { domain: 'vendor-metric-seed.example' },
+      scenario: 'seed_product',
+      params: {
+        product_id: productId,
+        fixture,
+      },
+    });
+    expect(seedProduct.result.success).toBe(true);
+
+    const seedPricing = await simulateCallTool(server, 'comply_test_controller', {
+      account,
+      brand: { domain: 'vendor-metric-seed.example' },
+      scenario: 'seed_pricing_option',
+      params: {
+        product_id: productId,
+        pricing_option_id: `${productId}_cpm`,
+        fixture: { pricing_model: 'cpm', currency: 'USD', fixed_price: 12 },
+      },
+    });
+    expect(seedPricing.result.success).toBe(true);
+  }
+
   it('rejects reach optimization_goal with reach_unit not in product supported_reach_units', async () => {
     const { productId, pricingOptionId } = findProductWithMetric('reach');
     const account = { brand: { domain: 'phantom-reach.example' }, operator: 'phantom-reach.example' };
@@ -2050,6 +2080,45 @@ describe('create_media_buy handler', () => {
     expect(typeof result.media_buy_id).toBe('string');
   });
 
+  it('surfaces vendor_metric_optimization products first for an attention brief', async () => {
+    const account = { brand: { domain: 'discover-vendor-goal.example' }, operator: 'discover-vendor-goal.example', sandbox: true };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    await seedVendorMetricProduct(server, account, 'display_vendor_metric_opt_unit', {
+      name: 'Display Vendor Metric Optimization',
+      description: 'Display inventory optimized to attentionvendor.example attention_score using a threshold rate.',
+      delivery_type: 'non_guaranteed',
+      channels: ['display'],
+      reporting_capabilities: {
+        available_metrics: ['impressions', 'clicks', 'spend'],
+        vendor_metrics: [{
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'attention_score',
+        }],
+      },
+      vendor_metric_optimization: {
+        supported_metrics: [{
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'attention_score',
+          supported_targets: ['threshold_rate'],
+        }],
+      },
+    });
+
+    const { result } = await simulateCallTool(server, 'get_products', {
+      account,
+      brand: { domain: 'discover-vendor-goal.example' },
+      buying_mode: 'brief',
+      brief: 'Find display inventory that can optimize to the attentionvendor.example attention_score vendor metric using a 70 percent threshold rate, and report that same vendor metric after delivery.',
+      filters: { channels: ['display'] },
+    });
+
+    const firstProduct = (result.products as Array<Record<string, unknown>>)[0] as {
+      vendor_metric_optimization?: { supported_metrics?: Array<{ metric_id?: string }> };
+    };
+    expect(firstProduct.vendor_metric_optimization?.supported_metrics?.some(entry => entry.metric_id === 'attention_score')).toBe(true);
+  });
+
   it('rejects vendor_metric optimization_goal whose metric is not in supported_metrics', async () => {
     const { productId, pricingOptionId } = findProductWithVendorMetric();
     const account = { brand: { domain: 'phantom-vendor-goal.example' }, operator: 'phantom-vendor-goal.example' };
@@ -2068,19 +2137,19 @@ describe('create_media_buy handler', () => {
         optimization_goals: [{
           kind: 'vendor_metric',
           vendor: { domain: 'attentionvendor.example' },
-          metric_id: 'emissions_score',
+          metric_id: 'attention_units',
         }],
         committed_metrics: [{
           scope: 'vendor',
           vendor: { domain: 'attentionvendor.example' },
-          metric_id: 'emissions_score',
+          metric_id: 'attention_units',
         }],
       }],
     });
 
-    expect(result.code).toBe('INVALID_REQUEST');
+    expect(result.code).toBe('TERMS_REJECTED');
     expect(result.field).toBe('packages[0].optimization_goals[0].metric_id');
-    expect((result.message as string).includes('emissions_score')).toBe(true);
+    expect((result.message as string).includes('attention_units')).toBe(true);
   });
 
   it('rejects vendor_metric optimization_goal without matching committed metric', async () => {
@@ -2107,9 +2176,56 @@ describe('create_media_buy handler', () => {
       }],
     });
 
-    expect(result.code).toBe('INVALID_REQUEST');
+    expect(result.code).toBe('TERMS_REJECTED');
     expect(result.field).toBe('packages[0].committed_metrics');
     expect((result.message as string).includes('committed_metrics')).toBe(true);
+  });
+
+  it('rejects vendor_metric optimization_goal when the metric is optimizable but not reportable', async () => {
+    const account = { brand: { domain: 'unreportable-vendor-goal.example' }, operator: 'unreportable-vendor-goal.example', sandbox: true };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    await seedVendorMetricProduct(server, account, 'unreportable_vendor_metric_opt', {
+      delivery_type: 'non_guaranteed',
+      channels: ['display'],
+      reporting_capabilities: {
+        available_metrics: ['impressions', 'spend'],
+      },
+      vendor_metric_optimization: {
+        supported_metrics: [{
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'attention_score',
+          supported_targets: ['threshold_rate'],
+        }],
+      },
+    });
+
+    const { result } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'unreportable-vendor-goal.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: 'unreportable_vendor_metric_opt',
+        pricing_option_id: 'unreportable_vendor_metric_opt_cpm',
+        budget: 10000,
+        bid_price: 5.0,
+        optimization_goals: [{
+          kind: 'vendor_metric',
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'attention_score',
+          target: { kind: 'threshold_rate', value: 70 },
+        }],
+        committed_metrics: [{
+          scope: 'vendor',
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'attention_score',
+        }],
+      }],
+    });
+
+    expect(result.code).toBe('TERMS_REJECTED');
+    expect(result.field).toBe('packages[0].committed_metrics');
+    expect((result.message as string).includes('reporting_capabilities.vendor_metrics')).toBe(true);
   });
 
   it('rejects vendor_metric optimization_goal with unsupported target kind', async () => {
@@ -2141,7 +2257,7 @@ describe('create_media_buy handler', () => {
       }],
     });
 
-    expect(result.code).toBe('INVALID_REQUEST');
+    expect(result.code).toBe('TERMS_REJECTED');
     expect(result.field).toBe('packages[0].optimization_goals[0].target.kind');
     expect((result.message as string).includes('cost_per')).toBe(true);
   });

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -29,6 +29,7 @@ import {
   HUMAN_REVIEW_CATEGORIES,
   HUMAN_REVIEW_POLICY_IDS,
 } from '../../src/training-agent/governance-handlers.js';
+import { TrainingSalesPlatform } from '../../src/training-agent/v6-sales-platform.js';
 
 // Valid channels per the enum schema at static/schemas/source/enums/channels.json
 const VALID_CHANNELS = [
@@ -1128,6 +1129,10 @@ describe('createTrainingAgentServer', () => {
     // Removed seller-level reporting (product-level is source of truth)
     expect(mediaBuy).not.toHaveProperty('reporting');
 
+    expect(mediaBuy.vendor_metric_optimization).toEqual({
+      supported_targets: ['threshold_rate'],
+    });
+
     // account required for media_buy sellers
     expect(caps.account).toBeDefined();
     const account = caps.account as Record<string, unknown>;
@@ -1135,6 +1140,13 @@ describe('createTrainingAgentServer', () => {
 
     // portfolio present
     expect(mediaBuy.portfolio).toBeDefined();
+  });
+
+  it('keeps v6 sales vendor_metric_optimization capabilities aligned with legacy discovery', () => {
+    const platform = new TrainingSalesPlatform();
+    expect((platform.capabilities as Record<string, unknown>).vendor_metric_optimization).toEqual({
+      supported_targets: ['threshold_rate'],
+    });
   });
 
   it('returns error for unknown tool', async () => {
@@ -2117,13 +2129,193 @@ describe('create_media_buy handler', () => {
     expect(typeof result.media_buy_id).toBe('string');
   });
 
+  it('keeps unknown vendor_metric product_id on the normal product-not-found path', async () => {
+    const account = { brand: { domain: 'unknown-product-vendor-goal.example' }, operator: 'unknown-product-vendor-goal.example' };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    const { result } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'unknown-product-vendor-goal.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: 'missing_vendor_metric_product',
+        pricing_option_id: 'missing_vendor_metric_price',
+        budget: 10000,
+        bid_price: 5.0,
+        optimization_goals: [{
+          kind: 'vendor_metric',
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'attention_score',
+          target: { kind: 'threshold_rate', value: 70 },
+        }],
+        committed_metrics: [{
+          scope: 'vendor',
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'attention_score',
+        }],
+      }],
+    });
+
+    expect(result.code).toBe('PRODUCT_NOT_FOUND');
+  });
+
+  it.each([
+    {
+      name: 'missing vendor.domain',
+      goal: { kind: 'vendor_metric', metric_id: 'attention_score' },
+      field: 'packages[0].optimization_goals[0].vendor.domain',
+    },
+    {
+      name: 'empty vendor.domain',
+      goal: { kind: 'vendor_metric', vendor: { domain: '' }, metric_id: 'attention_score' },
+      field: 'packages[0].optimization_goals[0].vendor.domain',
+    },
+    {
+      name: 'missing metric_id',
+      goal: { kind: 'vendor_metric', vendor: { domain: 'attentionvendor.example' } },
+      field: 'packages[0].optimization_goals[0].metric_id',
+    },
+  ])('rejects malformed vendor_metric optimization_goal: $name', async ({ goal, field }) => {
+    const { productId, pricingOptionId } = findProductWithVendorMetric();
+    const account = { brand: { domain: 'malformed-vendor-goal.example' }, operator: 'malformed-vendor-goal.example' };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    const { result } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'malformed-vendor-goal.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 10000,
+        bid_price: 5.0,
+        optimization_goals: [goal],
+        committed_metrics: [{
+          scope: 'vendor',
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'attention_score',
+        }],
+      }],
+    });
+
+    expect(result.code).toBe('INVALID_REQUEST');
+    expect(result.field).toBe(field);
+  });
+
   it('surfaces vendor_metric_optimization products first for an attention brief', async () => {
     const account = { brand: { domain: 'discover-vendor-goal.example' }, operator: 'discover-vendor-goal.example', sandbox: true };
     const server = createTrainingAgentServer(DEFAULT_CTX);
 
+    await seedVendorMetricProduct(server, account, 'display_vendor_metric_scope3_unit', {
+      name: 'Display Vendor Metric Optimization',
+      description: 'Display inventory with third-party metric optimization.',
+      delivery_type: 'non_guaranteed',
+      channels: ['display'],
+      reporting_capabilities: {
+        available_metrics: ['impressions', 'clicks', 'spend'],
+        vendor_metrics: [{
+          vendor: { domain: 'scope3.example' },
+          metric_id: 'gco2e_per_impression',
+        }],
+      },
+      vendor_metric_optimization: {
+        supported_metrics: [{
+          vendor: { domain: 'scope3.example' },
+          metric_id: 'gco2e_per_impression',
+          supported_targets: ['threshold_rate'],
+        }],
+      },
+    });
+
+    await seedVendorMetricProduct(server, account, 'display_vendor_metric_multi_unit', {
+      name: 'Display Vendor Metric Optimization',
+      description: 'Display inventory with third-party metric optimization.',
+      delivery_type: 'non_guaranteed',
+      channels: ['display'],
+      reporting_capabilities: {
+        available_metrics: ['impressions', 'clicks', 'spend'],
+        vendor_metrics: [
+          {
+            vendor: { domain: 'customattention.example' },
+            metric_id: 'view_quality',
+          },
+          {
+            vendor: { domain: 'customattention.example' },
+            metric_id: 'screen_focus',
+          },
+          {
+            vendor: { domain: 'customattention.example' },
+            metric_id: 'dwell_index',
+          },
+        ],
+      },
+      vendor_metric_optimization: {
+        supported_metrics: [
+          {
+            vendor: { domain: 'customattention.example' },
+            metric_id: 'view_quality',
+            supported_targets: ['threshold_rate'],
+          },
+          {
+            vendor: { domain: 'customattention.example' },
+            metric_id: 'screen_focus',
+            supported_targets: ['threshold_rate'],
+          },
+          {
+            vendor: { domain: 'customattention.example' },
+            metric_id: 'dwell_index',
+            supported_targets: ['threshold_rate'],
+          },
+        ],
+      },
+    });
+
     await seedVendorMetricProduct(server, account, 'display_vendor_metric_opt_unit', {
       name: 'Display Vendor Metric Optimization',
-      description: 'Display inventory optimized to attentionvendor.example attention_score using a threshold rate.',
+      description: 'Display inventory with third-party metric optimization.',
+      delivery_type: 'non_guaranteed',
+      channels: ['display'],
+      reporting_capabilities: {
+        available_metrics: ['impressions', 'clicks', 'spend'],
+        vendor_metrics: [{
+          vendor: { domain: 'customattention.example' },
+          metric_id: 'focus_depth',
+        }],
+      },
+      vendor_metric_optimization: {
+        supported_metrics: [{
+          vendor: { domain: 'customattention.example' },
+          metric_id: 'focus_depth',
+          supported_targets: ['threshold_rate'],
+        }],
+      },
+    });
+
+    const { result } = await simulateCallTool(server, 'get_products', {
+      account,
+      brand: { domain: 'discover-vendor-goal.example' },
+      buying_mode: 'brief',
+      brief: 'Find display inventory that can optimize to the customattention.example focus_depth vendor metric using a 70 percent threshold rate, and report that same vendor metric after delivery.',
+      filters: { channels: ['display'] },
+    });
+
+    const firstProduct = (result.products as Array<Record<string, unknown>>)[0] as {
+      vendor_metric_optimization?: { supported_metrics?: Array<{ vendor?: { domain?: string }; metric_id?: string }> };
+    };
+    expect(firstProduct.vendor_metric_optimization?.supported_metrics?.some(entry =>
+      entry.vendor?.domain === 'customattention.example' && entry.metric_id === 'focus_depth',
+    )).toBe(true);
+  });
+
+  it('surfaces emissions vendor_metric_optimization products for a generic emissions brief', async () => {
+    const account = { brand: { domain: 'discover-emissions-vendor-goal.example' }, operator: 'discover-emissions-vendor-goal.example', sandbox: true };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    await seedVendorMetricProduct(server, account, 'display_vendor_metric_attention_unit', {
+      name: 'Display Vendor Metric Optimization',
+      description: 'Display inventory with third-party metric optimization.',
       delivery_type: 'non_guaranteed',
       channels: ['display'],
       reporting_capabilities: {
@@ -2142,18 +2334,41 @@ describe('create_media_buy handler', () => {
       },
     });
 
+    await seedVendorMetricProduct(server, account, 'display_vendor_metric_emissions_unit', {
+      name: 'Display Vendor Metric Optimization',
+      description: 'Display inventory with third-party metric optimization.',
+      delivery_type: 'non_guaranteed',
+      channels: ['display'],
+      reporting_capabilities: {
+        available_metrics: ['impressions', 'clicks', 'spend'],
+        vendor_metrics: [{
+          vendor: { domain: 'scope3.example' },
+          metric_id: 'gco2e_per_impression',
+        }],
+      },
+      vendor_metric_optimization: {
+        supported_metrics: [{
+          vendor: { domain: 'scope3.example' },
+          metric_id: 'gco2e_per_impression',
+          supported_targets: ['threshold_rate'],
+        }],
+      },
+    });
+
     const { result } = await simulateCallTool(server, 'get_products', {
       account,
-      brand: { domain: 'discover-vendor-goal.example' },
+      brand: { domain: 'discover-emissions-vendor-goal.example' },
       buying_mode: 'brief',
-      brief: 'Find display inventory that can optimize to the attentionvendor.example attention_score vendor metric using a 70 percent threshold rate, and report that same vendor metric after delivery.',
+      brief: 'Find display inventory that can optimize to an emissions vendor metric and report that metric after delivery.',
       filters: { channels: ['display'] },
     });
 
     const firstProduct = (result.products as Array<Record<string, unknown>>)[0] as {
-      vendor_metric_optimization?: { supported_metrics?: Array<{ metric_id?: string }> };
+      vendor_metric_optimization?: { supported_metrics?: Array<{ vendor?: { domain?: string }; metric_id?: string }> };
     };
-    expect(firstProduct.vendor_metric_optimization?.supported_metrics?.some(entry => entry.metric_id === 'attention_score')).toBe(true);
+    expect(firstProduct.vendor_metric_optimization?.supported_metrics?.some(entry =>
+      entry.vendor?.domain === 'scope3.example' && entry.metric_id === 'gco2e_per_impression',
+    )).toBe(true);
   });
 
   it('rejects vendor_metric optimization_goal whose metric is not in supported_metrics', async () => {
@@ -2330,6 +2545,48 @@ describe('create_media_buy handler', () => {
 
     expect(result.code).toBe('INVALID_REQUEST');
     expect(result.field).toBe('packages[0].optimization_goals[0].target.kind');
+  });
+
+  it.each([
+    {
+      name: 'missing value',
+      target: { kind: 'threshold_rate' },
+    },
+    {
+      name: 'negative value',
+      target: { kind: 'threshold_rate', value: -1 },
+    },
+  ])('rejects vendor_metric optimization_goal when target has $name', async ({ target }) => {
+    const { productId, pricingOptionId } = findProductWithVendorMetric();
+    const account = { brand: { domain: 'malformed-vendor-target-value.example' }, operator: 'malformed-vendor-target-value.example' };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    const { result } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'malformed-vendor-target-value.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 10000,
+        bid_price: 5.0,
+        optimization_goals: [{
+          kind: 'vendor_metric',
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'attention_score',
+          target,
+        }],
+        committed_metrics: [{
+          scope: 'vendor',
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'attention_score',
+        }],
+      }],
+    });
+
+    expect(result.code).toBe('INVALID_REQUEST');
+    expect(result.field).toBe('packages[0].optimization_goals[0].target.value');
   });
 });
 

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -1890,6 +1890,23 @@ describe('create_media_buy handler', () => {
     throw new Error(`No catalog product supports ${metric}`);
   }
 
+  function findProductWithVendorMetric(): { productId: string; pricingOptionId: string } {
+    const catalog = buildCatalog();
+    for (const cp of catalog) {
+      const supported = (cp.product as {
+        vendor_metric_optimization?: { supported_metrics?: Array<{ metric_id?: string }> };
+      }).vendor_metric_optimization?.supported_metrics;
+      if (supported?.some(entry => entry.metric_id === 'attention_score')) {
+        const pricingOptions = cp.product.pricing_options as Array<Record<string, unknown>>;
+        return {
+          productId: cp.product.product_id as string,
+          pricingOptionId: pricingOptions[0].pricing_option_id as string,
+        };
+      }
+    }
+    throw new Error('No catalog product supports vendor_metric attention_score');
+  }
+
   it('rejects reach optimization_goal with reach_unit not in product supported_reach_units', async () => {
     const { productId, pricingOptionId } = findProductWithMetric('reach');
     const account = { brand: { domain: 'phantom-reach.example' }, operator: 'phantom-reach.example' };
@@ -1998,6 +2015,135 @@ describe('create_media_buy handler', () => {
 
     expect(result.errors).toBeUndefined();
     expect(typeof result.media_buy_id).toBe('string');
+  });
+
+  it('accepts vendor_metric optimization_goal with matching capability and committed metric', async () => {
+    const { productId, pricingOptionId } = findProductWithVendorMetric();
+    const account = { brand: { domain: 'bound-vendor-goal.example' }, operator: 'bound-vendor-goal.example' };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    const { result } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'bound-vendor-goal.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 10000,
+        bid_price: 5.0,
+        optimization_goals: [{
+          kind: 'vendor_metric',
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'attention_score',
+          target: { kind: 'threshold_rate', value: 70 },
+        }],
+        committed_metrics: [{
+          scope: 'vendor',
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'attention_score',
+        }],
+      }],
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(typeof result.media_buy_id).toBe('string');
+  });
+
+  it('rejects vendor_metric optimization_goal whose metric is not in supported_metrics', async () => {
+    const { productId, pricingOptionId } = findProductWithVendorMetric();
+    const account = { brand: { domain: 'phantom-vendor-goal.example' }, operator: 'phantom-vendor-goal.example' };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    const { result } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'phantom-vendor-goal.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 10000,
+        bid_price: 5.0,
+        optimization_goals: [{
+          kind: 'vendor_metric',
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'emissions_score',
+        }],
+        committed_metrics: [{
+          scope: 'vendor',
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'emissions_score',
+        }],
+      }],
+    });
+
+    expect(result.code).toBe('INVALID_REQUEST');
+    expect(result.field).toBe('packages[0].optimization_goals[0].metric_id');
+    expect((result.message as string).includes('emissions_score')).toBe(true);
+  });
+
+  it('rejects vendor_metric optimization_goal without matching committed metric', async () => {
+    const { productId, pricingOptionId } = findProductWithVendorMetric();
+    const account = { brand: { domain: 'uncommitted-vendor-goal.example' }, operator: 'uncommitted-vendor-goal.example' };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    const { result } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'uncommitted-vendor-goal.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 10000,
+        bid_price: 5.0,
+        optimization_goals: [{
+          kind: 'vendor_metric',
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'attention_score',
+          target: { kind: 'threshold_rate', value: 70 },
+        }],
+      }],
+    });
+
+    expect(result.code).toBe('INVALID_REQUEST');
+    expect(result.field).toBe('packages[0].committed_metrics');
+    expect((result.message as string).includes('committed_metrics')).toBe(true);
+  });
+
+  it('rejects vendor_metric optimization_goal with unsupported target kind', async () => {
+    const { productId, pricingOptionId } = findProductWithVendorMetric();
+    const account = { brand: { domain: 'bad-vendor-target.example' }, operator: 'bad-vendor-target.example' };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    const { result } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'bad-vendor-target.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 10000,
+        bid_price: 5.0,
+        optimization_goals: [{
+          kind: 'vendor_metric',
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'attention_score',
+          target: { kind: 'cost_per', value: 0.2 },
+        }],
+        committed_metrics: [{
+          scope: 'vendor',
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'attention_score',
+        }],
+      }],
+    });
+
+    expect(result.code).toBe('INVALID_REQUEST');
+    expect(result.field).toBe('packages[0].optimization_goals[0].target.kind');
+    expect((result.message as string).includes('cost_per')).toBe(true);
   });
 });
 

--- a/static/compliance/source/protocols/media-buy/scenarios/vendor_metric_optimization_flow.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/vendor_metric_optimization_flow.yaml
@@ -1,0 +1,343 @@
+id: media_buy_seller/vendor_metric_optimization_flow
+version: "1.0.0"
+title: "Vendor-metric optimization-goal: acceptance and rejection"
+category: media_buy_seller
+summary: "Verifies that a seller supporting vendor_metric_optimization accepts a media buy whose optimization_goal has kind 'vendor_metric' when all preconditions are met, and rejects goals that fail either the capability check or the reporting-coherence check."
+track: media_buy
+required_tools:
+  - get_products
+  - create_media_buy
+  - comply_test_controller
+
+narrative: |
+  AdCP 3.1 adds optimization_goals[].kind: "vendor_metric" — a goal that steers
+  the seller's bidding stack toward a specific vendor's measurement metric (e.g.,
+  attention, emissions, brand lift). Three runtime preconditions govern
+  acceptance:
+
+    1. Capability — the (vendor, metric_id) pair MUST appear in the product's
+       vendor_metric_optimization.supported_metrics[], and the goal's target.kind
+       MUST appear in that entry's supported_targets.
+
+    2. Reporting coherence — the package's committed_metrics[] MUST include a
+       matching { scope: "vendor", vendor, metric_id } entry. Optimization without
+       committed reporting is unverifiable and is rejected at the wire level.
+
+    3. Discovery (SHOULD) — the metric_id SHOULD be discoverable in the vendor's
+       published measurement.metrics[] catalog. This check is SHOULD-level in 3.1
+       while measurement-vendor adoption of AdCP-conformant capability publication
+       catches up; it tightens to MUST at the next minor. Sellers MAY reject with
+       INVALID_REQUEST on a catalog miss; sellers that accept do not fail this
+       storyboard.
+
+  This storyboard covers:
+    - Positive path: goal accepted when all preconditions are met
+    - Negative path A: goal rejected when (vendor, metric_id) not in supported_metrics
+    - Negative path B: goal rejected when package committed_metrics lacks vendor-scope entry
+
+  The existing vendor_metric_accountability storyboard (declaration → filter →
+  delivery emission) is unchanged and exercises a separate contract.
+
+agent:
+  interaction_model: media_buy_seller
+  capabilities:
+    - sells_media
+  examples:
+    - "Premium publishers with attention measurement optimization"
+    - "Sustainability-focused sellers with emissions-metric steering"
+    - "Sellers integrating brand-lift vendors into their bidding stack"
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: |
+    The seller supports comply_test_controller and can seed products with
+    vendor_metric_optimization.supported_metrics[]. The seeded product must
+    appear in get_products responses. The seller enforces the three preconditions
+    for vendor_metric goals at create_media_buy time.
+  test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  products:
+    - product_id: "display_vendor_metric_opt"
+      delivery_type: "non_guaranteed"
+      channels: ["display"]
+      format_ids:
+        - id: "display_300x250"
+      reporting_capabilities:
+        available_metrics:
+          - impressions
+          - clicks
+          - spend
+        vendor_metrics:
+          - vendor:
+              domain: "attentionvendor.example"
+            metric_id: "attention_score"
+      vendor_metric_optimization:
+        supported_metrics:
+          - vendor:
+              domain: "attentionvendor.example"
+            metric_id: "attention_score"
+            supported_targets:
+              - threshold_rate
+  pricing_options:
+    - product_id: "display_vendor_metric_opt"
+      pricing_option_id: "cpm_vendor_opt"
+      pricing_model: "cpm"
+      currency: "USD"
+      fixed_price: 14.0
+
+phases:
+  - id: discover_vendor_metric_optimization
+    title: "Discover a product that declares vendor_metric_optimization"
+    narrative: |
+      The buyer looks for display inventory that can steer delivery toward an
+      attention vendor's metric. The product response includes
+      vendor_metric_optimization.supported_metrics[] listing the
+      attentionvendor.example attention_score with threshold_rate as a supported
+      target kind.
+    steps:
+      - id: sync_accounts
+        title: "Establish account"
+        task: sync_accounts
+        schema_ref: "account/sync-accounts-request.json"
+        response_schema_ref: "account/sync-accounts-response.json"
+        doc_ref: "/accounts/tasks/sync_accounts"
+        stateful: true
+        expected: |
+          Return the account with account_id and status active.
+        sample_request:
+          accounts:
+            - brand:
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
+              billing: "operator"
+              payment_terms: "net_30"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_vendor_metric_opt_setup_sync_accounts"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-accounts-response.json schema"
+          - check: field_present
+            path: "accounts[0].account_id"
+            description: "Account has a platform-assigned ID"
+
+      - id: get_products_vendor_metric_opt
+        title: "Discover product with vendor_metric_optimization capability"
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        comply_scenario: full_sales_flow
+        stateful: false
+        expected: |
+          Return at least one product whose vendor_metric_optimization.supported_metrics[]
+          includes an entry for attentionvendor.example / attention_score. The
+          supported_targets on that entry includes threshold_rate.
+        sample_request:
+          buying_mode: "brief"
+          brief: "Display inventory with attention-score optimization from attentionvendor."
+          filters:
+            channels: ["display"]
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+        context_outputs:
+          - path: "products[0].product_id"
+            name: "product_id"
+          - path: "products[0].pricing_options[0].pricing_option_id"
+            name: "pricing_option_id"
+        validations:
+          - check: response_schema
+            description: "Response matches get-products-response.json schema"
+          - check: field_present
+            path: "products[0].product_id"
+            description: "At least one product returned"
+          - check: field_present
+            path: "products[0].vendor_metric_optimization.supported_metrics"
+            description: "Product declares vendor_metric_optimization.supported_metrics[]"
+          - check: field_value
+            path: "products[0].vendor_metric_optimization.supported_metrics[0].vendor.domain"
+            value: "attentionvendor.example"
+            description: "Capability binds the optimization metric to the declared vendor"
+          - check: field_value
+            path: "products[0].vendor_metric_optimization.supported_metrics[0].metric_id"
+            value: "attention_score"
+            description: "Capability lists the attention_score metric_id"
+          - check: field_value
+            path: "products[0].vendor_metric_optimization.supported_metrics[0].supported_targets[0]"
+            value: "threshold_rate"
+            description: "Capability lists threshold_rate as a supported target kind"
+
+  - id: create_positive_path
+    title: "Accept vendor_metric goal when all preconditions are satisfied"
+    narrative: |
+      The buyer submits a create_media_buy with an optimization_goal of kind
+      vendor_metric, targeting attention_score with a threshold_rate of 70. The
+      package also includes a vendor-scope committed_metrics[] entry for the same
+      (vendor, metric_id) pair — satisfying the reporting-coherence precondition.
+      The seller accepts and returns a media_buy_id.
+    steps:
+      - id: create_media_buy_positive
+        title: "Create media buy with valid vendor_metric optimization goal"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        comply_scenario: create_media_buy
+        stateful: true
+        expected: |
+          Accept the buy. The optimization goal is valid: attention_score is in
+          supported_metrics for attentionvendor.example, threshold_rate is in
+          supported_targets, and committed_metrics[] carries the vendor-scope entry.
+          Seller returns a media_buy_id.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-06-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "$context.product_id"
+              pricing_option_id: "$context.pricing_option_id"
+              budget: 5000
+              optimization_goals:
+                - kind: "vendor_metric"
+                  vendor:
+                    domain: "attentionvendor.example"
+                  metric_id: "attention_score"
+                  target:
+                    kind: "threshold_rate"
+                    value: 70
+                  priority: 1
+              committed_metrics:
+                - scope: "vendor"
+                  vendor:
+                    domain: "attentionvendor.example"
+                  metric_id: "attention_score"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_vendor_metric_opt_positive"
+        context_outputs:
+          - path: "media_buy_id"
+            name: "media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Seller returns a media_buy_id — buy accepted"
+
+  - id: reject_unsupported_capability
+    title: "Reject vendor_metric goal when (vendor, metric_id) not in supported_metrics"
+    narrative: |
+      The buyer sends a goal for emissions_score from attentionvendor.example —
+      a (vendor, metric_id) pair that does not appear in the product's
+      vendor_metric_optimization.supported_metrics[]. Per the spec, the seller
+      MUST reject such goals. The correct code is INVALID_REQUEST; error.field
+      should point at the offending goal's metric_id path.
+    steps:
+      - id: create_media_buy_unsupported_metric
+        title: "Submit goal with (vendor, metric_id) not in supported_metrics"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        comply_scenario: create_media_buy
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: false
+        expected: |
+          Reject with INVALID_REQUEST. The goal references emissions_score for
+          attentionvendor.example, which is not in supported_metrics — the
+          capability precondition fails. media_buy_id is not allocated.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-06-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "$context.product_id"
+              pricing_option_id: "$context.pricing_option_id"
+              budget: 5000
+              optimization_goals:
+                - kind: "vendor_metric"
+                  vendor:
+                    domain: "attentionvendor.example"
+                  metric_id: "emissions_score"
+                  priority: 1
+              committed_metrics:
+                - scope: "vendor"
+                  vendor:
+                    domain: "attentionvendor.example"
+                  metric_id: "emissions_score"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_vendor_metric_opt_bad_capability"
+        validations:
+          - check: error_code
+            allowed_values: ["INVALID_REQUEST"]
+            description: "Seller rejects unsupported (vendor, metric_id) with INVALID_REQUEST"
+
+  - id: reject_missing_committed_metric
+    title: "Reject vendor_metric goal when package lacks vendor-scope committed_metrics entry"
+    narrative: |
+      The buyer submits a goal for attention_score (a valid capability on the
+      product) but omits the vendor-scope committed_metrics[] entry from the
+      package. Per the spec, optimization without committed reporting is
+      unverifiable and MUST be rejected with INVALID_REQUEST.
+
+      This is a reporting-coherence precondition failure on the optimization
+      goal, not a committed_metrics over-proposal rejection. TERMS_REJECTED
+      covers a committed_metrics[] entry the seller cannot honor; INVALID_REQUEST
+      covers a vendor_metric optimization goal that lacks the required
+      committed_metrics pairing.
+    steps:
+      - id: create_media_buy_missing_committed
+        title: "Submit goal without matching vendor-scope committed_metrics entry"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        comply_scenario: create_media_buy
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: false
+        expected: |
+          Reject with INVALID_REQUEST. The optimization goal targets attention_score
+          but the package's committed_metrics[] has no vendor-scope entry for
+          (attentionvendor.example, attention_score). Optimizing for a metric the
+          seller will not commit to reporting is disallowed. media_buy_id is not allocated.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-06-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "$context.product_id"
+              pricing_option_id: "$context.pricing_option_id"
+              budget: 5000
+              optimization_goals:
+                - kind: "vendor_metric"
+                  vendor:
+                    domain: "attentionvendor.example"
+                  metric_id: "attention_score"
+                  target:
+                    kind: "threshold_rate"
+                    value: 70
+                  priority: 1
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_vendor_metric_opt_no_committed"
+        validations:
+          - check: error_code
+            allowed_values: ["INVALID_REQUEST"]
+            description: "Seller rejects goal missing reporting-coherence with INVALID_REQUEST"

--- a/static/compliance/source/protocols/media-buy/scenarios/vendor_metric_optimization_flow.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/vendor_metric_optimization_flow.yaml
@@ -41,10 +41,12 @@ narrative: |
        storyboard.
 
   This storyboard covers:
-    - Positive path: goal accepted when all preconditions are met
+    - Positive path: goal accepted when all preconditions are met, including
+      the target-less maximize-within-budget form
     - Negative path A: goal rejected when (vendor, metric_id) not in supported_metrics
     - Negative path B: goal rejected when target.kind is not in supported_targets
     - Negative path C: goal rejected when package committed_metrics lacks vendor-scope entry
+    - Negative path D: goal rejected when the metric is optimizable but not reportable
 
   The existing vendor_metric_accountability storyboard (declaration → filter →
   delivery emission) is unchanged and exercises a separate contract.
@@ -97,9 +99,31 @@ fixtures:
             metric_id: "attention_score"
             supported_targets:
               - threshold_rate
+    - product_id: "display_vendor_metric_unreportable"
+      delivery_type: "non_guaranteed"
+      channels: ["display"]
+      format_ids:
+        - id: "display_300x250"
+      reporting_capabilities:
+        available_metrics:
+          - impressions
+          - clicks
+          - spend
+      vendor_metric_optimization:
+        supported_metrics:
+          - vendor:
+              domain: "attentionvendor.example"
+            metric_id: "attention_score"
+            supported_targets:
+              - threshold_rate
   pricing_options:
     - product_id: "display_vendor_metric_opt"
       pricing_option_id: "cpm_vendor_opt"
+      pricing_model: "cpm"
+      currency: "USD"
+      fixed_price: 14.0
+    - product_id: "display_vendor_metric_unreportable"
+      pricing_option_id: "cpm_vendor_opt_unreportable"
       pricing_model: "cpm"
       currency: "USD"
       fixed_price: 14.0
@@ -245,6 +269,59 @@ phases:
           - check: field_present
             path: "media_buy_id"
             description: "Seller returns a media_buy_id — buy accepted"
+
+  - id: create_targetless_positive_path
+    title: "Accept target-less vendor_metric goal as maximize-within-budget"
+    narrative: |
+      A buyer may omit target on a vendor_metric optimization goal. In that
+      form, the seller maximizes the vendor metric within the package budget.
+      The capability precondition still applies to the (vendor, metric_id)
+      pair, and reporting coherence still requires a matching vendor-scope
+      committed_metrics[] entry.
+    steps:
+      - id: create_media_buy_targetless_positive
+        title: "Create media buy with target-less vendor_metric optimization goal"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        comply_scenario: create_media_buy
+        stateful: true
+        expected: |
+          Accept the buy. The optimization goal has no target, so supported_targets
+          does not need to be consulted; attention_score is in supported_metrics
+          and committed_metrics[] carries the vendor-scope entry.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-06-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "$context.product_id"
+              pricing_option_id: "$context.pricing_option_id"
+              budget: 5000
+              optimization_goals:
+                - kind: "vendor_metric"
+                  vendor:
+                    domain: "attentionvendor.example"
+                  metric_id: "attention_score"
+                  priority: 1
+              committed_metrics:
+                - scope: "vendor"
+                  vendor:
+                    domain: "attentionvendor.example"
+                  metric_id: "attention_score"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_vendor_metric_opt_targetless_positive"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Seller returns a media_buy_id — target-less goal accepted"
 
   - id: reject_unsupported_capability
     title: "Reject vendor_metric goal when (vendor, metric_id) not in supported_metrics"
@@ -418,3 +495,64 @@ phases:
             path: "errors[0].field"
             value: "packages[0].committed_metrics"
             description: "Error.field points at the missing committed_metrics pairing"
+
+  - id: reject_unreportable_vendor_metric
+    title: "Reject vendor_metric goal when optimizable metric is not reportable"
+    narrative: |
+      The buyer submits a goal for attention_score on a product whose bidding
+      stack can optimize to that metric but whose reporting_capabilities do not
+      declare the same vendor metric. The seller MUST reject because the
+      committed_metrics[] entry would over-promise a metric the product does not
+      publish as reportable.
+    steps:
+      - id: create_media_buy_unreportable_metric
+        title: "Submit goal whose committed vendor metric is not reportable"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        comply_scenario: create_media_buy
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: false
+        expected: |
+          Reject with TERMS_REJECTED. The product can optimize toward
+          attention_score, but reporting_capabilities.vendor_metrics does not
+          include the same (attentionvendor.example, attention_score) pair, so
+          the seller cannot honor the requested vendor-scope committed metric.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-06-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "display_vendor_metric_unreportable"
+              pricing_option_id: "cpm_vendor_opt_unreportable"
+              budget: 5000
+              optimization_goals:
+                - kind: "vendor_metric"
+                  vendor:
+                    domain: "attentionvendor.example"
+                  metric_id: "attention_score"
+                  target:
+                    kind: "threshold_rate"
+                    value: 70
+                  priority: 1
+              committed_metrics:
+                - scope: "vendor"
+                  vendor:
+                    domain: "attentionvendor.example"
+                  metric_id: "attention_score"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_vendor_metric_opt_unreportable"
+        validations:
+          - check: error_code
+            allowed_values: ["TERMS_REJECTED"]
+            description: "Seller rejects unreportable committed vendor metric with TERMS_REJECTED"
+          - check: field_value
+            path: "errors[0].field"
+            value: "packages[0].committed_metrics"
+            description: "Error.field points at the unsupported committed metric"

--- a/static/compliance/source/protocols/media-buy/scenarios/vendor_metric_optimization_flow.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/vendor_metric_optimization_flow.yaml
@@ -4,6 +4,16 @@ title: "Vendor-metric optimization-goal: acceptance and rejection"
 category: media_buy_seller
 summary: "Verifies that a seller supporting vendor_metric_optimization accepts a media buy whose optimization_goal has kind 'vendor_metric' when all preconditions are met, and rejects goals that fail either the capability check or the reporting-coherence check."
 track: media_buy
+
+# Gate: scenario runs only when the seller declares vendor-metric
+# optimization support and the threshold_rate target kind. The product-level
+# vendor_metric_optimization block remains the authoritative per-product
+# capability; this seller-level rollup keeps optional-capability sellers
+# not_applicable instead of failing.
+requires_capability:
+  path: media_buy.vendor_metric_optimization.supported_targets
+  contains: "threshold_rate"
+
 required_tools:
   - get_products
   - create_media_buy
@@ -27,13 +37,14 @@ narrative: |
        published measurement.metrics[] catalog. This check is SHOULD-level in 3.1
        while measurement-vendor adoption of AdCP-conformant capability publication
        catches up; it tightens to MUST at the next minor. Sellers MAY reject with
-       INVALID_REQUEST on a catalog miss; sellers that accept do not fail this
+       TERMS_REJECTED on a catalog miss; sellers that accept do not fail this
        storyboard.
 
   This storyboard covers:
     - Positive path: goal accepted when all preconditions are met
     - Negative path A: goal rejected when (vendor, metric_id) not in supported_metrics
-    - Negative path B: goal rejected when package committed_metrics lacks vendor-scope entry
+    - Negative path B: goal rejected when target.kind is not in supported_targets
+    - Negative path C: goal rejected when package committed_metrics lacks vendor-scope entry
 
   The existing vendor_metric_accountability storyboard (declaration → filter →
   delivery emission) is unchanged and exercises a separate contract.
@@ -76,6 +87,9 @@ fixtures:
           - vendor:
               domain: "attentionvendor.example"
             metric_id: "attention_score"
+          - vendor:
+              domain: "attentionvendor.example"
+            metric_id: "attention_units"
       vendor_metric_optimization:
         supported_metrics:
           - vendor:
@@ -235,10 +249,10 @@ phases:
   - id: reject_unsupported_capability
     title: "Reject vendor_metric goal when (vendor, metric_id) not in supported_metrics"
     narrative: |
-      The buyer sends a goal for emissions_score from attentionvendor.example —
-      a (vendor, metric_id) pair that does not appear in the product's
+      The buyer sends a goal for attention_units from attentionvendor.example —
+      a reportable (vendor, metric_id) pair that does not appear in the product's
       vendor_metric_optimization.supported_metrics[]. Per the spec, the seller
-      MUST reject such goals. The correct code is INVALID_REQUEST; error.field
+      MUST reject such goals. The correct code is TERMS_REJECTED; error.field
       should point at the offending goal's metric_id path.
     steps:
       - id: create_media_buy_unsupported_metric
@@ -252,8 +266,9 @@ phases:
         negative_path: payload_well_formed
         stateful: false
         expected: |
-          Reject with INVALID_REQUEST. The goal references emissions_score for
-          attentionvendor.example, which is not in supported_metrics — the
+          Reject with TERMS_REJECTED. The goal references attention_units for
+          attentionvendor.example, which is reportable but not in
+          vendor_metric_optimization.supported_metrics — the optimization
           capability precondition fails. media_buy_id is not allocated.
         sample_request:
           brand:
@@ -272,18 +287,82 @@ phases:
                 - kind: "vendor_metric"
                   vendor:
                     domain: "attentionvendor.example"
-                  metric_id: "emissions_score"
+                  metric_id: "attention_units"
                   priority: 1
               committed_metrics:
                 - scope: "vendor"
                   vendor:
                     domain: "attentionvendor.example"
-                  metric_id: "emissions_score"
+                  metric_id: "attention_units"
           idempotency_key: "$generate:uuid_v4#media_buy_seller_vendor_metric_opt_bad_capability"
         validations:
           - check: error_code
-            allowed_values: ["INVALID_REQUEST"]
-            description: "Seller rejects unsupported (vendor, metric_id) with INVALID_REQUEST"
+            allowed_values: ["TERMS_REJECTED"]
+            description: "Seller rejects unsupported (vendor, metric_id) with TERMS_REJECTED"
+          - check: field_value
+            path: "errors[0].field"
+            value: "packages[0].optimization_goals[0].metric_id"
+            description: "Error.field points at the offending metric_id path"
+
+  - id: reject_unsupported_target_kind
+    title: "Reject vendor_metric goal when target.kind is not in supported_targets"
+    narrative: |
+      The buyer sends a goal for attention_score (a supported vendor metric)
+      but asks for cost_per when the product only declares threshold_rate in
+      vendor_metric_optimization.supported_metrics[].supported_targets. Per the
+      spec, the seller MUST reject such goals with TERMS_REJECTED and point at
+      the unsupported target kind.
+    steps:
+      - id: create_media_buy_unsupported_target
+        title: "Submit goal with target.kind not in supported_targets"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        comply_scenario: create_media_buy
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: false
+        expected: |
+          Reject with TERMS_REJECTED. The goal references a supported vendor
+          metric, but target.kind cost_per is not declared in supported_targets.
+          media_buy_id is not allocated.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-06-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "$context.product_id"
+              pricing_option_id: "$context.pricing_option_id"
+              budget: 5000
+              optimization_goals:
+                - kind: "vendor_metric"
+                  vendor:
+                    domain: "attentionvendor.example"
+                  metric_id: "attention_score"
+                  target:
+                    kind: "cost_per"
+                    value: 0.20
+                  priority: 1
+              committed_metrics:
+                - scope: "vendor"
+                  vendor:
+                    domain: "attentionvendor.example"
+                  metric_id: "attention_score"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_vendor_metric_opt_bad_target"
+        validations:
+          - check: error_code
+            allowed_values: ["TERMS_REJECTED"]
+            description: "Seller rejects unsupported target.kind with TERMS_REJECTED"
+          - check: field_value
+            path: "errors[0].field"
+            value: "packages[0].optimization_goals[0].target.kind"
+            description: "Error.field points at the offending target.kind path"
 
   - id: reject_missing_committed_metric
     title: "Reject vendor_metric goal when package lacks vendor-scope committed_metrics entry"
@@ -291,13 +370,7 @@ phases:
       The buyer submits a goal for attention_score (a valid capability on the
       product) but omits the vendor-scope committed_metrics[] entry from the
       package. Per the spec, optimization without committed reporting is
-      unverifiable and MUST be rejected with INVALID_REQUEST.
-
-      This is a reporting-coherence precondition failure on the optimization
-      goal, not a committed_metrics over-proposal rejection. TERMS_REJECTED
-      covers a committed_metrics[] entry the seller cannot honor; INVALID_REQUEST
-      covers a vendor_metric optimization goal that lacks the required
-      committed_metrics pairing.
+      unverifiable and MUST be rejected with TERMS_REJECTED.
     steps:
       - id: create_media_buy_missing_committed
         title: "Submit goal without matching vendor-scope committed_metrics entry"
@@ -310,7 +383,7 @@ phases:
         negative_path: payload_well_formed
         stateful: false
         expected: |
-          Reject with INVALID_REQUEST. The optimization goal targets attention_score
+          Reject with TERMS_REJECTED. The optimization goal targets attention_score
           but the package's committed_metrics[] has no vendor-scope entry for
           (attentionvendor.example, attention_score). Optimizing for a metric the
           seller will not commit to reporting is disallowed. media_buy_id is not allocated.
@@ -339,5 +412,9 @@ phases:
           idempotency_key: "$generate:uuid_v4#media_buy_seller_vendor_metric_opt_no_committed"
         validations:
           - check: error_code
-            allowed_values: ["INVALID_REQUEST"]
-            description: "Seller rejects goal missing reporting-coherence with INVALID_REQUEST"
+            allowed_values: ["TERMS_REJECTED"]
+            description: "Seller rejects goal missing reporting-coherence with TERMS_REJECTED"
+          - check: field_value
+            path: "errors[0].field"
+            value: "packages[0].committed_metrics"
+            description: "Error.field points at the missing committed_metrics pairing"

--- a/static/compliance/source/protocols/media-buy/scenarios/vendor_metric_optimization_flow.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/vendor_metric_optimization_flow.yaml
@@ -6,13 +6,12 @@ summary: "Verifies that a seller supporting vendor_metric_optimization accepts a
 track: media_buy
 
 # Gate: scenario runs only when the seller declares vendor-metric
-# optimization support and the threshold_rate target kind. The product-level
-# vendor_metric_optimization block remains the authoritative per-product
-# capability; this seller-level rollup keeps optional-capability sellers
-# not_applicable instead of failing.
+# optimization support. The product-level vendor_metric_optimization block
+# remains the authoritative per-product capability, including target-kind
+# support on the seeded product.
 requires_capability:
-  path: media_buy.vendor_metric_optimization.supported_targets
-  contains: "threshold_rate"
+  path: media_buy.vendor_metric_optimization
+  present: true
 
 required_tools:
   - get_products

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -566,6 +566,26 @@
           "minItems": 1,
           "uniqueItems": true
         },
+        "vendor_metric_optimization": {
+          "type": "object",
+          "description": "Seller-level rollup of vendor-metric optimization capabilities supported by at least one product. Product-level vendor_metric_optimization.supported_metrics[] remains authoritative for the specific (vendor, metric_id) pairs and target kinds a buyer may bind on a package; this seller-level object exists so buyers and compliance runners can discover whether vendor_metric goals are in scope before walking the catalog. Sellers MUST keep this in sync with product-level vendor_metric_optimization declarations.",
+          "properties": {
+            "supported_targets": {
+              "type": "array",
+              "description": "Target kinds this seller can support for vendor_metric optimization goals on at least one product. Values match optimization_goals[].target.kind for kind: vendor_metric. A target-less vendor_metric goal maximizes the metric within budget and does not require a target-kind declaration.",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "cost_per",
+                  "threshold_rate"
+                ]
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            }
+          },
+          "additionalProperties": true
+        },
         "conversion_tracking": {
           "type": "object",
           "description": "Seller-level conversion tracking capabilities. Presence of this object indicates the seller supports sync_event_sources and log_event for conversion event tracking.",


### PR DESCRIPTION
Closes #4933

## Summary

Adds compliance coverage for the AdCP 3.1 `optimization_goals[].kind: "vendor_metric"` contract. The new media-buy storyboard verifies discovery of `vendor_metric_optimization.supported_metrics[]`, positive create-media-buy acceptance when capability and reporting-coherence preconditions are met, and negative paths for unsupported vendor metrics, unsupported target kinds, and missing vendor-scope `committed_metrics[]`.

The training agent now publishes vendor-metric optimization capability on both capability surfaces, ranks vendor-metric-capable products higher for relevant briefs, and enforces that vendor-metric goals are both optimizable and reportable before accepting a media buy.

## Expert Review

Ran protocol, ad-tech protocol, and code-review expert passes. Follow-up fixes addressed their findings:

- `TERMS_REJECTED` is used for vendor-metric capability/reporting-coherence rejection paths.
- The storyboard is gated on seller support for `media_buy.vendor_metric_optimization.supported_targets` containing `threshold_rate`.
- Unsupported metric and unsupported target negative paths are isolated and assert `errors[0].field`.
- Runtime validation now rejects metrics that are optimizable but missing from `reporting_capabilities.vendor_metrics`.
- Brief discovery now reliably surfaces vendor-metric optimization products for attention/vendor-metric briefs.

## Validation

- `npm run test:storyboard-validations-paths`
- direct sample-request and context-output lint on `vendor_metric_optimization_flow.yaml`
- `npm run build:compliance`
- `npx vitest run server/tests/unit/training-agent.test.ts --config server/vitest.config.ts`
- `npm run typecheck`
- `npm run test:storyboards`
- `npm run test:storyboards:3.0-compat`
- precommit hook: `test:unit`, `test:test-dynamic-imports`, `test:callapi-state-change`, `typecheck`
- push hook: version sync, current storyboard matrix, 3.0 storyboard compatibility matrix

Known unrelated repo drift remains in the full global lints: `test:storyboard-sample-request-schema` reports `protocols/creative/scenarios/native_in_feed.yaml`, and `test:storyboard-context-output-paths` reports `specialisms/sales-guaranteed/index.yaml`.