### PR TITLE
Clarify broadcast radio identifiers

### DIFF
--- a/.changeset/broadcast-radio-creative-identifiers.md
+++ b/.changeset/broadcast-radio-creative-identifiers.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": minor
+---
+
+Add `idcrea` as a supported creative identifier type for French ARPP.PUB workflows.
+
+This also clarifies that `ad_id` is common for US television and accepted by some radio/audio workflows, rather than requiring all broadcast or audio workflows to use Ad-ID.

--- a/docs/creative/channels/audio.mdx
+++ b/docs/creative/channels/audio.mdx
@@ -14,8 +14,9 @@ Audio formats include:
 - **VAST Audio** - DAAST/VAST tags for programmatic audio
 - **With Companion Banners** - Audio + synchronized display companion
 - **Podcast Insertion** - Dynamic ad insertion (DAI) for podcasts
+- **Broadcast Radio Spots** - Scheduled spot files identified by traffic or clearance IDs and measured through audience currency rather than pixels
 
-Audio ads are typically non-skippable and play during natural content breaks.
+Audio ads are typically non-skippable and play during natural content breaks. Streaming and podcast inventory may support impression trackers, completion events, and companion clickthroughs. Broadcast radio does not have a renderer that can fire pixels; buyers reconcile it through spot logs, station affidavits, and audience measurement sources declared on the product or package.
 
 ## Standard Audio Formats
 
@@ -102,6 +103,68 @@ Audio ads are typically non-skippable and play during natural content breaks.
         "format": ["MP3", "M4A"],
         "bitrate_min": "128kbps",
         "max_file_size_mb": 10
