### PR TITLE
Add publisher adagents revalidation endpoint

### DIFF
--- a/.changeset/publisher-adagents-revalidate-api.md
+++ b/.changeset/publisher-adagents-revalidate-api.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Add an admin publisher `adagents.json` revalidation endpoint that refreshes the cached registry verdict, records validation metadata, and retires stale publisher-origin authorizations when a live recheck fails.

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -1236,6 +1236,21 @@ export class CrawlerService {
     };
   }
 
+  private isTransientPublisherAdagentsFailure(validation: AdAgentsValidationResult): boolean {
+    if (validation.status_code !== undefined) {
+      return validation.status_code >= 500
+        || validation.status_code === 429
+        || (validation.status_code >= 300 && validation.status_code < 400);
+    }
+
+    return validation.errors.some((error) =>
+      error.field === 'timeout'
+      || error.field === 'connection'
+      || error.field === 'network'
+      || error.field === 'unknown'
+    );
+  }
+
   private summarizePublisherAdagentsRevalidation(
     domain: string,
     validation: AdAgentsValidationResult,
@@ -1274,6 +1289,21 @@ export class CrawlerService {
     }
 
     if (!validation.valid || !Array.isArray(validation.raw_data?.authorized_agents)) {
+      if (this.isTransientPublisherAdagentsFailure(validation)) {
+        await this.publisherDb.recordFailedAdagentsFetch({
+          domain,
+          statusCode: validation.status_code,
+          responseBytes: validation.response_bytes,
+          resolvedUrl: validation.resolved_url,
+        });
+        return { valid: false, affectedAgentUrls: new Set() };
+      }
+
+      // Authoritative-negative revalidation is intentionally destructive:
+      // it changes the registry's cached publisher-origin verdict, then
+      // reconciles legacy indexes to match. The writes are ordered so stale
+      // public auth/property projections are removed only after the failed
+      // verdict is durably recorded.
       await this.publisherDb.recordAdagentsValidationFailure({
         domain,
         statusCode: validation.status_code,

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -3,7 +3,7 @@ import { PropertyCrawler, getPropertyIndex, type AgentInfo, type CrawlResult } f
 import { sanitizeAdagentsProperty } from "./discovery/property-index-guard.js";
 import { FederatedIndexService } from "./federated-index.js";
 import type { DiscoveredAgent } from "./db/federated-index-db.js";
-import { AdAgentsManager } from "./adagents-manager.js";
+import { AdAgentsManager, type AdAgentsValidationResult } from "./adagents-manager.js";
 import { BrandManager } from "./brand-manager.js";
 import { BrandDatabase } from "./db/brand-db.js";
 import { PublisherDatabase, canonicalizeAgentUrl, type AdagentsManifest, type AdagentsAuthorizedAgent } from "./db/publisher-db.js";
@@ -65,6 +65,24 @@ function stableStringify(value: unknown): string {
   const obj = value as Record<string, unknown>;
   const keys = Object.keys(obj).sort();
   return '{' + keys.map(k => JSON.stringify(k) + ':' + stableStringify(obj[k])).join(',') + '}';
+}
+
+export interface PublisherAdagentsRevalidationResult {
+  domain: string;
+  adagents_valid: boolean;
+  checked_at: string;
+  error?: string;
+  issues?: {
+    errors: AdAgentsValidationResult['errors'];
+    warnings: AdAgentsValidationResult['warnings'];
+  };
+  properties_count?: number;
+  authorized_agents_count?: number;
+  status_code?: number;
+  response_bytes?: number;
+  resolved_url?: string;
+  discovery_method?: AdAgentsValidationResult['discovery_method'];
+  manager_domain?: string;
 }
 
 export class CrawlerService {
@@ -1206,6 +1224,155 @@ export class CrawlerService {
     } catch (err) {
       log.warn({ domain, err: err instanceof Error ? err.message : err }, 'Adagents legacy reconcile failed');
     }
+  }
+
+  private validationIssues(validation: AdAgentsValidationResult): {
+    errors: AdAgentsValidationResult['errors'];
+    warnings: AdAgentsValidationResult['warnings'];
+  } {
+    return {
+      errors: validation.errors,
+      warnings: validation.warnings,
+    };
+  }
+
+  private summarizePublisherAdagentsRevalidation(
+    domain: string,
+    validation: AdAgentsValidationResult,
+    checkedAt: Date,
+  ): PublisherAdagentsRevalidationResult {
+    const manifest = validation.raw_data as AdagentsManifest | undefined;
+    const valid = validation.valid && Array.isArray(manifest?.authorized_agents);
+    const error = validation.errors[0]?.message;
+    const hasIssues = !valid || validation.warnings.length > 0;
+    return {
+      domain,
+      adagents_valid: valid,
+      checked_at: checkedAt.toISOString(),
+      ...(valid ? {} : { error: error ?? 'Invalid adagents.json' }),
+      ...(hasIssues ? { issues: this.validationIssues(validation) } : {}),
+      properties_count: Array.isArray(manifest?.properties) ? manifest.properties.length : 0,
+      authorized_agents_count: Array.isArray(manifest?.authorized_agents) ? manifest.authorized_agents.length : 0,
+      ...(validation.status_code !== undefined ? { status_code: validation.status_code } : {}),
+      ...(validation.response_bytes !== undefined ? { response_bytes: validation.response_bytes } : {}),
+      ...(validation.resolved_url ? { resolved_url: validation.resolved_url } : {}),
+      discovery_method: validation.discovery_method,
+      ...(validation.manager_domain ? { manager_domain: validation.manager_domain } : {}),
+    };
+  }
+
+  private async persistPublisherAdagentsValidation(
+    domain: string,
+    validation: AdAgentsValidationResult,
+    actor: string,
+  ): Promise<{ valid: boolean; affectedAgentUrls: Set<string> }> {
+    const affectedAgentUrls = new Set<string>();
+    const existingAuthorizations = await this.federatedIndex.getAuthorizationsForDomain(domain);
+    for (const auth of existingAuthorizations) {
+      if (auth.source !== 'adagents_json') continue;
+      affectedAgentUrls.add(canonicalizeAgentUrl(auth.agent_url) ?? auth.agent_url);
+    }
+
+    if (!validation.valid || !Array.isArray(validation.raw_data?.authorized_agents)) {
+      await this.publisherDb.recordAdagentsValidationFailure({
+        domain,
+        statusCode: validation.status_code,
+        responseBytes: validation.response_bytes,
+        resolvedUrl: validation.resolved_url,
+        error: validation.errors[0]?.message,
+        issues: this.validationIssues(validation),
+      });
+      await this.federatedIndex.markPublisherHasInvalidAdagents(domain);
+      await this.federatedIndex.reconcileAdagentsAuthorizations(domain, []);
+      return { valid: false, affectedAgentUrls };
+    }
+
+    const manifest = validation.raw_data as AdagentsManifest;
+    await this.cacheAdagentsManifest(
+      domain,
+      manifest,
+      {
+        statusCode: validation.status_code,
+        responseBytes: validation.response_bytes,
+        resolvedUrl: validation.resolved_url,
+        discoveryMethod: validation.discovery_method,
+        managerDomain: validation.manager_domain,
+      },
+    );
+    await this.federatedIndex.markPublisherHasValidAdagents(domain);
+
+    for (const authorizedAgent of manifest.authorized_agents ?? []) {
+      if (!authorizedAgent.url) continue;
+      affectedAgentUrls.add(canonicalizeAgentUrl(authorizedAgent.url) ?? authorizedAgent.url);
+
+      await this.federatedIndex.recordAgentFromAdagentsJson(
+        authorizedAgent.url,
+        domain,
+        authorizedAgent.authorized_for,
+        authorizedAgent.property_ids,
+      );
+
+      await this.recordPropertiesForAgent(
+        (manifest.properties || []) as any,
+        domain,
+        authorizedAgent.url,
+        authorizedAgent.authorized_for,
+        authorizedAgent.property_ids,
+      );
+
+      if (validation.discovery_method !== 'ads_txt_managerdomain') {
+        await this.fanOutPublisherPropertiesAuthorizations(authorizedAgent, domain);
+      }
+    }
+    await this.reconcileLegacyAdagentsAgents(domain, manifest);
+
+    if (this.eventsDb) {
+      await this.eventsDb.writeEvent({
+        event_type: 'publisher.adagents_changed',
+        entity_type: 'publisher',
+        entity_id: domain,
+        payload: {
+          publisher_domain: domain,
+          agent_count: manifest.authorized_agents?.length ?? 0,
+          property_count: manifest.properties?.length ?? 0,
+          collection_count: manifest.collections?.length ?? 0,
+          discovery_method: validation.discovery_method,
+          manager_domain: validation.manager_domain,
+        },
+        actor,
+      });
+    }
+
+    return { valid: true, affectedAgentUrls };
+  }
+
+  async revalidatePublisherAdagents(
+    domain: string,
+    _options: { force?: boolean } = {},
+  ): Promise<PublisherAdagentsRevalidationResult> {
+    const normalizedDomain = canonicalizePublisherDomain(domain);
+    const checkedAt = new Date();
+    const validation = await this.adAgentsManager.validateDomain(normalizedDomain);
+    const persisted = await this.persistPublisherAdagentsValidation(
+      normalizedDomain,
+      validation,
+      'api:adagents-revalidate',
+    );
+
+    try {
+      await this.scanBrandForDomain(normalizedDomain);
+    } catch (err) {
+      log.warn({ domain: normalizedDomain, err: err instanceof Error ? err.message : err }, 'Brand scan during adagents revalidation failed');
+    }
+
+    if (persisted.affectedAgentUrls.size > 0) {
+      await this.buildInventoryProfiles({
+        agentUrls: [...persisted.affectedAgentUrls],
+        deleteStale: false,
+      });
+    }
+
+    return this.summarizePublisherAdagentsRevalidation(normalizedDomain, validation, checkedAt);
   }
 
   /**

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -1238,14 +1238,16 @@ export class CrawlerService {
 
   private isTransientPublisherAdagentsFailure(validation: AdAgentsValidationResult): boolean {
     // Network fetch failures come from classifySafeFetchError in
-    // utils/url-security.ts. Keep every known transport bucket
-    // non-destructive: only completed publisher-origin negatives may clear
-    // cached adagents-derived projections.
+    // utils/url-security.ts. Keep every known transport bucket and
+    // inconclusive 200 responses non-destructive: only completed
+    // publisher-origin negatives may clear cached adagents-derived projections.
     const hasTransientError = validation.errors.some((error) =>
       error.field === 'timeout'
       || error.field === 'connection'
       || error.field === 'network'
       || error.field === 'unknown'
+      || error.field === 'json'
+      || error.field === 'authoritative_location'
       || /HTTP (401|403|408|429|451|5\d\d)\b/i.test(error.message)
       || /Redirect \(HTTP 3\d\d\)/i.test(error.message)
       || /timed out|timeout|Cannot connect|ECONN|ENOTFOUND|EAI_/i.test(error.message)

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -1237,18 +1237,28 @@ export class CrawlerService {
   }
 
   private isTransientPublisherAdagentsFailure(validation: AdAgentsValidationResult): boolean {
-    if (validation.status_code !== undefined) {
-      return validation.status_code >= 500
-        || validation.status_code === 429
-        || (validation.status_code >= 300 && validation.status_code < 400);
-    }
-
-    return validation.errors.some((error) =>
+    // Network fetch failures come from classifySafeFetchError in
+    // utils/url-security.ts. Keep every known transport bucket
+    // non-destructive: only completed publisher-origin negatives may clear
+    // cached adagents-derived projections.
+    const hasTransientError = validation.errors.some((error) =>
       error.field === 'timeout'
       || error.field === 'connection'
       || error.field === 'network'
       || error.field === 'unknown'
+      || /HTTP (401|403|408|429|451|5\d\d)\b/i.test(error.message)
+      || /Redirect \(HTTP 3\d\d\)/i.test(error.message)
+      || /timed out|timeout|Cannot connect|ECONN|ENOTFOUND|EAI_/i.test(error.message)
     );
+    if (hasTransientError) return true;
+
+    if (validation.status_code !== undefined) {
+      return validation.status_code !== 200
+        && validation.status_code !== 404
+        && validation.status_code !== 410;
+    }
+
+    return false;
   }
 
   private summarizePublisherAdagentsRevalidation(
@@ -1312,8 +1322,6 @@ export class CrawlerService {
         error: validation.errors[0]?.message,
         issues: this.validationIssues(validation),
       });
-      await this.federatedIndex.markPublisherHasInvalidAdagents(domain);
-      await this.federatedIndex.reconcileAdagentsAuthorizations(domain, []);
       return { valid: false, affectedAgentUrls };
     }
 

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -1386,9 +1386,12 @@ export class CrawlerService {
 
   async revalidatePublisherAdagents(
     domain: string,
-    _options: { force?: boolean } = {},
+    options: { force?: boolean } = {},
   ): Promise<PublisherAdagentsRevalidationResult> {
     const normalizedDomain = canonicalizePublisherDomain(domain);
+    if (options.force) {
+      log.info({ domain: normalizedDomain }, 'Force revalidation requested; live origin validation is always performed');
+    }
     const checkedAt = new Date();
     const validation = await this.adAgentsManager.validateDomain(normalizedDomain);
     const persisted = await this.persistPublisherAdagentsValidation(

--- a/server/src/db/federated-index-db.ts
+++ b/server/src/db/federated-index-db.ts
@@ -508,7 +508,7 @@ export class FederatedIndexDatabase {
    * crawl-on-view or turn hosting.mode into `self`.
    */
   async hasValidAdagents(domain: string): Promise<boolean | null> {
-    const result = await query<{ catalog_present: boolean; legacy_or: boolean | null }>(
+    const result = await query<{ catalog_present: boolean; catalog_invalid: boolean; legacy_or: boolean | null }>(
       `SELECT
          EXISTS(
            SELECT 1 FROM publishers
@@ -517,6 +517,16 @@ export class FederatedIndexDatabase {
               AND source_type = 'adagents_json'
               AND review_status = 'approved'
          ) AS catalog_present,
+         EXISTS(
+           SELECT 1 FROM publishers
+            WHERE domain = $1
+              AND source_type <> 'adagents_json'
+              AND (
+                last_http_status IS NOT NULL
+                OR last_validation_error IS NOT NULL
+                OR last_validation_issues IS NOT NULL
+              )
+         ) AS catalog_invalid,
          (SELECT bool_or(has_valid_adagents)
             FROM discovered_publishers
            WHERE domain = $1) AS legacy_or`,
@@ -525,8 +535,19 @@ export class FederatedIndexDatabase {
     const row = result.rows[0];
     if (!row) return null;
     if (row.catalog_present) return true;
+    if (row.catalog_invalid) return false;
     if (row.legacy_or === null) return null;
     return row.legacy_or;
+  }
+
+  async markPublisherHasInvalidAdagents(domain: string): Promise<void> {
+    await query(
+      `UPDATE discovered_publishers
+          SET has_valid_adagents = FALSE,
+              last_validated = NOW()
+        WHERE domain = $1`,
+      [domain],
+    );
   }
 
   /**

--- a/server/src/db/federated-index-db.ts
+++ b/server/src/db/federated-index-db.ts
@@ -522,8 +522,7 @@ export class FederatedIndexDatabase {
             WHERE domain = $1
               AND source_type <> 'adagents_json'
               AND (
-                last_http_status IS NOT NULL
-                OR last_validation_error IS NOT NULL
+                last_validation_error IS NOT NULL
                 OR last_validation_issues IS NOT NULL
               )
          ) AS catalog_invalid,

--- a/server/src/db/migrations/516_publisher_adagents_validation_errors.sql
+++ b/server/src/db/migrations/516_publisher_adagents_validation_errors.sql
@@ -1,0 +1,13 @@
+-- Persist the latest publisher-origin adagents.json validation failure so
+-- support/operator revalidation can report and audit why the cached verdict
+-- was changed without requiring a separate registry edit record.
+
+ALTER TABLE publishers
+  ADD COLUMN IF NOT EXISTS last_validation_error TEXT,
+  ADD COLUMN IF NOT EXISTS last_validation_issues JSONB;
+
+COMMENT ON COLUMN publishers.last_validation_error IS
+  'Short message from the latest failed publisher-origin adagents.json validation attempt. NULL after a successful validation.';
+
+COMMENT ON COLUMN publishers.last_validation_issues IS
+  'Structured errors/warnings from the latest failed publisher-origin adagents.json validation attempt. NULL after a successful validation.';

--- a/server/src/db/publisher-db.ts
+++ b/server/src/db/publisher-db.ts
@@ -1009,6 +1009,21 @@ export class PublisherDatabase {
       );
 
       await client.query(
+        `UPDATE discovered_publishers
+            SET has_valid_adagents = FALSE,
+                last_validated = NOW()
+          WHERE domain = $1`,
+        [domain],
+      );
+
+      await client.query(
+        `DELETE FROM agent_publisher_authorizations
+          WHERE publisher_domain = $1
+            AND source = 'adagents_json'`,
+        [domain],
+      );
+
+      await client.query(
         `DELETE FROM agent_property_authorizations apa
           USING discovered_properties dp
          WHERE apa.property_id = dp.id

--- a/server/src/db/publisher-db.ts
+++ b/server/src/db/publisher-db.ts
@@ -108,6 +108,15 @@ export interface UpsertAdagentsCacheInput {
   collectionEventActor?: string;
 }
 
+export interface RecordAdagentsValidationFailureInput {
+  domain: string;
+  statusCode?: number;
+  responseBytes?: number;
+  resolvedUrl?: string;
+  error?: string;
+  issues?: unknown;
+}
+
 export interface UpsertAdagentsCacheResult {
   collectionEvents: CollectionProjectionEvent[];
 }
@@ -931,6 +940,119 @@ export class PublisherDatabase {
     }
   }
 
+  /**
+   * Persist an operator-triggered failed validation verdict. Unlike the
+   * routine failed-fetch path, this clears a stale publisher-origin cache and
+   * retires adagents_json authorizations because a human explicitly asked the
+   * registry to re-check the live source of truth now.
+   */
+  async recordAdagentsValidationFailure(input: RecordAdagentsValidationFailureInput): Promise<void> {
+    const domain = canonicalizePublisherDomain(input.domain);
+    const client = await getClient();
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        `INSERT INTO publishers
+           (domain, source_type, adagents_json, last_http_status, last_response_bytes,
+            resolved_url, discovery_method, manager_domain, last_validation_error,
+            last_validation_issues)
+         VALUES ($1, 'community', NULL, $2, $3, $4, NULL, NULL, $5, $6::jsonb)
+         ON CONFLICT (domain) DO UPDATE SET
+           adagents_json = CASE
+             WHEN publishers.source_type = 'adagents_json' THEN NULL
+             ELSE publishers.adagents_json
+           END,
+           source_type = CASE
+             WHEN publishers.source_type = 'adagents_json' THEN 'community'
+             ELSE publishers.source_type
+           END,
+           last_http_status = EXCLUDED.last_http_status,
+           last_response_bytes = EXCLUDED.last_response_bytes,
+           resolved_url = EXCLUDED.resolved_url,
+           discovery_method = CASE
+             WHEN publishers.source_type = 'adagents_json' THEN NULL
+             ELSE publishers.discovery_method
+           END,
+           manager_domain = CASE
+             WHEN publishers.source_type = 'adagents_json' THEN NULL
+             ELSE publishers.manager_domain
+           END,
+           last_validation_error = EXCLUDED.last_validation_error,
+           last_validation_issues = EXCLUDED.last_validation_issues,
+           updated_at = NOW()`,
+        [
+          domain,
+          clampHttpStatus(input.statusCode),
+          input.responseBytes ?? null,
+          truncateResolvedUrl(input.resolvedUrl),
+          input.error ?? null,
+          input.issues === undefined ? null : JSON.stringify(input.issues),
+        ],
+      );
+
+      await client.query(
+        `UPDATE catalog_agent_authorizations caa
+            SET deleted_at = NOW()
+          WHERE caa.evidence = 'adagents_json'
+            AND caa.created_by = 'system'
+            AND caa.deleted_at IS NULL
+            AND (
+              caa.publisher_domain = $1
+              OR caa.property_rid IN (
+                SELECT property_rid FROM catalog_properties WHERE created_by = $2
+              )
+              OR (caa.property_id_slug IS NOT NULL AND caa.property_rid IN (
+                SELECT property_rid FROM catalog_properties WHERE created_by = $2
+              ))
+            )`,
+        [domain, adagentsCreatedBy(domain)],
+      );
+
+      await client.query(
+        `DELETE FROM agent_property_authorizations apa
+          USING discovered_properties dp
+         WHERE apa.property_id = dp.id
+           AND dp.publisher_domain = $1
+           AND dp.source_type IN ('adagents_json', 'aao_hosted')`,
+        [domain],
+      );
+
+      await client.query(
+        `DELETE FROM discovered_properties
+          WHERE publisher_domain = $1
+            AND source_type IN ('adagents_json', 'aao_hosted')`,
+        [domain],
+      );
+
+      await client.query(
+        `DELETE FROM catalog_identifiers ci
+          USING catalog_properties cp
+         WHERE ci.property_rid = cp.property_rid
+           AND cp.created_by = $1`,
+        [adagentsCreatedBy(domain)],
+      );
+
+      await client.query(
+        `DELETE FROM catalog_properties WHERE created_by = $1`,
+        [adagentsCreatedBy(domain)],
+      );
+
+      await this.collectionCatalog.retireMissingAdagentsCollections(
+        client,
+        domain,
+        [],
+        adagentsCreatedBy(domain),
+      );
+
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
   async upsertAdagentsCache(input: UpsertAdagentsCacheInput): Promise<UpsertAdagentsCacheResult> {
     const domain = canonicalizePublisherDomain(input.domain);
     const client = await getClient();
@@ -968,6 +1090,8 @@ export class PublisherDatabase {
            resolved_url = EXCLUDED.resolved_url,
            discovery_method = EXCLUDED.discovery_method,
            manager_domain = EXCLUDED.manager_domain,
+           last_validation_error = NULL,
+           last_validation_issues = NULL,
            updated_at = NOW()`,
         [
           domain,

--- a/server/src/db/publisher-db.ts
+++ b/server/src/db/publisher-db.ts
@@ -1013,14 +1013,14 @@ export class PublisherDatabase {
           USING discovered_properties dp
          WHERE apa.property_id = dp.id
            AND dp.publisher_domain = $1
-           AND dp.source_type IN ('adagents_json', 'aao_hosted')`,
+           AND dp.source_type = 'adagents_json'`,
         [domain],
       );
 
       await client.query(
         `DELETE FROM discovered_properties
           WHERE publisher_domain = $1
-            AND source_type IN ('adagents_json', 'aao_hosted')`,
+            AND source_type = 'adagents_json'`,
         [domain],
       );
 

--- a/server/src/federated-index.ts
+++ b/server/src/federated-index.ts
@@ -371,6 +371,10 @@ export class FederatedIndexService {
     await this.db.markPublisherHasValidAdagents(domain);
   }
 
+  async markPublisherHasInvalidAdagents(domain: string): Promise<void> {
+    await this.db.markPublisherHasInvalidAdagents(domain);
+  }
+
   // ============================================
   // Sales-candidate probe lifecycle
   // ============================================

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -1302,7 +1302,7 @@ registry.registerPath({
   operationId: "revalidatePublisherAdagents",
   summary: "Revalidate publisher adagents.json",
   description:
-    "Admin-only endpoint for support/operator tooling to synchronously fetch a publisher's live `/.well-known/adagents.json`, run the registry validator, persist the refreshed verdict and fetch metadata, and return the validation result. `force=true` is accepted for operator tooling; the current validator always fetches the live origin.",
+    "Admin-only endpoint for support/operator tooling to synchronously fetch a publisher's live `/.well-known/adagents.json`, run the registry validator, persist the refreshed verdict and fetch metadata, and return the validation result. `force=true` is accepted for operator tooling; the current validator always fetches the live origin.\n\n**Rate limits:** 5 minutes per domain, 30 requests per user per hour.",
   tags: ["Authorization Lookups"],
   security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
@@ -1310,7 +1310,7 @@ registry.registerPath({
       domain: z.string().openapi({ example: "publisher.example" }),
     }),
     query: z.object({
-      force: z.coerce.boolean().optional().openapi({ description: "Accepted for tooling compatibility; live origin validation is always performed." }),
+      force: z.enum(["true", "1"]).optional().openapi({ description: "Accepted for tooling compatibility; live origin validation is always performed." }),
     }),
   },
   responses: {
@@ -1318,6 +1318,17 @@ registry.registerPath({
     400: { description: "Invalid domain format, private IP, or unresolvable domain", content: { "application/json": { schema: ErrorSchema } } },
     401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
     403: { description: "Admin access required", content: { "application/json": { schema: ErrorSchema } } },
+    429: {
+      description: "Rate limit exceeded",
+      content: {
+        "application/json": {
+          schema: z.object({
+            error: z.string(),
+            retry_after: z.number().int().openapi({ description: "Seconds to wait before retrying" }),
+          }),
+        },
+      },
+    },
   },
 });
 
@@ -9412,8 +9423,9 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
     req: import('express').Request,
     res: import('express').Response,
     rateLimitKey: string,
+    domainOverride?: string,
   ): Promise<string | null> {
-    const { domain } = req.body;
+    const domain = domainOverride ?? req.body?.domain;
     if (!domain || typeof domain !== 'string') {
       res.status(400).json({ error: "domain is required" });
       return null;
@@ -9476,13 +9488,8 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         return res.status(400).json({ error: "Invalid domain" });
       }
 
-      let normalizedDomain: string;
-      try {
-        normalizedDomain = await validateCrawlDomain(rawDomain);
-      } catch (err) {
-        const message = err instanceof Error ? err.message : 'Invalid domain';
-        return res.status(400).json({ error: message });
-      }
+      const normalizedDomain = await validateAndRateLimitCrawl(req, res, rawDomain, rawDomain);
+      if (!normalizedDomain) return;
 
       const force = req.query.force === 'true' || req.query.force === '1';
       const result = await crawler.revalidatePublisherAdagents(normalizedDomain, { force });

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -1270,6 +1270,57 @@ registry.registerPath({
   },
 });
 
+const PublisherAdagentsRevalidationResultSchema = z.object({
+  domain: z.string(),
+  adagents_valid: z.boolean(),
+  checked_at: z.string().datetime(),
+  error: z.string().optional(),
+  issues: z.object({
+    errors: z.array(z.object({
+      field: z.string(),
+      message: z.string(),
+      severity: z.literal("error"),
+    })),
+    warnings: z.array(z.object({
+      field: z.string(),
+      message: z.string(),
+      suggestion: z.string().optional(),
+    })),
+  }).optional(),
+  properties_count: z.number().int().nonnegative().optional(),
+  authorized_agents_count: z.number().int().nonnegative().optional(),
+  status_code: z.number().int().min(100).max(599).optional(),
+  response_bytes: z.number().int().nonnegative().optional(),
+  resolved_url: z.string().optional(),
+  discovery_method: z.enum(["direct", "authoritative_location", "ads_txt_managerdomain", "adagents_authoritative"]).optional(),
+  manager_domain: z.string().optional(),
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/registry/publisher/{domain}/adagents/revalidate",
+  operationId: "revalidatePublisherAdagents",
+  summary: "Revalidate publisher adagents.json",
+  description:
+    "Admin-only endpoint for support/operator tooling to synchronously fetch a publisher's live `/.well-known/adagents.json`, run the registry validator, persist the refreshed verdict and fetch metadata, and return the validation result. `force=true` is accepted for operator tooling; the current validator always fetches the live origin.",
+  tags: ["Authorization Lookups"],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
+  request: {
+    params: z.object({
+      domain: z.string().openapi({ example: "publisher.example" }),
+    }),
+    query: z.object({
+      force: z.coerce.boolean().optional().openapi({ description: "Accepted for tooling compatibility; live origin validation is always performed." }),
+    }),
+  },
+  responses: {
+    200: { description: "Revalidation result", content: { "application/json": { schema: PublisherAdagentsRevalidationResultSchema } } },
+    400: { description: "Invalid domain format, private IP, or unresolvable domain", content: { "application/json": { schema: ErrorSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
+    403: { description: "Admin access required", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
 registry.registerPath({
   method: "get",
   path: "/api/registry/publisher/authorization",
@@ -5600,6 +5651,21 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
     return (req as Request & { isStaticAdminApiKey?: boolean }).isStaticAdminApiKey === true;
   }
 
+  async function isRegistryAdminRequest(req: Request): Promise<boolean> {
+    if (isStaticAdminRequest(req)) return true;
+    const user = req.user as ({ id?: string; email?: string; isAdmin?: boolean } | undefined);
+    if (!user) return false;
+    if (user.isAdmin === true) return true;
+
+    const devUser = isDevModeEnabled() ? getDevUser(req) : null;
+    if (devUser?.isAdmin === true) return true;
+
+    const adminEmails = process.env.ADMIN_EMAILS?.split(',').map(e => e.trim().toLowerCase()) ?? [];
+    if (user.email && adminEmails.includes(user.email.toLowerCase())) return true;
+    if (!user.id) return false;
+    return isWebUserAAOAdmin(user.id);
+  }
+
   router.get(
     "/registry/agents/:encodedUrl/storyboard-status",
     ...memberReadMiddleware,
@@ -9393,6 +9459,40 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
   }
 
   if (!authMiddleware) throw new Error('requireAuth middleware is required for crawl-request endpoint');
+
+  router.post("/registry/publisher/:domain/adagents/revalidate", authMiddleware, async (req, res) => {
+    try {
+      if (!req.user && !isStaticAdminRequest(req)) {
+        return res.status(401).json({ error: "Authentication required" });
+      }
+      if (!(await isRegistryAdminRequest(req))) {
+        return res.status(403).json({ error: "Admin access required" });
+      }
+
+      const rawDomain = typeof req.params.domain === 'string'
+        ? extractDomain(req.params.domain)
+        : '';
+      if (!rawDomain || !isValidDomain(rawDomain)) {
+        return res.status(400).json({ error: "Invalid domain" });
+      }
+
+      let normalizedDomain: string;
+      try {
+        normalizedDomain = await validateCrawlDomain(rawDomain);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Invalid domain';
+        return res.status(400).json({ error: message });
+      }
+
+      const force = req.query.force === 'true' || req.query.force === '1';
+      const result = await crawler.revalidatePublisherAdagents(normalizedDomain, { force });
+      return res.json(result);
+    } catch (error) {
+      logger.error({ error, path: req.path }, "Failed to revalidate publisher adagents.json");
+      return res.status(500).json({ error: "Failed to revalidate publisher adagents.json" });
+    }
+  });
+
   router.post("/registry/crawl-request", authMiddleware, async (req, res) => {
     try {
       const normalizedDomain = await validateAndRateLimitCrawl(req, res, req.body?.domain?.toLowerCase?.()?.trim?.() || '');

--- a/server/tests/integration/publisher-adagents-revalidate-db.test.ts
+++ b/server/tests/integration/publisher-adagents-revalidate-db.test.ts
@@ -1,0 +1,297 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import type { Pool } from 'pg';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { CrawlerService } from '../../src/crawler.js';
+import { FederatedIndexService } from '../../src/federated-index.js';
+import { PublisherDatabase } from '../../src/db/publisher-db.js';
+import { createRegistryApiRouter, type RegistryApiConfig } from '../../src/routes/registry-api.js';
+
+const TEST_DATABASE_URL = process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test';
+const DOMAIN = `revalidate-${Date.now()}.registry-test.example`;
+const AGENT = 'https://sales-agent.example/mcp/storefront';
+const STALE_AGENT = 'https://stale-agent.example/mcp';
+
+function makeCrawler(validation: unknown) {
+  const proto = CrawlerService.prototype as unknown as Record<string, unknown>;
+  const ctx = Object.create(proto) as CrawlerService & Record<string, unknown>;
+  Object.assign(ctx, {
+    adAgentsManager: {
+      validateDomain: vi.fn().mockResolvedValue(validation),
+    },
+    federatedIndex: new FederatedIndexService(),
+    publisherDb: new PublisherDatabase(),
+    eventsDb: undefined,
+    fanOutPublisherPropertiesAuthorizations: vi.fn().mockResolvedValue(undefined),
+    scanBrandForDomain: vi.fn().mockResolvedValue(undefined),
+    buildInventoryProfiles: vi.fn().mockResolvedValue(new Map()),
+  });
+  return ctx;
+}
+
+async function cleanup(pool: Pool) {
+  await pool.query(
+    `DELETE FROM agent_property_authorizations apa
+      USING discovered_properties dp
+     WHERE apa.property_id = dp.id
+       AND (dp.publisher_domain = $1 OR apa.agent_url = ANY($2::text[]))`,
+    [DOMAIN, [AGENT, STALE_AGENT]],
+  );
+  await pool.query(
+    `DELETE FROM discovered_properties WHERE publisher_domain = $1`,
+    [DOMAIN],
+  );
+  await pool.query(
+    `DELETE FROM catalog_agent_authorizations
+      WHERE publisher_domain = $1 OR agent_url = ANY($2::text[])`,
+    [DOMAIN, [AGENT, STALE_AGENT]],
+  );
+  await pool.query(
+    `DELETE FROM agent_publisher_authorizations
+      WHERE publisher_domain = $1 OR agent_url = ANY($2::text[])`,
+    [DOMAIN, [AGENT, STALE_AGENT]],
+  );
+  await pool.query(
+    `DELETE FROM discovered_publishers
+      WHERE domain = $1 OR discovered_by_agent = ANY($2::text[])`,
+    [DOMAIN, [AGENT, STALE_AGENT]],
+  );
+  await pool.query(
+    `DELETE FROM discovered_agents WHERE agent_url = ANY($1::text[])`,
+    [[AGENT, STALE_AGENT]],
+  );
+  await pool.query(
+    `DELETE FROM catalog_identifiers
+      WHERE property_rid IN (
+        SELECT property_rid FROM catalog_properties WHERE created_by = $1
+      )`,
+    [`adagents_json:${DOMAIN}`],
+  );
+  await pool.query(
+    `DELETE FROM catalog_properties WHERE created_by = $1`,
+    [`adagents_json:${DOMAIN}`],
+  );
+  await pool.query(`DELETE FROM publishers WHERE domain = $1`, [DOMAIN]);
+}
+
+function buildLookupApp(federatedIndex: FederatedIndexService) {
+  const app = express();
+  app.use(express.json());
+
+  const requireAuth: import('express').RequestHandler = (req, _res, next) => {
+    req.user = { id: 'admin_user', email: 'admin@example.com', isAdmin: true } as typeof req.user;
+    next();
+  };
+
+  app.use('/api', createRegistryApiRouter({
+    brandManager: {} as RegistryApiConfig['brandManager'],
+    brandDb: {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(null),
+      getHostedBrandByDomain: vi.fn().mockResolvedValue(null),
+    } as unknown as RegistryApiConfig['brandDb'],
+    propertyDb: {
+      getHostedPropertyByDomain: vi.fn().mockResolvedValue(null),
+    } as unknown as RegistryApiConfig['propertyDb'],
+    adagentsManager: {} as RegistryApiConfig['adagentsManager'],
+    healthChecker: {} as RegistryApiConfig['healthChecker'],
+    crawler: {
+      getFederatedIndex: () => federatedIndex,
+      crawlSingleDomain: vi.fn().mockResolvedValue(undefined),
+      scanBrandForDomain: vi.fn().mockResolvedValue(undefined),
+    } as unknown as RegistryApiConfig['crawler'],
+    capabilityDiscovery: {} as RegistryApiConfig['capabilityDiscovery'],
+    registryRequestsDb: {
+      trackRequest: async () => {},
+      markResolved: async () => true,
+    },
+    requireAuth,
+    optionalAuth: requireAuth,
+  }));
+
+  return app;
+}
+
+describe('publisher adagents manual revalidation DB path', () => {
+  let pool: Pool;
+  let federatedIndex: FederatedIndexService;
+  let lookupApp: express.Express;
+
+  beforeAll(async () => {
+    process.env.DATABASE_URL = TEST_DATABASE_URL;
+    pool = initializeDatabase({ connectionString: TEST_DATABASE_URL });
+    await runMigrations();
+    federatedIndex = new FederatedIndexService();
+    lookupApp = buildLookupApp(federatedIndex);
+  });
+
+  beforeEach(async () => {
+    await cleanup(pool);
+  });
+
+  afterAll(async () => {
+    await cleanup(pool);
+    await closeDatabase();
+  });
+
+  it('updates the lookupPublisher verdict from stale invalid to live valid', async () => {
+    await federatedIndex.recordPublisherFromAgent(DOMAIN, STALE_AGENT, false);
+    expect(await federatedIndex.hasValidAdagents(DOMAIN)).toBe(false);
+
+    const crawler = makeCrawler({
+      valid: true,
+      errors: [],
+      warnings: [],
+      domain: DOMAIN,
+      url: `https://${DOMAIN}/.well-known/adagents.json`,
+      status_code: 200,
+      response_bytes: 512,
+      resolved_url: `https://${DOMAIN}/.well-known/adagents.json`,
+      discovery_method: 'direct',
+      raw_data: {
+        authorized_agents: [{ url: AGENT, authorized_for: 'Direct storefront sales' }],
+        properties: [
+          {
+            property_id: 'talpa-site',
+            property_type: 'website',
+            name: 'Example site',
+            identifiers: [{ type: 'domain', value: DOMAIN }],
+          },
+        ],
+      },
+    });
+
+    const result = await crawler.revalidatePublisherAdagents(DOMAIN, { force: true });
+
+    expect(result).toMatchObject({
+      domain: DOMAIN,
+      adagents_valid: true,
+      status_code: 200,
+      properties_count: 1,
+      authorized_agents_count: 1,
+    });
+    expect(await federatedIndex.hasValidAdagents(DOMAIN)).toBe(true);
+    const authorizations = await federatedIndex.getAuthorizationsForDomain(DOMAIN);
+    expect(authorizations).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        agent_url: AGENT,
+        publisher_domain: DOMAIN,
+        source: 'adagents_json',
+      }),
+    ]));
+    const lookup = await request(lookupApp)
+      .get('/api/registry/publisher')
+      .query({ domain: DOMAIN });
+    expect(lookup.status).toBe(200);
+    expect(lookup.body).toMatchObject({
+      domain: DOMAIN,
+      adagents_valid: true,
+      files: {
+        adagents_json: {
+          status: 'valid',
+        },
+      },
+    });
+  });
+
+  it('persists invalid revalidation and retires stale adagents authorizations', async () => {
+    const validCrawler = makeCrawler({
+      valid: true,
+      errors: [],
+      warnings: [],
+      domain: DOMAIN,
+      url: `https://${DOMAIN}/.well-known/adagents.json`,
+      status_code: 200,
+      response_bytes: 512,
+      resolved_url: `https://${DOMAIN}/.well-known/adagents.json`,
+      discovery_method: 'direct',
+      raw_data: {
+        authorized_agents: [{ url: AGENT, authorized_for: 'Direct storefront sales' }],
+        properties: [],
+      },
+    });
+    await validCrawler.revalidatePublisherAdagents(DOMAIN);
+    expect(await federatedIndex.hasValidAdagents(DOMAIN)).toBe(true);
+    await federatedIndex.recordProperty({
+      property_id: 'stale-site',
+      publisher_domain: DOMAIN,
+      property_type: 'website',
+      name: 'Stale site',
+      identifiers: [{ type: 'domain', value: DOMAIN }],
+      tags: ['stale'],
+    }, STALE_AGENT, 'Legacy stale authorization');
+
+    const staleLookup = await request(lookupApp)
+      .get('/api/registry/publisher')
+      .query({ domain: DOMAIN });
+    expect(staleLookup.status).toBe(200);
+    expect(staleLookup.body.properties).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'stale-site',
+        source: 'adagents_json',
+      }),
+    ]));
+
+    const invalidCrawler = makeCrawler({
+      valid: false,
+      errors: [{ field: 'http_status', message: 'File not found', severity: 'error' }],
+      warnings: [],
+      domain: DOMAIN,
+      url: `https://${DOMAIN}/.well-known/adagents.json`,
+      status_code: 404,
+      response_bytes: 32,
+      resolved_url: `https://${DOMAIN}/.well-known/adagents.json`,
+      discovery_method: 'direct',
+    });
+
+    const result = await invalidCrawler.revalidatePublisherAdagents(DOMAIN);
+
+    expect(result).toMatchObject({
+      domain: DOMAIN,
+      adagents_valid: false,
+      error: 'File not found',
+      status_code: 404,
+    });
+    expect(await federatedIndex.hasValidAdagents(DOMAIN)).toBe(false);
+    const lookup = await request(lookupApp)
+      .get('/api/registry/publisher')
+      .query({ domain: DOMAIN });
+    expect(lookup.status).toBe(200);
+    expect(lookup.body).toMatchObject({
+      domain: DOMAIN,
+      adagents_valid: false,
+      files: {
+        adagents_json: {
+          status: 'invalid',
+        },
+      },
+    });
+    expect(lookup.body.properties).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'stale-site',
+        source: 'adagents_json',
+      }),
+    ]));
+    const staleAgentProperties = await federatedIndex.getPropertiesForAgent(STALE_AGENT);
+    expect(staleAgentProperties.filter((property) => property.publisher_domain === DOMAIN)).toHaveLength(0);
+    const authorizations = await federatedIndex.getAuthorizationsForDomain(DOMAIN);
+    expect(authorizations.filter((auth) => auth.source === 'adagents_json')).toHaveLength(0);
+    const publisher = await pool.query<{
+      source_type: string;
+      adagents_json: unknown;
+      last_validation_error: string | null;
+      last_http_status: number | null;
+    }>(
+      `SELECT source_type, adagents_json, last_validation_error, last_http_status
+         FROM publishers WHERE domain = $1`,
+      [DOMAIN],
+    );
+    expect(publisher.rows[0]).toMatchObject({
+      source_type: 'community',
+      adagents_json: null,
+      last_validation_error: 'File not found',
+      last_http_status: 404,
+    });
+  });
+});

--- a/server/tests/integration/publisher-adagents-revalidate-db.test.ts
+++ b/server/tests/integration/publisher-adagents-revalidate-db.test.ts
@@ -13,6 +13,9 @@ const TEST_DATABASE_URL = process.env.DATABASE_URL || 'postgresql://adcp:localde
 const DOMAIN = `revalidate-${Date.now()}.registry-test.example`;
 const AGENT = 'https://sales-agent.example/mcp/storefront';
 const STALE_AGENT = 'https://stale-agent.example/mcp';
+const HOSTED_AGENT = 'https://hosted-agent.example/mcp';
+
+const TEST_AGENTS = [AGENT, STALE_AGENT, HOSTED_AGENT];
 
 function makeCrawler(validation: unknown) {
   const proto = CrawlerService.prototype as unknown as Record<string, unknown>;
@@ -37,7 +40,7 @@ async function cleanup(pool: Pool) {
       USING discovered_properties dp
      WHERE apa.property_id = dp.id
        AND (dp.publisher_domain = $1 OR apa.agent_url = ANY($2::text[]))`,
-    [DOMAIN, [AGENT, STALE_AGENT]],
+    [DOMAIN, TEST_AGENTS],
   );
   await pool.query(
     `DELETE FROM discovered_properties WHERE publisher_domain = $1`,
@@ -46,21 +49,21 @@ async function cleanup(pool: Pool) {
   await pool.query(
     `DELETE FROM catalog_agent_authorizations
       WHERE publisher_domain = $1 OR agent_url = ANY($2::text[])`,
-    [DOMAIN, [AGENT, STALE_AGENT]],
+    [DOMAIN, TEST_AGENTS],
   );
   await pool.query(
     `DELETE FROM agent_publisher_authorizations
       WHERE publisher_domain = $1 OR agent_url = ANY($2::text[])`,
-    [DOMAIN, [AGENT, STALE_AGENT]],
+    [DOMAIN, TEST_AGENTS],
   );
   await pool.query(
     `DELETE FROM discovered_publishers
       WHERE domain = $1 OR discovered_by_agent = ANY($2::text[])`,
-    [DOMAIN, [AGENT, STALE_AGENT]],
+    [DOMAIN, TEST_AGENTS],
   );
   await pool.query(
     `DELETE FROM discovered_agents WHERE agent_url = ANY($1::text[])`,
-    [[AGENT, STALE_AGENT]],
+    [TEST_AGENTS],
   );
   await pool.query(
     `DELETE FROM catalog_identifiers
@@ -221,6 +224,22 @@ describe('publisher adagents manual revalidation DB path', () => {
       identifiers: [{ type: 'domain', value: DOMAIN }],
       tags: ['stale'],
     }, STALE_AGENT, 'Legacy stale authorization');
+    const hostedProperty = await pool.query<{ id: string }>(
+      `INSERT INTO discovered_properties
+         (property_id, publisher_domain, property_type, name, identifiers, tags, source_type)
+       VALUES ($1, $2, 'website', 'Hosted site', $3::jsonb, ARRAY['hosted']::text[], 'aao_hosted')
+       RETURNING id`,
+      [
+        'hosted-site',
+        DOMAIN,
+        JSON.stringify([{ type: 'domain', value: `hosted.${DOMAIN}` }]),
+      ],
+    );
+    await pool.query(
+      `INSERT INTO agent_property_authorizations (agent_url, property_id, authorized_for)
+       VALUES ($1, $2, 'Hosted authorization')`,
+      [HOSTED_AGENT, hostedProperty.rows[0].id],
+    );
 
     const staleLookup = await request(lookupApp)
       .get('/api/registry/publisher')
@@ -229,6 +248,12 @@ describe('publisher adagents manual revalidation DB path', () => {
     expect(staleLookup.body.properties).toEqual(expect.arrayContaining([
       expect.objectContaining({
         id: 'stale-site',
+        source: 'adagents_json',
+      }),
+    ]));
+    expect(staleLookup.body.properties).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'hosted-site',
         source: 'adagents_json',
       }),
     ]));
@@ -273,8 +298,21 @@ describe('publisher adagents manual revalidation DB path', () => {
         source: 'adagents_json',
       }),
     ]));
