### PR TITLE
feat(brand): add machine-readable guideline constraints

### DIFF
--- a/.changeset/5090-fictional-brand-json-guideline-mappings.md
+++ b/.changeset/5090-fictional-brand-json-guideline-mappings.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": minor
+---
+
+spec(brand): add machine-readable brand guideline constraints
+
+Adds optional `logos[].id`, `logos[].slots[]`, canonical format `logo_slots[]` and `required_logo_slots[]` hints, plus `visual_guidelines.color_constraints[]`, `logo_usage_rules[]`, and `mark_lockups[]` to make guideline rules enforceable: color pairing matrices, deterministic logo slot selection, logo usage contexts, and co-brand/secondary-mark lockups. Includes two schema-valid fictional fixtures that exercise the new surface without adding real-brand public examples.

--- a/docs/brand-protocol/brand-json.mdx
+++ b/docs/brand-protocol/brand-json.mdx
@@ -840,7 +840,62 @@ Canonical creative formats still use `asset_group_id: "logo"` for the manifest a
 }
 ```
 
-#### Ingesting brand books
+### Color constraints
+
+Use `visual_guidelines.color_constraints[]` for machine-readable color usage and pairing rules, such as accent-only colors, forbidden background combinations, or colors that should never appear together.
+
+```json
+{
+  "visual_guidelines": {
+    "color_constraints": [
+      {
+        "color": { "kind": "name", "name": "market_yellow" },
+        "applies_to": ["accent"],
+        "forbidden_on": [
+          { "kind": "surface", "surface": "background" },
+          { "kind": "surface", "surface": "text" }
+        ],
+        "never_pair_with": [{ "kind": "name", "name": "linen" }],
+        "contexts": ["digital", "print", "ctv_end_card"],
+        "severity": "must",
+        "description": "Market yellow is accent only."
+      }
+    ]
+  }
+}
+```
+
+Each `color_ref` uses an explicit `kind` discriminator: `kind: "name"` looks up a key in `colors{}`, `kind: "value"` carries a literal hex color, and `kind: "surface"` identifies a layout surface such as `background`, `text`, or `logo_background`.
+
+### Mark lockups
+
+Use `visual_guidelines.mark_lockups[]` for co-brand, partner, sponsor, program, or secondary-mark layout rules. These fields make ordering, spacing, separators, and size-ratio guidance queryable while leaving optical balancing to layout/render review.
+
+```json
+{
+  "visual_guidelines": {
+    "mark_lockups": [
+      {
+        "lockup_type": "co_brand",
+        "ordering": "brand_first",
+        "brand_logo_id": "primary_horizontal",
+        "contexts": ["partner_campaign", "sponsored_content"],
+        "separator": {
+          "type": "keyline",
+          "color": { "kind": "name", "name": "text" },
+          "width": "1px"
+        },
+        "min_gap": "1x clear space",
+        "brand_min_optical_weight_ratio": 1,
+        "partner_max_optical_weight_ratio": 1,
+        "severity": "must"
+      }
+    ]
+  }
+}
+```
+
+### Tooling notes: ingesting brand books
 
 Tools that create a draft `brand.json` from a brand-guide PDF should keep asset extraction and guideline interpretation separate.
 

--- a/docs/brand-protocol/brand-json.mdx
+++ b/docs/brand-protocol/brand-json.mdx
@@ -840,6 +840,36 @@ Canonical creative formats still use `asset_group_id: "logo"` for the manifest a
 }
 ```
 
+#### Ingesting brand books
+
+Tools that create a draft `brand.json` from a brand-guide PDF should keep asset extraction and guideline interpretation separate.
+
+Use deterministic extraction to produce candidate asset IDs:
+
+- embedded PDF images for photography, mockups, raster icons, and examples
+- rendered-page crops for vector logos, marks, color swatches, and logo specimens that are not embedded image files
+
+Then use a multimodal model to classify those candidate IDs into proposed `logos[]`, `assets[]`, `colors`, and `visual_guidelines` rules. The model should map back to known candidate IDs; it should not be treated as the source of original asset bytes.
+
+A draft ingestion record can point from a proposed logo entry back to evidence:
+
+```json
+{
+  "asset_id": "candidate_logo_0007",
+  "source_page": 15,
+  "extraction_method": "rendered_page_crop",
+  "proposed_logo": {
+    "id": "primary_wordmark_dark_card",
+    "variant": "wordmark",
+    "background": "dark-bg",
+    "slots": ["logo_card_dark", "marketplace_listing"]
+  },
+  "review_status": "needs_review"
+}
+```
+
+Do not publish those candidates directly as canonical `logos[]` until a reviewer confirms the crop, assigns the correct slots/backgrounds, and replaces the candidate file with a durable HTTPS logo asset URL. If the source PDF lacks hosted assets, operator authorization, or trademark evidence, that is an ingestion warning rather than a schema gap.
+
 ### Colorways
 
 Named color pairings that define how colors work together. Allows a creative brief to reference "use my primary colorway" without specifying every color:

--- a/docs/brand-protocol/brand-json.mdx
+++ b/docs/brand-protocol/brand-json.mdx
@@ -792,6 +792,54 @@ Logo placement and clear space rules for automated creative production:
 | `min_height` | string | Minimum logo height for legibility (e.g., `40px`) |
 | `background_contrast` | enum | `light_only`, `dark_only`, `any` |
 
+### Logo selection slots
+
+Use `logos[].slots[]` when a renderer needs to choose the right logo variant for a specific surface, such as a light logo card, dark logo card, profile mark, CTV end card, co-brand lockup, or marketplace listing. `logos[].id` gives downstream rules a stable target that does not depend on a mutable asset URL.
+
+```json
+{
+  "logos": [
+    {
+      "id": "primary_horizontal",
+      "url": "https://assets.example.com/logos/primary.svg",
+      "orientation": "horizontal",
+      "background": "light-bg",
+      "variant": "primary",
+      "slots": ["logo_card_light", "nav_header", "marketplace_listing"]
+    },
+    {
+      "id": "knockout_horizontal",
+      "url": "https://assets.example.com/logos/knockout.svg",
+      "orientation": "horizontal",
+      "background": "dark-bg",
+      "variant": "secondary",
+      "slots": ["logo_card_dark", "ad_end_card"]
+    }
+  ]
+}
+```
+
+Canonical creative formats still use `asset_group_id: "logo"` for the manifest asset group. If a product narrows that slot with `format_options[].params.slots[].logo_slots[]`, builders should select from `brand.json` `logos[]` where `logos[].slots[]` intersects the requested slots. If the format also declares `required_logo_slots[]`, missing coverage should surface as a validation warning or approval mapping instead of falling back silently to prose.
+
+`visual_guidelines.logo_usage_rules[]` can then apply placement constraints to a stable `logo_id`:
+
+```json
+{
+  "visual_guidelines": {
+    "logo_usage_rules": [
+      {
+        "logo_id": "primary_horizontal",
+        "slots": ["logo_card_light", "marketplace_listing"],
+        "minimum_size": { "height": "18px" },
+        "clear_space": "1x cap height",
+        "forbidden_contexts": ["photography_without_knockout"],
+        "severity": "must"
+      }
+    ]
+  }
+}
+```
+
 ### Colorways
 
 Named color pairings that define how colors work together. Allows a creative brief to reference "use my primary colorway" without specifying every color:

