### PR TITLE
Add vendor metric catalog precondition coverage

### DIFF
--- a/.changeset/4983-vendor-metric-catalog-precondition.md
+++ b/.changeset/4983-vendor-metric-catalog-precondition.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Add deterministic vendor_metric measurement-catalog-miss coverage for 3.1 storyboards.

--- a/.github/workflows/training-agent-storyboards.yml
+++ b/.github/workflows/training-agent-storyboards.yml
@@ -297,6 +297,7 @@ jobs:
           set -euo pipefail
           required_clean=(
             "media_buy_seller/canonical_formats"
+            "media_buy_seller/vendor_metric_catalog_precondition"
           )
           for storyboard_id in "${required_clean[@]}"; do
             if grep -E "^[[:space:]]+${storyboard_id}[[:space:]]+✓" /tmp/storyboards.log >/dev/null; then

--- a/docs/building/by-layer/L3/comply-test-controller.mdx
+++ b/docs/building/by-layer/L3/comply-test-controller.mdx
@@ -77,13 +77,15 @@ Sellers that implement compliance test controller MUST:
           "seed_pricing_option",
           "seed_creative",
           "seed_plan",
-          "seed_media_buy"
+          "seed_media_buy",
+          "seed_creative_format",
+          "seed_measurement_catalog"
         ],
         "description": "The seller-side transition or fixture-seed to trigger."
       },
       "params": {
         "type": "object",
-        "description": "Scenario-specific parameters. Omit for list_scenarios. force_creative_status: {creative_id, status, rejection_reason?}. force_account_status: {account_id, status}. force_media_buy_status: {media_buy_id, status, rejection_reason?}. force_create_media_buy_arm: {arm, task_id?, message?} — task_id required when arm = submitted. force_task_completion: {task_id, result}. force_session_status: {session_id, status, termination_reason?}. simulate_delivery: {media_buy_id, impressions?, clicks?, reported_spend?, conversions?, reach?, frequency?, reach_window?, viewability?}. simulate_budget_spend: {account_id|media_buy_id, spend_percentage}. seed_product: {product_id, fixture?}. seed_pricing_option: {product_id, pricing_option_id, fixture?}. seed_creative: {creative_id, fixture?}. seed_plan: {plan_id, fixture?}. seed_media_buy: {media_buy_id, fixture?}."
+        "description": "Scenario-specific parameters. Omit for list_scenarios. force_creative_status: {creative_id, status, rejection_reason?}. force_account_status: {account_id, status}. force_media_buy_status: {media_buy_id, status, rejection_reason?}. force_create_media_buy_arm: {arm, task_id?, message?} — task_id required when arm = submitted. force_task_completion: {task_id, result}. force_session_status: {session_id, status, termination_reason?}. simulate_delivery: {media_buy_id, impressions?, clicks?, reported_spend?, conversions?, reach?, frequency?, reach_window?, viewability?}. simulate_budget_spend: {account_id|media_buy_id, spend_percentage}. seed_product: {product_id, fixture?}. seed_pricing_option: {product_id, pricing_option_id, fixture?}. seed_creative: {creative_id, fixture?}. seed_plan: {plan_id, fixture?}. seed_media_buy: {media_buy_id, fixture?}. seed_creative_format: {format_id, fixture?}. seed_measurement_catalog: {vendor, metrics[]}."
       }
     },
     "required": ["scenario"]
@@ -379,6 +381,8 @@ Creates (or upserts) a product fixture with a caller-supplied `product_id` so su
 | `product_id` | string | Yes | Stable identifier the storyboard will reference |
 | `fixture` | object | No | Product shape. Minimum useful fields: `delivery_type`, `channels`, `pricing_options[]`, `format_ids[]`. Sellers MAY fill in defaults for omitted fields. |
 
