### PR TITLE
feat(si): add sponsored context accountability

### DIFF
--- a/.changeset/si-sponsored-context-accountability.md
+++ b/.changeset/si-sponsored-context-accountability.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": minor
+---
+
+Add Sponsored Intelligence sponsored-context accountability primitives.
+
+New SI schemas define `context_use` (`presentation_only`, `comparison_set`, `reasoning_context`), `sponsored_context` declarations, and host `sponsored_context_receipt` records. `si_get_offering`, `si_initiate_session`, and `si_send_message` now have optional fields for carrying those declarations and receipts across the host boundary.
+
+The model separates `paying_principal` (who economically sponsored the context) from `host_receipt` (what use mode and disclosure commitment the receiving host accepted). Accepted receipts must include the accepted use mode and disclosure commitment; hosts that cannot honor the declaration reject the context rather than down-scoping it.

--- a/docs/sponsored-intelligence/specification.mdx
+++ b/docs/sponsored-intelligence/specification.mdx
@@ -132,6 +132,36 @@ When `include_products` is true and `intent` is provided, the response MAY inclu
 
 This enables hosts to show rich previews before session initiation.
 
+### Sponsored Context Accountability
+
+Offering responses and session responses MAY include `sponsored_context` when the returned offering, matching products, message, or UI elements are sponsored context entering the host boundary. The declaration separates three facts:
+
+| Field | Purpose |
+|-------|---------|
+| `paying_principal` | Economic accountability: the brand that funded or sponsored the context, with optional account/operator context |
+| `context_use` | Declared host-side use mode: `presentation_only`, `comparison_set`, or `reasoning_context` |
+| `disclosure_obligation` | Disclosure the host must either accept and satisfy or reject before using the context |
+
+| `context_use` | Applies when |
+|---------------|--------------|
+| `presentation_only` | The context is rendered or offered as a distinct labeled unit, such as a sponsored card, answer block, or brand-agent handoff. |
+| `comparison_set` | The context forms a sponsored candidate set for comparison, ranking, or selection. This applies naturally to `matching_products`: the returned products may shape comparison even when not every item is rendered. |
+| `reasoning_context` | The context is intended to be available to the host model or orchestration layer for answer generation, planning, ranking, or other reasoning. |
+
+The declaration applies to the returned offering and `matching_products` package as a whole unless a future extension narrows it to individual items.
+
+Hosts that accept sponsored context SHOULD retain an audit record linking the `paying_principal`, declared `context_use`, `disclosure_obligation`, and host receipt. When the host subsequently calls `si_initiate_session` or `si_send_message`, it MAY include `sponsored_context_receipt` to make that acceptance visible to the brand/seller. The receipt records the receiving-surface accountability fact: what use mode the host accepted and what disclosure commitment it made.
+
+For accepted receipts:
+
+- `accepted_context_use` MUST match the declaration's `context_use`
+- `disclosure_commitment.status` MUST be `accepted` when `disclosure_obligation.required` is true
+- `disclosure_commitment.status` MAY be `not_required` only when `disclosure_obligation.required` is false
+
+A host that cannot honor the declared use mode or satisfy a required disclosure obligation MUST reject the sponsored context instead of sending an accepted receipt.
+
+This is a boundary contract. AdCP does not inspect hidden model reasoning, standardize chain-of-thought, or guarantee how a host model internally uses context after receipt. A conforming host that cannot honor the declared use mode or disclosure obligation MUST reject the sponsored context rather than silently down-scope or use it without disclosure.
+
 ## Session Lifecycle
 
 ### Session States
@@ -210,6 +240,7 @@ Hosts MAY include:
 - `media_buy_id` - AdCP media buy ID if triggered by advertising
 - `offering_id` - Brand-specific offering to apply
 - `placement` - Where this session was triggered
+- `sponsored_context_receipt` - Host receipt for sponsored context accepted before session initiation
 
 #### Response Requirements
 
@@ -221,6 +252,7 @@ Brand agents SHOULD return:
 
 - `response.message` - Initial conversational message
 - `negotiated_capabilities` - Intersection of brand and host capabilities
+- `sponsored_context` - Declaration for sponsored context in the initial brand-agent response
 
 ### Send Message
 
@@ -237,6 +269,10 @@ Hosts MUST include one of:
 - `message` - User's text message
 - `action_response` - Response to a UI action
 
+Hosts MAY include:
+
+- `sponsored_context_receipt` - Host receipt for sponsored context accepted from a prior SI response in this session
+
 #### Response Requirements
 
 Brand agents MUST return:
@@ -247,6 +283,7 @@ Brand agents MUST return:
 Brand agents SHOULD return:
 
 - `response.message` - Conversational response
+- `sponsored_context` - Declaration for sponsored context in the response message or UI elements
 
 If `session_status` is `pending_handoff`, the response MUST include:
 

--- a/docs/sponsored-intelligence/specification.mdx
+++ b/docs/sponsored-intelligence/specification.mdx
@@ -138,7 +138,7 @@ Offering responses and session responses MAY include `sponsored_context` when th
 
 | Field | Purpose |
 |-------|---------|
-| `paying_principal` | Economic accountability: the brand that funded or sponsored the context, with optional account/operator context |
+| `paying_principal` | Economic accountability: the brand that funded or sponsored the context, with optional seller account/operator context |
 | `context_use` | Declared host-side use mode: `presentation_only`, `comparison_set`, or `reasoning_context` |
 | `disclosure_obligation` | Disclosure the host must either accept and satisfy or reject before using the context |
 
@@ -150,7 +150,7 @@ Offering responses and session responses MAY include `sponsored_context` when th
 
 The declaration applies to the returned offering and `matching_products` package as a whole unless a future extension narrows it to individual items.
 
-Hosts that accept sponsored context SHOULD retain an audit record linking the `paying_principal`, declared `context_use`, `disclosure_obligation`, and host receipt. When the host subsequently calls `si_initiate_session` or `si_send_message`, it MAY include `sponsored_context_receipt` to make that acceptance visible to the brand/seller. The receipt records the receiving-surface accountability fact: what use mode the host accepted and what disclosure commitment it made.
+Hosts SHOULD retain an audit record linking the `paying_principal`, declared `context_use`, `disclosure_obligation`, and host receipt when they accept or explicitly reject sponsored context. When the host subsequently calls `si_initiate_session` or `si_send_message`, it MAY include `sponsored_context_receipt` to make that decision visible to the brand/seller. The receipt records the receiving-surface accountability fact: whether the host accepted the context, and for accepted receipts, what use mode and disclosure commitment it made.
 
 For accepted receipts:
 
@@ -159,6 +159,8 @@ For accepted receipts:
 - `disclosure_commitment.status` MAY be `not_required` only when `disclosure_obligation.required` is false
 
 A host that cannot honor the declared use mode or satisfy a required disclosure obligation MUST reject the sponsored context instead of sending an accepted receipt.
