### PR TITLE
Prepare 3.1 RC prerelease mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,8 +1,8 @@
 {
   "mode": "pre",
-  "tag": "beta",
+  "tag": "rc",
   "initialVersions": {
-    "adcontextprotocol": "3.0.1"
+    "adcontextprotocol": "3.1.0-rc.0"
   },
   "changesets": [
     "2260-creative-retention-outlasts-campaigns",

--- a/.changeset/prepare-3-1-rc-mode.md
+++ b/.changeset/prepare-3-1-rc-mode.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": patch
+---
+
+Switch the 3.1 prerelease train from beta mode to RC mode.
+
+This is a release-process-only baseline: package and schema metadata move to
+`3.1.0-rc.0` so the GitHub Changesets release workflow can generate the signed
+`3.1.0-rc.1` Version Packages PR.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adcontextprotocol",
-  "version": "3.1.0-beta.7",
+  "version": "3.1.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adcontextprotocol",
-      "version": "3.1.0-beta.7",
+      "version": "3.1.0-rc.0",
       "dependencies": {
         "@adcp/sdk": "^8.1.0-beta.16",
         "@anthropic-ai/sdk": "^0.98.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adcontextprotocol",
-  "version": "3.1.0-beta.7",
+  "version": "3.1.0-rc.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -4,11 +4,11 @@
   "title": "AdCP Schema Registry",
   "version": "1.0.0",
   "description": "Registry of all AdCP JSON schemas for validation and discovery",
-  "adcp_version": "3.1.0-beta.7",
+  "adcp_version": "3.1.0-rc.0",
   "versioning": {
     "note": "AdCP uses path-based versioning. The schema URL path (/schemas/) indicates the version. Individual request/response schemas do NOT include adcp_version fields. Compatibility follows semantic versioning rules."
   },
-  "lastUpdated": "2026-05-16",
+  "lastUpdated": "2026-05-29",
   "baseUrl": "/schemas/latest",
   "schemas": {
     "core": {
@@ -1819,5 +1819,5 @@
       "code": "// Use everit-org/json-schema or similar library"
     }
   ],
-  "published_version": "3.1.0-beta.7"
+  "published_version": "3.1.0-rc.0"
 }


### PR DESCRIPTION
## Summary

- switch Changesets prerelease mode for 3.1 from `beta` to `rc`
- move package, lockfile, and schema registry metadata to the transient `3.1.0-rc.0` baseline
- add a small changeset explaining the release-mode transition

## Release impact

This PR intentionally does **not** commit the `3.1.0-rc.1` Version Packages artifacts.

The `3.1.0-rc.0` baseline is needed because Changesets derives the next prerelease counter from the current package version. With this merged, the GitHub release workflow can run `npm run version` under Actions, generate `adcontextprotocol 3.1.0-rc.1`, and sign the protocol tarball with the workflow OIDC identity.

Expected next step after merge: the existing `changeset-release/main` Version Packages PR should update from beta.8 to RC1 with signed schema/compliance/protocol artifacts.

## Validation

- `npm run verify-version-sync`
- `npx changeset status --since origin/main --verbose` -> `adcontextprotocol 3.1.0-rc.1` from `.changeset/prepare-3-1-rc-mode.md`
- `npx changeset status --verbose` -> `adcontextprotocol 3.1.0-rc.1` from all pending 3.1 changesets
- `npm run test:schemas`
- `npm run test:docs-nav`
- `git diff --check`
- `npm run test:storyboards`
- `npm run test:storyboards:3.0-compat`
- precommit hook: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run typecheck`
