### PR TITLE
chore(release): exit 3.1 prerelease mode

### DIFF
--- a/.changeset/exit-3-1-prerelease-mode.md
+++ b/.changeset/exit-3-1-prerelease-mode.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore(release): exit 3.1 prerelease mode so the next Version Packages PR cuts the stable 3.1.0 release.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "rc",
   "initialVersions": {
     "adcontextprotocol": "3.1.0-rc.0"


### PR DESCRIPTION
## Summary

- Exit Changesets prerelease mode for the 3.1 GA cut.
- Add an empty changeset so repository release guards treat this as an intentional release-process change.

## Validation

- `npx --yes @changesets/cli@^2.31.0 status --since=origin/main`
- `node -e "JSON.parse(require('fs').readFileSync('.changeset/pre.json','utf8')); console.log('pre.json ok')"`
- precommit hook: unit tests, dynamic import lint, callapi state-change lint, server-unit precommit gate, typecheck
- pre-push hook: version sync, changeset detection
