### PR TITLE
feat(compliance): cover delivery metrics storyboards

### DIFF
--- a/.changeset/4931-delivery-metrics-storyboards.md
+++ b/.changeset/4931-delivery-metrics-storyboards.md
@@ -1,0 +1,13 @@
+---
+"adcontextprotocol": patch
+---
+
+Add 3.1 compliance storyboards for `reach_window` and `viewability.viewed_seconds` in delivery reporting.
+
+`reach_buy_flow.yaml` now covers cumulative, period, and rolling `reach_window` delivery rows, including the required `period` shape for period and rolling windows. It also adds a permanent advisory for reach rows that omit `reach_window`, which remain schema-valid but are not safe for buyers to sum or average across reporting periods.
+
+`delivery_reporting.yaml` now includes a viewability-capable vCPM video buy and verifies that simulated delivery reports surface `viewability.viewed_seconds` alongside measurable impressions, viewable rate, and the viewability standard.
+
+`comply-test-controller-request.json` and the controller docs now declare typed `simulate_delivery` params for `reach`, `frequency`, `reach_window`, and `viewability` so storyboard examples have a schema-grounded controller contract.
+
+The training-agent controller now persists those simulated metrics and returns them through `get_media_buy_delivery`, keeping the reference sandbox aligned with the new storyboard coverage.

--- a/docs/building/by-layer/L3/comply-test-controller.mdx
+++ b/docs/building/by-layer/L3/comply-test-controller.mdx
@@ -83,7 +83,7 @@ Sellers that implement compliance test controller MUST:
       },
       "params": {
         "type": "object",
-        "description": "Scenario-specific parameters. Omit for list_scenarios. force_creative_status: {creative_id, status, rejection_reason?}. force_account_status: {account_id, status}. force_media_buy_status: {media_buy_id, status, rejection_reason?}. force_create_media_buy_arm: {arm, task_id?, message?} — task_id required when arm = submitted. force_task_completion: {task_id, result}. force_session_status: {session_id, status, termination_reason?}. simulate_delivery: {media_buy_id, impressions?, clicks?, reported_spend?, conversions?}. simulate_budget_spend: {account_id|media_buy_id, spend_percentage}. seed_product: {product_id, fixture?}. seed_pricing_option: {product_id, pricing_option_id, fixture?}. seed_creative: {creative_id, fixture?}. seed_plan: {plan_id, fixture?}. seed_media_buy: {media_buy_id, fixture?}."
+        "description": "Scenario-specific parameters. Omit for list_scenarios. force_creative_status: {creative_id, status, rejection_reason?}. force_account_status: {account_id, status}. force_media_buy_status: {media_buy_id, status, rejection_reason?}. force_create_media_buy_arm: {arm, task_id?, message?} — task_id required when arm = submitted. force_task_completion: {task_id, result}. force_session_status: {session_id, status, termination_reason?}. simulate_delivery: {media_buy_id, impressions?, clicks?, reported_spend?, conversions?, reach?, frequency?, reach_window?, viewability?}. simulate_budget_spend: {account_id|media_buy_id, spend_percentage}. seed_product: {product_id, fixture?}. seed_pricing_option: {product_id, pricing_option_id, fixture?}. seed_creative: {creative_id, fixture?}. seed_plan: {plan_id, fixture?}. seed_media_buy: {media_buy_id, fixture?}."
       }
     },
     "required": ["scenario"]
@@ -306,6 +306,10 @@ Injects synthetic delivery data for a media buy. Subsequent calls to `get_media_
 | `clicks` | integer | No | Clicks to simulate |
 | `reported_spend` | object | No | `{ amount: number, currency: string }` — spend as reported in delivery data, does not affect budget |
 | `conversions` | integer | No | Conversions to simulate |
+| `reach` | number | No | Unique reach count to surface at `totals.reach` |
+| `frequency` | number | No | Average frequency per reach unit to surface at `totals.frequency` |
+| `reach_window` | object | No | Measurement window for simulated reach/frequency. Shape: `{ kind: "cumulative" }`, `{ kind: "period", period: Duration }`, or `{ kind: "rolling", period: Duration }` |
+| `viewability` | object | No | Viewability block to surface at `totals.viewability`, including `measurable_impressions`, `viewable_impressions`, `viewable_rate`, `viewed_seconds`, and `standard` when supplied |
 
 **Example:**
 
@@ -316,6 +320,16 @@ Injects synthetic delivery data for a media buy. Subsequent calls to `get_media_
     "media_buy_id": "mb-789",
     "impressions": 10000,
     "clicks": 150,
+    "reach": 4000,
+    "frequency": 2.5,
+    "reach_window": { "kind": "rolling", "period": { "interval": 7, "unit": "days" } },
+    "viewability": {
+      "measurable_impressions": 9000,
+      "viewable_impressions": 7200,
+      "viewable_rate": 0.8,
+      "viewed_seconds": 4.3,
+      "standard": "mrc"
+    },
     "reported_spend": { "amount": 150.00, "currency": "USD" }
   }
 }
@@ -559,18 +573,38 @@ Creates a media buy fixture at a specified lifecycle state, bypassing the `creat
   "simulated": {
     "impressions": 10000,
     "clicks": 150,
+    "reach": 4000,
+    "frequency": 2.5,
+    "reach_window": { "kind": "rolling", "period": { "interval": 7, "unit": "days" } },
+    "viewability": {
+      "measurable_impressions": 9000,
+      "viewable_impressions": 7200,
+      "viewable_rate": 0.8,
+      "viewed_seconds": 4.3,
+      "standard": "mrc"
+    },
     "reported_spend": { "amount": 150.00, "currency": "USD" }
   },
   "cumulative": {
     "impressions": 25000,
     "clicks": 380,
+    "reach": 4000,
+    "frequency": 2.5,
+    "reach_window": { "kind": "rolling", "period": { "interval": 7, "unit": "days" } },
+    "viewability": {
+      "measurable_impressions": 9000,
+      "viewable_impressions": 7200,
+      "viewable_rate": 0.8,
+      "viewed_seconds": 4.3,
+      "standard": "mrc"
+    },
     "reported_spend": { "amount": 375.00, "currency": "USD" }
   },
   "message": "Delivery simulated for mb-789: 10000 impressions, 150 clicks, $150.00 spend"
 }
 ```
 
