### PR TITLE
feat(content): gate content submission on Professional+ membership

### DIFF
--- a/.changeset/propose-content-tier-gate.md
+++ b/.changeset/propose-content-tier-gate.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Add Professional+ membership tier gate to content submission (propose_content tool and UI).

--- a/.changeset/propose-content-tier-gate.md
+++ b/.changeset/propose-content-tier-gate.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": patch
+---
+
+Add Professional+ membership tier gate to content submission (propose_content tool and UI).
+
+Users without `individual_professional`, `company_standard`, `company_icl`, or `company_leader` tier are now blocked from submitting content via the `propose_content` MCP tool and the `/api/content/propose` HTTP endpoint. System users (`system:*` prefix) retain their existing bypass. The My Content dashboard UI now shows a membership upgrade nudge when a submission is rejected for insufficient tier.
+
+Closes #4449.

--- a/server/public/my-content.html
+++ b/server/public/my-content.html
@@ -1105,8 +1105,8 @@
       // Membership gate — Professional+ required for content submission.
       if (contentSubmissionEligible === false) {
         alert(
-          'Publishing perspectives is a benefit of Professional-tier membership and above.\n\n' +
-          'To submit content, upgrade your membership at:\nhttps://agenticadvertising.org/dashboard/membership'
+          'Publishing perspectives is a benefit of Professional, Builder, Partner, or Leader membership.\n\n' +
+          'To submit content, upgrade at:\nhttps://agenticadvertising.org/dashboard/membership'
         );
         return;
       }
@@ -1331,12 +1331,12 @@
           const err = await response.json();
           // Detect the Professional+ tier gate (HTTP 403 from the propose endpoint)
           // and show a persistent upgrade nudge instead of a generic error.
