### PR TITLE
test(signals): add coverage_rate bound and presence-bucket fixture tests

### DIFF
--- a/.changeset/signal-coverage-forecast-bound-tests.md
+++ b/.changeset/signal-coverage-forecast-bound-tests.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add negative bound tests for `coverage_rate.low/high > 1` and a positive test pinning `presence: "present"` with omitted `signal_value` in the Signal Forecast Dimension (items 3 and 5 from #5089).

--- a/tests/canonical-negative-fixtures.test.cjs
+++ b/tests/canonical-negative-fixtures.test.cjs
@@ -393,6 +393,50 @@ const NEGATIVE_CASES = {
       },
     },
   ],
+
+  // #5089 — signal coverage forecast schema cleanup follow-ups (items 3 and 5)
+  '/schemas/core/forecast-point.json': [
+    {
+      label: 'coverage_rate.low above maximum:1 rejected',
+      expected: false,
+      doc: {
+        metrics: { coverage_rate: { low: 1.5, high: 2.0 } },
+      },
+    },
+    {
+      label: 'coverage_rate.high above maximum:1 rejected',
+      expected: false,
+      doc: {
+        metrics: { coverage_rate: { low: 0.2, high: 1.5 } },
+      },
+    },
+    {
+      label: 'coverage_rate.mid above maximum:1 rejected',
+      expected: false,
+      doc: {
+        metrics: { coverage_rate: { mid: 1.5 } },
+      },
+    },
+    {
+      label: 'coverage_rate within [0, 1] accepted (positive control)',
+      expected: true,
+      doc: {
+        metrics: { coverage_rate: { low: 0.2, mid: 0.5, high: 0.8 } },
+      },
+    },
+  ],
+  '/schemas/core/forecast-point-dimensions.json': [
+    {
+      // Pins the intentional schema behavior: presence:present with omitted signal_value
+      // is valid for signal-level presence buckets (the `present` allOf branch does not
+      // require signal_value — only constrains its type when provided).
+      label: 'signal dimension presence:present without signal_value is valid (signal-level presence bucket)',
+      expected: true,
+      doc: [
+        { kind: 'signal', presence: 'present', signal_id: 'age_group' },
+      ],
+    },
+  ],
 };
 
 let pass = 0;


### PR DESCRIPTION
Refs #5089

Pins two schema enforcement behaviors from the post-#5088 cleanup list (items 3 and 5). No schema files changed.

**Non-breaking justification:** test-only change; no schema, protocol, or wire-format modifications.

## Changes

- `tests/canonical-negative-fixtures.test.cjs`: adds 5 test cases to the `NEGATIVE_CASES` suite:
  - `/schemas/core/forecast-point.json`: three cases for `coverage_rate` bounds — `low > 1`, `high > 1`, `mid > 1` each rejected; plus a positive control confirming `{ low: 0.2, mid: 0.5, high: 0.8 }` is accepted
  - `/schemas/core/forecast-point-dimensions.json`: one positive case pinning that `presence: "present"` with omitted `signal_value` is valid (signal-level presence bucket — the `present` allOf branch constrains `signal_value`'s type but does not require it)

All 43 fixtures pass (`npm run test:canonical-negative`).

## Pre-PR review

- **code-reviewer:** approved with one nit — `presence: "absent"` negative coverage is not included in this PR. Absent-branch is enforced by the schema's `required: ["signal_value"]` in the `absent` then-clause but has no fixture in this file. Left as a follow-up on #5089 rather than scope-expanding this PR.
- **ad-tech-protocol-expert:** approved — non-breaking per spec. `mid > 1` is also covered at `tests/schema-validation.test.cjs` line 617; adding it here makes `coverage_rate` bound tests complete and symmetric in a single file.

## Remaining items from #5089 (not in this PR)

Items 1, 2, and 4 require human decisions — see triage comment on #5089.

> **Triage-managed PR.** This bot does not currently iterate on review comments or PR conversation threads (only on the source issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout 5090` → fix → push.
> - **Or request a new first draft PR:** comment `/triage execute` on the source issue only when no triage-managed PR is already open. Triage does not update existing PRs.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121) for context.

Session: https://claude.ai/code/session_01TDM9WSgvuVvrsbNpxC2sPZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDM9WSgvuVvrsbNpxC2sPZ)_