### PR TITLE
[codex] Allow admin debug reads for compliance evidence

### DIFF
--- a/.changeset/admin-debug-read-bypass.md
+++ b/.changeset/admin-debug-read-bypass.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Allow static admin API key callers to read registry compliance diagnostics and outbound monitoring data across seller agents, without granting mutating agent-owner operations.

--- a/docs/registry/maintaining-your-agent.mdx
+++ b/docs/registry/maintaining-your-agent.mdx
@@ -63,7 +63,7 @@ The agent dashboard at [agenticadvertising.org/dashboard/agents](https://agentic
 
 ## How to manually trigger a re-probe
 
-AAO runs probes automatically on the ~1h heartbeat, but there are two ways to trigger an immediate refresh:
+AAO runs probes automatically on the ~1h heartbeat, but there are three ways to refresh agent state:
 
 ### Registry crawl (metadata update)
 
@@ -104,10 +104,14 @@ This runs asynchronously and returns `202 Accepted`. Rate-limited to one request
 
 ### Dashboard Refresh button
 
-In the agent card on [agenticadvertising.org/dashboard/agents](https://agenticadvertising.org/dashboard/agents), the **Refresh** button calls `/api/registry/agents/{encodedUrl}/refresh`. Like the crawl-request endpoint, this re-reads your agent's registry metadata and updates the dashboard view. It is a registry metadata refresh, not a full compliance re-run.
+In the agent card on [agenticadvertising.org/dashboard/agents](https://agenticadvertising.org/dashboard/agents), the **Recheck status** button calls `/api/registry/agents/{encodedUrl}/refresh`. It re-reads your agent's registry metadata and, when you own the agent and the capability probe succeeds, runs the full compliance storyboard suite synchronously before updating the dashboard view.
+
+### Compliance requeue
+
+The **Requeue comply** button does not run the storyboard suite immediately. It clears `last_checked_at` so the agent is picked up by the next scheduled heartbeat cycle, which can take up to about 1 hour.
 
 <Note>
-**Re: comply re-runner (#4253).** Manually triggering a full compliance storyboard re-run (outside the ~1h heartbeat schedule) is not currently available via the dashboard or API. If you need to confirm a fix before the next scheduled heartbeat, reproduce the storyboard locally using `@adcp/sdk/testing` — the local runner runs the same storyboard suite the heartbeat uses.
+If you need to confirm a fix immediately, use **Recheck status** or the dashboard **Test** flow rather than **Requeue comply**. For local reproduction, run the same storyboards with `@adcp/sdk/testing`.
 </Note>
 
 ## How to read a comply report

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -6,7 +6,7 @@
  */
 
 import { Router } from "express";
-import type { RequestHandler } from "express";
+import type { Request, RequestHandler } from "express";
 import { z } from "zod";
 import escapeHtml from "escape-html";
 import { findOwnerOrgForUser } from "../services/agent-ownership.js";
@@ -1922,7 +1922,7 @@ registry.registerPath({
   operationId: "getAgentStoryboardStatus",
   summary: "Get agent storyboard status",
   description:
-    "Returns per-storyboard test results for an agent. Includes title, category, track, pass/fail status, and step counts.\n\n**Members only** — requires authentication and an active membership.",
+    "Returns per-storyboard test results for an agent. Includes title, category, track, pass/fail status, and step counts.\n\n**Members only** — requires authentication and an active membership. Static admin API key callers may read this for support/debugging.",
   tags: ["Agent Compliance"],
   security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
@@ -1957,7 +1957,7 @@ registry.registerPath({
   operationId: "bulkAgentStoryboardStatus",
   summary: "Bulk storyboard status",
   description:
-    "Returns per-storyboard test results for multiple agents in a single request.\n\n**Members only** — requires authentication and an active membership. Maximum 100 agent URLs per request.",
+    "Returns per-storyboard test results for multiple agents in a single request.\n\n**Members only** — requires authentication and an active membership. Static admin API key callers may read this for support/debugging. Maximum 100 agent URLs per request.",
   tags: ["Agent Compliance"],
   security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
@@ -2186,7 +2186,7 @@ registry.registerPath({
   operationId: "requeueAgentForHeartbeat",
   summary: "Requeue agent for compliance heartbeat",
   description:
-    "Clears the agent's last_checked_at timestamp so it is picked up on the next heartbeat cycle (within ~1 hour). Requires authentication and ownership.",
+    "Clears the agent's last_checked_at timestamp so it is picked up on the next heartbeat cycle (within ~1 hour). This is queued-async; it does not run the compliance suite synchronously or change the current verdict until the heartbeat completes. Requires authentication and ownership.",
   tags: ["Agent Compliance"],
   security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
@@ -2210,7 +2210,7 @@ registry.registerPath({
   operationId: "getAgentComplianceStepDiagnostics",
   summary: "Get per-step diagnostics for a compliance run",
   description:
-    "Returns the exact request and response payloads the runner captured for failing storyboard steps on a single compliance run.\n\nLets agent owners diff what the runner sent against their own probes without re-running the storyboard. Owner-only — payloads echo seller-side account/brand identifiers and may carry sensitive descriptive fields. If `run_id` is omitted, resolves to the latest run for the agent.",
+    "Returns the exact request and response payloads the runner captured for failing storyboard steps on a single compliance run.\n\nLets agent owners diff what the runner sent against their own probes without re-running the storyboard. Owner-only, with static admin API key access for support/debugging — payloads echo seller-side account/brand identifiers and may carry sensitive descriptive fields. If `run_id` is omitted, resolves to the latest run for the agent.",
   tags: ["Agent Compliance"],
   security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
@@ -2249,7 +2249,7 @@ registry.registerPath({
   operationId: "getAgentMonitoringRequests",
   summary: "Get outbound request log",
   description:
-    "Returns the outbound request log for an agent (compliance checks, health probes, etc.). Requires authentication and ownership.",
+    "Returns the outbound request log for an agent (compliance checks, health probes, etc.). Requires authentication and ownership, or the static admin API key for support/debugging.",
   tags: ["Agent Compliance"],
   security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
@@ -2288,7 +2288,7 @@ registry.registerPath({
   operationId: "refreshAgent",
   summary: "Refresh agent snapshot",
   description:
-    "Re-probe the agent and update its registry health (online, tools_count, response_time_ms), capability snapshot (inferred type, discovered tools), and compliance verdict (storyboard pass/fail counts). Use after fixing your agent so the registry shows fresh data without waiting for the periodic heartbeat (~12h).\n\n**Compliance re-run:** when the caller owns the agent and the capability probe succeeds, the full storyboard suite runs (~30–90s) and `agent_storyboard_status` is updated under `triggered_by: 'manual'`. Badge fan-out reissues verification badges off the new run. If the compliance call fails (timeout, OAuth wall, internal error), the capability/health portion still returns successfully — `compliance.ran` is `false` with an `error` string.\n\n**Auth:** owner of the agent or AAO admin.\n\n**Rate limits:** 60 seconds per agent URL, 30 requests per user per hour.",
+    "Re-probe the agent and update its registry health (online, tools_count, response_time_ms), capability snapshot (inferred type, discovered tools), and compliance verdict (storyboard pass/fail counts). Use after fixing your agent so the registry shows fresh data without waiting for the periodic heartbeat (~1h).\n\n**Compliance re-run:** when the caller owns the agent and the capability probe succeeds, the full storyboard suite runs (~30–90s) and `agent_storyboard_status` is updated under `triggered_by: 'manual'`. Badge fan-out reissues verification badges off the new run. If the compliance call fails (timeout, OAuth wall, internal error), the capability/health portion still returns successfully — `compliance.ran` is `false` with an `error` string.\n\n**Auth:** owner of the agent or AAO admin.\n\n**Rate limits:** 60 seconds per agent URL, 30 requests per user per hour.",
   tags: ["Agent Compliance"],
   security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
@@ -4936,9 +4936,13 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
     }
   });
 
-  // ── Storyboard Status (members-only) ─────────────────────────────
+  // ── Storyboard Status (members-only; static-admin debug read) ────
 
   const memberReadMiddleware = authMiddleware ? [authMiddleware] : [];
+
+  function isStaticAdminRequest(req: Request): boolean {
+    return (req as Request & { isStaticAdminApiKey?: boolean }).isStaticAdminApiKey === true;
+  }
 
   router.get(
     "/registry/agents/:encodedUrl/storyboard-status",
@@ -4954,8 +4958,10 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           return res.status(401).json({ error: "Authentication required. Storyboard detail is available to members." });
         }
 
-        await enrichUserWithMembership(req.user as any);
-        if (!(req.user as any).isMember) {
+        if (!isStaticAdminRequest(req)) {
+          await enrichUserWithMembership(req.user as any);
+        }
+        if (!isStaticAdminRequest(req) && !(req.user as any).isMember) {
           return res.status(403).json({
             error: "Storyboard compliance detail is available to members only",
             members_only: true,
@@ -5012,8 +5018,10 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           return res.status(401).json({ error: "Authentication required" });
         }
 
-        await enrichUserWithMembership(req.user as any);
-        if (!(req.user as any).isMember) {
+        if (!isStaticAdminRequest(req)) {
+          await enrichUserWithMembership(req.user as any);
+        }
+        if (!isStaticAdminRequest(req) && !(req.user as any).isMember) {
           return res.status(403).json({
             error: "Batch storyboard status is available to members only",
             members_only: true,
@@ -5085,6 +5093,12 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
 
   async function verifyAgentOwnership(userId: string, agentUrl: string): Promise<boolean> {
     return (await resolveAgentOwnerOrg(userId, agentUrl)) !== null;
+  }
+
+  async function canViewAgentDebugData(req: Request, agentUrl: string): Promise<boolean> {
+    if (isStaticAdminRequest(req)) return true;
+    if (!req.user) return false;
+    return verifyAgentOwnership(req.user.id, agentUrl);
   }
 
   // Shared SSRF-resistant URL validator lives in utils/url-security.ts so the
@@ -5475,13 +5489,14 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
     }
   });
 
-  // ── Per-step compliance diagnostics (owner-only, adcp#4738) ──────
+  // ── Per-step compliance diagnostics (owner/static-admin, adcp#4738) ─
   //
   // Returns the exact request/response payloads the runner captured for
   // failing storyboard steps on a single compliance run. Lets owners diff
   // what the runner sent against their own probes without re-running.
-  // Owner-only because payloads echo seller-side account/brand identifiers
-  // and may contain sensitive descriptive fields.
+  // Owner-only, with static-admin debug read, because payloads echo
+  // seller-side account/brand identifiers and may contain sensitive
+  // descriptive fields.
   router.get(
     "/registry/agents/:encodedUrl/compliance/diagnostics",
     ...complianceWriteMiddleware,
@@ -5494,8 +5509,8 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         if (!req.user) {
           return res.status(401).json({ error: "Authentication required" });
         }
-        const isOwner = await verifyAgentOwnership(req.user.id, agentUrl);
-        if (!isOwner) {
+        const canView = await canViewAgentDebugData(req, agentUrl);
+        if (!canView) {
           return res.status(403).json({ error: "You do not have permission to view this agent" });
         }
 
@@ -5537,8 +5552,8 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       if (!req.user) {
         return res.status(401).json({ error: "Authentication required" });
       }
-      const isOwner = await verifyAgentOwnership(req.user.id, agentUrl);
-      if (!isOwner) {
+      const canView = await canViewAgentDebugData(req, agentUrl);
+      if (!canView) {
         return res.status(403).json({ error: "You do not have permission to view this agent" });
       }
 

--- a/server/tests/integration/registry-api-compliance-verdict-source.test.ts
+++ b/server/tests/integration/registry-api-compliance-verdict-source.test.ts
@@ -28,9 +28,15 @@ import { HTTPServer } from '../../src/http.js';
 import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
 import { runMigrations } from '../../src/db/migrate.js';
 
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY ||= 'sk_test_registry_debug';
+  process.env.WORKOS_CLIENT_ID ||= 'client_registry_debug';
+});
+
 const RUN_SUFFIX = Math.random().toString(36).slice(2, 8);
 const OWNER_USER_ID = `user_verdict_owner_${RUN_SUFFIX}`;
 const CROSS_ORG_USER_ID = `user_verdict_cross_${RUN_SUFFIX}`;
+const STATIC_ADMIN_USER_ID = 'admin_api_key';
 const OWNER_ORG_ID = `org_verdict_owner_${RUN_SUFFIX}`;
 const CROSS_ORG_ID = `org_verdict_cross_${RUN_SUFFIX}`;
 const AGENT_URL = `https://verdict-source-${RUN_SUFFIX}.example.com/mcp`;
@@ -39,22 +45,28 @@ const AGENT_URL = `https://verdict-source-${RUN_SUFFIX}.example.com/mcp`;
 // header parses successfully. Tests toggle currentUserId between owner,
 // cross-org, and null (anonymous) to exercise each auth branch.
 let currentUserId: string | null = null;
+let complianceRunId: string;
 
 vi.mock('../../src/middleware/auth.js', async () => {
   const actual = await vi.importActual<Record<string, unknown>>('../../src/middleware/auth.js');
+  const stampUser = (req: { user?: unknown; isStaticAdminApiKey?: boolean }) => {
+    if (currentUserId === null) return;
+    req.user = { id: currentUserId, email: `${currentUserId}@test.com` };
+    if (currentUserId === STATIC_ADMIN_USER_ID) {
+      req.isStaticAdminApiKey = true;
+    }
+  };
   return {
     ...actual,
-    requireAuth: (req: { user?: unknown }, res: { status: (n: number) => { json: (b: unknown) => void } }, next: () => void) => {
+    requireAuth: (req: { user?: unknown; isStaticAdminApiKey?: boolean }, res: { status: (n: number) => { json: (b: unknown) => void } }, next: () => void) => {
       if (currentUserId === null) {
         return res.status(401).json({ error: 'Authentication required' });
       }
-      req.user = { id: currentUserId, email: `${currentUserId}@test.com` };
+      stampUser(req);
       next();
     },
-    optionalAuth: (req: { user?: unknown }, _res: unknown, next: () => void) => {
-      if (currentUserId !== null) {
-        req.user = { id: currentUserId, email: `${currentUserId}@test.com` };
-      }
+    optionalAuth: (req: { user?: unknown; isStaticAdminApiKey?: boolean }, _res: unknown, next: () => void) => {
+      stampUser(req);
       next();
     },
     requireAdmin: (_req: unknown, _res: unknown, next: () => void) => next(),
@@ -142,7 +154,7 @@ describe('GET /api/registry/agents/:encodedUrl/compliance — owner-scope gate (
     // last_triggered_by='owner_test'. That's the field the route gates
     // behind is_owner — the test asserts owners see it and non-owners
     // see null.
-    await pool.query(
+    const runResult = await pool.query<{ id: string }>(
       `INSERT INTO agent_compliance_runs (
          agent_url, lifecycle_stage, overall_status, headline,
          tracks_json, tracks_passed, tracks_failed, tracks_skipped, tracks_partial,
@@ -151,6 +163,7 @@ describe('GET /api/registry/agents/:encodedUrl/compliance — owner-scope gate (
                  '[]'::jsonb, 0, 0, 0, 0, 'owner_test', false, NOW())`,
       [AGENT_URL],
     );
+    complianceRunId = runResult.rows[0].id;
     await pool.query(
       `INSERT INTO agent_compliance_status (
          agent_url, status, last_checked_at, last_passed_at,
@@ -165,6 +178,38 @@ describe('GET /api/registry/agents/:encodedUrl/compliance — owner-scope gate (
              updated_at = NOW()`,
       [AGENT_URL],
     );
+    await pool.query(
+      `INSERT INTO agent_storyboard_status (
+         agent_url, storyboard_id, status, last_tested_at, run_id,
+         steps_passed, steps_total, triggered_by
+       ) VALUES ($1, 'debug_storyboard', 'failing', NOW(), $2, 1, 2, 'owner_test')
+       ON CONFLICT (agent_url, storyboard_id) DO UPDATE
+         SET status = EXCLUDED.status,
+             last_tested_at = EXCLUDED.last_tested_at,
+             run_id = EXCLUDED.run_id,
+             steps_passed = EXCLUDED.steps_passed,
+             steps_total = EXCLUDED.steps_total,
+             triggered_by = EXCLUDED.triggered_by`,
+      [AGENT_URL, complianceRunId],
+    );
+    await pool.query(
+      `INSERT INTO agent_compliance_step_diagnostics (
+         run_id, agent_url, storyboard_id, phase_id, step_id, task,
+         step_passed, duration_ms, request_url, request_jsonb,
+         response_status, response_jsonb, error_text
+       ) VALUES (
+         $1, $2, 'debug_storyboard', 'debug_phase', 'debug_step', 'get_products',
+         false, 42, $2, '{"params":{"brief":"debug"}}'::jsonb,
+         200, '{"ok":false}'::jsonb, 'debug failure'
+       )`,
+      [complianceRunId, AGENT_URL],
+    );
+    await pool.query(
+      `INSERT INTO agent_outbound_requests (
+         agent_url, request_type, user_agent, response_time_ms, success, error_message
+       ) VALUES ($1, 'compliance', 'test-runner', 42, false, 'debug failure')`,
+      [AGENT_URL],
+    );
 
     server = new HTTPServer();
     await server.start(0);
@@ -172,6 +217,9 @@ describe('GET /api/registry/agents/:encodedUrl/compliance — owner-scope gate (
   });
 
   afterAll(async () => {
+    await pool.query('DELETE FROM agent_outbound_requests WHERE agent_url = $1', [AGENT_URL]);
+    await pool.query('DELETE FROM agent_compliance_step_diagnostics WHERE agent_url = $1', [AGENT_URL]);
+    await pool.query('DELETE FROM agent_storyboard_status WHERE agent_url = $1', [AGENT_URL]);
     await pool.query('DELETE FROM agent_compliance_runs WHERE agent_url = $1', [AGENT_URL]);
     await pool.query('DELETE FROM agent_compliance_status WHERE agent_url = $1', [AGENT_URL]);
     await pool.query('DELETE FROM member_profiles WHERE workos_organization_id = ANY($1)', [[OWNER_ORG_ID, CROSS_ORG_ID]]);
@@ -259,5 +307,68 @@ describe('GET /api/registry/agents/:encodedUrl/compliance — owner-scope gate (
         [OWNER_ORG_ID],
       );
     }
+  });
+
+  it('static admin API key can read storyboard status without membership', async () => {
+    currentUserId = STATIC_ADMIN_USER_ID;
+    const res = await request(app).get(`/api/registry/agents/${encodeURIComponent(AGENT_URL)}/storyboard-status`);
+    expect(res.status).toBe(200);
+    expect(res.body.storyboards).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        storyboard_id: 'debug_storyboard',
+        status: 'failing',
+        steps_passed: 1,
+        steps_total: 2,
+      }),
+    ]));
+  });
+
+  it('static admin API key can read per-step diagnostics for any agent', async () => {
+    currentUserId = STATIC_ADMIN_USER_ID;
+    const res = await request(app)
+      .get(`/api/registry/agents/${encodeURIComponent(AGENT_URL)}/compliance/diagnostics`)
+      .query({ run_id: complianceRunId });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      agent_url: AGENT_URL,
+      run_id: complianceRunId,
+      count: 1,
+    });
+    expect(res.body.diagnostics[0]).toMatchObject({
+      storyboard_id: 'debug_storyboard',
+      step_id: 'debug_step',
+      task: 'get_products',
+      error_text: 'debug failure',
+    });
+  });
+
+  it('static admin API key can read outbound monitoring requests for any agent', async () => {
+    currentUserId = STATIC_ADMIN_USER_ID;
+    const res = await request(app)
+      .get(`/api/registry/agents/${encodeURIComponent(AGENT_URL)}/monitoring/requests`)
+      .query({ limit: 5 });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      agent_url: AGENT_URL,
+      count: 1,
+      total: 1,
+    });
+    expect(res.body.requests[0]).toMatchObject({
+      agent_url: AGENT_URL,
+      request_type: 'compliance',
+      user_agent: 'test-runner',
+      success: false,
+      error_message: 'debug failure',
+    });
+  });
+
+  it('cross-org caller still cannot read owner diagnostics or monitoring requests', async () => {
+    currentUserId = CROSS_ORG_USER_ID;
+    const [diagnosticsRes, monitoringRes] = await Promise.all([
+      request(app).get(`/api/registry/agents/${encodeURIComponent(AGENT_URL)}/compliance/diagnostics`),
+      request(app).get(`/api/registry/agents/${encodeURIComponent(AGENT_URL)}/monitoring/requests`),
+    ]);
+    expect(diagnosticsRes.status).toBe(403);
+    expect(monitoringRes.status).toBe(403);
   });
 });

--- a/server/tests/integration/registry-api-compliance-verdict-source.test.ts
+++ b/server/tests/integration/registry-api-compliance-verdict-source.test.ts
@@ -160,7 +160,8 @@ describe('GET /api/registry/agents/:encodedUrl/compliance — owner-scope gate (
          tracks_json, tracks_passed, tracks_failed, tracks_skipped, tracks_partial,
          triggered_by, dry_run, tested_at
        ) VALUES ($1, 'production', 'passing', 'all clear',
-                 '[]'::jsonb, 0, 0, 0, 0, 'owner_test', false, NOW())`,
+                 '[]'::jsonb, 0, 0, 0, 0, 'owner_test', false, NOW())
+       RETURNING id`,
       [AGENT_URL],
     );
     complianceRunId = runResult.rows[0].id;

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -6061,7 +6061,7 @@ paths:
       description: |-
         Returns per-storyboard test results for an agent. Includes title, category, track, pass/fail status, and step counts.
 
-        **Members only** — requires authentication and an active membership.
+        **Members only** — requires authentication and an active membership. Static admin API key callers may read this for support/debugging.
       tags:
         - Agent Compliance
       security:
@@ -6138,7 +6138,7 @@ paths:
       description: |-
         Returns per-storyboard test results for multiple agents in a single request.
 
-        **Members only** — requires authentication and an active membership. Maximum 100 agent URLs per request.
+        **Members only** — requires authentication and an active membership. Static admin API key callers may read this for support/debugging. Maximum 100 agent URLs per request.
       tags:
         - Agent Compliance
       security:
@@ -6571,7 +6571,7 @@ paths:
     post:
       operationId: requeueAgentForHeartbeat
       summary: Requeue agent for compliance heartbeat
-      description: Clears the agent's last_checked_at timestamp so it is picked up on the next heartbeat cycle (within ~1 hour). Requires authentication and ownership.
+      description: Clears the agent's last_checked_at timestamp so it is picked up on the next heartbeat cycle (within ~1 hour). This is queued-async; it does not run the compliance suite synchronously or change the current verdict until the heartbeat completes. Requires authentication and ownership.
       tags:
         - Agent Compliance
       security:
@@ -6634,7 +6634,7 @@ paths:
       description: |-
         Returns the exact request and response payloads the runner captured for failing storyboard steps on a single compliance run.
 
-        Lets agent owners diff what the runner sent against their own probes without re-running the storyboard. Owner-only — payloads echo seller-side account/brand identifiers and may carry sensitive descriptive fields. If `run_id` is omitted, resolves to the latest run for the agent.
+        Lets agent owners diff what the runner sent against their own probes without re-running the storyboard. Owner-only, with static admin API key access for support/debugging — payloads echo seller-side account/brand identifiers and may carry sensitive descriptive fields. If `run_id` is omitted, resolves to the latest run for the agent.
       tags:
         - Agent Compliance
       security:
@@ -6715,7 +6715,7 @@ paths:
     get:
       operationId: getAgentMonitoringRequests
       summary: Get outbound request log
-      description: Returns the outbound request log for an agent (compliance checks, health probes, etc.). Requires authentication and ownership.
+      description: Returns the outbound request log for an agent (compliance checks, health probes, etc.). Requires authentication and ownership, or the static admin API key for support/debugging.
       tags:
         - Agent Compliance
       security:
@@ -6795,7 +6795,7 @@ paths:
       operationId: refreshAgent
       summary: Refresh agent snapshot
       description: |-
-        Re-probe the agent and update its registry health (online, tools_count, response_time_ms), capability snapshot (inferred type, discovered tools), and compliance verdict (storyboard pass/fail counts). Use after fixing your agent so the registry shows fresh data without waiting for the periodic heartbeat (~12h).
+        Re-probe the agent and update its registry health (online, tools_count, response_time_ms), capability snapshot (inferred type, discovered tools), and compliance verdict (storyboard pass/fail counts). Use after fixing your agent so the registry shows fresh data without waiting for the periodic heartbeat (~1h).
 
         **Compliance re-run:** when the caller owns the agent and the capability probe succeeds, the full storyboard suite runs (~30–90s) and `agent_storyboard_status` is updated under `triggered_by: 'manual'`. Badge fan-out reissues verification badges off the new run. If the compliance call fails (timeout, OAuth wall, internal error), the capability/health portion still returns successfully — `compliance.ran` is `false` with an `error` string.
 


### PR DESCRIPTION
## Summary

- allow static `ADMIN_API_KEY` callers to read compliance diagnostics, outbound monitoring requests, and storyboard status for support/debugging
- keep mutating owner-only routes unchanged, including refresh, requeue, and credential management
- clarify that Requeue comply is queued for the heartbeat while Recheck status can run the synchronous suite
- update the generated Registry OpenAPI document

## Why

Support needs to inspect compliance evidence for incidents like adcp#4738 without impersonating the seller or changing agent ownership. The previous static-admin path could read Addie threads but received 403s on the diagnostic evidence needed to compare persisted failures, outbound request logs, and seller audit windows.

## Validation

- `git diff --check`
- `npm run test:openapi`
- `npm run typecheck`
- precommit hook: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run typecheck`
- prepush hook: version sync, docs schema-link convention, Mintlify broken-links check

Note: targeted integration test `server/tests/integration/registry-api-compliance-verdict-source.test.ts` could not run locally because the local Postgres test database on `.env.local`'s port refused connection; the new test coverage is included for CI where the DB is available.