### PR TITLE
fix(compliance): address rc storyboard blockers

### DIFF
--- a/.changeset/release-blocker-storyboards.md
+++ b/.changeset/release-blocker-storyboards.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix release-blocking compliance storyboards by preloading a creative before media buy state-machine pause/resume checks and removing stale proposal flight start dates from proposal probes.

--- a/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
@@ -293,8 +293,8 @@ phases:
           total_budget:
             amount: 50000
             currency: "USD"
-          start_time: "2026-04-01T00:00:00Z"
-          end_time: "2026-06-30T23:59:59Z"
+          start_time: "asap"
+          end_time: "2027-06-30T23:59:59Z"
           io_acceptance:
             io_id: "$context.io_id"
             accepted_at: "2026-03-15T14:30:00Z"
@@ -381,8 +381,8 @@ phases:
           total_budget:
             amount: 50000
             currency: "USD"
-          start_time: "2026-04-01T00:00:00Z"
-          end_time: "2026-06-30T23:59:59Z"
+          start_time: "asap"
+          end_time: "2027-06-30T23:59:59Z"
 
           idempotency_key: "$generate:uuid_v4#media_buy_seller_proposal_finalize_unknown_proposal_create_media_buy"
         validations:

--- a/static/compliance/source/protocols/media-buy/scenarios/proposal_not_found_errors.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/proposal_not_found_errors.yaml
@@ -172,8 +172,8 @@ phases:
           total_budget:
             amount: 50000
             currency: "USD"
-          start_time: "2026-04-01T00:00:00Z"
-          end_time: "2026-06-30T23:59:59Z"
+          start_time: "asap"
+          end_time: "2027-06-30T23:59:59Z"
           idempotency_key: "$generate:uuid_v4#media_buy_seller_proposal_not_found_errors_unknown_proposal_create_create_media_buy_unknown_proposal"
           context:
             correlation_id: "proposal_not_found_errors--create_media_buy_unknown"
@@ -237,8 +237,8 @@ phases:
           total_budget:
             amount: 50000
             currency: "USD"
-          start_time: "2026-04-01T00:00:00Z"
-          end_time: "2026-06-30T23:59:59Z"
+          start_time: "asap"
+          end_time: "2027-06-30T23:59:59Z"
           idempotency_key: "$generate:uuid_v4#media_buy_seller_proposal_not_found_errors_expired_proposal_create_create_media_buy_expired_proposal"
           context:
             correlation_id: "proposal_not_found_errors--create_media_buy_expired"

--- a/static/compliance/source/protocols/media-buy/state-machine.yaml
+++ b/static/compliance/source/protocols/media-buy/state-machine.yaml
@@ -6,6 +6,7 @@ summary: "Validates media buy state transitions: create, pause, resume, cancel, 
 track: media_buy
 required_tools:
   - create_media_buy
+  - sync_creatives
   - update_media_buy
 
 narrative: |
@@ -25,6 +26,7 @@ agent:
   capabilities:
     - sells_media
     - accepts_briefs
+    - accepts_creatives
   examples:
     - "Any AdCP seller with media buy support"
 
@@ -108,9 +110,11 @@ phases:
             correlation_id: "media_buy_state_machine--discover_products"
         context_outputs:
           - name: product_id
-            path: 'products[0].product_id'
+            path: "products[0].product_id"
           - name: pricing_option_id
-            path: 'products[0].pricing_options[0].pricing_option_id'
+            path: "products[0].pricing_options[0].pricing_option_id"
+          - name: product_format_id
+            path: "products[0].format_ids[0]"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -134,11 +138,60 @@ phases:
           - check: field_present
             path: "products[0].format_ids[0].id"
             description: "Format IDs include id — must be accepted back in sync_creatives"
