### PR TITLE
[codex] Harden upstream traffic path lint

### DIFF
--- a/.changeset/5081-upstream-traffic-path-lint.md
+++ b/.changeset/5081-upstream-traffic-path-lint.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore(compliance): harden upstream_traffic identifier_paths and payload_must_contain.path lint follow-ups.

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -50,8 +50,11 @@ jobs:
       - name: Repo unit tests
         run: npm run test:unit
 
-      - name: Storyboard lint tests
-        run: npm run test:storyboard-raw-mode-required && npm run test:storyboard-upstream-traffic-paths
+      - name: Storyboard raw-mode-required lint tests
+        run: npm run test:storyboard-raw-mode-required
+
+      - name: Storyboard upstream-traffic path lint tests
+        run: npm run test:storyboard-upstream-traffic-paths
 
       - name: Schema link plugin tests
         run: npm run test:schema-links

--- a/scripts/lint-storyboard-upstream-traffic-paths.cjs
+++ b/scripts/lint-storyboard-upstream-traffic-paths.cjs
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 /**
- * Validate portable path grammar for upstream_traffic `identifier_paths`.
+ * Validate upstream_traffic request-payload paths.
  *
- * The runner contract intentionally supports a small, request-payload-relative
- * grammar: dotted object keys with optional `[*]` wildcards on path segments.
- * Rejecting unsupported JSONPath-like forms at publish time prevents different
- * runners from silently resolving the same storyboard to different vectors.
+ * `identifier_paths` is intentionally restricted to the portable
+ * request-payload-relative grammar. `payload_must_contain.path` follows the
+ * runner's JSONPath-lite compatibility surface so linting does not reject
+ * paths that the current runner can execute.
  */
 
 'use strict';
@@ -16,16 +16,22 @@ const yaml = require('js-yaml');
 
 const ROOT = path.resolve(__dirname, '..');
 const SOURCE_DIR = path.join(ROOT, 'static', 'compliance', 'source');