+For vendor-metric precondition tests, prefer `seed_measurement_catalog` for the external vendor catalog. A product fixture may also carry `measurement_catalogs[]` entries shaped as `{ vendor, metrics[] }` as a compatibility fallback for local harnesses that need the product contract and referenced measurement snapshot in one fixture. If both are supplied for the same vendor, the explicit `seed_measurement_catalog` snapshot takes precedence for that compliance session.
+
 **Example:**
 
 ```json
@@ -507,9 +511,38 @@ Creates a media buy fixture at a specified lifecycle state, bypassing the `creat
 }
 ```
 
+### `seed_measurement_catalog`
+
+Seeds a measurement vendor's `get_adcp_capabilities.measurement.metrics[]` snapshot for the compliance session, when the seller's controller advertises this scenario. Media-buy storyboards use an explicit `comply_test_controller` step with this scenario to distinguish a product-level vendor metric capability from the external vendor-catalog discovery precondition. Storyboards may also carry this snapshot in `seed_product.fixture.measurement_catalogs[]` as a compatibility fallback for controllers whose SDK adapter set has not adopted the scenario yet. When both sources are present for the same vendor, the explicit `seed_measurement_catalog` seed is authoritative.
+
+**Params:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `vendor` | BrandRef | Yes | Measurement vendor whose catalog is being seeded |
+| `metrics` | object[] | Yes | Catalog entries; each entry must include `metric_id` and may include the optional fields from `measurement.metrics[]` |
+
+**Example:**
+
+```json
+{
+  "scenario": "seed_measurement_catalog",
+  "params": {
+    "vendor": { "domain": "attentionvendor.example" },
+    "metrics": [
+      {
+        "metric_id": "attention_catalog_baseline",
+        "unit": "score",
+        "description": "Baseline attention metric present in this vendor catalog."
+      }
+    ]
+  }
+}
+```
+
 ### Seeding semantics and ordering
 
-- **Fixture shape.** `fixture` is kept permissive (`additionalProperties: true`) so storyboard authors can declare the minimum shape each test needs. Fixtures SHOULD conform to the corresponding domain schema (`core/product.json` for `seed_product`, `core/pricing-option.json` for `seed_pricing_option`, `media-buy/sync-creatives-request.json` creative-item shape for `seed_creative`, `core/media-buy.json` for `seed_media_buy`, the plan schema for `seed_plan`). Sellers MAY reject clearly malformed fixtures with `INVALID_PARAMS`.
+- **Fixture shape.** `fixture` is kept permissive (`additionalProperties: true`) so storyboard authors can declare the minimum shape each test needs. Fixtures SHOULD conform to the corresponding domain schema (`core/product.json` for `seed_product`, `core/pricing-option.json` for `seed_pricing_option`, `media-buy/sync-creatives-request.json` creative-item shape for `seed_creative`, `core/media-buy.json` for `seed_media_buy`, the plan schema for `seed_plan`). `seed_measurement_catalog.metrics[]` mirrors `get_adcp_capabilities.measurement.metrics[]`. Sellers MAY reject clearly malformed fixtures with `INVALID_PARAMS`.
 - **Idempotency on re-seed.** A second call with the same primary ID and a `fixture` equivalent to the first SHOULD succeed and return `success: true` with `previous_state: "existing"`. A second call with a **diverging** fixture MUST return `INVALID_PARAMS` with `error_detail` explaining which fields diverged — sellers MUST NOT merge or update silently. Storyboards that need to change fixture state mid-run MUST use `force_*` scenarios, not a re-seed. This keeps the same storyboard deterministic across sellers.
 - **Foreign-key ordering.** The runner seeds fixtures in dependency order so sellers receive referenced parents before their children. The dependency DAG:
 

--- a/docs/contributing/storyboard-authoring.md
+++ b/docs/contributing/storyboard-authoring.md
@@ -135,6 +135,8 @@ phases:
 
 The runner injects a fixtures phase that calls `comply_test_controller` with `scenario: seed_product`, `scenario: seed_pricing_option`, and `scenario: seed_creative` (in foreign-key order) before running `place_buy`. An agent that implements the seed scenarios passes out of the box; an agent that returns `UNKNOWN_SCENARIO` on the seeds causes the storyboard to grade as `not_applicable`, not failed — implementers don't get penalized for missing sandbox-only surface.
 
+When a vendor-metric storyboard needs a deterministic external `measurement.metrics[]` snapshot, add an explicit `comply_test_controller` step with `scenario: seed_measurement_catalog`. Use `measurement_catalogs[]` inside a product fixture only as a compatibility fallback when the same storyboard also needs to carry the seller's product-level capability fields.
+
 See the full list of seed scenarios and their params in [Compliance test controller — Scenarios](/docs/building/implementation/comply-test-controller#scenarios).
 
 ### Pattern B — flow-derived captures via `context_outputs:` + `$context.<name>`

--- a/docs/protocol/get_adcp_capabilities.mdx
+++ b/docs/protocol/get_adcp_capabilities.mdx
@@ -507,7 +507,7 @@ Compliance testing capabilities. The presence of this block declares that the ag
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `scenarios` | string[] | Compliance testing scenarios this agent supports. Possible values: `force_creative_status`, `force_account_status`, `force_media_buy_status`, `force_session_status`, `simulate_delivery`, `simulate_budget_spend`, `seed_product`, `seed_pricing_option`, `seed_creative`, `seed_plan`, `seed_media_buy`. Runners MUST accept unknown scenario strings — new scenarios may be added in additive minor bumps. |
+| `scenarios` | string[] | Compliance testing scenarios this agent supports. Possible values include `force_creative_status`, `force_account_status`, `force_media_buy_status`, `force_create_media_buy_arm`, `force_task_completion`, `force_session_status`, `simulate_delivery`, `simulate_budget_spend`, `seed_product`, `seed_pricing_option`, `seed_creative`, `seed_plan`, `seed_media_buy`, `seed_creative_format`, `seed_measurement_catalog`, `query_upstream_traffic`, and `force_upstream_unavailable`. Runners MUST accept unknown scenario strings — new scenarios may be added in additive releases. |
 
 Storyboard runners check for the `compliance_testing` block before running deterministic testing steps. If the agent does not include the block, controller-dependent storyboard steps cannot be validated.
 

--- a/scripts/overlay-compliance-cache.sh
+++ b/scripts/overlay-compliance-cache.sh
@@ -46,6 +46,95 @@ if [ -z "$DST" ] || [ ! -d "$DST" ]; then
 fi
 
 if [ "${SRC}" = "dist/compliance/latest" ]; then
+  # Current storyboard source may reference request/response schema additions
+  # from the same PR. Stage the development schema bundle into the SDK key that
+  # the overlaid compliance index advertises below; otherwise the runner grades
+  # new current YAML against the SDK-published schema snapshot.
+  echo "Building development schema bundle for SDK schema cache overlay"
+  node scripts/build-schemas.cjs
+  CACHE_VERSION="${PINNED_VERSION:-$(basename "$DST")}"
+  SCHEMA_STAGE_DIR=$(mktemp -d -t "adcp-schema-overlay.XXXXXX")
+  (cd "dist/schemas/latest" && tar -cf - .) | (cd "$SCHEMA_STAGE_DIR" && tar -xf -)
+  node - <<'NODE' "$SCHEMA_STAGE_DIR" "$CACHE_VERSION"
+const fs = require('node:fs');
+const path = require('node:path');
+const [root, version] = process.argv.slice(2);
+
+function walk(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const file = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(file);
+    } else if (entry.isFile() && entry.name.endsWith('.json')) {
+      const body = fs.readFileSync(file, 'utf8')
+        .replaceAll('/schemas/latest/', `/schemas/${version}/`)
+        .replaceAll('/schemas/latest"', `/schemas/${version}"`);
+      if (file.split(path.sep).includes('bundled')) {
+        const schema = JSON.parse(body);
+        stripNestedIds(schema, true);
+        fs.writeFileSync(file, `${JSON.stringify(schema, null, 2)}\n`);
+      } else {
+        fs.writeFileSync(file, body);
+      }
+    }
+  }
+}
+
+function stripNestedIds(value, isRoot = false) {
+  if (!value || typeof value !== 'object') return;
+  if (Array.isArray(value)) {
+    for (const item of value) stripNestedIds(item, false);
+    return;
+  }
+  if (!isRoot) delete value.$id;
+  for (const child of Object.values(value)) stripNestedIds(child, false);
+}
+
+walk(root);
+const indexPath = path.join(root, 'index.json');
+const index = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
+index.version = version;
+index.published_version = version;
+index.adcp_version = version;
+fs.writeFileSync(indexPath, `${JSON.stringify(index, null, 2)}\n`);
+NODE
+  bash "$(dirname "$0")/stage-sdk-schema-bundle.sh" "$SCHEMA_STAGE_DIR" "$CACHE_VERSION"
+  rm -rf "$SCHEMA_STAGE_DIR"
+
+  # The storyboard runner still imports @adcp/sdk's generated Zod validators for
+  # response checks. Those files are produced from the SDK-published schema
+  # snapshot at package build time, so staging the current JSON Schema bundle is
+  # not enough for same-PR compliance_testing.scenarios additions. Patch the
+  # installed generated validators for the local/CI current-source run; released
+  # 3.0 compatibility runs skip this overlay and keep the SDK snapshot intact.
+  node - <<'NODE'
+const fs = require('node:fs');
+
+function patchFile(file) {
+  if (!fs.existsSync(file)) return;
+  const backup = `${file}.adcp-overlay-backup`;
+  if (!fs.existsSync(backup)) {
+    fs.copyFileSync(file, backup);
+  }
+  let text = fs.readFileSync(file, 'utf8');
+  const legacyCapabilities =
+    'zod_1.z.literal("force_creative_status"), zod_1.z.literal("force_account_status"), zod_1.z.literal("force_media_buy_status"), zod_1.z.literal("force_session_status"), zod_1.z.literal("simulate_delivery"), zod_1.z.literal("simulate_budget_spend")]))';
+  const partialCapabilities =
+    'zod_1.z.literal("force_creative_status"), zod_1.z.literal("force_account_status"), zod_1.z.literal("force_media_buy_status"), zod_1.z.literal("force_create_media_buy_arm"), zod_1.z.literal("force_task_completion"), zod_1.z.literal("force_session_status"), zod_1.z.literal("simulate_delivery"), zod_1.z.literal("simulate_budget_spend"), zod_1.z.literal("seed_measurement_catalog")]))';
+  const currentCapabilities =
+    'zod_1.z.literal("force_creative_status"), zod_1.z.literal("force_account_status"), zod_1.z.literal("force_media_buy_status"), zod_1.z.literal("force_create_media_buy_arm"), zod_1.z.literal("force_task_completion"), zod_1.z.literal("force_session_status"), zod_1.z.literal("simulate_delivery"), zod_1.z.literal("simulate_budget_spend"), zod_1.z.literal("seed_product"), zod_1.z.literal("seed_pricing_option"), zod_1.z.literal("seed_creative"), zod_1.z.literal("seed_plan"), zod_1.z.literal("seed_media_buy"), zod_1.z.literal("seed_creative_format"), zod_1.z.literal("seed_measurement_catalog"), zod_1.z.literal("query_upstream_traffic"), zod_1.z.literal("force_upstream_unavailable")]))';
+  text = text.replace(legacyCapabilities, currentCapabilities);
+  text = text.replace(partialCapabilities, currentCapabilities);
+  text = text.replaceAll(
+    'zod_1.z.literal("seed_creative_format")]))',
+    'zod_1.z.literal("seed_creative_format"), zod_1.z.literal("seed_measurement_catalog")]))',
+  );
+  fs.writeFileSync(file, text);
+}
+
+patchFile('node_modules/@adcp/sdk/dist/lib/types/schemas.generated.js');
+NODE
+
   echo "Building development compliance bundle for SDK cache overlay"
   node scripts/build-compliance.cjs
 fi

--- a/scripts/run-storyboards-matrix.sh
+++ b/scripts/run-storyboards-matrix.sh
@@ -23,6 +23,15 @@ else
   RELEASE_GIT_REF="${RELEASE_BASE_REF}"
 fi
 export ADCP_RELEASE_GIT_REF="${RELEASE_GIT_REF}"
