### PR TITLE
fix(release): repair protocol asset upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,32 +71,78 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       # Attach the protocol tarball + signature sidecars to the GitHub
-      # Release that changesets/action just created. `createGithubReleases:
-      # true` only writes the changelog body — files have to be uploaded
-      # separately. The `published` output is the canonical signal that a
-      # tag-and-release just happened on this run (not a Version Packages
-      # PR-creation run, where `published` is false).
+      # Release. `createGithubReleases: true` only writes the changelog body
+      # — files have to be uploaded separately.
       #
       # Tarballs and sidecars (.sha256, .sig, .crt) are written to
       # dist/protocol/${VERSION}.tgz{,.sha256,.sig,.crt} by `npm run version`
-      # earlier in this job (build-protocol-tarball + sign-protocol-tarball).
+      # on normal changesets release PRs. Manual release PRs can already have
+      # a tag/release but lack the signature sidecars, so this step is
+      # idempotent: skip complete releases, repair incomplete releases.
       # Without this step the artifacts ship to the repo's dist/ tree but
       # are never attached as Release assets, leaving adopters who pin via
       # release URL with a 404. v3.0.0 had assets only because they were
       # uploaded manually; v3.0.1, v3.0.2, v3.0.3 all shipped empty.
       - name: Upload protocol tarball to GitHub Release
-        if: steps.changesets.outputs.published == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          CHANGESETS_PUBLISHED: ${{ steps.changesets.outputs.published }}
         run: |
           set -euo pipefail
           VERSION=$(node -p "require('./package.json').version")
           TAG="v${VERSION}"
           TARBALL="dist/protocol/${VERSION}.tgz"
+          TARBALL_NAME=$(basename "${TARBALL}")
+          SHA_NAME="${TARBALL_NAME}.sha256"
+          SIG_NAME="${TARBALL_NAME}.sig"
+          CRT_NAME="${TARBALL_NAME}.crt"
+
+          if ! gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "No GitHub Release exists for ${TAG}; skipping protocol asset upload."
+            exit 0
+          fi
+
+          mapfile -t EXISTING_ASSETS < <(gh release view "${TAG}" --json assets --jq '.assets[].name')
+          has_asset() {
+            local name="$1"
+            printf '%s\n' "${EXISTING_ASSETS[@]}" | grep -Fxq "${name}"
+          }
+
+          MISSING_ASSETS=()
+          for asset in "${TARBALL_NAME}" "${SHA_NAME}" "${SIG_NAME}" "${CRT_NAME}"; do
+            if ! has_asset "${asset}"; then
+              MISSING_ASSETS+=("${asset}")
+            fi
+          done
+
+          if [ "${CHANGESETS_PUBLISHED:-false}" != "true" ] && [ ${#MISSING_ASSETS[@]} -eq 0 ]; then
+            echo "GitHub Release ${TAG} already has protocol assets; skipping upload."
+            exit 0
+          fi
+
           if [ ! -f "${TARBALL}" ]; then
             echo "::error::Tarball not found at ${TARBALL}. Did npm run version fail upstream?"
             exit 1
           fi
+          if [ ! -f "${TARBALL}.sha256" ]; then
+            echo "::error::Checksum not found at ${TARBALL}.sha256."
+            exit 1
+          fi
+
+          if [ ! -f "${TARBALL}.sig" ] || [ ! -f "${TARBALL}.crt" ]; then
+            echo "Signing ${TARBALL} before upload."
+            COSIGN_YES=true cosign sign-blob \
+              --yes \
+              --output-signature "${TARBALL}.sig" \
+              --output-certificate "${TARBALL}.crt" \
+              "${TARBALL}"
+
+            if [ "$(head -c 5 "${TARBALL}.crt")" != "-----" ]; then
+              base64 -d < "${TARBALL}.crt" > "${TARBALL}.crt.pem"
+              mv "${TARBALL}.crt.pem" "${TARBALL}.crt"
+            fi
+          fi
+
           gh release upload "${TAG}" \
             "${TARBALL}" \
             "${TARBALL}.sha256" \


### PR DESCRIPTION
## Summary\n- make protocol release asset upload idempotent\n- sign missing protocol tarball sidecars in GitHub Actions before upload\n- repair existing releases that have a tag/release but missing assets\n\n## Validation\n- git diff --check\n- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'release.yml parses'"\n- precommit: npm run test:unit, npm run test:test-dynamic-imports, npm run typecheck