### PR TITLE
fix(changesets): skip status for non-protocol PRs

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -58,4 +58,8 @@ jobs:
             echo "Skipping changesets status for changeset policy maintenance."
             exit 0
           fi
+          if ! node scripts/check-changeset-protocol-scope.cjs origin/${{ github.base_ref }} --has-protocol-scoped-changes; then
+            echo "Skipping changesets status because this PR does not touch the protocol release surface."
+            exit 0
+          fi
           npx --yes @changesets/cli@^2.31.0 status --since=origin/${{ github.base_ref }}

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -14,15 +14,22 @@ case "$BRANCH_NAME" in
   *)
     CHANGESET_BASE="${ADCP_CHANGESET_BASE:-origin/main}"
     if git rev-parse --verify --quiet "$CHANGESET_BASE" >/dev/null; then
-      echo "🔍 Checking for changeset since $CHANGESET_BASE..."
-      if ! git diff --name-only --diff-filter=ACMR "$CHANGESET_BASE"...HEAD -- .changeset |
+      echo "🔍 Checking changeset policy since $CHANGESET_BASE..."
+      node scripts/check-changeset-protocol-scope.cjs "$CHANGESET_BASE" || exit 1
+
+      if node scripts/check-changeset-protocol-scope.cjs "$CHANGESET_BASE" --is-status-exempt-maintenance; then
+        echo "⏭  Changeset policy maintenance — skipping local changeset presence check"
+      elif ! node scripts/check-changeset-protocol-scope.cjs "$CHANGESET_BASE" --has-protocol-scoped-changes; then
+        echo "⏭  No protocol release-surface changes — skipping local changeset presence check"
+      elif ! git diff --name-only --diff-filter=ACMR "$CHANGESET_BASE"...HEAD -- .changeset |
         grep -Eq '^\.changeset/[^/]+\.md$'; then
-        echo "Missing changeset. Add one with 'npx changeset --empty' before pushing."
+        echo "Missing protocol changeset. Add one with 'npx changeset' before pushing."
         echo "Run the full CI-equivalent check with:"
         echo "  npx --yes @changesets/cli@^2.31.0 status --since=$CHANGESET_BASE"
         exit 1
+      else
+        echo "✅ Protocol changeset present"
       fi
-      echo "✅ Changeset present"
     else
       echo "⏭  $CHANGESET_BASE not found — skipping local changeset check"
     fi

--- a/scripts/check-changeset-protocol-scope.cjs
+++ b/scripts/check-changeset-protocol-scope.cjs
@@ -71,6 +71,10 @@ function isProtocolScopedPath(filePath) {
   return PROTOCOL_SCOPED_PATHS.some(pattern => pattern.test(normalized));
 }
 
