### PR TITLE
Backport proposal support gate to 3.0.x

### DIFF
--- a/.changeset/backport-supports-proposals-gate.md
+++ b/.changeset/backport-supports-proposals-gate.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Backport the proposal-finalize storyboard gate to 3.0.x so sellers that do not declare `media_buy.supports_proposals: true` skip the proposal lifecycle scenario instead of receiving false-negative compliance failures.

--- a/.changeset/backport-supports-proposals-gate.md
+++ b/.changeset/backport-supports-proposals-gate.md
@@ -2,4 +2,4 @@
 "adcontextprotocol": patch
 ---
 
-Backport the proposal-finalize storyboard gate to 3.0.x so sellers that do not declare `media_buy.supports_proposals: true` skip the proposal lifecycle scenario instead of receiving false-negative compliance failures.
+Backport the proposal-finalize storyboard gate to 3.0.x so sellers that do not declare `media_buy.supports_proposals: true` skip the proposal lifecycle scenario instead of receiving false-negative compliance failures, and refresh the idempotency storyboard flight dates so the 3.0.x runner preserves byte-identical replay payloads.

--- a/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
@@ -8,6 +8,12 @@ required_tools:
   - get_products
   - create_media_buy
 
+# `media_buy.supports_proposals` is defined in the 3.1 schema. On 3.0.x,
+# absence is treated as false so non-proposal sellers skip this scenario.
+requires_capability:
+  path: media_buy.supports_proposals
+  equals: true
+
 narrative: |
   Proposals are curated media plans that the seller generates alongside products. The buyer
   reviews proposals, refines them (adjust budget splits, swap products, add constraints),

--- a/static/compliance/source/universal/idempotency.yaml
+++ b/static/compliance/source/universal/idempotency.yaml
@@ -188,8 +188,8 @@ phases:
             operator: "pinnacle-agency.example"
           brand:
             domain: "acmeoutdoor.example"
-          start_time: "2026-07-01T00:00:00Z"
-          end_time: "2026-09-30T23:59:59Z"
+          start_time: "2027-07-01T00:00:00Z"
+          end_time: "2027-09-30T23:59:59Z"
           packages:
             - product_id: "test-product"
               budget: 5000
@@ -263,8 +263,8 @@ phases:
             operator: "pinnacle-agency.example"
           brand:
             domain: "acmeoutdoor.example"
-          start_time: "2026-06-01T00:00:00Z"
-          end_time: "2026-06-30T23:59:59Z"
+          start_time: "2027-06-01T00:00:00Z"
+          end_time: "2027-06-30T23:59:59Z"
           packages:
             - product_id: "test-product"
               budget: 5000
@@ -341,8 +341,8 @@ phases:
             operator: "pinnacle-agency.example"
           brand:
             domain: "acmeoutdoor.example"
-          start_time: "2026-06-01T00:00:00Z"
-          end_time: "2026-06-30T23:59:59Z"
+          start_time: "2027-06-01T00:00:00Z"
+          end_time: "2027-06-30T23:59:59Z"
           packages:
             - product_id: "test-product"
               budget: 5000
@@ -461,8 +461,8 @@ phases:
             operator: "pinnacle-agency.example"
           brand:
             domain: "acmeoutdoor.example"
-          start_time: "2026-06-01T00:00:00Z"
-          end_time: "2026-09-30T23:59:59Z"
+          start_time: "2027-06-01T00:00:00Z"
+          end_time: "2027-09-30T23:59:59Z"
           packages:
             - product_id: "test-product"
               budget: 25000
@@ -524,8 +524,8 @@ phases:
             operator: "pinnacle-agency.example"
           brand:
             domain: "acmeoutdoor.example"
-          start_time: "2026-06-01T00:00:00Z"
-          end_time: "2026-06-30T23:59:59Z"
+          start_time: "2027-06-01T00:00:00Z"
+          end_time: "2027-06-30T23:59:59Z"
           packages:
             - product_id: "test-product"
               budget: 5000


### PR DESCRIPTION
## Summary

Backports the proposal-finalize storyboard applicability gate to the 3.0.x release line.

- Adds `requires_capability` to the 3.0.x `proposal_finalize` storyboard.
- Treats absent `media_buy.supports_proposals` as false, so sellers without proposal support skip the scenario instead of failing.
- Does not add `media_buy.supports_proposals` to the 3.0.x schema, preserving the stable-schema patch rule.
- Adds a patch changeset.

Fixes #5256.

## Validation

- `npm run build:compliance`
- precommit hook: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run typecheck`
- push hook: version sync