+
+For rejected receipts, `accepted_context_use` and `disclosure_commitment` MUST be absent. A rejected receipt records that the host did not accept or use the sponsored context, with optional `rejection_reason` explaining why.
 
 This is a boundary contract. AdCP does not inspect hidden model reasoning, standardize chain-of-thought, or guarantee how a host model internally uses context after receipt. A conforming host that cannot honor the declared use mode or disclosure obligation MUST reject the sponsored context rather than silently down-scope or use it without disclosure.
 

--- a/docs/sponsored-intelligence/tasks/si_get_offering.mdx
+++ b/docs/sponsored-intelligence/tasks/si_get_offering.mdx
@@ -106,7 +106,7 @@ When the returned offering or `matching_products` are sponsored context entering
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `paying_principal` | object | Brand economically accountable for the sponsored context, with optional account/operator context |
+| `paying_principal` | object | Brand economically accountable for the sponsored context, with optional seller account/operator context |
 | `context_use` | string | Declared host-side use mode: `presentation_only`, `comparison_set`, or `reasoning_context` |
 | `disclosure_obligation` | object | Disclosure the host must either accept and satisfy or reject before using the context |
 
@@ -368,7 +368,7 @@ When the offering response included `sponsored_context` and the host accepted it
 }
 ```
 
-An accepted receipt means the host honored the declaration. `accepted_context_use` must match the original `context_use`, and `disclosure_commitment.status` must be `accepted` when the declaration required disclosure. If the host cannot honor either condition, it rejects the sponsored context instead of sending an accepted receipt.
+An accepted receipt means the host honored the declaration. `accepted_context_use` must match the original `context_use`, and `disclosure_commitment.status` must be `accepted` when the declaration required disclosure. If the host cannot honor either condition, it rejects the sponsored context instead of sending an accepted receipt. A rejected receipt may still be sent to make the rejection audit-visible, but it must omit `accepted_context_use` and `disclosure_commitment`.
 
 ## Key Points
 

--- a/docs/sponsored-intelligence/tasks/si_get_offering.mdx
+++ b/docs/sponsored-intelligence/tasks/si_get_offering.mdx
@@ -68,6 +68,7 @@ This request must not include any personally identifiable information. The `inte
 | `checked_at` | string | ISO 8601 timestamp of the lookup |
 | `offering` | object | Offering details |
 | `matching_products` | array | Products matching the intent (if requested) |
+| `sponsored_context` | object | Sponsored-context declaration for the returned offering and matching-products package |
 | `total_matching` | integer | Total products matching (may exceed returned count) |
 | `unavailable_reason` | string | Why offering is unavailable (if not available) |
 | `alternative_offering_ids` | array | Alternative offerings to check |
@@ -98,6 +99,18 @@ This request must not include any personally identifiable information. The `inte
 | `availability_summary` | string | Brief availability info |
 | `availability_status` | string | Machine-readable availability state (same enum as the offering field). Optional; structured counterpart to `availability_summary`. |
 | `url` | string | Product detail page URL |
+
+### Sponsored Context Object
+
+When the returned offering or `matching_products` are sponsored context entering the host boundary, include `sponsored_context` at the response level. It applies to the returned package as a whole:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `paying_principal` | object | Brand economically accountable for the sponsored context, with optional account/operator context |
+| `context_use` | string | Declared host-side use mode: `presentation_only`, `comparison_set`, or `reasoning_context` |
+| `disclosure_obligation` | object | Disclosure the host must either accept and satisfy or reject before using the context |
+
+Use `context_use: "comparison_set"` when `matching_products` are a sponsored candidate set for comparison, ranking, or selection. Use `presentation_only` for a distinct sponsored unit or handoff, and `reasoning_context` only when the context is intended to be available to host answer generation, planning, ranking, or other reasoning. Hosts that accept the package can include `sponsored_context_receipt` on the subsequent `si_initiate_session` request so the audit trail links the paying principal, declared use mode, disclosure obligation, and host receipt.
 
 ### Unavailable Reasons
 
@@ -192,6 +205,44 @@ This enables the host to show:
 
 > "Nike has 12 running shoes in your size starting at \$89. Want to explore with their assistant?"
 
+### Response with Sponsored Context
+
+```json
+{
+  "$schema": "/schemas/sponsored-intelligence/si-get-offering-response.json",
+  "status": "completed",
+  "available": true,
+  "offering_token": "offering_abc123xyz",
+  "matching_products": [
+    {
+      "product_id": "trail-pace-14",
+      "name": "Trail Pace 14",
+      "price": "$89",
+      "availability_summary": "Size 14 in stock"
+    }
+  ],
+  "sponsored_context": {
+    "paying_principal": {
+      "brand": { "domain": "acme-running.example" },
+      "display_name": "Acme Running"
+    },
+    "context_use": "comparison_set",
+    "disclosure_obligation": {
+      "required": true,
+      "label_text": "Sponsored results from Acme Running",
+      "timing": "near_each_influenced_output",
+      "proximity": "near_influenced_output"
+    },
+    "declared_by": {
+      "agent_url": "https://agent.acme-running.example/si",
+      "role": "brand_agent"
+    },
+    "declared_at": "2025-01-19T10:00:00Z"
+  },
+  "total_matching": 1
+}
+```
+
 ### Unavailable Response
 
 ```json
