### PR TITLE
[codex] Allow S3 managerdomain fallback

### DIFF
--- a/.changeset/managerdomain-403-fallback.md
+++ b/.changeset/managerdomain-403-fallback.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Allow the ads.txt `managerdomain` fallback when a publisher's direct `adagents.json` fetch returns an S3/CloudFront-style `403` `AccessDenied` XML response as well as `404`, while preserving manager-side scoping checks.

--- a/docs/governance/property/adagents.mdx
+++ b/docs/governance/property/adagents.mdx
@@ -318,7 +318,7 @@ For managed-network deployments in AdCP, the normative delegation pattern remain
 `/.well-known/adagents.json` pointer file. New deployments SHOULD use that pattern.
 </Warning>
 
-When `https://{publisher}/.well-known/adagents.json` returns `404`, validators MAY attempt a compatibility fallback via `https://{publisher}/ads.txt`:
+When `https://{publisher}/.well-known/adagents.json` returns `404`, or returns an S3/CloudFront-style `403` `AccessDenied` XML response, validators MAY attempt a compatibility fallback via `https://{publisher}/ads.txt`:
 
 1. Read `ads.txt` and parse `managerdomain` entries.
    - Accepted form: `MANAGERDOMAIN=example.com` (IAB directive form only).
@@ -331,6 +331,7 @@ When `https://{publisher}/.well-known/adagents.json` returns `404`, validators M
 - **One hop only**: maximum depth is exactly one (`publisher -> managerdomain`). Do not chain managerdomain lookups.
 - **Cycle detection required**: if `managerdomain` points to a visited domain, ignore it.
 - **`#noagents` opt-out**: if a managerdomain line has a trailing comment containing the token `noagents` (case-insensitive), clients MUST ignore that managerdomain for adagents discovery. Example: `MANAGERDOMAIN=example.com #NOAGENTS`.
+- **Trigger statuses are narrow**: validators SHOULD only attempt this fallback when the publisher's direct `adagents.json` fetch returns `404` or an S3/CloudFront-style `403` `AccessDenied` XML response. Other statuses and failures — generic `403` denial, `500`, timeout, malformed JSON, content-type mismatch, or schema validation failure — do not trigger `managerdomain`.
 - **Explicit publisher scoping required**: a manager-hosted `adagents.json` MUST positively name the source publisher domain in a `publisher_domain` field that is reachable from at least one `authorized_agents[]` entry. "Reachable" means one of the following paths resolves to the source domain:
 
   1. **Per-agent paths.** The agent entry directly carries the publisher domain under `publisher_properties[].publisher_domain`, inside `publisher_properties[].publisher_domains[]` (the compact managed-network form), or under `collections[].publisher_domain`.

--- a/server/src/adagents-manager.ts
+++ b/server/src/adagents-manager.ts
@@ -3,6 +3,21 @@ import { AAO_UA_VALIDATOR } from './config/user-agents.js';
 import { safeFetchAxiosLike, classifySafeFetchError } from './utils/url-security.js';
 import { canonicalizePublisherDomain } from './services/publisher-domain.js';
 
