### PR TITLE
fix(argus): support fork PR reviews safely

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -28,7 +28,7 @@ name: AI PR Review (Argus)
 # Adapted from scope3data/agentic-api's Argus workflow.
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - labeled
@@ -57,8 +57,14 @@ jobs:
     steps:
       # Third-party actions pinned to commit SHAs to close the "force-push
       # to a moving tag ships malicious code under the App token" vector.
+      #
+      # This workflow uses pull_request_target so fork PRs can access the
+      # review App token and Anthropic secret. Never check out the PR head or
+      # execute PR-controlled code in this job. Keep the workspace pinned to the
+      # trusted base SHA and inspect the PR through GitHub APIs / gh pr diff.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
 
       # ─────────────────────────────────────────────────────────────────────
@@ -77,11 +83,10 @@ jobs:
       # Workflow-modification gate.
       #
       # If this PR modifies `.github/ai-review/**` or `.github/workflows/
-      # ai-review.yml` alongside other files, the workflow runs with the
-      # PR head's modified prompt/workflow. That's a same-repo-write-access
-      # prompt-injection vector: a contributor could ship a malicious
-      # prompt edit + a sacrificial source change in one PR and have Argus
-      # rubber-stamp itself. Bail with a --comment requiring human review.
+      # ai-review.yml`, Argus may be reviewing the review system itself. Even
+      # though pull_request_target keeps this run on the base-branch prompt and
+      # workflow, a human should own those changes. Bail with a --comment
+      # requiring human review.
       #
       # `paths-ignore` at the workflow level only fires when ALL changed
       # paths are ignored — this step handles the mixed case.
@@ -90,11 +95,12 @@ jobs:
         id: workflow-mod
         shell: bash
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          CHANGED="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          CHANGED="$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)"
           MODIFIED=""
           while IFS= read -r f; do
             case "$f" in
@@ -128,7 +134,7 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number,
               event: 'COMMENT',
-              body: `Argus is **not auto-reviewing** this PR because it modifies the review workflow itself (${files}). Running with the PR head's modified prompt/workflow is a prompt-injection vector. A human reviewer should review and merge this PR; Argus will resume on subsequent PRs once these changes land on \`main\`.`
+              body: `Argus is **not auto-reviewing** this PR because it modifies the review workflow itself (${files}). A human reviewer should review and merge this PR; Argus will resume on subsequent PRs once these changes land on \`main\`.`
             });
 
       # ─────────────────────────────────────────────────────────────────────
@@ -158,18 +164,11 @@ jobs:
             echo "No prior Argus APPROVED review — running full review."
             exit 0
           fi
-          if ! git cat-file -e "$PRIOR_SHA" 2>/dev/null; then
-            git fetch --quiet origin "$PRIOR_SHA" 2>/dev/null || true
-          fi
-          if ! git cat-file -e "$PRIOR_SHA" 2>/dev/null; then
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-            echo "Prior review SHA $PRIOR_SHA unreachable (likely force-pushed) — running full review."
-            exit 0
-          fi
-          CHANGED="$(git diff --name-only "$PRIOR_SHA" "$HEAD_SHA")"
+          CHANGED="$(gh api "/repos/${REPO}/compare/${PRIOR_SHA}...${HEAD_SHA}" \
+            --jq '.files[]?.filename' 2>/dev/null || true)"
           if [ -z "$CHANGED" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "No file changes since prior approval at $PRIOR_SHA — skipping."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Could not compare $PRIOR_SHA...$HEAD_SHA (likely force-pushed or fork edge case) — running full review."
             exit 0
           fi
           # Trivial paths in AdCP — re-pushes touching only these skip re-review.


### PR DESCRIPTION
## Summary
- run Argus on pull_request_target so fork PRs can access the review App token and Anthropic secret
- keep checkout pinned to the trusted base SHA and inspect PR changes through GitHub APIs
- avoid local prior-SHA diffs in the skip check, falling back to full review when compare data is unavailable

## Validation
- git diff --check
- precommit hook: unit tests, dynamic import lint, callApi state-change lint, typecheck