### PR TITLE
[codex] Add canonical format curriculum coverage

### DIFF
--- a/.changeset/canonical-format-curriculum.md
+++ b/.changeset/canonical-format-curriculum.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": patch
+---
+
+Add canonical-format coverage to the S2 creative specialist curriculum, including a hands-on authoring lab, glossary entries, and stable success criteria for targeted recertification.
+
+Foundations and buyer-track learning pages now mention 3.1 `format_options[]` at orientation depth and point learners to S2 for canonical-first validation details.

--- a/.changeset/canonical-format-curriculum.md
+++ b/.changeset/canonical-format-curriculum.md
@@ -7,3 +7,5 @@ Add canonical-format coverage to the S2 creative specialist curriculum, includin
 Foundations and buyer-track learning pages now mention 3.1 `format_options[]` at orientation depth and point learners to S2 for canonical-first validation details.
 
 Recertification trigger wiring is intentionally deferred to the follow-up issue referenced from the PR; this patch only adds stable criterion IDs and curriculum coverage.
+
+Also clarifies that `creative_approval_mode` is a discovery declaration for auto-approval-dependent behavior, not a notification or approval workflow.

--- a/.changeset/canonical-format-curriculum.md
+++ b/.changeset/canonical-format-curriculum.md
@@ -5,3 +5,5 @@
 Add canonical-format coverage to the S2 creative specialist curriculum, including a hands-on authoring lab, glossary entries, and stable success criteria for targeted recertification.
 
 Foundations and buyer-track learning pages now mention 3.1 `format_options[]` at orientation depth and point learners to S2 for canonical-first validation details.
+
+Recertification trigger wiring is intentionally deferred to the follow-up issue referenced from the PR; this patch only adds stable criterion IDs and curriculum coverage.

--- a/docs/creative/canonical-formats.mdx
+++ b/docs/creative/canonical-formats.mdx
@@ -19,6 +19,8 @@ testable: true
 
 Canonical formats collapse today's separate format registry into product-bound declarations. AdCP defines a small set of **canonical formats** (universal building blocks); sellers' products carry inline `ProductFormatDeclaration`s that narrow canonicals with platform-specific parameters. Creative agents become transformation services declaring `build_creative` capabilities targeting canonical formats. Most existing concepts (CTAs, destinations, tracking, brand identity) are reused or stay in their current homes — canonical formats don't create a new vocabulary layer for those.
 
+For hands-on authoring practice, use the [S2 creative specialist module](/docs/learning/specialist/creative), which links to this reference instead of duplicating it.
+
 ## Glossary
 
 | Term | One-line definition |
@@ -1271,6 +1273,7 @@ The SDK side's v1→v2 projection (validated in [adcp-client #1815](https://gith
 
 ## Related
 
