### PR TITLE
feat(creative): add build recipe hash

### DIFF
--- a/.changeset/build-creative-recipe-hash.md
+++ b/.changeset/build-creative-recipe-hash.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add optional `recipe_hash` fields to `build_creative` success responses so creative agents can expose an opaque, agent-scoped identity for build-determining inputs without standardizing a cross-agent hash algorithm.

--- a/docs/creative/task-reference/build_creative.mdx
+++ b/docs/creative/task-reference/build_creative.mdx
@@ -62,6 +62,12 @@ When the creative agent charges and `account` is provided, the response includes
 
 For async builds (`status: "working"` with `context_id` polling), pricing fields appear on the final completed response only.
 
+### Recipe identity
+
+Agents MAY return a top-level `recipe_hash` on single-format success responses, and MAY return `variants[].recipe_hash` on multiplicity/refinement leaves. Multi-format `creative_manifests[]` responses do not carry `recipe_hash` in this revision; request the variant shape (`max_variants`) when you need per-output recipe identities. The value is an ETag-style identity for the build-determining inputs: agent-computed, opaque, and scoped to that agent. Buyers can compare it only across responses from the same agent.
+
+`recipe_hash` identifies the input recipe, not the output bytes or legal/disclosure envelope. A nondeterministic build can return different pixels, tags, or variants with the same `recipe_hash`; the value means "same instructions," not "same creative." For fan-out responses, best-of-N leaves produced from the same recipe SHOULD share the same value so clients can group alternatives by their shared source. When both `recipe_hash` and `build_variant_id` appear, `build_variant_id` identifies the output leaf and lineage while `recipe_hash` identifies the input recipe; neither implies the other. The build-to-delivery performance join still uses the lineage identifiers that survive trafficking, not `recipe_hash` alone.
+
 **Important**: Required input assets should be included in the `creative_manifest.assets` object, not as separate task parameters. The format definition specifies what assets it requires. Catalog context for dynamic creatives should be provided via the `creative_manifest.assets` map.
 
 ### Evaluator authentication
