### PR TITLE
fix(registry): serve enriched brand.json with X-AAO-Source provenance header

### DIFF
--- a/.changeset/fix-brand-viewer-enriched-link.md
+++ b/.changeset/fix-brand-viewer-enriched-link.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix(registry): serve enriched-source brand.json under `/brands/:domain/brand.json` with provenance signaled via the new `X-AAO-Source` response header. Previously the gate 404'd enriched rows, breaking the "Community brand.json" link on the brand viewer for every Brandfetch-derived brand (e.g. sbs.com.au). The viewer now labels the link and the badge by actual source — "Community contributed" / "Community brand.json" for community rows, "Enriched" / "Enriched brand.json" for Brandfetch-derived rows — so the UI no longer claims community attestation for unedited enrichments.

--- a/server/public/brand-viewer.html
+++ b/server/public/brand-viewer.html
@@ -1299,7 +1299,7 @@
               <span id="community-brand-domain" style="color: var(--color-text-muted); font-size: var(--text-sm);"></span>
             </div>
             <div style="display: flex; gap: var(--space-2); align-items: center;">
-              <span style="font-size: var(--text-xs); background: var(--color-purple-100); color: var(--color-purple-700); padding: 2px 8px; border-radius: var(--radius-full);">Community contributed</span>
+              <span id="community-brand-source-badge" style="font-size: var(--text-xs); background: var(--color-purple-100); color: var(--color-purple-700); padding: 2px 8px; border-radius: var(--radius-full);">Community contributed</span>
               <button id="edit-brand-btn" class="hidden" onclick="showEditForm()" style="padding: 4px 12px; font-size: var(--text-xs); font-weight: var(--font-semibold); background: var(--color-brand); color: white; border: none; border-radius: var(--radius-md); cursor: pointer; transition: var(--transition-all);">Edit</button>
               <button id="upload-logo-hero-btn" class="hidden" onclick="showUploadModal()" style="padding: 4px 12px; font-size: var(--text-xs); font-weight: var(--font-semibold); background: var(--color-bg-subtle); color: var(--color-text-secondary); border: var(--border-1) solid var(--color-border); border-radius: var(--radius-md); cursor: pointer; transition: var(--transition-all);">Upload logo</button>
             </div>
@@ -3357,6 +3357,22 @@
             document.getElementById('community-brand-name').textContent = brandInfo.brand_name || domain;
             document.getElementById('community-brand-domain').textContent = domain;
 
+            // Badge reflects actual provenance — "Community contributed" only when
+            // a human has curated the row; "Enriched" for Brandfetch-derived data
+            // that no one has edited yet.
+            const sourceBadge = document.getElementById('community-brand-source-badge');
+            if (sourceBadge) {
+              if (brandInfo.source_type === 'enriched') {
+                sourceBadge.textContent = 'Enriched';
+                sourceBadge.style.background = 'var(--color-bg-subtle)';
+                sourceBadge.style.color = 'var(--color-text-secondary)';
+              } else {
+                sourceBadge.textContent = 'Community contributed';
+                sourceBadge.style.background = 'var(--color-purple-100)';
+                sourceBadge.style.color = 'var(--color-purple-700)';
+              }
+            }
+
             // Update hero
             document.getElementById('hero-title').textContent = brandInfo.brand_name || domain;
 
@@ -3393,11 +3409,15 @@
                 <div class="community-info-value"><a href="https://${escapeAttr(domain)}" target="_blank" style="color: var(--color-brand); text-decoration: none;">${escapeHtml(domain)}</a></div>
               </div>`;
 
-            // Community-hosted brand.json URL
+            // AAO-hosted brand.json URL. The gate at /brands/:domain/brand.json serves
+            // community, enriched, and brand_json sources alike, with an X-AAO-Source
+            // header marking provenance. The label here reflects the actual source so
+            // we don't promise "community" data when the underlying row is enriched.
             const hostedBrandJsonUrl = `${window.location.origin}/brands/${encodeURIComponent(domain)}/brand.json`;
+            const linkLabel = brandInfo.source_type === 'enriched' ? 'Enriched brand.json' : 'Community brand.json';
             gridHtml += `
               <div class="community-info-item">
