### PR TITLE
Add 3.1 storyboard coverage for canonical formats

### DIFF
--- a/.changeset/4591-canonical-format-storyboards.md
+++ b/.changeset/4591-canonical-format-storyboards.md
@@ -1,0 +1,22 @@
+---
+"adcontextprotocol": patch
+---
+
+Expand the canonical-formats compliance storyboard track for #4591 with seeded
+producer coverage for v1-only, v2-only, custom v2-only, experimental, and
+divergent dual-emission product declarations.
+
+The training agent now preserves fixture-seeded `format_options`-only products
+without inventing v1 fallbacks, and emits a producer advisory when a dual-emitted
+product's `format_options[].v1_format_ref[]` does not resolve to that product's
+`format_ids[]`. The v5 dispatcher and v6 sales adapter both preserve populated
+success payloads that carry non-fatal `errors[]` advisories.
+
+The sales training-agent tenant also advertises the seller-level vendor-metric
+optimization capability fields needed to exercise the new vendor-metric
+storyboards instead of capability-skipping them.
+
+Add #4983 vendor-metric external-catalog precondition coverage as a separate 3.1
+storyboard that accepts either compatibility acceptance or `TERMS_REJECTED`
+rejection when vendor-catalog membership is unproven by the current harness,
+with the future 3.2 true catalog-miss cutover documented in the storyboard narrative.

--- a/scripts/run-storyboards-matrix.sh
+++ b/scripts/run-storyboards-matrix.sh
@@ -192,6 +192,38 @@ REQUIRED_CLEAN_CURRENT_SALES=(
   "media_buy_seller/canonical_formats"
 )
 
+storyboard_passed() {
+  local storyboard_id="$1"
+  local log_file="$2"
+  awk -v id="${storyboard_id}" '
+    $0 ~ "^[[:space:]]+" id "([[:space:]]|$)" {
+      if ($0 ~ /[[:space:]]✓[[:space:]]/) {
+        found = 1
+        exit 0
+      }
+      if ($0 ~ /[[:space:]]✗[[:space:]]/) {
+        exit 1
+      }
+      in_storyboard = 1
+      next
+    }
+    in_storyboard && $0 ~ /^[[:space:]]*✓[[:space:]]/ {
+      found = 1
+      exit 0
+    }
+    in_storyboard && $0 ~ /^[[:space:]]*✗[[:space:]]/ {
+      exit 1
+    }
+    in_storyboard && $0 ~ /^[[:space:]]+[[:alnum:]_\/-]+[[:space:]]/ {
+      exit 1
+    }
+    END {
+      if (found) exit 0
+      exit 1
+    }
+  ' "${log_file}"
+}
+
 for entry in "${TENANTS[@]}"; do
   tenant="${entry%%:*}"
   rest="${entry#*:}"
@@ -238,7 +270,7 @@ for entry in "${TENANTS[@]}"; do
 
   if [ "${FLOOR_SET}" = "current" ] && [ "${tenant}" = "sales" ]; then
     for storyboard_id in "${REQUIRED_CLEAN_CURRENT_SALES[@]}"; do
-      if grep -E "^[[:space:]]+${storyboard_id}[[:space:]]+✓" "${log}" >/dev/null; then
+      if storyboard_passed "${storyboard_id}" "${log}"; then
         echo "  ✓ required-clean ${storyboard_id}"
       else
         status="✗"

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -402,6 +402,39 @@ interface TaskError {
   field?: string;
   details?: unknown;
   recovery?: string;
+  source?: 'producer' | 'sdk';
+  sdk_id?: string;
+}
+
+const RESPONSE_ENVELOPE_KEYS = new Set([
+  'errors',
+  'context',
+  'ext',
+  'status',
+  'context_id',
+  'task_id',
+  'timestamp',
+  'message',
+  'replayed',
+  'adcp_error',
+  'push_notification_config',
+  'governance_context',
+  'adcp_version',
+  'adcp_major_version',
+]);
+
+export function hasAdcpSuccessPayload(resultObj: Record<string, unknown> | undefined): boolean {
+  if (!resultObj) return false;
+  if (resultObj.status === 'submitted' && typeof resultObj.task_id === 'string') return true;
+  return Object.keys(resultObj).some(key => !RESPONSE_ENVELOPE_KEYS.has(key) && resultObj[key] !== undefined);
+}
+
+function permitsAdvisoryErrors(toolName: string, resultObj: Record<string, unknown> | undefined): boolean {
+  if (toolName === 'get_products') return hasAdcpSuccessPayload(resultObj);
+  if (toolName === 'create_media_buy') {
+    return resultObj?.status === 'submitted' && typeof resultObj.task_id === 'string';
+  }
+  return false;
 }
 
 /** Signal deployment entry in get_signals response. */
@@ -910,13 +943,14 @@ function backfillTrainingProductDefaults(product: Product, ownAgentUrl: string):
     description?: string;
     publisher_properties?: Array<{ publisher_domain: string; selection_type: string }>;
     format_ids?: Array<{ agent_url?: string; id?: string }>;
+    format_options?: unknown[];
     pricing_options?: unknown[];
     reporting_capabilities?: Record<string, unknown>;
   };
-  if (!Array.isArray(p.format_ids) || p.format_ids.length === 0) {
+  if ((!Array.isArray(p.format_ids) || p.format_ids.length === 0) && (!Array.isArray(p.format_options) || p.format_options.length === 0)) {
     p.format_ids = [{ agent_url: ownAgentUrl, id: 'display_300x250' }];
   } else {
-    for (const fid of p.format_ids) {
+    for (const fid of p.format_ids ?? []) {
       if (typeof fid === 'object' && fid !== null && !fid.agent_url) {
         fid.agent_url = ownAgentUrl;
       }
@@ -1278,6 +1312,82 @@ function overlaySeededProducts(
     backfillTrainingProductDefaults(merged as Product, ownAgentUrl);
     productMap.set(productId, merged as Product);
   }
+}
+
+type CanonicalFormatRef = { agent_url?: string; id?: string };
+type CanonicalFormatOption = {
+  format_option_id?: string;
+  format_kind?: string;
+  v1_format_ref?: CanonicalFormatRef[];
+};
+
+function collectCanonicalFormatAdvisories(products: Product[]): TaskError[] {
+  const errors: TaskError[] = [];
+
+  for (let productIndex = 0; productIndex < products.length; productIndex++) {
+    const product = products[productIndex] as Product & {
+      format_ids?: CanonicalFormatRef[];
+      format_options?: CanonicalFormatOption[];
+    };
+    if (!Array.isArray(product.format_ids) || !Array.isArray(product.format_options)) continue;
+    if (product.format_ids.length === 0 || product.format_options.length === 0) continue;
+
+    const declaredRefs = new Set(
+      product.format_ids
+        .filter((ref): ref is Required<CanonicalFormatRef> =>
+          typeof ref.agent_url === 'string' && typeof ref.id === 'string',
+        )
+        .map(ref => `${canonicalizeAgentUrl(ref.agent_url)}#${ref.id}`),
+    );
+    const missingRefs: Array<{
+      format_option_index: number;
+      ref_index: number;
+      agent_url: string;
+      id: string;
+      format_option_id?: string;
+      format_kind?: string;
+    }> = [];
+
+    product.format_options.forEach((option, optionIndex) => {
+      if (!Array.isArray(option.v1_format_ref)) return;
+      option.v1_format_ref.forEach((ref, refIndex) => {
+        if (typeof ref.agent_url !== 'string' || typeof ref.id !== 'string') return;
+        const key = `${canonicalizeAgentUrl(ref.agent_url)}#${ref.id}`;
+        if (!declaredRefs.has(key)) {
+          const missingRef: (typeof missingRefs)[number] = {
+            format_option_index: optionIndex,
+            ref_index: refIndex,
+            agent_url: ref.agent_url,
+            id: ref.id,
+          };
+          if (typeof option.format_option_id === 'string') {
+            missingRef.format_option_id = option.format_option_id;
+          }
+          if (typeof option.format_kind === 'string') {
+            missingRef.format_kind = option.format_kind;
+          }
+          missingRefs.push(missingRef);
+        }
+      });
+    });
+
+    if (missingRefs.length > 0) {
+      errors.push({
+        code: 'FORMAT_DECLARATION_DIVERGENT',
+        message: `Product ${product.product_id} dual-emits format_options v1_format_ref entries that are absent from format_ids.`,
+        field: `products[${productIndex}].format_options`,
+        recovery: 'correctable',
+        source: 'producer',
+        details: {
+          product_id: product.product_id,
+          divergence_reason: 'v1_format_ref_not_declared_on_product',
+          missing_refs: missingRefs,
+        },
+      });
+    }
+  }
+
+  return errors;
 }
 
 // ── Channel aliases for brief matching (module-scoped for perf) ──
@@ -2029,17 +2139,22 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): P
           : alloc;
       }),
     }));
