### PR TITLE
Bump AdCP SDK for seeding isolation

### DIFF
--- a/.agents/sdk-shim-ledger.json
+++ b/.agents/sdk-shim-ledger.json
@@ -36,5 +36,22 @@
       "node_modules/@adcp/sdk/dist/lib/types/schemas.generated.js",
       "schemas.generated.js"
     ]
+  },
+  {
+    "id": "creative-transformer-runner-gap-skips",
+    "title": "Creative transformer storyboard step skips for SDK runner gaps",
+    "kind": "storyboard_step_skip",
+    "status": "temporary",
+    "owner": "compliance",
+    "upstream": "adcontextprotocol/adcp-client#2165",
+    "problem": "The manual storyboard runner carries known-failing step skips for creative transformer coverage while the packaged SDK runner lacks the task registry and response-schema support needed to dispatch and grade those steps.",
+    "localBehavior": "Skip only the affected creative_transformers steps in server/tests/manual/run-storyboards.ts so the rest of the storyboard matrix remains useful.",
+    "removalCondition": "Remove when the SDK runner can dispatch list_transformers and validate the build_creative variant response shape without local step skips.",
+    "paths": [
+      "server/tests/manual/run-storyboards.ts"
+    ],
+    "terms": [
+      "TOOL_RESPONSE_SCHEMAS"
+    ]
   }
 ]

