### PR TITLE
fix(compliance): pending_creatives_to_start status checks expect task-status not MediaBuyStatus

### DIFF
--- a/.changeset/fix-pending-creatives-storyboard-status-check.md
+++ b/.changeset/fix-pending-creatives-storyboard-status-check.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix storyboard `field_value_or_absent(status, MediaBuyStatus)` checks that created impossible-to-satisfy constraints alongside `response_schema`.
+
+`protocol-envelope.json` has `required: ["status"]` typed as the TaskStatus enum. Three storyboard checks across `pending_creatives_to_start.yaml` and `available_actions.yaml` were asserting MediaBuyStatus values ("pending_creatives", "pending_start"/"active", "active") at the envelope `status` key — leaving no valid response shape that could satisfy both `response_schema` and the field assertion. Replaced with `field_value(status, "completed")` matching what protocol-envelope mandates for synchronous success. Also updated two stale narrative prose references from "status: pending_creatives" to "media_buy_status: pending_creatives".
+
+Fixes #5416.

--- a/static/compliance/source/protocols/media-buy/scenarios/available_actions.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/available_actions.yaml
@@ -267,10 +267,10 @@ phases:
             path: "media_buy_status"
             value: "active"
             description: "Created buy is active before available_actions mutation probes"
-          - check: field_value_or_absent
+          - check: field_value
             path: "status"
-            value: "active"
-            description: "Legacy status, when present alongside media_buy_status, mirrors active"
+            value: "completed"
+            description: "Envelope task-status is completed on synchronous success (protocol-envelope.json required: [status])"
           - check: field_contains
             path: "available_actions[*]"
             value:

--- a/static/compliance/source/protocols/media-buy/scenarios/pending_creatives_to_start.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/pending_creatives_to_start.yaml
@@ -21,7 +21,7 @@ required_tools:
 
 narrative: |
   When a buyer creates a media buy without creative_assignments, the seller cannot start
-  delivery until creatives are supplied. The seller must report status: pending_creatives
+  delivery until creatives are supplied. The seller must report media_buy_status: pending_creatives
   and, after sync_creatives attaches the required assets, transition the buy to
   pending_start (awaiting flight start) or active (if already in flight).
 
@@ -94,7 +94,7 @@ phases:
     title: "Create media buy without creative_assignments"
     narrative: |
       The buyer intentionally omits creative_assignments. The seller must accept the
-      buy, persist it, and return status: pending_creatives with valid_actions
+      buy, persist it, and return media_buy_status: pending_creatives with valid_actions
       including sync_creatives.
 
     steps:
@@ -109,7 +109,8 @@ phases:
         expected: |
           Media buy created with:
           - media_buy_id assigned
-          - status: pending_creatives
+          - media_buy_status: pending_creatives
+          - status: completed (task envelope)
           - valid_actions including sync_creatives
 
         sample_request:
@@ -146,10 +147,10 @@ phases:
             path: "media_buy_status"
             value: "pending_creatives"
             description: "media_buy_status is pending_creatives because no creatives supplied"
-          - check: field_value_or_absent
+          - check: field_value
             path: "status"
-            value: "pending_creatives"
-            description: "Legacy status, when present alongside media_buy_status, MUST carry the same value (3.1 deprecation window — see #4908)"
+            value: "completed"
+            description: "Envelope task-status is completed on synchronous success (protocol-envelope.json required: [status])"
           - check: field_present
             path: "context"
             description: "Response echoes back the context object"
@@ -241,10 +242,10 @@ phases:
             path: "media_buy_status"
             allowed_values: ["pending_start", "active"]
             description: "media_buy_status advances out of pending_creatives once creatives attached"
-          - check: field_value_or_absent
+          - check: field_value
             path: "status"
-            allowed_values: ["pending_start", "active"]
-            description: "Legacy status, when present alongside media_buy_status, MUST carry the same value (3.1 deprecation window — see #4908)"
+            value: "completed"
+            description: "Envelope task-status is completed on synchronous update success (protocol-envelope.json required: [status])"
 
   - id: verify_transition
     title: "Verify the status transition"


### PR DESCRIPTION
## Summary

- Three storyboard `field_value_or_absent(status, MediaBuyStatus)` checks across `pending_creatives_to_start.yaml` and `available_actions.yaml` created impossible-to-satisfy constraints: `protocol-envelope.json` has `required: ["status"]` typed as `TaskStatus`, so the "absent" branch is a schema violation and the MediaBuyStatus values ("pending_creatives", "pending_start"/"active", "active") are enum mismatches.
- Replaced all three with `field_value(status, "completed")` — what protocol-envelope mandates for synchronous task success.
- Updated two stale narrative/expected-prose references from `status: pending_creatives` to `media_buy_status: pending_creatives`.

Closes #5416.

## Non-breaking justification

Storyboard fixtures only run in the conformance harness. The change makes previously impossible-to-satisfy checks satisfiable — it relaxes a false constraint, it does not tighten a passing one. No protocol spec, schema, or SDK surface is modified.

## Pre-PR review sign-offs

- `code-reviewer`: approved after `available_actions.yaml` fix and prose corrections were included.
- `ad-tech-protocol-expert`: confirmed `protocol-envelope.json required: ["status"]` makes the prior checks unsatisfiable; `field_value(status, "completed")` is the correct assertion.

## Test plan

- [ ] `npm run build:compliance` — passes locally (verified pre-push)
- [ ] `npm run build:schemas` — passes locally (verified pre-push)
- [ ] `npm run typecheck` — 0 errors (verified pre-push)
- [ ] CI storyboard matrix on this PR

---

> **Triage-managed PR** — opened by the AdCP triage routine on behalf of issue #5416.

https://claude.ai/code/session_0138zr5q2K6PHmCj6R5XMYMJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0138zr5q2K6PHmCj6R5XMYMJ)_