### PR TITLE
fix(docs): increase active nav contrast

### DIFF
--- a/.changeset/docs-active-nav-contrast.md
+++ b/.changeset/docs-active-nav-contrast.md
@@ -1,0 +1,6 @@
+---
+---
+
+docs(site): increase Mintlify active navigation color contrast.
+
+Refs #5074. This is a docs-site configuration change only.

--- a/docs.json
+++ b/docs.json
@@ -25,8 +25,8 @@
   "theme": "mint",
   "colors": {
     "primary": "#047857",
-    "light": "#07C983",
-    "dark": "#047857"
+    "light": "#34D399",
+    "dark": "#065F46"
   },
   "navbar": {
     "links": [


### PR DESCRIPTION
## Summary

Refs #5074.

I verified the live docs nav already marks the active left-nav item with `aria-current="page"` and Mintlify active classes, so this is a contrast/config fix rather than a missing active-state bug.

This widens the Mintlify color range by making the light active color brighter and the dark color deeper, following the triage recommendation, without adding custom CSS.

## What changed

- Updated `docs.json` `colors.light` from `#07C983` to `#34D399`.
- Updated `docs.json` `colors.dark` from `#047857` to `#065F46`.
- Added a docs-site config changeset.

## Testing

- `npm run test:docs-nav`
- `git diff --check`
- Live docs DOM check: active left-nav item has `aria-current="page"` and active Mintlify classes
- precommit hook: unit tests, dynamic-import lint, callApi state-change lint, typecheck
- pre-push hook: version sync