### PR TITLE
[codex] Fix training-agent AdCP version negotiation

### DIFF
--- a/.changeset/4711-training-agent-version-negotiation-runtime.md
+++ b/.changeset/4711-training-agent-version-negotiation-runtime.md
@@ -1,0 +1,4 @@
+---
+---
+
+Teach the training agent to advertise release-precision AdCP versions, resolve request pins to the served release, echo `adcp_version` on response envelopes, and return structured supported-version details for unsupported pins.

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -10,7 +10,9 @@ import { createHash, randomUUID } from 'node:crypto';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import {
   CallToolRequestSchema,
+  ErrorCode,
   ListToolsRequestSchema,
+  McpError,
 } from '@modelcontextprotocol/sdk/types.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks';
@@ -49,11 +51,14 @@ function escapeHtmlAttr(s: string): string {
 }
 
 /** Build a structured MCP error response for tool calls (L3 error compliance). */
-function adcpError(code: string, opts: { message: string; details?: unknown; recovery?: string; field?: string }, context?: unknown) {
+export function adcpError(code: string, opts: { message: string; details?: unknown; recovery?: string; field?: string }, context?: unknown, adcpVersion?: string) {
   const errorObj = { code, ...opts };
   const body = context !== undefined
     ? { adcp_error: errorObj, context }
     : { adcp_error: errorObj };
+  if (adcpVersion) {
+    (body as Record<string, unknown>).adcp_version = adcpVersion;
+  }
   return {
     isError: true,
     content: [{ type: 'text' as const, text: JSON.stringify(body) }],
@@ -388,7 +393,226 @@ import { maybeEmitCompletionWebhook } from './webhooks.js';
 import { selectSigningCapability } from './request-signing.js';
 
 const SUPPORTED_MAJOR_VERSIONS = [3] as const;
+const SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5'] as const;
+const DEFAULT_ADCP_VERSION = '3.0';
 const MAX_PACKAGES_PER_BUY = 50;
+
+interface ParsedAdcpReleaseVersion {
+  raw: string;
+  major: number;
+  minor: number;
+  prerelease?: string;
+}
+
+interface VersionUnsupportedDetails {
+  adcp_version?: string;
+  adcp_major_version?: number;
+  supported_versions: string[];
+  supported_majors: number[];
+  rejected_adcp_version?: string;
+}
+
+type VersionResolution =
+  | { ok: true; servedVersion: string }
+  | { ok: false; message: string; field: 'adcp_version' | 'adcp_major_version'; details: VersionUnsupportedDetails };
+
+type McpRequestHandler = (request: { params?: Record<string, unknown> }, extra: unknown) => Promise<unknown> | unknown;
+
+const TASK_PROTOCOL_METHODS = ['tasks/get', 'tasks/result', 'tasks/list', 'tasks/cancel'] as const;
+
+function parseAdcpReleaseVersion(value: unknown): ParsedAdcpReleaseVersion | undefined {
+  if (typeof value !== 'string') return undefined;
+  const match = value.match(/^(\d+)\.(\d+)(?:-([A-Za-z0-9.-]+))?$/);
+  if (!match) return undefined;
+  return {
+    raw: value,
+    major: Number.parseInt(match[1], 10),
+    minor: Number.parseInt(match[2], 10),
+    ...(match[3] && { prerelease: match[3] }),
+  };
+}
+
+function compareAdcpReleaseVersions(left: ParsedAdcpReleaseVersion, right: ParsedAdcpReleaseVersion): number {
+  if (left.major !== right.major) return left.major - right.major;
+  if (left.minor !== right.minor) return left.minor - right.minor;
+  if (left.prerelease === right.prerelease) return 0;
+  if (!left.prerelease) return 1;
+  if (!right.prerelease) return -1;
+  return left.prerelease.localeCompare(right.prerelease);
+}
+
+const PARSED_SUPPORTED_RELEASE_VERSIONS = SUPPORTED_RELEASE_VERSIONS
+  .map(version => parseAdcpReleaseVersion(version))
+  .filter((version): version is ParsedAdcpReleaseVersion => version !== undefined)
+  .sort(compareAdcpReleaseVersions);
+
+function highestSupportedRelease(major?: number): string | undefined {
+  const candidates = major === undefined
+    ? PARSED_SUPPORTED_RELEASE_VERSIONS
+    : PARSED_SUPPORTED_RELEASE_VERSIONS.filter(version => version.major === major);
+  return candidates.at(-1)?.raw;
+}
+
+function supportedVersionDetails(args: Record<string, unknown>): VersionUnsupportedDetails {
+  const requestedRelease = parseAdcpReleaseVersion(args.adcp_version);
+  const requestedMajor = typeof args.adcp_major_version === 'number' && Number.isInteger(args.adcp_major_version)
+    ? args.adcp_major_version
+    : undefined;
+  return {
+    ...(requestedRelease && { adcp_version: requestedRelease.raw }),
+    ...(requestedMajor !== undefined && { adcp_major_version: requestedMajor }),
+    ...(!requestedRelease && typeof args.adcp_version === 'string' && { rejected_adcp_version: args.adcp_version }),
+    supported_versions: [...SUPPORTED_RELEASE_VERSIONS],
+    supported_majors: [...SUPPORTED_MAJOR_VERSIONS],
+  };
+}
+
+export function resolveServedAdcpVersion(args: Record<string, unknown>): VersionResolution {
+  const requestedReleaseRaw = args.adcp_version;
+  const requestedMajorRaw = args.adcp_major_version;
+  const requestedMajor = typeof requestedMajorRaw === 'number' && Number.isInteger(requestedMajorRaw)
+    ? requestedMajorRaw
+    : undefined;
+
+  if (requestedReleaseRaw !== undefined) {
+    const requestedRelease = parseAdcpReleaseVersion(requestedReleaseRaw);
+    if (!requestedRelease) {
+      return {
+        ok: false,
+        message: `AdCP version ${JSON.stringify(requestedReleaseRaw)} is not supported`,
+        field: 'adcp_version',
+        details: supportedVersionDetails(args),
+      };
+    }
+
+    if (requestedMajor !== undefined && requestedMajor !== requestedRelease.major) {
+      return {
+        ok: false,
+        message: `Request carries adcp_version="${requestedRelease.raw}" (major ${requestedRelease.major}) and adcp_major_version=${requestedMajor}; majors must agree.`,
+        field: 'adcp_version',
+        details: supportedVersionDetails(args),
+      };
+    }
+
+    if ((SUPPORTED_RELEASE_VERSIONS as readonly string[]).includes(requestedRelease.raw)) {
+      return { ok: true, servedVersion: requestedRelease.raw };
+    }
+
+    if (requestedRelease.prerelease) {
+      return {
+        ok: false,
+        message: `AdCP version ${requestedRelease.raw} is not supported`,
+        field: 'adcp_version',
+        details: supportedVersionDetails(args),
+      };
+    }
+
+    const downshift = PARSED_SUPPORTED_RELEASE_VERSIONS
+      .filter(version => version.major === requestedRelease.major)
+      .filter(version => !version.prerelease)
+      .filter(version => compareAdcpReleaseVersions(version, requestedRelease) <= 0)
+      .at(-1);
+
+    if (downshift) {
+      return { ok: true, servedVersion: downshift.raw };
+    }
+
+    return {
+      ok: false,
+      message: `AdCP version ${requestedRelease.raw} is not supported`,
+      field: 'adcp_version',
+      details: supportedVersionDetails(args),
+    };
+  }
+
+  if (requestedMajorRaw !== undefined) {
+    if (requestedMajor === undefined) {
+      return {
+        ok: false,
+        message: `AdCP major version ${JSON.stringify(requestedMajorRaw)} is not supported`,
+        field: 'adcp_major_version',
+        details: supportedVersionDetails(args),
+      };
+    }
+    const servedVersion = highestSupportedRelease(requestedMajor);
+    if (servedVersion) return { ok: true, servedVersion };
+    return {
+      ok: false,
+      message: `AdCP major version ${requestedMajor} is not supported`,
+      field: 'adcp_major_version',
+      details: supportedVersionDetails(args),
+    };
+  }
+
+  return { ok: true, servedVersion: DEFAULT_ADCP_VERSION };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function mcpErrorMessage(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+  return error.message.replace(/^MCP error -?\d+: /, '');
+}
+
+function versionUnsupportedJsonRpcError(resolution: Extract<VersionResolution, { ok: false }>, context?: unknown): McpError {
+  const adcpError = {
+    code: 'VERSION_UNSUPPORTED',
+    message: resolution.message,
+    details: resolution.details,
+    field: resolution.field,
+  };
+  return new McpError(ErrorCode.InvalidParams, resolution.message, {
+    ...resolution.details,
+    adcp_error: adcpError,
+    ...(context !== undefined && { context }),
+  });
+}
+
+function rethrowWithServedAdcpVersion(error: unknown, servedAdcpVersion: string): never {
+  if (error instanceof McpError) {
+    const existingData = isRecord(error.data) ? error.data : {};
+    throw new McpError(error.code, mcpErrorMessage(error), {
+      ...existingData,
+      adcp_version: servedAdcpVersion,
+    });
+  }
+  throw error;
+}
+
+function addServedAdcpVersion(result: unknown, servedAdcpVersion: string, context?: unknown): unknown {
+  if (!isRecord(result)) return result;
+  return {
+    ...result,
+    adcp_version: servedAdcpVersion,
+    ...(context !== undefined && result.context === undefined && { context }),
+  };
+}
+
+function installTaskProtocolVersionNegotiation(server: Server): void {
+  const handlers = (server as unknown as { _requestHandlers?: Map<string, McpRequestHandler> })._requestHandlers;
+  if (!handlers) return;
+
+  for (const method of TASK_PROTOCOL_METHODS) {
+    const original = handlers.get(method);
+    if (!original) continue;
+    handlers.set(method, async (request, extra) => {
+      const rawParams = isRecord(request.params) ? request.params : {};
+      const { context: callerContext, ...versionArgs } = rawParams;
+      const versionResolution = resolveServedAdcpVersion(versionArgs);
+      if (!versionResolution.ok) {
+        throw versionUnsupportedJsonRpcError(versionResolution, callerContext);
+      }
+      try {
+        const result = await original(request, extra);
+        return addServedAdcpVersion(result, versionResolution.servedVersion, callerContext);
+      } catch (error) {
+        rethrowWithServedAdcpVersion(error, versionResolution.servedVersion);
+      }
+    });
+  }
+}
 
 // ── MCP Tasks store (SDK-managed) ─────────────────────────────────
 
@@ -4336,6 +4560,7 @@ export async function handleGetAdcpCapabilities(_args: ToolArgs, ctx: TrainingCo
   return {
     adcp: {
       major_versions: [...SUPPORTED_MAJOR_VERSIONS],
+      supported_versions: [...SUPPORTED_RELEASE_VERSIONS],
       idempotency: { supported: true, replay_ttl_seconds: 86400 },
     },
     supported_protocols: ['media_buy', 'creative', 'governance', 'signals', 'brand'],
@@ -5673,6 +5898,7 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
       return result;
     });
   });
+  installTaskProtocolVersionNegotiation(server);
 
   async function dispatchCallTool(
     request: { params: { name: string; arguments?: unknown; task?: { ttl?: number } } },
@@ -5684,29 +5910,27 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
     // echo caller's context object back unchanged in every response).
     const rawArgs = (args as Record<string, unknown> | undefined) ?? {};
     const { context: callerContext, ...handlerArgs } = rawArgs;
+    const versionResolution = resolveServedAdcpVersion(handlerArgs);
 
     const handler = HANDLER_MAP[name];
+
+    if (!versionResolution.ok) {
+      return {
+        result: adcpError('VERSION_UNSUPPORTED', {
+          message: versionResolution.message,
+          details: versionResolution.details,
+          field: versionResolution.field,
+        }, callerContext),
+        flushable: true,
+      };
+    }
+    const servedAdcpVersion = versionResolution.servedVersion;
 
     if (!handler) {
       // Pre-handler validation failures don't touch session state, so flushing
       // is a no-op; leaving flushable=true keeps behaviour consistent for
       // requests whose handlers DO legitimately mutate before failing.
-      return { result: adcpError('INVALID_REQUEST', { message: `Unknown tool: ${name}` }, callerContext), flushable: true };
-    }
-
-    const requestedVersion = (handlerArgs as { adcp_major_version?: unknown }).adcp_major_version;
-    if (
-      requestedVersion !== undefined
-      && !(SUPPORTED_MAJOR_VERSIONS as readonly number[]).includes(requestedVersion as number)
-    ) {
-      return {
-        result: adcpError('VERSION_UNSUPPORTED', {
-          message: `AdCP major version ${String(requestedVersion)} is not supported`,
-          details: { supported_major_versions: SUPPORTED_MAJOR_VERSIONS },
-          field: 'adcp_major_version',
-        }, callerContext),
-        flushable: true,
-      };
+      return { result: adcpError('INVALID_REQUEST', { message: `Unknown tool: ${name}` }, callerContext, servedAdcpVersion), flushable: true };
     }
 
     // Check for task-augmented request (explicit `task` field in params).
@@ -5749,7 +5973,7 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
             message: `idempotency_key is required for ${name}. Generate a UUID v4 and include it on every mutating request; reuse the same key for network retries.`,
             field: 'idempotency_key',
             recovery: 'correctable',
-          }, callerContext),
+          }, callerContext, servedAdcpVersion),
           flushable: true,
         };
       }