+      }
+    }
+  ]
+}
+```
+
+### Broadcast Radio Spot (30s)
+
+Broadcast radio uses the same canonical `audio_hosted` creative asset shape as streaming audio, narrowed to the `radio` channel. The spot is scheduled into a station or network log, and the creative is usually referenced by an Ad-ID or ISCI.
+
+The canonical product-format declaration is the preferred 3.1+ shape:
+
+```json
+{
+  "format_kind": "audio_hosted",
+  "format_option_id": "broadcast_radio_30s",
+  "display_name": "Broadcast radio :30 spot",
+  "applies_to_channels": ["radio"],
+  "params": {
+    "duration_ms_exact": 30000,
+    "audio_codecs": ["mp3", "wav"],
+    "audio_sample_rates": [44100, 48000],
+    "audio_channels": ["mono", "stereo"],
+    "loudness_lufs": -16,
+    "loudness_tolerance_db": 2,
+    "true_peak_dbfs": -2,
+    "asset_source": "buyer_uploaded",
+    "composition_model": "deterministic",
+    "slots": [
+      {
+        "asset_group_id": "audio_main",
+        "asset_type": "audio",
+        "required": true
+      }
+    ]
+  }
+}
+```
+
+Legacy named-format catalogs can still expose the equivalent shape through `format_id`:
+
+```json
+{
+  "format_id": {
+    "agent_url": "https://creative.adcontextprotocol.org",
+    "id": "broadcast_radio_30s"
+  },
+  "type": "audio",
+  "assets": [
+    {
+      "asset_id": "audio_file",
+      "asset_type": "audio",
+      "asset_role": "hero_audio",
+      "required": true,
+      "requirements": {
+        "duration": "30s",
+        "format": ["MP3", "WAV"],
+        "sample_rates": [44100, 48000],
+        "channels": ["stereo", "mono"],
+        "loudness_lufs": -16,
+        "loudness_tolerance_db": 2,
+        "true_peak_dbfs": -2
       }
     }
   ]
@@ -236,6 +299,42 @@ Multi-segment audio assembled dynamically:
 }
 ```
 
+### Broadcast Radio Manifest
+
+Use the protocol `creative_id` for the seller/buyer library object, and use the existing `industry_identifiers` field for the traffic or clearance identifier that the radio workflow expects. Ad-ID is appropriate when that is the identifier the buyer, agency, or broadcaster uses. Broadcast radio also still sees ISCI and Ad-ID/ISCI labels used interchangeably, and non-US markets may require other identifiers such as Clearcast clock numbers or IDcrea.
+
+For canonical 3.1+ manifests, slot keys come from the `audio_hosted` declaration:
+
+```json
+{
+  "creative_id": "nova_spring_radio_30s",
+  "name": "Nova Spring Campaign :30 Radio",
+  "format_kind": "audio_hosted",
+  "format_option_ref": {
+    "scope": "product",
+    "format_option_id": "broadcast_radio_30s"
+  },
+  "industry_identifiers": [
+    { "type": "isci", "value": "NOVA123430" }
+  ],
+  "assets": {
+    "audio_main": {
+      "asset_type": "audio",
+      "url": "https://cdn.nova-brands.example/radio/spring_30s.wav",
+      "duration_ms": 30000,
+      "container_format": "wav",
+      "codec": "pcm",
+      "sampling_rate_hz": 48000,
+      "channels": "stereo",
+      "loudness_lufs": -16,
+      "true_peak_dbfs": -2
+    }
+  }
+}
+```
+
+When the same source creative has different cuts (:15, :30, :60), assign the traffic identifier at the manifest level so each cut can carry its own Ad-ID, ISCI, clock number, or IDcrea. `creative-identifier-type` is intentionally limited to shared industry or market-standard schemes. If an adopter needs another scheme, add it to the enum by PR with evidence that it is a real shared workflow identifier rather than a seller-local traffic code.
+
 ## Audio-Specific Macros
 
 In addition to [universal macros](/docs/creative/universal-macros), audio formats support:
@@ -270,6 +369,11 @@ In addition to [universal macros](/docs/creative/universal-macros), audio format
 - **Baked-in**: Permanently encoded in installment
 - **Dynamic insertion (SSAI)**: Personalized, with targeting and reporting
 
+### Broadcast Radio
+- Station or network logs provide spot-level proof that the creative was scheduled or aired
+- Station affidavits may be used for invoice reconciliation
+- Audience size, GRPs, reach, and frequency come from the product's measurement source rather than creative-embedded tracking
+
 ### Companion Banners
 Appear alongside audio on screen-enabled devices:
 - Mobile apps, desktop players, smart speakers with displays
@@ -282,14 +386,30 @@ Appear alongside audio on screen-enabled devices:
 - **Bitrate**: Minimum 128kbps, recommended 192kbps
 - **Sample Rate**: 44.1kHz or 48kHz
 - **Channels**: Stereo or mono
+- **Loudness**: A target around -16 LUFS/LKFS with +/- 2 dB tolerance is a practical cross-audio recommendation; sellers may normalize final playout for their platform or transmitter chain
 
 ### Durations
 - **15s**: Quick message, high frequency
 - **30s**: Standard, most common
 - **60s**: Story-driven, common in podcasts
 
+## Measurement and Reporting
+
+Audio measurement depends on the distribution context:
+
+| Context | Typical evidence | Typical metrics |
+|---|---|---|
+| Streaming audio / SSAI | Ad-server logs, DAAST/VAST tracking, completion events | impressions, starts/views, completed_views, completion_rate, quartile_data |
+| Podcast DAI | Download or insertion logs, platform reporting windows | downloads, impressions, reach, frequency, completed_views where available |
+| Broadcast radio | Station affidavits, playout logs, audience measurement currency | plays, impressions or measured impressions, grps, reach, frequency |
+
+For broadcast radio, the protocol should receive the reliable audience number and its basis, not a made-up digital completion surrogate. Sellers can expose forecasted audience through `DeliveryForecast` with `measurement_source`, `demographic_system`, `demographic`, `reach_unit`, and metrics such as `grps`, `reach`, `frequency`, `impressions`, or `measured_impressions`. After the buy runs, delivery reports use the standard delivery metrics (`plays`, `impressions`, `grps`, `reach`, `frequency`) plus `vendor_metric_values` when the authoritative audience source provides a named metric outside the standard delivery-metrics list.
+
+If billing depends on a third-party or audience-currency count, set `measurement_terms.billing_measurement.vendor` and, when needed, `measurement_window` or a vendor metric commitment on the package. Station affidavits and playout logs prove that scheduled spots aired; audience measurement sources turn those plays into the audience-size number used for planning, guarantees, and reconciliation.
+
 ## Related Documentation
 
 - [Universal Macros](/docs/creative/universal-macros) - Complete macro reference
 - [Creative Manifests](/docs/creative/creative-manifests) - Manifest structure and validation
 - [Asset Types](/docs/creative/asset-types) - Audio asset specifications
+- [Product Discovery](/docs/media-buy/product-discovery/media-products#broadcast-audio-spot-plan) - Broadcast audio spot-plan forecasts

--- a/docs/creative/channels/broadcast.mdx
+++ b/docs/creative/channels/broadcast.mdx
@@ -1,6 +1,6 @@
 ---
 title: Broadcast TV
-description: "Broadcast TV ad formats in AdCP define spot file delivery, Ad-ID integration, and measurement maturation windows for linear television."
+description: "Broadcast TV ad formats in AdCP define spot file delivery, creative identifier integration, and measurement maturation windows for linear television."
 "og:title": "AdCP — Broadcast TV"
 ---
 
@@ -19,7 +19,7 @@ The protocol-level operations (`list_creative_formats`, `build_creative`, `sync_
 | **Tracking** | No impression pixels | Pixel fires, VAST tracking events |
 | **Clickthrough** | None (no interaction) | Clickthrough URL, QR codes |
 | **Measurement** | Panel/STB data, arrives days later | Server logs, real-time or near-real-time |
