### PR TITLE
Fix apex WorkOS domain verification records

### DIFF
--- a/.changeset/fix-apex-workos-domain-verification.md
+++ b/.changeset/fix-apex-workos-domain-verification.md
@@ -1,0 +1,7 @@
+---
+---
+
+Fix WorkOS domain-verification instructions for apex TXT challenges. When
+WorkOS returns a verification token without a `verification_prefix`, the
+member-facing Linked Domains and brand-claim flows now tell users to publish
+the TXT record at the domain apex instead of falling back to `_workos.<domain>`.

--- a/server/public/member-profile.html
+++ b/server/public/member-profile.html
@@ -1841,7 +1841,8 @@
           return;
         }
         pendingChallengeDomain = data.domain;
-        document.getElementById('add-domain-host').textContent = (data.verification_prefix || '_workos') + '.' + data.domain;
+        var prefix = data.verification_prefix || '';
+        document.getElementById('add-domain-host').textContent = data.dns_record_name || (prefix ? prefix + '.' + data.domain : data.domain);
         document.getElementById('add-domain-token').textContent = data.verification_token || '';
         document.getElementById('add-domain-verify-status').textContent = '';
         challengeEl.style.display = 'block';

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -2440,7 +2440,7 @@ export function createMemberToolHandlers(
       if (result.code === 'workos_misconfigured') {
         // Anti-loop: don't have the model offer to retry. The fix lives in
         // the WorkOS dashboard, not in the user's flow.
-        return `<!-- STATUS: workos_misconfigured -->\n\nI can't issue a DNS challenge for ${rawDomain} right now — our identity provider isn't returning a DNS record prefix, which means I have nowhere to tell you to publish the TXT record. This is an operator-side issue (WorkOS DNS verification template), not something you can fix. **Stop here.** The AAO team has been alerted; ask them to set this up manually if you need to move forward today.`;
+        return `<!-- STATUS: workos_misconfigured -->\n\nI can't issue a DNS challenge for ${rawDomain} right now — our identity provider did not return enough DNS record data. This is an operator-side issue, not something you can fix. **Stop here.** The AgenticAdvertising.org team has been alerted; ask them to set this up manually if you need to move forward today.`;
       }
       return `<!-- STATUS: workos_error -->\n\nCouldn't issue the domain challenge: ${result.message}`;
     }
@@ -2449,15 +2449,13 @@ export function createMemberToolHandlers(
       return `<!-- STATUS: already_verified -->\n\n${result.domain} is already verified for your organization in WorkOS. The brand registry should already reflect that — call \`verify_brand_domain_challenge\` if you want to force a sync.`;
     }
 
