### PR TITLE
fix(schemas): accept ad-server macros in VAST/DAAST tag URLs

### DIFF
--- a/.changeset/vast-daast-tag-url-macro-validation.md
+++ b/.changeset/vast-daast-tag-url-macro-validation.md
@@ -1,0 +1,13 @@
+---
+"adcontextprotocol": patch
+---
+
+Accept unsubstituted ad-server macros in VAST/DAAST tag URLs.
+
+`vast-asset.json` and `daast-asset.json` validated the `delivery_type: "url"` branch's `url` field with `format: "uri"` (strict RFC 3986). Real-world tags carry unsubstituted macros — VAST-style `[OMIDPARTNER]` / `[BUNDLEID]` placeholders and `${GDPR_CONSENT}`-style privacy macros — whose square brackets and curly braces are illegal unencoded in an RFC 3986 URI. Any verification-wrapped CTV tag (IAS, DV, MOAT wrappers) therefore failed `create_media_buy` validation even though the tag is valid per the IAB VAST spec, where players substitute macros before treating the string as a URL. Pre-encoding the delimiters is not a workaround: players and verification vendors match the literal macro token, so an encoded `%5BOMIDPARTNER%5D` never gets substituted.
+
+Both fields now use `format: "uri-template"` (RFC 6570), the same convention `url-asset.json` already uses for AdCP universal macros. RFC 6570 permits `[` / `]` as literal characters and parses `${MACRO}` as a literal `$` followed by a `{MACRO}` expression, so macro-laden tags validate while malformed strings (raw spaces, control characters, unbalanced braces) are still rejected. Schema descriptions now state that buyers MUST NOT pre-encode macro delimiters.
+
+Known limitation: GAM-style `%%MACRO%%` placeholders still fail (a bare `%` must be percent-encoded under RFC 6570). VAST 4.x official macros use `[MACRO]` and privacy conventions use `${...}`, so the common cases are covered; widening further would mean dropping `format` validation entirely.
+
+Adds a regression test validating a real verification-wrapped CTV tag against both asset schemas, with a negative case confirming malformed URLs are still rejected.

--- a/static/schemas/source/core/assets/daast-asset.json
+++ b/static/schemas/source/core/assets/daast-asset.json
@@ -54,8 +54,8 @@
         },
         "url": {
           "type": "string",
-          "format": "uri",
-          "description": "URL endpoint that returns DAAST XML"
+          "format": "uri-template",
+          "description": "URL endpoint that returns DAAST XML. May carry unsubstituted ad-server macros — DAAST/VAST-style `[MACRO]` and `${MACRO}` placeholders are accepted as-is (RFC 6570 syntax); buyers MUST NOT pre-encode macro delimiters, since players match the literal token at substitution time."
         }
       },
       "required": [

--- a/static/schemas/source/core/assets/vast-asset.json
+++ b/static/schemas/source/core/assets/vast-asset.json
@@ -60,8 +60,8 @@
         },
         "url": {
           "type": "string",
-          "format": "uri",
-          "description": "URL endpoint that returns VAST XML"
+          "format": "uri-template",
+          "description": "URL endpoint that returns VAST XML. May carry unsubstituted ad-server macros — VAST-style `[MACRO]` and `${MACRO}` placeholders are accepted as-is (RFC 6570 syntax); buyers MUST NOT pre-encode macro delimiters, since players match the literal token at substitution time."
         }
       },
       "required": [

--- a/tests/schema-validation.test.cjs
+++ b/tests/schema-validation.test.cjs
@@ -1632,6 +1632,44 @@ async function runTests() {
     return true;
   });
 
