### PR TITLE
Fix Ozone storyboard fixture assumptions

### DIFF
--- a/.changeset/deterministic-testing-product-fixture.md
+++ b/.changeset/deterministic-testing-product-fixture.md
@@ -1,5 +1,4 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Fix `deterministic_testing` media-buy phases by declaring controller seeding and adding the `test-product` / `test-pricing` fixtures referenced by its `create_media_buy` sample requests.

--- a/.changeset/deterministic-testing-product-fixture.md
+++ b/.changeset/deterministic-testing-product-fixture.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix `deterministic_testing` media-buy phases by declaring controller seeding and adding the `test-product` / `test-pricing` fixtures referenced by its `create_media_buy` sample requests.
+
+Without the fixture block, runners could reach the lifecycle test and fail on catalog availability (`PRODUCT_NOT_FOUND` / unavailable product) before exercising `force_media_buy_status`, `simulate_delivery`, or `simulate_budget_spend`.

--- a/.changeset/ozone-storyboard-fixture-followups.md
+++ b/.changeset/ozone-storyboard-fixture-followups.md
@@ -1,0 +1,8 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix additional storyboard fixture assumptions surfaced by the Ozone test run:
+
+- `idempotency` and `schema-validation` now declare controller seeding for the `test-product` / `test-pricing` create-media-buy payloads.
+- Creative pagination storyboards now filter list requests to their seeded fixture IDs so pre-existing catalog entries do not change exact count and terminal-page assertions.

--- a/.changeset/ozone-storyboard-fixture-followups.md
+++ b/.changeset/ozone-storyboard-fixture-followups.md
@@ -1,8 +1,7 @@
 ---
-"adcontextprotocol": patch
 ---
 
 Fix additional storyboard fixture assumptions surfaced by the Ozone test run:
 
 - `idempotency` and `schema-validation` now declare controller seeding for the `test-product` / `test-pricing` create-media-buy payloads.
-- Creative pagination storyboards now filter list requests to their seeded fixture IDs so pre-existing catalog entries do not change exact count and terminal-page assertions.
+- Creative pagination now filters list_creatives requests to seeded fixture IDs so pre-existing creative entries do not change exact count and terminal-page assertions.

--- a/static/compliance/source/universal/deterministic-testing.yaml
+++ b/static/compliance/source/universal/deterministic-testing.yaml
@@ -46,8 +46,25 @@ prerequisites:
   description: |
     The seller must expose the comply_test_controller tool. The controller is detected
     via list_scenarios before any state transitions are attempted. Phases that require
-    specific scenarios are skipped if the controller does not support them.
+    specific scenarios are skipped if the controller does not support them. The runner
+    also seeds the product and pricing option referenced by the media-buy phases so
+    those phases validate lifecycle behavior rather than catalog availability.
   test_kit: 'test-kits/acme-outdoor.yaml'
+  controller_seeding: true
+
+fixtures:
+  products:
+    - product_id: 'test-product'
+      delivery_type: 'non_guaranteed'
+      channels: ['display']
+      format_ids:
+        - id: 'display_300x250'
+  pricing_options:
+    - product_id: 'test-product'
+      pricing_option_id: 'test-pricing'
+      pricing_model: 'cpm'
+      currency: 'USD'
+      floor_price: 1.0
 
 phases:
   - id: capability_discovery

--- a/static/compliance/source/universal/idempotency.yaml
+++ b/static/compliance/source/universal/idempotency.yaml
@@ -99,10 +99,26 @@ caller:
 
 prerequisites:
   description: |
-    No special prerequisites. The storyboard uses create_media_buy as the canonical
-    mutating request. Sellers that do not support create_media_buy SHOULD still pass
-    idempotency compliance on whichever mutating task they do implement.
+    The runner seeds the product and pricing option referenced by the
+    create_media_buy payloads below. The storyboard uses create_media_buy as the
+    canonical mutating request. Sellers that do not support create_media_buy SHOULD
+    still pass idempotency compliance on whichever mutating task they do implement.
   test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  products:
+    - product_id: "test-product"
+      delivery_type: "non_guaranteed"
+      channels: ["display"]
+      format_ids:
+        - id: "display_300x250"
+  pricing_options:
+    - product_id: "test-product"
+      pricing_option_id: "test-pricing"
+      pricing_model: "cpm"
+      currency: "USD"
+      floor_price: 1.0
 
 phases:
   - id: capability_discovery

