### PR TITLE
fix(server): close admin add-users P0 gaps

### DIFF
--- a/.changeset/admin-add-users-p0-gaps.md
+++ b/.changeset/admin-add-users-p0-gaps.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix(server): close admin add-users P0 gaps.

--- a/server/src/auth/workos-client.ts
+++ b/server/src/auth/workos-client.ts
@@ -3,8 +3,10 @@ import type { WorkOSUser } from '../types.js';
 import { createLogger } from '../logger.js';
 
 const logger = createLogger('workos-client');
+const OWNERLESS_PROMOTION_WORKOS_TIMEOUT_MS = 10_000;
 
 let _workos: WorkOS | null = null;
+let _ownerlessPromotionWorkos: WorkOS | null = null;
 let _clientId = '';
 
 /** Returns the shared WorkOS client. Constructed on first call; WORKOS_API_KEY and WORKOS_CLIENT_ID must be set by then. */
@@ -16,6 +18,20 @@ export function getWorkos(): WorkOS {
     _workos = new WorkOS(process.env.WORKOS_API_KEY, { clientId: _clientId });
   }
   return _workos;
+}
+
+/** Returns a WorkOS client with a shorter timeout for DB-lock-held promotion flows. */
+export function getOwnerlessPromotionWorkos(): WorkOS {
+  if (!_ownerlessPromotionWorkos) {
+    if (!process.env.WORKOS_API_KEY) throw new Error('WORKOS_API_KEY environment variable is required');
+    if (!process.env.WORKOS_CLIENT_ID) throw new Error('WORKOS_CLIENT_ID environment variable is required');
+    _clientId = process.env.WORKOS_CLIENT_ID;
+    _ownerlessPromotionWorkos = new WorkOS(process.env.WORKOS_API_KEY, {
+      clientId: _clientId,
+      timeout: OWNERLESS_PROMOTION_WORKOS_TIMEOUT_MS,
+    });
+  }
+  return _ownerlessPromotionWorkos;
 }
 
 /**

--- a/server/src/db/membership-db.ts
+++ b/server/src/db/membership-db.ts
@@ -12,6 +12,7 @@ import { findPayingOrgForDomain } from './org-filters.js';
 import { createLogger } from '../logger.js';
 
 const logger = createLogger('membership-db');
+const OWNERLESS_PROMOTION_LOCK_TIMEOUT_MS = 5_000;
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -44,6 +45,60 @@ export interface MembershipUpsertParams {
 
 export interface MembershipUpsertResult {
   assigned_role: string;
+}
+
+async function withOwnerlessOrgPromotionLock<T>(
+  organizationId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const client = await getClient();
+  let callbackCompleted = false;
+
+  try {
+    await client.query('BEGIN');
+    await client.query("SELECT set_config('lock_timeout', $1, true)", [
+      `${OWNERLESS_PROMOTION_LOCK_TIMEOUT_MS}ms`,
+    ]);
+    await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [
+      `membership-ownerless-promote:${organizationId}`,
+    ]);
+
+    const result = await fn();
+    callbackCompleted = true;
+
+    try {
+      await client.query('COMMIT');
+    } catch (err) {
+      logger.warn(
+        { err, orgId: organizationId },
+        'Failed to commit ownerless-org promotion advisory lock transaction',
+      );
+      try {
+        await client.query('ROLLBACK');
+      } catch (rollbackErr) {
+        logger.warn(
+          { err: rollbackErr, orgId: organizationId },
+          'Failed to rollback ownerless-org promotion advisory lock transaction after commit failure',
+        );
+      }
+    }
+
+    return result;
+  } catch (err) {
+    if (!callbackCompleted) {
+      try {
+        await client.query('ROLLBACK');
+      } catch (rollbackErr) {
+        logger.warn(
+          { err: rollbackErr, orgId: organizationId },
+          'Failed to rollback ownerless-org promotion advisory lock transaction',
+        );
+      }
+    }
+    throw err;
+  } finally {
+    client.release();
+  }
 }
 
 // ── Upsert ───────────────────────────────────────────────────────────
@@ -158,56 +213,66 @@ export async function resolveRoleWithWorkosFirstPromote(args: {
     return { role: incomingRole, promoted: false };
   }
 
-  // Source-of-truth check: page through WorkOS memberships and look for
-  // an existing admin/owner that isn't this same user.
-  let hasOtherAdmin = false;
   try {
-    let after: string | undefined;
-    do {
-      const page = await workos.userManagement.listOrganizationMemberships({
-        organizationId,
-        statuses: ['active'],
-        limit: 100,
-        after,
-      });
-      for (const m of page.data) {
-        if (m.userId === userId) continue;
-        const slug = m.role?.slug;
-        if (slug === 'admin' || slug === 'owner') {
-          hasOtherAdmin = true;
-          break;
-        }
+    return await withOwnerlessOrgPromotionLock(organizationId, async () => {
+      // Source-of-truth check: page through WorkOS memberships and look for
+      // an existing admin/owner that isn't this same user.
+      let hasOtherAdmin = false;
+      try {
+        let after: string | undefined;
+        do {
+          const page = await workos.userManagement.listOrganizationMemberships({
+            organizationId,
+            statuses: ['active'],
+            limit: 100,
+            after,
+          });
+          for (const m of page.data) {
+            if (m.userId === userId) continue;
+            const slug = m.role?.slug;
+            if (slug === 'admin' || slug === 'owner') {
+              hasOtherAdmin = true;
+              break;
+            }
+          }
+          if (hasOtherAdmin) break;
+          after = page.listMetadata?.after ?? undefined;
+        } while (after);
+      } catch (err) {
+        // Can't verify WorkOS state — refuse to promote. Writing 'owner' locally
+        // when we don't know what WorkOS thinks is exactly the drift this rewrite
+        // is fixing.
+        logger.warn({ err, orgId: organizationId, userId },
+          'Could not list WorkOS memberships for ownerless-org check — assigning member');
+        return { role: 'member', promoted: false, promotionError: err };
       }
-      if (hasOtherAdmin) break;
-      after = page.listMetadata?.after ?? undefined;
-    } while (after);
-  } catch (err) {
-    // Can't verify WorkOS state — refuse to promote. Writing 'owner' locally
-    // when we don't know what WorkOS thinks is exactly the drift this rewrite
-    // is fixing.
-    logger.warn({ err, orgId: organizationId, userId },
-      'Could not list WorkOS memberships for ownerless-org check — assigning member');
-    return { role: 'member', promoted: false, promotionError: err };
-  }
 
-  if (hasOtherAdmin) {
-    return { role: 'member', promoted: false };
-  }
+      if (hasOtherAdmin) {
+        return { role: 'member', promoted: false };
+      }
 
-  // No other admin/owner — promote this membership to owner in WorkOS.
-  // If WorkOS rejects the update (role not configured, transient 5xx, etc.)
-  // we fall back to writing 'member' locally so the two sides stay aligned.
-  try {
-    await workos.userManagement.updateOrganizationMembership(membershipId, {
-      roleSlug: 'owner',
+      // No other admin/owner — promote this membership to owner in WorkOS.
+      // If WorkOS rejects the update (role not configured, transient 5xx, etc.)
+      // we fall back to writing 'member' locally so the two sides stay aligned.
+      try {
+        await workos.userManagement.updateOrganizationMembership(membershipId, {
+          roleSlug: 'owner',
+        });
+      } catch (err) {
+        logger.warn({ err, orgId: organizationId, userId, membershipId },
+          'Failed to promote member to owner in WorkOS — falling back to member locally');
+        return { role: 'member', promoted: false, promotionError: err };
+      }
+
+      return { role: 'owner', promoted: true };
     });
   } catch (err) {
-    logger.warn({ err, orgId: organizationId, userId, membershipId },
-      'Failed to promote member to owner in WorkOS — falling back to member locally');
+    logger.warn(
+      { err, orgId: organizationId, userId, membershipId },
+      'Could not acquire ownerless-org promotion lock — assigning member',
+    );
     return { role: 'member', promoted: false, promotionError: err };
   }
-
-  return { role: 'owner', promoted: true };
 }
 
 // ── Delete ───────────────────────────────────────────────────────────

--- a/server/src/routes/admin/organizations.ts
+++ b/server/src/routes/admin/organizations.ts
@@ -7,7 +7,7 @@ import { Router } from "express";
 import { WorkOS } from "@workos-inc/node";
 import { getPool } from "../../db/client.js";
 import { createLogger } from "../../logger.js";
-import { requireAuth, requireAdmin } from "../../middleware/auth.js";
+import { requireAuth, requireAdmin, requireGlobalAdmin } from "../../middleware/auth.js";
 import { OrganizationDatabase } from "../../db/organization-db.js";
 import { getPendingInvoices } from "../../billing/stripe-client.js";
 import {
@@ -1081,8 +1081,7 @@ export function setupOrganizationRoutes(
   // Used by Domain Health to move users from personal workspaces to company orgs
   apiRouter.post(
     "/organizations/:orgId/add-users",
-    requireAuth,
-    requireAdmin,
+    ...requireGlobalAdmin,
     async (req, res) => {
       try {
         const { orgId } = req.params;
@@ -1132,7 +1131,10 @@ export function setupOrganizationRoutes(
         for (const userId of user_ids) {
           try {
             // Validate user ID format
-            if (typeof userId !== "string" || !/^[\w-]+$/.test(userId)) {
+            if (
+              typeof userId !== "string" ||
+              !/^user_[0-9a-hjkmnp-tv-z]{26}$/i.test(userId)
+            ) {
               errors.push(`Invalid user ID format`);
               continue;
             }

--- a/server/src/routes/workos-webhooks.ts
+++ b/server/src/routes/workos-webhooks.ts
@@ -29,7 +29,7 @@ import {
   removeWorkosDomainAndReselectPrimary,
 } from '../db/organization-domains-db.js';
 import { BrandDatabase } from '../db/brand-db.js';
-import { getWorkos } from '../auth/workos-client.js';
+import { getWorkos, getOwnerlessPromotionWorkos } from '../auth/workos-client.js';
 import { invalidateUnifiedUsersCache } from '../cache/unified-users.js';
 import { tryAutoLinkWebsiteUserToSlack } from '../slack/sync.js';
 import { resolveUserNameWithFallbacks } from '../utils/resolve-user-name.js';
@@ -229,7 +229,7 @@ async function upsertMembership(
   // WorkOS first and only then write the resolved role locally. WorkOS is
   // the source of truth — local must never get ahead of it.
   const resolution = await resolveRoleWithWorkosFirstPromote({
-    workos: getWorkos(),
+    workos: getOwnerlessPromotionWorkos(),
     membershipId: membership.id,
     userId: membership.user_id,
     organizationId: membership.organization_id,

--- a/server/tests/integration/admin-add-users.test.ts
+++ b/server/tests/integration/admin-add-users.test.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import request from "supertest";
+import { readFileSync } from "node:fs";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { initializeDatabase, closeDatabase } from "../../src/db/client.js";
 import { runMigrations } from "../../src/db/migrate.js";
@@ -16,11 +17,13 @@ vi.mock("../../src/middleware/auth.js", async (importOriginal) => {
     next();
   };
   const requireAdmin = (_req: any, _res: any, next: any) => next();
+  const passThrough = (_req: any, _res: any, next: any) => next();
 
   return {
     ...(await importOriginal<typeof import("../../src/middleware/auth.js")>()),
     requireAuth,
     requireAdmin,
+    requireGlobalAdmin: [requireAuth, passThrough, requireAdmin],
   };
 });
 
@@ -119,6 +122,19 @@ describe("admin add-users", () => {
       [USER_ID, SOURCE_ORG_ID]
     );
   }
+
+  it("mounts add-users behind the global-admin chain", () => {
+    const source = readFileSync(
+      new URL("../../src/routes/admin/organizations.ts", import.meta.url),
+      "utf8"
+    );
+    const addUsersRoute = source.match(
+      /apiRouter\.post\(\s*"\/organizations\/:orgId\/add-users"[\s\S]*?async \(req, res\)/
+    )?.[0];
+
+    expect(addUsersRoute).toContain("...requireGlobalAdmin");
+    expect(addUsersRoute).not.toContain("requireAdmin");
+  });
 
   it("mirrors successful WorkOS adds through the shared membership upsert", async () => {
     const response = await request(app)
@@ -233,6 +249,18 @@ describe("admin add-users", () => {
       [USER_ID, TARGET_ORG_ID]
     );
     expect(row.rowCount).toBe(0);
+    await expectStagingRows(0);
+  });
+
+  it("rejects malformed WorkOS user ids before calling WorkOS", async () => {
+    const response = await request(app)
+      .post(`/api/admin/organizations/${TARGET_ORG_ID}/add-users`)
+      .send({ user_ids: ["user_does_not_exist"] })
+      .expect(200);
+
+    expect(response.body.added_count).toBe(0);
+    expect(response.body.errors).toEqual(["Invalid user ID format"]);
+    expect(createOrganizationMembership).not.toHaveBeenCalled();
     await expectStagingRows(0);
   });
 


### PR DESCRIPTION
## Summary

Closes #4911.

- move `POST /api/admin/organizations/:orgId/add-users` behind `...requireGlobalAdmin` so tenant-scoped WorkOS admin API keys cannot mutate cross-org membership state
- tighten admin add-users input validation to WorkOS-style `user_<26 base32 chars>` IDs before DB or WorkOS lookup
- serialize ownerless-org auto-promotion with a per-org PostgreSQL advisory transaction lock
- bound the lock path with a 5s transaction-local `lock_timeout` and a dedicated 10s WorkOS client for the webhook promotion flow
- add regression coverage for the route auth chain and malformed user IDs

## Expert review

- security-reviewer: initial availability finding addressed with bounded lock acquisition and short-timeout WorkOS client; re-review found no security blockers
- code-reviewer: initial blocker on DB transaction held across default WorkOS timeout addressed with the short-timeout client; auth regression coverage added

## Validation

- `npx vitest run server/tests/integration/membership-webhook.test.ts --config server/vitest.config.ts`
- `npx vitest run server/tests/integration/admin-add-users.test.ts --config server/vitest.config.ts`
- `npx vitest run server/tests/unit/require-admin-cross-tenant.test.ts --config server/vitest.config.ts`
- `npm run typecheck`
- `git diff --check`
- precommit hook: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run typecheck`
- push hook: `verify-version-sync`; storyboard and Mintlify checks skipped as not applicable

## Notes

Security re-review noted one residual non-blocking gap: no contention-focused test that forces the new lock-timeout path under concurrent ownerless-org promotions.