### PR TITLE
docs(si): apply residual prose cleanups missed in #5591 SI storyboard bundle

### DIFF
--- a/.changeset/si-storyboard-prose-cleanup.md
+++ b/.changeset/si-storyboard-prose-cleanup.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Apply residual prose cleanups to the `sponsored_context_accountability` storyboard: the `prerequisites.description` second paragraph and the `si_send_message_presentation_accepted` step narrative both still implied dynamic host-echo / different-identity substitution, contradicting the fixed Acme literal fixture the storyboard actually uses. Reword both spots to scope the prose to the static Acme fixture per @bokelley's #5551 review (2026-06-17 13:15 UTC).

--- a/static/compliance/source/protocols/sponsored-intelligence/sponsored-context-accountability.yaml
+++ b/static/compliance/source/protocols/sponsored-intelligence/sponsored-context-accountability.yaml
@@ -60,10 +60,12 @@ prerequisites:
     not echoes of the agent's own prior emission. The assertions test receipt acceptance and
     rejection semantics, not principal-matching against the agent's own declaration.
 
-    The acme-outdoor test kit is a natural fixture — it matches the catalog the reference
-    implementation (bragent) ships and is already used by other SI scenarios. A conformant
-    brand agent that prefers a different identity may substitute its own kit; the assertions
-    below are configuration-independent.
+    The acme-outdoor test kit is the fixture this storyboard is scoped to — it matches the
+    catalog the reference implementation (bragent) ships and is already used by other SI
+    scenarios. The receipt literals above are fixed to the Acme identity
+    (`acmeoutdoor.example` / "Acme Outdoor"), so this is not configuration-independent: a
+    brand agent under a different identity would need the receipt literals updated to match,
+    or the receipt's principal no longer corresponds to the agent's own declaration.
   test_kit: "test-kits/acme-outdoor.yaml"
 
 phases:
@@ -149,10 +151,10 @@ phases:
       - id: si_send_message_presentation_accepted
         title: "si_send_message with a matching accepted receipt"
         narrative: |
-          The host echoes the brand's sponsored_context back inside a receipt whose
-          `accepted_context_use` matches the declared value. A conformant brand agent accepts
-          the receipt, persists it for audit, and emits a fresh sponsored_context on the
-          response.
+          The receipt is a fixed Acme literal whose `accepted_context_use` matches the value
+          declared in the prior turn — it is not an echo of the agent's own emission. A
+          conformant brand agent accepts the receipt, persists it for audit, and emits a
+          fresh sponsored_context on the response.
         task: si_send_message
         schema_ref: "sponsored-intelligence/si-send-message-request.json"
         response_schema_ref: "sponsored-intelligence/si-send-message-response.json"


### PR DESCRIPTION
## Summary

Apply the two residual prose cleanups @bokelley requested in #5551 round 2 (comments [2026-06-17T13:15:45Z](https://github.com/adcontextprotocol/adcp/pull/5551#issuecomment-4730597418) and [2026-06-17T13:20:40Z](https://github.com/adcontextprotocol/adcp/pull/5551#issuecomment-4730660230) — exact-replacements diffs) that did not make it into the #5591 bundle which superseded #5551 for the 3.1 GA cut.

Both spots in `sponsored-context-accountability.yaml` still imply dynamic host-echo / configuration-independent substitution, which contradicts the fixed Acme literal fixture the storyboard actually exercises:

- `si_send_message_presentation_accepted` narrative — "host echoes the brand's sponsored_context back" rewritten as "the receipt is a fixed Acme literal whose `accepted_context_use` matches the value declared in the prior turn — it is not an echo of the agent's own emission".
- `prerequisites.description` second paragraph — "may substitute its own kit; assertions below are configuration-independent" rewritten to state the storyboard is scoped to the Acme identity (`acmeoutdoor.example` / "Acme Outdoor") and identity changes require updating the receipt literals.

Both edits are verbatim from @bokelley's exact-replacements comment.

## Validation

Local lint suite (all green):

- `npm run test:storyboard-sample-request-schema`
- `npm run test:storyboard-check-enum`
- `npm run test:storyboard-validations-paths`
- `npm run test:storyboard-scoping`

Pre-push storyboard matrix (all tenants meet floors):

- /signals: 65 clean, 99 steps
- /sales: 65 clean, 307 steps
- /governance: 65 clean, 156 steps
- /creative: 65 clean, 147 steps
- /creative-builder: 65 clean, 131 steps
- /brand: 65 clean, 84 steps

## Refs

- #5551 (closed, superseded) — original storyboard PR
- #5591 — bundling PR that shipped the storyboard with stale prose
- @bokelley's review comment with the exact diffs applied here