### PR TITLE
fix(compliance): recover hosted target selection

### DIFF
--- a/.changeset/hosted-compliance-target-recovery.md
+++ b/.changeset/hosted-compliance-target-recovery.md
@@ -1,0 +1,18 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix hosted compliance target recovery after temporary `adcp.supported_versions`
+declaration regressions. Diagnostic storyboard flows now re-derive the hosted
+target from the agent's live supported versions, preferring `3.1-rc`, then
+`3.1-beta`, then `3.0`; canonical badge-writing flows keep the stable `3.0`
+target when the agent still advertises it and only fall forward when no stable
+target is available. Canonical flows now also revoke stale public `3.0` badges
+when confirmed capabilities no longer advertise `3.0` support.
+
+Also patch the affected `media_buy_state_machine`,
+`measurement_terms_rejected`, and universal idempotency fixture copies to use
+forward-looking Q3 2026 windows, repair selected prerelease
+`measurement_terms_rejected` idempotency aliases, and fail the compliance build
+when a mutating storyboard step authors a stable or duplicate generated
+`idempotency_key`.

--- a/dist/compliance/3.0.14/domains/media-buy/scenarios/measurement_terms_rejected.yaml
+++ b/dist/compliance/3.0.14/domains/media-buy/scenarios/measurement_terms_rejected.yaml
@@ -107,8 +107,8 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
           idempotency_key: "$generate:uuid_v4#measurement_terms_rejected_aggressive_terms"
-          start_time: "2026-05-01T00:00:00Z"
-          end_time: "2026-05-31T23:59:59Z"
+          start_time: "2026-07-01T00:00:00Z"
+          end_time: "2026-09-30T23:59:59Z"
           packages:
             - product_id: "$context.product_id"
               budget: 25000
@@ -164,8 +164,8 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
           idempotency_key: "$generate:uuid_v4#measurement_terms_rejected_relaxed_terms"
-          start_time: "2026-05-01T00:00:00Z"
-          end_time: "2026-05-31T23:59:59Z"
+          start_time: "2026-07-01T00:00:00Z"
+          end_time: "2026-09-30T23:59:59Z"
           packages:
             - product_id: "$context.product_id"
               budget: 25000

--- a/dist/compliance/3.0.14/domains/media-buy/state-machine.yaml
+++ b/dist/compliance/3.0.14/domains/media-buy/state-machine.yaml
@@ -157,8 +157,8 @@ phases:
             operator: "pinnacle-agency.example"
           brand:
             domain: "acmeoutdoor.example"
-          start_time: "2026-05-01T00:00:00Z"
-          end_time: "2026-05-31T23:59:59Z"
+          start_time: "2026-07-01T00:00:00Z"
+          end_time: "2026-09-30T23:59:59Z"
           packages:
             - product_id: "test-product"
               budget: 10000

--- a/dist/compliance/3.0.14/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
+++ b/dist/compliance/3.0.14/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
@@ -107,8 +107,8 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
           idempotency_key: "$generate:uuid_v4#measurement_terms_rejected_aggressive_terms"
-          start_time: "2026-05-01T00:00:00Z"
-          end_time: "2026-05-31T23:59:59Z"
+          start_time: "2026-07-01T00:00:00Z"
+          end_time: "2026-09-30T23:59:59Z"
           packages:
             - product_id: "$context.product_id"
               budget: 25000
@@ -164,8 +164,8 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
           idempotency_key: "$generate:uuid_v4#measurement_terms_rejected_relaxed_terms"
-          start_time: "2026-05-01T00:00:00Z"
-          end_time: "2026-05-31T23:59:59Z"
+          start_time: "2026-07-01T00:00:00Z"
+          end_time: "2026-09-30T23:59:59Z"
           packages:
             - product_id: "$context.product_id"
               budget: 25000

--- a/dist/compliance/3.0.14/protocols/media-buy/state-machine.yaml
+++ b/dist/compliance/3.0.14/protocols/media-buy/state-machine.yaml
@@ -157,8 +157,8 @@ phases:
             operator: "pinnacle-agency.example"
           brand:
             domain: "acmeoutdoor.example"
-          start_time: "2026-05-01T00:00:00Z"
-          end_time: "2026-05-31T23:59:59Z"
+          start_time: "2026-07-01T00:00:00Z"
+          end_time: "2026-09-30T23:59:59Z"
           packages:
             - product_id: "test-product"
               budget: 10000

--- a/dist/compliance/3.0.14/universal/idempotency.yaml
+++ b/dist/compliance/3.0.14/universal/idempotency.yaml
@@ -188,8 +188,8 @@ phases:
             operator: "pinnacle-agency.example"
           brand:
             domain: "acmeoutdoor.example"
-          start_time: "2026-05-01T00:00:00Z"
-          end_time: "2026-05-31T23:59:59Z"
+          start_time: "2026-07-01T00:00:00Z"
+          end_time: "2026-09-30T23:59:59Z"
           packages:
             - product_id: "test-product"
               budget: 5000

--- a/dist/compliance/3.1.0-beta.7/domains/media-buy/scenarios/measurement_terms_rejected.yaml
+++ b/dist/compliance/3.1.0-beta.7/domains/media-buy/scenarios/measurement_terms_rejected.yaml
@@ -168,7 +168,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "$generate:uuid_v4#media_buy_seller_measurement_terms_rejected_reject_terms_create_media_buy_aggressive_terms"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_measurement_terms_rejected_accept_terms_create_media_buy_relaxed_terms"
           start_time: "2026-07-01T00:00:00Z"
           end_time: "2026-09-30T23:59:59Z"
           packages:

--- a/dist/compliance/3.1.0-beta.7/domains/media-buy/state-machine.yaml
+++ b/dist/compliance/3.1.0-beta.7/domains/media-buy/state-machine.yaml
@@ -157,8 +157,8 @@ phases:
             operator: "pinnacle-agency.example"
           brand:
             domain: "acmeoutdoor.example"
-          start_time: "2026-05-01T00:00:00Z"
-          end_time: "2026-05-31T23:59:59Z"
+          start_time: "2026-07-01T00:00:00Z"
+          end_time: "2026-09-30T23:59:59Z"
           packages:
             - product_id: "test-product"
               budget: 10000

--- a/dist/compliance/3.1.0-beta.7/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
+++ b/dist/compliance/3.1.0-beta.7/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
@@ -168,7 +168,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "$generate:uuid_v4#media_buy_seller_measurement_terms_rejected_reject_terms_create_media_buy_aggressive_terms"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_measurement_terms_rejected_accept_terms_create_media_buy_relaxed_terms"
           start_time: "2026-07-01T00:00:00Z"
           end_time: "2026-09-30T23:59:59Z"
           packages:

--- a/dist/compliance/3.1.0-beta.7/protocols/media-buy/state-machine.yaml
+++ b/dist/compliance/3.1.0-beta.7/protocols/media-buy/state-machine.yaml
@@ -157,8 +157,8 @@ phases:
             operator: "pinnacle-agency.example"
           brand:
             domain: "acmeoutdoor.example"
-          start_time: "2026-05-01T00:00:00Z"
-          end_time: "2026-05-31T23:59:59Z"
+          start_time: "2026-07-01T00:00:00Z"
+          end_time: "2026-09-30T23:59:59Z"
           packages:
             - product_id: "test-product"
               budget: 10000

--- a/dist/compliance/3.1.0-beta.7/universal/idempotency.yaml
+++ b/dist/compliance/3.1.0-beta.7/universal/idempotency.yaml
@@ -212,8 +212,8 @@ phases:
             operator: "pinnacle-agency.example"
           brand:
             domain: "acmeoutdoor.example"
-          start_time: "2026-05-01T00:00:00Z"
-          end_time: "2026-05-31T23:59:59Z"
+          start_time: "2026-07-01T00:00:00Z"
+          end_time: "2026-09-30T23:59:59Z"
           packages:
             - product_id: "test-product"
               budget: 5000

--- a/dist/compliance/3.1.0-rc.4/domains/media-buy/scenarios/measurement_terms_rejected.yaml
+++ b/dist/compliance/3.1.0-rc.4/domains/media-buy/scenarios/measurement_terms_rejected.yaml
@@ -168,7 +168,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "$generate:uuid_v4#media_buy_seller_measurement_terms_rejected_reject_terms_create_media_buy_aggressive_terms"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_measurement_terms_rejected_accept_terms_create_media_buy_relaxed_terms"
           start_time: "2026-07-01T00:00:00Z"
           end_time: "2026-09-30T23:59:59Z"
           packages:

--- a/dist/compliance/3.1.0-rc.4/domains/media-buy/state-machine.yaml
+++ b/dist/compliance/3.1.0-rc.4/domains/media-buy/state-machine.yaml
@@ -157,8 +157,8 @@ phases:
             operator: "pinnacle-agency.example"
           brand:
             domain: "acmeoutdoor.example"
-          start_time: "2026-05-01T00:00:00Z"
-          end_time: "2026-05-31T23:59:59Z"
+          start_time: "2026-07-01T00:00:00Z"
+          end_time: "2026-09-30T23:59:59Z"
           packages:
             - product_id: "test-product"
               budget: 10000

--- a/dist/compliance/3.1.0-rc.4/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
+++ b/dist/compliance/3.1.0-rc.4/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
@@ -168,7 +168,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "$generate:uuid_v4#media_buy_seller_measurement_terms_rejected_reject_terms_create_media_buy_aggressive_terms"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_measurement_terms_rejected_accept_terms_create_media_buy_relaxed_terms"
           start_time: "2026-07-01T00:00:00Z"
           end_time: "2026-09-30T23:59:59Z"
           packages:

--- a/dist/compliance/3.1.0-rc.4/protocols/media-buy/state-machine.yaml
+++ b/dist/compliance/3.1.0-rc.4/protocols/media-buy/state-machine.yaml
@@ -157,8 +157,8 @@ phases:
             operator: "pinnacle-agency.example"
           brand:
             domain: "acmeoutdoor.example"
-          start_time: "2026-05-01T00:00:00Z"
-          end_time: "2026-05-31T23:59:59Z"
+          start_time: "2026-07-01T00:00:00Z"
+          end_time: "2026-09-30T23:59:59Z"
           packages:
             - product_id: "test-product"
               budget: 10000

--- a/dist/compliance/3.1.0-rc.4/universal/idempotency.yaml
+++ b/dist/compliance/3.1.0-rc.4/universal/idempotency.yaml
@@ -212,8 +212,8 @@ phases:
             operator: "pinnacle-agency.example"
           brand:
             domain: "acmeoutdoor.example"
-          start_time: "2026-05-01T00:00:00Z"
-          end_time: "2026-05-31T23:59:59Z"
+          start_time: "2026-07-01T00:00:00Z"
+          end_time: "2026-09-30T23:59:59Z"
           packages:
             - product_id: "test-product"
               budget: 5000