@@ -5759,7 +5983,7 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
             message: 'idempotency_key must match ^[A-Za-z0-9_.:-]{16,255}$ (UUID v4 recommended).',
             field: 'idempotency_key',
             recovery: 'correctable',
-          }, callerContext),
+          }, callerContext, servedAdcpVersion),
           flushable: true,
         };
       }
@@ -5774,7 +5998,7 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
           result: adcpError('IDEMPOTENCY_EXPIRED', {
             message: 'idempotency_key is past the replay window. Generate a fresh UUID v4 and resend.',
             recovery: 'correctable',
-          }, callerContext),
+          }, callerContext, servedAdcpVersion),
           flushable: true,
         };
       }
@@ -5788,7 +6012,7 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
         return {
           result: adcpError('IDEMPOTENCY_CONFLICT', {
             message: 'idempotency_key was used with a different payload within the replay window. Either resend the exact original payload (to return the cached response) or generate a fresh UUID v4 to submit this new payload.',
-          }, callerContext),
+          }, callerContext, servedAdcpVersion),
           flushable: true,
         };
       }
@@ -5800,7 +6024,7 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
           result: adcpError('RATE_LIMITED', {
             message: 'A concurrent request with this idempotency_key is already in progress. Retry after a short delay.',
             recovery: 'transient',
-          }, callerContext),
+          }, callerContext, servedAdcpVersion),
           flushable: true,
         };
       }
