### PR TITLE
Publish CDN artifacts from release workflows

### DIFF
--- a/.changeset/cdn-artifact-release-automation.md
+++ b/.changeset/cdn-artifact-release-automation.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Wires release and deploy workflows to publish protocol artifacts to the R2-backed CDN bucket. No package release is needed.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -235,6 +235,31 @@ jobs:
             echo "No stale console machines found"
           fi
 
+      - name: Setup Node.js for artifact build
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies for artifact build
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: 'true'
+        run: npm ci
+
+      - name: Publish latest artifacts to R2
+        env:
+          ADCP_ARTIFACT_R2_BUCKET: ${{ vars.ADCP_ARTIFACT_R2_BUCKET || 'adcp-artifacts' }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID || secrets.CLOUDFLARE_ACCOUNT_ID }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID || secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY || secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${R2_ACCOUNT_ID:-}" ] || [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+            echo "::error::Missing R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, or R2_SECRET_ACCESS_KEY secret."
+            exit 1
+          fi
+          npm run backfill:cdn-artifacts -- --bucket "${ADCP_ARTIFACT_R2_BUCKET}" --build-latest --quiet
+
       # On any failure (hard or fallback-with-degraded-gates), snapshot Fly
       # state so the next-turn investigator doesn't have to fetch it
       # manually. v2760 on 2026-05-19 cost an extra debugging cycle because

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,3 +112,22 @@ jobs:
             "${TARBALL}.sig" \
             "${TARBALL}.crt" \
             --clobber
+
+      - name: Publish release artifacts to R2
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          ADCP_ARTIFACT_R2_BUCKET: ${{ vars.ADCP_ARTIFACT_R2_BUCKET || 'adcp-artifacts' }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID || secrets.CLOUDFLARE_ACCOUNT_ID }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID || secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY || secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${R2_ACCOUNT_ID:-}" ] || [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+            echo "::error::Missing R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, or R2_SECRET_ACCESS_KEY secret."
+            exit 1
+          fi
+          latest_args=()
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            latest_args=(--skip-latest)
+          fi
+          npm run backfill:cdn-artifacts -- --bucket "${ADCP_ARTIFACT_R2_BUCKET}" --quiet "${latest_args[@]}"

