### PR TITLE
feat(compliance): add JCS non-finite controller error

### DIFF
--- a/.changeset/5069-jcs-non-finite-controller-error.md
+++ b/.changeset/5069-jcs-non-finite-controller-error.md
@@ -1,0 +1,15 @@
+---
+"adcontextprotocol": minor
+---
+
+feat(compliance): add typed JCS non-finite controller error
+
+Adds `JCS_NON_FINITE_NUMBER` to the comply-test-controller `ControllerError.error`
+enum for digest-mode `query_upstream_traffic` responses that cannot be RFC
+8785/JCS-canonicalized because the parsed JSON-like value tree contains a
+non-finite numeric value (`NaN`, `+Infinity`, or `-Infinity`).
+Runner-output and storyboard contracts now state that this case grades the
+affected upstream_traffic digest validation as `not_applicable` and contributes
+to `validations_not_applicable`, not `steps_failed`.
+
+Closes #5069.

--- a/docs/building/by-layer/L3/comply-test-controller.mdx
+++ b/docs/building/by-layer/L3/comply-test-controller.mdx
@@ -668,6 +668,7 @@ Controllers MUST use structured error codes so the storyboard runner can assert 
 | `UNKNOWN_SCENARIO` | Scenario not implemented by this seller |
 | `INVALID_PARAMS` | Missing or malformed params, or precondition not met (e.g., `simulate_budget_spend` on an entity with no budget configured) |
 | `FORBIDDEN` | Production account referenced from a sandbox connection |
+| `JCS_NON_FINITE_NUMBER` | Digest-mode `query_upstream_traffic` cannot canonicalize a parsed JSON-like value tree containing `NaN`, `+Infinity`, or `-Infinity`; controllers must not coerce these values, and runners grade the affected validation `not_applicable` |
 | `INTERNAL_ERROR` | Transient seller-side failure (e.g., sandbox database unavailable). The runner SHOULD retry once before treating as a failure. |
 
 <Note>

--- a/docs/building/verification/get-test-ready.mdx
+++ b/docs/building/verification/get-test-ready.mdx
@@ -140,7 +140,7 @@ What the scaffold handles for you:
 - **Dispatch and `UNKNOWN_SCENARIO`.** Scenarios you do not register return `UNKNOWN_SCENARIO` automatically — never a schema error.
 - **Param validation.** Invalid params produce `INVALID_PARAMS` with a readable `error_detail` without reaching your adapter.
 - **Seed idempotency.** Calling `seed_product` twice with the same `product_id` and an equivalent `fixture` returns `previous_state: "existing"`; a divergent `fixture` returns `INVALID_PARAMS`. Your adapter is only invoked on the first seed.