--- a/specs/brand-json-machine-readable-guidelines.md
+++ b/specs/brand-json-machine-readable-guidelines.md
@@ -1,0 +1,239 @@
+# Machine-readable brand guideline constraints in `brand.json`
+
+**Status**: Accepted for schema draft
+
+**Decision**: `brand.json` should grow first-class fields for brand-guide rules that agents can enforce mechanically, while keeping `visual_guidelines.restrictions[]` for broad prose guardrails.
+
+## TL;DR
+
+Add one logo-selection field on `logos[]` plus three optional fields under `visual_guidelines`:
+
+- `logos[].slots[]` for renderer-facing logo selection, such as `logo_card_light`, `logo_card_dark`, `profile_mark`, and `co_brand_lockup`.
+- `format_options[].params.slots[].logo_slots[]` for connecting a creative-format `asset_group_id: "logo"` slot to the same logo-slot enum.
+- `format_options[].params.slots[].required_logo_slots[]` for declaring which logo slots need explicit coverage.
+- `color_constraints[]` for allowed/forbidden color pairings and "accent only" rules.
+- `logo_usage_rules[]` for machine-readable minimum size, clear space, and slot/context-specific placement constraints.
+- `mark_lockups[]` for co-brand, partner, and secondary-mark lockup rules: ordering, spacing, separator/keyline, and size ratios.
+
+Keep `restrictions[]` for broad prose guardrails. Do not add fields for durable asset URLs, agents, operator authorization, or trademark registrations; those already exist in `brand.json` and were simply absent from the source PDFs that triggered this review.
+
+## Problem
+
+The real-brand guideline stress test showed good coverage for most identity material:
+
+- Colors, typography, tone, and voice map cleanly.
+- Photography guidance maps cleanly to `visual_guidelines.photography`.
+- Logo asset selection maps partly to `logos[].orientation`, `logos[].background`, `logos[].variant`, and `logos[].usage`.
+- Iconography, motion, and broad restrictions map to existing `visual_guidelines` fields.
+
+Three rule types still collapse into prose:
+
+1. **Color pairing matrices.** A guide can say "yellow is accent only, never a background" or "do not pair these two palette colors." Today that goes into `restrictions[]`, so an agent cannot query the palette and mechanically filter invalid foreground/background choices.
+2. **Logo slot and usage semantics.** `logos[].usage` is human-readable. A renderer should not have to infer whether a logo is intended for a light card, dark card, profile mark, or co-brand lockup from prose or tags. A creative agent building a CTV end card also cannot reliably enforce per-logo minimum size, clear space, or "never on photography without knockout" constraints. A canonical format that asks for `asset_group_id: "logo"` also needs a way to say which renderer-facing logo slots are acceptable for that asset group.
+3. **Co-brand and secondary-mark lockups.** Partner mark ordering, keyline spacing, and optical size ratios are currently prose. This is the clearest structural gap because those rules are layout instructions, not just narrative guidance.
+
+## Non-goals
+
+- Do not make source-PDF omissions look like schema gaps. If the source guide lacks durable HTTPS logo assets, `agents`, `authorized_operators`, or `trademarks[]`, that is missing source data.
+- Do not replace `restrictions[]`. Generative systems still need prose guardrails for high-level brand judgment.
+- Do not model every design-system rule. This proposal targets rules that agents can enforce before rendering or when selecting assets.
+
+## Schema change
+
+Add definitions to `static/schemas/source/brand.json` and expose them on `visual_guidelines`.
+
+```jsonc
+{
+  "visual_guidelines": {
+    "color_constraints": [
+      {
+        "color": { "role": "market_yellow" },
+        "applies_to": ["accent"],
+        "forbidden_on": [{ "surface": "background" }],
+        "severity": "must",
+        "description": "Market yellow is accent only and must not be used as a dominant background."
+      }
+    ],
+    "logo_usage_rules": [
+      {
+        "logo_id": "primary_horizontal",
+        "logo_variant": "primary",
+        "slots": ["logo_card_light", "marketplace_listing"],
+        "minimum_size": { "height": "18px" },
+        "clear_space": "1x cap height",
+        "forbidden_contexts": ["photography_without_knockout", "yellow_background"],
+        "severity": "must"
+      }
+    ],
+    "mark_lockups": [
+      {
+        "lockup_type": "co_brand",
+        "ordering": "brand_first",
+        "separator": { "type": "keyline", "color": { "role": "text" }, "width": "1px" },
+        "min_gap": "1x clear space",
+        "partner_max_optical_weight_ratio": 1,
+        "description": "Separate partner marks with a keyline and keep partner marks optically no larger than the brand mark."
+      }
+    ]
+  }
+}
+```
+
+### `color_constraints[]`
+
+Use for rules that filter color selection:
+
+```jsonc
+{
+  "color": { "role": "market_yellow" },
+  "applies_to": ["accent"],
+  "allowed_on": [{ "surface": "accent" }],
+  "forbidden_on": [{ "surface": "background" }, { "surface": "text" }],
+  "never_pair_with": [{ "role": "lettuce_green" }],
+  "contexts": ["digital", "print", "ctv_end_card"],
+  "severity": "must",
+  "description": "Market yellow is accent only."
+}
+```
+
+`color` and list entries use a `color_ref` shape:
+
+- `{ "role": "primary" }` references a key in `colors`.
+- `{ "value": "#FFD449" }` references a literal color.
+- `{ "surface": "background" }` references a usage surface rather than a palette value.
+
+### `logo_usage_rules[]`
+
+Use for constraints that agents can check when selecting or placing a logo:
+
+```jsonc
+{
+  "logo_variant": "primary",
+  "logo_id": "primary_horizontal",
+  "logo_url": "https://assets.example/logos/primary.svg",
+  "slots": ["logo_card_light", "nav_header", "marketplace_listing"],
+  "contexts": ["display", "ctv_end_card"],
+  "minimum_size": { "height": "18px" },
+  "clear_space": "1x cap height",
+  "allowed_backgrounds": [{ "role": "white" }, { "role": "linen" }],
+  "forbidden_backgrounds": [{ "role": "market_yellow" }],
+  "forbidden_contexts": ["photography_without_knockout"],
+  "severity": "must"
+}
+```
+
+This does not deprecate `logos[].usage`; it makes the enforceable subset queryable.
+
+When multiple logo usage rules match, consumers should apply the most specific binding first:
+
+1. `logo_id`
+2. `logo_url`
+3. `slots`
+4. `logo_variant`
+5. `logo_tags`
+
+If multiple rules at the same specificity conflict, treat `severity: "must"` as blocking and surface the conflict for approval rather than choosing silently.
+
+### Bridge to `asset_group_id: "logo"`
+
+Keep the two concepts separate, but connect them explicitly:
+
+- `asset_group_id: "logo"` says the creative manifest has a logo asset group.
+- `logo_slots[]` on that format slot says which brand logo slots are acceptable for the surface.
+- `required_logo_slots[]` on that format slot says which logo slots need explicit coverage before a builder should consider the slot complete.
+- `logos[].slots[]` says which renderer-facing slots each brand logo variant supports.
+
+For example, `responsive_creative` can keep a single canonical `logo` asset group while declaring:
+
+```jsonc
+{
+  "asset_group_id": "logo",
+  "asset_type": "image",
+  "required": true,
+  "min": 1,
+  "max": 5,
+  "logo_slots": ["logo_card_light", "logo_card_dark", "marketplace_listing", "ad_end_card"],
+  "required_logo_slots": ["logo_card_light", "logo_card_dark"]
+}
+```
+
+Downstream selection algorithm:
+
+1. Read the format slot with `asset_group_id: "logo"`.
+2. Resolve slot hints from the product wire shape: `format_options[].params.slots[].logo_slots[]` on products, or `adagents.json` `formats[].params.slots[].logo_slots[]` in publisher catalogs.
+3. Filter `brand.json` `logos[]` to assets whose `slots[]` intersects the declared `logo_slots[]`.
+4. Check `required_logo_slots[]`. If a required slot has no matching logo, surface a validation warning or approval mapping; do not guess from `usage` prose.
+5. Apply `visual_guidelines.logo_usage_rules[]` for the chosen slot, including minimum size, clear space, allowed backgrounds, and forbidden contexts.
+6. If no `logo_slots[]` hint exists, fall back to `background`, `orientation`, and `variant`, then to `usage` prose only for human review or soft warnings.
+
+The enum lives at `/schemas/enums/logo-slot.json`, so implementers do not have to guess at slot strings.
+
+### `logos[].slots[]`
+
+Use `slots[]` for the renderer-facing answer to "which logo should I use here?" This is distinct from creative-format asset slots (`asset_group_id: "logo"`), which say a manifest contains a logo asset. `logos[].slots[]` says which brand logo variant is appropriate for a particular UI or creative placement.
+
+Initial canonical values, defined in `/schemas/enums/logo-slot.json`:
+
+- `logo_card_light`
+- `logo_card_dark`
+- `profile_mark`
+- `favicon`
+- `app_icon`
+- `social_profile_mark`
+- `nav_header`
+- `footer`
+- `email_header`
+- `watermark`
+- `ad_end_card`
+- `co_brand_lockup`
+- `marketplace_listing`
+
+Consumers should not guess from `tags[]` when a slot is declared. The fallback order is:
+
+1. Match `logos[].slots[]` to the requested slot.
+2. Apply `logo_usage_rules[]` for that slot.
+3. Fall back to `background`, `orientation`, and `variant`.
+4. Fall back to `usage` prose only for human review or soft warnings.
+
+### `mark_lockups[]`
+
+Use for co-brand, partner, sponsor, program, or secondary-mark lockups:
+
+```jsonc
+{
+  "lockup_type": "co_brand",
+  "ordering": "brand_first",
+  "contexts": ["partner_campaign", "sponsored_content"],
+  "separator": {
+    "type": "keyline",
+    "color": { "role": "text" },
+    "width": "1px"
+  },
+  "min_gap": "1x clear space",
+  "brand_min_optical_weight_ratio": 1,
+  "partner_max_optical_weight_ratio": 1,
+  "description": "Brand mark appears first; partner marks must not exceed the brand mark's optical weight."
+}
+```
+
+This is intentionally about layout constraints, not legal approval. Rights and authorization still belong in the brand protocol rights tasks and brand/operator authorization model.
+
+## Why optional additive fields
+
+These fields are not needed by every brand. A small brand can keep publishing `colors`, `logos`, and `restrictions[]`. A mature brand system with detailed guideline PDFs can add the structured fields incrementally. Existing consumers that ignore them remain valid.
+
+Because `visual_guidelines` already allows extension properties, adding named fields is non-breaking. Naming them in the schema gives SDKs and agent builders a stable place to look.
+
+## Fixture evidence
+
+The fictional fixtures in `static/examples/brand-json/` exercise both the current schema and the proposed fields:
+
+- `riverton-kitchen-guidelines.json`: QSR-style palette, logo, photography, and accent-only color constraints.
+- `kiran-learning-trust-guidelines.json`: foundation-style photography, mark rules, and co-brand lockup constraints.
+
+Both validate against `static/schemas/source/brand.json` and are covered by `npm run test:examples`.
+
+## Open questions
+
+1. Should lockups support multiple partner marks explicitly now, or start with aggregate partner constraints and add per-partner modeling later?
+2. Should `severity` stay at `must` / `should`, or align to a broader policy-enforcement vocabulary in a later release?

--- a/specs/brand-json-machine-readable-guidelines.md
+++ b/specs/brand-json-machine-readable-guidelines.md
@@ -233,6 +233,57 @@ The fictional fixtures in `static/examples/brand-json/` exercise both the curren
 
 Both validate against `static/schemas/source/brand.json` and are covered by `npm run test:examples`.
 
