### PR TITLE
Fix orphan prospect domain links

### DIFF
--- a/server/src/db/migrations/521_backfill_verified_orphan_prospect_domains.sql
+++ b/server/src/db/migrations/521_backfill_verified_orphan_prospect_domains.sql
@@ -1,0 +1,151 @@
+-- Backfill domain rows for fresh orphan prospect orgs.
+--
+-- Migration 481 handled legacy rows by deriving a non-verified domain from
+-- prospect_contact_email. The orphan-org audit now caught a newer inbound
+-- path where a prospect org was created from triage context without carrying
+-- the triaged domain into organizations.email_domain or organization_domains.
+--
+-- Strategy:
+--   1) Prefer a business prospect_contact_email domain when present.
+--   2) Otherwise use a matching prospect_triage_log create decision: same
+--      source, same company name, close in time.
+--   3) Exclude free-email/shared-platform domains and any domain already
+--      owned by another org.
+--   4) Write an unverified primary organization_domains row and sync
+--      organizations.email_domain so claim flows can find the prospect.
+--
+-- Important: contact emails and triage logs are not DNS proof-of-control.
+-- These rows intentionally remain verified=false; paying auto-link stays
+-- blocked until an admin/WorkOS path verifies the domain.
+
+WITH inferred AS (
+  SELECT
+    o.workos_organization_id,
+    LOWER(split_part(o.prospect_contact_email, '@', 2)) AS domain,
+    0 AS rank,
+    0::double precision AS age_delta
+  FROM organizations o
+  LEFT JOIN organization_domains od
+    ON od.workos_organization_id = o.workos_organization_id
+  WHERE o.is_personal = FALSE
+    AND (o.email_domain IS NULL OR o.email_domain = '')
+    AND od.workos_organization_id IS NULL
+    AND NULLIF(TRIM(o.prospect_contact_email), '') IS NOT NULL
+    AND position('@' IN o.prospect_contact_email) > 0
+
+  UNION ALL
+
+  SELECT
+    o.workos_organization_id,
+    LOWER(TRIM(ptl.domain)) AS domain,
+    1 AS rank,
+    ABS(EXTRACT(EPOCH FROM (ptl.created_at - o.created_at))) AS age_delta
+  FROM organizations o
+  LEFT JOIN organization_domains od
+    ON od.workos_organization_id = o.workos_organization_id
+  JOIN prospect_triage_log ptl
+    ON LOWER(TRIM(ptl.company_name)) = LOWER(TRIM(o.name))
+   AND ptl.action = 'create'
+   AND ptl.source = o.prospect_source
+   AND ptl.created_at BETWEEN o.created_at - INTERVAL '7 days'
+                          AND o.created_at + INTERVAL '7 days'
+  WHERE o.is_personal = FALSE
+    AND (o.email_domain IS NULL OR o.email_domain = '')
+    AND od.workos_organization_id IS NULL
+    AND o.prospect_source IN ('inbound', 'slack')
+    AND NULLIF(TRIM(ptl.domain), '') IS NOT NULL
+),
+valid_inferred AS (
+  SELECT workos_organization_id, domain, rank, age_delta
+  FROM inferred
+  WHERE domain ~ '^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$'
+    AND domain NOT IN (
+      -- Free-email providers
+      'gmail.com','googlemail.com',
+      'outlook.com','hotmail.com','live.com','msn.com',
+      'yahoo.com','yahoo.co.uk','ymail.com','rocketmail.com',
+      'aol.com','aim.com',
+      'icloud.com','me.com','mac.com',
+      'proton.me','protonmail.com','pm.me',
+      'zoho.com','fastmail.com','gmx.com','gmx.net','mail.com',
+      'yandex.com','yandex.ru','qq.com','163.com','126.com',
+      'duck.com','hey.com','tutanota.com','tutanota.de',
+      'uol.com.ar','uol.com.br','uol.com.co','uol.com.mx','uol.com.ve',
+      'uole.com','uole.com.ve','uolmail.com',
+      -- Shared platform / public-suffix domains
+      'vercel.app','vercel.com','netlify.app','netlify.com',
+      'fly.dev','fly.io','render.com','pages.dev','workers.dev',
+      'web.app','firebaseapp.com','cloudfront.net','amplifyapp.com',
+      'replit.app','replit.dev','repl.co','glitch.me','azurewebsites.net',
+      'herokuapp.com',
+      'github.io','gitlab.io','bitbucket.io','readthedocs.io',
+      'medium.com','substack.com','wordpress.com','blogspot.com',
+      'tumblr.com','wixsite.com','squarespace.com',
+      'linkedin.com','twitter.com','x.com','facebook.com','fb.com',
+      'instagram.com','youtube.com','tiktok.com','reddit.com',
+      'pinterest.com','discord.com','snapchat.com','threads.net',
+      'whatsapp.com','wa.me',
+      'co.uk','co.jp','com.au','com.br','co.in','co.nz','co.za',
+      'org.uk','ac.uk','gov.uk','me.uk','ne.jp','or.jp'
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM unnest(ARRAY[
+        '.hubspotusercontent.com',
+        '.hubspotusercontent-na1.net','.hubspotusercontent-na2.net',
+        '.hubspotusercontent-eu1.net','.hubspotusercontent-ap1.net',
+        '.amazonaws.com',
+        '.googleusercontent.com',
+        '.atlassian.net',
+        '.zendesk.com','.freshdesk.com',
+        '.salesforce.com','.force.com','.lightning.force.com',
+        '.shopify.com','.myshopify.com',
+        '.typeform.com','.airtable.com','.notion.site',
+        '.canva.site','.canva.com',
+        '.mailchimp.com','.intercom.io'
+      ]) AS shared_suffix(suffix)
+      WHERE domain LIKE '%' || shared_suffix.suffix
+    )
+),
+ranked AS (
+  SELECT DISTINCT ON (workos_organization_id)
+    workos_organization_id,
+    domain
+  FROM valid_inferred
+  ORDER BY workos_organization_id, rank ASC, age_delta ASC, domain ASC
+),
+candidate AS (
+  SELECT workos_organization_id, domain
+  FROM ranked
+  WHERE NOT EXISTS (
+      SELECT 1 FROM organization_domains od2
+      WHERE od2.domain = ranked.domain
+        AND od2.workos_organization_id != ranked.workos_organization_id
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM organizations o2
+      WHERE LOWER(o2.email_domain) = ranked.domain
+        AND o2.workos_organization_id != ranked.workos_organization_id
+    )
+),
+inserted AS (
+  INSERT INTO organization_domains
+    (workos_organization_id, domain, is_primary, verified, source, created_at, updated_at)
+  SELECT
+    workos_organization_id,
+    domain,
+    TRUE,
+    FALSE,
+    'backfill_prospect_contact',
+    NOW(),
+    NOW()
+  FROM candidate
+  ON CONFLICT (domain) DO NOTHING
+  RETURNING workos_organization_id, domain
+)
+UPDATE organizations o
+SET email_domain = inserted.domain, updated_at = NOW()
+FROM inserted
+WHERE o.workos_organization_id = inserted.workos_organization_id
+  AND o.is_personal = FALSE
+  AND (o.email_domain IS NULL OR o.email_domain = '');

