### PR TITLE
feat(schemas): extract delivery report row schemas

### DIFF
--- a/.changeset/delivery-schema-followups.md
+++ b/.changeset/delivery-schema-followups.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Extract remaining delivery-report inline row schemas into named core schemas for SDK generation, and reserve `x-adcp-open-payload: false` until a canonical generator contract exists.

--- a/docs/reference/schema-extensions.mdx
+++ b/docs/reference/schema-extensions.mdx
@@ -91,13 +91,14 @@ Migration history tracked at [adcontextprotocol/adcp#3827](https://github.com/ad
 
 Classifies fields that look open-ended to SDK generators. The annotation is documentary and non-validating; the field's JSON Schema still controls wire validation.
 
-Allowed values:
+Allowed authoring values:
 
 | Value | Meaning for schema authors and generators |
 |---|---|
 | `true` | The field intentionally carries free-form payload data. Generators MAY model the object/decoded-JSON arm as `Record<string, unknown>` or another generic JSON container without warning. |
-| `false` | The field is intentionally not a free-form payload, even if the schema permits extension keys for compatibility. Generators SHOULD model the declared properties normally and SHOULD NOT collapse the field into a generic payload type. |
 | Omitted | Unclassified. Generators and schema lint rules SHOULD NOT infer either `true` or `false`; they MAY warn on unannotated `additionalProperties: true` object fields during review. |
+
+`false` is reserved for a future structured-but-extension-tolerant marker. Source schemas MUST NOT set `x-adcp-open-payload: false` until the repository defines at least one canonical use site and the generator contract for that value.
 
 For mixed fields, the annotation applies only to the object or decoded-JSON payload arm. Scalar arms still follow their declared schema. For example, an upstream recorded body may be a decoded JSON object when the content type is JSON-shaped and a string otherwise; `x-adcp-open-payload: true` marks the decoded JSON payload as intentionally open, not the string arm as an object model.
 
@@ -109,7 +110,7 @@ For mixed fields, the annotation applies only to the object or decoded-JSON payl
 }
 ```
 
-Use `false` when a field has known structure but remains extension-tolerant. Use omission for legacy or not-yet-classified fields; do not use omission to mean "closed".
+Use omission for legacy or not-yet-classified fields; do not use omission to mean "closed".
 
 ## `x-adcp-hoist`
 

--- a/static/schemas/source/core/catalog-item-delivery-metrics.json
+++ b/static/schemas/source/core/catalog-item-delivery-metrics.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/catalog-item-delivery-metrics.json",
+  "title": "Catalog Item Delivery Metrics",
+  "description": "Delivery metrics row for one catalog item within a package.",
+  "allOf": [
+    {
+      "$ref": "/schemas/core/delivery-metrics.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "content_id": {
+          "type": "string",
+          "description": "Catalog item identifier (e.g., SKU, GTIN, job_id, offering_id)"
+        },
+        "content_id_type": {
+          "$ref": "/schemas/enums/content-id-type.json",
+          "description": "Identifier type for this content_id"
+        }
+      },
+      "required": [
+        "content_id",
+        "impressions",
+        "spend"
+      ]
+    }
+  ]
+}

--- a/static/schemas/source/core/creative-delivery-metrics.json
+++ b/static/schemas/source/core/creative-delivery-metrics.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/creative-delivery-metrics.json",
+  "title": "Creative Delivery Metrics",
+  "description": "Delivery metrics row for one creative within a package.",
+  "allOf": [
+    {
+      "$ref": "/schemas/core/delivery-metrics.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "creative_id": {
+          "type": "string",
+          "description": "Creative identifier matching the creative assignment",
+          "x-entity": "creative"
+        },
+        "weight": {
+          "type": "number",
+          "description": "Observed delivery share for this creative within the package during the reporting period, expressed as a percentage (0-100). Reflects actual delivery distribution, not a configured setting.",
+          "minimum": 0,
+          "maximum": 100
+        }
+      },
+      "required": [
+        "creative_id",
+        "impressions",
+        "spend"
+      ]
+    }
+  ]
+}

--- a/static/schemas/source/core/geo-delivery-metrics.json
+++ b/static/schemas/source/core/geo-delivery-metrics.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/geo-delivery-metrics.json",
+  "title": "Geo Delivery Metrics",
+  "description": "Delivery metrics row for one geographic area within a package.",
+  "allOf": [
+    {
+      "$ref": "/schemas/core/delivery-metrics.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "geo_level": {
+          "$ref": "/schemas/enums/geo-level.json",
+          "description": "Geographic level of this entry (country, region, metro, postal_area)"
+        },
+        "system": {
+          "type": "string",
+          "description": "Classification system for metro or postal_area levels (e.g., 'nielsen_dma', 'us_zip'). Present when geo_level is 'metro' or 'postal_area'."
+        },
+        "geo_code": {
+          "type": "string",
+          "description": "Geographic code within the level and system. Country: ISO 3166-1 alpha-2 ('US'). Region: ISO 3166-2 with country prefix ('US-CA'). Metro/postal: system-specific code ('501', '10001')."
+        },
+        "geo_name": {
+          "type": "string",
+          "description": "Human-readable geographic name (e.g., 'United States', 'California', 'New York DMA')"
+        }
+      },
+      "required": [
+        "geo_level",
+        "geo_code",
+        "impressions",
+        "spend"
+      ]
+    }
+  ]
+}

--- a/static/schemas/source/core/keyword-delivery-metrics.json
+++ b/static/schemas/source/core/keyword-delivery-metrics.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/keyword-delivery-metrics.json",
+  "title": "Keyword Delivery Metrics",
+  "description": "Delivery metrics row for one keyword and match-type pair within a package.",
+  "allOf": [
+    {
+      "$ref": "/schemas/core/delivery-metrics.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "keyword": {
+          "type": "string",
+          "description": "The targeted keyword"
+        },
+        "match_type": {
+          "$ref": "/schemas/enums/match-type.json"
+        }
+      },
+      "required": [
+        "keyword",
+        "match_type",
+        "impressions",
+        "spend"
+      ]
+    }
+  ]
+}

--- a/static/schemas/source/core/missing-metric.json
+++ b/static/schemas/source/core/missing-metric.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/missing-metric.json",
+  "title": "Missing Metric",
+  "description": "One metric the binding reporting contract declared but that is not populated in a delivery report. Symmetric with `committed_metrics` and discriminated by `scope`.",
+  "type": "object",
+  "discriminator": {
+    "propertyName": "scope"
+  },
+  "oneOf": [
+    {
+      "properties": {
+        "scope": {
+          "type": "string",
+          "const": "standard"
+        },
+        "metric_id": {
+          "$ref": "/schemas/enums/available-metric.json"
+        },
+        "qualifier": {
+          "type": "object",
+          "description": "Mirrors the qualifier on `committed_metrics` so the missing entry preserves the contract distinction (e.g., flagging MRC viewability as missing when only GroupM was reported, vendor-attested completion as missing when only seller-attested was reported, or deterministic_purchase attribution as missing when only probabilistic was reported). MUST match the qualifier on the corresponding `committed_metrics` entry the missing flag refers to.",
+          "properties": {
+            "viewability_standard": {
+              "$ref": "/schemas/enums/viewability-standard.json"
+            },
+            "completion_source": {
+              "$ref": "/schemas/enums/completion-source.json"
+            },
+            "attribution_methodology": {
+              "$ref": "/schemas/enums/attribution-methodology.json"
+            },
+            "attribution_window": {
+              "$ref": "/schemas/core/duration.json"
+            },
+            "lift_dimension": {
+              "$ref": "/schemas/enums/lift-dimension.json"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "scope",
+        "metric_id"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "scope": {
+          "type": "string",
+          "const": "vendor"
+        },
+        "vendor": {
+          "$ref": "/schemas/core/brand-ref.json"
+        },
+        "metric_id": {
+          "$ref": "/schemas/core/vendor-metric-id.json"
+        }
+      },
+      "required": [
+        "scope",
+        "vendor",
+        "metric_id"
+      ],
+      "additionalProperties": false
+    }
+  ]
+}

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -86,6 +86,26 @@
           "$ref": "/schemas/core/delivery-metric-aggregate.json",
           "description": "Cross-buy delivery aggregate partitioned by metric scope and qualifier"
         },
+        "missing-metric": {
+          "$ref": "/schemas/core/missing-metric.json",
+          "description": "Metric from the binding reporting contract that is absent from a delivery report"
+        },
+        "catalog-item-delivery-metrics": {
+          "$ref": "/schemas/core/catalog-item-delivery-metrics.json",
+          "description": "Delivery metrics row for one catalog item"
+        },
+        "creative-delivery-metrics": {
+          "$ref": "/schemas/core/creative-delivery-metrics.json",
+          "description": "Delivery metrics row for one creative"
+        },
+        "keyword-delivery-metrics": {
+          "$ref": "/schemas/core/keyword-delivery-metrics.json",
+          "description": "Delivery metrics row for one keyword and match type"
+        },
+        "geo-delivery-metrics": {
+          "$ref": "/schemas/core/geo-delivery-metrics.json",
+          "description": "Delivery metrics row for one geographic area"
+        },
         "creative-policy": {
           "$ref": "/schemas/core/creative-policy.json",
           "description": "Creative requirements and restrictions for a product"

--- a/static/schemas/source/media-buy/get-media-buy-delivery-response.json
+++ b/static/schemas/source/media-buy/get-media-buy-delivery-response.json
@@ -358,70 +358,7 @@
                       "type": "array",
                       "description": "Metrics that the binding reporting contract declared but that are NOT populated in this report. Reconciliation source: when `package.committed_metrics` is present, `missing_metrics` is computed against entries where `committed_at < reporting_period.end` — independent of subsequent product mutations and respecting the commitment timestamp on each entry (a metric committed mid-flight is only flagged missing in reports for periods after its commitment). When `package.committed_metrics` is absent, fall back to the product's current `reporting_capabilities.available_metrics` (no timestamp filter). Empty array (or absent) indicates clean delivery against the contract. Non-empty signals an accountability breach — the seller committed to the metric but did not produce the value here. Sellers MUST exclude metrics that are not yet measurable for the current `measurement_window` (e.g., post-IVT counts during the live window) — those will appear (or not) when a wider window supersedes this report via `supersedes_window`. Each entry uses an explicit `scope` discriminator: `standard` for entries from the closed `available-metric.json` enum, `vendor` for vendor-defined metrics anchored on a BrandRef. Symmetric with `committed_metrics`.",
                       "items": {
-                        "type": "object",
-                        "discriminator": {
-                          "propertyName": "scope"
-                        },
-                        "oneOf": [
-                          {
-                            "properties": {
-                              "scope": {
-                                "type": "string",
-                                "const": "standard"
-                              },
-                              "metric_id": {
-                                "$ref": "/schemas/enums/available-metric.json"
-                              },
-                              "qualifier": {
-                                "type": "object",
-                                "description": "Mirrors the qualifier on `committed_metrics` so the missing entry preserves the contract distinction (e.g., flagging MRC viewability as missing when only GroupM was reported, vendor-attested completion as missing when only seller-attested was reported, or deterministic_purchase attribution as missing when only probabilistic was reported). MUST match the qualifier on the corresponding `committed_metrics` entry the missing flag refers to.",
-                                "properties": {
-                                  "viewability_standard": {
-                                    "$ref": "/schemas/enums/viewability-standard.json"
-                                  },
-                                  "completion_source": {
-                                    "$ref": "/schemas/enums/completion-source.json"
-                                  },
-                                  "attribution_methodology": {
-                                    "$ref": "/schemas/enums/attribution-methodology.json"
-                                  },
-                                  "attribution_window": {
-                                    "$ref": "/schemas/core/duration.json"
-                                  },
-                                  "lift_dimension": {
-                                    "$ref": "/schemas/enums/lift-dimension.json"
-                                  }
-                                },
-                                "additionalProperties": false
-                              }
-                            },
-                            "required": [
-                              "scope",
-                              "metric_id"
-                            ],
-                            "additionalProperties": false
-                          },
-                          {
-                            "properties": {
-                              "scope": {
-                                "type": "string",
-                                "const": "vendor"
-                              },
-                              "vendor": {
-                                "$ref": "/schemas/core/brand-ref.json"
-                              },
-                              "metric_id": {
-                                "$ref": "/schemas/core/vendor-metric-id.json"
-                              }
-                            },
-                            "required": [
-                              "scope",
-                              "vendor",
-                              "metric_id"
-                            ],
-                            "additionalProperties": false
-                          }
-                        ]
+                        "$ref": "/schemas/core/missing-metric.json"
                       },
                       "examples": [
                         [],
@@ -450,128 +387,28 @@
                       "type": "array",
                       "description": "Delivery by catalog item within this package. Available for catalog-driven packages when the seller supports item-level reporting.",
                       "items": {
-                        "allOf": [
-                          {
-                            "$ref": "/schemas/core/delivery-metrics.json"
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "content_id": {
-                                "type": "string",
-                                "description": "Catalog item identifier (e.g., SKU, GTIN, job_id, offering_id)"
-                              },
-                              "content_id_type": {
-                                "$ref": "/schemas/enums/content-id-type.json",
-                                "description": "Identifier type for this content_id"
-                              }
-                            },
-                            "required": [
-                              "content_id",
-                              "impressions",
-                              "spend"
-                            ]
-                          }
-                        ]
+                        "$ref": "/schemas/core/catalog-item-delivery-metrics.json"
                       }
                     },
                     "by_creative": {
                       "type": "array",
                       "description": "Metrics broken down by creative within this package. Available when the seller supports creative-level reporting.",
                       "items": {
-                        "allOf": [
-                          {
-                            "$ref": "/schemas/core/delivery-metrics.json"
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "creative_id": {
-                                "type": "string",
-                                "description": "Creative identifier matching the creative assignment",
-                                "x-entity": "creative"
-                              },
-                              "weight": {
-                                "type": "number",
-                                "description": "Observed delivery share for this creative within the package during the reporting period, expressed as a percentage (0-100). Reflects actual delivery distribution, not a configured setting.",
-                                "minimum": 0,
-                                "maximum": 100
-                              }
-                            },
-                            "required": [
-                              "creative_id",
-                              "impressions",
-                              "spend"
-                            ]
-                          }
-                        ]
+                        "$ref": "/schemas/core/creative-delivery-metrics.json"
                       }
                     },
                     "by_keyword": {
                       "type": "array",
                       "description": "Metrics broken down by keyword within this package. One row per (keyword, match_type) pair — the same keyword with different match types appears as separate rows. Keyword-grain only: rows reflect aggregate performance of each targeted keyword, not individual search queries. Rows may not sum to package totals when a single impression is attributed to the triggering keyword only. Available for search and retail media packages when the seller supports keyword-level reporting.",
                       "items": {
-                        "allOf": [
-                          {
-                            "$ref": "/schemas/core/delivery-metrics.json"
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "keyword": {
-                                "type": "string",
-                                "description": "The targeted keyword"
-                              },
-                              "match_type": {
-                                "$ref": "/schemas/enums/match-type.json"
-                              }
-                            },
-                            "required": [
-                              "keyword",
-                              "match_type",
-                              "impressions",
-                              "spend"
-                            ]
-                          }
-                        ]
+                        "$ref": "/schemas/core/keyword-delivery-metrics.json"
                       }
                     },
                     "by_geo": {
                       "type": "array",
                       "description": "Delivery by geographic area within this package. Available when the buyer requests geo breakdown via reporting_dimensions and the seller supports it. Each dimension's rows are independent slices that should sum to the package total.",
                       "items": {
-                        "allOf": [
-                          {
-                            "$ref": "/schemas/core/delivery-metrics.json"
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "geo_level": {
-                                "$ref": "/schemas/enums/geo-level.json",
-                                "description": "Geographic level of this entry (country, region, metro, postal_area)"
-                              },
-                              "system": {
-                                "type": "string",
-                                "description": "Classification system for metro or postal_area levels (e.g., 'nielsen_dma', 'us_zip'). Present when geo_level is 'metro' or 'postal_area'."
-                              },
-                              "geo_code": {
-                                "type": "string",
-                                "description": "Geographic code within the level and system. Country: ISO 3166-1 alpha-2 ('US'). Region: ISO 3166-2 with country prefix ('US-CA'). Metro/postal: system-specific code ('501', '10001')."
-                              },
-                              "geo_name": {
-                                "type": "string",
-                                "description": "Human-readable geographic name (e.g., 'United States', 'California', 'New York DMA')"
-                              }
-                            },
-                            "required": [
-                              "geo_level",
-                              "geo_code",
-                              "impressions",
-                              "spend"
-                            ]
-                          }
-                        ]
+                        "$ref": "/schemas/core/geo-delivery-metrics.json"
                       }
                     },
                     "by_geo_truncated": {

--- a/tests/composed-schema-validation.test.cjs
+++ b/tests/composed-schema-validation.test.cjs
@@ -275,39 +275,112 @@ async function runTests() {
 
   // Test 4: Get Media Buy Delivery Response (allOf with delivery-metrics.json)
   log('Get Media Buy Delivery Response Schema (allOf with delivery-metrics.json):', 'info');
-  await testSchemaValidation(
-    '/schemas/media-buy/get-media-buy-delivery-response.json',
-    {
-      status: 'completed',
-      reporting_period: {
-        start: '2024-06-01T00:00:00Z',
-        end: '2024-06-15T23:59:59Z'
-      },
-      currency: 'USD',
-      media_buy_deliveries: [
-        {
-          media_buy_id: 'mb_123',
-          status: 'active',
-          totals: {
+  const deliveryResponseWithBreakdowns = {
+    status: 'completed',
+    reporting_period: {
+      start: '2024-06-01T00:00:00Z',
+      end: '2024-06-15T23:59:59Z'
+    },
+    currency: 'USD',
+    media_buy_deliveries: [
+      {
+        media_buy_id: 'mb_123',
+        status: 'active',
+        totals: {
+          spend: 25000,
+          impressions: 1000000,
+          effective_rate: 25.0
+        },
+        by_package: [
+          {
+            package_id: 'pkg_1',
             spend: 25000,
             impressions: 1000000,
-            effective_rate: 25.0
-          },
-          by_package: [
-            {
-              package_id: 'pkg_1',
-              spend: 25000,
-              impressions: 1000000,
-              pacing_index: 1.05,
-              pricing_model: 'cpm',
-              rate: 25.0,
-              currency: 'USD'
-            }
-          ]
-        }
-      ]
-    },
+            pacing_index: 1.05,
+            pricing_model: 'cpm',
+            rate: 25.0,
+            currency: 'USD',
+            missing_metrics: [
+              {
+                scope: 'standard',
+                metric_id: 'completed_views'
+              },
+              {
+                scope: 'vendor',
+                vendor: {
+                  domain: 'attentionvendor.example'
+                },
+                metric_id: 'attention_units'
+              }
+            ],
+            by_catalog_item: [
+              {
+                content_id: 'sku-123',
+                content_id_type: 'sku',
+                spend: 1200,
+                impressions: 48000
+              }
+            ],
+            by_creative: [
+              {
+                creative_id: 'cr_123',
+                spend: 14000,
+                impressions: 560000,
+                weight: 56
+              }
+            ],
+            by_keyword: [
+              {
+                keyword: 'trail running shoes',
+                match_type: 'phrase',
+                spend: 900,
+                impressions: 36000
+              }
+            ],
+            by_geo: [
+              {
+                geo_level: 'region',
+                geo_code: 'US-CA',
+                geo_name: 'California',
+                spend: 6500,
+                impressions: 260000
+              }
+            ],
+            by_geo_truncated: false
+          }
+        ]
+      }
+    ]
+  };
+
+  await testSchemaValidation(
+    '/schemas/media-buy/get-media-buy-delivery-response.json',
+    deliveryResponseWithBreakdowns,
     'Delivery response with aggregate metrics (allOf composition)'
+  );
+
+  const missingVendorMetricResponse = JSON.parse(JSON.stringify(deliveryResponseWithBreakdowns));
+  delete missingVendorMetricResponse.media_buy_deliveries[0].by_package[0].missing_metrics[1].vendor;
+  await testSchemaRejection(
+    '/schemas/media-buy/get-media-buy-delivery-response.json',
+    missingVendorMetricResponse,
+    'Delivery response rejects vendor missing_metric without vendor'
+  );
+
+  const missingKeywordMatchTypeResponse = JSON.parse(JSON.stringify(deliveryResponseWithBreakdowns));
+  delete missingKeywordMatchTypeResponse.media_buy_deliveries[0].by_package[0].by_keyword[0].match_type;
+  await testSchemaRejection(
+    '/schemas/media-buy/get-media-buy-delivery-response.json',
+    missingKeywordMatchTypeResponse,
+    'Delivery response rejects keyword metrics without match_type'
+  );
+
+  const missingGeoCodeResponse = JSON.parse(JSON.stringify(deliveryResponseWithBreakdowns));
+  delete missingGeoCodeResponse.media_buy_deliveries[0].by_package[0].by_geo[0].geo_code;
+  await testSchemaRejection(
+    '/schemas/media-buy/get-media-buy-delivery-response.json',
+    missingGeoCodeResponse,
+    'Delivery response rejects geo metrics without geo_code'
   );
 
   log('');
@@ -1517,6 +1590,8 @@ async function runTests() {
       // Every bundled schema must be self-contained and compile standalone.
       await testAllBundledSchemasCompile(bundledPath);
 
+      await testBundledDeliveryMetricSchemaTitles(BUNDLED_DIR);
+
       // Test a response schema to verify nested refs are resolved
       await testBundledSchemaValidation(
         path.join(bundledPath, 'media-buy/get-products-response.json'),
@@ -1647,6 +1722,64 @@ async function testBundledSchemaCompile(schemaPath, description) {
     return true;
   } catch (error) {
     log(`  \u2717 ${description}: ${error.message}`, 'error');
+    failedTests++;
+    return false;
+  }
+}
+
+async function testBundledDeliveryMetricSchemaTitles(bundledDir) {
+  totalTests++;
+  try {
+    const latestDir = path.join(bundledDir, 'latest');
+    const coreSchemas = [
+      ['core/missing-metric.json', 'Missing Metric'],
+      ['core/catalog-item-delivery-metrics.json', 'Catalog Item Delivery Metrics'],
+      ['core/creative-delivery-metrics.json', 'Creative Delivery Metrics'],
+      ['core/keyword-delivery-metrics.json', 'Keyword Delivery Metrics'],
+      ['core/geo-delivery-metrics.json', 'Geo Delivery Metrics']
+    ];
+
+    const missing = [];
+    for (const [relPath, expectedTitle] of coreSchemas) {
+      const schemaPath = path.join(latestDir, relPath);
+      const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+      if (schema.title !== expectedTitle) {
+        missing.push(`${relPath} title=${JSON.stringify(schema.title)} expected ${JSON.stringify(expectedTitle)}`);
+      }
+    }
+
+    const deliverySchema = JSON.parse(fs.readFileSync(
+      path.join(latestDir, 'bundled/media-buy/get-media-buy-delivery-response.json'),
+      'utf8'
+    ));
+    const packageItems = deliverySchema.properties.media_buy_deliveries.items.properties.by_package.items;
+    const packageBreakdowns = packageItems.allOf[1].properties;
+    const bundledTitles = [
+      [packageBreakdowns.missing_metrics.items, 'Missing Metric', 'by_package.missing_metrics.items'],
+      [packageBreakdowns.by_catalog_item.items, 'Catalog Item Delivery Metrics', 'by_package.by_catalog_item.items'],
+      [packageBreakdowns.by_creative.items, 'Creative Delivery Metrics', 'by_package.by_creative.items'],
+      [packageBreakdowns.by_keyword.items, 'Keyword Delivery Metrics', 'by_package.by_keyword.items'],
+      [packageBreakdowns.by_geo.items, 'Geo Delivery Metrics', 'by_package.by_geo.items']
+    ];
+
+    for (const [schema, expectedTitle, label] of bundledTitles) {
+      if (!schema || schema.title !== expectedTitle) {
+        missing.push(`${label} title=${JSON.stringify(schema && schema.title)} expected ${JSON.stringify(expectedTitle)}`);
+      }
+    }
+
+    if (missing.length === 0) {
+      log(`  \u2713 Bundled delivery metric schemas preserve named titles`, 'success');
+      passedTests++;
+      return true;
+    }
+
+    log(`  \u2717 Bundled delivery metric schemas preserve named titles`, 'error');
+    for (const issue of missing) log(`      ${issue}`, 'error');
+    failedTests++;
+    return false;
+  } catch (error) {
+    log(`  \u2717 Bundled delivery metric schemas preserve named titles: ${error.message}`, 'error');
     failedTests++;
     return false;
   }

--- a/tests/schema-validation.test.cjs
+++ b/tests/schema-validation.test.cjs
@@ -297,12 +297,12 @@ async function runTests() {
   });
 
   // Test 4B: Validate ADCP open-payload annotations
-  await test('x-adcp-open-payload annotations are explicit booleans', () => {
+  await test('x-adcp-open-payload annotations use currently supported values', () => {
     for (const [schemaPath, schema] of schemas) {
       const occurrences = collectKeywordOccurrences(schema, 'x-adcp-open-payload', path.basename(schemaPath));
       for (const occurrence of occurrences) {
-        if (typeof occurrence.value !== 'boolean') {
-          return `${occurrence.location}: x-adcp-open-payload must be boolean, found ${typeof occurrence.value}`;
+        if (occurrence.value !== true) {
+          return `${occurrence.location}: x-adcp-open-payload must be true; false is reserved and omission means unclassified`;
         }
       }
     }


### PR DESCRIPTION
Closes #5180.
Closes #5181.

## Summary

- Extract remaining delivery-report inline row schemas into named core schemas:
  - `missing-metric`
  - `catalog-item-delivery-metrics`
  - `creative-delivery-metrics`
  - `keyword-delivery-metrics`
  - `geo-delivery-metrics`
- Replace `get_media_buy_delivery` inline `items` shapes with `$ref`s to those named schemas and register them in `static/schemas/source/index.json`.
- Clarify that `x-adcp-open-payload: false` is reserved for future use, not a currently supported authoring value.
- Tighten schema validation so `x-adcp-open-payload` must be `true`; omission remains the unclassified state.
- Extend the composed delivery-response smoke sample to exercise the newly extracted refs through the parent schema.

## Validation

- `npm run build:schemas`
- `npm run test:schemas`
- `npm run test:oneof-discriminators`
- `npm run test:docs-nav`
- `npm run test:schema-utf8`
- `npm run test:extension-schemas`
- `npm run lint:schema-links`
- `npm run test:composed`
- `git diff --check`
- precommit hook: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run typecheck`
- push hook: version sync, schema link convention, Mintlify broken-links check
