### PR TITLE
Fix explicit compliance target badge eligibility

### DIFF
--- a/.changeset/5145-explicit-compliance-target-badges.md
+++ b/.changeset/5145-explicit-compliance-target-badges.md
@@ -1,0 +1,4 @@
+---
+---
+
+Empty changeset: server compliance behavior only. Owner-triggered quality evaluations now update public compliance state and badges when the explicit compliance target is a badge-eligible stable line advertised by the agent, instead of treating every non-default target as diagnostic-only.

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -3729,7 +3729,7 @@ export function createMemberToolHandlers(
     const agentUrl = input.agent_url as string;
     const tracks = input.tracks as ComplianceTrack[] | undefined;
     const runTarget = targetFromInput(input);
-    let skippedCanonicalWriteForTarget = false;
+    let skippedCanonicalWriteReason: 'target' | 'tracks' | null = null;
 
     const urlError = validateAgentUrl(agentUrl);
     if (urlError) return `**Error:** ${urlError}`;
@@ -3870,9 +3870,9 @@ export function createMemberToolHandlers(
             logger.warn({ error, agentUrl: resolved.resolvedUrl }, 'Could not write owner test result to canonical compliance state');
           }
         } else if (isAgentOwner && writesCanonicalComplianceState && tracks) {
-          skippedCanonicalWriteForTarget = true;
+          skippedCanonicalWriteReason = 'tracks';
         } else if (isAgentOwner) {
-          skippedCanonicalWriteForTarget = true;
+          skippedCanonicalWriteReason = 'target';
         }
 
         // Legacy write to agent_contexts + agent_test_history. Retained ONLY
