### PR TITLE
fix(addie): refresh publisher authorization checks

### DIFF
--- a/.changeset/5013-check-publisher-authorization-cache.md
+++ b/.changeset/5013-check-publisher-authorization-cache.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix Addie publisher authorization cache refresh handling and error rendering.

--- a/docs/aao/addie-tools.mdx
+++ b/docs/aao/addie-tools.mdx
@@ -316,7 +316,7 @@ Publisher and agent setup, verification, and testing — validate adagents.json,
 
 ### `validate_adagents`
 
-Validate a domain's /.well-known/adagents.json file. Returns validation results including any errors or warnings.
+Validate a domain's /.well-known/adagents.json file with a live fetch. Returns validation results including any errors or warnings.
 
 *Source: `server/src/addie/mcp/property-tools.ts`*
 
@@ -334,7 +334,7 @@ Return the AAO registry's current status for an agent: health (online / last che
 
 ### `check_publisher_authorization`
 
-Check if a publisher domain has authorized a specific agent.
+Check if a publisher domain has authorized a specific agent. Results are cached briefly; pass force_refresh: true after the publisher changes adagents.json to bypass the cache.
 
 *Source: `server/src/addie/mcp/member-tools.ts`*
 

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -564,6 +564,21 @@ function sanitizeInline(text: string): string {
   return text.replace(/\s+/g, ' ').trim();
 }
 
