### PR TITLE
fix(compliance): gate + coherence-ledger fix for dependency_impairment scenarios (#5664)

### DIFF
--- a/.changeset/5664-dependency-impairment-snapshot-gate.md
+++ b/.changeset/5664-dependency-impairment-snapshot-gate.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-Empty changeset: Gate the `dependency_impairment` and `dependency_impairment_cardinality` storyboards on `media_buy.propagation_surfaces` containing `snapshot`, so webhook-only and `out_of_band` sellers grade `not_applicable` instead of false-failing on the snapshot-coherence surface — wiring the opt-out the `propagation_surfaces` schema already documents. Fixes #5664.
+Empty changeset: Fix `dependency_impairment` and `dependency_impairment_cardinality` for #5664 on two fronts. (1) Gate both storyboards on `media_buy.propagation_surfaces` containing `snapshot`, so webhook-only / `out_of_band` sellers grade `not_applicable` instead of false-failing on the snapshot-coherence surface (wiring the opt-out the `propagation_surfaces` schema already documents). (2) Insert `list_creatives` re-reads after each `force_creative_status` rejection so the runner observes the offline status on the wire before the impaired `get_media_buys` read — without it the `impairment.coherence` ledger keeps the pre-rejection status and the scenario false-fails for every snapshot seller. Fixes #5664.

--- a/.changeset/5664-dependency-impairment-snapshot-gate.md
+++ b/.changeset/5664-dependency-impairment-snapshot-gate.md
@@ -1,0 +1,4 @@
+---
+---
+
+Empty changeset: Gate the `dependency_impairment` and `dependency_impairment_cardinality` storyboards on `media_buy.propagation_surfaces` containing `snapshot`, so webhook-only and `out_of_band` sellers grade `not_applicable` instead of false-failing on the snapshot-coherence surface — wiring the opt-out the `propagation_surfaces` schema already documents. Fixes #5664.

--- a/static/compliance/source/protocols/media-buy/scenarios/dependency_impairment.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/dependency_impairment.yaml
@@ -428,6 +428,44 @@ phases:
       invariant grades the cross-resource match.
 
     steps:
+      - id: reread_creative_rejected
+        title: "Re-read the creative — runner observes rejected (closes impairment.coherence)"
+        narrative: |
+          The impairment.coherence invariant ledgers each resource's last status
+          OBSERVED ON THE WIRE (sync_creatives / list_creatives), not the
+          comply_test_controller force directive (the runner has no observation
+          hook for the forced transition). Without this re-read the creative's
+          last observed status stays its pre-rejection value (e.g. pending_review
+          from the sync step), so the next get_media_buys — which correctly
+          reports health: impaired — trips coherence because impairments[]
+          references a creative the ledger still considers online. This re-read
+          surfaces the rejected status so the ledger and the buy agree.
+        task: list_creatives
+        schema_ref: "creative/list-creatives-request.json"
+        response_schema_ref: "creative/list-creatives-response.json"
+        doc_ref: "/creative/task-reference/list_creatives"
+        comply_scenario: creative_library
+        stateful: true
+        expected: |
+          The rejected creative is returned with status: rejected.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          filters:
+            creative_ids:
+              - "acme_dep_banner_001"
+          context:
+            correlation_id: "dependency_impairment--reread_creative_rejected"
+        validations:
+          - check: response_schema
+            description: "Response matches list-creatives-response.json schema"
+          - check: field_value
+            path: "creatives[0].status"
+            value: "rejected"
+            description: "Creative observed as rejected on the wire — closes the impairment.coherence ledger for the impaired read that follows"
+
       - id: get_buy_impaired
         title: "Read the buy — health: impaired, impairment entry present"
         task: get_media_buys

--- a/static/compliance/source/protocols/media-buy/scenarios/dependency_impairment.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/dependency_impairment.yaml
@@ -12,6 +12,17 @@ required_tools:
   - update_media_buy
   - comply_test_controller
 
+# Capability gate: this scenario grades the snapshot-coherence surface, so it
+# runs only for sellers that declare media_buy.propagation_surfaces including
+# "snapshot". Webhook-only or out_of_band sellers grade not_applicable instead
+# of false-failing on a contract that does not apply to them — the opt-out the
+# propagation_surfaces schema already documents (get-adcp-capabilities-response.json)
+# but that was never wired into this scenario. Requires runner support for the
+# `contains:` matcher (adcp-client >= 7.70).
+requires_capability:
+  path: media_buy.propagation_surfaces
+  contains: "snapshot"
+
 narrative: |
   Per the dependency-impairment surface ([adcp#2855](https://github.com/adcontextprotocol/adcp/issues/2855)
   and `core/impairment.json`), sellers MUST propagate resource-state transitions

--- a/static/compliance/source/protocols/media-buy/scenarios/dependency_impairment_cardinality.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/dependency_impairment_cardinality.yaml
@@ -12,6 +12,17 @@ required_tools:
   - update_media_buy
   - comply_test_controller
 
+# Capability gate: this scenario grades the snapshot-coherence surface, so it
+# runs only for sellers that declare media_buy.propagation_surfaces including
+# "snapshot". Webhook-only or out_of_band sellers grade not_applicable instead
+# of false-failing on a contract that does not apply to them — the opt-out the
+# propagation_surfaces schema already documents (get-adcp-capabilities-response.json)
+# but that was never wired into this scenario. Requires runner support for the
+# `contains:` matcher (adcp-client >= 7.70).
+requires_capability:
+  path: media_buy.propagation_surfaces
+  contains: "snapshot"
+
 narrative: |
   The base dependency_impairment scenario tests forward + inverse + health-iff
   with one creative on one package — a malicious or buggy seller can pass the

--- a/static/compliance/source/protocols/media-buy/scenarios/dependency_impairment_cardinality.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/dependency_impairment_cardinality.yaml
@@ -428,6 +428,44 @@ phases:
             allowed_values: [true]
             description: "Controller acknowledged the rejection directive"
 
+      - id: reread_a_rejected
+        title: "Re-read creative A — runner observes rejected"
+        narrative: |
+          The impairment.coherence invariant ledgers each resource's last status
+          OBSERVED ON THE WIRE (sync_creatives / list_creatives), not the
+          comply_test_controller force directive (the runner has no observation
+          hook for the forced transition). Without this re-read the creative's
+          last observed status stays its pre-rejection value (e.g. pending_review
+          from the sync step), so the next get_media_buys — which correctly
+          reports health: impaired — trips coherence because impairments[]
+          references a creative the ledger still considers online. This re-read
+          surfaces the rejected status so the ledger and the buy agree.
+        task: list_creatives
+        schema_ref: "creative/list-creatives-request.json"
+        response_schema_ref: "creative/list-creatives-response.json"
+        doc_ref: "/creative/task-reference/list_creatives"
+        comply_scenario: creative_library
+        stateful: true
+        expected: |
+          The rejected creative is returned with status: rejected.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          filters:
+            creative_ids:
+              - "acme_card_banner_a"
+          context:
+            correlation_id: "dependency_impairment_cardinality--reread_a_rejected"
+        validations:
+          - check: response_schema
+            description: "Response matches list-creatives-response.json schema"
+          - check: field_value
+            path: "creatives[0].status"
+            value: "rejected"
+            description: "Creative observed as rejected on the wire — closes the impairment.coherence ledger for the impaired read that follows"
+
       - id: verify_cardinality_one
         title: "Read the buy — exactly one impairment, scoped to package_a"
         task: get_media_buys
@@ -514,6 +552,44 @@ phases:
             path: "success"
             allowed_values: [true]
             description: "Controller acknowledged the rejection directive"
+
+      - id: reread_b_rejected
+        title: "Re-read creative B — runner observes rejected"
+        narrative: |
+          The impairment.coherence invariant ledgers each resource's last status
+          OBSERVED ON THE WIRE (sync_creatives / list_creatives), not the
+          comply_test_controller force directive (the runner has no observation
+          hook for the forced transition). Without this re-read the creative's
+          last observed status stays its pre-rejection value (e.g. pending_review
+          from the sync step), so the next get_media_buys — which correctly
+          reports health: impaired — trips coherence because impairments[]
+          references a creative the ledger still considers online. This re-read
+          surfaces the rejected status so the ledger and the buy agree.
+        task: list_creatives
+        schema_ref: "creative/list-creatives-request.json"
+        response_schema_ref: "creative/list-creatives-response.json"
+        doc_ref: "/creative/task-reference/list_creatives"
+        comply_scenario: creative_library
+        stateful: true
+        expected: |
+          The rejected creative is returned with status: rejected.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          filters:
+            creative_ids:
+              - "acme_card_banner_b"
+          context:
+            correlation_id: "dependency_impairment_cardinality--reread_b_rejected"
+        validations:
+          - check: response_schema
+            description: "Response matches list-creatives-response.json schema"
+          - check: field_value
+            path: "creatives[0].status"
+            value: "rejected"
+            description: "Creative observed as rejected on the wire — closes the impairment.coherence ledger for the impaired read that follows"
 
       - id: verify_cardinality_two
         title: "Read the buy — exactly two impairments, one per creative"


### PR DESCRIPTION
Fixes #5664 — both facets the triage identified.

**1. Capability gate (facet 1):** `dependency_impairment` and `dependency_impairment_cardinality` grade the snapshot-coherence surface but carried no `requires_capability` gate, so webhook-only / `out_of_band` sellers run them and false-fail on a contract that doesn't apply to them. The `propagation_surfaces` schema already documents this opt-out ("storyboards that exercise it … require `snapshot` to be declared, else they grade `not_applicable`"); this wires it into both scenarios. Mirrors the existing `contains:` matcher precedent (`clicks_buy_flow.yaml`), including the runner-version comment.

**2. Coherence ledger fix (facet 2):** `impairment.coherence` ledgers each resource's last status *observed on the wire* (`sync_creatives` / `list_creatives`), not the `comply_test_controller` force directive — the runner has no observation hook for the forced transition. Both scenarios force a creative to `rejected` via the controller but never re-read it, so the ledger keeps the pre-rejection status and the subsequent impaired `get_media_buys` read trips coherence — for **every** snapshot seller, not just opted-out ones. This inserts a `list_creatives` re-read after each rejection (1 in the base scenario, 2 in `_cardinality`) so the runner observes the offline status before the impaired read.

Together: facet 1 scopes the scenarios correctly; facet 2 makes them actually passable by a conformant snapshot seller. YAML-only, no schema change.
