### PR TITLE
[codex] Update 3.1 active development banners

### DIFF
--- a/.changeset/3-1-active-development-banner.md
+++ b/.changeset/3-1-active-development-banner.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs: update public and docs banners for AdCP 3.1 active development.

--- a/docs.json
+++ b/docs.json
@@ -2,7 +2,7 @@
   "$schema": "https://mintlify.com/schema.json",
   "name": "AdCP - Ad Context Protocol",
   "banner": {
-    "content": "🚀 AdCP 3.1 beta is now available — [see what's new](/docs/reference/whats-new-in-3-1)",
+    "content": "AdCP 3.1 is in active development — [see what's coming →](/docs/reference/release-notes)",
     "dismissible": true
   },
   "description": "AdCP (Ad Context Protocol) is the open standard for agentic advertising. It defines how AI agents buy media, generate creatives, activate audiences, and enforce governance across platforms.",

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -32,13 +32,13 @@
 </head>
 <body data-nav-theme="dark">
 
-<!-- 3.0 GA announcement strip (dismissible) -->
-<div id="aao-announcement" style="display:none;background:#047857;color:#fff;padding:10px 20px;text-align:center;font-size:14px;line-height:1.4;position:relative;">
-  🎉 <strong>AdCP 3.0 is now GA</strong> &mdash; <a href="https://docs.adcontextprotocol.org/docs/reference/whats-new-in-v3" style="color:#fff;text-decoration:underline;">see what's new</a>
-  <button onclick="document.getElementById('aao-announcement').style.display='none';document.cookie='aao_announce_30_dismissed=1;path=/;max-age=2592000';" aria-label="Dismiss announcement" style="position:absolute;right:12px;top:50%;transform:translateY(-50%);background:none;border:none;color:#fff;font-size:18px;cursor:pointer;padding:0 6px;line-height:1;">&times;</button>
+<!-- 3.1 active development announcement strip (dismissible) -->
+<div id="aao-announcement" style="display:none;background:var(--color-brand);color:var(--color-text-on-dark);padding:10px 20px;text-align:center;font-size:14px;line-height:1.4;position:relative;">
+  <strong>AdCP 3.1 is in active development</strong> &mdash; <a href="https://docs.adcontextprotocol.org/docs/reference/release-notes" style="color:var(--color-text-on-dark);text-decoration:underline;">see what's coming &rarr;</a>
+  <button onclick="document.getElementById('aao-announcement').style.display='none';document.cookie='aao_announce_31_dismissed=1;path=/;max-age=2592000';" aria-label="Dismiss announcement" style="position:absolute;right:12px;top:50%;transform:translateY(-50%);background:none;border:none;color:var(--color-text-on-dark);font-size:18px;cursor:pointer;padding:0 6px;line-height:1;">&times;</button>
 </div>
 <script>
-  if (!document.cookie.split(';').some(c => c.trim().startsWith('aao_announce_30_dismissed='))) {
+  if (!document.cookie.split(';').some(c => c.trim().startsWith('aao_announce_31_dismissed='))) {
     document.getElementById('aao-announcement').style.display = 'block';
   }
 </script>


### PR DESCRIPTION
## Summary
- update the Mintlify docs banner to the AdCP 3.1 active-development message and release-notes target
- update the AgenticAdvertising.org homepage announcement strip from stale 3.0 GA copy to the same 3.1 active-development message
- rotate the homepage dismissal cookie from `aao_announce_30_dismissed` to `aao_announce_31_dismissed` so prior 3.0 dismissals do not hide the new announcement

Closes #5032

## Validation
- `git diff --check`
- `npm run test:docs-nav`
- `npm run test:json-schema`
- `npm run typecheck`
- precommit: unit tests, dynamic-import lint, callApi state-change lint, typecheck

## Expert review
- Copy review found no blockers and gave a ship verdict.
