### PR TITLE
docs(creative): buyer-attached input contract — gate vs. advisory

### DIFF
--- a/.changeset/buyer-attached-inputs-contract.md
+++ b/.changeset/buyer-attached-inputs-contract.md
@@ -1,0 +1,19 @@
+---
+---
+
+docs(creative): buyer-attached input contract — the gate-vs-advisory governance distinction for `build_creative` inputs
+
+Adds [`docs/creative/buyer-attached-inputs.mdx`](https://docs.adcontextprotocol.org/docs/creative/buyer-attached-inputs), a normative reference that defines — once — the contract every input a buyer attaches to `build_creative` shares, so each future pointer inherits it instead of relitigating governance.
+
+**Two classes of buyer-attached input.**
+
+- **Enforced capability input** (`transformer_id` + `config`): a typed contract the creative agent owns and prices per account. It gates — the agent MUST reject unknown / out-of-range `config` with field-attributed errors. Normative today (shipped in #5219).
+- **Advisory context pointer** (`signal_ref`, `evaluator`, rights / provenance references): informs or steers production but MUST NOT hard-block it at the AdCP layer. Where enforcement exists, it lives in the layer that owns the thing — provider `generation_credentials` for rights, trafficking-compatibility checks for signals — not in the buyer's pointer.
+
+**Shared shape** all buyer-attached inputs inherit: account-scoped discovery (`list_transformers`-style), per-account pricing, and a result envelope with a stable per-leaf anchor (`build_variant_id`).
+
+**Rights are advisory at the pointer; enforcement is the credential.** Records the settled position against #5261's "`rights_tokens[]` as a hard creative-agent gate" proposal: hard-gating at the buyer pointer re-invents `generation_credentials` (provider-enforced at synthesis) plus `rights_constraint.verification_url` (live revocation). The pointer stays advisory / audit; the one real gap is structural — `voice_synthesis` carries no `rights_id` back-reference yet.
+
+**Forward pointers** `signal_ref` (#5240) and `evaluator` (#5241) are referenced by governance class only — not yet in the schema.
+
+Documentation only; no schema changes. Refs #5219, #5240, #5241, #5261.

--- a/docs.json
+++ b/docs.json
@@ -316,6 +316,7 @@
                         "group": "Building Creative Agents",
                         "pages": [
                           "docs/creative/implementing-creative-agents",
+                          "docs/creative/buyer-attached-inputs",
                           "docs/creative/sales-agent-creative-capabilities",
                           "docs/creative/multi-agent-orchestration",
                           "docs/creative/creative-manifests",
@@ -1515,6 +1516,7 @@
                     "group": "Building Creative Agents",
                     "pages": [
                       "docs/creative/implementing-creative-agents",
+                      "docs/creative/buyer-attached-inputs",
                       "docs/creative/sales-agent-creative-capabilities",
                       "docs/creative/multi-agent-orchestration",
                       "docs/creative/creative-manifests",

--- a/docs/creative/buyer-attached-inputs.mdx
+++ b/docs/creative/buyer-attached-inputs.mdx
@@ -1,0 +1,80 @@
+---
+title: Buyer-attached inputs to build_creative
+description: "The shared contract for inputs a buyer attaches to build_creative, and the one governance distinction that decides whether an input gates production or only steers it."
+"og:title": "AdCP — Buyer-attached inputs to build_creative"
+sidebarTitle: Buyer-attached inputs
+---
+
+[`build_creative`](/docs/creative/task-reference/build_creative) accepts inputs the buyer attaches to a build: a selected build capability, render configuration, and — over time — pointers to context the buyer wants the production to honor. This page defines the contract those inputs share so each new pointer inherits it instead of relitigating governance. The one distinction that matters is whether an input is an **enforced capability input** the agent validates and gates on, or an **advisory context pointer** that informs production but does not hard-block it at the AdCP layer.
+
+The boundary is deliberate and matches the rest of the protocol: capabilities are declared, not gated, and the default is exposure, not coercion. An input gates only when it is a typed contract the agent owns end to end — a render configuration that drives a paid render. Everything else steers.
+
+## Two classes of buyer-attached input
+
+| | Enforced capability input | Advisory context pointer |
+|---|---|---|
+| **Examples** | `transformer_id`, `config` | `signal_ref` ([#5240](https://github.com/adcontextprotocol/adcp/issues/5240)), `evaluator` ([#5241](https://github.com/adcontextprotocol/adcp/issues/5241)), rights / provenance pointers |
+| **Status** | Normative now | Rights/provenance advisory now; signal/evaluator are RFCs |
+| **What it does** | Selects and parameterizes the build; the agent MUST validate it | Informs or steers production toward buyer context |
+| **On bad/unknown input** | Reject with a field-attributed error | Does not hard-block at the AdCP layer |
+| **Where enforcement lives** | The creative agent, at build time | Elsewhere — the credential layer, trafficking-compatibility checks, or the seller's own verification |
+
+### Enforced capability input — `transformer_id` + `config`
+
+A `transformer_id` selects an account-scoped transformer (discovered via [`list_transformers`](/docs/creative/task-reference/list_transformers)) to perform the build. One transformer per call; `target_format_id` / `target_format_ids` MUST be a subset of the transformer's `output_format_ids`. Render configuration goes in `config`.
+
+`config` is a typed bag keyed by each param's `field` from the transformer's `params[]`. It gates, and it gates correctly: per [`build_creative`](/docs/creative/task-reference/build_creative), the creative agent **MUST reject unknown keys and out-of-range values with field-attributed errors** rather than silently ignoring them — `config` drives a paid render. Vendor-specific knobs that are not declared params go in `ext`, not here. The schema leaves the object open because legal keys are dynamic per transformer, so strict validation is a normative agent obligation.
+
+This is the only buyer-attached input that hard-blocks a build at the AdCP layer, and it is the right one to: `config` is a contract the creative agent owns, priced per account, and a mis-keyed value would charge for the wrong render. The agent declares `creative.supports_transformers` to expose this surface, and `transformer` and `build_variant` are registered `x-entity` types.
+
+### Advisory context pointers — `signal_ref`, `evaluator`, rights / provenance
+
+Advisory pointers carry buyer context the production SHOULD honor — an audience signal, an evaluator's preference, a rights or provenance reference. They inform or steer; they MUST NOT hard-block production at the AdCP layer. Where enforcement exists for the thing a pointer names, it lives in the layer that owns it, not in `build_creative`:
+
+- **Rights / provenance** — enforced by the credential layer (`generation_credentials` at synthesis, `rights_constraint.verification_url` for live revocation), not by the buyer's pointer.
+- **Signals** ([#5240](https://github.com/adcontextprotocol/adcp/issues/5240)) — where enforcement exists, it lives in trafficking-compatibility checks.
+- **Evaluators** ([#5241](https://github.com/adcontextprotocol/adcp/issues/5241)) — explore-and-rank guidance, surfaced as `recommended` / `rank` on leaves; not a gate.
+
+This mirrors the register the protocol already uses for advisory state: buyers MUST NOT gate downstream spend or package activation on an advisory value, the way [`sync_creatives`](/docs/creative/task-reference/sync_creatives) `status` is "a UI hint and polling-scheduling signal — not a spend-authorization gate." `keep_mode` is the same shape on the request side — advisory only, it does not change what is returned or billed.
+
+## Shared shape
+
+Every buyer-attached input — enforced or advisory — inherits the same three-part shape. This is normative for transformers today and is the pattern future pointers reuse:
+
+1. **Account-scoped discovery.** Options are discovered, not guessed. `list_transformers` is account-scoped, brief-filterable, and paginated, with an `expand_params` mode that enumerates an account's configured option values (for example, the voices provisioned for that account). There is no separate options endpoint — enumeration is a mode of the one discovery task. A future pointer's catalog is discovered the same way.
+
+2. **Per-account pricing.** Capabilities carry `pricing_options` (reusing `vendor-pricing-option.json`) resolved per account, echoed per leaf in the result, and reconciled via `report_usage`. An output that matches no pricing option and has no unscoped default surfaces `UNPRICEABLE_OUTPUT`.
+
+3. **Result envelope with a stable leaf anchor.** [`build_creative`](/docs/creative/task-reference/build_creative) returns each produced leaf with its own `build_variant_id` — a namespace distinct from a `preview_id` (preview), a served `variant_id` (delivery), and the call-level `build_creative_id`. Lineage, refinement parentage, and the build→delivery learning join all key on this leaf id, and each leaf carries its own pricing receipt. This is the anchor an evaluator's scores or a signal's targeting attach to when those pointers land. The response-shape contract and per-leaf field mechanics live in the [`build_creative`](/docs/creative/task-reference/build_creative) task reference.
+
+## Rights are advisory at the pointer; enforcement is the credential
+
+A rights or [provenance](/docs/creative/provenance) reference attached to a build is an advisory / audit pointer. It does not authorize the build at the AdCP layer, and the creative agent is not obligated to validate a rights token against it. A transformer's `voice_synthesis_ref[].rights_id` says this directly:
+
+> This is provenance metadata only, not a build_creative rights token.
+
+Enforcement for rights already ships, and it lives in the credential layer — not at the buyer's pointer:
+
+- **`generation_credentials`** are provider-enforced at synthesis. The rights agent coordinates with the provider to issue a scoped credential; the provider validates `rights_key` at generation time and is the gatekeeper. The credential is required on the acquired branch of `acquire_rights`.
+- **`rights_constraint.verification_url`** is the live-revocation channel: downstream participants (SSPs, verification vendors) hit it to confirm a grant is active before serving — HTTP 200 if active, 404 if revoked. (`approval_status` is a manifest-time snapshot, not a live value.)
+- **`creative-manifest` `rights[]`** travels with the creative as informational metadata: "For v1, rights constraints are informational metadata — the buyer/orchestrator manages creative lifecycle against these terms."
+
+Buyer-attached provenance follows the same [seller-publishes / buyer-represents / seller-confirms split](/docs/governance/creative/provenance-verification) — the buyer declares, the seller verifies. A buyer's `verify_agent.agent_url` MUST be a [canonicalized match](/docs/reference/url-canonicalization) of one of the seller's published `creative_policy.accepted_verifiers[]`; off-list URLs are rejected with `PROVENANCE_VERIFIER_NOT_ACCEPTED`. That rejection is the seller enforcing its own allowlist before any outbound call — not the buyer's pointer gating the build. The buyer's attached results are supplementary; a seller that requires verification runs its own detection rather than trusting them.
+
+<Note>
+**Settled position vs. [#5261](https://github.com/adcontextprotocol/adcp/issues/5261).** A proposal to treat buyer-attached `rights_tokens[]` as a hard creative-agent gate is resolved against this page. Hard-gating at the buyer pointer re-invents the `generation_credentials` enforcement that already ships at the synthesis layer plus `verification_url` live revocation at the serve layer. The pointer stays advisory; enforcement stays in the credential layer. The one real gap is structural, not a missing gate: `voice_synthesis` carries `provider` / `voice_id` / `settings` but no `rights_id` back-reference today. Adding that back-reference is a forward item — it would extend the advisory/audit trail, not introduce a build-time gate.
+</Note>
+
+## Forward pointers (not yet normative)
+
+The following advisory pointers belong to this contract's second class but are not yet in the schema. They are referenced here by governance class only — no fields are defined.
+
+- **`signal_ref` ([#5240](https://github.com/adcontextprotocol/adcp/issues/5240), RFC).** Signal-driven creative fan-out: a buyer-attached pointer to an audience signal the production steers toward. Advisory at the AdCP layer; where enforcement exists it lives in trafficking-compatibility checks. No `signal_ref` creative-context schema exists yet.
+
+<Warning>
+Do not confuse this proposed creative pointer with the signals-domain `signal-ref.json` (`x-entity: signal`, `scope` discriminator) used for signal targeting and discovery. They share a name but are different constructs; only the signals-domain one exists today.
+</Warning>
+
+- **`evaluator` / `evaluator_id` ([#5241](https://github.com/adcontextprotocol/adcp/issues/5241), RFC).** A creative evaluator/oracle the buyer attaches so the agent can explore and rank alternatives (the `best_of_n` dimension is where it would plug in, surfacing `recommended` / `rank` on leaves). Advisory — a preference signal, not a gate. No evaluator schema exists yet.
+
+When these merge, they inherit the shared shape above: account-scoped discovery, per-account pricing, and the same result envelope. They do not inherit the enforced class's gate — that is reserved for typed contracts the creative agent owns, like `config`.


### PR DESCRIPTION
## What

A normative reference page — `docs/creative/buyer-attached-inputs.mdx` — that defines, **once**, the contract every input a buyer attaches to `build_creative` shares. This is the "write the pointer contract once" follow-on to #5219 (account-scoped creative transformers + `build_creative` multiplicity): #5219 landed the first concrete pointer (`transformer_id`); this page defines the shared governance so the next pointers don't relitigate it.

## The one distinction

**Two classes of buyer-attached input:**

| | Enforced capability input | Advisory context pointer |
|---|---|---|
| Examples | `transformer_id`, `config` | `signal_ref` (#5240), `evaluator` (#5241), rights / provenance |
| On bad/unknown input | reject with a field-attributed error | does not hard-block at the AdCP layer |
| Enforcement lives | the creative agent, at build time | elsewhere — credential layer, trafficking-compat checks |

Plus the **shared shape** all of them inherit: account-scoped discovery (`list_transformers`-style), per-account pricing, and a stable per-leaf anchor (`build_variant_id`).

## Settled position vs. #5261

The page records — and the WG should confirm — that buyer-attached **rights stay advisory at the pointer; enforcement is the credential layer** (`generation_credentials` provider-enforced at synthesis + `rights_constraint.verification_url` live revocation). #5261's "`rights_tokens[]` as a hard creative-agent gate" would re-invent enforcement that already ships. The one real gap is structural: `voice_synthesis` has no `rights_id` back-reference yet — a forward item, not a gate.

## Scope

Documentation only — **no schema changes**. Every normative claim and quote references surfaces shipped in #5219 or the existing provenance/credential chain (verified against `main`). Nav added to both creative blocks in `docs.json`; empty-frontmatter changeset (docs-only, no version bump).

Refs #5219, #5240, #5241, #5261.

🤖 Generated with [Claude Code](https://claude.com/claude-code)