+    expect(lookup.body.properties).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'hosted-site',
+        source: 'adagents_json',
+      }),
+    ]));
     const staleAgentProperties = await federatedIndex.getPropertiesForAgent(STALE_AGENT);
     expect(staleAgentProperties.filter((property) => property.publisher_domain === DOMAIN)).toHaveLength(0);
+    const hostedAgentProperties = await federatedIndex.getPropertiesForAgent(HOSTED_AGENT);
+    expect(hostedAgentProperties).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        publisher_domain: DOMAIN,
+        property_id: 'hosted-site',
+      }),
+    ]));
     const authorizations = await federatedIndex.getAuthorizationsForDomain(DOMAIN);
     expect(authorizations.filter((auth) => auth.source === 'adagents_json')).toHaveLength(0);
     const publisher = await pool.query<{
@@ -293,5 +331,83 @@ describe('publisher adagents manual revalidation DB path', () => {
       last_validation_error: 'File not found',
       last_http_status: 404,
     });
+  });
+
+  it('records transient revalidation failures without retiring the cached authorization graph', async () => {
+    const validCrawler = makeCrawler({
+      valid: true,
+      errors: [],
+      warnings: [],
+      domain: DOMAIN,
+      url: `https://${DOMAIN}/.well-known/adagents.json`,
+      status_code: 200,
+      response_bytes: 512,
+      resolved_url: `https://${DOMAIN}/.well-known/adagents.json`,
+      discovery_method: 'direct',
+      raw_data: {
+        authorized_agents: [{ url: AGENT, authorized_for: 'Direct storefront sales' }],
+        properties: [],
+      },
+    });
+    await validCrawler.revalidatePublisherAdagents(DOMAIN);
+    expect(await federatedIndex.hasValidAdagents(DOMAIN)).toBe(true);
+
+    const transientCrawler = makeCrawler({
+      valid: false,
+      errors: [{ field: 'http_status', message: 'HTTP 503 error fetching adagents.json', severity: 'error' }],
+      warnings: [],
+      domain: DOMAIN,
+      url: `https://${DOMAIN}/.well-known/adagents.json`,
+      status_code: 503,
+      response_bytes: 24,
+      resolved_url: `https://${DOMAIN}/.well-known/adagents.json`,
+      discovery_method: 'direct',
+    });
+
+    const result = await transientCrawler.revalidatePublisherAdagents(DOMAIN);
+
+    expect(result).toMatchObject({
+      domain: DOMAIN,
+      adagents_valid: false,
+      error: 'HTTP 503 error fetching adagents.json',
+      status_code: 503,
+    });
+    expect(await federatedIndex.hasValidAdagents(DOMAIN)).toBe(true);
+    const authorizations = await federatedIndex.getAuthorizationsForDomain(DOMAIN);
+    expect(authorizations).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        agent_url: AGENT,
+        publisher_domain: DOMAIN,
+        source: 'adagents_json',
+      }),
+    ]));
+    const lookup = await request(lookupApp)
+      .get('/api/registry/publisher')
+      .query({ domain: DOMAIN });
+    expect(lookup.status).toBe(200);
+    expect(lookup.body).toMatchObject({
+      domain: DOMAIN,
+      adagents_valid: true,
+      files: {
+        adagents_json: {
+          status: 'valid',
+        },
+      },
+      hosting: {
+        last_http_status: 503,
+      },
+    });
+  });
+
+  it('does not let routine failed-fetch metadata override legacy valid adagents state', async () => {
+    await federatedIndex.recordPublisherFromAgent(DOMAIN, STALE_AGENT, true);
+    await new PublisherDatabase().recordFailedAdagentsFetch({
+      domain: DOMAIN,
+      statusCode: 503,
+      responseBytes: 24,
+      resolvedUrl: `https://${DOMAIN}/.well-known/adagents.json`,
+    });
+
+    expect(await federatedIndex.hasValidAdagents(DOMAIN)).toBe(true);
   });
 });