-| **Creative ID** | Ad-ID (industry standard) | Protocol creative_id |
+| **Creative ID** | Industry identifier (usually Ad-ID, with market-specific alternatives) | Protocol creative_id |
 | **Financial ref** | Agency Estimate Number | PO number |
 
 ## Format characteristics
@@ -29,7 +29,7 @@ Broadcast spots are:
 - **Fixed durations** — :15, :30, and :60 are standard
 - **No tracker assets** — No impression pixels, no VAST, no JavaScript
 - **No interactive elements** — No clickthrough, no companion, no overlay
-- **Identified by Ad-ID** — Industry-standard creative identifier that ties the spot to rotation instructions
+- **Identified by traffic/clearance ID** — Ad-ID, ISCI, Clearcast clock number, IDcrea, or another market-specific creative identifier that ties the spot to rotation instructions
 
 ## Standard broadcast formats
 
@@ -107,15 +107,17 @@ Whether a creative format supports third-party tracking is determined by whether
 
 A buyer agent that requires third-party measurement (DoubleVerify viewability, IAS brand safety) should check the format's assets before assigning creatives. If no tracker slot exists, those measurement vendors cannot instrument the creative. Measurement for broadcast comes from panel and set-top box data through the measurement vendor declared in `billing_measurement`, not from creative-level pixels.
 
-## Ad-ID integration
+## Creative identifier integration
 
