### PR TITLE
Send MCP Accept header on validation preflight

### DIFF
--- a/.changeset/5110-mcp-accept-header.md
+++ b/.changeset/5110-mcp-accept-header.md
@@ -1,0 +1,4 @@
+---
+---
+
+registry: send the MCP streamable HTTP Accept header during agent validation preflight (#5110)

--- a/server/src/adagents-manager.ts
+++ b/server/src/adagents-manager.ts
@@ -3,6 +3,18 @@ import { AAO_UA_VALIDATOR } from './config/user-agents.js';
 import { safeFetchAxiosLike, classifySafeFetchError } from './utils/url-security.js';
 import { canonicalizePublisherDomain } from './services/publisher-domain.js';
 
+const MCP_ACCEPT_HEADER = 'application/json, text/event-stream';
+const MCP_PREFLIGHT_INITIALIZE_BODY = {
+  jsonrpc: '2.0',
+  method: 'initialize',
+  params: {
+    protocolVersion: '2025-03-26',
+    capabilities: {},
+    clientInfo: { name: 'AAO Registry Validator', version: '1.0.0' },
+  },
+  id: 1,
+};
+
 function isManagerdomainFallbackEligibleResponse(status: number, data: unknown): boolean {
   if (status === 404) return true;
   if (status !== 403) return false;
@@ -1674,8 +1686,11 @@ export class AdAgentsManager {
       const preflightResponse = await safeFetchAxiosLike(agentUrl, {
         method: 'POST',
         timeoutMs: 3000,
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', params: {}, id: 1 }),
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: MCP_ACCEPT_HEADER,
+        },
+        body: JSON.stringify(MCP_PREFLIGHT_INITIALIZE_BODY),
       });
 
       if (preflightResponse.status === 401) {

--- a/server/tests/unit/adagents-manager.test.ts
+++ b/server/tests/unit/adagents-manager.test.ts
@@ -1693,11 +1693,57 @@ describe('AdAgentsManager', () => {
       // This test validates that combined error reporting works when both A2A and MCP fail.
       const results = await manager.validateAgentCards(agents);
 
+      const postCall = mockedSafeFetch.mock.calls.find(([, opts]) => opts?.method === 'POST');
+      expect(postCall).toBeDefined();
+      expect(postCall?.[1]?.headers).toMatchObject({
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      });
+      expect(JSON.parse(String(postCall?.[1]?.body))).toMatchObject({
+        jsonrpc: '2.0',
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'AAO Registry Validator', version: '1.0.0' },
+        },
+        id: 1,
+      });
+
       // With the real @adcp/sdk unable to connect, MCP validation will fail
       // and the result captures errors from both protocols
       expect(results[0].valid).toBe(false);
       expect(results[0].errors.some((e) => e.includes('A2A') || e.includes('agent card'))).toBe(true);
       expect(results[0].errors.some((e) => e.includes('MCP'))).toBe(true);
+    });
+
+    it('marks MCP agents as auth-required when the preflight returns 401', async () => {
+      const agents: AuthorizedAgent[] = [
+        {
+          url: 'https://private-mcp.example.com/mcp',
+          authorized_for: 'Test',
+        },
+      ];
+
+      mockedSafeFetch.mockImplementation(async (_url, opts) => {
+        if (opts?.method === 'POST') {
+          return {
+            status: 401,
+            data: buf({ error: 'unauthorized' }),
+            headers: { 'content-type': 'application/json' },
+          };
+        }
+        return { status: 404, data: buf({}), headers: {} };
+      });
+
+      const results = await manager.validateAgentCards(agents);
+
+      expect(results[0].valid).toBe(true);
+      expect(results[0].oauth_required).toBe(true);
+      expect(results[0].card_data).toMatchObject({
+        protocol: 'mcp',
+        requires_auth: true,
+      });
     });
 
     it('returns combined errors when both A2A and MCP fail', async () => {


### PR DESCRIPTION
## Summary

Adds the required `Accept: application/json, text/event-stream` header to the registry MCP validation preflight, and makes that preflight send a spec-shaped `initialize` request. This keeps strict MCP Streamable HTTP servers from rejecting the preflight before auth detection, so 401 responses can still set `oauth_required` correctly.

Closes #5110.

## Validation

Ran focused `adagents-manager` unit coverage, typecheck, and the full precommit hook.