+  // Test 12B: VAST/DAAST tag URLs accept unsubstituted ad-server macros
+  await test('VAST and DAAST tag URLs accept [MACRO] and ${MACRO} placeholders', async () => {
+    // Real-world IAS-wrapped CTV tag: [OMIDPARTNER]-style VAST macros and
+    // ${GDPR_CONSENT}-style privacy macros are illegal in strict RFC 3986 URIs
+    // but valid RFC 6570 templates. format: "uri" rejected these; the tag
+    // asset URLs must use format: "uri-template" (same convention as url-asset).
+    const macroUrl = 'https://unified.adsafeprotected.com/v2/2816045/94180721?mon=94180722&omidPartner=[OMIDPARTNER]&apiframeworks=[APIFRAMEWORKS]&bundleId=[BUNDLEID]&blockedAdTracking=${DC_BLOCKED_AD}&ias_dts=atw&ias_xappb=[ctv_appid]&originalVast=https://vast.extremereach.io/v/16115077?us_privacy=${US_PRIVACY}&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_1002}&gpp=${GPP_STRING_1002}&gpp_sid=${GPP_SID}&er_did=[INSERT_DEVICE_ID_HERE]&ba_cb=[INSERT_CACHEBREAKER_HERE]';
+
+    const cases = [
+      ['core/assets/vast-asset.json', { asset_type: 'vast', delivery_type: 'url', url: macroUrl }],
+      ['core/assets/daast-asset.json', { asset_type: 'daast', delivery_type: 'url', url: macroUrl }]
+    ];
+
+    for (const [schemaFile, asset] of cases) {
+      const assetSchema = loadSchema(path.join(SCHEMA_BASE_DIR, schemaFile));
+      const testAjv = new Ajv({
+        allErrors: true,
+        verbose: true,
+        strict: false,
+        discriminator: true,
+        loadSchema: loadExternalSchema
+      });
+      addFormats(testAjv);
+
+      const validate = await testAjv.compileAsync(assetSchema);
+      if (!validate(asset)) {
+        const errors = validate.errors.map(err => `${err.instancePath} ${err.message}`).join('; ');
+        return `${schemaFile}: macro-laden tag URL must validate: ${errors}`;
+      }
+
+      const malformed = { ...asset, url: 'not a valid uri template' };
+      if (validate(malformed)) {
+        return `${schemaFile}: url with raw spaces must still be rejected`;
+      }
+    }
+    return true;
+  });
+
   // Test 13: Validate schema examples against their schemas
   await test('Schema examples validate against their own schemas', async () => {
     // Skip schemas that require format-aware validation (creative manifests need format context)


### PR DESCRIPTION
## Problem

`create_media_buy` rejects valid VAST tags:

```
Validation failed for field '/packages/0/creatives/0/assets/vast_tag/url':
format: must match format "uri"
```

The failing tag was a standard verification-wrapped CTV tag (IAS wrapping an Extreme Reach VAST endpoint) carrying unsubstituted macros:

```
https://xx.xx.com/v2/.../...?omidPartner=[OMIDPARTNER]&bundleId=[BUNDLEID]
  &blockedAdTracking=${DC_BLOCKED_AD}&...&gdpr_consent=${GDPR_CONSENT_1002}&...
```

`vast-asset.json` and `daast-asset.json` validate the `delivery_type: "url"` branch's `url` with `format: "uri"`, i.e. strict RFC 3986. Square brackets are only legal in a URI as IPv6 authority delimiters, and curly braces are not legal anywhere unencoded — so `[OMIDPARTNER]` and `${GDPR}` fail. But these are exactly the macro conventions the IAB VAST spec and privacy frameworks (TCF, GPP, US Privacy) use: players substitute macros **before** treating the string as a URL, so the pre-substitution string is never meant to be a syntactically valid URI.

Pre-encoding the delimiters is not a workaround — players and verification vendors match the literal macro token, so an encoded `%5BOMIDPARTNER%5D` silently never gets substituted. In practice this meant essentially every verification-wrapped CTV tag was unsubmittable via `vast_tag` URL delivery, with inline XML delivery as the only escape hatch.

## Fix

Switch both `url` fields from `format: "uri"` to `format: "uri-template"` (RFC 6570) — the convention `url-asset.json` already established for AdCP universal macros, so this aligns the tag assets with existing repo precedent rather than inventing a new mechanism.

RFC 6570 makes this work without any custom pattern:
- `[` (0x5B) and `]` (0x5D) are permitted literal characters
- `${GDPR_CONSENT_1002}` parses as a literal `$` followed by a `{GDPR_CONSENT_1002}` template expression

Verified against ajv + ajv-formats (the validator stack used in CI): the exact failing production tag passes `uri-template` and fails `uri`; junk strings (raw spaces, unbalanced braces) are still rejected.

Schema descriptions on both fields now document that macros are accepted as-is and that buyers MUST NOT pre-encode macro delimiters.

## Changes

- `static/schemas/source/core/assets/vast-asset.json` — `url` format `uri` → `uri-template`, description documents macro handling
- `static/schemas/source/core/assets/daast-asset.json` — same fix for the audio analogue
- `tests/schema-validation.test.cjs` — regression test validating the real verification-wrapped tag against both asset schemas, plus a negative case confirming malformed URLs still fail
- `.changeset/vast-daast-tag-url-macro-validation.md` — patch changeset

## Known limitation

GAM-style `%%MACRO%%` placeholders still fail validation — a bare `%` must be percent-encoded under RFC 6570. VAST 4.x official macros are `[MACRO]` and privacy conventions use `${...}`, so the common cases are covered. Supporting `%%` would require dropping `format` validation entirely in favor of a loose pattern; left out of scope here deliberately, flagging for maintainers in case that's wanted.

## Testing

- `test:schemas` — 19/19 pass (includes the new regression test)
- `test:json-schema` — 284 doc blocks pass
- `test:examples` — 55 pass
- Canonical fixture validation (15) and negative fixtures (38) — pass
- `build:schemas` + `typecheck` — clean
- Pre-existing `test:snippets` failures (live-SDK snippets in `get_products.mdx` / `sync_creatives.mdx`) reproduce identically on a clean tree — unrelated

## Note on released versions

This fixes `static/schemas/source/` (`/schemas/latest/`). The error in the report cited the released `3.0.12` bundled schema, which is immutable — callers pinned to 3.0.x get the fix when the next release is cut. Until then, the workaround for macro-laden tags is `delivery_type: "inline"`.