### PR TITLE
fix(compliance): raise hosted full-assessment comply() budget to 600s

### DIFF
--- a/.changeset/hosted-full-compliance-timeout.md
+++ b/.changeset/hosted-full-compliance-timeout.md
@@ -1,0 +1,13 @@
+---
+"adcontextprotocol": patch
+---
+
+fix(compliance): raise hosted full-assessment comply() budget to 600s
+
+@adcp/sdk 9.0.0-beta.28 applies the per-call `--timeout` (default 120s) as the wall-clock budget for the *entire* pre-flight `comply()` assessment. A full capability-rich assessment legitimately runs ~117s, so the 120s ceiling graded the most compliant agents "unreachable" with 0 steps and let registry cards go stale silently.
+
+Adds `HOSTED_FULL_COMPLIANCE_TIMEOUT_MS = 600_000` and threads it through every hosted full-suite `comply()` call site — the compliance heartbeat job, the owner/admin registry-refresh endpoint, the `evaluate_agent_quality` member tool, and the heartbeat-mirroring diagnostic script — replacing the prior 60s/90s/SDK-default values.
+
+The heartbeat in-progress lock TTL now tracks the worst-case serial batch (batch size × budget) so an agent late in the loop isn't re-picked by an overlapping run.
+
+This is a hosted-side mitigation; it does not change the SDK's CLI default-timeout behavior (tracked upstream in adcontextprotocol/adcp-client#2221). Revisit the 600s budget when the SDK restores per-call timeout semantics.

--- a/server/src/addie/jobs/compliance-heartbeat.ts
+++ b/server/src/addie/jobs/compliance-heartbeat.ts
@@ -26,6 +26,7 @@ import { revokeUnsupportedPublicBadges, runBadgeFanOut } from '../../services/ba
 import { adaptAuthForSdk } from '../../services/sdk-auth-adapter.js';
 import {
   hostedComplianceTarget,
+  HOSTED_FULL_COMPLIANCE_TIMEOUT_MS,
 } from '../../services/hosted-compliance-version.js';
 
 const logger = baseLogger.child({ module: 'compliance-heartbeat' });
@@ -56,16 +57,21 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
   logger.debug({ count: agentsDue.length }, 'Agents due for compliance check');
 
   // Mark agents as in-progress to prevent concurrent pickup by overlapping runs.
-  // Use a 30-minute TTL instead of NOW() so a mid-loop process crash (OOM,
-  // Fly restart) re-queues the agent within 30 min rather than waiting the full
-  // check_interval (default 12 h). recordComplianceRun() stamps the real
-  // last_checked_at on success or failure — this is only a concurrency lock.
+  // Agents are processed serially, so the lock must outlive the worst-case batch
+  // runtime — otherwise an agent late in the loop has its lock expire before the
+  // loop reaches it and an overlapping run re-picks it (duplicate assessment,
+  // double badge fan-out). Worst case is batchSize × the full-comply budget, plus
+  // headroom for per-agent target selection. recordComplianceRun() stamps the
+  // real last_checked_at on success or failure — this is only a concurrency lock,
+  // so a mid-loop process crash re-queues the agent after this TTL rather than
+  // waiting the full check_interval (default 12 h).
   const urls = agentsDue.map(a => a.agent_url);
