### PR TITLE
fix(registry): reprobe unknown agents with backoff

### DIFF
--- a/.changeset/4493-unknown-agent-reprobe.md
+++ b/.changeset/4493-unknown-agent-reprobe.md
@@ -1,0 +1,6 @@
+---
+---
+
+Add durable backoff state for registry agents whose capability probes still infer `unknown`.
+
+The crawler now retries unknown classifications on a 1/2/4/7-day cadence, stops after 10 attempts, and records whether the terminal state was an unreachable endpoint or a reachable-but-unclassifiable agent.

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -11,7 +11,7 @@ import { canonicalizePublisherDomain } from "./services/publisher-domain.js";
 import { MemberDatabase } from "./db/member-db.js";
 import { CapabilityDiscovery } from "./capabilities.js";
 import { HealthChecker } from "./health.js";
-import { AgentSnapshotDatabase } from "./db/agent-snapshot-db.js";
+import { AgentSnapshotDatabase, type AgentCapabilitiesSnapshotRow } from "./db/agent-snapshot-db.js";
 import { AgentContextDatabase } from "./db/agent-context-db.js";
 import { AAO_HOST } from "./config/aao.js";
 import { AAO_UA_DISCOVERY } from "./config/user-agents.js";
@@ -24,6 +24,17 @@ import { resolveUserAgentAuth } from "./routes/helpers/resolve-user-agent-auth.j
 import { adaptAuthForSdk, type SdkAuth } from "./services/sdk-auth-adapter.js";
 
 const log = createLogger('crawler');
