### PR TITLE
Fix storyboard lint drift

### DIFF
--- a/.changeset/storyboard-lint-cleanups.md
+++ b/.changeset/storyboard-lint-cleanups.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Clear storyboard lint drift by registering tracker asset types in the creative asset union, supporting `task_completion.*` context-output paths in the static lint, and classifying `sync_audiences` as tenant-scoped.

--- a/scripts/lint-storyboard-context-output-paths.cjs
+++ b/scripts/lint-storyboard-context-output-paths.cjs
@@ -70,6 +70,14 @@ function parsePath(raw) {
   return raw.replace(/\[(\d+)\]/g, '.$1').split('.').filter(Boolean);
 }
 
+function contextOutputPathResolves(schema, segments) {
+  if (segments[0] === 'task_completion') {
+    if (segments.length === 1) return false;
+    return pathResolves(schema, segments.slice(1));
+  }
+  return pathResolves(schema, segments);
+}
+
 function schemaRefToPath(ref) {
   if (!ref) return null;
   const trimmed = ref.startsWith('/schemas/') ? ref.slice('/schemas/'.length) : ref;
@@ -296,7 +304,7 @@ function lintDoc(doc, filePath, allowlist = []) {
       const rawPath = out?.path;
       if (typeof rawPath !== 'string' || rawPath.length === 0) continue;
       const segments = parsePath(rawPath);
-      if (pathResolves(schema, segments)) continue;
+      if (contextOutputPathResolves(schema, segments)) continue;
       if (isAllowlisted(allowlist, filePath, step.stepId, rawPath)) continue;
       violations.push({
         rule: 'path_not_in_schema',

--- a/scripts/lint-storyboard-scoping.cjs
+++ b/scripts/lint-storyboard-scoping.cjs
@@ -48,6 +48,7 @@ const TENANT_SCOPED_TASKS = new Set([
   'get_products',
   'get_signals',
   'activate_signal',
+  'sync_audiences',
   'provide_performance_feedback',
   // Governance plans
   'sync_plans',

--- a/static/schemas/source/core/assets/asset-union.json
+++ b/static/schemas/source/core/assets/asset-union.json
@@ -19,7 +19,10 @@
     { "$ref": "/schemas/core/assets/markdown-asset.json" },
     { "$ref": "/schemas/core/assets/brief-asset.json" },
     { "$ref": "/schemas/core/assets/catalog-asset.json" },
-    { "$ref": "/schemas/core/assets/card-asset.json" }
+    { "$ref": "/schemas/core/assets/card-asset.json" },
+    { "$ref": "/schemas/core/assets/pixel-tracker-asset.json" },
+    { "$ref": "/schemas/core/assets/vast-tracker-asset.json" },
+    { "$ref": "/schemas/core/assets/daast-tracker-asset.json" }
   ],
   "discriminator": {
     "propertyName": "asset_type"

--- a/tests/lint-storyboard-context-output-paths.test.cjs
+++ b/tests/lint-storyboard-context-output-paths.test.cjs
@@ -102,8 +102,28 @@ test('pathResolves descends oneOf variants — captures from a discriminated arm
   const schema = loadSchema('brand/acquire-rights-response.json');
   assert.ok(schema, 'fixture schema loads');
   assert.equal(pathResolves(schema, parsePath('rights_id')), true);
-  assert.equal(pathResolves(schema, parsePath('status')), true);
+  assert.equal(pathResolves(schema, parsePath('rights_status')), true);
   assert.equal(pathResolves(schema, parsePath('reason')), true);
+});
+
+test('task_completion prefix validates against the terminal artifact schema', () => {
+  const doc = {
+    phases: [
+      {
+        id: 'p',
+        steps: [
+          {
+            id: 'create_media_buy',
+            task: 'create_media_buy',
+            response_schema_ref: 'media-buy/create-media-buy-response.json',
+            context_outputs: [{ name: 'media_buy_id', path: 'task_completion.media_buy_id' }],
+          },
+        ],
+      },
+    ],
+  };
+
+  assert.deepEqual(lintDoc(doc, '/synth/test.yaml'), []);
 });
 
 test('pathResolves rejects paths that no oneOf variant defines', () => {


### PR DESCRIPTION
## Summary

Fixes the three broader storyboard lint failures observed on `origin/main`:

- registers `pixel_tracker`, `vast_tracker`, and `daast_tracker` in the creative asset union so native in-feed tracker assets validate against `sync_creatives`
- teaches `lint-storyboard-context-output-paths` that `task_completion.*` paths resolve against the terminal task artifact schema
- classifies `sync_audiences` as tenant-scoped because its handler requires `account` and routes through `sessionKeyFromArgs`

Also updates the context-output lint test fixture from the old `status` field to the current `rights_status` field on `acquire_rights`.

## Validation

- `npm run test:storyboard-sample-request-schema`
- `npm run test:storyboard-context-output-paths`
- `npm run test:storyboard-scoping`
- `npm run build:schemas`
- `npm run test:schemas`
- `npm run test:json-schema`
- `npm run test:storyboard-validations-paths`
- `npm run test:storyboard-check-enum`
- precommit: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run typecheck`
- pre-push: `npm run verify-version-sync`
