### PR TITLE
Add member contacts CSV export

### DIFF
--- a/.changeset/member-contacts-export.md
+++ b/.changeset/member-contacts-export.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add an admin-only member contacts CSV export. No package release is needed for this internal admin UI/API change.

--- a/server/public/admin-accounts.html
+++ b/server/public/admin-accounts.html
@@ -853,7 +853,7 @@
       </select>
       <div id="membersActions" style="display: none; margin-left: auto; gap: var(--space-2); align-items: center;">
         <span id="membersSyncStatus" style="font-size: var(--text-xs); color: var(--color-text-secondary);"></span>
-        <button class="btn btn-secondary btn-sm" onclick="exportMembersCsv()">Export CSV</button>
+        <button class="btn btn-secondary btn-sm" onclick="exportMemberContactsCsv(this)">Export all contacts CSV</button>
         <button class="btn btn-primary btn-sm" id="syncAllStripeBtn" onclick="syncAllStripe()">Sync from Stripe</button>
       </div>
     </div>
@@ -1462,43 +1462,39 @@
       }
     }
 
-    async function exportMembersCsv() {
+    async function exportMemberContactsCsv(button) {
+      const statusEl = document.getElementById('membersSyncStatus');
+      const originalText = button.textContent;
+      button.disabled = true;
+      button.textContent = 'Exporting...';
+      statusEl.textContent = '';
+      statusEl.style.color = 'var(--color-text-secondary)';
+
       try {
-        const response = await fetch('/api/admin/accounts?view=members&limit=500');
-        if (!response.ok) throw new Error('Failed to load members');
-        const members = await response.json();
+        const response = await fetch('/api/admin/accounts/contacts-export');
+        if (!response.ok) {
+          const err = await response.json().catch(() => ({ message: response.statusText }));
+          throw new Error(err.message || `Export failed (${response.status})`);
+        }
 
-        const headers = ['Name', 'Domain', 'Subscription Status', 'Product', 'Renewal Date', 'Community Points', 'Interest Level'];
-        const rows = members.map(m => [
-          m.name || '',
-          m.email_domain || '',
-          m.subscription_status || '',
-          m.subscription_product_name || '',
-          m.subscription_current_period_end ? new Date(m.subscription_current_period_end).toISOString().split('T')[0] : '',
-          m.community_points ?? '',
-          m.interest_level || '',
-        ]);
-
-        const csv = [headers, ...rows]
-          .map(row => row.map(cell => {
-            // Defuse spreadsheet formula injection: prefix risky leading chars with '
-            const s = String(cell).replace(/"/g, '""');
-            const safe = /^[=+\-@\t\r]/.test(s) ? "'" + s : s;
-            return `"${safe}"`;
-          }).join(','))
-          .join('\n');
-
-        const blob = new Blob([csv], { type: 'text/csv' });
+        const blob = await response.blob();
+        const disposition = response.headers.get('content-disposition') || '';
+        const filenameMatch = disposition.match(/filename="([^"]+)"/);
+        const filename = filenameMatch?.[1] || `member-contacts-${new Date().toISOString().split('T')[0]}.csv`;
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;
-        a.download = `members-${new Date().toISOString().split('T')[0]}.csv`;
+        a.download = filename;
         document.body.appendChild(a);
         a.click();
         document.body.removeChild(a);
         URL.revokeObjectURL(url);
       } catch (err) {
-        alert('Failed to export: ' + err.message);
+        statusEl.textContent = err.message;
+        statusEl.style.color = 'var(--color-error-600)';
+      } finally {
+        button.disabled = false;
+        button.textContent = originalText;
       }
     }
 

--- a/server/src/routes/admin/accounts.ts
+++ b/server/src/routes/admin/accounts.ts
@@ -15,7 +15,7 @@ import { getPool } from "../../db/client.js";
 import { createLogger } from "../../logger.js";
 import { requireAuth, requireAdmin, requireGlobalAdmin } from "../../middleware/auth.js";
 import { serveHtmlWithConfig } from "../../utils/html-config.js";
-import { OrganizationDatabase, VALID_REVENUE_TIERS, resolveMembershipTier, type MembershipTier } from "../../db/organization-db.js";
+import { OrganizationDatabase, resolveMembershipTier, type MembershipTier } from "../../db/organization-db.js";
 import { formatCompanyTypes } from "../../config/company-types.js";
 import { deleteOrganizationMembership } from "../../db/membership-db.js";
 import { invalidateMembershipCache } from "../../db/org-filters.js";

--- a/server/src/routes/admin/accounts.ts
+++ b/server/src/routes/admin/accounts.ts
@@ -13,9 +13,10 @@
 import { Router, Request, Response } from "express";
 import { getPool } from "../../db/client.js";
 import { createLogger } from "../../logger.js";
-import { requireAuth, requireAdmin } from "../../middleware/auth.js";
+import { requireAuth, requireAdmin, requireGlobalAdmin } from "../../middleware/auth.js";
 import { serveHtmlWithConfig } from "../../utils/html-config.js";
-import { OrganizationDatabase, VALID_REVENUE_TIERS } from "../../db/organization-db.js";
+import { OrganizationDatabase, VALID_REVENUE_TIERS, resolveMembershipTier, type MembershipTier } from "../../db/organization-db.js";
+import { formatCompanyTypes } from "../../config/company-types.js";
 import { deleteOrganizationMembership } from "../../db/membership-db.js";
 import { invalidateMembershipCache } from "../../db/org-filters.js";
 import {
@@ -58,6 +59,19 @@ import {
 const orgDb = new OrganizationDatabase();
 const logger = createLogger("admin-accounts");
 
+const MEMBERSHIP_TIER_LABELS: Record<MembershipTier, string> = {
+  individual_academic: "Explorer",
+  individual_professional: "Professional",
+  company_standard: "Builder",
+  company_icl: "Partner",
+  company_leader: "Leader",
+};
+
+function escapeCsvValue(value: string | number | boolean | null | undefined): string {
+  const str = value == null ? "" : String(value);
+  const prefixed = /^[=+\-@\t\r]/.test(str) ? `'${str}` : str;
+  return `"${prefixed.replace(/"/g, '""')}"`;
+}
 
 export function setupAccountRoutes(
   pageRouter: Router,
@@ -326,6 +340,172 @@ export function setupAccountRoutes(
         res.status(500).json({
           error: "Internal server error",
           message: "Unable to fetch view counts",
+        });
+      }
+    }
+  );
+
+  // GET /api/admin/accounts/contacts-export - CSV of people attached to active member orgs.
+  // Registered before /accounts/:orgId so "contacts-export" is not treated as an org id.
+  apiRouter.get(
+    "/accounts/contacts-export",
+    ...requireGlobalAdmin,
+    async (_req: Request, res: Response) => {
+      try {
+        const pool = getPool();
+        const result = await pool.query<{
+          row_source: "membership" | "org_contact";
+          membership_first_name: string | null;
+          membership_last_name: string | null;
+          user_first_name: string | null;
+          user_last_name: string | null;
+          email: string;
+          role: string | null;
+          company: string;
+          company_types: string[] | null;
+          prospect_contact_name: string | null;
+          prospect_contact_email: string | null;
+          prospect_contact_title: string | null;
+          membership_tier: MembershipTier | null;
+          subscription_price_lookup_key: string | null;
+          subscription_status: string | null;
+          subscription_amount: number | null;
+          subscription_interval: string | null;
+          is_personal: boolean;
+          subscription_product_name: string | null;
+        }>(`
+          WITH active_member_orgs AS (
+            SELECT
+              o.workos_organization_id,
+              o.name,
+              COALESCE(
+                o.company_types,
+                CASE WHEN o.company_type IS NOT NULL THEN ARRAY[o.company_type] ELSE NULL END
+              ) AS company_types,
+              o.prospect_contact_name,
+              o.prospect_contact_email,
+              o.prospect_contact_title,
+              o.membership_tier,
+              o.subscription_price_lookup_key,
+              o.subscription_status,
+              o.subscription_amount,
+              o.subscription_interval,
+              o.is_personal,
+              o.subscription_product_name
+            FROM organizations o
+            WHERE ${MEMBER_FILTER_ALIASED}
+          ),
+          membership_contacts AS (
+            SELECT
+              'membership'::text AS row_source,
+              om.first_name AS membership_first_name,
+              om.last_name AS membership_last_name,
+              COALESCE(NULLIF(u.first_name, ''), NULL) AS user_first_name,
+              COALESCE(NULLIF(u.last_name, ''), NULL) AS user_last_name,
+              COALESCE(NULLIF(om.email, ''), u.email) AS email,
+              om.role,
+              o.name AS company,
+              o.company_types,
+              o.prospect_contact_name,
+              o.prospect_contact_email,
+              o.prospect_contact_title,
+              o.membership_tier,
+              o.subscription_price_lookup_key,
+              o.subscription_status,
+              o.subscription_amount,
+              o.subscription_interval,
+              o.is_personal,
+              o.subscription_product_name
+            FROM organization_memberships om
+            JOIN active_member_orgs o
+              ON o.workos_organization_id = om.workos_organization_id
+            LEFT JOIN users u
+              ON u.workos_user_id = om.workos_user_id
+          ),
+          org_contact_rows AS (
+            SELECT
+              'org_contact'::text AS row_source,
+              NULL::text AS membership_first_name,
+              NULL::text AS membership_last_name,
+              NULL::text AS user_first_name,
+              NULL::text AS user_last_name,
+              o.prospect_contact_email AS email,
+              NULL::text AS role,
+              o.name AS company,
+              o.company_types,
+              o.prospect_contact_name,
+              o.prospect_contact_email,
+              o.prospect_contact_title,
+              o.membership_tier,
+              o.subscription_price_lookup_key,
+              o.subscription_status,
+              o.subscription_amount,
+              o.subscription_interval,
+              o.is_personal,
+              o.subscription_product_name
+            FROM active_member_orgs o
+            WHERE NULLIF(TRIM(o.prospect_contact_email), '') IS NOT NULL
+              AND NOT EXISTS (
+                SELECT 1
+                FROM membership_contacts mc
+                WHERE mc.email IS NOT NULL
+                  AND LOWER(TRIM(mc.email)) = LOWER(TRIM(o.prospect_contact_email))
+              )
+          )
+          SELECT *
+          FROM (
+            SELECT * FROM membership_contacts
+            UNION ALL
+            SELECT * FROM org_contact_rows
+          ) contacts
+          ORDER BY LOWER(company), row_source, LOWER(COALESCE(user_last_name, membership_last_name, '')), LOWER(COALESCE(user_first_name, membership_first_name, prospect_contact_name, '')), LOWER(COALESCE(email, ''))
+        `);
+
+        const headers = [
+          "First Name",
+          "Last Name",
+          "Title",
+          "Company",
+          "Email Address",
+          "Membership Type",
+          "Company Type",
+          "Primary Contact",
+        ];
+
+        const rows = result.rows.map((row) => {
+          const email = row.email?.trim() ?? "";
+          const isKnownOrgContact =
+            email.length > 0 &&
+            row.prospect_contact_email?.trim().toLowerCase() === email.toLowerCase();
+          const tier = resolveMembershipTier(row);
+
+          return [
+            row.user_first_name || row.membership_first_name || (row.row_source === "org_contact" ? row.prospect_contact_name || "" : ""),
+            row.user_last_name || row.membership_last_name || "",
+            isKnownOrgContact ? row.prospect_contact_title || "" : "",
+            row.company,
+            email,
+            tier ? MEMBERSHIP_TIER_LABELS[tier] : "",
+            row.company_types?.length ? formatCompanyTypes(row.company_types) : "",
+            isKnownOrgContact ? "Yes" : "No",
+          ];
+        });
+
+        const csv = [headers, ...rows]
+          .map((row) => row.map(escapeCsvValue).join(","))
+          .join("\n");
+
+        res.setHeader("Content-Type", "text/csv; charset=utf-8");
+        res.setHeader(
+          "Content-Disposition",
+          `attachment; filename="member-contacts-${new Date().toISOString().split("T")[0]}.csv"`
+        );
+        res.send(csv);
+      } catch (error) {
+        logger.error({ err: error }, "Error exporting member contacts");
+        res.status(500).json({
+          error: "Internal server error",
+          message: "Unable to export member contacts",
         });
       }
     }
@@ -3140,4 +3320,3 @@ export function setupAccountRoutes(
     }
   );
 }
-

--- a/tests/admin-contacts-export-route.test.ts
+++ b/tests/admin-contacts-export-route.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import { Router } from 'express';
+import request from 'supertest';
+
+const {
+  mockPoolQuery,
+  mockLoadDraftAndState,
+} = vi.hoisted(() => {
+  process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'test';
+  process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+  return {
+    mockPoolQuery: vi.fn<any>(),
+    mockLoadDraftAndState: vi.fn<any>(),
+  };
+});
+
+vi.mock('../server/src/middleware/auth.js', () => ({
+  requireAuth: (req: any, _res: any, next: any) => {
+    req.user = { id: 'user_admin', email: 'admin@example.com', is_admin: true };
+    next();
+  },
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+  requireGlobalAdmin: [
+    (req: any, _res: any, next: any) => {
+      req.user = { id: 'user_admin', email: 'admin@example.com', is_admin: true };
+      next();
+    },
+    (_req: any, _res: any, next: any) => next(),
+  ],
+}));
+
+vi.mock('../server/src/db/client.js', () => ({
+  getPool: () => ({ query: mockPoolQuery }),
+}));
+
+vi.mock('../server/src/billing/stripe-client.js', () => ({
+  getPendingInvoices: vi.fn(),
+  createCheckoutSession: vi.fn(),
+  getProductsForCustomer: vi.fn(),
+}));
+
+vi.mock('../server/src/addie/jobs/announcement-handlers.js', () => ({
+  markLinkedInPosted: vi.fn(),
+  refreshReviewCardForOrg: vi.fn(),
+  loadDraftAndState: (...args: unknown[]) => mockLoadDraftAndState(...args),
+}));
+
+import { setupAccountRoutes } from '../server/src/routes/admin/accounts.js';
+
+function buildApp() {
+  const app = express();
+  const pageRouter = Router();
+  const apiRouter = Router();
+  setupAccountRoutes(pageRouter, apiRouter);
+  app.use('/api/admin', apiRouter);
+  return app;
+}
+
+beforeEach(() => {
+  mockPoolQuery.mockReset();
+  mockLoadDraftAndState.mockReset();
+});
+
+describe('GET /api/admin/accounts/contacts-export', () => {
+  it('exports active member and org-level contacts with membership tier, company type, and primary contact', async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          row_source: 'membership',
+          membership_first_name: 'Alice',
+          membership_last_name: 'Owner',
+          user_first_name: null,
+          user_last_name: null,
+          email: 'alice@example.com',
+          role: 'owner',
+          company: 'Nova Brands',
+          company_types: ['brand'],
+          prospect_contact_name: 'Maya Mason and Lee Chen',
+          prospect_contact_email: 'maya@example.com',
+          prospect_contact_title: 'VP Marketing',
+          membership_tier: 'company_standard',
+          subscription_price_lookup_key: null,
+          subscription_status: 'active',
+          subscription_amount: null,
+          subscription_interval: null,
+          is_personal: false,
+          subscription_product_name: null,
+        },
+        {
+          row_source: 'org_contact',
+          membership_first_name: null,
+          membership_last_name: null,
+          user_first_name: null,
+          user_last_name: null,
+          email: 'maya@example.com',
+          role: null,
+          company: 'Nova Brands',
+          company_types: ['brand'],
+          prospect_contact_name: 'Maya Mason and Lee Chen',
+          prospect_contact_email: 'maya@example.com',
+          prospect_contact_title: 'VP Marketing',
+          membership_tier: 'company_standard',
+          subscription_price_lookup_key: null,
+          subscription_status: 'active',
+          subscription_amount: null,
+          subscription_interval: null,
+          is_personal: false,
+          subscription_product_name: null,
+        },
+        {
+          row_source: 'membership',
+          membership_first_name: 'Rin',
+          membership_last_name: 'Patel',
+          user_first_name: null,
+          user_last_name: null,
+          email: 'rin@example.com',
+          role: 'member',
+          company: 'Pinnacle Media',
+          company_types: ['ai', 'adtech'],
+          prospect_contact_name: null,
+          prospect_contact_email: null,
+          prospect_contact_title: null,
+          membership_tier: null,
+          subscription_price_lookup_key: 'aao_membership_partner_10000',
+          subscription_status: 'active',
+          subscription_amount: null,
+          subscription_interval: null,
+          is_personal: false,
+          subscription_product_name: null,
+        },
+        {
+          row_source: 'membership',
+          membership_first_name: 'Zed',
+          membership_last_name: 'Nulltier',
+          user_first_name: null,
+          user_last_name: null,
+          email: 'zed@example.com',
+          role: 'member',
+          company: 'Zenith Data',
+          company_types: ['data'],
+          prospect_contact_name: null,
+          prospect_contact_email: null,
+          prospect_contact_title: null,
+          membership_tier: null,
+          subscription_price_lookup_key: null,
+          subscription_status: 'active',
+          subscription_amount: null,
+          subscription_interval: null,
+          is_personal: false,
+          subscription_product_name: 'Raw Stripe Product',
+        },
+      ],
+    });
+
+    const response = await request(buildApp()).get('/api/admin/accounts/contacts-export');
+
+    expect(response.status).toBe(200);
+    expect(response.headers['content-type']).toContain('text/csv');
+    expect(response.headers['content-disposition']).toContain('member-contacts-');
+    expect(response.text.split('\n')[0]).toBe('"First Name","Last Name","Title","Company","Email Address","Membership Type","Company Type","Primary Contact"');
+    expect(response.text).toContain('"Alice","Owner","","Nova Brands","alice@example.com","Builder","Brand","No"');
+    expect(response.text).toContain('"Maya Mason and Lee Chen","","VP Marketing","Nova Brands","maya@example.com","Builder","Brand","Yes"');
+    expect(response.text).toContain('"Rin","Patel","","Pinnacle Media","rin@example.com","Partner","AI & Tech Platforms, Ad Tech","No"');
+    expect(response.text).toContain('"Zed","Nulltier","","Zenith Data","zed@example.com","","Data & Measurement","No"');
+    expect(response.text).not.toContain('Raw Stripe Product');
+    expect(mockPoolQuery.mock.calls[0][0]).toContain("o.subscription_status = 'active' AND o.subscription_canceled_at IS NULL");
+    expect(mockPoolQuery.mock.calls[0][0]).toContain('org_contact_rows AS');
+    expect(mockPoolQuery.mock.calls[0][0]).toContain('NOT EXISTS');
+  });
+});

--- a/tests/announcement/announcement-admin-route.test.ts
+++ b/tests/announcement/announcement-admin-route.test.ts
@@ -47,6 +47,13 @@ vi.mock('../../server/src/middleware/auth.js', () => ({
     next();
   },
   requireAdmin: (_req: any, _res: any, next: any) => next(),
+  requireGlobalAdmin: [
+    (req: any, _res: any, next: any) => {
+      req.user = mockCurrentUser;
+      next();
+    },
+    (_req: any, _res: any, next: any) => next(),
+  ],
 }));
 
 // Everything else the route module imports but doesn't need for these


### PR DESCRIPTION
Adds a global-admin-only contacts CSV export for active member accounts, including organization membership rows plus standalone account contact rows. The export includes first/last name, title, company, email, membership type, company type, and primary-contact indicator, with CSV injection defusing. Updates the admin accounts toolbar to download the full contacts export with in-page error handling. Adds focused route coverage and updates the existing announcement route mock for the new global-admin route dependency.