### PR TITLE
feat(addie): add support recovery jobs and runbooks

### DIFF
--- a/.changeset/spicy-hairs-open.md
+++ b/.changeset/spicy-hairs-open.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add operational recovery for Addie support cycles: scheduled escalation SLA follow-up, certification completion reconciliation with fallback escalations, admin domain verification recovery, and training/runbook documentation for the remaining support gaps.

--- a/docs.json
+++ b/docs.json
@@ -218,7 +218,8 @@
                       "docs/building/operating/orchestrator-design",
                       "docs/building/operating/transport-errors",
                       "docs/building/operating/seller-integration",
-                      "docs/building/operating/storyboard-troubleshooting"
+                      "docs/building/operating/storyboard-troubleshooting",
+                      "docs/building/operating/support-recovery-runbooks"
                     ]
                   },
                   {
@@ -650,6 +651,15 @@
                       "docs/learning/specialist/governance",
                       "docs/learning/specialist/sponsored-intelligence",
                       "docs/learning/specialist/security"
+                    ]
+                  },
+                  {
+                    "group": "Supplements",
+                    "expanded": false,
+                    "pages": [
+                      "docs/learning/supplements/buyer-briefs-and-get-products",
+                      "docs/learning/supplements/governance-protocol-by-role",
+                      "docs/learning/supplements/creative-agent-workflows"
                     ]
                   },
                   {
@@ -1423,7 +1433,8 @@
                   "docs/building/operating/orchestrator-design",
                   "docs/building/operating/transport-errors",
                   "docs/building/operating/seller-integration",
-                  "docs/building/operating/storyboard-troubleshooting"
+                  "docs/building/operating/storyboard-troubleshooting",
+                  "docs/building/operating/support-recovery-runbooks"
                 ]
               },
               {
@@ -1830,6 +1841,15 @@
                   "docs/learning/specialist/governance",
                   "docs/learning/specialist/sponsored-intelligence",
                   "docs/learning/specialist/security"
+                ]
+              },
+              {
+                "group": "Supplements",
+                "expanded": false,
+                "pages": [
+                  "docs/learning/supplements/buyer-briefs-and-get-products",
+                  "docs/learning/supplements/governance-protocol-by-role",
+                  "docs/learning/supplements/creative-agent-workflows"
                 ]
               },
               {

--- a/docs/building/operating/support-recovery-runbooks.mdx
+++ b/docs/building/operating/support-recovery-runbooks.mdx
@@ -1,0 +1,127 @@
+---
+title: "Support recovery runbooks"
+sidebarTitle: "Support recovery"
+description: "Operational runbooks for escalation SLA follow-up, certification completion recovery, domain verification, and registry crawl recovery."
+"og:title": "AdCP - Support recovery runbooks"
+---
+
+# Support recovery runbooks
+
+These runbooks cover support cases that should not sit silently in Addie, certification, or registry queues.
+
+## Escalation SLA follow-up
+
+Addie support requests are visible in the admin escalation dashboard and in the requester's dashboard. The SLA enforcement job runs hourly.
+
+Admin follow-up rules:
+
+- Urgent open requests are re-surfaced to the configured private escalation Slack channel after 4 hours.
+- Other open requests are re-surfaced after 24 hours.
+- Acknowledged or in-progress requests are re-surfaced after 24 hours without an update.
+- Requesters receive a visible dashboard update after 24 hours and can add details or close the request themselves.
+
+Operator checklist:
+
+1. Open `/admin/escalations`.
+2. Filter to active requests and look for "Needs pickup" or "Needs update".
+3. Acknowledge or move the request to in progress when a human owns it.
+4. Add requester-visible notes when the requester needs status.
+5. Resolve the request when fixed, and notify the user when appropriate.
+
+If Slack notifications are missing, configure the escalation channel in `/admin/settings`.
+
+## Certification completion recovery
+
+The certification recovery job runs every 6 hours. It looks for passed attempts that did not finish module or credential reconciliation.
+
+Automatic behavior:
+
+- Reconcile the passed attempt to `learner_progress`.
+- Re-run credential eligibility and awarding.
+- File a deduplicated escalation if automatic repair cannot award the credential.
+
+Manual repair:
+
+1. Open `/admin/certification`.
+2. In "Attempts needing attention", click "Reconcile credentials" for passed attempts.
+3. If the attempt still has warnings, open the learner detail panel.
+4. Use "Admin completion repair" only when there is a teaching checkpoint for the learner, module, and Addie thread.
+5. Run "Issue missing badges" when the local credential exists but Certifier badge fields are missing.
+6. Record the escalation ID or reason in the note field.
+
+Do not create a duplicate manual credential unless the learner record already proves the module completion. Repair the learner record first, then issue or backfill the credential.
+
+## Domain verification recovery
+
+Use admin domain verification recovery when a member has published the WorkOS DNS TXT record but the self-service verify path is blocked, rate-limited, or the webhook did not update local state.
+
+This is an internal support workflow. Use authenticated admin domain tooling or the private ops runbook; public docs should not expose admin endpoint paths, bearer-token examples, or WorkOS challenge-token handling.
+
+Outcomes:
+
+- `success: true`: WorkOS confirmed DNS and local `organization_domains` was reconciled.
+- `still_pending`: WorkOS still cannot see the TXT record. Ask the member to confirm the record name and token.
+- `no_challenge`: issue a new domain challenge from the member domain settings or admin domain tooling.
+
+DNS propagation normally takes minutes, but stale provider caches can last longer. Do not keep retrying every few seconds; fix the DNS record and retry after propagation.
+
+## Registry and heartbeat recovery
+
+Use these triggers after a member fixes `adagents.json`, `brand.json`, authorization, or endpoint health.
+
+Publisher and brand crawl requests require an authenticated member or admin request and a JSON `domain` body:
+
+```bash
+curl -X POST "https://agenticadvertising.org/api/registry/crawl-request" \
+  -H "Content-Type: application/json" \
+  -b "$SESSION_COOKIE" \
+  --data '{"domain":"example.publisher"}'
+```
+
+Expected accepted response:
+
+```json
+{ "message": "Crawl request accepted", "domain": "example.publisher" }
+```
+
+For brand manifests, use the same body shape:
+
+```bash
+curl -X POST "https://agenticadvertising.org/api/registry/brand-crawl-request" \
+  -H "Content-Type: application/json" \
+  -b "$SESSION_COOKIE" \
+  --data '{"domain":"example.brand"}'
+```
+
+Expected accepted response:
+
+```json
+{ "message": "Brand crawl request accepted", "domain": "example.brand" }
+```
+
+Agent refresh and heartbeat requeue use an encoded agent URL. The caller must own the agent or be an AAO admin.
+
+```bash
+AGENT_URL="https://seller.example/adcp"
+ENCODED_URL="$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$AGENT_URL")"
+
+curl -X POST "https://agenticadvertising.org/api/registry/agents/$ENCODED_URL/refresh" \
+  -b "$SESSION_COOKIE"
+```
+
+Refresh returns the latest probe result or a `409`, `429`, or `502` error if monitoring is paused, rate-limited, or the probe fails.
+
+Queue heartbeat without synchronous probing when the agent should be checked by the normal monitor:
+
+```bash
+curl -X POST "https://agenticadvertising.org/api/registry/agents/$ENCODED_URL/monitoring/requeue" \
+  -b "$SESSION_COOKIE"
+```
+
+Expected response:
+
+```json
+{ "requeued": true }
+```
+
+Use refresh for a specific agent after endpoint or capability fixes. Use crawl request for publisher authorization changes.

--- a/docs/learning/supplements/buyer-briefs-and-get-products.mdx
+++ b/docs/learning/supplements/buyer-briefs-and-get-products.mdx
@@ -1,0 +1,103 @@
+---
+title: "Buyer briefs and get_products request shape"
+sidebarTitle: "Buyer briefs"
+description: "How buyer agents decide what belongs in the get_products brief string, structured filters, and follow-up refinement requests."
+"og:title": "AdCP - Buyer briefs and get_products request shape"
+---
+
+# Buyer briefs and get_products request shape
+
+This supplement prepares buyer-side implementers to turn a human campaign request into a precise `get_products` call.
+
+The goal is not to make the brief verbose. The goal is to put intent in the brief and hard constraints in typed fields so the seller can curate inventory without guessing which parts are negotiable.
+
+## Mental model
+
+| Input | Use it for | Avoid putting here |
+|---|---|---|
+| `brief` | Buyer intent, audience language, context, tone, business goal, and success definition | Machine-enforceable constraints that already have typed fields |
+| `filters` | Hard constraints that should silently exclude non-matching products | Soft preferences that a seller could satisfy through curation |
+| `brand` | The buyer brand identity the seller uses for eligibility, safety, and fit | A second copy of the campaign brief |
+| `catalog` | Commerce or product-set context when the campaign is catalog-driven | General brand positioning |
+| `refine` | Specific changes to a prior discovery response | New unrelated discovery goals |
+
+## What goes in the brief
+
+Use the brief for context that a seller or curator needs to make judgment calls:
+
+- campaign objective: awareness, consideration, qualified traffic, store visits, conversion, renewal
+- audience description in human terms
+- product, offer, seasonal context, or creative direction
+- must-understand sensitivities such as family suitability or competitive adjacency
+- success language that is not a metric filter, such as "favor trusted editorial environments"
+
+Example:
+
+```json
+{
+  "buying_mode": "brief",
+  "brief": "Launch Nova Running's spring trail shoe line with outdoor enthusiasts. Favor trusted adventure and fitness contexts, avoid discount-led positioning, and prioritize packages that can support a brand-lift readout.",
+  "brand": {
+    "domain": "novarunning.example"
+  }
+}
+```
+
+## What goes in filters
+
+Use filters when a product that fails the condition should not come back.
+
+Good filter candidates:
+
+- required channels or formats
+- required geo targeting support
+- required measurement or reporting capabilities
+- pricing currency constraints
+- budget ranges
+- fixed-price requirements
+- product categories for wholesale/catalog use
+
+Example:
+
+```json
+{
+  "buying_mode": "brief",
+  "brief": "Launch Nova Running's spring trail shoe line with outdoor enthusiasts. Favor trusted adventure and fitness contexts.",
+  "brand": {
+    "domain": "novarunning.example"
+  },
+  "filters": {
+    "channels": ["ctv", "display"],
+    "pricing_currencies": ["USD"],
+    "required_metrics": ["impressions", "clicks"]
+  }
+}
+```
+
+If the buyer says "ideally CTV, but display is okay," keep that preference in the brief. If they say "CTV only," use `filters.channels`.
+
+## Brief vs. refine
+
+Use `buying_mode: "refine"` when the buyer is reacting to a previous discovery response. A refine request should point at what changed: remove a product, adjust budget, request more premium placements, narrow geography, or ask for alternatives.
+
+Do not send a totally new campaign in `refine`; start a new `brief` request instead.
+
+## Implementation checklist
+
+- Normalize the human request into intent, hard constraints, and follow-up changes before calling the seller.
+- Preserve the buyer's business language in `brief`; do not collapse it into only keywords.
+- Put typed constraints in `filters` so sellers can explain exclusions through `filter_diagnostics`.
+- Keep `brief` out of `wholesale` mode.
+- Persist the request tuple with the response so later `refine` calls and `wholesale_feed_version` comparisons are scoped correctly.
+
+## Practice prompt
+
+A buyer says:
+
+> We need a six-week launch for Acme Meals' new family dinner kits. We want CTV or online video, only USD pricing, something suitable for parents with kids, and we need completion-rate reporting.
+
+Expected decomposition:
+
+- Brief: family dinner kit launch, parent audience, suitable contexts, six-week launch.
+- Filters: video-capable channel/format constraints, USD pricing, completion-rate reporting.
+- Brand: Acme Meals domain or BrandRef.

--- a/docs/learning/supplements/creative-agent-workflows.mdx
+++ b/docs/learning/supplements/creative-agent-workflows.mdx
@@ -1,0 +1,92 @@
+---
+title: "Creative agent workflows"
+sidebarTitle: "Creative workflows"
+description: "How creative agents implement build_creative, preview_creative, sync_creatives, and human approval workflows."
+"og:title": "AdCP - Creative agent workflows"
+---
+
+# Creative agent workflows
+
+This supplement prepares creative-agent implementers to model the full creative lifecycle: build, preview, approve, sync, and recover.
+
+Creative agents differ in how much state they own. A template transformer may return assets directly. A generative agent may need async production. An ad server may return a preview first and withhold a live tag until approval.
+
+## Core lifecycle
+
+1. Discover capabilities and supported formats.
+2. Build or transform the creative with `build_creative`.
+3. Preview the creative with `preview_creative`.
+4. Collect human approval when the agent or publisher requires it.
+5. Sync approved creatives with `sync_creatives`.
+6. Report usage or delivery where the workflow requires it.
+
+## build_creative
+
+Use `build_creative` to produce a creative manifest or start production.
+
+The request should carry:
+
+- the target format or canonical `format_kind`
+- assets or creative brief inputs
+- brand context
+- any product-specific narrowing from `format_options[]`
+- pricing option selection when the creative agent charges for production
+
+The response should be explicit about whether the creative is ready, still working, failed, or waiting for input.
+
+## preview_creative
+
+Use `preview_creative` for reviewable renderings. A preview is not necessarily the live tag.
+
+Common patterns:
+
+- Static asset preview: image, video, audio, or HTML preview.
+- Batch preview: many variations from the same manifest.
+- Historical preview: render a prior variant from delivery records.
+- Vendor preview: expiring preview link while the live tag remains withheld.
+
+If a vendor withholds a live tag until approval, model that as preview plus approval state. Do not invent a separate "get tag" task.
+
+## sync_creatives
+
+Use `sync_creatives` to push approved creative assets or tags into the seller or publisher environment.
+
+Implementation rules:
+
+- Accept async `working` states when upstream trafficking is not immediate.
+- Return stable creative IDs and platform IDs when available.
+- Preserve idempotency across retries.
+- Report validation failures with field-level detail.
+- Keep buyer-owned creative identity separate from seller platform IDs.
+
+## Human approval
+
+Human approval is part of the workflow when the creative has policy, brand, legal, publisher, or vendor review requirements.
+
+Model approval as state, not silence:
+
+- `pending_review`: someone must approve before sync or live tag release.
+- `approved`: sync may proceed or live tag may be released.
+- `rejected`: the buyer or creative agent must revise before resubmitting with `sync_creatives`.
+
+## Recovery patterns
+
+| Failure | Recovery |
+|---|---|
+| Format mismatch | Re-read product `format_options[]`, choose the correct `format_kind`, rebuild |
+| Missing required asset | Ask for only the missing asset; do not restart discovery |
+| Preview expired | Re-run `preview_creative` or request a fresh preview link |
+| Human approval stalled | Surface the pending approval state and owner |
+| Sync returns async working | Poll task status or subscribe to notifications |
+| Seller rejects creative | Preserve rejection reason, revise manifest, retry with a new logical revision |
+
+## Practice prompt
+
+A vendor creative agent returns a preview URL but no live display tag. The buyer asks the orchestrator to traffic the campaign immediately.
+
+Expected answer:
+
+- The orchestrator treats the creative as previewed but not approved/live.
+- The buyer or reviewer approves the preview.
+- The creative agent releases or syncs the live tag through the approved workflow.
+- The seller receives the synced creative only after the approval state permits execution.

--- a/docs/learning/supplements/governance-protocol-by-role.mdx
+++ b/docs/learning/supplements/governance-protocol-by-role.mdx
@@ -1,0 +1,85 @@
+---
+title: "Governance protocol by role"
+sidebarTitle: "Governance by role"
+description: "Buyer and seller responsibilities in the campaign governance loop, including sync_plans, check_governance, signed governance context, and report_plan_outcome."
+"og:title": "AdCP - Governance protocol by role"
+---
+
+# Governance protocol by role
+
+Governance in AdCP is a shared control loop. The buyer-side governance agent decides whether a planned or executed action is allowed. The buyer agent obtains and carries the governance context. The seller verifies that context before executing work and reports outcomes back into the audit trail.
+
+## Roles
+
+| Role | Responsibility |
+|---|---|
+| Buyer agent | Builds the plan, calls governance, and attaches governance context to seller requests |
+| Governance agent | Evaluates intent and execution against plan, policy, budget, and authority |
+| Seller agent | Verifies signed governance context before execution and reports confirmed outcomes |
+| Human reviewer | Handles exceptions, overrides, and ambiguous policy decisions when required |
+
+## Buyer-side flow
+
+1. Create or update the campaign plan with `sync_plans`.
+2. Call `check_governance` for the intent phase before asking a seller to execute.
+3. Attach the returned governance context to the seller request.
+4. When execution details come back, call `check_governance` again for the execution phase if the workflow requires it.
+5. Poll or subscribe to outcomes and preserve the governance audit trail.
+
+The buyer owns the planning truth. If the buyer changes budget, audience, seller, flight dates, product selection, or objective, it must update the plan or request a new governance decision.
+
+## Seller-side flow
+
+1. Receive a request with governance context.
+2. Verify the signed governance context before execution.
+3. Bind the token to the expected plan, caller, seller, phase, and operation.
+4. Reject missing, expired, revoked, replayed, or mismatched signed context with `PERMISSION_DENIED`.
+5. Report confirmed delivery or spend through `report_plan_outcome` when the seller is responsible for outcome reporting.
+
+The seller does not reinterpret buyer policy from scratch. It verifies that the buyer's governance agent authorized this exact execution and reports what actually happened.
+
+Use `GOVERNANCE_DENIED` only when the buyer-side governance agent returned an actual denial for the planned or executed action.
+
+## check_governance payload discipline
+
+The most common implementation bug is sending a partial check that omits the fields needed for the phase.
+
+Intent checks normally need:
+
+- `plan_id`
+- `caller`
+- proposed seller or operator identity
+- budget and pacing intent
+- targeting and policy-relevant constraints
+- products or package references when already selected
+
+Execution checks normally need:
+
+- `plan_id`
+- `caller`
+- seller identity
+- concrete package, creative, targeting, dates, and budget being executed
+- delivery or execution metrics when checking a delivery phase
+- prior governance context or correlation identifier when the task requires continuity
+
+## What to test
+
+- A valid plan passes intent check.
+- A seller swap fails unless the plan authorizes that seller.
+- A budget increase fails until `sync_plans` updates the plan.
+- A replayed governance token fails.
+- An expired or revoked token fails.
+- A delivery report outside the authorized plan fails or produces an audit finding.
+
+## Practice prompt
+
+Design a governance test for this case:
+
+> Pinnacle Media wants to buy a family-safe CTV package for Nova Snacks. The buyer plan caps spend at USD 75,000 and allows only two approved sellers. A seller returns a higher-budget package with a different seller identity.
+
+Expected answer:
+
+- Buyer updates or rejects the plan before execution.
+- Governance intent check should deny the unapproved seller or over-budget package.
+- Seller must not execute on a context bound to the original seller or budget.
+- Audit logs should show the denial reason and the attempted execution facts.

--- a/docs/registry/registering-an-agent.mdx
+++ b/docs/registry/registering-an-agent.mdx
@@ -113,4 +113,4 @@ To check whether your agent is referenced in a publisher's `adagents.json` (for 
 - [Registry overview](/docs/registry) — endpoint catalog, lookup flows, and brand resolution.
 - `GET /api/registry/operator?domain=X` — auth-aware per-entity view of agents and authorizations.
 - `GET /api/registry/agents` — full registry catalog.
-- `POST /api/registry/recrawl` — refresh a publisher's `adagents.json` mapping in the authorization graph.
+- `POST /api/registry/crawl-request` - refresh a publisher's `adagents.json` mapping in the authorization graph.

--- a/server/public/admin-certification.html
+++ b/server/public/admin-certification.html
@@ -388,7 +388,10 @@
       <!-- Attempts needing attention -->
       <div class="section" id="stuck-section" style="display:none;">
         <h2>Attempts needing attention</h2>
-        <p style="color:var(--color-text-secondary);font-size:14px;margin-bottom:16px;">Capstone attempts in progress for 7+ days, plus passed attempts that still need credential reconciliation.</p>
+        <p style="color:var(--color-text-secondary);font-size:14px;margin-bottom:16px;">
+          Capstone attempts in progress for 7+ days, plus passed attempts that still need credential reconciliation.
+          Follow the <a href="/docs/building/operating/support-recovery-runbooks#certification-completion-recovery" target="_blank" rel="noopener">recovery runbook</a> when automatic reconciliation returns warnings.
+        </p>
         <table id="stuck-table">
           <thead>
             <tr>

--- a/server/src/addie/jobs/certification-recovery.ts
+++ b/server/src/addie/jobs/certification-recovery.ts
@@ -1,0 +1,160 @@
+/**
+ * Certification recovery job.
+ *
+ * Repairs the common failure mode where an assessment attempt is already
+ * marked passed but the module/credential reconciliation did not finish. If
+ * the repair still cannot award the credential, file one deduplicated
+ * escalation so admins have a queue item instead of a silent learner block.
+ */
+
+import { createLogger } from '../../logger.js';
+import * as certDb from '../../db/certification-db.js';
+import {
+  createEscalation,
+  markNotificationSent,
+  type Escalation,
+} from '../../db/escalation-db.js';
+import { getEscalationChannel } from '../../db/system-settings-db.js';
+import { sendChannelMessage } from '../../slack/client.js';
+
+const logger = createLogger('certification-recovery');
+
+export interface CertificationRecoveryJobOptions {
+  limit?: number;
+}
+
+export interface CertificationRecoveryJobResult {
+  scanned: number;
+  repaired: number;
+  escalated: number;
+  notified: number;
+  skipped_no_channel: number;
+  errors: number;
+}
+
+function extractNumericScores(scores: Record<string, unknown> | null): Record<string, number> | null {
+  if (!scores || Array.isArray(scores) || typeof scores !== 'object') return null;
+  const numeric: Record<string, number> = {};
+  for (const [key, value] of Object.entries(scores)) {
+    if (key.startsWith('_')) continue;
+    if (typeof value === 'number' && Number.isFinite(value)) numeric[key] = value;
+  }
+  return Object.keys(numeric).length > 0 ? numeric : null;
+}
+
+function certificationEscalationText(escalation: Escalation, attemptId: string, moduleId: string): string {
+  return [
+    `:warning: *Certification recovery needed: escalation #${escalation.id}*`,
+    '',
+    `A passed certification attempt could not be reconciled automatically.`,
+    `*Attempt:* \`${attemptId}\``,
+    `*Module:* \`${moduleId}\``,
+    `*Learner:* \`${escalation.workos_user_id || 'unknown'}\``,
+    '',
+    `<https://agenticadvertising.org/admin/certification?user=${encodeURIComponent(escalation.workos_user_id || '')}&module=${encodeURIComponent(moduleId)}|Open certification admin>`,
+  ].join('\n');
+}
+
+async function notifyEscalation(escalation: Escalation, attemptId: string, moduleId: string): Promise<boolean | 'no_channel'> {
+  if (escalation.notification_message_ts) return false;
+
+  const channel = await getEscalationChannel();
+  if (!channel.channel_id) return 'no_channel';
+
+  const sent = await sendChannelMessage(
+    channel.channel_id,
+    { text: certificationEscalationText(escalation, attemptId, moduleId) },
+    { requirePrivate: true },
+  );
+  if (sent.ok && sent.ts) {
+    await markNotificationSent(escalation.id, channel.channel_id, sent.ts);
+    return true;
+  }
+  logger.warn(
+    { escalationId: escalation.id, channelId: channel.channel_id, error: sent.error },
+    'Failed to send certification recovery escalation notification',
+  );
+  return false;
+}
+
+export async function runCertificationRecoveryJob(
+  options: CertificationRecoveryJobOptions = {},
+): Promise<CertificationRecoveryJobResult> {
+  const stuck = await certDb.getStuckAttempts(7);
+  const candidates = stuck
+    .filter(a => a.status === 'passed' && a.module_id)
+    .slice(0, options.limit ?? 25);
+
+  const result: CertificationRecoveryJobResult = {
+    scanned: candidates.length,
+    repaired: 0,
+    escalated: 0,
+    notified: 0,
+    skipped_no_channel: 0,
+    errors: 0,
+  };
+
+  for (const candidate of candidates) {
+    const moduleId = candidate.module_id;
+    if (!moduleId) continue;
+
+    try {
+      const attempt = await certDb.getAttempt(candidate.id);
+      if (!attempt || attempt.status !== 'passed' || attempt.passing !== true) continue;
+
+      const scores = extractNumericScores(attempt.scores);
+      if (!scores) {
+        throw new Error('Passed attempt has no numeric scores to reconcile');
+      }
+
+      await certDb.reconcilePassedAttemptModule(attempt, moduleId, scores);
+      const awarded = await certDb.checkAndAwardCredentials(attempt.workos_user_id);
+      if (awarded.length > 0) {
+        result.repaired += 1;
+        continue;
+      }
+
+      const stillEligibleButMissing = await certDb.hasEligibleMissingCredentialForModule(
+        attempt.workos_user_id,
+        moduleId,
+      );
+      if (!stillEligibleButMissing) continue;
+
+      const escalation = await createEscalation({
+        workos_user_id: attempt.workos_user_id,
+        user_display_name: candidate.name,
+        user_email: candidate.email,
+        category: 'needs_human_action',
+        priority: 'high',
+        summary: `Certification attempt ${candidate.id} passed but no credential was awarded`,
+        addie_context: [
+          `Certification recovery tried to reconcile module ${moduleId} and re-run credential awarding, but no credential was awarded.`,
+          `Use the certification admin repair panel or backfill badges runbook.`,
+        ].join(' '),
+        dedup_key: `certification-recovery:${candidate.id}`,
+      });
+      result.escalated += 1;
+
+      const notified = await notifyEscalation(escalation, candidate.id, moduleId);
+      if (notified === true) result.notified += 1;
+      if (notified === 'no_channel') result.skipped_no_channel += 1;
+    } catch (err) {
+      result.errors += 1;
+      logger.warn(
+        { err, attemptId: candidate.id, moduleId },
+        'Certification recovery candidate failed',
+      );
+    }
+  }
+
+  if (
+    result.repaired > 0 ||
+    result.escalated > 0 ||
+    result.skipped_no_channel > 0 ||
+    result.errors > 0
+  ) {
+    logger.info(result, 'Certification recovery job completed');
+  }
+
+  return result;
+}

--- a/server/src/addie/jobs/escalation-sla.ts
+++ b/server/src/addie/jobs/escalation-sla.ts
@@ -1,0 +1,186 @@
+/**
+ * Escalation SLA enforcement.
+ *
+ * The admin dashboard can show overdue tickets, but visibility alone does not
+ * close the loop. This job re-surfaces overdue active escalations to the
+ * configured private escalation Slack channel, and writes a requester-visible
+ * update after 24 hours so the requester can see that the request is still
+ * open and has an alternate contact path.
+ */
+
+import { createLogger } from '../../logger.js';
+import {
+  addSystemEscalationUpdate,
+  describeEscalationSla,
+  listEscalationsForSlaEnforcement,
+  markEscalationSlaNotified,
+  type Escalation,
+} from '../../db/escalation-db.js';
+import { getEscalationChannel } from '../../db/system-settings-db.js';
+import { sendChannelMessage, sendDirectMessage } from '../../slack/client.js';
+
+const logger = createLogger('escalation-sla');
+
+const SUPPORT_EMAIL = 'support@agenticadvertising.org';
+
+export interface EscalationSlaJobOptions {
+  limit?: number;
+  now?: Date;
+}
+
+export interface EscalationSlaJobResult {
+  scanned: number;
+  admin_alerted: number;
+  requester_updated: number;
+  requester_dm_sent: number;
+  skipped_no_channel: number;
+  errors: number;
+}
+
+function hoursBetween(start: Date | string | null | undefined, end: Date): number {
+  if (!start) return 0;
+  const startMs = new Date(start).getTime();
+  if (!Number.isFinite(startMs)) return 0;
+  return Math.max(0, (end.getTime() - startMs) / (60 * 60 * 1000));
+}
+
+function isAdminAlertDue(escalation: Escalation, now: Date): boolean {
+  const sla = describeEscalationSla(escalation, now);
+  if (!sla.needs_follow_up) return false;
+  if (!escalation.sla_admin_last_notified_at) return true;
+  return hoursBetween(escalation.sla_admin_last_notified_at, now) >= 4;
+}
+
+function isRequesterUpdateDue(escalation: Escalation, now: Date): boolean {
+  if (hoursBetween(escalation.created_at, now) < 24) return false;
+  if (!escalation.sla_requester_last_notified_at) return true;
+  return hoursBetween(escalation.sla_requester_last_notified_at, now) >= 24;
+}
+
+function formatAge(hours: number): string {
+  if (hours < 24) return `${Math.round(hours)}h`;
+  const days = Math.floor(hours / 24);
+  const remainder = Math.round(hours % 24);
+  return remainder > 0 ? `${days}d ${remainder}h` : `${days}d`;
+}
+
+function adminAlertText(escalation: Escalation, now: Date): string {
+  const sla = describeEscalationSla(escalation, now);
+  const lines = [
+    `:rotating_light: *Escalation SLA follow-up needed: #${escalation.id}*`,
+    '',
+    `*Priority:* ${escalation.priority}`,
+    `*Status:* ${escalation.status}`,
+    `*Age:* ${formatAge(sla.age_hours)}${sla.label ? ` (${sla.label})` : ''}`,
+    `*Requester:* ${escalation.user_display_name || escalation.user_email || escalation.user_slack_handle || escalation.workos_user_id || escalation.slack_user_id || 'Unknown'}`,
+    '',
+    `*Summary:* ${escalation.summary}`,
+    '',
+    `<https://agenticadvertising.org/admin/escalations|Open escalation dashboard>`,
+  ];
+  if (escalation.thread_id) {
+    lines.push(`<https://agenticadvertising.org/admin/addie?thread=${escalation.thread_id}|View Addie thread>`);
+  }
+  return lines.join('\n');
+}
+
+function requesterUpdateText(escalation: Escalation): string {
+  return [
+    'This support request is still open, and we re-surfaced it to the AgenticAdvertising.org team.',
+    `If this is blocking you, email ${SUPPORT_EMAIL} and include support request #${escalation.id}.`,
+    'You can also add details or close the request from your dashboard.',
+  ].join(' ');
+}
+
+export async function runEscalationSlaJob(
+  options: EscalationSlaJobOptions = {},
+): Promise<EscalationSlaJobResult> {
+  const now = options.now ?? new Date();
+  const rows = await listEscalationsForSlaEnforcement(options.limit ?? 50);
+  const channel = await getEscalationChannel();
+
+  const result: EscalationSlaJobResult = {
+    scanned: rows.length,
+    admin_alerted: 0,
+    requester_updated: 0,
+    requester_dm_sent: 0,
+    skipped_no_channel: 0,
+    errors: 0,
+  };
+
+  for (const escalation of rows) {
+    const adminDue = isAdminAlertDue(escalation, now);
+    const requesterDue = isRequesterUpdateDue(escalation, now);
+    let adminNotified = false;
+    let requesterNotified = false;
+
+    if (adminDue) {
+      if (!channel.channel_id) {
+        result.skipped_no_channel += 1;
+      } else {
+        try {
+          const threadTs = escalation.notification_channel_id === channel.channel_id
+            ? escalation.notification_message_ts || undefined
+            : undefined;
+          const sent = await sendChannelMessage(
+            channel.channel_id,
+            {
+              text: adminAlertText(escalation, now),
+              thread_ts: threadTs,
+            },
+            { requirePrivate: true },
+          );
+          if (sent.ok) {
+            adminNotified = true;
+            result.admin_alerted += 1;
+          } else {
+            result.errors += 1;
+            logger.warn(
+              { escalationId: escalation.id, channelId: channel.channel_id, error: sent.error },
+              'Failed to send escalation SLA admin alert',
+            );
+          }
+        } catch (err) {
+          result.errors += 1;
+          logger.warn({ err, escalationId: escalation.id }, 'Escalation SLA admin alert threw');
+        }
+      }
+    }
+
+    if (requesterDue) {
+      const body = requesterUpdateText(escalation);
+      try {
+        const update = await addSystemEscalationUpdate(escalation.id, body, true);
+        if (update) {
+          requesterNotified = true;
+          result.requester_updated += 1;
+        }
+        if (escalation.slack_user_id) {
+          const dm = await sendDirectMessage(escalation.slack_user_id, { text: body });
+          if (dm.ok) result.requester_dm_sent += 1;
+        }
+      } catch (err) {
+        result.errors += 1;
+        logger.warn({ err, escalationId: escalation.id }, 'Failed to write requester SLA update');
+      }
+    }
+
+    if (adminNotified || requesterNotified) {
+      await markEscalationSlaNotified(escalation.id, {
+        admin: adminNotified,
+        requester: requesterNotified,
+      });
+    }
+  }
+
+  if (
+    result.admin_alerted > 0 ||
+    result.requester_updated > 0 ||
+    result.skipped_no_channel > 0 ||
+    result.errors > 0
+  ) {
+    logger.info(result, 'Escalation SLA job completed');
+  }
+
+  return result;
+}

--- a/server/src/addie/jobs/job-definitions.ts
+++ b/server/src/addie/jobs/job-definitions.ts
@@ -36,6 +36,7 @@ import { runSocialPostIdeasJob } from './social-post-ideas.js';
 import { runConversationInsightsJob } from './conversation-insights.js';
 import { autoLinkUnmappedSlackUsers, autoAddVerifiedDomainUsersAsMembers } from '../../slack/sync.js';
 import { runCredentialDigestJob } from './credential-digest.js';
+import { runCertificationRecoveryJob } from './certification-recovery.js';
 import { runBrandLogoDigestJob } from './brand-logo-digest.js';
 import { runWgDigestJob, runWgDigestPrepJob } from './wg-digest.js';
 import { runComplianceHeartbeatJob } from './compliance-heartbeat.js';
@@ -43,6 +44,7 @@ import { runShadowEvaluatorJob } from './shadow-evaluator.js';
 import { runAddieCorrectedCaptureJob } from './shadow-corrected-capture.js';
 import { runKnowledgeGapCloserJob } from './knowledge-gap-closer.js';
 import { runEscalationTriageJob } from './escalation-triage.js';
+import { runEscalationSlaJob } from './escalation-sla.js';
 import { runInviteExpirySweep } from './invite-expiry-sweep.js';
 import { runIntegrityInvariantsJob } from './integrity-invariants.js';
 import { generateNetworkConsistencyReports } from '../../services/network-consistency-reporter.js';
@@ -379,6 +381,22 @@ export function registerAllJobs(): void {
     failureThreshold: 1,
     businessHours: { startHour: 9, endHour: 11, skipWeekends: true },
     shouldLogResult: (r) => r.posted || r.awardsFound > 0,
+  });
+
+  // Certification recovery - repairs passed attempts that missed module or
+  // credential reconciliation, and escalates only when automatic repair fails.
+  jobScheduler.register({
+    name: 'certification-recovery',
+    description: 'Certification completion recovery',
+    interval: { value: 6, unit: 'hours' },
+    initialDelay: { value: 18, unit: 'minutes' },
+    runner: runCertificationRecoveryJob,
+    options: { limit: 25 },
+    shouldLogResult: (r) =>
+      r.repaired > 0 ||
+      r.escalated > 0 ||
+      r.skipped_no_channel > 0 ||
+      r.errors > 0,
   });
 
   // Brand logo pending-review digest - daily reminder when items are stuck
