### PR TITLE
Fix profile photo uploads

### DIFF
--- a/.changeset/profile-photo-upload-no-release.md
+++ b/.changeset/profile-photo-upload-no-release.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix profile photo uploads on the community profile editor without a package release.

--- a/server/public/community/profile-edit.html
+++ b/server/public/community/profile-edit.html
@@ -576,12 +576,12 @@
                 <div id="portrait-upload-area" style="border: 2px dashed var(--color-border); border-radius: var(--radius-md); padding: var(--space-4); text-align: center; cursor: pointer; transition: border-color var(--duration-normal) var(--ease-in-out);">
                   <input type="file" id="portrait-photo-input" accept="image/jpeg,image/png" style="display: none;">
                   <div id="portrait-upload-label">
-                    <div style="font-size: var(--text-sm); color: var(--color-text-heading); font-weight: var(--font-medium);">Upload a reference photo</div>
-                    <div style="font-size: var(--text-xs); color: var(--color-text-muted); margin-top: var(--space-1);">JPEG or PNG, max 5MB. Used as reference only, not stored.</div>
+                    <div style="font-size: var(--text-sm); color: var(--color-text-heading); font-weight: var(--font-medium);">Upload a photo</div>
+                    <div style="font-size: var(--text-xs); color: var(--color-text-muted); margin-top: var(--space-1);">JPEG or PNG, max 5MB. Save to use it directly, or generate an illustrated portrait.</div>
                   </div>
                   <div id="portrait-upload-preview" style="display: none;">
                     <img id="portrait-upload-thumb" style="max-height: 80px; border-radius: var(--radius-sm); margin-bottom: var(--space-2);">
-                    <div style="font-size: var(--text-xs); color: var(--color-text-muted);">Photo selected. <a href="#" id="portrait-clear-photo" style="color: var(--color-brand);">Remove</a></div>
+                    <div style="font-size: var(--text-xs); color: var(--color-text-muted);">Photo selected. Save changes to use it. <a href="#" id="portrait-clear-photo" style="color: var(--color-brand);">Remove</a></div>
                   </div>
                 </div>
 

--- a/server/public/community/profile-edit.js
+++ b/server/public/community/profile-edit.js
@@ -260,14 +260,10 @@
     document.getElementById('field-headline').value = profile.headline || '';
     updateCharCount();
     document.getElementById('field-bio').value = profile.bio || '';
-    const avatarPreview = document.getElementById('avatar-preview');
-    const avatarInfo = document.getElementById('avatar-info');
     if (profile.avatar_url) {
-      avatarPreview.innerHTML = '<img src="' + escapeHtml(profile.avatar_url) + '" alt="Profile photo" style="width: 100%; height: 100%; object-fit: cover;">';
-      avatarInfo.textContent = '';
+      setAvatarPreview(profile.avatar_url);
     } else {
-      avatarPreview.innerHTML = '<span style="font-size: var(--text-xl); color: var(--color-text-muted);">?</span>';
-      avatarInfo.textContent = 'No profile photo yet.';
+      clearAvatarPreview();
     }
 
     expertiseTags = (profile.expertise || []).slice();
@@ -408,6 +404,61 @@
     reader.readAsDataURL(file);
   }
 