+SDK_GENERATED_SCHEMA_FILE="${REPO_ROOT}/node_modules/@adcp/sdk/dist/lib/types/schemas.generated.js"
+
+restore_sdk_generated_schema() {
+  local backup="${SDK_GENERATED_SCHEMA_FILE}.adcp-overlay-backup"
+  if [ -f "${backup}" ]; then
+    cp "${backup}" "${SDK_GENERATED_SCHEMA_FILE}"
+    rm -f "${backup}"
+  fi
+}
 
 usage() {
   cat <<'USAGE'
@@ -153,7 +162,9 @@ NODE
   fi
 fi
 
+restore_sdk_generated_schema
 if [ "${OVERLAY}" -eq 1 ]; then
+  trap restore_sdk_generated_schema EXIT
   # Mirror CI's overlay step before running tenants: copies in-repo
   # compliance source onto the SDK's bundled cache so the runner grades
   # against current-PR fixtures, not the SDK-published snapshot. Without
@@ -190,6 +201,7 @@ REGRESSED=0
 SUMMARY=""
 REQUIRED_CLEAN_CURRENT_SALES=(
   "media_buy_seller/canonical_formats"
+  "media_buy_seller/vendor_metric_catalog_precondition"
 )
 
 storyboard_passed() {

--- a/server/src/training-agent/comply-test-controller.ts
+++ b/server/src/training-agent/comply-test-controller.ts
@@ -622,7 +622,7 @@ function createStore(session: SessionState): TestControllerStore {
  * adcontextprotocol/adcp-client — the dedup below means it is safe to leave this
  * entry in place during the transition; remove once a release has landed and the
  * cross-impl tests no longer rely on it). */
-const LOCAL_SCENARIOS = ['force_create_media_buy_arm', 'force_task_completion', 'seed_creative_format'] as const;
+const LOCAL_SCENARIOS = ['force_create_media_buy_arm', 'force_task_completion', 'seed_creative_format', 'seed_measurement_catalog'] as const;
 
 // ── Tool definition ───────────────────────────────────────────────
 
@@ -712,6 +712,9 @@ export async function handleComplyTestController(args: ToolArgs, ctx: TrainingCo
   }
   if (scenario === 'force_task_completion') {
     return handleForceTaskCompletion(sessionKey, rawArgs);
+  }
+  if (scenario === 'seed_measurement_catalog') {
+    return handleSeedMeasurementCatalog(session, rawArgs);
   }
   // seed_creative_format is a training-agent extension not in the SDK's
   // CONTROLLER_SCENARIOS. Handle it before the SDK dispatcher so the SDK
@@ -821,6 +824,124 @@ export async function handleComplyTestController(args: ToolArgs, ctx: TrainingCo
   }
 
   return sdkResponse;
+}
+
+function measurementVendorCatalogKey(vendor: { domain?: unknown; brand_id?: unknown }): string | null {
+  const domain = vendor.domain;
+  if (typeof domain !== 'string' || domain.length === 0) return null;
+  const brandId = typeof vendor.brand_id === 'string' ? vendor.brand_id : '';
+  return `${domain.toLowerCase()}|${brandId}`;
+}
+
+function canonicalJson(value: unknown, seen = new WeakSet<object>()): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? String(value);
+  if (seen.has(value)) return '"__cycle__"';
+  seen.add(value);
+  if (Array.isArray(value)) return `[${value.map(v => canonicalJson(v, seen)).join(',')}]`;
+  const record = value as Record<string, unknown>;
+  const entries = Object.keys(record)
+    .sort()
+    .map(k => `${JSON.stringify(k)}:${canonicalJson(record[k], seen)}`);
+  return `{${entries.join(',')}}`;
+}
+
+function handleSeedMeasurementCatalog(session: SessionState, rawArgs: Record<string, unknown>): object {
+  const params = rawArgs.params as Record<string, unknown> | undefined;
+  if (!params || typeof params !== 'object') {
+    return {
+      success: false,
+      error: 'INVALID_PARAMS',
+      error_detail: 'seed_measurement_catalog requires params',
+    };
+  }
+
+  const vendor = params.vendor as { domain?: unknown; brand_id?: unknown } | undefined;
+  const key = vendor ? measurementVendorCatalogKey(vendor) : null;
+  if (!vendor || !key) {
+    return {
+      success: false,
+      error: 'INVALID_PARAMS',
+      error_detail: 'seed_measurement_catalog requires params.vendor.domain',
+    };
+  }
+  const vendorDomain = (vendor.domain as string).toLowerCase();
+
+  const rawMetrics = params.metrics;
+  if (!Array.isArray(rawMetrics)) {
+    return {
+      success: false,
+      error: 'INVALID_PARAMS',
+      error_detail: 'seed_measurement_catalog requires params.metrics[]',
+    };
+  }
+  if (rawMetrics.length === 0) {
+    return {
+      success: false,
+      error: 'INVALID_PARAMS',
+      error_detail: 'seed_measurement_catalog requires at least one metric',
+    };
+  }
+
+  const metrics: Array<{ metric_id: string; [key: string]: unknown }> = [];
+  const seen = new Set<string>();
+  for (let i = 0; i < rawMetrics.length; i++) {
+    const metric = rawMetrics[i];
+    if (!metric || typeof metric !== 'object' || Array.isArray(metric)) {
+      return {
+        success: false,
+        error: 'INVALID_PARAMS',
+        error_detail: `seed_measurement_catalog params.metrics[${i}] must be an object`,
+      };
+    }
+    const entry = metric as Record<string, unknown>;
+    if (typeof entry.metric_id !== 'string' || entry.metric_id.length === 0) {
+      return {
+        success: false,
+        error: 'INVALID_PARAMS',
+        error_detail: `seed_measurement_catalog params.metrics[${i}].metric_id is required`,
+      };
+    }
+    if (seen.has(entry.metric_id)) {
+      return {
+        success: false,
+        error: 'INVALID_PARAMS',
+        error_detail: `seed_measurement_catalog duplicate metric_id "${entry.metric_id}"`,
+      };
+    }
+    seen.add(entry.metric_id);
+    metrics.push({ ...entry, metric_id: entry.metric_id });
+  }
+  metrics.sort((a, b) => a.metric_id.localeCompare(b.metric_id));
+
+  const nextCatalog = {
+    vendor: {
+      domain: vendorDomain,
+      ...(typeof vendor.brand_id === 'string' && { brand_id: vendor.brand_id }),
+    },
+    metrics,
+  };
+  const existing = session.complyExtensions.seededMeasurementCatalogs.get(key);
+  if (existing) {
+    if (canonicalJson(existing) !== canonicalJson(nextCatalog)) {
+      return {
+        success: false,
+        error: 'INVALID_PARAMS',
+        error_detail: `Measurement catalog for ${vendorDomain} diverges from the previously seeded fixture`,
+      };
+    }
+    return {
+      success: true,
+      message: 'Fixture re-seeded (equivalent)',
+    };
+  }
+
+  enforceMapCap(session.complyExtensions.seededMeasurementCatalogs, key, 'seeded measurement catalogs');
+  session.complyExtensions.seededMeasurementCatalogs.set(key, nextCatalog);
+
+  return {
+    success: true,
+    message: `Measurement catalog for ${vendorDomain} seeded with ${metrics.length} metric(s)`,
+  };
 }
 
 /**

--- a/server/src/training-agent/state.ts
+++ b/server/src/training-agent/state.ts
@@ -178,6 +178,7 @@ function createSession(): SessionState {
       seededProducts: new Map(),
       seededPricingOptions: new Map(),
       seededCreativeFormats: new Map(),
+      seededMeasurementCatalogs: new Map(),
     },
     createdAt: now,
     lastAccessedAt: now,
@@ -389,6 +390,7 @@ function deserializeSession(data: Record<string, unknown>): SessionState {
       seededProducts: asMap(hydratedComply.seededProducts, fresh.complyExtensions.seededProducts),
       seededPricingOptions: asMap(hydratedComply.seededPricingOptions, fresh.complyExtensions.seededPricingOptions),
       seededCreativeFormats: asMap(hydratedComply.seededCreativeFormats, fresh.complyExtensions.seededCreativeFormats),
+      seededMeasurementCatalogs: asMap(hydratedComply.seededMeasurementCatalogs, fresh.complyExtensions.seededMeasurementCatalogs),
       forcedCreateMediaBuyArm: hydratedComply.forcedCreateMediaBuyArm,
     },
     lastGetProductsContext: (hydrated.lastGetProductsContext as SessionState['lastGetProductsContext']) ?? undefined,
@@ -610,4 +612,3 @@ export async function clearSessions(): Promise<void> {
   }
   // Other AdcpStateStore implementations: no-op. Tests should inject a known store.
 }
-

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -171,6 +171,11 @@ interface ReportingCapabilitiesView {
   vendor_metrics?: VendorMetricRefView[];
 }
 
+interface MeasurementCatalogView {
+  vendor?: { domain?: unknown; brand_id?: unknown };
+  metrics?: Array<{ metric_id?: unknown }>;
+}
+
 function vendorMetricKey(entry: VendorMetricRefView | undefined): string | null {
   const domain = entry?.vendor?.domain;
   const metricId = entry?.metric_id;
@@ -179,6 +184,28 @@ function vendorMetricKey(entry: VendorMetricRefView | undefined): string | null 
   }
   const brandId = typeof entry?.vendor?.brand_id === 'string' ? entry.vendor.brand_id : '';
   return `${domain.toLowerCase()}|${brandId}|${metricId}`;
+}
+
+function vendorCatalogKey(entry: VendorMetricRefView | undefined): string | null {
+  const domain = entry?.vendor?.domain;
+  if (typeof domain !== 'string' || domain.length === 0) return null;
+  const brandId = typeof entry?.vendor?.brand_id === 'string' ? entry.vendor.brand_id : '';
+  return `${domain.toLowerCase()}|${brandId}`;
+}
+
+function productMeasurementCatalogForGoal(product: Product | undefined, goal: VendorMetricRefView): MeasurementCatalogView | undefined {
+  if (!product) return undefined;
+  const catalogKey = vendorCatalogKey(goal);
+  if (!catalogKey) return undefined;
+  const catalogs = (product as Product & {
+    measurement_catalogs?: unknown;
+    measurement_catalog?: unknown;
+  }).measurement_catalogs ?? (product as Product & { measurement_catalog?: unknown }).measurement_catalog;
+  const list = Array.isArray(catalogs) ? catalogs : catalogs ? [catalogs] : [];
+  return list.find((entry): entry is MeasurementCatalogView => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return false;
+    return vendorCatalogKey(entry as MeasurementCatalogView) === catalogKey;
+  });
 }
 
 function hasFixedPrice(option: PricingOption): boolean {
@@ -2603,6 +2630,23 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
             }] as TaskError[],
           };
         }
+
+        const catalogKey = vendorCatalogKey(goal);
+        const seededCatalog = catalogKey ? session.complyExtensions.seededMeasurementCatalogs.get(catalogKey) : undefined;
+        const productCatalog = productMeasurementCatalogForGoal(product, goal);
+        const catalogMetrics = seededCatalog?.metrics ?? productCatalog?.metrics;
+        if (
+          Array.isArray(catalogMetrics)
+          && !catalogMetrics.some(entry => entry?.metric_id === goal.metric_id)
+        ) {
+          return {
+            errors: [{
+              code: 'TERMS_REJECTED',
+              message: `vendor_metric goal "${goal.metric_id}" is not in ${goal.vendor?.domain}'s measurement.metrics catalog`,
+              field: `packages[${i}].optimization_goals[${j}].metric_id`,
+            }] as TaskError[],
+          };
+        }
       }
     }
   }
@@ -4022,9 +4066,18 @@ export async function handleGetAdcpCapabilities(_args: ToolArgs, ctx: TrainingCo
         'force_creative_status',
         'force_account_status',
         'force_media_buy_status',
+        'force_create_media_buy_arm',
+        'force_task_completion',
         'force_session_status',
         'simulate_delivery',
         'simulate_budget_spend',
+        'seed_product',
+        'seed_pricing_option',
+        'seed_creative',
+        'seed_plan',
+        'seed_media_buy',
+        'seed_creative_format',
+        'seed_measurement_catalog',
       ],
     },
     agent: {

--- a/server/src/training-agent/tenants/comply.ts
+++ b/server/src/training-agent/tenants/comply.ts
@@ -124,6 +124,7 @@ const SALES_COMPLY_INPUT_SCHEMA = {
     brand: z.object({ domain: z.string().optional() }).passthrough().optional(),
     sandbox: z.boolean().optional(),
   }).passthrough().optional(),
+  brand: z.object({ domain: z.string().optional() }).passthrough().optional(),
 };
 
 /**

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -18,9 +18,35 @@ import { buildSignedRevocationList } from '../governance-revocations.js';
 import { getTenantResponseSigningMaterial } from './signing.js';
 import { wrapResponseForSigning } from '../response-signing.js';
 import { salesCapabilityProjection } from '../v6-sales-platform.js';
+import { handleComplyTestController } from '../comply-test-controller.js';
 import type { TrainingContext } from '../types.js';
 
 const logger = createLogger('training-agent-tenant-router');
+
+const SALES_LEGACY_CAPABILITY_SCENARIOS = [
+  'force_creative_status',
+  'force_media_buy_status',
+  'simulate_delivery',
+  'simulate_budget_spend',
+] as const;
+
+const SALES_CURRENT_SCENARIOS = [
+  ...SALES_LEGACY_CAPABILITY_SCENARIOS,
+  'force_create_media_buy_arm',
+  'force_task_completion',
+  'seed_product',
+  'seed_pricing_option',
+  'seed_creative',
+  'seed_media_buy',
+  'seed_creative_format',
+  'seed_measurement_catalog',
+] as const;
+
+function salesComplyScenarios(storyboardCompat?: TrainingContext['storyboardCompat']): string[] {
+  return storyboardCompat?.version === '3.0'
+    ? [...SALES_LEGACY_CAPABILITY_SCENARIOS]
+    : [...SALES_CURRENT_SCENARIOS];
+}
 
 /**
  * Per-tenant connect-handle-close serializer.
@@ -88,7 +114,7 @@ function setCORSHeaders(res: Response): void {
  * (`test-agent.adcontextprotocol.org/sales/mcp`) and the local mount
  * (`/api/training-agent/sales/mcp`).
  */
