### PR TITLE
Uncap Addie usage for AAO org members

### DIFF
--- a/.changeset/addie-aao-org-uncapped.md
+++ b/.changeset/addie-aao-org-uncapped.md
@@ -1,0 +1,4 @@
+---
+---
+
+Addie now treats AgenticAdvertising.org organization members as part of the uncapped AAO team tier.

--- a/server/src/addie/claude-cost-tracker.ts
+++ b/server/src/addie/claude-cost-tracker.ts
@@ -71,9 +71,9 @@ const WINDOW_MS = 24 * 60 * 60 * 1000;
  * - `member_paid`: $25/day. Paying members get a generous ceiling
  *   that's still a real cap — a runaway automated session still
  *   trips it within an hour of sustained abuse.
- * - `aao_team`: uncapped. AAO staff/admin users are operating the
- *   service, not consuming member benefits, so they should not hit
- *   a self-service spend ceiling while doing support or admin work.
+ * - `aao_team`: uncapped. AAO staff/admin/team users are operating
+ *   the service, not consuming member benefits, so they should not
+ *   hit a self-service spend ceiling while doing support or admin work.
  */
 export const DAILY_BUDGET_USD = {
   anonymous: 3,
@@ -328,11 +328,11 @@ function writeCachedTier(userId: string, tier: UserTier): void {
  * at call time, so they stay `member_free` regardless of the underlying
  * person's membership — upgrading those paths would need the caller to
  * have already mapped to a WorkOS id and passed *that* here. AAO team
- * members (`aao-admin` governance group) return `aao_team`, which is
- * uncapped at the cost-gate boundary but still recorded for spend
- * observability. DB errors
- * fall back to `member_free` so a transient outage doesn't accidentally
- * grant the $25/day ceiling or uncapped staff access to unverified callers.
+ * members (`aao-admin` governance group or AgenticAdvertising.org org
+ * membership) return `aao_team`, which is uncapped at the cost-gate
+ * boundary but still recorded for spend observability. DB errors fall
+ * back to `member_free` so a transient outage doesn't accidentally grant
+ * the $25/day ceiling or uncapped staff access to unverified callers.
  *
  * The SQL predicate here (`subscription_status = 'active' AND
  * subscription_canceled_at IS NULL`) matches `MEMBER_FILTER` in
@@ -360,14 +360,23 @@ export async function resolveUserTierFromDb(userId: string | null | undefined): 
       has_active_subscription: boolean;
     }>(
       `SELECT
-          EXISTS (
-            SELECT 1
-              FROM working_groups wg
-              JOIN working_group_memberships wgm ON wgm.working_group_id = wg.id
-             WHERE wg.slug = 'aao-admin'
-               AND wg.status = 'active'
-               AND wgm.workos_user_id = $1
-               AND wgm.status = 'active'
+          (
+            EXISTS (
+              SELECT 1
+                FROM working_groups wg
+                JOIN working_group_memberships wgm ON wgm.working_group_id = wg.id
+               WHERE wg.slug = 'aao-admin'
+                 AND wg.status = 'active'
+                 AND wgm.workos_user_id = $1
+                 AND wgm.status = 'active'
+            )
+            OR EXISTS (
+              SELECT 1
+                FROM organization_memberships om
+                JOIN organizations o ON o.workos_organization_id = om.workos_organization_id
+               WHERE om.workos_user_id = $1
+                 AND LOWER(o.name) = 'agenticadvertising.org'
+            )
           ) AS is_aao_team,
           EXISTS (
             SELECT 1

--- a/server/src/routes/admin/addie-costs.ts
+++ b/server/src/routes/admin/addie-costs.ts
@@ -21,7 +21,8 @@
  * active-subscription members show `member_paid`; for everyone else we
  * fall back to the namespace-level inference (email/mcp/tavus/anon →
  * anonymous, slack/workos → member_free). WorkOS users in the
- * `aao-admin` governance group show `aao_team` and are uncapped.
+ * `aao-admin` governance group or AgenticAdvertising.org org show
+ * `aao_team` and are uncapped.
  */
 
 import { Router } from 'express';
@@ -209,14 +210,23 @@ export function setupAddieCostRoutes(apiRouter: Router): void {
            best_org.has_active_subscription AS org_has_active_subscription,
            (
              ${namespaceCaseSql('t.scope_key')} = 'workos'
-             AND EXISTS (
-               SELECT 1
-                 FROM working_groups wg
-                 JOIN working_group_memberships wgm ON wgm.working_group_id = wg.id
-                WHERE wg.slug = 'aao-admin'
-                  AND wg.status = 'active'
-                  AND wgm.workos_user_id = t.scope_key
-                  AND wgm.status = 'active'
+             AND (
+               EXISTS (
+                 SELECT 1
+                   FROM working_groups wg
+                   JOIN working_group_memberships wgm ON wgm.working_group_id = wg.id
+                  WHERE wg.slug = 'aao-admin'
+                    AND wg.status = 'active'
+                    AND wgm.workos_user_id = t.scope_key
+                    AND wgm.status = 'active'
+               )
+               OR EXISTS (
+                 SELECT 1
+                   FROM organization_memberships om
+                   JOIN organizations o ON o.workos_organization_id = om.workos_organization_id
+                  WHERE om.workos_user_id = t.scope_key
+                    AND LOWER(o.name) = 'agenticadvertising.org'
+               )
              )
            ) AS is_aao_team
          FROM scope_totals t

--- a/server/tests/unit/claude-cost-tier-resolution.test.ts
+++ b/server/tests/unit/claude-cost-tier-resolution.test.ts
@@ -63,7 +63,7 @@ describe('resolveUserTierFromDb', () => {
     expect(sql).toContain('subscription_canceled_at IS NULL');
   });
 
-  it('returns aao_team when the WorkOS user belongs to the AAO admin team', async () => {
+  it('returns aao_team when the WorkOS user belongs to the AAO admin team or org', async () => {
     queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: true, has_active_subscription: false }] });
     const tier = await resolveUserTierFromDb('user_aao_staff');
     expect(tier).toBe('aao_team');
@@ -71,6 +71,7 @@ describe('resolveUserTierFromDb', () => {
     const sql = queryMock.mock.calls[0][0] as string;
     expect(sql).toContain("wg.slug = 'aao-admin'");
     expect(sql).toContain("wgm.status = 'active'");
+    expect(sql).toContain("LOWER(o.name) = 'agenticadvertising.org'");
   });
 
   it('prefers aao_team over member_paid when both signals are true', async () => {


### PR DESCRIPTION
## Summary

- Broaden Addie's uncapped `aao_team` tier to include users with AgenticAdvertising.org organization membership.
- Keep the admin Addie cost leaderboard aligned with the runtime tier predicate.

## Validation

- `npx vitest run server/tests/unit/claude-cost-tier-resolution.test.ts server/tests/unit/claude-cost-tracker.test.ts server/tests/unit/admin-addie-costs.test.ts`
- precommit: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run typecheck`
- pre-push: version sync, changeset check, schema link convention, Mintlify broken-link check