@@ -843,6 +861,22 @@ export function registerAllJobs(): void {
     shouldLogResult: (r) => r.suggested > 0 || r.errors > 0,
   });
 
+  // Escalation SLA enforcement - re-surfaces overdue active support requests
+  // to admins and writes requester-visible "still open" updates after 24h.
+  jobScheduler.register({
+    name: 'escalation-sla',
+    description: 'Escalation SLA enforcement',
+    interval: { value: 60, unit: 'minutes' },
+    initialDelay: { value: 20, unit: 'minutes' },
+    runner: runEscalationSlaJob,
+    options: { limit: 50 },
+    shouldLogResult: (r) =>
+      r.admin_alerted > 0 ||
+      r.requester_updated > 0 ||
+      r.skipped_no_channel > 0 ||
+      r.errors > 0,
+  });
+
   // Integrity invariants - scheduled run of the framework that previously
   // only existed at GET /api/admin/integrity/check. Without this, classes
   // of drift like "org references a non-existent Stripe customer" only
@@ -880,6 +914,7 @@ export const JOB_NAMES = {
   WG_DIGEST: 'wg-digest',
   WG_DIGEST_PREP: 'wg-digest-prep',
   CREDENTIAL_DIGEST: 'credential-digest',
+  CERTIFICATION_RECOVERY: 'certification-recovery',
   BRAND_LOGO_DIGEST: 'brand-logo-digest',
   SOCIAL_POST_IDEAS: 'social-post-ideas',
   CONVERSATION_INSIGHTS: 'conversation-insights',
@@ -900,4 +935,5 @@ export const JOB_NAMES = {
   OUTBOUND_LOG_CLEANUP: 'outbound-log-cleanup',
   NETWORK_CONSISTENCY_REPORTER: 'network-consistency-reporter',
   ESCALATION_TRIAGE: 'escalation-triage',
+  ESCALATION_SLA: 'escalation-sla',
 } as const;

--- a/server/src/db/certification-db.ts
+++ b/server/src/db/certification-db.ts
@@ -1098,6 +1098,36 @@ export async function checkAndAwardCredentials(userId: string): Promise<string[]
   return awarded;
 }
 
