### PR TITLE
Cache immutable artifact CDN responses at the edge

### DIFF
--- a/.changeset/artifact-worker-edge-cache.md
+++ b/.changeset/artifact-worker-edge-cache.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Caches immutable artifact CDN responses at the Cloudflare edge while keeping movable aliases revalidated.

--- a/tests/artifact-cdn-worker.test.cjs
+++ b/tests/artifact-cdn-worker.test.cjs
@@ -21,13 +21,17 @@ class MockBucket {
   constructor(entries, options = {}) {
     this.entries = new Map(entries);
     this.pageSize = options.pageSize ?? Infinity;
+    this.getCalls = new Map();
+    this.headCalls = new Map();
   }
 
   async get(key) {
+    this.getCalls.set(key, (this.getCalls.get(key) ?? 0) + 1);
     return this.entries.get(key) ?? null;
   }
 
   async head(key) {
+    this.headCalls.set(key, (this.headCalls.get(key) ?? 0) + 1);
     const object = this.entries.get(key);
     return object ? new MockR2Object(key, null, object.httpMetadata) : null;
   }
@@ -59,6 +63,24 @@ class MockBucket {
       truncated,
       cursor: truncated ? String(next) : undefined,
     };
+  }
+}
+
+class MockEdgeCache {
+  constructor() {
+    this.entries = new Map();
+    this.matches = 0;
+    this.puts = 0;
+  }
+
+  async match(request) {
+    this.matches += 1;
+    return this.entries.get(request.url)?.clone();
+  }
+
+  async put(request, response) {
+    this.puts += 1;
+    this.entries.set(request.url, response.clone());
   }
 }
 
@@ -136,6 +158,21 @@ async function fetchPath(path, init) {
   return handleRequest(new Request(`https://artifacts.example${path}`, init), env(), {});
 }
 
