### PR TITLE
Add task lifecycle aliases

### DIFF
--- a/.changeset/issue-3209-task-lifecycle-tools.md
+++ b/.changeset/issue-3209-task-lifecycle-tools.md
@@ -5,7 +5,8 @@
 Add non-colliding AdCP task-lifecycle aliases in the protocol namespace:
 `get_task_status` and `list_tasks`.
 
-The existing `core/tasks-get-*` and `core/tasks-list-*` schemas remain valid
-through 3.x for compatibility. The new aliases give SDKs and sellers a
-non-colliding path before the legacy AdCP polling surfaces can be reconsidered
-in 4.0.
+These are aliases for AdCP's application-layer lifecycle tools, not aliases for
+transport-native MCP/A2A `tasks/*` APIs. The existing `core/tasks-get-*` and
+`core/tasks-list-*` schemas remain valid through 3.x for compatibility; the
+new aliases avoid transport-name collisions without changing AdCP async task
+polling or reconciliation semantics.

--- a/.changeset/issue-3209-task-lifecycle-tools.md
+++ b/.changeset/issue-3209-task-lifecycle-tools.md
@@ -1,0 +1,11 @@
+---
+"adcontextprotocol": minor
+---
+
+Add non-colliding AdCP task-lifecycle aliases in the protocol namespace:
+`get_task_status` and `list_tasks`.
+
+The existing `core/tasks-get-*` and `core/tasks-list-*` schemas remain valid
+through 3.x for compatibility. The new aliases give SDKs and sellers a
+non-colliding path before the legacy AdCP polling surfaces can be reconsidered
+in 4.0.

--- a/docs/building/by-layer/L0/a2a-guide.mdx
+++ b/docs/building/by-layer/L0/a2a-guide.mdx
@@ -301,6 +301,8 @@ For webhook payload formats, protocol comparison, and detailed handling examples
 
 A2A's key advantage is real-time updates via Server-Sent Events:
 
+AdCP still owns the application-layer task lifecycle on A2A. A2A `Task`, `taskId`, SSE, and push-notification frames are transport delivery mechanics; the durable business operation remains the AdCP payload keyed by AdCP `task_id`. A completed A2A task can still carry an AdCP response whose payload says `status: 'submitted'`.
+
 ### Task Monitoring
 
 ```javascript
@@ -355,7 +357,7 @@ const response = await a2a.send({
   }
 });
 
-// Monitor in real-time via SSE
+// Monitor A2A transport progress in real time via SSE
 if (response.status === 'working' || response.status === 'submitted') {
   const monitor = new A2aTaskMonitor(response.taskId);
   
@@ -368,6 +370,10 @@ if (response.status === 'working' || response.status === 'submitted') {
     const parts = final.artifacts[0].parts;
     const dataParts = parts.filter(p => p.data != null || p.kind === 'data');
     const payload = dataParts[dataParts.length - 1]?.data;
+    if (payload?.status === 'submitted') {
+      // A2A delivery completed, but the AdCP operation is still queued.
+      return pollAdcpTask(payload.task_id);
+    }
     console.log('Created:', payload?.media_buy_id);
   });
 }

--- a/docs/building/by-layer/L0/mcp-guide.mdx
+++ b/docs/building/by-layer/L0/mcp-guide.mdx
@@ -117,14 +117,16 @@ await mcp.call('activate_signal', {...});  // Deploy signals to platforms
 
 **Task Parameters**: See individual task documentation in [Media Buy](/docs/media-buy) and [Signals](/docs/signals/overview) sections.
 
-## Async Operations via MCP Tasks
+## MCP Tasks as a Transport Wrapper
 
-AdCP uses [MCP Tasks](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks) for long-running operations over MCP. This removes the LLM from the polling path — the client handles task lifecycle at the protocol level, and the model only sees the final result.
+AdCP task lifecycle state is application-layer state. MCP Tasks can wrap a `tools/call` request so the MCP client, rather than the LLM, waits for the `CallToolResult`; they do not replace the AdCP `task_id`, status payloads, webhooks, or polling/reconciliation surfaces.
+
+A task-augmented MCP call can complete successfully after delivering an AdCP payload whose `status` is still `submitted`. From that point, the media-buy, creative, signals, or governance workflow remains open at the AdCP layer and should be observed with webhooks or AdCP polling.
 
 :::warning Client support is limited
-Most chat-based MCP clients (Claude Desktop, Cursor) do not yet support MCP Tasks. If your client doesn't support task-augmented tool calls, use **webhooks** or **polling via `tasks/get`** instead — these work with any MCP client. See [Async Operations](/docs/building/by-layer/L3/async-operations) and [Push Notifications](/docs/building/by-layer/L3/webhooks) for transport-independent patterns.
+Most chat-based MCP clients (Claude Desktop, Cursor) do not yet support MCP Tasks. If your client doesn't support task-augmented tool calls, use standard `tools/call` plus **webhooks** or **AdCP polling** instead — these work with any MCP client. See [Async Operations](/docs/building/by-layer/L3/async-operations) and [Push Notifications](/docs/building/by-layer/L3/webhooks) for transport-independent patterns.
 
-MCP Tasks are the right choice when you control the MCP client (e.g., building your own orchestrator with `@modelcontextprotocol/sdk`) or when client support matures.
+MCP Tasks are useful when you control the MCP client (e.g., building your own orchestrator with `@modelcontextprotocol/sdk`) and want protocol-level waiting for the initial `tools/call` result. They are optional transport plumbing, not the canonical AdCP task store.
 :::
 
 ### SDK Implementation
@@ -232,7 +234,7 @@ Each tool declares whether it supports task-augmented execution via `execution.t
 
 Tools with `taskSupport: "optional"` can be called either way:
 - **Without `task` field**: Synchronous — returns the result directly
-- **With `task` field**: Returns a `CreateTaskResult` immediately; poll via `tasks/get`, retrieve the result via `tasks/result`
+- **With `task` field**: Returns a `CreateTaskResult` immediately; poll the MCP task via transport-native `tasks/get`, retrieve the `CallToolResult` via transport-native `tasks/result`, then inspect the AdCP payload inside that result.
 
 ### Invoking a Tool as a Task
 
