### PR TITLE
feat(compliance): add validation result ids

### DIFF
--- a/.changeset/validation-result-ids.md
+++ b/.changeset/validation-result-ids.md
@@ -1,0 +1,6 @@
+---
+"adcontextprotocol": minor
+---
+
+Add optional storyboard validation ids and require runners to echo them in
+validation results for stable per-assertion diagnostics.

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -26,7 +26,7 @@
 # --- Schema definition ---
 
 id: runner_output_contract
-version: "2.5.0"
+version: "2.6.0"
 title: "Runner output contract"
 summary: "Required failure-detail shape that AdCP storyboard runners MUST emit so implementors can self-diagnose validation failures."
 
@@ -514,6 +514,17 @@ validation_result:
       Any runner correctly implementing draft-07 JSON Schema validation
       already satisfies it.
   optional_fields:
+    - id                      # Stable machine-readable identifier copied from
+                              # the storyboard validation entry's optional
+                              # `id` field. When the authored validation has
+                              # an id, runners MUST echo it unchanged so
+                              # dashboards, support requests, and SDK adapters
+                              # can reference a specific assertion without
+                              # depending on mutable description text, path
+                              # values, or array position. Runner-synthesized
+                              # validations MAY omit this field unless they
+                              # define a stable generated id in the runner
+                              # contract.
     - remediation             # runner-suggested fix when the failure maps to
                               # a well-known cause (e.g., "agent did not echo
                               # context.correlation_id — see

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -1071,6 +1071,14 @@
 # runner-output-contract.yaml > validation_result. Add new kinds to that
 # enum AND document semantics here in the same PR.
 #
+# id: string (optional stable machine-readable identifier for this validation.
+#                Use when a step declares multiple validations that need a
+#                durable cross-reference in runner output, dashboards, support
+#                requests, or SDK adapters. The value is author-chosen and
+#                stable across description/path edits; it SHOULD be unique
+#                within the containing step's `validations` array. Runners
+#                echo this value in `validation_result.id`; see
+#                runner-output-contract.yaml > validation_result.)
 # check: string (what to validate: "response_schema", "field_present",
 #                "field_pattern" (path MUST resolve to a string matching
 #                `pattern`, a JavaScript regular expression source),


### PR DESCRIPTION
## Summary
- add an optional storyboard validation `id` field for stable per-assertion references
- require runners to echo authored validation ids as `validation_result.id`
- bump the runner output contract from 2.5.0 to 2.6.0 and add a minor changeset

This is the spec-only slice for #5337. Addie pass-through and adcp-client runner emission remain separate follow-ups.

## Validation
- `npx prettier --check .changeset/validation-result-ids.md`
- `rg -n 'version: "2\\.6\\.0"|validation_result\\.id|id: string \\(optional stable|echo this value' static/compliance/source/universal/storyboard-schema.yaml static/compliance/source/universal/runner-output-contract.yaml .changeset/validation-result-ids.md`\n\nNote: I did not reformat the touched contract YAML files because `runner-output-contract.yaml` already fails full-file Prettier/YAML parsing on `main`; this PR keeps the diff to the contract change only.