+
+function unknownClassificationProbeDue(
+  snapshot: AgentCapabilitiesSnapshotRow | undefined,
+  now: Date = new Date(),
+): boolean {
+  if (!snapshot) return true;
+  if (snapshot.inferred_type !== null) return true;
+  if (snapshot.probe_terminal_state) return false;
+  if (!snapshot.next_probe_after) return true;
+  return new Date(snapshot.next_probe_after).getTime() <= now.getTime();
+}
 
 /**
  * Compare a freshly-fetched adagents.json against the previously-cached
@@ -785,14 +796,46 @@ export class CrawlerService {
       return;
     }
 
+    const existingSnapshots = await this.snapshotDb.bulkGetCapabilities(toProbe.map(a => a.url));
+    const now = new Date();
+    const dueToProbe: Agent[] = [];
+    let skippedBackoff = 0;
+    let skippedTerminal = 0;
+
+    for (const agent of toProbe) {
+      const knownType = knownTypes.get(agent.url);
+      if (knownType && knownType !== 'unknown') {
+        dueToProbe.push(agent);
+        continue;
+      }
+
+      const snapshot = existingSnapshots.get(agent.url);
+      if (unknownClassificationProbeDue(snapshot, now)) {
+        dueToProbe.push(agent);
+      } else if (snapshot?.probe_terminal_state) {
+        skippedTerminal++;
+      } else {
+        skippedBackoff++;
+      }
+    }
+
+    if (dueToProbe.length === 0) {
+      log.info(
+        { skippedBackoff, skippedTerminal, probed: 0, candidates: toProbe.length },
+        'No agents due for snapshot refresh',
+      );
+      return;
+    }
+
     const CONCURRENCY = 5;
     const PROBE_TIMEOUT_MS = 10000;
     let typesUpdated = 0;
     let snapshotsWritten = 0;
     let failed = 0;
+    let unknownFailuresRecorded = 0;
 
-    for (let i = 0; i < toProbe.length; i += CONCURRENCY) {
-      const batch = toProbe.slice(i, i + CONCURRENCY);
+    for (let i = 0; i < dueToProbe.length; i += CONCURRENCY) {
+      const batch = dueToProbe.slice(i, i + CONCURRENCY);
       const results = await Promise.allSettled(
         batch.map(async (agent) => {
           // Use saved owner credentials when the agent has any — keeps the
@@ -812,6 +855,8 @@ export class CrawlerService {
           const inferredType = this.capabilityDiscovery.inferTypeFromProfile(profile);
           const effectiveType = knownTypes.get(agent.url) || inferredType;
           const agentForHealth: Agent = { ...agent, type: effectiveType as Agent['type'], protocol: profile.protocol };
+          const knownType = knownTypes.get(agent.url);
+          const trackUnknownProbe = !knownType || knownType === 'unknown';
 
           const [health, stats] = await Promise.all([
             Promise.race([
@@ -833,7 +878,11 @@ export class CrawlerService {
           ]);
 
           await Promise.all([
-            this.snapshotDb.upsertCapabilities(profile, inferredType === 'unknown' ? null : inferredType),
+            this.snapshotDb.upsertCapabilities(
+              profile,
+              inferredType === 'unknown' ? null : inferredType,
+              { trackUnknownProbe },
+            ),
             this.snapshotDb.upsertHealth(agent.url, health, stats),
           ]);
 
@@ -843,7 +892,6 @@ export class CrawlerService {
           //     Operator runs the backfill script to flip explicitly. Single
           //     probes can be wrong; auto-flipping would corrupt good rows on
           //     a transient bad probe. See #3538.
-          const knownType = knownTypes.get(agent.url);
           const canPromote = inferredType !== 'unknown' && (!knownType || knownType === 'unknown');
           const isDisagreement =
             !!knownType && knownType !== 'unknown' && inferredType !== 'unknown' && knownType !== inferredType;
@@ -876,18 +924,39 @@ export class CrawlerService {
         })
       );
 
-      for (const result of results) {
+      for (let j = 0; j < results.length; j++) {
+        const result = results[j];
         if (result.status === 'fulfilled') {
           snapshotsWritten++;
           if (result.value === 'type_updated') typesUpdated++;
         } else {
           failed++;
+          const agent = batch[j];
+          const knownType = agent ? knownTypes.get(agent.url) : undefined;
+          if (agent && (!knownType || knownType === 'unknown')) {
+            const error = result.reason instanceof Error ? result.reason.message : String(result.reason);
+            await this.snapshotDb.recordUnknownProbeFailure(
+              agent.url,
+              (agent.protocol as 'mcp' | 'a2a') || 'mcp',
+              error,
+            );
+            unknownFailuresRecorded++;
+          }
         }
       }
     }
 
     log.info(
-      { snapshotsWritten, typesUpdated, unreachable: failed, probed: toProbe.length },
+      {
+        snapshotsWritten,
+        typesUpdated,
+        unreachable: failed,
+        unknownFailuresRecorded,
+        skippedBackoff,
+        skippedTerminal,
+        probed: dueToProbe.length,
+        candidates: toProbe.length,
+      },
       'Agent snapshots refreshed',
     );
   }
@@ -982,7 +1051,11 @@ export class CrawlerService {
     ]);
 
     await Promise.all([
-      this.snapshotDb.upsertCapabilities(profile, inferredType === 'unknown' ? null : inferredType),
+      this.snapshotDb.upsertCapabilities(
+        profile,
+        inferredType === 'unknown' ? null : inferredType,
+        { trackUnknownProbe: !knownType },
+      ),
       this.snapshotDb.upsertHealth(agentUrl, health, stats),
     ]);
 

--- a/server/src/db/agent-snapshot-db.ts
+++ b/server/src/db/agent-snapshot-db.ts
@@ -12,6 +12,44 @@ import type {
 
 const logger = createLogger('agent-snapshot-db');
 
+export const UNKNOWN_PROBE_MAX_ATTEMPTS = 10;
+export const UNKNOWN_PROBE_MAX_BACKOFF_DAYS = 7;
+
+export type UnknownProbeTerminalState = 'unreachable' | 'unclassifiable';
+
+export interface UnknownProbeState {
+  attemptCount: number;
+  lastAttemptAt: Date;
+  nextProbeAfter: Date | null;
+  terminalState: UnknownProbeTerminalState | null;
+}
+
+export function unknownProbeBackoffDays(attemptCount: number): number {
+  if (attemptCount <= 1) return 1;
+  return Math.min(UNKNOWN_PROBE_MAX_BACKOFF_DAYS, 2 ** (attemptCount - 1));
+}
+
+export function buildUnknownProbeState(
+  previousAttemptCount: number | null | undefined,
+  terminalStateOnExhaustion: UnknownProbeTerminalState,
+  now: Date = new Date(),
+): UnknownProbeState {
+  const attemptCount = Math.max(0, previousAttemptCount ?? 0) + 1;
+  const terminalState = attemptCount >= UNKNOWN_PROBE_MAX_ATTEMPTS
+    ? terminalStateOnExhaustion
+    : null;
+  const nextProbeAfter = terminalState
+    ? null
+    : new Date(now.getTime() + unknownProbeBackoffDays(attemptCount) * 24 * 60 * 60 * 1000);
+
+  return {
+    attemptCount,
+    lastAttemptAt: now,
+    nextProbeAfter,
+    terminalState,
+  };
+}
+
 export interface AgentHealthSnapshotRow {
   agent_url: string;
   online: boolean;
@@ -37,6 +75,10 @@ export interface AgentCapabilitiesSnapshotRow {
   oauth_required: boolean;
   last_discovered: Date;
   updated_at: Date;
+  unknown_probe_attempt_count: number;
+  last_probe_attempt_at: Date | null;
+  next_probe_after: Date | null;
+  probe_terminal_state: UnknownProbeTerminalState | null;
 }
 
 export class AgentSnapshotDatabase {
@@ -98,15 +140,26 @@ export class AgentSnapshotDatabase {
   async upsertCapabilities(
     profile: AgentCapabilityProfile,
     inferredType: string | null,
+    options: { trackUnknownProbe?: boolean } = {},
   ): Promise<void> {
     try {
+      const trackUnknownProbe = options.trackUnknownProbe ?? true;
+      const unknownState = inferredType === null && trackUnknownProbe
+        ? await this.nextUnknownProbeState(
+            profile.agent_url,
+            profile.discovery_error ? 'unreachable' : 'unclassifiable',
+          )
+        : null;
+
       await query(
         `INSERT INTO agent_capabilities_snapshot
            (agent_url, protocol, discovered_tools_json, standard_operations_json,
             creative_capabilities_json, signals_capabilities_json,
             measurement_capabilities_json, inferred_type,
-            discovery_error, oauth_required, last_discovered, updated_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW())
+            discovery_error, oauth_required, last_discovered,
+            unknown_probe_attempt_count, last_probe_attempt_at, next_probe_after,
+            probe_terminal_state, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, NOW())
          ON CONFLICT (agent_url) DO UPDATE SET
            protocol = EXCLUDED.protocol,
            discovered_tools_json = EXCLUDED.discovered_tools_json,
@@ -114,10 +167,38 @@ export class AgentSnapshotDatabase {
            creative_capabilities_json = EXCLUDED.creative_capabilities_json,
            signals_capabilities_json = EXCLUDED.signals_capabilities_json,
            measurement_capabilities_json = EXCLUDED.measurement_capabilities_json,
-           inferred_type = EXCLUDED.inferred_type,
+           inferred_type = CASE
+             WHEN EXCLUDED.inferred_type IS NULL AND agent_capabilities_snapshot.inferred_type IS NOT NULL
+               THEN agent_capabilities_snapshot.inferred_type
+             ELSE EXCLUDED.inferred_type
+           END,
            discovery_error = EXCLUDED.discovery_error,
            oauth_required = EXCLUDED.oauth_required,
            last_discovered = EXCLUDED.last_discovered,
+           unknown_probe_attempt_count = CASE
+             WHEN EXCLUDED.inferred_type IS NOT NULL THEN 0
+             WHEN agent_capabilities_snapshot.inferred_type IS NULL
+               THEN EXCLUDED.unknown_probe_attempt_count
+             ELSE agent_capabilities_snapshot.unknown_probe_attempt_count
+           END,
+           last_probe_attempt_at = CASE
+             WHEN EXCLUDED.inferred_type IS NOT NULL THEN NULL
+             WHEN agent_capabilities_snapshot.inferred_type IS NULL
+               THEN EXCLUDED.last_probe_attempt_at
+             ELSE agent_capabilities_snapshot.last_probe_attempt_at
+           END,
+           next_probe_after = CASE
+             WHEN EXCLUDED.inferred_type IS NOT NULL THEN NULL
+             WHEN agent_capabilities_snapshot.inferred_type IS NULL
+               THEN EXCLUDED.next_probe_after
+             ELSE agent_capabilities_snapshot.next_probe_after
+           END,
+           probe_terminal_state = CASE
+             WHEN EXCLUDED.inferred_type IS NOT NULL THEN NULL
+             WHEN agent_capabilities_snapshot.inferred_type IS NULL
+               THEN EXCLUDED.probe_terminal_state
+             ELSE agent_capabilities_snapshot.probe_terminal_state
+           END,
            updated_at = NOW()`,
         [
           profile.agent_url,
@@ -131,11 +212,69 @@ export class AgentSnapshotDatabase {
           profile.discovery_error ?? null,
           profile.oauth_required ?? false,
           profile.last_discovered,
+          unknownState?.attemptCount ?? 0,
+          unknownState?.lastAttemptAt ?? null,
+          unknownState?.nextProbeAfter ?? null,
+          unknownState?.terminalState ?? null,
         ],
       );
     } catch (err) {
       logger.warn({ agentUrl: profile.agent_url, err }, 'Failed to upsert agent capabilities snapshot');
     }
+  }
+
+  async recordUnknownProbeFailure(
+    agentUrl: string,
+    protocol: 'mcp' | 'a2a',
+    error: string,
+  ): Promise<void> {
+    try {
+      const unknownState = await this.nextUnknownProbeState(agentUrl, 'unreachable');
+      await query(
+        `INSERT INTO agent_capabilities_snapshot
+           (agent_url, protocol, discovered_tools_json, inferred_type,
+            discovery_error, oauth_required, last_discovered,
+            unknown_probe_attempt_count, last_probe_attempt_at, next_probe_after,
+            probe_terminal_state, updated_at)
+         VALUES ($1, $2, '[]'::jsonb, NULL, $3, FALSE, NOW(), $4, $5, $6, $7, NOW())
+         ON CONFLICT (agent_url) DO UPDATE SET
+           discovery_error = EXCLUDED.discovery_error,
+           last_discovered = EXCLUDED.last_discovered,
+           unknown_probe_attempt_count = EXCLUDED.unknown_probe_attempt_count,
+           last_probe_attempt_at = EXCLUDED.last_probe_attempt_at,
+           next_probe_after = EXCLUDED.next_probe_after,
+           probe_terminal_state = EXCLUDED.probe_terminal_state,
+           updated_at = NOW()
+         WHERE agent_capabilities_snapshot.inferred_type IS NULL`,
+        [
+          agentUrl,
+          protocol,
+          error,
+          unknownState.attemptCount,
+          unknownState.lastAttemptAt,
+          unknownState.nextProbeAfter,
+          unknownState.terminalState,
+        ],
+      );
+    } catch (err) {
+      logger.warn({ agentUrl, err }, 'Failed to record unknown-agent probe failure');
+    }
+  }
+
+  private async nextUnknownProbeState(
+    agentUrl: string,
+    terminalStateOnExhaustion: UnknownProbeTerminalState,
+  ): Promise<UnknownProbeState> {
+    const result = await query<{ unknown_probe_attempt_count: number }>(
+      `SELECT unknown_probe_attempt_count
+         FROM agent_capabilities_snapshot
+        WHERE agent_url = $1`,
+      [agentUrl],
+    );
+    return buildUnknownProbeState(
+      result.rows[0]?.unknown_probe_attempt_count,
+      terminalStateOnExhaustion,
+    );
   }
 
   /**

--- a/server/src/db/migrations/500_unknown_agent_probe_backoff.sql
+++ b/server/src/db/migrations/500_unknown_agent_probe_backoff.sql
@@ -1,0 +1,25 @@
+-- Migration 500: durable backoff state for agents whose type remains unknown.
+--
+-- The crawler probes registered/discovered agents for capability metadata, but
+-- agents that cannot be classified should not be re-probed every crawl tick
+-- forever. These columns let the crawler retry unknown classifications on an
+-- exponential cadence, then stop after a bounded number of attempts with a
+-- terminal reason that distinguishes unreachable endpoints from reachable but
+-- unclassifiable agents.
+
+ALTER TABLE agent_capabilities_snapshot
+  ADD COLUMN IF NOT EXISTS unknown_probe_attempt_count INT NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS last_probe_attempt_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS next_probe_after TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS probe_terminal_state TEXT;
+
+ALTER TABLE agent_capabilities_snapshot
+  DROP CONSTRAINT IF EXISTS agent_capabilities_snapshot_probe_terminal_state_check;
+
+ALTER TABLE agent_capabilities_snapshot
+  ADD CONSTRAINT agent_capabilities_snapshot_probe_terminal_state_check
+  CHECK (probe_terminal_state IS NULL OR probe_terminal_state IN ('unreachable', 'unclassifiable'));
+
+CREATE INDEX IF NOT EXISTS idx_agent_capabilities_unknown_probe_due
+  ON agent_capabilities_snapshot (next_probe_after)
+  WHERE inferred_type IS NULL AND probe_terminal_state IS NULL;

--- a/server/src/db/migrations/501_unknown_agent_probe_backoff.sql
+++ b/server/src/db/migrations/501_unknown_agent_probe_backoff.sql
@@ -1,4 +1,4 @@
--- Migration 500: durable backoff state for agents whose type remains unknown.
+-- Migration 501: durable backoff state for agents whose type remains unknown.
 --
 -- The crawler probes registered/discovered agents for capability metadata, but
 -- agents that cannot be classified should not be re-probed every crawl tick

--- a/server/tests/unit/unknown-agent-probe-backoff.test.ts
+++ b/server/tests/unit/unknown-agent-probe-backoff.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+  UNKNOWN_PROBE_MAX_ATTEMPTS,
+  buildUnknownProbeState,
+  unknownProbeBackoffDays,
+} from '../../src/db/agent-snapshot-db.js';
+
+describe('unknown agent probe backoff', () => {
+  it('uses 1/2/4/7-day exponential backoff capped at seven days', () => {
+    expect(unknownProbeBackoffDays(1)).toBe(1);
+    expect(unknownProbeBackoffDays(2)).toBe(2);
+    expect(unknownProbeBackoffDays(3)).toBe(4);
+    expect(unknownProbeBackoffDays(4)).toBe(7);
+    expect(unknownProbeBackoffDays(8)).toBe(7);
+  });
+
+  it('schedules the next retry until the attempt cap is exhausted', () => {
+    const now = new Date('2026-05-29T12:00:00.000Z');
+    const state = buildUnknownProbeState(2, 'unreachable', now);
+
+    expect(state.attemptCount).toBe(3);
+    expect(state.terminalState).toBeNull();
+    expect(state.lastAttemptAt).toBe(now);
+    expect(state.nextProbeAfter?.toISOString()).toBe('2026-06-02T12:00:00.000Z');
+  });
+
+  it('sets a terminal state on the tenth failed or unclassified attempt', () => {
+    const now = new Date('2026-05-29T12:00:00.000Z');
+    const unreachable = buildUnknownProbeState(UNKNOWN_PROBE_MAX_ATTEMPTS - 1, 'unreachable', now);
+    const unclassifiable = buildUnknownProbeState(UNKNOWN_PROBE_MAX_ATTEMPTS - 1, 'unclassifiable', now);
+
+    expect(unreachable.attemptCount).toBe(UNKNOWN_PROBE_MAX_ATTEMPTS);
+    expect(unreachable.terminalState).toBe('unreachable');
+    expect(unreachable.nextProbeAfter).toBeNull();
+
+    expect(unclassifiable.attemptCount).toBe(UNKNOWN_PROBE_MAX_ATTEMPTS);
+    expect(unclassifiable.terminalState).toBe('unclassifiable');
+    expect(unclassifiable.nextProbeAfter).toBeNull();
+  });
+});


### PR DESCRIPTION
Adds durable backoff state for agents whose capability probes still infer unknown, including last attempt, next retry, attempt count, and terminal unreachable/unclassifiable states.

Wires the crawler to retry genuinely unknown agents on a 1/2/4/7-day cadence, stop after 10 attempts, preserve known declared types such as buying, and clear retry state after successful classification.

Adds migration 500, focused unit coverage for the backoff math, and a no-release changeset.

Validation: precommit hook passed (`test:unit`, `test:test-dynamic-imports`, `test:callapi-state-change`, `typecheck`); also ran focused unknown-agent tests and `npm run test:migrations`.