--- a/server/src/services/prospect.ts
+++ b/server/src/services/prospect.ts
@@ -10,11 +10,16 @@ import { createLogger } from '../logger.js';
 import { WorkOS, DomainDataState } from '@workos-inc/node';
 import { resolveOrgByDomain } from '../db/domain-resolution-db.js';
 import { researchDomain, trackBackground } from './brand-enrichment.js';
-import { linkDomain } from '../db/organization-domains-db.js';
+import { linkDomain, unlinkDomainAndReselectPrimary } from '../db/organization-domains-db.js';
 import { enrichOrganization } from './enrichment.js';
 import { isLushaConfigured } from './lusha.js';
 import { COMPANY_TYPE_VALUES } from '../config/company-types.js';
 import { VALID_REVENUE_TIERS } from '../db/organization-db.js';
+import { getCompanyDomain, isFreeEmailDomain } from '../utils/email-domain.js';
+import {
+  assertClaimableBrandDomain,
+  canonicalizeBrandDomain,
+} from './identifier-normalization.js';
 
 // Initialize WorkOS client if configured
 const workos =
@@ -30,6 +35,50 @@ const VALID_PROSPECT_STATUSES = [
   'prospect', 'contacted', 'responded', 'interested',
   'negotiating', 'joined', 'converted', 'declined', 'disqualified'
 ] as const;
