### PR TITLE
fix(registry): authenticate health fallback probes

### DIFF
--- a/.changeset/5592-authenticated-health-fallback.md
+++ b/.changeset/5592-authenticated-health-fallback.md
@@ -1,0 +1,4 @@
+---
+---
+
+Empty changeset: server dashboard behavior only. Sends saved owner credentials to same-origin HTTPS health-check fallbacks so authenticated agents no longer show false offline/OAuth-required status, while keeping fallback credential delivery scoped to the owning registration.

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -1,4 +1,4 @@
-import type { Agent } from "./types.js";
+import type { Agent, FederatedAgent } from "./types.js";
 import { PropertyCrawler, getPropertyIndex, type AgentInfo, type CrawlResult } from "@adcp/sdk";
 import { sanitizeAdagentsProperty } from "./discovery/property-index-guard.js";
 import { FederatedIndexService } from "./federated-index.js";
@@ -813,6 +813,7 @@ export class CrawlerService {
       mcp_endpoint: a.url,
       contact: { name: '', email: '', website: '' },
       added_date: new Date().toISOString().split('T')[0],
+      ...(a.health_check_url ? { health_check_url: a.health_check_url } : {}),
     } satisfies Agent))]) {
       if (seen.has(src.url) || pausedUrls.has(src.url)) continue;
       seen.add(src.url);
@@ -996,6 +997,25 @@ export class CrawlerService {
     return this.federatedIndex;
   }
 
+  private async findRegisteredAgentForOrg(orgId: string, agentUrl: string): Promise<FederatedAgent | undefined> {
+    const profile = await this.memberDb.getProfileByOrgId(orgId);
+    if (!profile) return undefined;
+    const key = canonicalizeAgentUrl(agentUrl) ?? agentUrl;
+    const agentConfig = (profile.agents || []).find((a) => (canonicalizeAgentUrl(a.url) ?? a.url) === key);
+    if (!agentConfig) return undefined;
+    return {
+      url: key,
+      name: agentConfig.name || profile.display_name,
+      type: agentConfig.type,
+      protocol: 'mcp',
+      ...(agentConfig.health_check_url ? { health_check_url: agentConfig.health_check_url } : {}),
+      member: {
+        slug: profile.slug,
+        display_name: profile.display_name,
+      },
+    };
+  }
+
   /**
    * Probe one agent and refresh both snapshot tables (health + capabilities)
    * for it. Used by `POST /api/registry/agents/{encodedUrl}/refresh` so an
@@ -1011,7 +1031,7 @@ export class CrawlerService {
    * route handler maps that to a 502 so the user sees why the refresh
    * couldn't happen (timeout, DNS, OAuth wall, etc).
    */
-  async refreshSingleAgent(agentUrl: string, options: { auth?: SdkAuth } = {}): Promise<{
+  async refreshSingleAgent(agentUrl: string, options: { auth?: SdkAuth; ownerOrgId?: string } = {}): Promise<{
     online: boolean;
     tools_count: number | null;
     response_time_ms: number | null;
@@ -1022,7 +1042,7 @@ export class CrawlerService {
     error?: string;
   }> {
     const PROBE_TIMEOUT_MS = 10000;
-    const { auth } = options;
+    const { auth, ownerOrgId } = options;
 
     const pausedUrls = await this.getPausedAgentUrls();
     if (pausedUrls.has(agentUrl)) {
@@ -1034,7 +1054,9 @@ export class CrawlerService {
     // who got here). `refreshAgentSnapshots` uses public-only because the
     // periodic crawl probes everything in the federated index regardless.
     const allAgents = await this.federatedIndex.listAllAgents(undefined, { includeMembersOnly: true });
-    const known = allAgents.find(a => a.url === agentUrl);
+    const known = ownerOrgId
+      ? await this.findRegisteredAgentForOrg(ownerOrgId, agentUrl)
+      : allAgents.find(a => a.url === agentUrl);
     const knownType = known?.type && known.type !== 'unknown' ? known.type : undefined;
 
     const agent: Agent = {
@@ -1046,6 +1068,7 @@ export class CrawlerService {
       mcp_endpoint: agentUrl,
       contact: { name: '', email: '', website: '' },
       added_date: new Date().toISOString().split('T')[0],
+      ...(known?.health_check_url ? { health_check_url: known.health_check_url } : {}),
     };
 
     const profile = await Promise.race([

--- a/server/src/federated-index.ts
+++ b/server/src/federated-index.ts
@@ -105,6 +105,7 @@ export class FederatedIndexService {
           name: agentConfig.name || profile.display_name,
           type: agentType as FederatedAgent['type'],
           protocol: 'mcp',
+          ...(agentConfig.health_check_url ? { health_check_url: agentConfig.health_check_url } : {}),
           member: {
             slug: profile.slug,
             display_name: profile.display_name,

--- a/server/src/health.ts
+++ b/server/src/health.ts
@@ -146,6 +146,30 @@ async function isHostUnreachableDns(url: string, timeoutMs = 1500): Promise<bool
   }
 }
 
+function healthProbeHeaders(auth?: SdkAuth): Record<string, string> {
+  const headers: Record<string, string> = { 'User-Agent': AAO_UA_HEALTH_CHECK };
+  const authFields = agentConfigAuthFields(auth);
+  if (authFields.auth_token) {
+    headers['Authorization'] = `Bearer ${authFields.auth_token}`;
+  } else if (authFields.headers?.Authorization) {
+    headers['Authorization'] = authFields.headers.Authorization;
+  } else if (authFields.oauth_tokens?.access_token) {
+    headers['Authorization'] = `Bearer ${authFields.oauth_tokens.access_token}`;
+  }
+  return headers;
+}
+
+function shouldSendHealthFallbackAuth(agent: Agent): boolean {
+  if (!agent.health_check_url) return false;
+  try {
+    const healthUrl = new URL(agent.health_check_url);
+    const agentUrl = new URL(agent.url);
+    return healthUrl.protocol === 'https:' && healthUrl.origin === agentUrl.origin;
+  } catch {
+    return false;
+  }
+}
+
 export class HealthChecker {
   private healthCache: Cache<AgentHealth>;
   private statsCache: Cache<AgentStats>;
@@ -230,7 +254,7 @@ export class HealthChecker {
           raw: classified.raw,
         };
       }
-      const fallback = await this.tryHealthCheckFallback(agent, startTime, classified);
+      const fallback = await this.tryHealthCheckFallback(agent, startTime, classified, auth);
       if (fallback) return fallback;
       return {
         online: false,
@@ -256,12 +280,13 @@ export class HealthChecker {
     agent: Agent,
     startTime: number,
     classified: ClassifiedProbeError,
+    auth?: SdkAuth,
   ): Promise<AgentHealth | null> {
     if (!agent.health_check_url) return null;
     try {
       const response = await safeFetch(agent.health_check_url, {
         method: "GET",
-        headers: { 'User-Agent': AAO_UA_HEALTH_CHECK },
+        headers: healthProbeHeaders(shouldSendHealthFallbackAuth(agent) ? auth : undefined),
         signal: AbortSignal.timeout(5000),
         maxRedirects: 0,
       });
@@ -289,15 +314,7 @@ export class HealthChecker {
     try {
       // Check for A2A agent card at /.well-known/agent.json
       const agentCardUrl = `${agent.url.replace(/\/$/, "")}/.well-known/agent.json`;
-      const headers: Record<string, string> = { 'User-Agent': AAO_UA_HEALTH_CHECK };
-      const authFields = agentConfigAuthFields(auth);
-      if (authFields.auth_token) {
-        headers['Authorization'] = `Bearer ${authFields.auth_token}`;
-      } else if (authFields.headers?.Authorization) {
-        headers['Authorization'] = authFields.headers.Authorization;
-      } else if (authFields.oauth_tokens?.access_token) {
-        headers['Authorization'] = `Bearer ${authFields.oauth_tokens.access_token}`;
-      }
+      const headers = healthProbeHeaders(auth);
       const response = await fetch(agentCardUrl, {
         headers,
         signal: AbortSignal.timeout(5000),

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -6125,7 +6125,10 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
 
       let probeResult: Awaited<ReturnType<typeof crawler.refreshSingleAgent>>;
       try {
-        probeResult = await crawler.refreshSingleAgent(agentUrl, { auth: resolvedAuth });
+        probeResult = await crawler.refreshSingleAgent(agentUrl, {
+          auth: resolvedAuth,
+          ...(ownerOrgId ? { ownerOrgId } : {}),
+        });
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Probe failed';
         if (/Monitoring paused/i.test(message)) {
@@ -6507,7 +6510,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         try {
           const auth = await resolveUserAgentAuth(agentContextDb, orgId, agentUrl, logger);
           const resolvedAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `connect:${agentUrl}` });
-          refreshed = await crawler.refreshSingleAgent(agentUrl, { auth: resolvedAuth });
+          refreshed = await crawler.refreshSingleAgent(agentUrl, { auth: resolvedAuth, ownerOrgId: orgId });
         } catch (refreshErr) {
           logger.warn(
             { err: refreshErr, agentUrl },
@@ -6591,7 +6594,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         try {
           const auth = await resolveUserAgentAuth(agentContextDb, orgId, agentUrl, logger);
           const resolvedAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `connect-cc:${agentUrl}` });
-          refreshed = await crawler.refreshSingleAgent(agentUrl, { auth: resolvedAuth });
+          refreshed = await crawler.refreshSingleAgent(agentUrl, { auth: resolvedAuth, ownerOrgId: orgId });
         } catch (refreshErr) {
           logger.warn(
             { err: refreshErr, agentUrl },

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1141,6 +1141,7 @@ export interface FederatedAgent {
   name?: string;
   type?: AgentType;
   protocol?: 'mcp' | 'a2a';
+  health_check_url?: string;
   member?: {
     slug: string;
     display_name: string;

--- a/server/tests/integration/federated-index-probeable-agents.test.ts
+++ b/server/tests/integration/federated-index-probeable-agents.test.ts
@@ -92,7 +92,13 @@ describe('FederatedIndexService.listAllProbeableAgents (adcp#4849)', () => {
       [
         ORG_ID,
         PROFILE_SLUG,
-        JSON.stringify([{ url: AGENT_REGISTERED, name: 'registered name', type: 'sales', visibility: 'public' }]),
+        JSON.stringify([{
+          url: AGENT_REGISTERED,
+          name: 'registered name',
+          type: 'sales',
+          visibility: 'public',
+          health_check_url: `${AGENT_REGISTERED}/health`,
+        }]),
       ],
     );
 
@@ -100,5 +106,6 @@ describe('FederatedIndexService.listAllProbeableAgents (adcp#4849)', () => {
     const found = probeable.find(a => a.url === AGENT_REGISTERED);
     expect(found).toBeDefined();
     expect(found!.name).toBe('registered name'); // member-profile metadata wins
+    expect(found!.health_check_url).toBe(`${AGENT_REGISTERED}/health`);
   });
 });

--- a/server/tests/integration/registry-api-agent-refresh.test.ts
+++ b/server/tests/integration/registry-api-agent-refresh.test.ts
@@ -402,6 +402,7 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
       agentUrl,
       expect.objectContaining({
         auth: { type: 'bearer', token: FAKE_BEARER },
+        ownerOrgId: TEST_ORG_ID,
       }),
     );
 

--- a/server/tests/unit/health-fallback.test.ts
+++ b/server/tests/unit/health-fallback.test.ts
@@ -163,6 +163,55 @@ describe('HealthChecker.tryMCP — health_check_url fallback', () => {
     expect(opts.method).toBe('GET');
   });
 
+  it('sends saved bearer auth to health_check_url fallback', async () => {
+    mockGetAgentInfo.mockRejectedValue(new Error('Failed to discover MCP endpoint'));
+    mockSafeFetch.mockResolvedValue(new Response('ok', { status: 200 }));
+    const checker = new HealthChecker(0);
+    const health = await checker.checkHealth(
+      baseAgent({ health_check_url: 'https://agent.example.com/health' }),
+      { type: 'bearer', token: 'saved-static-token' },
+    );
+    expect(health.online).toBe(true);
+    expect(health.error).toMatch(/Liveness via health_check_url/);
+    expect(health.tools_count).toBeUndefined();
+    expect(mockSafeFetch).toHaveBeenCalledTimes(1);
+    const [, opts] = mockSafeFetch.mock.calls[0];
+    expect(opts.headers).toMatchObject({
+      'User-Agent': 'AAO-HealthCheck/1.0 (+https://agenticadvertising.org/docs/monitoring)',
+      Authorization: 'Bearer saved-static-token',
+    });
+    expect(opts.maxRedirects).toBe(0);
+  });
+
+  it('does not send saved auth to cross-origin health_check_url fallback', async () => {
+    mockGetAgentInfo.mockRejectedValue(new Error('Failed to discover MCP endpoint'));
+    mockSafeFetch.mockResolvedValue(new Response('ok', { status: 200 }));
+    const checker = new HealthChecker(0);
+    const health = await checker.checkHealth(
+      baseAgent({ health_check_url: 'https://status.example.net/agent-health' }),
+      { type: 'bearer', token: 'saved-static-token' },
+    );
+    expect(health.online).toBe(true);
+    const [, opts] = mockSafeFetch.mock.calls[0];
+    expect(opts.headers).toMatchObject({
+      'User-Agent': 'AAO-HealthCheck/1.0 (+https://agenticadvertising.org/docs/monitoring)',
+    });
+    expect(opts.headers).not.toHaveProperty('Authorization');
+  });
+
+  it('does not send saved auth to plaintext health_check_url fallback', async () => {
+    mockGetAgentInfo.mockRejectedValue(new Error('Failed to discover MCP endpoint'));
+    mockSafeFetch.mockResolvedValue(new Response('ok', { status: 200 }));
+    const checker = new HealthChecker(0);
+    const health = await checker.checkHealth(
+      baseAgent({ health_check_url: 'http://agent.example.com/health' }),
+      { type: 'bearer', token: 'saved-static-token' },
+    );
+    expect(health.online).toBe(true);
+    const [, opts] = mockSafeFetch.mock.calls[0];
+    expect(opts.headers).not.toHaveProperty('Authorization');
+  });
+
   it('marks offline when MCP fails and health_check_url returns non-2xx', async () => {
     mockGetAgentInfo.mockRejectedValue(new Error('Failed to discover MCP endpoint'));
     mockSafeFetch.mockResolvedValue(new Response('not found', { status: 404 }));


### PR DESCRIPTION
Fixes dashboard health probes for agents that require saved bearer auth by forwarding credentials to HTTPS same-origin health_check_url fallbacks.

Also preserves health_check_url through crawler/manual refresh paths, binds owner-auth refreshes to the owner org registration, and adds regression coverage for same-origin, cross-origin, and plaintext fallback behavior.

Validation: precommit passed during commit, npx vitest run server/tests/unit/health-fallback.test.ts passed, npm run typecheck passed, and changeset status passed; DB-backed integration tests could not run locally because Postgres on localhost:53198 was unavailable.