@@ -276,11 +278,13 @@ The server returns a task handle immediately:
 }
 ```
 
-The client polls with `tasks/get` (respecting `pollInterval`) until the task reaches a terminal state (`completed`, `failed`, or `cancelled`), then retrieves the `CallToolResult` via `tasks/result`. To abort a running task, send `tasks/cancel` with the `taskId`.
+The client polls the MCP transport task with `tasks/get` (respecting `pollInterval`) until the task reaches a terminal state (`completed`, `failed`, or `cancelled`), then retrieves the `CallToolResult` via `tasks/result`. To abort the transport task, send `tasks/cancel` with the MCP `taskId`.
 
-### AdCP Status Mapping
+After retrieving the `CallToolResult`, inspect the AdCP response payload. If it contains `status: "submitted"` and an AdCP `task_id`, the transport task has delivered the queued AdCP response but the application workflow is still open. Continue with webhooks or AdCP polling (`get_task_status`, or legacy `tasks/get` in 3.x).
 
-AdCP uses a richer set of statuses than MCP Tasks. When serving over MCP, AdCP statuses map to MCP Task statuses:
+### MCP Task Status vs. AdCP Status
+
+AdCP uses a richer set of statuses than MCP Tasks. If an implementation mirrors AdCP progress into a transport-native MCP Task, use this mapping only for the MCP wrapper. The AdCP payload remains the source of truth for domain workflow state:
 
 | AdCP Status | MCP Task Status | Notes |
 |-------------|-----------------|-------|
@@ -295,7 +299,7 @@ AdCP uses a richer set of statuses than MCP Tasks. When serving over MCP, AdCP s
 
 ### Webhooks for Long-Lived Operations
 
-MCP Tasks handles polling within the MCP session, but some AdCP operations outlive a single session (e.g., a media buy that takes 24 hours for publisher approval). For these, combine MCP Tasks with `push_notification_config`:
+MCP Tasks handles waiting within the MCP session, but many AdCP operations outlive a single session (e.g., a media buy that takes 24 hours for publisher approval). For these, register `push_notification_config` on the AdCP call:
 
 ```json
 {
@@ -322,7 +326,7 @@ MCP Tasks handles polling within the MCP session, but some AdCP operations outli
 }
 ```
 
-The MCP Task tracks status within the session. If the session ends before the task completes, the webhook delivers the result independently. See [Push Notifications](/docs/building/by-layer/L3/webhooks) for webhook payload formats and authentication.
+The MCP Task tracks the transport wrapper within the session. The webhook tracks the AdCP application task independently and remains valid even after the MCP session ends. See [Push Notifications](/docs/building/by-layer/L3/webhooks) for webhook payload formats and authentication.
 
 ## Context Management (MCP-Specific)
 
@@ -422,7 +426,9 @@ const result = await session.call('create_media_buy',
   }
 );
 
-// result is a CreateTaskResult — the client handles polling via tasks/get
+// result is a CreateTaskResult for the MCP wrapper.
+// After tasks/result, inspect the AdCP payload; if it is still submitted,
+// continue via webhook or AdCP get_task_status / legacy tasks/get.
 ```
 
 **Webhook POST format:**