-    // Defensive: the service should have returned workos_misconfigured before
-    // reaching here, but if WorkOS returns a token without a prefix and the
-    // service guard ever regresses, surface the same failure mode rather than
-    // handing the model a half-broken record to render.
-    if (!result.verification_token || !result.verification_prefix) {
-      return `<!-- STATUS: workos_misconfigured -->\n\nIssued a challenge for ${result.domain} but WorkOS didn't return a complete DNS record (missing prefix or token). This is an operator-side issue — ask the AAO team to verify ${result.domain} manually for you.`;
+    if (!result.verification_token) {
+      return `<!-- STATUS: workos_error -->\n\nIssued a challenge for ${result.domain}, but WorkOS did not return a DNS TXT value. Ask the AgenticAdvertising.org team to verify ${result.domain} manually for you.`;
     }
 
-    const recordName = `${result.verification_prefix}.${result.domain}`;
+    const recordName = result.verification_prefix
+      ? `${result.verification_prefix}.${result.domain}`
+      : result.domain;
     const lines = [
       `<!-- STATUS: dns_record_issued -->`,
       ``,

--- a/server/src/routes/me-organization-domains.ts
+++ b/server/src/routes/me-organization-domains.ts
@@ -62,6 +62,10 @@ export function _resetVerifyCooldown() {
   verifyAttemptTimes.clear();
 }
 
+function dnsRecordName(domain: string, verificationPrefix?: string | null): string {
+  return verificationPrefix ? `${verificationPrefix}.${domain}` : domain;
+}
+
 // Returns true when `domain` is already linked to an organization other
 // than `orgId`. Used by the POST issue path to refuse cross-tenant
 // ownership transfer at issue time (before DNS proof). `linkDomain` would
@@ -323,7 +327,7 @@ export function createMeOrganizationDomainsRouter(
         }
         // Non-verified branches below MUST cross-check the local DB before
         // writing — see comment near the create path.
-        const tokenMissing = !existingEntry.verificationToken || !existingEntry.verificationPrefix;
+        const tokenMissing = !existingEntry.verificationToken;
         if (!tokenMissing) {
           const conflict = await crossOrgConflict(normalizedDomain, orgId);
           if (conflict) {
@@ -344,6 +348,7 @@ export function createMeOrganizationDomainsRouter(
             already_verified: false,
             verification_token: existingEntry.verificationToken,
             verification_prefix: existingEntry.verificationPrefix,
+            dns_record_name: dnsRecordName(normalizedDomain, existingEntry.verificationPrefix),
             verification_strategy: existingEntry.verificationStrategy ?? 'dns',
           });
         }
@@ -401,6 +406,9 @@ export function createMeOrganizationDomainsRouter(
           already_verified: false,
           verification_token: created.verificationToken ?? null,
           verification_prefix: created.verificationPrefix ?? null,
+          dns_record_name: created.verificationToken
+            ? dnsRecordName(normalizedDomain, created.verificationPrefix)
+            : null,
           verification_strategy: created.verificationStrategy ?? 'dns',
         });
       } catch (err: any) {
@@ -506,10 +514,12 @@ export function createMeOrganizationDomainsRouter(
         } catch (err: any) {
           const status = err?.status ?? err?.response?.status;
           if (status === 422 || status === 400) {
+            const recordName = dnsRecordName(normalizedDomain, entry.verificationPrefix);
             return res.status(400).json({
               error: 'still_pending',
-              message: 'WorkOS could not find a matching DNS TXT record. Make sure the prefix.domain TXT record is published, then retry.',
+              message: `WorkOS could not find a matching DNS TXT record. Make sure ${recordName} is published with the verification token, then retry.`,
               state: stateStr,
+              dns_record_name: recordName,
             });
           }
           logger.error({ err, orgId, domain: normalizedDomain }, 'verifyOrganizationDomain failed');

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -2169,7 +2169,7 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       }
       const dnsRecordName = result.verification_prefix
         ? `${result.verification_prefix}.${result.domain}`
-        : null;
+        : result.domain;
       const requestedOrgId = typeof req.query.org === 'string' && req.query.org.length > 0
         ? req.query.org
         : null;
@@ -2188,7 +2188,7 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
           ? `Domain is already verified. Run POST ${verifyPath} to sync the brand registry, or call PUT /brand-identity directly.`
           : dnsRecordName
             ? `Publish a DNS TXT record at ${dnsRecordName} with the value ${result.verification_token}, then call POST ${verifyPath}.`
-            : `Publish a DNS TXT record at <verification_prefix>.<domain> with the value <verification_token>, then call POST ${verifyPath}.`,
+            : `Publish a DNS TXT record at ${result.domain} with the value <verification_token>, then call POST ${verifyPath}.`,
       });
     } catch (error) {
       logger.error({ err: error }, 'Failed to issue brand claim challenge');
@@ -2232,6 +2232,7 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
             message: result.message,
             domain: canonical,
             state: result.state,
+            ...(result.dns_record_name !== undefined ? { dns_record_name: result.dns_record_name } : {}),
             ...(result.retry_after_seconds !== undefined ? { retry_after_seconds: result.retry_after_seconds } : {}),
           });
         }

