### PR TITLE
Document upstream attestation mode selection

### DIFF
--- a/.changeset/upstream-attestation-mode-selection.md
+++ b/.changeset/upstream-attestation-mode-selection.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": minor
+---
+
+Document the normative attestation-mode selection rule for upstream_traffic compliance checks.
+
+Conforming runners now have one explicit raw-vs-digest decision order for query_upstream_traffic that preserves assertion coverage, including the non-JSON identifier_paths case where raw mode is required to avoid grading an otherwise evaluable assertion as not_applicable. Storyboard authors should rely on that rule instead of non-schema attestation-mode hints.
+
+Closes #5080.

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -1418,6 +1418,34 @@
 #   recorded calls during the assertion window grade as failed (the
 #   "controller present and observed nothing" path is the façade signal).
 #
+#   Runner attestation-mode selection (normative):
+#     Conforming runners MUST choose params.attestation_mode for
+#     comply_test_controller query_upstream_traffic calls in a way that
+#     preserves assertion coverage:
+#       1. If any upstream_traffic validation in the current step sets
+#          attestation_mode_required: "raw", request "raw".
+#       2. Else if any upstream_traffic validation in the current step declares
+#          payload_must_contain, request "raw"; arbitrary payload-path
+#          assertions cannot be evaluated from digest attestations.
+#       3. Else if every upstream_traffic validation in the current step can
+#          be evaluated from count/endpoint/purpose plus identifier_paths, and
+#          the runner can supply params.identifier_value_digests for all
+#          resolved identifier values, the runner SHOULD request "digest" when
+#          it knows the matching upstream calls are JSON-shaped
+#          (`application/json` or `*/*+json`). If the runner does not know the
+#          matching calls are JSON-shaped, request "raw"; digest-mode
+#          identifier_match_proofs are intentionally unavailable for non-JSON
+#          payloads, so an unconditional digest request can turn an otherwise
+#          evaluable identifier_paths assertion into not_applicable.
+#       4. Otherwise, request "raw".
+#     Controllers MAY still return digest-mode attestations for a raw request
+#     when local policy forbids raw payload disclosure; raw-required and
+#     payload_must_contain assertions then grade not_applicable as described
+#     below.
+#     Storyboard authors SHOULD NOT invent non-schema attestation-mode hints.
+#     Use attestation_mode_required: "raw" only for hard raw requirements;
+#     otherwise rely on this runner selection rule.
+#
 #   Fields:
 #     min_count: integer (default: 1)
 #                              # Minimum number of recorded calls that match


### PR DESCRIPTION
## Summary
- document the normative upstream_traffic attestation-mode selection rule in storyboard-schema.yaml
- keep preferred_attestation_mode / attestation_mode_hint out of the storyboard schema
- preserve assertion coverage by requesting raw for raw-required, payload_must_contain, and unknown-content identifier_paths cases; digest is the preference only when identifier-only checks are known JSON-shaped and digests can be supplied
- add a minor changeset for the normative runner behavior

Closes #5080.

## Validation
- npm run test:storyboard-raw-mode-required
- npm run test:storyboard-upstream-traffic-paths
- npm run test:storyboard-doc-parity
- npm run build:compliance
- precommit: npm run test:unit && npm run test:test-dynamic-imports && npm run test:callapi-state-change && npm run typecheck
- push hook: storyboard matrix for current compliance source and 3.0 compatibility bundle

## Review
- protocol reviewer re-reviewed the revised diff and reported no protocol/spec correctness, workflow regression, or versioning findings. Residual risk: this repo has no executable runner selector to unit-test the new decision matrix directly.