### PR TITLE
docs(media-buy): clarify webhook context echoes

### DIFF
--- a/.changeset/webhook-package-context.md
+++ b/.changeset/webhook-package-context.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": patch
+---
+
+docs(media-buy): clarify context echo on webhook payload schemas.
+
+Refs #5131. This adds schema descriptions and example/docs clarification for existing context echo behavior without changing field shapes.

--- a/docs/media-buy/media-buys/lifecycle.mdx
+++ b/docs/media-buy/media-buys/lifecycle.mdx
@@ -213,6 +213,8 @@ When the underlying resource returns to a serviceable state (audience re-syncs, 
 
 When a buy's `health` transitions or an impairment is added/removed, the seller fires an `impairment` notification against the buy's `push_notification_config`. The payload reuses the `impairment` object shape plus the buy's updated `health`. See the [persistent webhook contract](/docs/building/by-layer/L3/webhooks#persistent-channel-contract) for delivery semantics (at-least-once, no-ordering, coalescence, replay via snapshot).
 
+Impairment webhooks identify affected packages with `package_ids[]` by design. Buyers that need package-level correlation context, such as `context.buyer_ref`, should call `get_media_buys` after receiving an impairment fire and read the package snapshot.
+
 ### Materiality coverage
 
 The MUST-strength materiality rule applies to resource types where the resource → buy join is cheap and 1:N — audience, event_source, property. For creative and catalog_item, materiality is SHOULD-strength: a creative in a large pool may not degrade serving when removed, and the join is more expensive for sellers to compute. Implementers SHOULD report conservatively when uncertain and MUST NOT report when serving is provably unaffected.

--- a/static/schemas/source/core/mcp-webhook-payload.json
+++ b/static/schemas/source/core/mcp-webhook-payload.json
@@ -120,6 +120,9 @@
               "pacing": "even",
               "pricing_option_id": "cpm-fixed-sports",
               "paused": false,
+              "context": {
+                "buyer_ref": "line-001"
+              },
               "creative_assignments": [],
               "format_ids_to_provide": [
                 {

--- a/static/schemas/source/media-buy/create-media-buy-response.json
+++ b/static/schemas/source/media-buy/create-media-buy-response.json
@@ -96,7 +96,8 @@
           "description": "When true, this response contains simulated data from sandbox mode."
         },
         "context": {
-          "$ref": "/schemas/core/context.json"
+          "$ref": "/schemas/core/context.json",
+          "description": "Opaque media-buy-level correlation data echoed unchanged from the create_media_buy request. Sellers MUST echo this object verbatim when the originating request carried context, including synchronous success, error, submitted, and webhook task-status payloads. Sellers MUST NOT parse this object for business logic."
         },
         "ext": {
           "$ref": "/schemas/core/ext.json"
@@ -172,7 +173,8 @@
           "minItems": 1
         },
         "context": {
-          "$ref": "/schemas/core/context.json"
+          "$ref": "/schemas/core/context.json",
+          "description": "Opaque media-buy-level correlation data echoed unchanged from the create_media_buy request. Sellers MUST echo this object verbatim when the originating request carried context, including synchronous success, error, submitted, and webhook task-status payloads. Sellers MUST NOT parse this object for business logic."
         },
         "ext": {
           "$ref": "/schemas/core/ext.json"
@@ -240,7 +242,8 @@
           }
         },
         "context": {
-          "$ref": "/schemas/core/context.json"
+          "$ref": "/schemas/core/context.json",
+          "description": "Opaque media-buy-level correlation data echoed unchanged from the create_media_buy request. Sellers MUST echo this object verbatim when the originating request carried context, including synchronous success, error, submitted, and webhook task-status payloads. Sellers MUST NOT parse this object for business logic."
         },
         "ext": {
           "$ref": "/schemas/core/ext.json"

--- a/static/schemas/source/media-buy/update-media-buy-response.json
+++ b/static/schemas/source/media-buy/update-media-buy-response.json
@@ -86,7 +86,8 @@
           "description": "When true, this response contains simulated data from sandbox mode."
         },
         "context": {
-          "$ref": "/schemas/core/context.json"
+          "$ref": "/schemas/core/context.json",
+          "description": "Opaque operation-level correlation data echoed unchanged from the update_media_buy request. Sellers MUST echo this object verbatim when the originating request carried context, including synchronous success, error, submitted, and webhook task-status payloads. Sellers MUST NOT parse this object for business logic."
         },
         "ext": {
           "$ref": "/schemas/core/ext.json"
@@ -117,7 +118,8 @@
           "minItems": 1
         },
         "context": {
-          "$ref": "/schemas/core/context.json"
+          "$ref": "/schemas/core/context.json",
+          "description": "Opaque operation-level correlation data echoed unchanged from the update_media_buy request. Sellers MUST echo this object verbatim when the originating request carried context, including synchronous success, error, submitted, and webhook task-status payloads. Sellers MUST NOT parse this object for business logic."
         },
         "ext": {
           "$ref": "/schemas/core/ext.json"
@@ -185,7 +187,8 @@
           }
         },
         "context": {
-          "$ref": "/schemas/core/context.json"
+          "$ref": "/schemas/core/context.json",
+          "description": "Opaque operation-level correlation data echoed unchanged from the update_media_buy request. Sellers MUST echo this object verbatim when the originating request carried context, including synchronous success, error, submitted, and webhook task-status payloads. Sellers MUST NOT parse this object for business logic."
         },
         "ext": {
           "$ref": "/schemas/core/ext.json"


### PR DESCRIPTION
## Summary

Refs #5131.

This clarifies existing context echo behavior on media-buy response schemas and webhook examples. It does not add or remove fields; it adds description text to existing `context` fields, updates the completed `create_media_buy` webhook example to show package-level context, and documents that impairment webhooks carry `package_ids[]` while package context is recovered from the `get_media_buys` snapshot.

## What changed

- Added context echo descriptions to `create-media-buy-response.json` response branches.
- Added context echo descriptions to `update-media-buy-response.json` response branches.
- Added package `context.buyer_ref` to the completed `create_media_buy` MCP webhook example.
- Clarified impairment webhook package-context recovery in the media-buy lifecycle docs.
- Added a patch changeset for the schema description clarification.

## Testing

- `npm run build:schemas`
- `npm run test:schemas`
- `npm run test:json-schema`
- `npm run test:schema-utf8`
- `npm run test:docs-nav`
- `git diff --check`
- Precommit hook: unit tests, dynamic import lint, callApi state-change lint, typecheck
- Pre-push hook: version sync, schema link convention, Mintlify broken-links
