### PR TITLE
fix(a11y): use semantic color tokens for dark mode on agent dashboard

### DIFF
--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -204,7 +204,7 @@
     .agent-verification-panel {
       margin-top: var(--space-3);
       padding: var(--space-3);
-      background: var(--color-success-50, #ecfdf5);
+      background: var(--color-success-bg);
       border: var(--border-1) solid var(--color-success-200, #a7f3d0);
       border-radius: var(--radius-md);
     }
@@ -220,7 +220,7 @@
       font-weight: var(--font-semibold);
       text-transform: uppercase;
       letter-spacing: 0.04em;
-      color: var(--color-success-700, #047857);
+      color: var(--color-success-fg);
       margin-bottom: var(--space-2);
     }
     .agent-verification-panel-empty .agent-verification-header {
@@ -314,7 +314,7 @@
     .verification-copy-btn.is-copied {
       background: var(--color-success-100, #d1fae5);
       border-color: var(--color-success-500, #10b981);
-      color: var(--color-success-700, #047857);
+      color: var(--color-success-fg);
     }
     .verification-eligibility-hint {
       margin-top: var(--space-2);
@@ -453,8 +453,8 @@
       color: var(--color-warning-700, #b45309);
     }
     .compliance-notice-severity--future_required {
-      background: #ffedd5;
-      color: #c2410c;
+      background: var(--color-warning-bg);
+      color: var(--color-warning-fg);
     }
     .compliance-notice-severity--unknown {
       background: var(--color-gray-100, #f3f4f6);
@@ -981,8 +981,8 @@
       font-size: var(--text-xs);
       margin-top: var(--space-2);
     }
-    .step-runner-result--pass { background: var(--color-success-50, #ecfdf5); border: 1px solid var(--color-success-200, #a7f3d0); }
-    .step-runner-result--fail { background: var(--color-error-50, #fef2f2); border: 1px solid var(--color-error-200, #fecaca); }
+    .step-runner-result--pass { background: var(--color-success-bg); border: 1px solid var(--color-success-200, #a7f3d0); }
+    .step-runner-result--fail { background: var(--color-error-bg); border: 1px solid var(--color-error-200, #fecaca); }
     .step-runner-result--skip { background: var(--color-gray-50, #f9fafb); border: 1px solid var(--color-gray-200, #e5e7eb); }
     .step-runner-actions { display: flex; gap: var(--space-2); margin-top: var(--space-2); }
     .step-runner-actions button {
@@ -3231,9 +3231,9 @@
         flash.className = 'agent-refresh-result';
         flash.style.cssText = 'font-size: var(--text-xs); margin-top: var(--space-2); padding: var(--space-2) var(--space-3); border-radius: 6px;';
         const palette = {
-          success: { bg: 'var(--color-success-50, #ecfdf5)', fg: 'var(--color-success-700, #047857)' },
-          warning: { bg: 'var(--color-warning-50, #fffbeb)', fg: 'var(--color-warning-700, #b45309)' },
-          error:   { bg: 'var(--color-error-50, #fef2f2)',   fg: 'var(--color-error-700, #b91c1c)' },
+          success: { bg: 'var(--color-success-bg)', fg: 'var(--color-success-fg)' },
+          warning: { bg: 'var(--color-warning-bg)', fg: 'var(--color-warning-fg)' },
+          error:   { bg: 'var(--color-error-bg)',   fg: 'var(--color-error-fg)' },
         }[severity] || { bg: 'var(--color-bg-subtle)', fg: 'var(--color-text-secondary)' };
         flash.style.background = palette.bg;
         flash.style.color = palette.fg;
@@ -3322,19 +3322,19 @@
         flash.style.cssText = 'font-size: var(--text-xs); margin-top: var(--space-2); padding: var(--space-2) var(--space-3); border-radius: 6px;';
 
         if (res.status === 200) {
-          flash.style.background = 'var(--color-success-50, #ecfdf5)';
-          flash.style.color = 'var(--color-success-700, #047857)';
+          flash.style.background = 'var(--color-success-bg)';
+          flash.style.color = 'var(--color-success-fg)';
           flash.textContent = 'Queued — compliance check will run on the next heartbeat cycle (within ~1 hour)';
           actionsRow.parentElement.appendChild(flash);
           setTimeout(() => flash.remove(), 10000);
         } else if (res.status === 429) {
-          flash.style.background = 'var(--color-warning-50, #fffbeb)';
-          flash.style.color = 'var(--color-warning-700, #b45309)';
+          flash.style.background = 'var(--color-warning-bg)';
+          flash.style.color = 'var(--color-warning-fg)';
           flash.textContent = `Rate limited — try again in ${data.retry_after || 60}s`;
           actionsRow.parentElement.appendChild(flash);
         } else {
-          flash.style.background = 'var(--color-error-50, #fef2f2)';
-          flash.style.color = 'var(--color-error-700, #b91c1c)';
+          flash.style.background = 'var(--color-error-bg)';
+          flash.style.color = 'var(--color-error-fg)';
           flash.textContent = data.error || `Requeue failed (HTTP ${res.status})`;
           actionsRow.parentElement.appendChild(flash);
         }
@@ -3342,7 +3342,7 @@
         if (actionsRow && actionsRow.parentElement) {
           const flash = document.createElement('div');
           flash.className = 'agent-refresh-result';
-          flash.style.cssText = 'font-size: var(--text-xs); margin-top: var(--space-2); padding: var(--space-2) var(--space-3); border-radius: 6px; background: var(--color-error-50, #fef2f2); color: var(--color-error-700, #b91c1c);';
+          flash.style.cssText = 'font-size: var(--text-xs); margin-top: var(--space-2); padding: var(--space-2) var(--space-3); border-radius: 6px; background: var(--color-error-bg); color: var(--color-error-fg);';
           flash.textContent = `Requeue failed: ${err?.message || err}`;
           actionsRow.parentElement.appendChild(flash);
         }


### PR DESCRIPTION
## Summary

Fixes the dark mode contrast issue on `/dashboard/agents` reported in #5260 (item 3).

The verification panel, compliance severity badges, step-runner results, and inline flash messages were using hardcoded light-mode hex values (`#ecfdf5`, `#047857`, `#ffedd5`, `#c2410c`) or raw palette stops (`--color-success-50`, `--color-success-700`) that don't respond to dark mode. This placed near-white text on light-green backgrounds in dark mode — a WCAG AA contrast failure.

**What changed:** Replaced all 17 affected call sites (CSS rules + inline JS styles) with the semantic `--color-{status}-bg` / `--color-{status}-fg` tokens from `design-system.css`, which already carry dark-mode overrides.

- No visual change in light mode
- Dark mode now gets proper contrast automatically
- No new tokens, components, or API changes — pure CSS variable substitution

## Files touched

- `server/public/dashboard-agents.html` — swapped hardcoded hex fallbacks to semantic tokens in both `<style>` rules and JS inline style assignments

## Test plan

- [ ] Open `/dashboard/agents` in light mode — verify verification panel, compliance badges, and flash messages look identical to before
- [ ] Switch to dark mode (OS preference or `data-theme="dark"`) — verify text is now readable against the panel backgrounds
- [ ] Trigger a compliance requeue to confirm JS-driven flash messages also use correct tokens

Closes #5260 (item 3)