### PR TITLE
[codex] Fix AAO badge specialism guidance

### DIFF
--- a/.changeset/fix-aao-badge-storyboard.md
+++ b/.changeset/fix-aao-badge-storyboard.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix AAO Verified specialism guidance and gate the media-buy state-machine storyboard to auto-approval sellers.

--- a/docs/building/verification/aao-verified.mdx
+++ b/docs/building/verification/aao-verified.mdx
@@ -91,7 +91,7 @@ Badges render as a single shields.io-style image with the qualifiers in parens:
 
 The badge URL is stable per agent + role. As an agent earns or loses an axis, the SVG content updates without changing the URL — embedded badges automatically reflect the current state.
 
-## How agents earn each axis
+## Declare specialisms
 
 ```json
 // agent declares its claims in get_adcp_capabilities
@@ -104,6 +104,13 @@ The badge URL is stable per agent + role. As an agent earns or loses an axis, th
   ]
 }
 ```
+
+`specialisms` is the badge-routing field. Omitting it means the agent still runs
+the universal and protocol-baseline storyboards implied by `supported_protocols`,
+but no specialism badge can be issued because the verification engine has no
+narrow claim to evaluate.
+
+## How agents earn each axis
 
 The axes are verification profiles over storyboard evidence, not separate runner implementations. The runner records what passed, failed, or skipped and why; the Spec and Sandbox profiles decide whether that evidence is sufficient for the public qualifier.
 

--- a/docs/protocol/get_adcp_capabilities.mdx
+++ b/docs/protocol/get_adcp_capabilities.mdx
@@ -141,7 +141,7 @@ Optional specialization claims. Each entry corresponds to a narrow storyboard at
 }
 ```
 
-See the full [Compliance Catalog](/docs/building/compliance-catalog) for every specialism and the [enum schema](https://adcontextprotocol.org/schemas/v3/enums/specialism.json) for the authoritative list.
+See the full [Compliance Catalog](/docs/building/verification/compliance-catalog) for every specialism and the [enum schema](https://adcontextprotocol.org/schemas/v3/enums/specialism.json) for the authoritative list.
 
 ### account
 

--- a/static/compliance/source/protocols/media-buy/state-machine.yaml
+++ b/static/compliance/source/protocols/media-buy/state-machine.yaml
@@ -4,6 +4,15 @@ title: "Media buy state machine lifecycle"
 category: media_buy_state_machine
 summary: "Validates media buy state transitions: create, pause, resume, cancel, and terminal state enforcement."
 track: media_buy
+
+# This storyboard drives pause/resume immediately after create_media_buy. That
+# only works for sellers that explicitly declare auto-approval; manual-review
+# sellers may legitimately remain pending until approval and should not fail
+# an active-state transition test they cannot reach through the buyer surface.
+requires_capability:
+  path: media_buy.creative_approval_mode
+  equals: auto_approve
+
 required_tools:
   - create_media_buy
   - sync_creatives
@@ -14,9 +23,10 @@ narrative: |
   paused, completed, rejected, canceled. Transitions between states must follow the spec — you cannot
   resume a canceled buy or pause a completed one.
 
-  This storyboard creates a media buy, walks it through pause/resume/cancel transitions, then
-  verifies that the agent rejects updates to a buy in a terminal state (canceled or completed).
-  It also tests package-level pause/resume independent of the media buy status.
+  This storyboard applies to sellers that declare media_buy.creative_approval_mode:
+  auto_approve. It creates a media buy, walks it through pause/resume/cancel transitions,
+  then verifies that the agent rejects updates to a buy in a terminal state (canceled or
+  completed). It also tests package-level pause/resume independent of the media buy status.
 
   The state machine is the backbone of media buy reliability. If an agent allows invalid
   transitions, buyers cannot trust the status field and automation breaks down.
@@ -233,6 +243,10 @@ phases:
           - check: field_present
             path: "media_buy_id"
             description: "Response includes a media_buy_id"
+          - check: field_value
+            path: "media_buy_status"
+            allowed_values: ["active"]
+            description: "Auto-approval state-machine test starts from an active media buy"
 
           - check: field_present
             path: "context"


### PR DESCRIPTION
## Summary

- Gate the media-buy state-machine storyboard on `media_buy.creative_approval_mode: auto_approve`
- Assert the created buy is active before the pause/resume sequence, so failures point at the real unmet prerequisite
- Add a stable `#declare-specialisms` section to the AAO Verified docs and clarify that `get_adcp_capabilities.specialisms` drives badge issuance
- Update the `get_adcp_capabilities` specialisms link to the current Compliance Catalog path

## Why

An adopter reported a green storyboard run that still could not issue a badge because the agent did not declare any specialisms. The docs had the relevant example, but the linked anchor was stale and the badge-routing role of `specialisms` was not explicit enough.

The same run also surfaced a false failure in the media-buy state-machine storyboard: the scenario paused a buy immediately after creation, which is only valid for sellers that explicitly auto-approve creatives and activate the buy. Manual-review sellers can legitimately remain pending and should not fail this active-state transition test.

## Validation

- `node --test tests/lint-storyboard-sample-request-schema.test.cjs tests/lint-storyboard-validations-paths.test.cjs tests/lint-storyboard-branch-sets.test.cjs tests/lint-storyboard-check-enum.test.cjs`
- `npm run test:docs-nav`
- `npm run build:compliance`
- Precommit hook:
  - `npm run test:unit`
  - `npm run test:test-dynamic-imports`
  - `npm run test:callapi-state-change`
  - `npm run typecheck`
