### PR TITLE
[codex] Add registry feed event schemas

### DIFF
--- a/.changeset/4792-registry-feed-event-schemas.md
+++ b/.changeset/4792-registry-feed-event-schemas.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": minor
+---
+
+Add published registry change-feed schemas for `/api/registry/feed`.
+
+The new `core/registry-feed-response.json` wrapper references `core/registry-event.json`, which now validates the current registry event vocabulary across property, agent, publisher, and authorization changes. Registry docs and specs now cite the schemas and align examples with the implemented cursor and filter contract.

--- a/docs/registry/index.mdx
+++ b/docs/registry/index.mdx
@@ -485,6 +485,8 @@ result = requests.post(
 
 Poll a cursor-based feed of registry changes. Use this to keep a local copy of the registry in sync without re-fetching the full dataset. Events are ordered by UUID v7 `event_id`, providing monotonic cursor progression. The feed retains events for 90 days — expired cursors return `410 Gone`.
 
+**Schema:** [`core/registry-feed-response.json`](https://adcontextprotocol.org/schemas/v3/core/registry-feed-response.json) wraps [`core/registry-event.json`](https://adcontextprotocol.org/schemas/v3/core/registry-event.json) items.
+
 **Query parameters:**
 
 | Parameter | Type | Default | Description |
@@ -505,9 +507,14 @@ Poll a cursor-based feed of registry changes. Use this to keep a local copy of t
 | `agent.discovered` | A new `agent_url` appeared in a publisher's `adagents.json` (authorization graph; does not imply the agent is in `/api/registry/agents`) |
 | `agent.removed` | An agent was removed from the registry |
 | `agent.profile_updated` | Agent inventory profile changed |
+| `agent.compliance_changed` | Agent compliance or verification status changed |
+| `agent.verification_earned` | Agent earned an AAO Verified badge |
+| `agent.verification_lost` | Agent lost an AAO Verified badge |
+| `publisher.adagents_discovered` | A publisher's adagents.json was discovered and projected into the registry |
 | `publisher.adagents_changed` | A publisher's adagents.json was updated |
 | `authorization.granted` | An agent was authorized for a property |
 | `authorization.revoked` | An authorization was removed |
+| `authorization.modified` | An authorization stayed visible, but externally visible metadata changed |
 
 <CodeGroup>
 
@@ -546,7 +553,14 @@ feed = requests.get(
       "event_type": "property.created",
       "entity_type": "property",
       "entity_id": "019539a0-b1c2-7000-8000-000000000002",
-      "payload": {},
+      "payload": {
+        "property_rid": "019539a0-b1c2-7000-8000-000000000002",
+        "classification": "property",
+        "source": "contributed",
+        "identifiers": [
+          { "type": "domain", "value": "streamer.example.com" }
+        ]
+      },
       "actor": "crawler",
       "created_at": "2026-03-31T10:00:00.000Z"
     }

--- a/specs/registry-authorization-model.md
+++ b/specs/registry-authorization-model.md
@@ -390,13 +390,13 @@ GET /api/registry/authorizations/snapshot?evidence=<csv>&include=<raw|effective>
   → ~150 MB on the wire at long-run scale (effective set, evidence='adagents_json')
   → DEFAULT excludes evidence='agent_claim' to prevent buy-side trust footgun
 
-GET /api/registry/feed?entity_type=authorization&cursor=<event_id>
+GET /api/registry/feed?types=authorization.*&cursor=<event_id>
   → REUSES the existing UUIDv7-cursor change feed (registry-change-feed.md)
   → emits authorization.granted / authorization.revoked / authorization.modified events
   → consumer applies events in event_id order, advances cursor
 ```
 
-The change feed is the canonical delta mechanism for the registry — the property-side cutover already uses it for `property.created` / `property.removed`. Authorization events are a new `entity_type` filter on the same feed; same UUIDv7 `cursor` parameter, same retention window, same recovery semantics. The snapshot endpoint exists only to bootstrap a consumer that's never synced before; once bootstrapped, the change feed is the live source. **`seq_no` on the table is internal — it orders rows for the change-feed emitter and for view-layer pagination, but it never crosses the wire.** Consumers see only `event_id`.
+The change feed is the canonical delta mechanism for the registry — the property-side cutover already uses it for `property.created` / `property.updated`. Authorization consumers filter the same feed with `types=authorization.*`; same UUIDv7 `cursor` parameter, same retention window, same recovery semantics. The snapshot endpoint exists only to bootstrap a consumer that's never synced before; once bootstrapped, the change feed is the live source. **`seq_no` on the table is internal — it orders rows for the change-feed emitter and for view-layer pagination, but it never crosses the wire.** Consumers see only `event_id`.
 
 `agent_claim` rows are excluded from the snapshot by default. Consumers that want unverified self-asserted authorizations (e.g. a registry-internal admin tool, or a DSP that has its own trust-by-vendor policy) opt in with `?evidence=adagents_json,agent_claim`. Mixing them by default would let a buy-side platform that doesn't filter treat self-claims as authoritative — exactly the failure mode the override layer was designed to prevent.
 
@@ -411,13 +411,13 @@ if local_cursor == 'snapshot':
   local_cursor = snapshot.headers['X-Sync-Cursor']  -- a UUIDv7 event_id
   persist("last_feed_cursor", local_cursor)
 while true:
-  events = GET /api/registry/feed?entity_type=authorization&cursor=local_cursor
+  events = GET /api/registry/feed?types=authorization.*&cursor=local_cursor
   for ev in events:
     if ev.type == 'authorization.revoked':
       local.delete(ev.entity_id)
     else:
       local.upsert(ev.payload)
-  local_cursor = events.next_cursor
+  local_cursor = events.cursor
   persist("last_feed_cursor", local_cursor)
   sleep(poll_interval)
   -- if server returns 410 Gone, cursor is older than feed retention;
@@ -482,7 +482,7 @@ This isn't a new design decision — it's the same trust posture as the property
 
 The doc above is buy-side-coded — DSPs, sales houses, agencies pulling and verifying. A publisher reading this should be able to answer "why am I in this catalog vs. just hosting `.well-known/adagents.json` and being done?" Three concrete reasons:
 
-1. **Discoverability.** Buyer agents subscribed to `/api/registry/change-feed?entity_type=authorization` see a publisher's authorized agents the moment the crawler picks up the manifest — no per-buyer crawl needed. For new publishers especially, this collapses time-to-discovery from "whenever each buyer's crawler gets to you" to "next change-feed poll."
+1. **Discoverability.** Buyer agents subscribed to `/api/registry/feed?types=authorization.*` see a publisher's authorized agents the moment the crawler picks up the manifest — no per-buyer crawl needed. For new publishers especially, this collapses time-to-discovery from "whenever each buyer's crawler gets to you" to "next change-feed poll."
 
 2. **Bad-actor protection via the override layer.** A publisher whose `.well-known/adagents.json` is being misrepresented (a buying agent claiming authorization that wasn't granted) can file a `bad_actor 'suppress'` override through the registry's moderation flow. The override propagates through the change feed to every consumer of `v_effective_agent_authorizations`. Without the catalog, the publisher's only recourse is changing the file and waiting for buyers to re-crawl — which can take days or weeks.
 

--- a/specs/registry-change-feed.md
+++ b/specs/registry-change-feed.md
@@ -51,10 +51,14 @@ Append-only within a 90-day retention window.
 | `property.reactivated` | Stale property resolved again | Available inventory again |
 | `agent.discovered` | New agent found via crawl or registration | New seller/creative/signals partner |
 | `agent.removed` | Agent no longer in any adagents.json | Authorization may be revoked |
+| `agent.verification_earned` | Agent earns an AAO Verified badge | Buyer routing decisions may expand |
+| `agent.verification_lost` | Agent loses an AAO Verified badge | Buyer routing decisions may need tightening |
+| `publisher.adagents_discovered` | Crawl finds a publisher adagents.json for the first time | Properties, agents, and authorizations may be available |
 | `publisher.adagents_changed` | Crawl detects adagents.json diff | Properties, authorizations may have changed |
 | `agent.profile_updated` | Inventory profile changed (new markets, channels, etc.) | Search results may change |
 | `authorization.granted` | Agent authorized for publisher in adagents.json | New selling relationship; TMP routers must update |
 | `authorization.revoked` | Agent removed from publisher's adagents.json | Selling relationship ended; TMP routers must update |
+| `authorization.modified` | Visible authorization metadata changed | TMP routers must update cached authorization metadata |
 | `agent.compliance_changed` | Compliance status transition (heartbeat or manual) | Buyer routing decisions may need updating |
 
 ### Event Payload Examples
@@ -99,11 +103,11 @@ Append-only within a 90-day retention window.
   "authorization_type": "property_ids",
   "property_ids": ["primetime_ctv", "news_live"],
   "placement_ids": ["pre_roll_30s", "mid_roll_15s"],
-  "collections": [{ "publisher_domain": "streamer.example.com", "collection_id": "primetime_drama" }],
+  "collections": [{ "publisher_domain": "streamer.example.com", "collection_ids": ["primetime_drama"] }],
   "countries": ["US", "CA"],
   "delegation_type": "direct",
   "exclusive": false,
-  "signing_keys": [{ "algorithm": "ed25519", "public_key": "base64..." }],
+  "signing_keys": [{ "kid": "pub-2026-04", "kty": "OKP", "alg": "EdDSA", "crv": "Ed25519", "x": "abc123" }],
   "effective_from": "2026-04-01T00:00:00Z",
   "effective_until": "2027-03-31T23:59:59Z"
 }
@@ -146,13 +150,17 @@ Poll the change feed.
 
 **Authentication:** Required. Member-only endpoint.
 
+**Schema:** Response payloads validate against
+`static/schemas/source/core/registry-feed-response.json`; each item in
+`events[]` validates against `static/schemas/source/core/registry-event.json`.
+
 **Parameters:**
 
 | Param | Type | Default | Description |
 |-------|------|---------|-------------|
 | `cursor` | UUID | (none) | Last event_id processed. Omit for start of retention window. |
 | `types` | string | all | Comma-separated event types. Supports glob: `property.*` |
-| `limit` | integer | 1000 | Max events per response. Max 10000. |
+| `limit` | integer | 100 | Max events per response. Max 10000. |
 
 **Response:**
 ```json
@@ -164,15 +172,16 @@ Poll the change feed.
       "entity_type": "property",
       "entity_id": "019539a0-b1c2-...",
       "payload": { "..." : "..." },
+      "actor": "crawler",
       "created_at": "2026-03-31T10:00:00Z"
     }
   ],
