### PR TITLE
fix(registry): honor managerdomain delegated authorization

### DIFF
--- a/.changeset/managerdomain-delegation-authorization.md
+++ b/.changeset/managerdomain-delegation-authorization.md
@@ -1,0 +1,4 @@
+---
+---
+
+Empty changeset: server registry behavior only. Treat ads.txt `managerdomain` delegation as authoritative when the manager `adagents.json` explicitly scopes the source publisher through `publisher_properties`, and keep delegated property authorization limited to the matching publisher and selector. Also isolates the agent-read rate-limit retry-after unit test from the production singleton limiter so parallel precommit runs stay deterministic.

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -67,6 +67,15 @@ function stableStringify(value: unknown): string {
   return '{' + keys.map(k => JSON.stringify(k) + ':' + stableStringify(obj[k])).join(',') + '}';
 }
 
+type ManifestProperty = {
+  property_id?: string;
+  property_type: string;
+  name: string;
+  identifiers: Array<{ type: string; value: string }>;
+  tags?: string[];
+  publisher_domain?: string;
+};
+
 export interface PublisherAdagentsRevalidationResult {
   domain: string;
   adagents_valid: boolean;
@@ -569,11 +578,10 @@ export class CrawlerService {
 
               // Record properties and link to this agent
               await this.recordPropertiesForAgent(
-                validation.raw_data.properties || [],
+                this.propertiesForValidation(validation, pubConfig.domain, authorizedAgent),
                 pubConfig.domain,
                 authorizedAgent.url,
-                authorizedAgent.authorized_for,
-                authorizedAgent.property_ids
+                authorizedAgent.authorized_for
               );
 
               // Fan out publisher_properties[].publisher_domains[] into
@@ -662,11 +670,10 @@ export class CrawlerService {
 
               // Record properties and link to this agent
               await this.recordPropertiesForAgent(
-                validation.raw_data.properties || [],
+                this.propertiesForValidation(validation, domain, authorizedAgent),
                 domain,
                 authorizedAgent.url,
-                authorizedAgent.authorized_for,
-                authorizedAgent.property_ids
+                authorizedAgent.authorized_for
               );
 
               // Skip fan-out when the source publisher delegates via
@@ -721,8 +728,8 @@ export class CrawlerService {
                   authorizedAgent.authorized_for, authorizedAgent.property_ids
                 );
                 await this.recordPropertiesForAgent(
-                  validation.raw_data.properties || [], domain,
-                  authorizedAgent.url, authorizedAgent.authorized_for, authorizedAgent.property_ids
+                  this.propertiesForValidation(validation, domain, authorizedAgent), domain,
+                  authorizedAgent.url, authorizedAgent.authorized_for
                 );
                 // Skip fan-out when the source publisher delegates via
                 // ads.txt MANAGERDOMAIN — see step 1/2 guards for rationale.
@@ -1353,11 +1360,10 @@ export class CrawlerService {
       );
 
       await this.recordPropertiesForAgent(
-        (manifest.properties || []) as any,
+        this.propertiesForValidation(validation, domain, authorizedAgent),
         domain,
         authorizedAgent.url,
         authorizedAgent.authorized_for,
-        authorizedAgent.property_ids,
       );
 
       if (validation.discovery_method !== 'ads_txt_managerdomain') {
@@ -1419,9 +1425,117 @@ export class CrawlerService {
   }
 
   /**
-   * Record properties from adagents.json and link them to an agent.
-   * If the agent has property_ids specified, only record those specific properties.
+   * Resolve an authorized_agents[] selector to the concrete manifest
+   * properties that should be written into the legacy property auth graph.
    */
+  private propertiesForValidation(
+    validation: AdAgentsValidationResult,
+    publisherDomain: string,
+    authorizedAgent: AdagentsAuthorizedAgent,
+  ): ManifestProperty[] {
+    const manifest = validation.raw_data as AdagentsManifest | undefined;
+    const properties = Array.isArray(manifest?.properties) ? manifest.properties as ManifestProperty[] : [];
+    const restrictToSourcePublisher = validation.discovery_method === 'ads_txt_managerdomain';
+    return this.selectPropertiesForAuthorizedAgent(properties, publisherDomain, authorizedAgent, restrictToSourcePublisher);
+  }
+
+  private selectPropertiesForAuthorizedAgent(
+    properties: ManifestProperty[],
+    publisherDomain: string,
+    authorizedAgent: AdagentsAuthorizedAgent,
+    restrictToSourcePublisher: boolean,
+  ): ManifestProperty[] {
+    const sourcePublisher = canonicalizePublisherDomain(publisherDomain);
+    const sourceProperties = (candidates: ManifestProperty[]) => restrictToSourcePublisher
+      ? candidates.filter((property) => this.propertyPublisherDomain(property, sourcePublisher) === sourcePublisher)
+      : candidates;
+    const byId = (ids: string[] | undefined, candidates = properties) => {
+      const idSet = new Set((ids || []).filter((id): id is string => typeof id === 'string' && id.length > 0));
+      if (idSet.size === 0) return [];
+      return sourceProperties(candidates).filter((property) => typeof property.property_id === 'string' && idSet.has(property.property_id));
+    };
+    const byTag = (tags: string[] | undefined, candidates = properties) => {
+      const tagSet = new Set((tags || []).filter((tag): tag is string => typeof tag === 'string' && tag.length > 0));
+      if (tagSet.size === 0) return [];
+      return sourceProperties(candidates).filter((property) => (property.tags || []).some((tag) => tagSet.has(tag)));
+    };
+
+    switch (authorizedAgent.authorization_type) {
+      case 'property_ids':
+        return byId(authorizedAgent.property_ids);
+      case 'property_tags':
+        return byTag(authorizedAgent.property_tags);
+      case 'inline_properties':
+        return sourceProperties(Array.isArray(authorizedAgent.properties) ? authorizedAgent.properties as ManifestProperty[] : []);
+      case 'publisher_properties':
+        return this.selectPublisherProperties(properties, sourcePublisher, authorizedAgent, restrictToSourcePublisher);
+      case 'signal_ids':
+      case 'signal_tags':
+        return [];
+      default:
+        return sourceProperties(properties);
+    }
+  }
+
+  private selectPublisherProperties(
+    properties: ManifestProperty[],
+    sourcePublisher: string,
+    authorizedAgent: AdagentsAuthorizedAgent,
+    restrictToSourcePublisher: boolean,
+  ): ManifestProperty[] {
+    const selected = new Map<string, ManifestProperty>();
+    const selectors = Array.isArray(authorizedAgent.publisher_properties) ? authorizedAgent.publisher_properties : [];
+    for (const selector of selectors) {
+      if (!selector || typeof selector !== 'object') continue;
+      const hasSingular = typeof selector.publisher_domain === 'string' && selector.publisher_domain.length > 0;
+      const hasPlural = Array.isArray(selector.publisher_domains) && selector.publisher_domains.length > 0;
+      if (hasSingular === hasPlural) continue;
+
+      const selectorDomains = new Set<string>();
+      if (hasSingular) {
+        selectorDomains.add(canonicalizePublisherDomain(selector.publisher_domain!));
+      } else {
+        for (const domain of selector.publisher_domains || []) {
+          if (typeof domain === 'string' && domain.length > 0) {
+            selectorDomains.add(canonicalizePublisherDomain(domain));
+          }
+        }
+      }
+      if (restrictToSourcePublisher && !selectorDomains.has(sourcePublisher)) continue;
+      if (hasPlural && selector.selection_type === 'by_id') continue;
+
+      const domainProperties = properties.filter((property) => {
+        const propertyPublisher = this.propertyPublisherDomain(property, sourcePublisher);
+        return restrictToSourcePublisher
+          ? propertyPublisher === sourcePublisher
+          : selectorDomains.has(propertyPublisher);
+      });
+
+      let matches: ManifestProperty[] = [];
+      if (selector.selection_type === 'all') {
+        matches = domainProperties;
+      } else if (selector.selection_type === 'by_id') {
+        const ids = new Set((selector.property_ids || []).filter((id): id is string => typeof id === 'string' && id.length > 0));
+        matches = domainProperties.filter((property) => typeof property.property_id === 'string' && ids.has(property.property_id));
+      } else if (selector.selection_type === 'by_tag') {
+        const tags = new Set((selector.property_tags || []).filter((tag): tag is string => typeof tag === 'string' && tag.length > 0));
+        matches = domainProperties.filter((property) => (property.tags || []).some((tag) => tags.has(tag)));
+      }
+
+      for (const property of matches) {
+        const key = `${this.propertyPublisherDomain(property, sourcePublisher)}:${property.property_id || property.name}:${property.property_type}`;
+        selected.set(key, property);
+      }
+    }
+    return [...selected.values()];
+  }
+
+  private propertyPublisherDomain(property: { publisher_domain?: string }, fallbackPublisher: string): string {
+    return typeof property.publisher_domain === 'string' && property.publisher_domain.trim().length > 0
+      ? canonicalizePublisherDomain(property.publisher_domain)
+      : fallbackPublisher;
+  }
+
   /**
    * Fan publisher_properties[].publisher_domains[] out into per-child
    * rows so the AAO directory inverse-lookup endpoint
@@ -1823,11 +1937,10 @@ export class CrawlerService {
         );
 
         await this.recordPropertiesForAgent(
-          validation.raw_data.properties || [],
+          this.propertiesForValidation(validation, domain, authorizedAgent),
           domain,
           authorizedAgent.url,
-          authorizedAgent.authorized_for,
-          authorizedAgent.property_ids
+          authorizedAgent.authorized_for
         );
 
         // Skip fan-out when the source publisher delegates via ads.txt
@@ -2110,11 +2223,10 @@ export class CrawlerService {
       );
 
       await this.recordPropertiesForAgent(
-        validation.raw_data.properties || [],
+        this.propertiesForValidation(validation, domain, authorizedAgent),
         domain,
         authorizedAgent.url,
-        authorizedAgent.authorized_for,
-        authorizedAgent.property_ids
+        authorizedAgent.authorized_for
       );
 
       // Skip fan-out when the source publisher delegates via ads.txt

--- a/server/src/db/federated-index-db.ts
+++ b/server/src/db/federated-index-db.ts
@@ -984,6 +984,16 @@ export class FederatedIndexDatabase {
             AND prop->>'property_id' = cp.property_id
             AND prop->>'name' IS NOT NULL
             AND prop->>'property_type' IS NOT NULL
+            AND LOWER(REGEXP_REPLACE(
+                  REGEXP_REPLACE(
+                    BTRIM(COALESCE(NULLIF(prop->>'publisher_domain', ''), pub.domain)),
+                    '^https?://',
+                    '',
+                    'i'
+                  ),
+                  '[./]+$',
+                  ''
+                )) = pub.domain
        ), deduped AS (
          SELECT DISTINCT ON (publisher_domain, name, property_type)
                 id, property_id, publisher_domain, property_type, name,
@@ -1072,6 +1082,16 @@ export class FederatedIndexDatabase {
             AND p.review_status = 'approved'
             AND prop->>'name' IS NOT NULL
             AND prop->>'property_type' IS NOT NULL
+            AND LOWER(REGEXP_REPLACE(
+                  REGEXP_REPLACE(
+                    BTRIM(COALESCE(NULLIF(prop->>'publisher_domain', ''), p.domain)),
+                    '^https?://',
+                    '',
+                    'i'
+                  ),
+                  '[./]+$',
+                  ''
+                )) = p.domain
        ), deduped AS (
          SELECT DISTINCT ON (publisher_domain, name, property_type)
                 id, property_id, publisher_domain, property_type, name,

--- a/server/src/db/property-db.ts
+++ b/server/src/db/property-db.ts
@@ -277,6 +277,16 @@ export class PropertyDatabase {
             AND p.source_type = 'adagents_json'
             AND prop->>'name' IS NOT NULL
             AND prop->>'property_type' IS NOT NULL
+            AND LOWER(REGEXP_REPLACE(
+                  REGEXP_REPLACE(
+                    BTRIM(COALESCE(NULLIF(prop->>'publisher_domain', ''), p.domain)),
+                    '^https?://',
+                    '',
+                    'i'
+                  ),
+                  '[./]+$',
+                  ''
+                )) = p.domain
        )
        SELECT DISTINCT ON (publisher_domain, name, property_type)
               id, property_id, publisher_domain, property_type, name,
@@ -335,6 +345,16 @@ export class PropertyDatabase {
             AND regexp_replace(cp.created_by, '^[^:]+:', '') = $1
             AND prop->>'property_id' = cp.property_id
             AND prop->>'name' IS NOT NULL
+            AND LOWER(REGEXP_REPLACE(
+                  REGEXP_REPLACE(
+                    BTRIM(COALESCE(NULLIF(prop->>'publisher_domain', ''), pub.domain)),
+                    '^https?://',
+                    '',
+                    'i'
+                  ),
+                  '[./]+$',
+                  ''
+                )) = pub.domain
        )
        SELECT DISTINCT ON (agent_url, name, COALESCE(authorized_for, ''))
               agent_url, name, authorized_for

--- a/server/src/db/publisher-db.ts
+++ b/server/src/db/publisher-db.ts
@@ -21,6 +21,7 @@ export interface AdagentsProperty {
   name?: string;
   identifiers?: Array<{ type?: string; value?: string }>;
   tags?: string[];
+  publisher_domain?: string;
 }
 
 export interface AdagentsCollection {
@@ -54,6 +55,7 @@ export interface AdagentsAuthorizedAgent {
     | 'signal_ids'
     | 'signal_tags';
   property_ids?: string[];
+  property_tags?: string[];
   properties?: AdagentsProperty[];           // for inline_properties variant
   publisher_properties?: Array<{
     publisher_domain?: string;
@@ -1492,6 +1494,17 @@ export class PublisherDatabase {
     publisherDomain: string,
     property: AdagentsProperty,
   ): Promise<void> {
+    const explicitPublisher = typeof property.publisher_domain === 'string' && property.publisher_domain.trim().length > 0
+      ? canonicalizePublisherDomain(property.publisher_domain)
+      : publisherDomain;
+    if (explicitPublisher !== publisherDomain) {
+      log.warn(
+        { publisherDomain, propertyId: property.property_id, explicitPublisher },
+        'Catalog projection refused: property.publisher_domain does not match publisher'
+      );
+      return;
+    }
+
     const rawIdentifiers = Array.isArray(property.identifiers) ? property.identifiers : [];
     const identifiers = rawIdentifiers
       .filter((i): i is { type: string; value: string } =>
@@ -1668,9 +1681,9 @@ export class PublisherDatabase {
    *                           to catalog first, then references them)
    *   - publisher_properties — only the lexical-anchor case lands
    *                            (entry.publisher_domain == publisherDomain)
-   *                            with selection_type='all' or 'by_id'.
-   *                            Cross-publisher claims and 'by_tag' are
-   *                            refused per spec.
+   *                            with selection_type='all', 'by_id', or
+   *                            'by_tag'. Cross-publisher claims are refused
+   *                            per spec.
    *   - no authorization_type (publisher-wide) — one row with
    *                            property_rid IS NULL, publisher_domain set
    *
@@ -1832,11 +1845,51 @@ export class PublisherDatabase {
           for (const row of rows.rows) {
             targets.push({ propertyRid: row.property_rid, slug: row.property_id });
           }
+        } else if (selectionType === 'by_tag') {
+          const tags = Array.isArray(sel.property_tags)
+            ? sel.property_tags.filter((s): s is string => typeof s === 'string' && s.length > 0)
+            : [];
+          if (tags.length === 0) continue;
+          const rows = await client.query<{ property_rid: string; property_id: string | null }>(
+            `SELECT cp.property_rid, cp.property_id
+               FROM catalog_properties cp
+               JOIN publishers p ON p.domain = $1
+              CROSS JOIN LATERAL jsonb_array_elements(
+                CASE WHEN jsonb_typeof(p.adagents_json->'properties') = 'array'
+                     THEN p.adagents_json->'properties'
+                     ELSE '[]'::jsonb END
+              ) AS prop
+              WHERE cp.created_by = $2
+                AND cp.property_id IS NOT NULL
+                AND prop->>'property_id' = cp.property_id
+                AND LOWER(REGEXP_REPLACE(
+                      REGEXP_REPLACE(
+                        BTRIM(COALESCE(NULLIF(prop->>'publisher_domain', ''), p.domain)),
+                        '^https?://',
+                        '',
+                        'i'
+                      ),
+                      '[./]+$',
+                      ''
+                    )) = p.domain
+                AND EXISTS (
+                  SELECT 1
+                    FROM jsonb_array_elements_text(
+                      CASE WHEN jsonb_typeof(prop->'tags') = 'array'
+                           THEN prop->'tags'
+                           ELSE '[]'::jsonb END
+                    ) AS tag(value)
+                   WHERE tag.value = ANY($3::text[])
+                )`,
+            [publisherDomain, adagentsCreatedBy(publisherDomain), tags]
+          );
+          for (const row of rows.rows) {
+            targets.push({ propertyRid: row.property_rid, slug: row.property_id });
+          }
         } else {
-          // selection_type='by_tag' is deferred per spec.
           log.debug(
             { publisherDomain, agentUrl: agentCanonical, selectionType },
-            'Skipping auth projection: publisher_properties.selection_type not supported in v1'
+            'Skipping auth projection: publisher_properties.selection_type is unknown'
           );
         }
       }

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -1,4 +1,5 @@
 import rateLimit from 'express-rate-limit';
+import type { Store } from 'express-rate-limit';
 import type { Request, Response } from 'express';
 import { createLogger } from '../logger.js';
 import { CachedPostgresStore, PostgresStore } from './pg-rate-limit-store.js';
@@ -318,41 +319,49 @@ export const storyboardStepRateLimiter = rateLimit({
  * (The sibling auth-status endpoint runs under complianceWriteMiddleware
  * and isn't gated by this limiter.)
  */
-export const agentReadRateLimiter = rateLimit({
-  windowMs: 60 * 1000, // 1 minute
-  max: 240, // 4/sec sustained; a 60-agent × 2-endpoint burst (120 req) fits with headroom
-  standardHeaders: true,
-  legacyHeaders: false,
-  store: new CachedPostgresStore('agent-read:'),
-  keyGenerator: generateKey,
-  validate: { keyGeneratorIpFallback: false },
-  handler: (req: Request, res: Response) => {
-    logger.warn({
-      userId: (req as any).user?.id,
-      ip: req.ip,
-      path: req.path,
-    }, 'Rate limit exceeded for agent dashboard reads');
+export function createAgentReadRateLimiter(options: {
+  windowMs?: number;
+  max?: number;
+  store?: Store;
+} = {}) {
+  return rateLimit({
+    windowMs: options.windowMs ?? 60 * 1000, // 1 minute
+    max: options.max ?? 240, // 4/sec sustained; a 60-agent × 2-endpoint burst (120 req) fits with headroom
+    standardHeaders: true,
+    legacyHeaders: false,
+    store: options.store ?? new CachedPostgresStore('agent-read:'),
+    keyGenerator: generateKey,
+    validate: { keyGeneratorIpFallback: false },
+    handler: (req: Request, res: Response) => {
+      logger.warn({
+        userId: (req as any).user?.id,
+        ip: req.ip,
+        path: req.path,
+      }, 'Rate limit exceeded for agent dashboard reads');
 
-    // standardHeaders emits `Retry-After` / `RateLimit-Reset` with the
-    // real remaining window — that's the authoritative signal. We also
-    // surface the same value in the JSON body as a proxy-stripped
-    // fallback (#2804): some reverse proxies drop non-standard
-    // headers, and the dashboard needs SOMETHING to key its countdown
-    // off. `retryAfter` is seconds-to-retry, matching the header's
-    // delta-seconds format.
-    //
-    // The HTTP spec (RFC 9110 §10.2.3) also allows an HTTP-date here,
-    // but express-rate-limit only emits delta-seconds — so a parseInt
-    // is sufficient. If that ever changes (e.g., we swap limiter
-    // libraries), the fallback below would need a second parse path.
-    const retryAfter = parseRetryAfterSeconds(res.getHeader('Retry-After'));
-    res.status(429).json({
-      error: 'Too many requests',
-      message: 'Agent dashboard read rate limit exceeded. Please try again in a moment.',
-      ...(retryAfter !== undefined ? { retryAfter } : {}),
-    });
-  },
-});
+      // standardHeaders emits `Retry-After` / `RateLimit-Reset` with the
+      // real remaining window — that's the authoritative signal. We also
+      // surface the same value in the JSON body as a proxy-stripped
+      // fallback (#2804): some reverse proxies drop non-standard
+      // headers, and the dashboard needs SOMETHING to key its countdown
+      // off. `retryAfter` is seconds-to-retry, matching the header's
+      // delta-seconds format.
+      //
+      // The HTTP spec (RFC 9110 §10.2.3) also allows an HTTP-date here,
+      // but express-rate-limit only emits delta-seconds — so a parseInt
+      // is sufficient. If that ever changes (e.g., we swap limiter
+      // libraries), the fallback below would need a second parse path.
+      const retryAfter = parseRetryAfterSeconds(res.getHeader('Retry-After'));
+      res.status(429).json({
+        error: 'Too many requests',
+        message: 'Agent dashboard read rate limit exceeded. Please try again in a moment.',
+        ...(retryAfter !== undefined ? { retryAfter } : {}),
+      });
+    },
+  });
+}
+
+export const agentReadRateLimiter = createAgentReadRateLimiter();
 
 /**
  * Rate limiter for bulk resolve endpoints

--- a/server/tests/integration/publisher-adagents-revalidate-db.test.ts
+++ b/server/tests/integration/publisher-adagents-revalidate-db.test.ts
@@ -11,6 +11,7 @@ import { createRegistryApiRouter, type RegistryApiConfig } from '../../src/route
 
 const TEST_DATABASE_URL = process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test';
 const DOMAIN = `revalidate-${Date.now()}.registry-test.example`;
+const OTHER_DOMAIN = `other-${Date.now()}.registry-test.example`;
 const AGENT = 'https://sales-agent.example/mcp/storefront';
 const STALE_AGENT = 'https://stale-agent.example/mcp';
 const HOSTED_AGENT = 'https://hosted-agent.example/mcp';
@@ -39,12 +40,12 @@ async function cleanup(pool: Pool) {
     `DELETE FROM agent_property_authorizations apa
       USING discovered_properties dp
      WHERE apa.property_id = dp.id
-       AND (dp.publisher_domain = $1 OR apa.agent_url = ANY($2::text[]))`,
-    [DOMAIN, TEST_AGENTS],
+       AND (dp.publisher_domain = ANY($1::text[]) OR apa.agent_url = ANY($2::text[]))`,
+    [[DOMAIN, OTHER_DOMAIN], TEST_AGENTS],
   );
   await pool.query(
-    `DELETE FROM discovered_properties WHERE publisher_domain = $1`,
-    [DOMAIN],
+    `DELETE FROM discovered_properties WHERE publisher_domain = ANY($1::text[])`,
+    [[DOMAIN, OTHER_DOMAIN]],
   );
   await pool.query(
     `DELETE FROM catalog_agent_authorizations
@@ -76,7 +77,7 @@ async function cleanup(pool: Pool) {
     `DELETE FROM catalog_properties WHERE created_by = $1`,
     [`adagents_json:${DOMAIN}`],
   );
-  await pool.query(`DELETE FROM publishers WHERE domain = $1`, [DOMAIN]);
+  await pool.query(`DELETE FROM publishers WHERE domain = ANY($1::text[])`, [[DOMAIN, OTHER_DOMAIN]]);
 }
 
 function buildLookupApp(federatedIndex: FederatedIndexService) {
@@ -196,6 +197,130 @@ describe('publisher adagents manual revalidation DB path', () => {
         },
       },
     });
+  });
+
+  it('persists ads.txt managerdomain delegation with compact by_tag publisher_properties as authorized', async () => {
+    const managerDomain = `manager.${DOMAIN}`;
+    const crawler = makeCrawler({
+      valid: true,
+      errors: [],
+      warnings: [
+        {
+          field: 'managerdomain',
+          message: `No directly usable adagents.json at https://${DOMAIN}/.well-known/adagents.json; used ads.txt managerdomain ${managerDomain}`,
+        },
+      ],
+      domain: DOMAIN,
+      url: `https://${DOMAIN}/.well-known/adagents.json`,
+      status_code: 200,
+      response_bytes: 2048,
+      resolved_url: `https://${managerDomain}/.well-known/adagents.json`,
+      discovery_method: 'ads_txt_managerdomain',
+      manager_domain: managerDomain,
+      raw_data: {
+        properties: [
+          {
+            property_id: 'managed-site',
+            property_type: 'website',
+            name: 'Managed site',
+            identifiers: [{ type: 'domain', value: DOMAIN }],
+            publisher_domain: DOMAIN,
+            tags: ['raptive_managed'],
+          },
+          {
+            property_id: 'other-site',
+            property_type: 'website',
+            name: 'Other site',
+            identifiers: [{ type: 'subdomain', value: `other.${DOMAIN}` }],
+            publisher_domain: DOMAIN,
+            tags: ['other'],
+          },
+          {
+            property_id: 'elsewhere-site',
+            property_type: 'website',
+            name: 'Elsewhere site',
+            identifiers: [{ type: 'domain', value: OTHER_DOMAIN }],
+            publisher_domain: OTHER_DOMAIN,
+            tags: ['raptive_managed'],
+          },
+        ],
+        authorized_agents: [
+          {
+            url: AGENT,
+            authorized_for: 'Official sales agent for managed display inventory',
+            authorization_type: 'publisher_properties',
+            publisher_properties: [
+              {
+                publisher_domains: ['elsewhere.example', DOMAIN],
+                selection_type: 'by_tag',
+                property_tags: ['raptive_managed'],
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const result = await crawler.revalidatePublisherAdagents(DOMAIN, { force: true });
+
+    expect(result).toMatchObject({
+      domain: DOMAIN,
+      adagents_valid: true,
+      discovery_method: 'ads_txt_managerdomain',
+      manager_domain: managerDomain,
+      properties_count: 3,
+      authorized_agents_count: 1,
+    });
+
+    const productAuth = await federatedIndex.validateAgentForProduct(AGENT, [
+      {
+        publisher_domain: DOMAIN,
+        selection_type: 'by_tag',
+        property_tags: ['raptive_managed'],
+      },
+    ]);
+    expect(productAuth.authorized).toBe(true);
+    expect(productAuth.total_requested).toBe(1);
+    expect(productAuth.total_authorized).toBe(1);
+
+    const otherDomainAuth = await federatedIndex.validateAgentForProduct(AGENT, [
+      {
+        publisher_domain: OTHER_DOMAIN,
+        selection_type: 'by_tag',
+        property_tags: ['raptive_managed'],
+      },
+    ]);
+    expect(otherDomainAuth.authorized).toBe(false);
+    expect(otherDomainAuth.total_requested).toBe(0);
+    expect(otherDomainAuth.total_authorized).toBe(0);
+
+    const lookup = await request(lookupApp)
+      .get('/api/registry/publisher')
+      .query({ domain: DOMAIN });
+    expect(lookup.status).toBe(200);
+    expect(lookup.body).toMatchObject({
+      domain: DOMAIN,
+      adagents_valid: true,
+      discovery_method: 'ads_txt_managerdomain',
+      manager_domain: managerDomain,
+      files: {
+        adagents_json: {
+          status: 'valid',
+        },
+      },
+    });
+    expect(lookup.body.properties.map((property: { id: string }) => property.id).sort()).toEqual([
+      'managed-site',
+      'other-site',
+    ]);
+    expect(lookup.body.authorized_agents).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        url: AGENT,
+        source: 'adagents_json',
+        properties_authorized: 1,
+        properties_total: 2,
+      }),
+    ]));
   });
 
   it('persists invalid revalidation and retires stale adagents authorizations', async () => {

--- a/server/tests/integration/registry-catalog-agent-auth-writer.test.ts
+++ b/server/tests/integration/registry-catalog-agent-auth-writer.test.ts
@@ -741,7 +741,7 @@ describe('catalog_agent_authorizations writer projection', () => {
       expect(rows.map((r) => r.property_id_slug)).toEqual(['site_a']);
     });
 
-    it('skips selection_type=by_tag (deferred per spec)', async () => {
+    it('resolves selection_type=by_tag against the publisher properties named by compact publisher_domains[]', async () => {
       await publisherDb.upsertAdagentsCache({
         domain: TEST_PUB,
         manifest: manifest(
@@ -750,7 +750,11 @@ describe('catalog_agent_authorizations writer projection', () => {
               url: TEST_AGENT_RAW,
               authorization_type: 'publisher_properties',
               publisher_properties: [
-                { publisher_domain: TEST_PUB, selection_type: 'by_tag', property_tags: ['flagship'] },
+                {
+                  publisher_domains: [VICTIM_PUB, TEST_PUB],
+                  selection_type: 'by_tag',
+                  property_tags: ['raptive_managed'],
+                },
               ],
             },
           ],
@@ -760,17 +764,56 @@ describe('catalog_agent_authorizations writer projection', () => {
               property_type: 'website',
               name: 'Site A',
               identifiers: [{ type: 'domain', value: TEST_PUB }],
-              tags: ['flagship'],
+              tags: ['raptive_managed'],
+            },
+            {
+              property_id: 'site_b',
+              property_type: 'website',
+              name: 'Site B',
+              identifiers: [{ type: 'subdomain', value: `b.${TEST_PUB}` }],
+              tags: ['other'],
+            },
+            {
+              property_id: 'victim_site',
+              property_type: 'website',
+              name: 'Victim site',
+              identifiers: [{ type: 'domain', value: VICTIM_PUB }],
+              publisher_domain: VICTIM_PUB,
+              tags: ['raptive_managed'],
             },
           ]
         ),
       });
-      const { rows } = await pool.query(
-        `SELECT 1 FROM catalog_agent_authorizations
-          WHERE agent_url_canonical = $1`,
+      const { rows } = await pool.query<{ property_id_slug: string }>(
+        `SELECT property_id_slug FROM catalog_agent_authorizations
+          WHERE agent_url_canonical = $1 AND property_rid IS NOT NULL
+          ORDER BY property_id_slug`,
         [TEST_AGENT_CANON]
       );
-      expect(rows).toHaveLength(0);
+      expect(rows.map((r) => r.property_id_slug)).toEqual(['site_a']);
+
+      const federatedDb = new FederatedIndexDatabase();
+      const validation = await federatedDb.validateAgentForProduct(TEST_AGENT_CANON, [
+        {
+          publisher_domain: TEST_PUB,
+          selection_type: 'by_tag',
+          property_tags: ['raptive_managed'],
+        },
+      ]);
+      expect(validation.authorized).toBe(true);
+      expect(validation.total_requested).toBe(1);
+      expect(validation.total_authorized).toBe(1);
+
+      const victimValidation = await federatedDb.validateAgentForProduct(TEST_AGENT_CANON, [
+        {
+          publisher_domain: VICTIM_PUB,
+          selection_type: 'by_tag',
+          property_tags: ['raptive_managed'],
+        },
+      ]);
+      expect(victimValidation.authorized).toBe(false);
+      expect(victimValidation.total_requested).toBe(0);
+      expect(victimValidation.total_authorized).toBe(0);
     });
   });
 

--- a/server/tests/unit/conformance-addie-tools.test.ts
+++ b/server/tests/unit/conformance-addie-tools.test.ts
@@ -11,11 +11,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { MemberContext } from '../../src/addie/member-context.js';
 
-process.env.CONFORMANCE_JWT_SECRET = 'test-addie-tools-secret';
-process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'test';
-process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+const { runStoryboardMock } = vi.hoisted(() => {
+  process.env.CONFORMANCE_JWT_SECRET = 'test-addie-tools-secret';
+  process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'test';
+  process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+  return { runStoryboardMock: vi.fn() };
+});
 
-const runStoryboardMock = vi.fn();
 vi.mock('../../src/conformance/run-storyboard-via-ws.js', async () => {
   const actual = await vi.importActual<Record<string, unknown>>(
     '../../src/conformance/run-storyboard-via-ws.js',
@@ -25,6 +27,8 @@ vi.mock('../../src/conformance/run-storyboard-via-ws.js', async () => {
     runStoryboardViaConformanceSocket: (...args: unknown[]) => runStoryboardMock(...args),
   };
 });
+import { createConformanceToolHandlers } from '../../src/addie/mcp/conformance-tools.js';
+import { conformanceSessions } from '../../src/conformance/session-store.js';
 
 function memberContextWithOrg(orgId: string): MemberContext {
   return {
@@ -49,15 +53,11 @@ function memberContextWithoutOrg(): MemberContext {
 
 beforeEach(async () => {
   runStoryboardMock.mockReset();
-  const { conformanceSessions } = await import('../../src/conformance/session-store.js');
   await conformanceSessions.closeAll();
 });
 
 describe('issue_conformance_token Addie tool', () => {
   it('returns a not-mapped hint when the caller has no org', async () => {
-    const { createConformanceToolHandlers } = await import(
-      '../../src/addie/mcp/conformance-tools.js'
-    );
     const handlers = createConformanceToolHandlers(memberContextWithoutOrg());
     const handler = handlers.get('issue_conformance_token');
     const out = await handler!({});
@@ -65,9 +65,6 @@ describe('issue_conformance_token Addie tool', () => {
   });
 
   it('returns a token + url + expiry when the caller has an org', async () => {
-    const { createConformanceToolHandlers } = await import(
-      '../../src/addie/mcp/conformance-tools.js'
-    );
     const handlers = createConformanceToolHandlers(memberContextWithOrg('org_alpha'));
     const handler = handlers.get('issue_conformance_token');
     const out = await handler!({});
@@ -80,9 +77,6 @@ describe('issue_conformance_token Addie tool', () => {
 
   it('returns a configuration error when CONFORMANCE_JWT_SECRET is missing', async () => {
     delete process.env.CONFORMANCE_JWT_SECRET;
-    const { createConformanceToolHandlers } = await import(
-      '../../src/addie/mcp/conformance-tools.js'
-    );
     const handlers = createConformanceToolHandlers(memberContextWithOrg('org_alpha'));
     const out = await handlers.get('issue_conformance_token')!({});
     expect(out).toMatch(/not configured/i);
@@ -92,9 +86,6 @@ describe('issue_conformance_token Addie tool', () => {
 
 describe('run_conformance_against_my_agent Addie tool', () => {
   it('returns a not-mapped hint when the caller has no org', async () => {
-    const { createConformanceToolHandlers } = await import(
-      '../../src/addie/mcp/conformance-tools.js'
-    );
     const handlers = createConformanceToolHandlers(memberContextWithoutOrg());
     const out = await handlers.get('run_conformance_against_my_agent')!({
       storyboard_id: 'media_buy_state_machine',
@@ -104,18 +95,12 @@ describe('run_conformance_against_my_agent Addie tool', () => {
   });
 
   it('returns a missing-id message when storyboard_id is empty', async () => {
-    const { createConformanceToolHandlers } = await import(
-      '../../src/addie/mcp/conformance-tools.js'
-    );
     const handlers = createConformanceToolHandlers(memberContextWithOrg('org_a'));
     const out = await handlers.get('run_conformance_against_my_agent')!({});
     expect(out).toMatch(/storyboard_id.*required/i);
   });
 
   it('returns the not-connected hint when the org has no live session', async () => {
-    const { createConformanceToolHandlers } = await import(
-      '../../src/addie/mcp/conformance-tools.js'
-    );
     const handlers = createConformanceToolHandlers(memberContextWithOrg('org_a'));
     const out = await handlers.get('run_conformance_against_my_agent')!({
       storyboard_id: 'media_buy_state_machine',
@@ -126,10 +111,6 @@ describe('run_conformance_against_my_agent Addie tool', () => {
   });
 
   it('formats a passing storyboard result as markdown', async () => {
-    const { createConformanceToolHandlers } = await import(
-      '../../src/addie/mcp/conformance-tools.js'
-    );
-    const { conformanceSessions } = await import('../../src/conformance/session-store.js');
     // Register a placeholder session so the not-connected guard doesn't fire.
     conformanceSessions.register({
       orgId: 'org_a',
@@ -171,10 +152,6 @@ describe('run_conformance_against_my_agent Addie tool', () => {
   });
 
   it('renders error text and failed validation details on failing steps', async () => {
-    const { createConformanceToolHandlers } = await import(
-      '../../src/addie/mcp/conformance-tools.js'
-    );
-    const { conformanceSessions } = await import('../../src/conformance/session-store.js');
     conformanceSessions.register({
       orgId: 'org_a',
       transport: { close: vi.fn().mockResolvedValue(undefined) } as never,

--- a/server/tests/unit/rate-limit-retry-after.test.ts
+++ b/server/tests/unit/rate-limit-retry-after.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import express from 'express';
 import request from 'supertest';
-import { parseRetryAfterSeconds, agentReadRateLimiter } from '../../src/middleware/rate-limit.js';
+import { parseRetryAfterSeconds, createAgentReadRateLimiter } from '../../src/middleware/rate-limit.js';
 
 /**
  * Tests for the retryAfter fallback field we surface on the 429 body
@@ -40,35 +40,30 @@ describe('parseRetryAfterSeconds', () => {
 
 describe('agentReadRateLimiter 429 body', () => {
   // Exercise the actual middleware through a tiny express app so the
-  // assertion lives at the same layer production depends on.
-  // `agentReadRateLimiter` is a module-singleton with a cached
-  // Postgres store — the increment hot path is in-memory, so no real
-  // DB is needed, but the counter persists across tests. `resetKey`
-  // scrubs the per-key counter in `beforeEach` so each test starts
-  // from zero regardless of what ran earlier in the suite.
+  // assertion lives at the same layer production depends on. Use an
+  // isolated limiter instance rather than the production singleton so
+  // parallel test files cannot reset or mutate this counter.
   function buildApp() {
     const app = express();
+    const limiter = createAgentReadRateLimiter({ max: 3 });
     app.use((req, _res, next) => {
       (req as any).user = { id: RATE_LIMIT_TEST_USER_ID };
       next();
     });
-    app.get('/ping', agentReadRateLimiter, (_req, res) => res.status(200).json({ ok: true }));
+    app.get('/ping', limiter, (_req, res) => res.status(200).json({ ok: true }));
     return app;
   }
 
   const RATE_LIMIT_TEST_USER_ID = 'rate-limit-retry-after-test-user';
-  beforeEach(async () => {
-    await agentReadRateLimiter.resetKey(RATE_LIMIT_TEST_USER_ID);
-  });
 
   it('includes `retryAfter` (seconds) in the body matching the Retry-After header', async () => {
     const app = buildApp();
-    // Race past the 240/min cap. Same IP so the limiter keys identically.
+    // Race past the configured cap. Same user so the limiter keys identically.
     // Serial rather than parallel — express-rate-limit's in-flight
     // tracking is more deterministic, and the assertion is about the
     // 429 body shape, not concurrent behavior.
     let last: Awaited<ReturnType<typeof request>>;
-    for (let i = 0; i < 241; i++) {
+    for (let i = 0; i < 4; i++) {
       last = await request(app).get('/ping');
     }
     expect(last!.status).toBe(429);


### PR DESCRIPTION
Treat ads.txt managerdomain delegation as authoritative when the manager adagents.json explicitly scopes the source publisher through publisher_properties, including compact publisher_domains[] with by_tag selectors.
The crawler, catalog projection, and registry read models now keep delegated authorization limited to the matching publisher and selector so manager-file sibling properties do not leak into another publisher's verdict.
This also adds integration coverage for delegated by_tag authorization and off-domain negative cases, plus isolates two flaky unit tests from shared limiter/import state so precommit is deterministic.

Validation: precommit hook passed during commit, including npm run test:unit, dynamic import checks, callapi state-change check, full server unit precommit selection, and npm run typecheck.
