### PR TITLE
[codex] Fix creative lifecycle display baseline

### DIFF
--- a/.changeset/4479-creative-lifecycle-display-only.md
+++ b/.changeset/4479-creative-lifecycle-display-only.md
@@ -1,0 +1,18 @@
+---
+---
+
+fix(compliance): make `creative_lifecycle` applicable to display-only creative agents.
+
+The generic creative lifecycle storyboard no longer exercises video-specific
+creative sync or VAST tag generation. It now syncs and previews a display
+creative only. VAST tag generation remains under the existing
+`creative-ad-server` specialism where agents explicitly claim that sub-modality.
+
+This prevents display-only creative agents that truthfully advertise no video
+formats from failing the baseline `creative_lifecycle` storyboard on
+`video_30s` / `vast_30s` requests. The baseline still uses the existing
+`display_300x250` sample shape; this change removes the video-specific
+applicability failure without adding a one-off test-kit gate or narrowing the
+preloaded creative-ad-server specialism.
+
+Closes #4479.

--- a/static/compliance/source/protocols/creative/index.yaml
+++ b/static/compliance/source/protocols/creative/index.yaml
@@ -2,7 +2,7 @@ id: creative_lifecycle
 version: "1.0.0"
 title: "Creative lifecycle"
 category: creative_lifecycle
-summary: "Full creative lifecycle on a stateful platform: sync multiple creatives, list with filtering, build and preview across formats, observe status transitions."
+summary: "Baseline creative lifecycle on a stateful platform: sync display creatives, list with filtering, and preview renderings."
 track: creative
 required_tools:
   - list_creative_formats
@@ -10,27 +10,24 @@ required_tools:
 narrative: |
   You run a creative platform with a persistent library — an ad server, creative management
   platform, or publisher that accepts and stores creative assets. A buyer agent pushes
-  multiple creatives in different formats, queries the library, builds serving tags, previews
-  renderings, and monitors creative status as assets move through your review pipeline.
+  display creatives, queries the library, and previews renderings before launch.
 
   This storyboard covers the complete creative lifecycle from the buyer's perspective:
-  uploading assets, browsing the library, building deliverables across formats, and
-  observing status transitions as creatives move from pending_review through to accepted.
+  uploading a display asset, browsing the library, and previewing the deliverable.
 
-  The individual creative storyboards (template, ad server, sales agent) cover specific
-  interaction models. This storyboard tests the full lifecycle across multiple creatives
-  and formats on a single platform.
+  The individual creative storyboards (template, ad server, native, sales agent) cover
+  specific interaction models and sub-modalities. This storyboard keeps the generic
+  creative baseline display-safe; video tag generation is covered by the
+  creative-ad-server specialism.
 
 agent:
-  interaction_model: stateful_preloaded
+  interaction_model: stateful_push
   capabilities:
     - has_creative_library
-    - supports_transformation
   examples:
-    - "Innovid"
-    - "Flashtalking"
-    - "CM360"
-    - "Creative management platforms"
+    - "Publisher creative intake platforms"
+    - "Retail media creative libraries"
+    - "Display ad management platforms"
 
 caller:
   role: buyer_agent
@@ -38,15 +35,15 @@ caller:
 
 prerequisites:
   description: |
-    The caller needs creative assets in multiple formats (display, video, native) and
-    a brand identity. The test kit provides sample assets at standard ad dimensions.
+    The caller needs display creative assets and a brand identity. The test kit provides
+    sample assets at standard ad dimensions.
   test_kit: "test-kits/acme-outdoor.yaml"
 
 phases:
   - id: capability_discovery
     title: "Capability discovery"
     narrative: |
-      The buyer calls get_adcp_capabilities to confirm the agent supports creative operations before browsing or building creatives.
+      The buyer calls get_adcp_capabilities to confirm the agent supports creative operations before browsing or previewing creatives.
 
     steps:
       - id: get_capabilities
@@ -132,19 +129,17 @@ phases:
             path: "formats[0].format_id.id"
             description: "Format IDs include id — must match those in get_products"
   - id: sync_multiple
-    title: "Sync multiple creatives"
+    title: "Sync display creative"
     narrative: |
-      The buyer pushes three creatives in different formats to your platform: a display
-      banner, a video spot, and a native card. Your platform validates each creative
-      against its format specs and returns per-creative status.
+      The buyer pushes a display banner to your platform. Your platform validates the
+      creative against its format specs and returns per-creative status.
 
     steps:
       - id: sync_creatives
-        title: "Push three creatives in different formats"
+        title: "Push a display creative"
         narrative: |
-          The buyer syncs three creatives simultaneously: a 300x250 display banner, a 30s
-          video spot, and a native content card. Your platform validates each against its
-          format specs and returns per-creative action and status.
+          The buyer syncs a 300x250 display banner. Your platform validates it against
+          its format specs and returns per-creative action and status.
         task: sync_creatives
         schema_ref: "creative/sync-creatives-request.json"
         response_schema_ref: "creative/sync-creatives-response.json"
@@ -152,10 +147,10 @@ phases:
         comply_scenario: creative_lifecycle
         stateful: true
         expected: |
-          Accept and validate all three creatives:
+          Accept and validate the display creative:
           - Per-creative action: created
           - Per-creative status: accepted or pending_review
-          - Validation results for each creative
+          - Validation results for the creative
           - Platform-assigned IDs if applicable
 
         sample_request:
@@ -176,35 +171,6 @@ phases:
                   width: 300
                   height: 250
                   mime_type: "image/png"
