### PR TITLE
fix(addie): scrub internal dollar amounts from cost-cap message

### DIFF
--- a/server/src/addie/claude-cost-tracker.ts
+++ b/server/src/addie/claude-cost-tracker.ts
@@ -241,25 +241,12 @@ export function formatCapExceededMessage(result: CostCheckResult): string {
   if (tier === 'aao_team') {
     return 'AAO team usage is uncapped.';
   }
-  const capUsd = DAILY_BUDGET_USD[tier];
-  const spentUsd = ((result.spentCents ?? 0) / 100).toFixed(2);
-  // Render the wait as hours when a user trips the cap early in the
-  // window — "reset in ~1440 minutes" reads as noise. Minutes only
-  // below 2 hours; rounded hours beyond that. The number is already
-  // approximate (the user can retry sooner as individual charges
-  // drop out), so hours-as-round-numbers is honest.
-  const retryMs = result.retryAfterMs ?? 60_000;
-  const retryMinutes = Math.max(1, Math.ceil(retryMs / 60_000));
-  const humanReset = retryMinutes >= 120
-    ? `~${Math.ceil(retryMinutes / 60)} hour${retryMinutes >= 180 ? 's' : ''}`
-    : `~${retryMinutes} minute${retryMinutes === 1 ? '' : 's'}`;
   return (
-    `You've hit today's Claude API usage cap (${capUsd} USD) — ` +
-    `spent ≈ $${spentUsd} in the last 24 hours. ` +
-    `You can try again in ${humanReset}. ` +
+    `You've reached your daily conversation limit with Addie. ` +
+    `Please try again tomorrow. ` +
     (tier === 'member_paid'
       ? 'Ping the AgenticAdvertising.org team if you need a higher ceiling for legitimate work.'
-      : 'Upgrade your membership at /membership for a higher daily ceiling.')
+      : 'Upgrade your membership at https://agenticadvertising.org/dashboard/membership for a higher daily limit.')
   );
 }
 

--- a/server/src/db/organization-db.ts
+++ b/server/src/db/organization-db.ts
@@ -546,8 +546,8 @@ export async function canAddSeat(
     const used = seatType === 'contributor' ? usage.contributor : usage.community_only;
 
     if (limit === -1) return { allowed: true };
-    if (limit === 0) return { allowed: false, reason: `Your membership tier does not include ${seatType === 'contributor' ? 'contributor' : 'community'} seats. Upgrade at /membership.` };
-    if (used >= limit) return { allowed: false, reason: `All ${limit} ${seatType === 'contributor' ? 'contributor' : 'community'} seats are in use. Upgrade at /membership to add more.` };
+    if (limit === 0) return { allowed: false, reason: `Your membership tier does not include ${seatType === 'contributor' ? 'contributor' : 'community'} seats. Upgrade at https://agenticadvertising.org/dashboard/membership.` };
+    if (used >= limit) return { allowed: false, reason: `All ${limit} ${seatType === 'contributor' ? 'contributor' : 'community'} seats are in use. Upgrade at https://agenticadvertising.org/dashboard/membership to add more.` };
     return { allowed: true };
   } catch (error) {
     await client.query('ROLLBACK');

--- a/server/tests/unit/claude-client-cost-gate.test.ts
+++ b/server/tests/unit/claude-client-cost-gate.test.ts
@@ -60,7 +60,7 @@ describe('claude-client entry-gate behavior (#2790)', () => {
 
     expect(response.flagged).toBe(true);
     expect(response.flag_reason).toBe('cost_cap_exceeded');
-    expect(response.text).toMatch(/usage cap/);
+    expect(response.text).toMatch(/conversation limit/);
     // No token usage because no Claude call fired.
     expect(response.usage).toBeUndefined();
     expect(anthropicCall).not.toHaveBeenCalled();

--- a/server/tests/unit/claude-cost-tracker.test.ts
+++ b/server/tests/unit/claude-cost-tracker.test.ts
@@ -112,18 +112,20 @@ describe('recordCost', () => {
 });
 
 describe('formatCapExceededMessage', () => {
-  it('includes the tier cap, current spend, and reset time', () => {
+  it('gives a clean member-facing message without internal dollar amounts', () => {
     const msg = formatCapExceededMessage({
       ok: false,
       spentCents: 550,
       remainingUsd: 0,
-      retryAfterMs: 45 * 60 * 1000, // 45 min
+      retryAfterMs: 45 * 60 * 1000,
       tier: 'member_free',
     });
-    expect(msg).toContain('5 USD'); // member_free cap
-    expect(msg).toContain('$5.50'); // current spend
-    expect(msg).toContain('45 minutes');
-    expect(msg).toContain('Upgrade'); // CTA for non-paying
+    expect(msg).toContain('daily conversation limit');
+    expect(msg).toContain('try again tomorrow');
+    expect(msg).toContain('/dashboard/membership');
+    expect(msg).toContain('Upgrade');
+    expect(msg).not.toContain('$5.50');
+    expect(msg).not.toContain('5 USD');
   });
 
   it('tells paying members to ping the team instead of upgrade', () => {


### PR DESCRIPTION
## Summary

The daily cost-cap error message was leaking internal implementation details to members:
- Raw dollar figures (`$6.21`, `5 USD`) that mean nothing to end users
- "Claude API" framing that exposes vendor/infra details
- A precise countdown (`~22 hours`) that's overly mechanical
- A broken `/membership` URL (lands on the public marketing page, not the member billing dashboard)

This PR replaces the message with a clean, member-facing string:

> You've reached your daily conversation limit with Addie. Please try again tomorrow. Upgrade your membership at https://agenticadvertising.org/dashboard/membership for a higher daily limit.

For paid members, the existing "ping the team" copy is preserved since they're already at the top tier.

Also noticed and fixed the same `/membership` → `/dashboard/membership` typo in `organization-db.ts` seat-limit messages (lines 549–550), matching the canonical URL convention used in `billing-tools.ts`, `alerts.ts`, and `billing-public.ts`.

## Files changed

- `server/src/addie/claude-cost-tracker.ts` — rewrote `formatCapExceededMessage` to drop internal amounts/countdown, fix URL
- `server/src/db/organization-db.ts` — fixed `/membership` → full canonical URL in seat-limit error strings
- `server/tests/unit/claude-cost-tracker.test.ts` — updated assertions to match new message shape (no dollar amounts, correct URL)
- `server/tests/unit/claude-client-cost-gate.test.ts` — updated regex from `usage cap` to `conversation limit`

## Test plan

- [x] `claude-cost-tracker.test.ts` — 22/22 pass
- [x] `claude-client-cost-gate.test.ts` — 4/4 pass
- [x] Full pre-commit suite — 4259 passed, 0 failed
- [ ] Manually trigger the cap on a test account and confirm the message reads cleanly on Slack, web chat, and email surfaces

Closes #5633, closes #5634, closes #5639