### PR TITLE
fix(compliance): add governance_agent_url context to protocol index storyboards

### DIFF
--- a/.changeset/fix-governance-index-storyboard-url.md
+++ b/.changeset/fix-governance-index-storyboard-url.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix unreachable governance fixture URL in protocol index storyboards. `protocols/media-buy/index.yaml` and `protocols/governance/index.yaml` had `https://governance.pinnacle-agency.example` hardcoded in their `sync_governance` sample_request, causing 4 Media Buy scenarios to always fail with DNS resolution errors. Adds root-level `context: governance_agent_url` block (matching the pattern from #3913) and switches the hardcoded URL to `$context.governance_agent_url`. The inventory-list targeting references to the same domain in `acme-outdoor.yaml` and `inventory_list_*.yaml` are a separate follow-up (they need a hosted property-list agent endpoint, not the same fix). Closes #5253.

--- a/static/compliance/source/protocols/governance/index.yaml
+++ b/static/compliance/source/protocols/governance/index.yaml
@@ -21,6 +21,9 @@ narrative: |
   those boundaries are exceeded, the system escalates to humans rather than blocking
   entirely. The audit trail provides accountability for every decision in the chain.
 
+context:
+  governance_agent_url: "https://test-agent.adcontextprotocol.org"
+
 agent:
   interaction_model: media_buy_seller
   capabilities:
@@ -196,7 +199,7 @@ phases:
                   domain: "acmeoutdoor.example"
                 operator: "pinnacle-agency.example"
               governance_agents:
-                - url: "https://governance.pinnacle-agency.example"
+                - url: "$context.governance_agent_url"
                   authentication:
                     schemes: ["Bearer"]
                     credentials: "gov-token-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

--- a/static/compliance/source/protocols/media-buy/index.yaml
+++ b/static/compliance/source/protocols/media-buy/index.yaml
@@ -35,6 +35,9 @@ narrative: |
   required scenarios that run alongside this storyboard. See requires_scenarios for the
   full set of seller behaviors validated.
 
+context:
+  governance_agent_url: "https://test-agent.adcontextprotocol.org"
+
 agent:
   interaction_model: media_buy_seller
   capabilities:
@@ -219,7 +222,7 @@ phases:
                   domain: "acmeoutdoor.example"
                 operator: "pinnacle-agency.example"
               governance_agents:
-                - url: "https://governance.pinnacle-agency.example"
+                - url: "$context.governance_agent_url"
                   authentication:
                     schemes: ["Bearer"]
                     credentials: "gov-token-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"


### PR DESCRIPTION
Closes #5253

## Summary

`static/compliance/source/protocols/media-buy/index.yaml` and `static/compliance/source/protocols/governance/index.yaml` hardcoded `https://governance.pinnacle-agency.example` in their `sync_governance` sample_request. This domain does not resolve, causing the seller under test to store an unreachable governance agent URL and then fail every `create_media_buy` governance check with `[Errno -2] Name or service not known`.

Adds a root-level `context:` block with `governance_agent_url: "https://test-agent.adcontextprotocol.org"` to each file and switches the hardcoded URL to `$context.governance_agent_url`. This matches the pattern already established by the named governance scenario files (`governance_conditions.yaml`, `governance_denied.yaml`, `governance_denied_recovery.yaml`, `governance_approved.yaml`) as part of #3913. The protocol index files were inadvertently missed in that fix.

**Out of scope (follow-up needed):** `inventory_list_targeting.yaml`, `inventory_list_no_match.yaml`, and `test-kits/acme-outdoor.yaml` also reference `governance.pinnacle-agency.example` as a property-list `agent_url`. These need a hosted list-server endpoint — a different fix — and are tracked in the changeset description.

**Non-breaking justification:** Storyboard fixture only. Adds a `context:` key to two YAML files. No schema, task definition, or normative wire behavior changed. Operators can override the URL via `--context governance_agent_url=...` at run time.

**Pre-PR review:**
- code-reviewer: approved — pattern matches all existing governance scenario files; `governance_multi_agent_rejected.yaml` carve-out (intentional invalid-payload test) confirmed correct. One nit: narrative override hint not added to index files (out of scope for this fix).
- ad-tech-protocol-expert: approved — no blockers; `$context.governance_agent_url` interpolation is sound; sandbox URL alignment with prior #3913 fix is correct. Out-of-scope follow-up for inventory targeting files noted.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or request a new first draft PR:** comment `/triage execute`
>   on the source issue only when no triage-managed PR is already
>   open. Triage does not update existing PRs.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_011fdethyShZbU2LhjBy6hyy

---
_Generated by [Claude Code](https://claude.ai/code/session_011fdethyShZbU2LhjBy6hyy)_