--- a/server/tests/unit/crawler-single-domain-profile-rebuild.test.ts
+++ b/server/tests/unit/crawler-single-domain-profile-rebuild.test.ts
@@ -70,4 +70,235 @@ describe('CrawlerService single-domain profile rebuild', () => {
       deleteStale: false,
     });
   });
+
+  it('manual adagents revalidation persists a successful verdict and refreshed authorizations', async () => {
+    const { CrawlerService } = await import('../../src/crawler.js');
+    const proto = (CrawlerService as any).prototype;
+    const ctx = Object.create(proto);
+
+    Object.assign(ctx, {
+      adAgentsManager: {
+        validateDomain: vi.fn().mockResolvedValue({
+          valid: true,
+          errors: [],
+          warnings: [],
+          domain: 'publisher.example',
+          url: 'https://publisher.example/.well-known/adagents.json',
+          raw_data: {
+            authorized_agents: [{ url: 'https://new-agent.example/mcp/', authorized_for: 'display' }],
+            properties: [{ property_id: 'site', property_type: 'website', name: 'Site' }],
+          },
+          status_code: 200,
+          response_bytes: 256,
+          resolved_url: 'https://publisher.example/.well-known/adagents.json',
+          discovery_method: 'direct',
+        }),
+      },
+      federatedIndex: {
+        getAuthorizationsForDomain: vi.fn().mockResolvedValue([
+          { agent_url: 'https://old-agent.example/mcp/', source: 'adagents_json' },
+        ]),
+        markPublisherHasValidAdagents: vi.fn().mockResolvedValue(undefined),
+        recordAgentFromAdagentsJson: vi.fn().mockResolvedValue(undefined),
+        reconcileAdagentsAuthorizations: vi.fn().mockResolvedValue(undefined),
+      },
+      publisherDb: {
+        recordAdagentsValidationFailure: vi.fn().mockResolvedValue(undefined),
+      },
+      cacheAdagentsManifest: vi.fn().mockResolvedValue(undefined),
+      recordPropertiesForAgent: vi.fn().mockResolvedValue(undefined),
+      fanOutPublisherPropertiesAuthorizations: vi.fn().mockResolvedValue(undefined),
+      reconcileLegacyAdagentsAgents: vi.fn().mockResolvedValue(undefined),
+      scanBrandForDomain: vi.fn().mockResolvedValue(undefined),
+      buildInventoryProfiles: vi.fn().mockResolvedValue(new Map()),
+    });
+
+    const result = await ctx.revalidatePublisherAdagents('publisher.example', { force: true });
+
+    expect(result).toMatchObject({
+      domain: 'publisher.example',
+      adagents_valid: true,
+      properties_count: 1,
+      authorized_agents_count: 1,
+      status_code: 200,
+    });
+    expect(ctx.cacheAdagentsManifest).toHaveBeenCalledWith(
+      'publisher.example',
+      expect.objectContaining({ authorized_agents: expect.any(Array) }),
+      expect.objectContaining({ statusCode: 200, discoveryMethod: 'direct' }),
+    );
+    expect(ctx.federatedIndex.markPublisherHasValidAdagents).toHaveBeenCalledWith('publisher.example');
+    expect(ctx.federatedIndex.recordAgentFromAdagentsJson).toHaveBeenCalledWith(
+      'https://new-agent.example/mcp/',
+      'publisher.example',
+      'display',
+      undefined,
+    );
+    expect(ctx.buildInventoryProfiles).toHaveBeenCalledWith({
+      agentUrls: ['https://old-agent.example/mcp', 'https://new-agent.example/mcp'],
+      deleteStale: false,
+    });
+  });
+
+  it('manual adagents revalidation returns warnings for a valid manifest', async () => {
+    const { CrawlerService } = await import('../../src/crawler.js');
+    const proto = (CrawlerService as any).prototype;
+    const ctx = Object.create(proto);
+
+    Object.assign(ctx, {
+      adAgentsManager: {
+        validateDomain: vi.fn().mockResolvedValue({
+          valid: true,
+          errors: [],
+          warnings: [{ field: '$schema', message: 'Missing schema declaration' }],
+          domain: 'publisher.example',
+          url: 'https://publisher.example/.well-known/adagents.json',
+          raw_data: {
+            authorized_agents: [{ url: 'https://new-agent.example/mcp/' }],
+            properties: [],
+          },
+          status_code: 200,
+          response_bytes: 128,
+          resolved_url: 'https://publisher.example/.well-known/adagents.json',
+          discovery_method: 'direct',
+        }),
+      },
+      federatedIndex: {
+        getAuthorizationsForDomain: vi.fn().mockResolvedValue([]),
+        markPublisherHasValidAdagents: vi.fn().mockResolvedValue(undefined),
+        recordAgentFromAdagentsJson: vi.fn().mockResolvedValue(undefined),
+        reconcileAdagentsAuthorizations: vi.fn().mockResolvedValue(undefined),
+      },
+      publisherDb: {},
+      cacheAdagentsManifest: vi.fn().mockResolvedValue(undefined),
+      recordPropertiesForAgent: vi.fn().mockResolvedValue(undefined),
+      fanOutPublisherPropertiesAuthorizations: vi.fn().mockResolvedValue(undefined),
+      reconcileLegacyAdagentsAgents: vi.fn().mockResolvedValue(undefined),
+      scanBrandForDomain: vi.fn().mockResolvedValue(undefined),
+      buildInventoryProfiles: vi.fn().mockResolvedValue(new Map()),
+    });
+
+    const result = await ctx.revalidatePublisherAdagents('publisher.example');
+
+    expect(result).toMatchObject({
+      domain: 'publisher.example',
+      adagents_valid: true,
+      issues: {
+        errors: [],
+        warnings: [{ field: '$schema', message: 'Missing schema declaration' }],
+      },
+    });
+  });
+
+  it('manual adagents revalidation persists an invalid verdict and retires stale authorizations', async () => {
+    const { CrawlerService } = await import('../../src/crawler.js');
+    const proto = (CrawlerService as any).prototype;
+    const ctx = Object.create(proto);
+
+    Object.assign(ctx, {
+      adAgentsManager: {
+        validateDomain: vi.fn().mockResolvedValue({
+          valid: false,
+          errors: [{ field: 'http_status', message: 'File not found', severity: 'error' }],
+          warnings: [],
+          domain: 'publisher.example',
+          url: 'https://publisher.example/.well-known/adagents.json',
+          status_code: 404,
+          response_bytes: 32,
+          resolved_url: 'https://publisher.example/.well-known/adagents.json',
+          discovery_method: 'direct',
+        }),
+      },
+      federatedIndex: {
+        getAuthorizationsForDomain: vi.fn().mockResolvedValue([
+          { agent_url: 'https://old-agent.example/mcp/', source: 'adagents_json' },
+          { agent_url: 'https://claimed-agent.example/mcp', source: 'agent_claim' },
+        ]),
+        markPublisherHasInvalidAdagents: vi.fn().mockResolvedValue(undefined),
+        reconcileAdagentsAuthorizations: vi.fn().mockResolvedValue(undefined),
+      },
+      publisherDb: {
+        recordAdagentsValidationFailure: vi.fn().mockResolvedValue(undefined),
+      },
+      scanBrandForDomain: vi.fn().mockResolvedValue(undefined),
+      buildInventoryProfiles: vi.fn().mockResolvedValue(new Map()),
+    });
+
+    const result = await ctx.revalidatePublisherAdagents('publisher.example');
+
+    expect(result).toMatchObject({
+      domain: 'publisher.example',
+      adagents_valid: false,
+      error: 'File not found',
+      properties_count: 0,
+      authorized_agents_count: 0,
+      status_code: 404,
+    });
+    expect(ctx.publisherDb.recordAdagentsValidationFailure).toHaveBeenCalledWith(expect.objectContaining({
+      domain: 'publisher.example',
+      statusCode: 404,
+      error: 'File not found',
+      issues: {
+        errors: [{ field: 'http_status', message: 'File not found', severity: 'error' }],
+        warnings: [],
+      },
+    }));
+    expect(ctx.federatedIndex.markPublisherHasInvalidAdagents).toHaveBeenCalledWith('publisher.example');
+    expect(ctx.federatedIndex.reconcileAdagentsAuthorizations).toHaveBeenCalledWith('publisher.example', []);
+    expect(ctx.buildInventoryProfiles).toHaveBeenCalledWith({
+      agentUrls: ['https://old-agent.example/mcp'],
+      deleteStale: false,
+    });
+  });
+
+  it('manual adagents revalidation persists schema-invalid 200 responses as invalid', async () => {
+    const { CrawlerService } = await import('../../src/crawler.js');
+    const proto = (CrawlerService as any).prototype;
+    const ctx = Object.create(proto);
+
+    Object.assign(ctx, {
+      adAgentsManager: {
+        validateDomain: vi.fn().mockResolvedValue({
+          valid: false,
+          errors: [{ field: 'authorized_agents', message: 'authorized_agents must be an array', severity: 'error' }],
+          warnings: [],
+          domain: 'publisher.example',
+          url: 'https://publisher.example/.well-known/adagents.json',
+          raw_data: { authorized_agents: 'not-an-array' },
+          status_code: 200,
+          response_bytes: 96,
+          resolved_url: 'https://publisher.example/.well-known/adagents.json',
+          discovery_method: 'direct',
+        }),
+      },
+      federatedIndex: {
+        getAuthorizationsForDomain: vi.fn().mockResolvedValue([]),
+        markPublisherHasInvalidAdagents: vi.fn().mockResolvedValue(undefined),
+        reconcileAdagentsAuthorizations: vi.fn().mockResolvedValue(undefined),
+      },
+      publisherDb: {
+        recordAdagentsValidationFailure: vi.fn().mockResolvedValue(undefined),
+      },
+      scanBrandForDomain: vi.fn().mockResolvedValue(undefined),
+      buildInventoryProfiles: vi.fn().mockResolvedValue(new Map()),
+    });
+
+    const result = await ctx.revalidatePublisherAdagents('publisher.example');
+
+    expect(result).toMatchObject({
+      domain: 'publisher.example',
+      adagents_valid: false,
+      error: 'authorized_agents must be an array',
+      status_code: 200,
+      issues: {
+        errors: [{ field: 'authorized_agents', message: 'authorized_agents must be an array', severity: 'error' }],
+        warnings: [],
+      },
+    });
+    expect(ctx.publisherDb.recordAdagentsValidationFailure).toHaveBeenCalledWith(expect.objectContaining({
+      domain: 'publisher.example',
+      statusCode: 200,
+      error: 'authorized_agents must be an array',
+    }));
+  });
 });

