### PR TITLE
test(media-buy): add legacy package correlation coverage

### DIFF
--- a/.changeset/package-correlation-legacy-fallback.md
+++ b/.changeset/package-correlation-legacy-fallback.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": patch
+---
+
+test(compliance): add a media-buy compatibility storyboard for legacy package correlation without `product_id`.
+
+The new non-required `media_buy_seller/package_correlation_legacy_fallback` scenario seeds a legacy-shaped media buy whose package omits `product_id` and verifies buyers can recover package correlation through persisted package `context.buyer_ref`.

--- a/docs/media-buy/task-reference/create_media_buy.mdx
+++ b/docs/media-buy/task-reference/create_media_buy.mdx
@@ -183,7 +183,7 @@ npx @adcp/sdk@latest \
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `product_id` | string | Yes | Product ID from `get_products`. Every response package object that represents this requested package MUST echo this value. |
+| `product_id` | string | Yes | Product ID from `get_products`. Sellers MUST echo this value on every response package object that represents this requested package. |
 | `pricing_option_id` | string | Yes | Pricing option ID from product's `pricing_options` array |
 | `format_ids` | FormatID[] | No | Legacy named-format selector. Format IDs that will be used — must be supported by product. When omitted (and no 3.1+ format-option selector is present), defaults to all formats supported by the product. Format-option-aware buyer SDKs targeting a heterogeneous seller population SHOULD dual-emit this alongside `format_option_refs` so legacy-format-only sellers receive an explicit format set rather than defaulting to all-formats. |
 | `format_option_refs` | FormatOptionRef[] | No | 3.1+ format-option selector. Structured references to entries in the package's target product `format_options[]`: `{scope: "publisher", publisher_domain, format_option_id}` for publisher-catalog-backed options, or `{scope: "product", format_option_id}` for product-local options (see [canonical formats](/docs/creative/canonical-formats)). When present, `format_option_refs` wins over `format_ids`. Sellers MUST reject with `UNSUPPORTED_FEATURE` (field path `packages[i].format_option_refs[j]`) when an entry doesn't match a `format_options[]` entry, when the product is legacy-format-only, or when the product's `format_options[]` entries don't publish selectable `format_option_id` values. |
@@ -927,7 +927,9 @@ The `context` field is an opaque object that sellers echo unchanged in responses
 
 Context works at two levels:
 - **Media buy level** — echoed in the `create_media_buy` response
-- **Package level** — echoed in each package's response, webhooks, and read surfaces, useful for mapping `package_id` back to your internal line items. For explicit package requests, 3.1+ sellers MUST also echo `product_id`; when targeting mixed seller populations, include package context such as `context.buyer_ref` as a legacy-safe fallback.
+- **Package level** — echoed in each package's response, webhooks, and read surfaces, useful for mapping `package_id` back to your internal line items. For explicit package requests, sellers MUST also echo `product_id`.
+
+When targeting mixed seller populations, include package context such as `context.buyer_ref` as a legacy-safe fallback for older sellers that may not echo `product_id`.
 
 **Mapping to internal campaign and line item IDs:**
 

--- a/docs/media-buy/task-reference/get_media_buys.mdx
+++ b/docs/media-buy/task-reference/get_media_buys.mdx
@@ -76,7 +76,7 @@ Returns an array of media buys with current status, creative approval state, and
 | Field | Description |
 |-------|-------------|
 | `package_id` | Seller's package identifier |
-| `product_id` | Product identifier this package is purchased from. For packages created from an explicit `create_media_buy` package request, every response package object that represents that requested package MUST echo the request package's `product_id`. |
+| `product_id` | Product identifier this package is purchased from. For packages created from an explicit `create_media_buy` package request, sellers MUST echo the request package's `product_id` on every response package object that represents that requested package. |
 | `currency` | Optional package-level currency override (defaults to media buy `currency`) |
 | `bid_price` | Current bid price for auction-based packages (in package `currency` if present, otherwise media buy `currency`) |
 | `start_time` | Flight start time (ISO 8601). Check this before interpreting delivery status. |

