### PR TITLE
feat(brand): add authorized operator validity scope

### DIFF
--- a/.changeset/authorized-operator-validity-scope.md
+++ b/.changeset/authorized-operator-validity-scope.md
@@ -1,0 +1,5 @@
+---
+"@adcp/spec": minor
+---
+
+Add optional `scopes`, `valid_from`, and `valid_until` fields to `brand.json` `authorized_operators[]` so houses can time-box and activity-scope agency-of-record or delegated-operator relationships. Existing entries remain valid when these fields are omitted.

--- a/.changeset/authorized-operator-validity-scope.md
+++ b/.changeset/authorized-operator-validity-scope.md
@@ -1,5 +1,5 @@
 ---
-"@adcp/spec": minor
+"adcontextprotocol": minor
 ---
 
 Add optional `scopes`, `valid_from`, and `valid_until` fields to `brand.json` `authorized_operators[]` so houses can time-box and activity-scope agency-of-record or delegated-operator relationships. Existing entries remain valid when these fields are omitted.

--- a/docs/brand-protocol/brand-json.mdx
+++ b/docs/brand-protocol/brand-json.mdx
@@ -338,6 +338,14 @@ There is no inheritance/override block. Each consumer-side question has a single
 
 **Identity fields** (`name`, `names`, `logos`, `colors`, `fonts`, `tone`, `voice`, `tagline`, `visual_guidelines`, `avatar`): brand-level value is authoritative; the house value is not consulted. Brand teams own brand identity.
 
+### Authorized Operator Resolution
+
+`authorized_operators[]` entries may be scoped by brand, country, activity, and time. Consumers evaluating an operator relationship MUST ignore an entry when the current time is before `valid_from` or at/after `valid_until`. Omitted validity fields mean the house has not published a machine-readable start or end bound.
+
+When `scopes` is omitted, consumers should treat the entry as backwards-compatible broad authorization for the listed brands and countries. When `scopes` is present, the operator is authorized only for the listed activities, or for all activities when it explicitly contains `all`.
+
+`authorized_operators[]` does not replace publisher-side inventory authorization. For delegated or network inventory, buyers still need the publisher's matching `adagents.json` authorization; the brand file establishes who may represent the brand or house, while `adagents.json` establishes who may sell a publisher's inventory.
+
 **Compliance and governance fields**: the resolved value is the **strictest of** the house-level and brand-level values. A brand cannot weaken a house's governance assertions; it can only add stricter constraints. Applies to:
 
 - `data_subject_contestation` — both contacts SHOULD be presented to data subjects (consumers may use either; brand-level does NOT replace house-level)

--- a/static/schemas/source/brand.json
+++ b/static/schemas/source/brand.json
@@ -798,7 +798,7 @@
     },
     "authorized_operator": {
       "type": "object",
-      "description": "An entity authorized to represent brands from this house. Verified by resolving the operator's domain.",
+      "description": "An entity authorized to represent brands from this house. Verified by resolving the operator's domain. Optional validity fields let houses time-box agency-of-record and delegated-operator relationships without changing historical entries.",
       "properties": {
         "domain": {
           "$ref": "#/definitions/domain",
@@ -820,6 +820,26 @@
             "type": "string",
             "pattern": "^[A-Z]{2}$"
           }
+        },
+        "scopes": {
+          "type": "array",
+          "description": "Activities this operator is authorized to perform for the listed brands and countries. Omit for backwards-compatible broad authorization. Use ['all'] only when every listed scope is delegated.",
+          "items": {
+            "type": "string",
+            "enum": ["all", "media_buying", "creative_generation", "rights_clearance", "governance", "measurement", "agent_operations"]
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "valid_from": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp when this operator authorization starts. Omit when authorization is already active or the start date is not tracked."
+        },
+        "valid_until": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp when this operator authorization expires. Consumers MUST treat entries at or after this timestamp as inactive for authorization decisions."
         }
       },
       "required": ["domain", "brands"],
@@ -2124,16 +2144,21 @@
         {
           "domain": "wpp.com",
           "brands": ["nike", "air_jordan"],
-          "countries": ["US", "GB", "DE", "FR"]
+          "countries": ["US", "GB", "DE", "FR"],
+          "scopes": ["media_buying", "creative_generation"],
+          "valid_from": "2026-01-01T00:00:00Z",
+          "valid_until": "2027-01-01T00:00:00Z"
         },
         {
           "domain": "dentsu.co.jp",
           "brands": ["nike"],
-          "countries": ["JP"]
+          "countries": ["JP"],
+          "scopes": ["media_buying"]
         },
         {
           "domain": "nike.com",
-          "brands": ["*"]
+          "brands": ["*"],
+          "scopes": ["all"]
         }
       ],
       "last_updated": "2026-01-15T10:00:00Z"


### PR DESCRIPTION
## Summary

- add optional `scopes`, `valid_from`, and `valid_until` to `brand.json` `authorized_operators[]`
- document consumer handling for expired, not-yet-valid, and scoped operator authorizations
- update the canonical schema example and add a minor changeset

## Why

Agency-of-record and delegated-operator relationships rotate. A static `authorized_operators[]` entry without time bounds or activity scope can remain machine-readable after the underlying relationship ends.

This keeps the model additive: omitted fields preserve existing broad authorization semantics, while houses that know the window or activity scope can publish it explicitly.

Closes #5140.

## Validation

- `npm run build:schemas`
- `npm run test:schemas`
- `npm run test:examples`
- `npm run lint:schema-links`
- `npm run precommit`
- push hook docs validation