-[Ad-ID](https://www.ad-id.org/) is the industry standard for identifying advertising assets. It replaced ISCI codes and is required for broadcast buying. An Ad-ID is a 12-character alphanumeric code (4-character company prefix + 8-character unique identifier).
+AdCP separates its protocol `creative_id` from the creative identifier used by traffic, clearance, and broadcast operations. Put Ad-ID, ISCI, Clearcast clock number, IDcrea, or another market-specific code in `industry_identifiers`.
 
-Ad-IDs serve two purposes in broadcast:
+Ad-ID is common for US television workflows and is often represented as a 12-character alphanumeric code (4-character company prefix + 8-character unique identifier). Other markets and legacy traffic systems use different identifiers. The protocol should preserve the identifier the workflow already uses rather than forcing every broadcaster or agency into Ad-ID.
+
+Industry identifiers serve two purposes in broadcast:
 1. **Asset identification** — uniquely identifies the spot across all systems
-2. **Rotation instructions** — when a buy has multiple creatives, the Ad-ID tells the station which spot to run in which window
+2. **Rotation instructions** — when a buy has multiple creatives, the identifier tells the station which spot to run in which window
 
-### Creative with Ad-ID
+### Creative with industry identifier
 
 ```json
 {
@@ -152,15 +154,18 @@ Ad-IDs serve two purposes in broadcast:
 }
 ```
 
-When the same source creative has different cuts (:15 and :30), each cut gets its own Ad-ID. Use `industry_identifiers` on the manifest level to assign distinct Ad-IDs per format version.
+When the same source creative has different cuts (:15 and :30), each cut gets its own traffic identifier. Use `industry_identifiers` on the manifest level to assign distinct Ad-IDs, ISCI codes, clock numbers, or IDcrea values per format version.
 
 ### Supported identifier types
 
 | Type | Description |
 |---|---|
-| `ad_id` | Ad-ID registry code (US/international standard) |
-| `isci` | Legacy ISCI code (older traffic systems) |
+| `ad_id` | Ad-ID registry code, common in US television and accepted by some audio workflows |
+| `isci` | Industry Standard Coding Identification, still used in legacy traffic systems and broadcast radio workflows |
 | `clearcast_clock` | UK Clearcast clock number |
+| `idcrea` | France ARPP.PUB IDcrea identifier for post-transition creative IDs |
+
+If a broadcast workflow depends on another shared identifier scheme, add it to `creative-identifier-type` by PR with evidence that the scheme is used across multiple participants. Do not use `industry_identifiers` for seller-local traffic codes.
 
 ## Agency Estimate Number
 

--- a/docs/learning/specialist/creative.mdx
+++ b/docs/learning/specialist/creative.mdx
@@ -36,7 +36,7 @@ The following `specialisms` fall under the `creative` domain. Each has its own c
 - Use `preview_creative` in all three request modes — single, batch (5–10× faster for many creatives), and variant (retrieve historical renders from `get_creative_delivery`) — and choose `output_format: "html"` when bypassing the iframe speeds rendering
 - Understand creative agent pricing: the `pricing_options[]` array on discovery responses, how `pricing_option_id` flows through `build_creative` and `report_usage`, and why CPM ad servers show zero `vendor_cost` at build time while transformation agents do not
 - Reason about tracker-slot presence — a format supports third-party measurement only if its `assets` array declares a tracker slot (e.g., `impression_tracker`). Broadcast formats intentionally omit tracker slots; measurement comes from panel and STB data via `billing_measurement`
-- Attach `industry_identifiers[]` to broadcast manifests with the correct `creative-identifier-type` (`ad_id`, `isci`, `clearcast_clock`), and give each cut (`:15` vs `:30`) its own Ad-ID
+- Attach `industry_identifiers[]` to broadcast manifests with the correct `creative-identifier-type` (`ad_id`, `isci`, `clearcast_clock`, or `idcrea`), and give each cut (`:15` vs `:30`) its own traffic identifier
 - Reason about format edge cases, accessibility, and provenance
 
 ## Prerequisite reading
@@ -83,7 +83,7 @@ The following `specialisms` fall under the `creative` domain. Each has its own c
     Channel-specific specs for video, display, audio, DOOH, and carousels.
   </Card>
   <Card title="Broadcast TV" icon="clapperboard" href="/docs/creative/channels/broadcast">
-    Broadcast formats, `industry_identifiers[]` (`ad_id`, `isci`, `clearcast_clock`), Ad-ID integration, and why broadcast formats omit tracker slots.
+    Broadcast formats, `industry_identifiers[]` (`ad_id`, `isci`, `clearcast_clock`, `idcrea`), creative identifier integration, and why broadcast formats omit tracker slots.
   </Card>
   <Card title="Generative creative" icon="wand-magic-sparkles" href="/docs/creative/generative-creative">
     AI-generated creative workflows and best practices.
@@ -196,7 +196,7 @@ Vendors often offer multiple pricing options per creative — volume/commitment 
 9. **Compliance** — Configure provenance metadata and disclosure requirements for AI-generated creatives
 10. **Preview modes** — Run `preview_creative` as `request_type: "single"`, then `"batch"` (submit 5 creatives in one call and measure the speedup), then `"variant"` against a prior `get_creative_delivery` result. Compare `output_format: "url"` vs `"html"` for rendering latency.
 11. **Tracker-slot audit** — For each sandbox format, inspect the `assets` array and determine whether it supports third-party measurement. Explain why assigning a DoubleVerify pixel to a broadcast spot won't work, and which `billing_measurement` vendor would instead.
-12. **Broadcast identifiers** — Build a broadcast manifest with distinct `industry_identifiers[]` for `:15` and `:30` cuts of the same spot. Verify the `creative-identifier-type` values and explain why each cut needs its own Ad-ID.
+12. **Broadcast identifiers** — Build a broadcast manifest with distinct `industry_identifiers[]` for `:15` and `:30` cuts of the same spot. Verify the `creative-identifier-type` values and explain why each cut needs its own traffic identifier.
 
 ## Assessment
 

--- a/docs/reference/whats-new-in-v3.mdx
+++ b/docs/reference/whats-new-in-v3.mdx
@@ -29,7 +29,7 @@ AdCP 3.0 expands the protocol beyond media buying into brand identity, governanc
 | **Disclosure matching** | Position-only disclosure handling | Position + persistence-aware disclosure matching (`continuous`, `initial`, `flexible`) |
 | **Collections and installments** | No content programming model | `shows` on products with distribution IDs, installment lifecycle, break-based inventory |
 | **Planning ergonomics** | No `time_budget`, `preferred_delivery_types`, `exclusivity`, or per-package flights | `time_budget` + `incomplete`, `preferred_delivery_types`, `exclusivity`, optional `delivery_measurement`, and package-level `start_time` / `end_time` |
-| **Channel model** | 9 channels | 20 planning-oriented channels (including `sponsored_intelligence`) with broadcast TV support (Ad-ID, measurement windows, spot formats) |
+| **Channel model** | 9 channels | 20 planning-oriented channels (including `sponsored_intelligence`) with broadcast TV support (creative identifiers, measurement windows, spot formats) |
 | **Capability discovery** | Agent card extensions | Runtime `get_adcp_capabilities` task |
 | **Sandbox discovery** | Mixed capability locations | `require_operator_auth` for auth model, `account.sandbox` for sandbox support, sandbox in natural account references |
 | **Creative assignment** | Simple ID arrays | Weighted assignments with placement targeting |
@@ -363,14 +363,14 @@ New targeting overlay fields `collection_list` and `collection_list_exclude` ena
 
 Linear TV sellers can now fully participate in AdCP. This release adds the protocol primitives that distinguish broadcast from digital:
 
-- **Ad-ID identifiers** — `industry_identifiers` on creative assets and manifests, with `creative-identifier-type` enum (`ad_id`, `isci`, `clearcast_clock`). Broadcast creatives are identified by Ad-ID, which ties spots to rotation instructions and traffic systems.
+- **Broadcast creative identifiers** — `industry_identifiers` on creative assets and manifests, with `creative-identifier-type` enum (`ad_id`, `isci`, `clearcast_clock`, `idcrea`). Broadcast creatives carry the traffic or clearance identifier used by the relevant workflow, which ties spots to rotation instructions and traffic systems.
 - **Broadcast spot formats** — Reference formats for :15, :30, and :60 spots. Video file only — no VAST, no impression trackers, no clickthrough URLs. The absence of tracker asset slots in a format signals that third-party pixel tracking is not supported.
 - **Agency Estimate Number** — `agency_estimate_number` on media buys and packages. The financial reference that links broadcast orders to agency media plans and billing.
 - **Measurement windows** — `measurement_windows` on `reporting_capabilities` for Live, C3, and C7 maturation. `measurement_window` on `billing_measurement` declares which window the guarantee is reconciled against.
 - **Delivery data completeness** — `is_final` and `measurement_window` on per-package delivery data. Buyers know whether numbers are provisional or closed, and which measurement window they represent. Applies to any channel with maturing data (broadcast, podcast, long-tail content).
 
 <Card title="Broadcast TV" icon="arrow-right" href="/docs/creative/channels/broadcast">
-  Channel guide covering spot formats, Ad-ID, measurement windows, and how broadcast differs from CTV.
+  Channel guide covering spot formats, creative identifiers, measurement windows, and how broadcast differs from CTV.
 </Card>
 
 ### Structured measurement terms

--- a/static/schemas/source/core/creative-asset.json
+++ b/static/schemas/source/core/creative-asset.json
@@ -106,7 +106,7 @@
     },
     "industry_identifiers": {
       "type": "array",
-      "description": "Industry-standard identifiers for this creative (e.g., Ad-ID, ISCI, Clearcast clock number). In broadcast buying, these identifiers tie the creative to rotation instructions and traffic systems. A creative may have multiple identifiers when different systems reference the same asset.",
+      "description": "Industry-standard or market-specific identifiers for this creative (e.g., Ad-ID, ISCI, Clearcast clock number, IDcrea). In broadcast and scheduled audio/video buying, these identifiers tie the creative to rotation instructions, clearance records, and traffic systems. A creative may have multiple identifiers when different systems reference the same asset. Add a PR to extend creative-identifier-type when another shared identifier scheme needs first-class support.",
       "items": {
         "$ref": "/schemas/core/industry-identifier.json"
       },

--- a/static/schemas/source/core/creative-manifest.json
+++ b/static/schemas/source/core/creative-manifest.json
@@ -47,7 +47,7 @@
     },
     "industry_identifiers": {
       "type": "array",
-      "description": "Industry-standard identifiers for this specific manifest (e.g., Ad-ID, ISCI, Clearcast clock number). When present, overrides creative-level identifiers. Use when different format versions of the same source creative have distinct Ad-IDs (e.g., the :15 and :30 cuts).",
+      "description": "Industry-standard or market-specific identifiers for this specific manifest (e.g., Ad-ID, ISCI, Clearcast clock number, IDcrea). When present, overrides creative-level identifiers. Use when different format versions of the same source creative have distinct traffic identifiers (e.g., the :15 and :30 cuts, or separate TV and radio versions). Add a PR to extend creative-identifier-type when another shared identifier scheme needs first-class support.",
       "items": {
         "$ref": "/schemas/core/industry-identifier.json"
       },

--- a/static/schemas/source/core/industry-identifier.json
+++ b/static/schemas/source/core/industry-identifier.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/core/industry-identifier.json",
   "title": "Industry Identifier",
-  "description": "An industry-standard identifier for an advertising creative (e.g., Ad-ID, ISCI, Clearcast clock number). These identifiers are managed by external registries and used across the supply chain to track and reference specific creative assets.",
+  "description": "An industry-standard or market-specific identifier for an advertising creative (e.g., Ad-ID, ISCI, Clearcast clock number, IDcrea). These identifiers are managed by external registries or clearance bodies and used across the supply chain to track and reference specific creative assets. Add a PR to extend creative-identifier-type when another shared identifier scheme needs first-class support.",
   "type": "object",
   "properties": {
     "type": {
@@ -11,7 +11,7 @@
     "value": {
       "type": "string",
       "maxLength": 64,
-      "description": "The identifier value (e.g., 'ABCD1234000H' for Ad-ID)"
+      "description": "The identifier value (e.g., 'ABCD1234000H' for Ad-ID). Preserve the value exactly as the traffic or clearance system expects it."
     }
   },
   "required": ["type", "value"],

--- a/static/schemas/source/enums/creative-identifier-type.json
+++ b/static/schemas/source/enums/creative-identifier-type.json
@@ -2,21 +2,24 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/enums/creative-identifier-type.json",
   "title": "Creative Identifier Type",
-  "description": "Industry-standard identifier types for advertising creatives. These identifiers are managed by external registries and used across the supply chain to track and reference specific creative assets.",
+  "description": "Industry-standard or market-specific identifier types for advertising creatives. These identifiers are managed by external registries or clearance bodies and are used across the supply chain to track and reference specific creative assets. This enum is intentionally closed: add a PR for additional shared identifier schemes rather than using an escape hatch.",
   "type": "string",
   "enum": [
     "ad_id",
     "isci",
-    "clearcast_clock"
+    "clearcast_clock",
+    "idcrea"
   ],
   "enumDescriptions": {
-    "ad_id": "Ad-ID registry code — the universal standard for identifying advertising assets in the US and increasingly worldwide. 12-character alphanumeric (4-character company prefix + 8-character unique identifier, e.g., ABCD1234000H). Managed by the Ad-ID registry (ad-id.org). Ties creative assets to rotation instructions in broadcast buying.",
-    "isci": "Industry Standard Coding Identification — legacy creative identifier that preceded Ad-ID. Some older inventory and traffic systems still reference ISCI codes.",
-    "clearcast_clock": "Clearcast clock number — UK broadcast creative identifier assigned during the Clearcast clearance process. Required for linear TV and VOD advertising in the UK."
+    "ad_id": "Ad-ID registry code. Common for US television workflows and accepted by some radio/audio workflows. Often 12-character alphanumeric (4-character company prefix + 8-character unique identifier, e.g., ABCD1234000H). Managed by the Ad-ID registry (ad-id.org). Ties creative assets to rotation instructions and traffic systems.",
+    "isci": "Industry Standard Coding Identification. Longstanding creative identifier still used by broadcast radio and legacy traffic systems, sometimes interchangeably with Ad-ID in audio workflows.",
+    "clearcast_clock": "Clearcast clock number. UK broadcast creative identifier assigned during the Clearcast clearance process and used from clearance through transmission and reporting.",
+    "idcrea": "IDcrea identifier. French ARPP.PUB creative identifier for current ARPP.PUB workflows; historical PubID values remain valid for older creatives."
   },
   "examples": [
     "ad_id",
     "isci",
-    "clearcast_clock"
+    "clearcast_clock",
+    "idcrea"
   ]
 }

--- a/static/schemas/source/media-buy/create-media-buy-request.json
+++ b/static/schemas/source/media-buy/create-media-buy-request.json
@@ -109,7 +109,7 @@
     "agency_estimate_number": {
       "type": "string",
       "maxLength": 100,
-      "description": "Agency estimate or authorization number. Primary financial reference for broadcast buys — links the order to the agency's media plan and billing system. Travels with the order and Ad-IDs through the transaction lifecycle."
+      "description": "Agency estimate or authorization number. Primary financial reference for broadcast buys — links the order to the agency's media plan and billing system. Travels with the order and creative traffic identifiers through the transaction lifecycle."
     },
     "start_time": {
       "$ref": "/schemas/core/start-timing.json"


### PR DESCRIPTION
Clarifies broadcast radio support in the audio channel docs with canonical `audio_hosted` examples, legacy named-format fallback, and measurement/reporting guidance.

Extends creative identifier schemas/docs with `idcrea` while keeping `creative-identifier-type` closed to shared schemes (`ad_id`, `isci`, `clearcast_clock`, `idcrea`) and directing new schemes through PRs instead of escape hatches.

Tests: `npm run build:schemas`; `node tests/example-validation-simple.test.cjs --file docs/creative/channels/audio.mdx`; `npm run test:schemas`; `npm run test:json-schema`; `npm run test:platform-agnostic`; `npm run test:schema-utf8`; `npm run test:oneof-discriminators`; `npm run lint:schema-links -- --check`; `git diff --check`; precommit suite (`npm run test:unit`, dynamic-import lint, callApi state-change lint, `npm run typecheck`); pre-push version, changeset, schema-link, and Mintlify broken-link checks.