+/**
+ * True when a missing credential that requires this module is currently
+ * eligible for the user. Used by recovery jobs to distinguish an award
+ * failure from a valid "module passed, other requirements still missing"
+ * state.
+ */
+export async function hasEligibleMissingCredentialForModule(
+  userId: string,
+  moduleId: string,
+): Promise<boolean> {
+  const result = await query<{ id: string }>(
+    `SELECT cc.id
+     FROM certification_credentials cc
+     WHERE $2 = ANY(cc.required_modules)
+       AND NOT EXISTS (
+         SELECT 1 FROM user_credentials uc
+         WHERE uc.workos_user_id = $1
+           AND uc.credential_id = cc.id
+       )
+     ORDER BY cc.tier, cc.sort_order`,
+    [userId, moduleId],
+  );
+
+  for (const row of result.rows) {
+    const { eligible } = await checkCredentialEligibility(userId, row.id);
+    if (eligible) return true;
+  }
+  return false;
+}
+
 // =====================================================
 // PROGRESS SUMMARIES
 // =====================================================

--- a/server/src/db/escalation-db.ts
+++ b/server/src/db/escalation-db.ts
@@ -61,6 +61,12 @@ export interface Escalation {
    *  with the same key are folded into the existing open escalation rather
    *  than creating a new one. See `createEscalation` and migration 459. */
   dedup_key: string | null;
+  /** Last time the SLA enforcement job re-surfaced this escalation to admins. */
+  sla_admin_last_notified_at: Date | null;
+  /** Last time the SLA enforcement job wrote a requester-visible follow-up. */
+  sla_requester_last_notified_at: Date | null;
+  /** Count of SLA follow-up cycles that touched this escalation. */
+  sla_follow_up_count: number;
   created_at: Date;
   updated_at: Date;
 }
