### PR TITLE
fix(db): correct stale catalog planner stats + debounce health-check alerts

### DIFF
--- a/.changeset/fix-catalog-planner-stats.md
+++ b/.changeset/fix-catalog-planner-stats.md
@@ -1,0 +1,10 @@
+---
+"adcontextprotocol": patch
+---
+
+fix(db): correct stale catalog planner statistics and debounce health-check alerts.
+
+`catalog_properties` autoanalyze had never run, leaving the planner statistics frozen near zero (~185 rows) while the table actually held 2.27M. With estimates that wrong, Postgres chose nested-loop/sequential-scan plans sized for a tiny table, so queries that scan the catalog/registry tables (brand enrichment, admin audit, registry reads) ran for tens of seconds.
+
+- Add migration 505: aggressive per-table autovacuum/analyze tuning for `catalog_properties`, `catalog_identifiers`, and `registry_requests` so statistics can never drift that far again, plus a one-time `ANALYZE`.
+- Debounce the `/health` database probe: a single transient connect timeout during a rolling deploy or Postgres failover no longer pages the error channel; alerting escalates only after consecutive failures. The 503 load-balancer response is unchanged.

--- a/server/src/db/migrations/505_catalog_autovacuum_tuning.sql
+++ b/server/src/db/migrations/505_catalog_autovacuum_tuning.sql
@@ -1,0 +1,42 @@
+-- Migration 505: aggressive per-table autovacuum/analyze for high-row catalog tables.
+--
+-- catalog_properties grows via incremental INSERT ... ON CONFLICT upserts to
+-- millions of rows, but with the cluster defaults (analyze_scale_factor 0.1,
+-- vacuum_scale_factor 0.2) autoanalyze does not fire until ~10-20% of the table
+-- has changed — ~227k mods on a 2.27M-row table. In production this let the
+-- planner statistics drift catastrophically: pg_class.reltuples stayed near zero
+-- (~185) while the table actually held 2.27M rows, so the planner chose
+-- nested-loop/seq-scan plans sized for a tiny table and queries that scan these
+-- tables (brand enrichment, catalog/registry reads) took tens of seconds.
+--
+-- Pin a much tighter cadence so statistics can never again fall that far behind.
+-- A fixed threshold (5000) plus a small scale factor keeps analyze tracking the
+-- table without waiting on a percentage of millions of rows. These are storage
+-- parameters (reloptions); setting them is idempotent and online (no rewrite,
+-- no blocking lock). Run a one-time ANALYZE so the corrected stats land
+-- immediately rather than on the next autoanalyze tick.
+
+ALTER TABLE catalog_properties SET (
+  autovacuum_analyze_scale_factor = 0.02,
+  autovacuum_analyze_threshold = 5000,
+  autovacuum_vacuum_scale_factor = 0.05,
+  autovacuum_vacuum_threshold = 5000
+);
+
+ALTER TABLE catalog_identifiers SET (
+  autovacuum_analyze_scale_factor = 0.02,
+  autovacuum_analyze_threshold = 5000,
+  autovacuum_vacuum_scale_factor = 0.05,
+  autovacuum_vacuum_threshold = 5000
+);
+
+ALTER TABLE registry_requests SET (
+  autovacuum_analyze_scale_factor = 0.02,
+  autovacuum_analyze_threshold = 5000,
+  autovacuum_vacuum_scale_factor = 0.05,
+  autovacuum_vacuum_threshold = 5000
+);
+
+ANALYZE catalog_properties;
+ANALYZE catalog_identifiers;
+ANALYZE registry_requests;

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -155,6 +155,20 @@ const __dirname = path.dirname(__filename);
 const logger = createLogger('http-server');
 
 /**
+ * Consecutive failed DB health probes on this machine. A single transient
+ * connect timeout — common during a rolling deploy or a Managed Postgres
+ * failover, when the direct endpoint briefly stops accepting connections —
+ * should not page #admin-errors. We only escalate (Slack + error-level log)
+ * once the database has been unreachable across HEALTH_DB_ALERT_THRESHOLD
+ * consecutive probes. At Fly's 15s probe interval that is ~45s of sustained
+ * unreachability, which is a real outage rather than deploy-window noise.
+ * The 503 response is unaffected: every failed probe still pulls the machine
+ * out of the load balancer immediately.
+ */
+let consecutiveDbHealthFailures = 0;
+const HEALTH_DB_ALERT_THRESHOLD = 3;
+
+/**
  * Validate slug format and check against reserved keywords
  */
 function isValidSlug(slug: string): boolean {
@@ -2243,15 +2257,32 @@ export class HTTPServer {
         // succeed even when the pool is fully occupied under load.
         await healthCheck(5000);
         checks.database = true;
+        consecutiveDbHealthFailures = 0;
       } catch (dbErr) {
         checks.database = false;
         const errMsg = dbErr instanceof Error ? dbErr.message : String(dbErr);
-        logger.error({ err: dbErr }, 'Database health check failed');
-        notifySystemError({
-          source: 'health-check',
-          errorMessage: `Database health check failed: ${errMsg}`,
-        });
+        consecutiveDbHealthFailures++;
         dbError = errMsg;
+
+        // Debounce alerting: a single transient connect timeout during a
+        // rolling deploy or Postgres failover is not an outage. Escalate to
+        // Slack (and error-level logs, which PostHog forwards as alerts) only
+        // after the DB has been unreachable across several consecutive probes.
+        if (consecutiveDbHealthFailures >= HEALTH_DB_ALERT_THRESHOLD) {
+          logger.error(
+            { err: dbErr, consecutiveFailures: consecutiveDbHealthFailures },
+            'Database health check failed',
+          );
+          notifySystemError({
+            source: 'health-check',
+            errorMessage: `Database health check failed (${consecutiveDbHealthFailures} consecutive): ${errMsg}`,
+          });
+        } else {
+          logger.warn(
+            { err: dbErr, consecutiveFailures: consecutiveDbHealthFailures },
+            'Database health check failed (transient, not yet alerting)',
+          );
+        }
       }
 
       checks.addie = isAddieBoltReady();


### PR DESCRIPTION
## Summary

Production database queries on the catalog/registry tables were running for tens of seconds. Root cause: **stale query-planner statistics**, not capacity.

`catalog_properties` autoanalyze had **never run**, so `pg_class.reltuples` stayed frozen near zero (~185 rows) while the table actually holds **2.27M rows** (`registry_requests`: planner thought 7.4k, actually 362k). With estimates that wrong, Postgres chose nested-loop / sequential-scan plans sized for a tiny table — fine on 185 rows, catastrophic on 2.3M. This made the heavy endpoints (brand enrichment, admin audit, registry reads) slow.

## Changes

- **`505_catalog_autovacuum_tuning.sql`** — per-table autovacuum/analyze tuning (`autovacuum_analyze_scale_factor=0.02`, `threshold=5000`, etc.) on `catalog_properties`, `catalog_identifiers`, and `registry_requests` so planner stats can never drift that far again, plus a one-time `ANALYZE`. Storage-param changes are online/non-blocking; `ANALYZE` (not `VACUUM`) keeps the migration transaction-safe.
- **`http.ts`** — debounce the `/health` DB probe. A single transient connect timeout during a rolling deploy or Postgres failover no longer pages `#admin-errors`; alerting escalates only after consecutive failures. The 503 load-balancer response is unchanged.

## Operational note

The corrective `VACUUM (ANALYZE)` and the per-table autovacuum settings were **already applied live** to the production Managed Postgres cluster while diagnosing (verified: planner now estimates 2,274,834 rows for `catalog_properties`). This migration persists those settings in code so they survive and apply to any rebuilt database — it is idempotent against the current live state.

## Testing

- `npm run typecheck` — passes
- `tsc --project server/tsconfig.json` build — passes
- Planner fix verified directly: `EXPLAIN` row estimate corrected from 185 → 2,274,834.
- Public page latency measured healthy server-side (homepage p50 71ms / p95 108ms over 30 reqs); the slowness was isolated to the query-heavy paths the stale stats mis-planned.
