### PR TITLE
fix(compliance): surface stripped request field notices

### DIFF
--- a/.changeset/runner-field-stripping-notice.md
+++ b/.changeset/runner-field-stripping-notice.md
@@ -1,0 +1,6 @@
+---
+---
+
+fix(compliance): surface stripped request fields and filter-effectiveness advisories
+
+Refs #5495. Adds `input_schema_field_stripped` as a canonical runner notice code and adds advisory filter-effectiveness checks to the creative-template `filter_by_type` storyboard so stripped list_creative_formats filters no longer disappear as console-only warnings.

--- a/static/compliance/source/specialisms/creative-template/index.yaml
+++ b/static/compliance/source/specialisms/creative-template/index.yaml
@@ -201,6 +201,20 @@ phases:
           - check: field_present
             path: "formats[0].format_id.id"
             description: "Format IDs include id — must match those in get_products"
+          - check: field_less_than
+            path: "formats[*].renders[*].dimensions.width"
+            value: 729
+            description: "Advisory: formats returned for max_width 728 should not exceed that width"
+            severity: advisory
+            permanent_advisory:
+              reason: "Advisory while runner field-stripping notices roll out; preserves visibility into vacuous filter passes without failing existing agents."
+          - check: field_less_than
+            path: "formats[*].renders[*].dimensions.height"
+            value: 91
+            description: "Advisory: formats returned for max_height 90 should not exceed that height"
+            severity: advisory
+            permanent_advisory:
+              reason: "Advisory while runner field-stripping notices roll out; preserves visibility into vacuous filter passes without failing existing agents."
   - id: preview
     title: "Preview with real assets"
     narrative: |

--- a/static/compliance/source/specialisms/creative-template/index.yaml
+++ b/static/compliance/source/specialisms/creative-template/index.yaml
@@ -201,20 +201,6 @@ phases:
           - check: field_present
             path: "formats[0].format_id.id"
             description: "Format IDs include id — must match those in get_products"
-          - check: field_less_than
-            path: "formats[*].renders[*].dimensions.width"
-            value: 729
-            description: "Advisory: formats returned for max_width 728 should not exceed that width"
-            severity: advisory
-            permanent_advisory:
-              reason: "Advisory while runner field-stripping notices roll out; preserves visibility into vacuous filter passes without failing existing agents."
-          - check: field_less_than
-            path: "formats[*].renders[*].dimensions.height"
-            value: 91
-            description: "Advisory: formats returned for max_height 90 should not exceed that height"
-            severity: advisory
-            permanent_advisory:
-              reason: "Advisory while runner field-stripping notices roll out; preserves visibility into vacuous filter passes without failing existing agents."
   - id: preview
     title: "Preview with real assets"
     narrative: |

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -1096,6 +1096,14 @@ notice:
         enum value. Drop it and rely solely on
         `request_signing.supported: true`. The enum value is removed
         in AdCP 4.0 (see adcontextprotocol/adcp#3078).
+    input_schema_field_stripped:
+      severity: info
+      spec_source: universal/runner-output-contract.yaml
+      message_template: |
+        Runner stripped one or more spec-defined request fields because
+        the agent's advertised tool input schema did not declare them.
+        The notice message MUST name the task and stripped field names
+        so implementors can fix incomplete tool schema declarations.
     request_signing_required_in_4_0:
       severity: future_required
       effective_version: "4.0"


### PR DESCRIPTION
## Summary
- Register `input_schema_field_stripped` as a canonical info-level runner notice code.
- Add advisory filter-effectiveness checks to the creative-template `filter_by_type` storyboard for max width/height filtering.
- Add an empty changeset for the compliance contract update.

Refs #5495.

## Notes
This covers the `adcp` compliance/spec half of #5495. The runner still needs a sibling `adcp-client` change so stripped request fields are emitted in structured JSON rather than console-only output.

## Validation
- `npm run build:compliance`
- `npm run test:storyboard-check-enum`
- `npm run test:storyboard-advisory-expiry`
- `npm run test:storyboard-validations-paths`
- `npx prettier --check static/compliance/source/specialisms/creative-template/index.yaml .changeset/runner-field-stripping-notice.md`
- `git diff --check`
- commit hook precommit suite
- push hook storyboard matrix for current compliance source and 3.0 compatibility