### PR TITLE
fix(compliance): don't degrade all-pass runs on active-track controller coverage-gap skips

### DIFF
--- a/.changeset/5429-coverage-gap-active-tracks.md
+++ b/.changeset/5429-coverage-gap-active-tracks.md
@@ -1,0 +1,12 @@
+---
+---
+
+fix(compliance): don't degrade an all-pass run when an active track carries step-level controller-gated skips
+
+`effectiveRunStatus()`'s coverage-gap guard (added in #5328) checked every track, including active (`pass`/`silent`) ones. A single-protocol agent (e.g. signals-only) legitimately skips the universal `track: core` pagination storyboards — which carry `requires: [controller]` — with skip reason `missing_test_controller`. Those expected step-level skips set the coverage-gap flag and suppressed the all-pass → `passing` promotion, so a fully-passing agent (every executed scenario green) was rendered `degraded`.
+
+Narrow the guard to track-level-skipped tracks (`status === 'skip'`), matching the intent of #5328 (surface gaps where a whole track was gated out) without penalizing active tracks that merely contain expected controller-gated step skips. The per-track `has_coverage_gap_skip` field is unchanged, so the gap is still surfaced — it just no longer degrades an otherwise all-pass run.
+
+Adds a regression test for the active-track case.
+
+Fixes #5429. Regression of #5328; prior art #4065.

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -441,7 +441,14 @@ function effectiveRunStatus(result: ComplianceResult): {
   tracks_partial: number;
 } {
   const activeTracks = result.tracks.filter((t: TrackResult) => t.status !== 'skip');
-  const hasCoverageGapSkip = result.tracks.some(trackHasCoverageGapSkip);
+  // Only a *track-level* skip (status === 'skip') counts as a coverage gap that
+  // blocks promotion. Step-level skips inside an active (pass/silent) track —
+  // e.g. a signals-only agent skipping controller-gated media-buy pagination
+  // storyboards with `missing_test_controller` — are expected and must not
+  // degrade an otherwise all-pass run (#5429, regression of #5328).
+  const hasCoverageGapSkip = result.tracks
+    .filter((t: TrackResult) => t.status === 'skip')
+    .some(trackHasCoverageGapSkip);
   if (
     !hasCoverageGapSkip &&
     activeTracks.length > 0 &&

--- a/server/tests/unit/compliance-testing-effective-run-status.test.ts
+++ b/server/tests/unit/compliance-testing-effective-run-status.test.ts
@@ -208,4 +208,52 @@ describe('complianceResultToDbInput — effectiveRunStatus', () => {
       expect.objectContaining({ track: 'reporting', status: 'skip', has_coverage_gap_skip: true }),
     ]);
   });
+
+  it('promotes an active clean track that carries step-level controller-gated skips (regression #5429)', () => {
+    // #5429: a signals-only agent's active `core` track carries step-level
+    // `missing_test_controller` skips on universal pagination storyboards that
+    // require a test controller. Those skips are expected and every executed
+    // scenario passes, so the run must promote to `passing` — the coverage-gap
+    // guard only blocks promotion for track-level-skipped tracks, not active ones.
+    const result = makeResult([
+      {
+        track: 'core',
+        label: 'Core',
+        status: 'silent',
+        duration_ms: 1000,
+        scenarios: [
+          {
+            scenario: 'discovery/basic',
+            overall_passed: true,
+            steps: [{ step: 'get_signals', passed: true, skipped: false, duration_ms: 5 }],
+          },
+          {
+            scenario: 'pagination_integrity/requirement_unmet',
+            overall_passed: true,
+            steps: [
+              {
+                step: 'requirement_unmet:controller',
+                passed: true,
+                skipped: true,
+                skip_reason: 'missing_test_controller',
+                duration_ms: 0,
+              },
+            ],
+          },
+        ],
+      },
+    ] as any);
+
+    const out = complianceResultToDbInput(result as any, 'https://agent.example.com/mcp', 'production');
+
+    expect(out.overall_status).toBe('passing');
+    expect(out.tracks_passed).toBe(1);
+    expect(out.tracks_failed).toBe(0);
+    expect(out.tracks_partial).toBe(0);
+    // The coverage gap is still surfaced on the track; it just no longer
+    // degrades an otherwise all-pass run.
+    expect(out.tracks_json).toEqual([
+      expect.objectContaining({ track: 'core', status: 'silent', has_coverage_gap_skip: true }),
+    ]);
+  });
 });


### PR DESCRIPTION
Fixes #5429.

## Problem

A single-protocol (signals-only) agent whose every executed scenario passes (core 13/13, signals 9/9) is rendered **`degraded`** on the public `/compliance` endpoint. This is a regression of #4065, introduced by #5328.

`effectiveRunStatus()`'s coverage-gap guard checks **every** track:

```ts
const hasCoverageGapSkip = result.tracks.some(trackHasCoverageGapSkip);
```

A signals-only agent legitimately skips the universal `track: core` pagination storyboards (e.g. `pagination-integrity.yaml`, which carry `requires: [controller]`) with skip reason `missing_test_controller`. `skipReasonIsCoverageGap()` classifies that as a coverage gap, so the **active** `core` track sets the flag and the all-pass → `passing` promotion is suppressed — degrading an otherwise fully-clean run.

## Fix

Narrow the guard to **track-level-skipped** tracks (`status === 'skip'`), which is what #5328 intended to protect (a whole track gated out by a coverage gap). Step-level skips inside an active (`pass`/`silent`) track no longer block promotion:

```ts
const hasCoverageGapSkip = result.tracks
  .filter((t) => t.status === 'skip')
  .some(trackHasCoverageGapSkip);
```

The per-track `has_coverage_gap_skip` field is unchanged, so the gap is still surfaced on the track — it just no longer degrades an otherwise all-pass run. This matches the maintainer triage on #5429 (Option A).

## Test

Adds a regression test in `compliance-testing-effective-run-status.test.ts`: an active `silent` track carrying a step-level `missing_test_controller` skip (all scenarios pass) now promotes to `overall_status: 'passing'`. The test fails on the pre-fix code and passes after. The existing #5328 test ("does not promote active clean tracks when reporting has controller-gated skips" — where the gap is on a *track-level-skipped* track) still passes.

## Notes

- Changeset is `--empty` — server-evaluator behavior only, no protocol/schema/API change.
- Per the triage, this is patch-eligible and appropriate to **cherry-pick to `3.0.x`** (the line our affected agents are graded against).
- Refs: #5328 (cause), #4065 (prior art).
