### PR TITLE
feat(registry): community-mirror catalog lifecycle (#2176)

### DIFF
--- a/.changeset/community-mirror-catalog-lifecycle.md
+++ b/.changeset/community-mirror-catalog-lifecycle.md
@@ -1,0 +1,16 @@
+---
+"adcontextprotocol": minor
+---
+
+Registry: community-mirror catalog lifecycle (#2176).
+
+Makes AAO catalog-only adagents.json mirrors first-class registry resources. A community mirror is the catalog-only adagents.json (`authorized_agents: []` + formats/properties/placements) AAO publishes on behalf of a platform that hasn't adopted AdCP, served at `creative.adcontextprotocol.org/translated/<platform>/adagents.json`. Builds on #5352/#5353, which made `authorized_agents: []` valid.
+
+- **Store:** new `community_mirrors` table (migration 506) keyed by `platform`, with the adagents.json body, `catalog_etag`, `superseded_by`, and provenance.
+- **Endpoints** (`/api/registry/mirrors`):
+  - `GET /api/registry/mirrors` — list mirrors with their `catalog_etag` (public).
+  - `GET /api/registry/mirrors/:platform` — read one mirror (public).
+  - `PUT /api/registry/mirrors/:platform` — idempotent publish/upsert (registry moderators or admins). Forces `authorized_agents: []`, requires catalog content, validates the proposal.
+- **Serving:** `GET /translated/:platform/adagents.json` on the creative agent serves the stored mirror with an `ETag` (from `catalog_etag`, falling back to a content hash), `If-None-Match` → `304`, `Cache-Control`, and a `superseded_by` → `Link: rel="successor-version"` header.
+
+Read-back by platform and listing close the gap where published mirrors could not be retrieved; the idempotent upsert lets audit fixes update in place instead of duplicating.

--- a/server/src/creative-agent/index.ts
+++ b/server/src/creative-agent/index.ts
@@ -8,11 +8,13 @@
 import { Router } from 'express';
 import type { Request, Response, NextFunction } from 'express';
 import rateLimit from 'express-rate-limit';
+import { createHash } from 'node:crypto';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { createLogger } from '../logger.js';
 import { constantTimeEqual } from '../utils/constant-time-equal.js';
 import { createCreativeAgentServer } from './task-handlers.js';
 import { getPreview, cleanExpiredPreviews } from './preview-store.js';
+import { CommunityMirrorDatabase } from '../db/community-mirror-db.js';
 
 const logger = createLogger('creative-agent-routes');
 
@@ -64,6 +66,7 @@ function getAgentBaseUrl(req: Request): string {
 
 export function createCreativeAgentRouter(): Router {
   const router = Router();
+  const mirrorDb = new CommunityMirrorDatabase();
 
   // Clean expired previews every 5 minutes
   const cleanupInterval = setInterval(() => cleanExpiredPreviews(), 5 * 60 * 1000);
@@ -91,6 +94,50 @@ export function createCreativeAgentRouter(): Router {
       }],
       last_updated: STARTUP_TIME,
     });
+  });
+
+  // Community-mirror serving route (#2176): serves the stored catalog-only
+  // adagents.json for an unadopted platform at the canonical mirror URL
+  // creative.adcontextprotocol.org/translated/<platform>/adagents.json.
+  router.get('/translated/:platform/adagents.json', async (req: Request, res: Response) => {
+    const platform = String(req.params.platform).toLowerCase();
+    if (!/^[a-z0-9_-]{1,64}$/.test(platform)) {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      return res.status(400).json({ error: 'Invalid platform identifier' });
+    }
+    try {
+      const mirror = await mirrorDb.getByPlatform(platform);
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      if (!mirror) {
+        return res.status(404).json({ error: 'Community mirror not found' });
+      }
+
+      const serialized = JSON.stringify(mirror.adagents_json);
+      const etagValue =
+        mirror.catalog_etag && mirror.catalog_etag.trim()
+          ? mirror.catalog_etag
+          : createHash('sha256').update(serialized).digest('hex').slice(0, 32);
+      const etag = `"${etagValue}"`;
+
+      res.setHeader('ETag', etag);
+      res.setHeader('Cache-Control', 'public, max-age=300');
+      // superseded_by lifecycle: the normative signal is the body field (buyer
+      // SDKs re-fetch the named URL); this Link header is an additive cache hint
+      // for caches keyed on the mirror URL, not the spec-defined mechanism.
+      if (mirror.superseded_by) {
+        res.setHeader('Link', `<${mirror.superseded_by}>; rel="successor-version"`);
+      }
+
+      if (req.headers['if-none-match'] === etag) {
+        return res.status(304).end();
+      }
+      res.setHeader('Content-Type', 'application/json');
+      res.setHeader('X-Content-Type-Options', 'nosniff');
+      return res.status(200).send(serialized);
+    } catch (error) {
+      logger.error({ error, platform }, 'Failed to serve translated community mirror');
+      return res.status(500).json({ error: 'Failed to serve mirror' });
+    }
   });
 
   // CORS preflight