+async function withMockEdgeCache(cache, callback) {
+  const hadCaches = Object.hasOwn(globalThis, 'caches');
+  const previousCaches = globalThis.caches;
+  globalThis.caches = { default: cache };
+  try {
+    await callback();
+  } finally {
+    if (hadCaches) {
+      globalThis.caches = previousCaches;
+    } else {
+      delete globalThis.caches;
+    }
+  }
+}
+
 describe('artifact CDN Worker', () => {
   it('rewrites major aliases to the latest matching semver directory', async () => {
     const response = await fetchPath('/schemas/v3/foo.json');
@@ -181,6 +218,60 @@ describe('artifact CDN Worker', () => {
     assert.equal(response.headers.get('cache-control'), 'public, max-age=31536000, immutable');
   });
 
+  it('uses edge cache for immutable versioned schema objects', async () => {
+    const { clearVersionCacheForTests, handleRequest } = await loadWorker();
+    const testEnv = env();
+    const edgeCache = new MockEdgeCache();
+    const pending = [];
+    const ctx = { waitUntil: (promise) => pending.push(promise) };
+    clearVersionCacheForTests();
+
+    await withMockEdgeCache(edgeCache, async () => {
+      const first = await handleRequest(
+        new Request('https://artifacts.example/schemas/3.0.12/foo.json?cache_bust=1'),
+        testEnv,
+        ctx,
+      );
+      assert.equal(first.status, 200);
+      assert.deepEqual(await first.json(), { version: '3.0.12' });
+      await Promise.all(pending);
+
+      const second = await handleRequest(
+        new Request('https://artifacts.example/schemas/3.0.12/foo.json?cache_bust=2'),
+        testEnv,
+        ctx,
+      );
+      assert.equal(second.status, 200);
+      assert.deepEqual(await second.json(), { version: '3.0.12' });
+    });
+
+    assert.equal(testEnv.ARTIFACTS.getCalls.get('schemas/3.0.12/foo.json'), 1);
+    assert.equal(edgeCache.matches, 2);
+    assert.equal(edgeCache.puts, 1);
+  });
+
+  it('does not edge-cache movable aliases', async () => {
+    const { clearVersionCacheForTests, handleRequest } = await loadWorker();
+    const testEnv = env();
+    const edgeCache = new MockEdgeCache();
+    const ctx = { waitUntil: () => assert.fail('aliases should not write to edge cache') };
+    clearVersionCacheForTests();
+
+    await withMockEdgeCache(edgeCache, async () => {
+      const first = await handleRequest(new Request('https://artifacts.example/schemas/v3/foo.json'), testEnv, ctx);
+      const second = await handleRequest(new Request('https://artifacts.example/schemas/v3/foo.json'), testEnv, ctx);
+
+      assert.equal(first.status, 200);
+      assert.equal(second.status, 200);
+      assert.deepEqual(await first.json(), { version: '3.1.0-beta.3' });
+      assert.deepEqual(await second.json(), { version: '3.1.0-beta.3' });
+    });
+
+    assert.equal(testEnv.ARTIFACTS.getCalls.get('schemas/3.1.0-beta.3/foo.json'), 2);
+    assert.equal(edgeCache.matches, 0);
+    assert.equal(edgeCache.puts, 0);
+  });
+
   it('redirects bare alias directories to concrete index.json paths', async () => {
     const response = await fetchPath('/schemas/v3/');
 
@@ -219,6 +310,30 @@ describe('artifact CDN Worker', () => {
     assert.equal(await response.text(), 'latest-tarball');
     assert.equal(response.headers.get('content-type'), 'application/gzip');
     assert.equal(response.headers.get('cache-control'), 'public, no-cache, must-revalidate');
+  });
+
+  it('uses edge cache for pinned protocol tarballs', async () => {
+    const { clearVersionCacheForTests, handleRequest } = await loadWorker();
+    const testEnv = env();
+    const edgeCache = new MockEdgeCache();
+    const pending = [];
+    const ctx = { waitUntil: (promise) => pending.push(promise) };
+    clearVersionCacheForTests();
+
+    await withMockEdgeCache(edgeCache, async () => {
+      const first = await handleRequest(new Request('https://artifacts.example/protocol/3.0.12.tgz'), testEnv, ctx);
+      assert.equal(first.status, 200);
+      assert.equal(await first.text(), 'pinned-tarball');
+      await Promise.all(pending);
+
+      const second = await handleRequest(new Request('https://artifacts.example/protocol/3.0.12.tgz'), testEnv, ctx);
+      assert.equal(second.status, 200);
+      assert.equal(await second.text(), 'pinned-tarball');
+    });
+
+    assert.equal(testEnv.ARTIFACTS.getCalls.get('protocol/3.0.12.tgz'), 1);
+    assert.equal(edgeCache.matches, 2);
+    assert.equal(edgeCache.puts, 1);
   });
 
   it('lists protocol tarballs for discovery', async () => {

--- a/workers/artifact-cdn/src/index.js
+++ b/workers/artifact-cdn/src/index.js
@@ -3,6 +3,8 @@ const VERSION_DIR_PATH = /^\/([^/]+)\/$/;
 const SEMVER_PATH = /^\/(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)(?:\/|$)/;
 const PINNED_TARBALL = /(?:^|\/)(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)\.tgz(?:\.sha256|\.sig|\.crt)?$/;
 
+const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
+const REVALIDATE_CACHE_CONTROL = "public, no-cache, must-revalidate";
 const VERSION_CACHE_TTL_MS = 60 * 1000;
 const versionCache = new Map();
 
@@ -12,7 +14,7 @@ export default {
   },
 };
 
-export async function handleRequest(request, env, _ctx) {
+export async function handleRequest(request, env, ctx) {
   const url = new URL(request.url);
   const pathname = normalizePath(url.pathname);
 
@@ -37,24 +39,27 @@ export async function handleRequest(request, env, _ctx) {
   }
 
   if (pathname.startsWith("/schemas/")) {
-    return versionedArtifactResponse(request, env, "schemas", pathname);
+    return versionedArtifactResponse(request, env, ctx, "schemas", pathname);
   }
 
   if (pathname.startsWith("/compliance/")) {
-    return versionedArtifactResponse(request, env, "compliance", pathname);
+    return versionedArtifactResponse(request, env, ctx, "compliance", pathname);
   }
 
   if (pathname.startsWith("/protocol/")) {
     const key = pathname.slice(1);
-    return r2ArtifactResponse(request, env, key, cacheControlForProtocolPath(pathname), {
+    const cacheControl = cacheControlForProtocolPath(pathname);
+    return r2ArtifactResponse(request, env, key, cacheControl, {
+      edgeCache: cacheControl === IMMUTABLE_CACHE_CONTROL,
       overrideCacheControl: true,
+      ctx,
     });
   }
 
   return new Response("Not Found", { status: 404, headers: corsHeaders() });
 }
 
-async function versionedArtifactResponse(request, env, mount, pathname) {
+async function versionedArtifactResponse(request, env, ctx, mount, pathname) {
   const mountPrefix = `/${mount}`;
   const requestPath = pathname.slice(mountPrefix.length);
   const aliasMatch = requestPath.match(ALIAS_PATH);
@@ -88,12 +93,15 @@ async function versionedArtifactResponse(request, env, mount, pathname) {
     return redirect(`/${mount}${resolvedPath}index.json`, 302);
   }
 
-  const cacheControl = !isAlias && SEMVER_PATH.test(requestPath)
-    ? "public, max-age=31536000, immutable"
-    : "public, no-cache, must-revalidate";
+  const isImmutableArtifact = !isAlias && SEMVER_PATH.test(requestPath);
+  const cacheControl = isImmutableArtifact
+    ? IMMUTABLE_CACHE_CONTROL
+    : REVALIDATE_CACHE_CONTROL;
 
   return r2ArtifactResponse(request, env, `${mount}${resolvedPath}`, cacheControl, {
+    edgeCache: isImmutableArtifact,
     overrideCacheControl: true,
+    ctx,
   });
 }
 
@@ -164,6 +172,13 @@ async function protocolDiscoveryResponse(bucket) {
 }
 
 async function r2ArtifactResponse(request, env, key, fallbackCacheControl, options = {}) {
+  const cache = options.edgeCache && request.method === "GET" ? getEdgeCache() : null;
+  const cacheKey = cache ? edgeCacheKey(request) : null;
+  if (cache && cacheKey) {
+    const cached = await cache.match(cacheKey);
+    if (cached) return cached;
+  }
+
   const object = request.method === "HEAD"
     ? await env.ARTIFACTS.head(key)
     : await env.ARTIFACTS.get(key);
@@ -187,7 +202,17 @@ async function r2ArtifactResponse(request, env, key, fallbackCacheControl, optio
     headers.set("cache-control", fallbackCacheControl);
   }
 
-  return new Response(request.method === "HEAD" ? null : object.body, { headers });
+  const response = new Response(request.method === "HEAD" ? null : object.body, { headers });
+  if (cache && cacheKey) {
+    const put = cache.put(cacheKey, response.clone()).catch(() => undefined);
+    if (typeof options.ctx?.waitUntil === "function") {
+      options.ctx.waitUntil(put);
+    } else {
+      await put;
+    }
+  }
+
+  return response;
 }
 
 async function fallbackResponse(request, env) {
@@ -340,8 +365,18 @@ function compareVersions(left, right) {
 
 function cacheControlForProtocolPath(pathname) {
   return PINNED_TARBALL.test(pathname)
-    ? "public, max-age=31536000, immutable"
-    : "public, no-cache, must-revalidate";
+    ? IMMUTABLE_CACHE_CONTROL
+    : REVALIDATE_CACHE_CONTROL;
+}
+
+function getEdgeCache() {
+  return typeof caches !== "undefined" ? caches.default : null;
+}
+
+function edgeCacheKey(request) {
+  const url = new URL(request.url);
+  url.search = "";
+  return new Request(url.toString(), { method: "GET" });
 }
 
 function contentTypeForKey(key) {
@@ -368,7 +403,7 @@ function jsonResponse(body, status = 200) {
     status,
     headers: corsHeaders({
       "content-type": "application/json; charset=utf-8",
-      "cache-control": "public, no-cache, must-revalidate",
+      "cache-control": REVALIDATE_CACHE_CONTROL,
     }),
   });
 }


### PR DESCRIPTION
## Summary
- use the Cloudflare Worker Cache API for immutable artifact requests
- keep movable aliases (`latest`, `v3`, `v3.0`) out of edge cache so they preserve revalidation semantics
- strip query strings from immutable cache keys to avoid cache-bust query fragmentation
- add worker tests for schema object caching, protocol tarball caching, and alias bypass behavior

## Validation
- node --test tests/artifact-cdn-worker.test.cjs
- npx --yes @changesets/cli@^2.31.0 status --since=origin/main
- pre-commit suite: npm run test:unit, npm run test:test-dynamic-imports, npm run test:callapi-state-change, npm run typecheck