### PR TITLE
fix(registry): refresh compliance verdicts

### DIFF
--- a/.changeset/fix-compliance-run-verdict-refresh.md
+++ b/.changeset/fix-compliance-run-verdict-refresh.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix registry compliance refresh semantics so full-suite compliance runs replace stale storyboard verdicts, while public advisory observations come only from the latest run in a redacted shape.

--- a/server/src/addie/jobs/compliance-heartbeat.ts
+++ b/server/src/addie/jobs/compliance-heartbeat.ts
@@ -128,7 +128,7 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
       // notification, since owner-driven runs already have a chat response.
       const declaredSpecialisms = complianceResult.agent_profile?.specialisms ?? [];
 
-      if (declaredSpecialisms.length > 0 && storyboardStatuses.length > 0) {
+      if (declaredSpecialisms.length > 0) {
         try {
           const badgeResult = await runBadgeFanOut({
             complianceDb,
@@ -217,7 +217,35 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
           observations_json: [{ category: observationCategory, severity: observationSeverity, message: observationMessage }],
           triggered_by: 'heartbeat',
           dry_run: false,
+          replace_storyboard_statuses: true,
         });
+
+        const existingBadges = await complianceDb.getBadgesForAgent(agent.agent_url);
+        const revoked = [];
+        for (const badge of existingBadges) {
+          await complianceDb.revokeBadge(
+            agent.agent_url,
+            badge.role,
+            badge.adcp_version,
+            'Authoritative compliance run failed before storyboard verification',
+          );
+          revoked.push({
+            role: badge.role,
+            reason: 'Authoritative compliance run failed',
+            adcp_version: badge.adcp_version,
+          });
+        }
+        if (revoked.length > 0) {
+          try {
+            await notifyVerificationChange({
+              agentUrl: agent.agent_url,
+              issued: [],
+              revoked,
+            });
+          } catch (notifyError) {
+            logger.error({ notifyError, agentUrl: agent.agent_url }, 'Failed to send verification revocation notification');
+          }
+        }
       } catch (recordError) {
         logger.error({ recordError, agentUrl: agent.agent_url }, 'Failed to record compliance failure');
       }

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -3811,7 +3811,7 @@ export function createMemberToolHandlers(
           );
         }
 
-        if (isAgentOwner && writesCanonicalComplianceState) {
+        if (isAgentOwner && writesCanonicalComplianceState && !tracks) {
           try {
             const metadata = await complianceDb.getRegistryMetadata(resolved.resolvedUrl);
             // Skip canonical write if the owner has opted out of compliance monitoring.
@@ -3823,6 +3823,9 @@ export function createMemberToolHandlers(
                   metadata?.lifecycle_stage ?? 'production',
                   'owner_test',
                 ),
+                // Track-filtered evaluations are diagnostic slices, not an
+                // authoritative replacement for every storyboard row.
+                replace_storyboard_statuses: !tracks,
                 // Owner test runs are not dry runs — they update the live public record.
                 // (complianceResultToDbInput hard-codes dry_run: true; override here.)
                 dry_run: false,
@@ -3859,6 +3862,8 @@ export function createMemberToolHandlers(
           } catch (error) {
             logger.warn({ error, agentUrl: resolved.resolvedUrl }, 'Could not write owner test result to canonical compliance state');
           }
+        } else if (isAgentOwner && writesCanonicalComplianceState && tracks) {
+          skippedCanonicalWriteForTarget = true;
         } else if (isAgentOwner) {
           skippedCanonicalWriteForTarget = true;
         }

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -657,6 +657,7 @@ export function complianceResultToDbInput(
     observations_json: result.observations,
     triggered_by: triggeredBy,
     storyboard_statuses: deriveStoryboardStatuses(result, storyboardIds),
+    replace_storyboard_statuses: !storyboardIds?.length,
     step_diagnostics: extractFailingStepDiagnostics(result),
     // Forward-compat: notices are an optional field in the runner output
     // contract (run_summary.notices). Unknown codes/severities are stored

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -265,6 +265,16 @@ export interface RecordComplianceRunInput {
   triggered_org_id?: string | null;
   dry_run?: boolean;
   storyboard_statuses?: StoryboardStatusEntry[];
+  /**
+   * When true, this run is authoritative for the agent's full storyboard
+   * surface. Existing materialized storyboard verdict rows for the agent are
+   * deleted before this run's rows are inserted, so removed/skipped storyboards
+   * from older runs cannot keep contributing stale pass/fail state.
+   *
+   * Leave false for partial owner-triggered storyboard reruns; those
+   * intentionally overlay one storyboard without discarding the rest.
+   */
+  replace_storyboard_statuses?: boolean;
   step_diagnostics?: StepDiagnosticEntry[];
   /**
    * Advisory notices emitted by the runner at run-summary level. Stored as
@@ -447,68 +457,91 @@ export class ComplianceDatabase {
         ],
       );
 
-      // 5. Batch upsert per-storyboard statuses (single query, not N+1)
+      // 5. Batch upsert per-storyboard statuses (single query, not N+1).
+      // Full-suite runs replace the agent's materialized storyboard rows before
+      // inserting fresh results. That invalidates stale verdicts from older
+      // compliance targets/cache versions while preserving partial overlay
+      // semantics for single-storyboard owner retests.
       // Uses a SAVEPOINT so a missing table (pre-migration) doesn't roll back
       // the entire compliance run — the run and status update still commit.
-      if (input.storyboard_statuses?.length) {
+      if (input.replace_storyboard_statuses || input.storyboard_statuses?.length) {
         // Validate status values before sending to Postgres to surface typos
         // as clear errors instead of cryptic constraint violations inside unnest
-        for (const sb of input.storyboard_statuses) {
+        for (const sb of input.storyboard_statuses ?? []) {
           if (!VALID_STORYBOARD_STATUSES.has(sb.status)) {
             throw new Error(`Invalid storyboard status "${sb.status}" for ${sb.storyboard_id}`);
           }
         }
 
-        const sbIds = input.storyboard_statuses.map(s => s.storyboard_id);
-        const sbStatuses = input.storyboard_statuses.map(s => s.status);
-        const sbStepsPassed = input.storyboard_statuses.map(s => s.steps_passed);
-        const sbStepsTotal = input.storyboard_statuses.map(s => s.steps_total);
-
         await client.query('SAVEPOINT storyboard_upsert');
         try {
-          await client.query(
-            `INSERT INTO agent_storyboard_status (
-              agent_url, storyboard_id, status, last_tested_at,
-              last_passed_at, last_failed_at, run_id,
-              steps_passed, steps_total, triggered_by, requested_compliance_target, adcp_version, updated_at
-            )
-            SELECT
-              $1, sb_id, sb_status, NOW(),
-              CASE WHEN sb_status = 'passing' THEN NOW() ELSE NULL END,
-              CASE WHEN sb_status IN ('failing', 'partial') THEN NOW() ELSE NULL END,
-              $4, sb_passed, sb_total, $7, $8, $9, NOW()
-            FROM unnest($2::text[], $3::text[], $5::int[], $6::int[])
-              AS t(sb_id, sb_status, sb_passed, sb_total)
-            ON CONFLICT (agent_url, storyboard_id) DO UPDATE SET
-              status = EXCLUDED.status,
-              last_tested_at = NOW(),
-              last_passed_at = CASE
-                WHEN EXCLUDED.status = 'passing' THEN NOW()
-                ELSE agent_storyboard_status.last_passed_at
-              END,
-              last_failed_at = CASE
-                WHEN EXCLUDED.status IN ('failing', 'partial') THEN NOW()
-                ELSE agent_storyboard_status.last_failed_at
-              END,
-              run_id = EXCLUDED.run_id,
-              steps_passed = EXCLUDED.steps_passed,
-              steps_total = EXCLUDED.steps_total,
-              triggered_by = EXCLUDED.triggered_by,
-              requested_compliance_target = EXCLUDED.requested_compliance_target,
-              adcp_version = EXCLUDED.adcp_version,
-              updated_at = NOW()`,
-            [
-              input.agent_url,
-              sbIds,
-              sbStatuses,
-              run.id,
-              sbStepsPassed,
-              sbStepsTotal,
-              input.triggered_by ?? 'heartbeat',
-              input.requested_compliance_target ?? null,
-              input.adcp_version ?? null,
-            ],
-          );
+          if (input.replace_storyboard_statuses) {
+            if (input.storyboard_statuses?.length) {
+              const freshIds = input.storyboard_statuses.map(s => s.storyboard_id);
+              await client.query(
+                `DELETE FROM agent_storyboard_status
+                 WHERE agent_url = $1
+                   AND NOT (storyboard_id = ANY($2::text[]))`,
+                [input.agent_url, freshIds],
+              );
+            } else {
+              await client.query(
+                `DELETE FROM agent_storyboard_status WHERE agent_url = $1`,
+                [input.agent_url],
+              );
+            }
+          }
+
+          if (input.storyboard_statuses?.length) {
+            const sbIds = input.storyboard_statuses.map(s => s.storyboard_id);
+            const sbStatuses = input.storyboard_statuses.map(s => s.status);
+            const sbStepsPassed = input.storyboard_statuses.map(s => s.steps_passed);
+            const sbStepsTotal = input.storyboard_statuses.map(s => s.steps_total);
+
+            await client.query(
+              `INSERT INTO agent_storyboard_status (
+                agent_url, storyboard_id, status, last_tested_at,
+                last_passed_at, last_failed_at, run_id,
+                steps_passed, steps_total, triggered_by, requested_compliance_target, adcp_version, updated_at
+              )
+              SELECT
+                $1, sb_id, sb_status, NOW(),
+                CASE WHEN sb_status = 'passing' THEN NOW() ELSE NULL END,
+                CASE WHEN sb_status IN ('failing', 'partial') THEN NOW() ELSE NULL END,
+                $4, sb_passed, sb_total, $7, $8, $9, NOW()
+              FROM unnest($2::text[], $3::text[], $5::int[], $6::int[])
+                AS t(sb_id, sb_status, sb_passed, sb_total)
+              ON CONFLICT (agent_url, storyboard_id) DO UPDATE SET
+                status = EXCLUDED.status,
+                last_tested_at = NOW(),
+                last_passed_at = CASE
+                  WHEN EXCLUDED.status = 'passing' THEN NOW()
+                  ELSE agent_storyboard_status.last_passed_at
+                END,
+                last_failed_at = CASE
+                  WHEN EXCLUDED.status IN ('failing', 'partial') THEN NOW()
+                  ELSE agent_storyboard_status.last_failed_at
+                END,
+                run_id = EXCLUDED.run_id,
+                steps_passed = EXCLUDED.steps_passed,
+                steps_total = EXCLUDED.steps_total,
+                triggered_by = EXCLUDED.triggered_by,
+                requested_compliance_target = EXCLUDED.requested_compliance_target,
+                adcp_version = EXCLUDED.adcp_version,
+                updated_at = NOW()`,
+              [
+                input.agent_url,
+                sbIds,
+                sbStatuses,
+                run.id,
+                sbStepsPassed,
+                sbStepsTotal,
+                input.triggered_by ?? 'heartbeat',
+                input.requested_compliance_target ?? null,
+                input.adcp_version ?? null,
+              ],
+            );
+          }
           await client.query('RELEASE SAVEPOINT storyboard_upsert');
         } catch (sbErr) {
           await client.query('ROLLBACK TO SAVEPOINT storyboard_upsert');
@@ -716,13 +749,18 @@ export class ComplianceDatabase {
     return map;
   }
 
-  async getComplianceHistory(agentUrl: string, limit: number = 30): Promise<ComplianceRun[]> {
+  async getComplianceHistory(
+    agentUrl: string,
+    limit: number = 30,
+    opts: { includeDryRuns?: boolean } = {},
+  ): Promise<ComplianceRun[]> {
     const result = await query(
       `SELECT * FROM agent_compliance_runs
        WHERE agent_url = $1
+         AND ($3::boolean OR dry_run = FALSE)
        ORDER BY tested_at DESC
        LIMIT $2`,
-      [agentUrl, limit],
+      [agentUrl, limit, opts.includeDryRuns ?? false],
     );
     return result.rows;
   }
@@ -823,6 +861,25 @@ export class ComplianceDatabase {
     const raw = result.rows[0]?.notices_json;
     if (!Array.isArray(raw)) return [];
     return raw as NoticeEntry[];
+  }
+
+  /**
+   * Return advisory observations from the most recent non-dry-run compliance
+   * run. These are fresh per-run observations from the runner (for example
+   * best-practice advisories); consumers must not merge them with older runs.
+   */
+  async getLatestObservations(agentUrl: string): Promise<unknown[]> {
+    const result = await query(
+      `SELECT observations_json
+       FROM agent_compliance_runs
+       WHERE agent_url = $1 AND dry_run = FALSE
+       ORDER BY tested_at DESC
+       LIMIT 1`,
+      [agentUrl],
+    );
+    const raw = result.rows[0]?.observations_json;
+    if (!Array.isArray(raw)) return [];
+    return raw;
   }
 
   // ----- Due-for-Check Query -----

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -147,6 +147,29 @@ function isUndefinedTableError(err: unknown): boolean {
     (err as { code?: unknown }).code === "42P01";
 }
 
+interface PublicComplianceObservation {
+  category: string;
+  severity: string;
+  message: string;
+}
+
+function toPublicComplianceObservation(obs: unknown): PublicComplianceObservation | null {
+  if (!obs || typeof obs !== "object") return null;
+  const record = obs as Record<string, unknown>;
+  if (
+    typeof record.category !== "string" ||
+    typeof record.severity !== "string" ||
+    typeof record.message !== "string"
+  ) {
+    return null;
+  }
+  return {
+    category: record.category,
+    severity: record.severity,
+    message: record.message,
+  };
+}
+
 /** Strip protocol, path, query, and fragment from a URL to extract the domain. */
 function extractDomain(raw: string): string {
   let d = raw.replace(/^https?:\/\//, "");
@@ -2334,6 +2357,8 @@ registry.registerPath({
             error: z.string().optional(),
             compliance: z.object({
               ran: z.boolean().openapi({ description: "True if the full storyboard suite ran and agent_storyboard_status was updated. False when ownership couldn't be resolved, the agent reported auth_required, or the compliance call itself failed." }),
+              run_id: z.string().optional().openapi({ description: "Compliance run id written by this refresh. Use with /compliance/diagnostics?run_id=... to inspect failing-step wire evidence." }),
+              test_session_id: z.string().optional().openapi({ description: "Fresh test session id used for the compliance run. Useful when matching seller-side logs to the refresh." }),
               requested_compliance_target: z.string().optional().openapi({ description: "Requested compliance target before alias resolution, e.g. 3.1, 3.0, or 3.1-beta. Present when `ran` is true." }),
               adcp_version: z.string().optional().openapi({ description: "Concrete AdCP compliance bundle version used for the run, e.g. 3.0.12 or 3.1.0-beta.7. Present when `ran` is true." }),
               badge_eligible: z.boolean().optional().openapi({ description: "True when this run can update public badge state." }),
@@ -2341,6 +2366,8 @@ registry.registerPath({
               overall_status: z.string().optional().openapi({ description: "Aggregate verdict from the run (passing / failing / partial / unknown). Only present when `ran` is true." }),
               storyboards_passing: z.number().int().optional().openapi({ description: "Number of storyboards passing on this run." }),
               storyboards_total: z.number().int().optional().openapi({ description: "Number of storyboards evaluated on this run." }),
+              observations_count: z.number().int().optional().openapi({ description: "Number of advisory observations emitted by this run." }),
+              notices_count: z.number().int().optional().openapi({ description: "Number of run-summary notices emitted by this run." }),
               error: z.string().optional().openapi({ description: "Reason compliance didn't run when `ran` is false." }),
             }).openapi({ description: "Compliance re-run summary. The capability/health portion of the response is independent of this block — a failed compliance run still returns the rest of the snapshot." }),
           }),
@@ -4577,6 +4604,19 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         logger.warn({ err, agentUrl }, "Notices query failed (column may not exist yet)");
       }
 
+      // Advisory observations from the latest run — these are per-run runner
+      // observations (best-practice warnings, suggestions, etc.). Do not merge
+      // observations across runs; a fixed field on the wire must clear the
+      // advisory as soon as the latest run stops emitting it.
+      let observations: PublicComplianceObservation[] = [];
+      try {
+        observations = (await complianceDb.getLatestObservations(agentUrl))
+          .map(toPublicComplianceObservation)
+          .filter((obs): obs is PublicComplianceObservation => obs !== null);
+      } catch (err) {
+        logger.warn({ err, agentUrl }, "Latest observations query failed");
+      }
+
       // Per-specialism status — the dashboard renders pass/fail/untested
       // dots so the developer can see which declared specialism is the
       // cause of an overall `failing` status without cross-referencing
@@ -4658,6 +4698,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         // Advisory notices from the latest run. Forward-compat: unknown codes
         // and severities are passed through verbatim (runner-output-contract.yaml).
         notices,
+        observations,
         // Owner-scoped: content is null/false for anonymous and cross-org
         // viewers, populated only when the authenticated viewer owns the
         // agent. Keys are always present so non-owners can't detect
@@ -4721,7 +4762,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       }
 
       const limit = Math.min(parseInt(req.query.limit as string) || 30, 100);
-      const history = await complianceDb.getComplianceHistory(agentUrl, limit);
+      const history = await complianceDb.getComplianceHistory(agentUrl, limit, { includeDryRuns: false });
 
       res.json({
         agent_url: agentUrl,
@@ -5514,6 +5555,10 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         overall_status?: string;
         storyboards_passing?: number;
         storyboards_total?: number;
+        run_id?: string;
+        test_session_id?: string;
+        observations_count?: number;
+        notices_count?: number;
         error?: string;
       } = { ran: false };
 
@@ -5551,12 +5596,16 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
             const passing = storyboardStatuses.filter(s => s.status === 'passing').length;
             complianceSummary = {
               ran: true,
+              run_id: run.id,
+              test_session_id: testSessionId,
               requested_compliance_target: complianceTarget.requested,
               adcp_version: complyResult.adcp_version,
               ...badgeEligibilityMetadata(badgeEligibleAdcpVersions.length > 0),
               overall_status: dbInput.overall_status,
               storyboards_passing: passing,
               storyboards_total: storyboardStatuses.length,
+              observations_count: Array.isArray(dbInput.observations_json) ? dbInput.observations_json.length : 0,
+              notices_count: Array.isArray(dbInput.notices_json) ? dbInput.notices_json.length : 0,
             };
 
             // Fan out badge issuance so verification badges reflect the new

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -353,6 +353,12 @@ export const AgentComplianceDetailSchema = z
     check_interval_hours: z.number().int().optional().openapi({ description: "How often the heartbeat re-tests this agent, in hours" }),
     declared_specialisms: z.array(z.string()).optional().openapi({ description: "Specialisms the agent declared in get_adcp_capabilities, from the latest run" }),
     specialism_status: z.record(z.string(), z.enum(['passing', 'failing', 'untested', 'unknown'])).optional().openapi({ description: "Per-specialism pass/fail/untested status — keyed on declared specialism, derived from the matching storyboard's status" }),
+    notices: z.array(z.any()).optional().openapi({ description: "Run-summary notices from the latest non-dry-run compliance run. Unknown codes/severities are preserved verbatim." }),
+    observations: z.array(z.object({
+      category: z.string(),
+      severity: z.string(),
+      message: z.string(),
+    })).optional().openapi({ description: "Public-safe advisory observations from the latest non-dry-run compliance run. Raw evidence is intentionally omitted; this array is not merged across runs, so cleared advisories disappear on the next fresh run." }),
     membership_tier: z.string().nullable().optional().openapi({ description: "Owner-scoped: the agent owner's membership tier. Populated only when the authenticated viewer owns the agent; null otherwise. Field is always present so response shape doesn't reveal ownership." }),
     membership_tier_label: z.string().nullable().optional().openapi({ description: "Owner-scoped: human-readable label for membership_tier (e.g. 'Builder'). Null for non-owners." }),
     subscription_status: z.string().nullable().optional().openapi({ description: "Owner-scoped: the agent owner's subscription status (active, past_due, trialing, etc.). Null for non-owners." }),

--- a/server/tests/integration/registry-api-agent-refresh.test.ts
+++ b/server/tests/integration/registry-api-agent-refresh.test.ts
@@ -132,6 +132,13 @@ function makeComplianceResult(options: { specialisms?: string[]; storyboardId?: 
       tracks_failed: 0,
       tracks_skipped: 0,
       tracks_partial: 0,
+      notices: [
+        {
+          severity: 'info',
+          code: 'fixture_notice',
+          message: 'Fixture notice',
+        },
+      ],
     },
     tracks: [{
       track: 'media-buy',
@@ -143,7 +150,13 @@ function makeComplianceResult(options: { specialisms?: string[]; storyboardId?: 
         steps: [{ step_id: 'get_adcp_capabilities', passed: true }],
       }],
     }],
-    observations: [],
+    observations: [
+      {
+        category: 'best_practice',
+        severity: 'suggestion',
+        message: 'Fixture observation',
+      },
+    ],
     agent_profile: { specialisms },
   };
 }
@@ -238,9 +251,13 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
       type_promoted: true,
       compliance: {
         ran: true,
+        run_id: expect.any(String),
+        test_session_id: expect.stringMatching(/^owner-refresh-\d+-[0-9a-f-]{36}$/),
         overall_status: 'passing',
         storyboards_passing: 1,
         storyboards_total: 1,
+        observations_count: 1,
+        notices_count: 1,
       },
     });
     expect(refreshSingleAgentMock).toHaveBeenCalledWith(agentUrl, expect.any(Object));

--- a/server/tests/unit/badge-fan-out.test.ts
+++ b/server/tests/unit/badge-fan-out.test.ts
@@ -77,6 +77,25 @@ describe('runBadgeFanOut', () => {
     expect(queryMock).not.toHaveBeenCalled();
   });
 
+  it('full-suite runId path still processes badges when the authoritative run wrote zero storyboard rows', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ workos_organization_id: 'org_member' }], rowCount: 1, command: 'SELECT', oid: 0, fields: [] } as never);
+
+    const db = makeDb({
+      existingBadges: [badge('media-buy')],
+      latestStatuses: [],
+    });
+
+    const result = await runBadgeFanOut({
+      complianceDb: db,
+      agentUrl: 'https://example.com/mcp',
+      declaredSpecialisms: ['sales-broadcast-tv'],
+      runId: 'run-zero-storyboards',
+    });
+
+    expect(db.getStoryboardStatuses).toHaveBeenCalledWith('https://example.com/mcp', { runId: 'run-zero-storyboards' });
+    expect(result.degraded.map(d => d.role)).toContain('media-buy');
+  });
+
   it('reads ALL latest storyboard statuses from the canonical table — not just what one partial run touched', async () => {
     // Agent declared two specialisms across two roles. The OTHER storyboard
     // is still passing on disk; this run only retested the broadcast-tv

--- a/server/tests/unit/compliance-db-last-write-wins.test.ts
+++ b/server/tests/unit/compliance-db-last-write-wins.test.ts
@@ -168,6 +168,99 @@ describe('ComplianceDatabase — last-write-wins on agent_compliance_status', ()
     expect(upsert).toBeDefined();
   });
 
+  it('full-suite compliance writes prune disappeared storyboard rows before upsert', async () => {
+    const statusRow = { rows: [{ status: 'passing', previous_status: 'passing' }] };
+    const client = makeTransactionClient([
+      EMPTY,                         // BEGIN
+      { rows: [makeRunRow('heartbeat')] },
+      statusRow,                     // UPSERT agent_compliance_status
+      EMPTY,                         // SAVEPOINT storyboard_upsert
+      EMPTY,                         // DELETE stale storyboard rows
+      EMPTY,                         // INSERT fresh storyboard rows
+      EMPTY,                         // RELEASE SAVEPOINT
+      EMPTY,                         // COMMIT
+    ]);
+    mockedGetClient.mockResolvedValueOnce(client as any);
+
+    await db.recordComplianceRun({
+      ...minimalInput('heartbeat'),
+      replace_storyboard_statuses: true,
+      storyboard_statuses: [
+        { storyboard_id: 'fresh_storyboard', status: 'passing', steps_passed: 3, steps_total: 3 },
+      ],
+    });
+
+    const deleteIndex = client.query.mock.calls.findIndex(
+      ([sql]: [string]) => typeof sql === 'string' && sql.includes('DELETE FROM agent_storyboard_status'),
+    );
+    const insertIndex = client.query.mock.calls.findIndex(
+      ([sql]: [string]) => typeof sql === 'string' && sql.includes('INSERT INTO agent_storyboard_status'),
+    );
+    expect(deleteIndex).toBeGreaterThan(-1);
+    expect(insertIndex).toBeGreaterThan(deleteIndex);
+    expect(client.query.mock.calls[deleteIndex][0]).toContain('NOT (storyboard_id = ANY($2::text[]))');
+    expect(client.query.mock.calls[deleteIndex][1]).toEqual([AGENT_URL, ['fresh_storyboard']]);
+  });
+
+  it('zero-row authoritative compliance writes clear all materialized storyboard rows', async () => {
+    const statusRow = { rows: [{ status: 'failing', previous_status: 'passing' }] };
+    const client = makeTransactionClient([
+      EMPTY,
+      { rows: [makeRunRow('heartbeat')] },
+      statusRow,
+      EMPTY,
+      EMPTY,
+      EMPTY,
+      EMPTY,
+    ]);
+    mockedGetClient.mockResolvedValueOnce(client as any);
+
+    await db.recordComplianceRun({
+      ...minimalInput('heartbeat'),
+      overall_status: 'failing',
+      tracks_json: [],
+      tracks_passed: 0,
+      tracks_failed: 0,
+      replace_storyboard_statuses: true,
+      storyboard_statuses: [],
+    });
+
+    const deleteCall = client.query.mock.calls.find(
+      ([sql]: [string]) => typeof sql === 'string' && sql.includes('DELETE FROM agent_storyboard_status'),
+    );
+    expect(deleteCall).toBeDefined();
+    expect(deleteCall![0]).toContain('WHERE agent_url = $1');
+    expect(deleteCall![0]).not.toContain('storyboard_id = ANY');
+    expect(deleteCall![1]).toEqual([AGENT_URL]);
+  });
+
+  it('partial storyboard writes overlay one row without clearing other storyboard rows', async () => {
+    const statusRow = { rows: [{ status: 'passing', previous_status: 'passing' }] };
+    const client = makeTransactionClient([
+      EMPTY,
+      { rows: [makeRunRow('owner_test')] },
+      statusRow,
+      EMPTY, // SAVEPOINT storyboard_upsert
+      EMPTY, // INSERT storyboard row
+      EMPTY, // RELEASE SAVEPOINT
+      EMPTY,
+    ]);
+    mockedGetClient.mockResolvedValueOnce(client as any);
+
+    await db.recordComplianceRun({
+      ...minimalInput('owner_test'),
+      replace_storyboard_statuses: false,
+      storyboard_statuses: [
+        { storyboard_id: 'single_storyboard', status: 'passing', steps_passed: 1, steps_total: 1 },
+      ],
+    });
+
+    const deleteCall = client.query.mock.calls.find(
+      ([sql]: [string]) => typeof sql === 'string' && sql.includes('DELETE FROM agent_storyboard_status'),
+    );
+    expect(deleteCall).toBeUndefined();
+  });
+
   it('getComplianceStatus LATERAL join returns last_triggered_by from most recent non-dry run', async () => {
     const now = new Date();
     mockedQuery.mockResolvedValueOnce({
@@ -332,6 +425,59 @@ describe('ComplianceDatabase — last-write-wins on agent_compliance_status', ()
     expect(sql).toContain('WITH latest_run AS');
     expect(sql).toContain('JOIN latest_run lr ON latest.run_id = lr.id');
     expect(params).toEqual([AGENT_URL, null, null, true]);
+  });
+
+  it('getLatestObservations returns advisory observations only from the latest non-dry run', async () => {
+    const observations = [
+      {
+        category: 'best_practice',
+        severity: 'suggestion',
+        message: 'Agent does not return valid_actions in get_media_buys response',
+      },
+    ];
+    mockedQuery.mockResolvedValueOnce({
+      rows: [{ observations_json: observations }],
+      rowCount: 1,
+      command: '',
+      oid: 0,
+      fields: [],
+    });
+
+    await expect(db.getLatestObservations(AGENT_URL)).resolves.toEqual(observations);
+
+    const [sql, params] = mockedQuery.mock.calls[0];
+    expect(sql).toContain('observations_json');
+    expect(sql).toContain('dry_run = FALSE');
+    expect(sql).toContain('ORDER BY tested_at DESC');
+    expect(params).toEqual([AGENT_URL]);
+  });
+
+  it('getComplianceHistory excludes dry-run diagnostic rows by default', async () => {
+    mockedQuery.mockResolvedValueOnce({
+      rows: [],
+      rowCount: 0,
+      command: '',
+      oid: 0,
+      fields: [],
+    });
+
+    await expect(db.getComplianceHistory(AGENT_URL, 10)).resolves.toEqual([]);
+
+    const [sql, params] = mockedQuery.mock.calls[0];
+    expect(sql).toContain('($3::boolean OR dry_run = FALSE)');
+    expect(params).toEqual([AGENT_URL, 10, false]);
+  });
+
+  it('getLatestObservations returns empty when the latest run has no observations array', async () => {
+    mockedQuery.mockResolvedValueOnce({
+      rows: [{ observations_json: null }],
+      rowCount: 1,
+      command: '',
+      oid: 0,
+      fields: [],
+    });
+
+    await expect(db.getLatestObservations(AGENT_URL)).resolves.toEqual([]);
   });
 
   it('getStoryboardStatusCounts can gate merged rows against the latest run inside the same SQL statement', async () => {

--- a/server/tests/unit/compliance-testing-effective-run-status.test.ts
+++ b/server/tests/unit/compliance-testing-effective-run-status.test.ts
@@ -103,4 +103,24 @@ describe('complianceResultToDbInput — effectiveRunStatus', () => {
     // No active tracks — falls through to mapOverallStatus('partial') → 'partial'
     expect(out.overall_status).toBe('partial');
   });
+
+  it('marks full-suite results as authoritative storyboard replacements', () => {
+    const result = makeResult([makeTrack('pass')], 'passing');
+    const out = complianceResultToDbInput(result as any, 'https://agent.example.com/mcp', 'production');
+
+    expect(out.replace_storyboard_statuses).toBe(true);
+  });
+
+  it('does not replace all storyboard rows for explicit single-storyboard runs', () => {
+    const result = makeResult([makeTrack('pass')], 'passing');
+    const out = complianceResultToDbInput(
+      result as any,
+      'https://agent.example.com/mcp',
+      'production',
+      'owner_test',
+      ['signal_owned'],
+    );
+
+    expect(out.replace_storyboard_statuses).toBe(false);
+  });
 });

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -1481,6 +1481,26 @@ components:
               - untested
               - unknown
           description: Per-specialism pass/fail/untested status — keyed on declared specialism, derived from the matching storyboard's status
+        notices:
+          type: array
+          items: {}
+          description: Run-summary notices from the latest non-dry-run compliance run. Unknown codes/severities are preserved verbatim.
+        observations:
+          type: array
+          items:
+            type: object
+            properties:
+              category:
+                type: string
+              severity:
+                type: string
+              message:
+                type: string
+            required:
+              - category
+              - severity
+              - message
+          description: Public-safe advisory observations from the latest non-dry-run compliance run. Raw evidence is intentionally omitted; this array is not merged across runs, so cleared advisories disappear on the next fresh run.
         membership_tier:
           type:
             - string
@@ -6890,6 +6910,12 @@ paths:
                       ran:
                         type: boolean
                         description: True if the full storyboard suite ran and agent_storyboard_status was updated. False when ownership couldn't be resolved, the agent reported auth_required, or the compliance call itself failed.
+                      run_id:
+                        type: string
+                        description: Compliance run id written by this refresh. Use with /compliance/diagnostics?run_id=... to inspect failing-step wire evidence.
+                      test_session_id:
+                        type: string
+                        description: Fresh test session id used for the compliance run. Useful when matching seller-side logs to the refresh.
                       requested_compliance_target:
                         type: string
                         description: Requested compliance target before alias resolution, e.g. 3.1, 3.0, or 3.1-beta. Present when `ran` is true.
@@ -6913,6 +6939,12 @@ paths:
                       storyboards_total:
                         type: integer
                         description: Number of storyboards evaluated on this run.
+                      observations_count:
+                        type: integer
+                        description: Number of advisory observations emitted by this run.
+                      notices_count:
+                        type: integer
+                        description: Number of run-summary notices emitted by this run.
                       error:
                         type: string
                         description: Reason compliance didn't run when `ran` is false.


### PR DESCRIPTION
Fixes #4738 and #4751 by making full-suite compliance runs replace stale materialized storyboard verdicts while keeping explicit storyboard reruns as partial overlays.

Latest-run advisory observations are now exposed through public registry APIs in a redacted shape, and compliance history excludes dry-run diagnostic rows so resolved wire fields clear stale warnings.

Heartbeat badge fan-out now handles zero-row authoritative runs and revokes existing badges when an authoritative run fails before storyboard verification, and track-filtered owner evaluations no longer overwrite canonical public compliance state.

Validated with `npm run typecheck`, `npx tsc --noEmit --pretty false`, targeted Vitest coverage, the full precommit unit/lint/typecheck suite, OpenAPI rebuild, and push-time version/docs checks; the DB-backed registry refresh integration test could not complete locally because Postgres refused the connection.
