### PR TITLE
fix(registry): allow admin refresh reruns

### DIFF
--- a/.changeset/admin-refresh-reruns.md
+++ b/.changeset/admin-refresh-reruns.md
@@ -1,0 +1,4 @@
+---
+---
+
+Empty changeset: server/admin behavior only. Allows the static admin API key to trigger registry refresh compliance reruns for already-registered agents, matching existing owner/admin refresh behavior without changing the AdCP protocol surface.

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -2304,7 +2304,7 @@ registry.registerPath({
   operationId: "refreshAgent",
   summary: "Refresh agent snapshot",
   description:
-    "Re-probe the agent and update its registry health (online, tools_count, response_time_ms), capability snapshot (inferred type, discovered tools), and compliance verdict (storyboard pass/fail counts). Use after fixing your agent so the registry shows fresh data without waiting for the periodic heartbeat (~1h).\n\n**Compliance re-run:** when the caller owns the agent and the capability probe succeeds, the full storyboard suite runs (~30–90s) with a fresh test session and `agent_storyboard_status` is updated under `triggered_by: 'owner_test'`. Badge fan-out reissues verification badges off the new run. If the compliance call fails (timeout, OAuth wall, internal error), the capability/health portion still returns successfully — `compliance.ran` is `false` with an `error` string.\n\n**Auth:** owner of the agent or AAO admin.\n\n**Rate limits:** 60 seconds per agent URL, 30 requests per user per hour.",
+    "Re-probe the agent and update its registry health (online, tools_count, response_time_ms), capability snapshot (inferred type, discovered tools), and compliance verdict (storyboard pass/fail counts). Use after fixing your agent so the registry shows fresh data without waiting for the periodic heartbeat (~1h).\n\n**Compliance re-run:** when the caller owns the agent or is an AAO admin and the capability probe succeeds, the full storyboard suite runs (~30–90s) with a fresh test session and `agent_storyboard_status` is updated. Owner-triggered runs use `triggered_by: 'owner_test'`; admin-triggered support runs use `triggered_by: 'manual'`. Badge fan-out reissues verification badges off the new run. If the compliance call fails (timeout, OAuth wall, internal error), the capability/health portion still returns successfully — `compliance.ran` is `false` with an `error` string.\n\n**Auth:** owner of the agent, AAO admin, or static `ADMIN_API_KEY`.\n\n**Rate limits:** 60 seconds per agent URL, 30 requests per user per hour.",
   tags: ["Agent Compliance"],
   security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
@@ -5416,14 +5416,16 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       // Dev-admin fallback is gated behind `isDevModeEnabled()` to match
       // `requireAdmin`'s pattern in middleware/auth.ts — in production
       // (no DEV_USER_EMAIL/DEV_USER_ID) this branch never fires.
+      const isStaticAdmin = isStaticAdminRequest(req);
       const [isOwner, isAaoAdmin] = await Promise.all([
         verifyAgentOwnership(req.user.id, agentUrl),
         isWebUserAAOAdmin(req.user.id),
       ]);
       const isDevAdmin = isDevModeEnabled() && getDevUser(req)?.isAdmin === true;
-      if (!isOwner && !isAaoAdmin && !isDevAdmin) {
+      if (!isOwner && !isAaoAdmin && !isDevAdmin && !isStaticAdmin) {
         return res.status(403).json({ error: "You do not have permission to refresh this agent" });
       }
+      const canRunCompliance = isOwner || isAaoAdmin || isDevAdmin || isStaticAdmin;
 
       const now = Date.now();
 
@@ -5494,10 +5496,11 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         error?: string;
       } = { ran: false };
 
-      if (ownerOrgId && !probeResult.error && !probeResult.oauth_required) {
+      if (canRunCompliance && !probeResult.error && !probeResult.oauth_required) {
         const complianceStart = Date.now();
         try {
           const testSessionId = `owner-refresh-${Date.now()}-${randomUUID()}`;
+          const triggeredBy = ownerOrgId ? 'owner_test' : 'manual';
           const complyResult = await comply(agentUrl, {
             test_session_id: testSessionId,
             timeout_ms: 90_000,
@@ -5519,7 +5522,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
               complyResult,
               agentUrl,
               metadata?.lifecycle_stage || 'production',
-              'owner_test',
+              triggeredBy,
             );
             dbInput.dry_run = false;
             dbInput.triggered_org_id = ownerOrgId;

--- a/server/tests/integration/registry-api-agent-refresh.test.ts
+++ b/server/tests/integration/registry-api-agent-refresh.test.ts
@@ -23,6 +23,7 @@ const RUN_SUFFIX = Math.random().toString(36).slice(2, 8);
 const OWNER_USER_ID = `user_test_refresh_owner_${RUN_SUFFIX}`;
 const OTHER_USER_ID = `user_test_refresh_other_${RUN_SUFFIX}`;
 const ADMIN_USER_ID = `user_test_refresh_admin_${RUN_SUFFIX}`;
+const STATIC_ADMIN_USER_ID = 'admin_api_key';
 const TEST_ORG_ID = `org_test_refresh_${RUN_SUFFIX}`;
 // Each test that expects a 200 uses its own URL — the per-agent rate-limit
 // closure inside the router is stateful across test cases, so reusing one
@@ -38,6 +39,7 @@ const ALL_OWNED_URLS = [
   ownedAgentUrl('rate-limit'),
   ownedAgentUrl('saved-bearer'),
   ownedAgentUrl('badge-fanout'),
+  ownedAgentUrl('static-admin'),
 ];
 
 // Toggle which user the auth middleware stamps onto the request. Tests
@@ -46,20 +48,25 @@ let currentUserId: string | null = OWNER_USER_ID;
 
 vi.mock('../../src/middleware/auth.js', async () => {
   const actual = await vi.importActual<Record<string, unknown>>('../../src/middleware/auth.js');
-  const requireAuth = (req: { user?: unknown }, res: { status: (n: number) => { json: (b: unknown) => void } }, next: () => void) => {
+  const stampUser = (req: { user?: unknown; isStaticAdminApiKey?: boolean }) => {
+    if (currentUserId === null) return;
+    req.user = { id: currentUserId, email: `${currentUserId}@test.com` };
+    if (currentUserId === STATIC_ADMIN_USER_ID) {
+      req.isStaticAdminApiKey = true;
+    }
+  };
+  const requireAuth = (req: { user?: unknown; isStaticAdminApiKey?: boolean }, res: { status: (n: number) => { json: (b: unknown) => void } }, next: () => void) => {
     if (currentUserId === null) {
       return res.status(401).json({ error: 'Authentication required' });
     }
-    req.user = { id: currentUserId, email: `${currentUserId}@test.com` };
+    stampUser(req);
     next();
   };
   return {
     ...actual,
     requireAuth,
-    optionalAuth: (req: { user?: unknown }, _res: unknown, next: () => void) => {
-      if (currentUserId !== null) {
-        req.user = { id: currentUserId, email: `${currentUserId}@test.com` };
-      }
+    optionalAuth: (req: { user?: unknown; isStaticAdminApiKey?: boolean }, _res: unknown, next: () => void) => {
+      stampUser(req);
       next();
     },
     requireAdmin: (_req: unknown, _res: unknown, next: () => void) => next(),
@@ -266,6 +273,42 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
     const res = await request(app).post(url(agentUrl)).send();
     expect(res.status).toBe(200);
     expect(refreshSingleAgentMock).toHaveBeenCalledWith(agentUrl, expect.any(Object));
+  });
+
+  it('static admin API key can refresh and rerun compliance for an agent it does not own', async () => {
+    currentUserId = STATIC_ADMIN_USER_ID;
+    const agentUrl = ownedAgentUrl('static-admin');
+
+    const res = await request(app).post(url(agentUrl)).send();
+
+    expect(res.status).toBe(200);
+    expect(res.body.compliance).toMatchObject({
+      ran: true,
+      overall_status: 'passing',
+      storyboards_passing: 1,
+      storyboards_total: 1,
+    });
+    expect(refreshSingleAgentMock).toHaveBeenCalledWith(agentUrl, expect.any(Object));
+    expect(complyMock).toHaveBeenCalledWith(
+      agentUrl,
+      expect.objectContaining({
+        timeout_ms: 90_000,
+        userAgent: AAO_UA_COMPLIANCE,
+      }),
+    );
+
+    const latestRun = await pool.query(
+      `SELECT triggered_by, triggered_org_id
+       FROM agent_compliance_runs
+       WHERE agent_url = $1
+       ORDER BY tested_at DESC
+       LIMIT 1`,
+      [agentUrl],
+    );
+    expect(latestRun.rows[0]).toMatchObject({
+      triggered_by: 'manual',
+      triggered_org_id: null,
+    });
   });
 
   it('non-owner non-admin gets 403', async () => {

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -6835,9 +6835,9 @@ paths:
       description: |-
         Re-probe the agent and update its registry health (online, tools_count, response_time_ms), capability snapshot (inferred type, discovered tools), and compliance verdict (storyboard pass/fail counts). Use after fixing your agent so the registry shows fresh data without waiting for the periodic heartbeat (~1h).
 
-        **Compliance re-run:** when the caller owns the agent and the capability probe succeeds, the full storyboard suite runs (~30–90s) with a fresh test session and `agent_storyboard_status` is updated under `triggered_by: 'owner_test'`. Badge fan-out reissues verification badges off the new run. If the compliance call fails (timeout, OAuth wall, internal error), the capability/health portion still returns successfully — `compliance.ran` is `false` with an `error` string.
+        **Compliance re-run:** when the caller owns the agent or is an AAO admin and the capability probe succeeds, the full storyboard suite runs (~30–90s) with a fresh test session and `agent_storyboard_status` is updated. Owner-triggered runs use `triggered_by: 'owner_test'`; admin-triggered support runs use `triggered_by: 'manual'`. Badge fan-out reissues verification badges off the new run. If the compliance call fails (timeout, OAuth wall, internal error), the capability/health portion still returns successfully — `compliance.ran` is `false` with an `error` string.
 
-        **Auth:** owner of the agent or AAO admin.
+        **Auth:** owner of the agent, AAO admin, or static `ADMIN_API_KEY`.
 
         **Rate limits:** 60 seconds per agent URL, 30 requests per user per hour.
       tags:


### PR DESCRIPTION
## Summary
Allow static `ADMIN_API_KEY` requests through the agent refresh authorization gate and run compliance as a manual support-triggered rerun when no owner org is present. Owner refreshes still record `owner_test` with `triggered_org_id`, while admin support refreshes record `manual` with no org attribution. Updated the refresh endpoint OpenAPI text and added integration coverage for the static admin API key path.

## Validation
`npm run typecheck` passed, and the commit prehook passed `test:unit`, `test:test-dynamic-imports`, `test:callapi-state-change`, and `typecheck`; the focused Postgres integration test could not run locally because the test DB on `localhost:53198` was unavailable (`ECONNREFUSED`).