--- a/static/compliance/source/protocols/media-buy/scenarios/package_correlation_legacy_fallback.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/package_correlation_legacy_fallback.yaml
@@ -1,0 +1,113 @@
+id: media_buy_seller/package_correlation_legacy_fallback
+version: "1.0.0"
+title: "Legacy package correlation fallback without product_id"
+category: media_buy_seller
+summary: "Models the mixed-seller compatibility path where a legacy package response omits product_id and buyers correlate by package context.buyer_ref."
+track: media_buy
+required_tools:
+  - get_media_buys
+
+narrative: |
+  Current sellers MUST echo package product_id for explicit create_media_buy
+  package requests. Legacy sellers may still return package objects without
+  product_id. Buyers and SDKs targeting mixed seller populations need an
+  executable compatibility vector for that legacy response shape: correlate the
+  seller-assigned package_id back to the requested line item through package
+  context, commonly context.buyer_ref.
+
+  This storyboard is a compatibility fixture, not the current seller
+  conformance path. The runner seeds a legacy-shaped media buy whose package
+  intentionally omits product_id, then verifies get_media_buys still surfaces
+  package-level context so a buyer can recover the mapping.
+
+agent:
+  interaction_model: stateful_preloaded
+  capabilities:
+    - sells_media
+  examples:
+    - "Compatibility test harnesses validating buyer-side package correlation"
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: |
+    The runner seeds a legacy-shaped media buy via seed_media_buy. Sellers or
+    SDK test harnesses that do not implement seed_media_buy grade this scenario
+    not_applicable rather than failing current seller conformance.
+  test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  media_buys:
+    - media_buy_id: "legacy_package_correlation_buy"
+      status: "active"
+      currency: "USD"
+      total_budget: 5000
+      confirmed_at: "2026-04-01T00:00:00Z"
+      revision: 1
+      context:
+        correlation_id: "legacy-package-correlation-media-buy"
+      packages:
+        - package_id: "pkg_legacy_context_only"
+          budget: 5000
+          currency: "USD"
+          context:
+            buyer_ref: "legacy-line-001"
+
+phases:
+  - id: read_legacy_package
+    title: "Read a legacy package shape"
+    narrative: |
+      The buyer reads a seeded media buy whose package intentionally has no
+      product_id. The response must still include package context.buyer_ref,
+      giving the buyer a stable fallback mapping from package_id to the line
+      item it submitted.
+    steps:
+      - id: get_seeded_legacy_buy
+        title: "Get seeded legacy media buy"
+        task: get_media_buys
+        schema_ref: "media-buy/get-media-buys-request.json"
+        response_schema_ref: "media-buy/get-media-buys-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buys"
+        comply_scenario: package_correlation_legacy_fallback
+        stateful: true
+        expected: |
+          Return the seeded media buy with:
+          - media_buys[0].packages[0].package_id present
+          - media_buys[0].packages[0].product_id absent, modeling the legacy response
+          - media_buys[0].packages[0].context.buyer_ref preserved for fallback correlation
+
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "legacy_package_correlation_buy"
+          context:
+            correlation_id: "package_correlation_legacy_fallback--get_seeded_legacy_buy"
+
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buys-response.json schema"
+          - check: field_value
+            path: "media_buys[0].media_buy_id"
+            value: "legacy_package_correlation_buy"
+            description: "The seeded legacy media buy is returned"
+          - check: field_value
+            path: "media_buys[0].packages[0].package_id"
+            value: "pkg_legacy_context_only"
+            description: "Package has the seller-assigned package_id buyers must persist"
+          - check: field_absent
+            path: "media_buys[0].packages[0].product_id"
+            description: "Legacy-shaped package omits product_id; this scenario verifies fallback behavior, not current seller conformance"
+          - check: field_value
+            path: "media_buys[0].packages[0].context.buyer_ref"
+            value: "legacy-line-001"
+            description: "Package context preserves buyer_ref for buyer-side fallback correlation"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "package_correlation_legacy_fallback--get_seeded_legacy_buy"
+            description: "Response context correlation_id returned unchanged"

--- a/static/schemas/source/core/package.json
+++ b/static/schemas/source/core/package.json
@@ -12,7 +12,7 @@
     },
     "product_id": {
       "type": "string",
-      "description": "ID of the product this package is based on. For packages created from an explicit create_media_buy package request, 3.1+ sellers MUST echo the request package's product_id on every response package object that represents that requested package, so buyers can correlate returned packages without relying on deprecated top-level buyer_ref fields. When interoperating with legacy sellers that do not echo product_id, buyers can fall back to package-level context correlation such as context.buyer_ref.",
+      "description": "ID of the product this package is based on. For packages created from an explicit create_media_buy package request, sellers MUST echo the request package's product_id on every response package object that represents that requested package.",
       "x-entity": "product"
     },
     "budget": {

--- a/static/schemas/source/media-buy/get-media-buys-response.json
+++ b/static/schemas/source/media-buy/get-media-buys-response.json
@@ -213,7 +213,7 @@
                 },
                 "product_id": {
                   "type": "string",
-                  "description": "Product identifier this package is purchased from. For packages created from an explicit create_media_buy package request, 3.1+ sellers MUST echo the request package's product_id on every response package object that represents that requested package.",
+                  "description": "Product identifier this package is purchased from. For packages created from an explicit create_media_buy package request, sellers MUST echo the request package's product_id on every response package object that represents that requested package.",
                   "x-entity": "product"
                 },
                 "budget": {

--- a/static/schemas/source/media-buy/package-request.json
+++ b/static/schemas/source/media-buy/package-request.json
@@ -15,7 +15,7 @@
   "properties": {
     "product_id": {
       "type": "string",
-      "description": "Product ID for this package. 3.1+ sellers MUST echo this value on every response package object that represents this requested package, allowing buyers to correlate seller-assigned package_id values back to requested products without relying on deprecated top-level buyer_ref fields.",
+      "description": "Product ID for this package. Sellers MUST echo this value on every response package object that represents this requested package.",
       "x-entity": "product"
     },
     "format_ids": {


### PR DESCRIPTION
## Summary

- normalize package `product_id` echo wording in schemas and task references so the normative contract does not carry inline version qualifiers
- keep legacy fallback guidance separate in package `context` docs
- add a non-required `media_buy_seller/package_correlation_legacy_fallback` storyboard that seeds a legacy-shaped package without `product_id` and verifies `context.buyer_ref` correlation remains available

Closes #5127
Closes #5128

## Validation

- Expert review: protocol reviewer and docs reviewer
- `npm run build:schemas`
- `npm run build:compliance`
- `npm run test:schemas`
- `npm run test:json-schema`
- `npm run test:storyboard-response-schema`
- `npm run test:storyboard-sample-request-schema`
- `npm run test:storyboard-validations-paths`
- `npm run test:storyboard-context-output-paths`
- `npm run test:storyboard-check-enum`
- `npm run test:docs-nav`
- `npm run lint:schema-links`
- `npm run precommit`
- `npm run test:examples`
- `npm run test:composed`
- `git diff --check`
- Pre-push hook: version sync, current-source storyboard matrix, 3.0 compatibility storyboard matrix, Mintlify broken-links check
