### PR TITLE
fix(compliance): enable AdCP 3.1 heartbeat grading

### DIFF
--- a/server/src/addie/jobs/compliance-heartbeat.ts
+++ b/server/src/addie/jobs/compliance-heartbeat.ts
@@ -159,6 +159,7 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
             declaredSpecialisms,
             runId: run.id,
             adcpVersions: badgeEligibleAdcpVersions,
+            supportedVersions: complianceResult.agent_profile?.adcp_supported_versions ?? runTargetSelection.supportedVersions,
           });
 
           if (badgeResult.issued.length > 0 || badgeResult.revoked.length > 0) {

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -148,7 +148,7 @@ function targetFromInput(input: Record<string, unknown>): ReturnType<typeof host
       ? hostedComplianceTarget(requested.trim())
       : complianceTarget;
   } catch {
-    throw new ToolError('Invalid compliance_target. Use 3.0, 3.1-rc, 3.1-beta, or an exact bundled version.');
+    throw new ToolError('Invalid compliance_target. Use 3.1, 3.0, 3.1-rc, 3.1-beta, or an exact bundled version.');
   }
 }
 
@@ -1742,7 +1742,7 @@ export const MEMBER_TOOLS: AddieTool[] = [
       properties: {
         agent_url: { type: 'string', description: 'Agent URL to evaluate' },
         tracks: { type: 'array', items: { type: 'string', enum: ['core', 'products', 'media_buy', 'creative', 'reporting', 'governance', 'signals', 'si', 'audiences'] }, description: 'Specific compliance tracks to run (default: all applicable, driven by the agent\'s get_adcp_capabilities response)' },
-        compliance_target: { type: 'string', description: 'Compliance target to run, e.g. "3.0" for a badge-eligible stable line or "3.1-rc"/"3.1-beta" for explicit prerelease diagnostics. Defaults to the canonical badge-eligible target when advertised.' },
+        compliance_target: { type: 'string', description: 'Compliance target to run, e.g. "3.1" or "3.0" for badge-eligible stable lines, or "3.1-rc"/"3.1-beta" for explicit prerelease diagnostics. Defaults to the canonical badge-eligible target when advertised.' },
       },
       required: ['agent_url'],
     },
@@ -1849,7 +1849,7 @@ export const MEMBER_TOOLS: AddieTool[] = [
       type: 'object',
       properties: {
         agent_url: { type: 'string', description: 'Agent URL to discover and recommend storyboards for' },
-        compliance_target: { type: 'string', description: 'Compliance target to inspect, e.g. "3.0", "3.1-rc", or "3.1-beta". Defaults to the canonical badge-eligible target when advertised. Explicit non-3.0 targets only run when the agent advertises support.' },
+        compliance_target: { type: 'string', description: 'Compliance target to inspect, e.g. "3.1", "3.0", "3.1-rc", or "3.1-beta". Defaults to the canonical badge-eligible target when advertised. Explicit targets only run when the agent advertises support.' },
       },
       required: ['agent_url'],
     },
@@ -1863,7 +1863,7 @@ export const MEMBER_TOOLS: AddieTool[] = [
       type: 'object',
       properties: {
         storyboard_id: { type: 'string', description: 'Storyboard ID (from recommend_storyboards)' },
-        compliance_target: { type: 'string', description: 'Compliance target to inspect, e.g. "3.0", "3.1-rc", or "3.1-beta". Defaults to 3.0.' },
+        compliance_target: { type: 'string', description: 'Compliance target to inspect, e.g. "3.1", "3.0", "3.1-rc", or "3.1-beta". Defaults to 3.0.' },
       },
       required: ['storyboard_id'],
     },