--- a/static/compliance/source/universal/pagination-integrity-creative-formats.yaml
+++ b/static/compliance/source/universal/pagination-integrity-creative-formats.yaml
@@ -190,6 +190,11 @@ phases:
         sample_request:
           account:
             account_id: "acct_pagination_integrity_formats"
+          format_ids:
+            - agent_url: "https://creative.adcontextprotocol.org"
+              id: "pagination_integrity_format_1"
+            - agent_url: "https://creative.adcontextprotocol.org"
+              id: "pagination_integrity_format_2"
           name_search: "Pagination Integrity Format"
           pagination:
             max_results: 1
@@ -238,6 +243,11 @@ phases:
         sample_request:
           account:
             account_id: "acct_pagination_integrity_formats"
+          format_ids:
+            - agent_url: "https://creative.adcontextprotocol.org"
+              id: "pagination_integrity_format_1"
+            - agent_url: "https://creative.adcontextprotocol.org"
+              id: "pagination_integrity_format_2"
           name_search: "Pagination Integrity Format"
           pagination:
             cursor: "$context.next_cursor"

--- a/static/compliance/source/universal/pagination-integrity-creative-formats.yaml
+++ b/static/compliance/source/universal/pagination-integrity-creative-formats.yaml
@@ -190,11 +190,6 @@ phases:
         sample_request:
           account:
             account_id: "acct_pagination_integrity_formats"
-          format_ids:
-            - agent_url: "https://creative.adcontextprotocol.org"
-              id: "pagination_integrity_format_1"
-            - agent_url: "https://creative.adcontextprotocol.org"
-              id: "pagination_integrity_format_2"
           name_search: "Pagination Integrity Format"
           pagination:
             max_results: 1
@@ -243,11 +238,6 @@ phases:
         sample_request:
           account:
             account_id: "acct_pagination_integrity_formats"
-          format_ids:
-            - agent_url: "https://creative.adcontextprotocol.org"
-              id: "pagination_integrity_format_1"
-            - agent_url: "https://creative.adcontextprotocol.org"
-              id: "pagination_integrity_format_2"
           name_search: "Pagination Integrity Format"
           pagination:
             cursor: "$context.next_cursor"

--- a/static/compliance/source/universal/pagination-integrity.yaml
+++ b/static/compliance/source/universal/pagination-integrity.yaml
@@ -158,6 +158,11 @@ phases:
         sample_request:
           account:
             account_id: "acct_pagination_integrity"
+          filters:
+            creative_ids:
+              - "pagination_integrity_creative_1"
+              - "pagination_integrity_creative_2"
+              - "pagination_integrity_creative_3"
           pagination:
             max_results: 2
 
@@ -227,6 +232,11 @@ phases:
         sample_request:
           account:
             account_id: "acct_pagination_integrity"
+          filters:
+            creative_ids:
+              - "pagination_integrity_creative_1"
+              - "pagination_integrity_creative_2"
+              - "pagination_integrity_creative_3"
           pagination:
             cursor: "$context.next_cursor"
             max_results: 2

--- a/static/compliance/source/universal/schema-validation.yaml
+++ b/static/compliance/source/universal/schema-validation.yaml
@@ -32,8 +32,26 @@ caller:
 
 prerequisites:
   description: |
-    The caller needs a brand identity for product discovery requests.
+    The caller needs a brand identity for product discovery requests. The runner
+    also seeds the product and pricing option referenced by the temporal
+    create_media_buy requests so date validation is isolated from catalog
+    availability.
   test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  products:
+    - product_id: "test-product"
+      delivery_type: "non_guaranteed"
+      channels: ["display"]
+      format_ids:
+        - id: "display_300x250"
+  pricing_options:
+    - product_id: "test-product"
+      pricing_option_id: "test-pricing"
+      pricing_model: "cpm"
+      currency: "USD"
+      floor_price: 1.0
 
 phases:
   - id: capability_discovery


### PR DESCRIPTION
Fixes universal storyboard assumptions surfaced by the Ozone compliance run. Adds controller-seeded `test-product` / `test-pricing` fixtures for deterministic-testing, idempotency, and schema-validation so create_media_buy steps exercise lifecycle/date/idempotency behavior instead of failing on missing catalog IDs. Narrows pagination-integrity list_creatives requests to the seeded creative IDs so unrelated catalog entries do not affect exact pagination assertions. Changesets are documentation-only for the harness changes and do not bump the package. Validated with storyboard contradiction/schema lints, compliance build, precommit, and both current-source and 3.0 compatibility storyboard matrices.