### PR TITLE
fix(billing): audit admin Stripe customer relinks

### DIFF
--- a/.changeset/admin-stripe-customer-link-audit.md
+++ b/.changeset/admin-stripe-customer-link-audit.md
@@ -1,0 +1,4 @@
+---
+---
+
+Empty changeset: server/admin behavior only. Requires an audited reason and Stripe pre-validation when admins link or replace an organization's Stripe customer ID.

--- a/server/public/admin-billing.html
+++ b/server/public/admin-billing.html
@@ -633,7 +633,7 @@
       document.getElementById(`link-btn-${customerId}`).disabled = false;
     }
 
-    async function linkCustomer(customerId, force) {
+    async function linkCustomer(customerId, force, existingReason) {
       const selectedOrg = selectedOrgs[customerId];
       if (!selectedOrg) {
         showError('Please select an organization first');
@@ -646,6 +646,12 @@
         }
       }
 
+      const reason = existingReason || prompt(`Reason for linking ${customerId} to "${selectedOrg.name}" (required):`);
+      if (!reason || reason.trim().length < 10) {
+        showError('A reason of at least 10 characters is required');
+        return;
+      }
+
       const btn = document.getElementById(`link-btn-${customerId}`);
       btn.disabled = true;
       btn.textContent = 'Linking...';
@@ -654,7 +660,11 @@
         const response = await fetch(`/api/admin/stripe-customers/${customerId}/link`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ org_id: selectedOrg.id, force: force || !!selectedOrg.existingCustomerId }),
+          body: JSON.stringify({
+            org_id: selectedOrg.id,
+            force: force || !!selectedOrg.existingCustomerId,
+            reason: reason.trim(),
+          }),
         });
 
         const data = await response.json();
@@ -662,7 +672,7 @@
         if (data.requires_force && !force) {
           // Server says force is needed (org got linked between search and submit)
           if (confirm(`${data.message} Replace anyway?`)) {
-            return linkCustomer(customerId, true);
+            return linkCustomer(customerId, true, reason);
           }
           btn.disabled = false;
           btn.textContent = 'Link';

--- a/server/src/routes/billing.ts
+++ b/server/src/routes/billing.ts
@@ -8,7 +8,7 @@
 import { Router } from "express";
 import Stripe from "stripe";
 import { createLogger } from "../logger.js";
-import { requireAuth, requireAdmin } from "../middleware/auth.js";
+import { requireAuth, requireAdmin, requireGlobalAdmin } from "../middleware/auth.js";
 import { serveHtmlWithConfig } from "../utils/html-config.js";
 import { getPool } from "../db/client.js";
 import {
@@ -26,7 +26,7 @@ import {
   type UpdateProductInput,
   type PendingInvoice,
 } from "../billing/stripe-client.js";
-import { OrganizationDatabase, buildSubscriptionUpdate } from "../db/organization-db.js";
+import { OrganizationDatabase, TIER_PRESERVING_STATUSES, buildSubscriptionUpdate } from "../db/organization-db.js";
 import { invalidateMembershipCache } from "../db/org-filters.js";
 import { pickMembershipSub } from "../billing/membership-prices.js";
 
@@ -155,7 +155,7 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
     });
   });
 
