### PR TITLE
Uncap Addie usage for AAO team

### DIFF
--- a/.changeset/addie-aao-team-uncapped.md
+++ b/.changeset/addie-aao-team-uncapped.md
@@ -1,0 +1,8 @@
+---
+---
+
+Addie now treats AgenticAdvertising.org admin team members as uncapped.
+
+- Users with active membership in the `aao-admin` working group resolve to the new `aao_team` tier.
+- The `aao_team` tier bypasses daily spend caps while still recording token cost events for admin visibility.
+- Admin Addie cost views display `aao_team` usage as uncapped and include a scoped 24-hour reset action.

--- a/server/public/admin-addie-costs.html
+++ b/server/public/admin-addie-costs.html
@@ -107,6 +107,7 @@
     .tier-anonymous { background: var(--color-bg-subtle); color: var(--color-text-secondary); }
     .tier-member_free { background: var(--color-info-50); color: var(--color-info-700); }
     .tier-member_paid { background: var(--color-success-50); color: var(--color-success-700); }
+    .tier-aao_team { background: var(--color-warning-50); color: var(--color-warning-700); }
 
     .ns-badge {
       display: inline-block;
@@ -182,6 +183,25 @@
       cursor: pointer;
       color: var(--color-text-secondary);
     }
+    .detail-actions {
+      display: flex;
+      gap: 8px;
+      justify-content: flex-end;
+      margin-bottom: 16px;
+    }
+    .danger-btn {
+      background: var(--color-error-50);
+      border: 1px solid var(--color-error-200);
+      border-radius: 6px;
+      color: var(--color-error-700);
+      cursor: pointer;
+      font-size: 14px;
+      padding: 6px 12px;
+    }
+    .danger-btn:disabled {
+      cursor: not-allowed;
+      opacity: 0.6;
+    }
     .detail-modal h3 { margin-bottom: 12px; color: var(--color-text-heading); }
   </style>
 </head>
@@ -192,7 +212,7 @@
     <h1>Addie Cost Cap</h1>
     <p class="subtitle">
       Per-user Anthropic API spend tracked against the rolling 24h cap
-      (anonymous $1 · member_free $5 · member_paid $25). Scope keys group
+      (anonymous $3 · member_free $5 · member_paid $25 · aao_team uncapped). Scope keys group
       callers by identity namespace — bare <code>user_…</code> ids join back
       to real members; <code>email:</code>/<code>mcp:</code>/<code>tavus:</code>
       stay opaque by design.
@@ -238,6 +258,9 @@
     <div class="panel">
       <button id="detailCloseBtn" class="close-btn" type="button">Close</button>
       <h3 id="detailTitle">Scope detail</h3>
+      <div class="detail-actions">
+        <button id="resetScopeBtn" class="danger-btn" type="button">Reset 24h cap</button>
+      </div>
       <div id="detailContent"><div class="loading">Loading…</div></div>
     </div>
   </div>
@@ -259,6 +282,8 @@
       if (pct >= 50) return 'warn';
       return '';
     }