@@ -202,6 +208,7 @@ Retrieve a creative from the agent's library and resolve it into a manifest with
 {
   "$schema": "/schemas/media-buy/build-creative-response.json",
   "status": "completed",
+  "recipe_hash": "rh_scope3_9f2c7a1d5b3e",
   "creative_manifest": {
     "format_id": {
       "agent_url": "https://creative.example.com",
@@ -224,6 +231,8 @@ Retrieve a creative from the agent's library and resolve it into a manifest with
 ```
 
 The `CLICK_URL` macro was substituted with the provided value; `CACHEBUSTER` remains as a placeholder for the sales agent to resolve at serve time.
+
+Do not use `recipe_hash` to deduplicate ad tags, prove legal/disclosure equivalence, or join build results to served delivery data. Use `build_variant_id` and the promoted `creative_id` for lineage and reporting.
 
 <Note>
 **Cross-agent workflow**: When creative generation and media buying are handled by different agents, use `build_creative` on the creative agent to produce a manifest with tags, then [`sync_creatives`](/docs/creative/task-reference/sync_creatives) on the sales agent to upload it. When the sales agent implements both protocols, this happens on a single endpoint — see [Creative capabilities on sales agents](/docs/creative/sales-agent-creative-capabilities).
@@ -481,6 +490,7 @@ When the request uses `target_format_id`, the response contains a single creativ
 {
   "$schema": "/schemas/media-buy/build-creative-response.json",
   "status": "completed",
+  "recipe_hash": "rh_winter_300x250_4c2a",
   "creative_manifest": {
     "format_id": {
       "agent_url": "https://creative.adcontextprotocol.org",
@@ -550,8 +560,9 @@ When the request uses `max_creatives`, `max_variants` > 1, `variant_axis`, or `r
       "variants": [
         {
           "build_variant_id": "bv_card01_a",
+          "recipe_hash": "rh_card01_bestofn_7b91",
           "creative_manifest": { "format_id": { "agent_url": "https://creative.example.com", "id": "display_300x250" }, "assets": { "...": "..." } },
-          "variant_axis_value": "studio",
+          "variant_axis_value": "take_1",
           "recommended": true,
           "rank": 1,
           "pricing_option_id": "po_per_image",
@@ -561,8 +572,9 @@ When the request uses `max_creatives`, `max_variants` > 1, `variant_axis`, or `r
         },
         {
           "build_variant_id": "bv_card01_b",
+          "recipe_hash": "rh_card01_bestofn_7b91",
           "creative_manifest": { "format_id": { "agent_url": "https://creative.example.com", "id": "display_300x250" }, "assets": { "...": "..." } },
-          "variant_axis_value": "lifestyle",
+          "variant_axis_value": "take_2",
           "recommended": false,
           "rank": 2,
           "pricing_option_id": "po_per_image",
@@ -589,6 +601,7 @@ _The `creatives[]` array above is abbreviated to one of the 5 returned groups; t
 - **creatives[].errors[]**: Present only on a *failed* catalog item — catalog fan-out is non-atomic, so a failed item is returned as a `creatives[]` entry carrying `errors[]` and no `variants[]`, without failing the batch.
 - **creatives[].variants[]**: The choose-among alternatives produced for this creative group. Length is at most `max_variants`. Each variant carries its own complete `creative_manifest`.
 - **variants[].build_variant_id**: Identifies a single variant — the leaf-level **lineage anchor**. This is its **own namespace** — never reuse a `preview_id` (a `preview_creative` render) or a served `variant_id` (a delivery-time identifier) here. You traffic a chosen build by passing its `build_variant_id`.
+- **variants[].recipe_hash**: Optional ETag-style identity for the build-determining inputs that produced the leaf. It is agent-computed, opaque, and comparable only within the same agent. Best-of-N leaves from the same source recipe SHOULD share a value. It is useful for cache transparency, cost-avoidance hints, and recipe-level grouping, but it is not output equality, not legal/disclosure equivalence, and not the build-to-delivery join.
 - **variants[].parent_build_variant_id**: Present only on a refined variant ([Refinement](#refinement)) — the `build_variant_id` of the source it was refined from. Absent for first-generation builds.
 - **variants[].variant_axis_value**: The value of the `variant_axis` dimension this variant represents (e.g. a voice, a theme).
 - **variants[].recommended** / **variants[].rank**: Best-of-N signals — `recommended` flags the agent's top pick; `rank` orders the variants. These plus `variant_axis` and `keep_mode` are how best-of-N is expressed.

--- a/static/schemas/source/media-buy/build-creative-response.json
+++ b/static/schemas/source/media-buy/build-creative-response.json
@@ -27,6 +27,10 @@
           "x-entity": "build_variant",
           "description": "Leaf handle for this produced creative — present when the agent supports refinement (creative.supports_refinement). Pass it as refine_from_build_variant_id to refine this build. Same namespace as BuildCreativeVariantSuccess leaves; distinct from served variant_id / preview_id. Lazily earns a creative_id on trafficking."
         },
+        "recipe_hash": {
+          "type": "string",
+          "description": "Optional agent-computed, opaque, agent-scoped identity for the build-determining inputs that produced this creative. Stable for identical inputs as defined by the agent, and comparable only within the same agent. ETag-style semantics: the protocol defines the field and contract, not the hash algorithm or canonical input set. Identifies generative-input identity, not output equality, legal/disclosure equivalence, or the build-to-delivery join."
+        },
         "sandbox": {
           "type": "boolean",
           "description": "When true, this response contains simulated data from sandbox mode."
@@ -323,6 +327,10 @@
                       "type": "string",
                       "x-entity": "build_variant",
                       "description": "Build-time handle for this produced variant — the leaf-level lineage anchor for the creative. Minted per produced variant. Its OWN namespace — MUST NOT reuse a `preview_id` (preview renders) or a served `variant_id` (delivery). Lineage and joins (refinement parentage, build→delivery learning, QA re-rolls) anchor on this leaf id, NOT on the call-level `build_creative_id`. A leaf lazily earns a durable `creative_id` only when trafficked / added to the library; that `creative_id` is what flows into `report_usage`. An untrafficked leaf has no `report_usage` key — it is billed via the inline per-leaf `vendor_cost` only, and `report_usage` reconciliation applies once the leaf earns a `creative_id`."
+                    },
+                    "recipe_hash": {
+                      "type": "string",
+                      "description": "Optional agent-computed, opaque, agent-scoped identity for the build-determining inputs that produced this variant leaf. Stable for identical inputs as defined by the agent, and comparable only within the same agent. Multiple leaves from the same best-of-N recipe SHOULD carry the same value so clients can group alternative outputs by their shared source recipe. ETag-style semantics: the protocol defines the field and contract, not the hash algorithm or canonical input set. Identifies generative-input identity, not output equality, legal/disclosure equivalence, or the build-to-delivery join."
                     },
                     "parent_build_variant_id": {
                       "type": "string",


### PR DESCRIPTION
Adds optional recipe_hash to build_creative single-format and variant-leaf responses as an opaque, agent-scoped identity for build-determining inputs.

Documents presence semantics, best-of-N grouping, and guardrails against treating it as output equality, disclosure equivalence, or a delivery join.

Adds a minor changeset for the schema addition.

Validation: build:schemas, test:schemas, test:json-schema, test:composed, test:oneof-discriminators, test:snippets for build_creative, and the precommit hook.