@@ -5815,6 +6039,7 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
         // requires envelope `status`.
         const body: Record<string, unknown> = { ...(outcome.response as Record<string, unknown>), replayed: true };
         if (body.status === undefined) body.status = 'completed';
+        body.adcp_version = servedAdcpVersion;
         if (callerContext !== undefined) body.context = callerContext;
         toolResult = {
           content: [{ type: 'text', text: JSON.stringify(body) }],
@@ -5856,6 +6081,7 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
           // happens to describe application-level errors — `completed` is
           // the correct TaskStatus regardless of body shape.
           const body: Record<string, unknown> = { status: 'completed', errors: resultObj.errors };
+          body.adcp_version = servedAdcpVersion;
           if (callerContext !== undefined) body.context = callerContext;
           toolResult = {
             content: [{ type: 'text', text: JSON.stringify(body) }],
@@ -5871,7 +6097,7 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
               : resultObj.errors!.length > 1
                 ? { all_errors: resultObj.errors }
                 : undefined,
-          }, callerContext);
+          }, callerContext, servedAdcpVersion);
         }
       } else {
         // Inner response (what gets cached for replay). Per security.mdx:
@@ -5891,6 +6117,7 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
         // `inner` and we honor that value.
         const response: Record<string, unknown> = { ...inner };
         if (response.status === undefined) response.status = 'completed';
+        response.adcp_version = servedAdcpVersion;
         if (name === 'create_media_buy') response.replayed = false;
         if (callerContext !== undefined) response.context = callerContext;
         // `structuredContent` is authoritative on success so raw-probe
@@ -5910,7 +6137,7 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
       toolResult = adcpError('SERVICE_UNAVAILABLE', {
         message: error instanceof Error ? error.message : 'Unknown error',
         recovery: 'transient',
-      }, callerContext);
+      }, callerContext, servedAdcpVersion);
     }
 
     // TypeScript: by this point toolResult is guaranteed set — either the
