### PR TITLE
fix(website): surface hero generation state in admin list

### DIFF
--- a/.changeset/wg-hero-admin-5386.md
+++ b/.changeset/wg-hero-admin-5386.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix(website): surface working group hero generation failures and admin re-trigger path

--- a/server/public/admin-content.html
+++ b/server/public/admin-content.html
@@ -83,6 +83,8 @@
     .badge-link { background: var(--color-primary-100); color: var(--color-primary-700); }
     .badge-committee { background: var(--color-primary-50); color: var(--color-primary-700); }
     .badge-author { background: var(--color-info-50); color: var(--color-info-700); }
+    .badge-hero-ready { background: var(--color-success-100); color: var(--color-success-700); }
+    .badge-hero-manual { background: var(--color-primary-100); color: var(--color-primary-700); }
     .badge-proposer { background: var(--color-warning-50); color: var(--color-warning-700); }
     .badge-owner { background: var(--color-success-50); color: var(--color-success-700); }
     .authors-list { display: flex; gap: var(--space-1); flex-wrap: wrap; margin-top: var(--space-1); }
@@ -362,6 +364,7 @@
               <th data-sort="author_name" onclick="sortAdminTable('author_name')">Author <span class="sort-arrow">&#9650;</span></th>
               <th data-sort="committee_name" onclick="sortAdminTable('committee_name')">Committee <span class="sort-arrow">&#9650;</span></th>
               <th data-sort="status" onclick="sortAdminTable('status')">Status <span class="sort-arrow">&#9650;</span></th>
+              <th>Hero</th>
               <th data-sort="published_at" onclick="sortAdminTable('published_at')">Published <span class="sort-arrow">&#9660;</span></th>
             </tr></thead>
             <tbody id="adminTableBody"></tbody>
@@ -1126,7 +1129,7 @@
 
       const tbody = document.getElementById('adminTableBody');
       if (pageItems.length === 0) {
-        tbody.innerHTML = '<tr><td colspan="7" class="empty-state">No content matches filters.</td></tr>';
+        tbody.innerHTML = '<tr><td colspan="8" class="empty-state">No content matches filters.</td></tr>';
         document.getElementById('adminPagination').innerHTML = '';
         return;
       }
@@ -1135,6 +1138,14 @@
         const statusClass = 'badge-' + esc(item.status || 'draft');
         const date = item.published_at ? new Date(item.published_at).toLocaleDateString() : '-';
         const sectionLabel = SECTION_LABELS[item.content_origin] || item.content_origin || '-';
+        const isArticle = item.content_type === 'article';
+        const heroState = isArticle
+          ? (item.featured_image_url
+            ? '<span class="badge badge-hero-manual">Manual hero</span>'
+            : item.illustration_id
+              ? '<span class="badge badge-hero-ready">AI hero</span>'
+              : `<button class="btn btn-small btn-outline" type="button" onclick="regenerateHeroFromTable(event, '${safeId(item.id)}')">Generate Hero</button>`)
+          : 'N/A';
         return `<tr onclick="openDetailModal('${safeId(item.id)}')">
           <td class="content-title-cell">${esc(item.title)}</td>
           <td>${esc(sectionLabel)}</td>
@@ -1142,6 +1153,7 @@
           <td>${esc(item.author_name || '-')}</td>
           <td>${esc(item.committee_name || '-')}</td>
           <td><span class="badge ${statusClass}">${formatStatus(item.status)}</span></td>
+          <td>${heroState}</td>
           <td>${esc(date)}</td>
         </tr>`;
       }).join('');
@@ -1289,6 +1301,43 @@
         openDetailModal(currentDetailItem.id);
       } catch (e) { alert('Failed to generate hero'); }
       finally { btn.disabled = false; document.getElementById('heroBtnLabel').textContent = 'Generate Hero'; }
