### PR TITLE
fix: resolve release-blocking storyboard drift

### DIFF
--- a/.changeset/hosted-rc-target-tests.md
+++ b/.changeset/hosted-rc-target-tests.md
@@ -1,0 +1,4 @@
+---
+---
+
+Keep hosted compliance target tests stable across prerelease bumps by asserting the resolved exact RC version rather than assuming the moving `3.1-rc` alias points at a fixed release candidate.

--- a/.changeset/storyboard-release-blocker-fixes.md
+++ b/.changeset/storyboard-release-blocker-fixes.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix release-blocking storyboard drift: creative lifecycle now verifies that `list_creatives` returns the creative synced earlier, stateful creative account requests declare sandbox mode, and catalog-dependent media-buy/governance storyboards use discovered or fixture-backed product and pricing IDs instead of stale hardcoded identifiers.

--- a/server/tests/unit/storyboards.test.ts
+++ b/server/tests/unit/storyboards.test.ts
@@ -243,18 +243,20 @@ describe('wrapper contract', () => {
     expect(selectCanonicalHostedComplianceTargetForSupportedVersions(['3.0']).requested).toBe('3.0');
     expect(selectCanonicalHostedComplianceTargetForSupportedVersions(['3.0', '3.1-rc.6']).requested).toBe('3.0');
     expect(selectCanonicalHostedComplianceTargetForSupportedVersions(['3.1']).requested).toBe('3.1');
-    expect(selectCanonicalHostedComplianceTargetForSupportedVersions(['3.1-rc.6']).requested).toBe('3.1-rc');
+    const rc6Target = selectCanonicalHostedComplianceTargetForSupportedVersions(['3.1-rc.6']);
+    expect(rc6Target.version).toBe('3.1.0-rc.6');
   });
 
   it('requires agents to advertise non-3.0 hosted targets before selecting them', () => {
     const stableTarget = hostedComplianceTarget('3.1');
     const rcTarget = hostedComplianceTarget('3.1-rc');
+    const latestRcWireVersion = rcTarget.version.replace(/^([0-9]+\.[0-9]+)\.0-/, '$1-');
     expect(agentAdvertisesHostedComplianceTarget(['3.0'], stableTarget)).toBe(false);
     expect(agentAdvertisesHostedComplianceTarget(['3.1'], stableTarget)).toBe(true);
     expect(agentAdvertisesHostedComplianceTarget(['3.1-rc.6'], stableTarget)).toBe(false);
     expect(agentAdvertisesHostedComplianceTarget(['3.0'], rcTarget)).toBe(false);
     expect(agentAdvertisesHostedComplianceTarget(undefined, rcTarget)).toBe(false);
-    expect(agentAdvertisesHostedComplianceTarget(['3.0', '3.1-rc.6'], rcTarget)).toBe(true);
+    expect(agentAdvertisesHostedComplianceTarget(['3.0', latestRcWireVersion], rcTarget)).toBe(true);
   });
 
   it('does not treat an unconfirmed fallback target as badge eligible', () => {

--- a/static/compliance/source/protocols/creative/index.yaml
+++ b/static/compliance/source/protocols/creative/index.yaml
@@ -158,6 +158,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
+            sandbox: true
           creatives:
             - creative_id: "display_trail_pro_300x250"
               name: "Trail Pro 3000 - Display 300x250"
@@ -174,6 +175,9 @@ phases:
           idempotency_key: "$generate:uuid_v4#creative_lifecycle_sync_multiple_sync_creatives"
           context:
             correlation_id: "creative_lifecycle--sync_creatives"
+        context_outputs:
+          - name: synced_creative_id
+            path: "creatives[0].creative_id"
         validations:
           - check: response_schema
             description: "Response matches sync-creatives-response.json schema"
@@ -219,6 +223,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
+            sandbox: true
 
           context:
             correlation_id: "creative_lifecycle--list_all"
@@ -236,6 +241,10 @@ phases:
             path: "context.correlation_id"
             value: "creative_lifecycle--list_all"
             description: "Context correlation_id returned unchanged"
+          - check: field_equals_context
+            path: "creatives[0].creative_id"
+            context_key: "synced_creative_id"
+            description: "list_creatives returns the creative synced earlier"
       - id: list_filtered
         title: "List creatives filtered by format"
         narrative: |
@@ -257,6 +266,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
+            sandbox: true
           filters:
             format_ids:
               - agent_url: "https://your-platform.example.com"
@@ -278,6 +288,10 @@ phases:
             path: "context.correlation_id"
             value: "creative_lifecycle--list_filtered"
             description: "Context correlation_id returned unchanged"
+          - check: field_equals_context
+            path: "creatives[0].creative_id"
+            context_key: "synced_creative_id"
+            description: "Filtered list_creatives returns the display creative synced earlier"
   - id: build_and_preview
     title: "Preview display creative"
     narrative: |
@@ -308,6 +322,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
+            sandbox: true
           request_type: "single"
           creative_manifest:
             creative_id: "display_trail_pro_300x250"

--- a/static/compliance/source/protocols/governance/index.yaml
+++ b/static/compliance/source/protocols/governance/index.yaml
@@ -325,6 +325,15 @@ phases:
 
           context:
             correlation_id: "media_buy_governance_escalation--get_products_brief"
+        context_outputs:
+          - name: product_1_id
+            path: "products[0].product_id"
+          - name: pricing_option_1_id
+            path: "products[0].pricing_options[0].pricing_option_id"
+          - name: product_2_id
+            path: "products[1].product_id"
+          - name: pricing_option_2_id
+            path: "products[1].pricing_options[0].pricing_option_id"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -396,12 +405,12 @@ phases:
             start_time: "2027-01-01T00:00:00Z"
             end_time: "2027-03-31T23:59:59Z"
             packages:
-              - product_id: "sports_ctv_q2"
+              - product_id: "$context.product_1_id"
                 budget: 30000
-                pricing_option_id: "cpm_standard"
-              - product_id: "outdoor_video_q2"
+                pricing_option_id: "$context.pricing_option_1_id"
+              - product_id: "$context.product_2_id"
                 budget: 20000
-                pricing_option_id: "cpm_standard"
+                pricing_option_id: "$context.pricing_option_2_id"
 
           context:
             correlation_id: "media_buy_governance_escalation--check_governance_denied"
@@ -471,12 +480,12 @@ phases:
             start_time: "2027-01-01T00:00:00Z"
             end_time: "2027-03-31T23:59:59Z"
             packages:
-              - product_id: "sports_ctv_q2"
+              - product_id: "$context.product_1_id"
                 budget: 30000
-                pricing_option_id: "cpm_standard"
-              - product_id: "outdoor_video_q2"
+                pricing_option_id: "$context.pricing_option_1_id"
+              - product_id: "$context.product_2_id"
                 budget: 20000
-                pricing_option_id: "cpm_standard"
+                pricing_option_id: "$context.pricing_option_2_id"
 
           context:
             correlation_id: "media_buy_governance_escalation--check_governance_approved"
@@ -544,14 +553,14 @@ phases:
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
           packages:
-            - product_id: "sports_ctv_q2"
+            - product_id: "$context.product_1_id"
               budget: 30000
-              pricing_option_id: "cpm_guaranteed"
+              pricing_option_id: "$context.pricing_option_1_id"
               creative_assignments:
                 - creative_id: "video_30s_trail_pro"
-            - product_id: "outdoor_video_q2"
+            - product_id: "$context.product_2_id"
               budget: 20000
-              pricing_option_id: "cpm_standard"
+              pricing_option_id: "$context.pricing_option_2_id"
               creative_assignments:
                 - creative_id: "video_15s_trail_pro"
 

--- a/static/compliance/source/protocols/media-buy/scenarios/delivery_reporting.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/delivery_reporting.yaml
@@ -120,6 +120,19 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
+        context_outputs:
+          - name: product_1_id
+            path: "products[0].product_id"
+          - name: pricing_option_1_id
+            path: "products[0].pricing_options[0].pricing_option_id"
+          - name: product_2_id
+            path: "products[1].product_id"
+          - name: pricing_option_2_id
+            path: "products[1].pricing_options[0].pricing_option_id"
+          - name: product_3_id
+            path: "products[2].product_id"
+          - name: pricing_option_3_id
+            path: "products[2].pricing_options[0].pricing_option_id"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -147,12 +160,12 @@ phases:
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
           packages:
-            - product_id: "outdoor_display_q2"
+            - product_id: "$context.product_1_id"
               budget: 15000
-              pricing_option_id: "cpm_standard"
-            - product_id: "outdoor_video_q2"
+              pricing_option_id: "$context.pricing_option_1_id"
+            - product_id: "$context.product_2_id"
               budget: 10000
-              pricing_option_id: "cpm_standard"
+              pricing_option_id: "$context.pricing_option_2_id"
           idempotency_key: "$generate:uuid_v4#media_buy_seller_delivery_reporting_setup_create_media_buy"
         validations:
           - check: response_schema
@@ -258,9 +271,9 @@ phases:
           start_time: "2026-06-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
           packages:
-            - product_id: "video_viewability_q2"
+            - product_id: "$context.product_3_id"
               budget: 20000
-              pricing_option_id: "vcpm_standard"
+              pricing_option_id: "$context.pricing_option_3_id"
               optimization_goals:
                 - kind: "metric"
                   metric: "viewed_seconds"

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_approved.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_approved.yaml
@@ -174,6 +174,15 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
+        context_outputs:
+          - name: product_1_id
+            path: "products[0].product_id"
+          - name: pricing_option_1_id
+            path: "products[0].pricing_options[0].pricing_option_id"
+          - name: product_2_id
+            path: "products[1].product_id"
+          - name: pricing_option_2_id
+            path: "products[1].pricing_options[0].pricing_option_id"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -202,12 +211,12 @@ phases:
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
           packages:
-            - product_id: "outdoor_display_q2"
+            - product_id: "$context.product_1_id"
               budget: 15000
-              pricing_option_id: "cpm_standard"
-            - product_id: "outdoor_video_q2"
+              pricing_option_id: "$context.pricing_option_1_id"
+            - product_id: "$context.product_2_id"
               budget: 10000
-              pricing_option_id: "cpm_standard"
+              pricing_option_id: "$context.pricing_option_2_id"
           idempotency_key: "$generate:uuid_v4#media_buy_seller_governance_approved_buy_approved_create_media_buy"
         validations:
           - check: response_schema

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_conditions.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_conditions.yaml
@@ -158,6 +158,11 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
+        context_outputs:
+          - name: product_id
+            path: "products[0].product_id"
+          - name: pricing_option_id
+            path: "products[0].pricing_options[0].pricing_option_id"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -190,9 +195,9 @@ phases:
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
           packages:
-            - product_id: "outdoor_ctv_q2"
+            - product_id: "$context.product_id"
               budget: 25000
-              pricing_option_id: "cpm_standard"
+              pricing_option_id: "$context.pricing_option_id"
           idempotency_key: "$generate:uuid_v4#media_buy_seller_governance_conditions_buy_with_conditions_create_media_buy_conditions"
         validations:
           - check: response_schema

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
@@ -151,6 +151,15 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
+        context_outputs:
+          - name: product_1_id
+            path: "products[0].product_id"
+          - name: pricing_option_1_id
+            path: "products[0].pricing_options[0].pricing_option_id"
+          - name: product_2_id
+            path: "products[1].product_id"
+          - name: pricing_option_2_id
+            path: "products[1].pricing_options[0].pricing_option_id"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -192,12 +201,12 @@ phases:
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
           packages:
-            - product_id: "outdoor_display_q2"
+            - product_id: "$context.product_1_id"
               budget: 30000
-              pricing_option_id: "cpm_standard"
-            - product_id: "outdoor_video_q2"
+              pricing_option_id: "$context.pricing_option_1_id"
+            - product_id: "$context.product_2_id"
               budget: 20000
-              pricing_option_id: "cpm_standard"
+              pricing_option_id: "$context.pricing_option_2_id"
         validations:
           - check: error_code
             value: "GOVERNANCE_DENIED"

--- a/static/compliance/source/specialisms/creative-generative/generative-seller.yaml
+++ b/static/compliance/source/specialisms/creative-generative/generative-seller.yaml
@@ -346,6 +346,15 @@ phases:
 
           context:
             correlation_id: "creative_generative--seller--get_products_brief"
+        context_outputs:
+          - name: product_1_id
+            path: "products[0].product_id"
+          - name: pricing_option_1_id
+            path: "products[0].pricing_options[0].pricing_option_id"
+          - name: product_2_id
+            path: "products[1].product_id"
+          - name: pricing_option_2_id
+            path: "products[1].pricing_options[0].pricing_option_id"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -409,12 +418,12 @@ phases:
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
           packages:
-            - product_id: "outdoor_display_q2"
+            - product_id: "$context.product_1_id"
               budget: 30000
-              pricing_option_id: "cpm_guaranteed"
-            - product_id: "outdoor_video_q2"
+              pricing_option_id: "$context.pricing_option_1_id"
+            - product_id: "$context.product_2_id"
               budget: 20000
-              pricing_option_id: "cpm_standard"
+              pricing_option_id: "$context.pricing_option_2_id"
           push_notification_config:
             url: "https://buyer.example/webhooks/adcp"
             authentication:
@@ -428,6 +437,10 @@ phases:
         context_outputs:
           - name: media_buy_id
             path: "media_buy_id"
+          - name: package_1_id
+            path: "packages[0].package_id"
+          - name: package_2_id
+            path: "packages[1].package_id"
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"
@@ -536,9 +549,9 @@ phases:
                         jurisdictions: ["US"]
           assignments:
             - creative_id: "gen_display_summer_sale"
-              package_id: "outdoor_display_q2"
+              package_id: "$context.package_1_id"
             - creative_id: "gen_video_summer_sale"
-              package_id: "outdoor_video_q2"
+              package_id: "$context.package_2_id"
 
           idempotency_key: "$generate:uuid_v4#creative_generative_seller_creative_brief_sync_sync_creatives_brief"
           context:

--- a/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
+++ b/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
@@ -238,7 +238,7 @@ phases:
               operator: "pinnacle-agency.example"
             total_budget: 40000
             packages:
-              - product_id: "sports_ctv_q2"
+              - product_id: "outdoor_display_q2"
                 budget: 20000
               - product_id: "outdoor_video_q2"
                 budget: 20000
@@ -296,9 +296,9 @@ phases:
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
           packages:
-            - product_id: "sports_ctv_q2"
+            - product_id: "outdoor_display_q2"
               budget: 20000
-              pricing_option_id: "cpm_guaranteed"
+              pricing_option_id: "cpm_standard"
             - product_id: "outdoor_video_q2"
               budget: 20000
               pricing_option_id: "cpm_standard"

--- a/static/compliance/source/specialisms/sales-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-guaranteed/index.yaml
@@ -320,6 +320,15 @@ phases:
 
           context:
             correlation_id: "sales_guaranteed--get_products_brief"
+        context_outputs:
+          - name: product_1_id
+            path: "products[0].product_id"
+          - name: pricing_option_1_id
+            path: "products[0].pricing_options[0].pricing_option_id"
+          - name: product_2_id
+            path: "products[1].product_id"
+          - name: pricing_option_2_id
+            path: "products[1].pricing_options[0].pricing_option_id"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -395,14 +404,14 @@ phases:
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
           packages:
-            - product_id: "sports_preroll_q2_guaranteed"
+            - product_id: "$context.product_1_id"
               budget: 30000
-              pricing_option_id: "cpm_guaranteed_fixed"
+              pricing_option_id: "$context.pricing_option_1_id"
               creative_assignments:
                 - creative_id: "video_30s_trail_pro"
-            - product_id: "outdoor_ctv_q2_guaranteed"
+            - product_id: "$context.product_2_id"
               budget: 20000
-              pricing_option_id: "cpm_guaranteed_fixed"
+              pricing_option_id: "$context.pricing_option_2_id"
           push_notification_config:
             url: "https://buyer.example/webhooks/adcp"
             authentication:


### PR DESCRIPTION
## Summary

- stabilize hosted compliance target tests so the moving `3.1-rc` alias no longer assumes a fixed RC wire version
- make catalog-dependent storyboard requests use discovered product/pricing IDs or fixture-backed IDs instead of stale hardcoded products
- strengthen `creative_lifecycle` so it captures the synced creative ID and requires subsequent `list_creatives` calls to return it for the same sandbox account

## Why

The release branch was failing TypeScript build after the hosted `3.1-rc` alias advanced from rc.6 to rc.7, because the unit test asserted the alias mapping instead of the resolved exact target. Separately, production compliance runs can fail permanently when storyboards send hardcoded product IDs that real catalogs do not contain, and the creative lifecycle storyboard did not machine-check the read-after-write behavior its prose required.

Fixes #5281.
Refs #5284.

## Validation

- `npm run test:compliance-source-authority`
- `npm run test:storyboard-sample-request-schema`
- `npm run test:storyboard-context-output-paths`
- `npm run test:storyboard-validations-paths`
- `npm run build:compliance`
- `npx vitest run server/tests/unit/storyboards.test.ts`
- precommit hook: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run typecheck`
- push hook storyboard matrix: current source and 3.0 compatibility, all tenants met floors
