### PR TITLE
docs: add Slack social link

### DIFF
--- a/.changeset/4243-slack-social-link.md
+++ b/.changeset/4243-slack-social-link.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs(site): add Slack social link to the Mintlify socials config. Config-only change; no package release needed.

--- a/docs.json
+++ b/docs.json
@@ -1461,7 +1461,8 @@
   "socials": {
     "linkedin": "https://www.linkedin.com/company/ad-context-protocol/",
     "youtube": "https://www.youtube.com/@AgenticAdvertising",
-    "github": "https://github.com/adcontextprotocol/adcp"
+    "github": "https://github.com/adcontextprotocol/adcp",
+    "slack": "https://join.slack.com/t/agenticads/shared_invite/zt-3h15gj6c0-FRTrD_y4HqmeXDKBl2TDEA"
   },
   "api": {
     "maintainOrder": true


### PR DESCRIPTION
## Summary

- Add Slack to the Mintlify social links in `docs.json`
- Use the same public invite URL already documented on the community Slack joining page

Closes #4243

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('docs.json','utf8')); console.log('docs.json valid')"`
- precommit hook during commit: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run typecheck`
- push hook: version sync passed; storyboard matrix and Mintlify checks skipped as not applicable