+  function setAvatarPreview(imageUrl) {
+    const avatarPreview = document.getElementById('avatar-preview');
+    const img = document.createElement('img');
+    img.src = imageUrl;
+    img.alt = 'Profile photo';
+    img.style.cssText = 'width: 100%; height: 100%; object-fit: cover;';
+    avatarPreview.textContent = '';
+    avatarPreview.appendChild(img);
+    document.getElementById('avatar-info').textContent = '';
+  }
+
+  function clearAvatarPreview() {
+    document.getElementById('avatar-preview').innerHTML =
+      '<span style="font-size: var(--text-xl); color: var(--color-text-muted);">?</span>';
+    document.getElementById('avatar-info').textContent = 'No profile photo yet.';
+  }
+
+  function clearSelectedPortraitPhoto() {
+    const fileInput = document.getElementById('portrait-photo-input');
+    if (fileInput) fileInput.value = '';
+
+    const label = document.getElementById('portrait-upload-label');
+    if (label) label.style.display = '';
+
+    const preview = document.getElementById('portrait-upload-preview');
+    if (preview) preview.style.display = 'none';
+  }
+
+  async function uploadSelectedAvatar() {
+    const fileInput = document.getElementById('portrait-photo-input');
+    if (!fileInput || !fileInput.files || !fileInput.files.length) {
+      return null;
+    }
+
+    const formData = new FormData();
+    formData.append('photo', fileInput.files[0]);
+
+    const resp = await fetch('/api/me/community-avatar', {
+      method: 'POST',
+      body: formData,
+    });
+
+    if (!resp.ok) {
+      const err = await resp.json().catch(function() { return {}; });
+      throw new Error(err.error || 'Failed to upload profile photo');
+    }
+
+    const data = await resp.json();
+    if (data.avatar_url) {
+      setAvatarPreview(data.avatar_url);
+      clearSelectedPortraitPhoto();
+    }
+    return data;
+  }
+
   async function handleGenerate() {
     const btn = document.getElementById('portrait-generate-btn');
     btn.disabled = true;
@@ -481,14 +532,8 @@
       });
       if (!resp.ok) throw new Error('Failed to approve');
 
-      const avatarPreview = document.getElementById('avatar-preview');
-      const img = document.createElement('img');
-      img.src = '/api/portraits/' + encodeURIComponent(pendingPortraitId) + '.png';
-      img.alt = 'Profile photo';
-      img.style.cssText = 'width: 100%; height: 100%; object-fit: cover;';
-      avatarPreview.textContent = '';
-      avatarPreview.appendChild(img);
-      document.getElementById('avatar-info').textContent = '';
+      setAvatarPreview('/api/portraits/' + encodeURIComponent(pendingPortraitId) + '.png');
+      clearSelectedPortraitPhoto();
 
       document.getElementById('portrait-pending').style.display = 'none';
       showGeneratePanel();
@@ -660,6 +705,7 @@
         throw new Error(errorData?.error || 'Failed to save profile');
       }
 
