### PR TITLE
docs(creative): social-DPA video pools + single-item render; card_video_max_file_size_kb parity

### DIFF
--- a/.changeset/social-dpa-video-render-docs.md
+++ b/.changeset/social-dpa-video-render-docs.md
@@ -1,0 +1,13 @@
+---
+"adcontextprotocol": patch
+---
+
+docs(creative): social-DPA video catalog pools + catalog-driven single-item render pattern; add `card_video_max_file_size_kb` parity field
+
+Clarifies that catalog asset pools accept video as a first-class asset group — `core/asset-group-vocabulary.json` already defines `video`, `video_vertical` (9:16), and `video_horizontal` (16:9) pools, and a feed URL mapped via `feed_field` + `asset_group_id` is wrapped as an image *or* video asset depending on the pool. Documented at the "Typed catalog assets" and "Feed field mappings" anchors in `docs/creative/catalogs.mdx`. Docs-only; the capability already ships (#5272).
+
+Documents the catalog-driven single-item render pattern — the platform composes one SKU per impression (Meta DPA single-product render, Snap Collection single-item, TikTok Shopping single-SKU) — using the existing `sponsored_placement` `fanout_mode: single_item`, and links the four adapter-contract families page. Extends the existing asset-bundle-vs-catalog-row prose in `docs/creative/canonical-formats.mdx`. Docs-only; addresses the docs half of #5277. The buyer-selection field and double-brace macro token syntax are deliberately out of scope (separate WG decision).
+
+Adds one optional `card_video_max_file_size_kb` (integer, minimum 1) to `image_carousel.json` as the video twin of the existing `card_image_max_file_size_kb`, so the two per-card file-size caps sit together. Additive optional field on a non-experimental canonical = backward-compatible patch. No codec/container enums or new `card_media_types` vocabulary (#5274).
+
+Closes #5272, #5274. Addresses docs half of #5277.

--- a/docs/creative/canonical-formats.mdx
+++ b/docs/creative/canonical-formats.mdx
@@ -898,6 +898,8 @@ Pinterest is the canonical disambiguation example because a single platform sell
 
 The cleave is **asset-bundle vs catalog-row composition**, not "is it Pinterest." Same logic applies to Snap Story Ad (native_in_feed) vs Snap Collection (sponsored_placement), TikTok TopView (native_in_feed via `applies_to_channels: ["social"]`) vs TikTok Collection (sponsored_placement), and so on. Buyer agents route on the composition shape; the publisher's brand of the surface is incidental.
 
+The `fanout_mode: single_item` case above is its own family: catalog-driven render where the platform composes **one SKU per impression** rather than a multi-item collection. Meta Dynamic Product Ads (single-product render), Snap Collection in single-item mode, and TikTok Shopping single-SKU all map to `sponsored_placement` with `fanout_mode: single_item` — the buyer ships a catalog reference and the seller renders one item per ad, with the platform selecting which item. This is still catalog-row composition; it differs from `multi_item_in_creative` only in how many items land in one creative. See [Sponsored Placement adapter contracts](/docs/creative/sponsored-placement-adapter-contracts) for the per-adopter runtime contracts (the Collection-layout family in §3 covers Pinterest/Snap Collection).
+
 A buyer agent reading a `format_kind: native_in_feed` product knows to assemble the title/image/body/CTA bundle from its own creative pool. Reading `format_kind: sponsored_placement`, it knows to attach a catalog feed and let the seller compose per-item. The discriminator carries the decision; no per-platform branching needed.
 
 ## Validation flow — `validate_input`

--- a/docs/creative/catalogs.mdx
+++ b/docs/creative/catalogs.mdx
@@ -167,7 +167,7 @@ By providing assets grouped by role, each catalog item self-describes the images
 }
 ```
 
-The `asset_group_id` vocabulary is not standardized at the protocol level — each format defines which group IDs it uses via `offering_asset_constraints` in the catalog asset's `requirements`. Common conventions: `images_landscape` (16:9), `images_vertical` (9:16), `images_square` (1:1), `logo`, `video`.
+The `asset_group_id` vocabulary is not standardized at the protocol level — each format defines which group IDs it uses via `offering_asset_constraints` in the catalog asset's `requirements`. Common conventions: `images_landscape` (16:9), `images_vertical` (9:16), `images_square` (1:1), `logo`, `video`. Video pools are first-class catalog asset groups alongside image pools — beyond the generic `video` pool, orientation-specific `video_vertical` (9:16) and `video_horizontal` (16:9) pool IDs let a feed carry per-orientation video the same way the image pools do.
 
 Formats use `field_bindings` (see [Format catalog requirements](#format-catalog-requirements)) to explicitly declare which template slot maps to which asset group.
 
@@ -457,7 +457,7 @@ Each mapping entry is one of:
 | Pattern | What it does |
 |---------|-------------|
 | `feed_field` + `catalog_field` | Renames a feed field to its schema equivalent (dot notation for nested fields) |
-| `feed_field` + `asset_group_id` | Places a URL into a typed asset pool on the item's `assets` array |
+| `feed_field` + `asset_group_id` | Places a URL into a typed asset pool on the item's `assets` array; the URL is wrapped as an image **or** video asset depending on the pool (e.g., `video`, `video_vertical`, `video_horizontal` wrap a video asset) |
 | `value` + `catalog_field` | Injects a static literal — useful for fields the feed omits (e.g., currency when always USD) |
 | Any of the above + `transform` | Applies a named coercion before writing |
 | Any of the above + `default` | Fallback when the feed field is absent or null |

--- a/docs/creative/channels/carousels.mdx
+++ b/docs/creative/channels/carousels.mdx
@@ -17,6 +17,8 @@ Carousel formats use repeatable asset groups to represent:
 
 All carousel formats use `asset_group_id` with `item_type: "repeatable_group"`, `min_count`, and `max_count` to define the structure.
 
+A card's media may be an image or a video. Where a card carries video, platforms can cap the per-card video file size via `card_video_max_file_size_kb` (the video counterpart to `card_image_max_file_size_kb`), alongside the per-card `card_video_max_duration_ms` duration cap. The authoritative per-card field list lives in the `image_carousel` schema.
+
 ## Repeatable Asset Groups
 
 ### Basic Structure

--- a/static/schemas/source/formats/canonical/image_carousel.json
+++ b/static/schemas/source/formats/canonical/image_carousel.json
@@ -48,6 +48,10 @@
       "type": "integer",
       "minimum": 1
     },
+    "card_video_max_file_size_kb": {
+      "type": "integer",
+      "minimum": 1
+    },
     "card_video_max_duration_ms": {
       "type": "integer",
       "minimum": 1


### PR DESCRIPTION
## What

Three coordinated, low-risk changes for the social-DPA cluster — mostly documenting capability that **already ships** in 3.1, plus one parity field. Corroborated by the agentic-adapters implementer review.

- **#5272 (video in catalog pools) — docs only.** The capability already exists: `asset-group-vocabulary.json` defines `video` / `video_vertical` / `video_horizontal` pools, and a feed URL mapped via `asset_group_id` wraps as an image *or* video asset by pool. Clarified at the "Typed catalog assets" and "Feed field mappings" anchors in `catalogs.mdx`. No schema change.
- **#5274 (card video) — one field.** `image_carousel` already has `allowed_card_media_asset_types`, `card_video_max_duration_ms`, `card_image_max_file_size_kb`, and `card-asset.media` is `oneOf[image, video]`. The only gap was the video file-size cap — added `card_video_max_file_size_kb` as the twin of the image cap. **No** parallel `card_media_types`/`video_card_constraints` vocab, **no** codec/container enums.
- **#5277 (single-item render) — docs half only.** Documents the catalog-driven single-SKU-per-impression pattern (Meta DPA, Snap Collection, TikTok Shopping) via the existing `fanout_mode: single_item`, linking the adapter-contract families page. The buyer-selection field and `{{macro}}` token syntax are **deliberately excluded** — those are a separate WG decision.

## Scope

`patch` — the sole schema change is an additive optional field on the non-experimental `image_carousel` canonical; everything else is documentation against shipped behavior.

Closes #5272, #5274. Addresses the docs half of #5277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)