### PR TITLE
Fix AI review guard for large PRs

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -100,7 +100,9 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          CHANGED="$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)"
+          # `gh pr diff --name-only` uses GitHub's diff endpoint, which 406s
+          # for generated release PRs over 300 files. The files API paginates.
+          CHANGED="$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" --jq '.[].filename')"
           MODIFIED=""
           while IFS= read -r f; do
             case "$f" in


### PR DESCRIPTION
## Summary
- use the paginated pull request files API in the AI review workflow-modification guard
- avoid GitHub diff endpoint 406 failures on generated release PRs over 300 files

## Validation
- exercised the replacement command against PR #5126; it returned all 961 changed files
- git diff --check
- precommit hook: unit tests, dynamic import lint, callApi state-change lint, typecheck