### PR TITLE
ci(changesets): block non-protocol protocol bumps

### DIFF
--- a/.changeset/fix-p0-p1-triage.md
+++ b/.changeset/fix-p0-p1-triage.md
@@ -1,5 +1,0 @@
----
-"adcontextprotocol": patch
----
-
-Fix membership subscription selection, admin review notes, profile-load errors, and saved bearer health probe classification.

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -49,5 +49,13 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Check changeset protocol scope
+        run: node scripts/check-changeset-protocol-scope.cjs origin/${{ github.base_ref }}
+
       - name: Check for changeset
-        run: npx --yes @changesets/cli@^2.31.0 status --since=origin/${{ github.base_ref }}
+        run: |
+          if node scripts/check-changeset-protocol-scope.cjs origin/${{ github.base_ref }} --is-delete-only-cleanup; then
+            echo "Skipping changesets status for delete-only bad-changeset cleanup."
+            exit 0
+          fi
+          npx --yes @changesets/cli@^2.31.0 status --since=origin/${{ github.base_ref }}

--- a/scripts/check-changeset-protocol-scope.cjs
+++ b/scripts/check-changeset-protocol-scope.cjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+
+const { execFileSync } = require('child_process');
+
+const CHANGESET_FILE_RE = /^\.changeset\/[^/]+[.]md$/;
+const PROTOCOL_CHANGESET_RE = /^["']adcontextprotocol["']\s*:\s*(major|minor|patch)\s*$/m;
+
+const PROTOCOL_SCOPED_PATHS = [
+  /^static\/schemas\/source\//,
+  /^static\/compliance\/source\//,
+  /^static\/registry\//,
+  /^docs\/reference\//,
+  /^mintlify-docs\/reference\//,
+  /^dist\/(?:schemas|compliance)\//,
+  /^dist\/protocol\/[^/]+[.]tgz(?:[.](?:sha256|sig|crt))?$/,
+  /^scripts\/(?:build-schemas|build-compliance|build-protocol-tarball|sign-protocol-tarball|stage-sdk-schema-bundle|overlay-compliance-cache|update-schema-versions|verify-version-sync|patch-3-0-compat-bundle)[.](?:cjs|mjs|sh)$/,
+  /^scripts\/(?:run-storyboards-[^/]+|run-storyboards-matrix)[.]sh$/,
+  /^[.]github\/workflows\/(?:release|training-agent-storyboards)[.]yml$/,
+];
+
+const CHANGESET_POLICY_MAINTENANCE_PATHS = new Set([
+  '.github/workflows/changeset-check.yml',
+  'scripts/check-changeset-protocol-scope.cjs',
+  'tests/changeset-protocol-scope.test.cjs',
+]);
+
+function normalizePath(filePath) {
+  return String(filePath || '').replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+function parseNameStatus(output) {
+  return String(output || '')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map(line => {
+      const parts = line.split('\t');
+      const status = parts[0];
+      if (status.startsWith('R') || status.startsWith('C')) {
+        return { status, paths: [parts[1], parts[2]].filter(Boolean).map(normalizePath) };
+      }
+      return { status, paths: [parts[1]].filter(Boolean).map(normalizePath) };
+    });
+}
+
+function isChangesetFile(filePath) {
+  return CHANGESET_FILE_RE.test(normalizePath(filePath));
+}
+
+function changesetTargetsProtocol(content) {
+  return PROTOCOL_CHANGESET_RE.test(String(content || ''));
+}
+
+function isProtocolScopedPath(filePath) {
+  const normalized = normalizePath(filePath);
+  if (isChangesetFile(normalized)) return false;
+  return PROTOCOL_SCOPED_PATHS.some(pattern => pattern.test(normalized));
+}
+
+function isChangesetDeleteOnlyCleanup(changes) {
+  let deletedChangeset = false;
+
+  for (const change of changes) {
+    for (const filePath of change.paths || []) {
+      if (isChangesetFile(filePath)) {
+        if (change.status !== 'D') return false;
+        deletedChangeset = true;
+        continue;
+      }
+
+      if (!CHANGESET_POLICY_MAINTENANCE_PATHS.has(normalizePath(filePath))) {
+        return false;
+      }
+    }
+  }
+
+  return deletedChangeset;
+}
+
+
+function changedPathForHead(change) {
+  if (!change || change.status === 'D') return null;
+  return change.paths[change.paths.length - 1] || null;
+}
+
+function findChangesetProtocolScopeViolations(changes, readFileAtHead) {
+  const protocolChangesets = [];
+  const protocolScopedFiles = [];
+
+  for (const change of changes) {
+    for (const filePath of change.paths || []) {
+      if (isProtocolScopedPath(filePath)) {
+        protocolScopedFiles.push(filePath);
+      }
+    }
+
+    const headPath = changedPathForHead(change);
+    if (!headPath || !isChangesetFile(headPath)) continue;
+
+    const content = readFileAtHead(headPath);
+    if (changesetTargetsProtocol(content)) {
+      protocolChangesets.push(headPath);
+    }
+  }
+
+  if (protocolChangesets.length === 0 || protocolScopedFiles.length > 0) {
+    return [];
+  }
+
+  return protocolChangesets.map(filePath => ({
+    filePath,
+    message:
+      'Protocol changesets are only allowed when the PR also changes protocol schemas, compliance assets, normative reference docs, release scripts, or versioned dist artifacts.',
+  }));
+}
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8' });
+}
+
+function readFileAtHead(filePath) {
+  return git(['show', `HEAD:${filePath}`]);
+}
+
+function defaultBaseRef() {
+  if (process.env.CHANGESET_SCOPE_BASE) return process.env.CHANGESET_SCOPE_BASE;
+  if (process.env.GITHUB_EVENT_NAME === 'pull_request' && process.env.GITHUB_BASE_REF) {
+    return `origin/${process.env.GITHUB_BASE_REF}`;
+  }
+  return 'origin/main';
+}
+
+function formatViolationMessage(violations) {
+  return [
+    'Non-protocol changeset detected:',
+    ...violations.map(v => `  - ${v.filePath}`),
+    '',
+    'Do not add an adcontextprotocol changeset for app, site, billing, admin, or operational-only changes.',
+    violations[0]?.message,
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+function run(argv = process.argv.slice(2)) {
+  const baseRef = argv[0] || defaultBaseRef();
+  const diffOutput = git(['diff', '--name-status', '--find-renames', `${baseRef}...HEAD`]);
+  const changes = parseNameStatus(diffOutput);
+
+  if (argv.includes('--is-delete-only-cleanup')) {
+    const isCleanup = isChangesetDeleteOnlyCleanup(changes);
+    if (isCleanup) {
+      console.log('Changeset delete-only cleanup detected.');
+      return 0;
+    }
+    console.log('Not a changeset delete-only cleanup.');
+    return 1;
+  }
+
+  const violations = findChangesetProtocolScopeViolations(changes, readFileAtHead);
+
+  if (violations.length > 0) {
+    console.error(formatViolationMessage(violations));
+    return 1;
+  }
+
+  console.log('Changeset protocol scope check passed.');
+  return 0;
+}
+
+if (require.main === module) {
+  process.exitCode = run();
+}
+
+module.exports = {
+  changesetTargetsProtocol,
+  findChangesetProtocolScopeViolations,
+  formatViolationMessage,
+  isChangesetDeleteOnlyCleanup,
+  isProtocolScopedPath,
+  parseNameStatus,
+  run,
+};

--- a/tests/changeset-protocol-scope.test.cjs
+++ b/tests/changeset-protocol-scope.test.cjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+const assert = require('assert');
+const {
+  changesetTargetsProtocol,
+  findChangesetProtocolScopeViolations,
+  isChangesetDeleteOnlyCleanup,
+  isProtocolScopedPath,
+  parseNameStatus,
+} = require('../scripts/check-changeset-protocol-scope.cjs');
+
+const protocolChangeset = `---
+"adcontextprotocol": patch
+---
+
+Update the protocol.
+`;
+
+const emptyChangeset = `---
+---
+
+No package release.
+`;
+
+function readFiles(files) {
+  return filePath => files[filePath] || '';
+}
+
+assert.strictEqual(changesetTargetsProtocol(protocolChangeset), true);
+assert.strictEqual(changesetTargetsProtocol(emptyChangeset), false);
+
+assert.strictEqual(isProtocolScopedPath('static/schemas/source/media-buy/create-media-buy-request.json'), true);
+assert.strictEqual(isProtocolScopedPath('static/compliance/source/universal/security.yaml'), true);
+assert.strictEqual(isProtocolScopedPath('docs/reference/versioning.mdx'), true);
+assert.strictEqual(isProtocolScopedPath('server/src/billing/subscription-sync.ts'), false);
+assert.strictEqual(isProtocolScopedPath('.changeset/billing-fix.md'), false);
+
+assert.deepStrictEqual(
+  parseNameStatus('M\tserver/src/billing/subscription-sync.ts\nA\t.changeset/billing-fix.md\n'),
+  [
+    { status: 'M', paths: ['server/src/billing/subscription-sync.ts'] },
+    { status: 'A', paths: ['.changeset/billing-fix.md'] },
+  ]
+);
+
+let violations = findChangesetProtocolScopeViolations(
+  [
+    { status: 'M', paths: ['server/src/billing/subscription-sync.ts'] },
+    { status: 'A', paths: ['.changeset/billing-fix.md'] },
+  ],
+  readFiles({ '.changeset/billing-fix.md': protocolChangeset })
+);
+assert.strictEqual(violations.length, 1, 'App-only changes with a protocol changeset must fail');
+
+violations = findChangesetProtocolScopeViolations(
+  [
+    { status: 'M', paths: ['static/schemas/source/media-buy/create-media-buy-request.json'] },
+    { status: 'A', paths: ['.changeset/schema-fix.md'] },
+  ],
+  readFiles({ '.changeset/schema-fix.md': protocolChangeset })
+);
+assert.deepStrictEqual(violations, [], 'Schema changes with a protocol changeset are allowed');
+
+violations = findChangesetProtocolScopeViolations(
+  [
+    { status: 'M', paths: ['server/src/billing/subscription-sync.ts'] },
+    { status: 'A', paths: ['.changeset/empty.md'] },
+  ],
+  readFiles({ '.changeset/empty.md': emptyChangeset })
+);
+assert.deepStrictEqual(violations, [], 'Empty/non-package changesets are not treated as protocol releases');
+
+violations = findChangesetProtocolScopeViolations(
+  [{ status: 'D', paths: ['.changeset/old-app-fix.md'] }],
+  readFiles({ '.changeset/old-app-fix.md': protocolChangeset })
+);
+assert.deepStrictEqual(violations, [], 'Deleting a bad changeset is allowed');
+
+assert.strictEqual(
+  isChangesetDeleteOnlyCleanup([
+    { status: 'D', paths: ['.changeset/old-app-fix.md'] },
+    { status: 'M', paths: ['.github/workflows/changeset-check.yml'] },
+    { status: 'A', paths: ['scripts/check-changeset-protocol-scope.cjs'] },
+    { status: 'A', paths: ['tests/changeset-protocol-scope.test.cjs'] },
+  ]),
+  true,
+  'Deleting a changeset while maintaining the policy check can bypass changesets status'
+);
+
+assert.strictEqual(
+  isChangesetDeleteOnlyCleanup([
+    { status: 'D', paths: ['.changeset/old-app-fix.md'] },
+    { status: 'M', paths: ['server/src/billing/subscription-sync.ts'] },
+  ]),
+  false,
+  'App changes plus a deleted changeset still need normal changesets status'
+);
+
+console.log('Changeset protocol scope tests passed.');


### PR DESCRIPTION
## Summary
- remove the lingering app-only `.changeset/fix-p0-p1-triage.md` so membership/admin/profile/bearer-health fixes do not cut a protocol patch
- add a Changeset Check workflow guard that fails `adcontextprotocol` changesets unless the PR also touches protocol-scoped surfaces
- add focused tests for app-only changeset rejection, schema/docs allowance, empty changesets, and deleting a bad changeset

## Verification
- `node tests/changeset-protocol-scope.test.cjs`
- `node scripts/check-changeset-protocol-scope.cjs origin/main`
- `npx --yes @changesets/cli@^2.31.0 status --since=origin/main`
- precommit hook ran during commit: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run precommit:server-unit`, `npm run typecheck`

## Release safety
- no changeset is included
- this PR should not create a Version Packages PR or protocol release
