### PR TITLE
fix(admin): preserve user context engagement contract

### DIFF
--- a/.changeset/brave-days-find.md
+++ b/.changeset/brave-days-find.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix(admin): preserve user context engagement contract

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -244,6 +244,21 @@ export function createAdminRouter(): { pageRouter: Router; apiRouter: Router } {
         const extendedContext: typeof context & {
           addie_goal?: { goal_key: string; goal_name: string; reasoning: string };
           insights?: Array<{ type_key: string; type_name: string; value: string }>;
+          relationship_engagement?: {
+            opportunities: Array<{
+              id: string;
+              description: string;
+              dimension: string;
+              relevance: number;
+            }>;
+            contact_eligibility: {
+              can_contact: boolean;
+              reason?: string;
+              channel?: string;
+            };
+            relationship_stage: string;
+            unreplied_count: number;
+          };
         } = { ...context };
 
         if (workosUserId) {
@@ -361,7 +376,7 @@ export function createAdminRouter(): { pageRouter: Router; apiRouter: Router } {
                   certification: relCtx.certification,
                 });
 
-                (extendedContext as unknown as Record<string, unknown>).engagement = {
+                extendedContext.relationship_engagement = {
                   opportunities: opportunities.map(o => ({
                     id: o.id,
                     description: o.description,

--- a/server/tests/integration/user-context.test.ts
+++ b/server/tests/integration/user-context.test.ts
@@ -153,6 +153,20 @@ describe('User Context API Tests', () => {
       [TEST_SLACK_USER_ID, 'test@example.com', 'Test User', 'Test User', false, false, 'mapped', TEST_WORKOS_USER_ID]
     );
 
+    await pool.query(
+      `DELETE FROM person_relationships
+       WHERE slack_user_id = $1 OR workos_user_id = $2 OR email = $3`,
+      [TEST_SLACK_USER_ID, TEST_WORKOS_USER_ID, 'test@example.com']
+    );
+
+    await pool.query(
+      `INSERT INTO person_relationships (
+        slack_user_id, workos_user_id, email, display_name, stage,
+        interaction_count, sentiment_trend, unreplied_outreach_count
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+      [TEST_SLACK_USER_ID, TEST_WORKOS_USER_ID, 'test@example.com', 'Test User', 'participating', 3, 'neutral', 0]
+    );
+
     // Create test member profile
     await pool.query(
       `INSERT INTO member_profiles (workos_organization_id, display_name, slug, tagline, offerings, headquarters, created_at, updated_at)
@@ -170,6 +184,7 @@ describe('User Context API Tests', () => {
   afterAll(async () => {
     // Clean up test data
     await pool.query('DELETE FROM member_profiles WHERE workos_organization_id = $1', [TEST_ORG_ID]);
+    await pool.query('DELETE FROM person_relationships WHERE slack_user_id = $1 OR workos_user_id = $2', [TEST_SLACK_USER_ID, TEST_WORKOS_USER_ID]);
     await pool.query('DELETE FROM slack_user_mappings WHERE slack_user_id = $1', [TEST_SLACK_USER_ID]);
     await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [TEST_ORG_ID]);
 
@@ -200,6 +215,27 @@ describe('User Context API Tests', () => {
       expect(response.body).toHaveProperty('slack_linked');
       expect(response.body.slack_user).toBeDefined();
       expect(response.body.slack_user.slack_user_id).toBe(TEST_SLACK_USER_ID);
+    });
+
+    it('should preserve member engagement when relationship engagement is present', async () => {
+      const response = await request(app)
+        .get(`/api/admin/users/${TEST_SLACK_USER_ID}/context?type=slack`)
+        .expect(200);
+
+      expect(response.body.engagement).toMatchObject({
+        login_count_30d: expect.any(Number),
+        working_group_count: expect.any(Number),
+        email_click_count_30d: expect.any(Number),
+      });
+
+      expect(response.body.relationship_engagement).toMatchObject({
+        opportunities: expect.any(Array),
+        contact_eligibility: expect.objectContaining({
+          can_contact: expect.any(Boolean),
+        }),
+        relationship_stage: 'participating',
+        unreplied_count: expect.any(Number),
+      });
     });
 
     it('should auto-detect WorkOS user ID format (starts with user_)', async () => {


### PR DESCRIPTION
## Summary
- Preserve the existing `MemberContext.engagement` activity contract in the admin user context route.
- Move relationship outreach/opportunity data into `relationship_engagement` so Slack-linked users do not break the `/admin/users` context modal renderer.
- Add an integration assertion that member engagement remains present when relationship engagement is returned.

## Root Cause
The admin route was overwriting `context.engagement`, which the admin HTML expects to contain dashboard activity fields like `login_count_30d`, with relationship outreach data. The modal renderer then called `.toString()` on missing activity fields and showed `Failed to load context.`

Fixes #4450

## Expert Review
- Code review: no must-fix issues; recommended replacing the source-grep guardrail with a route-level assertion. Addressed.
- Internal tools review: confirmed `relationship_engagement` is the right compatibility tradeoff; noted that displaying those relationship signals in the modal can be a follow-up.

## Validation
- `git diff --check`
- `npm run typecheck`
- Commit prehook passed: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run typecheck`
- Attempted `npx vitest run server/tests/integration/user-context.test.ts --config server/vitest.config.ts`; local run could not connect to test Postgres at `localhost:53198`, so the suite did not execute locally.