@@ -470,6 +476,28 @@ export async function addRequesterEscalationUpdate(
   return result.rows[0] || null;
 }
 
+export async function addSystemEscalationUpdate(
+  escalationId: number,
+  body: string,
+  visibleToRequester = false,
+): Promise<EscalationUpdate | null> {
+  const note = body.trim();
+  if (!note) return null;
+
+  const result = await query<EscalationUpdate>(
+    `INSERT INTO addie_escalation_updates
+       (escalation_id, author_type, author_user_id, body, visible_to_requester)
+     SELECT id, 'system', NULL, $2, $3
+     FROM addie_escalations
+     WHERE id = $1
+       AND status IN ('open', 'acknowledged', 'in_progress')
+     RETURNING *`,
+    [escalationId, note, visibleToRequester],
+  );
+
+  return result.rows[0] || null;
+}
+
 export async function listPublicEscalationUpdates(
   escalationIds: number[],
 ): Promise<Record<number, EscalationUpdate[]>> {
@@ -490,6 +518,88 @@ export async function listPublicEscalationUpdates(
     byEscalation[update.escalation_id].push(update);
   }
   return byEscalation;
+}
+
+export async function listEscalationsForSlaEnforcement(limit = 50): Promise<Escalation[]> {
+  const result = await query<Escalation>(
+    `SELECT e.*,
+            s.admin_last_notified_at AS sla_admin_last_notified_at,
+            s.requester_last_notified_at AS sla_requester_last_notified_at,
+            COALESCE(s.follow_up_count, 0) AS sla_follow_up_count
+     FROM addie_escalations e
+     LEFT JOIN addie_escalation_sla_notifications s ON s.escalation_id = e.id
+     WHERE e.status IN ('open', 'acknowledged', 'in_progress')
+       AND (
+         (
+           (
+             e.status = 'open'
+             AND (
+               (e.priority = 'urgent' AND e.created_at <= NOW() - INTERVAL '4 hours')
+               OR (e.priority <> 'urgent' AND e.created_at <= NOW() - INTERVAL '24 hours')
+             )
+           )
+           OR (
+             e.status IN ('acknowledged', 'in_progress')
+             AND e.updated_at <= NOW() - INTERVAL '24 hours'
+           )
+         )
+         AND (
+           s.admin_last_notified_at IS NULL
+           OR s.admin_last_notified_at <= NOW() - INTERVAL '4 hours'
+         )
+         OR (
+           e.created_at <= NOW() - INTERVAL '24 hours'
+           AND (
+             s.requester_last_notified_at IS NULL
+             OR s.requester_last_notified_at <= NOW() - INTERVAL '24 hours'
+           )
+         )
+       )
+     ORDER BY
+       CASE e.priority
+         WHEN 'urgent' THEN 1
+         WHEN 'high' THEN 2
+         WHEN 'normal' THEN 3
+         WHEN 'low' THEN 4
+       END,
+       e.created_at ASC
+     LIMIT $1`,
+    [limit],
+  );
+  return result.rows;
+}
+
+export async function markEscalationSlaNotified(
+  id: number,
+  options: { admin?: boolean; requester?: boolean },
+): Promise<void> {
+  if (!options.admin && !options.requester) return;
+
+  await query(
+    `INSERT INTO addie_escalation_sla_notifications (
+       escalation_id,
+       admin_last_notified_at,
+       requester_last_notified_at,
+       follow_up_count
+     )
+     VALUES (
+       $1,
+       CASE WHEN $2 THEN NOW() ELSE NULL END,
+       CASE WHEN $3 THEN NOW() ELSE NULL END,
+       1
+     )
+     ON CONFLICT (escalation_id) DO UPDATE
+       SET admin_last_notified_at = CASE
+             WHEN $2 THEN NOW()
+             ELSE addie_escalation_sla_notifications.admin_last_notified_at
+           END,
+           requester_last_notified_at = CASE
+             WHEN $3 THEN NOW()
+             ELSE addie_escalation_sla_notifications.requester_last_notified_at
+           END,
+           follow_up_count = addie_escalation_sla_notifications.follow_up_count + 1`,
+    [id, options.admin === true, options.requester === true],
+  );
 }
 
 /**

--- a/server/src/db/migrations/518_escalation_sla_notifications.sql
+++ b/server/src/db/migrations/518_escalation_sla_notifications.sql
@@ -1,0 +1,25 @@
+-- SLA notification state for Addie escalations. Keep this out of
+-- addie_escalations so job-only notification bookkeeping does not trip the
+-- escalation table's generic updated_at trigger and reset the human-progress
+-- SLA clock.
+
+CREATE TABLE IF NOT EXISTS addie_escalation_sla_notifications (
+  escalation_id INTEGER PRIMARY KEY REFERENCES addie_escalations(id) ON DELETE CASCADE,
+  admin_last_notified_at TIMESTAMPTZ,
+  requester_last_notified_at TIMESTAMPTZ,
+  follow_up_count INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TRIGGER update_addie_escalation_sla_notifications_updated_at
+  BEFORE UPDATE ON addie_escalation_sla_notifications
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+CREATE INDEX IF NOT EXISTS idx_addie_escalations_active_sla_notifications
+  ON addie_escalations(status, priority, created_at, updated_at)
+  WHERE status IN ('open', 'acknowledged', 'in_progress');
+
+CREATE INDEX IF NOT EXISTS idx_addie_escalation_sla_notifications_cooldowns
+  ON addie_escalation_sla_notifications(admin_last_notified_at, requester_last_notified_at);

--- a/server/src/routes/admin/domains.ts
+++ b/server/src/routes/admin/domains.ts
@@ -27,7 +27,12 @@ import { resolveOrgsByDomains } from "../../db/domain-resolution-db.js";
 import { complete, isLLMConfigured } from "../../utils/llm.js";
 import { BrandDatabase } from "../../db/brand-db.js";
 import { verifyDomainChallenge } from "../../services/brand-claim.js";
-import { FREE_EMAIL_PROVIDER_DOMAINS } from "../../services/identifier-normalization.js";
+import {
+  FREE_EMAIL_PROVIDER_DOMAINS,
+  canonicalizeBrandDomain,
+  assertClaimableBrandDomain,
+} from "../../services/identifier-normalization.js";
+import { invalidateMemberContextCache } from "../../addie/index.js";
 
 const slackDb = new SlackDatabase();
 const logger = createLogger("admin-domains");
@@ -1249,6 +1254,104 @@ export function setupDomainRoutes(
       } catch (error) {
         logger.error({ err: error, orgId, domain: rawDomain }, "Admin brand-claim verify failed");
         return res.status(500).json({ error: "Internal server error" });
+      }
+    }
+  );
+
+  // POST /api/admin/organizations/:orgId/domains/:domain/verify
+  // Admin recovery path for WorkOS DNS verification. Member self-service has
+  // a cooldown and requires the caller to belong to the org; this endpoint is
+  // for support/admin use after the customer has fixed DNS or a webhook missed
+  // the local reconciliation step.
+  apiRouter.post(
+    "/organizations/:orgId/domains/:domain/verify",
+    requireAuth,
+    requireAdmin,
+    async (req, res) => {
+      const { orgId } = req.params;
+      if (!workos) {
+        return res.status(503).json({ error: "WorkOS not configured" });
+      }
+
+      let normalizedDomain: string;
+      try {
+        normalizedDomain = canonicalizeBrandDomain(req.params.domain);
+        assertClaimableBrandDomain(normalizedDomain);
+      } catch (error) {
+        logger.warn({ error, rawDomain: req.params.domain }, "Admin domain verify rejected invalid domain");
+        return res.status(400).json({
+          error: "invalid_domain",
+          message: "The domain is malformed or cannot be claimed.",
+        });
+      }
+
+      try {
+        const org = await workos.organizations.getOrganization(orgId);
+        const entry = org.domains.find(d => d.domain.toLowerCase() === normalizedDomain);
+        if (!entry) {
+          return res.status(404).json({
+            error: "no_challenge",
+            message: "No WorkOS domain challenge exists for this organization and domain.",
+          });
+        }
+
+        const initialState = String(entry.state);
+        let verifiedState = initialState;
+        const alreadyVerified = initialState === "verified" || initialState === "legacy_verified";
+        if (!alreadyVerified) {
+          try {
+            const verified = await workos.organizationDomains.verifyOrganizationDomain(entry.id);
+            verifiedState = String(verified.state);
+          } catch (err: any) {
+            const status = err?.status ?? err?.response?.status;
+            if (status === 400 || status === 422) {
+              const recordName = entry.verificationPrefix
+                ? `${entry.verificationPrefix}.${normalizedDomain}`
+                : normalizedDomain;
+              return res.status(400).json({
+                error: "still_pending",
+                message: "WorkOS could not find the DNS TXT verification record yet.",
+                state: initialState,
+                dns_record_name: recordName,
+                verification_token: entry.verificationToken ?? null,
+              });
+            }
+            throw err;
+          }
+        }
+
+        if (verifiedState !== "verified" && verifiedState !== "legacy_verified") {
+          return res.status(400).json({
+            error: "still_pending",
+            message: "WorkOS has not confirmed the DNS record yet.",
+            state: verifiedState,
+          });
+        }
+
+        await upsertWorkosDomain({
+          orgId,
+          domain: normalizedDomain,
+          verified: true,
+        });
+        invalidateMemberContextCache();
+
+        logger.info(
+          { orgId, domain: normalizedDomain, actor: req.user?.id, alreadyVerified },
+          "Admin verified organization domain through WorkOS",
+        );
+
+        return res.json({
+          success: true,
+          domain: normalizedDomain,
+          state: verifiedState,
+          newly_verified: !alreadyVerified,
+        });
+      } catch (error) {
+        logger.error({ err: error, orgId, domain: normalizedDomain }, "Admin domain verification failed");
+        return res.status(502).json({
+          error: "workos_error",
+          message: "Failed to verify domain through WorkOS.",
+        });
       }
     }
   );

--- a/tests/addie/certification-recovery-job.test.ts
+++ b/tests/addie/certification-recovery-job.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockCheckAndAwardCredentials,
+  mockCreateEscalation,
+  mockGetAttempt,
+  mockGetEscalationChannel,
+  mockGetStuckAttempts,
+  mockHasEligibleMissingCredentialForModule,
+  mockMarkNotificationSent,
+  mockReconcilePassedAttemptModule,
+  mockSendChannelMessage,
+} = vi.hoisted(() => ({
+  mockCheckAndAwardCredentials: vi.fn<any>(),
+  mockCreateEscalation: vi.fn<any>(),
+  mockGetAttempt: vi.fn<any>(),
+  mockGetEscalationChannel: vi.fn<any>(),
+  mockGetStuckAttempts: vi.fn<any>(),
+  mockHasEligibleMissingCredentialForModule: vi.fn<any>(),
+  mockMarkNotificationSent: vi.fn<any>(),
+  mockReconcilePassedAttemptModule: vi.fn<any>(),
+  mockSendChannelMessage: vi.fn<any>(),
+}));
+
+vi.mock('../../server/src/db/certification-db.js', () => ({
+  checkAndAwardCredentials: (...args: unknown[]) => mockCheckAndAwardCredentials(...args),
+  getAttempt: (...args: unknown[]) => mockGetAttempt(...args),
+  getStuckAttempts: (...args: unknown[]) => mockGetStuckAttempts(...args),
+  hasEligibleMissingCredentialForModule: (...args: unknown[]) => mockHasEligibleMissingCredentialForModule(...args),
+  reconcilePassedAttemptModule: (...args: unknown[]) => mockReconcilePassedAttemptModule(...args),
+}));
+
+vi.mock('../../server/src/db/escalation-db.js', () => ({
+  createEscalation: (...args: unknown[]) => mockCreateEscalation(...args),
+  markNotificationSent: (...args: unknown[]) => mockMarkNotificationSent(...args),
+}));
+
+vi.mock('../../server/src/db/system-settings-db.js', () => ({
+  getEscalationChannel: (...args: unknown[]) => mockGetEscalationChannel(...args),
+}));
+
+vi.mock('../../server/src/slack/client.js', () => ({
+  sendChannelMessage: (...args: unknown[]) => mockSendChannelMessage(...args),
+}));
+
+import { runCertificationRecoveryJob } from '../../server/src/addie/jobs/certification-recovery.js';
+
+function stuckAttempt(overrides: Partial<any> = {}) {
+  return {
+    id: 'attempt_123',
+    workos_user_id: 'user_123',
+    name: 'Test User',
+    email: 'test@example.com',
+    track_id: 'specialist',
+    module_id: 'module_a',
+    status: 'passed',
+    credential_name: 'Specialist',
+    started_at: '2026-06-01T12:00:00Z',
+    days_stuck: 16,
+    ...overrides,
+  };
+}
+
+function fullAttempt(overrides: Partial<any> = {}) {
+  return {
+    id: 'attempt_123',
+    workos_user_id: 'user_123',
+    module_id: 'module_a',
+    status: 'passed',
+    passing: true,
+    scores: { criterion_a: 1, _admin_completed: true },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockCheckAndAwardCredentials.mockReset();
+  mockCreateEscalation.mockReset();
+  mockGetAttempt.mockReset();
+  mockGetEscalationChannel.mockReset();
+  mockGetStuckAttempts.mockReset();
+  mockHasEligibleMissingCredentialForModule.mockReset();
+  mockMarkNotificationSent.mockReset();
+  mockReconcilePassedAttemptModule.mockReset();
+  mockSendChannelMessage.mockReset();
+
+  mockGetStuckAttempts.mockResolvedValue([stuckAttempt()]);
+  mockGetAttempt.mockResolvedValue(fullAttempt());
+  mockCheckAndAwardCredentials.mockResolvedValue([]);
+  mockHasEligibleMissingCredentialForModule.mockResolvedValue(false);
+  mockReconcilePassedAttemptModule.mockResolvedValue(undefined);
+  mockGetEscalationChannel.mockResolvedValue({ channel_id: 'C_ESCALATIONS' });
+  mockSendChannelMessage.mockResolvedValue({ ok: true, ts: '1710000000.000' });
+  mockCreateEscalation.mockResolvedValue({
+    id: 77,
+    workos_user_id: 'user_123',
+    notification_message_ts: null,
+  });
+});
+
+describe('runCertificationRecoveryJob', () => {
+  it('does not escalate when the credential is still blocked by other requirements', async () => {
+    const result = await runCertificationRecoveryJob();
+
+    expect(result.scanned).toBe(1);
+    expect(result.escalated).toBe(0);
+    expect(mockReconcilePassedAttemptModule).toHaveBeenCalled();
+    expect(mockHasEligibleMissingCredentialForModule).toHaveBeenCalledWith('user_123', 'module_a');
+    expect(mockCreateEscalation).not.toHaveBeenCalled();
+    expect(mockSendChannelMessage).not.toHaveBeenCalled();
+  });
+
+  it('escalates when an eligible missing credential still was not awarded', async () => {
+    mockHasEligibleMissingCredentialForModule.mockResolvedValue(true);
+
+    const result = await runCertificationRecoveryJob();
+
+    expect(result.escalated).toBe(1);
+    expect(result.notified).toBe(1);
+    expect(mockCreateEscalation).toHaveBeenCalledWith(expect.objectContaining({
+      dedup_key: 'certification-recovery:attempt_123',
+      priority: 'high',
+    }));
+    expect(mockMarkNotificationSent).toHaveBeenCalledWith(77, 'C_ESCALATIONS', '1710000000.000');
+  });
+});

--- a/tests/addie/escalation-sla-job.test.ts
+++ b/tests/addie/escalation-sla-job.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockAddSystemEscalationUpdate,
+  mockGetEscalationChannel,
+  mockListEscalationsForSlaEnforcement,
+  mockMarkEscalationSlaNotified,
+  mockSendChannelMessage,
+  mockSendDirectMessage,
+} = vi.hoisted(() => ({
+  mockAddSystemEscalationUpdate: vi.fn<any>(),
+  mockGetEscalationChannel: vi.fn<any>(),
+  mockListEscalationsForSlaEnforcement: vi.fn<any>(),
+  mockMarkEscalationSlaNotified: vi.fn<any>(),
+  mockSendChannelMessage: vi.fn<any>(),
+  mockSendDirectMessage: vi.fn<any>(),
+}));
+
+vi.mock('../../server/src/db/escalation-db.js', () => ({
+  addSystemEscalationUpdate: (...args: unknown[]) => mockAddSystemEscalationUpdate(...args),
+  describeEscalationSla: (escalation: any, now: Date) => {
+    const createdAt = new Date(escalation.created_at).getTime();
+    const updatedAt = new Date(escalation.updated_at).getTime();
+    return {
+      age_hours: Math.max(0, (now.getTime() - createdAt) / (60 * 60 * 1000)),
+      hours_since_update: Math.max(0, (now.getTime() - updatedAt) / (60 * 60 * 1000)),
+      needs_follow_up: true,
+      label: 'Needs update',
+      threshold_hours: 24,
+    };
+  },
+  listEscalationsForSlaEnforcement: (...args: unknown[]) => mockListEscalationsForSlaEnforcement(...args),
+  markEscalationSlaNotified: (...args: unknown[]) => mockMarkEscalationSlaNotified(...args),
+}));
+
+vi.mock('../../server/src/db/system-settings-db.js', () => ({
+  getEscalationChannel: (...args: unknown[]) => mockGetEscalationChannel(...args),
+}));
+
+vi.mock('../../server/src/slack/client.js', () => ({
+  sendChannelMessage: (...args: unknown[]) => mockSendChannelMessage(...args),
+  sendDirectMessage: (...args: unknown[]) => mockSendDirectMessage(...args),
+}));
+
+import { runEscalationSlaJob } from '../../server/src/addie/jobs/escalation-sla.js';
+
+const NOW = new Date('2026-06-17T12:00:00Z');
+
+function escalation(overrides: Partial<any> = {}) {
+  return {
+    id: 42,
+    status: 'in_progress',
+    priority: 'high',
+    summary: 'Needs admin help',
+    created_at: new Date('2026-06-15T12:00:00Z'),
+    updated_at: new Date('2026-06-16T10:00:00Z'),
+    user_display_name: 'Test User',
+    user_email: 'test@example.com',
+    user_slack_handle: null,
+    workos_user_id: 'user_123',
+    slack_user_id: null,
+    thread_id: null,
+    notification_channel_id: 'C_OLD',
+    notification_message_ts: '1710000000.000',
+    sla_admin_last_notified_at: null,
+    sla_requester_last_notified_at: NOW,
+    sla_follow_up_count: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockAddSystemEscalationUpdate.mockReset();
+  mockGetEscalationChannel.mockReset();
+  mockListEscalationsForSlaEnforcement.mockReset();
+  mockMarkEscalationSlaNotified.mockReset();
+  mockSendChannelMessage.mockReset();
+  mockSendDirectMessage.mockReset();
+
+  mockGetEscalationChannel.mockResolvedValue({ channel_id: 'C_NEW' });
+  mockSendChannelMessage.mockResolvedValue({ ok: true, ts: '1710000001.000' });
+});
+
+describe('runEscalationSlaJob', () => {
+  it('does not thread an SLA alert under a message from a different escalation channel', async () => {
+    mockListEscalationsForSlaEnforcement.mockResolvedValue([escalation()]);
+
+    const result = await runEscalationSlaJob({ now: NOW });
+
+    expect(result.admin_alerted).toBe(1);
+    expect(mockSendChannelMessage).toHaveBeenCalledWith(
+      'C_NEW',
+      expect.objectContaining({ thread_ts: undefined }),
+      { requirePrivate: true },
+    );
+    expect(mockMarkEscalationSlaNotified).toHaveBeenCalledWith(42, {
+      admin: true,
+      requester: false,
+    });
+  });
+
+  it('threads an SLA alert when the original notification was in the configured channel', async () => {
+    mockGetEscalationChannel.mockResolvedValue({ channel_id: 'C_ESCALATIONS' });
+    mockListEscalationsForSlaEnforcement.mockResolvedValue([
+      escalation({ notification_channel_id: 'C_ESCALATIONS' }),
+    ]);
+
+    await runEscalationSlaJob({ now: NOW });
+
+    expect(mockSendChannelMessage).toHaveBeenCalledWith(
+      'C_ESCALATIONS',
+      expect.objectContaining({ thread_ts: '1710000000.000' }),
+      { requirePrivate: true },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds the remaining support-cycle recovery work after the Addie escalation UX merge:

- Escalation SLA enforcement: a scheduled Addie job resurfaces stale active escalations to the private escalation Slack channel and posts requester-visible updates after 24 hours.
- Certification completion recovery: a scheduled job reconciles passed attempts that are missing credentials and creates deduped support escalations when automatic repair cannot complete.
- Domain verification recovery: an admin endpoint can retry WorkOS domain verification and sync the verified domain locally.
- Operator docs: a support recovery runbook covers escalation SLA handling, certification repair, domain verification, and registry heartbeat/recrawl recovery.
- Training docs: adds supplements for buyer brief discipline, governance by role, and creative-agent workflows.
- Registry docs: fixes the stale recrawl endpoint reference.

## Validation

- Expert review passes: code, security, and docs. Follow-up fixes included for SLA bookkeeping, certification eligibility, Slack threading, public runbook exposure, and schema-accurate training docs.
- `git diff --cached --check`
- `npm run test:migrations`
- `npm run test:docs-nav`
- `npm run typecheck`
- `npm run test:schemas`
- `npm run build`
- `npm run lint:schema-links --silent`
- `npm run test:unit`
- commit hook: unit suite, dynamic-import tests, callapi state-change tests, server unit checks, typecheck
- `npx --yes @changesets/cli@^2.31.0 status --since=origin/main`
- pre-push hook: version sync, changeset presence, docs schema-link lint, Mintlify broken-links
