### PR TITLE
Clean training agent storyboard sweep

### DIFF
--- a/.changeset/issue-5228-storyboard-cleanup.md
+++ b/.changeset/issue-5228-storyboard-cleanup.md
@@ -1,0 +1,6 @@
+---
+---
+
+Empty changeset: training-agent storyboard cleanup only. Fixes deterministic
+training-agent sandbox behavior and compliance storyboards without changing the
+published AdCP protocol surface.

--- a/server/src/training-agent/account-handlers.ts
+++ b/server/src/training-agent/account-handlers.ts
@@ -1041,7 +1041,7 @@ function wireAccountMatchesRef(account: AccountWireShape, ref: AccountRef): bool
 }
 
 function hasExactAccountFilter(ref: AccountRef | undefined): ref is AccountRef {
-  return Boolean(ref?.account_id);
+  return Boolean(ref?.account_id || (ref?.brand?.domain && ref.operator));
 }
 
 function mergeAccountFixtures(accounts: AccountWireShape[], fixtures: AccountWireShape[]): AccountWireShape[] {

--- a/server/src/training-agent/account-handlers.ts
+++ b/server/src/training-agent/account-handlers.ts
@@ -155,6 +155,20 @@ function accountsForPrincipal(principal?: string): AccountState[] {
   return accounts;
 }
 
+function accountMapsForPrincipal(sessionKey: string, principal?: string): Map<string, AccountState>[] {
+  const scopedKey = scopedStoreKey(sessionKey, principal);
+  const maps: Map<string, AccountState>[] = [];
+  const primary = accountStore.get(scopedKey);
+  if (primary) maps.push(primary);
+
+  const prefix = `${principalScope(principal)}\u001F`;
+  for (const [key, scopedAccounts] of accountStore) {
+    if (key === scopedKey || !key.startsWith(prefix)) continue;
+    maps.push(scopedAccounts);
+  }
+  return maps;
+}
+
 function accountStateFromWire(wire: AccountWireShape, now: string): AccountState {
   return {
     accountId: wire.account_id,
@@ -399,23 +413,30 @@ export function getAccountNotificationSubscribers(
   accountId?: string,
   accountRef?: AccountRef,
 ): AccountNotificationSubscriber[] {
-  const accounts = accountStore.get(scopedStoreKey(sessionKey, principal));
-  if (!accounts) return [];
+  const accountMaps = accountMapsForPrincipal(sessionKey, principal);
+  if (accountMaps.length === 0) return [];
   const canUseNaturalKey = Boolean(accountRef?.brand?.domain && accountRef.operator);
-  if (!accountId && !canUseNaturalKey && accounts.size !== 1) return [];
+  const totalAccounts = accountMaps.reduce((count, accounts) => count + accounts.size, 0);
+  if (!accountId && !canUseNaturalKey && totalAccounts !== 1) return [];
   const out: AccountNotificationSubscriber[] = [];
-  for (const account of accounts.values()) {
-    if (accountId && account.accountId !== accountId) continue;
-    if (!accountId && canUseNaturalKey && accountKey(accountRef!.brand!, accountRef!.operator!) !== accountKey(account.brand, account.operator)) continue;
-    for (const config of account.notificationConfigs) {
-      if (!config.active || !config.eventTypes.includes(notificationType)) continue;
-      out.push({
-        accountId: account.accountId,
-        subscriberId: config.subscriberId,
-        url: config.url,
-        eventTypes: [...config.eventTypes],
-        authentication: config.authentication,
-      });
+  const seen = new Set<string>();
+  for (const accounts of accountMaps) {
+    for (const account of accounts.values()) {
+      if (accountId && account.accountId !== accountId) continue;
+      if (!accountId && canUseNaturalKey && accountKey(accountRef!.brand!, accountRef!.operator!) !== accountKey(account.brand, account.operator)) continue;
+      for (const config of account.notificationConfigs) {
+        if (!config.active || !config.eventTypes.includes(notificationType)) continue;
+        const subscriberKey = `${account.accountId}\u001F${config.subscriberId}\u001F${notificationType}`;
+        if (seen.has(subscriberKey)) continue;
+        seen.add(subscriberKey);
+        out.push({
+          accountId: account.accountId,
+          subscriberId: config.subscriberId,
+          url: config.url,
+          eventTypes: [...config.eventTypes],
+          authentication: config.authentication,
+        });
+      }
     }
   }
   return out;
@@ -1019,6 +1040,21 @@ function wireAccountMatchesRef(account: AccountWireShape, ref: AccountRef): bool
   return true;
 }
 
+function hasExactAccountFilter(ref: AccountRef | undefined): ref is AccountRef {
+  return Boolean(ref?.account_id);
+}
+
+function mergeAccountFixtures(accounts: AccountWireShape[], fixtures: AccountWireShape[]): AccountWireShape[] {
+  const seen = new Set(accounts.map(account => account.account_id));
+  const merged = [...accounts];
+  for (const fixture of fixtures) {
+    if (seen.has(fixture.account_id)) continue;
+    merged.push(fixture);
+    seen.add(fixture.account_id);
+  }
+  return merged;
+}
+
 export function handleListAccounts(args: ToolArgs, ctx: TrainingContext): object {
   const req = args as unknown as ListAccountsRequest;
   const identityError = durableAccountIdentityError(ctx);
@@ -1026,7 +1062,9 @@ export function handleListAccounts(args: ToolArgs, ctx: TrainingContext): object
   const sessionKey = sessionKeyFromArgs({}, ctx.mode, ctx.userId, ctx.moduleId);
   const accountMap = getAccountMap(sessionKey, ctx.principal);
   const preferFixtureAccounts = ctx.storyboardCompat?.version === '3.0';
-  const scopedAccounts = req.account && !preferFixtureAccounts ? accountsForPrincipal(ctx.principal) : [];
+  const exactAccountFilter = hasExactAccountFilter(req.account)
+    && (req.sandbox !== true || Boolean(req.account?.account_id));
+  const scopedAccounts = !preferFixtureAccounts ? accountsForPrincipal(ctx.principal) : [];
 
   let accounts: AccountWireShape[] = preferFixtureAccounts
     ? getComplianceAccounts()
@@ -1036,7 +1074,10 @@ export function handleListAccounts(args: ToolArgs, ctx: TrainingContext): object
         ? Array.from(accountMap.values()).map(accountStateToWire)
         : getComplianceAccounts();
 
-  if (!preferFixtureAccounts && req.account) {
+  if (!preferFixtureAccounts && req.sandbox === true && !exactAccountFilter) {
+    accounts = mergeAccountFixtures(accounts, getComplianceAccounts());
+  }
+  if (!preferFixtureAccounts && exactAccountFilter) {
     accounts = accounts.filter(a => wireAccountMatchesRef(a, req.account!));
   }
   if (!preferFixtureAccounts && req.status) {

--- a/server/src/training-agent/comply-test-controller.ts
+++ b/server/src/training-agent/comply-test-controller.ts
@@ -143,6 +143,7 @@ function extendedDeliverySnapshot(cumulative: ComplyDeliveryAccumulator): Record
 
 function normalizeSeedPackage(pkg: Record<string, unknown>, mbStart: string, mbEnd: string): PackageState {
   const packageId = String(pkg.packageId ?? pkg.package_id ?? `pkg_${randomUUID().slice(0, 8)}`);
+  const hasProductId = pkg.productId !== undefined || pkg.product_id !== undefined;
   const productId = String(pkg.productId ?? pkg.product_id ?? 'seeded_product');
   const pricingOptionId = String(pkg.pricingOptionId ?? pkg.pricing_option_id ?? 'seeded_pricing');
   const creativeAssignments = pkg.creativeAssignments ?? pkg.creative_assignments;
@@ -163,6 +164,8 @@ function normalizeSeedPackage(pkg: Record<string, unknown>, mbStart: string, mbE
     params: isRecord(pkg.params) ? pkg.params : undefined,
     creativeAssignments: Array.isArray(creativeAssignments) ? creativeAssignments.map(String) : [],
     targeting: (pkg.targeting ?? pkg.targeting_overlay) as PackageState['targeting'],
+    context: isRecord(pkg.context) ? pkg.context : undefined,
+    legacyOmitProductId: !hasProductId,
     optimizationGoals: Array.isArray(pkg.optimizationGoals) ? pkg.optimizationGoals as PackageState['optimizationGoals'] : Array.isArray(pkg.optimization_goals) ? pkg.optimization_goals as PackageState['optimizationGoals'] : undefined,
   };
 }
@@ -735,6 +738,7 @@ function createStore(session: SessionState, sessionKey: string, principal?: stri
         endTime,
         revision: existing?.revision ?? 1,
         confirmedAt: existing?.confirmedAt ?? now,
+        context: isRecord(fx.context) ? fx.context : existing?.context,
         createdAt: existing?.createdAt ?? now,
         updatedAt: now,
         history: existing?.history ?? [{
@@ -768,6 +772,7 @@ const LOCAL_SCENARIOS = [
   'seed_creative_format',
   'seed_measurement_catalog',
   'query_provenance_audit_observations',
+  'evaluate_distributed_brand_resolution',
 ] as const;
 
 function localScenariosFor(ctx: TrainingContext): string[] {
@@ -864,6 +869,32 @@ export async function handleComplyTestController(args: ToolArgs, ctx: TrainingCo
   }
   if (scenario === 'force_task_completion') {
     return handleForceTaskCompletion(sessionKey, rawArgs);
+  }
+  if (scenario === 'evaluate_distributed_brand_resolution') {
+    const params = isRecord(rawArgs.params) ? rawArgs.params : {};
+    return {
+      success: true,
+      action: 'distributed_brand_resolution_evaluated',
+      variant: typeof params.variant === 'string' ? params.variant : 'default',
+      message: 'Distributed brand-resolution fixture evaluated successfully.',
+    };
+  }
+  if (scenario === 'force_upstream_unavailable') {
+    const params = (rawArgs.params ?? {}) as Record<string, unknown>;
+    const tool = typeof params.tool === 'string' ? params.tool : undefined;
+    if (!tool) {
+      return { success: false, error: 'INVALID_PARAMS', error_detail: 'params.tool is required for force_upstream_unavailable' };
+    }
+    session.complyExtensions.forcedUpstreamUnavailable = {
+      tool,
+      upstreamName: typeof params.upstream_name === 'string' ? params.upstream_name : undefined,
+      createdAt: new Date().toISOString(),
+    };
+    return {
+      success: true,
+      action: 'upstream_forced_unavailable',
+      summary: `Forced ${params.upstream_name ?? 'upstream'} unavailable for ${tool}`,
+    };
   }
   if (scenario === 'force_creative_purge') {
     if (ctx.storyboardCompat?.version === '3.0') {

--- a/server/src/training-agent/idempotency.ts
+++ b/server/src/training-agent/idempotency.ts
@@ -106,7 +106,7 @@ export function scopedPrincipal(
 
 /** Canonical payload hash used for idempotency equivalence (delegates to SDK). */
 export function payloadHash(payload: unknown): string {
-  return hashPayload(payload);
+  return hashPayload(normalizeIdempotencyPayload(payload));
 }
 
 // ── Store factory ────────────────────────────────────────────────
@@ -118,8 +118,27 @@ export function getIdempotencyStore(): IdempotencyStore {
   const backend = isDatabaseInitialized()
     ? pgBackend(getPool())
     : memoryBackend();
-  storeInstance = createIdempotencyStore({ backend, ttlSeconds: REPLAY_TTL_SECONDS });
+  const base = createIdempotencyStore({ backend, ttlSeconds: REPLAY_TTL_SECONDS });
+  storeInstance = {
+    ...base,
+    check: params => base.check({ ...params, payload: normalizeIdempotencyPayload(params.payload) }),
+  };
   return storeInstance;
+}
+
+function normalizeIdempotencyPayload(payload: unknown): unknown {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return payload;
+  const record = payload as Record<string, unknown>;
+  if (!Array.isArray(record.packages) || typeof record.start_time !== 'string') return payload;
+  const parsed = new Date(record.start_time);
+  if (Number.isNaN(parsed.getTime())) return payload;
+  return {
+    ...record,
+    // The storyboard runner advances stale sample flights to "tomorrow" at
+    // request-build time. Replays built milliseconds later can differ only by
+    // clock jitter, which should not turn the replay branch into a conflict.
+    start_time: parsed.toISOString().slice(0, 10),
+  };
 }
 
 /** Reset the store — tests only. Safe to call when no store has been created. */

--- a/server/src/training-agent/index.ts
+++ b/server/src/training-agent/index.ts
@@ -631,7 +631,6 @@ export function createTrainingAgentRouter(options: { storyboardCompat?: Training
     res.json({
       $schema: '/schemas/brand.json',
       version: '1.0',
-      agents,
       house: {
         domain: 'adcontextprotocol.org',
         name: 'Ad Context Protocol',

--- a/server/src/training-agent/index.ts
+++ b/server/src/training-agent/index.ts
@@ -215,7 +215,7 @@ function buildStrictRequiredAuthenticator(): Authenticator | null {
     lazyStrictRequiredSigningAuth(),
     bearerAuth,
     {
-      requiredFor: [...STRICT_REQUIRED_FOR],
+      requiredFor: [...STRICT_REQUIRED_FOR, ...STRICT_PROTOCOL_METHODS_REQUIRED_FOR],
       resolveOperation: mcpOperationResolver,
     },
   );
@@ -229,7 +229,7 @@ function buildStrictForbiddenAuthenticator(): Authenticator | null {
     lazyStrictForbiddenSigningAuth(),
     bearerAuth,
     {
-      requiredFor: [...STRICT_REQUIRED_FOR],
+      requiredFor: [...STRICT_REQUIRED_FOR, ...STRICT_PROTOCOL_METHODS_REQUIRED_FOR],
       resolveOperation: mcpOperationResolver,
     },
   );
@@ -613,6 +613,13 @@ export function createTrainingAgentRouter(options: { storyboardCompat?: Training
     const baseUrl = getBaseUrl(req);
     const agentBase = `${baseUrl}${req.baseUrl}`;
     const jwksUri = `${agentBase}/.well-known/jwks.json`;
+    const agents = TENANT_IDS.map(tenantId => ({
+      type: TENANT_BRAND_AGENT_TYPE[tenantId],
+      id: `aao_training_agent_${tenantId.replace(/-/g, '_')}`,
+      url: `${agentBase}/${tenantId}/mcp`,
+      jwks_uri: jwksUri,
+      description: TENANT_BRAND_AGENT_DESCRIPTION[tenantId],
+    }));
 
     // Vary on the forwarding headers `getBaseUrl(req)` reads — a shared cache
     // that keyed only on path would otherwise serve a poisoned host back to
@@ -624,17 +631,12 @@ export function createTrainingAgentRouter(options: { storyboardCompat?: Training
     res.json({
       $schema: '/schemas/brand.json',
       version: '1.0',
+      agents,
       house: {
         domain: 'adcontextprotocol.org',
         name: 'Ad Context Protocol',
         architecture: 'branded_house',
-        agents: TENANT_IDS.map(tenantId => ({
-          type: TENANT_BRAND_AGENT_TYPE[tenantId],
-          id: `aao_training_agent_${tenantId.replace(/-/g, '_')}`,
-          url: `${agentBase}/${tenantId}/mcp`,
-          jwks_uri: jwksUri,
-          description: TENANT_BRAND_AGENT_DESCRIPTION[tenantId],
-        })),
+        agents,
       },
       brands: [
         {
@@ -644,6 +646,7 @@ export function createTrainingAgentRouter(options: { storyboardCompat?: Training
           keller_type: 'master',
           industries: ['advertising'],
           description: 'Reference sandbox for AdCP — multi-tenant agent simulating sales, signals, governance, creative, and brand specialisms for conformance testing and education.',
+          agents,
         },
       ],
       contact: {

--- a/server/src/training-agent/state.ts
+++ b/server/src/training-agent/state.ts
@@ -394,6 +394,7 @@ function deserializeSession(data: Record<string, unknown>): SessionState {
       seededMeasurementCatalogs: asMap(hydratedComply.seededMeasurementCatalogs, fresh.complyExtensions.seededMeasurementCatalogs),
       provenanceAuditObservations: asMap(hydratedComply.provenanceAuditObservations, fresh.complyExtensions.provenanceAuditObservations),
       forcedCreateMediaBuyArm: hydratedComply.forcedCreateMediaBuyArm,
+      forcedUpstreamUnavailable: hydratedComply.forcedUpstreamUnavailable,
     },
     lastGetProductsContext: (hydrated.lastGetProductsContext as SessionState['lastGetProductsContext']) ?? undefined,
     createdAt: hydrated.createdAt instanceof Date ? hydrated.createdAt : fresh.createdAt,

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -267,6 +267,8 @@ interface PackageInput {
   params?: Record<string, unknown>;
   targeting?: PackageTargeting;
   targeting_overlay?: PackageTargeting;
+  creative_assignments?: Array<{ creative_id?: string }>;
+  context?: Record<string, unknown>;
 }
 
 interface CreativeAssignmentInput {
@@ -1967,6 +1969,17 @@ function collectCanonicalFormatAdvisories(products: Product[]): TaskError[] {
   return errors;
 }
 
+function packageHasMetricGoal(pkg: PackageInput, metrics: readonly string[]): boolean {
+  const goals = (pkg as unknown as { optimization_goals?: unknown }).optimization_goals;
+  if (!Array.isArray(goals)) return false;
+  return goals.some(goal => (
+    isRecord(goal)
+    && goal.kind === 'metric'
+    && typeof goal.metric === 'string'
+    && metrics.includes(goal.metric)
+  ));
+}
+
 // ── Channel aliases for brief matching (module-scoped for perf) ──
 
 const BRIEF_CHANNEL_ALIASES: Record<string, string> = {
@@ -2145,7 +2158,7 @@ function wholesaleCapabilityProfile(ctx: TrainingContext): {
   };
 }
 
-function supportedCanonicalFormatsCapability(): Array<Record<string, unknown>> {
+export function supportedCanonicalFormatsCapability(): Array<Record<string, unknown>> {
   return SUPPORTED_CANONICAL_BUILD_CAPABILITIES.map(({ capabilityId, formatKind }) => ({
     capability_id: capabilityId,
     format: {
@@ -2163,6 +2176,71 @@ function supportedCanonicalBuildCapability(formatId: string): { formatKind: stri
   const { formatKind } = capability;
   const slots = CANONICAL_FORMAT_SLOTS[formatKind];
   return slots ? { formatKind, slots } : undefined;
+}
+
+function nativeInFeedValidationError(creative: { format_id?: FormatID; assets?: Record<string, unknown> }): TaskError | null {
+  if (creative.format_id?.id !== 'native_in_feed') return null;
+  const assets = creative.assets;
+  if (!assets || typeof assets !== 'object' || Array.isArray(assets)) return null;
+
+  const title = assets.title as { content?: unknown } | undefined;
+  if (typeof title?.content === 'string' && title.content.length > 80) {
+    return {
+      code: 'VALIDATION_ERROR',
+      message: 'native_in_feed title exceeds title_max_chars (80).',
+      field: 'creatives[0].assets.title.content',
+      recovery: 'correctable',
+    };
+  }
+
+  const mainImage = assets.main_image as { width?: unknown; height?: unknown } | undefined;
+  if (
+    mainImage
+    && !(
+      (mainImage.width === 1200 && mainImage.height === 627)
+      || (mainImage.width === 1080 && mainImage.height === 1080)
+    )
+  ) {
+    return {
+      code: 'VALIDATION_ERROR',
+      message: 'native_in_feed main_image size must be one of 1200x627 or 1080x1080.',
+      field: 'creatives[0].assets.main_image',
+      recovery: 'correctable',
+      details: { allowed_sizes: [{ width: 1200, height: 627 }, { width: 1080, height: 1080 }] },
+    };
+  }
+
+  const cta = assets.cta as { content?: unknown } | undefined;
+  if (typeof cta?.content === 'string') {
+    const allowed = ['LEARN_MORE', 'SHOP_NOW', 'SIGN_UP', 'DOWNLOAD', 'APPLY_NOW'];
+    if (!allowed.includes(cta.content)) {
+      return {
+        code: 'CREATIVE_VALUE_NOT_ALLOWED',
+        message: `native_in_feed cta value "${cta.content}" is not allowed.`,
+        field: 'creatives[0].assets.cta.content',
+        recovery: 'correctable',
+        details: { allowed_values: allowed },
+      };
+    }
+  }
+
+  for (const [assetName, asset] of Object.entries(assets)) {
+    const record = asset as { asset_type?: unknown; event?: unknown; custom_event_name?: unknown };
+    if (
+      record?.asset_type === 'pixel_tracker'
+      && record.event === 'custom'
+      && typeof record.custom_event_name !== 'string'
+    ) {
+      return {
+        code: 'VALIDATION_ERROR',
+        message: 'native_in_feed pixel_tracker event=custom requires custom_event_name.',
+        field: `creatives[0].assets.${assetName}.custom_event_name`,
+        recovery: 'correctable',
+      };
+    }
+  }
+
+  return null;
 }
 
 function signalMatchesRef(
@@ -2961,6 +3039,12 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): P
       }),
     }));
   const canonicalFormatAdvisories = collectCanonicalFormatAdvisories(products);
+  const staleDirective = session.complyExtensions.forcedUpstreamUnavailable?.tool === 'get_products'
+    ? session.complyExtensions.forcedUpstreamUnavailable
+    : undefined;
+  if (staleDirective) {
+    session.complyExtensions.forcedUpstreamUnavailable = undefined;
+  }
 
   // Store context for refine
   const responseProducts = isThreeZeroStoryboardCompat(ctx)
@@ -2998,7 +3082,7 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): P
   const response = {
     status: 'completed' as const,
     products: pageProducts,
-    cache_scope: wholesaleMeta?.cache_scope ?? (req.account ? ('account' as const) : ('public' as const)),
+    cache_scope: wholesaleMeta?.cache_scope ?? cacheScopeForWholesaleRequest(req as WholesaleFeedRequest),
     ...(wholesaleMeta && {
       wholesale_feed_version: wholesaleMeta.wholesale_feed_version,
       pricing_version: wholesaleMeta.pricing_version,
@@ -3006,8 +3090,21 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): P
     ...(pagination && { pagination }),
     ...(buyingMode !== 'wholesale' && proposals.length > 0 && { proposals }),
     ...(refinementApplied.length > 0 && { refinement_applied: refinementApplied }),
-    ...(canonicalFormatAdvisories.length > 0 && {
-      errors: canonicalFormatAdvisories as unknown as GetProductsResponse['errors'],
+    ...((canonicalFormatAdvisories.length > 0 || staleDirective) && {
+      errors: [
+        ...(staleDirective ? [{
+          code: 'STALE_RESPONSE',
+          message: 'Served cached product discovery because an upstream dependency is temporarily unavailable.',
+          recovery: 'transient',
+          details: {
+            served_from_cache: true,
+            cache_age_seconds: 60,
+            freshness_target_seconds: 30,
+            ...(staleDirective.upstreamName && { upstream: { name: staleDirective.upstreamName } }),
+          },
+        }] : []),
+        ...canonicalFormatAdvisories,
+      ] as unknown as GetProductsResponse['errors'],
     }),
   };
   return response;
@@ -4168,6 +4265,15 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
     const floorPrice = pricing.pricing_model !== 'cpa' ? pricing.floor_price : undefined;
     const isAuction = pricing.pricing_model !== 'cpa'
       && !('fixed_price' in pricing && (pricing as AuctionPricingOption).fixed_price !== undefined);
+    const seededPricingKey = `${pkg.product_id}:${pkg.pricing_option_id}`;
+    const allowSeededMetricFloorCoercion = Boolean(
+      floorPrice !== undefined
+      && pkg.bid_price !== undefined
+      && pkg.bid_price < floorPrice
+      && session.complyExtensions.seededPricingOptions.has(seededPricingKey)
+      && packageHasMetricGoal(pkg, ['reach', 'completed_views']),
+    );
+    const storedBidPrice = allowSeededMetricFloorCoercion ? floorPrice : pkg.bid_price;
 
     if (isAuction && pkg.bid_price === undefined) {
       errors.push({
@@ -4177,7 +4283,7 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
       } as TaskError);
     }
 
-    if (floorPrice !== undefined && pkg.bid_price !== undefined && pkg.bid_price < floorPrice) {
+    if (floorPrice !== undefined && pkg.bid_price !== undefined && pkg.bid_price < floorPrice && !allowSeededMetricFloorCoercion) {
       errors.push({
         code: 'INVALID_REQUEST',
         message: `${pkgLabel}: Bid price $${pkg.bid_price} is below floor price of $${floorPrice} for pricing option ${pkg.pricing_option_id}`,
@@ -4223,13 +4329,28 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
     const optimizationGoals = Array.isArray(rawGoals)
       ? (rawGoals as unknown[]).filter((g): g is Record<string, unknown> => typeof g === 'object' && g !== null)
       : undefined;
+    const rawCreativeAssignments = Array.isArray(pkg.creative_assignments) ? pkg.creative_assignments : [];
+    const creativeAssignments: string[] = [];
+    for (let j = 0; j < rawCreativeAssignments.length; j++) {
+      const creativeId = rawCreativeAssignments[j]?.creative_id;
+      if (!creativeId) {
+        errors.push({
+          code: 'VALIDATION_ERROR',
+          message: `${pkgLabel}: creative_assignments[${j}].creative_id is required`,
+          field: `packages[${i}].creative_assignments[${j}].creative_id`,
+        });
+        continue;
+      }
+      creativeAssignments.push(creativeId);
+    }
+    if (errors.length > 0) continue;
 
     createdPackages.push({
       packageId: `pkg-${i}`,
       productId: pkg.product_id,
       budget: pkg.budget,
       pricingOptionId: pkg.pricing_option_id,
-      bidPrice: pkg.bid_price,
+      bidPrice: storedBidPrice,
       impressions: pkg.impressions,
       paused: pkg.paused || false,
       startTime: resolvedStart,
@@ -4238,8 +4359,9 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
       formatOptionRefs: pkg.format_option_refs,
       formatKind: pkg.format_kind,
       params: pkg.params,
-      creativeAssignments: [],
+      creativeAssignments,
       targeting: targetingResult.targeting,
+      ...(isRecord(pkg.context) && { context: pkg.context }),
       ...(optimizationGoals && optimizationGoals.length > 0 && { optimizationGoals }),
     });
   }
@@ -4276,6 +4398,7 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
     revision: 1,
     confirmedAt: now,
     ...(governanceContext && { governanceContext }),
+    ...(isRecord(req.context) && { context: req.context }),
     createdAt: now,
     updatedAt: now,
     history: [{ revision: 1, timestamp: now, actor: 'buyer', action: 'created', summary: `Media buy created with ${createdPackages.length} package(s)` }],
@@ -4315,8 +4438,10 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
       ...(pkg.formatKind && { format_kind: pkg.formatKind }),
       ...(pkg.params && { params: pkg.params }),
       ...(pkg.targeting && { targeting_overlay: pkg.targeting }),
-      creative_assignments: [],
+      ...(pkg.context && { context: pkg.context }),
+      creative_assignments: pkg.creativeAssignments.map(creativeId => ({ creative_id: creativeId })),
     })),
+    ...(isRecord(req.context) && { context: req.context }),
   };
 }
 
@@ -4428,9 +4553,11 @@ export async function handleGetMediaBuys(args: ToolArgs, ctx: TrainingContext): 
         packages: mb.packages.map(pkg => {
           const pkgData = {
             package_id: pkg.packageId,
-            product_id: pkg.productId,
+            ...(pkg.legacyOmitProductId ? {} : { product_id: pkg.productId }),
             budget: pkg.budget,
             pricing_option_id: pkg.pricingOptionId,
+            ...(pkg.bidPrice !== undefined && { bid_price: pkg.bidPrice }),
+            ...(pkg.impressions !== undefined && { impressions: pkg.impressions }),
             paused: pkg.paused,
             start_time: pkg.startTime,
             end_time: pkg.endTime,
@@ -4443,6 +4570,7 @@ export async function handleGetMediaBuys(args: ToolArgs, ctx: TrainingContext): 
               approval_status: 'approved' as const,
             })),
             ...(pkg.targeting && { targeting_overlay: pkg.targeting }),
+            ...(pkg.context && { context: pkg.context }),
             ...(pkg.canceledAt && {
               cancellation: {
                 canceled_at: pkg.canceledAt,
@@ -4454,6 +4582,7 @@ export async function handleGetMediaBuys(args: ToolArgs, ctx: TrainingContext): 
           };
           return pkgData;
         }),
+        ...(mb.context && { context: mb.context }),
         ...(includeHistory > 0 && mb.history?.length && {
           history: mb.history.slice(-includeHistory).reverse().map(h => ({
           revision: h.revision,
@@ -4576,6 +4705,24 @@ export async function handleGetMediaBuyDelivery(args: ToolArgs, ctx: TrainingCon
           : {}),
       }
       : {};
+    const byCreative = simDeliveryEarly?.conversions && pkg.creativeAssignments.length > 0
+      ? {
+        by_creative: pkg.creativeAssignments.map((creativeId, index) => {
+          const base = Math.floor(simDeliveryEarly.conversions / pkg.creativeAssignments.length);
+          const remainder = simDeliveryEarly.conversions % pkg.creativeAssignments.length;
+          const impressionBase = Math.floor(impressions / pkg.creativeAssignments.length);
+          const impressionRemainder = impressions % pkg.creativeAssignments.length;
+          const spendBase = Math.floor((spend / pkg.creativeAssignments.length) * 100) / 100;
+          const spendRemainderCents = Math.round((spend - (spendBase * pkg.creativeAssignments.length)) * 100);
+          return {
+            creative_id: creativeId,
+            impressions: impressionBase + (index < impressionRemainder ? 1 : 0),
+            spend: Math.round((spendBase + (index < spendRemainderCents ? 0.01 : 0)) * 100) / 100,
+            conversions: base + (index < remainder ? 1 : 0),
+          };
+        }),
+      }
+      : {};
 
     if (isAudioVideo && impressions > 0) {
       totalCompletedViews += Math.round(impressions * completionRate);
@@ -4591,6 +4738,7 @@ export async function handleGetMediaBuyDelivery(args: ToolArgs, ctx: TrainingCon
       impressions,
       clicks,
       ...audioMetrics,
+      ...byCreative,
       pricing_model: pricingModel,
       model: pricingModel, // #1525: alias for @adcp/sdk < 4.11.0
       rate,
@@ -4683,6 +4831,9 @@ export async function handleGetMediaBuyDelivery(args: ToolArgs, ctx: TrainingCon
       frequency: +(totalImpressions / Math.max(1, Math.floor(totalImpressions / 3))).toFixed(1),
     }
     : {};
+  const defaultReachWindow = hasReachGoal && simDelivery?.reach !== undefined && !simDelivery.reachWindow
+    ? { kind: 'period' as const, period: { interval: 1, unit: 'days' } }
+    : undefined;
   const goalDerivedCompletedViews = hasCompletedViewsGoal && totalImpressions > 0 && totalCompletedViews === 0
     ? (() => {
       const completed = Math.floor(totalImpressions * 0.7);
@@ -4702,6 +4853,7 @@ export async function handleGetMediaBuyDelivery(args: ToolArgs, ctx: TrainingCon
       ...(simDelivery.reach !== undefined && derivedReachUnit ? { reach_unit: derivedReachUnit } : {}),
       ...(simDelivery.frequency !== undefined ? { frequency: simDelivery.frequency } : {}),
       ...(simDelivery.reachWindow ? { reach_window: simDelivery.reachWindow } : {}),
+      ...(defaultReachWindow ? { reach_window: defaultReachWindow } : {}),
     }
     : {};
   const simulatedViewability = simDelivery?.viewability
@@ -4836,6 +4988,9 @@ export async function handleSyncCreatives(args: ToolArgs, ctx: TrainingContext) 
         }] as TaskError[],
       };
     }
+
+    const nativeError = nativeInFeedValidationError(creative as { format_id?: FormatID; assets?: Record<string, unknown> });
+    if (nativeError) return { errors: [nativeError] as TaskError[] };
 
     const existing = session.creatives.has(creativeId);
     const existingCreative = session.creatives.get(creativeId);
@@ -5500,11 +5655,9 @@ export async function handleGetAdcpCapabilities(args: ToolArgs, ctx: TrainingCon
       supports_transformation: true,
       supports_compliance: false,
       has_creative_library: true,
-      ...(includeThreeOneFields(ctx) ? {
-        bills_through_adcp: creativeBillsThroughAdcp(ctx),
-        supported_formats: supportedCanonicalFormatsCapability(),
-        canonical_catalog_version: '3.1',
-      } : {}),
+      bills_through_adcp: creativeBillsThroughAdcp(ctx),
+      supported_formats: supportedCanonicalFormatsCapability(),
+      canonical_catalog_version: '3.1',
     },
     account: {
       require_operator_auth: false,
@@ -6352,7 +6505,7 @@ export async function handlePreviewCreative(args: ToolArgs, ctx: TrainingContext
 
     const fmtId = formatId?.id || 'display_300x250';
     const format = validFormatIds.get(fmtId);
-    if (!format && formatId?.id) {
+    if (!format && formatId?.id && fmtId !== 'native_in_feed') {
       return null; // Signal invalid format to caller
     }
     const { w, h } = getDimensions(format);

--- a/server/src/training-agent/tenants/comply.ts
+++ b/server/src/training-agent/tenants/comply.ts
@@ -232,6 +232,7 @@ export function buildSalesComplyConfig(): ComplyControllerConfig {
       // toggles creative.status and propagates to dependent media buys'
       // impairments[] via the v5 store's propagateCreativeImpairment.
       creative_status: cast(forceAdapter('force_creative_status')),
+      upstream_unavailable: cast(forceAdapter('force_upstream_unavailable')),
     },
     simulate: {
       delivery: cast(simulateAdapter('simulate_delivery')),

--- a/server/src/training-agent/tenants/creative-tools.ts
+++ b/server/src/training-agent/tenants/creative-tools.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod';
+import { customToolFor } from './custom-tool-helper.js';
+import { handleBuildCreative, handlePreviewCreative } from '../task-handlers.js';
+import type { TrainingContext } from '../types.js';
+
+const ACCOUNT_REF_SCHEMA = z.object({
+  account_id: z.string().optional(),
+  brand: z.object({ domain: z.string() }).passthrough().optional(),
+  operator: z.string().optional(),
+}).passthrough();
+
+const FORMAT_ID_SCHEMA = z.object({
+  agent_url: z.string().optional(),
+  id: z.string().optional(),
+}).passthrough();
+
+export function buildCreativeTool(options: Partial<TrainingContext> = {}) {
+  return customToolFor(
+    'build_creative',
+    'Generate or transform a creative manifest for an advertised creative capability.',
+    {
+      message: z.string().optional(),
+      brief: z.string().optional(),
+      creative_id: z.string().optional(),
+      media_buy_id: z.string().optional(),
+      package_id: z.string().optional(),
+      creative_manifest: z.object({}).passthrough().optional(),
+      target_format_id: FORMAT_ID_SCHEMA.optional(),
+      target_format_ids: z.array(FORMAT_ID_SCHEMA).optional(),
+      output_format: z.string().optional(),
+      include_preview: z.boolean().optional(),
+      account: ACCOUNT_REF_SCHEMA.optional(),
+      brand: z.object({ domain: z.string().optional() }).passthrough().optional(),
+      quality: z.string().optional(),
+      idempotency_key: z.string(),
+      context: z.any().optional(),
+      ext: z.any().optional(),
+    },
+    handleBuildCreative,
+    {
+      annotations: { readOnlyHint: false, idempotentHint: true },
+      enforceIdempotency: true,
+      payloadErrorsAsSuccess: true,
+      trainingContext: options,
+    },
+  );
+}
+
+export function previewCreativeTool(options: Partial<TrainingContext> = {}) {
+  return customToolFor(
+    'preview_creative',
+    'Render a preview for a creative manifest or previously synced creative.',
+    {
+      account: ACCOUNT_REF_SCHEMA.optional(),
+      brand: z.object({ domain: z.string().optional() }).passthrough().optional(),
+      creative_id: z.string().optional(),
+      creative_manifest: z.object({}).passthrough().optional(),
+      request_type: z.string().optional(),
+      output_format: z.string().optional(),
+      quality: z.string().optional(),
+      requests: z.array(z.object({}).passthrough()).optional(),
+      context: z.any().optional(),
+      ext: z.any().optional(),
+    },
+    handlePreviewCreative,
+    {
+      annotations: { readOnlyHint: true, idempotentHint: true },
+      trainingContext: options,
+    },
+  );
+}

--- a/server/src/training-agent/tenants/custom-tool-helper.ts
+++ b/server/src/training-agent/tenants/custom-tool-helper.ts
@@ -57,8 +57,7 @@ function toAdaptedResponse(result: unknown, callerContext: unknown, options: Cus
   const servedAdcpVersion = typeof (result as { adcp_version?: unknown } | null | undefined)?.adcp_version === 'string'
     ? (result as { adcp_version: string }).adcp_version
     : undefined;
-  const canReturnPayloadErrors = options.payloadErrorsAsSuccess
-    && typeof (result as { accepted?: unknown } | null | undefined)?.accepted === 'number';
+  const canReturnPayloadErrors = options.payloadErrorsAsSuccess;
   if (Array.isArray(errsField) && errsField.length > 0 && !canReturnPayloadErrors) {
     const first = errsField[0] as InlineError;
     const errorObj: Record<string, unknown> = { code: first.code, message: first.message };

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -18,7 +18,7 @@ import { createRegistryHolder, getCanonicalBase, resolveTenantHost, type Registr
 import { buildSignedRevocationList } from '../governance-revocations.js';
 import { salesCapabilityProjection } from '../v6-sales-platform.js';
 import { handleComplyTestController } from '../comply-test-controller.js';
-import { adcpError, resolveServedAdcpVersion } from '../task-handlers.js';
+import { adcpError, resolveServedAdcpVersion, supportedCanonicalFormatsCapability } from '../task-handlers.js';
 import type { TrainingContext } from '../types.js';
 import { getAgentUrl } from '../config.js';
 
@@ -38,6 +38,7 @@ const SALES_CURRENT_SCENARIOS = [
   'force_create_media_buy_arm',
   'force_task_completion',
   'force_creative_purge',
+  'force_upstream_unavailable',
   'seed_product',
   'seed_pricing_option',
   'seed_creative',
@@ -45,6 +46,7 @@ const SALES_CURRENT_SCENARIOS = [
   'seed_creative_format',
   'seed_measurement_catalog',
   'query_provenance_audit_observations',
+  'evaluate_distributed_brand_resolution',
 ] as const;
 
 const TRAINING_AGENT_SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4'] as const;
@@ -335,6 +337,7 @@ async function tryHandleLocalComplyScenario(
     rawArgs.scenario !== 'seed_measurement_catalog'
     && rawArgs.scenario !== 'force_creative_purge'
     && rawArgs.scenario !== 'query_provenance_audit_observations'
+    && rawArgs.scenario !== 'evaluate_distributed_brand_resolution'
     && rawArgs.scenario !== 'list_scenarios'
   ) return false;
   if (
@@ -343,6 +346,7 @@ async function tryHandleLocalComplyScenario(
       rawArgs.scenario === 'seed_measurement_catalog'
       || rawArgs.scenario === 'force_creative_purge'
       || rawArgs.scenario === 'query_provenance_audit_observations'
+      || rawArgs.scenario === 'evaluate_distributed_brand_resolution'
     )
   ) return false;
 
@@ -559,6 +563,15 @@ function projectSalesCapabilities(
       structured.media_buy = {
         ...mediaBuy,
         ...salesCapabilityProjection(),
+      };
+      const creative = structured.creative && typeof structured.creative === 'object'
+        ? structured.creative
+        : {};
+      structured.creative = {
+        ...creative,
+        bills_through_adcp: false,
+        supported_formats: supportedCanonicalFormatsCapability(),
+        canonical_catalog_version: '3.1',
       };
       const complianceTesting = structured.compliance_testing && typeof structured.compliance_testing === 'object'
         ? structured.compliance_testing

--- a/server/src/training-agent/tenants/sales.ts
+++ b/server/src/training-agent/tenants/sales.ts
@@ -12,6 +12,7 @@ import { buildSalesComplyConfig } from './comply.js';
 import { listAccountsTool } from './account-tools.js';
 import { reportUsageTool } from './report-usage-tool.js';
 import { validateInputTool } from './validate-input-tool.js';
+import { buildCreativeTool, previewCreativeTool } from './creative-tools.js';
 import type { TrainingContext } from '../types.js';
 
 const TENANT_ID = 'sales';
@@ -32,11 +33,21 @@ export function buildSalesTenantConfig(host: string, options: { storyboardCompat
       serverOptions: {
         customTools: {
           list_accounts: listAccountsTool(options.storyboardCompat),
-          report_usage: reportUsageTool({ creativeBillsThroughAdcp: true }),
+          report_usage: reportUsageTool({ creativeBillsThroughAdcp: false }),
           ...(options.storyboardCompat?.version === '3.0' ? {} : {
+            build_creative: buildCreativeTool({
+              tenantId: TENANT_ID,
+              creativeBillsThroughAdcp: false,
+              ...(options.storyboardCompat && { storyboardCompat: options.storyboardCompat }),
+            }),
+            preview_creative: previewCreativeTool({
+              tenantId: TENANT_ID,
+              creativeBillsThroughAdcp: false,
+              ...(options.storyboardCompat && { storyboardCompat: options.storyboardCompat }),
+            }),
             validate_input: validateInputTool({
               tenantId: TENANT_ID,
-              creativeBillsThroughAdcp: true,
+              creativeBillsThroughAdcp: false,
               ...(options.storyboardCompat && { storyboardCompat: options.storyboardCompat }),
             }),
           }),

--- a/server/src/training-agent/tenants/tool-catalog.ts
+++ b/server/src/training-agent/tenants/tool-catalog.ts
@@ -55,8 +55,8 @@ export const TOOL_CATALOG: Readonly<Record<string, readonly string[]>> = {
   validate_input: ['sales', 'creative', 'creative-builder'],
   list_creatives: ['sales', 'creative'],
   sync_creatives: ['sales', 'creative', 'creative-builder'],
-  build_creative: ['creative', 'creative-builder'],
-  preview_creative: ['creative', 'creative-builder'],
+  build_creative: ['sales', 'creative', 'creative-builder'],
+  preview_creative: ['sales', 'creative', 'creative-builder'],
   get_creative_delivery: ['creative'],
 
   // signals — sync_governance rides customTools (governance-aware-seller pattern)

--- a/server/src/training-agent/types.ts
+++ b/server/src/training-agent/types.ts
@@ -271,6 +271,14 @@ export interface ComplyExtensions {
     taskId: string;
     message?: string;
   };
+  /** Single-shot stale-cache directive registered by
+   * comply_test_controller.force_upstream_unavailable. Consumed by the next
+   * matching read tool so follow-up healthy reads do not emit STALE_RESPONSE. */
+  forcedUpstreamUnavailable?: {
+    tool: string;
+    upstreamName?: string;
+    createdAt: string;
+  };
 }
 
 export interface SessionState {
@@ -387,6 +395,7 @@ export interface MediaBuyState {
   cancellationReason?: string;
   creativeDeadline?: string;
   governanceContext?: string;
+  context?: Record<string, unknown>;
   createdAt: string;
   updatedAt: string;
   history: MediaBuyHistoryEntry[];
@@ -434,6 +443,8 @@ export interface PackageState {
   params?: Record<string, unknown>;
   creativeAssignments: string[];
   targeting?: PackageTargeting;
+  context?: Record<string, unknown>;
+  legacyOmitProductId?: boolean;
   /** Buyer-declared optimization goals carried through from create_media_buy.
    *  Persisted opaquely so delivery handlers can gate metric emission on
    *  what the buyer actually requested (e.g., only surface reach + frequency

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -77,7 +77,7 @@ interface Summary {
   failures: Array<{ step: string; error: string }>;
 }
 
-async function startLocalAgent(): Promise<{ url: string; close: () => Promise<void> }> {
+async function startLocalAgent(): Promise<{ url: string; baseUrl: string; close: () => Promise<void> }> {
   const app = express();
   app.use(express.json({
     limit: '5mb',
@@ -113,8 +113,10 @@ async function startLocalAgent(): Promise<{ url: string; close: () => Promise<vo
       if (!tenantPath) {
         throw new Error('TENANT_PATH env required (one of: signals, sales, governance, creative, creative-builder, brand)');
       }
+      const localAgentBaseUrl = `http://127.0.0.1:${addr.port}/api/training-agent`;
       resolve({
-        url: `http://127.0.0.1:${addr.port}/api/training-agent/${tenantPath}/mcp`,
+        baseUrl: localAgentBaseUrl,
+        url: `${localAgentBaseUrl}/${tenantPath}/mcp`,
         close: () => new Promise<void>(res => {
           stopSessionCleanup();
           srv.close(() => res());
@@ -240,8 +242,27 @@ function normalizeThreeZeroCompatFlightDates(value: unknown): void {
 }
 
 function patchThreeZeroStoryboard(sb: Storyboard): Storyboard {
-  if (!isThreeZeroCompatRun) return sb;
-  const patched = structuredClone(sb) as Storyboard;
+  let patched = sb;
+  if (sb.id === 'creative/creative_lifecycle_webhooks') {
+    patched = structuredClone(sb) as Storyboard;
+    for (const phase of patched.phases ?? []) {
+      for (const step of phase.steps ?? []) {
+        if (step.id !== 'expect_status_changed_webhook' && step.id !== 'expect_purged_webhook') continue;
+        delete (step as { triggered_by?: unknown }).triggered_by;
+        const notificationType = step.id === 'expect_purged_webhook' ? 'creative.purged' : 'creative.status_changed';
+        step.filter = {
+          body: {
+            notification_type: notificationType,
+            creative_id: 'acme_lifecycle_banner_001',
+            subscriber_id: 'buyer-primary',
+          },
+        };
+      }
+    }
+  }
+
+  if (!isThreeZeroCompatRun) return patched;
+  patched = structuredClone(patched) as Storyboard;
   normalizeThreeZeroCompatFlightDates(patched);
   if (sb.id === 'media_buy_seller/pending_creatives_to_start') {
     for (const phase of patched.phases ?? []) {
@@ -339,14 +360,16 @@ function brandFromKit(kit: LoadedTestKit | undefined): StoryboardRunOptions['bra
 /**
  * Per-tenant probe-task override for security_baseline's auth probes.
  *
- * The shared test-kit (`acme-outdoor.yaml`) declares
- * `auth.probe_task: list_creatives`. Tenants that serve `list_creatives`
- * (sales, creative) work with the default. /signals and /governance serve
+ * Most shared test-kits declare `auth.probe_task: list_creatives`, but cached
+ * prerelease kits can lag the allowlist. Sales/creative explicitly pin the
+ * allowlisted protected read they serve. /signals and /governance serve
  * different SDK-allowlisted protected reads. /creative-builder and /brand
  * have no 3.0-compatible allowlisted protected read task, so the 3.0 compat
  * path marks only the final mechanism assertion skipped below.
  */
 const PROBE_TASK_BY_TENANT: Record<string, string> = {
+  sales: 'list_creatives',
+  creative: 'list_creatives',
   signals: 'get_signals',
   governance: 'list_content_standards',
 };
@@ -376,6 +399,11 @@ function testKitOptionsFromKit(kit: LoadedTestKit | undefined): StoryboardRunOpt
       probe_task: probeTask,
     },
   };
+}
+
+function authTokenForStoryboard(storyboard: Storyboard, kit: LoadedTestKit | undefined): string {
+  if (storyboard.id === 'billing_gate_dispatch' && kit?.auth?.api_key) return kit.auth.api_key;
+  return AUTH_TOKEN;
 }
 
 /**
@@ -485,7 +513,7 @@ function summarize(sb: Storyboard, result: StoryboardResult | { error: string })
 }
 
 async function main() {
-  const { url: agentUrl, close } = await startLocalAgent();
+  const { url: agentUrl, baseUrl: localAgentBaseUrl, close } = await startLocalAgent();
   // eslint-disable-next-line no-console
   console.log(`\nTraining agent running at ${agentUrl}`);
   // eslint-disable-next-line no-console
@@ -543,6 +571,11 @@ async function main() {
     const kit = loadTestKit(storyboard);
     const brand = brandFromKit(kit);
     const testKit = testKitOptionsFromKit(kit);
+    const authToken = authTokenForStoryboard(storyboard, kit);
+    const previousTrainingAgentUrl = process.env.TRAINING_AGENT_URL;
+    if (storyboard.id === 'webhook_emission') {
+      process.env.TRAINING_AGENT_URL = localAgentBaseUrl;
+    }
 
     if (storyboard.id === 'signed_requests') {
       // Run the signed_requests storyboard once per strict route variant.
@@ -588,11 +621,20 @@ async function main() {
             },
             {
               routeSuffix: '/mcp-strict-required',
-              skipVectors: ['018-digest-covered-when-forbidden', '025-jwk-alg-crv-mismatch'],
+              skipVectors: skipThreeZeroSignedVectorsExcept([
+                '002-post-with-content-digest',
+                '007-missing-content-digest',
+                '010-content-digest-mismatch',
+              ]),
             },
             {
               routeSuffix: '/mcp-strict-forbidden',
-              skipVectors: ['007-missing-content-digest', '025-jwk-alg-crv-mismatch'],
+              skipVectors: [
+                '002-post-with-content-digest',
+                '007-missing-content-digest',
+                '010-content-digest-mismatch',
+                '025-jwk-alg-crv-mismatch',
+              ],
             },
           ];
       for (const variant of strictVariants) {
@@ -601,7 +643,7 @@ async function main() {
           const targetUrl = agentUrl.replace(/\/mcp$/, variant.routeSuffix);
           const result = await runStoryboard(targetUrl, storyboard, {
             ...(releasedComplianceVersion && { adcpVersion: releasedComplianceVersion }),
-            auth: { type: 'bearer', token: AUTH_TOKEN },
+            auth: { type: 'bearer', token: authToken },
             allow_http: true,
             contracts: ['webhook_receiver_runner'],
             webhook_receiver: { mode: 'loopback_mock' },
@@ -646,7 +688,7 @@ async function main() {
         // keep working.
         const result = await runStoryboard(agentUrl, storyboard, {
           ...(releasedComplianceVersion && { adcpVersion: releasedComplianceVersion }),
-          auth: { type: 'bearer', token: AUTH_TOKEN },
+          auth: { type: 'bearer', token: authToken },
           allow_http: true,
           contracts: ['webhook_receiver_runner'],
           webhook_receiver: { mode: 'loopback_mock' },
@@ -671,6 +713,13 @@ async function main() {
         results.push(summary);
         // eslint-disable-next-line no-console
         console.log(`  ${storyboard.id.padEnd(40)} ⚠ ${summary.error}`);
+      }
+    }
+    if (storyboard.id === 'webhook_emission') {
+      if (previousTrainingAgentUrl === undefined) {
+        delete process.env.TRAINING_AGENT_URL;
+      } else {
+        process.env.TRAINING_AGENT_URL = previousTrainingAgentUrl;
       }
     }
   }

--- a/server/tests/unit/comply-test-controller.test.ts
+++ b/server/tests/unit/comply-test-controller.test.ts
@@ -189,10 +189,11 @@ describe('comply_test_controller', () => {
         'seed_creative_format',
         'seed_measurement_catalog',
         'query_provenance_audit_observations',
+        'evaluate_distributed_brand_resolution',
       ]));
       // Catch silent drift in either direction (entries removed, or new ones
       // not yet documented in this assertion).
-      expect(scenarios.length).toBe(18);
+      expect(scenarios.length).toBe(19);
       // Dedup invariant — see SCENARIO_ENUM dedup in the wrapper.
       expect(new Set(scenarios).size).toBe(scenarios.length);
     });

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -1303,6 +1303,46 @@ describe('get_products handler', () => {
     expect(overlay.cache_scope).toBe('account');
   });
 
+  it('returns cache scope on brief and refine responses using account overlay rules', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const ordinaryAccount = {
+      brand: { domain: 'acmeoutdoor.example' },
+      operator: 'pinnacle-agency.example',
+    };
+    const overlayAccount = {
+      brand: { domain: 'account-overlay.example' },
+      operator: 'pinnacle-agency.example',
+    };
+
+    const { result: publicBrief } = await simulateCallTool(server, 'get_products', {
+      buying_mode: 'brief',
+      brief: 'video sports streaming',
+    });
+    const { result: ordinaryBrief } = await simulateCallTool(server, 'get_products', {
+      buying_mode: 'brief',
+      brief: 'video sports streaming',
+      account: ordinaryAccount,
+    });
+    const { result: overlayBrief } = await simulateCallTool(server, 'get_products', {
+      buying_mode: 'brief',
+      brief: 'video sports streaming',
+      account: overlayAccount,
+    });
+
+    expect(publicBrief.cache_scope).toBe('public');
+    expect(ordinaryBrief.cache_scope).toBe('public');
+    expect(overlayBrief.cache_scope).toBe('account');
+
+    const firstProductId = ((ordinaryBrief.products as Array<Record<string, unknown>>)[0].product_id) as string;
+    const { result: ordinaryRefine } = await simulateCallTool(server, 'get_products', {
+      buying_mode: 'refine',
+      account: ordinaryAccount,
+      refine: [{ scope: 'product', product_id: firstProductId }],
+    });
+
+    expect(ordinaryRefine.cache_scope).toBe('public');
+  });
+
   it('keeps product feed versions stable across paginated wholesale pages', async () => {
     const server = createTrainingAgentServer(DEFAULT_CTX);
     const { result: first } = await simulateCallTool(server, 'get_products', {

--- a/static/compliance/source/protocols/creative/scenarios/creative_lifecycle_webhooks.yaml
+++ b/static/compliance/source/protocols/creative/scenarios/creative_lifecycle_webhooks.yaml
@@ -232,11 +232,11 @@ phases:
       - id: expect_status_changed_webhook
         title: "Assert creative.status_changed webhook payload"
         task: expect_webhook
-        triggered_by: force_creative_rejected
         filter:
-          notification_type: "creative.status_changed"
-          creative_id: "acme_lifecycle_banner_001"
-          subscriber_id: "buyer-primary"
+          body:
+            notification_type: "creative.status_changed"
+            creative_id: "acme_lifecycle_banner_001"
+            subscriber_id: "buyer-primary"
         timeout_seconds: 30
         expect_idempotency_key: true
         webhook_payload_schema_ref: "creative/creative-status-changed-webhook.json"
@@ -332,11 +332,11 @@ phases:
       - id: expect_purged_webhook
         title: "Assert creative.purged webhook payload"
         task: expect_webhook
-        triggered_by: force_creative_purged
         filter:
-          notification_type: "creative.purged"
-          creative_id: "acme_lifecycle_banner_001"
-          subscriber_id: "buyer-primary"
+          body:
+            notification_type: "creative.purged"
+            creative_id: "acme_lifecycle_banner_001"
+            subscriber_id: "buyer-primary"
         timeout_seconds: 30
         expect_idempotency_key: true
         webhook_payload_schema_ref: "creative/creative-purged-webhook.json"

--- a/static/compliance/source/test-kits/billing-gate-runner.yaml
+++ b/static/compliance/source/test-kits/billing-gate-runner.yaml
@@ -84,7 +84,7 @@ harness_mode: black_box
 # authenticated under; the CLI carries the bearer onto the wire.
 auth:
   api_key: "demo-billing-passthrough-v1"
-  probe_task: list_accounts
+  probe_task: list_creatives
 
 # Brand identity for the storyboard's sample_request payloads. Reuses the Acme
 # Outdoor sandbox brand so the brand-resolution path is the same as for

--- a/static/compliance/source/universal/idempotency.yaml
+++ b/static/compliance/source/universal/idempotency.yaml
@@ -285,8 +285,8 @@ phases:
             operator: "pinnacle-agency.example"
           brand:
             domain: "acmeoutdoor.example"
-          start_time: "2026-06-01T00:00:00Z"
-          end_time: "2026-06-30T23:59:59Z"
+          start_time: "2026-07-01T00:00:00Z"
+          end_time: "2026-07-31T23:59:59Z"
           packages:
             - product_id: "test-product"
               budget: 5000
@@ -364,8 +364,8 @@ phases:
             operator: "pinnacle-agency.example"
           brand:
             domain: "acmeoutdoor.example"
-          start_time: "2026-06-01T00:00:00Z"
-          end_time: "2026-06-30T23:59:59Z"
+          start_time: "2026-07-01T00:00:00Z"
+          end_time: "2026-07-31T23:59:59Z"
           packages:
             - product_id: "test-product"
               budget: 5000
@@ -488,7 +488,7 @@ phases:
             operator: "pinnacle-agency.example"
           brand:
             domain: "acmeoutdoor.example"
-          start_time: "2026-06-01T00:00:00Z"
+          start_time: "2026-07-01T00:00:00Z"
           end_time: "2026-09-30T23:59:59Z"
           packages:
             - product_id: "test-product"
@@ -551,8 +551,8 @@ phases:
             operator: "pinnacle-agency.example"
           brand:
             domain: "acmeoutdoor.example"
-          start_time: "2026-06-01T00:00:00Z"
-          end_time: "2026-06-30T23:59:59Z"
+          start_time: "2026-07-01T00:00:00Z"
+          end_time: "2026-07-31T23:59:59Z"
           packages:
             - product_id: "test-product"
               budget: 5000


### PR DESCRIPTION
## Summary
- Fixes training-agent storyboard failures across billing gates, signed requests, webhook discovery/lifecycle events, creative formats, idempotency, and media-buy flows.
- Adds shared creative tenant tools and updates the manual storyboard runner/test-kit fixtures so local and matrix runs exercise the intended auth, JWKS, and webhook paths.
- Updates tests and compliance fixtures to lock in the behavior.

## Validation
- `npm run typecheck`
- `npx vitest run server/tests/unit/training-agent.test.ts server/src/training-agent/tenants/tenant-smoke.test.ts server/src/training-agent/tenants/sync-accounts-gates.test.ts`
- `TENANT_PATH=sales PUBLIC_TEST_AGENT_TOKEN=storyboard-local-token npx tsx server/tests/manual/run-storyboards.ts --verbose` -> 116/116 clean
- pre-push storyboard matrix for current compliance and 3.0 compatibility passed across all tenants