-          if (!id && response.status === 403 && err.message?.includes('Professional-tier membership')) {
+          if (!id && response.status === 403 && err.message?.includes('/dashboard/membership')) {
             contentSubmissionEligible = false;
             closeModal();
             alert(
-              'Publishing perspectives is a benefit of Professional-tier membership and above.\n\n' +
-              'To submit content, upgrade your membership at:\nhttps://agenticadvertising.org/dashboard/membership'
+              'Publishing perspectives is a benefit of Professional, Builder, Partner, or Leader membership.\n\n' +
+              'To submit content, upgrade at:\nhttps://agenticadvertising.org/dashboard/membership'
             );
             btn.disabled = false;
             btn.textContent = 'Save';

--- a/server/public/my-content.html
+++ b/server/public/my-content.html
@@ -780,6 +780,9 @@
     let reviewingContent = null;
     let canReview = false;
     let isAdmin = false;
+    // Set to false once we know the user lacks the Professional+ tier required
+    // to submit content. null = not yet determined.
+    let contentSubmissionEligible = null;
 
     // Initialize
     async function init() {
@@ -1099,6 +1102,14 @@
 
     // Show create modal
     function showCreateModal() {
+      // Membership gate — Professional+ required for content submission.
+      if (contentSubmissionEligible === false) {
+        alert(
+          'Publishing perspectives is a benefit of Professional-tier membership and above.\n\n' +
+          'To submit content, upgrade your membership at:\nhttps://agenticadvertising.org/dashboard/membership'
+        );
+        return;
+      }
       editingContent = null;
       document.getElementById('modalTitle').textContent = 'Create Content';
       document.getElementById('contentForm').reset();
@@ -1318,6 +1329,19 @@
 
         if (!response.ok) {
           const err = await response.json();
+          // Detect the Professional+ tier gate (HTTP 403 from the propose endpoint)
+          // and show a persistent upgrade nudge instead of a generic error.
+          if (!id && response.status === 403 && err.message?.includes('Professional-tier membership')) {
+            contentSubmissionEligible = false;
+            closeModal();
+            alert(
+              'Publishing perspectives is a benefit of Professional-tier membership and above.\n\n' +
+              'To submit content, upgrade your membership at:\nhttps://agenticadvertising.org/dashboard/membership'
+            );
+            btn.disabled = false;
+            btn.textContent = 'Save';
+            return;
+          }
           throw new Error(err.message || 'Failed to save');
         }
 

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -2636,20 +2636,6 @@ export function createMemberToolHandlers(
       return 'You need to be logged in to create content. Please log in at https://agenticadvertising.org/dashboard first.';
     }
 
-    // Membership tier gate — Professional+ required for content submission.
-    // We do a fast pre-check here using the already-resolved memberContext so
-    // the user gets a clear, actionable message before the DB round-trip in
-    // proposeContentForUser. The function-level gate in proposeContentForUser
-    // still runs as the authoritative check.
-    const userId = memberContext.workos_user.workos_user_id;
-    if (!userId.startsWith('system:')) {
-      const tier = memberContext.organization?.membership_tier ?? null;
-      const { isApiAccessTier } = await import('../../services/membership-tiers.js');
-      if (!memberContext.is_member || !isApiAccessTier(tier)) {
-        return 'Publishing perspectives is a benefit of Professional-tier membership and above. To submit content, upgrade your membership at https://agenticadvertising.org/dashboard/membership.';
-      }
-    }
-
     const title = input.title as string;
     const subtitle = input.subtitle as string | undefined;
     const contentBody = input.content as string | undefined;

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -2636,6 +2636,20 @@ export function createMemberToolHandlers(
       return 'You need to be logged in to create content. Please log in at https://agenticadvertising.org/dashboard first.';
     }
 
+    // Membership tier gate — Professional+ required for content submission.
+    // We do a fast pre-check here using the already-resolved memberContext so
+    // the user gets a clear, actionable message before the DB round-trip in
+    // proposeContentForUser. The function-level gate in proposeContentForUser
+    // still runs as the authoritative check.
+    const userId = memberContext.workos_user.workos_user_id;
+    if (!userId.startsWith('system:')) {
+      const tier = memberContext.organization?.membership_tier ?? null;
+      const { isApiAccessTier } = await import('../../services/membership-tiers.js');
+      if (!memberContext.is_member || !isApiAccessTier(tier)) {
+        return 'Publishing perspectives is a benefit of Professional-tier membership and above. To submit content, upgrade your membership at https://agenticadvertising.org/dashboard/membership.';
+      }
+    }
+
     const title = input.title as string;
     const subtitle = input.subtitle as string | undefined;
     const contentBody = input.content as string | undefined;

--- a/server/src/routes/content.ts
+++ b/server/src/routes/content.ts
@@ -401,14 +401,15 @@ export async function proposeContentForUser(
   }
 
   // Membership tier gate — Professional+ required for content submission.
-  // System users (system:* prefix) are exempt, matching the rate-limiter carve-out.
-  if (!user.id.startsWith('system:')) {
+  // System users (system:* prefix) and site admins are exempt, matching the
+  // rate-limiter carve-out and the existing admin bypass pattern below.
+  if (!user.id.startsWith('system:') && !(await isWebUserAAOAdmin(user.id))) {
     const eligible = await checkContentSubmissionTier(user.id);
     if (!eligible) {
       logger.warn({ userId: user.id }, 'proposeContentForUser blocked — insufficient membership tier');
       return {
         success: false,
-        error: 'Publishing perspectives is a benefit of Professional-tier membership and above. To submit content, upgrade your membership at https://agenticadvertising.org/dashboard/membership.',
+        error: 'Publishing perspectives is a benefit of Professional, Builder, Partner, or Leader membership. To submit content, upgrade at https://agenticadvertising.org/dashboard/membership.',
       };
     }
   }
@@ -1201,7 +1202,7 @@ export function createContentRouter(): Router {
 
       if (!result.success) {
         // Map errors to appropriate HTTP status codes
-        const isTierGate = result.error?.includes('Professional-tier membership');
+        const isTierGate = result.error?.includes('/dashboard/membership');
         const status = result.error?.includes('not found') ? 404
                      : (result.error?.includes('must be a member') || isTierGate) ? 403
                      : 400;

--- a/server/src/routes/content.ts
+++ b/server/src/routes/content.ts
@@ -29,6 +29,7 @@ import { generateIllustration } from '../services/illustration-generator.js';
 import { createIllustration, approveIllustration } from '../db/illustration-db.js';
 import { resolveEscalationsForPerspective } from '../db/escalation-db.js';
 import { listMyContent as listMyContentService, MyContentError } from '../services/my-content-service.js';
+import { checkContentSubmissionTier } from '../services/membership-tiers.js';
 
 const logger = createLogger('content-routes');
 
@@ -397,6 +398,19 @@ export async function proposeContentForUser(
       success: false,
       error: `Submission rate limit exceeded (${PROPOSE_MAX_PER_WINDOW} per ${PROPOSE_WINDOW_MS / 60000} minutes). Try again in ${retrySeconds} seconds.`,
     };
+  }
+
+  // Membership tier gate — Professional+ required for content submission.
+  // System users (system:* prefix) are exempt, matching the rate-limiter carve-out.
+  if (!user.id.startsWith('system:')) {
+    const eligible = await checkContentSubmissionTier(user.id);
+    if (!eligible) {
+      logger.warn({ userId: user.id }, 'proposeContentForUser blocked — insufficient membership tier');
+      return {
+        success: false,
+        error: 'Publishing perspectives is a benefit of Professional-tier membership and above. To submit content, upgrade your membership at https://agenticadvertising.org/dashboard/membership.',
+      };
+    }
   }
 
   // Validate required fields
@@ -1187,12 +1201,13 @@ export function createContentRouter(): Router {
 
       if (!result.success) {
         // Map errors to appropriate HTTP status codes
+        const isTierGate = result.error?.includes('Professional-tier membership');
         const status = result.error?.includes('not found') ? 404
-                     : result.error?.includes('must be a member') ? 403
+                     : (result.error?.includes('must be a member') || isTierGate) ? 403
                      : 400;
         return res.status(status).json({
           error: status === 404 ? 'Collection not found'
-               : status === 403 ? 'Not a member'
+               : status === 403 ? 'Membership required'
                : 'Validation error',
           message: result.error,
         });

--- a/server/src/services/membership-tiers.ts
+++ b/server/src/services/membership-tiers.ts
@@ -11,6 +11,9 @@
  * AAO membership-pricing taxonomy (project_membership_pricing_v2).
  */
 
+import { resolvePrimaryOrganization } from '../db/users-db.js';
+import { resolveEffectiveMembership } from '../db/org-filters.js';
+
 export const API_ACCESS_TIERS = [
   'individual_professional',
   'company_standard',
@@ -130,4 +133,34 @@ export async function resolveOwnerMembership(
     subscription_status: subStatus,
     is_api_access_tier: isApiAccessTier(tier) && isActiveSubscriptionStatus(subStatus),
   };
+}
+
+/**
+ * Returns true if the given user is eligible to submit content via
+ * `propose_content` (Professional+ tier required).
+ *
+ * System users (`system:*` prefix) are always allowed — they are automated
+ * pipelines that legitimately submit content on a cadence and bypass the
+ * human-facing membership gate the same way they bypass the rate limiter.
+ *
+ * For all other users, resolves their primary organization and checks that:
+ *   1. The organization's effective membership tier is in API_ACCESS_TIERS.
+ *   2. The subscription status is in ACTIVE_SUBSCRIPTION_STATUSES.
+ *
+ * Returns false when the user has no primary organization or when either
+ * condition is not met.
+ */
+export async function checkContentSubmissionTier(userId: string): Promise<boolean> {
+  if (userId.startsWith('system:')) return true;
+
+  const orgId = await resolvePrimaryOrganization(userId);
+  if (!orgId) return false;
+
+  const membership = await resolveEffectiveMembership(orgId);
+
+  // resolveEffectiveMembership walks the brand hierarchy and sets is_member
+  // only when the org (or a consenting ancestor) has an active, non-canceled
+  // subscription — so is_member already encodes subscription-status validity.
+  // We additionally require the tier to be in API_ACCESS_TIERS (Professional+).
+  return membership.is_member && isApiAccessTier(membership.membership_tier);
 }

--- a/server/tests/integration/content-my-content.test.ts
+++ b/server/tests/integration/content-my-content.test.ts
@@ -118,6 +118,32 @@ describe('My Content — body, admin scope, status, delete', () => {
   const WG_SLUG = 'mc-test-wg';
   const USER_ID = 'user_my_content';
   const OTHER_USER_ID = 'user_my_content_other';
+  const ELIGIBLE_ORG_ID = 'org_my_content_professional';
+  const INELIGIBLE_USER_ID = 'user_my_content_ineligible';
+  const RATE_LIMIT_USER_ID = 'user_mc_ratelimit_test';
+
+  async function ensureContentSubmissionEligibleUser(userId: string, email: string) {
+    await pool.query(
+      `INSERT INTO users (workos_user_id, email, first_name, last_name, primary_organization_id)
+       VALUES ($1, $2, 'Mary', 'Content', $3)
+       ON CONFLICT (workos_user_id) DO UPDATE SET
+         email = EXCLUDED.email,
+         primary_organization_id = EXCLUDED.primary_organization_id,
+         updated_at = NOW()`,
+      [userId, email, ELIGIBLE_ORG_ID]
+    );
+
+    await pool.query(
+      `INSERT INTO organization_memberships
+         (workos_user_id, workos_organization_id, workos_membership_id, email, role, created_at, updated_at, synced_at)
+       VALUES ($1, $2, $3, $4, 'member', NOW(), NOW(), NOW())
+       ON CONFLICT (workos_user_id, workos_organization_id) DO UPDATE SET
+         email = EXCLUDED.email,
+         updated_at = NOW(),
+         synced_at = NOW()`,
+      [userId, ELIGIBLE_ORG_ID, `om_${userId}`, email]
+    );
+  }
 
   beforeAll(async () => {
     pool = initializeDatabase({
@@ -125,19 +151,21 @@ describe('My Content — body, admin scope, status, delete', () => {
     });
     await runMigrations();
 
+    await pool.query(
+      `INSERT INTO organizations
+         (workos_organization_id, name, membership_tier, subscription_status, created_at, updated_at)
+       VALUES ($1, 'My Content Professional Org', 'individual_professional', 'active', NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO UPDATE SET
+         membership_tier = EXCLUDED.membership_tier,
+         subscription_status = EXCLUDED.subscription_status,
+         subscription_canceled_at = NULL,
+         updated_at = NOW()`,
+      [ELIGIBLE_ORG_ID]
+    );
+
     // Ensure users exist
-    await pool.query(
-      `INSERT INTO users (workos_user_id, email, first_name, last_name)
-       VALUES ($1, 'mc@example.com', 'Mary', 'Content')
-       ON CONFLICT (workos_user_id) DO NOTHING`,
-      [USER_ID]
-    );
-    await pool.query(
-      `INSERT INTO users (workos_user_id, email, first_name, last_name)
-       VALUES ($1, 'mc-other@example.com', 'Other', 'User')
-       ON CONFLICT (workos_user_id) DO NOTHING`,
-      [OTHER_USER_ID]
-    );
+    await ensureContentSubmissionEligibleUser(USER_ID, 'mc@example.com');
+    await ensureContentSubmissionEligibleUser(OTHER_USER_ID, 'mc-other@example.com');
 
     const wgResult = await pool.query(
       `INSERT INTO working_groups (name, slug, description, accepts_public_submissions)
@@ -167,9 +195,12 @@ describe('My Content — body, admin scope, status, delete', () => {
     await pool.query(`DELETE FROM working_groups WHERE slug = $1`, [WG_SLUG]);
     // Side tables the propose flow writes into. Clear everything referencing
     // the test users before deleting them so FKs don't block cleanup.
-    const testUsers = [USER_ID, OTHER_USER_ID];
+    const testUsers = [USER_ID, OTHER_USER_ID, INELIGIBLE_USER_ID, RATE_LIMIT_USER_ID];
     await pool.query(`DELETE FROM community_points WHERE workos_user_id = ANY($1)`, [testUsers]);
     await pool.query(`DELETE FROM user_badges WHERE workos_user_id = ANY($1)`, [testUsers]);
+    await pool.query(`DELETE FROM organization_memberships WHERE workos_user_id = ANY($1)`, [testUsers]);
+    await pool.query(`UPDATE users SET primary_organization_id = NULL WHERE workos_user_id = ANY($1)`, [testUsers]);
+    await pool.query(`DELETE FROM organizations WHERE workos_organization_id = $1`, [ELIGIBLE_ORG_ID]);
     await pool.query(`DELETE FROM users WHERE workos_user_id = ANY($1)`, [testUsers]);
     await server?.stop();
     await closeDatabase();
@@ -360,6 +391,30 @@ describe('My Content — body, admin scope, status, delete', () => {
       expect(response.body.status).toBe('pending_review');
     });
 
+    it('blocks users without a Professional+ membership tier', async () => {
+      authState.userId = INELIGIBLE_USER_ID;
+      authState.email = 'mc-ineligible@example.com';
+      await pool.query(
+        `INSERT INTO users (workos_user_id, email, first_name, last_name)
+         VALUES ($1, $2, 'Ineligible', 'User')
+         ON CONFLICT (workos_user_id) DO UPDATE SET email = EXCLUDED.email`,
+        [INELIGIBLE_USER_ID, authState.email]
+      );
+
+      const response = await request(app)
+        .post('/api/content/propose')
+        .send({
+          title: 'mc-test-ineligible',
+          content: 'body',
+          content_type: 'article',
+          collection: { slug: WG_SLUG },
+        })
+        .expect(403);
+
+      expect(response.body.error).toBe('Membership required');
+      expect(response.body.message).toContain('/dashboard/membership');
+    });
+
     it('returns 400 with field-specific message when title is too long (#2734)', async () => {
       const response = await request(app)
         .post('/api/content/propose')
@@ -409,13 +464,8 @@ describe('My Content — body, admin scope, status, delete', () => {
       // directly, bypassing HTTP middleware. Fresh user id so we start
       // with an empty window.
       const { proposeContentForUser } = await import('../../src/routes/content.js');
-      const testUser = { id: 'user_mc_ratelimit_test', email: 'ratelimit@test.local' };
-      await pool.query(
-        `INSERT INTO users (workos_user_id, email, first_name, last_name)
-         VALUES ($1, $2, 'Rate', 'Limit')
-         ON CONFLICT (workos_user_id) DO NOTHING`,
-        [testUser.id, testUser.email]
-      );
+      const testUser = { id: RATE_LIMIT_USER_ID, email: 'ratelimit@test.local' };
+      await ensureContentSubmissionEligibleUser(testUser.id, testUser.email);
 
       const results: Array<{ success: boolean; error?: string }> = [];
       for (let i = 0; i < 21; i++) {


### PR DESCRIPTION
## Summary

Closes #4449.

Gates the `propose_content` MCP tool and the `/api/content/propose` HTTP endpoint on Professional, Builder, Partner, or Leader membership. Explorer-tier members and unenrolled users receive a clear upgrade message.

**Authoritative check** (`services/membership-tiers.ts`): new `checkContentSubmissionTier(userId)` walks `resolveEffectiveMembership` so inherited members (child orgs under a brand-hierarchy parent) are correctly evaluated against the parent's effective tier, not just the child org's own row.

**HTTP gate** (`routes/content.ts`): runs in `proposeContentForUser` before field validation. Exempts `system:*` users and site admins (matching the existing rate-limiter and committee-membership carve-outs). HTTP 403 returned; status detection uses URL sentinel (`/dashboard/membership`) rather than prose matching to survive copy edits.

**MCP handler** (`addie/mcp/member-tools.ts`): no pre-check — the authoritative DB-level check in `proposeContentForUser` covers all cases correctly, including inherited members. A pre-check using `memberContext.organization.membership_tier` would have given false-positive blocks for inherited members whose effective tier lives on the parent.

**UI** (`server/public/my-content.html`): `showCreateModal()` checks a `contentSubmissionEligible` flag before opening the form. On HTTP 403 from the submit path the flag is set to false and an upgrade nudge is shown. Both copy strings list all qualifying tiers by public name.

## Test plan

- [ ] `npm run build && npm run typecheck` — both pass
- [ ] Explorer-tier user: `propose_content` via MCP returns upgrade message; `/api/content/propose` returns HTTP 403
- [ ] Professional/Builder/Partner/Leader member: submission succeeds
- [ ] Inherited member (child org under professional+ parent): submission succeeds (resolveEffectiveMembership path)
- [ ] `system:*` user: bypasses tier gate
- [ ] Site admin on explorer/no-org account: bypasses tier gate
- [ ] My Content UI: ineligible user sees upgrade alert on Create button; sees it again on submit if flag somehow not set

https://claude.ai/code/cse_019z2vvWLY5HTKTuxssHUQk9

---
_Generated by [Claude Code](https://claude.ai/code/session_019z2vvWLY5HTKTuxssHUQk9)_