### PR TITLE
Clarify inline creative management

### DIFF
--- a/.changeset/5359-inline-creative-capability.md
+++ b/.changeset/5359-inline-creative-capability.md
@@ -1,0 +1,8 @@
+---
+"adcontextprotocol": minor
+---
+
+Clarify that `inline_creative_management` covers inline package creatives on
+`create_media_buy` and `update_media_buy` independently of Creative Protocol
+support, and add compliance coverage for sellers that accept inline creatives
+without `sync_creatives`.

--- a/docs/creative/creative-libraries.mdx
+++ b/docs/creative/creative-libraries.mdx
@@ -5,9 +5,13 @@ description: "Creative libraries in AdCP let buyers browse, organize, and track 
 ---
 
 
-Creative libraries let buyers manage creatives through AdCP — browsing existing assets, uploading new ones, assigning them to campaigns, and tracking approval status. A creative library is hosted by any agent that declares `has_creative_library: true` in its capabilities: ad servers (CM360, Flashtalking), creative management platforms (Celtra), or sales agents with [inline creative management](/docs/creative/sales-agent-creative-capabilities).
+Creative libraries let buyers manage creatives through AdCP — browsing existing assets, uploading new ones, assigning them to campaigns, and tracking approval status. A creative library is hosted by any agent that declares `has_creative_library: true` in its capabilities: ad servers (CM360, Flashtalking), creative management platforms (Celtra), or sales agents that also expose the Creative Protocol.
 
 ## The model
+
+A creative library is an account-scoped collection of creative resources with stable `creative_id`s, observable lifecycle state, and assignment relationships that are separate from any one media buy or package. The implementation can be a full ad-server library or a thin view over seller storage, but the protocol commitment is the same: buyers can read the creative resource through `list_creatives`, update it through `sync_creatives`, and reference it by `creative_id` across assignments while the seller retains it.
+
+Inline package creatives from a seller that does not advertise a creative library are not library creatives. They are package-scoped creative attachments: the seller accepts and serves them as part of the media buy, but does not advertise independent library management or cross-buy reuse.
 
 A creative library organizes assets at three levels:
 
@@ -36,7 +40,7 @@ Buyer agents reusing a library creative on a new media buy check **creative stat
 
 ### Creatives outlast campaigns
 