@@ -571,16 +577,21 @@ function verifySignature(payload, signature, timestamp) {
 
 #### Task Management and Polling
 ```javascript
-// Check status of specific task
-const taskStatus = await session.pollTask('task_456', true);
+// Check status of a specific AdCP task
+const taskStatus = await session.call('get_task_status', {
+  task_id: 'task_456',
+  include_result: true
+});
 if (taskStatus.status === 'completed') {
   console.log('Result:', taskStatus.result);
 }
 
 // State reconciliation
-const reconciliation = await session.reconcileState();
-if (reconciliation.missing_from_client.length > 0) {
-  console.log('Found orphaned tasks:', reconciliation.missing_from_client);
+const reconciliation = await session.call('list_tasks', {
+  filters: { statuses: ['submitted', 'working', 'input-required'] }
+});
+if (reconciliation.tasks.length > 0) {
+  console.log('Found open AdCP tasks:', reconciliation.tasks);
   // Start tracking these tasks
 }
 
@@ -610,13 +621,13 @@ async function handleContextExpiration(session, tool, params) {
 
 ## Handling Async Operations
 
-When a task returns `working` or `submitted` status, you need a way to receive the result. This applies whether or not your MCP client supports MCP Tasks — the patterns below work with any client.
+When an AdCP response returns `working` or `submitted` status, you need a way to receive the result. This applies whether or not your MCP client supports MCP Tasks — the patterns below work with any client.
 
 | Approach | Best For | Trade-offs |
 |----------|----------|------------|
 | **Webhooks** | Production systems, any task duration | Handles hours/days, but requires a public endpoint |
 | **Polling** | Simple integrations, short tasks | Easy to implement, but inefficient for long waits |
-| **MCP Tasks** | Custom clients using the MCP SDK | Protocol-native, but requires client support |
+| **MCP Tasks** | Custom clients using the MCP SDK | Protocol-native wrapper for the initial `tools/call`, but does not replace AdCP task tracking |
 
 ### Option 1: Webhooks (recommended)
 
@@ -647,12 +658,15 @@ See [Push Notifications](/docs/building/by-layer/L3/webhooks) for payload format
 
 ### Option 2: Polling (backup)
 
-Use `tasks/get` as a backup for `submitted` operations, or when you can't expose a webhook endpoint:
+Use AdCP polling as a backup for `submitted` operations, or when you can't expose a webhook endpoint. In 3.x, prefer `get_task_status` when the seller advertises it; otherwise use legacy `tasks/get`:
 
 ```javascript
 async function pollForResult(session, taskId, pollInterval = 30000) {
   while (true) {
-    const response = await session.pollTask(taskId, true);
+    const response = await session.call('get_task_status', {
+      task_id: taskId,
+      include_result: true
+    });
 
     if (['completed', 'failed', 'canceled'].includes(response.status)) {
       return response;

--- a/docs/building/by-layer/L0/schemas.mdx
+++ b/docs/building/by-layer/L0/schemas.mdx
@@ -191,7 +191,7 @@ dist/schemas/{VERSION}/
 │   ├── content-standards/        # Content standards tasks
 │   ├── sponsored-intelligence/   # Sponsored intelligence tasks
 │   ├── protocol/                 # Protocol tasks
-│   └── core/                     # Core task schemas
+│   └── core/                     # Core shared schemas and legacy task lifecycle schemas
 ├── core/                         # Modular schemas with $ref
 ├── media-buy/
 └── index.json                    # Schema registry
@@ -209,7 +209,7 @@ All request/response task schemas are bundled:
 | `bundled/property/` | create-property-list, get-property-list, list-property-lists, update-property-list, delete-property-list, validate-property-delivery |
 | `bundled/content-standards/` | create-content-standards, get-content-standards, list-content-standards, update-content-standards, calibrate-content, validate-content-delivery, get-media-buy-artifacts |
 | `bundled/sponsored-intelligence/` | si-get-offering, si-initiate-session, si-send-message, si-terminate-session |
-| `bundled/protocol/` | get-adcp-capabilities |
+| `bundled/protocol/` | get-adcp-capabilities, get-task-status, list-tasks |
 | `bundled/core/` | tasks-get, tasks-list |
 
 See the [schema registry](https://adcontextprotocol.org/schemas/v3/index.json) for all available schemas.

--- a/docs/building/by-layer/L3/async-operations.mdx
+++ b/docs/building/by-layer/L3/async-operations.mdx
@@ -24,9 +24,9 @@ Any AdCP task can return one of these statuses. The server chooses based on what
 :::tip Webhooks for `submitted` operations
 **Webhooks** are the recommended approach for `submitted` operations — they work with any transport (MCP, A2A, REST) and handle operations that outlive a single session. See [Push Notifications](/docs/building/by-layer/L3/webhooks).
 
-**Polling** via `tasks/get` works as a simpler alternative or backup. See the [polling pattern](#polling-for-submitted-operations) below.
+**Polling** via the AdCP task polling surface works as a simpler alternative or backup. In 3.x, that surface is legacy `tasks/get`, with optional `get_task_status` when the seller advertises the alias. See the [polling pattern](#polling-for-submitted-operations) below.
 
-**MCP Tasks** handle async at the protocol level, but client support is still limited — most chat-based MCP clients (Claude Desktop, Cursor) don't yet support task-augmented tool calls. If you're building your own MCP client or using the JS SDK directly, MCP Tasks work well. See [MCP Guide](/docs/building/by-layer/L0/mcp-guide#async-operations-via-mcp-tasks).
+**Transport-native tasks are not the AdCP lifecycle.** MCP Tasks or A2A task updates may carry or stream an AdCP response, but the durable task state is the AdCP payload: `task_id`, `status`, webhook payloads, and AdCP polling/reconciliation. See [MCP Guide](/docs/building/by-layer/L0/mcp-guide#mcp-tasks-as-a-transport-wrapper).
 :::
 
 ## Operation examples
@@ -249,7 +249,7 @@ async function pollForResult(taskId, options = {}) {
 
     await sleep(pollInterval);
 
-    const response = await adcp.call('tasks/get', {
+    const response = await adcp.call('get_task_status', {
       task_id: taskId,
       include_result: true
     });
@@ -314,7 +314,7 @@ async function onStartup() {
 
   for (const operation of pending) {
     // Check current status on server
-    const response = await adcp.call('tasks/get', {
+    const response = await adcp.call('get_task_status', {
       task_id: operation.task_id,
       include_result: true
     });

--- a/docs/building/by-layer/L3/task-lifecycle.mdx
+++ b/docs/building/by-layer/L3/task-lifecycle.mdx
@@ -6,11 +6,10 @@ description: "AdCP task lifecycle: status values (submitted, working, input-requ
 
 Every AdCP response includes a `status` field that tells you exactly what state the operation is in and what action you should take next. This is the foundation for handling any AdCP operation.
 
-:::note Transport-specific task management
-The status values and lifecycle described here are transport-independent — they apply regardless of how you access AdCP. The *mechanism* for tracking async tasks varies by transport:
-- **MCP**: Use [MCP Tasks](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks) — the client polls via `tasks/get` and retrieves results via `tasks/result` at the protocol level. See [MCP Guide](/docs/building/by-layer/L0/mcp-guide#async-operations-via-mcp-tasks).
-- **A2A**: Use native A2A task lifecycle with SSE streaming. See [A2A Guide](/docs/building/by-layer/L0/a2a-guide).
-- **REST**: Use AdCP's `task_id` with polling or [push notifications](/docs/building/by-layer/L3/webhooks).
+:::note Application-layer task state
+The status values and lifecycle described here are transport-independent AdCP application state. MCP and A2A task mechanisms may wrap, stream, or deliver an AdCP response, but they do not replace AdCP's `task_id`, webhook payloads, or polling/reconciliation surfaces.
+
+For `submitted` operations, observe the AdCP task with [push notifications](/docs/building/by-layer/L3/webhooks) or the AdCP polling surface. In 3.x, that polling surface is legacy `tasks/get`, with optional `get_task_status` when the seller advertises the alias. Transport-native MCP/A2A `tasks/*` methods use their own wire shapes and are separate from AdCP task polling.
 :::
 
 ## Status Values
@@ -162,10 +161,9 @@ Operations that take longer than 30 seconds return either `working` or `submitte
 }
 ```
 
-**Transport-specific handling for `submitted` operations:**
-- **MCP**: Use [MCP Tasks](/docs/building/by-layer/L0/mcp-guide#async-operations-via-mcp-tasks) or poll via `tasks/get`
-- **A2A**: Subscribe to SSE stream for real-time updates
-- **REST**: Use [push notifications](/docs/building/by-layer/L3/webhooks) (recommended) or poll with `task_id`
+**Handling for `submitted` operations:**
+- **All transports**: Use [push notifications](/docs/building/by-layer/L3/webhooks) (recommended) or poll the AdCP task with `get_task_status` / legacy `tasks/get`.
+- **MCP/A2A transport tasks**: Treat native task state as transport state. A native task can finish once it has delivered an AdCP payload that still says `status: 'submitted'`.
 
 ## Status Progression
 
@@ -199,7 +197,7 @@ async function pollForResult(taskId, pollInterval = 30_000) {
   while (true) {
     await sleep(pollInterval);
 
-    const response = await adcp.call('tasks/get', {
+    const response = await adcp.call('get_task_status', {
       task_id: taskId,
       include_result: true
     });
@@ -233,11 +231,11 @@ function getTimeout(status) {
 
 ## Task Reconciliation
 
-Use `tasks/list` to recover from lost state:
+Use `list_tasks` (or legacy `tasks/list` in 3.x) to recover from lost state:
 
 ```javascript
 // Find all pending operations
-const pending = await session.call('tasks/list', {
+const pending = await session.call('list_tasks', {
   filters: {
     statuses: ["submitted", "working", "input-required"]
   }

--- a/docs/building/by-layer/L4/build-a-caller.mdx
+++ b/docs/building/by-layer/L4/build-a-caller.mdx
@@ -145,7 +145,7 @@ if ('errors' in response) {
   // for correctable failures (validation, oneOf, etc.)
 } else if (response.status === 'submitted') {
   // Async: the work is queued, NOT done. The completion payload arrives
-  // later — either via webhook (preferred) or by polling tasks/get.
+  // later — either via webhook (preferred) or by polling the AdCP task.
 } else {
   // Sync success: response carries the completion payload directly.
   // (e.g., response.media_buy_id, response.packages)
@@ -154,7 +154,7 @@ if ('errors' in response) {
 
 The SDK steers you to webhooks for async completion. Configure `webhookUrlTemplate` and a status-change handler at construction; the SDK verifies the inbound webhook against the seller's JWKS and fires your handler with the same `result` shape that synchronous responses carry — see [Receive webhooks](#receive-webhooks) below.
 
-If you must poll instead of using webhooks (e.g. inside a one-shot script), call `tasks/get` directly via the underlying transport. The [Async responses section of Calling an agent](/docs/protocol/calling-an-agent#async-responses-status-submitted-means-queued) has the wire contract.
+If you must poll instead of using webhooks (e.g. inside a one-shot script), call the AdCP polling surface: `get_task_status` when the seller advertises it, otherwise legacy AdCP `tasks/get` in 3.x. The [Async responses section of Calling an agent](/docs/protocol/calling-an-agent#async-responses-status-submitted-means-queued) has the wire contract.
 
 ## Recover from errors
 
@@ -182,7 +182,7 @@ switch (recovery) {
 
 ## Receive webhooks
 
-For async tasks, you can either poll or register a webhook. The webhook delivers the same `result` payload as a `tasks/get` with `include_result: true`. The SDK ships an RFC 9421 webhook verifier (`createWebhookVerifier` from `@adcp/sdk/signing/server`) that resolves keys via the seller's brand.json, enforces the replay window, and surfaces structured errors for the [webhook error taxonomy](/docs/building/by-layer/L1/security#webhook-error-taxonomy).
+For async tasks, you can either poll or register a webhook. The webhook delivers the same `result` payload as AdCP task polling with `include_result: true`. The SDK ships an RFC 9421 webhook verifier (`createWebhookVerifier` from `@adcp/sdk/signing/server`) that resolves keys via the seller's brand.json, enforces the replay window, and surfaces structured errors for the [webhook error taxonomy](/docs/building/by-layer/L1/security#webhook-error-taxonomy).
 
 If you wire the multi-agent client with a `webhookUrlTemplate` and status-change handlers (per the [@adcp/sdk README](https://github.com/adcontextprotocol/adcp-client#readme)), incoming webhooks are verified and dispatched into your handlers automatically — your HTTP route is one line that hands the request to the client.
 

--- a/docs/building/concepts/protocol-comparison.mdx
+++ b/docs/building/concepts/protocol-comparison.mdx
@@ -13,9 +13,9 @@ Both MCP and A2A provide identical AdCP capabilities using the same unified stat
 | **Request Style** | Tool calls | Task messages |
 | **Response Style** | Direct JSON | Artifacts |
 | **Status System** | Unified status field | Unified status field |
-| **Async Handling** | [MCP Tasks](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks) | SSE streaming |
+| **Async Handling** | AdCP status payloads over tool calls; optional MCP Tasks wrapper | AdCP status payloads in A2A artifacts; optional SSE streaming |
 | **Webhooks** | `push_notification_config` in tool args | Native PushNotificationConfig |
-| **Task Management** | MCP Tasks (`tasks/get`, `tasks/result`, `tasks/cancel`) | Native task lifecycle |
+| **Task Management** | AdCP `task_id` via webhooks or AdCP polling (`get_task_status`, legacy `tasks/get`) | AdCP `task_id` via webhooks or AdCP polling |
 | **Context** | Manual (pass context_id) | Automatic (protocol-managed) |
 | **Best For** | Claude, AI assistants | Agent workflows |
 
@@ -39,7 +39,7 @@ Every response includes a status field that tells you exactly what to do:
 |--------|---------------|-------------|
 | `completed` | Task finished | Process data, show success |
 | `input-required` | Need user input | Read message, prompt user, follow up |
-| `working` | Processing (< 120s) | Poll frequently, show progress |
+| `working` | Processing (< 120s) | Wait for the open call/stream result; show progress |
 | `submitted` | Long-running (hours to days) | Provide webhook or poll less frequently |
 | `failed` | Error occurred | Show error, handle gracefully |
 | `auth-required` | Need auth | Prompt for credentials |
@@ -88,16 +88,18 @@ Same status and data, different packaging:
 
 ## Async Operation Differences
 
-Both protocols handle async operations with the same status progression:
+Both protocols carry the same AdCP status progression:
 `submitted` → `working` → `completed`/`failed`
 
-### MCP Async Pattern (MCP Tasks)
+The progression above is AdCP application state. MCP Tasks and A2A task state are transport mechanics that can deliver an AdCP payload, but they are not a replacement for AdCP task polling or reconciliation.
+
+### MCP Task-Augmented Call (Transport Wrapper)
 ```javascript
 // Task-augmented tool call — returns CreateTaskResult immediately
 const createResult = await mcp.callTool({
   name: "create_media_buy",
   arguments: {
-    buyer_ref: "nike_q1",
+    buyer_ref: "acme_q1",
     packages: [...],
     push_notification_config: {  // Optional: webhook for session-outliving ops
       url: "https://buyer.com/webhooks/adcp/create_media_buy/op_123",
@@ -112,17 +114,26 @@ const createResult = await mcp.callTool({
 const status = await mcp.getTask({ taskId: "task-456" });
 // status = { taskId: "task-456", status: "completed", ... }
 
-// Retrieve the actual CallToolResult
+// Retrieve the actual CallToolResult, then inspect the AdCP payload inside it
 const result = await mcp.getTaskResult({ taskId: "task-456" });
 // result = { content: [...], isError: false }
+
+const adcpResponse = result.structuredContent;
+if (adcpResponse.status === "submitted") {
+  // The MCP task delivered the AdCP response; the media-buy workflow is still open.
+  await adcp.call("get_task_status", {
+    task_id: adcpResponse.task_id,
+    include_result: true
+  });
+}
 ```
 
 ### A2A Async Pattern
 ```javascript
-// Initial response with native task tracking
+// Initial response carries an AdCP payload inside A2A task/artifact transport
 {
   "status": "submitted",
-  "taskId": "task-456",
+  "task_id": "adcp-task-456",
   "contextId": "ctx-123",
   "estimatedCompletionTime": "2025-01-23T10:00:00Z"
 }

--- a/docs/building/operating/orchestrator-design.mdx
+++ b/docs/building/operating/orchestrator-design.mdx
@@ -121,8 +121,8 @@ Sync local state with server on startup:
 
 ```python
 async def reconcile_with_server(self, adcp_client):
-    """Sync local state with server using tasks/list"""
-    server_tasks = await adcp_client.call('tasks/list', {
+    """Sync local state with server using AdCP task reconciliation"""
+    server_tasks = await adcp_client.call('list_tasks', {
         'filters': {'statuses': ['submitted', 'working', 'input_required']}
     })
 
@@ -218,7 +218,7 @@ async def _poll_for_completion(self, operation_id, task_id, interval=60):
             await asyncio.sleep(interval)
             poll_count += 1
 
-            task_response = await self.adcp.call('tasks/get', {
+            task_response = await self.adcp.call('get_task_status', {
                 'task_id': task_id,
                 'include_result': True
             })

--- a/docs/learning/foundations/a2b-testing-your-first-agent.mdx
+++ b/docs/learning/foundations/a2b-testing-your-first-agent.mdx
@@ -153,7 +153,7 @@ curl -X POST https://test-agent.adcontextprotocol.org/mcp \
 |---|---|---|
 | `media_buy_id` + `status: "pending_creatives"` | Buy confirmed; attach creatives | Go to Step 4 |
 | `media_buy_id` + `status: "pending_start"` or `"active"` | Buy confirmed and ready | Creatives already attached or not required |
-| `status: "submitted"` + `task_id` | Buy queued for async processing | Poll `tasks/get` with `task_id` (see [Async polling](#async-polling) below) |
+| `status: "submitted"` + `task_id` | Buy queued for async processing | Poll the AdCP task with `task_id` (see [Async polling](#async-polling) below) |
 | `errors[]` present, no `media_buy_id` | Rejected — read `errors[0].code` | Fix the request and retry with a new `idempotency_key` |
 
 ### Step 4 — Attach creatives
@@ -237,17 +237,20 @@ curl -X POST https://test-agent.adcontextprotocol.org/mcp \
   -H "mcp-session-id: <session-id>" \
   -d '{
     "jsonrpc": "2.0",
-    "method": "tasks/get",
-    "params": { "task_id": "<task-id-from-create>", "include_result": true },
+    "method": "tools/call",
+    "params": {
+      "name": "get_task_status",
+      "arguments": { "task_id": "<task-id-from-create>", "include_result": true }
+    },
     "id": 6
   }'
 ```
 
 <Note>
-`tasks/get` is an MCP protocol-level method, not an AdCP tool — it uses `"method": "tasks/get"` directly rather than the `"method": "tools/call"` + `"name": "..."` pattern used for AdCP tasks. It is auto-registered by the MCP SDK alongside `tasks/result`, `tasks/list`, and `tasks/cancel`.
+`get_task_status` is an AdCP application-layer task polling tool. In 3.x, sellers that do not advertise this alias still expose the legacy AdCP `tasks/get` surface with the same snake_case payload. Do not confuse either AdCP polling surface with transport-native MCP/A2A `tasks/*` methods, which use their own task wire shapes.
 </Note>
 
-Poll every 2–5 seconds. When `task.status` is `completed`, the `result` field contains the full `create_media_buy` response with `media_buy_id`. See the [Task lifecycle](/docs/building/implementation/task-lifecycle) doc for all MCP task status values.
+Poll every 2–5 seconds. When the AdCP task `status` is `completed`, the `result` field contains the full `create_media_buy` response with `media_buy_id`. See the [Task lifecycle](/docs/building/by-layer/L3/task-lifecycle) doc for all AdCP task status values.
 
 ## Common errors
 
@@ -256,7 +259,7 @@ Poll every 2–5 seconds. When `task.status` is `completed`, the `result` field 
 | HTTP 401 / `error: "invalid_token"` | Expired or wrong API key | Reissue the token from your dashboard; confirm the `Bearer` prefix |
 | HTTP 401 / `error: "invalid_request"` | `Authorization` header missing | Add `-H "Authorization: Bearer <token>"` to every call |
 | `errors[]` in body, no `media_buy_id` | Schema validation failure | Read `errors[0].field` and `errors[0].code`; fix the field and retry with a **new** `idempotency_key` |
-| `status: "submitted"` stays indefinitely | Async task stalled | Check `task.status` via `tasks/get`; if `failed`, read `task.error.message` for the rejection reason |
+| `status: "submitted"` stays indefinitely | Async task stalled | Check AdCP task status via `get_task_status` or legacy `tasks/get`; if `failed`, read the task error for the rejection reason |
 | `mcp-session-id: invalid` error | Session expired or header missing | Re-run Step 1 to get a fresh session ID |
 
 ## Assessment

--- a/docs/protocol/calling-an-agent.mdx
+++ b/docs/protocol/calling-an-agent.mdx
@@ -71,12 +71,12 @@ A mutating tool can return one of three shapes:
 { "errors": [{ "code": "PRODUCT_NOT_FOUND", "message": "..." }] }
 ```
 
-When you see `status: 'submitted'`, the work is **not** complete. Poll via `tasks/get` (A2A) or the MCP async task extension, using the returned `task_id`. Over A2A the AdCP `task_id` also rides on `artifact.metadata.adcp_task_id`.
+When you see `status: 'submitted'`, the work is **not** complete. In 3.x, poll via the legacy AdCP `tasks/get` surface using the returned `task_id`. Sellers MAY also advertise the non-colliding `get_task_status` alias; callers MAY use that alias when it appears in discovery. Both AdCP polling names use the same snake_case payload shape. Do not confuse either AdCP polling shape with transport-native MCP/A2A `tasks/get`, which uses the transport's own task wire shape.
 
 Pass `include_result: true` when polling so the seller includes the completion payload once status transitions to `completed`:
 
 ```json
-// tasks/get request
+// tasks/get request (same payload as optional get_task_status alias)
 { "task_id": "task_456", "include_result": true }
 
 // tasks/get response — completed
@@ -143,7 +143,7 @@ Every validation failure produces an envelope shaped like:
 | `keyword: 'type'` or `additionalProperties` at `/budget` | Sent `{amount, currency}` | `budget` is a number. Currency is implied by `pricing_option_id`. |
 | `additionalProperties` at `/format_id` (string passed) | Sent `"format_id": "video_..."` | `format_id` is `{agent_url, id}` — always an object. |
 | `keyword: 'enum'` at `/destinations/*/type` | Made-up destination type | Use `'platform'` (with `platform`) or `'agent'` (with `agent_url`). |
-| Response carries `status: 'submitted'` and `task_id` | Async — work is queued, NOT done | Poll via `tasks/get` (A2A) or the MCP async task extension using `task_id`. |
+| Response carries `status: 'submitted'` and `task_id` | Async — work is queued, NOT done | Poll with legacy `tasks/get`, or `get_task_status` when the seller advertises the alias. |
 
 ## Transport notes
 

--- a/docs/protocol/calling-an-agent.mdx
+++ b/docs/protocol/calling-an-agent.mdx
@@ -71,6 +71,8 @@ A mutating tool can return one of three shapes:
 { "errors": [{ "code": "PRODUCT_NOT_FOUND", "message": "..." }] }
 ```
 
+AdCP task state is an **application-layer** contract. MCP and A2A may wrap, stream, or transport an AdCP response, but their native task mechanisms do not replace the AdCP `task_id`, status values, webhook payloads, or polling/reconciliation surfaces. A transport task can complete after delivering an AdCP response whose payload still says `status: 'submitted'`.
+
 When you see `status: 'submitted'`, the work is **not** complete. In 3.x, poll via the legacy AdCP `tasks/get` surface using the returned `task_id`. Sellers MAY also advertise the non-colliding `get_task_status` alias; callers MAY use that alias when it appears in discovery. Both AdCP polling names use the same snake_case payload shape. Do not confuse either AdCP polling shape with transport-native MCP/A2A `tasks/get`, which uses the transport's own task wire shape.
 
 Pass `include_result: true` when polling so the seller includes the completion payload once status transitions to `completed`:

--- a/docs/protocol/required-tasks.mdx
+++ b/docs/protocol/required-tasks.mdx
@@ -23,7 +23,7 @@ Every AdCP agent, regardless of protocol, implements:
 
 Caller-scope RBAC introspection is not a standalone task. Sellers that support scope introspection return a per-account `authorization` object on `sync_accounts` and `list_accounts` responses. See [Accounts Protocol — Caller authorization](/docs/accounts/overview#caller-authorization).
 
-3.x sellers MAY also advertise non-colliding aliases for task lifecycle polling: `get_task_status` for legacy `tasks/get`, and `list_tasks` for legacy `tasks/list`. These aliases are optional compatibility surfaces in 3.x; callers MUST continue to support the legacy names through the 3.x line.
+AdCP task lifecycle state is application-layer state, not MCP-native or A2A-native task state. 3.x sellers MAY advertise non-colliding AdCP aliases for polling and reconciliation: `get_task_status` for legacy `tasks/get`, and `list_tasks` for legacy `tasks/list`. These aliases are optional compatibility surfaces in 3.x; callers MUST continue to support the legacy names through the 3.x line.
 
 ## Media Buy Protocol
 

--- a/docs/protocol/required-tasks.mdx
+++ b/docs/protocol/required-tasks.mdx
@@ -23,6 +23,8 @@ Every AdCP agent, regardless of protocol, implements:
 
 Caller-scope RBAC introspection is not a standalone task. Sellers that support scope introspection return a per-account `authorization` object on `sync_accounts` and `list_accounts` responses. See [Accounts Protocol — Caller authorization](/docs/accounts/overview#caller-authorization).
 
+3.x sellers MAY also advertise non-colliding aliases for task lifecycle polling: `get_task_status` for legacy `tasks/get`, and `list_tasks` for legacy `tasks/list`. These aliases are optional compatibility surfaces in 3.x; callers MUST continue to support the legacy names through the 3.x line.
+
 ## Media Buy Protocol
 
 ### Sales agent (seller)

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -1658,21 +1658,21 @@
         "get-task-status": {
           "request": {
             "$ref": "/schemas/protocol/get-task-status-request.json",
-            "description": "Request parameters for get_task_status polling"
+            "description": "Request parameters for get_task_status, the 3.x AdCP application-layer alias for legacy tasks/get polling; distinct from transport-native tasks/* methods"
           },
           "response": {
             "$ref": "/schemas/protocol/get-task-status-response.json",
-            "description": "Task status, metadata, and optional completion result"
+            "description": "AdCP application-layer task status, metadata, and optional completion result; alias response for legacy tasks/get"
           }
         },
         "list-tasks": {
           "request": {
             "$ref": "/schemas/protocol/list-tasks-request.json",
-            "description": "Request parameters for cross-protocol task reconciliation"
+            "description": "Request parameters for list_tasks, the 3.x AdCP application-layer alias for legacy tasks/list reconciliation; distinct from transport-native tasks/* methods"
           },
           "response": {
             "$ref": "/schemas/protocol/list-tasks-response.json",
-            "description": "Filtered async task list for reconciliation"
+            "description": "Filtered AdCP application-layer async task list for reconciliation; alias response for legacy tasks/list"
           }
         }
       }

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -1654,6 +1654,26 @@
             "$ref": "/schemas/protocol/get-adcp-capabilities-response.json",
             "description": "Response payload for get_adcp_capabilities task - includes AdCP version, supported protocols, and protocol-specific capabilities (media_buy, signals, etc.)"
           }
+        },
+        "get-task-status": {
+          "request": {
+            "$ref": "/schemas/protocol/get-task-status-request.json",
+            "description": "Request parameters for get_task_status polling"
+          },
+          "response": {
+            "$ref": "/schemas/protocol/get-task-status-response.json",
+            "description": "Task status, metadata, and optional completion result"
+          }
+        },
+        "list-tasks": {
+          "request": {
+            "$ref": "/schemas/protocol/list-tasks-request.json",
+            "description": "Request parameters for cross-protocol task reconciliation"
+          },
+          "response": {
+            "$ref": "/schemas/protocol/list-tasks-response.json",
+            "description": "Filtered async task list for reconciliation"
+          }
         }
       }
     },

--- a/static/schemas/source/protocol/get-task-status-request.json
+++ b/static/schemas/source/protocol/get-task-status-request.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/protocol/get-task-status-request.json",
   "title": "Get Task Status Request",
-  "description": "Request parameters for the get_task_status AdCP tool. Retrieves a specific async task by ID with optional conversation history and terminal result payload.",
+  "description": "Request parameters for the get_task_status AdCP tool. This is a 3.x protocol-namespace alias for the legacy AdCP tasks/get polling surface, not a transport-native MCP/A2A tasks/* method. It retrieves a specific AdCP application-layer async task by ID with optional conversation history and terminal result payload.",
   "type": "object",
   "allOf": [
     {

--- a/static/schemas/source/protocol/get-task-status-request.json
+++ b/static/schemas/source/protocol/get-task-status-request.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/protocol/get-task-status-request.json",
+  "title": "Get Task Status Request",
+  "description": "Request parameters for the get_task_status AdCP tool. Retrieves a specific async task by ID with optional conversation history and terminal result payload.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/schemas/core/version-envelope.json"
+    }
+  ],
+  "properties": {
+    "task_id": {
+      "type": "string",
+      "description": "Unique identifier of the task to retrieve",
+      "x-entity": "task"
+    },
+    "include_history": {
+      "type": "boolean",
+      "default": false,
+      "description": "Include full conversation history for this task (may increase response size)"
+    },
+    "include_result": {
+      "type": "boolean",
+      "default": false,
+      "description": "Include the task's result payload when status is completed. Defaults to false for lightweight status-only polls. When true, sellers MUST include result on the response when status is completed."
+    },
+    "context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": [
+    "task_id"
+  ],
+  "additionalProperties": true,
+  "examples": [
+    {
+      "description": "Check task status",
+      "data": {
+        "task_id": "task_456"
+      }
+    },
+    {
+      "description": "Get task with full conversation history",
+      "data": {
+        "task_id": "task_123",
+        "include_history": true
+      }
+    },
+    {
+      "description": "Poll for task completion including result payload",
+      "data": {
+        "task_id": "task_456",
+        "include_result": true
+      }
+    }
+  ]
+}

--- a/static/schemas/source/protocol/get-task-status-response.json
+++ b/static/schemas/source/protocol/get-task-status-response.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/protocol/get-task-status-response.json",
   "title": "Get Task Status Response",
-  "description": "Response from the get_task_status AdCP tool containing task status, task metadata, and optional conversation history or terminal result payload.",
+  "description": "Response from the get_task_status AdCP tool, a 3.x protocol-namespace alias for legacy AdCP tasks/get. Contains AdCP application-layer task status, task metadata, and optional conversation history or terminal result payload; distinct from transport-native MCP/A2A task responses.",
   "type": "object",
   "allOf": [
     {

--- a/static/schemas/source/protocol/get-task-status-response.json
+++ b/static/schemas/source/protocol/get-task-status-response.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/protocol/get-task-status-response.json",
+  "title": "Get Task Status Response",
+  "description": "Response from the get_task_status AdCP tool containing task status, task metadata, and optional conversation history or terminal result payload.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/schemas/core/version-envelope.json"
+    },
+    {
+      "$ref": "/schemas/core/protocol-envelope.json"
+    }
+  ],
+  "properties": {
+    "task_id": {
+      "type": "string",
+      "description": "Unique identifier for this task",
+      "x-entity": "task"
+    },
+    "task_type": {
+      "$ref": "/schemas/enums/task-type.json",
+      "description": "Type of AdCP operation"
+    },
+    "protocol": {
+      "$ref": "/schemas/enums/adcp-protocol.json",
+      "description": "AdCP protocol this task belongs to"
+    },
+    "status": {
+      "$ref": "/schemas/enums/task-status.json",
+      "description": "Current task status"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When the task was initially created (ISO 8601)"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When the task was last updated (ISO 8601)"
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When the task completed (ISO 8601, only for completed/failed/canceled tasks)"
+    },
+    "has_webhook": {
+      "type": "boolean",
+      "description": "Whether this task has webhook configuration"
+    },
+    "progress": {
+      "type": "object",
+      "description": "Progress information for long-running tasks",
+      "properties": {
+        "percentage": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Completion percentage (0-100)"
+        },
+        "current_step": {
+          "type": "string",
+          "description": "Current step or phase of the operation"
+        },
+        "total_steps": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Total number of steps in the operation"
+        },
+        "step_number": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Current step number"
+        }
+      },
+      "additionalProperties": true
+    },
+    "error": {
+      "type": "object",
+      "description": "Error details for failed tasks",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Error code for programmatic handling"
+        },
+        "message": {
+          "type": "string",
+          "description": "Detailed error message"
+        },
+        "details": {
+          "type": "object",
+          "description": "Additional error context",
+          "properties": {
+            "protocol": {
+              "$ref": "/schemas/enums/adcp-protocol.json",
+              "description": "AdCP protocol where error occurred"
+            },
+            "operation": {
+              "type": "string",
+              "description": "Specific operation that failed"
+            },
+            "specific_context": {
+              "type": "object",
+              "description": "Domain-specific error context",
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "additionalProperties": true
+    },
+    "history": {
+      "type": "array",
+      "description": "Complete conversation history for this task (only included if include_history was true in request)",
+      "items": {
+        "type": "object",
+        "properties": {
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When this exchange occurred (ISO 8601)"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "request",
+              "response"
+            ],
+            "description": "Whether this was a request from client or response from server"
+          },
+          "data": {
+            "type": "object",
+            "description": "The full request or response payload",
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "timestamp",
+          "type",
+          "data"
+        ],
+        "additionalProperties": true
+      }
+    },
+    "result": {
+      "$ref": "/schemas/core/async-response-data.json",
+      "description": "Task-specific completion payload. Present when status is 'completed' and include_result was true in the request; absent otherwise. For failed tasks, use the error field instead. Uses the same anyOf union as the push-notification webhook result field."
+    },
+    "context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": [
+    "task_id",
+    "task_type",
+    "protocol",
+    "status",
+    "created_at",
+    "updated_at"
+  ],
+  "additionalProperties": true
+}

--- a/static/schemas/source/protocol/list-tasks-request.json
+++ b/static/schemas/source/protocol/list-tasks-request.json
@@ -1,0 +1,184 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/protocol/list-tasks-request.json",
+  "title": "List Tasks Request",
+  "description": "Request parameters for the list_tasks AdCP tool. Lists and filters async tasks across AdCP protocols for state reconciliation.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/schemas/core/version-envelope.json"
+    }
+  ],
+  "properties": {
+    "filters": {
+      "type": "object",
+      "description": "Filter criteria for querying tasks",
+      "properties": {
+        "protocol": {
+          "$ref": "/schemas/enums/adcp-protocol.json",
+          "description": "Filter by single AdCP protocol"
+        },
+        "protocols": {
+          "type": "array",
+          "description": "Filter by multiple AdCP protocols",
+          "items": {
+            "$ref": "/schemas/enums/adcp-protocol.json"
+          },
+          "minItems": 1
+        },
+        "status": {
+          "$ref": "/schemas/enums/task-status.json",
+          "description": "Filter by single task status"
+        },
+        "statuses": {
+          "type": "array",
+          "description": "Filter by multiple task statuses",
+          "items": {
+            "$ref": "/schemas/enums/task-status.json"
+          },
+          "minItems": 1
+        },
+        "task_type": {
+          "$ref": "/schemas/enums/task-type.json",
+          "description": "Filter by single task type"
+        },
+        "task_types": {
+          "type": "array",
+          "description": "Filter by multiple task types",
+          "items": {
+            "$ref": "/schemas/enums/task-type.json"
+          },
+          "minItems": 1
+        },
+        "created_after": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Filter tasks created after this date (ISO 8601)"
+        },
+        "created_before": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Filter tasks created before this date (ISO 8601)"
+        },
+        "updated_after": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Filter tasks last updated after this date (ISO 8601)"
+        },
+        "updated_before": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Filter tasks last updated before this date (ISO 8601)"
+        },
+        "task_ids": {
+          "type": "array",
+          "description": "Filter by specific task IDs",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "maxItems": 100
+        },
+        "context_contains": {
+          "type": "string",
+          "description": "Filter tasks where context contains this text (searches media_buy_id, signal_id, etc.)"
+        },
+        "has_webhook": {
+          "type": "boolean",
+          "description": "Filter tasks that have webhook configuration when true"
+        }
+      },
+      "additionalProperties": true
+    },
+    "sort": {
+      "type": "object",
+      "description": "Sorting parameters",
+      "properties": {
+        "field": {
+          "type": "string",
+          "enum": [
+            "created_at",
+            "updated_at",
+            "status",
+            "task_type",
+            "protocol"
+          ],
+          "default": "created_at",
+          "description": "Field to sort by"
+        },
+        "direction": {
+          "$ref": "/schemas/enums/sort-direction.json",
+          "default": "desc",
+          "description": "Sort direction"
+        }
+      },
+      "additionalProperties": true
+    },
+    "pagination": {
+      "$ref": "/schemas/core/pagination-request.json"
+    },
+    "include_history": {
+      "type": "boolean",
+      "default": false,
+      "description": "Include full conversation history for each task (may significantly increase response size)"
+    },
+    "context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "additionalProperties": true,
+  "examples": [
+    {
+      "description": "List all pending tasks across protocols",
+      "data": {
+        "filters": {
+          "statuses": [
+            "submitted",
+            "working",
+            "input-required"
+          ]
+        }
+      }
+    },
+    {
+      "description": "Find media-buy tasks requiring attention",
+      "data": {
+        "filters": {
+          "protocol": "media-buy",
+          "statuses": [
+            "input-required",
+            "failed"
+          ]
+        },
+        "sort": {
+          "field": "updated_at",
+          "direction": "asc"
+        }
+      }
+    },
+    {
+      "description": "Recent signal operations",
+      "data": {
+        "filters": {
+          "protocol": "signals",
+          "created_after": "2025-01-01T00:00:00Z"
+        },
+        "pagination": {
+          "max_results": 20
+        }
+      }
+    },
+    {
+      "description": "State reconciliation for specific campaign",
+      "data": {
+        "filters": {
+          "context_contains": "acme_q1_2025"
+        },
+        "include_history": true
+      }
+    }
+  ]
+}

--- a/static/schemas/source/protocol/list-tasks-request.json
+++ b/static/schemas/source/protocol/list-tasks-request.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/protocol/list-tasks-request.json",
   "title": "List Tasks Request",
-  "description": "Request parameters for the list_tasks AdCP tool. Lists and filters async tasks across AdCP protocols for state reconciliation.",
+  "description": "Request parameters for the list_tasks AdCP tool. This is a 3.x protocol-namespace alias for the legacy AdCP tasks/list reconciliation surface, not a transport-native MCP/A2A tasks/* method. It lists and filters AdCP application-layer async tasks for state reconciliation while preserving the legacy 3.x payload shape.",
   "type": "object",
   "allOf": [
     {

--- a/static/schemas/source/protocol/list-tasks-response.json
+++ b/static/schemas/source/protocol/list-tasks-response.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/protocol/list-tasks-response.json",
+  "title": "List Tasks Response",
+  "description": "Response from the list_tasks AdCP tool with filtered task results and state reconciliation data across AdCP protocols.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/schemas/core/version-envelope.json"
+    },
+    {
+      "$ref": "/schemas/core/protocol-envelope.json"
+    }
+  ],
+  "properties": {
+    "query_summary": {
+      "type": "object",
+      "description": "Summary of the query that was executed",
+      "properties": {
+        "total_matching": {
+          "type": "integer",
+          "description": "Total number of tasks matching filters (across all pages)",
+          "minimum": 0
+        },
+        "returned": {
+          "type": "integer",
+          "description": "Number of tasks returned in this response",
+          "minimum": 0
+        },
+        "domain_breakdown": {
+          "type": "object",
+          "description": "Count of tasks by domain",
+          "properties": {
+            "media-buy": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Number of media-buy tasks in results"
+            },
+            "signals": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Number of signals tasks in results"
+            }
+          },
+          "additionalProperties": true
+        },
+        "status_breakdown": {
+          "type": "object",
+          "description": "Count of tasks by status",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "filters_applied": {
+          "type": "array",
+          "description": "List of filters that were applied to the query",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sort_applied": {
+          "type": "object",
+          "description": "Sort order that was applied",
+          "properties": {
+            "field": {
+              "type": "string"
+            },
+            "direction": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
+          },
+          "required": [
+            "field",
+            "direction"
+          ],
+          "additionalProperties": true
+        }
+      },
+      "required": [],
+      "additionalProperties": true
+    },
+    "tasks": {
+      "type": "array",
+      "description": "Array of tasks matching the query criteria",
+      "items": {
+        "type": "object",
+        "properties": {
+          "task_id": {
+            "type": "string",
+            "description": "Unique identifier for this task",
+            "x-entity": "task"
+          },
+          "task_type": {
+            "$ref": "/schemas/enums/task-type.json",
+            "description": "Type of AdCP operation"
+          },
+          "domain": {
+            "type": "string",
+            "description": "AdCP domain this task belongs to",
+            "enum": [
+              "media-buy",
+              "signals"
+            ]
+          },
+          "status": {
+            "$ref": "/schemas/enums/task-status.json",
+            "description": "Current task status"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the task was initially created (ISO 8601)"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the task was last updated (ISO 8601)"
+          },
+          "completed_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the task completed (ISO 8601, only for completed/failed/canceled tasks)"
+          },
+          "has_webhook": {
+            "type": "boolean",
+            "description": "Whether this task has webhook configuration"
+          }
+        },
+        "required": [
+          "task_id",
+          "task_type",
+          "domain",
+          "status",
+          "created_at",
+          "updated_at"
+        ],
+        "additionalProperties": true
+      }
+    },
+    "pagination": {
+      "$ref": "/schemas/core/pagination-response.json"
+    },
+    "context": {
+      "$ref": "/schemas/core/context.json"
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": [
+    "query_summary",
+    "tasks",
+    "pagination"
+  ],
+  "additionalProperties": true
+}

--- a/static/schemas/source/protocol/list-tasks-response.json
+++ b/static/schemas/source/protocol/list-tasks-response.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/protocol/list-tasks-response.json",
   "title": "List Tasks Response",
-  "description": "Response from the list_tasks AdCP tool with filtered task results and state reconciliation data across AdCP protocols.",
+  "description": "Response from the list_tasks AdCP tool, a 3.x protocol-namespace alias for legacy AdCP tasks/list. Contains filtered AdCP application-layer task results and reconciliation data while preserving the legacy 3.x domain field shape; distinct from transport-native MCP/A2A task responses.",
   "type": "object",
   "allOf": [
     {


### PR DESCRIPTION
Adds optional 3.x task-lifecycle aliases, `get_task_status` and `list_tasks`, in the protocol schema namespace while retaining the legacy AdCP `core/tasks-get-*` and `core/tasks-list-*` schemas through 3.x.
Clarifies that AdCP owns the application-layer task lifecycle: `task_id`, polling, webhook completion payloads, and reconciliation are AdCP semantics regardless of whether MCP or A2A transports wrap or stream the response.
MCP Tasks and A2A task/SSE features are transport mechanics; they may deliver an AdCP payload, but a transport-native task reaching `completed` does not by itself mean the AdCP operation completed.
Validation: `npm run build:schemas`, `npm run test:schemas`, `npm run test:composed`, `npm run test:docs-nav`, `npm run test:schema-links`, `npm run test:examples`, `git diff --check`, and pre-push docs validation.
