### PR TITLE
fix(website): improve perspectives crawlability

### DIFF
--- a/.changeset/5357-perspectives-crawlability.md
+++ b/.changeset/5357-perspectives-crawlability.md
@@ -1,0 +1,10 @@
+---
+---
+
+website: make published Perspectives discoverable to crawlers.
+
+Adds dynamic `/llms.txt` and `/.well-known/llms.txt` responses that list published editorial Perspectives, plus `/perspectives/feed.xml` as an RSS feed with title, URL, author, publication date, and excerpt. The AAO LLM route is registered ahead of static serving, while the AdCP host still falls through to the existing protocol overview file. The RSS route is registered before `/perspectives/:slug` so `feed.xml` is not treated as an article slug.
+
+Replaces the dead dynamic `/robots.txt` handler with a host-aware route registered before static serving, so `agenticadvertising.org` advertises AAO crawl surfaces and `adcontextprotocol.org` advertises AdCP crawl surfaces.
+
+Closes #5357.

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -155,6 +155,204 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const logger = createLogger('http-server');
+const PUBLIC_SITE_URL = 'https://agenticadvertising.org';
+const PERSPECTIVES_CRAWLER_LIMIT = 200;
+
+interface PublicPerspectiveCrawlerItem {
+  slug: string;
+  content_type: string;
+  title: string;
+  excerpt: string | null;
+  external_url: string | null;
+  author_name: string | null;
+  published_at: Date | string | null;
+  updated_at: Date | string | null;
+}
+
+function escapeXml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function compactPlainText(value: unknown): string {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function escapeMarkdownText(value: unknown): string {
+  return compactPlainText(value).replace(/([\\[\]()])/g, '\\$1');
+}
+
+function coerceDate(value: unknown): Date | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(String(value));
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function formatRssDate(value: unknown): string {
+  return (coerceDate(value) ?? new Date()).toUTCString();
+}
+
+function buildPerspectiveUrl(slug: string): string {
+  return `${PUBLIC_SITE_URL}/perspectives/${encodeURIComponent(slug)}`;
+}
+
+function getPerspectiveCrawlerUrl(item: PublicPerspectiveCrawlerItem): string {
+  return item.content_type === 'link' && item.external_url
+    ? item.external_url
+    : buildPerspectiveUrl(item.slug);
+}
+
+async function getPublicPerspectiveCrawlerItems(limit = PERSPECTIVES_CRAWLER_LIMIT): Promise<PublicPerspectiveCrawlerItem[]> {
+  const pool = getPool();
+  const result = await pool.query<PublicPerspectiveCrawlerItem>(
+    `SELECT
+        p.slug,
+        p.content_type,
+        p.title,
+        p.excerpt,
+        p.external_url,
+        p.author_name,
+        COALESCE(p.published_at, p.created_at) AS published_at,
+        p.updated_at
+     FROM perspectives p
+     LEFT JOIN working_groups wg ON wg.id = p.working_group_id
+     WHERE p.status = 'published'
+       AND (p.working_group_id IS NULL OR wg.slug = 'editorial')
+       AND (p.source_type IS NULL OR p.source_type NOT IN ('rss', 'email'))
+     ORDER BY p.published_at DESC NULLS LAST, p.created_at DESC
+     LIMIT $1`,
+    [limit]
+  );
+  return result.rows;
+}
+
+function buildLlmsTxt(items: PublicPerspectiveCrawlerItem[]): string {
+  const lines = [
+    '# AgenticAdvertising.org',
+    '',
+    '> AgenticAdvertising.org is the member organization that maintains AdCP and publishes community perspectives on agentic advertising.',
+    '',
+    '## Discoverability',
+    '',
+    `- [Sitemap](${PUBLIC_SITE_URL}/sitemap.xml)`,
+    `- [Perspectives RSS feed](${PUBLIC_SITE_URL}/perspectives/feed.xml)`,
+    '',
+    '## Perspectives',
+    '',
+  ];
+
+  if (items.length === 0) {
+    lines.push(`- [Latest perspectives](${PUBLIC_SITE_URL}/latest/perspectives)`);
+  } else {
+    for (const item of items) {
+      const title = escapeMarkdownText(item.title);
+      const excerpt = escapeMarkdownText(item.excerpt);
+      lines.push(`- [${title}](${getPerspectiveCrawlerUrl(item)})${excerpt ? `: ${excerpt}` : ''}`);
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+function buildPerspectivesRss(items: PublicPerspectiveCrawlerItem[]): string {
+  const latestDate = items
+    .map((item) => coerceDate(item.updated_at) ?? coerceDate(item.published_at))
+    .filter((date): date is Date => date !== null)
+    .sort((a, b) => b.getTime() - a.getTime())[0] ?? new Date();
+
+  const entries = items.map((item) => {
+    const url = getPerspectiveCrawlerUrl(item);
+    const author = compactPlainText(item.author_name) || 'AgenticAdvertising.org';
+    return `    <item>
+      <title>${escapeXml(item.title)}</title>
+      <link>${escapeXml(url)}</link>
+      <guid isPermaLink="true">${escapeXml(url)}</guid>
+      <dc:creator>${escapeXml(author)}</dc:creator>
+      <pubDate>${formatRssDate(item.published_at)}</pubDate>
+      <description>${escapeXml(item.excerpt)}</description>
+    </item>`;
+  }).join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>AgenticAdvertising.org Perspectives</title>
+    <link>${PUBLIC_SITE_URL}/latest/perspectives</link>
+    <description>Published perspectives from AgenticAdvertising.org members and contributors.</description>
+    <language>en-us</language>
+    <lastBuildDate>${latestDate.toUTCString()}</lastBuildDate>
+    <atom:link href="${PUBLIC_SITE_URL}/perspectives/feed.xml" rel="self" type="application/rss+xml" />
+${entries}
+  </channel>
+</rss>`;
+}
+
+function buildRobotsTxt(baseUrl: string, hostLabel: string): string {
+  return `# robots.txt for ${hostLabel}
+# AdCP - Ad Context Protocol by AgenticAdvertising.org
+
+# Allow all standard crawlers
+User-agent: *
+Allow: /
+Disallow: /aao-w9.pdf
+
+# Explicitly allow AI crawlers
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: cohere-ai
+Allow: /
+
+User-agent: Meta-ExternalAgent
+Allow: /
+
+# Block known bad bots
+User-agent: AhrefsBot
+Disallow: /
+
+User-agent: SemrushBot
+Disallow: /
+
+User-agent: MJ12bot
+Disallow: /
+
+User-agent: DotBot
+Disallow: /
+
+User-agent: BLEXBot
+Disallow: /
+
+# Sitemap and LLMs.txt
+Sitemap: ${baseUrl}/sitemap.xml
+Llms-txt: ${baseUrl}/llms.txt
+`;
+}
 
 function isPendingWorkOSMembershipError(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false;
@@ -891,6 +1089,35 @@ export class HTTPServer {
         return res.redirect(301, target);
       }
       next();
+    });
+
+    // Host-aware robots.txt must run before public static files so AAO and
+    // AdCP advertise crawl surfaces on their own domains.
+    this.app.get('/robots.txt', (req, res) => {
+      const isAdcp = this.isAdcpDomain(req);
+      const baseUrl = isAdcp ? 'https://adcontextprotocol.org' : PUBLIC_SITE_URL;
+      const hostLabel = isAdcp ? 'adcontextprotocol.org' : 'agenticadvertising.org';
+      res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+      res.setHeader('Cache-Control', 'public, max-age=300');
+      res.send(buildRobotsTxt(baseUrl, hostLabel));
+    });
+
+    // Serve AAO llms.txt dynamically before public static files so the crawler
+    // inventory includes the latest published Perspectives. AdCP falls through
+    // to the static protocol overview at server/public/llms.txt.
+    this.app.get(['/llms.txt', '/.well-known/llms.txt'], async (req, res, next) => {
+      if (this.isAdcpDomain(req)) {
+        return next();
+      }
+      try {
+        const items = await getPublicPerspectiveCrawlerItems();
+        res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+        res.setHeader('Cache-Control', 'public, max-age=300');
+        res.send(buildLlmsTxt(items));
+      } catch (error) {
+        logger.error({ err: error }, 'Generate llms.txt error:');
+        res.status(500).send('Error generating llms.txt');
+      }
     });
 
     this.app.use(express.static(publicPath, {
@@ -2573,6 +2800,20 @@ export class HTTPServer {
     // Perspectives index redirects to perspectives section
     this.app.get("/perspectives", (req, res) => {
       res.redirect(301, "/latest/perspectives");
+    });
+
+    // RSS feed for published editorial Perspectives. Must be registered before
+    // /perspectives/:slug so feed.xml is not treated as an article slug.
+    this.app.get("/perspectives/feed.xml", async (_req, res) => {
+      try {
+        const items = await getPublicPerspectiveCrawlerItems();
+        res.setHeader('Content-Type', 'application/rss+xml; charset=utf-8');
+        res.setHeader('Cache-Control', 'public, max-age=300');
+        res.send(buildPerspectivesRss(items));
+      } catch (error) {
+        logger.error({ err: error }, 'Generate perspectives RSS error:');
+        res.status(500).send('Error generating perspectives RSS feed');
+      }
     });
 
     // Perspectives detail page - serves article content with SSR meta tags for social sharing
@@ -5704,7 +5945,7 @@ export class HTTPServer {
     this.app.use('/api/me/meetings', meetingsUserRouter);
 
     // ========================================
-    // SEO Routes (sitemap.xml, robots.txt)
+    // SEO Routes (sitemap.xml)
     // ========================================
 
     // GET /sitemap.xml - Dynamic sitemap including all published perspectives
@@ -5719,7 +5960,9 @@ export class HTTPServer {
            FROM perspectives p
            LEFT JOIN working_groups wg ON wg.id = p.working_group_id
            WHERE p.status = 'published'
+             AND p.content_type = 'article'
              AND (p.working_group_id IS NULL OR wg.slug = 'editorial')
+             AND (p.source_type IS NULL OR p.source_type NOT IN ('rss', 'email'))
            ORDER BY p.published_at DESC`
         );
 
@@ -5768,25 +6011,6 @@ export class HTTPServer {
         logger.error({ err: error }, 'Generate sitemap error:');
         res.status(500).send('Error generating sitemap');
       }
-    });
-
-    // GET /robots.txt - Robots file with sitemap reference
-    this.app.get('/robots.txt', (req, res) => {
-      const baseUrl = 'https://agenticadvertising.org';
-      const robotsTxt = `# AgenticAdvertising.org Robots.txt
-User-agent: *
-Allow: /
-
-# Sitemaps
-Sitemap: ${baseUrl}/sitemap.xml
-
-# Disallow admin pages
-Disallow: /admin/
-Disallow: /auth/
-Disallow: /api/admin/
-`;
-      res.set('Content-Type', 'text/plain');
-      res.send(robotsTxt);
     });
 
     // ========================================

--- a/server/tests/unit/perspectives-crawlability.test.ts
+++ b/server/tests/unit/perspectives-crawlability.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import request from 'supertest';
+import { HTTPServer } from '../../src/http.js';
+
+const queryMock = vi.hoisted(() => vi.fn());
+const ORIGINAL_WORKOS_ENV = vi.hoisted(() => ({
+  apiKey: process.env.WORKOS_API_KEY,
+  clientId: process.env.WORKOS_CLIENT_ID,
+}));
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY || 'sk_test_perspectives_crawlability';
+  process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID || 'client_test_perspectives_crawlability';
+});
+
+vi.mock('../../src/config.js', async () => {
+  const actual = await vi.importActual('../../src/config.js');
+  return {
+    ...actual,
+    getDatabaseConfig: vi.fn().mockReturnValue({
+      connectionString: 'postgresql://localhost/test',
+    }),
+  };
+});
+
+vi.mock('../../src/db/client.js', () => ({
+  initializeDatabase: vi.fn(),
+  getPool: vi.fn().mockReturnValue({ query: queryMock }),
+  isDatabaseInitialized: vi.fn().mockReturnValue(true),
+  closeDatabase: vi.fn(),
+  healthCheck: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/db/migrate.js', () => ({
+  runMigrations: vi.fn().mockResolvedValue(undefined),
+}));
+
+const perspectiveRows = [
+  {
+    slug: 'agentic-crawlability',
+    content_type: 'article',
+    title: 'Agentic crawlability & discovery',
+    excerpt: 'How AI crawlers find member perspectives.',
+    external_url: null,
+    author_name: 'Avery Writer',
+    published_at: new Date('2026-06-01T12:00:00Z'),
+    updated_at: new Date('2026-06-02T12:00:00Z'),
+  },
+  {
+    slug: 'xml-escaping',
+    content_type: 'article',
+    title: 'Signals <Strategy> & "Safety"',
+    excerpt: 'Escapes <unsafe> & quoted text.',
+    external_url: null,
+    author_name: 'Casey & Co.',
+    published_at: new Date('2026-05-30T12:00:00Z'),
+    updated_at: new Date('2026-05-30T12:00:00Z'),
+  },
+  {
+    slug: 'external-perspective',
+    content_type: 'link',
+    title: 'Partner [view] (field notes)',
+    excerpt: 'External (but curated) perspective with [brackets].',
+    external_url: 'https://partner.example/field-notes',
+    author_name: 'Drew Curator',
+    published_at: new Date('2026-05-29T12:00:00Z'),
+    updated_at: new Date('2026-05-29T12:00:00Z'),
+  },
+];
+
+describe('Perspectives crawlability routes', () => {
+  let server: HTTPServer | undefined;
+
+  afterEach(async () => {
+    queryMock.mockReset();
+    await server?.stop();
+    server = undefined;
+    if (ORIGINAL_WORKOS_ENV.apiKey === undefined) {
+      delete process.env.WORKOS_API_KEY;
+    } else {
+      process.env.WORKOS_API_KEY = ORIGINAL_WORKOS_ENV.apiKey;
+    }
+    if (ORIGINAL_WORKOS_ENV.clientId === undefined) {
+      delete process.env.WORKOS_CLIENT_ID;
+    } else {
+      process.env.WORKOS_CLIENT_ID = ORIGINAL_WORKOS_ENV.clientId;
+    }
+  });
+
+  function app() {
+    server = new HTTPServer();
+    return (server as unknown as { app: unknown }).app;
+  }
+
+  it('serves dynamic llms.txt with published perspective URLs before static llms.txt', async () => {
+    queryMock.mockResolvedValue({ rows: perspectiveRows });
+
+    const res = await request(app()).get('/llms.txt').set('Host', 'agenticadvertising.org');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/plain');
+    expect(res.headers['cache-control']).toBe('public, max-age=300');
+    expect(res.text).toContain('# AgenticAdvertising.org');
+    expect(res.text).toContain('## Perspectives');
+    expect(res.text).toContain('[Agentic crawlability & discovery](https://agenticadvertising.org/perspectives/agentic-crawlability)');
+    expect(res.text).toContain('[Partner \\[view\\] \\(field notes\\)](https://partner.example/field-notes): External \\(but curated\\) perspective with \\[brackets\\].');
+    expect(res.text).toContain('[Perspectives RSS feed](https://agenticadvertising.org/perspectives/feed.xml)');
+    expect(res.text).not.toContain('# AdCP - Ad Context Protocol');
+    expect(queryMock).toHaveBeenCalledWith(expect.stringContaining("p.status = 'published'"), [200]);
+  });
+
+  it('falls through to the static protocol llms.txt on the AdCP host', async () => {
+    const res = await request(app()).get('/llms.txt').set('Host', 'adcontextprotocol.org');
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('# AdCP - Ad Context Protocol');
+    expect(res.text).not.toContain('## Perspectives');
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('serves the same llms.txt from the well-known path', async () => {
+    queryMock.mockResolvedValue({ rows: perspectiveRows });
+
+    const res = await request(app()).get('/.well-known/llms.txt').set('Host', 'agenticadvertising.org');
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('https://agenticadvertising.org/perspectives/agentic-crawlability');
+  });
+
+  it('serves host-aware robots.txt before the shared static file', async () => {
+    const aao = await request(app()).get('/robots.txt').set('Host', 'agenticadvertising.org');
+
+    expect(aao.status).toBe(200);
+    expect(aao.headers['cache-control']).toBe('public, max-age=300');
+    expect(aao.text).toContain('Sitemap: https://agenticadvertising.org/sitemap.xml');
+    expect(aao.text).toContain('Llms-txt: https://agenticadvertising.org/llms.txt');
+    expect(aao.text).not.toContain('Llms-txt: https://adcontextprotocol.org/llms.txt');
+
+    await server?.stop();
+    server = undefined;
+
+    const adcp = await request(app()).get('/robots.txt').set('Host', 'adcontextprotocol.org');
+    expect(adcp.status).toBe(200);
+    expect(adcp.text).toContain('Sitemap: https://adcontextprotocol.org/sitemap.xml');
+    expect(adcp.text).toContain('Llms-txt: https://adcontextprotocol.org/llms.txt');
+  });
+
+  it('keeps sitemap generation scoped to first-party published article pages', async () => {
+    queryMock.mockResolvedValue({ rows: [perspectiveRows[0]] });
+
+    const res = await request(app()).get('/sitemap.xml').set('Host', 'agenticadvertising.org');
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('https://agenticadvertising.org/perspectives/agentic-crawlability');
+    expect(queryMock).toHaveBeenCalledWith(expect.stringContaining("p.content_type = 'article'"));
+    expect(queryMock).toHaveBeenCalledWith(expect.stringContaining("p.source_type IS NULL OR p.source_type NOT IN ('rss', 'email')"));
+  });
+
+  it('serves an RSS feed for perspectives and XML-escapes article fields', async () => {
+    queryMock.mockResolvedValue({ rows: perspectiveRows });
+
+    const res = await request(app()).get('/perspectives/feed.xml').set('Host', 'agenticadvertising.org');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('application/rss+xml');
+    expect(res.headers['cache-control']).toBe('public, max-age=300');
+    expect(res.text).toContain('<rss version="2.0"');
+    expect(res.text).toContain('<title>Agentic crawlability &amp; discovery</title>');
+    expect(res.text).toContain('<dc:creator>Casey &amp; Co.</dc:creator>');
+    expect(res.text).toContain('<title>Signals &lt;Strategy&gt; &amp; &quot;Safety&quot;</title>');
+    expect(res.text).toContain('<description>Escapes &lt;unsafe&gt; &amp; quoted text.</description>');
+    expect(res.text).toContain('<link>https://partner.example/field-notes</link>');
+    expect(res.text).toContain('<pubDate>Mon, 01 Jun 2026 12:00:00 GMT</pubDate>');
+  });
+});


### PR DESCRIPTION
Adds host-aware robots.txt responses so AAO and AdCP advertise crawl surfaces on their own domains, and adds dynamic AAO llms.txt while preserving the existing AdCP protocol llms.txt. Adds a Perspectives RSS feed and keeps sitemap generation scoped to first-party published article pages. Includes regression coverage for host routing, cache headers, Markdown/XML escaping, RSS link entries, and sitemap filters.

Checks: focused Vitest route test, precommit hook, typecheck, and git diff --check.