### PR TITLE
docs(trusted-match): close two narrative-vs-schema drifts in TMP spec

### DIFF
--- a/docs/trusted-match/specification.mdx
+++ b/docs/trusted-match/specification.mdx
@@ -51,7 +51,7 @@ Sent by the publisher (via router) to buyer agents. Contains content context. MU
 | `request_id` | string | Yes | Unique request identifier for logging. MUST NOT correlate with any Identity Match request_id. |
 | `property_rid` | UUID | Yes | Property catalog UUID (v7). Globally unique, stable. |
 | `property_id` | string | No | Publisher's human-readable slug. Optional when `property_rid` is present. |
-| `property_type` | enum | Yes | One of: `website`, `mobile_app`, `ctv_app`, `desktop_app`, `dooh`, `podcast`, `radio`, `streaming_audio`, `ai_assistant`. See `property-type` enum. |
+| `property_type` | enum | Yes | One of: `website`, `mobile_app`, `ctv_app`, `desktop_app`, `dooh`, `podcast`, `radio`, `linear_tv`, `streaming_audio`, `ai_assistant`. See `property-type` enum. |
 | `placement_id` | string | Yes | Placement identifier from the publisher's placement registry in `adagents.json`. One placement per request. |
 | `seller_agent_url` | string (URI) | Yes | API endpoint URL of the seller agent issuing this request. The provider resolves the active package set it has synced for this seller against it; an unsynced seller MUST yield an empty offer set, never a fall-back to another seller's set. A single per-placement value carrying no user identity. Compared with AdCP URL canonicalization. Consistent with `seller_agent_url` on the Identity Match request and `agent_url` in `adagents.json`. |
 | `artifact` | Artifact | No | Full content artifact adjacent to this ad opportunity. Same schema as content standards evaluation. The publisher sends the full artifact when they want the buyer to evaluate the actual content. Contractual protections govern buyer use. TEE deployment upgrades contractual trust to cryptographic verification. |
@@ -133,6 +133,7 @@ Returned by the buyer agent. Contains offers for matched packages and optional r
 | `type` | string | Yes | `"context_match_response"`. Message type discriminator for deserialization. |
 | `request_id` | string | Yes | Echo of the request's `request_id`. |
 | `offers` | List\<Offer\> | Yes | Offers from the buyer, one per activated package. Empty list means no packages matched. |
+| `cache_ttl` | integer | No | Provider override (in seconds) for the router's default Context Match response cache TTL. When present, routers MUST use this value instead of their default. `0` disables caching (e.g., when targeting configuration has just changed); schema-enforced maximum is 86400 seconds. See [Caching](#caching). |
 | `signals` | Signals | No | Response-level targeting signals for ad server pass-through. Not per-offer — applies to the response as a whole. In the GAM case, these carry the key-value pairs that trigger line items. |
 
 #### Offer


### PR DESCRIPTION
## Summary

Two narrative-vs-schema drifts in \`docs/trusted-match/specification.mdx\` where the prose field tables silently disagreed with the schema source of truth.

### \`property_type\` enum prose missed \`linear_tv\`

\`static/schemas/source/enums/property-type.json\` lists \`linear_tv\` as a valid property type (with the description "Linear television stations and networks, identified by station ID or facility ID"), and the reference TMP implementation has had \`PropertyTypeLinearTV\` since the 3.1 schema bundle. The inline enum list on the ContextMatchRequest field table did not include it, so a reader relying on the prose would not know \`linear_tv\` was acceptable.

### \`cache_ttl\` missing from ContextMatchResponse field table

The Caching section already says normatively:
> Providers MAY include a \`cache_ttl\` field (integer, seconds) in Context Match responses to override the default. Routers MUST respect this value when present.

…and the field appears in the response schema and the reference implementation, but the ContextMatchResponse field table at lines 131–136 did not list it. Anyone reading the response shape from the table would conclude there was no override mechanism. New row documents the override semantics, the \`0\`-disables-caching convention, the schema-enforced 86400s ceiling, and links to the Caching section for the full TTL rules.

Surfaced by an audit comparing the spec against the AdCP 3.1 schema bundle and the reference TMP implementation. Companion to the recently merged \`seller_agent_url\` signing fix (#5660).

## Test plan

- [x] \`npm run lint:schema-links\` passes
- [x] \`npm run test:docs-nav\` passes
- [x] \`npm run check:owned-links\` passes
- [x] Pre-commit (unit / server unit / typecheck) passes locally
- [ ] Spec preview renders the two updated tables correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)