### PR TITLE
fix(compliance): treat applicability skips as neutral

### DIFF
--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -431,12 +431,31 @@ function isExplicitRequiresToolMissingSkip(step: {
   return detail?.startsWith('Required tool "') === true && detail.includes('" not advertised');
 }
 
+function isRunnerApplicabilitySkip(step: {
+  skip_reason?: string;
+  step_id?: unknown;
+  requirement?: unknown;
+}, scenario?: unknown): boolean {
+  switch (step.skip_reason) {
+    case 'capability_unsupported':
+      return true;
+    case 'missing_test_kit_contract':
+      return scenario === 'idempotency/rate_limit_replay_invariant' &&
+        firstString(step.step_id) === 'expect_rate_limit_not_replayed';
+    case 'requirement_unmet':
+      return firstString(step.requirement) === 'webhook_receiver';
+    default:
+      return false;
+  }
+}
+
 function skipReasonIsCoverageGap(
   reason: string | undefined,
   step?: {
     skip_reason?: string;
     step?: unknown;
     step_id?: unknown;
+    requirement?: unknown;
     details?: unknown;
     error?: unknown;
     warnings?: unknown;
@@ -446,6 +465,7 @@ function skipReasonIsCoverageGap(
 ): boolean {
   if (step && isSyntheticRequiredToolsMissingSkip(step, scenario)) return false;
   if (step && isExplicitRequiresToolMissingSkip(step)) return false;
+  if (step && isRunnerApplicabilitySkip(step, scenario)) return false;
   switch (reason) {
     case 'not_applicable':
     case 'peer_branch_taken':
@@ -579,6 +599,7 @@ export function deriveStoryboardStatuses(
       details?: unknown;
       error?: unknown;
       warnings?: unknown;
+      requirement?: unknown;
       skip?: { detail?: unknown };
     },
     scenario: string,
@@ -590,6 +611,7 @@ export function deriveStoryboardStatuses(
     // out of scope for this agent, not that a claimed production step failed.
     if (isSyntheticRequiredToolsMissingSkip(step, scenario)) return true;
     if (isExplicitRequiresToolMissingSkip(step)) return true;
+    if (isRunnerApplicabilitySkip(step, scenario)) return true;
 
     return false;
   };

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -7109,14 +7109,33 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           steps_total: 0,
         };
         const serializedStoryboardStatus = serializeStoryboardRunStatus(storyboardStatus);
-        const isControllerCoverageGapScenario = (scenario: { steps?: any[] }): boolean => {
+        const isRunnerApplicabilitySkip = (scenarioId: string, step: {
+          skip_reason?: string;
+          step_id?: unknown;
+          requirement?: unknown;
+        }): boolean => {
+          switch (step.skip_reason) {
+            case 'capability_unsupported':
+              return true;
+            case 'missing_test_kit_contract':
+              return scenarioId === 'idempotency/rate_limit_replay_invariant' &&
+                step.step_id === 'expect_rate_limit_not_replayed';
+            case 'requirement_unmet':
+              return step.requirement === 'webhook_receiver';
+            default:
+              return false;
+          }
+        };
+        const isControllerCoverageGapScenario = (scenario: { scenario?: unknown; steps?: any[] }): boolean => {
           const steps = Array.isArray(scenario.steps) ? scenario.steps : [];
+          const scenarioId = typeof scenario.scenario === 'string' ? scenario.scenario : '';
           return steps.length > 0 && steps.every((step) => {
             if (!step?.skipped) return false;
             return step.skip_reason === 'peer_branch_taken' ||
               step.skip_reason === 'peer_substituted' ||
               step.skip_reason === 'missing_test_controller' ||
-              (step.skip_reason === 'requirement_unmet' && step.requirement === 'controller');
+              (step.skip_reason === 'requirement_unmet' && step.requirement === 'controller') ||
+              isRunnerApplicabilitySkip(scenarioId, step);
           });
         };
         const uiDiagnostics = (dbInput.step_diagnostics ?? []).map((diagnostic) => ({

--- a/tests/addie/compliance-testing.test.ts
+++ b/tests/addie/compliance-testing.test.ts
@@ -96,6 +96,141 @@ describe('compliance result adapter', () => {
     });
   });
 
+  it('does not count runner applicability skips against storyboard pass totals', () => {
+    const result = baseResult({
+      tracks: [
+        {
+          track: 'core',
+          label: 'Core',
+          status: 'pass',
+          duration_ms: 1,
+          scenarios: [
+            {
+              scenario: 'webhook_emission/requirement_unmet',
+              overall_passed: true,
+              steps: [
+                {
+                  step: "Storyboard skipped: requires 'webhook_receiver'",
+                  step_id: 'requirement_unmet:webhook_receiver',
+                  task: '',
+                  skipped: true,
+                  skip_reason: 'requirement_unmet',
+                  requirement: 'webhook_receiver',
+                  passed: true,
+                },
+              ],
+            },
+            {
+              scenario: 'idempotency/rate_limit_replay_invariant',
+              overall_passed: true,
+              steps: [
+                {
+                  step: 'Trip the limiter, replay the key after retry_after, assert the cached response is not RATE_LIMITED',
+                  step_id: 'expect_rate_limit_not_replayed',
+                  task: 'expect_rate_limit_not_replayed',
+                  skipped: true,
+                  skip_reason: 'missing_test_kit_contract',
+                  passed: true,
+                },
+              ],
+            },
+            {
+              scenario: 'media_buy_state_machine/capability_unsupported',
+              overall_passed: true,
+              steps: [
+                {
+                  step: 'Storyboard skipped: capability not supported by this agent',
+                  step_id: 'capability_unsupported',
+                  task: '',
+                  skipped: true,
+                  skip_reason: 'capability_unsupported',
+                  passed: true,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(deriveStoryboardStatuses(result)).toEqual([
+      {
+        storyboard_id: 'webhook_emission',
+        status: 'untested',
+        steps_passed: 0,
+        steps_total: 0,
+      },
+      {
+        storyboard_id: 'idempotency',
+        status: 'untested',
+        steps_passed: 0,
+        steps_total: 0,
+      },
+      {
+        storyboard_id: 'media_buy_state_machine',
+        status: 'untested',
+        steps_passed: 0,
+        steps_total: 0,
+      },
+    ]);
+
+    const dbInput = complianceResultToDbInput(result, 'https://agent.example/mcp', 'production');
+    expect(dbInput.tracks_json[0]).toMatchObject({
+      track: 'core',
+      has_coverage_gap_skip: false,
+    });
+  });
+
+  it('keeps non-idempotency missing runner contracts visible as coverage gaps', () => {
+    const result = baseResult({
+      tracks: [
+        {
+          track: 'core',
+          label: 'Core',
+          status: 'partial',
+          duration_ms: 1,
+          scenarios: [
+            {
+              scenario: 'signed_requests/stateful_nonce_replay',
+              overall_passed: true,
+              steps: [
+                {
+                  step: 'Reject replayed nonce',
+                  step_id: 'reject_replayed_nonce',
+                  task: 'request_signing_probe',
+                  skipped: true,
+                  skip_reason: 'missing_test_kit_contract',
+                  passed: true,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(deriveStoryboardStatuses(result)).toEqual([
+      {
+        storyboard_id: 'signed_requests',
+        status: 'failing',
+        steps_passed: 0,
+        steps_total: 1,
+        failure_count: 1,
+        skipped_count: 0,
+        first_failed_step_id: 'reject_replayed_nonce',
+        first_failed_step_title: 'Reject replayed nonce',
+        first_failed_step_task: 'request_signing_probe',
+        first_failure_message: 'missing_test_kit_contract',
+      },
+    ]);
+
+    const dbInput = complianceResultToDbInput(result, 'https://agent.example/mcp', 'production');
+    expect(dbInput.tracks_json[0]).toMatchObject({
+      track: 'core',
+      has_coverage_gap_skip: true,
+    });
+  });
+
   it('preserves billing-gate validation path, expected value, and actual value in diagnostics', () => {
     const result = baseResult({
       overall_status: 'failing',


### PR DESCRIPTION
## Summary

- Treat runner applicability skips as neutral in compliance status derivation and persisted dashboard coverage counts.
- Keep missing test-kit contracts visible except for the idempotency rate-limit replay runner contract.
- Add regressions for neutral applicability skips and non-idempotency coverage-gap skips.

## Why

Some seller runs were showing yellow/red compliance rows for scenarios the runner skipped because they were not applicable to that agent or local runner setup, including missing webhook receiver support, unsupported optional capabilities, and the idempotency rate-limit replay helper.

## Validation

- `npx vitest run tests/addie/compliance-testing.test.ts server/tests/unit/derive-storyboard-statuses.test.ts server/tests/unit/compliance-testing-effective-run-status.test.ts`
- `npm run test:storyboard-scoping`
- `npm run test:compliance-source-authority`
- `npm run build:compliance`
- `npm run typecheck`
- `git diff --check`
- `npx vitest run server/tests/unit/storyboards.test.ts tests/addie/compliance-testing.test.ts`

## Notes

Pre-commit was attempted and failed in the unrelated full server-unit sweep with timeout-only failures in unrelated tests. The failed files were rerun directly; three passed and two still timed out unrelated to this compliance change:

- `server/tests/unit/admin-stripe-customer-link.test.ts`
- `server/tests/unit/crawler-single-domain-profile-rebuild.test.ts`