-The `simulated` field echoes back the values injected by this call. The `cumulative` field returns running totals across all simulation calls for this media buy, so callers can verify expected state before checking `get_media_buy_delivery`.
+The `simulated` field echoes back the values injected by this call. The `cumulative` field returns running totals across additive counters and spend for this media buy, plus the latest non-additive reach-window and viewability state, so callers can verify expected state before checking `get_media_buy_delivery`.
 
 **`simulate_budget_spend` response:**
 

--- a/server/src/training-agent/comply-test-controller.ts
+++ b/server/src/training-agent/comply-test-controller.ts
@@ -88,6 +88,42 @@ export function getBudgetSimulation(session: SessionState, entityId: string): Co
   return session.complyExtensions.budgetSimulations.get(entityId);
 }
 
+function getOrCreateDeliveryAccumulator(session: SessionState, mediaBuyId: string, currency: string): ComplyDeliveryAccumulator {
+  const ext = session.complyExtensions;
+  let cumulative = ext.deliverySimulations.get(mediaBuyId);
+  if (!cumulative) {
+    enforceMapCap(ext.deliverySimulations, mediaBuyId, 'delivery simulations');
+    cumulative = {
+      impressions: 0,
+      clicks: 0,
+      reportedSpend: { amount: 0, currency },
+      conversions: 0,
+    };
+    ext.deliverySimulations.set(mediaBuyId, cumulative);
+  }
+  return cumulative;
+}
+
+function applyExtendedDeliveryParams(cumulative: ComplyDeliveryAccumulator, params: Record<string, unknown>) {
+  if (typeof params.reach === 'number') cumulative.reach = params.reach;
+  if (typeof params.frequency === 'number') cumulative.frequency = params.frequency;
+  if (params.reach_window && typeof params.reach_window === 'object' && !Array.isArray(params.reach_window)) {
+    cumulative.reachWindow = params.reach_window as ComplyDeliveryAccumulator['reachWindow'];
+  }
+  if (params.viewability && typeof params.viewability === 'object' && !Array.isArray(params.viewability)) {
+    cumulative.viewability = params.viewability as ComplyDeliveryAccumulator['viewability'];
+  }
+}
+
+function extendedDeliverySnapshot(cumulative: ComplyDeliveryAccumulator): Record<string, unknown> {
+  return {
+    ...(cumulative.reach !== undefined ? { reach: cumulative.reach } : {}),
+    ...(cumulative.frequency !== undefined ? { frequency: cumulative.frequency } : {}),
+    ...(cumulative.reachWindow ? { reach_window: cumulative.reachWindow } : {}),
+    ...(cumulative.viewability ? { viewability: cumulative.viewability } : {}),
+  };
+}
+
 /** Get account status set by comply test controller. */
 export function getAccountStatus(session: SessionState, accountId: string): string | undefined {
   return session.complyExtensions.accountStatuses.get(accountId);
@@ -295,19 +331,9 @@ function createStore(session: SessionState): TestControllerStore {
       const clicks = params.clicks || 0;
       const conversions = params.conversions || 0;
       const reportedSpend = params.reported_spend;
+      const typedParams = params as Record<string, unknown>;
 
-      const ext = session.complyExtensions;
-      let cumulative = ext.deliverySimulations.get(mediaBuyId);
-      if (!cumulative) {
-        enforceMapCap(ext.deliverySimulations, mediaBuyId, 'delivery simulations');
-        cumulative = {
-          impressions: 0,
-          clicks: 0,
-          reportedSpend: { amount: 0, currency: reportedSpend?.currency || mb.currency },
-          conversions: 0,
-        };
-        ext.deliverySimulations.set(mediaBuyId, cumulative);
-      }
+      const cumulative = getOrCreateDeliveryAccumulator(session, mediaBuyId, reportedSpend?.currency || mb.currency);
 
       cumulative.impressions += impressions;
       cumulative.clicks += clicks;
@@ -316,12 +342,17 @@ function createStore(session: SessionState): TestControllerStore {
         cumulative.reportedSpend.amount += reportedSpend.amount;
         cumulative.reportedSpend.currency = reportedSpend.currency;
       }
+      applyExtendedDeliveryParams(cumulative, typedParams);
 
       const simulated: Record<string, unknown> = {};
       if (impressions) simulated.impressions = impressions;
       if (clicks) simulated.clicks = clicks;
       if (reportedSpend) simulated.reported_spend = reportedSpend;
       if (conversions) simulated.conversions = conversions;
+      if (typedParams.reach !== undefined) simulated.reach = typedParams.reach;
+      if (typedParams.frequency !== undefined) simulated.frequency = typedParams.frequency;
+      if (typedParams.reach_window !== undefined) simulated.reach_window = typedParams.reach_window;
+      if (typedParams.viewability !== undefined) simulated.viewability = typedParams.viewability;
 
       return {
         success: true,
@@ -331,6 +362,7 @@ function createStore(session: SessionState): TestControllerStore {
           clicks: cumulative.clicks,
           reported_spend: cumulative.reportedSpend,
           conversions: cumulative.conversions,
+          ...extendedDeliverySnapshot(cumulative),
         },
         message: `Delivery simulated for ${mediaBuyId}: ${impressions} impressions, ${clicks} clicks${reportedSpend ? `, $${reportedSpend.amount.toFixed(2)} spend` : ''}`,
       };
@@ -658,30 +690,56 @@ export async function handleComplyTestController(args: ToolArgs, ctx: TrainingCo
     return { success: true, message: `Creative format "${formatId}" seeded — list_creative_formats will use the seeded catalog process-wide` };
   }
 
-  // Pre-capture vendor_metric_values from simulate_delivery before the SDK dispatcher
-  // strips them. The SDK's TestControllerStore.simulateDelivery interface only accepts
-  // standard scalar params; vendor_metric_values passthrough is a future adcp/client
-  // addition. Until then, read from rawArgs here and store in the accumulator directly
-  // so task-handlers.ts can emit them in get_media_buy_delivery by_package entries.
+  // Pre-capture extended simulate_delivery fields before the SDK dispatcher strips
+  // unknown params. The SDK's TestControllerStore.simulateDelivery interface can lag
+  // this repo's controller schema, so rawArgs remains the compatibility path for
+  // new delivery metrics until the SDK accepts them natively.
   if (scenario === 'simulate_delivery') {
     const params = (rawArgs.params ?? {}) as Record<string, unknown>;
     const mediaBuyId = params.media_buy_id as string | undefined;
     const vendorMetricValues = params.vendor_metric_values;
     const mb = mediaBuyId ? findMediaBuy(session, mediaBuyId) : undefined;
-    if (mb && Array.isArray(vendorMetricValues) && vendorMetricValues.length > 0) {
-      const ext = session.complyExtensions;
-      let cumulative = ext.deliverySimulations.get(mediaBuyId!);
-      if (!cumulative) {
-        enforceMapCap(ext.deliverySimulations, mediaBuyId!, 'delivery simulations');
-        cumulative = { impressions: 0, clicks: 0, reportedSpend: { amount: 0, currency: mb.currency }, conversions: 0 };
-        ext.deliverySimulations.set(mediaBuyId!, cumulative);
+    if (mb) {
+      const cumulative = getOrCreateDeliveryAccumulator(session, mediaBuyId!, mb.currency);
+      applyExtendedDeliveryParams(cumulative, params);
+      if (Array.isArray(vendorMetricValues) && vendorMetricValues.length > 0) {
+        cumulative.vendorMetricValues = vendorMetricValues;
       }
-      cumulative.vendorMetricValues = vendorMetricValues;
     }
   }
 
   const store = createStore(session);
   const sdkResponse = await handleTestControllerRequest(store, rawArgs, { seedCache: SEED_CACHE });
+
+  if (
+    scenario === 'simulate_delivery'
+    && sdkResponse
+    && typeof sdkResponse === 'object'
+    && (sdkResponse as { success?: boolean }).success === true
+  ) {
+    const params = (rawArgs.params ?? {}) as Record<string, unknown>;
+    const mediaBuyId = params.media_buy_id as string | undefined;
+    const cumulative = mediaBuyId ? getDeliverySimulation(session, mediaBuyId) : undefined;
+    const simulatedExtras: Record<string, unknown> = {};
+    if (params.reach !== undefined) simulatedExtras.reach = params.reach;
+    if (params.frequency !== undefined) simulatedExtras.frequency = params.frequency;
+    if (params.reach_window !== undefined) simulatedExtras.reach_window = params.reach_window;
+    if (params.viewability !== undefined) simulatedExtras.viewability = params.viewability;
+    if (Object.keys(simulatedExtras).length > 0 || cumulative) {
+      const response = sdkResponse as unknown as Record<string, unknown>;
+      return {
+        ...response,
+        simulated: {
+          ...((response.simulated && typeof response.simulated === 'object') ? response.simulated as Record<string, unknown> : {}),
+          ...simulatedExtras,
+        },
+        cumulative: {
+          ...((response.cumulative && typeof response.cumulative === 'object') ? response.cumulative as Record<string, unknown> : {}),
+          ...(cumulative ? extendedDeliverySnapshot(cumulative) : {}),
+        },
+      };
+    }
+  }
 
   // Augment list_scenarios with our local scenarios so storyboards detect support.
   // The SDK answers from store-method presence, which doesn't see the local handlers.

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -2656,6 +2656,21 @@ export async function handleGetMediaBuyDelivery(args: ToolArgs, ctx: TrainingCon
       };
     })()
     : {};
+  const simulatedReachMetrics = simDelivery && (
+    simDelivery.reach !== undefined
+    || simDelivery.frequency !== undefined
+    || simDelivery.reachWindow
+  )
+    ? {
+      ...(simDelivery.reach !== undefined ? { reach: simDelivery.reach } : {}),
+      ...(simDelivery.reach !== undefined && derivedReachUnit ? { reach_unit: derivedReachUnit } : {}),
+      ...(simDelivery.frequency !== undefined ? { frequency: simDelivery.frequency } : {}),
+      ...(simDelivery.reachWindow ? { reach_window: simDelivery.reachWindow } : {}),
+    }
+    : {};
+  const simulatedViewability = simDelivery?.viewability
+    ? { viewability: simDelivery.viewability }
+    : {};
 
   return {
     reporting_period: {
@@ -2683,7 +2698,9 @@ export async function handleGetMediaBuyDelivery(args: ToolArgs, ctx: TrainingCon
           frequency: +(totalImpressions / totalReach).toFixed(1),
         } : {}),
         ...goalDerivedReach,
+        ...simulatedReachMetrics,
         ...conversionTotals,
+        ...simulatedViewability,
       },
       by_package: byPackage,
     }],