-function tenantMcpHandler(holder: RegistryHolder, tenantId: string) {
+function tenantMcpHandler(holder: RegistryHolder, tenantId: string, storyboardCompat?: TrainingContext['storyboardCompat']) {
   return async (req: Request, res: Response): Promise<void> => {
     setCORSHeaders(res);
 
@@ -99,7 +125,7 @@ function tenantMcpHandler(holder: RegistryHolder, tenantId: string) {
     // responses pass through unsigned.
     const responseSigner = getTenantResponseSigningMaterial(tenantId);
     wrapResponseForSigning(req, res, responseSigner.signerKey, tenantId);
-    wrapSalesCapabilitiesProjection(req, res, tenantId);
+    wrapSalesCapabilitiesProjection(req, res, tenantId, storyboardCompat);
 
     // Bridge `res.locals.trainingPrincipal` (set by the upstream
     // `requireAuth` middleware) onto `req.auth` so the framework's MCP
@@ -197,6 +223,10 @@ function tenantMcpHandler(holder: RegistryHolder, tenantId: string) {
     // Serialize the connect/handle/close window per tenant — see
     // `withTenantLock` above for the race this prevents (adcp#4084).
     await withTenantLock(resolved.tenantId, async () => {
+      if (await tryHandleLocalComplyScenario(req, res, resolved.tenantId, principal, storyboardCompat)) {
+        return;
+      }
+
       const transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: undefined,
         enableJsonResponse: true,
@@ -227,7 +257,57 @@ function tenantMcpHandler(holder: RegistryHolder, tenantId: string) {
   };
 }
 
-function wrapSalesCapabilitiesProjection(req: Request, res: Response, tenantId: string): void {
+async function tryHandleLocalComplyScenario(
+  req: Request,
+  res: Response,
+  tenantId: string,
+  principal: string | undefined,
+  storyboardCompat?: TrainingContext['storyboardCompat'],
+): Promise<boolean> {
+  if (tenantId !== 'sales') return false;
+  if (req.body?.method !== 'tools/call') return false;
+  if (req.body?.params?.name !== 'comply_test_controller') return false;
+
+  const rawArgs = (req.body.params.arguments ?? {}) as Record<string, unknown>;
+  const isThreeZeroCompat = storyboardCompat?.version === '3.0';
+  if (rawArgs.scenario !== 'seed_measurement_catalog' && rawArgs.scenario !== 'list_scenarios') return false;
+  if (isThreeZeroCompat && rawArgs.scenario === 'seed_measurement_catalog') return false;
+
+  const { context, ...handlerArgs } = rawArgs;
+  const result = await runWithSessionContext(async () => {
+    const body = rawArgs.scenario === 'list_scenarios'
+      ? {
+          success: true,
+          scenarios: salesComplyScenarios(storyboardCompat),
+        }
+      : await handleComplyTestController(handlerArgs, {
+          mode: 'open',
+          principal: principal ?? 'anonymous',
+        });
+    await flushDirtySessions();
+    return body as Record<string, unknown>;
+  });
+  const structuredContent = {
+    ...result,
+    ...(context !== undefined && { context }),
+  };
+  res.json({
+    jsonrpc: '2.0',
+    id: req.body.id ?? null,
+    result: {
+      content: [{ type: 'text', text: JSON.stringify(structuredContent) }],
+      structuredContent,
+    },
+  });
+  return true;
+}
+
+function wrapSalesCapabilitiesProjection(
+  req: Request,
+  res: Response,
+  tenantId: string,
+  storyboardCompat?: TrainingContext['storyboardCompat'],
+): void {
   if (tenantId !== 'sales') return;
   if (req.body?.method !== 'tools/call') return;
   if (req.body?.params?.name !== 'get_adcp_capabilities') return;
@@ -245,7 +325,7 @@ function wrapSalesCapabilitiesProjection(req: Request, res: Response, tenantId: 
   (res as unknown as { end: (...args: unknown[]) => Response }).end = (chunk?: unknown, ...rest: unknown[]) => {
     if (chunk !== null && chunk !== undefined) chunks.push(toBuffer(chunk));
     const body = Buffer.concat(chunks);
-    const patched = projectSalesCapabilities(body);
+    const patched = projectSalesCapabilities(body, storyboardCompat);
     if (patched !== body) {
       res.setHeader('content-length', String(patched.length));
     }
@@ -260,12 +340,13 @@ function toBuffer(chunk: unknown): Buffer {
   return Buffer.from(String(chunk), 'utf8');
 }
 
-function projectSalesCapabilities(body: Buffer): Buffer {
+function projectSalesCapabilities(body: Buffer, storyboardCompat?: TrainingContext['storyboardCompat']): Buffer {
   try {
     const parsed = JSON.parse(body.toString('utf8')) as {
       result?: {
         structuredContent?: {
           media_buy?: Record<string, unknown>;
+          compliance_testing?: Record<string, unknown>;
         };
       };
     };
@@ -277,6 +358,21 @@ function projectSalesCapabilities(body: Buffer): Buffer {
     structured.media_buy = {
       ...mediaBuy,
       ...salesCapabilityProjection(),
+    };
+    const complianceTesting = structured.compliance_testing && typeof structured.compliance_testing === 'object'
+      ? structured.compliance_testing
+      : {};
+    const scenarios = new Set(
+      Array.isArray((complianceTesting as { scenarios?: unknown }).scenarios)
+        ? (complianceTesting as { scenarios: unknown[] }).scenarios.filter((s): s is string => typeof s === 'string')
+        : [],
+    );
+    for (const scenario of salesComplyScenarios(storyboardCompat)) {
+      scenarios.add(scenario);
+    }
+    structured.compliance_testing = {
+      ...complianceTesting,
+      scenarios: [...scenarios],
     };
     return Buffer.from(JSON.stringify(parsed), 'utf8');
   } catch {
@@ -338,7 +434,7 @@ export function mountTenantRoutes(
       setCORSHeaders(res);
       res.status(204).end();
     });
-    parent.post(`/${tenantId}/mcp`, ...mw, tenantMcpHandler(holder, tenantId));
+    parent.post(`/${tenantId}/mcp`, ...mw, tenantMcpHandler(holder, tenantId, middleware.storyboardCompat));
     parent.get(`/${tenantId}/mcp`, (_req, res) => {
       setCORSHeaders(res);
       res.setHeader('Allow', 'POST, OPTIONS');

--- a/server/src/training-agent/tenants/tenant-smoke.test.ts
+++ b/server/src/training-agent/tenants/tenant-smoke.test.ts
@@ -6,10 +6,36 @@
 import { describe, it, expect } from 'vitest';
 import express from 'express';
 import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import type { TrainingContext } from '../types.js';
 
 process.env.PUBLIC_TEST_AGENT_TOKEN = 'test-token';
 
-async function bootServer(): Promise<{ baseUrl: string; close: () => Promise<void> }> {
+const SALES_CURRENT_SCENARIOS = [
+  'force_creative_status',
+  'force_media_buy_status',
+  'simulate_delivery',
+  'simulate_budget_spend',
+  'force_create_media_buy_arm',
+  'force_task_completion',
+  'seed_product',
+  'seed_pricing_option',
+  'seed_creative',
+  'seed_media_buy',
+  'seed_creative_format',
+  'seed_measurement_catalog',
+];
+
+const SALES_THREE_ZERO_COMPAT_SCENARIOS = [
+  'force_creative_status',
+  'force_media_buy_status',
+  'simulate_delivery',
+  'simulate_budget_spend',
+];
+
+async function bootServer(options: { storyboardCompat?: TrainingContext['storyboardCompat'] } = {}): Promise<{ baseUrl: string; close: () => Promise<void> }> {
   const { createTrainingAgentRouter } = await import('../index.js');
   const app = express();
   app.use(express.json({
@@ -18,7 +44,7 @@ async function bootServer(): Promise<{ baseUrl: string; close: () => Promise<voi
       (req as unknown as { rawBody: string }).rawBody = buf.toString('utf8');
     },
   }));
-  app.use('/api/training-agent', createTrainingAgentRouter());
+  app.use('/api/training-agent', createTrainingAgentRouter(options));
   const srv = http.createServer(app);
   await new Promise<void>(r => srv.listen(0, '127.0.0.1', () => r()));
   const port = (srv.address() as { port: number }).port;
@@ -26,6 +52,25 @@ async function bootServer(): Promise<{ baseUrl: string; close: () => Promise<voi
     baseUrl: `http://127.0.0.1:${port}/api/training-agent`,
     close: () => new Promise(r => srv.close(() => r())),
   };
+}
+
+function stageLatestThreeZeroSchemaBundle(): void {
+  const schemasRoot = path.resolve('dist/schemas');
+  const latest = fs.readdirSync(schemasRoot)
+    .filter(name => /^3\.0\.\d+$/.test(name))
+    .sort((a, b) => {
+      const av = a.split('.').map(Number);
+      const bv = b.split('.').map(Number);
+      for (let i = 0; i < 3; i += 1) {
+        if (av[i] !== bv[i]) return av[i] - bv[i];
+      }
+      return 0;
+    })
+    .at(-1);
+  if (!latest) throw new Error('No dist/schemas/3.0.x bundle found');
+  execFileSync('bash', ['scripts/stage-sdk-schema-bundle.sh', path.join(schemasRoot, latest), '3.0'], {
+    stdio: 'ignore',
+  });
 }
 
 describe('tenant routing smoke', () => {
@@ -143,12 +188,169 @@ describe('tenant routing smoke', () => {
               supported_optimization_metrics?: string[];
               vendor_metric_optimization?: { supported_targets?: string[] };
             };
+            compliance_testing?: { scenarios?: string[] };
           };
         };
       };
       const mediaBuy = body.result?.structuredContent?.media_buy;
       expect(mediaBuy?.supported_optimization_metrics).toContain('clicks');
       expect(mediaBuy?.vendor_metric_optimization?.supported_targets).toContain('threshold_rate');
+      expect(body.result?.structuredContent?.compliance_testing?.scenarios).toEqual(expect.arrayContaining(SALES_CURRENT_SCENARIOS));
+    } finally {
+      await close();
+    }
+  }, 15000);
+
+  it('discovers and dispatches seed_measurement_catalog on /sales/mcp', async () => {
+    const { baseUrl, close } = await bootServer();
+    try {
+      const url = `${baseUrl}/sales/mcp`;
+      const headers = {
+        'content-type': 'application/json',
+        accept: 'application/json',
+        authorization: 'Bearer test-token',
+      };
+      await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          jsonrpc: '2.0', id: 1, method: 'initialize',
+          params: { protocolVersion: '2025-03-26', clientInfo: { name: 'x', version: '1' }, capabilities: {} },
+        }),
+      });
+      const list = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'tools/call',
+          params: {
+            name: 'comply_test_controller',
+            arguments: { account: { sandbox: true }, scenario: 'list_scenarios' },
+          },
+        }),
+      });
+      const listed = await list.json() as {
+        result?: {
+          structuredContent?: { scenarios?: string[] };
+        };
+      };
+      expect(listed.result?.structuredContent?.scenarios).toEqual(expect.arrayContaining(SALES_CURRENT_SCENARIOS));
+
+      const r = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 3,
+          method: 'tools/call',
+          params: {
+            name: 'comply_test_controller',
+            arguments: {
+              account: { sandbox: true, brand: { domain: 'tenant-seed.example' } },
+              brand: { domain: 'tenant-seed.example' },
+              scenario: 'seed_measurement_catalog',
+              params: {
+                vendor: { domain: 'attentionvendor.example' },
+                metrics: [{ metric_id: 'attention_baseline' }],
+              },
+              context: { correlation_id: 'tenant-seed-measurement-catalog' },
+            },
+          },
+        }),
+      });
+      const body = await r.json() as {
+        result?: {
+          structuredContent?: { success?: boolean; context?: { correlation_id?: string } };
+        };
+      };
+      expect(body.result?.structuredContent?.success).toBe(true);
+      expect(body.result?.structuredContent?.context?.correlation_id).toBe('tenant-seed-measurement-catalog');
+    } finally {
+      await close();
+    }
+  }, 15000);
+
+  it('does not advertise 3.1 measurement-catalog seeding in 3.0 storyboard compat mode', async () => {
+    stageLatestThreeZeroSchemaBundle();
+    const { baseUrl, close } = await bootServer({ storyboardCompat: { version: '3.0' } });
+    try {
+      const url = `${baseUrl}/sales/mcp`;
+      const headers = {
+        'content-type': 'application/json',
+        accept: 'application/json',
+        authorization: 'Bearer test-token',
+      };
+      await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          jsonrpc: '2.0', id: 1, method: 'initialize',
+          params: { protocolVersion: '2025-03-26', clientInfo: { name: 'x', version: '1' }, capabilities: {} },
+        }),
+      });
+      const capabilities = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'tools/call',
+          params: { name: 'get_adcp_capabilities', arguments: {} },
+        }),
+      });
+      const capabilitiesBody = await capabilities.json() as {
+        result?: { structuredContent?: { compliance_testing?: { scenarios?: string[] } } };
+      };
+      expect(capabilitiesBody.result?.structuredContent?.compliance_testing?.scenarios).toEqual(SALES_THREE_ZERO_COMPAT_SCENARIOS);
+      expect(capabilitiesBody.result?.structuredContent?.compliance_testing?.scenarios).not.toContain('seed_measurement_catalog');
+
+      const list = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 3,
+          method: 'tools/call',
+          params: {
+            name: 'comply_test_controller',
+            arguments: { account: { sandbox: true }, scenario: 'list_scenarios' },
+          },
+        }),
+      });
+      const listed = await list.json() as {
+        result?: { structuredContent?: { scenarios?: string[] } };
+      };
+      expect(listed.result?.structuredContent?.scenarios).toEqual(SALES_THREE_ZERO_COMPAT_SCENARIOS);
+      expect(listed.result?.structuredContent?.scenarios).not.toContain('seed_measurement_catalog');
+
+      const directSeed = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 4,
+          method: 'tools/call',
+          params: {
+            name: 'comply_test_controller',
+            arguments: {
+              account: { sandbox: true, brand: { domain: 'tenant-seed.example' } },
+              brand: { domain: 'tenant-seed.example' },
+              scenario: 'seed_measurement_catalog',
+              params: {
+                vendor: { domain: 'attentionvendor.example' },
+                metrics: [{ metric_id: 'attention_baseline' }],
+              },
+            },
+          },
+        }),
+      });
+      const directSeedBody = await directSeed.json() as {
+        result?: { structuredContent?: { success?: boolean } };
+        error?: unknown;
+      };
+      expect(directSeedBody.result?.structuredContent?.success).not.toBe(true);
     } finally {
       await close();
     }