--- a/scripts/build-compliance.cjs
+++ b/scripts/build-compliance.cjs
@@ -250,7 +250,14 @@ function loadMutatingSchemaRefs(schemasDir) {
 function lintStoryboardIdempotency(sourceDir, schemasDir) {
   const { refs: mutatingRefs, tools: mutatingTools } = loadMutatingSchemaRefs(schemasDir);
   const violations = [];
+  const stableKeyViolations = [];
+  const duplicateGeneratedKeyViolations = [];
   const missingSchemaRefs = [];
+  const generatedKeyUses = new Map();
+
+  function isGeneratedIdempotencyKey(value) {
+    return typeof value === 'string' && value.startsWith('$generate:uuid_v4');
+  }
 
   function lintFile(p) {
     const rel = path.relative(sourceDir, p);
@@ -267,9 +274,6 @@ function lintStoryboardIdempotency(sourceDir, schemasDir) {
       if (!phase || !Array.isArray(phase.steps)) continue;
       for (const step of phase.steps) {
         if (!step || typeof step !== 'object' || !step.task) continue;
-        // expect_error steps intentionally exercise invalid-request paths,
-        // including the "missing idempotency_key" test in universal/idempotency.yaml.
-        if (step.expect_error === true) continue;
         // Steps without schema_ref are HTTP probes, controller calls, or
         // synthetic invocations (e.g., comply_test_controller's
         // simulate_budget scenarios, universal/security.yaml's probe steps)
@@ -287,11 +291,40 @@ function lintStoryboardIdempotency(sourceDir, schemasDir) {
         }
         const schemaRef = step.schema_ref;
         if (!schemaRef || !mutatingRefs.has(schemaRef)) continue;
+        // The missing-key negative vector explicitly suppresses both runner
+        // auto-injection and this authored-sample lint.
+        if (step.omit_idempotency_key === true) continue;
         const hasKey =
           step.sample_request &&
           typeof step.sample_request === 'object' &&
           step.sample_request.idempotency_key !== undefined;
-        if (hasKey) continue;
+        if (hasKey) {
+          const key = step.sample_request.idempotency_key;
+          if (!isGeneratedIdempotencyKey(key)) {
+            stableKeyViolations.push({
+              file: rel,
+              phase: phase.id,
+              step: step.id,
+              task: step.task,
+              key,
+            });
+          } else if (rel !== 'universal/idempotency.yaml') {
+            const existing = generatedKeyUses.get(key);
+            const current = {
+              file: rel,
+              phase: phase.id,
+              step: step.id,
+              task: step.task,
+              key,
+            };
+            if (existing) {
+              duplicateGeneratedKeyViolations.push({ first: existing, second: current });
+            } else {
+              generatedKeyUses.set(key, current);
+            }
+          }
+          continue;
+        }
         violations.push({
           file: rel,
           phase: phase.id,
@@ -325,6 +358,33 @@ function lintStoryboardIdempotency(sourceDir, schemasDir) {
       `static/compliance/source/universal/idempotency.yaml for the convention, ` +
       `and note the deliberate alias-reuse pattern there when two steps must ` +
       `share a key (replay tests).`
+    );
+  }
+
+  if (stableKeyViolations.length > 0) {
+    const lines = stableKeyViolations.map(v =>
+      `  ${v.file} phase=${v.phase} step=${v.step}: task "${v.task}" uses stable idempotency_key ${JSON.stringify(v.key)}.`
+    );
+    throw new Error(
+      `Storyboard idempotency_key freshness lint: ${stableKeyViolations.length} step(s) use stable authored idempotency_key values.\n\n` +
+      lines.join('\n') +
+      `\n\nUse \`idempotency_key: "$generate:uuid_v4#<storyboard>_<phase>_<step>"\` ` +
+      `so each storyboard run mints fresh keys. Literal keys can replay stale ` +
+      `successful responses from a prior run and leak terminal state into later phases.`
+    );
+  }
+
+  if (duplicateGeneratedKeyViolations.length > 0) {
+    const lines = duplicateGeneratedKeyViolations.map(v =>
+      `  ${v.second.file} phase=${v.second.phase} step=${v.second.step}: ` +
+      `idempotency_key ${JSON.stringify(v.second.key)} was already used by ` +
+      `${v.first.file} phase=${v.first.phase} step=${v.first.step}.`
+    );
+    throw new Error(
+      `Storyboard idempotency_key freshness lint: ${duplicateGeneratedKeyViolations.length} duplicate generated alias use(s).\n\n` +
+      lines.join('\n') +
+      `\n\nUse a unique \`$generate:uuid_v4#...\` alias for each mutating storyboard step. ` +
+      `Only universal/idempotency.yaml may intentionally reuse aliases for replay vectors.`
     );
   }
 

--- a/server/src/addie/jobs/compliance-heartbeat.ts
+++ b/server/src/addie/jobs/compliance-heartbeat.ts
@@ -10,7 +10,10 @@ import {
   complianceResultToDbInput,
   classifyCapabilityResolutionError,
   presentCapabilityResolutionError,
+  badgeEligibleVersionsForTargetSelection,
+  selectComplianceTargetForAgentSelection,
   type ComplyOptions,
+  type ComplianceTargetSelection,
 } from '../services/compliance-testing.js';
 import { ComplianceDatabase, type LifecycleStage } from '../../db/compliance-db.js';
 import { query } from '../../db/client.js';
@@ -19,17 +22,15 @@ import { notifySystemError } from '../error-notifier.js';
 import { logger as baseLogger } from '../../logger.js';
 import { logOutboundRequest } from '../../db/outbound-log-db.js';
 import { AAO_UA_COMPLIANCE } from '../../config/user-agents.js';
-import { runBadgeFanOut } from '../../services/badge-issuance.js';
+import { revokeUnsupportedPublicBadges, runBadgeFanOut } from '../../services/badge-issuance.js';
 import { adaptAuthForSdk } from '../../services/sdk-auth-adapter.js';
 import {
-  badgeEligibleVersionsForHostedComplianceTarget,
   hostedComplianceTarget,
 } from '../../services/hosted-compliance-version.js';
 
 const logger = baseLogger.child({ module: 'compliance-heartbeat' });
 const complianceDb = new ComplianceDatabase();
-const complianceTarget = hostedComplianceTarget();
-const badgeEligibleAdcpVersions = [...badgeEligibleVersionsForHostedComplianceTarget(complianceTarget)];
+const fallbackComplianceTarget = hostedComplianceTarget();
 
 interface HeartbeatOptions {
   limit?: number;
@@ -69,6 +70,8 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
 
   for (const agent of agentsDue) {
     const startTime = Date.now();
+    let runTarget = fallbackComplianceTarget;
+    let runTargetSelection: ComplianceTargetSelection = { target: fallbackComplianceTarget, confirmed: false };
     try {
       const auth = await complianceDb.resolveOwnerAuth(agent.agent_url);
       const sdkAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `heartbeat:${agent.agent_url}` });
@@ -80,7 +83,14 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
         userAgent: AAO_UA_COMPLIANCE,
       };
 
-      const complianceResult = await comply(agent.agent_url, complyOptions, complianceTarget);
+      runTargetSelection = await selectComplianceTargetForAgentSelection(
+        agent.agent_url,
+        complyOptions,
+        fallbackComplianceTarget,
+        'canonical',
+      );
+      runTarget = runTargetSelection.target;
+      const complianceResult = await comply(agent.agent_url, complyOptions, runTarget);
 
       logOutboundRequest({
         agent_url: agent.agent_url,
@@ -131,8 +141,11 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
       // heartbeat is the only caller that follows it up with a Slack
       // notification, since owner-driven runs already have a chat response.
       const declaredSpecialisms = complianceResult.agent_profile?.specialisms ?? [];
+      const badgeEligibleAdcpVersions = [
+        ...badgeEligibleVersionsForTargetSelection(runTargetSelection, complianceResult.agent_profile),
+      ];
 
-      if (declaredSpecialisms.length > 0) {
+      if (declaredSpecialisms.length > 0 && badgeEligibleAdcpVersions.length > 0) {
         try {
           const badgeResult = await runBadgeFanOut({
             complianceDb,
@@ -159,6 +172,23 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
             source: 'compliance-badge-issuance',
             errorMessage: `Badge processing setup failed for ${agent.agent_url}: ${badgeError instanceof Error ? badgeError.message : String(badgeError)}`,
           });
+        }
+      } else {
+        try {
+          const badgeResult = await revokeUnsupportedPublicBadges({
+            complianceDb,
+            agentUrl: agent.agent_url,
+            supportedVersions: complianceResult.agent_profile?.adcp_supported_versions ?? runTargetSelection.supportedVersions,
+          });
+          if (badgeResult.revoked.length > 0) {
+            await notifyVerificationChange({
+              agentUrl: agent.agent_url,
+              issued: [],
+              revoked: badgeResult.revoked,
+            });
+          }
+        } catch (badgeError) {
+          logger.error({ badgeError, agentUrl: agent.agent_url }, 'Unsupported public badge revocation failed');
         }
       }
     } catch (error) {
@@ -207,10 +237,11 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
 
       // Record failure so stale passing data doesn't persist
       try {
+        const badgeEligibleAdcpVersions = [...badgeEligibleVersionsForTargetSelection(runTargetSelection)];
         await complianceDb.recordComplianceRun({
           agent_url: agent.agent_url,
-          requested_compliance_target: complianceTarget.requested,
-          adcp_version: complianceTarget.version,
+          requested_compliance_target: runTarget.requested,
+          adcp_version: runTarget.version,
           lifecycle_stage: agent.lifecycle_stage as LifecycleStage,
           overall_status: 'failing',
           headline,
@@ -225,30 +256,51 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
           replace_storyboard_statuses: true,
         });
 
-        const existingBadges = await complianceDb.getBadgesForAgent(agent.agent_url);
-        const revoked = [];
-        for (const badge of existingBadges) {
-          await complianceDb.revokeBadge(
-            agent.agent_url,
-            badge.role,
-            badge.adcp_version,
-            'Authoritative compliance run failed before storyboard verification',
-          );
-          revoked.push({
-            role: badge.role,
-            reason: 'Authoritative compliance run failed',
-            adcp_version: badge.adcp_version,
-          });
-        }
-        if (revoked.length > 0) {
-          try {
-            await notifyVerificationChange({
-              agentUrl: agent.agent_url,
-              issued: [],
-              revoked,
+        if (badgeEligibleAdcpVersions.length > 0) {
+          const eligibleBadgeVersions = new Set(badgeEligibleAdcpVersions);
+          const existingBadges = await complianceDb.getBadgesForAgent(agent.agent_url);
+          const revoked = [];
+          for (const badge of existingBadges) {
+            if (!eligibleBadgeVersions.has(badge.adcp_version)) continue;
+            await complianceDb.revokeBadge(
+              agent.agent_url,
+              badge.role,
+              badge.adcp_version,
+              'Authoritative compliance run failed before storyboard verification',
+            );
+            revoked.push({
+              role: badge.role,
+              reason: 'Authoritative compliance run failed',
+              adcp_version: badge.adcp_version,
             });
-          } catch (notifyError) {
-            logger.error({ notifyError, agentUrl: agent.agent_url }, 'Failed to send verification revocation notification');
+          }
+          if (revoked.length > 0) {
+            try {
+              await notifyVerificationChange({
+                agentUrl: agent.agent_url,
+                issued: [],
+                revoked,
+              });
+            } catch (notifyError) {
+              logger.error({ notifyError, agentUrl: agent.agent_url }, 'Failed to send verification revocation notification');
+            }
+          }
+        } else if (runTargetSelection.confirmed) {
+          const badgeResult = await revokeUnsupportedPublicBadges({
+            complianceDb,
+            agentUrl: agent.agent_url,
+            supportedVersions: runTargetSelection.supportedVersions,
+          });
+          if (badgeResult.revoked.length > 0) {
+            try {
+              await notifyVerificationChange({
+                agentUrl: agent.agent_url,
+                issued: [],
+                revoked: badgeResult.revoked,
+              });
+            } catch (notifyError) {
+              logger.error({ notifyError, agentUrl: agent.agent_url }, 'Failed to send verification revocation notification');
+            }
           }
         }
       } catch (recordError) {

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -39,7 +39,11 @@ import {
   presentCapabilityResolutionError,
   complianceResultToDbInput,
   loadComplianceIndex,
+  badgeEligibleVersionsForTargetSelection,
+  selectComplianceTargetForAgent,
+  selectComplianceTargetForAgentSelection,
   type ComplyOptions,
+  type ComplianceTargetSelection,
   type ComplianceTrack,
 } from '../services/compliance-testing.js';
 import {
@@ -63,9 +67,8 @@ import {
   hostedAuthProbeTaskForProfile,
   withHostedStoryboardRunOptions,
   withHostedTestOptions,
-  isDefaultHostedComplianceTarget,
   badgeEligibleVersionsForHostedComplianceTarget,
-  agentAdvertisesBadgeEligibleHostedComplianceTarget,
+  selectHostedComplianceTargetForProfile,
 } from '../../services/hosted-compliance-version.js';
 import { AgentContextDatabase, validateAuthTokenChars, type OAuthClientCredentials } from '../../db/agent-context-db.js';
 import { buildAgentOAuthAuthorizeUrl, isOAuthRequiredError } from '../../routes/helpers/agent-oauth-prompt.js';
@@ -82,7 +85,7 @@ import { canonicalizeBrandDomain } from '../../services/identifier-normalization
 import { isOrgOwnerOfAgent } from '../../services/agent-ownership.js';
 import { getBrandPrimaryDomain } from '../../services/brand-domain-resolver.js';
 import { ComplianceDatabase } from '../../db/compliance-db.js';
-import { runBadgeFanOut } from '../../services/badge-issuance.js';
+import { revokeUnsupportedPublicBadges, runBadgeFanOut } from '../../services/badge-issuance.js';
 import { AgentSnapshotDatabase } from '../../db/agent-snapshot-db.js';
 import { AgentValidator } from '../../validator.js';
 import {
@@ -125,6 +128,11 @@ import { canonicalizeAgentUrl } from '../../db/publisher-db.js';
 
 const logger = createLogger('addie-member-tools');
 const complianceTarget = hostedComplianceTarget();
+function hasExplicitComplianceTarget(input: Record<string, unknown>): boolean {
+  const requested = input.compliance_target;
+  return typeof requested === 'string' && requested.trim().length > 0;
+}
+
 function targetFromInput(input: Record<string, unknown>): ReturnType<typeof hostedComplianceTarget> {
   const requested = input.compliance_target;
   try {
@@ -132,7 +140,7 @@ function targetFromInput(input: Record<string, unknown>): ReturnType<typeof host
       ? hostedComplianceTarget(requested.trim())
       : complianceTarget;
   } catch {
-    throw new ToolError('Invalid compliance_target. Use 3.0, 3.1-beta, or an exact bundled version.');
+    throw new ToolError('Invalid compliance_target. Use 3.0, 3.1-rc, 3.1-beta, or an exact bundled version.');
   }
 }
 
@@ -1178,7 +1186,7 @@ export const MEMBER_TOOLS: AddieTool[] = [
       properties: {
         agent_url: { type: 'string', description: 'Agent URL to evaluate' },
         tracks: { type: 'array', items: { type: 'string', enum: ['core', 'products', 'media_buy', 'creative', 'reporting', 'governance', 'signals', 'si', 'audiences'] }, description: 'Specific compliance tracks to run (default: all applicable, driven by the agent\'s get_adcp_capabilities response)' },
-        compliance_target: { type: 'string', description: 'Compliance target to run, e.g. "3.0" for a badge-eligible stable line or "3.1-beta" for an explicit beta diagnostic run. Defaults to 3.0.' },
+        compliance_target: { type: 'string', description: 'Compliance target to run, e.g. "3.0" for a badge-eligible stable line or "3.1-rc"/"3.1-beta" for explicit prerelease diagnostics. Defaults to the canonical badge-eligible target when advertised.' },
       },
       required: ['agent_url'],
     },
@@ -1285,7 +1293,7 @@ export const MEMBER_TOOLS: AddieTool[] = [
       type: 'object',
       properties: {
         agent_url: { type: 'string', description: 'Agent URL to discover and recommend storyboards for' },
-        compliance_target: { type: 'string', description: 'Compliance target to inspect, e.g. "3.0" or "3.1-beta". Defaults to 3.0.' },
+        compliance_target: { type: 'string', description: 'Compliance target to inspect, e.g. "3.0", "3.1-rc", or "3.1-beta". Defaults to the best hosted target advertised by the agent.' },
       },
       required: ['agent_url'],
     },
@@ -1299,7 +1307,7 @@ export const MEMBER_TOOLS: AddieTool[] = [
       type: 'object',
       properties: {
         storyboard_id: { type: 'string', description: 'Storyboard ID (from recommend_storyboards)' },
-        compliance_target: { type: 'string', description: 'Compliance target to inspect, e.g. "3.0" or "3.1-beta". Defaults to 3.0.' },
+        compliance_target: { type: 'string', description: 'Compliance target to inspect, e.g. "3.0", "3.1-rc", or "3.1-beta". Defaults to 3.0.' },
       },
       required: ['storyboard_id'],
     },
@@ -1315,7 +1323,7 @@ export const MEMBER_TOOLS: AddieTool[] = [
         agent_url: { type: 'string', description: 'Agent URL to test' },
         storyboard_id: { type: 'string', description: 'Storyboard ID to run' },
         dry_run: { type: 'boolean', description: 'If true (default), use test data that won\'t affect production state', default: true },
-        compliance_target: { type: 'string', description: 'Compliance target to run, e.g. "3.0" or "3.1-beta". Defaults to 3.0. Explicit non-default targets are diagnostic-only.' },
+        compliance_target: { type: 'string', description: 'Compliance target to run, e.g. "3.0", "3.1-rc", or "3.1-beta". Defaults to the best hosted target advertised by the agent. Explicit non-default targets are diagnostic-only.' },
       },
       required: ['agent_url', 'storyboard_id'],
     },
@@ -1333,7 +1341,7 @@ export const MEMBER_TOOLS: AddieTool[] = [
         step_id: { type: 'string', description: 'Step ID to run (from storyboard detail or previous step\'s next.step_id)' },
         context: { type: 'object', description: 'Accumulated context from previous step (pass the context field from the previous run_storyboard_step result)', additionalProperties: true },
         dry_run: { type: 'boolean', description: 'If true (default), use test data', default: true },
-        compliance_target: { type: 'string', description: 'Compliance target to run, e.g. "3.0" or "3.1-beta". Defaults to 3.0. Explicit non-default targets are diagnostic-only.' },
+        compliance_target: { type: 'string', description: 'Compliance target to run, e.g. "3.0", "3.1-rc", or "3.1-beta". Defaults to the best hosted target advertised by the agent. Explicit non-default targets are diagnostic-only.' },
       },
       required: ['agent_url', 'storyboard_id', 'step_id'],
     },
@@ -3765,7 +3773,11 @@ export function createMemberToolHandlers(
   handlers.set('evaluate_agent_quality', async (input) => {
     const agentUrl = input.agent_url as string;
     const tracks = input.tracks as ComplianceTrack[] | undefined;
-    const runTarget = targetFromInput(input);
+    let runTarget = targetFromInput(input);
+    let runTargetSelection: ComplianceTargetSelection = {
+      target: runTarget,
+      confirmed: false,
+    };
     let skippedCanonicalWriteReason: 'target' | 'tracks' | null = null;
 
     const urlError = validateAgentUrl(agentUrl);
@@ -3785,20 +3797,30 @@ export function createMemberToolHandlers(
 
     const organizationId = memberContext?.organization?.workos_organization_id;
     const resolved = await resolveAgentAuth(agentUrl, organizationId);
+    const authOption = buildAuthOption(resolved);
+
+    if (!hasExplicitComplianceTarget(input)) {
+      runTargetSelection = await selectComplianceTargetForAgentSelection(
+        resolved.resolvedUrl,
+        { auth: authOption },
+        complianceTarget,
+        'canonical',
+      );
+      runTarget = runTargetSelection.target;
+    }
 
     const complyOptions: ComplyOptions = {
       test_session_id: `quality-eval-${Date.now()}`,
-      auth: buildAuthOption(resolved),
+      auth: authOption,
     };
     if (tracks) complyOptions.tracks = tracks;
 
     try {
       const result = await comply(resolved.resolvedUrl, complyOptions, runTarget);
-      const writesCanonicalComplianceState = isDefaultHostedComplianceTarget(runTarget) ||
-        agentAdvertisesBadgeEligibleHostedComplianceTarget(
-          result.agent_profile.adcp_supported_versions,
-          runTarget,
-        );
+      const badgeEligibleAdcpVersions = [
+        ...badgeEligibleVersionsForTargetSelection(runTargetSelection, result.agent_profile),
+      ];
+      const writesCanonicalComplianceState = badgeEligibleAdcpVersions.length > 0;
 
       // Surface OAuth-required short-circuit. comply() doesn't throw on auth
       // failures — it pushes a `category: 'auth'` observation and runs a
@@ -3896,10 +3918,20 @@ export function createMemberToolHandlers(
                     agentUrl: resolved.resolvedUrl,
                     declaredSpecialisms,
                     runId: tracks ? null : run.id,
-                    adcpVersions: badgeEligibleVersionsForHostedComplianceTarget(runTarget),
+                    adcpVersions: badgeEligibleAdcpVersions,
                   });
                 } catch (badgeError) {
                   logger.warn({ badgeError, agentUrl: resolved.resolvedUrl }, 'Badge fan-out failed after owner_test run');
+                }
+              } else {
+                try {
+                  await revokeUnsupportedPublicBadges({
+                    complianceDb,
+                    agentUrl: resolved.resolvedUrl,
+                    supportedVersions: result.agent_profile?.adcp_supported_versions ?? runTargetSelection.supportedVersions,
+                  });
+                } catch (badgeError) {
+                  logger.warn({ badgeError, agentUrl: resolved.resolvedUrl }, 'Unsupported public badge revocation failed after owner_test run');
                 }
               }
             }
@@ -3910,6 +3942,15 @@ export function createMemberToolHandlers(
           skippedCanonicalWriteReason = 'tracks';
         } else if (isAgentOwner) {
           skippedCanonicalWriteReason = 'target';
+          try {
+            await revokeUnsupportedPublicBadges({
+              complianceDb,
+              agentUrl: resolved.resolvedUrl,
+              supportedVersions: result.agent_profile?.adcp_supported_versions ?? runTargetSelection.supportedVersions,
+            });
+          } catch (badgeError) {
+            logger.warn({ badgeError, agentUrl: resolved.resolvedUrl }, 'Unsupported public badge revocation failed after owner_test run');
+          }
         }
 
         // Legacy write to agent_contexts + agent_test_history. Retained ONLY
@@ -4119,8 +4160,8 @@ export function createMemberToolHandlers(
 
   handlers.set('recommend_storyboards', async (input) => {
     const agentUrl = input.agent_url as string;
-    const runTarget = targetFromInput(input);
-    const runOptions = hostedComplianceOptions(runTarget);
+    let runTarget = targetFromInput(input);
+    let runOptions = hostedComplianceOptions(runTarget);
 
     const urlError = validateAgentUrl(agentUrl);
     if (urlError) return `**Error:** ${urlError}`;
@@ -4134,10 +4175,14 @@ export function createMemberToolHandlers(
     const authOption = buildAuthOption(resolved);
     let profile: AgentProfile | undefined;
     try {
-      const caps = await testCapabilityDiscovery(resolved.resolvedUrl, withHostedTestOptions({
+      const caps = await testCapabilityDiscovery(resolved.resolvedUrl, {
         ...(authOption && { auth: authOption }),
-      }, runTarget));
+      });
       profile = caps.profile;
+      if (!hasExplicitComplianceTarget(input)) {
+        runTarget = selectHostedComplianceTargetForProfile(profile, complianceTarget);
+        runOptions = hostedComplianceOptions(runTarget);
+      }
 
       // testCapabilityDiscovery catches its own throws and surfaces them as
       // step errors / capabilities_probe_error strings — the catch below
@@ -4379,6 +4424,9 @@ export function createMemberToolHandlers(
     output += `1. Run the full suite — \`evaluate_agent_quality\`\n`;
     output += `2. Walk one storyboard step-by-step for debugging — \`run_storyboard_step\`\n`;
     output += `3. Inspect a storyboard before running it — \`get_storyboard_detail\`\n`;
+    if (runTarget.requested !== complianceTarget.requested) {
+      output += `\nUse \`compliance_target: "${runTarget.requested}"\` on follow-up storyboard tools so they inspect the same catalog.`;
+    }
 
     // Activation hinge: if this is a member with an org and the agent isn't
     // saved yet, offer to save. Converts drive-by testing into an ongoing
@@ -4412,6 +4460,7 @@ export function createMemberToolHandlers(
 
     let output = `## ${sb.title}\n\n`;
     output += `**ID:** \`${sb.id}\`\n`;
+    output += `**Compliance target:** ${formatComplianceTarget(runTarget)}\n`;
     output += `**Track:** ${sb.track || 'general'}\n`;
     output += `**Summary:** ${sb.summary}\n\n`;
     if (sb.narrative) {
@@ -4452,20 +4501,28 @@ export function createMemberToolHandlers(
     const agentUrl = input.agent_url as string;
     const storyboardId = input.storyboard_id as string;
     const dryRun = input.dry_run !== false;
-    const runTarget = targetFromInput(input);
-    const runOptions = hostedComplianceOptions(runTarget);
+    let runTarget = targetFromInput(input);
 
     const urlError = validateAgentUrl(agentUrl);
     if (urlError) return `**Error:** ${urlError}`;
 
+    const organizationId = memberContext?.organization?.workos_organization_id;
+    const resolved = await resolveAgentAuth(agentUrl, organizationId);
+    const authOption = buildAuthOption(resolved);
+
+    if (!hasExplicitComplianceTarget(input)) {
+      runTarget = await selectComplianceTargetForAgent(
+        resolved.resolvedUrl,
+        { auth: authOption },
+        complianceTarget,
+      );
+    }
+
+    const runOptions = hostedComplianceOptions(runTarget);
     const sb = getComplianceStoryboardById(storyboardId, runOptions);
     if (!sb) return `Storyboard "${storyboardId}" not found. Use \`recommend_storyboards\` to see applicable storyboards.`;
 
-    const organizationId = memberContext?.organization?.workos_organization_id;
-    const resolved = await resolveAgentAuth(agentUrl, organizationId);
-
     try {
-      const authOption = buildAuthOption(resolved);
       const authProbeTask = await inferHostedAuthProbeTask(resolved.resolvedUrl, authOption, runTarget);
       const result = await runStoryboard(resolved.resolvedUrl, sb, withHostedStoryboardRunOptions({
         ...(authOption && { auth: authOption }),
@@ -4612,12 +4669,24 @@ export function createMemberToolHandlers(
     const stepId = input.step_id as string;
     const context = (input.context as StoryboardContext) || {};
     const dryRun = input.dry_run !== false;
-    const runTarget = targetFromInput(input);
-    const runOptions = hostedComplianceOptions(runTarget);
+    let runTarget = targetFromInput(input);
 
     const urlError = validateAgentUrl(agentUrl);
     if (urlError) return `**Error:** ${urlError}`;
 
+    const organizationId = memberContext?.organization?.workos_organization_id;
+    const resolved = await resolveAgentAuth(agentUrl, organizationId);
+    const authOption = buildAuthOption(resolved);
+
+    if (!hasExplicitComplianceTarget(input)) {
+      runTarget = await selectComplianceTargetForAgent(
+        resolved.resolvedUrl,
+        { auth: authOption },
+        complianceTarget,
+      );
+    }
+
+    const runOptions = hostedComplianceOptions(runTarget);
     const sb = getComplianceStoryboardById(storyboardId, runOptions);
     if (!sb) return `Storyboard "${storyboardId}" not found.`;
 
@@ -4649,11 +4718,7 @@ export function createMemberToolHandlers(
       }
     }
 
-    const organizationId = memberContext?.organization?.workos_organization_id;
-    const resolved = await resolveAgentAuth(agentUrl, organizationId);
-
     try {
-      const authOption = buildAuthOption(resolved);
       const authProbeTask = await inferHostedAuthProbeTask(resolved.resolvedUrl, authOption, runTarget);
       const result: StoryboardStepResult = await runStoryboardStep(resolved.resolvedUrl, sb, resolvedStepId, withHostedStoryboardRunOptions({
         context,

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -23,6 +23,10 @@ import {
 import {
   hostedComplianceTarget,
   hostedAuthProbeTaskForProfile,
+  agentAdvertisesBadgeEligibleHostedComplianceTarget,
+  badgeEligibleVersionsForHostedComplianceTarget,
+  selectCanonicalHostedComplianceTargetForProfile,
+  selectHostedComplianceTargetForProfile,
   withHostedComplianceRunOptions,
   type HostedComplianceTarget,
 } from '../../services/hosted-compliance-version.js';
@@ -39,6 +43,37 @@ import type {
 } from '../../db/compliance-db.js';
 
 const logger = createLogger('addie-compliance-testing');
+const DEFAULT_TARGET_DISCOVERY_TIMEOUT_MS = 10_000;
+
+export interface ComplianceTargetSelection {
+  target: HostedComplianceTarget;
+  confirmed: boolean;
+  supportedVersions?: readonly string[];
+}
+
+function complianceTargetDiscoveryTimeoutMs(options: ComplyOptions): number {
+  const requested = options.timeout_ms;
+  if (typeof requested !== 'number' || !Number.isFinite(requested)) {
+    return DEFAULT_TARGET_DISCOVERY_TIMEOUT_MS;
+  }
+  return Math.max(1_000, Math.min(requested, DEFAULT_TARGET_DISCOVERY_TIMEOUT_MS));
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
 
 // ── Re-exports ────────────────────────────────────────────────────
 
@@ -88,6 +123,53 @@ export function loadComplianceIndex(target: HostedComplianceTarget, options: Com
 
 export function defaultComplianceTarget(): HostedComplianceTarget {
   return hostedComplianceTarget();
+}
+
+export async function selectComplianceTargetForAgentSelection(
+  agentUrl: string,
+  options: ComplyOptions,
+  fallback: HostedComplianceTarget = defaultComplianceTarget(),
+  mode: 'preferred' | 'canonical' = 'preferred',
+): Promise<ComplianceTargetSelection> {
+  try {
+    const discovery = await withTimeout(
+      testCapabilityDiscovery(agentUrl, options),
+      complianceTargetDiscoveryTimeoutMs(options),
+      'Hosted compliance target pre-discovery',
+    );
+    const target = mode === 'canonical'
+      ? selectCanonicalHostedComplianceTargetForProfile(discovery.profile, fallback)
+      : selectHostedComplianceTargetForProfile(discovery.profile, fallback);
+    return { target, confirmed: true, supportedVersions: discovery.profile?.adcp_supported_versions };
+  } catch (err) {
+    logger.warn({ err, agentUrl }, 'Could not pre-discover hosted compliance target; using fallback');
+    return { target: fallback, confirmed: false };
+  }
+}
+
+export async function selectComplianceTargetForAgent(
+  agentUrl: string,
+  options: ComplyOptions,
+  fallback: HostedComplianceTarget = defaultComplianceTarget(),
+  mode: 'preferred' | 'canonical' = 'preferred',
+): Promise<HostedComplianceTarget> {
+  const selection = await selectComplianceTargetForAgentSelection(agentUrl, options, fallback, mode);
+  return selection.target;
+}
+
+export function badgeEligibleVersionsForTargetSelection(
+  selection: ComplianceTargetSelection,
+  profile?: { adcp_supported_versions?: readonly string[] },
+): readonly string[] {
+  const versions = badgeEligibleVersionsForHostedComplianceTarget(selection.target);
+  if (versions.length === 0) return [];
+  if (selection.confirmed) return versions;
+  return agentAdvertisesBadgeEligibleHostedComplianceTarget(
+    profile?.adcp_supported_versions ?? selection.supportedVersions,
+    selection.target,
+  )
+    ? versions
+    : [];
 }
 
 // ── Capability-resolution error classification ───────────────────

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -11,7 +11,7 @@ import { z } from "zod";
 import escapeHtml from "escape-html";
 import { findOwnerOrgForUser } from "../services/agent-ownership.js";
 import { CreativeAgentClient, SingleAgentClient, exchangeClientCredentials, ClientCredentialsExchangeError } from "@adcp/sdk";
-import { runStoryboardStep, getComplianceStoryboardById, getFirstStepPreview, testCapabilityDiscovery, resolveStoryboardsForCapabilities, loadComplianceIndex } from "@adcp/sdk/testing";
+import { runStoryboardStep, getComplianceStoryboardById, getFirstStepPreview, testCapabilityDiscovery, resolveStoryboardsForCapabilities, loadComplianceIndex, listAllComplianceStoryboards } from "@adcp/sdk/testing";
 import type { Agent, AgentType, AgentWithStats } from "../types.js";
 import { isValidAgentType } from "../types.js";
 import { MemberDatabase } from "../db/member-db.js";
@@ -27,7 +27,7 @@ import {
   hostedAuthProbeTaskForProfile,
   withHostedStoryboardRunOptions,
   withHostedTestOptions,
-  badgeEligibleVersionsForHostedComplianceTarget,
+  selectHostedComplianceTargetForProfile,
 } from "../services/hosted-compliance-version.js";
 import {
   comply,
@@ -35,10 +35,13 @@ import {
   classifyCapabilityResolutionError,
   presentCapabilityResolutionError,
   computeSpecialismStatus,
+  badgeEligibleVersionsForTargetSelection,
+  selectComplianceTargetForAgent,
+  selectComplianceTargetForAgentSelection,
 } from "../addie/services/compliance-testing.js";
 import { getPublicJwks } from "../services/verification-token.js";
 import { renderBadgeSvg, VALID_BADGE_ROLES } from "../services/badge-svg.js";
-import { runBadgeFanOut } from "../services/badge-issuance.js";
+import { revokeUnsupportedPublicBadges, runBadgeFanOut } from "../services/badge-issuance.js";
 import { resolveOwnerMembership, tierLabel } from "../services/membership-tiers.js";
 import { inferDiagnosticAgentType } from "../lib/diagnostic-agent-type-inference.js";
 import { isValidAdcpVersionShape } from "../services/adcp-taxonomy.js";
@@ -129,11 +132,44 @@ import { AAO_UA_COMPLIANCE } from "../config/user-agents.js";
 const logger = createLogger("registry-api");
 const complianceTarget = hostedComplianceTarget();
 const complianceOptions = hostedComplianceOptions(complianceTarget);
-const badgeEligibleAdcpVersions = [...badgeEligibleVersionsForHostedComplianceTarget(complianceTarget)];
-const badgeEligibilityMetadata = (eligible: boolean) => ({
-  badge_eligible: eligible,
-  badge_eligible_adcp_versions: eligible ? badgeEligibleAdcpVersions : [],
+const badgeEligibilityMetadata = (eligibleVersions: readonly string[]) => ({
+  badge_eligible: eligibleVersions.length > 0,
+  badge_eligible_adcp_versions: [...eligibleVersions],
 });
+const INVALID_COMPLIANCE_TARGET_MESSAGE =
+  "Invalid compliance_target. Use 3.0, 3.1-rc, 3.1-beta, or an exact bundled version.";
+
+class InvalidComplianceTargetError extends Error {}
+
+function targetFromRequestValue(value: unknown): ReturnType<typeof hostedComplianceTarget> {
+  const requested = typeof value === "string" ? value.trim() : "";
+  if (!requested) return complianceTarget;
+  try {
+    return hostedComplianceTarget(requested);
+  } catch {
+    throw new InvalidComplianceTargetError(INVALID_COMPLIANCE_TARGET_MESSAGE);
+  }
+}
+
+function summarizeStoryboardsForTarget(
+  target: ReturnType<typeof hostedComplianceTarget>,
+  category?: string,
+) {
+  const all = listAllComplianceStoryboards(hostedComplianceOptions(target));
+  const filtered = category ? all.filter((sb) => sb.category === category) : all;
+
+  return filtered.map((sb) => ({
+    id: sb.id,
+    title: sb.title,
+    category: sb.category,
+    summary: sb.summary,
+    interaction_model: sb.agent.interaction_model,
+    examples: sb.agent.examples || [],
+    phase_count: sb.phases.length,
+    step_count: sb.phases.reduce((sum, phase) => sum + phase.steps.length, 0),
+  }));
+}
+
 const propertyCheckService = new PropertyCheckService();
 const propertyCheckDb = new PropertyCheckDatabase();
 const bulkCheckService = new BulkPropertyCheckService();
@@ -2360,7 +2396,7 @@ registry.registerPath({
               ran: z.boolean().openapi({ description: "True if the full storyboard suite ran and agent_storyboard_status was updated. False when ownership couldn't be resolved, the agent reported auth_required, or the compliance call itself failed." }),
               run_id: z.string().optional().openapi({ description: "Compliance run id written by this refresh. Use with /compliance/diagnostics?run_id=... to inspect failing-step wire evidence." }),
               test_session_id: z.string().optional().openapi({ description: "Fresh test session id used for the compliance run. Useful when matching seller-side logs to the refresh." }),
-              requested_compliance_target: z.string().optional().openapi({ description: "Requested compliance target before alias resolution, e.g. 3.0 or 3.1-beta. Present when `ran` is true." }),
+              requested_compliance_target: z.string().optional().openapi({ description: "Requested compliance target before alias resolution, e.g. 3.0, 3.1-rc, or 3.1-beta. Present when `ran` is true." }),
               adcp_version: z.string().optional().openapi({ description: "Concrete AdCP compliance bundle version used for the run, e.g. 3.0.12 or 3.1.0-beta.7. Present when `ran` is true." }),
               badge_eligible: z.boolean().optional().openapi({ description: "True when this run can update public badge state." }),
               badge_eligible_adcp_versions: z.array(z.string()).optional().openapi({ description: "Public badge versions this run can issue, e.g. ['3.0']." }),
@@ -2657,6 +2693,7 @@ registry.registerPath({
   request: {
     query: z.object({
       category: z.string().optional().openapi({ description: "Filter by storyboard category" }),
+      compliance_target: z.string().optional().openapi({ description: "Compliance target to inspect, e.g. 3.0, 3.1-rc, or 3.1-beta" }),
     }),
   },
   responses: {
@@ -2688,6 +2725,9 @@ registry.registerPath({
   request: {
     params: z.object({
       id: z.string().openapi({ description: "Storyboard ID" }),
+    }),
+    query: z.object({
+      compliance_target: z.string().optional().openapi({ description: "Compliance target to inspect, e.g. 3.0, 3.1-rc, or 3.1-beta" }),
     }),
   },
   responses: {
@@ -2942,6 +2982,9 @@ registry.registerPath({
   request: {
     params: z.object({
       storyboardId: z.string(),
+    }),
+    query: z.object({
+      compliance_target: z.string().optional().openapi({ description: "Compliance target to inspect, e.g. 3.0, 3.1-rc, or 3.1-beta" }),
     }),
   },
   responses: {
@@ -5593,12 +5636,23 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         try {
           const testSessionId = `owner-refresh-${Date.now()}-${randomUUID()}`;
           const triggeredBy = ownerOrgId ? 'owner_test' : 'manual';
-          const complyResult = await comply(agentUrl, {
+          const complyOptions = {
             test_session_id: testSessionId,
             timeout_ms: 90_000,
             userAgent: AAO_UA_COMPLIANCE,
             ...(resolvedAuth && { auth: resolvedAuth }),
-          }, complianceTarget);
+          };
+          const runTargetSelection = await selectComplianceTargetForAgentSelection(
+            agentUrl,
+            complyOptions,
+            complianceTarget,
+            'canonical',
+          );
+          const runTarget = runTargetSelection.target;
+          const complyResult = await comply(agentUrl, complyOptions, runTarget);
+          const runBadgeEligibleVersions = [
+            ...badgeEligibleVersionsForTargetSelection(runTargetSelection, complyResult.agent_profile),
+          ];
           logOutboundRequest({
             agent_url: agentUrl,
             request_type: 'compliance',
@@ -5624,9 +5678,9 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
               ran: true,
               run_id: run.id,
               test_session_id: testSessionId,
-              requested_compliance_target: complianceTarget.requested,
+              requested_compliance_target: runTarget.requested,
               adcp_version: complyResult.adcp_version,
-              ...badgeEligibilityMetadata(badgeEligibleAdcpVersions.length > 0),
+              ...badgeEligibilityMetadata(runBadgeEligibleVersions),
               overall_status: dbInput.overall_status,
               storyboards_passing: passing,
               storyboards_total: storyboardStatuses.length,
@@ -5637,17 +5691,27 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
             // Fan out badge issuance so verification badges reflect the new
             // verdict immediately. Matches the per-storyboard owner-test path.
             const declaredSpecialisms = complyResult.agent_profile?.specialisms ?? [];
-            if (declaredSpecialisms.length > 0 && storyboardStatuses.length > 0) {
+            if (declaredSpecialisms.length > 0 && storyboardStatuses.length > 0 && runBadgeEligibleVersions.length > 0) {
               try {
                 await runBadgeFanOut({
                   complianceDb,
                   agentUrl,
                   declaredSpecialisms,
                   runId: run.id,
-                  adcpVersions: badgeEligibleAdcpVersions,
+                  adcpVersions: runBadgeEligibleVersions,
                 });
               } catch (badgeError) {
                 logger.warn({ err: badgeError, agentUrl }, 'Badge fan-out failed after manual refresh');
+              }
+            } else {
+              try {
+                await revokeUnsupportedPublicBadges({
+                  complianceDb,
+                  agentUrl,
+                  supportedVersions: complyResult.agent_profile?.adcp_supported_versions ?? runTargetSelection.supportedVersions,
+                });
+              } catch (badgeError) {
+                logger.warn({ err: badgeError, agentUrl }, 'Unsupported public badge revocation failed after manual refresh');
               }
             }
           }
@@ -6073,14 +6137,20 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
   router.get("/storyboards", async (req, res) => {
     try {
       const category = typeof req.query.category === "string" ? req.query.category : undefined;
-      const results = listStoryboards(category);
+      const runTarget = targetFromRequestValue(req.query.compliance_target);
+      const results = runTarget === complianceTarget
+        ? listStoryboards(category)
+        : summarizeStoryboardsForTarget(runTarget, category);
       res.json({
-        requested_compliance_target: complianceTarget.requested,
-        adcp_version: complianceTarget.version,
+        requested_compliance_target: runTarget.requested,
+        adcp_version: runTarget.version,
         storyboards: results,
         count: results.length,
       });
     } catch (error) {
+      if (error instanceof InvalidComplianceTargetError) {
+        return res.status(400).json({ error: INVALID_COMPLIANCE_TARGET_MESSAGE });
+      }
       logger.error({ err: error, path: req.path }, "Failed to list storyboards");
       res.status(500).json({ error: "Failed to list storyboards" });
     }
@@ -6088,19 +6158,25 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
 
   router.get("/storyboards/:id", async (req, res) => {
     try {
-      const storyboard = getStoryboard(req.params.id);
+      const runTarget = targetFromRequestValue(req.query.compliance_target);
+      const storyboard = runTarget === complianceTarget
+        ? getStoryboard(req.params.id)
+        : getComplianceStoryboardById(req.params.id, hostedComplianceOptions(runTarget));
       if (!storyboard) {
         return res.status(404).json({ error: "Storyboard not found" });
       }
 
       const testKit = getTestKitForStoryboard(req.params.id);
       res.json({
-        requested_compliance_target: complianceTarget.requested,
-        adcp_version: complianceTarget.version,
+        requested_compliance_target: runTarget.requested,
+        adcp_version: runTarget.version,
         storyboard,
         test_kit: testKit || null,
       });
     } catch (error) {
+      if (error instanceof InvalidComplianceTargetError) {
+        return res.status(400).json({ error: INVALID_COMPLIANCE_TARGET_MESSAGE });
+      }
       logger.error({ err: error, path: req.path }, "Failed to get storyboard");
       res.status(500).json({ error: "Failed to get storyboard" });
     }
@@ -6129,7 +6205,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       try {
         const caps = await testCapabilityDiscovery(
           agentUrl,
-          withHostedTestOptions({ ...(sdkAuth && { auth: sdkAuth }) }, complianceTarget),
+          { ...(sdkAuth && { auth: sdkAuth }) },
         );
         profile = caps.profile;
 
@@ -6157,6 +6233,8 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
 
       const supportedProtocols = profile?.supported_protocols ?? [];
       const specialisms = profile?.specialisms ?? [];
+      const runTarget = selectHostedComplianceTargetForProfile(profile, complianceTarget);
+      const runOptions = hostedComplianceOptions(runTarget);
 
       let resolved;
       try {
@@ -6166,7 +6244,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           major_versions: profile?.adcp_major_versions,
           supported_versions: profile?.adcp_supported_versions,
         };
-        resolved = resolveStoryboardsForCapabilities(caps, complianceOptions);
+        resolved = resolveStoryboardsForCapabilities(caps, runOptions);
       } catch (resolveErr) {
         // Fail-closed: agent capabilities are malformed. Distinguish the two
         // concrete cases the resolver throws for — parent-protocol-missing vs
@@ -6175,7 +6253,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         const capsError = classifyCapabilityResolutionError(resolveErr);
         let knownSpecialisms: string[] = [];
         try {
-          knownSpecialisms = loadComplianceIndex(complianceOptions).specialisms.map(s => s.id).sort();
+          knownSpecialisms = loadComplianceIndex(runOptions).specialisms.map(s => s.id).sort();
         } catch (indexErr) {
           logger.warn({ err: indexErr }, "Failed to load compliance index for 422 response");
         }
@@ -6230,8 +6308,8 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         agent_name: profile?.name || "Unknown",
         supported_protocols: supportedProtocols,
         specialisms,
-        requested_compliance_target: complianceTarget.requested,
-        adcp_version: complianceTarget.version,
+        requested_compliance_target: runTarget.requested,
+        adcp_version: runTarget.version,
         bundles,
         total_storyboards: bundles.reduce((n, b) => n + b.storyboards.length, 0),
       };
@@ -6280,17 +6358,26 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           return res.status(403).json({ error: "You do not have permission to test this agent" });
         }
 
-        const storyboard = getComplianceStoryboardById(req.params.storyboardId, complianceOptions);
+        const auth = await resolveUserAgentAuth(agentContextDb, orgId, agentUrl, logger);
+        const sdkAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `run-storyboard-step:${agentUrl}` });
+        const runTarget = await selectComplianceTargetForAgent(
+          agentUrl,
+          {
+            timeout_ms: 90_000,
+            ...(sdkAuth && { auth: sdkAuth }),
+          },
+          complianceTarget,
+        );
+        const runOptions = hostedComplianceOptions(runTarget);
+        const storyboard = getComplianceStoryboardById(req.params.storyboardId, runOptions);
         if (!storyboard) {
           return res.status(404).json({ error: "Storyboard not found" });
         }
 
-        const auth = await resolveUserAgentAuth(agentContextDb, orgId, agentUrl, logger);
-        const sdkAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `run-storyboard-step:${agentUrl}` });
         let authProbeTask: string | undefined;
         if (sdkAuth?.type === 'bearer' || sdkAuth?.type === 'basic') {
           try {
-            const caps = await testCapabilityDiscovery(agentUrl, withHostedTestOptions({ auth: sdkAuth }, complianceTarget));
+            const caps = await testCapabilityDiscovery(agentUrl, withHostedTestOptions({ auth: sdkAuth }, runTarget));
             authProbeTask = hostedAuthProbeTaskForProfile(caps.profile);
           } catch (err) {
             logger.warn({ err, agentUrl }, "Could not infer hosted auth probe task for storyboard step; using default");
@@ -6308,13 +6395,13 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         const result = await runStoryboardStep(agentUrl, storyboard, req.params.stepId, withHostedStoryboardRunOptions({
           ...(sdkAuth && { auth: sdkAuth }),
           ...(context && { context }),
-        }, complianceTarget, authProbeTask));
+        }, runTarget, authProbeTask));
 
         if (!result.passed && isOAuthRequiredErrorMessage(result.error)) {
           const agentContextId = await ensureAgentContextId(orgId, agentUrl, req.user.id);
           return res.json({
-            requested_compliance_target: complianceTarget.requested,
-            adcp_version: complianceTarget.version,
+            requested_compliance_target: runTarget.requested,
+            adcp_version: runTarget.version,
             ...result,
             needs_oauth: true,
             ...(agentContextId && { agent_context_id: agentContextId }),
@@ -6322,8 +6409,8 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         }
 
         res.json({
-          requested_compliance_target: complianceTarget.requested,
-          adcp_version: complianceTarget.version,
+          requested_compliance_target: runTarget.requested,
+          adcp_version: runTarget.version,
           ...result,
         });
       } catch (error) {
@@ -6338,7 +6425,11 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
     "/storyboards/:storyboardId/first-step",
     async (req, res) => {
       try {
-        const storyboard = getComplianceStoryboardById(req.params.storyboardId, complianceOptions);
+        const runTarget = targetFromRequestValue(req.query.compliance_target);
+        const storyboard = getComplianceStoryboardById(
+          req.params.storyboardId,
+          runTarget === complianceTarget ? complianceOptions : hostedComplianceOptions(runTarget),
+        );
         if (!storyboard) {
           return res.status(404).json({ error: "Storyboard not found" });
         }
@@ -6349,12 +6440,15 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         }
 
         res.json({
-          requested_compliance_target: complianceTarget.requested,
-          adcp_version: complianceTarget.version,
+          requested_compliance_target: runTarget.requested,
+          adcp_version: runTarget.version,
           storyboard: { id: storyboard.id, title: storyboard.title },
           step: preview,
         });
       } catch (error) {
+        if (error instanceof InvalidComplianceTargetError) {
+          return res.status(400).json({ error: INVALID_COMPLIANCE_TARGET_MESSAGE });
+        }
         logger.error({ err: error, path: req.path }, "Failed to get first step preview");
         res.status(500).json({ error: "Failed to get first step preview" });
       }
@@ -6381,19 +6475,30 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           return res.status(403).json({ error: "You do not have permission to test this agent" });
         }
 
-        const storyboard = getStoryboard(req.params.storyboardId);
+        const auth = await resolveUserAgentAuth(agentContextDb, orgId, agentUrl, logger);
+        const sdkAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `run-storyboard:${agentUrl}` });
+
+        const complyOptions = {
+          timeout_ms: 90_000,
+          storyboards: [req.params.storyboardId],
+          ...(sdkAuth && { auth: sdkAuth }),
+        };
+        const runTargetSelection = await selectComplianceTargetForAgentSelection(
+          agentUrl,
+          complyOptions,
+          complianceTarget,
+          'canonical',
+        );
+        const runTarget = runTargetSelection.target;
+        const storyboard = getComplianceStoryboardById(req.params.storyboardId, hostedComplianceOptions(runTarget));
         if (!storyboard) {
           return res.status(404).json({ error: "Storyboard not found" });
         }
 
-        const auth = await resolveUserAgentAuth(agentContextDb, orgId, agentUrl, logger);
-        const sdkAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `run-storyboard:${agentUrl}` });
-
-        const complyResult = await comply(agentUrl, {
-          timeout_ms: 90_000,
-          storyboards: [req.params.storyboardId],
-          ...(sdkAuth && { auth: sdkAuth }),
-        }, complianceTarget);
+        const complyResult = await comply(agentUrl, complyOptions, runTarget);
+        const runBadgeEligibleVersions = [
+          ...badgeEligibleVersionsForTargetSelection(runTargetSelection, complyResult.agent_profile),
+        ];
 
         if (complyResult.overall_status === 'auth_required') {
           const agentContextId = await ensureAgentContextId(orgId, agentUrl, req.user.id);
@@ -6422,16 +6527,26 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         // badges for storyboards it didn't touch. No notification — the
         // owner already sees the result in the HTTP response.
         const declaredSpecialisms = complyResult.agent_profile?.specialisms ?? [];
-        if (declaredSpecialisms.length > 0) {
+        if (declaredSpecialisms.length > 0 && runBadgeEligibleVersions.length > 0) {
           try {
             await runBadgeFanOut({
               complianceDb,
               agentUrl,
               declaredSpecialisms,
-              adcpVersions: badgeEligibleAdcpVersions,
+              adcpVersions: runBadgeEligibleVersions,
             });
           } catch (badgeError) {
             logger.warn({ err: badgeError, agentUrl }, 'Badge fan-out failed after storyboard-run');
+          }
+        } else {
+          try {
+            await revokeUnsupportedPublicBadges({
+              complianceDb,
+              agentUrl,
+              supportedVersions: complyResult.agent_profile?.adcp_supported_versions ?? runTargetSelection.supportedVersions,
+            });
+          } catch (badgeError) {
+            logger.warn({ err: badgeError, agentUrl }, 'Unsupported public badge revocation failed after storyboard-run');
           }
         }
 
@@ -6473,9 +6588,9 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
             url: agentUrl,
             profile: complyResult.agent_profile,
           },
-          requested_compliance_target: complianceTarget.requested,
+          requested_compliance_target: runTarget.requested,
           adcp_version: complyResult.adcp_version,
-          ...badgeEligibilityMetadata(badgeEligibleAdcpVersions.length > 0),
+          ...badgeEligibilityMetadata(runBadgeEligibleVersions),
           phases: annotatedPhases,
           summary: complyResult.summary,
           observations: complyResult.observations,
@@ -6509,26 +6624,27 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           return res.status(403).json({ error: "You do not have permission to test this agent" });
         }
 
-        const storyboard = getStoryboard(req.params.storyboardId);
+        const auth = await resolveUserAgentAuth(agentContextDb, orgId, agentUrl, logger);
+        const sdkAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `run-storyboard-compare:${agentUrl}` });
+        const storyboardIds = [req.params.storyboardId];
+        const userComplyOptions = {
+          timeout_ms: 90_000,
+          storyboards: storyboardIds,
+          ...(sdkAuth && { auth: sdkAuth }),
+        };
+        const runTarget = await selectComplianceTargetForAgent(agentUrl, userComplyOptions, complianceTarget);
+        const storyboard = getComplianceStoryboardById(req.params.storyboardId, hostedComplianceOptions(runTarget));
         if (!storyboard) {
           return res.status(404).json({ error: "Storyboard not found" });
         }
 
-        const auth = await resolveUserAgentAuth(agentContextDb, orgId, agentUrl, logger);
-        const sdkAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `run-storyboard-compare:${agentUrl}` });
-        const storyboardIds = [req.params.storyboardId];
-
         const [userResult, referenceResult] = await Promise.all([
-          comply(agentUrl, {
-            timeout_ms: 90_000,
-            storyboards: storyboardIds,
-            ...(sdkAuth && { auth: sdkAuth }),
-          }, complianceTarget),
+          comply(agentUrl, userComplyOptions, runTarget),
           comply(PUBLIC_TEST_AGENT.url, {
             timeout_ms: 90_000,
             storyboards: storyboardIds,
             auth: { type: "bearer", token: PUBLIC_TEST_AGENT.token },
-          }, complianceTarget),
+          }, runTarget),
         ]);
 
         if (userResult.overall_status === 'auth_required') {
@@ -6585,9 +6701,9 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
             profile: referenceResult.agent_profile,
             summary: referenceResult.summary,
           },
-          requested_compliance_target: complianceTarget.requested,
+          requested_compliance_target: runTarget.requested,
           adcp_version: userResult.adcp_version,
-          ...badgeEligibilityMetadata(false),
+          ...badgeEligibilityMetadata([]),
           phases: comparisonPhases,
           total_duration_ms: Math.max(userResult.total_duration_ms, referenceResult.total_duration_ms),
         });

--- a/server/src/services/badge-issuance.ts
+++ b/server/src/services/badge-issuance.ts
@@ -25,6 +25,46 @@ export interface BadgeIssuanceResult {
   unchanged: Array<{ role: BadgeRole; adcp_version: string }>;
 }
 
+function advertisesPublicBadgeVersion(
+  supportedVersions: readonly string[] | undefined,
+  adcpVersion: string,
+): boolean {
+  if (!supportedVersions?.length) return false;
+  return supportedVersions.some(version => {
+    if (version.includes('-')) return false;
+    const match = version.match(/^([1-9][0-9]*\.[0-9]+)(?:\.|$)/);
+    return match?.[1] === adcpVersion;
+  });
+}
+
+export async function revokeUnsupportedPublicBadges(params: {
+  complianceDb: ComplianceDatabase;
+  agentUrl: string;
+  supportedVersions: readonly string[] | undefined;
+}): Promise<BadgeIssuanceResult> {
+  const { complianceDb, agentUrl, supportedVersions } = params;
+  const result: BadgeIssuanceResult = { issued: [], revoked: [], degraded: [], unchanged: [] };
+  if (!supportedVersions?.length) return result;
+
+  const publicBadgeVersions = new Set<string>(SUPPORTED_BADGE_VERSIONS);
+  const existingBadges = await complianceDb.getBadgesForAgent(agentUrl);
+
+  for (const badge of existingBadges) {
+    if (!publicBadgeVersions.has(badge.adcp_version)) continue;
+    if (advertisesPublicBadgeVersion(supportedVersions, badge.adcp_version)) continue;
+
+    const reason = `Agent no longer advertises AdCP ${badge.adcp_version} support`;
+    await complianceDb.revokeBadge(agentUrl, badge.role, badge.adcp_version, reason);
+    result.revoked.push({ role: badge.role, reason, adcp_version: badge.adcp_version });
+    logger.info(
+      { agentUrl, role: badge.role, adcpVersion: badge.adcp_version },
+      'Badge revoked — agent no longer advertises public badge version',
+    );
+  }
+
+  return result;
+}
+
 /**
  * Check and update badge status for an agent after a compliance run.
  *

--- a/server/src/services/hosted-compliance-version.ts
+++ b/server/src/services/hosted-compliance-version.ts
@@ -6,9 +6,15 @@ import type {
   StoryboardRunOptions,
   TestOptions,
 } from '@adcp/sdk/testing';
+import { isComplianceVersionSupported } from '@adcp/sdk/testing';
 import { SUPPORTED_BADGE_VERSIONS } from './adcp-taxonomy.js';
 
 export const DEFAULT_HOSTED_COMPLIANCE_LINE = '3.0';
+export const HOSTED_COMPLIANCE_TARGET_PREFERENCE = [
+  '3.1-rc',
+  '3.1-beta',
+  DEFAULT_HOSTED_COMPLIANCE_LINE,
+] as const;
 
 export interface HostedComplianceTarget {
   requested: string;
@@ -30,6 +36,9 @@ type RuntimeTestKit = Omit<NonNullable<TestOptions['test_kit']>, 'auth'> & {
 type HostedAuthProbeProfile = {
   tools?: readonly string[];
   supported_protocols?: readonly string[];
+};
+type HostedComplianceProfile = {
+  adcp_supported_versions?: readonly string[];
 };
 
 const DEFAULT_HOSTED_AUTH_PROBE_TASK = 'list_creatives';
@@ -62,15 +71,21 @@ function escapeRegex(input: string): string {
 }
 
 function versionSortKey(version: string): number[] {
-  const match = version.match(/^([1-9][0-9]*)\.([0-9]+)\.([0-9]+)(?:-beta\.([0-9]+))?$/);
-  if (!match) return [0, 0, 0, -1];
+  const match = version.match(/^([1-9][0-9]*)\.([0-9]+)\.([0-9]+)(?:-(beta|rc)\.([0-9]+))?$/);
+  if (!match) return [0, 0, 0, -1, -1];
 
-  const [, major, minor, patch, beta] = match;
+  const [, major, minor, patch, prereleaseLabel, prereleaseNumber] = match;
+  const prereleaseRank = prereleaseLabel === 'beta'
+    ? 0
+    : prereleaseLabel === 'rc'
+      ? 1
+      : Number.MAX_SAFE_INTEGER;
   return [
     Number.parseInt(major, 10),
     Number.parseInt(minor, 10),
     Number.parseInt(patch, 10),
-    beta === undefined ? Number.MAX_SAFE_INTEGER : Number.parseInt(beta, 10),
+    prereleaseRank,
+    prereleaseNumber === undefined ? Number.MAX_SAFE_INTEGER : Number.parseInt(prereleaseNumber, 10),
   ];
 }
 
@@ -128,20 +143,28 @@ function latestStableComplianceVersionForLine(line: string): string {
   return latest;
 }
 
-function latestBetaComplianceVersionForLine(line: string): string {
+function latestPrereleaseComplianceVersionForLine(line: string, label: 'beta' | 'rc'): string {
   const complianceRoot = repoPath('dist', 'compliance');
-  const betaRe = new RegExp(`^${escapeRegex(line)}\\.0-beta\\.\\d+$`);
+  const prereleaseRe = new RegExp(`^${escapeRegex(line)}\\.0-${label}\\.\\d+$`);
   const versions = complianceVersions()
-    .filter(name => betaRe.test(name))
+    .filter(name => prereleaseRe.test(name))
     .sort(compareVersions);
 
   const latest = versions.at(-1);
   if (!latest) {
     throw new Error(
-      `No checked-in AdCP ${line}-beta compliance cache found at ${complianceRoot}. Run npm run build:compliance.`,
+      `No checked-in AdCP ${line}-${label} compliance cache found at ${complianceRoot}. Run npm run build:compliance.`,
     );
   }
   return latest;
+}
+
+function latestBetaComplianceVersionForLine(line: string): string {
+  return latestPrereleaseComplianceVersionForLine(line, 'beta');
+}
+
+function latestRcComplianceVersionForLine(line: string): string {
+  return latestPrereleaseComplianceVersionForLine(line, 'rc');
 }
 
 function latestBadgeEligibleComplianceVersionForLine(line: string): string {
@@ -182,11 +205,19 @@ export function resolveHostedComplianceVersion(target: string = DEFAULT_HOSTED_C
   if (betaMatch) {
     return latestBetaComplianceVersionForLine(betaMatch[1]);
   }
-  if (/^[1-9][0-9]*\.[0-9]+\.[0-9]+(?:-beta\.[0-9]+)?$/.test(target)) {
+  const rcMatch = target.match(/^([1-9][0-9]*\.[0-9]+)-rc$/);
+  if (rcMatch) {
+    return latestRcComplianceVersionForLine(rcMatch[1]);
+  }
+  const wirePrereleaseMatch = target.match(/^([1-9][0-9]*\.[0-9]+)-(beta|rc)\.([0-9]+)$/);
+  if (wirePrereleaseMatch) {
+    return `${wirePrereleaseMatch[1]}.0-${wirePrereleaseMatch[2]}.${wirePrereleaseMatch[3]}`;
+  }
+  if (/^[1-9][0-9]*\.[0-9]+\.[0-9]+(?:-(?:beta|rc)\.[0-9]+)?$/.test(target)) {
     return target;
   }
   throw new Error(
-    `Unsupported AdCP compliance target "${target}". Use a line alias like 3.0, a beta alias like 3.1-beta, or an exact bundled version like 3.0.12.`,
+    `Unsupported AdCP compliance target "${target}". Use a line alias like 3.0, a prerelease alias like 3.1-rc or 3.1-beta, or an exact bundled version like 3.0.12.`,
   );
 }
 
@@ -208,7 +239,7 @@ export function isDefaultHostedComplianceTarget(target: HostedComplianceTarget):
 export function badgeEligibleVersionsForHostedComplianceTarget(
   target: HostedComplianceTarget,
 ): readonly string[] {
-  if (target.requested.endsWith('-beta') || target.version.includes('-beta.')) {
+  if (target.requested.includes('-') || target.version.includes('-')) {
     return [];
   }
 
@@ -216,6 +247,111 @@ export function badgeEligibleVersionsForHostedComplianceTarget(
   if (!line || target.requested !== line) return [];
 
   return (SUPPORTED_BADGE_VERSIONS as readonly string[]).includes(line) ? [line] : [];
+}
+
+export function hostedComplianceTargetPreference(): HostedComplianceTarget[] {
+  return HOSTED_COMPLIANCE_TARGET_PREFERENCE.flatMap(requested => {
+    try {
+      return [hostedComplianceTarget(requested)];
+    } catch {
+      return [];
+    }
+  });
+}
+
+function hostedComplianceTargetForBundledVersion(version: string): HostedComplianceTarget {
+  const stableLine = complianceReleaseLine(version);
+  if (stableLine === DEFAULT_HOSTED_COMPLIANCE_LINE && !version.includes('-')) {
+    return hostedComplianceTarget(DEFAULT_HOSTED_COMPLIANCE_LINE);
+  }
+
+  const prerelease = version.match(/^([1-9][0-9]*\.[0-9]+)\.0-(beta|rc)\.([0-9]+)$/);
+  if (prerelease) {
+    return hostedComplianceTarget(`${prerelease[1]}-${prerelease[2]}.${prerelease[3]}`);
+  }
+
+  return hostedComplianceTarget(version);
+}
+
+function hostedComplianceTargetCandidates(): HostedComplianceTarget[] {
+  const byVersion = new Map<string, HostedComplianceTarget>();
+
+  function add(target: HostedComplianceTarget) {
+    if (!byVersion.has(target.version)) {
+      byVersion.set(target.version, target);
+    }
+  }
+
+  function addRequested(requested: string) {
+    try {
+      add(hostedComplianceTarget(requested));
+    } catch {
+      // Optional prerelease aliases may be absent on older release branches.
+    }
+  }
+
+  const bundledVersions = complianceVersions().sort(compareVersions).reverse();
+  addRequested('3.1-rc');
+  for (const version of bundledVersions.filter(v => /^3\.1\.0-rc\.\d+$/.test(v))) {
+    add(hostedComplianceTargetForBundledVersion(version));
+  }
+  addRequested('3.1-beta');
+  for (const version of bundledVersions.filter(v => /^3\.1\.0-beta\.\d+$/.test(v))) {
+    add(hostedComplianceTargetForBundledVersion(version));
+  }
+  addRequested(DEFAULT_HOSTED_COMPLIANCE_LINE);
+
+  for (const version of bundledVersions) {
+    if (version === 'latest') continue;
+    const target = hostedComplianceTargetForBundledVersion(version);
+    add(target);
+  }
+  return [...byVersion.values()];
+}
+
+export function selectHostedComplianceTargetForSupportedVersions(
+  supportedVersions: readonly string[] | undefined,
+  fallback: HostedComplianceTarget = hostedComplianceTarget(),
+): HostedComplianceTarget {
+  if (!supportedVersions?.length) return fallback;
+
+  for (const target of hostedComplianceTargetCandidates()) {
+    const hostedStableLineAlias = hostedStableLineAliasForVersion(target, target.version);
+    if (isComplianceVersionSupported(target.version, supportedVersions, { hostedStableLineAlias })) {
+      return target;
+    }
+  }
+
+  return fallback;
+}
+
+export function selectCanonicalHostedComplianceTargetForSupportedVersions(
+  supportedVersions: readonly string[] | undefined,
+  fallback: HostedComplianceTarget = hostedComplianceTarget(),
+): HostedComplianceTarget {
+  if (!supportedVersions?.length) return fallback;
+
+  const stableTarget = hostedComplianceTarget(DEFAULT_HOSTED_COMPLIANCE_LINE);
+  const hostedStableLineAlias = hostedStableLineAliasForVersion(stableTarget, stableTarget.version);
+  if (isComplianceVersionSupported(stableTarget.version, supportedVersions, { hostedStableLineAlias })) {
+    return stableTarget;
+  }
+
+  return selectHostedComplianceTargetForSupportedVersions(supportedVersions, fallback);
+}
+
+export function selectHostedComplianceTargetForProfile(
+  profile: HostedComplianceProfile | undefined,
+  fallback: HostedComplianceTarget = hostedComplianceTarget(),
+): HostedComplianceTarget {
+  return selectHostedComplianceTargetForSupportedVersions(profile?.adcp_supported_versions, fallback);
+}
+
+export function selectCanonicalHostedComplianceTargetForProfile(
+  profile: HostedComplianceProfile | undefined,
+  fallback: HostedComplianceTarget = hostedComplianceTarget(),
+): HostedComplianceTarget {
+  return selectCanonicalHostedComplianceTargetForSupportedVersions(profile?.adcp_supported_versions, fallback);
 }
 
 export function agentAdvertisesBadgeEligibleHostedComplianceTarget(

--- a/server/tests/unit/storyboards.test.ts
+++ b/server/tests/unit/storyboards.test.ts
@@ -17,9 +17,12 @@ import {
   badgeEligibleVersionsForHostedComplianceTarget,
   hostedAuthProbeTaskForProfile,
   hostedComplianceOptions,
+  hostedComplianceTargetPreference,
   hostedComplianceTarget,
   isDefaultHostedComplianceTarget,
   agentAdvertisesBadgeEligibleHostedComplianceTarget,
+  selectCanonicalHostedComplianceTargetForSupportedVersions,
+  selectHostedComplianceTargetForSupportedVersions,
   withHostedAuthTestKit,
   withHostedComplianceOptions,
 } from '../../src/services/hosted-compliance-version.js';
@@ -28,6 +31,9 @@ import {
   loadComplianceIndex,
   resolveStoryboardsForCapabilities,
 } from '@adcp/sdk/testing';
+import {
+  badgeEligibleVersionsForTargetSelection,
+} from '../../src/addie/services/compliance-testing.js';
 
 /**
  * These tests cover the wrapper in services/storyboards.ts. Catalog content
@@ -177,6 +183,14 @@ describe('wrapper contract', () => {
     const beta = hostedComplianceTarget('3.1-beta');
     expect(beta.requested).toBe('3.1-beta');
     expect(beta.version).toMatch(/^3\.1\.0-beta\.\d+$/);
+
+    const rc = hostedComplianceTarget('3.1-rc');
+    expect(rc.requested).toBe('3.1-rc');
+    expect(rc.version).toMatch(/^3\.1\.0-rc\.\d+$/);
+
+    const wireRc = hostedComplianceTarget('3.1-rc.4');
+    expect(wireRc.requested).toBe('3.1-rc.4');
+    expect(wireRc.version).toBe('3.1.0-rc.4');
   });
 
   it('keeps explicit beta targets diagnostic-only', () => {
@@ -200,6 +214,38 @@ describe('wrapper contract', () => {
     expect(isDefaultHostedComplianceTarget(exactHistoricalCache)).toBe(false);
     expect(badgeEligibleVersionsForHostedComplianceTarget(exactHistoricalCache)).toEqual([]);
     expect(agentAdvertisesBadgeEligibleHostedComplianceTarget(['3.0.5'], exactHistoricalCache)).toBe(false);
+  });
+
+  it('selects the highest hosted target advertised by the agent', () => {
+    expect(hostedComplianceTargetPreference().map(t => t.requested)).toEqual([
+      '3.1-rc',
+      '3.1-beta',
+      '3.0',
+    ]);
+
+    expect(selectHostedComplianceTargetForSupportedVersions(['3.0']).requested).toBe('3.0');
+    expect(selectHostedComplianceTargetForSupportedVersions(['3.0', '3.1-beta.7']).requested).toBe('3.1-beta');
+    expect(selectHostedComplianceTargetForSupportedVersions(['3.0', '3.1-rc.4']).requested).toBe('3.1-rc');
+    expect(selectHostedComplianceTargetForSupportedVersions(['3.1-beta.5']).requested).toBe('3.1-beta.5');
+    expect(selectHostedComplianceTargetForSupportedVersions(['3.1-beta.5']).version).toBe('3.1.0-beta.5');
+    expect(selectHostedComplianceTargetForSupportedVersions(['3.0', '3.1-beta.5']).requested).toBe('3.1-beta.5');
+    expect(selectHostedComplianceTargetForSupportedVersions(['3.0', '3.1-rc.3']).requested).toBe('3.1-rc.3');
+    expect(selectHostedComplianceTargetForSupportedVersions(['3.1']).requested).toBe('3.0');
+    expect(selectHostedComplianceTargetForSupportedVersions(undefined).requested).toBe('3.0');
+
+    expect(selectCanonicalHostedComplianceTargetForSupportedVersions(['3.0', '3.1-rc.4']).requested).toBe('3.0');
+    expect(selectCanonicalHostedComplianceTargetForSupportedVersions(['3.1-rc.4']).requested).toBe('3.1-rc');
+  });
+
+  it('does not treat an unconfirmed fallback target as badge eligible', () => {
+    const stable = hostedComplianceTarget('3.0');
+
+    expect(badgeEligibleVersionsForTargetSelection({ target: stable, confirmed: false })).toEqual([]);
+    expect(badgeEligibleVersionsForTargetSelection(
+      { target: stable, confirmed: false },
+      { adcp_supported_versions: ['3.0'] },
+    )).toEqual(['3.0']);
+    expect(badgeEligibleVersionsForTargetSelection({ target: stable, confirmed: true })).toEqual(['3.0']);
   });
 
   it('rejects unsupported compliance targets before path resolution', () => {

--- a/static/compliance/source/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
@@ -168,7 +168,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "$generate:uuid_v4#media_buy_seller_measurement_terms_rejected_reject_terms_create_media_buy_aggressive_terms"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_measurement_terms_rejected_accept_terms_create_media_buy_relaxed_terms"
           start_time: "2026-07-01T00:00:00Z"
           end_time: "2026-09-30T23:59:59Z"
           packages:

--- a/static/compliance/source/protocols/media-buy/state-machine.yaml
+++ b/static/compliance/source/protocols/media-buy/state-machine.yaml
@@ -157,8 +157,8 @@ phases:
             operator: "pinnacle-agency.example"
           brand:
             domain: "acmeoutdoor.example"
-          start_time: "2026-05-01T00:00:00Z"
-          end_time: "2026-05-31T23:59:59Z"
+          start_time: "2026-07-01T00:00:00Z"
+          end_time: "2026-09-30T23:59:59Z"
           packages:
             - product_id: "test-product"
               budget: 10000

--- a/static/compliance/source/universal/idempotency.yaml
+++ b/static/compliance/source/universal/idempotency.yaml
@@ -212,8 +212,8 @@ phases:
             operator: "pinnacle-agency.example"
           brand:
             domain: "acmeoutdoor.example"
-          start_time: "2026-05-01T00:00:00Z"
-          end_time: "2026-05-31T23:59:59Z"
+          start_time: "2026-07-01T00:00:00Z"
+          end_time: "2026-09-30T23:59:59Z"
           packages:
             - product_id: "test-product"
               budget: 5000

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -6973,7 +6973,7 @@ paths:
                         description: Fresh test session id used for the compliance run. Useful when matching seller-side logs to the refresh.
                       requested_compliance_target:
                         type: string
-                        description: Requested compliance target before alias resolution, e.g. 3.0 or 3.1-beta. Present when `ran` is true.
+                        description: Requested compliance target before alias resolution, e.g. 3.0, 3.1-rc, or 3.1-beta. Present when `ran` is true.
                       adcp_version:
                         type: string
                         description: Concrete AdCP compliance bundle version used for the run, e.g. 3.0.12 or 3.1.0-beta.7. Present when `ran` is true.
@@ -7588,6 +7588,13 @@ paths:
           description: Filter by storyboard category
           name: category
           in: query
+        - schema:
+            type: string
+            description: Compliance target to inspect, e.g. 3.0, 3.1-rc, or 3.1-beta
+          required: false
+          description: Compliance target to inspect, e.g. 3.0, 3.1-rc, or 3.1-beta
+          name: compliance_target
+          in: query
       responses:
         "200":
           description: Storyboard catalog
@@ -7632,6 +7639,13 @@ paths:
           description: Storyboard ID
           name: id
           in: path
+        - schema:
+            type: string
+            description: Compliance target to inspect, e.g. 3.0, 3.1-rc, or 3.1-beta
+          required: false
+          description: Compliance target to inspect, e.g. 3.0, 3.1-rc, or 3.1-beta
+          name: compliance_target
+          in: query
       responses:
         "200":
           description: Storyboard detail
@@ -8091,6 +8105,13 @@ paths:
           required: true
           name: storyboardId
           in: path
+        - schema:
+            type: string
+            description: Compliance target to inspect, e.g. 3.0, 3.1-rc, or 3.1-beta
+          required: false
+          description: Compliance target to inspect, e.g. 3.0, 3.1-rc, or 3.1-beta
+          name: compliance_target
+          in: query
       responses:
         "200":
           description: First step preview


### PR DESCRIPTION
## Summary
- fixes hosted compliance target recovery for 3.1 RC/beta diagnostics while keeping badge-writing flows stable-first
- revokes stale public 3.0 badges when confirmed agent capabilities no longer advertise 3.0 support
- patches AAO compliance fixtures for forward Q3 2026 media-buy windows and fresh idempotency aliases, including selected prerelease caches
- hardens compliance build lint against stable or duplicate generated idempotency keys on mutating storyboard steps

## Verification
- npm run typecheck
- npx vitest run server/tests/unit/storyboards.test.ts tests/addie/member-tools.test.ts --pool=threads
- npm run build:compliance
- npm run test:storyboard-contradictions
- git diff --check
- precommit hook: npm run test:unit, npm run test:test-dynamic-imports, npm run test:callapi-state-change, npm run typecheck
- pre-push hook: version sync, current + 3.0 storyboard matrix, docs link checks

## Notes
- Expert review was run twice. The second pass blockers were addressed: stale public badge revocation and selected prerelease measurement_terms_rejected idempotency aliases.
- A 3.0.x backport PR will carry only the stable-line fixture/lint fixes; hosted 3.1 target recovery is main-only.
