### PR TITLE
chore: update Argus to Opus 4.8

### DIFF
--- a/.changeset/argus-opus-4-8.md
+++ b/.changeset/argus-opus-4-8.md
@@ -1,0 +1,4 @@
+---
+---
+
+Update the Argus PR-review workflow to run Claude Opus 4.8 at high effort.

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -353,7 +353,8 @@ jobs:
           claude_args: |
             --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:*),Bash(gh api repos/*/pulls/*),Bash(gh api repos/*/contents/*),Bash(gh api repos/*/issues/*),Read,Glob,Grep,Task"
             --max-turns 60
-            --model claude-opus-4-7
+            --model claude-opus-4-8
+            --effort high
 
       - name: Verify Argus posted a review
         id: verify


### PR DESCRIPTION
## Summary
- update Argus PR review from Claude Opus 4.7 to Claude Opus 4.8
- set Claude Code effort explicitly to high
- add an empty changeset because this is workflow-only automation config

## Verification
- ruby YAML parse for .github/workflows/ai-review.yml
- precommit: unit tests, dynamic-import lint, callApi-state-change lint, typecheck
- pre-push: version sync and changeset check