-A creative MUST persist in the library independently of the buys that reference it. Buy rejection, cancellation, or completion releases assignments only — the creative remains in the library at its current `status` and may be reused on subsequent buys. This holds regardless of how the creative entered the library: explicit [`sync_creatives`](/docs/creative/task-reference/sync_creatives), inline creative on [`create_media_buy`](/docs/media-buy/task-reference/create_media_buy), or platform-native upload exposed through AdCP. Sellers whose underlying ad server has no library object distinct from per-buy attachment satisfy this rule by exposing the buyer-synced creative through `list_creatives` for the buy's lifetime and continuing to expose its terminal state (including `archived`) after teardown — the library can be a thin view over per-buy storage; it does not need to be a separate store.
+A creative MUST persist in the library independently of the buys that reference it. Buy rejection, cancellation, or completion releases assignments only — the creative remains in the library at its current `status` and may be reused on subsequent buys. This holds regardless of how the creative entered the library: explicit [`sync_creatives`](/docs/creative/task-reference/sync_creatives), library-backed inline creative on [`create_media_buy`](/docs/media-buy/task-reference/create_media_buy), or platform-native upload exposed through AdCP. Sellers whose underlying ad server has no library object distinct from per-buy attachment satisfy this rule by exposing the buyer-synced creative through `list_creatives` for the buy's lifetime and continuing to expose its terminal state (including `archived`) after teardown — the library can be a thin view over per-buy storage; it does not need to be a separate store.
 
 Retention beyond active assignments is seller-defined. An agent MAY archive an unassigned creative due to inactivity, post-flight expiry, or storage policy (see [creative status lifecycle](/docs/creative/specification#creative-status-lifecycle)), MAY transition `approved` → `suspended` for recoverable dependency loss such as a published-post authorization expiring, and MAY transition `approved` → `rejected` for policy revocation, takedown, or content drift. Whenever a creative's state changes after it has been synced by a buyer, the seller MUST make the new state observable so the buyer can resync, replace, or stop relying on the asset before reuse:
 
@@ -258,13 +262,15 @@ Upload the creative directly with the media buy — no separate sync step:
 }
 ```
 
-The agent adds the creative to its library and assigns it to the package in one operation. See [inline creative management](/docs/creative/sales-agent-creative-capabilities) for details.
+For sellers that also advertise `creative.has_creative_library: true`, the agent adds the creative to its library and assigns it to the package in one operation. For inline-only sellers that do not advertise a creative library, the same `creatives` payload assigns package-scoped assets without creating a reusable library entry. See [inline creative management](/docs/creative/sales-agent-creative-capabilities) for details.
 
-**Inline creatives follow the same library lifecycle as `sync_creatives` uploads.** The inline form is a convenience — "sync and assign in one call" — not a separate lifecycle. Once submitted, the creative enters the library with the same review flow, retention, and identifiers it would have under `sync_creatives`. If the `create_media_buy` task resolves as `pending_manual` and the buy never activates, or if the buy is rejected or canceled, only the package assignments are released; the creatives remain in the library and may be referenced by `creative_id` in a subsequent `create_media_buy` call. This assignment-release behavior is normative on the media-buy side — see the [Media Buy State Transitions](/docs/media-buy/specification#media-buy-state-transitions) rule.
+**Library-backed inline creatives follow the same library lifecycle as `sync_creatives` uploads.** When the seller advertises `creative.has_creative_library: true`, the inline form is a convenience — "sync and assign in one call" — not a separate lifecycle. Once submitted, the creative enters the library with the same review flow, retention, and identifiers it would have under `sync_creatives`. If the `create_media_buy` task resolves as `pending_manual` and the buy never activates, or if the buy is rejected or canceled, only the package assignments are released; the creatives remain in the library and may be referenced by `creative_id` in a subsequent `create_media_buy` call. This assignment-release behavior is normative on the media-buy side — see the [Media Buy State Transitions](/docs/media-buy/specification#media-buy-state-transitions) rule.
+
+For inline-only sellers, buyers should treat the creative body as attached to the media-buy package. The seller may retain enough package-scoped creative state to review, serve, replace, and audit the buy, but it has not advertised reusable library operations such as `list_creatives`, `sync_creatives`, or later `creative_assignments` reuse.
 
 Creative review proceeds independently of the media buy outcome. Sellers MUST NOT skip review solely because the buy did not activate, and a buy rejection does not by itself imply rejection of the submitted creatives — a creative rejection MUST be a deliberate review decision with its own `rejection_reason`, not implicit from the containing buy's status. Sellers MAY deprioritize review of creatives that currently have no active assignments, provided review completes before any future assignment activates.
 
-**Capability-flag scope.** `inline_creative_management: true` advertises that the sales agent accepts inline creatives on `create_media_buy`; it does **not** tie the inline creative's lifecycle to the buy. The decoupled library lifecycle applies regardless of submission path.
+**Capability-flag scope.** `inline_creative_management: true` advertises that the sales agent accepts inline creatives on `create_media_buy` and `update_media_buy`; it does not by itself advertise a creative library. The decoupled library lifecycle applies when the seller also advertises `creative.has_creative_library: true`.
 
 ### Multi-seller distribution
 

--- a/docs/creative/sales-agent-creative-capabilities.mdx
+++ b/docs/creative/sales-agent-creative-capabilities.mdx
@@ -39,11 +39,26 @@ A sales agent declares Creative Protocol support in `get_adcp_capabilities`:
 }
 ```
 
-Note that `inline_creative_management` (a media buy feature for attaching creatives to packages at buy time) and Creative Protocol support are independent. A sales agent can support one, the other, or both.
+Note that `inline_creative_management` (a media buy feature for attaching creatives to packages at buy time), Creative Protocol support, and `creative.has_creative_library` are distinct declarations. A sales agent can accept inline package creatives without a creative library, can host a library without inline package uploads, or can support both paths.
 
-`inline_creative_management` allows attaching creatives directly to packages in `create_media_buy` — the creative travels with the buy order. Creative Protocol support (`"creative"` in `supported_protocols`) means the agent implements creative tasks like `build_creative`, `list_creative_formats`, and [`sync_creatives`](/docs/creative/task-reference/sync_creatives). A sales agent might support inline creative management without implementing the Creative Protocol (the buyer manages creatives externally and just references them in the buy), or implement the Creative Protocol without inline management (creatives are synced separately via `sync_creatives` before being assigned to packages).
+`inline_creative_management` allows attaching creatives directly to packages in `create_media_buy` and `update_media_buy` — the creative travels with the buy or package update. Creative Protocol support (`"creative"` in `supported_protocols`) means the agent implements creative tasks such as `build_creative`, `list_creative_formats`, or [`sync_creatives`](/docs/creative/task-reference/sync_creatives), depending on its creative capability flags. A reusable creative library is advertised specifically by `creative.has_creative_library: true`. A sales agent might support inline creative management without implementing a library (the buyer supplies package-scoped creative bodies with the media-buy request), or host a library without inline management (creatives are synced separately via `sync_creatives` before being assigned to packages).
 
 The buyer calls all tasks — media buy and creative — on the same agent URL. The protocol the task belongs to determines the schema, not the type of agent.
+
+## Buyer creative path selection
+
+Buyers choose the creative delivery path from the media-buy inline flag and the Creative Protocol library capability:
+
+| `creative.has_creative_library` | `media_buy.features.inline_creative_management` | Buyer behavior |
+|---|---|---|
+| `true` | Absent or `false` | Use Creative Protocol tasks such as `sync_creatives`, then assign stored creatives with `packages[].creative_assignments`. |
+| Absent or `false` | `true` | Use `packages[].creatives` inline on `create_media_buy` and `update_media_buy`. Do not call `sync_creatives`; the seller has not advertised a creative library. |
+| `true` | `true` | Both paths are available. Use inline creatives for single-use package assets or immediate replacement, and `sync_creatives` plus `creative_assignments` for reusable library assets. Inline creatives become library creatives because the seller has advertised a creative library. |
+| Absent or `false` | Absent or `false` | The seller has not advertised creative delivery over AdCP. Buyers SHOULD NOT send `packages[].creatives` or `packages[].creative_assignments` unless another seller-specific extension explicitly defines that behavior. |
+
+When `inline_creative_management` is true and `creative.has_creative_library` is absent or false, `packages[].creatives` is the advertised creative surface. The seller may store those assets only as part of the media buy or package; buyers should not expect `list_creatives`, `sync_creatives`, or later `creative_assignments` reuse to work.
+
+Inline-only approval-state readback is package-scoped. `get_media_buys` surfaces the package's currently assigned inline creative approvals through `packages[].creative_approvals[]` (`creative_id`, `approval_status`, and optional `rejection_reason`), but it does not return the full creative body, placement routing, weights, or prior revisions. Buyers using inline-only sellers should retain the submitted creative manifest or asset payload on their side if they need to inspect or resubmit it later.
 
 ## Available creative tasks
 
@@ -99,12 +114,12 @@ Sales agents that receive creatives — whether via inline attachment in `create
 
 Creative review status is surfaced at two levels:
 
-- **Creative library**: The `status` field on each creative in [`list_creatives`](/docs/creative/task-reference/list_creatives) uses the creative status enum: `processing`, `pending_review`, `approved`, `rejected`, or `archived`.
+- **Creative library**: For sellers that advertise `creative.has_creative_library: true`, the `status` field on each creative in [`list_creatives`](/docs/creative/task-reference/list_creatives) uses the creative status enum: `processing`, `pending_review`, `approved`, `rejected`, or `archived`.
 - **Package level**: The `approval_status` field on each creative in [`get_media_buys`](/docs/media-buy/task-reference/get_media_buys) responses uses the creative approval status enum: `pending_review`, `approved`, or `rejected`. Rejected creatives include a `rejection_reason` with a human-readable explanation.
 
 A creative may be `approved` in the library but `rejected` at the package level if it violates placement-specific policies (e.g., a video creative on an audio-only placement).
 
-Buyers SHOULD poll `list_creatives` or `get_media_buys` after syncing or submitting a media buy with new creatives, especially for publishers with strict creative policies.
+Buyers SHOULD poll `list_creatives` or `get_media_buys` after syncing or submitting a media buy with new creatives, especially for publishers with strict creative policies. For inline-only sellers, `get_media_buys` is the approval-state readback surface.
 
 For generative formats where the seller generates at serve time, creative review applies to the brief and brand identity rather than individual creatives. The seller validates that the brief's constraints and brand assets meet its policies before generation begins.
 
@@ -315,6 +330,8 @@ if (caps.errors) {
 
 const sellsMedia = caps.supported_protocols.includes('media_buy');
 const managesCreatives = caps.supported_protocols.includes('creative');
+const acceptsInlineCreatives =
+  caps.media_buy?.features?.inline_creative_management === true;
 
 if (managesCreatives) {
   const { has_creative_library, supports_generation } = caps.creative;
@@ -336,6 +353,10 @@ if (managesCreatives) {
       console.error('Library browse failed:', creatives.errors);
     }
   }
+}
+
+if (sellsMedia && acceptsInlineCreatives && !managesCreatives) {
+  // Inline-only seller: send package creatives on create_media_buy or update_media_buy.
 }
 ```
 

--- a/docs/media-buy/creatives/index.mdx
+++ b/docs/media-buy/creatives/index.mdx
@@ -21,6 +21,8 @@ AdCP's creative management system handles:
 ### Creative Synchronization
 Use [`sync_creatives`](/docs/creative/task-reference/sync_creatives) to upload and manage creative assets in the creative library hosted by your seller or creative platform. This ensures your creatives are available for assignment across platforms and campaigns.
 
+For sellers that advertise `inline_creative_management: true` without `creative.has_creative_library: true`, creatives are supplied as package-scoped `packages[].creatives` on `create_media_buy` or `update_media_buy` instead of through a reusable library.
+
 ### Creative Library Management
 Use [`list_creatives`](/docs/creative/task-reference/list_creatives) to view and manage your creative asset library, including status tracking and performance metadata.
 

--- a/docs/media-buy/index.mdx
+++ b/docs/media-buy/index.mdx
@@ -42,7 +42,7 @@ One brief. Three sellers. Same JSON structure back.
 | Campaign brief | `brief` field on `get_products` |
 | Media plan | Products returned from `get_products` |
 | IO / insertion order | `create_media_buy` |
-| Trafficking creatives | `sync_creatives` to each seller |
+| Trafficking creatives | `sync_creatives` for library-backed sellers, or inline `packages[].creatives` for inline-only sellers |
 | Campaign report | `get_media_buy_delivery` across agents |
 | Flight dates | `start_time` / `end_time` on the media buy or packages |
 | Viewability / IVT / completion SLAs | `performance_standards` on packages — see [Accountability](/docs/media-buy/advanced-topics/accountability) |

--- a/docs/media-buy/media-buys/index.mdx
+++ b/docs/media-buy/media-buys/index.mdx
@@ -42,8 +42,8 @@ This phase may involve:
 - **Kevel**: Creates a Campaign with Flights
 - **Triton Digital**: Creates a Campaign with Flights
 
-### 2. Creative Upload Phase
-Once created, the media buy requires creative assets via [`sync_creatives`](/docs/creative/task-reference/sync_creatives):
+### 2. Creative Supply Phase
+Once created, the media buy requires creative assets through the path the seller advertises: [`sync_creatives`](/docs/creative/task-reference/sync_creatives) for library-backed sellers, or inline `packages[].creatives` on [`create_media_buy`](/docs/media-buy/task-reference/create_media_buy) and [`update_media_buy`](/docs/media-buy/task-reference/update_media_buy) for inline-only sellers.
 
 - **Platform-specific format support** (video, audio, display, custom)
 - **Validation and policy review** for creative compliance
@@ -302,7 +302,7 @@ pending_start ──────▶ rejected (terminal)  — seller rejects duri
 Any non-terminal ──── update(canceled: true) ──▶ canceled (terminal)
 ```
 
-- **`pending_creatives`**: Approved but no creatives assigned — **buyer-side action required** (call `sync_creatives`). Not a publisher- or governance-side approval queue: the seller has already accepted the buy; only the buyer's creative submission is missing.
+- **`pending_creatives`**: Approved but no creatives assigned — **buyer-side action required** (use `sync_creatives` for library-backed sellers, or inline `packages[].creatives` for inline-only sellers). Not a publisher- or governance-side approval queue: the seller has already accepted the buy; only the buyer's creative submission is missing.
 - **`pending_start`**: Ready to serve, waiting for flight date
 
 The `pending_X` naming convention names the lifecycle phase that is next required, NOT a state of waiting on seller/operator approval — `pending_creatives` means "creatives are the next phase," `pending_start` means "the flight date start is the next phase." Both are post-seller-acceptance states.

--- a/docs/media-buy/media-buys/lifecycle.mdx
+++ b/docs/media-buy/media-buys/lifecycle.mdx
@@ -17,7 +17,7 @@ flowchart TD
     C -->|creatives missing| D[pending_creatives]
     C -->|creatives present,\nflight not yet started| E[pending_start]
     C -->|creatives present,\nflight started| F[active]
-    D --> G[sync_creatives]
+    D --> G[creative supply]
     G --> E
     E --> F
     F --> H{delivery}
@@ -28,7 +28,7 @@ flowchart TD
 
 1. **`get_products`** — discover available inventory matching your brief.
 2. **`create_media_buy`** — submit packages; the seller validates and confirms.
-3. **`sync_creatives`** — assign creative assets to packages that need them.
+3. **Creative supply** — assign creative assets to packages that need them, either through `sync_creatives` and `creative_assignments` or through inline package `creatives` when the seller advertises inline creative management.
 4. **Delivery** — the buy enters `active`, accrues impressions, and eventually reaches a terminal state.
 
 ## State machine
@@ -57,7 +57,7 @@ stateDiagram-v2
     [*] --> pending_start : create_media_buy\n(creatives present,\nflight future)
     [*] --> active : create_media_buy\n(creatives present,\nflight started)
 
-    pending_creatives --> pending_start : sync_creatives
+    pending_creatives --> pending_start : sync_creatives\nor update_media_buy creatives
     pending_start --> active : flight date reached
 
     active --> paused : update_media_buy\n(paused: true)
@@ -94,6 +94,8 @@ Rather than hardcoding the state machine, read `valid_actions` from `get_media_b
 
 Buyers SHOULD pass the latest `revision` in every `update_media_buy` call intended to change state. The field is optional for backward compatibility, but when present the seller rejects with `CONFLICT` if the revision has changed since your last read, and the check must happen atomically with the write so concurrent updates cannot overwrite each other. See [optimistic concurrency](/docs/media-buy/task-reference/update_media_buy#optimistic-concurrency).
 
+For creative changes, `sync_creatives` in `valid_actions` is the legacy action label. Use the creative path the seller advertises: `sync_creatives` and `creative_assignments` for library-backed sellers, or `packages[].creatives` on `update_media_buy` for inline-only sellers.
+
 ## Guaranteed / PG deal variation
 
 Products with `delivery_type: "guaranteed"` require contractual commitment before delivery begins. The flow diverges after `create_media_buy`:
@@ -106,7 +108,7 @@ flowchart TD
     C -->|IO pre-signed| E[pending_creatives\nor pending_start]
     D --> F[IO signed\nout-of-band]
     F --> E
-    E --> G[sync_creatives\nif needed]
+    E --> G[creative supply\nif needed]
     G --> H[active — guaranteed delivery]
     H --> I{performance}
     I -->|standards met| J[completed]
@@ -138,13 +140,13 @@ A seller who accepts without under-delivering earns a favorable accountability s
 
 `create_media_buy` accepts inline `creative_assignments` or `creatives` per package. If you supply them at creation time and the flight date has passed, the buy enters `active` directly. If the flight date is in the future, it enters `pending_start`.
 
-If no creatives are assigned at creation, the buy enters `pending_creatives`. Delivery cannot begin until `sync_creatives` is called to assign at least one creative per package.
+If no creatives are assigned at creation, the buy enters `pending_creatives`. Delivery cannot begin until the buyer supplies at least one creative per package through a path the seller advertises. Sellers with `creative.has_creative_library: true` use `sync_creatives` and `creative_assignments`. Sellers that advertise both `creative.has_creative_library: true` and `inline_creative_management: true` also accept inline `packages[].creatives` on `create_media_buy` and `update_media_buy`. Inline-only sellers use only `packages[].creatives` on `update_media_buy`.
 
 ### The `creative_deadline`
 
 `create_media_buy` returns a `creative_deadline` timestamp on the media buy response. Individual packages may carry their own `creative_deadline`. **Package-level deadlines take precedence over the media buy deadline.** This matters for mixed-channel orders — a print package may have a material deadline days before the digital packages in the same buy.
 
-After the deadline, `sync_creatives` calls for that package return `CREATIVE_REJECTED`. Creative changes are blocked; delivery continues with whatever creatives are currently assigned (or the package remains in `pending_creatives` if none were ever assigned).
+After the deadline, creative submissions for that package return `CREATIVE_REJECTED`, whether they arrive through `sync_creatives` or inline `packages[].creatives` on `update_media_buy`. Creative changes are blocked; delivery continues with whatever creatives are currently assigned (or the package remains in `pending_creatives` if none were ever assigned).
 
 ```
 Deadline hierarchy:
@@ -155,7 +157,7 @@ Deadline hierarchy:
 
 ### Effect on creatives when a buy ends
 
-When a media buy reaches `rejected`, `canceled`, or `completed`, creative assignments are released. The creatives themselves are not deleted — they remain in the library with their existing review status and are available for assignment to other media buys.
+When a media buy reaches `rejected`, `canceled`, or `completed`, creative assignments are released. For library-backed sellers, the creatives themselves are not deleted — they remain in the library with their existing review status and are available for assignment to other media buys. Inline-only sellers may retain package-scoped creative records for audit and reporting without exposing reusable library entries.
 
 ## Health and dependency impairment
 
@@ -228,7 +230,7 @@ Each `reason_code` has a typical buyer remediation path. Sellers don't fill this
 | `consent_expired` | Refresh upstream consent (e.g., hashed-id consent renewal on a clean-room flow), then re-sync the audience via `sync_audiences`. |
 | `ttl_expired` | Re-sync the audience via `sync_audiences` to renew. |
 | `pii_audit_failed` | Address audit findings upstream (hashing, identifier hygiene). Re-sync only **after** the seller signals the audit is cleared — a buyer agent that loops `sync_audiences` against an uncleared audit will not converge. |
-| `content_rejected` | Same path as initial creative approval — fix the issue and resubmit via `sync_creatives`. Campaign-level decision (replace vs. wait for resubmit) depends on creative pool composition and is left to the buyer. |
+| `content_rejected` | Same path as initial creative approval — fix the issue and resubmit via `sync_creatives` for library-backed sellers, or via `packages[].creatives` on `update_media_buy` for inline-only sellers. Campaign-level decision (replace vs. wait for resubmit) depends on creative pool composition and is left to the buyer. |
 | `identity_authorization_revoked` | Restore the downstream identity/post authorization through the seller's connection flow, or replace the affected `published_post` creative if authorization cannot be restored. |
 | `identity_authorization_expired` | Renew the downstream identity/post authorization through the seller's connection flow, then let the seller re-check or re-review the creative. |
 | `source_private` | Restore source post visibility or replace the affected `published_post` reference. |
@@ -270,13 +272,13 @@ Default when absent is `["snapshot"]`. Each surface is independent of the others
 See the [Snapshot and log contract](/docs/protocol/snapshot-and-log) for the read-side rules that tie `impairments[]` (snapshot) to the `impairment` push (log).
 
 <Tip>
-Creative library state and creative assignment state are tracked independently. A creative that was assigned to a canceled buy still has whatever review status it earned and can be immediately assigned to a new buy. See [creative state and assignment state](/docs/creative/creative-libraries#creative-state-and-assignment-state-are-separate).
+For library-backed sellers, creative library state and creative assignment state are tracked independently. A creative that was assigned to a canceled buy still has whatever review status it earned and can be immediately assigned to a new buy. Inline-only sellers expose package-scoped creative status on `get_media_buys` but do not advertise reusable library creatives. See [creative state and assignment state](/docs/creative/creative-libraries#creative-state-and-assignment-state-are-separate).
 </Tip>
 
 ## See also
 
 - [Media Buy Lifecycle](/docs/media-buy/media-buys/) — full lifecycle reference: campaign structure, package model, async operations
 - [`create_media_buy`](/docs/media-buy/task-reference/create_media_buy) — task reference with request parameters, response shapes, and examples
-- [`sync_creatives`](/docs/creative/task-reference/sync_creatives) — assign and update creative assets on active packages
+- [`sync_creatives`](/docs/creative/task-reference/sync_creatives) — upload and update library creatives when the seller advertises `creative.has_creative_library: true`
 - [Accountability](/docs/media-buy/advanced-topics/accountability) — performance standards, measurement terms, makegood resolution
 - [Optimization & Reporting](/docs/media-buy/media-buys/optimization-reporting) — delivery monitoring, dimensional reporting, campaign updates

--- a/docs/media-buy/media-buys/optimization-reporting.mdx
+++ b/docs/media-buy/media-buys/optimization-reporting.mdx
@@ -1185,7 +1185,7 @@ See [Conversion Tracking](/docs/media-buy/conversion-tracking/) for the complete
 ### Creative optimization
 - **Performance analysis** by creative asset via [`get_media_buy_delivery`](/docs/media-buy/task-reference/get_media_buy_delivery) with by-creative breakdowns
 - **A/B testing** — assign multiple creatives with weights via `creative_assignments`
-- **Refresh strategies** — swap creatives via [`sync_creatives`](/docs/creative/task-reference/sync_creatives) to prevent fatigue
+- **Refresh strategies** — swap creatives via [`sync_creatives`](/docs/creative/task-reference/sync_creatives) for library-backed sellers, or inline `packages[].creatives` on [`update_media_buy`](/docs/media-buy/task-reference/update_media_buy) for inline-only sellers, to prevent fatigue
 
 ### Targeting refinement
 - **Geographic optimization** — adjust `targeting_overlay` based on delivery data by region

--- a/docs/media-buy/specification.mdx
+++ b/docs/media-buy/specification.mdx
@@ -156,10 +156,10 @@ Any non-terminal ──── update(canceled: true) ──▶ canceled (termina
 - Rejection (`rejected` status) is only valid from `pending_creatives` or `pending_start`. Sales agents MUST NOT reject media buys that have already transitioned to `active`.
 - Seller-initiated cancellation notifications MUST use the `push_notification_config` webhook provided by the orchestrator during `create_media_buy` or `update_media_buy`. The webhook payload MUST include `media_buy_id`, `status: "canceled"`, and a `cancellation` object with `canceled_at`, `canceled_by: "seller"`, and `reason`.
 - The `canceled` field on update requests uses `"const": true` — only `true` is valid. Sending `canceled: false` fails schema validation. Cancellation is irreversible; there is no "uncancel" operation.
-- **Creative assignments are released on buy rejection or cancellation; the creatives themselves remain in the creative library.** When a media buy transitions to `rejected` or `canceled`, all package-creative assignments on that media buy are released. The creatives persist in the creative library per [assignment state and creative state](/docs/creative/creative-libraries#creative-state-and-assignment-state-are-separate) and MAY be referenced by `creative_id` in a subsequent `create_media_buy` or `sync_creatives` call, regardless of submission path (inline creatives submitted on the rejected/canceled `create_media_buy` enter the library on the same lifecycle as `sync_creatives` uploads).
+- **Creative assignments are released on buy rejection or cancellation.** When a media buy transitions to `rejected` or `canceled`, all package-creative assignments on that media buy are released. For sellers that advertise `creative.has_creative_library: true`, the creatives persist in the creative library per [assignment state and creative state](/docs/creative/creative-libraries#creative-state-and-assignment-state-are-separate) and MAY be referenced by `creative_id` in a subsequent `create_media_buy` or `sync_creatives` call. Inline-only sellers that advertise `inline_creative_management` without a creative library MAY keep submitted creatives package-scoped; they do not advertise cross-buy reuse or `list_creatives` readback.
 - **Creative review is independent of buy outcome.** Sales agents MUST NOT implicitly reject a creative because its containing buy was rejected; a creative rejection MUST be a deliberate review decision with its own `rejection_reason`. If the buy was rejected because a creative violated content policy, the sales agent MAY reject that creative — but only via the normal review path with its own `rejection_reason`; the buy's `rejected` status is not itself sufficient.
-- **Observability of released assignments.** The media-buy-level `canceled` or `rejected` transition (surfaced in the buy's `history` and in the webhook notifications required above) IS the audit record for all its released assignments; buyers MUST NOT rely on per-assignment diff observability. Released assignments no longer appear in `get_media_buys` responses for that buy. Buyers confirming reusability SHOULD call `list_creatives` to verify the creative is still in the library and observe its current status. Package-scoped deadlines (`creative_deadline`) on the prior package have no bearing on the creative's eligibility for a new buy.
-- **Retention.** Sales agents SHOULD retain released creatives in the library for at least 90 days after the last assignment is released. A normative retention floor is specified in the creative retention contract tracked under [#2260](https://github.com/adcontextprotocol/adcp/issues/2260); until that contract lands, buyers relying on long-horizon reuse SHOULD verify persistence via `list_creatives` before referencing a released creative on a new buy.
+- **Observability of released assignments.** The media-buy-level `canceled` or `rejected` transition (surfaced in the buy's `history` and in the webhook notifications required above) IS the audit record for all its released assignments; buyers MUST NOT rely on per-assignment diff observability. Released assignments no longer appear in `get_media_buys` responses for that buy. Buyers confirming library reusability SHOULD call `list_creatives` to verify the creative is still in the library and observe its current status. Inline-only buyers should retain their submitted creative bodies because `get_media_buys` surfaces package-level approval state, not full creative-body retrieval. Package-scoped deadlines (`creative_deadline`) on the prior package have no bearing on a library creative's eligibility for a new buy.
+- **Retention.** Sales agents with creative libraries SHOULD retain released creatives in the library for at least 90 days after the last assignment is released. A normative retention floor is specified in the creative retention contract tracked under [#2260](https://github.com/adcontextprotocol/adcp/issues/2260); until that contract lands, buyers relying on long-horizon reuse SHOULD verify persistence via `list_creatives` before referencing a released creative on a new buy.
 
 #### Revision and confirmation semantics
 
@@ -193,11 +193,11 @@ Each package tracks per-creative approval status separately from the creative's 
 | `approved` | Creative approved for delivery on this package |
 | `rejected` | Creative rejected for this package; see `rejection_reason` |
 
-Rejection is not terminal — the buyer fixes the creative and resubmits via `sync_creatives`, which resets the approval to `pending_review`. The resubmission path:
+Rejection is not terminal — the buyer fixes the creative and resubmits through the seller's advertised creative path, which resets the approval to `pending_review`. The resubmission path:
 
 1. Check `rejection_reason` on `get_media_buys` response
 2. Fix the creative (update assets, adjust manifest)
-3. Resubmit via `sync_creatives`
+3. Resubmit via `sync_creatives` for library-backed sellers, or via `packages[].creatives` on `update_media_buy` for inline-only sellers
 4. Approval resets to `pending_review`
 
 **Interaction with `creative_deadline`:** If a creative is rejected after the package's `creative_deadline`, the buyer MAY still resubmit — sellers SHOULD accept resubmissions for rejected creatives even past the deadline, since the buyer is correcting a seller-identified issue. Sellers that cannot accept late resubmissions MUST return `CREATIVE_DEADLINE_EXCEEDED`.
@@ -335,7 +335,7 @@ Synchronize catalogs (products, inventory, stores, and vertical feeds) on a sell
 ### sync_creatives
 
 <Note>
-`sync_creatives` is defined in the [Creative Protocol](/docs/creative/specification#sync_creatives). Any agent that hosts a creative library implements `sync_creatives` as part of the Creative Protocol. See the [`sync_creatives` task reference](/docs/creative/task-reference/sync_creatives).
+`sync_creatives` is defined in the [Creative Protocol](/docs/creative/specification#sync_creatives). Any agent that advertises `creative.has_creative_library: true` implements `sync_creatives` as part of the Creative Protocol. See the [`sync_creatives` task reference](/docs/creative/task-reference/sync_creatives).
 </Note>
 
 ### get_media_buys
@@ -364,6 +364,9 @@ Retrieve operational media buy state, including package status, creative approva
 Sellers MAY omit actions based on business rules (e.g., omit `cancel` when contractual obligations prevent it, omit `add_packages` when the platform does not support mid-flight additions).
 
 `valid_actions` contains only mutation operations — read-only operations (`get_media_buys`, `get_media_buy_delivery`) are always permitted regardless of state. Agents SHOULD use `valid_actions` as an optimization hint but MUST handle `INVALID_STATE` errors gracefully, since `valid_actions` may not reflect real-time state changes from concurrent operations. Absence of an action means "not declared by this seller," not necessarily "forbidden."
+
+For creative changes, `sync_creatives` in `valid_actions` is a legacy creative-change action label, not proof that the `sync_creatives` task exists. Buyers use the creative path the seller advertises: `sync_creatives` and `creative_assignments` for sellers with `creative.has_creative_library: true`, or `packages[].creatives` on `update_media_buy` for inline-only sellers that advertise `media_buy.features.inline_creative_management: true`.
+
 - Orchestrators MAY request revision history by setting `include_history` to the number of most-recent entries desired. Sales agents SHOULD return a `history` array per media buy when `include_history > 0`, containing revision number, timestamp, server-derived actor identity, action type, and optional summary. History entries MUST be ordered most-recent-first.
 - Sales agents MUST include a media-buy currency and MUST denominate monetary fields consistently (`snapshot.currency` -> `package.currency` -> `media_buy.currency`)
 - Sales agents SHOULD include creative approval outcomes and pending format requirements when available

--- a/docs/media-buy/task-reference/create_media_buy.mdx
+++ b/docs/media-buy/task-reference/create_media_buy.mdx
@@ -201,7 +201,7 @@ When executing a proposal, `proposal_status` on the returned proposal determines
 | `start_time` | string | No | ISO 8601 date-time for this package's flight start. When omitted, inherits the media buy's `start_time`. Must fall within the media buy's date range. Does not support `"asap"`. |
 | `end_time` | string | No | ISO 8601 date-time for this package's flight end. When omitted, inherits the media buy's `end_time`. Must fall within the media buy's date range. |
 | `creative_assignments` | CreativeAssignment[] | No | Assign existing library creatives with optional weights and placement targeting |
-| `creatives` | CreativeAsset[] | No | Upload new creative assets and assign (`creative_id` must not already exist in library) |
+| `creatives` | CreativeAsset[] | No | Upload new creative assets inline and assign. Requires `media_buy.features.inline_creative_management: true`; when the seller also advertises `creative.has_creative_library: true`, `creative_id` must not already exist in the library. |
 | `context` | object | No | Opaque correlation data echoed unchanged in the package response, webhooks, and read surfaces. Use to map seller-assigned `package_id` back to your internal line items, campaign structure, or tracking state. Buyers targeting mixed seller populations SHOULD include a per-package correlation value here, commonly `context.buyer_ref`, for legacy sellers that do not echo `product_id`. |
 | `measurement_terms` | [MeasurementTerms](/docs/media-buy/advanced-topics/pricing-models#measurement-terms-and-performance-standards) | No | Buyer's proposed billing measurement and makegood terms. Overrides product defaults. Seller accepts (echoed on confirmed package), rejects with `TERMS_REJECTED`, or adjusts. When omitted, product's `measurement_terms` apply. |
 | `performance_standards` | [PerformanceStandard[]](/docs/media-buy/advanced-topics/pricing-models#measurement-terms-and-performance-standards) | No | Buyer's proposed performance standards (viewability, IVT, completion rate, brand safety, attention score). Overrides product defaults. Seller accepts, rejects with `TERMS_REJECTED`, or adjusts. When omitted, product's `performance_standards` apply. |
@@ -1021,7 +1021,7 @@ Common errors and resolutions:
 | `TARGETING_TOO_NARROW` | Targeting yields zero inventory | Broaden geographic or audience criteria |
 | `POLICY_VIOLATION` | Brand/product violates policy | Review publisher's content policies |
 | `INVALID_PRICING_OPTION` | pricing_option_id not found | Use ID from product's `pricing_options` |
-| `CREATIVE_ID_EXISTS` | Creative ID already exists in library | Use a different `creative_id`, assign existing creatives via `creative_assignments`, or update via `sync_creatives` |
+| `CREATIVE_ID_EXISTS` | Creative ID already exists in the seller's creative namespace | For library-backed sellers, assign existing creatives via `creative_assignments` or update via `sync_creatives`; for inline-only sellers, use a different package-scoped `creative_id` |
 
 Example error response:
 
@@ -1131,7 +1131,7 @@ When creating a media buy, format specification enables:
                        omit for all-formats default
    └── Publisher creates placeholders
    └── Clear creative requirements established
-5. sync_creatives → Upload actual files matching formats
+5. Creative supply → Upload matching files via `sync_creatives` for library-backed sellers, or inline `packages[].creatives` for inline-only sellers
 6. Campaign activation → Replace placeholders with real creatives
 ```
 
@@ -1550,8 +1550,8 @@ For complete async handling patterns, see [Async Operations](/docs/building/impl
 - Impression-time targeting (audience, frequency, suitability) is handled by [TMP](/docs/trusted-match)
 - Pending states (`working`, `submitted`) are normal, not errors
 - Orchestrators MUST handle pending states as part of normal workflow
-- **Inline creatives**: The `creatives` array creates NEW creatives only. To update existing creatives, use [`sync_creatives`](/docs/creative/task-reference/sync_creatives). To assign existing library creatives, use `creative_assignments` instead.
-- **Inline creative lifecycle**: Inline creatives enter the library with the same lifecycle as `sync_creatives` uploads. If the `create_media_buy` task resolves as `pending_manual` and the buy never activates, or if the buy is rejected or canceled, only the package assignments are released — the creatives remain in the library and can be reused by `creative_id` on a later `create_media_buy` call. Creative review is independent of the buy outcome; sellers MUST NOT skip review solely because the buy did not activate. Retention of unassigned creatives is seller-defined in 3.0. See [Inline creatives on the package](/docs/creative/creative-libraries#path-2-inline-creatives-on-the-package).
+- **Inline creatives**: The `creatives` array creates or supplies package creatives inline. If the seller advertises `creative.has_creative_library: true`, inline creatives enter the library; use [`sync_creatives`](/docs/creative/task-reference/sync_creatives) to update existing library creatives and `creative_assignments` to assign existing library creatives. If the seller advertises `inline_creative_management: true` without a creative library, use `packages[].creatives` on `create_media_buy` and `update_media_buy`; do not call `sync_creatives`.
+- **Inline creative lifecycle**: Library-backed inline creatives enter the library with the same lifecycle as `sync_creatives` uploads. Inline-only sellers may keep the creative package-scoped and do not advertise later reuse by `creative_id`. Creative review is independent of the buy outcome; sellers MUST NOT skip review solely because the buy did not activate. Retention of unassigned library creatives is seller-defined in 3.0. See [Inline creatives on the package](/docs/creative/creative-libraries#path-2-inline-creatives-on-the-package).
 
 ## Content Standards
 
@@ -1585,7 +1585,7 @@ Publishers should ensure:
 
 After creating a media buy:
 
-1. **Upload Creatives**: Use [`sync_creatives`](/docs/creative/task-reference/sync_creatives) before deadline
+1. **Supply creatives**: Use [`sync_creatives`](/docs/creative/task-reference/sync_creatives) for library-backed sellers, or `packages[].creatives` on [`update_media_buy`](/docs/media-buy/task-reference/update_media_buy) for inline-only sellers
 2. **Monitor Status**: Use [`get_media_buy_delivery`](/docs/media-buy/task-reference/get_media_buy_delivery)
 3. **Optimize**: Use [`provide_performance_feedback`](/docs/media-buy/task-reference/provide_performance_feedback)
 4. **Update**: Use [`update_media_buy`](/docs/media-buy/task-reference/update_media_buy) to modify campaign

--- a/docs/media-buy/task-reference/get_media_buy_delivery.mdx
+++ b/docs/media-buy/task-reference/get_media_buy_delivery.mdx
@@ -947,7 +947,7 @@ After retrieving delivery data:
 
 1. **Optimize Campaigns**: Use [`update_media_buy`](/docs/media-buy/task-reference/update_media_buy) to adjust budgets, pacing, or targeting
 2. **Provide Feedback**: Use [`provide_performance_feedback`](/docs/media-buy/task-reference/provide_performance_feedback) to share results with seller
-3. **Update Creatives**: Use [`sync_creatives`](/docs/creative/task-reference/sync_creatives) to refresh underperforming assets
+3. **Update Creatives**: Use [`sync_creatives`](/docs/creative/task-reference/sync_creatives) for library-backed sellers, or inline `packages[].creatives` on [`update_media_buy`](/docs/media-buy/task-reference/update_media_buy) for inline-only sellers
 4. **Create Follow-Up Campaigns**: Use [`create_media_buy`](/docs/media-buy/task-reference/create_media_buy) based on insights
 
 ## Learn More

--- a/docs/media-buy/task-reference/get_media_buys.mdx
+++ b/docs/media-buy/task-reference/get_media_buys.mdx
@@ -103,7 +103,9 @@ Returns an array of media buys with current status, creative approval state, and
 | `approval_status` | `pending_review`, `approved`, or `rejected` |
 | `rejection_reason` | Explanation of rejection (when `approval_status` is `rejected`) |
 
-Creative revisions are represented as `approval_status: "rejected"` with a specific `rejection_reason`. There is no package-level `input-required` status for creative edits; upload corrected assets via [`sync_creatives`](/docs/creative/task-reference/sync_creatives).
+For sellers that advertise `inline_creative_management` without a creative library, `creative_approvals` is the only standardized approval-state readback surface for the package's currently assigned inline creatives. It reports `creative_id`, `approval_status`, and optional `rejection_reason`, but it does not include the full `CreativeAsset` payload, placement routing, weights, or prior revisions submitted on `create_media_buy` or `update_media_buy`. Buyers should retain their own submitted creative bodies when integrating with inline-only sellers.
+
+Creative revisions are represented as `approval_status: "rejected"` with a specific `rejection_reason`. There is no package-level `input-required` status for creative edits; upload corrected library assets via [`sync_creatives`](/docs/creative/task-reference/sync_creatives), or corrected inline-only package assets via `packages[].creatives` on [`update_media_buy`](/docs/media-buy/task-reference/update_media_buy).
 
 ### History Entry Object
 
@@ -329,6 +331,8 @@ The `valid_actions` array tells agents what operations are permitted on a media 
 | `canceled` | *(empty array)* |
 
 Sellers MAY omit actions based on business rules (e.g., omit `cancel` when the media buy has contractual obligations that prevent cancellation).
+
+For creative changes, `sync_creatives` in `valid_actions` is a legacy creative-change action label, not proof that the `sync_creatives` task exists. Use the creative path the seller advertises: `sync_creatives` and `creative_assignments` for sellers with `creative.has_creative_library: true`, or `packages[].creatives` on `update_media_buy` for inline-only sellers.
 
 ## Common Scenarios
 
@@ -599,7 +603,7 @@ Use cursor pagination for broad status queries to avoid large payloads:
 
 ## Next Steps
 
-- **Upload missing creatives**: Use [`sync_creatives`](/docs/creative/task-reference/sync_creatives) for formats in `format_ids_pending`
+- **Upload missing creatives**: Use [`sync_creatives`](/docs/creative/task-reference/sync_creatives) for library-backed sellers, or `packages[].creatives` on [`update_media_buy`](/docs/media-buy/task-reference/update_media_buy) for inline-only sellers
 - **Investigate zero delivery**: Check `delivery_status: "not_delivering"` and `start_time` to confirm the flight is active, then use [`update_media_buy`](/docs/media-buy/task-reference/update_media_buy) to adjust pricing or targeting
 - **Detailed reporting**: Use [`get_media_buy_delivery`](/docs/media-buy/task-reference/get_media_buy_delivery) for date-range reporting and daily breakdowns
 - **Optimize campaigns**: Use [`provide_performance_feedback`](/docs/media-buy/task-reference/provide_performance_feedback) to share results with the seller

--- a/docs/media-buy/task-reference/get_products.mdx
+++ b/docs/media-buy/task-reference/get_products.mdx
@@ -1612,7 +1612,7 @@ After discovering products:
 1. **Review Options**: Compare products, pricing, and targeting capabilities
 2. **Create Media Buy**: Use [`create_media_buy`](/docs/media-buy/task-reference/create_media_buy) to execute campaign
 3. **Prepare Creatives**: Use [`list_creative_formats`](/docs/creative/task-reference/list_creative_formats) to see format requirements
-4. **Upload Assets**: Use [`sync_creatives`](/docs/creative/task-reference/sync_creatives) to provide creative assets
+4. **Supply Assets**: Use [`sync_creatives`](/docs/creative/task-reference/sync_creatives) for library-backed sellers, or inline `packages[].creatives` for inline-only sellers
 
 ## Learn More
 

--- a/docs/media-buy/task-reference/index.mdx
+++ b/docs/media-buy/task-reference/index.mdx
@@ -83,6 +83,7 @@ Handle creative assets throughout their lifecycle.
 
 - **[`sync_creatives`](/docs/creative/task-reference/sync_creatives)** - Upload assets to an agent-hosted creative library
 - **[`list_creatives`](/docs/creative/task-reference/list_creatives)** - Search and manage your creative library (creative protocol)
+- **Inline `packages[].creatives`** - Attach or replace package-scoped creative bodies when the seller advertises `inline_creative_management` without a creative library
 
 ### Performance & Optimization
 Monitor and optimize campaign performance.
@@ -150,7 +151,7 @@ Long-running tasks provide:
 3. **Refine Products**: Re-call [`get_products`](/docs/media-buy/task-reference/get_products) with `buying_mode: "refine"` to iterate on budgets, pricing, and targeting
 4. **Understand Formats**: Check [`list_creative_formats`](/docs/creative/task-reference/list_creative_formats) for requirements
 5. **Sync Catalogs**: Use [`sync_catalogs`](/docs/media-buy/task-reference/sync_catalogs) to push product feeds to the account
-6. **Upload Creatives**: Use [`sync_creatives`](/docs/creative/task-reference/sync_creatives) for asset management
+6. **Supply Creatives**: Use [`sync_creatives`](/docs/creative/task-reference/sync_creatives) for library-backed sellers, or inline `packages[].creatives` for inline-only sellers
 7. **Create Campaign**: Use [`create_media_buy`](/docs/media-buy/task-reference/create_media_buy) with selected products
 8. **Check Operational State**: Use [`get_media_buys`](/docs/media-buy/task-reference/get_media_buys) for status, approvals, and missing formats
 9. **Monitor Performance**: Track reporting metrics with [`get_media_buy_delivery`](/docs/media-buy/task-reference/get_media_buy_delivery)

--- a/docs/media-buy/task-reference/update_media_buy.mdx
+++ b/docs/media-buy/task-reference/update_media_buy.mdx
@@ -245,8 +245,8 @@ Configure automated delivery reporting for this media buy:
 | `keyword_targets_remove` | KeywordTarget[] | Keyword targets to remove by (keyword, match_type) identity. |
 | `negative_keywords_add` | NegativeKeyword[] | Negative keywords to append to this package. On create, these are set as `negative_keywords` inside `targeting_overlay`. |
 | `negative_keywords_remove` | NegativeKeyword[] | Negative keywords to remove from this package. |
-| `creative_assignments` | CreativeAssignment[] | Replace assigned creatives with optional weights and placement targeting |
-| `creatives` | CreativeAsset[] | Upload and assign new creatives inline (must not exist in library) |
+| `creative_assignments` | CreativeAssignment[] | Replace assigned library creatives with optional weights and placement targeting |
+| `creatives` | CreativeAsset[] | Replace assigned inline creative bodies for this package. Requires `media_buy.features.inline_creative_management: true`; when the seller also advertises `creative.has_creative_library: true`, new `creative_id` values must not already exist in the library. |
 
 `package_id` is required to identify the package to update.
 
@@ -738,7 +738,7 @@ Common errors and resolutions:
 | `NOT_CANCELLABLE` | Media buy or package cannot be canceled | Check seller's cancellation policy or contact seller |
 | `CREATIVE_REJECTED` | Creative failed content policy review | Revise the creative per the seller's advertising policies |
 | `CREATIVE_DEADLINE_EXCEEDED` | Creative change submitted past the package's `creative_deadline` | Check package `creative_deadline` before submitting creative changes |
-| `CREATIVE_ID_EXISTS` | Creative ID already exists in library | Use a different `creative_id`, assign existing creatives via `creative_assignments`, or update via `sync_creatives` |
+| `CREATIVE_ID_EXISTS` | Creative ID already exists in the seller's creative namespace | For library-backed sellers, assign existing creatives via `creative_assignments` or update via `sync_creatives`; for inline-only sellers, use a different package-scoped `creative_id` |
 | `BUDGET_EXCEEDED` | Operation would exceed allocated budget | Reduce the amount or increase media buy total budget |
 | `CONFLICT` | Revision mismatch — another update was applied since you last read | Re-read via `get_media_buys` and retry with current `revision` |
 | `REQUOTE_REQUIRED` | Requested change (budget, dates, volume, targeting, or signal targeting price) falls outside the envelope the original quote was priced against | Adjust the update to fit the current quote, rediscover products/terms, add packages when `add_packages` is available, or create a separate media buy. 3.1 does not define an amendment-quote artifact for `update_media_buy`. Seller's `error.details.envelope_field` names which fields breached. |
@@ -898,7 +898,7 @@ Check `affected_packages` in response to confirm changes were applied correctly.
 - Pending states (`working`, `submitted`) are normal, not errors
 - Orchestrators MUST handle pending states as part of normal workflow
 - `implementation_date` indicates when changes take effect (null if pending approval)
-- **Inline creatives**: The `creatives` array creates NEW creatives only. To update existing creatives, use [`sync_creatives`](/docs/creative/task-reference/sync_creatives). To assign existing library creatives, use `creative_assignments` in the Package Update object.
+- **Inline creatives**: The `creatives` array replaces the package's inline creative bodies. If the seller advertises `creative.has_creative_library: true`, use [`sync_creatives`](/docs/creative/task-reference/sync_creatives) to update existing library creatives and `creative_assignments` to assign existing library creatives. If the seller advertises `inline_creative_management: true` without a creative library, use `packages[].creatives` here for inline creative add, replace, and removal workflows.
 
 <Note>
 **Campaign Governance — Modification Phase**
@@ -913,7 +913,7 @@ See the [seller integration guide](/docs/building/implementation/seller-integrat
 After updating a media buy:
 
 1. **Verify Changes**: Use [`get_media_buy_delivery`](/docs/media-buy/task-reference/get_media_buy_delivery) to confirm updates
-2. **Upload New Creatives**: Use [`sync_creatives`](/docs/creative/task-reference/sync_creatives) if creative assignments changed
+2. **Supply New Creatives**: Use [`sync_creatives`](/docs/creative/task-reference/sync_creatives) for library-backed sellers, or `packages[].creatives` in this task for inline-only sellers
 3. **Monitor Performance**: Track impact of changes on campaign metrics
 4. **Optimize Further**: Use [`provide_performance_feedback`](/docs/media-buy/task-reference/provide_performance_feedback) for ongoing optimization
 

--- a/docs/protocol/get_adcp_capabilities.mdx
+++ b/docs/protocol/get_adcp_capabilities.mdx
@@ -214,7 +214,7 @@ Optional media-buy features. **If declared true, seller MUST honor requests usin
 
 | Feature | Description |
 |---------|-------------|
-| `inline_creative_management` | Accepts creatives inline in `create_media_buy` requests |
+| `inline_creative_management` | Accepts creatives inline in `create_media_buy` and `update_media_buy` package payloads |
 | `property_list_filtering` | Honors `property_list` parameter in `get_products` |
 | `catalog_management` | Supports `sync_catalogs` for catalog feed management |
 

--- a/server/src/training-agent/product-factory.ts
+++ b/server/src/training-agent/product-factory.ts
@@ -24,6 +24,7 @@ type DeliveryType = Product['delivery_type'];
 type PublisherPropertySelector = Product['publisher_properties'][number];
 type FlatRatePricingOption = Extract<PricingOption, { pricing_model: 'flat_rate' }>;
 type TimeBasedPricingOption = Extract<PricingOption, { pricing_model: 'time' }>;
+type ProductFormatDeclaration = NonNullable<Product['format_options']>[number];
 type ProductCardImage = NonNullable<NonNullable<Product['product_card']>['image']>;
 type CollectionSelector = {
   publisher_domain: string;
@@ -36,6 +37,7 @@ type ProductCardManifest = {
     assets: Record<string, unknown>;
   };
 };
+type CanonicalFormatKind = ProductFormatDeclaration['format_kind'];
 type TrainingProduct = Omit<Product, 'product_card' | 'product_card_detailed'> & {
   product_card?: Product['product_card'] | ProductCardManifest;
   product_card_detailed?: Product['product_card_detailed'] | ProductCardManifest;
@@ -243,6 +245,56 @@ function formatIdsForChannels(channels: string[], agentUrl: string): FormatID[] 
     }
   }
   return ids;
+}
+
+const CANONICAL_FORMAT_KIND_BY_LEGACY_ID: Partial<Record<string, CanonicalFormatKind>> = {
+  display_static: 'image',
+  display_300x250: 'image',
+  display_728x90: 'image',
+  display_320x50: 'image',
+  video_preroll: 'video_vast',
+  video_outstream: 'video_vast',
+  ctv_fullscreen: 'video_vast',
+  audio_spot: 'audio_daast',
+  dooh_landscape: 'image',
+  dooh_portrait: 'image',
+  social_feed_card: 'image',
+  social_story: 'image',
+  social_video_reel: 'video_hosted',
+  native_content_card: 'native_in_feed',
+  carousel_card: 'image_carousel',
+  email_sponsored: 'image',
+  sponsored_product: 'sponsored_placement',
+  gaming_interstitial: 'image',
+  gaming_rewarded_video: 'video_vast',
+  search_text_ad: 'responsive_creative',
+  search_shopping: 'sponsored_placement',
+  radio_spot: 'audio_hosted',
+  broadcast_30s: 'video_hosted',
+  broadcast_15s: 'video_hosted',
+  ssai_30s: 'video_hosted',
+  preroll_15s: 'video_hosted',
+  native_feed: 'native_in_feed',
+  display_300x250_generative: 'image',
+  video_30s_generative: 'video_hosted',
+  video_30s: 'video_hosted',
+  native_post: 'native_in_feed',
+  native_content: 'native_in_feed',
+  product_carousel_3_to_10: 'image_carousel',
+};
+
+function formatOptionsForFormatIds(formatIds: FormatID[]): ProductFormatDeclaration[] {
+  return formatIds.flatMap(formatId => {
+    // Omitted ids stay legacy-only until they have a clean canonical projection.
+    const formatKind = CANONICAL_FORMAT_KIND_BY_LEGACY_ID[formatId.id];
+    if (!formatKind) return [];
+    return {
+      format_kind: formatKind,
+      format_option_id: `${formatId.id}_${formatKind}`,
+      params: {},
+      v1_format_ref: [formatId],
+    } as ProductFormatDeclaration;
+  });
 }
 
 function publisherPropertySelectors(pub: PublisherProfile, channels?: string[]): PublisherPropertySelector[] {
@@ -565,13 +617,16 @@ function buildProduct(
     }
   }
 
+  const formatIds = formatIdsForChannels(template.channels, agentUrl);
+  const formatOptions = formatOptionsForFormatIds(formatIds);
   const product: TrainingProduct = {
     product_id: productId,
     name: template.name,
     description: template.description,
     publisher_properties: publisherPropertySelectors(pub, template.channels),
     channels: template.channels as MediaChannel[],
-    format_ids: formatIdsForChannels(template.channels, agentUrl),
+    format_ids: formatIds,
+    ...(formatOptions.length > 0 ? { format_options: formatOptions } : {}),
     delivery_type: template.deliveryType as DeliveryType,
     delivery_measurement: {
       provider: pub.measurementProvider,

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -69,8 +69,15 @@ export function adcpError(code: string, opts: { message: string; details?: unkno
 }
 
 // Derive types from SDK request types that aren't re-exported from main entry
+type InlineCreativeInput = { creative_id?: string };
 type PackageUpdate = NonNullable<UpdateMediaBuyRequest['packages']>[number];
-type PackageUpdateExt = PackageUpdate & { canceled?: boolean; cancellation_reason?: string; targeting?: PackageTargeting; targeting_overlay?: PackageTargeting };
+type PackageUpdateExt = PackageUpdate & {
+  canceled?: boolean;
+  cancellation_reason?: string;
+  targeting?: PackageTargeting;
+  targeting_overlay?: PackageTargeting;
+  creatives?: InlineCreativeInput[];
+};
 type Destination = NonNullable<ActivateSignalRequest['destinations']>[number];
 type SignalFilters = NonNullable<GetSignalsRequest['filters']>;
 type PricingOption = Product['pricing_options'][number];
@@ -268,6 +275,7 @@ interface PackageInput {
   targeting?: PackageTargeting;
   targeting_overlay?: PackageTargeting;
   creative_assignments?: Array<{ creative_id?: string }>;
+  creatives?: InlineCreativeInput[];
   context?: Record<string, unknown>;
 }
 
@@ -275,6 +283,29 @@ interface CreativeAssignmentInput {
   creative_id: string;
   package_id: string;
   media_buy_id: string;
+}
+
+function collectInlineCreativeIds(
+  rawCreatives: InlineCreativeInput[] | undefined,
+  fieldPrefix: string,
+): { creativeIds: string[]; errors: TaskError[] } {
+  const creativeIds: string[] = [];
+  const errors: TaskError[] = [];
+  if (!Array.isArray(rawCreatives)) return { creativeIds, errors };
+
+  for (let i = 0; i < rawCreatives.length; i++) {
+    const creativeId = rawCreatives[i]?.creative_id;
+    if (!creativeId) {
+      errors.push({
+        code: 'VALIDATION_ERROR',
+        message: `${fieldPrefix}[${i}].creative_id is required`,
+        field: `${fieldPrefix}[${i}].creative_id`,
+      });
+      continue;
+    }
+    creativeIds.push(creativeId);
+  }
+  return { creativeIds, errors };
 }
 
 function validateDirectCanonicalPackageSelector(pkg: PackageInput, product: Product, index: number): TaskError | undefined {
@@ -4598,6 +4629,9 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
       }
       creativeAssignments.push(creativeId);
     }
+    const inlineCreatives = collectInlineCreativeIds(pkg.creatives, `packages[${i}].creatives`);
+    errors.push(...inlineCreatives.errors);
+    creativeAssignments.push(...inlineCreatives.creativeIds);
     if (errors.length > 0) continue;
 
     createdPackages.push({
@@ -5594,6 +5628,10 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
     // pkg[0..N-1] with partially-applied assignments.
     for (const update of req.packages as PackageUpdateExt[]) {
       const assignments = (update as PackageUpdate & { creative_assignments?: Array<{ creative_id: string }> }).creative_assignments;
+      const inlineCreatives = collectInlineCreativeIds(update.creatives, `packages[${update.package_id || '?'}].creatives`);
+      if (inlineCreatives.errors.length) {
+        return { errors: inlineCreatives.errors };
+      }
       if (assignments === undefined) continue;
       const pkgId = update.package_id || '';
       if (assignments.length === 0) {
@@ -5681,6 +5719,11 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
         pkg.creativeAssignments = creativeIds;
         mb.history.push({ revision: mb.revision, timestamp: now, actor: 'buyer', action: 'creative_assignments_updated', summary: `Package ${pkgId} creative assignments replaced (${creativeIds.length} creatives)`, packageId: pkgId });
       }
+      if (update.creatives !== undefined) {
+        const creativeIds = collectInlineCreativeIds(update.creatives, `packages[${pkgId}].creatives`).creativeIds;
+        pkg.creativeAssignments = creativeIds;
+        mb.history.push({ revision: mb.revision, timestamp: now, actor: 'buyer', action: 'inline_creatives_updated', summary: `Package ${pkgId} inline creatives replaced (${creativeIds.length} creatives)`, packageId: pkgId });
+      }
     }
 
     // Recompute open impairments: a creative-impairment is cleared when no
@@ -5753,6 +5796,21 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
   mb.updatedAt = now;
 
   const status = deriveStatus(mb);
+  const updatedPackages = mb.packages.map(pkg => ({
+    package_id: pkg.packageId,
+    product_id: pkg.productId,
+    budget: pkg.budget,
+    pricing_option_id: pkg.pricingOptionId,
+    paused: pkg.paused,
+    start_time: pkg.startTime,
+    end_time: pkg.endTime,
+    ...(pkg.targeting && { targeting_overlay: pkg.targeting }),
+    ...(pkg.context && { context: pkg.context }),
+    creative_assignments: pkg.creativeAssignments.map(creativeId => ({ creative_id: creativeId })),
+    ...(pkg.canceledAt && {
+      cancellation: { canceled_at: pkg.canceledAt, canceled_by: pkg.canceledBy, reason: pkg.cancellationReason },
+    }),
+  }));
   // `media_buy_status` is the canonical 3.1 body field (#4895); legacy
   // body `status: MediaBuyStatus` removed in 3.2 (#4906).
   const result = {
@@ -5766,19 +5824,8 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
     ...(mb.canceledAt && {
       cancellation: { canceled_at: mb.canceledAt, canceled_by: mb.canceledBy, reason: mb.cancellationReason },
     }),
-    packages: mb.packages.map(pkg => ({
-      package_id: pkg.packageId,
-      product_id: pkg.productId,
-      budget: pkg.budget,
-      pricing_option_id: pkg.pricingOptionId,
-      paused: pkg.paused,
-      start_time: pkg.startTime,
-      end_time: pkg.endTime,
-      ...(pkg.targeting && { targeting_overlay: pkg.targeting }),
-      ...(pkg.canceledAt && {
-        cancellation: { canceled_at: pkg.canceledAt, canceled_by: pkg.canceledBy, reason: pkg.cancellationReason },
-      }),
-    })),
+    affected_packages: updatedPackages,
+    packages: updatedPackages,
     ...(warnings.length > 0 && { warnings }),
     ...(req.context !== undefined && { context: req.context }),
   };

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -581,9 +581,18 @@ function projectSalesCapabilities(
       const mediaBuy = structured.media_buy && typeof structured.media_buy === 'object'
         ? structured.media_buy
         : {};
+      const salesProjection = salesCapabilityProjection();
       structured.media_buy = {
         ...mediaBuy,
-        ...salesCapabilityProjection(),
+        ...salesProjection,
+        features: {
+          ...(
+            mediaBuy.features && typeof mediaBuy.features === 'object'
+              ? mediaBuy.features as Record<string, unknown>
+              : {}
+          ),
+          ...salesProjection.features,
+        },
       };
       const creative = structured.creative && typeof structured.creative === 'object'
         ? structured.creative

--- a/server/src/training-agent/tenants/tenant-smoke.test.ts
+++ b/server/src/training-agent/tenants/tenant-smoke.test.ts
@@ -236,6 +236,7 @@ describe('tenant routing smoke', () => {
             adcp_version?: string;
             adcp?: { major_versions?: number[]; supported_versions?: string[] };
             media_buy?: {
+              features?: { inline_creative_management?: boolean };
               supported_optimization_metrics?: string[];
               vendor_metric_optimization?: { supported_targets?: string[] };
             };
@@ -247,6 +248,7 @@ describe('tenant routing smoke', () => {
       expect(body.result?.structuredContent?.adcp_version).toBe('3.0');
       expect(body.result?.structuredContent?.adcp?.major_versions).toContain(3);
       expect(body.result?.structuredContent?.adcp?.supported_versions).toEqual(['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7']);
+      expect(mediaBuy?.features?.inline_creative_management).toBe(true);
       expect(mediaBuy?.supported_optimization_metrics).toContain('clicks');
       expect(mediaBuy?.vendor_metric_optimization?.supported_targets).toContain('threshold_rate');
       expect(body.result?.structuredContent?.compliance_testing?.scenarios).toEqual(

--- a/server/src/training-agent/v6-sales-platform.ts
+++ b/server/src/training-agent/v6-sales-platform.ts
@@ -94,6 +94,9 @@ export const TRAINING_SALES_CAPABILITIES = {
 
 export function salesCapabilityProjection() {
   return {
+    features: {
+      inline_creative_management: true,
+    },
     supported_optimization_metrics: [...TRAINING_SALES_CAPABILITIES.supported_optimization_metrics],
     vendor_metric_optimization: {
       supported_targets: [...TRAINING_SALES_CAPABILITIES.vendor_metric_optimization.supported_targets],

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -5113,6 +5113,49 @@ describe('update_media_buy handler', () => {
     expect(updateResult.media_buy_status).toBe('pending_creatives');
   });
 
+  it('accepts inline package creatives on create and update without sync_creatives', async () => {
+    const catalog = buildCatalog();
+    const product = catalog[0].product;
+    const pricingOptions = product.pricing_options as Array<Record<string, unknown>>;
+    const account = { brand: { domain: 'inline-create-update.example' }, operator: 'inline-create-update.example' };
+
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: createResult } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'inline-create-update.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: product.product_id,
+        pricing_option_id: pricingOptions[0].pricing_option_id,
+        budget: 10000,
+        creatives: [{ creative_id: 'inline_cr_v1', name: 'Inline v1' }],
+      }],
+    });
+    expect(createResult.code).toBeUndefined();
+    const mediaBuyId = createResult.media_buy_id as string;
+    const pkgId = ((createResult.packages as Array<Record<string, unknown>>)[0]).package_id as string;
+
+    const { result: updateResult } = await simulateCallTool(createTrainingAgentServer(DEFAULT_CTX), 'update_media_buy', {
+      account,
+      media_buy_id: mediaBuyId,
+      packages: [{ package_id: pkgId, creatives: [{ creative_id: 'inline_cr_v2', name: 'Inline v2' }] }],
+    });
+    expect(updateResult.code).toBeUndefined();
+    expect(updateResult.media_buy_id).toBe(mediaBuyId);
+    expect(((updateResult.affected_packages as Array<Record<string, unknown>>)[0]).package_id).toBe(pkgId);
+
+    const { result: buyResult } = await simulateCallTool(createTrainingAgentServer(DEFAULT_CTX), 'get_media_buys', {
+      account,
+      media_buy_ids: [mediaBuyId],
+    });
+    const buy = (buyResult.media_buys as Array<Record<string, unknown>>)[0];
+    const pkg = (buy.packages as Array<Record<string, unknown>>)[0];
+    const approvals = pkg.creative_approvals as Array<Record<string, unknown>>;
+    expect(approvals[0].creative_id).toBe('inline_cr_v2');
+    expect(approvals[0].approval_status).toBe('approved');
+  });
+
   it('rejects all creative_assignments atomically when any creative_id is missing', async () => {
     const catalog = buildCatalog();
     const product = catalog[0].product;

--- a/static/compliance/source/protocols/media-buy/index.yaml
+++ b/static/compliance/source/protocols/media-buy/index.yaml
@@ -18,6 +18,7 @@ requires_scenarios:
   - media_buy_seller/available_actions
   - media_buy_seller/invalid_transitions
   - media_buy_seller/creative_fate_after_cancellation
+  - media_buy_seller/inline_creatives_without_sync
   - media_buy_seller/create_media_buy_async
   - media_buy_seller/dependency_impairment
   - media_buy_seller/dependency_impairment_cardinality

--- a/static/compliance/source/protocols/media-buy/scenarios/inline_creatives_without_sync.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/inline_creatives_without_sync.yaml
@@ -1,0 +1,508 @@
+id: media_buy_seller/inline_creatives_without_sync
+version: "1.0.0"
+title: "Inline media-buy creatives without sync_creatives"
+category: media_buy_seller
+summary: "Verifies that a seller advertising inline_creative_management accepts package creatives on create_media_buy and update_media_buy without requiring the Creative Protocol or sync_creatives."
+track: media_buy
+
+# Gate: scenario runs only when the seller declares inline creative handling on
+# the media-buy feature surface. Sellers that do not advertise the flag grade
+# not_applicable. The scenario intentionally does not call sync_creatives; that
+# keeps inline-only media-buy sellers from being forced into the creative
+# library surface.
+requires_capability:
+  path: media_buy.features.inline_creative_management
+  equals: true
+
+required_tools:
+  - get_products
+  - create_media_buy
+  - update_media_buy
+  - get_media_buys
+
+narrative: |
+  Some sales agents do not expose the Creative Protocol or a reusable creative
+  library. They still accept creative bodies inline on media-buy operations. For
+  those sellers, the buyer should not call sync_creatives; it should put
+  CreativeAsset objects in packages[].creatives on create_media_buy and
+  update_media_buy.
+
+  This scenario walks that path end-to-end:
+
+  1. Discover that inline_creative_management is true.
+  2. Create a media buy with packages[].creatives populated.
+  3. Replace the package's inline creative through update_media_buy.
+  4. Read the media buy back and confirm the replacement approval state is visible.
+
+  The scenario accepts either product format representation. One branch uses the
+  3.1+ format_options[] path with a canonical format_kind; the other uses the
+  legacy format_ids[] path. Sellers need to pass one branch, not both.
+
+agent:
+  interaction_model: media_buy_seller
+  capabilities:
+    - sells_media
+    - accepts_inline_creatives
+  examples:
+    - "Media-buy sellers that attach creatives directly to buys"
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: |
+    Seller advertises media_buy.features.inline_creative_management: true and
+    accepts package-scoped CreativeAsset objects on create_media_buy and
+    update_media_buy. The seller does not need to implement sync_creatives.
+  test_kit: "test-kits/acme-outdoor.yaml"
+
+phases:
+  - id: capability_discovery
+    title: "Discover inline creative support"
+    narrative: |
+      The buyer confirms the seller accepts inline package creatives before
+      exercising either accepted product-format path.
+
+    steps:
+      - id: get_capabilities
+        title: "Check inline creative feature"
+        task: get_adcp_capabilities
+        schema_ref: "protocol/get-adcp-capabilities-request.json"
+        response_schema_ref: "protocol/get-adcp-capabilities-response.json"
+        doc_ref: "/protocol/get_adcp_capabilities"
+        comply_scenario: capability_discovery
+        stateful: false
+        expected: |
+          Return capabilities declaring media_buy support and
+          media_buy.features.inline_creative_management: true.
+        sample_request:
+          context:
+            correlation_id: "inline_creatives_without_sync--get_capabilities"
+        validations:
+          - check: response_schema
+            description: "Response matches get-adcp-capabilities-response.json schema"
+          - check: field_present
+            path: "supported_protocols"
+            description: "Agent declares supported protocols"
+          - check: field_value
+            path: "media_buy.features.inline_creative_management"
+            value: true
+            description: "Seller advertises inline creative handling on media-buy operations"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "inline_creatives_without_sync--get_capabilities"
+            description: "Context correlation_id returned unchanged"
+
+  - id: canonical_format_inline_path
+    title: "Inline creative path using format_options"
+    optional: true
+    branch_set:
+      id: inline_creative_format_path
+      semantics: any_of
+    narrative: |
+      A 3.1+ seller may publish products through format_options[] without any
+      legacy format_ids[]. This branch submits the inline creative with the
+      product's canonical format_kind and verifies create/update acceptance.
+
+    steps:
+      - id: get_products_canonical_format
+        title: "Discover a product with format_options"
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        comply_scenario: full_sales_flow
+        stateful: false
+        expected: |
+          Return at least one fixed-price product with a pricing option and a
+          format_options[] declaration that can be used by the inline CreativeAsset.
+        sample_request:
+          buying_mode: "brief"
+          brief: "Display inventory on outdoor lifestyle content. Q3 flight with buyer-supplied inline creative."
+          filters:
+            is_fixed_price: true
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          context:
+            correlation_id: "inline_creatives_without_sync--get_products_canonical"
+        context_outputs:
+          - path: "products[0].product_id"
+            key: "product_id"
+          - path: "products[0].pricing_options[0].pricing_option_id"
+            key: "pricing_option_id"
+          - path: "products[0].format_options[0].format_kind"
+            key: "format_kind"
+        validations:
+          - check: response_schema
+            description: "Response matches get-products-response.json schema"
+          - check: field_present
+            path: "products[0].format_options[0].format_kind"
+            description: "Product declares a canonical format option for inline creative validation"
+          - check: field_present
+            path: "products[0].pricing_options[0].fixed_price"
+            description: "The captured pricing option is fixed-price; fixed-price storyboards do not send bid_price"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "inline_creatives_without_sync--get_products_canonical"
+            description: "Context correlation_id returned unchanged"
+
+      - id: create_buy_with_canonical_inline_creative
+        title: "Create media buy with canonical inline creative"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        comply_scenario: create_media_buy
+        stateful: true
+        expected: |
+          Accept the media buy and attach the inline creative to the package.
+          The response should include the package and preserve package context.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          idempotency_key: "$generate:uuid_v4#inline_creatives_without_sync_create_canonical"
+          start_time: "2026-09-01T00:00:00Z"
+          end_time: "2026-09-30T23:59:59Z"
+          packages:
+            - product_id: "$context.product_id"
+              budget: 7500
+              pricing_option_id: "$context.pricing_option_id"
+              context:
+                buyer_ref: "inline-creative-line-001"
+              creatives:
+                - creative_id: "acme-inline-display-v1"
+                  name: "Acme Outdoor inline display v1"
+                  format_kind: "$context.format_kind"
+                  assets:
+                    image:
+                      asset_type: "image"
+                      url: "https://test-assets.adcontextprotocol.org/acme-outdoor/hero-master.jpg"
+                      width: 300
+                      height: 250
+                      mime_type: "image/jpeg"
+                    click_url:
+                      asset_type: "url"
+                      url: "https://acmeoutdoor.example/q3"
+          context:
+            correlation_id: "inline_creatives_without_sync--create_canonical"
+        context_outputs:
+          - path: "media_buy_id"
+            key: "media_buy_id"
+          - path: "packages[0].package_id"
+            key: "package_id"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Seller assigns a media_buy_id"
+          - check: field_present
+            path: "packages[0].package_id"
+            description: "Seller assigns a package_id"
+          - check: field_value
+            path: "packages[0].context.buyer_ref"
+            value: "inline-creative-line-001"
+            description: "Created package echoes package-level context for correlation"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "inline_creatives_without_sync--create_canonical"
+            description: "Context correlation_id returned unchanged"
+
+      - id: update_buy_with_replacement_canonical_inline_creative
+        title: "Replace canonical inline creative"
+        task: update_media_buy
+        schema_ref: "media-buy/update-media-buy-request.json"
+        response_schema_ref: "media-buy/update-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/update_media_buy"
+        comply_scenario: media_buy_lifecycle
+        stateful: true
+        contributes: true
+        expected: |
+          Replace the package's inline creative body with the new creative_id and
+          return the affected package.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_id: "$context.media_buy_id"
+          packages:
+            - package_id: "$context.package_id"
+              creatives:
+                - creative_id: "acme-inline-display-v2"
+                  name: "Acme Outdoor inline display v2"
+                  format_kind: "$context.format_kind"
+                  assets:
+                    image:
+                      asset_type: "image"
+                      url: "https://test-assets.adcontextprotocol.org/acme-outdoor/hero-alt.jpg"
+                      width: 300
+                      height: 250
+                      mime_type: "image/jpeg"
+                    click_url:
+                      asset_type: "url"
+                      url: "https://acmeoutdoor.example/q3-refresh"
+          idempotency_key: "$generate:uuid_v4#inline_creatives_without_sync_update_canonical"
+          context:
+            correlation_id: "inline_creatives_without_sync--update_canonical"
+        validations:
+          - check: response_schema
+            description: "Response matches update-media-buy-response.json schema"
+          - check: field_equals_context
+            path: "media_buy_id"
+            context_key: "media_buy_id"
+            description: "Update response references the same media buy"
+          - check: field_equals_context
+            path: "affected_packages[0].package_id"
+            context_key: "package_id"
+            description: "Update response includes the affected package"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "inline_creatives_without_sync--update_canonical"
+            description: "Context correlation_id returned unchanged"
+
+  - id: legacy_format_inline_path
+    title: "Inline creative path using format_ids"
+    optional: true
+    branch_set:
+      id: inline_creative_format_path
+      semantics: any_of
+    skip_if: "context.media_buy_id"
+    narrative: |
+      A seller may still publish products through legacy format_ids[]. This
+      branch runs only when the canonical branch did not already complete.
+
+    steps:
+      - id: get_products_legacy_format
+        title: "Discover a product with format_ids"
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        comply_scenario: full_sales_flow
+        stateful: false
+        expected: |
+          Return at least one fixed-price product with a pricing option and a
+          concrete format_id that can be used by the inline CreativeAsset.
+        sample_request:
+          buying_mode: "brief"
+          brief: "Display inventory on outdoor lifestyle content. Q3 flight with buyer-supplied inline creative."
+          filters:
+            is_fixed_price: true
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          context:
+            correlation_id: "inline_creatives_without_sync--get_products_legacy"
+        context_outputs:
+          - path: "products[0].product_id"
+            key: "product_id"
+          - path: "products[0].pricing_options[0].pricing_option_id"
+            key: "pricing_option_id"
+          - path: "products[0].format_ids[0]"
+            key: "format_id"
+        validations:
+          - check: response_schema
+            description: "Response matches get-products-response.json schema"
+          - check: field_present
+            path: "products[0].format_ids[0].id"
+            description: "Product declares a format_id for inline creative validation"
+          - check: field_present
+            path: "products[0].pricing_options[0].fixed_price"
+            description: "The captured pricing option is fixed-price; fixed-price storyboards do not send bid_price"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "inline_creatives_without_sync--get_products_legacy"
+            description: "Context correlation_id returned unchanged"
+
+      - id: create_buy_with_legacy_inline_creative
+        title: "Create media buy with legacy inline creative"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        comply_scenario: create_media_buy
+        stateful: true
+        expected: |
+          Accept the media buy and attach the inline creative to the package.
+          The response should include the package and preserve package context.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          idempotency_key: "$generate:uuid_v4#inline_creatives_without_sync_create_legacy"
+          start_time: "2026-09-01T00:00:00Z"
+          end_time: "2026-09-30T23:59:59Z"
+          packages:
+            - product_id: "$context.product_id"
+              budget: 7500
+              pricing_option_id: "$context.pricing_option_id"
+              context:
+                buyer_ref: "inline-creative-line-001"
+              creatives:
+                - creative_id: "acme-inline-display-v1"
+                  name: "Acme Outdoor inline display v1"
+                  format_id: "$context.format_id"
+                  assets:
+                    image:
+                      asset_type: "image"
+                      url: "https://test-assets.adcontextprotocol.org/acme-outdoor/hero-master.jpg"
+                      width: 300
+                      height: 250
+                      mime_type: "image/jpeg"
+                    click_url:
+                      asset_type: "url"
+                      url: "https://acmeoutdoor.example/q3"
+          context:
+            correlation_id: "inline_creatives_without_sync--create_legacy"
+        context_outputs:
+          - path: "media_buy_id"
+            key: "media_buy_id"
+          - path: "packages[0].package_id"
+            key: "package_id"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Seller assigns a media_buy_id"
+          - check: field_present
+            path: "packages[0].package_id"
+            description: "Seller assigns a package_id"
+          - check: field_value
+            path: "packages[0].context.buyer_ref"
+            value: "inline-creative-line-001"
+            description: "Created package echoes package-level context for correlation"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "inline_creatives_without_sync--create_legacy"
+            description: "Context correlation_id returned unchanged"
+
+      - id: update_buy_with_replacement_legacy_inline_creative
+        title: "Replace legacy inline creative"
+        task: update_media_buy
+        schema_ref: "media-buy/update-media-buy-request.json"
+        response_schema_ref: "media-buy/update-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/update_media_buy"
+        comply_scenario: media_buy_lifecycle
+        stateful: true
+        contributes: true
+        expected: |
+          Replace the package's inline creative body with the new creative_id and
+          return the affected package.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_id: "$context.media_buy_id"
+          packages:
+            - package_id: "$context.package_id"
+              creatives:
+                - creative_id: "acme-inline-display-v2"
+                  name: "Acme Outdoor inline display v2"
+                  format_id: "$context.format_id"
+                  assets:
+                    image:
+                      asset_type: "image"
+                      url: "https://test-assets.adcontextprotocol.org/acme-outdoor/hero-alt.jpg"
+                      width: 300
+                      height: 250
+                      mime_type: "image/jpeg"
+                    click_url:
+                      asset_type: "url"
+                      url: "https://acmeoutdoor.example/q3-refresh"
+          idempotency_key: "$generate:uuid_v4#inline_creatives_without_sync_update_legacy"
+          context:
+            correlation_id: "inline_creatives_without_sync--update_legacy"
+        validations:
+          - check: response_schema
+            description: "Response matches update-media-buy-response.json schema"
+          - check: field_equals_context
+            path: "media_buy_id"
+            context_key: "media_buy_id"
+            description: "Update response references the same media buy"
+          - check: field_equals_context
+            path: "affected_packages[0].package_id"
+            context_key: "package_id"
+            description: "Update response includes the affected package"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "inline_creatives_without_sync--update_legacy"
+            description: "Context correlation_id returned unchanged"
+
+  - id: inline_format_path_assertion
+    title: "Require one inline format path"
+    steps:
+      - id: assert_inline_creative_format_path
+        title: "Assert inline creative format path contributed"
+        task: assert_contribution
+        comply_scenario: media_buy_lifecycle
+        stateful: false
+        expected: |
+          At least one of the canonical format_options[] path or the legacy
+          format_ids[] path created and updated the buy with inline creatives.
+        validations:
+          - check: any_of
+            allowed_values: ["inline_creative_format_path"]
+            description: "Seller accepted inline creatives through either the format_options[] or format_ids[] path"
+
+  - id: verify_replacement
+    title: "Verify inline creative replacement persisted"
+    narrative: |
+      The buyer reads the media buy and confirms the current package approval
+      state reflects the replacement inline creative.
+
+    steps:
+      - id: get_media_buy_after_inline_replacement
+        title: "Read media buy after inline replacement"
+        task: get_media_buys
+        schema_ref: "media-buy/get-media-buys-request.json"
+        response_schema_ref: "media-buy/get-media-buys-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buys"
+        comply_scenario: media_buy_lifecycle
+        stateful: true
+        expected: |
+          Return the media buy with package approval state for the replacement
+          inline creative. The full CreativeAsset body is not required on this
+          read surface.
+
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "$context.media_buy_id"
+          context:
+            correlation_id: "inline_creatives_without_sync--get_media_buy"
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buys-response.json schema"
+          - check: field_equals_context
+            path: "media_buys[0].media_buy_id"
+            context_key: "media_buy_id"
+            description: "Read response returns the created media buy"
+          - check: field_equals_context
+            path: "media_buys[0].packages[0].package_id"
+            context_key: "package_id"
+            description: "Read response returns the created package"
+          - check: field_value
+            path: "media_buys[0].packages[0].creative_approvals[0].creative_id"
+            value: "acme-inline-display-v2"
+            description: "Read response reflects the replacement inline creative on the package approval-state surface"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "inline_creatives_without_sync--get_media_buy"
+            description: "Context correlation_id returned unchanged"

--- a/static/compliance/source/protocols/media-buy/scenarios/inline_creatives_without_sync.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/inline_creatives_without_sync.yaml
@@ -34,9 +34,11 @@ narrative: |
   3. Replace the package's inline creative through update_media_buy.
   4. Read the media buy back and confirm the replacement approval state is visible.
 
-  The scenario accepts either product format representation. One branch uses the
-  3.1+ format_options[] path with a canonical format_kind; the other uses the
-  legacy format_ids[] path. Sellers need to pass one branch, not both.
+  The scenario exercises both product format representations when the seller
+  dual-emits them. The first path uses the 3.1+ format_options[] path with a
+  canonical format_kind; the second uses the legacy format_ids[] path. Each
+  path creates its own media buy so the readback checks prove both replacements
+  persisted independently.
 
 agent:
   interaction_model: media_buy_seller
@@ -96,14 +98,10 @@ phases:
 
   - id: canonical_format_inline_path
     title: "Inline creative path using format_options"
-    optional: true
-    branch_set:
-      id: inline_creative_format_path
-      semantics: any_of
     narrative: |
-      A 3.1+ seller may publish products through format_options[] without any
-      legacy format_ids[]. This branch submits the inline creative with the
-      product's canonical format_kind and verifies create/update acceptance.
+      A 3.1+ seller may publish products through format_options[]. This path
+      submits the inline creative with the product's canonical format_kind and
+      verifies create/update acceptance.
 
     steps:
       - id: get_products_canonical_format
@@ -130,11 +128,11 @@ phases:
             correlation_id: "inline_creatives_without_sync--get_products_canonical"
         context_outputs:
           - path: "products[0].product_id"
-            key: "product_id"
+            key: "canonical_product_id"
           - path: "products[0].pricing_options[0].pricing_option_id"
-            key: "pricing_option_id"
+            key: "canonical_pricing_option_id"
           - path: "products[0].format_options[0].format_kind"
-            key: "format_kind"
+            key: "canonical_format_kind"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -171,15 +169,15 @@ phases:
           start_time: "2026-09-01T00:00:00Z"
           end_time: "2026-09-30T23:59:59Z"
           packages:
-            - product_id: "$context.product_id"
+            - product_id: "$context.canonical_product_id"
               budget: 7500
-              pricing_option_id: "$context.pricing_option_id"
+              pricing_option_id: "$context.canonical_pricing_option_id"
               context:
-                buyer_ref: "inline-creative-line-001"
+                buyer_ref: "inline-creative-canonical-line-001"
               creatives:
-                - creative_id: "acme-inline-display-v1"
-                  name: "Acme Outdoor inline display v1"
-                  format_kind: "$context.format_kind"
+                - creative_id: "acme-inline-canonical-display-v1"
+                  name: "Acme Outdoor inline canonical display v1"
+                  format_kind: "$context.canonical_format_kind"
                   assets:
                     image:
                       asset_type: "image"
@@ -194,9 +192,9 @@ phases:
             correlation_id: "inline_creatives_without_sync--create_canonical"
         context_outputs:
           - path: "media_buy_id"
-            key: "media_buy_id"
+            key: "canonical_media_buy_id"
           - path: "packages[0].package_id"
-            key: "package_id"
+            key: "canonical_package_id"
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"
@@ -208,7 +206,7 @@ phases:
             description: "Seller assigns a package_id"
           - check: field_value
             path: "packages[0].context.buyer_ref"
-            value: "inline-creative-line-001"
+            value: "inline-creative-canonical-line-001"
             description: "Created package echoes package-level context for correlation"
           - check: field_value
             path: "context.correlation_id"
@@ -223,7 +221,6 @@ phases:
         doc_ref: "/media-buy/task-reference/update_media_buy"
         comply_scenario: media_buy_lifecycle
         stateful: true
-        contributes: true
         expected: |
           Replace the package's inline creative body with the new creative_id and
           return the affected package.
@@ -232,13 +229,13 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          media_buy_id: "$context.media_buy_id"
+          media_buy_id: "$context.canonical_media_buy_id"
           packages:
-            - package_id: "$context.package_id"
+            - package_id: "$context.canonical_package_id"
               creatives:
-                - creative_id: "acme-inline-display-v2"
-                  name: "Acme Outdoor inline display v2"
-                  format_kind: "$context.format_kind"
+                - creative_id: "acme-inline-canonical-display-v2"
+                  name: "Acme Outdoor inline canonical display v2"
+                  format_kind: "$context.canonical_format_kind"
                   assets:
                     image:
                       asset_type: "image"
@@ -257,11 +254,11 @@ phases:
             description: "Response matches update-media-buy-response.json schema"
           - check: field_equals_context
             path: "media_buy_id"
-            context_key: "media_buy_id"
+            context_key: "canonical_media_buy_id"
             description: "Update response references the same media buy"
           - check: field_equals_context
             path: "affected_packages[0].package_id"
-            context_key: "package_id"
+            context_key: "canonical_package_id"
             description: "Update response includes the affected package"
           - check: field_value
             path: "context.correlation_id"
@@ -270,14 +267,10 @@ phases:
 
   - id: legacy_format_inline_path
     title: "Inline creative path using format_ids"
-    optional: true
-    branch_set:
-      id: inline_creative_format_path
-      semantics: any_of
-    skip_if: "context.media_buy_id"
     narrative: |
       A seller may still publish products through legacy format_ids[]. This
-      branch runs only when the canonical branch did not already complete.
+      path submits the inline creative with the product's legacy format_id and
+      verifies create/update acceptance separately from the canonical path.
 
     steps:
       - id: get_products_legacy_format
@@ -304,11 +297,11 @@ phases:
             correlation_id: "inline_creatives_without_sync--get_products_legacy"
         context_outputs:
           - path: "products[0].product_id"
-            key: "product_id"
+            key: "legacy_product_id"
           - path: "products[0].pricing_options[0].pricing_option_id"
-            key: "pricing_option_id"
+            key: "legacy_pricing_option_id"
           - path: "products[0].format_ids[0]"
-            key: "format_id"
+            key: "legacy_format_id"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -345,15 +338,15 @@ phases:
           start_time: "2026-09-01T00:00:00Z"
           end_time: "2026-09-30T23:59:59Z"
           packages:
-            - product_id: "$context.product_id"
+            - product_id: "$context.legacy_product_id"
               budget: 7500
-              pricing_option_id: "$context.pricing_option_id"
+              pricing_option_id: "$context.legacy_pricing_option_id"
               context:
-                buyer_ref: "inline-creative-line-001"
+                buyer_ref: "inline-creative-legacy-line-001"
               creatives:
-                - creative_id: "acme-inline-display-v1"
-                  name: "Acme Outdoor inline display v1"
-                  format_id: "$context.format_id"
+                - creative_id: "acme-inline-legacy-display-v1"
+                  name: "Acme Outdoor inline legacy display v1"
+                  format_id: "$context.legacy_format_id"
                   assets:
                     image:
                       asset_type: "image"
@@ -368,9 +361,9 @@ phases:
             correlation_id: "inline_creatives_without_sync--create_legacy"
         context_outputs:
           - path: "media_buy_id"
-            key: "media_buy_id"
+            key: "legacy_media_buy_id"
           - path: "packages[0].package_id"
-            key: "package_id"
+            key: "legacy_package_id"
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"
@@ -382,7 +375,7 @@ phases:
             description: "Seller assigns a package_id"
           - check: field_value
             path: "packages[0].context.buyer_ref"
-            value: "inline-creative-line-001"
+            value: "inline-creative-legacy-line-001"
             description: "Created package echoes package-level context for correlation"
           - check: field_value
             path: "context.correlation_id"
@@ -397,7 +390,6 @@ phases:
         doc_ref: "/media-buy/task-reference/update_media_buy"
         comply_scenario: media_buy_lifecycle
         stateful: true
-        contributes: true
         expected: |
           Replace the package's inline creative body with the new creative_id and
           return the affected package.
@@ -406,13 +398,13 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          media_buy_id: "$context.media_buy_id"
+          media_buy_id: "$context.legacy_media_buy_id"
           packages:
-            - package_id: "$context.package_id"
+            - package_id: "$context.legacy_package_id"
               creatives:
-                - creative_id: "acme-inline-display-v2"
-                  name: "Acme Outdoor inline display v2"
-                  format_id: "$context.format_id"
+                - creative_id: "acme-inline-legacy-display-v2"
+                  name: "Acme Outdoor inline legacy display v2"
+                  format_id: "$context.legacy_format_id"
                   assets:
                     image:
                       asset_type: "image"
@@ -431,42 +423,26 @@ phases:
             description: "Response matches update-media-buy-response.json schema"
           - check: field_equals_context
             path: "media_buy_id"
-            context_key: "media_buy_id"
+            context_key: "legacy_media_buy_id"
             description: "Update response references the same media buy"
           - check: field_equals_context
             path: "affected_packages[0].package_id"
-            context_key: "package_id"
+            context_key: "legacy_package_id"
             description: "Update response includes the affected package"
           - check: field_value
             path: "context.correlation_id"
             value: "inline_creatives_without_sync--update_legacy"
             description: "Context correlation_id returned unchanged"
 
-  - id: inline_format_path_assertion
-    title: "Require one inline format path"
-    steps:
-      - id: assert_inline_creative_format_path
-        title: "Assert inline creative format path contributed"
-        task: assert_contribution
-        comply_scenario: media_buy_lifecycle
-        stateful: false
-        expected: |
-          At least one of the canonical format_options[] path or the legacy
-          format_ids[] path created and updated the buy with inline creatives.
-        validations:
-          - check: any_of
-            allowed_values: ["inline_creative_format_path"]
-            description: "Seller accepted inline creatives through either the format_options[] or format_ids[] path"
-
   - id: verify_replacement
-    title: "Verify inline creative replacement persisted"
+    title: "Verify inline creative replacements persisted"
     narrative: |
-      The buyer reads the media buy and confirms the current package approval
-      state reflects the replacement inline creative.
+      The buyer reads both media buys and confirms each package approval state
+      reflects the replacement inline creative for its format path.
 
     steps:
-      - id: get_media_buy_after_inline_replacement
-        title: "Read media buy after inline replacement"
+      - id: get_canonical_media_buy_after_inline_replacement
+        title: "Read canonical media buy after inline replacement"
         task: get_media_buys
         schema_ref: "media-buy/get-media-buys-request.json"
         response_schema_ref: "media-buy/get-media-buys-response.json"
@@ -474,9 +450,9 @@ phases:
         comply_scenario: media_buy_lifecycle
         stateful: true
         expected: |
-          Return the media buy with package approval state for the replacement
-          inline creative. The full CreativeAsset body is not required on this
-          read surface.
+          Return the canonical-path media buy with package approval state for
+          the replacement inline creative. The full CreativeAsset body is not
+          required on this read surface.
 
         sample_request:
           account:
@@ -484,25 +460,67 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
           media_buy_ids:
-            - "$context.media_buy_id"
+            - "$context.canonical_media_buy_id"
           context:
-            correlation_id: "inline_creatives_without_sync--get_media_buy"
+            correlation_id: "inline_creatives_without_sync--get_canonical_media_buy"
         validations:
           - check: response_schema
             description: "Response matches get-media-buys-response.json schema"
           - check: field_equals_context
             path: "media_buys[0].media_buy_id"
-            context_key: "media_buy_id"
-            description: "Read response returns the created media buy"
+            context_key: "canonical_media_buy_id"
+            description: "Read response returns the created canonical media buy"
           - check: field_equals_context
             path: "media_buys[0].packages[0].package_id"
-            context_key: "package_id"
-            description: "Read response returns the created package"
+            context_key: "canonical_package_id"
+            description: "Read response returns the created canonical package"
           - check: field_value
             path: "media_buys[0].packages[0].creative_approvals[0].creative_id"
-            value: "acme-inline-display-v2"
-            description: "Read response reflects the replacement inline creative on the package approval-state surface"
+            value: "acme-inline-canonical-display-v2"
+            description: "Read response reflects the canonical replacement inline creative on the package approval-state surface"
           - check: field_value
             path: "context.correlation_id"
-            value: "inline_creatives_without_sync--get_media_buy"
+            value: "inline_creatives_without_sync--get_canonical_media_buy"
+            description: "Context correlation_id returned unchanged"
+
+      - id: get_legacy_media_buy_after_inline_replacement
+        title: "Read legacy media buy after inline replacement"
+        task: get_media_buys
+        schema_ref: "media-buy/get-media-buys-request.json"
+        response_schema_ref: "media-buy/get-media-buys-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buys"
+        comply_scenario: media_buy_lifecycle
+        stateful: true
+        expected: |
+          Return the legacy-path media buy with package approval state for the
+          replacement inline creative. The full CreativeAsset body is not
+          required on this read surface.
+
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "$context.legacy_media_buy_id"
+          context:
+            correlation_id: "inline_creatives_without_sync--get_legacy_media_buy"
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buys-response.json schema"
+          - check: field_equals_context
+            path: "media_buys[0].media_buy_id"
+            context_key: "legacy_media_buy_id"
+            description: "Read response returns the created legacy media buy"
+          - check: field_equals_context
+            path: "media_buys[0].packages[0].package_id"
+            context_key: "legacy_package_id"
+            description: "Read response returns the created legacy package"
+          - check: field_value
+            path: "media_buys[0].packages[0].creative_approvals[0].creative_id"
+            value: "acme-inline-legacy-display-v2"
+            description: "Read response reflects the legacy replacement inline creative on the package approval-state surface"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "inline_creatives_without_sync--get_legacy_media_buy"
             description: "Context correlation_id returned unchanged"

--- a/static/schemas/source/core/media-buy-features.json
+++ b/static/schemas/source/core/media-buy-features.json
@@ -7,7 +7,7 @@
   "properties": {
     "inline_creative_management": {
       "type": "boolean",
-      "description": "Supports creatives provided inline in create_media_buy requests"
+      "description": "Supports creatives provided inline in create_media_buy and update_media_buy package payloads. This flag does not imply a creative library: an inline-only seller can accept packages[].creatives without advertising sync_creatives, list_creatives, or reusable creative IDs."
     },
     "property_list_filtering": {
       "type": "boolean",

--- a/static/schemas/source/media-buy/package-request.json
+++ b/static/schemas/source/media-buy/package-request.json
@@ -193,7 +193,7 @@
     },
     "creatives": {
       "type": "array",
-      "description": "Upload new creative assets and assign to this package (creatives will be added to library). Use creative_assignments instead for existing library creatives.",
+      "description": "Upload creative assets inline and assign to this package. When the seller also advertises creative.has_creative_library: true, these creatives enter the seller's creative library and can be reused by creative_id while retained; inline-only sellers may store them as package-scoped assets. Use creative_assignments instead for existing library creatives.",
       "items": {
         "$ref": "/schemas/core/creative-asset.json"
       },

--- a/static/schemas/source/media-buy/package-update.json
+++ b/static/schemas/source/media-buy/package-update.json
@@ -167,7 +167,7 @@
     },
     "creatives": {
       "type": "array",
-      "description": "Upload new creative assets and assign to this package (creatives will be added to library). Use creative_assignments instead for existing library creatives.",
+      "description": "Replace this package's inline creative assets. When the seller also advertises creative.has_creative_library: true, new inline creatives enter the seller's creative library and can be reused by creative_id while retained; inline-only sellers may store them as package-scoped assets. Use creative_assignments instead for existing library creatives.",
       "items": {
         "$ref": "/schemas/core/creative-asset.json"
       },


### PR DESCRIPTION
Clarifies that `inline_creative_management` supports inline package creatives on both create and update without requiring a creative library.
Defines library-backed behavior around `creative.has_creative_library`, documents inline-only approval-state readback via `get_media_buys`, and updates media-buy workflow guidance so buyers route creative changes by advertised capability.
Adds a gated media-buy compliance scenario for inline creatives without `sync_creatives`, with canonical `format_options[]` and legacy `format_ids[]` branches.

Validation: ran schema/compliance builds, storyboard lints and matrices, schema/example tests, unit tests, typecheck, and Mintlify broken-link checks via local hooks.
