### PR TITLE
[codex] Add title to multi-finalize assertion step

### DIFF
--- a/.changeset/fix-refine-finalize-storyboard-title.md
+++ b/.changeset/fix-refine-finalize-storyboard-title.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix(compliance): add the missing title to the multi-finalize assertion step in the `refine_finalize_exclusivity` storyboard.

--- a/dist/compliance/3.1.0-beta.4/domains/media-buy/scenarios/refine_finalize_exclusivity.yaml
+++ b/dist/compliance/3.1.0-beta.4/domains/media-buy/scenarios/refine_finalize_exclusivity.yaml
@@ -352,6 +352,7 @@ phases:
     skip_if: "!context.proposal_id_2"
     steps:
       - id: assert_multi_finalize
+        title: "Assert multi-finalize path contributed"
         task: assert_contribution
         validations:
           - check: any_of

--- a/dist/compliance/3.1.0-beta.4/protocols/media-buy/scenarios/refine_finalize_exclusivity.yaml
+++ b/dist/compliance/3.1.0-beta.4/protocols/media-buy/scenarios/refine_finalize_exclusivity.yaml
@@ -352,6 +352,7 @@ phases:
     skip_if: "!context.proposal_id_2"
     steps:
       - id: assert_multi_finalize
+        title: "Assert multi-finalize path contributed"
         task: assert_contribution
         validations:
           - check: any_of

--- a/static/compliance/source/protocols/media-buy/scenarios/refine_finalize_exclusivity.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/refine_finalize_exclusivity.yaml
@@ -352,6 +352,7 @@ phases:
     skip_if: "!context.proposal_id_2"
     steps:
       - id: assert_multi_finalize
+        title: "Assert multi-finalize path contributed"
         task: assert_contribution
         validations:
           - check: any_of


### PR DESCRIPTION
## Summary
- add the missing title to the `assert_multi_finalize` storyboard step
- update the published 3.1.0-beta.4 protocol/domain compliance copies

## Why
The beta4 `refine_finalize_exclusivity` storyboard has one step without a title, which trips downstream structural completeness checks after syncing the compliance cache.

## Validation
- npm run build:compliance -- --release
- npm run test:storyboard-branch-sets
- npm run test:storyboard-provides-state-for