### PR TITLE
feat(schema): add last_updated to signal-definition — refs #5248 item 1

### DIFF
--- a/.changeset/5248-signal-definition-last-updated.md
+++ b/.changeset/5248-signal-definition-last-updated.md
@@ -1,0 +1,11 @@
+---
+"adcontextprotocol": minor
+---
+
+Add optional `last_updated` (date-time) to `signal-definition.json`, `signal-definition-enrichment.json`, and the `get_signals.fields` projection enum.
+
+Closes the signal-record freshness gap raised in #5248. `refresh_cadence` and `lookback_window` describe methodology freshness; `last_updated` tells buyer agents when the seller last published or updated this specific definition record — the one verifiable freshness signal that agents can compare across providers without trusting self-declared methodology claims.
+
+Description follows `signal-listing.json` precedent: "When this definition record was last updated. This indicates freshness of the definition record, not an attestation that the underlying data or model was refreshed at that time."
+
+Adding to `signal-definition-enrichment.json` means the field is also projectable through `get_signals.fields` for buyers that want it inline during discovery without fetching the full definition.

--- a/static/schemas/source/core/signal-definition-enrichment.json
+++ b/static/schemas/source/core/signal-definition-enrichment.json
@@ -315,6 +315,11 @@
       "required": ["channels"],
       "additionalProperties": false
     },
+    "last_updated": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When this definition record was last updated. This indicates freshness of the definition record, not an attestation that the underlying data or model was refreshed at that time."
+    },
     "dts_compliant_version": {
       "type": "string"
     }

--- a/static/schemas/source/core/signal-definition.json
+++ b/static/schemas/source/core/signal-definition.json
@@ -441,6 +441,11 @@
       "required": ["channels"],
       "additionalProperties": false
     },
+    "last_updated": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When this definition record was last updated. This indicates freshness of the definition record, not an attestation that the underlying data or model was refreshed at that time."
+    },
     "dts_compliant_version": {
       "type": "string",
       "description": "IAB Data Transparency Standard version this signal definition self-attests as satisfying, when applicable."

--- a/static/schemas/source/signals/get-signals-request.json
+++ b/static/schemas/source/signals/get-signals-request.json
@@ -93,7 +93,7 @@
     },
     "fields": {
       "type": "array",
-      "description": "Specific signal fields to include in the response, aligned with get_products.fields. Required identity and activation fields such as signal_ref or signal_id, signal_agent_segment_id, name, description, signal_type, coverage_percentage, and deployments are always included when required by the response schema. Use for progressive disclosure of rich signal-definition metadata: request fields such as taxonomy, data_sources, methodology, segmentation_criteria, criteria_url, refresh_cadence, lookback_window, onboarder, modeling, audience_expansion, device_expansion, countries, consent_basis, restricted_attributes, policy_categories, art9_basis, and data_subject_rights when the buyer needs them inline. Omit for the agent's default discovery projection. Agents SHOULD honor requested fields for exact lookup, refinement, small custom-signal result sets, and private/source-native signals when available. fields is a projection request, not an entitlement grant; agents MAY redact requested definition fields unless the caller is authorized for the underlying lineage, methodology, and rights-routing metadata. When consent_basis or art9_basis is projected for another provider's signal, the value remains provider-declared signal-definition posture; sellers and federating agents MUST NOT substitute their own processing basis. For broad discovery and wholesale pages, agents MAY return compact pointers instead of inlining large resources, especially when provider-published definitions can be resolved from signal_ref, taxonomy.ref, criteria_url, disclosure_url, and validators such as resolved URL plus catalog_etag, HTTP ETag/Last-Modified, or taxonomy.etag.",
+      "description": "Specific signal fields to include in the response, aligned with get_products.fields. Required identity and activation fields such as signal_ref or signal_id, signal_agent_segment_id, name, description, signal_type, coverage_percentage, and deployments are always included when required by the response schema. Use for progressive disclosure of rich signal-definition metadata: request fields such as taxonomy, data_sources, methodology, segmentation_criteria, criteria_url, refresh_cadence, lookback_window, onboarder, modeling, audience_expansion, device_expansion, countries, consent_basis, restricted_attributes, policy_categories, art9_basis, data_subject_rights, and last_updated when the buyer needs them inline. Omit for the agent's default discovery projection. Agents SHOULD honor requested fields for exact lookup, refinement, small custom-signal result sets, and private/source-native signals when available. fields is a projection request, not an entitlement grant; agents MAY redact requested definition fields unless the caller is authorized for the underlying lineage, methodology, and rights-routing metadata. When consent_basis or art9_basis is projected for another provider's signal, the value remains provider-declared signal-definition posture; sellers and federating agents MUST NOT substitute their own processing basis. For broad discovery and wholesale pages, agents MAY return compact pointers instead of inlining large resources, especially when provider-published definitions can be resolved from signal_ref, taxonomy.ref, criteria_url, disclosure_url, and validators such as resolved URL plus catalog_etag, HTTP ETag/Last-Modified, or taxonomy.etag.",
       "items": {
         "type": "string",
         "enum": [
@@ -126,7 +126,8 @@
           "restricted_attributes",
           "policy_categories",
           "art9_basis",
-          "data_subject_rights"
+          "data_subject_rights",
+          "last_updated"
         ]
       },
       "minItems": 1,


### PR DESCRIPTION
Implements item 1 from #5248 per the triage implementation brief (@bokelley, 2026-06-01).

## What

Three additive optional-field changes:

| File | Change |
|---|---|
| `static/schemas/source/core/signal-definition.json` | Add `last_updated` (string, date-time) before `dts_compliant_version` |
| `static/schemas/source/core/signal-definition-enrichment.json` | Same field — enables projection via `get_signals.fields` |
| `static/schemas/source/signals/get-signals-request.json` fields enum | Add `"last_updated"` |

## Why

`refresh_cadence` and `lookback_window` describe _methodology_ freshness (self-declared). `last_updated` is the one field that's **verifiable**: the seller published this definition record on that date, even if the underlying data or model freshness isn't attested. Buyer agents can compare `last_updated` across providers, sort by recency, or penalize stale definitions — all without requiring the attestation infrastructure needed for methodology-freshness claims.

## Description (follows signal-listing.json precedent)

> "When this definition record was last updated. This indicates freshness of the definition record, not an attestation that the underlying data or model was refreshed at that time."

## What's NOT changing

- `required[]` — field remains optional; existing definitions without `last_updated` stay valid
- No `allOf` guards — no conditional requirements triggered by this field
- Wire format for current publishers — additive, non-breaking

## Test plan

- [x] `signal-definition.json` — field added before `dts_compliant_version`, same format/description as `signal-listing.json`'s existing `last_updated`
- [x] `signal-definition-enrichment.json` — same field; projectable through `get_signals.fields`
- [x] `get-signals-request.json` — `"last_updated"` added to fields enum
- [ ] CI: `npm run test:schemas`, `npm run test:composed`, `npm run test:json-schema`, `lint:schema-links`

## Refs

Refs #5248 (item 1 of 4 — the only item marked ready-to-implement)
Follows `signal-listing.json` existing `last_updated` field (identical shape)

I have read the IPR Policy