### PR TITLE
[codex] Fix get_products brief type handling

### DIFF
--- a/.changeset/fix-get-products-brief-type.md
+++ b/.changeset/fix-get-products-brief-type.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix the training-agent `get_products` handler to reject non-string `brief` values with a structured `INVALID_REQUEST` instead of throwing on `toLowerCase()`.

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -1884,6 +1884,17 @@ const TOOLS = [
 export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): Promise<GetProductsResponse | { errors: TaskError[] }> {
   const req = args as unknown as GetProductsRequest & ToolArgs;
   const buyingMode = req.buying_mode || 'brief';
+  const brief = (req as Record<string, unknown>).brief;
+  if (brief !== undefined && typeof brief !== 'string') {
+    return {
+      errors: [{
+        code: 'INVALID_REQUEST',
+        message: 'brief must be a string.',
+        field: 'brief',
+        recovery: 'correctable',
+      }] as TaskError[],
+    };
+  }
   const session = await getSession(sessionKeyFromArgs(req, ctx.mode, ctx.userId, ctx.moduleId));
 
   let products: Product[] = getCatalog().map(cp => ({ ...cp.product }));
@@ -1931,8 +1942,8 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): P
   const filteredProducts = products;
 
   // Brief mode: channel-aware keyword matching
-  if (buyingMode === 'brief' && req.brief) {
-    const briefLower = req.brief.toLowerCase();
+  if (buyingMode === 'brief' && brief) {
+    const briefLower = brief.toLowerCase();
     const terms = briefLower.split(/\s+/);
 
     // Extract channel names mentioned in the brief — these get heavy weight

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -1360,6 +1360,19 @@ describe('get_products handler', () => {
     expect(products.length).toBeGreaterThan(0);
   });
 
+  it('rejects non-string brief instead of throwing', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { result, isError } = await simulateCallTool(server, 'get_products', {
+      buying_mode: 'brief',
+      brief: { text: 'video sports streaming' },
+    });
+
+    expect(isError).toBe(true);
+    expect(result.code).toBe('INVALID_REQUEST');
+    expect(result.field).toBe('brief');
+    expect(result.message).toContain('brief must be a string');
+  });
+
   it('every product in response has all schema-required fields', async () => {
     const server = createTrainingAgentServer(DEFAULT_CTX);
     const { result } = await simulateCallTool(server, 'get_products', {


### PR DESCRIPTION
## Summary

Fixes the training-agent `get_products` handler so malformed non-string `brief` values return a structured `INVALID_REQUEST` instead of throwing on `toLowerCase()`.

## Root Cause

The MCP tool schema advertises `brief` as a string, but the handler trusted runtime input and called string methods directly. When a caller supplied an object-shaped brief, the handler threw and the dispatcher surfaced it as a transient service error.

## Validation

- `npx vitest run server/tests/unit/training-agent.test.ts -t "get_products handler"`
- `npx tsc --project server/tsconfig.json --noEmit --pretty false`
- precommit hook: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run typecheck`
- pre-push hook: schema/compliance build, current storyboard matrix, 3.0 compatibility storyboard matrix
