### PR TITLE
docs: require sync_creatives read-after-write visibility

### DIFF
--- a/.changeset/sync-creatives-read-after-write.md
+++ b/.changeset/sync-creatives-read-after-write.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Require creatives accepted by a synchronous `sync_creatives` success response to be immediately visible through `list_creatives` for the same account and authorized caller, while preserving the submitted task envelope for whole-operation async ingestion.

--- a/docs/creative/task-reference/sync_creatives.mdx
+++ b/docs/creative/task-reference/sync_creatives.mdx
@@ -134,6 +134,12 @@ asyncio.run(main())
 
 **Note:** Per-creative async review is surfaced via `creatives[].status` (e.g., `pending_review`) on the synchronous success response. When the *whole* operation is queued (batch ingestion, governance review gating the sync), the response is a submitted envelope with top-level `status: "submitted"` and a `task_id`. See [Async approval workflow](#async-approval-workflow).
 
+## Read-after-write visibility
+
+Creatives accepted via a synchronous `sync_creatives` success response MUST be committed to the creative library before the response is returned. They MUST be immediately visible to subsequent `list_creatives` calls from the same account and authorized caller, including creatives whose review lifecycle status is `processing` or `pending_review`.
+
+Implementations that acknowledge a creative on the synchronous success branch but buffer the library write until a later background commit are not conformant. If the whole sync operation cannot commit before returning, use the submitted task envelope instead; the visibility requirement then applies when the task completes with accepted creatives.
+
 ## Request parameters
 
 | Parameter         | Type       | Required | Description                                                                                                                                                              |


### PR DESCRIPTION
## Summary

- Require synchronous `sync_creatives` success responses to commit accepted creatives before returning.
- Clarify that accepted creatives must be immediately visible through `list_creatives` for the same account and authorized caller, including `processing` and `pending_review` review states.
- Preserve the submitted task envelope path for whole-operation async ingestion.

Fixes #5284.

## Validation

- `git diff --check`
- `npm run test:docs-nav && npm run test:json-schema && npm run test:examples && npm run test:docs-error-handling-copy`
- commit hook: `npm run precommit`
- pre-push hook docs validation, including Mintlify broken-link check
