### PR TITLE
docs(media-buy): document the account field in the create_media_buy response

### DIFF
--- a/.changeset/document-account-in-create-media-buy-response.md
+++ b/.changeset/document-account-in-create-media-buy-response.md
@@ -1,0 +1,6 @@
+---
+---
+
+docs(media-buy): document the `account` field in the create_media_buy response
+
+The `create_media_buy` success response has carried an `account` field (full `Account`, including the canonical `account_id`) since 3.0.1, but the task-reference page documented `account` only as a request parameter. The response field table and the success/webhook-completion examples omitted it, so readers could not see that the seller echoes back the resolved account — including, for implicit `brand` + `operator` resolution, the `account_id` a buyer can reference on later account-scoped calls. Add `account` to the Success Response field table and to the success and approved-webhook example payloads.

--- a/docs/media-buy/task-reference/create_media_buy.mdx
+++ b/docs/media-buy/task-reference/create_media_buy.mdx
@@ -215,6 +215,7 @@ When executing a proposal, `proposal_status` on the returned proposal determines
 | Field | Description |
 |-------|-------------|
 | `media_buy_id` | Seller's unique identifier |
+| `account` | Resolved account billed for this media buy, echoed as a full [Account](/docs/building/integration/accounts-and-agents#account-references) object (includes `account_id`, `name`, `status`, and the resolved `brand`/`operator`). When the request used implicit resolution (`brand` + `operator`), this confirms the account the seller resolved. Optional. |
 | `confirmed_at` | ISO 8601 timestamp when the seller committed to the media buy. Stable after it is set. May be `null` in deferred/manual approval flows until seller commitment occurs. |
 | `creative_deadline` | ISO 8601 timestamp for creative upload deadline |
 | `revision` | Initial media-buy revision. Use this value as the `revision` token on the next `update_media_buy` call intended to change state. |
@@ -1237,6 +1238,13 @@ const response = await session.call('create_media_buy', {
 {
   "status": "completed",
   "media_buy_id": "mb_12345",
+  "account": {
+    "account_id": "acc_acme_direct",
+    "name": "Acme",
+    "status": "active",
+    "brand": { "domain": "acmecorp.com" },
+    "operator": "acmecorp.com"
+  },
   "media_buy_status": "active",
   "confirmed_at": "2025-06-01T10:00:00Z",
   "creative_deadline": "2025-06-15T23:59:59Z",
@@ -1300,6 +1308,13 @@ const response = await session.call('create_media_buy',
   "message": "Media buy approved and created",
   "result": {
     "media_buy_id": "mb_67890",
+    "account": {
+      "account_id": "acc_acme_direct",
+      "name": "Acme",
+      "status": "active",
+      "brand": { "domain": "acmecorp.com" },
+      "operator": "acmecorp.com"
+    },
     "confirmed_at": "2025-01-22T14:30:00Z",
     "creative_deadline": "2025-06-20T23:59:59Z",
     "revision": 1,


### PR DESCRIPTION
## Why

The `create_media_buy` **success response** has carried an `account` field — a full [`Account`](https://adcontextprotocol.org/schemas/v3/core/account.json) object, which requires `account_id` — since 3.0.1 (it's present through 3.1.0-rc.15). But the task-reference page documents `account` only as a *request* parameter. The Response field table and the example response payloads omit it entirely.

As a result, readers can't tell from the docs that the seller echoes back the resolved account. This matters most for **implicit resolution**: when a buyer sends `{ brand, operator }`, the response's `account` confirms what the seller resolved — including the canonical `account_id` a buyer can persist and reuse on later account-scoped calls. (The natural key remains valid per `account-ref.json`; the echoed `account_id` is a convenience, not a replacement.)

## What changed

Docs-only, in `docs/media-buy/task-reference/create_media_buy.mdx`:

- Added an `account` row to the **Success Response** field table (marked Optional, matching the schema — it's not in `required`).
- Added the `account` object to the **immediate-success** example payload.
- Added it to the **approved-webhook completion** (`result`) example payload.

No schema or normative change — the field already exists; this just documents it. Examples reuse existing fictional entities (`acmecorp.com`, `acc_acme_direct` from `account.json`) and are schema-valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)