### PR TITLE
[codex] Add S2 recertification policy

### DIFF
--- a/.changeset/s2-recertification-policy.md
+++ b/.changeset/s2-recertification-policy.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs(certification): add S2 canonical-format recertification policy and review-path alignment.

--- a/docs.json
+++ b/docs.json
@@ -651,6 +651,7 @@
                     "pages": [
                       "docs/learning/policies/nondiscrimination",
                       "docs/learning/policies/learner-records",
+                      "docs/learning/policies/recertification",
                       "docs/learning/policies/complaints",
                       "docs/learning/policies/conflict-of-interest",
                       "docs/learning/policies/intellectual-property",
@@ -1220,6 +1221,7 @@
                 "pages": [
                   "docs/learning/policies/nondiscrimination",
                   "docs/learning/policies/learner-records",
+                  "docs/learning/policies/recertification",
                   "docs/learning/policies/complaints",
                   "docs/learning/policies/conflict-of-interest",
                   "docs/learning/policies/intellectual-property",

--- a/docs/ai-disclosure.mdx
+++ b/docs/ai-disclosure.mdx
@@ -10,22 +10,22 @@ AgenticAdvertising.org uses AI extensively to write content, generate imagery, s
 
 ## What's AI-authored
 
-These surfaces are written primarily by an AI agent operated by AAO, with human editorial oversight:
+These surfaces are written primarily by an AI agent operated by AgenticAdvertising.org, with human editorial oversight:
 
-- **Addie** — AAO's teaching assistant and chat agent. All Addie chat responses are AI-generated.
+- **Addie** — AgenticAdvertising.org's teaching assistant and chat agent. All Addie chat responses are AI-generated.
 - **Sage** — the AdCP protocol explainer agent. Protocol Q&A in the docs chat is answered by Sage.
-- **The Prompt** — our biweekly newsletter, authored in first person as Addie. The Prompt is editorial and is also a marketing surface for AAO; read it as both.
+- **The Prompt** — our biweekly newsletter, authored in first person as Addie. The Prompt is editorial and is also a marketing surface for AgenticAdvertising.org; read it as both.
 - **The Build** — our triweekly technical newsletter, authored by Sage.
 - **Member portraits** — graphic-novel-style illustrations for members are AI-generated.
-- **Certification grading** — Addie grades the free Basics track against a fixed rubric of 3–5 required demonstrations per module, and also grades the paid Practitioner and Specialist tracks. AAO is both the issuer and the grader of these credentials; we disclose this conflict rather than deny it, and human review of any grading decision is available on request (see below).
+- **Certification grading** — Addie grades the free Basics track against a fixed rubric of 3–5 required demonstrations per module, and also grades the paid Practitioner and Specialist tracks. AgenticAdvertising.org is both the issuer and the grader of these credentials; we disclose this conflict rather than deny it, and human review of any grading decision is available on request (see below).
 
 ## What's AI-assisted
 
-Most of the rest of AAO's public surface is built with AI coding assistants, reviewed by humans before publishing. This includes:
+Most of the rest of AgenticAdvertising.org's public surface is built with AI coding assistants, reviewed by humans before publishing. This includes:
 
 - The protocol schemas and documentation (this site)
 - The open-source reference implementations
-- The admin tools operated by AAO staff
+- The admin tools operated by AgenticAdvertising.org staff
 - Most public-facing code in the [adcontextprotocol](https://github.com/adcontextprotocol) organization
 
 We don't mark individual paragraphs or pull requests as AI-assisted — the default is that AI tools were involved.
@@ -38,7 +38,7 @@ We don't mark individual paragraphs or pull requests as AI-assisted — the defa
 
 ## Data handling
 
-- **Addie and Sage chat** — conversations are logged to improve teaching quality and to allow appeals on grading decisions. Logs are retained by AAO and not used by model providers for training. EU/UK residents: chat inputs are processed on our behalf by Anthropic; see our [privacy policy](https://agenticadvertising.org/api/agreement?type=privacy_policy) for the current data-processor chain and transfer mechanism.
+- **Addie and Sage chat** — conversations are logged to improve teaching quality and to allow appeals on grading decisions. Logs are retained by AgenticAdvertising.org and not used by model providers for training. EU/UK residents: chat inputs are processed on our behalf by Anthropic; see our [privacy policy](https://agenticadvertising.org/api/agreement?type=privacy_policy) for the current data-processor chain and transfer mechanism.
 - **Grading decisions** — the required-demonstrations, the Addie interaction that produced the credit, and the resulting assessment are retained so that a learner (or a regulator) can reconstruct the decision.
 - **Member portraits** — AI-generated images are produced from member-provided inputs; the prompt and generated image are retained on the member's profile.
 
@@ -46,15 +46,15 @@ We don't mark individual paragraphs or pull requests as AI-assisted — the defa
 
 You can request human review on any AI-generated surface.
 
-**Certification grading appeals SLA.** Because AAO is both the issuer and the AI grader of its certifications, every grading appeal gets a documented human-review path:
+**Certification grading and targeting review SLA.** Because AgenticAdvertising.org is both the issuer and the AI grader of its certifications, every grading appeal and protocol-update targeting dispute gets a documented human-review path:
 
-- **Acknowledgement: 72 hours** from receipt at [help@agenticadvertising.org](mailto:help@agenticadvertising.org).
-- **Decision: 10 business days** from acknowledgement, by an AAO staff reviewer who did not participate in the original grading.
-- **Outcome on upheld appeals**: the credential is granted (if the appeal is for a denied attempt) or the assessment fee is refunded (if the appeal is for a graded attempt the learner does not want re-credentialed).
-- **Escalation**: appeals that the staff reviewer cannot resolve are escalated to the AAO certification committee, which meets monthly.
-- **Annual transparency report**: AAO publishes appeals volume, upheld rate, and median time-to-decision once per year as part of the AGM materials. The first report covers the period ending 2027-04.
+- **Acknowledgement: 2 business days** from receipt at [certification@agenticadvertising.org](mailto:certification@agenticadvertising.org).
+- **Resolution:** handled through the [certification complaints process](/docs/learning/policies/complaints), by an AgenticAdvertising.org staff reviewer who did not participate in the original grading or targeting decision.
+- **Outcome on upheld appeals**: the credential is granted or the learner record is corrected, depending on the issue under review.
+- **Escalation**: appeals that the staff reviewer cannot resolve are escalated to AgenticAdvertising.org program leadership.
+- **Annual transparency report**: AgenticAdvertising.org publishes appeals volume, upheld rate, and median time-to-decision once per year as part of the AGM materials. The first report covers the period ending 2027-04.
 
-To file a grading appeal, email [help@agenticadvertising.org](mailto:help@agenticadvertising.org) with your learner ID, the module or assessment in question, and the specific finding you are contesting.
+To file a grading appeal or protocol-update targeting dispute, email [certification@agenticadvertising.org](mailto:certification@agenticadvertising.org) with your learner ID, the module or assessment in question, and the specific finding you are contesting.
 
 Other AI-surface review paths:
 
@@ -63,20 +63,20 @@ Other AI-surface review paths:
 
 ## Content provenance (C2PA)
 
-Every AI-generated image AAO publishes carries an embedded [C2PA](https://c2pa.org/) manifest signed by AAO:
+Every AI-generated image AgenticAdvertising.org publishes carries an embedded [C2PA](https://c2pa.org/) manifest signed by AgenticAdvertising.org:
 
 - **Member portraits** — also carry a visible "AI" badge in the bottom-right corner (CA SB 942 visible-disclosure path).
 - **Newsletter cover art** — The Prompt and The Build covers, including the copies that ship in subscriber email and render as OpenGraph share cards.
 - **Perspective article hero images** — every editorial illustration attached to a published perspective.
 - **Docs walkthrough and concept illustrations** — the panel PNGs embedded throughout this site's walkthroughs and concept explainers.
 
-The manifest identifies Google Gemini as the generating software agent, marks the asset as `trainedAlgorithmicMedia` per the IPTC digital-source-type vocabulary, and includes a timestamp plus a SHA-256 of the generation prompt (not the prompt itself — portraits are generated from member-provided descriptions we do not want to republish). AAO signs with a self-signed P-256 certificate held in production secrets. CAI trust-list inclusion is a future step; today, public verifiers will show the signature as cryptographically valid but flag *"issuer not on trust list."*
+The manifest identifies Google Gemini as the generating software agent, marks the asset as `trainedAlgorithmicMedia` per the IPTC digital-source-type vocabulary, and includes a timestamp plus a SHA-256 of the generation prompt (not the prompt itself — portraits are generated from member-provided descriptions we do not want to republish). AgenticAdvertising.org signs with a self-signed P-256 certificate held in production secrets. CAI trust-list inclusion is a future step; today, public verifiers will show the signature as cryptographically valid but flag *"issuer not on trust list."*
 
-**Verify any AAO image** at [contentcredentials.org/verify](https://contentcredentials.org/verify) by uploading the file or pasting its URL.
+**Verify any AgenticAdvertising.org image** at [contentcredentials.org/verify](https://contentcredentials.org/verify) by uploading the file or pasting its URL.
 
-For editorial illustrations and docs storyboards where a visible mark would undermine the graphic-novel aesthetic, the C2PA manifest is the sole disclosure surface. CA SB 942's visible-disclosure rule targets upstream generative-AI providers rather than downstream publishers, so this placement is defensible for AAO — but it is a deliberate choice, not an oversight.
+For editorial illustrations and docs storyboards where a visible mark would undermine the graphic-novel aesthetic, the C2PA manifest is the sole disclosure surface. CA SB 942's visible-disclosure rule targets upstream generative-AI providers rather than downstream publishers, so this placement is defensible for AgenticAdvertising.org — but it is a deliberate choice, not an oversight.
 
-If you find an AAO-generated image that does not carry a manifest, please [open an issue](https://github.com/adcontextprotocol/adcp/issues) — we treat missing provenance as a bug.
+If you find an AgenticAdvertising.org-generated image that does not carry a manifest, please [open an issue](https://github.com/adcontextprotocol/adcp/issues) — we treat missing provenance as a bug.
 
 ## Regulatory posture
 
@@ -89,13 +89,13 @@ If you believe a specific AI surface falls short of an applicable standard, let 
 
 ## Institutional conflicts
 
-AI authorship and evaluation by AAO intersect with AAO's broader governance in ways readers should know:
+AI authorship and evaluation by AgenticAdvertising.org intersect with AgenticAdvertising.org's broader governance in ways readers should know:
 
-- AAO is both the issuer and the grader of its certifications (Addie evaluates coursework and grants credentials AAO sells).
-- AAO's founder's other company (Scope3) contributed funding and foundational IP — see the [FAQ entry](/docs/faq#how-is-aao-related-to-scope3) for the full relationship.
+- AgenticAdvertising.org is both the issuer and the grader of its certifications (Addie evaluates coursework and grants credentials AgenticAdvertising.org sells).
+- AgenticAdvertising.org's founder's other company (Scope3) contributed funding and foundational IP — see the [FAQ entry](/docs/faq#how-is-aao-related-to-scope3) for the full relationship.
 
 The governance framework, board composition, and recusal rules are set out in [CHARTER.md](https://github.com/adcontextprotocol/adcp/blob/main/CHARTER.md), with the authoritative board list and funding disclosures at [agenticadvertising.org/governance](https://agenticadvertising.org/governance).
 
 ---
 
-Material changes to how AI is used at AAO will be reflected on this page.
+Material changes to how AI is used at AgenticAdvertising.org will be reflected on this page.

--- a/docs/learning/instructional-design.mdx
+++ b/docs/learning/instructional-design.mdx
@@ -9,6 +9,10 @@ description: "AdCP certification instructional design: teaching methodology, ada
 
 This document describes how the AdCP certification program is designed, delivered, and maintained. It serves as the authoritative reference for teaching methodology and program quality.
 
+<Note>
+This framework is IACET-aligned and CPD-aligned. It is not an assertion of current IACET Accredited Provider status or IACET CEU issuance.
+</Note>
+
 ### Accreditation element reference
 
 | IACET Element | Section |
@@ -143,7 +147,7 @@ AdCP is a living protocol. When the specification evolves — new tasks added, e
 
 Each required demonstration is tracked by a stable ID tied to specific protocol knowledge. When a protocol change affects what a certified person should know, the system can identify which credential holders learned under the previous criteria and flag them for recertification.
 
-Recertification is targeted, not blanket. If a protocol update adds a new governance task but doesn't affect media buy workflows, only credentials that cover governance are flagged. Credential holders receive a notification through Addie with context on what changed and what they need to review.
+Recertification is targeted, not blanket. If a protocol update adds a new governance task but doesn't affect media buy workflows, only credentials that cover governance are flagged. Credential holders receive a notification through Addie with context on what changed and what they need to review. The decision process, delta-assessment rules, and AdCP 3.1 S2 canonical formats rationale are documented in the [recertification policy](/docs/learning/policies/recertification).
 
 | Tier | Validity | Recertification |
 |------|----------|-----------------|
@@ -292,10 +296,10 @@ Quality gates are enforced by the application, not by AI judgment alone:
 
 ## Accreditation alignment
 
-This framework is designed to satisfy the requirements of:
+This framework is designed to align with the requirements of:
 
 - **ANSI/IACET 1-2018 Standard for Continuing Education and Training** — Elements 2 (learning environment), 3 (instructional personnel), 5 (learning outcomes), 6 (content and instruction), 7 (assessment), and 9 (evaluation)
 - **ASTM E3416-24 Standard Practice for Competency-Based Work-Based Learning Programs** — competency alignment, formative and summative assessment, simulated workplace settings, credential issuance
 - **CPD Standards Office** accreditation requirements for continuing professional development
 
-Organizational policies supporting this framework are documented in the [policies section](/docs/learning/policies/nondiscrimination).
+Organizational policies supporting this framework are documented in the [policies section](/docs/learning/policies/nondiscrimination), including the [recertification policy](/docs/learning/policies/recertification).

--- a/docs/learning/policies/complaints.mdx
+++ b/docs/learning/policies/complaints.mdx
@@ -10,6 +10,10 @@ description: "AdCP certification complaints policy: how to file grievances, inve
 **Adopted:** March 2026
 **Responsible party:** AgenticAdvertising.org program leadership
 
+<Note>
+This policy is IACET-aligned and CPD-aligned. It is not an assertion of current IACET Accredited Provider status or IACET CEU issuance.
+</Note>
+
 ## Purpose
 
 Any learner or stakeholder may raise a concern about the AdCP certification program. This policy describes how complaints are filed, investigated, and resolved.
@@ -21,6 +25,7 @@ Email certification@agenticadvertising.org with the subject line "Certification 
 ## What qualifies
 
 - Assessment fairness concerns
+- Recertification or protocol-update targeting disputes
 - Accessibility issues
 - Content accuracy disputes
 - Conduct issues
@@ -45,7 +50,7 @@ If the complainant disagrees with the resolution, they may request escalation.
 
 **Internal:** If a complaint is not resolved satisfactorily, learners may escalate to AgenticAdvertising.org leadership by replying to the resolution email with a request for escalation. Leadership will review within 10 business days.
 
-**External:** If internal resolution is unsatisfactory and the complaint involves accreditation standards, learners may contact the relevant accreditation body directly.
+**External:** If AgenticAdvertising.org holds an active external accreditation applicable to the complaint, and internal resolution is unsatisfactory, learners may contact the relevant accreditation body under that body's published complaint process.
 
 ## Confidentiality
 

--- a/docs/learning/policies/learner-records.mdx
+++ b/docs/learning/policies/learner-records.mdx
@@ -10,6 +10,10 @@ description: "AdCP certification learner records policy: data retention, privacy
 **Adopted:** March 2026
 **Responsible party:** AgenticAdvertising.org engineering and program leadership
 
+<Note>
+This policy is IACET-aligned and CPD-aligned. It is not an assertion of current IACET Accredited Provider status or IACET CEU issuance.
+</Note>
+
 ## Purpose
 
 This policy establishes how learner data is collected, stored, accessed, and retained in the AdCP certification program.
@@ -35,7 +39,7 @@ Learner records are maintained in two systems:
 
 ## Retention
 
-Learner records are retained for a minimum of **7 years** from the date of last activity, consistent with IACET accreditation requirements.
+Learner records are retained for a minimum of **7 years** from the date of last activity, aligned with continuing-education accreditation record-retention expectations.
 
 ## Transcript access
 
@@ -48,7 +52,7 @@ Learners can view their progress and earned credentials at any time through the 
 - Learner feedback is reviewed in aggregate for curriculum improvement; individual feedback is not attributed publicly
 
 <Note>
-**GDPR:** Learners may request data export or deletion by contacting certification@agenticadvertising.org. Deletion requests are honored except where retention is required for accreditation compliance (7-year minimum). In such cases, records are anonymized rather than deleted.
+**GDPR:** Learners may request data export or deletion by contacting certification@agenticadvertising.org. Deletion requests are honored except where retention is required for continuing-education program records (7-year minimum). In such cases, records are anonymized rather than deleted.
 </Note>
 
 ## Non-compliance

--- a/docs/learning/policies/recertification.mdx
+++ b/docs/learning/policies/recertification.mdx
@@ -1,0 +1,129 @@
+---
+title: Recertification and protocol-change updates
+sidebarTitle: Recertification
+description: "AdCP certification recertification policy: targeted protocol-change updates, delta assessments, learner notifications, and the AdCP 3.1 canonical formats S2 rationale."
+"og:title": "AdCP - Recertification and protocol-change updates"
+---
+
+# Recertification and protocol-change updates
+
+**Adopted:** May 2026
+**Responsible party:** AgenticAdvertising.org program leadership
+
+<Note>
+This policy is IACET-aligned and CPD-aligned. It is not an assertion of current IACET Accredited Provider status or IACET CEU issuance.
+</Note>
+
+## Purpose
+
+AdCP credentials are tied to protocol competency. When the protocol changes, the certification program determines whether existing credential holders need no action, a targeted delta assessment, or full recertification.
+
+This policy documents that decision process and records the AdCP 3.1 canonical formats rationale for pre-3.1 S2 Creative specialist holders.
+
+## Decision levels
+
+| Level | When used | Learner requirement |
+|---|---|---|
+| No action | The protocol change does not affect the credential's required demonstrations | None |
+| Delta assessment | The protocol change adds or narrows a bounded competency that builds on prior demonstrated work | Complete only the new or changed required demonstrations |
+| Full recertification | The protocol change invalidates the prior competency evidence, the learner misses the delta window, or the prior record cannot support a delta decision | Complete the current module again |
+
+Delta assessment is available only when a written rationale maps the new criteria to prior demonstrated competencies before learner invitations or engine targeting go live.
+
+## General process
+
+1. Program leadership identifies the affected credential, module, and criterion IDs.
+2. The curriculum owner writes a rationale mapping the protocol change to prior evidence and the new required demonstrations.
+3. Engineering ships the updated module criteria and records the criteria effective point.
+4. The certification engine targets credential holders whose prior completion predates the criteria effective point and whose records do not already include the new criteria.
+5. Learners receive a notification explaining the change, required delta work, deadline, and escalation path.
+6. Delta completion is recorded in the learner record and retained under the [learner records policy](/docs/learning/policies/learner-records).
+
+## Effective dates and targeting
+
+For any protocol-change update, the curriculum change record must define these dates before engineering targets learners:
+
+| Field | Definition |
+|---|---|
+| `criteria_effective_at` | The later of the production deployment that adds the new required criteria and the protocol GA date that makes those criteria learner-facing |
+| `delta_window_opens_at` | The date learner targeting and notifications may begin |
+| `delta_window_closes_at` | The final date for delta-only completion |
+| `auditable_record_required` | The minimum learner record needed to offer a delta instead of full recertification |
+
+For the AdCP 3.1 S2 Creative canonical-format update:
+
+| Field | Value |
+|---|---|
+| `criteria_effective_at` | Later of the production deployment of `496_curriculum_3_1_canonical_formats_criteria.sql` and AdCP 3.1.0 GA |
+| `delta_window_opens_at` | `criteria_effective_at`; no learner targeting or notification may run before both AdCP 3.1.0 GA and production deployment of the new criteria |
+| `delta_window_closes_at` | 90 calendar days after `delta_window_opens_at`, ending at 23:59 UTC on the computed deadline date |
+| `auditable_record_required` | S2 learner progress completed before `criteria_effective_at`, plus an S2 completion record or teaching checkpoint trail sufficient to verify the prior required demonstrations |
+
+Holders whose learner records already include all five AdCP 3.1 canonical-format S2 criteria require no action. Holders whose records predate `criteria_effective_at` and lack one or more of the five criteria are delta candidates only when the auditable-record requirement is met.
+
+## AdCP 3.1 canonical formats: S2 Creative delta rationale
+
+AdCP 3.1 adds canonical format declarations to media-buy products through `format_options[]`. Creative specialists must now read a product's canonical declaration, choose the correct `format_kind`, distinguish product-level `format_option_id` from creative-agent `capability_id`, select the right asset-source model, and explain the validation order from shared canonical shape to product-specific narrowing.
+
+The change is material enough to require recertification for existing S2 Creative holders, but it does not invalidate the rest of the S2 credential. Pre-3.1 S2 holders already demonstrated creative workflow competency across format discovery, creative manifests, preview, sync, pricing, tracker-slot reasoning, and broadcast identifiers. Canonical formats extend those competencies with a new product-declaration layer rather than replacing the whole creative workflow.
+
+Therefore, pre-3.1 S2 Creative holders are eligible for a targeted delta assessment, not automatic full recertification, when their prior S2 learner record is available and complete.
+
+### Criteria mapping
+
+| New S2 criterion ID | New competency | Prior S2 evidence it builds on | Delta rationale |
+|---|---|---|---|
+| `s2_ex1_sc_format_kind_selection` | Select the correct canonical `format_kind` for a product and manifest | Format discovery, creative manifest authoring, and channel/format distinction | Adds the canonical vocabulary layer to an existing format-selection competency |
+| `s2_ex1_sc_format_options_cardinality` | Read `format_options[]` and explain single-option, multi-option, and multi-size fan-out declarations | Multi-format creative adaptation and sync across publisher requirements | Narrows how product declarations are represented; prior evidence covers adapting assets to publisher format constraints |
+| `s2_ex1_sc_option_vs_capability_id` | Distinguish media-buy `format_option_id` from creative-agent `capability_id` | Creative-agent capability discovery and media-buy product reading | Prevents namespace confusion introduced by 3.1; prior evidence covers both surfaces separately |
+| `s2_ex1_sc_source_taxonomy` | Choose the correct asset-source model across buyer-uploaded, agent-synthesized, seller pre-rendered, seller human-designed, and publisher-host-recorded workflows | Creative generation, transformation, preview, and sync workflows | Adds explicit taxonomy to workflow distinctions already assessed in S2 |
+| `s2_ex1_sc_validation_order` | Explain canonical-first, product-second validation and creative-agent capability narrowing | Schema compliance, preview validation, and sync error recovery | Adds validation sequencing for 3.1 product narrowing; prior evidence covers validation and recovery generally |
+
+### Eligibility
+
+The S2 canonical-format delta applies to learners who earned the S2 Creative specialist credential before `criteria_effective_at` and who have an auditable S2 completion record.
+
+Learners are assigned full S2 recertification instead of the delta when:
+
+- their prior S2 record is missing or incomplete;
+- they do not complete the delta within the published window;
+- their prior completion predates the current evidence-retention model and cannot be mapped to the criteria above;
+- program leadership determines that a future protocol change invalidates more than the canonical-format layer.
+
+### Window
+
+The delta-only window is 90 days after `delta_window_opens_at`. During that window, affected credential holders keep their S2 credential but are marked as requiring a protocol update. After the window closes, unresolved holders retain their historical S2 completion record, but their learner-facing S2 status is no longer current until they complete the current S2 module. Learner-facing messages must include the computed absolute deadline date.
+
+## CPD and accreditation disclosure
+
+Recommended disclosure for continuing professional development records:
+
+> AdCP 3.1 introduced canonical format declarations for media-buy products. AgenticAdvertising.org reviewed the S2 Creative specialist credential and determined that existing S2 holders require a targeted protocol-change update covering the new canonical-format criteria. The update is a delta assessment because the new criteria extend prior demonstrated creative workflow competencies rather than replacing the full S2 competency set. Learners who do not complete the delta assessment during the published window must complete the current S2 module.
+
+This rationale must be retained with the curriculum change record and learner records for audit purposes.
+
+## Learner notification copy
+
+In-product notification:
+
+> AdCP 3.1 adds canonical format declarations to creative workflows. Your S2 Creative specialist credential remains active, but you need a short protocol update covering the new canonical-format criteria. Complete the S2 canonical formats delta by `<computed deadline date>` to keep your credential current without retaking the full S2 module.
+>
+> If you believe you were targeted in error, email certification@agenticadvertising.org. We acknowledge assessment and targeting review requests within 2 business days and resolve them through the [complaints process](/docs/learning/policies/complaints).
+
+Email notification:
+
+> Subject: S2 Creative protocol update required for AdCP 3.1
+>
+> AdCP 3.1 adds canonical format declarations to media-buy products. Because you earned S2 Creative before this change, you need to complete a targeted delta assessment covering the new canonical-format criteria. This is not a full recertification: it focuses only on reading `format_options[]`, selecting `format_kind`, distinguishing `format_option_id` from creative-agent `capability_id`, choosing the correct asset-source model, and explaining canonical-first validation.
+>
+> Complete the delta by `<computed deadline date>` to keep your credential current. After that window, the current S2 module is required for renewal. If you believe you were targeted in error, email certification@agenticadvertising.org; we acknowledge assessment and targeting review requests within 2 business days and resolve them through the complaints process.
+
+## Implementation gates
+
+Engineering must not enable learner targeting or send learner notifications until all of the following are true:
+
+- this rationale is published;
+- the new S2 criteria are present in `certification_modules.exercise_definitions`;
+- the eligibility query can identify pre-effective-date S2 holders;
+- delta completion writes an auditable learner record showing the new criteria were verified;
+- support and complaints escalation paths are ready for learners who believe they were targeted incorrectly.

--- a/server/public/ai-disclosure.html
+++ b/server/public/ai-disclosure.html
@@ -80,22 +80,22 @@
       <p class="drop">AgenticAdvertising.org uses AI extensively to write content, generate imagery, ship code, and run operations. This page names every surface where that happens, the models behind it, and how to request human review.</p>
 
       <h2 id="authored">What's AI-authored</h2>
-      <p>These surfaces are written primarily by an AI agent operated by AAO, with human editorial oversight:</p>
+      <p>These surfaces are written primarily by an AI agent operated by AgenticAdvertising.org, with human editorial oversight:</p>
       <ul>
-        <li><strong>Addie</strong> — AAO's teaching assistant and chat agent. All Addie chat responses are AI-generated.</li>
+        <li><strong>Addie</strong> — AgenticAdvertising.org's teaching assistant and chat agent. All Addie chat responses are AI-generated.</li>
         <li><strong>Sage</strong> — the AdCP protocol explainer agent. Protocol Q&amp;A in the docs chat is answered by Sage.</li>
-        <li><strong>The Prompt</strong> — our biweekly newsletter, authored in first person as Addie. The Prompt is editorial and is also a marketing surface for AAO; read it as both.</li>
+        <li><strong>The Prompt</strong> — our biweekly newsletter, authored in first person as Addie. The Prompt is editorial and is also a marketing surface for AgenticAdvertising.org; read it as both.</li>
         <li><strong>The Build</strong> — our triweekly technical newsletter, authored by Sage.</li>
         <li><strong>Member portraits</strong> — graphic-novel-style illustrations for members are AI-generated.</li>
-        <li><strong>Certification grading</strong> — Addie grades the free Basics track against a fixed rubric of 3&ndash;5 required demonstrations per module, and also grades the paid Practitioner and Specialist tracks. AAO is both the issuer and the grader of these credentials; we disclose this conflict rather than deny it, and human review of any grading decision is available on request (see below).</li>
+        <li><strong>Certification grading</strong> — Addie grades the free Basics track against a fixed rubric of 3&ndash;5 required demonstrations per module, and also grades the paid Practitioner and Specialist tracks. AgenticAdvertising.org is both the issuer and the grader of these credentials; we disclose this conflict rather than deny it, and human review of any grading decision is available on request (see below).</li>
       </ul>
 
       <h2 id="assisted">What's AI-assisted</h2>
-      <p>Most of the rest of AAO's public surface is built with AI coding assistants, reviewed by humans before publishing. This includes:</p>
+      <p>Most of the rest of AgenticAdvertising.org's public surface is built with AI coding assistants, reviewed by humans before publishing. This includes:</p>
       <ul>
         <li>The protocol schemas and documentation (<a href="https://docs.adcontextprotocol.org" target="_blank" rel="noopener noreferrer">docs.adcontextprotocol.org</a>)</li>
         <li>The open-source reference implementations</li>
-        <li>The admin tools operated by AAO staff</li>
+        <li>The admin tools operated by AgenticAdvertising.org staff</li>
         <li>Most public-facing code in the <a href="https://github.com/adcontextprotocol" target="_blank" rel="noopener noreferrer">adcontextprotocol</a> organization</li>
       </ul>
       <p>We don't mark individual paragraphs or pull requests as AI-assisted &mdash; the default is that AI tools were involved.</p>
@@ -109,31 +109,40 @@
 
       <h2 id="data">Data handling</h2>
       <ul>
-        <li><strong>Addie and Sage chat</strong> &mdash; conversations are logged to improve teaching quality and to allow appeals on grading decisions. Logs are retained by AAO and not used by model providers for training. EU/UK residents: chat inputs are processed on our behalf by Anthropic; see our <a href="/api/agreement?type=privacy_policy">privacy policy</a> for the current data-processor chain and transfer mechanism.</li>
+        <li><strong>Addie and Sage chat</strong> &mdash; conversations are logged to improve teaching quality and to allow appeals on grading decisions. Logs are retained by AgenticAdvertising.org and not used by model providers for training. EU/UK residents: chat inputs are processed on our behalf by Anthropic; see our <a href="/api/agreement?type=privacy_policy">privacy policy</a> for the current data-processor chain and transfer mechanism.</li>
         <li><strong>Grading decisions</strong> &mdash; the required-demonstrations, the Addie interaction that produced the credit, and the resulting assessment are retained so that a learner (or a regulator) can reconstruct the decision.</li>
         <li><strong>Member portraits</strong> &mdash; AI-generated images are produced from member-provided inputs; the prompt and generated image are retained on the member's profile.</li>
       </ul>
 
       <h2 id="review">Human review</h2>
-      <p>You can request human review on any AI-generated surface. Target turnaround is <strong>five business days</strong>; complex cert appeals may take longer.</p>
+      <p>You can request human review on any AI-generated surface.</p>
+      <p><strong>Certification grading and targeting review SLA.</strong> Because AgenticAdvertising.org is both the issuer and the AI grader of its certifications, every grading appeal and protocol-update targeting dispute gets a documented human-review path:</p>
       <ul>
-        <li><strong>Certification grading</strong> &mdash; if you believe Addie's assessment of your work was wrong, email <a href="mailto:help@agenticadvertising.org">help@agenticadvertising.org</a> for human review by AAO staff.</li>
+        <li><strong>Acknowledgement: 2 business days</strong> from receipt at <a href="mailto:certification@agenticadvertising.org">certification@agenticadvertising.org</a>.</li>
+        <li><strong>Resolution:</strong> handled through the certification complaints process, by an AgenticAdvertising.org staff reviewer who did not participate in the original grading or targeting decision.</li>
+        <li><strong>Outcome on upheld appeals:</strong> the credential is granted or the learner record is corrected, depending on the issue under review.</li>
+        <li><strong>Escalation:</strong> appeals that the staff reviewer cannot resolve are escalated to AgenticAdvertising.org program leadership.</li>
+        <li><strong>Annual transparency report:</strong> AgenticAdvertising.org publishes appeals volume, upheld rate, and median time-to-decision once per year as part of the AGM materials. The first report covers the period ending 2027-04.</li>
+      </ul>
+      <p>To file a grading appeal or protocol-update targeting dispute, email <a href="mailto:certification@agenticadvertising.org">certification@agenticadvertising.org</a> with your learner ID, the module or assessment in question, and the specific finding you are contesting.</p>
+      <p>Other AI-surface review paths:</p>
+      <ul>
         <li><strong>Content corrections</strong> &mdash; factual errors in Addie's teaching, Sage's protocol explanations, or any AI-authored content can be reported via <a href="https://github.com/adcontextprotocol/adcp/issues" target="_blank" rel="noopener noreferrer">GitHub issues</a> or <a href="https://join.slack.com/t/agenticads/shared_invite/zt-3c5sxvdjk-x0rVmLB3OFHVUp~WutVWZg" target="_blank" rel="noopener noreferrer">Slack</a>.</li>
         <li><strong>Protocol guidance</strong> &mdash; Sage is not a substitute for legal or regulatory advice. For compliance-sensitive questions, consult qualified counsel.</li>
       </ul>
 
       <h2 id="provenance">Content provenance (C2PA)</h2>
-      <p>Every AI-generated image AAO publishes carries an embedded <a href="https://c2pa.org/" target="_blank" rel="noopener noreferrer">C2PA</a> manifest signed by AAO:</p>
+      <p>Every AI-generated image AgenticAdvertising.org publishes carries an embedded <a href="https://c2pa.org/" target="_blank" rel="noopener noreferrer">C2PA</a> manifest signed by AgenticAdvertising.org:</p>
       <ul>
         <li><strong>Member portraits</strong> &mdash; also carry a visible &ldquo;AI&rdquo; badge in the bottom-right corner (CA SB 942 visible-disclosure path).</li>
         <li><strong>Newsletter cover art</strong> &mdash; The Prompt and The Build covers, including the copies that ship in subscriber email and render as OpenGraph share cards.</li>
         <li><strong>Perspective article hero images</strong> &mdash; every editorial illustration attached to a published perspective.</li>
         <li><strong>Docs walkthrough and concept illustrations</strong> &mdash; the panel PNGs embedded throughout the docs site's walkthroughs and concept explainers.</li>
       </ul>
-      <p>The manifest identifies Google Gemini as the generating software agent, marks the asset as <code>trainedAlgorithmicMedia</code> per the IPTC digital-source-type vocabulary, and includes a timestamp plus a SHA-256 of the generation prompt (not the prompt itself &mdash; portraits are generated from member-provided descriptions we do not want to republish). AAO signs with a self-signed P-256 certificate held in production secrets. CAI trust-list inclusion is a future step; today, public verifiers will show the signature as cryptographically valid but flag <em>&ldquo;issuer not on trust list.&rdquo;</em></p>
-      <p><strong>Verify any AAO image</strong> at <a href="https://contentcredentials.org/verify" target="_blank" rel="noopener noreferrer">contentcredentials.org/verify</a> by uploading the file or pasting its URL.</p>
-      <p>For editorial illustrations and docs storyboards where a visible mark would undermine the graphic-novel aesthetic, the C2PA manifest is the sole disclosure surface. CA SB 942's visible-disclosure rule targets upstream generative-AI providers rather than downstream publishers, so this placement is defensible for AAO &mdash; but it is a deliberate choice, not an oversight.</p>
-      <p>If you find an AAO-generated image that does not carry a manifest, please <a href="https://github.com/adcontextprotocol/adcp/issues" target="_blank" rel="noopener noreferrer">open an issue</a> &mdash; we treat missing provenance as a bug.</p>
+      <p>The manifest identifies Google Gemini as the generating software agent, marks the asset as <code>trainedAlgorithmicMedia</code> per the IPTC digital-source-type vocabulary, and includes a timestamp plus a SHA-256 of the generation prompt (not the prompt itself &mdash; portraits are generated from member-provided descriptions we do not want to republish). AgenticAdvertising.org signs with a self-signed P-256 certificate held in production secrets. CAI trust-list inclusion is a future step; today, public verifiers will show the signature as cryptographically valid but flag <em>&ldquo;issuer not on trust list.&rdquo;</em></p>
+      <p><strong>Verify any AgenticAdvertising.org image</strong> at <a href="https://contentcredentials.org/verify" target="_blank" rel="noopener noreferrer">contentcredentials.org/verify</a> by uploading the file or pasting its URL.</p>
+      <p>For editorial illustrations and docs storyboards where a visible mark would undermine the graphic-novel aesthetic, the C2PA manifest is the sole disclosure surface. CA SB 942's visible-disclosure rule targets upstream generative-AI providers rather than downstream publishers, so this placement is defensible for AgenticAdvertising.org &mdash; but it is a deliberate choice, not an oversight.</p>
+      <p>If you find an AgenticAdvertising.org-generated image that does not carry a manifest, please <a href="https://github.com/adcontextprotocol/adcp/issues" target="_blank" rel="noopener noreferrer">open an issue</a> &mdash; we treat missing provenance as a bug.</p>
 
       <h2 id="regulatory">Regulatory posture</h2>
       <p>This disclosure is informed by the FTC Endorsement Guides (2023), EU AI Act Art 50, and California SB 942. It has not been reviewed by outside counsel.</p>
@@ -144,15 +153,15 @@
       <p>If you believe a specific AI surface falls short of an applicable standard, let us know.</p>
 
       <h2 id="conflicts">Institutional conflicts</h2>
-      <p>AI authorship and evaluation by AAO intersect with AAO's broader governance in ways readers should know:</p>
+      <p>AI authorship and evaluation by AgenticAdvertising.org intersect with AgenticAdvertising.org's broader governance in ways readers should know:</p>
       <ul>
-        <li>AAO is both the issuer and the grader of its certifications (Addie evaluates coursework and grants credentials AAO sells).</li>
-        <li>AAO's founder's other company (Scope3) contributed funding and foundational IP &mdash; see the <a href="https://docs.adcontextprotocol.org/docs/faq#how-is-aao-related-to-scope3" target="_blank" rel="noopener noreferrer">FAQ entry</a> for the full relationship.</li>
+        <li>AgenticAdvertising.org is both the issuer and the grader of its certifications (Addie evaluates coursework and grants credentials AgenticAdvertising.org sells).</li>
+        <li>AgenticAdvertising.org's founder's other company (Scope3) contributed funding and foundational IP &mdash; see the <a href="https://docs.adcontextprotocol.org/docs/faq#how-is-aao-related-to-scope3" target="_blank" rel="noopener noreferrer">FAQ entry</a> for the full relationship.</li>
       </ul>
       <p>The governance framework, board composition, and recusal rules are set out in <a href="https://github.com/adcontextprotocol/adcp/blob/main/CHARTER.md" target="_blank" rel="noopener noreferrer">CHARTER.md</a>, with the authoritative board list and funding disclosures at <a href="/governance">agenticadvertising.org/governance</a>.</p>
 
       <hr>
-      <p>Material changes to how AI is used at AAO will be reflected on this page.</p>
+      <p>Material changes to how AI is used at AgenticAdvertising.org will be reflected on this page.</p>
     </div>
   </div>
 

--- a/server/public/certification.html
+++ b/server/public/certification.html
@@ -1599,7 +1599,7 @@
 
         html += '<p><a href="/ai-disclosure#review" class="assessment-link">About Addie’s grading and your rights →</a></p>';
         html += '<div class="assessment-review-area" id="review-area-' + esc(mod.id) + '">';
-        html += '<p class="assessment-note">Disagree with this assessment? AgenticAdvertising.org staff will review within 2 business days.</p>';
+        html += '<p class="assessment-note">Disagree with this assessment? AgenticAdvertising.org staff will acknowledge review requests within 2 business days and resolve them through the certification complaints process.</p>';
         html += '<div class="assessment-review-actions">';
         html += '<button type="button" class="btn-review-request" onclick="submitReviewRequest(event, \'' + esc(mod.id) + '\')">';
         html += 'Request human review';
@@ -1772,7 +1772,7 @@
             if (reviewArea) {
               var msg = document.createElement('p');
               msg.className = 'review-submitted';
-              msg.textContent = 'Review requested — you’ll hear from us within 2 business days.';
+              msg.textContent = 'Review requested — we acknowledge review requests within 2 business days and resolve them through the certification complaints process.';
               reviewArea.replaceChildren(msg);
             }
           } else {


### PR DESCRIPTION
## Summary

- Adds a recertification policy page covering protocol-change updates and the AdCP 3.1 S2 Creative canonical-format delta rationale.
- Defines deterministic effective-date/window semantics for the S2 delta, including no targeting before both 3.1 GA and production deployment of the new criteria.
- Aligns certification review paths across docs and public pages to `certification@agenticadvertising.org`, 2-business-day acknowledgment, and the complaints process.
- Adds accreditation-status disclaimers where existing certification policy language could otherwise read as a current IACET AP / CEU claim.

## Notes

Refs #4696. This documents the policy/rationale and implementation gates required before learner targeting or notifications; the certification-engine targeting work remains a follow-up.

## Validation

- `npm run test:docs-nav`
- `npm run test:json-schema`
- `npm run typecheck`
- `git diff --check`
- precommit: `test:unit`, `test:test-dynamic-imports`, `test:callapi-state-change`, `typecheck`
- prepush: version sync, schema link convention, Mintlify broken-links check

## Expert review

- education-expert reviewed accreditation sequencing and requested the deterministic cutoff/window, disclaimer, and review-path fixes.
- docs-expert reviewed the policy/docs wording and confirmed the remaining blockers after the final fixes were limited to the two contradictions now addressed.