-- **Typed error envelopes.** Throw `TestControllerError(code, message, currentState?)` with `code` in `'INVALID_TRANSITION' | 'NOT_FOUND' | 'FORBIDDEN' | 'INVALID_PARAMS'` from any adapter.
+- **Typed error envelopes.** Throw `TestControllerError(code, message, currentState?)` with `code` from the controller error-code table. Common adapter codes are `'INVALID_TRANSITION' | 'NOT_FOUND' | 'FORBIDDEN' | 'INVALID_PARAMS'`; digest-mode `query_upstream_traffic` implementations may also return `JCS_NON_FINITE_NUMBER` when RFC 8785/JCS canonicalization encounters a non-finite numeric value.
 
 The scaffold does **not** own the state machine. Transition rules live in your adapters, so compliance testing and production share one source of truth — the mechanic the [anti-teach-to-test section](#avoiding-the-teach-to-test-trap) depends on.
 

--- a/server/src/training-agent/tenants/comply.ts
+++ b/server/src/training-agent/tenants/comply.ts
@@ -40,6 +40,26 @@ interface V5Response {
   [key: string]: unknown;
 }
 
+const CONTROLLER_ERROR_CODES = [
+  'NOT_FOUND',
+  'INVALID_PARAMS',
+  'INVALID_TRANSITION',
+  'INVALID_STATE',
+  'FORBIDDEN',
+  'UNKNOWN_SCENARIO',
+  'JCS_NON_FINITE_NUMBER',
+  'INTERNAL_ERROR',
+] as const;
+
+type ControllerErrorCode = typeof CONTROLLER_ERROR_CODES[number];
+
+function normalizeControllerErrorCode(code: unknown): ControllerErrorCode {
+  if (typeof code === 'string' && (CONTROLLER_ERROR_CODES as readonly string[]).includes(code)) {
+    return code as ControllerErrorCode;
+  }
+  return 'INTERNAL_ERROR';
+}
+
 /**
  * Generic v5 → v6 comply-adapter shim. Builds the `ToolArgs` for the v5
  * handler, dispatches, throws `TestControllerError` on `success: false`.
@@ -59,10 +79,10 @@ async function dispatchV5(scenario: string, params: Record<string, unknown>, inp
 
 function throwOnFailure(result: V5Response): void {
   if (result.success) return;
-  const code = result.error ?? 'INVALID_REQUEST';
+  const code = normalizeControllerErrorCode(result.error);
   const message = result.error_detail ?? `Comply controller returned ${code}`;
   throw new TestControllerError(
-    code as 'NOT_FOUND' | 'INVALID_PARAMS' | 'INVALID_TRANSITION' | 'FORBIDDEN' | 'UNKNOWN_SCENARIO' | 'INTERNAL_ERROR',
+    code as ConstructorParameters<typeof TestControllerError>[0],
     message,
     typeof result.current_state === 'string' ? result.current_state : undefined,
   );

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -420,6 +420,16 @@ validation_result:
           recorded_calls returned in raw mode, so a mixed-mode response
           (some calls raw, some digest) produces partial coverage rather
           than blanket not_applicable.
+        - If the controller cannot produce a digest-mode upstream_traffic
+          response because the parsed JSON-like value tree contains a
+          non-finite numeric value (`NaN`, `+Infinity`, or `-Infinity`),
+          it MUST NOT coerce that value to `null`, a string, or any other
+          placeholder for digest computation; it returns ControllerError
+          with error code `JCS_NON_FINITE_NUMBER`. The runner emits the affected
+          upstream_traffic validation_result with `passed: true` and a
+          `note` citing the RFC 8785/JCS non-finite-number constraint,
+          contributing to `validations_not_applicable` on run_summary
+          (NOT steps_failed).
         - `min_count` and `endpoint_pattern` are unchanged — count and URL
           matching work identically in both modes.
       Storyboards that strictly require raw introspection set

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -1606,6 +1606,14 @@
 #       - `payload_must_contain` arbitrary path assertions: NOT supported in
 #         digest mode. Each entry grades `not_applicable` per affected call,
 #         with a note explaining the mode constraint.
+#       - JCS non-finite numbers: when a digest-mode upstream_traffic response
+#         cannot be produced because the parsed JSON-like value tree contains
+#         a non-finite numeric value (`NaN`, `+Infinity`, or `-Infinity`), the
+#         controller MUST NOT coerce that value to `null`, a string, or any
+#         other placeholder for digest computation; it returns ControllerError
+#         with error code `JCS_NON_FINITE_NUMBER`; the runner grades the
+#         affected validation `not_applicable`, not failed, with a note citing
+#         the RFC 8785/JCS constraint.
 #       - `payload_length`: MUST equal the exact byte length covered by
 #         `payload_digest_sha256` — RFC 8785 (JCS) canonical bytes for
 #         JSON-shaped content after redaction, or post-redaction raw body bytes

--- a/static/schemas/source/compliance/comply-test-controller-response.json
+++ b/static/schemas/source/compliance/comply-test-controller-response.json
@@ -528,7 +528,7 @@
               "payload_digest_sha256": {
                 "type": "string",
                 "pattern": "^[a-f0-9]{64}$",
-                "description": "SHA-256 digest of the canonicalized outbound request body, lowercase hex (64 chars). Required when `attestation_mode` is `digest`; MUST be absent when `attestation_mode` is `raw`. Canonicalization order is normative: (1) controllers MUST apply the recursive secret-key redaction (same pattern as the raw-mode payload field) BEFORE computing the digest; (2) for `application/json` and `*+json` content types, controllers MUST then serialize the redacted body to RFC 8785 (JCS) canonical form — sorted keys, no extraneous whitespace — and digest the resulting bytes. Storyboard-supplied identifiers (hashed PII, request correlation values) MUST NOT be redacted before digest computation; they are the load-bearing match target for `identifier_match_proofs` and digesting them away makes echo verification impossible. Both `payload_digest_sha256` AND `identifier_match_proofs` MUST be computed against the same post-redaction canonical bytes — diverging the two surfaces breaks coherence between digest replay and identifier echo. JCS edge cases: payloads containing `NaN` or `Infinity` numbers MUST grade `not_applicable` for digest mode (RFC 8785 forbids them); payloads carrying numeric identifiers MUST serialize them as JSON strings before digest computation (adtech bid payloads regularly carry IDs outside ±2^53 where I-JSON / RFC 7493 number round-tripping diverges across implementations). For non-JSON content types the digest is computed over the post-redaction raw body bytes."
+                "description": "SHA-256 digest of the canonicalized outbound request body, lowercase hex (64 chars). Required when `attestation_mode` is `digest`; MUST be absent when `attestation_mode` is `raw`. Canonicalization order is normative: (1) controllers MUST apply the recursive secret-key redaction (same pattern as the raw-mode payload field) BEFORE computing the digest; (2) for `application/json` and `*+json` content types, controllers MUST then serialize the redacted body to RFC 8785 (JCS) canonical form — sorted keys, no extraneous whitespace — and digest the resulting bytes. Storyboard-supplied identifiers (hashed PII, request correlation values) MUST NOT be redacted before digest computation; they are the load-bearing match target for `identifier_match_proofs` and digesting them away makes echo verification impossible. Both `payload_digest_sha256` AND `identifier_match_proofs` MUST be computed against the same post-redaction canonical bytes — diverging the two surfaces breaks coherence between digest replay and identifier echo. JCS edge cases: when a digest-mode `query_upstream_traffic` response cannot be produced because the parsed JSON-like value tree contains a non-finite numeric value (`NaN`, `+Infinity`, or `-Infinity`), controllers MUST NOT coerce that value to `null`, a string, or any other placeholder for digest computation; they MUST return the typed ControllerError code `JCS_NON_FINITE_NUMBER`. Runners MUST grade the affected upstream_traffic digest validation `not_applicable` because RFC 8785 forbids non-finite numbers. Payloads carrying numeric identifiers MUST serialize them as JSON strings before digest computation (adtech bid payloads regularly carry IDs outside ±2^53 where I-JSON / RFC 7493 number round-tripping diverges across implementations). For non-JSON content types the digest is computed over the post-redaction raw body bytes."
               },
               "payload_length": {
                 "type": "integer",
@@ -698,7 +698,7 @@
     },
     {
       "title": "ControllerError",
-      "description": "The scenario failed — invalid transition, unknown entity, unsupported scenario, or invalid params",
+      "description": "The scenario failed or could not produce a conformant response — invalid transition, unknown entity, unsupported scenario, invalid params, forbidden sandbox access, non-finite JCS canonicalization, or internal failure",
       "type": "object",
       "properties": {
         "success": {
@@ -714,9 +714,10 @@
             "UNKNOWN_SCENARIO",
             "INVALID_PARAMS",
             "FORBIDDEN",
+            "JCS_NON_FINITE_NUMBER",
             "INTERNAL_ERROR"
           ],
-          "description": "Structured error code"
+          "description": "Structured error code. `JCS_NON_FINITE_NUMBER` is reserved for digest-mode upstream_traffic responses that cannot be RFC 8785/JCS-canonicalized because the parsed JSON-like value tree contains a non-finite numeric value (`NaN`, `+Infinity`, or `-Infinity`); controllers MUST NOT coerce those values during digest computation, and runners grade that validation `not_applicable`, not failed."
         },
         "error_detail": {
           "type": "string",

--- a/tests/schema-validation.test.cjs
+++ b/tests/schema-validation.test.cjs
@@ -600,7 +600,33 @@ async function runTests() {
     return true;
   });
 
-  // Test 11: Validate ForecastPoint dimension and viewability compatibility gates
+  // Test 11: Validate comply_test_controller accepts the JCS non-finite error code
+  await test('Comply controller response accepts JCS non-finite controller error', async () => {
+    const testAjv = new Ajv({
+      allErrors: true,
+      verbose: true,
+      strict: false,
+      discriminator: true,
+      loadSchema: loadExternalSchema
+    });
+    addFormats(testAjv);
+
+    const validateComplyResponse = await testAjv.compileAsync(loadSchema(path.join(SCHEMA_BASE_DIR, 'compliance/comply-test-controller-response.json')));
+    const response = {
+      status: 'completed',
+      success: false,
+      error: 'JCS_NON_FINITE_NUMBER',
+      error_detail: 'Digest-mode upstream traffic could not be JCS-canonicalized because the parsed JSON-like value tree contained a non-finite numeric value.'
+    };
+
+    if (!validateComplyResponse(response)) {
+      return `JCS_NON_FINITE_NUMBER response unexpectedly failed validation: ${validateComplyResponse.errors.map(err => `${err.instancePath} ${err.message}`).join('; ')}`;
+    }
+
+    return true;
+  });
+
+  // Test 12: Validate ForecastPoint dimension and viewability compatibility gates
   await test('ForecastPoint dimension and viewability compatibility gates behave as intended', async () => {
     const dimensionsSchema = loadSchema(path.join(SCHEMA_BASE_DIR, 'core/forecast-point-dimensions.json'));
     const uniqueProps = dimensionsSchema['x-adcp-validation']?.unique_item_properties || [];
@@ -992,7 +1018,7 @@ async function runTests() {
     return true;
   });
 
-  // Test 12: Validate schema examples against their schemas
+  // Test 13: Validate schema examples against their schemas
   await test('Schema examples validate against their own schemas', async () => {
     // Skip schemas that require format-aware validation (creative manifests need format context)
     const FORMAT_AWARE_SCHEMAS = ['sync-creatives-request.json', 'list-creatives-response.json'];


### PR DESCRIPTION
Adds the typed comply-test-controller error `JCS_NON_FINITE_NUMBER` for digest-mode `query_upstream_traffic` responses that cannot be RFC 8785/JCS-canonicalized because a parsed JSON-like value tree contains `NaN`, `+Infinity`, or `-Infinity`.
Clarifies runner and storyboard contracts so this condition grades the affected upstream_traffic digest validation as `not_applicable` and contributes to `validations_not_applicable`, not `steps_failed`.
Updates the training-agent controller-error shim plus public compliance docs so local and adopter-facing typed error guidance stays aligned.
Adds schema validation coverage for the new controller error arm and a minor changeset for #5069.

Validation: `npm run build`, `npm run typecheck`, `npm run test:schemas`, `npm run test:storyboard-doc-parity`, `npm run test:docs-nav`, `npm run test:error-codes`, `git diff --check`, precommit `test:unit`/dynamic-import/callapi/typecheck, and pre-push storyboard/docs checks.
