### PR TITLE
fix(compliance): treat optional tool skips as not applicable

### DIFF
--- a/.changeset/compliance-optional-tool-skips.md
+++ b/.changeset/compliance-optional-tool-skips.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix compliance reporting for optional-tool skips: storyboard-level `required_tools`
+and step-level `requires_tool` skips now remain untested/not applicable in Addie
+instead of surfacing as failures. Preview creative checks now declare their
+`preview_creative` gate explicitly, and idempotency replay key stability is pinned
+with a source-storyboard regression test.

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -404,7 +404,48 @@ function mapOverallStatus(status: string): OverallRunStatus {
   }
 }
 
-function skipReasonIsCoverageGap(reason: string | undefined): boolean {
+function isSyntheticRequiredToolsMissingSkip(
+  step: { skip_reason?: string; step?: unknown; step_id?: unknown },
+  scenario: unknown,
+): boolean {
+  if (step.skip_reason !== 'missing_tool' || typeof scenario !== 'string' || !scenario.endsWith('/missing_tool')) {
+    return false;
+  }
+  const stepId = firstString(step.step_id);
+  const title = firstString(step.step);
+  return stepId === 'missing_tool' || title?.startsWith('Skipped — agent does not advertise') === true;
+}
+
+function isExplicitRequiresToolMissingSkip(step: {
+  skip_reason?: string;
+  details?: unknown;
+  error?: unknown;
+  warnings?: unknown;
+  skip?: { detail?: unknown };
+}): boolean {
+  if (step.skip_reason !== 'missing_tool') return false;
+  const warning = Array.isArray(step.warnings)
+    ? step.warnings.find((w): w is string => typeof w === 'string' && w.trim().length > 0)
+    : undefined;
+  const detail = firstString(step.skip?.detail, step.details, step.error, warning);
+  return detail?.startsWith('Required tool "') === true && detail.includes('" not advertised');
+}
+
+function skipReasonIsCoverageGap(
+  reason: string | undefined,
+  step?: {
+    skip_reason?: string;
+    step?: unknown;
+    step_id?: unknown;
+    details?: unknown;
+    error?: unknown;
+    warnings?: unknown;
+    skip?: { detail?: unknown };
+  },
+  scenario?: unknown,
+): boolean {
+  if (step && isSyntheticRequiredToolsMissingSkip(step, scenario)) return false;
+  if (step && isExplicitRequiresToolMissingSkip(step)) return false;
   switch (reason) {
     case 'not_applicable':
     case 'peer_branch_taken':
@@ -418,7 +459,7 @@ function skipReasonIsCoverageGap(reason: string | undefined): boolean {
 function trackHasCoverageGapSkip(track: TrackResult): boolean {
   for (const scenario of track.scenarios) {
     for (const step of scenario.steps ?? []) {
-      if (step.skipped && skipReasonIsCoverageGap(step.skip_reason)) {
+      if (step.skipped && skipReasonIsCoverageGap(step.skip_reason, step, scenario.scenario)) {
         return true;
       }
     }
@@ -530,6 +571,28 @@ export function deriveStoryboardStatuses(
     branchSkipReasons.has(step.skip_reason ?? '');
   const isCascadeSkip = (step: { skip_reason?: string }): boolean =>
     cascadeSkipReasons.has(step.skip_reason ?? '');
+  const isNeutralApplicabilitySkip = (
+    step: {
+      skip_reason?: string;
+      step?: unknown;
+      step_id?: unknown;
+      details?: unknown;
+      error?: unknown;
+      warnings?: unknown;
+      skip?: { detail?: unknown };
+    },
+    scenario: string,
+  ): boolean => {
+    if (step.skip_reason === 'not_applicable') return true;
+
+    // `@adcp/sdk` emits a single synthetic `missing_tool` phase when a
+    // storyboard's `required_tools` gate is unmet. That means the storyboard is
+    // out of scope for this agent, not that a claimed production step failed.
+    if (isSyntheticRequiredToolsMissingSkip(step, scenario)) return true;
+    if (isExplicitRequiresToolMissingSkip(step)) return true;
+
+    return false;
+  };
   const perStoryboard = new Map<string, Aggregate>();
   // Storyboard ids in `static/compliance/source/**/index.yaml` are flat
   // identifiers (no `/`); splitting on the first `/` therefore always yields
@@ -578,6 +641,9 @@ export function deriveStoryboardStatuses(
           }
           if (isControllerSkip(step)) {
             agg.controllerSkipped++;
+            continue;
+          }
+          if (isNeutralApplicabilitySkip(step, String(s.scenario))) {
             continue;
           }
           if (isCascadeSkip(step)) {

--- a/server/tests/unit/compliance-testing-effective-run-status.test.ts
+++ b/server/tests/unit/compliance-testing-effective-run-status.test.ts
@@ -100,6 +100,83 @@ describe('complianceResultToDbInput — effectiveRunStatus', () => {
     ]);
   });
 
+  it('ignores storyboard-level required-tool skips when deciding promotion', () => {
+    const result = makeResult([
+      makeTrack('silent'),
+      {
+        track: 'governance',
+        label: 'Governance',
+        status: 'skip',
+        duration_ms: 1000,
+        skipped_scenarios: [],
+        observations: [],
+        scenarios: [
+          {
+            scenario: 'collection_lists/missing_tool',
+            overall_passed: true,
+            steps: [
+              {
+                step: 'Skipped — agent does not advertise any of [list_collection_lists]',
+                step_id: 'missing_tool',
+                passed: true,
+                skipped: true,
+                skip_reason: 'missing_tool',
+                duration_ms: 0,
+              },
+            ],
+          },
+        ],
+      },
+    ] as any);
+
+    const out = complianceResultToDbInput(result as any, 'https://agent.example.com/mcp', 'production');
+
+    expect(out.overall_status).toBe('passing');
+    expect(out.tracks_passed).toBe(1);
+    expect(out.tracks_failed).toBe(0);
+    expect(out.tracks_partial).toBe(0);
+    expect(out.tracks_json).toEqual([
+      expect.objectContaining({ track: 'core', has_coverage_gap_skip: false }),
+      expect.objectContaining({ track: 'governance', status: 'skip', has_coverage_gap_skip: false }),
+    ]);
+  });
+
+  it('does not flag explicit requires_tool skips as coverage gaps', () => {
+    const result = makeResult([
+      {
+        track: 'core',
+        label: 'Core',
+        status: 'silent',
+        duration_ms: 1000,
+        scenarios: [
+          {
+            scenario: 'media_buy_seller/governance_setup',
+            overall_passed: true,
+            steps: [
+              {
+                step: 'Register governance agents',
+                step_id: 'sync_governance',
+                task: 'sync_governance',
+                passed: true,
+                skipped: true,
+                skip_reason: 'missing_tool',
+                warnings: ['Required tool "sync_governance" not advertised; agent tools: [get_products, create_media_buy].'],
+                duration_ms: 0,
+              },
+            ],
+          },
+        ],
+      },
+    ] as any);
+
+    const out = complianceResultToDbInput(result as any, 'https://agent.example.com/mcp', 'production');
+
+    expect(out.overall_status).toBe('passing');
+    expect(out.tracks_json).toEqual([
+      expect.objectContaining({ track: 'core', status: 'silent', has_coverage_gap_skip: false }),
+    ]);
+  });
+
   it('does not promote when all tracks are skipped (no active tracks)', () => {
     const result = makeResult([makeTrack('skip'), makeTrack('skip')], 'partial');
     const out = complianceResultToDbInput(result as any, 'https://agent.example.com/mcp', 'production');

--- a/server/tests/unit/derive-storyboard-statuses.test.ts
+++ b/server/tests/unit/derive-storyboard-statuses.test.ts
@@ -208,6 +208,113 @@ describe('deriveStoryboardStatuses', () => {
     });
   });
 
+  it('marks a storyboard untested when every produced step is not applicable', () => {
+    const result = makeResult([
+      {
+        scenario: 'get_signals_pagination_integrity/not_applicable',
+        passed: true,
+        steps: [
+          { passed: true, skipped: true, skip_reason: 'not_applicable', step: 'Not applicable — missing required_tools' },
+        ],
+      },
+    ]);
+
+    const [entry] = deriveStoryboardStatuses(result);
+
+    expect(entry).toEqual({
+      storyboard_id: 'get_signals_pagination_integrity',
+      status: 'untested',
+      steps_passed: 0,
+      steps_total: 0,
+    });
+  });
+
+  it('treats storyboard-level required-tool skips as untested', () => {
+    const result = makeResult([
+      {
+        scenario: 'collection_lists/missing_tool',
+        passed: true,
+        steps: [
+          {
+            passed: true,
+            skipped: true,
+            skip_reason: 'missing_tool',
+            step_id: 'missing_tool',
+            step: 'Skipped — agent does not advertise any of [list_collection_lists]',
+          },
+        ],
+      },
+    ]);
+
+    const [entry] = deriveStoryboardStatuses(result);
+
+    expect(entry).toEqual({
+      storyboard_id: 'collection_lists',
+      status: 'untested',
+      steps_passed: 0,
+      steps_total: 0,
+    });
+  });
+
+  it('treats explicit requires_tool skips as untested', () => {
+    const result = makeResult([
+      {
+        scenario: 'media_buy_seller/governance_setup',
+        passed: true,
+        steps: [
+          {
+            passed: true,
+            skipped: true,
+            skip_reason: 'missing_tool',
+            step: 'Register governance agents',
+            step_id: 'sync_governance',
+            task: 'sync_governance',
+            warnings: ['Required tool "sync_governance" not advertised; agent tools: [get_products, create_media_buy].'],
+          },
+        ],
+      },
+    ]);
+
+    const [entry] = deriveStoryboardStatuses(result);
+
+    expect(entry).toEqual({
+      storyboard_id: 'media_buy_seller',
+      status: 'untested',
+      steps_passed: 0,
+      steps_total: 0,
+    });
+  });
+
+  it('excludes explicit requires_tool skips from mixed storyboard totals', () => {
+    const result = makeResult([
+      {
+        scenario: 'creative_lifecycle/build_and_preview',
+        passed: true,
+        steps: [
+          { passed: true, step: 'Sync creative', step_id: 'sync_creative', task: 'sync_creatives' },
+          {
+            passed: true,
+            skipped: true,
+            skip_reason: 'missing_tool',
+            step: 'Preview the display creative',
+            step_id: 'preview_display',
+            task: 'preview_creative',
+            warnings: ['Required tool "preview_creative" not advertised; agent tools: [list_creative_formats, sync_creatives].'],
+          },
+        ],
+      },
+    ]);
+
+    const [entry] = deriveStoryboardStatuses(result);
+
+    expect(entry).toEqual({
+      storyboard_id: 'creative_lifecycle',
+      status: 'passing',
+      steps_passed: 1,
+      steps_total: 1,
+    });
+  });
+
   it('still counts missing production-tool skips as non-passing coverage gaps', () => {
     const result = makeResult([
       {

--- a/static/compliance/source/protocols/creative/index.yaml
+++ b/static/compliance/source/protocols/creative/index.yaml
@@ -310,6 +310,7 @@ phases:
         response_schema_ref: "creative/preview-creative-response.json"
         doc_ref: "/creative/task-reference/preview_creative"
         comply_scenario: creative_flow
+        requires_tool: preview_creative
         stateful: true
         expected: |
           Return a preview of the display creative:

--- a/static/compliance/source/protocols/creative/scenarios/native_in_feed.yaml
+++ b/static/compliance/source/protocols/creative/scenarios/native_in_feed.yaml
@@ -491,6 +491,7 @@ phases:
         response_schema_ref: "creative/preview-creative-response.json"
         doc_ref: "/creative/task-reference/preview_creative"
         comply_scenario: creative_flow
+        requires_tool: preview_creative
         stateful: true
         expected: |
           Return a preview of the assembled native unit:

--- a/static/compliance/source/protocols/media-buy/scenarios/creative_reception.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/creative_reception.yaml
@@ -194,6 +194,7 @@ phases:
         response_schema_ref: "creative/preview-creative-response.json"
         doc_ref: "/creative/task-reference/preview_creative"
         comply_scenario: creative_flow
+        requires_tool: preview_creative
         stateful: true
         expected: |
           Return a preview showing the creative in your platform's environment.

--- a/static/compliance/source/specialisms/creative-template/index.yaml
+++ b/static/compliance/source/specialisms/creative-template/index.yaml
@@ -230,6 +230,7 @@ phases:
         response_schema_ref: "creative/preview-creative-response.json"
         doc_ref: "/creative/task-reference/preview_creative"
         comply_scenario: creative_flow
+        requires_tool: preview_creative
         stateful: false
         expected: |
           Return a preview render. The response should include:

--- a/tests/lint-storyboard-idempotency-generated-context.test.cjs
+++ b/tests/lint-storyboard-idempotency-generated-context.test.cjs
@@ -8,6 +8,10 @@ const os = require('node:os');
 const path = require('node:path');
 
 const { lintStoryboardIdempotency } = require('../scripts/build-compliance.cjs');
+const {
+  injectContext,
+  parseStoryboard,
+} = require('@adcp/sdk/testing');
 
 function makeFixture(storyboardYaml) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-idem-lint-'));
@@ -76,4 +80,52 @@ phases:
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
+});
+
+test('source idempotency storyboard reuses one replay key across replay steps', () => {
+  const storyboardPath = path.join(
+    __dirname,
+    '..',
+    'static/compliance/source/universal/idempotency.yaml',
+  );
+  const storyboard = parseStoryboard(fs.readFileSync(storyboardPath, 'utf8'), storyboardPath);
+  const capabilityStep = storyboard.phases
+    .find(phase => phase.id === 'capability_discovery')
+    ?.steps.find(step => step.id === 'get_capabilities');
+  assert.ok(capabilityStep, 'capability_discovery/get_capabilities step should exist');
+
+  assert.deepEqual(
+    capabilityStep.context_outputs
+      .filter(output => output.generate === 'uuid_v4')
+      .map(output => output.key)
+      .sort(),
+    ['fresh_key', 'replay_key'],
+  );
+
+  const context = {
+    replay_key: '11111111-1111-4111-8111-111111111111',
+    fresh_key: '22222222-2222-4222-8222-222222222222',
+  };
+
+  const replaySteps = storyboard.phases
+    .find(phase => phase.id === 'replay_same_payload')
+    ?.steps.filter(step => [
+      'create_media_buy_initial',
+      'create_media_buy_replay',
+      'create_media_buy_conflict',
+    ].includes(step.id));
+  assert.equal(replaySteps?.length, 3, 'expected all replay_same_payload steps');
+
+  const requests = replaySteps.map(step => injectContext(step.sample_request, context));
+  assert.match(requests[0].idempotency_key, /^[0-9a-f-]{36}$/i);
+  assert.equal(requests[0].idempotency_key, requests[1].idempotency_key);
+  assert.equal(requests[0].idempotency_key, requests[2].idempotency_key);
+
+  const freshStep = storyboard.phases
+    .find(phase => phase.id === 'fresh_key_new_resource')
+    ?.steps.find(step => step.id === 'create_media_buy_fresh_key');
+  assert.ok(freshStep, 'fresh_key_new_resource/create_media_buy_fresh_key step should exist');
+  const freshRequest = injectContext(freshStep.sample_request, context);
+  assert.match(freshRequest.idempotency_key, /^[0-9a-f-]{36}$/i);
+  assert.notEqual(freshRequest.idempotency_key, requests[0].idempotency_key);
 });


### PR DESCRIPTION
## Summary

- Treat storyboard-level `required_tools` skips and step-level `requires_tool` skips as neutral/untested in Addie instead of failures.
- Add explicit `preview_creative` gates to optional preview storyboard steps.
- Add regression coverage for idempotency replay-key stability in the source storyboard.
- Add a patch changeset so the normal Version Packages flow can cut this into the next release.

## Validation

- `npm run build:compliance`
- `npx vitest run server/tests/unit/derive-storyboard-statuses.test.ts server/tests/unit/compliance-testing-effective-run-status.test.ts`
- `node --test --test-force-exit --test-timeout=30000 tests/lint-storyboard-idempotency-generated-context.test.cjs`
- `npm run typecheck`
- `npm run test:release-workflow`
- precommit hook: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run precommit:server-unit`, `npm run typecheck`
- pre-push hook: current compliance storyboard matrix, 3.0 compatibility storyboard matrix, version sync, changeset check

## Notes

This does not change the schema-validation synthetic final-step behavior yet. We still need the concrete failing result row shape before making that targeted fix.