-            - creative_id: "video_30s_trail_pro"
-              name: "Trail Pro 3000 - 30s Video"
-              format_id:
-                agent_url: "https://your-platform.example.com"
-                id: "video_30s"
-              assets:
-                video:
-                  asset_type: "video"
-                  url: "https://cdn.pinnacle-agency.example/trail-pro-30s.mp4"
-                  width: 1920
-                  height: 1080
-                  duration_ms: 30000
-                  mime_type: "video/mp4"
-            - creative_id: "native_trail_pro"
-              name: "Trail Pro 3000 - Native Card"
-              format_id:
-                agent_url: "https://your-platform.example.com"
-                id: "native_content"
-              assets:
-                image:
-                  asset_type: "image"
-                  url: "https://cdn.pinnacle-agency.example/trail-pro-native.png"
-                  width: 1200
-                  height: 628
-                  mime_type: "image/png"
-                headline:
-                  asset_type: "text"
-                  content: "Trail Pro 3000 — Built for the Summit"
-
           idempotency_key: "$generate:uuid_v4#creative_lifecycle_sync_multiple_sync_creatives"
           context:
             correlation_id: "creative_lifecycle--sync_creatives"
@@ -234,7 +200,7 @@ phases:
         title: "List all creatives in library"
         narrative: |
           The buyer calls list_creatives with no filters to see all creatives in the
-          library for their account. The response includes the three creatives synced
+          library for their account. The response includes the display creative synced
           in the previous phase.
         task: list_creatives
         schema_ref: "creative/list-creatives-request.json"
@@ -246,7 +212,7 @@ phases:
           Return creatives in the library:
           - creatives array containing the synced items
           - Each creative includes: creative_id, name, format_id, status
-          - At least three creatives from the sync phase
+          - At least one creative from the sync phase
 
         sample_request:
           account:
@@ -284,7 +250,7 @@ phases:
         expected: |
           Return only creatives matching the format filter:
           - creatives array filtered to display format
-          - Should include display_trail_pro_300x250 but not video or native
+          - Should include display_trail_pro_300x250
 
         sample_request:
           account:
@@ -313,11 +279,11 @@ phases:
             value: "creative_lifecycle--list_filtered"
             description: "Context correlation_id returned unchanged"
   - id: build_and_preview
-    title: "Build and preview across formats"
+    title: "Preview display creative"
     narrative: |
-      The buyer builds serving tags and previews renderings for the synced creatives.
-      This tests multi-format output: a display tag, a VAST tag for video, and a
-      native rendering preview.
+      The buyer previews renderings for the synced display creative. Video/VAST tag
+      generation is covered by the creative-ad-server specialism, where the agent has
+      explicitly claimed that sub-modality.
 
     steps:
       - id: preview_display
@@ -370,45 +336,4 @@ phases:
           - check: field_value
             path: "context.correlation_id"
             value: "creative_lifecycle--preview_display"
-            description: "Context correlation_id returned unchanged"
-      - id: build_video_tag
-        title: "Build a VAST tag for the video creative"
-        narrative: |
-          The buyer builds a serving tag for the video creative. The platform produces
-          a VAST-compatible tag that the buyer can traffic to ad servers.
-        task: build_creative
-        schema_ref: "media-buy/build-creative-request.json"
-        response_schema_ref: "media-buy/build-creative-response.json"
-        doc_ref: "/creative/task-reference/build_creative"
-        comply_scenario: creative_flow
-        stateful: true
-        expected: |
-          Return a built serving tag for the video creative:
-          - tag: VAST-compatible serving tag or URL
-          - format: matches the video format
-          - creative_id: matches the requested creative
-
-        sample_request:
-          account:
-            brand:
-              domain: "acmeoutdoor.example"
-            operator: "pinnacle-agency.example"
-          creative_id: "video_30s_trail_pro"
-          target_format_id:
-            agent_url: "https://your-platform.example.com"
-            id: "vast_30s"
-          idempotency_key: "$generate:uuid_v4#creative_lifecycle_build_video_tag"
-
-          context:
-            correlation_id: "creative_lifecycle--build_video_tag"
-        validations:
-          - check: response_schema
-            description: "Response matches build-creative-response.json schema"
-
-          - check: field_present
-            path: "context"
-            description: "Response echoes back the context object"
-          - check: field_value
-            path: "context.correlation_id"
-            value: "creative_lifecycle--build_video_tag"
             description: "Context correlation_id returned unchanged"


### PR DESCRIPTION
## Summary

- remove video and native hardcoded creative submissions from the generic `creative_lifecycle` baseline
- remove the `build_video_tag` / `vast_30s` step from the generic creative baseline
- update the storyboard metadata and prose so it describes a display push/list/preview flow
- add an empty changeset documenting the compliance-only fix without bumping the package

## Why

Display-only creative agents that truthfully advertise no video formats were being graded against `video_30s` and `vast_30s` requests. This keeps the generic baseline display-safe while leaving VAST tag coverage in the `creative-ad-server` specialism.

## Validation

- `npm run test:storyboard-sample-request-schema`
- `npm run test:storyboard-response-schema`
- `npm run test:storyboard-contradictions`
- `npm run test:storyboard-test-kits`
- `npm run test:storyboard-validations-paths`
- `git diff --check`
- `npx changeset status --since origin/main` with the new changeset included via intent-to-add
- precommit hook: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run typecheck`
- pre-push hook: current storyboard matrix and 3.0 compatibility matrix

Closes #4479.