### PR TITLE
fix(compliance): gate sibling controller-seeded storyboards

### DIFF
--- a/.changeset/controller-gated-pagination-siblings.md
+++ b/.changeset/controller-gated-pagination-siblings.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Align controller-seeded pagination and canonical-format storyboards with the controller load-phase gate so agents without `comply_test_controller` skip cleanly at storyboard scope.

--- a/static/compliance/source/universal/canonical-format-validate-input.yaml
+++ b/static/compliance/source/universal/canonical-format-validate-input.yaml
@@ -9,6 +9,9 @@ required_tools:
   - validate_input
   - comply_test_controller
 
+requires:
+  - controller
+
 narrative: |
   AdCP 3.1 adds `validate_input` so buyers can dry-run a v2 creative
   manifest against canonical formats and product-specific format declarations

--- a/static/compliance/source/universal/get-media-buys-pagination-integrity.yaml
+++ b/static/compliance/source/universal/get-media-buys-pagination-integrity.yaml
@@ -7,6 +7,9 @@ track: core
 required_tools:
   - get_media_buys
 
+requires:
+  - controller
+
 narrative: |
   Every paginated read in AdCP returns a `pagination` envelope satisfying
   the cursor↔has_more invariant: `has_more=true` carries a `cursor`,

--- a/static/compliance/source/universal/pagination-integrity-list-accounts.yaml
+++ b/static/compliance/source/universal/pagination-integrity-list-accounts.yaml
@@ -7,6 +7,9 @@ track: core
 required_tools:
   - list_accounts
 
+requires:
+  - controller
+
 narrative: |
   Pagination is cursor-based across AdCP. Every response carrying a
   `pagination` block satisfies a single invariant: when `has_more` is true the

--- a/static/compliance/source/universal/pagination-integrity.yaml
+++ b/static/compliance/source/universal/pagination-integrity.yaml
@@ -7,6 +7,9 @@ track: core
 required_tools:
   - list_creatives
 
+requires:
+  - controller
+
 narrative: |
   Pagination is cursor-based across AdCP. Every response carrying a
   `pagination` block satisfies a single invariant: when `has_more` is true the


### PR DESCRIPTION
## Summary
- Adds the controller load-phase gate to sibling controller-seeded pagination and canonical-format storyboards.
- Keeps agents that lack `comply_test_controller` from accumulating per-step fixture seeding noise when the storyboard should skip at load scope.
- Follows up on the #5301 / #5328 review thread around controller-gated coverage gaps.

## Tests
- `npm run build:compliance`
- `npm run test:compliance-source-authority`
- `npm run test:pagination-invariant`
- `npx prettier --check static/compliance/source/universal/pagination-integrity.yaml static/compliance/source/universal/pagination-integrity-list-accounts.yaml static/compliance/source/universal/get-media-buys-pagination-integrity.yaml static/compliance/source/universal/canonical-format-validate-input.yaml .changeset/controller-gated-pagination-siblings.md`
- `git diff --check -- static/compliance/source/universal/pagination-integrity.yaml static/compliance/source/universal/pagination-integrity-list-accounts.yaml static/compliance/source/universal/get-media-buys-pagination-integrity.yaml static/compliance/source/universal/canonical-format-validate-input.yaml .changeset/controller-gated-pagination-siblings.md`
- Pre-push hook: unit tests, dynamic-import lint, callApi state-change lint, typecheck, current storyboard matrix, and 3.0.15 compatibility matrix