### PR TITLE
Use resolved authoritative manifest for `validate_adagents` counts

### DIFF
--- a/.changeset/fix-validate-adagents-authoritative-location-counts.md
+++ b/.changeset/fix-validate-adagents-authoritative-location-counts.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix `validate_adagents` counts when `/.well-known/adagents.json` is a pointer stub. We now expose the resolved authoritative manifest as `raw_data` after following `authoritative_location`, so Addie's `agent_count` and `property_count` are derived from the canonical file instead of the stub.

--- a/server/src/adagents-manager.ts
+++ b/server/src/adagents-manager.ts
@@ -335,9 +335,6 @@ export class AdAgentsManager {
         return result;
       }
 
-      // Only include raw data for successful responses
-      result.raw_data = adagentsData;
-
       // Check if this is a URL reference
       let wasUrlReference = false;
       if (this.isUrlReference(adagentsData)) {
@@ -355,6 +352,11 @@ export class AdAgentsManager {
           return result;
         }
       }
+
+      // Surface the canonical (post-pointer) manifest so downstream
+      // callers like validate_adagents count agents/properties from the
+      // authoritative file rather than the pointer stub (#5093).
+      result.raw_data = adagentsData;
 
       this.validateStructure(adagentsData, result);
       this.validateContent(adagentsData, result);


### PR DESCRIPTION
fixes #5093 

### Motivation
- When a publisher's `/.well-known/adagents.json` is a pointer (`authoritative_location`), downstream callers (notably the `validate_adagents` tool and Addie) were counting `authorized_agents` and `properties` from the pointer stub instead of the resolved canonical manifest, producing incorrect `agent_count`/`property_count` (#5093). 

### Description
- In `AdAgentsManager.validateDomain` assign `result.raw_data` after following an `authoritative_location` pointer so `raw_data` reflects the canonical (post-pointer) manifest rather than the stub. 
- Added an empty changeset file `fix-validate-adagents-authoritative-location-counts.md` documenting this non-protocol bugfix.

### Testing
- Ran `npm run -s typecheck` in this environment as an automated verification step, which failed due to broad/missing dependency and type-setup issues unrelated to this localized patch (typecheck failure is environment-wide, not caused by the change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a17530beafc832bbad186a009885071)