### PR TITLE
docs(schemas): clarify why hosted video requires width/height but VAST does not

### DIFF
--- a/.changeset/video-asset-dimension-rationale.md
+++ b/.changeset/video-asset-dimension-rationale.md
@@ -1,0 +1,4 @@
+---
+---
+
+Empty changeset: Document the rationale for the dimension-policy difference between the hosted `video` asset (width/height required — a file has intrinsic native pixel dimensions) and the `vast` asset (no width/height — renditions are resolved per-`MediaFile` at serve time). Description and `$comment` only; no schema-shape or required-field changes.

--- a/static/schemas/source/core/assets/vast-asset.json
+++ b/static/schemas/source/core/assets/vast-asset.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/core/assets/vast-asset.json",
   "title": "VAST Asset",
-  "description": "VAST (Video Ad Serving Template) tag for third-party video ad serving",
+  "description": "VAST (Video Ad Serving Template) tag for third-party video ad serving. Unlike the hosted `video` asset, a VAST tag carries no `width`/`height`: a VAST response can return multiple renditions of differing dimensions, and the player selects one per device at serve time, so there is no single width/height for the ad. Dimensional, duration, and codec *constraints* for a placement live on the format/requirements layer, not on this asset.",
   "type": "object",
   "properties": {
     "asset_type": {

--- a/static/schemas/source/core/assets/video-asset.json
+++ b/static/schemas/source/core/assets/video-asset.json
@@ -2,7 +2,8 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/core/assets/video-asset.json",
   "title": "Video Asset",
-  "description": "Video asset with URL and technical specifications including audio track properties",
+  "description": "A hosted video file delivered directly (e.g., an MP4 you host), with URL and technical specifications including audio track properties. `width` and `height` are required because a hosted video file has intrinsic, native pixel dimensions that are known when the file is created. Tag-delivered video uses the separate `vast` asset, which carries no `width`/`height`: a VAST response resolves geometry per-`MediaFile` at serve time, so there is no single width/height for the ad. Aspect-ratio and size *constraints* (what a placement accepts) belong on the format/requirements layer, not on the asset.",
+  "$comment": "Dimension policy is deliberate and differs by asset type: a hosted `video` asset requires width/height (intrinsic pixels of a concrete file), while the `vast` asset omits them entirely (renditions are selected per-MediaFile by the player at serve time). Do not infer that AdCP forces a single width/height onto all video — only onto hosted files.",
   "type": "object",
   "properties": {
     "asset_type": {
@@ -18,12 +19,12 @@
     "width": {
       "type": "integer",
       "minimum": 1,
-      "description": "Width in pixels"
+      "description": "Width in pixels — the video file's intrinsic native width. Required: a hosted file always has concrete dimensions. (Tag-delivered video carries no width; see the `vast` asset.)"
     },
     "height": {
       "type": "integer",
       "minimum": 1,
-      "description": "Height in pixels"
+      "description": "Height in pixels — the video file's intrinsic native height. Required: a hosted file always has concrete dimensions. (Tag-delivered video carries no height; see the `vast` asset.)"
     },
     "duration_ms": {
       "type": "integer",


### PR DESCRIPTION
## Why

A recurring misread of the spec is that "AdCP forces a single width/height onto all video." It doesn't — and the reason isn't written down where a reader (or an LLM training on the published schemas) would find it. The policy is deliberate and differs by asset type:

- A **hosted `video` asset** is a concrete file with intrinsic native pixel dimensions known at creation, so `width`/`height` are required.
- A **`vast` asset** is a pointer to a runtime decision: a VAST response can return multiple renditions of differing dimensions, and the player selects one per device at serve time — so there is no single width/height, and the `vast` asset deliberately omits them (`required: ["asset_type"]`, no `width`/`height` properties).

Sizing/duration/codec *constraints* (what a placement accepts) belong on the format/requirements layer, not on the asset. This PR records that rationale on the two schemas themselves.

## What Changed

- **`core/assets/video-asset.json`** — expanded the top-level `description` to explain that `width`/`height` are required because a hosted file has intrinsic dimensions (and that tag-delivered video uses the `vast` asset); added a `$comment` stating the asset-vs-tag dimension boundary; clarified the `width`/`height` property descriptions.
- **`core/assets/vast-asset.json`** — expanded the `description` to state that a VAST tag carries no `width`/`height` by design (per-`MediaFile` resolution at serve time) and that constraints live on the format layer.

**Description/`$comment` only — no `required` arrays, properties, or shapes change.** Source-only edit; `dist/schemas/latest/` regenerates from source (gitignored) and released version directories are immutable and untouched.