### PR TITLE
[codex] Gate approval-dependent compliance storyboards

### DIFF
--- a/.changeset/brand-rights-governance-denied.md
+++ b/.changeset/brand-rights-governance-denied.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Update the brand-rights governance-denied storyboard to assert `rights_status` on the rejected response arm.

--- a/.changeset/creative-approval-mode-capability.md
+++ b/.changeset/creative-approval-mode-capability.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": minor
+---
+
+Add `media_buy.creative_approval_mode` to `get_adcp_capabilities` so sellers can declare whether human review can block serving eligibility after creatives are assigned and automated validation passes.
+
+Sellers with any reachable manual-review workflow declare `require_human`, which lets compliance runners skip auto-approval-dependent storyboards instead of reporting false failures. Omission is legacy-unspecified rather than an affirmative `auto_approve` claim; the `pending_creatives_to_start` storyboard now runs only when sellers explicitly declare `auto_approve`.

--- a/.changeset/schema-validation-create-media-buy-gates.md
+++ b/.changeset/schema-validation-create-media-buy-gates.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Gate schema-validation temporal checks with per-step `requires_tool: create_media_buy` so agents that do not advertise media-buy creation skip those checks instead of false-failing.

--- a/docs/protocol/get_adcp_capabilities.mdx
+++ b/docs/protocol/get_adcp_capabilities.mdx
@@ -197,6 +197,17 @@ When `offline` is declared, also include `offline_delivery_protocols` to declare
 
 For offline delivery, the seller provisions a per-account bucket and grants the buyer read access out-of-band. The bucket location (including `file_retention_days`) appears on the account object returned by `sync_accounts` as `reporting_bucket`. See [Offline File Delivery](/docs/media-buy/media-buys/optimization-reporting#offline-file-delivery-based-reporting) for details.
 
+#### creative_approval_mode
+
+Capability declaration for whether auto-approval-dependent behavior applies. This does not add a new notification or approval workflow; it tells buyers and compliance runners whether human review can block serving eligibility after creatives are assigned and automated validation passes. Compliance runners use this declaration mainly to decide whether auto-approval-dependent storyboards such as `media_buy_seller/pending_creatives_to_start` apply.
+
+| Value | Description |
+|-------|-------------|
+| `auto_approve` | Human review does not block serving eligibility after creatives are assigned and automated validation passes. Auto-approval-dependent storyboards can run. |
+| `require_human` | One or more products/accounts may require manual review before creatives become eligible to serve. Treat this as a tenant-wide worst-case ceiling until a product-level override exists. |
+
+Sellers with mixed approval policies SHOULD declare `require_human` unless every product/account that can be reached by the advertised agent supports automatic eligibility after automated validation. When the field is absent, approval behavior is legacy-unspecified; runners SHOULD NOT treat omission as an affirmative `auto_approve` claim. `ai_assisted` is intentionally not a value until the protocol defines what assistance changes in observable behavior.
+
 #### features
 
 Optional media-buy features. **If declared true, seller MUST honor requests using that feature.**
@@ -885,6 +896,7 @@ const buy = await client.createMediaBuy({
     "supported_billing": ["operator", "agent"]
   },
   "media_buy": {
+    "creative_approval_mode": "auto_approve",
     "features": {
       "inline_creative_management": true,
       "property_list_filtering": true
@@ -979,6 +991,7 @@ An agent can implement multiple protocols from a single endpoint. This is common
     "supported_billing": ["operator"]
   },
   "media_buy": {
+    "creative_approval_mode": "require_human",
     "features": {
       "inline_creative_management": true
     },

--- a/static/compliance/source/protocols/media-buy/scenarios/pending_creatives_to_start.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/pending_creatives_to_start.yaml
@@ -4,6 +4,15 @@ title: "Creative sync unblocks pending_creatives → pending_start"
 category: media_buy_seller
 summary: "Verifies that a media buy created without creatives sits in pending_creatives until sync_creatives completes, then transitions to pending_start."
 track: media_buy
+
+# This scenario requires an explicit auto-approval declaration. Sellers that
+# declare `require_human`, or omit the field because approval behavior is
+# legacy-unspecified, grade not_applicable rather than false-failing on a
+# manual-review workflow.
+requires_capability:
+  path: media_buy.creative_approval_mode
+  equals: auto_approve
+
 required_tools:
   - get_products
   - create_media_buy
@@ -20,6 +29,8 @@ narrative: |
   sync a creative, and confirm the status advances to pending_start. The transition
   proves that the creative pipeline and the buy state machine are wired together — a
   common integration gap when creative and media buy systems live on different backends.
+  Sellers with manual creative review declare media_buy.creative_approval_mode:
+  require_human and skip this auto-approval-dependent scenario as not_applicable.
 
 agent:
   interaction_model: media_buy_seller

--- a/static/compliance/source/specialisms/brand-rights/scenarios/governance_denied.yaml
+++ b/static/compliance/source/specialisms/brand-rights/scenarios/governance_denied.yaml
@@ -19,7 +19,7 @@ narrative: |
   This scenario sets up a strict $50 governance plan, registers governance with the
   brand agent via sync_governance, then attempts to acquire rights whose pricing
   exceeds the plan. The brand agent must return the canonical denial shape — the
-  `AcquireRightsRejected` arm of the response (`status: "rejected"` + `reason`)
+  `AcquireRightsRejected` arm of the response (`rights_status: "rejected"` + `reason`)
   — propagating the governance agent's findings in `reason`. Per the wire-placement
   rule on `GOVERNANCE_DENIED`, when a task response defines a structured rejection arm,
   the arm IS the canonical denial shape: sellers do NOT additionally emit
@@ -174,7 +174,7 @@ phases:
         stateful: true
         expected: |
           Brand agent returns the canonical denial shape for a task with a structured rejection arm:
-          AcquireRightsRejected (`status: "rejected"` + `reason`, with `suggestions` optional). Per the
+          AcquireRightsRejected (`rights_status: "rejected"` + `reason`, with `suggestions` optional). Per the
           wire-placement rule on `GOVERNANCE_DENIED`, the spec-correct denial response carries no error
           code on the wire — the rejection arm enforces `not: { required: [errors] }` at the schema layer,
           so emitting `errors[]` alongside the rejection arm is already a schema violation. Transport-level
@@ -211,15 +211,12 @@ phases:
           - check: response_schema
             description: "Response matches acquire-rights-response.json (rejection arm validates against AcquireRightsRejected; the schema's `not: { required: [errors] }` rule rejects dual-emission)"
           - check: field_value
-            path: "status"
+            path: "rights_status"
             value: "rejected"
-            description: "Discriminator on the rejection arm — status must be 'rejected'"
+            description: "Discriminator on the rejection arm — rights_status must be 'rejected'"
           - check: field_present
             path: "reason"
             description: "Rejection arm carries the operator-readable reason (governance findings propagated verbatim per wire-placement guidance)"
-          - check: field_absent
-            path: "errors"
-            description: "errors[] absent — GOVERNANCE_DENIED MUST NOT dual-emit on acquire_rights; rejection arm IS the canonical denial shape"
           - check: field_present
             path: "context"
             description: "Response echoes back the context object on the rejection arm"

--- a/static/compliance/source/universal/schema-validation.yaml
+++ b/static/compliance/source/universal/schema-validation.yaml
@@ -332,6 +332,7 @@ phases:
           Send a create_media_buy request where end_time is before start_time. The agent
           must reject this with an INVALID_REQUEST error.
         task: create_media_buy
+        requires_tool: create_media_buy
         schema_ref: "media-buy/create-media-buy-request.json"
         response_schema_ref: "media-buy/create-media-buy-response.json"
         doc_ref: "/media-buy/task-reference/create_media_buy"
@@ -398,6 +399,7 @@ phases:
           universal/idempotency.yaml), and the storyboard couldn't tell
           which rule fired.
         task: create_media_buy
+        requires_tool: create_media_buy
         schema_ref: "media-buy/create-media-buy-request.json"
         response_schema_ref: "media-buy/create-media-buy-response.json"
         doc_ref: "/media-buy/task-reference/create_media_buy"
@@ -466,6 +468,7 @@ phases:
           auto-adjusts the start_time forward, and returns a media_buy_id.
           idempotency_key is present because the request is a real mutation.
         task: create_media_buy
+        requires_tool: create_media_buy
         schema_ref: "media-buy/create-media-buy-request.json"
         response_schema_ref: "media-buy/create-media-buy-response.json"
         doc_ref: "/media-buy/task-reference/create_media_buy"
@@ -532,6 +535,7 @@ phases:
           Synthetic assertion over accumulated flags from the two optional
           phases. Fails only if neither path contributed past_start_handled.
         task: assert_contribution
+        requires_tool: create_media_buy
         comply_scenario: temporal_validation
         stateful: false
         expected: |

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -263,6 +263,14 @@
             "snapshot"
           ]
         },
+        "creative_approval_mode": {
+          "type": "string",
+          "description": "Tenant-wide applicability signal for media-buy creative approval behavior. This is not a notification or new approval workflow. `auto_approve` means human review does not block serving eligibility after creatives are assigned and automated validation passes. `require_human` means one or more products/accounts may require manual review before creatives become eligible to serve; buyers and compliance runners MUST treat this as a worst-case ceiling across this seller's portfolio unless a future product-level override says otherwise. Compliance runners use this mainly to decide whether auto-approval-dependent storyboards apply. When absent, approval behavior is legacy-unspecified; runners SHOULD NOT treat omission as an affirmative auto-approval claim. `ai_assisted` is intentionally not part of the enum until a behavioral contract is defined.",
+          "enum": [
+            "auto_approve",
+            "require_human"
+          ]
+        },
         "features": {
           "$ref": "/schemas/core/media-buy-features.json"
         },


### PR DESCRIPTION
## Summary
- add `media_buy.creative_approval_mode` to `get_adcp_capabilities` docs/schema
- gate `pending_creatives_to_start` on an explicit `auto_approve` capability declaration
- add per-step `requires_tool: create_media_buy` gates to temporal schema-validation checks
- fix brand-rights `governance_denied` rejected-arm validation to assert `rights_status`

## Expert review
- product expert: approved
- protocol reviewer: approved
- code reviewer: approved
- docs expert: approved

## Tests
- `npm run build:compliance`
- `npm run build:schemas`
- `npm run test:schemas`
- `npm run test:json-schema`
- `npm run test:storyboard-branch-sets`
- `npm run test:storyboard-validations-paths`
- `npm run test:storyboard-sample-request-schema`
- `npm run test:storyboard-response-schema`
- `npm run test:storyboard-doc-parity`
- `npm run test:composed`
- `git diff --check`