@@ -285,6 +336,40 @@ When initiating a session after getting offering details, include the token:
 }
 ```
 
+When the offering response included `sponsored_context` and the host accepted it, the host can also include a receipt:
+
+```json
+{
+  "intent": "User wants more detail about the sponsored trail shoe preview",
+  "offering_token": "offering_abc123xyz",
+  "sponsored_context_receipt": {
+    "sponsored_context": {
+      "paying_principal": {
+        "brand": { "domain": "acme-running.example" },
+        "display_name": "Acme Running"
+      },
+      "context_use": "comparison_set",
+      "disclosure_obligation": {
+        "required": true,
+        "label_text": "Sponsored results from Acme Running"
+      }
+    },
+    "host_receipt": {
+      "status": "accepted",
+      "accepted_context_use": "comparison_set",
+      "received_at": "2025-01-19T10:00:02Z",
+      "host_surface": "assistant_comparison",
+      "disclosure_commitment": {
+        "status": "accepted",
+        "label_text": "Sponsored results from Acme Running"
+      }
+    }
+  }
+}
+```
+
+An accepted receipt means the host honored the declaration. `accepted_context_use` must match the original `context_use`, and `disclosure_commitment.status` must be `accepted` when the declaration required disclosure. If the host cannot honor either condition, it rejects the sponsored context instead of sending an accepted receipt.
+
 ## Key Points
 
 1. **Anonymous by design** - No user data is sent with offering lookups. This protects user privacy while enabling hosts to show rich previews.
@@ -293,11 +378,13 @@ When initiating a session after getting offering details, include the token:
 
 3. **Product matching** - When `include_products` is true and `intent` is provided, brands can return relevant products. This powers pre-session previews like "12 shoes in your size from \$89."
 
-4. **Caching** - Hosts may cache responses for up to `ttl_seconds`. This reduces load on brand agents for frequently checked offerings.
+4. **Sponsored context accountability** - `sponsored_context` declares the paying principal, intended use mode, and disclosure obligation for returned sponsored context. Hosts that accept it should record a `sponsored_context_receipt`.
 
-5. **Graceful degradation** - If the lookup fails or times out, hosts may still initiate sessions directly. The offering lookup is optional.
+5. **Caching** - Hosts may cache responses for up to `ttl_seconds`. This reduces load on brand agents for frequently checked offerings.
 
-6. **Alternative suggestions** - When offerings are unavailable, brand agents may suggest alternatives via `alternative_offering_ids`.
+6. **Graceful degradation** - If the lookup fails or times out, hosts may still initiate sessions directly. The offering lookup is optional.
+
+7. **Alternative suggestions** - When offerings are unavailable, brand agents may suggest alternatives via `alternative_offering_ids`.
 
 ## Best Practices
 
@@ -305,6 +392,8 @@ When initiating a session after getting offering details, include the token:
 
 - Get offering details before showing sponsored results to users
 - Use `include_products` with an `intent` for richer previews
+- Honor or reject `sponsored_context` before using matching products for presentation, comparison, or reasoning context
+- Retain a receipt linking `paying_principal`, `context_use`, disclosure obligation, and host acceptance
 - Respect TTL for caching to avoid stale data
 - Handle unavailable gracefully - don't show expired offerings
 - Include offering token in session initiation when available
@@ -313,6 +402,7 @@ When initiating a session after getting offering details, include the token:
 
 - Return rich `offering` details to help hosts display accurate information
 - Support `include_products` for contextual product matching
+- Attach `sponsored_context` when returned products or offering details are sponsored context entering the host boundary
 - Use reasonable TTL values (e.g., 5-60 minutes depending on volatility)
 - Provide helpful `unavailable_reason` for debugging
 - Suggest alternatives when primary offering is unavailable

--- a/docs/sponsored-intelligence/tasks/si_initiate_session.mdx
+++ b/docs/sponsored-intelligence/tasks/si_initiate_session.mdx
@@ -42,7 +42,7 @@ The token lets the brand agent know exactly what products were shown to the user
 
 ### Sponsored Context Receipt
 
-If the host accepted sponsored context from a pre-session lookup, include `sponsored_context_receipt` to make the host's boundary commitment visible to the brand/seller:
+If the host accepted or explicitly rejected sponsored context from a pre-session lookup, include `sponsored_context_receipt` to make the host's boundary decision visible to the brand/seller:
 
 ```json
 {
@@ -73,7 +73,7 @@ If the host accepted sponsored context from a pre-session lookup, include `spons
 }
 ```
 
-The receipt records what the host accepted and committed to honor. It does not assert that AdCP can inspect hidden model reasoning.
+The receipt records whether the host accepted or rejected the sponsored context. For accepted receipts, it records what the host committed to honor. It does not assert that AdCP can inspect hidden model reasoning.
 
 | Receipt field | Description |
 |---------------|-------------|
@@ -83,7 +83,7 @@ The receipt records what the host accepted and committed to honor. It does not a
 | `host_receipt.disclosure_commitment` | Required for accepted receipts; records the host's disclosure commitment |
 | `host_receipt.rejection_reason` | Optional explanation when the host rejects the sponsored context |
 
-An accepted receipt cannot down-scope the use mode or decline a required disclosure. A host that cannot honor either condition rejects the sponsored context instead.
+An accepted receipt cannot down-scope the use mode or decline a required disclosure. A host that cannot honor either condition rejects the sponsored context instead. Rejected receipts must omit `accepted_context_use` and `disclosure_commitment`.
 
 ### Identity Object
 

--- a/docs/sponsored-intelligence/tasks/si_initiate_session.mdx
+++ b/docs/sponsored-intelligence/tasks/si_initiate_session.mdx
@@ -21,6 +21,7 @@ Start a conversational session with a brand agent. The host platform invokes thi
 | `offering_id` | string | No | Brand-specific offering reference to apply |
 | `supported_capabilities` | object | No | What the host platform supports |
 | `offering_token` | string | No | Token from `si_get_offering` for correlation |
+| `sponsored_context_receipt` | object | No | Host receipt for sponsored context accepted before session initiation |
 | `context` | object | No | Opaque correlation data echoed unchanged in the response (see [application context](/docs/building/integration/context-sessions#application-context-context)) |
 
 ### Offering Token
@@ -38,6 +39,51 @@ The token lets the brand agent know exactly what products were shown to the user
 - User sees: "Nike Pegasus (\$89), Air Max (\$129), Vomero (\$139)"
 - User says: "Tell me more about the middle one"
 - Brand agent resolves "middle one" → Air Max via the token's stored context
+
+### Sponsored Context Receipt
+
+If the host accepted sponsored context from a pre-session lookup, include `sponsored_context_receipt` to make the host's boundary commitment visible to the brand/seller:
+
+```json
+{
+  "offering_token": "offering_abc123xyz",
+  "sponsored_context_receipt": {
+    "sponsored_context": {
+      "paying_principal": {
+        "brand": { "domain": "acme-running.example" },
+        "display_name": "Acme Running"
+      },
+      "context_use": "comparison_set",
+      "disclosure_obligation": {
+        "required": true,
+        "label_text": "Sponsored results from Acme Running"
+      }
+    },
+    "host_receipt": {
+      "status": "accepted",
+      "accepted_context_use": "comparison_set",
+      "received_at": "2025-01-19T10:00:02Z",
+      "host_surface": "assistant_comparison",
+      "disclosure_commitment": {
+        "status": "accepted",
+        "label_text": "Sponsored results from Acme Running"
+      }
+    }
+  }
+}
+```
+
+The receipt records what the host accepted and committed to honor. It does not assert that AdCP can inspect hidden model reasoning.
+
+| Receipt field | Description |
+|---------------|-------------|
+| `sponsored_context` | Sender declaration being acknowledged: paying principal, declared use mode, and disclosure obligation |
+| `host_receipt.status` | `accepted` when the host honored the declaration; `rejected` when it did not use the context |
+| `host_receipt.accepted_context_use` | Required for accepted receipts; must match the declaration's `context_use` |
+| `host_receipt.disclosure_commitment` | Required for accepted receipts; records the host's disclosure commitment |
+| `host_receipt.rejection_reason` | Optional explanation when the host rejects the sponsored context |
+
+An accepted receipt cannot down-scope the use mode or decline a required disclosure. A host that cannot honor either condition rejects the sponsored context instead.
 
 ### Identity Object
 
@@ -89,6 +135,7 @@ Declares what the host platform can render:
 | `session_id` | string | Unique identifier for this session |
 | `response` | object | Brand agent's initial response |
 | `negotiated_capabilities` | object | Intersection of brand and host capabilities |
+| `sponsored_context` | object | Sponsored-context declaration for sponsored context in the initial response |
 
 ### Response Object
 
@@ -187,4 +234,6 @@ Declares what the host platform can render:
 
 4. **Capability negotiation** - The response includes `negotiated_capabilities` showing what features this session can use (intersection of brand and host capabilities).
 
-5. **Clear PII with explicit consent** - When `consent_granted` is true, actual email/name are passed (not hashed). This is a direct, consented handoff.
+5. **Sponsored context receipt** - When a session follows a sponsored preflight lookup, `sponsored_context_receipt` records the host's accepted use mode and disclosure commitment. This is a boundary acceptance record, not a claim about hidden model reasoning.
+
+6. **Clear PII with explicit consent** - When `consent_granted` is true, actual email/name are passed (not hashed). This is a direct, consented handoff.

--- a/docs/sponsored-intelligence/tasks/si_send_message.mdx
+++ b/docs/sponsored-intelligence/tasks/si_send_message.mdx
@@ -17,7 +17,7 @@ Send a message within an active SI session. The host invokes this task to relay 
 | `session_id` | string | Yes | Session ID from `si_initiate_session` |
 | `message` | string | No | User's text message |
 | `action_response` | object | No | Response to a UI action (button click, form submit) |
-| `sponsored_context_receipt` | object | No | Host receipt for sponsored context accepted from a prior SI response |
+| `sponsored_context_receipt` | object | No | Host receipt for sponsored context accepted or explicitly rejected from a prior SI response |
 
 At least one of `message` or `action_response` must be provided.
 
@@ -40,6 +40,14 @@ When the user interacts with a UI element:
 | `session_status` | string | Current session state |
 | `sponsored_context` | object | Sponsored-context declaration for sponsored context in this response |
 | `handoff` | object | Present when session_status is "pending_handoff" |
+
+### Sponsored Context Receipts
+
+If a prior `si_initiate_session` or `si_send_message` response included `sponsored_context`, the host decides whether it can honor the declared `context_use` and `disclosure_obligation` before presenting, comparing, or otherwise using that context. On a subsequent `si_send_message` request, the host MAY include `sponsored_context_receipt` alongside a normal `message` or `action_response` to make that decision visible to the brand/seller.
+
+For accepted receipts, `accepted_context_use` must match the declaration's `context_use`, and `disclosure_commitment.status` must be `accepted` when disclosure was required. For rejected receipts, omit `accepted_context_use` and `disclosure_commitment`; use `rejection_reason` when the host wants to explain why the context was not accepted or used.
+
+When a `si_send_message` response includes new `sponsored_context`, the same acceptance or rejection decision applies before the host uses that response context on the receiving surface. The host can include the receipt on the next turn, or retain it in its own audit record when there is no next SI call.
 
 ### Session Status Values
 

--- a/docs/sponsored-intelligence/tasks/si_send_message.mdx
+++ b/docs/sponsored-intelligence/tasks/si_send_message.mdx
@@ -17,6 +17,7 @@ Send a message within an active SI session. The host invokes this task to relay 
 | `session_id` | string | Yes | Session ID from `si_initiate_session` |
 | `message` | string | No | User's text message |
 | `action_response` | object | No | Response to a UI action (button click, form submit) |
+| `sponsored_context_receipt` | object | No | Host receipt for sponsored context accepted from a prior SI response |
 
 At least one of `message` or `action_response` must be provided.
 
@@ -37,6 +38,7 @@ When the user interacts with a UI element:
 | `session_id` | string | Confirms the active session |
 | `response` | object | Brand agent's response |
 | `session_status` | string | Current session state |
+| `sponsored_context` | object | Sponsored-context declaration for sponsored context in this response |
 | `handoff` | object | Present when session_status is "pending_handoff" |
 
 ### Session Status Values

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -1731,6 +1731,18 @@
         "si-ui-element": {
           "$ref": "/schemas/sponsored-intelligence/si-ui-element.json",
           "description": "Standard visual components (text, link, image, product_card, carousel, action_button, app_handoff)"
+        },
+        "si-context-use": {
+          "$ref": "/schemas/sponsored-intelligence/si-context-use.json",
+          "description": "Declared host-side use mode for sponsored context entering an SI boundary"
+        },
+        "si-sponsored-context": {
+          "$ref": "/schemas/sponsored-intelligence/si-sponsored-context.json",
+          "description": "Declaration linking paying principal, context use, and disclosure obligation for sponsored context"
+        },
+        "si-sponsored-context-receipt": {
+          "$ref": "/schemas/sponsored-intelligence/si-sponsored-context-receipt.json",
+          "description": "Host receipt recording accepted use mode and disclosure commitment for sponsored context"
         }
       },
       "tasks": {

--- a/static/schemas/source/sponsored-intelligence/si-context-use.json
+++ b/static/schemas/source/sponsored-intelligence/si-context-use.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/sponsored-intelligence/si-context-use.json",
   "title": "SI Context Use",
   "description": "Declared use mode for sponsored context crossing into a Sponsored Intelligence host boundary. This is a boundary declaration, not a claim that AdCP can inspect hidden model reasoning after the host receives the context.",
+  "x-status": "experimental",
   "type": "string",
   "enum": [
     "presentation_only",

--- a/static/schemas/source/sponsored-intelligence/si-context-use.json
+++ b/static/schemas/source/sponsored-intelligence/si-context-use.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/sponsored-intelligence/si-context-use.json",
+  "title": "SI Context Use",
+  "description": "Declared use mode for sponsored context crossing into a Sponsored Intelligence host boundary. This is a boundary declaration, not a claim that AdCP can inspect hidden model reasoning after the host receives the context.",
+  "type": "string",
+  "enum": [
+    "presentation_only",
+    "comparison_set",
+    "reasoning_context"
+  ],
+  "enumDescriptions": {
+    "presentation_only": "The sponsored context is intended to be rendered or offered as a distinct labeled unit, not used as comparison candidates or folded into host model reasoning.",
+    "comparison_set": "The sponsored context is intended to form or influence a candidate set used for comparison, ranking, or selection; individual candidates may or may not be rendered.",
+    "reasoning_context": "The sponsored context is intended to be available to the host model or orchestration layer as context for answer generation, planning, ranking, or other reasoning."
+  }
+}

--- a/static/schemas/source/sponsored-intelligence/si-get-offering-response.json
+++ b/static/schemas/source/sponsored-intelligence/si-get-offering-response.json
@@ -128,6 +128,10 @@
         "additionalProperties": true
       }
     },
+    "sponsored_context": {
+      "$ref": "/schemas/sponsored-intelligence/si-sponsored-context.json",
+      "description": "Declaration for the sponsored context carried by this offering response. When present, it applies to the returned offering and matching_products package as a whole unless a future extension narrows the declaration to individual items. Hosts MUST either honor the declared context_use and disclosure_obligation or reject the context before using it."
+    },
     "total_matching": {
       "type": "integer",
       "minimum": 0,

--- a/static/schemas/source/sponsored-intelligence/si-initiate-session-request.json
+++ b/static/schemas/source/sponsored-intelligence/si-initiate-session-request.json
@@ -44,6 +44,10 @@
       "type": "string",
       "description": "Token from si_get_offering response for session continuity. Brand uses this to recall what products were shown to the user, enabling natural references like 'the second one' or 'that blue shoe'."
     },
+    "sponsored_context_receipt": {
+      "$ref": "/schemas/sponsored-intelligence/si-sponsored-context-receipt.json",
+      "description": "Host receipt for sponsored context accepted from a prior si_get_offering response or other pre-session context package. This records the accepted context_use, disclosure commitment, paying_principal, and host receipt for audit."
+    },
     "idempotency_key": {
       "type": "string",
       "description": "Client-generated unique key for this request. Prevents duplicate session creation on retries. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.",

--- a/static/schemas/source/sponsored-intelligence/si-initiate-session-response.json
+++ b/static/schemas/source/sponsored-intelligence/si-initiate-session-response.json
@@ -41,6 +41,10 @@
       "$ref": "/schemas/sponsored-intelligence/si-capabilities.json",
       "description": "Intersection of brand and host capabilities for this session"
     },
+    "sponsored_context": {
+      "$ref": "/schemas/sponsored-intelligence/si-sponsored-context.json",
+      "description": "Declaration for sponsored context carried by the initial brand-agent response. Hosts MUST either honor the declared context_use and disclosure_obligation or reject the context before using it outside the labeled brand-agent exchange."
+    },
     "session_status": {
       "$ref": "/schemas/enums/si-session-status.json",
       "description": "Current session lifecycle state. Returned in initiation, message, and termination responses."

--- a/static/schemas/source/sponsored-intelligence/si-initiate-session-response.json
+++ b/static/schemas/source/sponsored-intelligence/si-initiate-session-response.json
@@ -43,7 +43,7 @@
     },
     "sponsored_context": {
       "$ref": "/schemas/sponsored-intelligence/si-sponsored-context.json",
-      "description": "Declaration for sponsored context carried by the initial brand-agent response. Hosts MUST either honor the declared context_use and disclosure_obligation or reject the context before using it outside the labeled brand-agent exchange."
+      "description": "Declaration for sponsored context carried by the initial brand-agent response. Hosts MUST either honor the declared context_use and disclosure_obligation or reject the context before presenting, comparing, or otherwise using it."
     },
     "session_status": {
       "$ref": "/schemas/enums/si-session-status.json",

--- a/static/schemas/source/sponsored-intelligence/si-send-message-request.json
+++ b/static/schemas/source/sponsored-intelligence/si-send-message-request.json
@@ -43,6 +43,10 @@
       },
       "additionalProperties": true
     },
