### PR TITLE
feat(media-buy): add publisher_domain to get_media_buy_delivery by_placement rows

### DIFF
--- a/.changeset/5299-publisher-domain-on-by-placement.md
+++ b/.changeset/5299-publisher-domain-on-by-placement.md
@@ -1,0 +1,16 @@
+---
+"adcontextprotocol": minor
+---
+
+spec(media-buy): add optional `publisher_domain` to `get_media_buy_delivery` `by_placement` rows (closes #5299).
+
+`by_placement` rows carried only `placement_id` and `placement_name`, so a buyer running across multiple publishers through one sales agent could not attribute delivered impressions to a publisher namespace without re-fetching `get_products` and cross-referencing the product's `placements[]` — a round-trip that requires retaining the buy-time catalog and breaks for inline placements.
+
+Changes:
+
+- `static/schemas/source/media-buy/get-media-buy-delivery-response.json` — add an optional `publisher_domain` (with the same domain regex as `core/placement.json`) to `by_placement` row items. It is a flat sibling of the existing `placement_id`/`placement_name` (not a nested PlacementRef — the row already ships those fields flat, so nesting would break consumers). Sellers SHOULD emit it whenever the resolving product placement carries a `publisher_domain` (always true for `kind: publisher_ref`); MAY omit only for `seller_inline` placements in a legacy single-publisher context. Single-valued because a placement resolves within exactly one publisher namespace. While in the block, add the missing `x-entity: "placement"` annotation to `placement_id` for parity with `core/placement.json` and `core/placement-ref.json`.
+- `docs/media-buy/task-reference/get_media_buy_delivery.mdx` — note the optional `publisher_domain` field under "Available dimensions".
+
+Strictly additive — no existing field changes shape, no new required fields. `by_placement` rows are already `additionalProperties: true`, and the obligation is SHOULD-when-known (not a retroactive MUST), so pre-existing single- and multi-publisher reports remain spec-valid.
+
+Package-level publisher attribution on `get_media_buys` (the PackageStatus proposal in #5299's comments) is intentionally out of scope: an ad-network product can span multiple publishers, so a scalar there has an unresolved cardinality question (scalar-absent-when-multi vs. plural). This change covers only the placement grain, where the scalar is sound.

--- a/docs/media-buy/task-reference/get_media_buy_delivery.mdx
+++ b/docs/media-buy/task-reference/get_media_buy_delivery.mdx
@@ -880,6 +880,8 @@ Each dimension accepts optional `limit` (max rows; defaults to 25 for geo, audie
 
 Check `reporting_capabilities` on the product to discover which dimensions are available. Product-level capabilities are authoritative since different products from the same seller may support different breakdowns.
 
+Placement rows MAY also carry an optional `publisher_domain` — the publisher namespace (matching the product placement's `publisher_domain` in `adagents.json`) that `placement_id` resolves to. Sellers SHOULD populate it whenever the placement resolves to a publisher namespace, letting buyers attribute delivered impressions to a publisher for multi-publisher buys without re-fetching the product catalog. It is single-valued because each placement belongs to exactly one publisher namespace.
+
 ### Truncation
 
 Each breakdown array has a sibling boolean flag (e.g., `by_geo_truncated`). When `true`, additional rows exist beyond the returned set. When `false`, the list is complete. Sellers MUST return the truncated flag whenever the corresponding breakdown array is present. Rows are sorted by the requested `sort_by` metric descending.

--- a/static/schemas/source/media-buy/get-media-buy-delivery-response.json
+++ b/static/schemas/source/media-buy/get-media-buy-delivery-response.json
@@ -525,11 +525,17 @@
                             "properties": {
                               "placement_id": {
                                 "type": "string",
-                                "description": "Placement identifier from the product's placements array"
+                                "description": "Placement identifier from the product's placements array",
+                                "x-entity": "placement"
                               },
                               "placement_name": {
                                 "type": "string",
                                 "description": "Human-readable placement name"
+                              },
+                              "publisher_domain": {
+                                "type": "string",
+                                "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$",
+                                "description": "Canonical publisher domain whose adagents.json namespace this placement belongs to, matching the `publisher_domain` on the product's `placements[]` entry that `placement_id` resolves to (see core/placement.json). Lets buyers attribute delivered impressions to a publisher namespace without re-fetching the product catalog — the common case for multi-publisher buys through a single sales agent. Sellers SHOULD emit it whenever the resolving product placement carries a publisher_domain (always true for `kind: publisher_ref`); sellers MAY omit it only for `seller_inline` placements in a legacy single-publisher context where the seller agent's own domain is the namespace. Single-valued: a placement resolves within exactly one publisher namespace (package-level attribution, where an ad-network product can span publishers, is a separate concern)."
                               }
                             },
                             "required": [


### PR DESCRIPTION
Closes #5299.

## Problem

`get_media_buy_delivery` `by_placement` rows carried only `placement_id` and `placement_name`. A buyer running across multiple publishers through one sales agent could not attribute delivered impressions to a publisher namespace without re-fetching `get_products` and cross-referencing the product's `placements[]` — a round-trip that requires retaining the buy-time catalog and breaks entirely for inline placements.

## Change

Add an **optional** `publisher_domain` to `by_placement` row items.

- **Flat sibling** of `placement_id`/`placement_name` — *not* a nested `PlacementRef`. The row already ships those two fields flat, so nesting `placement_id` under a ref would break the row-level `required:[placement_id]` contract and every consumer's `row.placement_id` read path. `core/placement.json` already models `publisher_domain` as a flat sibling of `placement_id`, so this matches the protocol's own canonical shape.
- Same **domain regex** as `core/placement.json`.
- **SHOULD-when-known, keyed to the resolving product placement's kind**: sellers SHOULD emit it whenever the product placement carries a `publisher_domain` (always true for `kind: publisher_ref`); MAY omit only for `seller_inline` placements in a legacy single-publisher context. Deliberately **not** a retroactive MUST — a MUST keyed to "spans multiple publishers" would reclassify already-valid reports as non-conformant and the seller can't self-assess a buyer-frame ambiguity condition at emit time. SHOULD-when-known keeps the `minor` bump honestly non-breaking and matches the rule `core/placement-ref.json` already uses for new senders.
- **Single-valued**: a placement resolves within exactly one publisher namespace.
- Also adds the missing **`x-entity: "placement"`** annotation to `placement_id` for parity with `core/placement.json` and `core/placement-ref.json`.

## Out of scope (intentional)

The PackageStatus / `get_media_buys` `publisher_domain` proposed in #5299's comments is **not** included: an ad-network product can span multiple `publisher_properties[]`, so a scalar there has an unresolved cardinality question (scalar-absent-when-multi vs. plural). This PR covers only the placement grain, where the scalar is sound. The package-level decision can ship separately once that's settled.

## Verification

- `test:json-schema`, `test:schemas`, `test:examples`, `test:composed` (incl. bundled form) all pass.
- Strictly additive: no existing field changes shape, no new required field; `by_placement` rows are already `additionalProperties: true`.
- Changeset: `minor` (closes #5299).

---

@sangilish — you volunteered to take this `by_placement` slice on the issue. This branch implements exactly that scope (and intentionally leaves PackageStatus out, per the unresolved scalar-vs-plural decision). Happy to hand it over or close this in favor of yours — didn't mean to step on it; flagging so we don't double-work.
