### PR TITLE
Add docs example coverage reporting

### DIFF
--- a/.changeset/docs-example-coverage.md
+++ b/.changeset/docs-example-coverage.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add docs example coverage and JSON field-audit tooling. No package release is needed.

--- a/.github/workflows/check-testable-snippets.yml
+++ b/.github/workflows/check-testable-snippets.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - 'docs/**/*.md'
       - 'docs/**/*.mdx'
+      - 'scripts/check-testable-snippets.cjs'
+      - 'scripts/docs-example-coverage.cjs'
+      - 'scripts/docs-json-field-audit.cjs'
+      - '.github/workflows/check-testable-snippets.yml'
 
 jobs:
   check-snippets:
@@ -31,3 +35,20 @@ jobs:
           else
             echo "✓ No documentation files changed"
           fi
+
+      - name: Publish docs example coverage
+        run: |
+          node scripts/docs-example-coverage.cjs --markdown >> "$GITHUB_STEP_SUMMARY"
+          node scripts/docs-example-coverage.cjs --json > docs-example-coverage.json
+          node scripts/docs-json-field-audit.cjs --markdown >> "$GITHUB_STEP_SUMMARY"
+          node scripts/docs-json-field-audit.cjs --json > docs-json-field-audit.json
+          node scripts/docs-json-field-audit.cjs --check --top 1
+
+      - name: Upload docs example coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-example-coverage
+          path: |
+            docs-example-coverage.json
+            docs-json-field-audit.json

--- a/docs/contributing/testable-snippets.md
+++ b/docs/contributing/testable-snippets.md
@@ -282,6 +282,56 @@ This will:
 
 Integration-only snippets are skipped unless `--integration` is passed or `SNIPPET_INTEGRATION=true` is set.
 
+### Coverage Reporting
+
+Use the docs example coverage report to see where schema-backed JSON examples
+and runnable snippets are concentrated:
+
+```bash test=false
+npm run docs:example-coverage
+```
+
+The report scans `docs/` and shows:
+
+- JSON blocks that include `$schema` and are therefore covered by `npm run test:json-schema`
+- complete JSON blocks without `$schema`
+- runnable JavaScript, TypeScript, Python, and shell snippets that are covered by `npm run test:snippets`
+- top files with the largest unvalidated JSON or untested runnable-snippet gaps
+
+For CI dashboards or saved baselines, emit machine-readable output:
+
+```bash test=false
+npm run --silent docs:example-coverage -- --json
+```
+
+For GitHub job summaries, emit Markdown:
+
+```bash test=false
+npm run --silent docs:example-coverage -- --markdown
+```
+
+Schema validation accepts extension fields where the wire protocol is
+extensible. To audit schema-backed docs examples for unknown public-looking
+fields, run:
+
+```bash test=false
+npm run docs:json-field-audit
+```
+
+The field audit is advisory by default. Use `--check` only when intentionally
+ratcheting against `scripts/docs-json-field-audit-baseline.json`:
+
+```bash test=false
+npm run docs:json-field-audit -- --check
+```
+
+When you intentionally clean up findings, refresh the baseline in the same
+change:
+
+```bash test=false
+npm run docs:json-field-audit -- --update-baseline
+```
+
 ### In CI/CD
 
 The full test suite (including snippet tests) can be run with:

--- a/docs/creative/channels/video.mdx
+++ b/docs/creative/channels/video.mdx
@@ -30,7 +30,6 @@ Video ads play before (pre-roll), during (mid-roll), or after (post-roll) video 
     "id": "video_15s"
   },
   "name": "Standard Video - 15 seconds",
-  "type": "video",
   "assets": [
     {
       "asset_id": "video_file",
@@ -66,7 +65,6 @@ Video ads play before (pre-roll), during (mid-roll), or after (post-roll) video 
     "id": "video_30s"
   },
   "name": "Standard Video - 30 seconds",
-  "type": "video",
   "assets": [
     {
       "asset_id": "video_file",
@@ -102,7 +100,6 @@ Video ads play before (pre-roll), during (mid-roll), or after (post-roll) video 
     "id": "video_6s"
   },
   "name": "6-Second Bumper",
-  "type": "video",
   "assets": [
     {
       "asset_id": "video_file",
@@ -138,7 +135,6 @@ Video ads play before (pre-roll), during (mid-roll), or after (post-roll) video 
     "id": "video_vertical_15s"
   },
   "name": "Vertical Video - 15 seconds",
-  "type": "video",
   "assets": [
     {
       "asset_id": "video_file",
@@ -179,7 +175,6 @@ This format represents common CTV requirements across most platforms:
     "id": "video_30s_ctv"
   },
   "name": "CTV Video - 30 seconds",
-  "type": "video",
   "assets": [
     {
       "asset_id": "video_file",
@@ -203,10 +198,6 @@ This format represents common CTV requirements across most platforms:
         "frame_rates": [23.976, 24, 25, 29.97, 30, 59.94, 60],
         "frame_rate_type": "constant",
         "scan_type": "progressive",
-        "color_space": "rec709",
-        "hdr_format": "sdr",
-        "chroma_subsampling": ["4:2:0"],
-        "video_bit_depth": [8],
         "min_gop_interval_seconds": 1,
         "max_gop_interval_seconds": 2,
         "gop_type": "closed",
@@ -215,11 +206,19 @@ This format represents common CTV requirements across most platforms:
         "audio_codecs": ["aac", "pcm"],
         "audio_sample_rates": [48000],
         "audio_channels": ["stereo"],
-        "audio_bit_depth": [16, 24],
-        "audio_bitrate_kbps_min": 192,
         "loudness_lufs": -24,
         "loudness_tolerance_db": 2,
-        "true_peak_dbfs": -2
+        "true_peak_dbfs": -2,
+        "ext": {
+          "ctv_profile": {
+            "color_space": "rec709",
+            "hdr_format": "sdr",
+            "chroma_subsampling": ["4:2:0"],
+            "video_bit_depth": [8],
+            "audio_bit_depth": [16, 24],
+            "audio_bitrate_kbps_min": 192
+          }
+        }
       }
     }
   ]
@@ -239,7 +238,6 @@ Different CTV platforms have varying requirements. Sales agents should define fo
     "id": "video_30s_roku"
   },
   "name": "Roku CTV - 30 seconds",
-  "type": "video",
   "assets": [
     {
       "asset_id": "video_file",
@@ -262,10 +260,14 @@ Different CTV platforms have varying requirements. Sales agents should define fo
         "audio_codecs": ["pcm", "aac"],
         "audio_sample_rates": [48000],
         "audio_channels": ["stereo"],
-        "audio_bit_depth": [16, 24],
-        "audio_bitrate_kbps_min": 192,
         "loudness_lufs": -23,
-        "loudness_tolerance_db": 2
+        "loudness_tolerance_db": 2,
+        "ext": {
+          "roku_profile": {
+            "audio_bit_depth": [16, 24],
+            "audio_bitrate_kbps_min": 192
+          }
+        }
       }
     }
   ]
@@ -281,7 +283,6 @@ Different CTV platforms have varying requirements. Sales agents should define fo
     "id": "video_30s_hulu"
   },
   "name": "Hulu CTV - 30 seconds",
