### PR TITLE
chore: route P0 and spec work out of Evergreen

### DIFF
--- a/.agents/playbook.md
+++ b/.agents/playbook.md
@@ -46,12 +46,13 @@ through this lens: **is this worth the tokens it will cost to complete?**
 
 - **In triage:** default-defer low-value issues. Use the `P0 Bugs`
   milestone for immediate user/revenue/security/reliability bugs that
-  should be worked before the general backlog, and use `Evergreen` only
-  for non-versioned work that still matters later. Closing issues is a
-  human call; triage should route, clarify, defer, or leave an
-  implementation brief. Don't punt for the sake of punting — spec
-  quality and pain-prevention are strong "keep" signals even without an
-  active PR.
+  should be worked before the general backlog. Use `Spec Backlog` for
+  protocol/spec/schema/normative-doc work that is not yet committed to a
+  numbered release. Use `Evergreen` only for non-spec, non-versioned
+  work that still matters later. Closing issues is a human call; triage
+  should route, clarify, defer, or leave an implementation brief. Don't
+  punt for the sake of punting — spec quality and pain-prevention are
+  strong "keep" signals even without an active PR.
 - **In implementation:** if a task touches three files when you scoped
   it to one, stop. Either re-scope or defer.
 - **In scope decisions:** prefer the smallest change that closes the

--- a/.agents/playbook.md
+++ b/.agents/playbook.md
@@ -44,12 +44,14 @@ through this lens: **is this worth the tokens it will cost to complete?**
 
 ### How to apply
 
-- **In triage:** default-defer low-value issues, and use the
-  `Evergreen` milestone only for non-versioned work that still matters
-  later. Closing issues is a human call; triage should route, clarify,
-  defer, or leave an implementation brief. Don't punt for the sake of
-  punting — spec quality and pain-prevention are strong "keep" signals
-  even without an active PR.
+- **In triage:** default-defer low-value issues. Use the `P0 Bugs`
+  milestone for immediate user/revenue/security/reliability bugs that
+  should be worked before the general backlog, and use `Evergreen` only
+  for non-versioned work that still matters later. Closing issues is a
+  human call; triage should route, clarify, defer, or leave an
+  implementation brief. Don't punt for the sake of punting — spec
+  quality and pain-prevention are strong "keep" signals even without an
+  active PR.
 - **In implementation:** if a task touches three files when you scoped
   it to one, stop. Either re-scope or defer.
 - **In scope decisions:** prefer the smallest change that closes the

--- a/.agents/routines/triage-prompt.md
+++ b/.agents/routines/triage-prompt.md
@@ -350,6 +350,32 @@ Scope buckets — **label application is strictly gated**:
    comment body and flag the missing label in your run summary.
 4. Default to not applying when uncertain.
 
+### Priority labels
+
+Priority is an overlay on top of classification and bucket labels. It
+answers "should this be worked before the general backlog?", not "what
+kind of issue is this?"
+
+Apply priority labels only when the exact label exists in the label
+list. Never create labels.
+
+- **`priority:P0`** — immediate bug queue. Apply when the issue is a
+  Bug or Conformance failure and at least one of these is true:
+  community/customer reported, named member or revenue prospect blocked,
+  security/auth/data-integrity risk, silent or empty user-facing
+  failure, production admin workflow broken, or AAO scoring/compliance
+  trust is visibly wrong for an adopter. Use sparingly; P0 means "work
+  before normal Evergreen backlog."
+- **`priority:P1`** — important bug or operational follow-up with a
+  clear path, but not current-fire P0. Typical P1s are reproducible
+  admin/product bugs with a workaround, freshness/maintenance jobs, or
+  high-value polish that is not actively blocking a user.
+
+If `priority:P0` applies and the `bug` label exists, apply `bug` too.
+Apply `severity:significant` or `severity:critical` only when the
+impact genuinely matches those labels; priority and severity are
+related but not interchangeable.
+
 Common buckets (verify every time):
 
 - **runtime-crash** — overlay bucket: any issue whose body carries
