### PR TITLE
feat(registry): retire community mirror (DELETE /api/registry/mirrors/:platform)

### DIFF
--- a/.changeset/community-mirror-delete.md
+++ b/.changeset/community-mirror-delete.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": minor
+---
+
+Registry: add `DELETE /api/registry/mirrors/:platform` to retire a community mirror.
+
+Completes the #2176 community-mirror lifecycle with a moderator/admin-gated retire endpoint, closing the post-supersession deprecation window. Because buyers cache the mirror URL and fall back to it until the platform self-adopts, deletion refuses a mirror that has not published a `superseded_by` migration signal unless `?force=true` is passed — so live fallback traffic isn't yanked out from under buyers. After deletion the serving route returns 404, the documented "no mirror" state. The publish/delete authorization check is factored into a shared helper.

--- a/server/src/db/community-mirror-db.ts
+++ b/server/src/db/community-mirror-db.ts
@@ -94,4 +94,10 @@ export class CommunityMirrorDatabase {
       total: parseInt(count.rows[0]?.count ?? '0', 10),
     };
   }
+
+  /** Delete a mirror. Returns true if a row was removed, false if absent. */
+  async deleteByPlatform(platform: string): Promise<boolean> {
+    const result = await query('DELETE FROM community_mirrors WHERE platform = $1', [platform]);
+    return (result.rowCount ?? 0) > 0;
+  }
 }

--- a/server/src/routes/community-mirrors.ts
+++ b/server/src/routes/community-mirrors.ts
@@ -15,7 +15,7 @@
  */
 
 import { Router } from 'express';
-import type { RequestHandler } from 'express';
+import type { RequestHandler, Response } from 'express';
 import { z } from 'zod';
 import { CommunityMirrorDatabase } from '../db/community-mirror-db.js';
 import { isRegistryModerator } from '../services/brand-logo-auth.js';
@@ -62,6 +62,35 @@ const MirrorBodySchema = z
 
 export interface CommunityMirrorRouterConfig {
   requireAuth?: RequestHandler;
+}
+
+/**
+ * Resolve the authenticated caller and confirm they may manage community
+ * mirrors — a registry moderator or AAO admin (the static ADMIN_API_KEY
+ * sentinel always passes). Returns the user id, or null after sending the
+ * 401/403 response. `req.user` has no isAdmin field — admin status is resolved
+ * via isWebUserAAOAdmin, not the request.
+ */
+async function resolvePublisher(
+  req: { user?: { id?: string; email?: string } },
+  res: Response
+): Promise<string | null> {
+  const userId = req.user?.id;
+  if (!userId) {
+    res.status(401).json({ error: 'Authentication required' });
+    return null;
+  }
+  if (userId !== 'admin_api_key') {
+    const [isAaoAdmin, isModerator] = await Promise.all([
+      isWebUserAAOAdmin(userId),
+      isRegistryModerator(userId),
+    ]);
+    if (!isAaoAdmin && !isModerator) {
+      res.status(403).json({ error: 'Only registry moderators or AAO admins can manage community mirrors' });
+      return null;
+    }
+  }
+  return userId;
 }
 
 export function createCommunityMirrorRouter(config: CommunityMirrorRouterConfig): Router {
@@ -121,22 +150,8 @@ export function createCommunityMirrorRouter(config: CommunityMirrorRouterConfig)
       return res.status(400).json({ error: 'Invalid platform identifier (expected ^[a-z0-9_-]{1,64}$)' });
     }
 
-    const userId = req.user?.id;
-    if (!userId) {
-      return res.status(401).json({ error: 'Authentication required' });
-    }
-    // The static ADMIN_API_KEY sentinel always passes; otherwise the caller
-    // must be a registry moderator or an AAO admin. (req.user has no isAdmin
-    // field — admin status is resolved via isWebUserAAOAdmin, not the request.)
-    if (userId !== 'admin_api_key') {
-      const [isAaoAdmin, isModerator] = await Promise.all([
-        isWebUserAAOAdmin(userId),
-        isRegistryModerator(userId),
-      ]);
-      if (!isAaoAdmin && !isModerator) {
-        return res.status(403).json({ error: 'Only registry moderators or AAO admins can publish community mirrors' });
-      }
-    }
+    const userId = await resolvePublisher(req, res);
+    if (!userId) return;
 
     const parsed = MirrorBodySchema.safeParse(req.body);
     if (!parsed.success) {
@@ -211,6 +226,42 @@ export function createCommunityMirrorRouter(config: CommunityMirrorRouterConfig)
     } catch (err) {
       logger.error({ err, platform }, 'Failed to publish community mirror');
       return res.status(500).json({ error: 'Failed to publish community mirror' });
+    }
+  });
+
+  // ── DELETE /api/registry/mirrors/:platform — retire ─────────────
+  router.delete('/mirrors/:platform', ...writeMiddleware, async (req, res) => {
+    const platform = String(req.params.platform).toLowerCase();
+    if (!PLATFORM_RE.test(platform)) {
+      return res.status(400).json({ error: 'Invalid platform identifier (expected ^[a-z0-9_-]{1,64}$)' });
+    }
+    const userId = await resolvePublisher(req, res);
+    if (!userId) return;
+
+    try {
+      const mirror = await mirrorDb.getByPlatform(platform);
+      if (!mirror) {
+        return res.status(404).json({ error: 'Community mirror not found' });
+      }
+      // Buyer caches key on the mirror URL and fall back to it until the
+      // platform self-adopts. Refuse to remove a mirror that has not published
+      // a `superseded_by` migration signal unless explicitly forced, so live
+      // fallback traffic isn't yanked out from under buyers. (404 is the
+      // documented "no mirror" state buyers already handle, so a hard delete
+      // is safe once the deprecation window has been signalled.)
+      const force = req.query.force === 'true';
+      if (!mirror.superseded_by && !force) {
+        return res.status(409).json({
+          error:
+            'Refusing to delete a mirror that has not been superseded. Set superseded_by first (so buyers get a migration signal), or pass ?force=true to delete anyway.',
+        });
+      }
+      await mirrorDb.deleteByPlatform(platform);
+      logger.info({ platform, by: userId, force }, 'Deleted community mirror');
+      return res.json({ success: true, platform });
+    } catch (err) {
+      logger.error({ err, platform }, 'Failed to delete community mirror');
+      return res.status(500).json({ error: 'Failed to delete community mirror' });
     }
   });
 