-  "type": "video",
   "assets": [
     {
       "asset_id": "video_file",
@@ -303,15 +304,19 @@ Different CTV platforms have varying requirements. Sales agents should define fo
         "frame_rates": [23.976, 24, 25, 29.97, 30],
         "frame_rate_type": "constant",
         "scan_type": "progressive",
-        "chroma_subsampling": ["4:2:0", "4:2:2"],
         "audio_codecs": ["pcm", "aac"],
         "audio_sample_rates": [48000],
         "audio_channels": ["stereo"],
-        "audio_bit_depth": [16, 24],
-        "audio_bitrate_kbps_min": 192,
-        "audio_bitrate_kbps_max": 256,
         "loudness_lufs": -24,
-        "loudness_tolerance_db": 2
+        "loudness_tolerance_db": 2,
+        "ext": {
+          "hulu_profile": {
+            "chroma_subsampling": ["4:2:0", "4:2:2"],
+            "audio_bit_depth": [16, 24],
+            "audio_bitrate_kbps_min": 192,
+            "audio_bitrate_kbps_max": 256
+          }
+        }
       }
     }
   ]
@@ -327,7 +332,6 @@ Different CTV platforms have varying requirements. Sales agents should define fo
     "id": "video_30s_youtube_ctv"
   },
   "name": "YouTube CTV - 30 seconds",
-  "type": "video",
   "assets": [
     {
       "asset_id": "video_file",
@@ -349,8 +353,12 @@ Different CTV platforms have varying requirements. Sales agents should define fo
         "audio_codecs": ["aac"],
         "audio_sample_rates": [48000],
         "audio_channels": ["stereo"],
-        "audio_bitrate_kbps_min": 128,
-        "loudness_lufs": -14
+        "loudness_lufs": -14,
+        "ext": {
+          "youtube_profile": {
+            "audio_bitrate_kbps_min": 128
+          }
+        }
       }
     }
   ]
@@ -369,7 +377,6 @@ For server-side ad insertion (SSAI) compatibility, GOP structure is critical:
     "id": "video_30s_ssai"
   },
   "name": "SSAI Video - 30 seconds",
-  "type": "video",
   "assets": [
     {
       "asset_id": "video_file",
@@ -415,7 +422,6 @@ For third-party ad servers:
     "id": "video_30s_vast"
   },
   "name": "VAST Tag - 30 seconds",
-  "type": "video",
   "assets": [
     {
       "asset_id": "vast_tag",
@@ -440,7 +446,6 @@ For third-party ad servers:
     "id": "video_30s_vpaid"
   },
   "name": "VPAID Interactive - 30 seconds",
-  "type": "video",
   "assets": [
     {
       "asset_id": "vpaid_tag",
@@ -448,9 +453,14 @@ For third-party ad servers:
       "item_type": "individual",
       "required": true,
       "requirements": {
-        "vpaid_version": ["2.0"],
-        "api_framework": "VPAID",
-        "vpaid_enabled": true
+        "vast_version": "4.2",
+        "ext": {
+          "vpaid": {
+            "vpaid_version": ["2.0"],
+            "api_framework": "VPAID",
+            "vpaid_enabled": true
+          }
+        }
       }
     }
   ]
@@ -765,9 +775,14 @@ VPAID (Video Player Ad-Serving Interface Definition) enables interactive video a
       "item_type": "individual",
       "required": true,
       "requirements": {
-        "vpaid_version": ["2.0"],
-        "api_framework": "VPAID",
-        "vpaid_enabled": true
+        "vast_version": "4.2",
+        "ext": {
+          "vpaid": {
+            "vpaid_version": ["2.0"],
+            "api_framework": "VPAID",
+            "vpaid_enabled": true
+          }
+        }
       }
     }
   ]