-  "next_cursor": "019539a1-...",
+  "cursor": "019539a1-...",
   "has_more": true
 }
 ```
 
-Consumers save `next_cursor` and pass it as `cursor` on the next poll. When `has_more` is false, the consumer is caught up.
+Consumers save `cursor` and pass it as `cursor` on the next poll. When `has_more` is false, the consumer is caught up.
 
 ### `POST /api/registry/crawl-request`
 
@@ -274,13 +283,14 @@ Events are written at the point of change, not reconstructed later:
 | Crawler diff (agent no longer in any adagents.json) | `agent.removed` |
 | Crawler diff (adagents.json content changed) | `publisher.adagents_changed` |
 | Crawler diff (authorization added/removed) | `authorization.granted`, `authorization.revoked` |
+| Authorization row body update | `authorization.modified` |
 | Crawler diff (agent inventory profile changed) | `agent.profile_updated` |
 | Catalog governance (dispute resolved, classification changed) | `property.updated` |
 | Staleness cron (90-day inactivity) | `property.stale` |
 | Resolve reactivation (stale property resolved) | `property.reactivated` |
 | Compliance heartbeat status transition | `agent.compliance_changed` |
 
-**Seed operations** do not write individual events. A single `catalog.seed_complete` summary event is written. Consumers who need full state after a seed should use `/catalog/sync`.
+**Seed operations** do not write individual registry feed events. Consumers who need full state after a seed should use `/catalog/sync`.
 
 ---
 

--- a/static/schemas/source/core/registry-event.json
+++ b/static/schemas/source/core/registry-event.json
@@ -1,0 +1,624 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/registry-event.json",
+  "title": "Registry Event",
+  "description": "A single cursor-ordered event from the AgenticAdvertising.org registry change feed. Events are denormalized so RegistrySync clients can update local property, agent, publisher, and authorization indexes without re-reading the full registry. The discriminator is event_type; each branch defines the event-specific payload shape. See specs/registry-change-feed.md.",
+  "type": "object",
+  "discriminator": {
+    "propertyName": "event_type"
+  },
+  "required": [
+    "event_id",
+    "event_type",
+    "entity_type",
+    "entity_id",
+    "payload",
+    "actor",
+    "created_at"
+  ],
+  "properties": {
+    "event_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Stable logical event identifier and feed cursor. UUID v7 is REQUIRED so consumers can apply events in event_id order without relying on producer clocks."
+    },
+    "event_type": {
+      "type": "string",
+      "enum": [
+        "property.created",
+        "property.updated",
+        "property.merged",
+        "property.stale",
+        "property.reactivated",
+        "agent.discovered",
+        "agent.removed",
+        "agent.profile_updated",
+        "agent.compliance_changed",
+        "agent.verification_earned",
+        "agent.verification_lost",
+        "publisher.adagents_discovered",
+        "publisher.adagents_changed",
+        "authorization.granted",
+        "authorization.revoked",
+        "authorization.modified"
+      ],
+      "description": "Discriminator. Determines the shape of payload."
+    },
+    "entity_type": {
+      "type": "string",
+      "enum": [
+        "property",
+        "agent",
+        "publisher",
+        "authorization"
+      ],
+      "description": "Entity class touched by this event."
+    },
+    "entity_id": {
+      "type": "string",
+      "description": "Primary identifier for the changed entity. For property.* events this is the property_rid; for agent.* events this is the agent_url; for publisher.adagents_changed this is the publisher domain; for authorization.* events this is the authorization row id or a stable agent/publisher composite."
+    },
+    "payload": {
+      "type": "object",
+      "description": "Event-type-specific payload. Shape is determined by event_type per the oneOf below."
+    },
+    "actor": {
+      "type": "string",
+      "description": "Internal producer label for audit and debugging, such as pipeline:crawler or trigger:caa_emit_event. Consumers MUST treat this as informational and not as an authorization principal."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp when the registry emitted the event. Advisory only; consumers MUST order and cursor by event_id."
+    }
+  },
+  "oneOf": [
+    {
+      "description": "property.created - a new property_rid was assigned.",
+      "properties": {
+        "event_type": { "type": "string", "const": "property.created" },
+        "entity_type": { "type": "string", "const": "property" },
+        "payload": {
+          "allOf": [
+            { "$ref": "#/$defs/propertyPayload" },
+            {
+              "type": "object",
+              "required": ["property_rid", "classification", "identifiers"]
+            }
+          ]
+        }
+      },
+      "required": ["event_type"]
+    },
+    {
+      "description": "property.updated - classification, identifiers, or metadata changed.",
+      "properties": {
+        "event_type": { "type": "string", "const": "property.updated" },
+        "entity_type": { "type": "string", "const": "property" },
+        "payload": {
+          "allOf": [
+            { "$ref": "#/$defs/propertyPayload" },
+            {
+              "type": "object",
+              "required": ["property_rid"]
+            }
+          ]
+        }
+      },
+      "required": ["event_type"]
+    },
+    {
+      "description": "property.merged - one property_rid became an alias of another.",
+      "properties": {
+        "event_type": { "type": "string", "const": "property.merged" },
+        "entity_type": { "type": "string", "const": "property" },
+        "payload": {
+          "type": "object",
+          "required": ["alias_rid", "canonical_rid"],
+          "properties": {
+            "alias_rid": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Retired property_rid that now aliases to canonical_rid."
+            },
+            "canonical_rid": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Canonical property_rid that consumers should retain."
+            },
+            "evidence": {
+              "type": "string",
+              "description": "Registry evidence source for the merge, such as adagents_json or manual_review."
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "required": ["event_type"]
+    },
+    {
+      "description": "property.stale - a property has aged out of active resolution.",
+      "properties": {
+        "event_type": { "type": "string", "const": "property.stale" },
+        "entity_type": { "type": "string", "const": "property" },
+        "payload": {
+          "type": "object",
+          "required": ["property_rid"],
+          "properties": {
+            "property_rid": { "type": "string", "format": "uuid" },
+            "last_resolved_at": { "type": "string", "format": "date-time" },
+            "reason": { "type": "string" }
+          },
+          "additionalProperties": true
+        }
+      },
+      "required": ["event_type"]
+    },
+    {
+      "description": "property.reactivated - a stale property was resolved again.",
+      "properties": {
+        "event_type": { "type": "string", "const": "property.reactivated" },
+        "entity_type": { "type": "string", "const": "property" },
+        "payload": {
+          "allOf": [
+            { "$ref": "#/$defs/propertyPayload" },
+            {
+              "type": "object",
+              "required": ["property_rid"],
+              "properties": {
+                "reactivated_at": { "type": "string", "format": "date-time" }
+              }
+            }
+          ]
+        }
+      },
+      "required": ["event_type"]
+    },
+    {
+      "description": "agent.discovered - a new agent appeared in crawled registry data.",
+      "properties": {
+        "event_type": { "type": "string", "const": "agent.discovered" },
+        "entity_type": { "type": "string", "const": "agent" },
+        "payload": {
+          "allOf": [
+            { "$ref": "#/$defs/agentProfilePayload" },
+            {
+              "type": "object",
+              "required": ["agent_url"]
+            }
+          ]
+        }
+      },
+      "required": ["event_type"]
+    },
+    {
+      "description": "agent.removed - an agent no longer appears in any crawled adagents.json authorization graph.",
+      "properties": {
+        "event_type": { "type": "string", "const": "agent.removed" },
+        "entity_type": { "type": "string", "const": "agent" },
+        "payload": {
+          "type": "object",
+          "required": ["agent_url"],
+          "properties": {
+            "agent_url": { "type": "string", "format": "uri" },
+            "removed_from_publishers": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/domain" },
+              "minItems": 1
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "required": ["event_type"]
+    },
+    {
+      "description": "agent.profile_updated - an agent inventory profile changed.",
+      "properties": {
+        "event_type": { "type": "string", "const": "agent.profile_updated" },
+        "entity_type": { "type": "string", "const": "agent" },
+        "payload": {
+          "allOf": [
+            { "$ref": "#/$defs/agentProfilePayload" },
+            {
+              "type": "object",
+              "required": ["agent_url"],
+              "properties": {
+                "changed_fields": { "$ref": "#/$defs/changedFields" }
+              }
+            }
+          ]
+        }
+      },
+      "required": ["event_type"]
+    },
+    {
+      "description": "agent.compliance_changed - an agent verification or compliance heartbeat changed status.",
+      "properties": {
+        "event_type": { "type": "string", "const": "agent.compliance_changed" },
+        "entity_type": { "type": "string", "const": "agent" },
+        "payload": { "$ref": "#/$defs/compliancePayload" }
+      },
+      "required": ["event_type"]
+    },
+    {
+      "description": "agent.verification_earned - an agent earned an AAO Verified badge.",
+      "properties": {
+        "event_type": { "type": "string", "const": "agent.verification_earned" },
+        "entity_type": { "type": "string", "const": "agent" },
+        "payload": {
+          "type": "object",
+          "required": ["agent_url", "role", "verified_specialisms"],
+          "properties": {
+            "agent_url": { "type": "string", "format": "uri" },
+            "role": { "$ref": "#/$defs/badgeRole" },
+            "verified_specialisms": {
+              "type": "array",
+              "items": { "type": "string" },
+              "minItems": 1
+            },
+            "adcp_version": { "type": "string" }
+          },
+          "additionalProperties": true
+        }
+      },
+      "required": ["event_type"]
+    },
+    {
+      "description": "agent.verification_lost - an agent lost an AAO Verified badge.",
+      "properties": {
+        "event_type": { "type": "string", "const": "agent.verification_lost" },
+        "entity_type": { "type": "string", "const": "agent" },
+        "payload": {
+          "type": "object",
+          "required": ["agent_url", "role", "reason"],
+          "properties": {
+            "agent_url": { "type": "string", "format": "uri" },
+            "role": { "$ref": "#/$defs/badgeRole" },
+            "reason": { "type": "string" },
+            "adcp_version": { "type": "string" }
+          },
+          "additionalProperties": true
+        }
+      },
+      "required": ["event_type"]
+    },
+    {
+      "description": "publisher.adagents_discovered - the crawler found a publisher adagents.json file and projected it into the registry.",
+      "properties": {
+        "event_type": { "type": "string", "const": "publisher.adagents_discovered" },
+        "entity_type": { "type": "string", "const": "publisher" },
+        "payload": { "$ref": "#/$defs/publisherAdagentsPayload" }
+      },
+      "required": ["event_type"]
+    },
+    {
+      "description": "publisher.adagents_changed - the registry crawler detected a publisher adagents.json change.",
+      "properties": {
+        "event_type": { "type": "string", "const": "publisher.adagents_changed" },
+        "entity_type": { "type": "string", "const": "publisher" },
+        "payload": {
+          "allOf": [
+            { "$ref": "#/$defs/publisherAdagentsPayload" },
+            {
+              "type": "object",
+              "properties": {
+                "properties_added": { "type": "integer", "minimum": 0 },
+                "properties_removed": { "type": "integer", "minimum": 0 },
+                "agents_added": {
+                  "type": "array",
+                  "items": { "type": "string", "format": "uri" }
+                },
+                "agents_removed": {
+                  "type": "array",
+                  "items": { "type": "string", "format": "uri" }
+                },
+                "changed_fields": { "$ref": "#/$defs/changedFields" }
+              }
+            }
+          ]
+        }
+      },
+      "required": ["event_type"]
+    },
+    {
+      "description": "authorization.granted - an agent became authorized for a publisher or scoped inventory slice.",
+      "properties": {
+        "event_type": { "type": "string", "const": "authorization.granted" },
+        "entity_type": { "type": "string", "const": "authorization" },
+        "payload": { "$ref": "#/$defs/authorizationPayload" }
+      },
+      "required": ["event_type"]
+    },
+    {
+      "description": "authorization.revoked - an agent authorization is no longer visible in the effective registry set.",
+      "properties": {
+        "event_type": { "type": "string", "const": "authorization.revoked" },
+        "entity_type": { "type": "string", "const": "authorization" },
+        "payload": { "$ref": "#/$defs/authorizationPayload" }
+      },
+      "required": ["event_type"]
+    },
+    {
+      "description": "authorization.modified - an authorization row remained visible, but externally visible metadata changed.",
+      "properties": {
+        "event_type": { "type": "string", "const": "authorization.modified" },
+        "entity_type": { "type": "string", "const": "authorization" },
+        "payload": { "$ref": "#/$defs/authorizationPayload" }
+      },
+      "required": ["event_type"]
+    }
+  ],
+  "$defs": {
+    "domain": {
+      "type": "string",
+      "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$"
+    },
+    "publisherAdagentsPayload": {
+          "type": "object",
+          "anyOf": [
+            { "required": ["publisher_domain"] },
+            { "required": ["domain"] }
+          ],
+          "properties": {
+            "publisher_domain": { "$ref": "#/$defs/domain" },
+            "domain": {
+              "$ref": "#/$defs/domain",
+              "description": "Legacy alias for publisher_domain retained for early feed examples."
+            },
+            "properties_added": { "type": "integer", "minimum": 0 },
+            "properties_removed": { "type": "integer", "minimum": 0 },
+            "agents_added": {
+              "type": "array",
+              "items": { "type": "string", "format": "uri" }
+            },
+            "agents_removed": {
+              "type": "array",
+              "items": { "type": "string", "format": "uri" }
+            },
+            "agent_count": { "type": "integer", "minimum": 0 },
+            "property_count": { "type": "integer", "minimum": 0 },
+            "discovery_method": { "type": "string" },
+            "manager_domain": { "type": ["string", "null"] },
+            "source": { "type": "string" }
+          },
+          "additionalProperties": true
+    },
+    "badgeRole": {
+      "type": "string",
+      "enum": ["media-buy", "creative", "signals", "governance", "brand", "sponsored-intelligence"]
+    },
+    "stringArray": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "changedFields": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 1,
+      "description": "Advisory list of changed top-level field names. Consumers MAY use this for targeted index refresh but MUST treat the event payload as authoritative."
+    },
+    "classification": {
+      "type": "string",
+      "enum": ["property", "ad_infra", "publisher_mask", "network", "unclassified"]
+    },
+    "propertySource": {
+      "type": "string",
+      "enum": ["authoritative", "enriched", "contributed"]
+    },
+    "propertyPayload": {
+      "type": "object",
+      "properties": {
+        "property_rid": { "type": "string", "format": "uuid" },
+        "classification": { "$ref": "#/$defs/classification" },
+        "source": { "$ref": "#/$defs/propertySource" },
+        "identifiers": {
+          "type": "array",
+          "items": { "$ref": "/schemas/core/identifier.json" },
+          "minItems": 1
+        },
+        "publisher_domain": { "$ref": "#/$defs/domain" },
+        "property": {
+          "$ref": "/schemas/core/property.json",
+          "description": "Optional full post-change property object when available."
+        },
+        "changed_fields": { "$ref": "#/$defs/changedFields" }
+      },
+      "additionalProperties": true
+    },
+    "agentProfilePayload": {
+      "type": "object",
+      "properties": {
+        "agent_url": { "type": "string", "format": "uri" },
+        "name": { "type": "string" },
+        "type": {
+          "type": "string",
+          "enum": ["sales", "creative", "signals", "governance", "measurement", "unknown"]
+        },
+        "channels": { "$ref": "#/$defs/stringArray" },
+        "property_types": { "$ref": "#/$defs/stringArray" },
+        "markets": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Z]{2}$"
+          },
+          "uniqueItems": true
+        },
+        "categories": { "$ref": "#/$defs/stringArray" },
+        "category_taxonomy": { "type": ["string", "null"] },
+        "format_ids": {
+          "type": "array",
+          "items": { "$ref": "/schemas/core/format-id.json" }
+        },
+        "tags": { "$ref": "#/$defs/stringArray" },
+        "delivery_types": { "$ref": "#/$defs/stringArray" },
+        "property_count": { "type": "integer", "minimum": 0 },
+        "publisher_count": { "type": "integer", "minimum": 0 },
+        "has_tmp": { "type": "boolean" },
+        "updated_at": { "type": "string", "format": "date-time" }
+      },
+      "additionalProperties": true
+    },
+    "countries": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Z]{2}$"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "authorizationPayload": {
+      "type": "object",
+      "required": ["agent_url", "publisher_domain"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Registry authorization row id when the event is backed by a materialized effective authorization row."
+        },
+        "agent_url": { "type": "string", "format": "uri" },
+        "agent_url_canonical": {
+          "type": "string",
+          "description": "Registry-canonicalized form of agent_url for equality checks."
+        },
+        "publisher_domain": { "$ref": "#/$defs/domain" },
+        "authorization_type": {
+          "type": "string",
+          "enum": [
+            "property_ids",
+            "property_tags",
+            "inline_properties",
+            "publisher_properties",
+            "signal_ids",
+            "signal_tags"
+          ],
+          "description": "When present, identifies the adagents.json authorization variant represented by this payload."
+        },
+        "authorized_for": { "type": ["string", "null"] },
+        "property_ids": {
+          "type": "array",
+          "items": { "$ref": "/schemas/core/property-id.json" },
+          "minItems": 1
+        },
+        "property_tags": {
+          "type": "array",
+          "items": { "$ref": "/schemas/core/property-tag.json" },
+          "minItems": 1
+        },
+        "properties": {
+          "type": "array",
+          "items": { "$ref": "/schemas/core/property.json" },
+          "minItems": 1
+        },
+        "publisher_properties": {
+          "type": "array",
+          "items": { "$ref": "/schemas/core/publisher-property-selector.json" },
+          "minItems": 1
+        },
+        "property_rid": {
+          "type": ["string", "null"],
+          "format": "uuid",
+          "description": "Catalog property_rid for materialized per-property authorization rows. Null for publisher-wide rows."
+        },
+        "property_id_slug": {
+          "type": ["string", "null"],
+          "description": "Publisher-local property id for materialized per-property authorization rows."
+        },
+        "placement_ids": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
+        },
+        "placement_tags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "collections": {
+          "type": "array",
+          "items": { "$ref": "/schemas/core/collection-selector.json" },
+          "minItems": 1
+        },
+        "countries": { "$ref": "#/$defs/countries" },
+        "delegation_type": {
+          "type": "string",
+          "enum": ["direct", "delegated", "ad_network"]
+        },
+        "exclusive": { "type": "boolean" },
+        "signing_keys": {
+          "type": "array",
+          "items": { "$ref": "/schemas/core/agent-signing-key.json" },
+          "minItems": 1,
+          "description": "Publisher-attested signing keys copied from adagents.json when the registry has them. Advisory in feed events; verifiers MUST re-fetch the authoritative publisher artifact before treating keys as a trust anchor."
+        },
+        "effective_from": { "type": "string", "format": "date-time" },
+        "effective_until": { "type": "string", "format": "date-time" },
+        "evidence": {
+          "type": "string",
+          "enum": ["adagents_json", "agent_claim", "community", "override"]
+        },
+        "disputed": { "type": "boolean" },
+        "created_by": { "type": ["string", "null"] },
+        "expires_at": { "type": ["string", "null"], "format": "date-time" },
+        "created_at": { "type": ["string", "null"], "format": "date-time" },
+        "updated_at": { "type": ["string", "null"], "format": "date-time" },
+        "override_applied": { "type": "boolean" },
+        "override_reason": { "type": ["string", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "compliancePayload": {
+      "type": "object",
+      "required": [
+        "agent_url",
+        "previous_status",
+        "current_status",
+        "tracks",
+        "storyboards_passing",
+        "storyboards_total"
+      ],
+      "properties": {
+        "agent_url": { "type": "string", "format": "uri" },
+        "previous_status": { "$ref": "#/$defs/complianceStatus" },
+        "current_status": { "$ref": "#/$defs/complianceStatus" },
+        "headline": { "type": ["string", "null"] },
+        "tracks": {
+          "type": "object",
+          "description": "Map of compliance track id to track status.",
+          "additionalProperties": {
+            "type": "string",
+            "enum": ["pass", "fail", "partial", "skip", "silent", "warning", "unknown", "skipped"]
+          }
+        },
+        "storyboards_passing": { "type": "integer", "minimum": 0 },
+        "storyboards_total": { "type": "integer", "minimum": 0 },
+        "storyboards": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["storyboard_id", "status"],
+            "properties": {
+              "storyboard_id": { "type": "string" },
+              "status": { "$ref": "#/$defs/storyboardStatus" },
+              "steps_passed": { "type": "integer", "minimum": 0 },
+              "steps_total": { "type": "integer", "minimum": 0 }
+            },
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "complianceStatus": {
+      "type": "string",
+      "enum": ["passing", "degraded", "failing", "unknown"]
+    },
+    "storyboardStatus": {
+      "type": "string",
+      "enum": ["passing", "failing", "partial", "untested", "skipped", "not_selected", "unknown"]
+    }
+  }
+}

--- a/static/schemas/source/core/registry-feed-response.json
+++ b/static/schemas/source/core/registry-feed-response.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/registry-feed-response.json",
+  "title": "Registry Feed Response",
+  "description": "Response from GET /api/registry/feed. The events array contains cursor-ordered registry events; cursor is the value to pass on the next poll. See specs/registry-change-feed.md.",
+  "type": "object",
+  "properties": {
+    "events": {
+      "type": "array",
+      "items": {
+        "$ref": "/schemas/core/registry-event.json"
+      }
+    },
+    "cursor": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "uuid",
+      "description": "Pass this value as cursor on the next request to continue polling. Null only when the feed has no events and no prior cursor."
+    },
+    "has_more": {
+      "type": "boolean",
+      "description": "True when more events are immediately available after cursor."
+    }
+  },
+  "required": [
+    "events",
+    "cursor",
+    "has_more"
+  ],
+  "additionalProperties": true
+}

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -158,6 +158,14 @@
           "$ref": "/schemas/core/reference-asset.json",
           "description": "A reference asset with semantic role for creative context"
         },
+        "registry-event": {
+          "$ref": "/schemas/core/registry-event.json",
+          "description": "A cursor-ordered registry change-feed event from /api/registry/feed"
+        },
+        "registry-feed-response": {
+          "$ref": "/schemas/core/registry-feed-response.json",
+          "description": "Response wrapper for GET /api/registry/feed"
+        },
         "proposal": {
           "$ref": "/schemas/core/proposal.json",
           "description": "A proposed media plan with budget allocations across products - actionable via create_media_buy"

--- a/tests/composed-schema-validation.test.cjs
+++ b/tests/composed-schema-validation.test.cjs
@@ -912,6 +912,171 @@ async function runTests() {
     },
     'Wholesale signal event accepts deprecated signal_id and relaxed data_provider/pricing_options'
   );
+
+  log('Registry change feed schemas:', 'info');
+  await testSchemaValidation(
+    '/schemas/core/registry-feed-response.json',
+    {
+      events: [
+        {
+          event_id: '019539a0-1234-7000-8000-000000000001',
+          event_type: 'property.created',
+          entity_type: 'property',
+          entity_id: '019539a0-b1c2-7000-8000-000000000002',
+          payload: {
+            property_rid: '019539a0-b1c2-7000-8000-000000000002',
+            classification: 'property',
+            source: 'contributed',
+            identifiers: [{ type: 'domain', value: 'streamer.example.com' }]
+          },
+          actor: 'pipeline:crawler',
+          created_at: '2026-03-31T10:00:00.000Z'
+        },
+        {
+          event_id: '019539a0-1234-7000-8000-000000000003',
+          event_type: 'authorization.granted',
+          entity_type: 'authorization',
+          entity_id: 'https://ads.agency.example.com:streamer.example.com',
+          payload: {
+            agent_url: 'https://ads.agency.example.com',
+            publisher_domain: 'streamer.example.com',
+            authorization_type: 'property_ids',
+            property_ids: ['primetime_ctv'],
+            placement_ids: ['pre_roll_30s'],
+            countries: ['US', 'CA'],
+            delegation_type: 'direct',
+            exclusive: false,
+            signing_keys: [{ kid: 'pub-2026-04', kty: 'OKP', alg: 'EdDSA', crv: 'Ed25519', x: 'abc123' }]
+          },
+          actor: 'pipeline:crawler',
+          created_at: '2026-03-31T10:01:00.000Z'
+        },
+        {
+          event_id: '019539a0-1234-7000-8000-000000000007',
+          event_type: 'agent.discovered',
+          entity_type: 'agent',
+          entity_id: 'https://new-agent.example.com',
+          payload: {
+            agent_url: 'https://new-agent.example.com',
+            channels: [],
+            property_types: [],
+            markets: [],
+            categories: [],
+            tags: [],
+            delivery_types: [],
+            property_count: 0,
+            publisher_count: 0,
+            has_tmp: false
+          },
+          actor: 'pipeline:crawler',
+          created_at: '2026-03-31T10:01:30.000Z'
+        },
+        {
+          event_id: '019539a0-1234-7000-8000-000000000004',
+          event_type: 'agent.compliance_changed',
+          entity_type: 'agent',
+          entity_id: 'https://ads.agency.example.com',
+          payload: {
+            agent_url: 'https://ads.agency.example.com',
+            previous_status: 'passing',
+            current_status: 'degraded',
+            headline: 'media_buy track failing: 2 scenarios down',
+            tracks: { core: 'pass', media_buy: 'partial', creative: 'skip', governance: 'silent' },
+            storyboards_passing: 24,
+            storyboards_total: 27,
+            storyboards: [
+              { storyboard_id: 'media_buy_seller', status: 'failing', steps_passed: 4, steps_total: 7 },
+              { storyboard_id: 'optional_controller', status: 'untested' },
+              { storyboard_id: 'mixed_flow', status: 'partial', steps_passed: 3, steps_total: 5 }
+            ]
+          },
+          actor: 'pipeline:compliance-heartbeat',
+          created_at: '2026-03-31T10:02:00.000Z'
+        },
+        {
+          event_id: '019539a0-1234-7000-8000-000000000008',
+          event_type: 'agent.verification_earned',
+          entity_type: 'agent',
+          entity_id: 'https://ads.agency.example.com',
+          payload: {
+            agent_url: 'https://ads.agency.example.com',
+            role: 'media-buy',
+            verified_specialisms: ['sales-catalog-driven'],
+            adcp_version: '3.1.0-beta.5'
+          },
+          actor: 'pipeline:compliance-heartbeat',
+          created_at: '2026-03-31T10:02:30.000Z'
+        },
+        {
+          event_id: '019539a0-1234-7000-8000-000000000009',
+          event_type: 'agent.verification_lost',
+          entity_type: 'agent',
+          entity_id: 'https://ads.agency.example.com',
+          payload: {
+            agent_url: 'https://ads.agency.example.com',
+            role: 'media-buy',
+            reason: 'media_buy track failing'
+          },
+          actor: 'pipeline:compliance-heartbeat',
+          created_at: '2026-03-31T10:02:45.000Z'
+        },
+        {
+          event_id: '019539a0-1234-7000-8000-000000000010',
+          event_type: 'publisher.adagents_discovered',
+          entity_type: 'publisher',
+          entity_id: 'streamer.example.com',
+          payload: {
+            publisher_domain: 'streamer.example.com',
+            agent_count: 2,
+            property_count: 4,
+            source: 'catalog_crawl',
+            discovery_method: 'direct',
+            manager_domain: null
+          },
+          actor: 'pipeline:catalog_crawl',
+          created_at: '2026-03-31T10:03:00.000Z'
+        }
+      ],
+      cursor: '019539a0-1234-7000-8000-000000000010',
+      has_more: false
+    },
+    'Registry feed response validates typed property, authorization, and compliance events'
+  );
+  await testSchemaRejection(
+    '/schemas/core/registry-event.json',
+    {
+      event_id: '019539a0-1234-7000-8000-000000000005',
+      event_type: 'authorization.granted',
+      entity_type: 'authorization',
+      entity_id: 'https://ads.agency.example.com:streamer.example.com',
+      payload: {
+        agent_url: 'https://ads.agency.example.com'
+      },
+      actor: 'pipeline:crawler',
+      created_at: '2026-03-31T10:03:00.000Z'
+    },
+    'Registry authorization events reject missing publisher_domain'
+  );
+  await testSchemaRejection(
+    '/schemas/core/registry-event.json',
+    {
+      event_id: '019539a0-1234-7000-8000-000000000006',
+      event_type: 'agent.compliance_changed',
+      entity_type: 'publisher',
+      entity_id: 'https://ads.agency.example.com',
+      payload: {
+        agent_url: 'https://ads.agency.example.com',
+        previous_status: 'passing',
+        current_status: 'degraded',
+        tracks: { core: 'pass' },
+        storyboards_passing: 1,
+        storyboards_total: 2
+      },
+      actor: 'pipeline:compliance-heartbeat',
+      created_at: '2026-03-31T10:04:00.000Z'
+    },
+    'Registry event discriminator rejects mismatched entity_type'
+  );
   log('');
 
   // Product `publisher_properties` rejects `publisher_domains[]` compact form (#4508):


### PR DESCRIPTION
## Summary
- add core registry feed response and event schemas for `/api/registry/feed`
- register the schemas for generation/SDK discovery
- align registry docs/specs with the implemented cursor, filters, and event vocabulary
- add composed-schema validation coverage for representative registry feed events

Fixes #4792

## Tests
- npm run build:schemas
- npm run test:composed
- npm run test:schemas
- npm run test:oneof-discriminators
- npm run test:json-schema
- npm run test:schema-links
- npm run test:docs-nav
- npm run lint:schema-links
- git diff --check
- precommit: npm run test:unit && npm run test:test-dynamic-imports && npm run test:callapi-state-change && npm run typecheck
- prepush: verify-version-sync, schema-link lint, Mintlify broken-links check