--- a/.changeset/adcp-sdk-seeding-isolation.md
+++ b/.changeset/adcp-sdk-seeding-isolation.md
@@ -1,0 +1,10 @@
+---
+---
+
+chore(deps): bump `@adcp/sdk` to `9.0.0-beta.22`
+
+Pulls in the storyboard runner fix for adcontextprotocol/adcp#5247 via
+adcontextprotocol/adcp-client#2156: generated `__controller_seeding__` calls
+now carry a storyboard-scoped `context.correlation_id`, letting sellers isolate
+seeded fixtures per storyboard instead of accumulating state across a full
+suite run.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.1.0-rc.6",
       "dependencies": {
-        "@adcp/sdk": "^8.1.0-beta.21",
+        "@adcp/sdk": "^9.0.0-beta.22",
         "@anthropic-ai/sdk": "^0.98.0",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "8.1.0-beta.21",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-8.1.0-beta.21.tgz",
-      "integrity": "sha512-XPE7aWMdOJN2I1OoDvYH3/wfPw+g/ALfWspSp0jqNAdh9HyjW7dV3/Wb9Fyo0nIxYVMO5FBCg9asl6xd57CJOw==",
+      "version": "9.0.0-beta.22",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-9.0.0-beta.22.tgz",
+      "integrity": "sha512-wYEOojND72K3m6md+7MJPitYrg7T//mGJO26gTG0lodk3yDNpKvE1maGEGJdxjNir5sJ2SjZfZ7Wp75Az3lDng==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "docs:json-field-audit": "node scripts/docs-json-field-audit.cjs"
   },
   "dependencies": {
-    "@adcp/sdk": "^8.1.0-beta.21",
+    "@adcp/sdk": "^9.0.0-beta.22",
     "@anthropic-ai/sdk": "^0.98.0",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -45,7 +45,7 @@ import type {
   BuildCreativeResponse,
   CreativeManifest as AdcpCreativeManifest,
 } from '@adcp/sdk';
-import { CreativeManifestSchema } from '@adcp/sdk/types';
+import { CreativeManifestSchema } from '@adcp/sdk/schemas';
 /** Escape HTML special characters to prevent injection in generated HTML responses. */
 function escapeHtmlAttr(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -33,6 +33,17 @@ const SALES_LEGACY_CAPABILITY_SCENARIOS = [
   'simulate_budget_spend',
 ] as const;
 
+const SALES_THREE_ZERO_COMPLY_SCENARIOS = [
+  ...SALES_LEGACY_CAPABILITY_SCENARIOS,
+  'force_create_media_buy_arm',
+  'force_task_completion',
+  'seed_product',
+  'seed_pricing_option',
+  'seed_creative',
+  'seed_media_buy',
+  'seed_creative_format',
+] as const;
+
 const SALES_CURRENT_SCENARIOS = [
   ...SALES_LEGACY_CAPABILITY_SCENARIOS,
   'force_create_media_buy_arm',
@@ -83,7 +94,7 @@ function apiKeyCredential(req: Request, principal: string): { kind: 'api_key'; k
 
 function salesComplyScenarios(storyboardCompat?: TrainingContext['storyboardCompat']): string[] {
   return storyboardCompat?.version === '3.0'
-    ? [...SALES_LEGACY_CAPABILITY_SCENARIOS]
+    ? [...SALES_THREE_ZERO_COMPLY_SCENARIOS]
     : [...SALES_CURRENT_SCENARIOS];
 }
 
@@ -585,12 +596,16 @@ function projectSalesCapabilities(
       const complianceTesting = structured.compliance_testing && typeof structured.compliance_testing === 'object'
         ? structured.compliance_testing
         : {};
+      const capabilityScenarios = salesCapabilityScenarios(storyboardCompat);
+      const existingCapabilityScenarios = Array.isArray((complianceTesting as { scenarios?: unknown }).scenarios)
+        ? (complianceTesting as { scenarios: unknown[] }).scenarios.filter((s): s is string => typeof s === 'string')
+        : [];
       const scenarios = new Set(
-        Array.isArray((complianceTesting as { scenarios?: unknown }).scenarios)
-          ? (complianceTesting as { scenarios: unknown[] }).scenarios.filter((s): s is string => typeof s === 'string')
-          : [],
+        storyboardCompat?.version === '3.0'
+          ? capabilityScenarios
+          : existingCapabilityScenarios,
       );
-      for (const scenario of salesCapabilityScenarios(storyboardCompat)) {
+      for (const scenario of capabilityScenarios) {
         scenarios.add(scenario);
       }
       structured.compliance_testing = {

--- a/server/src/training-agent/tenants/tenant-smoke.test.ts
+++ b/server/src/training-agent/tenants/tenant-smoke.test.ts
@@ -37,6 +37,17 @@ const SALES_THREE_ZERO_COMPAT_SCENARIOS = [
   'simulate_budget_spend',
 ];
 
+const SALES_THREE_ZERO_COMPLY_SCENARIOS = [
+  ...SALES_THREE_ZERO_COMPAT_SCENARIOS,
+  'force_create_media_buy_arm',
+  'force_task_completion',
+  'seed_product',
+  'seed_pricing_option',
+  'seed_creative',
+  'seed_media_buy',
+  'seed_creative_format',
+];
+
 async function bootServer(options: { storyboardCompat?: TrainingContext['storyboardCompat'] } = {}): Promise<{ baseUrl: string; close: () => Promise<void> }> {
   const { createTrainingAgentRouter } = await import('../index.js');
   const app = express();
@@ -402,6 +413,7 @@ describe('tenant routing smoke', () => {
       };
       const scenarios = capabilitiesBody.result?.structuredContent?.compliance_testing?.scenarios ?? [];
       expect(scenarios).toEqual(expect.arrayContaining(SALES_THREE_ZERO_COMPAT_SCENARIOS));
+      expect(scenarios).not.toContain('seed_product');
       expect(scenarios).not.toContain('seed_measurement_catalog');
       expect(scenarios).not.toContain('query_provenance_audit_observations');
 
@@ -421,7 +433,7 @@ describe('tenant routing smoke', () => {
       const listed = await list.json() as {
         result?: { structuredContent?: { scenarios?: string[] } };
       };
-      expect(listed.result?.structuredContent?.scenarios).toEqual(SALES_THREE_ZERO_COMPAT_SCENARIOS);
+      expect(listed.result?.structuredContent?.scenarios).toEqual(SALES_THREE_ZERO_COMPLY_SCENARIOS);
       expect(listed.result?.structuredContent?.scenarios).not.toContain('seed_measurement_catalog');
 
       const directSeed = await fetch(url, {


### PR DESCRIPTION
## Summary
- Bumps @adcp/sdk to 9.0.0-beta.22 and updates the CreativeManifestSchema import for SDK 9.
- Adds the changeset and SDK shim ledger entry for the remaining creative transformer runner gap.
- Keeps 3.0 sales capabilities schema-safe while allowing comply_test_controller to advertise supported 3.0 seed scenarios for SDK 9 fixture preflight.

## Tests
- npx vitest run server/src/training-agent/tenants/tenant-smoke.test.ts
- npm run typecheck
- npm run test:sdk-shims
- npm run test:storyboards:3.0-compat
- git push pre-push hook: current and 3.0 storyboard matrices passed

Closes #5247