@@ -1879,7 +1879,7 @@ export const MEMBER_TOOLS: AddieTool[] = [
         agent_url: { type: 'string', description: 'Agent URL to test' },
         storyboard_id: { type: 'string', description: 'Storyboard ID to run' },
         dry_run: { type: 'boolean', description: 'If true (default), use test data that won\'t affect production state', default: true },
-        compliance_target: { type: 'string', description: 'Compliance target to run, e.g. "3.0", "3.1-rc", or "3.1-beta". Defaults to the canonical badge-eligible target when advertised. Explicit non-3.0 targets are diagnostic-only and only run when the agent advertises support.' },
+        compliance_target: { type: 'string', description: 'Compliance target to run, e.g. "3.1", "3.0", "3.1-rc", or "3.1-beta". Defaults to the canonical badge-eligible target when advertised. Explicit prerelease targets are diagnostic-only and only run when the agent advertises support.' },
       },
       required: ['agent_url', 'storyboard_id'],
     },
@@ -1905,7 +1905,7 @@ export const MEMBER_TOOLS: AddieTool[] = [
           additionalProperties: false,
         },
         dry_run: { type: 'boolean', description: 'If true (default), use test data', default: true },
-        compliance_target: { type: 'string', description: 'Compliance target to run, e.g. "3.0", "3.1-rc", or "3.1-beta". Defaults to the canonical badge-eligible target when advertised. Explicit non-3.0 targets are diagnostic-only and only run when the agent advertises support.' },
+        compliance_target: { type: 'string', description: 'Compliance target to run, e.g. "3.1", "3.0", "3.1-rc", or "3.1-beta". Defaults to the canonical badge-eligible target when advertised. Explicit prerelease targets are diagnostic-only and only run when the agent advertises support.' },
       },
       required: ['agent_url', 'storyboard_id', 'step_id'],
     },
