### PR TITLE
fix(admin): repair newsletter editor bugs

### DIFF
--- a/.changeset/curly-moons-live.md
+++ b/.changeset/curly-moons-live.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix newsletter admin pasted-content rendering and inline editing safeguards.

--- a/server/public/admin-newsletter.html
+++ b/server/public/admin-newsletter.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" href="/sage-icon.svg" type="image/svg+xml">
   <title>Admin - Newsletter</title>
+  <script src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
   <script src="/admin-sidebar.js"></script>
   <link rel="stylesheet" href="/design-system.css">
   <style>
@@ -65,9 +67,15 @@
     .markdown-content blockquote { margin: 8px 0; padding-left: 12px; border-left: 3px solid var(--nl-primary); color: var(--color-text-secondary); }
     .markdown-content code { background: var(--color-bg-subtle); padding: 2px 4px; border-radius: var(--radius-sm); font-size: 0.92em; }
     .markdown-content pre { background: var(--color-bg-subtle); padding: 10px 12px; border-radius: var(--radius-md); overflow-x: auto; }
+    .markdown-content h1, .markdown-content h2, .markdown-content h3 { color: var(--color-text-heading); line-height: 1.25; margin: 14px 0 8px; }
+    .markdown-content h1 { font-size: 20px; }
+    .markdown-content h2 { font-size: 17px; }
+    .markdown-content h3 { font-size: 15px; }
+    .rendered-pasted-content { cursor: default; }
 
     .paste-area { width: 100%; min-height: 200px; font-family: monospace; font-size: 13px; padding: 12px; border: 1px solid var(--color-border-strong); border-radius: 6px; resize: vertical; box-sizing: border-box; }
     .paste-area:focus { border-color: var(--nl-primary); outline: none; }
+    .paste-warning { background: var(--color-warning-50); border: 1px solid var(--color-warning-200); border-left: 4px solid var(--color-warning-500); border-radius: 6px; padding: 10px 12px; margin-bottom: 12px; color: var(--color-warning-800); font-size: 13px; line-height: 1.45; }
 
     .mode-tabs { display: flex; gap: 0; margin-bottom: 16px; border-bottom: 2px solid var(--color-border); }
     .mode-tab { padding: 8px 16px; font-size: 14px; font-weight: 500; color: var(--color-text-secondary); cursor: pointer; border: none; border-bottom: 2px solid transparent; margin-bottom: -2px; background: none; }
@@ -101,14 +109,17 @@
 
     <div id="editorContent" style="display:none;">
       <div class="mode-tabs">
-        <button class="mode-tab active" onclick="switchMode('edit')">Edit Sections</button>
-        <button class="mode-tab" onclick="switchMode('paste')">Paste Content</button>
+        <button class="mode-tab active" onclick="switchMode('edit')">Edit sections</button>
+        <button class="mode-tab" onclick="switchMode('paste')">Paste content</button>
       </div>
 
       <!-- Paste mode -->
       <div id="pasteMode" style="display:none;">
         <div class="section">
-          <h2>Paste Your Newsletter</h2>
+          <h2>Paste your newsletter</h2>
+          <div class="paste-warning">
+            Replace content hides the auto-generated body sections and sends this pasted body instead. Custom sections still send unless you remove them separately.
+          </div>
           <p class="section-hint">Replaces all auto-generated sections. Use **bold**, [links](url), and `code` markdown.</p>
           <div style="margin-bottom:12px;">
             <label style="font-size:13px;color:#666;display:block;margin-bottom:4px;">Subject line override (optional)</label>
@@ -121,7 +132,7 @@
           <label style="font-size:13px;color:#666;display:block;margin-bottom:4px;">Body</label>
           <textarea id="pasteBody" class="paste-area" placeholder="Paste your newsletter content here..."></textarea>
           <div style="margin-top:12px;display:flex;gap:8px;">
-            <button class="btn btn-nl" onclick="submitPaste()">Replace Content</button>
+            <button class="btn btn-nl" onclick="submitPaste()">Replace content</button>
             <button class="btn btn-outline" onclick="switchMode('edit')">Cancel</button>
           </div>
         </div>
