### PR TITLE
fix(website): add working group post copy link

### DIFF
--- a/.changeset/working-group-post-copy-link.md
+++ b/.changeset/working-group-post-copy-link.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add a copy-link affordance to working group article posts.

--- a/server/public/working-groups/detail.html
+++ b/server/public/working-groups/detail.html
@@ -1097,6 +1097,9 @@
       width: 14px;
       height: 14px;
     }
+    .article-view-share-actions {
+      justify-content: center;
+    }
     .article-view-hero {
       width: 100%;
       max-height: 300px;
@@ -1388,6 +1391,15 @@
       <div class="article-view-header">
         <h1 id="articleViewTitle" class="article-view-title"></h1>
         <div id="articleViewMeta" class="article-view-meta"></div>
+        <div class="article-view-actions article-view-share-actions">
+          <button class="btn btn-secondary btn-icon" id="copyArticleLinkBtn" onclick="copyCurrentArticleLink(this)" title="Copy post link" aria-label="Copy post link">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/>
+              <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
+            </svg>
+            Copy link
+          </button>
+        </div>
         <div id="articleViewActions" class="article-view-actions" style="display:none;">
           <button class="btn btn-secondary btn-icon" onclick="editCurrentArticle()">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
@@ -2429,6 +2441,11 @@
 
     let currentArticleSlug = null;
 
+    function articlePermalinkForPost(post) {
+      const groupSlug = post.source_group?.slug || currentSlug;
+      return `/working-groups/${encodeURIComponent(groupSlug)}#post-${encodeURIComponent(post.slug)}`;
+    }
+
     function openArticle(postSlug) {
       const post = postsData.find(p => p.slug === postSlug);
       if (!post) return;
@@ -2436,7 +2453,7 @@
       currentArticleSlug = postSlug;
 
       // Update URL without reloading (use encodeURIComponent for safety)
-      history.pushState(null, '', `/working-groups/${encodeURIComponent(currentSlug)}#post-${encodeURIComponent(postSlug)}`);
+      history.pushState(null, '', articlePermalinkForPost(post));
 
       // Populate modal
       document.getElementById('articleViewTitle').textContent = post.title;
@@ -2477,6 +2494,27 @@
       // Show modal
       document.getElementById('articleViewModal').style.display = 'flex';
       document.body.style.overflow = 'hidden';
+    }
+
+    function copyCurrentArticleLink(button) {
+      const post = postsData.find(p => p.slug === currentArticleSlug);
+      if (!post) return;
+
+      const url = `${window.location.origin}${articlePermalinkForPost(post)}`;
+      navigator.clipboard.writeText(url).then(() => {
+        const originalHtml = button.innerHTML;
+        button.innerHTML = `
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20 6L9 17l-5-5"/>
+          </svg>
+          Copied`;
+        setTimeout(() => {
+          button.innerHTML = originalHtml;
+        }, 2000);
+      }).catch((err) => {
+        console.error('Copy post link failed:', err);
+        alert('Failed to copy link');
+      });
     }
 
     function closeArticleView() {


### PR DESCRIPTION
## Summary
- add a visible copy-link button to working group article post modals
- copy the canonical post permalink instead of relying on the current browser state
- preserve subgroup post permalinks when article links are opened from a parent group page

Addresses item 3 from #5386. I left the Slack unfurl route decision and hero-generation visibility out of scope.

## Validation
- `perl -0ne 'while (/<script>([\\s\\S]*?)<\\/script>/g) { print $1, "\\n" }' server/public/working-groups/detail.html > /tmp/adcp-5386/detail-inline.js && node --check /tmp/adcp-5386/detail-inline.js`\n- `npx prettier --check .changeset/working-group-post-copy-link.md`\n- `git diff --no-index /tmp/adcp-5386-original/server/public/working-groups/detail.html /tmp/adcp-5386/server/public/working-groups/detail.html --check`\n\nNote: `server/public/working-groups/detail.html` already fails full-file Prettier on main, so I avoided reformatting the page in this narrow UI fix.