### PR TITLE
fix: address P0/P1 triage bugs

### DIFF
--- a/.changeset/fix-p0-p1-triage.md
+++ b/.changeset/fix-p0-p1-triage.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix membership subscription selection, admin review notes, profile-load errors, and saved bearer health probe classification.

--- a/server/public/admin-content.html
+++ b/server/public/admin-content.html
@@ -119,6 +119,7 @@
     .content-table tr { cursor: pointer; }
     .content-table tr:hover td { background: var(--color-bg-row-hover); }
     .content-title-cell { max-width: 300px; color: var(--color-text-heading); font-weight: var(--font-semibold); }
+    .content-title-cell .review-note-badges { display: flex; gap: var(--space-1); flex-wrap: wrap; margin-top: var(--space-1); }
     .table-pagination { display: flex; justify-content: space-between; align-items: center; margin-top: var(--space-4); font-size: var(--text-sm); color: var(--color-text-secondary); }
     .table-pagination button { padding: var(--space-1_5) var(--space-3); border: var(--border-1) solid var(--color-border-strong); border-radius: var(--radius-md); background: var(--color-bg-card); cursor: pointer; font-size: var(--text-sm); }
     .table-pagination button:disabled { opacity: 0.4; cursor: not-allowed; }
@@ -590,6 +591,7 @@
         </div>
       </div>
       <img id="articleHero" class="article-hero" style="display:none;" alt="">
+      <div id="articleReviewNotes"></div>
       <div id="articleDetailContent" class="article-content"></div>
     </div>
   </div>
@@ -1138,6 +1140,10 @@
         const statusClass = 'badge-' + esc(item.status || 'draft');
         const date = item.published_at ? new Date(item.published_at).toLocaleDateString() : '-';
         const sectionLabel = SECTION_LABELS[item.content_origin] || item.content_origin || '-';
