### PR TITLE
fix(changesets): block agent PR title prefixes

### DIFF
--- a/.agents/playbook.md
+++ b/.agents/playbook.md
@@ -283,6 +283,14 @@ Description of change.
 
 Types: `patch` (fixes), `minor` (new features), `major` (breaking), `--empty` (no protocol impact)
 
+#### PR title hygiene
+
+PR titles must be review- and release-ready:
+
+- Use conventional-commits format (`fix(scope): summary`, `docs: summary`, `feat(schema): summary`).
+- Do not prefix titles with the tool or model that authored the PR. In particular, never use `[codex]`, `[claude]`, `[agent]`, or similar ownership tags.
+- The authoring tool belongs in the PR body/session link or labels when useful, not in the title. PR titles flow into release/review surfaces, so tool prefixes create noise and can break title-based automation.
+
 **Use `--empty` (no package entry) for everything that isn't a protocol change:**
 - Addie (any server-side AI behavior, tools, routing, bolt app)
 - Website / admin UI / member pages

--- a/.changeset/block-agent-pr-title-prefixes.md
+++ b/.changeset/block-agent-pr-title-prefixes.md
@@ -1,0 +1,7 @@
+---
+---
+
+ci(changeset-check): reject agent-prefixed PR titles such as `[codex]`.
+
+Empty changeset because this only affects repository automation and agent
+guidance, not the published AdCP protocol.

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -5,6 +5,24 @@ on:
     branches: [main, '3.0.x', '2.6.x', '2.5-maintenance']
 
 jobs:
+  pr-title:
+    name: Check PR title
+    runs-on: ubuntu-latest
+    # Keep the release-machinery exceptions aligned with the changeset check below.
+    if: ${{ !startsWith(github.head_ref, 'changeset-release/') && !startsWith(github.head_ref, 'forward-merge/') && !startsWith(github.head_ref, 'auto/docs-v') }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Check PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: node scripts/check-pr-title.cjs "$PR_TITLE"
+
   check:
     name: Check for changeset
     runs-on: ubuntu-latest

--- a/scripts/check-pr-title.cjs
+++ b/scripts/check-pr-title.cjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+const title = (process.argv.slice(2).join(' ') || process.env.PR_TITLE || '').trim();
+
+if (!title) {
+  console.error('PR title is empty.');
+  process.exit(1);
+}
+
+const disallowedAgentPrefix =
+  /^\[(codex|claude|claude-code|openai|chatgpt|copilot|cursor|aider|devin|agent|ai)\](?:\s|:|-|$)/i;
+
+if (disallowedAgentPrefix.test(title)) {
+  console.error(`Invalid PR title: ${title}`);
+  console.error('Remove the leading agent/tool prefix. Use a concrete conventional-commits title instead, for example:');
+  console.error('  fix(changesets): block agent PR title prefixes');
+  process.exit(1);
+}
+
+const conventionalCommit =
+  /^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z0-9._/-]+\))?!?: .+/;
+
+const allowedAutomationTitles = [/^Version Packages$/, /^Forward-merge\b/, /^chore: snapshot docs for v[0-9]/];
+
+if (!conventionalCommit.test(title) && !allowedAutomationTitles.some((pattern) => pattern.test(title))) {
+  console.log(
+    '::notice title=PR title convention::Regular PR titles should use conventional-commits format, ' +
+      'for example "fix(changesets): block agent PR title prefixes".',
+  );
+}


### PR DESCRIPTION
## Summary

Blocks agent/tool ownership prefixes like \`[codex]\`, \`[claude]\`, \`[cursor]\`, and similar tags from PR titles before they can pollute Changesets and release/review surfaces.

Adds the rule to the shared agent playbook so future agent-authored PRs know to use conventional-commits titles without tool prefixes.

## Validation

- \`node scripts/check-pr-title.cjs \"fix(changesets): block agent PR title prefixes\"\`
- \`node scripts/check-pr-title.cjs \"[cursor] fix: test\"\` exits 1 with the expected remediation message
- \`npx --yes @changesets/cli@^2.31.0 status --since=origin/main\`
- \`git diff --check\`
- precommit hook: \`npm run test:unit\`, \`npm run test:test-dynamic-imports\`, \`npm run test:callapi-state-change\`, \`npm run typecheck\`

## Review

DX review found no blockers or material issues. One nit about matching guidance to CI coverage was addressed by expanding the blocked prefix list.