### PR TITLE
Clarify per-tenant JWKS entries in brand agents

### DIFF
--- a/.changeset/per-tenant-jwks-agent-entries.md
+++ b/.changeset/per-tenant-jwks-agent-entries.md
@@ -1,0 +1,8 @@
+---
+"adcontextprotocol": patch
+---
+
+Clarify that brand.json may contain multiple same-type `agents[]` entries when
+they use distinct endpoint URLs, such as one sales-agent URL per publisher
+tenant. Each entry can publish its own static `jwks_uri` shard; dynamic key
+routing is optional rather than required.

--- a/specs/capabilities-brand-url.md
+++ b/specs/capabilities-brand-url.md
@@ -82,19 +82,19 @@ For any signature verification on a request from agent URL `A`:
 
 ## Multi-tenant operators
 
-An agent has exactly one `brand_url` — pointing to its **operator's** brand.json. Per-advertiser identity (an agency running on behalf of multiple advertisers) rides on **per-principal keys**, not on multiple `brand_url` values. The flow:
+An agent endpoint has exactly one `brand_url` — pointing to its **operator's** brand.json. Multi-tenant operators MAY publish multiple `agents[]` entries with the same `type` when each entry has a distinct `url`. Tenant, publisher, or property scope is represented by distinct endpoint URLs, such as one `type: "sales"` entry per publisher tenant at `/mcp/{publisher}`, under the same operator brand.json. Same-URL duplicates remain ambiguous and are rejected by verifier algorithm step 5.
 
-- The agency is the operator. Its brand.json `agents[]` lists the agent endpoint(s) it runs.
-- For per-advertiser key isolation, the operator declares `identity.per_principal_key_isolation: true` on capabilities and scopes signing keys per-principal in the JWKS (existing schema, response:1017–1021).
-- The agency's brand.json MAY declare `authorized_operators[]` granting other domains permission to operate on its behalf (existing schema, brand.json:663).
-- For the SaaS-platform case (Scope3 runs an agent at `agent.scope3.com/mcp` on behalf of Nike, whose brand.json is at `nike.com`): Nike's brand.json `agents[]` lists `agent.scope3.com/mcp`, and Nike's `authorized_operators[]` lists `scope3.com`. The verifier algorithm step 3 accepts the cross-domain agent because of the explicit delegation.
+Each `agents[]` entry can carry its own `jwks_uri`. A1-style per-tenant static shards are valid: `/.well-known/jwks/{tenant}.json` files with a small key set per tenant satisfy this spec and do not require a dynamic key-routing endpoint. A2-style routing endpoints remain an implementation option, not a protocol mandate.
 
-This keeps "one agent → one brand.json" without forcing per-advertiser endpoint proliferation.
+Per-advertiser or per-principal identity on a shared endpoint still rides on **per-principal keys**, not on multiple `brand_url` values. The operator declares `identity.per_principal_key_isolation: true` on capabilities and scopes signing keys per-principal in the JWKS (existing schema, response:1017-1021). If another domain operates an endpoint on behalf of the brand, the brand.json MAY declare `authorized_operators[]` granting that domain permission to operate on its behalf (existing schema, brand.json:663). For example, if Example Platform runs an agent at `agent.example-platform.test/mcp` on behalf of Acme Media, Acme Media's brand.json lists `agent.example-platform.test/mcp`, and `authorized_operators[]` lists `example-platform.test`. The verifier algorithm step 3 accepts the cross-domain agent because of the explicit delegation.
+
+This keeps "one endpoint → one brand.json" without forcing a single JWKS for every tenant or requiring dynamic key routing when pre-rendered shards are sufficient.
 
 ## What stays the same
 
 - `adagents.json signing_keys` precedence is unchanged: publisher pin > operator brand.json `jwks_uri` for sell-side webhooks.
-- brand.json schema is unchanged. Existing `agents[].jwks_uri` and the `/.well-known/jwks.json` origin default are unchanged.
+- brand.json validation semantics are unchanged. Existing `agents[].jwks_uri` and the `/.well-known/jwks.json` origin default are unchanged.
+- Multiple same-type `agents[]` entries remain valid when they identify distinct endpoint URLs for tenant/property scopes.
 - Webhook-signing key publication is unchanged (`security.mdx:1176`).
 - `sponsored_intelligence.brand_url` is **kept**, not deprecated. It serves a distinct rendering role and may resolve to a different URL than the trust-root `brand_url`.
 
@@ -365,7 +365,8 @@ What we lose vs. the hosted shape: the three-line `createRemoteJWKSet(aaoUrl)` i
 - **Protocol (error-code naming)**: prefixed with `request_signature_*` to join the existing family.
 - **Protocol (cross-protocol coverage gap)**: consistency check is purpose-generic — covers `webhook_signing`, `governance_signing`, `tmp_signing` not just request-signing.
 - **Protocol (SI brand_url deprecation)**: reverted — kept as a distinct rendering pointer.
