### PR TITLE
chore(changesets): remove Addie non-protocol version bump

### DIFF
--- a/.changeset/addie-docs-stream-fallbacks.md
+++ b/.changeset/addie-docs-stream-fallbacks.md
@@ -1,5 +1,0 @@
----
-"adcontextprotocol": patch
----
-
-Refresh Addie's docs search index on a scheduler and avoid duplicate Slack replies when stream finalization fails after text was already delivered.

--- a/.changeset/nice-paths-own.md
+++ b/.changeset/nice-paths-own.md
@@ -1,0 +1,4 @@
+---
+---
+
+Remove the accidental Addie-only patch changeset from #5615. The merged work had no protocol, schema, compliance, or published package impact.


### PR DESCRIPTION
## Summary

Removes the accidental patch changeset from #5615 and replaces it with an empty changeset.

#5615 changed Addie/server runtime behavior only. It did not touch protocol schemas, protocol docs, compliance artifacts, published tarball inputs, or package code that should drive a version bump.

## Validation

- Precommit hook passed:
  - `npm run test:unit`
  - `npm run test:test-dynamic-imports`
  - `npm run test:callapi-state-change`
  - `npm run precommit:server-unit`
  - `npm run typecheck`
- Pre-push hook passed:
  - `node scripts/verify-version-sync.cjs`
