### PR TITLE
fix: clarify broadcast buys and Addie entitlements

### DIFF
--- a/.changeset/broadcast-entitlements-patch.md
+++ b/.changeset/broadcast-entitlements-patch.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Clarify broadcast product/reporting ownership, correct the broadcast compliance channel fixture to `linear_tv`, and document that scheduled broadcast buys should not be modeled as `non_guaranteed` solely because third-party audience measurement settles later.

--- a/docs/creative/channels/broadcast.mdx
+++ b/docs/creative/channels/broadcast.mdx
@@ -11,6 +11,19 @@ Broadcast TV differs from CTV in fundamental ways: there is no ad server, no VAS
 
 The protocol-level operations (`list_creative_formats`, `build_creative`, `sync_creatives`) work identically for broadcast as for any other format. The broadcast-specific details are in format definitions, asset requirements, and measurement models covered below.
 
+## Metadata ownership in broadcast syndication
+
+Linear broadcast carriage is not the same as web syndication. In web syndication, an embedding publisher can add its own context, decisioning, and audience layer around another party's content. In linear broadcast, an affiliate or station usually carries a scheduled asset under the originating seller's order; it does not fork or materially transform the creative.
+
+That distinction keeps AdCP metadata simple:
+
+- The creative record stays singular and stable. Use `creative_id` plus `industry_identifiers` for the canonical asset and traffic identity.
+- Network, national, or rep-firm buys are usually one seller product with multi-market fulfillment, not a chain of per-affiliate AdCP instances.
+- Local spot, station-group, and market-cleared syndication buys may be genuinely multi-seller. Each seller reports its own delivery; the buyer aggregates across sellers.
+- Station, market, daypart, placement, and measurement-window differences belong in delivery reporting and product/package context, not by mutating the creative metadata.
+
+When a single spot performs differently across markets or dayparts, preserve that difference as delivery signal. Do not merge it into one evolving creative metadata object.
+
 ## How broadcast differs from CTV
 
 | | Broadcast | CTV |

--- a/docs/media-buy/media-buys/optimization-reporting.mdx
+++ b/docs/media-buy/media-buys/optimization-reporting.mdx
@@ -466,6 +466,8 @@ For channels where billing-grade data is produced in **phases** rather than arri
 
 Each window's numbers supersede the previous one. One window is typically the `is_guarantee_basis` — the number both sides reconcile against. The measurement vendor's processing time is captured in `expected_availability_days` on each window (it includes both accumulation and processing).
 
+For broadcast, delayed or sparse early-window data is usually a measurement-vendor settlement issue, not a seller-side metadata problem. Nielsen, Comscore, VideoAmp, or another named vendor may publish Live, C3, C7, Live+5, or market-level results in waves. During that period, sellers should label delivery as provisional or awaiting measurement-vendor finalization, preserve the `measurement_window`, and use `is_final`, `finalized_at`, `supersedes_window`, and delayed/window-update notifications to show what changed. Buyers should not fork creative records or product metadata to represent partial affiliate or station visibility; aggregate the seller's delivery rows by market, placement, daypart, creative, and measurement window instead.
+
 Sellers set `expected_delay_minutes` on their products to reflect the first-available data pipeline. The `measurement_windows` array on `reporting_capabilities` provides per-window timelines.
 
 Delivery data for products with measurement windows includes three fields on each package:

--- a/docs/media-buy/product-discovery/media-products.mdx
+++ b/docs/media-buy/product-discovery/media-products.mdx
@@ -1563,6 +1563,14 @@ Broadcast TV sellers offer distinct inventory packages rather than impressions a
 
 Each point represents a distinct package — different dayparts, unit types, and flight structures — not the same product at three spend levels. The `label` field lets buyer agents reference packages by name when negotiating or requesting specific options. The `measurement_source: "nielsen"` tells the buyer agent that the impression and GRP numbers are modeled against Nielsen data, not the broadcaster's own measurement. The `measured_impressions` metric expresses delivery as counted by Nielsen — paired with `method: "modeled"`, these are Nielsen-measured estimates. To make them contractual commitments, the seller would use `method: "guaranteed"` instead.
 
