### PR TITLE
Activate 3.1 badge issuance

### DIFF
--- a/.changeset/activate-3-1-badge-issuance.md
+++ b/.changeset/activate-3-1-badge-issuance.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": minor
+---
+
+Activate public AAO Verified badge issuance for AdCP 3.1 while keeping AdCP 3.0 compatibility badges active.
+
+The badge-eligible default compliance target is now the 3.1 line, with explicit non-default targets such as `3.0` or `3.1-beta` remaining diagnostic-only for public compliance state. Registry and Addie outputs now surface whether a compliance run can update public badges and which badge versions it can issue.
+
+Closes #5108.

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -2010,9 +2010,9 @@
       // Header count: "1 badge" / "N badges" / "N badges across M roles"
       // The "across M roles" suffix only appears when at least one role
       // has parallel-version badges (i.e. distinctRoleCount < badges.length).
-      // Today with SUPPORTED_BADGE_VERSIONS = ['3.0'] every agent has at
-      // most one badge per role, so this only kicks in once parallel
-      // versions ship.
+      // Parallel-version badge issuance means one role can hold both 3.1
+      // and 3.0 badges. Keep the role suffix so the count doesn't read as
+      // duplicate roles.
       const badgeCountSummary = badges.length === 1
         ? '1 badge'
         : `${badges.length} badges${distinctRoleCount < badges.length ? ` across ${distinctRoleCount} role${distinctRoleCount === 1 ? '' : 's'}` : ''}`;

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -62,6 +62,8 @@ import {
   hostedComplianceOptions,
   withHostedStoryboardRunOptions,
   withHostedTestOptions,
+  isDefaultHostedComplianceTarget,
+  badgeEligibleVersionsForHostedComplianceTarget,
 } from '../../services/hosted-compliance-version.js';
 import { AgentContextDatabase, validateAuthTokenChars, type OAuthClientCredentials } from '../../db/agent-context-db.js';
 import { buildAgentOAuthAuthorizeUrl, isOAuthRequiredError } from '../../routes/helpers/agent-oauth-prompt.js';
@@ -128,18 +130,26 @@ function targetFromInput(input: Record<string, unknown>): ReturnType<typeof host
       ? hostedComplianceTarget(requested.trim())
       : complianceTarget;
   } catch {
-    throw new ToolError('Invalid compliance_target. Use 3.0, 3.1-beta, or an exact bundled version.');
+    throw new ToolError('Invalid compliance_target. Use 3.1, 3.0, 3.1-beta, or an exact bundled version.');
   }
 }
 