@@ -5999,7 +6226,7 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
       'Created MCP task',
     );
 
-    return { result: { task } as object, flushable: !handlerThrew };
+    return { result: { task, adcp_version: servedAdcpVersion } as object, flushable: !handlerThrew };
   }
 
   // tasks/get, tasks/result, tasks/list, tasks/cancel are auto-registered

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -19,6 +19,7 @@ import { getTenantResponseSigningMaterial } from './signing.js';
 import { wrapResponseForSigning } from '../response-signing.js';
 import { salesCapabilityProjection } from '../v6-sales-platform.js';
 import { handleComplyTestController } from '../comply-test-controller.js';
+import { adcpError, resolveServedAdcpVersion } from '../task-handlers.js';
 import type { TrainingContext } from '../types.js';
 import { getAgentUrl } from '../config.js';
 
@@ -45,6 +46,9 @@ const SALES_CURRENT_SCENARIOS = [
   'seed_creative_format',
   'seed_measurement_catalog',
 ] as const;
+
+const TRAINING_AGENT_SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5'] as const;
+const TRAINING_AGENT_DEFAULT_ADCP_VERSION = '3.0';
 
 function salesComplyScenarios(storyboardCompat?: TrainingContext['storyboardCompat']): string[] {
   return storyboardCompat?.version === '3.0'
@@ -301,6 +305,20 @@ async function tryHandleLocalComplyScenario(
   ) return false;
 
   const { context, ...handlerArgs } = rawArgs;
+  const versionResolution = resolveServedAdcpVersion(handlerArgs);
+  if (!versionResolution.ok) {
+    res.json({
+      jsonrpc: '2.0',
+      id: req.body.id ?? null,
+      result: adcpError('VERSION_UNSUPPORTED', {
+        message: versionResolution.message,
+        details: versionResolution.details,
+        field: versionResolution.field,
+      }, context),
+    });
+    return true;
+  }
+
   const result = await runWithSessionContext(async () => {
     const body = rawArgs.scenario === 'list_scenarios'
       ? {
@@ -315,6 +333,8 @@ async function tryHandleLocalComplyScenario(
     return body as Record<string, unknown>;
   });
   const structuredContent = {
+    status: 'completed',
+    adcp_version: versionResolution.servedVersion,
     ...result,
     ...(context !== undefined && { context }),
   };
@@ -374,7 +394,10 @@ function projectSalesCapabilities(
   try {
     const parsed = JSON.parse(body.toString('utf8')) as {
       result?: {
+        content?: Array<{ type?: string; text?: string }>;
         structuredContent?: {
+          adcp_version?: unknown;
+          adcp?: Record<string, unknown>;
           supported_protocols?: unknown;
           creative?: Record<string, unknown>;
           media_buy?: Record<string, unknown>;
@@ -389,6 +412,19 @@ function projectSalesCapabilities(
     };
     const structured = parsed.result?.structuredContent;
     if (!structured || typeof structured !== 'object') return body;
+    const servedVersion = typeof structured.adcp_version === 'string'
+      ? structured.adcp_version
+      : TRAINING_AGENT_DEFAULT_ADCP_VERSION;
+    structured.adcp_version = servedVersion;
+    const adcp = structured.adcp && typeof structured.adcp === 'object'
+      ? structured.adcp
+      : {};
+    structured.adcp = {
+      ...adcp,
+      supported_versions: Array.isArray(adcp.supported_versions)
+        ? adcp.supported_versions
+        : [...TRAINING_AGENT_SUPPORTED_RELEASE_VERSIONS],
+    };
     if (
       tenantId === 'creative'
       && storyboardCompat?.version !== '3.0'
@@ -433,6 +469,10 @@ function projectSalesCapabilities(
       };
     }
     projectWholesaleCapabilities(structured, tenantId, storyboardCompat);
+    const firstText = parsed.result?.content?.[0];
+    if (firstText?.type === 'text') {
+      firstText.text = JSON.stringify(structured);
+    }
     return Buffer.from(JSON.stringify(parsed), 'utf8');
   } catch {
     return body;

--- a/server/src/training-agent/tenants/tenant-smoke.test.ts
+++ b/server/src/training-agent/tenants/tenant-smoke.test.ts
@@ -220,6 +220,8 @@ describe('tenant routing smoke', () => {
       const body = await r.json() as {
         result?: {
           structuredContent?: {
+            adcp_version?: string;
+            adcp?: { major_versions?: number[]; supported_versions?: string[] };
             media_buy?: {
               supported_optimization_metrics?: string[];
               vendor_metric_optimization?: { supported_targets?: string[] };
@@ -229,6 +231,9 @@ describe('tenant routing smoke', () => {
         };
       };
       const mediaBuy = body.result?.structuredContent?.media_buy;
+      expect(body.result?.structuredContent?.adcp_version).toBe('3.0');
+      expect(body.result?.structuredContent?.adcp?.major_versions).toContain(3);
+      expect(body.result?.structuredContent?.adcp?.supported_versions).toEqual(['3.0', '3.1-beta.5']);
       expect(mediaBuy?.supported_optimization_metrics).toContain('clicks');
       expect(mediaBuy?.vendor_metric_optimization?.supported_targets).toContain('threshold_rate');
       expect(body.result?.structuredContent?.compliance_testing?.scenarios).toEqual(SALES_CURRENT_SCENARIOS);
@@ -263,15 +268,22 @@ describe('tenant routing smoke', () => {
           method: 'tools/call',
           params: {
             name: 'comply_test_controller',
-            arguments: { account: { sandbox: true }, scenario: 'list_scenarios' },
+            arguments: {
+              account: { sandbox: true },
+              adcp_version: '3.1',
+              adcp_major_version: 3,
+              scenario: 'list_scenarios',
+            },
           },
         }),
       });
       const listed = await list.json() as {
         result?: {
-          structuredContent?: { scenarios?: string[] };
+          structuredContent?: { status?: string; adcp_version?: string; scenarios?: string[] };
         };
       };
+      expect(listed.result?.structuredContent?.status).toBe('completed');
+      expect(listed.result?.structuredContent?.adcp_version).toBe('3.0');
       expect(listed.result?.structuredContent?.scenarios).toEqual(expect.arrayContaining(SALES_CURRENT_SCENARIOS));
 
       const r = await fetch(url, {
@@ -285,6 +297,8 @@ describe('tenant routing smoke', () => {
             name: 'comply_test_controller',
             arguments: {
               account: { sandbox: true, brand: { domain: 'tenant-seed.example' } },
+              adcp_version: '3.1',
+              adcp_major_version: 3,
               brand: { domain: 'tenant-seed.example' },
               scenario: 'seed_measurement_catalog',
               params: {
@@ -298,11 +312,55 @@ describe('tenant routing smoke', () => {
       });
       const body = await r.json() as {
         result?: {
-          structuredContent?: { success?: boolean; context?: { correlation_id?: string } };
+          structuredContent?: { status?: string; adcp_version?: string; success?: boolean; context?: { correlation_id?: string } };
         };
       };
+      expect(body.result?.structuredContent?.status).toBe('completed');
+      expect(body.result?.structuredContent?.adcp_version).toBe('3.0');
       expect(body.result?.structuredContent?.success).toBe(true);
       expect(body.result?.structuredContent?.context?.correlation_id).toBe('tenant-seed-measurement-catalog');
+
+      const unsupported = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 4,
+          method: 'tools/call',
+          params: {
+            name: 'comply_test_controller',
+            arguments: {
+              account: { sandbox: true },
+              adcp_version: '4.0',
+              scenario: 'list_scenarios',
+              context: { correlation_id: 'tenant-local-version-unsupported' },
+            },
+          },
+        }),
+      });
+      const unsupportedBody = await unsupported.json() as {
+        result?: {
+          isError?: boolean;
+          structuredContent?: {
+            adcp_error?: {
+              code?: string;
+              field?: string;
+              details?: { adcp_version?: string; supported_versions?: string[] };
+            };
+            context?: { correlation_id?: string };
+          };
+        };
+      };
+      expect(unsupportedBody.result?.isError).toBe(true);
+      expect(unsupportedBody.result?.structuredContent?.adcp_error).toMatchObject({
+        code: 'VERSION_UNSUPPORTED',
+        field: 'adcp_version',
+        details: {
+          adcp_version: '4.0',
+          supported_versions: ['3.0', '3.1-beta.5'],
+        },
+      });
+      expect(unsupportedBody.result?.structuredContent?.context?.correlation_id).toBe('tenant-local-version-unsupported');
     } finally {
       await close();
     }

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -137,13 +137,14 @@ async function simulateCallToolAsTask(
 async function simulateGetTask(
   server: ReturnType<typeof createTrainingAgentServer>,
   taskId: string,
+  params: Record<string, unknown> = {},
 ): Promise<Record<string, unknown>> {
   const requestHandlers = (server as any)._requestHandlers as Map<string, Function>;
   const handler = requestHandlers.get('tasks/get');
   if (!handler) {
     throw new Error('tasks/get handler not found');
   }
-  return handler({ method: 'tasks/get', params: { taskId } }, {});
+  return handler({ method: 'tasks/get', params: { taskId, ...params } }, {});
 }
 
 /**
@@ -152,13 +153,14 @@ async function simulateGetTask(
 async function simulateGetTaskResult(
   server: ReturnType<typeof createTrainingAgentServer>,
   taskId: string,
+  params: Record<string, unknown> = {},
 ): Promise<Record<string, unknown>> {
   const requestHandlers = (server as any)._requestHandlers as Map<string, Function>;
   const handler = requestHandlers.get('tasks/result');
   if (!handler) {
     throw new Error('tasks/result handler not found');
   }
-  return handler({ method: 'tasks/result', params: { taskId } }, {});
+  return handler({ method: 'tasks/result', params: { taskId, ...params } }, {});
 }
 
 /**
@@ -166,13 +168,14 @@ async function simulateGetTaskResult(
  */
 async function simulateListTasks(
   server: ReturnType<typeof createTrainingAgentServer>,
+  params: Record<string, unknown> = {},
 ): Promise<Record<string, unknown>> {
   const requestHandlers = (server as any)._requestHandlers as Map<string, Function>;
   const handler = requestHandlers.get('tasks/list');
   if (!handler) {
     throw new Error('tasks/list handler not found');
   }
-  return handler({ method: 'tasks/list', params: {} }, {});
+  return handler({ method: 'tasks/list', params }, {});
 }
 
 /**
@@ -181,13 +184,14 @@ async function simulateListTasks(
 async function simulateCancel(
   server: ReturnType<typeof createTrainingAgentServer>,
   taskId: string,
+  params: Record<string, unknown> = {},
 ): Promise<Record<string, unknown>> {
   const requestHandlers = (server as any)._requestHandlers as Map<string, Function>;
   const handler = requestHandlers.get('tasks/cancel');
   if (!handler) {
     throw new Error('tasks/cancel handler not found');
   }
-  return handler({ method: 'tasks/cancel', params: { taskId } }, {});
+  return handler({ method: 'tasks/cancel', params: { taskId, ...params } }, {});
 }
 
 // ── Catalog (buildCatalog) ─────────────────────────────────────────
@@ -6420,8 +6424,9 @@ describe('get_adcp_capabilities handler', () => {
     const server = createTrainingAgentServer(DEFAULT_CTX);
     const { result } = await simulateCallTool(server, 'get_adcp_capabilities', {});
 
-    expect(result.adcp).toEqual({
+    expect(result.adcp).toMatchObject({
       major_versions: [3],
+      supported_versions: ['3.0', '3.1-beta.5'],
       idempotency: { supported: true, replay_ttl_seconds: 86400 },
     });
     expect(result.protocol_version).toBe('3.0');
@@ -7230,9 +7235,12 @@ describe('MCP Tasks protocol', () => {
   it('returns CreateTaskResult for task-augmented get_products call', async () => {
     const server = createTrainingAgentServer(DEFAULT_CTX);
     const response = await simulateCallToolAsTask(server, 'get_products', {
+      adcp_version: '3.1',
+      adcp_major_version: 3,
       buying_mode: 'wholesale',
     });
 
+    expect(response.adcp_version).toBe('3.0');
     expect(response.task).toBeDefined();
     const task = response.task as Record<string, unknown>;
     expect(task.taskId).toBeDefined();
@@ -7261,7 +7269,11 @@ describe('MCP Tasks protocol', () => {
     });
     const taskId = (createResponse.task as Record<string, unknown>).taskId as string;
 
-    const getResponse = await simulateGetTask(server, taskId);
+    const getResponse = await simulateGetTask(server, taskId, {
+      adcp_version: '3.1',
+      adcp_major_version: 3,
+    });
+    expect(getResponse.adcp_version).toBe('3.0');
     expect(getResponse.taskId).toBe(taskId);
     expect(getResponse.status).toBe('completed');
   });
@@ -7273,7 +7285,11 @@ describe('MCP Tasks protocol', () => {
     });
     const taskId = (createResponse.task as Record<string, unknown>).taskId as string;
 
-    const result = await simulateGetTaskResult(server, taskId);
+    const result = await simulateGetTaskResult(server, taskId, {
+      adcp_version: '3.1',
+      adcp_major_version: 3,
+    });
+    expect(result.adcp_version).toBe('3.0');
     const parsed = result.structuredContent as Record<string, unknown> | undefined;
     expect(parsed).toBeDefined();
     expect(Array.isArray(parsed!.products)).toBe(true);
@@ -7291,9 +7307,59 @@ describe('MCP Tasks protocol', () => {
     await simulateCallToolAsTask(server, 'get_products', { buying_mode: 'wholesale' });
     await simulateCallToolAsTask(server, 'get_products', { buying_mode: 'brief', brief: 'ctv' });
 
-    const listResponse = await simulateListTasks(server);
+    const listResponse = await simulateListTasks(server, {
+      adcp_version: '3.1',
+      adcp_major_version: 3,
+    });
+    expect(listResponse.adcp_version).toBe('3.0');
     const tasks = listResponse.tasks as Array<Record<string, unknown>>;
     expect(tasks.length).toBe(2);
+  });
+
+  it('rejects unsupported adcp_version on task lifecycle methods', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const createResponse = await simulateCallToolAsTask(server, 'get_products', {
+      buying_mode: 'wholesale',
+    });
+    const taskId = (createResponse.task as Record<string, unknown>).taskId as string;
+    const unsupported = {
+      adcp_version: '99.0',
+      context: { correlation_id: 'task-version-unsupported' },
+    };
+
+    for (const call of [
+      () => simulateGetTask(server, taskId, unsupported),
+      () => simulateGetTaskResult(server, taskId, unsupported),
+      () => simulateListTasks(server, unsupported),
+      () => simulateCancel(server, taskId, unsupported),
+    ]) {
+      await expect(call()).rejects.toMatchObject({
+        code: -32602,
+        data: {
+          adcp_version: '99.0',
+          supported_versions: ['3.0', '3.1-beta.5'],
+          supported_majors: [3],
+          context: { correlation_id: 'task-version-unsupported' },
+          adcp_error: {
+            code: 'VERSION_UNSUPPORTED',
+            field: 'adcp_version',
+          },
+        },
+      });
+    }
+  });
+
+  it('echoes served adcp_version on task lifecycle JSON-RPC errors', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    await expect(
+      simulateGetTask(server, 'nonexistent-task-id', { adcp_version: '3.1', adcp_major_version: 3 }),
+    ).rejects.toMatchObject({
+      code: -32602,
+      data: {
+        adcp_version: '3.0',
+      },
+    });
   });
 
   it('structured errors complete the task (with adcp_error in result)', async () => {
@@ -9053,8 +9119,9 @@ describe('AdCP protocol compliance', () => {
     });
     expect(isError).toBe(true);
     expect(result.code).toBe('VERSION_UNSUPPORTED');
-    const details = result.details as { supported_major_versions?: number[] };
-    expect(details?.supported_major_versions).toContain(3);
+    const details = result.details as { supported_versions?: string[]; supported_majors?: number[] };
+    expect(details?.supported_versions).toContain('3.0');
+    expect(details?.supported_majors).toContain(3);
   });
 
   it('accepts supported adcp_major_version', async () => {
@@ -9066,6 +9133,174 @@ describe('AdCP protocol compliance', () => {
     });
     expect(isError).toBeFalsy();
     expect(Array.isArray(result.products)).toBe(true);
+  });
+
+  it('advertises supported_versions and echoes the default served adcp_version', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { parsed, isError } = await simulateCallToolRaw(server, 'get_adcp_capabilities', {});
+
+    expect(isError).toBeFalsy();
+    expect(parsed.adcp_version).toBe('3.0');
+    expect(parsed.adcp).toMatchObject({
+      major_versions: [3],
+      supported_versions: ['3.0', '3.1-beta.5'],
+    });
+  });
+
+  it('echoes the exact served release for supported adcp_version pins', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { parsed, isError } = await simulateCallToolRaw(server, 'get_products', {
+      adcp_version: '3.0',
+      adcp_major_version: 3,
+      buying_mode: 'brief',
+      brief: 'test',
+    });
+
+    expect(isError).toBeFalsy();
+    expect(parsed.adcp_version).toBe('3.0');
+    expect(Array.isArray(parsed.products)).toBe(true);
+  });
+
+  it('echoes exact supported pre-release adcp_version pins', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { parsed, isError } = await simulateCallToolRaw(server, 'get_products', {
+      adcp_version: '3.1-beta.5',
+      adcp_major_version: 3,
+      buying_mode: 'brief',
+      brief: 'test',
+    });
+
+    expect(isError).toBeFalsy();
+    expect(parsed.adcp_version).toBe('3.1-beta.5');
+    expect(Array.isArray(parsed.products)).toBe(true);
+  });
+
+  it('downshifts same-major release pins and echoes the served release', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { parsed, isError } = await simulateCallToolRaw(server, 'get_products', {
+      adcp_version: '3.1',
+      adcp_major_version: 3,
+      buying_mode: 'brief',
+      brief: 'test',
+    });
+
+    expect(isError).toBeFalsy();
+    expect(parsed.adcp_version).toBe('3.0');
+    expect(Array.isArray(parsed.products)).toBe(true);
+  });
+
+  it('rejects cross-major adcp_version pins with structured supported_versions details', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { parsed, isError } = await simulateCallToolRaw(server, 'get_products', {
+      adcp_version: '4.0',
+      adcp_major_version: 4,
+      buying_mode: 'brief',
+      brief: 'test',
+    });
+
+    expect(isError).toBe(true);
+    expect(parsed.adcp_error).toMatchObject({
+      code: 'VERSION_UNSUPPORTED',
+      field: 'adcp_version',
+      details: {
+        adcp_version: '4.0',
+        adcp_major_version: 4,
+        supported_versions: ['3.0', '3.1-beta.5'],
+        supported_majors: [3],
+      },
+    });
+  });
+
+  it('requires pre-release adcp_version pins to match exactly', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { parsed, isError } = await simulateCallToolRaw(server, 'get_products', {
+      adcp_version: '3.1-beta',
+      adcp_major_version: 3,
+      buying_mode: 'brief',
+      brief: 'test',
+    });
+
+    expect(isError).toBe(true);
+    expect(parsed.adcp_error).toMatchObject({
+      code: 'VERSION_UNSUPPORTED',
+      field: 'adcp_version',
+      details: {
+        adcp_version: '3.1-beta',
+        supported_versions: ['3.0', '3.1-beta.5'],
+        supported_majors: [3],
+      },
+    });
+  });
+
+  it('echoes served adcp_version on MCP error envelopes', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { parsed, isError } = await simulateCallToolRaw(server, 'nonexistent_tool', {
+      adcp_version: '3.1',
+      adcp_major_version: 3,
+    });
+
+    expect(isError).toBe(true);
+    expect(parsed.adcp_version).toBe('3.0');
+    expect(parsed.adcp_error).toMatchObject({ code: 'INVALID_REQUEST' });
+  });
+
+  it('echoes served adcp_version on errors-in-body responses', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const account = { brand: { domain: 'version-body-error.example' }, operator: 'version-body-error.example' };
+    const product = buildCatalog()[0].product;
+    const pricingOptionId = (product.pricing_options as Array<Record<string, unknown>>)[0].pricing_option_id as string;
+
+    const { parsed: created } = await simulateCallToolRaw(server, 'create_media_buy', {
+      account,
+      adcp_version: '3.1',
+      adcp_major_version: 3,
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{ product_id: product.product_id, budget: 50000, pricing_option_id: pricingOptionId }],
+    });
+
+    await simulateCallToolRaw(server, 'update_media_buy', {
+      account,
+      adcp_version: '3.1',
+      adcp_major_version: 3,
+      media_buy_id: created.media_buy_id as string,
+      canceled: true,
+    });
+    const { parsed, isError } = await simulateCallToolRaw(server, 'update_media_buy', {
+      account,
+      adcp_version: '3.1',
+      adcp_major_version: 3,
+      media_buy_id: created.media_buy_id as string,
+      canceled: true,
+    });
+
+    expect(isError).toBeFalsy();
+    expect(parsed.adcp_version).toBe('3.0');
+    expect((parsed.errors as Array<Record<string, unknown>>)[0]).toMatchObject({ code: 'NOT_CANCELLABLE' });
+  });
+
+  it('echoes served adcp_version on idempotency replay responses', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const product = buildCatalog()[0].product;
+    const pricingOptionId = (product.pricing_options as Array<Record<string, unknown>>)[0].pricing_option_id as string;
+    const args = {
+      account: { brand: { domain: 'version-replay.example' }, operator: 'version-replay.example' },
+      adcp_version: '3.1',
+      adcp_major_version: 3,
+      idempotency_key: `version-replay-${randomUUID()}`,
+      start_time: '2027-08-01T00:00:00Z',
+      end_time: '2027-09-01T00:00:00Z',
+      packages: [{ product_id: product.product_id, budget: 50000, pricing_option_id: pricingOptionId }],
+    };
+
+    const first = await simulateCallToolRaw(server, 'create_media_buy', args);
+    const second = await simulateCallToolRaw(server, 'create_media_buy', args);
+
+    expect(first.isError).toBeFalsy();
+    expect(first.parsed.adcp_version).toBe('3.0');
+    expect(second.isError).toBeFalsy();
+    expect(second.parsed.replayed).toBe(true);
+    expect(second.parsed.adcp_version).toBe('3.0');
   });
 
   it('persists property_list and collection_list in package targeting', async () => {


### PR DESCRIPTION
## Summary
- advertise release-precision `adcp.supported_versions` from training-agent capabilities
- resolve inbound `adcp_version` / `adcp_major_version` pins, including exact beta support, same-major release downshift, prerelease exact-only rejection, and structured `VERSION_UNSUPPORTED` details
- echo served `adcp_version` on tool, async task, idempotency replay, local tenant shortcut, and JSON-RPC task lifecycle responses

Closes #4711.

## Validation
- `npx vitest run server/tests/unit/training-agent.test.ts server/src/training-agent/tenants/tenant-smoke.test.ts`
- `npm run typecheck`
- `bash scripts/overlay-compliance-cache.sh && TENANT_PATH=sales PUBLIC_TEST_AGENT_TOKEN=storyboard-local-token npx tsx server/tests/manual/run-storyboards.ts --filter version_negotiation`
- `TENANT_PATH=sales PUBLIC_TEST_AGENT_TOKEN=storyboard-local-token npx tsx server/tests/manual/run-storyboards.ts --filter vendor_metric_catalog_precondition`
- precommit: unit tests, dynamic-import lint, callapi-state-change lint, typecheck
- pre-push: current compliance storyboard matrix and 3.0.13 compatibility storyboard matrix