### PR TITLE
feat(media-buy): add tiktok_shop / pinterest_catalog / openai_product_feed feed formats (#5271)

### DIFF
--- a/.changeset/feed-format-social-commerce.md
+++ b/.changeset/feed-format-social-commerce.md
@@ -1,0 +1,15 @@
+---
+"adcontextprotocol": minor
+---
+
+Add `tiktok_shop`, `pinterest_catalog`, and `openai_product_feed` to the `feed_format` enum, and reconcile `brand.json` to reference the canonical enum.
+
+All three are externally-documented, Google-Merchant-Center-derived product-feed dialects that real sellers (TikTok Shop, Pinterest, OpenAI/ChatGPT commerce) parse natively — so buyers declaring them no longer have to fall back to `custom` + `feed_field_mappings` to re-describe a standardized feed. Each carries material deltas a strict GMC parser would mis-handle (TikTok `sku_id`/`video_link`; Pinterest composite price/shipping + mandatory `google_product_category`; OpenAI `is_eligible_*` flags), which is the bar for a dialect to earn its own value under the #3456 enum-membership criterion.
+
+`feed_format` values are vendor spec names (proper nouns), not semantic categories — a feed format *is* the vendor's published spec, so there is no vendor-neutral name (the deliberate inverse of the semantic `video_placement_types`/`social_placement_surfaces` axes). The enum now carries `enumDescriptions` documenting each format and citing its spec.
+
+`brand.json` previously inlined a drifted feed_format enum (it had `openai_product_feed` but was missing `shopify`/`linkedin_jobs`); it now `$ref`s `/schemas/enums/feed-format.json` (matching `core/catalog.json`), so the two surfaces can no longer diverge.
+
+`feed_format` is a seller-side parsing label only — AdCP ships no per-format mapping table and SDKs do not parse feeds, so first-class membership is a label + SDK enum-widening, not a parser obligation.
+
+Closes #5271. Implements the #3456 enum-membership criterion.

--- a/static/schemas/source/brand.json
+++ b/static/schemas/source/brand.json
@@ -370,8 +370,7 @@
       "properties": {
         "feed_url": { "type": "string", "format": "uri", "description": "URL to product catalog feed" },
         "feed_format": {
-          "type": "string",
-          "enum": ["google_merchant_center", "facebook_catalog", "openai_product_feed", "custom"],
+          "$ref": "/schemas/enums/feed-format.json",
           "description": "Format of the product feed"
         },
         "categories": {

--- a/static/schemas/source/enums/feed-format.json
+++ b/static/schemas/source/enums/feed-format.json
@@ -2,13 +2,26 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/enums/feed-format.json",
   "title": "Feed Format",
-  "description": "Catalog feed formats. Determines how the platform parses items from an external feed URL.",
+  "description": "Catalog feed formats. Determines how the platform (seller) parses items from an external feed URL. Each named value is an externally-documented feed specification a seller parses natively without buyer-supplied feed_field_mappings; values are vendor spec names (proper nouns), not semantic categories. Use `custom` + feed_field_mappings for any feed whose shape is not one of the named formats.",
   "type": "string",
   "enum": [
     "google_merchant_center",
     "facebook_catalog",
     "shopify",
     "linkedin_jobs",
+    "tiktok_shop",
+    "pinterest_catalog",
+    "openai_product_feed",
     "custom"
-  ]
+  ],
+  "enumDescriptions": {
+    "google_merchant_center": "Google Merchant Center / Google Shopping product data specification — the de-facto e-commerce product-feed lingua franca that the other named commerce formats derive from.",
+    "facebook_catalog": "Meta (Facebook / Instagram) product catalog feed — a Google-Merchant-Center-derived dialect, the closest clone of the GMC field set.",
+    "shopify": "Shopify product feed export.",
+    "linkedin_jobs": "LinkedIn job-posting feed (XML).",
+    "tiktok_shop": "TikTok Shop product catalog feed — a GMC-derived dialect with material deltas (sku_id as the primary identifier rather than id, and a first-class video_link) that a GMC parser keyed on id would mis-parse.",
+    "pinterest_catalog": "Pinterest product catalog feed — a GMC-derived dialect with stricter serialization (composite-encoded price and shipping, a mandatory google_product_category, space-delimited availability enums) that a strict GMC parser would mis-handle.",
+    "openai_product_feed": "OpenAI Commerce product feed for ChatGPT shopping — a GMC-derived dialect adding ChatGPT-specific eligibility flags (is_eligible_search / is_eligible_checkout / is_eligible_ads). Spec: https://developers.openai.com/commerce/specs/file-upload/products",
+    "custom": "A feed whose shape is not one of the named formats above. The buyer MUST supply feed_field_mappings to normalize it to the AdCP catalog item schema."
+  }
 }

--- a/tests/check-platform-agnostic.cjs
+++ b/tests/check-platform-agnostic.cjs
@@ -93,14 +93,8 @@ const ENUM_VALUE_ALLOWLIST = [
   { value: 'amazon', pathContains: 'brand/verify-brand-claims-request.json' },
   { value: 'roku',   pathContains: 'brand/verify-brand-claims-request.json' },
 
-  // brand.json — feed_format: google_merchant_center and facebook_catalog are
-  // widely-adopted open interchange formats implemented by many third parties.
-  { value: 'google_merchant_center', pathContains: 'brand.json' },
-  { value: 'facebook_catalog',       pathContains: 'brand.json' },
-  // openai_product_feed is contested (see #3456): code-reviewer treats it as
-  // a violation; protocol expert treats it as a canonical feed schema identifier
-  // parallel to google_merchant_center. Allowlisted pending @bokelley decision.
-  { value: 'openai_product_feed',    pathContains: 'brand.json' },
+  // brand.json — feed_format now $refs enums/feed-format.json (no inline enum
+  // values), so the canonical feed-format.json entries below cover it.
 
   // enums/demographic-system.json — Nielsen notation IS the industry-standard
   // demographic audience measurement vocabulary (parallel to Nielsen DMA).
@@ -122,6 +116,11 @@ const ENUM_VALUE_ALLOWLIST = [
   // linkedin_jobs names LinkedIn's job-listing feed format, the canonical format
   // for ATS/job-board integrations — parallel to google_merchant_center for retail.
   { value: 'linkedin_jobs', pathContains: 'enums/feed-format.json' },
+  // openai_product_feed — OpenAI Commerce product feed for ChatGPT shopping;
+  // approved as a canonical feed format per #3456 (@bokelley). Same open-spec
+  // justification as the other named formats. (tiktok_shop / pinterest_catalog
+  // need no entry — 'tiktok'/'pinterest' are not vendor tokens.)
+  { value: 'openai_product_feed', pathContains: 'enums/feed-format.json' },
 
   // enums/genre-taxonomy.json — platform taxonomy system identifiers, comparable
   // to gracenote and eidr. Note: bare 'roku' is inconsistent with the {vendor}_genres


### PR DESCRIPTION
Implements **#5271** under the **#3456** enum-membership criterion.

## What

- Adds `tiktok_shop`, `pinterest_catalog`, `openai_product_feed` to `enums/feed-format.json`, with `enumDescriptions` documenting each format (and citing the OpenAI Commerce feed spec).
- Reconciles the **`brand.json` drift**: it inlined a divergent feed_format enum (had `openai_product_feed`, lacked `shopify`/`linkedin_jobs`) — now `$ref`s `/schemas/enums/feed-format.json` like `core/catalog.json` does, so the two surfaces can't diverge again.

## Why these three (the #3456 criterion)

A `feed_format` value earns first-class membership when it's **(a) externally documented**, **(b) parsed natively by a real seller without buyer `feed_field_mappings`**, and **(c) multi-seller/buyer relevant** — and a **material dialect** of a listed format earns its own value only when the deltas would make the parent's parser mis-parse. All three qualify:
- **tiktok_shop** — `sku_id` primary key + `video_link`; a GMC parser keyed on `id` mis-parses.
- **pinterest_catalog** — composite price/shipping + mandatory `google_product_category` + spaced enums break a strict GMC parser.
- **openai_product_feed** — OpenAI Commerce feed for ChatGPT shopping; adds `is_eligible_search/checkout/ads` flags. ([spec](https://developers.openai.com/commerce/specs/file-upload/products))

## Scope / cost

`feed_format` is a **seller-side parsing label** — AdCP owns no per-format mapping table and the SDKs don't parse feeds. So membership is a string + SDK enum-widening codegen, **not** a parser or mapping obligation. The enum stays a curated, high-signal roster of real published dialects, not a registry of every commerce platform.

**Note:** `feed_format` values are deliberately **proper-noun** (vendor spec names) — the inverse of the semantic `video_placement_types`/`social_placement_surfaces` axes — because a feed format *is* the vendor's published spec; there's no vendor-neutral name. Worth stating so nobody tries to "semanticize" it.

Closes #5271. Refs #3456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)