### PR TITLE
fix(domains): enforce one primary organization domain

### DIFF
--- a/.changeset/cold-numbers-share.md
+++ b/.changeset/cold-numbers-share.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix primary organization domain invariant enforcement.

--- a/server/src/db/migrations/509_unique_primary_organization_domain.sql
+++ b/server/src/db/migrations/509_unique_primary_organization_domain.sql
@@ -1,0 +1,80 @@
+-- Enforce the invariant that an organization has at most one
+-- organization_domains.is_primary=true row.
+--
+-- The original partial index was non-unique, so a WorkOS full-domain sync
+-- could insert a newly first-listed domain as primary while preserving the
+-- existing canonical primary. Repair any existing duplicates before replacing
+-- the index with a unique partial index.
+
+LOCK TABLE organization_domains IN SHARE ROW EXCLUSIVE MODE;
+
+WITH ranked AS (
+  SELECT
+    od.id,
+    od.workos_organization_id,
+    od.domain,
+    ROW_NUMBER() OVER (
+      PARTITION BY od.workos_organization_id
+      ORDER BY
+        (o.email_domain IS NOT NULL AND LOWER(od.domain) = LOWER(o.email_domain)) DESC,
+        od.verified DESC,
+        CASE od.source
+          WHEN 'workos' THEN 0
+          WHEN 'email_verification' THEN 1
+          WHEN 'manual' THEN 2
+          ELSE 3
+        END,
+        od.created_at ASC,
+        od.id ASC
+    ) AS rn,
+    COUNT(*) OVER (PARTITION BY od.workos_organization_id) AS primary_count
+  FROM organization_domains od
+  LEFT JOIN organizations o
+    ON o.workos_organization_id = od.workos_organization_id
+  WHERE od.is_primary = true
+),
+chosen AS (
+  SELECT workos_organization_id, domain
+  FROM ranked
+  WHERE rn = 1 AND primary_count > 1
+)
+UPDATE organizations o
+SET email_domain = chosen.domain,
+    updated_at = NOW()
+FROM chosen
+WHERE o.workos_organization_id = chosen.workos_organization_id
+  AND o.is_personal = false;
+
+WITH ranked AS (
+  SELECT
+    od.id,
+    ROW_NUMBER() OVER (
+      PARTITION BY od.workos_organization_id
+      ORDER BY
+        (o.email_domain IS NOT NULL AND LOWER(od.domain) = LOWER(o.email_domain)) DESC,
+        od.verified DESC,
+        CASE od.source
+          WHEN 'workos' THEN 0
+          WHEN 'email_verification' THEN 1
+          WHEN 'manual' THEN 2
+          ELSE 3
+        END,
+        od.created_at ASC,
+        od.id ASC
+    ) AS rn
+  FROM organization_domains od
+  LEFT JOIN organizations o
+    ON o.workos_organization_id = od.workos_organization_id
+  WHERE od.is_primary = true
+)
+UPDATE organization_domains od
+SET is_primary = false,
+    updated_at = NOW()
+FROM ranked
+WHERE od.id = ranked.id
+  AND ranked.rn > 1;
+
+DROP INDEX IF EXISTS idx_organization_domains_primary;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_organization_domains_primary
+  ON organization_domains(workos_organization_id)
+  WHERE is_primary = true;

--- a/server/src/db/organization-domains-db.ts
+++ b/server/src/db/organization-domains-db.ts
@@ -52,6 +52,82 @@ export async function linkDomain(args: LinkDomainArgs): Promise<LinkDomainResult
   const { orgId, domain, source, verified, isPrimary = false } = args;
   const pool = getPool();
 