-function formatComplianceTarget(target = complianceTarget, resolvedVersion = target.version): string {
-  return target.requested === resolvedVersion
+function formatComplianceTarget(
+  target = complianceTarget,
+  resolvedVersion = target.version,
+  options: { includeBadgeEligibility?: boolean } = {},
+): string {
+  let label = target.requested === resolvedVersion
     ? resolvedVersion
     : `${target.requested} (resolved ${resolvedVersion})`;
-}
 
-function isDefaultComplianceTarget(target: ReturnType<typeof hostedComplianceTarget>): boolean {
-  return target.requested === complianceTarget.requested && target.version === complianceTarget.version;
+  if (options.includeBadgeEligibility) {
+    const versions = badgeEligibleVersionsForHostedComplianceTarget(target);
+    label += versions.length
+      ? ` — badge eligible for public AdCP ${versions.join('/')} badges`
+      : ' — diagnostic only';
+  }
+  return label;
 }
 
 const memberDb = new MemberDatabase();
@@ -1131,7 +1141,7 @@ export const MEMBER_TOOLS: AddieTool[] = [
       properties: {
         agent_url: { type: 'string', description: 'Agent URL to evaluate' },
         tracks: { type: 'array', items: { type: 'string', enum: ['core', 'products', 'media_buy', 'creative', 'reporting', 'governance', 'signals', 'si', 'audiences'] }, description: 'Specific compliance tracks to run (default: all applicable, driven by the agent\'s get_adcp_capabilities response)' },
-        compliance_target: { type: 'string', description: 'Compliance target to run, e.g. "3.0" for the latest checked-in stable 3.0.x cache or "3.1-beta" for the latest checked-in 3.1 beta cache. Defaults to 3.0.' },
+        compliance_target: { type: 'string', description: 'Compliance target to run, e.g. "3.1" for the badge-eligible default line, "3.0" for a diagnostic 3.0 run, or "3.1-beta" for an explicit beta diagnostic run. Defaults to 3.1.' },
       },
       required: ['agent_url'],
     },
@@ -1238,7 +1248,7 @@ export const MEMBER_TOOLS: AddieTool[] = [
       type: 'object',
       properties: {
         agent_url: { type: 'string', description: 'Agent URL to discover and recommend storyboards for' },
-        compliance_target: { type: 'string', description: 'Compliance target to inspect, e.g. "3.0" or "3.1-beta". Defaults to 3.0.' },
+        compliance_target: { type: 'string', description: 'Compliance target to inspect, e.g. "3.1", "3.0", or "3.1-beta". Defaults to 3.1.' },
       },
       required: ['agent_url'],
     },
@@ -1252,7 +1262,7 @@ export const MEMBER_TOOLS: AddieTool[] = [
       type: 'object',
       properties: {
         storyboard_id: { type: 'string', description: 'Storyboard ID (from recommend_storyboards)' },
-        compliance_target: { type: 'string', description: 'Compliance target to inspect, e.g. "3.0" or "3.1-beta". Defaults to 3.0.' },
+        compliance_target: { type: 'string', description: 'Compliance target to inspect, e.g. "3.1", "3.0", or "3.1-beta". Defaults to 3.1.' },
       },
       required: ['storyboard_id'],
     },
@@ -1268,7 +1278,7 @@ export const MEMBER_TOOLS: AddieTool[] = [
         agent_url: { type: 'string', description: 'Agent URL to test' },
         storyboard_id: { type: 'string', description: 'Storyboard ID to run' },
         dry_run: { type: 'boolean', description: 'If true (default), use test data that won\'t affect production state', default: true },
-        compliance_target: { type: 'string', description: 'Compliance target to run, e.g. "3.0" or "3.1-beta". Defaults to 3.0.' },
+        compliance_target: { type: 'string', description: 'Compliance target to run, e.g. "3.1", "3.0", or "3.1-beta". Defaults to 3.1. Explicit non-default targets are diagnostic-only.' },
       },
       required: ['agent_url', 'storyboard_id'],
     },
@@ -1286,7 +1296,7 @@ export const MEMBER_TOOLS: AddieTool[] = [
         step_id: { type: 'string', description: 'Step ID to run (from storyboard detail or previous step\'s next.step_id)' },
         context: { type: 'object', description: 'Accumulated context from previous step (pass the context field from the previous run_storyboard_step result)', additionalProperties: true },
         dry_run: { type: 'boolean', description: 'If true (default), use test data', default: true },
-        compliance_target: { type: 'string', description: 'Compliance target to run, e.g. "3.0" or "3.1-beta". Defaults to 3.0.' },
+        compliance_target: { type: 'string', description: 'Compliance target to run, e.g. "3.1", "3.0", or "3.1-beta". Defaults to 3.1. Explicit non-default targets are diagnostic-only.' },
       },
       required: ['agent_url', 'storyboard_id', 'step_id'],
     },