+  const canonicalFormatAdvisories = collectCanonicalFormatAdvisories(products);
 
   // Store context for refine
   session.lastGetProductsContext = { products, proposals };
 
-  return {
+  const response = {
     status: 'completed' as const,
     products,
-    cache_scope: req.account ? 'account' : 'public',
+    cache_scope: req.account ? 'account' as const : 'public' as const,
     ...(proposals.length > 0 && { proposals }),
     ...(refinementApplied.length > 0 && { refinement_applied: refinementApplied }),
+    ...(canonicalFormatAdvisories.length > 0 && {
+      errors: canonicalFormatAdvisories as unknown as GetProductsResponse['errors'],
+    }),
   };
+  return response;
 }
 
 export async function handleListCreativeFormats(args: ToolArgs, _ctx: TrainingContext): Promise<object> {
@@ -5184,17 +5299,21 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
       }
     }
 
-    // Execute the tool handler. Structured AdCP errors (handler returns
-    // { errors: [...] }) are well-formed responses — the task completes
-    // successfully with an adcp_error envelope. Only thrown exceptions
-    // mark the task as failed.
+    // Execute the tool handler. Structured AdCP error-only bodies (handler
+    // returns { errors: [...] }) are well-formed responses — the task
+    // completes successfully with an adcp_error envelope. Some response
+    // schemas also permit non-fatal advisories in errors[] alongside a
+    // populated success body; those must stay on the success response.
     if (skipHandler) {
       // toolResult already set from idempotency replay path above
     } else try {
       const result = await Promise.resolve(handler((handlerArgs as ToolArgs) || {}, ctx));
-      const resultObj = result as { errors?: Array<{ code: string; message: string; field?: string; details?: unknown; recovery?: string }> };
-      const hasErrors = resultObj.errors && resultObj.errors.length > 0;
-      if (hasErrors) {
+      const resultObj = result as Record<string, unknown> & {
+        errors?: Array<{ code: string; message: string; field?: string; details?: unknown; recovery?: string }>;
+      };
+      const hasErrors = Array.isArray(resultObj.errors) && resultObj.errors.length > 0;
+      const hasAdvisorySuccessPayload = permitsAdvisoryErrors(name, resultObj);
+      if (hasErrors && !hasAdvisorySuccessPayload) {
         // Error-in-body responses are errors from the buyer's POV — do NOT
         // cache (security.mdx rule 3). cachableResponse stays null so the
         // post-dispatch gate below never inserts this into the replay cache.
@@ -5270,7 +5389,7 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
     }
 
     // Resolve the in-flight claim from check(). Cache only successful inner
-    // responses (security.mdx rule 2+3); errors, structured { errors: [...] }
+    // responses (security.mdx rule 2+3); errors, structured error-only
     // bodies, and exceptions all release the claim so a retry re-executes.
     if (idempotencyClaimed && typeof idempotencyKey === 'string') {
       const store = getIdempotencyStore();

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -17,6 +17,7 @@ import { createRegistryHolder, getCanonicalBase, resolveTenantHost, type Registr
 import { buildSignedRevocationList } from '../governance-revocations.js';
 import { getTenantResponseSigningMaterial } from './signing.js';
 import { wrapResponseForSigning } from '../response-signing.js';
+import { salesCapabilityProjection } from '../v6-sales-platform.js';
 import type { TrainingContext } from '../types.js';
 
 const logger = createLogger('training-agent-tenant-router');
@@ -98,6 +99,7 @@ function tenantMcpHandler(holder: RegistryHolder, tenantId: string) {
     // responses pass through unsigned.
     const responseSigner = getTenantResponseSigningMaterial(tenantId);
     wrapResponseForSigning(req, res, responseSigner.signerKey, tenantId);
+    wrapSalesCapabilitiesProjection(req, res, tenantId);
 
     // Bridge `res.locals.trainingPrincipal` (set by the upstream
     // `requireAuth` middleware) onto `req.auth` so the framework's MCP
@@ -223,6 +225,63 @@ function tenantMcpHandler(holder: RegistryHolder, tenantId: string) {
       }
     });
   };
+}
+
+function wrapSalesCapabilitiesProjection(req: Request, res: Response, tenantId: string): void {
+  if (tenantId !== 'sales') return;
+  if (req.body?.method !== 'tools/call') return;
+  if (req.body?.params?.name !== 'get_adcp_capabilities') return;
+
+  const origEnd = res.end.bind(res);
+  const chunks: Buffer[] = [];
+
+  (res as unknown as { write: (...args: unknown[]) => boolean }).write = (chunk: unknown, ...rest: unknown[]) => {
+    if (chunk !== null && chunk !== undefined) chunks.push(toBuffer(chunk));
+    const cb = rest.find(arg => typeof arg === 'function') as (() => void) | undefined;
+    if (cb) queueMicrotask(cb);
+    return true;
+  };
+
+  (res as unknown as { end: (...args: unknown[]) => Response }).end = (chunk?: unknown, ...rest: unknown[]) => {
+    if (chunk !== null && chunk !== undefined) chunks.push(toBuffer(chunk));
+    const body = Buffer.concat(chunks);
+    const patched = projectSalesCapabilities(body);
+    if (patched !== body) {
+      res.setHeader('content-length', String(patched.length));
+    }
+    return origEnd(patched, ...rest as []);
+  };
+}
+
+function toBuffer(chunk: unknown): Buffer {
+  if (Buffer.isBuffer(chunk)) return chunk;
+  if (typeof chunk === 'string') return Buffer.from(chunk, 'utf8');
+  if (chunk instanceof Uint8Array) return Buffer.from(chunk);
+  return Buffer.from(String(chunk), 'utf8');
+}
+
+function projectSalesCapabilities(body: Buffer): Buffer {
+  try {
+    const parsed = JSON.parse(body.toString('utf8')) as {
+      result?: {
+        structuredContent?: {
+          media_buy?: Record<string, unknown>;
+        };
+      };
+    };
+    const structured = parsed.result?.structuredContent;
+    if (!structured || typeof structured !== 'object') return body;
+    const mediaBuy = structured.media_buy && typeof structured.media_buy === 'object'
+      ? structured.media_buy
+      : {};
+    structured.media_buy = {
+      ...mediaBuy,
+      ...salesCapabilityProjection(),
+    };
+    return Buffer.from(JSON.stringify(parsed), 'utf8');
+  } catch {
+    return body;
+  }
 }
 
 /**

--- a/server/src/training-agent/tenants/tenant-smoke.test.ts
+++ b/server/src/training-agent/tenants/tenant-smoke.test.ts
@@ -108,4 +108,49 @@ describe('tenant routing smoke', () => {
       await close();
     }
   }, 15000);
+
+  it('advertises sales vendor-metric optimization capabilities', async () => {
+    const { baseUrl, close } = await bootServer();
+    try {
+      const url = `${baseUrl}/sales/mcp`;
+      const headers = {
+        'content-type': 'application/json',
+        accept: 'application/json',
+        authorization: 'Bearer test-token',
+      };
+      await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          jsonrpc: '2.0', id: 1, method: 'initialize',
+          params: { protocolVersion: '2025-03-26', clientInfo: { name: 'x', version: '1' }, capabilities: {} },
+        }),
+      });
+      const r = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'tools/call',
+          params: { name: 'get_adcp_capabilities', arguments: {} },
+        }),
+      });
+      const body = await r.json() as {
+        result?: {
+          structuredContent?: {
+            media_buy?: {
+              supported_optimization_metrics?: string[];
+              vendor_metric_optimization?: { supported_targets?: string[] };
+            };
+          };
+        };
+      };
+      const mediaBuy = body.result?.structuredContent?.media_buy;
+      expect(mediaBuy?.supported_optimization_metrics).toContain('clicks');
+      expect(mediaBuy?.vendor_metric_optimization?.supported_targets).toContain('threshold_rate');
+    } finally {
+      await close();
+    }
+  }, 15000);
 });

--- a/server/src/training-agent/v6-sales-platform.ts
+++ b/server/src/training-agent/v6-sales-platform.ts
@@ -29,6 +29,7 @@ import {
   handleSyncCreatives,
   handleListCreatives,
   handleListCreativeFormats,
+  hasAdcpSuccessPayload,
 } from './task-handlers.js';
 import {
   handleProvidePerformanceFeedback,
@@ -48,6 +49,54 @@ interface TrainingSalesMeta {
 
 interface TrainingSalesConfig {
   strict: boolean;
+}
+
+export const TRAINING_SALES_CAPABILITIES = {
+  specialisms: ['sales-non-guaranteed', 'sales-guaranteed'] as const,
+  creative_agents: [],
+  channels: [] as const,
+  pricingModels: ['cpm', 'cpa'] as const,
+  targeting: {
+    geo_countries: true,
+    geo_regions: true,
+    geo_metros: { nielsen_dma: true },
+    geo_postal_areas: { us_zip: true },
+    language: true,
+    keyword_targets: { supported_match_types: ['broad', 'phrase', 'exact'] as const },
+    negative_keywords: { supported_match_types: ['broad', 'phrase', 'exact'] as const },
+  },
+  audience_targeting: {
+    supported_identifier_types: ['hashed_email' as const],
+    minimum_audience_size: 100,
+  },
+  conversion_tracking: {
+    supported_event_types: ['purchase' as const, 'add_to_cart' as const, 'lead' as const, 'page_view' as const],
+    supported_hashed_identifiers: ['hashed_email' as const],
+    supported_action_sources: ['website' as const, 'app' as const],
+  },
+  // Seller-level rollup of metric-optimization capabilities. Honest union
+  // across catalog products (product-factory.ts assigns these by channel mix).
+  // The tenant router projects these fields onto get_adcp_capabilities until
+  // the SDK exposes them directly (adcp-client#1818).
+  supported_optimization_metrics: ['clicks' as const, 'views' as const, 'completed_views' as const, 'engagements' as const, 'reach' as const],
+  vendor_metric_optimization: {
+    supported_targets: ['threshold_rate' as const],
+  },
+  supportedBillings: ['agent', 'operator'] as const,
+  // Auto-derives `compliance_testing.scenarios[]` from the adapters wired in
+  // `serverOptions.complyTest`. Empty block opts in; the capability/adapter
+  // consistency check at construction throws if adapters aren't supplied.
+  compliance_testing: {},
+  config: { strict: false },
+};
+
+export function salesCapabilityProjection() {
+  return {
+    supported_optimization_metrics: [...TRAINING_SALES_CAPABILITIES.supported_optimization_metrics],
+    vendor_metric_optimization: {
+      supported_targets: [...TRAINING_SALES_CAPABILITIES.vendor_metric_optimization.supported_targets],
+    },
+  };
 }
 
 /** Build a TrainingContext from a v6 RequestContext.Account.authInfo. */
@@ -78,8 +127,8 @@ function brandDomainFromCtx(account: unknown): string | undefined {
  * v5 → v6 envelope translator. v5 handlers return `{ errors: [...] }` for
  * structured rejection; v6 platform methods throw `AdcpError`.
  */
-function translateV5Result<T extends object>(result: unknown): T {
-  const errs = (result as {
+function translateV5Result<T extends object>(result: unknown, options: { allowAdvisories?: boolean } = {}): T {
+  const resultObj = result as (Record<string, unknown> & {
     errors?: Array<{
       code: string;
       message: string;
@@ -87,8 +136,10 @@ function translateV5Result<T extends object>(result: unknown): T {
       details?: unknown;
       recovery?: string;
     }>;
-  } | undefined)?.errors;
-  if (Array.isArray(errs) && errs.length > 0) {
+  } | undefined);
+  const errs = resultObj?.errors;
+  const hasAdvisorySuccessPayload = options.allowAdvisories === true && hasAdcpSuccessPayload(resultObj);
+  if (Array.isArray(errs) && errs.length > 0 && !hasAdvisorySuccessPayload) {
     const first = errs[0]!;
     const recovery = (first.recovery === 'transient' || first.recovery === 'correctable' || first.recovery === 'terminal')
       ? first.recovery
@@ -157,48 +208,7 @@ export class TrainingSalesPlatform
 {
   constructor(private readonly storyboardCompat?: TrainingContext['storyboardCompat']) {}
 
-  capabilities = {
-    specialisms: ['sales-non-guaranteed', 'sales-guaranteed'] as const,
-    creative_agents: [],
-    channels: [] as const,
-    pricingModels: ['cpm', 'cpa'] as const,
-    targeting: {
-      geo_countries: true,
-      geo_regions: true,
-      geo_metros: { nielsen_dma: true },
-      geo_postal_areas: { us_zip: true },
-      language: true,
-      keyword_targets: { supported_match_types: ['broad', 'phrase', 'exact'] as const },
-      negative_keywords: { supported_match_types: ['broad', 'phrase', 'exact'] as const },
-    },
-    audience_targeting: {
-      supported_identifier_types: ['hashed_email' as const],
-      minimum_audience_size: 100,
-    },
-    conversion_tracking: {
-      supported_event_types: ['purchase' as const, 'add_to_cart' as const, 'lead' as const, 'page_view' as const],
-      supported_hashed_identifiers: ['hashed_email' as const],
-      supported_action_sources: ['website' as const, 'app' as const],
-    },
-    // Seller-level rollup of metric-optimization capabilities. Honest
-    // union across catalog products (product-factory.ts assigns these
-    // by channel mix). Mirrors the same declaration on the legacy /mcp
-    // route (task-handlers.ts handleGetAdcpCapabilities). adcp-client#1818
-    // will auto-derive this from product-level supported_metrics once
-    // the SDK ships the seller-level field; until then both surfaces
-    // declare it manually for parity.
-    supported_optimization_metrics: ['clicks' as const, 'views' as const, 'completed_views' as const, 'engagements' as const, 'reach' as const],
-    vendor_metric_optimization: {
-      supported_targets: ['threshold_rate' as const],
-    },
-    supportedBillings: ['agent', 'operator'] as const,
-    // Auto-derives `compliance_testing.scenarios[]` from the adapters
-    // wired in `serverOptions.complyTest`. Empty block opts in; the
-    // capability/adapter consistency check at construction throws if
-    // adapters aren't supplied alongside.
-    compliance_testing: {},
-    config: { strict: false },
-  };
+  capabilities = TRAINING_SALES_CAPABILITIES;
 
   statusMappers = {};
   accounts: AccountStore<TrainingSalesMeta> = trainingSalesAccounts;
@@ -208,7 +218,7 @@ export class TrainingSalesPlatform
   sales: SalesPlatform<TrainingSalesMeta> = {
     getProducts: async (req, ctx) => {
       const result = await handleGetProducts(req as ToolArgs, buildTrainingCtx(ctx.account, this.storyboardCompat));
-      return translateV5Result(result);
+      return translateV5Result(result, { allowAdvisories: true });
     },
 
     createMediaBuy: async (req, ctx) => {

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -528,7 +528,6 @@ async function main() {
           ];
       for (const variant of strictVariants) {
         const variantLabel = `${storyboard.id}${variant.routeSuffix.replace('/mcp', '')}`;
-        process.stdout.write(`  ${variantLabel.padEnd(40)} `);
         try {
           const targetUrl = agentUrl.replace(/\/mcp$/, variant.routeSuffix);
           const result = await runStoryboard(targetUrl, storyboard, {
@@ -561,16 +560,15 @@ async function main() {
             ? `✓ ${summary.passed}P / ${summary.skipped}S / ${summary.not_applicable}N/A`
             : `✗ ${summary.passed}P / ${summary.failed}F / ${summary.skipped}S / ${summary.not_applicable}N/A`;
           // eslint-disable-next-line no-console
-          console.log(pill);
+          console.log(`  ${variantLabel.padEnd(40)} ${pill}`);
         } catch (err) {
           const summary = { ...summarize(storyboard, { error: err instanceof Error ? err.message : String(err) }), id: variantLabel };
           results.push(summary);
           // eslint-disable-next-line no-console
-          console.log(`⚠ ${summary.error}`);
+          console.log(`  ${variantLabel.padEnd(40)} ⚠ ${summary.error}`);
         }
       }
     } else {
-      process.stdout.write(`  ${storyboard.id.padEnd(40)} `);
       try {
         // The default `/mcp` route is the public sandbox (bearer OR signed,
         // no `required_for` enforcement). Every storyboard other than
@@ -596,12 +594,12 @@ async function main() {
           ? `✓ ${summary.passed}P / ${summary.skipped}S / ${summary.not_applicable}N/A`
           : `✗ ${summary.passed}P / ${summary.failed}F / ${summary.skipped}S / ${summary.not_applicable}N/A`;
         // eslint-disable-next-line no-console
-        console.log(pill);
+        console.log(`  ${storyboard.id.padEnd(40)} ${pill}`);
       } catch (err) {
         const summary = summarize(storyboard, { error: err instanceof Error ? err.message : String(err) });
         results.push(summary);
         // eslint-disable-next-line no-console
-        console.log(`⚠ ${summary.error}`);
+        console.log(`  ${storyboard.id.padEnd(40)} ⚠ ${summary.error}`);
       }
     }
   }

--- a/static/compliance/source/protocols/media-buy/scenarios/canonical_formats.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/canonical_formats.yaml
@@ -1,9 +1,10 @@
 id: media_buy_seller/canonical_formats
 version: "1.0.0"
-title: "Canonical formats producer scenario"
+title: "Canonical formats producer scenarios"
 category: media_buy_seller
-summary: "Validates that get_products can expose a seeded product through both v1 format_ids and v2 canonical format_options without drift."
+summary: "Validates that get_products can expose seeded canonical-format products through dual, v1-only, v2-only, custom, experimental, and divergent declaration shapes."
 track: products
+introduced_in: "3.1"
 required_tools:
   - get_products
   - comply_test_controller
@@ -19,12 +20,13 @@ narrative: |
   both. It exercises the dual-emission contract only after the runner seeds a
   product that deliberately carries both shapes.
 
-  The scenario seeds a deterministic display product that accepts a
-  300x250 image creative and declares a unique vendor metric so the buyer can
-  isolate that product with a structured filter. The buyer requests the
-  wholesale product feed and verifies that the seeded product is discoverable
-  as an image canonical, carries the expected v2 parameters, and links that
-  declaration back to the same v1 format identifier exposed in `format_ids[]`.
+  The scenario seeds deterministic display products that declare unique vendor
+  metrics so the buyer can isolate each product with a structured filter. The
+  buyer requests the wholesale product feed and verifies that the seeded
+  products cover the migration shapes from the canonical-formats conformance
+  track: agreeing dual emission, v1-only emission, v2-only emission, custom
+  v2-only emission, experimental declarations, and divergent dual-emission
+  advisories.
 
 agent:
   interaction_model: media_buy_seller
@@ -94,6 +96,216 @@ fixtures:
           - vendor:
               domain: "prism.example"
             metric_id: "canonical_format_storyboard_probe"
+        date_range_support: "date_range"
+    - product_id: "canonical_formats_ids_only_display"
+      name: "Canonical Formats IDs Only Display"
+      description: "Seeded wholesale product for v1-only format declaration validation."
+      publisher_properties:
+        - publisher_domain: "outdoormagazine.example"
+          selection_type: "all"
+      channels: ["display"]
+      delivery_type: "guaranteed"
+      format_ids:
+        - agent_url: "https://creative.adcontextprotocol.org/"
+          id: "display_728x90_image"
+      pricing_options:
+        - pricing_option_id: "canonical_formats_ids_only_cpm"
+          pricing_model: "cpm"
+          currency: "USD"
+          fixed_price: 10
+      reporting_capabilities:
+        available_reporting_frequencies: ["daily"]
+        expected_delay_minutes: 60
+        timezone: "UTC"
+        supports_webhooks: false
+        available_metrics: ["impressions", "clicks", "spend"]
+        vendor_metrics:
+          - vendor:
+              domain: "prism.example"
+            metric_id: "canonical_format_storyboard_probe_ids_only"
+        date_range_support: "date_range"
+    - product_id: "canonical_formats_options_only_display"
+      name: "Canonical Formats Options Only Display"
+      description: "Seeded wholesale product for v2-only canonical image declaration validation."
+      publisher_properties:
+        - publisher_domain: "outdoormagazine.example"
+          selection_type: "all"
+      channels: ["display"]
+      delivery_type: "guaranteed"
+      format_options:
+        - format_kind: "image"
+          format_option_id: "canonical_formats_image_leaderboard"
+          display_name: "Canonical Formats Image Leaderboard"
+          params:
+            width: 728
+            height: 90
+            max_file_size_kb: 200
+            image_formats: ["jpg", "png"]
+            ssl_required: true
+            asset_source: "buyer_uploaded"
+            buyer_asset_acceptance: "accepted"
+            composition_model: "deterministic"
+            slots:
+              - asset_group_id: "image_main"
+                asset_type: "image"
+                required: true
+      pricing_options:
+        - pricing_option_id: "canonical_formats_options_only_cpm"
+          pricing_model: "cpm"
+          currency: "USD"
+          fixed_price: 11
+      reporting_capabilities:
+        available_reporting_frequencies: ["daily"]
+        expected_delay_minutes: 60
+        timezone: "UTC"
+        supports_webhooks: false
+        available_metrics: ["impressions", "clicks", "spend"]
+        vendor_metrics:
+          - vendor:
+              domain: "prism.example"
+            metric_id: "canonical_format_storyboard_probe_options_only"
+        date_range_support: "date_range"
+    - product_id: "canonical_formats_custom_takeover"
+      name: "Canonical Formats Custom Takeover"
+      description: "Seeded wholesale product for custom v2-only format_schema declaration validation."
+      publisher_properties:
+        - publisher_domain: "outdoormagazine.example"
+          selection_type: "all"
+      channels: ["display"]
+      delivery_type: "guaranteed"
+      format_options:
+        - format_kind: "custom"
+          format_option_id: "canonical_formats_custom_takeover"
+          display_name: "Canonical Formats Custom Takeover"
+          canonical_formats_only: true
+          experimental: true
+          format_shape: "multi_placement_takeover"
+          format_schema:
+            uri: "https://creative.adcontextprotocol.org/translated/acme-outdoor/schemas/custom_takeover_v1"
+            digest: "sha256:a3f5b7c9d8e2f1a4b6c8d0e2f4a6b8c0d2e4f6a8b0c2d4e6f8a0b2c4d6e8f0a2"
+          params:
+            placements:
+              - slot_id: "homepage_billboard"
+                width: 970
+                height: 250
+                required: true
+              - slot_id: "article_mrec"
+                width: 300
+                height: 250
+                required: true
+            asset_source: "buyer_uploaded"
+            buyer_asset_acceptance: "accepted"
+            composition_model: "deterministic"
+      pricing_options:
+        - pricing_option_id: "canonical_formats_custom_takeover_cpm"
+          pricing_model: "cpm"
+          currency: "USD"
+          fixed_price: 35
+      reporting_capabilities:
+        available_reporting_frequencies: ["daily"]
+        expected_delay_minutes: 60
+        timezone: "UTC"
+        supports_webhooks: false
+        available_metrics: ["impressions", "clicks", "spend"]
+        vendor_metrics:
+          - vendor:
+              domain: "prism.example"
+            metric_id: "canonical_format_storyboard_probe_custom"
+        date_range_support: "date_range"
+    - product_id: "canonical_formats_experimental_display"
+      name: "Canonical Formats Experimental Display"
+      description: "Seeded wholesale product for experimental canonical declaration visibility."
+      publisher_properties:
+        - publisher_domain: "outdoormagazine.example"
+          selection_type: "all"
+      channels: ["display"]
+      delivery_type: "guaranteed"
+      format_ids:
+        - agent_url: "https://creative.adcontextprotocol.org/"
+          id: "display_300x250_image"
+      format_options:
+        - format_kind: "image"
+          format_option_id: "canonical_formats_experimental_image_mrec"
+          display_name: "Canonical Formats Experimental Image MREC"
+          experimental: true
+          v1_format_ref:
+            - agent_url: "https://creative.adcontextprotocol.org/"
+              id: "display_300x250_image"
+          params:
+            width: 300
+            height: 250
+            max_file_size_kb: 200
+            image_formats: ["jpg", "png"]
+            ssl_required: true
+            asset_source: "buyer_uploaded"
+            buyer_asset_acceptance: "accepted"
+            composition_model: "deterministic"
+            slots:
+              - asset_group_id: "image_main"
+                asset_type: "image"
+                required: true
+      pricing_options:
+        - pricing_option_id: "canonical_formats_experimental_cpm"
+          pricing_model: "cpm"
+          currency: "USD"
+          fixed_price: 9
+      reporting_capabilities:
+        available_reporting_frequencies: ["daily"]
+        expected_delay_minutes: 60
+        timezone: "UTC"
+        supports_webhooks: false
+        available_metrics: ["impressions", "clicks", "spend"]
+        vendor_metrics:
+          - vendor:
+              domain: "prism.example"
+            metric_id: "canonical_format_storyboard_probe_experimental"
+        date_range_support: "date_range"
+    - product_id: "canonical_formats_divergent_display"
+      name: "Canonical Formats Divergent Display"
+      description: "Seeded wholesale product with intentionally divergent v1 and v2 references."
+      publisher_properties:
+        - publisher_domain: "outdoormagazine.example"
+          selection_type: "all"
+      channels: ["display"]
+      delivery_type: "guaranteed"
+      format_ids:
+        - agent_url: "https://creative.adcontextprotocol.org/"
+          id: "display_300x250_image"
+      format_options:
+        - format_kind: "image"
+          format_option_id: "canonical_formats_divergent_image"
+          display_name: "Canonical Formats Divergent Image"
+          v1_format_ref:
+            - agent_url: "https://creative.adcontextprotocol.org/"
+              id: "display_728x90_image"
+          params:
+            width: 728
+            height: 90
+            max_file_size_kb: 200
+            image_formats: ["jpg", "png"]
+            ssl_required: true
+            asset_source: "buyer_uploaded"
+            buyer_asset_acceptance: "accepted"
+            composition_model: "deterministic"
+            slots:
+              - asset_group_id: "image_main"
+                asset_type: "image"
+                required: true
+      pricing_options:
+        - pricing_option_id: "canonical_formats_divergent_cpm"
+          pricing_model: "cpm"
+          currency: "USD"
+          fixed_price: 8
+      reporting_capabilities:
+        available_reporting_frequencies: ["daily"]
+        expected_delay_minutes: 60
+        timezone: "UTC"
+        supports_webhooks: false
+        available_metrics: ["impressions", "clicks", "spend"]
+        vendor_metrics:
+          - vendor:
+              domain: "prism.example"
+            metric_id: "canonical_format_storyboard_probe_divergent"
         date_range_support: "date_range"
 
 phases:
@@ -209,3 +421,291 @@ phases:
             path: "context.correlation_id"
             value: "canonical_formats--get_seeded_canonical_product"
             description: "Context correlation_id returned unchanged"
+
+      - id: get_seeded_v1_only_product
+        title: "Read v1-only format declarations"
+        narrative: |
+          Request the seeded product that intentionally publishes only
+          `format_ids[]` on the producer side. This remains a valid 3.x
+          product shape during the canonical-format migration window; this
+          producer storyboard MUST NOT require the seller to synthesize
+          `format_options[]` for that product.
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        comply_scenario: schema_compliance
+        stateful: true
+        expected: |
+          Return the seeded canonical_formats_ids_only_display product with a
+          v1 fallback format_id. No producer-side `format_options[]` projection
+          is required for v1-only products.
+        sample_request:
+          buying_mode: "wholesale"
+          filters:
+            channels: ["display"]
+            delivery_type: "guaranteed"
+            required_vendor_metrics:
+              - vendor:
+                  domain: "prism.example"
+                metric_id: "canonical_format_storyboard_probe_ids_only"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          context:
+            correlation_id: "canonical_formats--get_seeded_v1_only_product"
+
+        validations:
+          - check: response_schema
+            description: "Response matches get-products-response.json schema"
+          - check: field_value
+            path: "products[0].product_id"
+            value: "canonical_formats_ids_only_display"
+            description: "The vendor-metric filter isolates the v1-only seeded product"
+          - check: field_value
+            path: "products[0].format_ids[0].agent_url"
+            value: "https://creative.adcontextprotocol.org/"
+            description: "v1-only product names the AAO creative-format catalog"
+          - check: field_value
+            path: "products[0].format_ids[0].id"
+            value: "display_728x90_image"
+            description: "v1-only product carries the expected named format"
+
+      - id: get_seeded_v2_only_product
+        title: "Read v2-only format declarations"
+        narrative: |
+          Request the seeded product that intentionally publishes only
+          `format_options[]`. Producers can expose canonical product-bound
+          declarations without also carrying v1 named-format fallbacks.
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        comply_scenario: schema_compliance
+        stateful: true
+        expected: |
+          Return the seeded canonical_formats_options_only_display product with
+          an image canonical declaration and no format_ids fallback.
+        sample_request:
+          buying_mode: "wholesale"
+          filters:
+            channels: ["display"]
+            delivery_type: "guaranteed"
+            required_vendor_metrics:
+              - vendor:
+                  domain: "prism.example"
+                metric_id: "canonical_format_storyboard_probe_options_only"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          context:
+            correlation_id: "canonical_formats--get_seeded_v2_only_product"
+
+        validations:
+          - check: field_value
+            path: "products[0].product_id"
+            value: "canonical_formats_options_only_display"
+            description: "The vendor-metric filter isolates the v2-only seeded product"
+          - check: field_absent
+            path: "products[0].format_ids"
+            description: "v2-only product does not invent v1 named-format fallbacks"
+          - check: field_value
+            path: "products[0].format_options[0].format_kind"
+            value: "image"
+            description: "v2-only product advertises the image canonical"
+          - check: field_value
+            path: "products[0].format_options[0].format_option_id"
+            value: "canonical_formats_image_leaderboard"
+            description: "v2-only product carries a stable format_option_id"
+          - check: field_value
+            path: "products[0].format_options[0].params.width"
+            value: 728
+            description: "Canonical image params include the expected width"
+          - check: field_value
+            path: "products[0].format_options[0].params.height"
+            value: 90
+            description: "Canonical image params include the expected height"
+
+      - id: get_seeded_custom_v2_only_product
+        title: "Read custom v2-only declarations"
+        narrative: |
+          Request the seeded product that publishes a custom canonical
+          declaration with `canonical_formats_only: true`, `format_shape`, and
+          a digest-pinned `format_schema` reference.
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        comply_scenario: schema_compliance
+        stateful: true
+        expected: |
+          Return the seeded canonical_formats_custom_takeover product with a
+          custom v2-only declaration and digest-pinned format_schema reference.
+        sample_request:
+          buying_mode: "wholesale"
+          filters:
+            channels: ["display"]
+            delivery_type: "guaranteed"
+            required_vendor_metrics:
+              - vendor:
+                  domain: "prism.example"
+                metric_id: "canonical_format_storyboard_probe_custom"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          context:
+            correlation_id: "canonical_formats--get_seeded_custom_v2_only_product"
+
+        validations:
+          - check: field_value
+            path: "products[0].product_id"
+            value: "canonical_formats_custom_takeover"
+            description: "The vendor-metric filter isolates the custom seeded product"
+          - check: field_absent
+            path: "products[0].format_ids"
+            description: "Custom v2-only product does not invent v1 named-format fallbacks"
+          - check: field_value
+            path: "products[0].format_options[0].format_kind"
+            value: "custom"
+            description: "Custom declaration uses the custom format_kind discriminator"
+          - check: field_value
+            path: "products[0].format_options[0].canonical_formats_only"
+            value: true
+            description: "Custom declaration explicitly marks itself as v2-only"
+          - check: field_value
+            path: "products[0].format_options[0].experimental"
+            value: true
+            description: "Custom declaration is surfaced as experimental instead of using runtime_status"
+          - check: field_value
+            path: "products[0].format_options[0].format_shape"
+            value: "multi_placement_takeover"
+            description: "Custom declaration declares the shared format-shape vocabulary term"
+          - check: field_value
+            path: "products[0].format_options[0].format_schema.uri"
+            value: "https://creative.adcontextprotocol.org/translated/acme-outdoor/schemas/custom_takeover_v1"
+            description: "Custom declaration carries a fetchable format_schema URI"
+          - check: field_value
+            path: "products[0].format_options[0].format_schema.digest"
+            value: "sha256:a3f5b7c9d8e2f1a4b6c8d0e2f4a6b8c0d2e4f6a8b0c2d4e6f8a0b2c4d6e8f0a2"
+            description: "Custom declaration carries a digest-pinned format_schema reference"
+
+      - id: get_seeded_experimental_product
+        title: "Read experimental declarations"
+        narrative: |
+          Request the seeded product that dual-emits an image declaration and
+          marks the v2 declaration `experimental: true`. This replaces the
+          earlier runtime_status skip-gate model.
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        comply_scenario: schema_compliance
+        stateful: true
+        expected: |
+          Return the seeded canonical_formats_experimental_display product with
+          both v1 and v2 declarations and an experimental v2 marker.
+        sample_request:
+          buying_mode: "wholesale"
+          filters:
+            channels: ["display"]
+            delivery_type: "guaranteed"
+            required_vendor_metrics:
+              - vendor:
+                  domain: "prism.example"
+                metric_id: "canonical_format_storyboard_probe_experimental"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          context:
+            correlation_id: "canonical_formats--get_seeded_experimental_product"
+
+        validations:
+          - check: response_schema
+            description: "Response matches get-products-response.json schema"
+          - check: field_value
+            path: "products[0].product_id"
+            value: "canonical_formats_experimental_display"
+            description: "The vendor-metric filter isolates the experimental seeded product"
+          - check: field_value
+            path: "products[0].format_ids[0].id"
+            value: "display_300x250_image"
+            description: "Experimental declaration still exposes its v1 fallback"
+          - check: field_value
+            path: "products[0].format_options[0].format_kind"
+            value: "image"
+            description: "Experimental declaration still carries the canonical format_kind"
+          - check: field_value
+            path: "products[0].format_options[0].experimental"
+            value: true
+            description: "Experimental marker replaces the obsolete runtime_status field"
+          - check: refs_resolve
+            description: "The experimental declaration's v1_format_ref still resolves to a product format_id"
+            source:
+              from: current_step
+              path: "products[0].format_options[*].v1_format_ref[*]"
+            target:
+              from: current_step
+              path: "products[0].format_ids[*]"
+            match_keys: [agent_url, id]
+            on_out_of_scope: fail
+
+      - id: get_seeded_divergent_product
+        title: "Flag divergent dual-emission"
+        narrative: |
+          Request the seeded product whose `format_ids[]` and
+          `format_options[].v1_format_ref[]` intentionally disagree. Producers
+          that self-detect this drift surface a non-fatal advisory on
+          `errors[]` so consumers do not silently lose inventory.
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        comply_scenario: schema_compliance
+        auth:
+          type: api_key
+          from_test_kit: true
+        stateful: true
+        expected: |
+          Return the seeded canonical_formats_divergent_display product and
+          flag the divergent declarations with a non-fatal
+          FORMAT_DECLARATION_DIVERGENT advisory in `errors[]`.
+        sample_request:
+          buying_mode: "wholesale"
+          filters:
+            channels: ["display"]
+            delivery_type: "guaranteed"
+            required_vendor_metrics:
+              - vendor:
+                  domain: "prism.example"
+                metric_id: "canonical_format_storyboard_probe_divergent"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          context:
+            correlation_id: "canonical_formats--get_seeded_divergent_product"
+
+        validations:
+          - check: response_schema
+            description: "Divergent dual-emission remains a populated get_products success response"
+          - check: field_value
+            path: "products[0].product_id"
+            value: "canonical_formats_divergent_display"
+            description: "Success response still returns the matching seeded product"
+          - check: field_value
+            path: "errors[0].code"
+            value: "FORMAT_DECLARATION_DIVERGENT"
+            description: "Producer flags divergent dual-emission with the canonical advisory code"
+          - check: field_value
+            path: "errors[0].source"
+            value: "producer"
+            description: "Advisory is attributed to the producer declaration"

--- a/static/compliance/source/protocols/media-buy/scenarios/vendor_metric_catalog_precondition.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/vendor_metric_catalog_precondition.yaml
@@ -1,0 +1,265 @@
+id: media_buy_seller/vendor_metric_catalog_precondition
+version: "1.0.0"
+title: "Vendor-metric external catalog precondition"
+category: media_buy_seller
+summary: "Exercises the 3.1 SHOULD-window behavior for vendor_metric goals whose external vendor catalog membership is not proven by the harness."
+track: media_buy
+introduced_in: "3.1"
+
+# Gate: scenario runs only when the seller declares vendor-metric
+# optimization support. Sellers that do not advertise this optional 3.1
+# capability are not expected to handle vendor_metric optimization goals.
+requires_capability:
+  path: media_buy.vendor_metric_optimization
+  present: true
+
+required_tools:
+  - create_media_buy
+  - sync_accounts
+  - comply_test_controller
+
+narrative: |
+  Vendor-metric optimization goals bind to a measurement vendor's
+  `measurement.metrics[]` catalog. In AdCP 3.1, sellers SHOULD verify that the
+  goal's `(vendor, metric_id)` is present in that vendor-published catalog, but
+  MAY accept catalog misses while measurement vendors finish publishing
+  conformant capability catalogs. The next minor tightens this discovery
+  precondition to MUST.
+
+  This storyboard seeds a product whose `attention_catalog_probe` metric is
+  valid by the seller's product-level capability and reporting contract. The
+  current runner does not fetch or seed an external measurement-agent
+  `measurement.metrics[]` catalog for `attentionvendor.example`, so this
+  storyboard does not certify real vendor-catalog discovery. It captures the
+  3.1 compatibility window for catalog-unproven metrics: a seller may accept the
+  request, or it may reject with `TERMS_REJECTED`. A future 3.2 storyboard should
+  add a real measurement-catalog fixture and make the reject path required for
+  true catalog misses.
+
+agent:
+  interaction_model: media_buy_seller
+  capabilities:
+    - sells_media
+    - supports_vendor_metric_optimization
+  examples:
+    - "Premium publishers with attention measurement optimization"
+    - "Sellers integrating vendor-defined measurement into bidding"
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: |
+    The runner seeds a product that can optimize and report the
+    attention_catalog_probe metric. The runner does not currently provide an
+    external measurement.metrics[] catalog for attentionvendor.example, so this
+    scenario exercises 3.1 behavior for a catalog-unproven metric rather than a
+    verified catalog miss.
+  test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  products:
+    - product_id: "display_vendor_metric_catalog_precondition"
+      delivery_type: "non_guaranteed"
+      channels: ["display"]
+      format_ids:
+        - id: "display_300x250"
+      reporting_capabilities:
+        available_metrics:
+          - impressions
+          - clicks
+          - spend
+        vendor_metrics:
+          - vendor:
+              domain: "attentionvendor.example"
+            metric_id: "attention_catalog_probe"
+      vendor_metric_optimization:
+        supported_metrics:
+          - vendor:
+              domain: "attentionvendor.example"
+            metric_id: "attention_catalog_probe"
+            supported_targets:
+              - threshold_rate
+  pricing_options:
+    - product_id: "display_vendor_metric_catalog_precondition"
+      pricing_option_id: "cpm_vendor_metric_catalog_precondition"
+      pricing_model: "cpm"
+      currency: "USD"
+      fixed_price: 14.0
+
+phases:
+  - id: account_setup
+    title: "Establish account"
+    narrative: |
+      The buyer provisions or resolves an account so subsequent media-buy
+      creation uses the same tenant scope as the seeded product.
+    steps:
+      - id: sync_accounts
+        title: "Establish buyer account"
+        task: sync_accounts
+        schema_ref: "account/sync-accounts-request.json"
+        response_schema_ref: "account/sync-accounts-response.json"
+        doc_ref: "/accounts/tasks/sync_accounts"
+        stateful: true
+        expected: |
+          Return the account with account_id and status active.
+        sample_request:
+          accounts:
+            - brand:
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
+              billing: "operator"
+              payment_terms: "net_30"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_vendor_metric_catalog_precondition_sync_accounts"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-accounts-response.json schema"
+          - check: field_present
+            path: "accounts[0].account_id"
+            description: "Account has a platform-assigned ID"
+
+  - id: catalog_miss_accept_path
+    title: "3.1 catalog-unproven metric — accept path"
+    narrative: |
+      The seller may accept the buy during the 3.1 SHOULD window even though
+      the harness has not proven attention_catalog_probe exists in the vendor's
+      external catalog.
+    optional: true
+    branch_set:
+      id: vendor_metric_catalog_miss_handled
+      semantics: any_of
+    steps:
+      - id: create_media_buy_catalog_miss_accept
+        title: "Accept vendor_metric with unproven catalog membership during 3.1 SHOULD window"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        comply_scenario: create_media_buy
+        auth:
+          type: api_key
+          from_test_kit: true
+        stateful: false
+        contributes: true
+        expected: |
+          3.1 compatibility behavior: accept the buy even though the metric is
+          not proven by a vendor measurement.metrics[] catalog in this harness.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-06-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "display_vendor_metric_catalog_precondition"
+              pricing_option_id: "cpm_vendor_metric_catalog_precondition"
+              budget: 5000
+              optimization_goals:
+                - kind: "vendor_metric"
+                  vendor:
+                    domain: "attentionvendor.example"
+                  metric_id: "attention_catalog_probe"
+                  target:
+                    kind: "threshold_rate"
+                    value: 70
+                  priority: 1
+              committed_metrics:
+                - scope: "vendor"
+                  vendor:
+                    domain: "attentionvendor.example"
+                  metric_id: "attention_catalog_probe"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_vendor_metric_catalog_precondition_accept"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema for the 3.1 catalog-unproven accept branch"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Seller returns a media_buy_id during the 3.1 catalog-unproven SHOULD window"
+
+  - id: catalog_miss_reject_path
+    title: "3.1 catalog-unproven metric — reject path"
+    narrative: |
+      The seller may also reject the same request in 3.1. This is the
+      recommended behavior ahead of the 3.2 MUST boundary.
+    optional: true
+    branch_set:
+      id: vendor_metric_catalog_miss_handled
+      semantics: any_of
+    steps:
+      - id: create_media_buy_catalog_miss_reject
+        title: "Reject vendor_metric with unproven catalog membership using TERMS_REJECTED"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        comply_scenario: create_media_buy
+        expect_error: true
+        negative_path: payload_well_formed
+        auth:
+          type: api_key
+          from_test_kit: true
+        stateful: false
+        contributes: true
+        expected: |
+          Recommended 3.1 behavior and required 3.2 behavior: reject with
+          TERMS_REJECTED because the metric is not proven by the vendor's
+          measurement.metrics[] catalog.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-06-01T00:00:00Z"
+          end_time: "2026-06-30T23:59:59Z"
+          packages:
+            - product_id: "display_vendor_metric_catalog_precondition"
+              pricing_option_id: "cpm_vendor_metric_catalog_precondition"
+              budget: 5000
+              optimization_goals:
+                - kind: "vendor_metric"
+                  vendor:
+                    domain: "attentionvendor.example"
+                  metric_id: "attention_catalog_probe"
+                  target:
+                    kind: "threshold_rate"
+                    value: 70
+                  priority: 1
+              committed_metrics:
+                - scope: "vendor"
+                  vendor:
+                    domain: "attentionvendor.example"
+                  metric_id: "attention_catalog_probe"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_vendor_metric_catalog_precondition_reject"
+        validations:
+          - check: error_code
+            allowed_values: ["TERMS_REJECTED"]
+            description: "Seller may reject catalog-unproven vendor metrics with TERMS_REJECTED in 3.1; true catalog misses become required rejections at 3.2"
+
+  - id: catalog_miss_assertion
+    title: "Require catalog-unproven metric handling"
+    narrative: |
+      Synthetic assertion over the accept and reject branches. In 3.1, either
+      compatibility acceptance or recommended TERMS_REJECTED rejection satisfies
+      the catalog-unproven metric behavior. The 3.2 storyboard cut should add a
+      real measurement-catalog fixture and collapse true catalog misses to the
+      reject branch only.
+    steps:
+      - id: assert_vendor_metric_catalog_miss_handled
+        title: "Require catalog-miss handling from either branch"
+        task: assert_contribution
+        comply_scenario: create_media_buy
+        stateful: false
+        expected: |
+          At least one of catalog_miss_accept_path or catalog_miss_reject_path
+          contributed vendor_metric_catalog_miss_handled.
+        validations:
+          - check: any_of
+            allowed_values: ["vendor_metric_catalog_miss_handled"]
+            description: "Agent must either accept the catalog-unproven metric during the 3.1 SHOULD window or reject it with TERMS_REJECTED."

--- a/static/compliance/source/protocols/media-buy/scenarios/vendor_metric_optimization_flow.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/vendor_metric_optimization_flow.yaml
@@ -4,6 +4,7 @@ title: "Vendor-metric optimization-goal: acceptance and rejection"
 category: media_buy_seller
 summary: "Verifies that a seller supporting vendor_metric_optimization accepts a media buy whose optimization_goal has kind 'vendor_metric' when all preconditions are met, and rejects goals that fail either the capability check or the reporting-coherence check."
 track: media_buy
+introduced_in: "3.1"
 
 # Gate: scenario runs only when the seller declares vendor-metric
 # optimization support. The product-level vendor_metric_optimization block
@@ -225,6 +226,9 @@ phases:
         response_schema_ref: "media-buy/create-media-buy-response.json"
         doc_ref: "/media-buy/task-reference/create_media_buy"
         comply_scenario: create_media_buy
+        auth:
+          type: api_key
+          from_test_kit: true
         stateful: true
         expected: |
           Accept the buy. The optimization goal is valid: attention_score is in
@@ -285,6 +289,9 @@ phases:
         response_schema_ref: "media-buy/create-media-buy-response.json"
         doc_ref: "/media-buy/task-reference/create_media_buy"
         comply_scenario: create_media_buy
+        auth:
+          type: api_key
+          from_test_kit: true
         stateful: true
         expected: |
           Accept the buy. The optimization goal has no target, so supported_targets
@@ -340,6 +347,9 @@ phases:
         comply_scenario: create_media_buy
         expect_error: true
         negative_path: payload_well_formed
+        auth:
+          type: api_key
+          from_test_kit: true
         stateful: false
         expected: |
           Reject with TERMS_REJECTED. The goal references attention_units for
@@ -398,6 +408,9 @@ phases:
         comply_scenario: create_media_buy
         expect_error: true
         negative_path: payload_well_formed
+        auth:
+          type: api_key
+          from_test_kit: true
         stateful: false
         expected: |
           Reject with TERMS_REJECTED. The goal references a supported vendor
@@ -457,6 +470,9 @@ phases:
         comply_scenario: create_media_buy
         expect_error: true
         negative_path: payload_well_formed
+        auth:
+          type: api_key
+          from_test_kit: true
         stateful: false
         expected: |
           Reject with TERMS_REJECTED. The optimization goal targets attention_score
@@ -513,6 +529,9 @@ phases:
         comply_scenario: create_media_buy
         expect_error: true
         negative_path: payload_well_formed
+        auth:
+          type: api_key
+          from_test_kit: true
         stateful: false
         expected: |
           Reject with TERMS_REJECTED. The product can optimize toward


### PR DESCRIPTION
## Summary

- expand the 3.1 canonical-format storyboard to cover v1-only, v2-only, custom, experimental, aligned dual-emission, and divergent dual-emission cases
- add vendor-metric catalog-precondition coverage and make the sales tenant advertise vendor-metric optimization so those storyboards run instead of capability-skipping
- preserve 3.0 compatibility by gating 3.1-only storyboards with `introduced_in: "3.1"` and keeping the released 3.0.13 storyboard matrix in the test flow
- tighten advisory `errors[]` handling so only tool-specific success/advisory shapes avoid the error path

## Notes

Two storyboard steps use raw MCP auth because current SDK behavior blocks valid 3.1 wire behavior before the training agent can be tested:

- adcontextprotocol/adcp-client#2013 tracks SDK request validation rejecting `vendor_metric` optimization goals
- adcontextprotocol/adcp-client#2014 tracks SDK response unwrapping treating advisory `errors[]` as terminal failures

## Validation

- `npm run typecheck`
- `npm run build:compliance`
- `npx vitest run server/tests/unit/training-agent.test.ts -t "report_usage handler"`
- `npx vitest run server/src/training-agent/tenants/tenant-smoke.test.ts`
- focused storyboard runs for `canonical_formats`, `vendor_metric_optimization_flow`, and `vendor_metric_catalog_precondition`
- `npm run test:storyboards`
- `npm run test:storyboards:3.0-compat`
- precommit suite during commit: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run typecheck`
- pre-push hook: version sync, current storyboard matrix, released 3.0.13 compatibility matrix