@@ -190,6 +201,8 @@
     let uiConfig = null;
     let recipientCount = null;
     let activeEditable = null;
+    let editSaveChain = Promise.resolve();
+    let pendingEditSaves = 0;
 
     function esc(s) {
       const d = document.createElement('div');
@@ -326,6 +339,24 @@
       return out.join('');
     }
 
+    function renderPastedMarkdown(markdown) {
+      const text = String(markdown || '');
+      if (!text.trim()) return '';
+      if (window.marked?.parse && window.DOMPurify?.sanitize) {
+        const renderer = new window.marked.Renderer();
+        renderer.html = (token) => esc(typeof token === 'string' ? token : token?.text || '');
+        renderer.image = () => '';
+        renderer.link = (hrefOrToken, _title, linkText) => {
+          const href = typeof hrefOrToken === 'object' ? hrefOrToken.href : hrefOrToken;
+          const textValue = typeof hrefOrToken === 'object' ? hrefOrToken.text : linkText;
+          if (!isSafeHttpUrl(href || '')) return textValue || '';
+          return `<a href="${esc(href)}">${textValue || esc(href)}</a>`;
+        };
+        return window.DOMPurify.sanitize(window.marked.parse(text, { renderer }));
+      }
+      return renderMarkdown(text);
+    }
+
     function htmlToMarkdown(html) {
       if (!html) return '';
       const doc = new DOMParser().parseFromString(html, 'text/html');
@@ -337,6 +368,30 @@
 
       function childrenToMarkdown(node) {
         return Array.from(node.childNodes).map(nodeToMarkdown).join('');
+      }
+
+      function blockMarkdown(markdown) {
+        const block = markdown
+          .replace(/[ \t]+\n/g, '\n')
+          .replace(/\n{3,}/g, '\n\n')
+          .trim();
+        return block ? `\n\n${block}\n\n` : '';
+      }
+
+      function listItemMarkdown(node, marker) {
+        const text = childrenToMarkdown(node)
+          .replace(/[ \t]+\n/g, '\n')
+          .replace(/\n{3,}/g, '\n\n')
+          .trim();
+        if (!text) return '';
+        const lines = text.split('\n');
+        return `${marker} ${lines[0]}${lines.slice(1).map(line => `\n  ${line}`).join('')}\n`;
+      }
+
+      function listMarkdown(node, ordered) {
+        const items = Array.from(node.children).filter(child => child.tagName.toLowerCase() === 'li');
+        const markdown = items.map((item, index) => listItemMarkdown(item, ordered ? `${index + 1}.` : '-')).join('');
+        return markdown ? `\n${markdown}\n` : '';
       }
 
       function nodeToMarkdown(node) {
@@ -367,12 +422,13 @@
             return inline && isSafeHttpUrl(href) ? `[${inline}](${href})` : inline;
           }
           case 'li':
-            return inline ? `- ${inline}\n` : '';
+            return listItemMarkdown(node, '-');
           case 'ul':
+            return listMarkdown(node, false);
           case 'ol':
-            return `\n${childMarkdown}\n`;
+            return listMarkdown(node, true);
           case 'blockquote':
-            return inline ? `\n\n${inline.split('\n').map(line => `> ${line}`).join('\n')}\n\n` : '';
+            return childMarkdown.trim() ? `\n\n${childMarkdown.trim().split('\n').map(line => line.trim() ? `> ${line}` : '>').join('\n')}\n\n` : '';
           case 'h1':
             return inline ? `\n\n# ${inline}\n\n` : '';
           case 'h2':
@@ -383,7 +439,7 @@
           case 'div':
           case 'section':
           case 'article':
-            return inline ? `\n\n${inline}\n\n` : '';
+            return blockMarkdown(childMarkdown);
           default:
             return childMarkdown;
         }
@@ -457,6 +513,15 @@
       });
       document.getElementById('editMode').style.display = mode === 'edit' ? 'block' : 'none';
       document.getElementById('pasteMode').style.display = mode === 'paste' ? 'block' : 'none';
