### PR TITLE
fix: add copy button to user messages in Addie chat UI

### DIFF
--- a/.changeset/5363-chat-user-message-copy-button.md
+++ b/.changeset/5363-chat-user-message-copy-button.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add a copy button to user messages in the Addie chat UI so prompts can be copied back out of the conversation. This is a UI-only change with no protocol impact.

--- a/server/public/chat.html
+++ b/server/public/chat.html
@@ -987,6 +987,18 @@
       margin-top: 8px;
     }
 
+    @media (hover: hover) and (pointer: fine) {
+      .user-copy-actions {
+        opacity: 0;
+        transition: opacity 0.2s;
+      }
+
+      .message--user:hover .user-copy-actions,
+      .message--user:focus-within .user-copy-actions {
+        opacity: 1;
+      }
+    }
+
     .user-copy-actions .copy-btn {
       color: var(--color-text-on-dark-secondary);
       border-color: color-mix(in srgb, var(--color-text-on-dark) 35%, transparent);

--- a/server/public/chat.html
+++ b/server/public/chat.html
@@ -989,12 +989,17 @@
 
     @media (hover: hover) and (pointer: fine) {
       .user-copy-actions {
+        max-height: 0;
+        margin-top: 0;
+        overflow: hidden;
         opacity: 0;
-        transition: opacity 0.2s;
+        transition: max-height 0.2s, margin-top 0.2s, opacity 0.2s;
       }
 
       .message--user:hover .user-copy-actions,
       .message--user:focus-within .user-copy-actions {
+        max-height: 32px;
+        margin-top: 8px;
         opacity: 1;
       }
     }


### PR DESCRIPTION
## Summary

User messages in the Addie chat UI get a copy button, so long structured prompts can be copied back for reuse. The control is a standalone hover-revealed action row outside `createFeedbackUI()`, so the "Was this helpful?" feedback framing stays assistant-only, and the hidden state is collapsed out of flow so user bubbles do not reserve blank footer space on desktop.

## Why this matters

#5363 was triaged P1 ready-to-implement with the implementation brief this follows: a `role === 'user'` branch in `addMessage()` after the assistant feedback branch, reusing the existing `.copy-btn` styling. The layout blocker the triage flagged (`contentDiv` is not a flex container, so `margin-left: auto` alone renders the button full-width inside the colored bubble) is handled with a `flex; justify-content: flex-end` wrapper.

## Testing

UI-only change in `server/public/chat.html` plus an empty changeset for changeset-check CI. Verified states: hover/focus reveal on desktop, always-visible fallback on touch, no reserved space when hidden, and assistant messages unchanged.

Fixes #5363
