### PR TITLE
[codex] Add PROPOSAL_NOT_FOUND storyboard coverage

### DIFF
--- a/.changeset/4935-proposal-not-found-storyboard.md
+++ b/.changeset/4935-proposal-not-found-storyboard.md
@@ -1,0 +1,10 @@
+---
+"adcontextprotocol": patch
+---
+
+media-buy: add `PROPOSAL_NOT_FOUND` compliance coverage for unknown proposal references.
+
+The training agent now returns the canonical `PROPOSAL_NOT_FOUND` error with
+`correctable` recovery for unknown `proposal_id` references in `get_products`
+refine/finalize and `create_media_buy`, and prevalidates proposal refinements
+before applying finalize side effects.

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -1496,6 +1496,7 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext) {
   const refinementApplied: RefinementAppliedEntry[] = [];
   const proposalOmitIds = new Set<string>();
   if (buyingMode === 'refine' && req.refine) {
+    const refineOps = req.refine as unknown as RefineEntry[];
     const previousProducts = session.lastGetProductsContext?.products || products;
     const previousProposals = session.lastGetProductsContext?.proposals || getProposals();
     const omitIds = new Set<string>();
@@ -1504,7 +1505,29 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext) {
     const askAckNotes = (ask?: string) =>
       ask ? { notes: `Ask acknowledged but not applied by training agent: ${ask}` } : {};
 
-    for (const op of req.refine as unknown as RefineEntry[]) {
+    // Validate proposal references before applying any refinements. This keeps
+    // failed multi-entry refine calls from partially finalizing earlier entries.
+    for (let opIndex = 0; opIndex < refineOps.length; opIndex++) {
+      const op = refineOps[opIndex];
+      if (op.scope !== 'proposal') continue;
+      let proposal = previousProposals.find(p => p.proposal_id === op.proposal_id);
+      if (!proposal && isThreeZeroStoryboardCompat(ctx) && op.proposal_id === THREE_ZERO_LEGACY_PROPOSAL_ID) {
+        proposal = resolveThreeZeroProposalAlias([...previousProposals, ...getProposals()]);
+      }
+      if (!proposal) {
+        return {
+          errors: [{
+            code: 'PROPOSAL_NOT_FOUND',
+            message: `Proposal not found: ${op.proposal_id}`,
+            field: `refine[${opIndex}].proposal_id`,
+            recovery: 'correctable',
+          }] as TaskError[],
+        };
+      }
+    }
+
+    for (let opIndex = 0; opIndex < refineOps.length; opIndex++) {
+      const op = refineOps[opIndex];
       if (op.scope === 'product') {
         const action = op.action ?? 'include';
         if (action === 'omit') {
@@ -1532,10 +1555,7 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext) {
         if (!proposal && isThreeZeroStoryboardCompat(ctx) && op.proposal_id === THREE_ZERO_LEGACY_PROPOSAL_ID) {
           proposal = resolveThreeZeroProposalAlias([...previousProposals, ...getProposals()]);
         }
-        if (!proposal) {
-          refinementApplied.push({ scope: 'proposal', proposal_id: op.proposal_id, status: 'unable', notes: `Proposal not found: ${op.proposal_id}` });
-          continue;
-        }
+        if (!proposal) continue;
         if (action === 'omit') {
           proposalOmitIds.add(op.proposal_id);
           refinementApplied.push({ scope: 'proposal', proposal_id: op.proposal_id, status: 'applied' });
@@ -1984,7 +2004,12 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
     }
     if (!proposal) {
       return {
-        errors: [{ code: 'INVALID_REQUEST', message: `Proposal not found: ${req.proposal_id}` }] as TaskError[],
+        errors: [{
+          code: 'PROPOSAL_NOT_FOUND',
+          message: `Proposal not found: ${req.proposal_id}`,
+          field: 'proposal_id',
+          recovery: 'correctable',
+        }] as TaskError[],
       };
     }
 

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -6292,6 +6292,23 @@ describe('proposal lifecycle', () => {
     expect(result.code).toBe('PROPOSAL_NOT_COMMITTED');
   });
 
+  it('rejects create_media_buy for unknown proposal with PROPOSAL_NOT_FOUND', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { result, isError } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'proposal-test.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      proposal_id: 'nonexistent_proposal_id',
+      total_budget: { amount: 75000, currency: 'USD' },
+    });
+
+    expect(isError).toBe(true);
+    expect(result.code).toBe('PROPOSAL_NOT_FOUND');
+    expect(result.field).toBe('proposal_id');
+    expect(result.recovery).toBe('correctable');
+  });
+
   it('rejects create_media_buy for expired proposal with PROPOSAL_EXPIRED', async () => {
     // Get and finalize a proposal
     const server1 = createTrainingAgentServer(DEFAULT_CTX);
@@ -6486,7 +6503,7 @@ describe('proposal lifecycle', () => {
     expect(result.media_buy_id).toBeDefined();
   });
 
-  it('returns unable when finalizing a nonexistent proposal', async () => {
+  it('rejects finalizing a nonexistent proposal with PROPOSAL_NOT_FOUND', async () => {
     const server1 = createTrainingAgentServer(DEFAULT_CTX);
     const { result: initial } = await simulateCallTool(server1, 'get_products', {
       buying_mode: 'brief',
@@ -6496,15 +6513,64 @@ describe('proposal lifecycle', () => {
     expect(initial.proposals).toBeDefined();
 
     const server2 = createTrainingAgentServer(DEFAULT_CTX);
-    const { result: refined } = await simulateCallTool(server2, 'get_products', {
+    const { result, isError } = await simulateCallTool(server2, 'get_products', {
       buying_mode: 'refine',
       account,
       refine: [{ scope: 'proposal', action: 'finalize', proposal_id: 'nonexistent_proposal_id' }],
     });
 
-    const applied = refined.refinement_applied as Array<Record<string, unknown>>;
-    expect(applied).toBeDefined();
-    expect(applied[0].status).toBe('unable');
+    expect(isError).toBe(true);
+    expect(result.code).toBe('PROPOSAL_NOT_FOUND');
+    expect(result.field).toBe('refine[0].proposal_id');
+    expect(result.recovery).toBe('correctable');
+  });
+
+  it('rejects mixed proposal refine before committing earlier finalize entries', async () => {
+    const server1 = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: initial } = await simulateCallTool(server1, 'get_products', {
+      buying_mode: 'brief',
+      brief: 'premium video news',
+      account,
+    });
+    const draftProposal = (initial.proposals as Array<Record<string, unknown>>)?.find(
+      p => p.proposal_status === 'draft',
+    );
+    expect(draftProposal).toBeDefined();
+    const originalExpiresAt = draftProposal!.expires_at;
+
+    const server2 = createTrainingAgentServer(DEFAULT_CTX);
+    const { result, isError } = await simulateCallTool(server2, 'get_products', {
+      buying_mode: 'refine',
+      account,
+      refine: [
+        { scope: 'proposal', action: 'finalize', proposal_id: draftProposal!.proposal_id },
+        { scope: 'proposal', action: 'finalize', proposal_id: 'nonexistent_proposal_id' },
+      ],
+    });
+
+    expect(isError).toBe(true);
+    expect(result.code).toBe('PROPOSAL_NOT_FOUND');
+    expect(result.field).toBe('refine[1].proposal_id');
+    expect(result.recovery).toBe('correctable');
+
+    const server3 = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: afterRejected } = await simulateCallTool(server3, 'get_products', {
+      buying_mode: 'refine',
+      account,
+      refine: [{
+        scope: 'proposal',
+        proposal_id: draftProposal!.proposal_id,
+        ask: 'Confirm the current proposal status.',
+      }],
+    });
+
+    const proposalAfterRejected = (afterRejected.proposals as Array<Record<string, unknown>>)?.find(
+      p => p.proposal_id === draftProposal!.proposal_id,
+    );
+    expect(proposalAfterRejected).toBeDefined();
+    expect(proposalAfterRejected!.proposal_status).toBe('draft');
+    expect(proposalAfterRejected!.expires_at).toBe(originalExpiresAt);
+    expect(proposalAfterRejected!.insertion_order).toBeUndefined();
   });
 
   it('omits proposals via refine action', async () => {

--- a/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
@@ -161,6 +161,53 @@ phases:
             path: "proposals"
             description: "Response contains updated proposals"
 
+  - id: unknown_proposal_finalize
+    title: "Reject unknown proposals during finalization"
+    narrative: |
+      The buyer asks to finalize a proposal reference that was never issued by
+      the seller. The request is schema-valid; the rejection is semantic and
+      must use the canonical proposal-not-found code.
+
+    steps:
+      - id: get_products_finalize_unknown_proposal
+        title: "Reject finalize against an unknown proposal"
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: true
+        expected: |
+          Reject with:
+          - code: PROPOSAL_NOT_FOUND
+          - recovery: correctable
+          - field: refine[0].proposal_id
+
+        sample_request:
+          buying_mode: "refine"
+          refine:
+            - scope: "proposal"
+              proposal_id: "prop_unknown_proposal_not_found"
+              action: "finalize"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+
+        validations:
+          - check: error_code
+            value: "PROPOSAL_NOT_FOUND"
+            description: "Unknown proposal finalize returns the canonical proposal-not-found code"
+          - check: field_value
+            path: "adcp_error.recovery"
+            value: "correctable"
+            description: "Recovery is correctable"
+          - check: field_value
+            path: "adcp_error.field"
+            value: "refine[0].proposal_id"
+            description: "Error field identifies the missing proposal reference"
+
   - id: finalize_proposal
     title: "Finalize the proposal"
     narrative: |
@@ -257,3 +304,96 @@ phases:
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"
+
+  - id: unknown_proposal_references
+    title: "Reject unknown proposal references"
+    narrative: |
+      The buyer references proposal IDs that were never issued by the seller.
+      These requests are schema-valid; the rejection is semantic. The seller
+      must return the canonical PROPOSAL_NOT_FOUND code rather than generic
+      NOT_FOUND, INVALID_REQUEST, or platform-specific proposal errors.
+
+    steps:
+      - id: get_products_refine_unknown_proposal
+        title: "Reject refine against an unknown proposal"
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: true
+        expected: |
+          Reject with:
+          - code: PROPOSAL_NOT_FOUND
+          - recovery: correctable
+          - field: refine[0].proposal_id
+
+        sample_request:
+          buying_mode: "refine"
+          refine:
+            - scope: "proposal"
+              proposal_id: "prop_unknown_proposal_not_found"
+              ask: "Shift budget toward premium video."
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+
+        validations:
+          - check: error_code
+            value: "PROPOSAL_NOT_FOUND"
+            description: "Unknown proposal refine returns the canonical proposal-not-found code"
+          - check: field_value
+            path: "adcp_error.recovery"
+            value: "correctable"
+            description: "Recovery is correctable"
+          - check: field_value
+            path: "adcp_error.field"
+            value: "refine[0].proposal_id"
+            description: "Error field identifies the missing proposal reference"
+
+      - id: create_media_buy_unknown_proposal
+        title: "Reject create_media_buy from an unknown proposal"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        comply_scenario: create_media_buy
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: true
+        expected: |
+          Reject with:
+          - code: PROPOSAL_NOT_FOUND
+          - recovery: correctable
+          - field: proposal_id
+
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          proposal_id: "prop_unknown_proposal_not_found"
+          total_budget:
+            amount: 50000
+            currency: "USD"
+          start_time: "2026-04-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_proposal_finalize_unknown_proposal_create_media_buy"
+        validations:
+          - check: error_code
+            value: "PROPOSAL_NOT_FOUND"
+            description: "Unknown proposal create returns the canonical proposal-not-found code"
+          - check: field_value
+            path: "adcp_error.recovery"
+            value: "correctable"
+            description: "Recovery is correctable"
+          - check: field_value
+            path: "adcp_error.field"
+            value: "proposal_id"
+            description: "Error field identifies the missing proposal reference"


### PR DESCRIPTION
Closes #4935

## Summary
- Adds media-buy storyboard coverage for unknown proposal references in get_products refine/finalize and create_media_buy.
- Returns canonical PROPOSAL_NOT_FOUND with correctable recovery and proposal reference fields from the training agent.
- Prevalidates proposal refine references before applying mutations so mixed finalize requests cannot partially commit state.
- Adds unit coverage for unknown proposal errors and the no-partial-commit invariant.

## Expert review
- Ran protocol and code review subagents. Both initially flagged issues: multi-finalize storyboard portability and missing/stale unit coverage.
- Addressed those findings by making the storyboard use a single unknown-finalize probe and moving atomicity coverage to training-agent unit tests.
- Re-ran both experts on the revised diff; both reported no blocking findings.

## Validation
- npm run typecheck
- npx vitest run server/tests/unit/training-agent.test.ts
- npx vitest run server/tests/unit/training-agent.test.ts -t "proposal"
- npm run test:storyboard-check-enum && npm run test:storyboard-validations-paths && npm run test:storyboard-contradictions && npm run test:error-codes
- bash scripts/overlay-compliance-cache.sh && TENANT_PATH=sales PUBLIC_TEST_AGENT_TOKEN=storyboard-local-token npx tsx server/tests/manual/run-storyboards.ts --filter proposal_finalize --verbose
- npm run test:storyboards
- precommit hook: npm run test:unit && npm run test:test-dynamic-imports && npm run test:callapi-state-change && npm run typecheck
- pre-push hook: version sync, current compliance storyboard matrix, released 3.0 compatibility storyboard matrix
