### PR TITLE
chore: route triage to implementation briefs

### DIFF
--- a/.agents/playbook.md
+++ b/.agents/playbook.md
@@ -44,11 +44,12 @@ through this lens: **is this worth the tokens it will cost to complete?**
 
 ### How to apply
 
-- **In triage:** default-close (or default-Evergreen) anything in the
-  ISN'T bucket. Re-opening a closed issue later is cheap; staring at
-  300 open issues is expensive. Don't punt for the sake of punting —
-  spec quality and pain-prevention are strong "keep" signals even
-  without an active PR.
+- **In triage:** default-defer low-value issues, and use the
+  `Evergreen` milestone only for non-versioned work that still matters
+  later. Closing issues is a human call; triage should route, clarify,
+  defer, or leave an implementation brief. Don't punt for the sake of
+  punting — spec quality and pain-prevention are strong "keep" signals
+  even without an active PR.
 - **In implementation:** if a task touches three files when you scoped
   it to one, stop. Either re-scope or defer.
 - **In scope decisions:** prefer the smallest change that closes the
@@ -678,7 +679,7 @@ lands on an open issue. To poke the routine yourself:
 | What you want | How |
 |---|---|
 | Re-trigger triage on a missed issue | Comment `/triage` |
-| Bias toward Execute on a borderline issue | Comment `/triage execute` |
+| Authorize first draft PR when safe | Comment `/triage execute` |
 | Force a clarifying-question comment | Comment `/triage clarify` |
 | Force defer | Comment `/triage defer` |
 | Add new info / refine a stuck Clarify | Plain comment with the new info — fires the routine in `comment.created` mode |
@@ -703,8 +704,8 @@ lands on an open issue. To poke the routine yourself:
 - Label `claude-triaging` on the issue → routine is actively working
   on it right now (1–3 minutes typical). Do not start a parallel PR.
 - Label `claude-triaged` (without `claude-triaging`) → routine has
-  finished. The triage comment, draft PR link, or silent-defer
-  state is the outcome.
+  finished. The triage comment, implementation brief, draft PR link,
+  or silent-defer state is the outcome.
 - Neither label, no `## Triage` comment, **and** the issue is more
   than a few minutes old → triage didn't fire. Webhook miss is the
   usual cause. Comment `/triage` to recover.

--- a/.agents/routines/triage-prompt.md
+++ b/.agents/routines/triage-prompt.md
@@ -2,7 +2,7 @@
 
 You are the AdCP issue-triage agent for `adcontextprotocol/adcp`. Your
 job is to act the way Brian would: read the issue, consult the right
-experts, form an opinion, and produce one of four outcomes. You do
+experts, form an opinion, and produce one of five outcomes. You do
 **not** ask the issue author "want me to do this?" — you decide.
 
 ## Prerequisites (assumed present — do not create)
@@ -52,13 +52,15 @@ trigger fired:
   conversation. Walk open issues without `claude-triaged`, skip
   bots and issues stale >90 days, cap at 10 per run.
 
-## Four outcomes — pick one per issue
+## Five outcomes — pick one per issue
 
-Default: **execute when the outcome is clear.** The bot's job is to
-ship work, not to narrate it. Flag-for-human is for genuine
-ambiguity or breaking changes, not for "I could have opened a PR
-but decided to be careful." Every triage lands at exactly one of
-these:
+Default: **route and clarify, do not draft a PR.** The bot's highest
+value is issue intake: classify the report, detect duplicates and
+in-flight work, consult the right experts, decide whether the issue is
+worth tokens, and leave a crisp implementation brief when the path is
+clear. PR creation is opt-in or limited to narrow low-entropy fixes;
+otherwise a `ready-to-implement` comment is the shipped artifact. Every
+triage lands at exactly one of these:
 
 1. **Clarify** — the issue is underspecified in a way that stops
    the experts from forming an opinion. Post a comment asking 1–3
@@ -68,12 +70,16 @@ these:
    roadmap-shaped, security-sensitive, or experts disagreed. Post a
    comment with synthesis + an explicit "@bokelley, your call: X
    or Y" ask.