-const SEGMENT_RE = /^[A-Za-z_][A-Za-z0-9_-]*(?:\[\*\])?$/;
+const IDENTIFIER_SEGMENT_RE = /^[A-Za-z_][A-Za-z0-9_-]*(?:\[\*\])?$/;
+const PAYLOAD_SEGMENT_RE = /^(?:[^\[\]]+|\[\d+\]|[^\[\]]*\[\*\](?:\[(?:\*|\d+)\])*)$/;
 const RESERVED_ROOTS = new Set(['request', 'response', 'context']);
 
 const RULE_MESSAGES = {
   invalid_identifier_path: (identifierPath) =>
     `identifier_paths entry "${identifierPath}" is outside the portable upstream_traffic grammar. ` +
-    'Use request-payload-relative dotted paths whose segments are keys optionally followed by [*], ' +
+    'Use request-payload-relative dotted paths whose segments are keys optionally followed by literal `[*]`, ' +
     'for example audiences[*].add[*].hashed_email. Bracket-quoted keys, numeric indexes, recursive ' +
     'descent, explicit roots, empty segments, and reserved roots request.*, response.*, and context.* ' +
     'are not portable.',
+  invalid_payload_path: (payloadPath) =>
+    `payload_must_contain.path "${payloadPath}" is outside the upstream_traffic JSONPath-lite grammar. ` +
+    'Use dotted paths with optional `[*]` wildcards, for example audiences[*].add[*].hashed_email. ' +
+    'Standalone numeric index tokens such as items.[0].id are tolerated for SDK compatibility. ' +
+    'Recursive descent, bracket-quoted keys, and key-attached numeric indexes such as items[0].id are not supported.',
 };
 
 function isStoryboardYaml(rel) {
@@ -38,7 +44,7 @@ function isStoryboardYaml(rel) {
 function isPortableIdentifierPath(value) {
   if (typeof value !== 'string') return false;
   if (value.length === 0) return false;
-  if (value.startsWith('$.') || value.startsWith('$..')) return false;
+  if (value.startsWith('$.')) return false;
 
   const segments = value.split('.');
   if (segments.some((segment) => segment.length === 0)) return false;
@@ -46,7 +52,27 @@ function isPortableIdentifierPath(value) {
   const root = segments[0].replace(/\[\*\]$/, '');
   if (RESERVED_ROOTS.has(root)) return false;
 
-  return segments.every((segment) => SEGMENT_RE.test(segment));
+  return segments.every((segment) => IDENTIFIER_SEGMENT_RE.test(segment));
+}
+
+function isSupportedPayloadPath(value) {
+  if (typeof value !== 'string') return false;
+  if (value.length === 0) return false;
+  if (value.startsWith('$..')) return false;
+
+  let p = value;
+  if (p.startsWith('$.')) {
+    p = p.slice(2);
+  } else if (p.startsWith('$')) {
+    p = p.slice(1);
+  }
+  if (p.startsWith('.')) p = p.slice(1);
+  if (p.length === 0) return true;
+  if (p.includes('..')) return false;
+
+  const segments = p.split('.');
+  if (segments.some((segment) => segment.length === 0)) return false;
+  return segments.every((segment) => PAYLOAD_SEGMENT_RE.test(segment));
 }
 
 function* walkUpstreamTrafficChecks(doc) {
@@ -84,8 +110,7 @@ function lint(sourceDir = SOURCE_DIR) {
     }
     for (const hit of walkUpstreamTrafficChecks(doc)) {
       const paths = hit.validation.identifier_paths;
-      if (paths === undefined || paths === null) continue;
-      if (!Array.isArray(paths)) {
+      if (paths !== undefined && paths !== null && !Array.isArray(paths)) {
         violations.push({
           file: rel,
           phase: hit.phaseId,
@@ -93,18 +118,41 @@ function lint(sourceDir = SOURCE_DIR) {
           index: hit.index,
           rule: 'invalid_identifier_path',
           identifier_path: String(paths),
+          path_kind: 'identifier_paths',
         });
-        continue;
       }
-      for (const identifierPath of paths) {
-        if (isPortableIdentifierPath(identifierPath)) continue;
+      if (Array.isArray(paths)) {
+        for (const identifierPath of paths) {
+          if (isPortableIdentifierPath(identifierPath)) continue;
+          violations.push({
+            file: rel,
+            phase: hit.phaseId,
+            step: hit.stepId,
+            index: hit.index,
+            rule: 'invalid_identifier_path',
+            identifier_path: String(identifierPath),
+            path_kind: 'identifier_paths',
+          });
+        }
+      }
+
+      const payloadAssertions = hit.validation.payload_must_contain;
+      if (!Array.isArray(payloadAssertions)) continue;
+      for (let payloadIndex = 0; payloadIndex < payloadAssertions.length; payloadIndex++) {
+        const assertion = payloadAssertions[payloadIndex];
+        if (!assertion || typeof assertion !== 'object') continue;
+        const payloadPath = assertion.path;
+        if (payloadPath === undefined || payloadPath === null) continue;
+        if (isSupportedPayloadPath(payloadPath)) continue;
         violations.push({
           file: rel,
           phase: hit.phaseId,
           step: hit.stepId,
           index: hit.index,
-          rule: 'invalid_identifier_path',
-          identifier_path: String(identifierPath),
+          rule: 'invalid_payload_path',
+          identifier_path: String(payloadPath),
+          path_kind: 'payload_must_contain.path',
+          path_index: payloadIndex,
         });
       }
     }
@@ -130,13 +178,17 @@ function lint(sourceDir = SOURCE_DIR) {
 function main() {
   const violations = lint();
   if (violations.length === 0) {
-    console.log('✓ storyboard upstream_traffic path lint: all identifier_paths use the portable grammar');
+    console.log(
+      '✓ storyboard upstream_traffic path lint: all identifier_paths and payload_must_contain.path values use supported grammars',
+    );
     return;
   }
   console.error(`✗ storyboard upstream_traffic path lint: ${violations.length} violation(s)\n`);
   for (const v of violations) {
     const msg = RULE_MESSAGES[v.rule] ? RULE_MESSAGES[v.rule](v.identifier_path) : v.rule;
-    console.error(`  ${v.file} phase=${v.phase} step=${v.step} validations[${v.index}] (${v.rule})`);
+    const pathIndex = v.path_index === undefined ? '' : `[${v.path_index}]`;
+    const pathKind = v.path_kind ? ` ${v.path_kind}${pathIndex}` : '';
+    console.error(`  ${v.file} phase=${v.phase} step=${v.step} validations[${v.index}]${pathKind} (${v.rule})`);
     console.error(`    ${msg}`);
     console.error('');
   }
@@ -148,6 +200,7 @@ if (require.main === module) main();
 module.exports = {
   RULE_MESSAGES,
   isPortableIdentifierPath,
+  isSupportedPayloadPath,
   walkUpstreamTrafficChecks,
   lint,
 };

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -1443,16 +1443,21 @@
 #     payload_must_contain: array of MatchSpec (optional)
 #                              # Each entry asserts a path/value pair that MUST
 #                              # appear in at least one matching call's payload.
-#                              # Path syntax: positional dotted path with `[*]`
-#                              # array wildcards. Examples:
+#                              # Path syntax: JSONPath-lite positional path
+#                              # with `[*]` array wildcards. Shared storyboards
+#                              # SHOULD use the bare dotted form. Examples:
 #                              #   "users[*].hashed_email"
 #                              #   "data.audience.members[*].id"
-#                              # The `[*]` wildcard flattens over arrays and
-#                              # passes if any element matches. RFC 9535
-#                              # JSONPath descendant syntax (`$..foo`) is NOT
+#                              # The literal `[*]` wildcard flattens over arrays
+#                              # and passes if any element matches. The runner
+#                              # also tolerates optional `$` / `$.` prefixes and
+#                              # standalone numeric index tokens for SDK
+#                              # compatibility (for example `items.[0].id`);
+#                              # shared storyboards should avoid indexes unless
+#                              # a position-specific assertion is intentional.
+#                              # RFC 9535 JSONPath descendant syntax (`$..foo`) is NOT
 #                              # supported — the runner uses
-#                              # parsePathWithWildcards from @adcp/sdk, which
-#                              # recognizes `[*]` only. Path matching only
+#                              # JSONPath-lite matching from @adcp/sdk. Path matching only
 #                              # applies when recorded_calls[].content_type is
 #                              # JSON-shaped — defined as `application/json`
 #                              # or any structured-syntax-suffix `*/*+json`

--- a/static/schemas/source/compliance/comply-test-controller-response.json
+++ b/static/schemas/source/compliance/comply-test-controller-response.json
@@ -499,7 +499,7 @@
               },
               "content_type": {
                 "type": "string",
-                "description": "Media type of the outbound request body, mirroring the agent's outbound `Content-Type` header (e.g., `application/json`, `application/x-www-form-urlencoded`, `multipart/form-data`, `text/plain`). In raw mode this describes the returned `payload`; in digest mode it describes the body the digest was computed over. Storyboard `payload_must_contain` JSONPath assertions are valid only when content_type is `application/json` or has a `+json` suffix AND attestation_mode is `raw` — digest mode and non-JSON content types grade `payload_must_contain` as not_applicable. Required so the runner can choose the right matcher deterministically."
+                "description": "Media type of the outbound request body, mirroring the agent's outbound `Content-Type` header (e.g., `application/json`, `application/x-www-form-urlencoded`, `multipart/form-data`, `text/plain`). In raw mode this describes the returned `payload`; in digest mode it describes the body the digest was computed over. Storyboard `payload_must_contain` JSONPath-lite assertions are valid only when content_type is `application/json` or has a `+json` suffix AND attestation_mode is `raw` — digest mode and non-JSON content types grade `payload_must_contain` as not_applicable. Required so the runner can choose the right matcher deterministically."
               },
               "attestation_mode": {
                 "type": "string",

--- a/tests/lint-storyboard-upstream-traffic-paths.test.cjs
+++ b/tests/lint-storyboard-upstream-traffic-paths.test.cjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Tests for the upstream_traffic identifier_paths portable grammar lint.
+ * Tests for the upstream_traffic request-payload path lint.
  */
 
 'use strict';
@@ -15,6 +15,7 @@ const {
   lint,
   RULE_MESSAGES,
   isPortableIdentifierPath,
+  isSupportedPayloadPath,
 } = require('../scripts/lint-storyboard-upstream-traffic-paths.cjs');
 
 test('source tree passes the upstream_traffic path lint', () => {
@@ -70,6 +71,47 @@ test('non-portable identifier_paths are rejected', () => {
   }
 });
 
+test('JSONPath-lite payload_must_contain paths are accepted', () => {
+  const accepted = [
+    'audiences[*].add[*].hashed_email',
+    '$.audiences[*].add[*].hashed_email',
+    'items.[0].id',
+    'line_items[*].creative-id',
+    'audiences[*].foo-',
+    '0audiences[*].hashed_email',
+    '[0].id',
+  ];
+  for (const value of accepted) {
+    assert.equal(isSupportedPayloadPath(value), true, value);
+  }
+});
+
+test('unsupported payload_must_contain paths are rejected', () => {
+  const rejected = [
+    '',
+    '$..hashed_email',
+    'audiences[*].add["hashed_email"]',
+    'audiences..hashed_email',
+    'items[0].id',
+  ];
+  for (const value of rejected) {
+    assert.equal(isSupportedPayloadPath(value), false, value);
+  }
+});
+
+function assertSyntheticViolation(violation, file, rule, identifierPath, pathKind, pathIndex) {
+  assert.equal(violation.file, file);
+  assert.equal(violation.phase, 'phase_a');
+  assert.equal(violation.step, 'step_a');
+  assert.equal(violation.index, 0);
+  assert.equal(violation.rule, rule);
+  assert.equal(violation.identifier_path, identifierPath);
+  assert.equal(violation.path_kind, pathKind);
+  if (pathIndex !== undefined) {
+    assert.equal(violation.path_index, pathIndex);
+  }
+}
+
 test('invalid identifier_path in storyboard is flagged', () => {
   const doc = `
 id: temp_storyboard
@@ -88,8 +130,13 @@ phases:
   withTempStoryboardDir('invalid.yaml', doc, (dir) => {
     const violations = lint(dir);
     assert.equal(violations.length, 1);
-    assert.equal(violations[0].rule, 'invalid_identifier_path');
-    assert.equal(violations[0].identifier_path, 'audiences[0].add[*].hashed_email');
+    assertSyntheticViolation(
+      violations[0],
+      'invalid.yaml',
+      'invalid_identifier_path',
+      'audiences[0].add[*].hashed_email',
+      'identifier_paths',
+    );
   });
 });
 
@@ -110,12 +157,48 @@ phases:
   withTempStoryboardDir('non-array.yaml', doc, (dir) => {
     const violations = lint(dir);
     assert.equal(violations.length, 1);
-    assert.equal(violations[0].rule, 'invalid_identifier_path');
-    assert.equal(violations[0].identifier_path, 'audiences[*].add[*].hashed_email');
+    assertSyntheticViolation(
+      violations[0],
+      'non-array.yaml',
+      'invalid_identifier_path',
+      'audiences[*].add[*].hashed_email',
+      'identifier_paths',
+    );
   });
 });
 
-test('valid identifier_path in storyboard is accepted', () => {
+test('invalid payload_must_contain path in storyboard is flagged', () => {
+  const doc = `
+id: temp_storyboard
+phases:
+  - id: phase_a
+    steps:
+      - id: step_a
+        task: get_products
+        validations:
+          - check: upstream_traffic
+            description: bad payload path
+            min_count: 1
+            payload_must_contain:
+              - path: "audiences[*].add[\\"hashed_email\\"]"
+                match: equals
+                value: "bad"
+`;
+  withTempStoryboardDir('invalid-payload.yaml', doc, (dir) => {
+    const violations = lint(dir);
+    assert.equal(violations.length, 1);
+    assertSyntheticViolation(
+      violations[0],
+      'invalid-payload.yaml',
+      'invalid_payload_path',
+      'audiences[*].add["hashed_email"]',
+      'payload_must_contain.path',
+      0,
+    );
+  });
+});
+
+test('valid identifier_path and payload_must_contain path in storyboard are accepted', () => {
   const doc = `
 id: temp_storyboard
 phases:
@@ -129,6 +212,13 @@ phases:
             min_count: 1
             identifier_paths:
               - "audiences[*].add[*].hashed_email"
+            payload_must_contain:
+              - path: "audiences[*].add[*].hashed_email"
+                match: equals
+                value: "abc123"
+              - path: "$.items.[0].id"
+                match: equals
+                value: "item-1"
 `;
   withTempStoryboardDir('valid.yaml', doc, (dir) => {
     assert.deepEqual(lint(dir), []);
@@ -136,7 +226,7 @@ phases:
 });
 
 test('every rule ID has a message', () => {
-  const ruleIds = ['invalid_identifier_path'];
+  const ruleIds = ['invalid_identifier_path', 'invalid_payload_path'];
   for (const id of ruleIds) {
     assert.ok(typeof RULE_MESSAGES[id] === 'function', `missing message for rule ${id}`);
   }


### PR DESCRIPTION
## Summary
- extend upstream_traffic path lint coverage to payload_must_contain.path using a separate JSONPath-lite validator aligned with the current SDK runner
- keep identifier_paths on the existing portable grammar while tightening diagnostics and synthetic violation assertions
- clarify JSONPath-lite wording in storyboard/compliance contract text
- split the two storyboard lint CI steps for clearer failures

Closes #5081.

## Expert review
- protocol_reviewer: no findings after rework; numeric-index mismatch resolved
- code-reviewer: no blocker findings after rework; numeric-index coverage adequate

## Validation
- npm run test:storyboard-upstream-traffic-paths
- npm run test:storyboard-raw-mode-required
- npm run build:compliance
- npm run build:schemas
- npm run test:schemas
- npx --yes @changesets/cli@^2.31.0 status --since=origin/main
- precommit hook: npm run test:unit, npm run test:test-dynamic-imports, npm run test:callapi-state-change, npm run typecheck
- pre-push hook: version sync, current compliance storyboard matrix, 3.0 compatibility storyboard matrix