### PR TITLE
docs(media-buy): align not-found recovery guidance

### DIFF
--- a/.changeset/not-found-recovery-prose.md
+++ b/.changeset/not-found-recovery-prose.md
@@ -1,0 +1,6 @@
+---
+---
+
+docs(media-buy): align not-found recovery guidance.
+
+Refs #5132. This is docs-only and does not change protocol behavior.

--- a/docs/creative/task-reference/sync_creatives.mdx
+++ b/docs/creative/task-reference/sync_creatives.mdx
@@ -768,7 +768,7 @@ Poll `tasks/get` or wait for the webhook. The completion artifact carries the `c
 | ------------------------- | ------------------------------------------------- | -------------------------------------------------------------------- |
 | `INVALID_FORMAT`          | Format not supported by product                   | Check product's supported formats via `list_creative_formats`        |
 | `ASSET_PROCESSING_FAILED` | Asset file corrupt or invalid                     | Verify asset meets format requirements (codec, dimensions, duration) |
-| `PACKAGE_NOT_FOUND`       | Package ID doesn't exist in media buy             | Verify `package_id` from `create_media_buy` response                 |
+| `PACKAGE_NOT_FOUND`       | Package ID doesn't exist in media buy             | Verify `package_id`; for legacy package correlation use `get_media_buys` + package `context.buyer_ref` |
 | `BRAND_SAFETY_VIOLATION`  | Creative failed brand safety scan                 | Review content against publisher's brand safety guidelines           |
 | `FORMAT_MISMATCH`         | Assets don't match format requirements            | Verify asset types and specifications match format definition        |
 | `CREATIVE_IN_ACTIVE_DELIVERY` | Creative is assigned to an active, non-paused package (blocks updates and `delete_missing` deletions) | Pause the package first, or create a new creative version        |

--- a/docs/media-buy/task-reference/get_media_buy_delivery.mdx
+++ b/docs/media-buy/task-reference/get_media_buy_delivery.mdx
@@ -642,7 +642,7 @@ asyncio.run(main())
 |------------|-------------|------------|
 | `AUTH_MISSING` | No credentials presented | Provide credentials via auth header |
 | `AUTH_INVALID` | Credentials rejected (expired / revoked) | Human credential rotation required; do not auto-retry |
-| `MEDIA_BUY_NOT_FOUND` | Media buy doesn't exist | Verify media_buy_id |
+| `MEDIA_BUY_NOT_FOUND` | Media buy doesn't exist | Verify `media_buy_id`; for legacy correlation use `get_media_buys` + `context.internal_campaign_id` |
 | `INVALID_DATE_RANGE` | Invalid start/end dates | Use YYYY-MM-DD format, ensure start < end |
 | `DATE_RANGE_NOT_SUPPORTED` | Product only supports lifetime reporting | Omit `start_date` and `end_date`. Check `reporting_capabilities.date_range_support` on the product. |
 | `UNSUPPORTED_GRANULARITY` | Requested `time_granularity` is not in the product's `windowed_pull_granularities` | Re-issue with a granularity from `error.details.supported_granularities`, or omit `time_granularity` to fall back to cumulative date-range pulls. See [Windowed pull recovery](#windowed-pull-recovery). |

--- a/docs/media-buy/task-reference/update_media_buy.mdx
+++ b/docs/media-buy/task-reference/update_media_buy.mdx
@@ -731,8 +731,8 @@ Common errors and resolutions:
 
 | Error Code | Description | Resolution |
 |------------|-------------|------------|
-| `MEDIA_BUY_NOT_FOUND` | Media buy doesn't exist | Verify media_buy_id |
-| `PACKAGE_NOT_FOUND` | Package doesn't exist | Verify package_id |
+| `MEDIA_BUY_NOT_FOUND` | Media buy doesn't exist | Verify `media_buy_id`; for legacy correlation use `get_media_buys` + `context.internal_campaign_id` |
+| `PACKAGE_NOT_FOUND` | Package doesn't exist | Verify `package_id`; for legacy package correlation use `get_media_buys` + package `context.buyer_ref` |
 | `UPDATE_NOT_ALLOWED` | Field cannot be changed | See "What Can Be Updated" above |
 | `BUDGET_INSUFFICIENT` | New budget below minimum | Increase budget amount |
 | `POLICY_VIOLATION` | Update violates content policy | Review policy requirements |


### PR DESCRIPTION
## Summary

Refs #5132.

This aligns the task-reference not-found recovery table prose with the canonical error-code guidance from #5123. The updates point legacy media-buy and package correlation recovery at persisted `context` handles instead of stale `buyer_ref` wording.

## What changed

- Updated `PACKAGE_NOT_FOUND` recovery guidance in `sync_creatives`.
- Updated `MEDIA_BUY_NOT_FOUND` recovery guidance in `get_media_buy_delivery`.
- Updated both `MEDIA_BUY_NOT_FOUND` and `PACKAGE_NOT_FOUND` recovery rows in `update_media_buy`.
- Added a docs-only changeset.

## Testing

- `npm run test:docs-nav`
- `git diff --check`
- Precommit hook: unit tests, dynamic import lint, callApi state-change lint, typecheck
- Pre-push hook: version sync, schema link convention, Mintlify broken-links