+Broadcast buying shape determines product shape:
+
+- **Network or rep-firm package**: model as one seller product when one seller commits the order and fulfills across multiple markets or affiliates. The affiliates are fulfillment surfaces, not independent AdCP hops.
+- **Local spot or station-group inventory**: model separate products or packages when inventory is sold by distinct stations, station groups, or market sellers.
+- **Market-by-market syndication**: model by the party that sells and commits the inventory. If multiple sellers commit separately, the buyer aggregates their delivery reports across media buys.
+
+Use `delivery_type: "guaranteed"` when spots, units, or inventory are reserved or scheduled. Use `forecast.method: "modeled"` for historical audience ranges and `forecast.method: "guaranteed"` only when the seller is contractually committing to make good delivery outside the stated range. Do not use `non_guaranteed` merely because final measured impressions depend on historical ranges or third-party measurement settlement.
+
 If packages share the same inventory pool and differ only in volume or mix, use `package` forecast points on one product. If they represent fundamentally different inventory (different shows, properties, or dayparts with no overlap), create separate products with their own forecasts.
 
 Sellers expressing the same inventory in multiple measurement currencies (e.g., both Nielsen and VideoAmp) should provide separate DeliveryForecast objects, one per `measurement_source`.

--- a/server/src/addie/claude-cost-tracker.ts
+++ b/server/src/addie/claude-cost-tracker.ts
@@ -44,6 +44,7 @@
 
 import { createLogger } from '../logger.js';
 import { query } from '../db/client.js';
+import { TIER_PRESERVING_STATUSES } from '../db/organization-db.js';
 import { costUsdMicros, type ClaudeUsage } from './claude-pricing.js';
 import { SYSTEM_USER_IDS } from './system-identities.js';
 import type { MemberContext } from './member-context.js';