+
+function normalizeExplicitDomain(domain: string): string {
+  const normalized = canonicalizeBrandDomain(domain);
+  assertClaimableBrandDomain(normalized);
+  if (isFreeEmailDomain(normalized)) {
+    throw new Error(`"${normalized}" is a free email provider domain and can't be claimed as a prospect domain.`);
+  }
+  return normalized;
+}
+
+function inferBusinessDomainFromContactEmail(email: string | undefined): string | null {
+  if (!email) return null;
+  const companyDomain = getCompanyDomain(email);
+  if (!companyDomain) return null;
+
+  const normalized = canonicalizeBrandDomain(companyDomain);
+  try {
+    assertClaimableBrandDomain(normalized);
+  } catch {
+    return null;
+  }
+  return normalized;
+}
+
+function normalizeProspectDomain(input: CreateProspectInput): string | null {
+  const explicit = input.domain?.trim();
+  if (explicit) return normalizeExplicitDomain(explicit);
+  return inferBusinessDomainFromContactEmail(input.prospect_contact_email);
+}
+
+function prospectDomainTrust(input: CreateProspectInput): {
+  source: 'import' | 'backfill_prospect_contact';
+  verified: boolean;
+  workosState: DomainDataState;
+} {
+  if (input.domain?.trim()) {
+    return { source: 'import', verified: true, workosState: DomainDataState.Verified };
+  }
+  return {
+    source: 'backfill_prospect_contact',
+    verified: false,
+    workosState: DomainDataState.Pending,
+  };
+}
 
 export interface CreateProspectInput {
   name: string;
@@ -87,8 +136,22 @@ export async function createProspect(
     };
   }
 
