### PR TITLE
[codex] Backport proposal support gate fix to 3.0.x

### DIFF
--- a/.changeset/proposal-support-gate-skip.md
+++ b/.changeset/proposal-support-gate-skip.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix the 3.0.x proposal-finalize storyboard gate so sellers that omit `media_buy.supports_proposals` skip the proposal lifecycle scenario instead of running optional proposal assertions.

--- a/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
@@ -10,6 +10,9 @@ required_tools:
 
 # `media_buy.supports_proposals` is defined in the 3.1 schema. On 3.0.x,
 # absence is treated as false so non-proposal sellers skip this scenario.
+# The storyboard-level equals check skips explicit false; phase-level
+# present checks below skip absent values for runners whose equals matcher
+# treats absence as satisfied.
 requires_capability:
   path: media_buy.supports_proposals
   equals: true
@@ -48,6 +51,9 @@ prerequisites:
 
 phases:
   - id: setup
+    requires_capability:
+      path: media_buy.supports_proposals
+      present: true
     title: "Account setup"
     steps:
       - id: sync_accounts
@@ -77,6 +83,9 @@ phases:
             description: "Account has a platform-assigned ID"
 
   - id: brief_with_proposals
+    requires_capability:
+      path: media_buy.supports_proposals
+      present: true
     title: "Brief with proposals"
     narrative: |
       Send a brief and receive proposals alongside products. Proposals are curated
@@ -122,6 +131,9 @@ phases:
             description: "Proposals have IDs"
 
   - id: refine_proposal
+    requires_capability:
+      path: media_buy.supports_proposals
+      present: true
     title: "Refine the proposal"
     narrative: |
       The buyer reviews the proposals and wants to adjust one. They call get_products in
@@ -164,6 +176,9 @@ phases:
             description: "Response contains updated proposals"
 
   - id: finalize_proposal
+    requires_capability:
+      path: media_buy.supports_proposals
+      present: true
     title: "Finalize the proposal"
     narrative: |
       The buyer is satisfied with the refined proposal and requests finalization. This
@@ -209,6 +224,9 @@ phases:
             description: "Response contains the finalized proposal"
 
   - id: accept_proposal
+    requires_capability:
+      path: media_buy.supports_proposals
+      present: true
     title: "Accept the committed proposal"
     narrative: |
       The buyer accepts the committed proposal by creating a media buy with the

--- a/tests/lint-storyboard-sample-request-schema.test.cjs
+++ b/tests/lint-storyboard-sample-request-schema.test.cjs
@@ -10,7 +10,9 @@
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
 
+const fs = require('node:fs');
 const path = require('node:path');
+const YAML = require('yaml');
 
 const {
   lintAll,
@@ -60,6 +62,26 @@ test('allowlist has no stale entries', async () => {
         'Regenerate the allowlist:\n' +
         '  node scripts/lint-storyboard-sample-request-schema.cjs --write-allowlist\n\n' +
         rendered,
+    );
+  }
+});
+
+test('proposal finalize gates absent and false supports_proposals separately', () => {
+  const file = path.join(
+    STORYBOARD_DIR,
+    'protocols/media-buy/scenarios/proposal_finalize.yaml',
+  );
+  const storyboard = YAML.parse(fs.readFileSync(file, 'utf8'));
+
+  assert.deepEqual(storyboard.requires_capability, {
+    path: 'media_buy.supports_proposals',
+    equals: true,
+  });
+  for (const phase of storyboard.phases) {
+    assert.deepEqual(
+      phase.requires_capability,
+      { path: 'media_buy.supports_proposals', present: true },
+      `phase ${phase.id}`,
     );
   }
 });


### PR DESCRIPTION
## Summary

Backport the proposal-finalize capability gate fix to the `3.0.x` release line.

The 3.0.x `proposal_finalize` storyboard already documents that absent `media_buy.supports_proposals` should be treated as unsupported, but the authored gate only used `equals: true`. Runners whose `equals` matcher treats an absent path as satisfied would then execute the optional proposal lifecycle scenario and produce false failures for direct-buy sellers.

This PR keeps the storyboard-level `equals: true` gate for explicit `false`, and adds phase-level `present: true` gates so absent values skip before executing proposal phases.

## Notes

This backports the compliance source behavior for the next 3.0.x patch bundle. Already-published SDK runners such as `@adcp/sdk@7.11.2` may still need a runner-side patch because that version does not enforce phase-level `requires_capability`.

## Validation

- `npm run test:storyboard-sample-request-schema`
- `git diff --check`