### PR TITLE
docs(sellers): document brand identity publication

### DIFF
--- a/.changeset/seller-brand-identity-docs.md
+++ b/.changeset/seller-brand-identity-docs.md
@@ -1,0 +1,6 @@
+---
+---
+
+docs(sellers): document seller brand identity publication.
+
+Refs #5094. This is docs-only and does not change protocol behavior.

--- a/docs/brand-protocol/brand-json.mdx
+++ b/docs/brand-protocol/brand-json.mdx
@@ -1005,7 +1005,7 @@ Properties default to `owned` — the brand operates the property directly. For 
 | `delegated` | Brand manages monetization — in charge of ad sales | Mediavine managing a food blog |
 | `ad_network` | Brand sells as part of a network/exchange — a path, not the path | PubMatic as an SSP |
 
-This is the AdCP equivalent of `sellers.json` — the operator's public declaration of which publishers they work with. The publisher confirms by setting the matching `delegation_type` on the agent's authorization in their [adagents.json](/docs/governance/property/adagents). See [ad networks](/docs/sponsored-intelligence/networks) for the bilateral verification pattern.
+This is the AdCP equivalent of `sellers.json` — the operator's public declaration of which publishers they work with. The publisher confirms by setting the matching `delegation_type` on the agent's authorization in their [adagents.json](/docs/governance/property/adagents). Sellers implementing this workflow should publish both files as part of [making inventory available to AI agents](/docs/building/operating/seller-integration#publish-your-brand-identity). See [ad networks](/docs/sponsored-intelligence/networks) for the bilateral verification pattern.
 
 ## Resolution algorithm
 

--- a/docs/brand-protocol/index.mdx
+++ b/docs/brand-protocol/index.mdx
@@ -90,6 +90,9 @@ The more tools that adopt the protocol, the more value your `brand.json` deliver
   <Card title="For rights holders" icon="shield-halved" href="/docs/brand-protocol/for-rights-holders">
     How AdCP protects and monetizes talent rights.
   </Card>
+  <Card title="For publishers / sellers" icon="store" href="/docs/building/operating/seller-integration#publish-your-brand-identity">
+    How to publish seller identity, property relationships, and signing keys.
+  </Card>
   <Card title="Rights licensing" icon="film" href="/docs/brand-protocol/walkthrough-rights-licensing">
     Follow a buyer from talent discovery through acquisition and revocation.
   </Card>

--- a/docs/building/operating/seller-integration.mdx
+++ b/docs/building/operating/seller-integration.mdx
@@ -17,7 +17,7 @@ Platforms that implement AdCP are discoverable by buyer agents out of the box. P
 
 ## What you need to implement
 
-AdCP sell-side integration has three parts:
+AdCP sell-side integration has four parts:
 
 <Steps>
 
@@ -48,6 +48,39 @@ Buyer agents check `adagents.json` to find authorized sales agents, verify relat
 <Note>
 This shows a simplified structure. The full adagents.json schema uses separate `properties` and `authorized_agents` arrays with a `delegation_type` field. See the [adagents.json tech spec](/docs/governance/property/adagents) for the complete schema.
 </Note>
+
+### Publish your brand identity
+
+Publish `brand.json` at `https://{your-domain}/.well-known/brand.json` for the selling organization. `adagents.json` tells buyers which publisher authorizes a sales agent; `brand.json` tells buyers which operator is claiming the sales path, which properties it represents, and where to find signing keys.
+
+For publisher-owned sales teams, list owned or direct properties. For networks and SSPs, list represented properties with `relationship: "delegated"` or `relationship: "ad_network"` and make sure that value matches the publisher's `authorized_agents[].delegation_type` in `adagents.json`. The two files form the bilateral verification chain: the operator declares "I sell this property", and the publisher confirms "this operator is authorized to sell it".
+
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
+  "version": "1.0",
+  "id": "example_publisher",
+  "url": "https://publisher.example.com",
+  "names": [{ "en_US": "Example Publisher" }],
+  "properties": [
+    {
+      "type": "website",
+      "identifier": "publisher.example.com",
+      "relationship": "direct"
+    }
+  ],
+  "agents": [
+    {
+      "type": "sales",
+      "url": "https://ads.publisher.example.com",
+      "id": "publisher_sales",
+      "jwks_uri": "https://ads.publisher.example.com/.well-known/jwks.json"
+    }
+  ]
+}
+```
+
+The `agents[].jwks_uri` lets buyers resolve your public signing keys. Sellers that send AdCP webhooks should publish a webhook-signing JWK with `adcp_use: "webhook-signing"` in that JWKS so buyers can verify outbound webhook signatures. See [request signing](/docs/building/by-layer/L1/request-signing) for the key-publication and webhook-signing profile.
 
 ### Expose your inventory
 


### PR DESCRIPTION
## Summary

Refs #5094.

This expands the existing seller integration journey instead of adding a separate brand-protocol page. It documents where seller operators publish `brand.json`, how `properties[].relationship` pairs with publisher `adagents.json` `delegation_type`, and why seller `agents[].jwks_uri` matters for webhook-signing key discovery.

## What changed

- Added a `Publish your brand identity` step to the seller integration guide.
- Included a minimal seller `brand.json` example with `properties[]`, `relationship`, `agents[]`, and `jwks_uri`.
- Linked the brand.json property-relationships spec back to the seller workflow.
- Added a `For publishers / sellers` card on the brand protocol index.
- Added a docs-only changeset.

## Testing

- `npm run test:docs-nav`
- `git diff --check`
- precommit hook: unit tests, dynamic-import lint, callApi state-change lint, typecheck
- pre-push hook: version sync, schema-link convention, Mintlify broken-links check

## Notes

- `npm run test:snippets` was attempted. The changed files report no testable snippets, but the repo-wide command currently fails on existing unrelated docs snippets: missing local Python `adcp` module, unset `$ADCP_AUTH_TOKEN` in `uvx adcp` examples, and existing live-agent/schema validation drift in media-buy/creative docs.