-- **Product (multi-tenant agencies)**: explicit §Multi-tenant operators section — agent's `brand_url` = operator; per-advertiser identity rides on per-principal keys; `authorized_operators[]` covers the SaaS-platform case.
+- **Product (multi-tenant agencies/operators)**: explicit §Multi-tenant operators section — endpoint `brand_url` = operator; per-advertiser identity rides on per-principal keys; `authorized_operators[]` covers the SaaS-platform case.
+- **Product (multi-tenant seller-agent operators)**: clarified that multiple same-type `agents[]` entries are permitted for distinct tenant/publisher/property scopes, and that A1-style per-entry static JWKS shards satisfy the spec without mandating a dynamic key-routing endpoint.
 - **Product (AAO as SPOF)**: reframed AAO resolver as a self-hostable reference implementation; trust posture moved to the top of the §Hosted resolver section; native example first in caller integration.
 - **Product (bulk endpoint premature)**: dropped from v1 (open question 5).
 - **DX (JOSE example gotchas)**: native example shown first with explicit `algorithms`, `cacheMaxAge`, `cooldownDuration`, `issuer`; `kid` required on every JWK in resolver responses.

--- a/static/schemas/source/brand.json
+++ b/static/schemas/source/brand.json
@@ -594,7 +594,7 @@
         },
         "agents": {
           "$ref": "#/definitions/agents",
-          "description": "Agents authorized to act on behalf of this brand. Overrides house-level agents of the same type."
+          "description": "Agents authorized to act on behalf of this brand. Consumers resolving an agent by URL use the matching brand-level entry; do not infer a type-wide override of unrelated house-level entries when multiple same-type entries exist."
         },
         "brand_agent": {
           "$ref": "#/definitions/brand_agent",
@@ -827,7 +827,7 @@
     },
     "agents": {
       "type": "array",
-      "description": "Agents declared by this brand or house. One agent per type.",
+      "description": "Agents declared by this brand or house. Multiple entries with the same type are permitted when they have distinct url values, such as one endpoint URL per tenant or property scope.",
       "items": { "$ref": "#/definitions/brand_agent_entry" },
       "maxItems": 20
     },

--- a/tests/schema-validation.test.cjs
+++ b/tests/schema-validation.test.cjs
@@ -296,6 +296,44 @@ async function runTests() {
     return validateRegistryConsistency();
   });
 
+  // Test 4A: Validate brand.json permits same-type agents for scoped endpoints
+  await test('brand.json permits multiple same-type agents for scoped endpoints', async () => {
+    const testAjv = new Ajv({
+      allErrors: true,
+      verbose: true,
+      strict: false,
+      discriminator: true,
+      loadSchema: loadExternalSchema
+    });
+    addFormats(testAjv);
+
+    const validateBrand = await testAjv.compileAsync(loadSchema(path.join(SCHEMA_BASE_DIR, 'brand.json')));
+    const manifest = {
+      $schema: '/schemas/brand.json',
+      version: '1.0',
+      agents: [
+        {
+          type: 'sales',
+          url: 'https://seller.example/mcp/northwind',
+          id: 'sales_northwind',
+          jwks_uri: 'https://seller.example/.well-known/jwks/northwind.json'
+        },
+        {
+          type: 'sales',
+          url: 'https://seller.example/mcp/southridge',
+          id: 'sales_southridge',
+          jwks_uri: 'https://seller.example/.well-known/jwks/southridge.json'
+        }
+      ]
+    };
+
+    if (!validateBrand(manifest)) {
+      return validateBrand.errors.map(err => `${err.instancePath} ${err.message}`).join('; ');
+    }
+
+    return true;
+  });
+
   // Test 4B: Validate ADCP open-payload annotations
   await test('x-adcp-open-payload annotations use currently supported values', () => {
     for (const [schemaPath, schema] of schemas) {


### PR DESCRIPTION
## Summary
- Clarify that multi-tenant operators may publish multiple same-type brand.json agents entries only when each entry has a distinct endpoint URL
- Document A1-style per-tenant static JWKS shards as valid and dynamic key routing as optional
- Update brand.json schema descriptions and add a schema validation regression fixture
- Add a patch changeset

## Expert review
- Ran protocol reviewer and docs writer expert passes
- Addressed both medium findings by tightening the wording to distinct URL-based entries and removing undefined scope override semantics

## Tests
- npm run test:schemas
- precommit hook: test:unit, test:test-dynamic-imports, test:callapi-state-change, typecheck