--- a/server/tests/unit/crawler-single-domain-profile-rebuild.test.ts
+++ b/server/tests/unit/crawler-single-domain-profile-rebuild.test.ts
@@ -251,6 +251,60 @@ describe('CrawlerService single-domain profile rebuild', () => {
     });
   });
 
+  it('manual adagents revalidation preserves cached state on transient fetch failures', async () => {
+    const { CrawlerService } = await import('../../src/crawler.js');
+    const proto = (CrawlerService as any).prototype;
+    const ctx = Object.create(proto);
+
+    Object.assign(ctx, {
+      adAgentsManager: {
+        validateDomain: vi.fn().mockResolvedValue({
+          valid: false,
+          errors: [{ field: 'http_status', message: 'HTTP 503 error fetching https://publisher.example/.well-known/adagents.json', severity: 'error' }],
+          warnings: [],
+          domain: 'publisher.example',
+          url: 'https://publisher.example/.well-known/adagents.json',
+          status_code: 503,
+          response_bytes: 18,
+          resolved_url: 'https://publisher.example/.well-known/adagents.json',
+          discovery_method: 'direct',
+        }),
+      },
+      federatedIndex: {
+        getAuthorizationsForDomain: vi.fn().mockResolvedValue([
+          { agent_url: 'https://old-agent.example/mcp/', source: 'adagents_json' },
+        ]),
+        markPublisherHasInvalidAdagents: vi.fn().mockResolvedValue(undefined),
+        reconcileAdagentsAuthorizations: vi.fn().mockResolvedValue(undefined),
+      },
+      publisherDb: {
+        recordAdagentsValidationFailure: vi.fn().mockResolvedValue(undefined),
+        recordFailedAdagentsFetch: vi.fn().mockResolvedValue(undefined),
+      },
+      scanBrandForDomain: vi.fn().mockResolvedValue(undefined),
+      buildInventoryProfiles: vi.fn().mockResolvedValue(new Map()),
+    });
+
+    const result = await ctx.revalidatePublisherAdagents('publisher.example');
+
+    expect(result).toMatchObject({
+      domain: 'publisher.example',
+      adagents_valid: false,
+      status_code: 503,
+      error: 'HTTP 503 error fetching https://publisher.example/.well-known/adagents.json',
+    });
+    expect(ctx.publisherDb.recordFailedAdagentsFetch).toHaveBeenCalledWith({
+      domain: 'publisher.example',
+      statusCode: 503,
+      responseBytes: 18,
+      resolvedUrl: 'https://publisher.example/.well-known/adagents.json',
+    });
+    expect(ctx.publisherDb.recordAdagentsValidationFailure).not.toHaveBeenCalled();
+    expect(ctx.federatedIndex.markPublisherHasInvalidAdagents).not.toHaveBeenCalled();
+    expect(ctx.federatedIndex.reconcileAdagentsAuthorizations).not.toHaveBeenCalled();
+    expect(ctx.buildInventoryProfiles).not.toHaveBeenCalled();
+  });
+
   it('manual adagents revalidation persists schema-invalid 200 responses as invalid', async () => {
     const { CrawlerService } = await import('../../src/crawler.js');
     const proto = (CrawlerService as any).prototype;

--- a/server/tests/unit/crawler-single-domain-profile-rebuild.test.ts
+++ b/server/tests/unit/crawler-single-domain-profile-rebuild.test.ts
@@ -214,8 +214,6 @@ describe('CrawlerService single-domain profile rebuild', () => {
           { agent_url: 'https://old-agent.example/mcp/', source: 'adagents_json' },
           { agent_url: 'https://claimed-agent.example/mcp', source: 'agent_claim' },
         ]),
-        markPublisherHasInvalidAdagents: vi.fn().mockResolvedValue(undefined),
-        reconcileAdagentsAuthorizations: vi.fn().mockResolvedValue(undefined),
       },
       publisherDb: {
         recordAdagentsValidationFailure: vi.fn().mockResolvedValue(undefined),
@@ -243,8 +241,6 @@ describe('CrawlerService single-domain profile rebuild', () => {
         warnings: [],
       },
     }));