@@ -3923,7 +3923,9 @@ export function createMemberToolHandlers(
       output += `## Quality Evaluation: ${safeName || resolved.resolvedUrl}\n\n`;
       output += `**Agent:** ${resolved.resolvedUrl}\n`;
       output += `**Compliance target:** ${formatComplianceTarget(runTarget, result.adcp_version ?? runTarget.version, { includeBadgeEligibility: true })}\n`;
-      if (skippedCanonicalWriteForTarget) {
+      if (skippedCanonicalWriteReason === 'tracks') {
+        output += `_Track-filtered evaluations are diagnostic slices; public compliance status and badges were not updated._\n`;
+      } else if (skippedCanonicalWriteReason === 'target') {
         output += `_This compliance target is diagnostic only for this agent; public compliance status and badges were not updated._\n`;
       }
       const safeTools = (result.agent_profile.tools || []).map(t => sanitizeAgentField(t, 80)).filter(Boolean);

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -65,6 +65,7 @@ import {
   withHostedTestOptions,
   isDefaultHostedComplianceTarget,
   badgeEligibleVersionsForHostedComplianceTarget,
+  agentAdvertisesBadgeEligibleHostedComplianceTarget,
 } from '../../services/hosted-compliance-version.js';
 import { AgentContextDatabase, validateAuthTokenChars, type OAuthClientCredentials } from '../../db/agent-context-db.js';
 import { buildAgentOAuthAuthorizeUrl, isOAuthRequiredError } from '../../routes/helpers/agent-oauth-prompt.js';
@@ -1142,7 +1143,7 @@ export const MEMBER_TOOLS: AddieTool[] = [
       properties: {
         agent_url: { type: 'string', description: 'Agent URL to evaluate' },
         tracks: { type: 'array', items: { type: 'string', enum: ['core', 'products', 'media_buy', 'creative', 'reporting', 'governance', 'signals', 'si', 'audiences'] }, description: 'Specific compliance tracks to run (default: all applicable, driven by the agent\'s get_adcp_capabilities response)' },
-        compliance_target: { type: 'string', description: 'Compliance target to run, e.g. "3.0" for the badge-eligible default line or "3.1-beta" for an explicit beta diagnostic run. Defaults to 3.0.' },
+        compliance_target: { type: 'string', description: 'Compliance target to run, e.g. "3.0" for a badge-eligible stable line or "3.1-beta" for an explicit beta diagnostic run. Defaults to 3.0.' },
       },
       required: ['agent_url'],
     },
@@ -3728,7 +3729,6 @@ export function createMemberToolHandlers(
     const agentUrl = input.agent_url as string;
     const tracks = input.tracks as ComplianceTrack[] | undefined;
     const runTarget = targetFromInput(input);
-    const writesCanonicalComplianceState = isDefaultHostedComplianceTarget(runTarget);
     let skippedCanonicalWriteForTarget = false;
 
     const urlError = validateAgentUrl(agentUrl);
@@ -3757,6 +3757,11 @@ export function createMemberToolHandlers(
 
     try {
       const result = await comply(resolved.resolvedUrl, complyOptions, runTarget);
+      const writesCanonicalComplianceState = isDefaultHostedComplianceTarget(runTarget) ||
+        agentAdvertisesBadgeEligibleHostedComplianceTarget(
+          result.agent_profile.adcp_supported_versions,
+          runTarget,
+        );
 
       // Surface OAuth-required short-circuit. comply() doesn't throw on auth
       // failures — it pushes a `category: 'auth'` observation and runs a
@@ -3919,7 +3924,7 @@ export function createMemberToolHandlers(
       output += `**Agent:** ${resolved.resolvedUrl}\n`;
       output += `**Compliance target:** ${formatComplianceTarget(runTarget, result.adcp_version ?? runTarget.version, { includeBadgeEligibility: true })}\n`;
       if (skippedCanonicalWriteForTarget) {
-        output += `_Explicit non-default compliance targets are diagnostic only; public compliance status and badges were not updated._\n`;
+        output += `_This compliance target is diagnostic only for this agent; public compliance status and badges were not updated._\n`;
       }
       const safeTools = (result.agent_profile.tools || []).map(t => sanitizeAgentField(t, 80)).filter(Boolean);
       output += `**Tools:** ${safeTools.length} (${safeTools.join(', ')})\n`;

--- a/server/src/services/hosted-compliance-version.ts
+++ b/server/src/services/hosted-compliance-version.ts
@@ -256,8 +256,10 @@ export function badgeEligibleVersionsForHostedComplianceTarget(
     return [];
   }
 
-  const line = complianceReleaseLine(target.requested) ?? complianceReleaseLine(target.version);
-  return line && (SUPPORTED_BADGE_VERSIONS as readonly string[]).includes(line) ? [line] : [];
+  const line = complianceReleaseLine(target.requested);
+  if (!line || target.requested !== line) return [];
+
+  return (SUPPORTED_BADGE_VERSIONS as readonly string[]).includes(line) ? [line] : [];
 }
 
 export function agentAdvertisesBadgeEligibleHostedComplianceTarget(
@@ -267,12 +269,15 @@ export function agentAdvertisesBadgeEligibleHostedComplianceTarget(
   if (!supportedVersions?.length) return false;
 
   const eligibleVersions = new Set(badgeEligibleVersionsForHostedComplianceTarget(target));
-  if (eligibleVersions.size === 0) return false;
+  const [requestedLine] = eligibleVersions;
+  if (!requestedLine) {
+    return false;
+  }
 
   return supportedVersions.some(version => {
     if (version.includes('-')) return false;
     const line = complianceReleaseLine(version);
-    return line ? eligibleVersions.has(line) : false;
+    return line === requestedLine;
   });
 }
 

--- a/server/src/services/hosted-compliance-version.ts
+++ b/server/src/services/hosted-compliance-version.ts
@@ -260,6 +260,22 @@ export function badgeEligibleVersionsForHostedComplianceTarget(
   return line && (SUPPORTED_BADGE_VERSIONS as readonly string[]).includes(line) ? [line] : [];
 }
 
+export function agentAdvertisesBadgeEligibleHostedComplianceTarget(
+  supportedVersions: readonly string[] | undefined,
+  target: HostedComplianceTarget,
+): boolean {
+  if (!supportedVersions?.length) return false;
+
+  const eligibleVersions = new Set(badgeEligibleVersionsForHostedComplianceTarget(target));
+  if (eligibleVersions.size === 0) return false;
+
+  return supportedVersions.some(version => {
+    if (version.includes('-')) return false;
+    const line = complianceReleaseLine(version);
+    return line ? eligibleVersions.has(line) : false;
+  });
+}
+
 function assertHostedArtifacts(version: string): void {
   const complianceDir = hostedComplianceDir(version);
   const schemaRoot = hostedSchemaRoot(version);

--- a/server/tests/unit/storyboards.test.ts
+++ b/server/tests/unit/storyboards.test.ts
@@ -188,16 +188,20 @@ describe('wrapper contract', () => {
     expect(badgeEligibleVersionsForHostedComplianceTarget(hostedComplianceTarget('3.1-beta'))).toEqual([]);
   });
 
-  it('recognizes badge-eligible explicit targets advertised by the agent', () => {
-    const explicitStable = hostedComplianceTarget('3.0.5');
+  it('recognizes badge-eligible line targets advertised by the agent', () => {
+    const stableLine = hostedComplianceTarget('3.0');
+    const exactHistoricalCache = hostedComplianceTarget('3.0.5');
 
-    expect(isDefaultHostedComplianceTarget(explicitStable)).toBe(false);
-    expect(badgeEligibleVersionsForHostedComplianceTarget(explicitStable)).toEqual(['3.0']);
-    expect(agentAdvertisesBadgeEligibleHostedComplianceTarget(['3.0'], explicitStable)).toBe(true);
-    expect(agentAdvertisesBadgeEligibleHostedComplianceTarget(['3.0.5'], explicitStable)).toBe(true);
-    expect(agentAdvertisesBadgeEligibleHostedComplianceTarget(['3.1'], explicitStable)).toBe(false);
-    expect(agentAdvertisesBadgeEligibleHostedComplianceTarget(['3.0-beta.1'], explicitStable)).toBe(false);
-    expect(agentAdvertisesBadgeEligibleHostedComplianceTarget(undefined, explicitStable)).toBe(false);
+    expect(badgeEligibleVersionsForHostedComplianceTarget(stableLine)).toEqual(['3.0']);
+    expect(agentAdvertisesBadgeEligibleHostedComplianceTarget(['3.0'], stableLine)).toBe(true);
+    expect(agentAdvertisesBadgeEligibleHostedComplianceTarget(['3.0.5'], stableLine)).toBe(true);
+    expect(agentAdvertisesBadgeEligibleHostedComplianceTarget(['3.1'], stableLine)).toBe(false);
+    expect(agentAdvertisesBadgeEligibleHostedComplianceTarget(['3.0-beta.1'], stableLine)).toBe(false);
+    expect(agentAdvertisesBadgeEligibleHostedComplianceTarget(undefined, stableLine)).toBe(false);
+
+    expect(isDefaultHostedComplianceTarget(exactHistoricalCache)).toBe(false);
+    expect(badgeEligibleVersionsForHostedComplianceTarget(exactHistoricalCache)).toEqual([]);
+    expect(agentAdvertisesBadgeEligibleHostedComplianceTarget(['3.0.5'], exactHistoricalCache)).toBe(false);
   });
 
   it('rejects unsupported compliance targets before path resolution', () => {

--- a/server/tests/unit/storyboards.test.ts
+++ b/server/tests/unit/storyboards.test.ts
@@ -21,6 +21,7 @@ import {
   hostedCapabilitiesForCompliance,
   hostedSupportedVersionsForCompliance,
   isDefaultHostedComplianceTarget,
+  agentAdvertisesBadgeEligibleHostedComplianceTarget,
   withHostedComplianceCompatibility,
   withHostedComplianceOptions,
 } from '../../src/services/hosted-compliance-version.js';
@@ -185,6 +186,18 @@ describe('wrapper contract', () => {
     expect(isDefaultHostedComplianceTarget(hostedComplianceTarget('3.1-beta'))).toBe(false);
     expect(badgeEligibleVersionsForHostedComplianceTarget(hostedComplianceTarget('3.0'))).toEqual(['3.0']);
     expect(badgeEligibleVersionsForHostedComplianceTarget(hostedComplianceTarget('3.1-beta'))).toEqual([]);
+  });
+
+  it('recognizes badge-eligible explicit targets advertised by the agent', () => {
+    const explicitStable = hostedComplianceTarget('3.0.5');
+
+    expect(isDefaultHostedComplianceTarget(explicitStable)).toBe(false);
+    expect(badgeEligibleVersionsForHostedComplianceTarget(explicitStable)).toEqual(['3.0']);
+    expect(agentAdvertisesBadgeEligibleHostedComplianceTarget(['3.0'], explicitStable)).toBe(true);
+    expect(agentAdvertisesBadgeEligibleHostedComplianceTarget(['3.0.5'], explicitStable)).toBe(true);
+    expect(agentAdvertisesBadgeEligibleHostedComplianceTarget(['3.1'], explicitStable)).toBe(false);
+    expect(agentAdvertisesBadgeEligibleHostedComplianceTarget(['3.0-beta.1'], explicitStable)).toBe(false);
+    expect(agentAdvertisesBadgeEligibleHostedComplianceTarget(undefined, explicitStable)).toBe(false);
   });
 
   it('rejects unsupported compliance targets before path resolution', () => {

--- a/tests/addie/member-tools.test.ts
+++ b/tests/addie/member-tools.test.ts
@@ -8,13 +8,52 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MemberContext } from '../../server/src/addie/member-context.js';
 
+const memberToolMocks = vi.hoisted(() => ({
+  checkToolRateLimit: vi.fn(),
+  comply: vi.fn(),
+  isOrgOwnerOfAgent: vi.fn(),
+  recordAgentTestRun: vi.fn(),
+  runBadgeFanOut: vi.fn(),
+  setAgentTesterLogger: vi.fn(),
+}));
+
 vi.mock('../../server/src/services/pipes.js', () => ({
   getGitHubAccessToken: vi.fn(),
 }));
 
+vi.mock('../../server/src/addie/mcp/tool-rate-limiter.js', () => ({
+  checkToolRateLimit: memberToolMocks.checkToolRateLimit,
+}));
+
+vi.mock('../../server/src/addie/services/compliance-testing.js', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>;
+  return {
+    ...actual,
+    comply: memberToolMocks.comply,
+    setAgentTesterLogger: memberToolMocks.setAgentTesterLogger,
+  };
+});
+
+vi.mock('../../server/src/db/agent-test-db.js', () => ({
+  recordAgentTestRun: memberToolMocks.recordAgentTestRun,
+}));
+
+vi.mock('../../server/src/services/agent-ownership.js', () => ({
+  isOrgOwnerOfAgent: memberToolMocks.isOrgOwnerOfAgent,
+}));
+
+vi.mock('../../server/src/services/badge-issuance.js', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>;
+  return {
+    ...actual,
+    runBadgeFanOut: memberToolMocks.runBadgeFanOut,
+  };
+});
+
 // Import the tool definitions directly (no side effects)
 import { MEMBER_TOOLS, createMemberToolHandlers } from '../../server/src/addie/mcp/member-tools.js';
 import { getGitHubAccessToken } from '../../server/src/services/pipes.js';
+import { AgentContextDatabase } from '../../server/src/db/agent-context-db.js';
 import { ComplianceDatabase } from '../../server/src/db/compliance-db.js';
 import { AgentSnapshotDatabase } from '../../server/src/db/agent-snapshot-db.js';
 import * as wgService from '../../server/src/services/working-group-membership-service.js';
@@ -542,6 +581,163 @@ describe('createMemberToolHandlers', () => {
 
       expect(result).toContain('network error');
       expect(result).toContain('draft_github_issue');
+    });
+  });
+
+  describe('evaluate_agent_quality handler', () => {
+    const ownerContext = {
+      is_mapped: true,
+      is_member: true,
+      slack_linked: false,
+      workos_user: {
+        workos_user_id: 'user_owner',
+        email: 'owner@example.com',
+        first_name: 'Owner',
+        last_name: 'User',
+      },
+      organization: {
+        workos_organization_id: 'org_owner',
+        name: 'Acme Corp',
+      },
+    } as unknown as MemberContext;
+
+    function makeComplianceResult(supportedVersions: string[]) {
+      return {
+        agent_url: 'https://seller.example.com/mcp',
+        adcp_version: '3.0.14',
+        requested_compliance_target: '3.0',
+        agent_profile: {
+          name: 'Seller Agent',
+          tools: ['get_products'],
+          adcp_supported_versions: supportedVersions,
+          specialisms: ['sales-catalog-driven'],
+        },
+        overall_status: 'passing',
+        tracks: [{
+          track: 'media_buy',
+          status: 'pass',
+          label: 'Media buy',
+          skipped_scenarios: [],
+          observations: [],
+          duration_ms: 25,
+          scenarios: [{
+            scenario: 'sales_catalog_driven/discovery',
+            overall_passed: true,
+            duration_ms: 25,
+            steps: [{
+              step: 'discover-products',
+              passed: true,
+              duration_ms: 25,
+            }],
+          }],
+        }],
+        tested_tracks: [],
+        skipped_tracks: [],
+        summary: {
+          tracks_passed: 1,
+          tracks_failed: 0,
+          tracks_skipped: 0,
+          tracks_partial: 0,
+          tracks_silent: 0,
+          headline: 'All applicable tracks passed',
+        },
+        observations: [],
+        total_duration_ms: 25,
+      } as never;
+    }
+
+    beforeEach(() => {
+      memberToolMocks.checkToolRateLimit.mockResolvedValue({ ok: true });
+      memberToolMocks.comply.mockResolvedValue(makeComplianceResult(['3.0']));
+      memberToolMocks.isOrgOwnerOfAgent.mockResolvedValue(true);
+      memberToolMocks.recordAgentTestRun.mockResolvedValue(undefined);
+      memberToolMocks.runBadgeFanOut.mockResolvedValue({ issued: [], revoked: [], degraded: [], unchanged: [] });
+      vi.spyOn(AgentContextDatabase.prototype, 'getAuthInfoByOrgAndUrl').mockResolvedValue(null as never);
+      vi.spyOn(AgentContextDatabase.prototype, 'getOAuthTokensByOrgAndUrl').mockResolvedValue(null as never);
+      vi.spyOn(ComplianceDatabase.prototype, 'getRegistryMetadata').mockResolvedValue({
+        lifecycle_stage: 'production',
+        compliance_opt_out: false,
+        monitoring_paused: false,
+        check_interval_hours: 12,
+        monitoring_paused_at: null,
+        created_at: new Date(),
+        updated_at: new Date(),
+      } as never);
+      vi.spyOn(ComplianceDatabase.prototype, 'recordComplianceRun').mockResolvedValue({
+        run: { id: 'run_123' },
+        statusTransition: null,
+        storyboardStatuses: [],
+      } as never);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      memberToolMocks.checkToolRateLimit.mockReset();
+      memberToolMocks.comply.mockReset();
+      memberToolMocks.isOrgOwnerOfAgent.mockReset();
+      memberToolMocks.recordAgentTestRun.mockReset();
+      memberToolMocks.runBadgeFanOut.mockReset();
+    });
+
+    it('writes canonical compliance state and fans out badges for owner full-suite stable-line runs', async () => {
+      const handlers = createMemberToolHandlers(ownerContext);
+      const result = await handlers.get('evaluate_agent_quality')!({
+        agent_url: 'https://seller.example.com/mcp',
+        compliance_target: '3.0',
+      });
+
+      expect(result).toContain('Quality Evaluation: Seller Agent');
+      expect(result).not.toContain('diagnostic only');
+      expect(ComplianceDatabase.prototype.recordComplianceRun).toHaveBeenCalledTimes(1);
+      expect(ComplianceDatabase.prototype.recordComplianceRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agent_url: 'https://seller.example.com/mcp',
+          requested_compliance_target: '3.0',
+          adcp_version: '3.0.14',
+          triggered_by: 'owner_test',
+          triggered_org_id: 'org_owner',
+          dry_run: false,
+          replace_storyboard_statuses: true,
+        }),
+      );
+      expect(memberToolMocks.runBadgeFanOut).toHaveBeenCalledWith(expect.objectContaining({
+        agentUrl: 'https://seller.example.com/mcp',
+        declaredSpecialisms: ['sales-catalog-driven'],
+        runId: 'run_123',
+        adcpVersions: ['3.0'],
+      }));
+    });
+
+    it('keeps exact historical stable-cache targets diagnostic-only', async () => {
+      memberToolMocks.comply.mockResolvedValueOnce({
+        ...makeComplianceResult(['3.0.5']),
+        adcp_version: '3.0.5',
+        requested_compliance_target: '3.0.5',
+      } as never);
+
+      const handlers = createMemberToolHandlers(ownerContext);
+      const result = await handlers.get('evaluate_agent_quality')!({
+        agent_url: 'https://seller.example.com/mcp',
+        compliance_target: '3.0.5',
+      });
+
+      expect(result).toContain('diagnostic only for this agent');
+      expect(ComplianceDatabase.prototype.recordComplianceRun).not.toHaveBeenCalled();
+      expect(memberToolMocks.runBadgeFanOut).not.toHaveBeenCalled();
+    });
+
+    it('keeps track-filtered owner runs diagnostic without blaming the target', async () => {
+      const handlers = createMemberToolHandlers(ownerContext);
+      const result = await handlers.get('evaluate_agent_quality')!({
+        agent_url: 'https://seller.example.com/mcp',
+        compliance_target: '3.0',
+        tracks: ['media_buy'],
+      });
+
+      expect(result).toContain('Track-filtered evaluations are diagnostic slices');
+      expect(result).not.toContain('This compliance target is diagnostic only for this agent');
+      expect(ComplianceDatabase.prototype.recordComplianceRun).not.toHaveBeenCalled();
+      expect(memberToolMocks.runBadgeFanOut).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Fixes #5145.

This updates hosted compliance badge eligibility so owner-triggered explicit stable targets can write canonical compliance state when the agent advertises support for that target line. The root cause was that `evaluate_agent_quality` treated canonical writes as default-target-only before the compliance run returned the agent profile. The PR also refreshes the tool/output wording, adds focused unit coverage for explicit 3.0.x targets, and includes an empty server-behavior changeset.

Validation: targeted unit tests, full precommit hook, typecheck, Addie tool reference check, and pre-push validation all passed.