+      if (mode === 'paste') populatePasteForm();
+    }
+
+    function populatePasteForm() {
+      if (!currentDigest?.content) return;
+      const c = currentDigest.content;
+      document.getElementById('pasteSubject').value = c.emailSubject || '';
+      document.getElementById('pasteStatusLine').value = c.statusLine || c.openingTake || '';
+      document.getElementById('pasteBody').value = c.pastedContent || '';
     }
 
     // ─── Load ───────────────────────────────────────────────────────
@@ -570,7 +635,7 @@
               ${status === 'draft' ? '<button class="btn btn-outline btn-sm" onclick="clearPastedContent()">Clear pasted content</button>' : ''}
             </div>
             <h2>Pasted content</h2>
-            <div class="custom-section-body markdown-content">${renderMarkdown(c.pastedContent)}</div>
+            <div class="custom-section-body markdown-content rendered-pasted-content" contenteditable="false">${renderPastedMarkdown(c.pastedContent)}</div>
           </div>`;
       } else {
         let halfBuffer = [];
@@ -678,6 +743,7 @@
       if (data.digest) currentDigest = data.digest;
       if (data.subject) currentSubject = data.subject;
       if (data.uiConfig) uiConfig = data.uiConfig;
+      if (pendingEditSaves > 0) return;
       if (activeEditable?.dataset.editing === 'true') return;
       render();
     }
@@ -686,6 +752,7 @@
 
     function startEdit(el, field) {
       if (currentDigest?.status !== 'draft') return;
+      if (el.contentEditable === 'true') return;
       if (el.dataset.editing === 'true') return;
       if (activeEditable && activeEditable !== el) activeEditable.blur();
 
@@ -719,17 +786,23 @@
         cleanup();
         el.innerHTML = renderMarkdown(value) || '<em style="color:#888;">Click to edit</em>';
 
-        api('/editions/' + currentDigest.id + '/edit', {
+        const request = editSaveChain.catch(() => {}).then(() => api('/editions/' + currentDigest.id + '/edit', {
           method: 'POST',
           body: JSON.stringify({ field, value }),
-        }).then(async r => {
+        })).then(async r => {
           const data = await r.json();
           if (!r.ok) throw new Error(data.error || 'Save failed');
           return data;
-        }).then(data => {
+        });
+        editSaveChain = request.catch(() => {});
+
+        pendingEditSaves += 1;
+        request.then(data => {
+          pendingEditSaves -= 1;
           updateFromResponse(data);
           toast('Saved');
         }).catch((err) => {
+          pendingEditSaves -= 1;
           currentDigest.content[field] = previousValue;
           currentSubject = previousSubject;
           if (activeEditable?.dataset.editing !== 'true') render();
@@ -878,6 +951,7 @@
     }
 
     async function clearPastedContent() {
+      if (!window.confirm('Clear pasted content and return to auto-generated sections?')) return;
       try {
         const res = await api('/editions/' + currentDigest.id + '/paste-content', { method: 'DELETE' });
         const data = await res.json();

--- a/server/src/newsletters/the-build/template.ts
+++ b/server/src/newsletters/the-build/template.ts
@@ -9,24 +9,67 @@ import type { BuildContent } from '../../db/build-db.js';
 import type { SlackBlockMessage } from '../../slack/types.js';
 import { escapeHtml, trackLink, formatDate, renderEmailShell } from '../email-layout.js';
 import { isSectionHidden, getCustomSections, getPastedContent } from '../config.js';
+import { markdownToEmailHtml as renderMarkdownToEmailHtml } from '../../utils/markdown.js';
+import DOMPurify from 'isomorphic-dompurify';
 import { BUILD_PALETTE } from './index.js';
 
 const BASE_URL = process.env.BASE_URL || 'https://agenticadvertising.org';
 
 export type BuildSegment = 'website_only' | 'slack_only' | 'both' | 'active';
 
-/** Simple markdown-to-HTML for pasted/custom content. Only allows http(s) URLs. */
-function markdownToHtml(md: string): string {
-  return escapeHtml(md)
-    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, text, url) => {
-      // After escapeHtml, "https://" stays as "https://" (no special chars).
-      // Reject anything that doesn't start with the escaped http(s) prefix.
-      if (!/^https?:\/\//i.test(url)) return text as string;
-      return `<a href="${url}" style="color: ${BUILD_PALETTE.primary}; text-decoration: none;">${text}</a>`;
-    })
-    .replace(/`([^`]+)`/g, '<code style="background:#f1f5f9;padding:2px 4px;border-radius:3px;font-size:13px;">$1</code>')
-    .replace(/\n/g, '<br>');
+type SanitizedElement = {
+  getAttribute(name: string): string | null;
+  setAttribute(name: string, value: string): void;
+};
+
+type SanitizedFragment = {
+  querySelectorAll(selector: string): { forEach(callback: (el: SanitizedElement) => void): void };
+  innerHTML: string;
+};
+
+function markdownToTrackedEmailHtml(md: string, trackingId: string, tagPrefix = 'pasted_body'): string {
+  let linkIndex = 0;
+  const dom = DOMPurify.sanitize(renderMarkdownToEmailHtml(md), {
+    ALLOWED_TAGS: ['p', 'br', 'strong', 'b', 'em', 'i', 'a', 'ul', 'ol', 'li', 'code', 'pre', 'h1', 'h2', 'h3'],
+    ALLOWED_ATTR: ['href'],
+    RETURN_DOM: true,
+  }) as unknown as SanitizedFragment;
+
+  dom.querySelectorAll('a[href]').forEach((anchor) => {
+    linkIndex += 1;
+    const href = anchor.getAttribute('href') || '';
+    anchor.setAttribute('href', trackLink(trackingId, `${tagPrefix}_${linkIndex}`, href));
+    anchor.setAttribute('style', `color: ${BUILD_PALETTE.primary}; text-decoration: none;`);
+  });
+  dom.querySelectorAll('p').forEach((el) => el.setAttribute('style', 'margin: 0 0 12px 0;'));
+  dom.querySelectorAll('ul').forEach((el) => el.setAttribute('style', 'margin: 8px 0 12px 0; padding-left: 20px;'));
+  dom.querySelectorAll('ol').forEach((el) => el.setAttribute('style', 'margin: 8px 0 12px 0; padding-left: 20px;'));
+  dom.querySelectorAll('li').forEach((el) => el.setAttribute('style', 'margin-bottom: 4px;'));
+  dom.querySelectorAll('code').forEach((el) => el.setAttribute('style', 'background:#f1f5f9;padding:2px 4px;border-radius:3px;font-size:13px;'));
+  dom.querySelectorAll('h1').forEach((el) => el.setAttribute('style', `font-size: 22px; margin: 20px 0 8px 0; color: ${BUILD_PALETTE.dark};`));
+  dom.querySelectorAll('h2').forEach((el) => el.setAttribute('style', `font-size: 18px; margin: 18px 0 8px 0; color: ${BUILD_PALETTE.dark};`));
+  dom.querySelectorAll('h3').forEach((el) => el.setAttribute('style', `font-size: 16px; margin: 16px 0 8px 0; color: ${BUILD_PALETTE.dark};`));
+
+  return dom.innerHTML;
+}
+
+function markdownToPlainText(md: string): string {
+  return md
+    .replace(/!\[[^\]]*\]\([^)]+\)/g, '')
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/\*\*(.+?)\*\*/g, '$1')
+    .replace(/\*([^*]+)\*/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '$1 ($2)')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function appendCustomSectionsText(lines: string[], content: BuildContent) {
+  for (const section of getCustomSections(content)) {
+    if (section.title) lines.push(section.title, '');
+    lines.push(markdownToPlainText(section.body), '');
+  }
 }
 
 // ─── Email Rendering ───────────────────────────────────────────────────
