### PR TITLE
fix(schema): reject unknown top-level fields on SignalCoverageForecast

### DIFF
--- a/.changeset/fix-signal-coverage-forecast-additionalproperties.md
+++ b/.changeset/fix-signal-coverage-forecast-additionalproperties.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix SignalCoverageForecast schema validation to reject unknown top-level fields while preserving open scope qualifiers for seller-specific denominator metadata.

--- a/static/schemas/source/core/signal-coverage-forecast.json
+++ b/static/schemas/source/core/signal-coverage-forecast.json
@@ -149,5 +149,5 @@
       }
     }
   ],
-  "additionalProperties": true
+  "additionalProperties": false
 }

--- a/tests/composed-schema-validation.test.cjs
+++ b/tests/composed-schema-validation.test.cjs
@@ -1167,6 +1167,34 @@ async function runTests() {
   );
   log('');
 
+  log('SignalCoverageForecast schema (top-level additionalProperties enforcement):', 'info');
+  await testSchemaValidation(
+    '/schemas/core/signal-coverage-forecast.json',
+    signalCoverageForecast,
+    'SignalCoverageForecast accepts valid forecast with presence: present and omitted signal_value'
+  );
+  await testSchemaValidation(
+    '/schemas/core/signal-coverage-forecast.json',
+    {
+      ...signalCoverageForecast,
+      scope: {
+        kind: 'inventory',
+        label: 'network price-priority inventory',
+        inventory_class: 'price_priority'
+      }
+    },
+    'SignalCoverageForecast scope accepts seller-specific extra qualifier (inventory_class)'
+  );
+  await testSchemaRejection(
+    '/schemas/core/signal-coverage-forecast.json',
+    {
+      ...signalCoverageForecast,
+      bucket_completness: 'partial'
+    },
+    'SignalCoverageForecast rejects unknown top-level field (bucket_completness typo)'
+  );
+  log('');
+
   log('SignalId compatibility during SignalRef migration:', 'info');
   await testSchemaValidation(
     '/schemas/signals/get-signals-response.json',


### PR DESCRIPTION
## Summary

Closes #5089.

This tightens the `SignalCoverageForecast` schema so unknown top-level fields are rejected, while preserving open seller-specific qualifiers inside `scope`.

The intent is to prevent typo fields such as `bucket_completness` from validating at the forecast object level without removing the intended extension surface for denominator metadata.

## Changes

- Set top-level `additionalProperties` to `false` in `signal-coverage-forecast.json`
- Kept `scope.additionalProperties` as `true`
- Added composed schema validation coverage for:
  - valid `presence: "present"` with omitted `signal_value`
  - seller-specific extra qualifier inside `scope`
  - unknown top-level typo rejection

## Verification

- `npm run test:composed`
  - 103/103 passed
- `npm run typecheck`
  - passed
- `npm test`
  - 51 files passed
  - 942 tests passed
- `node scripts/check-pr-title.cjs "fix(schema): reject unknown top-level fields on SignalCoverageForecast"`
  - passed

## Notes

All test fixtures use fictional/test data only. No platform- or vendor-specific normative fields were introduced.