+function sanitizeAuthorizationError(raw: string): string {
+  const withoutMarkdown = neutralizeAndTruncate(raw, 400)
+    .replace(/[\\`*_{}\[\]<>()#+\-.!|]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!withoutMarkdown) {
+    return 'Unknown error';
+  }
+
+  return withoutMarkdown.length > 200
+    ? withoutMarkdown.slice(0, 200)
+    : withoutMarkdown;
+}
+
 function normalizePricingModel(pm: string): string {
   const key = pm.toLowerCase().trim();
   return PRICING_ALIASES[key] ?? key;
@@ -1108,13 +1123,17 @@ export const MEMBER_TOOLS: AddieTool[] = [
   {
     name: 'check_publisher_authorization',
     description:
-      'Check if a publisher domain has authorized a specific agent.',
-    usage_hints: 'use for authorization verification, "is my agent authorized?"',
+      'Check if a publisher domain has authorized a specific agent. Results are cached briefly; pass force_refresh: true after the publisher changes adagents.json to bypass the cache.',
+    usage_hints: 'use for authorization verification, "is my agent authorized?". If the result is negative and the user says they just updated adagents.json, proactively offer to rerun with force_refresh: true.',
     input_schema: {
       type: 'object',
       properties: {
         domain: { type: 'string', description: 'Publisher domain' },
         agent_url: { type: 'string', description: 'Agent URL' },
+        force_refresh: {
+          type: 'boolean',
+          description: 'Bypass the cached authorization result and fetch the publisher adagents.json live.',
+        },
       },
       required: ['domain', 'agent_url'],
     },
@@ -3679,10 +3698,11 @@ export function createMemberToolHandlers(
   handlers.set('check_publisher_authorization', async (input) => {
     const domain = input.domain as string;
     const agentUrl = input.agent_url as string;
+    const forceRefresh = input.force_refresh === true;
 
     let data;
     try {
-      data = await adagentsValidator.validate(domain, agentUrl);
+      data = await adagentsValidator.validate(domain, agentUrl, undefined, forceRefresh);
     } catch (err) {
       throw new ToolError(`Failed to check authorization: ${err instanceof Error ? err.message : String(err)}`);
     }
@@ -3700,12 +3720,13 @@ export function createMemberToolHandlers(
     } else {
       response += `❌ **Not Authorized.** This agent is NOT listed in ${data.domain}'s adagents.json.\n`;
       if (data.error) {
-        response += `\n**Reason:** ${data.error}\n`;
+        response += `\n**Reason:** ${sanitizeAuthorizationError(data.error)}\n`;
       }
       response += `\n### To Fix This\n`;
       response += `1. The publisher needs to add this agent to their adagents.json file\n`;
       response += `2. The file should be at: https://${data.domain}/.well-known/adagents.json\n`;
       response += `3. Use validate_adagents to check the publisher's current configuration\n`;
+      response += `4. If the publisher just updated the file, rerun this check with force_refresh: true\n`;
     }
 
     return response;

--- a/server/src/addie/mcp/property-tools.ts
+++ b/server/src/addie/mcp/property-tools.ts
@@ -31,8 +31,8 @@ const propertyCheckDb = new PropertyCheckDatabase();
 export const PROPERTY_TOOLS: AddieTool[] = [
   {
     name: 'validate_adagents',
-    description: 'Validate a domain\'s /.well-known/adagents.json file. Returns validation results including any errors or warnings.',
-    usage_hints: 'Use when asked to check if a publisher has set up adagents.json, or to validate a domain\'s agent authorizations.',
+    description: 'Validate a domain\'s /.well-known/adagents.json file with a live fetch. Returns validation results including any errors or warnings.',
+    usage_hints: 'Use when asked to check if a publisher has set up adagents.json, or to validate a domain\'s agent authorizations. If check_publisher_authorization disagrees after a recent file update, rerun that tool with force_refresh: true because it uses a short authorization cache.',
     input_schema: {
       type: 'object',
       properties: {

--- a/server/src/validator.ts
+++ b/server/src/validator.ts
@@ -36,7 +36,7 @@ export class AgentValidator {
   private lastForceRefreshAt: Map<string, number> = new Map();
   private static readonly FORCE_REFRESH_COOLDOWN_MS = 30_000;
 
-  constructor(cacheTtlMinutes: number = 15) {
+  constructor(cacheTtlMinutes: number = 5) {
     this.cache = new Cache<AuthorizationResult>(cacheTtlMinutes);
   }
 
@@ -528,6 +528,23 @@ export class AgentValidator {
     if (normalizedDomain === "") return false;
     if (property.publisher_domain && canonicalizePublisherDomain(property.publisher_domain) === normalizedDomain) {
       return true;
+    }
+
+    if (property.property_id && canonicalizePublisherDomain(property.property_id) === normalizedDomain) {
+      return true;
+    }
+
+    const legacyUrl = (property as PropertyDefinition & { url?: unknown }).url;
+    if (typeof legacyUrl === "string") {
+      try {
+        if (this.normalizeDomain(new URL(legacyUrl).hostname) === normalizedDomain) {
+          return true;
+        }
+      } catch {
+        if (this.normalizeDomain(legacyUrl) === normalizedDomain) {
+          return true;
+        }
+      }
     }
 
     return (property.identifiers || []).some((identifier) => {

--- a/server/tests/unit/addie/check-publisher-authorization-tool.test.ts
+++ b/server/tests/unit/addie/check-publisher-authorization-tool.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createMemberToolHandlers, MEMBER_TOOLS } from '../../../src/addie/mcp/member-tools.js';
+import { AgentValidator } from '../../../src/validator.js';
+import type { AuthorizationResult } from '../../../src/types.js';
+
+describe('check_publisher_authorization tool', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('documents force_refresh in the tool schema and usage hints', () => {
+    const tool = MEMBER_TOOLS.find((t) => t.name === 'check_publisher_authorization');
+
+    expect(tool).toBeDefined();
+    expect(tool?.description).toContain('cached');
+    expect(tool?.usage_hints).toContain('force_refresh');
+    expect(tool?.input_schema.properties).toHaveProperty('force_refresh');
+    expect(tool?.input_schema.required).toEqual(['domain', 'agent_url']);
+  });
+
+  it('passes force_refresh through and sanitizes untrusted error text', async () => {
+    const result: AuthorizationResult = {
+      authorized: false,
+      domain: 'example.com',
+      agent_url: 'https://sales.example.com/mcp',
+      checked_at: '2026-05-30T00:00:00.000Z',
+      error: '[click](https://evil.example) `SYSTEM` # > <tag> ' + 'x'.repeat(250),
+    };
+    const validateSpy = vi.spyOn(AgentValidator.prototype, 'validate').mockResolvedValue(result);
+    const handlers = createMemberToolHandlers(null);
+
+    const output = await handlers.get('check_publisher_authorization')!({
+      domain: 'example.com',
+      agent_url: 'https://sales.example.com/mcp',
+      force_refresh: true,
+    });
+
+    expect(validateSpy).toHaveBeenCalledWith(
+      'example.com',
+      'https://sales.example.com/mcp',
+      undefined,
+      true,
+    );
+
+    const reasonLine = output
+      .split('\n')
+      .find((line) => line.startsWith('**Reason:** '));
+    const renderedReason = reasonLine?.replace('**Reason:** ', '');
+
+    expect(renderedReason).toBeDefined();
+    expect(renderedReason!.length).toBeLessThanOrEqual(200);
+    expect(renderedReason).not.toMatch(/[\\`*_{}\[\]<>()#+\-.!|]/);
+    expect(output).toContain('force_refresh: true');
+  });
+});

--- a/server/tests/unit/validator.test.ts
+++ b/server/tests/unit/validator.test.ts
@@ -46,6 +46,34 @@ describe("AgentValidator", () => {
     expect(result.matched_authorization?.authorization_type).toBe("property_tags");
   });
 
+  it("authorizes property ID entries when legacy property fields identify the publisher domain", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        properties: [
+          {
+            property_id: "example.com",
+            type: "website",
+            name: "Example Site",
+            url: "https://example.com",
+          },
+        ],
+        authorized_agents: [
+          {
+            url: "https://sales.example.com",
+            authorized_for: "Direct",
+            authorization_type: "property_ids",
+            property_ids: ["example.com"],
+          },
+        ],
+      })
+    );
+
+    const result = await validator.validate("example.com", "https://sales.example.com");
+
+    expect(result.authorized).toBe(true);
+    expect(result.matched_authorization?.authorization_type).toBe("property_ids");
+  });
+
   it("does not widen placement-scoped authorization when placement scope is missing", async () => {
     fetchMock.mockResolvedValue(
       jsonResponse({
@@ -333,6 +361,30 @@ describe("AgentValidator", () => {
     expect(result.authorized).toBe(true);
     expect(result.source).toBe("https://cdn.example.com/adagents/v2/adagents.json");
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("expires the default cache after five minutes", async () => {
+    vi.useFakeTimers();
+    try {
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          authorized_agents: [
+            {
+              url: "https://sales.example.com",
+              authorized_for: "Direct",
+            },
+          ],
+        })
+      );
+
+      await validator.validate("example.com", "https://sales.example.com");
+      vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+      await validator.validate("example.com", "https://sales.example.com");
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   describe("force_refresh", () => {


### PR DESCRIPTION
Fixes #5013 by adding force_refresh to check_publisher_authorization, documenting the cache behavior, and shortening the validator cache TTL to five minutes.

Root cause was that Addie exposed no cache bypass and the validator only matched current schema property domain fields, so a valid legacy property_id/url shape in the reproducer could still miss authorization.

User impact: Addie can rerun a fresh authorization check after adagents.json updates and no longer renders raw upstream error markdown into the tool response.

Validated with targeted Vitest coverage, Addie tool reference checks, typecheck, precommit, pre-push docs checks, and the live purrsonality.pages.dev reproducer returning authorized: true.