@@ -3717,7 +3727,7 @@ export function createMemberToolHandlers(
     const agentUrl = input.agent_url as string;
     const tracks = input.tracks as ComplianceTrack[] | undefined;
     const runTarget = targetFromInput(input);
-    const writesCanonicalComplianceState = isDefaultComplianceTarget(runTarget);
+    const writesCanonicalComplianceState = isDefaultHostedComplianceTarget(runTarget);
     let skippedCanonicalWriteForTarget = false;
 
     const urlError = validateAgentUrl(agentUrl);
@@ -3900,7 +3910,7 @@ export function createMemberToolHandlers(
       const safeName = sanitizeAgentField(result.agent_profile.name, 120);
       output += `## Quality Evaluation: ${safeName || resolved.resolvedUrl}\n\n`;
       output += `**Agent:** ${resolved.resolvedUrl}\n`;
-      output += `**Compliance target:** ${formatComplianceTarget(runTarget, result.adcp_version ?? runTarget.version)}\n`;
+      output += `**Compliance target:** ${formatComplianceTarget(runTarget, result.adcp_version ?? runTarget.version, { includeBadgeEligibility: true })}\n`;
       if (skippedCanonicalWriteForTarget) {
         output += `_Explicit non-default compliance targets are diagnostic only; public compliance status and badges were not updated._\n`;
       }

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -26,6 +26,7 @@ import {
   hostedComplianceOptions,
   withHostedStoryboardRunOptions,
   withHostedTestOptions,
+  badgeEligibleVersionsForHostedComplianceTarget,
 } from "../services/hosted-compliance-version.js";
 import {
   comply,
@@ -127,6 +128,11 @@ import { AAO_UA_COMPLIANCE } from "../config/user-agents.js";
 const logger = createLogger("registry-api");
 const complianceTarget = hostedComplianceTarget();
 const complianceOptions = hostedComplianceOptions(complianceTarget);
+const badgeEligibleAdcpVersions = [...badgeEligibleVersionsForHostedComplianceTarget(complianceTarget)];
+const badgeEligibilityMetadata = (eligible: boolean) => ({
+  badge_eligible: eligible,
+  badge_eligible_adcp_versions: eligible ? badgeEligibleAdcpVersions : [],
+});
 const propertyCheckService = new PropertyCheckService();
 const propertyCheckDb = new PropertyCheckDatabase();
 const bulkCheckService = new BulkPropertyCheckService();
@@ -2328,8 +2334,10 @@ registry.registerPath({
             error: z.string().optional(),
             compliance: z.object({
               ran: z.boolean().openapi({ description: "True if the full storyboard suite ran and agent_storyboard_status was updated. False when ownership couldn't be resolved, the agent reported auth_required, or the compliance call itself failed." }),
-              requested_compliance_target: z.string().optional().openapi({ description: "Requested compliance target before alias resolution, e.g. 3.0 or 3.1-beta. Present when `ran` is true." }),
-              adcp_version: z.string().optional().openapi({ description: "Concrete AdCP compliance bundle version used for the run, e.g. 3.0.12. Present when `ran` is true." }),
+              requested_compliance_target: z.string().optional().openapi({ description: "Requested compliance target before alias resolution, e.g. 3.1, 3.0, or 3.1-beta. Present when `ran` is true." }),
+              adcp_version: z.string().optional().openapi({ description: "Concrete AdCP compliance bundle version used for the run, e.g. 3.0.12 or 3.1.0-beta.7. Present when `ran` is true." }),
+              badge_eligible: z.boolean().optional().openapi({ description: "True when this run can update public badge state." }),
+              badge_eligible_adcp_versions: z.array(z.string()).optional().openapi({ description: "Public badge versions this run can issue, e.g. ['3.1', '3.0']." }),
               overall_status: z.string().optional().openapi({ description: "Aggregate verdict from the run (passing / failing / partial / unknown). Only present when `ran` is true." }),
               storyboards_passing: z.number().int().optional().openapi({ description: "Number of storyboards passing on this run." }),
               storyboards_total: z.number().int().optional().openapi({ description: "Number of storyboards evaluated on this run." }),
@@ -2960,6 +2968,8 @@ registry.registerPath({
             }),
             adcp_version: z.string(),
             requested_compliance_target: z.string(),
+            badge_eligible: z.boolean(),
+            badge_eligible_adcp_versions: z.array(z.string()),
             phases: z.any(),
             summary: z.any(),
             observations: z.any(),
@@ -3003,6 +3013,8 @@ registry.registerPath({
             reference_agent: z.object({ url: z.string(), name: z.string(), profile: z.any(), summary: z.any() }),
             adcp_version: z.string(),
             requested_compliance_target: z.string(),
+            badge_eligible: z.boolean(),
+            badge_eligible_adcp_versions: z.array(z.string()),
             phases: z.any(),
             total_duration_ms: z.number(),
           }),
@@ -5497,6 +5509,8 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         ran: boolean;
         requested_compliance_target?: string;
         adcp_version?: string;
+        badge_eligible?: boolean;
+        badge_eligible_adcp_versions?: string[];
         overall_status?: string;
         storyboards_passing?: number;
         storyboards_total?: number;
@@ -5539,6 +5553,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
               ran: true,
               requested_compliance_target: complianceTarget.requested,
               adcp_version: complyResult.adcp_version,
+              ...badgeEligibilityMetadata(badgeEligibleAdcpVersions.length > 0),
               overall_status: dbInput.overall_status,
               storyboards_passing: passing,
               storyboards_total: storyboardStatuses.length,
@@ -6372,6 +6387,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           },
           requested_compliance_target: complianceTarget.requested,
           adcp_version: complyResult.adcp_version,
+          ...badgeEligibilityMetadata(badgeEligibleAdcpVersions.length > 0),
           phases: annotatedPhases,
           summary: complyResult.summary,
           observations: complyResult.observations,
@@ -6483,6 +6499,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           },
           requested_compliance_target: complianceTarget.requested,
           adcp_version: userResult.adcp_version,
+          ...badgeEligibilityMetadata(false),
           phases: comparisonPhases,
           total_duration_ms: Math.max(userResult.total_duration_ms, referenceResult.total_duration_ms),
         });

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -301,7 +301,7 @@ export const PropertyRegistryItemSchema = z
 export const AgentComplianceSchema = z
   .object({
     status: z.enum(["passing", "degraded", "failing", "unknown"]),
-    requested_compliance_target: z.string().nullable().optional().openapi({ description: "Requested compliance target before alias resolution, e.g. 3.0 or 3.1-beta." }),
+    requested_compliance_target: z.string().nullable().optional().openapi({ description: "Requested compliance target before alias resolution, e.g. 3.1, 3.0, or 3.1-beta." }),
     adcp_version: z.string().nullable().optional().openapi({ description: "Concrete AdCP compliance bundle version used for the latest run, e.g. 3.0.12." }),
     lifecycle_stage: z.enum(["development", "testing", "production", "deprecated"]),
     tracks: z.record(z.string(), z.string()).openapi({ example: { core: "pass", products: "fail" } }),
@@ -336,7 +336,7 @@ export const VerificationBadgeSchema = z
 export const AgentComplianceDetailSchema = z
   .object({
     agent_url: z.string(),
-    requested_compliance_target: z.string().nullable().optional().openapi({ description: "Requested compliance target before alias resolution, e.g. 3.0 or 3.1-beta. Null for legacy rows before target recording." }),
+    requested_compliance_target: z.string().nullable().optional().openapi({ description: "Requested compliance target before alias resolution, e.g. 3.1, 3.0, or 3.1-beta. Null for legacy rows before target recording." }),
     adcp_version: z.string().nullable().optional().openapi({ description: "Concrete AdCP compliance bundle version used for the latest run, e.g. 3.0.12. Null for legacy rows before version recording." }),
     status: z.enum(["passing", "degraded", "failing", "unknown", "opted_out"]),
     lifecycle_stage: z.enum(["development", "testing", "production", "deprecated"]),
@@ -376,7 +376,7 @@ export const AgentVerificationSchema = z
 export const StoryboardStatusSchema = z
   .object({
     storyboard_id: z.string(),
-    requested_compliance_target: z.string().nullable().optional().openapi({ description: "Requested compliance target from the run that produced this storyboard verdict, e.g. 3.0 or 3.1-beta." }),
+    requested_compliance_target: z.string().nullable().optional().openapi({ description: "Requested compliance target from the run that produced this storyboard verdict, e.g. 3.1, 3.0, or 3.1-beta." }),
     adcp_version: z.string().nullable().optional().openapi({ description: "Concrete AdCP compliance bundle version from the run that produced this storyboard verdict." }),
     title: z.string(),
     category: z.string().nullable(),

--- a/server/src/services/adcp-taxonomy.ts
+++ b/server/src/services/adcp-taxonomy.ts
@@ -42,7 +42,7 @@ export function isVerificationMode(value: unknown): value is VerificationMode {
  * Order matters: highest version first so heartbeat reports and queue
  * draining surface the newest version's pass/fail state first.
  */
-export const SUPPORTED_BADGE_VERSIONS = ['3.0'] as const;
+export const SUPPORTED_BADGE_VERSIONS = ['3.1', '3.0'] as const;
 export type SupportedBadgeVersion = typeof SUPPORTED_BADGE_VERSIONS[number];
 
 export function isSupportedBadgeVersion(value: unknown): value is SupportedBadgeVersion {

--- a/server/src/services/badge-issuance.ts
+++ b/server/src/services/badge-issuance.ts
@@ -221,6 +221,18 @@ export async function runBadgeFanOut(params: {
   const overallPassing = storyboardStatuses.length > 0 &&
     storyboardStatuses.every(s => s.status === 'passing');
 
+  if (!membershipOrgId) {
+    return processAgentBadges(
+      complianceDb,
+      agentUrl,
+      declaredSpecialisms,
+      storyboardStatuses,
+      overallPassing,
+      undefined,
+      SUPPORTED_BADGE_VERSIONS[0],
+    );
+  }
+
   for (const adcpVersion of SUPPORTED_BADGE_VERSIONS) {
     // Per-version try/catch matches the heartbeat behavior: a failure
     // at one version must not poison another version's issuance, and a

--- a/server/src/services/hosted-compliance-version.ts
+++ b/server/src/services/hosted-compliance-version.ts
@@ -93,8 +93,24 @@ function latestBetaComplianceVersionForLine(line: string): string {
   return latest;
 }
 
+function latestBadgeEligibleComplianceVersionForLine(line: string): string {
+  try {
+    return latestStableComplianceVersionForLine(line);
+  } catch (stableError) {
+    if (line !== DEFAULT_HOSTED_COMPLIANCE_LINE) {
+      throw stableError;
+    }
+
+    // During the 3.1 readiness window, the badge-eligible line is 3.1
+    // while the checked-in compliance cache is still published as a beta
+    // bundle. Keep the public target at the stable line alias (`3.1`) and
+    // let explicit beta aliases remain non-default diagnostic runs.
+    return latestBetaComplianceVersionForLine(line);
+  }
+}
+
 export const DEFAULT_HOSTED_COMPLIANCE_VERSION =
-  latestStableComplianceVersionForLine(DEFAULT_HOSTED_COMPLIANCE_LINE);
+  latestBadgeEligibleComplianceVersionForLine(DEFAULT_HOSTED_COMPLIANCE_LINE);
 
 export function hostedComplianceDir(version = DEFAULT_HOSTED_COMPLIANCE_VERSION): string {
   return repoPath('dist', 'compliance', version);
@@ -110,7 +126,7 @@ function hostedSchemaRootForVersion(version: string, target: HostedComplianceTar
 
 export function resolveHostedComplianceVersion(target: string = DEFAULT_HOSTED_COMPLIANCE_LINE): string {
   if (/^[1-9][0-9]*\.[0-9]+$/.test(target)) {
-    return latestStableComplianceVersionForLine(target);
+    return latestBadgeEligibleComplianceVersionForLine(target);
   }
   const betaMatch = target.match(/^([1-9][0-9]*\.[0-9]+)-beta$/);
   if (betaMatch) {
@@ -132,6 +148,17 @@ export function hostedComplianceTarget(target: string = DEFAULT_HOSTED_COMPLIANC
     complianceDir: hostedComplianceDir(version),
     schemaRoot: hostedSchemaRoot(version),
   };
+}
+
+export function isDefaultHostedComplianceTarget(target: HostedComplianceTarget): boolean {
+  return target.requested === DEFAULT_HOSTED_COMPLIANCE_LINE &&
+    target.version === DEFAULT_HOSTED_COMPLIANCE_VERSION;
+}
+
+export function badgeEligibleVersionsForHostedComplianceTarget(
+  target: HostedComplianceTarget,
+): readonly string[] {
+  return isDefaultHostedComplianceTarget(target) ? SUPPORTED_BADGE_VERSIONS : [];
 }
 
 function assertHostedArtifacts(version: string): void {

--- a/server/tests/unit/adcp-taxonomy.test.ts
+++ b/server/tests/unit/adcp-taxonomy.test.ts
@@ -53,6 +53,10 @@ describe('specialism status', () => {
 });
 
 describe('SUPPORTED_BADGE_VERSIONS', () => {
+  it('keeps public badge issuance enabled for 3.1 and 3.0, newest first', () => {
+    expect(SUPPORTED_BADGE_VERSIONS).toEqual(['3.1', '3.0']);
+  });
+
   it('is a non-empty array of MAJOR.MINOR strings', () => {
     expect(SUPPORTED_BADGE_VERSIONS.length).toBeGreaterThan(0);
     for (const v of SUPPORTED_BADGE_VERSIONS) {

--- a/server/tests/unit/badge-fan-out.test.ts
+++ b/server/tests/unit/badge-fan-out.test.ts
@@ -8,6 +8,7 @@ vi.mock('../../src/db/client.js', () => ({
 
 import { query } from '../../src/db/client.js';
 import { runBadgeFanOut } from '../../src/services/badge-issuance.js';
+import { SUPPORTED_BADGE_VERSIONS } from '../../src/services/adcp-taxonomy.js';
 import type {
   AgentVerificationBadge,
   BadgeRole,
@@ -97,8 +98,9 @@ describe('runBadgeFanOut', () => {
     });
 
     expect(db.getStoryboardStatuses).toHaveBeenCalledWith('https://example.com/mcp');
-    // Both roles should be issued — no revoke of the role we didn't retest
-    expect(db.upsertBadge).toHaveBeenCalledTimes(2);
+    // Both roles should be issued at every public badge version — no revoke
+    // of the role we didn't retest.
+    expect(db.upsertBadge).toHaveBeenCalledTimes(2 * SUPPORTED_BADGE_VERSIONS.length);
     expect(db.revokeBadge).not.toHaveBeenCalled();
   });
 
@@ -150,10 +152,8 @@ describe('runBadgeFanOut', () => {
       declaredSpecialisms: ['sales-broadcast-tv'],
     });
 
-    // With one supported version (3.0) we get one issuance; the test
-    // documents the aggregation contract (one entry per (role, version)
-    // pair) so adding 3.1 to SUPPORTED_BADGE_VERSIONS will surface here.
-    expect(result.issued.length).toBeGreaterThanOrEqual(1);
-    expect(result.issued.every(i => typeof i.adcp_version === 'string')).toBe(true);
+    expect(result.issued.map(i => i.adcp_version)).toEqual([...SUPPORTED_BADGE_VERSIONS]);
+    expect((db.upsertBadge as ReturnType<typeof vi.fn>).mock.calls.map(call => call[0].adcp_version))
+      .toEqual([...SUPPORTED_BADGE_VERSIONS]);
   });
 });

--- a/server/tests/unit/storyboards.test.ts
+++ b/server/tests/unit/storyboards.test.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_HOSTED_COMPLIANCE_VERSION,
   hostedComplianceOptions,
   hostedComplianceTarget,
+  isDefaultHostedComplianceTarget,
   withHostedComplianceOptions,
 } from '../../src/services/hosted-compliance-version.js';
 import { loadComplianceIndex } from '@adcp/sdk/testing';
@@ -147,12 +148,15 @@ describe('wrapper contract', () => {
     expect(typeof summary.step_count).toBe('number');
   });
 
-  it('uses the hosted stable compliance bundle by default', () => {
+  it('uses the hosted badge-eligible compliance bundle by default', () => {
     const target = hostedComplianceTarget();
     const index = loadComplianceIndex(hostedComplianceOptions(target));
     expect(index.adcp_version).toBe(DEFAULT_HOSTED_COMPLIANCE_VERSION);
+    expect(DEFAULT_HOSTED_COMPLIANCE_LINE).toBe('3.1');
     expect(target.requested).toBe(DEFAULT_HOSTED_COMPLIANCE_LINE);
     expect(target.version).toBe(DEFAULT_HOSTED_COMPLIANCE_VERSION);
+    expect(target.version).toMatch(/^3\.1\.(?:\d+|0-beta\.\d+)$/);
+    expect(isDefaultHostedComplianceTarget(target)).toBe(true);
   });
 
   it('resolves compliance target aliases against checked-in caches', () => {
@@ -163,6 +167,11 @@ describe('wrapper contract', () => {
     const beta = hostedComplianceTarget('3.1-beta');
     expect(beta.requested).toBe('3.1-beta');
     expect(beta.version).toMatch(/^3\.1\.0-beta\.\d+$/);
+  });
+
+  it('keeps explicit non-default targets diagnostic-only', () => {
+    expect(isDefaultHostedComplianceTarget(hostedComplianceTarget('3.0'))).toBe(false);
+    expect(isDefaultHostedComplianceTarget(hostedComplianceTarget('3.1-beta'))).toBe(false);
   });
 
   it('rejects unsupported compliance targets before path resolution', () => {

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -583,7 +583,7 @@ components:
           type:
             - string
             - "null"
-          description: Requested compliance target before alias resolution, e.g. 3.0 or 3.1-beta.
+          description: Requested compliance target before alias resolution, e.g. 3.1, 3.0, or 3.1-beta.
         adcp_version:
           type:
             - string
@@ -1410,7 +1410,7 @@ components:
           type:
             - string
             - "null"
-          description: Requested compliance target before alias resolution, e.g. 3.0 or 3.1-beta. Null for legacy rows before target recording.
+          description: Requested compliance target before alias resolution, e.g. 3.1, 3.0, or 3.1-beta. Null for legacy rows before target recording.
         adcp_version:
           type:
             - string
@@ -1615,7 +1615,7 @@ components:
           type:
             - string
             - "null"
-          description: Requested compliance target from the run that produced this storyboard verdict, e.g. 3.0 or 3.1-beta.
+          description: Requested compliance target from the run that produced this storyboard verdict, e.g. 3.1, 3.0, or 3.1-beta.
         adcp_version:
           type:
             - string
@@ -6892,10 +6892,18 @@ paths:
                         description: True if the full storyboard suite ran and agent_storyboard_status was updated. False when ownership couldn't be resolved, the agent reported auth_required, or the compliance call itself failed.
                       requested_compliance_target:
                         type: string
-                        description: Requested compliance target before alias resolution, e.g. 3.0 or 3.1-beta. Present when `ran` is true.
+                        description: Requested compliance target before alias resolution, e.g. 3.1, 3.0, or 3.1-beta. Present when `ran` is true.
                       adcp_version:
                         type: string
-                        description: Concrete AdCP compliance bundle version used for the run, e.g. 3.0.12. Present when `ran` is true.
+                        description: Concrete AdCP compliance bundle version used for the run, e.g. 3.0.12 or 3.1.0-beta.7. Present when `ran` is true.
+                      badge_eligible:
+                        type: boolean
+                        description: True when this run can update public badge state.
+                      badge_eligible_adcp_versions:
+                        type: array
+                        items:
+                          type: string
+                        description: Public badge versions this run can issue, e.g. ['3.1', '3.0'].
                       overall_status:
                         type: string
                         description: Aggregate verdict from the run (passing / failing / partial / unknown). Only present when `ran` is true.
@@ -8093,6 +8101,12 @@ paths:
                     type: string
                   requested_compliance_target:
                     type: string
+                  badge_eligible:
+                    type: boolean
+                  badge_eligible_adcp_versions:
+                    type: array
+                    items:
+                      type: string
                   phases: {}
                   summary: {}
                   observations: {}
@@ -8104,6 +8118,8 @@ paths:
                   - agent
                   - adcp_version
                   - requested_compliance_target
+                  - badge_eligible
+                  - badge_eligible_adcp_versions
                   - total_duration_ms
         "400":
           description: Invalid agent URL
@@ -8204,6 +8220,12 @@ paths:
                     type: string
                   requested_compliance_target:
                     type: string
+                  badge_eligible:
+                    type: boolean
+                  badge_eligible_adcp_versions:
+                    type: array
+                    items:
+                      type: string
                   phases: {}
                   total_duration_ms:
                     type: number
@@ -8213,6 +8235,8 @@ paths:
                   - reference_agent
                   - adcp_version
                   - requested_compliance_target
+                  - badge_eligible
+                  - badge_eligible_adcp_versions
                   - total_duration_ms
         "400":
           description: Invalid agent URL


### PR DESCRIPTION
## Summary

- enable public AAO Verified badge issuance for AdCP 3.1 while keeping 3.0 compatibility badges active
- make the default hosted compliance target the badge-eligible 3.1 line, with explicit `3.0` / `3.1-beta` targets remaining diagnostic-only
- surface badge eligibility in Addie and registry compliance run outputs, and regenerate OpenAPI

## Validation

- `npx vitest run server/tests/unit/adcp-taxonomy.test.ts server/tests/unit/storyboards.test.ts server/tests/unit/badge-fan-out.test.ts server/tests/unit/badge-issuance.test.ts --pool=threads`
- `npm run typecheck`
- `npm run build:openapi`
- `npm run test:openapi`
- precommit hook: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run typecheck`
- pre-push hook: version sync, storyboard-matrix skip, schema link convention, Mintlify broken-links check

Closes #5108.