+function hasProtocolScopedChanges(changes) {
+  return changes.some(change => (change.paths || []).some(isProtocolScopedPath));
+}
+
 function isChangesetDeleteOnlyCleanup(changes) {
   let deletedChangeset = false;
 
@@ -122,7 +126,7 @@ function changedPathForHead(change) {
 }
 
 function findChangesetProtocolScopeViolations(changes, readFileAtHead) {
-  const protocolChangesets = [];
+  const changesetFiles = [];
   const protocolScopedFiles = [];
 
   for (const change of changes) {
@@ -136,19 +140,21 @@ function findChangesetProtocolScopeViolations(changes, readFileAtHead) {
     if (!headPath || !isChangesetFile(headPath)) continue;
 
     const content = readFileAtHead(headPath);
-    if (changesetTargetsProtocol(content)) {
-      protocolChangesets.push(headPath);
-    }
+    changesetFiles.push({
+      filePath: headPath,
+      targetsProtocol: changesetTargetsProtocol(content),
+    });
   }
 
-  if (protocolChangesets.length === 0 || protocolScopedFiles.length > 0) {
+  if (changesetFiles.length === 0 || protocolScopedFiles.length > 0) {
     return [];
   }
 
-  return protocolChangesets.map(filePath => ({
-    filePath,
-    message:
-      'Protocol changesets are only allowed when the PR also changes protocol schemas, compliance assets, normative reference docs, release scripts, or versioned dist artifacts.',
+  return changesetFiles.map(changeset => ({
+    filePath: changeset.filePath,
+    message: changeset.targetsProtocol
+      ? 'Protocol changesets are only allowed when the PR also changes protocol schemas, compliance assets, normative reference docs, release scripts, or versioned dist artifacts.'
+      : 'Empty/non-package changesets are not allowed for non-protocol PRs. Remove the changeset file instead.',
   }));
 }
 
@@ -173,7 +179,7 @@ function formatViolationMessage(violations) {
     'Non-protocol changeset detected:',
     ...violations.map(v => `  - ${v.filePath}`),
     '',
-    'Do not add an adcontextprotocol changeset for app, site, billing, admin, or operational-only changes.',
+    'Do not add .changeset files for app, site, billing, admin, or operational-only changes.',
     violations[0]?.message,
   ]
     .filter(Boolean)
@@ -205,6 +211,16 @@ function run(argv = process.argv.slice(2)) {
     return 1;
   }
 
+  if (argv.includes('--has-protocol-scoped-changes')) {
+    const hasProtocol = hasProtocolScopedChanges(changes);
+    if (hasProtocol) {
+      console.log('Protocol-scoped changes detected.');
+      return 0;
+    }
+    console.log('No protocol-scoped changes detected.');
+    return 1;
+  }
+
   const violations = findChangesetProtocolScopeViolations(changes, readFileAtHead);
 
   if (violations.length > 0) {
@@ -224,6 +240,7 @@ module.exports = {
   changesetTargetsProtocol,
   findChangesetProtocolScopeViolations,
   formatViolationMessage,
+  hasProtocolScopedChanges,
   isChangesetDeleteOnlyCleanup,
   isChangesetStatusExemptMaintenance,
   isProtocolScopedPath,

--- a/tests/changeset-protocol-scope.test.cjs
+++ b/tests/changeset-protocol-scope.test.cjs
@@ -4,6 +4,7 @@ const assert = require('assert');
 const {
   changesetTargetsProtocol,
   findChangesetProtocolScopeViolations,
+  hasProtocolScopedChanges,
   isChangesetDeleteOnlyCleanup,
   isChangesetStatusExemptMaintenance,
   isProtocolScopedPath,
@@ -35,6 +36,16 @@ assert.strictEqual(isProtocolScopedPath('static/compliance/source/universal/secu
 assert.strictEqual(isProtocolScopedPath('docs/reference/versioning.mdx'), true);
 assert.strictEqual(isProtocolScopedPath('server/src/billing/subscription-sync.ts'), false);
 assert.strictEqual(isProtocolScopedPath('.changeset/billing-fix.md'), false);
+assert.strictEqual(
+  hasProtocolScopedChanges([{ status: 'M', paths: ['server/src/billing/subscription-sync.ts'] }]),
+  false,
+  'App-only changes do not require changesets status'
+);
+assert.strictEqual(
+  hasProtocolScopedChanges([{ status: 'M', paths: ['docs/reference/versioning.mdx'] }]),
+  true,
+  'Normative reference docs require changesets status'
+);
 
 assert.deepStrictEqual(
   parseNameStatus('M\tserver/src/billing/subscription-sync.ts\nA\t.changeset/billing-fix.md\n'),
@@ -69,7 +80,7 @@ violations = findChangesetProtocolScopeViolations(
   ],
   readFiles({ '.changeset/empty.md': emptyChangeset })
 );
-assert.deepStrictEqual(violations, [], 'Empty/non-package changesets are not treated as protocol releases');
+assert.strictEqual(violations.length, 1, 'App-only changes with an empty changeset must fail');
 
 violations = findChangesetProtocolScopeViolations(
   [{ status: 'D', paths: ['.changeset/old-app-fix.md'] }],


### PR DESCRIPTION
## Summary
- make the changeset scope guard fail any `.changeset/*.md` file on non-protocol-only diffs, including empty changesets
- skip Changesets status in CI when a PR does not touch the protocol release surface
- update the tracked pre-push hook to match CI and stop recommending `npx changeset --empty`

## Testing
- `node tests/changeset-protocol-scope.test.cjs`
- `node scripts/check-changeset-protocol-scope.cjs origin/main`
- `node scripts/check-changeset-protocol-scope.cjs origin/main --has-protocol-scoped-changes` (expected non-zero: no protocol-scoped changes)
- `ADCP_CHANGESET_BASE=origin/main .husky/pre-push`
- `git diff --check`
- precommit hook passed: unit subset, dynamic import lint, callapi state-change lint, server-unit precommit, and typecheck

No changeset by design: this is changeset policy/tooling, not a protocol package change.