### PR TITLE
chore: bump @adcp/sdk to 8.1.0-beta.19 (storyboard window fix)

### DIFF
--- a/.changeset/sdk-beta-19-window-fix.md
+++ b/.changeset/sdk-beta-19-window-fix.md
@@ -1,0 +1,12 @@
+---
+"adcontextprotocol": patch
+---
+
+Bump `@adcp/sdk` to `8.1.0-beta.19` to pick up the storyboard request-builder fix
+(adcp-client #2144, closing #2143): `create_media_buy` flight windows are now
+resolved as a pair, so a frozen-compliance-bundle fixture with a past `start_time`
+and a same-day `end_time` no longer defaults the start forward into
+`start_time > end_time`. Fixes the one-day `Storyboards (3.0-compat /sales)`
+regression where `measurement_terms_rejected` and `media_buy_state_machine` failed
+on the flight's end date (dropping clean storyboards below the floor) on every PR
+and `main` run that landed on that calendar day.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.1.0-rc.4",
       "dependencies": {
-        "@adcp/sdk": "^8.1.0-beta.18",
+        "@adcp/sdk": "^8.1.0-beta.19",
         "@anthropic-ai/sdk": "^0.98.0",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "8.1.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-8.1.0-beta.18.tgz",
-      "integrity": "sha512-q1i/B6vsfFuNDsuWU0gwJGooEF3tCLDKdeZ0xsZirU5UJtSYmL4rGwiu62TO3o6OTMmvqYp2GGRsh2MTwPfm/Q==",
+      "version": "8.1.0-beta.19",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-8.1.0-beta.19.tgz",
+      "integrity": "sha512-HBVMy0WE2ADr7p5eVatjkHUssjfgONszPyvPkcTVKbstNdxvudzq6O7tEsqpRDfK3EavrkcD4D2uYjAmc4gKuw==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "docs:json-field-audit": "node scripts/docs-json-field-audit.cjs"
   },
   "dependencies": {
-    "@adcp/sdk": "^8.1.0-beta.18",
+    "@adcp/sdk": "^8.1.0-beta.19",
     "@anthropic-ai/sdk": "^0.98.0",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",


### PR DESCRIPTION
Bumps `@adcp/sdk` `^8.1.0-beta.18` → `^8.1.0-beta.19` to pick up the storyboard request-builder fix from [adcp-client #2144](https://github.com/adcontextprotocol/adcp-client/pull/2144) (closing #2143).

## Why

The storyboard request-builder resolved `create_media_buy` `start_time` and `end_time` **independently**: a fixture with a past `start_time` defaulted the start forward (`now + 1 day`) while a same-day `end_time` was kept — yielding `start_time > end_time` and `INVALID_REQUEST: start_time must be before end_time`. This is a **one-day time bomb**: it fires on the calendar day equal to a frozen-bundle fixture's `end_time`.

It hit `Storyboards (3.0-compat /sales)` on **2026-05-31** (the frozen 3.0.14 `measurement_terms_rejected` and `media_buy_state_machine` fixtures both flight `2026-05-01 → 2026-05-31`), dropping clean storyboards below the floor on `main` and **every open PR** that ran that day. beta.19 resolves the window as a pair, so it can't invert.

## Verification

Local run against the frozen 3.0.14 bundle under beta.19:

```
media_buy_seller/measurement_terms_rejected  ✓ 3P / 0S / 0N/A  → 1/1 clean
media_buy_state_machine                              → 1/1 clean
```

(Confirmed the installed beta.19 ships the `resolveMediaBuyWindow` fix.)

## Scope

`package.json` (one-line pin), `package-lock.json`, and a `patch` changeset. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)