+
+    let activeScopeKey = null;
 
     async function loadSummary() {
       try {
@@ -330,8 +355,9 @@
         }
 
         const rows = data.leaderboard.map(row => {
-          const fillCls = percentFillClass(row.percent_of_cap);
-          const widthPct = Math.max(0, Math.min(100, row.percent_of_cap));
+          const isUncapped = row.cap_usd === null || row.percent_of_cap === null;
+          const fillCls = isUncapped ? '' : percentFillClass(row.percent_of_cap);
+          const widthPct = isUncapped ? 0 : Math.max(0, Math.min(100, row.percent_of_cap));
           const memberCell = row.member_name
             ? `<div class="member-name">${escapeHtml(row.member_name)}</div><div class="scope-key">${escapeHtml(row.member_email || '')}</div>`
             : '<span class="scope-key" style="color: var(--color-text-muted);">—</span>';
@@ -346,8 +372,10 @@
               <td><span class="tier-badge tier-${escapeHtml(row.inferred_tier)}">${escapeHtml(row.inferred_tier)}</span></td>
               <td>$${row.spent_usd.toFixed(2)}</td>
               <td>
-                <span class="percent-bar"><span class="fill ${fillCls}" style="width: ${widthPct}%;"></span></span>
-                ${row.percent_of_cap.toFixed(1)}%
+                ${isUncapped
+                  ? '<span class="scope-key">Uncapped</span>'
+                  : `<span class="percent-bar"><span class="fill ${fillCls}" style="width: ${widthPct}%;"></span></span>${row.percent_of_cap.toFixed(1)}%`
+                }
               </td>
               <td>${row.event_count}</td>
               <td>${escapeHtml(row.models.join(', '))}</td>
@@ -379,6 +407,7 @@
     }
 
     async function openDetail(scopeKey) {
+      activeScopeKey = scopeKey;
       const modal = document.getElementById('detailModal');
       document.getElementById('detailTitle').textContent = `Scope: ${scopeKey}`;
       document.getElementById('detailContent').innerHTML = '<div class="loading">Loading…</div>';
@@ -426,13 +455,46 @@
     }
 
     function closeDetail() {
+      activeScopeKey = null;
       document.getElementById('detailModal').classList.remove('show');
+    }
+
+    async function resetActiveScope() {
+      if (!activeScopeKey) return;
+      const scopeKey = activeScopeKey;
+      const confirmed = window.confirm(`Reset the last 24 hours of Addie cost events for ${scopeKey}?`);
+      if (!confirmed) return;
+
+      const btn = document.getElementById('resetScopeBtn');
+      btn.disabled = true;
+      btn.textContent = 'Resetting…';
+      try {
+        const res = await fetch(`/api/admin/addie-costs/scope/${encodeURIComponent(scopeKey)}/reset`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{}'
+        });
+        if (!res.ok) throw new Error('reset failed');
+        const data = await res.json();
+        await Promise.all([loadSummary(), loadLeaderboard()]);
+        if (activeScopeKey === scopeKey) {
+          await openDetail(scopeKey);
+        }
+        window.alert(`Reset ${data.deleted_events} events ($${data.deleted_cost_usd.toFixed(2)}).`);
+      } catch (err) {
+        console.error(err);
+        window.alert('Failed to reset this scope.');
+      } finally {
+        btn.disabled = false;
+        btn.textContent = 'Reset 24h cap';
+      }
     }
 
     document.getElementById('detailModal').addEventListener('click', (e) => {
       if (e.target.id === 'detailModal') closeDetail();
     });
     document.getElementById('detailCloseBtn').addEventListener('click', closeDetail);
+    document.getElementById('resetScopeBtn').addEventListener('click', resetActiveScope);
     document.addEventListener('keydown', (e) => {
       if (e.key === 'Escape') closeDetail();
     });

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -1662,9 +1662,10 @@ async function handleUserMessage({
     ? CERTIFICATION_MAX_ITERATIONS
     : undefined;
   // Resolve the cost-cap identity + tier (#2790 / #2945 f/u).
-  // Prefers a mapped WorkOS user ID (member_paid for active subs);
-  // falls back to `slack:${userId}` at member_free when no mapping
-  // exists, bounding an individual Slack user's Addie spend.
+  // Prefers a mapped WorkOS user ID (aao_team for AAO admins,
+  // member_paid for active subs); falls back to `slack:${userId}` at
+  // member_free when no mapping exists, bounding an individual Slack
+  // user's Addie spend.
   const processOptions: import('./claude-client.js').ProcessMessageOptions = {
     requestContext: requestContextWithRouting,
     ...(routedTools.isAAOAdmin && { maxIterations: ADMIN_MAX_ITERATIONS }),

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -20,7 +20,7 @@ import { withRetry, isRetryableError, RetriesExhaustedError, type RetryConfig } 
 import { formatTokenCount, getConversationTokenLimit, buildDroppedMessagesSummary, type MessageTurn } from '../utils/token-limiter.js';
 import { notifySystemError, notifyToolError } from './error-notifier.js';
 import { ToolError } from './tool-error.js';
-import { checkCostCap, recordCost, formatCapExceededMessage } from './claude-cost-tracker.js';
+import { checkCostCap, recordCost, formatCapExceededMessage, type UserTier } from './claude-cost-tracker.js';
 import { EMPTY_RESPONSE_FALLBACK, applyResponsePipeline, stripBannedRituals } from './response-postprocess.js';
 
 type ToolHandler = (input: Record<string, unknown>) => Promise<string>;
@@ -358,7 +358,7 @@ export interface ProcessMessageOptions {
    */
   costScope?: {
     userId: string;
-    tier: 'anonymous' | 'member_free' | 'member_paid';
+    tier: UserTier;
   };
   /**
    * Explicit opt-out for system / router callers that shouldn't

--- a/server/src/addie/claude-cost-tracker.ts
+++ b/server/src/addie/claude-cost-tracker.ts
@@ -71,20 +71,24 @@ const WINDOW_MS = 24 * 60 * 60 * 1000;
  * - `member_paid`: $25/day. Paying members get a generous ceiling
  *   that's still a real cap — a runaway automated session still
  *   trips it within an hour of sustained abuse.
+ * - `aao_team`: uncapped. AAO staff/admin users are operating the
+ *   service, not consuming member benefits, so they should not hit
+ *   a self-service spend ceiling while doing support or admin work.
  */
-export const DAILY_BUDGET_USD: Record<'anonymous' | 'member_free' | 'member_paid', number> = {
+export const DAILY_BUDGET_USD = {
   anonymous: 3,
   member_free: 5,
   member_paid: 25,
-};
+} as const satisfies Record<'anonymous' | 'member_free' | 'member_paid', number>;
 
-const DAILY_BUDGET_MICROS: Record<keyof typeof DAILY_BUDGET_USD, number> = {
+type CappedUserTier = keyof typeof DAILY_BUDGET_USD;
+const DAILY_BUDGET_MICROS: Record<CappedUserTier, number> = {
   anonymous: DAILY_BUDGET_USD.anonymous * MICROS_PER_DOLLAR,
   member_free: DAILY_BUDGET_USD.member_free * MICROS_PER_DOLLAR,
   member_paid: DAILY_BUDGET_USD.member_paid * MICROS_PER_DOLLAR,
 };
 
-export type UserTier = keyof typeof DAILY_BUDGET_USD;
+export type UserTier = CappedUserTier | 'aao_team';
 
 export interface CostCheckResult {
   ok: boolean;
@@ -177,6 +181,7 @@ export async function checkCostCap(
 ): Promise<CostCheckResult> {
   if (!userId) return { ok: true };
   if (SYSTEM_USER_IDS.has(userId)) return { ok: true };
+  if (tier === 'aao_team') return { ok: true, tier };
 
   const budgetMicros = DAILY_BUDGET_MICROS[tier];
   const { totalMicros, firstAtMs } = await store.sumInWindow(userId, WINDOW_MS);
@@ -232,6 +237,9 @@ export async function recordCost(
  */
 export function formatCapExceededMessage(result: CostCheckResult): string {
   const tier = result.tier ?? 'anonymous';
+  if (tier === 'aao_team') {
+    return 'AAO team usage is uncapped.';
+  }
   const capUsd = DAILY_BUDGET_USD[tier];
   const spentUsd = ((result.spentCents ?? 0) / 100).toFixed(2);
   // Render the wait as hours when a user trips the cap early in the
@@ -261,9 +269,11 @@ export function formatCapExceededMessage(result: CostCheckResult): string {
  */
 export function resolveUserTier(opts: {
   isAnonymous?: boolean;
+  isAAOTeam?: boolean;
   hasActiveSubscription?: boolean;
 }): UserTier {
   if (opts.isAnonymous) return 'anonymous';
+  if (opts.isAAOTeam) return 'aao_team';
   return opts.hasActiveSubscription ? 'member_paid' : 'member_free';
 }
 
@@ -317,9 +327,12 @@ function writeCachedTier(userId: string, tier: UserTier): void {
  * (`slack:...`, `email:...`, etc.) can't resolve a real subscription
  * at call time, so they stay `member_free` regardless of the underlying
  * person's membership — upgrading those paths would need the caller to
- * have already mapped to a WorkOS id and passed *that* here. DB errors
+ * have already mapped to a WorkOS id and passed *that* here. AAO team
+ * members (`aao-admin` governance group) return `aao_team`, which is
+ * uncapped at the cost-gate boundary but still recorded for spend
+ * observability. DB errors
  * fall back to `member_free` so a transient outage doesn't accidentally
- * grant the $25/day ceiling to unverified callers.
+ * grant the $25/day ceiling or uncapped staff access to unverified callers.
  *
  * The SQL predicate here (`subscription_status = 'active' AND
  * subscription_canceled_at IS NULL`) matches `MEMBER_FILTER` in
@@ -342,17 +355,35 @@ export async function resolveUserTierFromDb(userId: string | null | undefined): 
   if (cached && cached.expiresAt > now) return cached.tier;
 
   try {
-    const { rows } = await query<{ exists: 1 }>(
-      `SELECT 1 AS exists
-         FROM organization_memberships om
-         JOIN organizations o ON o.workos_organization_id = om.workos_organization_id
-        WHERE om.workos_user_id = $1
-          AND o.subscription_status = 'active'
-          AND o.subscription_canceled_at IS NULL
-        LIMIT 1`,
+    const { rows } = await query<{
+      is_aao_team: boolean;
+      has_active_subscription: boolean;
+    }>(
+      `SELECT
+          EXISTS (
+            SELECT 1
+              FROM working_groups wg
+              JOIN working_group_memberships wgm ON wgm.working_group_id = wg.id
+             WHERE wg.slug = 'aao-admin'
+               AND wg.status = 'active'
+               AND wgm.workos_user_id = $1
+               AND wgm.status = 'active'
+          ) AS is_aao_team,
+          EXISTS (
+            SELECT 1
+              FROM organization_memberships om
+              JOIN organizations o ON o.workos_organization_id = om.workos_organization_id
+             WHERE om.workos_user_id = $1
+               AND o.subscription_status = 'active'
+               AND o.subscription_canceled_at IS NULL
+          ) AS has_active_subscription`,
       [userId],
     );
-    const tier: UserTier = rows.length > 0 ? 'member_paid' : 'member_free';
+    const row = rows[0];
+    const tier = resolveUserTier({
+      isAAOTeam: row?.is_aao_team === true,
+      hasActiveSubscription: row?.has_active_subscription === true,
+    });
     writeCachedTier(userId, tier);
     return tier;
   } catch (err) {

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -867,8 +867,9 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
 
       // Cost-cap scope (#2790 / #2945 f/u). Authenticated callers key
       // off the WorkOS user ID and resolve their tier from
-      // subscription status — paying members land on member_paid
-      // ($25/day), free accounts on member_free ($5). Anonymous
+      // AAO team/admin + subscription status — AAO team users are
+      // uncapped, paying members land on member_paid ($25/day), free
+      // accounts on member_free ($5). Anonymous
       // callers key off a hashed IP; the client-generated
       // `externalId` alone was a bypass vector (an attacker could
       // rotate it to get a fresh budget per request). The per-IP 50

--- a/server/src/routes/admin/addie-costs-helpers.ts
+++ b/server/src/routes/admin/addie-costs-helpers.ts
@@ -8,6 +8,7 @@
 const MICROS_PER_DOLLAR = 1_000_000;
 
 export type Namespace = 'email' | 'slack' | 'mcp' | 'tavus' | 'anon' | 'workos' | 'unknown';
+export type DisplayTier = 'anonymous' | 'member_free' | 'member_paid' | 'aao_team';
 
 /**
  * Fallback tier inference when we can't join to organizations (every
@@ -15,7 +16,7 @@ export type Namespace = 'email' | 'slack' | 'mcp' | 'tavus' | 'anon' | 'workos' 
  * tightest cap; slack (which *could* be a real member but wasn't mapped
  * at call time) gets member_free.
  */
-export const NAMESPACE_FALLBACK_TIER: Record<Namespace, 'anonymous' | 'member_free' | 'member_paid'> = {
+export const NAMESPACE_FALLBACK_TIER: Record<Namespace, Exclude<DisplayTier, 'aao_team'>> = {
   email: 'anonymous',
   mcp: 'anonymous',
   tavus: 'anonymous',
@@ -36,7 +37,9 @@ export const NAMESPACE_FALLBACK_TIER: Record<Namespace, 'anonymous' | 'member_fr
 export function inferDisplayTier(
   namespace: Namespace,
   hasActiveSubscription: boolean | null,
-): 'anonymous' | 'member_free' | 'member_paid' {
+  isAAOTeam: boolean | null = null,
+): DisplayTier {
+  if (isAAOTeam === true) return 'aao_team';
   if (hasActiveSubscription === true) return 'member_paid';
   return NAMESPACE_FALLBACK_TIER[namespace];
 }
@@ -55,6 +58,16 @@ export function classifyScopeKey(key: string): Namespace {
   if (key.startsWith('anon:')) return 'anon';
   if (key.startsWith('user_')) return 'workos';
   return 'unknown';
+}
+
+/**
+ * Validate scope keys accepted by the admin detail/reset endpoints.
+ * SQL parameterization is the real injection defense; this keeps
+ * control characters and whitespace out of logs and audit trails while
+ * allowing IdP-shaped subjects inside `mcp:<sub>` keys.
+ */
+export function isValidScopeKey(scopeKey: string): boolean {
+  return scopeKey.length > 0 && scopeKey.length <= 256 && /^[\x21-\x7E]+$/.test(scopeKey);
 }
 
 export function microsToUsd(micros: number): number {

--- a/server/src/routes/admin/addie-costs.ts
+++ b/server/src/routes/admin/addie-costs.ts
@@ -20,7 +20,8 @@
  * IDs we join through `organization_memberships` + `organizations` so
  * active-subscription members show `member_paid`; for everyone else we
  * fall back to the namespace-level inference (email/mcp/tavus/anon →
- * anonymous, slack/workos → member_free).
+ * anonymous, slack/workos → member_free). WorkOS users in the
+ * `aao-admin` governance group show `aao_team` and are uncapped.
  */
 
 import { Router } from 'express';
@@ -30,6 +31,7 @@ import { getPool } from '../../db/client.js';
 import { DAILY_BUDGET_USD } from '../../addie/claude-cost-tracker.js';
 import {
   inferDisplayTier,
+  isValidScopeKey,
   microsToUsd,
   NAMESPACE_FALLBACK_TIER,
   type Namespace,
@@ -176,6 +178,7 @@ export function setupAddieCostRoutes(apiRouter: Router): void {
         member_email: string | null;
         org_name: string | null;
         org_has_active_subscription: boolean | null;
+        is_aao_team: boolean | null;
       }>(
         `WITH scope_totals AS (
            SELECT
@@ -203,7 +206,19 @@ export function setupAddieCostRoutes(apiRouter: Router): void {
            u.last_name  AS member_last_name,
            u.email      AS member_email,
            best_org.name AS org_name,
-           best_org.has_active_subscription AS org_has_active_subscription
+           best_org.has_active_subscription AS org_has_active_subscription,
+           (
+             ${namespaceCaseSql('t.scope_key')} = 'workos'
+             AND EXISTS (
+               SELECT 1
+                 FROM working_groups wg
+                 JOIN working_group_memberships wgm ON wgm.working_group_id = wg.id
+                WHERE wg.slug = 'aao-admin'
+                  AND wg.status = 'active'
+                  AND wgm.workos_user_id = t.scope_key
+                  AND wgm.status = 'active'
+             )
+           ) AS is_aao_team
          FROM scope_totals t
          LEFT JOIN users u ON u.workos_user_id = t.scope_key
          LEFT JOIN LATERAL (
@@ -224,10 +239,10 @@ export function setupAddieCostRoutes(apiRouter: Router): void {
 
       const leaderboard = rows.map(row => {
         const namespace = row.namespace;
-        const inferredTier = inferDisplayTier(namespace, row.org_has_active_subscription);
-        const capUsd = DAILY_BUDGET_USD[inferredTier];
+        const inferredTier = inferDisplayTier(namespace, row.org_has_active_subscription, row.is_aao_team);
+        const capUsd = inferredTier === 'aao_team' ? null : DAILY_BUDGET_USD[inferredTier];
         const spentUsd = microsToUsd(Number(row.total_micros));
-        const percentOfCap = capUsd > 0 ? Math.round((spentUsd / capUsd) * 1000) / 10 : 0;
+        const percentOfCap = capUsd && capUsd > 0 ? Math.round((spentUsd / capUsd) * 1000) / 10 : null;
 
         const displayName = [row.member_first_name, row.member_last_name].filter(Boolean).join(' ').trim() || null;
 
@@ -271,7 +286,7 @@ export function setupAddieCostRoutes(apiRouter: Router): void {
       // traffic. SQL injection is already prevented by $N
       // parameterization; this regex is belt-and-suspenders to keep
       // control bytes out of logs.
-      if (!scopeKey || scopeKey.length > 256 || !/^[\x21-\x7E]+$/.test(scopeKey)) {
+      if (!isValidScopeKey(scopeKey)) {
         return res.status(400).json({ error: 'Invalid scope key' });
       }
       const pool = getPool();
@@ -320,6 +335,51 @@ export function setupAddieCostRoutes(apiRouter: Router): void {
     } catch (err) {
       logger.error({ err, scopeKey: req.params.scopeKey }, 'Failed to load scope events');
       res.status(500).json({ error: 'Failed to load events' });
+    }
+  });
+
+  // POST /api/admin/addie-costs/scope/:scopeKey/reset — clear the
+  // rolling 24h cap window for one caller. This is intentionally a
+  // narrow operational escape hatch: it restores access without making
+  // a human permanently uncapped and without deleting older 7-day
+  // observability rows.
+  apiRouter.post('/addie-costs/scope/:scopeKey/reset', ...requireGlobalAdmin, async (req, res) => {
+    try {
+      const scopeKey = req.params.scopeKey;
+      if (!isValidScopeKey(scopeKey)) {
+        return res.status(400).json({ error: 'Invalid scope key' });
+      }
+
+      const pool = getPool();
+      const { rows } = await pool.query<{ cost_usd_micros: string }>(
+        `DELETE FROM addie_token_cost_events
+         WHERE scope_key = $1
+           AND recorded_at > NOW() - INTERVAL '24 hours'
+         RETURNING cost_usd_micros::text`,
+        [scopeKey],
+      );
+      const deletedMicros = rows.reduce((sum, row) => sum + Number(row.cost_usd_micros), 0);
+
+      logger.info(
+        {
+          event: 'admin_addie_cost_scope_reset',
+          scopeKey,
+          deletedEvents: rows.length,
+          deletedCostUsd: microsToUsd(deletedMicros),
+          adminUserId: (req as unknown as { user?: { id?: string } }).user?.id,
+        },
+        'Admin reset Addie cost scope',
+      );
+
+      res.json({
+        scope_key: scopeKey,
+        window: '24h',
+        deleted_events: rows.length,
+        deleted_cost_usd: microsToUsd(deletedMicros),
+      });
+    } catch (err) {
+      logger.error({ err, scopeKey: req.params.scopeKey }, 'Failed to reset Addie cost scope');
+      res.status(500).json({ error: 'Failed to reset scope' });
     }
   });
 }

--- a/server/tests/unit/admin-addie-costs.test.ts
+++ b/server/tests/unit/admin-addie-costs.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   classifyScopeKey,
   inferDisplayTier,
+  isValidScopeKey,
   microsToUsd,
   NAMESPACE_FALLBACK_TIER,
 } from '../../src/routes/admin/addie-costs-helpers.js';
@@ -53,6 +54,11 @@ describe('classifyScopeKey', () => {
 });
 
 describe('inferDisplayTier', () => {
+  it('promotes to aao_team when the user is in the AAO admin team', () => {
+    expect(inferDisplayTier('workos', false, true)).toBe('aao_team');
+    expect(inferDisplayTier('workos', true, true)).toBe('aao_team');
+  });
+
   it('promotes to member_paid when the joined org has an active subscription', () => {
     expect(inferDisplayTier('workos', true)).toBe('member_paid');
     // Subscription status wins over namespace fallback even for a
@@ -105,5 +111,21 @@ describe('microsToUsd', () => {
     // Summing a day's spend for a leaderboard row — 250,000 micros ×
     // 1000 events = 250M micros = $250. Must not drift to $249.9999.
     expect(microsToUsd(250_000_000)).toBe(250);
+  });
+});
+
+describe('isValidScopeKey', () => {
+  it('accepts printable scope keys used by cost namespaces', () => {
+    expect(isValidScopeKey('user_01H2ABC3DEF')).toBe(true);
+    expect(isValidScopeKey('slack:U12345')).toBe(true);
+    expect(isValidScopeKey('mcp:oauth/user+001@example.com')).toBe(true);
+    expect(isValidScopeKey('email:abc123def4567890')).toBe(true);
+  });
+
+  it('rejects empty, oversized, whitespace, and control-byte keys', () => {
+    expect(isValidScopeKey('')).toBe(false);
+    expect(isValidScopeKey('user abc')).toBe(false);
+    expect(isValidScopeKey('user_abc\nnext')).toBe(false);
+    expect(isValidScopeKey('x'.repeat(257))).toBe(false);
   });
 });

--- a/server/tests/unit/claude-cost-tier-resolution.test.ts
+++ b/server/tests/unit/claude-cost-tier-resolution.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 /**
  * #2945 follow-up — `resolveUserTierFromDb` does a single-row
- * probe to the DB to decide whether a bare WorkOS id should get the
- * `member_paid` ($25/day) ceiling or stay at `member_free` ($5). The
- * DB query is mocked per test so we can drive each branch without a
- * Postgres connection.
+ * probe to the DB to decide whether a bare WorkOS id should be
+ * uncapped as `aao_team`, get the `member_paid` ($25/day) ceiling,
+ * or stay at `member_free` ($5). The DB query is mocked per test so
+ * we can drive each branch without a Postgres connection.
  */
 
 const queryMock = vi.fn();
@@ -51,7 +51,7 @@ describe('resolveUserTierFromDb', () => {
   });
 
   it('returns member_paid when the WorkOS user has an active, non-canceled subscription', async () => {
-    queryMock.mockResolvedValueOnce({ rows: [{ exists: 1 }] });
+    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: false, has_active_subscription: true }] });
     const tier = await resolveUserTierFromDb('user_01H2ABC');
     expect(tier).toBe('member_paid');
     expect(queryMock).toHaveBeenCalledOnce();
@@ -63,8 +63,23 @@ describe('resolveUserTierFromDb', () => {
     expect(sql).toContain('subscription_canceled_at IS NULL');
   });
 
-  it('returns member_free when the WorkOS user has no active subscription (empty rows)', async () => {
-    queryMock.mockResolvedValueOnce({ rows: [] });
+  it('returns aao_team when the WorkOS user belongs to the AAO admin team', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: true, has_active_subscription: false }] });
+    const tier = await resolveUserTierFromDb('user_aao_staff');
+    expect(tier).toBe('aao_team');
+    expect(queryMock).toHaveBeenCalledOnce();
+    const sql = queryMock.mock.calls[0][0] as string;
+    expect(sql).toContain("wg.slug = 'aao-admin'");
+    expect(sql).toContain("wgm.status = 'active'");
+  });
+
+  it('prefers aao_team over member_paid when both signals are true', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: true, has_active_subscription: true }] });
+    expect(await resolveUserTierFromDb('user_aao_paid')).toBe('aao_team');
+  });
+
+  it('returns member_free when the WorkOS user has no active subscription or AAO team membership', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: false, has_active_subscription: false }] });
     const tier = await resolveUserTierFromDb('user_01H2ABC');
     expect(tier).toBe('member_free');
   });
@@ -82,7 +97,7 @@ describe('resolveUserTierFromDb', () => {
   it('memoizes results so repeated probes for the same user hit the DB once', async () => {
     // 60s in-process cache. A chat burst should not produce N DB
     // probes for the same user — one probe, cached tier, replayed.
-    queryMock.mockResolvedValueOnce({ rows: [{ exists: 1 }] });
+    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: false, has_active_subscription: true }] });
     expect(await resolveUserTierFromDb('user_01H2ABC')).toBe('member_paid');
     expect(await resolveUserTierFromDb('user_01H2ABC')).toBe('member_paid');
     expect(await resolveUserTierFromDb('user_01H2ABC')).toBe('member_paid');
@@ -94,15 +109,15 @@ describe('resolveUserTierFromDb', () => {
     // member_paid for a full 60s. The first call fails → returns
     // member_free without caching; the second call retries.
     queryMock.mockRejectedValueOnce(new Error('Connection refused'));
-    queryMock.mockResolvedValueOnce({ rows: [{ exists: 1 }] });
+    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: false, has_active_subscription: true }] });
     expect(await resolveUserTierFromDb('user_01H2ABC')).toBe('member_free');
     expect(await resolveUserTierFromDb('user_01H2ABC')).toBe('member_paid');
     expect(queryMock).toHaveBeenCalledTimes(2);
   });
 
   it('memoizes per-user, not globally — different users get independent probes', async () => {
-    queryMock.mockResolvedValueOnce({ rows: [{ exists: 1 }] });
-    queryMock.mockResolvedValueOnce({ rows: [] });
+    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: false, has_active_subscription: true }] });
+    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: false, has_active_subscription: false }] });
     expect(await resolveUserTierFromDb('user_alice')).toBe('member_paid');
     expect(await resolveUserTierFromDb('user_bob')).toBe('member_free');
     expect(queryMock).toHaveBeenCalledTimes(2);
@@ -115,7 +130,7 @@ describe('resolveUserTierFromDb', () => {
 
 describe('buildSlackCostScope', () => {
   it('prefers the mapped WorkOS user id when memberContext carries one', async () => {
-    queryMock.mockResolvedValueOnce({ rows: [{ exists: 1 }] });
+    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: false, has_active_subscription: true }] });
     const scope = await buildSlackCostScope(
       { workos_user: { workos_user_id: 'user_01H2ABC' } },
       'U_slack',

--- a/server/tests/unit/claude-cost-tracker.test.ts
+++ b/server/tests/unit/claude-cost-tracker.test.ts
@@ -70,6 +70,13 @@ describe('checkCostCap', () => {
     expect((await checkCostCap('u-tier', 'member_paid')).ok).toBe(true);
   });
 
+  it('does not cap AAO team usage', async () => {
+    await recordCost('u-aao-team', 'claude-opus-4-7', { input_tokens: 10_000_000, output_tokens: 10_000_000 });
+    const result = await checkCostCap('u-aao-team', 'aao_team');
+    expect(result.ok).toBe(true);
+    expect(result.tier).toBe('aao_team');
+  });
+
   it('aggregates multiple recorded calls into the running total', async () => {
     // 10× small Haiku calls (10 * 100 micros = 1000 micros = $0.001)
     for (let i = 0; i < 10; i++) {
@@ -138,6 +145,11 @@ describe('resolveUserTier', () => {
 
   it('returns member_paid for active subscribers', () => {
     expect(resolveUserTier({ hasActiveSubscription: true })).toBe('member_paid');
+  });
+
+  it('returns aao_team for AAO staff/admin users regardless of subscription status', () => {
+    expect(resolveUserTier({ isAAOTeam: true })).toBe('aao_team');
+    expect(resolveUserTier({ isAAOTeam: true, hasActiveSubscription: true })).toBe('aao_team');
   });
 
   it('returns member_free when authenticated but no subscription', () => {


### PR DESCRIPTION
## Summary

- Add `aao_team` as an uncapped Addie tier for active `aao-admin` working group members.
- Keep recording token cost events for uncapped users so admin cost reporting remains visible.
- Add an admin 24-hour scope reset endpoint and UI action for Addie cost scopes.

## Validation

- `npx vitest run server/tests/unit/claude-cost-tracker.test.ts server/tests/unit/claude-cost-tier-resolution.test.ts server/tests/unit/admin-addie-costs.test.ts server/tests/unit/claude-client-cost-gate.test.ts`
- precommit: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run typecheck`
- pre-push: version sync, changeset check, schema link convention, Mintlify broken-link check