--- a/server/src/training-agent/types.ts
+++ b/server/src/training-agent/types.ts
@@ -217,6 +217,11 @@ export interface ComplyBudgetSimulation {
   budget: { amount: number; currency: string };
 }
 
+export interface SeededMeasurementCatalog {
+  vendor: { domain: string; brand_id?: string };
+  metrics: Array<{ metric_id: string; [key: string]: unknown }>;
+}
+
 export interface ComplyExtensions {
   accountStatuses: Map<string, string>;
   siSessions: Map<string, { status: string; terminationReason?: string }>;
@@ -233,6 +238,11 @@ export interface ComplyExtensions {
    * giving storyboards a deterministic, size-controlled result set for
    * pagination-integrity assertions. Keyed by the format's id string. */
   seededCreativeFormats: Map<string, Record<string, unknown>>;
+  /** Measurement vendor catalogs seeded via comply_test_controller.seed_measurement_catalog.
+   * Keyed by `(vendor.domain, vendor.brand_id)` so vendor_metric optimization
+   * storyboards can distinguish product/reporting preconditions from the
+   * external measurement.metrics[] discovery precondition. */
+  seededMeasurementCatalogs: Map<string, SeededMeasurementCatalog>;
   /** Single-shot directive registered via comply_test_controller.force_create_media_buy_arm.
    * Consumed by the next create_media_buy call from this session and cleared. A second
    * force_create_media_buy_arm before consumption overwrites the directive. Buyer-side

--- a/server/tests/unit/comply-test-controller.test.ts
+++ b/server/tests/unit/comply-test-controller.test.ts
@@ -178,10 +178,11 @@ describe('comply_test_controller', () => {
         'force_create_media_buy_arm',
         'force_task_completion',
         'seed_creative_format',
+        'seed_measurement_catalog',
       ]));
       // Catch silent drift in either direction (entries removed, or new ones
       // not yet documented in this assertion).
-      expect(scenarios.length).toBe(9);
+      expect(scenarios.length).toBe(10);
       // Dedup invariant — see SCENARIO_ENUM dedup in the wrapper.
       expect(new Set(scenarios).size).toBe(scenarios.length);
     });
@@ -367,6 +368,141 @@ describe('comply_test_controller', () => {
       const pkgs = result.packages as Array<Record<string, unknown>>;
       expect(pkgs).toHaveLength(1);
       expect(pkgs[0].package_id).toBe('pkg-0');
+    });
+
+    it('seed_measurement_catalog lets vendor_metric create reject a catalog miss after product preconditions pass', async () => {
+      const seedProd = await simulateCallTool(server, 'comply_test_controller', {
+        scenario: 'seed_product',
+        account: ACCOUNT,
+        brand: BRAND,
+        params: {
+          product_id: 'seeded_vendor_catalog_product',
+          fixture: {
+            delivery_type: 'non_guaranteed',
+            channels: ['display'],
+            reporting_capabilities: {
+              available_metrics: ['impressions', 'clicks', 'spend'],
+              vendor_metrics: [
+                {
+                  vendor: { domain: 'attentionvendor.example' },
+                  metric_id: 'attention_catalog_probe',
+                },
+              ],
+            },
+            vendor_metric_optimization: {
+              supported_metrics: [
+                {
+                  vendor: { domain: 'attentionvendor.example' },
+                  metric_id: 'attention_catalog_probe',
+                  supported_targets: ['threshold_rate'],
+                },
+              ],
+            },
+          },
+        },
+      });
+      expect((seedProd.result as any).success).toBe(true);
+
+      const seedPricing = await simulateCallTool(server, 'comply_test_controller', {
+        scenario: 'seed_pricing_option',
+        account: ACCOUNT,
+        brand: BRAND,
+        params: {
+          product_id: 'seeded_vendor_catalog_product',
+          pricing_option_id: 'seeded_vendor_catalog_cpm',
+          fixture: { pricing_model: 'cpm', currency: 'USD', floor_price: 5.0 },
+        },
+      });
+      expect((seedPricing.result as any).success).toBe(true);
+
+      const seedCatalog = await simulateCallTool(server, 'comply_test_controller', {
+        scenario: 'seed_measurement_catalog',
+        account: ACCOUNT,
+        brand: BRAND,
+        params: {
+          vendor: { domain: 'attentionvendor.example' },
+          metrics: [
+            { metric_id: 'attention_catalog_baseline', unit: 'score' },
+            { metric_id: 'attention_catalog_secondary', unit: 'score' },
+          ],
+        },
+      });
+      expect((seedCatalog.result as any).success).toBe(true);
+
+      const replayCatalog = await simulateCallTool(server, 'comply_test_controller', {
+        scenario: 'seed_measurement_catalog',
+        account: ACCOUNT,
+        brand: BRAND,
+        params: {
+          metrics: [
+            { unit: 'score', metric_id: 'attention_catalog_secondary' },
+            { unit: 'score', metric_id: 'attention_catalog_baseline' },
+          ],
+          vendor: { domain: 'attentionvendor.example' },
+        },
+      });
+      expect((replayCatalog.result as any).success).toBe(true);
+      expect((replayCatalog.result as any).message).toBe('Fixture re-seeded (equivalent)');
+
+      const divergentCatalog = await simulateCallTool(server, 'comply_test_controller', {
+        scenario: 'seed_measurement_catalog',
+        account: ACCOUNT,
+        brand: BRAND,
+        params: {
+          vendor: { domain: 'attentionvendor.example' },
+          metrics: [{ metric_id: 'attention_catalog_other', unit: 'score' }],
+        },
+      });
+      expect((divergentCatalog.result as any).success).toBe(false);
+      expect((divergentCatalog.result as any).error).toBe('INVALID_PARAMS');
+
+      const { result } = await simulateCallTool(server, 'create_media_buy', {
+        account: ACCOUNT,
+        brand: BRAND,
+        start_time: '2027-06-01T00:00:00Z',
+        end_time: '2027-07-01T00:00:00Z',
+        packages: [{
+          product_id: 'seeded_vendor_catalog_product',
+          pricing_option_id: 'seeded_vendor_catalog_cpm',
+          bid_price: 8.50,
+          budget: 10000,
+          optimization_goals: [
+            {
+              kind: 'vendor_metric',
+              vendor: { domain: 'attentionvendor.example' },
+              metric_id: 'attention_catalog_probe',
+              target: { kind: 'threshold_rate', value: 70 },
+            },
+          ],
+          committed_metrics: [
+            {
+              scope: 'vendor',
+              vendor: { domain: 'attentionvendor.example' },
+              metric_id: 'attention_catalog_probe',
+            },
+          ],
+        }],
+      });
+
+      expect((result as any).code).toBe('TERMS_REJECTED');
+      expect((result as any).field).toBe('packages[0].optimization_goals[0].metric_id');
+      expect((result as any).message).toMatch(/measurement\.metrics catalog/);
+    });
+
+    it('seed_measurement_catalog rejects an empty metrics catalog', async () => {
+      const result = await simulateCallTool(server, 'comply_test_controller', {
+        scenario: 'seed_measurement_catalog',
+        account: ACCOUNT,
+        brand: BRAND,
+        params: {
+          vendor: { domain: 'attentionvendor.example' },
+          metrics: [],
+        },
+      });
+
+      expect((result.result as any).success).toBe(false);
+      expect((result.result as any).error).toBe('INVALID_PARAMS');
+      expect((result.result as any).error_detail).toMatch(/at least one metric/);
     });
 
     it('create_media_buy resolves product allowed_actions into buy available_actions and enforcement', async () => {

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -6207,6 +6207,31 @@ describe('get_adcp_capabilities handler', () => {
     expect(tasks).not.toContain('get_adcp_capabilities');
   });
 
+  it('advertises the compliance test controller scenarios it implements', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { result } = await simulateCallTool(server, 'get_adcp_capabilities', {});
+
+    const complianceTesting = result.compliance_testing as Record<string, unknown>;
+    const scenarios = complianceTesting.scenarios as string[];
+    expect(scenarios).toEqual(expect.arrayContaining([
+      'force_creative_status',
+      'force_account_status',
+      'force_media_buy_status',
+      'force_create_media_buy_arm',
+      'force_task_completion',
+      'force_session_status',
+      'simulate_delivery',
+      'simulate_budget_spend',
+      'seed_product',
+      'seed_pricing_option',
+      'seed_creative',
+      'seed_plan',
+      'seed_media_buy',
+      'seed_creative_format',
+      'seed_measurement_catalog',
+    ]));
+  });
+
   it('derives channels from the publisher catalog', async () => {
     const server = createTrainingAgentServer(DEFAULT_CTX);
     const { result } = await simulateCallTool(server, 'get_adcp_capabilities', {});
@@ -9089,6 +9114,84 @@ describe('cross-machine session persistence', () => {
     const buys = fetched.result.media_buys as Array<{ media_buy_id: string }>;
     expect(buys.length).toBe(1);
     expect(buys[0]!.media_buy_id).toBe(mediaBuyId);
+  });
+
+  it('seeded measurement catalogs survive across server instances', async () => {
+    const account = { brand: { domain: 'catalog-machine-test.example' }, operator: 'pinnacle-agency.com' };
+    const brand = { domain: 'catalog-machine-test.example' };
+
+    const serverA = createTrainingAgentServer(DEFAULT_CTX);
+    await simulateCallTool(serverA, 'comply_test_controller', {
+      account,
+      brand,
+      scenario: 'seed_product',
+      params: {
+        product_id: 'catalog_machine_product',
+        fixture: {
+          delivery_type: 'non_guaranteed',
+          channels: ['display'],
+          reporting_capabilities: {
+            available_metrics: ['impressions', 'clicks', 'spend'],
+            vendor_metrics: [{ vendor: { domain: 'attentionvendor.example' }, metric_id: 'attention_probe' }],
+          },
+          vendor_metric_optimization: {
+            supported_metrics: [{
+              vendor: { domain: 'attentionvendor.example' },
+              metric_id: 'attention_probe',
+              supported_targets: ['threshold_rate'],
+            }],
+          },
+        },
+      },
+    });
+    await simulateCallTool(serverA, 'comply_test_controller', {
+      account,
+      brand,
+      scenario: 'seed_pricing_option',
+      params: {
+        product_id: 'catalog_machine_product',
+        pricing_option_id: 'catalog_machine_cpm',
+        fixture: { pricing_model: 'cpm', currency: 'USD', floor_price: 5 },
+      },
+    });
+    const seededCatalog = await simulateCallTool(serverA, 'comply_test_controller', {
+      account,
+      brand,
+      scenario: 'seed_measurement_catalog',
+      params: {
+        vendor: { domain: 'attentionvendor.example' },
+        metrics: [{ metric_id: 'attention_baseline' }],
+      },
+    });
+    expect(seededCatalog.result.success).toBe(true);
+
+    const serverB = createTrainingAgentServer(DEFAULT_CTX);
+    const created = await simulateCallTool(serverB, 'create_media_buy', {
+      account,
+      brand,
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: 'catalog_machine_product',
+        pricing_option_id: 'catalog_machine_cpm',
+        bid_price: 8,
+        budget: 1000,
+        optimization_goals: [{
+          kind: 'vendor_metric',
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'attention_probe',
+          target: { kind: 'threshold_rate', value: 70 },
+        }],
+        committed_metrics: [{
+          scope: 'vendor',
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'attention_probe',
+        }],
+      }],
+    });
+
+    expect(created.result.code).toBe('TERMS_REJECTED');
+    expect(created.result.field).toBe('packages[0].optimization_goals[0].metric_id');
   });
 });
 

--- a/static/compliance/source/protocols/media-buy/scenarios/vendor_metric_catalog_precondition.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/vendor_metric_catalog_precondition.yaml
@@ -2,7 +2,7 @@ id: media_buy_seller/vendor_metric_catalog_precondition
 version: "1.0.0"
 title: "Vendor-metric external catalog precondition"
 category: media_buy_seller
-summary: "Exercises the 3.1 SHOULD-window behavior for vendor_metric goals whose external vendor catalog membership is not proven by the harness."
+summary: "Exercises the 3.1 SHOULD-window behavior for vendor_metric goals whose metric_id is absent from a seeded measurement.metrics[] catalog."
 track: media_buy
 introduced_in: "3.1"
 
@@ -26,15 +26,14 @@ narrative: |
   conformant capability catalogs. The next minor tightens this discovery
   precondition to MUST.
 
-  This storyboard seeds a product whose `attention_catalog_probe` metric is
-  valid by the seller's product-level capability and reporting contract. The
-  current runner does not fetch or seed an external measurement-agent
-  `measurement.metrics[]` catalog for `attentionvendor.example`, so this
-  storyboard does not certify real vendor-catalog discovery. It captures the
-  3.1 compatibility window for catalog-unproven metrics: a seller may accept the
-  request, or it may reject with `TERMS_REJECTED`. A future 3.2 storyboard should
-  add a real measurement-catalog fixture and make the reject path required for
-  true catalog misses.
+  This storyboard seeds two facts that intentionally diverge. The seller product
+  can optimize and report `attention_catalog_probe`, satisfying the product
+  capability and reporting-coherence preconditions. The measurement vendor
+  catalog seeded for `attentionvendor.example` publishes only
+  `attention_catalog_baseline`, so `attention_catalog_probe` is a deterministic
+  external catalog miss. The storyboard captures the 3.1 compatibility window:
+  a seller may accept the request, or it may reject with `TERMS_REJECTED`. The
+  3.2 storyboard cut should collapse this branch set to the reject path only.
 
 agent:
   interaction_model: media_buy_seller
@@ -52,10 +51,10 @@ caller:
 prerequisites:
   description: |
     The runner seeds a product that can optimize and report the
-    attention_catalog_probe metric. The runner does not currently provide an
-    external measurement.metrics[] catalog for attentionvendor.example, so this
-    scenario exercises 3.1 behavior for a catalog-unproven metric rather than a
-    verified catalog miss.
+    attention_catalog_probe metric, with an attentionvendor.example
+    measurement.metrics[] fixture that deliberately omits that metric_id. The
+    request is therefore valid by product capability and reporting coherence,
+    but is a deterministic external catalog miss.
   test_kit: "test-kits/acme-outdoor.yaml"
   controller_seeding: true
 
@@ -120,19 +119,63 @@ phases:
             path: "accounts[0].account_id"
             description: "Account has a platform-assigned ID"
 
+  - id: seed_measurement_catalog
+    title: "Seed the measurement vendor catalog"
+    narrative: |
+      The product fixture proves the seller-side vendor_metric capability and
+      reporting contract. This controller step separately seeds the external
+      measurement vendor catalog so the later create_media_buy request is a
+      deterministic catalog miss rather than merely catalog-unproven.
+
+    steps:
+      - id: seed_attention_vendor_catalog
+        title: "Seed attentionvendor.example without the requested metric"
+        task: comply_test_controller
+        requires_tool: comply_test_controller
+        stateful: true
+        expected: |
+          The controller stores attentionvendor.example's measurement.metrics[]
+          catalog for this compliance session.
+        sample_request:
+          account:
+            sandbox: true
+          brand:
+            domain: "acmeoutdoor.example"
+          scenario: "seed_measurement_catalog"
+          params:
+            vendor:
+              domain: "attentionvendor.example"
+            metrics:
+              - metric_id: "attention_catalog_baseline"
+                unit: "score"
+                description: "Baseline attention metric present in the seeded vendor catalog."
+          context:
+            correlation_id: "vendor_metric_catalog_precondition--seed_catalog"
+        validations:
+          - check: field_value
+            path: "success"
+            allowed_values: [true]
+            description: "Measurement catalog seeding succeeds"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "vendor_metric_catalog_precondition--seed_catalog"
+            description: "Context correlation_id returned unchanged"
+
   - id: catalog_miss_accept_path
-    title: "3.1 catalog-unproven metric — accept path"
+    title: "3.1 catalog-miss metric — accept path"
     narrative: |
       The seller may accept the buy during the 3.1 SHOULD window even though
-      the harness has not proven attention_catalog_probe exists in the vendor's
-      external catalog.
+      attention_catalog_probe is absent from the seeded vendor catalog.
     optional: true
     branch_set:
       id: vendor_metric_catalog_miss_handled
       semantics: any_of
     steps:
       - id: create_media_buy_catalog_miss_accept
-        title: "Accept vendor_metric with unproven catalog membership during 3.1 SHOULD window"
+        title: "Accept vendor_metric with catalog miss during 3.1 SHOULD window"
         task: create_media_buy
         schema_ref: "media-buy/create-media-buy-request.json"
         response_schema_ref: "media-buy/create-media-buy-response.json"
@@ -145,7 +188,7 @@ phases:
         contributes: true
         expected: |
           3.1 compatibility behavior: accept the buy even though the metric is
-          not proven by a vendor measurement.metrics[] catalog in this harness.
+          absent from the seeded vendor measurement.metrics[] catalog.
         sample_request:
           brand:
             domain: "acmeoutdoor.example"
@@ -176,13 +219,13 @@ phases:
           idempotency_key: "$generate:uuid_v4#media_buy_seller_vendor_metric_catalog_precondition_accept"
         validations:
           - check: response_schema
-            description: "Response matches create-media-buy-response.json schema for the 3.1 catalog-unproven accept branch"
+            description: "Response matches create-media-buy-response.json schema for the 3.1 catalog-miss accept branch"
           - check: field_present
             path: "media_buy_id"
-            description: "Seller returns a media_buy_id during the 3.1 catalog-unproven SHOULD window"
+            description: "Seller returns a media_buy_id during the 3.1 catalog-miss SHOULD window"
 
   - id: catalog_miss_reject_path
-    title: "3.1 catalog-unproven metric — reject path"
+    title: "3.1 catalog-miss metric — reject path"
     narrative: |
       The seller may also reject the same request in 3.1. This is the
       recommended behavior ahead of the 3.2 MUST boundary.
@@ -192,7 +235,7 @@ phases:
       semantics: any_of
     steps:
       - id: create_media_buy_catalog_miss_reject
-        title: "Reject vendor_metric with unproven catalog membership using TERMS_REJECTED"
+        title: "Reject vendor_metric with catalog miss using TERMS_REJECTED"
         task: create_media_buy
         schema_ref: "media-buy/create-media-buy-request.json"
         response_schema_ref: "media-buy/create-media-buy-response.json"
@@ -207,7 +250,7 @@ phases:
         contributes: true
         expected: |
           Recommended 3.1 behavior and required 3.2 behavior: reject with
-          TERMS_REJECTED because the metric is not proven by the vendor's
+          TERMS_REJECTED because the metric is absent from the vendor's seeded
           measurement.metrics[] catalog.
         sample_request:
           brand:
@@ -240,16 +283,15 @@ phases:
         validations:
           - check: error_code
             allowed_values: ["TERMS_REJECTED"]
-            description: "Seller may reject catalog-unproven vendor metrics with TERMS_REJECTED in 3.1; true catalog misses become required rejections at 3.2"
+            description: "Seller may reject catalog-miss vendor metrics with TERMS_REJECTED in 3.1; catalog misses become required rejections at 3.2"
 
   - id: catalog_miss_assertion
-    title: "Require catalog-unproven metric handling"
+    title: "Require catalog-miss metric handling"
     narrative: |
       Synthetic assertion over the accept and reject branches. In 3.1, either
       compatibility acceptance or recommended TERMS_REJECTED rejection satisfies
-      the catalog-unproven metric behavior. The 3.2 storyboard cut should add a
-      real measurement-catalog fixture and collapse true catalog misses to the
-      reject branch only.
+      the catalog-miss metric behavior. The 3.2 storyboard cut should collapse
+      this branch set to the reject branch only.
     steps:
       - id: assert_vendor_metric_catalog_miss_handled
         title: "Require catalog-miss handling from either branch"
@@ -262,4 +304,4 @@ phases:
         validations:
           - check: any_of
             allowed_values: ["vendor_metric_catalog_miss_handled"]
-            description: "Agent must either accept the catalog-unproven metric during the 3.1 SHOULD window or reject it with TERMS_REJECTED."
+            description: "Agent must either accept the catalog-miss metric during the 3.1 SHOULD window or reject it with TERMS_REJECTED."

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -356,8 +356,12 @@
 #           status: "active"
 #   Each top-level key maps to a seed_* scenario (products → seed_product,
 #   pricing_options → seed_pricing_option, creatives → seed_creative,
-#   plans → seed_plan, media_buys → seed_media_buy). Foreign-key dependency DAG
-#   the runner MUST honor when auto-seeding:
+#   plans → seed_plan, media_buys → seed_media_buy). Storyboards that need an
+#   external measurement vendor catalog SHOULD add an explicit
+#   comply_test_controller step with scenario: seed_measurement_catalog. Product
+#   fixtures may carry `measurement_catalogs[]` entries only as a compatibility
+#   fallback when a storyboard needs to keep that snapshot beside the product
+#   contract. Foreign-key dependency DAG the runner MUST honor when auto-seeding:
 #
 #     product ──┬─→ pricing_option
 #               ├─→ plan

--- a/static/schemas/source/compliance/comply-test-controller-request.json
+++ b/static/schemas/source/compliance/comply-test-controller-request.json
@@ -364,6 +364,28 @@
       "if": {
         "properties": {
           "scenario": {
+            "const": "seed_measurement_catalog"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "params"
+        ],
+        "properties": {
+          "params": {
+            "required": [
+              "vendor",
+              "metrics"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "scenario": {
             "const": "query_upstream_traffic"
           }
         }
@@ -455,10 +477,11 @@
         "seed_plan",
         "seed_media_buy",
         "seed_creative_format",
+        "seed_measurement_catalog",
         "query_upstream_traffic",
         "force_upstream_unavailable"
       ],
-      "description": "Test scenario to execute. 'list_scenarios' discovers supported scenarios. 'force_*' and 'simulate_*' trigger state transitions. 'seed_*' scenarios pre-populate fixtures (product, pricing option, creative, plan, media buy, creative format) so storyboards can reference them by stable ID without the implementer having to guess which IDs the conformance suite expects. 'query_upstream_traffic' returns outbound HTTP calls the agent has made since session start (or since a caller-supplied timestamp), so storyboard runners can assert upstream side-effects via `check: upstream_traffic`. 'force_upstream_unavailable' marks a named upstream dependency as unreachable for the duration of the compliance session (or until the seller resets it), so storyboards can exercise stale-cache fallback paths — see the `stale_response_advisory` universal storyboard. The contract raises the bar against unintentional façades — adapters that satisfy AdCP schema requirements with synthetic placeholders. It is NOT an adversarial integrity check: adopters self-report their own traffic. Adopters MUST scope the response to traffic caused by the requesting principal's session/auth context — cross-caller traffic MUST NOT be returned, regardless of the supplied since_timestamp. Multi-tenant sandboxes MUST key the recording buffer on the comply_test_controller invocation's auth principal."
+      "description": "Test scenario to execute. 'list_scenarios' discovers supported scenarios. 'force_*' and 'simulate_*' trigger state transitions. 'seed_*' scenarios pre-populate fixtures (product, pricing option, creative, plan, media buy, creative format, measurement catalog) so storyboards can reference stable IDs and external-catalog facts without the implementer having to guess which fixtures the conformance suite expects. 'query_upstream_traffic' returns outbound HTTP calls the agent has made since session start (or since a caller-supplied timestamp), so storyboard runners can assert upstream side-effects via `check: upstream_traffic`. 'force_upstream_unavailable' marks a named upstream dependency as unreachable for the duration of the compliance session (or until the seller resets it), so storyboards can exercise stale-cache fallback paths — see the `stale_response_advisory` universal storyboard. The contract raises the bar against unintentional façades — adapters that satisfy AdCP schema requirements with synthetic placeholders. It is NOT an adversarial integrity check: adopters self-report their own traffic. Adopters MUST scope the response to traffic caused by the requesting principal's session/auth context — cross-caller traffic MUST NOT be returned, regardless of the supplied since_timestamp. Multi-tenant sandboxes MUST key the recording buffer on the comply_test_controller invocation's auth principal. Runners and sellers MUST accept unknown scenario strings — new scenarios may be added in additive releases."
     },
     "params": {
       "type": "object",
@@ -661,6 +684,28 @@
         "format_id": {
           "type": "string",
           "description": "Creative format ID to seed. Used by seed_creative_format. The seller MUST expose this format ID in list_creative_formats responses for the duration of the compliance session."
+        },
+        "vendor": {
+          "$ref": "/schemas/core/brand-ref.json",
+          "description": "Measurement vendor whose catalog is being seeded. Used by seed_measurement_catalog. The seller MUST treat `metrics[]` as this vendor's `get_adcp_capabilities.measurement.metrics[]` snapshot for the duration of the compliance session."
+        },
+        "metrics": {
+          "type": "array",
+          "description": "Measurement catalog entries to seed for the vendor. Used by seed_measurement_catalog. Shape mirrors `get_adcp_capabilities.measurement.metrics[]`; each metric_id is unique within the seeded vendor catalog.",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "required": [
+              "metric_id"
+            ],
+            "properties": {
+              "metric_id": {
+                "$ref": "/schemas/core/vendor-metric-id.json"
+              }
+            },
+            "additionalProperties": true
+          }
         },
         "tool": {
           "type": "string",

--- a/static/schemas/source/compliance/comply-test-controller-response.json
+++ b/static/schemas/source/compliance/comply-test-controller-response.json
@@ -41,11 +41,12 @@
               "seed_plan",
               "seed_media_buy",
               "seed_creative_format",
+              "seed_measurement_catalog",
               "query_upstream_traffic",
               "force_upstream_unavailable"
             ]
           },
-          "description": "Scenarios this seller has implemented. Runners and sellers MUST accept unknown scenario strings (open-for-extension) — new scenarios may be added in additive minor bumps. Adopters who advertise `query_upstream_traffic` opt in to the upstream-traffic conformance contract; storyboards that declare `check: upstream_traffic` grade `not_applicable` against adopters who do not advertise it. Adopters who advertise `force_upstream_unavailable` opt in to stale-cache conformance testing via the `stale_response_advisory` storyboard."
+          "description": "Scenarios this seller has implemented. Runners and sellers MUST accept unknown scenario strings (open-for-extension) — new scenarios may be added in additive releases. Adopters who advertise `seed_measurement_catalog` opt in to deterministic measurement-catalog fixtures used by vendor_metric precondition storyboards. Adopters who advertise `query_upstream_traffic` opt in to the upstream-traffic conformance contract; storyboards that declare `check: upstream_traffic` grade `not_applicable` against adopters who do not advertise it. Adopters who advertise `force_upstream_unavailable` opt in to stale-cache conformance testing via the `stale_response_advisory` storyboard."
         },
         "context": {
           "$ref": "/schemas/core/context.json"

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -1505,9 +1505,20 @@
               "force_creative_status",
               "force_account_status",
               "force_media_buy_status",
+              "force_create_media_buy_arm",
+              "force_task_completion",
               "force_session_status",
               "simulate_delivery",
-              "simulate_budget_spend"
+              "simulate_budget_spend",
+              "seed_product",
+              "seed_pricing_option",
+              "seed_creative",
+              "seed_plan",
+              "seed_media_buy",
+              "seed_creative_format",
+              "seed_measurement_catalog",
+              "query_upstream_traffic",
+              "force_upstream_unavailable"
             ]
           },
           "minItems": 1


### PR DESCRIPTION
## Summary

Closes #4983.

Adds deterministic 3.1 storyboard coverage for the `vendor_metric` external measurement-catalog precondition. The storyboard now seeds a product that supports/reports `attention_catalog_probe` and separately seeds `attentionvendor.example`'s measurement catalog without that metric, so the later `create_media_buy` request is a real catalog miss during the 3.1 accept-or-`TERMS_REJECTED` window.

## Implementation

- Adds `seed_measurement_catalog` to the compliance controller schemas, docs, discovery, and training-agent session state.
- Enforces seeded measurement catalog membership during `create_media_buy`, while preserving product `measurement_catalogs[]` as a documented compatibility fallback.
- Updates `/sales/mcp` discovery/dispatch so current 3.1 surfaces advertise the supported seed scenarios consistently, while 3.0 storyboard compatibility hides and rejects the 3.1-only measurement-catalog seed.
- Adds current-source SDK schema/validator overlay support for same-PR storyboard/schema additions, with restore logic so local 3.0 compatibility runs stay strict.
- Makes `media_buy_seller/vendor_metric_catalog_precondition` required-clean in local and CI storyboard gates.

## Validation

- Expert protocol review: no blockers.
- Expert code review after fixes: no blockers.
- `npm run typecheck`
- focused `vitest` for tenant smoke, controller, and training-agent catalog persistence/discovery
- `npm run build:compliance`
- `npm run test:storyboard-sample-request-schema`
- `npm run test:storyboard-response-schema`
- `npm run test:schemas`
- targeted vendor metric catalog storyboard
- `npm run test:storyboards`
- `npm run test:storyboards:3.0-compat`
- `git diff --check`
- precommit hook: unit tests, dynamic-import lint, callApi state-change lint, typecheck
- prepush hook: version sync, current storyboard matrix, 3.0.13 compat matrix, docs broken-link check