+    "sponsored_context_receipt": {
+      "$ref": "/schemas/sponsored-intelligence/si-sponsored-context-receipt.json",
+      "description": "Host receipt for sponsored context accepted from a prior SI response in this session. This gives the brand/seller an audit-visible record of the host's accepted use mode and disclosure commitment for that context."
+    },
     "context": {
       "$ref": "/schemas/core/context.json"
     },

--- a/static/schemas/source/sponsored-intelligence/si-send-message-response.json
+++ b/static/schemas/source/sponsored-intelligence/si-send-message-response.json
@@ -48,7 +48,7 @@
     },
     "sponsored_context": {
       "$ref": "/schemas/sponsored-intelligence/si-sponsored-context.json",
-      "description": "Declaration for sponsored context carried by this brand-agent response. Hosts MUST either honor the declared context_use and disclosure_obligation or reject the context before using it outside the labeled brand-agent exchange."
+      "description": "Declaration for sponsored context carried by this brand-agent response. Hosts MUST either honor the declared context_use and disclosure_obligation or reject the context before presenting, comparing, or otherwise using it."
     },
     "session_status": {
       "$ref": "/schemas/enums/si-session-status.json",

--- a/static/schemas/source/sponsored-intelligence/si-send-message-response.json
+++ b/static/schemas/source/sponsored-intelligence/si-send-message-response.json
@@ -46,6 +46,10 @@
       "type": "string",
       "description": "MCP resource URI for hosts with MCP Apps support (e.g., ui://si/session-abc123)"
     },
