### PR TITLE
Prepare artifact CDN release and cache semantics

### DIFF
--- a/.changeset/release-artifact-detection.md
+++ b/.changeset/release-artifact-detection.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fixes release artifact publication so Version Packages commits upload protocol assets and R2 artifacts even when Changesets reports no publish output. No package release is needed.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,32 +79,60 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
+      - name: Detect committed release artifacts
+        id: release-artifacts
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+          changed_files="$(git show --format= --name-only --no-renames "${GITHUB_SHA}")"
+          if printf '%s\n' "${changed_files}" | grep -Eq "^dist/(schemas|compliance)/${VERSION}/|^dist/protocol/${VERSION}[.]"; then
+            echo "has_release_artifacts=true" >> "$GITHUB_OUTPUT"
+            echo "Detected committed release artifacts for ${VERSION}."
+          else
+            echo "has_release_artifacts=false" >> "$GITHUB_OUTPUT"
+            echo "No committed release artifacts detected for ${VERSION}."
+          fi
+
       # Attach the protocol tarball + signature sidecars to the GitHub
-      # Release that changesets/action just created. `createGithubReleases:
-      # true` only writes the changelog body — files have to be uploaded
-      # separately. The `published` output is the canonical signal that a
-      # tag-and-release just happened on this run (not a Version Packages
-      # PR-creation run, where `published` is false).
+      # Release. For packages with real publish output, changesets/action may
+      # create the GitHub Release first. For this private repo, Version
+      # Packages commits can already contain the release artifacts while
+      # changesets/action reports "All changesets are empty"; create the
+      # release here if needed.
       #
       # Tarballs and sidecars (.sha256, .sig, .crt) are written to
       # dist/protocol/${VERSION}.tgz{,.sha256,.sig,.crt} by `npm run version`
-      # earlier in this job (build-protocol-tarball + sign-protocol-tarball).
+      # in the Version Packages PR (build-protocol-tarball +
+      # sign-protocol-tarball).
       # Without this step the artifacts ship to the repo's dist/ tree but
       # are never attached as Release assets, leaving adopters who pin via
       # release URL with a 404. v3.0.0 had assets only because they were
       # uploaded manually; v3.0.1, v3.0.2, v3.0.3 all shipped empty.
       - name: Upload protocol tarball to GitHub Release
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.changesets.outputs.published == 'true' || steps.release-artifacts.outputs.has_release_artifacts == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
-          VERSION=$(node -p "require('./package.json').version")
+          VERSION="${{ steps.release-artifacts.outputs.version }}"
           TAG="v${VERSION}"
           TARBALL="dist/protocol/${VERSION}.tgz"
           if [ ! -f "${TARBALL}" ]; then
             echo "::error::Tarball not found at ${TARBALL}. Did npm run version fail upstream?"
             exit 1
+          fi
+          if ! gh release view "${TAG}" >/dev/null 2>&1; then
+            release_args=()
+            if [[ "${VERSION}" == *-* ]]; then
+              release_args+=(--prerelease)
+            fi
+            gh release create "${TAG}" \
+              --target "${GITHUB_SHA}" \
+              --title "${TAG}" \
+              --notes "AdCP ${VERSION}" \
+              "${release_args[@]}"
           fi
           gh release upload "${TAG}" \
             "${TARBALL}" \
