### PR TITLE
docs: clarify final 3.1 docs status

### DIFF
--- a/.changeset/final-3-1-docs-summary.md
+++ b/.changeset/final-3-1-docs-summary.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs: make the final 3.1 feature set and current rc.7 validation path easier to find from the overview and versions pages.

--- a/dist/docs/3.1.0-rc.7/reference/release-notes.mdx
+++ b/dist/docs/3.1.0-rc.7/reference/release-notes.mdx
@@ -19,6 +19,16 @@ For adoption-oriented framing before the full change list, start with [What's Ne
 
 Additive over 3.0 — every existing brand.json publisher continues to validate unchanged.
 
+### 3.1 feature index
+
+- **Versioning and validation:** release-precision `adcp_version`, exact RC pins, `supported_versions`, envelope echo, and version-scoped badges.
+- **Brand trust:** distributed `brand.json`, `brand_refs[]`, typed brand constraints, authorized-operator scoping, and signed brand-verification responses.
+- **Signals and wholesale feeds:** enriched signal definitions, `SignalRef`, wholesale signal enumeration, product-scoped signal targeting, conditional fetch, `cache_scope`, and feed webhooks.
+- **Creative formats and generation:** canonical `format_kind`, publisher catalogs, hosted audio/video `duration_ms_range`, published-post references, `list_transformers`, fan-out, evaluator ranking, spend controls, and per-output pricing receipts.
+- **Media-buy operations:** dependency impairments, buyer-visible webhook activity, action discovery, proposal cleanup, currency-scoped discovery, sponsored/social placement fields, and SI availability status.
+- **Measurement, billing, and runtime hardening:** vendor-attested goals, reach-window semantics, delivery/usage finality, idempotency on every task, open error-code decoding, auth tightening, webhook operation-id echo, and flat MCP envelope tolerance.
+- **SDK and compliance readiness:** named codegen schemas, async-response refs, open-payload markers, capability-gated storyboards, packaged compliance closure, and release-artifact drift checks.
+
 <Info>
 **Upgrading from 3.0.x?** No code changes required. Schemas remain wire-compatible. SDK consumers pin the AdCP release to `"3.1"` on GA to pick up the new variant and field shapes. The one publisher-visible behavior change: free-text values for `trademarks[].status` or `trademarks[].countries` now validate against the typed enum / ISO 3166-1 alpha-2 — non-conforming values surface as schema errors.
 </Info>
@@ -82,7 +92,7 @@ Modeled signals now have explicit validation hooks: `methodology: "modeled"` and
 
 Product signal targeting also clarifies the broad-feed workflow. Products may set `signal_targeting_allowed: true` and omit inline `signal_targeting_options` instead of duplicating a wholesale signal feed inline. Buyers use `get_signals` for candidate discovery, then confirm product eligibility and composability with `get_products.filters.signal_targeting` or a product-specific `get_products` response before sending `packages[].targeting_overlay.signal_targeting_groups`.
 
-### RC4 release-candidate locks — response signing, proposal lifecycle, signals conformance, and packaged compliance closure
+### Brand signing, proposal lifecycle, signals conformance, and packaged compliance
 
 **Brand designated-task response signing.** `verify_brand_claim` and `verify_brand_claims` success responses now require `signed_response`, a payload-envelope JWS over the canonical task-body response. The envelope binds the response to the designated task, resolved `brand_domain`, responding `agent_url`, caller/request hash, and `iat`/`exp` freshness window. Verifiers resolve the `kid` to a published JWK with `adcp_use: "response-signing"` and reject mismatches between the unsigned response fields and `signed_response.payload.response`. This is ordinary JWS over the JCS-canonicalized payload, not general RFC 9421 transport response signing. See [Brand Protocol § verify_brand_claim](/dist/docs/3.1.0-rc.7/brand-protocol/tasks/verify_brand_claim#trust-model) and [Security § Designated-task response signing](/dist/docs/3.1.0-rc.7/building/by-layer/L1/security#designated-task-response-signing). PR [#5192](https://github.com/adcontextprotocol/adcp/pull/5192).
 
@@ -96,7 +106,7 @@ Product signal targeting also clarifies the broad-feed workflow. Products may se
 
 **Packaged compliance references are closed.** Webhook receiver envelope vectors now live under the versioned compliance tree, and release validation fails if storyboard vector/test-kit references do not resolve inside the packaged compliance bundle or protocol tarball. This keeps public `/compliance/{version}/` artifacts self-contained.
 
-### Late release-candidate locks — canonical formats, badges, and discovery precision
+### Canonical formats, badges, and discovery precision
 
 **Creative-agent canonical build capabilities.** Creative agents declare what they can produce via `creative.supported_formats[]` on `get_adcp_capabilities`. Entries that buyers can target over time SHOULD carry an agent-local stable `capability_id`; buyers use that ID as `target_format_id.id` in `build_creative` when present. This is intentionally separate from media-buy `format_option_id`, which selects a product-local or publisher-catalog format option. The training agent and storyboards verify advertised capability IDs, canonical `format_kind` manifests, unsupported target rejection, and 3.0 compatibility gating. See [Canonical formats](/dist/docs/3.1.0-rc.7/creative/canonical-formats) and [`build_creative`](/dist/docs/3.1.0-rc.7/creative/task-reference/build_creative).
 
@@ -112,7 +122,7 @@ Sellers match `pricing_currencies` against product-level `pricing_options`, prun
 
 **Upstream traffic attestation mode selection.** The upstream-traffic storyboards now lock the normative choice between raw and digest attestation modes so sellers cannot pass by emitting the wrong proof shape for the negotiated mode. See [Compliance catalog](/dist/docs/3.1.0-rc.7/building/verification/compliance-catalog).
 
-### RC7 release-candidate cleanup — hosted audio/video duration ranges
+### Hosted audio/video duration ranges
 
 Hosted `audio_hosted` and `video_hosted` declarations now allow one-sided `duration_ms_range` values. `[null, 60000]` expresses "up to 60 seconds"; `[15000, null]` expresses "at least 15 seconds"; `[null, null]` remains invalid because at least one side must be bounded.
 
@@ -194,7 +204,7 @@ See [Metric lifecycle](/dist/docs/3.1.0-rc.7/media-buy/media-buys/optimization-r
 
 `adcp_major_version` (the 3.0 integer field) and `adcp.major_versions` remain functional through all of 3.x — additive ship, no required changes for 3.0-conformant agents. The full migration table lives in [Versioning & Governance § Migration timeline](/dist/docs/3.1.0-rc.7/reference/versioning#migration-timeline).
 
-**Pin your release.** Every SDK exposes a constructor option for the version pin. Through 3.x, the SDK SHOULD also emit `adcp_major_version` automatically so legacy 3.x sellers that only read the integer keep negotiating correctly. The wire shape is **release-precision only** (`"3.1"`, `"3.1-rc.7"`) — full semver like `"3.1.2"` or `"3.1.0-rc.7"` is invalid on the wire.
+**Pin your release.** Every SDK exposes a constructor option for the version pin. Through 3.x, the SDK SHOULD also emit `adcp_major_version` automatically so legacy 3.x sellers that only read the integer keep negotiating correctly. During RC validation, use the exact advertised prerelease value such as `"3.1-rc.7"`; after GA, use `"3.1"`. The wire shape is **release-precision only** (`"3.1"`, `"3.1-rc.7"`) — full semver like `"3.1.2"` or `"3.1.0-rc.7"` is invalid on the wire.
 
 ```typescript
 // @adcp/sdk (TypeScript)
@@ -202,8 +212,8 @@ import { SingleAgentClient } from "@adcp/sdk";
 
 const client = new SingleAgentClient(
   { agent_uri: "https://sales.example/mcp/", protocol: "mcp" },
-  { adcpVersion: "3.1" },   // emitted on every request as adcp_version
-                            // adcp_major_version: 3 mirror auto-emitted
+  { adcpVersion: "3.1-rc.7" }, // use "3.1" after GA
+                               // adcp_major_version: 3 mirror auto-emitted
 );
 ```
 
@@ -214,8 +224,8 @@ from adcp.types import AgentConfig, Protocol
 
 client = ADCPClient(
     AgentConfig(agent_uri="https://sales.example/mcp/", protocol=Protocol.MCP),
-    adcp_version="3.1",     # emitted on every request as adcp_version
-                            # adcp_major_version: 3 mirror auto-emitted
+    adcp_version="3.1-rc.7",  # use "3.1" after GA
+                              # adcp_major_version: 3 mirror auto-emitted
 )
 ```
 
@@ -516,553 +526,6 @@ For the full per-PR change list, see [CHANGELOG.md § 3.0.2](https://github.com/
 
 ---
 
-## Version 3.0.6
-
-**Status:** Patch release — stable-surface no-op for 3.0-conformant agents
-
-**3.0.6 makes the `GOVERNANCE_DENIED` wire-placement rule discoverable from the error code itself**, reserves the `ctx_metadata` keyword as an adapter-internal round-trip key, expands the SKILL.md guidance for `issues[]` recovery on the calling-agent side, and fixes two storyboard fixture bugs that were rejecting spec-compliant adopters. Wire format unchanged for any 3.0 agent.
-
-<Info>
-**Upgrading from 3.0.5?** No code changes required for 3.0-conformant agents. SDK consumers bump `ADCP_VERSION` to `3.0.6` to pick up the tightened error-code prose, the `ctx_metadata` reservation, and the corrected storyboard fixtures.
-</Info>
-
-### Adopter action
-
-| If you are… | What you need to do |
-|---|---|
-| A 3.0-conformant production agent | Nothing. Stable schemas remain wire-compatible with 3.0.0. |
-| Returning `GOVERNANCE_DENIED` from `acquire_rights` or `creative_approval` | Read the new wire-placement guidance on the error code. The canonical denial shape is the structured rejection arm (`AcquireRightsRejected` / `CreativeRejected`) — `status: "rejected"` + `reason`, **no** `errors[]`, transport markers stay green. The schema's `not: { required: ["errors"] }` clause was already enforcing this; the prose now makes the rule discoverable from the code. |
-| Returning `GOVERNANCE_DENIED` from `create_media_buy` (or any task without a rejection arm) | Continue populating `errors[].code` AND `adcp_error.code` per the two-layer model and flipping transport-level failure markers (HTTP 4xx / MCP `isError: true` / A2A `failed`). The wire-placement guidance distinguishes this Case-2 path from the rejection-arm path. |
-| Building an SDK adapter that wants to round-trip publisher state through AdCP resources | You MAY now use the reserved top-level `ctx_metadata` key on Product / MediaBuy / Package / Creative / AudienceSegment / Signal / RightsGrant. SDKs MUST strip the key before wire egress and SHOULD log a warning when stripping. Buyers never see this field. |
-| Authoring storyboards that capture state from A2A submitted-arm responses | The `task_completion.<inner>` prefix on `context_outputs[].path` is now documented in the storyboard schema. The runner polls `tasks/get` until terminal and resolves the suffix against the completion artifact's `data` — needed for captures like seller-assigned `media_buy_id` on IO-signing flows. Requires runner ≥ adcp-client v6.7. |
-| Running `comply_test_controller` | The visibility rule is now explicitly deployment-scoped, not request-gated. Production deployments MUST NOT expose the tool on any surface (`tools/list`, `compliance_testing` block in `get_adcp_capabilities`, dispatch). Live-mode probes get unknown-tool, not `FORBIDDEN`. |
-
-### `GOVERNANCE_DENIED` / `GOVERNANCE_UNAVAILABLE` wire-placement guidance (#3929, closes the doc-comment item on #3918; companion to #3914)
-
-`error-code.json` defined the two governance codes' semantics but didn't say WHERE in the response they appear. Storyboards interpreted differently — issue #3914 surfaced one mismatch where the brand-rights compliance storyboard expected `expect_error: code: GOVERNANCE_DENIED` even though `acquire_rights` already has a first-class `AcquireRightsRejected` discriminated arm. Adopters returning the spec-correct shape were failing the storyboard.
-
-The `enumDescriptions` for both codes now state placement explicitly:
-
-- **`GOVERNANCE_DENIED`** — structured business outcome, not a system error. **When the task response defines a structured rejection arm**, that arm IS the canonical denial shape: populate `status: "rejected"` + `reason`, do NOT additionally emit the code in `errors[]` or `adcp_error`, and do NOT flip transport-level failure markers. **When the task has no rejection arm**, populate `errors[].code` AND `adcp_error.code` per the two-layer model and DO flip transport markers.
-- **`GOVERNANCE_UNAVAILABLE`** — system error, governance call failed at all. Always populate both layers with the code and flip transport markers. Sellers MUST NOT use a structured rejection arm for unavailability even when the task offers one — the buyer's recovery semantics differ (retry-with-backoff vs. restructure-or-escalate).
-
-The MUST NOT against dual-emission isn't a behavior change — `AcquireRightsRejected` and `CreativeRejected` already declare `not: { required: [errors] }` at the schema layer, so emitting `errors[]` alongside a rejection arm was already a schema violation. The doc-comment makes the rule discoverable from the error code without changing what conformant senders produce.
-
-A parallel storyboard-authoring note in `error-handling.mdx` directs authors to assert on `field_value path: "status" value: "rejected"` rather than `error_code` for tasks that define a rejection arm. The existing `error_code` guidance is correct for tasks without a rejection arm.
-
-### `ctx_metadata` reserved as adapter-internal round-trip key (#3640)
-
-Reserves the top-level key `ctx_metadata` on AdCP resource objects (Product, MediaBuy, Package, Creative, AudienceSegment, Signal, RightsGrant) as a publisher-to-SDK round-trip cache for adapter-internal state. SDKs MUST strip the key before wire egress and MUST emit a warning-level log entry when stripping, so operators can detect accidental collisions with existing adapter code. Buyers never see this field.
-
-The convention is non-binding at the wire level — these resources already declare `additionalProperties: true` so existing payloads remain valid. The reservation locks the keyword name before two SDKs converge on it accidentally and ship divergent semantics. PropertyList and CollectionList are out of scope (`additionalProperties: false`) until a follow-up PR widens those schemas.
-
-### Implementation-dependent `issues[]` fields documented in SKILL.md (#3927 backport)
-
-`skills/call-adcp-agent/SKILL.md` already documented the three required `issues[]` fields (`pointer`, `keyword`, `variants`). 3.0.6 adds the four optional fields a calling agent will encounter when the seller's validator opts into them — `discriminator`, `schemaId`, `allowedValues`, `hint` — with a one-line preface clarifying these are implementation-dependent (not every validator emits them) and an updated recovery order: read `hint` first when present, then `discriminator`, then walk `variants`. Two new rows added to the symptom-fix lookup table for the same fields.
-
-No wire-format change. Pure documentation: shipping these fields is already a valid validator extension; this gives callers a curated path through them.
-
-### Storyboard-schema documents `task_completion.<inner>` prefix (#3955, closes #3950)
-
-The `context_outputs[].path` resolver gained a `task_completion.` prefix in the storyboard runner (`@adcp/sdk` 6.7+) for capturing values that materialize only on the terminal task artifact (e.g., seller-assigned `media_buy_id` on IO-signing flows where `create_media_buy` returns an A2A submitted-arm envelope). 3.0.6 adds the corresponding documentation to the storyboard authoring schema (`static/compliance/source/universal/storyboard-schema.yaml`).
-
-### `comply_test_controller` is deployment-scoped, not request-gated (#3992)
-
-Tightens the visibility rule for `comply_test_controller`: production deployments MUST NOT expose the tool on any surface — neither `tools/list`, nor the `compliance_testing` block in `get_adcp_capabilities`, nor request dispatch. Live-mode probes get unknown-tool (treated as a regular catalog miss), **not** `FORBIDDEN`. The previous prose left enough room that some adopters were emitting `FORBIDDEN` on live-mode dispatch, which is itself an information leak (an attacker probing for the tool can distinguish "not deployed" from "deployed but you can't use it").
-
-### Storyboard fixture fixes
-
-Two compliance-bundle fixture fixes that were causing spec-compliant adopters to fail published storyboards:
-
-- **`inventory_list_targeting`** — the 5 account blocks across this scenario use the brand+operator natural-key variant of `AccountReference` but omitted the `sandbox` flag. Sellers whose `accounts.resolve` has separate code paths for sandbox vs production refs were routing `create_media_buy` and `get_media_buys` through different account-id namespaces, breaking `mediaBuyStore` backfill of `targeting_overlay`. Setting `sandbox: true` on every account block keeps both create and get on the sandbox path. Mirror of [#3989](https://github.com/adcontextprotocol/adcp/pull/3989) on `main`. Follow-up to align the SDK runner's enricher asymmetry tracked at [adcp-client#1487](https://github.com/adcontextprotocol/adcp-client/issues/1487).
-- **`sales_guaranteed/create_media_buy`** — the `context_outputs[0].path` was bare `"media_buy_id"`, which the runner resolved against the immediate submitted-arm response — a step that fails with `capture_path_not_resolvable` and masks downstream phases. Updated to `"task_completion.media_buy_id"` so the runner polls `tasks/get` and captures the seller-issued id from the terminal artifact, per the runner contract introduced in adcp-client#1426. Mirror of [#3990](https://github.com/adcontextprotocol/adcp/pull/3990) on `main`.
-
----
-
-## Version 3.0.5
-
-**Status:** Patch release — stable-surface no-op for 3.0-conformant agents
-
-**3.0.5 unblocks `brand_json_url` adoption on 3.0**, ships an optional storyboard-authoring affordance, and corrects a brand-rights storyboard capture path that was rejecting spec-compliant agents. Wire format unchanged for any 3.0 agent that doesn't claim a new optional surface.
-
-<Info>
-**Upgrading from 3.0.4?** No code changes required for 3.0-conformant agents. SDK consumers bump `ADCP_VERSION` to `3.0.5` to pick up the relaxed `identity` validator and the brand-rights storyboard fix.
-</Info>
-
-### Adopter action
-
-| If you are… | What you need to do |
-|---|---|
-| A 3.0-conformant production agent | Nothing. Stable schemas remain wire-compatible with 3.0.0. |
-| Adopting `identity.brand_json_url` from #3690 on 3.0 | Bump to 3.0.5 (or have your SDK pick it up). 3.0.4 and earlier rejected the field at validation; 3.0.5 accepts it. |
-| Running brand-rights conformance against the published storyboard | Bump SDK to pick up `dist/compliance/3.0.5/specialisms/brand-rights/index.yaml`. Spec-compliant agents that return `rights_id` (per the published `acquire-rights-response.json`) now pass `rights_acquisition` and stop cascade-skipping `rights_enforcement`. |
-| Authoring multi-agent storyboards | You MAY now declare a top-level `default_agent: <key>` so multi-agent runners route cross-domain steps without per-CI-invocation overrides. Single-agent runs ignore the field. |
-
-### `identity.additionalProperties: true` on `get_adcp_capabilities` (#3896, closes Scope3 adoption gap)
-
-The `identity` block on `get-adcp-capabilities-response.json` was schema-closed (`additionalProperties: false`), which was the lone outlier among capability blocks — every peer (`media_buy`, `signals`, `creative`, `brand`, `compliance_testing`, `request_signing`, `webhook_signing`, `measurement`) already had `additionalProperties: true` at the outer level. The closed shape silently contradicted the forward-compat promise made by [#3690](https://github.com/adcontextprotocol/adcp/pull/3690) (`brand_url on get_adcp_capabilities for keys-from-agent-URL discovery`), which explicitly stated that 3.0-pinned implementers could adopt `identity.brand_json_url` without waiting for a schema bump.
-
-Without this relaxation, `@adcp/sdk`'s `createAdcpServer` (default strict-validation mode) rejected any operator response carrying `brand_json_url`, forcing adopters to disable validation entirely (a footgun) or wait for 3.1.
-
-3.0.5 mirrors what `main` already shipped post-#3690: the outer `identity` object opens; the inner blocks (`key_origins`, `compromise_notification`) stay closed where the security weight actually sits. Strictly additive — the closed property list (`per_principal_key_isolation`, `key_origins`, `compromise_notification`) is unchanged; receivers that ignore unknown fields keep working; receivers that look for new identity fields gain forward-compat without waiting for a 3.x bump. Buyers and verifiers SHOULD continue to allowlist known identity fields at read time rather than rely on schema closure for trust decisions.
-
-### Storyboard-level `default_agent` field (#3897, closes #3894)
-
-Optional top-level `default_agent: <key>` on the storyboard authoring schema (`dist/compliance/3.0.5/universal/storyboard-schema.yaml`). The multi-agent storyboard runner ([adcp-client#1066](https://github.com/adcontextprotocol/adcp-client/issues/1066), [#1355](https://github.com/adcontextprotocol/adcp-client/pull/1355)) already accepts `default_agent` via run-options; this change lets storyboard authors encode the topology intent in YAML once instead of re-asserting `--default-agent sales` on every CI invocation. Cross-domain tools (`sync_creatives`, `list_creative_formats`) become deterministic without per-step `agent:` overrides.
-
-Resolution order (runner contract):
-
-1. Step-level `agent:` override.
-2. Specialism-claimant match against the runtime agents map. Multi-claim grades `unrouted_step` (operator-config error); slots 3/4 do not rescue. Zero claimants falls through to slot 3.
-3. Storyboard-level `default_agent` (this field). Set-but-unmatched grades `default_agent_unresolved` — the runner does NOT silently fall through to slot 4, because that would invisibly override the storyboard author's encoded intent.
-4. Run-options `default_agent`. Same set-but-unmatched rule.
-5. Fail-fast — `unrouted_step`.
-
-Single-agent runs ignore the field entirely; existing 3.0.x storyboards keep working unchanged. Mirrors the `provides_state_for` precedent (#3775) for additive storyboard-schema affordances on 3.0.x.
-
-The key shape is a free-form non-empty string keyed by the runtime agents map — the spec does not constrain to the specialism enum because production multi-agent topologies legitimately fan out per-property (`nyt_sales`, `wsj_sales`), per-region (`sales_eu`, `sales_us`), or per-brand-rights-holder. Cross-operator portability is the storyboard author's concern, not the spec's.
-
-### Brand-rights storyboard `acquire_rights` capture fix (#3893, closes #3892)
-
-The `brand_rights/rights_acquisition` storyboard's `acquire_rights` step captured a `context_outputs` field at path `rights_grant_id`, but `brand/acquire-rights-response.json` defines that field as `rights_id` (the `AcquireRightsAcquired` arm). Spec-compliant agents passed `response_schema` validation but failed the capture-and-pass-to-next-step machinery, which then cascade-skipped `rights_enforcement` with `prerequisite_failed`.
-
-3.0.5 corrects the storyboard to read `rights_id` (preserving the storyboard-internal `rights_grant_id` key name so no other steps need updates) and aligns the `expected:` prose to match the published schema (`status: acquired`, not the legacy `status: active`).
-
-Adopters running brand-rights conformance against a spec-compliant agent: bumping your SDK past 3.0.4 should flip the `brand_rights` storyboard from 3/5 scenarios passing to 5/5 with no agent-side changes.
-
-### Release mechanics (#3820)
-
-`forward-merge-3.0.yml`: explicitly push the `forward-merge/3.0.x` branch to origin **before** `peter-evans/create-pull-request@v8` runs. Discovered when 3.0.4's forward-merge ran for real: auto-resolution succeeded, then peter-evans crashed with `fatal: ambiguous argument 'origin/forward-merge/3.0.x': unknown revision`. Last gap in the auto-resolution chain — every subsequent Version Packages cut now auto-creates the forward-merge PR without human intervention.
-
-### Detailed changelog
-
-For the full per-PR change list, see [CHANGELOG.md § 3.0.5](https://github.com/adcontextprotocol/adcp/blob/main/CHANGELOG.md#305).
-
----
-
-## Version 3.0.4
-
-**Status:** Patch release — stable-surface no-op for 3.0-conformant agents
-
-**3.0.4 is the third 3.0.x patch.** Three additive cherry-picks from main, all hand-adapted for the maintenance line: the `manifest.json` + structured `enumMetadata` artifact (so SDKs stop hand-transcribing the spec), a normative `issues[]` array on `core/error.json`, and prose-only tightening of `AUTH_REQUIRED` to call out the retry-storm risk. Wire format unchanged.
-
-<Info>
-**Upgrading from 3.0.3?** No code changes required for 3.0-conformant agents. SDK consumers bump `ADCP_VERSION` to `3.0.4` to pick up `manifest.json` and the new `enumMetadata` block.
-</Info>
-
-### Adopter action
-
-| If you are… | What you need to do |
-|---|---|
-| A 3.0-conformant production agent | Nothing. Stable schemas remain wire-compatible with 3.0.0. |
-| An SDK author | Switch from parsing `Recovery: X` prose out of `enumDescriptions` to consuming the structured `enumMetadata` block. The build-time lint guarantees structured/prose parity, so the prose path can stay as a fallback while you migrate. |
-| An SDK consumer | Bump `ADCP_VERSION` to `3.0.4`. Pick up `/schemas/3.0.4/manifest.json` for one-stop tool/error/specialism enumeration. |
-| Implementing a buyer agent | Read the new `AUTH_REQUIRED` sub-cases in [error-handling.mdx](/dist/docs/3.1.0-rc.7/building/by-layer/L3/error-handling) — the wire code stays the same but you SHOULD NOT auto-retry when credentials were attached and rejected (terminal case). 3.1 will split this into separate enum values via #3739. |
-| Returning multi-field validation errors | Optionally populate `core/error.json`'s new top-level `issues[]` array (each entry: RFC 6901 pointer, message, JSON Schema keyword). Pre-3.1 consumers reading only `field` get the first failure; 3.1+ consumers prefer `issues`. |
-
-### `manifest.json` + structured `enumMetadata` (#3725, #3738)
-
-Two additive artifacts published with every released schema bundle:
-
-1. **`enums/error-code.json` gains an `enumMetadata` block.** Every error code now carries structured `recovery` (`correctable` | `transient` | `terminal`) and `suggestion` fields. SDKs MUST consume this block instead of parsing `Recovery: X` prose out of `enumDescriptions` — a build-time lint enforces structured/prose parity. Closes the root cause of [adcp-client#1135](https://github.com/adcontextprotocol/adcp-client/issues/1135) (17 missing codes, 3 wrong recovery classifications shipped in TS SDK for over a year).
-
-2. **`/schemas/3.0.4/manifest.json`.** Single canonical artifact listing every tool (with `protocol`, `mutating`, `request_schema`, `response_schema`, `async_response_schemas`, `specialisms`), every error code (with `recovery`, `description`, `suggestion`), an `error_code_policy` block (defining `default_unknown_recovery` so SDKs handle non-spec codes correctly), and every storyboard specialism (with `protocol`, `entry_point_tools`, `exercised_tools`). Validates against `manifest.schema.json`. Lets SDKs derive their internal tool/error tables from one place at codegen time.
-
-The 3.0.4 manifest covers exactly the 45 error codes 3.0.x ships (vs. main's 48 — three of main's codes don't exist in 3.0.x's enum and were trimmed during the cherry-pick).
-
-### `core/error.json` — `issues[]` field (#3059, #3562)
-
-Optional top-level `issues` array on the standard error envelope, normalizing what `@adcp/sdk` and prospectively `adcp-go` / `adcp-client-python` already need for multi-field validation rejections.
-
-```json
-{
-  "code": "VALIDATION_ERROR",
-  "message": "Request validation failed",
-  "field": "creatives[0].assets.image",
-  "issues": [
-    {
-      "pointer": "/creatives/0/assets/image",
-      "message": "Required",
-      "keyword": "required"
-    },
-    {
-      "pointer": "/creatives/0/format_id",
-      "message": "Must match pattern",
-      "keyword": "pattern"
-    }
-  ]
-}
-```
-
-Each entry is `{ pointer (RFC 6901), message, keyword, schemaPath? }`. `schemaPath` MAY be omitted in production to avoid fingerprinting `oneOf` branch selection on adversarial payloads.
-
-**Backward compatibility with `field` (singular):** when both are present, sellers SHOULD set `field` to `issues[0].pointer`. Pre-3.1 consumers reading only `field` get the first failure; 3.1+ consumers prefer the top-level `issues`. Sellers MAY mirror `issues[]` into `details.issues` for backward compat with consumers reading from `details`.
-
-### `AUTH_REQUIRED` retry-storm prose (#3730 partial, #3739 backport)
-
-`AUTH_REQUIRED` conflates two operationally distinct cases — credentials missing (genuinely correctable) and credentials presented but rejected (terminal — needs human rotation). A buyer agent treating both as `correctable` will retry-loop on revoked tokens, hammering seller SSO endpoints in a pattern indistinguishable from a brute-force probe.
-
-The 3.1 line splits this into `AUTH_MISSING` and `AUTH_INVALID` (#3739). 3.0.x cannot adopt the split — adding new enum values violates the maintenance line's semver rules. 3.0.4 ships the prose-only backport: the wire code stays `AUTH_REQUIRED` with `recovery: correctable`, but the description and `enumMetadata.suggestion` now spell out the two sub-cases and the SHOULD-NOT-auto-retry rule for the rejected-credential case. SDKs running against 3.0.x sellers can apply the operational distinction at the application layer.
-
-`docs/building/implementation/error-handling.mdx` gets a sub-case callout and an updated example showing how to branch on whether credentials were attached. Closes the 3.0.x portion of #3730; the full split lands in 3.1.0.
-
-### Detailed changelog
-
-For the full per-PR change list, see [CHANGELOG.md § 3.0.4](https://github.com/adcontextprotocol/adcp/blob/main/CHANGELOG.md#304).
-
----
-
-## Version 3.0.3
-
-**Status:** Patch release — additive storyboard schema field, stable-surface no-op for 3.0-conformant agents
-
-**3.0.3 ships the `provides_state_for` storyboard field** so the conformance suite can rescue cascade-skipping when two interchangeable stateful steps live in the same phase. Plus a docs-only fix for the `url_type` enum in channel docs that was emitting a value the published schema already excluded.
-
-<Info>
-**Upgrading from 3.0.2?** No code changes required for 3.0-conformant agents. Storyboard runners on `@adcp/sdk` 6.5.0+ pick up the new field automatically once the cache refreshes against 3.0.3.
-</Info>
-
-### Adopter action
-
-| If you are… | What you need to do |
-|---|---|
-| A 3.0-conformant production agent | Nothing. Stable schemas unchanged. |
-| Authoring storyboards | Optionally use `provides_state_for: <step_id>` on a stateful step to declare it substitutes for a missing peer step's state. Same-phase only; both steps must be `stateful: true`. The build-time lint enforces shape, target validity, statefulness, no self-reference, and no two-step cycles. |
-| Running storyboards via `@adcp/sdk` | Bump to 6.5.0+ to pick up the cascade-rescue runtime. Older SDK versions ignore the field and fall back to the existing `missing_tool` cascade behavior. |
-| A storyboard-authoring docs source (channels) | Replace `"url_type": "tracker"` with `"url_type": "tracker_pixel"` in any examples. The published schema enum already excluded `"tracker"`, so existing valid wire payloads are unaffected — only the prose docs were drifting. |
-
-### `provides_state_for` storyboard field (#3734)
-
-Optional `provides_state_for: <step_id> | <step_id>[]` on a stateful storyboard step declares that this step's pass establishes equivalent state for the named peer step(s) in the same phase. Pairs with the cascade-skip mechanism in `@adcp/sdk` 6.5.0+: when a peer step would otherwise grade `missing_tool` or `missing_test_controller`, the substitute waives the cascade and the runner grades the peer with the new `peer_substituted` skip reason.
-
-**Concrete impact:** explicit-mode social platforms (Snap, Meta, TikTok) intentionally pre-provision advertiser accounts out-of-band — `sync_accounts` is `missing_tool` by design, with `list_accounts` as the canonical alternative. 3.0.3's `sales-social/index.yaml` declares `provides_state_for: sync_accounts` on the `list_accounts` step, letting these adapters graduate from `1/9/0` (8 downstream stateful steps cascade-skipped) to `9/10` against the `sales_social` storyboard once the SDK cache refreshes.
-
-The field is part of the conformance harness, so it ships under the harness-additive patch-eligibility rule. Existing storyboards that don't use it keep their current cascade behavior — pure additive.
-
-Build-time validation (`scripts/lint-storyboard-provides-state-for.cjs`): rule shape, self-reference, unknown target, cross-phase reference (rejected — must be same-phase), target-not-stateful, substitute-not-stateful, and direct-cycle violations all fail loud.
-
-### `runner-output-contract.yaml` — `peer_substituted` skip reason
-
-Companion to `provides_state_for`: when the runner waives a cascade because a same-phase peer substituted for the state contract, it grades the original peer with `skip_result.reason = peer_substituted` and detail `"<this_step_id> state provided by <peer_phase_id>.<peer_step_id>"`. Distinct from `peer_branch_taken` (branch-set routing for mutually exclusive behaviors) and `not_applicable` (coverage gap — agent didn't declare the protocol).
-
-### `url_type: tracker` → `tracker_pixel` (#2986 step 1)
-
-Display, audio, carousels, and DOOH channel docs were emitting `"url_type": "tracker"` in examples — a value the published `url-asset-type.json` enum (`clickthrough` / `tracker_pixel` / `tracker_script`) already excluded. Fixed to `tracker_pixel`. Wire format unchanged; only prose docs were drifting.
-
-### Detailed changelog
-
-For the full per-PR change list, see [CHANGELOG.md § 3.0.3](https://github.com/adcontextprotocol/adcp/blob/main/CHANGELOG.md#303).
-
----
-
-## Version 3.0.2
-
-**Status:** Patch release — additive storyboard check kind + canonical asset-union schema
-
-**3.0.2 ships a new storyboard check kind** that closes a static-analysis gap in `@adcp/sdk`'s drift verifier, plus extracts a shared asset-variant `oneOf` union into its own schema file so codegen tools (notably `json-schema-to-typescript`) stop emitting numbered duplicate types.
-
-<Info>
-**Upgrading from 3.0.1?** No code changes required for 3.0-conformant agents. The check kind is consumed by the conformance runner, not by sellers; the asset-union refactor is a wire-format no-op.
-</Info>
-
-### Adopter action
-
-| If you are… | What you need to do |
-|---|---|
-| A 3.0-conformant production agent | Nothing. Wire format and validation semantics unchanged. |
-| An SDK author running codegen against schemas | Re-run `json-schema-to-typescript` (or your equivalent) to drop the `VASTAsset1`, `DAASTAsset1`, `BriefAsset1`, `CatalogAsset1` numbered duplicates. They were artifacts of the same `oneOf` union being encountered through multiple parent schemas; 3.0.2 references the canonical `core/assets/asset-union.json` from both `creative-asset.json` and `creative-manifest.json`. |
-| Authoring storyboards that assert envelope-level fields | Optionally use the new `envelope_field_present` check kind in place of `field_present` for `protocol-envelope.json` fields like `status`. The new check walks the envelope schema rather than the step's `response_schema_ref`, eliminating the static-analysis `VERIFIER_UNREACHABLE` gap in adcp-client's storyboard-drift verifier. |
-| Running storyboards via `@adcp/sdk` | Bump to the version that lands [adcp-client#1045](https://github.com/adcontextprotocol/adcp-client/pull/1045) for the new check kind. |
-
-### `envelope_field_present` check kind
-
-Storyboard `validations[].check` gains `envelope_field_present` as a peer of `field_present`. Same shape — `path` is RFC 6901-style — but resolves the path against `protocol-envelope.json` rather than the step's `response_schema_ref`. Used in `static/compliance/source/universal/v3-envelope-integrity.yaml` to assert that responses include `status`, where the previous `field_present` check left a `VERIFIER_UNREACHABLE` hole because `status` lives on the envelope, not the per-task response schema.
-
-### Canonical `core/assets/asset-union.json`
-
-The asset-variant `oneOf` union (the discriminated set of `image | video | text | url | vast | daast | ...` shapes) was inlined identically in `creative-asset.json` and `creative-manifest.json`. `json-schema-to-typescript` walking those parent schemas independently emitted `VASTAsset1`, `DAASTAsset1`, `BriefAsset1`, `CatalogAsset1` numbered-duplicate types — invisible at the wire level, irritating in generated code.
-
-3.0.2 promotes the union to `core/assets/asset-union.json` and references it via `$ref` from both parents. Codegen now emits a single `Asset` (or whatever your tool chooses) without the numbered duplicates. Wire format and validation semantics unchanged — pure refactor of the schema reference graph.
-
-### Detailed changelog
-
-For the full per-PR change list, see [CHANGELOG.md § 3.0.2](https://github.com/adcontextprotocol/adcp/blob/main/CHANGELOG.md#302).
-
----
-
-## Version 3.0.6
-
-**Status:** Patch release — stable-surface no-op for 3.0-conformant agents
-
-**3.0.6 makes the `GOVERNANCE_DENIED` wire-placement rule discoverable from the error code itself**, reserves the `ctx_metadata` keyword as an adapter-internal round-trip key, expands the SKILL.md guidance for `issues[]` recovery on the calling-agent side, and fixes two storyboard fixture bugs that were rejecting spec-compliant adopters. Wire format unchanged for any 3.0 agent.
-
-<Info>
-**Upgrading from 3.0.5?** No code changes required for 3.0-conformant agents. SDK consumers bump `ADCP_VERSION` to `3.0.6` to pick up the tightened error-code prose, the `ctx_metadata` reservation, and the corrected storyboard fixtures.
-</Info>
-
-### Adopter action
-
-| If you are… | What you need to do |
-|---|---|
-| A 3.0-conformant production agent | Nothing. Stable schemas remain wire-compatible with 3.0.0. |
-| Returning `GOVERNANCE_DENIED` from `acquire_rights` or `creative_approval` | Read the new wire-placement guidance on the error code. The canonical denial shape is the structured rejection arm (`AcquireRightsRejected` / `CreativeRejected`) — `status: "rejected"` + `reason`, **no** `errors[]`, transport markers stay green. The schema's `not: { required: ["errors"] }` clause was already enforcing this; the prose now makes the rule discoverable from the code. |
-| Returning `GOVERNANCE_DENIED` from `create_media_buy` (or any task without a rejection arm) | Continue populating `errors[].code` AND `adcp_error.code` per the two-layer model and flipping transport-level failure markers (HTTP 4xx / MCP `isError: true` / A2A `failed`). The wire-placement guidance distinguishes this Case-2 path from the rejection-arm path. |
-| Building an SDK adapter that wants to round-trip publisher state through AdCP resources | You MAY now use the reserved top-level `ctx_metadata` key on Product / MediaBuy / Package / Creative / AudienceSegment / Signal / RightsGrant. SDKs MUST strip the key before wire egress and SHOULD log a warning when stripping. Buyers never see this field. |
-| Authoring storyboards that capture state from A2A submitted-arm responses | The `task_completion.<inner>` prefix on `context_outputs[].path` is now documented in the storyboard schema. The runner polls `tasks/get` until terminal and resolves the suffix against the completion artifact's `data` — needed for captures like seller-assigned `media_buy_id` on IO-signing flows. Requires runner ≥ adcp-client v6.7. |
-| Running `comply_test_controller` | The visibility rule is now explicitly deployment-scoped, not request-gated. Production deployments MUST NOT expose the tool on any surface (`tools/list`, `compliance_testing` block in `get_adcp_capabilities`, dispatch). Live-mode probes get unknown-tool, not `FORBIDDEN`. |
-
-### `GOVERNANCE_DENIED` / `GOVERNANCE_UNAVAILABLE` wire-placement guidance (#3929, closes the doc-comment item on #3918; companion to #3914)
-
-`error-code.json` defined the two governance codes' semantics but didn't say WHERE in the response they appear. Storyboards interpreted differently — issue #3914 surfaced one mismatch where the brand-rights compliance storyboard expected `expect_error: code: GOVERNANCE_DENIED` even though `acquire_rights` already has a first-class `AcquireRightsRejected` discriminated arm. Adopters returning the spec-correct shape were failing the storyboard.
-
-The `enumDescriptions` for both codes now state placement explicitly:
-
-- **`GOVERNANCE_DENIED`** — structured business outcome, not a system error. **When the task response defines a structured rejection arm**, that arm IS the canonical denial shape: populate `status: "rejected"` + `reason`, do NOT additionally emit the code in `errors[]` or `adcp_error`, and do NOT flip transport-level failure markers. **When the task has no rejection arm**, populate `errors[].code` AND `adcp_error.code` per the two-layer model and DO flip transport markers.
-- **`GOVERNANCE_UNAVAILABLE`** — system error, governance call failed at all. Always populate both layers with the code and flip transport markers. Sellers MUST NOT use a structured rejection arm for unavailability even when the task offers one — the buyer's recovery semantics differ (retry-with-backoff vs. restructure-or-escalate).
-
-The MUST NOT against dual-emission isn't a behavior change — `AcquireRightsRejected` and `CreativeRejected` already declare `not: { required: [errors] }` at the schema layer, so emitting `errors[]` alongside a rejection arm was already a schema violation. The doc-comment makes the rule discoverable from the error code without changing what conformant senders produce.
-
-A parallel storyboard-authoring note in `error-handling.mdx` directs authors to assert on `field_value path: "status" value: "rejected"` rather than `error_code` for tasks that define a rejection arm. The existing `error_code` guidance is correct for tasks without a rejection arm.
-
-### `ctx_metadata` reserved as adapter-internal round-trip key (#3640)
-
-Reserves the top-level key `ctx_metadata` on AdCP resource objects (Product, MediaBuy, Package, Creative, AudienceSegment, Signal, RightsGrant) as a publisher-to-SDK round-trip cache for adapter-internal state. SDKs MUST strip the key before wire egress and MUST emit a warning-level log entry when stripping, so operators can detect accidental collisions with existing adapter code. Buyers never see this field.
-
-The convention is non-binding at the wire level — these resources already declare `additionalProperties: true` so existing payloads remain valid. The reservation locks the keyword name before two SDKs converge on it accidentally and ship divergent semantics. PropertyList and CollectionList are out of scope (`additionalProperties: false`) until a follow-up PR widens those schemas.
-
-### Implementation-dependent `issues[]` fields documented in SKILL.md (#3927 backport)
-
-`skills/call-adcp-agent/SKILL.md` already documented the three required `issues[]` fields (`pointer`, `keyword`, `variants`). 3.0.6 adds the four optional fields a calling agent will encounter when the seller's validator opts into them — `discriminator`, `schemaId`, `allowedValues`, `hint` — with a one-line preface clarifying these are implementation-dependent (not every validator emits them) and an updated recovery order: read `hint` first when present, then `discriminator`, then walk `variants`. Two new rows added to the symptom-fix lookup table for the same fields.
-
-No wire-format change. Pure documentation: shipping these fields is already a valid validator extension; this gives callers a curated path through them.
-
-### Storyboard-schema documents `task_completion.<inner>` prefix (#3955, closes #3950)
-
-The `context_outputs[].path` resolver gained a `task_completion.` prefix in the storyboard runner (`@adcp/sdk` 6.7+) for capturing values that materialize only on the terminal task artifact (e.g., seller-assigned `media_buy_id` on IO-signing flows where `create_media_buy` returns an A2A submitted-arm envelope). 3.0.6 adds the corresponding documentation to the storyboard authoring schema (`static/compliance/source/universal/storyboard-schema.yaml`).
-
-### `comply_test_controller` is deployment-scoped, not request-gated (#3992)
-
-Tightens the visibility rule for `comply_test_controller`: production deployments MUST NOT expose the tool on any surface — neither `tools/list`, nor the `compliance_testing` block in `get_adcp_capabilities`, nor request dispatch. Live-mode probes get unknown-tool (treated as a regular catalog miss), **not** `FORBIDDEN`. The previous prose left enough room that some adopters were emitting `FORBIDDEN` on live-mode dispatch, which is itself an information leak (an attacker probing for the tool can distinguish "not deployed" from "deployed but you can't use it").
-
-### Storyboard fixture fixes
-
-Two compliance-bundle fixture fixes that were causing spec-compliant adopters to fail published storyboards:
-
-- **`inventory_list_targeting`** — the 5 account blocks across this scenario use the brand+operator natural-key variant of `AccountReference` but omitted the `sandbox` flag. Sellers whose `accounts.resolve` has separate code paths for sandbox vs production refs were routing `create_media_buy` and `get_media_buys` through different account-id namespaces, breaking `mediaBuyStore` backfill of `targeting_overlay`. Setting `sandbox: true` on every account block keeps both create and get on the sandbox path. Mirror of [#3989](https://github.com/adcontextprotocol/adcp/pull/3989) on `main`. Follow-up to align the SDK runner's enricher asymmetry tracked at [adcp-client#1487](https://github.com/adcontextprotocol/adcp-client/issues/1487).
-- **`sales_guaranteed/create_media_buy`** — the `context_outputs[0].path` was bare `"media_buy_id"`, which the runner resolved against the immediate submitted-arm response — a step that fails with `capture_path_not_resolvable` and masks downstream phases. Updated to `"task_completion.media_buy_id"` so the runner polls `tasks/get` and captures the seller-issued id from the terminal artifact, per the runner contract introduced in adcp-client#1426. Mirror of [#3990](https://github.com/adcontextprotocol/adcp/pull/3990) on `main`.
-
----
-
-## Version 3.0.5
-
-**Status:** Patch release — stable-surface no-op for 3.0-conformant agents
-
-**3.0.5 unblocks `brand_json_url` adoption on 3.0**, ships an optional storyboard-authoring affordance, and corrects a brand-rights storyboard capture path that was rejecting spec-compliant agents. Wire format unchanged for any 3.0 agent that doesn't claim a new optional surface.
-
-<Info>
-**Upgrading from 3.0.4?** No code changes required for 3.0-conformant agents. SDK consumers bump `ADCP_VERSION` to `3.0.5` to pick up the relaxed `identity` validator and the brand-rights storyboard fix.
-</Info>
-
-### Adopter action
-
-| If you are… | What you need to do |
-|---|---|
-| A 3.0-conformant production agent | Nothing. Stable schemas remain wire-compatible with 3.0.0. |
-| Adopting `identity.brand_json_url` from #3690 on 3.0 | Bump to 3.0.5 (or have your SDK pick it up). 3.0.4 and earlier rejected the field at validation; 3.0.5 accepts it. |
-| Running brand-rights conformance against the published storyboard | Bump SDK to pick up `dist/compliance/3.0.5/specialisms/brand-rights/index.yaml`. Spec-compliant agents that return `rights_id` (per the published `acquire-rights-response.json`) now pass `rights_acquisition` and stop cascade-skipping `rights_enforcement`. |
-| Authoring multi-agent storyboards | You MAY now declare a top-level `default_agent: <key>` so multi-agent runners route cross-domain steps without per-CI-invocation overrides. Single-agent runs ignore the field. |
-
-### `identity.additionalProperties: true` on `get_adcp_capabilities` (#3896, closes Scope3 adoption gap)
-
-The `identity` block on `get-adcp-capabilities-response.json` was schema-closed (`additionalProperties: false`), which was the lone outlier among capability blocks — every peer (`media_buy`, `signals`, `creative`, `brand`, `compliance_testing`, `request_signing`, `webhook_signing`, `measurement`) already had `additionalProperties: true` at the outer level. The closed shape silently contradicted the forward-compat promise made by [#3690](https://github.com/adcontextprotocol/adcp/pull/3690) (`brand_url on get_adcp_capabilities for keys-from-agent-URL discovery`), which explicitly stated that 3.0-pinned implementers could adopt `identity.brand_json_url` without waiting for a schema bump.
-
-Without this relaxation, `@adcp/sdk`'s `createAdcpServer` (default strict-validation mode) rejected any operator response carrying `brand_json_url`, forcing adopters to disable validation entirely (a footgun) or wait for 3.1.
-
-3.0.5 mirrors what `main` already shipped post-#3690: the outer `identity` object opens; the inner blocks (`key_origins`, `compromise_notification`) stay closed where the security weight actually sits. Strictly additive — the closed property list (`per_principal_key_isolation`, `key_origins`, `compromise_notification`) is unchanged; receivers that ignore unknown fields keep working; receivers that look for new identity fields gain forward-compat without waiting for a 3.x bump. Buyers and verifiers SHOULD continue to allowlist known identity fields at read time rather than rely on schema closure for trust decisions.
-
-### Storyboard-level `default_agent` field (#3897, closes #3894)
-
-Optional top-level `default_agent: <key>` on the storyboard authoring schema (`dist/compliance/3.0.5/universal/storyboard-schema.yaml`). The multi-agent storyboard runner ([adcp-client#1066](https://github.com/adcontextprotocol/adcp-client/issues/1066), [#1355](https://github.com/adcontextprotocol/adcp-client/pull/1355)) already accepts `default_agent` via run-options; this change lets storyboard authors encode the topology intent in YAML once instead of re-asserting `--default-agent sales` on every CI invocation. Cross-domain tools (`sync_creatives`, `list_creative_formats`) become deterministic without per-step `agent:` overrides.
-
-Resolution order (runner contract):
-
-1. Step-level `agent:` override.
-2. Specialism-claimant match against the runtime agents map. Multi-claim grades `unrouted_step` (operator-config error); slots 3/4 do not rescue. Zero claimants falls through to slot 3.
-3. Storyboard-level `default_agent` (this field). Set-but-unmatched grades `default_agent_unresolved` — the runner does NOT silently fall through to slot 4, because that would invisibly override the storyboard author's encoded intent.
-4. Run-options `default_agent`. Same set-but-unmatched rule.
-5. Fail-fast — `unrouted_step`.
-
-Single-agent runs ignore the field entirely; existing 3.0.x storyboards keep working unchanged. Mirrors the `provides_state_for` precedent (#3775) for additive storyboard-schema affordances on 3.0.x.
-
-The key shape is a free-form non-empty string keyed by the runtime agents map — the spec does not constrain to the specialism enum because production multi-agent topologies legitimately fan out per-property (`nyt_sales`, `wsj_sales`), per-region (`sales_eu`, `sales_us`), or per-brand-rights-holder. Cross-operator portability is the storyboard author's concern, not the spec's.
-
-### Brand-rights storyboard `acquire_rights` capture fix (#3893, closes #3892)
-
-The `brand_rights/rights_acquisition` storyboard's `acquire_rights` step captured a `context_outputs` field at path `rights_grant_id`, but `brand/acquire-rights-response.json` defines that field as `rights_id` (the `AcquireRightsAcquired` arm). Spec-compliant agents passed `response_schema` validation but failed the capture-and-pass-to-next-step machinery, which then cascade-skipped `rights_enforcement` with `prerequisite_failed`.
-
-3.0.5 corrects the storyboard to read `rights_id` (preserving the storyboard-internal `rights_grant_id` key name so no other steps need updates) and aligns the `expected:` prose to match the published schema (`status: acquired`, not the legacy `status: active`).
-
-Adopters running brand-rights conformance against a spec-compliant agent: bumping your SDK past 3.0.4 should flip the `brand_rights` storyboard from 3/5 scenarios passing to 5/5 with no agent-side changes.
-
-### Release mechanics (#3820)
-
-`forward-merge-3.0.yml`: explicitly push the `forward-merge/3.0.x` branch to origin **before** `peter-evans/create-pull-request@v8` runs. Discovered when 3.0.4's forward-merge ran for real: auto-resolution succeeded, then peter-evans crashed with `fatal: ambiguous argument 'origin/forward-merge/3.0.x': unknown revision`. Last gap in the auto-resolution chain — every subsequent Version Packages cut now auto-creates the forward-merge PR without human intervention.
-
-### Detailed changelog
-
-For the full per-PR change list, see [CHANGELOG.md § 3.0.5](https://github.com/adcontextprotocol/adcp/blob/main/CHANGELOG.md#305).
-
----
-
-## Version 3.0.4
-
-**Status:** Patch release — stable-surface no-op for 3.0-conformant agents
-
-**3.0.4 is the third 3.0.x patch.** Three additive cherry-picks from main, all hand-adapted for the maintenance line: the `manifest.json` + structured `enumMetadata` artifact (so SDKs stop hand-transcribing the spec), a normative `issues[]` array on `core/error.json`, and prose-only tightening of `AUTH_REQUIRED` to call out the retry-storm risk. Wire format unchanged.
-
-<Info>
-**Upgrading from 3.0.3?** No code changes required for 3.0-conformant agents. SDK consumers bump `ADCP_VERSION` to `3.0.4` to pick up `manifest.json` and the new `enumMetadata` block.
-</Info>
-
-### Adopter action
-
-| If you are… | What you need to do |
-|---|---|
-| A 3.0-conformant production agent | Nothing. Stable schemas remain wire-compatible with 3.0.0. |
-| An SDK author | Switch from parsing `Recovery: X` prose out of `enumDescriptions` to consuming the structured `enumMetadata` block. The build-time lint guarantees structured/prose parity, so the prose path can stay as a fallback while you migrate. |
-| An SDK consumer | Bump `ADCP_VERSION` to `3.0.4`. Pick up `/schemas/3.0.4/manifest.json` for one-stop tool/error/specialism enumeration. |
-| Implementing a buyer agent | Read the new `AUTH_REQUIRED` sub-cases in [error-handling.mdx](/dist/docs/3.1.0-rc.7/building/by-layer/L3/error-handling) — the wire code stays the same but you SHOULD NOT auto-retry when credentials were attached and rejected (terminal case). 3.1 will split this into separate enum values via #3739. |
-| Returning multi-field validation errors | Optionally populate `core/error.json`'s new top-level `issues[]` array (each entry: RFC 6901 pointer, message, JSON Schema keyword). Pre-3.1 consumers reading only `field` get the first failure; 3.1+ consumers prefer `issues`. |
-
-### `manifest.json` + structured `enumMetadata` (#3725, #3738)
-
-Two additive artifacts published with every released schema bundle:
-
-1. **`enums/error-code.json` gains an `enumMetadata` block.** Every error code now carries structured `recovery` (`correctable` | `transient` | `terminal`) and `suggestion` fields. SDKs MUST consume this block instead of parsing `Recovery: X` prose out of `enumDescriptions` — a build-time lint enforces structured/prose parity. Closes the root cause of [adcp-client#1135](https://github.com/adcontextprotocol/adcp-client/issues/1135) (17 missing codes, 3 wrong recovery classifications shipped in TS SDK for over a year).
-
-2. **`/schemas/3.0.4/manifest.json`.** Single canonical artifact listing every tool (with `protocol`, `mutating`, `request_schema`, `response_schema`, `async_response_schemas`, `specialisms`), every error code (with `recovery`, `description`, `suggestion`), an `error_code_policy` block (defining `default_unknown_recovery` so SDKs handle non-spec codes correctly), and every storyboard specialism (with `protocol`, `entry_point_tools`, `exercised_tools`). Validates against `manifest.schema.json`. Lets SDKs derive their internal tool/error tables from one place at codegen time.
-
-The 3.0.4 manifest covers exactly the 45 error codes 3.0.x ships (vs. main's 48 — three of main's codes don't exist in 3.0.x's enum and were trimmed during the cherry-pick).
-
-### `core/error.json` — `issues[]` field (#3059, #3562)
-
-Optional top-level `issues` array on the standard error envelope, normalizing what `@adcp/sdk` and prospectively `adcp-go` / `adcp-client-python` already need for multi-field validation rejections.
-
-```json
-{
-  "code": "VALIDATION_ERROR",
-  "message": "Request validation failed",
-  "field": "creatives[0].assets.image",
-  "issues": [
-    {
-      "pointer": "/creatives/0/assets/image",
-      "message": "Required",
-      "keyword": "required"
-    },
-    {
-      "pointer": "/creatives/0/format_id",
-      "message": "Must match pattern",
-      "keyword": "pattern"
-    }
-  ]
-}
-```
-
-Each entry is `{ pointer (RFC 6901), message, keyword, schemaPath? }`. `schemaPath` MAY be omitted in production to avoid fingerprinting `oneOf` branch selection on adversarial payloads.
-
-**Backward compatibility with `field` (singular):** when both are present, sellers SHOULD set `field` to `issues[0].pointer`. Pre-3.1 consumers reading only `field` get the first failure; 3.1+ consumers prefer the top-level `issues`. Sellers MAY mirror `issues[]` into `details.issues` for backward compat with consumers reading from `details`.
-
-### `AUTH_REQUIRED` retry-storm prose (#3730 partial, #3739 backport)
-
-`AUTH_REQUIRED` conflates two operationally distinct cases — credentials missing (genuinely correctable) and credentials presented but rejected (terminal — needs human rotation). A buyer agent treating both as `correctable` will retry-loop on revoked tokens, hammering seller SSO endpoints in a pattern indistinguishable from a brute-force probe.
-
-The 3.1 line splits this into `AUTH_MISSING` and `AUTH_INVALID` (#3739). 3.0.x cannot adopt the split — adding new enum values violates the maintenance line's semver rules. 3.0.4 ships the prose-only backport: the wire code stays `AUTH_REQUIRED` with `recovery: correctable`, but the description and `enumMetadata.suggestion` now spell out the two sub-cases and the SHOULD-NOT-auto-retry rule for the rejected-credential case. SDKs running against 3.0.x sellers can apply the operational distinction at the application layer.
-
-`docs/building/implementation/error-handling.mdx` gets a sub-case callout and an updated example showing how to branch on whether credentials were attached. Closes the 3.0.x portion of #3730; the full split lands in 3.1.0.
-
-### Detailed changelog
-
-For the full per-PR change list, see [CHANGELOG.md § 3.0.4](https://github.com/adcontextprotocol/adcp/blob/main/CHANGELOG.md#304).
-
----
-
-## Version 3.0.3
-
-**Status:** Patch release — additive storyboard schema field, stable-surface no-op for 3.0-conformant agents
-
-**3.0.3 ships the `provides_state_for` storyboard field** so the conformance suite can rescue cascade-skipping when two interchangeable stateful steps live in the same phase. Plus a docs-only fix for the `url_type` enum in channel docs that was emitting a value the published schema already excluded.
-
-<Info>
-**Upgrading from 3.0.2?** No code changes required for 3.0-conformant agents. Storyboard runners on `@adcp/sdk` 6.5.0+ pick up the new field automatically once the cache refreshes against 3.0.3.
-</Info>
-
-### Adopter action
-
-| If you are… | What you need to do |
-|---|---|
-| A 3.0-conformant production agent | Nothing. Stable schemas unchanged. |
-| Authoring storyboards | Optionally use `provides_state_for: <step_id>` on a stateful step to declare it substitutes for a missing peer step's state. Same-phase only; both steps must be `stateful: true`. The build-time lint enforces shape, target validity, statefulness, no self-reference, and no two-step cycles. |
-| Running storyboards via `@adcp/sdk` | Bump to 6.5.0+ to pick up the cascade-rescue runtime. Older SDK versions ignore the field and fall back to the existing `missing_tool` cascade behavior. |
-| A storyboard-authoring docs source (channels) | Replace `"url_type": "tracker"` with `"url_type": "tracker_pixel"` in any examples. The published schema enum already excluded `"tracker"`, so existing valid wire payloads are unaffected — only the prose docs were drifting. |
-
-### `provides_state_for` storyboard field (#3734)
-
-Optional `provides_state_for: <step_id> | <step_id>[]` on a stateful storyboard step declares that this step's pass establishes equivalent state for the named peer step(s) in the same phase. Pairs with the cascade-skip mechanism in `@adcp/sdk` 6.5.0+: when a peer step would otherwise grade `missing_tool` or `missing_test_controller`, the substitute waives the cascade and the runner grades the peer with the new `peer_substituted` skip reason.
-
-**Concrete impact:** explicit-mode social platforms (Snap, Meta, TikTok) intentionally pre-provision advertiser accounts out-of-band — `sync_accounts` is `missing_tool` by design, with `list_accounts` as the canonical alternative. 3.0.3's `sales-social/index.yaml` declares `provides_state_for: sync_accounts` on the `list_accounts` step, letting these adapters graduate from `1/9/0` (8 downstream stateful steps cascade-skipped) to `9/10` against the `sales_social` storyboard once the SDK cache refreshes.
-
-The field is part of the conformance harness, so it ships under the harness-additive patch-eligibility rule. Existing storyboards that don't use it keep their current cascade behavior — pure additive.
-
-Build-time validation (`scripts/lint-storyboard-provides-state-for.cjs`): rule shape, self-reference, unknown target, cross-phase reference (rejected — must be same-phase), target-not-stateful, substitute-not-stateful, and direct-cycle violations all fail loud.
-
-### `runner-output-contract.yaml` — `peer_substituted` skip reason
-
-Companion to `provides_state_for`: when the runner waives a cascade because a same-phase peer substituted for the state contract, it grades the original peer with `skip_result.reason = peer_substituted` and detail `"<this_step_id> state provided by <peer_phase_id>.<peer_step_id>"`. Distinct from `peer_branch_taken` (branch-set routing for mutually exclusive behaviors) and `not_applicable` (coverage gap — agent didn't declare the protocol).
-
-### `url_type: tracker` → `tracker_pixel` (#2986 step 1)
-
-Display, audio, carousels, and DOOH channel docs were emitting `"url_type": "tracker"` in examples — a value the published `url-asset-type.json` enum (`clickthrough` / `tracker_pixel` / `tracker_script`) already excluded. Fixed to `tracker_pixel`. Wire format unchanged; only prose docs were drifting.
-
-### Detailed changelog
-
-For the full per-PR change list, see [CHANGELOG.md § 3.0.3](https://github.com/adcontextprotocol/adcp/blob/main/CHANGELOG.md#303).
-
----
-
-## Version 3.0.2
-
-**Status:** Patch release — additive storyboard check kind + canonical asset-union schema
-
-**3.0.2 ships a new storyboard check kind** that closes a static-analysis gap in `@adcp/sdk`'s drift verifier, plus extracts a shared asset-variant `oneOf` union into its own schema file so codegen tools (notably `json-schema-to-typescript`) stop emitting numbered duplicate types.
-
-<Info>
-**Upgrading from 3.0.1?** No code changes required for 3.0-conformant agents. The check kind is consumed by the conformance runner, not by sellers; the asset-union refactor is a wire-format no-op.
-</Info>
-
-### Adopter action
-
-| If you are… | What you need to do |
-|---|---|
-| A 3.0-conformant production agent | Nothing. Wire format and validation semantics unchanged. |
-| An SDK author running codegen against schemas | Re-run `json-schema-to-typescript` (or your equivalent) to drop the `VASTAsset1`, `DAASTAsset1`, `BriefAsset1`, `CatalogAsset1` numbered duplicates. They were artifacts of the same `oneOf` union being encountered through multiple parent schemas; 3.0.2 references the canonical `core/assets/asset-union.json` from both `creative-asset.json` and `creative-manifest.json`. |
-| Authoring storyboards that assert envelope-level fields | Optionally use the new `envelope_field_present` check kind in place of `field_present` for `protocol-envelope.json` fields like `status`. The new check walks the envelope schema rather than the step's `response_schema_ref`, eliminating the static-analysis `VERIFIER_UNREACHABLE` gap in adcp-client's storyboard-drift verifier. |
-| Running storyboards via `@adcp/sdk` | Bump to the version that lands [adcp-client#1045](https://github.com/adcontextprotocol/adcp-client/pull/1045) for the new check kind. |
-
-### `envelope_field_present` check kind
-
-Storyboard `validations[].check` gains `envelope_field_present` as a peer of `field_present`. Same shape — `path` is RFC 6901-style — but resolves the path against `protocol-envelope.json` rather than the step's `response_schema_ref`. Used in `static/compliance/source/universal/v3-envelope-integrity.yaml` to assert that responses include `status`, where the previous `field_present` check left a `VERIFIER_UNREACHABLE` hole because `status` lives on the envelope, not the per-task response schema.
-
-### Canonical `core/assets/asset-union.json`
-
-The asset-variant `oneOf` union (the discriminated set of `image | video | text | url | vast | daast | ...` shapes) was inlined identically in `creative-asset.json` and `creative-manifest.json`. `json-schema-to-typescript` walking those parent schemas independently emitted `VASTAsset1`, `DAASTAsset1`, `BriefAsset1`, `CatalogAsset1` numbered-duplicate types — invisible at the wire level, irritating in generated code.
-
-3.0.2 promotes the union to `core/assets/asset-union.json` and references it via `$ref` from both parents. Codegen now emits a single `Asset` (or whatever your tool chooses) without the numbered duplicates. Wire format and validation semantics unchanged — pure refactor of the schema reference graph.
-
-### Detailed changelog
-
-For the full per-PR change list, see [CHANGELOG.md § 3.0.2](https://github.com/adcontextprotocol/adcp/blob/main/CHANGELOG.md#302).
-
----
 
 ## Version 3.0.1
 

--- a/dist/docs/3.1.0-rc.7/reference/versions.mdx
+++ b/dist/docs/3.1.0-rc.7/reference/versions.mdx
@@ -7,16 +7,21 @@ description: "Every published AdCP version, its status, and its end-of-life date
 
 ## At a glance
 
+<Info>
+**Choosing today:** stable production integrations use 3.0 with wire pin `"3.0"`. 3.1 validation uses the current RC, `v3.1.0-rc.7`, with wire pin `"3.1-rc.7"`. After GA, 3.1 integrations use wire pin `"3.1"`.
+</Info>
+
 | Status | Versions | Wire pin | What it means |
 |---|---|---|---|
-| **Active** | 3.0 (current: 3.0.11) | `"3.0"` | Default for new integrations. Receives feature and security patches. |
+| **Active** | 3.0 (current stable: 3.0.15) | `"3.0"` | Stable default for production integrations. Receives feature and security patches. |
+| **Validation** | 3.1 (current RC: `v3.1.0-rc.7`) | `"3.1-rc.7"` during validation; `"3.1"` at GA | Feature-complete minor release validating through RC artifacts. See [What's New in AdCP 3.1](/dist/docs/3.1.0-rc.7/reference/whats-new-in-3-1) for the final feature set. |
 | **Security-only** | 2.5.0, 2.5.1, 2.5.3 | `"2.5"` | Security patches through **August 1, 2026 (UTC)**. Not safe for AAO-network production — see [v2 sunset](/dist/docs/3.1.0-rc.7/reference/v2-sunset). |
 | **End of life** | 2.0.0, 2.1.0 | — | No patches. Migrate to 3.0. |
-| **Planned** | 3.1, 3.2, 4.0 | — | Targets in [planned releases](/dist/docs/3.1.0-rc.7/reference/versioning#planned-releases). |
+| **Planned** | 3.2, 4.0 | — | Targets in [planned releases](/dist/docs/3.1.0-rc.7/reference/versioning#planned-releases). |
 
-**Wire values are release-precision only.** Send `"3.0"`, not `"3.0.11"` — a patch component on the wire is rejected. See [patches are not negotiated](/dist/docs/3.1.0-rc.7/reference/versioning#patches-are-not-negotiated).
+**Wire values are release-precision only.** Send `"3.0"` for the stable 3.0 line, exact pre-release pins such as `"3.1-rc.7"` while validating 3.1, and `"3.1"` only after GA. Do not send patch components like `"3.0.15"` or full semver pre-release values like `"3.1.0-rc.7"`. See [patches are not negotiated](/dist/docs/3.1.0-rc.7/reference/versioning#patches-are-not-negotiated).
 
-*Status legend: Active = current generation, receiving feature work. Security-only = patches for security issues only, no features. End of life = no patches. Planned = not yet released.*
+*Status legend: Active = current stable generation. Validation = feature-complete release candidate, not GA. Security-only = patches for security issues only, no features. End of life = no patches. Planned = not yet released.*
 
 ## All published versions
 
@@ -26,9 +31,10 @@ description: "Every published AdCP version, its status, and its end-of-life date
 |---|---|---|
 | 3.0.0 | 2026-04-22 | GA — stable baseline for the 3.x cycle. |
 | 3.0.1 through 3.0.10 | 2026-04-28 to 2026-05-10 | Patches. Wire-compatible with 3.0.0. |
-| **3.0.11** | **2026-05-11** | **Latest published patch.** |
+| 3.0.11 through **3.0.15** | 2026-05-11 to 2026-05-31 | Patches. **3.0.15 is the latest stable patch.** Wire-compatible with 3.0.0. |
+| 3.1.0-rc.1 through **3.1.0-rc.7** | 2026-05-29 to 2026-06-04 | Feature-complete 3.1 validation train. Current published RC is `v3.1.0-rc.7`; use wire pin `"3.1-rc.7"` during validation and `"3.1"` only after GA. See [What's New in AdCP 3.1](/dist/docs/3.1.0-rc.7/reference/whats-new-in-3-1) for the final feature list. |
 
-Patches don't change the wire contract. Upgrading within 3.0.x is always safe. For per-version detail, see [Release Notes](/dist/docs/3.1.0-rc.7/reference/release-notes) (curated narrative) and the [Changelog](/dist/docs/3.1.0-rc.7/reference/changelog) (full technical history).
+Patches don't change the wire contract. Upgrading within 3.0.x is always safe. 3.1 RC artifacts validate the next minor release; they are pinned exactly during validation and collapse to the `"3.1"` wire value at GA. For per-version detail, see [Release Notes](/dist/docs/3.1.0-rc.7/reference/release-notes) (curated narrative) and the [Changelog](/dist/docs/3.1.0-rc.7/reference/changelog) (full technical history).
 
 ### Prereleases (superseded)
 
@@ -52,7 +58,7 @@ After August 1, 2026 (UTC), the entire 2.x line is fully deprecated. The 2.x sch
 ## FAQ
 
 ### What's "current"?
-**3.0.11.** Pin your integration to `"3.0"` (not `"3.0.11"`) — wire values use release precision. See [Version negotiation](/dist/docs/3.1.0-rc.7/reference/versioning#version-negotiation).
+For stable production, **3.0.15** is current; pin your integration to `"3.0"` (not `"3.0.15"`). For 3.1 validation, the current published RC is **v3.1.0-rc.7**; pin to `"3.1-rc.7"` until GA, then use `"3.1"`. See [Version negotiation](/dist/docs/3.1.0-rc.7/reference/versioning#version-negotiation).
 
 ### What happened to 2.2, 2.3, 2.4, 2.6?
 The 2.x line skipped version numbers during its working-group cycle. Some appear as in-flight changelog entries but were never released — the changes were rolled forward into the next published version or deferred to 3.0. The five published 2.x releases are 2.0.0, 2.1.0, 2.5.0, 2.5.1, and 2.5.3.
@@ -70,15 +76,17 @@ Targeted for early 2027. 3.x is mid-cycle — see the [planned releases table](/
 
 | If you are… | Use |
 |---|---|
-| Building a new integration today | **3.0** (latest patch). Pin `"3.0"` on the wire. |
+| Building a production integration today | **3.0** (latest stable patch). Pin `"3.0"` on the wire. |
+| Validating the final 3.1 feature set before GA | **3.1.0-rc.7**. Pin `"3.1-rc.7"` on the wire, read [What's New in AdCP 3.1](/dist/docs/3.1.0-rc.7/reference/whats-new-in-3-1), and move to `"3.1"` at GA. |
 | Running a 2.5.x integration | Migrate to 3.0 before **Aug 1, 2026 (UTC)**. Start with the [migration guide](/dist/docs/3.1.0-rc.7/reference/migration). |
 | Running a 2.0 or 2.1 integration | Upgrade now — out of support. |
-| Trying an unreleased feature | See [prerelease upgrade notes](/dist/docs/3.1.0-rc.7/reference/migration/prerelease-upgrades) and [experimental status](/dist/docs/3.1.0-rc.7/reference/experimental-status). |
+| Trying a post-3.1 unreleased feature | See [Release Notes](/dist/docs/3.1.0-rc.7/reference/release-notes), [Versioning & Governance](/dist/docs/3.1.0-rc.7/reference/versioning), and [experimental status](/dist/docs/3.1.0-rc.7/reference/experimental-status). |
 
 ## Related
 
 - **[Versioning & Governance](/dist/docs/3.1.0-rc.7/reference/versioning)** — release tiers, schema-change scope, cadence policy
 - **[v2 Sunset](/dist/docs/3.1.0-rc.7/reference/v2-sunset)** — full v2 end-of-life timeline and migration paths
 - **[What's new in v3](/dist/docs/3.1.0-rc.7/reference/whats-new-in-v3)** — feature-by-feature summary of what 3.0 adds
+- **[What's New in AdCP 3.1](/dist/docs/3.1.0-rc.7/reference/whats-new-in-3-1)** — final 3.1 feature set and adopter actions
 - **[Release Notes](/dist/docs/3.1.0-rc.7/reference/release-notes)** — curated narrative for each version
 - **[Changelog](/dist/docs/3.1.0-rc.7/reference/changelog)** — full technical change history

--- a/dist/docs/3.1.0-rc.7/reference/whats-new-in-3-1.mdx
+++ b/dist/docs/3.1.0-rc.7/reference/whats-new-in-3-1.mdx
@@ -5,7 +5,7 @@ description: "Adopter overview of AdCP 3.1 — distributed brand.json, dependenc
 ---
 
 <Warning>
-**Status: 3.1 release-candidate validation.** The current published release candidate is `v3.1.0-rc.7`; its wire negotiation value is `adcp_version: "3.1-rc.7"`. The spec is feature-complete for 3.1 and validating through RC artifacts. Use `"3.1"` only after GA.
+**Status: 3.1 release-candidate validation.** Stable today: 3.0, wire pin `"3.0"`. Current validation track: `v3.1.0-rc.7`, wire pin `adcp_version: "3.1-rc.7"`. After GA: 3.1, wire pin `"3.1"`. The spec is feature-complete for 3.1 and validating through RC artifacts.
 </Warning>
 
 AdCP 3.1 is a minor release. Every 3.1 change is **additive** over 3.0: new fields are optional, no required field was removed, no shape changed in a way that breaks a 3.0-conformant client. **No breaking changes for 3.0-conformant agents.** Pre-GA adopters following the 3.1 RC stream should read the RC notes below because a few release-candidate surfaces were tightened before GA. During RC validation, use exact pre-release pins from `supported_versions`; move production pins to `"3.1"` at GA to pick up the new fields.
@@ -15,6 +15,21 @@ This page is the curated adopter overview for the 3.1 minor release. Need the fu
 <Note>
 **Looking for the major v2 → v3 changes instead?** See [What's New in AdCP 3](/dist/docs/3.1.0-rc.7/reference/whats-new-in-v3). This page covers the 3.0 → 3.1 minor delta only.
 </Note>
+
+## Final 3.1 feature set
+
+If you only need the final 3.1 shape after the RC train, read this list first:
+
+- **Versioning and validation.** Release-precision `adcp_version` pins, exact RC wire values such as `"3.1-rc.7"` during validation, `"3.1"` at GA, `supported_versions` advertisement, envelope echo, and version-scoped verification badges.
+- **Brand trust.** Distributed `brand.json`, sub-brand self-publishing through `brand_refs[]`, typed brand constraints, authorized operator scoping, and required signed responses for `verify_brand_claim` / `verify_brand_claims`.
+- **Signals and product targeting.** Enriched signal definitions, `SignalRef`, wholesale signal enumeration, product-scoped `included_signals`, selectable `signal_targeting_options`, grouped buy-time `signal_targeting_groups`, and clarified owned-vs-marketplace conformance.
+- **Wholesale feed mirroring.** Conditional fetch tokens, public/account `cache_scope`, product and signal wholesale-feed webhooks, and repair-by-read semantics for storefronts, registries, and federated marketplaces.
+- **Creative formats.** Canonical `format_kind` declarations, publisher format catalogs, `v1_format_ref` dual-emission, hosted audio/video `duration_ms_exact` plus one-sided `duration_ms_range`, published-post references, and video placement semantics.
+- **Creative generation.** `list_transformers`, account-scoped transformer selection, strict typed `config`, catalog and variant fan-out, advisory evaluator ranking, spend controls, content macros, free-text params, and per-output pricing receipts.
+- **Media-buy operations.** Dependency impairments, buyer-visible `webhook_activity[]`, action discovery, proposal-lifecycle cleanup, currency-scoped product discovery, sponsored/social placement fields, and SI availability status.
+- **Measurement and billing.** Vendor-attested `vendor_metric` goals, reach-window semantics, `viewability.viewed_seconds`, windowed delivery recovery, finality flags on delivery and usage, and out-of-band creative billing declarations.
+- **Runtime hardening.** Request idempotency on every task, `IDEMPOTENCY_IN_FLIGHT`, open error-code decoding with recovery classification, auth error split, credential-in-payload rejection, webhook operation-id echo, and flat MCP envelope tolerance.
+- **SDK and compliance readiness.** Named schemas for code generators, async-response refs, intentionally open payload markers, capability-gated storyboard coverage, packaged compliance bundle closure, and drift checks for release artifacts.
 
 ## Why upgrade
 

--- a/docs.json
+++ b/docs.json
@@ -2,7 +2,7 @@
   "$schema": "https://mintlify.com/schema.json",
   "name": "AdCP - Ad Context Protocol",
   "banner": {
-    "content": "AdCP 3.1 is in active development — [see what's coming →](/docs/reference/release-notes)",
+    "content": "AdCP 3.1 is in release-candidate validation — [see what's new →](/docs/reference/whats-new-in-3-1)",
     "dismissible": true
   },
   "description": "AdCP (Ad Context Protocol) is the open standard for agentic advertising. It defines how AI agents buy media, generate creatives, activate audiences, and enforce governance across platforms.",
@@ -81,7 +81,7 @@
                 "pages": [
                   "docs/building/index",
                   {
-                    "group": "AdCP 3.0",
+                    "group": "AdCP 3.x",
                     "expanded": false,
                     "pages": [
                       "docs/reference/whats-new-in-v3",
@@ -687,7 +687,7 @@
             "pages": [
               "dist/docs/3.1.0-rc.7/building/index",
               {
-                "group": "AdCP 3.0",
+                "group": "AdCP 3.x",
                 "expanded": false,
                 "pages": [
                   "dist/docs/3.1.0-rc.7/reference/whats-new-in-v3",
@@ -699,6 +699,7 @@
                   "dist/docs/3.1.0-rc.7/reference/migration/pricing",
                   "dist/docs/3.1.0-rc.7/reference/migration/geo-targeting",
                   "dist/docs/3.1.0-rc.7/reference/migration/creatives",
+                  "dist/docs/3.1.0-rc.7/reference/migration/creative-transformers",
                   "dist/docs/3.1.0-rc.7/reference/migration/catalogs",
                   "dist/docs/3.1.0-rc.7/reference/migration/optimization-goals",
                   "dist/docs/3.1.0-rc.7/reference/migration/brand-identity",
@@ -1291,7 +1292,7 @@
             "pages": [
               "docs/building/index",
               {
-                "group": "AdCP 3.0",
+                "group": "AdCP 3.x",
                 "expanded": false,
                 "pages": [
                   "docs/reference/whats-new-in-v3",

--- a/docs/reference/release-notes.mdx
+++ b/docs/reference/release-notes.mdx
@@ -19,6 +19,16 @@ For adoption-oriented framing before the full change list, start with [What's Ne
 
 Additive over 3.0 — every existing brand.json publisher continues to validate unchanged.
 
+### 3.1 feature index
+
+- **Versioning and validation:** release-precision `adcp_version`, exact RC pins, `supported_versions`, envelope echo, and version-scoped badges.
+- **Brand trust:** distributed `brand.json`, `brand_refs[]`, typed brand constraints, authorized-operator scoping, and signed brand-verification responses.
+- **Signals and wholesale feeds:** enriched signal definitions, `SignalRef`, wholesale signal enumeration, product-scoped signal targeting, conditional fetch, `cache_scope`, and feed webhooks.
+- **Creative formats and generation:** canonical `format_kind`, publisher catalogs, hosted audio/video `duration_ms_range`, published-post references, `list_transformers`, fan-out, evaluator ranking, spend controls, and per-output pricing receipts.
+- **Media-buy operations:** dependency impairments, buyer-visible webhook activity, action discovery, proposal cleanup, currency-scoped discovery, sponsored/social placement fields, and SI availability status.
+- **Measurement, billing, and runtime hardening:** vendor-attested goals, reach-window semantics, delivery/usage finality, idempotency on every task, open error-code decoding, auth tightening, webhook operation-id echo, and flat MCP envelope tolerance.
+- **SDK and compliance readiness:** named codegen schemas, async-response refs, open-payload markers, capability-gated storyboards, packaged compliance closure, and release-artifact drift checks.
+
 <Info>
 **Upgrading from 3.0.x?** No code changes required. Schemas remain wire-compatible. SDK consumers pin the AdCP release to `"3.1"` on GA to pick up the new variant and field shapes. The one publisher-visible behavior change: free-text values for `trademarks[].status` or `trademarks[].countries` now validate against the typed enum / ISO 3166-1 alpha-2 — non-conforming values surface as schema errors.
 </Info>
@@ -82,7 +92,7 @@ Modeled signals now have explicit validation hooks: `methodology: "modeled"` and
 
 Product signal targeting also clarifies the broad-feed workflow. Products may set `signal_targeting_allowed: true` and omit inline `signal_targeting_options` instead of duplicating a wholesale signal feed inline. Buyers use `get_signals` for candidate discovery, then confirm product eligibility and composability with `get_products.filters.signal_targeting` or a product-specific `get_products` response before sending `packages[].targeting_overlay.signal_targeting_groups`.
 
-### RC4 release-candidate locks — response signing, proposal lifecycle, signals conformance, and packaged compliance closure
+### Brand signing, proposal lifecycle, signals conformance, and packaged compliance
 
 **Brand designated-task response signing.** `verify_brand_claim` and `verify_brand_claims` success responses now require `signed_response`, a payload-envelope JWS over the canonical task-body response. The envelope binds the response to the designated task, resolved `brand_domain`, responding `agent_url`, caller/request hash, and `iat`/`exp` freshness window. Verifiers resolve the `kid` to a published JWK with `adcp_use: "response-signing"` and reject mismatches between the unsigned response fields and `signed_response.payload.response`. This is ordinary JWS over the JCS-canonicalized payload, not general RFC 9421 transport response signing. See [Brand Protocol § verify_brand_claim](/docs/brand-protocol/tasks/verify_brand_claim#trust-model) and [Security § Designated-task response signing](/docs/building/by-layer/L1/security#designated-task-response-signing). PR [#5192](https://github.com/adcontextprotocol/adcp/pull/5192).
 
@@ -96,7 +106,7 @@ Product signal targeting also clarifies the broad-feed workflow. Products may se
 
 **Packaged compliance references are closed.** Webhook receiver envelope vectors now live under the versioned compliance tree, and release validation fails if storyboard vector/test-kit references do not resolve inside the packaged compliance bundle or protocol tarball. This keeps public `/compliance/{version}/` artifacts self-contained.
 
-### Late release-candidate locks — canonical formats, badges, and discovery precision
+### Canonical formats, badges, and discovery precision
 
 **Creative-agent canonical build capabilities.** Creative agents declare what they can produce via `creative.supported_formats[]` on `get_adcp_capabilities`. Entries that buyers can target over time SHOULD carry an agent-local stable `capability_id`; buyers use that ID as `target_format_id.id` in `build_creative` when present. This is intentionally separate from media-buy `format_option_id`, which selects a product-local or publisher-catalog format option. The training agent and storyboards verify advertised capability IDs, canonical `format_kind` manifests, unsupported target rejection, and 3.0 compatibility gating. See [Canonical formats](/docs/creative/canonical-formats) and [`build_creative`](/docs/creative/task-reference/build_creative).
 
@@ -112,7 +122,7 @@ Sellers match `pricing_currencies` against product-level `pricing_options`, prun
 
 **Upstream traffic attestation mode selection.** The upstream-traffic storyboards now lock the normative choice between raw and digest attestation modes so sellers cannot pass by emitting the wrong proof shape for the negotiated mode. See [Compliance catalog](/docs/building/verification/compliance-catalog).
 
-### RC7 release-candidate cleanup — hosted audio/video duration ranges
+### Hosted audio/video duration ranges
 
 Hosted `audio_hosted` and `video_hosted` declarations now allow one-sided `duration_ms_range` values. `[null, 60000]` expresses "up to 60 seconds"; `[15000, null]` expresses "at least 15 seconds"; `[null, null]` remains invalid because at least one side must be bounded.
 
@@ -194,7 +204,7 @@ See [Metric lifecycle](/docs/media-buy/media-buys/optimization-reporting#metric-
 
 `adcp_major_version` (the 3.0 integer field) and `adcp.major_versions` remain functional through all of 3.x — additive ship, no required changes for 3.0-conformant agents. The full migration table lives in [Versioning & Governance § Migration timeline](/docs/reference/versioning#migration-timeline).
 
-**Pin your release.** Every SDK exposes a constructor option for the version pin. Through 3.x, the SDK SHOULD also emit `adcp_major_version` automatically so legacy 3.x sellers that only read the integer keep negotiating correctly. The wire shape is **release-precision only** (`"3.1"`, `"3.1-rc.7"`) — full semver like `"3.1.2"` or `"3.1.0-rc.7"` is invalid on the wire.
+**Pin your release.** Every SDK exposes a constructor option for the version pin. Through 3.x, the SDK SHOULD also emit `adcp_major_version` automatically so legacy 3.x sellers that only read the integer keep negotiating correctly. During RC validation, use the exact advertised prerelease value such as `"3.1-rc.7"`; after GA, use `"3.1"`. The wire shape is **release-precision only** (`"3.1"`, `"3.1-rc.7"`) — full semver like `"3.1.2"` or `"3.1.0-rc.7"` is invalid on the wire.
 
 ```typescript
 // @adcp/sdk (TypeScript)
@@ -202,8 +212,8 @@ import { SingleAgentClient } from "@adcp/sdk";
 
 const client = new SingleAgentClient(
   { agent_uri: "https://sales.example/mcp/", protocol: "mcp" },
-  { adcpVersion: "3.1" },   // emitted on every request as adcp_version
-                            // adcp_major_version: 3 mirror auto-emitted
+  { adcpVersion: "3.1-rc.7" }, // use "3.1" after GA
+                               // adcp_major_version: 3 mirror auto-emitted
 );
 ```
 
@@ -214,8 +224,8 @@ from adcp.types import AgentConfig, Protocol
 
 client = ADCPClient(
     AgentConfig(agent_uri="https://sales.example/mcp/", protocol=Protocol.MCP),
-    adcp_version="3.1",     # emitted on every request as adcp_version
-                            # adcp_major_version: 3 mirror auto-emitted
+    adcp_version="3.1-rc.7",  # use "3.1" after GA
+                              # adcp_major_version: 3 mirror auto-emitted
 )
 ```
 
@@ -516,553 +526,6 @@ For the full per-PR change list, see [CHANGELOG.md § 3.0.2](https://github.com/
 
 ---
 
-## Version 3.0.6
-
-**Status:** Patch release — stable-surface no-op for 3.0-conformant agents
-
-**3.0.6 makes the `GOVERNANCE_DENIED` wire-placement rule discoverable from the error code itself**, reserves the `ctx_metadata` keyword as an adapter-internal round-trip key, expands the SKILL.md guidance for `issues[]` recovery on the calling-agent side, and fixes two storyboard fixture bugs that were rejecting spec-compliant adopters. Wire format unchanged for any 3.0 agent.
-
-<Info>
-**Upgrading from 3.0.5?** No code changes required for 3.0-conformant agents. SDK consumers bump `ADCP_VERSION` to `3.0.6` to pick up the tightened error-code prose, the `ctx_metadata` reservation, and the corrected storyboard fixtures.
-</Info>
-
-### Adopter action
-
-| If you are… | What you need to do |
-|---|---|
-| A 3.0-conformant production agent | Nothing. Stable schemas remain wire-compatible with 3.0.0. |
-| Returning `GOVERNANCE_DENIED` from `acquire_rights` or `creative_approval` | Read the new wire-placement guidance on the error code. The canonical denial shape is the structured rejection arm (`AcquireRightsRejected` / `CreativeRejected`) — `status: "rejected"` + `reason`, **no** `errors[]`, transport markers stay green. The schema's `not: { required: ["errors"] }` clause was already enforcing this; the prose now makes the rule discoverable from the code. |
-| Returning `GOVERNANCE_DENIED` from `create_media_buy` (or any task without a rejection arm) | Continue populating `errors[].code` AND `adcp_error.code` per the two-layer model and flipping transport-level failure markers (HTTP 4xx / MCP `isError: true` / A2A `failed`). The wire-placement guidance distinguishes this Case-2 path from the rejection-arm path. |
-| Building an SDK adapter that wants to round-trip publisher state through AdCP resources | You MAY now use the reserved top-level `ctx_metadata` key on Product / MediaBuy / Package / Creative / AudienceSegment / Signal / RightsGrant. SDKs MUST strip the key before wire egress and SHOULD log a warning when stripping. Buyers never see this field. |
-| Authoring storyboards that capture state from A2A submitted-arm responses | The `task_completion.<inner>` prefix on `context_outputs[].path` is now documented in the storyboard schema. The runner polls `tasks/get` until terminal and resolves the suffix against the completion artifact's `data` — needed for captures like seller-assigned `media_buy_id` on IO-signing flows. Requires runner ≥ adcp-client v6.7. |
-| Running `comply_test_controller` | The visibility rule is now explicitly deployment-scoped, not request-gated. Production deployments MUST NOT expose the tool on any surface (`tools/list`, `compliance_testing` block in `get_adcp_capabilities`, dispatch). Live-mode probes get unknown-tool, not `FORBIDDEN`. |
-
-### `GOVERNANCE_DENIED` / `GOVERNANCE_UNAVAILABLE` wire-placement guidance (#3929, closes the doc-comment item on #3918; companion to #3914)
-
-`error-code.json` defined the two governance codes' semantics but didn't say WHERE in the response they appear. Storyboards interpreted differently — issue #3914 surfaced one mismatch where the brand-rights compliance storyboard expected `expect_error: code: GOVERNANCE_DENIED` even though `acquire_rights` already has a first-class `AcquireRightsRejected` discriminated arm. Adopters returning the spec-correct shape were failing the storyboard.
-
-The `enumDescriptions` for both codes now state placement explicitly:
-
-- **`GOVERNANCE_DENIED`** — structured business outcome, not a system error. **When the task response defines a structured rejection arm**, that arm IS the canonical denial shape: populate `status: "rejected"` + `reason`, do NOT additionally emit the code in `errors[]` or `adcp_error`, and do NOT flip transport-level failure markers. **When the task has no rejection arm**, populate `errors[].code` AND `adcp_error.code` per the two-layer model and DO flip transport markers.
-- **`GOVERNANCE_UNAVAILABLE`** — system error, governance call failed at all. Always populate both layers with the code and flip transport markers. Sellers MUST NOT use a structured rejection arm for unavailability even when the task offers one — the buyer's recovery semantics differ (retry-with-backoff vs. restructure-or-escalate).
-
-The MUST NOT against dual-emission isn't a behavior change — `AcquireRightsRejected` and `CreativeRejected` already declare `not: { required: [errors] }` at the schema layer, so emitting `errors[]` alongside a rejection arm was already a schema violation. The doc-comment makes the rule discoverable from the error code without changing what conformant senders produce.
-
-A parallel storyboard-authoring note in `error-handling.mdx` directs authors to assert on `field_value path: "status" value: "rejected"` rather than `error_code` for tasks that define a rejection arm. The existing `error_code` guidance is correct for tasks without a rejection arm.
-
-### `ctx_metadata` reserved as adapter-internal round-trip key (#3640)
-
-Reserves the top-level key `ctx_metadata` on AdCP resource objects (Product, MediaBuy, Package, Creative, AudienceSegment, Signal, RightsGrant) as a publisher-to-SDK round-trip cache for adapter-internal state. SDKs MUST strip the key before wire egress and MUST emit a warning-level log entry when stripping, so operators can detect accidental collisions with existing adapter code. Buyers never see this field.
-
-The convention is non-binding at the wire level — these resources already declare `additionalProperties: true` so existing payloads remain valid. The reservation locks the keyword name before two SDKs converge on it accidentally and ship divergent semantics. PropertyList and CollectionList are out of scope (`additionalProperties: false`) until a follow-up PR widens those schemas.
-
-### Implementation-dependent `issues[]` fields documented in SKILL.md (#3927 backport)
-
-`skills/call-adcp-agent/SKILL.md` already documented the three required `issues[]` fields (`pointer`, `keyword`, `variants`). 3.0.6 adds the four optional fields a calling agent will encounter when the seller's validator opts into them — `discriminator`, `schemaId`, `allowedValues`, `hint` — with a one-line preface clarifying these are implementation-dependent (not every validator emits them) and an updated recovery order: read `hint` first when present, then `discriminator`, then walk `variants`. Two new rows added to the symptom-fix lookup table for the same fields.
-
-No wire-format change. Pure documentation: shipping these fields is already a valid validator extension; this gives callers a curated path through them.
-
-### Storyboard-schema documents `task_completion.<inner>` prefix (#3955, closes #3950)
-
-The `context_outputs[].path` resolver gained a `task_completion.` prefix in the storyboard runner (`@adcp/sdk` 6.7+) for capturing values that materialize only on the terminal task artifact (e.g., seller-assigned `media_buy_id` on IO-signing flows where `create_media_buy` returns an A2A submitted-arm envelope). 3.0.6 adds the corresponding documentation to the storyboard authoring schema (`static/compliance/source/universal/storyboard-schema.yaml`).
-
-### `comply_test_controller` is deployment-scoped, not request-gated (#3992)
-
-Tightens the visibility rule for `comply_test_controller`: production deployments MUST NOT expose the tool on any surface — neither `tools/list`, nor the `compliance_testing` block in `get_adcp_capabilities`, nor request dispatch. Live-mode probes get unknown-tool (treated as a regular catalog miss), **not** `FORBIDDEN`. The previous prose left enough room that some adopters were emitting `FORBIDDEN` on live-mode dispatch, which is itself an information leak (an attacker probing for the tool can distinguish "not deployed" from "deployed but you can't use it").
-
-### Storyboard fixture fixes
-
-Two compliance-bundle fixture fixes that were causing spec-compliant adopters to fail published storyboards:
-
-- **`inventory_list_targeting`** — the 5 account blocks across this scenario use the brand+operator natural-key variant of `AccountReference` but omitted the `sandbox` flag. Sellers whose `accounts.resolve` has separate code paths for sandbox vs production refs were routing `create_media_buy` and `get_media_buys` through different account-id namespaces, breaking `mediaBuyStore` backfill of `targeting_overlay`. Setting `sandbox: true` on every account block keeps both create and get on the sandbox path. Mirror of [#3989](https://github.com/adcontextprotocol/adcp/pull/3989) on `main`. Follow-up to align the SDK runner's enricher asymmetry tracked at [adcp-client#1487](https://github.com/adcontextprotocol/adcp-client/issues/1487).
-- **`sales_guaranteed/create_media_buy`** — the `context_outputs[0].path` was bare `"media_buy_id"`, which the runner resolved against the immediate submitted-arm response — a step that fails with `capture_path_not_resolvable` and masks downstream phases. Updated to `"task_completion.media_buy_id"` so the runner polls `tasks/get` and captures the seller-issued id from the terminal artifact, per the runner contract introduced in adcp-client#1426. Mirror of [#3990](https://github.com/adcontextprotocol/adcp/pull/3990) on `main`.
-
----
-
-## Version 3.0.5
-
-**Status:** Patch release — stable-surface no-op for 3.0-conformant agents
-
-**3.0.5 unblocks `brand_json_url` adoption on 3.0**, ships an optional storyboard-authoring affordance, and corrects a brand-rights storyboard capture path that was rejecting spec-compliant agents. Wire format unchanged for any 3.0 agent that doesn't claim a new optional surface.
-
-<Info>
-**Upgrading from 3.0.4?** No code changes required for 3.0-conformant agents. SDK consumers bump `ADCP_VERSION` to `3.0.5` to pick up the relaxed `identity` validator and the brand-rights storyboard fix.
-</Info>
-
-### Adopter action
-
-| If you are… | What you need to do |
-|---|---|
-| A 3.0-conformant production agent | Nothing. Stable schemas remain wire-compatible with 3.0.0. |
-| Adopting `identity.brand_json_url` from #3690 on 3.0 | Bump to 3.0.5 (or have your SDK pick it up). 3.0.4 and earlier rejected the field at validation; 3.0.5 accepts it. |
-| Running brand-rights conformance against the published storyboard | Bump SDK to pick up `dist/compliance/3.0.5/specialisms/brand-rights/index.yaml`. Spec-compliant agents that return `rights_id` (per the published `acquire-rights-response.json`) now pass `rights_acquisition` and stop cascade-skipping `rights_enforcement`. |
-| Authoring multi-agent storyboards | You MAY now declare a top-level `default_agent: <key>` so multi-agent runners route cross-domain steps without per-CI-invocation overrides. Single-agent runs ignore the field. |
-
-### `identity.additionalProperties: true` on `get_adcp_capabilities` (#3896, closes Scope3 adoption gap)
-
-The `identity` block on `get-adcp-capabilities-response.json` was schema-closed (`additionalProperties: false`), which was the lone outlier among capability blocks — every peer (`media_buy`, `signals`, `creative`, `brand`, `compliance_testing`, `request_signing`, `webhook_signing`, `measurement`) already had `additionalProperties: true` at the outer level. The closed shape silently contradicted the forward-compat promise made by [#3690](https://github.com/adcontextprotocol/adcp/pull/3690) (`brand_url on get_adcp_capabilities for keys-from-agent-URL discovery`), which explicitly stated that 3.0-pinned implementers could adopt `identity.brand_json_url` without waiting for a schema bump.
-
-Without this relaxation, `@adcp/sdk`'s `createAdcpServer` (default strict-validation mode) rejected any operator response carrying `brand_json_url`, forcing adopters to disable validation entirely (a footgun) or wait for 3.1.
-
-3.0.5 mirrors what `main` already shipped post-#3690: the outer `identity` object opens; the inner blocks (`key_origins`, `compromise_notification`) stay closed where the security weight actually sits. Strictly additive — the closed property list (`per_principal_key_isolation`, `key_origins`, `compromise_notification`) is unchanged; receivers that ignore unknown fields keep working; receivers that look for new identity fields gain forward-compat without waiting for a 3.x bump. Buyers and verifiers SHOULD continue to allowlist known identity fields at read time rather than rely on schema closure for trust decisions.
-
-### Storyboard-level `default_agent` field (#3897, closes #3894)
-
-Optional top-level `default_agent: <key>` on the storyboard authoring schema (`dist/compliance/3.0.5/universal/storyboard-schema.yaml`). The multi-agent storyboard runner ([adcp-client#1066](https://github.com/adcontextprotocol/adcp-client/issues/1066), [#1355](https://github.com/adcontextprotocol/adcp-client/pull/1355)) already accepts `default_agent` via run-options; this change lets storyboard authors encode the topology intent in YAML once instead of re-asserting `--default-agent sales` on every CI invocation. Cross-domain tools (`sync_creatives`, `list_creative_formats`) become deterministic without per-step `agent:` overrides.
-
-Resolution order (runner contract):
-
-1. Step-level `agent:` override.
-2. Specialism-claimant match against the runtime agents map. Multi-claim grades `unrouted_step` (operator-config error); slots 3/4 do not rescue. Zero claimants falls through to slot 3.
-3. Storyboard-level `default_agent` (this field). Set-but-unmatched grades `default_agent_unresolved` — the runner does NOT silently fall through to slot 4, because that would invisibly override the storyboard author's encoded intent.
-4. Run-options `default_agent`. Same set-but-unmatched rule.
-5. Fail-fast — `unrouted_step`.
-
-Single-agent runs ignore the field entirely; existing 3.0.x storyboards keep working unchanged. Mirrors the `provides_state_for` precedent (#3775) for additive storyboard-schema affordances on 3.0.x.
-
-The key shape is a free-form non-empty string keyed by the runtime agents map — the spec does not constrain to the specialism enum because production multi-agent topologies legitimately fan out per-property (`nyt_sales`, `wsj_sales`), per-region (`sales_eu`, `sales_us`), or per-brand-rights-holder. Cross-operator portability is the storyboard author's concern, not the spec's.
-
-### Brand-rights storyboard `acquire_rights` capture fix (#3893, closes #3892)
-
-The `brand_rights/rights_acquisition` storyboard's `acquire_rights` step captured a `context_outputs` field at path `rights_grant_id`, but `brand/acquire-rights-response.json` defines that field as `rights_id` (the `AcquireRightsAcquired` arm). Spec-compliant agents passed `response_schema` validation but failed the capture-and-pass-to-next-step machinery, which then cascade-skipped `rights_enforcement` with `prerequisite_failed`.
-
-3.0.5 corrects the storyboard to read `rights_id` (preserving the storyboard-internal `rights_grant_id` key name so no other steps need updates) and aligns the `expected:` prose to match the published schema (`status: acquired`, not the legacy `status: active`).
-
-Adopters running brand-rights conformance against a spec-compliant agent: bumping your SDK past 3.0.4 should flip the `brand_rights` storyboard from 3/5 scenarios passing to 5/5 with no agent-side changes.
-
-### Release mechanics (#3820)
-
-`forward-merge-3.0.yml`: explicitly push the `forward-merge/3.0.x` branch to origin **before** `peter-evans/create-pull-request@v8` runs. Discovered when 3.0.4's forward-merge ran for real: auto-resolution succeeded, then peter-evans crashed with `fatal: ambiguous argument 'origin/forward-merge/3.0.x': unknown revision`. Last gap in the auto-resolution chain — every subsequent Version Packages cut now auto-creates the forward-merge PR without human intervention.
-
-### Detailed changelog
-
-For the full per-PR change list, see [CHANGELOG.md § 3.0.5](https://github.com/adcontextprotocol/adcp/blob/main/CHANGELOG.md#305).
-
----
-
-## Version 3.0.4
-
-**Status:** Patch release — stable-surface no-op for 3.0-conformant agents
-
-**3.0.4 is the third 3.0.x patch.** Three additive cherry-picks from main, all hand-adapted for the maintenance line: the `manifest.json` + structured `enumMetadata` artifact (so SDKs stop hand-transcribing the spec), a normative `issues[]` array on `core/error.json`, and prose-only tightening of `AUTH_REQUIRED` to call out the retry-storm risk. Wire format unchanged.
-
-<Info>
-**Upgrading from 3.0.3?** No code changes required for 3.0-conformant agents. SDK consumers bump `ADCP_VERSION` to `3.0.4` to pick up `manifest.json` and the new `enumMetadata` block.
-</Info>
-
-### Adopter action
-
-| If you are… | What you need to do |
-|---|---|
-| A 3.0-conformant production agent | Nothing. Stable schemas remain wire-compatible with 3.0.0. |
-| An SDK author | Switch from parsing `Recovery: X` prose out of `enumDescriptions` to consuming the structured `enumMetadata` block. The build-time lint guarantees structured/prose parity, so the prose path can stay as a fallback while you migrate. |
-| An SDK consumer | Bump `ADCP_VERSION` to `3.0.4`. Pick up `/schemas/3.0.4/manifest.json` for one-stop tool/error/specialism enumeration. |
-| Implementing a buyer agent | Read the new `AUTH_REQUIRED` sub-cases in [error-handling.mdx](/docs/building/implementation/error-handling) — the wire code stays the same but you SHOULD NOT auto-retry when credentials were attached and rejected (terminal case). 3.1 will split this into separate enum values via #3739. |
-| Returning multi-field validation errors | Optionally populate `core/error.json`'s new top-level `issues[]` array (each entry: RFC 6901 pointer, message, JSON Schema keyword). Pre-3.1 consumers reading only `field` get the first failure; 3.1+ consumers prefer `issues`. |
-
-### `manifest.json` + structured `enumMetadata` (#3725, #3738)
-
-Two additive artifacts published with every released schema bundle:
-
-1. **`enums/error-code.json` gains an `enumMetadata` block.** Every error code now carries structured `recovery` (`correctable` | `transient` | `terminal`) and `suggestion` fields. SDKs MUST consume this block instead of parsing `Recovery: X` prose out of `enumDescriptions` — a build-time lint enforces structured/prose parity. Closes the root cause of [adcp-client#1135](https://github.com/adcontextprotocol/adcp-client/issues/1135) (17 missing codes, 3 wrong recovery classifications shipped in TS SDK for over a year).
-
-2. **`/schemas/3.0.4/manifest.json`.** Single canonical artifact listing every tool (with `protocol`, `mutating`, `request_schema`, `response_schema`, `async_response_schemas`, `specialisms`), every error code (with `recovery`, `description`, `suggestion`), an `error_code_policy` block (defining `default_unknown_recovery` so SDKs handle non-spec codes correctly), and every storyboard specialism (with `protocol`, `entry_point_tools`, `exercised_tools`). Validates against `manifest.schema.json`. Lets SDKs derive their internal tool/error tables from one place at codegen time.
-
-The 3.0.4 manifest covers exactly the 45 error codes 3.0.x ships (vs. main's 48 — three of main's codes don't exist in 3.0.x's enum and were trimmed during the cherry-pick).
-
-### `core/error.json` — `issues[]` field (#3059, #3562)
-
-Optional top-level `issues` array on the standard error envelope, normalizing what `@adcp/sdk` and prospectively `adcp-go` / `adcp-client-python` already need for multi-field validation rejections.
-
-```json
-{
-  "code": "VALIDATION_ERROR",
-  "message": "Request validation failed",
-  "field": "creatives[0].assets.image",
-  "issues": [
-    {
-      "pointer": "/creatives/0/assets/image",
-      "message": "Required",
-      "keyword": "required"
-    },
-    {
-      "pointer": "/creatives/0/format_id",
-      "message": "Must match pattern",
-      "keyword": "pattern"
-    }
-  ]
-}
-```
-
-Each entry is `{ pointer (RFC 6901), message, keyword, schemaPath? }`. `schemaPath` MAY be omitted in production to avoid fingerprinting `oneOf` branch selection on adversarial payloads.
-
-**Backward compatibility with `field` (singular):** when both are present, sellers SHOULD set `field` to `issues[0].pointer`. Pre-3.1 consumers reading only `field` get the first failure; 3.1+ consumers prefer the top-level `issues`. Sellers MAY mirror `issues[]` into `details.issues` for backward compat with consumers reading from `details`.
-
-### `AUTH_REQUIRED` retry-storm prose (#3730 partial, #3739 backport)
-
-`AUTH_REQUIRED` conflates two operationally distinct cases — credentials missing (genuinely correctable) and credentials presented but rejected (terminal — needs human rotation). A buyer agent treating both as `correctable` will retry-loop on revoked tokens, hammering seller SSO endpoints in a pattern indistinguishable from a brute-force probe.
-
-The 3.1 line splits this into `AUTH_MISSING` and `AUTH_INVALID` (#3739). 3.0.x cannot adopt the split — adding new enum values violates the maintenance line's semver rules. 3.0.4 ships the prose-only backport: the wire code stays `AUTH_REQUIRED` with `recovery: correctable`, but the description and `enumMetadata.suggestion` now spell out the two sub-cases and the SHOULD-NOT-auto-retry rule for the rejected-credential case. SDKs running against 3.0.x sellers can apply the operational distinction at the application layer.
-
-`docs/building/implementation/error-handling.mdx` gets a sub-case callout and an updated example showing how to branch on whether credentials were attached. Closes the 3.0.x portion of #3730; the full split lands in 3.1.0.
-
-### Detailed changelog
-
-For the full per-PR change list, see [CHANGELOG.md § 3.0.4](https://github.com/adcontextprotocol/adcp/blob/main/CHANGELOG.md#304).
-
----
-
-## Version 3.0.3
-
-**Status:** Patch release — additive storyboard schema field, stable-surface no-op for 3.0-conformant agents
-
-**3.0.3 ships the `provides_state_for` storyboard field** so the conformance suite can rescue cascade-skipping when two interchangeable stateful steps live in the same phase. Plus a docs-only fix for the `url_type` enum in channel docs that was emitting a value the published schema already excluded.
-
-<Info>
-**Upgrading from 3.0.2?** No code changes required for 3.0-conformant agents. Storyboard runners on `@adcp/sdk` 6.5.0+ pick up the new field automatically once the cache refreshes against 3.0.3.
-</Info>
-
-### Adopter action
-
-| If you are… | What you need to do |
-|---|---|
-| A 3.0-conformant production agent | Nothing. Stable schemas unchanged. |
-| Authoring storyboards | Optionally use `provides_state_for: <step_id>` on a stateful step to declare it substitutes for a missing peer step's state. Same-phase only; both steps must be `stateful: true`. The build-time lint enforces shape, target validity, statefulness, no self-reference, and no two-step cycles. |
-| Running storyboards via `@adcp/sdk` | Bump to 6.5.0+ to pick up the cascade-rescue runtime. Older SDK versions ignore the field and fall back to the existing `missing_tool` cascade behavior. |
-| A storyboard-authoring docs source (channels) | Replace `"url_type": "tracker"` with `"url_type": "tracker_pixel"` in any examples. The published schema enum already excluded `"tracker"`, so existing valid wire payloads are unaffected — only the prose docs were drifting. |
-
-### `provides_state_for` storyboard field (#3734)
-
-Optional `provides_state_for: <step_id> | <step_id>[]` on a stateful storyboard step declares that this step's pass establishes equivalent state for the named peer step(s) in the same phase. Pairs with the cascade-skip mechanism in `@adcp/sdk` 6.5.0+: when a peer step would otherwise grade `missing_tool` or `missing_test_controller`, the substitute waives the cascade and the runner grades the peer with the new `peer_substituted` skip reason.
-
-**Concrete impact:** explicit-mode social platforms (Snap, Meta, TikTok) intentionally pre-provision advertiser accounts out-of-band — `sync_accounts` is `missing_tool` by design, with `list_accounts` as the canonical alternative. 3.0.3's `sales-social/index.yaml` declares `provides_state_for: sync_accounts` on the `list_accounts` step, letting these adapters graduate from `1/9/0` (8 downstream stateful steps cascade-skipped) to `9/10` against the `sales_social` storyboard once the SDK cache refreshes.
-
-The field is part of the conformance harness, so it ships under the harness-additive patch-eligibility rule. Existing storyboards that don't use it keep their current cascade behavior — pure additive.
-
-Build-time validation (`scripts/lint-storyboard-provides-state-for.cjs`): rule shape, self-reference, unknown target, cross-phase reference (rejected — must be same-phase), target-not-stateful, substitute-not-stateful, and direct-cycle violations all fail loud.
-
-### `runner-output-contract.yaml` — `peer_substituted` skip reason
-
-Companion to `provides_state_for`: when the runner waives a cascade because a same-phase peer substituted for the state contract, it grades the original peer with `skip_result.reason = peer_substituted` and detail `"<this_step_id> state provided by <peer_phase_id>.<peer_step_id>"`. Distinct from `peer_branch_taken` (branch-set routing for mutually exclusive behaviors) and `not_applicable` (coverage gap — agent didn't declare the protocol).
-
-### `url_type: tracker` → `tracker_pixel` (#2986 step 1)
-
-Display, audio, carousels, and DOOH channel docs were emitting `"url_type": "tracker"` in examples — a value the published `url-asset-type.json` enum (`clickthrough` / `tracker_pixel` / `tracker_script`) already excluded. Fixed to `tracker_pixel`. Wire format unchanged; only prose docs were drifting.
-
-### Detailed changelog
-
-For the full per-PR change list, see [CHANGELOG.md § 3.0.3](https://github.com/adcontextprotocol/adcp/blob/main/CHANGELOG.md#303).
-
----
-
-## Version 3.0.2
-
-**Status:** Patch release — additive storyboard check kind + canonical asset-union schema
-
-**3.0.2 ships a new storyboard check kind** that closes a static-analysis gap in `@adcp/sdk`'s drift verifier, plus extracts a shared asset-variant `oneOf` union into its own schema file so codegen tools (notably `json-schema-to-typescript`) stop emitting numbered duplicate types.
-
-<Info>
-**Upgrading from 3.0.1?** No code changes required for 3.0-conformant agents. The check kind is consumed by the conformance runner, not by sellers; the asset-union refactor is a wire-format no-op.
-</Info>
-
-### Adopter action
-
-| If you are… | What you need to do |
-|---|---|
-| A 3.0-conformant production agent | Nothing. Wire format and validation semantics unchanged. |
-| An SDK author running codegen against schemas | Re-run `json-schema-to-typescript` (or your equivalent) to drop the `VASTAsset1`, `DAASTAsset1`, `BriefAsset1`, `CatalogAsset1` numbered duplicates. They were artifacts of the same `oneOf` union being encountered through multiple parent schemas; 3.0.2 references the canonical `core/assets/asset-union.json` from both `creative-asset.json` and `creative-manifest.json`. |
-| Authoring storyboards that assert envelope-level fields | Optionally use the new `envelope_field_present` check kind in place of `field_present` for `protocol-envelope.json` fields like `status`. The new check walks the envelope schema rather than the step's `response_schema_ref`, eliminating the static-analysis `VERIFIER_UNREACHABLE` gap in adcp-client's storyboard-drift verifier. |
-| Running storyboards via `@adcp/sdk` | Bump to the version that lands [adcp-client#1045](https://github.com/adcontextprotocol/adcp-client/pull/1045) for the new check kind. |
-
-### `envelope_field_present` check kind
-
-Storyboard `validations[].check` gains `envelope_field_present` as a peer of `field_present`. Same shape — `path` is RFC 6901-style — but resolves the path against `protocol-envelope.json` rather than the step's `response_schema_ref`. Used in `static/compliance/source/universal/v3-envelope-integrity.yaml` to assert that responses include `status`, where the previous `field_present` check left a `VERIFIER_UNREACHABLE` hole because `status` lives on the envelope, not the per-task response schema.
-
-### Canonical `core/assets/asset-union.json`
-
-The asset-variant `oneOf` union (the discriminated set of `image | video | text | url | vast | daast | ...` shapes) was inlined identically in `creative-asset.json` and `creative-manifest.json`. `json-schema-to-typescript` walking those parent schemas independently emitted `VASTAsset1`, `DAASTAsset1`, `BriefAsset1`, `CatalogAsset1` numbered-duplicate types — invisible at the wire level, irritating in generated code.
-
-3.0.2 promotes the union to `core/assets/asset-union.json` and references it via `$ref` from both parents. Codegen now emits a single `Asset` (or whatever your tool chooses) without the numbered duplicates. Wire format and validation semantics unchanged — pure refactor of the schema reference graph.
-
-### Detailed changelog
-
-For the full per-PR change list, see [CHANGELOG.md § 3.0.2](https://github.com/adcontextprotocol/adcp/blob/main/CHANGELOG.md#302).
-
----
-
-## Version 3.0.6
-
-**Status:** Patch release — stable-surface no-op for 3.0-conformant agents
-
-**3.0.6 makes the `GOVERNANCE_DENIED` wire-placement rule discoverable from the error code itself**, reserves the `ctx_metadata` keyword as an adapter-internal round-trip key, expands the SKILL.md guidance for `issues[]` recovery on the calling-agent side, and fixes two storyboard fixture bugs that were rejecting spec-compliant adopters. Wire format unchanged for any 3.0 agent.
-
-<Info>
-**Upgrading from 3.0.5?** No code changes required for 3.0-conformant agents. SDK consumers bump `ADCP_VERSION` to `3.0.6` to pick up the tightened error-code prose, the `ctx_metadata` reservation, and the corrected storyboard fixtures.
-</Info>
-
-### Adopter action
-
-| If you are… | What you need to do |
-|---|---|
-| A 3.0-conformant production agent | Nothing. Stable schemas remain wire-compatible with 3.0.0. |
-| Returning `GOVERNANCE_DENIED` from `acquire_rights` or `creative_approval` | Read the new wire-placement guidance on the error code. The canonical denial shape is the structured rejection arm (`AcquireRightsRejected` / `CreativeRejected`) — `status: "rejected"` + `reason`, **no** `errors[]`, transport markers stay green. The schema's `not: { required: ["errors"] }` clause was already enforcing this; the prose now makes the rule discoverable from the code. |
-| Returning `GOVERNANCE_DENIED` from `create_media_buy` (or any task without a rejection arm) | Continue populating `errors[].code` AND `adcp_error.code` per the two-layer model and flipping transport-level failure markers (HTTP 4xx / MCP `isError: true` / A2A `failed`). The wire-placement guidance distinguishes this Case-2 path from the rejection-arm path. |
-| Building an SDK adapter that wants to round-trip publisher state through AdCP resources | You MAY now use the reserved top-level `ctx_metadata` key on Product / MediaBuy / Package / Creative / AudienceSegment / Signal / RightsGrant. SDKs MUST strip the key before wire egress and SHOULD log a warning when stripping. Buyers never see this field. |
-| Authoring storyboards that capture state from A2A submitted-arm responses | The `task_completion.<inner>` prefix on `context_outputs[].path` is now documented in the storyboard schema. The runner polls `tasks/get` until terminal and resolves the suffix against the completion artifact's `data` — needed for captures like seller-assigned `media_buy_id` on IO-signing flows. Requires runner ≥ adcp-client v6.7. |
-| Running `comply_test_controller` | The visibility rule is now explicitly deployment-scoped, not request-gated. Production deployments MUST NOT expose the tool on any surface (`tools/list`, `compliance_testing` block in `get_adcp_capabilities`, dispatch). Live-mode probes get unknown-tool, not `FORBIDDEN`. |
-
-### `GOVERNANCE_DENIED` / `GOVERNANCE_UNAVAILABLE` wire-placement guidance (#3929, closes the doc-comment item on #3918; companion to #3914)
-
-`error-code.json` defined the two governance codes' semantics but didn't say WHERE in the response they appear. Storyboards interpreted differently — issue #3914 surfaced one mismatch where the brand-rights compliance storyboard expected `expect_error: code: GOVERNANCE_DENIED` even though `acquire_rights` already has a first-class `AcquireRightsRejected` discriminated arm. Adopters returning the spec-correct shape were failing the storyboard.
-
-The `enumDescriptions` for both codes now state placement explicitly:
-
-- **`GOVERNANCE_DENIED`** — structured business outcome, not a system error. **When the task response defines a structured rejection arm**, that arm IS the canonical denial shape: populate `status: "rejected"` + `reason`, do NOT additionally emit the code in `errors[]` or `adcp_error`, and do NOT flip transport-level failure markers. **When the task has no rejection arm**, populate `errors[].code` AND `adcp_error.code` per the two-layer model and DO flip transport markers.
-- **`GOVERNANCE_UNAVAILABLE`** — system error, governance call failed at all. Always populate both layers with the code and flip transport markers. Sellers MUST NOT use a structured rejection arm for unavailability even when the task offers one — the buyer's recovery semantics differ (retry-with-backoff vs. restructure-or-escalate).
-
-The MUST NOT against dual-emission isn't a behavior change — `AcquireRightsRejected` and `CreativeRejected` already declare `not: { required: [errors] }` at the schema layer, so emitting `errors[]` alongside a rejection arm was already a schema violation. The doc-comment makes the rule discoverable from the error code without changing what conformant senders produce.
-
-A parallel storyboard-authoring note in `error-handling.mdx` directs authors to assert on `field_value path: "status" value: "rejected"` rather than `error_code` for tasks that define a rejection arm. The existing `error_code` guidance is correct for tasks without a rejection arm.
-
-### `ctx_metadata` reserved as adapter-internal round-trip key (#3640)
-
-Reserves the top-level key `ctx_metadata` on AdCP resource objects (Product, MediaBuy, Package, Creative, AudienceSegment, Signal, RightsGrant) as a publisher-to-SDK round-trip cache for adapter-internal state. SDKs MUST strip the key before wire egress and MUST emit a warning-level log entry when stripping, so operators can detect accidental collisions with existing adapter code. Buyers never see this field.
-
-The convention is non-binding at the wire level — these resources already declare `additionalProperties: true` so existing payloads remain valid. The reservation locks the keyword name before two SDKs converge on it accidentally and ship divergent semantics. PropertyList and CollectionList are out of scope (`additionalProperties: false`) until a follow-up PR widens those schemas.
-
-### Implementation-dependent `issues[]` fields documented in SKILL.md (#3927 backport)
-
-`skills/call-adcp-agent/SKILL.md` already documented the three required `issues[]` fields (`pointer`, `keyword`, `variants`). 3.0.6 adds the four optional fields a calling agent will encounter when the seller's validator opts into them — `discriminator`, `schemaId`, `allowedValues`, `hint` — with a one-line preface clarifying these are implementation-dependent (not every validator emits them) and an updated recovery order: read `hint` first when present, then `discriminator`, then walk `variants`. Two new rows added to the symptom-fix lookup table for the same fields.
-
-No wire-format change. Pure documentation: shipping these fields is already a valid validator extension; this gives callers a curated path through them.
-
-### Storyboard-schema documents `task_completion.<inner>` prefix (#3955, closes #3950)
-
-The `context_outputs[].path` resolver gained a `task_completion.` prefix in the storyboard runner (`@adcp/sdk` 6.7+) for capturing values that materialize only on the terminal task artifact (e.g., seller-assigned `media_buy_id` on IO-signing flows where `create_media_buy` returns an A2A submitted-arm envelope). 3.0.6 adds the corresponding documentation to the storyboard authoring schema (`static/compliance/source/universal/storyboard-schema.yaml`).
-
-### `comply_test_controller` is deployment-scoped, not request-gated (#3992)
-
-Tightens the visibility rule for `comply_test_controller`: production deployments MUST NOT expose the tool on any surface — neither `tools/list`, nor the `compliance_testing` block in `get_adcp_capabilities`, nor request dispatch. Live-mode probes get unknown-tool (treated as a regular catalog miss), **not** `FORBIDDEN`. The previous prose left enough room that some adopters were emitting `FORBIDDEN` on live-mode dispatch, which is itself an information leak (an attacker probing for the tool can distinguish "not deployed" from "deployed but you can't use it").
-
-### Storyboard fixture fixes
-
-Two compliance-bundle fixture fixes that were causing spec-compliant adopters to fail published storyboards:
-
-- **`inventory_list_targeting`** — the 5 account blocks across this scenario use the brand+operator natural-key variant of `AccountReference` but omitted the `sandbox` flag. Sellers whose `accounts.resolve` has separate code paths for sandbox vs production refs were routing `create_media_buy` and `get_media_buys` through different account-id namespaces, breaking `mediaBuyStore` backfill of `targeting_overlay`. Setting `sandbox: true` on every account block keeps both create and get on the sandbox path. Mirror of [#3989](https://github.com/adcontextprotocol/adcp/pull/3989) on `main`. Follow-up to align the SDK runner's enricher asymmetry tracked at [adcp-client#1487](https://github.com/adcontextprotocol/adcp-client/issues/1487).
-- **`sales_guaranteed/create_media_buy`** — the `context_outputs[0].path` was bare `"media_buy_id"`, which the runner resolved against the immediate submitted-arm response — a step that fails with `capture_path_not_resolvable` and masks downstream phases. Updated to `"task_completion.media_buy_id"` so the runner polls `tasks/get` and captures the seller-issued id from the terminal artifact, per the runner contract introduced in adcp-client#1426. Mirror of [#3990](https://github.com/adcontextprotocol/adcp/pull/3990) on `main`.
-
----
-
-## Version 3.0.5
-
-**Status:** Patch release — stable-surface no-op for 3.0-conformant agents
-
-**3.0.5 unblocks `brand_json_url` adoption on 3.0**, ships an optional storyboard-authoring affordance, and corrects a brand-rights storyboard capture path that was rejecting spec-compliant agents. Wire format unchanged for any 3.0 agent that doesn't claim a new optional surface.
-
-<Info>
-**Upgrading from 3.0.4?** No code changes required for 3.0-conformant agents. SDK consumers bump `ADCP_VERSION` to `3.0.5` to pick up the relaxed `identity` validator and the brand-rights storyboard fix.
-</Info>
-
-### Adopter action
-
-| If you are… | What you need to do |
-|---|---|
-| A 3.0-conformant production agent | Nothing. Stable schemas remain wire-compatible with 3.0.0. |
-| Adopting `identity.brand_json_url` from #3690 on 3.0 | Bump to 3.0.5 (or have your SDK pick it up). 3.0.4 and earlier rejected the field at validation; 3.0.5 accepts it. |
-| Running brand-rights conformance against the published storyboard | Bump SDK to pick up `dist/compliance/3.0.5/specialisms/brand-rights/index.yaml`. Spec-compliant agents that return `rights_id` (per the published `acquire-rights-response.json`) now pass `rights_acquisition` and stop cascade-skipping `rights_enforcement`. |
-| Authoring multi-agent storyboards | You MAY now declare a top-level `default_agent: <key>` so multi-agent runners route cross-domain steps without per-CI-invocation overrides. Single-agent runs ignore the field. |
-
-### `identity.additionalProperties: true` on `get_adcp_capabilities` (#3896, closes Scope3 adoption gap)
-
-The `identity` block on `get-adcp-capabilities-response.json` was schema-closed (`additionalProperties: false`), which was the lone outlier among capability blocks — every peer (`media_buy`, `signals`, `creative`, `brand`, `compliance_testing`, `request_signing`, `webhook_signing`, `measurement`) already had `additionalProperties: true` at the outer level. The closed shape silently contradicted the forward-compat promise made by [#3690](https://github.com/adcontextprotocol/adcp/pull/3690) (`brand_url on get_adcp_capabilities for keys-from-agent-URL discovery`), which explicitly stated that 3.0-pinned implementers could adopt `identity.brand_json_url` without waiting for a schema bump.
-
-Without this relaxation, `@adcp/sdk`'s `createAdcpServer` (default strict-validation mode) rejected any operator response carrying `brand_json_url`, forcing adopters to disable validation entirely (a footgun) or wait for 3.1.
-
-3.0.5 mirrors what `main` already shipped post-#3690: the outer `identity` object opens; the inner blocks (`key_origins`, `compromise_notification`) stay closed where the security weight actually sits. Strictly additive — the closed property list (`per_principal_key_isolation`, `key_origins`, `compromise_notification`) is unchanged; receivers that ignore unknown fields keep working; receivers that look for new identity fields gain forward-compat without waiting for a 3.x bump. Buyers and verifiers SHOULD continue to allowlist known identity fields at read time rather than rely on schema closure for trust decisions.
-
-### Storyboard-level `default_agent` field (#3897, closes #3894)
-
-Optional top-level `default_agent: <key>` on the storyboard authoring schema (`dist/compliance/3.0.5/universal/storyboard-schema.yaml`). The multi-agent storyboard runner ([adcp-client#1066](https://github.com/adcontextprotocol/adcp-client/issues/1066), [#1355](https://github.com/adcontextprotocol/adcp-client/pull/1355)) already accepts `default_agent` via run-options; this change lets storyboard authors encode the topology intent in YAML once instead of re-asserting `--default-agent sales` on every CI invocation. Cross-domain tools (`sync_creatives`, `list_creative_formats`) become deterministic without per-step `agent:` overrides.
-
-Resolution order (runner contract):
-
-1. Step-level `agent:` override.
-2. Specialism-claimant match against the runtime agents map. Multi-claim grades `unrouted_step` (operator-config error); slots 3/4 do not rescue. Zero claimants falls through to slot 3.
-3. Storyboard-level `default_agent` (this field). Set-but-unmatched grades `default_agent_unresolved` — the runner does NOT silently fall through to slot 4, because that would invisibly override the storyboard author's encoded intent.
-4. Run-options `default_agent`. Same set-but-unmatched rule.
-5. Fail-fast — `unrouted_step`.
-
-Single-agent runs ignore the field entirely; existing 3.0.x storyboards keep working unchanged. Mirrors the `provides_state_for` precedent (#3775) for additive storyboard-schema affordances on 3.0.x.
-
-The key shape is a free-form non-empty string keyed by the runtime agents map — the spec does not constrain to the specialism enum because production multi-agent topologies legitimately fan out per-property (`nyt_sales`, `wsj_sales`), per-region (`sales_eu`, `sales_us`), or per-brand-rights-holder. Cross-operator portability is the storyboard author's concern, not the spec's.
-
-### Brand-rights storyboard `acquire_rights` capture fix (#3893, closes #3892)
-
-The `brand_rights/rights_acquisition` storyboard's `acquire_rights` step captured a `context_outputs` field at path `rights_grant_id`, but `brand/acquire-rights-response.json` defines that field as `rights_id` (the `AcquireRightsAcquired` arm). Spec-compliant agents passed `response_schema` validation but failed the capture-and-pass-to-next-step machinery, which then cascade-skipped `rights_enforcement` with `prerequisite_failed`.
-
-3.0.5 corrects the storyboard to read `rights_id` (preserving the storyboard-internal `rights_grant_id` key name so no other steps need updates) and aligns the `expected:` prose to match the published schema (`status: acquired`, not the legacy `status: active`).
-
-Adopters running brand-rights conformance against a spec-compliant agent: bumping your SDK past 3.0.4 should flip the `brand_rights` storyboard from 3/5 scenarios passing to 5/5 with no agent-side changes.
-
-### Release mechanics (#3820)
-
-`forward-merge-3.0.yml`: explicitly push the `forward-merge/3.0.x` branch to origin **before** `peter-evans/create-pull-request@v8` runs. Discovered when 3.0.4's forward-merge ran for real: auto-resolution succeeded, then peter-evans crashed with `fatal: ambiguous argument 'origin/forward-merge/3.0.x': unknown revision`. Last gap in the auto-resolution chain — every subsequent Version Packages cut now auto-creates the forward-merge PR without human intervention.
-
-### Detailed changelog
-
-For the full per-PR change list, see [CHANGELOG.md § 3.0.5](https://github.com/adcontextprotocol/adcp/blob/main/CHANGELOG.md#305).
-
----
-
-## Version 3.0.4
-
-**Status:** Patch release — stable-surface no-op for 3.0-conformant agents
-
-**3.0.4 is the third 3.0.x patch.** Three additive cherry-picks from main, all hand-adapted for the maintenance line: the `manifest.json` + structured `enumMetadata` artifact (so SDKs stop hand-transcribing the spec), a normative `issues[]` array on `core/error.json`, and prose-only tightening of `AUTH_REQUIRED` to call out the retry-storm risk. Wire format unchanged.
-
-<Info>
-**Upgrading from 3.0.3?** No code changes required for 3.0-conformant agents. SDK consumers bump `ADCP_VERSION` to `3.0.4` to pick up `manifest.json` and the new `enumMetadata` block.
-</Info>
-
-### Adopter action
-
-| If you are… | What you need to do |
-|---|---|
-| A 3.0-conformant production agent | Nothing. Stable schemas remain wire-compatible with 3.0.0. |
-| An SDK author | Switch from parsing `Recovery: X` prose out of `enumDescriptions` to consuming the structured `enumMetadata` block. The build-time lint guarantees structured/prose parity, so the prose path can stay as a fallback while you migrate. |
-| An SDK consumer | Bump `ADCP_VERSION` to `3.0.4`. Pick up `/schemas/3.0.4/manifest.json` for one-stop tool/error/specialism enumeration. |
-| Implementing a buyer agent | Read the new `AUTH_REQUIRED` sub-cases in [error-handling.mdx](/docs/building/implementation/error-handling) — the wire code stays the same but you SHOULD NOT auto-retry when credentials were attached and rejected (terminal case). 3.1 will split this into separate enum values via #3739. |
-| Returning multi-field validation errors | Optionally populate `core/error.json`'s new top-level `issues[]` array (each entry: RFC 6901 pointer, message, JSON Schema keyword). Pre-3.1 consumers reading only `field` get the first failure; 3.1+ consumers prefer `issues`. |
-
-### `manifest.json` + structured `enumMetadata` (#3725, #3738)
-
-Two additive artifacts published with every released schema bundle:
-
-1. **`enums/error-code.json` gains an `enumMetadata` block.** Every error code now carries structured `recovery` (`correctable` | `transient` | `terminal`) and `suggestion` fields. SDKs MUST consume this block instead of parsing `Recovery: X` prose out of `enumDescriptions` — a build-time lint enforces structured/prose parity. Closes the root cause of [adcp-client#1135](https://github.com/adcontextprotocol/adcp-client/issues/1135) (17 missing codes, 3 wrong recovery classifications shipped in TS SDK for over a year).
-
-2. **`/schemas/3.0.4/manifest.json`.** Single canonical artifact listing every tool (with `protocol`, `mutating`, `request_schema`, `response_schema`, `async_response_schemas`, `specialisms`), every error code (with `recovery`, `description`, `suggestion`), an `error_code_policy` block (defining `default_unknown_recovery` so SDKs handle non-spec codes correctly), and every storyboard specialism (with `protocol`, `entry_point_tools`, `exercised_tools`). Validates against `manifest.schema.json`. Lets SDKs derive their internal tool/error tables from one place at codegen time.
-
-The 3.0.4 manifest covers exactly the 45 error codes 3.0.x ships (vs. main's 48 — three of main's codes don't exist in 3.0.x's enum and were trimmed during the cherry-pick).
-
-### `core/error.json` — `issues[]` field (#3059, #3562)
-
-Optional top-level `issues` array on the standard error envelope, normalizing what `@adcp/sdk` and prospectively `adcp-go` / `adcp-client-python` already need for multi-field validation rejections.
-
-```json
-{
-  "code": "VALIDATION_ERROR",
-  "message": "Request validation failed",
-  "field": "creatives[0].assets.image",
-  "issues": [
-    {
-      "pointer": "/creatives/0/assets/image",
-      "message": "Required",
-      "keyword": "required"
-    },
-    {
-      "pointer": "/creatives/0/format_id",
-      "message": "Must match pattern",
-      "keyword": "pattern"
-    }
-  ]
-}
-```
-
-Each entry is `{ pointer (RFC 6901), message, keyword, schemaPath? }`. `schemaPath` MAY be omitted in production to avoid fingerprinting `oneOf` branch selection on adversarial payloads.
-
-**Backward compatibility with `field` (singular):** when both are present, sellers SHOULD set `field` to `issues[0].pointer`. Pre-3.1 consumers reading only `field` get the first failure; 3.1+ consumers prefer the top-level `issues`. Sellers MAY mirror `issues[]` into `details.issues` for backward compat with consumers reading from `details`.
-
-### `AUTH_REQUIRED` retry-storm prose (#3730 partial, #3739 backport)
-
-`AUTH_REQUIRED` conflates two operationally distinct cases — credentials missing (genuinely correctable) and credentials presented but rejected (terminal — needs human rotation). A buyer agent treating both as `correctable` will retry-loop on revoked tokens, hammering seller SSO endpoints in a pattern indistinguishable from a brute-force probe.
-
-The 3.1 line splits this into `AUTH_MISSING` and `AUTH_INVALID` (#3739). 3.0.x cannot adopt the split — adding new enum values violates the maintenance line's semver rules. 3.0.4 ships the prose-only backport: the wire code stays `AUTH_REQUIRED` with `recovery: correctable`, but the description and `enumMetadata.suggestion` now spell out the two sub-cases and the SHOULD-NOT-auto-retry rule for the rejected-credential case. SDKs running against 3.0.x sellers can apply the operational distinction at the application layer.
-
-`docs/building/implementation/error-handling.mdx` gets a sub-case callout and an updated example showing how to branch on whether credentials were attached. Closes the 3.0.x portion of #3730; the full split lands in 3.1.0.
-
-### Detailed changelog
-
-For the full per-PR change list, see [CHANGELOG.md § 3.0.4](https://github.com/adcontextprotocol/adcp/blob/main/CHANGELOG.md#304).
-
----
-
-## Version 3.0.3
-
-**Status:** Patch release — additive storyboard schema field, stable-surface no-op for 3.0-conformant agents
-
-**3.0.3 ships the `provides_state_for` storyboard field** so the conformance suite can rescue cascade-skipping when two interchangeable stateful steps live in the same phase. Plus a docs-only fix for the `url_type` enum in channel docs that was emitting a value the published schema already excluded.
-
-<Info>
-**Upgrading from 3.0.2?** No code changes required for 3.0-conformant agents. Storyboard runners on `@adcp/sdk` 6.5.0+ pick up the new field automatically once the cache refreshes against 3.0.3.
-</Info>
-
-### Adopter action
-
-| If you are… | What you need to do |
-|---|---|
-| A 3.0-conformant production agent | Nothing. Stable schemas unchanged. |
-| Authoring storyboards | Optionally use `provides_state_for: <step_id>` on a stateful step to declare it substitutes for a missing peer step's state. Same-phase only; both steps must be `stateful: true`. The build-time lint enforces shape, target validity, statefulness, no self-reference, and no two-step cycles. |
-| Running storyboards via `@adcp/sdk` | Bump to 6.5.0+ to pick up the cascade-rescue runtime. Older SDK versions ignore the field and fall back to the existing `missing_tool` cascade behavior. |
-| A storyboard-authoring docs source (channels) | Replace `"url_type": "tracker"` with `"url_type": "tracker_pixel"` in any examples. The published schema enum already excluded `"tracker"`, so existing valid wire payloads are unaffected — only the prose docs were drifting. |
-
-### `provides_state_for` storyboard field (#3734)
-
-Optional `provides_state_for: <step_id> | <step_id>[]` on a stateful storyboard step declares that this step's pass establishes equivalent state for the named peer step(s) in the same phase. Pairs with the cascade-skip mechanism in `@adcp/sdk` 6.5.0+: when a peer step would otherwise grade `missing_tool` or `missing_test_controller`, the substitute waives the cascade and the runner grades the peer with the new `peer_substituted` skip reason.
-
-**Concrete impact:** explicit-mode social platforms (Snap, Meta, TikTok) intentionally pre-provision advertiser accounts out-of-band — `sync_accounts` is `missing_tool` by design, with `list_accounts` as the canonical alternative. 3.0.3's `sales-social/index.yaml` declares `provides_state_for: sync_accounts` on the `list_accounts` step, letting these adapters graduate from `1/9/0` (8 downstream stateful steps cascade-skipped) to `9/10` against the `sales_social` storyboard once the SDK cache refreshes.
-
-The field is part of the conformance harness, so it ships under the harness-additive patch-eligibility rule. Existing storyboards that don't use it keep their current cascade behavior — pure additive.
-
-Build-time validation (`scripts/lint-storyboard-provides-state-for.cjs`): rule shape, self-reference, unknown target, cross-phase reference (rejected — must be same-phase), target-not-stateful, substitute-not-stateful, and direct-cycle violations all fail loud.
-
-### `runner-output-contract.yaml` — `peer_substituted` skip reason
-
-Companion to `provides_state_for`: when the runner waives a cascade because a same-phase peer substituted for the state contract, it grades the original peer with `skip_result.reason = peer_substituted` and detail `"<this_step_id> state provided by <peer_phase_id>.<peer_step_id>"`. Distinct from `peer_branch_taken` (branch-set routing for mutually exclusive behaviors) and `not_applicable` (coverage gap — agent didn't declare the protocol).
-
-### `url_type: tracker` → `tracker_pixel` (#2986 step 1)
-
-Display, audio, carousels, and DOOH channel docs were emitting `"url_type": "tracker"` in examples — a value the published `url-asset-type.json` enum (`clickthrough` / `tracker_pixel` / `tracker_script`) already excluded. Fixed to `tracker_pixel`. Wire format unchanged; only prose docs were drifting.
-
-### Detailed changelog
-
-For the full per-PR change list, see [CHANGELOG.md § 3.0.3](https://github.com/adcontextprotocol/adcp/blob/main/CHANGELOG.md#303).
-
----
-
-## Version 3.0.2
-
-**Status:** Patch release — additive storyboard check kind + canonical asset-union schema
-
-**3.0.2 ships a new storyboard check kind** that closes a static-analysis gap in `@adcp/sdk`'s drift verifier, plus extracts a shared asset-variant `oneOf` union into its own schema file so codegen tools (notably `json-schema-to-typescript`) stop emitting numbered duplicate types.
-
-<Info>
-**Upgrading from 3.0.1?** No code changes required for 3.0-conformant agents. The check kind is consumed by the conformance runner, not by sellers; the asset-union refactor is a wire-format no-op.
-</Info>
-
-### Adopter action
-
-| If you are… | What you need to do |
-|---|---|
-| A 3.0-conformant production agent | Nothing. Wire format and validation semantics unchanged. |
-| An SDK author running codegen against schemas | Re-run `json-schema-to-typescript` (or your equivalent) to drop the `VASTAsset1`, `DAASTAsset1`, `BriefAsset1`, `CatalogAsset1` numbered duplicates. They were artifacts of the same `oneOf` union being encountered through multiple parent schemas; 3.0.2 references the canonical `core/assets/asset-union.json` from both `creative-asset.json` and `creative-manifest.json`. |
-| Authoring storyboards that assert envelope-level fields | Optionally use the new `envelope_field_present` check kind in place of `field_present` for `protocol-envelope.json` fields like `status`. The new check walks the envelope schema rather than the step's `response_schema_ref`, eliminating the static-analysis `VERIFIER_UNREACHABLE` gap in adcp-client's storyboard-drift verifier. |
-| Running storyboards via `@adcp/sdk` | Bump to the version that lands [adcp-client#1045](https://github.com/adcontextprotocol/adcp-client/pull/1045) for the new check kind. |
-
-### `envelope_field_present` check kind
-
-Storyboard `validations[].check` gains `envelope_field_present` as a peer of `field_present`. Same shape — `path` is RFC 6901-style — but resolves the path against `protocol-envelope.json` rather than the step's `response_schema_ref`. Used in `static/compliance/source/universal/v3-envelope-integrity.yaml` to assert that responses include `status`, where the previous `field_present` check left a `VERIFIER_UNREACHABLE` hole because `status` lives on the envelope, not the per-task response schema.
-
-### Canonical `core/assets/asset-union.json`
-
-The asset-variant `oneOf` union (the discriminated set of `image | video | text | url | vast | daast | ...` shapes) was inlined identically in `creative-asset.json` and `creative-manifest.json`. `json-schema-to-typescript` walking those parent schemas independently emitted `VASTAsset1`, `DAASTAsset1`, `BriefAsset1`, `CatalogAsset1` numbered-duplicate types — invisible at the wire level, irritating in generated code.
-
-3.0.2 promotes the union to `core/assets/asset-union.json` and references it via `$ref` from both parents. Codegen now emits a single `Asset` (or whatever your tool chooses) without the numbered duplicates. Wire format and validation semantics unchanged — pure refactor of the schema reference graph.
-
-### Detailed changelog
-
-For the full per-PR change list, see [CHANGELOG.md § 3.0.2](https://github.com/adcontextprotocol/adcp/blob/main/CHANGELOG.md#302).
-
----
 
 ## Version 3.0.1
 

--- a/docs/reference/versions.mdx
+++ b/docs/reference/versions.mdx
@@ -7,16 +7,21 @@ description: "Every published AdCP version, its status, and its end-of-life date
 
 ## At a glance
 
+<Info>
+**Choosing today:** stable production integrations use 3.0 with wire pin `"3.0"`. 3.1 validation uses the current RC, `v3.1.0-rc.7`, with wire pin `"3.1-rc.7"`. After GA, 3.1 integrations use wire pin `"3.1"`.
+</Info>
+
 | Status | Versions | Wire pin | What it means |
 |---|---|---|---|
-| **Active** | 3.0 (current: 3.0.11) | `"3.0"` | Default for new integrations. Receives feature and security patches. |
+| **Active** | 3.0 (current stable: 3.0.15) | `"3.0"` | Stable default for production integrations. Receives feature and security patches. |
+| **Validation** | 3.1 (current RC: `v3.1.0-rc.7`) | `"3.1-rc.7"` during validation; `"3.1"` at GA | Feature-complete minor release validating through RC artifacts. See [What's New in AdCP 3.1](/docs/reference/whats-new-in-3-1) for the final feature set. |
 | **Security-only** | 2.5.0, 2.5.1, 2.5.3 | `"2.5"` | Security patches through **August 1, 2026 (UTC)**. Not safe for AAO-network production — see [v2 sunset](/docs/reference/v2-sunset). |
 | **End of life** | 2.0.0, 2.1.0 | — | No patches. Migrate to 3.0. |
-| **Planned** | 3.1, 3.2, 4.0 | — | Targets in [planned releases](/docs/reference/versioning#planned-releases). |
+| **Planned** | 3.2, 4.0 | — | Targets in [planned releases](/docs/reference/versioning#planned-releases). |
 
-**Wire values are release-precision only.** Send `"3.0"`, not `"3.0.11"` — a patch component on the wire is rejected. See [patches are not negotiated](/docs/reference/versioning#patches-are-not-negotiated).
+**Wire values are release-precision only.** Send `"3.0"` for the stable 3.0 line, exact pre-release pins such as `"3.1-rc.7"` while validating 3.1, and `"3.1"` only after GA. Do not send patch components like `"3.0.15"` or full semver pre-release values like `"3.1.0-rc.7"`. See [patches are not negotiated](/docs/reference/versioning#patches-are-not-negotiated).
 
-*Status legend: Active = current generation, receiving feature work. Security-only = patches for security issues only, no features. End of life = no patches. Planned = not yet released.*
+*Status legend: Active = current stable generation. Validation = feature-complete release candidate, not GA. Security-only = patches for security issues only, no features. End of life = no patches. Planned = not yet released.*
 
 ## All published versions
 
@@ -26,9 +31,10 @@ description: "Every published AdCP version, its status, and its end-of-life date
 |---|---|---|
 | 3.0.0 | 2026-04-22 | GA — stable baseline for the 3.x cycle. |
 | 3.0.1 through 3.0.10 | 2026-04-28 to 2026-05-10 | Patches. Wire-compatible with 3.0.0. |
-| **3.0.11** | **2026-05-11** | **Latest published patch.** |
+| 3.0.11 through **3.0.15** | 2026-05-11 to 2026-05-31 | Patches. **3.0.15 is the latest stable patch.** Wire-compatible with 3.0.0. |
+| 3.1.0-rc.1 through **3.1.0-rc.7** | 2026-05-29 to 2026-06-04 | Feature-complete 3.1 validation train. Current published RC is `v3.1.0-rc.7`; use wire pin `"3.1-rc.7"` during validation and `"3.1"` only after GA. See [What's New in AdCP 3.1](/docs/reference/whats-new-in-3-1) for the final feature list. |
 
-Patches don't change the wire contract. Upgrading within 3.0.x is always safe. For per-version detail, see [Release Notes](/docs/reference/release-notes) (curated narrative) and the [Changelog](/docs/reference/changelog) (full technical history).
+Patches don't change the wire contract. Upgrading within 3.0.x is always safe. 3.1 RC artifacts validate the next minor release; they are pinned exactly during validation and collapse to the `"3.1"` wire value at GA. For per-version detail, see [Release Notes](/docs/reference/release-notes) (curated narrative) and the [Changelog](/docs/reference/changelog) (full technical history).
 
 ### Prereleases (superseded)
 
@@ -52,7 +58,7 @@ After August 1, 2026 (UTC), the entire 2.x line is fully deprecated. The 2.x sch
 ## FAQ
 
 ### What's "current"?
-**3.0.11.** Pin your integration to `"3.0"` (not `"3.0.11"`) — wire values use release precision. See [Version negotiation](/docs/reference/versioning#version-negotiation).
+For stable production, **3.0.15** is current; pin your integration to `"3.0"` (not `"3.0.15"`). For 3.1 validation, the current published RC is **v3.1.0-rc.7**; pin to `"3.1-rc.7"` until GA, then use `"3.1"`. See [Version negotiation](/docs/reference/versioning#version-negotiation).
 
 ### What happened to 2.2, 2.3, 2.4, 2.6?
 The 2.x line skipped version numbers during its working-group cycle. Some appear as in-flight changelog entries but were never released — the changes were rolled forward into the next published version or deferred to 3.0. The five published 2.x releases are 2.0.0, 2.1.0, 2.5.0, 2.5.1, and 2.5.3.
@@ -70,15 +76,17 @@ Targeted for early 2027. 3.x is mid-cycle — see the [planned releases table](/
 
 | If you are… | Use |
 |---|---|
-| Building a new integration today | **3.0** (latest patch). Pin `"3.0"` on the wire. |
+| Building a production integration today | **3.0** (latest stable patch). Pin `"3.0"` on the wire. |
+| Validating the final 3.1 feature set before GA | **3.1.0-rc.7**. Pin `"3.1-rc.7"` on the wire, read [What's New in AdCP 3.1](/docs/reference/whats-new-in-3-1), and move to `"3.1"` at GA. |
 | Running a 2.5.x integration | Migrate to 3.0 before **Aug 1, 2026 (UTC)**. Start with the [migration guide](/docs/reference/migration). |
 | Running a 2.0 or 2.1 integration | Upgrade now — out of support. |
-| Trying an unreleased feature | See [prerelease upgrade notes](/docs/reference/migration/prerelease-upgrades) and [experimental status](/docs/reference/experimental-status). |
+| Trying a post-3.1 unreleased feature | See [Release Notes](/docs/reference/release-notes), [Versioning & Governance](/docs/reference/versioning), and [experimental status](/docs/reference/experimental-status). |
 
 ## Related
 
 - **[Versioning & Governance](/docs/reference/versioning)** — release tiers, schema-change scope, cadence policy
 - **[v2 Sunset](/docs/reference/v2-sunset)** — full v2 end-of-life timeline and migration paths
 - **[What's new in v3](/docs/reference/whats-new-in-v3)** — feature-by-feature summary of what 3.0 adds
+- **[What's New in AdCP 3.1](/docs/reference/whats-new-in-3-1)** — final 3.1 feature set and adopter actions
 - **[Release Notes](/docs/reference/release-notes)** — curated narrative for each version
 - **[Changelog](/docs/reference/changelog)** — full technical change history

--- a/docs/reference/whats-new-in-3-1.mdx
+++ b/docs/reference/whats-new-in-3-1.mdx
@@ -5,7 +5,7 @@ description: "Adopter overview of AdCP 3.1 — distributed brand.json, dependenc
 ---
 
 <Warning>
-**Status: 3.1 release-candidate validation.** The current published release candidate is `v3.1.0-rc.7`; its wire negotiation value is `adcp_version: "3.1-rc.7"`. The spec is feature-complete for 3.1 and validating through RC artifacts. Use `"3.1"` only after GA.
+**Status: 3.1 release-candidate validation.** Stable today: 3.0, wire pin `"3.0"`. Current validation track: `v3.1.0-rc.7`, wire pin `adcp_version: "3.1-rc.7"`. After GA: 3.1, wire pin `"3.1"`. The spec is feature-complete for 3.1 and validating through RC artifacts.
 </Warning>
 
 AdCP 3.1 is a minor release. Every 3.1 change is **additive** over 3.0: new fields are optional, no required field was removed, no shape changed in a way that breaks a 3.0-conformant client. **No breaking changes for 3.0-conformant agents.** Pre-GA adopters following the 3.1 RC stream should read the RC notes below because a few release-candidate surfaces were tightened before GA. During RC validation, use exact pre-release pins from `supported_versions`; move production pins to `"3.1"` at GA to pick up the new fields.
@@ -15,6 +15,21 @@ This page is the curated adopter overview for the 3.1 minor release. Need the fu
 <Note>
 **Looking for the major v2 → v3 changes instead?** See [What's New in AdCP 3](/docs/reference/whats-new-in-v3). This page covers the 3.0 → 3.1 minor delta only.
 </Note>
+
+## Final 3.1 feature set
+
+If you only need the final 3.1 shape after the RC train, read this list first:
+
+- **Versioning and validation.** Release-precision `adcp_version` pins, exact RC wire values such as `"3.1-rc.7"` during validation, `"3.1"` at GA, `supported_versions` advertisement, envelope echo, and version-scoped verification badges.
+- **Brand trust.** Distributed `brand.json`, sub-brand self-publishing through `brand_refs[]`, typed brand constraints, authorized operator scoping, and required signed responses for `verify_brand_claim` / `verify_brand_claims`.
+- **Signals and product targeting.** Enriched signal definitions, `SignalRef`, wholesale signal enumeration, product-scoped `included_signals`, selectable `signal_targeting_options`, grouped buy-time `signal_targeting_groups`, and clarified owned-vs-marketplace conformance.
+- **Wholesale feed mirroring.** Conditional fetch tokens, public/account `cache_scope`, product and signal wholesale-feed webhooks, and repair-by-read semantics for storefronts, registries, and federated marketplaces.
+- **Creative formats.** Canonical `format_kind` declarations, publisher format catalogs, `v1_format_ref` dual-emission, hosted audio/video `duration_ms_exact` plus one-sided `duration_ms_range`, published-post references, and video placement semantics.
+- **Creative generation.** `list_transformers`, account-scoped transformer selection, strict typed `config`, catalog and variant fan-out, advisory evaluator ranking, spend controls, content macros, free-text params, and per-output pricing receipts.
+- **Media-buy operations.** Dependency impairments, buyer-visible `webhook_activity[]`, action discovery, proposal-lifecycle cleanup, currency-scoped product discovery, sponsored/social placement fields, and SI availability status.
+- **Measurement and billing.** Vendor-attested `vendor_metric` goals, reach-window semantics, `viewability.viewed_seconds`, windowed delivery recovery, finality flags on delivery and usage, and out-of-band creative billing declarations.
+- **Runtime hardening.** Request idempotency on every task, `IDEMPOTENCY_IN_FLIGHT`, open error-code decoding with recovery classification, auth error split, credential-in-payload rejection, webhook operation-id echo, and flat MCP envelope tolerance.
+- **SDK and compliance readiness.** Named schemas for code generators, async-response refs, intentionally open payload markers, capability-gated storyboard coverage, packaged compliance bundle closure, and drift checks for release artifacts.
 
 ## Why upgrade
 


### PR DESCRIPTION
## Summary
- add a compact final 3.1 feature-set summary to the 3.1 overview and release notes
- update Versions & Compatibility to show stable 3.0.15 vs 3.1 rc.7 validation, including the right wire pins
- rename 3.1 release-note sections from RC-process wording to feature-first headings
- remove duplicated 3.0.6 through 3.0.2 release-note blocks
- align docs nav/sidebar labels and mirror the rc.7 snapshot

## Validation
- npm run test:docs-nav
- npm run test:release-docs-nav
- npm run test:rewrite-dist-redirect-links
- npm run test:rewrite-dist-links-idempotency
- npm run test:docs-error-handling-copy
- npm run check:owned-links
- git diff --check
- precommit hook: test:unit, test:test-dynamic-imports, test:callapi-state-change, typecheck
- pre-push hook: verify-version-sync, changeset guard, schema-link lint, Mintlify broken-links

Docs and DX expert passes found no remaining blockers after the stable 3.0 patch and banner fixes.