### PR TITLE
fix(addie): prevent stalled digest jobs

### DIFF
--- a/.changeset/chilly-bats-obey.md
+++ b/.changeset/chilly-bats-obey.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix stalled Addie digest jobs and catch up approved Prompt editions.

--- a/server/src/addie/jobs/scheduler.ts
+++ b/server/src/addie/jobs/scheduler.ts
@@ -148,7 +148,7 @@ function isWithinBusinessHours(constraint: BusinessHoursConstraint): boolean {
 /**
  * Job Scheduler - manages registration and execution of scheduled jobs
  */
-class JobScheduler {
+export class JobScheduler {
   private configs: Map<string, JobConfig> = new Map();
   private runningJobs: Map<string, RunningJob> = new Map();
   /** Consecutive failure count per job — resets on success. */
@@ -166,16 +166,15 @@ class JobScheduler {
       return Promise.resolve();
     }
     return new Promise<void>((resolve) => {
-      this.waitQueue.push(() => {
-        this.activeJobs++;
-        resolve();
-      });
+      this.waitQueue.push(resolve);
     });
   }
 
   private releaseSlot(): void {
     const next = this.waitQueue.shift();
     if (next) {
+      // Transfer this job's slot to the queued job. activeJobs already counts
+      // the slot, so do not increment it again or the scheduler can jam.
       next();
     } else {
       this.activeJobs--;

--- a/server/src/addie/jobs/weekly-digest.ts
+++ b/server/src/addie/jobs/weekly-digest.ts
@@ -3,6 +3,7 @@ import { buildDigestContent, hasMinimumContent, generateDigestSubject } from '..
 import {
   createDigest,
   getDigestByDate,
+  getLatestApprovedDigest,
   setReviewMessage,
   updateDigestContent,
   markSent,
@@ -57,11 +58,16 @@ function getTodayEditionDate(): string {
   return formatter.format(new Date());
 }
 
+function getEditionDateString(date: Date | string): string {
+  return new Date(date).toISOString().split('T')[0];
+}
+
 /**
  * Main weekly digest job runner.
  * Runs hourly. Uses newsletter config cadence (biweekly Tuesdays).
  * - generateHourET: Generates a draft and posts to Editorial channel for review
  * - sendHourET+: Sends the digest if approved, or nudges if still waiting
+ * - catch-up: Sends any previously approved edition that missed its cadence
  */
 export async function runWeeklyDigestJob(): Promise<WeeklyDigestResult> {
   const result: WeeklyDigestResult = { generated: false, sent: 0, skipped: false };
@@ -70,12 +76,26 @@ export async function runWeeklyDigestJob(): Promise<WeeklyDigestResult> {
   const { thePromptConfig } = await import('../../newsletters/the-prompt/index.js');
   const cadence = thePromptConfig.cadence;
 
+  const etHour = getETHour();
+  const editionDate = getTodayEditionDate();
+
+  // Catch up approved editions that missed their original send window. This
+  // also keeps the normal same-day approval behavior: today's edition still
+  // waits until the configured send hour.
+  const approvedDigest = await getLatestApprovedDigest();
+  if (approvedDigest) {
+    const approvedEditionDate = getEditionDateString(approvedDigest.edition_date);
+    const isTodaysEdition = approvedEditionDate === editionDate;
+    if (!isTodaysEdition || etHour >= cadence.sendHourET) {
+      const sendResult = await sendDigest(approvedDigest);
+      result.sent = sendResult.sent;
+      return result;
+    }
+  }
+
   if (!cadence.shouldRunToday()) {
     return result;
   }
-
-  const etHour = getETHour();
-  const editionDate = getTodayEditionDate();
 
   // Phase 1: Generate draft
   if (etHour >= cadence.generateHourET && etHour < cadence.generateHourET + 1) {

--- a/server/src/db/digest-db.ts
+++ b/server/src/db/digest-db.ts
@@ -291,6 +291,21 @@ export async function getCurrentWeekDigest(): Promise<DigestRecord | null> {
 }
 
 /**
+ * Get the newest approved edition that has not been marked sent yet.
+ * Used by the scheduler as a catch-up path for editions approved after
+ * their original cadence window.
+ */
+export async function getLatestApprovedDigest(): Promise<DigestRecord | null> {
+  const result = await query<DigestRecord>(
+    `SELECT ${DIGEST_COLUMNS} FROM weekly_digests
+     WHERE status = 'approved'
+     ORDER BY edition_date DESC
+     LIMIT 1`,
+  );
+  return result.rows[0] || null;
+}
+
+/**
  * Approve a digest. Sets status to 'approved' and records who approved it.
  */
 export async function approveDigest(id: number, approvedBy: string): Promise<DigestRecord | null> {

--- a/server/tests/unit/job-scheduler.test.ts
+++ b/server/tests/unit/job-scheduler.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { JobScheduler } from '../../src/addie/jobs/scheduler.js';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+async function flushMicrotasks(times = 5) {
+  for (let i = 0; i < times; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe('JobScheduler', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('releases transferred concurrency slots after queued jobs finish', async () => {
+    vi.useFakeTimers();
+
+    const scheduler = new JobScheduler();
+    const started: string[] = [];
+    const blockers = new Map<string, ReturnType<typeof deferred>>();
+
+    for (let i = 0; i < 10; i++) {
+      const name = `job-${i}`;
+      const blocker = deferred();
+      blockers.set(name, blocker);
+      scheduler.register({
+        name,
+        description: name,
+        interval: { value: 1, unit: 'hours' },
+        initialDelay: { value: 1, unit: 'seconds' },
+        runner: async () => {
+          started.push(name);
+          await blocker.promise;
+        },
+      });
+    }
+
+    scheduler.startAll();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(started).toEqual(['job-0', 'job-1', 'job-2', 'job-3', 'job-4']);
+
+    for (let i = 0; i < 5; i++) {
+      blockers.get(`job-${i}`)?.resolve();
+    }
+    await flushMicrotasks();
+
+    expect(started).toEqual([
+      'job-0',
+      'job-1',
+      'job-2',
+      'job-3',
+      'job-4',
+      'job-5',
+      'job-6',
+      'job-7',
+      'job-8',
+      'job-9',
+    ]);
+
+    for (let i = 5; i < 10; i++) {
+      blockers.get(`job-${i}`)?.resolve();
+    }
+    await flushMicrotasks();
+
+    scheduler.register({
+      name: 'after-queue',
+      description: 'after queue',
+      interval: { value: 1, unit: 'hours' },
+      initialDelay: { value: 1, unit: 'seconds' },
+      runner: async () => {
+        started.push('after-queue');
+      },
+    });
+    scheduler.start('after-queue');
+    await vi.advanceTimersByTimeAsync(1000);
+    await flushMicrotasks();
+
+    expect(started).toContain('after-queue');
+    scheduler.stopAll();
+  });
+});

--- a/server/tests/unit/weekly-digest-job.test.ts
+++ b/server/tests/unit/weekly-digest-job.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DigestRecord } from '../../src/db/digest-db.js';
+
+const getLatestApprovedDigest = vi.fn();
+const getDigestByDate = vi.fn();
+const markSent = vi.fn();
+const getDigestEmailRecipients = vi.fn();
+const getUserWorkingGroupMap = vi.fn();
+const sendTrackedBatchMarketingEmails = vi.fn();
+
+vi.mock('../../src/db/digest-db.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/db/digest-db.js')>();
+  return {
+    ...actual,
+    createDigest: vi.fn(),
+    getDigestByDate,
+    getLatestApprovedDigest,
+    setReviewMessage: vi.fn(),
+    updateDigestContent: vi.fn(),
+    markSent,
+    getDigestEmailRecipients,
+    getUserWorkingGroupMap,
+    isLegacyContent: (content: unknown) =>
+      !content || typeof content !== 'object' || (content as { contentVersion?: number }).contentVersion !== 2,
+    getPersonaCluster: vi.fn(() => 'newcomer'),
+  };
+});
+
+vi.mock('../../src/newsletters/the-prompt/index.js', () => ({
+  thePromptConfig: {
+    cadence: {
+      generateHourET: 7,
+      sendHourET: 10,
+      shouldRunToday: vi.fn(() => false),
+    },
+  },
+}));
+
+vi.mock('../../src/db/working-group-db.js', () => ({
+  WorkingGroupDatabase: class {
+    getWorkingGroupBySlug = vi.fn();
+  },
+}));
+
+vi.mock('../../src/slack/client.js', () => ({
+  sendChannelMessage: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock('../../src/notifications/email.js', () => ({
+  sendTrackedBatchMarketingEmails,
+}));
+
+vi.mock('../../src/addie/templates/weekly-digest.js', () => ({
+  renderDigestEmail: vi.fn(() => ({ html: '<p>The Prompt</p>', text: 'The Prompt' })),
+  renderDigestSlack: vi.fn(() => ({ text: 'The Prompt' })),
+  renderDigestReview: vi.fn(() => ({ text: 'Review' })),
+}));
+
+vi.mock('../../src/addie/services/digest-builder.js', () => ({
+  buildDigestContent: vi.fn(),
+  hasMinimumContent: vi.fn(() => true),
+  generateDigestSubject: vi.fn(() => 'The Prompt test subject'),
+}));
+
+vi.mock('../../src/addie/services/digest-publisher.js', () => ({
+  publishDigestAsPerspective: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../src/newsletters/cover.js', () => ({
+  generateCoverForEdition: vi.fn(),
+}));
+
+vi.mock('../../src/db/newsletter-suggestions-db.js', () => ({
+  markSuggestionsIncluded: vi.fn(),
+}));
+
+function approvedDigest(overrides: Partial<DigestRecord> = {}): DigestRecord {
+  return {
+    id: 123,
+    edition_date: new Date('2026-06-05T00:00:00.000Z'),
+    status: 'approved',
+    approved_by: 'editor',
+    approved_at: new Date('2026-06-12T14:22:39.869Z'),
+    review_channel_id: null,
+    review_message_ts: null,
+    content: {
+      contentVersion: 2,
+      openingTake: 'Opening take',
+      whatToWatch: [],
+      fromTheInside: [],
+      voices: [],
+      newMembers: [],
+      generatedAt: '2026-06-05T10:00:00.000Z',
+    },
+    created_at: new Date('2026-06-05T11:00:00.000Z'),
+    sent_at: null,
+    send_stats: null,
+    perspective_id: null,
+    has_cover_image: false,
+    ...overrides,
+  };
+}
+
+describe('runWeeklyDigestJob', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getDigestEmailRecipients.mockResolvedValue([
+      {
+        workos_user_id: 'user_123',
+        email: 'reader@example.com',
+        first_name: 'Reader',
+        has_slack: false,
+        persona: null,
+        journey_stage: null,
+        seat_type: 'contributor',
+        wg_count: 0,
+        cert_modules_completed: 0,
+        cert_total_modules: 0,
+        is_member: true,
+        has_profile: true,
+      },
+    ]);
+    getUserWorkingGroupMap.mockResolvedValue(new Map());
+    sendTrackedBatchMarketingEmails.mockResolvedValue({ sent: 1, skipped: 0, failed: 0 });
+    markSent.mockResolvedValue(true);
+  });
+
+  it('sends an older approved digest even when today is not a cadence day', async () => {
+    getLatestApprovedDigest.mockResolvedValue(approvedDigest());
+
+    const { runWeeklyDigestJob } = await import('../../src/addie/jobs/weekly-digest.js');
+    const result = await runWeeklyDigestJob();
+
+    expect(result.sent).toBe(1);
+    expect(sendTrackedBatchMarketingEmails).toHaveBeenCalledTimes(1);
+    expect(markSent).toHaveBeenCalledWith(123, expect.objectContaining({ email_count: 1 }));
+    expect(getDigestByDate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the Addie scheduled job scheduler and The Prompt delivery path after weekly digest jobs stopped progressing in production.

- Fixes the scheduler concurrency queue so a completed job transfers its slot to a queued job without incrementing the active job count again.
- Adds a catch-up query/path for approved-but-unsent Prompt editions, so editions approved after their original cadence window do not remain stranded.
- Adds regression coverage for the scheduler queue leak and Prompt catch-up send path.
- Adds an empty changeset for the internal app fix.

## Root Cause

The scheduler concurrency gate leaked active slots when queued jobs resumed: `releaseSlot()` handed off work to the next queued job while the queued callback incremented `activeJobs` again. Once enough queued work flowed through, the scheduler could appear idle with no executing jobs while future ticks waited forever behind an inflated active-job count.

The Prompt also only sent the edition for the current cadence date. A previously approved edition could remain approved and unsent unless an admin manually used send-now.

## Production Recovery

Before opening this PR, the approved June 5 Prompt edition was manually sent through the existing production send path. It sent 475 emails and was marked sent at 2026-06-14T07:42:04.959Z. The fix was also deployed to production as Fly app version 3149, and the worker reported `weekly-digest` ran cleanly afterward at 2026-06-14T08:02:41.994Z.

## Validation

- `npx vitest run server/tests/unit/job-scheduler.test.ts server/tests/unit/weekly-digest-job.test.ts`
- `npm run typecheck`
- precommit hook: `test:unit`, `test:test-dynamic-imports`, `test:callapi-state-change`, `precommit:server-unit`, `typecheck`
- pre-push hook: version sync, changeset check, storyboard/docs skip checks