--- a/docs/media-buy/advanced-topics/targeting.mdx
+++ b/docs/media-buy/advanced-topics/targeting.mdx
@@ -134,15 +134,73 @@ When publishers return products, they include targeting information buyers need:
 
 ```json
 {
-  "product_id": "premium_millennial_mobile",
-  "name": "Premium Millennial Mobile Package",
-  "description": "Mobile display inventory targeting millennials (25-40) across lifestyle and entertainment apps in top 25 US markets",
-  "targeting_description": "Ages 25-40, household income $50K+, interests in lifestyle/entertainment, mobile apps only, top 25 US metro areas",
-  "audience_size": "~2.5M monthly unique users",
-  "pricing": {
-    "cpm": 8.50,
-    "targeting_included": true
-  }
+  "$schema": "/schemas/media-buy/get-products-response.json",
+  "status": "completed",
+  "cache_scope": "public",
+  "products": [
+    {
+      "product_id": "premium_millennial_mobile",
+      "name": "Premium Millennial Mobile Package",
+      "description": "Mobile display inventory reaching adults 25-40 across lifestyle and entertainment apps in the top 25 US metro areas.",
+      "publisher_properties": [
+        {
+          "publisher_domain": "pinnacle-media.example",
+          "selection_type": "by_tag",
+          "property_tags": ["lifestyle", "entertainment", "mobile_app"]
+        }
+      ],
+      "channels": ["display"],
+      "delivery_type": "guaranteed",
+      "format_ids": [
+        {
+          "agent_url": "https://creative.adcontextprotocol.org",
+          "id": "display_300x250_image"
+        }
+      ],
+      "pricing_options": [
+        {
+          "pricing_option_id": "premium_mobile_cpm",
+          "pricing_model": "cpm",
+          "currency": "USD",
+          "fixed_price": 8.50
+        }
+      ],
+      "forecast": {
+        "forecast_range_unit": "availability",
+        "method": "modeled",
+        "currency": "USD",
+        "reach_unit": "individuals",
+        "points": [
+          {
+            "metrics": {
+              "audience_size": { "mid": 2500000 },
+              "impressions": { "mid": 12000000 }
+            }
+          }
+        ]
+      },
+      "included_signals": [
+        {
+          "signal_ref": {
+            "scope": "product",
+            "signal_id": "lifestyle_entertainment_interest"
+          },
+          "name": "Lifestyle and entertainment interest",
+          "value_type": "binary",
+          "description": "Seller-modeled users with recent lifestyle or entertainment content engagement."
+        }
+      ],
+      "reporting_capabilities": {
+        "available_reporting_frequencies": ["daily"],
+        "expected_delay_minutes": 240,
+        "timezone": "America/New_York",
+        "supports_webhooks": false,
+        "available_metrics": ["impressions", "clicks", "spend", "ctr"],
+        "date_range_support": "date_range"
+      },
+      "brief_relevance": "Matches the requested millennial audience, mobile app environment, lifestyle/entertainment context, and major US metro coverage."
+    }
+  ]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -104,7 +104,9 @@
     "lint:schema-links": "node scripts/lint-schema-links.mjs --check",
     "fix:schema-links": "node scripts/lint-schema-links.mjs",
     "test:schema-links": "node scripts/remark-schema-links/test.mjs",
-    "dev:docs": "node scripts/dev-docs.mjs"
+    "dev:docs": "node scripts/dev-docs.mjs",
+    "docs:example-coverage": "node scripts/docs-example-coverage.cjs",
+    "docs:json-field-audit": "node scripts/docs-json-field-audit.cjs"
   },
   "dependencies": {
     "@adcp/sdk": "^8.1.0-beta.14",

--- a/scripts/docs-example-coverage.cjs
+++ b/scripts/docs-example-coverage.cjs
@@ -1,0 +1,392 @@
+#!/usr/bin/env node
+/**
+ * Report test coverage for documentation examples.
+ *
+ * This is intentionally non-gating by default. It gives maintainers a baseline
+ * for JSON examples with schema validation and runnable snippets, so CI can
+ * publish trends before enforcing thresholds.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const DEFAULT_DOCS_DIR = path.join(ROOT, 'docs');
+const EXECUTABLE_LANGUAGES = new Set([
+  'bash',
+  'javascript',
+  'js',
+  'py',
+  'python',
+  'sh',
+  'shell',
+  'ts',
+  'typescript'
+]);
+
+const args = process.argv.slice(2);
+
+function readArg(name, fallback = null) {
+  const index = args.indexOf(name);
+  if (index === -1 || index + 1 >= args.length) return fallback;
+  return args[index + 1];
+}
+
+const docsDir = path.resolve(readArg('--docs-dir', DEFAULT_DOCS_DIR));
+const topN = Number.parseInt(readArg('--top', '10'), 10);
+const format = args.includes('--json')
+  ? 'json'
+  : args.includes('--markdown')
+    ? 'markdown'
+    : 'text';
+
+function percent(part, whole) {
+  if (!whole) return 0;
+  return Number(((part / whole) * 100).toFixed(1));
+}
+
+function pct(part, whole) {
+  return `${percent(part, whole).toFixed(1)}%`;
+}
+
+function walkFiles(dir) {
+  const files = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(fullPath));
+    } else if (entry.isFile() && /\.(md|mdx)$/.test(entry.name)) {
+      files.push(fullPath);
+    }
+  }
+  return files.sort();
+}
+
+function parseFrontmatter(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  return match ? match[1] : '';
+}
+
+function isTestablePage(content) {
+  return /(?:^|\n)testable:\s*true\s*(?:\n|$)/i.test(parseFrontmatter(content));
+}
+
+function metadataHas(metadata, pattern) {
+  return pattern.test(metadata || '');
+}
+
+function isPlaceholderJson(text) {
+  return /\[\.\.\.\]|\{\.\.\.\}|\.\.\./.test(text);
+}
+
+function extractCodeBlocks(content) {
+  const blocks = [];
+  const codeBlockRegex = /```(\w+)([^\n]*)\n([\s\S]*?)```/g;
+  let match;
+  let index = 0;
+
+  while ((match = codeBlockRegex.exec(content)) !== null) {
+    blocks.push({
+      language: match[1].toLowerCase(),
+      metadata: match[2] || '',
+      code: match[3].trim(),
+      line: content.substring(0, match.index).split('\n').length,
+      index: index++
+    });
+  }
+
+  return blocks;
+}
+
+function emptyFileStats(relativePath) {
+  return {
+    path: relativePath,
+    json: {
+      total: 0,
+      parseable: 0,
+      placeholder: 0,
+      invalid: 0,
+      schemaBacked: 0,
+      unvalidated: 0
+    },
+    snippets: {
+      executable: 0,
+      eligible: 0,
+      testable: 0,
+      disabled: 0,
+      untested: 0,
+      integration: 0,
+      requiresEnv: 0
+    }
+  };
+}
+
+function analyzeFile(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const relativePath = path.relative(ROOT, filePath);
+  const pageTestable = isTestablePage(content);
+  const stats = emptyFileStats(relativePath);
+
+  for (const block of extractCodeBlocks(content)) {
+    if (block.language === 'json') {
+      stats.json.total++;
+
+      if (isPlaceholderJson(block.code)) {
+        stats.json.placeholder++;
+      } else {
+        try {
+          const parsed = JSON.parse(block.code);
+          stats.json.parseable++;
+          if (parsed && typeof parsed === 'object' && typeof parsed.$schema === 'string') {
+            stats.json.schemaBacked++;
+          } else {
+            stats.json.unvalidated++;
+          }
+        } catch {
+          stats.json.invalid++;
+        }
+      }
+    }
+
+    if (EXECUTABLE_LANGUAGES.has(block.language)) {
+      stats.snippets.executable++;
+
+      const disabled = metadataHas(block.metadata, /\btest=false\b/);
+      const testable = !disabled && (
+        pageTestable ||
+        metadataHas(block.metadata, /\btest=true\b/) ||
+        metadataHas(block.metadata, /\btestable\b/)
+      );
+
+      if (disabled) {
+        stats.snippets.disabled++;
+      } else {
+        stats.snippets.eligible++;
+      }
+
+      if (testable) {
+        stats.snippets.testable++;
+        if (metadataHas(block.metadata, /\bintegration(?:=true)?\b/) || metadataHas(block.metadata, /\blive\b/)) {
+          stats.snippets.integration++;
+        }
+        if (metadataHas(block.metadata, /\b(?:requires-env|requires_env|env|requires)=/)) {
+          stats.snippets.requiresEnv++;
+        }
+      }
+    }
+  }
+
+  stats.snippets.untested = Math.max(0, stats.snippets.eligible - stats.snippets.testable);
+  return stats;
+}
+
+function addTotals(target, fileStats) {
+  for (const key of Object.keys(target.json)) {
+    target.json[key] += fileStats.json[key];
+  }
+  for (const key of Object.keys(target.snippets)) {
+    target.snippets[key] += fileStats.snippets[key];
+  }
+}
+
+function sectionName(relativePath) {
+  const withoutRoot = relativePath.replace(/^docs\//, '');
+  const parts = withoutRoot.split('/');
+  return parts.length > 1 ? parts[0] : '(root)';
+}
+
+function buildReport() {
+  const files = walkFiles(docsDir);
+  const fileStats = files.map(analyzeFile);
+  const totals = emptyFileStats('TOTAL');
+  const sections = new Map();
+
+  for (const stat of fileStats) {
+    addTotals(totals, stat);
+    const section = sectionName(stat.path);
+    if (!sections.has(section)) {
+      sections.set(section, emptyFileStats(section));
+    }
+    addTotals(sections.get(section), stat);
+  }
+
+  const jsonDenominator = totals.json.parseable;
+  const snippetDenominator = totals.snippets.eligible;
+
+  return {
+    docsDir: path.relative(ROOT, docsDir) || '.',
+    generatedAt: new Date().toISOString(),
+    files: {
+      scanned: files.length,
+      withJson: fileStats.filter((f) => f.json.total > 0).length,
+      withExecutableSnippets: fileStats.filter((f) => f.snippets.executable > 0).length
+    },
+    json: {
+      ...totals.json,
+      schemaCoverage: percent(totals.json.schemaBacked, jsonDenominator)
+    },
+    snippets: {
+      ...totals.snippets,
+      testableCoverage: percent(totals.snippets.testable, snippetDenominator)
+    },
+    sections: [...sections.values()]
+      .map((section) => ({
+        path: section.path,
+        json: {
+          ...section.json,
+          schemaCoverage: percent(section.json.schemaBacked, section.json.parseable)
+        },
+        snippets: {
+          ...section.snippets,
+          testableCoverage: percent(section.snippets.testable, section.snippets.eligible)
+        }
+      }))
+      .sort((a, b) => a.path.localeCompare(b.path)),
+    topGaps: {
+      json: fileStats
+        .filter((f) => f.json.unvalidated > 0)
+        .sort((a, b) => b.json.unvalidated - a.json.unvalidated || a.path.localeCompare(b.path))
+        .slice(0, topN)
+        .map((f) => ({
+          path: f.path,
+          unvalidated: f.json.unvalidated,
+          schemaBacked: f.json.schemaBacked,
+          total: f.json.total
+        })),
+      snippets: fileStats
+        .filter((f) => f.snippets.untested > 0)
+        .sort((a, b) => b.snippets.untested - a.snippets.untested || a.path.localeCompare(b.path))
+        .slice(0, topN)
+        .map((f) => ({
+          path: f.path,
+          untested: f.snippets.untested,
+          testable: f.snippets.testable,
+          executable: f.snippets.executable
+        }))
+    }
+  };
+}
+
+function table(headers, rows) {
+  const widths = headers.map((h, i) => Math.max(
+    h.length,
+    ...rows.map((row) => String(row[i]).length)
+  ));
+  const line = (cols) => cols.map((col, i) => String(col).padEnd(widths[i])).join('  ');
+  return [line(headers), line(widths.map((w) => '-'.repeat(w))), ...rows.map(line)].join('\n');
+}
+
+function renderText(report) {
+  const rows = [
+    ['Files scanned', report.files.scanned],
+    ['Files with JSON', report.files.withJson],
+    ['Files with executable snippets', report.files.withExecutableSnippets],
+    ['JSON schema-backed', `${report.json.schemaBacked}/${report.json.parseable} (${report.json.schemaCoverage.toFixed(1)}%)`],
+    ['JSON placeholders', report.json.placeholder],
+    ['JSON invalid', report.json.invalid],
+    ['Runnable snippets testable', `${report.snippets.testable}/${report.snippets.eligible} (${report.snippets.testableCoverage.toFixed(1)}%)`],
+    ['Runnable snippets disabled', report.snippets.disabled]
+  ];
+
+  const sectionRows = report.sections.map((section) => [
+    section.path,
+    `${section.json.schemaBacked}/${section.json.parseable}`,
+    pct(section.json.schemaBacked, section.json.parseable),
+    `${section.snippets.testable}/${section.snippets.eligible}`,
+    pct(section.snippets.testable, section.snippets.eligible)
+  ]);
+
+  const jsonGapRows = report.topGaps.json.map((gap) => [
+    gap.path,
+    gap.unvalidated,
+    gap.schemaBacked,
+    gap.total
+  ]);
+
+  const snippetGapRows = report.topGaps.snippets.map((gap) => [
+    gap.path,
+    gap.untested,
+    gap.testable,
+    gap.executable
+  ]);
+
+  return [
+    'Documentation Example Coverage',
+    `Docs directory: ${report.docsDir}`,
+    '',
+    table(['Metric', 'Value'], rows),
+    '',
+    'By Section',
+    table(['Section', 'JSON schema', 'JSON %', 'Snippets', 'Snippet %'], sectionRows),
+    '',
+    `Top ${report.topGaps.json.length} JSON schema gaps`,
+    jsonGapRows.length
+      ? table(['File', 'Unvalidated', 'Schema-backed', 'JSON blocks'], jsonGapRows)
+      : 'No unvalidated JSON blocks found.',
+    '',
+    `Top ${report.topGaps.snippets.length} runnable snippet gaps`,
+    snippetGapRows.length
+      ? table(['File', 'Untested', 'Testable', 'Executable'], snippetGapRows)
+      : 'No untested runnable snippets found.'
+  ].join('\n');
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    '## Documentation Example Coverage',
+    '',
+    `Docs directory: \`${report.docsDir}\``,
+    '',
+    '| Metric | Value |',
+    '|---|---:|',
+    `| Files scanned | ${report.files.scanned} |`,
+    `| Files with JSON | ${report.files.withJson} |`,
+    `| Files with executable snippets | ${report.files.withExecutableSnippets} |`,
+    `| JSON schema-backed | ${report.json.schemaBacked}/${report.json.parseable} (${report.json.schemaCoverage.toFixed(1)}%) |`,
+    `| JSON placeholders | ${report.json.placeholder} |`,
+    `| JSON invalid | ${report.json.invalid} |`,
+    `| Runnable snippets testable | ${report.snippets.testable}/${report.snippets.eligible} (${report.snippets.testableCoverage.toFixed(1)}%) |`,
+    `| Runnable snippets disabled | ${report.snippets.disabled} |`,
+    '',
+    '### By Section',
+    '',
+    '| Section | JSON schema | JSON % | Snippets | Snippet % |',
+    '|---|---:|---:|---:|---:|'
+  ];
+
+  for (const section of report.sections) {
+    lines.push(`| \`${section.path}\` | ${section.json.schemaBacked}/${section.json.parseable} | ${pct(section.json.schemaBacked, section.json.parseable)} | ${section.snippets.testable}/${section.snippets.eligible} | ${pct(section.snippets.testable, section.snippets.eligible)} |`);
+  }
+
+  lines.push('', '### Top JSON Schema Gaps', '');
+  if (report.topGaps.json.length === 0) {
+    lines.push('No unvalidated JSON blocks found.');
+  } else {
+    lines.push('| File | Unvalidated | Schema-backed | JSON blocks |', '|---|---:|---:|---:|');
+    for (const gap of report.topGaps.json) {
+      lines.push(`| \`${gap.path}\` | ${gap.unvalidated} | ${gap.schemaBacked} | ${gap.total} |`);
+    }
+  }
+
+  lines.push('', '### Top Runnable Snippet Gaps', '');
+  if (report.topGaps.snippets.length === 0) {
+    lines.push('No untested runnable snippets found.');
+  } else {
+    lines.push('| File | Untested | Testable | Executable |', '|---|---:|---:|---:|');
+    for (const gap of report.topGaps.snippets) {
+      lines.push(`| \`${gap.path}\` | ${gap.untested} | ${gap.testable} | ${gap.executable} |`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+const report = buildReport();
+
+if (format === 'json') {
+  console.log(JSON.stringify(report, null, 2));
+} else if (format === 'markdown') {
+  console.log(renderMarkdown(report));
+} else {
+  console.log(renderText(report));
+}

--- a/scripts/docs-json-field-audit-baseline.json
+++ b/scripts/docs-json-field-audit-baseline.json
@@ -1,0 +1,105 @@
+{
+  "version": 1,
+  "updated_at": "2026-05-28T16:57:58.895Z",
+  "description": "Baseline for docs-json-field-audit. CI fails only on findings whose key count exceeds this baseline.",
+  "entries": [
+    {
+      "file": "docs/creative/channels/broadcast.mdx",
+      "path": "$",
+      "field": "type",
+      "schema": "/schemas/core/format.json",
+      "count": 1
+    },
+    {
+      "file": "docs/creative/channels/broadcast.mdx",
+      "path": "$.assets[1].requirements",
+      "field": "description",
+      "schema": "/schemas/core/format.json",
+      "count": 1
+    },
+    {
+      "file": "docs/creative/channels/ctv.mdx",
+      "path": "$",
+      "field": "type",
+      "schema": "/schemas/core/format.json",
+      "count": 2
+    },
+    {
+      "file": "docs/creative/formats.mdx",
+      "path": "$",
+      "field": "type",
+      "schema": "https://adcontextprotocol.org/schemas/v3/core/format.json",
+      "count": 3
+    },
+    {
+      "file": "docs/creative/formats.mdx",
+      "path": "$.formats[0]",
+      "field": "type",
+      "schema": "https://adcontextprotocol.org/schemas/v3/creative/list-creative-formats-response.json",
+      "count": 1
+    },
+    {
+      "file": "docs/governance/content-standards/tasks/validate_content_delivery.mdx",
+      "path": "$.results[0].features[0]",
+      "field": "value",
+      "schema": "/schemas/content-standards/validate-content-delivery-response.json",
+      "count": 1
+    },
+    {
+      "file": "docs/governance/content-standards/tasks/validate_content_delivery.mdx",
+      "path": "$.results[1].features[0]",
+      "field": "message",
+      "schema": "/schemas/content-standards/validate-content-delivery-response.json",
+      "count": 1
+    },
+    {
+      "file": "docs/governance/content-standards/tasks/validate_content_delivery.mdx",
+      "path": "$.results[1].features[0]",
+      "field": "value",
+      "schema": "/schemas/content-standards/validate-content-delivery-response.json",
+      "count": 1
+    },
+    {
+      "file": "docs/intro.mdx",
+      "path": "$.brands[0]",
+      "field": "identity_agent",
+      "schema": "https://adcontextprotocol.org/schemas/v3/brand.json",
+      "count": 1
+    },
+    {
+      "file": "docs/media-buy/capability-discovery/implementing-standard-formats.mdx",
+      "path": "$",
+      "field": "type",
+      "schema": "/schemas/core/format.json",
+      "count": 1
+    },
+    {
+      "file": "docs/media-buy/capability-discovery/implementing-standard-formats.mdx",
+      "path": "$.formats[0]",
+      "field": "type",
+      "schema": "/schemas/media-buy/list-creative-formats-response.json",
+      "count": 1
+    },
+    {
+      "file": "docs/media-buy/task-reference/provide_performance_feedback.mdx",
+      "path": "$",
+      "field": "vendor",
+      "schema": "/schemas/media-buy/provide-performance-feedback-request.json",
+      "count": 1
+    },
+    {
+      "file": "docs/protocol/get_adcp_capabilities.mdx",
+      "path": "$.governance",
+      "field": "content_standards",
+      "schema": "/schemas/protocol/get-adcp-capabilities-response.json",
+      "count": 1
+    },
+    {
+      "file": "docs/protocol/get_adcp_capabilities.mdx",
+      "path": "$.governance",
+      "field": "policy_registry",
+      "schema": "/schemas/protocol/get-adcp-capabilities-response.json",
+      "count": 1
+    }
+  ]
+}

--- a/scripts/docs-json-field-audit.cjs
+++ b/scripts/docs-json-field-audit.cjs
@@ -1,0 +1,558 @@
+#!/usr/bin/env node
+/**
+ * Advisory audit for unknown public fields in schema-backed docs JSON examples.
+ *
+ * JSON Schema intentionally leaves many protocol objects extensible at the wire
+ * level. Docs examples are different: unknown public-looking fields often mean
+ * stale documentation. This reporter flags those fields without failing by
+ * default; pass --check to make findings gating.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const DOCS_DIR = path.join(ROOT, 'docs');
+const SCHEMAS_DIR = path.join(ROOT, 'static', 'schemas', 'source');
+
+const args = process.argv.slice(2);
+const format = args.includes('--json')
+  ? 'json'
+  : args.includes('--markdown')
+    ? 'markdown'
+    : 'text';
+const check = args.includes('--check');
+const updateBaseline = args.includes('--update-baseline');
+const topN = Number.parseInt(readArg('--top', '25'), 10);
+const baselinePath = path.resolve(readArg(
+  '--baseline',
+  path.join(ROOT, 'scripts', 'docs-json-field-audit-baseline.json')
+));
+
+const FLEXIBLE_FIELD_NAMES = new Set([
+  'context',
+  'data',
+  'details',
+  'ext',
+  'extensions',
+  'fields',
+  'metadata',
+  'params',
+  'platform_extensions'
+]);
+
+function readArg(name, fallback = null) {
+  const index = args.indexOf(name);
+  if (index === -1 || index + 1 >= args.length) return fallback;
+  return args[index + 1];
+}
+
+function walkFiles(dir, predicate) {
+  const files = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(fullPath, predicate));
+    } else if (entry.isFile() && predicate(fullPath)) {
+      files.push(fullPath);
+    }
+  }
+  return files.sort();
+}
+
+function loadSchemas() {
+  const schemas = new Map();
+  for (const file of walkFiles(SCHEMAS_DIR, (f) => f.endsWith('.json'))) {
+    const schema = JSON.parse(fs.readFileSync(file, 'utf8'));
+    tagSchemaNodes(schema, schema);
+    const rel = path.relative(SCHEMAS_DIR, file).replace(/\\/g, '/');
+    const id = schema.$id || `/schemas/${rel}`;
+    for (const key of schemaKeys(id, rel)) {
+      schemas.set(key, schema);
+    }
+  }
+  return schemas;
+}
+
+function tagSchemaNodes(node, root) {
+  if (!node || typeof node !== 'object') return;
+  Object.defineProperty(node, '__root', {
+    value: root,
+    enumerable: false,
+    configurable: false
+  });
+
+  for (const value of Object.values(node)) {
+    if (value && typeof value === 'object') {
+      tagSchemaNodes(value, root);
+    }
+  }
+}
+
+function resolveJsonPointer(root, pointer) {
+  const parts = pointer
+    .replace(/^#/, '')
+    .replace(/^\//, '')
+    .split('/')
+    .filter(Boolean)
+    .map((part) => part.replace(/~1/g, '/').replace(/~0/g, '~'));
+
+  let current = root;
+  for (const part of parts) {
+    if (!current || typeof current !== 'object') return null;
+    current = current[part];
+  }
+  return current || null;
+}
+
+function schemaKeys(id, rel) {
+  const bare = id.replace(/^\/schemas\//, '');
+  return [
+    id,
+    `/schemas/${bare}`,
+    `/schemas/latest/${bare}`,
+    `https://adcontextprotocol.org/schemas/${bare}`,
+    `https://adcontextprotocol.org/schemas/latest/${bare}`,
+    path.join(SCHEMAS_DIR, rel)
+  ];
+}
+
+function normalizeSchemaUri(uri) {
+  let schemaPath = uri.replace(/^https?:\/\/[^/]+/, '');
+  schemaPath = schemaPath.replace(/^\/schemas\/latest\//, '/schemas/');
+  schemaPath = schemaPath.replace(/^\/schemas\/v\d+(?:\.\d+)*(?:-[^/]+)?\//, '/schemas/');
+  return schemaPath;
+}
+
+function isAdcpSchemaUri(uri) {
+  return uri.startsWith('/schemas/') ||
+    /^https?:\/\/adcontextprotocol\.org\/schemas\//.test(uri);
+}
+
+function extractJsonBlocks(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const blocks = [];
+  const codeBlockRegex = /```json[^\n]*\n([\s\S]*?)```/g;
+  let match;
+
+  while ((match = codeBlockRegex.exec(content)) !== null) {
+    const code = match[1].trim();
+    const line = content.substring(0, match.index).split('\n').length;
+
+    if (/\[\.\.\.\]|\{\.\.\.\}|\.\.\./.test(code)) {
+      blocks.push({ file: filePath, line, code, kind: 'placeholder' });
+      continue;
+    }
+
+    try {
+      const parsed = JSON.parse(code);
+      blocks.push({
+        file: filePath,
+        line,
+        code,
+        parsed,
+        kind: parsed && typeof parsed === 'object' && typeof parsed.$schema === 'string'
+          ? 'schema'
+          : 'plain'
+      });
+    } catch (error) {
+      blocks.push({ file: filePath, line, code, kind: 'invalid', error: error.message });
+    }
+  }
+
+  return blocks;
+}
+
+function deref(schema, schemas, seen = new Set()) {
+  if (!schema || typeof schema !== 'object' || !schema.$ref) return schema;
+  const ref = schema.$ref.startsWith('#')
+    ? schema.$ref
+    : normalizeSchemaUri(schema.$ref);
+  if (seen.has(ref)) return schema;
+  const resolved = schema.$ref.startsWith('#')
+    ? resolveJsonPointer(schema.__root || schema, schema.$ref)
+    : schemas.get(ref);
+  if (!resolved) return schema;
+  seen.add(ref);
+  return deref(resolved, schemas, seen);
+}
+
+function childSchemas(schema, schemas) {
+  const resolved = deref(schema, schemas);
+  if (!resolved || typeof resolved !== 'object') return [];
+  const children = [];
+  for (const key of ['allOf', 'oneOf', 'anyOf']) {
+    if (Array.isArray(resolved[key])) {
+      children.push(...resolved[key].map((child) => deref(child, schemas)));
+    }
+  }
+  return children;
+}
+
+function collectObjectContract(schema, schemas, seen = new Set()) {
+  const resolved = deref(schema, schemas);
+  if (!resolved || typeof resolved !== 'object') {
+    return { properties: new Map(), patterns: [] };
+  }
+
+  const marker = resolved.$id || JSON.stringify(Object.keys(resolved).sort());
+  if (seen.has(marker)) {
+    return { properties: new Map(), patterns: [] };
+  }
+  seen.add(marker);
+
+  const properties = new Map();
+  const patterns = [];
+
+  if (resolved.properties && typeof resolved.properties === 'object') {
+    for (const [key, value] of Object.entries(resolved.properties)) {
+      if (!properties.has(key)) properties.set(key, []);
+      properties.get(key).push(value);
+    }
+  }
+
+  if (resolved.patternProperties && typeof resolved.patternProperties === 'object') {
+    for (const pattern of Object.keys(resolved.patternProperties)) {
+      patterns.push(pattern);
+    }
+  }
+
+  for (const child of childSchemas(resolved, schemas)) {
+    const childContract = collectObjectContract(child, schemas, new Set(seen));
+    for (const [key, values] of childContract.properties.entries()) {
+      if (!properties.has(key)) properties.set(key, []);
+      properties.get(key).push(...values);
+    }
+    patterns.push(...childContract.patterns);
+  }
+
+  return { properties, patterns };
+}
+
+function matchesPattern(key, patterns) {
+  return patterns.some((pattern) => {
+    try {
+      return new RegExp(pattern).test(key);
+    } catch {
+      return false;
+    }
+  });
+}
+
+function schemaForProperty(schema, propertyName, schemas) {
+  const contract = collectObjectContract(schema, schemas);
+  const candidates = contract.properties.get(propertyName) || [];
+  if (candidates.length === 0) return null;
+  if (candidates.length === 1) return candidates[0];
+  return { anyOf: candidates };
+}
+
+function schemaForItems(schema, schemas) {
+  const resolved = deref(schema, schemas);
+  if (!resolved || typeof resolved !== 'object') return null;
+  if (resolved.items) return resolved.items;
+
+  for (const child of childSchemas(resolved, schemas)) {
+    const itemSchema = schemaForItems(child, schemas);
+    if (itemSchema) return itemSchema;
+  }
+
+  return null;
+}
+
+function isFlexiblePath(jsonPath) {
+  return jsonPath
+    .split('.')
+    .some((part) => FLEXIBLE_FIELD_NAMES.has(part.replace(/\[\d+\]$/, '')));
+}
+
+function auditValue({ value, schema, schemas, jsonPath, findings }) {
+  const resolved = deref(schema, schemas);
+  if (!resolved || value === null || typeof value !== 'object') return;
+
+  if (Array.isArray(value)) {
+    const itemSchema = schemaForItems(resolved, schemas);
+    if (!itemSchema) return;
+    value.forEach((item, index) => {
+      auditValue({
+        value: item,
+        schema: itemSchema,
+        schemas,
+        jsonPath: `${jsonPath}[${index}]`,
+        findings
+      });
+    });
+    return;
+  }
+
+  if (isFlexiblePath(jsonPath)) return;
+
+  const contract = collectObjectContract(resolved, schemas);
+  if (contract.properties.size > 0) {
+    for (const key of Object.keys(value)) {
+      if (jsonPath === '$' && key === '$schema') continue;
+      if (FLEXIBLE_FIELD_NAMES.has(key)) continue;
+      if (contract.properties.has(key)) continue;
+      if (matchesPattern(key, contract.patterns)) continue;
+
+      findings.push({
+        path: jsonPath,
+        field: key,
+        message: `Unknown field ${jsonPath}.${key}`
+      });
+    }
+  }
+
+  for (const [key, childValue] of Object.entries(value)) {
+    if (jsonPath === '$' && key === '$schema') continue;
+    const childSchema = schemaForProperty(resolved, key, schemas);
+    if (!childSchema) continue;
+    auditValue({
+      value: childValue,
+      schema: childSchema,
+      schemas,
+      jsonPath: jsonPath === '$' ? `$.${key}` : `${jsonPath}.${key}`,
+      findings
+    });
+  }
+}
+
+function runAudit() {
+  const schemas = loadSchemas();
+  const docs = walkFiles(DOCS_DIR, (f) => /\.(md|mdx)$/.test(f));
+  const findings = [];
+  let schemaBackedBlocks = 0;
+
+  for (const file of docs) {
+    for (const block of extractJsonBlocks(file)) {
+      if (block.kind !== 'schema') continue;
+      if (!isAdcpSchemaUri(block.parsed.$schema)) continue;
+      schemaBackedBlocks++;
+
+      const schemaUri = normalizeSchemaUri(block.parsed.$schema);
+      const schema = schemas.get(schemaUri);
+      if (!schema) {
+        findings.push({
+          file: path.relative(ROOT, file),
+          line: block.line,
+          schema: block.parsed.$schema,
+          path: '$',
+          field: '$schema',
+          message: `Schema not found: ${block.parsed.$schema}`
+        });
+        continue;
+      }
+
+      const blockFindings = [];
+      auditValue({
+        value: block.parsed,
+        schema,
+        schemas,
+        jsonPath: '$',
+        findings: blockFindings
+      });
+
+      for (const finding of blockFindings) {
+        findings.push({
+          file: path.relative(ROOT, file),
+          line: block.line,
+          schema: block.parsed.$schema,
+          ...finding
+        });
+      }
+    }
+  }
+
+  const byFile = new Map();
+  for (const finding of findings) {
+    byFile.set(finding.file, (byFile.get(finding.file) || 0) + 1);
+  }
+
+  const baseline = compareBaseline(findings);
+
+  if (updateBaseline) {
+    writeBaseline(findings);
+    baseline.updated = true;
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    schemaBackedBlocks,
+    findings: findings.slice(0, topN),
+    totalFindings: findings.length,
+    baseline,
+    topFiles: [...byFile.entries()]
+      .map(([file, count]) => ({ file, count }))
+      .sort((a, b) => b.count - a.count || a.file.localeCompare(b.file))
+      .slice(0, topN)
+  };
+}
+
+function findingKey(finding) {
+  return [
+    finding.file,
+    finding.path,
+    finding.field,
+    finding.schema
+  ].join('|');
+}
+
+function summarizeFindings(findings) {
+  const counts = new Map();
+  for (const finding of findings) {
+    const key = findingKey(finding);
+    counts.set(key, (counts.get(key) || 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .map(([key, count]) => {
+      const [file, objectPath, field, schema] = key.split('|');
+      return { file, path: objectPath, field, schema, count };
+    })
+    .sort((a, b) =>
+      a.file.localeCompare(b.file) ||
+      a.path.localeCompare(b.path) ||
+      a.field.localeCompare(b.field) ||
+      a.schema.localeCompare(b.schema)
+    );
+}
+
+function readBaseline() {
+  if (!fs.existsSync(baselinePath)) {
+    return { exists: false, entries: [] };
+  }
+
+  const baseline = JSON.parse(fs.readFileSync(baselinePath, 'utf8'));
+  return {
+    exists: true,
+    entries: Array.isArray(baseline.entries) ? baseline.entries : []
+  };
+}
+
+function writeBaseline(findings) {
+  const baseline = {
+    version: 1,
+    updated_at: new Date().toISOString(),
+    description: 'Baseline for docs-json-field-audit. CI fails only on findings whose key count exceeds this baseline.',
+    entries: summarizeFindings(findings)
+  };
+  fs.writeFileSync(baselinePath, `${JSON.stringify(baseline, null, 2)}\n`);
+}
+
+function compareBaseline(findings) {
+  const currentEntries = summarizeFindings(findings);
+  const baseline = readBaseline();
+  const baselineCounts = new Map(
+    baseline.entries.map((entry) => [
+      findingKey({
+        file: entry.file,
+        path: entry.path,
+        field: entry.field,
+        schema: entry.schema
+      }),
+      entry.count || 0
+    ])
+  );
+
+  const newEntries = [];
+  for (const entry of currentEntries) {
+    const key = findingKey(entry);
+    const allowed = baselineCounts.get(key) || 0;
+    if (entry.count > allowed) {
+      newEntries.push({ ...entry, allowed, new_count: entry.count - allowed });
+    }
+  }
+
+  return {
+    path: path.relative(ROOT, baselinePath),
+    exists: baseline.exists,
+    entries: baseline.entries.length,
+    current_entries: currentEntries.length,
+    new_entries: newEntries,
+    new_findings: newEntries.reduce((sum, entry) => sum + entry.new_count, 0),
+    updated: false
+  };
+}
+
+function table(headers, rows) {
+  const widths = headers.map((h, i) => Math.max(
+    h.length,
+    ...rows.map((row) => String(row[i]).length)
+  ));
+  const line = (cols) => cols.map((col, i) => String(col).padEnd(widths[i])).join('  ');
+  return [line(headers), line(widths.map((w) => '-'.repeat(w))), ...rows.map(line)].join('\n');
+}
+
+function renderText(report) {
+  const findingRows = report.findings.map((finding) => [
+    `${finding.file}:${finding.line}`,
+    finding.path,
+    finding.field,
+    finding.schema
+  ]);
+  const topRows = report.topFiles.map((entry) => [entry.file, entry.count]);
+
+  return [
+    'Docs JSON Field Audit',
+    '',
+    `Schema-backed JSON blocks: ${report.schemaBackedBlocks}`,
+    `Unknown-field findings: ${report.totalFindings}`,
+    `Baseline: ${report.baseline.exists ? report.baseline.path : `${report.baseline.path} (missing)`}`,
+    `New findings vs baseline: ${report.baseline.new_findings}`,
+    '',
+    'Top files',
+    topRows.length ? table(['File', 'Findings'], topRows) : 'No findings.',
+    '',
+    `First ${report.findings.length} findings`,
+    findingRows.length ? table(['Location', 'Object', 'Field', 'Schema'], findingRows) : 'No findings.'
+  ].join('\n');
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    '## Docs JSON Field Audit',
+    '',
+    `Schema-backed JSON blocks: **${report.schemaBackedBlocks}**`,
+    `Unknown-field findings: **${report.totalFindings}**`,
+    `Baseline: \`${report.baseline.path}\`${report.baseline.exists ? '' : ' (missing)'}`,
+    `New findings vs baseline: **${report.baseline.new_findings}**`,
+    '',
+    '### Top Files',
+    ''
+  ];
+
+  if (report.topFiles.length === 0) {
+    lines.push('No findings.');
+  } else {
+    lines.push('| File | Findings |', '|---|---:|');
+    for (const entry of report.topFiles) {
+      lines.push(`| \`${entry.file}\` | ${entry.count} |`);
+    }
+  }
+
+  lines.push('', '### Sample Findings', '');
+  if (report.findings.length === 0) {
+    lines.push('No findings.');
+  } else {
+    lines.push('| Location | Object | Field | Schema |', '|---|---|---|---|');
+    for (const finding of report.findings) {
+      lines.push(`| \`${finding.file}:${finding.line}\` | \`${finding.path}\` | \`${finding.field}\` | \`${finding.schema}\` |`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+const report = runAudit();
+
+if (format === 'json') {
+  console.log(JSON.stringify(report, null, 2));
+} else if (format === 'markdown') {
+  console.log(renderMarkdown(report));
+} else {
+  console.log(renderText(report));
+}
+
+if (check && report.baseline.new_findings > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
Adds docs example coverage reporting for schema-backed JSON blocks and runnable snippets, plus a JSON field audit that ratchets against a checked-in baseline.
Fixes the stale get_products targeting example by replacing targeting_description with schema-backed product fields and brief_relevance.
Cleans the video channel examples so their platform-specific fields live under ext and no longer create audit findings.
Validation included focused JSON schema checks, script syntax/audit checks, precommit tests/typecheck, storyboard matrices, and Mintlify broken-link validation.