### PR TITLE
feat(certification): add S2 canonical formats delta path

### DIFF
--- a/.changeset/s2-canonical-formats-delta.md
+++ b/.changeset/s2-canonical-formats-delta.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add gated S2 canonical-formats delta status and assessment entry path for pre-3.1 Creative specialist holders.

--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -392,8 +392,9 @@ function getCriterionIds(mod: certDb.CertificationModule | null): string[] {
 function checkDemonstrations(
   mod: certDb.CertificationModule | null,
   checkpoint: certDb.TeachingCheckpoint,
+  requiredIds?: readonly string[],
 ): string | null {
-  const allIds = getCriterionIds(mod);
+  const allIds = requiredIds ? [...requiredIds] : getCriterionIds(mod);
   if (allIds.length === 0) return null;
 
   const verified = new Set(checkpoint.demonstrations_verified ?? []);
@@ -412,6 +413,15 @@ function checkDemonstrations(
 
   const details = unverified.map(id => `${id}: ${idToText.get(id) || id}`);
   return `Required demonstrations not yet verified:\n- ${details.join('\n- ')}\n\nVerify each through conversation, then save a checkpoint with demonstrations_verified (using criterion IDs) before completing.`;
+}
+
+function checkCriterionEvidence(
+  requiredIds: readonly string[],
+  evidenceByCriterionId: Record<string, string>,
+): string | null {
+  const missingEvidence = requiredIds.filter(id => !evidenceByCriterionId[id]?.trim());
+  if (missingEvidence.length === 0) return null;
+  return `Required demonstration evidence is missing for:\n- ${missingEvidence.join('\n- ')}\n\nSave a checkpoint with demonstration_evidence for each criterion ID before completing.`;
 }
 
 /**
@@ -543,6 +553,16 @@ function buildShareLinks(
 
   lines.push('- [View all credentials](/certification.html)');
   return lines;
+}
+
+function formatUtcDate(value: string | null): string {
+  if (!value) return 'the published deadline';
+  return new Date(value).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
 }
 
 /**
@@ -1963,12 +1983,13 @@ export function createCertificationToolHandlers(
     if (!userId) return 'You need to be logged in to see your certification progress.';
 
     try {
-      const [progress, trackProgress, credentials, userCredentials, tracks] = await Promise.all([
+      const [progress, trackProgress, credentials, userCredentials, tracks, s2DeltaStatus] = await Promise.all([
         certDb.getProgress(userId),
         certDb.getTrackProgress(userId),
         certDb.getCredentials(),
         certDb.getUserCredentials(userId),
         certDb.getTracks(),
+        certDb.getS2CanonicalFormatsDeltaStatus(userId),
       ]);
 
       const lines: string[] = ['# Your certification progress\n'];
@@ -1983,6 +2004,21 @@ export function createCertificationToolHandlers(
         for (const cred of earnedCreds) {
           const uc = userCredentials.find(u => u.credential_id === cred.id);
           lines.push(`- **${cred.name}** (Level ${cred.tier}) — earned ${uc ? new Date(uc.awarded_at).toLocaleDateString() : ''}`);
+        }
+        lines.push('');
+      }
+
+      if (s2DeltaStatus.active && s2DeltaStatus.status !== 'not_required') {
+        lines.push('## Protocol updates');
+        if (s2DeltaStatus.status === 'delta_available') {
+          lines.push(`- **S2 Creative canonical formats update** — complete the S2 canonical formats delta by ${formatUtcDate(s2DeltaStatus.delta_window_closes_at)} to keep the S2 credential current without retaking the full module.`);
+          lines.push(`  Remaining criteria: ${s2DeltaStatus.missing_criterion_ids.join(', ')}`);
+          lines.push('  If you believe you were targeted in error, email certification@agenticadvertising.org for review.');
+          lines.push('  To begin, say "start capstone S2".');
+        } else if (s2DeltaStatus.status === 'delta_completed') {
+          lines.push('- **S2 Creative canonical formats update** — completed.');
+        } else if (s2DeltaStatus.status === 'full_recertification_required') {
+          lines.push('- **S2 Creative canonical formats update** — the delta path is no longer available. The current S2 module is required for renewal.');
         }
         lines.push('');
       }
@@ -2168,6 +2204,74 @@ export function createCertificationToolHandlers(
       // Prevent restarting completed modules
       const existingMod = await certDb.getModuleProgress(userId, moduleId);
       if (existingMod && (existingMod.status === 'completed' || existingMod.status === 'tested_out')) {
+        if (moduleId === certDb.S2_CANONICAL_FORMATS_MODULE_ID) {
+          const s2DeltaStatus = await certDb.getS2CanonicalFormatsDeltaStatus(userId);
+          if (
+            s2DeltaStatus.active
+            && (s2DeltaStatus.status === 'delta_available' || s2DeltaStatus.status === 'delta_completed')
+          ) {
+            const expired = await certDb.expireStaleAttempts(userId, moduleId);
+            if (expired > 0) {
+              logger.info({ userId, moduleId, expired }, 'Auto-expired stale S2 delta attempts');
+            }
+            const active = await certDb.getActiveAttemptForModule(userId, moduleId);
+            if (active) {
+              return `You already have an active S2 canonical formats delta attempt (started ${new Date(active.started_at).toLocaleDateString()}). Continue the delta assessment.\n\nAttempt ID: ${active.id}`;
+            }
+          }
+          if (s2DeltaStatus.active && s2DeltaStatus.status === 'full_recertification_required') {
+            const active = await certDb.getActiveAttemptForModule(userId, moduleId);
+            if (active) {
+              await certDb.cancelAttempt(active.id, 'S2 canonical formats delta window closed');
+            }
+            return `S2 is complete, but the AdCP 3.1 canonical-formats delta window is no longer available. The current S2 module is required for renewal. Contact certification@agenticadvertising.org to reset this module for full recertification.`;
+          }
+          if (s2DeltaStatus.active && s2DeltaStatus.status === 'delta_completed') {
+            return `The S2 canonical formats delta is already complete. Deadline: ${formatUtcDate(s2DeltaStatus.delta_window_closes_at)}.`;
+          }
+          if (s2DeltaStatus.active && s2DeltaStatus.status === 'delta_available') {
+
+            const attempt = await certDb.createAttempt(userId, mod.track_id, options?.threadId, moduleId);
+            const exercises = mod.exercise_definitions as certDb.ExerciseDefinition[] | null;
+            const criteria = mod.assessment_criteria as certDb.AssessmentCriteria | null;
+            const required = new Set(s2DeltaStatus.missing_criterion_ids);
+            const lines = [
+              `# S2 Creative canonical formats delta`,
+              '',
+              `Attempt ID: ${attempt.id}`,
+              `Deadline: ${formatUtcDate(s2DeltaStatus.delta_window_closes_at)}`,
+              '',
+              'This is a targeted AdCP 3.1 protocol update for an existing S2 Creative specialist holder. Assess only the canonical-format criteria listed here; do not retake the full S2 module unless the learner asks for a full review.',
+              '',
+              '## Required delta demonstrations',
+            ];
+
+            for (const ex of exercises ?? []) {
+              const matching = ex.success_criteria.filter(sc => required.has(sc.id));
+              if (matching.length === 0) continue;
+              lines.push(`### ${ex.title}`);
+              lines.push(ex.description);
+              lines.push('**Steps**:');
+              ex.sandbox_actions.forEach(a => lines.push(`- Use \`${a.tool}\`: ${a.guidance}`));
+              lines.push('**Success criteria**:');
+              matching.forEach(sc => lines.push(`- **${sc.id}**: ${sc.text}`));
+              lines.push('');
+            }
+
+            lines.push('## Assessment instructions');
+            lines.push('Conduct a short lab and oral assessment focused on these missing canonical-format criteria. Before completion, call checkpoint_teaching_progress for S2 with demonstrations_verified and demonstration_evidence for every listed criterion ID. Then call complete_certification_exam with the attempt ID above and internal scores. Do not share scores with the learner.');
+
+            if (criteria?.dimensions?.length) {
+              lines.push('');
+              lines.push('**Internal scoring rubric** (do not share with learner):');
+              for (const d of criteria.dimensions) {
+                lines.push(`- **${d.name}** (weight: ${d.weight}%): ${d.description}`);
+              }
+            }
+
+            return lines.join('\n');
+          }
+        }
         return `Module ${moduleId} is already ${existingMod.status.replace('_', ' ')}. You can proceed to the next module or use get_learner_progress to check your overall progress.`;
       }
 
@@ -2336,6 +2440,17 @@ export function createCertificationToolHandlers(
       const examAc = capstoneMod.assessment_criteria as certDb.AssessmentCriteria | undefined;
 
       const capstoneId = capstoneMod.id;
+      const s2DeltaStatus = capstoneId === certDb.S2_CANONICAL_FORMATS_MODULE_ID
+        ? await certDb.getS2CanonicalFormatsDeltaStatus(userId)
+        : null;
+      const isS2CanonicalFormatsDelta = !!(
+        s2DeltaStatus?.active
+        && s2DeltaStatus.status === 'delta_available'
+      );
+      if (capstoneId === certDb.S2_CANONICAL_FORMATS_MODULE_ID && s2DeltaStatus?.status === 'full_recertification_required') {
+        await certDb.cancelAttempt(attempt.id, 'S2 canonical formats delta window closed');
+        return notCompleted(capstoneId, 'state', 'The S2 canonical-formats delta window has closed. This delta attempt cannot be completed; the learner needs the current full S2 module for renewal.');
+      }
 
       // Validate scores against assessment criteria (range, dimensions, floor, threshold)
       const scoreResult = await validateCompletionScores(scores, examAc);
@@ -2375,14 +2490,40 @@ export function createCertificationToolHandlers(
       }
 
       // Verify all required demonstrations from exercise success_criteria
-      const demoError = checkDemonstrations(capstoneMod, examCheckpoint);
-      if (demoError) return notCompleted(capstoneId, 'evidence', demoError);
+      let s2DeltaEvidence: certDb.S2CanonicalFormatsDeltaEvidence | null = null;
+      if (isS2CanonicalFormatsDelta) {
+        s2DeltaEvidence = await certDb.getS2CanonicalFormatsDeltaEvidence(userId);
+        const missingCumulative = certDb.S2_CANONICAL_FORMATS_CRITERION_IDS.filter(
+          id => !s2DeltaEvidence!.verifiedCriterionIds.includes(id),
+        );
+        if (missingCumulative.length > 0) {
+          return notCompleted(capstoneId, 'evidence', `Required demonstrations not yet verified:\n- ${missingCumulative.join('\n- ')}\n\nVerify each through conversation, then save a checkpoint with demonstrations_verified and demonstration_evidence before completing.`);
+        }
+        const evidenceError = checkCriterionEvidence(
+          certDb.S2_CANONICAL_FORMATS_CRITERION_IDS,
+          s2DeltaEvidence.evidenceByCriterionId,
+        );
+        if (evidenceError) return notCompleted(capstoneId, 'evidence', evidenceError);
+      } else {
+        const demoError = checkDemonstrations(capstoneMod, examCheckpoint);
+        if (demoError) return notCompleted(capstoneId, 'evidence', demoError);
+      }
 
       const overallScore = Math.round(scoreResult.weightedAvg);
       const allAboveThreshold = Object.values(scores).every(s => s >= 70);
       const passing = allAboveThreshold && overallScore >= 70;
 
-      await certDb.completeAttempt(attempt.id, scores, overallScore, passing);
+      if (isS2CanonicalFormatsDelta && passing) {
+        await certDb.completeS2CanonicalFormatsDeltaAttempt(
+          attempt.id,
+          userId,
+          scores,
+          overallScore,
+          s2DeltaEvidence!.evidenceByCriterionId,
+        );
+      } else {
+        await certDb.completeAttempt(attempt.id, scores, overallScore, passing);
+      }
 
       // --- From this point the attempt is recorded. Failures below must not ---
       // --- surface as "Failed to record capstone results" to the learner.   ---
@@ -2390,6 +2531,15 @@ export function createCertificationToolHandlers(
       const lines: string[] = [];
 
       if (passing) {
+        if (isS2CanonicalFormatsDelta) {
+          lines.push('# S2 Creative canonical formats delta completed!');
+          lines.push('');
+          lines.push('The learner has demonstrated the AdCP 3.1 canonical-format update criteria. Congratulate them warmly. Do NOT share any scores or percentages.');
+          lines.push('');
+          lines.push('Their existing S2 Creative specialist credential remains current for the AdCP 3.1 canonical-format update.');
+          return lines.join('\n');
+        }
+
         // SUCCESS LINE — pinned by `addie/rules/constraints.md` and by
         // `cert-not-completed-sentinel.test.ts`. If you change the
         // "# Congratulations! The learner passed the capstone!" prefix,
@@ -2469,7 +2619,20 @@ export function createCertificationToolHandlers(
       const progress = await certDb.getProgress(userId);
       const modProgress = progress.find(p => p.module_id === moduleId);
       if (!modProgress || modProgress.status !== 'in_progress') {
-        return `Module ${moduleId} is not in progress. Start the module first with start_certification_module before saving checkpoints.`;
+        const s2DeltaStatus = moduleId === certDb.S2_CANONICAL_FORMATS_MODULE_ID
+          ? await certDb.getS2CanonicalFormatsDeltaStatus(userId)
+          : null;
+        const hasActiveS2DeltaAttempt = moduleId === certDb.S2_CANONICAL_FORMATS_MODULE_ID
+          ? await certDb.getActiveAttemptForModule(userId, moduleId)
+          : null;
+        const canCheckpointS2Delta = !!(
+          hasActiveS2DeltaAttempt
+          && s2DeltaStatus?.active
+          && (s2DeltaStatus.status === 'delta_available' || s2DeltaStatus.status === 'delta_completed')
+        );
+        if (!canCheckpointS2Delta) {
+          return `Module ${moduleId} is not in progress. Start the module first with start_certification_module before saving checkpoints.`;
+        }
       }
 
       // Validate demonstration IDs and evidence keys are real criteria for this module

--- a/server/src/certification/s2-canonical-formats-delta.ts
+++ b/server/src/certification/s2-canonical-formats-delta.ts
@@ -1,0 +1,223 @@
+export const S2_CANONICAL_FORMATS_DELTA_UPDATE_ID = 's2_canonical_formats_3_1';
+export const S2_CANONICAL_FORMATS_MODULE_ID = 'S2';
+export const S2_CANONICAL_FORMATS_CREDENTIAL_ID = 'specialist_creative';
+
+export const S2_CANONICAL_FORMATS_CRITERION_IDS = [
+  's2_ex1_sc_format_kind_selection',
+  's2_ex1_sc_format_options_cardinality',
+  's2_ex1_sc_option_vs_capability_id',
+  's2_ex1_sc_source_taxonomy',
+  's2_ex1_sc_validation_order',
+] as const;
+
+export interface S2CanonicalFormatsDeltaReleaseSetting {
+  adcp_3_1_ga_at: string | null;
+  criteria_deployed_at: string | null;
+}
+
+export type S2CanonicalFormatsDeltaStatusKind =
+  | 'gated'
+  | 'not_required'
+  | 'delta_available'
+  | 'delta_completed'
+  | 'full_recertification_required';
+
+export interface S2CanonicalFormatsDeltaStatus {
+  update_id: typeof S2_CANONICAL_FORMATS_DELTA_UPDATE_ID;
+  module_id: typeof S2_CANONICAL_FORMATS_MODULE_ID;
+  credential_id: typeof S2_CANONICAL_FORMATS_CREDENTIAL_ID;
+  status: S2CanonicalFormatsDeltaStatusKind;
+  active: boolean;
+  reason: string;
+  adcp_3_1_ga_at: string | null;
+  criteria_deployed_at: string | null;
+  criteria_effective_at: string | null;
+  delta_window_opens_at: string | null;
+  delta_window_closes_at: string | null;
+  missing_criterion_ids: string[];
+}
+
+export interface S2CanonicalFormatsDeltaInput {
+  release: S2CanonicalFormatsDeltaReleaseSetting | null;
+  hasCreativeSpecialistCredential: boolean;
+  credentialAwardedAt: string | null;
+  s2CompletedAt: string | null;
+  deltaCompletedAt?: string | null;
+  canonicalCriteriaPresent?: boolean;
+  hasPriorAuditableS2Record?: boolean;
+  verifiedCriterionIds: string[];
+  now?: Date;
+}
+
+function parseDate(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function toIso(value: Date | null): string | null {
+  return value ? value.toISOString() : null;
+}
+
+function addUtcCalendarDaysEndOfDay(value: Date, days: number): Date {
+  return new Date(Date.UTC(
+    value.getUTCFullYear(),
+    value.getUTCMonth(),
+    value.getUTCDate() + days,
+    23,
+    59,
+    59,
+    999,
+  ));
+}
+
+function baseStatus(
+  release: S2CanonicalFormatsDeltaReleaseSetting | null,
+  status: S2CanonicalFormatsDeltaStatusKind,
+  active: boolean,
+  reason: string,
+  criteriaEffectiveAt: Date | null,
+  missingCriterionIds: string[] = [],
+): S2CanonicalFormatsDeltaStatus {
+  return {
+    update_id: S2_CANONICAL_FORMATS_DELTA_UPDATE_ID,
+    module_id: S2_CANONICAL_FORMATS_MODULE_ID,
+    credential_id: S2_CANONICAL_FORMATS_CREDENTIAL_ID,
+    status,
+    active,
+    reason,
+    adcp_3_1_ga_at: release?.adcp_3_1_ga_at ?? null,
+    criteria_deployed_at: release?.criteria_deployed_at ?? null,
+    criteria_effective_at: toIso(criteriaEffectiveAt),
+    delta_window_opens_at: toIso(criteriaEffectiveAt),
+    delta_window_closes_at: criteriaEffectiveAt ? toIso(addUtcCalendarDaysEndOfDay(criteriaEffectiveAt, 90)) : null,
+    missing_criterion_ids: missingCriterionIds,
+  };
+}
+
+export function computeS2CanonicalFormatsDeltaStatus(
+  input: S2CanonicalFormatsDeltaInput,
+): S2CanonicalFormatsDeltaStatus {
+  const gaAt = parseDate(input.release?.adcp_3_1_ga_at);
+  const deployedAt = parseDate(input.release?.criteria_deployed_at);
+
+  if (!gaAt || !deployedAt) {
+    const missing = [
+      !gaAt ? 'AdCP 3.1.0 GA date' : null,
+      !deployedAt ? 'production deployment date for migration 496_curriculum_3_1_canonical_formats_criteria.sql' : null,
+    ].filter(Boolean).join(' and ');
+    return baseStatus(input.release, 'gated', false, `Blocked until ${missing} is configured.`, null);
+  }
+
+  const criteriaEffectiveAt = new Date(Math.max(gaAt.getTime(), deployedAt.getTime()));
+  const deltaWindowClosesAt = addUtcCalendarDaysEndOfDay(criteriaEffectiveAt, 90);
+  const now = input.now ?? new Date();
+
+  if (input.canonicalCriteriaPresent === false) {
+    return baseStatus(
+      input.release,
+      'gated',
+      false,
+      'Blocked until the five AdCP 3.1 S2 canonical-format criteria are present in certification_modules.exercise_definitions.',
+      criteriaEffectiveAt,
+    );
+  }
+
+  if (now < criteriaEffectiveAt) {
+    return baseStatus(
+      input.release,
+      'gated',
+      false,
+      'Blocked until the later of AdCP 3.1.0 GA and production deployment of the S2 canonical-format criteria.',
+      criteriaEffectiveAt,
+    );
+  }
+
+  if (!input.hasCreativeSpecialistCredential) {
+    return baseStatus(
+      input.release,
+      'not_required',
+      true,
+      'Learner does not hold the S2 Creative specialist credential.',
+      criteriaEffectiveAt,
+    );
+  }
+
+  const awardedAt = parseDate(input.credentialAwardedAt);
+  const completedAt = parseDate(input.s2CompletedAt);
+  const deltaCompletedAt = parseDate(input.deltaCompletedAt);
+
+  if (completedAt && completedAt >= criteriaEffectiveAt) {
+    return baseStatus(
+      input.release,
+      'not_required',
+      true,
+      'S2 completion is already on or after the AdCP 3.1 canonical-format criteria effective point.',
+      criteriaEffectiveAt,
+    );
+  }
+
+  if (!completedAt) {
+    if (awardedAt && awardedAt >= criteriaEffectiveAt) {
+      return baseStatus(
+        input.release,
+        'not_required',
+        true,
+        'S2 credential was awarded after the AdCP 3.1 canonical-format criteria effective point.',
+        criteriaEffectiveAt,
+      );
+    }
+    return baseStatus(
+      input.release,
+      'full_recertification_required',
+      true,
+      'Prior S2 completion record is missing, so the learner does not meet the auditable-record requirement for a delta.',
+      criteriaEffectiveAt,
+      [...S2_CANONICAL_FORMATS_CRITERION_IDS],
+    );
+  }
+
+  const verified = new Set(input.verifiedCriterionIds);
+  const missingCriterionIds = S2_CANONICAL_FORMATS_CRITERION_IDS.filter(id => !verified.has(id));
+
+  if (deltaCompletedAt) {
+    return baseStatus(
+      input.release,
+      'delta_completed',
+      true,
+      'Learner has auditable evidence for all AdCP 3.1 S2 canonical-format criteria.',
+      criteriaEffectiveAt,
+    );
+  }
+
+  if (input.hasPriorAuditableS2Record === false) {
+    return baseStatus(
+      input.release,
+      'full_recertification_required',
+      true,
+      'Prior S2 checkpoint trail is missing, so the learner does not meet the auditable-record requirement for a delta.',
+      criteriaEffectiveAt,
+      missingCriterionIds,
+    );
+  }
+
+  if (now > deltaWindowClosesAt) {
+    return baseStatus(
+      input.release,
+      'full_recertification_required',
+      true,
+      'The S2 canonical-formats delta window has closed.',
+      criteriaEffectiveAt,
+      missingCriterionIds,
+    );
+  }
+
+  return baseStatus(
+    input.release,
+    'delta_available',
+    true,
+    'Pre-3.1 S2 holder is eligible for the canonical-formats delta assessment.',
+    criteriaEffectiveAt,
+    missingCriterionIds,
+  );
+}

--- a/server/src/db/certification-db.ts
+++ b/server/src/db/certification-db.ts
@@ -1,5 +1,14 @@
 import { query, getClient } from './client.js';
 import { createLogger } from '../logger.js';
+import {
+  computeS2CanonicalFormatsDeltaStatus,
+  S2_CANONICAL_FORMATS_CREDENTIAL_ID,
+  S2_CANONICAL_FORMATS_CRITERION_IDS,
+  S2_CANONICAL_FORMATS_DELTA_UPDATE_ID,
+  S2_CANONICAL_FORMATS_MODULE_ID,
+  type S2CanonicalFormatsDeltaStatus,
+} from '../certification/s2-canonical-formats-delta.js';
+import { getS2CanonicalFormatsDeltaRelease } from './system-settings-db.js';
 
 const logger = createLogger('certification-db');
 
@@ -119,6 +128,14 @@ export interface UserCredential {
   certifier_public_id: string | null;
   certifier_badge_url: string | null;
 }
+
+export type { S2CanonicalFormatsDeltaStatus };
+export {
+  S2_CANONICAL_FORMATS_CREDENTIAL_ID,
+  S2_CANONICAL_FORMATS_CRITERION_IDS,
+  S2_CANONICAL_FORMATS_DELTA_UPDATE_ID,
+  S2_CANONICAL_FORMATS_MODULE_ID,
+};
 
 // =====================================================
 // TRACKS
@@ -580,6 +597,212 @@ export async function getUserCredentials(userId: string): Promise<UserCredential
     [userId]
   );
   return result.rows;
+}
+
+export interface S2CanonicalFormatsDeltaEvidence {
+  verifiedCriterionIds: string[];
+  evidenceByCriterionId: Record<string, string>;
+}
+
+export async function getS2CanonicalFormatsDeltaEvidence(
+  userId: string,
+): Promise<S2CanonicalFormatsDeltaEvidence> {
+  const result = await query<{ criterion_id: string; evidence: string | null }>(
+    `SELECT v.criterion_id,
+            NULLIF(BTRIM(tc.demonstration_evidence ->> v.criterion_id), '') AS evidence
+     FROM teaching_checkpoints tc
+     CROSS JOIN LATERAL unnest(tc.demonstrations_verified) AS v(criterion_id)
+     WHERE tc.workos_user_id = $1
+       AND tc.module_id = $2
+       AND v.criterion_id = ANY($3::text[])
+     ORDER BY tc.created_at DESC`,
+    [userId, S2_CANONICAL_FORMATS_MODULE_ID, [...S2_CANONICAL_FORMATS_CRITERION_IDS]]
+  );
+
+  const evidenceByCriterionId: Record<string, string> = {};
+  for (const row of result.rows) {
+    if (row.evidence && !evidenceByCriterionId[row.criterion_id]) {
+      evidenceByCriterionId[row.criterion_id] = row.evidence;
+    }
+  }
+
+  return {
+    verifiedCriterionIds: Object.keys(evidenceByCriterionId),
+    evidenceByCriterionId,
+  };
+}
+
+export async function getS2CanonicalFormatsDeltaCompletedAt(userId: string): Promise<string | null> {
+  const result = await query<{ completed_at: string }>(
+    `SELECT completed_at
+     FROM learner_protocol_updates
+     WHERE workos_user_id = $1 AND update_id = $2
+     LIMIT 1`,
+    [userId, S2_CANONICAL_FORMATS_DELTA_UPDATE_ID]
+  );
+  return result.rows[0]?.completed_at ?? null;
+}
+
+export async function recordS2CanonicalFormatsDeltaCompletion(
+  userId: string,
+  attemptId: string,
+  evidenceByCriterionId: Record<string, string>,
+): Promise<void> {
+  await query(
+    `INSERT INTO learner_protocol_updates
+       (workos_user_id, update_id, module_id, credential_id, attempt_id, criterion_ids, evidence)
+     VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
+     ON CONFLICT (workos_user_id, update_id) DO UPDATE
+       SET attempt_id = EXCLUDED.attempt_id,
+           completed_at = NOW(),
+           criterion_ids = EXCLUDED.criterion_ids,
+           evidence = EXCLUDED.evidence`,
+    [
+      userId,
+      S2_CANONICAL_FORMATS_DELTA_UPDATE_ID,
+      S2_CANONICAL_FORMATS_MODULE_ID,
+      S2_CANONICAL_FORMATS_CREDENTIAL_ID,
+      attemptId,
+      [...S2_CANONICAL_FORMATS_CRITERION_IDS],
+      JSON.stringify(evidenceByCriterionId),
+    ]
+  );
+}
+
+async function hasS2CanonicalFormatsCriteriaPresent(): Promise<boolean> {
+  const mod = await getModule(S2_CANONICAL_FORMATS_MODULE_ID);
+  const exerciseDefs = mod?.exercise_definitions ?? [];
+  const ids = new Set(
+    exerciseDefs.flatMap(ex =>
+      ex.success_criteria.map(sc => typeof sc === 'string' ? sc : sc.id)
+    )
+  );
+  return S2_CANONICAL_FORMATS_CRITERION_IDS.every(id => ids.has(id));
+}
+
+async function hasPriorAuditableS2Record(
+  userId: string,
+  s2CompletedAt: string | null | undefined,
+): Promise<boolean> {
+  if (!s2CompletedAt) return false;
+
+  const mod = await getModule(S2_CANONICAL_FORMATS_MODULE_ID);
+  const priorCriterionIds = (mod?.exercise_definitions ?? [])
+    .flatMap(ex => ex.success_criteria.map(sc => typeof sc === 'string' ? sc : sc.id))
+    .filter(id => !S2_CANONICAL_FORMATS_CRITERION_IDS.includes(
+      id as (typeof S2_CANONICAL_FORMATS_CRITERION_IDS)[number],
+    ));
+  if (priorCriterionIds.length === 0) return false;
+
+  const result = await query<{ criterion_id: string }>(
+    `SELECT DISTINCT v.criterion_id
+     FROM teaching_checkpoints tc
+     CROSS JOIN LATERAL unnest(tc.demonstrations_verified) AS v(criterion_id)
+     WHERE tc.workos_user_id = $1
+       AND tc.module_id = $2
+       AND tc.created_at <= $3::timestamptz + INTERVAL '1 hour'
+       AND v.criterion_id = ANY($4::text[])
+       AND NULLIF(BTRIM(tc.demonstration_evidence ->> v.criterion_id), '') IS NOT NULL`,
+    [userId, S2_CANONICAL_FORMATS_MODULE_ID, s2CompletedAt, priorCriterionIds]
+  );
+  const evidenced = new Set(result.rows.map(row => row.criterion_id));
+  return priorCriterionIds.every(id => evidenced.has(id));
+}
+
+export async function completeS2CanonicalFormatsDeltaAttempt(
+  attemptId: string,
+  userId: string,
+  scores: Record<string, number>,
+  overallScore: number,
+  evidenceByCriterionId: Record<string, string>,
+): Promise<CertificationAttempt> {
+  const client = await getClient();
+  try {
+    await client.query('BEGIN');
+
+    const attemptResult = await client.query<CertificationAttempt>(
+      `UPDATE certification_attempts
+       SET status = 'passed',
+           completed_at = NOW(),
+           scores = $2,
+           overall_score = $3,
+           passing = true
+       WHERE id = $1
+         AND workos_user_id = $4
+         AND module_id = $5
+         AND status = 'in_progress'
+       RETURNING *`,
+      [
+        attemptId,
+        JSON.stringify(scores),
+        overallScore,
+        userId,
+        S2_CANONICAL_FORMATS_MODULE_ID,
+      ]
+    );
+    const attempt = attemptResult.rows[0];
+    if (!attempt) {
+      throw new Error(`Active S2 canonical formats delta attempt ${attemptId} not found`);
+    }
+
+    await client.query(
+      `INSERT INTO learner_protocol_updates
+         (workos_user_id, update_id, module_id, credential_id, attempt_id, criterion_ids, evidence)
+       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
+       ON CONFLICT (workos_user_id, update_id) DO UPDATE
+         SET attempt_id = EXCLUDED.attempt_id,
+             completed_at = NOW(),
+             criterion_ids = EXCLUDED.criterion_ids,
+             evidence = EXCLUDED.evidence`,
+      [
+        userId,
+        S2_CANONICAL_FORMATS_DELTA_UPDATE_ID,
+        S2_CANONICAL_FORMATS_MODULE_ID,
+        S2_CANONICAL_FORMATS_CREDENTIAL_ID,
+        attemptId,
+        [...S2_CANONICAL_FORMATS_CRITERION_IDS],
+        JSON.stringify(evidenceByCriterionId),
+      ]
+    );
+
+    await client.query('COMMIT');
+    return attempt;
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function getS2CanonicalFormatsDeltaStatus(
+  userId: string,
+  now: Date = new Date(),
+): Promise<S2CanonicalFormatsDeltaStatus> {
+  const [release, credentials, s2Progress, evidence, deltaCompletedAt, criteriaPresent] = await Promise.all([
+    getS2CanonicalFormatsDeltaRelease(),
+    getUserCredentials(userId),
+    getModuleProgress(userId, S2_CANONICAL_FORMATS_MODULE_ID),
+    getS2CanonicalFormatsDeltaEvidence(userId),
+    getS2CanonicalFormatsDeltaCompletedAt(userId),
+    hasS2CanonicalFormatsCriteriaPresent(),
+  ]);
+
+  const creativeCredential = credentials.find(
+    c => c.credential_id === S2_CANONICAL_FORMATS_CREDENTIAL_ID
+  );
+
+  return computeS2CanonicalFormatsDeltaStatus({
+    release,
+    hasCreativeSpecialistCredential: !!creativeCredential,
+    credentialAwardedAt: creativeCredential?.awarded_at ?? null,
+    s2CompletedAt: s2Progress?.completed_at ?? null,
+    deltaCompletedAt,
+    canonicalCriteriaPresent: criteriaPresent,
+    hasPriorAuditableS2Record: await hasPriorAuditableS2Record(userId, s2Progress?.completed_at),
+    verifiedCriterionIds: evidence.verifiedCriterionIds,
+    now,
+  });
 }
 
 /**

--- a/server/src/db/migrations/498_s2_canonical_formats_delta_release_setting.sql
+++ b/server/src/db/migrations/498_s2_canonical_formats_delta_release_setting.sql
@@ -1,0 +1,37 @@
+-- Release gates for the AdCP 3.1 S2 Creative canonical-formats delta.
+--
+-- Both dates must be configured before learner targeting, status display, or
+-- delta assessment entry points become active. Updates should go through
+-- system_settings helpers so system_settings_audit records who enabled them.
+
+INSERT INTO system_settings (key, value, description)
+VALUES (
+  'certification_s2_canonical_formats_delta_release',
+  '{"adcp_3_1_ga_at": null, "criteria_deployed_at": null}'::jsonb,
+  'Release gates for the S2 canonical-formats delta: AdCP 3.1.0 GA and production deployment of migration 496_curriculum_3_1_canonical_formats_criteria.sql'
+)
+ON CONFLICT (key) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS learner_protocol_updates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workos_user_id TEXT NOT NULL REFERENCES users(workos_user_id),
+  update_id TEXT NOT NULL,
+  module_id VARCHAR(10) NOT NULL REFERENCES certification_modules(id),
+  credential_id VARCHAR(50) NOT NULL REFERENCES certification_credentials(id),
+  attempt_id UUID REFERENCES certification_attempts(id),
+  completed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  criterion_ids TEXT[] NOT NULL DEFAULT '{}',
+  evidence JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (workos_user_id, update_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_learner_protocol_updates_update
+  ON learner_protocol_updates(update_id, completed_at DESC);
+
+COMMENT ON TABLE learner_protocol_updates IS
+  'Auditable protocol-change update completions, including targeted recertification deltas.';
+COMMENT ON COLUMN learner_protocol_updates.update_id IS
+  'Stable update identifier, e.g. s2_canonical_formats_3_1.';
+COMMENT ON COLUMN learner_protocol_updates.evidence IS
+  'Criterion-id keyed evidence retained for accreditation audit trails.';

--- a/server/src/db/system-settings-db.ts
+++ b/server/src/db/system-settings-db.ts
@@ -59,6 +59,11 @@ export interface AnnouncementChannelSetting {
   channel_name: string | null;
 }
 
+export interface S2CanonicalFormatsDeltaReleaseSetting {
+  adcp_3_1_ga_at: string | null;
+  criteria_deployed_at: string | null;
+}
+
 // ============== Setting Keys ==============
 
 export const SETTING_KEYS = {
@@ -70,6 +75,7 @@ export const SETTING_KEYS = {
   ERROR_SLACK_CHANNEL: 'error_slack_channel',
   EDITORIAL_SLACK_CHANNEL: 'editorial_slack_channel',
   ANNOUNCEMENT_SLACK_CHANNEL: 'announcement_slack_channel',
+  CERTIFICATION_S2_CANONICAL_FORMATS_DELTA_RELEASE: 'certification_s2_canonical_formats_delta_release',
 } as const;
 
 // ============== Generic Operations ==============
@@ -342,5 +348,25 @@ export async function setAnnouncementChannel(
     SETTING_KEYS.ANNOUNCEMENT_SLACK_CHANNEL,
     { channel_id: channelId, channel_name: channelName },
     updatedBy
+  );
+}
+
+// ============== Certification Protocol-Update Gates ==============
+
+export async function getS2CanonicalFormatsDeltaRelease(): Promise<S2CanonicalFormatsDeltaReleaseSetting> {
+  const result = await getSetting<S2CanonicalFormatsDeltaReleaseSetting>(
+    SETTING_KEYS.CERTIFICATION_S2_CANONICAL_FORMATS_DELTA_RELEASE,
+  );
+  return result ?? { adcp_3_1_ga_at: null, criteria_deployed_at: null };
+}
+
+export async function setS2CanonicalFormatsDeltaRelease(
+  value: S2CanonicalFormatsDeltaReleaseSetting,
+  updatedBy?: string
+): Promise<void> {
+  await setSetting<S2CanonicalFormatsDeltaReleaseSetting>(
+    SETTING_KEYS.CERTIFICATION_S2_CANONICAL_FORMATS_DELTA_RELEASE,
+    value,
+    updatedBy,
   );
 }

--- a/server/src/routes/admin/settings.ts
+++ b/server/src/routes/admin/settings.ts
@@ -27,6 +27,8 @@ import {
   setEditorialChannel,
   getAnnouncementChannel,
   setAnnouncementChannel,
+  getS2CanonicalFormatsDeltaRelease,
+  setS2CanonicalFormatsDeltaRelease,
   getSettingAuditHistory,
 } from '../../db/system-settings-db.js';
 import {
@@ -77,6 +79,18 @@ async function requireChannelPrivacy(
   });
 }
 
+function normalizeOptionalDate(value: unknown): string | null | undefined {
+  if (value === null) return null;
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string') return undefined;
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?(?:Z|[+-]\d{2}:\d{2})$/.test(value)) {
+    return undefined;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return undefined;
+  return parsed.toISOString();
+}
+
 export function createAdminSettingsRouter(): Router {
   const router = Router();
 
@@ -93,6 +107,7 @@ export function createAdminSettingsRouter(): Router {
 
       const editorialChannel = await getEditorialChannel();
       const announcementChannel = await getAnnouncementChannel();
+      const s2CanonicalFormatsDeltaRelease = await getS2CanonicalFormatsDeltaRelease();
 
       res.json({
         settings,
@@ -104,6 +119,7 @@ export function createAdminSettingsRouter(): Router {
         error_channel: errorChannel,
         editorial_channel: editorialChannel,
         announcement_channel: announcementChannel,
+        s2_canonical_formats_delta_release: s2CanonicalFormatsDeltaRelease,
       });
     } catch (error) {
       logger.error({ err: error }, 'Failed to get system settings');
@@ -475,6 +491,38 @@ export function createAdminSettingsRouter(): Router {
       logger.error({ err: error }, 'Failed to update announcement channel');
       res.status(500).json({
         error: 'Failed to update announcement channel',
+      });
+    }
+  });
+
+  // PUT /api/admin/settings/s2-canonical-formats-delta-release
+  router.put('/s2-canonical-formats-delta-release', ...requireGlobalAdmin, async (req: Request, res: Response) => {
+    try {
+      const adcpGaAt = normalizeOptionalDate(req.body?.adcp_3_1_ga_at);
+      const criteriaDeployedAt = normalizeOptionalDate(req.body?.criteria_deployed_at);
+
+      if (adcpGaAt === undefined || criteriaDeployedAt === undefined) {
+        res.status(400).json({
+          error: 'Invalid release gate',
+          message: 'adcp_3_1_ga_at and criteria_deployed_at must be ISO date strings or null',
+        });
+        return;
+      }
+
+      const userId = req.user?.id;
+      await setS2CanonicalFormatsDeltaRelease({
+        adcp_3_1_ga_at: adcpGaAt,
+        criteria_deployed_at: criteriaDeployedAt,
+      }, userId);
+
+      logger.info({ adcpGaAt, criteriaDeployedAt, userId }, 'S2 canonical formats delta release gates updated');
+
+      const updated = await getS2CanonicalFormatsDeltaRelease();
+      res.json({ success: true, s2_canonical_formats_delta_release: updated });
+    } catch (error) {
+      logger.error({ err: error }, 'Failed to update S2 canonical formats delta release gates');
+      res.status(500).json({
+        error: 'Failed to update release gates',
       });
     }
   });

--- a/tests/certification-s2-canonical-formats-delta.test.ts
+++ b/tests/certification-s2-canonical-formats-delta.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeS2CanonicalFormatsDeltaStatus,
+  S2_CANONICAL_FORMATS_CRITERION_IDS,
+} from '../server/src/certification/s2-canonical-formats-delta.js';
+
+const release = {
+  adcp_3_1_ga_at: '2026-06-01T12:00:00.000Z',
+  criteria_deployed_at: '2026-05-28T13:00:00.000Z',
+};
+
+describe('computeS2CanonicalFormatsDeltaStatus', () => {
+  it('stays gated until both release dates are configured', () => {
+    const status = computeS2CanonicalFormatsDeltaStatus({
+      release: { adcp_3_1_ga_at: null, criteria_deployed_at: '2026-05-28T13:00:00.000Z' },
+      hasCreativeSpecialistCredential: true,
+      credentialAwardedAt: '2026-05-01T00:00:00.000Z',
+      s2CompletedAt: '2026-05-01T00:00:00.000Z',
+      verifiedCriterionIds: [],
+      now: new Date('2026-06-02T00:00:00.000Z'),
+    });
+
+    expect(status.active).toBe(false);
+    expect(status.status).toBe('gated');
+    expect(status.criteria_effective_at).toBeNull();
+  });
+
+  it('stays gated until the later configured release date has passed', () => {
+    const status = computeS2CanonicalFormatsDeltaStatus({
+      release,
+      hasCreativeSpecialistCredential: true,
+      credentialAwardedAt: '2026-05-01T00:00:00.000Z',
+      s2CompletedAt: '2026-05-01T00:00:00.000Z',
+      verifiedCriterionIds: [],
+      now: new Date('2026-06-01T11:59:59.000Z'),
+    });
+
+    expect(status.active).toBe(false);
+    expect(status.status).toBe('gated');
+    expect(status.criteria_effective_at).toBe('2026-06-01T12:00:00.000Z');
+  });
+
+  it('stays gated when the canonical-format criteria are not present in the curriculum', () => {
+    const status = computeS2CanonicalFormatsDeltaStatus({
+      release,
+      hasCreativeSpecialistCredential: true,
+      credentialAwardedAt: '2026-05-01T00:00:00.000Z',
+      s2CompletedAt: '2026-05-01T00:00:00.000Z',
+      canonicalCriteriaPresent: false,
+      verifiedCriterionIds: [],
+      now: new Date('2026-06-02T00:00:00.000Z'),
+    });
+
+    expect(status.active).toBe(false);
+    expect(status.status).toBe('gated');
+  });
+
+  it('targets pre-effective S2 holders for a delta during the 90-day window', () => {
+    const status = computeS2CanonicalFormatsDeltaStatus({
+      release,
+      hasCreativeSpecialistCredential: true,
+      credentialAwardedAt: '2026-05-01T00:00:00.000Z',
+      s2CompletedAt: '2026-05-01T00:00:00.000Z',
+      verifiedCriterionIds: [],
+      now: new Date('2026-06-02T00:00:00.000Z'),
+    });
+
+    expect(status.active).toBe(true);
+    expect(status.status).toBe('delta_available');
+    expect(status.criteria_effective_at).toBe('2026-06-01T12:00:00.000Z');
+    expect(status.delta_window_closes_at).toBe('2026-08-30T23:59:59.999Z');
+    expect(status.missing_criterion_ids).toEqual([...S2_CANONICAL_FORMATS_CRITERION_IDS]);
+  });
+
+  it('requires full recertification when prior S2 audit trail is missing', () => {
+    const status = computeS2CanonicalFormatsDeltaStatus({
+      release,
+      hasCreativeSpecialistCredential: true,
+      credentialAwardedAt: '2026-05-01T00:00:00.000Z',
+      s2CompletedAt: '2026-05-01T00:00:00.000Z',
+      hasPriorAuditableS2Record: false,
+      verifiedCriterionIds: [],
+      now: new Date('2026-06-02T00:00:00.000Z'),
+    });
+
+    expect(status.status).toBe('full_recertification_required');
+    expect(status.reason).toContain('auditable-record requirement');
+  });
+
+  it('keeps the delta available until a passing delta outcome is recorded', () => {
+    const status = computeS2CanonicalFormatsDeltaStatus({
+      release,
+      hasCreativeSpecialistCredential: true,
+      credentialAwardedAt: '2026-05-01T00:00:00.000Z',
+      s2CompletedAt: '2026-05-01T00:00:00.000Z',
+      verifiedCriterionIds: [...S2_CANONICAL_FORMATS_CRITERION_IDS],
+      now: new Date('2026-06-02T00:00:00.000Z'),
+    });
+
+    expect(status.status).toBe('delta_available');
+    expect(status.missing_criterion_ids).toEqual([]);
+  });
+
+  it('marks the delta complete when a passing delta outcome is recorded', () => {
+    const status = computeS2CanonicalFormatsDeltaStatus({
+      release,
+      hasCreativeSpecialistCredential: true,
+      credentialAwardedAt: '2026-05-01T00:00:00.000Z',
+      s2CompletedAt: '2026-05-01T00:00:00.000Z',
+      deltaCompletedAt: '2026-06-02T00:00:00.000Z',
+      verifiedCriterionIds: [...S2_CANONICAL_FORMATS_CRITERION_IDS],
+      now: new Date('2026-08-31T00:00:00.000Z'),
+    });
+
+    expect(status.status).toBe('delta_completed');
+    expect(status.missing_criterion_ids).toEqual([]);
+  });
+
+  it('requires full recertification when the delta window has closed', () => {
+    const status = computeS2CanonicalFormatsDeltaStatus({
+      release,
+      hasCreativeSpecialistCredential: true,
+      credentialAwardedAt: '2026-05-01T00:00:00.000Z',
+      s2CompletedAt: '2026-05-01T00:00:00.000Z',
+      verifiedCriterionIds: [],
+      now: new Date('2026-08-31T00:00:00.000Z'),
+    });
+
+    expect(status.status).toBe('full_recertification_required');
+  });
+
+  it('requires full recertification after the deadline even when all criteria have evidence but no passing delta outcome', () => {
+    const status = computeS2CanonicalFormatsDeltaStatus({
+      release,
+      hasCreativeSpecialistCredential: true,
+      credentialAwardedAt: '2026-05-01T00:00:00.000Z',
+      s2CompletedAt: '2026-05-01T00:00:00.000Z',
+      verifiedCriterionIds: [...S2_CANONICAL_FORMATS_CRITERION_IDS],
+      now: new Date('2026-08-31T00:00:00.000Z'),
+    });
+
+    expect(status.status).toBe('full_recertification_required');
+    expect(status.missing_criterion_ids).toEqual([]);
+  });
+
+  it('reports only criteria without cumulative evidence as missing', () => {
+    const status = computeS2CanonicalFormatsDeltaStatus({
+      release,
+      hasCreativeSpecialistCredential: true,
+      credentialAwardedAt: '2026-05-01T00:00:00.000Z',
+      s2CompletedAt: '2026-05-01T00:00:00.000Z',
+      verifiedCriterionIds: [
+        's2_ex1_sc_format_kind_selection',
+        's2_ex1_sc_format_options_cardinality',
+      ],
+      now: new Date('2026-06-02T00:00:00.000Z'),
+    });
+
+    expect(status.status).toBe('delta_available');
+    expect(status.missing_criterion_ids).toEqual([
+      's2_ex1_sc_option_vs_capability_id',
+      's2_ex1_sc_source_taxonomy',
+      's2_ex1_sc_validation_order',
+    ]);
+  });
+
+  it('does not target learners without the S2 Creative credential', () => {
+    const status = computeS2CanonicalFormatsDeltaStatus({
+      release,
+      hasCreativeSpecialistCredential: false,
+      credentialAwardedAt: null,
+      s2CompletedAt: null,
+      verifiedCriterionIds: [],
+      now: new Date('2026-06-02T00:00:00.000Z'),
+    });
+
+    expect(status.status).toBe('not_required');
+  });
+
+  it('requires full recertification when the prior S2 completion record is missing', () => {
+    const status = computeS2CanonicalFormatsDeltaStatus({
+      release,
+      hasCreativeSpecialistCredential: true,
+      credentialAwardedAt: '2026-05-01T00:00:00.000Z',
+      s2CompletedAt: null,
+      verifiedCriterionIds: [],
+      now: new Date('2026-06-02T00:00:00.000Z'),
+    });
+
+    expect(status.status).toBe('full_recertification_required');
+    expect(status.reason).toContain('auditable-record requirement');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the gated S2 canonical-formats delta status model for pre-3.1 Creative specialist holders.
- Adds durable learner protocol update storage, admin release-date settings, and SQL-backed eligibility/evidence checks.
- Wires the targeted delta path into Addie certification tools without re-awarding the S2 module or credential.
- Adds focused status-contract tests and an empty changeset.

Closes #4696

## Validation
- npm run test:unit -- --run tests/certification-s2-canonical-formats-delta.test.ts
- npm run typecheck
- npm run test:migrations
- git diff --check
- npx --yes @changesets/cli@^2.31.0 status --since=origin/main
- npm run precommit
- pre-push hook: version sync, schema-link check, Mintlify broken-links check

## Review
- Code review: no blockers after transaction/criteria-gate/stale-attempt fixes.
- Education review: no blockers after tightening prior S2 auditability to require evidence for every pre-3.1 S2 criterion before the original completion window.
- Residual non-blocking gap: no DB integration test directly exercises the SQL-backed prior-audit query; covered at status-contract level.