### PR TITLE
docs: fix supported_versions examples to use release-precision format

### DIFF
--- a/.changeset/fix-supported-versions-precision-examples.md
+++ b/.changeset/fix-supported-versions-precision-examples.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix incorrect `supported_versions` examples in version-adaptation guide that showed patch-precision values (`'3.0.5'`, `'3.1.0'`) instead of the correct release-precision format (`'3.0'`, `'3.1'`). Closes #5250.

--- a/docs/building/by-layer/L4/migrate-from-hand-rolled.mdx
+++ b/docs/building/by-layer/L4/migrate-from-hand-rolled.mdx
@@ -169,7 +169,7 @@ const buyerB = new ADCPMultiAgentClient([{
   agent_uri: 'https://buyer-b.example.com/a2a',
   protocol: 'a2a',
   auth_token: process.env.BUYER_B_TOKEN,
-  adcpVersion: '3.0.5', // ← canonical / current
+  adcpVersion: '3.0', // ← canonical / current
 }]);
 ```
 
@@ -181,7 +181,7 @@ import { createAdcpServer } from '@adcp/sdk/server';
 createAdcpServer({
   capabilities: {
     major_versions: [3],
-    supported_versions: ['3.0.5'],
+    supported_versions: ['3.0'],
   },
   // …handlers, all on the canonical 3.0 shape;
   // 2.5 callers are translated by client-side adapters before they reach you.

--- a/docs/building/cross-cutting/version-adaptation.mdx
+++ b/docs/building/cross-cutting/version-adaptation.mdx
@@ -9,7 +9,7 @@ Three versions move at the same time when you ship an AdCP agent or client:
 
 | Axis | Example | What changes |
 |---|---|---|
-| **Spec version** | AdCP `2.5 → 3.0.5 → 3.1` | Wire shapes, error codes, lifecycle states, new tools |
+| **Spec version** | AdCP `2.5 → 3.0 → 3.1` | Wire shapes, error codes, lifecycle states, new tools |
 | **SDK version** | SDK `5.x → 6.x` | API surface, ergonomics, compile-time guarantees |
 | **Peer version** (per call) | Buyer at v3.0, seller at v2.5 | A single conversation crosses versions |
 
@@ -97,7 +97,7 @@ Use this when you're a **server** and you want to be explicit about which spec v
 
 ### Declare what you support
 
-`supported_versions` (release-precision strings) and/or `major_versions` go on your agent's capability declaration. Use release-precision strings — `'3.0.5'`, `'3.1.0'` — not the legacy aliases (`'v2.5'`, `'v3'`) used for client-side pinning. A 3.x server with no v2.5 handler logic should not declare `'v2.5'` here — its 2.5 callers go through *client-side* adapters at the buyer end, not the server's accepted-version set.
+`supported_versions` (release-precision strings) and/or `major_versions` go on your agent's capability declaration. Use release-precision strings — `'3.0'`, `'3.1'` — not the legacy aliases (`'v2.5'`, `'v3'`) used for client-side pinning. A 3.x server with no v2.5 handler logic should not declare `'v2.5'` here — its 2.5 callers go through *client-side* adapters at the buyer end, not the server's accepted-version set. If you want to surface your deployment's patch build for incident triage, use the `build_version` capability field — not `supported_versions`.
 
 Example with `@adcp/sdk` (lower-level handler-bag API):
 
@@ -109,7 +109,7 @@ const server = createAdcpServer({
   version: '1.0.0',
   capabilities: {
     major_versions: [3],
-    supported_versions: ['3.0.5', '3.1.0'],
+    supported_versions: ['3.0', '3.1'],
     // …other capability fields
   },
   // …handlers
@@ -161,7 +161,7 @@ This is the third mechanism rather than a fallback to the first: negotiation tel
 
 A typical multi-version production setup:
 
-1. **Server**: declare `supported_versions: ['3.0.5', '3.1.0']` in capabilities. The SDK accepts both on the wire and returns `VERSION_UNSUPPORTED` to anyone outside the set. (Only declare a version your handlers actually satisfy.)
+1. **Server**: declare `supported_versions: ['3.0', '3.1']` in capabilities. The SDK accepts both on the wire and returns `VERSION_UNSUPPORTED` to anyone outside the set. (Only declare a version your handlers actually satisfy.)
 2. **Client (per peer)**: pin `adcpVersion` (e.g., `'v2.5'`) based on what the registry or peer's capabilities advertise. The client-side adapters translate the wire shape so your application code stays on the current spec.
 3. **SDK upgrades**: bump the SDK on your schedule; switch to the new entry point per specialism over time; keep the rest on the legacy import until you're ready.
 


### PR DESCRIPTION
Closes #5250

SDK guide examples used patch-precision values (`'3.0.5'`, `'3.1.0'`) for `supported_versions`, directly contradicting the spec (`versioning.mdx`) and the `get-adcp-capabilities-response.json` schema, which both require release-precision (`MAJOR.MINOR`) format. The prose even labeled the wrong values as "release-precision strings." The Python SDK's `SupportedVersion` Pydantic model already rejected patch values at validation time; the docs were the sole inconsistency. This caused real compliance-runner failures with no obvious error trail for implementers.

**Non-breaking justification:** Docs-only correction (no schema, no wire, no SDK changes). Fixes examples to match the existing spec and schema; no implementer behavior changes.

**Files changed:**
- `docs/building/cross-cutting/version-adaptation.mdx` — 4 instances fixed (intro table, prose label, code example, "Putting it together" step); added `build_version` aside to pre-empt the patch-value confusion at the point of instruction
- `docs/building/by-layer/L4/migrate-from-hand-rolled.mdx` — 2 instances fixed (`adcpVersion` client pin and `supported_versions` server declaration)

**Pre-PR review:**
- code-reviewer: approved — no remaining blockers after `migrate-from-hand-rolled.mdx` instances were caught and fixed
- docs-expert: approved — all changes schema-consistent, `build_version` aside accurate and well-placed, no Mintlify issues

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or request a new first draft PR:** comment `/triage execute`
>   on the source issue only when no triage-managed PR is already
>   open. Triage does not update existing PRs.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01SBdEjcwCBc4gLnevTcpdsE

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBdEjcwCBc4gLnevTcpdsE)_