### PR TITLE
refactor(certification): generalize protocol-delta recert engine beyond S2

### DIFF
--- a/.changeset/metal-aliens-look.md
+++ b/.changeset/metal-aliens-look.md
@@ -1,0 +1,4 @@
+---
+---
+
+refactor(certification): generalize the protocol-triggered recertification engine beyond S2 into a config-driven delta registry (`server/src/config/recertification-deltas.ts`). Behavior-preserving — the S2 canonical-formats delta is unchanged (frozen 13-case test stays green); other modules can now register recert deltas via config instead of hard-coded constants. Server-internal; no package release.

--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -19,6 +19,7 @@ function safeSubscriptionStatus(status: string | null | undefined): string | nul
   return KNOWN_SUBSCRIPTION_STATUSES.has(status) ? status : 'unknown';
 }
 import * as certDb from '../../db/certification-db.js';
+import { DELTA_DEFINITIONS, getDeltaForModule } from '../../config/recertification-deltas.js';
 import { isUuid } from '../../utils/uuid.js';
 import { query } from '../../db/client.js';
 import { getPool } from '../../db/client.js';
@@ -2071,13 +2072,15 @@ export function createCertificationToolHandlers(
     if (!userId) return 'You need to be logged in to see your certification progress.';
 
     try {
-      const [progress, trackProgress, credentials, userCredentials, tracks, s2DeltaStatus] = await Promise.all([
+      const [progress, trackProgress, credentials, userCredentials, tracks, deltaStatuses] = await Promise.all([
         certDb.getProgress(userId),
         certDb.getTrackProgress(userId),
         certDb.getCredentials(),
         certDb.getUserCredentials(userId),
         certDb.getTracks(),
-        certDb.getS2CanonicalFormatsDeltaStatus(userId),
+        Promise.all(
+          DELTA_DEFINITIONS.map(async def => ({ def, status: await certDb.getDeltaStatus(def, userId) })),
+        ),
       ]);
 
       const lines: string[] = ['# Your certification progress\n'];
@@ -2096,17 +2099,22 @@ export function createCertificationToolHandlers(
         lines.push('');
       }
 
-      if (s2DeltaStatus.active && s2DeltaStatus.status !== 'not_required') {
+      const activeDeltas = deltaStatuses.filter(
+        ({ status }) => status.active && status.status !== 'not_required',
+      );
+      if (activeDeltas.length > 0) {
         lines.push('## Protocol updates');
-        if (s2DeltaStatus.status === 'delta_available') {
-          lines.push(`- **S2 Creative canonical formats update** — complete the S2 canonical formats delta by ${formatUtcDate(s2DeltaStatus.delta_window_closes_at)} to keep the S2 credential current without retaking the full module.`);
-          lines.push(`  Remaining criteria: ${s2DeltaStatus.missing_criterion_ids.join(', ')}`);
-          lines.push('  If you believe you were targeted in error, email certification@agenticadvertising.org for review.');
-          lines.push('  To begin, say "start capstone S2".');
-        } else if (s2DeltaStatus.status === 'delta_completed') {
-          lines.push('- **S2 Creative canonical formats update** — completed.');
-        } else if (s2DeltaStatus.status === 'full_recertification_required') {
-          lines.push('- **S2 Creative canonical formats update** — the delta path is no longer available. The current S2 module is required for renewal.');
+        for (const { def, status } of activeDeltas) {
+          if (status.status === 'delta_available') {
+            lines.push(`- **${def.label} update** — complete the ${def.delta_action_label} delta by ${formatUtcDate(status.delta_window_closes_at)} to keep the ${def.module_id} credential current without retaking the full module.`);
+            lines.push(`  Remaining criteria: ${status.missing_criterion_ids.join(', ')}`);
+            lines.push('  If you believe you were targeted in error, email certification@agenticadvertising.org for review.');
+            lines.push(`  To begin, say "start capstone ${def.module_id}".`);
+          } else if (status.status === 'delta_completed') {
+            lines.push(`- **${def.label} update** — completed.`);
+          } else if (status.status === 'full_recertification_required') {
+            lines.push(`- **${def.label} update** — the delta path is no longer available. The current ${def.module_id} module is required for renewal.`);
+          }
         }
         lines.push('');
       }
@@ -2292,44 +2300,45 @@ export function createCertificationToolHandlers(
       // Prevent restarting completed modules
       const existingMod = await certDb.getModuleProgress(userId, moduleId);
       if (existingMod && (existingMod.status === 'completed' || existingMod.status === 'tested_out')) {
-        if (moduleId === certDb.S2_CANONICAL_FORMATS_MODULE_ID) {
-          const s2DeltaStatus = await certDb.getS2CanonicalFormatsDeltaStatus(userId);
+        const delta = getDeltaForModule(moduleId);
+        if (delta) {
+          const deltaStatus = await certDb.getDeltaStatus(delta, userId);
           if (
-            s2DeltaStatus.active
-            && (s2DeltaStatus.status === 'delta_available' || s2DeltaStatus.status === 'delta_completed')
+            deltaStatus.active
+            && (deltaStatus.status === 'delta_available' || deltaStatus.status === 'delta_completed')
           ) {
             const expired = await certDb.expireStaleAttempts(userId, moduleId);
             if (expired > 0) {
-              logger.info({ userId, moduleId, expired }, 'Auto-expired stale S2 delta attempts');
+              logger.info({ userId, moduleId, expired }, 'Auto-expired stale delta attempts');
             }
             const active = await certDb.getActiveAttemptForModule(userId, moduleId);
             if (active) {
-              return `You already have an active S2 canonical formats delta attempt (started ${new Date(active.started_at).toLocaleDateString()}). Continue the delta assessment.\n\nAttempt ID: ${active.id}`;
+              return `You already have an active ${delta.delta_action_label} delta attempt (started ${new Date(active.started_at).toLocaleDateString()}). Continue the delta assessment.\n\nAttempt ID: ${active.id}`;
             }
           }
-          if (s2DeltaStatus.active && s2DeltaStatus.status === 'full_recertification_required') {
+          if (deltaStatus.active && deltaStatus.status === 'full_recertification_required') {
             const active = await certDb.getActiveAttemptForModule(userId, moduleId);
             if (active) {
-              await certDb.cancelAttempt(active.id, 'S2 canonical formats delta window closed');
+              await certDb.cancelAttempt(active.id, `${delta.delta_action_label} delta window closed`);
             }
-            return `S2 is complete, but the AdCP 3.1 canonical-formats delta window is no longer available. The current S2 module is required for renewal. Contact certification@agenticadvertising.org to reset this module for full recertification.`;
+            return `${delta.module_id} is complete, but the AdCP 3.1 canonical-formats delta window is no longer available. The current ${delta.module_id} module is required for renewal. Contact certification@agenticadvertising.org to reset this module for full recertification.`;
           }
-          if (s2DeltaStatus.active && s2DeltaStatus.status === 'delta_completed') {
-            return `The S2 canonical formats delta is already complete. Deadline: ${formatUtcDate(s2DeltaStatus.delta_window_closes_at)}.`;
+          if (deltaStatus.active && deltaStatus.status === 'delta_completed') {
+            return `The ${delta.delta_action_label} delta is already complete. Deadline: ${formatUtcDate(deltaStatus.delta_window_closes_at)}.`;
           }
-          if (s2DeltaStatus.active && s2DeltaStatus.status === 'delta_available') {
+          if (deltaStatus.active && deltaStatus.status === 'delta_available') {
 
             const attempt = await certDb.createAttempt(userId, mod.track_id, options?.threadId, moduleId);
             const exercises = mod.exercise_definitions as certDb.ExerciseDefinition[] | null;
             const criteria = mod.assessment_criteria as certDb.AssessmentCriteria | null;
-            const required = new Set(s2DeltaStatus.missing_criterion_ids);
+            const required = new Set(deltaStatus.missing_criterion_ids);
             const lines = [
-              `# S2 Creative canonical formats delta`,
+              `# ${delta.label} delta`,
               '',
               `Attempt ID: ${attempt.id}`,
-              `Deadline: ${formatUtcDate(s2DeltaStatus.delta_window_closes_at)}`,
+              `Deadline: ${formatUtcDate(deltaStatus.delta_window_closes_at)}`,
               '',
-              'This is a targeted AdCP 3.1 protocol update for an existing S2 Creative specialist holder. Assess only the canonical-format criteria listed here; do not retake the full S2 module unless the learner asks for a full review.',
+              `This is a targeted AdCP 3.1 protocol update for an existing ${delta.specialist_label} specialist holder. Assess only the canonical-format criteria listed here; do not retake the full ${delta.module_id} module unless the learner asks for a full review.`,
               '',
               '## Required delta demonstrations',
             ];
@@ -2347,7 +2356,7 @@ export function createCertificationToolHandlers(
             }
 
             lines.push('## Assessment instructions');
-            lines.push('Conduct a short lab and oral assessment focused on these missing canonical-format criteria. Before completion, call checkpoint_teaching_progress for S2 with demonstrations_verified and demonstration_evidence for every listed criterion ID. Then call complete_certification_exam with the attempt ID above and internal scores. Do not share scores with the learner.');
+            lines.push(`Conduct a short lab and oral assessment focused on these missing canonical-format criteria. Before completion, call checkpoint_teaching_progress for ${delta.module_id} with demonstrations_verified and demonstration_evidence for every listed criterion ID. Then call complete_certification_exam with the attempt ID above and internal scores. Do not share scores with the learner.`);
 
             if (criteria?.dimensions?.length) {
               lines.push('');
@@ -2561,16 +2570,17 @@ export function createCertificationToolHandlers(
       const examAc = capstoneMod.assessment_criteria as certDb.AssessmentCriteria | undefined;
 
       const capstoneId = capstoneMod.id;
-      const s2DeltaStatus = capstoneId === certDb.S2_CANONICAL_FORMATS_MODULE_ID
-        ? await certDb.getS2CanonicalFormatsDeltaStatus(userId)
+      const deltaDef = getDeltaForModule(capstoneId) ?? null;
+      const deltaStatus = deltaDef
+        ? await certDb.getDeltaStatus(deltaDef, userId)
         : null;
-      const isS2CanonicalFormatsDelta = !!(
-        s2DeltaStatus?.active
-        && s2DeltaStatus.status === 'delta_available'
+      const isProtocolDelta = !!(
+        deltaStatus?.active
+        && deltaStatus.status === 'delta_available'
       );
-      if (capstoneId === certDb.S2_CANONICAL_FORMATS_MODULE_ID && s2DeltaStatus?.status === 'full_recertification_required') {
-        await certDb.cancelAttempt(attempt.id, 'S2 canonical formats delta window closed');
-        return notCompleted(capstoneId, 'state', 'The S2 canonical-formats delta window has closed. This delta attempt cannot be completed; the learner needs the current full S2 module for renewal.');
+      if (deltaDef && deltaStatus?.status === 'full_recertification_required') {
+        await certDb.cancelAttempt(attempt.id, `${deltaDef.delta_action_label} delta window closed`);
+        return notCompleted(capstoneId, 'state', `The ${deltaDef.reason_phrases.delta_name} delta window has closed. This delta attempt cannot be completed; the learner needs the current full ${deltaDef.module_id} module for renewal.`);
       }
 
       // Validate scores against assessment criteria (range, dimensions, floor, threshold)
@@ -2611,18 +2621,18 @@ export function createCertificationToolHandlers(
       }
 
       // Verify all required demonstrations from exercise success_criteria
-      let s2DeltaEvidence: certDb.S2CanonicalFormatsDeltaEvidence | null = null;
-      if (isS2CanonicalFormatsDelta) {
-        s2DeltaEvidence = await certDb.getS2CanonicalFormatsDeltaEvidence(userId);
-        const missingCumulative = certDb.S2_CANONICAL_FORMATS_CRITERION_IDS.filter(
-          id => !s2DeltaEvidence!.verifiedCriterionIds.includes(id),
+      let deltaEvidence: certDb.ProtocolDeltaEvidence | null = null;
+      if (isProtocolDelta && deltaDef) {
+        deltaEvidence = await certDb.getDeltaEvidence(deltaDef, userId);
+        const missingCumulative = deltaDef.criterion_ids.filter(
+          id => !deltaEvidence!.verifiedCriterionIds.includes(id),
         );
         if (missingCumulative.length > 0) {
           return notCompleted(capstoneId, 'evidence', `Required demonstrations not yet verified:\n- ${missingCumulative.join('\n- ')}\n\nVerify each through conversation, then save a checkpoint with demonstrations_verified and demonstration_evidence before completing.`);
         }
         const evidenceError = checkCriterionEvidence(
-          certDb.S2_CANONICAL_FORMATS_CRITERION_IDS,
-          s2DeltaEvidence.evidenceByCriterionId,
+          deltaDef.criterion_ids,
+          deltaEvidence.evidenceByCriterionId,
         );
         if (evidenceError) return notCompleted(capstoneId, 'evidence', evidenceError);
       } else {
@@ -2634,13 +2644,14 @@ export function createCertificationToolHandlers(
       const allAboveThreshold = Object.values(scores).every(s => s >= 70);
       const passing = allAboveThreshold && overallScore >= 70;
 
-      if (isS2CanonicalFormatsDelta && passing) {
-        await certDb.completeS2CanonicalFormatsDeltaAttempt(
+      if (isProtocolDelta && deltaDef && passing) {
+        await certDb.completeDeltaAttempt(
+          deltaDef,
           attempt.id,
           userId,
           scores,
           overallScore,
-          s2DeltaEvidence!.evidenceByCriterionId,
+          deltaEvidence!.evidenceByCriterionId,
         );
       } else {
         await certDb.completeAttempt(attempt.id, scores, overallScore, passing);
@@ -2652,12 +2663,12 @@ export function createCertificationToolHandlers(
       const lines: string[] = [];
 
       if (passing) {
-        if (isS2CanonicalFormatsDelta) {
-          lines.push('# S2 Creative canonical formats delta completed!');
+        if (isProtocolDelta && deltaDef) {
+          lines.push(`# ${deltaDef.label} delta completed!`);
           lines.push('');
           lines.push('The learner has demonstrated the AdCP 3.1 canonical-format update criteria. Congratulate them warmly. Do NOT share any scores or percentages.');
           lines.push('');
-          lines.push('Their existing S2 Creative specialist credential remains current for the AdCP 3.1 canonical-format update.');
+          lines.push(`Their existing ${deltaDef.specialist_label} specialist credential remains current for the AdCP 3.1 canonical-format update.`);
           return lines.join('\n');
         }
 
@@ -2742,18 +2753,19 @@ export function createCertificationToolHandlers(
       const progress = await certDb.getProgress(userId);
       const modProgress = progress.find(p => p.module_id === moduleId);
       if (!modProgress || modProgress.status !== 'in_progress') {
-        const s2DeltaStatus = moduleId === certDb.S2_CANONICAL_FORMATS_MODULE_ID
-          ? await certDb.getS2CanonicalFormatsDeltaStatus(userId)
+        const checkpointDelta = getDeltaForModule(moduleId);
+        const deltaStatus = checkpointDelta
+          ? await certDb.getDeltaStatus(checkpointDelta, userId)
           : null;
-        const hasActiveS2DeltaAttempt = moduleId === certDb.S2_CANONICAL_FORMATS_MODULE_ID
+        const hasActiveDeltaAttempt = checkpointDelta
           ? await certDb.getActiveAttemptForModule(userId, moduleId)
           : null;
-        const canCheckpointS2Delta = !!(
-          hasActiveS2DeltaAttempt
-          && s2DeltaStatus?.active
-          && (s2DeltaStatus.status === 'delta_available' || s2DeltaStatus.status === 'delta_completed')
+        const canCheckpointDelta = !!(
+          hasActiveDeltaAttempt
+          && deltaStatus?.active
+          && (deltaStatus.status === 'delta_available' || deltaStatus.status === 'delta_completed')
         );
-        if (!canCheckpointS2Delta) {
+        if (!canCheckpointDelta) {
           return `Module ${moduleId} is not in progress. Start the module first with start_certification_module before saving checkpoints.`;
         }
       }

--- a/server/src/certification/s2-canonical-formats-delta.ts
+++ b/server/src/certification/s2-canonical-formats-delta.ts
@@ -1,32 +1,29 @@
-export const S2_CANONICAL_FORMATS_DELTA_UPDATE_ID = 's2_canonical_formats_3_1';
-export const S2_CANONICAL_FORMATS_MODULE_ID = 'S2';
-export const S2_CANONICAL_FORMATS_CREDENTIAL_ID = 'specialist_creative';
+import type { DeltaDefinition } from '../config/recertification-deltas.js';
+import { S2_DELTA_DEFINITION } from '../config/recertification-deltas.js';
 
-export const S2_CANONICAL_FORMATS_CRITERION_IDS = [
-  's2_ex1_sc_format_kind_selection',
-  's2_ex1_sc_format_options_cardinality',
-  's2_ex1_sc_option_vs_capability_id',
-  's2_ex1_sc_source_taxonomy',
-  's2_ex1_sc_validation_order',
-] as const;
+export const S2_CANONICAL_FORMATS_DELTA_UPDATE_ID = S2_DELTA_DEFINITION.update_id;
+export const S2_CANONICAL_FORMATS_MODULE_ID = S2_DELTA_DEFINITION.module_id;
+export const S2_CANONICAL_FORMATS_CREDENTIAL_ID = S2_DELTA_DEFINITION.credential_id;
 
-export interface S2CanonicalFormatsDeltaReleaseSetting {
+export const S2_CANONICAL_FORMATS_CRITERION_IDS = S2_DELTA_DEFINITION.criterion_ids;
+
+export interface ProtocolDeltaReleaseSetting {
   adcp_3_1_ga_at: string | null;
   criteria_deployed_at: string | null;
 }
 
-export type S2CanonicalFormatsDeltaStatusKind =
+export type ProtocolDeltaStatusKind =
   | 'gated'
   | 'not_required'
   | 'delta_available'
   | 'delta_completed'
   | 'full_recertification_required';
 
-export interface S2CanonicalFormatsDeltaStatus {
-  update_id: typeof S2_CANONICAL_FORMATS_DELTA_UPDATE_ID;
-  module_id: typeof S2_CANONICAL_FORMATS_MODULE_ID;
-  credential_id: typeof S2_CANONICAL_FORMATS_CREDENTIAL_ID;
-  status: S2CanonicalFormatsDeltaStatusKind;
+export interface ProtocolDeltaStatus {
+  update_id: string;
+  module_id: string;
+  credential_id: string;
+  status: ProtocolDeltaStatusKind;
   active: boolean;
   reason: string;
   adcp_3_1_ga_at: string | null;
@@ -35,6 +32,31 @@ export interface S2CanonicalFormatsDeltaStatus {
   delta_window_opens_at: string | null;
   delta_window_closes_at: string | null;
   missing_criterion_ids: string[];
+}
+
+export interface ProtocolDeltaInput {
+  release: ProtocolDeltaReleaseSetting | null;
+  hasCredential: boolean;
+  credentialAwardedAt: string | null;
+  moduleCompletedAt: string | null;
+  deltaCompletedAt?: string | null;
+  criteriaPresent?: boolean;
+  hasPriorAuditableRecord?: boolean;
+  verifiedCriterionIds: string[];
+  now?: Date;
+}
+
+// ---------------------------------------------------------------------------
+// Back-compat S2 surface
+// ---------------------------------------------------------------------------
+
+export type S2CanonicalFormatsDeltaReleaseSetting = ProtocolDeltaReleaseSetting;
+export type S2CanonicalFormatsDeltaStatusKind = ProtocolDeltaStatusKind;
+
+export interface S2CanonicalFormatsDeltaStatus extends ProtocolDeltaStatus {
+  update_id: typeof S2_CANONICAL_FORMATS_DELTA_UPDATE_ID;
+  module_id: typeof S2_CANONICAL_FORMATS_MODULE_ID;
+  credential_id: typeof S2_CANONICAL_FORMATS_CREDENTIAL_ID;
 }
 
 export interface S2CanonicalFormatsDeltaInput {
@@ -72,17 +94,18 @@ function addUtcCalendarDaysEndOfDay(value: Date, days: number): Date {
 }
 
 function baseStatus(
-  release: S2CanonicalFormatsDeltaReleaseSetting | null,
-  status: S2CanonicalFormatsDeltaStatusKind,
+  definition: DeltaDefinition,
+  release: ProtocolDeltaReleaseSetting | null,
+  status: ProtocolDeltaStatusKind,
   active: boolean,
   reason: string,
   criteriaEffectiveAt: Date | null,
   missingCriterionIds: string[] = [],
-): S2CanonicalFormatsDeltaStatus {
+): ProtocolDeltaStatus {
   return {
-    update_id: S2_CANONICAL_FORMATS_DELTA_UPDATE_ID,
-    module_id: S2_CANONICAL_FORMATS_MODULE_ID,
-    credential_id: S2_CANONICAL_FORMATS_CREDENTIAL_ID,
+    update_id: definition.update_id,
+    module_id: definition.module_id,
+    credential_id: definition.credential_id,
     status,
     active,
     reason,
@@ -90,69 +113,77 @@ function baseStatus(
     criteria_deployed_at: release?.criteria_deployed_at ?? null,
     criteria_effective_at: toIso(criteriaEffectiveAt),
     delta_window_opens_at: toIso(criteriaEffectiveAt),
-    delta_window_closes_at: criteriaEffectiveAt ? toIso(addUtcCalendarDaysEndOfDay(criteriaEffectiveAt, 90)) : null,
+    delta_window_closes_at: criteriaEffectiveAt
+      ? toIso(addUtcCalendarDaysEndOfDay(criteriaEffectiveAt, definition.delta_window_days))
+      : null,
     missing_criterion_ids: missingCriterionIds,
   };
 }
 
-export function computeS2CanonicalFormatsDeltaStatus(
-  input: S2CanonicalFormatsDeltaInput,
-): S2CanonicalFormatsDeltaStatus {
+export function computeProtocolDeltaStatus(
+  definition: DeltaDefinition,
+  input: ProtocolDeltaInput,
+): ProtocolDeltaStatus {
+  const phrases = definition.reason_phrases;
   const gaAt = parseDate(input.release?.adcp_3_1_ga_at);
   const deployedAt = parseDate(input.release?.criteria_deployed_at);
 
   if (!gaAt || !deployedAt) {
     const missing = [
-      !gaAt ? 'AdCP 3.1.0 GA date' : null,
-      !deployedAt ? 'production deployment date for migration 496_curriculum_3_1_canonical_formats_criteria.sql' : null,
+      !gaAt ? phrases.ga_date_label : null,
+      !deployedAt ? `production deployment date for migration ${definition.criteria_migration}` : null,
     ].filter(Boolean).join(' and ');
-    return baseStatus(input.release, 'gated', false, `Blocked until ${missing} is configured.`, null);
+    return baseStatus(definition, input.release, 'gated', false, `Blocked until ${missing} is configured.`, null);
   }
 
   const criteriaEffectiveAt = new Date(Math.max(gaAt.getTime(), deployedAt.getTime()));
-  const deltaWindowClosesAt = addUtcCalendarDaysEndOfDay(criteriaEffectiveAt, 90);
+  const deltaWindowClosesAt = addUtcCalendarDaysEndOfDay(criteriaEffectiveAt, definition.delta_window_days);
   const now = input.now ?? new Date();
 
-  if (input.canonicalCriteriaPresent === false) {
+  if (input.criteriaPresent === false) {
     return baseStatus(
+      definition,
       input.release,
       'gated',
       false,
-      'Blocked until the five AdCP 3.1 S2 canonical-format criteria are present in certification_modules.exercise_definitions.',
+      `Blocked until the ${phrases.criteria_count_word} ${phrases.criteria_phrase} criteria are present in certification_modules.exercise_definitions.`,
       criteriaEffectiveAt,
     );
   }
 
   if (now < criteriaEffectiveAt) {
     return baseStatus(
+      definition,
       input.release,
       'gated',
       false,
-      'Blocked until the later of AdCP 3.1.0 GA and production deployment of the S2 canonical-format criteria.',
+      `Blocked until the later of ${phrases.ga_milestone_label} and production deployment of the ${phrases.criteria_short_phrase} criteria.`,
       criteriaEffectiveAt,
     );
   }
 
-  if (!input.hasCreativeSpecialistCredential) {
+  if (!input.hasCredential) {
     return baseStatus(
+      definition,
       input.release,
       'not_required',
       true,
-      'Learner does not hold the S2 Creative specialist credential.',
+      phrases.not_credentialed,
       criteriaEffectiveAt,
     );
   }
 
   const awardedAt = parseDate(input.credentialAwardedAt);
-  const completedAt = parseDate(input.s2CompletedAt);
+  const completedAt = parseDate(input.moduleCompletedAt);
   const deltaCompletedAt = parseDate(input.deltaCompletedAt);
 
   if (completedAt && completedAt >= criteriaEffectiveAt) {
     return baseStatus(
+      definition,
       input.release,
       'not_required',
       true,
-      'S2 completion is already on or after the AdCP 3.1 canonical-format criteria effective point.',
+      phrases.completion_after_effective,
       criteriaEffectiveAt,
     );
   }
@@ -160,42 +191,46 @@ export function computeS2CanonicalFormatsDeltaStatus(
   if (!completedAt) {
     if (awardedAt && awardedAt >= criteriaEffectiveAt) {
       return baseStatus(
+        definition,
         input.release,
         'not_required',
         true,
-        'S2 credential was awarded after the AdCP 3.1 canonical-format criteria effective point.',
+        phrases.credential_after_effective,
         criteriaEffectiveAt,
       );
     }
     return baseStatus(
+      definition,
       input.release,
       'full_recertification_required',
       true,
-      'Prior S2 completion record is missing, so the learner does not meet the auditable-record requirement for a delta.',
+      `Prior ${phrases.module_label} completion record is missing, so the learner does not meet the auditable-record requirement for a delta.`,
       criteriaEffectiveAt,
-      [...S2_CANONICAL_FORMATS_CRITERION_IDS],
+      [...definition.criterion_ids],
     );
   }
 
   const verified = new Set(input.verifiedCriterionIds);
-  const missingCriterionIds = S2_CANONICAL_FORMATS_CRITERION_IDS.filter(id => !verified.has(id));
+  const missingCriterionIds = definition.criterion_ids.filter(id => !verified.has(id));
 
   if (deltaCompletedAt) {
     return baseStatus(
+      definition,
       input.release,
       'delta_completed',
       true,
-      'Learner has auditable evidence for all AdCP 3.1 S2 canonical-format criteria.',
+      phrases.delta_completed,
       criteriaEffectiveAt,
     );
   }
 
-  if (input.hasPriorAuditableS2Record === false) {
+  if (input.hasPriorAuditableRecord === false) {
     return baseStatus(
+      definition,
       input.release,
       'full_recertification_required',
       true,
-      'Prior S2 checkpoint trail is missing, so the learner does not meet the auditable-record requirement for a delta.',
+      `Prior ${phrases.module_label} checkpoint trail is missing, so the learner does not meet the auditable-record requirement for a delta.`,
       criteriaEffectiveAt,
       missingCriterionIds,
     );
@@ -203,21 +238,46 @@ export function computeS2CanonicalFormatsDeltaStatus(
 
   if (now > deltaWindowClosesAt) {
     return baseStatus(
+      definition,
       input.release,
       'full_recertification_required',
       true,
-      'The S2 canonical-formats delta window has closed.',
+      `The ${phrases.delta_name} delta window has closed.`,
       criteriaEffectiveAt,
       missingCriterionIds,
     );
   }
 
   return baseStatus(
+    definition,
     input.release,
     'delta_available',
     true,
-    'Pre-3.1 S2 holder is eligible for the canonical-formats delta assessment.',
+    phrases.delta_available,
     criteriaEffectiveAt,
     missingCriterionIds,
   );
+}
+
+function mapLegacyInput(input: S2CanonicalFormatsDeltaInput): ProtocolDeltaInput {
+  return {
+    release: input.release,
+    hasCredential: input.hasCreativeSpecialistCredential,
+    credentialAwardedAt: input.credentialAwardedAt,
+    moduleCompletedAt: input.s2CompletedAt,
+    deltaCompletedAt: input.deltaCompletedAt,
+    criteriaPresent: input.canonicalCriteriaPresent,
+    hasPriorAuditableRecord: input.hasPriorAuditableS2Record,
+    verifiedCriterionIds: input.verifiedCriterionIds,
+    now: input.now,
+  };
+}
+
+export function computeS2CanonicalFormatsDeltaStatus(
+  input: S2CanonicalFormatsDeltaInput,
+): S2CanonicalFormatsDeltaStatus {
+  return computeProtocolDeltaStatus(
+    S2_DELTA_DEFINITION,
+    mapLegacyInput(input),
+  ) as S2CanonicalFormatsDeltaStatus;
 }

--- a/server/src/config/recertification-deltas.ts
+++ b/server/src/config/recertification-deltas.ts
@@ -1,0 +1,179 @@
+/**
+ * Registry of protocol-triggered recertification deltas.
+ *
+ * A "delta" is a targeted re-assessment that lets an existing credential holder
+ * stay current with a protocol change by demonstrating only the new criteria,
+ * instead of retaking the full module. The recertification engine
+ * (`certification/s2-canonical-formats-delta.ts`) is definition-driven: it
+ * computes status, windows, and learner-facing copy from a `DeltaDefinition`.
+ *
+ * Each module that needs a delta registers one entry here. The reason strings
+ * a delta surfaces are phrased per-definition via `reason_phrases` so the
+ * engine stays module-agnostic while every module reads naturally.
+ */
+
+import { SETTING_KEYS } from '../db/system-settings-db.js';
+
+/**
+ * Per-definition reason fragments. The engine assembles full reason strings by
+ * interpolating these into shared templates. Each module phrases these for its
+ * own protocol change so the engine never hard-codes module-specific wording.
+ */
+export interface DeltaReasonPhrases {
+  /**
+   * Spelled-out count of delta criteria as it reads in prose, e.g. "five".
+   * Used in "Blocked until the {criteria_count_word} ... criteria are present".
+   */
+  criteria_count_word: string;
+  /**
+   * Noun phrase naming the criteria, e.g. "AdCP 3.1 S2 canonical-format".
+   * Used in "Blocked until the {criteria_count_word} {criteria_phrase} criteria
+   * are present in certification_modules.exercise_definitions."
+   */
+  criteria_phrase: string;
+  /**
+   * Short noun phrase naming the criteria for the "later of GA and deployment"
+   * gate, e.g. "S2 canonical-format". Used in "production deployment of the
+   * {criteria_short_phrase} criteria."
+   */
+  criteria_short_phrase: string;
+  /** GA milestone label, e.g. "AdCP 3.1.0 GA". */
+  ga_milestone_label: string;
+  /** Display name of the GA date for the gated-config message, e.g. "AdCP 3.1.0 GA date". */
+  ga_date_label: string;
+  /**
+   * Label for the credential/module record whose absence fails the
+   * auditable-record requirement, e.g. "S2". Used in "Prior {module_label}
+   * completion record is missing" and "Prior {module_label} checkpoint trail
+   * is missing".
+   */
+  module_label: string;
+  /** Name of the delta, e.g. "S2 canonical-formats". Used in "The {delta_name} delta window has closed.". */
+  delta_name: string;
+  /** Reason shown when the holder's completion is already on/after the effective point. */
+  completion_after_effective: string;
+  /** Reason shown when the credential was awarded after the effective point. */
+  credential_after_effective: string;
+  /** Reason shown when the delta is completed (all criteria evidenced). */
+  delta_completed: string;
+  /** Reason shown when the holder does not hold the credential. */
+  not_credentialed: string;
+  /** Reason shown when the holder is eligible for the delta during the window. */
+  delta_available: string;
+}
+
+export interface DeltaDefinition {
+  update_id: string;
+  module_id: string;
+  credential_id: string;
+  criterion_ids: readonly string[];
+  /** system_settings key holding the `{ adcp_3_1_ga_at, criteria_deployed_at }` release gate. */
+  release_setting_key: string;
+  /** Calendar days the delta window stays open after the criteria effective point. */
+  delta_window_days: number;
+  /** Human label for the delta (e.g. surfaced as the "Protocol updates" heading copy). */
+  label: string;
+  /**
+   * Name of the delta as it reads inside a sentence, e.g. "S2 canonical formats"
+   * in "complete the {delta_action_label} delta by ...". Distinct from `label`,
+   * which is the bold heading copy.
+   */
+  delta_action_label: string;
+  /**
+   * Holder descriptor for the start-of-delta brief, e.g. "S2 Creative" in
+   * "an existing {specialist_label} specialist holder".
+   */
+  specialist_label: string;
+  /** Migration filename that deploys the criteria, named in the gated-config reason. */
+  criteria_migration: string;
+  /** Per-definition reason fragments interpolated into the engine's shared templates. */
+  reason_phrases: DeltaReasonPhrases;
+}
+
+export const S2_DELTA_DEFINITION: DeltaDefinition = {
+  update_id: 's2_canonical_formats_3_1',
+  module_id: 'S2',
+  credential_id: 'specialist_creative',
+  criterion_ids: [
+    's2_ex1_sc_format_kind_selection',
+    's2_ex1_sc_format_options_cardinality',
+    's2_ex1_sc_option_vs_capability_id',
+    's2_ex1_sc_source_taxonomy',
+    's2_ex1_sc_validation_order',
+  ],
+  release_setting_key: SETTING_KEYS.CERTIFICATION_S2_CANONICAL_FORMATS_DELTA_RELEASE,
+  delta_window_days: 90,
+  label: 'S2 Creative canonical formats',
+  delta_action_label: 'S2 canonical formats',
+  specialist_label: 'S2 Creative',
+  criteria_migration: '496_curriculum_3_1_canonical_formats_criteria.sql',
+  reason_phrases: {
+    criteria_count_word: 'five',
+    criteria_phrase: 'AdCP 3.1 S2 canonical-format',
+    criteria_short_phrase: 'S2 canonical-format',
+    ga_milestone_label: 'AdCP 3.1.0 GA',
+    ga_date_label: 'AdCP 3.1.0 GA date',
+    module_label: 'S2',
+    delta_name: 'S2 canonical-formats',
+    completion_after_effective:
+      'S2 completion is already on or after the AdCP 3.1 canonical-format criteria effective point.',
+    credential_after_effective:
+      'S2 credential was awarded after the AdCP 3.1 canonical-format criteria effective point.',
+    delta_completed:
+      'Learner has auditable evidence for all AdCP 3.1 S2 canonical-format criteria.',
+    not_credentialed: 'Learner does not hold the S2 Creative specialist credential.',
+    delta_available:
+      'Pre-3.1 S2 holder is eligible for the canonical-formats delta assessment.',
+  },
+};
+
+export const DELTA_DEFINITIONS: DeltaDefinition[] = [S2_DELTA_DEFINITION];
+
+export function getDeltaByUpdateId(id: string): DeltaDefinition | undefined {
+  return DELTA_DEFINITIONS.find(d => d.update_id === id);
+}
+
+/**
+ * Return the active delta for a module. When more than one delta ever targets
+ * the same module, prefer the one whose window has not closed at `now`, using
+ * the release gate's later-of(GA, deployment) point + `delta_window_days`.
+ * Definitions whose release gate is unconfigured (no resolver available) sort
+ * last so a configured, open delta always wins. Today there is a single S2
+ * delta, so this resolves to it.
+ *
+ * `releaseResolver` lets the caller supply the release gate (read from
+ * system_settings) without this config module depending on the DB layer.
+ */
+export function getDeltaForModule(
+  moduleId: string,
+  options?: {
+    now?: Date;
+    releaseResolver?: (def: DeltaDefinition) => { adcp_3_1_ga_at: string | null; criteria_deployed_at: string | null } | null;
+  },
+): DeltaDefinition | undefined {
+  const candidates = DELTA_DEFINITIONS.filter(d => d.module_id === moduleId);
+  if (candidates.length <= 1) return candidates[0];
+
+  const now = options?.now ?? new Date();
+  const resolver = options?.releaseResolver;
+
+  const windowClosesAt = (def: DeltaDefinition): number | null => {
+    const release = resolver?.(def);
+    if (!release) return null;
+    const ga = release.adcp_3_1_ga_at ? new Date(release.adcp_3_1_ga_at).getTime() : NaN;
+    const deployed = release.criteria_deployed_at ? new Date(release.criteria_deployed_at).getTime() : NaN;
+    if (Number.isNaN(ga) || Number.isNaN(deployed)) return null;
+    const effective = Math.max(ga, deployed);
+    return effective + def.delta_window_days * 24 * 60 * 60 * 1000;
+  };
+
+  // Prefer definitions whose window is still open; among those, the one
+  // closing soonest (most specific to the current change). Definitions with an
+  // unknown/unconfigured window fall to the back.
+  const open = candidates
+    .map(def => ({ def, closesAt: windowClosesAt(def) }))
+    .filter(({ closesAt }) => closesAt !== null && closesAt >= now.getTime())
+    .sort((a, b) => (a.closesAt! - b.closesAt!));
+
+  return open[0]?.def ?? candidates[0];
+}

--- a/server/src/db/certification-db.ts
+++ b/server/src/db/certification-db.ts
@@ -1,14 +1,16 @@
 import { query, getClient } from './client.js';
 import { createLogger } from '../logger.js';
 import {
-  computeS2CanonicalFormatsDeltaStatus,
+  computeProtocolDeltaStatus,
   S2_CANONICAL_FORMATS_CREDENTIAL_ID,
   S2_CANONICAL_FORMATS_CRITERION_IDS,
   S2_CANONICAL_FORMATS_DELTA_UPDATE_ID,
   S2_CANONICAL_FORMATS_MODULE_ID,
+  type ProtocolDeltaStatus,
   type S2CanonicalFormatsDeltaStatus,
 } from '../certification/s2-canonical-formats-delta.js';
-import { getS2CanonicalFormatsDeltaRelease } from './system-settings-db.js';
+import { S2_DELTA_DEFINITION, type DeltaDefinition } from '../config/recertification-deltas.js';
+import { getDeltaRelease } from './system-settings-db.js';
 
 const logger = createLogger('certification-db');
 
@@ -735,14 +737,17 @@ export async function getUserCredentials(userId: string): Promise<UserCredential
   return result.rows;
 }
 
-export interface S2CanonicalFormatsDeltaEvidence {
+export interface ProtocolDeltaEvidence {
   verifiedCriterionIds: string[];
   evidenceByCriterionId: Record<string, string>;
 }
 
-export async function getS2CanonicalFormatsDeltaEvidence(
+export type S2CanonicalFormatsDeltaEvidence = ProtocolDeltaEvidence;
+
+export async function getDeltaEvidence(
+  def: DeltaDefinition,
   userId: string,
-): Promise<S2CanonicalFormatsDeltaEvidence> {
+): Promise<ProtocolDeltaEvidence> {
   const result = await query<{ criterion_id: string; evidence: string | null }>(
     `SELECT v.criterion_id,
             NULLIF(BTRIM(tc.demonstration_evidence ->> v.criterion_id), '') AS evidence
@@ -752,7 +757,7 @@ export async function getS2CanonicalFormatsDeltaEvidence(
        AND tc.module_id = $2
        AND v.criterion_id = ANY($3::text[])
      ORDER BY tc.created_at DESC`,
-    [userId, S2_CANONICAL_FORMATS_MODULE_ID, [...S2_CANONICAL_FORMATS_CRITERION_IDS]]
+    [userId, def.module_id, [...def.criterion_ids]]
   );
 
   const evidenceByCriterionId: Record<string, string> = {};
@@ -768,18 +773,19 @@ export async function getS2CanonicalFormatsDeltaEvidence(
   };
 }
 
-export async function getS2CanonicalFormatsDeltaCompletedAt(userId: string): Promise<string | null> {
+export async function getDeltaCompletedAt(def: DeltaDefinition, userId: string): Promise<string | null> {
   const result = await query<{ completed_at: string }>(
     `SELECT completed_at
      FROM learner_protocol_updates
      WHERE workos_user_id = $1 AND update_id = $2
      LIMIT 1`,
-    [userId, S2_CANONICAL_FORMATS_DELTA_UPDATE_ID]
+    [userId, def.update_id]
   );
   return result.rows[0]?.completed_at ?? null;
 }
 
-export async function recordS2CanonicalFormatsDeltaCompletion(
+export async function recordDeltaCompletion(
+  def: DeltaDefinition,
   userId: string,
   attemptId: string,
   evidenceByCriterionId: Record<string, string>,
@@ -795,39 +801,39 @@ export async function recordS2CanonicalFormatsDeltaCompletion(
            evidence = EXCLUDED.evidence`,
     [
       userId,
-      S2_CANONICAL_FORMATS_DELTA_UPDATE_ID,
-      S2_CANONICAL_FORMATS_MODULE_ID,
-      S2_CANONICAL_FORMATS_CREDENTIAL_ID,
+      def.update_id,
+      def.module_id,
+      def.credential_id,
       attemptId,
-      [...S2_CANONICAL_FORMATS_CRITERION_IDS],
+      [...def.criterion_ids],
       JSON.stringify(evidenceByCriterionId),
     ]
   );
 }
 
-async function hasS2CanonicalFormatsCriteriaPresent(): Promise<boolean> {
-  const mod = await getModule(S2_CANONICAL_FORMATS_MODULE_ID);
+export async function hasCriteriaPresent(def: DeltaDefinition): Promise<boolean> {
+  const mod = await getModule(def.module_id);
   const exerciseDefs = mod?.exercise_definitions ?? [];
   const ids = new Set(
     exerciseDefs.flatMap(ex =>
       ex.success_criteria.map(sc => typeof sc === 'string' ? sc : sc.id)
     )
   );
-  return S2_CANONICAL_FORMATS_CRITERION_IDS.every(id => ids.has(id));
+  return def.criterion_ids.every(id => ids.has(id));
 }
 
-async function hasPriorAuditableS2Record(
+export async function hasPriorAuditableRecord(
+  def: DeltaDefinition,
   userId: string,
-  s2CompletedAt: string | null | undefined,
+  moduleCompletedAt: string | null | undefined,
 ): Promise<boolean> {
-  if (!s2CompletedAt) return false;
+  if (!moduleCompletedAt) return false;
 
-  const mod = await getModule(S2_CANONICAL_FORMATS_MODULE_ID);
+  const mod = await getModule(def.module_id);
+  const deltaCriterionIds = new Set<string>(def.criterion_ids);
   const priorCriterionIds = (mod?.exercise_definitions ?? [])
     .flatMap(ex => ex.success_criteria.map(sc => typeof sc === 'string' ? sc : sc.id))
-    .filter(id => !S2_CANONICAL_FORMATS_CRITERION_IDS.includes(
-      id as (typeof S2_CANONICAL_FORMATS_CRITERION_IDS)[number],
-    ));
+    .filter(id => !deltaCriterionIds.has(id));
   if (priorCriterionIds.length === 0) return false;
 
   const result = await query<{ criterion_id: string }>(
@@ -839,13 +845,14 @@ async function hasPriorAuditableS2Record(
        AND tc.created_at <= $3::timestamptz + INTERVAL '1 hour'
        AND v.criterion_id = ANY($4::text[])
        AND NULLIF(BTRIM(tc.demonstration_evidence ->> v.criterion_id), '') IS NOT NULL`,
-    [userId, S2_CANONICAL_FORMATS_MODULE_ID, s2CompletedAt, priorCriterionIds]
+    [userId, def.module_id, moduleCompletedAt, priorCriterionIds]
   );
   const evidenced = new Set(result.rows.map(row => row.criterion_id));
   return priorCriterionIds.every(id => evidenced.has(id));
 }
 
-export async function completeS2CanonicalFormatsDeltaAttempt(
+export async function completeDeltaAttempt(
+  def: DeltaDefinition,
   attemptId: string,
   userId: string,
   scores: Record<string, number>,
@@ -873,12 +880,12 @@ export async function completeS2CanonicalFormatsDeltaAttempt(
         JSON.stringify(scores),
         overallScore,
         userId,
-        S2_CANONICAL_FORMATS_MODULE_ID,
+        def.module_id,
       ]
     );
     const attempt = attemptResult.rows[0];
     if (!attempt) {
-      throw new Error(`Active S2 canonical formats delta attempt ${attemptId} not found`);
+      throw new Error(`Active ${def.label} delta attempt ${attemptId} not found`);
     }
 
     await client.query(
@@ -892,11 +899,11 @@ export async function completeS2CanonicalFormatsDeltaAttempt(
              evidence = EXCLUDED.evidence`,
       [
         userId,
-        S2_CANONICAL_FORMATS_DELTA_UPDATE_ID,
-        S2_CANONICAL_FORMATS_MODULE_ID,
-        S2_CANONICAL_FORMATS_CREDENTIAL_ID,
+        def.update_id,
+        def.module_id,
+        def.credential_id,
         attemptId,
-        [...S2_CANONICAL_FORMATS_CRITERION_IDS],
+        [...def.criterion_ids],
         JSON.stringify(evidenceByCriterionId),
       ]
     );
@@ -911,34 +918,70 @@ export async function completeS2CanonicalFormatsDeltaAttempt(
   }
 }
 
+export async function getDeltaStatus(
+  def: DeltaDefinition,
+  userId: string,
+  now: Date = new Date(),
+): Promise<ProtocolDeltaStatus> {
+  const [release, credentials, moduleProgress, evidence, deltaCompletedAt, criteriaPresent] = await Promise.all([
+    getDeltaRelease(def.release_setting_key),
+    getUserCredentials(userId),
+    getModuleProgress(userId, def.module_id),
+    getDeltaEvidence(def, userId),
+    getDeltaCompletedAt(def, userId),
+    hasCriteriaPresent(def),
+  ]);
+
+  const credential = credentials.find(c => c.credential_id === def.credential_id);
+
+  return computeProtocolDeltaStatus(def, {
+    release,
+    hasCredential: !!credential,
+    credentialAwardedAt: credential?.awarded_at ?? null,
+    moduleCompletedAt: moduleProgress?.completed_at ?? null,
+    deltaCompletedAt,
+    criteriaPresent,
+    hasPriorAuditableRecord: await hasPriorAuditableRecord(def, userId, moduleProgress?.completed_at),
+    verifiedCriterionIds: evidence.verifiedCriterionIds,
+    now,
+  });
+}
+
+// ----- S2 canonical-formats delta — back-compat wrappers binding the S2 definition -----
+
+export async function getS2CanonicalFormatsDeltaEvidence(
+  userId: string,
+): Promise<S2CanonicalFormatsDeltaEvidence> {
+  return getDeltaEvidence(S2_DELTA_DEFINITION, userId);
+}
+
+export async function getS2CanonicalFormatsDeltaCompletedAt(userId: string): Promise<string | null> {
+  return getDeltaCompletedAt(S2_DELTA_DEFINITION, userId);
+}
+
+export async function recordS2CanonicalFormatsDeltaCompletion(
+  userId: string,
+  attemptId: string,
+  evidenceByCriterionId: Record<string, string>,
+): Promise<void> {
+  return recordDeltaCompletion(S2_DELTA_DEFINITION, userId, attemptId, evidenceByCriterionId);
+}
+
+export async function completeS2CanonicalFormatsDeltaAttempt(
+  attemptId: string,
+  userId: string,
+  scores: Record<string, number>,
+  overallScore: number,
+  evidenceByCriterionId: Record<string, string>,
+): Promise<CertificationAttempt> {
+  return completeDeltaAttempt(S2_DELTA_DEFINITION, attemptId, userId, scores, overallScore, evidenceByCriterionId);
+}
+
 export async function getS2CanonicalFormatsDeltaStatus(
   userId: string,
   now: Date = new Date(),
 ): Promise<S2CanonicalFormatsDeltaStatus> {
-  const [release, credentials, s2Progress, evidence, deltaCompletedAt, criteriaPresent] = await Promise.all([
-    getS2CanonicalFormatsDeltaRelease(),
-    getUserCredentials(userId),
-    getModuleProgress(userId, S2_CANONICAL_FORMATS_MODULE_ID),
-    getS2CanonicalFormatsDeltaEvidence(userId),
-    getS2CanonicalFormatsDeltaCompletedAt(userId),
-    hasS2CanonicalFormatsCriteriaPresent(),
-  ]);
-
-  const creativeCredential = credentials.find(
-    c => c.credential_id === S2_CANONICAL_FORMATS_CREDENTIAL_ID
-  );
-
-  return computeS2CanonicalFormatsDeltaStatus({
-    release,
-    hasCreativeSpecialistCredential: !!creativeCredential,
-    credentialAwardedAt: creativeCredential?.awarded_at ?? null,
-    s2CompletedAt: s2Progress?.completed_at ?? null,
-    deltaCompletedAt,
-    canonicalCriteriaPresent: criteriaPresent,
-    hasPriorAuditableS2Record: await hasPriorAuditableS2Record(userId, s2Progress?.completed_at),
-    verifiedCriterionIds: evidence.verifiedCriterionIds,
-    now,
-  });
+  return getDeltaStatus(S2_DELTA_DEFINITION, userId, now) as Promise<S2CanonicalFormatsDeltaStatus>;
 }
 
 /**

--- a/server/src/db/system-settings-db.ts
+++ b/server/src/db/system-settings-db.ts
@@ -353,20 +353,31 @@ export async function setAnnouncementChannel(
 
 // ============== Certification Protocol-Update Gates ==============
 
-export async function getS2CanonicalFormatsDeltaRelease(): Promise<S2CanonicalFormatsDeltaReleaseSetting> {
-  const result = await getSetting<S2CanonicalFormatsDeltaReleaseSetting>(
-    SETTING_KEYS.CERTIFICATION_S2_CANONICAL_FORMATS_DELTA_RELEASE,
-  );
+/**
+ * Release gate for a protocol-triggered recertification delta. Keyed by the
+ * delta's `release_setting_key` so the recertification engine can read any
+ * module's gate, not just S2. An unset gate reads as "both dates unconfigured."
+ */
+export async function getDeltaRelease(key: string): Promise<S2CanonicalFormatsDeltaReleaseSetting> {
+  const result = await getSetting<S2CanonicalFormatsDeltaReleaseSetting>(key);
   return result ?? { adcp_3_1_ga_at: null, criteria_deployed_at: null };
+}
+
+export async function setDeltaRelease(
+  key: string,
+  value: S2CanonicalFormatsDeltaReleaseSetting,
+  updatedBy?: string,
+): Promise<void> {
+  await setSetting<S2CanonicalFormatsDeltaReleaseSetting>(key, value, updatedBy);
+}
+
+export async function getS2CanonicalFormatsDeltaRelease(): Promise<S2CanonicalFormatsDeltaReleaseSetting> {
+  return getDeltaRelease(SETTING_KEYS.CERTIFICATION_S2_CANONICAL_FORMATS_DELTA_RELEASE);
 }
 
 export async function setS2CanonicalFormatsDeltaRelease(
   value: S2CanonicalFormatsDeltaReleaseSetting,
   updatedBy?: string
 ): Promise<void> {
-  await setSetting<S2CanonicalFormatsDeltaReleaseSetting>(
-    SETTING_KEYS.CERTIFICATION_S2_CANONICAL_FORMATS_DELTA_RELEASE,
-    value,
-    updatedBy,
-  );
+  await setDeltaRelease(SETTING_KEYS.CERTIFICATION_S2_CANONICAL_FORMATS_DELTA_RELEASE, value, updatedBy);
 }

--- a/server/src/routes/admin/settings.ts
+++ b/server/src/routes/admin/settings.ts
@@ -496,6 +496,11 @@ export function createAdminSettingsRouter(): Router {
   });
 
   // PUT /api/admin/settings/s2-canonical-formats-delta-release
+  // TODO: When a second recertification delta registers in
+  // config/recertification-deltas.ts, add a generic
+  // PUT /delta-release/:updateId path that resolves the definition via
+  // getDeltaByUpdateId and writes through setDeltaRelease(def.release_setting_key, ...).
+  // Until then this S2-specific route is the only configured gate.
   router.put('/s2-canonical-formats-delta-release', ...requireGlobalAdmin, async (req: Request, res: Response) => {
     try {
       const adcpGaAt = normalizeOptionalDate(req.body?.adcp_3_1_ga_at);

--- a/tests/certification-protocol-delta-engine.test.ts
+++ b/tests/certification-protocol-delta-engine.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeProtocolDeltaStatus,
+  type ProtocolDeltaInput,
+} from '../server/src/certification/s2-canonical-formats-delta.js';
+import type { DeltaDefinition } from '../server/src/config/recertification-deltas.js';
+
+// A second, synthetic definition for a hypothetical module — NOT S2. Different
+// window length (30 days vs S2's 90) and a different criterion count (3 vs 5),
+// with its own reason phrasing. This proves the engine is definition-driven:
+// the same code path that serves S2 must produce this module's windows, counts,
+// and copy without any S2 hard-coding leaking through.
+const SYNTHETIC_DELTA: DeltaDefinition = {
+  update_id: 'x9_widget_protocol_4_0',
+  module_id: 'X9',
+  credential_id: 'specialist_widget',
+  criterion_ids: ['x9_c1', 'x9_c2', 'x9_c3'],
+  release_setting_key: 'certification_x9_widget_delta_release',
+  delta_window_days: 30,
+  label: 'X9 Widget protocol refresh',
+  delta_action_label: 'X9 widget refresh',
+  specialist_label: 'X9 Widget',
+  criteria_migration: '900_x9_widget_criteria.sql',
+  reason_phrases: {
+    criteria_count_word: 'three',
+    criteria_phrase: 'AdCP 4.0 X9 widget',
+    criteria_short_phrase: 'X9 widget',
+    ga_milestone_label: 'AdCP 4.0.0 GA',
+    ga_date_label: 'AdCP 4.0.0 GA date',
+    module_label: 'X9',
+    delta_name: 'X9 widget',
+    completion_after_effective: 'X9 completion is already on or after the AdCP 4.0 widget criteria effective point.',
+    credential_after_effective: 'X9 credential was awarded after the AdCP 4.0 widget criteria effective point.',
+    delta_completed: 'Learner has auditable evidence for all AdCP 4.0 X9 widget criteria.',
+    not_credentialed: 'Learner does not hold the X9 Widget specialist credential.',
+    delta_available: 'Pre-4.0 X9 holder is eligible for the widget refresh delta assessment.',
+  },
+};
+
+const release = {
+  adcp_3_1_ga_at: '2027-01-10T00:00:00.000Z',
+  criteria_deployed_at: '2027-01-05T00:00:00.000Z',
+};
+
+function input(overrides: Partial<ProtocolDeltaInput> = {}): ProtocolDeltaInput {
+  return {
+    release,
+    hasCredential: true,
+    credentialAwardedAt: '2026-12-01T00:00:00.000Z',
+    moduleCompletedAt: '2026-12-01T00:00:00.000Z',
+    verifiedCriterionIds: [],
+    now: new Date('2027-01-12T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('computeProtocolDeltaStatus is module-agnostic', () => {
+  it('uses the definition window (30 days) for the closes-at boundary', () => {
+    const status = computeProtocolDeltaStatus(SYNTHETIC_DELTA, input());
+
+    // Effective point = later of GA (2027-01-10) and deploy (2027-01-05) = 2027-01-10.
+    // Window closes 30 calendar days later at end-of-day UTC.
+    expect(status.status).toBe('delta_available');
+    expect(status.criteria_effective_at).toBe('2027-01-10T00:00:00.000Z');
+    expect(status.delta_window_closes_at).toBe('2027-02-09T23:59:59.999Z');
+  });
+
+  it('carries the definition identity into the status payload', () => {
+    const status = computeProtocolDeltaStatus(SYNTHETIC_DELTA, input());
+    expect(status.update_id).toBe('x9_widget_protocol_4_0');
+    expect(status.module_id).toBe('X9');
+    expect(status.credential_id).toBe('specialist_widget');
+  });
+
+  it('reports all three (not five) criteria as missing when none are verified', () => {
+    const status = computeProtocolDeltaStatus(SYNTHETIC_DELTA, input());
+    expect(status.missing_criterion_ids).toEqual(['x9_c1', 'x9_c2', 'x9_c3']);
+  });
+
+  it('templates the gated-config reason from the definition migration + GA label', () => {
+    const status = computeProtocolDeltaStatus(SYNTHETIC_DELTA, input({
+      release: { adcp_3_1_ga_at: null, criteria_deployed_at: null },
+    }));
+    expect(status.status).toBe('gated');
+    expect(status.reason).toBe(
+      'Blocked until AdCP 4.0.0 GA date and production deployment date for migration 900_x9_widget_criteria.sql is configured.',
+    );
+  });
+
+  it('templates the criteria-present gate from the definition count word + phrase', () => {
+    const status = computeProtocolDeltaStatus(SYNTHETIC_DELTA, input({ criteriaPresent: false }));
+    expect(status.status).toBe('gated');
+    expect(status.reason).toBe(
+      'Blocked until the three AdCP 4.0 X9 widget criteria are present in certification_modules.exercise_definitions.',
+    );
+  });
+
+  it('keeps the auditable-record reason wording while substituting the module label', () => {
+    const status = computeProtocolDeltaStatus(SYNTHETIC_DELTA, input({ moduleCompletedAt: null }));
+    expect(status.status).toBe('full_recertification_required');
+    expect(status.reason).toBe(
+      'Prior X9 completion record is missing, so the learner does not meet the auditable-record requirement for a delta.',
+    );
+    // Same invariant the frozen S2 guard pins, proven for a different module.
+    expect(status.reason).toContain('auditable-record requirement');
+  });
+
+  it('names the definition delta when the window has closed', () => {
+    const status = computeProtocolDeltaStatus(SYNTHETIC_DELTA, input({
+      now: new Date('2027-03-01T00:00:00.000Z'),
+    }));
+    expect(status.status).toBe('full_recertification_required');
+    expect(status.reason).toBe('The X9 widget delta window has closed.');
+  });
+
+  it('surfaces the not-credentialed reason from the definition', () => {
+    const status = computeProtocolDeltaStatus(SYNTHETIC_DELTA, input({
+      hasCredential: false,
+      credentialAwardedAt: null,
+      moduleCompletedAt: null,
+    }));
+    expect(status.status).toBe('not_required');
+    expect(status.reason).toBe('Learner does not hold the X9 Widget specialist credential.');
+  });
+});


### PR DESCRIPTION
## Why
The protocol-triggered recertification engine was hard-coded to a single module: `server/src/certification/s2-canonical-formats-delta.ts` was the *only* file in `server/src/certification/`, with S2-specific constants. When 3.1 GAs, **no module other than S2 can be flagged for a recert delta** — even though the docs-and-training review found several modules will need one. This generalizes the engine without changing any S2 behavior.

## What
- **New `server/src/config/recertification-deltas.ts`** — a `DeltaDefinition` registry with `getDeltaForModule(moduleId)` / `getDeltaByUpdateId(id)` lookups. S2 is the seed entry, populated verbatim from the old constants. `getDeltaForModule` tolerates multiple deltas per module (prefers the open window).
- **`s2-canonical-formats-delta.ts`** — adds definition-driven `computeProtocolDeltaStatus(definition, input)`; window length, criterion count, migration name, and reason strings are templated from the definition. The S2 functions/constants/types remain as back-compat shims.
- **`certification-db.ts` / `system-settings-db.ts`** — the six S2 helpers + release accessors generalized to be definition-driven; `getS2CanonicalFormatsDelta*` wrappers preserved.
- **`certification-tools.ts`** — the four `moduleId === S2_…_MODULE_ID` branches now use `getDeltaForModule(moduleId)`; learner-facing copy is driven from the definition.

Adding a future module's delta is now a registry entry + a criteria migration + a release-dates row — no engine changes.

## Behavior preservation
- Every S2 learner-facing string is **byte-identical** (carried as definition fields where they don't derive from `label`).
- The frozen guard `tests/certification-s2-canonical-formats-delta.test.ts` (13 cases) passes **unchanged** — not edited.
- `server/tests/unit/certification-checkpoint-handler.test.ts` passes unchanged.
- New `tests/certification-protocol-delta-engine.test.ts` (8 cases) runs a synthetic non-S2 definition through the engine to prove module-agnosticism.
- `npm run typecheck` clean. Pre-commit full unit suite green.

Server-internal; no spec/package release (empty changeset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)