### PR TITLE
fix(test): stabilize admin cross-tenant auth test

### DIFF
--- a/.changeset/fix-admin-cross-tenant-test-flake.md
+++ b/.changeset/fix-admin-cross-tenant-test-flake.md
@@ -1,0 +1,6 @@
+---
+---
+
+Empty changeset: server test-infra cleanup only. Auth middleware background
+cleanup timers no longer keep Vitest workers alive, and the flaky admin
+cross-tenant unit test now bootstraps its WorkOS env before importing auth.

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -64,8 +64,15 @@ function warnOncePerSession(
   }
 }
 
+function startBackgroundCleanup(callback: () => void, intervalMs: number): void {
+  const timer = setInterval(callback, intervalMs) as ReturnType<typeof setInterval> & {
+    unref?: () => void;
+  };
+  timer.unref?.();
+}
+
 // Clean up expired cache entries periodically (every 5 minutes)
-setInterval(() => {
+startBackgroundCleanup(() => {
   const now = Date.now();
   let cleaned = 0;
   for (const [key, value] of sessionCache.entries()) {
@@ -89,7 +96,7 @@ setInterval(() => {
 }, 5 * 60 * 1000);
 
 // Clean up expired DB session refresh entries (every 10 minutes)
-setInterval(() => {
+startBackgroundCleanup(() => {
   cleanExpiredRefreshes().then(cleaned => {
     if (cleaned > 0) {
       logger.debug({ cleaned }, 'Cleaned expired session refresh DB entries');
@@ -107,7 +114,7 @@ const banCache = new Map<string, CachedBanCheck>();
 const BAN_CACHE_TTL_MS = 60 * 1000;
 
 // Clean up expired ban cache entries alongside session cache
-setInterval(() => {
+startBackgroundCleanup(() => {
   const now = Date.now();
   for (const [key, value] of banCache.entries()) {
     if (value.expiresAt < now) {

--- a/server/tests/unit/require-admin-cross-tenant.test.ts
+++ b/server/tests/unit/require-admin-cross-tenant.test.ts
@@ -15,21 +15,26 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 
-// requireAdmin reads ADMIN_EMAILS lazily; populate before import so the
-// SSO-admin branch is reachable in tests that want it. WorkOS init
-// happens at module-load — give it placeholder env so the import works.
-process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'test';
-process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+// requireAdmin imports WorkOS at module load. Keep these local defaults so
+// this file runs under both root Vitest config and server/vitest.config.ts.
+process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'sk_test_mock_key';
+process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_mock_id';
 process.env.WORKOS_COOKIE_PASSWORD =
   process.env.WORKOS_COOKIE_PASSWORD ??
-  'placeholder-cookie-password-32-bytes-min';
+  'test-cookie-password-at-least-32-chars-long';
+
+const {
+  requireAdmin,
+  requireAuth,
+  requireGlobalAdmin,
+  refuseAnyApiKeyOnGlobalAdmin,
+  refuseCrossTenantAdminApiKey,
+} = await import('../../src/middleware/auth.js');
 
 describe('requireAdmin cross-tenant API key defense', () => {
   let app: express.Application;
 
-  beforeAll(async () => {
-    const { requireAdmin } = await import('../../src/middleware/auth.js');
-
+  beforeAll(() => {
     app = express();
 
     // Helper that lets each test set req.apiKey and req.params.orgId
@@ -155,10 +160,7 @@ describe('requireAdmin cross-tenant API key defense', () => {
 describe('refuseCrossTenantAdminApiKey + refuseAnyApiKeyOnGlobalAdmin helpers', () => {
   let app: express.Application;
 
-  beforeAll(async () => {
-    const { refuseCrossTenantAdminApiKey, refuseAnyApiKeyOnGlobalAdmin } =
-      await import('../../src/middleware/auth.js');
-
+  beforeAll(() => {
     app = express();
 
     app.use((req, _res, next) => {
@@ -239,10 +241,7 @@ describe('requireGlobalAdmin composite middleware', () => {
   // requireAuth has a real session to validate; here we pin the
   // composition shape so a future refactor doesn't silently re-order
   // or drop a middleware from the chain.
-  it('is a 3-element middleware array in the documented order', async () => {
-    const { requireGlobalAdmin, requireAuth, requireAdmin } = await import(
-      '../../src/middleware/auth.js'
-    );
+  it('is a 3-element middleware array in the documented order', () => {
     expect(requireGlobalAdmin).toHaveLength(3);
     // First and last are the existing requireAuth / requireAdmin
     // exports; the middle is the chain's new contribution. Pinning
@@ -255,7 +254,6 @@ describe('requireGlobalAdmin composite middleware', () => {
   });
 
   it('the middle middleware refuses an apiKey-bearing request and short-circuits next()', async () => {
-    const { requireGlobalAdmin } = await import('../../src/middleware/auth.js');
     const middle = requireGlobalAdmin[1];
 
     let nextCalled = false;
@@ -280,7 +278,6 @@ describe('requireGlobalAdmin composite middleware', () => {
   });
 
   it('the middle middleware calls next() when no apiKey is present', async () => {
-    const { requireGlobalAdmin } = await import('../../src/middleware/auth.js');
     const middle = requireGlobalAdmin[1];
 
     let nextCalled = false;


### PR DESCRIPTION
## Summary

- Make auth middleware background cleanup intervals call `unref()` so they do not keep Vitest workers alive.
- Keep the admin cross-tenant unit test env bootstrap local before importing auth so it works under both root and server Vitest configs.
- Add an empty changeset for server test-infra cleanup.

## Root Cause

`auth.ts` starts long-lived module-level cleanup intervals. Under full unit-test runs those timers can keep workers alive or race with test teardown, surfacing as a flaky admin cross-tenant test even though the middleware logic is pure.

## Validation

- `npx vitest run server/tests/unit/require-admin-cross-tenant.test.ts`
- `npx vitest run server/tests/unit/require-admin-cross-tenant.test.ts --config server/vitest.config.ts`
- commit hook: `npm run test:unit && npm run test:test-dynamic-imports && npm run test:callapi-state-change && npm run typecheck`
