### PR TITLE
Add ext to discovery filters

### DIFF
--- a/.changeset/5120-product-filters-ext.md
+++ b/.changeset/5120-product-filters-ext.md
@@ -1,0 +1,13 @@
+---
+"adcontextprotocol": minor
+---
+
+Add optional `ext` fields to discovery filters for vendor-namespaced,
+seller-specific criteria.
+
+This closes the schema gap surfaced by adcp-go#277 and tracked for follow-up
+in adcp-go#279: `product-filters.json` already allowed extension keys via
+`additionalProperties: true`, but did not expose the protocol-standard `ext`
+slot. The same request-side filter pattern applied to creative and signal
+discovery filters. Existing wire payloads remain compatible, while generated
+SDKs can now surface discoverable extension objects.

--- a/static/schemas/source/core/creative-filters.json
+++ b/static/schemas/source/core/creative-filters.json
@@ -113,6 +113,10 @@
     "has_variables": {
       "type": "boolean",
       "description": "When true, return only creatives with dynamic variables (DCO). When false, return only static creatives."
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json",
+      "description": "Vendor-namespaced extension parameters for seller- or platform-specific creative filter criteria not covered by standard fields. Keys MUST be namespaced under a vendor or platform key (e.g., ext.gam, ext.platform_x). Sellers MUST treat all values as untrusted buyer input; avoid unbounded logging or labels, and do not interpolate values into caller-visible error strings, LLM prompts, SQL queries, or system commands without sanitization. Persistent use of an extension key across multiple buyers is a signal to propose standardization."
     }
   },
   "additionalProperties": true

--- a/static/schemas/source/core/product-filters.json
+++ b/static/schemas/source/core/product-filters.json
@@ -428,6 +428,10 @@
         "additionalProperties": false
       },
       "minItems": 1
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json",
+      "description": "Vendor-namespaced extension parameters for seller-specific filter criteria not covered by standard fields. Keys MUST be namespaced under a vendor or platform key (e.g., ext.gam, ext.platform_x). Sellers MUST treat all values as untrusted buyer input; do not interpolate into LLM prompts, SQL queries, or system commands without sanitization. Persistent use of an extension key across multiple buyers is a signal to propose standardization."
     }
   },
   "additionalProperties": true

--- a/static/schemas/source/core/signal-filters.json
+++ b/static/schemas/source/core/signal-filters.json
@@ -37,6 +37,10 @@
       "description": "Minimum coverage requirement",
       "minimum": 0,
       "maximum": 100
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json",
+      "description": "Vendor-namespaced extension parameters for seller- or platform-specific signal filter criteria not covered by standard fields. Keys MUST be namespaced under a vendor or platform key (e.g., ext.gam, ext.platform_x). Sellers MUST treat all values as untrusted buyer input; avoid unbounded logging or labels, and do not interpolate values into caller-visible error strings, LLM prompts, SQL queries, or system commands without sanitization. Persistent use of an extension key across multiple buyers is a signal to propose standardization."
     }
   },
   "additionalProperties": true


### PR DESCRIPTION
Adds explicit `ext` extension points to product, creative, and signal discovery filter schemas while preserving their existing `additionalProperties: true` compatibility posture. This makes vendor-namespaced filter extensions discoverable for generated SDKs instead of relying on opaque unknown top-level keys. Includes a minor changeset for the additive schema surface. Validated with `npm run build`, `npm run typecheck`, precommit checks, and pre-push version sync.