### PR TITLE
fix(compliance): guard state-machine storyboard against non-display sellers

### DIFF
--- a/static/compliance/source/protocols/media-buy/state-machine.yaml
+++ b/static/compliance/source/protocols/media-buy/state-machine.yaml
@@ -93,6 +93,14 @@ phases:
       Discover products and create a media buy to use for state transition testing.
       The media buy ID is captured and passed to subsequent phases.
 
+    # The sync_creatives step sends display (image) assets keyed to the seller's
+    # own format_id. Sellers without a creative library cannot accept
+    # sync_creatives and would fail setup before reaching the state-machine
+    # transitions this storyboard actually tests.
+    requires_capability:
+      path: creative.has_creative_library
+      equals: true
+
     steps:
       - id: discover_products
         title: "Discover products for media buy"
@@ -112,7 +120,7 @@ phases:
 
         sample_request:
           buying_mode: "brief"
-          brief: "Display advertising products for state machine testing"
+          brief: "Products for state machine testing"
           brand:
             domain: "acmeoutdoor.example"
 


### PR DESCRIPTION
## Summary

Fixes the `media_buy_state_machine` storyboard failing with `VALIDATION_ERROR` on sellers that don't support display (image) creative formats (#5549).

The `format_id` fix (`$context.product_format_id`) already landed on main and addresses the original reported error ("unknown format 'video_standard'"). This PR closes the two residual gaps identified in triage:

- **Phase-level capability guard:** Added `requires_capability: creative.has_creative_library: true` on the `setup` phase. Sellers without a creative library (audio-only, non-display specialists) now get a clean `not_applicable` skip instead of a misleading creative-validation failure that cascades into 6 skipped state-transition steps.

- **Generalized brief:** Changed `get_products` brief from `"Display advertising products for state machine testing"` to `"Products for state machine testing"` so non-display sellers with a creative library can still return products.

No schema change, no `comply_test_controller` enum change, no normative behavior change. Existing passing compliance results are unaffected.

## Test plan

- [x] Pre-commit hooks pass (unit tests, type checks, storyboard matrix)
- [ ] Run `media_buy_state_machine` against a display seller — should pass as before
- [ ] Run `media_buy_state_machine` against an audio-only seller — should skip with `not_applicable` instead of failing

Closes #5549