-    expect(ctx.federatedIndex.markPublisherHasInvalidAdagents).toHaveBeenCalledWith('publisher.example');
-    expect(ctx.federatedIndex.reconcileAdagentsAuthorizations).toHaveBeenCalledWith('publisher.example', []);
     expect(ctx.buildInventoryProfiles).toHaveBeenCalledWith({
       agentUrls: ['https://old-agent.example/mcp'],
       deleteStale: false,
@@ -305,6 +301,60 @@ describe('CrawlerService single-domain profile rebuild', () => {
     expect(ctx.buildInventoryProfiles).not.toHaveBeenCalled();
   });
 
+  it('manual adagents revalidation preserves cached state on access-denied origin responses', async () => {
+    const { CrawlerService } = await import('../../src/crawler.js');
+    const proto = (CrawlerService as any).prototype;
+    const ctx = Object.create(proto);
+
+    Object.assign(ctx, {
+      adAgentsManager: {
+        validateDomain: vi.fn().mockResolvedValue({
+          valid: false,
+          errors: [{ field: 'http_status', message: 'HTTP 403 error fetching https://publisher.example/.well-known/adagents.json', severity: 'error' }],
+          warnings: [],
+          domain: 'publisher.example',
+          url: 'https://publisher.example/.well-known/adagents.json',
+          status_code: 403,
+          response_bytes: 42,
+          resolved_url: 'https://publisher.example/.well-known/adagents.json',
+          discovery_method: 'direct',
+        }),
+      },
+      federatedIndex: {
+        getAuthorizationsForDomain: vi.fn().mockResolvedValue([
+          { agent_url: 'https://old-agent.example/mcp/', source: 'adagents_json' },
+        ]),
+        markPublisherHasInvalidAdagents: vi.fn().mockResolvedValue(undefined),
+        reconcileAdagentsAuthorizations: vi.fn().mockResolvedValue(undefined),
+      },
+      publisherDb: {
+        recordAdagentsValidationFailure: vi.fn().mockResolvedValue(undefined),
+        recordFailedAdagentsFetch: vi.fn().mockResolvedValue(undefined),
+      },
+      scanBrandForDomain: vi.fn().mockResolvedValue(undefined),
+      buildInventoryProfiles: vi.fn().mockResolvedValue(new Map()),
+    });
+
+    const result = await ctx.revalidatePublisherAdagents('publisher.example');
+
+    expect(result).toMatchObject({
+      domain: 'publisher.example',
+      adagents_valid: false,
+      status_code: 403,
+      error: 'HTTP 403 error fetching https://publisher.example/.well-known/adagents.json',
+    });
+    expect(ctx.publisherDb.recordFailedAdagentsFetch).toHaveBeenCalledWith({
+      domain: 'publisher.example',
+      statusCode: 403,
+      responseBytes: 42,
+      resolvedUrl: 'https://publisher.example/.well-known/adagents.json',
+    });
+    expect(ctx.publisherDb.recordAdagentsValidationFailure).not.toHaveBeenCalled();
+    expect(ctx.federatedIndex.markPublisherHasInvalidAdagents).not.toHaveBeenCalled();
+    expect(ctx.federatedIndex.reconcileAdagentsAuthorizations).not.toHaveBeenCalled();
+    expect(ctx.buildInventoryProfiles).not.toHaveBeenCalled();
+  });
+
   it('manual adagents revalidation persists schema-invalid 200 responses as invalid', async () => {
     const { CrawlerService } = await import('../../src/crawler.js');
     const proto = (CrawlerService as any).prototype;
@@ -327,8 +377,6 @@ describe('CrawlerService single-domain profile rebuild', () => {
       },
       federatedIndex: {
         getAuthorizationsForDomain: vi.fn().mockResolvedValue([]),
-        markPublisherHasInvalidAdagents: vi.fn().mockResolvedValue(undefined),
-        reconcileAdagentsAuthorizations: vi.fn().mockResolvedValue(undefined),
       },
       publisherDb: {
         recordAdagentsValidationFailure: vi.fn().mockResolvedValue(undefined),

--- a/server/tests/unit/crawler-single-domain-profile-rebuild.test.ts
+++ b/server/tests/unit/crawler-single-domain-profile-rebuild.test.ts
@@ -355,6 +355,114 @@ describe('CrawlerService single-domain profile rebuild', () => {
     expect(ctx.buildInventoryProfiles).not.toHaveBeenCalled();
   });
 
+  it('manual adagents revalidation preserves cached state on unparseable 200 responses', async () => {
+    const { CrawlerService } = await import('../../src/crawler.js');
+    const proto = (CrawlerService as any).prototype;
+    const ctx = Object.create(proto);
+
+    Object.assign(ctx, {
+      adAgentsManager: {
+        validateDomain: vi.fn().mockResolvedValue({
+          valid: false,
+          errors: [{ field: 'json', message: 'Invalid JSON response from https://publisher.example/.well-known/adagents.json', severity: 'error' }],
+          warnings: [],
+          domain: 'publisher.example',
+          url: 'https://publisher.example/.well-known/adagents.json',
+          status_code: 200,
+          response_bytes: 4096,
+          resolved_url: 'https://publisher.example/.well-known/adagents.json',
+          discovery_method: 'direct',
+        }),
+      },
+      federatedIndex: {
+        getAuthorizationsForDomain: vi.fn().mockResolvedValue([
+          { agent_url: 'https://old-agent.example/mcp/', source: 'adagents_json' },
+        ]),
+        markPublisherHasInvalidAdagents: vi.fn().mockResolvedValue(undefined),
+        reconcileAdagentsAuthorizations: vi.fn().mockResolvedValue(undefined),
+      },
+      publisherDb: {
+        recordAdagentsValidationFailure: vi.fn().mockResolvedValue(undefined),
+        recordFailedAdagentsFetch: vi.fn().mockResolvedValue(undefined),
+      },
+      scanBrandForDomain: vi.fn().mockResolvedValue(undefined),
+      buildInventoryProfiles: vi.fn().mockResolvedValue(new Map()),
+    });
+
+    const result = await ctx.revalidatePublisherAdagents('publisher.example');
+
+    expect(result).toMatchObject({
+      domain: 'publisher.example',
+      adagents_valid: false,
+      status_code: 200,
+      error: 'Invalid JSON response from https://publisher.example/.well-known/adagents.json',
+    });
+    expect(ctx.publisherDb.recordFailedAdagentsFetch).toHaveBeenCalledWith({
+      domain: 'publisher.example',
+      statusCode: 200,
+      responseBytes: 4096,
+      resolvedUrl: 'https://publisher.example/.well-known/adagents.json',
+    });
+    expect(ctx.publisherDb.recordAdagentsValidationFailure).not.toHaveBeenCalled();
+    expect(ctx.federatedIndex.markPublisherHasInvalidAdagents).not.toHaveBeenCalled();
+    expect(ctx.federatedIndex.reconcileAdagentsAuthorizations).not.toHaveBeenCalled();
+    expect(ctx.buildInventoryProfiles).not.toHaveBeenCalled();
+  });
+
+  it('manual adagents revalidation preserves cached state when authoritative_location fetch is inconclusive', async () => {
+    const { CrawlerService } = await import('../../src/crawler.js');
+    const proto = (CrawlerService as any).prototype;
+    const ctx = Object.create(proto);
+
+    Object.assign(ctx, {
+      adAgentsManager: {
+        validateDomain: vi.fn().mockResolvedValue({
+          valid: false,
+          errors: [{ field: 'authoritative_location', message: 'Failed to fetch authoritative file: socket hang up', severity: 'error' }],
+          warnings: [],
+          domain: 'publisher.example',
+          url: 'https://publisher.example/.well-known/adagents.json',
+          status_code: 200,
+          response_bytes: 96,
+          resolved_url: 'https://cdn.publisher.example/adagents.json',
+          discovery_method: 'direct',
+        }),
+      },
+      federatedIndex: {
+        getAuthorizationsForDomain: vi.fn().mockResolvedValue([
+          { agent_url: 'https://old-agent.example/mcp/', source: 'adagents_json' },
+        ]),
+        markPublisherHasInvalidAdagents: vi.fn().mockResolvedValue(undefined),
+        reconcileAdagentsAuthorizations: vi.fn().mockResolvedValue(undefined),
+      },
+      publisherDb: {
+        recordAdagentsValidationFailure: vi.fn().mockResolvedValue(undefined),
+        recordFailedAdagentsFetch: vi.fn().mockResolvedValue(undefined),
+      },
+      scanBrandForDomain: vi.fn().mockResolvedValue(undefined),
+      buildInventoryProfiles: vi.fn().mockResolvedValue(new Map()),
+    });
+
+    const result = await ctx.revalidatePublisherAdagents('publisher.example');
+
+    expect(result).toMatchObject({
+      domain: 'publisher.example',
+      adagents_valid: false,
+      status_code: 200,
+      error: 'Failed to fetch authoritative file: socket hang up',
+    });
+    expect(ctx.publisherDb.recordFailedAdagentsFetch).toHaveBeenCalledWith({
+      domain: 'publisher.example',
+      statusCode: 200,
+      responseBytes: 96,
+      resolvedUrl: 'https://cdn.publisher.example/adagents.json',
+    });
+    expect(ctx.publisherDb.recordAdagentsValidationFailure).not.toHaveBeenCalled();
+    expect(ctx.federatedIndex.markPublisherHasInvalidAdagents).not.toHaveBeenCalled();
+    expect(ctx.federatedIndex.reconcileAdagentsAuthorizations).not.toHaveBeenCalled();
+    expect(ctx.buildInventoryProfiles).not.toHaveBeenCalled();
+  });
+
   it('manual adagents revalidation persists schema-invalid 200 responses as invalid', async () => {
     const { CrawlerService } = await import('../../src/crawler.js');
     const proto = (CrawlerService as any).prototype;

--- a/server/tests/unit/registry-publisher-adagents-revalidate-route.test.ts
+++ b/server/tests/unit/registry-publisher-adagents-revalidate-route.test.ts
@@ -147,6 +147,34 @@ describe('POST /api/registry/publisher/:domain/adagents/revalidate', () => {
     });
   });
 
+  it('rate limits repeated revalidation for the same domain', async () => {
+    const revalidatePublisherAdagents = vi.fn().mockResolvedValue({
+      domain: 'rate-limited.example',
+      adagents_valid: true,
+      checked_at: '2026-06-16T12:00:00.000Z',
+      status_code: 200,
+    });
+    const app = buildApp({
+      user: { id: 'admin_user', email: 'admin@example.com', isAdmin: true },
+      crawler: { revalidatePublisherAdagents },
+    });
+
+    const first = await request(app)
+      .post('/api/registry/publisher/rate-limited.example/adagents/revalidate')
+      .send();
+    const second = await request(app)
+      .post('/api/registry/publisher/rate-limited.example/adagents/revalidate')
+      .send();
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(429);
+    expect(second.body).toMatchObject({
+      error: 'Rate limit exceeded for this domain',
+    });
+    expect(typeof second.body.retry_after).toBe('number');
+    expect(revalidatePublisherAdagents).toHaveBeenCalledTimes(1);
+  });
+
   it('rejects authenticated non-admin callers', async () => {
     const revalidatePublisherAdagents = vi.fn();
     isWebUserAAOAdminMock.mockResolvedValue(false);

--- a/server/tests/unit/registry-publisher-adagents-revalidate-route.test.ts
+++ b/server/tests/unit/registry-publisher-adagents-revalidate-route.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+const validateCrawlDomainMock = vi.fn();
+const isWebUserAAOAdminMock = vi.fn();
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY || 'sk_test_registry_adagents_revalidate';
+  process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID || 'client_test_registry_adagents_revalidate';
+});
+
+vi.mock('../../src/utils/url-security.js', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('../../src/utils/url-security.js');
+  return {
+    ...actual,
+    validateCrawlDomain: (domain: string) => validateCrawlDomainMock(domain),
+  };
+});
+
+vi.mock('../../src/addie/admin-status-lookup.js', () => ({
+  isWebUserAAOAdmin: (userId: string) => isWebUserAAOAdminMock(userId),
+}));
+
+import { createRegistryApiRouter, type RegistryApiConfig } from '../../src/routes/registry-api.js';
+
+const ORIGINAL_ADMIN_EMAILS = process.env.ADMIN_EMAILS;
+const ORIGINAL_DEV_USER_EMAIL = process.env.DEV_USER_EMAIL;
+const ORIGINAL_DEV_USER_ID = process.env.DEV_USER_ID;
+
+function buildApp(options: {
+  user?: { id: string; email: string; isAdmin?: boolean };
+  crawler: Pick<RegistryApiConfig['crawler'], 'revalidatePublisherAdagents'>;
+}) {
+  const app = express();
+  app.use(express.json());
+
+  const requireAuth: import('express').RequestHandler = (req, _res, next) => {
+    if (options.user) {
+      req.user = options.user as typeof req.user;
+    }
+    next();
+  };
+
+  app.use('/api', createRegistryApiRouter({
+    brandManager: {} as RegistryApiConfig['brandManager'],
+    brandDb: {} as RegistryApiConfig['brandDb'],
+    propertyDb: {} as RegistryApiConfig['propertyDb'],
+    adagentsManager: {} as RegistryApiConfig['adagentsManager'],
+    healthChecker: {} as RegistryApiConfig['healthChecker'],
+    crawler: options.crawler as RegistryApiConfig['crawler'],
+    capabilityDiscovery: {} as RegistryApiConfig['capabilityDiscovery'],
+    registryRequestsDb: {
+      trackRequest: async () => {},
+      markResolved: async () => true,
+    },
+    requireAuth,
+    optionalAuth: requireAuth,
+  }));
+
+  return app;
+}
+
+describe('POST /api/registry/publisher/:domain/adagents/revalidate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.ADMIN_EMAILS;
+    delete process.env.DEV_USER_EMAIL;
+    delete process.env.DEV_USER_ID;
+    validateCrawlDomainMock.mockImplementation(async (domain: string) => domain.toLowerCase().trim());
+    isWebUserAAOAdminMock.mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_ADMIN_EMAILS === undefined) delete process.env.ADMIN_EMAILS;
+    else process.env.ADMIN_EMAILS = ORIGINAL_ADMIN_EMAILS;
+    if (ORIGINAL_DEV_USER_EMAIL === undefined) delete process.env.DEV_USER_EMAIL;
+    else process.env.DEV_USER_EMAIL = ORIGINAL_DEV_USER_EMAIL;
+    if (ORIGINAL_DEV_USER_ID === undefined) delete process.env.DEV_USER_ID;
+    else process.env.DEV_USER_ID = ORIGINAL_DEV_USER_ID;
+  });
+
+  it('revalidates a publisher domain for an admin and returns the persisted verdict', async () => {
+    const revalidatePublisherAdagents = vi.fn().mockResolvedValue({
+      domain: 'publisher.example',
+      adagents_valid: true,
+      checked_at: '2026-06-16T12:00:00.000Z',
+      properties_count: 3,
+      authorized_agents_count: 1,
+      status_code: 200,
+      resolved_url: 'https://publisher.example/.well-known/adagents.json',
+      discovery_method: 'direct',
+    });
+
+    const res = await request(buildApp({
+      user: { id: 'admin_user', email: 'admin@example.com', isAdmin: true },
+      crawler: { revalidatePublisherAdagents },
+    }))
+      .post('/api/registry/publisher/Publisher.Example/adagents/revalidate?force=true')
+      .send();
+
+    expect(res.status).toBe(200);
+    expect(validateCrawlDomainMock).toHaveBeenCalledWith('publisher.example');
+    expect(revalidatePublisherAdagents).toHaveBeenCalledWith('publisher.example', { force: true });
+    expect(res.body).toMatchObject({
+      domain: 'publisher.example',
+      adagents_valid: true,
+      checked_at: '2026-06-16T12:00:00.000Z',
+      properties_count: 3,
+      authorized_agents_count: 1,
+    });
+  });
+
+  it('returns validation issues for an invalid or missing adagents.json', async () => {
+    const revalidatePublisherAdagents = vi.fn().mockResolvedValue({
+      domain: 'missing.example',
+      adagents_valid: false,
+      checked_at: '2026-06-16T12:05:00.000Z',
+      error: 'File not found at https://missing.example/.well-known/adagents.json',
+      issues: {
+        errors: [{ field: 'http_status', message: 'File not found at https://missing.example/.well-known/adagents.json', severity: 'error' }],
+        warnings: [],
+      },
+      properties_count: 0,
+      authorized_agents_count: 0,
+      status_code: 404,
+    });
+
+    const res = await request(buildApp({
+      user: { id: 'admin_user', email: 'admin@example.com', isAdmin: true },
+      crawler: { revalidatePublisherAdagents },
+    }))
+      .post('/api/registry/publisher/missing.example/adagents/revalidate')
+      .send();
+
+    expect(res.status).toBe(200);
+    expect(revalidatePublisherAdagents).toHaveBeenCalledWith('missing.example', { force: false });
+    expect(res.body).toMatchObject({
+      domain: 'missing.example',
+      adagents_valid: false,
+      error: 'File not found at https://missing.example/.well-known/adagents.json',
+      issues: {
+        errors: [{ field: 'http_status', severity: 'error' }],
+        warnings: [],
+      },
+      status_code: 404,
+    });
+  });
+
+  it('rejects authenticated non-admin callers', async () => {
+    const revalidatePublisherAdagents = vi.fn();
+    isWebUserAAOAdminMock.mockResolvedValue(false);
+
+    const res = await request(buildApp({
+      user: { id: 'member_user', email: 'member@example.com', isAdmin: false },
+      crawler: { revalidatePublisherAdagents },
+    }))
+      .post('/api/registry/publisher/example.com/adagents/revalidate')
+      .send();
+
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ error: 'Admin access required' });
+    expect(revalidatePublisherAdagents).not.toHaveBeenCalled();
+  });
+
+  it('rejects unauthenticated callers', async () => {
+    const revalidatePublisherAdagents = vi.fn();
+
+    const res = await request(buildApp({
+      crawler: { revalidatePublisherAdagents },
+    }))
+      .post('/api/registry/publisher/example.com/adagents/revalidate')
+      .send();
+
+    expect(res.status).toBe(401);
+    expect(res.body).toMatchObject({ error: 'Authentication required' });
+    expect(revalidatePublisherAdagents).not.toHaveBeenCalled();
+  });
+});

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -5055,7 +5055,10 @@ paths:
     post:
       operationId: revalidatePublisherAdagents
       summary: Revalidate publisher adagents.json
