### PR TITLE
Fix hosted compliance prerelease gate

### DIFF
--- a/.changeset/hosted-compliance-stable-line-prerelease.md
+++ b/.changeset/hosted-compliance-stable-line-prerelease.md
@@ -1,0 +1,9 @@
+---
+---
+
+server(compliance): allow the hosted badge target's prerelease cache to run
+when a seller advertises the stable AdCP line in `adcp.supported_versions`.
+During the 3.1 readiness window, the public target remains `3.1` while the
+checked-in compliance bundle can still be `3.1.0-beta.N`; the hosted runner now
+treats `supported_versions: ["3.1"]` as compatible with that cache gate so
+sellers do not have to redeploy for every beta cache bump.

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -60,6 +60,7 @@ import { renderAllHintFixPlans } from '../services/storyboard-fix-plan.js';
 import {
   hostedComplianceTarget,
   hostedComplianceOptions,
+  hostedCapabilitiesForCompliance,
   withHostedStoryboardRunOptions,
   withHostedTestOptions,
   isDefaultHostedComplianceTarget,
@@ -4223,12 +4224,13 @@ export function createMemberToolHandlers(
     // Classify and coach accordingly.
     let resolvedBundles: Array<{ ref: { id: string; kind: string }; storyboards: Storyboard[] }>;
     try {
-      const res = resolveStoryboardsForCapabilities({
+      const caps = hostedCapabilitiesForCompliance({
         supported_protocols: supportedProtocols,
         specialisms,
         major_versions: profile?.adcp_major_versions,
         supported_versions: profile?.adcp_supported_versions,
-      }, runOptions);
+      }, runTarget);
+      const res = resolveStoryboardsForCapabilities(caps, runOptions);
       resolvedBundles = res.bundles;
     } catch (error) {
       const capsError = classifyCapabilityResolutionError(error);

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -21,6 +21,7 @@ import {
 } from '@adcp/sdk/testing';
 import {
   hostedComplianceTarget,
+  withHostedComplianceCompatibility,
   withHostedComplianceRunOptions,
   type HostedComplianceTarget,
 } from '../../services/hosted-compliance-version.js';
@@ -54,7 +55,10 @@ export async function comply(
   options: ComplyOptions,
   target: HostedComplianceTarget,
 ): Promise<ComplianceResult> {
-  const result = await sdkComply(agentUrl, withHostedComplianceRunOptions(options, target));
+  const result = await withHostedComplianceCompatibility(
+    target,
+    () => sdkComply(agentUrl, withHostedComplianceRunOptions(options, target)),
+  );
   result.adcp_version ??= target.version;
   (result as ComplianceResult & { requested_compliance_target?: string }).requested_compliance_target = target.requested;
   return result;

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -24,6 +24,7 @@ import { listStoryboards, getStoryboard, getTestKitForStoryboard } from "../serv
 import {
   hostedComplianceTarget,
   hostedComplianceOptions,
+  hostedCapabilitiesForCompliance,
   withHostedStoryboardRunOptions,
   withHostedTestOptions,
   badgeEligibleVersionsForHostedComplianceTarget,
@@ -6133,12 +6134,13 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
 
       let resolved;
       try {
-        resolved = resolveStoryboardsForCapabilities({
+        const caps = hostedCapabilitiesForCompliance({
           supported_protocols: supportedProtocols,
           specialisms,
           major_versions: profile?.adcp_major_versions,
           supported_versions: profile?.adcp_supported_versions,
-        }, complianceOptions);
+        }, complianceTarget);
+        resolved = resolveStoryboardsForCapabilities(caps, complianceOptions);
       } catch (resolveErr) {
         // Fail-closed: agent capabilities are malformed. Distinguish the two
         // concrete cases the resolver throws for — parent-protocol-missing vs

--- a/server/src/services/hosted-compliance-version.ts
+++ b/server/src/services/hosted-compliance-version.ts
@@ -1,7 +1,16 @@
 import { existsSync, readdirSync } from 'node:fs';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { createRequire } from 'node:module';
 import { join, resolve } from 'node:path';
 import { registerExternalSchemaRoot } from '@adcp/sdk/testing';
-import type { ComplyOptions, ResolveOptions, StoryboardRunOptions, TestOptions } from '@adcp/sdk/testing';
+import type {
+  AgentCapabilities,
+  ComplyOptions,
+  ResolveOptions,
+  ResolvedStoryboards,
+  StoryboardRunOptions,
+  TestOptions,
+} from '@adcp/sdk/testing';
 import { SUPPORTED_BADGE_VERSIONS } from './adcp-taxonomy.js';
 
 export const DEFAULT_HOSTED_COMPLIANCE_LINE = SUPPORTED_BADGE_VERSIONS[0];
@@ -16,6 +25,15 @@ export interface HostedComplianceTarget {
 type HostedResolveOptions = ResolveOptions & { schemaRoot: string };
 
 const registeredSchemaRoots = new Set<string>();
+const SDK_STORYBOARD_RESOLVER_PATCHED = Symbol.for('adcp.hostedStoryboardResolverPatched');
+const hostedComplianceContext = new AsyncLocalStorage<HostedComplianceTarget>();
+
+type SdkStoryboardResolverFn = ((
+  caps: AgentCapabilities,
+  options?: ResolveOptions,
+) => ResolvedStoryboards) & {
+  [SDK_STORYBOARD_RESOLVER_PATCHED]?: true;
+};
 
 function repoPath(...parts: string[]): string {
   return resolve(process.cwd(), ...parts);
@@ -51,6 +69,78 @@ function compareVersions(a: string, b: string): number {
     if (diff !== 0) return diff;
   }
   return 0;
+}
+
+function prereleaseComplianceLine(version: string): string | undefined {
+  const fullSemver = version.match(/^([1-9][0-9]*)\.([0-9]+)\.[0-9]+-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*(?:\+[0-9A-Za-z.-]+)?$/);
+  if (fullSemver) return `${fullSemver[1]}.${fullSemver[2]}`;
+
+  const wirePrecision = version.match(/^([1-9][0-9]*)\.([0-9]+)-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*(?:\+[0-9A-Za-z.-]+)?$/);
+  return wirePrecision ? `${wirePrecision[1]}.${wirePrecision[2]}` : undefined;
+}
+
+function stableLineForHostedPrereleaseTarget(target: HostedComplianceTarget): string | undefined {
+  if (!isDefaultHostedComplianceTarget(target)) return undefined;
+
+  const line = prereleaseComplianceLine(target.version);
+  return line === target.requested ? line : undefined;
+}
+
+export function hostedSupportedVersionsForCompliance(
+  supportedVersions: readonly string[] | undefined,
+  target: HostedComplianceTarget,
+): string[] | undefined {
+  if (!supportedVersions || supportedVersions.length === 0) return supportedVersions ? [] : undefined;
+
+  const line = stableLineForHostedPrereleaseTarget(target);
+  if (!line || !supportedVersions.includes(line) || supportedVersions.includes(target.version)) {
+    return [...supportedVersions];
+  }
+
+  return [target.version, ...supportedVersions];
+}
+
+export function hostedCapabilitiesForCompliance(
+  caps: AgentCapabilities,
+  target: HostedComplianceTarget,
+): AgentCapabilities {
+  const supported_versions = hostedSupportedVersionsForCompliance(caps.supported_versions, target);
+  return supported_versions === caps.supported_versions ? caps : { ...caps, supported_versions };
+}
+
+export function withHostedComplianceCompatibility<T>(
+  target: HostedComplianceTarget,
+  fn: () => T,
+): T {
+  return hostedComplianceContext.run(target, fn);
+}
+
+function installHostedStoryboardResolverPatch(): void {
+  // The hosted badge line can resolve to a checked-in prerelease bundle before
+  // GA (for example public target `3.1` backed by cache `3.1.0-beta.7`).
+  // Keep the compatibility shim scoped to storyboard compliance resolution;
+  // normal AdCP wire-version negotiation still requires exact prerelease pins.
+  let complianceModule: { resolveStoryboardsForCapabilities?: SdkStoryboardResolverFn };
+  try {
+    const require = createRequire(import.meta.url);
+    const packageRoot = resolve(require.resolve('@adcp/sdk/package.json'), '..');
+    complianceModule = require(join(packageRoot, 'dist', 'lib', 'testing', 'storyboard', 'compliance.js')) as {
+      resolveStoryboardsForCapabilities?: SdkStoryboardResolverFn;
+    };
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to install hosted storyboard resolver patch: ${detail}`);
+  }
+
+  const original = complianceModule.resolveStoryboardsForCapabilities;
+  if (!original || original[SDK_STORYBOARD_RESOLVER_PATCHED]) return;
+
+  const patched: SdkStoryboardResolverFn = (caps, options) => {
+    const target = hostedComplianceContext.getStore();
+    return original(target ? hostedCapabilitiesForCompliance(caps, target) : caps, options);
+  };
+  patched[SDK_STORYBOARD_RESOLVER_PATCHED] = true;
+  complianceModule.resolveStoryboardsForCapabilities = patched;
 }
 
 function complianceVersions(): string[] {
@@ -251,3 +341,5 @@ export function withHostedTestOptions<T extends Partial<TestOptions> | undefined
     schemaRoot: input.schemaRoot ?? hostedSchemaRootForVersion(version, target),
   } as T extends undefined ? TestOptions : NonNullable<T> & TestOptions;
 }
+
+installHostedStoryboardResolverPatch();

--- a/server/tests/unit/storyboards.test.ts
+++ b/server/tests/unit/storyboards.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
 import {
   listStoryboards,
   getStoryboard,
@@ -16,10 +17,19 @@ import {
   DEFAULT_HOSTED_COMPLIANCE_VERSION,
   hostedComplianceOptions,
   hostedComplianceTarget,
+  hostedCapabilitiesForCompliance,
+  hostedSupportedVersionsForCompliance,
   isDefaultHostedComplianceTarget,
+  withHostedComplianceCompatibility,
   withHostedComplianceOptions,
 } from '../../src/services/hosted-compliance-version.js';
-import { loadComplianceIndex } from '@adcp/sdk/testing';
+import {
+  isComplianceVersionSupported,
+  loadComplianceIndex,
+  resolveStoryboardsForCapabilities,
+} from '@adcp/sdk/testing';
+
+const require = createRequire(import.meta.url);
 
 /**
  * These tests cover the wrapper in services/storyboards.ts. Catalog content
@@ -184,6 +194,54 @@ describe('wrapper contract', () => {
     const options = withHostedComplianceOptions({ version: '3.0' }, target);
     expect(options.version).toBe(target.version);
     expect(options.complianceDir).toContain(target.version);
+  });
+
+  it('lets only the default hosted prerelease cache run for sellers advertising the stable line', () => {
+    const defaultTarget = hostedComplianceTarget('3.1');
+    const betaTarget = hostedComplianceTarget('3.1-beta');
+    const defaultIsPrerelease = /-/.test(defaultTarget.version);
+
+    expect(hostedSupportedVersionsForCompliance(['3.1'], defaultTarget)).toEqual(
+      defaultIsPrerelease ? [defaultTarget.version, '3.1'] : ['3.1'],
+    );
+    expect(hostedSupportedVersionsForCompliance(['3.1'], betaTarget)).toEqual(['3.1']);
+    expect(isComplianceVersionSupported(defaultTarget.version, ['3.1'])).toBe(!defaultIsPrerelease);
+
+    const rawTarget = hostedComplianceTarget('3.1');
+    const rawResolve = () => resolveStoryboardsForCapabilities({
+      supported_versions: ['3.1'],
+    }, hostedComplianceOptions(rawTarget));
+    if (defaultIsPrerelease) {
+      expect(rawResolve).toThrow(/not supported by this seller/);
+    } else {
+      expect(rawResolve).not.toThrow();
+    }
+
+    const target = hostedComplianceTarget('3.1');
+    const caps = hostedCapabilitiesForCompliance({
+      supported_versions: ['3.1'],
+    }, target);
+    const resolved = resolveStoryboardsForCapabilities({
+      supported_versions: caps.supported_versions,
+    }, hostedComplianceOptions(target));
+    expect(resolved.storyboards.length).toBeGreaterThan(0);
+
+    const sdkPackageRoot = require.resolve('@adcp/sdk/package.json').replace(/\/package\.json$/, '');
+    const sdkCompliance = require(`${sdkPackageRoot}/dist/lib/testing/storyboard/compliance.js`) as {
+      resolveStoryboardsForCapabilities: typeof resolveStoryboardsForCapabilities;
+    };
+
+    expect(() => withHostedComplianceCompatibility(target, () => sdkCompliance.resolveStoryboardsForCapabilities({
+      supported_versions: ['3.1'],
+    }, hostedComplianceOptions(target)))).not.toThrow();
+    const betaResolveWithStableOnly = () => withHostedComplianceCompatibility(betaTarget, () => sdkCompliance.resolveStoryboardsForCapabilities({
+      supported_versions: ['3.1'],
+    }, hostedComplianceOptions(betaTarget)));
+    if (/-/.test(betaTarget.version)) {
+      expect(betaResolveWithStableOnly).toThrow(/not supported by this seller/);
+    } else {
+      expect(betaResolveWithStableOnly).not.toThrow();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes the hosted compliance cache gate so the default public `3.1` target can run against the current prerelease cache when a seller advertises `adcp.supported_versions: ["3.1"]`.
The compatibility is scoped to hosted compliance resolution only: normal AdCP prerelease negotiation still requires exact prerelease matches, and explicit `3.1-beta` diagnostic runs do not get the stable-line exception.
Direct storyboard resolver callers now normalize hosted capabilities before resolving, while the async `comply()` path uses an AsyncLocalStorage-scoped resolver shim.

## Validation

`npx vitest run server/tests/unit/storyboards.test.ts --config server/vitest.config.ts`; `npm run typecheck`; precommit hook (`test:unit`, `test:test-dynamic-imports`, `test:callapi-state-change`, `typecheck`); push hook (`verify-version-sync`, docs schema-link check, Mintlify broken-links check).
