### PR TITLE
docs(concepts): add structural-problem section to Why AdCP page

### DIFF
--- a/docs/building/concepts/index.mdx
+++ b/docs/building/concepts/index.mdx
@@ -14,6 +14,14 @@ AdCP enables portfolio-level allocation: *"How should I invest my ad budget?"* T
   Why the RTB mental model doesn't fit how advertisers actually make decisions.
 </Card>
 
+## The Structural Problem
+
+Programmatic advertising defaults to a single question: *"What is this impression worth right now?"* That framing embeds CPM-based, auction-centric assumptions into the transaction layer — assumptions that do not hold for most global ad spend. Direct deals, sponsorships, broadcast, out-of-home, and retail media all operate on different pricing models, different timelines, and different success metrics. They are not edge cases; they are the majority.
+
+AdCP sits at the **campaign-workflow layer**, above the auction. It does not replace OpenRTB or compete with serve-time decisioning — it coordinates the planning, negotiation, proposal, and deal-creation steps that happen before and after the auction fires. The [protocol comparison](/docs/building/concepts/adcp-vs-openrtb) explains how AdCP and OpenRTB coexist.
+
+By structuring these workflow steps as protocol-level tasks, AdCP enables agents to apply [brand identity](/docs/brand-protocol/brand-json), [content standards](/docs/governance/content-standards/), and governance checks at decision time — not as an afterthought. Agents that use these tasks can reason about brand suitability, creative fit, and compliance as part of the buying process rather than bolting them on post-execution. The protocol makes this possible; individual agents decide how much of it to use.
+
 ## The Fragmentation Problem
 
 Today, advertisers face three completely different buying systems:


### PR DESCRIPTION
## Summary

- Adds a "The Structural Problem" section to `docs/building/concepts/index.mdx` (the "Why AdCP" page), placed between "Allocation, Not Day Trading" and "The Fragmentation Problem"
- Addresses the knowledge gap where Addie lacked framing to explain *why* AdCP exists beyond fragmentation — specifically, that most ad spend doesn't fit auction/CPM assumptions
- Positions AdCP at the campaign-workflow layer above the auction (not inside it), per adtech-product-expert feedback
- Frames brand identity, content standards, and governance tasks as capabilities agents can opt into, not protocol-level guarantees
- Cross-links to [protocol comparison](/docs/building/concepts/adcp-vs-openrtb), [brand.json](/docs/brand-protocol/brand-json), and [content standards](/docs/governance/content-standards/)
- No historical "fifteen years" framing — present tense throughout

Non-normative docs addition. No schema, task-semantic, or protocol surface changes.

## Test plan

- [x] Pre-commit hooks pass (unit tests, type checks)
- [x] Cross-link targets verified to exist
- [ ] Mintlify build (CI will check)

Closes #5562