+
+      - id: sync_creative
+        title: "Sync a creative for the test buy"
+        narrative: |
+          Upload a creative using the exact format_id returned by get_products. The
+          subsequent create_media_buy request assigns this creative to the package so
+          the created buy is pausable instead of legitimately remaining in
+          pending_creatives.
+        task: sync_creatives
+        schema_ref: "creative/sync-creatives-request.json"
+        response_schema_ref: "creative/sync-creatives-response.json"
+        doc_ref: "/creative/task-reference/sync_creatives"
+        comply_scenario: creative_sync
+        stateful: true
+        expected: |
+          Accept the creative into the account library so it can be assigned on
+          create_media_buy.
+
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          creatives:
+            - creative_id: "state_machine_display_creative"
+              name: "Acme Outdoor State Machine Creative"
+              format_id: "$context.product_format_id"
+              assets:
+                image:
+                  asset_type: "image"
+                  url: "https://cdn.pinnacle-agency.example/state-machine-display.png"
+                  width: 300
+                  height: 250
+                  mime_type: "image/png"
+
+          idempotency_key: "$generate:uuid_v4#media_buy_state_machine_setup_sync_creative"
+          context:
+            correlation_id: "media_buy_state_machine--sync_creative"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-creatives-response.json schema"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_state_machine--sync_creative"
+            description: "Context correlation_id returned unchanged"
+
       - id: create_buy
         title: "Create the test media buy"
         narrative: |
-          Create a media buy using the discovered product. This buy will be used for
-          all subsequent state transition tests.
+          Create a media buy using the discovered product and synced creative. This
+          buy will be used for all subsequent state transition tests.
         task: create_media_buy
         schema_ref: "media-buy/create-media-buy-request.json"
         response_schema_ref: "media-buy/create-media-buy-response.json"
@@ -163,15 +216,17 @@ phases:
             - product_id: "$context.product_id"
               budget: 10000
               pricing_option_id: "$context.pricing_option_id"
+              creative_assignments:
+                - creative_id: "state_machine_display_creative"
 
           idempotency_key: "$generate:uuid_v4#media_buy_state_machine_setup_create_buy"
           context:
             correlation_id: "media_buy_state_machine--create_buy"
         context_outputs:
           - name: media_buy_id
-            path: 'media_buy_id'
+            path: "media_buy_id"
           - name: package_id
-            path: 'packages[0].package_id'
+            path: "packages[0].package_id"
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"

--- a/static/compliance/source/specialisms/sales-proposal-mode/index.yaml
+++ b/static/compliance/source/specialisms/sales-proposal-mode/index.yaml
@@ -392,8 +392,8 @@ phases:
           total_budget:
             amount: 50000
             currency: "USD"
-          start_time: "2026-04-01T00:00:00Z"
-          end_time: "2026-06-30T23:59:59Z"
+          start_time: "asap"
+          end_time: "2027-06-30T23:59:59Z"
           io_acceptance:
             io_id: "$context.io_id"
             accepted_at: "2026-03-15T14:30:00Z"


### PR DESCRIPTION
## Summary

Fixes release-blocking compliance storyboard issues from the Bidcliq blocker list:

- preload a creative in `media_buy_state_machine` and assign it on `create_media_buy` so pause/resume/cancel runs against a pausable buy instead of a legitimate `pending_creatives` buy
- replace now-past April 1, 2026 proposal start dates with `asap` in proposal finalization/not-found probes and the legacy sales-proposal-mode specialism
- add a patch changeset for the next RC

## Validation

- `npm run build:compliance`
- `npm run build:schemas`
- `npm run test:storyboard-sample-request-schema`
- `npm run test:storyboard-context-output-paths`
- `npm run test:storyboard-validations-paths`
- `npm run test:compliance-source-authority`
- `npx vitest run server/tests/unit/storyboards.test.ts`
- `npx prettier --check ...`
- `git diff --check`
- precommit hook: unit tests, dynamic-import lint, callApi state-change lint, typecheck
- pre-push hook: current compliance source storyboard matrix and released 3.0.15 compatibility matrix

## Release note

Hold the RC until this lands. The remaining Bidcliq asks appear to be runner/infra-side: rc.6 hosted eval resolution, get_products per-check trace consumption, and seed/controller harness support.