-      description: Admin-only endpoint for support/operator tooling to synchronously fetch a publisher's live `/.well-known/adagents.json`, run the registry validator, persist the refreshed verdict and fetch metadata, and return the validation result. `force=true` is accepted for operator tooling; the current validator always fetches the live origin.
+      description: |-
+        Admin-only endpoint for support/operator tooling to synchronously fetch a publisher's live `/.well-known/adagents.json`, run the registry validator, persist the refreshed verdict and fetch metadata, and return the validation result. `force=true` is accepted for operator tooling; the current validator always fetches the live origin.
+
+        **Rate limits:** 5 minutes per domain, 30 requests per user per hour.
       tags:
         - Authorization Lookups
       security:
@@ -5069,9 +5072,10 @@ paths:
           name: domain
           in: path
         - schema:
-            type:
-              - boolean
-              - "null"
+            type: string
+            enum:
+              - "1"
+              - "true"
             description: Accepted for tooling compatibility; live origin validation is always performed.
           required: false
           description: Accepted for tooling compatibility; live origin validation is always performed.
@@ -5177,6 +5181,21 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  retry_after:
+                    type: integer
+                    description: Seconds to wait before retrying
+                required:
+                  - error
+                  - retry_after
   /api/registry/publisher/authorization:
     get:
       operationId: lookupPublisherAgentAuthorization

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -5051,6 +5051,132 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /api/registry/publisher/{domain}/adagents/revalidate:
+    post:
+      operationId: revalidatePublisherAdagents
+      summary: Revalidate publisher adagents.json
+      description: Admin-only endpoint for support/operator tooling to synchronously fetch a publisher's live `/.well-known/adagents.json`, run the registry validator, persist the refreshed verdict and fetch metadata, and return the validation result. `force=true` is accepted for operator tooling; the current validator always fetches the live origin.
+      tags:
+        - Authorization Lookups
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            example: publisher.example
+          required: true
+          name: domain
+          in: path
+        - schema:
+            type:
+              - boolean
+              - "null"
+            description: Accepted for tooling compatibility; live origin validation is always performed.
+          required: false
+          description: Accepted for tooling compatibility; live origin validation is always performed.
+          name: force
+          in: query
+      responses:
+        "200":
+          description: Revalidation result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  domain:
+                    type: string
+                  adagents_valid:
+                    type: boolean
+                  checked_at:
+                    type: string
+                    format: date-time
+                  error:
+                    type: string
+                  issues:
+                    type: object
+                    properties:
+                      errors:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            field:
+                              type: string
+                            message:
+                              type: string
+                            severity:
+                              type: string
+                              enum:
+                                - error
+                          required:
+                            - field
+                            - message
+                            - severity
+                      warnings:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            field:
+                              type: string
+                            message:
+                              type: string
+                            suggestion:
+                              type: string
+                          required:
+                            - field
+                            - message
+                    required:
+                      - errors
+                      - warnings
+                  properties_count:
+                    type: integer
+                    minimum: 0
+                  authorized_agents_count:
+                    type: integer
+                    minimum: 0
+                  status_code:
+                    type: integer
+                    minimum: 100
+                    maximum: 599
+                  response_bytes:
+                    type: integer
+                    minimum: 0
+                  resolved_url:
+                    type: string
+                  discovery_method:
+                    type: string
+                    enum:
+                      - direct
+                      - authoritative_location
+                      - ads_txt_managerdomain
+                      - adagents_authoritative
+                  manager_domain:
+                    type: string
+                required:
+                  - domain
+                  - adagents_valid
+                  - checked_at
+        "400":
+          description: Invalid domain format, private IP, or unresolvable domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Admin access required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /api/registry/publisher/authorization:
     get:
       operationId: lookupPublisherAgentAuthorization