+  if (isPrimary) {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      await client.query(
+        'SELECT 1 FROM organizations WHERE workos_organization_id = $1 FOR UPDATE',
+        [orgId],
+      );
+
+      const insertResult = await client.query<{ workos_organization_id: string }>(
+        `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source)
+         VALUES ($1, $2, false, $3, $4)
+         ON CONFLICT (domain) DO NOTHING
+         RETURNING workos_organization_id`,
+        [orgId, domain, verified, source],
+      );
+
+      const inserted = (insertResult.rowCount ?? 0) > 0;
+      if (!inserted) {
+        const existing = await client.query<{ workos_organization_id: string }>(
+          `SELECT workos_organization_id FROM organization_domains WHERE domain = $1 FOR UPDATE`,
+          [domain],
+        );
+        const existingOrgId = existing.rows[0]?.workos_organization_id ?? null;
+        const conflictOrgId = existingOrgId !== orgId ? existingOrgId : null;
+        if (conflictOrgId) {
+          await client.query('COMMIT');
+          logger.warn(
+            { domain, orgId, existingOrgId },
+            'linkDomain: domain conflict — left existing organization_domains row in place',
+          );
+          return { inserted: false, conflictOrgId };
+        }
+
+        await client.query(
+          `UPDATE organization_domains
+              SET verified = organization_domains.verified OR $3,
+                  source = CASE
+                    WHEN organization_domains.verified = false AND $3 = true THEN $4
+                    ELSE organization_domains.source
+                  END,
+                  updated_at = NOW()
+            WHERE workos_organization_id = $1 AND domain = $2`,
+          [orgId, domain, verified, source],
+        );
+      }
+
+      await client.query(
+        `UPDATE organization_domains SET is_primary = false, updated_at = NOW()
+          WHERE workos_organization_id = $1 AND is_primary = true AND domain != $2`,
+        [orgId, domain],
+      );
+      await client.query(
+        `UPDATE organization_domains SET is_primary = true, updated_at = NOW()
+          WHERE workos_organization_id = $1 AND domain = $2`,
+        [orgId, domain],
+      );
+      await client.query(
+        `UPDATE organizations SET email_domain = $1, updated_at = NOW()
+          WHERE workos_organization_id = $2`,
+        [domain, orgId],
+      );
+
+      await client.query('COMMIT');
+      return { inserted, conflictOrgId: null };
+    } catch (err) {
+      await client.query('ROLLBACK').catch((rbErr) => {
+        logger.error({ rbErr, orgId, domain }, 'ROLLBACK failed in linkDomain');
+      });
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
   const insertResult = await pool.query<{ workos_organization_id: string }>(
     `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source)
      VALUES ($1, $2, $3, $4, $5)
@@ -213,6 +289,11 @@ export async function upsertWorkosDomain(
      VALUES ($1, $2, $3, $4, 'workos')
      ON CONFLICT (domain) DO UPDATE SET
        workos_organization_id = EXCLUDED.workos_organization_id,
+       is_primary = CASE
+         WHEN organization_domains.workos_organization_id = EXCLUDED.workos_organization_id
+           THEN organization_domains.is_primary
+         ELSE false
+       END,
        verified = EXCLUDED.verified,
        source = 'workos',
        updated_at = NOW()`,

--- a/server/src/routes/workos-webhooks.ts
+++ b/server/src/routes/workos-webhooks.ts
@@ -587,6 +587,13 @@ export async function syncOrganizationDomains(org: OrganizationData): Promise<vo
   try {
     await client.query('BEGIN');
 
+    await client.query(
+      `SELECT 1 FROM organizations
+        WHERE workos_organization_id = $1
+        FOR UPDATE`,
+      [org.id],
+    );
+
     // Get current domains for this org
     const currentDomainsResult = await client.query(
       `SELECT domain FROM organization_domains WHERE workos_organization_id = $1`,
@@ -598,20 +605,14 @@ export async function syncOrganizationDomains(org: OrganizationData): Promise<vo
     // can verify and own a brand domain; we record that fact. Squeeze
     // prevention happens at the seat-cap layer, not by hiding ownership.
     const workOSDomains = new Set<string>();
-    for (let i = 0; i < org.domains.length; i++) {
-      const domainData = org.domains[i];
+    for (const domainData of org.domains) {
       workOSDomains.add(domainData.domain);
-
-      // is_primary + the email_domain update below drive auto-membership
-      // inference and only apply to non-personal orgs.
-      const isPrimaryEligible = !isPersonal && i === 0;
 
       await upsertWorkosDomain(
         {
           orgId: org.id,
           domain: domainData.domain,
           verified: domainData.state === 'verified',
-          isPrimary: isPrimaryEligible,
         },
         client,
       );
@@ -629,6 +630,23 @@ export async function syncOrganizationDomains(org: OrganizationData): Promise<vo
       }
     }
 
+    if (!isPersonal) {
+      const fallbackPrimary = await client.query<{ domain: string }>(
+        `SELECT domain FROM organization_domains
+          WHERE workos_organization_id = $1 AND verified = true
+          ORDER BY created_at ASC
+          LIMIT 1`,
+        [org.id],
+      );
+      const fallbackPrimaryDomain = fallbackPrimary.rows[0]?.domain ?? null;
+      if (fallbackPrimaryDomain) {
+        await autoPromotePrimaryIfNone(
+          { orgId: org.id, domain: fallbackPrimaryDomain },
+          client,
+        );
+      }
+    }
+
     // Update organizations.email_domain only for non-personal orgs — this
     // column is the auto-membership inference key and applying it to
     // personal-tier orgs would let `@vastlint.org` users auto-resolve to a
@@ -641,14 +659,16 @@ export async function syncOrganizationDomains(org: OrganizationData): Promise<vo
     // can have WorkOS list the failed one first, which would otherwise
     // overwrite the correct email_domain on every webhook fire. The
     // `upsertWorkosDomain` loop above doesn't change `is_primary` on
-    // conflict, so our table preserves the canonical choice; reading from
+    // same-org conflict, and `autoPromotePrimaryIfNone` only fills a missing
+    // primary, so our table preserves the canonical choice; reading from
     // there keeps `email_domain` in lockstep with what auto-membership
     // inference and brand-registry lookups already use.
     //
     // Fallback to `org.domains[0]` covers the initial-sync case (this is
-    // the first webhook for this org, no `organization_domains` rows are
-    // is_primary=true yet — the upsert above set `i===0` as primary, so
-    // the query usually picks it up, but the fallback is a safety net).
+    // the first webhook for this org and none of its domains are verified
+    // yet, no `organization_domains` rows are is_primary=true. The fallback
+    // preserves the legacy email_domain behavior without manufacturing a
+    // brand-primary row from an unverified domain.
     let primaryDomain: string | null = null;
     if (!isPersonal) {
       const primaryRow = await client.query<{ domain: string }>(
@@ -866,6 +886,13 @@ async function deleteSingleOrganizationDomain(domainData: OrganizationDomainEven
 
     // Normalize domain to lowercase
     const normalizedDomain = domainData.domain.toLowerCase();
+
+    await client.query(
+      `SELECT 1 FROM organizations
+        WHERE workos_organization_id = $1
+        FOR UPDATE`,
+      [domainData.organization_id],
+    );
 
     const result = await removeWorkosDomainAndReselectPrimary(
       { orgId: domainData.organization_id, domain: normalizedDomain },

--- a/server/tests/integration/brand-domain-resolver.test.ts
+++ b/server/tests/integration/brand-domain-resolver.test.ts
@@ -109,18 +109,12 @@ describe('getBrandPrimaryDomain', () => {
     expect(await getBrandPrimaryDomainRecord(ORG_A)).toBeNull();
   });
 
-  it('returns the first row but does not throw when multiple is_primary=true rows exist (data anomaly)', async () => {
-    // The invariant is exactly one is_primary=true row per org. If a
-    // future bug regresses it, the resolver should still produce a valid
-    // primary (some primary is better than none) and surface the anomaly
-    // via logger.error. This test documents the don't-crash contract;
-    // the log assertion isn't checked here.
+  it('prevents multiple is_primary=true rows for the same org', async () => {
     await seedOrg(pool, ORG_A, 'A Co');
     await seedDomain(pool, ORG_A, 'a-1.example', true);
-    await seedDomain(pool, ORG_A, 'a-2.example', true);
 
-    const result = await getBrandPrimaryDomain(ORG_A);
-    expect(result === 'a-1.example' || result === 'a-2.example').toBe(true);
+    await expect(seedDomain(pool, ORG_A, 'a-2.example', true)).rejects.toThrow();
+    await expect(getBrandPrimaryDomain(ORG_A)).resolves.toBe('a-1.example');
   });
 });
 

--- a/server/tests/integration/organization-domains-db.test.ts
+++ b/server/tests/integration/organization-domains-db.test.ts
@@ -102,6 +102,68 @@ describe('organization-domains-db (#4159 Stage 3a)', () => {
       expect(org.rows[0].email_domain).toBe(D1);
     });
 
+    it('with isPrimary=true demotes the existing primary for that org', async () => {
+      await linkDomain({
+        orgId: ORG_A,
+        domain: D1,
+        source: 'email_verification',
+        verified: true,
+        isPrimary: true,
+      });
+
+      await linkDomain({
+        orgId: ORG_A,
+        domain: D2,
+        source: 'email_verification',
+        verified: true,
+        isPrimary: true,
+      });
+
+      const rows = await getPool().query(
+        `SELECT domain, is_primary FROM organization_domains
+          WHERE workos_organization_id = $1 ORDER BY domain`,
+        [ORG_A],
+      );
+      expect(rows.rows).toEqual([
+        { domain: D1, is_primary: false },
+        { domain: D2, is_primary: true },
+      ]);
+
+      const org = await getPool().query(
+        `SELECT email_domain FROM organizations WHERE workos_organization_id = $1`,
+        [ORG_A],
+      );
+      expect(org.rows[0].email_domain).toBe(D2);
+    });
+
+    it('with isPrimary=true promotes an existing same-org row idempotently', async () => {
+      await linkDomain({
+        orgId: ORG_A,
+        domain: D1,
+        source: 'manual',
+        verified: false,
+        isPrimary: false,
+      });
+
+      const result = await linkDomain({
+        orgId: ORG_A,
+        domain: D1,
+        source: 'email_verification',
+        verified: true,
+        isPrimary: true,
+      });
+
+      expect(result).toEqual({ inserted: false, conflictOrgId: null });
+
+      const row = await getPool().query(
+        `SELECT is_primary, verified, source FROM organization_domains WHERE workos_organization_id = $1 AND domain = $2`,
+        [ORG_A, D1],
+      );
+      expect(row.rows[0].is_primary).toBe(true);
+      expect(row.rows[0].verified).toBe(true);
+      expect(row.rows[0].source).toBe('email_verification');
+    });
+
     it('does NOT touch email_domain when isPrimary=false', async () => {
       await getPool().query(
         `UPDATE organizations SET email_domain = 'pre-existing.test' WHERE workos_organization_id = $1`,
@@ -306,6 +368,23 @@ describe('organization-domains-db (#4159 Stage 3a)', () => {
         workos_organization_id: ORG_A,
         is_primary: false,
       });
+    });
+
+    it('on cross-org conflict, demotes a transferred primary row for the new org', async () => {
+      await upsertWorkosDomain({ orgId: ORG_A, domain: D1, verified: true, isPrimary: true });
+      await upsertWorkosDomain({ orgId: ORG_B, domain: D_TAKEN, verified: true, isPrimary: true });
+
+      await upsertWorkosDomain({ orgId: ORG_A, domain: D_TAKEN, verified: true });
+
+      const rows = await getPool().query(
+        `SELECT domain, is_primary FROM organization_domains
+          WHERE workos_organization_id = $1 ORDER BY domain`,
+        [ORG_A],
+      );
+      expect(rows.rows).toEqual([
+        { domain: D1, is_primary: true },
+        { domain: D_TAKEN, is_primary: false },
+      ]);
     });
   });
 

--- a/server/tests/integration/workos-sync-email-domain.test.ts
+++ b/server/tests/integration/workos-sync-email-domain.test.ts
@@ -89,12 +89,133 @@ describe('syncOrganizationDomains email_domain sourcing', () => {
     expect(org.rows[0].email_domain).toBe('wkos-sync-email-root.test');
   });
 
+  it('does NOT create a second primary when WorkOS lists a new domain first', async () => {
+    await pool.query(
+      `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source, created_at, updated_at)
+       VALUES ($1, 'wkos-sync-email-existing.test', true, true, 'workos', NOW(), NOW())`,
+      [TEST_ORG],
+    );
+    await pool.query(
+      `UPDATE organizations SET email_domain = 'wkos-sync-email-existing.test'
+       WHERE workos_organization_id = $1`,
+      [TEST_ORG],
+    );
+
+    await syncOrganizationDomains({
+      id: TEST_ORG,
+      name: 'Sync Email Domain Test Co',
+      domains: [
+        { domain: 'wkos-sync-email-new-first.test', state: 'verified' },
+        { domain: 'wkos-sync-email-existing.test', state: 'verified' },
+      ],
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-05-12T00:00:00Z',
+    });
+
+    const rows = await pool.query<{ domain: string; is_primary: boolean }>(
+      `SELECT domain, is_primary FROM organization_domains
+        WHERE workos_organization_id = $1
+        ORDER BY domain`,
+      [TEST_ORG],
+    );
+    expect(rows.rows).toEqual([
+      { domain: 'wkos-sync-email-existing.test', is_primary: true },
+      { domain: 'wkos-sync-email-new-first.test', is_primary: false },
+    ]);
+
+    const org = await pool.query<{ email_domain: string | null }>(
+      `SELECT email_domain FROM organizations WHERE workos_organization_id = $1`,
+      [TEST_ORG],
+    );
+    expect(org.rows[0].email_domain).toBe('wkos-sync-email-existing.test');
+  });
+
+  it('promotes a replacement when the previous WorkOS primary is removed', async () => {
+    await pool.query(
+      `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source, created_at, updated_at)
+       VALUES ($1, 'wkos-sync-email-removed.test', true, true, 'workos', NOW(), NOW())`,
+      [TEST_ORG],
+    );
+    await pool.query(
+      `UPDATE organizations SET email_domain = 'wkos-sync-email-removed.test'
+       WHERE workos_organization_id = $1`,
+      [TEST_ORG],
+    );
+
+    await syncOrganizationDomains({
+      id: TEST_ORG,
+      name: 'Sync Email Domain Test Co',
+      domains: [
+        { domain: 'wkos-sync-email-replacement.test', state: 'verified' },
+      ],
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-05-12T00:00:00Z',
+    });
+
+    const rows = await pool.query<{ domain: string; is_primary: boolean }>(
+      `SELECT domain, is_primary FROM organization_domains
+        WHERE workos_organization_id = $1
+        ORDER BY domain`,
+      [TEST_ORG],
+    );
+    expect(rows.rows).toEqual([
+      { domain: 'wkos-sync-email-replacement.test', is_primary: true },
+    ]);
+
+    const org = await pool.query<{ email_domain: string | null }>(
+      `SELECT email_domain FROM organizations WHERE workos_organization_id = $1`,
+      [TEST_ORG],
+    );
+    expect(org.rows[0].email_domain).toBe('wkos-sync-email-replacement.test');
+  });
+
+  it('uses the oldest verified remaining domain when the previous primary is removed', async () => {
+    await pool.query(
+      `INSERT INTO organization_domains (workos_organization_id, domain, is_primary, verified, source, created_at, updated_at)
+       VALUES
+         ($1, 'wkos-sync-email-removed.test', true,  true, 'workos', '2024-01-01T00:00:00Z', NOW()),
+         ($1, 'wkos-sync-email-older.test',   false, true, 'workos', '2024-02-01T00:00:00Z', NOW())`,
+      [TEST_ORG],
+    );
+    await pool.query(
+      `UPDATE organizations SET email_domain = 'wkos-sync-email-removed.test'
+       WHERE workos_organization_id = $1`,
+      [TEST_ORG],
+    );
+
+    await syncOrganizationDomains({
+      id: TEST_ORG,
+      name: 'Sync Email Domain Test Co',
+      domains: [
+        { domain: 'wkos-sync-email-newer-first.test', state: 'verified' },
+        { domain: 'wkos-sync-email-older.test', state: 'verified' },
+      ],
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-05-12T00:00:00Z',
+    });
+
+    const rows = await pool.query<{ domain: string; is_primary: boolean }>(
+      `SELECT domain, is_primary FROM organization_domains
+        WHERE workos_organization_id = $1
+        ORDER BY domain`,
+      [TEST_ORG],
+    );
+    expect(rows.rows).toEqual([
+      { domain: 'wkos-sync-email-newer-first.test', is_primary: false },
+      { domain: 'wkos-sync-email-older.test', is_primary: true },
+    ]);
+
+    const org = await pool.query<{ email_domain: string | null }>(
+      `SELECT email_domain FROM organizations WHERE workos_organization_id = $1`,
+      [TEST_ORG],
+    );
+    expect(org.rows[0].email_domain).toBe('wkos-sync-email-older.test');
+  });
+
   it('initial sync (no is_primary row yet) falls back to org.domains[0]', async () => {
     // Cold start: no organization_domains rows exist. The upsert loop
-    // inside the function inserts both, and the first one (i===0) is
-    // upserted with isPrimary=true — so by the time the email_domain
-    // UPDATE runs, the SELECT finds a primary row. Either way, the
-    // initial-sync expectation is that email_domain matches org.domains[0].
+    // inside the function inserts the verified domain, and then the
+    // oldest-verified fallback promotes it because no primary exists.
     await syncOrganizationDomains({
       id: TEST_ORG,
       name: 'Sync Email Domain Test Co',


### PR DESCRIPTION
Fixes the organization_domains invariant that allowed multiple is_primary=true rows for one organization.

The root cause was WorkOS full-domain sync and primary link paths inserting or preserving primaries without atomically demoting the existing row.

This adds a repair-and-enforce migration with a unique partial index, hardens the writer paths, and covers the sync/replacement cases with integration tests.

Validated with targeted integration tests, typecheck, migration validation, and the repo precommit/pre-push hooks.