--- a/server/src/creative-agent/index.ts
+++ b/server/src/creative-agent/index.ts
@@ -113,8 +113,11 @@ export function createCreativeAgentRouter(): Router {
       }
 
       const serialized = JSON.stringify(mirror.adagents_json);
+      // Use catalog_etag only when it is safe to embed in a quoted ETag header
+      // (no quotes / control chars); otherwise fall back to a content hash so a
+      // moderator-supplied token can't produce a malformed ETag.
       const etagValue =
-        mirror.catalog_etag && mirror.catalog_etag.trim()
+        mirror.catalog_etag && /^[A-Za-z0-9_\-:.+=]+$/.test(mirror.catalog_etag)
           ? mirror.catalog_etag
           : createHash('sha256').update(serialized).digest('hex').slice(0, 32);
       const etag = `"${etagValue}"`;

--- a/server/src/db/community-mirror-db.ts
+++ b/server/src/db/community-mirror-db.ts
@@ -1,0 +1,97 @@
+import { query } from './client.js';
+
+/**
+ * A stored AAO catalog-only community mirror (#2176). The body is a
+ * catalog-only adagents.json (authorized_agents: []) for a platform that has
+ * not adopted AdCP, served at /translated/<platform>/adagents.json. One row
+ * per platform; re-publishing the same platform updates the row in place.
+ */
+export interface CommunityMirror {
+  platform: string;
+  adagents_json: Record<string, unknown>;
+  catalog_etag: string | null;
+  superseded_by: string | null;
+  created_by_user_id: string | null;
+  created_by_email: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** List projection — enough to verify presence + currency without the body. */
+export interface CommunityMirrorSummary {
+  platform: string;
+  catalog_etag: string | null;
+  superseded_by: string | null;
+  updated_at: string;
+}
+
+export interface UpsertCommunityMirrorInput {
+  platform: string;
+  adagents_json: Record<string, unknown>;
+  catalog_etag?: string | null;
+  superseded_by?: string | null;
+  created_by_user_id?: string | null;
+  created_by_email?: string | null;
+}
+
+export class CommunityMirrorDatabase {
+  /**
+   * Idempotent publish: insert a mirror, or update it in place when the
+   * platform already exists. `created_by_*` is preserved across re-publishes
+   * (it records the original creator); `updated_at` is bumped by the trigger.
+   */
+  async upsert(input: UpsertCommunityMirrorInput): Promise<CommunityMirror> {
+    const result = await query<CommunityMirror>(
+      `INSERT INTO community_mirrors
+         (platform, adagents_json, catalog_etag, superseded_by,
+          created_by_user_id, created_by_email)
+       VALUES ($1, $2::jsonb, $3, $4, $5, $6)
+       ON CONFLICT (platform) DO UPDATE SET
+         adagents_json = EXCLUDED.adagents_json,
+         catalog_etag = EXCLUDED.catalog_etag,
+         superseded_by = EXCLUDED.superseded_by,
+         updated_at = NOW()
+       RETURNING *`,
+      [
+        input.platform,
+        JSON.stringify(input.adagents_json),
+        input.catalog_etag ?? null,
+        input.superseded_by ?? null,
+        input.created_by_user_id ?? null,
+        input.created_by_email ?? null,
+      ]
+    );
+    return result.rows[0];
+  }
+
+  async getByPlatform(platform: string): Promise<CommunityMirror | null> {
+    const result = await query<CommunityMirror>(
+      `SELECT * FROM community_mirrors WHERE platform = $1`,
+      [platform]
+    );
+    return result.rows[0] ?? null;
+  }
+
+  async list(
+    options: { limit?: number; offset?: number } = {}
+  ): Promise<{ mirrors: CommunityMirrorSummary[]; total: number }> {
+    const limit = Math.min(Math.max(options.limit ?? 100, 1), 500);
+    const offset = Math.max(options.offset ?? 0, 0);
+    const [rows, count] = await Promise.all([
+      query<CommunityMirrorSummary>(
+        `SELECT platform, catalog_etag, superseded_by, updated_at
+           FROM community_mirrors
+          ORDER BY updated_at DESC
+          LIMIT $1 OFFSET $2`,
+        [limit, offset]
+      ),
+      query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count FROM community_mirrors`
+      ),
+    ]);
+    return {
+      mirrors: rows.rows,
+      total: parseInt(count.rows[0]?.count ?? '0', 10),
+    };
+  }
+}

--- a/server/src/db/migrations/506_community_mirrors.sql
+++ b/server/src/db/migrations/506_community_mirrors.sql
@@ -1,0 +1,29 @@
+-- Community-mirror catalog lifecycle (#2176).
+-- First-class storage for AAO-maintained catalog-only adagents.json mirrors,
+-- served at creative.adcontextprotocol.org/translated/<platform>/adagents.json
+-- for platforms that have not adopted AdCP. One mirror per platform; the body
+-- is a catalog-only adagents.json (authorized_agents: []) carrying formats/
+-- properties/placements. Idempotent re-publish updates in place (PK = platform).
+CREATE TABLE IF NOT EXISTS community_mirrors (
+  platform           TEXT PRIMARY KEY CHECK (platform ~ '^[a-z0-9_-]{1,64}$'),
+  adagents_json      JSONB NOT NULL,
+  catalog_etag       TEXT,
+  superseded_by      TEXT,
+  created_by_user_id TEXT,
+  created_by_email   TEXT,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_community_mirrors_updated_at
+  ON community_mirrors (updated_at DESC);
+
+DROP TRIGGER IF EXISTS update_community_mirrors_updated_at ON community_mirrors;
+CREATE TRIGGER update_community_mirrors_updated_at
+  BEFORE UPDATE ON community_mirrors
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+COMMENT ON TABLE community_mirrors IS 'AAO catalog-only adagents.json mirrors for unadopted platforms, keyed by platform slug; served at /translated/<platform>/adagents.json';
+COMMENT ON COLUMN community_mirrors.adagents_json IS 'Catalog-only adagents.json body (authorized_agents: []) — formats/properties/placements';
+COMMENT ON COLUMN community_mirrors.catalog_etag IS 'Publisher-controlled cache validator; used for the serving ETag (falls back to a content hash when absent)';
+COMMENT ON COLUMN community_mirrors.superseded_by IS 'URL of the platform-hosted adagents.json once the platform self-adopts (per the adagents.json superseded_by lifecycle)';

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -123,6 +123,7 @@ import {
 import { createRegistryApiRouters } from "./routes/registry-api.js";
 import { getPublicJwks } from "./services/verification-token.js";
 import { createCatalogApiRouter } from "./routes/catalog-api.js";
+import { createCommunityMirrorRouter } from "./routes/community-mirrors.js";
 import { getLogo, isAllowedLogoContentType } from "./services/logo-cdn.js";
 import { BrandLogoDatabase } from "./db/brand-logo-db.js";
 import { createApiKeysRouter } from "./routes/api-keys.js";
@@ -1133,6 +1134,11 @@ export class HTTPServer {
     // Mount property catalog API routes (resolve, browse, sync, disputes)
     const catalogApiRouter = createCatalogApiRouter({ requireAuth, requireAdmin });
     this.app.use('/api/registry', catalogApiRouter);
+
+    // Community-mirror catalog lifecycle (#2176): publish/read/list catalog-only
+    // adagents.json mirrors for unadopted platforms (served at /translated/<platform>).
+    const communityMirrorRouter = createCommunityMirrorRouter({ requireAuth });
+    this.app.use('/api/registry', communityMirrorRouter);
 
     // Mount network health API routes (page route is in createAdminRouter)
     const networkHealthApiRouter = createNetworkHealthApiRouter();

--- a/server/src/routes/community-mirrors.ts
+++ b/server/src/routes/community-mirrors.ts
@@ -1,0 +1,216 @@
+/**
+ * Community-mirror catalog lifecycle API (#2176).
+ *
+ * AAO publishes catalog-only adagents.json mirrors for platforms that have not
+ * adopted AdCP (Meta, TikTok, …). These mirrors carry catalog content
+ * (formats/properties/placements) and an empty `authorized_agents: []` — there
+ * is no sales agent to authorize. This router makes them first-class:
+ *
+ *   GET  /api/registry/mirrors            — list mirrors (public, with etags)
+ *   GET  /api/registry/mirrors/:platform  — read one mirror (public)
+ *   PUT  /api/registry/mirrors/:platform  — idempotent publish/upsert (moderator/admin)
+ *
+ * The stored body is served at /translated/<platform>/adagents.json by the
+ * creative agent. Mounted at /api/registry alongside catalog-api.ts.
+ */
+
+import { Router } from 'express';
+import type { RequestHandler } from 'express';
+import { z } from 'zod';
+import { CommunityMirrorDatabase } from '../db/community-mirror-db.js';
+import { isRegistryModerator } from '../services/brand-logo-auth.js';
+import { isWebUserAAOAdmin } from '../addie/admin-status-lookup.js';
+import { validateAdagentsDocument } from '../services/adagents-schema-validator.js';
+import { registryReadRateLimiter, brandCreationRateLimiter } from '../middleware/rate-limit.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('community-mirrors');
+
+const PLATFORM_RE = /^[a-z0-9_-]{1,64}$/;
+
+const MirrorBodySchema = z
+  .object({
+    catalog_etag: z.string().min(1).max(255).optional(),
+    formats: z.array(z.unknown()).optional(),
+    properties: z.array(z.unknown()).optional(),
+    placements: z.array(z.unknown()).optional(),
+    placement_tags: z.record(z.string(), z.unknown()).optional(),
+    collections: z.array(z.unknown()).optional(),
+    signals: z.array(z.unknown()).optional(),
+    signal_tags: z.record(z.string(), z.unknown()).optional(),
+    contact: z.unknown().optional(),
+    superseded_by: z
+      .string()
+      .url()
+      .refine(
+        (v) => {
+          try {
+            return ['http:', 'https:'].includes(new URL(v).protocol);
+          } catch {
+            return false;
+          }
+        },
+        { message: 'superseded_by must be an http(s) URL' }
+      )
+      .optional(),
+  })
+  // adagents.json defaults additionalProperties:true; allow forward-compatible
+  // catalog fields. `authorized_agents` is intentionally ignored and forced to
+  // [] so a mirror can never imply sales authorization.
+  .passthrough();
+
+export interface CommunityMirrorRouterConfig {
+  requireAuth?: RequestHandler;
+}
+
+export function createCommunityMirrorRouter(config: CommunityMirrorRouterConfig): Router {
+  const router = Router();
+  const { requireAuth: authMiddleware } = config;
+  const mirrorDb = new CommunityMirrorDatabase();
+
+  const writeMiddleware: RequestHandler[] = authMiddleware
+    ? [authMiddleware, brandCreationRateLimiter]
+    : [brandCreationRateLimiter];
+
+  // ── GET /api/registry/mirrors — list ────────────────────────────
+  router.get('/mirrors', registryReadRateLimiter, async (req, res) => {
+    try {
+      const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : undefined;
+      const offset = req.query.offset ? parseInt(req.query.offset as string, 10) : undefined;
+      const { mirrors, total } = await mirrorDb.list({
+        limit: Number.isFinite(limit) ? limit : undefined,
+        offset: Number.isFinite(offset) ? offset : undefined,
+      });
+      return res.json({ mirrors, total });
+    } catch (err) {
+      logger.error({ err }, 'Failed to list community mirrors');
+      return res.status(500).json({ error: 'Failed to list community mirrors' });
+    }
+  });
+
+  // ── GET /api/registry/mirrors/:platform — read one ──────────────
+  router.get('/mirrors/:platform', registryReadRateLimiter, async (req, res) => {
+    const platform = String(req.params.platform).toLowerCase();
+    if (!PLATFORM_RE.test(platform)) {
+      return res.status(400).json({ error: 'Invalid platform identifier' });
+    }
+    try {
+      const mirror = await mirrorDb.getByPlatform(platform);
+      if (!mirror) {
+        return res.status(404).json({ error: 'Community mirror not found' });
+      }
+      return res.json({
+        platform: mirror.platform,
+        catalog_etag: mirror.catalog_etag,
+        superseded_by: mirror.superseded_by,
+        adagents_json: mirror.adagents_json,
+        created_at: mirror.created_at,
+        updated_at: mirror.updated_at,
+      });
+    } catch (err) {
+      logger.error({ err, platform }, 'Failed to read community mirror');
+      return res.status(500).json({ error: 'Failed to read community mirror' });
+    }
+  });
+
+  // ── PUT /api/registry/mirrors/:platform — idempotent publish ────
+  router.put('/mirrors/:platform', ...writeMiddleware, async (req, res) => {
+    const platform = String(req.params.platform).toLowerCase();
+    if (!PLATFORM_RE.test(platform)) {
+      return res.status(400).json({ error: 'Invalid platform identifier (expected ^[a-z0-9_-]{1,64}$)' });
+    }
+
+    const userId = req.user?.id;
+    if (!userId) {
+      return res.status(401).json({ error: 'Authentication required' });
+    }
+    // The static ADMIN_API_KEY sentinel always passes; otherwise the caller
+    // must be a registry moderator or an AAO admin. (req.user has no isAdmin
+    // field — admin status is resolved via isWebUserAAOAdmin, not the request.)
+    if (userId !== 'admin_api_key') {
+      const [isAaoAdmin, isModerator] = await Promise.all([
+        isWebUserAAOAdmin(userId),
+        isRegistryModerator(userId),
+      ]);
+      if (!isAaoAdmin && !isModerator) {
+        return res.status(403).json({ error: 'Only registry moderators or AAO admins can publish community mirrors' });
+      }
+    }
+
+    const parsed = MirrorBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: 'Invalid request body', details: parsed.error.issues });
+    }
+    const body = parsed.data as Record<string, unknown> & {
+      catalog_etag?: string;
+      formats?: unknown[];
+      properties?: unknown[];
+      placements?: unknown[];
+      placement_tags?: Record<string, unknown>;
+      collections?: unknown[];
+      signals?: unknown[];
+      signal_tags?: Record<string, unknown>;
+      superseded_by?: string;
+    };
+
+    const nonEmpty = (v: unknown): boolean => Array.isArray(v) && v.length > 0;
+    const hasCatalogContent =
+      nonEmpty(body.formats) ||
+      nonEmpty(body.properties) ||
+      nonEmpty(body.placements) ||
+      nonEmpty(body.collections) ||
+      nonEmpty(body.signals);
+    if (!hasCatalogContent) {
+      return res.status(400).json({
+        error: 'A community mirror must carry catalog content (formats, properties, placements, collections, or signals)',
+      });
+    }
+
+    // Assemble the served document: forced authorized_agents:[] + $schema.
+    // Any caller-supplied authorized_agents is dropped — a mirror never asserts
+    // sales authorization.
+    const { authorized_agents: _ignored, $schema: _schema, last_updated: _lu, ...rest } = body;
+    const adagentsJson: Record<string, unknown> = {
+      $schema: 'https://adcontextprotocol.org/schemas/v3/adagents.json',
+      ...rest,
+      authorized_agents: [],
+      last_updated: new Date().toISOString(),
+    };
+
+    // Validate the fully-assembled document against the published adagents.json
+    // schema before persisting — AAO must never serve a mirror that a buyer SDK
+    // validating against the schema would reject (e.g. a formats[] entry
+    // missing required params).
+    const conformance = await validateAdagentsDocument(adagentsJson);
+    if (!conformance.valid) {
+      return res.status(400).json({
+        error: 'Document does not conform to the adagents.json schema',
+        details: conformance.errors.slice(0, 20),
+      });
+    }
+
+    try {
+      const mirror = await mirrorDb.upsert({
+        platform,
+        adagents_json: adagentsJson,
+        catalog_etag: body.catalog_etag ?? null,
+        superseded_by: body.superseded_by ?? null,
+        created_by_user_id: userId,
+        created_by_email: req.user?.email ?? null,
+      });
+      logger.info({ platform, by: userId }, 'Published community mirror');
+      return res.json({
+        success: true,
+        platform: mirror.platform,
+        catalog_etag: mirror.catalog_etag,
+        superseded_by: mirror.superseded_by,
+        updated_at: mirror.updated_at,
+      });
+    } catch (err) {
+      logger.error({ err, platform }, 'Failed to publish community mirror');
+      return res.status(500).json({ error: 'Failed to publish community mirror' });
+    }
+  });
+
+  return router;
+}

--- a/server/src/routes/community-mirrors.ts
+++ b/server/src/routes/community-mirrors.ts
@@ -45,12 +45,13 @@ const MirrorBodySchema = z
       .refine(
         (v) => {
           try {
-            return ['http:', 'https:'].includes(new URL(v).protocol);
+            // adagents.json requires superseded_by to be https (^https://).
+            return new URL(v).protocol === 'https:';
           } catch {
             return false;
           }
         },
-        { message: 'superseded_by must be an http(s) URL' }
+        { message: 'superseded_by must be an https URL' }
       )
       .optional(),
   })
@@ -167,8 +168,9 @@ export function createCommunityMirrorRouter(config: CommunityMirrorRouterConfig)
     }
 
     // Assemble the served document: forced authorized_agents:[] + $schema.
-    // Any caller-supplied authorized_agents is dropped — a mirror never asserts
-    // sales authorization.
+    // authorized_agents is dropped so a mirror never asserts sales
+    // authorization; $schema and last_updated are also stripped from the caller
+    // body and regenerated below so both stay server-controlled.
     const { authorized_agents: _ignored, $schema: _schema, last_updated: _lu, ...rest } = body;
     const adagentsJson: Record<string, unknown> = {
       $schema: 'https://adcontextprotocol.org/schemas/v3/adagents.json',

--- a/server/src/services/adagents-schema-validator.ts
+++ b/server/src/services/adagents-schema-validator.ts
@@ -13,9 +13,14 @@ import Ajv, { type ValidateFunction } from 'ajv';
 import addFormats from 'ajv-formats';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { createLogger } from '../logger.js';
 
 const logger = createLogger('adagents-schema-validator');
+
+// ESM has no __dirname; derive it (matches http.ts / mcp-tools.ts).
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // static/ is shipped in the image (Dockerfile COPY static ./static). Resolve
 // the source schema tree relative to this module, mirroring the NODE_ENV split
@@ -28,12 +33,20 @@ const SOURCE_DIR =
 
 let compiled: Promise<ValidateFunction> | null = null;
 
+const SOURCE_ROOT = path.resolve(SOURCE_DIR);
+
 function loadLocalSchema(uri: string): object {
   if (!uri.startsWith('/schemas/')) {
     throw new Error(`Cannot resolve non-local $ref: ${uri}`);
   }
   const rel = uri.replace('/schemas/', '');
-  return JSON.parse(readFileSync(path.join(SOURCE_DIR, rel), 'utf8'));
+  // Defense-in-depth: $refs come from our trusted schema tree today, but never
+  // resolve outside SOURCE_DIR even if a future ref carries `../`.
+  const full = path.resolve(SOURCE_ROOT, rel);
+  if (full !== SOURCE_ROOT && !full.startsWith(SOURCE_ROOT + path.sep)) {
+    throw new Error(`Refusing to resolve $ref outside the schema tree: ${uri}`);
+  }
+  return JSON.parse(readFileSync(full, 'utf8'));
 }
 
 function getValidator(): Promise<ValidateFunction> {

--- a/server/src/services/adagents-schema-validator.ts
+++ b/server/src/services/adagents-schema-validator.ts
@@ -1,0 +1,76 @@
+/**
+ * Validates an assembled adagents.json document against the published JSON
+ * Schema (static/schemas/source/adagents.json), with all `/schemas/...` $refs
+ * resolved from the local source tree.
+ *
+ * This is the authoritative wire-contract check — stronger than
+ * AdAgentsManager.validateProposed, which only does shallow structural checks
+ * (e.g. it does not require `params` on a `formats[]` entry). The community-
+ * mirror publish path uses this so AAO never stores/serves a mirror that a
+ * buyer SDK validating against the schema would reject.
+ */
+import Ajv, { type ValidateFunction } from 'ajv';
+import addFormats from 'ajv-formats';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('adagents-schema-validator');
+
+// static/ is shipped in the image (Dockerfile COPY static ./static). Resolve
+// the source schema tree relative to this module, mirroring the NODE_ENV split
+// used for express.static in http.ts. This module lives one directory deeper
+// (services/), hence the extra `..`.
+const SOURCE_DIR =
+  process.env.NODE_ENV === 'production'
+    ? path.join(__dirname, '../../static/schemas/source')
+    : path.join(__dirname, '../../../static/schemas/source');
+
+let compiled: Promise<ValidateFunction> | null = null;
+
+function loadLocalSchema(uri: string): object {
+  if (!uri.startsWith('/schemas/')) {
+    throw new Error(`Cannot resolve non-local $ref: ${uri}`);
+  }
+  const rel = uri.replace('/schemas/', '');
+  return JSON.parse(readFileSync(path.join(SOURCE_DIR, rel), 'utf8'));
+}
+
+function getValidator(): Promise<ValidateFunction> {
+  if (!compiled) {
+    compiled = (async () => {
+      const ajv = new Ajv({
+        strict: false,
+        allErrors: true,
+        discriminator: true,
+        loadSchema: async (uri: string) => loadLocalSchema(uri),
+      });
+      addFormats(ajv);
+      const schema = JSON.parse(
+        readFileSync(path.join(SOURCE_DIR, 'adagents.json'), 'utf8')
+      );
+      return ajv.compileAsync(schema);
+    })().catch((err) => {
+      // Allow a retry on a transient load/compile failure rather than caching
+      // a rejected promise forever.
+      compiled = null;
+      logger.error({ err, SOURCE_DIR }, 'Failed to compile adagents.json schema validator');
+      throw err;
+    });
+  }
+  return compiled;
+}
+
+export async function validateAdagentsDocument(
+  doc: unknown
+): Promise<{ valid: boolean; errors: string[] }> {
+  const validate = await getValidator();
+  const valid = validate(doc) as boolean;
+  if (valid) return { valid: true, errors: [] };
+  const errors = (validate.errors || []).map((e) => {
+    const where = e.instancePath || '(root)';
+    const params = e.params && Object.keys(e.params).length ? ` ${JSON.stringify(e.params)}` : '';
+    return `${where}: ${e.message ?? 'invalid'}${params}`;
+  });
+  return { valid: false, errors };
+}

--- a/server/tests/integration/community-mirrors.test.ts
+++ b/server/tests/integration/community-mirrors.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Community-mirror catalog lifecycle (#2176): publish (idempotent), read one,
+ * list, and serve at /translated/<platform>/adagents.json.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import type { Pool } from 'pg';
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'test';
+  process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+});
+
+// Mutable identity for the authenticated caller so a re-publish can come from a
+// different user (used to assert created_by_* is preserved).
+const authState = vi.hoisted(() => ({ userId: 'user_test_mirrors', email: 'mirrors@test.com' }));
+
+vi.mock('../../src/middleware/auth.js', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('../../src/middleware/auth.js');
+  const pass = (req: { user: unknown }, _res: unknown, next: () => void) => {
+    req.user = { id: authState.userId, email: authState.email };
+    next();
+  };
+  return { ...actual, requireAuth: pass, requireAdmin: (_r: unknown, _s: unknown, n: () => void) => n() };
+});
+
+vi.mock('../../src/middleware/csrf.js', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('../../src/middleware/csrf.js');
+  return { ...actual, csrfProtection: (_r: unknown, _s: unknown, n: () => void) => n() };
+});
+
+vi.mock('../../src/billing/stripe-client.js', () => ({
+  stripe: null,
+  getSubscriptionInfo: vi.fn().mockResolvedValue(null),
+  createStripeCustomer: vi.fn().mockResolvedValue(null),
+  createCustomerSession: vi.fn().mockResolvedValue(null),
+  createBillingPortalSession: vi.fn().mockResolvedValue(null),
+}));
+
+// Publish gate dependencies. Defaults set in beforeEach.
+const isRegistryModerator = vi.hoisted(() => vi.fn());
+const isWebUserAAOAdmin = vi.hoisted(() => vi.fn());
+vi.mock('../../src/services/brand-logo-auth.js', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('../../src/services/brand-logo-auth.js');
+  return { ...actual, isRegistryModerator };
+});
+vi.mock('../../src/addie/admin-status-lookup.js', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('../../src/addie/admin-status-lookup.js');
+  return { ...actual, isWebUserAAOAdmin };
+});
+
+import { HTTPServer } from '../../src/http.js';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+
+const PLATFORM = 'test-meta';
+const PLATFORM_LIKE = 'test-%';
+
+const MINIMAL_PROPERTY = {
+  property_id: 'instagram',
+  property_type: 'mobile_app',
+  name: 'Instagram',
+  identifiers: [{ type: 'domain', value: 'instagram.com' }],
+  publisher_domain: 'instagram.com',
+};
+// A valid ProductFormatDeclaration: format_kind + params are both required.
+const MINIMAL_FORMAT = {
+  format_option_id: 'meta_feed_image',
+  display_name: 'Meta Feed Image',
+  format_kind: 'image',
+  params: { width: 1080, height: 1080 },
+};
+
+function publishBody(overrides: Record<string, unknown> = {}) {
+  return {
+    catalog_etag: 'test-etag-1',
+    properties: [MINIMAL_PROPERTY],
+    formats: [MINIMAL_FORMAT],
+    ...overrides,
+  };
+}
+
+describe('Community-mirror lifecycle — /api/registry/mirrors + /translated', () => {
+  let server: HTTPServer;
+  let app: unknown;
+  let pool: Pool;
+
+  async function clear() {
+    await pool.query('DELETE FROM community_mirrors WHERE platform LIKE $1', [PLATFORM_LIKE]);
+  }
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+    server = new HTTPServer();
+    await server.start(0);
+    app = (server as unknown as { app: unknown }).app;
+  });
+
+  afterAll(async () => {
+    await clear();
+    await server?.stop();
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    isRegistryModerator.mockResolvedValue(true);
+    isWebUserAAOAdmin.mockResolvedValue(false);
+    authState.userId = 'user_test_mirrors';
+    authState.email = 'mirrors@test.com';
+    await clear();
+  });
+
+  it('publishes a catalog-only mirror (authorized_agents forced to [])', async () => {
+    const res = await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody());
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.platform).toBe(PLATFORM);
+    expect(res.body.catalog_etag).toBe('test-etag-1');
+
+    const read = await request(app).get(`/api/registry/mirrors/${PLATFORM}`);
+    expect(read.status).toBe(200);
+    expect(read.body.adagents_json.authorized_agents).toEqual([]);
+    expect(read.body.adagents_json.formats).toHaveLength(1);
+    expect(read.body.adagents_json.$schema).toMatch(/adagents\.json$/);
+  });
+
+  it('drops any caller-supplied authorized_agents', async () => {
+    const res = await request(app)
+      .put(`/api/registry/mirrors/${PLATFORM}`)
+      .send(publishBody({ authorized_agents: [{ url: 'https://evil.example', authorized_for: 'all' }] }));
+    expect(res.status).toBe(200);
+    const read = await request(app).get(`/api/registry/mirrors/${PLATFORM}`);
+    expect(read.body.adagents_json.authorized_agents).toEqual([]);
+  });
+
+  it('allows an AAO admin who is not a registry moderator to publish', async () => {
+    isRegistryModerator.mockResolvedValue(false);
+    isWebUserAAOAdmin.mockResolvedValue(true);
+    const res = await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody());
+    expect(res.status).toBe(200);
+  });
+
+  it('re-publish is idempotent — updates in place, no duplicate row', async () => {
+    await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody({ catalog_etag: 'v1' }));
+    await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody({ catalog_etag: 'v2' }));
+
+    const { rows } = await pool.query('SELECT catalog_etag FROM community_mirrors WHERE platform = $1', [PLATFORM]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].catalog_etag).toBe('v2');
+
+    const list = await request(app).get('/api/registry/mirrors');
+    const mine = list.body.mirrors.filter((m: { platform: string }) => m.platform === PLATFORM);
+    expect(mine).toHaveLength(1);
+    expect(mine[0].catalog_etag).toBe('v2');
+  });
+
+  it('preserves created_by_* across a re-publish by a different user', async () => {
+    authState.userId = 'creator-A';
+    await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody({ catalog_etag: 'v1' }));
+    authState.userId = 'editor-B';
+    await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody({ catalog_etag: 'v2' }));
+
+    const { rows } = await pool.query(
+      'SELECT created_by_user_id, catalog_etag FROM community_mirrors WHERE platform = $1',
+      [PLATFORM]
+    );
+    expect(rows[0].created_by_user_id).toBe('creator-A');
+    expect(rows[0].catalog_etag).toBe('v2');
+  });
+
+  it('rejects a mirror with no catalog content (400)', async () => {
+    const res = await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send({ catalog_etag: 'x' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/catalog content/i);
+  });
+
+  it('rejects a formats[] entry missing required params — must conform to adagents.json (400)', async () => {
+    const res = await request(app)
+      .put(`/api/registry/mirrors/${PLATFORM}`)
+      .send(publishBody({ formats: [{ format_option_id: 'x', display_name: 'X', format_kind: 'image' }] }));
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/conform/i);
+  });
+
+  it('rejects an invalid platform identifier (400)', async () => {
+    const res = await request(app).put('/api/registry/mirrors/Bad_Platform!').send(publishBody());
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a non-moderator, non-admin caller (403)', async () => {
+    isRegistryModerator.mockResolvedValue(false);
+    isWebUserAAOAdmin.mockResolvedValue(false);
+    const res = await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody());
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 for an unknown mirror', async () => {
+    const res = await request(app).get(`/api/registry/mirrors/${PLATFORM}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('serves the mirror at /translated/<platform>/adagents.json with an ETag, and 304 on If-None-Match', async () => {
+    await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody({ catalog_etag: 'serve-etag' }));
+
+    const served = await request(app).get(`/api/creative-agent/translated/${PLATFORM}/adagents.json`);
+    expect(served.status).toBe(200);
+    expect(served.headers['content-type']).toMatch(/^application\/json/);
+    expect(served.headers['access-control-allow-origin']).toBe('*');
+    expect(served.headers['x-content-type-options']).toBe('nosniff');
+    expect(served.headers['etag']).toBe('"serve-etag"');
+    expect(served.body.authorized_agents).toEqual([]);
+
+    const revalidate = await request(app)
+      .get(`/api/creative-agent/translated/${PLATFORM}/adagents.json`)
+      .set('If-None-Match', '"serve-etag"');
+    expect(revalidate.status).toBe(304);
+  });
+
+  it('falls back to a content-hash ETag when catalog_etag is absent', async () => {
+    await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody({ catalog_etag: undefined }));
+    const served = await request(app).get(`/api/creative-agent/translated/${PLATFORM}/adagents.json`);
+    expect(served.status).toBe(200);
+    expect(served.headers['etag']).toMatch(/^"[0-9a-f]{32}"$/);
+
+    const revalidate = await request(app)
+      .get(`/api/creative-agent/translated/${PLATFORM}/adagents.json`)
+      .set('If-None-Match', served.headers['etag']);
+    expect(revalidate.status).toBe(304);
+  });
+
+  it('serving carries superseded_by in the body and advertises it via a Link header', async () => {
+    await request(app)
+      .put(`/api/registry/mirrors/${PLATFORM}`)
+      .send(publishBody({ superseded_by: 'https://meta.com/.well-known/adagents.json' }));
+    const served = await request(app).get(`/api/creative-agent/translated/${PLATFORM}/adagents.json`);
+    expect(served.status).toBe(200);
+    // The body field is the normative SDK trigger; the Link header is an additive hint.
+    expect(served.body.superseded_by).toBe('https://meta.com/.well-known/adagents.json');
+    expect(served.headers['link']).toContain('rel="successor-version"');
+    expect(served.headers['link']).toContain('https://meta.com/.well-known/adagents.json');
+  });
+
+  it('serving returns 404 for an unpublished platform', async () => {
+    const res = await request(app).get(`/api/creative-agent/translated/${PLATFORM}/adagents.json`);
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
Closes #5361. Builds on #5352/#5353 (which made `authorized_agents: []` valid).

Makes AAO catalog-only adagents.json mirrors first-class registry resources — closing the gap where published mirrors couldn't be read back, listed, or re-published in place, and there was no `translated/<platform>` serving route.

## Change

- **Store** — `community_mirrors` table (migration 506), keyed by `platform`, with the adagents.json body (JSONB), `catalog_etag`, `superseded_by`, provenance, and the shared `updated_at` trigger. `CommunityMirrorDatabase`: idempotent `upsert` / `getByPlatform` / `list`.
- **Endpoints** (`/api/registry/mirrors`):
  - `GET /api/registry/mirrors` — list with `catalog_etag` (public).
  - `GET /api/registry/mirrors/:platform` — read one (public).
  - `PUT /api/registry/mirrors/:platform` — idempotent publish/upsert (registry moderators or AAO admins). Forces `authorized_agents: []`, requires catalog content, and **validates the assembled document against the published adagents.json schema** (Ajv, resolved from `static/schemas/source`) before persisting.
- **Serving** — `GET /translated/:platform/adagents.json` on the creative agent: `ETag` (`catalog_etag` or content hash), `If-None-Match` → `304`, `Cache-Control`, `X-Content-Type-Options: nosniff`, and `superseded_by` in-body + `Link: rel="successor-version"`.

Identity is `platform` (one mirror per platform), matching the spec's serving URL.

## Testing
14 integration tests against Postgres (real `HTTPServer`): publish, idempotent re-publish (no dup, `created_by` preserved), drops caller `authorized_agents`, AAO-admin path, **rejects a `formats[]` entry missing `params` (schema-conformance)**, 403 gate, 404s, serving with ETag/304/content-hash-fallback, and `superseded_by` body + Link. Typecheck, migration lint, and dist-asset check pass.

## Review
Reviewed by a code/protocol/security/product expert panel. Two findings fixed and verified:
- **Schema conformance** — the publish path now validates the full assembled document against `adagents.json` (the panel proved a `params`-less `formats[]` would otherwise be stored/served). 
- **Admin gate** — replaced a dead `req.user.isAdmin` read with `isWebUserAAOAdmin()` (real AAO admins were getting 403). 
Plus nits: `http(s)`-only `superseded_by`, `nosniff` on serving, combined imports.

Follow-ups (out of scope, by design): a moderator-gated `DELETE /:platform` to close the post-supersession window; SDK methods to consume these endpoints (tracked upstream in `adcontextprotocol/adcp-client`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