+## Brand-book ingestion workflow
+
+The same fields support an automated "brand guide PDF to draft `brand.json`" workflow, but the extraction pipeline needs two distinct asset sources. A model that reads the PDF can identify logo intent and usage rules, but it should not be treated as the source of original asset bytes.
+
+Recommended ingestion pipeline:
+
+1. Extract PDF text by page for names, colors, typography, tone, restrictions, and page-level evidence.
+2. Extract embedded image objects with deterministic IDs such as `pdf_image_0001`.
+3. Render selected pages and crop candidate regions for vector/page-art assets that do not appear as embedded images. This is especially important for primary logos, marks, color swatches, and logo variant specimens.
+4. Assign every candidate a stable local `asset_id`, source page, extraction method, crop box when applicable, dimensions, and file path.
+5. Ask a multimodal model to classify candidates by `asset_id`, not to "extract images" directly. The model output should map candidate IDs to proposed `logos[]`, `assets[]`, color swatches, typography samples, photography examples, misuse examples, and `visual_guidelines` rules.
+6. Validate every returned `asset_id` against the manifest. Treat model-reported counts and summary fields as advisory, not authoritative.
+7. Save the result as a draft with source evidence and review status. Do not publish until durable HTTPS asset URLs, operator authority, and any rights/trademark evidence are present.
+
+This produces two useful evidence layers:
+
+- **Semantic evidence**: page references and extracted rules, such as "this is the primary wordmark for dark logo cards" or "this color is accent only."
+- **Asset evidence**: concrete candidate files that reviewers can approve, replace, or reject before publishing.
+
+Ingestion systems should store candidate metadata separately from published `brand.json` fields. A candidate crop can suggest:
+
+```jsonc
+{
+  "asset_id": "candidate_logo_0007",
+  "source_page": 15,
+  "extraction_method": "rendered_page_crop",
+  "crop_box": { "x": 303, "y": 202, "width": 522, "height": 240 },
+  "proposed_logo": {
+    "id": "primary_wordmark_dark_card",
+    "variant": "wordmark",
+    "background": "dark-bg",
+    "slots": ["logo_card_dark", "marketplace_listing"]
+  },
+  "review_status": "needs_review"
+}
+```
+
+Only after review and durable hosting should it become a `logos[]` entry with a real HTTPS `url`.
+
+### Multimodal crop coordinates
+
+When using a multimodal model to identify page regions, implementations should not assume returned boxes are native rendered-image pixels. Some models return normalized coordinates. Ingesters should record the coordinate space explicitly and verify crop results with a second vision or image-quality pass before presenting candidates as usable logo assets.
+
+Minimum review checks for a logo candidate:
+
+- The crop contains the intended mark, not a solid background, text label, or guideline annotation.
+- The crop is centered and has acceptable clear space.
+- The candidate is not a misuse example, mockup, duplicate, mask, or alpha fragment.
+- The candidate's `slots[]` and `background` are consistent with the surrounding guide text.
+- The candidate has or can be replaced by a durable, authorized hosted asset URL.
+
 ## Open questions
 
 1. Should lockups support multiple partner marks explicitly now, or start with aggregate partner constraints and add per-partner modeling later?

