### PR TITLE
compliance: knock out 3.1 candidates

### DIFF
--- a/.changeset/4714-4732-compliance-storyboard-tightening.md
+++ b/.changeset/4714-4732-compliance-storyboard-tightening.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": minor
+---
+
+Add `field_pattern` / `envelope_field_pattern` compliance check kinds and use the envelope-scoped form to validate `adcp_version` shape in the version-negotiation storyboard.
+
+Tighten media-buy storyboards that reuse a discovered `pricing_option_id` so auction-priced flows send `bid_price` and fixed-price flows validate the captured option before downstream package creation.

--- a/scripts/lint-storyboard-contradictions.cjs
+++ b/scripts/lint-storyboard-contradictions.cjs
@@ -445,16 +445,19 @@ function classifyOutcome(step) {
     return { kind: 'error', codes };
   }
 
-  // Looks like a success assertion path (field_present, envelope_field_present,
-  // response_schema, field_value on happy-path fields). Distinguish from
-  // "unspecified" — we need at least one positive assertion to call it success.
+  // Looks like a success assertion path (field_present, field_pattern,
+  // envelope_field_present, envelope_field_pattern, response_schema, field_value
+  // on happy-path fields). Distinguish from "unspecified" — we need at least
+  // one positive assertion to call it success.
   const hasPositiveAssertion = validations.some((v) => {
     if (!v || typeof v !== 'object') return false;
     const check = v.check;
     return (
       check === 'response_schema' ||
       check === 'field_present' ||
+      check === 'field_pattern' ||
       check === 'envelope_field_present' ||
+      check === 'envelope_field_pattern' ||
       check === 'field_value' ||
       check === 'field_value_or_absent' ||
       check === 'http_status' ||

--- a/scripts/lint-storyboard-validations-paths.cjs
+++ b/scripts/lint-storyboard-validations-paths.cjs
@@ -17,8 +17,10 @@
  *   - field_value
  *   - field_value_or_absent
  *   - field_absent
+ *   - field_pattern
  *   - envelope_field_present
  *   - envelope_field_absent
+ *   - envelope_field_pattern
  *
  * Non-path-bearing checks (error_code, response_schema, http_status_in,
  * http_status, any_of, on_401_require_header) are skipped — they don't
@@ -45,8 +47,10 @@ const PATH_BEARING_CHECKS = new Set([
   'field_value',
   'field_value_or_absent',
   'field_absent',
+  'field_pattern',
   'envelope_field_present',
   'envelope_field_absent',
+  'envelope_field_pattern',
 ]);
 
 function loadAllowlist() {
@@ -105,12 +109,13 @@ function loadSchema(ref) {
 }
 
 /**
- * `core/protocol-envelope.json` defines the fields wrapping every task
- * response — `status`, `task_id`, `context_id`, `replayed`, `adcp_error`,
- * `governance_context`, `push_notification_config`, etc. The envelope's
- * top-level description explicitly states "Task response schemas should
- * NOT include these fields - they are protocol-level concerns," so they
- * never appear in the per-task response schemas this lint walks.
+ * `core/protocol-envelope.json` and `core/version-envelope.json` define
+ * fields wrapping or mixed into every task response — `status`, `task_id`,
+ * `context_id`, `replayed`, `adcp_error`, `adcp_version`,
+ * `adcp_major_version`, etc. Protocol-envelope fields never appear in the
+ * per-task response schemas this lint walks; version-envelope fields are
+ * composed via allOf into source schemas but can be absent from older built
+ * artifacts and still need envelope-scoped validation semantics.
  *
  * Storyboards do assert on envelope fields (e.g., `path: "replayed"`,
  * `path: "adcp_error"`), so the resolver falls back to the envelope when
@@ -119,11 +124,33 @@ function loadSchema(ref) {
  * envelope property, further resolution proceeds normally.
  */
 const ENVELOPE_REF = 'core/protocol-envelope.json';
+const VERSION_ENVELOPE_REF = 'core/version-envelope.json';
+const ENVELOPE_REFS = [ENVELOPE_REF, VERSION_ENVELOPE_REF];
 
 function isEnvelopeProperty(name) {
-  const envelope = loadSchema(ENVELOPE_REF);
-  if (!envelope || !envelope.properties) return false;
-  return Object.prototype.hasOwnProperty.call(envelope.properties, name);
+  for (const ref of ENVELOPE_REFS) {
+    const envelope = loadSchema(ref);
+    if (envelope?.properties && Object.prototype.hasOwnProperty.call(envelope.properties, name)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function pathResolvesAgainstAnyEnvelope(segments) {
+  for (const ref of ENVELOPE_REFS) {
+    const envelope = loadSchema(ref);
+    if (envelope && pathResolves(envelope, segments)) return true;
+  }
+  return false;
+}
+
+function pathIsForbiddenByAnyEnvelope(segments) {
+  for (const ref of ENVELOPE_REFS) {
+    const envelope = loadSchema(ref);
+    if (envelope && pathIsForbiddenByRequiredNot(envelope, segments)) return true;
+  }
+  return false;
 }
 
 /**
@@ -295,14 +322,13 @@ function resolveExpectedArmSchema(schema, expectedArm, expectError) {
 
 function pathResolvesAgainstResponseOrEnvelope(schema, segments) {
   if (pathResolves(schema, segments)) return true;
-  // Fall back to the protocol envelope. Storyboards address envelope-level
-  // fields with bare top-level names (e.g., `replayed`, `adcp_error`,
-  // `status`), so we only consult the envelope when the FIRST segment
-  // matches an envelope property; subsequent segments resolve through
-  // the envelope's own definition of that field.
+  // Fall back to the protocol/version envelopes. Storyboards address
+  // envelope-level fields with bare top-level names (e.g., `replayed`,
+  // `adcp_error`, `status`, `adcp_version`), so we only consult envelope
+  // schemas when the FIRST segment matches an envelope property; subsequent
+  // segments resolve through that envelope's own definition of the field.
   if (segments.length > 0 && isEnvelopeProperty(segments[0])) {
-    const envelope = loadSchema(ENVELOPE_REF);
-    if (envelope && pathResolves(envelope, segments)) return true;
+    if (pathResolvesAgainstAnyEnvelope(segments)) return true;
   }
   return false;
 }
@@ -341,11 +367,9 @@ function pathIsForbiddenByRequiredNot(node, segments, seen = new Set()) {
 }
 
 function absentPathForbiddenState(schema, segments) {
-  const envelope = loadSchema(ENVELOPE_REF);
-  const forbiddenByEnvelope = Boolean(envelope && pathIsForbiddenByRequiredNot(envelope, segments));
   return {
     forbiddenBySchema: pathIsForbiddenByRequiredNot(schema, segments),
-    forbiddenByEnvelope,
+    forbiddenByEnvelope: pathIsForbiddenByAnyEnvelope(segments),
   };
 }
 
@@ -382,11 +406,14 @@ function lintDoc(doc, filePath, allowlist = []) {
       const rawPath = v.path;
       if (typeof rawPath !== 'string' || rawPath.length === 0) continue;
       const segments = parsePath(rawPath);
-      if (v.check === 'envelope_field_present' || v.check === 'envelope_field_absent') {
-        const envelope = loadSchema(ENVELOPE_REF);
-        const resolvesOnEnvelope = Boolean(envelope && pathResolves(envelope, segments));
-        const forbiddenOnEnvelope = Boolean(envelope && pathIsForbiddenByRequiredNot(envelope, segments));
-        if (v.check === 'envelope_field_present' && resolvesOnEnvelope) continue;
+      if (
+        v.check === 'envelope_field_present' ||
+        v.check === 'envelope_field_absent' ||
+        v.check === 'envelope_field_pattern'
+      ) {
+        const resolvesOnEnvelope = pathResolvesAgainstAnyEnvelope(segments);
+        const forbiddenOnEnvelope = pathIsForbiddenByAnyEnvelope(segments);
+        if ((v.check === 'envelope_field_present' || v.check === 'envelope_field_pattern') && resolvesOnEnvelope) continue;
         if (v.check === 'envelope_field_absent' && (resolvesOnEnvelope || forbiddenOnEnvelope)) continue;
         if (isAllowlisted(allowlist, filePath, step.stepId, rawPath)) continue;
         violations.push({

--- a/static/compliance/source/protocols/media-buy/scenarios/product_signal_targeting.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/product_signal_targeting.yaml
@@ -110,6 +110,7 @@ phases:
           buying_mode: "wholesale"
           filters:
             channels: ["display"]
+            is_fixed_price: false
           account:
             brand:
               domain: "acmeoutdoor.example"
@@ -132,6 +133,9 @@ phases:
           - check: field_present
             path: "products[0].signal_targeting_rules"
             description: "Product declares signal targeting composition rules"
+          - check: field_present
+            path: "products[0].pricing_options[0].floor_price"
+            description: "The captured pricing option accepts bid_price for auction-priced package creation"
           - check: field_present
             path: "context"
             description: "Response echoes back the context object"
@@ -237,6 +241,7 @@ phases:
           packages:
             - product_id: "$context.product_id"
               pricing_option_id: "$context.pricing_option_id"
+              bid_price: 4.25
               budget: 12000
               targeting_overlay:
                 signal_targeting_groups:
@@ -350,6 +355,7 @@ phases:
           packages:
             - product_id: "$context.product_id"
               pricing_option_id: "$context.pricing_option_id"
+              bid_price: 4.25
               budget: 5000
               targeting_overlay:
                 signal_targeting_groups:

--- a/static/compliance/source/protocols/media-buy/scenarios/vendor_metric_optimization_flow.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/vendor_metric_optimization_flow.yaml
@@ -178,6 +178,7 @@ phases:
           buying_mode: "brief"
           brief: "Display inventory with attention-score optimization from attentionvendor."
           filters:
+            is_fixed_price: true
             channels: ["display"]
           account:
             brand:
@@ -194,6 +195,9 @@ phases:
           - check: field_present
             path: "products[0].product_id"
             description: "At least one product returned"
+          - check: field_present
+            path: "products[0].pricing_options[0].fixed_price"
+            description: "The captured pricing option is fixed-price; fixed-price storyboards do not send bid_price"
           - check: field_present
             path: "products[0].vendor_metric_optimization.supported_metrics"
             description: "Product declares vendor_metric_optimization.supported_metrics[]"

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -26,7 +26,7 @@
 # --- Schema definition ---
 
 id: runner_output_contract
-version: "2.4.0"
+version: "2.5.0"
 title: "Runner output contract"
 summary: "Required failure-detail shape that AdCP storyboard runners MUST emit so implementors can self-diagnose validation failures."
 
@@ -43,8 +43,10 @@ authored_check_kinds:
   - response_schema
   - field_present
   - field_absent
+  - field_pattern
   - envelope_field_present
   - envelope_field_absent
+  - envelope_field_pattern
   - field_value
   - field_value_or_absent
   - status_code
@@ -146,8 +148,10 @@ validation_result:
     - check                   # Validation kind. For storyboard-authored checks,
                               # mirrors the storyboard's step.validations[].check:
                               # response_schema | field_present |
-                              # field_absent | envelope_field_present |
-                              # envelope_field_absent | field_value |
+                              # field_absent | field_pattern |
+                              # envelope_field_present |
+                              # envelope_field_absent |
+                              # envelope_field_pattern | field_value |
                               # field_value_or_absent | status_code | http_status |
                               # http_status_in | error_code | on_401_require_header |
                               # resource_equals_agent_url | any_of | refs_resolve |
@@ -206,10 +210,15 @@ validation_result:
                               #                          from the storyboard validation
                               #   field_present        → the path that should resolve
                               #   field_absent         → null (the field must not be present)
+                              #   field_pattern        → object { pattern } where pattern is
+                              #                          the JavaScript regular expression
+                              #                          source the observed string MUST match
                               #   envelope_field_present → the path that should resolve
                               #                          in the protocol envelope
                               #   envelope_field_absent → null (the envelope field must
                               #                          not be present)
+                              #   envelope_field_pattern → object { pattern } scoped to the
+                              #                          protocol/version envelope
                               #   status_code          → expected status
                               #   error_code           → expected error code
                               #   any_of               → array of acceptable forms
@@ -270,12 +279,18 @@ validation_result:
                               #                          value
                               #   field_absent         → observed value at path (any JSON
                               #                          type); emitted only on failure
+                              #   field_pattern        → observed value at path (any JSON
+                              #                          type); null when the field was
+                              #                          missing
                               #   envelope_field_present → null (the field was missing)
                               #                          or the observed non-object
                               #                          value (scoped to envelope)
                               #   envelope_field_absent → observed value at path (any JSON
                               #                          type); emitted only on failure
 	                              #                          and scoped to envelope
+                              #   envelope_field_pattern → observed envelope value at path
+                              #                          (any JSON type); null when the field
+                              #                          was missing
                               #   field_less_than      → the observed value at `path`
                               #                          (number when resolvable, null
                               #                          when the field was missing).

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -1063,10 +1063,15 @@
 # enum AND document semantics here in the same PR.
 #
 # check: string (what to validate: "response_schema", "field_present",
+#                "field_pattern" (path MUST resolve to a string matching
+#                `pattern`, a JavaScript regular expression source),
 #                "envelope_field_present" / "envelope_field_absent" (walks
 #                protocol-envelope.json instead of response_schema_ref — use for
 #                top-level envelope fields like `status`, `task_status`, and
 #                `response_status`),
+#                "envelope_field_pattern" (same as field_pattern, but scoped to
+#                protocol-envelope.json / version-envelope.json instead of
+#                response_schema_ref),
 #                "field_value",
 #                "field_value_or_absent", "status_code", "http_status", "http_status_in",
 #                "error_code", "on_401_require_header", "resource_equals_agent_url",

--- a/static/compliance/source/universal/version-negotiation.yaml
+++ b/static/compliance/source/universal/version-negotiation.yaml
@@ -114,12 +114,20 @@ phases:
               reason: "Per docs/reference/versioning.mdx > Migration timeline, sellers SHOULD declare supported_versions at 3.1 and the compliance grader reports presence as advisory. At 3.2 the storyboard cut promotes this validation to required (manual flip — not gated on runner_capability_version because the 3.2 boundary is a protocol-spec cutover, not a runner-capability cutover). 4.0 promotes to MUST per the spec. Marking permanent_advisory here is a deliberate use of the field to defer promotion to the 3.2 storyboard PR rather than relying on the expires_after_version semver gate."
             description: "Seller advertises release-precision supported_versions (advisory at 3.1, required at 3.2)"
 
-          - check: field_present
+          - check: envelope_field_present
             path: "adcp_version"
             severity: advisory
             permanent_advisory:
               reason: "Per docs/reference/versioning.mdx > Migration timeline, sellers SHOULD echo adcp_version at 3.1 and the compliance grader reports presence as advisory. At 3.2 the storyboard cut promotes this validation to required (manual flip — see the supported_versions check above for the same rationale). 4.0 promotes to MUST per the spec."
             description: "Seller echoes adcp_version on the response envelope (advisory at 3.1, required at 3.2)"
+
+          - check: envelope_field_pattern
+            path: "adcp_version"
+            pattern: "^\\d+\\.\\d+(-[a-zA-Z0-9.-]+)?$"
+            severity: advisory
+            permanent_advisory:
+              reason: "Per docs/reference/versioning.mdx > Version format, adcp_version is release-precision (MAJOR.MINOR, optionally with a prerelease suffix during RC windows). 3.1 reports shape mismatches as advisory while runners adopt envelope-field pattern validation; the 3.2 storyboard cut can promote this validation with the presence check."
+            description: "Seller echoes a release-precision adcp_version string on the response envelope"
 
           - check: field_present
             path: "context"

--- a/tests/lint-storyboard-check-enum.test.cjs
+++ b/tests/lint-storyboard-check-enum.test.cjs
@@ -39,7 +39,7 @@ test('authored_check_kinds enum loads from runner-output-contract.yaml', () => {
   const kinds = loadKnownCheckKinds();
   // Spot-check a few load-bearing entries — keep this tight so the test
   // doesn't have to track every authored kind. Full enum is the contract.
-  for (const expected of ['response_schema', 'field_present', 'upstream_traffic']) {
+  for (const expected of ['response_schema', 'field_present', 'field_pattern', 'envelope_field_pattern', 'upstream_traffic']) {
     assert.ok(kinds.has(expected), `expected "${expected}" in authored_check_kinds`);
   }
   // Synthesized codes MUST NOT be in the authored enum.

--- a/tests/lint-storyboard-contradictions.test.cjs
+++ b/tests/lint-storyboard-contradictions.test.cjs
@@ -174,6 +174,18 @@ test('classifyOutcome treats envelope_field_present as success assertion', () =>
   assert.equal(outcome.kind, 'success');
 });
 
+test('classifyOutcome treats pattern checks as success assertions', () => {
+  for (const check of ['field_pattern', 'envelope_field_pattern']) {
+    const step = {
+      validations: [
+        { check, path: 'adcp_version', pattern: '^\\d+\\.\\d+$' },
+      ],
+    };
+    const outcome = classifyOutcome(step);
+    assert.equal(outcome.kind, 'success', `${check} should imply success`);
+  }
+});
+
 test('classifyOutcome treats envelope_field_absent alone as unspecified', () => {
   const step = {
     validations: [

--- a/tests/lint-storyboard-validations-paths.test.cjs
+++ b/tests/lint-storyboard-validations-paths.test.cjs
@@ -285,9 +285,63 @@ test('envelope_field_absent does not accept payload-only paths', () => {
   assert.equal(violations[0].check, 'envelope_field_absent');
 });
 
+test('envelope_field_pattern resolves only against envelope fields', () => {
+  const ok = lintDoc({
+    phases: [
+      {
+        id: 'p',
+        steps: [
+          {
+            id: 's',
+            task: 'get_adcp_capabilities',
+            response_schema_ref: 'protocol/get-adcp-capabilities-response.json',
+            validations: [
+              {
+                check: 'envelope_field_pattern',
+                path: 'adcp_version',
+                pattern: '^\\d+\\.\\d+$',
+                description: 'version envelope field',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  }, '/synth/envelope-pattern-ok.yaml');
+  assert.deepEqual(ok, []);
+
+  const bad = lintDoc({
+    phases: [
+      {
+        id: 'p',
+        steps: [
+          {
+            id: 's',
+            task: 'get_adcp_capabilities',
+            response_schema_ref: 'protocol/get-adcp-capabilities-response.json',
+            validations: [
+              {
+                check: 'envelope_field_pattern',
+                path: 'adcp.supported_versions[0]',
+                pattern: '^\\d+\\.\\d+$',
+                description: 'payload field is not an envelope field',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  }, '/synth/envelope-pattern-payload-path.yaml');
+  assert.equal(bad.length, 1);
+  assert.equal(bad[0].rule, 'path_not_in_schema');
+  assert.equal(bad[0].check, 'envelope_field_pattern');
+});
+
 test('isEnvelopeProperty identifies envelope fields', () => {
   assert.equal(isEnvelopeProperty('replayed'), true);
   assert.equal(isEnvelopeProperty('adcp_error'), true);
+  assert.equal(isEnvelopeProperty('adcp_version'), true);
+  assert.equal(isEnvelopeProperty('adcp_major_version'), true);
   assert.equal(isEnvelopeProperty('status'), true);
   assert.equal(isEnvelopeProperty('task_id'), true);
   assert.equal(isEnvelopeProperty('context_id'), true);
@@ -310,8 +364,10 @@ test('PATH_BEARING_CHECKS is the documented set', () => {
   assert.ok(PATH_BEARING_CHECKS.has('field_value'));
   assert.ok(PATH_BEARING_CHECKS.has('field_value_or_absent'));
   assert.ok(PATH_BEARING_CHECKS.has('field_absent'));
+  assert.ok(PATH_BEARING_CHECKS.has('field_pattern'));
   assert.ok(PATH_BEARING_CHECKS.has('envelope_field_present'));
   assert.ok(PATH_BEARING_CHECKS.has('envelope_field_absent'));
+  assert.ok(PATH_BEARING_CHECKS.has('envelope_field_pattern'));
   assert.ok(!PATH_BEARING_CHECKS.has('error_code'));
   assert.ok(!PATH_BEARING_CHECKS.has('response_schema'));
 });


### PR DESCRIPTION
Adds `field_pattern` and `envelope_field_pattern` to the compliance runner contract, then uses the envelope-scoped check to validate the `adcp_version` wire shape in version negotiation.

Tightens the remaining pricing-option storyboards from #4732 so auction-priced requests send `bid_price` and fixed-price flows validate `fixed_price` before downstream use.

Also updates the storyboard validation-path lint to understand version-envelope fields alongside protocol-envelope fields, with targeted tests and a changeset.

Validation: precommit, `npm run build:compliance`, `npm run test:storyboard-validations-paths`, `npm run test:storyboard-check-enum`, `npm run test:storyboard-sample-request-schema`, `npm run test:version-envelope`, and push-hook storyboard matrix for current and 3.0 compatibility.