-  pageRouter.get("/billing", requireAuth, requireAdmin, (req, res) => {
+  pageRouter.get("/billing", ...requireGlobalAdmin, (req, res) => {
     serveHtmlWithConfig(req, res, "admin-billing.html").catch((err) => {
       logger.error({ err }, "Error serving admin billing page");
       res.status(500).send("Internal server error");
@@ -569,7 +569,7 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
   // =========================================================================
 
   // GET /api/admin/stripe-customers - List all Stripe customers with link status and payment totals
-  apiRouter.get("/stripe-customers", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/stripe-customers", ...requireGlobalAdmin, async (req, res) => {
     if (!stripe) {
       return res.status(400).json({ error: "Stripe not configured" });
     }
@@ -680,9 +680,10 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
   });
 
   // POST /api/admin/stripe-customers/:customerId/link - Manually link a Stripe customer to an org
-  apiRouter.post("/stripe-customers/:customerId/link", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.post("/stripe-customers/:customerId/link", ...requireGlobalAdmin, async (req, res) => {
     const { customerId } = req.params;
     const { org_id, force } = req.body;
+    const reason = typeof req.body.reason === 'string' ? req.body.reason.trim() : '';
 
     if (!customerId || !customerId.startsWith("cus_")) {
       return res.status(400).json({ error: "Invalid customer ID format" });
@@ -692,12 +693,33 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
       return res.status(400).json({ error: "org_id is required" });
     }
 
+    if (reason.length < 10) {
+      return res.status(400).json({
+        error: "Reason required",
+        message: "reason must be at least 10 characters",
+      });
+    }
+
+    if (!stripe) {
+      return res.status(503).json({
+        error: "Stripe not configured",
+        message: "Cannot validate Stripe customer before linking",
+      });
+    }
+
     try {
       const pool = getPool();
 
       // Verify org exists
       const orgResult = await pool.query(
-        "SELECT workos_organization_id, name, stripe_customer_id, is_personal FROM organizations WHERE workos_organization_id = $1",
+        `SELECT workos_organization_id, name, stripe_customer_id, is_personal,
+                subscription_status, stripe_subscription_id, subscription_amount,
+                subscription_currency, subscription_interval,
+                subscription_current_period_end, subscription_canceled_at,
+                subscription_product_id, subscription_product_name,
+                subscription_price_id, subscription_price_lookup_key,
+                membership_tier
+           FROM organizations WHERE workos_organization_id = $1`,
         [org_id]
       );
 
@@ -719,7 +741,7 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
         }
         previousCustomerId = org.stripe_customer_id;
         logger.info(
-          { customerId, orgId: org_id, previousCustomerId, adminEmail: req.user?.email },
+          { customerId, orgId: org_id, previousCustomerId, adminEmail: req.user?.email, reason },
           "Force-replacing existing Stripe customer link"
         );
       }
@@ -737,8 +759,215 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
         });
       }
 
-      // Clear org metadata on the old Stripe customer to prevent stale search matches
-      if (previousCustomerId && stripe) {
+      let customer: Stripe.Customer | Stripe.DeletedCustomer;
+      try {
+        customer = await stripe.customers.retrieve(customerId);
+      } catch (err) {
+        const stripeError = err as { code?: string; statusCode?: number; message?: string };
+        const notFound = stripeError.code === 'resource_missing' || stripeError.statusCode === 404;
+        logger.warn({ err, customerId, org_id }, "Failed to validate Stripe customer before linking");
+        return res.status(notFound ? 404 : 502).json({
+          error: notFound ? "Stripe customer not found" : "Stripe validation failed",
+          message: stripeError.message ?? "Unable to retrieve Stripe customer",
+        });
+      }
+
+      if ('deleted' in customer && customer.deleted) {
+        return res.status(400).json({
+          error: "Stripe customer deleted",
+          message: "Cannot link a deleted Stripe customer",
+        });
+      }
+
+      let stripeSubscriptions: Stripe.Subscription[];
+      try {
+        const subscriptionsResp = await stripe.subscriptions.list({
+          customer: customerId,
+          status: 'all',
+          limit: 100,
+        });
+        stripeSubscriptions = subscriptionsResp.data;
+      } catch (err) {
+        const stripeError = err as { message?: string };
+        logger.warn({ err, customerId, org_id }, "Failed to list Stripe subscriptions before linking");
+        return res.status(502).json({
+          error: "Stripe validation failed",
+          message: stripeError.message ?? "Unable to list Stripe subscriptions",
+        });
+      }
+
+      // Sync subscription data from Stripe
+      let subscriptionSynced = false;
+      const liveSubscriptions = stripeSubscriptions
+        .filter((sub) => (TIER_PRESERVING_STATUSES as readonly string[]).includes(sub.status));
+      const conflictingStripeOrgIds = new Set(
+        liveSubscriptions
+          .map((sub) => sub.metadata?.workos_organization_id)
+          .filter((stripeOrgId): stripeOrgId is string => Boolean(stripeOrgId && stripeOrgId !== org_id)),
+      );
+      if (conflictingStripeOrgIds.size > 0) {
+        return res.status(400).json({
+          error: "Stripe customer belongs to another organization",
+          message: "This Stripe customer has a live subscription associated with a different organization",
+          conflicting_org_ids: [...conflictingStripeOrgIds],
+        });
+      }
+
+      // Filter to membership subs before picking. A customer with a
+      // non-membership sub stacked alongside a real membership would
+      // otherwise have its row overwritten with the wrong sub's state
+      // because Stripe doesn't guarantee `subscriptions.data` order.
+      const subscription = pickMembershipSub(stripeSubscriptions);
+      const subUpdate = subscription
+        ? buildSubscriptionUpdate(subscription as any, org.is_personal ?? false)
+        : null;
+
+      const beforeState = {
+        stripe_customer_id: org.stripe_customer_id,
+        subscription_status: org.subscription_status,
+        stripe_subscription_id: org.stripe_subscription_id,
+        subscription_amount: org.subscription_amount,
+        subscription_currency: org.subscription_currency,
+        subscription_interval: org.subscription_interval,
+        subscription_current_period_end: org.subscription_current_period_end,
+        subscription_canceled_at: org.subscription_canceled_at,
+        subscription_product_id: org.subscription_product_id,
+        subscription_product_name: org.subscription_product_name,
+        subscription_price_id: org.subscription_price_id,
+        subscription_price_lookup_key: org.subscription_price_lookup_key,
+        membership_tier: org.membership_tier,
+      };
+      const afterState = subUpdate
+        ? { stripe_customer_id: customerId, ...subUpdate }
+        : previousCustomerId
+          ? {
+              stripe_customer_id: customerId,
+              subscription_status: null,
+              stripe_subscription_id: null,
+              subscription_amount: null,
+              subscription_currency: null,
+              subscription_interval: null,
+              subscription_current_period_end: null,
+              subscription_canceled_at: null,
+              subscription_product_id: null,
+              subscription_product_name: null,
+              subscription_price_id: null,
+              subscription_price_lookup_key: null,
+              membership_tier: null,
+            }
+          : { ...beforeState, stripe_customer_id: customerId };
+
+      const txClient = await pool.connect();
+      try {
+        await txClient.query("BEGIN");
+        await txClient.query(
+          "UPDATE organizations SET stripe_customer_id = $1, updated_at = NOW() WHERE workos_organization_id = $2",
+          [customerId, org_id],
+        );
+
+        if (subUpdate) {
+          await txClient.query(
+            `UPDATE organizations
+             SET subscription_status = $1,
+                 subscription_amount = $2,
+                 subscription_interval = $3,
+                 subscription_currency = $4,
+                 subscription_current_period_end = $5,
+                 subscription_canceled_at = $6,
+                 stripe_subscription_id = $7,
+                 subscription_product_id = $8,
+                 subscription_product_name = COALESCE($9, subscription_product_name),
+                 subscription_price_id = $10,
+                 subscription_price_lookup_key = $11,
+                 membership_tier = $12,
+                 updated_at = NOW()
+             WHERE workos_organization_id = $13`,
+            [
+              subUpdate.subscription_status,
+              subUpdate.subscription_amount,
+              subUpdate.subscription_interval,
+              subUpdate.subscription_currency,
+              subUpdate.subscription_current_period_end,
+              subUpdate.subscription_canceled_at,
+              subUpdate.stripe_subscription_id,
+              subUpdate.subscription_product_id,
+              subUpdate.subscription_product_name,
+              subUpdate.subscription_price_id,
+              subUpdate.subscription_price_lookup_key,
+              subUpdate.membership_tier,
+              org_id,
+            ]
+          );
+          subscriptionSynced = true;
+        } else if (previousCustomerId) {
+          // Force-replace path with no membership sub on the new customer:
+          // clear subscription state derived from the old customer.
+          await txClient.query(
+            `UPDATE organizations SET
+                stripe_subscription_id = NULL,
+                subscription_status = NULL,
+                subscription_amount = NULL,
+                subscription_currency = NULL,
+                subscription_interval = NULL,
+                subscription_current_period_end = NULL,
+                subscription_canceled_at = NULL,
+                subscription_product_id = NULL,
+                subscription_product_name = NULL,
+                subscription_price_id = NULL,
+                subscription_price_lookup_key = NULL,
+                membership_tier = NULL,
+                updated_at = NOW()
+             WHERE workos_organization_id = $1`,
+            [org_id],
+          );
+        }
+
+        await txClient.query(
+          `INSERT INTO registry_audit_log
+           (workos_organization_id, workos_user_id, action, resource_type, resource_id, details)
+           VALUES ($1, $2, $3, $4, $5, $6)`,
+          [
+            org_id,
+            req.user?.id ?? 'unknown',
+            previousCustomerId ? 'admin_stripe_link_replace' : 'admin_stripe_link',
+            'subscription',
+            customerId,
+            JSON.stringify({
+              stripe_customer_id: customerId,
+              ...(previousCustomerId && { previous_customer_id: previousCustomerId }),
+              subscription_synced: subscriptionSynced,
+              admin_email: req.user?.email,
+              reason,
+              before_state: beforeState,
+              after_state: afterState,
+            }),
+          ],
+        );
+        await txClient.query("COMMIT");
+      } catch (txErr) {
+        try { await txClient.query("ROLLBACK"); } catch { /* swallow */ }
+        throw txErr;
+      } finally {
+        txClient.release();
+      }
+
+      if (subscriptionSynced || previousCustomerId) {
+        invalidateMembershipCache(org_id);
+      }
+
+      try {
+        await stripe.customers.update(customerId, {
+          metadata: { workos_organization_id: org_id },
+        });
+      } catch (err) {
+        logger.warn({ err, customerId, org_id }, "Failed to stamp metadata on new Stripe customer");
+      }
+
+      // Clear org metadata on the old Stripe customer and its subscriptions to
+      // prevent stale webhook fallback from silently relinking the old customer.
+      // This happens after the DB transaction commits so a failed audit insert
+      // cannot leave Stripe metadata cleared while the local link is unchanged.
+      if (previousCustomerId) {
         try {
           await stripe.customers.update(previousCustomerId, {
             metadata: { workos_organization_id: '' },
@@ -746,133 +975,40 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
         } catch (err) {
           logger.warn({ err, previousCustomerId }, "Failed to clear metadata on old Stripe customer");
         }
-      }
 
-      // Link the customer
-      await pool.query("UPDATE organizations SET stripe_customer_id = $1 WHERE workos_organization_id = $2", [
-        customerId,
-        org_id,
-      ]);
-
-      // Sync invoices for this customer to local cache
-      const invoicesSynced = await syncInvoicesForCustomer(customerId, org_id);
-
-      // Sync subscription data from Stripe
-      let subscriptionSynced = false;
-      let subscriptionSyncError: string | null = null;
-      if (stripe) {
         try {
-          const customerResp = await stripe.customers.retrieve(customerId, {
-            expand: ["subscriptions"],
+          const subs = await stripe.subscriptions.list({
+            customer: previousCustomerId,
+            status: 'all',
+            limit: 100,
           });
-          const customer = customerResp as Stripe.Customer | Stripe.DeletedCustomer;
-
-          if (!('deleted' in customer && customer.deleted)) {
-            const subscriptions = (customer as Stripe.Customer).subscriptions;
-            // Filter to membership subs before picking. A customer with a
-            // non-membership sub stacked alongside a real membership would
-            // otherwise have its row overwritten with the wrong sub's state
-            // — Stripe doesn't guarantee `subscriptions.data` order. Same
-            // hardening as POST /api/admin/accounts/:orgId/sync (#3646).
-            const subscription = subscriptions
-              ? pickMembershipSub(subscriptions.data)
-              : null;
-            if (subscription) {
-              const subUpdate = buildSubscriptionUpdate(subscription as any, org.is_personal ?? false);
-
-              await pool.query(
-                `UPDATE organizations
-                 SET subscription_status = $1,
-                     subscription_amount = $2,
-                     subscription_interval = $3,
-                     subscription_currency = $4,
-                     subscription_current_period_end = $5,
-                     subscription_canceled_at = $6,
-                     stripe_subscription_id = $7,
-                     subscription_product_id = $8,
-                     subscription_product_name = COALESCE($9, subscription_product_name),
-                     subscription_price_id = $10,
-                     subscription_price_lookup_key = $11,
-                     membership_tier = $12,
-                     updated_at = NOW()
-                 WHERE workos_organization_id = $13`,
-                [
-                  subUpdate.subscription_status,
-                  subUpdate.subscription_amount,
-                  subUpdate.subscription_interval,
-                  subUpdate.subscription_currency,
-                  subUpdate.subscription_current_period_end,
-                  subUpdate.subscription_canceled_at,
-                  subUpdate.stripe_subscription_id,
-                  subUpdate.subscription_product_id,
-                  subUpdate.subscription_product_name,
-                  subUpdate.subscription_price_id,
-                  subUpdate.subscription_price_lookup_key,
-                  subUpdate.membership_tier,
-                  org_id,
-                ]
-              );
-              subscriptionSynced = true;
-              invalidateMembershipCache(org_id);
-            } else if (previousCustomerId) {
-              // Force-replace path with no membership sub on the new
-              // customer: clear the subscription state that came from the
-              // previous customer. Without this, the org keeps stale
-              // `subscription_status='active'` etc. derived from a
-              // customer it's no longer linked to.
-              await pool.query(
-                `UPDATE organizations SET
-                    stripe_subscription_id = NULL,
-                    subscription_status = NULL,
-                    subscription_amount = NULL,
-                    subscription_interval = NULL,
-                    subscription_current_period_end = NULL,
-                    subscription_canceled_at = NULL,
-                    subscription_product_id = NULL,
-                    subscription_product_name = NULL,
-                    subscription_price_id = NULL,
-                    subscription_price_lookup_key = NULL,
-                    membership_tier = NULL,
-                    updated_at = NOW()
-                 WHERE workos_organization_id = $1`,
-                [org_id],
-              );
-              invalidateMembershipCache(org_id);
+          for (const sub of subs.data) {
+            if (sub.metadata?.workos_organization_id) {
+              try {
+                await stripe.subscriptions.update(sub.id, {
+                  metadata: { workos_organization_id: '' },
+                });
+              } catch (subErr) {
+                logger.warn(
+                  { err: subErr, previousCustomerId, subscriptionId: sub.id },
+                  "Failed to clear workos_organization_id metadata on old Stripe subscription during replace",
+                );
+              }
             }
           }
-        } catch (syncError) {
-          subscriptionSyncError = syncError instanceof Error ? syncError.message : "Unknown error";
-          logger.warn({ err: syncError, customerId, org_id }, "Failed to sync subscription data during link");
+        } catch (listErr) {
+          logger.warn(
+            { err: listErr, previousCustomerId },
+            "Failed to list subscriptions during replace for metadata clear",
+          );
         }
       }
 
-      // Forensic record of the entitlement-affecting admin action. Mirrors
-      // the audit row written by the unlink path. Force-replace is the
-      // riskier branch — it changes which Stripe customer drives this org's
-      // entitlement.
-      const orgDb = new OrganizationDatabase();
-      await orgDb.recordAuditLog({
-        workos_organization_id: org_id,
-        workos_user_id: req.user?.id ?? 'unknown',
-        action: previousCustomerId ? 'admin_stripe_link_replace' : 'admin_stripe_link',
-        resource_type: 'subscription',
-        resource_id: customerId,
-        details: {
-          stripe_customer_id: customerId,
-          ...(previousCustomerId && { previous_customer_id: previousCustomerId }),
-          subscription_synced: subscriptionSynced,
-          ...(subscriptionSyncError && { subscription_sync_error: subscriptionSyncError }),
-          admin_email: req.user?.email,
-        },
-      }).catch((err) => {
-        logger.error(
-          { err, customerId, org_id },
-          `Failed to record ${previousCustomerId ? 'admin_stripe_link_replace' : 'admin_stripe_link'} audit log entry`,
-        );
-      });
+      // Sync invoices for this customer to local cache after the link/audit commit.
+      const invoicesSynced = await syncInvoicesForCustomer(customerId, org_id);
 
       logger.info(
-        { customerId, orgId: org_id, orgName: org.name, adminEmail: req.user?.email, invoicesSynced, subscriptionSynced, subscriptionSyncError },
+        { customerId, orgId: org_id, orgName: org.name, adminEmail: req.user?.email, invoicesSynced, subscriptionSynced },
         "Manually linked Stripe customer to org"
       );
 
@@ -887,7 +1023,6 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
         invoices_synced: invoicesSynced,
         subscription_synced: subscriptionSynced,
         ...(previousCustomerId && { previous_customer_id: previousCustomerId }),
-        ...(subscriptionSyncError && { subscription_sync_error: subscriptionSyncError }),
       });
     } catch (error) {
       logger.error({ err: error, customerId, org_id }, "Error linking Stripe customer");
@@ -898,7 +1033,7 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
   });
 
   // POST /api/admin/stripe-customers/:customerId/unlink - Unlink a Stripe customer from its org
-  apiRouter.post("/stripe-customers/:customerId/unlink", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.post("/stripe-customers/:customerId/unlink", ...requireGlobalAdmin, async (req, res) => {
     const { customerId } = req.params;
 
     if (!customerId || !customerId.startsWith("cus_")) {
@@ -1047,7 +1182,7 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
   });
 
   // GET /api/admin/org-search - Search organizations for linking
-  apiRouter.get("/org-search", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/org-search", ...requireGlobalAdmin, async (req, res) => {
     const rawQuery = req.query.q;
     const query = Array.isArray(rawQuery) ? String(rawQuery[0]) : String(rawQuery || '');
 
@@ -1080,7 +1215,7 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
   });
 
   // DELETE /api/admin/stripe-customers/:customerId - Delete an unlinked Stripe customer
-  apiRouter.delete("/stripe-customers/:customerId", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.delete("/stripe-customers/:customerId", ...requireGlobalAdmin, async (req, res) => {
     const { customerId } = req.params;
 
     if (!customerId || !customerId.startsWith("cus_")) {

--- a/server/tests/integration/admin-stripe-link-unlink.test.ts
+++ b/server/tests/integration/admin-stripe-link-unlink.test.ts
@@ -24,6 +24,13 @@ vi.mock('../../src/middleware/auth.js', async (importOriginal) => ({
     next();
   },
   requireAdmin: (_req: any, _res: any, next: any) => next(),
+  requireGlobalAdmin: [
+    (req: any, _res: any, next: any) => {
+      req.user = { id: 'user_test_admin', email: 'admin@test.com', is_admin: true };
+      next();
+    },
+    (_req: any, _res: any, next: any) => next(),
+  ],
 }));
 
 vi.mock('../../src/middleware/csrf.js', () => ({
@@ -148,6 +155,7 @@ describe('POST /api/admin/stripe-customers/:customerId/link + /unlink', () => {
   let pool: Pool;
   const TEST_ORG_ID = 'org_link_test_target';
   const ADMIN_USER_ID = 'user_test_admin';
+  const LINK_REASON = 'correcting wrong Stripe customer link';
 
   beforeAll(async () => {
     pool = initializeDatabase({
@@ -176,6 +184,13 @@ describe('POST /api/admin/stripe-customers/:customerId/link + /unlink', () => {
          stripe_customer_id = NULL,
          subscription_status = NULL,
          subscription_amount = NULL,
+         subscription_currency = NULL,
+         subscription_interval = NULL,
+         subscription_current_period_end = NULL,
+         subscription_canceled_at = NULL,
+         subscription_product_id = NULL,
+         subscription_product_name = NULL,
+         subscription_price_id = NULL,
          subscription_price_lookup_key = NULL,
          stripe_subscription_id = NULL,
          membership_tier = NULL`,
@@ -191,12 +206,23 @@ describe('POST /api/admin/stripe-customers/:customerId/link + /unlink', () => {
   });
 
   describe('link', () => {
+    it('requires an audit reason before looking up the org or Stripe customer', async () => {
+      const response = await request(app)
+        .post(`/api/admin/stripe-customers/${mocks.multiSubCustomer.id}/link`)
+        .send({ org_id: TEST_ORG_ID, reason: 'too short' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('Reason required');
+      expect(mocks.mockCustomersRetrieve).not.toHaveBeenCalled();
+    });
+
     it('picks the membership sub when customer has multi-sub (data[0] regression)', async () => {
       mocks.mockCustomersRetrieve.mockResolvedValueOnce(mocks.multiSubCustomer);
+      mocks.mockSubscriptionsList.mockResolvedValueOnce({ data: mocks.multiSubCustomer.subscriptions.data });
 
       const response = await request(app)
         .post(`/api/admin/stripe-customers/${mocks.multiSubCustomer.id}/link`)
-        .send({ org_id: TEST_ORG_ID });
+        .send({ org_id: TEST_ORG_ID, reason: LINK_REASON });
 
       expect(response.status).toBe(200);
       expect(response.body.subscription_synced).toBe(true);
@@ -218,10 +244,11 @@ describe('POST /api/admin/stripe-customers/:customerId/link + /unlink', () => {
 
     it('writes admin_stripe_link audit log entry', async () => {
       mocks.mockCustomersRetrieve.mockResolvedValueOnce(mocks.multiSubCustomer);
+      mocks.mockSubscriptionsList.mockResolvedValueOnce({ data: mocks.multiSubCustomer.subscriptions.data });
 
       await request(app)
         .post(`/api/admin/stripe-customers/${mocks.multiSubCustomer.id}/link`)
-        .send({ org_id: TEST_ORG_ID });
+        .send({ org_id: TEST_ORG_ID, reason: LINK_REASON });
 
       const audit = await pool.query<{ action: string; resource_id: string; details: any }>(
         `SELECT action, resource_id, details FROM registry_audit_log
@@ -231,6 +258,160 @@ describe('POST /api/admin/stripe-customers/:customerId/link + /unlink', () => {
       expect(audit.rows[0]?.action).toBe('admin_stripe_link');
       expect(audit.rows[0]?.resource_id).toBe(mocks.multiSubCustomer.id);
       expect(audit.rows[0]?.details?.admin_email).toBe('admin@test.com');
+      expect(audit.rows[0]?.details?.reason).toBe(LINK_REASON);
+      expect(audit.rows[0]?.details?.before_state?.stripe_customer_id).toBeNull();
+      expect(audit.rows[0]?.details?.after_state?.stripe_customer_id).toBe(mocks.multiSubCustomer.id);
+    });
+
+    it('force-replace clears stale state and old Stripe metadata fallback paths', async () => {
+      await pool.query(
+        `UPDATE organizations SET
+            stripe_customer_id = 'cus_link_test_previous',
+            stripe_subscription_id = 'sub_prior',
+            subscription_status = 'active',
+            subscription_amount = 25000,
+            subscription_currency = 'usd',
+            subscription_interval = 'year',
+            subscription_price_lookup_key = 'aao_membership_professional_250',
+            membership_tier = 'individual_professional'
+         WHERE workos_organization_id = $1`,
+        [TEST_ORG_ID],
+      );
+      mocks.mockCustomersRetrieve.mockResolvedValueOnce(mocks.nonMembershipCustomer);
+      mocks.mockSubscriptionsList
+        .mockResolvedValueOnce({ data: mocks.nonMembershipCustomer.subscriptions.data })
+        .mockResolvedValueOnce({
+          data: [
+            { id: 'sub_old_meta', metadata: { workos_organization_id: TEST_ORG_ID } },
+            { id: 'sub_old_no_meta', metadata: {} },
+          ],
+        });
+
+      const response = await request(app)
+        .post(`/api/admin/stripe-customers/${mocks.nonMembershipCustomer.id}/link`)
+        .send({ org_id: TEST_ORG_ID, force: true, reason: LINK_REASON });
+
+      expect(response.status).toBe(200);
+      expect(response.body.previous_customer_id).toBe('cus_link_test_previous');
+      expect(response.body.subscription_synced).toBe(false);
+
+      const orgRow = await pool.query<{
+        stripe_customer_id: string | null;
+        stripe_subscription_id: string | null;
+        subscription_status: string | null;
+        subscription_amount: number | null;
+        subscription_currency: string | null;
+        subscription_price_lookup_key: string | null;
+        membership_tier: string | null;
+      }>(
+        `SELECT stripe_customer_id, stripe_subscription_id, subscription_status,
+                subscription_amount, subscription_currency, subscription_price_lookup_key,
+                membership_tier
+           FROM organizations WHERE workos_organization_id = $1`,
+        [TEST_ORG_ID],
+      );
+      expect(orgRow.rows[0]).toMatchObject({
+        stripe_customer_id: mocks.nonMembershipCustomer.id,
+        stripe_subscription_id: null,
+        subscription_status: null,
+        subscription_amount: null,
+        subscription_currency: null,
+        subscription_price_lookup_key: null,
+        membership_tier: null,
+      });
+
+      expect(mocks.mockCustomersUpdate).toHaveBeenCalledWith(mocks.nonMembershipCustomer.id, {
+        metadata: { workos_organization_id: TEST_ORG_ID },
+      });
+      expect(mocks.mockCustomersUpdate).toHaveBeenCalledWith('cus_link_test_previous', {
+        metadata: { workos_organization_id: '' },
+      });
+      expect(mocks.mockSubscriptionsList).toHaveBeenCalledWith({
+        customer: 'cus_link_test_previous',
+        status: 'all',
+        limit: 100,
+      });
+      expect(mocks.mockSubscriptionsUpdate).toHaveBeenCalledWith('sub_old_meta', {
+        metadata: { workos_organization_id: '' },
+      });
+      expect(mocks.mockSubscriptionsUpdate).not.toHaveBeenCalledWith('sub_old_no_meta', expect.anything());
+
+      const audit = await pool.query<{ action: string; details: any }>(
+        `SELECT action, details FROM registry_audit_log
+          WHERE workos_organization_id = $1 ORDER BY created_at DESC LIMIT 1`,
+        [TEST_ORG_ID],
+      );
+      expect(audit.rows[0]?.action).toBe('admin_stripe_link_replace');
+      expect(audit.rows[0]?.details?.previous_customer_id).toBe('cus_link_test_previous');
+      expect(audit.rows[0]?.details?.reason).toBe(LINK_REASON);
+      expect(audit.rows[0]?.details?.before_state?.stripe_customer_id).toBe('cus_link_test_previous');
+      expect(audit.rows[0]?.details?.after_state?.stripe_subscription_id).toBeNull();
+    });
+
+    it('refuses to link a deleted Stripe customer before writing the org row', async () => {
+      mocks.mockCustomersRetrieve.mockResolvedValueOnce({
+        id: 'cus_link_test_deleted',
+        deleted: true,
+      });
+
+      const response = await request(app)
+        .post('/api/admin/stripe-customers/cus_link_test_deleted/link')
+        .send({ org_id: TEST_ORG_ID, reason: LINK_REASON });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('Stripe customer deleted');
+
+      const orgRow = await pool.query<{ stripe_customer_id: string | null }>(
+        `SELECT stripe_customer_id FROM organizations WHERE workos_organization_id = $1`,
+        [TEST_ORG_ID],
+      );
+      expect(orgRow.rows[0].stripe_customer_id).toBeNull();
+    });
+
+    it('blocks live Stripe subscriptions associated with another org', async () => {
+      mocks.mockCustomersRetrieve.mockResolvedValueOnce({
+        id: 'cus_link_test_conflict',
+        deleted: false,
+        metadata: { workos_organization_id: 'org_other_owner' },
+        subscriptions: {
+          data: [
+            {
+              id: 'sub_other_owner',
+              status: 'active',
+              metadata: { workos_organization_id: 'org_other_owner' },
+              current_period_end: Math.floor(Date.now() / 1000) + 86400 * 30,
+              canceled_at: null,
+              items: { data: [] },
+            },
+          ],
+        },
+      });
+      mocks.mockSubscriptionsList.mockResolvedValueOnce({
+        data: [
+          {
+            id: 'sub_other_owner',
+            status: 'active',
+            metadata: { workos_organization_id: 'org_other_owner' },
+            current_period_end: Math.floor(Date.now() / 1000) + 86400 * 30,
+            canceled_at: null,
+            items: { data: [] },
+          },
+        ],
+      });
+
+      const response = await request(app)
+        .post('/api/admin/stripe-customers/cus_link_test_conflict/link')
+        .send({ org_id: TEST_ORG_ID, reason: LINK_REASON });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('Stripe customer belongs to another organization');
+      expect(response.body.conflicting_org_ids).toEqual(['org_other_owner']);
+
+      const orgRow = await pool.query<{ stripe_customer_id: string | null }>(
+        `SELECT stripe_customer_id FROM organizations WHERE workos_organization_id = $1`,
+        [TEST_ORG_ID],
+      );
+      expect(orgRow.rows[0].stripe_customer_id).toBeNull();
     });
   });
 

--- a/server/tests/unit/admin-stripe-customer-link.test.ts
+++ b/server/tests/unit/admin-stripe-customer-link.test.ts
@@ -1,0 +1,477 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+const {
+  mockPoolQuery,
+  mockPoolConnect,
+  mockCustomersRetrieve,
+  mockCustomersUpdate,
+  mockSubscriptionsList,
+  mockSubscriptionsUpdate,
+  mockInvoicesList,
+  mockProductsRetrieve,
+  mockInvalidateMembershipCache,
+  stripeMockState,
+} = vi.hoisted(() => ({
+  mockPoolQuery: vi.fn<any>(),
+  mockPoolConnect: vi.fn<any>(),
+  mockCustomersRetrieve: vi.fn<any>(),
+  mockCustomersUpdate: vi.fn<any>(),
+  mockSubscriptionsList: vi.fn<any>(),
+  mockSubscriptionsUpdate: vi.fn<any>(),
+  mockInvoicesList: vi.fn<any>(),
+  mockProductsRetrieve: vi.fn<any>(),
+  mockInvalidateMembershipCache: vi.fn<any>(),
+  stripeMockState: { configured: true } as { configured: boolean },
+}));
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  requireAuth: (req: any, _res: any, next: any) => {
+    req.user = { id: 'user_admin_01', email: 'admin@test', is_admin: true };
+    next();
+  },
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+  requireGlobalAdmin: [
+    (req: any, _res: any, next: any) => {
+      req.user = { id: 'user_admin_01', email: 'admin@test', is_admin: true };
+      next();
+    },
+    (_req: any, _res: any, next: any) => next(),
+  ],
+}));
+
+vi.mock('../../src/db/client.js', () => ({
+  getPool: () => ({
+    query: (...args: unknown[]) => mockPoolQuery(...args),
+    connect: () => mockPoolConnect(),
+  }),
+}));
+
+vi.mock('../../src/db/org-filters.js', () => ({
+  invalidateMembershipCache: (...args: unknown[]) => mockInvalidateMembershipCache(...args),
+}));
+
+vi.mock('../../src/billing/stripe-client.js', () => ({
+  get stripe() {
+    if (!stripeMockState.configured) return null;
+    return {
+      customers: {
+        retrieve: (...args: unknown[]) => mockCustomersRetrieve(...args),
+        update: (...args: unknown[]) => mockCustomersUpdate(...args),
+      },
+      subscriptions: {
+        list: (...args: unknown[]) => mockSubscriptionsList(...args),
+        update: (...args: unknown[]) => mockSubscriptionsUpdate(...args),
+      },
+      invoices: {
+        list: (...args: unknown[]) => mockInvoicesList(...args),
+      },
+      products: {
+        retrieve: (...args: unknown[]) => mockProductsRetrieve(...args),
+      },
+    };
+  },
+  getBillingProducts: vi.fn(),
+  getProductsForCustomer: vi.fn(),
+  createProduct: vi.fn(),
+  updateProductMetadata: vi.fn(),
+  archiveProduct: vi.fn(),
+  clearProductsCache: vi.fn(),
+  getPendingInvoices: vi.fn(),
+  voidInvoice: vi.fn(),
+  deleteDraftInvoice: vi.fn(),
+}));
+
+const ORG_ID = 'org_link_target';
+const CUSTOMER_ID = 'cus_link_target';
+const LINK_REASON = 'correcting wrong Stripe customer link';
+
+function makeOrgRow(overrides: Record<string, unknown> = {}) {
+  return {
+    workos_organization_id: ORG_ID,
+    name: 'Link Target Org',
+    stripe_customer_id: null,
+    is_personal: false,
+    subscription_status: null,
+    stripe_subscription_id: null,
+    subscription_amount: null,
+    subscription_currency: null,
+    subscription_interval: null,
+    subscription_current_period_end: null,
+    subscription_canceled_at: null,
+    subscription_product_id: null,
+    subscription_product_name: null,
+    subscription_price_id: null,
+    subscription_price_lookup_key: null,
+    membership_tier: null,
+    ...overrides,
+  };
+}
+
+function makeMembershipCustomer(overrides: Record<string, unknown> = {}) {
+  return {
+    id: CUSTOMER_ID,
+    deleted: false,
+    metadata: { workos_organization_id: ORG_ID },
+    subscriptions: {
+      data: [
+        {
+          id: 'sub_member_01',
+          status: 'active',
+          metadata: { workos_organization_id: ORG_ID },
+          current_period_end: 1_800_000_000,
+          canceled_at: null,
+          items: {
+            data: [{
+              price: {
+                id: 'price_member_01',
+                product: { id: 'prod_member_01', name: 'Professional', metadata: { category: 'membership' } },
+                unit_amount: 25000,
+                currency: 'usd',
+                recurring: { interval: 'year' },
+                lookup_key: 'aao_membership_professional_250',
+              },
+            }],
+          },
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+function makeTxClient(opts?: { failOn?: 'UPDATE' | 'INSERT' }) {
+  const calls: Array<{ sql: string; params?: unknown[] }> = [];
+  const query = vi.fn(async (sql: string, params?: unknown[]) => {
+    const trimmed = sql.trim();
+    calls.push({ sql: trimmed, params });
+    if (opts?.failOn === 'UPDATE' && trimmed.startsWith('UPDATE organizations')) {
+      throw new Error('UPDATE failed');
+    }
+    if (opts?.failOn === 'INSERT' && trimmed.startsWith('INSERT INTO registry_audit_log')) {
+      throw new Error('audit INSERT failed');
+    }
+    return { rows: [], rowCount: 0 };
+  });
+  const release = vi.fn();
+  return { client: { query, release }, calls, query, release };
+}
+
+async function buildApp() {
+  const { createBillingRouter } = await import('../../src/routes/billing.js');
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin', createBillingRouter().apiRouter);
+  return app;
+}
+
+describe('POST /api/admin/stripe-customers/:customerId/link', () => {
+  beforeEach(() => {
+    mockPoolQuery.mockReset();
+    mockPoolConnect.mockReset();
+    mockCustomersRetrieve.mockReset();
+    mockCustomersUpdate.mockReset();
+    mockSubscriptionsList.mockReset();
+    mockSubscriptionsUpdate.mockReset();
+    mockInvoicesList.mockReset();
+    mockProductsRetrieve.mockReset();
+    mockInvalidateMembershipCache.mockReset();
+    stripeMockState.configured = true;
+    mockSubscriptionsList.mockResolvedValue({ data: [] });
+    mockInvoicesList.mockResolvedValue({ data: [] });
+  });
+
+  it('requires a reason before database or Stripe work', async () => {
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/stripe-customers/${CUSTOMER_ID}/link`)
+      .send({ org_id: ORG_ID, reason: 'too short' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Reason required');
+    expect(mockPoolQuery).not.toHaveBeenCalled();
+    expect(mockCustomersRetrieve).not.toHaveBeenCalled();
+  });
+
+  it('requires Stripe configuration before database work', async () => {
+    stripeMockState.configured = false;
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/stripe-customers/${CUSTOMER_ID}/link`)
+      .send({ org_id: ORG_ID, reason: LINK_REASON });
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe('Stripe not configured');
+    expect(mockPoolQuery).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for missing Stripe customers before opening a transaction', async () => {
+    mockPoolQuery
+      .mockResolvedValueOnce({ rows: [makeOrgRow()] })
+      .mockResolvedValueOnce({ rows: [] });
+    mockCustomersRetrieve.mockRejectedValueOnce(Object.assign(new Error('No such customer'), {
+      code: 'resource_missing',
+      statusCode: 404,
+    }));
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/stripe-customers/${CUSTOMER_ID}/link`)
+      .send({ org_id: ORG_ID, reason: LINK_REASON });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Stripe customer not found');
+    expect(mockPoolConnect).not.toHaveBeenCalled();
+  });
+
+  it('validates Stripe, updates the org, and records audit details in one transaction', async () => {
+    mockPoolQuery
+      .mockResolvedValueOnce({ rows: [makeOrgRow()] })
+      .mockResolvedValueOnce({ rows: [] });
+    const customer = makeMembershipCustomer();
+    mockCustomersRetrieve.mockResolvedValueOnce(customer);
+    mockSubscriptionsList.mockResolvedValueOnce({ data: (customer as any).subscriptions.data });
+    const tx = makeTxClient();
+    mockPoolConnect.mockResolvedValueOnce(tx.client);
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/stripe-customers/${CUSTOMER_ID}/link`)
+      .send({ org_id: ORG_ID, reason: LINK_REASON });
+
+    expect(res.status).toBe(200);
+    expect(mockCustomersRetrieve).toHaveBeenCalledWith(CUSTOMER_ID);
+    expect(mockSubscriptionsList).toHaveBeenCalledWith({
+      customer: CUSTOMER_ID,
+      status: 'all',
+      limit: 100,
+    });
+    expect(tx.calls[0].sql).toBe('BEGIN');
+    expect(tx.calls[tx.calls.length - 1].sql).toBe('COMMIT');
+
+    const orgUpdate = tx.calls.find((call) =>
+      call.sql.startsWith('UPDATE organizations SET stripe_customer_id'),
+    );
+    expect(orgUpdate?.params).toEqual([CUSTOMER_ID, ORG_ID]);
+
+    const auditInsert = tx.calls.find((call) =>
+      call.sql.startsWith('INSERT INTO registry_audit_log'),
+    );
+    expect(auditInsert).toBeTruthy();
+    expect(auditInsert?.params?.slice(0, 5)).toEqual([
+      ORG_ID,
+      'user_admin_01',
+      'admin_stripe_link',
+      'subscription',
+      CUSTOMER_ID,
+    ]);
+    const auditDetails = JSON.parse(String(auditInsert?.params?.[5]));
+    expect(auditDetails.reason).toBe(LINK_REASON);
+    expect(auditDetails.admin_email).toBe('admin@test');
+    expect(auditDetails.before_state.stripe_customer_id).toBeNull();
+    expect(auditDetails.after_state.stripe_customer_id).toBe(CUSTOMER_ID);
+    expect(auditDetails.after_state.stripe_subscription_id).toBe('sub_member_01');
+    expect(mockCustomersUpdate).toHaveBeenCalledWith(CUSTOMER_ID, {
+      metadata: { workos_organization_id: ORG_ID },
+    });
+    expect(mockInvalidateMembershipCache).toHaveBeenCalledWith(ORG_ID);
+  });
+
+  it('repairs stale target-customer metadata when live subscriptions do not belong to another org', async () => {
+    mockPoolQuery
+      .mockResolvedValueOnce({ rows: [makeOrgRow()] })
+      .mockResolvedValueOnce({ rows: [] });
+    const customer = makeMembershipCustomer({
+      metadata: { workos_organization_id: 'org_stale_metadata' },
+      subscriptions: {
+        data: [{
+          id: 'sub_no_org_metadata',
+          status: 'active',
+          metadata: {},
+          current_period_end: 1_800_000_000,
+          canceled_at: null,
+          items: {
+            data: [{
+              price: {
+                id: 'price_member_01',
+                product: { id: 'prod_member_01', name: 'Professional', metadata: { category: 'membership' } },
+                unit_amount: 25000,
+                currency: 'usd',
+                recurring: { interval: 'year' },
+                lookup_key: 'aao_membership_professional_250',
+              },
+            }],
+          },
+        }],
+      },
+    });
+    mockCustomersRetrieve.mockResolvedValueOnce(customer);
+    mockSubscriptionsList.mockResolvedValueOnce({ data: (customer as any).subscriptions.data });
+    const tx = makeTxClient();
+    mockPoolConnect.mockResolvedValueOnce(tx.client);
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/stripe-customers/${CUSTOMER_ID}/link`)
+      .send({ org_id: ORG_ID, reason: LINK_REASON });
+
+    expect(res.status).toBe(200);
+    expect(mockCustomersUpdate).toHaveBeenCalledWith(CUSTOMER_ID, {
+      metadata: { workos_organization_id: ORG_ID },
+    });
+  });
+
+  it('force-replaces an existing link, clears stale subscription state, and audits the replacement', async () => {
+    const previousCustomerId = 'cus_previous_link';
+    mockPoolQuery
+      .mockResolvedValueOnce({
+        rows: [makeOrgRow({
+          stripe_customer_id: previousCustomerId,
+          subscription_status: 'active',
+          stripe_subscription_id: 'sub_previous',
+          subscription_amount: 25000,
+          subscription_currency: 'usd',
+          subscription_interval: 'year',
+          subscription_price_lookup_key: 'aao_membership_professional_250',
+          membership_tier: 'individual_professional',
+        })],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+    const customer = makeMembershipCustomer({
+      subscriptions: {
+        data: [{
+          id: 'sub_event_only',
+          status: 'active',
+          metadata: { workos_organization_id: ORG_ID },
+          current_period_end: 1_800_000_000,
+          canceled_at: null,
+          items: {
+            data: [{
+              price: {
+                id: 'price_event_only',
+                product: { id: 'prod_event_only', name: 'Event Ticket', metadata: { category: 'event' } },
+                unit_amount: 5000,
+                currency: 'usd',
+                recurring: { interval: 'year' },
+                lookup_key: 'aao_event_ticket_2026',
+              },
+            }],
+          },
+        }],
+      },
+    });
+    mockCustomersRetrieve.mockResolvedValueOnce(customer);
+    mockSubscriptionsList
+      .mockResolvedValueOnce({ data: (customer as any).subscriptions.data })
+      .mockResolvedValueOnce({
+        data: [
+          { id: 'sub_previous_keep_clear', metadata: { workos_organization_id: ORG_ID } },
+          { id: 'sub_previous_no_org_meta', metadata: {} },
+        ],
+      });
+    const tx = makeTxClient();
+    mockPoolConnect.mockResolvedValueOnce(tx.client);
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/stripe-customers/${CUSTOMER_ID}/link`)
+      .send({ org_id: ORG_ID, force: true, reason: LINK_REASON });
+
+    expect(res.status).toBe(200);
+    expect(res.body.previous_customer_id).toBe(previousCustomerId);
+
+    const clearState = tx.calls.find((call) =>
+      call.sql.startsWith('UPDATE organizations SET') &&
+      call.sql.includes('stripe_subscription_id = NULL') &&
+      call.sql.includes('subscription_currency = NULL'),
+    );
+    expect(clearState?.params).toEqual([ORG_ID]);
+
+    const auditInsert = tx.calls.find((call) =>
+      call.sql.startsWith('INSERT INTO registry_audit_log'),
+    );
+    expect(auditInsert?.params?.[2]).toBe('admin_stripe_link_replace');
+    const auditDetails = JSON.parse(String(auditInsert?.params?.[5]));
+    expect(auditDetails.previous_customer_id).toBe(previousCustomerId);
+    expect(auditDetails.before_state.stripe_customer_id).toBe(previousCustomerId);
+    expect(auditDetails.after_state.stripe_customer_id).toBe(CUSTOMER_ID);
+    expect(auditDetails.after_state.stripe_subscription_id).toBeNull();
+
+    expect(mockCustomersUpdate).toHaveBeenCalledWith(previousCustomerId, {
+      metadata: { workos_organization_id: '' },
+    });
+    expect(mockSubscriptionsList).toHaveBeenCalledWith({
+      customer: CUSTOMER_ID,
+      status: 'all',
+      limit: 100,
+    });
+    expect(mockSubscriptionsList).toHaveBeenCalledWith({
+      customer: previousCustomerId,
+      status: 'all',
+      limit: 100,
+    });
+    expect(mockSubscriptionsUpdate).toHaveBeenCalledWith('sub_previous_keep_clear', {
+      metadata: { workos_organization_id: '' },
+    });
+    expect(mockSubscriptionsUpdate).not.toHaveBeenCalledWith('sub_previous_no_org_meta', expect.anything());
+    expect(mockCustomersUpdate).toHaveBeenCalledWith(CUSTOMER_ID, {
+      metadata: { workos_organization_id: ORG_ID },
+    });
+    expect(mockInvalidateMembershipCache).toHaveBeenCalledWith(ORG_ID);
+  });
+
+  it('rolls back the org update if the audit insert fails', async () => {
+    mockPoolQuery
+      .mockResolvedValueOnce({ rows: [makeOrgRow()] })
+      .mockResolvedValueOnce({ rows: [] });
+    const customer = makeMembershipCustomer();
+    mockCustomersRetrieve.mockResolvedValueOnce(customer);
+    mockSubscriptionsList.mockResolvedValueOnce({ data: (customer as any).subscriptions.data });
+    const tx = makeTxClient({ failOn: 'INSERT' });
+    mockPoolConnect.mockResolvedValueOnce(tx.client);
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/stripe-customers/${CUSTOMER_ID}/link`)
+      .send({ org_id: ORG_ID, reason: LINK_REASON });
+
+    expect(res.status).toBe(500);
+    expect(tx.calls.map((call) => call.sql)).toContain('ROLLBACK');
+    expect(tx.calls.map((call) => call.sql)).not.toContain('COMMIT');
+    expect(tx.release).toHaveBeenCalled();
+  });
+
+  it('blocks live Stripe subscriptions associated with another organization before opening a transaction', async () => {
+    mockPoolQuery
+      .mockResolvedValueOnce({ rows: [makeOrgRow()] })
+      .mockResolvedValueOnce({ rows: [] });
+    const customer = makeMembershipCustomer({
+      metadata: { workos_organization_id: 'org_other_owner' },
+      subscriptions: {
+        data: [{
+          id: 'sub_other_owner',
+          status: 'active',
+          metadata: { workos_organization_id: 'org_other_owner' },
+          current_period_end: 1_800_000_000,
+          canceled_at: null,
+          items: { data: [] },
+        }],
+      },
+    });
+    mockCustomersRetrieve.mockResolvedValueOnce(customer);
+    mockSubscriptionsList.mockResolvedValueOnce({ data: (customer as any).subscriptions.data });
+    const app = await buildApp();
+
+    const res = await request(app)
+      .post(`/api/admin/stripe-customers/${CUSTOMER_ID}/link`)
+      .send({ org_id: ORG_ID, reason: LINK_REASON });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Stripe customer belongs to another organization');
+    expect(res.body.conflicting_org_ids).toEqual(['org_other_owner']);
+    expect(mockPoolConnect).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #5113.

- Requires a human audit reason before linking or replacing an org's Stripe customer ID.
- Validates the Stripe customer and lists all Stripe subscriptions before writing local billing state.
- Writes the org update and registry audit row in one transaction, with before/after state and admin identity.
- Clears stale metadata from the previous Stripe customer and its subscriptions on force-replace, and stamps the new customer metadata to the selected org.
- Tightens global Stripe customer admin routes to the `requireGlobalAdmin` chain so tenant-scoped WorkOS API keys cannot operate on cross-org billing surfaces.
- Updates the admin billing UI to collect the required reason.

## Root Cause

The existing admin link route could replace `organizations.stripe_customer_id`, but it did not require an operator reason, did not validate the target Stripe customer before writing, and wrote audit information outside the state update transaction. Force-replace also left stale Stripe metadata paths that could allow later webhooks to reattach the old customer.

## Expert Review

Ran code, security, and Node testing expert passes. Addressed blockers from review:

- Added force-replace coverage for stale subscription-state clearing and old subscription metadata cleanup.
- Cleared old customer subscription metadata to close the webhook re-link fallback.
- Stamped new customer metadata while allowing stale target customer metadata to be repaired.
- Switched target subscription validation to `stripe.subscriptions.list` instead of relying on the embedded customer subscription page.
- Moved global Stripe customer admin routes to `requireGlobalAdmin`.

## Validation

- `npx vitest run server/tests/unit/admin-stripe-customer-link.test.ts --config server/vitest.config.ts`
- `DATABASE_URL=postgresql://adcp:localdev@localhost:53198/adcp_test npx vitest run server/tests/integration/admin-stripe-link-unlink.test.ts --config server/vitest.config.ts` using a local Docker Postgres 16 container: 10 tests passed.
- `npm run typecheck`
- precommit hook passed: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run typecheck`
