### PR TITLE
docs(media-buy): clarify optimization_goal priority precedence (#5447)

### DIFF
--- a/.changeset/5447-optimization-goal-priority.md
+++ b/.changeset/5447-optimization-goal-priority.md
@@ -1,0 +1,8 @@
+---
+---
+
+docs(media-buy): clarify optimization_goal priority precedence when no goal is priority 1
+
+`core/optimization-goal.json` already states priority is ordinal ("1 is highest priority; higher numbers are secondary"), but was silent on the present-but-no-1 case, so a literal-reading seller could reject `[2, 3]` while a relative-ordering seller treats `2` as primary. States the only internally-consistent reading: when priorities are present but no goal is `priority: 1`, the goal with the lowest priority value is primary (e.g., `2` and `3` mean `2` is primary).
+
+Description/docs clarification of already-published ordinal-precedence semantics — no structural schema change and no wire-contract change, so no version bump (applies to 3.0 via the living docs). Touches the `optimization-goal.json` top-level `description` and a normative rule in `optimization-reporting.mdx`. Closes #5447.

--- a/docs/media-buy/media-buys/optimization-reporting.mdx
+++ b/docs/media-buy/media-buys/optimization-reporting.mdx
@@ -85,6 +85,8 @@ Three rules connect the layers and prevent orphaned goals:
    - Standard only — "you owe me ≥ X," seller decides how to hit it
    - Both — optimization steers; standard backstops
 
+4. **Priority is ordinal, lowest-value-first.** When `optimization_goals[]` carry explicit `priority` values, the seller treats the goal with the **lowest** priority value as primary — even when no goal is `priority: 1` (priorities of `2` and `3` mean `2` is primary). When `priority` is omitted, sellers may use array position. Duplicate priority values are undefined.
+
 ### Worked example: Adelaide attention end-to-end
 
 A buyer wants to optimize against Adelaide's `attention_score` with a threshold of 70. Here's how the four surfaces line up:

--- a/static/schemas/source/core/optimization-goal.json
+++ b/static/schemas/source/core/optimization-goal.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/core/optimization-goal.json",
   "title": "Optimization Goal",
-  "description": "A single optimization target for a package. Packages accept an array of optimization_goals. When multiple goals are present, priority determines which the seller focuses on — 1 is highest priority (primary goal); higher numbers are secondary. Duplicate priority values result in undefined seller behavior.",
+  "description": "A single optimization target for a package. Packages accept an array of optimization_goals. When multiple goals are present, priority determines which the seller focuses on — 1 is highest priority (primary goal); higher numbers are secondary. When priorities are present but no goal is priority 1, the goal with the lowest priority value is primary (e.g., priorities of 2 and 3 mean 2 is primary). Duplicate priority values result in undefined seller behavior.",
   "discriminator": {
     "propertyName": "kind"
   },


### PR DESCRIPTION
Resolves #5447.

`core/optimization-goal.json` already states priority is ordinal ("1 is highest priority; higher numbers are secondary") but was silent on the present-but-no-1 case — a literal-reading seller could reject `[2, 3]` while a relative-ordering seller treats `2` as primary. States the only internally-consistent reading: **when priorities are present but no goal is `priority: 1`, the goal with the lowest priority value is primary** (e.g. `2` and `3` mean `2` is primary).

Description/docs clarification of already-published ordinal-precedence semantics — **no structural schema change, no wire-contract change, no version bump** (no-bump changeset, matching the `#2303` description-only precedent). Applies to 3.0 via the living docs, so no separate 3.0.x cut is needed. Touches the schema top-level `description` and adds a normative rule in `optimization-reporting.mdx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)