### PR DESCRIPTION
## Summary
- Add an admin-only POST /api/registry/publisher/{domain}/adagents/revalidate endpoint with SSRF-gated domain validation and optional force query support.
- Reuse the registry adagents validator to refresh cached publisher verdicts, fetch metadata, validation issues, and lookupPublisher-visible state.
- Persist invalid revalidation metadata and retire stale adagents-derived catalog, legacy publisher, and legacy property authorization projections.
- Add DB migration, OpenAPI output, changeset, unit tests, and Docker-backed DB integration coverage.

## Verification
- npx vitest run server/tests/unit/registry-publisher-adagents-revalidate-route.test.ts server/tests/unit/crawler-single-domain-profile-rebuild.test.ts --config server/vitest.config.ts
- DATABASE_URL=postgresql://adcp:localdev@localhost:63945/adcp_registry npx vitest run server/tests/integration/publisher-adagents-revalidate-db.test.ts --config server/vitest.config.ts
- npm run typecheck
- npm run build:openapi
- git diff --check
- npx --yes @changesets/cli@^2.31.0 status --since=origin/main
- precommit hook on commit: repository unit suite passed (4177 passed, 30 skipped) plus remaining precommit checks completed

## Docker
- docker compose up -d postgres succeeded and the integration test passed against the Docker Postgres service.
- docker compose up -d --build app was retried; it failed while cloning external reference repos in the Dockerfile with Git RPC/HTTP2 cancel and early EOF, then Docker reported EOF reading build status. This matched the earlier external clone failure and did not reach application compilation.

## Expert Review
- Code, security, testing, and protocol reviewers were run. Actionable findings were addressed before this PR: warning propagation, query-only force handling, changeset, auth rejection coverage, lookupPublisher assertions, invalid schema coverage, and stale legacy property/auth cleanup.