### PR TITLE
Bump AdCP SDK beta 29

### DIFF
--- a/.changeset/sdk-beta-29-phase-capability-gates.md
+++ b/.changeset/sdk-beta-29-phase-capability-gates.md
@@ -1,0 +1,12 @@
+---
+"adcontextprotocol": patch
+---
+
+Bump `@adcp/sdk` to `9.0.0-beta.29` so hosted and local storyboard runs pick
+up phase-level `requires_capability` enforcement. Protocol-specific phases in
+universal storyboards now skip as `not_applicable` before dispatch when the
+agent does not advertise the gated capability.
+
+The training agent now also advertises and accepts the SDK runner's `3.1-rc.14`
+wire pin so local storyboard matrices do not reject current prerelease probes
+with `VERSION_UNSUPPORTED`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.1.0-rc.13",
       "dependencies": {
-        "@adcp/sdk": "9.0.0-beta.28",
+        "@adcp/sdk": "9.0.0-beta.29",
         "@anthropic-ai/sdk": "^0.104.1",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "9.0.0-beta.28",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-9.0.0-beta.28.tgz",
-      "integrity": "sha512-MY0cS7guu5G4Pr4r034/7w2YDXV58S5T4CA+OvQENsOgQgGT+CKpZ8vntS7SakctyksGyIzh1Muylm7hn2kFvQ==",
+      "version": "9.0.0-beta.29",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-9.0.0-beta.29.tgz",
+      "integrity": "sha512-qRjo1cqMBlNxbtp60a5VEss4ba7NR6acDs9MCKo3Zpr6C2FDaEDjuFGnoiLs0JxA441ea8KKsY1X/HaUbC16VA==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "docs:json-field-audit": "node scripts/docs-json-field-audit.cjs"
   },
   "dependencies": {
-    "@adcp/sdk": "9.0.0-beta.28",
+    "@adcp/sdk": "9.0.0-beta.29",
     "@anthropic-ai/sdk": "^0.104.1",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -717,9 +717,9 @@ import { maybeEmitCompletionWebhook } from './webhooks.js';
 import { selectSigningCapability } from './request-signing.js';
 
 const SUPPORTED_MAJOR_VERSIONS = [3] as const;
-const SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10'] as const;
+const SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14'] as const;
 const DEFAULT_ADCP_VERSION = '3.0';
-const CURRENT_ADCP_VERSION = '3.1-rc.10';
+const CURRENT_ADCP_VERSION = '3.1-rc.14';
 const MAX_PACKAGES_PER_BUY = 50;
 
 interface ParsedAdcpReleaseVersion {

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -61,7 +61,7 @@ const SALES_CURRENT_SCENARIOS = [
   'evaluate_distributed_brand_resolution',
 ] as const;
 
-const TRAINING_AGENT_SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10'] as const;
+const TRAINING_AGENT_SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14'] as const;
 const TRAINING_AGENT_DEFAULT_ADCP_VERSION = '3.0';
 
 function bearerToken(req: Request): string | undefined {

--- a/server/src/training-agent/tenants/tenant-smoke.test.ts
+++ b/server/src/training-agent/tenants/tenant-smoke.test.ts
@@ -247,7 +247,7 @@ describe('tenant routing smoke', () => {
       const mediaBuy = body.result?.structuredContent?.media_buy;
       expect(body.result?.structuredContent?.adcp_version).toBe('3.0');
       expect(body.result?.structuredContent?.adcp?.major_versions).toContain(3);
-      expect(body.result?.structuredContent?.adcp?.supported_versions).toEqual(['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10']);
+      expect(body.result?.structuredContent?.adcp?.supported_versions).toEqual(['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14']);
       expect(mediaBuy?.features?.inline_creative_management).toBe(true);
       expect(mediaBuy?.supported_optimization_metrics).toContain('clicks');
       expect(mediaBuy?.vendor_metric_optimization?.supported_targets).toContain('threshold_rate');
@@ -374,7 +374,7 @@ describe('tenant routing smoke', () => {
         field: 'adcp_version',
         details: {
           adcp_version: '4.0',
-          supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10'],
+          supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14'],
         },
       });
       expect(unsupportedBody.result?.structuredContent?.context?.correlation_id).toBe('tenant-local-version-unsupported');

--- a/server/tests/integration/training-agent-3-0-compat-tools.test.ts
+++ b/server/tests/integration/training-agent-3-0-compat-tools.test.ts
@@ -20,7 +20,7 @@ const { stopSessionCleanup } = await import('../../src/training-agent/state.js')
 
 const COMPAT_CTX = { mode: 'open' as const, storyboardCompat: { version: '3.0' as const } };
 const AUTH = 'Bearer compat-tools-token';
-const CURRENT_ADCP_VERSION = '3.1-rc.10';
+const CURRENT_ADCP_VERSION = '3.1-rc.14';
 
 async function simulateListTools(server: ReturnType<typeof createTrainingAgentServer>): Promise<string[]> {
   const requestHandlers = (server as any)._requestHandlers as Map<string, Function>;

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -48,7 +48,7 @@ const VALID_PRICING_MODELS = [
 ] as const;
 
 const TEST_AGENT_URL = 'http://localhost:3000/api/training-agent';
-const CURRENT_ADCP_VERSION = '3.1-rc.10';
+const CURRENT_ADCP_VERSION = '3.1-rc.14';
 
 const DEFAULT_CTX: TrainingContext = { mode: 'open' };
 
@@ -7953,7 +7953,7 @@ describe('get_adcp_capabilities handler', () => {
 
     expect(result.adcp).toMatchObject({
       major_versions: [3],
-      supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10'],
+      supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14'],
       idempotency: { supported: true, replay_ttl_seconds: 86400 },
     });
     expect(result.adcp_version).toBe('3.0');
@@ -8868,7 +8868,7 @@ describe('MCP Tasks protocol', () => {
         code: -32602,
         data: {
           adcp_version: '99.0',
-          supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10'],
+          supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14'],
           supported_majors: [3],
           context: { correlation_id: 'task-version-unsupported' },
           adcp_error: {
@@ -10693,7 +10693,7 @@ describe('AdCP protocol compliance', () => {
     expect(parsed.adcp_version).toBe('3.0');
     expect(parsed.adcp).toMatchObject({
       major_versions: [3],
-      supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10'],
+      supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14'],
     });
   });
 
@@ -10714,7 +10714,7 @@ describe('AdCP protocol compliance', () => {
   it('echoes exact supported pre-release adcp_version pins', async () => {
     const server = createTrainingAgentServer(DEFAULT_CTX);
 
-    for (const adcpVersion of ['3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10']) {
+    for (const adcpVersion of ['3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14']) {
       const { parsed, isError } = await simulateCallToolRaw(server, 'get_products', {
         adcp_version: adcpVersion,
         adcp_major_version: 3,
@@ -10758,7 +10758,7 @@ describe('AdCP protocol compliance', () => {
       details: {
         adcp_version: '4.0',
         adcp_major_version: 4,
-        supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10'],
+        supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14'],
         supported_majors: [3],
       },
     });
@@ -10779,7 +10779,7 @@ describe('AdCP protocol compliance', () => {
       field: 'adcp_version',
       details: {
         adcp_version: '3.1-beta',
-        supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10'],
+        supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14'],
         supported_majors: [3],
       },
     });


### PR DESCRIPTION
## Summary

Bumps `@adcp/sdk` from `9.0.0-beta.28` to `9.0.0-beta.29` so hosted and local storyboard runs pick up the runner-side phase-level `requires_capability` gate fix from `adcp-client#2226`.

Also updates the training agent prerelease allowlists from `3.1-rc.10` to include and serve `3.1-rc.14`, matching the SDK runner pin in beta.29. Without that companion change, the local storyboard matrix rejects current prerelease probes with `VERSION_UNSUPPORTED`.

## Impact

Protocol-specific phases in universal storyboards can now skip as `not_applicable` before dispatch when the agent does not advertise the gated capability. This is the repo-side pull-through for the runner support requested after `adcp#5451` / `adcp#5492`.

## Validation

- `npm run test:sdk-shims`
- `npm run typecheck`
- `npx vitest run server/tests/unit/training-agent.test.ts server/src/training-agent/tenants/tenant-smoke.test.ts --pool=threads`
- precommit hook: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run precommit:server-unit`, `npm run typecheck`
- push hook: version sync, changeset check, current storyboard matrix, 3.0 storyboard compatibility matrix
