### PR TITLE
feat(si): optional availability_status enum on SI offering + matching products

### DIFF
--- a/.changeset/5264-si-offering-availability-status.md
+++ b/.changeset/5264-si-offering-availability-status.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": patch
+---
+
+Add an optional `availability_status` enum to the `si_get_offering` response. It appears on the `offering` object (alongside `expires_at`) and on each `matching_products[]` item (alongside the free-string `availability_summary`), and is defined by a new centralized enum `enums/offering-availability-status.json` (`available`, `limited`, `sold_out`, `expired`, `region_restricted`, `inactive`).
+
+The value set deliberately matches the SI task page's existing "Unavailable Reasons" vocabulary so the structured enum and the free-string `unavailable_reason` stay coherent. The field is optional and additive: it is not in `required`, both objects already carry `additionalProperties: true`, and the schema is `x-status: experimental`, so existing producers and consumers are unaffected.
+
+Refs #5264.

--- a/docs/sponsored-intelligence/tasks/si_get_offering.mdx
+++ b/docs/sponsored-intelligence/tasks/si_get_offering.mdx
@@ -81,6 +81,7 @@ This request must not include any personally identifiable information. The `inte
 | `summary` | string | Brief description |
 | `tagline` | string | Short promotional tagline |
 | `expires_at` | string | When the offering expires |
+| `availability_status` | string | Machine-readable availability state (enum: `available`, `limited`, `sold_out`, `expired`, `region_restricted`, `inactive`). Optional; aligns to the Unavailable Reasons vocabulary below. |
 | `price_hint` | string | Price indication (e.g., "from \$89") |
 | `image_url` | string | Hero image URL |
 | `landing_url` | string | Landing page URL |
@@ -95,6 +96,7 @@ This request must not include any personally identifiable information. The `inte
 | `original_price` | string | Original price if on sale |
 | `image_url` | string | Product image URL |
 | `availability_summary` | string | Brief availability info |
+| `availability_status` | string | Machine-readable availability state (same enum as the offering field). Optional; structured counterpart to `availability_summary`. |
 | `url` | string | Product detail page URL |
 
 ### Unavailable Reasons

--- a/static/schemas/source/enums/offering-availability-status.json
+++ b/static/schemas/source/enums/offering-availability-status.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/enums/offering-availability-status.json",
+  "title": "Offering Availability Status",
+  "description": "Machine-readable availability state for an SI offering or a matching product. Provides a structured counterpart to the free-string availability_summary and aligns to the same vocabulary as the free-string unavailable_reason (sold_out, expired, region_restricted, inactive) plus positive in-stock states.",
+  "type": "string",
+  "enum": [
+    "available",
+    "limited",
+    "sold_out",
+    "expired",
+    "region_restricted",
+    "inactive"
+  ],
+  "enumDescriptions": {
+    "available": "In stock and orderable.",
+    "limited": "Available but constrained (low stock, limited sizes/variants, or limited time).",
+    "sold_out": "Inventory exhausted. Corresponds to unavailable_reason 'sold_out'.",
+    "expired": "Offering is past its end date (see expires_at). Corresponds to unavailable_reason 'expired'.",
+    "region_restricted": "Not available in the requesting region. Corresponds to unavailable_reason 'region_restricted'.",
+    "inactive": "Campaign paused or ended by the seller. Corresponds to unavailable_reason 'inactive'."
+  }
+}

--- a/static/schemas/source/sponsored-intelligence/si-get-offering-response.json
+++ b/static/schemas/source/sponsored-intelligence/si-get-offering-response.json
@@ -58,6 +58,10 @@
           "format": "date-time",
           "description": "When this offering expires"
         },
+        "availability_status": {
+          "$ref": "/schemas/enums/offering-availability-status.json",
+          "description": "Machine-readable availability state for the offering. Optional; when omitted, derive availability from the top-level 'available' boolean and 'unavailable_reason'."
+        },
         "price_hint": {
           "type": "string",
           "description": "Price indication (e.g., 'from $199', '50% off')"
@@ -106,6 +110,10 @@
           "availability_summary": {
             "type": "string",
             "description": "Brief availability info (e.g., 'In stock', 'Size 14 available', '3 left')"
+          },
+          "availability_status": {
+            "$ref": "/schemas/enums/offering-availability-status.json",
+            "description": "Machine-readable availability state for this product. Structured counterpart to availability_summary."
           },
           "url": {
             "type": "string",


### PR DESCRIPTION
## What

Adds an optional `availability_status` enum to the `si_get_offering` response — on the `offering` object (alongside `expires_at`) and on each `matching_products[]` item (alongside the free-string `availability_summary`). Backed by a new `enums/offering-availability-status.json`.

## Why this shape

`si_get_offering` is a live, high-intent conversational surface, but it had no machine-readable availability signal — a brand agent could return an offering for an out-of-stock or region-restricted product with nothing structured to gate on (#5264).

The value set **deliberately matches the SI page's existing "Unavailable Reasons" vocabulary** (`available`, `limited`, `sold_out`, `expired`, `region_restricted`, `inactive`) so the structured enum and the free-string `unavailable_reason` stay coherent — no second vocabulary.

**Scoped down from the issue:** dropped `offer_expires_at` (redundant with `offering.expires_at`), `regional` (covered by `unavailable_reason: region_restricted`), and `fallback` (covered by `alternative_offering_ids` + cross-agent concerns).

## Scope

Additive and optional — not in `required`, both objects already carry `additionalProperties: true`, and the schema is `x-status: experimental`, so existing producers/consumers are unaffected. `patch` bump.

Closes #5264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)