+    }
+
+    async function regenerateHeroFromTable(event, id) {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const rowBtn = event.currentTarget;
+      const item = adminContent.find(i => String(i.id) === String(id));
+      if (!item || !item.slug) {
+        alert('Cannot regenerate hero for this item.');
+        return;
+      }
+
+      const originalText = rowBtn?.textContent || 'Generate Hero';
+      if (rowBtn) {
+        rowBtn.disabled = true;
+        rowBtn.textContent = 'Generating...';
+      }
+
+      try {
+        const res = await fetch(`/api/admin/illustrations/regenerate/${encodeURIComponent(item.slug)}`, { method: 'POST', credentials: 'include' });
+        if (!res.ok) {
+          const data = await res.json();
+          throw new Error(data.error || 'Failed to generate hero');
+        }
+        await loadAdminContent();
+        if (currentDetailItem && String(currentDetailItem.id) === String(item.id)) {
+          await openDetailModal(currentDetailItem.id);
+        }
+      } catch (e) {
+        alert(e.message || 'Failed to generate hero');
+      } finally {
+        if (rowBtn) {
+          rowBtn.disabled = false;
+          rowBtn.textContent = originalText;
+        }
+      }
     }
 
     async function deleteArticle() {

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -6396,6 +6396,7 @@ export class HTTPServer {
                          THEN '/api/perspectives/' || p.slug || '/card.png'
                          ELSE NULL END) AS featured_image_url,
                   p.status, p.published_at,
+                  p.illustration_id,
                   p.content_origin, p.source_type,
                   wg.slug as committee_slug, wg.name as committee_name
            FROM perspectives p
@@ -6467,6 +6468,7 @@ export class HTTPServer {
                          THEN '/api/perspectives/' || p.slug || '/card.png'
                          ELSE NULL END) AS featured_image_url,
                   p.status, p.published_at,
+                  p.illustration_id,
                   p.content_origin, p.source_type, p.updated_at,
                   wg.slug as committee_slug, wg.name as committee_name
            FROM perspectives p

--- a/server/src/routes/admin/illustrations.ts
+++ b/server/src/routes/admin/illustrations.ts
@@ -11,6 +11,7 @@ import { requireGlobalAdmin } from '../../middleware/auth.js';
 import { getPool } from '../../db/client.js';
 import * as illustrationDb from '../../db/illustration-db.js';
 import { generateIllustration } from '../../services/illustration-generator.js';
+import { notifySystemError } from '../../addie/error-notifier.js';
 
 const logger = createLogger('admin-illustrations');
 
@@ -119,6 +120,10 @@ export function setupIllustrationRoutes(apiRouter: Router): void {
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           logger.error({ err, slug: perspective.slug }, 'Failed to generate illustration');
+          notifySystemError({
+            source: 'admin-illustration-generate',
+            errorMessage: `Failed to generate perspective illustration for slug=${perspective.slug}: ${message}`,
+          });
           results.push({ slug: perspective.slug, title: perspective.title, status: 'error', error: message });
         }
       }
@@ -183,6 +188,10 @@ export function setupIllustrationRoutes(apiRouter: Router): void {
       });
     } catch (err) {
       logger.error({ err, slug: req.params.slug }, 'Failed to regenerate illustration');
+      notifySystemError({
+        source: 'admin-illustration-regenerate',
+        errorMessage: `Failed to regenerate perspective illustration for slug=${req.params.slug}: ${err instanceof Error ? err.message : String(err)}`,
+      });
       res.status(500).json({ error: 'Failed to regenerate illustration' });
     }
   });

--- a/server/src/services/working-group-content-service.ts
+++ b/server/src/services/working-group-content-service.ts
@@ -27,6 +27,7 @@ import { sendChannelMessage, isSlackConfigured } from '../slack/client.js';
 import { reindexDocument } from '../addie/jobs/committee-document-indexer.js';
 import { refreshWorkingGroupDocs } from '../addie/mcp/docs-indexer.js';
 import { isUuid } from '../utils/uuid.js';
+import { notifySystemError } from '../addie/error-notifier.js';
 import type { WorkingGroupServiceUser } from './working-group-membership-service.js';
 
 const logger = createLogger('working-group-content-service');
@@ -255,6 +256,10 @@ export async function createWorkingGroupPost(input: CreateWorkingGroupPostInput)
     isMembersOnly: finalMembersOnly,
   }).catch((err) => {
     logger.warn({ err }, 'Failed to send Slack channel notification for working group post');
+    notifySystemError({
+      source: 'wg-post-publish',
+      errorMessage: `Failed to notify Slack for working group post: group=${slug}, post_slug=${postSlug}, error=${err instanceof Error ? err.message : String(err)}`,
+    });
   });
 
   return { post: inserted, groupName: group.name, groupSlug: group.slug };


### PR DESCRIPTION
## Summary
- surfaces hero state in the admin content table so operators can distinguish AI-generated heroes from manually supplied cover images
- adds an inline Generate Hero action for article rows without a hero, using the existing regenerate endpoint
- includes `illustration_id` in admin content list/detail payloads so the UI can classify hero source correctly
- sends `notifySystemError` alerts when illustration generation/regeneration or WG post Slack notification fails

Addresses item 2 of #5386 only. Item 1 (Slack unfurl URL architecture) remains blocked on the URL decision, and item 3 was handled by #5395.

## Validation
- npm run typecheck
- git diff --check
