### PR TITLE
Improve brand setup registry flow

### DIFF
--- a/.changeset/brand-setup-registry-pointer.md
+++ b/.changeset/brand-setup-registry-pointer.md
@@ -1,0 +1,6 @@
+---
+---
+
+Improve the brand builder setup flow so member organizations can save a full
+brand.json draft to the expert-run AgenticAdvertising.org registry and publish
+a small authoritative pointer file on their own domain.

--- a/server/public/brand-builder.html
+++ b/server/public/brand-builder.html
@@ -625,6 +625,40 @@
         border: 1px solid var(--color-success-100);
       }
 
+      .registry-setup-panel {
+        background: var(--color-bg-card);
+        border: 1px solid var(--color-success-100);
+        border-radius: var(--radius-md);
+        padding: var(--space-4);
+        margin-bottom: var(--space-4);
+      }
+
+      .registry-setup-panel p {
+        margin: 0 0 var(--space-3) 0;
+        color: var(--text-secondary);
+        font-size: var(--text-sm);
+      }
+
+      .registry-setup-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-2);
+        margin-top: var(--space-3);
+      }
+
+      .pointer-snippet {
+        background: var(--color-gray-900);
+        color: var(--color-gray-100);
+        border-radius: var(--radius-md);
+        padding: var(--space-3);
+        overflow-x: auto;
+        white-space: pre-wrap;
+        word-break: break-word;
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        margin: var(--space-2) 0 0 0;
+      }
+
       .verify-result {
         margin-top: var(--space-3);
         padding: var(--space-3);
@@ -1174,8 +1208,8 @@
               <button class="btn btn-secondary" onclick="copyJson()">Copy JSON</button>
               <button class="btn btn-secondary" onclick="downloadJson()">Download</button>
               <div style="display: flex; flex-direction: column; align-items: flex-end;">
-                <button class="btn" id="save-registry-btn" onclick="saveToRegistry()" disabled title="Log in to save">Save to Registry</button>
-                <span id="save-registry-hint" class="btn-disabled-hint">Log in as a member to save</span>
+                <button class="btn" id="save-registry-btn" onclick="saveToRegistry()" disabled title="Log in to save">Save setup</button>
+                <span id="save-registry-hint" class="btn-disabled-hint">Log in as a member to save setup</span>
               </div>
             </div>
           </div>
@@ -1600,20 +1634,35 @@
           <!-- Next Steps / Success State -->
           <div class="next-steps" id="next-steps">
             <h4>Next steps</h4>
+            <div class="registry-setup-panel hidden" id="registry-setup-panel">
+              <p id="registry-setup-message">
+                Your brand.json is saved in the expert-run AgenticAdvertising.org registry.
+                To make it authoritative, publish this small pointer file on your domain.
+              </p>
+              <p><strong>Registry URL</strong></p>
+              <code id="registry-hosted-url">https://agenticadvertising.org/brands/example.com/brand.json</code>
+              <p style="margin-top: var(--space-3);"><strong>Pointer file contents</strong></p>
+              <pre class="pointer-snippet" id="pointer-snippet">{}</pre>
+              <div class="registry-setup-actions">
+                <button class="btn" onclick="copyPointerSnippet()" style="padding: var(--space-2) var(--space-4);">Copy pointer JSON</button>
+                <button class="btn btn-secondary" onclick="downloadPointerJson()" style="padding: var(--space-2) var(--space-4);">Download pointer file</button>
+                <button class="btn btn-secondary" onclick="copyWebTeamInstructions()" style="padding: var(--space-2) var(--space-4);">Copy web team instructions</button>
+              </div>
+            </div>
             <ol>
               <li>
                 <div class="step-number">1</div>
                 <div class="step-content">
-                  <strong>Download your file</strong>
-                  <p>Save the generated brand.json to your computer.</p>
-                  <button class="btn" onclick="downloadJson()" style="padding: var(--space-2) var(--space-4);">Download brand.json</button>
+                  <strong id="next-step-1-title">Download your file</strong>
+                  <p id="next-step-1-copy">Save the generated brand.json to your computer.</p>
+                  <button class="btn" id="next-step-download-json-btn" onclick="downloadJson()" style="padding: var(--space-2) var(--space-4);">Download brand.json</button>
                 </div>
               </li>
               <li>
                 <div class="step-number">2</div>
                 <div class="step-content">
-                  <strong>Upload to your website</strong>
-                  <p>Place the file at this exact location on your server:</p>
+                  <strong id="next-step-2-title">Upload to your website</strong>
+                  <p id="next-step-2-copy">Place the file at this exact location on your server:</p>
                   <code id="deploy-path">https://example.com/.well-known/brand.json</code>
                   <p style="margin-top: var(--space-2);">Create the <code>.well-known</code> folder if it doesn't exist.</p>
                 </div>
@@ -1673,6 +1722,7 @@
       let selectedBrandId = null; // For portfolio mode
       let brandIdManuallyEdited = { single: false }; // Track if user manually edited brand ID
       let autoSaveTimer = null;
+      let latestRegistrySetup = null;
 
       // ============================================================================
       // localStorage Auto-Save
@@ -2153,6 +2203,7 @@
 
         // Clear any previous verification result
         document.getElementById('verify-result').innerHTML = '';
+        clearRegistrySetupPanel();
 
         updatePreview();
 
@@ -3717,17 +3768,34 @@
         const config = window.__APP_CONFIG__;
         if (!config?.user) {
           btn.disabled = true;
-          btn.title = 'Log in to save to registry';
-          if (hint) { hint.textContent = 'Log in as a member to save'; hint.style.display = ''; }
+          btn.title = 'Log in to save brand setup';
+          if (hint) { hint.textContent = 'Log in as a member to save setup'; hint.style.display = ''; }
         } else if (!config.user.isMember) {
           btn.disabled = true;
           btn.title = 'Members only';
           if (hint) { hint.textContent = 'Members only'; hint.style.display = ''; }
         } else {
           btn.disabled = false;
-          btn.title = 'Save brand.json to the AgenticAdvertising.org registry';
+          btn.title = 'Save setup and get publish instructions';
           if (hint) { hint.style.display = 'none'; }
         }
+      }
+
+      function getSetupBrandName(json) {
+        if (json?.house?.name) return String(json.house.name);
+        const firstName = json?.brands?.[0]?.names?.[0]?.en;
+        if (firstName) return String(firstName);
+        return currentDomain;
+      }
+
+      function getSetupLogoUrl(json) {
+        const logoUrl = json?.brands?.[0]?.logos?.[0]?.url;
+        return typeof logoUrl === 'string' && logoUrl ? logoUrl : undefined;
+      }
+
+      function getSetupBrandColor(json) {
+        const primary = json?.brands?.[0]?.colors?.primary;
+        return typeof primary === 'string' && primary ? primary : undefined;
       }
 
       async function saveToRegistry() {
@@ -3735,44 +3803,141 @@
         const btn = document.getElementById('save-registry-btn');
         const originalText = btn.textContent;
         btn.disabled = true;
-        btn.textContent = 'Saving...';
+        btn.textContent = 'Saving setup...';
 
         try {
-          const json = generateJson();
-
-          // Try to create first
-          let response = await fetch('/api/brands/hosted', {
+          const json = finalizeJson();
+          const response = await fetch('/api/brands/setup-my-brand', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             credentials: 'include',
-            body: JSON.stringify({ brand_domain: currentDomain, brand_json: json })
+            body: JSON.stringify({
+              domain: currentDomain,
+              brand_name: getSetupBrandName(json),
+              brand_json: json,
+              logo_url: getSetupLogoUrl(json),
+              brand_color: getSetupBrandColor(json)
+            })
           });
-
-          // If already exists, update instead
-          if (response.status === 409) {
-            response = await fetch(`/api/brands/hosted/${encodeURIComponent(currentDomain)}`, {
-              method: 'PUT',
-              headers: { 'Content-Type': 'application/json' },
-              credentials: 'include',
-              body: JSON.stringify({ brand_json: json })
-            });
-          }
 
           if (!response.ok) {
             const data = await response.json().catch(() => ({}));
             throw new Error(data.error || 'Failed to save');
           }
 
-          btn.textContent = 'Saved!';
+          const setup = await response.json();
+          showRegistrySetup(setup);
+
+          btn.textContent = 'Setup saved';
           setTimeout(() => {
-            btn.textContent = originalText;
+            btn.textContent = 'Save setup';
             btn.disabled = false;
           }, 2000);
         } catch (error) {
-          alert(error.message || 'Failed to save to registry');
+          alert(error.message || 'Failed to save brand setup');
           btn.textContent = originalText;
           btn.disabled = false;
         }
+      }
+
+      function clearRegistrySetupPanel() {
+        latestRegistrySetup = null;
+        const panel = document.getElementById('registry-setup-panel');
+        if (panel) panel.classList.add('hidden');
+        const step1Title = document.getElementById('next-step-1-title');
+        const step1Copy = document.getElementById('next-step-1-copy');
+        const step2Title = document.getElementById('next-step-2-title');
+        const step2Copy = document.getElementById('next-step-2-copy');
+        const downloadBtn = document.getElementById('next-step-download-json-btn');
+        if (step1Title) step1Title.textContent = 'Download your file';
+        if (step1Copy) step1Copy.textContent = 'Save the generated brand.json to your computer.';
+        if (step2Title) step2Title.textContent = 'Upload to your website';
+        if (step2Copy) step2Copy.textContent = 'Place the file at this exact location on your server:';
+        if (downloadBtn) downloadBtn.style.display = '';
+      }
+
+      function showRegistrySetup(setup) {
+        latestRegistrySetup = setup;
+        const panel = document.getElementById('registry-setup-panel');
+        const hostedUrl = document.getElementById('registry-hosted-url');
+        const pointer = document.getElementById('pointer-snippet');
+        const deployPath = document.getElementById('deploy-path');
+        const message = document.getElementById('registry-setup-message');
+        if (!panel || !hostedUrl || !pointer || !deployPath) return;
+
+        hostedUrl.textContent = setup.hosted_brand_json_url || '';
+        pointer.textContent = setup.pointer_snippet || '{}';
+        deployPath.textContent = `https://${setup.domain || currentDomain}/.well-known/brand.json`;
+        if (message) {
+          message.textContent = setup.has_brand_json
+            ? 'Your domain already has a valid brand.json. Keep using the file on your site as the authoritative source.'
+            : 'Your brand.json is saved in the expert-run AgenticAdvertising.org registry. To make it authoritative, publish this small pointer file on your domain.';
+        }
+        panel.classList.remove('hidden');
+
+        const step1Title = document.getElementById('next-step-1-title');
+        const step1Copy = document.getElementById('next-step-1-copy');
+        const step2Title = document.getElementById('next-step-2-title');
+        const step2Copy = document.getElementById('next-step-2-copy');
+        const downloadBtn = document.getElementById('next-step-download-json-btn');
+        if (step1Title) step1Title.textContent = setup.has_brand_json ? 'brand.json is already live' : 'Registry setup saved';
+        if (step1Copy) {
+          step1Copy.textContent = setup.has_brand_json
+            ? 'The file on your domain is already the authoritative source agents will read.'
+            : 'Your full brand.json is hosted by the expert-run AgenticAdvertising.org registry. Your website only needs the pointer file above.';
+        }
+        if (step2Title) step2Title.textContent = setup.has_brand_json ? 'No pointer needed' : 'Publish the pointer file';
+        if (step2Copy) {
+          step2Copy.textContent = setup.has_brand_json
+            ? 'If you later switch to registry hosting, place the pointer file at this exact location:'
+            : 'Place the pointer file at this exact location on your server:';
+        }
+        if (downloadBtn) downloadBtn.style.display = 'none';
+        panel.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+
+      function getPointerSnippetText() {
+        return latestRegistrySetup?.pointer_snippet || document.getElementById('pointer-snippet')?.textContent || '';
+      }
+
+      function copyPointerSnippet() {
+        const snippet = getPointerSnippetText();
+        if (!snippet) return;
+        navigator.clipboard.writeText(snippet)
+          .then(() => alert('Pointer JSON copied.'))
+          .catch(() => alert('Failed to copy pointer JSON.'));
+      }
+
+      function downloadPointerJson() {
+        const snippet = getPointerSnippetText();
+        if (!snippet) return;
+        const blob = new Blob([snippet], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'brand.json';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      }
+
+      function copyWebTeamInstructions() {
+        const setup = latestRegistrySetup;
+        if (!setup) return;
+        const targetUrl = `https://${setup.domain}/.well-known/brand.json`;
+        const instructions = [
+          `Please publish this file at:`,
+          targetUrl,
+          '',
+          'Contents:',
+          setup.pointer_snippet,
+          '',
+          `This points to the brand.json hosted by the expert-run AgenticAdvertising.org registry at ${setup.hosted_brand_json_url}.`
+        ].join('\n');
+        navigator.clipboard.writeText(instructions)
+          .then(() => alert('Web team instructions copied.'))
+          .catch(() => alert('Failed to copy instructions.'));
       }
 
       async function loadFromRegistry(domain) {

--- a/server/src/integrations/google-calendar.ts
+++ b/server/src/integrations/google-calendar.ts
@@ -8,8 +8,7 @@
  * See: https://developers.google.com/calendar/api/quickstart/nodejs
  */
 
-import { calendar as buildCalendarClient, calendar_v3 } from '@googleapis/calendar';
-import { JWT, OAuth2Client } from 'google-auth-library';
+import { auth as googleAuth, calendar as buildCalendarClient, calendar_v3 } from '@googleapis/calendar';
 import { createLogger } from '../logger.js';
 
 const logger = createLogger('google-calendar');
@@ -114,7 +113,7 @@ async function getCalendarClient(): Promise<calendar_v3.Calendar> {
 
   // Prefer OAuth with refresh token
   if (GOOGLE_CLIENT_ID && GOOGLE_CLIENT_SECRET && GOOGLE_REFRESH_TOKEN) {
-    const oauth2Client = new OAuth2Client(
+    const oauth2Client = new googleAuth.OAuth2(
       GOOGLE_CLIENT_ID,
       GOOGLE_CLIENT_SECRET
     );
@@ -129,7 +128,7 @@ async function getCalendarClient(): Promise<calendar_v3.Calendar> {
 
   // Fall back to service account
   if (GOOGLE_SERVICE_ACCOUNT_EMAIL && GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY) {
-    const auth = new JWT({
+    const auth = new googleAuth.JWT({
       email: GOOGLE_SERVICE_ACCOUNT_EMAIL,
       key: GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY,
       scopes: ['https://www.googleapis.com/auth/calendar'],

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -3147,6 +3147,7 @@ registry.registerPath({
           schema: z.object({
             domain: z.string().openapi({ example: "acmecorp.com" }),
             brand_name: z.string(),
+            brand_json: z.record(z.string(), z.any()).optional().openapi({ description: "Optional full brand.json draft to host in the registry" }),
             logo_url: z.string().optional(),
             brand_color: z.string().optional(),
           }),
@@ -8530,7 +8531,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
   const setupBrandMiddleware = authMiddleware ? [authMiddleware, brandCreationRateLimiter] : [brandCreationRateLimiter];
 
   router.post("/brands/setup-my-brand", ...setupBrandMiddleware, async (req, res) => {
-    const { brand_name, logo_url, brand_color } = req.body;
+    const { brand_name, logo_url, brand_color, brand_json } = req.body;
     const rawDomain = req.body.domain as string;
 
     if (!rawDomain || typeof rawDomain !== "string") {
@@ -8538,6 +8539,15 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
     }
     if (!brand_name || typeof brand_name !== "string") {
       return res.status(400).json({ error: "brand_name is required" });
+    }
+    if (
+      brand_json !== undefined
+      && (typeof brand_json !== "object" || brand_json === null || Array.isArray(brand_json))
+    ) {
+      return res.status(400).json({ error: "brand_json must be a JSON object" });
+    }
+    if (brand_json !== undefined && JSON.stringify(brand_json).length > 100 * 1024) {
+      return res.status(400).json({ error: "brand_json exceeds maximum size (100KB)" });
     }
 
     const domain = extractDomain(rawDomain).replace(/^www\./, "");
@@ -8587,7 +8597,9 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         // Otherwise build a minimal entry from the request params.
         let brandJson: Record<string, unknown>;
         const manifest = discovered?.brand_manifest as Record<string, unknown> | undefined;
-        if (manifest && discovered!.review_status !== 'pending' && typeof manifest.house === 'object' && manifest.house !== null) {
+        if (brand_json) {
+          brandJson = brand_json as Record<string, unknown>;
+        } else if (manifest && discovered!.review_status !== 'pending' && typeof manifest.house === 'object' && manifest.house !== null) {
           brandJson = manifest;
         } else {
           const brandId = brand_name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '');

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -8573,7 +8573,12 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       // Verify the requested domain belongs to this org (matches a WorkOS-verified domain or subdomain).
       // Skipped in dev mode (DEV_USER_EMAIL set) since dev orgs are not in WorkOS.
       const devMode = !!(process.env.DEV_USER_EMAIL && process.env.DEV_USER_ID);
-      if (!devMode && orgId) {
+      if (!devMode && !orgId) {
+        return res.status(403).json({
+          error: 'A verified organization is required to set up a brand',
+        });
+      }
+      if (!devMode) {
         const orgDomainsResult = await query<{ domain: string }>(
           'SELECT domain FROM organization_domains WHERE workos_organization_id = $1 AND verified = true',
           [orgId]

--- a/server/tests/unit/registry-brand-setup-route.test.ts
+++ b/server/tests/unit/registry-brand-setup-route.test.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import request from 'supertest';
 
 const resolvePrimaryOrganizationMock = vi.fn();
+const queryMock = vi.fn();
 const ORIGINAL_DEV_USER_EMAIL = process.env.DEV_USER_EMAIL;
 const ORIGINAL_DEV_USER_ID = process.env.DEV_USER_ID;
 
@@ -13,6 +14,10 @@ vi.hoisted(() => {
 
 vi.mock('../../src/db/users-db.js', () => ({
   resolvePrimaryOrganization: (userId: string) => resolvePrimaryOrganizationMock(userId),
+}));
+
+vi.mock('../../src/db/client.js', () => ({
+  query: (...args: unknown[]) => queryMock(...args),
 }));
 
 import { createRegistryApiRouter, type RegistryApiConfig } from '../../src/routes/registry-api.js';
@@ -54,6 +59,7 @@ describe('POST /api/brands/setup-my-brand', () => {
     process.env.DEV_USER_EMAIL = 'dev@test.example';
     process.env.DEV_USER_ID = 'user_test';
     resolvePrimaryOrganizationMock.mockResolvedValue('org_test');
+    queryMock.mockResolvedValue({ rows: [] });
   });
 
   afterEach(() => {
@@ -116,5 +122,63 @@ describe('POST /api/brands/setup-my-brand', () => {
 
     expect(res.status).toBe(400);
     expect(res.body.error).toBe('brand_json must be a JSON object');
+  });
+
+  it('denies non-dev callers without a resolvable organization', async () => {
+    delete process.env.DEV_USER_EMAIL;
+    delete process.env.DEV_USER_ID;
+    resolvePrimaryOrganizationMock.mockResolvedValue(null);
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn(),
+      getHostedBrandByDomain: vi.fn(),
+      createHostedBrand: vi.fn(),
+    };
+
+    const res = await request(buildApp(brandDb))
+      .post('/api/brands/setup-my-brand')
+      .send({
+        domain: 'victim.example',
+        brand_name: 'Victim',
+        brand_json: {
+          house: { domain: 'victim.example', name: 'Victim' },
+          brands: [{ id: 'victim', names: [{ en: 'Victim' }], keller_type: 'master' }],
+        },
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('A verified organization is required to set up a brand');
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(brandDb.createHostedBrand).not.toHaveBeenCalled();
+  });
+
+  it('denies non-dev callers whose organization does not own the requested domain', async () => {
+    delete process.env.DEV_USER_EMAIL;
+    delete process.env.DEV_USER_ID;
+    resolvePrimaryOrganizationMock.mockResolvedValue('org_test');
+    queryMock.mockResolvedValue({ rows: [{ domain: 'owned.example' }] });
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn(),
+      getHostedBrandByDomain: vi.fn(),
+      createHostedBrand: vi.fn(),
+    };
+
+    const res = await request(buildApp(brandDb))
+      .post('/api/brands/setup-my-brand')
+      .send({
+        domain: 'victim.example',
+        brand_name: 'Victim',
+        brand_json: {
+          house: { domain: 'victim.example', name: 'Victim' },
+          brands: [{ id: 'victim', names: [{ en: 'Victim' }], keller_type: 'master' }],
+        },
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('This domain is not associated with your organization');
+    expect(queryMock).toHaveBeenCalledWith(
+      'SELECT domain FROM organization_domains WHERE workos_organization_id = $1 AND verified = true',
+      ['org_test']
+    );
+    expect(brandDb.createHostedBrand).not.toHaveBeenCalled();
   });
 });

--- a/server/tests/unit/registry-brand-setup-route.test.ts
+++ b/server/tests/unit/registry-brand-setup-route.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+const resolvePrimaryOrganizationMock = vi.fn();
+const ORIGINAL_DEV_USER_EMAIL = process.env.DEV_USER_EMAIL;
+const ORIGINAL_DEV_USER_ID = process.env.DEV_USER_ID;
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY || 'sk_test_registry_brand_setup';
+  process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID || 'client_test_registry_brand_setup';
+});
+
+vi.mock('../../src/db/users-db.js', () => ({
+  resolvePrimaryOrganization: (userId: string) => resolvePrimaryOrganizationMock(userId),
+}));
+
+import { createRegistryApiRouter, type RegistryApiConfig } from '../../src/routes/registry-api.js';
+
+function buildApp(brandDb: Partial<RegistryApiConfig['brandDb']>, brandManager: Partial<RegistryApiConfig['brandManager']> = {}) {
+  const app = express();
+  app.use(express.json());
+
+  const requireAuth: import('express').RequestHandler = (req, _res, next) => {
+    req.user = { id: 'user_test', email: 'user@test.example' } as typeof req.user;
+    next();
+  };
+
+  app.use('/api', createRegistryApiRouter({
+    brandManager: {
+      validateDomain: vi.fn().mockResolvedValue({ valid: false, errors: [] }),
+      ...brandManager,
+    } as RegistryApiConfig['brandManager'],
+    brandDb: brandDb as RegistryApiConfig['brandDb'],
+    propertyDb: {} as RegistryApiConfig['propertyDb'],
+    adagentsManager: {} as RegistryApiConfig['adagentsManager'],
+    healthChecker: {} as RegistryApiConfig['healthChecker'],
+    crawler: {} as RegistryApiConfig['crawler'],
+    capabilityDiscovery: {} as RegistryApiConfig['capabilityDiscovery'],
+    registryRequestsDb: {
+      trackRequest: async () => {},
+      markResolved: async () => true,
+    },
+    requireAuth,
+    optionalAuth: requireAuth,
+  }));
+
+  return app;
+}
+
+describe('POST /api/brands/setup-my-brand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.DEV_USER_EMAIL = 'dev@test.example';
+    process.env.DEV_USER_ID = 'user_test';
+    resolvePrimaryOrganizationMock.mockResolvedValue('org_test');
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_DEV_USER_EMAIL === undefined) {
+      delete process.env.DEV_USER_EMAIL;
+    } else {
+      process.env.DEV_USER_EMAIL = ORIGINAL_DEV_USER_EMAIL;
+    }
+    if (ORIGINAL_DEV_USER_ID === undefined) {
+      delete process.env.DEV_USER_ID;
+    } else {
+      process.env.DEV_USER_ID = ORIGINAL_DEV_USER_ID;
+    }
+  });
+
+  it('hosts the full builder draft and returns the pointer snippet', async () => {
+    const brandJson = {
+      house: { domain: 'example.com', name: 'Example' },
+      brands: [{ id: 'example', names: [{ en: 'Example' }], keller_type: 'master' }],
+    };
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(null),
+      getHostedBrandByDomain: vi.fn().mockResolvedValue(null),
+      createHostedBrand: vi.fn().mockResolvedValue({ id: 'brand_1' }),
+    };
+
+    const res = await request(buildApp(brandDb))
+      .post('/api/brands/setup-my-brand')
+      .send({
+        domain: 'example.com',
+        brand_name: 'Example',
+        brand_json: brandJson,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      domain: 'example.com',
+      has_brand_json: false,
+      hosted_brand_json_url: 'https://agenticadvertising.org/brands/example.com/brand.json',
+      pointer_snippet: '{\n  "authoritative_location": "https://agenticadvertising.org/brands/example.com/brand.json"\n}',
+    });
+    expect(brandDb.createHostedBrand).toHaveBeenCalledWith(expect.objectContaining({
+      workos_organization_id: 'org_test',
+      created_by_user_id: 'user_test',
+      created_by_email: 'user@test.example',
+      brand_domain: 'example.com',
+      brand_json: brandJson,
+      is_public: true,
+    }));
+  });
+
+  it('rejects non-object brand_json drafts', async () => {
+    const res = await request(buildApp({}))
+      .post('/api/brands/setup-my-brand')
+      .send({
+        domain: 'example.com',
+        brand_name: 'Example',
+        brand_json: 'not-json',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('brand_json must be a JSON object');
+  });
+});

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -8920,6 +8920,10 @@ paths:
                   example: acmecorp.com
                 brand_name:
                   type: string
+                brand_json:
+                  type: object
+                  additionalProperties: {}
+                  description: Optional full brand.json draft to host in the registry
                 logo_url:
                   type: string
                 brand_color:


### PR DESCRIPTION
This PR lets the brand builder save the full generated brand.json through /api/brands/setup-my-brand and returns pointer-file instructions for authoritative publication.

It updates the success UX to describe the expert-run AgenticAdvertising.org registry, hides the full-download CTA after setup, adds OpenAPI coverage, and adds focused route tests.

It also fixes the Google Calendar auth type mismatch by constructing OAuth and JWT clients from @googleapis/calendar's own auth surface, matching the generated Calendar client types.

Validation: focused unit test, inline builder syntax check, browser E2E locally, browser E2E against Docker Compose, git diff --check, full precommit hook, and pre-push version/changeset checks passed.