+      await uploadSelectedAvatar();
       showToast('Profile saved', 'success');
     } catch (error) {
       console.error('Save error:', error);

--- a/server/src/db/migrations/500_user_avatar_uploads.sql
+++ b/server/src/db/migrations/500_user_avatar_uploads.sql
@@ -1,0 +1,14 @@
+-- Direct community profile photo uploads.
+-- Generated portraits continue to live in member_portraits; this table stores
+-- normalized user-uploaded avatar images used by users.avatar_url.
+
+CREATE TABLE IF NOT EXISTS user_avatar_uploads (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workos_user_id TEXT NOT NULL REFERENCES users(workos_user_id) ON DELETE CASCADE,
+  image_data BYTEA NOT NULL,
+  content_type TEXT NOT NULL DEFAULT 'image/png',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_avatar_uploads_user
+  ON user_avatar_uploads(workos_user_id, created_at DESC);

--- a/server/src/routes/community.ts
+++ b/server/src/routes/community.ts
@@ -1,5 +1,7 @@
 import { randomBytes } from "node:crypto";
-import { Router } from "express";
+import { Router, type NextFunction, type Request, type Response } from "express";
+import multer from "multer";
+import sharp from "sharp";
 import { createLogger } from "../logger.js";
 import { isUuid } from "../utils/uuid.js";
 import { requireAuth } from "../middleware/auth.js";
@@ -13,6 +15,35 @@ import { VALID_MEMBER_OFFERINGS, type MemberOffering } from "../types.js";
 import { notifyUser } from "../notifications/notification-service.js";
 
 const logger = createLogger("community-routes");
+const AVATAR_MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+const avatarUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: AVATAR_MAX_FILE_SIZE },
+  fileFilter: (_req: Request, file: { mimetype: string }, cb: (error: Error | null, acceptFile?: boolean) => void) => {
+    if (file.mimetype === "image/jpeg" || file.mimetype === "image/png") {
+      cb(null, true);
+    } else {
+      cb(new Error("Only JPEG and PNG files are accepted"));
+    }
+  },
+});
+const avatarUploadSingle = avatarUpload.single('photo');
+
+function handleAvatarUpload(req: Request, res: Response, next: NextFunction) {
+  avatarUploadSingle(req, res, (error: unknown) => {
+    if (!error) {
+      next();
+      return;
+    }
+    if (error instanceof multer.MulterError && error.code === 'LIMIT_FILE_SIZE') {
+      res.status(413).json({ error: 'Photo must be under 5MB' });
+      return;
+    }
+    const message = error instanceof Error ? error.message : 'Invalid profile photo';
+    res.status(400).json({ error: message });
+  });
+}
 
 export interface CommunityRoutesConfig {
   communityDb: CommunityDatabase;
@@ -34,6 +65,35 @@ export function createCommunityRouters(config: CommunityRoutesConfig) {
   // =====================================================
   // PUBLIC ROUTES (/api/community/*)
   // =====================================================
+
+  // GET /api/community/avatars/:id.png -- serve uploaded profile avatar
+  publicRouter.get('/avatars/:id.png', async (req, res) => {
+    try {
+      if (!isUuid(req.params.id)) {
+        return res.status(404).send('Avatar not found');
+      }
+
+      const result = await query<{ image_data: Buffer; content_type: string }>(
+        `SELECT image_data, content_type
+         FROM user_avatar_uploads
+         WHERE id = $1`,
+        [req.params.id]
+      );
+      const avatar = result.rows[0];
+      if (!avatar) {
+        return res.status(404).send('Avatar not found');
+      }
+
+      res.set({
+        'Content-Type': avatar.content_type || 'image/png',
+        'Cache-Control': 'public, max-age=31536000, immutable',
+      });
+      return res.send(avatar.image_data);
+    } catch (error) {
+      logger.error({ error, id: req.params.id }, 'Failed to serve avatar');
+      return res.status(500).send('Internal error');
+    }
+  });
 
   // GET /api/community/expertise -- distinct expertise tags for filter dropdown
   publicRouter.get('/expertise', requireAuth, async (_req, res) => {
@@ -179,6 +239,72 @@ export function createCommunityRouters(config: CommunityRoutesConfig) {
   // =====================================================
   // USER ROUTES (/api/me/*)
   // =====================================================
+
+  // POST /api/me/community-avatar -- upload a direct profile photo
+  userRouter.post('/community-avatar', requireAuth, handleAvatarUpload, async (req, res) => {
+    try {
+      const user = req.user!;
+      if (!req.file) {
+        return res.status(400).json({ error: 'Photo is required' });
+      }
+
+      const imageBuffer = await sharp(req.file.buffer, { failOn: 'error', limitInputPixels: 24_000_000 })
+        .rotate()
+        .resize(512, 512, { fit: 'cover' })
+        .png({ compressionLevel: 9 })
+        .toBuffer();
+
+      const inserted = await query<{ id: string }>(
+        `INSERT INTO user_avatar_uploads (workos_user_id, image_data, content_type)
+         VALUES ($1, $2, $3)
+         RETURNING id`,
+        [user.id, imageBuffer, 'image/png']
+      );
+      const avatarId = inserted.rows[0]?.id;
+      if (!avatarId) {
+        throw new Error('Avatar insert returned no id');
+      }
+
+      const avatarUrl = `/api/community/avatars/${avatarId}.png`;
+      const updated = await query<CommunityProfile>(
+        `UPDATE users
+         SET avatar_url = $1, portrait_id = NULL, updated_at = NOW()
+         WHERE workos_user_id = $2
+         RETURNING workos_user_id, slug, headline, bio, avatar_url, expertise, interests,
+                   linkedin_url, twitter_url, github_username, is_public, open_to_coffee_chat, open_to_intros, city`,
+        [avatarUrl, user.id]
+      );
+      const profile = updated.rows[0];
+      if (!profile) {
+        return res.status(404).json({ error: 'User not found' });
+      }
+
+      if (memberDb && orgDb) {
+        const orgId = await resolvePrimaryOrganization(user.id);
+        if (orgId) {
+          const org = await orgDb.getOrganization(orgId);
+          if (org?.is_personal) {
+            await query(
+              `UPDATE member_profiles
+               SET logo_url = $1, portrait_id = NULL, updated_at = NOW()
+               WHERE workos_organization_id = $2`,
+              [avatarUrl, orgId]
+            );
+          }
+        }
+      }
+
+      communityDb.checkAndAwardBadges(user.id, 'profile').catch(
+        err => logger.error({ err }, 'Badge check failed')
+      );
+
+      invalidateMemberContextCache?.();
+      return res.json({ avatar_url: avatarUrl, profile });
+    } catch (error) {
+      logger.error({ error }, 'Failed to upload community avatar');
+      return res.status(500).json({ error: 'Failed to upload profile photo' });
+    }
+  });
 
   // PUT /api/me/community-profile -- update community profile fields
   userRouter.put('/community-profile', requireAuth, async (req, res) => {

--- a/tests/community/profile-edit.test.ts
+++ b/tests/community/profile-edit.test.ts
@@ -222,6 +222,40 @@ describe('profile-edit: handleSubmit', () => {
     expect(capturedPayload!.contact_email).toBeUndefined();
   });
 
+  it('uploads a selected profile photo when saving', async () => {
+    const fileInput = win.document.getElementById('portrait-photo-input') as HTMLInputElement;
+    const file = new win.File(['avatar-bytes'], 'avatar.png', { type: 'image/png' });
+    Object.defineProperty(fileInput, 'files', {
+      value: [file],
+      configurable: true,
+    });
+
+    const calls: string[] = [];
+    let uploadedPhoto: unknown = null;
+    win.fetch = async (url: unknown, opts: { body?: BodyInit }) => {
+      calls.push(String(url));
+      if (url === '/api/me/community-profile') {
+        return { ok: true, json: async () => ({}) };
+      }
+      if (url === '/api/me/community-avatar') {
+        uploadedPhoto = (opts.body as FormData).get('photo');
+        return {
+          ok: true,
+          json: async () => ({ avatar_url: '/api/community/avatars/avatar-id.png' }),
+        };
+      }
+      return { ok: false };
+    };
+
+    const event = new win.Event('submit', { cancelable: true });
+    await win.ProfileEdit.handleSubmit(event);
+
+    expect(calls).toEqual(['/api/me/community-profile', '/api/me/community-avatar']);
+    expect(uploadedPhoto).toBe(file);
+    const img = win.document.querySelector('#avatar-preview img') as HTMLImageElement;
+    expect(img.getAttribute('src')).toBe('/api/community/avatars/avatar-id.png');
+  });
+
   it('includes offerings and contact fields for personal accounts', async () => {
     win.ProfileEdit.setPersonalAccount(true);
     (win.document.getElementById('offering-consulting') as HTMLInputElement).checked = true;


### PR DESCRIPTION
Fixes #4658 by adding a direct authenticated community avatar upload path for the profile edit page, storing normalized PNG avatars in a new table and serving them from /api/community/avatars/:id.png.

The profile editor now treats selected photo files as saveable direct avatars while preserving the existing generated portrait flow.

Validation: npx vitest run tests/community/profile-edit.test.ts --pool=threads, npm run typecheck, npm run test:migrations, and the precommit hook.