### PR TITLE
fix(compliance): keep owner refresh state consistent

### DIFF
--- a/.changeset/fix-compliance-refresh-state.md
+++ b/.changeset/fix-compliance-refresh-state.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix registry compliance refresh state consistency so latest runs without storyboard rows do not display stale storyboard counts, and owner-triggered refreshes use canonical owner test metadata.

--- a/server/src/addie/jobs/compliance-heartbeat.ts
+++ b/server/src/addie/jobs/compliance-heartbeat.ts
@@ -91,7 +91,7 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
         'heartbeat',
       );
       dbInput.dry_run = false;
-      const { statusTransition, storyboardStatuses } = await complianceDb.recordComplianceRun(dbInput);
+      const { run, statusTransition, storyboardStatuses } = await complianceDb.recordComplianceRun(dbInput);
 
       result.checked++;
       if (dbInput.overall_status === 'passing') {
@@ -132,6 +132,7 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
             complianceDb,
             agentUrl: agent.agent_url,
             declaredSpecialisms,
+            runId: run.id,
           });
 
           if (badgeResult.issued.length > 0 || badgeResult.revoked.length > 0) {

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -3787,7 +3787,7 @@ export function createMemberToolHandlers(
                 // See migration 490.
                 triggered_org_id: organizationId,
               };
-              await complianceDb.recordComplianceRun(dbInput);
+              const { run } = await complianceDb.recordComplianceRun(dbInput);
               // notifyComplianceChange intentionally omitted: owner test runs are
               // exploratory; compliance-change notifications fire on heartbeat
               // transitions only to prevent iteration-loop spam.
@@ -3798,12 +3798,13 @@ export function createMemberToolHandlers(
               // Verification-change notifications are intentionally skipped —
               // the owner already received the result in their chat response.
               const declaredSpecialisms = result.agent_profile?.specialisms ?? [];
-              if (declaredSpecialisms.length > 0) {
+              if (declaredSpecialisms.length > 0 && dbInput.storyboard_statuses?.length) {
                 try {
                   await runBadgeFanOut({
                     complianceDb,
                     agentUrl: resolved.resolvedUrl,
                     declaredSpecialisms,
+                    runId: run.id,
                   });
                 } catch (badgeError) {
                   logger.warn({ badgeError, agentUrl: resolved.resolvedUrl }, 'Badge fan-out failed after owner_test run');

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -3804,7 +3804,7 @@ export function createMemberToolHandlers(
                     complianceDb,
                     agentUrl: resolved.resolvedUrl,
                     declaredSpecialisms,
-                    runId: run.id,
+                    runId: tracks ? null : run.id,
                   });
                 } catch (badgeError) {
                   logger.warn({ badgeError, agentUrl: resolved.resolvedUrl }, 'Badge fan-out failed after owner_test run');

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -136,6 +136,8 @@ export interface AgentComplianceStatus {
   previous_status: string | null;
   status_changed_at: Date | null;
   updated_at: Date;
+  /** id of the most recent non-dry-run row in agent_compliance_runs */
+  last_run_id: string | null;
   /** triggered_by of the most recent non-dry-run in agent_compliance_runs */
   last_triggered_by: TriggeredBy | null;
 }
@@ -579,11 +581,12 @@ export class ComplianceDatabase {
   async getComplianceStatus(agentUrl: string): Promise<AgentComplianceStatus | null> {
     const result = await query(
       `SELECT s.*, COALESCE(m.lifecycle_stage, 'production') AS lifecycle_stage,
+              r.id AS last_run_id,
               r.triggered_by AS last_triggered_by
        FROM agent_compliance_status s
        LEFT JOIN agent_registry_metadata m ON m.agent_url = s.agent_url
        LEFT JOIN LATERAL (
-         SELECT triggered_by FROM agent_compliance_runs
+         SELECT id, triggered_by FROM agent_compliance_runs
          WHERE agent_url = s.agent_url AND dry_run = false
          ORDER BY tested_at DESC LIMIT 1
        ) r ON true
@@ -613,11 +616,12 @@ export class ComplianceDatabase {
 
     const result = await query(
       `SELECT s.*, COALESCE(m.lifecycle_stage, 'production') AS lifecycle_stage,
+              r.id AS last_run_id,
               r.triggered_by AS last_triggered_by
        FROM agent_compliance_status s
        LEFT JOIN agent_registry_metadata m ON m.agent_url = s.agent_url
        LEFT JOIN LATERAL (
-         SELECT triggered_by FROM agent_compliance_runs
+         SELECT id, triggered_by FROM agent_compliance_runs
          WHERE agent_url = s.agent_url AND dry_run = false
          ORDER BY tested_at DESC LIMIT 1
        ) r ON true
@@ -855,7 +859,10 @@ export class ComplianceDatabase {
 
   // ----- Storyboard Status Queries -----
 
-  async getStoryboardStatuses(agentUrl: string): Promise<Array<{
+  async getStoryboardStatuses(agentUrl: string, options: {
+    runId?: string | null;
+    requireRowsForRunId?: string | null;
+  } = {}): Promise<Array<{
     storyboard_id: string;
     status: string;
     last_tested_at: Date | null;
@@ -870,20 +877,39 @@ export class ComplianceDatabase {
               steps_passed, steps_total, triggered_by
        FROM agent_storyboard_status
        WHERE agent_url = $1
+         AND ($2::text IS NULL OR run_id::text = $2)
+         AND (
+           $3::text IS NULL OR EXISTS (
+             SELECT 1 FROM agent_storyboard_status latest
+             WHERE latest.agent_url = $1
+               AND latest.run_id::text = $3
+           )
+         )
        ORDER BY storyboard_id`,
-      [agentUrl],
+      [agentUrl, options.runId ?? null, options.requireRowsForRunId ?? null],
     );
     return result.rows;
   }
 
-  async getStoryboardStatusCounts(agentUrl: string): Promise<{ passing: number; total: number }> {
+  async getStoryboardStatusCounts(agentUrl: string, options: {
+    runId?: string | null;
+    requireRowsForRunId?: string | null;
+  } = {}): Promise<{ passing: number; total: number }> {
     const result = await query(
       `SELECT
          COUNT(*) FILTER (WHERE status = 'passing') AS passing,
          COUNT(*) AS total
        FROM agent_storyboard_status
-       WHERE agent_url = $1`,
-      [agentUrl],
+       WHERE agent_url = $1
+         AND ($2::text IS NULL OR run_id::text = $2)
+         AND (
+           $3::text IS NULL OR EXISTS (
+             SELECT 1 FROM agent_storyboard_status latest
+             WHERE latest.agent_url = $1
+               AND latest.run_id::text = $3
+           )
+         )`,
+      [agentUrl, options.runId ?? null, options.requireRowsForRunId ?? null],
     );
     const row = result.rows[0];
     return { passing: parseInt(row?.passing ?? '0'), total: parseInt(row?.total ?? '0') };
@@ -900,11 +926,30 @@ export class ComplianceDatabase {
     if (agentUrls.length === 0) return new Map();
 
     const result = await query(
-      `SELECT agent_url, storyboard_id, status, last_tested_at, last_passed_at,
-              steps_passed, steps_total
-       FROM agent_storyboard_status
-       WHERE agent_url = ANY($1)
-       ORDER BY agent_url, storyboard_id`,
+      `WITH latest_runs AS (
+         SELECT DISTINCT ON (agent_url) agent_url, id
+         FROM agent_compliance_runs
+         WHERE agent_url = ANY($1)
+           AND dry_run = false
+         ORDER BY agent_url, tested_at DESC
+       )
+       latest_run_flags AS (
+         SELECT
+           lr.agent_url,
+           EXISTS (
+             SELECT 1 FROM agent_storyboard_status latest
+             WHERE latest.agent_url = lr.agent_url
+               AND latest.run_id = lr.id
+           ) AS has_rows
+         FROM latest_runs lr
+       )
+       SELECT s.agent_url, s.storyboard_id, s.status, s.last_tested_at, s.last_passed_at,
+              s.steps_passed, s.steps_total
+       FROM agent_storyboard_status s
+       LEFT JOIN latest_run_flags lf ON lf.agent_url = s.agent_url
+       WHERE s.agent_url = ANY($1)
+         AND COALESCE(lf.has_rows, true) = true
+       ORDER BY s.agent_url, s.storyboard_id`,
       [agentUrls],
     );
 

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -142,6 +142,11 @@ export interface AgentComplianceStatus {
   last_triggered_by: TriggeredBy | null;
 }
 
+export interface ComplianceStatusWithStoryboardCounts {
+  status: AgentComplianceStatus;
+  storyboardCounts: { passing: number; total: number };
+}
+
 export type StoryboardStatus = 'passing' | 'failing' | 'partial' | 'untested';
 const VALID_STORYBOARD_STATUSES = new Set<StoryboardStatus>(['passing', 'failing', 'partial', 'untested']);
 
@@ -596,6 +601,49 @@ export class ComplianceDatabase {
     return result.rows[0] || null;
   }
 
+  async getComplianceStatusWithStoryboardCounts(agentUrl: string): Promise<ComplianceStatusWithStoryboardCounts | null> {
+    const result = await query(
+      `SELECT s.*, COALESCE(m.lifecycle_stage, 'production') AS lifecycle_stage,
+              r.id AS last_run_id,
+              r.triggered_by AS last_triggered_by,
+              COALESCE(sb_counts.passing, 0)::int AS storyboards_passing,
+              COALESCE(sb_counts.total, 0)::int AS storyboards_total
+       FROM agent_compliance_status s
+       LEFT JOIN agent_registry_metadata m ON m.agent_url = s.agent_url
+       LEFT JOIN LATERAL (
+         SELECT id, triggered_by FROM agent_compliance_runs
+         WHERE agent_url = s.agent_url AND dry_run = false
+         ORDER BY tested_at DESC LIMIT 1
+       ) r ON true
+       LEFT JOIN LATERAL (
+         SELECT
+           COUNT(*) FILTER (WHERE ss.status = 'passing') AS passing,
+           COUNT(*) AS total
+         FROM agent_storyboard_status ss
+         WHERE ss.agent_url = s.agent_url
+           AND (
+             r.id IS NULL OR EXISTS (
+               SELECT 1 FROM agent_storyboard_status latest
+               WHERE latest.agent_url = s.agent_url
+                 AND latest.run_id = r.id
+             )
+           )
+       ) sb_counts ON true
+       WHERE s.agent_url = $1`,
+      [agentUrl],
+    );
+    const row = result.rows[0];
+    if (!row) return null;
+    const { storyboards_passing, storyboards_total, ...status } = row;
+    return {
+      status: status as AgentComplianceStatus,
+      storyboardCounts: {
+        passing: Number(storyboards_passing ?? 0),
+        total: Number(storyboards_total ?? 0),
+      },
+    };
+  }
+
   async bulkGetRegistryMetadata(agentUrls: string[]): Promise<Map<string, AgentRegistryMetadata>> {
     if (agentUrls.length === 0) return new Map();
 
@@ -862,6 +910,7 @@ export class ComplianceDatabase {
   async getStoryboardStatuses(agentUrl: string, options: {
     runId?: string | null;
     requireRowsForRunId?: string | null;
+    requireRowsForLatestRun?: boolean;
   } = {}): Promise<Array<{
     storyboard_id: string;
     status: string;
@@ -873,20 +922,37 @@ export class ComplianceDatabase {
     triggered_by: string | null;
   }>> {
     const result = await query(
-      `SELECT storyboard_id, status, last_tested_at, last_passed_at, last_failed_at,
+      `WITH latest_run AS (
+         SELECT id
+         FROM agent_compliance_runs
+         WHERE agent_url = $1
+           AND dry_run = false
+         ORDER BY tested_at DESC
+         LIMIT 1
+       )
+       SELECT storyboard_id, status, last_tested_at, last_passed_at, last_failed_at,
               steps_passed, steps_total, triggered_by
-       FROM agent_storyboard_status
-       WHERE agent_url = $1
-         AND ($2::text IS NULL OR run_id::text = $2)
+       FROM agent_storyboard_status s
+       WHERE s.agent_url = $1
+         AND ($2::uuid IS NULL OR s.run_id = $2::uuid)
          AND (
-           $3::text IS NULL OR EXISTS (
+           $3::uuid IS NULL OR EXISTS (
              SELECT 1 FROM agent_storyboard_status latest
              WHERE latest.agent_url = $1
-               AND latest.run_id::text = $3
+               AND latest.run_id = $3::uuid
+           )
+         )
+         AND (
+           $4::boolean = false
+           OR NOT EXISTS (SELECT 1 FROM latest_run)
+           OR EXISTS (
+             SELECT 1 FROM agent_storyboard_status latest
+             JOIN latest_run lr ON latest.run_id = lr.id
+             WHERE latest.agent_url = $1
            )
          )
        ORDER BY storyboard_id`,
-      [agentUrl, options.runId ?? null, options.requireRowsForRunId ?? null],
+      [agentUrl, options.runId ?? null, options.requireRowsForRunId ?? null, options.requireRowsForLatestRun === true],
     );
     return result.rows;
   }
@@ -894,22 +960,40 @@ export class ComplianceDatabase {
   async getStoryboardStatusCounts(agentUrl: string, options: {
     runId?: string | null;
     requireRowsForRunId?: string | null;
+    requireRowsForLatestRun?: boolean;
   } = {}): Promise<{ passing: number; total: number }> {
     const result = await query(
-      `SELECT
+      `WITH latest_run AS (
+         SELECT id
+         FROM agent_compliance_runs
+         WHERE agent_url = $1
+           AND dry_run = false
+         ORDER BY tested_at DESC
+         LIMIT 1
+       )
+       SELECT
          COUNT(*) FILTER (WHERE status = 'passing') AS passing,
          COUNT(*) AS total
-       FROM agent_storyboard_status
-       WHERE agent_url = $1
-         AND ($2::text IS NULL OR run_id::text = $2)
+       FROM agent_storyboard_status s
+       WHERE s.agent_url = $1
+         AND ($2::uuid IS NULL OR s.run_id = $2::uuid)
          AND (
-           $3::text IS NULL OR EXISTS (
+           $3::uuid IS NULL OR EXISTS (
              SELECT 1 FROM agent_storyboard_status latest
              WHERE latest.agent_url = $1
-               AND latest.run_id::text = $3
+               AND latest.run_id = $3::uuid
+           )
+         )
+         AND (
+           $4::boolean = false
+           OR NOT EXISTS (SELECT 1 FROM latest_run)
+           OR EXISTS (
+             SELECT 1 FROM agent_storyboard_status latest
+             JOIN latest_run lr ON latest.run_id = lr.id
+             WHERE latest.agent_url = $1
            )
          )`,
-      [agentUrl, options.runId ?? null, options.requireRowsForRunId ?? null],
+      [agentUrl, options.runId ?? null, options.requireRowsForRunId ?? null, options.requireRowsForLatestRun === true],
     );
     const row = result.rows[0];
     return { passing: parseInt(row?.passing ?? '0'), total: parseInt(row?.total ?? '0') };
@@ -932,7 +1016,7 @@ export class ComplianceDatabase {
          WHERE agent_url = ANY($1)
            AND dry_run = false
          ORDER BY agent_url, tested_at DESC
-       )
+       ),
        latest_run_flags AS (
          SELECT
            lr.agent_url,

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -99,7 +99,7 @@ import { adaptAuthForSdk, type SdkAuth } from "../services/sdk-auth-adapter.js";
 import { parseOAuthClientCredentialsInput } from "./helpers/oauth-client-credentials-input.js";
 import { isOAuthRequiredErrorMessage } from "./helpers/oauth-error-detection.js";
 import { AgentContextDatabase, validateAuthTokenChars } from "../db/agent-context-db.js";
-import { getRequestLog, getRequestCount } from "../db/outbound-log-db.js";
+import { getRequestLog, getRequestCount, logOutboundRequest } from "../db/outbound-log-db.js";
 import { enrichUserWithMembership } from "../utils/html-config.js";
 import { classifyProbeError } from "../utils/probe-error.js";
 import { isWebUserAAOAdmin } from "../addie/admin-status-lookup.js";
@@ -114,8 +114,9 @@ import {
   parseEvidenceParam,
   parseIncludeParam,
 } from "../db/authorization-snapshot-db.js";
-import { createHash } from "crypto";
+import { createHash, randomUUID } from "crypto";
 import { createGzip, constants as zlibConstants } from "zlib";
+import { AAO_UA_COMPLIANCE } from "../config/user-agents.js";
 
 const logger = createLogger("registry-api");
 const propertyCheckService = new PropertyCheckService();
@@ -2288,7 +2289,7 @@ registry.registerPath({
   operationId: "refreshAgent",
   summary: "Refresh agent snapshot",
   description:
-    "Re-probe the agent and update its registry health (online, tools_count, response_time_ms), capability snapshot (inferred type, discovered tools), and compliance verdict (storyboard pass/fail counts). Use after fixing your agent so the registry shows fresh data without waiting for the periodic heartbeat (~1h).\n\n**Compliance re-run:** when the caller owns the agent and the capability probe succeeds, the full storyboard suite runs (~30–90s) and `agent_storyboard_status` is updated under `triggered_by: 'manual'`. Badge fan-out reissues verification badges off the new run. If the compliance call fails (timeout, OAuth wall, internal error), the capability/health portion still returns successfully — `compliance.ran` is `false` with an `error` string.\n\n**Auth:** owner of the agent or AAO admin.\n\n**Rate limits:** 60 seconds per agent URL, 30 requests per user per hour.",
+    "Re-probe the agent and update its registry health (online, tools_count, response_time_ms), capability snapshot (inferred type, discovered tools), and compliance verdict (storyboard pass/fail counts). Use after fixing your agent so the registry shows fresh data without waiting for the periodic heartbeat (~1h).\n\n**Compliance re-run:** when the caller owns the agent and the capability probe succeeds, the full storyboard suite runs (~30–90s) with a fresh test session and `agent_storyboard_status` is updated under `triggered_by: 'owner_test'`. Badge fan-out reissues verification badges off the new run. If the compliance call fails (timeout, OAuth wall, internal error), the capability/health portion still returns successfully — `compliance.ran` is `false` with an `error` string.\n\n**Auth:** owner of the agent or AAO admin.\n\n**Rate limits:** 60 seconds per agent URL, 30 requests per user per hour.",
   tags: ["Agent Compliance"],
   security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
@@ -4477,7 +4478,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       // if the table hasn't been migrated yet
       let sbCounts = { passing: 0, total: 0 };
       try {
-        sbCounts = await complianceDb.getStoryboardStatusCounts(agentUrl);
+        sbCounts = await complianceDb.getStoryboardStatusCounts(agentUrl, { requireRowsForRunId: status.last_run_id });
       } catch (err) {
         logger.warn({ err, agentUrl }, "Storyboard status query failed");
       }
@@ -4519,7 +4520,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       let specialismStatus: Record<string, string> = {};
       if (declaredSpecialisms.length > 0) {
         try {
-          const sbStatuses = await complianceDb.getStoryboardStatuses(agentUrl);
+          const sbStatuses = await complianceDb.getStoryboardStatuses(agentUrl, { requireRowsForRunId: status.last_run_id });
           specialismStatus = computeSpecialismStatus(
             declaredSpecialisms,
             sbStatuses.map(s => ({
@@ -4973,9 +4974,10 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           return res.json({ agent_url: agentUrl, status: "opted_out", storyboards: [] });
         }
 
+        const complianceStatus = await complianceDb.getComplianceStatus(agentUrl);
         let statuses: Awaited<ReturnType<typeof complianceDb.getStoryboardStatuses>> = [];
         try {
-          statuses = await complianceDb.getStoryboardStatuses(agentUrl);
+          statuses = await complianceDb.getStoryboardStatuses(agentUrl, { requireRowsForRunId: complianceStatus?.last_run_id });
         } catch (err) {
           logger.warn({ err, agentUrl }, "Storyboard status query failed (table may not exist)");
         }
@@ -5435,10 +5437,21 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       } = { ran: false };
 
       if (ownerOrgId && !probeResult.error && !probeResult.oauth_required) {
+        const complianceStart = Date.now();
         try {
+          const testSessionId = `owner-refresh-${Date.now()}-${randomUUID()}`;
           const complyResult = await comply(agentUrl, {
+            test_session_id: testSessionId,
             timeout_ms: 90_000,
+            userAgent: AAO_UA_COMPLIANCE,
             ...(resolvedAuth && { auth: resolvedAuth }),
+          });
+          logOutboundRequest({
+            agent_url: agentUrl,
+            request_type: 'compliance',
+            user_agent: AAO_UA_COMPLIANCE,
+            response_time_ms: Date.now() - complianceStart,
+            success: true,
           });
           if (complyResult.overall_status === 'auth_required') {
             complianceSummary = { ran: false, error: 'Agent requires OAuth authorization' };
@@ -5448,10 +5461,11 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
               complyResult,
               agentUrl,
               metadata?.lifecycle_stage || 'production',
-              'manual',
+              'owner_test',
             );
             dbInput.dry_run = false;
-            const { storyboardStatuses } = await complianceDb.recordComplianceRun(dbInput);
+            dbInput.triggered_org_id = ownerOrgId;
+            const { run, storyboardStatuses } = await complianceDb.recordComplianceRun(dbInput);
             const passing = storyboardStatuses.filter(s => s.status === 'passing').length;
             complianceSummary = {
               ran: true,
@@ -5463,12 +5477,13 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
             // Fan out badge issuance so verification badges reflect the new
             // verdict immediately. Matches the per-storyboard owner-test path.
             const declaredSpecialisms = complyResult.agent_profile?.specialisms ?? [];
-            if (declaredSpecialisms.length > 0) {
-              try {
-                await runBadgeFanOut({
+              if (declaredSpecialisms.length > 0 && storyboardStatuses.length > 0) {
+                try {
+                  await runBadgeFanOut({
                   complianceDb,
                   agentUrl,
                   declaredSpecialisms,
+                  runId: run.id,
                 });
               } catch (badgeError) {
                 logger.warn({ err: badgeError, agentUrl }, 'Badge fan-out failed after manual refresh');
@@ -5477,7 +5492,15 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           }
         } catch (complyErr) {
           const msg = complyErr instanceof Error ? complyErr.message : 'compliance run failed';
-          logger.warn({ agentUrl, err: complyErr }, 'Compliance re-run failed during manual refresh');
+          logOutboundRequest({
+            agent_url: agentUrl,
+            request_type: 'compliance',
+            user_agent: AAO_UA_COMPLIANCE,
+            response_time_ms: Date.now() - complianceStart,
+            success: false,
+            error_message: msg,
+          });
+          logger.warn({ agentUrl, err: complyErr }, 'Compliance re-run failed during owner refresh');
           complianceSummary = { ran: false, error: msg };
         }
       }

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -126,6 +126,13 @@ const complianceDb = new ComplianceDatabase();
 const agentSnapshotDb = new AgentSnapshotDatabase();
 const agentContextDb = new AgentContextDatabase();
 
+function isUndefinedTableError(err: unknown): boolean {
+  return typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code?: unknown }).code === "42P01";
+}
+
 /** Strip protocol, path, query, and fragment from a URL to extract the domain. */
 function extractDomain(raw: string): string {
   let d = raw.replace(/^https?:\/\//, "");
@@ -4445,8 +4452,19 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       if (!validateAgentUrlParam(agentUrl)) {
         return res.status(400).json({ error: "Invalid agent URL" });
       }
-      const status = await complianceDb.getComplianceStatus(agentUrl);
       const metadata = await complianceDb.getRegistryMetadata(agentUrl);
+      let statusWithCounts: Awaited<ReturnType<typeof complianceDb.getComplianceStatusWithStoryboardCounts>> = null;
+      try {
+        statusWithCounts = await complianceDb.getComplianceStatusWithStoryboardCounts(agentUrl);
+      } catch (err) {
+        if (!isUndefinedTableError(err)) throw err;
+        logger.warn({ err, agentUrl }, "Storyboard status query skipped because table is missing");
+        const fallbackStatus = await complianceDb.getComplianceStatus(agentUrl);
+        statusWithCounts = fallbackStatus
+          ? { status: fallbackStatus, storyboardCounts: { passing: 0, total: 0 } }
+          : null;
+      }
+      const status = statusWithCounts?.status ?? null;
 
       // If opted out, return minimal response (no ownership check needed —
       // the opt-out preference is enforced uniformly for public endpoints)
@@ -4474,14 +4492,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         });
       }
 
-      // Storyboard counts are supplementary — don't fail the whole response
-      // if the table hasn't been migrated yet
-      let sbCounts = { passing: 0, total: 0 };
-      try {
-        sbCounts = await complianceDb.getStoryboardStatusCounts(agentUrl, { requireRowsForRunId: status.last_run_id });
-      } catch (err) {
-        logger.warn({ err, agentUrl }, "Storyboard status query failed");
-      }
+      const sbCounts = statusWithCounts?.storyboardCounts ?? { passing: 0, total: 0 };
 
       // Verification badges — supplementary, don't fail the response
       let badges: Awaited<ReturnType<typeof complianceDb.getBadgesForAgent>> = [];
@@ -4520,7 +4531,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       let specialismStatus: Record<string, string> = {};
       if (declaredSpecialisms.length > 0) {
         try {
-          const sbStatuses = await complianceDb.getStoryboardStatuses(agentUrl, { requireRowsForRunId: status.last_run_id });
+          const sbStatuses = await complianceDb.getStoryboardStatuses(agentUrl, { requireRowsForLatestRun: true });
           specialismStatus = computeSpecialismStatus(
             declaredSpecialisms,
             sbStatuses.map(s => ({
@@ -4533,7 +4544,8 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
             })),
           );
         } catch (err) {
-          logger.warn({ err, agentUrl }, "Per-specialism status query failed");
+          if (!isUndefinedTableError(err)) throw err;
+          logger.warn({ err, agentUrl }, "Per-specialism status query skipped because table is missing");
         }
       }
 
@@ -4974,12 +4986,12 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           return res.json({ agent_url: agentUrl, status: "opted_out", storyboards: [] });
         }
 
-        const complianceStatus = await complianceDb.getComplianceStatus(agentUrl);
         let statuses: Awaited<ReturnType<typeof complianceDb.getStoryboardStatuses>> = [];
         try {
-          statuses = await complianceDb.getStoryboardStatuses(agentUrl, { requireRowsForRunId: complianceStatus?.last_run_id });
+          statuses = await complianceDb.getStoryboardStatuses(agentUrl, { requireRowsForLatestRun: true });
         } catch (err) {
-          logger.warn({ err, agentUrl }, "Storyboard status query failed (table may not exist)");
+          if (!isUndefinedTableError(err)) throw err;
+          logger.warn({ err, agentUrl }, "Storyboard status query skipped because table is missing");
         }
 
         const enriched = statuses.map(s => {
@@ -5048,7 +5060,8 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         try {
           statusMap = await complianceDb.bulkGetStoryboardStatuses(nonOptedOut);
         } catch (err) {
-          logger.warn({ err }, "Bulk storyboard status query failed (table may not exist)");
+          if (!isUndefinedTableError(err)) throw err;
+          logger.warn({ err }, "Bulk storyboard status query skipped because table is missing");
         }
 
         const results: Record<string, any> = {};
@@ -5477,9 +5490,9 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
             // Fan out badge issuance so verification badges reflect the new
             // verdict immediately. Matches the per-storyboard owner-test path.
             const declaredSpecialisms = complyResult.agent_profile?.specialisms ?? [];
-              if (declaredSpecialisms.length > 0 && storyboardStatuses.length > 0) {
-                try {
-                  await runBadgeFanOut({
+            if (declaredSpecialisms.length > 0 && storyboardStatuses.length > 0) {
+              try {
+                await runBadgeFanOut({
                   complianceDb,
                   agentUrl,
                   declaredSpecialisms,

--- a/server/src/services/badge-issuance.ts
+++ b/server/src/services/badge-issuance.ts
@@ -170,8 +170,10 @@ export async function runBadgeFanOut(params: {
   complianceDb: ComplianceDatabase;
   agentUrl: string;
   declaredSpecialisms: string[];
+  /** Full-suite runs pass their run id so stale prior storyboard rows cannot issue/degrade badges. */
+  runId?: string | null;
 }): Promise<BadgeIssuanceResult> {
-  const { complianceDb, agentUrl, declaredSpecialisms } = params;
+  const { complianceDb, agentUrl, declaredSpecialisms, runId } = params;
   const aggregate: BadgeIssuanceResult = { issued: [], revoked: [], degraded: [], unchanged: [] };
 
   if (declaredSpecialisms.length === 0) {
@@ -203,7 +205,9 @@ export async function runBadgeFanOut(params: {
   // earlier storyboard's last result — essential for partial runs
   // (single-storyboard owner_test) so unrelated storyboards' badges
   // aren't degraded just because they weren't touched this run.
-  const latestStatuses = await complianceDb.getStoryboardStatuses(agentUrl);
+  const latestStatuses = runId
+    ? await complianceDb.getStoryboardStatuses(agentUrl, { runId })
+    : await complianceDb.getStoryboardStatuses(agentUrl);
   const storyboardStatuses: StoryboardStatusEntry[] = latestStatuses.map(s => ({
     storyboard_id: s.storyboard_id,
     status: s.status as StoryboardStatus,

--- a/server/tests/integration/registry-api-agent-refresh.test.ts
+++ b/server/tests/integration/registry-api-agent-refresh.test.ts
@@ -17,6 +17,7 @@ import type { Pool } from 'pg';
 import { HTTPServer } from '../../src/http.js';
 import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
 import { runMigrations } from '../../src/db/migrate.js';
+import { AAO_UA_COMPLIANCE } from '../../src/config/user-agents.js';
 
 const RUN_SUFFIX = Math.random().toString(36).slice(2, 8);
 const OWNER_USER_ID = `user_test_refresh_owner_${RUN_SUFFIX}`;
@@ -102,6 +103,41 @@ vi.mock('../../src/crawler.js', async () => {
   return actual;
 });
 
+const complyMock = vi.fn();
+vi.mock('../../src/addie/services/compliance-testing.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/addie/services/compliance-testing.js')>('../../src/addie/services/compliance-testing.js');
+  return {
+    ...actual,
+    comply: (agentUrl: string, options?: unknown) => complyMock(agentUrl, options),
+  };
+});
+
+function makeComplianceResult() {
+  return {
+    overall_status: 'passing',
+    total_duration_ms: 42,
+    summary: {
+      headline: 'All storyboards passing',
+      tracks_passed: 1,
+      tracks_failed: 0,
+      tracks_skipped: 0,
+      tracks_partial: 0,
+    },
+    tracks: [{
+      track: 'media-buy',
+      status: 'pass',
+      duration_ms: 42,
+      scenarios: [{
+        scenario: 'media_buy_seller/capability_discovery',
+        overall_passed: true,
+        steps: [{ step_id: 'get_adcp_capabilities', passed: true }],
+      }],
+    }],
+    observations: [],
+    agent_profile: { specialisms: [] },
+  };
+}
+
 describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
   let server: HTTPServer;
   let app: unknown;
@@ -143,6 +179,10 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
 
   afterAll(async () => {
     const allUrls = [...ALL_OWNED_URLS, OTHER_AGENT_URL];
+    await pool.query('DELETE FROM agent_compliance_step_diagnostics WHERE agent_url = ANY($1)', [allUrls]);
+    await pool.query('DELETE FROM agent_storyboard_status WHERE agent_url = ANY($1)', [allUrls]);
+    await pool.query('DELETE FROM agent_compliance_status WHERE agent_url = ANY($1)', [allUrls]);
+    await pool.query('DELETE FROM agent_compliance_runs WHERE agent_url = ANY($1)', [allUrls]);
     await pool.query('DELETE FROM agent_health_snapshot WHERE agent_url = ANY($1)', [allUrls]);
     await pool.query('DELETE FROM agent_capabilities_snapshot WHERE agent_url = ANY($1)', [allUrls]);
     await pool.query('DELETE FROM member_profiles WHERE workos_organization_id = $1', [TEST_ORG_ID]);
@@ -165,6 +205,8 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
       oauth_required: false,
       checked_at: new Date().toISOString(),
     });
+    complyMock.mockReset();
+    complyMock.mockResolvedValue(makeComplianceResult());
   });
 
   const url = (agentUrl: string) => `/api/registry/agents/${encodeURIComponent(agentUrl)}/refresh`;
@@ -178,8 +220,35 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
       tools_count: 4,
       inferred_type: 'governance',
       type_promoted: true,
+      compliance: {
+        ran: true,
+        overall_status: 'passing',
+        storyboards_passing: 1,
+        storyboards_total: 1,
+      },
     });
     expect(refreshSingleAgentMock).toHaveBeenCalledWith(agentUrl, expect.any(Object));
+    expect(complyMock).toHaveBeenCalledWith(
+      agentUrl,
+      expect.objectContaining({
+        timeout_ms: 90_000,
+        userAgent: AAO_UA_COMPLIANCE,
+        test_session_id: expect.stringMatching(/^owner-refresh-\d+-[0-9a-f-]{36}$/),
+      }),
+    );
+
+    const latestRun = await pool.query(
+      `SELECT triggered_by, triggered_org_id
+       FROM agent_compliance_runs
+       WHERE agent_url = $1
+       ORDER BY tested_at DESC
+       LIMIT 1`,
+      [agentUrl],
+    );
+    expect(latestRun.rows[0]).toMatchObject({
+      triggered_by: 'owner_test',
+      triggered_org_id: TEST_ORG_ID,
+    });
   });
 
   it('admin can refresh an agent they do not own', async () => {

--- a/server/tests/integration/registry-api-agent-refresh.test.ts
+++ b/server/tests/integration/registry-api-agent-refresh.test.ts
@@ -37,6 +37,7 @@ const ALL_OWNED_URLS = [
   ownedAgentUrl('paused'),
   ownedAgentUrl('rate-limit'),
   ownedAgentUrl('saved-bearer'),
+  ownedAgentUrl('badge-fanout'),
 ];
 
 // Toggle which user the auth middleware stamps onto the request. Tests
@@ -112,7 +113,9 @@ vi.mock('../../src/addie/services/compliance-testing.js', async () => {
   };
 });
 
-function makeComplianceResult() {
+function makeComplianceResult(options: { specialisms?: string[]; storyboardId?: string } = {}) {
+  const specialisms = options.specialisms ?? [];
+  const storyboardId = options.storyboardId ?? 'media_buy_seller';
   return {
     overall_status: 'passing',
     total_duration_ms: 42,
@@ -128,13 +131,13 @@ function makeComplianceResult() {
       status: 'pass',
       duration_ms: 42,
       scenarios: [{
-        scenario: 'media_buy_seller/capability_discovery',
+        scenario: `${storyboardId}/capability_discovery`,
         overall_passed: true,
         steps: [{ step_id: 'get_adcp_capabilities', passed: true }],
       }],
     }],
     observations: [],
-    agent_profile: { specialisms: [] },
+    agent_profile: { specialisms },
   };
 }
 
@@ -150,9 +153,14 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
     await runMigrations();
 
     await pool.query(
-      `INSERT INTO organizations (workos_organization_id, name, created_at, updated_at)
-       VALUES ($1, 'Test Refresh Org', NOW(), NOW())
-       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      `INSERT INTO organizations (
+         workos_organization_id, name, membership_tier, subscription_status, created_at, updated_at
+       )
+       VALUES ($1, 'Test Refresh Org', 'company_standard', 'active', NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO UPDATE
+         SET membership_tier = EXCLUDED.membership_tier,
+             subscription_status = EXCLUDED.subscription_status,
+             updated_at = NOW()`,
       [TEST_ORG_ID],
     );
     await pool.query(
@@ -179,6 +187,7 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
 
   afterAll(async () => {
     const allUrls = [...ALL_OWNED_URLS, OTHER_AGENT_URL];
+    await pool.query('DELETE FROM agent_verification_badges WHERE agent_url = ANY($1)', [allUrls]);
     await pool.query('DELETE FROM agent_compliance_step_diagnostics WHERE agent_url = ANY($1)', [allUrls]);
     await pool.query('DELETE FROM agent_storyboard_status WHERE agent_url = ANY($1)', [allUrls]);
     await pool.query('DELETE FROM agent_compliance_status WHERE agent_url = ANY($1)', [allUrls]);
@@ -336,5 +345,38 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
     );
 
     await pool.query('DELETE FROM agent_contexts WHERE id = $1', [context.id]);
+  });
+
+  it('fans out badge issuance for an owner refresh with a passing specialism', async () => {
+    const agentUrl = ownedAgentUrl('badge-fanout');
+    complyMock.mockResolvedValueOnce(makeComplianceResult({
+      specialisms: ['sales-broadcast-tv'],
+      storyboardId: 'sales_broadcast_tv',
+    }));
+
+    const res = await request(app).post(url(agentUrl)).send();
+
+    expect(res.status).toBe(200);
+    expect(res.body.compliance).toMatchObject({
+      ran: true,
+      storyboards_passing: 1,
+      storyboards_total: 1,
+    });
+
+    const badges = await pool.query(
+      `SELECT role, status, verified_specialisms, membership_org_id
+       FROM agent_verification_badges
+       WHERE agent_url = $1
+       ORDER BY role`,
+      [agentUrl],
+    );
+    expect(badges.rows).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        role: 'media-buy',
+        status: 'active',
+        verified_specialisms: ['sales-broadcast-tv'],
+        membership_org_id: TEST_ORG_ID,
+      }),
+    ]));
   });
 });

--- a/server/tests/integration/registry-api-compliance-verdict-source.test.ts
+++ b/server/tests/integration/registry-api-compliance-verdict-source.test.ts
@@ -324,6 +324,23 @@ describe('GET /api/registry/agents/:encodedUrl/compliance — owner-scope gate (
     ]));
   });
 
+  it('static admin API key can read bulk storyboard status through real Postgres SQL', async () => {
+    currentUserId = STATIC_ADMIN_USER_ID;
+    const res = await request(app)
+      .post('/api/registry/agents/storyboard-status')
+      .send({ agent_urls: [AGENT_URL] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.agents[AGENT_URL]).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        storyboard_id: 'debug_storyboard',
+        status: 'failing',
+        steps_passed: 1,
+        steps_total: 2,
+      }),
+    ]));
+  });
+
   it('static admin API key can read per-step diagnostics for any agent', async () => {
     currentUserId = STATIC_ADMIN_USER_ID;
     const res = await request(app)

--- a/server/tests/unit/badge-fan-out.test.ts
+++ b/server/tests/unit/badge-fan-out.test.ts
@@ -102,6 +102,23 @@ describe('runBadgeFanOut', () => {
     expect(db.revokeBadge).not.toHaveBeenCalled();
   });
 
+  it('scopes storyboard reads to runId when full-suite callers provide one', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ workos_organization_id: 'org_member' }], rowCount: 1, command: 'SELECT', oid: 0, fields: [] } as never);
+
+    const db = makeDb({
+      latestStatuses: [status('sales_broadcast_tv', 'passing')],
+    });
+
+    await runBadgeFanOut({
+      complianceDb: db,
+      agentUrl: 'https://example.com/mcp',
+      declaredSpecialisms: ['sales-broadcast-tv'],
+      runId: 'run-full-suite',
+    });
+
+    expect(db.getStoryboardStatuses).toHaveBeenCalledWith('https://example.com/mcp', { runId: 'run-full-suite' });
+  });
+
   it('passes undefined membershipOrgId when the org lookup returns no row, causing all badges to revoke', async () => {
     queryMock.mockResolvedValueOnce({ rows: [], rowCount: 0, command: 'SELECT', oid: 0, fields: [] } as never);
 

--- a/server/tests/unit/compliance-db-last-write-wins.test.ts
+++ b/server/tests/unit/compliance-db-last-write-wins.test.ts
@@ -183,6 +183,7 @@ describe('ComplianceDatabase — last-write-wins on agent_compliance_status', ()
         previous_status: null,
         status_changed_at: null,
         updated_at: now,
+        last_run_id: 'run-owner-test',
         last_triggered_by: 'owner_test',
       }],
       rowCount: 1,
@@ -194,11 +195,104 @@ describe('ComplianceDatabase — last-write-wins on agent_compliance_status', ()
     const status = await db.getComplianceStatus(AGENT_URL);
 
     expect(status).not.toBeNull();
+    expect(status!.last_run_id).toBe('run-owner-test');
     expect(status!.last_triggered_by).toBe('owner_test');
 
     const [sql] = mockedQuery.mock.calls[0];
+    expect(sql).toContain('r.id AS last_run_id');
     expect(sql).toContain('dry_run = false');
     expect(sql).toContain('ORDER BY tested_at DESC');
     expect(sql).toContain('LIMIT 1');
+  });
+
+  it('getStoryboardStatusCounts can scope counts to the latest compliance run id', async () => {
+    mockedQuery.mockResolvedValueOnce({
+      rows: [{ passing: '0', total: '0' }],
+      rowCount: 1,
+      command: '',
+      oid: 0,
+      fields: [],
+    });
+
+    const counts = await db.getStoryboardStatusCounts(AGENT_URL, { runId: 'run-new-empty' });
+
+    expect(counts).toEqual({ passing: 0, total: 0 });
+    const [sql, params] = mockedQuery.mock.calls[0];
+    expect(sql).toContain('run_id::text = $2');
+    expect(params).toEqual([AGENT_URL, 'run-new-empty', null]);
+  });
+
+  it('getStoryboardStatuses can scope storyboard detail to a single compliance run id', async () => {
+    mockedQuery.mockResolvedValueOnce({
+      rows: [],
+      rowCount: 0,
+      command: '',
+      oid: 0,
+      fields: [],
+    });
+
+    const statuses = await db.getStoryboardStatuses(AGENT_URL, { runId: 'run-new-empty' });
+
+    expect(statuses).toEqual([]);
+    const [sql, params] = mockedQuery.mock.calls[0];
+    expect(sql).toContain('run_id::text = $2');
+    expect(params).toEqual([AGENT_URL, 'run-new-empty', null]);
+  });
+
+  it('getStoryboardStatusCounts can suppress stale rows when the latest run wrote no storyboard rows', async () => {
+    mockedQuery.mockResolvedValueOnce({
+      rows: [{ passing: '0', total: '0' }],
+      rowCount: 1,
+      command: '',
+      oid: 0,
+      fields: [],
+    });
+
+    const counts = await db.getStoryboardStatusCounts(AGENT_URL, { requireRowsForRunId: 'run-new-empty' });
+
+    expect(counts).toEqual({ passing: 0, total: 0 });
+    const [sql, params] = mockedQuery.mock.calls[0];
+    expect(sql).toContain('EXISTS');
+    expect(sql).toContain('latest.run_id::text = $3');
+    expect(params).toEqual([AGENT_URL, null, 'run-new-empty']);
+  });
+
+  it('getStoryboardStatuses can preserve merged rows only when the latest run wrote storyboard rows', async () => {
+    mockedQuery.mockResolvedValueOnce({
+      rows: [],
+      rowCount: 0,
+      command: '',
+      oid: 0,
+      fields: [],
+    });
+
+    const statuses = await db.getStoryboardStatuses(AGENT_URL, { requireRowsForRunId: 'run-new-empty' });
+
+    expect(statuses).toEqual([]);
+    const [sql, params] = mockedQuery.mock.calls[0];
+    expect(sql).toContain('EXISTS');
+    expect(sql).toContain('latest.run_id::text = $3');
+    expect(params).toEqual([AGENT_URL, null, 'run-new-empty']);
+  });
+
+  it('bulkGetStoryboardStatuses preserves merged rows unless the latest run explicitly wrote none', async () => {
+    mockedQuery.mockResolvedValueOnce({
+      rows: [],
+      rowCount: 0,
+      command: '',
+      oid: 0,
+      fields: [],
+    });
+
+    const statuses = await db.bulkGetStoryboardStatuses([AGENT_URL]);
+
+    expect(statuses).toEqual(new Map());
+    const [sql, params] = mockedQuery.mock.calls[0];
+    expect(sql).toContain('WITH latest_runs AS');
+    expect(sql).toContain('AND dry_run = false');
+    expect(sql).toContain('latest_run_flags AS');
+    expect(sql).toContain('latest.run_id = lr.id');
+    expect(sql).toContain('COALESCE(lf.has_rows, true) = true');
+    expect(params).toEqual([[AGENT_URL]]);
   });
 });

--- a/server/tests/unit/compliance-db-last-write-wins.test.ts
+++ b/server/tests/unit/compliance-db-last-write-wins.test.ts
@@ -36,6 +36,8 @@ function makeTransactionClient(queryResponses: Array<{ rows: any[] }>) {
 }
 
 const AGENT_URL = 'https://agent.example.com';
+const RUN_ID = '00000000-0000-4000-8000-000000000001';
+const EMPTY_RUN_ID = '00000000-0000-4000-8000-000000000002';
 
 function makeRunRow(triggeredBy: string) {
   return {
@@ -183,7 +185,7 @@ describe('ComplianceDatabase — last-write-wins on agent_compliance_status', ()
         previous_status: null,
         status_changed_at: null,
         updated_at: now,
-        last_run_id: 'run-owner-test',
+        last_run_id: RUN_ID,
         last_triggered_by: 'owner_test',
       }],
       rowCount: 1,
@@ -195,7 +197,7 @@ describe('ComplianceDatabase — last-write-wins on agent_compliance_status', ()
     const status = await db.getComplianceStatus(AGENT_URL);
 
     expect(status).not.toBeNull();
-    expect(status!.last_run_id).toBe('run-owner-test');
+    expect(status!.last_run_id).toBe(RUN_ID);
     expect(status!.last_triggered_by).toBe('owner_test');
 
     const [sql] = mockedQuery.mock.calls[0];
@@ -203,6 +205,45 @@ describe('ComplianceDatabase — last-write-wins on agent_compliance_status', ()
     expect(sql).toContain('dry_run = false');
     expect(sql).toContain('ORDER BY tested_at DESC');
     expect(sql).toContain('LIMIT 1');
+  });
+
+  it('getComplianceStatusWithStoryboardCounts resolves status and stale-row suppression in one SQL statement', async () => {
+    const now = new Date();
+    mockedQuery.mockResolvedValueOnce({
+      rows: [{
+        agent_url: AGENT_URL,
+        status: 'passing',
+        lifecycle_stage: 'production',
+        last_checked_at: now,
+        last_passed_at: now,
+        last_failed_at: null,
+        streak_days: 1,
+        streak_started_at: now,
+        tracks_summary_json: { core: 'pass' },
+        headline: null,
+        previous_status: null,
+        status_changed_at: null,
+        updated_at: now,
+        last_run_id: RUN_ID,
+        last_triggered_by: 'owner_test',
+        storyboards_passing: 1,
+        storyboards_total: 2,
+      }],
+      rowCount: 1,
+      command: '',
+      oid: 0,
+      fields: [],
+    });
+
+    const statusWithCounts = await db.getComplianceStatusWithStoryboardCounts(AGENT_URL);
+
+    expect(statusWithCounts?.status.last_run_id).toBe(RUN_ID);
+    expect(statusWithCounts?.storyboardCounts).toEqual({ passing: 1, total: 2 });
+    const [sql, params] = mockedQuery.mock.calls[0];
+    expect(sql).toContain('LEFT JOIN LATERAL');
+    expect(sql).toContain('agent_storyboard_status latest');
+    expect(sql).toContain('latest.run_id = r.id');
+    expect(params).toEqual([AGENT_URL]);
   });
 
   it('getStoryboardStatusCounts can scope counts to the latest compliance run id', async () => {
@@ -214,12 +255,12 @@ describe('ComplianceDatabase — last-write-wins on agent_compliance_status', ()
       fields: [],
     });
 
-    const counts = await db.getStoryboardStatusCounts(AGENT_URL, { runId: 'run-new-empty' });
+    const counts = await db.getStoryboardStatusCounts(AGENT_URL, { runId: EMPTY_RUN_ID });
 
     expect(counts).toEqual({ passing: 0, total: 0 });
     const [sql, params] = mockedQuery.mock.calls[0];
-    expect(sql).toContain('run_id::text = $2');
-    expect(params).toEqual([AGENT_URL, 'run-new-empty', null]);
+    expect(sql).toContain('s.run_id = $2::uuid');
+    expect(params).toEqual([AGENT_URL, EMPTY_RUN_ID, null, false]);
   });
 
   it('getStoryboardStatuses can scope storyboard detail to a single compliance run id', async () => {
@@ -231,12 +272,12 @@ describe('ComplianceDatabase — last-write-wins on agent_compliance_status', ()
       fields: [],
     });
 
-    const statuses = await db.getStoryboardStatuses(AGENT_URL, { runId: 'run-new-empty' });
+    const statuses = await db.getStoryboardStatuses(AGENT_URL, { runId: EMPTY_RUN_ID });
 
     expect(statuses).toEqual([]);
     const [sql, params] = mockedQuery.mock.calls[0];
-    expect(sql).toContain('run_id::text = $2');
-    expect(params).toEqual([AGENT_URL, 'run-new-empty', null]);
+    expect(sql).toContain('s.run_id = $2::uuid');
+    expect(params).toEqual([AGENT_URL, EMPTY_RUN_ID, null, false]);
   });
 
   it('getStoryboardStatusCounts can suppress stale rows when the latest run wrote no storyboard rows', async () => {
@@ -248,13 +289,13 @@ describe('ComplianceDatabase — last-write-wins on agent_compliance_status', ()
       fields: [],
     });
 
-    const counts = await db.getStoryboardStatusCounts(AGENT_URL, { requireRowsForRunId: 'run-new-empty' });
+    const counts = await db.getStoryboardStatusCounts(AGENT_URL, { requireRowsForRunId: EMPTY_RUN_ID });
 
     expect(counts).toEqual({ passing: 0, total: 0 });
     const [sql, params] = mockedQuery.mock.calls[0];
     expect(sql).toContain('EXISTS');
-    expect(sql).toContain('latest.run_id::text = $3');
-    expect(params).toEqual([AGENT_URL, null, 'run-new-empty']);
+    expect(sql).toContain('latest.run_id = $3::uuid');
+    expect(params).toEqual([AGENT_URL, null, EMPTY_RUN_ID, false]);
   });
 
   it('getStoryboardStatuses can preserve merged rows only when the latest run wrote storyboard rows', async () => {
@@ -266,13 +307,49 @@ describe('ComplianceDatabase — last-write-wins on agent_compliance_status', ()
       fields: [],
     });
 
-    const statuses = await db.getStoryboardStatuses(AGENT_URL, { requireRowsForRunId: 'run-new-empty' });
+    const statuses = await db.getStoryboardStatuses(AGENT_URL, { requireRowsForRunId: EMPTY_RUN_ID });
 
     expect(statuses).toEqual([]);
     const [sql, params] = mockedQuery.mock.calls[0];
     expect(sql).toContain('EXISTS');
-    expect(sql).toContain('latest.run_id::text = $3');
-    expect(params).toEqual([AGENT_URL, null, 'run-new-empty']);
+    expect(sql).toContain('latest.run_id = $3::uuid');
+    expect(params).toEqual([AGENT_URL, null, EMPTY_RUN_ID, false]);
+  });
+
+  it('getStoryboardStatuses can gate merged rows against the latest run inside the same SQL statement', async () => {
+    mockedQuery.mockResolvedValueOnce({
+      rows: [],
+      rowCount: 0,
+      command: '',
+      oid: 0,
+      fields: [],
+    });
+
+    const statuses = await db.getStoryboardStatuses(AGENT_URL, { requireRowsForLatestRun: true });
+
+    expect(statuses).toEqual([]);
+    const [sql, params] = mockedQuery.mock.calls[0];
+    expect(sql).toContain('WITH latest_run AS');
+    expect(sql).toContain('JOIN latest_run lr ON latest.run_id = lr.id');
+    expect(params).toEqual([AGENT_URL, null, null, true]);
+  });
+
+  it('getStoryboardStatusCounts can gate merged rows against the latest run inside the same SQL statement', async () => {
+    mockedQuery.mockResolvedValueOnce({
+      rows: [{ passing: '0', total: '0' }],
+      rowCount: 1,
+      command: '',
+      oid: 0,
+      fields: [],
+    });
+
+    const counts = await db.getStoryboardStatusCounts(AGENT_URL, { requireRowsForLatestRun: true });
+
+    expect(counts).toEqual({ passing: 0, total: 0 });
+    const [sql, params] = mockedQuery.mock.calls[0];
+    expect(sql).toContain('WITH latest_run AS');
+    expect(sql).toContain('JOIN latest_run lr ON latest.run_id = lr.id');
+    expect(params).toEqual([AGENT_URL, null, null, true]);
   });
 
   it('bulkGetStoryboardStatuses preserves merged rows unless the latest run explicitly wrote none', async () => {
@@ -289,6 +366,7 @@ describe('ComplianceDatabase — last-write-wins on agent_compliance_status', ()
     expect(statuses).toEqual(new Map());
     const [sql, params] = mockedQuery.mock.calls[0];
     expect(sql).toContain('WITH latest_runs AS');
+    expect(sql).toMatch(/\)\s*,\s*latest_run_flags AS/);
     expect(sql).toContain('AND dry_run = false');
     expect(sql).toContain('latest_run_flags AS');
     expect(sql).toContain('latest.run_id = lr.id');

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -6797,7 +6797,7 @@ paths:
       description: |-
         Re-probe the agent and update its registry health (online, tools_count, response_time_ms), capability snapshot (inferred type, discovered tools), and compliance verdict (storyboard pass/fail counts). Use after fixing your agent so the registry shows fresh data without waiting for the periodic heartbeat (~1h).
 
-        **Compliance re-run:** when the caller owns the agent and the capability probe succeeds, the full storyboard suite runs (~30–90s) and `agent_storyboard_status` is updated under `triggered_by: 'manual'`. Badge fan-out reissues verification badges off the new run. If the compliance call fails (timeout, OAuth wall, internal error), the capability/health portion still returns successfully — `compliance.ran` is `false` with an `error` string.
+        **Compliance re-run:** when the caller owns the agent and the capability probe succeeds, the full storyboard suite runs (~30–90s) with a fresh test session and `agent_storyboard_status` is updated under `triggered_by: 'owner_test'`. Badge fan-out reissues verification badges off the new run. If the compliance call fails (timeout, OAuth wall, internal error), the capability/health portion still returns successfully — `compliance.ran` is `false` with an `error` string.
 
         **Auth:** owner of the agent or AAO admin.
 


### PR DESCRIPTION
## Summary
- Make owner-triggered full compliance refreshes use fresh test sessions and write canonical owner_test runs with org scope.
- Prevent zero-storyboard latest runs from displaying stale storyboard counts while preserving merged latest-per-storyboard state for partial owner tests.
- Scope full-suite badge fan-out to the just-written run and skip badge updates when a run materializes no storyboard rows.
- Log owner refresh compliance attempts to outbound request diagnostics.

## Root Cause
Dashboard refresh could write a new agent_compliance_runs/status row without writing any agent_storyboard_status rows. The status API then combined the latest run headline/timestamp with stale storyboard rows from prior runs, producing misleading results like “No applicable tracks found” with old storyboard counts. Owner refreshes also used legacy manual labeling and were not visible in outbound request logs.

## Validation
- npm run build:openapi
- npx vitest run server/tests/unit/compliance-db-last-write-wins.test.ts server/tests/unit/badge-fan-out.test.ts --config server/vitest.config.ts
- npm run typecheck
- precommit hook: npm run test:unit, test:test-dynamic-imports, test:callapi-state-change, typecheck
- pre-push hook: verify-version-sync, schema link convention, Mintlify broken-links

## Notes
- Local Postgres-backed integration tests were not run here because localhost:53198 was unavailable.