--- a/specs/brand-json-machine-readable-guidelines.md
+++ b/specs/brand-json-machine-readable-guidelines.md
@@ -47,7 +47,7 @@ Add definitions to `static/schemas/source/brand.json` and expose them on `visual
   "visual_guidelines": {
     "color_constraints": [
       {
-        "color": { "role": "market_yellow" },
+        "color": { "name": "market_yellow" },
         "applies_to": ["accent"],
         "forbidden_on": [{ "surface": "background" }],
         "severity": "must",
@@ -69,7 +69,7 @@ Add definitions to `static/schemas/source/brand.json` and expose them on `visual
       {
         "lockup_type": "co_brand",
         "ordering": "brand_first",
-        "separator": { "type": "keyline", "color": { "role": "text" }, "width": "1px" },
+        "separator": { "type": "keyline", "color": { "name": "text" }, "width": "1px" },
         "min_gap": "1x clear space",
         "partner_max_optical_weight_ratio": 1,
         "description": "Separate partner marks with a keyline and keep partner marks optically no larger than the brand mark."
@@ -85,11 +85,11 @@ Use for rules that filter color selection:
 
 ```jsonc
 {
-  "color": { "role": "market_yellow" },
+  "color": { "name": "market_yellow" },
   "applies_to": ["accent"],
   "allowed_on": [{ "surface": "accent" }],
   "forbidden_on": [{ "surface": "background" }, { "surface": "text" }],
-  "never_pair_with": [{ "role": "lettuce_green" }],
+  "never_pair_with": [{ "name": "lettuce_green" }],
   "contexts": ["digital", "print", "ctv_end_card"],
   "severity": "must",
   "description": "Market yellow is accent only."
@@ -98,7 +98,7 @@ Use for rules that filter color selection:
 
 `color` and list entries use a `color_ref` shape:
 
-- `{ "role": "primary" }` references a key in `colors`.
+- `{ "name": "primary" }` references a key in `colors`.
 - `{ "value": "#FFD449" }` references a literal color.
 - `{ "surface": "background" }` references a usage surface rather than a palette value.
 
@@ -115,8 +115,8 @@ Use for constraints that agents can check when selecting or placing a logo:
   "contexts": ["display", "ctv_end_card"],
   "minimum_size": { "height": "18px" },
   "clear_space": "1x cap height",
-  "allowed_backgrounds": [{ "role": "white" }, { "role": "linen" }],
-  "forbidden_backgrounds": [{ "role": "market_yellow" }],
+  "allowed_backgrounds": [{ "name": "white" }, { "name": "linen" }],
+  "forbidden_backgrounds": [{ "name": "market_yellow" }],
   "forbidden_contexts": ["photography_without_knockout"],
   "severity": "must"
 }
@@ -206,7 +206,7 @@ Use for co-brand, partner, sponsor, program, or secondary-mark lockups:
   "contexts": ["partner_campaign", "sponsored_content"],
   "separator": {
     "type": "keyline",
-    "color": { "role": "text" },
+    "color": { "name": "text" },
     "width": "1px"
   },
   "min_gap": "1x clear space",

--- a/specs/brand-json-machine-readable-guidelines.md
+++ b/specs/brand-json-machine-readable-guidelines.md
@@ -47,9 +47,9 @@ Add definitions to `static/schemas/source/brand.json` and expose them on `visual
   "visual_guidelines": {
     "color_constraints": [
       {
-        "color": { "name": "market_yellow" },
+        "color": { "kind": "name", "name": "market_yellow" },
         "applies_to": ["accent"],
-        "forbidden_on": [{ "surface": "background" }],
+        "forbidden_on": [{ "kind": "surface", "surface": "background" }],
         "severity": "must",
         "description": "Market yellow is accent only and must not be used as a dominant background."
       }
@@ -69,7 +69,7 @@ Add definitions to `static/schemas/source/brand.json` and expose them on `visual
       {
         "lockup_type": "co_brand",
         "ordering": "brand_first",
-        "separator": { "type": "keyline", "color": { "name": "text" }, "width": "1px" },
+        "separator": { "type": "keyline", "color": { "kind": "name", "name": "text" }, "width": "1px" },
         "min_gap": "1x clear space",
         "partner_max_optical_weight_ratio": 1,
         "description": "Separate partner marks with a keyline and keep partner marks optically no larger than the brand mark."
@@ -85,11 +85,11 @@ Use for rules that filter color selection:
 
 ```jsonc
 {
-  "color": { "name": "market_yellow" },
+  "color": { "kind": "name", "name": "market_yellow" },
   "applies_to": ["accent"],
-  "allowed_on": [{ "surface": "accent" }],
-  "forbidden_on": [{ "surface": "background" }, { "surface": "text" }],
-  "never_pair_with": [{ "name": "lettuce_green" }],
+  "allowed_on": [{ "kind": "surface", "surface": "accent" }],
+  "forbidden_on": [{ "kind": "surface", "surface": "background" }, { "kind": "surface", "surface": "text" }],
+  "never_pair_with": [{ "kind": "name", "name": "lettuce_green" }],
   "contexts": ["digital", "print", "ctv_end_card"],
   "severity": "must",
   "description": "Market yellow is accent only."
@@ -98,9 +98,9 @@ Use for rules that filter color selection:
 
 `color` and list entries use a `color_ref` shape:
 
-- `{ "name": "primary" }` references a key in `colors`.
-- `{ "value": "#FFD449" }` references a literal color.
-- `{ "surface": "background" }` references a usage surface rather than a palette value.
+- `{ "kind": "name", "name": "primary" }` references a key in `colors`.
+- `{ "kind": "value", "value": "#FFD449" }` references a literal color.
+- `{ "kind": "surface", "surface": "background" }` references a usage surface rather than a palette value.
 
 ### `logo_usage_rules[]`
 
@@ -115,8 +115,8 @@ Use for constraints that agents can check when selecting or placing a logo:
   "contexts": ["display", "ctv_end_card"],
   "minimum_size": { "height": "18px" },
   "clear_space": "1x cap height",
-  "allowed_backgrounds": [{ "name": "white" }, { "name": "linen" }],
-  "forbidden_backgrounds": [{ "name": "market_yellow" }],
+  "allowed_backgrounds": [{ "kind": "name", "name": "white" }, { "kind": "name", "name": "linen" }],
+  "forbidden_backgrounds": [{ "kind": "name", "name": "market_yellow" }],
   "forbidden_contexts": ["photography_without_knockout"],
   "severity": "must"
 }
@@ -206,7 +206,7 @@ Use for co-brand, partner, sponsor, program, or secondary-mark lockups:
   "contexts": ["partner_campaign", "sponsored_content"],
   "separator": {
     "type": "keyline",
-    "color": { "name": "text" },
+    "color": { "kind": "name", "name": "text" },
     "width": "1px"
   },
   "min_gap": "1x clear space",

--- a/static/examples/brand-json/kiran-learning-trust-guidelines.json
+++ b/static/examples/brand-json/kiran-learning-trust-guidelines.json
@@ -277,9 +277,11 @@
         "clear_space": "1x full mark height",
         "allowed_backgrounds": [
           {
+            "kind": "name",
             "name": "warm_gray"
           },
           {
+            "kind": "name",
             "name": "white"
           }
         ],
@@ -304,6 +306,7 @@
         "separator": {
           "type": "keyline",
           "color": {
+            "kind": "name",
             "name": "charcoal"
           },
           "width": "1px"

--- a/static/examples/brand-json/kiran-learning-trust-guidelines.json
+++ b/static/examples/brand-json/kiran-learning-trust-guidelines.json
@@ -277,10 +277,10 @@
         "clear_space": "1x full mark height",
         "allowed_backgrounds": [
           {
-            "role": "warm_gray"
+            "name": "warm_gray"
           },
           {
-            "role": "white"
+            "name": "white"
           }
         ],
         "forbidden_contexts": [
@@ -304,7 +304,7 @@
         "separator": {
           "type": "keyline",
           "color": {
-            "role": "charcoal"
+            "name": "charcoal"
           },
           "width": "1px"
         },

--- a/static/examples/brand-json/kiran-learning-trust-guidelines.json
+++ b/static/examples/brand-json/kiran-learning-trust-guidelines.json
@@ -1,0 +1,404 @@
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
+  "version": "1.0",
+  "id": "kiran_learning_trust",
+  "names": [
+    {
+      "en": "Kiran Learning Trust"
+    }
+  ],
+  "last_updated": "2026-05-27T00:00:00Z",
+  "url": "https://kiran-learning.example",
+  "description": "Fictional foundation brand focused on expanding access to education, skills, and community opportunity.",
+  "industries": [
+    "philanthropy",
+    "education",
+    "economic_development"
+  ],
+  "target_audience": "Learners, community partners, funders, educators, and program operators.",
+  "properties": [
+    {
+      "type": "website",
+      "identifier": "kiran-learning.example",
+      "primary": true
+    }
+  ],
+  "logos": [
+    {
+      "id": "vertical_full_color",
+      "url": "https://assets.kiran-learning.example/logos/kiran-vertical-full-color.svg",
+      "orientation": "vertical",
+      "background": "light-bg",
+      "variant": "primary",
+      "slots": [
+        "logo_card_light",
+        "marketplace_listing",
+        "co_brand_lockup"
+      ],
+      "usage": "Preferred full-color mark for light gray or white backgrounds."
+    },
+    {
+      "id": "vertical_white",
+      "url": "https://assets.kiran-learning.example/logos/kiran-vertical-white.svg",
+      "orientation": "vertical",
+      "background": "dark-bg",
+      "variant": "secondary",
+      "slots": [
+        "logo_card_dark",
+        "ad_end_card",
+        "footer"
+      ],
+      "usage": "White mark for charcoal backgrounds and dark photography with simple negative space."
+    },
+    {
+      "id": "circle_profile_mark",
+      "url": "https://assets.kiran-learning.example/logos/kiran-circle-icon.svg",
+      "orientation": "square",
+      "background": "transparent-bg",
+      "variant": "icon",
+      "slots": [
+        "profile_mark",
+        "favicon",
+        "social_profile_mark"
+      ],
+      "usage": "Social profile mark and favicon only; do not use as a replacement for the full mark in partner lockups."
+    }
+  ],
+  "colors": {
+    "primary": "#E8562A",
+    "secondary": [
+      "#F2A01F",
+      "#FFD05A",
+      "#6AA84F"
+    ],
+    "accent": [
+      "#B8343A",
+      "#4CC7B0"
+    ],
+    "background": [
+      "#EFEAE1",
+      "#1D1B18"
+    ],
+    "text": "#1D1B18",
+    "clay": "#E8562A",
+    "gold": "#F2A01F",
+    "sun": "#FFD05A",
+    "leaf": "#6AA84F",
+    "redwood": "#B8343A",
+    "teal": "#4CC7B0",
+    "warm_gray": "#EFEAE1",
+    "charcoal": "#1D1B18",
+    "white": "#FFFFFF"
+  },
+  "fonts": {
+    "primary": {
+      "family": "Kiran Sans",
+      "fallbacks": [
+        "Helvetica",
+        "Arial",
+        "sans-serif"
+      ]
+    },
+    "secondary": {
+      "family": "Kiran Sans Narrow",
+      "fallbacks": [
+        "Helvetica",
+        "Arial",
+        "sans-serif"
+      ]
+    }
+  },
+  "tone": {
+    "voice": "clear, warm, rigorous, inclusive, and quietly optimistic",
+    "attributes": [
+      "human",
+      "specific",
+      "aspirational",
+      "grounded",
+      "inclusive",
+      "calm"
+    ],
+    "dos": [
+      "Write about people with agency and dignity.",
+      "Use direct explanations before institutional language.",
+      "Create hierarchy with simple sentences and generous space.",
+      "Use program names consistently across partner materials."
+    ],
+    "donts": [
+      "Do not use savior language.",
+      "Do not overstate program outcomes.",
+      "Do not use the mark as a word inside body copy.",
+      "Do not translate the organization name unless a localized legal name has been approved."
+    ]
+  },
+  "visual_guidelines": {
+    "photography": {
+      "realism": "natural",
+      "lighting": "soft daylight",
+      "color_temperature": "warm",
+      "contrast": "medium",
+      "depth_of_field": "medium",
+      "subject": {
+        "people": {
+          "age_range": "16+",
+          "diversity": "authentic learners, educators, and community partners",
+          "mood": [
+            "capable",
+            "focused",
+            "optimistic"
+          ]
+        },
+        "product_focus": "lifestyle",
+        "setting": "real learning and work environments",
+        "consent": "Use only consented photography with accurate location and program context."
+      },
+      "framing": {
+        "subject_position": "primary subject as focus",
+        "crop_style": "supportive environment visible around subject",
+        "perspective": "eye-level"
+      },
+      "preferred_aspect_ratios": [
+        "16:9",
+        "4:5",
+        "1:1"
+      ],
+      "tags": [
+        "authentic",
+        "community",
+        "bright color",
+        "not staged"
+      ]
+    },
+    "graphic_style": {
+      "style_type": "geometric",
+      "stroke_style": "mixed",
+      "stroke_weight": "thin outline for circle elements",
+      "tags": [
+        "simple",
+        "open",
+        "circle-based",
+        "warm"
+      ]
+    },
+    "shapes": {
+      "primary_shape": "overlapping learning circles",
+      "secondary_shapes": [
+        "outline circle",
+        "program arc",
+        "partner keyline"
+      ],
+      "usage": {
+        "max_per_layout": 2,
+        "overlap_allowed": true,
+        "ratio": "1:1.6"
+      }
+    },
+    "iconography": {
+      "style": "glyph",
+      "stroke_weight": "1.5px",
+      "corner_style": "mixed",
+      "usage": {
+        "max_per_frame": 3,
+        "size_ratio": "1:10",
+        "guidance": "Use icons for navigation, topic markers, or small explanatory cues. Do not use icons as hero images."
+      },
+      "coloration": "Use charcoal on warm gray and white on charcoal; color may emphasize one relevant element only."
+    },
+    "composition": {
+      "overlays": {
+        "gradient_style": "none"
+      },
+      "texture": {
+        "style": "none"
+      },
+      "backgrounds": {
+        "types_allowed": [
+          "solid_color",
+          "image"
+        ],
+        "guidance": "Warm gray should dominate most institutional layouts. Charcoal backgrounds signal formal or high-emphasis moments."
+      }
+    },
+    "spacing": {
+      "unit": "4px",
+      "scale": {
+        "xs": "4px",
+        "sm": "8px",
+        "md": "16px",
+        "lg": "24px",
+        "xl": "40px",
+        "2xl": "64px"
+      }
+    },
+    "logo_placement": {
+      "preferred_position": "bottom-left",
+      "min_clear_space": "1x full mark height",
+      "min_height": "24px digital / 9mm print",
+      "background_contrast": "any",
+      "configuration": "Vertical mark preferred; horizontal lockups require approval."
+    },
+    "colorways": [
+      {
+        "name": "warm_gray_dominant",
+        "foreground": "#1D1B18",
+        "background": "#EFEAE1",
+        "accent": "#E8562A"
+      },
+      {
+        "name": "charcoal_formal",
+        "foreground": "#FFFFFF",
+        "background": "#1D1B18",
+        "accent": "#F2A01F"
+      },
+      {
+        "name": "white_program",
+        "foreground": "#1D1B18",
+        "background": "#FFFFFF",
+        "accent": "#4CC7B0"
+      }
+    ],
+    "logo_usage_rules": [
+      {
+        "logo_id": "vertical_full_color",
+        "logo_variant": "primary",
+        "slots": [
+          "logo_card_light",
+          "co_brand_lockup",
+          "marketplace_listing"
+        ],
+        "contexts": [
+          "institutional",
+          "partner_campaign",
+          "program_material"
+        ],
+        "minimum_size": {
+          "height": "24px"
+        },
+        "clear_space": "1x full mark height",
+        "allowed_backgrounds": [
+          {
+            "role": "warm_gray"
+          },
+          {
+            "role": "white"
+          }
+        ],
+        "forbidden_contexts": [
+          "read_through_text",
+          "low_resolution_reproduction"
+        ],
+        "severity": "must",
+        "description": "Use the full-color vertical mark where format and background allow."
+      }
+    ],
+    "mark_lockups": [
+      {
+        "lockup_type": "co_brand",
+        "ordering": "brand_first",
+        "brand_logo_id": "vertical_full_color",
+        "contexts": [
+          "partner_campaign",
+          "sponsored_content",
+          "program_material"
+        ],
+        "separator": {
+          "type": "keyline",
+          "color": {
+            "role": "charcoal"
+          },
+          "width": "1px"
+        },
+        "min_gap": "1x clear space",
+        "brand_min_optical_weight_ratio": 1,
+        "partner_max_optical_weight_ratio": 1,
+        "severity": "must",
+        "description": "Separate partner marks with a keyline and keep partner marks optically no larger than the Kiran Learning Trust mark."
+      }
+    ],
+    "type_scale": {
+      "heading": {
+        "font": "primary",
+        "size": "56-96px",
+        "weight": "300",
+        "line_height": "1.05",
+        "letter_spacing": "0",
+        "text_transform": "none"
+      },
+      "subheading": {
+        "font": "primary",
+        "size": "32-48px",
+        "weight": "400",
+        "line_height": "1.15",
+        "letter_spacing": "0",
+        "text_transform": "none"
+      },
+      "body": {
+        "font": "secondary",
+        "size": "16-20px",
+        "weight": "400",
+        "line_height": "1.45",
+        "letter_spacing": "0",
+        "text_transform": "none"
+      },
+      "caption": {
+        "font": "secondary",
+        "size": "12-14px",
+        "weight": "500",
+        "line_height": "1.35",
+        "letter_spacing": "0",
+        "text_transform": "none"
+      }
+    },
+    "motion": {
+      "transition_style": "fade",
+      "animation_speed": "moderate",
+      "pacing": "moderate",
+      "kinetic_typography": false,
+      "tags": [
+        "build to final mark",
+        "hold final frame"
+      ]
+    },
+    "restrictions": [
+      "Use the full-color vertical mark whenever format and background allow.",
+      "Do not omit the center circle from the mark.",
+      "Do not recolor, outline, fragment, or independently resize mark elements.",
+      "Do not translate the organization name in the logo.",
+      "Do not use the mark as a read-through in text.",
+      "Do not use more than one accent color in a layout.",
+      "Do not use icons as hero imagery or replacements for photography.",
+      "In co-branding, separate partner marks with a keyline and preserve free space around each mark.",
+      "Do not give partner marks greater optical weight than the Kiran Learning Trust mark unless a signed partner agreement says otherwise."
+    ]
+  },
+  "contact": {
+    "email": "brand@kiran-learning.example"
+  },
+  "ext": {
+    "example_status": "fictional_public_schema_fitness_example",
+    "source_pattern": "Synthetic conversion from a hypothetical brand standards PDF. No real brand source text or asset URL is represented.",
+    "schema_fit_notes": {
+      "strong_fit": [
+        "colors",
+        "fonts",
+        "tone",
+        "visual_guidelines.photography",
+        "visual_guidelines.iconography",
+        "visual_guidelines.motion",
+        "visual_guidelines.restrictions",
+        "visual_guidelines.logo_usage_rules",
+        "visual_guidelines.mark_lockups",
+        "logos[].slots[]"
+      ],
+      "remaining_source_gaps": [
+        "No durable downloadable production asset package, agent declarations, or trademark registration data is modeled because the hypothetical source guide does not provide it."
+      ],
+      "not_source_gaps": [
+        "agents",
+        "authorized_operators",
+        "trademarks",
+        "asset_libraries"
+      ]
+    }
+  }
+}

--- a/static/examples/brand-json/riverton-kitchen-guidelines.json
+++ b/static/examples/brand-json/riverton-kitchen-guidelines.json
@@ -1,0 +1,369 @@
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
+  "version": "1.0",
+  "id": "riverton_kitchen",
+  "names": [
+    {
+      "en": "Riverton Kitchen"
+    }
+  ],
+  "last_updated": "2026-05-27T00:00:00Z",
+  "url": "https://riverton-kitchen.example",
+  "description": "Fictional quick-service restaurant brand positioned around crisp ingredients, flexible meals, and approachable value.",
+  "industries": [
+    "quick_service_restaurant",
+    "food_and_beverage"
+  ],
+  "target_audience": "People seeking a fast meal that still feels fresh, local, and personal.",
+  "tagline": [
+    {
+      "en": "Built fresh, close by."
+    }
+  ],
+  "logos": [
+    {
+      "id": "primary_horizontal",
+      "url": "https://assets.riverton-kitchen.example/logos/riverton-primary.svg",
+      "orientation": "horizontal",
+      "background": "light-bg",
+      "variant": "primary",
+      "slots": [
+        "logo_card_light",
+        "nav_header",
+        "email_header",
+        "marketplace_listing"
+      ],
+      "usage": "Primary wordmark for white or pale neutral backgrounds. Do not place directly over photography."
+    },
+    {
+      "id": "knockout_horizontal",
+      "url": "https://assets.riverton-kitchen.example/logos/riverton-knockout.svg",
+      "orientation": "horizontal",
+      "background": "dark-bg",
+      "variant": "secondary",
+      "slots": [
+        "logo_card_dark",
+        "ad_end_card",
+        "footer"
+      ],
+      "usage": "Knockout wordmark for dark green, slate, or photography only when contrast is high."
+    },
+    {
+      "id": "leaf_profile_mark",
+      "url": "https://assets.riverton-kitchen.example/logos/riverton-leaf-icon.svg",
+      "orientation": "square",
+      "background": "transparent-bg",
+      "variant": "icon",
+      "slots": [
+        "profile_mark",
+        "favicon",
+        "app_icon",
+        "social_profile_mark"
+      ],
+      "usage": "Use as app icon, social profile mark, or small-space brand marker; never lock up with the wordmark."
+    }
+  ],
+  "colors": {
+    "primary": "#146B3A",
+    "secondary": "#FFD449",
+    "accent": [
+      "#0E9AA7",
+      "#E95D2A"
+    ],
+    "background": "#FFFFFF",
+    "text": "#14322A",
+    "river_green": "#146B3A",
+    "market_yellow": "#FFD449",
+    "water_blue": "#0E9AA7",
+    "tomato": "#E95D2A",
+    "kale": "#14322A",
+    "linen": "#F7F2E8",
+    "white": "#FFFFFF"
+  },
+  "fonts": {
+    "primary": {
+      "family": "Riverton Display",
+      "fallbacks": [
+        "Arial",
+        "sans-serif"
+      ]
+    },
+    "secondary": {
+      "family": "Riverton Text",
+      "fallbacks": [
+        "Inter",
+        "Arial",
+        "sans-serif"
+      ]
+    }
+  },
+  "tone": {
+    "voice": "plainspoken, upbeat, specific, and neighborly",
+    "attributes": [
+      "fresh",
+      "quick",
+      "warm",
+      "confident",
+      "local",
+      "direct"
+    ],
+    "dos": [
+      "Lead with appetite and immediacy.",
+      "Use short copy that sounds like a person at the counter.",
+      "Name concrete ingredients instead of generic quality claims.",
+      "Keep headlines in sentence case."
+    ],
+    "donts": [
+      "Do not overuse freshness claims.",
+      "Do not use forced puns, rhymes, or alliteration.",
+      "Do not make premium dining claims.",
+      "Do not use all caps for headlines."
+    ]
+  },
+  "visual_guidelines": {
+    "photography": {
+      "realism": "natural",
+      "lighting": "clean studio daylight",
+      "color_temperature": "neutral",
+      "contrast": "high",
+      "depth_of_field": "medium",
+      "subject": {
+        "product_focus": "detail",
+        "setting": "studio",
+        "ingredients": "Show whole ingredients and assembled meals with visible texture and separation."
+      },
+      "framing": {
+        "subject_position": "edge-aware",
+        "crop_style": "tight product crop with generous negative space",
+        "perspective": "overhead or shallow angled table view"
+      },
+      "preferred_aspect_ratios": [
+        "1:1",
+        "4:5",
+        "16:9"
+      ],
+      "tags": [
+        "ingredient-led",
+        "bright surfaces",
+        "real food",
+        "no stock lifestyle scenes"
+      ]
+    },
+    "graphic_style": {
+      "style_type": "geometric",
+      "stroke_style": "mixed",
+      "tags": [
+        "bold",
+        "flat",
+        "ingredient shapes",
+        "simple arrows"
+      ]
+    },
+    "shapes": {
+      "primary_shape": "leaf arrow",
+      "secondary_shapes": [
+        "ingredient tiles",
+        "horizontal meal bands"
+      ],
+      "usage": {
+        "max_per_layout": 2,
+        "overlap_allowed": false
+      }
+    },
+    "iconography": {
+      "style": "flat",
+      "corner_style": "mixed",
+      "usage": {
+        "max_per_frame": 1,
+        "size_ratio": "1:12",
+        "guidance": "Use icons only for simple ordering cues, never as decorative filler."
+      }
+    },
+    "composition": {
+      "overlays": {
+        "gradient_style": "none"
+      },
+      "texture": {
+        "style": "none"
+      },
+      "backgrounds": {
+        "types_allowed": [
+          "solid_color",
+          "image",
+          "video"
+        ],
+        "guidance": "Use white, linen, or river green as dominant backgrounds. Market yellow is an accent only."
+      }
+    },
+    "logo_placement": {
+      "preferred_position": "bottom-right",
+      "min_clear_space": "1x cap height",
+      "min_height": "18px digital / 6mm print",
+      "background_contrast": "any"
+    },
+    "colorways": [
+      {
+        "name": "green_primary",
+        "foreground": "#FFFFFF",
+        "background": "#146B3A",
+        "accent": "#FFD449"
+      },
+      {
+        "name": "linen_food_story",
+        "foreground": "#14322A",
+        "background": "#F7F2E8",
+        "accent": "#E95D2A"
+      },
+      {
+        "name": "white_ordering",
+        "foreground": "#146B3A",
+        "background": "#FFFFFF",
+        "accent": "#FFD449"
+      }
+    ],
+    "color_constraints": [
+      {
+        "color": {
+          "role": "market_yellow"
+        },
+        "applies_to": [
+          "accent"
+        ],
+        "forbidden_on": [
+          {
+            "surface": "background"
+          },
+          {
+            "surface": "text"
+          },
+          {
+            "surface": "logo_background"
+          }
+        ],
+        "contexts": [
+          "digital",
+          "print",
+          "ctv_end_card"
+        ],
+        "severity": "must",
+        "description": "Market yellow is accent only and must not be used as a dominant background or behind the primary wordmark."
+      },
+      {
+        "color": {
+          "role": "market_yellow"
+        },
+        "never_pair_with": [
+          {
+            "role": "linen"
+          }
+        ],
+        "severity": "should",
+        "description": "Avoid low-energy yellow and linen combinations in food-led layouts."
+      }
+    ],
+    "logo_usage_rules": [
+      {
+        "logo_id": "primary_horizontal",
+        "logo_variant": "primary",
+        "slots": [
+          "logo_card_light",
+          "nav_header",
+          "marketplace_listing"
+        ],
+        "minimum_size": {
+          "height": "18px"
+        },
+        "clear_space": "1x cap height",
+        "allowed_backgrounds": [
+          {
+            "role": "white"
+          },
+          {
+            "role": "linen"
+          }
+        ],
+        "forbidden_backgrounds": [
+          {
+            "role": "market_yellow"
+          }
+        ],
+        "forbidden_contexts": [
+          "photography_without_knockout"
+        ],
+        "severity": "must",
+        "description": "Use the primary wordmark only when the background preserves legibility and clear space."
+      }
+    ],
+    "type_scale": {
+      "heading": {
+        "font": "primary",
+        "size": "44-96px",
+        "line_height": "1.05",
+        "letter_spacing": "0",
+        "text_transform": "none"
+      },
+      "subheading": {
+        "font": "primary",
+        "size": "24-40px",
+        "line_height": "1.1",
+        "letter_spacing": "0",
+        "text_transform": "none"
+      },
+      "body": {
+        "font": "secondary",
+        "size": "14-18px",
+        "line_height": "1.35",
+        "letter_spacing": "0",
+        "text_transform": "none"
+      },
+      "caption": {
+        "font": "secondary",
+        "size": "11-13px",
+        "line_height": "1.3",
+        "letter_spacing": "0",
+        "text_transform": "none"
+      }
+    },
+    "motion": {
+      "transition_style": "fade",
+      "animation_speed": "moderate",
+      "pacing": "moderate",
+      "kinetic_typography": false,
+      "tags": [
+        "ingredient reveal",
+        "simple end-card hold"
+      ]
+    },
+    "restrictions": [
+      "Do not recolor, outline, crop, stretch, rotate, or add effects to the wordmark.",
+      "Do not use market yellow as a dominant background.",
+      "Do not use market yellow behind the primary wordmark.",
+      "Do not place text over food photography.",
+      "Do not use gradients in typography or backgrounds.",
+      "Do not use more than four brand colors in a single layout.",
+      "Do not use stock imagery of people eating.",
+      "Do not lock the leaf icon up with the wordmark."
+    ]
+  },
+  "ext": {
+    "example_status": "fictional_public_schema_fitness_example",
+    "source_pattern": "Synthetic conversion from a hypothetical brand standards PDF. No real brand source text or asset URL is represented.",
+    "schema_fit_notes": {
+      "strong_fit": [
+        "colors",
+        "fonts",
+        "tone",
+        "visual_guidelines.photography",
+        "visual_guidelines.iconography",
+        "visual_guidelines.motion",
+        "visual_guidelines.restrictions",
+        "visual_guidelines.color_constraints",
+        "visual_guidelines.logo_usage_rules",
+        "logos[].slots[]"
+      ],
+      "remaining_source_gaps": [
+        "No durable downloadable production asset package or trademark registration data is modeled because the hypothetical source guide does not provide it."
+      ]
+    }
+  }
+}

--- a/static/examples/brand-json/riverton-kitchen-guidelines.json
+++ b/static/examples/brand-json/riverton-kitchen-guidelines.json
@@ -224,7 +224,7 @@
     "color_constraints": [
       {
         "color": {
-          "role": "market_yellow"
+          "name": "market_yellow"
         },
         "applies_to": [
           "accent"
@@ -250,11 +250,11 @@
       },
       {
         "color": {
-          "role": "market_yellow"
+          "name": "market_yellow"
         },
         "never_pair_with": [
           {
-            "role": "linen"
+            "name": "linen"
           }
         ],
         "severity": "should",
@@ -276,15 +276,15 @@
         "clear_space": "1x cap height",
         "allowed_backgrounds": [
           {
-            "role": "white"
+            "name": "white"
           },
           {
-            "role": "linen"
+            "name": "linen"
           }
         ],
         "forbidden_backgrounds": [
           {
-            "role": "market_yellow"
+            "name": "market_yellow"
           }
         ],
         "forbidden_contexts": [

--- a/static/examples/brand-json/riverton-kitchen-guidelines.json
+++ b/static/examples/brand-json/riverton-kitchen-guidelines.json
@@ -224,6 +224,7 @@
     "color_constraints": [
       {
         "color": {
+          "kind": "name",
           "name": "market_yellow"
         },
         "applies_to": [
@@ -231,12 +232,15 @@
         ],
         "forbidden_on": [
           {
+            "kind": "surface",
             "surface": "background"
           },
           {
+            "kind": "surface",
             "surface": "text"
           },
           {
+            "kind": "surface",
             "surface": "logo_background"
           }
         ],
@@ -250,10 +254,12 @@
       },
       {
         "color": {
+          "kind": "name",
           "name": "market_yellow"
         },
         "never_pair_with": [
           {
+            "kind": "name",
             "name": "linen"
           }
         ],
@@ -276,14 +282,17 @@
         "clear_space": "1x cap height",
         "allowed_backgrounds": [
           {
+            "kind": "name",
             "name": "white"
           },
           {
+            "kind": "name",
             "name": "linen"
           }
         ],
         "forbidden_backgrounds": [
           {
+            "kind": "name",
             "name": "market_yellow"
           }
         ],

--- a/static/schemas/source/brand.json
+++ b/static/schemas/source/brand.json
@@ -168,8 +168,13 @@
     },
     "color_ref": {
       "type": "object",
-      "description": "Reference to a brand color or usage surface for machine-readable guideline constraints. Use name for palette lookup keys in colors, value for a literal hex color, and surface for layout surfaces such as background or text.",
+      "description": "Reference to a brand color or usage surface for machine-readable guideline constraints. Use kind=name for palette lookup keys in colors, kind=value for a literal hex color, and kind=surface for layout surfaces such as background or text.",
       "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["name", "value", "surface"],
+          "description": "Discriminator for the color reference variant."
+        },
         "name": {
           "type": "string",
           "description": "Key from the colors object, such as market_yellow, river_green, or any custom palette key. Unambiguous lookup into colors{}."
@@ -185,9 +190,18 @@
         }
       },
       "oneOf": [
-        { "required": ["name"] },
-        { "required": ["value"] },
-        { "required": ["surface"] }
+        {
+          "properties": { "kind": { "const": "name" } },
+          "required": ["kind", "name"]
+        },
+        {
+          "properties": { "kind": { "const": "value" } },
+          "required": ["kind", "value"]
+        },
+        {
+          "properties": { "kind": { "const": "surface" } },
+          "required": ["kind", "surface"]
+        }
       ],
       "additionalProperties": false
     },
@@ -1229,6 +1243,7 @@
         "logo_tags": {
           "type": "array",
           "items": { "type": "string" },
+          "minItems": 1,
           "description": "Logo tags this rule applies to."
         },
         "contexts": {
@@ -1239,6 +1254,7 @@
         "slots": {
           "type": "array",
           "items": { "$ref": "#/definitions/logo_slot" },
+          "minItems": 1,
           "uniqueItems": true,
           "description": "Canonical renderer slots where this rule applies. Use this for deterministic logo-card, profile-mark, end-card, and lockup selection."
         },

--- a/static/schemas/source/brand.json
+++ b/static/schemas/source/brand.json
@@ -14,6 +14,14 @@
       "description": "Brand identifier within the house portfolio. Lowercase alphanumeric with underscores. House chooses this ID.",
       "pattern": "^[a-z0-9_]+$"
     },
+    "logo_slot": {
+      "$ref": "/schemas/enums/logo-slot.json"
+    },
+    "logo_id": {
+      "type": "string",
+      "description": "Stable identifier for a logo entry within this brand.json document. Use lowercase words separated by underscores or hyphens; do not key integrations on mutable asset URLs.",
+      "pattern": "^[a-z0-9][a-z0-9_-]*$"
+    },
     "trademark": {
       "type": "object",
       "description": "A registered trademark. May appear at house level (corporate marks, e.g., 'NIKE' owned by Nike, Inc.) or at brand level (brand-specific marks, e.g., 'CONVERSE' owned by Converse). Resolution between house- and brand-level trademarks is union — both lists are valid claims about marks the publisher controls.",
@@ -102,6 +110,10 @@
       "type": "object",
       "description": "Brand logo asset with structured fields for orientation, background compatibility, and variant type",
       "properties": {
+        "id": {
+          "$ref": "#/definitions/logo_id",
+          "description": "Stable identifier for this logo entry. Recommended when logo usage rules or mark lockups need to bind to a specific logo asset."
+        },
         "url": {
           "type": "string",
           "format": "uri",
@@ -127,6 +139,12 @@
           "description": "Additional semantic tags for custom categorization beyond the standard orientation, background, and variant fields",
           "items": { "type": "string" }
         },
+        "slots": {
+          "type": "array",
+          "description": "Canonical renderer slots where this logo is appropriate. Consumers SHOULD prefer this over inferring from tags or usage prose when selecting a logo for a specific UI surface.",
+          "items": { "$ref": "#/definitions/logo_slot" },
+          "uniqueItems": true
+        },
         "usage": {
           "type": "string",
           "description": "Human-readable description of when to use this logo variant (e.g., 'Primary logo for use on light backgrounds')"
@@ -147,6 +165,36 @@
         { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
         { "type": "array", "items": { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" }, "minItems": 1 }
       ]
+    },
+    "color_ref": {
+      "type": "object",
+      "description": "Reference to a brand color or usage surface for machine-readable guideline constraints. Use role for keys in colors, value for a literal hex color, and surface for layout surfaces such as background or text.",
+      "properties": {
+        "role": {
+          "type": "string",
+          "description": "Key from the colors object, such as primary, secondary, text, or a custom palette role."
+        },
+        "value": {
+          "$ref": "#/definitions/hex_color",
+          "description": "Literal hex color when no palette role exists."
+        },
+        "surface": {
+          "type": "string",
+          "enum": ["background", "foreground", "text", "logo_background", "cta", "accent", "border", "icon", "graphic_element"],
+          "description": "Usage surface rather than a specific color value."
+        }
+      },
+      "oneOf": [
+        { "required": ["role"] },
+        { "required": ["value"] },
+        { "required": ["surface"] }
+      ],
+      "additionalProperties": false
+    },
+    "guideline_severity": {
+      "type": "string",
+      "enum": ["must", "should"],
+      "description": "Strength of a machine-readable brand guideline constraint."
     },
     "colors": {
       "type": "object",
@@ -1115,6 +1163,195 @@
       "required": ["name", "foreground", "background"],
       "additionalProperties": true
     },
+    "color_constraint": {
+      "type": "object",
+      "description": "Machine-readable rule constraining how a brand color may be used or paired. Use for accent-only colors, forbidden foreground/background combinations, and palette pairs that should never appear together.",
+      "properties": {
+        "color": {
+          "$ref": "#/definitions/color_ref",
+          "description": "Color role or value this constraint governs."
+        },
+        "applies_to": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["background", "foreground", "text", "logo_background", "cta", "accent", "border", "icon", "graphic_element"]
+          },
+          "description": "Surfaces where this color may be used."
+        },
+        "allowed_on": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/color_ref" },
+          "description": "Backgrounds, surfaces, or color roles where this color is allowed."
+        },
+        "forbidden_on": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/color_ref" },
+          "description": "Backgrounds, surfaces, or color roles where this color is forbidden."
+        },
+        "never_pair_with": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/color_ref" },
+          "description": "Color roles or values that must not be paired with this color."
+        },
+        "contexts": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Channels or creative contexts where this constraint applies, such as digital, print, social, or ctv_end_card."
+        },
+        "severity": { "$ref": "#/definitions/guideline_severity" },
+        "description": {
+          "type": "string",
+          "description": "Human-readable rationale or source-language summary for the rule."
+        }
+      },
+      "required": ["color"],
+      "additionalProperties": true
+    },
+    "logo_usage_rule": {
+      "type": "object",
+      "description": "Machine-readable logo selection and placement rule. Complements logos[].usage by making enforceable minimum size, clear-space, background, and context constraints queryable.",
+      "properties": {
+        "logo_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Specific logo asset URL this rule applies to. Omit when the rule applies by variant or tags."
+        },
+        "logo_id": {
+          "$ref": "#/definitions/logo_id",
+          "description": "Stable `logos[].id` this rule applies to. Prefer this over logo_url when the rule targets a specific logo entry."
+        },
+        "logo_variant": {
+          "type": "string",
+          "enum": ["primary", "secondary", "icon", "wordmark", "full-lockup"],
+          "description": "Logo variant this rule applies to."
+        },
+        "logo_tags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Logo tags this rule applies to."
+        },
+        "contexts": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Creative contexts where this rule applies."
+        },
+        "slots": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/logo_slot" },
+          "uniqueItems": true,
+          "description": "Canonical renderer slots where this rule applies. Use this for deterministic logo-card, profile-mark, end-card, and lockup selection."
+        },
+        "minimum_size": {
+          "type": "object",
+          "description": "Minimum rendered size needed for legibility.",
+          "properties": {
+            "width": { "type": "string", "description": "Minimum width, such as 48px or 12mm." },
+            "height": { "type": "string", "description": "Minimum height, such as 18px or 6mm." }
+          },
+          "additionalProperties": false
+        },
+        "clear_space": {
+          "type": "string",
+          "description": "Minimum clear space around the logo, expressed in brand terms or units."
+        },
+        "allowed_backgrounds": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/color_ref" },
+          "description": "Background color roles, values, or surfaces where this logo may be placed."
+        },
+        "forbidden_backgrounds": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/color_ref" },
+          "description": "Background color roles, values, or surfaces where this logo must not be placed."
+        },
+        "forbidden_contexts": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Contexts where this logo must not be used, such as photography_without_knockout."
+        },
+        "severity": { "$ref": "#/definitions/guideline_severity" },
+        "description": {
+          "type": "string",
+          "description": "Human-readable rationale or source-language summary for the rule."
+        }
+      },
+      "anyOf": [
+        { "required": ["logo_id"] },
+        { "required": ["logo_url"] },
+        { "required": ["logo_variant"] },
+        { "required": ["logo_tags"] },
+        { "required": ["slots"] }
+      ],
+      "additionalProperties": true
+    },
+    "mark_lockup": {
+      "type": "object",
+      "description": "Machine-readable layout constraints for co-brand, partner, sponsor, program, or secondary-mark lockups.",
+      "properties": {
+        "lockup_type": {
+          "type": "string",
+          "enum": ["co_brand", "secondary_mark", "partner", "sponsor", "program", "talent", "custom"],
+          "description": "Type of mark relationship governed by this lockup rule."
+        },
+        "ordering": {
+          "type": "string",
+          "enum": ["brand_first", "partner_first", "equal", "contextual"],
+          "description": "Required visual ordering of the brand mark relative to partner or secondary marks."
+        },
+        "contexts": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Creative contexts where this lockup rule applies."
+        },
+        "brand_logo_id": {
+          "$ref": "#/definitions/logo_id",
+          "description": "Stable `logos[].id` for the brand logo this lockup rule is anchored on."
+        },
+        "secondary_logo_ids": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/logo_id" },
+          "uniqueItems": true,
+          "description": "Stable `logos[].id` values for secondary, program, sponsor, or partner marks governed by this lockup rule when those marks are represented in this brand.json."
+        },
+        "separator": {
+          "type": "object",
+          "description": "Separator between marks, when required.",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["none", "keyline", "space", "divider"],
+              "description": "Separator style."
+            },
+            "color": { "$ref": "#/definitions/color_ref" },
+            "width": { "type": "string", "description": "Separator width, such as 1px." }
+          },
+          "required": ["type"],
+          "additionalProperties": true
+        },
+        "min_gap": {
+          "type": "string",
+          "description": "Minimum gap between marks, expressed in brand terms or units."
+        },
+        "brand_min_optical_weight_ratio": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Minimum optical weight of the brand mark relative to partner marks. 1 means at least equal."
+        },
+        "partner_max_optical_weight_ratio": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Maximum optical weight of partner marks relative to the brand mark. 1 means no larger than the brand mark."
+        },
+        "severity": { "$ref": "#/definitions/guideline_severity" },
+        "description": {
+          "type": "string",
+          "description": "Human-readable rationale or source-language summary for the lockup rule."
+        }
+      },
+      "required": ["lockup_type"],
+      "additionalProperties": true
+    },
     "type_scale_entry": {
       "type": "object",
       "description": "A single entry in the type scale",
@@ -1316,6 +1553,21 @@
           "type": "array",
           "items": { "$ref": "#/definitions/colorway" },
           "description": "Named color pairings for consistent foreground/background combinations"
+        },
+        "color_constraints": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/color_constraint" },
+          "description": "Machine-readable constraints for color usage and pairings, such as accent-only rules or forbidden foreground/background combinations."
+        },
+        "logo_usage_rules": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/logo_usage_rule" },
+          "description": "Machine-readable logo selection and placement constraints for minimum size, clear space, backgrounds, and contexts."
+        },
+        "mark_lockups": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/mark_lockup" },
+          "description": "Machine-readable co-brand, partner, sponsor, program, or secondary-mark lockup rules."
         },
         "type_scale": {
           "type": "object",

--- a/static/schemas/source/brand.json
+++ b/static/schemas/source/brand.json
@@ -168,15 +168,15 @@
     },
     "color_ref": {
       "type": "object",
-      "description": "Reference to a brand color or usage surface for machine-readable guideline constraints. Use role for keys in colors, value for a literal hex color, and surface for layout surfaces such as background or text.",
+      "description": "Reference to a brand color or usage surface for machine-readable guideline constraints. Use name for palette lookup keys in colors, value for a literal hex color, and surface for layout surfaces such as background or text.",
       "properties": {
-        "role": {
+        "name": {
           "type": "string",
-          "description": "Key from the colors object, such as primary, secondary, text, or a custom palette role."
+          "description": "Key from the colors object, such as market_yellow, river_green, or any custom palette key. Unambiguous lookup into colors{}."
         },
         "value": {
           "$ref": "#/definitions/hex_color",
-          "description": "Literal hex color when no palette role exists."
+          "description": "Literal hex color when no palette key exists."
         },
         "surface": {
           "type": "string",
@@ -185,7 +185,7 @@
         }
       },
       "oneOf": [
-        { "required": ["role"] },
+        { "required": ["name"] },
         { "required": ["value"] },
         { "required": ["surface"] }
       ],
@@ -1341,7 +1341,7 @@
         "partner_max_optical_weight_ratio": {
           "type": "number",
           "exclusiveMinimum": 0,
-          "description": "Maximum optical weight of partner marks relative to the brand mark. 1 means no larger than the brand mark."
+          "description": "Maximum optical weight of partner marks relative to the brand mark. 1 means no larger than the brand mark. Enforcement is at layout time, not parse time — this value signals to renderers and creative agents how much space to provision for each mark."
         },
         "severity": { "$ref": "#/definitions/guideline_severity" },
         "description": {

--- a/static/schemas/source/core/asset-group-vocabulary.json
+++ b/static/schemas/source/core/asset-group-vocabulary.json
@@ -3,8 +3,8 @@
   "$id": "/schemas/core/asset-group-vocabulary.json",
   "title": "AdCP Asset Group Vocabulary Registry",
   "description": "Canonical registry of asset_group_id values used in offering asset groups (OfferingAssetGroup) and in v2 product format declarations. Non-canonical IDs remain valid for platform-specific extensions; this registry codifies the recommended canonical set so that buyers and sellers share a vocabulary for the most common slot roles. Validators may emit soft warnings on non-canonical IDs to encourage convergence.\n\nThe registry covers everything the buyer ships in the manifest's `assets` map — both directly-rendered creative content (image, video, audio) AND content the seller consumes for production (script, creative_brief, video_brief). The seller dispatches per the format's slot declaration. There is no separate \"inputs\" map on the manifest; everything is an asset.\n\n**Two-tier boundary (normative).** This registry is the *canonical, portable* tier — IAB-aligned, platform-agnostic slot roles every adopter shares (`headline`, `body_text`, `main_image`, `cta`, `landing_page_url`, etc.). Platform-specific asset identifiers (e.g., YouTube video IDs, Pinterest pin IDs, TikTok video IDs, Snap attachment IDs, Meta Advantage+ creative IDs) MUST NOT be added here — they live on the canonical's `platform_extensions[]` (URI+digest reference to the platform's extension schema) so the canonical registry stays portable. Earlier drafts carried `youtube_video_id` and `pin_id` here; they were dropped in 3.1 GA precisely because adding them set precedent for every platform's identifier vocabulary to leak into the canonical tier, defeating the registry's portability purpose. Adopters needing to reference an existing platform-hosted asset attach a `platform_extensions[]` entry on the format declaration whose extension schema defines the platform-specific ID slot.",
-  "version": "1.1.0",
-  "lastUpdated": "2026-04-28",
+  "version": "1.2.0",
+  "lastUpdated": "2026-05-28",
   "vocabulary": {
     "headlines": {
       "description": "Pool of headline text variants for the surface to choose from.",
@@ -43,9 +43,22 @@
       "aliases": ["square_image", "feed_image"]
     },
     "logo": {
-      "description": "Brand logo asset (typically 1:1 or 2:1).",
+      "description": "Brand logo asset (typically 1:1 or 2:1). When the logo comes from brand.json, select from `logos[]` using the format slot's `logo_slots` hint, the asset's `logos[].slots[]`, and `visual_guidelines.logo_usage_rules[]`. `asset_group_id: \"logo\"` names the creative manifest slot; logo slots name the renderer-facing placements where a brand logo variant is appropriate.",
       "asset_type": "image",
       "typical_use": "Brand attribution overlay (Google PMax/RDA, Snap Story Ad, Amazon SB).",
+      "brand_json_bridge": {
+        "source": "brand.json logos[]",
+        "selection_fields": [
+          "format_options[].params.slots[].logo_slots",
+          "adagents.json formats[].params.slots[].logo_slots",
+          "logos[].slots[]",
+          "logos[].id",
+          "visual_guidelines.logo_usage_rules[]",
+          "logos[].background",
+          "logos[].orientation",
+          "logos[].variant"
+        ]
+      },
       "aliases": ["brand_logo", "logo_image"]
     },
     "video": {

--- a/static/schemas/source/enums/logo-slot.json
+++ b/static/schemas/source/enums/logo-slot.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/enums/logo-slot.json",
+  "title": "Logo Slot",
+  "description": "Canonical renderer-facing logo slot. Use when selecting a logo variant from brand.json for a specific UI or creative placement.",
+  "type": "string",
+  "enum": [
+    "logo_card_light",
+    "logo_card_dark",
+    "profile_mark",
+    "favicon",
+    "app_icon",
+    "social_profile_mark",
+    "nav_header",
+    "footer",
+    "email_header",
+    "watermark",
+    "ad_end_card",
+    "co_brand_lockup",
+    "marketplace_listing"
+  ],
+  "enumDescriptions": {
+    "logo_card_light": "Logo rendered in a card or framed placement on a light background.",
+    "logo_card_dark": "Logo rendered in a card or framed placement on a dark background.",
+    "profile_mark": "Small square logo mark for profile-style UI. Distinct from brand.json's top-level animated or conversational avatar object.",
+    "favicon": "Browser favicon or similarly tiny tab/bookmark icon.",
+    "app_icon": "Application icon or launcher icon.",
+    "social_profile_mark": "Social profile logo mark or feed identity mark.",
+    "nav_header": "Primary navigation header logo.",
+    "footer": "Footer logo.",
+    "email_header": "Email header logo.",
+    "watermark": "Subtle watermark or bug.",
+    "ad_end_card": "Advertising end card, especially video or CTV.",
+    "co_brand_lockup": "Co-brand, partner, sponsor, or secondary-mark lockup.",
+    "marketplace_listing": "Marketplace, catalog, directory, or store listing logo."
+  }
+}

--- a/static/schemas/source/formats/canonical/_base.json
+++ b/static/schemas/source/formats/canonical/_base.json
@@ -90,6 +90,18 @@
             "minimum": 1,
             "description": "Per-slot file size limit in kilobytes. Valid only when `asset_type` is `image`, `video`, `audio`, or `zip`. Mutually exclusive with `max_chars` (which applies to text asset types). Schema enforces via if/then so a producer can't set both on the same slot."
           },
+          "logo_slots": {
+            "type": "array",
+            "items": { "$ref": "/schemas/enums/logo-slot.json" },
+            "uniqueItems": true,
+            "description": "When `asset_group_id` is `logo`, renderer-facing brand.json logo slots acceptable for this format slot. Producers selecting from brand.json SHOULD prefer `logos[]` entries whose `slots[]` intersects this list, then apply `visual_guidelines.logo_usage_rules[]`."
+          },
+          "required_logo_slots": {
+            "type": "array",
+            "items": { "$ref": "/schemas/enums/logo-slot.json" },
+            "uniqueItems": true,
+            "description": "Subset of `logo_slots` for which this format expects explicit logo coverage. A manifest or brand-derived logo pool SHOULD include at least one usable logo for each required slot; if coverage is missing, builders SHOULD surface a validation warning or approval mapping instead of guessing from prose."
+          },
           "description": {
             "type": "string",
             "description": "Human-readable description of what the slot expects from the buyer."

--- a/static/schemas/source/formats/canonical/_base.json
+++ b/static/schemas/source/formats/canonical/_base.json
@@ -130,6 +130,21 @@
             "then": { "not": { "required": ["max_chars"] } }
           },
           {
+            "$comment": "Logo slot narrowing is only meaningful on the canonical logo asset group.",
+            "if": {
+              "not": {
+                "properties": { "asset_group_id": { "const": "logo" } },
+                "required": ["asset_group_id"]
+              }
+            },
+            "then": {
+              "not": { "anyOf": [
+                { "required": ["logo_slots"] },
+                { "required": ["required_logo_slots"] }
+              ] }
+            }
+          },
+          {
             "$comment": "Non-size asset types (url, catalog, html, css, javascript, webhook, daast, vast, card, object, pixel_tracker, vast_tracker, daast_tracker) reject both — there's no defined per-slot size semantics on those.",
             "if": {
               "properties": { "asset_type": { "enum": ["url", "catalog", "html", "css", "javascript", "webhook", "daast", "vast", "card", "object", "pixel_tracker", "vast_tracker", "daast_tracker"] } },

--- a/static/schemas/source/formats/canonical/responsive_creative.json
+++ b/static/schemas/source/formats/canonical/responsive_creative.json
@@ -22,7 +22,7 @@
         { "asset_group_id": "images_square", "asset_type": "image", "required": false, "min": 1, "max": 20 },
         { "asset_group_id": "images_vertical", "asset_type": "image", "required": false, "min": 1, "max": 20 },
         { "asset_group_id": "video", "asset_type": "video", "required": false, "min": 0, "max": 5 },
-        { "asset_group_id": "logo", "asset_type": "image", "required": true, "min": 1, "max": 5 },
+        { "asset_group_id": "logo", "asset_type": "image", "required": true, "min": 1, "max": 5, "logo_slots": ["logo_card_light", "logo_card_dark", "marketplace_listing", "ad_end_card"], "required_logo_slots": ["logo_card_light", "logo_card_dark"] },
         { "asset_group_id": "landing_page_url", "asset_type": "url", "required": true, "min": 1, "max": 1 }
       ]
     },

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -584,6 +584,10 @@
           "$ref": "/schemas/enums/creative-quality.json",
           "description": "Quality tier for creative generation (draft, production)"
         },
+        "logo-slot": {
+          "$ref": "/schemas/enums/logo-slot.json",
+          "description": "Renderer-facing logo slots for selecting brand.json logo variants"
+        },
         "pacing": {
           "$ref": "/schemas/enums/pacing.json",
           "description": "Budget pacing strategy"

--- a/tests/example-validation-simple.test.cjs
+++ b/tests/example-validation-simple.test.cjs
@@ -151,6 +151,23 @@ async function runTests() {
     await validateExample(example.data, example.schema, example.description);
   }
 
+  for (const fixture of [
+    {
+      path: 'static/examples/brand-json/riverton-kitchen-guidelines.json',
+      description: 'fictional Riverton Kitchen brand.json guideline mapping fixture'
+    },
+    {
+      path: 'static/examples/brand-json/kiran-learning-trust-guidelines.json',
+      description: 'fictional Kiran Learning Trust brand.json guideline mapping fixture'
+    }
+  ]) {
+    await validateExample(
+      JSON.parse(fs.readFileSync(path.join(__dirname, '..', fixture.path), 'utf8')),
+      '/schemas/brand.json',
+      fixture.description
+    );
+  }
+
   // Test request/response examples
   await validateExample(
     {

--- a/tests/schema-validation.test.cjs
+++ b/tests/schema-validation.test.cjs
@@ -202,6 +202,14 @@ function validateRegistryConsistency() {
   if (missingSchemas.length > 0) {
     return `Registry references missing schemas: ${missingSchemas.join(', ')}`;
   }
+
+  const requiredDiscoverableSchemas = [
+    '/schemas/enums/logo-slot.json'
+  ];
+  const missingRegistryRefs = requiredDiscoverableSchemas.filter(ref => !registryRefs.has(ref));
+  if (missingRegistryRefs.length > 0) {
+    return `Required schemas missing from registry: ${missingRegistryRefs.join(', ')}`;
+  }
   
   return true;
 }


### PR DESCRIPTION
Adds machine-readable brand guideline constraints to brand.json, including stable logo IDs, logo slots, color constraints, logo usage rules, and mark lockups.

Connects creative format asset_group_id: "logo" to brand.json selection via logo_slots and required_logo_slots, with docs for downstream renderer behavior.

Adds fictional brand guideline fixtures and validation coverage for the new schema surfaces.

Validated with build:schemas, test:schemas, test:examples, test:canonical-conventions, test:docs-nav, precommit, and push-time docs link checks.

Refs #5090.