+        const reviewNoteBadges = [
+          item.revision_notes ? '<span class="badge badge-needs_revisions">Notes</span>' : '',
+          item.rejection_reason ? '<span class="badge badge-rejected">Reason</span>' : '',
+        ].filter(Boolean).join('');
         const isArticle = item.content_type === 'article';
         const heroState = isArticle
           ? (item.featured_image_url
@@ -1147,7 +1153,10 @@
               : `<button class="btn btn-small btn-outline" type="button" onclick="regenerateHeroFromTable(event, '${safeId(item.id)}')">Generate Hero</button>`)
           : 'N/A';
         return `<tr onclick="openDetailModal('${safeId(item.id)}')">
-          <td class="content-title-cell">${esc(item.title)}</td>
+          <td class="content-title-cell">
+            ${esc(item.title)}
+            ${reviewNoteBadges ? `<div class="review-note-badges">${reviewNoteBadges}</div>` : ''}
+          </td>
           <td>${esc(sectionLabel)}</td>
           <td>${esc(item.category || '-')}</td>
           <td>${esc(item.author_name || '-')}</td>
@@ -1179,7 +1188,10 @@
 
       try {
         const res = await fetch(`/api/admin/content/${encodeURIComponent(item.id)}`, { credentials: 'include' });
-        if (res.ok) { const full = await res.json(); item.content = full.content; item.tags = full.tags; }
+        if (res.ok) {
+          const full = await res.json();
+          Object.assign(item, full);
+        }
       } catch (e) { console.error('Failed to load full content:', e); }
 
       currentDetailItem = item;
@@ -1202,6 +1214,15 @@
       heroImg.onerror = function() { this.style.display = 'none'; };
 
       document.getElementById('heroBtnLabel').textContent = item.featured_image_url ? 'Regenerate Hero' : 'Generate Hero';
+
+      const reviewNotes = document.getElementById('articleReviewNotes');
+      const rejectionInfo = item.rejection_reason
+        ? `<div class="rejection-reason"><strong>Rejection reason:</strong> ${esc(item.rejection_reason)}</div>`
+        : '';
+      const revisionInfo = item.revision_notes
+        ? `<div class="rejection-reason" style="border-color: var(--color-warning-300); color: var(--color-warning-700); background: var(--color-warning-50);"><strong>Revision notes:</strong> ${esc(item.revision_notes)}</div>`
+        : '';
+      reviewNotes.innerHTML = `${rejectionInfo}${revisionInfo}`;
 
       const html = item.content ? marked.parse(item.content) : '<p><em>No content available.</em></p>';
       document.getElementById('articleDetailContent').innerHTML = DOMPurify.sanitize(html);

--- a/server/public/member-profile.html
+++ b/server/public/member-profile.html
@@ -1333,19 +1333,26 @@
     }
 
     // Initialize
-    document.addEventListener('DOMContentLoaded', () => {
-      // Setup event listeners first
-      setupOfferingsToggle();
-      setupTagsInput();
-      setupSlugCheck();
-      setupPhotoPreview();
-      setupMemberCardPreview();
-      setupPhoneFormatting();
-      setupMarketsAutoSelect();
-      setupBrandColorSync();
-      // Load profile data after listeners are ready
-      loadProfile();
-    });
+    document.addEventListener('DOMContentLoaded', initMemberProfilePage);
+
+    async function initMemberProfilePage() {
+      try {
+        // Setup event listeners first
+        setupOfferingsToggle();
+        setupTagsInput();
+        setupSlugCheck();
+        setupPhotoPreview();
+        setupMemberCardPreview();
+        setupPhoneFormatting();
+        setupMarketsAutoSelect();
+        setupBrandColorSync();
+        // Load profile data after listeners are ready
+        await loadProfile();
+      } catch (error) {
+        console.error('Member profile initialization error:', error);
+        handleLoadProfileError(error);
+      }
+    }
 
     function setupMemberCardPreview() {
       // Update preview when key fields change
@@ -1435,7 +1442,11 @@
 
         // Individual accounts use the community profile as their single profile
         if (isPersonal) {
-          window.location.href = '/account';
+          document.getElementById('loading').style.display = 'none';
+          showError('This page is for organization profiles. Opening your account profile instead.');
+          window.setTimeout(() => {
+            window.location.href = '/account';
+          }, 1200);
           return;
         }
 
@@ -1495,17 +1506,23 @@
 
       } catch (error) {
         console.error('Load profile error:', error);
-        document.getElementById('loading').style.display = 'none';
-        let msg;
-        if (error.name === 'AbortError') {
-          msg = 'The server is taking too long to respond. Please try again in a moment.';
-        } else if (error.message) {
-          msg = error.message;
-        } else {
-          msg = 'Failed to load your profile. Please try again.';
-        }
-        showError(msg);
+        handleLoadProfileError(error);
       }
+    }
+
+    function handleLoadProfileError(error) {
+      const loading = document.getElementById('loading');
+      if (loading) loading.style.display = 'none';
+
+      let msg;
+      if (error && error.name === 'AbortError') {
+        msg = 'The server is taking too long to respond. Please try again in a moment.';
+      } else if (error && error.message) {
+        msg = error.message;
+      } else {
+        msg = 'Failed to load your profile. Please try again.';
+      }
+      showError(msg);
     }
 
     // Update form labels and placeholders based on account type

--- a/server/src/billing/active-subscription-guard.ts
+++ b/server/src/billing/active-subscription-guard.ts
@@ -41,7 +41,11 @@ export interface ActiveSubscriptionBlock {
  */
 const BLOCKING_STATUSES: ReadonlySet<string> = new Set(TIER_PRESERVING_STATUSES);
 
-function formatAmount(cents: number): string {
+function formatAmount(cents: number): string | null {
+  if (!Number.isSafeInteger(cents) || cents < 0) {
+    return null;
+  }
+
   // Render as fixed 2-decimal currency; otherwise $250.50 displays as "$250.5".
   return `$${(cents / 100).toLocaleString('en-US', {
     minimumFractionDigits: 2,
@@ -99,7 +103,7 @@ export async function blockIfActiveSubscription(
   }
 
   const productName = info.product_name || info.lookup_key || 'membership';
-  const amountDisplay = info.amount_cents != null ? formatAmount(info.amount_cents) : 'an active tier';
+  const amountDisplay = info.amount_cents != null ? formatAmount(info.amount_cents) ?? 'an active tier' : 'an active tier';
 
   const remediation = portalUrl
     ? 'To change tiers, cancel, or update payment method, use the Stripe Customer Portal.'

--- a/server/src/billing/stripe-client.ts
+++ b/server/src/billing/stripe-client.ts
@@ -3,6 +3,7 @@ import { createLogger } from '../logger.js';
 import { notifySystemError } from '../addie/error-notifier.js';
 import { getPool } from '../db/client.js';
 import { isStripeNotFound } from '../audit/integrity/stripe-helpers.js';
+import { pickMembershipSubWithProductFetch } from './membership-prices.js';
 
 const logger = createLogger('stripe-client');
 
@@ -396,9 +397,17 @@ export async function getStripeSubscriptionInfo(
       return { status: 'none' };
     }
 
+    const picked = await pickMembershipSubWithProductFetch(
+      subscriptions.data as Stripe.Subscription[],
+      (productId) => stripe.products.retrieve(productId),
+    );
+    if (!picked) {
+      return { status: 'none' };
+    }
+
     // The subscription from customer.subscriptions is a limited object
     // We need to fetch the full subscription with latest_invoice expanded to get current_period_end
-    const subscriptionId = subscriptions.data[0].id;
+    const subscriptionId = picked.sub.id;
     const subscription = await stripe.subscriptions.retrieve(subscriptionId, {
       expand: ['items.data.price.product', 'latest_invoice'],
     });

--- a/server/src/capabilities.ts
+++ b/server/src/capabilities.ts
@@ -390,8 +390,10 @@ export class CapabilityDiscovery {
         logger.info({ url, hasOAuth: error.hasOAuth }, 'MCP agent requires OAuth authentication');
         throw error;
       }
-      // For generic 401 errors, wrap in AuthenticationRequiredError
-      if (is401Error(error)) {
+      // For generic 401 errors, unauthenticated probes can offer the OAuth
+      // affordance. Authed probes should surface as credential failures
+      // instead of relabeling a sent-but-rejected bearer as "OAuth required."
+      if (is401Error(error) && !auth) {
         logger.info({ url }, 'MCP agent returned 401');
         throw new AuthenticationRequiredError(url, undefined, 'Agent requires authentication');
       }
@@ -429,8 +431,10 @@ export class CapabilityDiscovery {
         logger.info({ url, hasOAuth: error.hasOAuth }, 'A2A agent requires OAuth authentication');
         throw error;
       }
-      // For generic 401 errors, wrap in AuthenticationRequiredError
-      if (is401Error(error)) {
+      // For generic 401 errors, unauthenticated probes can offer the OAuth
+      // affordance. Authed probes should surface as credential failures
+      // instead of relabeling a sent-but-rejected bearer as "OAuth required."
+      if (is401Error(error) && !auth) {
         logger.info({ url }, 'A2A agent returned 401');
         throw new AuthenticationRequiredError(url, undefined, 'Agent requires authentication');
       }

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -6483,6 +6483,7 @@ export class HTTPServer {
                          THEN '/api/perspectives/' || p.slug || '/card.png'
                          ELSE NULL END) AS featured_image_url,
                   p.status, p.published_at,
+                  p.revision_notes, p.rejection_reason,
                   p.illustration_id,
                   p.content_origin, p.source_type,
                   wg.slug as committee_slug, wg.name as committee_name
@@ -6555,6 +6556,7 @@ export class HTTPServer {
                          THEN '/api/perspectives/' || p.slug || '/card.png'
                          ELSE NULL END) AS featured_image_url,
                   p.status, p.published_at,
+                  p.revision_notes, p.rejection_reason,
                   p.illustration_id,
                   p.content_origin, p.source_type, p.updated_at,
                   wg.slug as committee_slug, wg.name as committee_name

--- a/server/tests/integration/perspective-assets.test.ts
+++ b/server/tests/integration/perspective-assets.test.ts
@@ -335,6 +335,45 @@ describe('Perspective Assets Integration Tests', () => {
       expect(testItem.content_origin).toBe('member');
       expect(testItem.title).toBe('Test Asset Perspective');
     });
+
+    it('should include moderation notes needed by the admin table', async () => {
+      await pool.query(
+        `UPDATE perspectives
+         SET status = 'needs_revisions',
+             revision_notes = 'Please tighten the intro.',
+             rejection_reason = 'Off-topic for the current queue.'
+         WHERE id = $1`,
+        [testPerspectiveId]
+      );
+
+      const listResponse = await request(app)
+        .get('/api/admin/content')
+        .expect(200);
+
+      const listItem = listResponse.body.items.find((i: any) => i.slug === TEST_SLUG);
+      expect(listItem).toMatchObject({
+        revision_notes: 'Please tighten the intro.',
+        rejection_reason: 'Off-topic for the current queue.',
+      });
+
+      const detailResponse = await request(app)
+        .get(`/api/admin/content/${testPerspectiveId}`)
+        .expect(200);
+
+      expect(detailResponse.body).toMatchObject({
+        revision_notes: 'Please tighten the intro.',
+        rejection_reason: 'Off-topic for the current queue.',
+      });
+
+      await pool.query(
+        `UPDATE perspectives
+         SET status = 'published',
+             revision_notes = NULL,
+             rejection_reason = NULL
+         WHERE id = $1`,
+        [testPerspectiveId]
+      );
+    });
   });
 
   describe('PUT /api/admin/content/:id/origin', () => {

--- a/server/tests/unit/active-subscription-guard.test.ts
+++ b/server/tests/unit/active-subscription-guard.test.ts
@@ -134,6 +134,23 @@ describe('blockIfActiveSubscription', () => {
     expect(result!.body.message).toContain('$250.50');
   });
 
+  it('falls back to generic tier copy when amount_cents is not a safe cent value', async () => {
+    const orgDb = makeOrgDb({
+      info: {
+        status: 'active',
+        product_name: 'Membership',
+        amount_cents: Number.MAX_SAFE_INTEGER + 1,
+      },
+      org: { stripe_customer_id: null },
+    });
+
+    const result = await blockIfActiveSubscription('org_x', orgDb, { customerPortalReturnUrl: PORTAL_RETURN_URL });
+
+    expect(result).not.toBeNull();
+    expect(result!.body.message).toContain('Membership (an active tier)');
+    expect(result!.body.message).not.toContain('$');
+  });
+
   it('omits customer_portal_url when caller does not pass customerPortalReturnUrl (privilege check)', async () => {
     // The invite-acceptance route omits returnUrl because the recipient gets
     // `member` role only and a portal session would grant admin-equivalent

--- a/server/tests/unit/capability-discovery-auth-classification.test.ts
+++ b/server/tests/unit/capability-discovery-auth-classification.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+
+class MockAuthenticationRequiredError extends Error {
+  hasOAuth = false;
+
+  constructor(url: string, _metadata?: unknown, message = 'Agent requires authentication') {
+    super(message);
+    this.name = 'AuthenticationRequiredError';
+    this.hasOAuth = url.includes('oauth');
+  }
+}
+
+const getAgentInfoMock = vi.fn();
+
+vi.mock('@adcp/sdk', () => ({
+  AuthenticationRequiredError: MockAuthenticationRequiredError,
+  is401Error: (error: unknown) => (error as { status?: number })?.status === 401,
+  AdCPClient: class {
+    agent() {
+      return {
+        getAgentInfo: getAgentInfoMock,
+      };
+    }
+  },
+}));
+
+vi.mock('../../src/db/outbound-log-db.js', () => ({
+  logOutboundRequest: vi.fn(),
+}));
+
+const { CapabilityDiscovery } = await import('../../src/capabilities.js');
+
+const AGENT = {
+  name: 'Auth Test Agent',
+  url: 'https://agent.example.com/mcp',
+  type: 'sales' as const,
+  protocol: 'mcp' as const,
+  description: '',
+  mcp_endpoint: 'https://agent.example.com/mcp',
+  contact: { name: '', email: '', website: '' },
+  added_date: '2026-06-18',
+};
+
+describe('CapabilityDiscovery auth classification', () => {
+  it('marks unauthenticated generic 401 discovery as oauth_required', async () => {
+    getAgentInfoMock.mockRejectedValueOnce(Object.assign(new Error('Unauthorized'), { status: 401 }));
+
+    const profile = await new CapabilityDiscovery().discoverCapabilities(AGENT);
+
+    expect(profile.discovered_tools).toEqual([]);
+    expect(profile.discovery_error).toBe('Agent requires authentication');
+    expect(profile.oauth_required).toBe(true);
+  });
+
+  it('does not relabel rejected saved bearer auth as oauth_required', async () => {
+    getAgentInfoMock.mockRejectedValueOnce(Object.assign(new Error('Unauthorized'), { status: 401 }));
+
+    const profile = await new CapabilityDiscovery().discoverCapabilities(AGENT, {
+      type: 'bearer',
+      token: 'saved-but-rejected',
+    });
+
+    expect(profile.discovered_tools).toEqual([]);
+    expect(profile.discovery_error).toBe('Unauthorized');
+    expect(profile.oauth_required).toBe(false);
+  });
+});

--- a/server/tests/unit/stripe-client-subscription-info.test.ts
+++ b/server/tests/unit/stripe-client-subscription-info.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type Stripe from 'stripe';
+
+const retrieveCustomer = vi.fn();
+const retrieveSubscription = vi.fn();
+const retrieveProduct = vi.fn();
+
+vi.mock('stripe', () => {
+  class MockStripe {
+    static API_VERSION = '2025-02-24.acacia';
+
+    customers = {
+      retrieve: retrieveCustomer,
+    };
+
+    subscriptions = {
+      retrieve: retrieveSubscription,
+    };
+
+    products = {
+      retrieve: retrieveProduct,
+    };
+  }
+
+  return { default: MockStripe };
+});
+
+process.env.STRIPE_SECRET_KEY = 'sk_test_subscription_info';
+
+const { getStripeSubscriptionInfo } = await import('../../src/billing/stripe-client.js');
+
+function subscriptionFixture(
+  id: string,
+  lookupKey: string | null,
+  product: string | Stripe.Product,
+): Stripe.Subscription {
+  return {
+    id,
+    status: 'active',
+    items: {
+      data: [
+        {
+          price: {
+            lookup_key: lookupKey,
+            product,
+            unit_amount: 100000,
+          },
+        },
+      ],
+    },
+  } as Stripe.Subscription;
+}
+
+describe('getStripeSubscriptionInfo', () => {
+  beforeEach(() => {
+    retrieveCustomer.mockReset();
+    retrieveSubscription.mockReset();
+    retrieveProduct.mockReset();
+  });
+
+  it('selects the membership subscription instead of the first stacked non-membership sub', async () => {
+    const nonMembership = subscriptionFixture('sub_event', 'aao_event_ticket_2026', 'prod_event');
+    const membership = subscriptionFixture('sub_member', 'aao_membership_builder_3000', 'prod_member');
+
+    retrieveCustomer.mockResolvedValue({
+      id: 'cus_x',
+      deleted: false,
+      subscriptions: {
+        data: [nonMembership, membership],
+      },
+    });
+    retrieveSubscription.mockResolvedValue({
+      ...membership,
+      latest_invoice: {
+        id: 'in_x',
+        period_start: 100,
+        period_end: 200,
+      },
+      cancel_at_period_end: false,
+      items: {
+        data: [
+          {
+            price: {
+              lookup_key: 'aao_membership_builder_3000',
+              product: {
+                id: 'prod_member',
+                name: 'Builder Membership',
+              },
+              unit_amount: 300000,
+              recurring: { interval: 'year', interval_count: 1 },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getStripeSubscriptionInfo('cus_x');
+
+    expect(result).toMatchObject({
+      status: 'active',
+      product_id: 'prod_member',
+      product_name: 'Builder Membership',
+      lookup_key: 'aao_membership_builder_3000',
+      amount_cents: 300000,
+      current_period_end: 200,
+      cancel_at_period_end: false,
+    });
+    expect(retrieveSubscription).toHaveBeenCalledWith('sub_member', {
+      expand: ['items.data.price.product', 'latest_invoice'],
+    });
+  });
+
+  it('uses product metadata fallback for legacy membership subscriptions without membership lookup keys', async () => {
+    const legacyMembership = subscriptionFixture('sub_founding', null, 'prod_founding');
+
+    retrieveCustomer.mockResolvedValue({
+      id: 'cus_x',
+      deleted: false,
+      subscriptions: {
+        data: [legacyMembership],
+      },
+    });
+    retrieveProduct.mockResolvedValue({
+      id: 'prod_founding',
+      deleted: false,
+      metadata: { category: 'membership' },
+    });
+    retrieveSubscription.mockResolvedValue({
+      ...legacyMembership,
+      latest_invoice: null,
+      cancel_at_period_end: false,
+      items: {
+        data: [
+          {
+            price: {
+              lookup_key: null,
+              product: {
+                id: 'prod_founding',
+                name: 'Founding Membership',
+              },
+              unit_amount: 1000000,
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getStripeSubscriptionInfo('cus_x');
+
+    expect(result).toMatchObject({
+      status: 'active',
+      product_id: 'prod_founding',
+      product_name: 'Founding Membership',
+      amount_cents: 1000000,
+    });
+    expect(retrieveProduct).toHaveBeenCalledWith('prod_founding');
+    expect(retrieveSubscription).toHaveBeenCalledWith('sub_founding', {
+      expand: ['items.data.price.product', 'latest_invoice'],
+    });
+  });
+
+  it('returns none when the customer only has non-membership subscriptions', async () => {
+    retrieveCustomer.mockResolvedValue({
+      id: 'cus_x',
+      deleted: false,
+      subscriptions: {
+        data: [subscriptionFixture('sub_event', 'aao_event_ticket_2026', 'prod_event')],
+      },
+    });
+
+    const result = await getStripeSubscriptionInfo('cus_x');
+
+    expect(result).toEqual({ status: 'none' });
+    expect(retrieveSubscription).not.toHaveBeenCalled();
+  });
+});

--- a/tests/billing/stripe-client.test.ts
+++ b/tests/billing/stripe-client.test.ts
@@ -99,6 +99,15 @@ describe('stripe-client', () => {
             subscriptions: {
               data: [{
                 id: 'sub_123',
+                status: 'active',
+                items: {
+                  data: [{
+                    price: {
+                      lookup_key: 'aao_membership_test',
+                      product: 'prod_123',
+                    },
+                  }],
+                },
               }],
             },
           }),


### PR DESCRIPTION
## Summary

- Fix Stripe subscription selection for stacked non-membership subscriptions and guard against unsafe cent values in active-subscription upgrade copy
- Surface revision notes and rejection reasons in the admin editorial queue list/detail views
- Add a visible member-profile initialization failure path instead of leaving `/member-profile?org=` blank
- Preserve saved-bearer health probe failures as credential failures instead of relabeling them as OAuth-required

Closes #5600
Closes #5597
Closes #5596
Closes #5592

## Test plan

- [x] `npm exec -- vitest run server/tests/unit/active-subscription-guard.test.ts server/tests/unit/stripe-client-subscription-info.test.ts server/tests/unit/capability-discovery-auth-classification.test.ts`
- [x] `npm exec -- vitest run tests/billing/stripe-client.test.ts`
- [x] precommit hook during commit: 270 files passed, 4219 tests passed, 30 skipped; typecheck passed
- [x] `git diff --check`
- [ ] `npm exec -- vitest run server/tests/integration/perspective-assets.test.ts` cannot complete locally: test DB connection refused on `::1:53198` / `127.0.0.1:53198`; suite setup fails before tests run
