### PR TITLE
[codex] Dedupe escalation SLA reminders

### DIFF
--- a/server/src/addie/jobs/escalation-sla.ts
+++ b/server/src/addie/jobs/escalation-sla.ts
@@ -9,6 +9,7 @@
  */
 
 import { createLogger } from '../../logger.js';
+import { getClient } from '../../db/client.js';
 import {
   addSystemEscalationUpdate,
   describeEscalationSla,
@@ -23,6 +24,13 @@ const logger = createLogger('escalation-sla');
 
 const SUPPORT_EMAIL = 'support@agenticadvertising.org';
 
+/**
+ * Session-scoped advisory lock key for the SLA job. Prevents multi-process
+ * deploys or overlapping scheduler ticks from selecting the same due
+ * escalations and posting duplicate Slack follow-ups.
+ */
+const SLA_JOB_LOCK_ID = 8136735768681787317n;
+
 export interface EscalationSlaJobOptions {
   limit?: number;
   now?: Date;
@@ -35,6 +43,7 @@ export interface EscalationSlaJobResult {
   requester_dm_sent: number;
   skipped_no_channel: number;
   errors: number;
+  locked_out?: boolean;
 }
 
 function hoursBetween(start: Date | string | null | undefined, end: Date): number {
@@ -95,12 +104,8 @@ function requesterUpdateText(escalation: Escalation): string {
 export async function runEscalationSlaJob(
   options: EscalationSlaJobOptions = {},
 ): Promise<EscalationSlaJobResult> {
-  const now = options.now ?? new Date();
-  const rows = await listEscalationsForSlaEnforcement(options.limit ?? 50);
-  const channel = await getEscalationChannel();
-
   const result: EscalationSlaJobResult = {
-    scanned: rows.length,
+    scanned: 0,
     admin_alerted: 0,
     requester_updated: 0,
     requester_dm_sent: 0,
@@ -108,79 +113,117 @@ export async function runEscalationSlaJob(
     errors: 0,
   };
 
-  for (const escalation of rows) {
-    const adminDue = isAdminAlertDue(escalation, now);
-    const requesterDue = isRequesterUpdateDue(escalation, now);
-    let adminNotified = false;
-    let requesterNotified = false;
+  const client = await getClient();
+  let haveLock = false;
+  try {
+    const lockRes = await client.query<{ pg_try_advisory_lock: boolean }>(
+      'SELECT pg_try_advisory_lock($1) AS pg_try_advisory_lock',
+      [SLA_JOB_LOCK_ID.toString()],
+    );
+    haveLock = lockRes.rows[0]?.pg_try_advisory_lock === true;
+    if (!haveLock) {
+      logger.warn('escalation-sla: another run is already holding the advisory lock - refusing');
+      result.locked_out = true;
+      return result;
+    }
 
-    if (adminDue) {
-      if (!channel.channel_id) {
-        result.skipped_no_channel += 1;
-      } else {
-        try {
-          const threadTs = escalation.notification_channel_id === channel.channel_id
-            ? escalation.notification_message_ts || undefined
-            : undefined;
-          const sent = await sendChannelMessage(
-            channel.channel_id,
-            {
-              text: adminAlertText(escalation, now),
-              thread_ts: threadTs,
-            },
-            { requirePrivate: true },
-          );
-          if (sent.ok) {
-            adminNotified = true;
-            result.admin_alerted += 1;
-          } else {
-            result.errors += 1;
-            logger.warn(
-              { escalationId: escalation.id, channelId: channel.channel_id, error: sent.error },
-              'Failed to send escalation SLA admin alert',
+    const now = options.now ?? new Date();
+    const rows = await listEscalationsForSlaEnforcement(options.limit ?? 50);
+    const channel = await getEscalationChannel();
+    result.scanned = rows.length;
+
+    for (const escalation of rows) {
+      const adminDue = isAdminAlertDue(escalation, now);
+      const requesterDue = isRequesterUpdateDue(escalation, now);
+      let adminNotified = false;
+      let requesterNotified = false;
+
+      if (adminDue) {
+        if (!channel.channel_id) {
+          result.skipped_no_channel += 1;
+        } else {
+          try {
+            const threadTs = escalation.notification_channel_id === channel.channel_id
+              ? escalation.notification_message_ts || undefined
+              : undefined;
+            const sent = await sendChannelMessage(
+              channel.channel_id,
+              {
+                text: adminAlertText(escalation, now),
+                thread_ts: threadTs,
+              },
+              { requirePrivate: true },
             );
+            if (sent.ok) {
+              adminNotified = true;
+              result.admin_alerted += 1;
+            } else {
+              result.errors += 1;
+              logger.warn(
+                { escalationId: escalation.id, channelId: channel.channel_id, error: sent.error },
+                'Failed to send escalation SLA admin alert',
+              );
+            }
+          } catch (err) {
+            result.errors += 1;
+            logger.warn({ err, escalationId: escalation.id }, 'Escalation SLA admin alert threw');
+          }
+        }
+      }
+
+      if (requesterDue) {
+        const body = requesterUpdateText(escalation);
+        try {
+          const update = await addSystemEscalationUpdate(escalation.id, body, true);
+          if (update) {
+            requesterNotified = true;
+            result.requester_updated += 1;
+          }
+          if (escalation.slack_user_id) {
+            const dm = await sendDirectMessage(escalation.slack_user_id, { text: body });
+            if (dm.ok) result.requester_dm_sent += 1;
           }
         } catch (err) {
           result.errors += 1;
-          logger.warn({ err, escalationId: escalation.id }, 'Escalation SLA admin alert threw');
+          logger.warn({ err, escalationId: escalation.id }, 'Failed to write requester SLA update');
         }
+      }
+
+      if (adminNotified || requesterNotified) {
+        await markEscalationSlaNotified(escalation.id, {
+          admin: adminNotified,
+          requester: requesterNotified,
+        });
       }
     }
 
-    if (requesterDue) {
-      const body = requesterUpdateText(escalation);
+    if (
+      result.admin_alerted > 0 ||
+      result.requester_updated > 0 ||
+      result.skipped_no_channel > 0 ||
+      result.errors > 0
+    ) {
+      logger.info(result, 'Escalation SLA job completed');
+    }
+
+    return result;
+  } finally {
+    let destroyClient = false;
+    if (haveLock) {
       try {
-        const update = await addSystemEscalationUpdate(escalation.id, body, true);
-        if (update) {
-          requesterNotified = true;
-          result.requester_updated += 1;
-        }
-        if (escalation.slack_user_id) {
-          const dm = await sendDirectMessage(escalation.slack_user_id, { text: body });
-          if (dm.ok) result.requester_dm_sent += 1;
+        const unlockRes = await client.query<{ pg_advisory_unlock: boolean }>(
+          'SELECT pg_advisory_unlock($1) AS pg_advisory_unlock',
+          [SLA_JOB_LOCK_ID.toString()],
+        );
+        destroyClient = unlockRes.rows[0]?.pg_advisory_unlock !== true;
+        if (destroyClient) {
+          logger.warn('escalation-sla: advisory unlock returned false - destroying client');
         }
       } catch (err) {
-        result.errors += 1;
-        logger.warn({ err, escalationId: escalation.id }, 'Failed to write requester SLA update');
+        destroyClient = true;
+        logger.warn({ err }, 'escalation-sla: failed to release advisory lock - destroying client');
       }
     }
-
-    if (adminNotified || requesterNotified) {
-      await markEscalationSlaNotified(escalation.id, {
-        admin: adminNotified,
-        requester: requesterNotified,
-      });
-    }
+    client.release(destroyClient);
   }
-
-  if (
-    result.admin_alerted > 0 ||
-    result.requester_updated > 0 ||
-    result.skipped_no_channel > 0 ||
-    result.errors > 0
-  ) {
-    logger.info(result, 'Escalation SLA job completed');
-  }
-
-  return result;
 }

--- a/server/tests/unit/escalation-sla.test.ts
+++ b/server/tests/unit/escalation-sla.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const client = {
+    query: vi.fn(),
+    release: vi.fn(),
+  };
+
+  return {
+    client,
+    getClient: vi.fn(async () => client),
+    addSystemEscalationUpdate: vi.fn(),
+    describeEscalationSla: vi.fn(),
+    listEscalationsForSlaEnforcement: vi.fn(),
+    markEscalationSlaNotified: vi.fn(),
+    getEscalationChannel: vi.fn(),
+    sendChannelMessage: vi.fn(),
+    sendDirectMessage: vi.fn(),
+  };
+});
+
+vi.mock('../../src/db/client.js', () => ({
+  getClient: mocks.getClient,
+}));
+
+vi.mock('../../src/db/escalation-db.js', () => ({
+  addSystemEscalationUpdate: mocks.addSystemEscalationUpdate,
+  describeEscalationSla: mocks.describeEscalationSla,
+  listEscalationsForSlaEnforcement: mocks.listEscalationsForSlaEnforcement,
+  markEscalationSlaNotified: mocks.markEscalationSlaNotified,
+}));
+
+vi.mock('../../src/db/system-settings-db.js', () => ({
+  getEscalationChannel: mocks.getEscalationChannel,
+}));
+
+vi.mock('../../src/slack/client.js', () => ({
+  sendChannelMessage: mocks.sendChannelMessage,
+  sendDirectMessage: mocks.sendDirectMessage,
+}));
+
+import { runEscalationSlaJob } from '../../src/addie/jobs/escalation-sla.js';
+
+function makeEscalation(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 15,
+    thread_id: null,
+    message_id: null,
+    slack_user_id: null,
+    workos_user_id: null,
+    user_display_name: 'Jane Doe',
+    user_email: 'jane@example.com',
+    user_slack_handle: null,
+    category: 'needs_human_action',
+    priority: 'normal',
+    summary: 'Needs help with account setup',
+    original_request: null,
+    addie_context: null,
+    notification_channel_id: 'CADMIN',
+    notification_sent_at: new Date('2026-06-18T09:00:00Z'),
+    notification_message_ts: '1718710800.000000',
+    status: 'open',
+    resolved_by: null,
+    resolved_at: null,
+    resolution_notes: null,
+    perspective_id: null,
+    perspective_slug: null,
+    github_issue_url: null,
+    github_issue_number: null,
+    github_issue_repo: null,
+    dedup_key: null,
+    sla_admin_last_notified_at: null,
+    sla_requester_last_notified_at: null,
+    sla_follow_up_count: 0,
+    created_at: new Date('2026-06-18T09:00:00Z'),
+    updated_at: new Date('2026-06-18T09:00:00Z'),
+    ...overrides,
+  };
+}
+
+describe('runEscalationSlaJob', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.getClient.mockResolvedValue(mocks.client);
+    mocks.client.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('pg_try_advisory_lock')) {
+        return { rows: [{ pg_try_advisory_lock: true }] };
+      }
+      if (sql.includes('pg_advisory_unlock')) {
+        return { rows: [{ pg_advisory_unlock: true }] };
+      }
+      return { rows: [] };
+    });
+    mocks.describeEscalationSla.mockReturnValue({
+      age_hours: 25,
+      hours_since_update: 25,
+      needs_follow_up: true,
+      label: 'Needs pickup',
+      threshold_hours: 24,
+    });
+    mocks.listEscalationsForSlaEnforcement.mockResolvedValue([]);
+    mocks.getEscalationChannel.mockResolvedValue({ channel_id: 'CADMIN', channel_name: 'aao-admin' });
+    mocks.sendChannelMessage.mockResolvedValue({ ok: true, ts: '1718800000.000000' });
+    mocks.sendDirectMessage.mockResolvedValue({ ok: true });
+    mocks.addSystemEscalationUpdate.mockResolvedValue({ id: 1 });
+  });
+
+  it('does not scan or send when another SLA run holds the advisory lock', async () => {
+    mocks.client.query.mockResolvedValueOnce({ rows: [{ pg_try_advisory_lock: false }] });
+
+    const result = await runEscalationSlaJob();
+
+    expect(result).toEqual({
+      scanned: 0,
+      admin_alerted: 0,
+      requester_updated: 0,
+      requester_dm_sent: 0,
+      skipped_no_channel: 0,
+      errors: 0,
+      locked_out: true,
+    });
+    expect(mocks.listEscalationsForSlaEnforcement).not.toHaveBeenCalled();
+    expect(mocks.getEscalationChannel).not.toHaveBeenCalled();
+    expect(mocks.sendChannelMessage).not.toHaveBeenCalled();
+    expect(mocks.markEscalationSlaNotified).not.toHaveBeenCalled();
+    expect(mocks.client.release).toHaveBeenCalledWith(false);
+    expect(mocks.client.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('posts due reminders and releases the advisory lock', async () => {
+    mocks.listEscalationsForSlaEnforcement.mockResolvedValue([
+      makeEscalation(),
+    ]);
+
+    const result = await runEscalationSlaJob({
+      now: new Date('2026-06-19T10:00:00Z'),
+    });
+
+    expect(result).toEqual({
+      scanned: 1,
+      admin_alerted: 1,
+      requester_updated: 1,
+      requester_dm_sent: 0,
+      skipped_no_channel: 0,
+      errors: 0,
+    });
+    expect(mocks.sendChannelMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.sendChannelMessage).toHaveBeenCalledWith(
+      'CADMIN',
+      expect.objectContaining({
+        text: expect.stringContaining('Escalation SLA follow-up needed: #15'),
+        thread_ts: '1718710800.000000',
+      }),
+      { requirePrivate: true },
+    );
+    expect(mocks.addSystemEscalationUpdate).toHaveBeenCalledWith(
+      15,
+      expect.stringContaining('support request #15'),
+      true,
+    );
+    expect(mocks.markEscalationSlaNotified).toHaveBeenCalledWith(15, {
+      admin: true,
+      requester: true,
+    });
+    const lockCall = mocks.client.query.mock.calls.find(([sql]) =>
+      String(sql).includes('pg_try_advisory_lock'),
+    );
+    const unlockCall = mocks.client.query.mock.calls.find(([sql]) =>
+      String(sql).includes('pg_advisory_unlock'),
+    );
+    expect(unlockCall).toEqual([
+      'SELECT pg_advisory_unlock($1) AS pg_advisory_unlock',
+      lockCall?.[1],
+    ]);
+    expect(mocks.client.release).toHaveBeenCalledWith(false);
+  });
+
+  it('releases the advisory lock when the run fails after acquiring it', async () => {
+    const error = new Error('db unavailable');
+    mocks.listEscalationsForSlaEnforcement.mockRejectedValue(error);
+
+    await expect(runEscalationSlaJob()).rejects.toThrow('db unavailable');
+
+    expect(mocks.client.query).toHaveBeenCalledWith(
+      'SELECT pg_advisory_unlock($1) AS pg_advisory_unlock',
+      expect.any(Array),
+    );
+    expect(mocks.client.release).toHaveBeenCalledWith(false);
+  });
+
+  it('destroys the client when advisory unlock fails', async () => {
+    mocks.client.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('pg_try_advisory_lock')) {
+        return { rows: [{ pg_try_advisory_lock: true }] };
+      }
+      if (sql.includes('pg_advisory_unlock')) {
+        throw new Error('network reset');
+      }
+      return { rows: [] };
+    });
+
+    const result = await runEscalationSlaJob();
+
+    expect(result.scanned).toBe(0);
+    expect(mocks.client.release).toHaveBeenCalledWith(true);
+  });
+
+  it('destroys the client when advisory unlock returns false', async () => {
+    mocks.client.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('pg_try_advisory_lock')) {
+        return { rows: [{ pg_try_advisory_lock: true }] };
+      }
+      if (sql.includes('pg_advisory_unlock')) {
+        return { rows: [{ pg_advisory_unlock: false }] };
+      }
+      return { rows: [] };
+    });
+
+    const result = await runEscalationSlaJob();
+
+    expect(result.scanned).toBe(0);
+    expect(mocks.client.release).toHaveBeenCalledWith(true);
+  });
+});

--- a/tests/addie/escalation-sla-job.test.ts
+++ b/tests/addie/escalation-sla-job.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const {
   mockAddSystemEscalationUpdate,
   mockGetEscalationChannel,
+  mockGetClient,
+  mockDbClient,
   mockListEscalationsForSlaEnforcement,
   mockMarkEscalationSlaNotified,
   mockSendChannelMessage,
@@ -10,10 +12,19 @@ const {
 } = vi.hoisted(() => ({
   mockAddSystemEscalationUpdate: vi.fn<any>(),
   mockGetEscalationChannel: vi.fn<any>(),
+  mockDbClient: {
+    query: vi.fn<any>(),
+    release: vi.fn<any>(),
+  },
+  mockGetClient: vi.fn<any>(),
   mockListEscalationsForSlaEnforcement: vi.fn<any>(),
   mockMarkEscalationSlaNotified: vi.fn<any>(),
   mockSendChannelMessage: vi.fn<any>(),
   mockSendDirectMessage: vi.fn<any>(),
+}));
+
+vi.mock('../../server/src/db/client.js', () => ({
+  getClient: () => mockGetClient(),
 }));
 
 vi.mock('../../server/src/db/escalation-db.js', () => ({
@@ -71,12 +82,25 @@ function escalation(overrides: Partial<any> = {}) {
 
 beforeEach(() => {
   mockAddSystemEscalationUpdate.mockReset();
+  mockDbClient.query.mockReset();
+  mockDbClient.release.mockReset();
+  mockGetClient.mockReset();
   mockGetEscalationChannel.mockReset();
   mockListEscalationsForSlaEnforcement.mockReset();
   mockMarkEscalationSlaNotified.mockReset();
   mockSendChannelMessage.mockReset();
   mockSendDirectMessage.mockReset();
 
+  mockGetClient.mockResolvedValue(mockDbClient);
+  mockDbClient.query.mockImplementation(async (sql: string) => {
+    if (sql.includes('pg_try_advisory_lock')) {
+      return { rows: [{ pg_try_advisory_lock: true }] };
+    }
+    if (sql.includes('pg_advisory_unlock')) {
+      return { rows: [{ pg_advisory_unlock: true }] };
+    }
+    return { rows: [] };
+  });
   mockGetEscalationChannel.mockResolvedValue({ channel_id: 'C_NEW' });
   mockSendChannelMessage.mockResolvedValue({ ok: true, ts: '1710000001.000' });
 });


### PR DESCRIPTION
## Summary

Fixes duplicate Addie escalation SLA reminders caused by concurrent scheduled job runs selecting the same due escalations before notification bookkeeping is updated.

- wraps `runEscalationSlaJob` in a Postgres session advisory lock so only one worker processes a reminder cycle at a time
- returns `locked_out: true` for skipped concurrent runs without scanning or sending
- confirms advisory unlock and destroys the pooled client if unlock is not confirmed, avoiding pinned session locks
- adds unit coverage for locked-out runs, successful send/mark/unlock, mid-run failure cleanup, unlock failure, unlock false, and existing thread behavior

## Root Cause

The SLA job queried due escalations, posted Slack/admin reminders, then updated SLA notification state. In multi-process or overlapping scheduler scenarios, two runs could select the same due rows before either run recorded `sla_admin_last_notified_at`, producing duplicate Slack messages for the same escalation IDs.

## Validation

- `npx vitest run server/tests/unit/escalation-sla.test.ts`
- `npx vitest run tests/addie/escalation-sla-job.test.ts`
- Docker/Postgres smoke: compose Postgres 16 + real `pg_advisory_lock` held on one session, actual `runEscalationSlaJob()` returned `locked_out: true` with `scanned: 0`
- `npm run test:server-unit`
- `npm run build`
- pre-commit hook: `npm run test:unit`, `npm run test:test-dynamic-imports`, `npm run test:callapi-state-change`, `npm run precommit:server-unit`, `npm run typecheck`

## Review

Read-only expert reviews were run for code quality, Node.js testing, and security/reliability. The actionable lock-cleanup and test-coverage findings were addressed before this PR.