@@ -654,6 +680,25 @@ Fetch all open milestones before deciding:
 gh api repos/<owner>/<repo>/milestones --jq \
   '.[] | select(.state == "open") | {title, number, due: .due_on, description}'
 ```
+
+Apply `P0 Bugs` to the **issue** when all are true:
+
+- The issue is classified as Bug or Conformance failure.
+- You applied `priority:P0`.
+- The work is not a numbered release blocker that belongs on a version
+  milestone.
+- The open milestone list contains exact title `P0 Bugs`.
+
+```bash
+gh issue edit <N> --repo <owner>/<repo> --milestone "P0 Bugs"
+```
+
+`P0 Bugs` is an execution queue, not a release train. PR base branch and
+release milestone still follow the PR release routing below. If a P0
+bug is also a release blocker, prefer the version milestone and keep the
+`priority:P0` label as the urgency signal. If `P0 Bugs` is missing,
+mention `Milestone: P0 Bugs missing` in the run summary and continue
+with the normal milestone decision.
 
 Apply `Evergreen` to the **issue** when all are true:
 

--- a/.agents/routines/triage-prompt.md
+++ b/.agents/routines/triage-prompt.md
@@ -387,7 +387,8 @@ Common buckets (verify every time):
   the surface panel adds context.
 - **spec / protocol** — AdCP schemas, task definitions, spec docs.
   Non-breaking schema changes (see definition) are Ready/Execute
-  eligible.
+  eligible. If the issue is not urgent and is not tied to a numbered
+  release, route it to `Spec Backlog`, not `Evergreen`.
 - **web / site / docs** — public site (`docs/`, `static/`). Typo
   fixes and broken links may Execute if the PR authorization gate
   passes; new doc sections and semantic clarifications usually become
@@ -402,10 +403,10 @@ Common buckets (verify every time):
   training-agent tests, certification modules that need to track
   current protocol behavior. Use this as an overlay with the surface
   bucket (`compliance suite`, `training / certification`, etc.). These
-  issues route to the `Evergreen` milestone only when they teach or
-  test already-released behavior and are not tied to a specific
-  numbered release. If the work is needed to validate, teach, certify,
-  or document behavior shipping in a numbered release, keep it on that
+  issues route to `Spec Backlog` when they teach, test, certify, or
+  score protocol behavior but are not tied to a specific numbered
+  release. If the work is needed to validate, teach, certify, or
+  document behavior shipping in a numbered release, keep it on that
   version milestone even when the implementation work itself is
   non-normative. If resolving the issue requires a normative
   schema/task/doc semantics change, tightens or reinterprets what
@@ -700,9 +701,36 @@ bug is also a release blocker, prefer the version milestone and keep the
 mention `Milestone: P0 Bugs missing` in the run summary and continue
 with the normal milestone decision.
 
+Apply `Spec Backlog` to the **issue** when all are true:
+
+- The issue is classified as Spec question, or is bucketed `spec /
+  protocol`, or has the `spec-adjacent enablement` overlay.
+- The issue is not urgent enough for `P0 Bugs`.
+- The issue is not a blocker for a numbered release milestone.
+- The issue directly touches protocol semantics, schemas, task
+  definitions, normative docs, adopter interoperability, compliance
+  scoring, conformance testing, training-agent behavior, or
+  certification behavior.
+- The open milestone list contains exact title `Spec Backlog`.
+- The issue has no existing milestone, or the existing milestone is
+  clearly wrong for spec/protocol work.
+
+```bash
+gh issue edit <N> --repo <owner>/<repo> --milestone "Spec Backlog"
+```
+
+`Spec Backlog` is a spec-owner execution queue, not a release
+commitment. PR base branch and PR release milestone still follow the PR
+release routing below. If `Spec Backlog` is missing, mention
+`Milestone: Spec Backlog missing` in the run summary and continue with
+the normal milestone decision.
+
 Apply `Evergreen` to the **issue** when all are true:
 
-- The issue is clearly bucketed `evergreen`, or has the
+- The issue is clearly bucketed `evergreen`, or is non-spec docs,
+  examples, product, or operational backlog that should remain
+  findable.
+- It is not bucketed `spec / protocol` and does not have the
   `spec-adjacent enablement` overlay.
 - It is not proposing a normative schema/task/doc semantics change
   that should ship in a numbered protocol release.
@@ -732,19 +760,26 @@ that numbered milestone even when the work itself is non-normative
 3.1 behavior). Numbered milestones should reflect real ship blockers,
 not only schema diffs.
 
-Use `Evergreen` only when the change teaches, tests, or documents
-already-released behavior. If it tightens or reinterprets what
-conformant implementations must do, route it to the relevant version
-milestone even if no schema field changes.
+Use `Spec Backlog` for unscheduled work that teaches, tests, scores,
+or documents protocol behavior. Use `Evergreen` only for work that is
+not directly related to the spec. If an issue tightens or reinterprets
+what conformant implementations must do, route it to the relevant
+version milestone even if no schema field changes.
 
 Use this split to keep spec planning clean:
 
 - **Version milestones (`3.1.0`, `3.2.0`, `4.0`, etc.)** — normative
   protocol/schema/task behavior, release-contract changes, or docs
   that materially change implementer obligations.
-- **Evergreen** — testing, compliance tooling, training-agent,
-  certification, examples, and general docs that support or explain
-  current behavior without changing the release contract.
+- **Spec Backlog** — protocol/schema/task semantics, normative docs,
+  adopter interoperability, compliance/scoring, conformance testing,
+  training-agent, or certification issues directly tied to protocol
+  behavior, when not urgent and not yet scheduled for a numbered
+  release.
+- **Evergreen** — non-spec examples, product cleanup, operational
+  follow-ups, and general docs that are useful later but do not change
+  implementer obligations, adopter interoperability, or protocol
+  behavior.
 
 #### PR release routing
 

--- a/.changeset/p0-bugs-triage-routing.md
+++ b/.changeset/p0-bugs-triage-routing.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-chore(triage): route immediate bugs into the P0 Bugs work queue and priority labels. Process-only change; no package release needed.
+chore(triage): route immediate bugs into the P0 Bugs queue, add priority labels, and keep direct spec/protocol work out of Evergreen via Spec Backlog. Process-only change; no package release needed.

--- a/.changeset/p0-bugs-triage-routing.md
+++ b/.changeset/p0-bugs-triage-routing.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore(triage): route immediate bugs into the P0 Bugs work queue and priority labels. Process-only change; no package release needed.


### PR DESCRIPTION
## Summary

- Add `P0 Bugs` triage routing to the shared playbook and issue-triage routine
- Define `priority:P0` and `priority:P1` usage rules for future triage runs
- Add `Spec Backlog` routing so direct spec/protocol/schema work does not get buried in `Evergreen`
- Keep `Evergreen` as the non-spec, non-versioned backlog instead of the immediate bug or spec queue

## GitHub setup already applied

- Created milestone `P0 Bugs`
- Created milestone `Spec Backlog`
- Created labels `priority:P0` and `priority:P1`
- Moved current P0 bug set into `P0 Bugs`: #4738, #4751, #4430, #4911, #4565, #4573
- Moved 29 current `Evergreen` issues with `spec / protocol`, `compliance-suite`, or `schema` labels into `Spec Backlog`

## Validation

- `npx --yes @changesets/cli@^2.31.0 status --since=origin/main`
- precommit hook: unit tests, dynamic import lint, callApi state-change lint, typecheck
- push hook: version sync passed; storyboard and Mintlify checks skipped as not applicable