+    "sponsored_context": {
+      "$ref": "/schemas/sponsored-intelligence/si-sponsored-context.json",
+      "description": "Declaration for sponsored context carried by this brand-agent response. Hosts MUST either honor the declared context_use and disclosure_obligation or reject the context before using it outside the labeled brand-agent exchange."
+    },
     "session_status": {
       "$ref": "/schemas/enums/si-session-status.json",
       "description": "Current session status. On a successful response, one of: active, pending_handoff, or complete. Terminated sessions return error codes (SESSION_NOT_FOUND or SESSION_TERMINATED) instead of a success response."

--- a/static/schemas/source/sponsored-intelligence/si-sponsored-context-receipt.json
+++ b/static/schemas/source/sponsored-intelligence/si-sponsored-context-receipt.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/sponsored-intelligence/si-sponsored-context-receipt.json",
   "title": "SI Sponsored Context Receipt",
   "description": "Host receipt for sponsored context previously delivered into an SI host boundary. The receipt records what use mode the host accepted and what disclosure commitment it made; it does not claim that AdCP inspected hidden model reasoning.",
+  "x-status": "experimental",
   "type": "object",
   "properties": {
     "sponsored_context": {
@@ -87,6 +88,34 @@
               "accepted_context_use",
               "disclosure_commitment"
             ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "rejected"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          "then": {
+            "not": {
+              "anyOf": [
+                {
+                  "required": [
+                    "accepted_context_use"
+                  ]
+                },
+                {
+                  "required": [
+                    "disclosure_commitment"
+                  ]
+                }
+              ]
+            }
           }
         }
       ]

--- a/static/schemas/source/sponsored-intelligence/si-sponsored-context-receipt.json
+++ b/static/schemas/source/sponsored-intelligence/si-sponsored-context-receipt.json
@@ -1,0 +1,280 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/sponsored-intelligence/si-sponsored-context-receipt.json",
+  "title": "SI Sponsored Context Receipt",
+  "description": "Host receipt for sponsored context previously delivered into an SI host boundary. The receipt records what use mode the host accepted and what disclosure commitment it made; it does not claim that AdCP inspected hidden model reasoning.",
+  "type": "object",
+  "properties": {
+    "sponsored_context": {
+      "$ref": "/schemas/sponsored-intelligence/si-sponsored-context.json",
+      "description": "The sponsored-context declaration the host received and is accepting or rejecting."
+    },
+    "host_receipt": {
+      "type": "object",
+      "description": "Receiving-surface accountability fact: the use mode the host accepted and committed to honor for this sponsored context.",
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Whether the host accepted the declared sponsored context for use.",
+          "enum": [
+            "accepted",
+            "rejected"
+          ]
+        },
+        "accepted_context_use": {
+          "$ref": "/schemas/sponsored-intelligence/si-context-use.json",
+          "description": "Use mode the host accepted. When host_receipt.status is accepted, this MUST match the declaration's context_use; a host that cannot honor the declared use mode rejects the sponsored context instead of down-scoping it."
+        },
+        "received_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When the host received the sponsored context."
+        },
+        "host_surface": {
+          "type": "string",
+          "description": "Host-defined surface or placement where the context was accepted, such as an assistant session, search result page, or comparison module."
+        },
+        "disclosure_commitment": {
+          "type": "object",
+          "description": "How the host committed to handle the declared disclosure obligation. Required when host_receipt.status is accepted.",
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "accepted",
+                "not_required"
+              ],
+              "description": "Host commitment status for the disclosure obligation. Use accepted when the declaration requires disclosure and the host will satisfy it; use not_required only when the declaration's disclosure_obligation.required is false. A host that will not satisfy a required disclosure rejects the sponsored context."
+            },
+            "label_text": {
+              "type": "string",
+              "description": "Disclosure label text the host committed to render, if different from or copied from the declaration."
+            },
+            "notes": {
+              "type": "string",
+              "description": "Optional host explanation for the disclosure commitment."
+            }
+          },
+          "required": [
+            "status"
+          ],
+          "additionalProperties": true
+        },
+        "rejection_reason": {
+          "type": "string",
+          "description": "Optional explanation when status is rejected, for example unsupported context_use or inability to satisfy the disclosure obligation."
+        }
+      },
+      "required": [
+        "status",
+        "received_at"
+      ],
+      "additionalProperties": true,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "accepted"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          "then": {
+            "required": [
+              "accepted_context_use",
+              "disclosure_commitment"
+            ]
+          }
+        }
+      ]
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": [
+    "sponsored_context",
+    "host_receipt"
+  ],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "sponsored_context": {
+            "properties": {
+              "context_use": {
+                "const": "presentation_only"
+              }
+            },
+            "required": [
+              "context_use"
+            ]
+          },
+          "host_receipt": {
+            "properties": {
+              "status": {
+                "const": "accepted"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          }
+        },
+        "required": [
+          "sponsored_context",
+          "host_receipt"
+        ]
+      },
+      "then": {
+        "properties": {
+          "host_receipt": {
+            "properties": {
+              "accepted_context_use": {
+                "const": "presentation_only"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "sponsored_context": {
+            "properties": {
+              "context_use": {
+                "const": "comparison_set"
+              }
+            },
+            "required": [
+              "context_use"
+            ]
+          },
+          "host_receipt": {
+            "properties": {
+              "status": {
+                "const": "accepted"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          }
+        },
+        "required": [
+          "sponsored_context",
+          "host_receipt"
+        ]
+      },
+      "then": {
+        "properties": {
+          "host_receipt": {
+            "properties": {
+              "accepted_context_use": {
+                "const": "comparison_set"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "sponsored_context": {
+            "properties": {
+              "context_use": {
+                "const": "reasoning_context"
+              }
+            },
+            "required": [
+              "context_use"
+            ]
+          },
+          "host_receipt": {
+            "properties": {
+              "status": {
+                "const": "accepted"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          }
+        },
+        "required": [
+          "sponsored_context",
+          "host_receipt"
+        ]
+      },
+      "then": {
+        "properties": {
+          "host_receipt": {
+            "properties": {
+              "accepted_context_use": {
+                "const": "reasoning_context"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "sponsored_context": {
+            "properties": {
+              "disclosure_obligation": {
+                "properties": {
+                  "required": {
+                    "const": true
+                  }
+                },
+                "required": [
+                  "required"
+                ]
+              }
+            },
+            "required": [
+              "disclosure_obligation"
+            ]
+          },
+          "host_receipt": {
+            "properties": {
+              "status": {
+                "const": "accepted"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          }
+        },
+        "required": [
+          "sponsored_context",
+          "host_receipt"
+        ]
+      },
+      "then": {
+        "properties": {
+          "host_receipt": {
+            "properties": {
+              "disclosure_commitment": {
+                "properties": {
+                  "status": {
+                    "const": "accepted"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "additionalProperties": true
+}

--- a/static/schemas/source/sponsored-intelligence/si-sponsored-context.json
+++ b/static/schemas/source/sponsored-intelligence/si-sponsored-context.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/sponsored-intelligence/si-sponsored-context.json",
+  "title": "SI Sponsored Context",
+  "description": "Declaration attached to sponsored context delivered into an SI host boundary. Separates the economic accountability fact (`paying_principal`) from the host's receipt/acceptance record, which is carried separately by si-sponsored-context-receipt.json.",
+  "type": "object",
+  "properties": {
+    "paying_principal": {
+      "type": "object",
+      "description": "Economic accountability fact: the brand that funded or sponsored this context, with optional account/operator context. This identifies who paid for the sponsored context; it is distinct from the host's later receipt and use commitment.",
+      "properties": {
+        "brand": {
+          "$ref": "/schemas/core/brand-ref.json",
+          "description": "Brand economically accountable for the sponsored context."
+        },
+        "account": {
+          "$ref": "/schemas/core/account-ref.json",
+          "description": "Optional account reference when the seller or network has an account namespace for the paying principal."
+        },
+        "operator": {
+          "type": "string",
+          "description": "Domain of the operator acting for the paying principal, when different from the brand domain.",
+          "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$",
+          "x-entity": "operator"
+        },
+        "display_name": {
+          "type": "string",
+          "description": "Human-readable label for disclosure rendering. The canonical identity remains the brand/account reference."
+        }
+      },
+      "required": [
+        "brand"
+      ],
+      "additionalProperties": true
+    },
+    "context_use": {
+      "$ref": "/schemas/sponsored-intelligence/si-context-use.json",
+      "description": "Declared host-side use mode for this sponsored context."
+    },
+    "disclosure_obligation": {
+      "type": "object",
+      "description": "Disclosure obligation the receiving host must either accept and satisfy or reject before using this sponsored context. This is a declared obligation and audit input, not a protocol-level legal determination.",
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "description": "Whether the declaring party requires disclosure for this sponsored context."
+        },
+        "label_text": {
+          "type": "string",
+          "description": "Disclosure label text the host should render when disclosure is required."
+        },
+        "timing": {
+          "type": "string",
+          "description": "When the disclosure must be presented relative to the sponsored context's influence.",
+          "enum": [
+            "before_use",
+            "at_first_influenced_output",
+            "near_each_influenced_output"
+          ],
+          "enumDescriptions": {
+            "before_use": "Disclose before the host uses the sponsored context.",
+            "at_first_influenced_output": "Disclose at the first host output influenced by the sponsored context.",
+            "near_each_influenced_output": "Disclose near each output that presents, compares, or is materially influenced by the sponsored context."
+          }
+        },
+        "proximity": {
+          "type": "string",
+          "description": "Where the disclosure should appear relative to the affected output.",
+          "enum": [
+            "session_level",
+            "near_rendered_unit",
+            "near_influenced_output"
+          ],
+          "enumDescriptions": {
+            "session_level": "A session-level disclosure is sufficient.",
+            "near_rendered_unit": "Disclosure should appear near the sponsored card, answer block, handoff, or other rendered unit.",
+            "near_influenced_output": "Disclosure should appear near the host output that was shaped by the sponsored context, even if no single rendered unit is the ad."
+          }
+        },
+        "jurisdictions": {
+          "type": "array",
+          "description": "Jurisdictions where this declared disclosure obligation applies.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "country": {
+                "type": "string",
+                "description": "ISO 3166-1 alpha-2 country code."
+              },
+              "region": {
+                "type": "string",
+                "description": "Optional sub-national region code."
+              },
+              "regulation": {
+                "type": "string",
+                "description": "Regulation or policy identifier."
+              }
+            },
+            "required": [
+              "country",
+              "regulation"
+            ],
+            "additionalProperties": true
+          },
+          "minItems": 1
+        }
+      },
+      "required": [
+        "required"
+      ],
+      "additionalProperties": true
+    },
+    "declared_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When this sponsored-context declaration was made."
+    },
+    "declared_by": {
+      "type": "object",
+      "description": "Agent or service that attached the declaration.",
+      "properties": {
+        "agent_url": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^https://",
+          "description": "HTTPS URL of the declaring agent or service."
+        },
+        "role": {
+          "type": "string",
+          "enum": [
+            "brand_agent",
+            "seller",
+            "network",
+            "platform"
+          ],
+          "description": "Role of the declaring party."
+        }
+      },
+      "required": [
+        "role"
+      ],
+      "additionalProperties": true
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": [
+    "paying_principal",
+    "context_use",
+    "disclosure_obligation"
+  ],
+  "additionalProperties": true
+}

--- a/static/schemas/source/sponsored-intelligence/si-sponsored-context.json
+++ b/static/schemas/source/sponsored-intelligence/si-sponsored-context.json
@@ -3,6 +3,7 @@
   "$id": "/schemas/sponsored-intelligence/si-sponsored-context.json",
   "title": "SI Sponsored Context",
   "description": "Declaration attached to sponsored context delivered into an SI host boundary. Separates the economic accountability fact (`paying_principal`) from the host's receipt/acceptance record, which is carried separately by si-sponsored-context-receipt.json.",
+  "x-status": "experimental",
   "type": "object",
   "properties": {
     "paying_principal": {
@@ -14,8 +15,19 @@
           "description": "Brand economically accountable for the sponsored context."
         },
         "account": {
-          "$ref": "/schemas/core/account-ref.json",
-          "description": "Optional account reference when the seller or network has an account namespace for the paying principal."
+          "type": "object",
+          "description": "Optional seller-assigned account context for the paying principal. This intentionally carries only an account_id so the canonical economic principal remains paying_principal.brand.",
+          "properties": {
+            "account_id": {
+              "type": "string",
+              "description": "Seller-assigned account identifier for the paying principal.",
+              "x-entity": "account"
+            }
+          },
+          "required": [
+            "account_id"
+          ],
+          "additionalProperties": false
         },
         "operator": {
           "type": "string",

--- a/tests/example-validation-simple.test.cjs
+++ b/tests/example-validation-simple.test.cjs
@@ -154,6 +154,7 @@ async function runTests() {
   const sponsoredContext = {
     paying_principal: {
       brand: { domain: 'acme-running.example' },
+      account: { account_id: 'acct_acme_running_001' },
       display_name: 'Acme Running'
     },
     context_use: 'comparison_set',
@@ -192,6 +193,20 @@ async function runTests() {
     },
     '/schemas/sponsored-intelligence/si-sponsored-context-receipt.json',
     'SI sponsored context receipt example'
+  );
+
+  await validateExample(
+    {
+      sponsored_context: sponsoredContext,
+      host_receipt: {
+        status: 'rejected',
+        received_at: '2025-01-19T10:00:02Z',
+        host_surface: 'assistant_comparison',
+        rejection_reason: 'Host cannot satisfy the declared disclosure obligation'
+      }
+    },
+    '/schemas/sponsored-intelligence/si-sponsored-context-receipt.json',
+    'SI sponsored context rejected receipt example'
   );
 
   const sponsoredContextReceipt = {
@@ -238,6 +253,45 @@ async function runTests() {
     },
     '/schemas/sponsored-intelligence/si-initiate-session-request.json',
     'SI initiate session request with sponsored context receipt'
+  );
+
+  await validateExample(
+    {
+      status: 'completed',
+      session_id: 'si_sess_abc123',
+      session_status: 'active',
+      response: {
+        message: 'I can help compare trail shoes from Acme Running.'
+      },
+      sponsored_context: sponsoredContext
+    },
+    '/schemas/sponsored-intelligence/si-initiate-session-response.json',
+    'SI initiate session response with sponsored context'
+  );
+
+  await validateExample(
+    {
+      idempotency_key: 'a7b8c9d0-e1f2-4567-8901-345678901234',
+      session_id: 'si_sess_abc123',
+      message: 'Show me more waterproof options',
+      sponsored_context_receipt: sponsoredContextReceipt
+    },
+    '/schemas/sponsored-intelligence/si-send-message-request.json',
+    'SI send message request with sponsored context receipt'
+  );
+
+  await validateExample(
+    {
+      status: 'completed',
+      session_id: 'si_sess_abc123',
+      session_status: 'active',
+      response: {
+        message: 'Here are the waterproof trail options.'
+      },
+      sponsored_context: sponsoredContext
+    },
+    '/schemas/sponsored-intelligence/si-send-message-response.json',
+    'SI send message response with sponsored context'
   );
 
   await expectInvalid(
@@ -302,6 +356,24 @@ async function runTests() {
     '/schemas/sponsored-intelligence/si-sponsored-context-receipt.json',
     'SI sponsored context accepted receipt cannot decline required disclosure',
     ['must be equal to constant']
+  );
+
+  await expectInvalid(
+    {
+      sponsored_context: sponsoredContext,
+      host_receipt: {
+        status: 'rejected',
+        accepted_context_use: 'comparison_set',
+        received_at: '2025-01-19T10:00:02Z',
+        disclosure_commitment: {
+          status: 'accepted'
+        },
+        rejection_reason: 'Host cannot satisfy the declared disclosure obligation'
+      }
+    },
+    '/schemas/sponsored-intelligence/si-sponsored-context-receipt.json',
+    'SI sponsored context rejected receipt cannot include accepted-only fields',
+    ['must NOT be valid']
   );
 
   for (const fixture of [

--- a/tests/example-validation-simple.test.cjs
+++ b/tests/example-validation-simple.test.cjs
@@ -151,6 +151,159 @@ async function runTests() {
     await validateExample(example.data, example.schema, example.description);
   }
 
+  const sponsoredContext = {
+    paying_principal: {
+      brand: { domain: 'acme-running.example' },
+      display_name: 'Acme Running'
+    },
+    context_use: 'comparison_set',
+    disclosure_obligation: {
+      required: true,
+      label_text: 'Sponsored results from Acme Running',
+      timing: 'near_each_influenced_output',
+      proximity: 'near_influenced_output'
+    },
+    declared_by: {
+      agent_url: 'https://agent.acme-running.example/si',
+      role: 'brand_agent'
+    },
+    declared_at: '2025-01-19T10:00:00Z'
+  };
+
+  await validateExample(
+    sponsoredContext,
+    '/schemas/sponsored-intelligence/si-sponsored-context.json',
+    'SI sponsored context example'
+  );
+
+  await validateExample(
+    {
+      sponsored_context: sponsoredContext,
+      host_receipt: {
+        status: 'accepted',
+        accepted_context_use: 'comparison_set',
+        received_at: '2025-01-19T10:00:02Z',
+        host_surface: 'assistant_comparison',
+        disclosure_commitment: {
+          status: 'accepted',
+          label_text: 'Sponsored results from Acme Running'
+        }
+      }
+    },
+    '/schemas/sponsored-intelligence/si-sponsored-context-receipt.json',
+    'SI sponsored context receipt example'
+  );
+
+  const sponsoredContextReceipt = {
+    sponsored_context: sponsoredContext,
+    host_receipt: {
+      status: 'accepted',
+      accepted_context_use: 'comparison_set',
+      received_at: '2025-01-19T10:00:02Z',
+      host_surface: 'assistant_comparison',
+      disclosure_commitment: {
+        status: 'accepted',
+        label_text: 'Sponsored results from Acme Running'
+      }
+    }
+  };
+
+  await validateExample(
+    {
+      status: 'completed',
+      available: true,
+      offering_token: 'offering_abc123xyz',
+      matching_products: [
+        {
+          product_id: 'trail-pace-14',
+          name: 'Trail Pace 14'
+        }
+      ],
+      sponsored_context: sponsoredContext
+    },
+    '/schemas/sponsored-intelligence/si-get-offering-response.json',
+    'SI get offering response with sponsored context'
+  );
+
+  await validateExample(
+    {
+      idempotency_key: 'f6a7b8c9-d0e1-4234-f567-234567890123',
+      intent: 'User wants more detail about the sponsored trail shoe preview',
+      identity: {
+        consent_granted: false,
+        anonymous_session_id: 'anon_sess_123'
+      },
+      offering_token: 'offering_abc123xyz',
+      sponsored_context_receipt: sponsoredContextReceipt
+    },
+    '/schemas/sponsored-intelligence/si-initiate-session-request.json',
+    'SI initiate session request with sponsored context receipt'
+  );
+
+  await expectInvalid(
+    {
+      sponsored_context: sponsoredContext,
+      host_receipt: {
+        status: 'accepted',
+        received_at: '2025-01-19T10:00:02Z'
+      }
+    },
+    '/schemas/sponsored-intelligence/si-sponsored-context-receipt.json',
+    'SI sponsored context accepted receipt requires use mode and disclosure commitment',
+    ['must have required property']
+  );
+
+  await expectInvalid(
+    {
+      sponsored_context: sponsoredContext,
+      host_receipt: {
+        status: 'accepted',
+        accepted_context_use: 'comparison_set',
+        received_at: '2025-01-19T10:00:02Z',
+        disclosure_commitment: {
+          status: 'rejected'
+        }
+      }
+    },
+    '/schemas/sponsored-intelligence/si-sponsored-context-receipt.json',
+    'SI sponsored context accepted receipt rejects contradictory disclosure commitment',
+    ['must be equal to one of the allowed values']
+  );
+
+  await expectInvalid(
+    {
+      sponsored_context: sponsoredContext,
+      host_receipt: {
+        status: 'accepted',
+        accepted_context_use: 'presentation_only',
+        received_at: '2025-01-19T10:00:02Z',
+        disclosure_commitment: {
+          status: 'accepted'
+        }
+      }
+    },
+    '/schemas/sponsored-intelligence/si-sponsored-context-receipt.json',
+    'SI sponsored context accepted receipt cannot change declared context use',
+    ['must be equal to constant']
+  );
+
+  await expectInvalid(
+    {
+      sponsored_context: sponsoredContext,
+      host_receipt: {
+        status: 'accepted',
+        accepted_context_use: 'comparison_set',
+        received_at: '2025-01-19T10:00:02Z',
+        disclosure_commitment: {
+          status: 'not_required'
+        }
+      }
+    },
+    '/schemas/sponsored-intelligence/si-sponsored-context-receipt.json',
+    'SI sponsored context accepted receipt cannot decline required disclosure',
+    ['must be equal to constant']
+  );
+
   for (const fixture of [
     {
       path: 'static/examples/brand-json/riverton-kitchen-guidelines.json',


### PR DESCRIPTION
## Summary

Adds SI sponsored-context accountability schemas for `context_use`, `sponsored_context`, and host receipts, separating `paying_principal` from `host_receipt`.
Wires optional `sponsored_context` and `sponsored_context_receipt` fields through `si_get_offering`, `si_initiate_session`, and `si_send_message`, with docs explaining accepted versus rejected host behavior.
Adds validation coverage for accepted receipts requiring matching context use and accepted disclosure when disclosure is required, plus a minor changeset.

## Validation

`npm run test:schemas`; `npm run test:examples`; `npm run test:json-schema`; `npm run build:schemas`; precommit hook (`test:unit`, dynamic imports, callapi state change, server unit, typecheck); pre-push docs validation.
