### PR TITLE
[codex] Separate 3.1 upgrade docs from migrations

### DIFF
--- a/.changeset/5655-migration-upgrade-nav.md
+++ b/.changeset/5655-migration-upgrade-nav.md
@@ -1,0 +1,4 @@
+---
+---
+
+Empty changeset: Separate breaking v2 to v3.0 migration docs from additive 3.1 badge prep guides, and align version navigation so the 3.1 upgrade guides are discoverable.

--- a/docs.json
+++ b/docs.json
@@ -699,6 +699,7 @@
                   "docs/reference/whats-new-in-3-1",
                   "docs/reference/migration/v3-readiness",
                   "docs/reference/migration/index",
+                  "docs/reference/migration/3-0-to-3-1",
                   "docs/reference/migration/prerelease-upgrades",
                   "docs/reference/migration/channels",
                   "docs/reference/migration/pricing",
@@ -1317,7 +1318,8 @@
                   "docs/reference/migration/brand-identity",
                   "docs/reference/migration/signals",
                   "docs/reference/migration/audiences",
-                  "docs/reference/migration/attribution"
+                  "docs/reference/migration/attribution",
+                  "docs/reference/migration/media-buy-status"
                 ]
               },
               "docs/protocol/architecture",

--- a/docs/reference/migration/index.mdx
+++ b/docs/reference/migration/index.mdx
@@ -92,7 +92,7 @@ During migration, sellers can accept both v2 and v3 traffic and buyers can route
 2. **Branch by seller** — Route v3-capable sellers through your v3 integration and v2-only sellers through your existing v2 code.
 3. **Migrate incrementally** — Start with the rename changes (pricing fields, channel updates), then tackle structural changes (creative assignments, optimization goals), then adopt new capabilities (accounts, governance) as needed.
 
-## Deep-dive pages
+## Breaking migrations (v2 → v3.0)
 
 <CardGroup cols={2}>
   <Card title="Channels" icon="tv" href="/docs/reference/migration/channels">
@@ -124,5 +124,21 @@ During migration, sellers can accept both v2 and v3 traffic and buyers can route
   </Card>
   <Card title="Attribution" icon="link" href="/docs/reference/migration/attribution">
     Integer days to structured `Duration` objects
+  </Card>
+</CardGroup>
+
+## 3.1 badge prep guides
+
+You can stay on 3.0 without breaking compatibility. To claim the 3.1 badge, complete this short prep checklist.
+
+<CardGroup cols={2}>
+  <Card title="3.1 badge checklist" icon="rocket" href="/docs/reference/migration/3-0-to-3-1">
+    Additive prep for buyers, sellers, agents, SDKs, and compliance workflows
+  </Card>
+  <Card title="Creative transformers" icon="wand-magic-sparkles" href="/docs/reference/migration/creative-transformers">
+    Move build capability discovery and pricing from formats to transformers
+  </Card>
+  <Card title="Media buy status" icon="circle-check" href="/docs/reference/migration/media-buy-status">
+    Split body-level buy status from envelope task status on success responses
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

- Split the migration index card group into breaking v2 -> v3.0 migrations and 3.1 badge prep guides.
- Add cards for the three 3.1 upgrade docs so they are discoverable from the migration index.
- Align `docs.json` navigation for the 3.1 and latest docs versions so all 3.1 upgrade guides are present.
- Add an empty changeset for the protocol-scoped docs update.

Closes #5655.

## Expert review

- docs-expert: approved the index framing, flagged navigation alignment as blocking; addressed by updating `docs.json`.
- copywriter: recommended tighter badge-prep wording; addressed in the new 3.1 section heading, caption, and first card.
- ad-tech-protocol-expert: no blocking concerns; confirmed the additive 3.1 workflow framing is correct.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('docs.json','utf8')); console.log('docs.json ok')"`
- `npm run docs:example-coverage -- --json`
- `npm run docs:json-field-audit -- --check` (0 new findings vs baseline)
- `git diff --check`
- `npx vitest run server/tests/unit/admin-stripe-customer-link.test.ts server/tests/unit/brand-ownership-route.test.ts --pool=threads`
- pre-push: version sync, changeset policy, schema link convention, and Mintlify broken-links all passed

Note: the first commit attempt ran the full precommit suite and hit two unrelated/flaky server unit failures; both failed tests passed when rerun directly.