@@ -114,7 +142,7 @@ jobs:
             --clobber
 
       - name: Publish release artifacts to R2
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.changesets.outputs.published == 'true' || steps.release-artifacts.outputs.has_release_artifacts == 'true'
         env:
           ADCP_ARTIFACT_R2_BUCKET: ${{ vars.ADCP_ARTIFACT_R2_BUCKET || 'adcp-artifacts' }}
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID || secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/tests/artifact-cdn-worker.test.cjs
+++ b/tests/artifact-cdn-worker.test.cjs
@@ -73,13 +73,31 @@ async function loadWorker() {
 function env() {
   return {
     ARTIFACTS: new MockBucket([
-      object('schemas/3.0.12/index.json', '{"version":"3.0.12"}', { contentType: 'application/json; charset=utf-8' }),
-      object('schemas/3.0.12/foo.json', '{"version":"3.0.12"}', { contentType: 'application/json; charset=utf-8' }),
-      object('schemas/3.1.0-beta.3/index.json', '{"version":"3.1.0-beta.3"}', { contentType: 'application/json; charset=utf-8' }),
-      object('schemas/3.1.0-beta.3/foo.json', '{"version":"3.1.0-beta.3"}', { contentType: 'application/json; charset=utf-8' }),
+      object('schemas/3.0.12/index.json', '{"version":"3.0.12"}', {
+        contentType: 'application/json; charset=utf-8',
+        cacheControl: 'public, max-age=31536000, immutable',
+      }),
+      object('schemas/3.0.12/foo.json', '{"version":"3.0.12"}', {
+        contentType: 'application/json; charset=utf-8',
+        cacheControl: 'public, max-age=31536000, immutable',
+      }),
+      object('schemas/3.1.0-beta.3/index.json', '{"version":"3.1.0-beta.3"}', {
+        contentType: 'application/json; charset=utf-8',
+        cacheControl: 'public, max-age=31536000, immutable',
+      }),
+      object('schemas/3.1.0-beta.3/foo.json', '{"version":"3.1.0-beta.3"}', {
+        contentType: 'application/json; charset=utf-8',
+        cacheControl: 'public, max-age=31536000, immutable',
+      }),
       object('schemas/latest/foo.json', '{"version":"latest"}', { contentType: 'application/json; charset=utf-8' }),
-      object('compliance/3.0.12/index.json', '{"version":"3.0.12"}', { contentType: 'application/json; charset=utf-8' }),
-      object('compliance/3.1.0-beta.3/index.json', '{"version":"3.1.0-beta.3"}', { contentType: 'application/json; charset=utf-8' }),
+      object('compliance/3.0.12/index.json', '{"version":"3.0.12"}', {
+        contentType: 'application/json; charset=utf-8',
+        cacheControl: 'public, max-age=31536000, immutable',
+      }),
+      object('compliance/3.1.0-beta.3/index.json', '{"version":"3.1.0-beta.3"}', {
+        contentType: 'application/json; charset=utf-8',
+        cacheControl: 'public, max-age=31536000, immutable',
+      }),
       object('protocol/3.0.12.tgz', 'pinned-tarball', {
         contentType: 'application/gzip',
         cacheControl: 'public, max-age=31536000, immutable',

--- a/workers/artifact-cdn/src/index.js
+++ b/workers/artifact-cdn/src/index.js
@@ -46,7 +46,9 @@ export async function handleRequest(request, env, _ctx) {
 
   if (pathname.startsWith("/protocol/")) {
     const key = pathname.slice(1);
-    return r2ArtifactResponse(request, env, key, cacheControlForProtocolPath(pathname));
+    return r2ArtifactResponse(request, env, key, cacheControlForProtocolPath(pathname), {
+      overrideCacheControl: true,
+    });
   }
 
   return new Response("Not Found", { status: 404, headers: corsHeaders() });
@@ -90,7 +92,9 @@ async function versionedArtifactResponse(request, env, mount, pathname) {
     ? "public, max-age=31536000, immutable"
     : "public, no-cache, must-revalidate";
 
-  return r2ArtifactResponse(request, env, `${mount}${resolvedPath}`, cacheControl);
+  return r2ArtifactResponse(request, env, `${mount}${resolvedPath}`, cacheControl, {
+    overrideCacheControl: true,
+  });
 }
 
 async function discoveryResponse(bucket, mount) {
@@ -159,7 +163,7 @@ async function protocolDiscoveryResponse(bucket) {
   }
 }
 
-async function r2ArtifactResponse(request, env, key, fallbackCacheControl) {
+async function r2ArtifactResponse(request, env, key, fallbackCacheControl, options = {}) {
   const object = request.method === "HEAD"
     ? await env.ARTIFACTS.head(key)
     : await env.ARTIFACTS.get(key);
@@ -179,7 +183,7 @@ async function r2ArtifactResponse(request, env, key, fallbackCacheControl) {
   if (!headers.has("content-type")) {
     headers.set("content-type", contentTypeForKey(key));
   }
-  if (!headers.has("cache-control")) {
+  if (options.overrideCacheControl || !headers.has("cache-control")) {
     headers.set("cache-control", fallbackCacheControl);
   }
 


### PR DESCRIPTION
## Summary
- detects Version Packages commits that already include dist release artifacts
- lets release workflow upload protocol assets and publish R2 artifacts when Changesets reports no published package
- creates the GitHub release if it does not already exist, marking prereleases correctly
- forces worker cache headers from request semantics so movable aliases stay revalidated even when they resolve to immutable R2 objects

## Validation
- parsed .github/workflows/release.yml with the yaml package
- verified detection returns true for the v3.1.0-beta.4 Version Packages commit
- node --test tests/artifact-cdn-worker.test.cjs
- npm run typecheck
- pre-commit suite: npm run test:unit, npm run test:test-dynamic-imports, npm run test:callapi-state-change, npm run typecheck

## Live beta4 check
- R2/Worker currently serves v3.1.0-beta.4 schemas, compliance, protocol tarball, checksum, signature, and certificate
- Current deployed worker returns immutable cache headers for aliases; this PR fixes that before cutover