### PR TITLE
fix(server): harden admin add-users mirroring

### DIFF
--- a/.changeset/4911-admin-add-users-upsert.md
+++ b/.changeset/4911-admin-add-users-upsert.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix admin add-users local membership mirroring and WorkOS already-exists handling.

--- a/server/src/routes/admin/organizations.ts
+++ b/server/src/routes/admin/organizations.ts
@@ -10,7 +10,11 @@ import { createLogger } from "../../logger.js";
 import { requireAuth, requireAdmin } from "../../middleware/auth.js";
 import { OrganizationDatabase } from "../../db/organization-db.js";
 import { getPendingInvoices } from "../../billing/stripe-client.js";
-import { findSuccessorForPromotion, setMembershipRole } from "../../db/membership-db.js";
+import {
+  findSuccessorForPromotion,
+  setMembershipRole,
+  upsertOrganizationMembership,
+} from "../../db/membership-db.js";
 
 const orgDb = new OrganizationDatabase();
 const logger = createLogger("admin-organizations");
@@ -18,6 +22,10 @@ const logger = createLogger("admin-organizations");
 interface OrganizationRoutesConfig {
   workos: WorkOS | null;
 }
+
+type WorkOSOrganizationMembership = Awaited<
+  ReturnType<WorkOS["userManagement"]["createOrganizationMembership"]>
+>;
 
 export function setupOrganizationRoutes(
   apiRouter: Router,
@@ -1167,38 +1175,123 @@ export function setupOrganizationRoutes(
               continue;
             }
 
-            let newMembership: Awaited<ReturnType<WorkOS['userManagement']['createOrganizationMembership']>>;
+            const stagingKey = `admin_add_${orgId}_${userId}`;
+            await pool.query(
+              "DELETE FROM invitation_seat_types WHERE workos_organization_id = $1 AND lower(email) = lower($2)",
+              [orgId, user.email]
+            );
+            await pool.query(
+              `INSERT INTO invitation_seat_types (workos_invitation_id, workos_organization_id, email, seat_type, source)
+               VALUES ($1, $2, $3, 'community_only', 'admin_added')
+               ON CONFLICT (workos_invitation_id) DO UPDATE SET
+                 seat_type = EXCLUDED.seat_type,
+                 source = EXCLUDED.source`,
+              [stagingKey, orgId, user.email]
+            );
+
+            let membership: WorkOSOrganizationMembership | null = null;
+            let membershipAlreadyExisted = false;
             try {
-              newMembership = await workos.userManagement.createOrganizationMembership({
-                userId,
-                organizationId: orgId,
-                roleSlug: 'member',
-              });
+              membership =
+                await workos.userManagement.createOrganizationMembership({
+                  userId,
+                  organizationId: orgId,
+                  roleSlug: "member",
+                });
             } catch (workosErr) {
-              const message = workosErr instanceof Error ? workosErr.message : String(workosErr);
-              logger.error(
-                { err: workosErr, userId, orgId },
-                "Failed to create WorkOS membership during admin add-users",
-              );
-              errors.push(`User ${userId}: ${message}`);
-              continue;
+              if (
+                (workosErr as { code?: string })?.code ===
+                "organization_membership_already_exists"
+              ) {
+                membershipAlreadyExisted = true;
+                try {
+                  const existingMemberships =
+                    await workos.userManagement.listOrganizationMemberships({
+                      userId,
+                      organizationId: orgId,
+                    });
+                  membership =
+                    existingMemberships.data?.find(
+                      (candidate) =>
+                        candidate.userId === userId &&
+                        candidate.organizationId === orgId
+                    ) ?? null;
+                } catch (repairErr) {
+                  logger.error(
+                    { err: repairErr, userId, orgId },
+                    "Failed to inspect existing WorkOS membership during admin add-users repair"
+                  );
+                }
+              }
+
+              if (!membership) {
+                try {
+                  await pool.query(
+                    "DELETE FROM invitation_seat_types WHERE workos_invitation_id = $1",
+                    [stagingKey]
+                  );
+                } catch (rollbackErr) {
+                  logger.error(
+                    { err: rollbackErr, userId, orgId, stagingKey },
+                    "CRITICAL: failed to rollback admin add-users staging row after WorkOS membership failure"
+                  );
+                }
+
+                logger.error(
+                  { err: workosErr, userId, orgId },
+                  "Failed to create WorkOS membership during admin add-users"
+                );
+                errors.push(`User ${userId}: Could not add membership`);
+                continue;
+              }
             }
 
             // Mirror locally now that WorkOS has the row.
-            await pool.query(
-              `INSERT INTO organization_memberships
-               (workos_user_id, workos_organization_id, workos_membership_id, email, first_name, last_name, role, synced_at)
-               VALUES ($1, $2, $3, $4, $5, $6, 'member', NOW())
-               ON CONFLICT (workos_user_id, workos_organization_id)
-               DO UPDATE SET workos_membership_id = EXCLUDED.workos_membership_id,
-                 email = EXCLUDED.email,
-                 first_name = COALESCE(NULLIF(TRIM(organization_memberships.first_name), ''), EXCLUDED.first_name),
-                 last_name = COALESCE(NULLIF(TRIM(organization_memberships.last_name), ''), EXCLUDED.last_name),
-                 role = EXCLUDED.role,
-                 synced_at = NOW(),
-                 updated_at = NOW()`,
-              [userId, orgId, newMembership.id, user.email, user.first_name, user.last_name]
-            );
+            try {
+              await upsertOrganizationMembership({
+                user_id: userId,
+                organization_id: orgId,
+                membership_id: membership.id,
+                email: user.email,
+                first_name: user.first_name,
+                last_name: user.last_name,
+                role: membership.role?.slug ?? "member",
+                seat_type: "community_only",
+                has_explicit_seat_type: false,
+                provisioning_source: membershipAlreadyExisted
+                  ? undefined
+                  : "admin_added",
+              });
+            } finally {
+              try {
+                await pool.query(
+                  "DELETE FROM invitation_seat_types WHERE workos_invitation_id = $1",
+                  [stagingKey]
+                );
+              } catch (cleanupErr) {
+                logger.error(
+                  { err: cleanupErr, userId, orgId, stagingKey },
+                  "CRITICAL: failed to cleanup admin add-users staging row after local membership mirror"
+                );
+              }
+            }
+
+            await orgDb.recordAuditLog({
+              workos_organization_id: orgId,
+              workos_user_id: req.user!.id,
+              action: "member_added",
+              resource_type: "membership",
+              resource_id: membership.id,
+              details: {
+                target_user_id: userId,
+                target_email: user.email,
+                role: membership.role?.slug ?? "member",
+                seat_type: "community_only",
+                actor_email: req.user!.email,
+                via: "admin_add_users",
+                repaired_existing_membership: membershipAlreadyExisted,
+              },
+            });
 
             addedCount++;
 
@@ -1209,6 +1302,7 @@ export function setupOrganizationRoutes(
                 targetOrgId: orgId,
                 targetOrgName: orgName,
                 previousOrgId: user.workos_organization_id,
+                membershipAlreadyExisted,
                 adminEmail: req.user!.email,
               },
               "Admin added user to organization"

--- a/server/tests/integration/admin-add-users.test.ts
+++ b/server/tests/integration/admin-add-users.test.ts
@@ -1,0 +1,282 @@
+import express from "express";
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { initializeDatabase, closeDatabase } from "../../src/db/client.js";
+import { runMigrations } from "../../src/db/migrate.js";
+import { setupOrganizationRoutes } from "../../src/routes/admin/organizations.js";
+import type { Pool } from "pg";
+
+vi.mock("../../src/middleware/auth.js", async (importOriginal) => {
+  const requireAuth = (req: any, _res: any, next: any) => {
+    req.user = {
+      id: "user_admin_add_users_actor",
+      email: "admin@example.test",
+      is_admin: true,
+    };
+    next();
+  };
+  const requireAdmin = (_req: any, _res: any, next: any) => next();
+
+  return {
+    ...(await importOriginal<typeof import("../../src/middleware/auth.js")>()),
+    requireAuth,
+    requireAdmin,
+  };
+});
+
+describe("admin add-users", () => {
+  const TARGET_ORG_ID = "org_admin_add_users_target";
+  const SOURCE_ORG_ID = "org_admin_add_users_personal";
+  const USER_ID = "user_01ARZ3NDEKTSV4RRFFQ69G5FAV";
+  const MEMBERSHIP_ID = "om_01ARZ3NDEKTSV4RRFFQ69G5FAV";
+  const EXISTING_MEMBERSHIP_ID = "om_01BRZ3NDEKTSV4RRFFQ69G5FAV";
+
+  let pool: Pool;
+  let app: express.Express;
+  let createOrganizationMembership: ReturnType<typeof vi.fn>;
+  let listOrganizationMemberships: ReturnType<typeof vi.fn>;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString:
+        process.env.DATABASE_URL ||
+        "postgresql://adcp:localdev@localhost:5432/adcp_test",
+    });
+    await runMigrations();
+
+    createOrganizationMembership = vi.fn();
+    listOrganizationMemberships = vi.fn();
+
+    const router = express.Router();
+    setupOrganizationRoutes(router, {
+      workos: {
+        userManagement: {
+          createOrganizationMembership,
+          listOrganizationMemberships,
+        },
+      } as any,
+    });
+
+    app = express();
+    app.use(express.json());
+    app.use("/api/admin", router);
+  }, 60000);
+
+  afterAll(async () => {
+    await cleanup();
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanup();
+    createOrganizationMembership.mockReset().mockResolvedValue({
+      id: MEMBERSHIP_ID,
+      userId: USER_ID,
+      organizationId: TARGET_ORG_ID,
+      role: { slug: "member" },
+      status: "active",
+    });
+    listOrganizationMemberships.mockReset().mockResolvedValue({ data: [] });
+
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+       VALUES
+         ($1, 'Target org', false, NOW(), NOW()),
+         ($2, 'Personal org', true, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO UPDATE SET
+         name = EXCLUDED.name,
+         is_personal = EXCLUDED.is_personal`,
+      [TARGET_ORG_ID, SOURCE_ORG_ID]
+    );
+    await seedSourceMembership();
+  });
+
+  async function cleanup() {
+    if (!pool) return;
+    await pool.query(
+      "DELETE FROM registry_audit_log WHERE workos_organization_id IN ($1, $2)",
+      [TARGET_ORG_ID, SOURCE_ORG_ID]
+    );
+    await pool.query(
+      "DELETE FROM invitation_seat_types WHERE workos_organization_id IN ($1, $2)",
+      [TARGET_ORG_ID, SOURCE_ORG_ID]
+    );
+    await pool.query(
+      "DELETE FROM organization_memberships WHERE workos_organization_id IN ($1, $2)",
+      [TARGET_ORG_ID, SOURCE_ORG_ID]
+    );
+    await pool.query(
+      "DELETE FROM organizations WHERE workos_organization_id IN ($1, $2)",
+      [TARGET_ORG_ID, SOURCE_ORG_ID]
+    );
+  }
+
+  async function seedSourceMembership() {
+    await pool.query(
+      `INSERT INTO organization_memberships
+       (workos_user_id, workos_organization_id, workos_membership_id, email, first_name, last_name, role, seat_type, created_at, updated_at, synced_at)
+       VALUES ($1, $2, 'om_source_admin_add_user', 'user@example.test', 'Ada', 'Admin', 'owner', 'community_only', NOW(), NOW(), NOW())`,
+      [USER_ID, SOURCE_ORG_ID]
+    );
+  }
+
+  it("mirrors successful WorkOS adds through the shared membership upsert", async () => {
+    const response = await request(app)
+      .post(`/api/admin/organizations/${TARGET_ORG_ID}/add-users`)
+      .send({ user_ids: [USER_ID] })
+      .expect(200);
+
+    expect(response.body.added_count).toBe(1);
+    expect(createOrganizationMembership).toHaveBeenCalledWith({
+      userId: USER_ID,
+      organizationId: TARGET_ORG_ID,
+      roleSlug: "member",
+    });
+
+    const row = await pool.query<{
+      workos_membership_id: string;
+      role: string;
+      seat_type: string;
+      provisioning_source: string | null;
+    }>(
+      `SELECT workos_membership_id, role, seat_type, provisioning_source
+       FROM organization_memberships
+       WHERE workos_user_id = $1 AND workos_organization_id = $2`,
+      [USER_ID, TARGET_ORG_ID]
+    );
+
+    expect(row.rows[0]).toMatchObject({
+      workos_membership_id: MEMBERSHIP_ID,
+      role: "member",
+      seat_type: "community_only",
+      provisioning_source: "admin_added",
+    });
+    await expectAuditRow({
+      membershipId: MEMBERSHIP_ID,
+      repairedExistingMembership: false,
+    });
+    await expectStagingRows(0);
+  });
+
+  it("repairs local drift without inventing admin_added attribution", async () => {
+    const alreadyExists = new Error("already exists") as Error & { code: string };
+    alreadyExists.code = "organization_membership_already_exists";
+    createOrganizationMembership.mockRejectedValueOnce(alreadyExists);
+    listOrganizationMemberships.mockResolvedValueOnce({
+      data: [
+        {
+          id: EXISTING_MEMBERSHIP_ID,
+          userId: USER_ID,
+          organizationId: TARGET_ORG_ID,
+          role: { slug: "admin" },
+          status: "active",
+        },
+      ],
+    });
+
+    const response = await request(app)
+      .post(`/api/admin/organizations/${TARGET_ORG_ID}/add-users`)
+      .send({ user_ids: [USER_ID] })
+      .expect(200);
+
+    expect(response.body.added_count).toBe(1);
+    expect(listOrganizationMemberships).toHaveBeenCalledWith({
+      userId: USER_ID,
+      organizationId: TARGET_ORG_ID,
+    });
+
+    const row = await pool.query<{
+      workos_membership_id: string;
+      role: string;
+      provisioning_source: string | null;
+    }>(
+      `SELECT workos_membership_id, role, provisioning_source
+       FROM organization_memberships
+       WHERE workos_user_id = $1 AND workos_organization_id = $2`,
+      [USER_ID, TARGET_ORG_ID]
+    );
+
+    expect(row.rows[0]).toMatchObject({
+      workos_membership_id: EXISTING_MEMBERSHIP_ID,
+      role: "admin",
+      provisioning_source: null,
+    });
+    await expectAuditRow({
+      membershipId: EXISTING_MEMBERSHIP_ID,
+      repairedExistingMembership: true,
+    });
+    await expectStagingRows(0);
+  });
+
+  it("does not echo raw WorkOS errors to the API response", async () => {
+    createOrganizationMembership.mockRejectedValueOnce(
+      new Error("User not found: sensitive-workos-detail")
+    );
+
+    const response = await request(app)
+      .post(`/api/admin/organizations/${TARGET_ORG_ID}/add-users`)
+      .send({ user_ids: [USER_ID] })
+      .expect(200);
+
+    expect(response.body.added_count).toBe(0);
+    expect(response.body.errors).toEqual([
+      `User ${USER_ID}: Could not add membership`,
+    ]);
+    expect(JSON.stringify(response.body)).not.toContain(
+      "sensitive-workos-detail"
+    );
+
+    const row = await pool.query(
+      `SELECT 1
+       FROM organization_memberships
+       WHERE workos_user_id = $1 AND workos_organization_id = $2`,
+      [USER_ID, TARGET_ORG_ID]
+    );
+    expect(row.rowCount).toBe(0);
+    await expectStagingRows(0);
+  });
+
+  async function expectStagingRows(expected: number) {
+    const rows = await pool.query<{ count: string }>(
+      "SELECT COUNT(*)::int AS count FROM invitation_seat_types WHERE workos_organization_id = $1",
+      [TARGET_ORG_ID]
+    );
+    expect(Number(rows.rows[0].count)).toBe(expected);
+  }
+
+  async function expectAuditRow(args: {
+    membershipId: string;
+    repairedExistingMembership: boolean;
+  }) {
+    const rows = await pool.query<{
+      action: string;
+      workos_user_id: string;
+      resource_id: string;
+      details: {
+        target_user_id: string;
+        target_email: string;
+        via: string;
+        repaired_existing_membership: boolean;
+      };
+    }>(
+      `SELECT action, workos_user_id, resource_id, details
+       FROM registry_audit_log
+       WHERE workos_organization_id = $1
+       ORDER BY created_at DESC
+       LIMIT 1`,
+      [TARGET_ORG_ID]
+    );
+
+    expect(rows.rows[0]).toMatchObject({
+      action: "member_added",
+      workos_user_id: "user_admin_add_users_actor",
+      resource_id: args.membershipId,
+    });
+    expect(rows.rows[0].details).toMatchObject({
+      target_user_id: USER_ID,
+      target_email: "user@example.test",
+      via: "admin_add_users",
+      repaired_existing_membership: args.repairedExistingMembership,
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Refs #4911.

- routes admin add-users local writes through `upsertOrganizationMembership`
- stages `admin_added` attribution before the WorkOS create so a racing webhook can preserve the right source
- repairs the drift case where WorkOS returns `organization_membership_already_exists` but the local cache row is missing, without inventing new `admin_added` attribution for an already-existing membership
- replaces raw WorkOS error messages in the API response with a fixed per-user failure string
- writes a durable audit row for both fresh adds and repaired existing memberships

## Notes

This intentionally does not change the auth policy on `POST /api/admin/organizations/:orgId/add-users`; the `requireGlobalAdmin` vs scoped API-key decision still needs human review.

## Validation

- `npx vitest run server/tests/integration/admin-add-users.test.ts --config server/vitest.config.ts`
- `npm run typecheck`
- precommit hook: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run typecheck`
