### PR TITLE
fix(addie): refresh docs index and avoid stream duplicates

### DIFF
--- a/.changeset/addie-docs-stream-fallbacks.md
+++ b/.changeset/addie-docs-stream-fallbacks.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Refresh Addie's docs search index on a scheduler and avoid duplicate Slack replies when stream finalization fails after text was already delivered.

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -108,6 +108,8 @@ import {
   splitMrkdwnIntoSections,
   truncateNotificationText,
   decideStreamAppend,
+  planStreamStopFailureFallback,
+  STREAM_DELIVERY_UNCERTAIN_NOTICE,
   DEFAULT_STREAM_SOFT_CAP,
 } from './slack-blocks.js';
 
@@ -1913,30 +1915,39 @@ async function handleUserMessage({
         // Stream was closed mid-flow (length-cap stop failed, or upstream
         // interruption with a successful recovery banner). Skip the second
         // stop attempt — it would throw and we'd just land in the same
-        // chunked-say fallback. Ship the full reply directly here unless
-        // the stream_error branch already posted a recovery banner.
+        // fallback branch. If answer text already reached Slack, post only a
+        // delivery notice so we do not duplicate the streamed response.
         if (!streamWasInterrupted) {
-          try {
-            const guarded = guardBareJsonEnvelope(fullText, { pathTag: 'dm-streaming-stop-failed' });
-            const fallbackValidation = validateOutput(guarded.text);
-            const { text: fallbackText, images: fallbackImages } = extractMarkdownImages(fallbackValidation.sanitized);
-            const slackText = wrapUrlsForSlack(fallbackText);
-            if (slackText.trim()) {
-              await say({
-                text: truncateNotificationText(slackText),
-                blocks: [
-                  ...splitMrkdwnIntoSections(slackText),
-                  ...fallbackImages.slice(0, 3).map(img => ({
-                    type: 'image' as const,
-                    image_url: img.url,
-                    alt_text: img.alt,
-                  })),
-                  buildFeedbackBlock(),
-                ],
-              });
+          const fallbackPlan = planStreamStopFailureFallback(streamedLen);
+          if (fallbackPlan === 'delivery-notice') {
+            try {
+              await say(STREAM_DELIVERY_UNCERTAIN_NOTICE);
+            } catch (noticeError) {
+              logger.warn({ noticeError, streamedLen, fullTextLen: fullText.length }, 'Addie Bolt: Stream delivery notice say() failed');
             }
-          } catch (fallbackError) {
-            logger.error({ fallbackError, fullTextLen: fullText.length }, 'Addie Bolt: Stop-failed fallback say() also failed');
+          } else {
+            try {
+              const guarded = guardBareJsonEnvelope(fullText, { pathTag: 'dm-streaming-stop-failed' });
+              const fallbackValidation = validateOutput(guarded.text);
+              const { text: fallbackText, images: fallbackImages } = extractMarkdownImages(fallbackValidation.sanitized);
+              const slackText = wrapUrlsForSlack(fallbackText);
+              if (slackText.trim()) {
+                await say({
+                  text: truncateNotificationText(slackText),
+                  blocks: [
+                    ...splitMrkdwnIntoSections(slackText),
+                    ...fallbackImages.slice(0, 3).map(img => ({
+                      type: 'image' as const,
+                      image_url: img.url,
+                      alt_text: img.alt,
+                    })),
+                    buildFeedbackBlock(),
+                  ],
+                });
+              }
+            } catch (fallbackError) {
+              logger.error({ fallbackError, fullTextLen: fullText.length }, 'Addie Bolt: Stop-failed fallback say() also failed');
+            }
           }
         }
       } else {
@@ -1968,42 +1979,51 @@ async function handleUserMessage({
             });
           }
         } catch (stopError) {
-          logger.warn({ stopError }, 'Addie Bolt: Stream stop failed, falling back to say()');
-          // Fallback: send via say() so the user isn't left without a response
-          try {
-            const guarded = guardBareJsonEnvelope(fullText, { pathTag: 'dm-streaming-fallback' });
-            const fallbackValidation = validateOutput(guarded.text);
-            const { text: fallbackText, images: fallbackImages } = extractMarkdownImages(fallbackValidation.sanitized);
-            const slackText = wrapUrlsForSlack(fallbackText);
-            // Slack rejects section blocks with empty mrkdwn text. If streaming
-            // produced nothing (e.g. upstream overload before any deltas), fall
-            // back to a plain apology so the user isn't left silent. For
-            // cost_cap_exceeded, deliver the cap message directly.
-            if (!slackText.trim()) {
-              const apology = response?.flag_reason === 'cost_cap_exceeded'
-                ? response.text
-                : isRetriesExhaustedError(stopError)
-                  ? `${stopError.reason}. Please try again in a moment.`
-                  : "I'm sorry, I encountered an error. Please try again.";
-              await say(apology);
-            } else {
-              await say({
-                text: truncateNotificationText(slackText),
-                blocks: [
-                  ...splitMrkdwnIntoSections(slackText),
-                  ...fallbackImages.slice(0, 3).map(img => ({
-                    type: 'image' as const,
-                    image_url: img.url,
-                    alt_text: img.alt,
-                  })),
-                  buildFeedbackBlock(),
-                ],
-              });
+          logger.warn({ stopError, streamedLen }, 'Addie Bolt: Stream stop failed, planning fallback delivery');
+          const fallbackPlan = planStreamStopFailureFallback(streamedLen);
+          if (fallbackPlan === 'delivery-notice') {
+            try {
+              await say(STREAM_DELIVERY_UNCERTAIN_NOTICE);
+            } catch (noticeError) {
+              logger.warn({ noticeError, stopError, streamedLen }, 'Addie Bolt: Stream delivery notice say() failed');
             }
-          } catch (sayError) {
-            const rootCause = isRetriesExhaustedError(stopError) ? 'retries-exhausted' : 'other';
-            const logLevel = rootCause === 'retries-exhausted' ? 'warn' : 'error';
-            logger[logLevel]({ sayError, stopError, rootCause }, 'Addie Bolt: Fallback say() also failed');
+          } else {
+            // Fallback: send via say() so the user isn't left without a response
+            try {
+              const guarded = guardBareJsonEnvelope(fullText, { pathTag: 'dm-streaming-fallback' });
+              const fallbackValidation = validateOutput(guarded.text);
+              const { text: fallbackText, images: fallbackImages } = extractMarkdownImages(fallbackValidation.sanitized);
+              const slackText = wrapUrlsForSlack(fallbackText);
+              // Slack rejects section blocks with empty mrkdwn text. If streaming
+              // produced nothing (e.g. upstream overload before any deltas), fall
+              // back to a plain apology so the user isn't left silent. For
+              // cost_cap_exceeded, deliver the cap message directly.
+              if (!slackText.trim()) {
+                const apology = response?.flag_reason === 'cost_cap_exceeded'
+                  ? response.text
+                  : isRetriesExhaustedError(stopError)
+                    ? `${stopError.reason}. Please try again in a moment.`
+                    : "I'm sorry, I encountered an error. Please try again.";
+                await say(apology);
+              } else {
+                await say({
+                  text: truncateNotificationText(slackText),
+                  blocks: [
+                    ...splitMrkdwnIntoSections(slackText),
+                    ...fallbackImages.slice(0, 3).map(img => ({
+                      type: 'image' as const,
+                      image_url: img.url,
+                      alt_text: img.alt,
+                    })),
+                    buildFeedbackBlock(),
+                  ],
+                });
+              }
+            } catch (sayError) {
+              const rootCause = isRetriesExhaustedError(stopError) ? 'retries-exhausted' : 'other';
+              const logLevel = rootCause === 'retries-exhausted' ? 'warn' : 'error';
+              logger[logLevel]({ sayError, stopError, rootCause }, 'Addie Bolt: Fallback say() also failed');
+            }
           }
         }
       }

--- a/server/src/addie/jobs/docs-index-refresh.ts
+++ b/server/src/addie/jobs/docs-index-refresh.ts
@@ -1,0 +1,22 @@
+/**
+ * Scheduled refresh for Addie's in-memory docs search index.
+ */
+
+import {
+  getDocCount,
+  getHeadingCount,
+  initializeDocsIndex,
+} from '../mcp/docs-indexer.js';
+
+export interface DocsIndexRefreshResult {
+  docsIndexed: number;
+  headingsIndexed: number;
+}
+
+export async function runDocsIndexRefreshJob(): Promise<DocsIndexRefreshResult> {
+  await initializeDocsIndex();
+  return {
+    docsIndexed: getDocCount(),
+    headingsIndexed: getHeadingCount(),
+  };
+}

--- a/server/src/addie/jobs/job-definitions.ts
+++ b/server/src/addie/jobs/job-definitions.ts
@@ -27,6 +27,7 @@ import { SlackDatabase } from '../../db/slack-db.js';
 import { runPersonaInferenceJob } from '../services/persona-inference.js';
 import { runJourneyComputationJob } from '../services/journey-computation.js';
 import { runKnowledgeStalenessJob } from './knowledge-staleness.js';
+import { runDocsIndexRefreshJob } from './docs-index-refresh.js';
 import { runGeoMonitorJob } from './geo-monitor.js';
 import { runGeoSnapshotJob } from './geo-snapshot.js';
 import { runGeoContentPlannerJob } from './geo-content-planner.js';
@@ -313,6 +314,16 @@ export function registerAllJobs(): void {
     runner: runKnowledgeStalenessJob,
     options: { limit: 200 },
     shouldLogResult: (r) => r.staleEntries > 0,
+  });
+
+  // Addie docs index refresh - re-walks protocol docs, website pages, and DB-backed content
+  jobScheduler.register({
+    name: 'addie-docs-index-refresh',
+    description: 'Addie docs index refresh',
+    interval: { value: 24, unit: 'hours' },
+    initialDelay: { value: 12, unit: 'minutes' },
+    runner: runDocsIndexRefreshJob,
+    shouldLogResult: (r) => r.docsIndexed === 0,
   });
 
   // Prospect triage - assesses unmapped Slack domains and creates prospects
@@ -908,6 +919,7 @@ export const JOB_NAMES = {
   PERSONA_INFERENCE: 'persona-inference',
   JOURNEY_COMPUTATION: 'journey-computation',
   KNOWLEDGE_STALENESS: 'knowledge-staleness',
+  ADDIE_DOCS_INDEX_REFRESH: 'addie-docs-index-refresh',
   PROSPECT_TRIAGE: 'prospect-triage',
   PROSPECT_ESCALATION: 'prospect-escalation',
   WEEKLY_DIGEST: 'weekly-digest',

--- a/server/src/addie/mcp/docs-indexer.ts
+++ b/server/src/addie/mcp/docs-indexer.ts
@@ -490,8 +490,8 @@ export async function initializeDocsIndex(): Promise<void> {
     }
   }
 
-  docsIndex = [];
-  headingsIndex = [];
+  const nextDocsIndex: IndexedDoc[] = [];
+  const nextHeadingsIndex: IndexedHeading[] = [];
 
   // Index markdown docs
   if (docsRoot) {
@@ -517,7 +517,7 @@ export async function initializeDocsIndex(): Promise<void> {
         const id = `doc:${relativePath.replace(/\\/g, '/').replace(/\.(md|mdx)$/, '')}`;
         const sourceUrl = buildSourceUrl(filePath, docsRoot);
 
-        docsIndex.push({
+        nextDocsIndex.push({
           id,
           title,
           category,
@@ -528,7 +528,7 @@ export async function initializeDocsIndex(): Promise<void> {
 
         // Extract and index headings from this doc
         const docHeadings = extractHeadings(cleanedContent, id, title, sourceUrl);
-        headingsIndex.push(...docHeadings);
+        nextHeadingsIndex.push(...docHeadings);
       } catch (error) {
         logger.warn({ error, filePath }, 'Addie Docs: Failed to index file');
       }
@@ -541,7 +541,7 @@ export async function initializeDocsIndex(): Promise<void> {
   if (publicRoot) {
     logger.info({ publicRoot }, 'Addie Docs: Indexing website pages');
     const websitePages = indexWebsitePages(publicRoot);
-    docsIndex.push(...websitePages);
+    nextDocsIndex.push(...websitePages);
   } else {
     logger.warn({ paths: possiblePublicPaths }, 'Addie Docs: Could not find public directory');
   }
@@ -549,7 +549,7 @@ export async function initializeDocsIndex(): Promise<void> {
   // Index working group documents from database
   try {
     const workingGroupDocs = await loadWorkingGroupDocuments();
-    docsIndex.push(...workingGroupDocs);
+    nextDocsIndex.push(...workingGroupDocs);
     if (workingGroupDocs.length > 0) {
       logger.info({ count: workingGroupDocs.length }, 'Addie Docs: Indexed working group documents');
     }
@@ -560,7 +560,7 @@ export async function initializeDocsIndex(): Promise<void> {
   // Index published perspectives from database
   try {
     const perspectives = await loadPublishedPerspectives();
-    docsIndex.push(...perspectives);
+    nextDocsIndex.push(...perspectives);
     if (perspectives.length > 0) {
       logger.info({ count: perspectives.length }, 'Addie Docs: Indexed published perspectives');
     }
@@ -568,6 +568,8 @@ export async function initializeDocsIndex(): Promise<void> {
     logger.warn({ error }, 'Addie Docs: Failed to index perspectives');
   }
 
+  docsIndex = nextDocsIndex;
+  headingsIndex = nextHeadingsIndex;
   initialized = true;
 
   const categories = [...new Set(docsIndex.map((d) => d.category))];

--- a/server/src/addie/slack-blocks.ts
+++ b/server/src/addie/slack-blocks.ts
@@ -84,6 +84,9 @@ export function splitMrkdwnIntoSections(text: string): SlackSectionBlock[] {
  */
 export const DEFAULT_STREAM_SOFT_CAP = 9000;
 
+export const STREAM_DELIVERY_UNCERTAIN_NOTICE =
+  "_(I streamed that response, but couldn't finish Slack's delivery metadata. Some of the response may be missing; ask again and I'll retry.)_";
+
 export interface StreamAppendDecision {
   /** Pass to `streamer.append({ markdown_text: appendPart })` when non-empty. */
   appendPart: string;
@@ -119,6 +122,17 @@ export function decideStreamAppend(
     carryPart: delta.slice(cut),
     shouldFinalize: true,
   };
+}
+
+export type StreamStopFailureFallbackPlan = 'full-response' | 'delivery-notice';
+
+/**
+ * Slack can persist appended stream text even when chat.stopStream fails.
+ * If any answer text was appended successfully, reposting the full response
+ * via say() duplicates content; use a short delivery notice instead.
+ */
+export function planStreamStopFailureFallback(streamedLen: number): StreamStopFailureFallbackPlan {
+  return streamedLen > 0 ? 'delivery-notice' : 'full-response';
 }
 
 /**

--- a/server/tests/unit/addie/slack-blocks.test.ts
+++ b/server/tests/unit/addie/slack-blocks.test.ts
@@ -3,6 +3,8 @@ import {
   splitMrkdwnIntoSections,
   truncateNotificationText,
   decideStreamAppend,
+  planStreamStopFailureFallback,
+  STREAM_DELIVERY_UNCERTAIN_NOTICE,
   SLACK_SECTION_MRKDWN_LIMIT,
   SLACK_SECTION_HARD_LIMIT,
   SLACK_MAX_SECTION_BLOCKS,
@@ -219,6 +221,17 @@ describe('decideStreamAppend', () => {
     const delta = 'sentence one. sentence two.\n\nparagraph two starts here and continues.';
     const d = decideStreamAppend(50, delta, CAP);
     expect(d.appendPart + d.carryPart).toBe(delta);
+  });
+});
+
+describe('planStreamStopFailureFallback', () => {
+  it('uses full-response fallback when no text was streamed', () => {
+    expect(planStreamStopFailureFallback(0)).toBe('full-response');
+  });
+
+  it('uses a delivery notice when text already streamed successfully', () => {
+    expect(planStreamStopFailureFallback(1)).toBe('delivery-notice');
+    expect(STREAM_DELIVERY_UNCERTAIN_NOTICE).toContain('Some of the response may be missing');
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes two Addie P1s:

- Closes #5607 by rebuilding the docs search index into local arrays and atomically swapping the module-level indices after a full rebuild completes. This avoids serving an empty or half-built index while a worker refreshes. It also registers a daily scheduled refresh job so long-lived workers re-walk protocol docs, website pages, working group docs, and published perspectives after startup.
- Closes #5606 by changing Slack stream finalization fallback behavior. When `chat.stopStream` fails after text was already appended successfully, Addie now posts a short delivery notice instead of reposting the full response through `say()`, preventing duplicate answers. If no text was delivered, the existing full-response fallback still runs.

## Validation

- `npx vitest run server/tests/unit/docs-indexer.test.ts`
- `npx vitest run server/tests/unit/addie/slack-blocks.test.ts`
- `npm run typecheck`
- Commit hook precommit suite:
  - `npm run test:unit`
  - `npm run test:test-dynamic-imports`
  - `npm run test:callapi-state-change`
  - `npm run precommit:server-unit`
  - `npm run typecheck`
