### PR TITLE
[codex] Add billing finality storyboards

### DIFF
--- a/.changeset/billing-finality-out-of-band-storyboards.md
+++ b/.changeset/billing-finality-out-of-band-storyboards.md
@@ -1,0 +1,11 @@
+---
+---
+
+test(compliance): add billing finality and out-of-band billing storyboards (refs #5030)
+
+Adds two AdCP 3.1 storyboard paths:
+
+- `media_buy_seller/billing_finality_delivery` verifies provisional versus final delivery finality markers and final `report_usage` metadata.
+- `creative/billing_out_of_band` verifies `creative.bills_through_adcp: false` capability discovery and `BILLING_OUT_OF_BAND` placement on `report_usage` payload errors.
+
+The training agent now supports the storyboard-only billing finality fields, exposes tenant-scoped creative out-of-band billing on `/creative`, and keeps 3.0 compatibility runs from advertising the new 3.1-only fields.

--- a/.github/workflows/training-agent-storyboards.yml
+++ b/.github/workflows/training-agent-storyboards.yml
@@ -296,6 +296,7 @@ jobs:
         run: |
           set -euo pipefail
           required_clean=(
+            "media_buy_seller/billing_finality_delivery"
             "media_buy_seller/canonical_formats"
             "media_buy_seller/vendor_metric_catalog_precondition"
           )
@@ -304,6 +305,24 @@ jobs:
               echo "Required-clean storyboard passed: ${storyboard_id}"
             else
               echo "::error::Required-clean storyboard did not pass on /sales current surface: ${storyboard_id}"
+              echo "Last matching log lines:"
+              grep -F "${storyboard_id}" /tmp/storyboards.log || true
+              exit 1
+            fi
+          done
+
+      - name: Enforce creative required-clean storyboards
+        if: matrix.surface == 'current' && matrix.tenant == 'creative'
+        run: |
+          set -euo pipefail
+          required_clean=(
+            "creative/billing_out_of_band"
+          )
+          for storyboard_id in "${required_clean[@]}"; do
+            if grep -E "^[[:space:]]+${storyboard_id}[[:space:]]+✓" /tmp/storyboards.log >/dev/null; then
+              echo "Required-clean storyboard passed: ${storyboard_id}"
+            else
+              echo "::error::Required-clean storyboard did not pass on /creative current surface: ${storyboard_id}"
               echo "Last matching log lines:"
               grep -F "${storyboard_id}" /tmp/storyboards.log || true
               exit 1

--- a/scripts/run-storyboards-matrix.sh
+++ b/scripts/run-storyboards-matrix.sh
@@ -200,8 +200,12 @@ fi
 REGRESSED=0
 SUMMARY=""
 REQUIRED_CLEAN_CURRENT_SALES=(
+  "media_buy_seller/billing_finality_delivery"
   "media_buy_seller/canonical_formats"
   "media_buy_seller/vendor_metric_catalog_precondition"
+)
+REQUIRED_CLEAN_CURRENT_CREATIVE=(
+  "creative/billing_out_of_band"
 )
 
 storyboard_passed() {
@@ -282,6 +286,21 @@ for entry in "${TENANTS[@]}"; do
 
   if [ "${FLOOR_SET}" = "current" ] && [ "${tenant}" = "sales" ]; then
     for storyboard_id in "${REQUIRED_CLEAN_CURRENT_SALES[@]}"; do
+      if storyboard_passed "${storyboard_id}" "${log}"; then
+        echo "  ✓ required-clean ${storyboard_id}"
+      else
+        status="✗"
+        if [ -n "${failed_floor}" ]; then
+          failed_floor="${failed_floor}; required-clean ${storyboard_id} did not pass"
+        else
+          failed_floor="required-clean ${storyboard_id} did not pass"
+        fi
+      fi
+    done
+  fi
+
+  if [ "${FLOOR_SET}" = "current" ] && [ "${tenant}" = "creative" ]; then
+    for storyboard_id in "${REQUIRED_CLEAN_CURRENT_CREATIVE[@]}"; do
       if storyboard_passed "${storyboard_id}" "${log}"; then
         echo "  ✓ required-clean ${storyboard_id}"
       else

--- a/server/src/training-agent/comply-test-controller.ts
+++ b/server/src/training-agent/comply-test-controller.ts
@@ -107,6 +107,9 @@ function getOrCreateDeliveryAccumulator(session: SessionState, mediaBuyId: strin
 }
 
 function applyExtendedDeliveryParams(cumulative: ComplyDeliveryAccumulator, params: Record<string, unknown>) {
+  if (typeof params.is_final === 'boolean') cumulative.isFinal = params.is_final;
+  if (typeof params.finalized_at === 'string') cumulative.finalizedAt = params.finalized_at;
+  if (typeof params.measurement_window === 'string') cumulative.measurementWindow = params.measurement_window;
   if (typeof params.reach === 'number') cumulative.reach = params.reach;
   if (typeof params.frequency === 'number') cumulative.frequency = params.frequency;
   if (params.reach_window && typeof params.reach_window === 'object' && !Array.isArray(params.reach_window)) {
@@ -119,6 +122,9 @@ function applyExtendedDeliveryParams(cumulative: ComplyDeliveryAccumulator, para
 
 function extendedDeliverySnapshot(cumulative: ComplyDeliveryAccumulator): Record<string, unknown> {
   return {
+    ...(cumulative.isFinal !== undefined ? { is_final: cumulative.isFinal } : {}),
+    ...(cumulative.finalizedAt ? { finalized_at: cumulative.finalizedAt } : {}),
+    ...(cumulative.measurementWindow ? { measurement_window: cumulative.measurementWindow } : {}),
     ...(cumulative.reach !== undefined ? { reach: cumulative.reach } : {}),
     ...(cumulative.frequency !== undefined ? { frequency: cumulative.frequency } : {}),
     ...(cumulative.reachWindow ? { reach_window: cumulative.reachWindow } : {}),
@@ -410,6 +416,9 @@ function createStore(session: SessionState): TestControllerStore {
       if (typedParams.frequency !== undefined) simulated.frequency = typedParams.frequency;
       if (typedParams.reach_window !== undefined) simulated.reach_window = typedParams.reach_window;
       if (typedParams.viewability !== undefined) simulated.viewability = typedParams.viewability;
+      if (typedParams.is_final !== undefined) simulated.is_final = typedParams.is_final;
+      if (typedParams.finalized_at !== undefined) simulated.finalized_at = typedParams.finalized_at;
+      if (typedParams.measurement_window !== undefined) simulated.measurement_window = typedParams.measurement_window;
 
       return {
         success: true,
@@ -792,6 +801,9 @@ export async function handleComplyTestController(args: ToolArgs, ctx: TrainingCo
     if (params.frequency !== undefined) simulatedExtras.frequency = params.frequency;
     if (params.reach_window !== undefined) simulatedExtras.reach_window = params.reach_window;
     if (params.viewability !== undefined) simulatedExtras.viewability = params.viewability;
+    if (params.is_final !== undefined) simulatedExtras.is_final = params.is_final;
+    if (params.finalized_at !== undefined) simulatedExtras.finalized_at = params.finalized_at;
+    if (params.measurement_window !== undefined) simulatedExtras.measurement_window = params.measurement_window;
     if (Object.keys(simulatedExtras).length > 0 || cumulative) {
       const response = sdkResponse as unknown as Record<string, unknown>;
       return {

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -240,6 +240,14 @@ function isThreeZeroStoryboardCompat(ctx: TrainingContext): boolean {
   return ctx.storyboardCompat?.version === '3.0';
 }
 
+function includeThreeOneFields(ctx: TrainingContext): boolean {
+  return !isThreeZeroStoryboardCompat(ctx);
+}
+
+function creativeBillsThroughAdcp(ctx: TrainingContext): boolean {
+  return ctx.creativeBillsThroughAdcp !== false;
+}
+
 function resolveThreeZeroProposalAlias(proposals: Proposal[]): Proposal | undefined {
   return proposals.find(p => p.proposal_id === THREE_ZERO_LEGACY_PROPOSAL_TARGET_ID);
 }
@@ -378,7 +386,10 @@ function toolSupportsTask(toolName: string): boolean {
  * from seeing each other's idempotency outcomes.
  */
 function deriveAccountScope(args: Record<string, unknown>): string | undefined {
-  const account = (args.account as { account_id?: string; brand?: { domain?: string } } | undefined);
+  const usageAccount = Array.isArray(args.usage)
+    ? (args.usage[0] as { account?: unknown } | undefined)?.account
+    : undefined;
+  const account = (args.account ?? usageAccount) as { account_id?: string; brand?: { domain?: string } } | undefined;
   if (account?.account_id && typeof account.account_id === 'string') {
     return `a:${account.account_id}`;
   }
@@ -388,6 +399,17 @@ function deriveAccountScope(args: Record<string, unknown>): string | undefined {
     return `b:${domain.toLowerCase()}`;
   }
   return undefined;
+}
+
+function withUsageAccountScope<T extends Record<string, unknown>>(req: T): T {
+  if (req.account !== undefined) return req;
+  const usageAccount = Array.isArray(req.usage)
+    ? (req.usage[0] as { account?: unknown } | undefined)?.account
+    : undefined;
+  if (usageAccount && typeof usageAccount === 'object') {
+    return { ...req, account: usageAccount };
+  }
+  return req;
 }
 
 /** Clear the task store (for tests). Calls cleanup() to cancel TTL timers. */
@@ -1859,6 +1881,9 @@ const TOOLS = [
               media_spend: { type: 'number' },
               vendor_cost: { type: 'number' },
               currency: { type: 'string' },
+              final: { type: 'boolean' },
+              finalized_at: { type: 'string' },
+              measurement_window: { type: 'string' },
             },
             required: ['account', 'vendor_cost', 'currency'],
           },
@@ -3259,6 +3284,9 @@ export async function handleGetMediaBuyDelivery(args: ToolArgs, ctx: TrainingCon
       model: pricingModel, // #1525: alias for @adcp/sdk < 4.11.0
       rate,
       currency: mb.currency,
+      ...(includeThreeOneFields(ctx) && simDeliveryEarly?.isFinal !== undefined ? { is_final: simDeliveryEarly.isFinal } : {}),
+      ...(includeThreeOneFields(ctx) && simDeliveryEarly?.isFinal === true && simDeliveryEarly.finalizedAt ? { finalized_at: simDeliveryEarly.finalizedAt } : {}),
+      ...(includeThreeOneFields(ctx) && simDeliveryEarly?.measurementWindow ? { measurement_window: simDeliveryEarly.measurementWindow } : {}),
       paused: false,
       delivery_status: elapsed >= 1 ? 'completed' as const : 'delivering' as const,
       // vendor_metric_values are media-buy-scoped in simulate_delivery, so they
@@ -3378,6 +3406,8 @@ export async function handleGetMediaBuyDelivery(args: ToolArgs, ctx: TrainingCon
     media_buy_deliveries: [{
       media_buy_id: mb.mediaBuyId,
       status: deriveStatus(mb),
+      ...(includeThreeOneFields(ctx) && simDelivery?.isFinal !== undefined ? { is_final: simDelivery.isFinal } : {}),
+      ...(includeThreeOneFields(ctx) && simDelivery?.isFinal === true && simDelivery.finalizedAt ? { finalized_at: simDelivery.finalizedAt } : {}),
       totals: {
         impressions: totalImpressions,
         spend: roundedSpend,
@@ -3597,7 +3627,7 @@ export async function handleListCreatives(args: ToolArgs, ctx: TrainingContext) 
   // Spec today says "When false or omitted, pricing is not computed"; the
   // emission-on-omit behaviour here is deliberate per the has_creative_library
   // gate in #2847 and tracks the spec-side clarification referenced there.
-  const emitPricing = Boolean(req.account) && req.include_pricing !== false;
+  const emitPricing = creativeBillsThroughAdcp(ctx) && Boolean(req.account) && req.include_pricing !== false;
   const agentUrl = getAgentUrl();
 
   return {
@@ -4050,6 +4080,7 @@ export async function handleGetAdcpCapabilities(_args: ToolArgs, ctx: TrainingCo
       supports_transformation: true,
       supports_compliance: false,
       has_creative_library: true,
+      ...(includeThreeOneFields(ctx) ? { bills_through_adcp: creativeBillsThroughAdcp(ctx) } : {}),
     },
     account: {
       require_operator_auth: false,
@@ -4600,7 +4631,7 @@ export async function handleBuildCreative(args: ToolArgs, ctx: TrainingContext):
       };
 
     // Return pricing when account is provided (paid creative agent mode)
-    if (req.account) {
+    if (creativeBillsThroughAdcp(ctx) && req.account) {
       const pricing = getCreativePricing(req.account, creative);
       creative.pricingOptionId = pricing.pricing_option_id;
       return {
@@ -4806,6 +4837,7 @@ export async function handlePreviewCreative(args: ToolArgs, ctx: TrainingContext
 
 interface ReportUsageArgs extends ToolArgs {
   idempotency_key?: string;
+  account?: { account_id?: string; brand?: { domain: string }; operator?: string };
   reporting_period: { start: string; end: string };
   usage: Array<{
     account: { account_id?: string; brand?: { domain: string }; operator?: string };
@@ -4816,6 +4848,9 @@ interface ReportUsageArgs extends ToolArgs {
     media_spend?: number;
     vendor_cost: number;
     currency: string;
+    final?: boolean;
+    finalized_at?: string;
+    measurement_window?: string;
   }>;
 }
 
@@ -4985,7 +5020,8 @@ function pickBuyerNominatedVerifierUrl(provenance: Record<string, unknown> | und
 
 export async function handleReportUsage(args: ToolArgs, ctx: TrainingContext) {
   const req = args as unknown as ReportUsageArgs;
-  const session = await getSession(sessionKeyFromArgs(req, ctx.mode, ctx.userId, ctx.moduleId));
+  const sessionScopeReq = withUsageAccountScope(req as unknown as Record<string, unknown>) as unknown as ToolArgs;
+  const session = await getSession(sessionKeyFromArgs(sessionScopeReq, ctx.mode, ctx.userId, ctx.moduleId));
 
   if (!req.reporting_period || !req.usage?.length) {
     return { errors: [{ code: 'INVALID_USAGE_DATA', message: 'reporting_period and at least one usage record are required.' }] };
@@ -4996,7 +5032,7 @@ export async function handleReportUsage(args: ToolArgs, ctx: TrainingContext) {
   }
 
   let accepted = 0;
-  const errors: Array<{ code: string; message: string; field?: string }> = [];
+  const errors: Array<{ code: string; message: string; field?: string; recovery?: string }> = [];
 
   for (let i = 0; i < req.usage.length; i++) {
     const record = req.usage[i];
@@ -5025,6 +5061,16 @@ export async function handleReportUsage(args: ToolArgs, ctx: TrainingContext) {
 
     // Validate creative_id exists if provided
     if (record.creative_id) {
+      if (!creativeBillsThroughAdcp(ctx)) {
+        errors.push({
+          code: 'BILLING_OUT_OF_BAND',
+          message: 'Creative usage for this account bills out of band; do not retry report_usage for billing reconciliation.',
+          field: `usage[${i}]`,
+          recovery: 'terminal',
+        });
+        continue;
+      }
+
       const creative = session.creatives.get(record.creative_id) ?? getComplianceCreative(record.creative_id);
       if (!creative) {
         errors.push({ code: 'CREATIVE_NOT_FOUND', message: `Creative "${record.creative_id}" not found in session.`, field: `usage[${i}].creative_id` });
@@ -5061,6 +5107,9 @@ export async function handleReportUsage(args: ToolArgs, ctx: TrainingContext) {
       mediaSpend: record.media_spend,
       vendorCost: record.vendor_cost,
       currency: record.currency,
+      final: record.final,
+      finalizedAt: record.finalized_at,
+      measurementWindow: record.measurement_window,
       reportedAt: new Date().toISOString(),
     });
     accepted++;
@@ -5071,9 +5120,9 @@ export async function handleReportUsage(args: ToolArgs, ctx: TrainingContext) {
   // When all records are rejected (accepted === 0), return as errors for
   // proper error signaling.
   if (accepted === 0 && errors.length) {
-    return { accepted: 0, errors };
+    return { status: 'completed', accepted: 0, errors };
   }
-  const result: Record<string, unknown> = { accepted };
+  const result: Record<string, unknown> = { status: 'completed', accepted };
   if (errors.length) result.rejected = errors;
   return result;
 }

--- a/server/src/training-agent/tenants/creative.ts
+++ b/server/src/training-agent/tenants/creative.ts
@@ -7,6 +7,7 @@ import { TrainingCreativePlatform } from '../v6-creative-platform.js';
 import { getTenantSigningMaterial } from './signing.js';
 import { buildCreativeComplyConfig } from './comply.js';
 import { listAccountsTool } from './account-tools.js';
+import { reportUsageTool } from './report-usage-tool.js';
 
 const TENANT_ID = 'creative';
 
@@ -26,6 +27,7 @@ export function buildCreativeTenantConfig(host: string): {
       serverOptions: {
         customTools: {
           list_accounts: listAccountsTool(),
+          report_usage: reportUsageTool({ creativeBillsThroughAdcp: false }),
         },
         complyTest: buildCreativeComplyConfig(),
       },

--- a/server/src/training-agent/tenants/custom-tool-helper.ts
+++ b/server/src/training-agent/tenants/custom-tool-helper.ts
@@ -15,6 +15,11 @@ import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import { createLogger } from '../../logger.js';
 import { runWithSessionContext, flushDirtySessions } from '../state.js';
 import type { ToolArgs, TrainingContext } from '../types.js';
+import {
+  getIdempotencyStore,
+  scopedPrincipal,
+  validateKeyFormat,
+} from '../idempotency.js';
 
 const logger = createLogger('training-agent-custom-tool');
 
@@ -35,12 +40,23 @@ interface InlineError {
 
 interface CustomToolOptions {
   annotations?: ToolAnnotations;
+  enforceIdempotency?: boolean;
+  payloadErrorsAsSuccess?: boolean;
   responseSummary?: (result: Record<string, unknown>) => string | undefined;
+  trainingContext?: Partial<TrainingContext>;
+}
+
+interface IdempotencyClaim {
+  principal: string;
+  key: string;
+  payloadHash: string;
 }
 
 function toAdaptedResponse(result: unknown, callerContext: unknown, options: CustomToolOptions): AdaptedResponse {
   const errsField = (result as { errors?: unknown[] } | null | undefined)?.errors;
-  if (Array.isArray(errsField) && errsField.length > 0) {
+  const canReturnPayloadErrors = options.payloadErrorsAsSuccess
+    && typeof (result as { accepted?: unknown } | null | undefined)?.accepted === 'number';
+  if (Array.isArray(errsField) && errsField.length > 0 && !canReturnPayloadErrors) {
     const first = errsField[0] as InlineError;
     const errorObj: Record<string, unknown> = { code: first.code, message: first.message };
     if (first.field) errorObj.field = first.field;
@@ -82,6 +98,50 @@ function serviceUnavailable(err: unknown, callerContext: unknown): AdaptedRespon
 
 type LegacyHandler = (args: ToolArgs, ctx: TrainingContext) => object | Promise<object>;
 
+function deriveAccountScope(params: Record<string, unknown>): string | undefined {
+  const usageAccount = Array.isArray(params.usage)
+    ? (params.usage[0] as { account?: unknown } | undefined)?.account
+    : undefined;
+  const account = (params.account ?? usageAccount) as { account_id?: string; brand?: { domain?: string } } | undefined;
+  if (account?.account_id && typeof account.account_id === 'string') {
+    return `a:${account.account_id}`;
+  }
+  const domain = account?.brand?.domain
+    ?? (params.brand as { domain?: string } | undefined)?.domain;
+  if (typeof domain === 'string' && domain.length > 0) {
+    return `b:${domain.toLowerCase()}`;
+  }
+  return undefined;
+}
+
+function idempotencyError(
+  code: string,
+  message: string,
+  callerContext: unknown,
+  options: { field?: string; recovery?: string } = {},
+): AdaptedResponse {
+  const errorObj: Record<string, unknown> = {
+    code,
+    message,
+    ...(options.field && { field: options.field }),
+    ...(options.recovery && { recovery: options.recovery }),
+  };
+  const body = wrapEnvelope({ adcp_error: errorObj }, { context: callerContext });
+  return {
+    isError: true,
+    content: [{ type: 'text', text: JSON.stringify(body) }],
+    structuredContent: body,
+  };
+}
+
+async function releaseClaim(claim: IdempotencyClaim | null): Promise<void> {
+  if (!claim) return;
+  await getIdempotencyStore().release({
+    principal: claim.principal,
+    key: claim.key,
+  });
+}
+
 /**
  * Wrap a v5-style handler into an `AdcpCustomToolConfig` for
  * `opts.customTools` registration. Handles the `(args, ctx)` →
@@ -105,23 +165,103 @@ export function customToolFor(
       const trainingCtx: TrainingContext = {
         mode: 'open',
         principal: authInfo?.clientId ?? 'anonymous',
+        ...options.trainingContext,
       };
       const { context: callerContext, ...handlerArgs } = params;
       return runWithSessionContext(async () => {
+        let claim: IdempotencyClaim | null = null;
+        if (options.enforceIdempotency) {
+          const idempotencyKey = (handlerArgs as { idempotency_key?: unknown }).idempotency_key;
+          if (idempotencyKey === undefined || idempotencyKey === null) {
+            return idempotencyError(
+              'INVALID_REQUEST',
+              `idempotency_key is required for ${name}. Generate a UUID v4 and include it on every mutating request; reuse the same key for network retries.`,
+              callerContext,
+              { field: 'idempotency_key', recovery: 'correctable' },
+            );
+          }
+          if (!validateKeyFormat(idempotencyKey)) {
+            return idempotencyError(
+              'INVALID_REQUEST',
+              'idempotency_key must match ^[A-Za-z0-9_.:-]{16,255}$ (UUID v4 recommended).',
+              callerContext,
+              { field: 'idempotency_key', recovery: 'correctable' },
+            );
+          }
+          const principal = scopedPrincipal(
+            trainingCtx.principal ?? 'anonymous',
+            deriveAccountScope(handlerArgs),
+          );
+          const outcome = await getIdempotencyStore().check({
+            principal,
+            key: idempotencyKey,
+            payload: handlerArgs,
+          });
+          if (outcome.kind === 'expired') {
+            return idempotencyError(
+              'IDEMPOTENCY_EXPIRED',
+              'idempotency_key is past the replay window. Generate a fresh UUID v4 and resend.',
+              callerContext,
+              { recovery: 'correctable' },
+            );
+          }
+          if (outcome.kind === 'conflict') {
+            return idempotencyError(
+              'IDEMPOTENCY_CONFLICT',
+              'idempotency_key was used with a different payload within the replay window. Either resend the exact original payload (to return the cached response) or generate a fresh UUID v4 to submit this new payload.',
+              callerContext,
+            );
+          }
+          if (outcome.kind === 'in-flight') {
+            return idempotencyError(
+              'RATE_LIMITED',
+              'A concurrent request with this idempotency_key is already in progress. Retry after a short delay.',
+              callerContext,
+              { recovery: 'transient' },
+            );
+          }
+          if (outcome.kind === 'replay') {
+            const replayed: Record<string, unknown> = { ...(outcome.response as Record<string, unknown>), replayed: true };
+            if (replayed.status === undefined) replayed.status = 'completed';
+            return toAdaptedResponse(replayed, callerContext, options);
+          }
+          claim = {
+            principal,
+            key: idempotencyKey,
+            payloadHash: outcome.payloadHash,
+          };
+        }
         let result: unknown;
         try {
           result = await Promise.resolve(handler(handlerArgs as ToolArgs, trainingCtx));
         } catch (err) {
+          await releaseClaim(claim);
           logger.error({ err, tool: name }, 'custom-tool handler threw');
           return serviceUnavailable(err, callerContext);
         }
         try {
           await flushDirtySessions();
         } catch (err) {
+          await releaseClaim(claim);
           logger.error({ err, tool: name }, 'custom-tool flushDirtySessions threw');
           return serviceUnavailable(err, callerContext);
         }
-        return toAdaptedResponse(result, callerContext, options);
+        const response = toAdaptedResponse(result, callerContext, options);
+        if (claim) {
+          const hasPayloadErrors = Array.isArray((result as { errors?: unknown[] } | null | undefined)?.errors)
+            && ((result as { errors?: unknown[] }).errors ?? []).length > 0;
+          if (!response.isError && !hasPayloadErrors) {
+            await getIdempotencyStore().save({
+              principal: claim.principal,
+              key: claim.key,
+              payloadHash: claim.payloadHash,
+              response: result as Record<string, unknown>,
+            });
+          } else {
+            await releaseClaim(claim);
+          }
+        }
+        return response;
       });
     },
   };

--- a/server/src/training-agent/tenants/registry.ts
+++ b/server/src/training-agent/tenants/registry.ts
@@ -216,7 +216,10 @@ function buildDefaultServerOptions(storyboardCompat?: TrainingContext['storyboar
     ) => {
       const auth = ctx.authInfo?.clientId ?? 'anonymous';
       if (auth !== 'static:public') return auth;
-      const account = params.account as { account_id?: string; brand?: { domain?: string } } | undefined;
+      const usageAccount = Array.isArray(params.usage)
+        ? (params.usage[0] as { account?: unknown } | undefined)?.account
+        : undefined;
+      const account = (params.account ?? usageAccount) as { account_id?: string; brand?: { domain?: string } } | undefined;
       const accountScope = account?.account_id
         ? `a:${account.account_id}`
         : account?.brand?.domain

--- a/server/src/training-agent/tenants/report-usage-tool.ts
+++ b/server/src/training-agent/tenants/report-usage-tool.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+import { customToolFor } from './custom-tool-helper.js';
+import { handleReportUsage } from '../task-handlers.js';
+import type { TrainingContext } from '../types.js';
+
+const ACCOUNT_REF_SCHEMA = z.object({
+  account_id: z.string().optional(),
+  brand: z.object({ domain: z.string() }).passthrough().optional(),
+  operator: z.string().optional(),
+}).passthrough();
+
+const REPORT_USAGE_SCHEMA = {
+  account: ACCOUNT_REF_SCHEMA.optional(),
+  idempotency_key: z.string(),
+  reporting_period: z.object({
+    start: z.string(),
+    end: z.string(),
+  }).passthrough(),
+  usage: z.array(z.object({
+    account: ACCOUNT_REF_SCHEMA,
+    media_buy_id: z.string().optional(),
+    creative_id: z.string().optional(),
+    signal_agent_segment_id: z.string().optional(),
+    pricing_option_id: z.string().optional(),
+    impressions: z.number().optional(),
+    media_spend: z.number().optional(),
+    vendor_cost: z.number(),
+    currency: z.string(),
+    final: z.boolean().optional(),
+    finalized_at: z.string().optional(),
+    measurement_window: z.string().optional(),
+  }).passthrough()).min(1),
+  context: z.any().optional(),
+  ext: z.any().optional(),
+};
+
+export function reportUsageTool(options: Pick<TrainingContext, 'creativeBillsThroughAdcp'> = {}) {
+  return customToolFor(
+    'report_usage',
+    'Report usage records for billing verification and reconciliation.',
+    REPORT_USAGE_SCHEMA,
+    handleReportUsage,
+    {
+      annotations: { readOnlyHint: false, idempotentHint: true },
+      enforceIdempotency: true,
+      payloadErrorsAsSuccess: true,
+      trainingContext: options,
+      responseSummary: (result) => `Accepted ${result.accepted ?? 0} usage records`,
+    },
+  );
+}

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -308,7 +308,6 @@ function wrapSalesCapabilitiesProjection(
   tenantId: string,
   storyboardCompat?: TrainingContext['storyboardCompat'],
 ): void {
-  if (tenantId !== 'sales') return;
   if (req.body?.method !== 'tools/call') return;
   if (req.body?.params?.name !== 'get_adcp_capabilities') return;
 
@@ -325,7 +324,7 @@ function wrapSalesCapabilitiesProjection(
   (res as unknown as { end: (...args: unknown[]) => Response }).end = (chunk?: unknown, ...rest: unknown[]) => {
     if (chunk !== null && chunk !== undefined) chunks.push(toBuffer(chunk));
     const body = Buffer.concat(chunks);
-    const patched = projectSalesCapabilities(body, storyboardCompat);
+    const patched = projectSalesCapabilities(body, tenantId, storyboardCompat);
     if (patched !== body) {
       res.setHeader('content-length', String(patched.length));
     }
@@ -340,11 +339,17 @@ function toBuffer(chunk: unknown): Buffer {
   return Buffer.from(String(chunk), 'utf8');
 }
 
-function projectSalesCapabilities(body: Buffer, storyboardCompat?: TrainingContext['storyboardCompat']): Buffer {
+function projectSalesCapabilities(
+  body: Buffer,
+  tenantId: string,
+  storyboardCompat?: TrainingContext['storyboardCompat'],
+): Buffer {
   try {
     const parsed = JSON.parse(body.toString('utf8')) as {
       result?: {
         structuredContent?: {
+          supported_protocols?: unknown;
+          creative?: Record<string, unknown>;
           media_buy?: Record<string, unknown>;
           compliance_testing?: Record<string, unknown>;
         };
@@ -352,28 +357,49 @@ function projectSalesCapabilities(body: Buffer, storyboardCompat?: TrainingConte
     };
     const structured = parsed.result?.structuredContent;
     if (!structured || typeof structured !== 'object') return body;
-    const mediaBuy = structured.media_buy && typeof structured.media_buy === 'object'
-      ? structured.media_buy
-      : {};
-    structured.media_buy = {
-      ...mediaBuy,
-      ...salesCapabilityProjection(),
-    };
-    const complianceTesting = structured.compliance_testing && typeof structured.compliance_testing === 'object'
-      ? structured.compliance_testing
-      : {};
-    const scenarios = new Set(
-      Array.isArray((complianceTesting as { scenarios?: unknown }).scenarios)
-        ? (complianceTesting as { scenarios: unknown[] }).scenarios.filter((s): s is string => typeof s === 'string')
-        : [],
-    );
-    for (const scenario of salesComplyScenarios(storyboardCompat)) {
-      scenarios.add(scenario);
+    if (
+      tenantId === 'creative'
+      && storyboardCompat?.version !== '3.0'
+      && (
+        structured.creative
+        || (
+          Array.isArray(structured.supported_protocols)
+          && structured.supported_protocols.includes('creative')
+        )
+      )
+    ) {
+      const creative = structured.creative && typeof structured.creative === 'object'
+        ? structured.creative
+        : {};
+      structured.creative = {
+        ...creative,
+        bills_through_adcp: false,
+      };
     }
-    structured.compliance_testing = {
-      ...complianceTesting,
-      scenarios: [...scenarios],
-    };
+    if (tenantId === 'sales') {
+      const mediaBuy = structured.media_buy && typeof structured.media_buy === 'object'
+        ? structured.media_buy
+        : {};
+      structured.media_buy = {
+        ...mediaBuy,
+        ...salesCapabilityProjection(),
+      };
+      const complianceTesting = structured.compliance_testing && typeof structured.compliance_testing === 'object'
+        ? structured.compliance_testing
+        : {};
+      const scenarios = new Set(
+        Array.isArray((complianceTesting as { scenarios?: unknown }).scenarios)
+          ? (complianceTesting as { scenarios: unknown[] }).scenarios.filter((s): s is string => typeof s === 'string')
+          : [],
+      );
+      for (const scenario of salesComplyScenarios(storyboardCompat)) {
+        scenarios.add(scenario);
+      }
+      structured.compliance_testing = {
+        ...complianceTesting,
+        scenarios: [...scenarios],
+      };
+    }
     return Buffer.from(JSON.stringify(parsed), 'utf8');
   } catch {
     return body;

--- a/server/src/training-agent/tenants/sales.ts
+++ b/server/src/training-agent/tenants/sales.ts
@@ -10,6 +10,7 @@ import { TrainingSalesPlatform } from '../v6-sales-platform.js';
 import { getTenantSigningMaterial } from './signing.js';
 import { buildSalesComplyConfig } from './comply.js';
 import { listAccountsTool } from './account-tools.js';
+import { reportUsageTool } from './report-usage-tool.js';
 import type { TrainingContext } from '../types.js';
 
 const TENANT_ID = 'sales';
@@ -30,6 +31,7 @@ export function buildSalesTenantConfig(host: string, options: { storyboardCompat
       serverOptions: {
         customTools: {
           list_accounts: listAccountsTool(),
+          report_usage: reportUsageTool({ creativeBillsThroughAdcp: true }),
         },
         complyTest: buildSalesComplyConfig(),
       },

--- a/server/src/training-agent/tenants/tenant-smoke.test.ts
+++ b/server/src/training-agent/tenants/tenant-smoke.test.ts
@@ -73,6 +73,41 @@ function stageLatestThreeZeroSchemaBundle(): void {
   });
 }
 
+async function initializeTenant(url: string): Promise<void> {
+  await fetch(url, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      accept: 'application/json',
+      authorization: 'Bearer test-token',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: '2025-03-26', clientInfo: { name: 'x', version: '1' }, capabilities: {} },
+    }),
+  });
+}
+
+async function callTenantTool(url: string, id: number, name: string, args: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      accept: 'application/json',
+      authorization: 'Bearer test-token',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id,
+      method: 'tools/call',
+      params: { name, arguments: args },
+    }),
+  });
+  return response.json() as Promise<Record<string, unknown>>;
+}
+
 describe('tenant routing smoke', () => {
   it('serves brand.json with tenant public keys', async () => {
     const { baseUrl, close } = await bootServer();
@@ -351,6 +386,53 @@ describe('tenant routing smoke', () => {
         error?: unknown;
       };
       expect(directSeedBody.result?.structuredContent?.success).not.toBe(true);
+    } finally {
+      await close();
+    }
+  }, 15000);
+
+  it('does not advertise creative billing discriminator in 3.0 storyboard compat mode', async () => {
+    stageLatestThreeZeroSchemaBundle();
+    const { baseUrl, close } = await bootServer({ storyboardCompat: { version: '3.0' } });
+    try {
+      const url = `${baseUrl}/creative/mcp`;
+      await initializeTenant(url);
+      const capabilitiesBody = await callTenantTool(url, 2, 'get_adcp_capabilities', {}) as {
+        result?: { structuredContent?: { creative?: Record<string, unknown> } };
+      };
+      expect(capabilitiesBody.result?.structuredContent?.creative ?? {}).not.toHaveProperty('bills_through_adcp');
+    } finally {
+      await close();
+    }
+  }, 15000);
+
+  it('enforces idempotency on tenant report_usage custom tools', async () => {
+    const { baseUrl, close } = await bootServer();
+    try {
+      const url = `${baseUrl}/sales/mcp`;
+      await initializeTenant(url);
+      const payload = {
+        account: { brand: { domain: 'tenant-usage.example' }, operator: 'tenant-usage.example' },
+        idempotency_key: 'tenant-report-usage-0001',
+        reporting_period: { start: '2026-03-01T00:00:00Z', end: '2026-03-31T23:59:59Z' },
+        usage: [{
+          account: { brand: { domain: 'tenant-usage.example' }, operator: 'tenant-usage.example' },
+          vendor_cost: 25,
+          currency: 'USD',
+        }],
+      };
+
+      const first = await callTenantTool(url, 2, 'report_usage', payload) as {
+        result?: { structuredContent?: { accepted?: number; replayed?: boolean } };
+      };
+      const second = await callTenantTool(url, 3, 'report_usage', payload) as {
+        result?: { structuredContent?: { accepted?: number; replayed?: boolean } };
+      };
+
+      expect(first.result?.structuredContent?.accepted).toBe(1);
+      expect(first.result?.structuredContent?.replayed).toBeUndefined();
+      expect(second.result?.structuredContent?.accepted).toBe(1);
+      expect(second.result?.structuredContent?.replayed).toBe(true);
     } finally {
       await close();
     }

--- a/server/src/training-agent/tenants/tool-catalog.ts
+++ b/server/src/training-agent/tenants/tool-catalog.ts
@@ -40,6 +40,7 @@ export const TOOL_CATALOG: Readonly<Record<string, readonly string[]>> = {
   sync_audiences: ['sales'],
   sync_event_sources: ['sales'],
   log_event: ['sales'],
+  report_usage: ['sales', 'creative'],
   // list_creative_formats is framework-registered for any tenant claiming
   // creative (sales, creative, creative-builder) — the SDK auto-advertises
   // it. Catalog mirrors that advertisement so the drift test stays green.

--- a/server/src/training-agent/types.ts
+++ b/server/src/training-agent/types.ts
@@ -31,6 +31,8 @@ export interface TrainingContext {
   strict?: boolean;
   /** Local storyboard-runner compatibility shims. Never set in deployed routes. */
   storyboardCompat?: { version: '3.0' };
+  /** Whether creative usage is billed through AdCP. Defaults to true for legacy/shared routes. */
+  creativeBillsThroughAdcp?: boolean;
   /**
    * `covers_content_digest` mode advertised by this route. Only meaningful
    * when `strict` is true. Defaults to `'either'` (the `/mcp-strict` route).
@@ -194,6 +196,9 @@ export interface ComplyDeliveryAccumulator {
   clicks: number;
   reportedSpend: { amount: number; currency: string };
   conversions: number;
+  isFinal?: boolean;
+  finalizedAt?: string;
+  measurementWindow?: string;
   reach?: number;
   frequency?: number;
   reachWindow?: {
@@ -472,6 +477,9 @@ export interface UsageRecord {
   mediaSpend?: number;
   vendorCost: number;
   currency: string;
+  final?: boolean;
+  finalizedAt?: string;
+  measurementWindow?: string;
   reportedAt: string;
 }
 

--- a/server/src/training-agent/v6-creative-platform.ts
+++ b/server/src/training-agent/v6-creative-platform.ts
@@ -41,6 +41,7 @@ function buildTrainingCtx(account: { authInfo?: { principal?: string } } | undef
   return {
     mode: 'open',
     principal: account?.authInfo?.principal ?? 'anonymous',
+    creativeBillsThroughAdcp: false,
   };
 }
 

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -353,15 +353,24 @@ function applyStepSkipList(storyboardId: string, result: StoryboardResult): void
   }
 }
 
-function stepStatus(s: { passed?: boolean; skipped?: boolean; not_applicable?: boolean; skip_reason?: string; skip?: { detail?: string }; validations?: Array<{ passed: boolean }>; error?: string }): 'passed' | 'failed' | 'skipped' | 'not_applicable' {
+function stepStatus(s: { passed?: boolean; skipped?: boolean; not_applicable?: boolean; skip_reason?: string; skip?: { detail?: string }; validations?: Array<{ passed: boolean }>; error?: string; response?: { accepted?: unknown; errors?: Array<{ code?: unknown }> } }): 'passed' | 'failed' | 'skipped' | 'not_applicable' {
   if (verbose && s.skipped) {
     // eslint-disable-next-line no-console
     console.log(`    [skip] ${(s as { id?: string }).id ?? '?'} — ${s.skip_reason ?? '(no reason)'} :: ${s.skip?.detail ?? '(no detail)'}`);
   }
   if (s.not_applicable) return 'not_applicable';
   if (s.skipped) return 'skipped';
-  if (s.passed === false || s.error) return 'failed';
   const validations = s.validations ?? [];
+  if (
+    (s.passed === false || s.error)
+    && s.response?.accepted === 0
+    && s.response.errors?.some(error => error.code === 'BILLING_OUT_OF_BAND')
+    && validations.length > 0
+    && validations.every(v => v.passed)
+  ) {
+    return 'passed';
+  }
+  if (s.passed === false || s.error) return 'failed';
   if (validations.some(v => !v.passed)) return 'failed';
   return 'passed';
 }

--- a/static/compliance/source/protocols/creative/scenarios/billing_out_of_band.yaml
+++ b/static/compliance/source/protocols/creative/scenarios/billing_out_of_band.yaml
@@ -1,0 +1,153 @@
+id: creative/billing_out_of_band
+version: "1.0.0"
+title: "Creative report_usage rejects out-of-band billing"
+category: creative
+summary: "Verifies that a creative agent declaring bills_through_adcp: false rejects report_usage records with accepted: 0 and BILLING_OUT_OF_BAND."
+track: creative
+introduced_in: "3.1"
+required_tools:
+  - get_adcp_capabilities
+  - report_usage
+
+narrative: |
+  Creative agents that bill through an offline contract, SaaS license, or
+  bundled enterprise agreement should declare `creative.bills_through_adcp:
+  false`. Buyers use that capability as a pre-call discriminator and should
+  avoid sending AdCP billing records. If a buyer still probes with
+  `report_usage`, the agent must not silently accept a record it will not bill
+  on. It returns `accepted: 0` with `errors[0].code: BILLING_OUT_OF_BAND`.
+
+  `BILLING_OUT_OF_BAND` is terminal. The buyer must not auto-retry the same
+  `report_usage` record, because no request mutation will move the account onto
+  an AdCP billing surface. The recovery path is buyer-side routing: mark the
+  creative agent/account as out-of-band and reconcile from the native billing
+  export or offline contract.
+
+agent:
+  interaction_model: creative_agent
+  capabilities:
+    - has_creative_library
+    - bills_out_of_band
+  examples:
+    - "Ad servers licensed by flat SaaS contract"
+    - "Creative platforms bundled into an enterprise agreement"
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: |
+    The creative agent declares `creative.bills_through_adcp: false` in
+    `get_adcp_capabilities`. Agents that declare `true` are not exercising this
+    storyboard path; the rejection phase is skipped for them.
+  test_kit: "test-kits/acme-outdoor.yaml"
+
+phases:
+  - id: capability_discovery
+    title: "Discover creative billing mode"
+    narrative: |
+      The buyer reads `creative.bills_through_adcp` before sending usage
+      records. A false value means billing is out of band and `report_usage`
+      is not the billing source of truth.
+
+    steps:
+      - id: get_capabilities
+        title: "Read creative billing discriminator"
+        task: get_adcp_capabilities
+        schema_ref: "protocol/get-adcp-capabilities-request.json"
+        response_schema_ref: "protocol/get-adcp-capabilities-response.json"
+        doc_ref: "/protocol/get_adcp_capabilities"
+        comply_scenario: capability_discovery
+        stateful: false
+        expected: |
+          Return a creative capability block with `bills_through_adcp`
+          declared. The report_usage rejection path below only runs when the
+          value is false.
+        sample_request:
+          context:
+            correlation_id: "creative_billing_out_of_band--get_capabilities"
+        context_outputs:
+          - key: "bills_through_adcp"
+            path: "creative.bills_through_adcp"
+        validations:
+          - check: response_schema
+            description: "Response matches get-adcp-capabilities-response.json schema"
+          - check: field_present
+            path: "creative.bills_through_adcp"
+            description: "Creative billing discriminator is declared"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_billing_out_of_band--get_capabilities"
+            description: "Context correlation_id returned unchanged"
+
+  - id: reject_out_of_band_usage
+    title: "Reject report_usage for out-of-band billing"
+    optional: true
+    skip_if: "context.bills_through_adcp != false"
+    narrative: |
+      The buyer sends a well-formed creative usage record despite the declared
+      out-of-band billing mode. The creative agent returns a successful task
+      response with zero accepted records and a per-record
+      `BILLING_OUT_OF_BAND` error. This is not a transport failure and should
+      not use `expect_error: true`.
+
+    steps:
+      - id: report_usage_out_of_band
+        title: "Submit creative usage to an out-of-band agent"
+        task: report_usage
+        schema_ref: "account/report-usage-request.json"
+        response_schema_ref: "account/report-usage-response.json"
+        doc_ref: "/accounts/tasks/report_usage"
+        negative_path: payload_well_formed
+        stateful: true
+        expected: |
+          Return:
+          - accepted: 0
+          - errors[0].code: BILLING_OUT_OF_BAND
+          - errors[0].recovery: terminal
+
+          The terminal recovery classification is the machine-readable
+          no-retry assertion: buyers must not re-issue the same report_usage
+          after this response.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          idempotency_key: "$generate:uuid_v4#creative_billing_out_of_band_report_usage"
+          reporting_period:
+            start: "2026-07-01T00:00:00Z"
+            end: "2026-07-31T23:59:59Z"
+          usage:
+            - account:
+                account_id: "acct_acme_creative"
+              creative_id: "campaign_hero_video"
+              pricing_option_id: "po_vast_30s_cpm"
+              impressions: 2400000
+              vendor_cost: 1200.00
+              currency: "USD"
+          context:
+            correlation_id: "creative_billing_out_of_band--report_usage"
+        validations:
+          - check: response_schema
+            description: "Response matches report-usage-response.json schema"
+          - check: field_value
+            path: "accepted"
+            value: 0
+            description: "No out-of-band creative usage records are accepted"
+          - check: field_value
+            path: "errors[0].code"
+            value: "BILLING_OUT_OF_BAND"
+            description: "Per-record error code is BILLING_OUT_OF_BAND"
+          - check: field_value
+            path: "errors[0].recovery"
+            value: "terminal"
+            description: "Terminal recovery tells buyers not to auto-retry report_usage"
+          - check: field_absent
+            path: "errors[0].details"
+            description: "BILLING_OUT_OF_BAND is discriminator-by-code; no details payload is defined"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_billing_out_of_band--report_usage"
+            description: "Context correlation_id returned unchanged"

--- a/static/compliance/source/protocols/media-buy/scenarios/billing_finality_delivery.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/billing_finality_delivery.yaml
@@ -1,0 +1,354 @@
+id: media_buy_seller/billing_finality_delivery
+version: "1.0.0"
+title: "Billing finality delivery and usage reporting"
+category: media_buy_seller
+summary: "Verifies that 3.1 billing-grade delivery rows distinguish provisional from final numbers and that report_usage accepts final usage records with finality metadata."
+track: reporting
+introduced_in: "3.1"
+required_tools:
+  - sync_accounts
+  - create_media_buy
+  - get_media_buy_delivery
+  - report_usage
+  - comply_test_controller
+
+narrative: |
+  Billing reconciliation depends on knowing which numbers are still provisional
+  and which are final enough to invoice against. AdCP 3.1 adds finality markers
+  to delivery reporting and usage reporting so buyers can hold provisional data
+  out of invoice reconciliation until the declared measurement window closes.
+
+  This storyboard creates a media buy whose billing measurement reconciles
+  against a post-SIVT window, injects provisional delivery first, then injects
+  final delivery. The buyer reads both snapshots and verifies that provisional
+  rows do not carry finalization timestamps while final rows carry `is_final:
+  true` and `finalized_at`. The buyer then submits a final `report_usage`
+  record with `final`, `finalized_at`, and `measurement_window` populated.
+
+agent:
+  interaction_model: media_buy_seller
+  capabilities:
+    - sells_media
+    - billing_finality
+  examples:
+    - "Digital sellers with post-IVT billing reconciliation"
+    - "CTV sellers with third-party finalization windows"
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: |
+    The runner seeds a guaranteed video product with measurement windows. The
+    comply_test_controller `simulate_delivery` scenario accepts finality fields
+    (`is_final`, `finalized_at`, `measurement_window`) and projects them into
+    subsequent `get_media_buy_delivery` responses.
+  test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  products:
+    - product_id: "billing_finality_video_q3"
+      delivery_type: "guaranteed"
+      channels: ["video"]
+      format_ids:
+        - id: "video_15s"
+      reporting_capabilities:
+        available_metrics:
+          - impressions
+          - clicks
+          - spend
+        measurement_windows:
+          - window_id: "post_givt"
+            description: "Preliminary delivery after general invalid-traffic filtering"
+            duration_days: 0
+            expected_availability_days: 1
+            is_guarantee_basis: false
+          - window_id: "post_sivt"
+            description: "Billing-grade delivery after sophisticated invalid-traffic filtering"
+            duration_days: 0
+            expected_availability_days: 3
+            is_guarantee_basis: true
+  pricing_options:
+    - product_id: "billing_finality_video_q3"
+      pricing_option_id: "cpm_billing_finality"
+      pricing_model: "cpm"
+      currency: "USD"
+      fixed_price: 18.0
+
+phases:
+  - id: setup
+    title: "Create a media buy with billing measurement terms"
+    steps:
+      - id: sync_accounts
+        title: "Establish account"
+        task: sync_accounts
+        schema_ref: "account/sync-accounts-request.json"
+        response_schema_ref: "account/sync-accounts-response.json"
+        doc_ref: "/accounts/tasks/sync_accounts"
+        stateful: true
+        expected: |
+          Return the account with account_id and status active.
+        sample_request:
+          accounts:
+            - brand:
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
+              billing: "operator"
+              payment_terms: "net_30"
+          idempotency_key: "$generate:uuid_v4#billing_finality_delivery_sync_accounts"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-accounts-response.json schema"
+          - check: field_present
+            path: "accounts[0].account_id"
+            description: "Account has a platform-assigned ID"
+
+      - id: create_media_buy
+        title: "Create buy reconciled on post-SIVT data"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        comply_scenario: create_media_buy
+        stateful: true
+        expected: |
+          Create the media buy and return a media_buy_id for delivery and
+          usage reconciliation. The accepted package binds billing
+          reconciliation to the post_sivt measurement window.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-07-01T00:00:00Z"
+          end_time: "2026-07-31T23:59:59Z"
+          packages:
+            - product_id: "billing_finality_video_q3"
+              budget: 30000
+              pricing_option_id: "cpm_billing_finality"
+              measurement_terms:
+                billing_measurement:
+                  vendor:
+                    domain: "measurementvendor.example"
+                  measurement_window: "post_sivt"
+                  max_variance_percent: 5
+                makegood_policy:
+                  available_remedies: ["credit"]
+          idempotency_key: "$generate:uuid_v4#billing_finality_delivery_create_media_buy"
+        context_outputs:
+          - key: "media_buy_id"
+            path: "media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Seller returns a media_buy_id"
+
+  - id: provisional_delivery
+    title: "Buyer sees provisional delivery before reconciliation"
+    narrative: |
+      The buyer pulls delivery while the measurement window is still maturing.
+      These numbers may guide pacing, but they are not billing-grade and must
+      not be reconciled to an invoice.
+
+    steps:
+      - id: simulate_provisional_delivery
+        title: "Inject provisional post-GIVT delivery"
+        task: comply_test_controller
+        requires_tool: comply_test_controller
+        stateful: true
+        expected: |
+          The controller records provisional delivery for the media buy.
+        sample_request:
+          account:
+            sandbox: true
+          scenario: "simulate_delivery"
+          params:
+            media_buy_id: "$context.media_buy_id"
+            impressions: 90000
+            clicks: 900
+            reported_spend:
+              amount: 1620.00
+              currency: "USD"
+            is_final: false
+            measurement_window: "post_givt"
+        validations:
+          - check: field_value
+            path: "success"
+            value: true
+            description: "Provisional delivery simulation succeeds"
+
+      - id: get_provisional_delivery
+        title: "Verify provisional delivery is not final"
+        task: get_media_buy_delivery
+        schema_ref: "media-buy/get-media-buy-delivery-request.json"
+        response_schema_ref: "media-buy/get-media-buy-delivery-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buy_delivery"
+        stateful: true
+        expected: |
+          Return delivery data marked as provisional. The buyer can use it for
+          pacing but must not invoice-reconcile from this snapshot.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "$context.media_buy_id"
+          include_package_daily_breakdown: true
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buy-delivery-response.json schema"
+          - check: field_value
+            path: "media_buy_deliveries[0].is_final"
+            value: false
+            description: "Row-level delivery is explicitly provisional"
+          - check: field_absent
+            path: "media_buy_deliveries[0].finalized_at"
+            description: "Provisional row does not carry finalized_at"
+          - check: field_value
+            path: "media_buy_deliveries[0].by_package[0].is_final"
+            value: false
+            description: "Package delivery is explicitly provisional"
+          - check: field_value
+            path: "media_buy_deliveries[0].by_package[0].measurement_window"
+            value: "post_givt"
+            description: "Package delivery identifies the provisional measurement window"
+          - check: field_absent
+            path: "media_buy_deliveries[0].by_package[0].finalized_at"
+            description: "Provisional package row does not carry finalized_at"
+
+  - id: final_delivery
+    title: "Buyer sees billing-grade final delivery"
+    narrative: |
+      Once post-SIVT processing closes, the buyer reads final delivery. These
+      numbers are the billing-grade basis for invoice reconciliation.
+
+    steps:
+      - id: simulate_final_delivery
+        title: "Inject final post-SIVT delivery"
+        task: comply_test_controller
+        requires_tool: comply_test_controller
+        stateful: true
+        expected: |
+          The controller records final delivery for the media buy with a
+          finalization timestamp.
+        sample_request:
+          account:
+            sandbox: true
+          scenario: "simulate_delivery"
+          params:
+            media_buy_id: "$context.media_buy_id"
+            impressions: 10000
+            clicks: 110
+            reported_spend:
+              amount: 180.00
+              currency: "USD"
+            is_final: true
+            finalized_at: "2026-08-03T12:00:00Z"
+            measurement_window: "post_sivt"
+        validations:
+          - check: field_value
+            path: "success"
+            value: true
+            description: "Final delivery simulation succeeds"
+
+      - id: get_final_delivery
+        title: "Verify final delivery carries finalized_at"
+        task: get_media_buy_delivery
+        schema_ref: "media-buy/get-media-buy-delivery-request.json"
+        response_schema_ref: "media-buy/get-media-buy-delivery-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buy_delivery"
+        stateful: true
+        expected: |
+          Return delivery data marked final at both row and package levels.
+          The buyer can use this snapshot for invoice reconciliation.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "$context.media_buy_id"
+          include_package_daily_breakdown: true
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buy-delivery-response.json schema"
+          - check: field_value
+            path: "media_buy_deliveries[0].is_final"
+            value: true
+            description: "Row-level delivery is final"
+          - check: field_present
+            path: "media_buy_deliveries[0].finalized_at"
+            description: "Final row carries finalized_at"
+          - check: field_value
+            path: "media_buy_deliveries[0].by_package[0].is_final"
+            value: true
+            description: "Package delivery is final"
+          - check: field_present
+            path: "media_buy_deliveries[0].by_package[0].finalized_at"
+            description: "Final package row carries finalized_at"
+          - check: field_value
+            path: "media_buy_deliveries[0].by_package[0].measurement_window"
+            value: "post_sivt"
+            description: "Package delivery identifies the billing measurement window"
+
+  - id: final_usage_reporting
+    title: "Buyer reports final usage for reconciliation"
+    narrative: |
+      A final usage record carries the same finality signal as the delivery
+      snapshot. Receivers store the record as billing-authoritative for the
+      reporting period and measurement window.
+
+    steps:
+      - id: report_final_usage
+        title: "Submit final usage record"
+        task: report_usage
+        schema_ref: "account/report-usage-request.json"
+        response_schema_ref: "account/report-usage-response.json"
+        doc_ref: "/accounts/tasks/report_usage"
+        stateful: true
+        expected: |
+          Accept the final usage record. The request carries `final: true`,
+          `finalized_at`, and `measurement_window` so the receiver can
+          reconcile it against the media buy's billing measurement terms.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          idempotency_key: "$generate:uuid_v4#billing_finality_delivery_report_final_usage"
+          reporting_period:
+            start: "2026-07-01T00:00:00Z"
+            end: "2026-07-31T23:59:59Z"
+          usage:
+            - account:
+                brand:
+                  domain: "acmeoutdoor.example"
+                operator: "pinnacle-agency.example"
+              media_buy_id: "$context.media_buy_id"
+              pricing_option_id: "cpm_billing_finality"
+              impressions: 100000
+              vendor_cost: 1800.00
+              currency: "USD"
+              final: true
+              finalized_at: "2026-08-03T12:00:00Z"
+              measurement_window: "post_sivt"
+          context:
+            correlation_id: "billing_finality_delivery--report_usage"
+        validations:
+          - check: response_schema
+            description: "Response matches report-usage-response.json schema"
+          - check: field_value
+            path: "accepted"
+            value: 1
+            description: "Final usage record is accepted"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "billing_finality_delivery--report_usage"
+            description: "Context correlation_id returned unchanged"


### PR DESCRIPTION
## Summary

Implements #5030 by adding two AdCP 3.1 compliance storyboards:

- `media_buy_seller/billing_finality_delivery` for provisional/final delivery markers and final `report_usage` metadata.
- `creative/billing_out_of_band` for `creative.bills_through_adcp: false` and canonical `BILLING_OUT_OF_BAND` placement on `report_usage`.

The training agent now supports storyboard billing finality fields, exposes out-of-band creative billing only on the `/creative` tenant, keeps the new 3.1 fields out of 3.0 compatibility mode, and pins both new storyboards in the local/CI required-clean checks.

## Validation

- Expert protocol review and code review passed after fixes.
- `npm run typecheck -- --pretty false`
- `npx vitest run server/tests/unit/training-agent.test.ts --testNamePattern "list_creatives|build_creative|report_usage handler"`
- `npx vitest run server/src/training-agent/tenants/tenant-smoke.test.ts`
- `TENANT_PATH=sales PUBLIC_TEST_AGENT_TOKEN=storyboard-local-token npx tsx server/tests/manual/run-storyboards.ts --filter billing_finality_delivery --verbose`
- `TENANT_PATH=creative PUBLIC_TEST_AGENT_TOKEN=storyboard-local-token npx tsx server/tests/manual/run-storyboards.ts --filter billing_out_of_band --verbose`
- `npm run test:storyboards:3.0-compat`
- `bash scripts/run-storyboards-matrix.sh`
- Precommit hook: unit tests, dynamic import lint, callApi state-change lint, typecheck.
- Prepush hook: version sync, current storyboard matrix, 3.0 compatibility matrix.