+  const lockSeconds = urls.length * (HOSTED_FULL_COMPLIANCE_TIMEOUT_MS / 1000) + 300;
   await query(
     `INSERT INTO agent_compliance_status (agent_url, status, last_checked_at)
-     SELECT unnest($1::text[]), 'unknown', NOW() + INTERVAL '30 minutes'
-     ON CONFLICT (agent_url) DO UPDATE SET last_checked_at = NOW() + INTERVAL '30 minutes'`,
-    [urls],
+     SELECT unnest($1::text[]), 'unknown', NOW() + make_interval(secs => $2)
+     ON CONFLICT (agent_url) DO UPDATE SET last_checked_at = NOW() + make_interval(secs => $2)`,
+    [urls, lockSeconds],
   );
 
   for (const agent of agentsDue) {
@@ -78,7 +84,7 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
 
       const complyOptions: ComplyOptions = {
         test_session_id: `heartbeat-${Date.now()}`,
-        timeout_ms: 60_000,
+        timeout_ms: HOSTED_FULL_COMPLIANCE_TIMEOUT_MS,
         auth: sdkAuth,
         userAgent: AAO_UA_COMPLIANCE,
       };
@@ -207,7 +213,7 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
       let observationSeverity: 'warning' | 'error';
       let observationMessage: string;
       if (isAgentTimeout) {
-        headline = 'Timed out: agent did not respond within 60s';
+        headline = `Timed out: assessment did not complete within ${HOSTED_FULL_COMPLIANCE_TIMEOUT_MS / 1000}s`;
         observationCategory = 'connectivity';
         observationSeverity = 'warning';
         observationMessage = headline;

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -69,6 +69,7 @@ import { renderAllHintFixPlans } from '../services/storyboard-fix-plan.js';
 import {
   hostedComplianceTarget,
   hostedComplianceOptions,
+  HOSTED_FULL_COMPLIANCE_TIMEOUT_MS,
   hostedAuthProbeTaskForProfile,
   withHostedStoryboardRunOptions,
   withHostedTestOptions,
@@ -3928,6 +3929,7 @@ export function createMemberToolHandlers(
 
     const complyOptions: ComplyOptions = {
       test_session_id: `quality-eval-${Date.now()}`,
+      timeout_ms: HOSTED_FULL_COMPLIANCE_TIMEOUT_MS,
       auth: authOption,
     };
     if (tracks) complyOptions.tracks = tracks;

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -24,6 +24,7 @@ import { listStoryboards, getStoryboard, getTestKitForStoryboard } from "../serv
 import {
   hostedComplianceTarget,
   hostedComplianceOptions,
+  HOSTED_FULL_COMPLIANCE_TIMEOUT_MS,
   hostedAuthProbeTaskForProfile,
   withHostedStoryboardRunOptions,
   withHostedTestOptions,
@@ -2720,7 +2721,7 @@ registry.registerPath({
   operationId: "refreshAgent",
   summary: "Refresh agent snapshot",
   description:
-    "Re-probe the agent and update its registry health (online, tools_count, response_time_ms), capability snapshot (inferred type, discovered tools), and compliance verdict (storyboard pass/fail counts). Use after fixing your agent so the registry shows fresh data without waiting for the periodic heartbeat (~1h).\n\n**Compliance re-run:** when the caller owns the agent or is an AAO admin and the capability probe succeeds, the full storyboard suite runs (~30–90s) with a fresh test session and `agent_storyboard_status` is updated. Owner-triggered runs use `triggered_by: 'owner_test'`; admin-triggered support runs use `triggered_by: 'manual'`. Badge fan-out reissues verification badges off the new run. If the compliance call fails (timeout, OAuth wall, internal error), the capability/health portion still returns successfully — `compliance.ran` is `false` with an `error` string.\n\n**Auth:** owner of the agent, AAO admin, or static `ADMIN_API_KEY`.\n\n**Rate limits:** 60 seconds per agent URL, 30 requests per user per hour.",
+    "Re-probe the agent and update its registry health (online, tools_count, response_time_ms), capability snapshot (inferred type, discovered tools), and compliance verdict (storyboard pass/fail counts). Use after fixing your agent so the registry shows fresh data without waiting for the periodic heartbeat (~1h).\n\n**Compliance re-run:** when the caller owns the agent or is an AAO admin and the capability probe succeeds, the full storyboard suite can run for several minutes on capability-rich agents with a fresh test session, and `agent_storyboard_status` is updated. Owner-triggered runs use `triggered_by: 'owner_test'`; admin-triggered support runs use `triggered_by: 'manual'`. Badge fan-out reissues verification badges off the new run. If the compliance call fails (timeout, OAuth wall, internal error), the capability/health portion still returns successfully — `compliance.ran` is `false` with an `error` string.\n\n**Auth:** owner of the agent, AAO admin, or static `ADMIN_API_KEY`.\n\n**Rate limits:** 60 seconds per agent URL, 30 requests per user per hour.",
   tags: ["Agent Compliance"],
   security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
@@ -6037,10 +6038,14 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       // capability/health probe. Prior to #4886, /refresh probed capabilities
       // and health but left agent_storyboard_status untouched, leaving owners
       // to stare at a stale verdict for up to a full heartbeat cycle after
-      // deploying a fix. The full storyboard suite can run 30–90s; the
-      // per-agent 60s rate limit above bounds repeat-clicks. comply() failure
-      // is a soft-fail — we still return the capability/health refresh so a
-      // partially-working agent still moves the snapshot forward.
+      // deploying a fix. The full storyboard suite can run for several minutes
+      // on capability-rich agents (bounded by HOSTED_FULL_COMPLIANCE_TIMEOUT_MS).
+      // The per-agent 60s rate limit above only bounds repeat-clicks, not the
+      // duration of an in-flight run, so a second refresh of the same agent can
+      // start while the first is still running; that is acceptable for this
+      // owner/admin-gated path. comply() failure is a soft-fail — we still
+      // return the capability/health refresh so a partially-working agent still
+      // moves the snapshot forward.
       let complianceSummary: {
         ran: boolean;
         requested_compliance_target?: string;
@@ -6064,7 +6069,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           const triggeredBy = ownerOrgId ? 'owner_test' : 'manual';
           const complyOptions = {
             test_session_id: testSessionId,
-            timeout_ms: 90_000,
+            timeout_ms: HOSTED_FULL_COMPLIANCE_TIMEOUT_MS,
             userAgent: AAO_UA_COMPLIANCE,
             ...(resolvedAuth && { auth: resolvedAuth }),
           };

--- a/server/src/scripts/test-comply-storyboard-statuses.ts
+++ b/server/src/scripts/test-comply-storyboard-statuses.ts
@@ -18,7 +18,7 @@ import {
   complianceResultToDbInput,
   type ComplyOptions,
 } from '../addie/services/compliance-testing.js';
-import { hostedComplianceTarget } from '../services/hosted-compliance-version.js';
+import { hostedComplianceTarget, HOSTED_FULL_COMPLIANCE_TIMEOUT_MS } from '../services/hosted-compliance-version.js';
 
 const urls = process.argv.slice(2).filter(a => !a.startsWith('--'));
 const complianceTarget = hostedComplianceTarget();
@@ -34,7 +34,7 @@ async function probe(agentUrl: string): Promise<void> {
 
   const opts: ComplyOptions = {
     test_session_id: `local-probe-${Date.now()}`,
-    timeout_ms: 90_000,
+    timeout_ms: HOSTED_FULL_COMPLIANCE_TIMEOUT_MS,
     userAgent: AAO_UA_COMPLIANCE,
   };
 

--- a/server/src/services/hosted-compliance-version.ts
+++ b/server/src/services/hosted-compliance-version.ts
@@ -16,6 +16,14 @@ export const HOSTED_COMPLIANCE_TARGET_PREFERENCE = [
   '3.1-beta',
   DEFAULT_HOSTED_COMPLIANCE_LINE,
 ] as const;
+// Budget for a full-suite comply() assessment. @adcp/sdk 9.0.0-beta.28 applies
+// this value as the wall-clock budget for the *entire* pre-flight assessment
+// (not per-call), and a capability-rich agent legitimately runs ~117s — the SDK
+// default (120s) grades such agents "unreachable" with 0 steps. 600s clears
+// that ceiling. Revisit when the SDK restores per-call timeout semantics
+// (adcontextprotocol/adcp-client#2221): a per-call ceiling this large would let
+// a single hung call hold a connection for 10 minutes.
+export const HOSTED_FULL_COMPLIANCE_TIMEOUT_MS = 600_000;
 
 export interface HostedComplianceTarget {
   requested: string;

--- a/server/tests/integration/registry-api-agent-refresh.test.ts
+++ b/server/tests/integration/registry-api-agent-refresh.test.ts
@@ -18,6 +18,7 @@ import { HTTPServer } from '../../src/http.js';
 import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
 import { runMigrations } from '../../src/db/migrate.js';
 import { AAO_UA_COMPLIANCE } from '../../src/config/user-agents.js';
+import { HOSTED_FULL_COMPLIANCE_TIMEOUT_MS } from '../../src/services/hosted-compliance-version.js';
 
 const RUN_SUFFIX = Math.random().toString(36).slice(2, 8);
 const OWNER_USER_ID = `user_test_refresh_owner_${RUN_SUFFIX}`;
@@ -264,7 +265,7 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
     expect(complyMock).toHaveBeenCalledWith(
       agentUrl,
       expect.objectContaining({
-        timeout_ms: 90_000,
+        timeout_ms: HOSTED_FULL_COMPLIANCE_TIMEOUT_MS,
         userAgent: AAO_UA_COMPLIANCE,
         test_session_id: expect.stringMatching(/^owner-refresh-\d+-[0-9a-f-]{36}$/),
       }),
@@ -309,7 +310,7 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
     expect(complyMock).toHaveBeenCalledWith(
       agentUrl,
       expect.objectContaining({
-        timeout_ms: 90_000,
+        timeout_ms: HOSTED_FULL_COMPLIANCE_TIMEOUT_MS,
         userAgent: AAO_UA_COMPLIANCE,
       }),
     );

--- a/server/tests/unit/compliance-heartbeat.test.ts
+++ b/server/tests/unit/compliance-heartbeat.test.ts
@@ -42,6 +42,7 @@ vi.mock('../../src/addie/services/compliance-testing.js', () => ({
 
 vi.mock('../../src/services/hosted-compliance-version.js', () => ({
   hostedComplianceTarget: mocks.hostedComplianceTarget,
+  HOSTED_FULL_COMPLIANCE_TIMEOUT_MS: 600_000,
 }));
 
 vi.mock('../../src/db/outbound-log-db.js', () => ({
@@ -91,6 +92,13 @@ describe('runComplianceHeartbeatJob', () => {
     const result = await runComplianceHeartbeatJob({ limit: 1 });
 
     expect(result).toEqual({ checked: 1, passed: 0, failed: 1, skipped: 0 });
+    expect(mocks.comply).toHaveBeenCalledWith(
+      'https://agent.example.com/mcp',
+      expect.objectContaining({
+        timeout_ms: 600_000,
+      }),
+      target,
+    );
     expect(mocks.recordComplianceRun).toHaveBeenCalledWith(
       expect.objectContaining({
         agent_url: 'https://agent.example.com/mcp',

--- a/server/tests/unit/storyboards.test.ts
+++ b/server/tests/unit/storyboards.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   DEFAULT_HOSTED_COMPLIANCE_LINE,
   DEFAULT_HOSTED_COMPLIANCE_VERSION,
+  HOSTED_FULL_COMPLIANCE_TIMEOUT_MS,
   badgeEligibleVersionsForHostedComplianceTarget,
   hostedAuthProbeTaskForProfile,
   hostedComplianceOptions,
@@ -169,6 +170,7 @@ describe('wrapper contract', () => {
     expect(index.adcp_version).toBe(DEFAULT_HOSTED_COMPLIANCE_VERSION);
     expect(DEFAULT_HOSTED_COMPLIANCE_VERSION).toBe('3.0.14');
     expect(DEFAULT_HOSTED_COMPLIANCE_LINE).toBe('3.0');
+    expect(HOSTED_FULL_COMPLIANCE_TIMEOUT_MS).toBe(600_000);
     expect(target.requested).toBe(DEFAULT_HOSTED_COMPLIANCE_LINE);
     expect(target.version).toBe(DEFAULT_HOSTED_COMPLIANCE_VERSION);
     expect(target.version).toMatch(/^3\.0\.\d+$/);

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -8083,7 +8083,7 @@ paths:
       description: |-
         Re-probe the agent and update its registry health (online, tools_count, response_time_ms), capability snapshot (inferred type, discovered tools), and compliance verdict (storyboard pass/fail counts). Use after fixing your agent so the registry shows fresh data without waiting for the periodic heartbeat (~1h).
 
-        **Compliance re-run:** when the caller owns the agent or is an AAO admin and the capability probe succeeds, the full storyboard suite runs (~30–90s) with a fresh test session and `agent_storyboard_status` is updated. Owner-triggered runs use `triggered_by: 'owner_test'`; admin-triggered support runs use `triggered_by: 'manual'`. Badge fan-out reissues verification badges off the new run. If the compliance call fails (timeout, OAuth wall, internal error), the capability/health portion still returns successfully — `compliance.ran` is `false` with an `error` string.
+        **Compliance re-run:** when the caller owns the agent or is an AAO admin and the capability probe succeeds, the full storyboard suite can run for several minutes on capability-rich agents with a fresh test session, and `agent_storyboard_status` is updated. Owner-triggered runs use `triggered_by: 'owner_test'`; admin-triggered support runs use `triggered_by: 'manual'`. Badge fan-out reissues verification badges off the new run. If the compliance call fails (timeout, OAuth wall, internal error), the capability/health portion still returns successfully — `compliance.ran` is `false` with an `error` string.
 
         **Auth:** owner of the agent, AAO admin, or static `ADMIN_API_KEY`.
 


### PR DESCRIPTION
## Problem

`@adcp/sdk` 9.0.0-beta.28 applies the per-call `--timeout` (default 120s) as the wall-clock budget for the **entire** pre-flight `comply()` assessment. A full capability-rich assessment legitimately runs ~117s, so the 120s ceiling graded the most compliant agents **"unreachable" with 0 steps** — and registry cards went stale silently when the heartbeat ran on beta.28.

Reported by Sharad Yadav with a clean repro matrix (same agent, same hour):
- beta.27, default timeout → 155 passed, ~2 min
- beta.28, default timeout → pre-flight `comply()` timed out after 120000ms → unreachable, 0 graded
- beta.28, `--timeout 600` → 155 passed in 117.0s (identical to beta.27)

## Fix (hosted-side mitigation)

Adds `HOSTED_FULL_COMPLIANCE_TIMEOUT_MS = 600_000` and threads it through **every** hosted full-suite `comply()` call site:
- compliance heartbeat job (was 60s)
- owner/admin registry-refresh endpoint (was 90s)
- `evaluate_agent_quality` member tool (was silently on the 120s SDK default — same regression)
- heartbeat-mirroring diagnostic script (was 90s)

The heartbeat **in-progress lock TTL** now tracks the worst-case serial batch (`batchSize × budget`) instead of a fixed 30 min — otherwise an agent late in the loop could have its lock expire and be re-picked by an overlapping run (duplicate assessment, double badge fan-out).

## Scope notes

- This is a **hosted-side mitigation**. It does not change the SDK's CLI default-timeout behavior, tracked upstream in [adcontextprotocol/adcp-client#2221](https://github.com/adcontextprotocol/adcp-client/issues/2221).
- Under beta.28, `timeout_ms` is the **whole-`comply()`** budget, so 600s is a true per-assessment ceiling (bounded). **Revisit the 600s value when the SDK restores per-call timeout semantics** — at that point a per-call ceiling this large would let a single hung call hold a connection for 10 minutes. The constant carries a comment to this effect.

## Review

Run through code-reviewer and security-reviewer:
- Code review Must-Fix items (missed `evaluate_agent_quality` call site, changeset) and Should-Fix items (constant doc comment, heartbeat lock TTL, stale rate-limit comment, test imports real constant) — all addressed.
- Security review: no ship-blocker. Auth/SSRF/tenancy posture unchanged. The longer window is bounded at 600s under beta.28 and gated to owner/admin + rate-limited on `/refresh`.

## Validation

- `npm run typecheck` clean
- Full precommit suite green (961 + 4140 server tests)
- `npm run build:openapi` idempotent

🤖 Generated with [Claude Code](https://claude.com/claude-code)