### PR TITLE
fix(auth): accept empty Basic auth passwords

### DIFF
--- a/.changeset/fix-basic-auth-empty-password-rfc7617.md
+++ b/.changeset/fix-basic-auth-empty-password-rfc7617.md
@@ -1,0 +1,7 @@
+---
+---
+
+fix(server): accept RFC 7617 Basic auth credentials with empty passwords
+
+Stored HTTP Basic credentials now enforce a non-empty user-id without rejecting
+valid `user:` credentials whose password is empty.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.1.0-rc.12",
       "dependencies": {
-        "@adcp/sdk": "9.0.0-beta.26",
+        "@adcp/sdk": "9.0.0-beta.28",
         "@anthropic-ai/sdk": "^0.98.0",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -123,9 +123,9 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "9.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-9.0.0-beta.26.tgz",
-      "integrity": "sha512-UJ4rd9r9qJkTmVpLaYmCZefacgYansHc6rfjmP792lyfs0B5czF03a1v/JYHXa9lZSK5/eQUmuvG4rZvvZOq0g==",
+      "version": "9.0.0-beta.28",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-9.0.0-beta.28.tgz",
+      "integrity": "sha512-MY0cS7guu5G4Pr4r034/7w2YDXV58S5T4CA+OvQENsOgQgGT+CKpZ8vntS7SakctyksGyIzh1Muylm7hn2kFvQ==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "docs:json-field-audit": "node scripts/docs-json-field-audit.cjs"
   },
   "dependencies": {
-    "@adcp/sdk": "9.0.0-beta.26",
+    "@adcp/sdk": "9.0.0-beta.28",
     "@anthropic-ai/sdk": "^0.98.0",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",

--- a/server/src/addie/jobs/compliance-heartbeat.ts
+++ b/server/src/addie/jobs/compliance-heartbeat.ts
@@ -194,7 +194,7 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       const isAgentTimeout = /timed?\s*out/i.test(errorMessage);
-      const isSavedAuthConfigError = /step\.auth\.basic\.(?:username|password) must be a non-empty string/i.test(errorMessage);
+      const isSavedAuthConfigError = /step\.auth\.basic\.username must be a non-empty string/i.test(errorMessage);
       const capsError = classifyCapabilityResolutionError(error);
 
       // Classify failure. Timeouts and capability-config faults are expected
@@ -213,11 +213,11 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
         observationMessage = headline;
         logger.warn({ agentUrl: agent.agent_url }, `Compliance check timed out for agent: ${agent.agent_url}`);
       } else if (isSavedAuthConfigError) {
-        headline = 'Saved Basic auth credentials are incomplete';
+        headline = 'Saved Basic auth credentials are malformed';
         observationCategory = 'authentication';
         observationSeverity = 'warning';
-        observationMessage = 'The saved Basic auth credentials for this agent must include both username and password.';
-        logger.warn({ agentUrl: agent.agent_url }, 'Compliance check skipped complete Basic auth due to incomplete saved credentials');
+        observationMessage = 'The saved Basic auth credentials for this agent must include a non-empty username.';
+        logger.warn({ agentUrl: agent.agent_url }, 'Compliance check skipped Basic auth due to malformed saved credentials');
       } else if (capsError) {
         const presentation = presentCapabilityResolutionError(capsError);
         headline = presentation.headline;

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -455,7 +455,7 @@ export async function resolveAgentAuth(
         if (savedInfo.authType === 'basic' && !isCompleteStoredBasicCredential(savedInfo.token)) {
           logger.warn(
             { agentUrl: resolvedUrl, organizationId },
-            'Addie: ignoring incomplete saved Basic auth credentials while resolving agent auth',
+            'Addie: ignoring malformed saved Basic auth credentials while resolving agent auth',
           );
         } else {
           return { authToken: savedInfo.token, authType: savedInfo.authType, source: 'saved', resolvedUrl };
@@ -1473,7 +1473,7 @@ export const MEMBER_TOOLS: AddieTool[] = [
           description: 'What kind of agent this is. Required — ask the owner; do not guess. `brand` (brand-side intent), `rights` (rights/clearance), `measurement` (verification/attribution), `governance` (policy/compliance), `creative` (creative production/format), `sales` (publisher/sell-side inventory), `buying` (DSP/buy-side execution), `signals` (audience/signal provider).',
         },
         auth_token: { type: 'string', description: 'Static auth token (stored encrypted). Mutually exclusive with oauth_client_credentials on any given save call.' },
-        auth_type: { type: 'string', enum: ['bearer', 'basic'], description: 'How the auth_token is sent. "bearer" (default): sends Authorization: Bearer <token>. "basic": auth_token is "user:password" (the tool also accepts the base64-encoded form); stored base64-encoded and sent as Authorization: Basic <token>.' },
+        auth_type: { type: 'string', enum: ['bearer', 'basic'], description: 'How the auth_token is sent. "bearer" (default): sends Authorization: Bearer <token>. "basic": auth_token is "username:password" with a non-empty username and a password that may be empty (the tool also accepts the base64-encoded form); stored base64-encoded and sent as Authorization: Basic <token>.' },
         oauth_client_credentials: {
           type: 'object',
           description: 'OAuth 2.0 client-credentials configuration for machine-to-machine auth (RFC 6749 §4.4). The SDK exchanges at the token endpoint before every call and refreshes on 401. Use this when the agent requires a bearer token minted from a client_id/client_secret pair, not a human authorization flow.',
@@ -6282,10 +6282,11 @@ export function createMemberToolHandlers(
     const rawAuthType = input.auth_type as string | undefined;
     const authType: 'bearer' | 'basic' = rawAuthType === 'basic' ? 'basic' : 'bearer';
 
-    // For Basic auth, accept either raw "user:password" or the base64-encoded
-    // form and normalize to base64 for storage. Aligns with CLI
-    // (--auth user:pass), SDK (createTestClient with {username, password}),
-    // and the dashboard's connect form — all of which accept raw input.
+    // For Basic auth, accept either raw "username:password" (password may be
+    // empty) or the base64-encoded form and normalize to base64 for storage.
+    // Aligns with CLI (--auth user:pass), SDK (createTestClient with
+    // {username, password}), and the dashboard's connect form — all of which
+    // accept raw input.
     // Without normalization, save_agent was the ecosystem outlier requiring
     // users to pre-encode; a raw value silently landed in the DB and got
     // re-classified as Bearer at request time.
@@ -6293,7 +6294,7 @@ export function createMemberToolHandlers(
     if (authToken && authType === 'basic') {
       const normalized = normalizeBasicAuthForStorage(authToken);
       if (!normalized.ok) {
-        return `**Error:** Basic auth_token must be "user:password" (or the base64-encoded form of it). The value you provided doesn't decode to a user:password pair.`;
+        return `**Error:** Basic auth_token must be "username:password" with a non-empty username; the password may be empty. The base64-encoded form is also accepted.`;
       }
       storedAuthToken = normalized.stored;
     }

--- a/server/src/compliance/storyboard-runner-options.ts
+++ b/server/src/compliance/storyboard-runner-options.ts
@@ -72,8 +72,10 @@ export function authForStoryboard(
 
   if (storyboardId === 'security_baseline' && kit?.auth?.basic) {
     const { username, password, credentials } = kit.auth.basic;
-    if (username && password) return { type: 'basic', username, password };
-    if (credentials) {
+    if (typeof username === 'string' && username && typeof password === 'string') {
+      return { type: 'basic', username, password };
+    }
+    if (typeof credentials === 'string') {
       const colonIndex = credentials.indexOf(':');
       if (colonIndex > 0) {
         return {
@@ -83,7 +85,7 @@ export function authForStoryboard(
         };
       }
     }
-    throw new Error('security_baseline auth.basic must provide username/password or credentials in "username:password" form');
+    throw new Error('security_baseline auth.basic must provide a non-empty username and a password string, or credentials in "username:password" form; the password may be empty');
   }
 
   return { type: 'bearer', token: defaultBearerToken };

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -50,10 +50,9 @@ export type ResolvedOwnerAuth =
 
 /**
  * Decode an HTTP Basic Authorization credential (base64(`username:password`))
- * into a typed shape. Returns null when the payload is not complete
- * base64(`username:password`). The storyboard runner requires complete Basic
- * credentials, and passing through malformed rows turns saved-credential
- * issues into platform-looking heartbeat failures.
+ * into a typed shape. Returns null when the payload is not valid RFC 7617
+ * form: missing the colon separator or carrying an empty user-id. Empty
+ * passwords are valid Basic credentials.
  */
 export function decodeBasicCredentials(
   token: string,
@@ -63,7 +62,7 @@ export function decodeBasicCredentials(
   if (colonIndex < 0) return null;
   const username = decoded.slice(0, colonIndex);
   const password = decoded.slice(colonIndex + 1);
-  if (!username || !password) return null;
+  if (!username) return null;
   return {
     type: 'basic',
     username,

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -6327,7 +6327,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         const normalized = normalizeBasicAuthForStorage(authTokenToStore);
         if (!normalized.ok) {
           return res.status(400).json({
-            error: 'Basic auth_token must be "user:password" or base64("user:password") with non-empty username and password',
+            error: 'Basic auth_token must be "username:password" with a non-empty username; the password may be empty. The base64-encoded form is also accepted.',
           });
         }
         authTokenToStore = normalized.stored;

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -717,9 +717,9 @@ import { maybeEmitCompletionWebhook } from './webhooks.js';
 import { selectSigningCapability } from './request-signing.js';
 
 const SUPPORTED_MAJOR_VERSIONS = [3] as const;
-const SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9'] as const;
+const SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10'] as const;
 const DEFAULT_ADCP_VERSION = '3.0';
-const CURRENT_ADCP_VERSION = '3.1-rc.9';
+const CURRENT_ADCP_VERSION = '3.1-rc.10';
 const MAX_PACKAGES_PER_BUY = 50;
 
 interface ParsedAdcpReleaseVersion {
@@ -763,7 +763,32 @@ function compareAdcpReleaseVersions(left: ParsedAdcpReleaseVersion, right: Parse
   if (left.prerelease === right.prerelease) return 0;
   if (!left.prerelease) return 1;
   if (!right.prerelease) return -1;
-  return left.prerelease.localeCompare(right.prerelease);
+  return compareAdcpPrerelease(left.prerelease, right.prerelease);
+}
+
+function compareAdcpPrerelease(left: string, right: string): number {
+  const leftParts = left.split('.');
+  const rightParts = right.split('.');
+  const maxParts = Math.max(leftParts.length, rightParts.length);
+
+  for (let index = 0; index < maxParts; index += 1) {
+    const leftPart = leftParts[index];
+    const rightPart = rightParts[index];
+    if (leftPart === undefined) return -1;
+    if (rightPart === undefined) return 1;
+    if (leftPart === rightPart) continue;
+
+    const leftNumeric = /^\d+$/.test(leftPart);
+    const rightNumeric = /^\d+$/.test(rightPart);
+    if (leftNumeric && rightNumeric) {
+      return Number.parseInt(leftPart, 10) - Number.parseInt(rightPart, 10);
+    }
+    if (leftNumeric) return -1;
+    if (rightNumeric) return 1;
+    return leftPart.localeCompare(rightPart);
+  }
+
+  return 0;
 }
 
 const PARSED_SUPPORTED_RELEASE_VERSIONS = SUPPORTED_RELEASE_VERSIONS

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -61,7 +61,7 @@ const SALES_CURRENT_SCENARIOS = [
   'evaluate_distributed_brand_resolution',
 ] as const;
 
-const TRAINING_AGENT_SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9'] as const;
+const TRAINING_AGENT_SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10'] as const;
 const TRAINING_AGENT_DEFAULT_ADCP_VERSION = '3.0';
 
 function bearerToken(req: Request): string | undefined {

--- a/server/src/training-agent/tenants/tenant-smoke.test.ts
+++ b/server/src/training-agent/tenants/tenant-smoke.test.ts
@@ -247,7 +247,7 @@ describe('tenant routing smoke', () => {
       const mediaBuy = body.result?.structuredContent?.media_buy;
       expect(body.result?.structuredContent?.adcp_version).toBe('3.0');
       expect(body.result?.structuredContent?.adcp?.major_versions).toContain(3);
-      expect(body.result?.structuredContent?.adcp?.supported_versions).toEqual(['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9']);
+      expect(body.result?.structuredContent?.adcp?.supported_versions).toEqual(['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10']);
       expect(mediaBuy?.features?.inline_creative_management).toBe(true);
       expect(mediaBuy?.supported_optimization_metrics).toContain('clicks');
       expect(mediaBuy?.vendor_metric_optimization?.supported_targets).toContain('threshold_rate');
@@ -374,7 +374,7 @@ describe('tenant routing smoke', () => {
         field: 'adcp_version',
         details: {
           adcp_version: '4.0',
-          supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9'],
+          supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10'],
         },
       });
       expect(unsupportedBody.result?.structuredContent?.context?.correlation_id).toBe('tenant-local-version-unsupported');

--- a/server/src/utils/basic-auth-credentials.ts
+++ b/server/src/utils/basic-auth-credentials.ts
@@ -1,13 +1,13 @@
 export function isCompleteStoredBasicCredential(token: string): boolean {
   const decoded = Buffer.from(token, 'base64').toString('utf8');
   const colonIndex = decoded.indexOf(':');
-  return colonIndex > 0 && colonIndex < decoded.length - 1;
+  return colonIndex > 0;
 }
 
 export function normalizeBasicAuthForStorage(token: string): { ok: true; stored: string } | { ok: false } {
   if (token.includes(':')) {
     const colonIndex = token.indexOf(':');
-    if (!token.slice(0, colonIndex) || !token.slice(colonIndex + 1)) return { ok: false };
+    if (!token.slice(0, colonIndex)) return { ok: false };
     return { ok: true, stored: Buffer.from(token, 'utf8').toString('base64') };
   }
   if (!isCompleteStoredBasicCredential(token)) return { ok: false };

--- a/server/tests/integration/registry-api-oauth.test.ts
+++ b/server/tests/integration/registry-api-oauth.test.ts
@@ -176,10 +176,30 @@ describe('registry-api OAuth credential endpoints (integration)', () => {
         .toBe(Buffer.from('test-user:test-password', 'utf8').toString('base64'));
     });
 
-    it('rejects Basic credentials with a blank password', async () => {
+    it('normalizes raw Basic credentials with a blank password before storing', async () => {
       const res = await request(app).put(url).send({ auth_token: 'test-user:', auth_type: 'basic' });
+      expect(res.status).toBe(200);
+
+      const stored = await pool.query(
+        `SELECT auth_token_encrypted, auth_token_iv, auth_type, auth_token_hint
+         FROM agent_contexts
+         WHERE organization_id = $1 AND agent_url = $2`,
+        [TEST_ORG_ID, TEST_AGENT_URL],
+      );
+      expect(stored.rows).toHaveLength(1);
+      expect(stored.rows[0].auth_type).toBe('basic');
+      expect(stored.rows[0].auth_token_hint).toBe('test-user:****');
+      expect(decrypt(stored.rows[0].auth_token_encrypted, stored.rows[0].auth_token_iv, TEST_ORG_ID))
+        .toBe(Buffer.from('test-user:', 'utf8').toString('base64'));
+    });
+
+    it.each([
+      ['raw', ':test-password'],
+      ['base64', Buffer.from(':test-password', 'utf8').toString('base64')],
+    ])('rejects %s Basic credentials with a blank username', async (_label, authToken) => {
+      const res = await request(app).put(url).send({ auth_token: authToken, auth_type: 'basic' });
       expect(res.status).toBe(400);
-      expect(res.body.error).toMatch(/Basic auth_token/);
+      expect(res.body.error).toMatch(/non-empty username/);
 
       const stored = await pool.query(
         `SELECT id FROM agent_contexts WHERE organization_id = $1 AND agent_url = $2`,

--- a/server/tests/integration/training-agent-3-0-compat-tools.test.ts
+++ b/server/tests/integration/training-agent-3-0-compat-tools.test.ts
@@ -20,7 +20,7 @@ const { stopSessionCleanup } = await import('../../src/training-agent/state.js')
 
 const COMPAT_CTX = { mode: 'open' as const, storyboardCompat: { version: '3.0' as const } };
 const AUTH = 'Bearer compat-tools-token';
-const CURRENT_ADCP_VERSION = '3.1-rc.9';
+const CURRENT_ADCP_VERSION = '3.1-rc.10';
 
 async function simulateListTools(server: ReturnType<typeof createTrainingAgentServer>): Promise<string[]> {
   const requestHandlers = (server as any)._requestHandlers as Map<string, Function>;

--- a/server/tests/unit/addie/basic-auth-normalization.test.ts
+++ b/server/tests/unit/addie/basic-auth-normalization.test.ts
@@ -35,10 +35,15 @@ describe('normalizeBasicAuthForStorage', () => {
     expect(normalizeBasicAuthForStorage('nopairhere').ok).toBe(false);
   });
 
-  it('rejects raw or encoded basic credentials with a blank side', () => {
-    expect(normalizeBasicAuthForStorage('user:').ok).toBe(false);
+  it('accepts empty passwords and rejects empty usernames', () => {
+    const rawEmptyPassword = normalizeBasicAuthForStorage('user:');
+    expect(rawEmptyPassword.ok).toBe(true);
+    if (rawEmptyPassword.ok) {
+      expect(rawEmptyPassword.stored).toBe(Buffer.from('user:', 'utf8').toString('base64'));
+    }
     expect(normalizeBasicAuthForStorage(':pass').ok).toBe(false);
-    expect(normalizeBasicAuthForStorage(Buffer.from('user:', 'utf8').toString('base64')).ok).toBe(false);
+    const encodedEmptyPassword = Buffer.from('user:', 'utf8').toString('base64');
+    expect(normalizeBasicAuthForStorage(encodedEmptyPassword).ok).toBe(true);
     expect(normalizeBasicAuthForStorage(Buffer.from(':pass', 'utf8').toString('base64')).ok).toBe(false);
   });
 });
@@ -74,14 +79,14 @@ describe('buildAuthOption (basic auth)', () => {
     expect(option).toBeUndefined();
   });
 
-  it('returns undefined for an incomplete decoded basic credential', () => {
+  it('decodes a basic credential with an empty password', () => {
     const option = buildAuthOption({
       authToken: Buffer.from('user:', 'utf8').toString('base64'),
       authType: 'basic',
       source: 'saved',
       resolvedUrl: 'https://example.com',
     });
-    expect(option).toBeUndefined();
+    expect(option).toEqual({ type: 'basic', username: 'user', password: '' });
   });
 
   it('splits on the first colon so passwords may contain colons', () => {
@@ -107,13 +112,13 @@ describe('buildAuthOption (basic auth)', () => {
 });
 
 describe('resolveAgentAuth', () => {
-  it('falls through to OAuth when saved basic auth has an empty password', async () => {
+  it('uses saved basic auth when it has an empty password', async () => {
     const agentUrl = 'https://private-agent.example.com/mcp';
     vi.spyOn(AgentContextDatabase.prototype, 'getAuthInfoByOrgAndUrl').mockResolvedValueOnce({
       token: Buffer.from('test-user:', 'utf8').toString('base64'),
       authType: 'basic',
     });
-    vi.spyOn(AgentContextDatabase.prototype, 'getOAuthTokensByOrgAndUrl').mockResolvedValueOnce({
+    const oauthSpy = vi.spyOn(AgentContextDatabase.prototype, 'getOAuthTokensByOrgAndUrl').mockResolvedValueOnce({
       access_token: 'oauth-access',
       refresh_token: 'oauth-refresh',
     });
@@ -121,10 +126,11 @@ describe('resolveAgentAuth', () => {
     const resolved = await resolveAgentAuth(agentUrl, 'org_123');
 
     expect(resolved).toEqual({
-      authToken: 'oauth-access',
-      authType: 'bearer',
-      source: 'oauth',
+      authToken: Buffer.from('test-user:', 'utf8').toString('base64'),
+      authType: 'basic',
+      source: 'saved',
       resolvedUrl: agentUrl,
     });
+    expect(oauthSpy).not.toHaveBeenCalled();
   });
 });

--- a/server/tests/unit/compliance-db-resolve-owner-auth.test.ts
+++ b/server/tests/unit/compliance-db-resolve-owner-auth.test.ts
@@ -78,17 +78,17 @@ describe('ComplianceDatabase.resolveOwnerAuth', () => {
     expect(auth).toEqual({ type: 'basic', username, password });
   });
 
-  it('returns undefined when basic-typed token has an empty password', async () => {
-    const malformed = Buffer.from('test-user:', 'utf8').toString('base64');
+  it('decodes static basic auth with an empty password', async () => {
+    const credentials = Buffer.from('test-user:', 'utf8').toString('base64');
     mockRow({ auth_token_encrypted: 'enc_empty_password', auth_token_iv: 'iv_empty_password', auth_type: 'basic' });
-    mockedDecrypt.mockReturnValueOnce(malformed);
+    mockedDecrypt.mockReturnValueOnce(credentials);
 
     const auth = await db.resolveOwnerAuth('https://agent.example.com');
-    expect(auth).toBeUndefined();
+    expect(auth).toEqual({ type: 'basic', username: 'test-user', password: '' });
   });
 
-  it('falls through to OAuth when basic-typed token has an empty password', async () => {
-    const malformed = Buffer.from('test-user:', 'utf8').toString('base64');
+  it('prefers static basic auth with an empty password over OAuth', async () => {
+    const credentials = Buffer.from('test-user:', 'utf8').toString('base64');
     mockRow({
       auth_token_encrypted: 'enc_empty_password',
       auth_token_iv: 'iv_empty_password',
@@ -99,17 +99,15 @@ describe('ComplianceDatabase.resolveOwnerAuth', () => {
       oauth_refresh_token_iv: 'iv_refresh',
     });
     mockedDecrypt.mockImplementation((encrypted: string) => {
-      if (encrypted === 'enc_empty_password') return malformed;
+      if (encrypted === 'enc_empty_password') return credentials;
       if (encrypted === 'enc_access') return 'access-plaintext';
       if (encrypted === 'enc_refresh') return 'refresh-plaintext';
       throw new Error(`unexpected decrypt call: ${encrypted}`);
     });
 
     const auth = await db.resolveOwnerAuth('https://agent.example.com');
-    expect(auth).toEqual({
-      type: 'oauth',
-      tokens: { access_token: 'access-plaintext', refresh_token: 'refresh-plaintext' },
-    });
+    expect(auth).toEqual({ type: 'basic', username: 'test-user', password: '' });
+    expect(mockedDecrypt).toHaveBeenCalledTimes(1);
   });
 
   it('returns undefined when basic-typed token has no colon separator and no fallback auth exists', async () => {

--- a/server/tests/unit/compliance-heartbeat.test.ts
+++ b/server/tests/unit/compliance-heartbeat.test.ts
@@ -84,8 +84,8 @@ describe('runComplianceHeartbeatJob', () => {
     mocks.recordComplianceRun.mockResolvedValue({});
   });
 
-  it('counts incomplete saved Basic auth as a checked failure', async () => {
-    mocks.comply.mockRejectedValueOnce(new Error('step.auth.basic.password must be a non-empty string'));
+  it('counts malformed saved Basic auth as a checked failure', async () => {
+    mocks.comply.mockRejectedValueOnce(new Error('step.auth.basic.username must be a non-empty string'));
 
     const { runComplianceHeartbeatJob } = await import('../../src/addie/jobs/compliance-heartbeat.js');
     const result = await runComplianceHeartbeatJob({ limit: 1 });
@@ -95,11 +95,11 @@ describe('runComplianceHeartbeatJob', () => {
       expect.objectContaining({
         agent_url: 'https://agent.example.com/mcp',
         overall_status: 'failing',
-        headline: 'Saved Basic auth credentials are incomplete',
+        headline: 'Saved Basic auth credentials are malformed',
         observations_json: [{
           category: 'authentication',
           severity: 'warning',
-          message: 'The saved Basic auth credentials for this agent must include both username and password.',
+          message: 'The saved Basic auth credentials for this agent must include a non-empty username.',
         }],
       }),
     );

--- a/server/tests/unit/mcp-eval-tools.test.ts
+++ b/server/tests/unit/mcp-eval-tools.test.ts
@@ -7,7 +7,11 @@
  * - Handler factories create callable handlers
  * - Auth-required tools reject anonymous callers
  */
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import * as hostnameVerification from '../../src/services/agent-hostname-verification.js';
+import { AgentContextDatabase } from '../../src/db/agent-context-db.js';
+import { MemberDatabase } from '../../src/db/member-db.js';
+import * as clientDb from '../../src/db/client.js';
 import {
   EVAL_TOOL_DEFINITIONS,
   AGENT_CONTEXT_TOOL_DEFINITIONS,
@@ -17,6 +21,40 @@ import {
   createMemberToolHandler,
   createStatelessToolHandlers,
 } from '../../src/mcp/exposed-tools.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function savedAgentContext(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'ctx_123',
+    organization_id: 'org_123',
+    agent_url: 'https://agent.example.com/mcp',
+    agent_name: null,
+    agent_type: 'unknown',
+    protocol: 'mcp',
+    has_auth_token: false,
+    auth_token_hint: null,
+    auth_type: 'bearer',
+    has_oauth_token: false,
+    has_oauth_refresh_token: false,
+    oauth_token_expires_at: null,
+    has_oauth_client: false,
+    has_oauth_client_credentials: false,
+    tools_discovered: null,
+    last_discovered_at: null,
+    last_test_scenario: null,
+    last_test_passed: null,
+    last_test_summary: null,
+    last_tested_at: null,
+    total_tests_run: 0,
+    created_at: new Date('2026-01-01T00:00:00Z'),
+    updated_at: new Date('2026-01-01T00:00:00Z'),
+    created_by: 'user_123',
+    ...overrides,
+  } as any;
+}
 
 describe('EVAL_TOOL_DEFINITIONS', () => {
   const EXPECTED = [
@@ -163,6 +201,90 @@ describe('createMemberToolHandler', () => {
     );
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('Authentication required');
+  });
+
+  it('save_agent rejects Basic credentials with a blank username before saving', async () => {
+    vi.spyOn(hostnameVerification, 'verifyAgentHostname').mockResolvedValueOnce({
+      ok: true,
+      verified_domain: 'example.com',
+      agent_hostname: 'agent.example.com',
+    });
+    const createSpy = vi.spyOn(AgentContextDatabase.prototype, 'create');
+    const saveAuthSpy = vi.spyOn(AgentContextDatabase.prototype, 'saveAuthToken');
+
+    const handler = createMemberToolHandler('save_agent');
+    const result = await handler(
+      {
+        agent_url: 'https://agent.example.com/mcp',
+        type: 'sales',
+        auth_type: 'basic',
+        auth_token: ':test-password',
+      },
+      {
+        sub: 'user_123',
+        orgId: 'org_123',
+        email: 'user@example.com',
+        isM2M: false,
+        payload: {},
+      },
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toMatch(/non-empty username/);
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(saveAuthSpy).not.toHaveBeenCalled();
+  });
+
+  it('save_agent accepts Basic credentials with a blank password and stores base64 form', async () => {
+    vi.spyOn(hostnameVerification, 'verifyAgentHostname').mockResolvedValueOnce({
+      ok: true,
+      verified_domain: 'example.com',
+      agent_hostname: 'agent.example.com',
+    });
+    vi.spyOn(AgentContextDatabase.prototype, 'getByOrgAndUrl').mockResolvedValueOnce(null);
+    vi.spyOn(AgentContextDatabase.prototype, 'create').mockResolvedValueOnce(savedAgentContext());
+    const saveAuthSpy = vi.spyOn(AgentContextDatabase.prototype, 'saveAuthToken').mockResolvedValueOnce();
+    vi.spyOn(AgentContextDatabase.prototype, 'getById').mockResolvedValueOnce(
+      savedAgentContext({
+        has_auth_token: true,
+        auth_token_hint: 'test-user:****',
+        auth_type: 'basic',
+      }),
+    );
+    vi.spyOn(MemberDatabase.prototype, 'getProfileByOrgId').mockResolvedValueOnce({
+      id: 'profile_123',
+      workos_organization_id: 'org_123',
+      display_name: 'Example Org',
+      slug: 'example-org',
+      agents: [],
+    } as any);
+    vi.spyOn(MemberDatabase.prototype, 'updateProfile').mockResolvedValueOnce({} as any);
+    vi.spyOn(clientDb, 'query').mockResolvedValueOnce({ rows: [], rowCount: 0 } as any);
+
+    const handler = createMemberToolHandler('save_agent');
+    const result = await handler(
+      {
+        agent_url: 'https://agent.example.com/mcp',
+        type: 'sales',
+        auth_type: 'basic',
+        auth_token: 'test-user:',
+      },
+      {
+        sub: 'user_123',
+        orgId: 'org_123',
+        email: 'user@example.com',
+        isM2M: false,
+        payload: {},
+      },
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain('Basic auth token saved securely');
+    expect(saveAuthSpy).toHaveBeenCalledWith(
+      'ctx_123',
+      Buffer.from('test-user:', 'utf8').toString('base64'),
+      'basic',
+    );
   });
 });
 

--- a/server/tests/unit/resolve-user-agent-auth.test.ts
+++ b/server/tests/unit/resolve-user-agent-auth.test.ts
@@ -63,18 +63,17 @@ describe('resolveUserAgentAuth', () => {
     expect(auth).toEqual({ type: 'basic', username, password });
   });
 
-  it('returns undefined when static basic auth has an empty password and no fallback auth exists', async () => {
+  it('decodes static basic auth with an empty password', async () => {
     const encoded = Buffer.from('test-user:', 'utf8').toString('base64');
     db.getAuthInfoByOrgAndUrl.mockResolvedValueOnce({ token: encoded, authType: 'basic' });
-    db.getByOrgAndUrl.mockResolvedValueOnce(null);
 
     const auth = await call();
 
-    expect(auth).toBeUndefined();
-    expect(db.getByOrgAndUrl).toHaveBeenCalledWith(ORG, URL);
+    expect(auth).toEqual({ type: 'basic', username: 'test-user', password: '' });
+    expect(db.getByOrgAndUrl).not.toHaveBeenCalled();
   });
 
-  it('falls through to OAuth when static basic auth has an empty password', async () => {
+  it('prefers static basic auth with an empty password over OAuth', async () => {
     const encoded = Buffer.from('test-user:', 'utf8').toString('base64');
     db.getAuthInfoByOrgAndUrl.mockResolvedValueOnce({ token: encoded, authType: 'basic' });
     db.getByOrgAndUrl.mockResolvedValueOnce({ id: 'ctx_1', has_oauth_token: true });
@@ -86,14 +85,9 @@ describe('resolveUserAgentAuth', () => {
 
     const auth = await call();
 
-    expect(auth).toEqual({
-      type: 'oauth',
-      tokens: { access_token: 'access', refresh_token: 'refresh' },
-    });
-    expect(logger.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ agentUrl: URL, orgId: ORG }),
-      expect.stringContaining('malformed saved Basic auth'),
-    );
+    expect(auth).toEqual({ type: 'basic', username: 'test-user', password: '' });
+    expect(db.getByOrgAndUrl).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it('returns undefined when basic auth has no colon separator and no fallback auth exists', async () => {

--- a/server/tests/unit/storyboard-runner-options.test.ts
+++ b/server/tests/unit/storyboard-runner-options.test.ts
@@ -33,6 +33,21 @@ describe('storyboard runner option helpers', () => {
     });
   });
 
+  it('threads Basic test-kit auth with an empty password into security_baseline transport auth', () => {
+    const kit: LoadedTestKit = {
+      auth: {
+        basic: { username: 'agent-user', password: '' },
+        probe_task: 'list_creatives',
+      },
+    };
+
+    expect(authForStoryboard('security_baseline', kit, 'default-token')).toEqual({
+      type: 'basic',
+      username: 'agent-user',
+      password: '',
+    });
+  });
+
   it('parses Basic credentials pairs without truncating passwords that contain colons', () => {
     const kit: LoadedTestKit = {
       auth: {
@@ -45,6 +60,21 @@ describe('storyboard runner option helpers', () => {
       type: 'basic',
       username: 'agent-user',
       password: 'pass:with:colons',
+    });
+  });
+
+  it('parses Basic credentials pairs with an empty password', () => {
+    const kit: LoadedTestKit = {
+      auth: {
+        basic: { credentials: 'agent-user:' },
+        probe_task: 'list_creatives',
+      },
+    };
+
+    expect(authForStoryboard('security_baseline', kit, 'default-token')).toEqual({
+      type: 'basic',
+      username: 'agent-user',
+      password: '',
     });
   });
 

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -48,7 +48,7 @@ const VALID_PRICING_MODELS = [
 ] as const;
 
 const TEST_AGENT_URL = 'http://localhost:3000/api/training-agent';
-const CURRENT_ADCP_VERSION = '3.1-rc.9';
+const CURRENT_ADCP_VERSION = '3.1-rc.10';
 
 const DEFAULT_CTX: TrainingContext = { mode: 'open' };
 
@@ -7953,7 +7953,7 @@ describe('get_adcp_capabilities handler', () => {
 
     expect(result.adcp).toMatchObject({
       major_versions: [3],
-      supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9'],
+      supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10'],
       idempotency: { supported: true, replay_ttl_seconds: 86400 },
     });
     expect(result.adcp_version).toBe('3.0');
@@ -8868,7 +8868,7 @@ describe('MCP Tasks protocol', () => {
         code: -32602,
         data: {
           adcp_version: '99.0',
-          supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9'],
+          supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10'],
           supported_majors: [3],
           context: { correlation_id: 'task-version-unsupported' },
           adcp_error: {
@@ -10693,7 +10693,7 @@ describe('AdCP protocol compliance', () => {
     expect(parsed.adcp_version).toBe('3.0');
     expect(parsed.adcp).toMatchObject({
       major_versions: [3],
-      supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9'],
+      supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10'],
     });
   });
 
@@ -10714,7 +10714,7 @@ describe('AdCP protocol compliance', () => {
   it('echoes exact supported pre-release adcp_version pins', async () => {
     const server = createTrainingAgentServer(DEFAULT_CTX);
 
-    for (const adcpVersion of ['3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9']) {
+    for (const adcpVersion of ['3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10']) {
       const { parsed, isError } = await simulateCallToolRaw(server, 'get_products', {
         adcp_version: adcpVersion,
         adcp_major_version: 3,
@@ -10758,7 +10758,7 @@ describe('AdCP protocol compliance', () => {
       details: {
         adcp_version: '4.0',
         adcp_major_version: 4,
-        supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9'],
+        supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10'],
         supported_majors: [3],
       },
     });
@@ -10779,7 +10779,7 @@ describe('AdCP protocol compliance', () => {
       field: 'adcp_version',
       details: {
         adcp_version: '3.1-beta',
-        supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9'],
+        supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10'],
         supported_majors: [3],
       },
     });


### PR DESCRIPTION
## Summary
- accept RFC 7617 Basic credentials with an empty password while still rejecting empty usernames
- update Addie, registry, compliance, and storyboard auth handling to preserve `user:` credentials
- bump `@adcp/sdk` to `9.0.0-beta.28` and align the training agent with `3.1-rc.10` support used by that SDK

Closes #5443.
Related adcp-client fix: adcontextprotocol/adcp-client#2213.

## Expert review
- Security review: no blockers; empty-password Basic auth keeps non-empty username validation and does not expose credentials
- Code review: addressed stale copy and added Addie/route coverage

## Validation
- `npx vitest run server/tests/unit/addie/basic-auth-normalization.test.ts server/tests/unit/compliance-db-resolve-owner-auth.test.ts server/tests/unit/resolve-user-agent-auth.test.ts server/tests/unit/compliance-heartbeat.test.ts server/tests/unit/storyboard-runner-options.test.ts server/tests/unit/mcp-eval-tools.test.ts`
- `npx vitest run server/tests/unit/training-agent.test.ts server/src/training-agent/tenants/tenant-smoke.test.ts server/tests/integration/training-agent-3-0-compat-tools.test.ts`
- `npm run typecheck`
- pre-commit: `npm run test:unit`, `test:test-dynamic-imports`, `test:callapi-state-change`, `typecheck`
- pre-push: version sync, changeset check, current storyboard matrix, 3.0 compatibility storyboard matrix
