### PR TITLE
docs(site): update 3.1 release homepage banner

### DIFF
--- a/server/public/index.html
+++ b/server/public/index.html
@@ -32,9 +32,9 @@
 </head>
 <body data-nav-theme="dark">
 
-<!-- 3.1 active development announcement strip (dismissible) -->
+<!-- 3.1 release announcement strip (dismissible) -->
 <div id="aao-announcement" style="display:none;background:var(--color-brand);color:var(--color-text-on-dark);padding:10px 20px;text-align:center;font-size:14px;line-height:1.4;position:relative;">
-  <strong>AdCP 3.1 is in active development</strong> &mdash; <a href="https://docs.adcontextprotocol.org/docs/reference/release-notes" style="color:var(--color-text-on-dark);text-decoration:underline;">see what's coming &rarr;</a>
+  <strong>AdCP 3.1 is released</strong> &mdash; <a href="https://docs.adcontextprotocol.org/docs/reference/whats-new-in-3-1" style="color:var(--color-text-on-dark);text-decoration:underline;">see what's new &rarr;</a>
   <button onclick="document.getElementById('aao-announcement').style.display='none';document.cookie='aao_announce_31_dismissed=1;path=/;max-age=2592000';" aria-label="Dismiss announcement" style="position:absolute;right:12px;top:50%;transform:translateY(-50%);background:none;border:none;color:var(--color-text-on-dark);font-size:18px;cursor:pointer;padding:0 6px;line-height:1;">&times;</button>
 </div>
 <script>


### PR DESCRIPTION
## Summary
- Update the public homepage announcement strip from 3.1 active-development copy to 3.1 released copy.
- Point the banner at the 3.1 what's-new page, matching the Mintlify docs banner.

## Verification
- `rg -n "3\.1 active development|3\.1 is in active development|see what's coming|AdCP 3\.1 is released|what's new" server/public/index.html docs.json`
- `git diff --check`
- `npx vitest run server/tests/unit/brand-json-endpoint-gate.test.ts server/tests/unit/brand-logos-upload-auth.test.ts`

Note: the local precommit hook ran the full server-unit suite because this touches `server/public`; that broad suite failed in two unrelated brand tests. Those same two files pass in isolation with the command above, so this PR leaves the server behavior untouched.