### PR TITLE
schema(brand): raise agents[] maxItems to 200 + reconcile JWKS size budget (#5445)

### DIFF
--- a/.changeset/5445-jwks-multitenant-size-guidance.md
+++ b/.changeset/5445-jwks-multitenant-size-guidance.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": minor
+---
+
+schema(brand): raise brand.json `agents[]` maxItems 20 → 200 for multi-tenant operators, and reconcile the JWKS size budget
+
+The per-tenant JWKS pattern blessed in #5458 is one `agents[]` entry per tenant, but the `maxItems: 20` cap made a >20-tenant `brand.json` schema-invalid — below the scale the multi-tenant case is actually about. Raises the cap to 200 (additive and non-breaking — loosening a `maxItems` never invalidates an existing valid document).
+
+Also reconciles the two JWKS size figures in L1 security so a conservative verifier can't reject a conformant shard: the 64 KiB `MAX_JWKS_BYTES` is the JWKS-specific budget (deliberately tighter than the generic 5 MB SSRF body ceiling), and per-tenant `jwks_uri` sharding is the conformant path above it — for size as well as key isolation. Closes #5445.

--- a/docs/building/by-layer/L1/security.mdx
+++ b/docs/building/by-layer/L1/security.mdx
@@ -641,7 +641,7 @@ Sellers and auditors resolve the governance agent's public keys via JWKS (RFC 75
 
 1. Establish the buyer domain via the rules in [Buyer identity resolution](#buyer-identity-resolution).
 2. Fetch the buyer's brand.json. Locate the `agents[]` entry whose `type` is `governance` and whose `url` byte-for-byte equals the token's `iss`. Reject if no matching entry exists.
-3. Use the entry's `jwks_uri` if declared. If absent, default to `{origin of iss}/.well-known/jwks.json` where origin = scheme+host+port per RFC 6454. Multi-tenant governance agents serving multiple buyers from a shared origin MUST declare explicit per-tenant `jwks_uri` so tenant key material is not pooled across the origin.
+3. Use the entry's `jwks_uri` if declared. If absent, default to `{origin of iss}/.well-known/jwks.json` where origin = scheme+host+port per RFC 6454. Multi-tenant governance agents serving multiple buyers from a shared origin MUST declare explicit per-tenant `jwks_uri` so tenant key material is not pooled across the origin. Sharding is also a size requirement, not only an isolation one: each `jwks_uri` is fetched under the `MAX_JWKS_BYTES` budget (64 KiB — see the verifier pseudocode below), which is the JWKS-specific cap and is deliberately tighter than the generic 5 MB SSRF body ceiling. A single JWKS that pools hundreds of per-tenant keys exceeds 64 KiB and is rejected, so per-tenant `jwks_uri` (each serving a small key set) — not one aggregated document — is the conformant path at scale.
 4. Fetch the JWKS over HTTPS.
 5. Locate the key in the JWKS whose `kid` matches the token header. On cache miss for a `kid`, refetch the JWKS once (respecting a minimum 30-second cooldown to prevent unbounded refetches) before rejecting.
 

--- a/static/schemas/source/brand.json
+++ b/static/schemas/source/brand.json
@@ -827,9 +827,9 @@
     },
     "agents": {
       "type": "array",
-      "description": "Agents declared by this brand or house. Multiple entries with the same type are permitted when they have distinct url values, such as one endpoint URL per tenant or property scope.",
+      "description": "Agents declared by this brand or house. Multiple entries with the same type are permitted when they have distinct url values, such as one endpoint URL per tenant or property scope. The cap bounds document size; multi-tenant operators beyond it shard key material via per-tenant `jwks_uri` rather than enumerating every tenant here (see L1 security, governance key discovery).",
       "items": { "$ref": "#/definitions/brand_agent_entry" },
-      "maxItems": 20
+      "maxItems": 200
     },
     "authorized_operator": {
       "type": "object",


### PR DESCRIPTION
Resolves #5445 (residual, after #5458 merged the per-tenant-entry clarification).

**`brand.json` `agents[]` maxItems 20 → 200.** The per-tenant JWKS pattern blessed in #5458 is one `agents[]` entry per tenant, but `maxItems: 20` made a >20-tenant `brand.json` schema-invalid — below the scale the multi-tenant case is actually about. Loosening the cap is additive and non-breaking (it never invalidates an existing valid document).

**JWKS size-budget reconciliation (L1 security).** The spec carried two figures — the generic 5 MB SSRF body cap and the 64 KiB `MAX_JWKS_BYTES` verifier budget — without saying which governs JWKS. Clarifies that `MAX_JWKS_BYTES` (64 KiB) is the JWKS-specific budget, deliberately tighter than the 5 MB ceiling, and that per-tenant `jwks_uri` sharding is the conformant path above it **for size as well as key isolation** — so a conservative verifier can never reject a conformant per-tenant shard.

Schema change → `minor`. The sharding-vs-aggregation fork was already decided in #5458; this closes the residual `maxItems` blocker + size-cap ambiguity. Folds in the multi-tenant-JWKS guidance tracked by #3556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)