### PR TITLE
Pin storyboard schema roots for compliance runs

### DIFF
--- a/.changeset/pin-storyboard-schema-root.md
+++ b/.changeset/pin-storyboard-schema-root.md
@@ -1,0 +1,4 @@
+---
+---
+
+Pin storyboard compatibility runs to the matching schema root without changing package output.

--- a/.github/workflows/training-agent-storyboards.yml
+++ b/.github/workflows/training-agent-storyboards.yml
@@ -225,16 +225,13 @@ jobs:
           echo "schema_dir=${SCHEMA_DIR}" >> "$GITHUB_OUTPUT"
           echo "Using ${DIR}"
 
-      - name: Stage latest released 3.0.x schema bundle
-        if: matrix.surface == '3.0-compat'
-        run: bash scripts/stage-sdk-schema-bundle.sh "${{ steps.compat-bundle.outputs.schema_dir }}" "${{ steps.compat-bundle.outputs.version }}"
-
       - name: Run storyboards against /${{ matrix.tenant }}
         id: run
         env:
           TENANT_PATH: ${{ matrix.tenant }}
           PUBLIC_TEST_AGENT_TOKEN: storyboard-ci-token
           ADCP_COMPLIANCE_DIR: ${{ steps.compat-bundle.outputs.dir }}
+          ADCP_SCHEMA_ROOT: ${{ steps.compat-bundle.outputs.schema_dir }}
         run: |
           set -uo pipefail
           # The runner exits 1 when any storyboard step fails (intentional —

--- a/scripts/run-storyboards-matrix.sh
+++ b/scripts/run-storyboards-matrix.sh
@@ -167,6 +167,43 @@ const index = JSON.parse(fs.readFileSync(path.join(dir, 'index.json'), 'utf8'));
 process.stdout.write(index.adcp_version || '');
 NODE
 )
+  if [ -z "${SCHEMA_ROOT}" ]; then
+    SCHEMA_ROOT=$(node - <<'NODE' "${COMPLIANCE_DIR}" "${bundle_version}" "${REPO_ROOT}"
+const fs = require('node:fs');
+const path = require('node:path');
+const complianceDir = path.resolve(process.argv[2]);
+const bundleVersion = process.argv[3];
+const repoRoot = path.resolve(process.argv[4]);
+const bundleName = path.basename(complianceDir);
+const keys = [...new Set([bundleVersion, bundleName].filter(Boolean))];
+const candidates = [];
+const add = (candidate) => {
+  if (candidate && !candidates.includes(candidate)) candidates.push(candidate);
+};
+
+const complianceParent = path.dirname(complianceDir);
+const distDir = path.dirname(complianceParent);
+if (path.basename(complianceParent) === 'compliance' && path.basename(distDir) === 'dist') {
+  const packageRoot = path.dirname(distDir);
+  for (const key of keys) {
+    add(path.join(packageRoot, 'dist', 'schemas', key));
+    add(path.join(packageRoot, 'schemas', 'cache', key));
+  }
+}
+for (const key of keys) {
+  add(path.join(repoRoot, 'dist', 'schemas', key));
+  add(path.join(repoRoot, 'schemas', 'cache', key));
+}
+
+const found = candidates.find(candidate => fs.existsSync(path.join(candidate, 'index.json')));
+if (found) process.stdout.write(found);
+NODE
+)
+  fi
+  if [ -z "${SCHEMA_ROOT}" ]; then
+    echo "::error::No matching schema bundle found for compliance bundle ${COMPLIANCE_DIR}. Set ADCP_SCHEMA_ROOT or use a co-located dist/schemas/<version> bundle."
+    exit 1
+  fi
   if [[ "${bundle_version}" =~ ^3\.0\.[0-9]+$ ]]; then
     FLOOR_SET="3.0-compat"
   fi

--- a/scripts/run-storyboards-matrix.sh
+++ b/scripts/run-storyboards-matrix.sh
@@ -14,6 +14,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 OVERLAY=1
 COMPLIANCE_DIR=""
+SCHEMA_ROOT="${ADCP_SCHEMA_ROOT:-}"
 LABEL="current compliance source"
 FLOOR_SET="current"
 RELEASE_BASE_REF="${ADCP_RELEASE_BASE_REF:-origin/3.0.x}"
@@ -116,7 +117,7 @@ NODE
         node "${SCRIPT_DIR}/patch-3-0-compat-bundle.cjs" "${COMPLIANCE_DIR}"
         if git -C "${REPO_ROOT}" cat-file -e "${RELEASE_GIT_REF}:dist/schemas/${latest_3_0}/index.json" 2>/dev/null; then
           git -C "${REPO_ROOT}" archive "${RELEASE_GIT_REF}" "dist/schemas/${latest_3_0}" | tar -x -C "${bundle_tmp}"