@@ -4495,6 +4495,7 @@ export function createMemberToolHandlers(
                     declaredSpecialisms,
                     runId: tracks ? null : run.id,
                     adcpVersions: badgeEligibleAdcpVersions,
+                    supportedVersions: result.agent_profile?.adcp_supported_versions ?? runTargetSelection.supportedVersions,
                   });
                 } catch (badgeError) {
                   logger.warn({ badgeError, agentUrl: resolved.resolvedUrl }, 'Badge fan-out failed after owner_test run');

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -321,7 +321,7 @@ const badgeEligibilityMetadata = (eligibleVersions: readonly string[]) => ({
   badge_eligible_adcp_versions: [...eligibleVersions],
 });
 const INVALID_COMPLIANCE_TARGET_MESSAGE =
-  "Invalid compliance_target. Use 3.0, 3.1-rc, 3.1-beta, or an exact bundled version.";
+  "Invalid compliance_target. Use 3.1, 3.0, 3.1-rc, 3.1-beta, or an exact bundled version.";
 
 class InvalidComplianceTargetError extends Error {}
 
@@ -2866,7 +2866,7 @@ registry.registerPath({
               ran: z.boolean().openapi({ description: "True if the full storyboard suite ran and agent_storyboard_status was updated. False when ownership couldn't be resolved, the agent reported auth_required, or the compliance call itself failed." }),
               run_id: z.string().optional().openapi({ description: "Compliance run id written by this refresh. Use with /compliance/diagnostics?run_id=... to inspect failing-step wire evidence." }),
               test_session_id: z.string().optional().openapi({ description: "Fresh test session id used for the compliance run. Useful when matching seller-side logs to the refresh." }),
-              requested_compliance_target: z.string().optional().openapi({ description: "Requested compliance target before alias resolution, e.g. 3.0, 3.1-rc, or 3.1-beta. Present when `ran` is true." }),
+              requested_compliance_target: z.string().optional().openapi({ description: "Requested compliance target before alias resolution, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta. Present when `ran` is true." }),
               adcp_version: z.string().optional().openapi({ description: "Concrete AdCP compliance bundle version used for the run, e.g. 3.0.12 or 3.1.0-beta.7. Present when `ran` is true." }),
               badge_eligible: z.boolean().optional().openapi({ description: "True when this run can update public badge state." }),
               badge_eligible_adcp_versions: z.array(z.string()).optional().openapi({ description: "Public badge versions this run can issue, e.g. ['3.0']." }),
@@ -3163,7 +3163,7 @@ registry.registerPath({
   request: {
     query: z.object({
       category: z.string().optional().openapi({ description: "Filter by storyboard category" }),
-      compliance_target: z.string().optional().openapi({ description: "Compliance target to inspect, e.g. 3.0, 3.1-rc, or 3.1-beta" }),
+      compliance_target: z.string().optional().openapi({ description: "Compliance target to inspect, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta" }),
     }),
   },
   responses: {
@@ -3197,7 +3197,7 @@ registry.registerPath({
       id: z.string().openapi({ description: "Storyboard ID" }),
     }),
     query: z.object({
-      compliance_target: z.string().optional().openapi({ description: "Compliance target to inspect, e.g. 3.0, 3.1-rc, or 3.1-beta" }),
+      compliance_target: z.string().optional().openapi({ description: "Compliance target to inspect, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta" }),
     }),
   },
   responses: {
@@ -3455,7 +3455,7 @@ registry.registerPath({
       storyboardId: z.string(),
     }),
     query: z.object({
-      compliance_target: z.string().optional().openapi({ description: "Compliance target to inspect, e.g. 3.0, 3.1-rc, or 3.1-beta" }),
+      compliance_target: z.string().optional().openapi({ description: "Compliance target to inspect, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta" }),
     }),
   },
   responses: {
@@ -6234,6 +6234,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
                   declaredSpecialisms,
                   runId: run.id,
                   adcpVersions: runBadgeEligibleVersions,
+                  supportedVersions: complyResult.agent_profile?.adcp_supported_versions ?? runTargetSelection.supportedVersions,
                 });
               } catch (badgeError) {
                 logger.warn({ err: badgeError, agentUrl }, 'Badge fan-out failed after manual refresh');
@@ -7086,6 +7087,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
               agentUrl,
               declaredSpecialisms,
               adcpVersions: runBadgeEligibleVersions,
+              supportedVersions: complyResult.agent_profile?.adcp_supported_versions ?? runTargetSelection.supportedVersions,
             });
           } catch (badgeError) {
             logger.warn({ err: badgeError, agentUrl }, 'Badge fan-out failed after storyboard-run');

--- a/server/src/services/adcp-taxonomy.ts
+++ b/server/src/services/adcp-taxonomy.ts
@@ -40,7 +40,7 @@ export function isVerificationMode(value: unknown): value is VerificationMode {
  * Order matters for display and filtering where callers show all badge
  * versions: newest first.
  */
-export const SUPPORTED_BADGE_VERSIONS = ['3.0'] as const;
+export const SUPPORTED_BADGE_VERSIONS = ['3.1', '3.0'] as const;
 export type SupportedBadgeVersion = typeof SUPPORTED_BADGE_VERSIONS[number];
 
 export function isSupportedBadgeVersion(value: unknown): value is SupportedBadgeVersion {

--- a/server/src/services/badge-issuance.ts
+++ b/server/src/services/badge-issuance.ts
@@ -214,8 +214,10 @@ export async function runBadgeFanOut(params: {
   runId?: string | null;
   /** Public AdCP badge versions this compliance run is authoritative for. */
   adcpVersions?: readonly string[];
+  /** Current get_adcp_capabilities.adcp.supported_versions snapshot for revoking unsupported public badges. */
+  supportedVersions?: readonly string[];
 }): Promise<BadgeIssuanceResult> {
-  const { complianceDb, agentUrl, declaredSpecialisms, runId } = params;
+  const { complianceDb, agentUrl, declaredSpecialisms, runId, supportedVersions } = params;
   const adcpVersions = (params.adcpVersions === undefined ? [DEFAULT_BADGE_ADCP_VERSION] : params.adcpVersions)
     .filter((version): version is string => typeof version === 'string' && version.length > 0);
   const aggregate: BadgeIssuanceResult = { issued: [], revoked: [], degraded: [], unchanged: [] };
@@ -280,13 +282,22 @@ export async function runBadgeFanOut(params: {
   const supportedBadgeVersions = new Set<string>(SUPPORTED_BADGE_VERSIONS);
   const existingBadges = await complianceDb.getBadgesForAgent(agentUrl);
   for (const badge of existingBadges) {
-    if (supportedBadgeVersions.has(badge.adcp_version)) continue;
-    const reason = `AdCP ${badge.adcp_version} public badge issuance is not currently enabled`;
+    let reason: string | undefined;
+    if (!supportedBadgeVersions.has(badge.adcp_version)) {
+      reason = `AdCP ${badge.adcp_version} public badge issuance is not currently enabled`;
+    } else if (
+      supportedVersions?.length &&
+      !advertisesPublicBadgeVersion(supportedVersions, badge.adcp_version)
+    ) {
+      reason = `Agent no longer advertises AdCP ${badge.adcp_version} support`;
+    }
+    if (!reason) continue;
+
     await complianceDb.revokeBadge(agentUrl, badge.role, badge.adcp_version, reason);
     aggregate.revoked.push({ role: badge.role, reason, adcp_version: badge.adcp_version });
     logger.info(
       { agentUrl, role: badge.role, adcpVersion: badge.adcp_version },
-      'Badge revoked — version no longer publicly badge-eligible',
+      'Badge revoked — version is no longer supported by the public badge policy or agent capabilities',
     );
   }
 

--- a/server/src/services/hosted-compliance-version.ts
+++ b/server/src/services/hosted-compliance-version.ts
@@ -345,10 +345,18 @@ export function selectCanonicalHostedComplianceTargetForSupportedVersions(
 ): HostedComplianceTarget {
   if (!supportedVersions?.length) return fallback;
 
-  const stableTarget = hostedComplianceTarget(DEFAULT_HOSTED_COMPLIANCE_LINE);
-  const hostedStableLineAlias = hostedStableLineAliasForVersion(stableTarget, stableTarget.version);
-  if (isComplianceVersionSupported(stableTarget.version, supportedVersions, { hostedStableLineAlias })) {
-    return stableTarget;
+  for (const line of SUPPORTED_BADGE_VERSIONS) {
+    try {
+      const stableTarget = hostedComplianceTarget(line);
+      const hostedStableLineAlias = hostedStableLineAliasForVersion(stableTarget, stableTarget.version);
+      if (isComplianceVersionSupported(stableTarget.version, supportedVersions, { hostedStableLineAlias })) {
+        return stableTarget;
+      }
+    } catch {
+      // A badge line may be configured before its compliance artifacts are
+      // present on a release branch. Skip it and keep looking for a usable
+      // public target.
+    }
   }
 
   return selectHostedComplianceTargetForSupportedVersions(supportedVersions, fallback);

--- a/server/tests/unit/adcp-taxonomy.test.ts
+++ b/server/tests/unit/adcp-taxonomy.test.ts
@@ -53,8 +53,8 @@ describe('specialism status', () => {
 });
 
 describe('SUPPORTED_BADGE_VERSIONS', () => {
-  it('keeps public badge issuance on 3.0 until 3.1 is GA-ready', () => {
-    expect(SUPPORTED_BADGE_VERSIONS).toEqual(['3.0']);
+  it('enables public badge issuance on 3.1 before 3.0', () => {
+    expect(SUPPORTED_BADGE_VERSIONS).toEqual(['3.1', '3.0']);
   });
 
   it('is a non-empty array of MAJOR.MINOR strings', () => {

--- a/server/tests/unit/badge-fan-out.test.ts
+++ b/server/tests/unit/badge-fan-out.test.ts
@@ -176,7 +176,7 @@ describe('runBadgeFanOut', () => {
     queryMock.mockResolvedValueOnce({ rows: [{ workos_organization_id: 'org_member' }], rowCount: 1, command: 'SELECT', oid: 0, fields: [] } as never);
 
     const db = makeDb({
-      existingBadges: [badge('media-buy', 'active', '3.1')],
+      existingBadges: [badge('media-buy', 'active', '4.0')],
       latestStatuses: [status('sales_broadcast_tv', 'passing')],
     });
 
@@ -190,7 +190,38 @@ describe('runBadgeFanOut', () => {
     expect(result.revoked).toEqual([
       {
         role: 'media-buy',
-        reason: 'AdCP 3.1 public badge issuance is not currently enabled',
+        reason: 'AdCP 4.0 public badge issuance is not currently enabled',
+        adcp_version: '4.0',
+      },
+    ]);
+    expect(db.revokeBadge).toHaveBeenCalledWith(
+      'https://example.com/mcp',
+      'media-buy',
+      '4.0',
+      'AdCP 4.0 public badge issuance is not currently enabled',
+    );
+  });
+
+  it('revokes previously issued public badges for versions the agent no longer advertises', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ workos_organization_id: 'org_member' }], rowCount: 1, command: 'SELECT', oid: 0, fields: [] } as never);
+
+    const db = makeDb({
+      existingBadges: [badge('media-buy', 'active', '3.1')],
+      latestStatuses: [status('sales_broadcast_tv', 'passing')],
+    });
+
+    const result = await runBadgeFanOut({
+      complianceDb: db,
+      agentUrl: 'https://example.com/mcp',
+      declaredSpecialisms: ['sales-broadcast-tv'],
+      adcpVersions: ['3.0'],
+      supportedVersions: ['3.0'],
+    });
+
+    expect(result.revoked).toEqual([
+      {
+        role: 'media-buy',
+        reason: 'Agent no longer advertises AdCP 3.1 support',
         adcp_version: '3.1',
       },
     ]);
@@ -198,7 +229,7 @@ describe('runBadgeFanOut', () => {
       'https://example.com/mcp',
       'media-buy',
       '3.1',
-      'AdCP 3.1 public badge issuance is not currently enabled',
+      'Agent no longer advertises AdCP 3.1 support',
     );
   });
 

--- a/server/tests/unit/compliance-heartbeat.test.ts
+++ b/server/tests/unit/compliance-heartbeat.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   recordComplianceRun: vi.fn(),
   query: vi.fn(),
   comply: vi.fn(),
+  complianceResultToDbInput: vi.fn(),
   classifyCapabilityResolutionError: vi.fn(),
   presentCapabilityResolutionError: vi.fn(),
   badgeEligibleVersionsForTargetSelection: vi.fn(),
@@ -33,7 +34,7 @@ vi.mock('../../src/db/client.js', () => ({
 
 vi.mock('../../src/addie/services/compliance-testing.js', () => ({
   comply: mocks.comply,
-  complianceResultToDbInput: vi.fn(),
+  complianceResultToDbInput: mocks.complianceResultToDbInput,
   classifyCapabilityResolutionError: mocks.classifyCapabilityResolutionError,
   presentCapabilityResolutionError: mocks.presentCapabilityResolutionError,
   badgeEligibleVersionsForTargetSelection: mocks.badgeEligibleVersionsForTargetSelection,
@@ -68,7 +69,7 @@ vi.mock('../../src/addie/error-notifier.js', () => ({
 }));
 
 describe('runComplianceHeartbeatJob', () => {
-  const target = { requested: '3.1.0-rc.6', version: '3.1.0-rc.6' };
+  const target = { requested: '3.1', version: '3.1.0' };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -82,7 +83,58 @@ describe('runComplianceHeartbeatJob', () => {
     mocks.selectComplianceTargetForAgentSelection.mockResolvedValue({ target, confirmed: false });
     mocks.classifyCapabilityResolutionError.mockReturnValue(null);
     mocks.badgeEligibleVersionsForTargetSelection.mockReturnValue([]);
+    mocks.complianceResultToDbInput.mockReturnValue({
+      agent_url: 'https://agent.example.com/mcp',
+      lifecycle_stage: 'testing',
+      overall_status: 'passing',
+      headline: 'All good',
+      tracks_json: [],
+      storyboard_statuses: [],
+      dry_run: true,
+    });
     mocks.recordComplianceRun.mockResolvedValue({});
+  });
+
+  it('runs heartbeat against the selected canonical target and passes supported versions to badge fan-out', async () => {
+    const complianceResult = {
+      overall_status: 'passing',
+      summary: { headline: 'All good' },
+      agent_profile: {
+        specialisms: ['sales-broadcast-tv'],
+        adcp_supported_versions: ['3.0', '3.1'],
+      },
+    };
+    mocks.comply.mockResolvedValueOnce(complianceResult);
+    mocks.badgeEligibleVersionsForTargetSelection.mockReturnValue(['3.1']);
+    mocks.recordComplianceRun.mockResolvedValueOnce({
+      run: { id: 'run-31' },
+      statusTransition: null,
+      storyboardStatuses: [],
+    });
+    mocks.runBadgeFanOut.mockResolvedValueOnce({ issued: [], revoked: [], degraded: [], unchanged: [] });
+
+    const { runComplianceHeartbeatJob } = await import('../../src/addie/jobs/compliance-heartbeat.js');
+    const result = await runComplianceHeartbeatJob({ limit: 1 });
+
+    expect(result).toEqual({ checked: 1, passed: 1, failed: 0, skipped: 0 });
+    expect(mocks.selectComplianceTargetForAgentSelection).toHaveBeenCalledWith(
+      'https://agent.example.com/mcp',
+      expect.objectContaining({ timeout_ms: 600_000 }),
+      target,
+      'canonical',
+    );
+    expect(mocks.comply).toHaveBeenCalledWith(
+      'https://agent.example.com/mcp',
+      expect.objectContaining({ timeout_ms: 600_000 }),
+      target,
+    );
+    expect(mocks.runBadgeFanOut).toHaveBeenCalledWith(expect.objectContaining({
+      agentUrl: 'https://agent.example.com/mcp',
+      declaredSpecialisms: ['sales-broadcast-tv'],
+      runId: 'run-31',
+      adcpVersions: ['3.1'],
+      supportedVersions: ['3.0', '3.1'],
+    }));
   });
 
   it('counts malformed saved Basic auth as a checked failure', async () => {

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -8349,7 +8349,7 @@ paths:
                         description: Fresh test session id used for the compliance run. Useful when matching seller-side logs to the refresh.
                       requested_compliance_target:
                         type: string
-                        description: Requested compliance target before alias resolution, e.g. 3.0, 3.1-rc, or 3.1-beta. Present when `ran` is true.
+                        description: Requested compliance target before alias resolution, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta. Present when `ran` is true.
                       adcp_version:
                         type: string
                         description: Concrete AdCP compliance bundle version used for the run, e.g. 3.0.12 or 3.1.0-beta.7. Present when `ran` is true.
@@ -8966,9 +8966,9 @@ paths:
           in: query
         - schema:
             type: string
-            description: Compliance target to inspect, e.g. 3.0, 3.1-rc, or 3.1-beta
+            description: Compliance target to inspect, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta
           required: false
-          description: Compliance target to inspect, e.g. 3.0, 3.1-rc, or 3.1-beta
+          description: Compliance target to inspect, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta
           name: compliance_target
           in: query
       responses:
@@ -9017,9 +9017,9 @@ paths:
           in: path
         - schema:
             type: string
-            description: Compliance target to inspect, e.g. 3.0, 3.1-rc, or 3.1-beta
+            description: Compliance target to inspect, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta
           required: false
-          description: Compliance target to inspect, e.g. 3.0, 3.1-rc, or 3.1-beta
+          description: Compliance target to inspect, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta
           name: compliance_target
           in: query
       responses:
@@ -9487,9 +9487,9 @@ paths:
           in: path
         - schema:
             type: string
-            description: Compliance target to inspect, e.g. 3.0, 3.1-rc, or 3.1-beta
+            description: Compliance target to inspect, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta
           required: false
-          description: Compliance target to inspect, e.g. 3.0, 3.1-rc, or 3.1-beta
+          description: Compliance target to inspect, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta
           name: compliance_target
           in: query
       responses:

--- a/tests/addie/member-tools.test.ts
+++ b/tests/addie/member-tools.test.ts
@@ -945,6 +945,7 @@ describe('createMemberToolHandlers', () => {
         declaredSpecialisms: ['sales-catalog-driven'],
         runId: 'run_123',
         adcpVersions: ['3.0'],
+        supportedVersions: ['3.0'],
       }));
     });
 

--- a/tests/hosted-compliance-version.test.ts
+++ b/tests/hosted-compliance-version.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  agentAdvertisesBadgeEligibleHostedComplianceTarget,
+  badgeEligibleVersionsForHostedComplianceTarget,
+  hostedComplianceTarget,
+  selectCanonicalHostedComplianceTargetForSupportedVersions,
+} from '../server/src/services/hosted-compliance-version.js';
+
+describe('hosted compliance target selection', () => {
+  it('selects the 3.1 GA target when an agent advertises both 3.0 and 3.1', () => {
+    const target = selectCanonicalHostedComplianceTargetForSupportedVersions(['3.0', '3.1']);
+
+    expect(target.requested).toBe('3.1');
+    expect(target.version).toBe('3.1.0');
+  });
+
+  it('selects the 3.1 GA target when an agent advertises patch-form 3.1.0', () => {
+    const target = selectCanonicalHostedComplianceTargetForSupportedVersions(['3.0', '3.1.0']);
+
+    expect(target.requested).toBe('3.1');
+    expect(target.version).toBe('3.1.0');
+  });
+
+  it('keeps 3.0-only agents on the 3.0 public target', () => {
+    const target = selectCanonicalHostedComplianceTargetForSupportedVersions(['3.0']);
+
+    expect(target.requested).toBe('3.0');
+    expect(target.version.startsWith('3.0.')).toBe(true);
+  });
+
+  it('treats stable 3.1 as public badge eligible', () => {
+    const target = hostedComplianceTarget('3.1');
+
+    expect(badgeEligibleVersionsForHostedComplianceTarget(target)).toEqual(['3.1']);
+    expect(agentAdvertisesBadgeEligibleHostedComplianceTarget(['3.0', '3.1'], target)).toBe(true);
+  });
+
+  it('treats patch-form stable 3.1.0 advertisements as public badge eligible', () => {
+    const target = hostedComplianceTarget('3.1');
+
+    expect(agentAdvertisesBadgeEligibleHostedComplianceTarget(['3.0', '3.1.0'], target)).toBe(true);
+  });
+
+  it('does not treat prerelease 3.1 targets as public badge eligible', () => {
+    const target = hostedComplianceTarget('3.1-rc');
+
+    expect(badgeEligibleVersionsForHostedComplianceTarget(target)).toEqual([]);
+    expect(agentAdvertisesBadgeEligibleHostedComplianceTarget(['3.1-rc.15'], target)).toBe(false);
+    expect(agentAdvertisesBadgeEligibleHostedComplianceTarget(['3.1.0-rc.15'], target)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- enable AdCP 3.1 as a public badge-eligible compliance line ahead of 3.0
- make canonical hosted compliance target selection choose the newest advertised public line, so heartbeat grades 3.1 agents against the 3.1.0 GA bundle
- pass supported_versions snapshots into badge fan-out so stale 3.1 badges revoke when an agent falls back to 3.0-only support
- refresh manual compliance-target guidance and generated OpenAPI descriptions for stable 3.1

## Why

AdCP 3.1.0 is shipped, but the public heartbeat/canonical grading path still preferred 3.0 when an agent advertised both 3.0 and 3.1. That left upgraded agents publicly graded at 3.0. Enabling 3.1 also exposed a stale-badge edge case: a later 3.0-only run could update 3.0 while leaving an existing 3.1 badge active. This PR closes both paths.

## Expert review

- code review caught the stale adcp-taxonomy expectation and stale manual target guidance
- protocol review caught stale 3.1 badge survival when an agent no longer advertises 3.1; fixed in badge fan-out and covered by tests
- patch-form stable supported_versions such as 3.1.0 remain tolerated for adoption compatibility, while prerelease full-semver values remain non-public-badge-eligible

## Validation

- npx vitest run tests/hosted-compliance-version.test.ts server/tests/unit/adcp-taxonomy.test.ts server/tests/unit/badge-fan-out.test.ts server/tests/unit/compliance-heartbeat.test.ts tests/addie/member-tools.test.ts --pool=threads
- npm run typecheck
- npm run test:openapi
- precommit hook: npm run test:unit, npm run test:test-dynamic-imports, npm run test:callapi-state-change, npm run precommit:server-unit, npm run typecheck
- pre-push hook: version sync, changeset policy, current storyboard matrix, 3.0 compatibility storyboard matrix
