### PR TITLE
fix(addie): add behavior rule for email verification failures

### DIFF
--- a/server/src/addie/rules/behaviors.md
+++ b/server/src/addie/rules/behaviors.md
@@ -58,6 +58,21 @@ If someone reports that the invite failed for them:
 
 The help page at /docs/community/joining-slack has the full explanation of what happens and what to do.
 
+## Email Verification and Notification Failures
+
+When a user reports that they never received a verification email, password reset, or any other platform notification:
+
+1. Acknowledge it as a platform-side delivery failure, not user error. Do not suggest "check your spam folder" as the primary response — lead with the fact that this is a known failure mode on our end.
+2. Ask for or confirm their email address in the same turn so the escalation is actionable. If you already have it from their member context, confirm it: "I have your email as [address] — is that the one you're expecting the email at?"
+3. Call `escalate_to_admin` with category `account` and include the email address and the type of email that failed (verification, password reset, notification, etc.) before telling the user the team will investigate.
+4. Tell the user the team will follow up — do not commit to a specific timeline.
+
+Do NOT:
+- Claim to check email delivery logs, async operation status, or email provider dashboards (you have no such tool)
+- Return a generic "try again later" error response
+- Fabricate a resolution timeline or SLA ("you should receive it within 24 hours")
+- Treat this as a user-side problem (wrong email, spam filter) without first acknowledging the platform failure
+
 ## Post-Exploration Channel Summary
 After a productive spec exploration in DM about a meeting agenda topic or working group concern, offer to post a summary to the relevant working group's Slack channel. This makes the exploration visible to others and models the interaction pattern.
 

--- a/server/src/addie/rules/behaviors.md
+++ b/server/src/addie/rules/behaviors.md
@@ -64,7 +64,7 @@ When a user reports that they never received a verification email, password rese
 
 1. Acknowledge it as a platform-side delivery failure, not user error. Do not suggest "check your spam folder" as the primary response — lead with the fact that this is a known failure mode on our end.
 2. Ask for or confirm their email address in the same turn so the escalation is actionable. If you already have it from their member context, confirm it: "I have your email as [address] — is that the one you're expecting the email at?"
-3. Call `escalate_to_admin` with category `account` and include the email address and the type of email that failed (verification, password reset, notification, etc.) before telling the user the team will investigate.
+3. Call `escalate_to_admin` with category `needs_human_action` and include the email address and the type of email that failed (verification, password reset, notification, etc.) before telling the user the team will investigate.
 4. Tell the user the team will follow up — do not commit to a specific timeline.
 
 Do NOT:


### PR DESCRIPTION
## Summary

- Adds a named scenario section to `behaviors.md` for handling email verification and notification delivery failures
- Modeled on the existing "Slack Invite Domain Restrictions" pattern — same structure: trigger, required steps, hard nots
- Ensures Addie acknowledges the failure as platform-side (not user error), confirms the email address, calls `escalate_to_admin` before claiming escalation, and avoids fabricating timelines or claiming access to email delivery tools she doesn't have

Purely additive — no existing behavior changed, no schema or protocol surface touched.

## Test plan

- [x] Pre-commit hooks pass (unit tests, type checks, dynamic import tests)
- [ ] Verify Addie follows the new rule when a user reports a missing verification email (manual QA in Slack sandbox)

Closes #5563