### PR TITLE
[codex] Fix supported_macros schema ambiguity

### DIFF
--- a/.changeset/fix-supported-macros-anyof.md
+++ b/.changeset/fix-supported-macros-anyof.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix `supported_macros` schema validation for standard universal macro names.
+
+`core/format.supported_macros.items` now uses `anyOf` so universal macro enum
+values such as `MEDIA_BUY_ID`, `CREATIVE_ID`, `CACHEBUSTER`, and `CLICK_URL`
+validate without conflicting with the custom string branch. Fixes #5099.

--- a/scripts/oneof-discriminators.baseline.json
+++ b/scripts/oneof-discriminators.baseline.json
@@ -196,11 +196,6 @@
       "variants": 2,
       "note": "0:[dimensions] | 1:[parameters_from_format_id]"
     },
-    "core/format.json##/properties/supported_macros/items/oneOf": {
-      "kind": "dangerous",
-      "variants": 2,
-      "note": "shared-required=[∅]; 0:ref-only(/schemas/enums/universal-macro.json) | 1:string"
-    },
     "core/product-filters.json##/properties/geo_proximity/items/oneOf": {
       "kind": "narrowable",
       "variants": 3,

--- a/static/schemas/source/core/format.json
+++ b/static/schemas/source/core/format.json
@@ -546,7 +546,7 @@
       "type": "array",
       "description": "List of universal macros supported by this format (e.g., MEDIA_BUY_ID, CACHEBUSTER, DEVICE_ID). Used for validation and developer tooling. See docs/creative/universal-macros.mdx for full documentation.",
       "items": {
-        "oneOf": [
+        "anyOf": [
           { "$ref": "/schemas/enums/universal-macro.json" },
           { "type": "string", "description": "Custom or publisher-specific macro name" }
         ]

--- a/tests/schema-validation.test.cjs
+++ b/tests/schema-validation.test.cjs
@@ -388,7 +388,59 @@ async function runTests() {
     return true;
   });
 
-  // Test 8: Validate media-buy available_actions SLAWindow wire shape
+  // Test 8: Validate list_creative_formats supported_macros permits universal and custom macro strings
+  await test('list_creative_formats supported_macros accepts universal and custom macro names', async () => {
+    const responseSchema = loadSchema(path.join(SCHEMA_BASE_DIR, 'creative/list-creative-formats-response.json'));
+    const formatSchema = loadSchema(path.join(SCHEMA_BASE_DIR, 'core/format.json'));
+    const supportedMacrosItems = formatSchema.properties?.supported_macros?.items;
+    const macroBranches = supportedMacrosItems?.anyOf || [];
+    if (supportedMacrosItems?.oneOf) {
+      return 'supported_macros.items must use anyOf, not oneOf';
+    }
+    if (!macroBranches.some(branch => branch.$ref === '/schemas/enums/universal-macro.json')) {
+      return 'supported_macros.items is missing the UniversalMacro enum branch';
+    }
+    if (!macroBranches.some(branch => branch.type === 'string')) {
+      return 'supported_macros.items is missing the custom string branch';
+    }
+
+    const testAjv = new Ajv({
+      allErrors: true,
+      verbose: true,
+      strict: false,
+      discriminator: true,
+      loadSchema: loadExternalSchema
+    });
+    addFormats(testAjv);
+
+    const validate = await testAjv.compileAsync(responseSchema);
+    const response = {
+      status: 'completed',
+      formats: [
+        {
+          format_id: {
+            agent_url: 'https://creative-agent.example.com',
+            id: 'display_standard'
+          },
+          name: 'Display standard',
+          supported_macros: [
+            'MEDIA_BUY_ID',
+            'CREATIVE_ID',
+            'CACHEBUSTER',
+            'CLICK_URL',
+            'PUBLISHER_CUSTOM_ID'
+          ]
+        }
+      ]
+    };
+
+    if (!validate(response)) {
+      return validate.errors.map(err => `${err.instancePath} ${err.message}`).join('; ');
+    }
+    return true;
+  });
+
+  // Test 9: Validate media-buy available_actions SLAWindow wire shape
   await test('get_media_buys available_actions uses generated SLAWindow duration shape', async () => {
     const responseSchema = loadSchema(path.join(SCHEMA_BASE_DIR, 'media-buy/get-media-buys-response.json'));
     const testAjv = new Ajv({
@@ -443,7 +495,7 @@ async function runTests() {
     return true;
   });
 
-  // Test 9: Validate provisional media-buy confirmation guards
+  // Test 10: Validate provisional media-buy confirmation guards
   await test('provisional media buys cannot be active or carry committed_metrics', async () => {
     const createSchema = loadSchema(path.join(SCHEMA_BASE_DIR, 'media-buy/create-media-buy-response.json'));
     const getSchema = loadSchema(path.join(SCHEMA_BASE_DIR, 'media-buy/get-media-buys-response.json'));
@@ -548,7 +600,7 @@ async function runTests() {
     return true;
   });
 
-  // Test 10: Validate ForecastPoint dimension and viewability compatibility gates
+  // Test 11: Validate ForecastPoint dimension and viewability compatibility gates
   await test('ForecastPoint dimension and viewability compatibility gates behave as intended', async () => {
     const dimensionsSchema = loadSchema(path.join(SCHEMA_BASE_DIR, 'core/forecast-point-dimensions.json'));
     const uniqueProps = dimensionsSchema['x-adcp-validation']?.unique_item_properties || [];
@@ -876,7 +928,7 @@ async function runTests() {
     return true;
   });
 
-  // Test 10: Validate schema examples against their schemas
+  // Test 12: Validate schema examples against their schemas
   await test('Schema examples validate against their own schemas', async () => {
     // Skip schemas that require format-aware validation (creative manifests need format context)
     const FORMAT_AWARE_SCHEMAS = ['sync-creatives-request.json', 'list-creatives-response.json'];


### PR DESCRIPTION
## Summary

Fixes the `supported_macros.items` schema ambiguity from #5099.

- Changes `core/format.supported_macros.items` from `oneOf` to `anyOf`
- Keeps both the UniversalMacro enum branch and custom string branch
- Adds a `list_creative_formats` regression test covering standard macro names and a custom macro
- Removes the stale oneOf audit baseline entry
- Adds a patch changeset for the published schema bugfix

## Root Cause

Standard macro strings such as `MEDIA_BUY_ID`, `CREATIVE_ID`, `CACHEBUSTER`, and `CLICK_URL` matched both branches of the previous `oneOf`: the UniversalMacro enum branch and the generic custom string branch. Under JSON Schema `oneOf`, matching both branches is invalid.

## Expert Review

- Protocol/schema expert: no blockers or issues. Suggested adding a schema-shape guard so the regression test also verifies `anyOf` and the enum branch remain present; addressed.
- Code reviewer: no blockers, issues, or nits. Ready to push.

## Validation

- `npm run test:schemas`
- `npm run test:oneof-discriminators`
- `git diff --check`
- Commit hook: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run typecheck`

Closes #5099.