@@ -334,12 +335,10 @@ function writeCachedTier(userId: string, tier: UserTier): void {
  * back to `member_free` so a transient outage doesn't accidentally grant
  * the $25/day ceiling or uncapped staff access to unverified callers.
  *
- * The SQL predicate here (`subscription_status = 'active' AND
- * subscription_canceled_at IS NULL`) matches `MEMBER_FILTER` in
- * `db/org-filters.ts` — the two must stay in sync so admin views and
- * the cap agree on who counts as a paying member. Trialing / past_due /
- * comped-$0 states all correctly fall through to `member_free`; if
- * future policy promotes any of those, update `MEMBER_FILTER` first.
+ * The SQL predicate here uses `TIER_PRESERVING_STATUSES`
+ * (active/past_due/trialing) so the cap agrees with billing entitlement
+ * policy. `past_due` keeps paid headroom during Stripe dunning instead
+ * of framing the member as unpaid mid-retry.
  *
  * This is the async, DB-touching counterpart to the pure
  * `resolveUserTier` above — the `FromDb` suffix is deliberate so a
@@ -357,7 +356,7 @@ export async function resolveUserTierFromDb(userId: string | null | undefined): 
   try {
     const { rows } = await query<{
       is_aao_team: boolean;
-      has_active_subscription: boolean;
+      has_entitled_subscription: boolean;
     }>(
       `SELECT
           (
@@ -383,15 +382,15 @@ export async function resolveUserTierFromDb(userId: string | null | undefined): 
               FROM organization_memberships om
               JOIN organizations o ON o.workos_organization_id = om.workos_organization_id
              WHERE om.workos_user_id = $1
-               AND o.subscription_status = 'active'
+               AND o.subscription_status = ANY($2::text[])
                AND o.subscription_canceled_at IS NULL
-          ) AS has_active_subscription`,
-      [userId],
+          ) AS has_entitled_subscription`,
+      [userId, TIER_PRESERVING_STATUSES],
     );
     const row = rows[0];
     const tier = resolveUserTier({
       isAAOTeam: row?.is_aao_team === true,
-      hasActiveSubscription: row?.has_active_subscription === true,
+      hasActiveSubscription: row?.has_entitled_subscription === true,
     });
     writeCachedTier(userId, tier);
     return tier;

--- a/server/src/addie/member-context.ts
+++ b/server/src/addie/member-context.ts
@@ -1412,25 +1412,33 @@ export function formatMemberContextForPrompt(context: MemberContext, channel: 'w
     if (context.organization.is_personal) {
       lines.push('They have an individual account (not a company account).');
       if (context.is_member) {
-        lines.push('They are an active AgenticAdvertising.org individual member.');
+        lines.push('They currently have AgenticAdvertising.org individual member access.');
+        const subStatus = safeSubscriptionStatus(context.organization.subscription_status);
+        if (subStatus && subStatus !== 'active' && subStatus !== 'none') {
+          lines.push(`Subscription status: ${subStatus}.`);
+        }
       } else {
         lines.push('They are not currently an AgenticAdvertising.org member.');
         const subStatus = safeSubscriptionStatus(context.organization.subscription_status);
         if (subStatus && subStatus !== 'none') {
-          lines.push(`Subscription status: ${subStatus} (requires "active" for membership).`);
+          lines.push(`Subscription status: ${subStatus} (not currently granting membership access).`);
         }
       }
     } else {
       lines.push(`They work at ${promptFact(context.organization.name, 200)}.`);
 
       if (context.is_member) {
-        lines.push('Their organization is an active AgenticAdvertising.org member.');
+        lines.push('Their organization currently has AgenticAdvertising.org member access.');
+        const subStatus = safeSubscriptionStatus(context.organization.subscription_status);
+        if (subStatus && subStatus !== 'active' && subStatus !== 'none') {
+          lines.push(`Subscription status: ${subStatus}.`);
+        }
       } else {
         lines.push('Their organization is not currently an AgenticAdvertising.org member.');
         // Include subscription status when available to help diagnose membership issues
         const subStatus = safeSubscriptionStatus(context.organization.subscription_status);
         if (subStatus && subStatus !== 'none') {
-          lines.push(`Subscription status: ${subStatus} (requires "active" for membership).`);
+          lines.push(`Subscription status: ${subStatus} (not currently granting membership access).`);
         }
       }
     }

--- a/server/src/db/org-filters.ts
+++ b/server/src/db/org-filters.ts
@@ -1,6 +1,6 @@
 import { getPool } from './client.js';
 import { createLogger } from '../logger.js';
-import { resolveMembershipTier, type MembershipTierRow } from './organization-db.js';
+import { resolveMembershipTier, TIER_PRESERVING_STATUSES, type MembershipTierRow } from './organization-db.js';
 
 const logger = createLogger('org-filters');
 
@@ -37,6 +37,21 @@ export function isPayingMembership(row: {
   subscription_canceled_at: Date | null;
 }): boolean {
   return row.subscription_status === 'active' && row.subscription_canceled_at === null;
+}
+
+/**
+ * Subscription statuses that keep member entitlements available. This is
+ * intentionally broader than `isPayingMembership`: `past_due` and `trialing`
+ * preserve tiers during Stripe dunning/trial windows.
+ */
+function hasEntitledSubscription(row: {
+  subscription_status: string | null;
+  subscription_canceled_at: Date | null;
+}): boolean {
+  return (
+    (TIER_PRESERVING_STATUSES as readonly string[]).includes(row.subscription_status ?? '') &&
+    row.subscription_canceled_at === null
+  );
 }
 
 /** Organization has at least one user (site account or Slack user) */
@@ -187,8 +202,9 @@ const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
  * Resolve effective membership for an organization, including inheritance
  * through the brand registry hierarchy (house_domain chain).
  *
- * If the org itself is a paying member, returns direct membership.
- * Otherwise, walks up the house_domain chain looking for a paying ancestor.
+ * If the org itself has an entitlement-preserving subscription, returns direct
+ * membership. Otherwise, walks up the house_domain chain looking for an
+ * entitled/paying ancestor.
  *
  * Trust gates on inheritance — same shape as findPayingOrgForDomain so the
  * pre-link auto-provisioning path and post-link is_member resolution agree
@@ -197,7 +213,7 @@ const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
  *   - cycle protection via visited-domain array
  *   - only edges classified at confidence='high' (LLM classifier output)
  *   - 180-day TTL on the brand classification
- *   - inherited match only counts if the paying ancestor has opted into
+ *   - inherited match only counts if the entitled/paying ancestor has opted into
  *     auto_provision_brand_hierarchy_children (default false). Without
  *     opt-in, the child org's is_member stays false even if the brand
  *     registry says it's a subsidiary.
@@ -288,9 +304,9 @@ export async function resolveEffectiveMembership(orgId: string): Promise<Effecti
     }
 
     // Check the org itself first (depth 1) — opt-in flag does not apply to
-    // self; an org's own paying subscription always counts.
+    // self; an org's own entitlement-preserving subscription always counts.
     const self = rows[0];
-    if (self.subscription_status === 'active' && !self.subscription_canceled_at) {
+    if (hasEntitledSubscription(self)) {
       const directResult: EffectiveMembership = {
         is_member: true,
         is_inherited: false,
@@ -303,11 +319,11 @@ export async function resolveEffectiveMembership(orgId: string): Promise<Effecti
       return directResult;
     }
 
-    // Check ancestors (depth > 1) for a paying member that has opted into
+    // Check ancestors (depth > 1) for an entitled/paying member that has opted into
     // hierarchy inheritance. An ancestor that didn't consent to children
     // auto-joining doesn't grant is_member to those children either.
     for (const row of rows.slice(1)) {
-      if (row.subscription_status === 'active' && !row.subscription_canceled_at && row.auto_provision_hierarchy) {
+      if (hasEntitledSubscription(row) && row.auto_provision_hierarchy) {
         const chain = rows
           .filter(r => r.depth <= row.depth)
           .map(r => r.email_domain)
@@ -326,7 +342,7 @@ export async function resolveEffectiveMembership(orgId: string): Promise<Effecti
       }
     }
 
-    // No paying member in chain
+    // No entitled/paying member in chain
     const noMemberResult: EffectiveMembership = {
       is_member: false,
       is_inherited: false,
@@ -385,13 +401,13 @@ export interface DomainOwnerOrg {
 }
 
 /**
- * Find the paying organization that "owns" a raw email domain — directly via a
- * verified `organization_domains` row or transitively up the brand registry's
- * `house_domain` chain.
+ * Find the entitled/paying organization that "owns" a raw email domain —
+ * directly via a verified `organization_domains` row or transitively up the
+ * brand registry's `house_domain` chain.
  *
  * Returns the closest match: a direct verified-domain hit on the input wins
  * over an inherited one. When two ancestors at different depths both have
- * paying orgs, the shallower one wins.
+ * entitled/paying orgs, the shallower one wins.
  *
  * Trust gates on the inheritance walk:
  *   - max 4 hops up from the input domain
@@ -457,13 +473,13 @@ export async function findPayingOrgForDomain(domain: string): Promise<DomainOwne
         JOIN organization_domains od ON LOWER(od.domain) = LOWER(dc.domain)
         JOIN organizations o ON o.workos_organization_id = od.workos_organization_id
         WHERE od.verified = true
-          AND o.subscription_status = 'active'
+          AND o.subscription_status = ANY($2::text[])
           AND o.subscription_canceled_at IS NULL
         ORDER BY dc.depth ASC  -- direct match (depth 1) wins over inherited
         LIMIT 1
       )
       SELECT * FROM paying_match
-    `, [normalizedDomain]);
+    `, [normalizedDomain, TIER_PRESERVING_STATUSES]);
 
     if (result.rows.length === 0) return null;
 

--- a/server/src/routes/admin/addie-costs.ts
+++ b/server/src/routes/admin/addie-costs.ts
@@ -18,8 +18,8 @@
  * The `inferred_tier` column reflects the most-lenient cap the caller
  * would have been subject to at the time of the call. For bare WorkOS
  * IDs we join through `organization_memberships` + `organizations` so
- * active-subscription members show `member_paid`; for everyone else we
- * fall back to the namespace-level inference (email/mcp/tavus/anon →
+ * entitlement-preserving subscriptions show `member_paid`; for everyone else
+ * we fall back to the namespace-level inference (email/mcp/tavus/anon →
  * anonymous, slack/workos → member_free). WorkOS users in the
  * `aao-admin` governance group or AgenticAdvertising.org org show
  * `aao_team` and are uncapped.
@@ -29,6 +29,7 @@ import { Router } from 'express';
 import { createLogger } from '../../logger.js';
 import { requireGlobalAdmin } from '../../middleware/auth.js';
 import { getPool } from '../../db/client.js';
+import { TIER_PRESERVING_STATUSES } from '../../db/organization-db.js';
 import { DAILY_BUDGET_USD } from '../../addie/claude-cost-tracker.js';
 import {
   inferDisplayTier,
@@ -178,7 +179,7 @@ export function setupAddieCostRoutes(apiRouter: Router): void {
         member_last_name: string | null;
         member_email: string | null;
         org_name: string | null;
-        org_has_active_subscription: boolean | null;
+        org_has_entitled_subscription: boolean | null;
         is_aao_team: boolean | null;
       }>(
         `WITH scope_totals AS (
@@ -207,7 +208,7 @@ export function setupAddieCostRoutes(apiRouter: Router): void {
            u.last_name  AS member_last_name,
            u.email      AS member_email,
            best_org.name AS org_name,
-           best_org.has_active_subscription AS org_has_active_subscription,
+           best_org.has_entitled_subscription AS org_has_entitled_subscription,
            (
              ${namespaceCaseSql('t.scope_key')} = 'workos'
              AND (
@@ -234,22 +235,22 @@ export function setupAddieCostRoutes(apiRouter: Router): void {
          LEFT JOIN LATERAL (
            SELECT
              o.name,
-             (o.subscription_status = 'active' AND o.subscription_canceled_at IS NULL) AS has_active_subscription
+             (o.subscription_status = ANY($3::text[]) AND o.subscription_canceled_at IS NULL) AS has_entitled_subscription
            FROM organization_memberships om
            JOIN organizations o ON o.workos_organization_id = om.workos_organization_id
            WHERE om.workos_user_id = t.scope_key
            ORDER BY
-             CASE WHEN o.subscription_status = 'active' AND o.subscription_canceled_at IS NULL THEN 0 ELSE 1 END,
+             CASE WHEN o.subscription_status = ANY($3::text[]) AND o.subscription_canceled_at IS NULL THEN 0 ELSE 1 END,
              o.workos_organization_id
            LIMIT 1
          ) best_org ON true
          ORDER BY t.total_micros DESC, t.scope_key`,
-        [windowHours, limit],
+        [windowHours, limit, TIER_PRESERVING_STATUSES],
       );
 
       const leaderboard = rows.map(row => {
         const namespace = row.namespace;
-        const inferredTier = inferDisplayTier(namespace, row.org_has_active_subscription, row.is_aao_team);
+        const inferredTier = inferDisplayTier(namespace, row.org_has_entitled_subscription, row.is_aao_team);
         const capUsd = inferredTier === 'aao_team' ? null : DAILY_BUDGET_USD[inferredTier];
         const spentUsd = microsToUsd(Number(row.total_micros));
         const percentOfCap = capUsd && capUsd > 0 ? Math.round((spentUsd / capUsd) * 1000) / 10 : null;
@@ -270,7 +271,7 @@ export function setupAddieCostRoutes(apiRouter: Router): void {
           member_name: displayName,
           member_email: row.member_email,
           org_name: row.org_name,
-          has_active_subscription: row.org_has_active_subscription,
+          has_active_subscription: row.org_has_entitled_subscription,
         };
       });
 

--- a/server/src/services/membership-tiers.ts
+++ b/server/src/services/membership-tiers.ts
@@ -159,8 +159,9 @@ export async function checkContentSubmissionTier(userId: string): Promise<boolea
   const membership = await resolveEffectiveMembership(orgId);
 
   // resolveEffectiveMembership walks the brand hierarchy and sets is_member
-  // only when the org (or a consenting ancestor) has an active, non-canceled
-  // subscription — so is_member already encodes subscription-status validity.
-  // We additionally require the tier to be in API_ACCESS_TIERS (Professional+).
+  // only when the org (or a consenting ancestor) has an entitlement-preserving,
+  // non-canceled subscription — so is_member already encodes subscription-status
+  // validity. We additionally require the tier to be in API_ACCESS_TIERS
+  // (Professional+).
   return membership.is_member && isApiAccessTier(membership.membership_tier);
 }

--- a/server/tests/integration/find-paying-org-for-domain.test.ts
+++ b/server/tests/integration/find-paying-org-for-domain.test.ts
@@ -155,6 +155,16 @@ describe('findPayingOrgForDomain', () => {
     expect(result!.auto_provision_hierarchy_allowed).toBe(false); // default
   });
 
+  it('treats past_due as an entitlement-preserving verified-domain match', async () => {
+    await seedPayingOrg(pool, TEST_DIRECT_ORG, CHILD_DOMAIN, { subscription_status: 'past_due' });
+
+    const result = await findPayingOrgForDomain(CHILD_DOMAIN);
+
+    expect(result).not.toBeNull();
+    expect(result!.organization_id).toBe(TEST_DIRECT_ORG);
+    expect(result!.matched_domain).toBe(CHILD_DOMAIN);
+  });
+
   it('walks brands.house_domain to inherit from a paying parent', async () => {
     await seedPayingOrg(pool, TEST_PARENT_ORG, PARENT_DOMAIN);
     await seedBrandHierarchy(pool, CHILD_DOMAIN, PARENT_DOMAIN);
@@ -367,6 +377,22 @@ describe('resolveEffectiveMembership coherence with findPayingOrgForDomain', () 
     expect(result.is_member).toBe(true);
     expect(result.is_inherited).toBe(false);
     expect(result.membership_tier).toBe('individual_professional');
+  });
+
+  it('resolves past_due direct membership during the Stripe dunning window', async () => {
+    await seedPayingOrg(pool, TEST_DIRECT_ORG, CHILD_DOMAIN, {
+      subscription_status: 'past_due',
+      membership_tier: 'company_icl',
+      subscription_amount: 700000,
+      subscription_interval: 'year',
+      is_personal: false,
+    });
+
+    const result = await resolveEffectiveMembership(TEST_DIRECT_ORG);
+
+    expect(result.is_member).toBe(true);
+    expect(result.is_inherited).toBe(false);
+    expect(result.membership_tier).toBe('company_icl');
   });
 
   it('resolves direct membership tier through amount fallback when lookup key is absent', async () => {

--- a/server/tests/unit/claude-cost-tier-resolution.test.ts
+++ b/server/tests/unit/claude-cost-tier-resolution.test.ts
@@ -50,21 +50,32 @@ describe('resolveUserTierFromDb', () => {
     expect(queryMock).not.toHaveBeenCalled();
   });
 
-  it('returns member_paid when the WorkOS user has an active, non-canceled subscription', async () => {
-    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: false, has_active_subscription: true }] });
+  it('returns member_paid when the WorkOS user has an entitlement-preserving, non-canceled subscription', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: false, has_entitled_subscription: true }] });
     const tier = await resolveUserTierFromDb('user_01H2ABC');
     expect(tier).toBe('member_paid');
     expect(queryMock).toHaveBeenCalledOnce();
-    // The probe must filter on both active status AND not-canceled —
-    // otherwise a canceled org would still read as paid until grace
-    // period ends.
+    // The probe must use the shared entitlement-preserving statuses
+    // and still exclude canceled rows.
     const sql = queryMock.mock.calls[0][0] as string;
-    expect(sql).toContain("subscription_status = 'active'");
+    expect(sql).toContain('subscription_status = ANY($2::text[])');
     expect(sql).toContain('subscription_canceled_at IS NULL');
+    expect(queryMock.mock.calls[0][1]).toEqual([
+      'user_01H2ABC',
+      ['active', 'past_due', 'trialing'],
+    ]);
+  });
+
+  it('treats past_due as member_paid during the Stripe dunning window', async () => {
+    // The mocked row is the DB's answer after applying the SQL status
+    // predicate; the parameter assertion pins past_due in that predicate.
+    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: false, has_entitled_subscription: true }] });
+    await expect(resolveUserTierFromDb('user_past_due')).resolves.toBe('member_paid');
+    expect(queryMock.mock.calls[0][1][1]).toContain('past_due');
   });
 
   it('returns aao_team when the WorkOS user belongs to the AAO admin team or org', async () => {
-    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: true, has_active_subscription: false }] });
+    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: true, has_entitled_subscription: false }] });
     const tier = await resolveUserTierFromDb('user_aao_staff');
     expect(tier).toBe('aao_team');
     expect(queryMock).toHaveBeenCalledOnce();
@@ -75,12 +86,12 @@ describe('resolveUserTierFromDb', () => {
   });
 
   it('prefers aao_team over member_paid when both signals are true', async () => {
-    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: true, has_active_subscription: true }] });
+    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: true, has_entitled_subscription: true }] });
     expect(await resolveUserTierFromDb('user_aao_paid')).toBe('aao_team');
   });
 
   it('returns member_free when the WorkOS user has no active subscription or AAO team membership', async () => {
-    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: false, has_active_subscription: false }] });
+    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: false, has_entitled_subscription: false }] });
     const tier = await resolveUserTierFromDb('user_01H2ABC');
     expect(tier).toBe('member_free');
   });
@@ -98,7 +109,7 @@ describe('resolveUserTierFromDb', () => {
   it('memoizes results so repeated probes for the same user hit the DB once', async () => {
     // 60s in-process cache. A chat burst should not produce N DB
     // probes for the same user — one probe, cached tier, replayed.
-    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: false, has_active_subscription: true }] });
+    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: false, has_entitled_subscription: true }] });
     expect(await resolveUserTierFromDb('user_01H2ABC')).toBe('member_paid');
     expect(await resolveUserTierFromDb('user_01H2ABC')).toBe('member_paid');
     expect(await resolveUserTierFromDb('user_01H2ABC')).toBe('member_paid');
@@ -110,15 +121,15 @@ describe('resolveUserTierFromDb', () => {
     // member_paid for a full 60s. The first call fails → returns
     // member_free without caching; the second call retries.
     queryMock.mockRejectedValueOnce(new Error('Connection refused'));
-    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: false, has_active_subscription: true }] });
+    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: false, has_entitled_subscription: true }] });
     expect(await resolveUserTierFromDb('user_01H2ABC')).toBe('member_free');
     expect(await resolveUserTierFromDb('user_01H2ABC')).toBe('member_paid');
     expect(queryMock).toHaveBeenCalledTimes(2);
   });
 
   it('memoizes per-user, not globally — different users get independent probes', async () => {
-    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: false, has_active_subscription: true }] });
-    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: false, has_active_subscription: false }] });
+    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: false, has_entitled_subscription: true }] });
+    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: false, has_entitled_subscription: false }] });
     expect(await resolveUserTierFromDb('user_alice')).toBe('member_paid');
     expect(await resolveUserTierFromDb('user_bob')).toBe('member_free');
     expect(queryMock).toHaveBeenCalledTimes(2);
@@ -131,7 +142,7 @@ describe('resolveUserTierFromDb', () => {
 
 describe('buildSlackCostScope', () => {
   it('prefers the mapped WorkOS user id when memberContext carries one', async () => {
-    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: false, has_active_subscription: true }] });
+    queryMock.mockResolvedValueOnce({ rows: [{ is_aao_team: false, has_entitled_subscription: true }] });
     const scope = await buildSlackCostScope(
       { workos_user: { workos_user_id: 'user_01H2ABC' } },
       'U_slack',

--- a/server/tests/unit/member-context.test.ts
+++ b/server/tests/unit/member-context.test.ts
@@ -128,7 +128,7 @@ describe('formatMemberContextForPrompt', () => {
 
     const result = formatMemberContextForPrompt(context);
     expect(result).toContain('Acme Corp');
-    expect(result).toContain('active AgenticAdvertising.org member');
+    expect(result).toContain('currently has AgenticAdvertising.org member access');
   });
 
   it('should indicate individual member status for personal org members', () => {
@@ -151,7 +151,7 @@ describe('formatMemberContextForPrompt', () => {
 
     const result = formatMemberContextForPrompt(context);
     expect(result).toContain('individual account');
-    expect(result).toContain('AgenticAdvertising.org individual member');
+    expect(result).toContain('AgenticAdvertising.org individual member access');
   });
 
   it('should indicate non-member status', () => {
@@ -177,7 +177,7 @@ describe('formatMemberContextForPrompt', () => {
     expect(result).not.toContain('Subscription status:');
   });
 
-  it('should include subscription status diagnostic for non-members with subscription data', () => {
+  it('should include subscription status diagnostic for non-members with subscription data without active-only policy text', () => {
     const context: MemberContext = {
       is_mapped: true,
       is_member: false,
@@ -197,7 +197,8 @@ describe('formatMemberContextForPrompt', () => {
 
     const result = formatMemberContextForPrompt(context);
     expect(result).toContain('not currently an AgenticAdvertising.org member');
-    expect(result).toContain('Subscription status: past_due (requires "active" for membership).');
+    expect(result).toContain('Subscription status: past_due (not currently granting membership access).');
+    expect(result).not.toContain('requires "active"');
   });
 
   it('should include subscription status diagnostic for non-member individual accounts', () => {
@@ -220,7 +221,7 @@ describe('formatMemberContextForPrompt', () => {
 
     const result = formatMemberContextForPrompt(context);
     expect(result).toContain('not currently an AgenticAdvertising.org member');
-    expect(result).toContain('Subscription status: incomplete (requires "active" for membership).');
+    expect(result).toContain('Subscription status: incomplete (not currently granting membership access).');
   });
 
   it('lists active organization choices without selecting one for multi-org users', () => {

--- a/static/compliance/source/specialisms/sales-broadcast-tv/index.yaml
+++ b/static/compliance/source/specialisms/sales-broadcast-tv/index.yaml
@@ -75,12 +75,12 @@ fixtures:
   products:
     - product_id: "primetime_30s_mf"
       delivery_type: "guaranteed"
-      channels: ["video"]
+      channels: ["linear_tv"]
       format_ids:
         - id: "broadcast_spot_30s"
     - product_id: "late_fringe_15s_mf"
       delivery_type: "guaranteed"
-      channels: ["video"]
+      channels: ["linear_tv"]
       format_ids:
         - id: "broadcast_spot_15s"
   pricing_options:

--- a/static/schemas/source/enums/delivery-type.json
+++ b/static/schemas/source/enums/delivery-type.json
@@ -10,6 +10,6 @@
   ],
   "enumDescriptions": {
     "guaranteed": "Reserved inventory with guaranteed delivery",
-    "non_guaranteed": "Auction-based inventory without delivery guarantees"
+    "non_guaranteed": "Inventory without reserved or guaranteed delivery, commonly auction-based or otherwise best-effort. Do not use for scheduled broadcast buys solely because final audience delivery is estimated from historical ranges or settles through third-party measurement."
   }
 }


### PR DESCRIPTION
## Summary
- Clarify broadcast syndication/product ownership: creative metadata stays canonical, while station/market/daypart/window variance belongs in products and delivery reporting.
- Correct the broadcast compliance fixture channel from `video` to `linear_tv` and add a patch changeset for the protocol-facing clarification.
- Preserve Addie paid-member entitlements for non-canceled `active`, `past_due`, and `trialing` subscriptions across membership resolution, domain matching, cost caps, and admin cost reporting.

## Validation
- Expert review: protocol/schema/docs reviewer and backend code reviewer
- `npx vitest run server/tests/unit/claude-cost-tier-resolution.test.ts server/tests/unit/member-context.test.ts server/tests/unit/admin-addie-costs.test.ts`
- `npx vitest run server/tests/integration/find-paying-org-for-domain.test.ts --config server/vitest.config.ts`
- `node scripts/check-changeset-protocol-scope.cjs`
- `npx changeset status --since=origin/main`
- `npm run test:schemas`
- `npm run test:docs-nav`
- `npm run test:compliance-source-authority`
- `npm run test:compliance-packaged-refs`
- `npm run typecheck`
- Precommit hook: `test:unit`, `test:test-dynamic-imports`, `test:callapi-state-change`, `precommit:server-unit`, `typecheck`
- Pre-push hook: version sync, changeset policy, current compliance storyboard matrix, 3.0 compatibility matrix, Mintlify broken-link check