@@ -42,6 +85,7 @@ export function renderBuildEmail(
 
   // Build the body sections
   const sections: string[] = [];
+  const customSections = getCustomSections(content);
 
   // Status line
   sections.push(`<p style="font-size: 15px; color: #333; line-height: 1.6;">${escapeHtml(content.statusLine)}</p>`);
@@ -58,14 +102,14 @@ export function renderBuildEmail(
   const pasted = getPastedContent(content);
   if (pasted) {
     sections.push('<hr style="border: none; border-top: 1px solid #e5e5e5; margin: 24px 0;">');
-    sections.push(`<div style="font-size: 14px; color: #333; line-height: 1.6;">${markdownToHtml(pasted)}</div>`);
+    sections.push(`<div style="font-size: 14px; color: #333; line-height: 1.6;">${markdownToTrackedEmailHtml(pasted, trackingId)}</div>`);
 
     // Also render any custom sections
-    for (const cs of getCustomSections(content)) {
+    for (const [index, cs] of customSections.entries()) {
       if (cs.title) {
         sections.push(`<h2 style="font-size: 17px; color: ${BUILD_PALETTE.dark}; margin-bottom: 16px;">${escapeHtml(cs.title)}</h2>`);
       }
-      sections.push(`<div style="font-size: 14px; color: #333; line-height: 1.6;">${markdownToHtml(cs.body)}</div>`);
+      sections.push(`<div style="font-size: 14px; color: #333; line-height: 1.6;">${markdownToTrackedEmailHtml(cs.body, trackingId, `custom_${index + 1}`)}</div>`);
       sections.push('<hr style="border: none; border-top: 1px solid #e5e5e5; margin: 24px 0;">');
     }
 
@@ -75,15 +119,18 @@ export function renderBuildEmail(
       perspectiveSlugPrefix: 'the-build', signOff: { text: "That's the cycle. If something broke, file an issue. If something's missing, open a PR.", attribution: 'Sage', domain: 'docs.adcontextprotocol.org' },
       preheaderText: content.statusLine, editionDate, trackingId, segment, firstName, coverImageUrl: content.coverImageUrl, bodyHtml,
     });
-    return { html, text: `The Build — ${formatDate(editionDate)}\n\n${content.statusLine}\n\n${pasted}` };
+    const textLines = [`The Build — ${formatDate(editionDate)}`, '', content.statusLine, '', markdownToPlainText(pasted), ''];
+    appendCustomSectionsText(textLines, content);
+    return { html, text: textLines.join('\n').trim() };
   }
 
   sections.push('<hr style="border: none; border-top: 1px solid #e5e5e5; margin: 24px 0;">');
 
   // Render custom sections positioned before auto sections (position 0)
-  for (const cs of getCustomSections(content).filter(s => s.position === 0)) {
+  for (const [index, cs] of customSections.entries()) {
+    if (cs.position !== 0) continue;
     if (cs.title) sections.push(`<h2 style="font-size: 17px; color: ${BUILD_PALETTE.dark}; margin-bottom: 16px;">${escapeHtml(cs.title)}</h2>`);
-    sections.push(`<div style="font-size: 14px; color: #333; line-height: 1.6;">${markdownToHtml(cs.body)}</div>`);
+    sections.push(`<div style="font-size: 14px; color: #333; line-height: 1.6;">${markdownToTrackedEmailHtml(cs.body, trackingId, `custom_${index + 1}`)}</div>`);
     sections.push('<hr style="border: none; border-top: 1px solid #e5e5e5; margin: 24px 0;">');
   }
 
@@ -183,9 +230,10 @@ export function renderBuildEmail(
   }
 
   // Custom sections at end (position > 0, not already rendered)
-  for (const cs of getCustomSections(content).filter(s => s.position > 0)) {
+  for (const [index, cs] of customSections.entries()) {
+    if (cs.position <= 0) continue;
     if (cs.title) sections.push(`<h2 style="font-size: 17px; color: ${BUILD_PALETTE.dark}; margin-bottom: 16px;">${escapeHtml(cs.title)}</h2>`);
-    sections.push(`<div style="font-size: 14px; color: #333; line-height: 1.6;">${markdownToHtml(cs.body)}</div>`);
+    sections.push(`<div style="font-size: 14px; color: #333; line-height: 1.6;">${markdownToTrackedEmailHtml(cs.body, trackingId, `custom_${index + 1}`)}</div>`);
     sections.push('<hr style="border: none; border-top: 1px solid #e5e5e5; margin: 24px 0;">');
   }
 

--- a/server/tests/unit/digest-link-formatting.test.ts
+++ b/server/tests/unit/digest-link-formatting.test.ts
@@ -5,20 +5,18 @@ vi.mock('../../src/notifications/email.js', () => ({
   trackedUrl: (id: string, tag: string, url: string) => `tracked:${id}:${tag}:${url}`,
 }));
 
-vi.mock('../../src/utils/markdown.js', () => ({
-  markdownToEmailHtml: (text: string) => text
-    .replace(/^## (.+)$/gm, '<h2>$1</h2>')
-    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-    .replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, '<a href="$2">$1</a>')
-    .replace(/`([^`]+)`/g, '<code>$1</code>')
-    .split(/\n{2,}/)
-    .map(part => /^<h2>/.test(part) ? part : `<p>${part.replace(/\n/g, '<br>')}</p>`)
-    .join('\n'),
-  markdownToEmailHtmlInline: (text: string) => text,
-}));
+vi.mock('../../src/utils/markdown.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/utils/markdown.js')>();
+  return {
+    ...actual,
+    markdownToEmailHtmlInline: (text: string) => text,
+  };
+});
 
 import { renderDigestEmail, renderDigestSlack } from '../../src/addie/templates/weekly-digest.js';
+import { renderBuildEmail } from '../../src/newsletters/the-build/template.js';
 import type { DigestContent } from '../../src/db/digest-db.js';
+import type { BuildContent } from '../../src/db/build-db.js';
 
 function makeContent(overrides: Partial<DigestContent> = {}): DigestContent {
   return {
@@ -28,6 +26,20 @@ function makeContent(overrides: Partial<DigestContent> = {}): DigestContent {
     fromTheInside: [],
     voices: [],
     newMembers: [],
+    generatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeBuildContent(overrides: Partial<BuildContent> = {}): BuildContent {
+  return {
+    contentVersion: 1,
+    statusLine: 'Test status line.',
+    decisions: [],
+    whatShipped: [],
+    deepDive: null,
+    helpNeeded: [],
+    contributorSpotlight: [],
     generatedAt: new Date().toISOString(),
     ...overrides,
   };
@@ -191,5 +203,36 @@ describe('digest editor note link formatting', () => {
       expect(rendered).toContain('Custom body');
       expect(rendered).not.toContain('Generated article');
     });
+  });
+});
+
+describe('Build pasted content mode', () => {
+  it('renders pasted markdown and custom sections in email with tracked links', () => {
+    const content = makeBuildContent({
+      pastedContent: '## Lead\n\nPasted **body** with [brief](https://example.com/brief).',
+      customSections: [{ id: 'custom-1', title: 'Extra note', body: 'See [more](https://example.com/more)', position: 0 }],
+    });
+    const { html, text } = renderBuildEmail(content, 'recipient-1', '2026-04-01', 'both');
+
+    expect(html).toContain('Lead');
+    expect(html).toContain('<strong>body</strong>');
+    expect(html).toContain('tracked:recipient-1:pasted_body_1:https://example.com/brief');
+    expect(html).toContain('Extra note');
+    expect(html).toContain('tracked:recipient-1:custom_1_1:https://example.com/more');
+    expect(text).toContain('Extra note');
+    expect(text).toContain('more (https://example.com/more)');
+  });
+
+  it('keeps custom section tracking tags unique before and after generated content', () => {
+    const content = makeBuildContent({
+      customSections: [
+        { id: 'custom-1', title: 'Before', body: 'See [before](https://example.com/before)', position: 0 },
+        { id: 'custom-2', title: 'After', body: 'See [after](https://example.com/after)', position: 2 },
+      ],
+    });
+    const { html } = renderBuildEmail(content, 'recipient-1', '2026-04-01', 'both');
+
+    expect(html).toContain('tracked:recipient-1:custom_1_1:https://example.com/before');
+    expect(html).toContain('tracked:recipient-1:custom_2_1:https://example.com/after');
   });
 });


### PR DESCRIPTION
Fixes the newsletter admin editor paths behind issue #5442.

This queues inline saves to avoid stale blur renders, improves rich-text paste conversion and pasted markdown preview parity, and clarifies destructive paste-mode behavior.

It also updates The Build email renderer so pasted/custom markdown is sanitized, tracked consistently, and represented in text output, with unit coverage for pasted content and custom-section link tags.

Validation: precommit passed, including root unit tests, dynamic-import and callApi lints, full server unit tests, and typecheck.
