### PR TITLE
feat(brandfetch): add authenticated Brand Context enrichment

### DIFF
--- a/.changeset/brandfetch-brand-context-api.md
+++ b/.changeset/brandfetch-brand-context-api.md
@@ -1,0 +1,4 @@
+---
+---
+
+Integrate Brandfetch Brand Context API as authenticated ephemeral enrichment context.

--- a/.changeset/brandfetch-brand-context-api.md
+++ b/.changeset/brandfetch-brand-context-api.md
@@ -1,4 +1,5 @@
 ---
+"adcontextprotocol": minor
 ---
 
 Integrate Brandfetch Brand Context API as authenticated ephemeral enrichment context.

--- a/server/src/addie/mcp/brand-tools.ts
+++ b/server/src/addie/mcp/brand-tools.ts
@@ -186,8 +186,8 @@ export function createBrandToolHandlers(): Map<string, (args: Record<string, unk
     const existing = await brandDb.getDiscoveredBrandByDomain(domain);
     if (existing?.has_brand_manifest && existing.brand_manifest && existing.last_validated) {
       const ageMs = Date.now() - new Date(existing.last_validated).getTime();
+      const manifest = existing.brand_manifest as Record<string, unknown>;
       if (ageMs < ENRICHMENT_CACHE_MAX_AGE_MS) {
-        const manifest = existing.brand_manifest as Record<string, unknown>;
         const response: Record<string, unknown> = {
           success: true,
           domain: existing.domain,
@@ -197,6 +197,7 @@ export function createBrandToolHandlers(): Map<string, (args: Record<string, unk
           name: manifest.name,
           description: manifest.description,
           url: manifest.url,
+          tone: manifest.tone,
         };
         if (Array.isArray(manifest.logos) && manifest.logos.length > 0) {
           const logos = manifest.logos as Array<{ url: string; tags: string[] }>;
@@ -261,6 +262,7 @@ export function createBrandToolHandlers(): Map<string, (args: Record<string, unk
               logos,
               colors: result.manifest!.colors,
               fonts: result.manifest!.fonts,
+              tone: result.manifest!.tone,
               ...(result.company ? { company: result.company } : {}),
               ...(result.raw?.qualityScore !== undefined ? { quality_score: result.raw.qualityScore } : {}),
               ...(result.raw?.isNsfw ? { is_nsfw: true } : {}),
@@ -286,6 +288,7 @@ export function createBrandToolHandlers(): Map<string, (args: Record<string, unk
         name: result.manifest.name,
         description: result.manifest.description,
         url: result.manifest.url,
+        tone: result.manifest.tone,
       };
 
       if (result.manifest.logos && result.manifest.logos.length > 0) {
@@ -307,7 +310,6 @@ export function createBrandToolHandlers(): Map<string, (args: Record<string, unk
     if (result.company) {
       response.company = result.company;
     }
-
     return JSON.stringify(response, null, 2);
   });
 

--- a/server/src/addie/mcp/registry-review.ts
+++ b/server/src/addie/mcp/registry-review.ts
@@ -11,7 +11,7 @@ import { createLogger } from '../../logger.js';
 
 const logger = createLogger('addie-registry-review');
 import { ModelConfig } from '../../config/models.js';
-import { BrandDatabase } from '../../db/brand-db.js';
+import { BrandDatabase, sanitizeBrandSnapshot } from '../../db/brand-db.js';
 import { PropertyDatabase } from '../../db/property-db.js';
 import { BansDatabase } from '../../db/bans-db.js';
 import {
@@ -28,6 +28,10 @@ export interface ReviewResult {
 const brandDb = new BrandDatabase();
 const propertyDb = new PropertyDatabase();
 const bansDb = new BansDatabase();
+
+function reviewSnapshot(entityType: 'brand' | 'property', snapshot: Record<string, unknown>): Record<string, unknown> {
+  return entityType === 'brand' ? sanitizeBrandSnapshot(snapshot) : snapshot;
+}
 
 let client: Anthropic | null = null;
 function getClient(): Anthropic {
@@ -148,10 +152,12 @@ export async function reviewNewRecord(record: {
   snapshot: Record<string, unknown>;
   slack_thread_ts?: string;
 }): Promise<ReviewResult> {
+  const snapshot = reviewSnapshot(record.entity_type, record.snapshot);
+
   const prompt = `A community member (${record.editor_email || record.editor_user_id}) created a new ${record.entity_type} record for "${record.domain}".
 
 Record data:
-${JSON.stringify(record.snapshot, null, 2)}
+${JSON.stringify(snapshot, null, 2)}
 
 Does this look like a legitimate ${record.entity_type} record? Check for spam, nonsensical data, or obviously fake entries.`;
 
@@ -239,7 +245,9 @@ export async function reviewRegistryEdit(edit: {
   revision_number: number;
   slack_thread_ts?: string;
 }): Promise<ReviewResult> {
-  const diff = diffSnapshots(edit.old_snapshot, edit.new_snapshot);
+  const oldSnapshot = reviewSnapshot(edit.entity_type, edit.old_snapshot);
+  const newSnapshot = reviewSnapshot(edit.entity_type, edit.new_snapshot);
+  const diff = diffSnapshots(oldSnapshot, newSnapshot);
 
   const prompt = `A community member (${edit.editor_email || edit.editor_user_id}) edited the ${edit.entity_type} record for "${edit.domain}".
 

--- a/server/src/db/brand-db.ts
+++ b/server/src/db/brand-db.ts
@@ -11,7 +11,10 @@ import type {
 } from '../types.js';
 
 /**
- * Brand-manifest keys that the auth path reads as trust signals
+ * Brand-manifest keys that must not be accepted from caller-supplied
+ * manifests or historical snapshots restored through rollback.
+ *
+ * `classification` is a trust signal that the auth path reads
  * (`brand_manifest->'classification'->>'confidence' = 'high'` in
  * `org-filters.ts` gates membership inheritance via `house_domain`).
  *
@@ -30,25 +33,48 @@ import type {
  *
  * See issue #3467 and the architecture follow-up there.
  */
-const TRUSTED_MANIFEST_KEYS: ReadonlySet<string> = new Set(['classification']);
+const DISALLOWED_MANIFEST_KEYS: ReadonlySet<string> = new Set(['classification', 'brand_context']);
 
 /**
  * Strip auth-relevant keys from a caller-supplied brand_manifest. Returns
  * undefined when the input is undefined so caller checks for "provided"
  * still work. Mutates a shallow copy — does not touch the caller's object.
  */
-function sanitizeBrandManifest(
+export function sanitizeBrandManifest(
   manifest: Record<string, unknown> | undefined,
 ): Record<string, unknown> | undefined {
   if (!manifest) return manifest;
   let stripped: Record<string, unknown> | null = null;
-  for (const key of TRUSTED_MANIFEST_KEYS) {
+  for (const key of DISALLOWED_MANIFEST_KEYS) {
     if (key in manifest) {
       stripped ??= { ...manifest };
       delete stripped[key];
     }
   }
   return stripped ?? manifest;
+}
+
+export function sanitizeBrandSnapshot<T extends Record<string, unknown>>(snapshot: T): T {
+  const rawManifest = snapshot.brand_manifest;
+  let manifest: Record<string, unknown> | undefined;
+
+  if (typeof rawManifest === 'string') {
+    try {
+      const parsed = JSON.parse(rawManifest);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        manifest = parsed as Record<string, unknown>;
+      }
+    } catch {
+      return snapshot;
+    }
+  } else if (rawManifest && typeof rawManifest === 'object' && !Array.isArray(rawManifest)) {
+    manifest = rawManifest as Record<string, unknown>;
+  }
+
+  if (!manifest) return snapshot;
+  const sanitized = sanitizeBrandManifest(manifest);
+  if (sanitized === rawManifest) return snapshot;
+  return { ...snapshot, brand_manifest: sanitized } as T;
 }
 
 /**
@@ -1103,7 +1129,7 @@ export class BrandDatabase {
         ) VALUES ($1, 1, $2, $3, $4, $5, 'Initial record')`,
         [
           brand.domain,
-          JSON.stringify(brand),
+          JSON.stringify(sanitizeBrandSnapshot(brand as unknown as Record<string, unknown>)),
           editor.user_id,
           editor.email || null,
           editor.name || null,
@@ -1160,7 +1186,10 @@ export class BrandDatabase {
         if (current.source_type === 'brand_json') {
           throw new Error('Cannot modify agents on authoritative brand (managed via brand.json)');
         }
-        const manifest = (current.brand_manifest as Record<string, unknown>) || {};
+        const currentManifest = typeof current.brand_manifest === 'string'
+          ? JSON.parse(current.brand_manifest)
+          : current.brand_manifest;
+        const manifest = sanitizeBrandManifest((currentManifest as Record<string, unknown>) || {}) || {};
         manifest.agents = agents;
 
         // Create revision snapshot (brand_revisions uses brand_domain, not domain)
@@ -1173,7 +1202,15 @@ export class BrandDatabase {
         await client.query(
           `INSERT INTO brand_revisions (brand_domain, revision_number, snapshot, editor_user_id, editor_email, editor_name, edit_summary)
            VALUES ($1, $2, $3::jsonb, $4, $5, $6, $7)`,
-          [domain.toLowerCase(), revisionNumber, JSON.stringify(current), editor.user_id, editor.email || null, editor.name || null, editor.summary]
+          [
+            domain.toLowerCase(),
+            revisionNumber,
+            JSON.stringify(sanitizeBrandSnapshot(current as unknown as Record<string, unknown>)),
+            editor.user_id,
+            editor.email || null,
+            editor.name || null,
+            editor.summary,
+          ]
         );
 
         await client.query(
@@ -1262,7 +1299,7 @@ export class BrandDatabase {
         [
           domain.toLowerCase(),
           revisionNumber,
-          JSON.stringify(current),
+          JSON.stringify(sanitizeBrandSnapshot(current as unknown as Record<string, unknown>)),
           input.editor_user_id,
           input.editor_email || null,
           input.editor_name || null,
@@ -1410,9 +1447,9 @@ export class BrandDatabase {
         throw new Error(`Revision ${toRevisionNumber} not found for ${domain}`);
       }
 
-      const snapshot = typeof targetResult.rows[0].snapshot === 'string'
+      const snapshot = sanitizeBrandSnapshot((typeof targetResult.rows[0].snapshot === 'string'
         ? JSON.parse(targetResult.rows[0].snapshot)
-        : targetResult.rows[0].snapshot;
+        : targetResult.rows[0].snapshot) as Record<string, unknown>);
 
       // Lock current row and get current state for the new revision snapshot
       const currentResult = await client.query<DiscoveredBrand>(
@@ -1440,7 +1477,7 @@ export class BrandDatabase {
         [
           domain.toLowerCase(),
           revisionNumber,
-          JSON.stringify(currentResult.rows[0]),
+          JSON.stringify(sanitizeBrandSnapshot(currentResult.rows[0] as unknown as Record<string, unknown>)),
           editor.user_id,
           editor.email || null,
           editor.name || null,
@@ -1589,7 +1626,7 @@ export class BrandDatabase {
         [
           canonicalDomain,
           revisionNumber,
-          JSON.stringify(current),
+          JSON.stringify(sanitizeBrandSnapshot(current as unknown as Record<string, unknown>)),
           editor.userId,
           editor.email ?? null,
           editor.name ?? null,
@@ -1627,7 +1664,7 @@ export class BrandDatabase {
     return {
       ...row,
       domain: row.brand_domain || row.domain,
-      snapshot: typeof row.snapshot === 'string' ? JSON.parse(row.snapshot) : row.snapshot,
+      snapshot: sanitizeBrandSnapshot((typeof row.snapshot === 'string' ? JSON.parse(row.snapshot) : row.snapshot) as Record<string, unknown>),
       created_at: new Date(row.created_at),
     };
   }

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -574,6 +574,11 @@ async function getUserFromRequest(
   return null;
 }
 
+function stripLegacyBrandContext(manifest: Record<string, unknown>): Record<string, unknown> {
+  const { brand_context: _brandContext, ...publicManifest } = manifest;
+  return publicManifest;
+}
+
 export class HTTPServer {
   private app: express.Application;
   private server: Server | null = null;
@@ -1136,10 +1141,11 @@ export class HTTPServer {
         }
 
         const schemaUrl = 'https://adcontextprotocol.org/schemas/v3/brand.json';
+        const publicManifest = stripLegacyBrandContext(manifest);
         const brandJson: Record<string, unknown> =
-          typeof manifest.$schema === 'string' && manifest.$schema.startsWith('https://')
-            ? { ...manifest }
-            : { $schema: schemaUrl, ...manifest };
+          typeof publicManifest.$schema === 'string' && publicManifest.$schema.startsWith('https://')
+            ? { ...publicManifest }
+            : { $schema: schemaUrl, ...publicManifest };
 
         res.setHeader('Content-Type', 'application/json');
         res.setHeader('Cache-Control', 'public, max-age=300');
@@ -3035,7 +3041,7 @@ export class HTTPServer {
           editable: true,
           source_type: brand.source_type,
           brand_name: brand.brand_name,
-          brand_manifest: brand.brand_manifest,
+          brand_manifest: stripLegacyBrandContext((brand.brand_manifest as Record<string, unknown>) || {}),
           house_domain: brand.house_domain,
           keller_type: brand.keller_type,
         });

--- a/server/src/mcp-tools.ts
+++ b/server/src/mcp-tools.ts
@@ -1321,6 +1321,7 @@ export class MCPToolHandler {
         const existingBrand = await brandDb.getDiscoveredBrandByDomain(enrichDomain);
         if (existingBrand?.has_brand_manifest && existingBrand.brand_manifest && existingBrand.last_validated) {
           const ageMs = Date.now() - new Date(existingBrand.last_validated).getTime();
+          const { brand_context: _brandContext, ...manifest } = existingBrand.brand_manifest as Record<string, unknown>;
           if (ageMs < ENRICHMENT_CACHE_MAX_AGE_MS) {
             return {
               content: [
@@ -1333,8 +1334,8 @@ export class MCPToolHandler {
                       success: true,
                       domain: existingBrand.domain,
                       cached: true,
-                      manifest: existingBrand.brand_manifest,
-                      source: "enriched",
+                      manifest,
+                      source_type: existingBrand.source_type,
                       enrichment_provider: "brandfetch",
                     }, null, 2),
                   },
@@ -1365,22 +1366,28 @@ export class MCPToolHandler {
 
         const enrichment = await fetchBrandData(enrichDomain);
 
-        // Save enrichment to DB for future cache hits
-        if (enrichment.success && enrichment.manifest) {
-          brandDb.upsertDiscoveredBrand({
-            domain: enrichment.domain,
-            brand_name: enrichment.manifest.name,
-            brand_manifest: {
+        const manifest = enrichment.manifest
+          ? {
               name: enrichment.manifest.name,
               url: enrichment.manifest.url,
               description: enrichment.manifest.description,
               logos: enrichment.manifest.logos,
               colors: enrichment.manifest.colors,
               fonts: enrichment.manifest.fonts,
+              tone: enrichment.manifest.tone,
               ...(enrichment.company ? { company: enrichment.company } : {}),
-            },
+            }
+          : undefined;
+        const sourceType = enrichment.highQuality !== false ? 'enriched' : 'community';
+
+        // Save enrichment to DB for future cache hits
+        if (enrichment.success && enrichment.manifest) {
+          brandDb.upsertDiscoveredBrand({
+            domain: enrichment.domain,
+            brand_name: enrichment.manifest.name,
+            brand_manifest: manifest,
             has_brand_manifest: true,
-            source_type: 'enriched',
+            source_type: sourceType,
           }).catch((err) => {
             logger.warn({ err, domain: enrichDomain }, 'Failed to cache enrichment result');
           });
@@ -1394,8 +1401,12 @@ export class MCPToolHandler {
                 uri: `brand://enrichment/${encodeURIComponent(enrichDomain)}`,
                 mimeType: "application/json",
                 text: JSON.stringify({
-                  ...enrichment,
-                  source: "enriched",
+                  success: enrichment.success,
+                  domain: enrichment.domain,
+                  cached: false,
+                  ...(enrichment.error ? { error: enrichment.error } : {}),
+                  ...(manifest ? { manifest } : {}),
+                  source_type: enrichment.success ? sourceType : undefined,
                   enrichment_provider: "brandfetch",
                 }, null, 2),
               },

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -774,8 +774,6 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
     req.accessToken = 'workos-api-key';
     // Store API key info for permission checks
     (req as Request & { apiKey?: ValidatedApiKey }).apiKey = apiKey;
-    // API keys are org-scoped, so the caller is a member by definition
-    (req.user as unknown as Record<string, unknown>).isMember = true;
 
     // Check platform ban for API key
     const apiKeyBan = await checkPlatformBan(

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1765,6 +1765,73 @@ function extractSealedSession(req: Request): string | undefined {
  * Supports both cookie-based auth (web) and Authorization header (native apps)
  */
 export async function optionalAuth(req: Request, res: Response, next: NextFunction) {
+  if (hasValidAdminApiKey(req)) {
+    logger.debug({ path: req.path }, 'Authenticated via static admin API key (optional auth)');
+    req.user = {
+      id: 'admin_api_key',
+      email: 'admin-api-key@internal',
+      firstName: 'Admin',
+      lastName: 'API Key',
+      emailVerified: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    req.accessToken = 'admin-api-key';
+    (req as Request & { isStaticAdminApiKey?: boolean }).isStaticAdminApiKey = true;
+    return next();
+  }
+
+  const apiKey = await validateWorkOSApiKey(req);
+  if (apiKey) {
+    logger.debug({ path: req.path, apiKeyId: apiKey.id }, 'Authenticated via WorkOS API key (optional auth)');
+    req.user = {
+      id: `api_key_${apiKey.id}`,
+      email: `api-key@org-${apiKey.organizationId}`,
+      firstName: 'API',
+      lastName: apiKey.name,
+      emailVerified: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    req.accessToken = 'workos-api-key';
+    (req as Request & { apiKey?: ValidatedApiKey }).apiKey = apiKey;
+    (req.user as unknown as Record<string, unknown>).isMember = true;
+
+    const apiKeyBan = await checkPlatformBan(
+      `apikey:${apiKey.id}`,
+      () => bansDb.checkPlatformBanForApiKey(apiKey.id, apiKey.organizationId)
+    );
+    if (apiKeyBan) {
+      logger.info({ apiKeyId: apiKey.id, banId: apiKeyBan.id }, 'API key optional-auth request blocked by platform ban');
+      return sendBanResponse(res, apiKeyBan);
+    }
+
+    return next();
+  }
+
+  const jwtAuth = await validateWorkOSBearerJWT(req);
+  if (jwtAuth) {
+    logger.debug({ path: req.path, userId: jwtAuth.user.id }, 'Authenticated via OAuth user JWT (optional auth)');
+    req.user = jwtAuth.user;
+    req.accessToken = jwtAuth.rawToken;
+
+    try {
+      const userBan = await checkPlatformBan(
+        `user:${jwtAuth.user.id}`,
+        () => bansDb.checkPlatformBan(jwtAuth.user.id),
+      );
+      if (userBan) {
+        logger.info({ userId: jwtAuth.user.id, banId: userBan.id }, 'User optional-auth request blocked by platform ban');
+        return sendBanResponse(res, userBan);
+      }
+    } catch (banError) {
+      logger.warn({ err: banError, userId: jwtAuth.user.id, path: req.path }, 'Ban check failed — allowing optional-auth request through');
+    }
+
+    await attachIdentityId(req.user);
+    return next();
+  }
+
   // Dev mode: set dev user if logged in via dev-session cookie
   if (DEV_MODE_ENABLED) {
     const devUser = createDevUser(req);

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1795,7 +1795,6 @@ export async function optionalAuth(req: Request, res: Response, next: NextFuncti
     };
     req.accessToken = 'workos-api-key';
     (req as Request & { apiKey?: ValidatedApiKey }).apiKey = apiKey;
-    (req.user as unknown as Record<string, unknown>).isMember = true;
 
     const apiKeyBan = await checkPlatformBan(
       `apikey:${apiKey.id}`,

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -467,7 +467,8 @@ const EnrichBrandManifestSchema = z.object({
     role: z.string(),
   }).passthrough()).optional(),
   company: z.object({
-    name: z.string(),
+    name: z.string().optional(),
+    industry: z.string().optional(),
     industries: z.array(z.string()).optional(),
     employees: z.string().optional(),
     founded: z.number().optional(),

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -480,8 +480,11 @@ const EnrichBrandResponseSchema = z.object({
   domain: z.string(),
   cached: z.boolean(),
   manifest: EnrichBrandManifestSchema.optional(),
+  company: EnrichBrandManifestSchema.shape.company.optional(),
   source_type: z.enum(["brand_json", "community", "enriched"]).optional(),
   context: z.object({}).passthrough().optional(),
+  context_source: z.literal("brandfetch").optional(),
+  context_scope: z.literal("ephemeral").optional(),
   context_error: z.string().optional(),
 });
 

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -3468,17 +3468,20 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       if (existing?.has_brand_manifest && existing.brand_manifest && existing.last_validated) {
         const ageMs = Date.now() - new Date(existing.last_validated).getTime();
         const manifest = stripLegacyBrandContext(existing.brand_manifest) || {};
+        const company = (manifest as { company?: unknown }).company;
         if (ageMs < ENRICHMENT_CACHE_MAX_AGE_MS) {
           const contextResult = includeContext && isBrandfetchConfigured()
             ? await fetchBrandContext(domain)
             : undefined;
+          const hasContext = contextResult?.success && contextResult.context;
           return res.json({
             success: true,
             domain: existing.domain,
             cached: true,
             manifest,
+            ...(company ? { company } : {}),
             source_type: existing.source_type,
-            ...(contextResult?.success && contextResult.context ? { context: contextResult.context } : {}),
+            ...(hasContext ? { context: contextResult.context, context_source: 'brandfetch', context_scope: 'ephemeral' } : {}),
             ...(contextResult && !contextResult.success ? { context_error: contextResult.error } : {}),
           });
         }
@@ -3525,8 +3528,9 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         domain: enrichment.domain,
         cached: false,
         manifest,
+        ...(enrichment.company ? { company: enrichment.company } : {}),
         ...(sourceType ? { source_type: sourceType } : {}),
-        ...(includeContext && enrichment.context ? { context: enrichment.context } : {}),
+        ...(includeContext && enrichment.context ? { context: enrichment.context, context_source: 'brandfetch', context_scope: 'ephemeral' } : {}),
         ...(includeContext && enrichment.contextError ? { context_error: enrichment.contextError } : {}),
       });
     } catch (error) {

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -95,7 +95,7 @@ import type { CrawlerService } from "../crawler.js";
 import type { CapabilityDiscovery } from "../capabilities.js";
 import { aaoHostedBrandJsonUrl, aaoHostedAdagentsJsonUrl, expectedAdagentsJsonUrl } from "../config/aao.js";
 import { canonicalTargetUri } from "@adcp/sdk/signing";
-import { fetchBrandData, isBrandfetchConfigured, ENRICHMENT_CACHE_MAX_AGE_MS } from "../services/brandfetch.js";
+import { fetchBrandContext, fetchBrandData, isBrandfetchConfigured, ENRICHMENT_CACHE_MAX_AGE_MS } from "../services/brandfetch.js";
 import { extractPublisherPropertiesFromBrandJson } from "../services/brand-json-properties.js";
 import { syncHostedPropertyToFederatedIndex } from "../services/hosted-property-sync.js";
 import { verifyHostedPropertyOrigin } from "../services/hosted-property-origin-verifier.js";
@@ -449,16 +449,58 @@ registry.registerPath({
   },
 });
 
+const EnrichBrandManifestSchema = z.object({
+  name: z.string(),
+  url: z.string(),
+  description: z.string().optional(),
+  logos: z.array(z.object({
+    url: z.string(),
+    tags: z.array(z.string()),
+  })).optional(),
+  colors: z.object({
+    primary: z.string().optional(),
+    secondary: z.string().optional(),
+    accent: z.string().optional(),
+  }).passthrough().optional(),
+  fonts: z.array(z.object({
+    name: z.string(),
+    role: z.string(),
+  }).passthrough()).optional(),
+  company: z.object({
+    name: z.string(),
+    industries: z.array(z.string()).optional(),
+    employees: z.string().optional(),
+    founded: z.number().optional(),
+    location: z.string().optional(),
+  }).passthrough().optional(),
+}).passthrough();
+
+const EnrichBrandResponseSchema = z.object({
+  success: z.literal(true),
+  domain: z.string(),
+  cached: z.boolean(),
+  manifest: EnrichBrandManifestSchema.optional(),
+  source_type: z.enum(["brand_json", "community", "enriched"]).optional(),
+  context: z.object({}).passthrough().optional(),
+  context_error: z.string().optional(),
+});
+
+function stripLegacyBrandContext(manifest: unknown): Record<string, unknown> | undefined {
+  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) return undefined;
+  const { brand_context: _brandContext, ...publicManifest } = manifest as Record<string, unknown>;
+  return publicManifest;
+}
+
 registry.registerPath({
   method: "get",
   path: "/api/brands/enrich",
   operationId: "enrichBrand",
   summary: "Enrich brand",
-  description: "Enrich brand data using Brandfetch. Returns logo, colors, and company information.",
+  description: "Enrich brand data using Brandfetch. Returns logo, colors, and company information. Authenticated callers may also receive ephemeral Brand Context API identity/positioning/voice data.",
   tags: ["Brand Resolution"],
   request: { query: z.object({ domain: z.string().openapi({ example: "acmecorp.com" }) }) },
   responses: {
-    200: { description: "Enrichment data from Brandfetch", content: { "application/json": { schema: z.object({}).passthrough() } } },
+    200: { description: "Enrichment data from Brandfetch", content: { "application/json": { schema: EnrichBrandResponseSchema } } },
     503: { description: "Brandfetch not configured", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
@@ -3261,7 +3303,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
             canonical_domain: discovered.canonical_domain || discovered.domain,
             brand_name: discovered.brand_name,
             source: discovered.source_type,
-            brand_manifest: discovered.brand_manifest,
+            brand_manifest: stripLegacyBrandContext(discovered.brand_manifest),
           });
         }
         registryRequestsDb
@@ -3375,7 +3417,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       // Serve from DB — single brands table
       const brand = await brandDb.getDiscoveredBrandByDomain(domain);
       if (brand && brand.is_public !== false) {
-        const manifest = (brand.brand_manifest as Record<string, unknown>) || {};
+        const manifest = stripLegacyBrandContext(brand.brand_manifest) || {};
         const data = { name: brand.brand_name || domain, ...manifest };
         const enrichedData = await enrichBrandDataWithVerification(data);
 
@@ -3411,7 +3453,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
     }
   });
 
-  router.get("/brands/enrich", async (req, res) => {
+  router.get("/brands/enrich", optAuth, async (req, res) => {
     try {
       const rawDomain = req.query.domain as string;
       if (!rawDomain) {
@@ -3419,13 +3461,26 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       }
 
       const domain = extractDomain(rawDomain);
+      const includeContext = !!req.user || (req as Request & { isStaticAdminApiKey?: boolean }).isStaticAdminApiKey === true;
 
       // Return cached enrichment if still fresh (avoids Brandfetch API cost)
       const existing = await brandDb.getDiscoveredBrandByDomain(domain);
       if (existing?.has_brand_manifest && existing.brand_manifest && existing.last_validated) {
         const ageMs = Date.now() - new Date(existing.last_validated).getTime();
+        const manifest = stripLegacyBrandContext(existing.brand_manifest) || {};
         if (ageMs < ENRICHMENT_CACHE_MAX_AGE_MS) {
-          return res.json({ success: true, domain: existing.domain, cached: true, manifest: existing.brand_manifest });
+          const contextResult = includeContext && isBrandfetchConfigured()
+            ? await fetchBrandContext(domain)
+            : undefined;
+          return res.json({
+            success: true,
+            domain: existing.domain,
+            cached: true,
+            manifest,
+            source_type: existing.source_type,
+            ...(contextResult?.success && contextResult.context ? { context: contextResult.context } : {}),
+            ...(contextResult && !contextResult.success ? { context_error: contextResult.error } : {}),
+          });
         }
       }
 
@@ -3433,17 +3488,14 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         return res.status(503).json({ error: "Brandfetch not configured" });
       }
 
-      const enrichment = await fetchBrandData(domain);
+      const enrichment = await fetchBrandData(domain, { includeContext });
 
       if (!enrichment.success) {
         return res.status(404).json({ error: enrichment.error, domain });
       }
 
-      if (enrichment.manifest) {
-        brandDb.upsertDiscoveredBrand({
-          domain: enrichment.domain,
-          brand_name: enrichment.manifest.name,
-          brand_manifest: {
+      const manifest = enrichment.manifest
+        ? {
             name: enrichment.manifest.name,
             url: enrichment.manifest.url,
             description: enrichment.manifest.description,
@@ -3451,13 +3503,32 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
             colors: enrichment.manifest.colors,
             fonts: enrichment.manifest.fonts,
             ...(enrichment.company ? { company: enrichment.company } : {}),
-          },
+          }
+        : undefined;
+      const sourceType = enrichment.raw
+        ? (enrichment.highQuality !== false ? 'enriched' : 'community')
+        : undefined;
+
+      if (enrichment.raw && enrichment.manifest) {
+        const persistedSourceType = enrichment.highQuality !== false ? 'enriched' : 'community';
+        brandDb.upsertDiscoveredBrand({
+          domain: enrichment.domain,
+          brand_name: enrichment.manifest.name,
+          brand_manifest: manifest,
           has_brand_manifest: true,
-          source_type: 'enriched',
+          source_type: persistedSourceType,
         }).catch((err) => logger.warn({ err, domain }, 'Failed to save enrichment result'));
       }
 
-      return res.json({ success: true, domain: enrichment.domain, cached: false, manifest: enrichment.manifest, company: enrichment.company });
+      return res.json({
+        success: true,
+        domain: enrichment.domain,
+        cached: false,
+        manifest,
+        ...(sourceType ? { source_type: sourceType } : {}),
+        ...(includeContext && enrichment.context ? { context: enrichment.context } : {}),
+        ...(includeContext && enrichment.contextError ? { context_error: enrichment.contextError } : {}),
+      });
     } catch (error) {
       logger.error({ error }, "Failed to enrich brand");
       return res.status(500).json({ error: "Failed to enrich brand" });
@@ -3504,7 +3575,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
                   canonical_domain: discovered.canonical_domain || discovered.domain,
                   brand_name: discovered.brand_name,
                   source: discovered.source_type,
-                  brand_manifest: discovered.brand_manifest,
+                  brand_manifest: stripLegacyBrandContext(discovered.brand_manifest),
                 },
               };
             }

--- a/server/src/services/brand-identity.ts
+++ b/server/src/services/brand-identity.ts
@@ -302,7 +302,7 @@ function applyToBrandJson(
   logoUrl: string | null | undefined,
   brandColor: string | null | undefined,
 ): Record<string, unknown> {
-  const bj = { ...source };
+  const { brand_context: _brandContext, ...bj } = source;
   const brands = (bj.brands as Array<Record<string, unknown>> | undefined) ?? [];
 
   let primaryBrand: Record<string, unknown>;
@@ -330,4 +330,3 @@ function applyToBrandJson(
   bj.brands = [primaryBrand, ...brands.slice(1)];
   return bj;
 }
-

--- a/server/src/services/brandfetch.ts
+++ b/server/src/services/brandfetch.ts
@@ -256,6 +256,10 @@ function normalizeBrandfetchDomain(domain: string): { domain: string } | { error
   return { domain: normalizedDomain };
 }
 
+function brandfetchDomainPathSegment(domain: string): string {
+  return encodeURIComponent(domain);
+}
+
 /**
  * Fetch brand data from Brandfetch API
  */
@@ -291,10 +295,10 @@ export async function fetchBrandData(domain: string, options: FetchBrandDataOpti
     try {
       logger.info({ domain: normalizedDomain, attempt }, 'Fetching brand data from Brandfetch');
 
-      // CodeQL: BRANDFETCH_BRANDS_API_URL is from constant config, domain is normalized
-      const response = await axios.get( // lgtm[js/request-forgery]
-        `${BRANDFETCH_BRANDS_API_URL}/domain/${normalizedDomain}`,
+      const response = await axios.get(
+        `/domain/${brandfetchDomainPathSegment(normalizedDomain)}`,
         {
+          baseURL: BRANDFETCH_BRANDS_API_URL,
           headers: {
             Authorization: `Bearer ${BRANDFETCH_API_KEY}`,
             Accept: 'application/json',
@@ -426,10 +430,10 @@ export async function fetchBrandContext(domain: string): Promise<BrandfetchConte
     try {
       logger.info({ domain: normalizedDomain, attempt }, 'Fetching brand context from Brandfetch');
 
-      // CodeQL: BRANDFETCH_CONTEXT_API_URL is from constant config, domain is normalized
-      const response = await axios.get( // lgtm[js/request-forgery]
-        `${BRANDFETCH_CONTEXT_API_URL}/${normalizedDomain}`,
+      const response = await axios.get(
+        `/${brandfetchDomainPathSegment(normalizedDomain)}`,
         {
+          baseURL: BRANDFETCH_CONTEXT_API_URL,
           headers: {
             Authorization: `Bearer ${BRANDFETCH_API_KEY}`,
             Accept: 'application/json',

--- a/server/src/services/brandfetch.ts
+++ b/server/src/services/brandfetch.ts
@@ -4,16 +4,21 @@
  * When a domain doesn't have a brand.json file, we can use Brandfetch
  * to get brand data (logos, colors, company info) as a fallback.
  *
- * API Docs: https://docs.brandfetch.com/brand-api/overview
+ * API Docs:
+ * - https://docs.brandfetch.com/brand-api/overview
+ * - https://docs.brandfetch.com/brand-context-api/overview
  */
 
 import axios from 'axios';
 import { createLogger } from '../logger.js';
+import { assertValidBrandDomain, canonicalizeBrandDomain } from './identifier-normalization.js';
 
 const logger = createLogger('brandfetch');
 
 const BRANDFETCH_API_KEY = process.env.BRANDFETCH_API_KEY;
-const BRANDFETCH_API_URL = 'https://api.brandfetch.io/v2/brands';
+const BRANDFETCH_API_BASE_URL = 'https://api.brandfetch.io/v2';
+const BRANDFETCH_BRANDS_API_URL = `${BRANDFETCH_API_BASE_URL}/brands`;
+const BRANDFETCH_CONTEXT_API_URL = `${BRANDFETCH_API_BASE_URL}/context`;
 
 const BRANDFETCH_TIMEOUT_MS = 30_000; // 30 seconds
 const BRANDFETCH_MAX_RETRIES = 2;
@@ -106,6 +111,51 @@ export interface BrandfetchResponse {
   company?: BrandfetchCompany;
 }
 
+export interface BrandfetchContextResponse {
+  meta?: {
+    domain?: string;
+    canonical_name?: string;
+    resolved_at?: string;
+  };
+  identity?: {
+    tagline?: string;
+    mission?: string;
+    description?: string;
+    tags?: string[];
+  };
+  positioning?: {
+    value_proposition?: string;
+    target_audience?: Array<{
+      segment?: string;
+      description?: string;
+    }>;
+    products_and_services?: Array<{
+      name?: string;
+      type?: string;
+      description?: string;
+    }>;
+  };
+  brand?: {
+    voice?: {
+      summary?: string;
+      attributes?: string[];
+      avoid?: string[];
+    };
+    style?: {
+      summary?: string;
+      attributes?: string[];
+    };
+  };
+}
+
+export interface BrandfetchContextResult {
+  success: boolean;
+  domain: string;
+  context?: BrandfetchContextResponse;
+  error?: string;
+  cached?: boolean;
+}
+
 /**
  * AdCP Brand Manifest format (subset for enrichment)
  */
@@ -144,13 +194,24 @@ export interface BrandfetchEnrichmentResult {
    * When false, the result should be saved as 'community' rather than 'enriched'. */
   highQuality?: boolean;
   raw?: BrandfetchResponse;
+  context?: BrandfetchContextResponse;
+  contextError?: string;
   error?: string;
   cached?: boolean;
+}
+
+export interface FetchBrandDataOptions {
+  /**
+   * When true, also fetch Brandfetch Brand Context API data and return it as
+   * ephemeral context. Context text must not be persisted into brand_manifest.
+   */
+  includeContext?: boolean;
 }
 
 // Simple in-memory cache with short TTL (rate-limit protection only)
 // Enriched data should be saved to brands table for persistence
 const cache = new Map<string, { data: BrandfetchEnrichmentResult; expiresAt: number }>();
+const contextCache = new Map<string, { data: BrandfetchContextResult; expiresAt: number }>();
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes (rate-limit protection)
 
 // DB-level cache: callers should check brands.last_validated before hitting the API
@@ -166,10 +227,39 @@ export function isBrandfetchConfigured(): boolean {
   return !!BRANDFETCH_API_KEY;
 }
 
+export function summarizeBrandfetchError(error: unknown): { name?: string; message: string; code?: string; status?: number } {
+  if (!axios.isAxiosError(error)) {
+    return error instanceof Error
+      ? { name: error.name, message: error.message }
+      : { message: String(error) };
+  }
+
+  return {
+    name: error.name,
+    message: error.message,
+    code: error.code,
+    status: error.response?.status,
+  };
+}
+
+function normalizeBrandfetchDomain(domain: string): { domain: string } | { error: string; domain: string } {
+  const normalizedDomain = canonicalizeBrandDomain(domain);
+  try {
+    assertValidBrandDomain(normalizedDomain);
+  } catch {
+    return {
+      domain: normalizedDomain,
+      error: 'Invalid domain format',
+    };
+  }
+
+  return { domain: normalizedDomain };
+}
+
 /**
  * Fetch brand data from Brandfetch API
  */
-export async function fetchBrandData(domain: string): Promise<BrandfetchEnrichmentResult> {
+export async function fetchBrandData(domain: string, options: FetchBrandDataOptions = {}): Promise<BrandfetchEnrichmentResult> {
   if (!BRANDFETCH_API_KEY) {
     return {
       success: false,
@@ -178,15 +268,13 @@ export async function fetchBrandData(domain: string): Promise<BrandfetchEnrichme
     };
   }
 
-  // Normalize domain
-  const normalizedDomain = domain.replace(/^https?:\/\//, '').replace(/\/$/, '').toLowerCase();
-
-  // Validate domain to prevent SSRF — only allow valid domain characters
-  if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/.test(normalizedDomain)) {
+  const normalized = normalizeBrandfetchDomain(domain);
+  const normalizedDomain = normalized.domain;
+  if ('error' in normalized) {
     return {
       success: false,
       domain: normalizedDomain,
-      error: 'Invalid domain format',
+      error: normalized.error,
     };
   }
 
@@ -194,16 +282,18 @@ export async function fetchBrandData(domain: string): Promise<BrandfetchEnrichme
   const cached = cache.get(normalizedDomain);
   if (cached && cached.expiresAt > Date.now()) {
     logger.debug({ domain: normalizedDomain }, 'Brandfetch cache hit');
-    return { ...cached.data, cached: true };
+    const cachedResult = { ...cached.data, cached: true };
+    if (!options.includeContext) return cachedResult;
+    return withBrandContext(cachedResult);
   }
 
   for (let attempt = 0; attempt <= BRANDFETCH_MAX_RETRIES; attempt++) {
     try {
       logger.info({ domain: normalizedDomain, attempt }, 'Fetching brand data from Brandfetch');
 
-      // CodeQL: BRANDFETCH_API_URL is from env config, domain is normalized
+      // CodeQL: BRANDFETCH_BRANDS_API_URL is from constant config, domain is normalized
       const response = await axios.get( // lgtm[js/request-forgery]
-        `${BRANDFETCH_API_URL}/domain/${normalizedDomain}`,
+        `${BRANDFETCH_BRANDS_API_URL}/domain/${normalizedDomain}`,
         {
           headers: {
             Authorization: `Bearer ${BRANDFETCH_API_KEY}`,
@@ -216,6 +306,14 @@ export async function fetchBrandData(domain: string): Promise<BrandfetchEnrichme
       );
 
       if (response.status === 404) {
+        if (options.includeContext) {
+          const contextResult = await fetchBrandContext(normalizedDomain);
+          if (contextResult.success && contextResult.context) {
+            const result = mapContextToEnrichmentResult(normalizedDomain, contextResult.context);
+            return result;
+          }
+        }
+
         const result: BrandfetchEnrichmentResult = {
           success: false,
           domain: normalizedDomain,
@@ -265,7 +363,8 @@ export async function fetchBrandData(domain: string): Promise<BrandfetchEnrichme
         'Brand data fetched successfully'
       );
 
-      return result;
+      if (!options.includeContext) return result;
+      return withBrandContext(result);
     } catch (error) {
       const isTimeout = axios.isAxiosError(error) && (error.code === 'ECONNABORTED' || error.code === 'ETIMEDOUT');
       const isRetryable = isTimeout || (axios.isAxiosError(error) && !error.response);
@@ -278,7 +377,7 @@ export async function fetchBrandData(domain: string): Promise<BrandfetchEnrichme
       }
 
       const message = error instanceof Error ? error.message : 'Unknown error';
-      logger.warn({ error, domain: normalizedDomain, attempt }, 'Brandfetch fetch failed after retries');
+      logger.warn({ error: summarizeBrandfetchError(error), domain: normalizedDomain, attempt }, 'Brandfetch fetch failed after retries');
       return {
         success: false,
         domain: normalizedDomain,
@@ -292,6 +391,165 @@ export async function fetchBrandData(domain: string): Promise<BrandfetchEnrichme
     success: false,
     domain: normalizedDomain,
     error: 'Brandfetch fetch exhausted retries',
+  };
+}
+
+/**
+ * Fetch AI-oriented brand context from Brandfetch Brand Context API.
+ */
+export async function fetchBrandContext(domain: string): Promise<BrandfetchContextResult> {
+  if (!BRANDFETCH_API_KEY) {
+    return {
+      success: false,
+      domain,
+      error: 'BRANDFETCH_API_KEY not configured',
+    };
+  }
+
+  const normalized = normalizeBrandfetchDomain(domain);
+  const normalizedDomain = normalized.domain;
+  if ('error' in normalized) {
+    return {
+      success: false,
+      domain: normalizedDomain,
+      error: normalized.error,
+    };
+  }
+
+  const cached = contextCache.get(normalizedDomain);
+  if (cached && cached.expiresAt > Date.now()) {
+    logger.debug({ domain: normalizedDomain }, 'Brandfetch context cache hit');
+    return { ...cached.data, cached: true };
+  }
+
+  for (let attempt = 0; attempt <= BRANDFETCH_MAX_RETRIES; attempt++) {
+    try {
+      logger.info({ domain: normalizedDomain, attempt }, 'Fetching brand context from Brandfetch');
+
+      // CodeQL: BRANDFETCH_CONTEXT_API_URL is from constant config, domain is normalized
+      const response = await axios.get( // lgtm[js/request-forgery]
+        `${BRANDFETCH_CONTEXT_API_URL}/${normalizedDomain}`,
+        {
+          headers: {
+            Authorization: `Bearer ${BRANDFETCH_API_KEY}`,
+            Accept: 'application/json',
+          },
+          timeout: BRANDFETCH_TIMEOUT_MS,
+          validateStatus: () => true,
+          responseType: 'arraybuffer',
+        }
+      );
+
+      if (response.status === 404) {
+        const result: BrandfetchContextResult = {
+          success: false,
+          domain: normalizedDomain,
+          error: 'Brand context not found in Brandfetch',
+        };
+        contextCache.set(normalizedDomain, { data: result, expiresAt: Date.now() + 5 * 60 * 1000 });
+        return result;
+      }
+
+      const isRetryableStatus = response.status === 429 || (response.status >= 500 && response.status < 600);
+      if (isRetryableStatus && attempt < BRANDFETCH_MAX_RETRIES) {
+        const delay = BRANDFETCH_RETRY_DELAY_MS * Math.pow(2, attempt);
+        logger.warn({ status: response.status, domain: normalizedDomain, attempt, delay }, 'Brandfetch context transient error, retrying');
+        await new Promise(resolve => setTimeout(resolve, delay));
+        continue;
+      }
+
+      if (response.status !== 200) {
+        logger.warn({ status: response.status, domain: normalizedDomain }, 'Brandfetch context API non-2xx response');
+        return {
+          success: false,
+          domain: normalizedDomain,
+          error: `Brandfetch context API error: ${response.status}`,
+        };
+      }
+
+      let context: BrandfetchContextResponse;
+      try {
+        const text = Buffer.from(response.data as Buffer).toString('utf-8');
+        context = JSON.parse(text) as BrandfetchContextResponse;
+      } catch {
+        logger.warn({ domain: normalizedDomain }, 'Brandfetch context returned invalid JSON');
+        return {
+          success: false,
+          domain: normalizedDomain,
+          error: 'Brandfetch context returned invalid JSON',
+        };
+      }
+
+      const result: BrandfetchContextResult = {
+        success: true,
+        domain: normalizedDomain,
+        context,
+      };
+      contextCache.set(normalizedDomain, { data: result, expiresAt: Date.now() + CACHE_TTL_MS });
+      return result;
+    } catch (error) {
+      const isTimeout = axios.isAxiosError(error) && (error.code === 'ECONNABORTED' || error.code === 'ETIMEDOUT');
+      const isRetryable = isTimeout || (axios.isAxiosError(error) && !error.response);
+
+      if (isRetryable && attempt < BRANDFETCH_MAX_RETRIES) {
+        const delay = BRANDFETCH_RETRY_DELAY_MS * Math.pow(2, attempt);
+        logger.warn({ domain: normalizedDomain, attempt, delay, code: axios.isAxiosError(error) ? error.code : undefined }, 'Brandfetch context request failed, retrying');
+        await new Promise(resolve => setTimeout(resolve, delay));
+        continue;
+      }
+
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.warn({ error: summarizeBrandfetchError(error), domain: normalizedDomain, attempt }, 'Brandfetch context fetch failed after retries');
+      return {
+        success: false,
+        domain: normalizedDomain,
+        error: `Failed to fetch Brandfetch context: ${message}`,
+      };
+    }
+  }
+
+  return {
+    success: false,
+    domain: normalizedDomain,
+    error: 'Brandfetch context fetch exhausted retries',
+  };
+}
+
+async function withBrandContext(result: BrandfetchEnrichmentResult): Promise<BrandfetchEnrichmentResult> {
+  const contextResult = await fetchBrandContext(result.domain);
+  if (!contextResult.success || !contextResult.context) {
+    return {
+      ...result,
+      contextError: contextResult.error,
+    };
+  }
+
+  const context = contextResult.context;
+  if (!result.manifest) {
+    return mapContextToEnrichmentResult(result.domain, context);
+  }
+
+  return {
+    ...result,
+    context,
+  };
+}
+
+function mapContextToEnrichmentResult(
+  domain: string,
+  context: BrandfetchContextResponse
+): BrandfetchEnrichmentResult {
+  const name = context.meta?.canonical_name || domain;
+
+  return {
+    success: true,
+    domain,
+    manifest: {
+      name,
+      url: `https://${domain}`,
+    },
+    highQuality: false,
+    context,
   };
 }
 
@@ -408,4 +666,5 @@ function mapToEnrichmentResult(
  */
 export function clearCache(): void {
   cache.clear();
+  contextCache.clear();
 }

--- a/server/tests/integration/brand-orphan-adoption.test.ts
+++ b/server/tests/integration/brand-orphan-adoption.test.ts
@@ -117,6 +117,10 @@ describe('Brand orphan-adoption integration', () => {
         TEST_DOMAIN,
         PRIOR_ORG,
         JSON.stringify({
+          brand_context: {
+            brand: { voice: { summary: 'Legacy context must stay private.' } },
+            positioning: { value_proposition: 'Legacy positioning.' },
+          },
           brands: [{
             id: 'prior',
             names: [{ en: 'Prior Brand' }],
@@ -226,6 +230,7 @@ describe('Brand orphan-adoption integration', () => {
     const logos = r.brand_manifest.brands?.[0]?.logos ?? [];
     expect(logos.length).toBe(1);
     expect(logos[0].url).toBe('https://newowner.example.com/logo.png');
+    expect('brand_context' in r.brand_manifest).toBe(false);
   });
 
   it('updateBrandIdentity with adoptPriorManifest=true keeps the prior manifest and merges the new logo', async () => {
@@ -247,6 +252,7 @@ describe('Brand orphan-adoption integration', () => {
       workos_organization_id: string | null;
       is_public: boolean;
       brand_manifest: {
+        brand_context?: unknown;
         brands?: Array<{
           id?: string;
           names?: Array<Record<string, string>>;
@@ -272,6 +278,7 @@ describe('Brand orphan-adoption integration', () => {
     expect(primary?.colors?.primary).toBe('#aabbcc');
     expect(primary?.id).toBe('prior'); // prior brand id survives
     expect(primary?.names).toEqual([{ en: 'Prior Brand' }]); // prior name survives
+    expect('brand_context' in r.brand_manifest).toBe(false);
   });
 
   it('cross-org write to a non-orphaned brand still throws cross_org_ownership (not the orphan code)', async () => {

--- a/server/tests/unit/brand-db-house-domain-validation.test.ts
+++ b/server/tests/unit/brand-db-house-domain-validation.test.ts
@@ -20,7 +20,7 @@
  * target org.
  *
  * This test pins:
- *   1. `classification.*` keys are stripped from caller-supplied
+ *   1. `classification.*` and `brand_context` keys are stripped from caller-supplied
  *      brand_manifest on every community write path (upsert/create/edit).
  *   2. `house_domain` self-references are rejected.
  *   3. Control characters (NUL/CR/LF) and malformed domains are rejected.
@@ -61,7 +61,7 @@ describe('BrandDatabase: house_domain write-path validation (#3467)', () => {
   });
 
   describe('upsertDiscoveredBrand', () => {
-    it('strips caller-supplied classification.confidence from brand_manifest', async () => {
+    it('strips caller-supplied classification.confidence and brand_context from brand_manifest', async () => {
       mocks.query.mockResolvedValueOnce({
         rows: [{ domain: 'attacker.example', brand_names: '[]', brand_manifest: null, discovered_at: new Date(), last_validated: new Date() }],
       });
@@ -73,6 +73,7 @@ describe('BrandDatabase: house_domain write-path validation (#3467)', () => {
           name: 'Attacker',
           // Adversarial: try to inject the high-confidence trust signal directly.
           classification: { confidence: 'high', reasoning: 'forged' },
+          brand_context: { voice: { summary: 'persist me' } },
         },
         source_type: 'community',
       });
@@ -82,6 +83,7 @@ describe('BrandDatabase: house_domain write-path validation (#3467)', () => {
       // brand_manifest is the 12th positional param ($12) in the INSERT.
       const persistedManifest = JSON.parse(params[11] as string);
       expect(persistedManifest).not.toHaveProperty('classification');
+      expect(persistedManifest).not.toHaveProperty('brand_context');
       expect(persistedManifest.name).toBe('Attacker');
     });
 
@@ -161,7 +163,7 @@ describe('BrandDatabase: house_domain write-path validation (#3467)', () => {
   });
 
   describe('createDiscoveredBrand', () => {
-    it('strips caller-supplied classification.* from brand_manifest', async () => {
+    it('strips caller-supplied classification.* and brand_context from brand_manifest', async () => {
       const client = makeClient();
       mocks.getClient.mockResolvedValueOnce(client);
       client.query
@@ -180,7 +182,10 @@ describe('BrandDatabase: house_domain write-path validation (#3467)', () => {
         {
           domain: 'attacker.example',
           brand_name: 'Attacker',
-          brand_manifest: { classification: { confidence: 'high' } },
+          brand_manifest: {
+            classification: { confidence: 'high' },
+            brand_context: { voice: { summary: 'persist me' } },
+          },
           source_type: 'community',
         },
         { user_id: 'u1', email: 'a@b.c' },
@@ -200,6 +205,7 @@ describe('BrandDatabase: house_domain write-path validation (#3467)', () => {
       // failed write attempt with the auth signal removed).
       const parsed = JSON.parse(manifestParam!);
       expect(parsed).not.toHaveProperty('classification');
+      expect(parsed).not.toHaveProperty('brand_context');
     });
 
     it('rejects house_domain self-reference', async () => {
@@ -220,7 +226,7 @@ describe('BrandDatabase: house_domain write-path validation (#3467)', () => {
   });
 
   describe('editDiscoveredBrand', () => {
-    it('strips classification from caller-supplied brand_manifest and preserves prior classification', async () => {
+    it('strips classification and brand_context from caller-supplied brand_manifest and preserves prior classification', async () => {
       const client = makeClient();
       mocks.getClient.mockResolvedValueOnce(client);
       // BEGIN
@@ -252,6 +258,7 @@ describe('BrandDatabase: house_domain write-path validation (#3467)', () => {
           name: 'New',
           // Adversarial: try to overwrite the high-confidence trust signal.
           classification: { confidence: 'low' },
+          brand_context: { voice: { summary: 'persist me' } },
         },
         edit_summary: 'attacker edit',
         editor_user_id: 'u1',
@@ -268,6 +275,7 @@ describe('BrandDatabase: house_domain write-path validation (#3467)', () => {
       expect(manifestJson).toBeDefined();
       const persistedManifest = JSON.parse(manifestJson);
       expect(persistedManifest.name).toBe('New');
+      expect(persistedManifest).not.toHaveProperty('brand_context');
       // Prior trusted classification is preserved (caller cannot demote it
       // by supplying a low-confidence override).
       expect(persistedManifest.classification).toEqual({
@@ -286,6 +294,98 @@ describe('BrandDatabase: house_domain write-path validation (#3467)', () => {
           editor_user_id: 'u1',
         }),
       ).rejects.toThrow(/self-reference/i);
+    });
+  });
+
+  describe('rollbackBrand and revision reads', () => {
+    it('strips brand_context and caller-supplied classification when restoring from a revision snapshot', async () => {
+      const client = makeClient();
+      mocks.getClient.mockResolvedValueOnce(client);
+      client.query
+        // BEGIN
+        .mockResolvedValueOnce(undefined)
+        // SELECT target revision
+        .mockResolvedValueOnce({
+          rows: [{
+            snapshot: JSON.stringify({
+              domain: 'attacker.example',
+              brand_name: 'Attacker',
+              brand_names: [],
+              has_brand_manifest: true,
+              brand_manifest: {
+                name: 'Attacker',
+                classification: { confidence: 'high', reasoning: 'forged old snapshot' },
+                brand_context: { voice: { summary: 'legacy context' } },
+              },
+            }),
+          }],
+        })
+        // SELECT current FOR UPDATE
+        .mockResolvedValueOnce({
+          rows: [{
+            domain: 'attacker.example',
+            brand_name: 'Current',
+            brand_names: [],
+            brand_manifest: {
+              name: 'Current',
+              brand_context: { voice: { summary: 'current context' } },
+            },
+          }],
+        })
+        // SELECT next revision
+        .mockResolvedValueOnce({ rows: [{ next_rev: 4 }] })
+        // INSERT rollback revision
+        .mockResolvedValueOnce(undefined)
+        // UPDATE brands
+        .mockResolvedValueOnce({
+          rows: [{ domain: 'attacker.example', brand_names: '[]', brand_manifest: null, discovered_at: new Date() }],
+        })
+        // COMMIT
+        .mockResolvedValueOnce(undefined);
+
+      await db.rollbackBrand('attacker.example', 2, { user_id: 'admin' });
+
+      const updateCall = client.query.mock.calls.find(call =>
+        typeof call[0] === 'string' && (call[0] as string).includes('UPDATE brands SET'),
+      );
+      expect(updateCall).toBeDefined();
+      const params = updateCall![1] as unknown[];
+      const restoredManifest = JSON.parse(params[10] as string);
+      expect(restoredManifest).toEqual({ name: 'Attacker' });
+
+      const insertRevisionCall = client.query.mock.calls.find(call =>
+        typeof call[0] === 'string' && (call[0] as string).includes('INSERT INTO brand_revisions'),
+      );
+      const rollbackSnapshot = JSON.parse((insertRevisionCall![1] as unknown[])[2] as string);
+      expect(rollbackSnapshot.brand_manifest).toEqual({ name: 'Current' });
+    });
+
+    it('redacts brand_context from returned revision snapshots', async () => {
+      mocks.query.mockResolvedValueOnce({
+        rows: [{
+          id: 'rev-1',
+          brand_domain: 'attacker.example',
+          revision_number: 1,
+          snapshot: JSON.stringify({
+            domain: 'attacker.example',
+            brand_manifest: {
+              name: 'Attacker',
+              classification: { confidence: 'high' },
+              brand_context: { voice: { summary: 'legacy context' } },
+            },
+          }),
+          created_at: new Date(),
+        }],
+      });
+
+      const revision = await db.getBrandRevision('attacker.example', 1);
+
+      expect(revision?.snapshot).toMatchObject({
+        domain: 'attacker.example',
+        brand_manifest: { name: 'Attacker' },
+      });
+      expect((revision?.snapshot as Record<string, unknown>).brand_manifest).not.toHaveProperty('classification');
+      expect((revision?.snapshot as Record<string, unknown>).brand_manifest).not.toHaveProperty('brand_context');
     });
   });
 });

--- a/server/tests/unit/brandfetch-cache.test.ts
+++ b/server/tests/unit/brandfetch-cache.test.ts
@@ -67,6 +67,11 @@ describe('Brandfetch DB caching', () => {
           logos: [{ url: 'https://acme.com/logo.svg', tags: ['logo'] }],
           colors: { primary: '#ff0000' },
           fonts: [{ name: 'Inter', role: 'body' }],
+          tone: 'Plain-spoken and practical.',
+          brand_context: {
+            brand: { voice: { summary: 'Plain-spoken and practical.' } },
+            positioning: { value_proposition: 'Useful fictional tools.' },
+          },
           company: { name: 'Acme Corp', industry: 'Technology' },
         },
         last_validated: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000), // 7 days ago
@@ -84,6 +89,8 @@ describe('Brandfetch DB caching', () => {
       expect(result.logos).toHaveLength(1);
       expect(result.colors.primary).toBe('#ff0000');
       expect(result.company.name).toBe('Acme Corp');
+      expect(result.brand.tone).toBe('Plain-spoken and practical.');
+      expect(result.brand_context).toBeUndefined();
       expect(mockFetchBrandData).not.toHaveBeenCalled();
     });
 
@@ -149,6 +156,7 @@ describe('Brandfetch DB caching', () => {
           url: 'https://save.com',
           logos: [{ url: 'https://save.com/logo.svg', tags: ['logo'] }],
           colors: { primary: '#0000ff' },
+          tone: 'Confident but restrained.',
         },
         company: { name: 'Save Corp' },
       });
@@ -167,6 +175,7 @@ describe('Brandfetch DB caching', () => {
           brand_manifest: expect.objectContaining({
             name: 'Save Corp',
             url: 'https://save.com',
+            tone: 'Confident but restrained.',
             company: { name: 'Save Corp' },
           }),
         })

--- a/server/tests/unit/brandfetch-retry.test.ts
+++ b/server/tests/unit/brandfetch-retry.test.ts
@@ -36,6 +36,41 @@ function successPayload(domain: string) {
   return bufferOf({ id: 'x', name: 'Acme', domain, claimed: true, verified: true });
 }
 
+function brandPayload(domain: string, overrides: Record<string, unknown> = {}) {
+  return bufferOf({ id: 'x', name: 'Acme', domain, claimed: true, verified: true, ...overrides });
+}
+
+function contextPayload() {
+  return bufferOf({
+    meta: {
+      domain: 'acme.com',
+      canonical_name: 'Acme',
+      resolved_at: '2026-05-25T08:48:36.843440+00:00',
+    },
+    identity: {
+      tagline: 'Built for useful tests.',
+      description: 'Acme is a fictional brand used for integration tests.',
+      tags: ['B2B', 'Testing'],
+    },
+    positioning: {
+      value_proposition: 'Reliable fictional products for test suites.',
+      target_audience: [{ segment: 'Developers', description: 'Teams testing integrations.' }],
+      products_and_services: [{ name: 'Fixtures', type: 'product', description: 'Reusable test assets.' }],
+    },
+    brand: {
+      voice: {
+        summary: 'Clear and pragmatic.',
+        attributes: ['clear', 'direct'],
+        avoid: ['hype'],
+      },
+      style: {
+        summary: 'Simple, structured, and restrained.',
+        attributes: ['minimal', 'legible'],
+      },
+    },
+  });
+}
+
 describe('fetchBrandData retry behavior', () => {
   it('retries on 504 then succeeds', async () => {
     const { fetchBrandData } = await loadFresh();
@@ -107,6 +142,33 @@ describe('fetchBrandData retry behavior', () => {
     expect(mockedAxios.get).toHaveBeenCalledTimes(2);
   });
 
+  it('summarizes Axios errors without logging request config or authorization headers', async () => {
+    const { summarizeBrandfetchError } = await loadFresh();
+
+    const axiosError = Object.assign(new Error('socket hang up'), {
+      name: 'AxiosError',
+      isAxiosError: true,
+      code: 'ECONNRESET',
+      response: { status: 503 },
+      config: { headers: { Authorization: 'Bearer secret-brandfetch-key' } },
+    }) as AxiosError & { isAxiosError: true };
+    mockedAxios.isAxiosError.mockImplementation((err: unknown): err is AxiosError =>
+      typeof err === 'object' && err !== null && (err as { isAxiosError?: boolean }).isAxiosError === true
+    );
+
+    const summary = summarizeBrandfetchError(axiosError);
+
+    expect(summary).toEqual({
+      name: 'AxiosError',
+      message: 'socket hang up',
+      code: 'ECONNRESET',
+      status: 503,
+    });
+    expect(summary).not.toHaveProperty('config');
+    expect(JSON.stringify(summary)).not.toContain('secret-brandfetch-key');
+    expect(JSON.stringify(summary)).not.toContain('Authorization');
+  });
+
   it('returns failure (no retry) on 404', async () => {
     const { fetchBrandData } = await loadFresh();
 
@@ -143,6 +205,194 @@ describe('fetchBrandData retry behavior', () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain('504');
     // Initial attempt + 2 retries = 3 calls
+    expect(mockedAxios.get).toHaveBeenCalledTimes(3);
+  });
+
+  it('merges Brand Context API data when requested', async () => {
+    const { fetchBrandData } = await loadFresh();
+
+    mockedAxios.get
+      .mockResolvedValueOnce({ status: 200, data: successPayload('acme.com') })
+      .mockResolvedValueOnce({ status: 200, data: contextPayload() });
+
+    const result = await fetchBrandData('https://acme.com/about', { includeContext: true });
+
+    expect(result.success).toBe(true);
+    expect(result.highQuality).toBe(false);
+    expect(result.context?.identity?.description).toBe('Acme is a fictional brand used for integration tests.');
+    expect(result.context?.brand?.voice?.summary).toBe('Clear and pragmatic.');
+    expect((result.manifest as Record<string, unknown> | undefined)?.brand_context).toBeUndefined();
+    expect(result.manifest?.tone).toBeUndefined();
+    expect(mockedAxios.get).toHaveBeenNthCalledWith(
+      1,
+      'https://api.brandfetch.io/v2/brands/domain/acme.com',
+      expect.objectContaining({ headers: expect.objectContaining({ Accept: 'application/json' }) })
+    );
+    expect(mockedAxios.get).toHaveBeenNthCalledWith(
+      2,
+      'https://api.brandfetch.io/v2/context/acme.com',
+      expect.objectContaining({ headers: expect.objectContaining({ Accept: 'application/json' }) })
+    );
+  });
+
+  it('recovers a cached Brand API miss with Brand Context API data when context is later requested', async () => {
+    const { fetchBrandData } = await loadFresh();
+
+    mockedAxios.get
+      .mockResolvedValueOnce({ status: 404, data: Buffer.from('Not found') })
+      .mockResolvedValueOnce({ status: 200, data: contextPayload() });
+
+    const firstResult = await fetchBrandData('acme.com');
+    const secondResult = await fetchBrandData('acme.com', { includeContext: true });
+
+    expect(firstResult.success).toBe(false);
+    expect(firstResult.error).toContain('not found');
+    expect(secondResult.success).toBe(true);
+    expect(secondResult.manifest?.name).toBe('Acme');
+    expect(secondResult.context?.identity?.tagline).toBe('Built for useful tests.');
+    expect((secondResult.manifest as Record<string, unknown> | undefined)?.brand_context).toBeUndefined();
+    expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+    expect(mockedAxios.get).toHaveBeenNthCalledWith(
+      2,
+      'https://api.brandfetch.io/v2/context/acme.com',
+      expect.objectContaining({ headers: expect.objectContaining({ Accept: 'application/json' }) })
+    );
+  });
+
+  it('keeps Brand API data successful when Brand Context API fails', async () => {
+    const { fetchBrandData } = await loadFresh();
+
+    mockedAxios.get
+      .mockResolvedValueOnce({
+        status: 200,
+        data: brandPayload('acme.com', { description: 'Primary Brand API description.' }),
+      })
+      .mockResolvedValueOnce({ status: 400, data: Buffer.from('Bad request') });
+
+    const result = await fetchBrandData('acme.com', { includeContext: true });
+
+    expect(result.success).toBe(true);
+    expect(result.manifest?.description).toBe('Primary Brand API description.');
+    expect(result.context).toBeUndefined();
+    expect(result.contextError).toBe('Brandfetch context API error: 400');
+  });
+
+  it('retries transient Brand Context API failures', async () => {
+    const { fetchBrandContext } = await loadFresh();
+
+    mockedAxios.get
+      .mockResolvedValueOnce({ status: 429, data: Buffer.from('Too many requests') })
+      .mockResolvedValueOnce({ status: 200, data: contextPayload() });
+
+    const promise = fetchBrandContext('acme.com');
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    expect(result.context?.brand?.voice?.summary).toBe('Clear and pragmatic.');
+    expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('preserves Brand API description over Brand Context description', async () => {
+    const { fetchBrandData } = await loadFresh();
+
+    mockedAxios.get
+      .mockResolvedValueOnce({
+        status: 200,
+        data: brandPayload('acme.com', { description: 'Primary Brand API description.' }),
+      })
+      .mockResolvedValueOnce({ status: 200, data: contextPayload() });
+
+    const result = await fetchBrandData('acme.com', { includeContext: true });
+
+    expect(result.manifest?.description).toBe('Primary Brand API description.');
+    expect(result.context?.identity?.description).toBe('Acme is a fictional brand used for integration tests.');
+    expect((result.manifest as Record<string, unknown> | undefined)?.brand_context).toBeUndefined();
+  });
+
+  it('keeps low-score and NSFW Brand API results low quality even with narrative context', async () => {
+    const { fetchBrandData, clearCache } = await loadFresh();
+
+    mockedAxios.get
+      .mockResolvedValueOnce({
+        status: 200,
+        data: brandPayload('low-score.com', {
+          domain: 'low-score.com',
+          description: 'A low-score brand with text.',
+          qualityScore: 0.1,
+        }),
+      })
+      .mockResolvedValueOnce({ status: 200, data: contextPayload() });
+
+    const lowScore = await fetchBrandData('low-score.com', { includeContext: true });
+    expect(lowScore.success).toBe(true);
+    expect(lowScore.highQuality).toBe(false);
+
+    clearCache();
+    mockedAxios.get
+      .mockResolvedValueOnce({
+        status: 200,
+        data: brandPayload('nsfw.com', {
+          domain: 'nsfw.com',
+          description: 'A flagged brand with text.',
+          isNsfw: true,
+        }),
+      })
+      .mockResolvedValueOnce({ status: 200, data: contextPayload() });
+
+    const nsfw = await fetchBrandData('nsfw.com', { includeContext: true });
+    expect(nsfw.success).toBe(true);
+    expect(nsfw.highQuality).toBe(false);
+  });
+
+  it('does not promote weak Brand API results using Brand Context API narrative data', async () => {
+    const { fetchBrandData } = await loadFresh();
+
+    mockedAxios.get
+      .mockResolvedValueOnce({
+        status: 200,
+        data: brandPayload('weak.com', { domain: 'weak.com' }),
+      })
+      .mockResolvedValueOnce({ status: 200, data: contextPayload() });
+
+    const result = await fetchBrandData('weak.com', { includeContext: true });
+
+    expect(result.success).toBe(true);
+    expect(result.highQuality).toBe(false);
+    expect(result.context?.identity?.description).toBe('Acme is a fictional brand used for integration tests.');
+  });
+
+  it('uses Brand Context API as a fallback when the Brand API has no asset record', async () => {
+    const { fetchBrandData } = await loadFresh();
+
+    mockedAxios.get
+      .mockResolvedValueOnce({ status: 404, data: Buffer.from('Not found') })
+      .mockResolvedValueOnce({ status: 200, data: contextPayload() });
+
+    const result = await fetchBrandData('acme.com', { includeContext: true });
+
+    expect(result.success).toBe(true);
+    expect(result.manifest?.name).toBe('Acme');
+    expect(result.manifest?.description).toBeUndefined();
+    expect(result.context?.positioning?.value_proposition).toBe('Reliable fictional products for test suites.');
+    expect((result.manifest as Record<string, unknown> | undefined)?.brand_context).toBeUndefined();
+  });
+
+  it('does not serve context-only fallback results from the Brand API cache to no-context callers', async () => {
+    const { fetchBrandData } = await loadFresh();
+
+    mockedAxios.get
+      .mockResolvedValueOnce({ status: 404, data: Buffer.from('Not found') })
+      .mockResolvedValueOnce({ status: 200, data: contextPayload() })
+      .mockResolvedValueOnce({ status: 404, data: Buffer.from('Not found') });
+
+    const contextOnly = await fetchBrandData('acme.com', { includeContext: true });
+    const noContext = await fetchBrandData('acme.com');
+
+    expect(contextOnly.success).toBe(true);
+    expect(contextOnly.raw).toBeUndefined();
+    expect(noContext.success).toBe(false);
+    expect(noContext.error).toContain('not found');
     expect(mockedAxios.get).toHaveBeenCalledTimes(3);
   });
 });

--- a/server/tests/unit/brandfetch-retry.test.ts
+++ b/server/tests/unit/brandfetch-retry.test.ts
@@ -225,13 +225,19 @@ describe('fetchBrandData retry behavior', () => {
     expect(result.manifest?.tone).toBeUndefined();
     expect(mockedAxios.get).toHaveBeenNthCalledWith(
       1,
-      'https://api.brandfetch.io/v2/brands/domain/acme.com',
-      expect.objectContaining({ headers: expect.objectContaining({ Accept: 'application/json' }) })
+      '/domain/acme.com',
+      expect.objectContaining({
+        baseURL: 'https://api.brandfetch.io/v2/brands',
+        headers: expect.objectContaining({ Accept: 'application/json' }),
+      })
     );
     expect(mockedAxios.get).toHaveBeenNthCalledWith(
       2,
-      'https://api.brandfetch.io/v2/context/acme.com',
-      expect.objectContaining({ headers: expect.objectContaining({ Accept: 'application/json' }) })
+      '/acme.com',
+      expect.objectContaining({
+        baseURL: 'https://api.brandfetch.io/v2/context',
+        headers: expect.objectContaining({ Accept: 'application/json' }),
+      })
     );
   });
 
@@ -254,8 +260,11 @@ describe('fetchBrandData retry behavior', () => {
     expect(mockedAxios.get).toHaveBeenCalledTimes(2);
     expect(mockedAxios.get).toHaveBeenNthCalledWith(
       2,
-      'https://api.brandfetch.io/v2/context/acme.com',
-      expect.objectContaining({ headers: expect.objectContaining({ Accept: 'application/json' }) })
+      '/acme.com',
+      expect.objectContaining({
+        baseURL: 'https://api.brandfetch.io/v2/context',
+        headers: expect.objectContaining({ Accept: 'application/json' }),
+      })
     );
   });
 

--- a/server/tests/unit/certification-api-key-membership-gate.test.ts
+++ b/server/tests/unit/certification-api-key-membership-gate.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+const mocks = vi.hoisted(() => ({
+  createValidation: vi.fn(),
+  checkPlatformBanForApiKey: vi.fn(),
+  checkPlatformBan: vi.fn(),
+  enrichUserWithMembership: vi.fn(),
+  getModule: vi.fn(),
+  checkPrerequisites: vi.fn(),
+  getModuleProgress: vi.fn(),
+  startModule: vi.fn(),
+}));
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'sk_test';
+  process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+  process.env.WORKOS_COOKIE_PASSWORD =
+    process.env.WORKOS_COOKIE_PASSWORD ?? 'placeholder-cookie-password-32-bytes-min';
+});
+
+vi.mock('@workos-inc/node', () => ({
+  WorkOS: vi.fn(function WorkOS() {
+    return {
+      apiKeys: {
+        createValidation: mocks.createValidation,
+      },
+      userManagement: {
+        listOrganizationMemberships: vi.fn(),
+      },
+    };
+  }),
+}));
+
+vi.mock('../../src/db/bans-db.js', () => ({
+  bansDb: {
+    checkPlatformBanForApiKey: mocks.checkPlatformBanForApiKey,
+    checkPlatformBan: mocks.checkPlatformBan,
+  },
+}));
+
+vi.mock('../../src/utils/html-config.js', () => ({
+  enrichUserWithMembership: mocks.enrichUserWithMembership,
+}));
+
+vi.mock('../../src/db/certification-db.js', () => ({
+  getModule: mocks.getModule,
+  checkPrerequisites: mocks.checkPrerequisites,
+  getModuleProgress: mocks.getModuleProgress,
+  startModule: mocks.startModule,
+}));
+
+import { createCertificationRouters } from '../../src/routes/certification.js';
+
+function buildApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  const { userRouter } = createCertificationRouters();
+  app.use('/api/me', userRouter);
+  return app;
+}
+
+describe('certification API-key membership gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createValidation.mockResolvedValue({
+      apiKey: {
+        id: 'key_123',
+        owner: { id: 'org_free_tier' },
+        name: 'Free tier API key',
+        permissions: [],
+      },
+    });
+    mocks.checkPlatformBanForApiKey.mockResolvedValue({ banned: false, ban: null });
+    mocks.getModule.mockResolvedValue({
+      id: 'paid-module',
+      track_id: 'A',
+      title: 'Paid module',
+      description: null,
+      format: 'lesson',
+      duration_minutes: 30,
+      sort_order: 1,
+      is_free: false,
+      prerequisites: [],
+      lesson_plan: { objectives: [], key_concepts: [], discussion_prompts: [] },
+      exercise_definitions: [],
+      assessment_criteria: null,
+      tenant_ids: null,
+    });
+    mocks.enrichUserWithMembership.mockImplementation(async (user: { isMember?: boolean } | null | undefined) => {
+      if (user && user.isMember === undefined) user.isMember = false;
+      return user;
+    });
+    mocks.checkPrerequisites.mockResolvedValue({ met: true, missing: [] });
+    mocks.getModuleProgress.mockResolvedValue(null);
+    mocks.startModule.mockResolvedValue({ module_id: 'paid-module', status: 'in_progress' });
+  });
+
+  it('does not let a WorkOS API key start a paid module without resolved membership', async () => {
+    const res = await request(buildApp())
+      .post('/api/me/certification/modules/paid-module/start')
+      .set('Authorization', 'Bearer sk_test_free_tier')
+      .send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({
+      error: 'Membership required',
+      message: 'This module requires an active AgenticAdvertising.org membership.',
+    });
+    expect(mocks.enrichUserWithMembership).toHaveBeenCalledOnce();
+    expect(mocks.checkPrerequisites).not.toHaveBeenCalled();
+    expect(mocks.startModule).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/mcp-enrich-brand-context.test.ts
+++ b/server/tests/unit/mcp-enrich-brand-context.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getDiscoveredBrandByDomain: vi.fn(),
+  upsertDiscoveredBrand: vi.fn(),
+  fetchBrandData: vi.fn(),
+  isBrandfetchConfigured: vi.fn(),
+}));
+
+vi.mock('../../src/db/brand-db.js', () => ({
+  brandDb: {
+    getDiscoveredBrandByDomain: mocks.getDiscoveredBrandByDomain,
+    upsertDiscoveredBrand: mocks.upsertDiscoveredBrand,
+  },
+  BrandDatabase: class {},
+}));
+
+vi.mock('../../src/services/brandfetch.js', () => ({
+  fetchBrandData: mocks.fetchBrandData,
+  isBrandfetchConfigured: mocks.isBrandfetchConfigured,
+  ENRICHMENT_CACHE_MAX_AGE_MS: 30 * 24 * 60 * 60 * 1000,
+}));
+
+vi.mock('../../src/db/member-db.js', () => ({
+  MemberDatabase: class {},
+}));
+
+vi.mock('../../src/db/federated-index-db.js', () => ({
+  FederatedIndexDatabase: class {},
+}));
+
+vi.mock('../../src/db/organization-db.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/db/organization-db.js')>(
+    '../../src/db/organization-db.js'
+  );
+  return {
+    ...actual,
+    OrganizationDatabase: class {},
+  };
+});
+
+vi.mock('../../src/agent-service.js', () => ({ AgentService: class {} }));
+vi.mock('../../src/validator.js', () => ({ AgentValidator: class {} }));
+vi.mock('../../src/federated-index.js', () => ({ FederatedIndexService: class {} }));
+vi.mock('../../src/brand-manager.js', () => ({ BrandManager: class {} }));
+vi.mock('../../src/adagents-manager.js', () => ({ AdAgentsManager: class {} }));
+
+const { MCPToolHandler } = await import('../../src/mcp-tools.js');
+
+function parseResource(result: Awaited<ReturnType<InstanceType<typeof MCPToolHandler>['handleToolCall']>>) {
+  const first = result.content[0];
+  if (first.type !== 'resource' || !first.resource) throw new Error('expected resource');
+  return JSON.parse(first.resource.text);
+}
+
+describe('MCP enrich_brand Brand Context boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isBrandfetchConfigured.mockReturnValue(true);
+    mocks.upsertDiscoveredBrand.mockResolvedValue({});
+  });
+
+  it('strips legacy brand_context from cached manifests', async () => {
+    mocks.getDiscoveredBrandByDomain.mockResolvedValue({
+      domain: 'acme.com',
+      has_brand_manifest: true,
+      last_validated: new Date(),
+      source_type: 'enriched',
+      brand_manifest: {
+        name: 'Acme',
+        url: 'https://acme.com',
+        brand_context: { brand: { voice: { summary: 'legacy private context' } } },
+      },
+    });
+
+    const handler = new MCPToolHandler();
+    const result = await handler.handleToolCall('enrich_brand', { domain: 'https://acme.com/about' });
+    const body = parseResource(result);
+
+    expect(body).toMatchObject({
+      success: true,
+      domain: 'acme.com',
+      cached: true,
+      manifest: {
+        name: 'Acme',
+        url: 'https://acme.com',
+      },
+      source_type: 'enriched',
+      enrichment_provider: 'brandfetch',
+    });
+    expect(body.manifest.brand_context).toBeUndefined();
+    expect(body.context).toBeUndefined();
+    expect(mocks.fetchBrandData).not.toHaveBeenCalled();
+  });
+
+  it('does not emit or persist Brand Context from fresh enrichment results', async () => {
+    mocks.getDiscoveredBrandByDomain.mockResolvedValue(null);
+    mocks.fetchBrandData.mockResolvedValue({
+      success: true,
+      domain: 'acme.com',
+      raw: { id: 'bf_1', name: 'Acme', domain: 'acme.com' },
+      manifest: {
+        name: 'Acme',
+        url: 'https://acme.com',
+        description: 'Brand API description.',
+      },
+      context: {
+        brand: { voice: { summary: 'private context' } },
+      },
+      highQuality: true,
+    });
+
+    const handler = new MCPToolHandler();
+    const result = await handler.handleToolCall('enrich_brand', { domain: 'acme.com' });
+    const body = parseResource(result);
+
+    expect(mocks.fetchBrandData).toHaveBeenCalledWith('acme.com');
+    expect(body.context).toBeUndefined();
+    expect(body.manifest.brand_context).toBeUndefined();
+    expect(body.manifest).toEqual({
+      name: 'Acme',
+      url: 'https://acme.com',
+      description: 'Brand API description.',
+    });
+    expect(mocks.upsertDiscoveredBrand).toHaveBeenCalledWith(expect.objectContaining({
+      domain: 'acme.com',
+      brand_name: 'Acme',
+      source_type: 'enriched',
+      brand_manifest: {
+        name: 'Acme',
+        url: 'https://acme.com',
+        description: 'Brand API description.',
+      },
+    }));
+  });
+});

--- a/server/tests/unit/optional-auth-api-key-membership.test.ts
+++ b/server/tests/unit/optional-auth-api-key-membership.test.ts
@@ -1,0 +1,75 @@
+import type { NextFunction, Request, Response } from 'express';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  createValidation: vi.fn(),
+  checkPlatformBanForApiKey: vi.fn(),
+  checkPlatformBan: vi.fn(),
+}));
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'sk_test';
+  process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+  process.env.WORKOS_COOKIE_PASSWORD =
+    process.env.WORKOS_COOKIE_PASSWORD ?? 'placeholder-cookie-password-32-bytes-min';
+});
+
+vi.mock('@workos-inc/node', () => ({
+  WorkOS: vi.fn(function WorkOS() {
+    return {
+      apiKeys: {
+        createValidation: mocks.createValidation,
+      },
+    };
+  }),
+}));
+
+vi.mock('../../src/db/bans-db.js', () => ({
+  bansDb: {
+    checkPlatformBanForApiKey: mocks.checkPlatformBanForApiKey,
+    checkPlatformBan: mocks.checkPlatformBan,
+  },
+}));
+
+import { optionalAuth } from '../../src/middleware/auth.js';
+
+describe('optionalAuth WorkOS API keys', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.checkPlatformBanForApiKey.mockResolvedValue({ banned: false, ban: null });
+  });
+
+  it('authenticates the API key without granting AAO membership', async () => {
+    mocks.createValidation.mockResolvedValue({
+      apiKey: {
+        id: 'key_123',
+        owner: { id: 'org_free_tier' },
+        name: 'Free tier API key',
+        permissions: [],
+      },
+    });
+    const req = {
+      headers: { authorization: 'Bearer sk_test_free_tier' },
+      path: '/api/certification/modules/paid-module',
+    } as Request & { apiKey?: unknown };
+    const res = {} as Response;
+    const next = vi.fn() as NextFunction;
+
+    await optionalAuth(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(req.user).toMatchObject({
+      id: 'api_key_key_123',
+      email: 'api-key@org-org_free_tier',
+      firstName: 'API',
+      lastName: 'Free tier API key',
+    });
+    expect(req.accessToken).toBe('workos-api-key');
+    expect(req.apiKey).toMatchObject({
+      id: 'key_123',
+      organizationId: 'org_free_tier',
+      permissions: [],
+    });
+    expect((req.user as unknown as { isMember?: boolean }).isMember).toBeUndefined();
+  });
+});

--- a/server/tests/unit/public-brand-json-route.test.ts
+++ b/server/tests/unit/public-brand-json-route.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import request from 'supertest';
+import { HTTPServer } from '../../src/http.js';
+
+const ORIGINAL_WORKOS_ENV = vi.hoisted(() => ({
+  apiKey: process.env.WORKOS_API_KEY,
+  clientId: process.env.WORKOS_CLIENT_ID,
+}));
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY || 'sk_test_public_brand_json_route';
+  process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID || 'client_test_public_brand_json_route';
+});
+
+vi.mock('../../src/config.js', async () => {
+  const actual = await vi.importActual('../../src/config.js');
+  return {
+    ...actual,
+    getDatabaseConfig: vi.fn().mockReturnValue({
+      connectionString: 'postgresql://localhost/test',
+    }),
+  };
+});
+
+vi.mock('../../src/db/client.js', () => ({
+  initializeDatabase: vi.fn(),
+  getPool: vi.fn().mockReturnValue({ query: vi.fn() }),
+  isDatabaseInitialized: vi.fn().mockReturnValue(true),
+  closeDatabase: vi.fn(),
+  healthCheck: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/db/migrate.js', () => ({
+  runMigrations: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe('GET /brands/:domain/brand.json real route', () => {
+  let server: HTTPServer | undefined;
+
+  afterEach(async () => {
+    await server?.stop();
+    server = undefined;
+    if (ORIGINAL_WORKOS_ENV.apiKey === undefined) {
+      delete process.env.WORKOS_API_KEY;
+    } else {
+      process.env.WORKOS_API_KEY = ORIGINAL_WORKOS_ENV.apiKey;
+    }
+    if (ORIGINAL_WORKOS_ENV.clientId === undefined) {
+      delete process.env.WORKOS_CLIENT_ID;
+    } else {
+      process.env.WORKOS_CLIENT_ID = ORIGINAL_WORKOS_ENV.clientId;
+    }
+  });
+
+  it('strips legacy Brand Context API data from public enriched brand.json responses', async () => {
+    server = new HTTPServer();
+    const app = (server as unknown as { app: unknown }).app;
+    const getDiscoveredBrandByDomain = vi.fn().mockResolvedValue({
+      is_public: true,
+      source_type: 'enriched',
+      brand_manifest: {
+        name: 'Acme',
+        url: 'https://acme.com',
+        colors: { primary: '#123456' },
+        brand_context: {
+          brand: { voice: { summary: 'Private context should not be public.' } },
+          positioning: { value_proposition: 'Private positioning.' },
+        },
+      },
+    });
+    (server as unknown as { brandDb: { getDiscoveredBrandByDomain: typeof getDiscoveredBrandByDomain } }).brandDb = {
+      getDiscoveredBrandByDomain,
+    };
+
+    const res = await request(app).get('/brands/acme.com/brand.json');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['x-aao-source']).toBe('enriched');
+    expect(res.body).toMatchObject({
+      $schema: 'https://adcontextprotocol.org/schemas/v3/brand.json',
+      name: 'Acme',
+      url: 'https://acme.com',
+      colors: { primary: '#123456' },
+    });
+    expect(res.body.brand_context).toBeUndefined();
+  });
+
+  it('strips legacy Brand Context API data from discovered brand edit-status responses', async () => {
+    server = new HTTPServer();
+    const app = (server as unknown as { app: unknown }).app;
+    const getDiscoveredBrandByDomain = vi.fn().mockResolvedValue({
+      source_type: 'enriched',
+      review_status: 'approved',
+      brand_name: 'Acme',
+      brand_manifest: {
+        name: 'Acme',
+        url: 'https://acme.com',
+        brand_context: {
+          identity: { description: 'Private context should not be public.' },
+        },
+      },
+    });
+    (server as unknown as { brandDb: { getDiscoveredBrandByDomain: typeof getDiscoveredBrandByDomain } }).brandDb = {
+      getDiscoveredBrandByDomain,
+    };
+
+    const res = await request(app).get('/api/brands/discovered/acme.com/edit-status');
+
+    expect(res.status).toBe(200);
+    expect(res.body.editable).toBe(true);
+    expect(res.body.brand_manifest).toEqual({ name: 'Acme', url: 'https://acme.com' });
+  });
+});

--- a/server/tests/unit/registry-brand-enrich-route.test.ts
+++ b/server/tests/unit/registry-brand-enrich-route.test.ts
@@ -163,6 +163,50 @@ describe('GET /api/brands/enrich', () => {
     expect(mocks.fetchBrandData).not.toHaveBeenCalled();
   });
 
+  it('returns cached manifest with context_error when live cached Brand Context fetch fails', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue({
+        id: 'brand-1',
+        domain: 'acme.com',
+        has_brand_manifest: true,
+        brand_manifest: {
+          name: 'Acme',
+          url: 'https://acme.com',
+          brand_context: { identity: { description: 'legacy stored context' } },
+        },
+        source_type: 'enriched',
+        last_validated: new Date(),
+      }),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+    mocks.fetchBrandContext.mockResolvedValue({
+      success: false,
+      domain: 'acme.com',
+      error: 'Brand Context unavailable',
+    });
+
+    const res = await request(buildApp(brandDb, true)).get('/api/brands/enrich?domain=acme.com');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      success: true,
+      domain: 'acme.com',
+      cached: true,
+      manifest: {
+        name: 'Acme',
+        url: 'https://acme.com',
+      },
+      source_type: 'enriched',
+      context_error: 'Brand Context unavailable',
+    });
+    expect(res.body.context).toBeUndefined();
+    expect(res.body.context_source).toBeUndefined();
+    expect(res.body.context_scope).toBeUndefined();
+    expect(mocks.fetchBrandContext).toHaveBeenCalledWith('acme.com');
+    expect(mocks.fetchBrandData).not.toHaveBeenCalled();
+    expect(brandDb.upsertDiscoveredBrand).not.toHaveBeenCalled();
+  });
+
   it('persists only Brand API fields while returning Brand Context as ephemeral response context', async () => {
     const brandDb = {
       getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(null),

--- a/server/tests/unit/registry-brand-enrich-route.test.ts
+++ b/server/tests/unit/registry-brand-enrich-route.test.ts
@@ -26,6 +26,7 @@ function buildApp(
   brandDb: Pick<RegistryApiConfig['brandDb'], 'getDiscoveredBrandByDomain' | 'upsertDiscoveredBrand'>,
   authenticated = false,
   brandManager: Partial<RegistryApiConfig['brandManager']> = {},
+  staticAdminApiKey = false,
 ): express.Express {
   const app = express();
   app.use(express.json());
@@ -33,6 +34,9 @@ function buildApp(
   const optionalAuth: import('express').RequestHandler = (req, _res, next) => {
     if (authenticated) {
       req.user = { id: 'user_test', email: 'user@test.example' } as typeof req.user;
+    }
+    if (staticAdminApiKey) {
+      (req as typeof req & { isStaticAdminApiKey?: boolean }).isStaticAdminApiKey = true;
     }
     next();
   };
@@ -91,6 +95,7 @@ describe('GET /api/brands/enrich', () => {
           name: 'Acme',
           url: 'https://acme.com',
           description: 'Brand API description.',
+          company: { industry: 'Software' },
           brand_context: { brand: { voice: { summary: 'legacy stored context' } } },
         },
         source_type: 'enriched',
@@ -112,10 +117,50 @@ describe('GET /api/brands/enrich', () => {
       name: 'Acme',
       url: 'https://acme.com',
       description: 'Brand API description.',
+      company: { industry: 'Software' },
     });
+    expect(res.body.company).toEqual({ industry: 'Software' });
     expect(res.body.context.brand.voice.summary).toBe('live context');
+    expect(res.body.context_source).toBe('brandfetch');
+    expect(res.body.context_scope).toBe('ephemeral');
     expect(mocks.fetchBrandData).not.toHaveBeenCalled();
     expect(brandDb.upsertDiscoveredBrand).not.toHaveBeenCalled();
+  });
+
+  it('returns live context for static admin API key callers', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue({
+        id: 'brand-1',
+        domain: 'acme.com',
+        has_brand_manifest: true,
+        brand_manifest: {
+          name: 'Acme',
+          url: 'https://acme.com',
+          brand_context: { identity: { description: 'legacy stored context' } },
+        },
+        source_type: 'enriched',
+        last_validated: new Date(),
+      }),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+    mocks.fetchBrandContext.mockResolvedValue({
+      success: true,
+      domain: 'acme.com',
+      context: { identity: { description: 'live admin context' } },
+    });
+
+    const res = await request(buildApp(brandDb, false, {}, true)).get('/api/brands/enrich?domain=acme.com');
+
+    expect(res.status).toBe(200);
+    expect(res.body.manifest).toEqual({
+      name: 'Acme',
+      url: 'https://acme.com',
+    });
+    expect(res.body.context.identity.description).toBe('live admin context');
+    expect(res.body.context_source).toBe('brandfetch');
+    expect(res.body.context_scope).toBe('ephemeral');
+    expect(mocks.fetchBrandContext).toHaveBeenCalledWith('acme.com');
+    expect(mocks.fetchBrandData).not.toHaveBeenCalled();
   });
 
   it('persists only Brand API fields while returning Brand Context as ephemeral response context', async () => {
@@ -132,6 +177,7 @@ describe('GET /api/brands/enrich', () => {
         url: 'https://acme.com',
         description: 'Brand API description.',
       },
+      company: { industry: 'Software' },
       context: { identity: { description: 'Context description.' } },
       highQuality: true,
     });
@@ -144,8 +190,12 @@ describe('GET /api/brands/enrich', () => {
       name: 'Acme',
       url: 'https://acme.com',
       description: 'Brand API description.',
+      company: { industry: 'Software' },
     });
+    expect(res.body.company).toEqual({ industry: 'Software' });
     expect(res.body.context.identity.description).toBe('Context description.');
+    expect(res.body.context_source).toBe('brandfetch');
+    expect(res.body.context_scope).toBe('ephemeral');
     expect(brandDb.upsertDiscoveredBrand).toHaveBeenCalledWith(expect.objectContaining({
       domain: 'acme.com',
       brand_name: 'Acme',
@@ -154,6 +204,7 @@ describe('GET /api/brands/enrich', () => {
         name: 'Acme',
         url: 'https://acme.com',
         description: 'Brand API description.',
+        company: { industry: 'Software' },
       },
     }));
   });

--- a/server/tests/unit/registry-brand-enrich-route.test.ts
+++ b/server/tests/unit/registry-brand-enrich-route.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+const mocks = vi.hoisted(() => ({
+  fetchBrandData: vi.fn(),
+  fetchBrandContext: vi.fn(),
+  isBrandfetchConfigured: vi.fn(),
+}));
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'sk_test';
+  process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+});
+
+vi.mock('../../src/services/brandfetch.js', () => ({
+  fetchBrandData: mocks.fetchBrandData,
+  fetchBrandContext: mocks.fetchBrandContext,
+  isBrandfetchConfigured: mocks.isBrandfetchConfigured,
+  ENRICHMENT_CACHE_MAX_AGE_MS: 30 * 24 * 60 * 60 * 1000,
+}));
+
+import { createRegistryApiRouter, type RegistryApiConfig } from '../../src/routes/registry-api.js';
+
+function buildApp(
+  brandDb: Pick<RegistryApiConfig['brandDb'], 'getDiscoveredBrandByDomain' | 'upsertDiscoveredBrand'>,
+  authenticated = false,
+  brandManager: Partial<RegistryApiConfig['brandManager']> = {},
+): express.Express {
+  const app = express();
+  app.use(express.json());
+  const passAuth: import('express').RequestHandler = (_req, _res, next) => next();
+  const optionalAuth: import('express').RequestHandler = (req, _res, next) => {
+    if (authenticated) {
+      req.user = { id: 'user_test', email: 'user@test.example' } as typeof req.user;
+    }
+    next();
+  };
+  app.use('/api', createRegistryApiRouter({
+    brandManager: {
+      resolveBrand: vi.fn().mockResolvedValue(null),
+      validateDomain: vi.fn().mockResolvedValue({ valid: false, errors: [] }),
+      ...brandManager,
+    } as RegistryApiConfig['brandManager'],
+    brandDb: brandDb as RegistryApiConfig['brandDb'],
+    propertyDb: {} as RegistryApiConfig['propertyDb'],
+    adagentsManager: {} as RegistryApiConfig['adagentsManager'],
+    healthChecker: {} as RegistryApiConfig['healthChecker'],
+    crawler: {} as RegistryApiConfig['crawler'],
+    capabilityDiscovery: {} as RegistryApiConfig['capabilityDiscovery'],
+    registryRequestsDb: {
+      trackRequest: async () => {},
+      markResolved: async () => true,
+    },
+    requireAuth: passAuth,
+    optionalAuth,
+  }));
+  return app;
+}
+
+function discoveredBrandWithContext() {
+  return {
+    id: 'brand-1',
+    domain: 'acme.com',
+    canonical_domain: 'acme.com',
+    brand_name: 'Acme',
+    source_type: 'enriched',
+    is_public: true,
+    manifest_orphaned: false,
+    brand_manifest: {
+      name: 'Acme',
+      url: 'https://acme.com',
+      brand_context: { brand: { voice: { summary: 'legacy stored context' } } },
+    },
+  };
+}
+
+describe('GET /api/brands/enrich', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isBrandfetchConfigured.mockReturnValue(true);
+  });
+
+  it('strips persisted brand_context from cached manifests and returns live context top-level', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue({
+        id: 'brand-1',
+        domain: 'acme.com',
+        has_brand_manifest: true,
+        brand_manifest: {
+          name: 'Acme',
+          url: 'https://acme.com',
+          description: 'Brand API description.',
+          brand_context: { brand: { voice: { summary: 'legacy stored context' } } },
+        },
+        source_type: 'enriched',
+        last_validated: new Date(),
+      }),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+    mocks.fetchBrandContext.mockResolvedValue({
+      success: true,
+      domain: 'acme.com',
+      context: { brand: { voice: { summary: 'live context' } } },
+    });
+
+    const res = await request(buildApp(brandDb, true)).get('/api/brands/enrich?domain=acme.com');
+
+    expect(res.status).toBe(200);
+    expect(res.body.cached).toBe(true);
+    expect(res.body.manifest).toEqual({
+      name: 'Acme',
+      url: 'https://acme.com',
+      description: 'Brand API description.',
+    });
+    expect(res.body.context.brand.voice.summary).toBe('live context');
+    expect(mocks.fetchBrandData).not.toHaveBeenCalled();
+    expect(brandDb.upsertDiscoveredBrand).not.toHaveBeenCalled();
+  });
+
+  it('persists only Brand API fields while returning Brand Context as ephemeral response context', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(null),
+      upsertDiscoveredBrand: vi.fn().mockResolvedValue({}),
+    };
+    mocks.fetchBrandData.mockResolvedValue({
+      success: true,
+      domain: 'acme.com',
+      raw: { id: 'bf_1', name: 'Acme', domain: 'acme.com', claimed: true, verified: true, description: 'Brand API description.' },
+      manifest: {
+        name: 'Acme',
+        url: 'https://acme.com',
+        description: 'Brand API description.',
+      },
+      context: { identity: { description: 'Context description.' } },
+      highQuality: true,
+    });
+
+    const res = await request(buildApp(brandDb, true)).get('/api/brands/enrich?domain=acme.com');
+
+    expect(res.status).toBe(200);
+    expect(res.body.cached).toBe(false);
+    expect(res.body.manifest).toEqual({
+      name: 'Acme',
+      url: 'https://acme.com',
+      description: 'Brand API description.',
+    });
+    expect(res.body.context.identity.description).toBe('Context description.');
+    expect(brandDb.upsertDiscoveredBrand).toHaveBeenCalledWith(expect.objectContaining({
+      domain: 'acme.com',
+      brand_name: 'Acme',
+      source_type: 'enriched',
+      brand_manifest: {
+        name: 'Acme',
+        url: 'https://acme.com',
+        description: 'Brand API description.',
+      },
+    }));
+  });
+
+  it('does not persist context-only fallback results', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(null),
+      upsertDiscoveredBrand: vi.fn().mockResolvedValue({}),
+    };
+    mocks.fetchBrandData.mockResolvedValue({
+      success: true,
+      domain: 'context-only.com',
+      manifest: {
+        name: 'Context Only',
+        url: 'https://context-only.com',
+      },
+      context: { identity: { tagline: 'Only available from context.' } },
+      highQuality: false,
+    });
+
+    const res = await request(buildApp(brandDb, true)).get('/api/brands/enrich?domain=context-only.com');
+
+    expect(res.status).toBe(200);
+    expect(res.body.manifest.name).toBe('Context Only');
+    expect(res.body.context.identity.tagline).toBe('Only available from context.');
+    expect(res.body).not.toHaveProperty('source_type');
+    expect(brandDb.upsertDiscoveredBrand).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch or return Brand Context for anonymous callers', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(null),
+      upsertDiscoveredBrand: vi.fn().mockResolvedValue({}),
+    };
+    mocks.fetchBrandData.mockResolvedValue({
+      success: true,
+      domain: 'acme.com',
+      raw: { id: 'bf_1', name: 'Acme', domain: 'acme.com', claimed: true, verified: true },
+      manifest: {
+        name: 'Acme',
+        url: 'https://acme.com',
+      },
+      highQuality: true,
+    });
+
+    const res = await request(buildApp(brandDb)).get('/api/brands/enrich?domain=acme.com');
+
+    expect(res.status).toBe(200);
+    expect(res.body.context).toBeUndefined();
+    expect(res.body.context_error).toBeUndefined();
+    expect(mocks.fetchBrandData).toHaveBeenCalledWith('acme.com', { includeContext: false });
+    expect(mocks.fetchBrandContext).not.toHaveBeenCalled();
+  });
+});
+
+describe('public registry brand read paths', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isBrandfetchConfigured.mockReturnValue(true);
+  });
+
+  it('strips legacy brand_context from /api/brands/resolve fallback manifests', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(discoveredBrandWithContext()),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+
+    const res = await request(buildApp(brandDb)).get('/api/brands/resolve?domain=acme.com');
+
+    expect(res.status).toBe(200);
+    expect(res.body.brand_manifest).toEqual({ name: 'Acme', url: 'https://acme.com' });
+  });
+
+  it('strips legacy brand_context from /api/brands/resolve/bulk fallback manifests', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(discoveredBrandWithContext()),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+
+    const res = await request(buildApp(brandDb))
+      .post('/api/brands/resolve/bulk')
+      .send({ domains: ['acme.com'] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.results['acme.com'].brand_manifest).toEqual({ name: 'Acme', url: 'https://acme.com' });
+  });
+
+  it('strips legacy brand_context from /api/brands/brand-json cached data', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(discoveredBrandWithContext()),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+
+    const res = await request(buildApp(brandDb)).get('/api/brands/brand-json?domain=acme.com');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ name: 'Acme', url: 'https://acme.com' });
+  });
+});

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -2762,7 +2762,7 @@ paths:
     get:
       operationId: enrichBrand
       summary: Enrich brand
-      description: Enrich brand data using Brandfetch. Returns logo, colors, and company information.
+      description: Enrich brand data using Brandfetch. Returns logo, colors, and company information. Authenticated callers may also receive ephemeral Brand Context API identity/positioning/voice data.
       tags:
         - Brand Resolution
       parameters:
@@ -2779,8 +2779,99 @@ paths:
             application/json:
               schema:
                 type: object
-                properties: {}
-                additionalProperties: {}
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  domain:
+                    type: string
+                  cached:
+                    type: boolean
+                  manifest:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                      description:
+                        type: string
+                      logos:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            url:
+                              type: string
+                            tags:
+                              type: array
+                              items:
+                                type: string
+                          required:
+                            - url
+                            - tags
+                      colors:
+                        type: object
+                        properties:
+                          primary:
+                            type: string
+                          secondary:
+                            type: string
+                          accent:
+                            type: string
+                        additionalProperties: {}
+                      fonts:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            role:
+                              type: string
+                          required:
+                            - name
+                            - role
+                          additionalProperties: {}
+                      company:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          industries:
+                            type: array
+                            items:
+                              type: string
+                          employees:
+                            type: string
+                          founded:
+                            type: number
+                          location:
+                            type: string
+                        required:
+                          - name
+                        additionalProperties: {}
+                    required:
+                      - name
+                      - url
+                    additionalProperties: {}
+                  source_type:
+                    type: string
+                    enum:
+                      - brand_json
+                      - community
+                      - enriched
+                  context:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                  context_error:
+                    type: string
+                required:
+                  - success
+                  - domain
+                  - cached
         "503":
           description: Brandfetch not configured
           content:

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -2839,6 +2839,8 @@ paths:
                         properties:
                           name:
                             type: string
+                          industry:
+                            type: string
                           industries:
                             type: array
                             items:
@@ -2849,8 +2851,6 @@ paths:
                             type: number
                           location:
                             type: string
-                        required:
-                          - name
                         additionalProperties: {}
                     required:
                       - name
@@ -2860,6 +2860,8 @@ paths:
                     type: object
                     properties:
                       name:
+                        type: string
+                      industry:
                         type: string
                       industries:
                         type: array
@@ -2871,8 +2873,6 @@ paths:
                         type: number
                       location:
                         type: string
-                    required:
-                      - name
                     additionalProperties: {}
                   source_type:
                     type: string

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -2856,6 +2856,24 @@ paths:
                       - name
                       - url
                     additionalProperties: {}
+                  company:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      industries:
+                        type: array
+                        items:
+                          type: string
+                      employees:
+                        type: string
+                      founded:
+                        type: number
+                      location:
+                        type: string
+                    required:
+                      - name
+                    additionalProperties: {}
                   source_type:
                     type: string
                     enum:
@@ -2866,6 +2884,14 @@ paths:
                     type: object
                     properties: {}
                     additionalProperties: {}
+                  context_source:
+                    type: string
+                    enum:
+                      - brandfetch
+                  context_scope:
+                    type: string
+                    enum:
+                      - ephemeral
                   context_error:
                     type: string
                 required:


### PR DESCRIPTION
## Summary

Integrates Brandfetch Brand Context API as authenticated, ephemeral enrichment context for `/api/brands/enrich`.

Key boundaries:
- Brand Context is returned only as top-level `context` for authenticated enrich callers.
- Anonymous enrich calls remain Brand API-only.
- Brand Context is not persisted into `brand_manifest`.
- Brand Context does not populate `description`/`tone`, influence `highQuality`, or determine `source_type`.
- Legacy persisted `brand_context` is stripped from public/read/tool surfaces before serialization.
- Brandfetch terminal failure logs summarize Axios errors without request config or authorization headers.

## Why

Brand Context is useful narrative context for internal/authenticated workflows, but it is vendor-generated and not brand-attested or community-reviewed. Keeping it ephemeral avoids promoting vendor narrative into canonical registry data or public `brand.json` output.

## Validation

- `npx vitest run server/tests/unit/registry-brand-enrich-route.test.ts server/tests/unit/brandfetch-retry.test.ts server/tests/unit/brandfetch-cache.test.ts server/tests/unit/brandfetch-quality.test.ts server/tests/unit/public-brand-json-route.test.ts server/tests/integration/brand-orphan-adoption.test.ts` → 54/54
- `npm run typecheck`
- `npm run test:addie-tools`
- `npm run build:openapi`
- `git diff --check`
- Precommit hook during both commits:
  - `npm run test:unit` → 51 files / 942 tests
  - `npm run test:test-dynamic-imports`
  - `npm run test:callapi-state-change`
  - `npm run typecheck`
- Pre-push hook:
  - version sync
  - changeset check
  - schema link convention
  - Mintlify broken-link check
