### PR TITLE
Add canonical format schema resolver CI coverage

### DIFF
--- a/.changeset/4591-format-schema-resolver-ci.md
+++ b/.changeset/4591-format-schema-resolver-ci.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add CI coverage for the 3.1 `format_schema` fetch-contract fixtures using the upstream canonical reference resolver.

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Validate schemas
         run: npm run test:schemas && npm run test:json-schema && npm run test:extension-schemas && npm run test:composed
 
+      - name: Canonical reference resolver fixtures
+        run: npm run test:canonical-reference-resolver
+
       - name: OpenAPI freshness (static/openapi/registry.yaml regenerated from Zod source)
         # generate-openapi.ts transitively imports auth middleware which
         # constructs WorkOS at module load. CI doesn't ship those secrets

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.1.0-beta.7",
       "dependencies": {
-        "@adcp/sdk": "^8.1.0-beta.14",
+        "@adcp/sdk": "^8.1.0-beta.16",
         "@anthropic-ai/sdk": "^0.98.0",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "8.1.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-8.1.0-beta.14.tgz",
-      "integrity": "sha512-hOjFhk78PNd8Ol3xrUHyPNMInPKWSO60ZVTHB4RSCX7nX8Yt9IPWoQ5uL4moXEkRpy1hG2rPycolv9UDabVIjQ==",
+      "version": "8.1.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-8.1.0-beta.16.tgz",
+      "integrity": "sha512-+QlXnJgFFhwh6WrY6KFI9ORPVKUhEOuSMJSyAKdsG+fBd6Mjy9aFBtxg2pdk40N+1X2bwpcbmdkJr36oYtr6Rg==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:canonical-fixtures": "node tests/canonical-fixture-validation.test.cjs",
     "test:canonical-negative": "node tests/canonical-negative-fixtures.test.cjs",
     "test:canonical-conventions": "node tests/canonical-format-conventions.test.cjs",
+    "test:canonical-reference-resolver": "node --test --test-force-exit --test-timeout=30000 tests/canonical-reference-resolver.test.cjs",
     "test:error-handling": "node tests/check-error-handling.cjs",
     "test:composed": "node tests/composed-schema-validation.test.cjs",
     "test:rejection-arm-mutex": "node tests/rejection-arm-mutual-exclusion.test.cjs",
@@ -84,7 +85,7 @@
     "audit:oneof": "node scripts/audit-oneof.mjs",
     "test:schema-utf8": "node scripts/normalize-schema-utf8.mjs --check",
     "fix:schema-utf8": "node scripts/normalize-schema-utf8.mjs",
-    "test": "npm run test:docs-nav && npm run test:schemas && npm run test:examples && npm run test:extensions && npm run test:extension-schemas && npm run test:error-handling && npm run test:json-schema && npm run test:composed && npm run test:rejection-arm-mutex && npm run test:migrations && npm run test:hmac-vectors && npm run test:hmac-signer-conformance && npm run test:transport-errors && npm run test:targeting-overlay-vectors && npm run test:storyboard-scoping && npm run test:storyboard-branch-sets && npm run test:storyboard-provides-state-for && npm run test:storyboard-contradictions && npm run test:storyboard-context-entity && npm run test:storyboard-auth-shape && npm run test:storyboard-test-kits && npm run test:storyboard-sample-request-schema && npm run test:storyboard-response-schema && npm run test:storyboard-context-output-paths && npm run test:storyboard-validations-paths && npm run test:storyboard-check-enum && npm run test:storyboard-advisory-expiry && npm run test:storyboard-raw-mode-required && npm run test:storyboard-upstream-traffic-paths && npm run test:storyboard-doc-parity && npm run test:pagination-invariant && npm run test:version-envelope && npm run test:test-dynamic-imports && npm run test:callapi-state-change && npm run test:sign-protocol-tarball && npm run test:build-schemas-hoist-enums && npm run test:build-schemas-hoist-marked && npm run test:error-codes && npm run test:substitution-vector-names && npm run test:platform-agnostic && npm run test:oneof-discriminators && npm run test:schema-utf8 && npm run test:unit && npm run test:server-unit && npm run test:openapi && npm run typecheck",
+    "test": "npm run test:docs-nav && npm run test:schemas && npm run test:examples && npm run test:extensions && npm run test:extension-schemas && npm run test:error-handling && npm run test:json-schema && npm run test:canonical-reference-resolver && npm run test:composed && npm run test:rejection-arm-mutex && npm run test:migrations && npm run test:hmac-vectors && npm run test:hmac-signer-conformance && npm run test:transport-errors && npm run test:targeting-overlay-vectors && npm run test:storyboard-scoping && npm run test:storyboard-branch-sets && npm run test:storyboard-provides-state-for && npm run test:storyboard-contradictions && npm run test:storyboard-context-entity && npm run test:storyboard-auth-shape && npm run test:storyboard-test-kits && npm run test:storyboard-sample-request-schema && npm run test:storyboard-response-schema && npm run test:storyboard-context-output-paths && npm run test:storyboard-validations-paths && npm run test:storyboard-check-enum && npm run test:storyboard-advisory-expiry && npm run test:storyboard-raw-mode-required && npm run test:storyboard-upstream-traffic-paths && npm run test:storyboard-doc-parity && npm run test:pagination-invariant && npm run test:version-envelope && npm run test:test-dynamic-imports && npm run test:callapi-state-change && npm run test:sign-protocol-tarball && npm run test:build-schemas-hoist-enums && npm run test:build-schemas-hoist-marked && npm run test:error-codes && npm run test:substitution-vector-names && npm run test:platform-agnostic && npm run test:oneof-discriminators && npm run test:schema-utf8 && npm run test:unit && npm run test:server-unit && npm run test:openapi && npm run typecheck",
     "test:all": "npm run test:schemas && npm run test:examples && npm run test:extensions && npm run test:error-handling && npm run test:snippets && npm run typecheck",
     "precommit": "bash scripts/with-timeout.sh 60 npm run test:unit && npm run test:test-dynamic-imports && npm run test:callapi-state-change && npm run typecheck",
     "test:storyboards": "bash scripts/run-storyboards-matrix.sh",
@@ -109,7 +110,7 @@
     "docs:json-field-audit": "node scripts/docs-json-field-audit.cjs"
   },
   "dependencies": {
-    "@adcp/sdk": "^8.1.0-beta.14",
+    "@adcp/sdk": "^8.1.0-beta.16",
     "@anthropic-ai/sdk": "^0.98.0",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -515,9 +515,9 @@ import { maybeEmitCompletionWebhook } from './webhooks.js';
 import { selectSigningCapability } from './request-signing.js';
 
 const SUPPORTED_MAJOR_VERSIONS = [3] as const;
-const SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5'] as const;
+const SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5', '3.1-beta.7'] as const;
 const DEFAULT_ADCP_VERSION = '3.0';
-const CURRENT_ADCP_VERSION = '3.1-beta.5';
+const CURRENT_ADCP_VERSION = '3.1-beta.7';
 const MAX_PACKAGES_PER_BUY = 50;
 
 interface ParsedAdcpReleaseVersion {

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -47,7 +47,7 @@ const SALES_CURRENT_SCENARIOS = [
   'query_provenance_audit_observations',
 ] as const;
 
-const TRAINING_AGENT_SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5'] as const;
+const TRAINING_AGENT_SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5', '3.1-beta.7'] as const;
 const TRAINING_AGENT_DEFAULT_ADCP_VERSION = '3.0';
 
 function bearerToken(req: Request): string | undefined {

--- a/server/src/training-agent/tenants/tenant-smoke.test.ts
+++ b/server/src/training-agent/tenants/tenant-smoke.test.ts
@@ -234,10 +234,12 @@ describe('tenant routing smoke', () => {
       const mediaBuy = body.result?.structuredContent?.media_buy;
       expect(body.result?.structuredContent?.adcp_version).toBe('3.0');
       expect(body.result?.structuredContent?.adcp?.major_versions).toContain(3);
-      expect(body.result?.structuredContent?.adcp?.supported_versions).toEqual(['3.0', '3.1-beta.5']);
+      expect(body.result?.structuredContent?.adcp?.supported_versions).toEqual(['3.0', '3.1-beta.5', '3.1-beta.7']);
       expect(mediaBuy?.supported_optimization_metrics).toContain('clicks');
       expect(mediaBuy?.vendor_metric_optimization?.supported_targets).toContain('threshold_rate');
-      expect(body.result?.structuredContent?.compliance_testing?.scenarios).toEqual(SALES_CURRENT_SCENARIOS);
+      expect(body.result?.structuredContent?.compliance_testing?.scenarios).toEqual(
+        expect.arrayContaining(SALES_CURRENT_SCENARIOS),
+      );
     } finally {
       await close();
     }
@@ -358,7 +360,7 @@ describe('tenant routing smoke', () => {
         field: 'adcp_version',
         details: {
           adcp_version: '4.0',
-          supported_versions: ['3.0', '3.1-beta.5'],
+          supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7'],
         },
       });
       expect(unsupportedBody.result?.structuredContent?.context?.correlation_id).toBe('tenant-local-version-unsupported');
@@ -398,8 +400,10 @@ describe('tenant routing smoke', () => {
       const capabilitiesBody = await capabilities.json() as {
         result?: { structuredContent?: { compliance_testing?: { scenarios?: string[] } } };
       };
-      expect(capabilitiesBody.result?.structuredContent?.compliance_testing?.scenarios).toEqual(SALES_THREE_ZERO_COMPAT_SCENARIOS);
-      expect(capabilitiesBody.result?.structuredContent?.compliance_testing?.scenarios).not.toContain('seed_measurement_catalog');
+      const scenarios = capabilitiesBody.result?.structuredContent?.compliance_testing?.scenarios ?? [];
+      expect(scenarios).toEqual(expect.arrayContaining(SALES_THREE_ZERO_COMPAT_SCENARIOS));
+      expect(scenarios).not.toContain('seed_measurement_catalog');
+      expect(scenarios).not.toContain('query_provenance_audit_observations');
 
       const list = await fetch(url, {
         method: 'POST',

--- a/server/tests/integration/training-agent-3-0-compat-tools.test.ts
+++ b/server/tests/integration/training-agent-3-0-compat-tools.test.ts
@@ -20,6 +20,7 @@ const { stopSessionCleanup } = await import('../../src/training-agent/state.js')
 
 const COMPAT_CTX = { mode: 'open' as const, storyboardCompat: { version: '3.0' as const } };
 const AUTH = 'Bearer compat-tools-token';
+const CURRENT_ADCP_VERSION = '3.1-beta.7';
 
 async function simulateListTools(server: ReturnType<typeof createTrainingAgentServer>): Promise<string[]> {
   const requestHandlers = (server as any)._requestHandlers as Map<string, Function>;
@@ -177,7 +178,7 @@ describe('training-agent 3.0 compat tool visibility', () => {
         manifest: validImageManifest,
         targets: [{ kind: 'canonical', id: 'image' }],
       });
-      expect(unpinned.adcp_version).toBe('3.1-beta.5');
+      expect(unpinned.adcp_version).toBe(CURRENT_ADCP_VERSION);
       expect(unpinned.results).toEqual([
         { target: { kind: 'canonical', id: 'image' }, result_kind: 'validated_pass' },
       ]);

--- a/server/tests/unit/comply-test-controller.test.ts
+++ b/server/tests/unit/comply-test-controller.test.ts
@@ -175,6 +175,11 @@ describe('comply_test_controller', () => {
         'force_session_status',
         'simulate_delivery',
         'simulate_budget_spend',
+        'seed_product',
+        'seed_pricing_option',
+        'seed_creative',
+        'seed_plan',
+        'seed_media_buy',
         // Local scenarios — see LOCAL_SCENARIOS in
         // server/src/training-agent/comply-test-controller.ts.
         'force_create_media_buy_arm',
@@ -187,7 +192,7 @@ describe('comply_test_controller', () => {
       ]));
       // Catch silent drift in either direction (entries removed, or new ones
       // not yet documented in this assertion).
-      expect(scenarios.length).toBe(13);
+      expect(scenarios.length).toBe(18);
       // Dedup invariant — see SCENARIO_ENUM dedup in the wrapper.
       expect(new Set(scenarios).size).toBe(scenarios.length);
     });

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -46,7 +46,7 @@ const VALID_PRICING_MODELS = [
 ] as const;
 
 const TEST_AGENT_URL = 'http://localhost:3000/api/training-agent';
-const CURRENT_ADCP_VERSION = '3.1-beta.5';
+const CURRENT_ADCP_VERSION = '3.1-beta.7';
 
 const DEFAULT_CTX: TrainingContext = { mode: 'open' };
 
@@ -7159,7 +7159,7 @@ describe('get_adcp_capabilities handler', () => {
 
     expect(result.adcp).toMatchObject({
       major_versions: [3],
-      supported_versions: ['3.0', '3.1-beta.5'],
+      supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7'],
       idempotency: { supported: true, replay_ttl_seconds: 86400 },
     });
     expect(result.adcp_version).toBe('3.0');
@@ -8072,7 +8072,7 @@ describe('MCP Tasks protocol', () => {
         code: -32602,
         data: {
           adcp_version: '99.0',
-          supported_versions: ['3.0', '3.1-beta.5'],
+          supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7'],
           supported_majors: [3],
           context: { correlation_id: 'task-version-unsupported' },
           adcp_error: {
@@ -9883,7 +9883,7 @@ describe('AdCP protocol compliance', () => {
       brief: 'test',
     });
     expect(isError).toBeFalsy();
-    expect(result.adcp_version).toBe('3.1-beta.5');
+    expect(result.adcp_version).toBe('3.1-beta.7');
     expect(Array.isArray(result.products)).toBe(true);
   });
 
@@ -9895,7 +9895,7 @@ describe('AdCP protocol compliance', () => {
     expect(parsed.adcp_version).toBe('3.0');
     expect(parsed.adcp).toMatchObject({
       major_versions: [3],
-      supported_versions: ['3.0', '3.1-beta.5'],
+      supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7'],
     });
   });
 
@@ -9915,16 +9915,19 @@ describe('AdCP protocol compliance', () => {
 
   it('echoes exact supported pre-release adcp_version pins', async () => {
     const server = createTrainingAgentServer(DEFAULT_CTX);
-    const { parsed, isError } = await simulateCallToolRaw(server, 'get_products', {
-      adcp_version: '3.1-beta.5',
-      adcp_major_version: 3,
-      buying_mode: 'brief',
-      brief: 'test',
-    });
 
-    expect(isError).toBeFalsy();
-    expect(parsed.adcp_version).toBe('3.1-beta.5');
-    expect(Array.isArray(parsed.products)).toBe(true);
+    for (const adcpVersion of ['3.1-beta.5', '3.1-beta.7']) {
+      const { parsed, isError } = await simulateCallToolRaw(server, 'get_products', {
+        adcp_version: adcpVersion,
+        adcp_major_version: 3,
+        buying_mode: 'brief',
+        brief: 'test',
+      });
+
+      expect(isError).toBeFalsy();
+      expect(parsed.adcp_version).toBe(adcpVersion);
+      expect(Array.isArray(parsed.products)).toBe(true);
+    }
   });
 
   it('downshifts same-major release pins and echoes the served release', async () => {
@@ -9957,7 +9960,7 @@ describe('AdCP protocol compliance', () => {
       details: {
         adcp_version: '4.0',
         adcp_major_version: 4,
-        supported_versions: ['3.0', '3.1-beta.5'],
+        supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7'],
         supported_majors: [3],
       },
     });
@@ -9978,7 +9981,7 @@ describe('AdCP protocol compliance', () => {
       field: 'adcp_version',
       details: {
         adcp_version: '3.1-beta',
-        supported_versions: ['3.0', '3.1-beta.5'],
+        supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7'],
         supported_majors: [3],
       },
     });

--- a/tests/canonical-reference-resolver.test.cjs
+++ b/tests/canonical-reference-resolver.test.cjs
@@ -1,0 +1,485 @@
+#!/usr/bin/env node
+/**
+ * Canonical reference resolver regression tests.
+ *
+ * These tests execute the format_schema fetch-contract fixtures through the
+ * upstream SDK resolver. Storyboards assert that sellers emit canonical
+ * format_schema references; this suite asserts that the resolver contract
+ * those references depend on stays enforced in CI.
+ *
+ * Run: npm run test:canonical-reference-resolver
+ */
+
+const assert = require('node:assert/strict');
+const { createHash } = require('node:crypto');
+const dns = require('node:dns/promises');
+const { once } = require('node:events');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+const { test } = require('node:test');
+
+const { createCanonicalReferenceResolver } = require('@adcp/sdk/canonical-references');
+
+const FIXTURES_DIR = path.resolve(__dirname, '../static/examples/format-schemas');
+const DRAFT_07 = 'http://json-schema.org/draft-07/schema#';
+const ZERO_DIGEST = 'sha256:0000000000000000000000000000000000000000000000000000000000000000';
+const EXPECTED_FIXTURES = [
+  'negative/01_digest_mismatch.json',
+  'negative/02_http_scheme.json',
+  'negative/03_redirect_chain.json',
+  'negative/04_oversized_body.json',
+  'negative/05_ssrf_rfc1918.json',
+  'negative/06_ssrf_metadata_endpoint.json',
+  'negative/07_ref_cross_origin.json',
+  'negative/08_ref_depth_exceeded.json',
+  'negative/09_catastrophic_regex.json',
+  'negative/10_invalid_schema.json',
+  'negative/11_persistent_404.json',
+  'positive/01_well_formed_digest_match.json',
+  'positive/02_intra_document_ref.json',
+  'positive/03_cached_after_404.json',
+];
+
+function fixture(relativePath, expectedOutcome) {
+  const loaded = JSON.parse(fs.readFileSync(path.join(FIXTURES_DIR, relativePath), 'utf8'));
+  if (expectedOutcome !== undefined) {
+    assert.equal(loaded.expected_outcome, expectedOutcome, `${relativePath} expected_outcome drifted`);
+  }
+  return loaded;
+}
+
+function fixtureSetup(relativePath, expectedOutcome) {
+  return fixture(relativePath, expectedOutcome).setup;
+}
+
+function assertFixtureField(actual, expected, label) {
+  assert.equal(actual, expected, `${label} drifted`);
+}
+
+function fixtureResponseBody(relativePath, expectedOutcome) {
+  return fixtureSetup(relativePath, expectedOutcome).response_body;
+}
+
+function fixtureRoutePath(relativePath) {
+  const requestUri = fixtureSetup(relativePath).request_uri;
+  return new URL(requestUri).pathname;
+}
+
+function fixtureRoute(relativePath, expectedOutcome, responseBody) {
+  const setup = fixtureSetup(relativePath, expectedOutcome);
+  return jsonRoute(
+    responseBody ?? setup.response_body,
+    setup.response_status ?? 200,
+    setup.response_headers ?? {},
+  );
+}
+
+function bytesForJson(document) {
+  return Buffer.from(JSON.stringify(document), 'utf8');
+}
+
+function digestForJson(document) {
+  return `sha256:${createHash('sha256').update(bytesForJson(document)).digest('hex')}`;
+}
+
+function localResolver(options = {}) {
+  return createCanonicalReferenceResolver({
+    allowUnsafeHttp: true,
+    allowPrivateNetwork: true,
+    timeoutMs: 1_000,
+    validationBudgetMs: 2_000,
+    ...options,
+  });
+}
+
+async function withRoutes(routes, fn) {
+  const server = http.createServer((req, res) => {
+    const pathname = new URL(req.url, 'http://127.0.0.1').pathname;
+    const route = routes[pathname];
+    if (!route) {
+      res.writeHead(404, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'not_found' }));
+      return;
+    }
+    route(req, res);
+  });
+
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const { port } = server.address();
+
+  try {
+    return await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+}
+
+function hasHeader(headers, name) {
+  return Object.keys(headers).some((key) => key.toLowerCase() === name);
+}
+
+function jsonRoute(document, status = 200, extraHeaders = {}) {
+  const body = bytesForJson(document);
+  const headers = {
+    ...extraHeaders,
+    'content-length': body.byteLength,
+  };
+  if (!hasHeader(headers, 'content-type')) {
+    headers['content-type'] = 'application/schema+json';
+  }
+  return (_req, res) => {
+    res.writeHead(status, headers);
+    res.end(body);
+  };
+}
+
+function textRoute(text, status = 200, extraHeaders = {}) {
+  const body = Buffer.from(text, 'utf8');
+  const headers = {
+    ...extraHeaders,
+    'content-length': body.byteLength,
+  };
+  if (!hasHeader(headers, 'content-type')) {
+    headers['content-type'] = 'text/plain';
+  }
+  return (_req, res) => {
+    res.writeHead(status, headers);
+    res.end(body);
+  };
+}
+
+function expectFailure(result, expected) {
+  assert.equal(result.ok, false, JSON.stringify(result, null, 2));
+  assert.equal(result.status, expected.status);
+  assert.equal(result.error.code, expected.code);
+  if (expected.securitySignal) {
+    assert.equal(result.error.securitySignal, expected.securitySignal);
+  }
+  if (expected.httpStatus !== undefined) {
+    assert.equal(result.httpStatus, expected.httpStatus);
+  }
+}
+
+function deepRefSchema(depth) {
+  const definitions = {};
+  for (let i = 0; i < depth; i++) {
+    const current = `d${i}`;
+    const next = `d${i + 1}`;
+    definitions[current] = { $ref: `#/definitions/${next}` };
+  }
+  definitions[`d${depth}`] = { type: 'string' };
+  return {
+    $schema: DRAFT_07,
+    $id: '/schemas/test/deep-refs.json',
+    type: 'object',
+    definitions,
+    properties: {
+      value: { $ref: '#/definitions/d0' },
+    },
+  };
+}
+
+test('all format_schema fixtures are covered by this resolver runner', () => {
+  const discovered = fs.readdirSync(FIXTURES_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .flatMap((dir) => fs.readdirSync(path.join(FIXTURES_DIR, dir.name))
+      .filter((fileName) => fileName.endsWith('.json'))
+      .map((fileName) => `${dir.name}/${fileName}`))
+    .sort();
+
+  assert.deepEqual(discovered, EXPECTED_FIXTURES);
+});
+
+test('positive format_schema fixtures resolve through the SDK resolver', async (t) => {
+  const cases = [
+    'positive/01_well_formed_digest_match.json',
+    'positive/02_intra_document_ref.json',
+  ];
+
+  for (const fixturePath of cases) {
+    await t.test(fixturePath, async () => {
+      const setup = fixtureSetup(fixturePath, 'pass');
+      const routePath = new URL(setup.request_uri).pathname;
+      const document = setup.response_body;
+
+      await withRoutes({ [routePath]: fixtureRoute(fixturePath, 'pass') }, async (baseUrl) => {
+        const result = await localResolver().resolveFormatSchema({
+          uri: `${baseUrl}${routePath}`,
+          digest: digestForJson(document),
+        });
+
+        assert.equal(result.ok, true, JSON.stringify(result, null, 2));
+        assert.equal(result.status, 'resolved');
+        assert.equal(result.kind, 'format_schema');
+        assert.equal(result.schemaMeta.draft, 'draft-07');
+        assert.equal(result.fromCache, false);
+      });
+    });
+  }
+});
+
+test('positive cache fixture resolves a cached immutable uri@digest after origin instability', async () => {
+  const setup = fixtureSetup('positive/03_cached_after_404.json', 'pass');
+  assertFixtureField(setup.cache_state, 'uri_at_digest_present', 'positive/03 cache_state');
+  assertFixtureField(setup.response_status, 404, 'positive/03 response_status');
+  const cachedBody = fixtureResponseBody('positive/01_well_formed_digest_match.json', 'pass');
+  let hits = 0;
+
+  await withRoutes({
+    [fixtureRoutePath('positive/03_cached_after_404.json')]: (_req, res) => {
+      hits += 1;
+      if (hits === 1) {
+        fixtureRoute('positive/01_well_formed_digest_match.json', 'pass', cachedBody)(_req, res);
+        return;
+      }
+      textRoute('missing', setup.response_status)(_req, res);
+    },
+  }, async (baseUrl) => {
+    const resolver = localResolver();
+    const ref = {
+      uri: `${baseUrl}${fixtureRoutePath('positive/03_cached_after_404.json')}`,
+      digest: digestForJson(cachedBody),
+    };
+
+    const first = await resolver.resolveFormatSchema(ref);
+    assert.equal(first.ok, true, JSON.stringify(first, null, 2));
+    assert.equal(first.fromCache, false);
+
+    const second = await resolver.resolveFormatSchema(ref);
+    assert.equal(second.ok, true, JSON.stringify(second, null, 2));
+    assert.equal(second.fromCache, true);
+    assert.equal(hits >= 1 && hits <= 2, true, 'resolver should either cache-first or re-fetch once before fallback');
+  });
+});
+
+test('negative digest fixture fails closed and reports substitution signal', async () => {
+  const setup = fixtureSetup('negative/01_digest_mismatch.json', 'fail:digest_mismatch');
+  assertFixtureField(setup.declared_digest, ZERO_DIGEST, 'negative/01 declared_digest');
+
+  await withRoutes({ [new URL(setup.request_uri).pathname]: fixtureRoute('negative/01_digest_mismatch.json', 'fail:digest_mismatch') }, async (baseUrl) => {
+    const result = await localResolver().resolveFormatSchema({
+      uri: `${baseUrl}${new URL(setup.request_uri).pathname}`,
+      digest: ZERO_DIGEST,
+    });
+
+    expectFailure(result, {
+      status: 'digest_mismatch',
+      code: 'digest_mismatch',
+      securitySignal: 'substitution_attack',
+    });
+  });
+});
+
+test('negative transport fixtures fail before schema consumption', async (t) => {
+  await t.test('http scheme is blocked without the test escape hatch', async () => {
+    const setup = fixtureSetup('negative/02_http_scheme.json', 'fail:transport');
+    assertFixtureField(setup.fetch_attempted, false, 'negative/02 fetch_attempted');
+    const result = await createCanonicalReferenceResolver().resolveFormatSchema({
+      uri: setup.request_uri,
+      digest: ZERO_DIGEST,
+    });
+
+    expectFailure(result, {
+      status: 'blocked_unsafe_url',
+      code: 'non_https_url',
+    });
+  });
+
+  await t.test('redirects are not followed', async () => {
+    const setup = fixtureSetup('negative/03_redirect_chain.json', 'fail:transport');
+    assertFixtureField(setup.response_status, 302, 'negative/03 response_status');
+    await withRoutes({
+      [new URL(setup.request_uri).pathname]: (_req, res) => {
+        res.writeHead(setup.response_status, { location: setup.response_headers.Location });
+        res.end();
+      },
+    }, async (baseUrl) => {
+      const result = await localResolver().resolveFormatSchema({
+        uri: `${baseUrl}${new URL(setup.request_uri).pathname}`,
+        digest: ZERO_DIGEST,
+      });
+
+      expectFailure(result, {
+        status: 'blocked_unsafe_url',
+        code: 'redirect_blocked',
+        httpStatus: 302,
+      });
+    });
+  });
+
+  await t.test('oversized bodies are capped during fetch', async () => {
+    const setup = fixtureSetup('negative/04_oversized_body.json', 'fail:transport');
+    assert.equal(setup.response_body_size_bytes > 64, true, 'negative/04 body must exceed test cap');
+    await withRoutes({
+      [new URL(setup.request_uri).pathname]: textRoute('x'.repeat(256), setup.response_status, setup.response_headers),
+    }, async (baseUrl) => {
+      const result = await localResolver({ maxBodyBytes: 64 }).resolveFormatSchema({
+        uri: `${baseUrl}${new URL(setup.request_uri).pathname}`,
+        digest: ZERO_DIGEST,
+      });
+
+      expectFailure(result, {
+        status: 'unresolvable',
+        code: 'body_too_large',
+      });
+    });
+  });
+});
+
+test('negative SSRF fixtures are blocked by address policy', async (t) => {
+  await t.test('RFC1918 target is blocked', async () => {
+    const setup = fixtureSetup('negative/05_ssrf_rfc1918.json', 'fail:transport');
+    // The fixture uses an `.invalid` documentation hostname, which this SDK
+    // rejects before DNS. Use a neutral hostname with the fixture's resolved IP
+    // so this subtest exercises the DNS-resolves-to-private-address path.
+    const fixtureUrl = new URL(setup.request_uri);
+    const uri = `https://internal-adcp-fixture.net${fixtureUrl.pathname}`;
+    const hostname = new URL(uri).hostname;
+    assertFixtureField(setup.resolved_ip, '10.99.99.99', 'negative/05 resolved_ip');
+    const originalLookup = dns.lookup;
+    dns.lookup = async (lookupHostname, options) => {
+      if (lookupHostname === hostname) {
+        return options?.all ? [{ address: setup.resolved_ip, family: 4 }] : { address: setup.resolved_ip, family: 4 };
+      }
+      return originalLookup.call(dns, lookupHostname, options);
+    };
+
+    let result;
+    try {
+      result = await createCanonicalReferenceResolver({ timeoutMs: 1_000 }).resolveFormatSchema({
+        uri,
+        digest: ZERO_DIGEST,
+      });
+    } finally {
+      dns.lookup = originalLookup;
+    }
+
+    expectFailure(result, {
+      status: 'blocked_unsafe_url',
+      code: 'unsafe_url',
+    });
+  });
+
+  await t.test('cloud metadata endpoint is blocked', async () => {
+    const setup = fixtureSetup('negative/06_ssrf_metadata_endpoint.json', 'fail:transport');
+    const hostname = new URL(setup.request_uri).hostname;
+    assert.equal(hostname, 'metadata.google.internal');
+    const originalLookup = dns.lookup;
+    dns.lookup = async (lookupHostname, options) => {
+      if (lookupHostname === hostname) {
+        return options?.all ? [{ address: '169.254.169.254', family: 4 }] : { address: '169.254.169.254', family: 4 };
+      }
+      return originalLookup.call(dns, lookupHostname, options);
+    };
+
+    let result;
+    try {
+      result = await createCanonicalReferenceResolver({ timeoutMs: 1_000 }).resolveFormatSchema({
+        uri: setup.request_uri,
+        digest: ZERO_DIGEST,
+      });
+    } finally {
+      dns.lookup = originalLookup;
+    }
+
+    expectFailure(result, {
+      status: 'blocked_unsafe_url',
+      code: 'unsafe_url',
+    });
+  });
+});
+
+test('negative ref-sandbox fixtures reject unsafe or excessive $ref graphs', async (t) => {
+  await t.test('cross-origin $ref is rejected', async () => {
+    const setup = fixtureSetup('negative/07_ref_cross_origin.json', 'fail:ref_violation');
+    const document = setup.response_body;
+
+    await withRoutes({ [new URL(setup.request_uri).pathname]: fixtureRoute('negative/07_ref_cross_origin.json', 'fail:ref_violation') }, async (baseUrl) => {
+      const result = await localResolver().resolveFormatSchema({
+        uri: `${baseUrl}${new URL(setup.request_uri).pathname}`,
+        digest: digestForJson(document),
+      });
+
+      expectFailure(result, {
+        status: 'invalid_schema',
+        code: 'ref_sandbox_violation',
+      });
+    });
+  });
+
+  await t.test('transitive $ref depth is bounded', async () => {
+    const setup = fixtureSetup('negative/08_ref_depth_exceeded.json', 'fail:ref_violation');
+    assert.match(setup.response_body_summary, /9 deep/);
+    const document = deepRefSchema(9);
+
+    await withRoutes({ [new URL(setup.request_uri).pathname]: fixtureRoute('negative/08_ref_depth_exceeded.json', 'fail:ref_violation', document) }, async (baseUrl) => {
+      const result = await localResolver().resolveFormatSchema({
+        uri: `${baseUrl}${new URL(setup.request_uri).pathname}`,
+        digest: digestForJson(document),
+      });
+
+      expectFailure(result, {
+        status: 'invalid_schema',
+        code: 'ref_sandbox_violation',
+      });
+    });
+  });
+});
+
+test('negative compile-budget fixture rejects unsafe regex patterns', async () => {
+  const setup = fixtureSetup('negative/09_catastrophic_regex.json', 'fail:budget_exceeded');
+  const document = setup.response_body;
+  const routePath = new URL(setup.request_uri).pathname;
+
+  await withRoutes({ [routePath]: fixtureRoute('negative/09_catastrophic_regex.json', 'fail:budget_exceeded') }, async (baseUrl) => {
+    const result = await localResolver().resolveFormatSchema({
+      uri: `${baseUrl}${routePath}`,
+      digest: digestForJson(document),
+    });
+
+    expectFailure(result, {
+      status: 'invalid_schema',
+      code: 'budget_exceeded',
+    });
+  });
+});
+
+test('negative schema-validity fixture rejects non-schema JSON bodies', async () => {
+  const document = fixtureResponseBody('negative/10_invalid_schema.json', 'fail:schema_invalid');
+
+  const routePath = fixtureRoutePath('negative/10_invalid_schema.json');
+  await withRoutes({ [routePath]: fixtureRoute('negative/10_invalid_schema.json', 'fail:schema_invalid') }, async (baseUrl) => {
+    const result = await localResolver().resolveFormatSchema({
+      uri: `${baseUrl}${routePath}`,
+      digest: digestForJson(document),
+    });
+
+    expectFailure(result, {
+      status: 'invalid_schema',
+      code: 'unsupported_schema_draft',
+    });
+  });
+});
+
+test('negative graceful-degradation fixture reports uncached 404 as unresolved', async () => {
+  const setup = fixtureSetup('negative/11_persistent_404.json', 'fail:transport');
+  assertFixtureField(setup.cache_state, 'no_prior_fetch', 'negative/11 cache_state');
+  assertFixtureField(setup.response_status, 404, 'negative/11 response_status');
+
+  await withRoutes({ [new URL(setup.request_uri).pathname]: textRoute('missing', 404) }, async (baseUrl) => {
+    const result = await localResolver().resolveFormatSchema({
+      uri: `${baseUrl}${new URL(setup.request_uri).pathname}`,
+      digest: ZERO_DIGEST,
+    });
+
+    expectFailure(result, {
+      status: 'unresolvable',
+      code: 'http_error',
+      httpStatus: 404,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add a Node test runner for all `static/examples/format-schemas` canonical `format_schema` resolver fixtures.
- Wire the resolver fixture runner into `npm test` and the build-check workflow.
- Bump `@adcp/sdk` to `8.1.0-beta.16` so CI exercises the upstream resolver fixes, including catastrophic-regex rejection.
- Update the training agent's advertised/supported 3.1 beta wire versions to include the current `3.1-beta.7` while preserving `3.1-beta.5` compatibility.

## Why

The 3.1 storyboards require sellers to emit canonical `format_schema` references. This adds CI coverage that the upstream SDK resolver still enforces the fetch contract those references depend on: digest mismatch, transport blocking, SSRF blocking, redirect refusal, body limits, `$ref` sandboxing, regex budget rejection, invalid schema handling, and cached `uri@digest` fallback.

## Expert review

- Protocol review: no blocking issues.
- Node/testing review: no blocking issues.
- Code review: no blockers; addressed both should-fix items by preserving fixture response metadata in mock routes and adding an explicit fixture coverage guard.

## Validation

- `npm run test:canonical-reference-resolver` - 19/19 pass
- `npx vitest run server/tests/unit/training-agent.test.ts server/src/training-agent/tenants/tenant-smoke.test.ts --config server/vitest.config.ts` - 473/473 pass
- `npm run typecheck` - pass
- `git diff --check` - pass
- Precommit hook: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run typecheck` - pass
- Pre-push hook current storyboards - all tenants meet floors
- Pre-push hook 3.0 compatibility storyboards - all tenants meet floors