+function isManagerdomainFallbackEligibleResponse(status: number, data: unknown): boolean {
+  if (status === 404) return true;
+  if (status !== 403) return false;
+
+  // safeFetchAxiosLike returns Buffer data, but keep the string branch so
+  // unit fixtures can exercise the response-shape predicate directly.
+  const text = Buffer.isBuffer(data)
+    ? data.toString('utf-8')
+    : typeof data === 'string'
+      ? data
+      : '';
+
+  return /<Code>\s*AccessDenied\s*<\/Code>/i.test(text);
+}
+
 export interface ValidationError {
   field: string;
   message: string;
@@ -232,9 +247,13 @@ export class AdAgentsManager {
       // Check HTTP status
       if (response.status !== 200) {
         // Fallback for publisher-manager patterns: if the publisher does not
-        // serve /.well-known/adagents.json but does serve ads.txt with a
-        // managerdomain declaration, attempt discovery on the manager domain.
-        if (response.status === 404) {
+        // serve a directly usable /.well-known/adagents.json but does serve
+        // ads.txt with a managerdomain declaration, attempt discovery on the
+        // manager domain. S3/CloudFront commonly returns a 403 AccessDenied
+        // XML body instead of 404 for missing or inaccessible objects, so
+        // that shape is included but still must pass the manager-side
+        // explicit-scope gate.
+        if (isManagerdomainFallbackEligibleResponse(response.status, response.data)) {
           const managerDomains = await this.tryResolveManagerDomains(normalizedDomain);
           const isHopAllowed = managerFallbackDepth < 1;
           if (managerDomains.length > 0 && isHopAllowed) {
@@ -272,7 +291,7 @@ export class AdAgentsManager {
                     ...managerResult.warnings,
                     {
                       field: 'managerdomain',
-                      message: `No adagents.json at ${url}; used ads.txt managerdomain ${managerDomain}`,
+                      message: `No directly usable adagents.json at ${url}; used ads.txt managerdomain ${managerDomain}`,
                     },
                   ],
                 };

--- a/server/tests/unit/adagents-manager.test.ts
+++ b/server/tests/unit/adagents-manager.test.ts
@@ -223,6 +223,66 @@ describe('AdAgentsManager', () => {
       expect(result.manager_domain).toBe('manager.example');
     });
 
+    it('falls back to managerdomain adagents.json when origin returns 403 for a missing S3/CloudFront object', async () => {
+      mockedSafeFetch.mockImplementation(async (url) => {
+        if (url === 'https://publisher.example/.well-known/adagents.json') {
+          return {
+            status: 403,
+            data: Buffer.from('<Error><Code>AccessDenied</Code></Error>'),
+            headers: { 'content-type': 'application/xml' },
+          };
+        }
+        if (url === 'https://publisher.example/ads.txt') {
+          return { status: 200, data: Buffer.from('MANAGERDOMAIN=manager.example\n'), headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://manager.example/.well-known/adagents.json') {
+          return {
+            status: 200,
+            data: buf({
+              authorized_agents: [{
+                url: 'https://agent.example',
+                authorized_for: 'All inventory',
+                authorization_type: 'publisher_properties',
+                publisher_properties: [{ publisher_domain: 'publisher.example', selection_type: 'all' }],
+              }],
+            }),
+            headers: { 'content-type': 'application/json' },
+          };
+        }
+        throw new Error(`Unexpected URL: ${url}`);
+      });
+
+      const result = await manager.validateDomain('publisher.example');
+      expect(result.valid).toBe(true);
+      expect(result.warnings.some(w => w.field === 'managerdomain')).toBe(true);
+      expect(result.domain).toBe('publisher.example');
+      expect(result.discovery_method).toBe('ads_txt_managerdomain');
+      expect(result.manager_domain).toBe('manager.example');
+    });
+
+    it('does not trigger manager fallback on generic 403 denial responses', async () => {
+      let calledAdsTxt = false;
+      mockedSafeFetch.mockImplementation(async (url) => {
+        if (url === 'https://publisher.example/.well-known/adagents.json') {
+          return {
+            status: 403,
+            data: Buffer.from('<html>Forbidden</html>'),
+            headers: { 'content-type': 'text/html' },
+          };
+        }
+        if (url === 'https://publisher.example/ads.txt') {
+          calledAdsTxt = true;
+          return { status: 200, data: Buffer.from('MANAGERDOMAIN=manager.example\n'), headers: { 'content-type': 'text/plain' } };
+        }
+        throw new Error(`Unexpected URL: ${url}`);
+      });
+
+      const result = await manager.validateDomain('publisher.example');
+      expect(result.valid).toBe(false);
+      expect(calledAdsTxt).toBe(false);
+      expect(result.errors.some(e => e.message.includes('HTTP 403'))).toBe(true);
+    });
+
     it('does not recurse indefinitely when managerdomain points back to original domain', async () => {
       mockedSafeFetch.mockImplementation(async (url) => {
         if (url === 'https://publisher.example/.well-known/adagents.json') {
@@ -865,7 +925,7 @@ describe('AdAgentsManager', () => {
       expect(result.valid).toBe(true);
     });
 
-    it('does not trigger manager fallback on non-404 adagents responses', async () => {
+    it('does not trigger manager fallback on non-403/404 adagents responses', async () => {
       let calledAdsTxt = false;
       mockedSafeFetch.mockImplementation(async (url) => {
         if (url === 'https://publisher.example/.well-known/adagents.json') {


### PR DESCRIPTION
## Summary

Closes #4473.

Allows the ads.txt `managerdomain` compatibility fallback when the publisher's direct `/.well-known/adagents.json` fetch returns either:

- `404`, as before
- an S3/CloudFront-style `403` XML `AccessDenied` missing-object response

Generic `403` denials still do not trigger fallback, so WAF/auth/geo-policy blocks are not silently masked by a manager manifest. The existing one-hop, cycle-detection, `#noagents`, and explicit publisher-scope safety gates remain unchanged.

## Validation

- Expert code review: blocker fixed, re-review found no blockers or nits
- `npx vitest run server/tests/unit/adagents-manager.test.ts --pool=threads`
- `npm run test:unit`
- `npm run typecheck`
- `npm run test:docs-nav`
- `npm run check:owned-links`
- `npm run lint:schema-links`
- `npm run test:test-dynamic-imports`
- `npm run test:callapi-state-change`
- `git diff --check`
- precommit hook
- pre-push hook