--- a/scripts/backfill-cdn-artifacts.sh
+++ b/scripts/backfill-cdn-artifacts.sh
@@ -19,6 +19,8 @@ Options:
   --aws-dry-run       Execute AWS with --dryrun. Very verbose: AWS prints
                       every object it would upload.
   --build-latest      Rebuild dist/*/latest and dist/protocol/latest.tgz first.
+  --skip-latest       Upload only versioned artifacts; do not update mutable
+                      schemas/latest, compliance/latest, or protocol/latest.
   --apply-cors        Apply public read CORS config to the bucket via Wrangler.
   --quiet             Pass --only-show-errors to aws s3 operations.
   -h, --help          Show this help.
@@ -42,6 +44,7 @@ env_file=""
 dry_run=0
 aws_dry_run=0
 build_latest=0
+skip_latest=0
 apply_cors=0
 quiet=0
 
@@ -84,6 +87,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --build-latest)
       build_latest=1
+      shift
+      ;;
+    --skip-latest)
+      skip_latest=1
       shift
       ;;
     --apply-cors)
@@ -172,7 +179,7 @@ for dir in dist/schemas dist/compliance dist/protocol; do
   fi
 done
 
-if [[ ! -d dist/schemas/latest || ! -d dist/compliance/latest || ! -f dist/protocol/latest.tgz ]]; then
+if [[ "$skip_latest" -eq 0 && ( ! -d dist/schemas/latest || ! -d dist/compliance/latest || ! -f dist/protocol/latest.tgz ) ]]; then
   cat >&2 <<'WARN'
 Warning: one or more latest artifacts are missing.
 Run with --build-latest if this checkout has not already run the artifact build.
@@ -335,12 +342,12 @@ immutable_cache="public, max-age=31536000, immutable"
 revalidate_cache="public, no-cache, must-revalidate"
 
 exclude_latest=1 sync_schema_tree dist/schemas schemas "$immutable_cache"
-if [[ -d dist/schemas/latest ]]; then
+if [[ "$skip_latest" -eq 0 && -d dist/schemas/latest ]]; then
   cp_schema_tree dist/schemas/latest schemas/latest "$revalidate_cache"
 fi
 
 exclude_latest=1 sync_compliance_tree dist/compliance compliance "$immutable_cache"
-if [[ -d dist/compliance/latest ]]; then
+if [[ "$skip_latest" -eq 0 && -d dist/compliance/latest ]]; then
   cp_compliance_tree dist/compliance/latest compliance/latest "$revalidate_cache"
 fi
 
@@ -349,16 +356,16 @@ exclude_latest=1 sync_filtered dist/protocol protocol "$immutable_cache" "text/p
 exclude_latest=1 sync_filtered dist/protocol protocol "$immutable_cache" "application/octet-stream" "*.sig"
 exclude_latest=1 sync_filtered dist/protocol protocol "$immutable_cache" "application/x-pem-file" "*.crt"
 
-if [[ -f dist/protocol/latest.tgz ]]; then
+if [[ "$skip_latest" -eq 0 && -f dist/protocol/latest.tgz ]]; then
   cp_file dist/protocol/latest.tgz protocol/latest.tgz "$revalidate_cache" "application/gzip"
 fi
-if [[ -f dist/protocol/latest.tgz.sha256 ]]; then
+if [[ "$skip_latest" -eq 0 && -f dist/protocol/latest.tgz.sha256 ]]; then
   cp_file dist/protocol/latest.tgz.sha256 protocol/latest.tgz.sha256 "$revalidate_cache" "text/plain; charset=utf-8"
 fi
-if [[ -f dist/protocol/latest.tgz.sig ]]; then
+if [[ "$skip_latest" -eq 0 && -f dist/protocol/latest.tgz.sig ]]; then
   cp_file dist/protocol/latest.tgz.sig protocol/latest.tgz.sig "$revalidate_cache" "application/octet-stream"
 fi
-if [[ -f dist/protocol/latest.tgz.crt ]]; then
+if [[ "$skip_latest" -eq 0 && -f dist/protocol/latest.tgz.crt ]]; then
   cp_file dist/protocol/latest.tgz.crt protocol/latest.tgz.crt "$revalidate_cache" "application/x-pem-file"
 fi
 

--- a/workers/artifact-cdn/README.md
+++ b/workers/artifact-cdn/README.md
@@ -18,6 +18,23 @@ npm run verify:cdn-artifacts-cutover
 The cutover config is deliberately separate from `wrangler.toml` so a normal
 Worker deploy does not attach production routes.
 
+Before cutover, GitHub Actions must have R2 credentials so release and deploy
+workflows keep the bucket fresh:
+
+- `R2_ACCOUNT_ID` or `CLOUDFLARE_ACCOUNT_ID`
+- `R2_ACCESS_KEY_ID` or `AWS_ACCESS_KEY_ID`
+- `R2_SECRET_ACCESS_KEY` or `AWS_SECRET_ACCESS_KEY`
+- optional variable: `ADCP_ARTIFACT_R2_BUCKET` (defaults to `adcp-artifacts`)
+
+Automation after these are set:
+
+- `release.yml` uploads the newly published versioned artifacts after a real
+  Changesets publish. Main-line releases also update mutable `latest`; release
+  branches such as `3.0.x` use `--skip-latest` so they cannot move global
+  `latest` backward.
+- `deploy.yml` rebuilds and uploads mutable `latest` artifacts after the Fly
+  deploy, machine-image check, tenant smoke, and console cleanup all pass.
+
 1. Refresh mutable artifacts in R2.
 
    ```sh


### PR DESCRIPTION
## Summary

Wires ongoing artifact publication to the R2-backed CDN bucket before we cut over production routes.

- release workflow uploads newly published versioned artifacts to R2 after a real Changesets publish
- main-line releases also update mutable `/latest`; maintenance release branches use `--skip-latest` so they cannot move global `/latest` backward
- deploy workflow rebuilds and uploads mutable `/latest` artifacts after Fly deploy health checks, machine-image verification, tenant smoke, and console cleanup pass
- adds `--skip-latest` to `scripts/backfill-cdn-artifacts.sh`
- documents the required GitHub secrets/vars in the artifact CDN runbook

Refs #4984.

## Required GitHub config

Secrets, using either naming scheme:

- `R2_ACCOUNT_ID` or `CLOUDFLARE_ACCOUNT_ID`
- `R2_ACCESS_KEY_ID` or `AWS_ACCESS_KEY_ID`
- `R2_SECRET_ACCESS_KEY` or `AWS_SECRET_ACCESS_KEY`

Optional variable:

- `ADCP_ARTIFACT_R2_BUCKET` defaults to `adcp-artifacts`

## Verification

- parsed `.github/workflows/release.yml` and `.github/workflows/deploy.yml` with the repo YAML parser
- `bash -n scripts/backfill-cdn-artifacts.sh`
- `npm run backfill:cdn-artifacts -- --bucket adcp-artifacts --dry-run --skip-latest --quiet`
- `npm run backfill:cdn-artifacts -- --bucket adcp-artifacts --dry-run --quiet`
- precommit: unit tests, dynamic-import lint, callApi-state-change lint, typecheck
- pre-push: version sync; storyboard and docs gates skipped because unaffected
