### PR TITLE
[codex] Clarify 3.1 whats-new page role

### DIFF
--- a/.changeset/5068-whats-new-disposition.md
+++ b/.changeset/5068-whats-new-disposition.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs: clarify the role split between release notes and the 3.1 whats-new overview.

--- a/docs/reference/release-notes.mdx
+++ b/docs/reference/release-notes.mdx
@@ -1,17 +1,19 @@
 ---
 title: Release Notes
-description: "AdCP release notes with version highlights and migration guides. Covers breaking changes, new tasks, and schema updates for each major release."
+description: "Authoritative AdCP version-by-version release record with cumulative change detail, migration guidance, and per-version adoption notes."
 "og:title": "AdCP — Release Notes"
 ---
 
 
-High-level summaries of major AdCP releases with migration guidance. For the at-a-glance status of every published version, see [Versions & Compatibility](/docs/reference/versions). For detailed technical changelogs, see [CHANGELOG.md](https://github.com/adcontextprotocol/adcp/blob/main/CHANGELOG.md). For version stability, schema-change scope, and the 3.x guarantees see [Versioning & Governance](/docs/reference/versioning). For v2 end-of-life see the [v2 sunset page](/docs/reference/v2-sunset).
+Authoritative version-by-version release record for AdCP, with cumulative change detail, migration guidance, and per-version adoption notes. For a curated adopter overview of the 3.1 minor release, see [What's New in AdCP 3.1](/docs/reference/whats-new-in-3-1). For the at-a-glance status of every published version, see [Versions & Compatibility](/docs/reference/versions). For source-level changelogs, see [CHANGELOG.md](https://github.com/adcontextprotocol/adcp/blob/main/CHANGELOG.md). For version stability, schema-change scope, and the 3.x guarantees see [Versioning & Governance](/docs/reference/versioning). For v2 end-of-life see the [v2 sunset page](/docs/reference/v2-sunset).
 
 ---
 
 ## Version 3.1.0 (unreleased)
 
 **Status:** Accumulating — minor release. The published 3.0.x line remains the stable surface; 3.1 features land here as their changesets accumulate. SDKs pin to a specific 3.x and pick up minors at their own cadence.
+
+For adoption-oriented framing before the full change list, start with [What's New in AdCP 3.1](/docs/reference/whats-new-in-3-1).
 
 **Headline:** **Distributed `brand.json`.** A brand can now publish its **own** canonical document on its own domain while the corporate house declares ownership via a portfolio pointer. The hierarchy stays one level deep — only houses declare ownership — and trust between a leaf and a house resolves via mutual assertion (both sides reciprocate). Identity attributes (logos, colors, tone, tagline) trust on the leaf's TLS alone; relationship trust (governance propagation, billable inclusion) gates on the reciprocal entry.
 

--- a/docs/reference/whats-new-in-3-1.mdx
+++ b/docs/reference/whats-new-in-3-1.mdx
@@ -10,7 +10,7 @@ description: "Adopter overview of AdCP 3.1 — distributed brand.json, dependenc
 
 AdCP 3.1 is a minor release. Every 3.1 change is **additive** over 3.0: new fields are optional, no required field was removed, no shape changed in a way that breaks a 3.0-conformant client. **No breaking changes.** But schemas moved — 3.1 introduces meaningful new surfaces that solve production problems 3.0 left open. **You should bump your pin to 3.1 as soon as your SDK is ready** to pick up the new fields.
 
-For per-PR detail and migration tables, see [Release Notes § Version 3.1.0](/docs/reference/release-notes#version-3-1-0-unreleased). For long-form normative reference, follow the link on each headline below.
+This page is the curated adopter overview for the 3.1 minor release. Need the full 3.1 change list, per-PR detail, or migration tables? Use [Release Notes § Version 3.1.0](/docs/reference/release-notes#version-3-1-0-unreleased), the authoritative version record. For long-form normative reference, follow the link on each headline below.
 
 <Note>
 **Looking for the major v2 → v3 changes instead?** See [What's New in AdCP 3](/docs/reference/whats-new-in-v3). This page covers the 3.0 → 3.1 minor delta only.


### PR DESCRIPTION
## Summary
- clarify that Release Notes is the authoritative version-by-version release record for 3.1 details, migration guidance, and adoption notes
- keep What's New in AdCP 3.1 as the curated adopter overview
- cross-link both pages so banners and readers have clear destinations

Closes #5068.

## Expert review
- docs-expert: clear; release notes now reads as the authoritative version record and whats-new as the curated adopter overview
- copywriter: clear; no remaining blockers and the role split reads cleanly

## Validation
- npm run test:docs-nav
- npm run test:json-schema
- precommit hook: npm run test:unit, npm run test:test-dynamic-imports, npm run test:callapi-state-change, npm run typecheck