--- a/server/tests/integration/community-mirrors.test.ts
+++ b/server/tests/integration/community-mirrors.test.ts
@@ -247,4 +247,46 @@ describe('Community-mirror lifecycle — /api/registry/mirrors + /translated', (
     const res = await request(app).get(`/api/creative-agent/translated/${PLATFORM}/adagents.json`);
     expect(res.status).toBe(404);
   });
+
+  it('deletes a superseded mirror and returns the serving route to 404', async () => {
+    await request(app)
+      .put(`/api/registry/mirrors/${PLATFORM}`)
+      .send(publishBody({ superseded_by: 'https://meta.com/.well-known/adagents.json' }));
+    const del = await request(app).delete(`/api/registry/mirrors/${PLATFORM}`);
+    expect(del.status).toBe(200);
+    expect(del.body.success).toBe(true);
+    expect((await request(app).get(`/api/registry/mirrors/${PLATFORM}`)).status).toBe(404);
+    expect((await request(app).get(`/api/creative-agent/translated/${PLATFORM}/adagents.json`)).status).toBe(404);
+  });
+
+  it('refuses to delete a mirror that has not been superseded (409)', async () => {
+    await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody());
+    const del = await request(app).delete(`/api/registry/mirrors/${PLATFORM}`);
+    expect(del.status).toBe(409);
+    expect(del.body.error).toMatch(/superseded/i);
+    // The mirror is still served — fallback traffic is protected.
+    expect((await request(app).get(`/api/registry/mirrors/${PLATFORM}`)).status).toBe(200);
+  });
+
+  it('force-deletes a non-superseded mirror with ?force=true', async () => {
+    await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody());
+    const del = await request(app).delete(`/api/registry/mirrors/${PLATFORM}?force=true`);
+    expect(del.status).toBe(200);
+    expect((await request(app).get(`/api/registry/mirrors/${PLATFORM}`)).status).toBe(404);
+  });
+
+  it('returns 404 deleting an unknown mirror', async () => {
+    const del = await request(app).delete(`/api/registry/mirrors/${PLATFORM}`);
+    expect(del.status).toBe(404);
+  });
+
+  it('rejects delete from a non-moderator, non-admin caller (403)', async () => {
+    await request(app)
+      .put(`/api/registry/mirrors/${PLATFORM}`)
+      .send(publishBody({ superseded_by: 'https://meta.com/.well-known/adagents.json' }));
+    isRegistryModerator.mockResolvedValue(false);
+    isWebUserAAOAdmin.mockResolvedValue(false);
+    const del = await request(app).delete(`/api/registry/mirrors/${PLATFORM}`);
+    expect(del.status).toBe(403);
+  });
 });


### PR DESCRIPTION
Follow-up to #5362 — completes the #2176 community-mirror lifecycle with a retire endpoint (the panel-flagged deferred item).

## Change

- **`DELETE /api/registry/mirrors/:platform`** — moderator/admin-gated (same `resolvePublisher()` helper as `PUT`, now factored out). To protect buyer fallback traffic — buyers cache the mirror URL and fall back to it until the platform self-adopts — it **refuses to delete a mirror that has not published a `superseded_by` migration signal** unless `?force=true`. After deletion the serving route returns `404`, the documented "no mirror" state buyers already handle.
- `CommunityMirrorDatabase.deleteByPlatform`.

## Testing
5 new integration cases (19 total, all green against Postgres): delete a superseded mirror → 200 + serving 404; unsuperseded → 409 (still served); `?force=true` → 200; unknown → 404; non-moderator → 403. Typecheck passes.
