### PR TITLE
fix(training-agent): wire sync_governance onto /sales tenant

### DIFF
--- a/.changeset/sync-governance-sales-tenant.md
+++ b/.changeset/sync-governance-sales-tenant.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Wire `sync_governance` onto the reference agent's `/sales` (`media_buy_seller`) tenant. Every media_buy_seller specialism (sales-guaranteed, sales-non-guaranteed, sales-broadcast-tv, sales-catalog-driven, sales-social, governance-aware-seller) lists `sync_governance` in `required_tools` and calls it against `/sales`, but the tool was only registered on `/signals` — so the "Register governance agents" step failed with `MCP error -32602: Tool sync_governance not found`. The handler is tenant-agnostic; this registers it via `customTools` on `/sales` (mirroring `/signals`) and updates the tool catalog so the drift test reflects both tenants.

--- a/server/src/training-agent/tenants/sales.ts
+++ b/server/src/training-agent/tenants/sales.ts
@@ -5,6 +5,7 @@
  * call sales-track tools at this URL; signals tools live on /signals.
  */
 
+import { z } from 'zod';
 import type { TenantConfig } from '@adcp/sdk/server';
 import { TrainingSalesPlatform } from '../v6-sales-platform.js';
 import { getTenantSigningMaterial } from './signing.js';
@@ -13,9 +14,38 @@ import { listAccountsTool } from './account-tools.js';
 import { reportUsageTool } from './report-usage-tool.js';
 import { validateInputTool } from './validate-input-tool.js';
 import { buildCreativeTool, previewCreativeTool } from './creative-tools.js';
+import { customToolFor } from './custom-tool-helper.js';
+import { handleSyncGovernance } from '../account-handlers.js';
 import type { TrainingContext } from '../types.js';
 
 const TENANT_ID = 'sales';
+
+// sync_governance rides opts.customTools (same merge seam as /signals) until
+// the SDK promotes it to a first-class AccountStore method. Every media_buy_seller
+// specialism (sales-guaranteed, sales-non-guaranteed, sales-broadcast-tv,
+// sales-catalog-driven, sales-social, governance-aware-seller) registers a
+// governance agent on the account before spend moves, then consults it via
+// check_governance during the media buy lifecycle.
+const ACCOUNT_REF = z.object({
+  account_id: z.string().optional(),
+  brand: z.object({ domain: z.string().optional() }).passthrough().optional(),
+  operator: z.string().optional(),
+}).passthrough();
+
+const SYNC_GOVERNANCE_SCHEMA = {
+  accounts: z.array(z.object({
+    account: ACCOUNT_REF,
+    governance_agents: z.array(z.object({
+      url: z.string(),
+      authentication: z.object({
+        schemes: z.array(z.string()),
+        credentials: z.string(),
+      }),
+    })).min(1),
+  })),
+  idempotency_key: z.string().optional(),
+  context: z.any().optional(),
+};
 
 export function buildSalesTenantConfig(host: string, options: { storyboardCompat?: TrainingContext['storyboardCompat'] } = {}): {
   tenantId: string;
@@ -34,7 +64,18 @@ export function buildSalesTenantConfig(host: string, options: { storyboardCompat
         customTools: {
           list_accounts: listAccountsTool(options.storyboardCompat),
           report_usage: reportUsageTool({ creativeBillsThroughAdcp: false }),
+          // sync_governance is a 3.1+ account task. The released 3.0.x sales
+          // scenarios predate it and gracefully skip the step when the tool is
+          // absent; advertising it under 3.0-compat makes those steps execute
+          // and fail the older response schema. Gate it off 3.0 like the
+          // creative tools below. (/signals keeps it across versions.)
           ...(options.storyboardCompat?.version === '3.0' ? {} : {
+            sync_governance: customToolFor(
+              'sync_governance',
+              'Register governance agent endpoints on accounts. The seller calls these agents via check_governance during media buy lifecycle events. Uses replace semantics: each call replaces previously synced agents on the specified accounts.',
+              SYNC_GOVERNANCE_SCHEMA,
+              handleSyncGovernance,
+            ),
             build_creative: buildCreativeTool({
               tenantId: TENANT_ID,
               creativeBillsThroughAdcp: false,

--- a/server/src/training-agent/tenants/tool-catalog.ts
+++ b/server/src/training-agent/tenants/tool-catalog.ts
@@ -62,8 +62,10 @@ export const TOOL_CATALOG: Readonly<Record<string, readonly string[]>> = {
   preview_creative: ['sales', 'creative', 'creative-builder'],
   get_creative_delivery: ['creative'],
 
-  // signals — sync_governance rides customTools (governance-aware-seller pattern)
-  sync_governance: ['signals'],
+  // sync_governance rides customTools on both /sales (every media_buy_seller
+  // specialism registers a buyer governance agent before spend moves) and
+  // /signals (signal-marketplace governance-denial pattern).
+  sync_governance: ['sales', 'signals'],
   get_signals: ['signals'],
   activate_signal: ['signals'],
 
@@ -111,12 +113,17 @@ export function toolsForTenant(
   return Object.entries(TOOL_CATALOG)
     .filter(([, tenants]) => tenants.includes(tenantId))
     .map(([tool]) => tool)
-    .filter(tool => !(
-      (tool === 'validate_input' || tool === 'list_transformers')
-      && (
-        options.storyboardCompat?.version === '3.0'
-        || options.adcpVersion?.startsWith('3.0')
-      )
-    ))
+    .filter(tool => {
+      const is30 = options.storyboardCompat?.version === '3.0'
+        || options.adcpVersion?.startsWith('3.0');
+      if (!is30) return true;
+      // 3.0-compat exclusions. validate_input / list_transformers are gated off
+      // on every tenant that serves them. sync_governance is a 3.1+ account task
+      // gated off /sales under 3.0 (the released 3.0.x sales scenarios skip it),
+      // but /signals keeps it across versions.
+      if (tool === 'validate_input' || tool === 'list_transformers') return false;
+      if (tool === 'sync_governance' && tenantId === 'sales') return false;
+      return true;
+    })
     .sort();
 }


### PR DESCRIPTION
Every media_buy_seller specialism lists sync_governance in required_tools and calls it against /sales, but the tool was only registered on /signals, so the 'Register governance agents' compliance step failed with 'MCP error -32602: Tool sync_governance not found'. The handler is tenant-agnostic; register it via customTools on /sales (mirroring /signals) and update the tool catalog so the drift test covers both tenants.