-          bash "${SCRIPT_DIR}/stage-sdk-schema-bundle.sh" "${bundle_tmp}/dist/schemas/${latest_3_0}" "${latest_3_0}"
+          SCHEMA_ROOT="${bundle_tmp}/dist/schemas/${latest_3_0}"
         fi
       else
         bundle_tmp=$(mktemp -d -t "storyboards-3-0-compat.XXXXXX")
@@ -125,8 +126,12 @@ NODE
         COMPLIANCE_DIR="${bundle_tmp}/dist/compliance/${latest_3_0}"
         node "${SCRIPT_DIR}/patch-3-0-compat-bundle.cjs" "${COMPLIANCE_DIR}"
         if [ -f "${REPO_ROOT}/dist/schemas/${latest_3_0}/index.json" ]; then
-          bash "${SCRIPT_DIR}/stage-sdk-schema-bundle.sh" "${REPO_ROOT}/dist/schemas/${latest_3_0}" "${latest_3_0}"
+          SCHEMA_ROOT="${REPO_ROOT}/dist/schemas/${latest_3_0}"
         fi
+      fi
+      if [ -z "${SCHEMA_ROOT}" ]; then
+        echo "::error::No dist/schemas/${latest_3_0} bundle found"
+        exit 1
       fi
       LABEL="released compliance bundle: ${latest_3_0}"
       FLOOR_SET="3.0-compat"
@@ -165,6 +170,17 @@ NODE
   if [[ "${bundle_version}" =~ ^3\.0\.[0-9]+$ ]]; then
     FLOOR_SET="3.0-compat"
   fi
+fi
+
+if [ -n "${SCHEMA_ROOT}" ]; then
+  if [ "${SCHEMA_ROOT#/}" = "${SCHEMA_ROOT}" ]; then
+    SCHEMA_ROOT="${REPO_ROOT}/${SCHEMA_ROOT}"
+  fi
+  if [ ! -f "${SCHEMA_ROOT}/index.json" ]; then
+    echo "::error::Schema bundle not found at ${SCHEMA_ROOT}"
+    exit 1
+  fi
+  export ADCP_SCHEMA_ROOT="${SCHEMA_ROOT}"
 fi
 
 restore_sdk_generated_schema

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -639,6 +639,7 @@ async function main() {
           const targetUrl = agentUrl.replace(/\/mcp$/, variant.routeSuffix);
           const result = await runStoryboard(targetUrl, storyboard, {
             ...(releasedComplianceVersion && { adcpVersion: releasedComplianceVersion }),
+            ...(complianceOptions?.schemaRoot && { schemaRoot: complianceOptions.schemaRoot }),
             auth,
             allow_http: true,
             contracts: ['webhook_receiver_runner'],
@@ -684,6 +685,7 @@ async function main() {
         // calls keep working.
         const result = await runStoryboard(agentUrl, storyboard, {
           ...(releasedComplianceVersion && { adcpVersion: releasedComplianceVersion }),
+          ...(complianceOptions?.schemaRoot && { schemaRoot: complianceOptions.schemaRoot }),
           auth,
           allow_http: true,
           contracts: ['webhook_receiver_runner'],


### PR DESCRIPTION
## Summary

Fixes the in-repo storyboard matrix paths so released compliance bundle runs validate with the matching schema bundle instead of falling back to the installed SDK schema snapshot.

Changes:
- Thread `ADCP_SCHEMA_ROOT` through both manual `runStoryboard()` call sites when `ADCP_COMPLIANCE_DIR` is set.
- Update the local `--latest-3.0` path to export `ADCP_SCHEMA_ROOT` directly instead of staging released schemas into `node_modules/@adcp/sdk`.
- Update the CI 3.0-compat path to pass `ADCP_SCHEMA_ROOT` directly.
- Resolve or fail-hard on matching schemas for explicit local `--compliance-dir` runs, so manual released-bundle pins cannot silently validate against the wrong schema line.
- Add an empty changeset because this is test/CI runner plumbing with no package output change.

## Why

`adcp#5449` reported version skew where storyboards were pinned to an older compliance bundle while AJV validation could still use newer installed SDK schemas. This PR fixes the in-repo runner/matrix half of that problem.

The broader user-facing `adcp-client` CLI behavior remains tracked upstream in `adcontextprotocol/adcp-client#2206`.

## Validation

- `bash -n scripts/run-storyboards-matrix.sh`
- resolver check: `dist/compliance/3.0.13 -> dist/schemas/3.0.13`
- precommit checks:
  - `npm run test:unit`
  - `npm run test:test-dynamic-imports`
  - `npm run test:callapi-state-change`
  - `npm run typecheck`
- pre-push current-source storyboard matrix: all tenant floors passed
- pre-push released `3.0.15` compatibility matrix: all tenant floors passed