-                <div class="community-info-label">Community brand.json</div>
+                <div class="community-info-label">${escapeHtml(linkLabel)}</div>
                 <div class="community-info-value"><a href="${escapeAttr(hostedBrandJsonUrl)}" target="_blank" style="color: var(--color-brand); text-decoration: none; word-break: break-all;">${escapeHtml(hostedBrandJsonUrl)}</a></div>
               </div>`;
 

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -1098,11 +1098,12 @@ export class HTTPServer {
         const brand = await this.brandDb.getDiscoveredBrandByDomain(domain);
         if (!brand || brand.is_public === false) return res.status(404).json({ error: 'Brand not found' });
 
-        // Only serve brand_json and community source types. Enriched (Brandfetch) entries are
-        // not brand-attested — serving them under this URL would misrepresent third-party data
-        // as brand-authoritative. editDiscoveredBrand promotes enriched→community on first
-        // human edit, so curated rows land here under the community type.
-        if (brand.source_type !== 'brand_json' && brand.source_type !== 'community') {
+        // Serve brand_json (brand-attested), community (human-curated), and enriched
+        // (Brandfetch-derived) source types. Provenance is signaled to consumers via
+        // the X-AAO-Source response header so agents can decide how much trust to
+        // place in each row — the JSON body itself stays clean of non-spec fields.
+        const ALLOWED_SOURCE_TYPES = new Set(['brand_json', 'community', 'enriched']);
+        if (!ALLOWED_SOURCE_TYPES.has(brand.source_type as string)) {
           return res.status(404).json({ error: 'Brand not found' });
         }
 
@@ -1121,6 +1122,7 @@ export class HTTPServer {
 
         res.setHeader('Content-Type', 'application/json');
         res.setHeader('Cache-Control', 'public, max-age=300');
+        res.setHeader('X-AAO-Source', brand.source_type as string);
         return res.json(brandJson);
       } catch (error) {
         logger.error({ err: error, domain }, 'Failed to serve brand.json');

--- a/server/tests/unit/brand-json-endpoint-gate.test.ts
+++ b/server/tests/unit/brand-json-endpoint-gate.test.ts
@@ -1,14 +1,16 @@
 /**
  * Unit tests for GET /brands/:domain/brand.json gate behavior.
  *
- * Pins the source_type gate from #3529 (no enriched data served under a
- * brand-attested URL) while confirming that community-attested manifests
- * with a flat shape — the shape our edit UI actually writes — are served.
+ * Pins the gate's source_type acceptance set and provenance signaling.
+ * The endpoint serves brand_json, community, and enriched rows; consumers
+ * tell them apart via the X-AAO-Source response header. The JSON body itself
+ * stays free of non-spec fields so it round-trips as a valid brand.json.
  *
- * The earlier structural-shape check (#3529) over-rotated and 404'd every
- * AAO-hosted brand whose manifest didn't wrap itself in house/brands/agents/
- * brand_agent/authoritative_location, which broke scope3.com and fandom.com
- * post-merge. This test pins that those flat community manifests are served.
+ * History: the original shape-based gate (#3529) was tightened to a source_type
+ * allowlist that excluded enriched, which then made the "Community brand.json"
+ * link in the viewer 404 for every Brandfetch-derived row (sbs.com.au, etc.).
+ * Enriched is now served with X-AAO-Source: enriched so agents can decide
+ * how much trust to place in it.
  */
 
 import { describe, it, expect, vi } from 'vitest';
@@ -25,7 +27,8 @@ function mountGate(brandDb: {
     const domain = req.params.domain.toLowerCase();
     const brand: any = await brandDb.getDiscoveredBrandByDomain(domain);
     if (!brand || brand.is_public === false) return res.status(404).json({ error: 'Brand not found' });
-    if (brand.source_type !== 'brand_json' && brand.source_type !== 'community') {
+    const ALLOWED_SOURCE_TYPES = new Set(['brand_json', 'community', 'enriched']);
+    if (!ALLOWED_SOURCE_TYPES.has(brand.source_type)) {
       return res.status(404).json({ error: 'Brand not found' });
     }
     const manifest = brand.brand_manifest as Record<string, unknown> | undefined;
@@ -38,6 +41,7 @@ function mountGate(brandDb: {
       typeof manifest.$schema === 'string' && manifest.$schema.startsWith('https://')
         ? { ...manifest }
         : { $schema: schemaUrl, ...manifest };
+    res.setHeader('X-AAO-Source', brand.source_type);
     return res.json(brandJson);
   });
   return app;
@@ -50,15 +54,29 @@ describe('GET /brands/:domain/brand.json gate', () => {
     expect(res.status).toBe(404);
   });
 
-  it('404s enriched (Brandfetch) rows so third-party data is not served as brand-attested', async () => {
+  it('serves enriched (Brandfetch) rows with X-AAO-Source: enriched so agents can tell unattested data apart from brand-attested', async () => {
     const app = mountGate({
       getDiscoveredBrandByDomain: vi.fn().mockResolvedValue({
         is_public: true,
         source_type: 'enriched',
-        brand_manifest: { name: 'Whatever', logos: [], colors: {} },
+        brand_manifest: { name: 'SBS Australia', url: 'https://sbs.com.au', logos: [], colors: { accent: '#FCB502' } },
       }),
     });
-    const res = await request(app).get('/brands/enriched.example/brand.json');
+    const res = await request(app).get('/brands/sbs.com.au/brand.json');
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('SBS Australia');
+    expect(res.headers['x-aao-source']).toBe('enriched');
+  });
+
+  it('404s unknown source_types (e.g. hosted) — only the explicit allowlist is served', async () => {
+    const app = mountGate({
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue({
+        is_public: true,
+        source_type: 'hosted',
+        brand_manifest: { name: 'Hosted' },
+      }),
+    });
+    const res = await request(app).get('/brands/hosted.example/brand.json');
     expect(res.status).toBe(404);
   });
 
@@ -82,6 +100,7 @@ describe('GET /brands/:domain/brand.json gate', () => {
     expect(res.body.name).toBe('Scope3');
     expect(res.body.colors.accent).toBe('#dcfc01');
     expect(res.body.$schema).toBe('https://adcontextprotocol.org/schemas/v3/brand.json');
+    expect(res.headers['x-aao-source']).toBe('community');
   });
 
   it('serves brand_json source rows untouched', async () => {
@@ -95,6 +114,7 @@ describe('GET /brands/:domain/brand.json gate', () => {
     const res = await request(app).get('/brands/acme.com/brand.json');
     expect(res.status).toBe(200);
     expect(res.body.house.domain).toBe('acme.com');
+    expect(res.headers['x-aao-source']).toBe('brand_json');
   });
 
   it('404s community brands still pending review', async () => {


### PR DESCRIPTION
## Summary

- `/brands/:domain/brand.json` previously 404'd enriched (Brandfetch-derived) rows on the grounds that they aren't brand-attested, while the brand viewer at `/brand/view/:domain` happily rendered the same data. Result: a broken "Community brand.json" link on every Brandfetch-derived brand (sbs.com.au being the case that surfaced this).
- The gate now serves `brand_json`, `community`, and `enriched` source types alike, with provenance signaled via a new `X-AAO-Source` response header so agents can decide trust without the body carrying non-spec fields.
- The brand viewer's hardcoded "Community contributed" badge and "Community brand.json" link label are now driven by `source_type` — "Enriched" / "Enriched brand.json" for Brandfetch-derived rows, "Community contributed" / "Community brand.json" for human-curated rows. UI no longer promises community attestation for unedited enrichments.

## Test plan

- [x] `npx vitest run server/tests/unit/brand-json-endpoint-gate.test.ts` — 8/8 pass (flipped enriched-404 pin to enriched-200-with-header pin; added `X-AAO-Source` header assertions on community + brand_json cases; added unknown-source-type 404 pin)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [ ] After deploy: `curl -I https://agenticadvertising.org/brands/sbs.com.au/brand.json` returns 200 with `X-AAO-Source: enriched`
- [ ] After deploy: brand viewer page for sbs.com.au shows the link as clickable and labeled "Enriched brand.json"; badge reads "Enriched"
- [ ] After deploy: brand viewer page for a community-source brand still shows "Community contributed" badge and "Community brand.json" link label