### PR TITLE
feat(compliance): surface runner notices in dashboard panel

### DIFF
--- a/.changeset/compliance-notices-dashboard.md
+++ b/.changeset/compliance-notices-dashboard.md
@@ -1,0 +1,4 @@
+---
+---
+
+Surface compliance run notices from runner output through DB, API, and dashboard panel.

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ server/node_modules
 *.tsbuildinfo
 .codex/
 .claude/scheduled_tasks.lock
+.claude/worktrees/
 
 # Misc
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ server/node_modules
 *.tsbuildinfo
 .codex/
 .claude/scheduled_tasks.lock
-.claude/worktrees/
 
 # Misc
 .DS_Store

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -384,6 +384,94 @@
       background: var(--color-gray-200, #e5e7eb);
       color: var(--color-text-muted);
     }
+    /* Compliance notices (runner-output-contract.yaml) */
+    .compliance-notices {
+      margin-top: var(--space-3);
+      border-top: 1px solid var(--color-gray-200, #e5e7eb);
+      padding-top: var(--space-2);
+    }
+    .compliance-notices-label {
+      font-size: var(--text-xs);
+      font-weight: var(--font-semibold);
+      color: var(--color-text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: var(--space-1);
+    }
+    .compliance-notice {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-1);
+      padding: var(--space-2);
+      border-radius: 4px;
+      border: 1px solid var(--color-gray-200, #e5e7eb);
+      background: var(--color-gray-50, #f9fafb);
+      font-size: var(--text-xs);
+      line-height: 1.5;
+      margin-bottom: var(--space-1);
+    }
+    .compliance-notice:last-child { margin-bottom: 0; }
+    .compliance-notice-header {
+      display: flex;
+      align-items: center;
+      gap: var(--space-2);
+      flex-wrap: wrap;
+    }
+    .compliance-notice-severity {
+      display: inline-block;
+      padding: 1px 6px;
+      border-radius: 3px;
+      font-size: 10px;
+      font-weight: var(--font-semibold);
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      white-space: nowrap;
+    }
+    .compliance-notice-severity--info {
+      background: var(--color-gray-200, #e5e7eb);
+      color: var(--color-text-secondary, #374151);
+    }
+    .compliance-notice-severity--deprecation {
+      background: var(--color-warning-100, #fef3c7);
+      color: var(--color-warning-700, #b45309);
+    }
+    .compliance-notice-severity--future_required {
+      background: #ffedd5;
+      color: #c2410c;
+    }
+    .compliance-notice-severity--unknown {
+      background: var(--color-gray-100, #f3f4f6);
+      color: var(--color-text-muted);
+    }
+    .compliance-notice-code {
+      font-family: var(--font-mono, monospace);
+      font-size: 10px;
+      color: var(--color-text-muted);
+      background: var(--color-gray-100, #f3f4f6);
+      padding: 1px 5px;
+      border-radius: 3px;
+    }
+    .compliance-notice-message {
+      color: var(--color-text-secondary, #374151);
+    }
+    .compliance-notice-meta {
+      color: var(--color-text-muted);
+      font-size: 10px;
+    }
+    .compliance-notice-details summary {
+      cursor: pointer;
+      color: var(--color-text-muted);
+      font-size: 10px;
+      user-select: none;
+    }
+    .compliance-notice-details[open] summary { margin-bottom: 2px; }
+    .compliance-notice-cap-path {
+      font-family: var(--font-mono, monospace);
+      font-size: 10px;
+      background: var(--color-gray-100, #f3f4f6);
+      padding: 1px 5px;
+      border-radius: 3px;
+    }
     .history-run {
       display: flex;
       align-items: center;
@@ -1623,6 +1711,65 @@
     // Empty state: when storyboards are passing but no badges have issued
     // (membership inactive, specialisms not declared), surface a hint
     // pointing at the docs.
+    // Build the notices section HTML for a compliance status object.
+    // Forward-compat: unknown severity values render with a neutral style
+    // rather than being dropped (runner-output-contract.yaml).
+    // XSS note: all notice text fields (message, code, etc.) are rendered
+    // via DOM textContent or escapeHtml — NOT innerHTML — because these
+    // strings originate from storyboard authors, not AAO.
+    function buildNoticesSectionHtml(cs) {
+      const notices = Array.isArray(cs && cs.notices) ? cs.notices : [];
+      if (notices.length === 0) return '';
+
+      const SEVERITY_CLASS = {
+        info: 'compliance-notice-severity--info',
+        deprecation: 'compliance-notice-severity--deprecation',
+        future_required: 'compliance-notice-severity--future_required',
+      };
+
+      const noticesHtml = notices.map(notice => {
+        const severityClass = SEVERITY_CLASS[notice.severity] || 'compliance-notice-severity--unknown';
+        // All text content rendered via escapeHtml (storyboard-author-controlled)
+        const severityLabel = escapeHtml(String(notice.severity ?? ''));
+        const codeLabel = escapeHtml(String(notice.code ?? ''));
+        const messageText = escapeHtml(String(notice.message ?? ''));
+
+        let metaHtml = '';
+        if (notice.effective_version) {
+          metaHtml += `<span class="compliance-notice-meta">Effective in v${escapeHtml(String(notice.effective_version))}</span> `;
+        }
+        if (notice.reference_url && typeof notice.reference_url === 'string' && notice.reference_url.startsWith('http')) {
+          metaHtml += `<a href="${escapeHtml(notice.reference_url)}" target="_blank" rel="noopener" class="compliance-notice-meta">Spec reference</a>`;
+        }
+
+        let capPathHtml = '';
+        if (notice.capability_path) {
+          capPathHtml = `
+            <details class="compliance-notice-details">
+              <summary>Capability path</summary>
+              <span class="compliance-notice-cap-path">${escapeHtml(String(notice.capability_path))}</span>
+            </details>`;
+        }
+
+        return `
+          <div class="compliance-notice">
+            <div class="compliance-notice-header">
+              <span class="compliance-notice-severity ${severityClass}">${severityLabel}</span>
+              <span class="compliance-notice-code">${codeLabel}</span>
+            </div>
+            <div class="compliance-notice-message">${messageText}</div>
+            ${metaHtml ? '<div>' + metaHtml + '</div>' : ''}
+            ${capPathHtml}
+          </div>`;
+      }).join('');
+
+      return `
+        <div class="compliance-notices">
+          <div class="compliance-notices-label">Notices</div>
+          ${noticesHtml}
+        </div>`;
+    }
+
     function renderVerificationPanel(cs, agentUrl, hasAuth) {
       const badges = Array.isArray(cs && cs.verified_badges) ? cs.verified_badges : [];
       // Audit-comment from #3603: values MUST NOT end in "Agent" or
@@ -1738,6 +1885,7 @@
             </div>
             ${declaredHtml}
             <div class="verification-eligibility-hint">${hint}</div>
+            ${buildNoticesSectionHtml(cs)}
           </div>`;
       }
 
@@ -1876,6 +2024,7 @@
           </div>
           ${rowsHtml}
           ${liveHint}
+          ${buildNoticesSectionHtml(cs)}
         </div>`;
     }
 

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -1714,9 +1714,9 @@
     // Build the notices section HTML for a compliance status object.
     // Forward-compat: unknown severity values render with a neutral style
     // rather than being dropped (runner-output-contract.yaml).
-    // XSS note: all notice text fields (message, code, etc.) are rendered
-    // via DOM textContent or escapeHtml — NOT innerHTML — because these
-    // strings originate from storyboard authors, not AAO.
+    // XSS note: all notice text fields (message, code, etc.) are escaped
+    // before being included in the rendered HTML because these strings
+    // originate from storyboard authors, not AAO.
     function buildNoticesSectionHtml(cs) {
       const notices = Array.isArray(cs && cs.notices) ? cs.notices : [];
       if (notices.length === 0) return '';
@@ -1729,7 +1729,8 @@
 
       const noticesHtml = notices.map(notice => {
         const severityClass = SEVERITY_CLASS[notice.severity] || 'compliance-notice-severity--unknown';
-        // All text content rendered via escapeHtml (storyboard-author-controlled)
+        // All text content is storyboard-author-controlled; escape before
+        // including it in HTML or attribute contexts.
         const severityLabel = escapeHtml(String(notice.severity ?? ''));
         const codeLabel = escapeHtml(String(notice.code ?? ''));
         const messageText = escapeHtml(String(notice.message ?? ''));

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -577,6 +577,10 @@ export function complianceResultToDbInput(
     triggered_by: triggeredBy,
     storyboard_statuses: deriveStoryboardStatuses(result, storyboardIds),
     step_diagnostics: extractFailingStepDiagnostics(result),
+    // Forward-compat: notices are an optional field in the runner output
+    // contract (run_summary.notices). Unknown codes/severities are stored
+    // verbatim — do not filter or validate the values here.
+    notices_json: (result.summary as any).notices ?? null,
   };
 }
 

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -77,6 +77,22 @@ export interface AgentRegistryMetadata {
   updated_at: Date;
 }
 
+/**
+ * A single advisory notice emitted by the compliance runner at run-summary
+ * level. Defined in static/compliance/source/universal/runner-output-contract.yaml.
+ *
+ * Forward-compat: receivers MUST treat unknown `code` and `severity` values as
+ * well-formed and surface them verbatim — do not validate or filter these fields.
+ */
+export interface NoticeEntry {
+  severity: string;
+  code: string;
+  message: string;
+  effective_version?: string | null;
+  capability_path?: string | null;
+  reference_url?: string | null;
+}
+
 export interface ComplianceRun {
   id: string;
   agent_url: string;
@@ -95,6 +111,7 @@ export interface ComplianceRun {
   triggered_by: TriggeredBy;
   triggered_org_id: string | null;
   dry_run: boolean;
+  notices_json: NoticeEntry[] | null;
 }
 
 export interface TrackSummaryEntry {
@@ -234,6 +251,12 @@ export interface RecordComplianceRunInput {
   dry_run?: boolean;
   storyboard_statuses?: StoryboardStatusEntry[];
   step_diagnostics?: StepDiagnosticEntry[];
+  /**
+   * Advisory notices emitted by the runner at run-summary level. Stored as
+   * JSONB. Forward-compat: unknown codes/severities are preserved verbatim.
+   * See NoticeEntry and runner-output-contract.yaml.
+   */
+  notices_json?: NoticeEntry[] | null;
 }
 
 // =====================================================
@@ -313,8 +336,9 @@ export class ComplianceDatabase {
           agent_url, lifecycle_stage, overall_status, headline,
           total_duration_ms, tracks_json, tracks_passed, tracks_failed,
           tracks_skipped, tracks_partial, agent_profile_json,
-          observations_json, triggered_by, triggered_org_id, dry_run
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+          observations_json, triggered_by, triggered_org_id, dry_run,
+          notices_json
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
         RETURNING *`,
         [
           input.agent_url,
@@ -332,6 +356,7 @@ export class ComplianceDatabase {
           input.triggered_by ?? 'heartbeat',
           input.triggered_org_id ?? null,
           input.dry_run ?? true,
+          input.notices_json ? JSON.stringify(input.notices_json) : null,
         ],
       );
       const run = runResult.rows[0] as ComplianceRun;
@@ -692,6 +717,28 @@ export class ComplianceDatabase {
     }
     if (!Array.isArray(list)) return [];
     return list.filter((s: unknown): s is string => typeof s === 'string');
+  }
+
+  /**
+   * Return the notices_json array from the most recent non-dry-run compliance
+   * run for the agent. Returns an empty array when no run exists or when the
+   * latest run stored no notices.
+   *
+   * Forward-compat: unknown codes/severities are preserved verbatim — callers
+   * MUST NOT validate or filter notice.code / notice.severity values.
+   */
+  async getLatestNotices(agentUrl: string): Promise<NoticeEntry[]> {
+    const result = await query(
+      `SELECT notices_json
+       FROM agent_compliance_runs
+       WHERE agent_url = $1 AND dry_run = FALSE
+       ORDER BY tested_at DESC
+       LIMIT 1`,
+      [agentUrl],
+    );
+    const raw = result.rows[0]?.notices_json;
+    if (!Array.isArray(raw)) return [];
+    return raw as NoticeEntry[];
   }
 
   // ----- Due-for-Check Query -----

--- a/server/src/db/migrations/493_agent_compliance_runs_notices_json.sql
+++ b/server/src/db/migrations/493_agent_compliance_runs_notices_json.sql
@@ -1,0 +1,14 @@
+-- Migration 493: add notices_json to agent_compliance_runs.
+--
+-- Surfaces runner-emitted advisory notices from run-summary level through to
+-- the DB, API, and dashboard. Notices are informational signals (info,
+-- deprecation, future_required) that MUST NOT affect pass/fail counters.
+-- Defined in static/compliance/source/universal/runner-output-contract.yaml.
+--
+-- Forward-compat: unknown notice codes and severities are stored verbatim.
+
+ALTER TABLE agent_compliance_runs
+  ADD COLUMN IF NOT EXISTS notices_json JSONB;
+
+COMMENT ON COLUMN agent_compliance_runs.notices_json IS
+  'Advisory notices emitted by the compliance runner at run-summary level (runner-output-contract.yaml §run_summary.notices). Each element has {severity, code, message} required and {effective_version, capability_path, reference_url} optional. Stored verbatim — unknown codes/severities MUST be preserved. NULL when the runner emitted no notices.';

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -4476,6 +4476,17 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         logger.warn({ err, agentUrl }, "Latest declared specialisms query failed");
       }
 
+      // Advisory notices from the latest run — forward-looking migration
+      // advisories emitted by the runner (e.g., deprecated specialism names,
+      // future-required capabilities). Forward-compat: unknown codes/severities
+      // are passed through verbatim; callers MUST NOT filter on these values.
+      let notices: Awaited<ReturnType<typeof complianceDb.getLatestNotices>> = [];
+      try {
+        notices = await complianceDb.getLatestNotices(agentUrl);
+      } catch (err) {
+        logger.warn({ err, agentUrl }, "Notices query failed (column may not exist yet)");
+      }
+
       // Per-specialism status — the dashboard renders pass/fail/untested
       // dots so the developer can see which declared specialism is the
       // cause of an overall `failing` status without cross-referencing
@@ -4550,6 +4561,9 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         check_interval_hours: metadata?.check_interval_hours ?? 12,
         declared_specialisms: declaredSpecialisms,
         specialism_status: specialismStatus,
+        // Advisory notices from the latest run. Forward-compat: unknown codes
+        // and severities are passed through verbatim (runner-output-contract.yaml).
+        notices,
         // Owner-scoped: content is null/false for anonymous and cross-org
         // viewers, populated only when the authenticated viewer owns the
         // agent. Keys are always present so non-owners can't detect

--- a/server/tests/unit/compliance-notices.test.ts
+++ b/server/tests/unit/compliance-notices.test.ts
@@ -142,7 +142,7 @@ describe('complianceResultToDbInput — notices pass-through', () => {
     expect(dbInput.notices_json).toBeNull();
   });
 
-  it('sets notices_json to null when summary.notices is an empty array', () => {
+  it('preserves an empty summary.notices array', () => {
     const result = baseResult({ notices: [] });
 
     const dbInput = complianceResultToDbInput(
@@ -151,11 +151,6 @@ describe('complianceResultToDbInput — notices pass-through', () => {
       'production',
     );
 
-    // Empty array is falsy via `?? null` — acceptable: no notices to show
-    // (null and [] are both "no notices" in the API/dashboard logic)
-    expect(dbInput.notices_json == null || Array.isArray(dbInput.notices_json)).toBe(true);
-    if (Array.isArray(dbInput.notices_json)) {
-      expect(dbInput.notices_json).toHaveLength(0);
-    }
+    expect(dbInput.notices_json).toEqual([]);
   });
 });

--- a/server/tests/unit/compliance-notices.test.ts
+++ b/server/tests/unit/compliance-notices.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests that compliance runner notices are correctly passed through
+ * complianceResultToDbInput() and preserved verbatim (forward-compat).
+ *
+ * runner-output-contract.yaml: receivers MUST treat unknown code/severity
+ * values as well-formed and surface them verbatim — do not drop or
+ * schema-validate these fields.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@adcp/sdk/testing', () => ({
+  setAgentTesterLogger: vi.fn(),
+  comply: vi.fn(),
+  loadComplianceIndex: vi.fn(() => ({ specialisms: [] })),
+  SAMPLE_BRIEFS: [],
+  getBriefsByVertical: vi.fn(() => []),
+}));
+
+vi.mock('../../src/services/storyboards.js', () => ({
+  getStoryboard: vi.fn(() => null),
+  getAllStoryboards: vi.fn(() => []),
+}));
+
+vi.mock('../../src/services/adcp-taxonomy.js', () => ({
+  isStableSpecialism: vi.fn(() => true),
+}));
+
+import { complianceResultToDbInput } from '../../src/addie/services/compliance-testing.js';
+
+function baseResult(overrides: Record<string, unknown> = {}) {
+  return {
+    overall_status: 'passing',
+    tracks: [],
+    summary: {
+      headline: 'All checks passed',
+      tracks_passed: 1,
+      tracks_failed: 0,
+      tracks_partial: 0,
+      tracks_skipped: 0,
+      ...overrides,
+    },
+    total_duration_ms: 1234,
+    agent_profile: { name: 'test-agent', tools: [] },
+    observations: [],
+  };
+}
+
+describe('complianceResultToDbInput — notices pass-through', () => {
+  it('maps a deprecation notice from result.summary.notices to notices_json', () => {
+    const result = baseResult({
+      notices: [
+        {
+          severity: 'deprecation',
+          code: 'signed_requests_specialism_deprecated',
+          message: 'Agent advertises the deprecated `signed-requests` specialism enum value.',
+          capability_path: 'specialisms',
+          reference_url: 'https://github.com/adcontextprotocol/adcp/issues/3078',
+        },
+      ],
+    });
+
+    const dbInput = complianceResultToDbInput(
+      result as any,
+      'https://example.com/agent',
+      'production',
+      'heartbeat',
+    );
+
+    expect(dbInput.notices_json).toHaveLength(1);
+    const notice = dbInput.notices_json![0];
+    expect(notice.severity).toBe('deprecation');
+    expect(notice.code).toBe('signed_requests_specialism_deprecated');
+    expect(notice.message).toContain('deprecated');
+    expect(notice.capability_path).toBe('specialisms');
+    expect(notice.reference_url).toContain('3078');
+    expect(notice.effective_version).toBeUndefined();
+  });
+
+  it('maps a future_required notice with effective_version', () => {
+    const result = baseResult({
+      notices: [
+        {
+          severity: 'future_required',
+          code: 'request_signing_required_in_4_0',
+          message: '`request_signing.supported: true` is optional in 3.x but required in AdCP 4.0.',
+          effective_version: '4.0',
+          capability_path: 'request_signing.supported',
+        },
+      ],
+    });
+
+    const dbInput = complianceResultToDbInput(
+      result as any,
+      'https://example.com/agent',
+      'production',
+    );
+
+    expect(dbInput.notices_json).toHaveLength(1);
+    const notice = dbInput.notices_json![0];
+    expect(notice.severity).toBe('future_required');
+    expect(notice.code).toBe('request_signing_required_in_4_0');
+    expect(notice.effective_version).toBe('4.0');
+    expect(notice.capability_path).toBe('request_signing.supported');
+  });
+
+  it('preserves unknown notice codes and severities verbatim (forward-compat)', () => {
+    const result = baseResult({
+      notices: [
+        {
+          severity: 'supersedes_future_requirement',   // unknown severity
+          code: 'some_new_code_from_future_runner',    // unknown code
+          message: 'Advisory from a future runner version.',
+        },
+      ],
+    });
+
+    const dbInput = complianceResultToDbInput(
+      result as any,
+      'https://example.com/agent',
+      'production',
+    );
+
+    // Forward-compat: MUST NOT drop or filter unknown values
+    expect(dbInput.notices_json).toHaveLength(1);
+    const notice = dbInput.notices_json![0];
+    expect(notice.severity).toBe('supersedes_future_requirement');
+    expect(notice.code).toBe('some_new_code_from_future_runner');
+    expect(notice.message).toBe('Advisory from a future runner version.');
+  });
+
+  it('sets notices_json to null when summary has no notices field', () => {
+    const result = baseResult();
+    // No `notices` key in summary
+
+    const dbInput = complianceResultToDbInput(
+      result as any,
+      'https://example.com/agent',
+      'production',
+    );
+
+    expect(dbInput.notices_json).toBeNull();
+  });
+
+  it('sets notices_json to null when summary.notices is an empty array', () => {
+    const result = baseResult({ notices: [] });
+
+    const dbInput = complianceResultToDbInput(
+      result as any,
+      'https://example.com/agent',
+      'production',
+    );
+
+    // Empty array is falsy via `?? null` — acceptable: no notices to show
+    // (null and [] are both "no notices" in the API/dashboard logic)
+    expect(dbInput.notices_json == null || Array.isArray(dbInput.notices_json)).toBe(true);
+    if (Array.isArray(dbInput.notices_json)) {
+      expect(dbInput.notices_json).toHaveLength(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #4436.

Passes compliance runner notices (deprecation warnings, future-required signals, etc.) from the storyboard runner output all the way through DB → API → verification panel dashboard UI.

**DB** (`migration 493_agent_compliance_runs_notices_json.sql`): adds `notices_json JSONB` column to `agent_compliance_runs`. `compliance-db.ts` gains `NoticeEntry` interface, `notices_json` on `ComplianceRun`/`RecordComplianceRunInput`, updated INSERT, and a new `getLatestNotices(agentUrl)` helper.

**Mapping** (`compliance-testing.ts`): `complianceResultToDbInput()` reads `result.summary.notices` into `notices_json`. Cast as `any` because `notices` is not yet in the SDK types; fully forward-compatible when the type is added.

**API** (`registry-api.ts`): `/api/registry/agents/{url}/compliance` fetches notices via `getLatestNotices` and includes them in the response `notices` field. Wrapped in try/catch like other supplementary queries — failure is non-fatal.

**UI** (`dashboard-agents.html`): `buildNoticesSectionHtml()` renders notices in the verification panel using `escapeHtml()` throughout (no raw innerHTML for notice text). Severity classes: `info`, `deprecation`, `future_required`, `unknown` (neutral gray for forward-compat). Integrated into both the badged and no-badges return paths of `renderVerificationPanel`.

## Test plan

- [ ] `npm run build && npm run typecheck` — both pass
- [ ] 5 new unit tests (`tests/unit/compliance-notices.test.ts`) pass:
  - deprecation notice pass-through
  - future_required notice with `effective_version`
  - unknown code/severity verbatim pass-through
  - null when no `notices` field
  - null/empty when `notices` is empty array
- [ ] Apply migration in dev DB; verify `notices_json` column present on `agent_compliance_runs`
- [ ] Compliance panel in dashboard shows notices section when runner returns notices
- [ ] Panel renders safely with unknown severity values (neutral gray, not dropped)
- [ ] No XSS: notice text containing `<script>` tags renders as escaped text

https://claude.ai/code/cse_019z2vvWLY5HTKTuxssHUQk9

---
_Generated by [Claude Code](https://claude.ai/code/session_019z2vvWLY5HTKTuxssHUQk9)_