### PR TITLE
Allow API keys to upload brand logos

### DIFF
--- a/.changeset/5437-api-key-brand-logo-upload.md
+++ b/.changeset/5437-api-key-brand-logo-upload.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix WorkOS API-key membership and org provenance for brand logo uploads.

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -11,6 +11,7 @@ import { verifyWorkOSJWT, looksLikeJWT } from '../auth/workos-jwt.js';
 import { storeRefreshedSession, getRefreshedSession, cleanExpiredRefreshes } from '../db/session-refresh-db.js';
 import { getPool } from '../db/client.js';
 import { constantTimeEqual } from '../utils/constant-time-equal.js';
+import { resolveEffectiveMembership } from '../db/org-filters.js';
 
 const logger = createLogger('auth-middleware');
 
@@ -216,6 +217,8 @@ export interface ValidatedApiKey {
   permissions: string[];
 }
 
+type ApiKeySyntheticUser = WorkOSUser & { isMember?: boolean };
+
 /**
  * Validate a WorkOS API key from the Authorization header
  * Returns the validated API key info or null if invalid
@@ -250,6 +253,27 @@ export async function validateWorkOSApiKey(req: Request): Promise<ValidatedApiKe
  */
 function apiKeyHasPermission(apiKey: ValidatedApiKey, permission: string): boolean {
   return apiKey.permissions.includes(permission);
+}
+
+async function buildApiKeyUser(apiKey: ValidatedApiKey): Promise<ApiKeySyntheticUser> {
+  let isMember = false;
+  try {
+    const membership = await resolveEffectiveMembership(apiKey.organizationId);
+    isMember = membership.is_member;
+  } catch (err) {
+    logger.warn({ err, apiKeyId: apiKey.id, organizationId: apiKey.organizationId }, 'Failed to resolve API key owner membership');
+  }
+
+  return {
+    id: `api_key_${apiKey.id}`,
+    email: `api-key@org-${apiKey.organizationId}`,
+    firstName: 'API',
+    lastName: apiKey.name,
+    emailVerified: true,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    isMember,
+  };
 }
 
 /**
@@ -762,15 +786,7 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
   if (apiKey) {
     logger.debug({ path: req.path, apiKeyId: apiKey.id }, 'Authenticated via WorkOS API key');
     // Create a synthetic user for API key auth - the organization owns the key
-    req.user = {
-      id: `api_key_${apiKey.id}`,
-      email: `api-key@org-${apiKey.organizationId}`,
-      firstName: 'API',
-      lastName: apiKey.name,
-      emailVerified: true,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    };
+    req.user = await buildApiKeyUser(apiKey);
     req.accessToken = 'workos-api-key';
     // Store API key info for permission checks
     (req as Request & { apiKey?: ValidatedApiKey }).apiKey = apiKey;
@@ -1782,15 +1798,7 @@ export async function optionalAuth(req: Request, res: Response, next: NextFuncti
   const apiKey = await validateWorkOSApiKey(req);
   if (apiKey) {
     logger.debug({ path: req.path, apiKeyId: apiKey.id }, 'Authenticated via WorkOS API key (optional auth)');
-    req.user = {
-      id: `api_key_${apiKey.id}`,
-      email: `api-key@org-${apiKey.organizationId}`,
-      firstName: 'API',
-      lastName: apiKey.name,
-      emailVerified: true,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    };
+    req.user = await buildApiKeyUser(apiKey);
     req.accessToken = 'workos-api-key';
     (req as Request & { apiKey?: ValidatedApiKey }).apiKey = apiKey;
 

--- a/server/src/routes/brand-logos.ts
+++ b/server/src/routes/brand-logos.ts
@@ -4,7 +4,7 @@
 
 import { Router, type Request, type Response } from 'express';
 import multer from 'multer';
-import { requireAuth, optionalAuth } from '../middleware/auth.js';
+import { requireAuth, optionalAuth, type ValidatedApiKey } from '../middleware/auth.js';
 import { logoUploadRateLimiter } from '../middleware/rate-limit.js';
 import { BrandLogoDatabase } from '../db/brand-logo-db.js';
 import { BrandDatabase } from '../db/brand-db.js';
@@ -75,6 +75,7 @@ export function createBrandLogoRouter(config: BrandLogoRoutesConfig): Router {
       try {
         const domain = req.params.domain.toLowerCase();
         const user = (req as any).user;
+        const apiKey = (req as Request & { apiKey?: ValidatedApiKey }).apiKey;
 
         if (!logoDomainPattern.test(domain)) {
           return res.status(400).json({ error: 'Invalid domain' });
@@ -101,7 +102,12 @@ export function createBrandLogoRouter(config: BrandLogoRoutesConfig): Router {
         // claimed. When no owner has verified yet, community uploads stay
         // allowed but queue for moderation (see review_status below).
         const hostedForOwnership = await brandDb.getHostedBrandByDomain(domain);
-        const isOwner = await isVerifiedBrandOwner(user.id, domain, brandDb);
+        const isApiKeyOwner = !!(
+          apiKey?.organizationId &&
+          hostedForOwnership?.domain_verified &&
+          hostedForOwnership.workos_organization_id === apiKey.organizationId
+        );
+        const isOwner = isApiKeyOwner || (await isVerifiedBrandOwner(user.id, domain, brandDb));
         if (!isOwner) {
           if (hostedForOwnership?.domain_verified && hostedForOwnership.workos_organization_id) {
             return res.status(403).json({
@@ -207,11 +213,11 @@ export function createBrandLogoRouter(config: BrandLogoRoutesConfig): Router {
         // Original filename
         const originalFilename = req.file.originalname?.slice(0, 255);
         const uploaderOrgId = isOwner
-          ? hostedForOwnership?.workos_organization_id ?? null
-          : await resolvePrimaryOrganization(user.id).catch((err) => {
-            logger.warn({ err, userId: user.id }, 'Failed to resolve uploader org for brand-logo provenance');
-            return null;
-          });
+          ? hostedForOwnership?.workos_organization_id ?? apiKey?.organizationId ?? null
+          : apiKey?.organizationId ?? (await resolvePrimaryOrganization(user.id).catch((err) => {
+              logger.warn({ err, userId: user.id }, 'Failed to resolve uploader org for brand-logo provenance');
+              return null;
+            }));
 
         // Verified owners are auto-approved — domain control is the attestation.
         // Community uploads (only allowed when no owner has verified yet) queue

--- a/server/tests/unit/brand-logos-upload-auth.test.ts
+++ b/server/tests/unit/brand-logos-upload-auth.test.ts
@@ -28,6 +28,7 @@ const mocks = vi.hoisted(() => ({
   listLogos: vi.fn().mockResolvedValue([]),
   rebuildManifestLogos: vi.fn().mockResolvedValue(undefined),
   notifyPendingBrandLogo: vi.fn().mockResolvedValue(null),
+  resolvePrimaryOrganization: vi.fn().mockResolvedValue('org_test'),
 }));
 
 vi.mock('../../src/notifications/registry.js', () => ({
@@ -49,7 +50,24 @@ vi.mock('../../src/middleware/rate-limit.js', () => ({
 
 vi.mock('../../src/middleware/auth.js', () => ({
   requireAuth: (req: any, _res: unknown, next: () => void) => {
-    req.user = { id: 'user_test', email: 'test@example.com', isMember: true };
+    const apiKeyOrgId = req.headers['x-test-api-key-org-id'];
+    if (typeof apiKeyOrgId === 'string') {
+      req.apiKey = {
+        id: 'key_test',
+        organizationId: apiKeyOrgId,
+        name: 'Test API key',
+        permissions: [],
+      };
+      req.user = {
+        id: 'api_key_key_test',
+        email: `api-key@org-${apiKeyOrgId}`,
+        firstName: 'API',
+        lastName: 'Test API key',
+        isMember: true,
+      };
+    } else {
+      req.user = { id: 'user_test', email: 'test@example.com', isMember: true };
+    }
     next();
   },
   optionalAuth: (req: any, _res: unknown, next: () => void) => {
@@ -70,7 +88,7 @@ vi.mock('../../src/db/brand-logo-db.js', () => ({
 }));
 
 vi.mock('../../src/db/users-db.js', () => ({
-  resolvePrimaryOrganization: vi.fn().mockResolvedValue('org_test'),
+  resolvePrimaryOrganization: (...args: unknown[]) => mocks.resolvePrimaryOrganization(...args),
 }));
 
 vi.mock('../../src/services/brand-logo-service.js', async () => {
@@ -130,6 +148,8 @@ describe('POST /api/brands/:domain/logos write authority', () => {
     mocks.countPendingDomainsForUser.mockResolvedValue(0);
     mocks.setSlackThreadTs.mockReset();
     mocks.setSlackThreadTs.mockResolvedValue(undefined);
+    mocks.resolvePrimaryOrganization.mockReset();
+    mocks.resolvePrimaryOrganization.mockResolvedValue('org_test');
     mocks.insertLogo.mockImplementation(async (input) => ({
       id: 'logo_test_id',
       ...input,
@@ -152,6 +172,22 @@ describe('POST /api/brands/:domain/logos write authority', () => {
     expect(mocks.insertLogo).not.toHaveBeenCalled();
   });
 
+  it('returns 403 when an API key belongs to a different org than the verified owner', async () => {
+    const { app } = makeApp({
+      hostedBrand: { workos_organization_id: 'org_owner', domain_verified: true },
+      isOwner: false,
+    });
+    const res = await request(app)
+      .post('/api/brands/example.com/logos')
+      .set('x-test-api-key-org-id', 'org_other')
+      .field('tags', 'primary')
+      .attach('file', MINIMAL_PNG, { filename: 'logo.png', contentType: 'image/png' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('verified_owner_required');
+    expect(mocks.insertLogo).not.toHaveBeenCalled();
+  });
+
   it('auto-approves uploads from a verified owner', async () => {
     const { app } = makeApp({
       hostedBrand: { workos_organization_id: 'org_owner', domain_verified: true },
@@ -171,6 +207,32 @@ describe('POST /api/brands/:domain/logos write authority', () => {
       }),
     );
     // Owner-attested uploads don't need a moderator nudge.
+    expect(mocks.notifyPendingBrandLogo).not.toHaveBeenCalled();
+  });
+
+  it('auto-approves API-key uploads from the verified owner org', async () => {
+    const { app } = makeApp({
+      hostedBrand: { workos_organization_id: 'org_owner', domain_verified: true },
+      isOwner: false,
+    });
+    const res = await request(app)
+      .post('/api/brands/example.com/logos')
+      .set('x-test-api-key-org-id', 'org_owner')
+      .field('tags', 'primary')
+      .attach('file', MINIMAL_PNG, { filename: 'logo.png', contentType: 'image/png' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.review_status).toBe('approved');
+    expect(mocks.insertLogo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'brand_owner',
+        review_status: 'approved',
+        uploaded_by_user_id: 'api_key_key_test',
+        uploaded_by_org_id: 'org_owner',
+        uploaded_by_email: 'api-key@org-org_owner',
+      }),
+    );
+    expect(mocks.resolvePrimaryOrganization).not.toHaveBeenCalled();
     expect(mocks.notifyPendingBrandLogo).not.toHaveBeenCalled();
   });
 
@@ -211,5 +273,27 @@ describe('POST /api/brands/:domain/logos write authority', () => {
       .attach('file', MINIMAL_PNG, { filename: 'logo.png', contentType: 'image/png' });
     expect(res.status).toBe(201);
     expect(res.body.review_status).toBe('pending');
+  });
+
+  it('uses API key owner org as community upload provenance', async () => {
+    const { app } = makeApp({ hostedBrand: null, isOwner: false });
+    const res = await request(app)
+      .post('/api/brands/example.com/logos')
+      .set('x-test-api-key-org-id', 'org_registry')
+      .field('tags', 'primary')
+      .attach('file', MINIMAL_PNG, { filename: 'logo.png', contentType: 'image/png' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.review_status).toBe('pending');
+    expect(mocks.insertLogo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'community',
+        review_status: 'pending',
+        uploaded_by_user_id: 'api_key_key_test',
+        uploaded_by_org_id: 'org_registry',
+        uploaded_by_email: 'api-key@org-org_registry',
+      }),
+    );
+    expect(mocks.resolvePrimaryOrganization).not.toHaveBeenCalled();
   });
 });

--- a/server/tests/unit/certification-api-key-membership-gate.test.ts
+++ b/server/tests/unit/certification-api-key-membership-gate.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   checkPrerequisites: vi.fn(),
   getModuleProgress: vi.fn(),
   startModule: vi.fn(),
+  resolveEffectiveMembership: vi.fn(),
 }));
 
 vi.hoisted(() => {
@@ -38,6 +39,10 @@ vi.mock('../../src/db/bans-db.js', () => ({
     checkPlatformBanForApiKey: mocks.checkPlatformBanForApiKey,
     checkPlatformBan: mocks.checkPlatformBan,
   },
+}));
+
+vi.mock('../../src/db/org-filters.js', () => ({
+  resolveEffectiveMembership: mocks.resolveEffectiveMembership,
 }));
 
 vi.mock('../../src/utils/html-config.js', () => ({
@@ -73,6 +78,7 @@ describe('certification API-key membership gate', () => {
       },
     });
     mocks.checkPlatformBanForApiKey.mockResolvedValue({ banned: false, ban: null });
+    mocks.resolveEffectiveMembership.mockResolvedValue({ is_member: false });
     mocks.getModule.mockResolvedValue({
       id: 'paid-module',
       track_id: 'A',

--- a/server/tests/unit/optional-auth-api-key-membership.test.ts
+++ b/server/tests/unit/optional-auth-api-key-membership.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   createValidation: vi.fn(),
   checkPlatformBanForApiKey: vi.fn(),
   checkPlatformBan: vi.fn(),
+  resolveEffectiveMembership: vi.fn(),
 }));
 
 vi.hoisted(() => {
@@ -31,26 +32,32 @@ vi.mock('../../src/db/bans-db.js', () => ({
   },
 }));
 
-import { optionalAuth } from '../../src/middleware/auth.js';
+vi.mock('../../src/db/org-filters.js', () => ({
+  resolveEffectiveMembership: mocks.resolveEffectiveMembership,
+}));
 
-describe('optionalAuth WorkOS API keys', () => {
+import { optionalAuth, requireAuth } from '../../src/middleware/auth.js';
+
+describe('WorkOS API key membership hydration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.checkPlatformBanForApiKey.mockResolvedValue({ banned: false, ban: null });
+    mocks.resolveEffectiveMembership.mockResolvedValue({ is_member: false });
   });
 
-  it('authenticates the API key without granting AAO membership', async () => {
+  it('optionalAuth authenticates the API key and applies membership from the owner org', async () => {
     mocks.createValidation.mockResolvedValue({
       apiKey: {
         id: 'key_123',
-        owner: { id: 'org_free_tier' },
-        name: 'Free tier API key',
+        owner: { id: 'org_member' },
+        name: 'Member API key',
         permissions: [],
       },
     });
+    mocks.resolveEffectiveMembership.mockResolvedValue({ is_member: true });
     const req = {
-      headers: { authorization: 'Bearer sk_test_free_tier' },
-      path: '/api/certification/modules/paid-module',
+      headers: { authorization: 'Bearer sk_test_member' },
+      path: '/api/brands/example.com/logos',
     } as Request & { apiKey?: unknown };
     const res = {} as Response;
     const next = vi.fn() as NextFunction;
@@ -60,16 +67,54 @@ describe('optionalAuth WorkOS API keys', () => {
     expect(next).toHaveBeenCalledOnce();
     expect(req.user).toMatchObject({
       id: 'api_key_key_123',
-      email: 'api-key@org-org_free_tier',
+      email: 'api-key@org-org_member',
       firstName: 'API',
-      lastName: 'Free tier API key',
+      lastName: 'Member API key',
+      isMember: true,
     });
     expect(req.accessToken).toBe('workos-api-key');
     expect(req.apiKey).toMatchObject({
       id: 'key_123',
+      organizationId: 'org_member',
+      permissions: [],
+    });
+    expect(mocks.resolveEffectiveMembership).toHaveBeenCalledWith('org_member');
+  });
+
+  it('requireAuth authenticates the API key without granting membership to non-member orgs', async () => {
+    mocks.createValidation.mockResolvedValue({
+      apiKey: {
+        id: 'key_456',
+        owner: { id: 'org_free_tier' },
+        name: 'Free tier API key',
+        permissions: [],
+      },
+    });
+    const req = {
+      headers: { authorization: 'Bearer sk_test_free_tier' },
+      path: '/api/brands/example.com/logos',
+      accepts: () => false,
+      originalUrl: '/api/brands/example.com/logos',
+    } as unknown as Request & { apiKey?: unknown };
+    const res = {} as Response;
+    const next = vi.fn() as NextFunction;
+
+    await requireAuth(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(req.user).toMatchObject({
+      id: 'api_key_key_456',
+      email: 'api-key@org-org_free_tier',
+      firstName: 'API',
+      lastName: 'Free tier API key',
+      isMember: false,
+    });
+    expect(req.accessToken).toBe('workos-api-key');
+    expect(req.apiKey).toMatchObject({
+      id: 'key_456',
       organizationId: 'org_free_tier',
       permissions: [],
     });
-    expect((req.user as unknown as { isMember?: boolean }).isMember).toBeUndefined();
+    expect(mocks.resolveEffectiveMembership).toHaveBeenCalledWith('org_free_tier');
   });
 });


### PR DESCRIPTION
Fixes #5437.

WorkOS API-key callers now get membership from the key owner org, and brand logo uploads use that org for verified-owner checks and upload provenance.
This unblocks registry API keys from uploading AAO-hosted brand assets while preserving the verified-owner gate and moderation path.

Validated with focused Vitest coverage, precommit checks, typecheck, and the branch push hooks.