+- [S2 creative specialist module](/docs/learning/specialist/creative) — training lab for reading product `format_options[]`, selecting `format_kind`, and mapping `asset_source`
 - [v1 → canonical-formats migration guide](/docs/creative/canonical-formats-migration) — concrete migration paths for sellers, creative agents, buyers, and publisher-direct integrations
 - [RFC #3305](https://github.com/adcontextprotocol/adcp/issues/3305) — v2 architecture decisions and rationale
 - [PR #3307](https://github.com/adcontextprotocol/adcp/pull/3307) — Phase 1 + Phase 2 implementation, on hold pending 3.1.0 beta cycle

--- a/docs/learning/foundations/a2-protocol-architecture.mdx
+++ b/docs/learning/foundations/a2-protocol-architecture.mdx
@@ -16,6 +16,7 @@ description: "Module A2: Execute your first AdCP media buy. Free 20-minute hands
 - Execute the full media buy lifecycle: discovery, purchase, creative sync, delivery
 - Identify the agent roles involved: buyer agent, sales agent, creative agent, signals agent
 - Read and understand real protocol messages at each stage
+- Recognize that 3.1 products may describe creative requirements with canonical `format_options[]` that narrow shared `format_kind` contracts
 - Observe a live agent-to-agent transaction
 - Recognize the two things that make agent-to-agent requests safe: the request is signed (so the seller can verify who sent it) and it carries an `idempotency_key` (so a retry doesn't double-book)
 
@@ -57,6 +58,7 @@ description: "Module A2: Execute your first AdCP media buy. Free 20-minute hands
 | **Idempotency key** | A unique tag on each mutating request that lets a buyer safely retry without creating a duplicate |
 | **Domain** | A broad protocol area an agent supports — `media_buy`, `creative`, `signals`, `governance`, `brand`, `sponsored_intelligence`. Declared via `supported_protocols`. |
 | **Specialism** | A narrow capability claim within a domain — e.g. `sales-guaranteed`, `creative-generative`, `signal-marketplace`. Declared via `specialisms`. See the [Compliance Catalog](/docs/building/compliance-catalog). |
+| **Canonical formats** | AdCP 3.1's v2 path for creative requirements: products can publish `format_options[]` that narrow shared creative archetypes such as `image` or `video_hosted`. Validate against the canonical first, then the product's narrowing. |
 | **Storyboard** | A scripted compliance scenario shipped by the protocol at `/compliance/{version}/` — agents don't write them, they're run against agents. An agent demonstrates its domain and specialism claims by passing the matching storyboards. |
 
 ## Protocol versioning

--- a/docs/learning/specialist/creative.mdx
+++ b/docs/learning/specialist/creative.mdx
@@ -179,7 +179,7 @@ Vendors often offer multiple pricing options per creative — volume/commitment 
 
 ### Canonical formats
 
-6. **Canonical-formats authoring** — Using a multi-format display product and a generative video product from the canonical fixture pool:
+6. **Canonical-formats authoring** — Using the validated reference fixtures in `static/examples/products/canonical/`: the multi-format display fixture (`nytimes_homepage_mrec.json`) and the generative video fixture (`veo_generative_video_15s.json`):
    - Read each product's `format_options[]` and identify every available `format_kind`
    - Select `format_option_id` when the product publishes one, and explain why a single-option product may not expose a separate selector
    - Write the manifest asset map implied by the selected option's slots, including when the buyer ships rendered assets and when the buyer ships a brief, video brief, or structured object
@@ -200,7 +200,7 @@ Vendors often offer multiple pricing options per creative — volume/commitment 
 | Dimension | Weight | What Addie evaluates |
 |-----------|--------|---------------------|
 | Interaction models | 20% | Correctly identifies and works with all three creative agent types |
-| Cross-platform and canonical formats | 25% | Adapts creatives across channels and formats; reads `format_options[]`, selects `format_kind`, maps `asset_source`, and explains product narrowing |
+| Cross-platform and canonical formats | 25% | Adapts creatives across channels and formats; reads `format_options[]`, selects `format_kind`, maps `asset_source` values to buyer-provided, agent-synthesized, seller-rendered, seller-designed, and publisher-hosted workflows, and explains product narrowing |
 | Compliance | 25% | Configures disclosures, provenance, and regulatory requirements |
 | Pricing and accounts | 15% | Understands rate cards, reads pricing from `list_creatives` and `list_creative_formats`, interprets build costs, closes the `report_usage` loop |
 | Analytical skill | 15% | Interprets creative feature evaluation and delivery results |

--- a/docs/learning/specialist/creative.mdx
+++ b/docs/learning/specialist/creative.mdx
@@ -32,6 +32,7 @@ The following `specialisms` fall under the `creative` domain. Each has its own c
 - Work with stateful ad servers: browse a creative library, generate tags per media buy, track delivery
 - Work with stateful sales agents: push creatives, preview in the publisher's environment
 - Adapt a single creative concept across multiple channels and formats
+- Author against AdCP canonical formats: read `format_options[]`, choose the right `format_kind`, map `asset_source`, and explain how a product narrows the canonical contract
 - Use `preview_creative` in all three request modes — single, batch (5–10× faster for many creatives), and variant (retrieve historical renders from `get_creative_delivery`) — and choose `output_format: "html"` when bypassing the iframe speeds rendering
 - Understand creative agent pricing: the `pricing_options[]` array on discovery responses, how `pricing_option_id` flows through `build_creative` and `report_usage`, and why CPM ad servers show zero `vendor_cost` at build time while transformation agents do not
 - Reason about tracker-slot presence — a format supports third-party measurement only if its `assets` array declares a tracker slot (e.g., `impression_tracker`). Broadcast formats intentionally omit tracker slots; measurement comes from panel and STB data via `billing_measurement`
@@ -68,6 +69,9 @@ The following `specialisms` fall under the `creative` domain. Each has its own c
   </Card>
   <Card title="Formats reference" icon="image" href="/docs/creative/formats">
     Format definitions, technical specs, and the renders structure.
+  </Card>
+  <Card title="Canonical formats" icon="shapes" href="/docs/creative/canonical-formats">
+    AdCP-defined format archetypes, product-level `format_options[]`, and asset-source taxonomy.
   </Card>
   <Card title="Asset types" icon="photo-film" href="/docs/creative/asset-types">
     Images, video, audio, HTML5, and native asset specifications.
@@ -129,6 +133,17 @@ export AGENT_URL="https://test-agent.adcontextprotocol.org/creative/mcp"
 
 See the [Quickstart](/docs/quickstart) for a walkthrough of your first call.
 
+## Canonical-format glossary
+
+| Term | Definition |
+|---|---|
+| **Canonical format** | An AdCP-defined creative archetype such as `image`, `video_hosted`, or `native_in_feed`. Buyers validate the creative manifest against the canonical first. |
+| **`format_kind`** | The discriminator that names which canonical applies to a product format option. It controls creative shape, not delivery channel or targeting. |
+| **`format_options[]`** | Product-level declarations that narrow canonicals with sizes, slots, production source, and platform constraints. A product can offer one option or several alternatives. |
+| **`format_option_id`** | Stable identifier for a product or publisher-catalog option. Select it when the product publishes one; do not substitute creative-agent capability IDs in media-buy products or creative manifests. |
+| **`capability_id`** | Creative-agent build capability selector on `creative.supported_formats`. It chooses a `build_creative` path and is separate from product-level `format_option_id`. |
+| **`asset_source`** | Declares who renders the asset bytes for `image`, `video_hosted`, and `audio_hosted`: `buyer_uploaded`, `publisher_host_recorded`, `seller_pre_rendered_from_brief`, `seller_human_designed`, or `agent_synthesized`. |
+
 ## Lab exercises
 
 ### Interaction models
@@ -162,21 +177,30 @@ All vendor services use the same pattern: `pricing_options[]` on discovery respo
 Vendors often offer multiple pricing options per creative — volume/commitment tiers (lower CPM at higher spend), context-specific rates (premium vs. standard placements), or different pricing models for different product lines (CPM for rich media, per-unit for social variants). The buyer selects the appropriate `pricing_option_id` and passes it in `report_usage`.
 </Note>
 
+### Canonical formats
+
+6. **Canonical-formats authoring** — Using a multi-format display product and a generative video product from the canonical fixture pool:
+   - Read each product's `format_options[]` and identify every available `format_kind`
+   - Select `format_option_id` when the product publishes one, and explain why a single-option product may not expose a separate selector
+   - Write the manifest asset map implied by the selected option's slots, including when the buyer ships rendered assets and when the buyer ships a brief, video brief, or structured object
+   - Explain single-option vs multi-option products: when one product accepts several canonical alternatives, and when one option fans out to several sizes through `v1_format_ref[]`
+   - Explain why the seller validates against the canonical shape first and the product's narrowing second, while the creative agent's own capability can only narrow what it promises to produce
+
 ### Cross-platform skills
 
-6. **Format discovery** — Query sandbox agents for supported formats, compare requirements across publishers
-7. **Cross-platform adaptation** — Adapt one concept across display, video, and native formats using `build_creative` with `target_format_ids`
-8. **Compliance** — Configure provenance metadata and disclosure requirements for AI-generated creatives
-9. **Preview modes** — Run `preview_creative` as `request_type: "single"`, then `"batch"` (submit 5 creatives in one call and measure the speedup), then `"variant"` against a prior `get_creative_delivery` result. Compare `output_format: "url"` vs `"html"` for rendering latency.
-10. **Tracker-slot audit** — For each sandbox format, inspect the `assets` array and determine whether it supports third-party measurement. Explain why assigning a DoubleVerify pixel to a broadcast spot won't work, and which `billing_measurement` vendor would instead.
-11. **Broadcast identifiers** — Build a broadcast manifest with distinct `industry_identifiers[]` for `:15` and `:30` cuts of the same spot. Verify the `creative-identifier-type` values and explain why each cut needs its own Ad-ID.
+7. **Format discovery** — Query sandbox agents for supported formats, compare requirements across publishers
+8. **Cross-platform adaptation** — Adapt one concept across display, video, and native formats using `build_creative` with `target_format_ids`
+9. **Compliance** — Configure provenance metadata and disclosure requirements for AI-generated creatives
+10. **Preview modes** — Run `preview_creative` as `request_type: "single"`, then `"batch"` (submit 5 creatives in one call and measure the speedup), then `"variant"` against a prior `get_creative_delivery` result. Compare `output_format: "url"` vs `"html"` for rendering latency.
+11. **Tracker-slot audit** — For each sandbox format, inspect the `assets` array and determine whether it supports third-party measurement. Explain why assigning a DoubleVerify pixel to a broadcast spot won't work, and which `billing_measurement` vendor would instead.
+12. **Broadcast identifiers** — Build a broadcast manifest with distinct `industry_identifiers[]` for `:15` and `:30` cuts of the same spot. Verify the `creative-identifier-type` values and explain why each cut needs its own Ad-ID.
 
 ## Assessment
 
 | Dimension | Weight | What Addie evaluates |
 |-----------|--------|---------------------|
 | Interaction models | 20% | Correctly identifies and works with all three creative agent types |
-| Cross-platform | 25% | Adapts creatives across channels and formats |
+| Cross-platform and canonical formats | 25% | Adapts creatives across channels and formats; reads `format_options[]`, selects `format_kind`, maps `asset_source`, and explains product narrowing |
 | Compliance | 25% | Configures disclosures, provenance, and regulatory requirements |
 | Pricing and accounts | 15% | Understands rate cards, reads pricing from `list_creatives` and `list_creative_formats`, interprets build costs, closes the `report_usage` loop |
 | Analytical skill | 15% | Interprets creative feature evaluation and delivery results |

--- a/docs/learning/specialist/creative.mdx
+++ b/docs/learning/specialist/creative.mdx
@@ -141,8 +141,10 @@ See the [Quickstart](/docs/quickstart) for a walkthrough of your first call.
 | **`format_kind`** | The discriminator that names which canonical applies to a product format option. It controls creative shape, not delivery channel or targeting. |
 | **`format_options[]`** | Product-level declarations that narrow canonicals with sizes, slots, production source, and platform constraints. A product can offer one option or several alternatives. |
 | **`format_option_id`** | Stable identifier for a product or publisher-catalog option. Select it when the product publishes one; do not substitute creative-agent capability IDs in media-buy products or creative manifests. |
+| **`v1_format_ref[]`** | Legacy creative-format references attached to a canonical option. One option can point to one existing format or fan out to several size-specific formats. |
 | **`capability_id`** | Creative-agent build capability selector on `creative.supported_formats`. It chooses a `build_creative` path and is separate from product-level `format_option_id`. |
 | **`asset_source`** | Declares who renders the asset bytes for `image`, `video_hosted`, and `audio_hosted`: `buyer_uploaded`, `publisher_host_recorded`, `seller_pre_rendered_from_brief`, `seller_human_designed`, or `agent_synthesized`. |
+| **Manifest asset map** | The slot-by-slot mapping from the selected format option's requirements to the creative manifest assets, including which inputs the buyer provides and which assets are seller-, publisher-, or agent-produced. |
 
 ## Lab exercises
 
@@ -200,7 +202,7 @@ Vendors often offer multiple pricing options per creative — volume/commitment 
 | Dimension | Weight | What Addie evaluates |
 |-----------|--------|---------------------|
 | Interaction models | 20% | Correctly identifies and works with all three creative agent types |
-| Cross-platform and canonical formats | 25% | Adapts creatives across channels and formats; reads `format_options[]`, selects `format_kind`, maps `asset_source` values to buyer-provided, agent-synthesized, seller-rendered, seller-designed, and publisher-hosted workflows, and explains product narrowing |
+| Cross-platform and canonical formats | 25% | Adapts creatives across channels and formats; reads `format_options[]`, selects `format_kind` and `format_option_id`, explains single-option, multi-option, and `v1_format_ref[]` fan-out cardinality, maps `asset_source` values to buyer-provided, agent-synthesized, seller-rendered, seller-designed, and publisher-hosted workflows, and explains canonical-first/product-second validation order |
 | Compliance | 25% | Configures disclosures, provenance, and regulatory requirements |
 | Pricing and accounts | 15% | Understands rate cards, reads pricing from `list_creatives` and `list_creative_formats`, interprets build costs, closes the `report_usage` loop |
 | Analytical skill | 15% | Interprets creative feature evaluation and delivery results |

--- a/docs/learning/specialist/creative.mdx
+++ b/docs/learning/specialist/creative.mdx
@@ -129,7 +129,7 @@ export AGENT_URL="https://test-agent.adcontextprotocol.org/creative/mcp"
 |---|---|---|
 | Creative ad server | `https://test-agent.adcontextprotocol.org/creative/mcp` | Exercises 2, 4 |
 | Stateless transformation / template agent | `https://test-agent.adcontextprotocol.org/creative-builder/mcp` | Exercises 1, 5 |
-| Sales agent (push-and-preview) | `https://test-agent.adcontextprotocol.org/sales/mcp` | Exercise 3 |
+| Sales agent (push-and-preview) | `https://test-agent.adcontextprotocol.org/sales/mcp` | Exercises 3, 6 |
 
 See the [Quickstart](/docs/quickstart) for a walkthrough of your first call.
 
@@ -184,6 +184,7 @@ Vendors often offer multiple pricing options per creative — volume/commitment 
 6. **Canonical-formats authoring** — Using the validated reference fixtures in `static/examples/products/canonical/`: the multi-format display fixture (`nytimes_homepage_mrec.json`) and the generative video fixture (`veo_generative_video_15s.json`):
    - Read each product's `format_options[]` and identify every available `format_kind`
    - Select `format_option_id` when the product publishes one, and explain why a single-option product may not expose a separate selector
+   - Explain why a creative-agent `capability_id` is not a substitute for a media-buy product's `format_option_id`
    - Write the manifest asset map implied by the selected option's slots, including when the buyer ships rendered assets and when the buyer ships a brief, video brief, or structured object
    - Explain single-option vs multi-option products: when one product accepts several canonical alternatives, and when one option fans out to several sizes through `v1_format_ref[]`
    - Explain why the seller validates against the canonical shape first and the product's narrowing second, while the creative agent's own capability can only narrow what it promises to produce
@@ -202,7 +203,8 @@ Vendors often offer multiple pricing options per creative — volume/commitment 
 | Dimension | Weight | What Addie evaluates |
 |-----------|--------|---------------------|
 | Interaction models | 20% | Correctly identifies and works with all three creative agent types |
-| Cross-platform and canonical formats | 25% | Adapts creatives across channels and formats; reads `format_options[]`, selects `format_kind` and `format_option_id`, explains single-option, multi-option, and `v1_format_ref[]` fan-out cardinality, maps `asset_source` values to buyer-provided, agent-synthesized, seller-rendered, seller-designed, and publisher-hosted workflows, and explains canonical-first/product-second validation order |
+| Cross-platform adaptation | 15% | Adapts creatives across display, video, native, preview, measurement, and broadcast workflows |
+| Canonical formats | 10% | Reads `format_options[]`, selects `format_kind` and `format_option_id`, explains single-option, multi-option, and `v1_format_ref[]` fan-out cardinality, maps `asset_source` values to buyer-provided, agent-synthesized, seller-rendered, seller-designed, and publisher-hosted workflows, and explains canonical-first/product-second validation order |
 | Compliance | 25% | Configures disclosures, provenance, and regulatory requirements |
 | Pricing and accounts | 15% | Understands rate cards, reads pricing from `list_creatives` and `list_creative_formats`, interprets build costs, closes the `report_usage` loop |
 | Analytical skill | 15% | Interprets creative feature evaluation and delivery results |

--- a/docs/learning/tracks/buyer.mdx
+++ b/docs/learning/tracks/buyer.mdx
@@ -179,6 +179,9 @@ How creative assets flow through AdCP: `build_creative`, `preview_creative`, `sy
   <Card title="Creative agent pricing" icon="money-bill" href="/docs/creative/implementing-creative-agents#pricing-walkthrough">
     How creative agents charge: pricing discovery, build costs, and billing reconciliation.
   </Card>
+  <Card title="Canonical formats" icon="shapes" href="/docs/creative/canonical-formats">
+    Product-level `format_options[]`, `format_kind`, and canonical-first validation for 3.1 creative requirements.
+  </Card>
   <Card title="Sponsored Intelligence" icon="message-bot" href="/docs/sponsored-intelligence/overview">
     Conversational brand experiences in AI assistants.
   </Card>
@@ -191,7 +194,7 @@ How creative assets flow through AdCP: `build_creative`, `preview_creative`, `sy
 
 - **Creative lifecycle** — `build_creative`, `preview_creative`, `sync_creatives` — callable on any agent implementing the Creative Protocol, including sales agents
 - **Preview modes** — `preview_creative` supports single, batch, and variant requests — choose the mode that fits the workflow (S2 covers the tradeoffs)
-- **Cross-platform adaptation** — agents adapt assets across display, video, audio, native, and broadcast formats. Broadcast manifests carry `industry_identifiers[]` (Ad-ID, ISCI) — S2 goes deep
+- **Cross-platform adaptation** — agents adapt assets across display, video, audio, native, and broadcast formats. In 3.1, sellers may publish canonical `format_options[]`; choose `format_kind` by creative shape, then validate the canonical first and the product's narrowing second. S2 covers the hands-on details
 - **Seller-side generation** — sales agents can generate creatives at serve time from a brief provided in the media buy
 - **Creative pricing** — creative agents can charge for their services. When they do, `list_creatives` returns `pricing_options` from your account's rate card, and `build_creative` returns the cost incurred. See the [creative pricing specification](/docs/creative/specification#pricing) for details.
 - **Sponsored Intelligence** — brands participate in conversational AI with transparency and user control. SI is an [experimental surface](/docs/reference/experimental-status) in AdCP 3.0 (feature id `sponsored_intelligence.core`); session lifecycle and UI components may change between 3.x releases with at least 6 weeks' notice.

--- a/docs/protocol/get_adcp_capabilities.mdx
+++ b/docs/protocol/get_adcp_capabilities.mdx
@@ -199,7 +199,7 @@ For offline delivery, the seller provisions a per-account bucket and grants the 
 
 #### creative_approval_mode
 
-Declares whether auto-approval-dependent behavior applies. This is not a new notification or approval workflow; it tells buyers and compliance runners whether human review can block serving eligibility after creatives are assigned and automated validation passes. Compliance runners use this declaration mainly to decide whether auto-approval-dependent storyboards such as `media_buy_seller/pending_creatives_to_start` apply.
+Declares the seller's tenant-wide creative approval posture after creatives are assigned and automated validation passes. This is not a notification surface or a new approval workflow; it tells buyers and compliance runners whether human review can still block serving eligibility. Compliance runners use this declaration mainly to decide whether auto-approval-dependent storyboards such as `media_buy_seller/pending_creatives_to_start` apply.
 
 | Value | Description |
 |-------|-------------|

--- a/docs/protocol/get_adcp_capabilities.mdx
+++ b/docs/protocol/get_adcp_capabilities.mdx
@@ -199,7 +199,7 @@ For offline delivery, the seller provisions a per-account bucket and grants the 
 
 #### creative_approval_mode
 
-Discovery-time capability signal for whether auto-approval-dependent behavior applies. This is not a new notification or approval workflow; it tells buyers and compliance runners whether human review can block serving eligibility after creatives are assigned and automated validation passes. Compliance runners use this declaration mainly to decide whether auto-approval-dependent storyboards such as `media_buy_seller/pending_creatives_to_start` apply.
+Declares whether auto-approval-dependent behavior applies. This is not a new notification or approval workflow; it tells buyers and compliance runners whether human review can block serving eligibility after creatives are assigned and automated validation passes. Compliance runners use this declaration mainly to decide whether auto-approval-dependent storyboards such as `media_buy_seller/pending_creatives_to_start` apply.
 
 | Value | Description |
 |-------|-------------|

--- a/docs/protocol/get_adcp_capabilities.mdx
+++ b/docs/protocol/get_adcp_capabilities.mdx
@@ -199,7 +199,7 @@ For offline delivery, the seller provisions a per-account bucket and grants the 
 
 #### creative_approval_mode
 
-Capability declaration for whether auto-approval-dependent behavior applies. This does not add a new notification or approval workflow; it tells buyers and compliance runners whether human review can block serving eligibility after creatives are assigned and automated validation passes. Compliance runners use this declaration mainly to decide whether auto-approval-dependent storyboards such as `media_buy_seller/pending_creatives_to_start` apply.
+Discovery-time capability signal for whether auto-approval-dependent behavior applies. This is not a new notification or approval workflow; it tells buyers and compliance runners whether human review can block serving eligibility after creatives are assigned and automated validation passes. Compliance runners use this declaration mainly to decide whether auto-approval-dependent storyboards such as `media_buy_seller/pending_creatives_to_start` apply.
 
 | Value | Description |
 |-------|-------------|

--- a/server/src/db/migrations/496_curriculum_3_1_canonical_formats_criteria.sql
+++ b/server/src/db/migrations/496_curriculum_3_1_canonical_formats_criteria.sql
@@ -5,15 +5,13 @@
 -- preview-status recertification criteria should land only after those tasks
 -- are explicitly assessable in the module.
 
+-- S2 remains creative-primary. The sales tenant is also in scope because the
+-- canonical-format lab asks creative learners to read product format_options[]
+-- with get_products before building or syncing creative assets.
 UPDATE certification_modules
-SET tenant_ids = (
-  SELECT ARRAY(
-    SELECT DISTINCT tenant_id
-    FROM unnest(COALESCE(tenant_ids, '{}'::text[]) || ARRAY['creative', 'creative-builder', 'sales']) AS tenant_id
-    ORDER BY tenant_id
-  )
-)
-WHERE id = 'S2';
+SET tenant_ids = ARRAY['creative', 'creative-builder', 'sales']
+WHERE id = 'S2'
+  AND tenant_ids IS DISTINCT FROM ARRAY['creative', 'creative-builder', 'sales'];
 
 UPDATE certification_modules
 SET lesson_plan = jsonb_set(
@@ -22,7 +20,7 @@ SET lesson_plan = jsonb_set(
   COALESCE(lesson_plan->'key_concepts', '[]'::jsonb) || jsonb_build_array(
     jsonb_build_object(
       'topic', 'Canonical formats',
-      'teaching_notes', 'AdCP 3.1 products may publish format_options[] that narrow shared canonical formats such as image, video_hosted, or native_in_feed. Teach learners to select format_kind by creative shape, validate against the canonical first and the product narrowing second, select format_option_id when a product publishes one, and distinguish buyer_uploaded from agent_synthesized asset_source values.'
+      'teaching_notes', 'AdCP 3.1 products may publish format_options[] that narrow shared canonical formats such as image, video_hosted, or native_in_feed. Teach learners to select format_kind by creative shape, validate against the canonical first and the product narrowing second, select format_option_id when a product publishes one, and distinguish buyer_uploaded, agent_synthesized, seller_pre_rendered_from_brief, seller_human_designed, and publisher_host_recorded asset_source values.'
     )
   )
 )
@@ -152,6 +150,9 @@ SELECT _append_criterion('S2', 's2_ex1', 's2_ex1_sc_format_options_cardinality',
   'Reads product format_options[] and explains single-option, multi-option, and multi-size fan-out declarations, including when a buyer should select a format_option_id.');
 
 SELECT _append_criterion('S2', 's2_ex1', 's2_ex1_sc_source_taxonomy',
-  'Chooses the correct asset_source model for buyer_uploaded or agent_synthesized creative workflows, and maps that choice to the manifest assets the buyer must provide.');
+  'Chooses the correct asset_source model across buyer_uploaded, agent_synthesized, seller_pre_rendered_from_brief, seller_human_designed, and publisher_host_recorded workflows, and maps that choice to the manifest assets or seller/publisher-supplied inputs required.');
+
+SELECT _append_criterion('S2', 's2_ex1', 's2_ex1_sc_validation_order',
+  'Explains why sellers validate against the shared canonical shape before applying product-specific narrowing, and why creative-agent capabilities only narrow what the agent can produce.');
 
 DROP FUNCTION _append_criterion(text, text, text, text);

--- a/server/src/db/migrations/496_curriculum_3_1_canonical_formats_criteria.sql
+++ b/server/src/db/migrations/496_curriculum_3_1_canonical_formats_criteria.sql
@@ -53,6 +53,8 @@ BEGIN
   LOOP
     IF ex->>'id' = 's2_ex1' THEN
       exercise_matched := true;
+      -- S2 exercise 1 prose is migration-owned for the 3.1 canonical-format
+      -- lab; re-runs intentionally restore this title and description.
       ex := jsonb_set(ex, '{title}', to_jsonb('Creative production and canonical-format authoring'::text));
       ex := jsonb_set(ex, '{description}', to_jsonb('Build, preview, and sync creatives while also authoring against 3.1 product format_options[] declarations.'::text));
 
@@ -148,6 +150,9 @@ SELECT _append_criterion('S2', 's2_ex1', 's2_ex1_sc_format_kind_selection',
 
 SELECT _append_criterion('S2', 's2_ex1', 's2_ex1_sc_format_options_cardinality',
   'Reads product format_options[] and explains single-option, multi-option, and multi-size fan-out declarations, including when a buyer should select a format_option_id.');
+
+SELECT _append_criterion('S2', 's2_ex1', 's2_ex1_sc_option_vs_capability_id',
+  'Distinguishes product-level format_option_id from creative-agent capability_id and avoids substituting one namespace for the other in media-buy products or creative manifests.');
 
 SELECT _append_criterion('S2', 's2_ex1', 's2_ex1_sc_source_taxonomy',
   'Chooses the correct asset_source model across buyer_uploaded, agent_synthesized, seller_pre_rendered_from_brief, seller_human_designed, and publisher_host_recorded workflows, and maps that choice to the manifest assets or seller/publisher-supplied inputs required.');

--- a/server/src/db/migrations/496_curriculum_3_1_canonical_formats_criteria.sql
+++ b/server/src/db/migrations/496_curriculum_3_1_canonical_formats_criteria.sql
@@ -1,0 +1,157 @@
+-- Add SuccessCriterion IDs for AdCP 3.1 canonical-format demonstrations in S2.
+--
+-- These criteria are intentionally limited to the concepts exercised by the
+-- S2 canonical-formats authoring lab. Third-party creative-agent flow and
+-- preview-status recertification criteria should land only after those tasks
+-- are explicitly assessable in the module.
+
+UPDATE certification_modules
+SET tenant_ids = (
+  SELECT ARRAY(
+    SELECT DISTINCT tenant_id
+    FROM unnest(COALESCE(tenant_ids, '{}'::text[]) || ARRAY['creative', 'creative-builder', 'sales']) AS tenant_id
+    ORDER BY tenant_id
+  )
+)
+WHERE id = 'S2';
+
+UPDATE certification_modules
+SET lesson_plan = jsonb_set(
+  lesson_plan,
+  '{key_concepts}',
+  COALESCE(lesson_plan->'key_concepts', '[]'::jsonb) || jsonb_build_array(
+    jsonb_build_object(
+      'topic', 'Canonical formats',
+      'teaching_notes', 'AdCP 3.1 products may publish format_options[] that narrow shared canonical formats such as image, video_hosted, or native_in_feed. Teach learners to select format_kind by creative shape, validate against the canonical first and the product narrowing second, select format_option_id when a product publishes one, and distinguish buyer_uploaded from agent_synthesized asset_source values.'
+    )
+  )
+)
+WHERE id = 'S2'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(COALESCE(lesson_plan->'key_concepts', '[]'::jsonb)) concept
+    WHERE concept->>'topic' = 'Canonical formats'
+  );
+
+CREATE OR REPLACE FUNCTION _update_s2_canonical_exercise()
+RETURNS void AS $$
+DECLARE
+  defs jsonb;
+  updated jsonb := '[]'::jsonb;
+  ex jsonb;
+  actions jsonb;
+  already_present boolean;
+  exercise_matched boolean := false;
+BEGIN
+  SELECT exercise_definitions INTO defs
+  FROM certification_modules
+  WHERE id = 'S2';
+
+  IF defs IS NULL OR jsonb_typeof(defs) <> 'array' THEN
+    RAISE EXCEPTION 'Module S2 not found or has no exercise_definitions array';
+  END IF;
+
+  FOR ex IN SELECT * FROM jsonb_array_elements(defs)
+  LOOP
+    IF ex->>'id' = 's2_ex1' THEN
+      exercise_matched := true;
+      ex := jsonb_set(ex, '{title}', to_jsonb('Creative production and canonical-format authoring'::text));
+      ex := jsonb_set(ex, '{description}', to_jsonb('Build, preview, and sync creatives while also authoring against 3.1 product format_options[] declarations.'::text));
+
+      actions := COALESCE(ex->'sandbox_actions', '[]'::jsonb);
+      SELECT EXISTS (
+        SELECT 1 FROM jsonb_array_elements(actions) action
+        WHERE action->>'tool' = 'get_products'
+          AND action->>'guidance' ILIKE '%format_options%'
+      ) INTO already_present;
+
+      IF NOT already_present THEN
+        actions := actions || jsonb_build_array(
+          jsonb_build_object(
+            'tool', 'get_products',
+            'guidance', 'Read 3.1 product format_options[] from a sales-agent product and identify format_kind, format_option_id when present, asset_source, and the canonical-first/product-second validation order before building or syncing a creative.'
+          )
+        );
+        ex := jsonb_set(ex, '{sandbox_actions}', actions);
+      END IF;
+    END IF;
+    updated := updated || jsonb_build_array(ex);
+  END LOOP;
+
+  IF NOT exercise_matched THEN
+    RAISE EXCEPTION 'Exercise s2_ex1 not found in module S2';
+  END IF;
+
+  UPDATE certification_modules
+  SET exercise_definitions = updated
+  WHERE id = 'S2';
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT _update_s2_canonical_exercise();
+
+DROP FUNCTION _update_s2_canonical_exercise();
+
+CREATE OR REPLACE FUNCTION _append_criterion(
+  p_module_id text,
+  p_exercise_id text,
+  p_criterion_id text,
+  p_text text
+) RETURNS void AS $$
+DECLARE
+  defs jsonb;
+  updated jsonb := '[]'::jsonb;
+  ex jsonb;
+  criteria jsonb;
+  already_present boolean;
+  exercise_matched boolean := false;
+BEGIN
+  SELECT exercise_definitions INTO defs
+  FROM certification_modules
+  WHERE id = p_module_id;
+
+  IF defs IS NULL OR jsonb_typeof(defs) <> 'array' THEN
+    RAISE EXCEPTION 'Module % not found or has no exercise_definitions array', p_module_id;
+  END IF;
+
+  FOR ex IN SELECT * FROM jsonb_array_elements(defs)
+  LOOP
+    IF ex->>'id' = p_exercise_id THEN
+      exercise_matched := true;
+      criteria := COALESCE(ex->'success_criteria', '[]'::jsonb);
+
+      SELECT EXISTS (
+        SELECT 1 FROM jsonb_array_elements(criteria) c
+        WHERE c->>'id' = p_criterion_id
+      ) INTO already_present;
+
+      IF NOT already_present THEN
+        criteria := criteria || jsonb_build_array(
+          jsonb_build_object('id', p_criterion_id, 'text', p_text)
+        );
+        ex := jsonb_set(ex, '{success_criteria}', criteria);
+      END IF;
+    END IF;
+    updated := updated || jsonb_build_array(ex);
+  END LOOP;
+
+  IF NOT exercise_matched THEN
+    RAISE EXCEPTION 'Exercise % not found in module %', p_exercise_id, p_module_id;
+  END IF;
+
+  UPDATE certification_modules
+  SET exercise_definitions = updated
+  WHERE id = p_module_id;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT _append_criterion('S2', 's2_ex1', 's2_ex1_sc_format_kind_selection',
+  'Selects the correct format_kind for a product and creative manifest, and distinguishes creative shape from delivery channel, targeting, or measurement context.');
+
+SELECT _append_criterion('S2', 's2_ex1', 's2_ex1_sc_format_options_cardinality',
+  'Reads product format_options[] and explains single-option, multi-option, and multi-size fan-out declarations, including when a buyer should select a format_option_id.');
+
+SELECT _append_criterion('S2', 's2_ex1', 's2_ex1_sc_source_taxonomy',
+  'Chooses the correct asset_source model for buyer_uploaded or agent_synthesized creative workflows, and maps that choice to the manifest assets the buyer must provide.');
+
+DROP FUNCTION _append_criterion(text, text, text, text);

--- a/server/tests/integration/certification-module-tenants.test.ts
+++ b/server/tests/integration/certification-module-tenants.test.ts
@@ -53,9 +53,10 @@ describe('certification_modules.tenant_ids (migration 464)', () => {
     const c2 = await getModule('C2');
     expect(c2!.tenant_ids).toEqual(['brand', 'governance']);
 
-    // S2 (creative mastery) covers both creative tenants.
+    // S2 (creative mastery) covers both creative tenants plus the sales
+    // tenant used for canonical format discovery and preview workflows.
     const s2 = await getModule('S2');
-    expect(s2!.tenant_ids).toEqual(['creative', 'creative-builder']);
+    expect(s2!.tenant_ids).toEqual(['creative', 'creative-builder', 'sales']);
   });
 
   it('SI-dependent modules are intentionally NULL until an si tenant exists', async () => {


### PR DESCRIPTION
## Summary

- Adds S2 canonical-format curriculum coverage: glossary, canonical-formats lab, assessment language, and a backlink from the canonical-formats reference.
- Adds migration `496` to project the S2 update into DB-backed curriculum data, including the runtime lesson plan, exercise metadata, sales/creative tenant coverage, and three stable criterion IDs.
- Adds shallow A2 and buyer-track orientation for `format_options[]`, `format_kind`, and canonical-first/product-second validation.
- Clarifies `creative_approval_mode` as a discovery-time capability signal, addressing the review note that it is not a notification workflow.

Closes #4694.
Closes #4698.
Refs #4695: adds the three fixture-backed S2 criterion IDs, leaving third-party creative-agent flow, preview-status criteria, and recertification trigger wiring for separate work.
Refs #4697: adds buyer-track orientation, but leaves the requested buyer exercise/glossary/error-code treatment open.

## Validation

- `git diff --check`
- `npm run test:migrations`
- `npm run test:docs-nav`
- `npm run check:owned-links`
- `npm run lint:schema-links`
- `npm run test:test-dynamic-imports`
- `npm run test:unit`
- `npm run typecheck`
- pre-push hook: version sync, current storyboard matrix, 3.0 compatibility storyboard matrix, schema-link lint, Mintlify broken-links check

`npm run test:snippets` still fails repo-wide on existing snippets outside this diff: missing Python `adcp` package, unset `ADCP_AUTH_TOKEN` bash examples, existing `get_media_buy_delivery` missing-buy examples, and `sync_creatives` SDK validation failures.
