### PR TITLE
docs(migration): show package context correlation

### DIFF
--- a/.changeset/package-context-readiness-example.md
+++ b/.changeset/package-context-readiness-example.md
@@ -1,0 +1,6 @@
+---
+---
+
+docs(migration): show package-level buyer_ref context.
+
+Refs #5130. This is docs-only and does not change protocol behavior.

--- a/docs/reference/migration/v3-readiness.mdx
+++ b/docs/reference/migration/v3-readiness.mdx
@@ -143,6 +143,52 @@ If your agent used `buyer_ref` for internal tracking or correlation (e.g. mappin
 }
 ```
 
+For package-level line-item correlation, keep the buy-level context separate from each package's fallback correlation handle:
+
+```json test=false
+{
+  "idempotency_key": "550e8400-e29b-41d4-a716-446655440001",
+  "context": {
+    "internal_campaign_id": "camp-2024-q3"
+  },
+  "brand": {
+    "domain": "example-brand.test"
+  },
+  "packages": [
+    {
+      "product_id": "prod_weekday_display",
+      "pricing_option_id": "cpm_usd_auction",
+      "format_ids": [
+        {
+          "agent_url": "https://creative.adcontextprotocol.org",
+          "id": "display_300x250_image"
+        }
+      ],
+      "budget": 12000,
+      "context": {
+        "buyer_ref": "line-001"
+      }
+    },
+    {
+      "product_id": "prod_weekend_video",
+      "pricing_option_id": "cpm_usd_auction",
+      "format_ids": [
+        {
+          "agent_url": "https://creative.adcontextprotocol.org",
+          "id": "video_standard_30s"
+        }
+      ],
+      "budget": 18000,
+      "context": {
+        "buyer_ref": "line-002"
+      }
+    }
+  ],
+  "start_time": "2026-07-01T00:00:00Z",
+  "end_time": "2026-07-31T23:59:59Z"
+}
+```
+
 ---
 
 ## 8. Implement `sync_accounts`


### PR DESCRIPTION
## Summary

Refs #5130.

This adds a `create_media_buy` example to the v3 readiness guide showing package-level line-item correlation with `packages[i].context.buyer_ref`. The example keeps buy-level `context.internal_campaign_id` separate from per-package fallback correlation handles so adopters do not place all legacy correlation data at the media-buy level.

## What changed

- Added a two-package `create_media_buy` example in section 7 of the v3 readiness guide.
- Used structured `format_ids` objects rather than string shorthand.
- Added a docs-only changeset.

## Testing

- `npm run test:docs-nav`
- `git diff --check`
- Precommit hook: unit tests, dynamic import lint, callApi state-change lint, typecheck
- Pre-push hook: version sync, schema link convention, Mintlify broken-links