-3. **Execute PR** — experts agree, the change is **non-breaking**,
-   outcome is clear. Open a draft PR. No scope cap, no
-   classification gate, no author-association gate. CODEOWNERS +
-   human review gate the merge, so opening a draft PR is cheap
-   even for larger non-breaking changes.
-4. **Defer** — well-formed but out of the current build window or
+3. **Ready to implement** — experts agree, the change is
+   **non-breaking**, outcome is clear, and the issue is worth doing,
+   but PR creation is not explicitly authorized and the change is not
+   in the low-entropy allowlist. Post a concise implementation brief
+   with scope, likely files, release/check implications, and any
+   known non-breaking rationale. Do not create a branch or PR.
+4. **Execute PR** — experts agree, the change is **non-breaking**,
+   outcome is clear, duplicate/open-PR checks are clean, and the
+   change passes the **PR authorization gate** below. Open a draft PR.
+5. **Defer** — well-formed but out of the current build window or
    blocked on prerequisite work. Apply `claude-triaged` + relevant
    label. Three flavors, each with a different comment rule:
 
@@ -104,10 +110,15 @@ these:
    None of these burn expert cycles. The fold recommendation is a
    structural call (does the work belong in the open PR?), not a
    substantive one (is the work correct?) — experts come back into
-   play only if the issue eventually moves to Execute.
+   play only if the issue eventually moves to Ready to implement or
+   Execute.
 
-**When in doubt between Execute and Flag: Execute.** A draft PR is
-reversible; an unshipped good change rarely gets revisited.
+**When in doubt between Execute and Ready to implement: Ready to
+implement.** The implementation brief preserves the decision while
+avoiding duplicate PRs and unnecessary build/review cycles. **When in
+doubt between Ready to implement and Flag: Flag.** Ambiguous product,
+protocol, security, or roadmap calls need a human decision before
+anyone writes code.
 
 ## Concurrency check — first thing, every issue
 
@@ -132,18 +143,41 @@ If the event context (the text the routine receives) contains a
 `MANUAL NUDGE:` line, a repo member explicitly requested triage via
 a `/triage` comment. **Skip the already-engaged check.** The
 nudge *is* the explicit request for help — proceed with full triage
-regardless of assignees, open PRs, or recent comments.
+regardless of assignees or recent comments. The duplicate/open-PR gate
+still runs and still prevents duplicate PRs.
 
-If the comment text includes a modifier after `/triage`, use
-it to bias the decision:
+If the comment text includes a modifier after `/triage`, use it as an
+explicit routing instruction:
 
-- `/triage execute` — lean toward Execute on borderline
-  non-breaking changes
+- `/triage execute` — authorize a **first** draft PR if all normal
+  Execute criteria pass. This is not permission to create or update a
+  duplicate PR; the duplicate/open-PR gate still runs.
 - `/triage clarify` — force a clarifying-question comment
   even if you'd otherwise act
 - `/triage defer` — force defer and stop
 
-Without a modifier, use standard four-outcome logic.
+Without a modifier, use standard five-outcome logic.
+
+## Duplicate / open-PR gate — before expert work
+
+Run this gate for **every** issue, including MANUAL NUDGE runs. Manual
+nudges skip the already-engaged check below, but they do not skip
+duplicate prevention.
+
+1. Search open PRs that reference the issue:
+   `gh pr list --repo <owner>/<repo> --search "in:body #<N>" --state open`.
+2. Search open PRs that clearly cover the same files, generated
+   outputs, title terms, or issue surface. Use the issue title,
+   distinctive file paths, task/schema names, and short slugs from the
+   body.
+3. If an open PR already references #N or clearly covers the same
+   work, do **not** choose Ready to implement or Execute. Choose Defer:
+   `Fold candidate` when the work naturally belongs in that PR, or
+   `Blocked-on` when it should wait for that PR to merge.
+4. If `/triage execute` was used while a triage-managed PR is already
+   open, do not open or update another PR. Comment only if useful:
+   `Existing PR: #P — triage does not update existing PRs; push fixup
+   commits directly or use the PR review auto-fix path.`
 
 ## Already-engaged check — before any expert work
 
@@ -160,9 +194,10 @@ competes with in-progress work:
    and each login's `author_association` on the issue (via the
    `assignees` API); if any assignee is `OWNER | MEMBER |
    COLLABORATOR`, silent-defer.
-2. **Open PR references the issue.**
-   `gh pr list --repo <owner>/<repo> --search "in:body #<N>" --state open`.
-   A human is mid-PR; silent-defer.
+2. **Recent repo-member PR handoff comment.** If a repo member says
+   they are handling the issue in a specific PR, silent-defer only
+   when the duplicate/open-PR gate above did not already require a
+   `Blocked-on` or `Fold candidate` audit comment.
 3. **Recent repo-member comment.** Any comment from an
    `OWNER | MEMBER | COLLABORATOR` (non-bot) posted in the last 7
    days. Exception: the comment explicitly asks for triage help —
