### PR TITLE
Fix storyboard idempotency false failures

### DIFF
--- a/.changeset/storyboard-idempotency-schema-validation-fixes.md
+++ b/.changeset/storyboard-idempotency-schema-validation-fixes.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix two universal storyboard false failures: remove runner-only webhook URL templating from the core idempotency replay requests while preserving webhook replay side-effect coverage in the webhook-emission universal, and spell out the schema-validation past-start contribution flag for runners that do not normalize `contributes: true` shorthand before grading.

--- a/scripts/lint-storyboard-validations-paths.cjs
+++ b/scripts/lint-storyboard-validations-paths.cjs
@@ -110,6 +110,10 @@ function loadSchema(ref) {
   return doc;
 }
 
+function isRuntimeSchemaRef(ref) {
+  return typeof ref === 'string' && ref.startsWith('$test_kit.');
+}
+
 /**
  * `core/protocol-envelope.json` and `core/version-envelope.json` define
  * fields wrapping or mixed into every task response — `status`, `task_id`,
@@ -379,8 +383,34 @@ function lintDoc(doc, filePath, allowlist = []) {
   const violations = [];
   if (!doc) return violations;
   for (const step of findStepsWithValidations(doc, [])) {
+    const pathValidations = step.validations
+      .map((v, index) => ({ v, index }))
+      .filter(({ v }) => {
+        if (!v || typeof v !== 'object') return false;
+        if (!PATH_BEARING_CHECKS.has(v.check)) return false;
+        return typeof v.path === 'string' && v.path.length > 0;
+      });
+    if (pathValidations.length === 0) continue;
+
     const fullSchema = loadSchema(step.responseRef);
     if (!fullSchema) {
+      if (isRuntimeSchemaRef(step.responseRef)) {
+        for (const { v, index } of pathValidations) {
+          const segments = parsePath(v.path);
+          if (pathResolvesAgainstAnyEnvelope(segments)) continue;
+          if (isAllowlisted(allowlist, filePath, step.stepId, v.path)) continue;
+          violations.push({
+            rule: 'runtime_response_schema_unresolved_path',
+            filePath,
+            stepId: step.stepId,
+            responseRef: step.responseRef,
+            validationPath: v.path,
+            check: v.check,
+            index,
+          });
+        }
+        continue;
+      }
       violations.push({
         rule: 'response_schema_not_found',
         filePath,
@@ -401,12 +431,8 @@ function lintDoc(doc, filePath, allowlist = []) {
       continue;
     }
     const schema = armResult.schema;
-    for (let i = 0; i < step.validations.length; i++) {
-      const v = step.validations[i];
-      if (!v || typeof v !== 'object') continue;
-      if (!PATH_BEARING_CHECKS.has(v.check)) continue;
+    for (const { v, index: i } of pathValidations) {
       const rawPath = v.path;
-      if (typeof rawPath !== 'string' || rawPath.length === 0) continue;
       const segments = parsePath(rawPath);
       if (segments.includes('*') && v.check !== 'field_contains') {
         violations.push({
@@ -493,6 +519,10 @@ const RULE_MESSAGES = {
     '`scripts/storyboard-validations-paths-allowlist.json` with a `reason` string.',
   response_schema_not_found: ({ responseRef }) =>
     `response_schema_ref \`${responseRef}\` could not be loaded — fix the ref or the schema path.`,
+  runtime_response_schema_unresolved_path: ({ validationPath, responseRef, check }) =>
+    `validations[].path \`${validationPath}\` (check: \`${check}\`) uses runtime response_schema_ref ` +
+    `\`${responseRef}\`, so the source-tree lint can only validate protocol envelope fields. ` +
+    'Use an envelope field, a concrete response_schema_ref, or add a documented allowlist entry.',
   unknown_expected_arm: ({ expectedArm, responseRef }) =>
     `expected_arm \`${expectedArm}\` does not match any oneOf/anyOf branch in \`${responseRef}\`. ` +
     'Match rule: a branch must declare some property with `const: "<expected_arm>"`. ' +

--- a/static/compliance/source/test-kits/webhook-receiver-runner.yaml
+++ b/static/compliance/source/test-kits/webhook-receiver-runner.yaml
@@ -3,16 +3,15 @@
 # Applies to:
 #   - universal/webhook-emission.yaml (primary consumer — grades outbound
 #     webhook conformance: operation_id echo, idempotency_key presence,
-#     stability across retries, and RFC 9421 signature validity when 9421 is in
-#     effect)
-#   - universal/idempotency.yaml (replay-side-effect invariant — "no duplicate
-#     webhooks on replay" step is gated on this contract being in scope)
+#     stability across retries, idempotency replay side effects, and RFC 9421
+#     signature validity when 9421 is in effect)
 #   - Any future storyboard that needs to observe outbound webhooks.
 #
 # The webhook-emission universal grades an agent's outbound-webhook
 # conformance: operation_id echo, idempotency_key presence and stability
-# across retries, and — when the 9421 webhook profile is in effect — RFC 9421
-# signature validity per docs/building/implementation/security.mdx#webhook-callbacks.
+# across retries, absence of duplicate webhooks on request replay, and — when
+# the 9421 webhook profile is in effect — RFC 9421 signature validity per
+# docs/building/implementation/security.mdx#webhook-callbacks.
 #
 # Storyboards are unidirectional by default (runner → agent). Verifying what
 # the agent sends back requires the runner to host a webhook receiver during
@@ -29,7 +28,6 @@ id: webhook_receiver_runner
 applies_to:
   universals:
     - webhook-emission
-    - idempotency
 
 description: |
   Coordination contract between a black-box runner hosting a webhook receiver
@@ -37,8 +35,8 @@ description: |
   endpoints, injects them into push_notification_config.url on the steps that
   trigger webhooks, observes incoming deliveries via @adcp/client AsyncHandler
   hooks, and asserts on operation_id echo, idempotency_key presence,
-  idempotency_key stability across retries, and (when advertised) 9421
-  signature validity.
+  idempotency_key stability across retries, absence of duplicate webhooks on
+  request replay, and (when advertised) 9421 signature validity.
 
 endpoint_scope: sandbox
 # Storyboards that drive webhook emission typically call spend-committing

--- a/static/compliance/source/universal/idempotency.yaml
+++ b/static/compliance/source/universal/idempotency.yaml
@@ -38,7 +38,7 @@ narrative: |
 
   1. First call with a fresh key is processed normally and returns the canonical response.
   2. Replay with the same key and an equivalent payload returns the cached response
-     without re-executing side effects (same media_buy_id, no new webhooks fired).
+     without re-executing resource mutations (same media_buy_id).
   3. Replay with the same key but a materially different payload is rejected with
      IDEMPOTENCY_CONFLICT. The buyer has clearly reused a key by mistake.
   4. A request with a different key is treated as a new request, even if the payload
@@ -85,6 +85,12 @@ narrative: |
   rate-limit error forever, defeating the point of `retry_after`. The
   threshold (60/300 req/sec) remains seller self-attestation pending
   operator-side tooling.
+
+  **Webhook side effects are graded separately.** A replay MUST NOT duplicate
+  outbound webhook fires, but observing that side effect requires a runner-hosted
+  webhook receiver. The webhook-specific replay assertion lives in
+  universal/webhook-emission.yaml so this core idempotency storyboard remains
+  runnable by agents and runners that do not host receiver URLs.
 
 agent:
   interaction_model: media_buy_seller
@@ -307,17 +313,6 @@ phases:
             - product_id: "test-product"
               budget: 5000
               pricing_option_id: "test-pricing"
-          # Both the initial call and the replay below use the SAME webhook URL
-          # so the canonical payload hash matches across the two calls. A
-          # different URL between the two requests would hash differently and
-          # trip IDEMPOTENCY_CONFLICT instead of exercising replay. The URL
-          # template resolves against the runner's ephemeral webhook receiver
-          # (webhook_receiver_runner contract); runners without a receiver
-          # grade `no_duplicate_webhooks_on_replay` as not_applicable.
-          push_notification_config:
-            url: "{{runner.webhook_url:create_media_buy_initial}}"
-            operation_id: "op_idempotency_replay_initial"
-
           context:
             correlation_id: "idempotency--create_media_buy_initial"
         validations:
@@ -351,8 +346,8 @@ phases:
         narrative: |
           Re-send the exact same create_media_buy request — same idempotency_key,
           same payload, same everything. The seller MUST return the same media_buy_id
-          from the prior step. It MUST NOT create a second media buy or fire a
-          second set of webhooks. This is the whole point of idempotency_key.
+          from the prior step. It MUST NOT create a second media buy. This is
+          the whole point of idempotency_key.
         task: create_media_buy
         schema_ref: "media-buy/create-media-buy-request.json"
         response_schema_ref: "media-buy/create-media-buy-response.json"
@@ -362,15 +357,7 @@ phases:
         expected: |
           Return the cached response from the initial request:
           - media_buy_id: same as $context.initial_media_buy_id
-          - No new side effects (no duplicate webhooks, no new audit log entry)
-
-          Programmatic verification of "no duplicate webhooks" runs in the next step
-          (no_duplicate_webhooks_on_replay) when the storyboard is driven by a runner
-          that implements the webhook_receiver_runner contract. Runners without a
-          webhook receiver grade that step as not_applicable — agents MAY still claim
-          idempotency compliance, but the replay-side-effect invariant is only
-          programmatically graded when the webhook_callbacks specialism is also in
-          scope.
+          - No new side effects (no duplicate audit log entry or resource mutation)
 
         sample_request:
           idempotency_key: "$generate:uuid_v4#replay_key"
@@ -386,14 +373,6 @@ phases:
             - product_id: "test-product"
               budget: 5000
               pricing_option_id: "test-pricing"
-          # Byte-identical to the initial call above — same URL, same step id
-          # token and same explicit operation_id — so the canonical payload
-          # hash matches and the request lands on the replay branch rather
-          # than IDEMPOTENCY_CONFLICT.
-          push_notification_config:
-            url: "{{runner.webhook_url:create_media_buy_initial}}"
-            operation_id: "op_idempotency_replay_initial"
-
           context:
             correlation_id: "idempotency--create_media_buy_replay"
         validations:
@@ -418,55 +397,6 @@ phases:
             path: "context.correlation_id"
             value: "idempotency--create_media_buy_replay"
             description: "Context correlation_id returned unchanged"
-
-      - id: no_duplicate_webhooks_on_replay
-        title: "No duplicate webhooks fired across initial + replay"
-        narrative: |
-          The central invariant of idempotency: replaying with the same key MUST
-          NOT produce duplicate side effects. Webhook emission is the observable
-          side effect most likely to leak if the seller re-executes on replay
-          instead of returning cached state.
-
-          This step requires the storyboard runner to implement the
-          `webhook_receiver_runner` contract at
-          `test-kits/webhook-receiver-runner.yaml`. Runners without a webhook
-          receiver skip this step with a stable not_applicable marker; the
-          replay-side-effect invariant then relies on the next phase's cached-
-          response assertions plus manual audit of the seller's webhook
-          delivery history.
-
-          When the receiver IS in scope, the runner counts webhooks arriving at
-          {{runner.webhook_url:create_media_buy_initial}} across the initial
-          call's window AND the replay call's window. A conformant seller emits
-          webhooks only on the first execution; a non-conformant seller that
-          re-executes on replay emits a second set, catchable only by live
-          observation.
-        task: expect_webhook
-        # `triggered_by` points at the initial call (not the replay) because
-        # both calls share the initial step's receiver URL and explicit
-        # operation_id. The execution-order wait still spans the replay window:
-        # this step runs after `create_media_buy_replay` in YAML order and
-        # `wait_all` drains the full `timeout_seconds` so any webhook re-fired
-        # by the replay is captured and counted against the cap below. A
-        # non-conformant seller that re-executes on replay would deliver a
-        # second webhook with a fresh idempotency_key and trip
-        # `duplicate_webhook_on_replay`.
-        triggered_by: create_media_buy_initial
-        filter:
-          body:
-            operation_id: "op_idempotency_replay_initial"
-        timeout_seconds: 30
-        expect_max_deliveries_per_logical_event: 1
-        requires_contract: webhook_receiver_runner
-        stateful: true
-        expected: |
-          At most one logical webhook event delivered for the create_media_buy
-          operation across both the initial and replay windows. If the runner
-          observes a second webhook delivery tagged with a distinct
-          idempotency_key but the same media_buy_id/operation_id, the seller is
-          re-executing on replay and the step fails with
-          duplicate_webhook_on_replay. Not_applicable when the runner does not
-          host a webhook receiver.
 
       - id: create_media_buy_conflict
         title: "Same key, different payload returns IDEMPOTENCY_CONFLICT"

--- a/static/compliance/source/universal/schema-validation.yaml
+++ b/static/compliance/source/universal/schema-validation.yaml
@@ -425,7 +425,7 @@ phases:
         expect_error: true
         negative_path: payload_well_formed
         stateful: false
-        contributes: true
+        contributes_to: past_start_handled
         expected: |
           Reject the request with:
           - Error code: INVALID_REQUEST
@@ -492,7 +492,7 @@ phases:
         doc_ref: "/media-buy/task-reference/create_media_buy"
         comply_scenario: temporal_validation
         stateful: false
-        contributes: true
+        contributes_to: past_start_handled
         expected: |
           Accept the request with auto-adjusted dates:
           - Response matches create-media-buy-response.json schema

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -617,12 +617,14 @@
 #                         that a later assert_contribution step can require)
 # contributes: boolean (optional — shorthand for `contributes_to: <enclosing phase's branch_set.id>`
 #                       introduced alongside first-class `branch_set:` declarations.
-#                       Legal only inside a phase that declares `branch_set:`; the runner's
-#                       loader resolves `contributes: true` to the phase's branch_set.id
-#                       and raises a storyboard-load error on `contributes: true` outside
+#                       Legal only inside a phase that declares `branch_set:`; current
+#                       SDK runners resolve `contributes: true` to the phase's branch_set.id
+#                       and raise a storyboard-load error on `contributes: true` outside
 #                       a branch_set phase or on a step that also declares `contributes_to`.
-#                       See adcp-client#693 and `lint:storyboard-branch-sets` for the
-#                       full rule set.)
+#                       Use explicit `contributes_to` when a storyboard must remain
+#                       compatible with older runners that grade before loader
+#                       normalization. See adcp-client#693 and
+#                       `lint:storyboard-branch-sets` for the full rule set.)
 # contributes_if: string (optional — runner-evaluated expression gating the contribution)
 #   Supported grammar (single form; not a general-purpose DSL):
 #     "prior_step.<step_id>.passed"   → true if the named prior step in the same storyboard passed
@@ -906,10 +908,11 @@
 #   `@adcp/client` 5.8.0+ also accepts the boolean shorthand
 #   `contributes: true` on a step inside a branch_set phase — the runner's
 #   loader resolves it to the enclosing phase's `branch_set.id`. The two
-#   forms are semantically identical; `contributes: true` is preferred
-#   inside a branch_set phase because it eliminates the typo surface (the
-#   string form must equal `branch_set.id` exactly). Authors may use
-#   either; the lint enforces both.
+#   forms are semantically identical in current SDK runners. Use explicit
+#   `contributes_to: <branch_set.id>` for storyboards that need to run against
+#   older graders that may inspect the field before loader normalization;
+#   use `contributes: true` only when the target runner line is known to
+#   support shorthand normalization. The lint enforces both forms.
 #
 #   New storyboards MUST declare branch-set membership with a `branch_set:`
 #   object. The implicit-detection fallback below exists only so pre-#2633
@@ -925,11 +928,13 @@
 #   Per-step contribution signalling is REQUIRED on each contributing step —
 #   the phase-level `branch_set:` declares membership but does not replace
 #   the step-level flag. Runners accumulate contributions at the step level.
-#   Two equivalent forms:
-#     - `contributes: true` (preferred inside a branch_set phase; resolves
-#       to the enclosing phase's `branch_set.id`)
-#     - `contributes_to: <branch_set.id>` (string form; required outside a
-#       branch_set phase and must equal `branch_set.id` inside one)
+#   Two equivalent forms in current SDK runners:
+#     - `contributes_to: <branch_set.id>` (compatibility-safe string form;
+#       required outside a branch_set phase and must equal `branch_set.id`
+#       inside one)
+#     - `contributes: true` (shorthand inside a branch_set phase; resolves
+#       to the enclosing phase's `branch_set.id` on runners that support
+#       shorthand normalization)
 #
 #   Authoring rules (enforced by `lint:storyboard-branch-sets`):
 #     - A phase with `branch_set:` MUST set `optional: true`. A
@@ -1896,8 +1901,9 @@
 # for the reference contract (endpoint modes, retry-replay shape, client-primitive
 # hooks). Storyboard authors MUST declare the contract in prerequisites; the
 # webhook-emission universal (universal/webhook-emission.yaml) is the reference
-# consumer, and universal/idempotency.yaml uses it for the "no duplicate webhooks
-# on replay" assertion.
+# consumer, including idempotency replay side-effect assertions that need
+# webhook observation. Keep those assertions on webhook-specific storyboards so
+# core idempotency requests do not depend on runner-only URL templating.
 #
 # --- Substitution variables (webhook-receiver enabled) ---
 #

--- a/static/compliance/source/universal/webhook-emission.yaml
+++ b/static/compliance/source/universal/webhook-emission.yaml
@@ -1,8 +1,8 @@
 id: webhook_emission
-version: "1.2.0"
+version: "1.3.0"
 title: "Webhook emission — outbound webhook conformance (operation ID + signing + idempotency + sync silence)"
 category: core
-summary: "Any agent that emits webhooks MUST echo the caller-supplied operation_id in every payload, carry a stable idempotency_key across retries, and — when the buyer has not opted into the deprecated HMAC fallback — MUST sign deliveries under the RFC 9421 webhook profile. Sellers MUST NOT emit task webhooks for inline terminal responses; any future sync-completion notification mode would be explicit and capability-advertised. Graded by a runner hosting a webhook receiver during storyboard execution."
+summary: "Any agent that emits webhooks MUST echo the caller-supplied operation_id in every payload, carry a stable idempotency_key across retries, avoid duplicate webhook side effects on request replay, and — when the buyer has not opted into the deprecated HMAC fallback — MUST sign deliveries under the RFC 9421 webhook profile. Sellers MUST NOT emit task webhooks for inline terminal responses; any future sync-completion notification mode would be explicit and capability-advertised. Graded by a runner hosting a webhook receiver during storyboard execution."
 track: core
 
 narrative: |
@@ -13,8 +13,8 @@ narrative: |
   Every agent that accepts `push_notification_config` on any operation is in
   scope for this universal — no capability flag, no opt-in.
 
-  Four load-bearing conformance requirements apply across this universal. The
-  first three apply to emitted outbound webhooks; the fourth guards the absence
+  Five load-bearing conformance requirements apply across this universal. The
+  first four apply to emitted outbound webhooks; the fifth guards the absence
   of task webhooks on synchronous completions:
 
   1. **`operation_id` echoes the caller-supplied value from
@@ -27,13 +27,17 @@ narrative: |
      a sender that regenerates the key on retry breaks at-least-once delivery
      semantics and creates duplicate side effects downstream.
 
-  3. **RFC 9421 webhook signing is baseline in 3.0** unless the buyer opts into
+  3. **Idempotency replay does not duplicate outbound webhook side effects.**
+     Replaying the same operation request with the same idempotency_key MUST
+     return the cached response and MUST NOT emit a second logical webhook.
+
+  4. **RFC 9421 webhook signing is baseline in 3.0** unless the buyer opts into
      the deprecated HMAC fallback via `push_notification_config.authentication`.
      Required by adcontextprotocol/adcp#2423. Signatures carry
      `tag="adcp/webhook-signing/v1"`, cover `content-digest`, and verify
      against the seller's brand.json-published JWKS.
 
-  4. **Synchronous completions do not emit task webhooks.**
+  5. **Synchronous completions do not emit task webhooks.**
      `push_notification_config` registers a notification channel for operations
      whose initial response is non-terminal (`working` or `submitted`); it does
      not ask the seller to duplicate an inline terminal result onto the webhook
@@ -279,6 +283,98 @@ phases:
           status, and result shape required by the schema; any task status is
           acceptable because every webhook for the operation must echo the
           registered operation_id.
+
+  - id: idempotency_replay_side_effects
+    title: "Idempotency replay does not duplicate webhook side effects"
+    narrative: |
+      The runner triggers a webhook-emitting operation, then replays the exact
+      same request with the same idempotency_key and same webhook registration.
+      The seller MUST return the cached task response and MUST NOT re-execute
+      outbound webhook side effects on replay.
+
+      This check lives in the webhook-emission universal rather than the core
+      idempotency universal because it depends on runner-hosted webhook URL
+      substitution. Core idempotency remains runnable by agents and runners
+      that do not host a webhook receiver; webhook side-effect idempotency is
+      graded here when the receiver contract is in scope.
+
+    steps:
+      - id: trigger_idempotent_webhook_initial
+        title: "Trigger a webhook-emitting operation with a fresh idempotency key"
+        narrative: |
+          Runner calls a webhook-emitting operation with a fresh idempotency_key
+          and a receiver URL. This first request establishes the cached response
+          and the single logical webhook event that the replay below must not
+          duplicate.
+        task: "$test_kit.operations.primary_webhook_emitter"
+        task_default: create_media_buy
+        schema_ref: "$test_kit.schemas.primary_request"
+        response_schema_ref: "$test_kit.schemas.primary_response"
+        doc_ref: "/building/implementation/webhooks"
+        comply_scenario: webhook_idempotency_replay_trigger
+        stateful: true
+        sample_request:
+          push_notification_config:
+            url: "{{runner.webhook_url:trigger_idempotent_webhook_initial}}"
+            operation_id: "op_webhook_idempotency_replay"
+          idempotency_key: "$generate:uuid_v4#webhook_emission_replay_key"
+          context:
+            correlation_id: "webhook_emission--idempotent_replay_initial"
+        expected: |
+          Agent accepts the request and emits at most one logical webhook event
+          for this operation.
+
+      - id: trigger_idempotent_webhook_replay
+        title: "Replay the same request with the same idempotency key"
+        narrative: |
+          Runner re-sends the same logical request: same idempotency_key, same
+          payload, same webhook receiver URL, and same explicit operation_id.
+          The seller must return the cached response and must not emit another
+          webhook for the replay.
+        task: "$test_kit.operations.primary_webhook_emitter"
+        task_default: create_media_buy
+        schema_ref: "$test_kit.schemas.primary_request"
+        response_schema_ref: "$test_kit.schemas.primary_response"
+        doc_ref: "/building/implementation/webhooks"
+        comply_scenario: webhook_idempotency_replay_trigger
+        stateful: true
+        sample_request:
+          push_notification_config:
+            url: "{{runner.webhook_url:trigger_idempotent_webhook_initial}}"
+            operation_id: "op_webhook_idempotency_replay"
+          idempotency_key: "$generate:uuid_v4#webhook_emission_replay_key"
+          context:
+            correlation_id: "webhook_emission--idempotent_replay_replay"
+        validations:
+          - check: field_value
+            path: "replayed"
+            value: true
+            description: "Replay resolves from the idempotency cache"
+        expected: |
+          Agent returns the cached response for the original operation without
+          re-executing outbound webhook side effects.
+
+      - id: expect_no_duplicate_webhook_on_replay
+        title: "Assert replay did not duplicate the logical webhook"
+        narrative: |
+          The runner counts webhooks arriving at the initial request's receiver
+          URL across both the initial and replay windows. A conformant seller
+          emits the logical webhook at most once; a seller that re-executes on
+          replay emits a second event and fails this step.
+        task: expect_webhook
+        triggered_by: trigger_idempotent_webhook_initial
+        filter:
+          body:
+            operation_id: "op_webhook_idempotency_replay"
+        timeout_seconds: 30
+        expect_max_deliveries_per_logical_event: 1
+        webhook_payload_schema_ref: "core/mcp-webhook-payload.json"
+        stateful: true
+        expected: |
+          At most one logical webhook event is delivered for the operation
+          across the initial request and idempotency replay. Duplicate delivery
+          with a distinct webhook idempotency_key but the same operation_id
+          fails as duplicate_webhook_on_replay.
 
   - id: synchronous_completion_success_path
     title: "Synchronous-only reads stay terminal when accepted"

--- a/tests/lint-storyboard-validations-paths.test.cjs
+++ b/tests/lint-storyboard-validations-paths.test.cjs
@@ -297,6 +297,61 @@ test('envelope-aware resolution: replayed and adcp_error resolve via protocol-en
   );
 });
 
+test('runtime test-kit response refs allow envelope-only path assertions', () => {
+  const violations = lintDoc({
+    phases: [
+      {
+        id: 'p',
+        steps: [
+          {
+            id: 'webhook_replay',
+            task: '$test_kit.operations.primary_webhook_emitter',
+            response_schema_ref: '$test_kit.schemas.primary_response',
+            validations: [
+              {
+                check: 'field_value',
+                path: 'replayed',
+                value: true,
+                description: 'Replay resolves from the idempotency cache',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  }, '/synth/test.yaml');
+
+  assert.deepEqual(violations, []);
+});
+
+test('runtime test-kit response refs still flag non-envelope path assertions', () => {
+  const violations = lintDoc({
+    phases: [
+      {
+        id: 'p',
+        steps: [
+          {
+            id: 'webhook_replay',
+            task: '$test_kit.operations.primary_webhook_emitter',
+            response_schema_ref: '$test_kit.schemas.primary_response',
+            validations: [
+              {
+                check: 'field_present',
+                path: 'media_buy_id',
+                description: 'Body fields require a concrete response schema',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  }, '/synth/test.yaml');
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].rule, 'runtime_response_schema_unresolved_path');
+  assert.equal(violations[0].validationPath, 'media_buy_id');
+});
+
 test('source tree allows envelope_field_absent for protocol-envelope forbidden fields', () => {
   const violations = lintDoc({
     phases: [


### PR DESCRIPTION
Fixes two storyboard false failures reported by conformance runs: core idempotency no longer sends runner-only webhook URL templates in create_media_buy replay requests, and schema-validation uses explicit `contributes_to` for past-start branch contributions.

Webhook replay side-effect coverage is preserved in `webhook_emission` with a receiver-scoped idempotency replay phase, and the webhook receiver/test-kit authoring docs now point to that location.

Validation: `npm run build:compliance -- --check`, storyboard branch-set/test-kit/sample-request lints, local idempotency/schema-validation runs, precommit unit/typecheck hook, and pre-push current plus 3.0 compatibility storyboard matrices.