### PR TITLE
docs(trusted-match): bind seller_agent_url into the TMP request signature

### DIFF
--- a/docs/trusted-match/specification.mdx
+++ b/docs/trusted-match/specification.mdx
@@ -498,6 +498,8 @@ The router signs all requests using Ed25519. Both Context Match and Identity Mat
 
 Signatures bind the request to a specific provider. The router signs a separate signature per fan-out target using the provider's endpoint URL from the router's provider registration. Providers MUST verify that the signed `provider_endpoint_url` matches their own advertised endpoint and reject the request otherwise. This prevents a captured signature from being replayed against a different provider in the registry within the epoch.
 
+Signatures also bind to `seller_agent_url`, the asking seller's agent URL. `seller_agent_url` selects which seller's registered active package set the receiver evaluates against (see [Seller Agent Attribution](#seller-agent-attribution)) and is the lookup key receivers use to resolve the publisher's signing keys for verification. Including it in the signed bytes prevents a captured signature from being replayed under a different seller's identity to read another seller's offers or active package set.
+
 The daily epoch provides replay protection — a captured signature is valid for at most ~48 hours (current + previous epoch accepted by verifiers).
 
 ### Signature envelope
@@ -516,6 +518,7 @@ Concatenated in this order, UTF-8, newline-separated:
 | Field | Source |
 |---|---|
 | `type` | `context_match_request` |
+| `seller_agent_url` | From the request body, compared using the [AdCP URL canonicalization rules](/docs/reference/url-canonicalization). Binds the signature to the asking seller — reusing a signature under a different `seller_agent_url` fails verification. |
 | `property_rid` | From the request body |
 | `placement_id` | From the request body |
 | `package_ids` | Sorted, comma-separated list of active package IDs |
@@ -524,7 +527,7 @@ Concatenated in this order, UTF-8, newline-separated:
 
 When `package_ids` is absent from the request, the signature MUST use an empty string for that field in the signed payload.
 
-Because the signed fields are static per placement per provider, the same signature can be cached and reused for all requests to the same `(placement_id, provider_endpoint_url)` pair within a 24-hour epoch. Cache keys MUST include `provider_endpoint_url` — reusing a signature across providers violates the binding and will fail verification.
+Because the signed fields are static per seller per placement per provider, the same signature can be cached and reused for all requests to the same `(seller_agent_url, placement_id, provider_endpoint_url)` triple within a 24-hour epoch. Cache keys MUST include `seller_agent_url` and `provider_endpoint_url` — reusing a signature across sellers or providers violates the binding and will fail verification.
 
 #### Identity Match signed fields
 
@@ -534,6 +537,7 @@ The signed input is the hex-encoded SHA-256 of the [RFC 8785 JCS](https://datatr
 |---|---|
 | `type` | `"identity_match_request"` |
 | `request_id` | From the request body |
+| `seller_agent_url` | From the request body, compared using the [AdCP URL canonicalization rules](/docs/reference/url-canonicalization). Binds the signature to the asking seller — reusing a signature under a different `seller_agent_url` fails verification. |
 | `identities_hash` | Hex-encoded SHA-256 of the canonical `identities` bytes (see below) |
 | `consent` | The request's `consent` object verbatim, or `null` when absent |
 | `package_ids` | The request's `package_ids` sorted lexicographically by UTF-8 byte order |


### PR DESCRIPTION
## Summary

Adds `seller_agent_url` to the Context Match and Identity Match signed-fields tables in the TMP specification.

`seller_agent_url` is the asking seller's agent URL on the request. It selects which seller's registered active package set the receiver evaluates ([Seller Agent Attribution](https://github.com/adcontextprotocol/adcp/blob/main/docs/trusted-match/specification.mdx#seller-agent-attribution)) and is the lookup key receivers use to resolve the publisher's signing keys for verification. Leaving it out of the signed bytes lets a holder of a valid registry key replay a captured signature under a different seller's URL to read another seller's offers or active package set — a structural break of the "binds the request to a specific seller" property the rest of the section already assumes.

Both reference implementations of TMP signing already cover `seller_agent_url` in the signed input — this change brings the normative spec into alignment.

## Changes

- **Context Match signed fields**: insert `seller_agent_url` immediately after `type` in the newline-joined input, compared using the AdCP URL canonicalization rules.
- **Identity Match signed fields**: insert `seller_agent_url` immediately after `request_id` in the JCS canonical object.
- **Context Match signature reuse**: extend the cache-reuse key for static placement signatures from `(placement_id, provider_endpoint_url)` to `(seller_agent_url, placement_id, provider_endpoint_url)` so that a cached signature under one seller cannot be reused under another.
- **Signing model prose**: add a paragraph next to the existing `provider_endpoint_url` binding explanation describing the same role for `seller_agent_url`.

## Compatibility note

This changes the signed bytes for both request types. Verifiers that have been following the spec literally (without `seller_agent_url`) will reject signatures from updated signers and vice versa during rollout. Both signers and verifiers should land the change together.

## Test plan

- [ ] Repo's docs/lint/typecheck suites (run via the local pre-commit and pre-push hooks)
- [ ] CI green on the PR
- [ ] Spec preview renders the updated tables correctly
- [ ] Cross-check that the in-tree reference implementation's signing input matches the updated tables field-for-field

🤖 Generated with [Claude Code](https://claude.com/claude-code)