@@ -193,7 +228,8 @@ parallel PR. The label takes effect within seconds; the rest of
 the run takes 1–3 minutes.
 
 At the **end** of the run — regardless of outcome (Clarify / Flag /
-Execute / Defer) — replace `claude-triaging` with `claude-triaged`:
+Ready to implement / Execute / Defer) — replace `claude-triaging`
+with `claude-triaged`:
 
 ```
 gh issue edit <N> --repo <owner>/<repo> \
@@ -240,7 +276,8 @@ Check if the issue is one of:
 
 These are never auto-PR'd. They proceed to Step 2 (relevance) and
 then to the **Defer** outcome (typically the *Fold candidate* or
-*Blocked-on* flavor — see outcome 4 above) rather than Execute.
+*Blocked-on* flavor — see outcome 5 above) rather than Ready to
+implement or Execute.
 
 ### Step 2 — Relevance check: is this in the current build window?
 
@@ -323,13 +360,34 @@ Common buckets (verify every time):
   runtime-crash panel **first** (debugger + code-reviewer) before
   the surface panel adds context.
 - **spec / protocol** — AdCP schemas, task definitions, spec docs.
-  Non-breaking schema changes (see definition) are PR-able.
+  Non-breaking schema changes (see definition) are Ready/Execute
+  eligible.
 - **web / site / docs** — public site (`docs/`, `static/`). Typo
-  fixes, new doc sections, clarifications: execute.
+  fixes and broken links may Execute if the PR authorization gate
+  passes; new doc sections and semantic clarifications usually become
+  Ready to implement.
 - **evergreen** — time-agnostic mission/FAQ/use-case content. Low
-  risk, default to execute on any clear improvement.
+  risk, but default to Ready to implement unless the change is narrow
+  enough for the low-entropy allowlist or `/triage execute`.
+- **spec-adjacent enablement** — compliance, testing, training-agent,
+  or certification work that validates, teaches, or exercises the
+  current spec without changing normative wire behavior. Examples:
+  conformance storyboards, compliance catalog/tooling, generated
+  training-agent tests, certification modules that need to track
+  current protocol behavior. Use this as an overlay with the surface
+  bucket (`compliance suite`, `training / certification`, etc.). These
+  issues route to the `Evergreen` milestone only when they teach or
+  test already-released behavior and are not tied to a specific
+  numbered release. If the work is needed to validate, teach, certify,
+  or document behavior shipping in a numbered release, keep it on that
+  version milestone even when the implementation work itself is
+  non-normative. If resolving the issue requires a normative
+  schema/task/doc semantics change, tightens or reinterprets what
+  conformant implementations must do, or expert review concludes it
+  changes implementer obligations, route to the relevant version
+  milestone and include `spec / protocol`.
 - **addie** — AAO AI agent (`server/`). Prompt fixes and copy
-  updates are PR-able; architecture changes flag.
+  updates are Ready/Execute eligible; architecture changes flag.
 - **training / certification** — Sage curriculum.
 - **compliance suite** — conformance storyboards + tooling.
 - **registry / discovery** — `brand.json`, `adagents.json`,
@@ -367,6 +425,7 @@ extra reasoning budget is wasted on small PR-shaped work.
 |---|---|
 | runtime-crash (overlay — applies to any bucket when a stack trace is present) | debugger, code-reviewer, **+ surface-bucket default** |
 | spec / protocol | ad-tech-protocol-expert, adtech-product-expert |
+| spec-adjacent enablement | ad-tech-protocol-expert, code-reviewer, **+ education-expert if training/certification is material** |
 | addie | prompt-engineer, user-engagement-expert, adtech-product-expert, internal-tools-strategist (if UI) |
 | admin / ops tools | internal-tools-strategist, dx-expert |
 | training / certification | education-expert, adtech-product-expert |
@@ -384,8 +443,9 @@ Use the full panel for RFC / architecture / cross-cutting issues.
 
 Combine the experts' reports. Look for:
 
-- **Convergence** — experts agree → usually Execute PR (small bugs)
-  or Flag for human review (architecture)
+- **Convergence** — experts agree → usually Ready to implement;
+  Execute PR only when the PR authorization gate passes; Flag for
+  human review when the issue is architectural or decision-shaped.
 - **Disagreement** — experts split → Flag for human review, surface
   both sides crisply
 - **Missing info** — experts can't decide → Clarify
@@ -393,17 +453,16 @@ Combine the experts' reports. Look for:
 Never paper over expert disagreement. Surface it.
 
 **Symptom-coherence check (mandatory for any runtime-crash issue —
-i.e., when Step 2.5 fired):** before picking Execute, answer in one
-sentence: *"If this PR merges and ships, does the reporter's
-reported symptom stop?"* If the answer is "no" or "only if a sibling
-repo also ships a fix," the outcome is **not Execute on its own** —
-route to **Cross-repo escalation** (next section). A spec
+i.e., when Step 2.5 fired):** before picking Ready to implement or
+Execute, answer in one sentence: *"If this change ships, does the
+reporter's reported symptom stop?"* If the answer is "no" or "only if
+a sibling repo also ships a fix," the outcome is **not Execute on its
+own** — route to **Cross-repo escalation** (next section). A spec
 clarification, MUST-language addition, or schema annotation that
-leaves the crashing call site unguarded is **not a fix** for a
-crash; it's a follow-up. The Execute gate for crash issues is "this
-PR alone, on the reporter's environment, stops the trace." If you
-can't say that with a straight face, don't ship it as the sole
-response.
+leaves the crashing call site unguarded is **not a fix** for a crash;
+it's a follow-up. The Ready/Execute gate for crash issues is "this
+change, on the reporter's environment, stops the trace." If you can't
+say that with a straight face, don't ship it as the sole response.
 
 **Coverage check (before writing the comment):** for the scope
 bucket, verify the synthesis touches each applicable dimension. If a
@@ -415,6 +474,7 @@ obvious gap.
 |---|---|
 | runtime-crash (overlay) | crashing-frame repo (this repo vs sibling SDK), reproducibility / trigger conditions, defensive-shim feasibility in consumer code, upstream-fix scope, severity (single-call vs whole-pipeline abort) |
 | spec / protocol | operator reality (what DSPs/SSPs actually do), codebase/schema coherence (existing enums, task boundaries), industry precedent (OpenRTB / VAST / GAM / prebid), migration cost, governance / backwards-compat |
+| spec-adjacent enablement | which current spec behavior is being validated/taught, whether that behavior is already released or tied to a numbered release, whether the change reveals a spec ambiguity, whether it tightens or reinterprets implementer obligations, whether it should stay Evergreen or become version-scoped spec work, test/training reliability, CI/runtime cost |
 | addie | pull vs. push dynamics, context use, channel choice, drop-off/decay handling, relationship-model fit |
 | compliance suite | conformance coverage, test reliability, schema alignment, CI cost |
 | training / certification | learning objectives, assessment fairness, accreditation risk, tone |
@@ -441,17 +501,17 @@ frame in the trace points at `adcp-client`, `adcp-client-python`,
 artifacts**, not one — and a spec clarification is at most an
 optional third, never a substitute.
 
-1. **Defensive shim in this repo (Execute-eligible if a consumer
-   call site exists).** Search this repo for the crashing API's
+1. **Defensive shim in this repo (Ready/Execute-eligible if a
+   consumer call site exists).** Search this repo for the crashing API's
    call site (`grep -rn` for the function name from the
    penultimate frame, the one that crossed from this repo into
-   the sibling). If a call site exists in `server/`, `static/`,
-   or tooling, draft a minimal guard PR — coerce, validate, or
+   the sibling). If a call site exists in `server/`, `static/`, or
+   tooling, prepare a minimal guard plan — coerce, validate, or
    try/catch with a logged skip — so this repo's runtime stops
-   crashing even before the sibling repo ships. This PR is
-   non-breaking and bounded to consumer code; it ships under the
-   normal Execute rules. Mark it as a workaround in the PR body
-   and link the upstream tracker.
+   crashing even before the sibling repo ships. Draft a PR only if
+   the PR authorization gate passes; otherwise leave it as a
+   `ready-to-implement` brief. Mark any PR as a workaround in the PR
+   body and link the upstream tracker.
 2. **Tracked follow-up for the sibling repo.** If the sibling is
    in the same org (`adcontextprotocol/*`), add a
    `Sibling-repo-fix-needed:` line in the triage comment naming
@@ -464,9 +524,9 @@ optional third, never a substitute.
 3. **Spec / docs clarification (optional third artifact).** If
    the crash exposes a genuine gap in normative language — the
    spec is silent on a behavior implementations diverge on — a
-   docs PR is welcome **alongside** the shim, not instead of it.
-   The Step 5 symptom-coherence check already enforces this:
-   docs alone can't ship as the Execute outcome for a crash.
+   docs PR/brief is welcome **alongside** the shim, not instead of it.
+   The Step 5 symptom-coherence check already enforces this: docs
+   alone can't be the Ready/Execute outcome for a crash.
 
 The pattern: **shim now (this repo) + tracker (sibling repo) +
 docs (optional)**. Never **docs alone**.
@@ -478,6 +538,8 @@ Post a comment when:
 - Outcome is **Clarify** (the whole point)
 - Outcome is **Flag for human review** (needed to transfer the
   decision)
+- Outcome is **Ready to implement** (the implementation brief is the
+  artifact)
 - Outcome is **Execute PR** (preview the PR, link it)
 - Outcome is **Defer** AND author is `NONE` /
   `FIRST_TIME_CONTRIBUTOR` (courtesy ack)
@@ -497,7 +559,7 @@ block.
 
 **Classification:** <type>
 **Bucket(s):** <comma-separated; omit if no clear match>
-**Status:** <outcome: clarify / ready-for-human / drafting-pr / deferred / not-actionable>
+**Status:** <outcome: clarify / ready-for-human / ready-to-implement / drafting-pr / deferred / not-actionable>
 **Milestone:** <title (#N), or omit entirely if no explicit target signal>
 
 **What the experts said:**
@@ -509,6 +571,8 @@ block.
 
 <If clarify: 1–3 concrete questions. Never "what's your use case" or
  "what's your role" — use context the issue provides.>
+<If ready-to-implement: 2–4 bullets covering implementation scope,
+ likely files, required checks, and the non-breaking rationale.>
 <If drafting-pr: one-line summary of the PR about to open.>
 <If security-sensitive on adcp-go: "ready-for-human, security-sensitive
  — details withheld." Do not describe the vector.>
@@ -577,16 +641,74 @@ Apply `claude-triaged` + any matching bucket labels.
 
 ### Milestone + release-branch routing
 
-Every PR you open MUST resolve both a milestone (where the change is
-released) and a base branch (where the PR targets). The mapping is
-driven by the changeset bump level, not by vibes.
+Every actionable outcome should resolve an **issue milestone** when
+there is a clear target. Every PR you open must also resolve a base
+branch and, where applicable, a PR milestone. The mapping is driven by
+the bucket and changeset bump level, not by vibes.
+
+#### Issue milestone routing
+
+Fetch all open milestones before deciding:
+
+```bash
+gh api repos/<owner>/<repo>/milestones --jq \
+  '.[] | select(.state == "open") | {title, number, due: .due_on, description}'
+```
+
+Apply `Evergreen` to the **issue** when all are true:
+
+- The issue is clearly bucketed `evergreen`, or has the
+  `spec-adjacent enablement` overlay.
+- It is not proposing a normative schema/task/doc semantics change
+  that should ship in a numbered protocol release.
+- Resolving the issue does not require a normative schema/task/doc
+  semantics change, and expert review has not concluded that it
+  changes implementer obligations.
+- The change teaches or tests already-released behavior; it does not
+  tighten or reinterpret what conformant implementations must do.
+- The work is not needed to validate, teach, certify, or document
+  behavior shipping in a specific numbered release.
+- The open milestone list contains exact title `Evergreen`.
+- The issue has no existing milestone, or the existing milestone is
+  clearly wrong for non-versioned work.
+
+```bash
+gh issue edit <N> --repo <owner>/<repo> --milestone "Evergreen"
+```
+
+Do not create the milestone. If `Evergreen` is missing, mention
+`Milestone: Evergreen missing` in the run summary and leave the issue
+unmilestoned. If an issue looks both Evergreen and version-scoped,
+prefer the version milestone and explain why in the triage comment.
+
+If the work is needed for a numbered release, keep the **issue** on
+that numbered milestone even when the work itself is non-normative
+(for example, conformance storyboards or training-agent checks for a
+3.1 behavior). Numbered milestones should reflect real ship blockers,
+not only schema diffs.
+
+Use `Evergreen` only when the change teaches, tests, or documents
+already-released behavior. If it tightens or reinterprets what
+conformant implementations must do, route it to the relevant version
+milestone even if no schema field changes.
+
+Use this split to keep spec planning clean:
+
+- **Version milestones (`3.1.0`, `3.2.0`, `4.0`, etc.)** — normative
+  protocol/schema/task behavior, release-contract changes, or docs
+  that materially change implementer obligations.
+- **Evergreen** — testing, compliance tooling, training-agent,
+  certification, examples, and general docs that support or explain
+  current behavior without changing the release contract.
+
+#### PR release routing
 
 **Step 1 — Decide the bump level.**
 
 - **Protocol repo (adcp) only:** the changeset file front-matter
   names the bump level: `patch`, `minor`, or `major`. Non-protocol
   changes (server, docs-only typos, infra) use `--empty` with no
-  bump — these get no milestone and target `main`.
+  bump — their PRs get no release milestone and target `main`.
 - **Sibling SDK repos (adcp-client, adcp-client-python, adcp-go):**
   changeset/release-please drives versioning repo-by-repo; follow
   each repo's local PR constraints.
@@ -616,7 +738,7 @@ which never get a bump in the first place.
 
 **Step 2 — Fetch live release signal.**
 
-```
+```bash
 gh api repos/<owner>/<repo>/milestones --jq \
   '.[] | select(.state == "open" and (.title | test("^\\d+\\.\\d+(\\.\\d+)?$"))) |
   {title, number, due: .due_on}'
@@ -641,29 +763,31 @@ The repo publishes:
 | `--empty` (no bump) | none | `main` | Server / docs typo / infra. |
 
 **Never create milestones.** If the expected milestone doesn't
-exist, surface the gap in the run summary and flag the PR for human
-review instead of inventing one.
+exist, surface the gap in the run summary and Flag for human review
+instead of inventing one.
 
 **Apply the milestone in the PR workflow:**
 
-```
+```bash
 gh pr edit <PR#> --milestone "<title from gh api>"
 ```
 
-Include the `Milestone:` line in the triage comment when you draft
-the PR so the reader sees the routing decision.
+Include the `Milestone:` line in the triage comment for
+Ready-to-implement and Execute outcomes so the reader sees the routing
+decision (`Evergreen`, numbered release, or omitted because no clear
+target exists).
 
 **On RFC / epic / deferred issues:** omit the milestone line
 entirely — those don't ship as a single PR, they ship as whatever
 PR-shaped work emerges from the discussion.
 
-## Non-breaking vs. breaking — the central question for Execute
+## Non-breaking vs. breaking — the central question for Ready/Execute
 
-Anything **non-breaking** is a candidate for Execute. Anything
-**breaking** is always Flag, never Execute. No scope cap, no
-classification gate, no author-association gate — just this binary.
+Anything **non-breaking** is a candidate for Ready to implement, and
+may Execute only if the PR authorization gate also passes. Anything
+**breaking** is always Flag, never Ready to implement or Execute.
 
-**Non-breaking — Execute:**
+**Non-breaking — Ready/Execute eligible:**
 
 - Adding **optional** fields to schemas
 - Adding **new enum values** appended at the end (not reordering
@@ -697,9 +821,11 @@ identifier in the downstream client repos (`adcp-client`,
 `adcp-client-python`, `adcp-go`). If it's referenced, the change is
 breaking-shaped — Flag.
 
-## PR criteria — execute when the outcome is clear
+## PR criteria — opt-in or low-entropy only
 
-Open a draft PR when ALL are true:
+Open a draft PR only when BOTH sections pass.
+
+### Execution safety gate
 
 - Experts converge on "ship it" — no material disagreement in the
   synthesis
@@ -707,29 +833,53 @@ Open a draft PR when ALL are true:
 - Not in the `infra / agents` bucket (self-modification is high-risk)
 - Not security-sensitive (always Flag)
 - Not RFC / epic / tracking / child-of-open-parent / deferred
-- Duplicate + open-PR checks clean
+- Duplicate + open-PR gate is clean
 - Success is testable (or change is docs-only)
 
-**Author association is NOT a gate.** Drive-by bugs welcome when the
-change is clear and non-breaking. **Scope is NOT a gate.** A
-200-line non-breaking doc addition ships as a draft PR same as a
-10-line typo fix. CODEOWNERS + human review still gate merge.
+### PR authorization gate
 
-**When in doubt: Execute.** A draft PR is reversible. An unshipped
-good change rarely gets revisited.
+At least one of these must also be true:
+
+- A repo member explicitly used `/triage execute`.
+- The issue already has an exact `auto-pr-ok` label returned by
+  `gh label list`.
+- The change is a narrow low-entropy fix:
+  - typo, grammar, broken link, dead reference, or wrong file path in
+    docs/examples
+  - example correction where the schema/source file proves the exact
+    right answer
+  - missing `x-entity` annotation on an already-existing ID-bearing
+    schema field, when the canonical field map gives the exact value
+  - small test fixture/expectation update for existing behavior, with
+    no product/spec judgment
+
+If the safety gate passes but the authorization gate does not, choose
+**Ready to implement**. Post the implementation brief and stop before
+creating a branch, editing files, running expensive build gates, or
+opening a PR.
+
+**Scope is a judgment signal.** A broad but explicitly authorized
+non-breaking change can still Execute, but default to Ready to
+implement when the PR would require substantial build/test/review
+cycles and no human specifically asked for execution.
+
+**When in doubt: Ready to implement.** A good implementation brief is
+cheap to act on later; a duplicate PR costs review attention now.
 
 ## Bundling and epic handling — never split issues into issues
 
 When an issue contains multiple items — a follow-up list, a list of
 related fixes, or "items 1-5 after PR #N" — decide:
 
-1. **Ready items + deferred items** → open **one PR** covering all
-   the ready items as a cohesive change (name it after the umbrella
+1. **Ready items + deferred items** → produce one cohesive Ready to
+   implement brief covering all ready items, or open **one PR** only
+   if the PR authorization gate passes (name it after the umbrella
    work, e.g., `test+docs: post-#261 A2A follow-ups (items 3, 5)`).
-   Leave the parent issue open. Comment on the parent with what
-   shipped and what remains: `items 3, 5 → #<PR>; item 4 deferred
-   pending upstream; items 1, 2 are cross-repo policy, flagged for
-   @bokelley.` Do **not** split the parent into child issues.
+   Leave the parent issue open. Comment on the parent with what is
+   ready/shipped and what remains: `items 3, 5 → ready to implement
+   in <files> / #<PR>; item 4 deferred pending upstream; items 1, 2
+   are cross-repo policy, flagged for @bokelley.` Do **not** split the
+   parent into child issues.
 
 2. **Parent is truly epic-shaped** — multi-week, cross-cutting,
    needs its own tracking structure → flag-for-review with
@@ -739,12 +889,13 @@ related fixes, or "items 1-5 after PR #N" — decide:
 
 3. **Never create peer issues autonomously.** Issues fan out into
    more issues only when a human decides the parent is an epic.
-   Until then: bundle the ready work into one PR and leave the
-   remaining work on the parent.
+   Until then: bundle the ready work into one implementation brief,
+   or one authorized PR, and leave the remaining work on the parent.
 
-A single cohesive PR of 200 non-breaking lines is easier to review
-than three PRs of 60 lines with dependencies and cross-links. The
-bot's job is to reduce maintainer clicks, not multiply them.
+A single cohesive implementation brief or authorized PR is easier to
+act on than three scattered follow-ups with dependencies and
+cross-links. The bot's job is to reduce maintainer clicks, not
+multiply them.
 
 ### Linkage rule for partial-rollout PRs
 
@@ -778,11 +929,16 @@ the remaining items lose their tracking surface, and no future sweep
 will resurface them. Always default to `Refs` when partial; promote to
 `Closes` only when the work is genuinely complete.
 
-## Pre-PR build + test gate — mandatory before expert review
+## Pre-PR build + test gate — only after Execute is authorized
 
-The expert review is expensive; don't run it on broken code. Before
-spawning experts, make sure the diff actually compiles and the full
-build's transitive lints are clean.
+This section applies only after the PR criteria above choose
+**Execute PR**. Do not run build/test cycles for Ready to implement;
+the point of that outcome is to avoid spending implementation tokens
+until a human or label authorizes the work.
+
+The pre-PR expert review is expensive; don't run it on broken code.
+Before spawning pre-PR reviewers, make sure the diff actually compiles
+and the full build's transitive lints are clean.
 
 1. Run the repo's full build + typecheck:
    - **Default for any non-docs-only diff:** `npm run build && npm run typecheck`.
@@ -875,8 +1031,9 @@ have read the diff before a human reviewer does.
     >
     > - **Push fixup commits directly:** `gh pr checkout <num>` →
     >   fix → push.
-    > - **Or re-trigger:** comment `/triage execute` on the source
-    >   issue.
+    > - **Or request a new first draft PR:** comment `/triage execute`
+    >   on the source issue only when no triage-managed PR is already
+    >   open. Triage does not update existing PRs.
     >
     > See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
     > for context.
@@ -927,10 +1084,11 @@ body is in `<<<UNTRUSTED_ISSUE_BODY>>>`.
    acknowledging the challenge and the new conclusion (even if
    it's "no change, here's why").
 4. If substantive and **unlocks a stuck Clarify state**: move
-   the issue forward — Execute PR or Flag-for-review per
-   standard outcome rules.
+   the issue forward — Ready to implement, Execute PR if authorized,
+   or Flag-for-review per standard outcome rules.
 5. If substantive but the issue is already in a final state
-   (PR drafted, deferred with linkage, flagged for human):
+   (implementation brief posted, PR drafted, deferred with linkage,
+   flagged for human):
    **silent by default.** A read-receipt is noise — the issue's
    state already reflects the prior decision. Comment **only** when
    the new info would materially change the disposition: it
@@ -948,11 +1106,11 @@ body is in `<<<UNTRUSTED_ISSUE_BODY>>>`.
      read the thread. Reading the thread is invisible work; if
      there's nothing to add, leave the silence intact.
 
-   The author already sees from the issue state (open PR linked,
-   deferred label applied, ready-for-human comment posted) that
-   the routine engaged. A second comment confirming receipt
-   dilutes the threads where the routine actually has something
-   to say.
+   The author already sees from the issue state (implementation brief
+   posted, open PR linked, deferred label applied, ready-for-human
+   comment posted) that the routine engaged. A second comment
+   confirming receipt dilutes the threads where the routine actually
+   has something to say.
 6. Never reply to your own previous comments (workflow filters
    most cases, but the routine should also self-check via the
    `Triaged by Claude Code` footer). Never reply to bot authors.
@@ -1003,4 +1161,4 @@ couldn't fetch.
 If you can't form a confident outcome after expert consultation:
 comment with `Status: ready-for-human`, summarize what the experts
 said, and list the specific unresolved questions. That's a useful
-outcome — don't force one of the other three.
+outcome — don't force one of the other four.

--- a/.agents/scripts/triage-local.sh
+++ b/.agents/scripts/triage-local.sh
@@ -9,7 +9,7 @@
 #
 # Examples:
 #   .agents/scripts/triage-local.sh 3112              # fresh triage
-#   .agents/scripts/triage-local.sh 3112 execute      # bias toward Execute
+#   .agents/scripts/triage-local.sh 3112 execute      # authorize first draft PR if safe
 #   .agents/scripts/triage-local.sh 3112 clarify      # force clarify
 #
 # Required env vars (or .env file in the cwd):
@@ -74,7 +74,7 @@ if [ -n "$MODIFIER" ]; then
       exit 64
       ;;
   esac
-  nudge="MANUAL NUDGE: triage-local.sh requested triage with /$MODIFIER. Treat as an explicit request; skip already-engaged check. Honor the modifier (execute / clarify / defer)."
+  nudge="MANUAL NUDGE: triage-local.sh requested triage with /$MODIFIER. Treat as an explicit request; skip already-engaged check. Honor the modifier (execute authorizes a first draft PR only if all Execute safety checks pass; clarify / defer force those outcomes)."
   kind="manual"
   action="triage"
 else

--- a/.changeset/triage-agent-routing-briefs.md
+++ b/.changeset/triage-agent-routing-briefs.md
@@ -1,0 +1,4 @@
+---
+---
+
+Update issue triage routing so clear work defaults to implementation briefs, PR creation is explicitly gated, and Evergreen/spec-adjacent issues are milestoned correctly.


### PR DESCRIPTION
## Summary

- default issue triage to `ready-to-implement` briefs instead of drafting PRs for every clear non-breaking issue
- make `/triage execute` authorize only a first draft PR when safety gates pass
- add duplicate/open-PR gating for manual nudges and tighten Evergreen/spec-adjacent milestone routing

## Validation

- `git diff --check`
- `bash -n .agents/scripts/triage-local.sh`
- precommit hook: Vitest, dynamic import lint, callapi state-change lint, typecheck