-  // Normalize domain to lowercase
-  const normalizedDomain = input.domain?.trim().toLowerCase() || null;
+  let normalizedDomain: string | null;
+  try {
+    normalizedDomain = normalizeProspectDomain(input);
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Invalid domain',
+    };
+  }
+
+  if (!normalizedDomain) {
+    return {
+      success: false,
+      error: 'A valid business domain or business contact email is required to create a prospect',
+    };
+  }
 
   // Check if domain resolves to an existing organization (exact, alias, sub-brand, or redirect)
   if (normalizedDomain) {
@@ -134,12 +197,11 @@ export async function createProspect(
   }
 
   try {
+    const domainTrust = prospectDomainTrust(input);
     // Create organization in WorkOS
     const workosOrg = await workos.organizations.createOrganization({
       name,
-      domainData: normalizedDomain
-        ? [{ domain: normalizedDomain, state: DomainDataState.Verified }]
-        : undefined,
+      domainData: [{ domain: normalizedDomain, state: domainTrust.workosState }],
     });
 
     logger.info(
@@ -172,7 +234,7 @@ export async function createProspect(
         workosOrg.id,
         name,
         input.company_type || null,
-        normalizedDomain,
+        null,
         input.prospect_status || 'prospect',
         input.prospect_source || 'manual',
         input.prospect_notes || null,
@@ -187,27 +249,33 @@ export async function createProspect(
 
     const org = result.rows[0];
 
-    if (normalizedDomain) {
-      await linkDomain({
-        orgId: workosOrg.id,
-        domain: normalizedDomain,
-        source: 'import',
-        verified: true,
-        isPrimary: true,
-      });
-
-      const bgPromise = researchDomain(normalizedDomain, { org_id: workosOrg.id }).catch((err) => {
-        logger.warn(
-          { err, domain: normalizedDomain, orgId: workosOrg.id },
-          'Background research failed for new prospect'
-        );
-      });
-      trackBackground(bgPromise);
+    const linkResult = await linkDomain({
+      orgId: workosOrg.id,
+      domain: normalizedDomain,
+      source: domainTrust.source,
+      verified: domainTrust.verified,
+      isPrimary: true,
+    });
+    if (linkResult.conflictOrgId) {
+      await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [workosOrg.id]);
+      return {
+        success: false,
+        alreadyExists: true,
+        error: `Domain ${normalizedDomain} is already linked to another organization (${linkResult.conflictOrgId})`,
+      };
     }
+
+    const bgPromise = researchDomain(normalizedDomain, { org_id: workosOrg.id }).catch((err) => {
+      logger.warn(
+        { err, domain: normalizedDomain, orgId: workosOrg.id },
+        'Background research failed for new prospect'
+      );
+    });
+    trackBackground(bgPromise);
 
     return {
       success: true,
-      organization: org,
+      organization: { ...org, email_domain: normalizedDomain },
     };
   } catch (error) {
     logger.error({ err: error, name }, 'Error creating prospect');
@@ -299,8 +367,8 @@ export async function updateProspect(
   const pool = getPool();
 
   // Verify org exists (and get existing notes for append mode)
-  const existing = await pool.query(
-    `SELECT name, prospect_notes FROM organizations WHERE workos_organization_id = $1`,
+  const existing = await pool.query<{ name: string; prospect_notes: string | null; email_domain: string | null }>(
+    `SELECT name, prospect_notes, email_domain FROM organizations WHERE workos_organization_id = $1`,
     [orgId]
   );
 
@@ -312,6 +380,8 @@ export async function updateProspect(
   const values: unknown[] = [];
   const fieldsChanged: string[] = [];
   let paramIndex = 1;
+  let domainToLink: string | null | undefined;
+  const previousDomain = existing.rows[0].email_domain?.trim().toLowerCase() || null;
 
   const updatableSet = new Set<string>(UPDATABLE_PROSPECT_FIELDS);
   const VALID_INTEREST_LEVELS = ['low', 'medium', 'high', 'very_high'];
@@ -384,23 +454,72 @@ export async function updateProspect(
       continue;
     }
 
+    if (key === 'email_domain') {
+      if (value === null || value === '') {
+        setClauses.push(`email_domain = $${paramIndex}`);
+        values.push(null);
+        paramIndex++;
+        fieldsChanged.push('email_domain');
+        domainToLink = null;
+        continue;
+      }
+
+      if (typeof value !== 'string') {
+        return { success: false, error: 'Invalid email_domain' };
+      }
+
+      try {
+        domainToLink = normalizeExplicitDomain(value);
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Invalid email_domain',
+        };
+      }
+      fieldsChanged.push('email_domain');
+      continue;
+    }
+
     setClauses.push(`${key} = $${paramIndex}`);
     values.push(value === '' ? null : value);
     paramIndex++;
     fieldsChanged.push(key);
   }
 
-  if (setClauses.length === 0) {
+  if (setClauses.length === 0 && domainToLink === undefined) {
     return { success: false, error: 'No valid fields to update' };
   }
 
-  setClauses.push('updated_at = NOW()');
-  values.push(orgId);
+  if (domainToLink) {
+    const linkResult = await linkDomain({
+      orgId,
+      domain: domainToLink,
+      source: 'admin_discovery',
+      verified: true,
+      isPrimary: true,
+    });
+    if (linkResult.conflictOrgId) {
+      return {
+        success: false,
+        error: `Domain ${domainToLink} is already linked to another organization (${linkResult.conflictOrgId})`,
+      };
+    }
+    if (previousDomain && previousDomain !== domainToLink) {
+      await unlinkDomainAndReselectPrimary({ orgId, domain: previousDomain });
+    }
+  } else if (domainToLink === null && previousDomain) {
+    await unlinkDomainAndReselectPrimary({ orgId, domain: previousDomain });
+  }
 
-  const result = await pool.query(
-    `UPDATE organizations SET ${setClauses.join(', ')} WHERE workos_organization_id = $${paramIndex} RETURNING *`,
-    values
-  );
+  const result = setClauses.length > 0
+    ? await pool.query(
+        `UPDATE organizations SET ${[...setClauses, 'updated_at = NOW()'].join(', ')} WHERE workos_organization_id = $${paramIndex} RETURNING *`,
+        [...values, orgId]
+      )
+    : await pool.query(
+        `SELECT * FROM organizations WHERE workos_organization_id = $1`,
+        [orgId]
+      );
 
   if (result.rows.length === 0) {
     return { success: false, error: 'Account not found' };

--- a/server/tests/integration/backfill-verified-orphan-prospect-domains.test.ts
+++ b/server/tests/integration/backfill-verified-orphan-prospect-domains.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Integration test for migration 521: repair fresh orphan prospects by
+ * backfilling an unverified primary organization_domains row from the original
+ * inbound/slack triage decision or a business contact email.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { findClaimableProspectOrgForDomain } from '../../src/db/org-filters.js';
+import type { Pool } from 'pg';
+
+const ORG_TRIAGE = 'org_521_triage_orphan_test';
+const ORG_CONTACT = 'org_521_contact_orphan_test';
+const ORG_CONFLICT = 'org_521_conflict_orphan_test';
+const ORG_OWNER = 'org_521_owner_test';
+const ORG_FREE = 'org_521_free_test';
+
+const TEST_ORGS = [ORG_TRIAGE, ORG_CONTACT, ORG_CONFLICT, ORG_OWNER, ORG_FREE];
+const TEST_DOMAINS = [
+  'triage-orphan.test',
+  'contact-orphan.test',
+  'already-owned-521.test',
+  'gmail.com',
+  'uol.com.br',
+];
+
+const MIGRATION_SQL = readFileSync(
+  resolve(__dirname, '../../src/db/migrations/521_backfill_verified_orphan_prospect_domains.sql'),
+  'utf8',
+);
+
+async function cleanup(pool: Pool) {
+  await pool.query('DELETE FROM prospect_triage_log WHERE domain = ANY($1)', [TEST_DOMAINS]);
+  await pool.query('DELETE FROM organization_domains WHERE workos_organization_id = ANY($1)', [TEST_ORGS]);
+  await pool.query('DELETE FROM organization_domains WHERE domain = ANY($1)', [TEST_DOMAINS]);
+  await pool.query('DELETE FROM organizations WHERE workos_organization_id = ANY($1)', [TEST_ORGS]);
+}
+
+async function seedOrg(
+  pool: Pool,
+  orgId: string,
+  opts: {
+    name?: string;
+    prospect_source?: string | null;
+    prospect_contact_email?: string | null;
+    email_domain?: string | null;
+  } = {},
+) {
+  await pool.query(
+    `INSERT INTO organizations (
+       workos_organization_id, name, is_personal, email_domain,
+       prospect_source, prospect_contact_email, created_at, updated_at
+     ) VALUES ($1, $2, false, $3, $4, $5, NOW(), NOW())`,
+    [
+      orgId,
+      opts.name ?? `Org ${orgId}`,
+      opts.email_domain ?? null,
+      opts.prospect_source ?? 'inbound',
+      opts.prospect_contact_email ?? null,
+    ],
+  );
+}
+
+async function seedDomain(pool: Pool, orgId: string, domain: string) {
+  await pool.query(
+    `INSERT INTO organization_domains
+       (workos_organization_id, domain, is_primary, verified, source, created_at, updated_at)
+     VALUES ($1, $2, TRUE, TRUE, 'workos', NOW(), NOW())`,
+    [orgId, domain],
+  );
+}
+
+async function seedTriageLog(pool: Pool, opts: { domain: string; company_name: string; source?: string }) {
+  await pool.query(
+    `INSERT INTO prospect_triage_log
+       (domain, action, reason, owner, priority, verdict, company_name, source, enriched, created_at)
+     VALUES ($1, 'create', 'test', 'human', 'standard', 'test', $2, $3, false, NOW())`,
+    [opts.domain, opts.company_name, opts.source ?? 'inbound'],
+  );
+}
+
+async function readOrg(pool: Pool, orgId: string) {
+  const r = await pool.query<{ email_domain: string | null }>(
+    'SELECT email_domain FROM organizations WHERE workos_organization_id = $1',
+    [orgId],
+  );
+  return r.rows[0] ?? null;
+}
+
+async function readDomains(pool: Pool, orgId: string) {
+  const r = await pool.query<{ domain: string; is_primary: boolean; verified: boolean; source: string }>(
+    'SELECT domain, is_primary, verified, source FROM organization_domains WHERE workos_organization_id = $1',
+    [orgId],
+  );
+  return r.rows;
+}
+
+describe('migration 521: backfill orphan prospect domains', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString:
+        process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  }, 60000);
+
+  afterAll(async () => {
+    await cleanup(pool);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanup(pool);
+  });
+
+  it('backfills an unverified primary domain row from a matching inbound triage log', async () => {
+    await seedOrg(pool, ORG_TRIAGE, { name: 'Triage Prospect', prospect_source: 'inbound' });
+    await seedTriageLog(pool, {
+      company_name: 'Triage Prospect',
+      domain: 'triage-orphan.test',
+      source: 'inbound',
+    });
+
+    await pool.query(MIGRATION_SQL);
+
+    expect((await readOrg(pool, ORG_TRIAGE))?.email_domain).toBe('triage-orphan.test');
+    expect(await readDomains(pool, ORG_TRIAGE)).toEqual([
+      {
+        domain: 'triage-orphan.test',
+        is_primary: true,
+        verified: false,
+        source: 'backfill_prospect_contact',
+      },
+    ]);
+    expect((await findClaimableProspectOrgForDomain('triage-orphan.test'))?.organization_id).toBe(ORG_TRIAGE);
+  });
+
+  it('prefers a business contact email domain when present', async () => {
+    await seedOrg(pool, ORG_CONTACT, {
+      name: 'Contact Prospect',
+      prospect_source: 'inbound',
+      prospect_contact_email: 'buyer@contact-orphan.test',
+    });
+    await seedTriageLog(pool, {
+      company_name: 'Contact Prospect',
+      domain: 'triage-orphan.test',
+      source: 'inbound',
+    });
+
+    await pool.query(MIGRATION_SQL);
+
+    expect((await readOrg(pool, ORG_CONTACT))?.email_domain).toBe('contact-orphan.test');
+    const domains = await readDomains(pool, ORG_CONTACT);
+    expect(domains).toHaveLength(1);
+    expect(domains[0]).toMatchObject({
+      domain: 'contact-orphan.test',
+      verified: false,
+      source: 'backfill_prospect_contact',
+    });
+  });
+
+  it('does not steal a domain already owned by another organization', async () => {
+    await seedOrg(pool, ORG_OWNER, {
+      name: 'Existing Owner',
+      email_domain: 'already-owned-521.test',
+      prospect_source: null,
+    });
+    await seedDomain(pool, ORG_OWNER, 'already-owned-521.test');
+
+    await seedOrg(pool, ORG_CONFLICT, { name: 'Conflicting Prospect', prospect_source: 'inbound' });
+    await seedTriageLog(pool, {
+      company_name: 'Conflicting Prospect',
+      domain: 'already-owned-521.test',
+      source: 'inbound',
+    });
+
+    await pool.query(MIGRATION_SQL);
+
+    expect((await readOrg(pool, ORG_CONFLICT))?.email_domain).toBeNull();
+    expect(await readDomains(pool, ORG_CONFLICT)).toHaveLength(0);
+    expect((await readOrg(pool, ORG_OWNER))?.email_domain).toBe('already-owned-521.test');
+  });
+
+  it('skips free-email domains from triage logs', async () => {
+    await seedOrg(pool, ORG_FREE, { name: 'Free Email Prospect', prospect_source: 'inbound' });
+    await seedTriageLog(pool, {
+      company_name: 'Free Email Prospect',
+      domain: 'uol.com.br',
+      source: 'inbound',
+    });
+
+    await pool.query(MIGRATION_SQL);
+
+    expect((await readOrg(pool, ORG_FREE))?.email_domain).toBeNull();
+    expect(await readDomains(pool, ORG_FREE)).toHaveLength(0);
+  });
+
+  it('falls back to the triage domain when the contact email domain is a public mailbox', async () => {
+    await seedOrg(pool, ORG_CONTACT, {
+      name: 'Mailbox Contact Prospect',
+      prospect_source: 'inbound',
+      prospect_contact_email: 'luiz@uol.com.br',
+    });
+    await seedTriageLog(pool, {
+      company_name: 'Mailbox Contact Prospect',
+      domain: 'contact-orphan.test',
+      source: 'inbound',
+    });
+
+    await pool.query(MIGRATION_SQL);
+
+    expect((await readOrg(pool, ORG_CONTACT))?.email_domain).toBe('contact-orphan.test');
+    const domains = await readDomains(pool, ORG_CONTACT);
+    expect(domains).toHaveLength(1);
+    expect(domains[0]).toMatchObject({
+      domain: 'contact-orphan.test',
+      verified: false,
+      source: 'backfill_prospect_contact',
+    });
+  });
+});

--- a/server/tests/integration/prospect-domain-conflict.test.ts
+++ b/server/tests/integration/prospect-domain-conflict.test.ts
@@ -21,6 +21,8 @@ const {
   TAKEN_DOMAIN,
   FRESH_DOMAIN,
   RACE_DOMAIN,
+  CONTACT_DOMAIN,
+  UPDATE_DOMAIN,
   mockCreateOrganization,
   mockResolveOrgByDomain,
 } = vi.hoisted(() => {
@@ -32,6 +34,8 @@ const {
     TAKEN_DOMAIN: 'taken-by-original.test',
     FRESH_DOMAIN: 'fresh-domain-for-prospect.test',
     RACE_DOMAIN: 'race-conflict.test',
+    CONTACT_DOMAIN: 'contact-only-prospect.test',
+    UPDATE_DOMAIN: 'updated-prospect-domain.test',
     mockCreateOrganization: vi.fn(),
     mockResolveOrgByDomain: vi.fn(),
   };
@@ -68,11 +72,11 @@ vi.mock('../../src/services/lusha.js', () => ({
 
 import { initializeDatabase, closeDatabase, getPool } from '../../src/db/client.js';
 import { runMigrations } from '../../src/db/migrate.js';
-import { createProspect } from '../../src/services/prospect.js';
+import { createProspect, updateProspect } from '../../src/services/prospect.js';
 import type { Pool } from 'pg';
 
 const TEST_ORGS = [EXISTING_ORG_ID, PROSPECT_ORG_ID];
-const TEST_DOMAINS = [TAKEN_DOMAIN, FRESH_DOMAIN, RACE_DOMAIN];
+const TEST_DOMAINS = [TAKEN_DOMAIN, FRESH_DOMAIN, RACE_DOMAIN, CONTACT_DOMAIN, UPDATE_DOMAIN];
 
 async function clearFixtures(pool: Pool) {
   await pool.query('DELETE FROM organization_domains WHERE workos_organization_id = ANY($1)', [TEST_ORGS]);
@@ -161,8 +165,9 @@ describe('createProspect domain conflict handling (#4321)', () => {
       prospect_source: 'manual',
     });
 
-    // Org-level creation succeeded — only the domain link was rejected.
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
+    expect(result.alreadyExists).toBe(true);
+    expect(result.error).toContain('already linked');
 
     const row = await pool.query(
       `SELECT workos_organization_id, is_primary, source
@@ -174,12 +179,18 @@ describe('createProspect domain conflict handling (#4321)', () => {
     expect(row.rows[0].is_primary).toBe(true);
     expect(row.rows[0].source).toBe('workos');
 
-    // Prospect org exists in organizations but has no domain link.
+    // Prospect org was not persisted locally with a conflicting email_domain.
     const prospectDomains = await pool.query(
       `SELECT domain FROM organization_domains WHERE workos_organization_id = $1`,
       [PROSPECT_ORG_ID],
     );
     expect(prospectDomains.rowCount).toBe(0);
+
+    const prospectOrg = await pool.query(
+      `SELECT email_domain FROM organizations WHERE workos_organization_id = $1`,
+      [PROSPECT_ORG_ID],
+    );
+    expect(prospectOrg.rowCount).toBe(0);
   });
 
   it('inserts a new organization_domains row for a fresh domain (no conflict)', async () => {
@@ -201,5 +212,77 @@ describe('createProspect domain conflict handling (#4321)', () => {
     expect(row.rows[0].is_primary).toBe(true);
     expect(row.rows[0].verified).toBe(true);
     expect(row.rows[0].source).toBe('import');
+  });
+
+  it('infers and verifies the domain from a business contact email when domain is omitted', async () => {
+    const result = await createProspect({
+      name: 'Contact Only Prospect',
+      prospect_contact_email: `buyer@${CONTACT_DOMAIN}`,
+      prospect_source: 'inbound',
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockCreateOrganization).toHaveBeenCalledWith({
+      name: 'Contact Only Prospect',
+      domainData: [{ domain: CONTACT_DOMAIN, state: 'pending' }],
+    });
+
+    const org = await pool.query(
+      `SELECT email_domain FROM organizations WHERE workos_organization_id = $1`,
+      [PROSPECT_ORG_ID],
+    );
+    expect(org.rows[0].email_domain).toBe(CONTACT_DOMAIN);
+
+    const row = await pool.query(
+      `SELECT workos_organization_id, is_primary, verified, source
+         FROM organization_domains WHERE domain = $1`,
+      [CONTACT_DOMAIN],
+    );
+    expect(row.rowCount).toBe(1);
+    expect(row.rows[0]).toMatchObject({
+      workos_organization_id: PROSPECT_ORG_ID,
+      is_primary: true,
+      verified: false,
+      source: 'backfill_prospect_contact',
+    });
+  });
+
+  it('rejects prospect creation when neither a domain nor business contact email is present', async () => {
+    const result = await createProspect({
+      name: 'No Domain Prospect',
+      prospect_source: 'manual',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('business domain');
+    expect(mockCreateOrganization).not.toHaveBeenCalled();
+  });
+
+  it('mirrors admin email_domain updates into a verified primary organization_domains row', async () => {
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at, updated_at)
+       VALUES ($1, $2, false, NOW(), NOW())`,
+      [PROSPECT_ORG_ID, 'Update Domain Prospect'],
+    );
+
+    const result = await updateProspect(PROSPECT_ORG_ID, {
+      fields: { email_domain: UPDATE_DOMAIN },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.updated?.email_domain).toBe(UPDATE_DOMAIN);
+
+    const row = await pool.query(
+      `SELECT workos_organization_id, is_primary, verified, source
+         FROM organization_domains WHERE domain = $1`,
+      [UPDATE_DOMAIN],
+    );
+    expect(row.rowCount).toBe(1);
+    expect(row.rows[0]).toMatchObject({
+      workos_organization_id: PROSPECT_ORG_ID,
+      is_primary: true,
+      verified: true,
+      source: 'admin_discovery',
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Harden prospect creation so inbound/admin prospects must include either a claimable business domain or a business contact email that can infer one.
- Route all prospect domain writes through `linkDomain`, including conflict handling, primary-domain sync, and cleanup when admin updates replace or clear a prospect domain.
- Add migration 521 to backfill orphan prospect orgs with unverified primary domain hints from contact emails or matching triage logs while skipping public/shared mailbox domains, including UOL.
- Keep proofless inferred/backfilled domains unverified/pending instead of marking them verified.

## Root Cause

Production showed the UOL prospect was created on 2026-06-19 by Addie/manual inbound flow with a contact name/title but no contact email, no domain, no members, no Stripe, and no existing `organization_domains` row. The prior `createProspect` path accepted that placeholder and inserted an org that future `@domain` signups could never auto-link to because `findPayingOrgForDomain` only works from `organization_domains`/`email_domain`.

## Validation

- Code-reviewer, security-reviewer, and Node.js testing expert agents reviewed the patch; their findings were addressed.
- `npm exec vitest run server/tests/integration/prospect-domain-conflict.test.ts server/tests/integration/backfill-verified-orphan-prospect-domains.test.ts --config server/vitest.config.ts`
- `npm run typecheck`
- `npm run test:migrations`
- Precommit hook: `npm run test:unit` and `npm run typecheck`
- Push hook: version sync, changeset policy, storyboard/doc skips
