### PR TITLE
fix(addie): stabilize upcoming event day count

### DIFF
--- a/.changeset/member-event-days-rounding.md
+++ b/.changeset/member-event-days-rounding.md
@@ -1,0 +1,6 @@
+---
+"adcontextprotocol": patch
+---
+
+Match the 3.1 line's upcoming-event day calculation in member context prompts
+so events exactly five days out do not intermittently render as four days.

--- a/server/src/addie/member-context.ts
+++ b/server/src/addie/member-context.ts
@@ -1564,7 +1564,7 @@ export function formatMemberContextForPrompt(context: MemberContext, channel: 'w
   // Upcoming registered event — context for time-bound discussions.
   if (context.next_event) {
     const e = context.next_event;
-    const days = Math.floor(
+    const days = Math.round(
       (e.starts_at.getTime() - Date.now()) / (24 * 60 * 60 * 1000)
     );
     lines.push('');


### PR DESCRIPTION
## Summary
- match main's upcoming-event day calculation by rounding the day delta instead of flooring it
- add a 3.0.x changeset so the release PR consumes the source fix cleanly

## Verification
- npx vitest run server/tests/unit/member-context.test.ts --pool=threads
- precommit: unit tests, dynamic import lint, typecheck
- pre-push: version sync, Mintlify broken-link check