--- a/server/src/training-agent/types.ts
+++ b/server/src/training-agent/types.ts
@@ -186,6 +186,19 @@ export interface ComplyDeliveryAccumulator {
   clicks: number;
   reportedSpend: { amount: number; currency: string };
   conversions: number;
+  reach?: number;
+  frequency?: number;
+  reachWindow?: {
+    kind: 'cumulative' | 'period' | 'rolling';
+    period?: { interval: number; unit: string };
+  };
+  viewability?: {
+    measurable_impressions?: number;
+    viewable_impressions?: number;
+    viewable_rate?: number;
+    viewed_seconds?: number;
+    standard?: string;
+  };
   /** vendor_metric_values injected via comply_test_controller simulate_delivery. */
   vendorMetricValues?: unknown[];
 }

--- a/server/tests/unit/comply-test-controller.test.ts
+++ b/server/tests/unit/comply-test-controller.test.ts
@@ -795,6 +795,56 @@ describe('comply_test_controller', () => {
       expect((result as any).cumulative.impressions).toBe(8000);
     });
 
+    it('injects reach_window and viewability metrics into delivery reporting', async () => {
+      const mediaBuyId = await createMediaBuy(server);
+
+      const viewability = {
+        measurable_impressions: 7400,
+        viewable_impressions: 5920,
+        viewable_rate: 0.8,
+        viewed_seconds: 4.3,
+        standard: 'mrc',
+      };
+      const reachWindow = {
+        kind: 'rolling',
+        period: { interval: 7, unit: 'days' },
+      };
+
+      const { result: simResult } = await simulateCallTool(server, 'comply_test_controller', {
+        scenario: 'simulate_delivery',
+        params: {
+          media_buy_id: mediaBuyId,
+          impressions: 10000,
+          reach: 4000,
+          frequency: 2.5,
+          reach_window: reachWindow,
+          viewability,
+        },
+        account: ACCOUNT,
+        brand: BRAND,
+      });
+
+      expect(simResult.success).toBe(true);
+      expect((simResult as any).simulated.reach).toBe(4000);
+      expect((simResult as any).simulated.frequency).toBe(2.5);
+      expect((simResult as any).simulated.reach_window).toEqual(reachWindow);
+      expect((simResult as any).simulated.viewability).toEqual(viewability);
+      expect((simResult as any).cumulative.reach).toBe(4000);
+      expect((simResult as any).cumulative.reach_window).toEqual(reachWindow);
+      expect((simResult as any).cumulative.viewability).toEqual(viewability);
+
+      const { result: delivery } = await simulateCallTool(server, 'get_media_buy_delivery', {
+        media_buy_id: mediaBuyId,
+        account: ACCOUNT,
+        brand: BRAND,
+      });
+      const totals = (delivery as any).media_buy_deliveries[0].totals;
+      expect(totals.reach).toBe(4000);
+      expect(totals.frequency).toBe(2.5);
+      expect(totals.reach_window).toEqual(reachWindow);
+      expect(totals.viewability).toEqual(viewability);
+    });
+
     it('returns NOT_FOUND for unknown media buy', async () => {
       const { result } = await simulateCallTool(server, 'comply_test_controller', {
         scenario: 'simulate_delivery',

--- a/static/compliance/source/protocols/media-buy/scenarios/delivery_reporting.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/delivery_reporting.yaml
@@ -51,6 +51,13 @@ fixtures:
       channels: ["video"]
       format_ids:
         - id: "video_15s"
+    - product_id: "video_viewability_q2"
+      delivery_type: "guaranteed"
+      channels: ["video"]
+      format_ids:
+        - id: "video_15s"
+      metric_optimization:
+        supported_metrics: ["viewed_seconds"]
   pricing_options:
     - product_id: "outdoor_display_q2"
       pricing_option_id: "cpm_standard"
@@ -62,6 +69,11 @@ fixtures:
       pricing_model: "cpm"
       currency: "USD"
       fixed_price: 12.0
+    - product_id: "video_viewability_q2"
+      pricing_option_id: "vcpm_standard"
+      pricing_model: "vcpm"
+      currency: "USD"
+      fixed_price: 14.0
 
 phases:
   - id: setup
@@ -205,3 +217,141 @@ phases:
           - check: field_present
             path: "media_buy_deliveries"
             description: "Response contains delivery data"
+
+  - id: viewability_delivery
+    title: "Delivery reporting surfaces viewability.viewed_seconds for viewability-capable products"
+    narrative: |
+      3.1 adds `viewability.viewed_seconds` to delivery-metrics — the
+      average in-view duration per measurable impression in seconds. It
+      shares the same denominator (`measurable_impressions`) as
+      `viewable_rate` and is governed by the same measurement `standard`
+      (e.g., MRC 50%/1s for display, 50%/2s for video). Sellers reporting
+      against a `viewed_seconds` optimization goal MUST populate this field.
+
+      This phase creates a separate media buy for a viewability-capable
+      vCPM video product, injects simulated delivery with a full viewability
+      block (measurable_impressions, viewable_impressions, viewable_rate,
+      viewed_seconds, standard), and verifies that get_media_buy_delivery
+      returns the viewed_seconds field inside the viewability block.
+      Response schema validation anchors the viewability block shape and
+      scalar bounds; the named fields make the shared denominator explicit
+      for buyers and controller implementers.
+
+    steps:
+      - id: create_media_buy_viewability
+        title: "Create media buy for viewability-capable video product"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        expected: |
+          Create the media buy. Returns a media_buy_id used for the
+          viewability delivery simulation.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-06-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "video_viewability_q2"
+              budget: 20000
+              pricing_option_id: "vcpm_standard"
+              optimization_goals:
+                - kind: "metric"
+                  metric: "viewed_seconds"
+                  target:
+                    kind: "threshold_rate"
+                    value: 3.0
+                  priority: 1
+          idempotency_key: "$generate:uuid_v4#delivery_reporting_viewability_delivery_create_media_buy"
+        context_outputs:
+          - name: viewability_media_buy_id
+            path: "media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Media buy has a platform-assigned ID"
+
+      - id: simulate_viewability_delivery
+        title: "Inject simulated delivery with full viewability block including viewed_seconds"
+        task: comply_test_controller
+        requires_tool: comply_test_controller
+        stateful: true
+        expected: |
+          The test controller acknowledges the simulated delivery with a
+          full viewability block: measurable_impressions as the shared
+          denominator, viewable_impressions, viewable_rate, viewed_seconds,
+          and the MRC standard.
+        sample_request:
+          account:
+            sandbox: true
+          scenario: "simulate_delivery"
+          params:
+            media_buy_id: "$context.viewability_media_buy_id"
+            impressions: 80000
+            viewability:
+              measurable_impressions: 74000
+              viewable_impressions: 59200
+              viewable_rate: 0.80
+              viewed_seconds: 4.3
+              standard: "mrc"
+            reported_spend:
+              amount: 1030.00
+              currency: "USD"
+        validations:
+          - check: field_value
+            path: "success"
+            allowed_values: [true]
+            description: "Delivery simulation with viewability block succeeds"
+
+      - id: get_viewability_delivery
+        title: "Verify viewability.viewed_seconds appears in delivery report"
+        task: get_media_buy_delivery
+        schema_ref: "media-buy/get-media-buy-delivery-request.json"
+        response_schema_ref: "media-buy/get-media-buy-delivery-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buy_delivery"
+        stateful: true
+        expected: |
+          Delivery response carries a viewability block with viewed_seconds,
+          measurable_impressions (shared denominator), viewable_rate, and
+          standard. The viewed_seconds value represents the average in-view
+          duration per measurable impression — the reporting counterpart to
+          the viewed_seconds optimization metric. The denominator for both
+          viewable_rate and viewed_seconds is measurable_impressions (not
+          total impressions) since some environments cannot measure viewability.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "$context.viewability_media_buy_id"
+          include_package_daily_breakdown: true
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buy-delivery-response.json schema"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.viewability"
+            description: "Viewability block present on delivery row"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.viewability.viewed_seconds"
+            description: "viewed_seconds — average in-view duration per measurable impression — present in viewability block"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.viewability.measurable_impressions"
+            description: "measurable_impressions denominator present (shared basis for viewable_rate and viewed_seconds)"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.viewability.viewable_impressions"
+            description: "viewable_impressions numerator present for viewable_rate"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.viewability.viewable_rate"
+            description: "viewable_rate present alongside viewed_seconds in the viewability block"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.viewability.standard"
+            description: "viewability standard present — governs threshold for both viewable_rate and viewed_seconds"

--- a/static/compliance/source/protocols/media-buy/scenarios/reach_buy_flow.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/reach_buy_flow.yaml
@@ -54,10 +54,10 @@ narrative: |
 
   Per-window reach-window breakdown (cumulative vs period vs rolling
   semantics declared in delivery-metrics.json's reach_window block) is
-  deliberately NOT asserted at the per-row level here. The scenario asserts
-  that totals.reach and totals.frequency are present at the buy level;
-  follow-up scenarios will exercise the per-window semantics once the
-  reach_window field is widely populated by adopters.
+  asserted in dedicated follow-up phases after the base reach delivery
+  check. The omission case remains an advisory because reach_window is
+  schema-valid to omit, but buyers must treat omitted-window reach rows
+  as unsafe to sum or average across reporting periods.
 
 agent:
   interaction_model: media_buy_seller
@@ -347,3 +347,477 @@ phases:
           - check: field_present
             path: "media_buy_deliveries[0].totals.frequency"
             description: "Frequency surfaced at the buy level — average exposures per reach unit"
+
+  - id: reach_window_cumulative
+    title: "Delivery row carries reach_window.kind cumulative"
+    narrative: |
+      A cumulative reach_window declares that the reach value represents
+      unique audiences since campaign start. Each successive delivery row
+      supersedes the prior one — buyers MUST NOT sum cumulative rows to
+      compute campaign reach, since each later row already includes all
+      prior audiences. No period field is required for cumulative.
+
+      This phase injects a delivery row with reach_window.kind cumulative
+      and verifies that the seller surfaces the window semantics on the
+      delivery response. Sellers that omit reach_window on a reach-optimized
+      buy force buyers to guess the window — creating silent double-counting
+      when buyers aggregate across reporting periods.
+
+    steps:
+      - id: create_media_buy_cumulative_reach
+        title: "Create media buy for cumulative reach-window delivery"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        expected: |
+          Create a fresh reach-optimized media buy so the cumulative
+          reach_window assertion is not contaminated by prior delivery
+          simulation calls.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-06-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "reach_ctv_q2"
+              budget: 10000
+              pricing_option_id: "auction_cpm"
+              optimization_goals:
+                - kind: "metric"
+                  metric: "reach"
+                  reach_unit: "households"
+                  priority: 1
+          idempotency_key: "$generate:uuid_v4#reach_buy_flow_reach_window_cumulative_create_media_buy"
+        context_outputs:
+          - name: cumulative_media_buy_id
+            path: "media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Media buy has a platform-assigned ID"
+
+      - id: simulate_cumulative_reach
+        title: "Inject delivery with cumulative reach_window"
+        task: comply_test_controller
+        requires_tool: comply_test_controller
+        stateful: true
+        expected: |
+          The test controller acknowledges the simulated delivery with a
+          cumulative reach_window.
+        sample_request:
+          account:
+            sandbox: true
+          scenario: "simulate_delivery"
+          params:
+            media_buy_id: "$context.cumulative_media_buy_id"
+            impressions: 1200000
+            reach: 400000
+            frequency: 3.0
+            reach_window:
+              kind: "cumulative"
+            reported_spend:
+              amount: 22000.00
+              currency: "USD"
+        validations:
+          - check: field_value
+            path: "success"
+            allowed_values: [true]
+            description: "Delivery simulation with cumulative reach_window succeeds"
+
+      - id: get_cumulative_reach_delivery
+        title: "Verify reach_window.kind cumulative on delivery row"
+        task: get_media_buy_delivery
+        schema_ref: "media-buy/get-media-buy-delivery-request.json"
+        response_schema_ref: "media-buy/get-media-buy-delivery-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buy_delivery"
+        stateful: true
+        expected: |
+          Delivery row carries reach_window with kind: cumulative. No period
+          field is expected — cumulative reach is campaign-to-date and the
+          window is implicit. The row's reach value is the total unique count
+          since campaign start; each subsequent cumulative row supersedes
+          this one.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "$context.cumulative_media_buy_id"
+          include_package_daily_breakdown: true
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buy-delivery-response.json schema"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.reach_window"
+            description: "Seller populates reach_window on the delivery row"
+          - check: field_value
+            path: "media_buy_deliveries[0].totals.reach_window.kind"
+            allowed_values: ["cumulative"]
+            description: "reach_window.kind is cumulative as injected"
+
+  - id: reach_window_period
+    title: "Delivery row carries reach_window.kind period with period field"
+    narrative: |
+      A period reach_window declares that the reach value covers a single
+      non-overlapping reporting period (e.g., one calendar day). Adjacent
+      period rows do not share audiences by construction — the same person
+      MAY appear across multiple periods — so buyers MUST NOT sum period
+      rows to compute campaign reach. The period field is REQUIRED for
+      kind: period and declares the snapshot length (e.g., 1 day).
+
+      This phase injects a delivery row with reach_window.kind period and
+      period: {interval:1, unit:"days"} and verifies the seller surfaces
+      both the kind and the period duration on the delivery response.
+
+    steps:
+      - id: create_media_buy_period_reach
+        title: "Create media buy for period reach-window delivery"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        expected: |
+          Create a fresh reach-optimized media buy so the period
+          reach_window assertion is isolated from cumulative or rolling
+          delivery simulations.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-06-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "reach_ctv_q2"
+              budget: 10000
+              pricing_option_id: "auction_cpm"
+              optimization_goals:
+                - kind: "metric"
+                  metric: "reach"
+                  reach_unit: "households"
+                  priority: 1
+          idempotency_key: "$generate:uuid_v4#reach_buy_flow_reach_window_period_create_media_buy"
+        context_outputs:
+          - name: period_media_buy_id
+            path: "media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Media buy has a platform-assigned ID"
+
+      - id: simulate_period_reach
+        title: "Inject delivery with period reach_window"
+        task: comply_test_controller
+        requires_tool: comply_test_controller
+        stateful: true
+        expected: |
+          The test controller acknowledges the simulated delivery with a
+          period reach_window carrying a 1-day period.
+        sample_request:
+          account:
+            sandbox: true
+          scenario: "simulate_delivery"
+          params:
+            media_buy_id: "$context.period_media_buy_id"
+            impressions: 175000
+            reach: 140000
+            frequency: 1.25
+            reach_window:
+              kind: "period"
+              period:
+                interval: 1
+                unit: "days"
+            reported_spend:
+              amount: 3200.00
+              currency: "USD"
+        validations:
+          - check: field_value
+            path: "success"
+            allowed_values: [true]
+            description: "Delivery simulation with period reach_window succeeds"
+
+      - id: get_period_reach_delivery
+        title: "Verify reach_window.kind period and period duration on delivery row"
+        task: get_media_buy_delivery
+        schema_ref: "media-buy/get-media-buy-delivery-request.json"
+        response_schema_ref: "media-buy/get-media-buy-delivery-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buy_delivery"
+        stateful: true
+        expected: |
+          Delivery row carries reach_window with kind: period and a period
+          duration of 1 day. The period field is required for kind: period —
+          its absence would leave buyers unable to determine the snapshot
+          length, making cross-period reach comparisons unreliable.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "$context.period_media_buy_id"
+          include_package_daily_breakdown: true
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buy-delivery-response.json schema"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.reach_window"
+            description: "Seller populates reach_window on the delivery row"
+          - check: field_value
+            path: "media_buy_deliveries[0].totals.reach_window.kind"
+            allowed_values: ["period"]
+            description: "reach_window.kind is period as injected"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.reach_window.period"
+            description: "period field is present — required for kind: period"
+
+  - id: reach_window_rolling
+    title: "Delivery row carries reach_window.kind rolling with period field"
+    narrative: |
+      A rolling reach_window declares that the reach value covers a trailing
+      window ending at the row's reporting timestamp (e.g., trailing-7-day
+      unique reach). Adjacent rolling rows overlap — each row stands alone
+      and MUST NOT be summed; summing rolling rows double-counts audiences
+      seen in multiple windows. The period field is REQUIRED for kind: rolling
+      and declares the trailing-window length (e.g., 7 days).
+
+      This phase injects a delivery row with reach_window.kind rolling and
+      period: {interval:7, unit:"days"} and verifies the seller surfaces
+      both the kind and the window duration. A trailing-7-day reach window
+      is the canonical frequency-cap companion — buyers reading this value
+      know exactly which audiences are within the 7-day dedup window.
+
+    steps:
+      - id: create_media_buy_rolling_reach
+        title: "Create media buy for rolling reach-window delivery"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        expected: |
+          Create a fresh reach-optimized media buy so the rolling
+          reach_window assertion is isolated from period or cumulative
+          delivery simulations.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-06-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "reach_ctv_q2"
+              budget: 10000
+              pricing_option_id: "auction_cpm"
+              optimization_goals:
+                - kind: "metric"
+                  metric: "reach"
+                  reach_unit: "households"
+                  priority: 1
+          idempotency_key: "$generate:uuid_v4#reach_buy_flow_reach_window_rolling_create_media_buy"
+        context_outputs:
+          - name: rolling_media_buy_id
+            path: "media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Media buy has a platform-assigned ID"
+
+      - id: simulate_rolling_reach
+        title: "Inject delivery with rolling reach_window"
+        task: comply_test_controller
+        requires_tool: comply_test_controller
+        stateful: true
+        expected: |
+          The test controller acknowledges the simulated delivery with a
+          rolling reach_window carrying a 7-day trailing window.
+        sample_request:
+          account:
+            sandbox: true
+          scenario: "simulate_delivery"
+          params:
+            media_buy_id: "$context.rolling_media_buy_id"
+            impressions: 450000
+            reach: 210000
+            frequency: 2.1
+            reach_window:
+              kind: "rolling"
+              period:
+                interval: 7
+                unit: "days"
+            reported_spend:
+              amount: 8500.00
+              currency: "USD"
+        validations:
+          - check: field_value
+            path: "success"
+            allowed_values: [true]
+            description: "Delivery simulation with rolling reach_window succeeds"
+
+      - id: get_rolling_reach_delivery
+        title: "Verify reach_window.kind rolling and period duration on delivery row"
+        task: get_media_buy_delivery
+        schema_ref: "media-buy/get-media-buy-delivery-request.json"
+        response_schema_ref: "media-buy/get-media-buy-delivery-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buy_delivery"
+        stateful: true
+        expected: |
+          Delivery row carries reach_window with kind: rolling and a period
+          of 7 days. The period field is required for kind: rolling — without
+          it, buyers cannot determine the trailing window length and cannot
+          safely use the reach value for frequency optimization.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "$context.rolling_media_buy_id"
+          include_package_daily_breakdown: true
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buy-delivery-response.json schema"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.reach_window"
+            description: "Seller populates reach_window on the delivery row"
+          - check: field_value
+            path: "media_buy_deliveries[0].totals.reach_window.kind"
+            allowed_values: ["rolling"]
+            description: "reach_window.kind is rolling as injected"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.reach_window.period"
+            description: "period field is present — required for kind: rolling"
+
+  - id: reach_window_absent_advisory
+    title: "Advisory: delivery row with reach but no reach_window is schema-valid but sum-unsafe"
+    narrative: |
+      Reach/frequency rows with `reach_window` omitted are schema-valid —
+      the schema marks the field SHOULD (not MUST) populate it. However,
+      buyers MUST NOT treat omitted-window rows as sum-safe: the value may
+      be a daily snapshot, a cumulative total, or something else. Summing
+      reach values across rows without a declared window silently
+      double-counts audiences.
+
+      This phase simulates a delivery row without reach_window and issues
+      an advisory (not a conformance fail) when the seller returns reach
+      without the window declaration. Advisory grading: sellers that do
+      not populate reach_window on reach-optimized buys are warned but
+      not failed — the omission is spec-valid. Sellers should treat this
+      advisory as a signal to add reach_window to their delivery responses
+      for 3.1+ buyers.
+
+    steps:
+      - id: create_media_buy_reach_no_window
+        title: "Create media buy for omitted reach-window advisory"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        expected: |
+          Create a fresh reach-optimized media buy so the omitted-window
+          advisory observes a delivery row whose reach_window was never
+          populated by earlier simulation calls.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-06-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "reach_ctv_q2"
+              budget: 10000
+              pricing_option_id: "auction_cpm"
+              optimization_goals:
+                - kind: "metric"
+                  metric: "reach"
+                  reach_unit: "households"
+                  priority: 1
+          idempotency_key: "$generate:uuid_v4#reach_buy_flow_reach_window_absent_create_media_buy"
+        context_outputs:
+          - name: no_window_media_buy_id
+            path: "media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Media buy has a platform-assigned ID"
+
+      - id: simulate_reach_no_window
+        title: "Inject delivery with reach but no reach_window"
+        task: comply_test_controller
+        requires_tool: comply_test_controller
+        stateful: true
+        expected: |
+          The test controller injects a delivery row with reach and frequency
+          but no reach_window. This is a valid operation — the scenario
+          tests the advisory behavior, not a rejection.
+        sample_request:
+          account:
+            sandbox: true
+          scenario: "simulate_delivery"
+          params:
+            media_buy_id: "$context.no_window_media_buy_id"
+            impressions: 300000
+            reach: 180000
+            frequency: 1.67
+            reported_spend:
+              amount: 5800.00
+              currency: "USD"
+        validations:
+          - check: field_value
+            path: "success"
+            allowed_values: [true]
+            description: "Delivery simulation without reach_window succeeds"
+
+      - id: get_delivery_reach_no_window
+        title: "Verify advisory when reach is present but reach_window is absent"
+        task: get_media_buy_delivery
+        schema_ref: "media-buy/get-media-buy-delivery-request.json"
+        response_schema_ref: "media-buy/get-media-buy-delivery-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buy_delivery"
+        stateful: true
+        expected: |
+          Delivery row contains reach without reach_window. Schema-valid —
+          this is a SHOULD, not a MUST. The advisory validation below fires
+          when reach_window is absent, surfacing the omission for the seller
+          to address in future delivery responses.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "$context.no_window_media_buy_id"
+          include_package_daily_breakdown: true
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buy-delivery-response.json schema"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.reach_window"
+            severity: advisory
+            permanent_advisory:
+              reason: "delivery-metrics.json declares reach_window as SHOULD (not MUST) for 3.1. Omitting it is schema-valid but prevents buyers from determining the measurement window, making the reach value sum-unsafe across reporting periods. Sellers on the 3.1 track should populate reach_window on all reach-bearing delivery rows. This advisory is permanent: promotion to required is a 4.0 breaking change and will be tracked separately."
+            description: "reach_window populated on reach-bearing delivery row (advisory — SHOULD per 3.1 spec)"

--- a/static/schemas/source/compliance/comply-test-controller-request.json
+++ b/static/schemas/source/compliance/comply-test-controller-request.json
@@ -520,6 +520,97 @@
             "currency"
           ]
         },
+        "reach": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Unique reach count to inject into the simulated delivery row. Used by simulate_delivery. The unit of measurement matches the reach_unit declared on the media buy's optimization goal. When supplied, sellers MUST surface this value at `totals.reach` in the next get_media_buy_delivery response."
+        },
+        "frequency": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Average frequency per reach unit to inject. Used by simulate_delivery. When supplied alongside reach, sellers MUST surface this value at `totals.frequency`. The measurement window for this frequency value is declared in `reach_window` when also present."
+        },
+        "reach_window": {
+          "type": "object",
+          "description": "Measurement window semantics to attach to the simulated reach and frequency values. Used by simulate_delivery. When present, sellers MUST populate `reach_window` on the delivery row so buyers can determine the window semantics (cumulative vs. period vs. rolling). Omitting this param produces a row with no `reach_window` — valid per schema but sum-unsafe. Mirrors the `reach_window` shape in delivery-metrics.json.",
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "cumulative",
+                "period",
+                "rolling"
+              ],
+              "description": "Window kind. `cumulative` — no period field required. `period` and `rolling` — period field REQUIRED."
+            },
+            "period": {
+              "allOf": [
+                {
+                  "$ref": "/schemas/core/duration.json"
+                }
+              ],
+              "description": "Duration of the measurement window. REQUIRED when kind is `period` or `rolling`. Matches the `period` field in delivery-metrics.json's reach_window block."
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "kind": {
+                    "enum": [
+                      "period",
+                      "rolling"
+                    ]
+                  }
+                },
+                "required": [
+                  "kind"
+                ]
+              },
+              "then": {
+                "required": [
+                  "period"
+                ]
+              }
+            }
+          ],
+          "additionalProperties": true
+        },
+        "viewability": {
+          "type": "object",
+          "description": "Viewability metrics to inject into the simulated delivery row. Used by simulate_delivery. When present, sellers MUST surface these values inside `viewability` on the next get_media_buy_delivery response. Mirrors the `viewability` block in delivery-metrics.json: measurable_impressions is the shared denominator for viewable_rate and viewed_seconds.",
+          "properties": {
+            "measurable_impressions": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Impressions where viewability could be measured. Coverage denominator for viewable_rate and viewed_seconds."
+            },
+            "viewable_impressions": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Impressions that met the viewability threshold."
+            },
+            "viewable_rate": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1,
+              "description": "Viewable impression rate (viewable_impressions / measurable_impressions)."
+            },
+            "viewed_seconds": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Average in-view duration per measurable impression in seconds. Reporting counterpart to the viewed_seconds optimization metric."
+            },
+            "standard": {
+              "$ref": "/schemas/enums/viewability-standard.json",
+              "description": "Viewability measurement standard governing the threshold for viewable_rate and viewed_seconds."
+            }
+          },
+          "additionalProperties": true
+        },
         "spend_percentage": {
           "type": "number",
           "minimum": 0,

--- a/static/schemas/source/compliance/comply-test-controller-response.json
+++ b/static/schemas/source/compliance/comply-test-controller-response.json
@@ -154,7 +154,7 @@
     },
     {
       "title": "SimulationSuccess",
-      "description": "A simulate_delivery or simulate_budget_spend scenario succeeded. For delivery: simulated contains impressions/clicks/reported_spend/conversions and cumulative contains running totals. For budget: simulated contains spend_percentage/computed_spend/budget.",
+      "description": "A simulate_delivery or simulate_budget_spend scenario succeeded. For delivery: simulated contains the metrics injected by this call (impressions/clicks/reported_spend/conversions plus optional reach/frequency/reach_window/viewability values) and cumulative contains running totals or latest non-additive metric state. For budget: simulated contains spend_percentage/computed_spend/budget.",
       "type": "object",
       "properties": {
         "success": {


### PR DESCRIPTION
Closes #4931

## Summary

- Adds delivery-reporting storyboard coverage for `reach_window` cumulative, period, and rolling shapes.
- Adds an advisory for reach/frequency delivery rows that omit `reach_window`, which remain schema-valid but are not sum/average-safe for buyers.
- Adds `viewability.viewed_seconds` coverage on a viewability-capable buy that explicitly optimizes for `viewed_seconds`.
- Extends `simulate_delivery` controller schema/docs and the training-agent implementation so injected `reach`, `frequency`, `reach_window`, and `viewability` values round-trip through `get_media_buy_delivery`.

## Expert review

Ran protocol/schema and code-review experts before publishing. Must-fix findings were addressed:

- Isolated each reach-window assertion on its own fresh media buy so additive delivery simulation state cannot contaminate later phases.
- Bound the viewed-seconds delivery check to an explicit `viewed_seconds` optimization goal.
- Updated the reference training-agent accumulator/emission path and added unit coverage for injected reach-window and viewability metrics.
- Updated controller docs and response prose for the expanded `simulate_delivery` contract.

## Validation

- `git diff --check`
- `npm run test:schemas`
- `npm run test:json-schema`
- `npm run test:storyboard-validations-paths`
- `npm run test:storyboard-check-enum`
- `npm run test:storyboard-advisory-expiry`
- `npm run test:storyboard-response-schema`
- `npm run test:storyboard-contradictions`
- Targeted sample_request schema lint for changed media-buy storyboards
- `npx vitest run server/tests/unit/comply-test-controller.test.ts`
- `npm run typecheck`
- `npm run build:schemas`
- `npm run build:compliance`
- `npm run test:storyboards`
- Pre-push hook also passed current storyboard matrix, 3.0 compatibility storyboard matrix, and docs validation.

Known unrelated local red: full `npm run test:server-unit` failed once in `server/tests/unit/addie-router.test.ts` with expected `respond` / received `ignore` for an Addie router confidence test, outside this PR's touched code. The targeted controller unit test and precommit unit chain passed.