### PR TITLE
chore(changesets): remove empty non-protocol changeset

### DIFF
--- a/.changeset/nice-paths-own.md
+++ b/.changeset/nice-paths-own.md
@@ -1,4 +1,0 @@
----
----
-
-Remove the accidental Addie-only patch changeset from #5615. The merged work had no protocol, schema, compliance, or published package impact.


### PR DESCRIPTION
## Summary
- remove the empty `.changeset/nice-paths-own.md` placeholder from #5619
- leaves no pending changeset for Addie/app-only work

## Verification
- `node scripts/check-changeset-protocol-scope.cjs origin/main`
- `node scripts/check-changeset-protocol-scope.cjs origin/main --is-delete-only-cleanup`

## Release safety
- delete-only changeset cleanup
- no package bump and no protocol release intended
