### PR TITLE
fix(aao): follow ads.txt redirect chains

### DIFF
--- a/.changeset/adagents-canonical-host-troubleshooting.md
+++ b/.changeset/adagents-canonical-host-troubleshooting.md
@@ -1,0 +1,14 @@
+---
+"adcontextprotocol": patch
+---
+
+fix(aao): follow ads.txt redirect chains for managerdomain fallback (#5440)
+
+Publisher domains whose `/.well-known/adagents.json` is missing can still be
+authorized through the legacy ads.txt `MANAGERDOMAIN` fallback when the manager
+manifest explicitly scopes the publisher. The fallback now follows normal
+ads.txt redirect chains before parsing `MANAGERDOMAIN`, fixing managed-network
+setups where the publisher's `/ads.txt` redirects through a canonical hostname
+and then to a hosted ads.txt file. The adagents docs also clarify that hostname
+redirect chains must end at a `200` JSON file when relying on direct
+well-known deployment.

--- a/docs/governance/property/adagents.mdx
+++ b/docs/governance/property/adagents.mdx
@@ -91,6 +91,12 @@ https://example.com/.well-known/adagents.json
 
 Following [RFC 8615](https://datatracker.ietf.org/doc/html/rfc8615) well-known URI conventions, this location ensures consistent discoverability across publishers.
 
+<Note>
+If the publisher origin canonicalizes hostnames with HTTP redirects, deploy the file at the final resolved URL too. For example, if `https://example.com/.well-known/adagents.json` redirects to `https://www.example.com/.well-known/adagents.json`, the `www` URL must serve the JSON file with a `200` response.
+
+A redirect chain that ends in `404` means the file is missing at the canonical host; troubleshoot the terminal status and resolved URL, not only the intermediate `301` or `302`.
+</Note>
+
 ## Basic Structure
 
 The file must be valid JSON with UTF-8 encoding and return HTTP 200 status.
@@ -337,6 +343,7 @@ When `https://{publisher}/.well-known/adagents.json` returns `404`, or returns a
 1. Read `ads.txt` and parse `managerdomain` entries.
    - Accepted form: `MANAGERDOMAIN=example.com` (IAB directive form only).
    - Key matching is case-insensitive (`MANAGERDOMAIN`, `managerdomain`, etc.).
+   - Validators that support this fallback SHOULD follow a bounded HTTP redirect chain when fetching `ads.txt`, applying the same SSRF and public-host checks to each redirect hop.
 2. If one or more eligible managerdomain entries remain, use the **last** eligible entry in file order and attempt `https://{managerdomain}/.well-known/adagents.json`.
 3. If that manager file validates **and explicitly scopes authorization to the source publisher domain**, treat it as the discovered authorization source for this lookup.
 

--- a/server/src/adagents-manager.ts
+++ b/server/src/adagents-manager.ts
@@ -4,6 +4,7 @@ import { safeFetchAxiosLike, classifySafeFetchError } from './utils/url-security
 import { canonicalizePublisherDomain } from './services/publisher-domain.js';
 
 const MCP_ACCEPT_HEADER = 'application/json, text/event-stream';
+const ADS_TXT_MAX_REDIRECTS = 5;
 const MCP_PREFLIGHT_INITIALIZE_BODY = {
   jsonrpc: '2.0',
   method: 'initialize',
@@ -390,7 +391,7 @@ export class AdAgentsManager {
     try {
       const response = await safeFetchAxiosLike(adsTxtUrl, {
         timeoutMs: 10000,
-        maxRedirects: 1,
+        maxRedirects: ADS_TXT_MAX_REDIRECTS,
         headers: {
           'Accept': 'text/plain',
           'User-Agent': AAO_UA_VALIDATOR,

--- a/server/src/utils/url-security.ts
+++ b/server/src/utils/url-security.ts
@@ -391,7 +391,8 @@ export async function safeFetch(
   // Response body is a stream the caller consumes after this function returns;
   // closing here would tear down the underlying socket mid-stream. Connections
   // are reaped by undici's idle timeout (the same lifecycle as the global agent).
-  let response = await fetchWithDispatcher(sanitizeUrl(parsedUrl), {
+  let currentUrl = parsedUrl;
+  let response = await fetchWithDispatcher(sanitizeUrl(currentUrl), {
     method,
     headers,
     body,
@@ -405,7 +406,7 @@ export async function safeFetch(
     const location = response.headers.get('location');
     if (!location) throw new Error('Redirect with no Location header');
     // Pre-flight check on the redirect hop, then dial through the same SSRF-safe dispatcher.
-    const redirectUrl = await validateRedirectTarget(location, parsedUrl);
+    const redirectUrl = await validateRedirectTarget(location, currentUrl);
     // Per RFC 7231 §6.4.4 a 303 ALWAYS rewrites to GET; for 301/302 most
     // clients also rewrite for non-idempotent verbs even though the spec
     // only mandates user confirmation. We rewrite POST→GET on 301/302/303
@@ -433,6 +434,7 @@ export async function safeFetch(
       signal,
       dispatcher,
     } as RequestInit & { dispatcher: Dispatcher });
+    currentUrl = redirectUrl;
   }
 
   return response;

--- a/server/tests/unit/adagents-manager.test.ts
+++ b/server/tests/unit/adagents-manager.test.ts
@@ -223,6 +223,41 @@ describe('AdAgentsManager', () => {
       expect(result.manager_domain).toBe('manager.example');
     });
 
+    it('follows common ads.txt redirect chains before parsing managerdomain', async () => {
+      mockedSafeFetch.mockImplementation(async (url, options) => {
+        if (url === 'https://publisher.example/.well-known/adagents.json') {
+          return { status: 404, data: 'Not Found', headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://publisher.example/ads.txt') {
+          if ((options?.maxRedirects ?? 0) < 2) {
+            return { status: 301, data: Buffer.from(''), headers: { location: 'https://ads.manager.example/sites/pub/ads.txt' } };
+          }
+          return { status: 200, data: Buffer.from('MANAGERDOMAIN=manager.example\n'), headers: { 'content-type': 'text/plain' } };
+        }
+        if (url === 'https://manager.example/.well-known/adagents.json') {
+          return {
+            status: 200,
+            data: buf({
+              authorized_agents: [{
+                url: 'https://agent.example',
+                authorized_for: 'Managed inventory',
+                authorization_type: 'publisher_properties',
+                publisher_properties: [{ publisher_domains: ['publisher.example'], selection_type: 'all' }],
+              }],
+            }),
+            headers: { 'content-type': 'application/json' },
+          };
+        }
+        throw new Error(`Unexpected URL: ${url}`);
+      });
+
+      const result = await manager.validateDomain('publisher.example');
+
+      expect(result.valid).toBe(true);
+      expect(result.discovery_method).toBe('ads_txt_managerdomain');
+      expect(result.manager_domain).toBe('manager.example');
+    });
+
     it('falls back to managerdomain adagents.json when origin returns 403 for a missing S3/CloudFront object', async () => {
       mockedSafeFetch.mockImplementation(async (url) => {
         if (url === 'https://publisher.example/.well-known/adagents.json') {

--- a/server/tests/unit/url-security-redirects.test.ts
+++ b/server/tests/unit/url-security-redirects.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const fetchMock = vi.hoisted(() => vi.fn());
+const agentMock = vi.hoisted(() => vi.fn(function FakeAgent(this: { opts: unknown }, opts: unknown) {
+  this.opts = opts;
+}));
+const resolve4Mock = vi.hoisted(() => vi.fn(async () => ['93.184.216.34']));
+const resolve6Mock = vi.hoisted(() => vi.fn(async () => []));
+
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('undici')>();
+  return {
+    ...actual,
+    Agent: agentMock,
+    fetch: fetchMock,
+  };
+});
+
+vi.mock('dns/promises', () => ({
+  default: {
+    resolve4: resolve4Mock,
+    resolve6: resolve6Mock,
+  },
+  resolve4: resolve4Mock,
+  resolve6: resolve6Mock,
+}));
+
+import { safeFetch } from '../../src/utils/url-security.js';
+
+describe('safeFetch redirects', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    agentMock.mockClear();
+    resolve4Mock.mockClear();
+    resolve6Mock.mockClear();
+    resolve4Mock.mockResolvedValue(['93.184.216.34']);
+    resolve6Mock.mockResolvedValue([]);
+  });
+
+  it('resolves relative redirect locations against the current hop', async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response('', {
+        status: 302,
+        headers: { Location: 'https://www.publisher.example/ads.txt' },
+      }))
+      .mockResolvedValueOnce(new Response('', {
+        status: 302,
+        headers: { Location: '/sites/pub/ads.txt' },
+      }))
+      .mockResolvedValueOnce(new Response('MANAGERDOMAIN=manager.example\n', {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+      }));
+
+    const response = await safeFetch('https://publisher.example/ads.txt', {
+      maxRedirects: 5,
+      signal: AbortSignal.timeout(2_000),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('MANAGERDOMAIN=manager.example');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[0][0]).toBe('https://publisher.example/ads.txt');
+    expect(fetchMock.mock.calls[1][0]).toBe('https://www.publisher.example/ads.txt');
+    expect(fetchMock.mock.calls[2][0]).toBe('https://www.publisher.example/sites/pub/ads.txt');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #5440 by allowing the `ads.txt` `MANAGERDOMAIN` fallback to handle real managed-publisher redirect chains.

The root cause for the CafeMedia/Raptive case was not the direct `adagents.json` 301 by itself. `recipetineats.com/.well-known/adagents.json` redirects to `www` and then 404s, but `recipetineats.com/ads.txt` redirects through the publisher canonical host and then to an AdThrive-hosted ads.txt containing `managerdomain=cafemedia.com`. The validator only allowed one ads.txt redirect, so it never parsed that managerdomain and never reached CafeMedia's valid manager manifest.

This PR:

- raises the ads.txt managerdomain fetch redirect budget to a bounded 5 hops
- fixes shared `safeFetch` redirect resolution so relative `Location` headers resolve against the current hop, not the original URL
- adds regression coverage for current-hop relative redirect chains and the managerdomain fallback caller path
- documents canonical-host `adagents.json` troubleshooting and bounded ads.txt redirect handling
- adds a patch changeset

## Validation

- Expert protocol review: no blockers
- Expert code review: initial blocker fixed, follow-up no blockers
- `npx vitest run server/tests/unit/url-security-redirects.test.ts server/tests/unit/adagents-manager.test.ts`
- live local validator check for `recipetineats.com` now returns `valid: true`, `discovery_method: ads_txt_managerdomain`, `manager_domain: cafemedia.com`, `resolved_url: https://cafemedia.com/.well-known/adagents.json`, 1 agent, 6843 properties
- `node tests/snippet-validation.test.cjs --file docs/governance/property/adagents.mdx`
- `node tests/json-schema-validation.test.cjs --file docs/governance/property/adagents.mdx`
- `npm run typecheck`
- commit hook: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run typecheck`
- push hook: version sync, changeset presence, schema-link convention, Mintlify broken-links