--- a/server/src/services/brand-claim.ts
+++ b/server/src/services/brand-claim.ts
@@ -36,11 +36,9 @@ export type IssueChallengeResult =
   | { ok: false; code: 'invalid_domain'; message: string }
   | { ok: false; code: 'collision'; message: string }
   | { ok: false; code: 'workos_error'; message: string }
-  // WorkOS issued a domain record but didn't return a verification_prefix —
-  // typically an env-wide config gap (no DNS-verification template set up
-  // in the WorkOS dashboard). Without the prefix, the caller has no hostname
-  // to publish the TXT record at, so the flow is unrecoverable without
-  // operator action. Surface clearly instead of returning broken instructions.
+  // Kept for API compatibility with older callers. Current WorkOS Domain
+  // Verification may return no verification_prefix, which means the TXT
+  // record name is the domain apex itself.
   | { ok: false; code: 'workos_misconfigured'; message: string };
 
 export type VerifyChallengeResult =
@@ -52,7 +50,7 @@ export type VerifyChallengeResult =
       brand: { brand_domain: string; domain_verified: boolean } | null;
     }
   | { ok: false; code: 'no_challenge'; message: string }
-  | { ok: false; code: 'still_pending'; message: string; state: string; retry_after_seconds?: number }
+  | { ok: false; code: 'still_pending'; message: string; state: string; retry_after_seconds?: number; dns_record_name?: string }
   | { ok: false; code: 'workos_error'; message: string };
 
 /**
@@ -65,6 +63,10 @@ export type VerifyChallengeResult =
 function isVerifiedState(state: unknown): boolean {
   const s = String(state);
   return s === 'verified' || s === 'legacy_verified';
+}
+
+function dnsRecordName(domain: string, verificationPrefix?: string | null): string {
+  return verificationPrefix ? `${verificationPrefix}.${domain}` : domain;
 }
 
 // In-process verify cooldown to stop autonomous LLM loops from polling. DNS
@@ -137,20 +139,15 @@ export async function issueDomainChallenge(input: {
   // (pending or verified), surface the existing challenge instead of
   // creating a new one. WorkOS would reject the duplicate create anyway.
   //
-  // Two distinct broken states to separate:
-  //   - `tokenMissing`: WorkOS returned a domain with no verificationToken.
-  //     Recoverable — delete and recreate produces a usable challenge.
-  //   - `prefixMissing` (with token present): the WorkOS env isn't returning
-  //     a verification_prefix at all. Recreate won't fix it; the operator
-  //     needs to fix the WorkOS DNS-verification template. Surface
-  //     `workos_misconfigured` instead of churning tokens in a no-win loop.
+  // Broken state: WorkOS returned a pending domain with no verificationToken.
+  // Recoverable — delete and recreate produces a usable challenge. A missing
+  // verificationPrefix is valid; it means publish the TXT at the domain apex.
   try {
     const existing = await workos.organizations.getOrganization(orgId);
     const existingDomain = existing.domains.find(d => d.domain.toLowerCase() === domain);
     if (existingDomain) {
       const verified = isVerifiedState(existingDomain.state);
       const tokenMissing = !existingDomain.verificationToken;
-      const prefixMissing = !!existingDomain.verificationToken && !existingDomain.verificationPrefix;
       if (!verified && tokenMissing) {
         logger.warn(
           { orgId, domain, existingDomainId: existingDomain.id, state: String(existingDomain.state) },
@@ -163,16 +160,6 @@ export async function issueDomainChallenge(input: {
           return { ok: false, code: 'workos_error', message: 'Failed to clear a broken pending challenge for this domain. Try again or contact support.' };
         }
         // Fall through to the create branch below.
-      } else if (!verified && prefixMissing) {
-        logger.error(
-          { orgId, domain, existingDomainId: existingDomain.id, state: String(existingDomain.state) },
-          'brand-claim: WorkOS env returned a domain without verificationPrefix; cannot construct DNS instructions',
-        );
-        return {
-          ok: false,
-          code: 'workos_misconfigured',
-          message: 'WorkOS did not return a DNS record prefix for this domain. The WorkOS environment is missing a DNS verification template — an operator needs to configure it before brand claims can complete.',
-        };
       } else {
         return {
           ok: true,
@@ -193,21 +180,6 @@ export async function issueDomainChallenge(input: {
 
   try {
     const created = await workos.organizationDomains.createOrganizationDomain({ organizationId: orgId, domain });
-    // Same prefix-missing guard as the existing-domain branch. WorkOS now
-    // owns a pending record we can't give the user instructions for; leave
-    // it in place so an operator can either fix the env template (the next
-    // issue call will succeed idempotently) or clean it up via the dashboard.
-    if (!isVerifiedState(created.state) && created.verificationToken && !created.verificationPrefix) {
-      logger.error(
-        { orgId, domain, createdDomainId: created.id, state: String(created.state) },
-        'brand-claim: WorkOS created a domain without verificationPrefix; cannot construct DNS instructions',
-      );
-      return {
-        ok: false,
-        code: 'workos_misconfigured',
-        message: 'WorkOS did not return a DNS record prefix for this domain. The WorkOS environment is missing a DNS verification template — an operator needs to configure it before brand claims can complete.',
-      };
-    }
     return {
       ok: true,
       domain,
@@ -310,11 +282,13 @@ export async function verifyDomainChallenge(input: {
     } catch (err: any) {
       const status = err?.status ?? err?.response?.status;
       if (status === 422 || status === 400) {
+        const recordName = dnsRecordName(domain, existingDomain.verificationPrefix);
         return {
           ok: false,
           code: 'still_pending',
-          message: 'WorkOS could not find a matching DNS TXT record. Make sure verification_prefix.{domain} is published with the verification_token, then retry.',
+          message: `WorkOS could not find a matching DNS TXT record. Make sure ${recordName} is published with the verification token, then retry.`,
           state: String(existingDomain.state),
+          dns_record_name: recordName,
         };
       }
       logger.error({ err, orgId, domain }, 'workos.organizationDomains.verifyOrganizationDomain failed');

--- a/server/tests/integration/me-organization-domains.test.ts
+++ b/server/tests/integration/me-organization-domains.test.ts
@@ -379,6 +379,7 @@ describe('POST /api/me/organization/domains (issue + verify challenge)', () => {
       domain: 'me-domains-new.test',
       already_verified: false,
       verification_prefix: '_workos',
+      dns_record_name: '_workos.me-domains-new.test',
       verification_strategy: 'dns',
     });
     expect(typeof res.body.verification_token).toBe('string');
@@ -463,6 +464,7 @@ describe('POST /api/me/organization/domains (issue + verify challenge)', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.verification_token).toBe('preexisting-token');
+    expect(res.body.dns_record_name).toBe('_workos.me-domains-new.test');
     expect(res.body.already_verified).toBe(false);
 
     // Local row mirrors pending state at source=workos.
@@ -472,6 +474,45 @@ describe('POST /api/me/organization/domains (issue + verify challenge)', () => {
     );
     expect(row.rows[0].source).toBe('workos');
     expect(row.rows[0].verified).toBe(false);
+  });
+
+  it('uses the domain apex as the TXT record name when WorkOS returns no verificationPrefix', async () => {
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+       VALUES ($1, $2, false, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      [TEST_ORG, 'Me Domains Test Co'],
+    );
+    await seedProfile(pool);
+    await seedMembership(pool, OWNER_USER, 'owner');
+
+    const fakeWorkos = makeFakeWorkos([
+      {
+        id: 'org_domain_existing_no_prefix',
+        domain: 'me-domains-apex.test',
+        state: 'pending',
+        verificationToken: 'preexisting-token',
+        verificationPrefix: null,
+        verificationStrategy: 'dns',
+      },
+    ]);
+    const app = buildApp(() => { cacheInvalidations += 1; }, fakeWorkos);
+
+    const res = await request(app)
+      .post('/api/me/organization/domains?org=' + TEST_ORG)
+      .set('x-test-user', OWNER_USER)
+      .send({ domain: 'me-domains-apex.test' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      domain: 'me-domains-apex.test',
+      verification_token: 'preexisting-token',
+      verification_prefix: null,
+      dns_record_name: 'me-domains-apex.test',
+      already_verified: false,
+    });
+    expect(fakeWorkos.state.domains).toHaveLength(1);
+    expect(fakeWorkos.state.domains[0].id).toBe('org_domain_existing_no_prefix');
   });
 
   it('returns 409 when WorkOS reports the domain belongs to another org', async () => {
@@ -563,12 +604,46 @@ describe('POST /api/me/organization/domains (issue + verify challenge)', () => {
 
     expect(res.status).toBe(400);
     expect(res.body.error).toBe('still_pending');
+    expect(res.body.dns_record_name).toBe('_workos.me-domains-new.test');
 
     const row = await pool.query<{ verified: boolean }>(
       `SELECT verified FROM organization_domains WHERE workos_organization_id = $1 AND domain = $2`,
       [TEST_ORG, 'me-domains-new.test'],
     );
     expect(row.rows[0].verified).toBe(false);
+  });
+
+  it('verify still_pending uses the domain apex when WorkOS challenge has no verificationPrefix', async () => {
+    await seedOrgWithDomains(pool, [
+      { domain: 'me-domains-apex.test', verified: false, is_primary: false, source: 'workos' },
+    ]);
+    await seedProfile(pool);
+    await seedMembership(pool, OWNER_USER, 'owner');
+
+    const fakeWorkos = makeFakeWorkos([
+      {
+        id: 'org_domain_apex',
+        domain: 'me-domains-apex.test',
+        state: 'pending',
+        verificationToken: 'token123',
+        verificationPrefix: null,
+        verificationStrategy: 'dns',
+      },
+    ]);
+    const pendingErr: any = new Error('not yet propagated');
+    pendingErr.status = 422;
+    fakeWorkos.setVerifyError(pendingErr);
+    const app = buildApp(() => { cacheInvalidations += 1; }, fakeWorkos);
+
+    const res = await request(app)
+      .post('/api/me/organization/domains/me-domains-apex.test/verify?org=' + TEST_ORG)
+      .set('x-test-user', OWNER_USER);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('still_pending');
+    expect(res.body.dns_record_name).toBe('me-domains-apex.test');
+    expect(res.body.message).toContain('me-domains-apex.test');
+    expect(res.body.message).not.toContain('prefix.domain');
   });
 
   it('verify returns 404 when no WorkOS challenge exists', async () => {
@@ -722,10 +797,11 @@ describe('POST /api/me/organization/domains (issue + verify challenge)', () => {
   });
 
   it('deletes and recreates a broken pending WorkOS entry (no verification token)', async () => {
-    // Broken state on WorkOS: a domain is attached but verificationToken /
-    // verificationPrefix are null. Returning the broken state would echo
-    // nulls back to the user forever. The route deletes the broken entry
-    // and falls through to a fresh create.
+    // Broken state on WorkOS: a domain is attached but verificationToken is
+    // null. Returning the broken state would echo nulls back to the user
+    // forever. The route deletes the broken entry and falls through to a
+    // fresh create. A missing verificationPrefix alone is valid: it means
+    // publish at the domain apex.
     await pool.query(
       `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
        VALUES ($1, $2, false, NOW(), NOW())

--- a/server/tests/unit/brand-claim-service.test.ts
+++ b/server/tests/unit/brand-claim-service.test.ts
@@ -183,7 +183,7 @@ describe('issueDomainChallenge', () => {
     expect(createFn).not.toHaveBeenCalled();
   });
 
-  it('returns workos_misconfigured when existing pending domain has a token but no verificationPrefix (no delete, no recreate)', async () => {
+  it('returns apex-record instructions when existing pending domain has a token but no verificationPrefix', async () => {
     const deleteFn = vi.fn();
     const createFn = vi.fn();
     const workos = makeWorkos({
@@ -206,14 +206,17 @@ describe('issueDomainChallenge', () => {
       orgId: ORG,
       rawDomain: DOMAIN,
     });
-    expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.code).toBe('workos_misconfigured');
-    // Must not churn WorkOS — recreate won't help if the env template is the bug.
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.workos_domain_id).toBe('dom_no_prefix');
+      expect(result.verification_token).toBe('tok_present');
+      expect(result.verification_prefix).toBeNull();
+    }
     expect(deleteFn).not.toHaveBeenCalled();
     expect(createFn).not.toHaveBeenCalled();
   });
 
-  it('returns workos_misconfigured when createOrganizationDomain succeeds but returns no verificationPrefix', async () => {
+  it('returns apex-record instructions when createOrganizationDomain succeeds but returns no verificationPrefix', async () => {
     const createFn = vi.fn().mockResolvedValue({
       id: 'dom_new_no_prefix',
       state: 'pending',
@@ -232,8 +235,12 @@ describe('issueDomainChallenge', () => {
       orgId: ORG,
       rawDomain: DOMAIN,
     });
-    expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.code).toBe('workos_misconfigured');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.workos_domain_id).toBe('dom_new_no_prefix');
+      expect(result.verification_token).toBe('tok_new');
+      expect(result.verification_prefix).toBeNull();
+    }
     expect(createFn).toHaveBeenCalledTimes(1);
   });
 
@@ -449,7 +456,13 @@ describe('verifyDomainChallenge', () => {
   it('returns still_pending on 422 from workos.verify', async () => {
     const workos = makeWorkos({
       getOrganization: vi.fn().mockResolvedValue({
-        domains: [{ id: 'd1', domain: DOMAIN, state: 'pending' }],
+        domains: [{
+          id: 'd1',
+          domain: DOMAIN,
+          state: 'pending',
+          verificationToken: 'tok_pending',
+          verificationPrefix: null,
+        }],
       }),
       verifyOrganizationDomain: vi.fn().mockRejectedValue({ status: 422 }),
     });
@@ -460,7 +473,12 @@ describe('verifyDomainChallenge', () => {
       rawDomain: DOMAIN,
     });
     expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.code).toBe('still_pending');
+    if (!result.ok) {
+      expect(result.code).toBe('still_pending');
+      expect(result.message).toContain(DOMAIN);
+      expect(result.message).not.toContain('verification_prefix');
+      expect(result.dns_record_name).toBe(DOMAIN);
+    }
   });
 
   it('returns ok with newly_verified=true on a fresh verify success', async () => {


### PR DESCRIPTION
## Summary

Fix WorkOS domain-verification instructions when WorkOS returns a TXT token without `verification_prefix`.

## Root Cause

Our member-facing Linked Domains flow treated a missing `verification_prefix` as broken and the UI fell back to `_workos.<domain>`. WorkOS can issue apex TXT challenges where no prefix means the TXT record name is the domain itself. That made users publish a valid-looking TXT record at the wrong name and left the domain stuck pending.

## Changes

- Treat missing `verification_prefix` as a valid apex-record challenge.
- Return and render `dns_record_name` for Linked Domains.
- Apply the same apex-record handling to brand-claim HTTP and Addie MCP flows.
- Update still-pending verify guidance so it references the same record name.
- Add unit and integration coverage for no-prefix issue and verify paths.

## Validation

- Expert code review: fixed one finding around still-pending verify messages.
- Expert security review: no issues found; WorkOS remains the source of truth before local ownership changes.
- `npx vitest run server/tests/unit/brand-claim-service.test.ts --pool=threads`
- `npx vitest run server/tests/integration/me-organization-domains.test.ts --config server/vitest.config.ts --pool=threads`
- `npx tsc --project server/tsconfig.json --noEmit`
- precommit hook: `npm run test:unit`, dynamic import lint, callApi state-change lint, typecheck
- pre-push hook: version sync, skipped storyboard matrix, schema link convention check, Mintlify broken-link check
